### PR TITLE
test(colonizethis_data): add terrain_region_rules and naming_rules coverage

### DIFF
--- a/packages/colonizethis_data/test/naming_rules_test.dart
+++ b/packages/colonizethis_data/test/naming_rules_test.dart
@@ -1,0 +1,127 @@
+import 'package:colonizethis_test/test.dart';
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+
+void main() {
+  final config = defaultNamingConfig;
+
+  group('allGreatPowerIds', () {
+    test('contains expected GPs (GDD 09)', () {
+      expect(allGreatPowerIds, contains('england'));
+      expect(allGreatPowerIds, contains('france'));
+      expect(allGreatPowerIds, contains('prussia'));
+      expect(allGreatPowerIds, contains('sweden'));
+      expect(allGreatPowerIds.length, 7);
+    });
+  });
+
+  group('Prussia variant ids', () {
+    test('prussia has two leader variants', () {
+      final gp = config.gpById('prussia');
+      expect(gp, isNotNull);
+      expect(gp!.hasMultipleVariants, isTrue);
+      expect(gp.leaderVariants.length, 2);
+    });
+
+    test('variantById returns correct variant', () {
+      final gp = config.gpById('prussia')!;
+      final frederick = gp.variantById(prussiaVariantFrederickTheGreat);
+      expect(frederick.name, contains('Frederick the Great'));
+      final frederickWilliam = gp.variantById(prussiaVariantFrederickWilliam);
+      expect(frederickWilliam.name, contains('Frederick William'));
+    });
+
+    test('variantById unknown falls back to first', () {
+      final gp = config.gpById('england')!;
+      final v = gp.variantById('unknown');
+      expect(v, equals(gp.leaderVariants.first));
+    });
+  });
+
+  group('ResolvedNamingConfig.gpById', () {
+    test('returns GreatPowerNaming for known id', () {
+      final gp = config.gpById('england');
+      expect(gp, isNotNull);
+      expect(gp!.id, 'england');
+      expect(gp.countryName, 'England');
+      expect(gp.capitalCityName, 'London');
+    });
+
+    test('returns null for unknown id', () {
+      expect(config.gpById('unknown_gp'), isNull);
+    });
+  });
+
+  group('ResolvedNamingConfig.defaultLeaderVariantId', () {
+    test('returns first variant id for known GP', () {
+      expect(config.defaultLeaderVariantId('england'), 'queen_victoria');
+      expect(config.defaultLeaderVariantId('prussia'), prussiaVariantFrederickTheGreat);
+    });
+
+    test('returns empty string for unknown GP', () {
+      expect(config.defaultLeaderVariantId('unknown'), '');
+    });
+  });
+
+  group('ResolvedNamingConfig.hasMultipleLeaderVariants', () {
+    test('true for prussia', () {
+      expect(config.hasMultipleLeaderVariants('prussia'), isTrue);
+    });
+
+    test('false for england', () {
+      expect(config.hasMultipleLeaderVariants('england'), isFalse);
+    });
+
+    test('false for unknown GP', () {
+      expect(config.hasMultipleLeaderVariants('unknown'), isFalse);
+    });
+  });
+
+  group('ResolvedNamingConfig.minorById', () {
+    test('returns MinorNationNaming for known id', () {
+      final m = config.minorById('minor1');
+      expect(m, isNotNull);
+      expect(m!.id, 'minor1');
+      expect(m.displayName, 'Italy');
+      expect(m.provinceNamePool, isNotEmpty);
+    });
+
+    test('returns null for unknown id', () {
+      expect(config.minorById('unknown_minor'), isNull);
+    });
+  });
+
+  group('ResolvedNamingConfig.tribeById', () {
+    test('returns TribeNaming for known id', () {
+      final t = config.tribeById('tribe1');
+      expect(t, isNotNull);
+      expect(t!.id, 'tribe1');
+      expect(t.displayName, 'Aztec');
+      expect(t.provinceNamePool, isNotEmpty);
+    });
+
+    test('returns null for unknown id', () {
+      expect(config.tribeById('unknown_tribe'), isNull);
+    });
+  });
+
+  group('defaultNamingConfig structure', () {
+    test('greatPowers count matches allGreatPowerIds', () {
+      expect(config.greatPowers.length, allGreatPowerIds.length);
+    });
+
+    test('minorNations and tribes are non-empty (GDD 09b/09c)', () {
+      expect(config.minorNations.length, greaterThanOrEqualTo(6));
+      expect(config.tribes.length, greaterThanOrEqualTo(6));
+    });
+
+    test('LeaderVariant has required fields', () {
+      final gp = config.gpById('england')!;
+      final v = gp.leaderVariants.first;
+      expect(v.id, isNotEmpty);
+      expect(v.name, isNotEmpty);
+      expect(v.leaderKey, isNotEmpty);
+      expect(v.provinceNamePool, isNotEmpty);
+    });
+  });
+}

