### PR TITLE
fix(ai): document gap #1 fixed, add regression test for naval mission aggregation

### DIFF
--- a/.github/ISSUE_AI_SPEC_GAPS.md
+++ b/.github/ISSUE_AI_SPEC_GAPS.md
@@ -1,0 +1,151 @@
+# AI implementation vs SPEC — missing parts
+
+**Summary:** Comparison of current AI implementation (`colonizethis_ai`, `colonizethis_logic` AI paths) against SPEC/ai and SPEC/program AI docs. Identifies missing or partial features for Phase 6 full AI.
+
+## Specs consulted
+
+- **SPEC/ai/ai-architecture.md** — Hybrid stack, turn pipeline, tactical rules, seeding
+- **SPEC/ai/ai-personalities.md** — Leader personalities, domain weights, behavioral modifiers
+- **SPEC/ai/ai-dossier.md** — Dossier structure, PlayerView-safe rules
+- **SPEC/ai/hidden-agendas.md** — Agenda assignment, behavior modifiers, evidence
+- **SPEC/ai/dialogue-and-mood.md** — DialogueEvent, PortraitMoodEvent, when to emit
+- **SPEC/program/ai-planner.md** — Control rules, seeding, order merge
+- **SPEC/program/ai-systems-impl.md** — Module boundaries, strategic/tactical APIs
+- **SPEC/program/ai-events-and-dossier.md** — Events, evidence flow, dossier projection
+
+---
+
+## 1. Bug: Naval mission orders dropped in full-AI aggregation — **FIXED**
+
+**Spec:** `generateOrdersForGameFullAI` should aggregate all order types including naval (ai_planner.md: "Aggregates all order types including naval").
+
+**Current:** `packages/colonizethis_logic/lib/src/ai/ai_planner.dart` — `generateOrdersForGameFullAI` now aggregates both `navalMoveOrdersByPlayerId` and `navalMissionOrdersByPlayerId` and passes them into the returned `Orders()`. Regression test in `ai_planner_test.dart` ensures per-player naval (move + mission) orders are preserved in game-level aggregation.
+
+---
+
+## 2. Evidence accumulation not implemented
+
+**Spec:** SPEC/ai/hidden-agendas.md — "When the game or AI performs an action, evidence rules may add points to that agenda's suspicion counter". SPEC/program/ai-events-and-dossier.md — "Evidence rules evaluated when actions are applied (turn resolution or post-resolution hook)."
+
+**Current:** `Game.dossierEvidenceEntries` and `DossierEvidenceEntry` exist; `getDossierForSubject` reads them. **No code** in `colonizethis_logic` (or elsewhere) appends evidence when actions occur (e.g. declare war on weaker neighbor → +2 Warmonger suspicion). Diplomacy resolver, turn resolver, and combat resolution do not call any evidence-rule evaluation.
+
+**Missing:**  
+- Define evidence rules (e.g. "declared war on weaker neighbor" → warmonger +2; "broke alliance" → backstabber +2).  
+- Hook into turn resolution (or post-resolution) so that when a diplomatic/combat action is applied, relevant evidence is appended to `game.dossierEvidenceEntries` (per observer: only human observers need evidence stored; spec says per (observer, subject, agenda type)).
+
+---
+
+## 3. Dossier projection incomplete
+
+**Spec:** SPEC/ai/ai-dossier.md — Dossier sections: **Basic intel** (personality/archetype, relation, relative military/economic strength), **Hidden agenda analysis** (suspicion scores, bands, best-guess agenda id and confidence %), **Evidence list**, **Behavioral notes** (war history, diplomatic pattern, military buildup), **Timeline** (chronological notable actions).
+
+**Current:** `DossierView` in `colonizethis_ai/lib/src/dossier.dart` has only `subjectId`, `suspicionByAgendaType`, `evidenceList`. Basic intel (personality, relation, relative strength), behavioral notes, and timeline are not exposed. No "best-guess agenda id and confidence %" derived from suspicion.
+
+**Missing:** Extend dossier projection (and optionally storage) to include basic intel, behavioral notes, timeline; add best-guess agenda id + confidence % from suspicion bands for display.
+
+---
+
+## 4. Dialogue and mood mostly stubs
+
+**Spec:** SPEC/ai/dialogue-and-mood.md — Dialogue categories: diplomatic, reactive, event, agenda, negotiation. Emit `DialogueEvent` on diplomatic actions, game events, reactive banter, agenda-flavour (keys + context; content in data assets). Emit `PortraitMoodEvent` on negotiation mood transition (mood state machine: current mood, offerQualityDelta, stallCounter → next mood).
+
+**Current:**  
+- **Dialogue:** Only one emission in `generateStrategicOrders`: when `dialogueSeed % 7 == 0`, a single generic `DialogueEvent(leaderId, category: 'agenda', situation: 'comment', era: 'earlyModern')`. No diplomatic, reactive, event, or negotiation dialogue; no use of actual situation/era/variables from context.  
+- **Mood:** `PortraitMoodEvent` is never emitted. No mood state machine, no negotiation offer/quality/stall inputs.
+
+**Missing:**  
+- Emit dialogue on actual events (declare war, peace offer, battle result, etc.) with correct category/situation/era/variables.  
+- Implement negotiation mood state machine and emit `PortraitMoodEvent` on transition.  
+- (Optional) Dialogue content keys/catalog in data package per spec.
+
+---
+
+## 5. Tactical (Quick Battle) not state-aware
+
+**Spec:** SPEC/ai/ai-architecture.md — Tactical behavior rules: prefer good terrain (hill, town, woods) with high-value units; avoid fragile units in swamp; use Volley Fire / Defend when outmatched or holding key lanes; use Maneuver / Fall Back to rotate damaged units; use Assault / Charge when enemy lane disrupted and terrain favorable. SPEC/program/ai-systems-impl.md — `decideQuickBattleActions(QuickBattleState, nationId, config, tacticalSeed)` returns CP-based actions per lane; deterministic given state and seed.
+
+**Current:** `decideQuickBattleActions` in `colonizethis_ai/lib/src/tactical_ai.dart` takes `QuickBattleInput` (and nationId, config, tacticalSeed) but **ignores** input state. It picks a random strategy from a fixed list of action lists. No use of lane state, strength, terrain, or unit health.
+
+**Missing:** Use `QuickBattleInput` (and any extended state) to choose actions per spec: e.g. when outmatched or holding center → Volley Fire / Defend; when damaged → Maneuver / Fall Back; when enemy disrupted and terrain favorable → Assault / Charge. Remain deterministic via `tacticalSeed`.
+
+---
+
+## 6. Perception summary incomplete
+
+**Spec:** SPEC/ai/ai-architecture.md — Perception: threats, opportunities, economy, relations from PlayerView only.
+
+**Current:** `AIWorldSnapshot` / `ThreatSummary` / `OpportunitySummary` in `perception.dart`:  
+- `ThreatSummary`: `atWarWith` is populated; `neighborProvincesHostile` and `capitalThreatened` are never set (comment: "stub for now").  
+- `OpportunitySummary`: `unclaimedProvinces` is set; `weakNeighbors` and `richUnexploitedProvinces` are always empty.
+
+**Missing:** Compute `neighborProvincesHostile` and `capitalThreatened` from topology + visibility (and optionally unit positions). Populate `weakNeighbors` and `richUnexploitedProvinces` from view data where observable.
+
+---
+
+## 7. No diplomacy domain planner
+
+**Spec:** SPEC/ai/ai-architecture.md — Domain planning: economy, military, diplomacy, research planners; each emits candidate orders. SPEC/program/ai-systems-impl.md — AI uses suggestion API for all order types; when naval in scope, API exposes naval candidates.
+
+**Current:** `runDomainPlanners` runs economy (work/build), movement, naval (move + mission), and research. There is **no diplomacy planner**; full AI never produces `DiplomaticOrder`s. Order suggestion API has no `suggestDiplomaticOrders`; even if it did, domain_planners does not call it.
+
+**Missing:**  
+- Add diplomatic order suggestion (e.g. in OrderSuggestionAPI / DefaultOrderSuggestionAPI) so AI can get candidates (declare war, offer peace, alliance, overture, grant aid, etc.) consistent with visibility and rules.  
+- Add a diplomacy domain planner that, when goal is diplomacy/conquer/trade, scores and selects diplomatic orders using personality and agenda modifiers (e.g. war likelihood, peace tendency, alliance tendency from ai-personalities.md).
+
+---
+
+## 8. Hidden agenda modifiers incomplete
+
+**Spec:** SPEC/ai/hidden-agendas.md — Behavior modifiers per agenda: war declaration, peace acceptance, alliance acceptance, build/order choice (e.g. tech_thief: spy/research; envy: mirror human), treaty breaking.
+
+**Current:** `hidden_agenda.dart` implements `agendaConquerModifier` and `agendaDiplomacyModifier` for warmonger, peacemaker, backstabber, isolationist. **tech_thief** and **envy** have no modifiers. No modifiers for peace acceptance, alliance acceptance, or treaty breaking; no build/order choice weighting for tech_thief or envy.
+
+**Missing:** Define and use modifiers for tech_thief (spy/research order boost) and envy (orders mirroring human builds/targets). Optionally add peace/alliance/treaty-breaking thresholds or weights used by a diplomacy planner.
+
+---
+
+## 9. Personality thresholds not implemented
+
+**Spec:** SPEC/ai/ai-personalities.md — Personality also adjusts **thresholds**: War likelihood, Peace tendency, Alliance tendency, Research preference (weights per tech category). "Applied when scoring actions (e.g. declare war, accept peace, choose research slot)."
+
+**Current:** Personality config in `colonizethis_data` provides only **domain weights** (economy, military, diplomacy, research) and **goal weights** (defend, expand, conquer, trade, tech, diplomacy). No war likelihood, peace tendency, alliance tendency, or per-category research preference.
+
+**Missing:** Add personality (and optionally agenda) threshold/weight config for war, peace, alliance, and research category; use them in goal selection and in diplomacy/research planners when scoring actions.
+
+---
+
+## 10. Goal selection is weighted random, not behavior tree
+
+**Spec:** SPEC/ai/ai-architecture.md — "Behavior trees pick top-level goals"; "Behavior trees pick long-term strategy (expand, defend, trade, conquer, tech, diplomacy)."
+
+**Current:** `goal_manager.dart` implements **weighted random** choice over `StrategicGoal` using personality goal weights, agenda modifiers, and snapshot situational modifiers. No actual behavior tree (nodes, sequences, selectors).
+
+**Note:** This may be acceptable if "behavior tree" is interpreted as "hierarchical goal selection"; the spec also says "utility AI scores and selects concrete objectives". If strict behavior-tree structure is required (e.g. for designer-editable trees), replace weighted random with a small tree (e.g. selector over defend/expand/conquer/trade/tech/diplomacy) that uses the same weights as inputs.
+
+---
+
+## 11. Order suggestion API has no diplomatic suggestions
+
+**Spec:** SPEC/program/ai-systems-impl.md — "AI calls the suggestion API with PlayerView and current orders"; "When naval is in scope, API also exposes naval candidates."
+
+**Current:** `OrderSuggestionAPI` has suggestMoveOrders, suggestWorkOrders, suggestBuildOrders, suggestResearchOrders, suggestNavalMoveOrders, suggestNavalMissionOrders. No method for diplomatic order candidates.
+
+**Missing:** Add `suggestDiplomaticOrders(PlayerView, Game, MapTopology, Orders)` (or equivalent) returning candidate `DiplomaticOrder`s that are valid and visible, so a diplomacy domain planner can score and select them.
+
+---
+
+## Summary table
+
+| # | Area | Status | Priority |
+|---|------|--------|----------|
+| 1 | Naval mission orders dropped in full-AI aggregation | Fixed | High |
+| 2 | Evidence accumulation | Missing | High |
+| 3 | Dossier (basic intel, behavioral notes, timeline) | Partial | Medium |
+| 4 | Dialogue and mood | Stub only | Medium |
+| 5 | Tactical Quick Battle state-aware | Missing | Medium |
+| 6 | Perception (threats/opportunities) | Partial | Medium |
+| 7 | Diplomacy domain planner + API | Missing | High |
+| 8 | Hidden agenda (tech_thief, envy; peace/alliance/treaty) | Partial | Medium |
+| 9 | Personality thresholds (war/peace/alliance/research) | Missing | Medium |
+| 10 | Behavior tree vs weighted random | Design choice | Low |
+| 11 | OrderSuggestionAPI diplomatic | Missing | High (for #7) |

--- a/packages/colonizethis_logic/test/ai_planner_test.dart
+++ b/packages/colonizethis_logic/test/ai_planner_test.dart
@@ -216,6 +216,61 @@ void main() {
         reason: 'full AI should produce at least research when no capital',
       );
     });
