### PR TITLE
fix(victory): spec test gaps and dismissible View final state (issue #15)

### DIFF
--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -63,18 +63,46 @@ class GameScreen extends ConsumerWidget {
             ),
           ],
           if (game != null && victory != null)
-            Positioned.fill(
-              child: Container(
-                color: Colors.black54,
-                child: Center(
-                  child: _VictoryPanel(
-                    game: game,
-                    victory: victory,
-                  ),
-                ),
-              ),
+            _VictoryOverlay(
+              game: game!,
+              victory: victory!,
             ),
         ],
+      ),
+    );
+  }
+}
+
+/// Stateful overlay so "View final state" can hide the panel without a route (SPEC/game/victory.md).
+class _VictoryOverlay extends StatefulWidget {
+  const _VictoryOverlay({
+    required this.game,
+    required this.victory,
+  });
+
+  final ct_models.Game game;
+  final ct_models.VictoryState victory;
+
+  @override
+  State<_VictoryOverlay> createState() => _VictoryOverlayState();
+}
+
+class _VictoryOverlayState extends State<_VictoryOverlay> {
+  bool _dismissed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (_dismissed) return const SizedBox.shrink();
+    return Positioned.fill(
+      child: Container(
+        color: Colors.black54,
+        child: Center(
+          child: _VictoryPanel(
+            game: widget.game,
+            victory: widget.victory,
+            onViewFinalState: () => setState(() => _dismissed = true),
+          ),
+        ),
       ),
     );
   }
@@ -84,10 +112,12 @@ class _VictoryPanel extends StatelessWidget {
   const _VictoryPanel({
     required this.game,
     required this.victory,
+    this.onViewFinalState,
   });
 
   final ct_models.Game game;
   final ct_models.VictoryState victory;
+  final VoidCallback? onViewFinalState;
 
   @override
   Widget build(BuildContext context) {
@@ -129,8 +159,7 @@ class _VictoryPanel extends StatelessWidget {
                 const SizedBox(width: 12),
                 TextButton(
                   onPressed: () {
-                    // Simply close the panel; map remains visible but game is finished.
-                    Navigator.of(context).maybePop();
+                    onViewFinalState?.call();
                   },
                   child: const Text('View final state'),
                 ),

--- a/ctdev/lib/screens/running_game_screen.dart
+++ b/ctdev/lib/screens/running_game_screen.dart
@@ -46,6 +46,9 @@ class _RunningGameScreenState extends State<RunningGameScreen>
   bool _showImprovements = false;
   bool _showUnits = false;
 
+  /// When set, victory overlay is hidden (View final state); game.victory still set.
+  int? _dismissedVictoryTurnNumber;
+
   @override
   void initState() {
     super.initState();
@@ -209,7 +212,8 @@ class _RunningGameScreenState extends State<RunningGameScreen>
               ),
             ],
           ),
-          if (victory != null) _buildVictoryOverlay(context, victory),
+          if (victory != null && _dismissedVictoryTurnNumber != victory.turnNumber)
+            _buildVictoryOverlay(context, victory),
         ],
       ),
     );
@@ -251,7 +255,9 @@ class _RunningGameScreenState extends State<RunningGameScreen>
                     const SizedBox(width: 16),
                     OutlinedButton(
                       onPressed: () {
-                        setState(() {});
+                        setState(() {
+                          _dismissedVictoryTurnNumber = victory.turnNumber;
+                        });
                       },
                       child: const Text('View final state'),
                     ),

--- a/packages/colonizethis_logic/test/turn_resolver_test.dart
+++ b/packages/colonizethis_logic/test/turn_resolver_test.dart
@@ -783,6 +783,141 @@ void main() {
       expect(next.victory!.type, VictoryType.military);
     });
 
