### PR TITLE
chore: add workflow to enable PR auto-merge

### DIFF
--- a/.github/workflows/enable-automerge.yml
+++ b/.github/workflows/enable-automerge.yml
@@ -1,0 +1,19 @@
+name: Enable PR auto-merge
+
+on:
+  pull_request:
+    types: [opened, reopened]
+    branches: [main, dev]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  enable-automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/enable-automerge.yml
+++ b/.github/workflows/enable-automerge.yml
@@ -13,6 +13,9 @@ jobs:
   enable-automerge:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
         env:


### PR DESCRIPTION
Adds a workflow that enables auto-merge (squash) on every new or reopened PR targeting `main` or `dev`.

Requires repo setting **Allow auto-merge** and branch protection with at least one requirement on the base branch.

Made with [Cursor](https://cursor.com)