### PR TITLE
feat(ai): evidence accumulation in diplomacy phase (gap #2)

### DIFF
--- a/.github/ISSUE_AI_SPEC_GAPS.md
+++ b/.github/ISSUE_AI_SPEC_GAPS.md
@@ -23,15 +23,11 @@
 
 ---
 
-## 2. Evidence accumulation not implemented
+## 2. Evidence accumulation — **IMPLEMENTED** (diplomacy phase)
 
 **Spec:** SPEC/ai/hidden-agendas.md — "When the game or AI performs an action, evidence rules may add points to that agenda's suspicion counter". SPEC/program/ai-events-and-dossier.md — "Evidence rules evaluated when actions are applied (turn resolution or post-resolution hook)."
 
-**Current:** `Game.dossierEvidenceEntries` and `DossierEvidenceEntry` exist; `getDossierForSubject` reads them. **No code** in `colonizethis_logic` (or elsewhere) appends evidence when actions occur (e.g. declare war on weaker neighbor → +2 Warmonger suspicion). Diplomacy resolver, turn resolver, and combat resolution do not call any evidence-rule evaluation.
-
-**Missing:**  
-- Define evidence rules (e.g. "declared war on weaker neighbor" → warmonger +2; "broke alliance" → backstabber +2).  
-- Hook into turn resolution (or post-resolution) so that when a diplomatic/combat action is applied, relevant evidence is appended to `game.dossierEvidenceEntries` (per observer: only human observers need evidence stored; spec says per (observer, subject, agenda type)).
+**Current:** `colonizethis_logic/lib/src/dossier/evidence_rules.dart` defines evidence rules. Diplomacy resolver calls them when applying declare war and offer peace: **declare war** → warmonger +2 if target is weaker GP (by military level), backstabber +2 if target was allied; **offer peace** → peacemaker +1. Evidence is appended to `game.dossierEvidenceEntries` per (observer, subject, agenda type); only human observers receive entries, and only when the actor (subject) is AI-controlled. Combat/other actions not yet hooked.
 
 ---
 
@@ -136,7 +132,7 @@
 | # | Area | Status | Priority |
 |---|------|--------|----------|
 | 1 | Naval mission orders dropped in full-AI aggregation | Fixed | High |
-| 2 | Evidence accumulation | Missing | High |
+| 2 | Evidence accumulation | Implemented (diplomacy) | High |
 | 3 | Dossier (basic intel, behavioral notes, timeline) | Partial | Medium |
 | 4 | Dialogue and mood | Stub only | Medium |
 | 5 | Tactical Quick Battle state-aware | Missing | Medium |

--- a/packages/colonizethis_logic/lib/colonizethis_logic.dart
+++ b/packages/colonizethis_logic/lib/colonizethis_logic.dart
@@ -45,6 +45,9 @@ export 'src/orders/orders_application.dart';
 // Diplomacy
 export 'src/diplomacy/diplomacy_resolver.dart';
 
+// Dossier (evidence rules)
+export 'src/dossier/evidence_rules.dart';
+
 // AI
 export 'src/ai/ai_planner.dart';
 export 'src/ai/sim_game_ai.dart';

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -5,6 +5,7 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../combat/conflict_detection.dart';
+import '../dossier/evidence_rules.dart';
 
 /// Overture costs per diplomacy-resolution. Consulate £500, Embassy £1000.
 const int overtureConsulateCost = 500;
@@ -290,6 +291,7 @@ Game _processWarAndPeace(
         final rel = getRelation(game, gpId, targetId);
         final atPeace = rel == null || rel.atPeace;
         if (atPeace) {
+          final evidence = evidenceForDeclareWar(game, gpId, targetId, turn);
           final ids = _pairIds(gpId, targetId);
           relations = upsertRelation(relations, gpId, targetId, (existing) {
             if (existing == null) {
@@ -312,12 +314,16 @@ Game _processWarAndPeace(
               level: scoreToLevel(newScore),
             );
           });
-          game = game.copyWith(diplomacyRelations: relations);
+          game = game.copyWith(
+            diplomacyRelations: relations,
+            dossierEvidenceEntries: [...game.dossierEvidenceEntries, ...evidence],
+          );
         }
       } else if (order.type == DiplomaticOrderType.offerPeace) {
         final targetId = order.targetFactionId;
         final rel = getRelation(game, gpId, targetId);
         if (rel != null && rel.atWar) {
+          final evidence = evidenceForOfferPeace(game, gpId, targetId, turn);
           relations = upsertRelation(relations, gpId, targetId, (existing) {
             return existing!.copyWith(
               state: RelationState.atPeace,
@@ -325,7 +331,10 @@ Game _processWarAndPeace(
               lastInteractionTurn: turn,
             );
           });
-          game = game.copyWith(diplomacyRelations: relations);
+          game = game.copyWith(
+            diplomacyRelations: relations,
+            dossierEvidenceEntries: [...game.dossierEvidenceEntries, ...evidence],
+          );
         }
       }
     }

--- a/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+++ b/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
@@ -1,0 +1,121 @@
+// Evidence rules for dossier. SPEC/ai/hidden-agendas.md, SPEC/program/ai-events-and-dossier.md.
+// When diplomatic (or other) actions are applied, evidence rules add suspicion points per agenda type.
+// Evidence is stored per (observer, subject, agenda type); only human observers receive entries.
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
+
+final _log = Logger();
+
+/// Human Great Power ids (observers for whom we store evidence).
+List<String> _humanObserverIds(Game game) {
+  return game.players
+      .where((p) => p.isHuman)
+      .map((p) => p.id)
+      .toList();
+}
+
+/// True if [playerId] is AI-controlled (evidence is only for AI subjects).
+bool _isAiControlled(Game game, String playerId) {
+  final explicit = game.aiControlByGpId[playerId];
+  if (explicit != null) return explicit;
+  final p = _getPlayer(game, playerId);
+  return p != null && !p.isHuman;
+}
+
+Player? _getPlayer(Game game, String playerId) {
+  for (final p in game.players) {
+    if (p.id == playerId) return p;
+  }
+  return null;
+}
+
+/// Returns true if [targetId] is a weaker GP than [actorId] by military level (for warmonger evidence).
+bool _isWeakerGp(Game game, String actorId, String targetId) {
+  final actor = _getPlayer(game, actorId);
+  final target = _getPlayer(game, targetId);
+  if (actor == null || target == null) return false;
+  final aLevel = actor.militaryLevel ?? 0;
+  final tLevel = target.militaryLevel ?? 0;
+  return tLevel < aLevel;
+}
+
+DiplomacyRelation? _getRelation(Game game, String factionId1, String factionId2) {
+  final key = factionId1.compareTo(factionId2) <= 0 ? '$factionId1|$factionId2' : '$factionId2|$factionId1';
+  for (final r in game.diplomacyRelations) {
+    final rKey = r.factionId1.compareTo(r.factionId2) <= 0 ? '${r.factionId1}|${r.factionId2}' : '${r.factionId2}|${r.factionId1}';
+    if (rKey == key) return r;
+  }
+  return null;
+}
+
+/// Evidence entries for "AI declared war". Warmonger if target is weaker GP; backstabber if was allied.
+List<DossierEvidenceEntry> evidenceForDeclareWar(
+  Game game,
+  String actorGpId,
+  String targetFactionId,
+  int turnNumber,
+) {
+  if (!_isAiControlled(game, actorGpId)) return [];
+  final observers = _humanObserverIds(game);
+  if (observers.isEmpty) return [];
+
+  final rel = _getRelation(game, actorGpId, targetFactionId);
+  final wasAllied = rel != null && rel.level == RelationLevel.allied;
+  final targetIsGp = _getPlayer(game, targetFactionId) != null;
+  final weaker = targetIsGp && _isWeakerGp(game, actorGpId, targetFactionId);
+
+  final entries = <DossierEvidenceEntry>[];
+  for (final observerId in observers) {
+    if (wasAllied) {
+      entries.add(DossierEvidenceEntry(
+        observerId: observerId,
+        subjectId: actorGpId,
+        agendaType: 'backstabber',
+        turnNumber: turnNumber,
+        description: 'declared war on ally',
+        scoreDelta: 2,
+      ));
+    }
+    if (weaker) {
+      entries.add(DossierEvidenceEntry(
+        observerId: observerId,
+        subjectId: actorGpId,
+        agendaType: 'warmonger',
+        turnNumber: turnNumber,
+        description: 'declared war on weaker neighbor',
+        scoreDelta: 2,
+      ));
+    }
+  }
+  if (entries.isNotEmpty) {
+    _log.d('data: evidence for declareWar actor=$actorGpId target=$targetFactionId entries=${entries.length}');
+  }
+  return entries;
+}
+
+/// Evidence entries for "AI offered peace". Peacemaker tendency.
+List<DossierEvidenceEntry> evidenceForOfferPeace(
+  Game game,
+  String actorGpId,
+  String targetFactionId,
+  int turnNumber,
+) {
+  if (!_isAiControlled(game, actorGpId)) return [];
+  final observers = _humanObserverIds(game);
+  if (observers.isEmpty) return [];
+
+  final entries = <DossierEvidenceEntry>[];
+  for (final observerId in observers) {
+    entries.add(DossierEvidenceEntry(
+      observerId: observerId,
+      subjectId: actorGpId,
+      agendaType: 'peacemaker',
+      turnNumber: turnNumber,
+      description: 'offered peace',
+      scoreDelta: 1,
+    ));
+  }
+  _log.d('data: evidence for offerPeace actor=$actorGpId target=$targetFactionId entries=${entries.length}');
+  return entries;
+}

--- a/packages/colonizethis_logic/test/diplomacy_resolver_test.dart
+++ b/packages/colonizethis_logic/test/diplomacy_resolver_test.dart
@@ -388,6 +388,154 @@ void main() {
     });
   });
 
