### PR TITLE
ci: run quality gate only on PRs to main or dev

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,8 +1,10 @@
 name: Quality
 
 on:
-  push:
   pull_request:
+    branches:
+      - main
+      - dev
 
 jobs:
   quality:


### PR DESCRIPTION
Restricts the Quality workflow to run only on pull requests whose target branch is `main` or `dev`. Removes `push` trigger so quality is not run on every push; since dev (and main) require PRs before merging, running on PR is sufficient.

Made with [Cursor](https://cursor.com)