### PR TITLE
ci: use AUTOMERGE_TOKEN for enable-automerge workflow

### DIFF
--- a/.github/workflows/enable-automerge.yml
+++ b/.github/workflows/enable-automerge.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}


### PR DESCRIPTION
Switches the Enable PR auto-merge workflow to use the AUTOMERGE_TOKEN secret instead of GITHUB_TOKEN so that `gh pr merge --auto` can call enablePullRequestAutoMerge (GITHUB_TOKEN does not have permission).

Made with [Cursor](https://cursor.com)