--- a/packages/colonizethis_data/test/terrain_region_rules_test.dart
+++ b/packages/colonizethis_data/test/terrain_region_rules_test.dart
@@ -1,0 +1,82 @@
+import 'package:colonizethis_test/test.dart';
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+
+void main() {
+  group('oldWorldTerrains / newWorldTerrains', () {
+    test('oldWorldTerrains does not include desert', () {
+      expect(oldWorldTerrains.contains(TerrainType.desert), isFalse);
+      expect(oldWorldTerrains, contains(TerrainType.plains));
+      expect(oldWorldTerrains, contains(TerrainType.forest));
+      expect(oldWorldTerrains, contains(TerrainType.mountain));
+    });
+
+    test('newWorldTerrains includes desert (SPEC resource-terrain-region)', () {
+      expect(newWorldTerrains, contains(TerrainType.desert));
+      expect(newWorldTerrains.length, greaterThan(oldWorldTerrains.length));
+    });
+  });
+
+  group('allowedTerrainsForRegion', () {
+    test('oldWorld returns oldWorldTerrains', () {
+      final list = allowedTerrainsForRegion('oldWorld');
+      expect(list, equals(oldWorldTerrains));
+    });
+
+    test('newWorld returns newWorldTerrains', () {
+      final list = allowedTerrainsForRegion('newWorld');
+      expect(list, equals(newWorldTerrains));
+    });
+
+    test('unknown region falls back to oldWorldTerrains', () {
+      final list = allowedTerrainsForRegion('unknown');
+      expect(list, equals(oldWorldTerrains));
+    });
+  });
+
+  group('terrainDistributionForRegion', () {
+    test('oldWorld returns distribution with mountain fraction', () {
+      final dist = terrainDistributionForRegion('oldWorld');
+      expect(dist.mountainFraction, inInclusiveRange(0.0, 1.0));
+      expect(dist.fractionFor(TerrainType.mountain), dist.mountainFraction);
+    });
+
+    test('newWorld returns distribution including desert', () {
+      final dist = terrainDistributionForRegion('newWorld');
+      expect(dist.nonMountainFractions, contains(TerrainType.desert));
+      expect(dist.fractionFor(TerrainType.desert), greaterThan(0));
+    });
+
+    test('unknown region falls back to oldWorld distribution', () {
+      final dist = terrainDistributionForRegion('other');
+      expect(dist.mountainFraction, inInclusiveRange(0.0, 1.0));
+      expect(dist.nonMountainFractions, isNotEmpty);
+    });
+  });
+
+  group('TerrainDistribution.fractionFor', () {
+    test('mountain returns mountainFraction', () {
+      const dist = TerrainDistribution(
+        mountainFraction: 0.2,
+        nonMountainFractions: {
+          TerrainType.plains: 0.5,
+          TerrainType.forest: 0.3,
+        },
+      );
+      expect(dist.fractionFor(TerrainType.mountain), 0.2);
+    });
+
+    test('non-mountain returns value from map or 0', () {
+      const dist = TerrainDistribution(
+        mountainFraction: 0.1,
+        nonMountainFractions: {
+          TerrainType.plains: 0.6,
+          TerrainType.forest: 0.3,
+        },
+      );
+      expect(dist.fractionFor(TerrainType.plains), 0.6);
+      expect(dist.fractionFor(TerrainType.forest), 0.3);
+      expect(dist.fractionFor(TerrainType.desert), 0.0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Raises test coverage in `packages/colonizethis_data` for the low-coverage files noted in the memory-bank outstanding tasks: `terrain_region_rules` and `naming_rules`.

## Changes

- **terrain_region_rules_test.dart** (new): Tests for `oldWorldTerrains` / `newWorldTerrains` (OW vs NW, desert in NW only), `allowedTerrainsForRegion` (oldWorld, newWorld, unknown fallback), `terrainDistributionForRegion` (oldWorld, newWorld, unknown fallback), and `TerrainDistribution.fractionFor` (mountain vs non-mountain). Aligned with SPEC tile-map and resource-terrain-region.
- **naming_rules_test.dart** (new): Tests for `allGreatPowerIds`, Prussia leader variants (`variantById`, `hasMultipleVariants`), `ResolvedNamingConfig` (`gpById`, `defaultLeaderVariantId`, `hasMultipleLeaderVariants`, `minorById`, `tribeById`), and `defaultNamingConfig` structure (GDD 09).

## Coverage

- **colonizethis_data** line coverage: **87.4%** (up from 79.7% after PR #14).
- Quality gate (colonizethis_logic ≥ 90%) unchanged and passing.