### PR TITLE
Fix #1: SPEC capital-and-connectivity gaps

### DIFF
--- a/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
+++ b/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
@@ -1,6 +1,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../world/connectivity_resolver.dart';
+
 /// Per-player extraction totals: land (same region as capital) vs overseas.
 class ExtractionTotals {
   const ExtractionTotals({
@@ -15,22 +17,25 @@ class ExtractionTotals {
 /// Computes per-player extraction from connected tiles. SPEC/game/extraction-and-improvements.
 ///
 /// For each connected tile: production = min(improvementLevel, techCap);
-/// transportLevel = road level (0/1/2/4); town development level caps yield (SPEC capital-and-connectivity).
-/// effective = min(production, transportLevel, province.townDevelopmentLevel).
+/// effective = min(production, pathTransportCap, province.townDevelopmentLevel).
+/// Path transport cap = min road/port level along path to town then to capital (from [connectivityResult]);
+/// when absent, falls back to tile's own transport level.
 /// Sums by commodity; splits land (same region as capital) vs overseas.
 Map<String, ExtractionTotals> computeExtraction({
   required Game game,
   required Map<String, TileMapResult> tileMapByRegion,
-  required Map<String, Set<String>> connectivityResult,
+  required Map<String, ConnectivityResult> connectivityResult,
   int Function(String playerId) techCapForPlayer = _defaultTechCap,
 }) {
   final out = <String, ExtractionTotals>{};
   for (final player in game.players) {
-    final connected = connectivityResult[player.id];
+    final cr = connectivityResult[player.id];
+    final connected = cr?.connected;
     if (connected == null || connected.isEmpty) {
       out[player.id] = const ExtractionTotals();
       continue;
     }
+    final pathTransportCap = cr!.pathTransportCap;
     final cap = player.capitalTile;
     final capitalRegionId = cap?.regionId;
     final techCap = techCapForPlayer(player.id);
@@ -76,10 +81,11 @@ Map<String, ExtractionTotals> computeExtraction({
       final improvementLevel = game.worldState.tileState.improvementLevel(tileKey).clamp(0, 4);
       final roadLevel = game.worldState.tileState.roadLevel(tileKey);
       final isPort = game.worldState.portsByProvinceSeaboard.values.contains(tileKey);
-      final transportLevel = isPort ? 4 : (roadLevel > 0 ? roadLevel : 0);
+      final tileTransportLevel = isPort ? 4 : (roadLevel > 0 ? roadLevel : 0);
+      final pathCap = pathTransportCap[tileKey] ?? tileTransportLevel;
 
       final production = (improvementLevel < techCap ? improvementLevel : techCap).clamp(0, 4);
-      final effective = (production < transportLevel ? production : transportLevel).clamp(0, 4);
+      final effective = (production < pathCap ? production : pathCap).clamp(0, 4);
       final effectiveCapped = (effective < townDevelopmentCap ? effective : townDevelopmentCap).clamp(0, 4);
       if (effectiveCapped <= 0) continue;
 

--- a/packages/colonizethis_logic/lib/src/setup/game_setup.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup.dart
@@ -512,12 +512,7 @@ Game _applyNaming({
               : '$fallbackPrefix ${i + 1}');
       if (name.isEmpty) name = generateFallback(rngSeed + i);
       if (p.id != capitalProvinceId && pool.isNotEmpty) poolIndex++;
-      final updated = Province(
-        id: p.id,
-        regionId: p.regionId,
-        ownerId: p.ownerId,
-        displayName: name,
-      );
+      final updated = p.copyWith(displayName: name);
       outById[p.id] = updated;
     }
   }

--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -3,30 +3,46 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
 
+/// Result of connectivity resolution: connected tile set and per-tile path transport cap.
+/// SPEC/game/capital-and-connectivity, extraction-and-improvements: effective yield is
+/// capped by min transport level along path to town then to capital; [pathTransportCap]
+/// is that cap (max over paths of min road level on path).
+class ConnectivityResult {
+  const ConnectivityResult({
+    required this.connected,
+    this.pathTransportCap = const {},
+  });
+
+  final Set<String> connected;
+  final Map<String, int> pathTransportCap;
+}
+
 /// Resolves which tiles are connected to each player's capital. SPEC/game/capital-and-connectivity.
 ///
 /// Connectivity: from capital, BFS over land; edges are same-province adjacency;
 /// we expand only from capital or tiles with road/port. Overseas: ports connected
 /// by shared sea zone; from those ports, BFS within province by road/adjacency.
+/// Also computes [ConnectivityResult.pathTransportCap]: for each connected tile,
+/// the maximum over paths from capital of (min road/port level on that path).
 
-/// Returns per player id the set of connected tile keys (format "regionId|provinceId|x|y").
-/// Players without capital or with no tile map get an empty set.
-Map<String, Set<String>> resolveConnectivity({
+/// Returns per player id [ConnectivityResult] (connected set + path transport cap).
+/// Players without capital or with no tile map get an empty result.
+Map<String, ConnectivityResult> resolveConnectivity({
   required Game game,
   required Map<String, TileMapResult> tileMapByRegion,
   required MapTopology topology,
 }) {
   final provinceIdsByType = _provinceIdsFromTopology(topology);
-  final result = <String, Set<String>>{};
+  final result = <String, ConnectivityResult>{};
 
   for (final player in game.players) {
     final capital = player.capitalTile;
     if (capital == null || player.capitalProvinceId == null) {
-      result[player.id] = {};
+      result[player.id] = ConnectivityResult(connected: {});
       continue;
     }
 
-    final connected = _connectedTilesForPlayer(
+    final cr = _connectedTilesForPlayer(
       game: game,
       playerId: player.id,
       capital: capital,
@@ -34,7 +50,7 @@ Map<String, Set<String>> resolveConnectivity({
       topology: topology,
       provinceIdsByType: provinceIdsByType,
     );
-    result[player.id] = connected;
+    result[player.id] = cr;
   }
 
   return result;
@@ -147,7 +163,14 @@ Map<String, (String, String)> _portToProvinceSeaZone(WorldState worldState) {
   return out;
 }
 
-Set<String> _connectedTilesForPlayer({
+int _transportLevelAtTile(WorldState worldState, String tileKey) {
+  final portInfo = _portToProvinceSeaZone(worldState);
+  if (portInfo.containsKey(tileKey)) return 4;
+  final r = worldState.tileState.roadLevel(tileKey);
+  return r > 0 ? r : 0;
+}
+
+ConnectivityResult _connectedTilesForPlayer({
   required Game game,
   required String playerId,
   required CapitalTile capital,
@@ -158,17 +181,20 @@ Set<String> _connectedTilesForPlayer({
   final worldState = game.worldState;
   final tileState = worldState.tileState;
   final owned = _ownedProvinceIdsForPlayer(game, playerId);
-  if (!owned.contains(capital.provinceId)) return {};
+  if (!owned.contains(capital.provinceId)) {
+    return const ConnectivityResult(connected: {});
+  }
 
   final capitalRegionId = capital.regionId;
   final mapOpt = tileMapByRegion[capitalRegionId];
-  if (mapOpt == null) return {};
+  if (mapOpt == null) return const ConnectivityResult(connected: {});
 
   final capitalKey = capital.toTileKey();
-  final connected = <String>{capitalKey};
-  final queue = <String>[capitalKey];
-
   final portInfo = _portToProvinceSeaZone(worldState);
+  final connected = <String>{capitalKey};
+  final pathCap = <String, int>{};
+  pathCap[capitalKey] = _transportLevelAtTile(worldState, capitalKey);
+  final queue = <String>[capitalKey];
 
   while (queue.isNotEmpty) {
     final key = queue.removeAt(0);
@@ -192,10 +218,24 @@ Set<String> _connectedTilesForPlayer({
 
     if (!canExpand) continue;
 
+    final bottleneckU = pathCap[key] ?? 0;
     for (final n in _adjacentTileKeys(regionId, localProvinceId, x, y, map, provinceIdsByType)) {
-      if (connected.contains(n)) continue;
-      connected.add(n);
-      queue.add(n);
+      final transportN = _transportLevelAtTile(worldState, n);
+      final candidate = bottleneckU < transportN ? bottleneckU : transportN;
+      final existing = pathCap[n] ?? -1;
+      if (candidate > existing) {
+        pathCap[n] = candidate;
+        if (!connected.contains(n)) {
+          connected.add(n);
+          queue.add(n);
+        } else {
+          queue.add(n);
+        }
+      } else if (!connected.contains(n)) {
+        connected.add(n);
+        pathCap[n] = candidate;
+        queue.add(n);
+      }
     }
   }
 
@@ -248,6 +288,7 @@ Set<String> _connectedTilesForPlayer({
     if (x < 0 || y < 0) continue;
 
     connected.add(portKey);
+    pathCap[portKey] = 4;
     queue.add(portKey);
   }
 
@@ -269,14 +310,28 @@ Set<String> _connectedTilesForPlayer({
     final map = tileMapByRegion[regionId];
     if (map == null) continue;
 
+    final bottleneckU = pathCap[key] ?? 0;
     for (final n in _adjacentTileKeys(regionId, provinceId, x, y, map, provinceIdsByType)) {
-      if (connected.contains(n)) continue;
-      connected.add(n);
-      queue.add(n);
+      final transportN = _transportLevelAtTile(worldState, n);
+      final candidate = bottleneckU < transportN ? bottleneckU : transportN;
+      final existing = pathCap[n] ?? -1;
+      if (candidate > existing) {
+        pathCap[n] = candidate;
+        if (!connected.contains(n)) {
+          connected.add(n);
+          queue.add(n);
+        } else {
+          queue.add(n);
+        }
+      } else if (!connected.contains(n)) {
+        connected.add(n);
+        pathCap[n] = candidate;
+        queue.add(n);
+      }
     }
   }
 
-  return connected;
+  return ConnectivityResult(connected: connected, pathTransportCap: pathCap);
 }
 
 /// Adjacent tile keys (4-neighbour). Includes tiles in same or neighbouring provinces (any land cell). Tile key uses neighbour's province id.

--- a/packages/colonizethis_logic/test/connectivity_resolver_test.dart
+++ b/packages/colonizethis_logic/test/connectivity_resolver_test.dart
@@ -43,12 +43,13 @@ void main() {
         topology: topology,
       );
       expect(result['pl1'], isNotNull);
-      expect(result['pl1']!.length, 5);
-      expect(result['pl1']!.contains('oldWorld|p1|1|1'), true);
-      expect(result['pl1']!.contains('oldWorld|p1|0|1'), true);
-      expect(result['pl1']!.contains('oldWorld|p1|2|1'), true);
-      expect(result['pl1']!.contains('oldWorld|p1|1|0'), true);
-      expect(result['pl1']!.contains('oldWorld|p1|1|2'), true);
+      final connected = result['pl1']!.connected;
+      expect(connected.length, 5);
+      expect(connected.contains('oldWorld|p1|1|1'), true);
+      expect(connected.contains('oldWorld|p1|0|1'), true);
+      expect(connected.contains('oldWorld|p1|2|1'), true);
+      expect(connected.contains('oldWorld|p1|1|0'), true);
+      expect(connected.contains('oldWorld|p1|1|2'), true);
     });
 
     test('road extends connectivity beyond capital-adjacent', () {
@@ -93,10 +94,11 @@ void main() {
         tileMapByRegion: {'oldWorld': tileMap},
         topology: topology,
       );
-      expect(result['pl1']!.contains('oldWorld|p1|1|1'), true);
-      expect(result['pl1']!.contains('oldWorld|p1|0|1'), true);
-      expect(result['pl1']!.contains('oldWorld|p1|0|0'), true);
-      expect(result['pl1']!.length, greaterThanOrEqualTo(6));
+      final connected = result['pl1']!.connected;
+      expect(connected.contains('oldWorld|p1|1|1'), true);
+      expect(connected.contains('oldWorld|p1|0|1'), true);
+      expect(connected.contains('oldWorld|p1|0|0'), true);
+      expect(connected.length, greaterThanOrEqualTo(6));
     });
 
     test('player without capital gets empty set', () {
@@ -124,7 +126,7 @@ void main() {
         tileMapByRegion: {'oldWorld': tileMap},
         topology: topology,
       );
-      expect(result['pl1'], isEmpty);
+      expect(result['pl1']!.connected, isEmpty);
     });
 
     test('overseas province with port connected via sea', () {
@@ -188,10 +190,11 @@ void main() {
         },
         topology: topology,
       );
-      expect(result['pl1']!.contains('oldWorld|p1|0|0'), true);
-      expect(result['pl1']!.contains('oldWorld|p1|1|0'), true);
-      expect(result['pl1']!.contains('newWorld|p2|0|0'), true);
-      expect(result['pl1']!.length, greaterThanOrEqualTo(3));
+      final connected = result['pl1']!.connected;
+      expect(connected.contains('oldWorld|p1|0|0'), true);
+      expect(connected.contains('oldWorld|p1|1|0'), true);
+      expect(connected.contains('newWorld|p2|0|0'), true);
+      expect(connected.length, greaterThanOrEqualTo(3));
     });
 
     test('capital not on seaboard: only ports reachable by road from capital connected', () {
@@ -247,9 +250,10 @@ void main() {
         },
         topology: topology,
       );
-      expect(result['pl1']!.contains('oldWorld|p1|1|1'), true);
-      expect(result['pl1']!.contains('oldWorld|p1|0|0'), true);
-      expect(result['pl1']!.contains('newWorld|p2|0|0'), false);
+      final connected = result['pl1']!.connected;
+      expect(connected.contains('oldWorld|p1|1|1'), true);
+      expect(connected.contains('oldWorld|p1|0|0'), true);
+      expect(connected.contains('newWorld|p2|0|0'), false);
     });
 
     test('sea path multi-zone: S1–S2 edge, capital on S1, overseas port on S2 connected', () {
@@ -296,8 +300,90 @@ void main() {
         },
         topology: topology,
       );
-      expect(result['pl1']!.contains('oldWorld|p1|0|0'), true);
-      expect(result['pl1']!.contains('newWorld|p2|0|0'), true);
+      final connected = result['pl1']!.connected;
+      expect(connected.contains('oldWorld|p1|0|0'), true);
+      expect(connected.contains('newWorld|p2|0|0'), true);
+    });
+
+    test('severed road: losing province on path to capital removes tiles beyond it', () {
+      const ow = 'oldWorld';
+      final grid = [
+        ['p1', 'p2', 'p3'],
+        ['p1', 'p2', 'p3'],
+      ];
+      final tileMap = TileMapResult(width: 3, height: 2, grid: grid);
+      final topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'p1', regionId: ow, type: TopologyNodeType.province),
+          TopologyNode(id: 'p2', regionId: ow, type: TopologyNodeType.province),
+          TopologyNode(id: 'p3', regionId: ow, type: TopologyNodeType.province),
+        ],
+        edges: [],
+      );
+      final cap = CapitalTile(regionId: ow, provinceId: '$ow|p1', x: 0, y: 0);
+      final tileState = TileMapState()
+          .setRoadLevel('oldWorld|p1|0|0', 1)
+          .setRoadLevel('oldWorld|p1|1|0', 1)
+          .setRoadLevel('oldWorld|p2|1|0', 1)
+          .setRoadLevel('oldWorld|p2|2|0', 1)
+          .setRoadLevel('oldWorld|p3|2|0', 1);
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+          oldWorld: RegionData(provinces: [
+            Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1'),
+            Province(id: '$ow|p2', regionId: ow, ownerId: 'pl1'),
+            Province(id: '$ow|p3', regionId: ow, ownerId: 'pl1'),
+          ]),
+          newWorld: const RegionData(),
+          tileState: tileState,
+        ),
+        players: [
+          Player(id: 'pl1', displayName: 'Spain', isHuman: true, capitalProvinceId: '$ow|p1', capitalTile: cap),
+        ],
+      );
+      final tileMapByRegion = {'oldWorld': tileMap};
+      var result = resolveConnectivity(game: game, tileMapByRegion: tileMapByRegion, topology: topology);
+      expect(result['pl1']!.connected.contains('oldWorld|p3|2|0'), true);
+
+      final gameP2Lost = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+          oldWorld: RegionData(provinces: [
+            Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1'),
+            Province(id: '$ow|p2', regionId: ow, ownerId: 'other'),
+            Province(id: '$ow|p3', regionId: ow, ownerId: 'pl1'),
+          ]),
+          newWorld: const RegionData(),
+          tileState: tileState,
+        ),
+        players: [
+          Player(id: 'pl1', displayName: 'Spain', isHuman: true, capitalProvinceId: '$ow|p1', capitalTile: cap),
+        ],
+      );
+      result = resolveConnectivity(game: gameP2Lost, tileMapByRegion: tileMapByRegion, topology: topology);
+      expect(result['pl1']!.connected.contains('oldWorld|p3|2|0'), false);
+
+      final gameP2Restored = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+          oldWorld: RegionData(provinces: [
+            Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1'),
+            Province(id: '$ow|p2', regionId: ow, ownerId: 'pl1'),
+            Province(id: '$ow|p3', regionId: ow, ownerId: 'pl1'),
+          ]),
+          newWorld: const RegionData(),
+          tileState: tileState,
+        ),
+        players: [
+          Player(id: 'pl1', displayName: 'Spain', isHuman: true, capitalProvinceId: '$ow|p1', capitalTile: cap),
+        ],
+      );
+      result = resolveConnectivity(game: gameP2Restored, tileMapByRegion: tileMapByRegion, topology: topology);
+      expect(result['pl1']!.connected.contains('oldWorld|p3|2|0'), true);
     });
   });
 }

--- a/packages/colonizethis_logic/test/game_setup_test.dart
+++ b/packages/colonizethis_logic/test/game_setup_test.dart
@@ -73,6 +73,17 @@ void main() {
       expect(result.game.worldState.portsByProvinceSeaboard.containsKey('oldWorld|p1|sea1'), true);
       expect(result.game.worldState.portsByProvinceSeaboard.containsKey('newWorld|nw1|sea1'), true);
 
+      // SPEC capital-and-connectivity § Town per province: every province has townTileKey set.
+      final gp = result.game.players.first;
+      for (final p in result.game.worldState.oldWorld.provinces) {
+        expect(p.townTileKey, isNotNull, reason: 'OW province ${p.id} must have townTileKey');
+      }
+      for (final p in result.game.worldState.newWorld.provinces) {
+        expect(p.townTileKey, isNotNull, reason: 'NW province ${p.id} must have townTileKey');
+      }
+      final capitalProvince = result.game.worldState.oldWorld.provinces.firstWhere((p) => p.id == gp.capitalProvinceId);
+      expect(capitalProvince.townTileKey, gp.capitalTile?.toTileKey(), reason: 'Capital province townTileKey must equal capital tile key');
+
       // Province naming: mandatory; GP capital gets capital city name, others from pool.
       expect(result.game.players.first.displayName, 'England');
       final owProvinces = result.game.worldState.oldWorld.provinces;

--- a/packages/colonizethis_logic/test/resource_extractor_test.dart
+++ b/packages/colonizethis_logic/test/resource_extractor_test.dart
@@ -48,11 +48,13 @@ void main() {
         players: [player],
       );
       final connectivity = {
-        'pl1': {
-          'oldWorld|p1|0|0',
-          'oldWorld|p1|1|0',
-          'oldWorld|p1|0|1',
-        },
+        'pl1': ConnectivityResult(
+          connected: {
+            'oldWorld|p1|0|0',
+            'oldWorld|p1|1|0',
+            'oldWorld|p1|0|1',
+          },
+        ),
       };
       final result = computeExtraction(
         game: game,
@@ -101,7 +103,7 @@ void main() {
       final result = computeExtraction(
         game: game,
         tileMapByRegion: {'oldWorld': tileMap},
-        connectivityResult: {'pl1': {'oldWorld|p1|0|0'}},
+        connectivityResult: {'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'})},
         techCapForPlayer: (_) => 4,
       );
       expect(result['pl1']!.land['grain'], 1);
@@ -155,7 +157,7 @@ void main() {
       final result = computeExtraction(
         game: game,
         tileMapByRegion: {'oldWorld': tileMap},
-        connectivityResult: {'pl1': connectedTiles},
+        connectivityResult: {'pl1': ConnectivityResult(connected: connectedTiles)},
         techCapForPlayer: (_) => 4,
       );
       expect(result['pl1']!.land['wool'], 1);
@@ -197,7 +199,7 @@ void main() {
       final result = computeExtraction(
         game: game,
         tileMapByRegion: {'oldWorld': tileMap},
-        connectivityResult: {'pl1': {'oldWorld|p1|0|0'}},
+        connectivityResult: {'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'})},
         techCapForPlayer: (_) => 4,
       );
       expect(result['pl1']!.land['iron'], isNull);
@@ -238,7 +240,7 @@ void main() {
       final result = computeExtraction(
         game: game,
         tileMapByRegion: {'oldWorld': tileMap},
-        connectivityResult: {'pl1': {'oldWorld|p1|0|0'}},
+        connectivityResult: {'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'})},
         techCapForPlayer: (_) => 4,
       );
       expect(result['pl1']!.land['iron'], 2);
@@ -277,7 +279,7 @@ void main() {
       final result = computeExtraction(
         game: game,
         tileMapByRegion: {'oldWorld': tileMap},
-        connectivityResult: {'pl1': {'oldWorld|p1|0|0'}},
+        connectivityResult: {'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'})},
         techCapForPlayer: (_) => 4,
       );
       expect(result['pl1']!.land['grain'], 1);
@@ -318,11 +320,67 @@ void main() {
       final result = computeExtraction(
         game: game,
         tileMapByRegion: {'oldWorld': TileMapResult(width: 1, height: 1, grid: [['p1']], resourceGrid: [[null]]), 'newWorld': tileMapNw},
-        connectivityResult: {'pl1': {'newWorld|n1|0|0'}},
+        connectivityResult: {'pl1': ConnectivityResult(connected: {'newWorld|n1|0|0'})},
         techCapForPlayer: (_) => 4,
       );
       expect(result['pl1']!.overseas['sugarCane'], 1);
       expect(result['pl1']!.land, isEmpty);
+    });
+
+    test('effective yield capped by min transport level along path to capital', () {
+      // SPEC: effective yield = min(production, tech cap, town dev, min transport along path).
+      // When pathTransportCap is provided, it caps yield (e.g. path with road-1 segment → cap 1).
+      final grid = [['p1']];
+      final tileMap = TileMapResult(
+        width: 1,
+        height: 1,
+        grid: grid,
+        resourceGrid: [[Resource.grain]],
+      );
+      final tileState = TileMapState()
+          .setImprovement('oldWorld|p1|0|0', 3)
+          .setRoadLevel('oldWorld|p1|0|0', 3);
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+          oldWorld: RegionData(provinces: [
+            Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
+          ]),
+          newWorld: const RegionData(),
+          tileState: tileState,
+        ),
+        players: [
+          Player(
+            id: 'pl1',
+            displayName: 'Spain',
+            isHuman: true,
+            capitalProvinceId: 'p1',
+            capitalTile: CapitalTile(regionId: 'oldWorld', provinceId: 'p1', x: 0, y: 0),
+          ),
+        ],
+      );
+      final connectivity = resolveConnectivity(
+        game: game,
+        tileMapByRegion: {'oldWorld': tileMap},
+        topology: MapTopology(
+          nodes: [TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province)],
+          edges: [],
+        ),
+      );
+      expect(connectivity['pl1']!.pathTransportCap['oldWorld|p1|0|0'], 3);
+      final resultWithPathCap = computeExtraction(
+        game: game,
+        tileMapByRegion: {'oldWorld': tileMap},
+        connectivityResult: {
+          'pl1': ConnectivityResult(
+            connected: {'oldWorld|p1|0|0'},
+            pathTransportCap: {'oldWorld|p1|0|0': 1},
+          ),
+        },
+        techCapForPlayer: (_) => 4,
+      );
+      expect(resultWithPathCap['pl1']!.land['grain'], 1);
     });
 
     test('returns empty ExtractionTotals when player has no connected tiles', () {
@@ -347,7 +405,7 @@ void main() {
       final result = computeExtraction(
         game: game,
         tileMapByRegion: const {},
-        connectivityResult: {'pl1': {}},
+        connectivityResult: {'pl1': ConnectivityResult(connected: {})},
         techCapForPlayer: (_) => 4,
       );
       expect(result['pl1']!.land, isEmpty);


### PR DESCRIPTION
Addresses [issue #1](https://github.com/waigore/colonizethisv3/issues/1) (SPEC capital-and-connectivity: gaps in implementation and test coverage).

## Summary

- **Effective yield (path transport cap):** Implement min transport level along path to capital per SPEC. `resolveConnectivity` now returns `ConnectivityResult` (connected set + `pathTransportCap` map). `computeExtraction` uses path transport cap so effective yield = min(production, tech cap, town dev, **pathTransportCap**). Unit test added.
- **Connectivity edge cases:** Test that losing a province on the road path to the capital removes tiles beyond it from the connected set, and retaking that province restores connections.
- **Town per province:** Fix `_applyNaming` so it preserves `townTileKey` (use `p.copyWith(displayName: name)` instead of constructing a new `Province`). Add test assertions that every province has `townTileKey` set and capital province’s `townTileKey` equals the capital tile key.

Capital loss/reassignment tests (issue §3) are left for a follow-up.

Quality gate: `python3 tool/test_coverage.py` and `tool/check_coverage_threshold.sh 90 packages/colonizethis_logic` pass.

Made with [Cursor](https://cursor.com)