### PR TITLE
feat(ai): perception threat and opportunity from topology (gap #6)

### DIFF
--- a/packages/colonizethis_ai/lib/src/perception.dart
+++ b/packages/colonizethis_ai/lib/src/perception.dart
@@ -1,3 +1,4 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 
@@ -62,10 +63,12 @@ class AIWorldSnapshot {
   /// Relation state keyed by other faction id (war, peace, etc.).
   final Map<String, DiplomacyRelation> relations;
 
-  /// Builds snapshot from [view]. Deterministic: same view → same snapshot.
-  static AIWorldSnapshot fromPlayerView(PlayerView view) {
-    final threats = _buildThreatSummary(view);
-    final opportunities = _buildOpportunitySummary(view);
+  /// Builds snapshot from [view]. When [topology] is provided, computes
+  /// neighborProvincesHostile, capitalThreatened, weakNeighbors, and
+  /// richUnexploitedProvinces from view + topology. Deterministic: same view → same snapshot.
+  static AIWorldSnapshot fromPlayerView(PlayerView view, {MapTopology? topology}) {
+    final threats = _buildThreatSummary(view, topology);
+    final opportunities = _buildOpportunitySummary(view, topology);
     final economy = _buildEconomySummary(view);
     return AIWorldSnapshot(
       playerId: view.playerId,
@@ -76,7 +79,7 @@ class AIWorldSnapshot {
     );
   }
 
-  static ThreatSummary _buildThreatSummary(PlayerView view) {
+  static ThreatSummary _buildThreatSummary(PlayerView view, MapTopology? topology) {
     final atWarWith = <String>[];
     for (final e in view.diplomacyByOtherId.entries) {
       final rel = e.value;
@@ -84,17 +87,118 @@ class AIWorldSnapshot {
         atWarWith.add(e.key);
       }
     }
-    // Neighbor hostility and capital threat would need topology + visibility;
-    // stub for now.
-    return ThreatSummary(atWarWith: atWarWith);
+    if (topology == null) {
+      return ThreatSummary(atWarWith: atWarWith);
+    }
+    final ownedIds = <String>{};
+    for (final p in view.provincesById.entries) {
+      if (p.value.ownerId == view.playerId) ownedIds.add(p.key);
+    }
+    int neighborProvincesHostile = 0;
+    final neighborProvinceIds = _neighborProvinceIdsFromTopology(topology, ownedIds, view);
+    for (final neighborFullId in neighborProvinceIds) {
+      final prov = view.provincesById[neighborFullId];
+      if (prov == null) continue;
+      final ownerId = prov.ownerId;
+      if (ownerId == null || ownerId.isEmpty || ownerId == view.playerId) continue;
+      final rel = view.diplomacyByOtherId[ownerId];
+      if (rel != null && rel.state == RelationState.atWar) {
+        neighborProvincesHostile++;
+      }
+    }
+    bool capitalThreatened = false;
+    final capitalId = view.player.capitalProvinceId;
+    if (capitalId != null && capitalId.isNotEmpty && ownedIds.contains(capitalId)) {
+      final capitalNeighbors = _neighborProvinceIdsFromTopology(
+        topology,
+        {capitalId},
+        view,
+      );
+      for (final neighborFullId in capitalNeighbors) {
+        final prov = view.provincesById[neighborFullId];
+        if (prov == null) continue;
+        final ownerId = prov.ownerId;
+        if (ownerId == null || ownerId.isEmpty || ownerId == view.playerId) continue;
+        final rel = view.diplomacyByOtherId[ownerId];
+        if (rel != null && rel.state == RelationState.atWar) {
+          capitalThreatened = true;
+          break;
+        }
+      }
+    }
+    return ThreatSummary(
+      atWarWith: atWarWith,
+      neighborProvincesHostile: neighborProvincesHostile,
+      capitalThreatened: capitalThreatened,
+    );
   }
 
-  static OpportunitySummary _buildOpportunitySummary(PlayerView view) {
-    int unclaimed = 0;
-    for (final p in view.provincesById.values) {
-      if (p.ownerId == null || p.ownerId!.isEmpty) unclaimed++;
+  /// Returns full province ids of provinces adjacent to [ownedFullIds] per [topology].
+  static Set<String> _neighborProvinceIdsFromTopology(
+    MapTopology topology,
+    Set<String> ownedFullIds,
+    PlayerView view,
+  ) {
+    final out = <String>{};
+    for (final fullId in ownedFullIds) {
+      final regionId = ProvinceId.regionIdFrom(fullId);
+      final localId = ProvinceId.localIdFrom(fullId);
+      for (final edge in topology.edges) {
+        String? neighborLocalId;
+        if (edge.id1 == localId) {
+          neighborLocalId = edge.id2;
+        } else if (edge.id2 == localId) {
+          neighborLocalId = edge.id1;
+        }
+        if (neighborLocalId == null) continue;
+        TopologyNode? neighborNode;
+        for (final n in topology.nodes) {
+          if (n.id == neighborLocalId) {
+            neighborNode = n;
+            break;
+          }
+        }
+        if (neighborNode == null || neighborNode.type != TopologyNodeType.province) continue;
+        if (neighborNode.regionId != regionId) continue;
+        final neighborFullId = ProvinceId.full(neighborNode.regionId, neighborNode.id);
+        if (!ownedFullIds.contains(neighborFullId)) out.add(neighborFullId);
+      }
     }
-    return OpportunitySummary(unclaimedProvinces: unclaimed);
+    return out;
+  }
+
+  static OpportunitySummary _buildOpportunitySummary(PlayerView view, MapTopology? topology) {
+    int unclaimed = 0;
+    int richUnexploited = 0;
+    for (final p in view.provincesById.values) {
+      if (p.ownerId == null || p.ownerId!.isEmpty) {
+        unclaimed++;
+        richUnexploited++;
+      } else if (p.ownerId != view.playerId && p.townDevelopmentLevel > 0) {
+        richUnexploited++;
+      }
+    }
+    final weakNeighbors = <String>[];
+    if (topology != null) {
+      final ownedIds = <String>{};
+      for (final p in view.provincesById.entries) {
+        if (p.value.ownerId == view.playerId) ownedIds.add(p.key);
+      }
+      final neighborIds = _neighborProvinceIdsFromTopology(topology, ownedIds, view);
+      for (final fid in neighborIds) {
+        final prov = view.provincesById[fid];
+        if (prov == null) continue;
+        final ownerId = prov.ownerId;
+        if (ownerId != null && ownerId.isNotEmpty && ownerId != view.playerId) {
+          if (!weakNeighbors.contains(ownerId)) weakNeighbors.add(ownerId);
+        }
+      }
+    }
+    return OpportunitySummary(
+      weakNeighbors: weakNeighbors,
+      richUnexploitedProvinces: richUnexploited,
+      unclaimedProvinces: unclaimed,
+    );
   }
 
   static EconomySummary _buildEconomySummary(PlayerView view) {

--- a/packages/colonizethis_ai/lib/src/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/strategic_ai.dart
@@ -26,7 +26,7 @@ Orders generateStrategicOrders({
 }) {
   final turn = game.worldState.turnState.turnNumber;
   Logger().i('ai: generateStrategicOrders nationId=$nationId turn=$turn');
-  final snapshot = AIWorldSnapshot.fromPlayerView(view);
+  final snapshot = AIWorldSnapshot.fromPlayerView(view, topology: topology);
   final primaryGoal = selectPrimaryGoal(snapshot, config, seeds.goalSeed);
   Logger().d('ai: primaryGoal=$primaryGoal');
   final orders = runDomainPlanners(

--- a/packages/colonizethis_ai/test/perception_test.dart
+++ b/packages/colonizethis_ai/test/perception_test.dart
@@ -1,3 +1,4 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
@@ -91,6 +92,85 @@ void main() {
       final snap = AIWorldSnapshot.fromPlayerView(view);
       expect(snap.relations.length, 1);
       expect(snap.relations['gp2'], isNotNull);
+    });
+
+    test('with topology: neighborProvincesHostile and capitalThreatened when neighbor at war', () {
+      const r = 'oldWorld';
+      final view = _view(
+        playerId: 'gp1',
+        diplomacyByOtherId: {
+          'gp2': DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'gp2',
+            state: RelationState.atWar,
+          ),
+        },
+        provincesById: {
+          '$r|p1': Province(id: 'p1', regionId: r, ownerId: 'gp1', displayName: 'P1'),
+          '$r|p2': Province(id: 'p2', regionId: r, ownerId: 'gp2', displayName: 'P2'),
+        },
+      );
+      final playerWithCapital = view.player.copyWith(capitalProvinceId: '$r|p1');
+      final viewWithCapital = PlayerView(
+        playerId: view.playerId,
+        player: playerWithCapital,
+        ownUnitsById: view.ownUnitsById,
+        provincesById: view.provincesById,
+        visibilityByTile: view.visibilityByTile,
+        prospectedTiles: view.prospectedTiles,
+        diplomacyByOtherId: view.diplomacyByOtherId,
+      );
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'p1', regionId: r, type: TopologyNodeType.province),
+          TopologyNode(id: 'p2', regionId: r, type: TopologyNodeType.province),
+        ],
+        edges: [TopologyEdge(id1: 'p1', id2: 'p2')],
+      );
+      final snap = AIWorldSnapshot.fromPlayerView(viewWithCapital, topology: topology);
+      expect(snap.threats.neighborProvincesHostile, 1);
+      expect(snap.threats.capitalThreatened, true);
+    });
+
+    test('with topology: weakNeighbors lists faction ids owning adjacent provinces', () {
+      const r = 'oldWorld';
+      final view = _view(
+        playerId: 'gp1',
+        provincesById: {
+          '$r|p1': Province(id: 'p1', regionId: r, ownerId: 'gp1', displayName: 'P1'),
+          '$r|p2': Province(id: 'p2', regionId: r, ownerId: 'gp2', displayName: 'P2'),
+          '$r|p3': Province(id: 'p3', regionId: r, ownerId: null, displayName: 'P3'),
+        },
+      );
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'p1', regionId: r, type: TopologyNodeType.province),
+          TopologyNode(id: 'p2', regionId: r, type: TopologyNodeType.province),
+          TopologyNode(id: 'p3', regionId: r, type: TopologyNodeType.province),
+        ],
+        edges: [
+          TopologyEdge(id1: 'p1', id2: 'p2'),
+          TopologyEdge(id1: 'p1', id2: 'p3'),
+        ],
+      );
+      final snap = AIWorldSnapshot.fromPlayerView(view, topology: topology);
+      expect(snap.opportunities.weakNeighbors, contains('gp2'));
+      expect(snap.opportunities.weakNeighbors.length, 1);
+    });
+
+    test('richUnexploitedProvinces counts unclaimed and others with development', () {
+      const r = 'oldWorld';
+      final view = _view(
+        playerId: 'gp1',
+        provincesById: {
+          '$r|p1': Province(id: 'p1', regionId: r, ownerId: 'gp1', displayName: 'P1'),
+          '$r|p2': Province(id: 'p2', regionId: r, ownerId: 'gp2', displayName: 'P2', townDevelopmentLevel: 2),
+          '$r|p3': Province(id: 'p3', regionId: r, ownerId: null, displayName: 'P3'),
+        },
+      );
+      final snap = AIWorldSnapshot.fromPlayerView(view);
+      expect(snap.opportunities.unclaimedProvinces, 1);
+      expect(snap.opportunities.richUnexploitedProvinces, 2); // unclaimed p3 + gp2's p2 with development
     });
   });
 }


