### PR TITLE
fix(ai): aggregate naval mission orders in generateOrdersForGameFullAI

### DIFF
--- a/packages/colonizethis_logic/lib/src/ai/ai_planner.dart
+++ b/packages/colonizethis_logic/lib/src/ai/ai_planner.dart
@@ -128,6 +128,7 @@ Orders generateOrdersForGameFullAI(
   final researchByPlayer = <String, List<ResearchOrder>>{};
   final diploByPlayer = <String, List<DiplomaticOrder>>{};
   final navalByPlayer = <String, List<NavalMoveOrder>>{};
+  final missionByPlayer = <String, List<NavalMissionOrder>>{};
 
   for (final player in game.players) {
     if (!isAiControlled(game, player.id)) continue;
@@ -147,6 +148,7 @@ Orders generateOrdersForGameFullAI(
     add(researchByPlayer, player.id, ordersForPlayer.researchOrdersByPlayerId[player.id]);
     add(diploByPlayer, player.id, ordersForPlayer.diplomaticOrdersByPlayerId[player.id]);
     add(navalByPlayer, player.id, ordersForPlayer.navalMoveOrdersByPlayerId[player.id]);
+    add(missionByPlayer, player.id, ordersForPlayer.navalMissionOrdersByPlayerId[player.id]);
   }
 
   return Orders(
@@ -156,5 +158,6 @@ Orders generateOrdersForGameFullAI(
     diplomaticOrdersByPlayerId: diploByPlayer,
     researchOrdersByPlayerId: researchByPlayer,
     navalMoveOrdersByPlayerId: navalByPlayer,
+    navalMissionOrdersByPlayerId: missionByPlayer,
   );
 }

--- a/packages/colonizethis_logic/test/ai_planner_test.dart
+++ b/packages/colonizethis_logic/test/ai_planner_test.dart
@@ -208,6 +208,7 @@ void main() {
       expect(orders.buildUnitOrdersByPlayerId, isNotNull);
       expect(orders.researchOrdersByPlayerId, isNotNull);
       expect(orders.navalMoveOrdersByPlayerId, isNotNull);
+      expect(orders.navalMissionOrdersByPlayerId, isNotNull);
       expect(orders.diplomaticOrdersByPlayerId, isNotNull);
       expect(
         orders.researchOrdersByPlayerId['gp1'],


### PR DESCRIPTION
## Summary
Fixes **item 1** of #18 (AI Phase 6 gaps): naval mission orders were dropped when aggregating full-AI orders.

**Spec:** `generateOrdersForGameFullAI` must aggregate all order types including naval (SPEC/program/ai-planner.md).

**Problem:** `generateOrdersForGameFullAI` aggregated `navalMoveOrdersByPlayerId` but did not include `navalMissionOrdersByPlayerId` in the returned `Orders`. Domain planners in `colonizethis_ai` produce naval mission orders via `_appendNavalMissionOrders`, but the logic layer dropped them.

**Fix:**
- Added `missionByPlayer` map and aggregate `ordersForPlayer.navalMissionOrdersByPlayerId[player.id]` (same pattern as naval moves).
- Pass `navalMissionOrdersByPlayerId: missionByPlayer` into the returned `Orders()`.
- Assert `orders.navalMissionOrdersByPlayerId` in `ai_planner_test`.

Tests and coverage gate (colonizethis_logic ≥90%) pass.

Made with [Cursor](https://cursor.com)