+  group('dossier evidence (Phase 6)', () {
+    test('AI declare war on weaker GP appends warmonger evidence for human observer', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true),
+          Player(id: 'gp2', displayName: 'AI Strong', isHuman: false, militaryLevel: 3),
+          Player(id: 'gp3', displayName: 'AI Weak', isHuman: false, militaryLevel: 1),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'gp2',
+            factionId2: 'gp3',
+            score: 50,
+            level: RelationLevel.neutral,
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      final orders = Orders(
+        diplomaticOrdersByPlayerId: {
+          'gp2': const [
+            DiplomaticOrder(type: DiplomaticOrderType.declareWar, targetFactionId: 'gp3'),
+          ],
+        },
+      );
+      final after = resolveDiplomacyPhase(game, orders);
+      final evidence = after.dossierEvidenceEntries;
+      expect(evidence.any((e) =>
+          e.observerId == 'gp1' && e.subjectId == 'gp2' && e.agendaType == 'warmonger' && e.scoreDelta == 2),
+          isTrue);
+      expect(evidence.any((e) => e.description.contains('weaker neighbor')), isTrue);
+    });
+
+    test('AI declare war on ally appends backstabber evidence for human observer', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true),
+          Player(id: 'gp2', displayName: 'AI', isHuman: false),
+          Player(id: 'gp3', displayName: 'Other', isHuman: false),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'gp2',
+            factionId2: 'gp3',
+            score: 80,
+            level: RelationLevel.allied,
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      final orders = Orders(
+        diplomaticOrdersByPlayerId: {
+          'gp2': const [
+            DiplomaticOrder(type: DiplomaticOrderType.declareWar, targetFactionId: 'gp3'),
+          ],
+        },
+      );
+      final after = resolveDiplomacyPhase(game, orders);
+      final evidence = after.dossierEvidenceEntries;
+      expect(evidence.any((e) =>
+          e.observerId == 'gp1' && e.subjectId == 'gp2' && e.agendaType == 'backstabber' && e.scoreDelta == 2),
+          isTrue);
+      expect(evidence.any((e) => e.description.contains('ally')), isTrue);
+    });
+
+    test('AI offer peace appends peacemaker evidence for human observer', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true),
+          Player(id: 'gp2', displayName: 'AI', isHuman: false),
+          Player(id: 'gp3', displayName: 'Other', isHuman: false),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'gp2',
+            factionId2: 'gp3',
+            score: 40,
+            level: RelationLevel.neutral,
+            state: RelationState.atWar,
+          ),
+        ],
+      );
+      final orders = Orders(
+        diplomaticOrdersByPlayerId: {
+          'gp2': const [
+            DiplomaticOrder(type: DiplomaticOrderType.offerPeace, targetFactionId: 'gp3'),
+          ],
+        },
+      );
+      final after = resolveDiplomacyPhase(game, orders);
+      final evidence = after.dossierEvidenceEntries;
+      expect(evidence.any((e) =>
+          e.observerId == 'gp1' && e.subjectId == 'gp2' && e.agendaType == 'peacemaker' && e.scoreDelta == 1),
+          isTrue);
+    });
+
+    test('human declare war does not append evidence', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true),
+          Player(id: 'gp2', displayName: 'AI', isHuman: false),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'gp2',
+            score: 50,
+            level: RelationLevel.neutral,
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      final orders = Orders(
+        diplomaticOrdersByPlayerId: {
+          'gp1': const [
+            DiplomaticOrder(type: DiplomaticOrderType.declareWar, targetFactionId: 'gp2'),
+          ],
+        },
+      );
+      final after = resolveDiplomacyPhase(game, orders);
+      expect(after.dossierEvidenceEntries, isEmpty);
+    });
+  });
+
   group('intervention helpers', () {
     test('needsInterventionChoice returns gp id with embassy for attacked minor', () {
       final game = Game(


### PR DESCRIPTION
## Summary
Implements **gap #2** (Evidence accumulation) from `.github/ISSUE_AI_SPEC_GAPS.md` for the diplomacy phase.

- **Evidence rules** (`colonizethis_logic/lib/src/dossier/evidence_rules.dart`): When an AI declares war → warmonger +2 if target is weaker GP (by military level), backstabber +2 if target was allied; when an AI offers peace → peacemaker +1. Evidence is per (observer, subject, agenda type); only **human** observers receive entries, and only when the **actor is AI**.
- **Hook**: `resolveDiplomacyPhase` calls evidence rules when applying declare war and offer peace and appends entries to `game.dossierEvidenceEntries`.
- **Tests**: Four tests in `diplomacy_resolver_test.dart` (AI declare war on weaker GP, AI declare war on ally, AI offer peace, human declare war adds no evidence).
- **Docs**: Gap #2 marked as **Implemented (diplomacy)** in `ISSUE_AI_SPEC_GAPS.md`. Combat/other actions can be hooked in a later PR.

Part of **#18** (AI: Align implementation with SPEC Phase 6 gaps).

## Spec refs
- SPEC/ai/hidden-agendas.md (evidence and suspicion)
- SPEC/program/ai-events-and-dossier.md (evidence flow)

Made with [Cursor](https://cursor.com)