### PR TITLE
fix(#5): verify leader multipliers in combat resolution path

### DIFF
--- a/packages/colonizethis_logic/test/combat_resolver_test.dart
+++ b/packages/colonizethis_logic/test/combat_resolver_test.dart
@@ -198,10 +198,37 @@ void main() {
         fortLevel: 0,
         terrain: 'plains',
       );
+      // SPEC/game/leader-bonuses.md: napoleon 1.25, frederick 1.15. Verify combat path
+      // passes these multipliers by matching resolveEngagement with same params.
+      const attMult = 1.25;
+      const defMult = 1.15;
+      final engagementOutcome = resolveEngagement(
+        attackerUnits: attackerUnits,
+        defenderUnits: defenderUnits,
+        fortLevel: ctx.fortLevel,
+        terrain: ctx.terrain,
+        attackerLeaderMultiplier: attMult,
+        defenderLeaderMultiplier: defMult,
+      );
       final result = resolveBattleContext(game, ctx);
       expect(result.worldState.oldWorld.units.length, lessThanOrEqualTo(3),
           reason: 'some units may be casualties');
       expect(result.worldState.oldWorld.provinces.single.id, 'p');
+      // Battle result must match engagement: same casualties and province ownership.
+      final allCasualties = {
+        ...engagementOutcome.attackerCasualties,
+        ...engagementOutcome.defenderCasualties,
+      };
+      final survivingIds = result.worldState.oldWorld.units.map((u) => u.id).toSet();
+      for (final id in allCasualties) {
+        expect(survivingIds.contains(id), isFalse,
+            reason: 'Casualty $id should not survive');
+      }
+      final expectedOwner = engagementOutcome.result == EngagementResult.attackerVictory
+          ? 'att'
+          : ctx.defenderFactionId;
+      expect(result.worldState.oldWorld.provinces.single.ownerId, expectedOwner,
+          reason: 'Province owner should match engagement result');
     });
 
     test('resolveBattleContext updates newWorld when regionId is newWorld', () {


### PR DESCRIPTION
## Summary

Closes #5 (Leader bonuses: Quick Battle + leader bonus logic under-tested).

Quick Battle and `buildQuickBattleInput` already apply leader multipliers; `leaderCombatBonusMultiplier` and Quick Battle tests were already in place. This PR adds the missing **combat resolution path** assertion required by the issue.

## Changes

- **combat_resolver_test.dart**: Strengthen the test _leader keys from Game produce correct multipliers in resolveEngagement path_ so that it:
  1. Calls `resolveEngagement` with spec multipliers (napoleon 1.25, frederick 1.15) for the same units and context.
  2. Calls `resolveBattleContext(game, ctx)` with a `Game` whose players have `leaderKey: 'napoleon'` / `'frederick'`.
  3. Asserts that the battle result matches the engagement outcome: same casualties (no survivor in the casualty set) and province ownership consistent with the engagement result.

This verifies that leader keys from `Game`/`Player` result in the correct multipliers being passed to the engagement resolver (SPEC/game/leader-bonuses.md).

## Acceptance criteria (from issue #5)

- [x] Quick Battle applies the same leader bonus rule as auto-resolve — already implemented.
- [x] `leaderCombatBonusMultiplier` has unit tests (napoleon 1.25, frederick 1.15, reserve/empty/unknown 1.0) — already in colonizethis_data.
- [x] Combat resolution path has at least one test that verifies leader keys from Game/Player result in the correct multipliers being passed to the engagement resolver — **added in this PR**.
- [x] No new behavior that contradicts SPEC/game/leader-bonuses.md.

## Quality gate

- `python3 tool/test_coverage.py` — all tests pass.
- `tool/check_coverage_threshold.sh 90 packages/colonizethis_logic` — colonizethis_logic at or above 90% line coverage.