### PR DESCRIPTION
## Summary
Implements **perception gap #6**: compute `neighborProvincesHostile`, `capitalThreatened`, `weakNeighbors`, and `richUnexploitedProvinces` in `AIWorldSnapshot` when topology is provided.

Part of **#18** (AI: Align implementation with SPEC Phase 6 gaps).

## Spec
- **SPEC/ai/ai-architecture.md** — Perception: threats, opportunities from PlayerView.
- **.github/ISSUE_AI_SPEC_GAPS.md** §6 — Perception summary incomplete: `neighborProvincesHostile` and `capitalThreatened` never set; `weakNeighbors` and `richUnexploitedProvinces` always empty.

## Changes
- **perception.dart:** `fromPlayerView(view, {MapTopology? topology})`. When `topology` is non-null:
  - **ThreatSummary:** `neighborProvincesHostile` = count of neighbor provinces (by topology) owned by factions at war; `capitalThreatened` = true if any neighbor of capital is owned by faction at war.
  - **OpportunitySummary:** `weakNeighbors` = list of faction ids owning a province adjacent to ours; `richUnexploitedProvinces` = unclaimed count + provinces owned by others with `townDevelopmentLevel > 0`.
- **strategic_ai.dart:** Pass `topology` into `AIWorldSnapshot.fromPlayerView(view, topology: topology)`.
- **perception_test.dart:** Tests for topology-based threat (neighborProvincesHostile, capitalThreatened), weakNeighbors, and richUnexploitedProvinces.

All data still derived from PlayerView + optional topology; no hidden state. Deterministic.

All tests pass.

Made with [Cursor](https://cursor.com)