+
+    test('generateOrdersForGameFullAI preserves naval mission orders from per-player AI', () {
+      // Regression for gap #1: naval mission orders must be aggregated, not dropped.
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'P1', regionId: 'oldWorld', ownerId: 'gp1'),
+            ],
+            units: const [
+              Unit(id: 'u1', type: 'grenadiers', ownerId: 'gp1', provinceId: 'P1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          fleets: const [
+            Fleet(
+              id: 'f1',
+              ownerId: 'gp1',
+              seaZoneId: 'sea1',
+              regionId: 'oldWorld',
+              shipTypeIds: ['carrack'],
+            ),
+          ],
+          playerVisibilityByTile: const {
+            'gp1': {'oldWorld|P1|0|0': 'fullyVisible'},
+          },
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'AI', isHuman: false),
+        ],
+        globalGameSeed: 1,
+        aiSeedByGpId: const {'gp1': 1},
+      );
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+        ],
+        edges: [],
+      );
+      final singleOrders = generateOrdersForPlayerFullAI(game, topology, 'gp1');
+      final gameOrders = generateOrdersForGameFullAI(game, topology);
+      expect(
+        gameOrders.navalMissionOrdersByPlayerId['gp1'],
+        equals(singleOrders.navalMissionOrdersByPlayerId['gp1']),
+        reason: 'full-AI aggregation must include naval mission orders (SPEC gap #1)',
+      );
+      expect(
+        gameOrders.navalMoveOrdersByPlayerId['gp1'],
+        equals(singleOrders.navalMoveOrdersByPlayerId['gp1']),
+        reason: 'full-AI aggregation must include naval move orders',
+      );
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

- **Gap #1** (naval mission orders dropped in full-AI aggregation): Code in `generateOrdersForGameFullAI` already aggregates `navalMissionOrdersByPlayerId`; the gaps doc was outdated.
- Added regression test in `ai_planner_test.dart`: per-player full-AI naval move and mission orders are preserved in game-level aggregation.
- Updated `.github/ISSUE_AI_SPEC_GAPS.md`: mark gap #1 as **Fixed** and adjust description.

Part of **#18** (AI: Align implementation with SPEC Phase 6 gaps).

Made with [Cursor](https://cursor.com)