+    test('endOfTurn sets military victory when one GP controls exactly 31 OW provinces', () {
+      const ow = 'oldWorld';
+      final provinces = List<Province>.generate(
+        31,
+        (i) => Province(id: '$ow|P$i', regionId: ow, ownerId: 'p1'),
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
+          oldWorld: RegionData(provinces: provinces),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'A', isHuman: true),
+          Player(id: 'p2', displayName: 'B', isHuman: true),
+        ],
+      );
+      final topology = MapTopology(
+        nodes: [
+          for (var i = 0; i < 31; i++)
+            TopologyNode(id: 'P$i', regionId: ow, type: TopologyNodeType.province),
+        ],
+        edges: const [],
+      );
+      final next = resolveTurnForGame(
+        game: game,
+        topology: topology,
+        orders: const Orders(),
+      );
+      expect(next.victory, isNotNull);
+      expect(next.victory!.winnerPlayerId, 'p1');
+      expect(next.victory!.type, VictoryType.military);
+    });
+
+    test('endOfTurn tie-break: two GPs with ≥31 OW provinces wins lexicographically smallest id', () {
+      const ow = 'oldWorld';
+      final provinces = <Province>[
+        ...List<Province>.generate(31, (i) => Province(id: '$ow|A$i', regionId: ow, ownerId: 'p1')),
+        ...List<Province>.generate(31, (i) => Province(id: '$ow|B$i', regionId: ow, ownerId: 'p2')),
+      ];
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(provinces: provinces),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+          Player(id: 'p2', displayName: 'P2', isHuman: true),
+        ],
+      );
+      final topology = MapTopology(
+        nodes: [
+          ...List.generate(31, (i) => TopologyNode(id: 'A$i', regionId: ow, type: TopologyNodeType.province)),
+          ...List.generate(31, (i) => TopologyNode(id: 'B$i', regionId: ow, type: TopologyNodeType.province)),
+        ],
+        edges: const [],
+      );
+      final next = resolveTurnForGame(
+        game: game,
+        topology: topology,
+        orders: const Orders(),
+      );
+      expect(next.victory, isNotNull);
+      expect(next.victory!.winnerPlayerId, 'p1');
+    });
+
+    test('endOfTurn no victory when only Minor/Tribe has ≥31 OW provinces', () {
+      const ow = 'oldWorld';
+      final provinces = List<Province>.generate(
+        31,
+        (i) => Province(id: '$ow|P$i', regionId: ow, ownerId: 'minor1'),
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+          oldWorld: RegionData(provinces: provinces),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'GP1', isHuman: true),
+          Player(id: 'p2', displayName: 'GP2', isHuman: true),
+        ],
+      );
+      final topology = MapTopology(
+        nodes: [
+          for (var i = 0; i < 31; i++)
+            TopologyNode(id: 'P$i', regionId: ow, type: TopologyNodeType.province),
+        ],
+        edges: const [],
+      );
+      final next = resolveTurnForGame(
+        game: game,
+        topology: topology,
+        orders: const Orders(),
+      );
+      expect(next.victory, isNull);
+    });
+
+    test('endOfTurn no victory when no GP has ≥31 OW provinces', () {
+      const ow = 'oldWorld';
+      final provinces = <Province>[
+        ...List<Province>.generate(30, (i) => Province(id: '$ow|A$i', regionId: ow, ownerId: 'p1')),
+        ...List<Province>.generate(30, (i) => Province(id: '$ow|B$i', regionId: ow, ownerId: 'p2')),
+      ];
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(provinces: provinces),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+          Player(id: 'p2', displayName: 'P2', isHuman: true),
+        ],
+      );
+      final topology = MapTopology(
+        nodes: [
+          ...List.generate(30, (i) => TopologyNode(id: 'A$i', regionId: ow, type: TopologyNodeType.province)),
+          ...List.generate(30, (i) => TopologyNode(id: 'B$i', regionId: ow, type: TopologyNodeType.province)),
+        ],
+        edges: const [],
+      );
+      final next = resolveTurnForGame(
+        game: game,
+        topology: topology,
+        orders: const Orders(),
+      );
+      expect(next.victory, isNull);
+    });
+
     test('endOfTurn phase leaves game unchanged when victory already set', () {
       const ow = 'oldWorld';
       final game = Game(


### PR DESCRIPTION
## Summary

Closes #15. Implements the missing victory spec tests and makes **View final state** actually dismiss the victory overlay per SPEC/game/victory.md.

## Changes

### 1. Unit tests (colonizethis_logic)

- **Exactly 31 OW provinces:** One GP with exactly 31 Old World provinces triggers military victory (spec: "31 or more").
- **Tie-breaking:** Two GPs each with ≥31 OW provinces → winner is lexicographically smallest player id (`p1` before `p2`).
- **Eligibility:** Only Minor/Tribe has ≥31 OW provinces (GPs have fewer) → `victory` remains `null`.
- **No false positive:** All GPs have &lt;31 OW provinces (e.g. 30 each) → `victory` remains `null`.

### 2. View final state (ctdev)

- Added `_dismissedVictoryTurnNumber`; when user taps **View final state**, the overlay is hidden and they can continue viewing the map without further turns. Return to main menu unchanged.

### 3. View final state (app)

- Replaced inline overlay with stateful `_VictoryOverlay`; **View final state** sets `_dismissed = true` so the panel is hidden (no route, so `maybePop()` was ineffective). Map remains visible; Return to main menu unchanged.

## Acceptance criteria (from issue #15)

- [x] All four unit tests exist and pass.
- [x] "View final state" dismisses the victory overlay and leaves the user viewing the map, no further turn advancement.
- [x] "Return to main menu" continues to work.
- [x] No regressions (colonizethis_logic tests and quality gate pass).