### PR TITLE
feat(ai): hidden agenda modifiers for tech_thief and envy (gap #8)

### DIFF
--- a/.github/ISSUE_AI_SPEC_GAPS.md
+++ b/.github/ISSUE_AI_SPEC_GAPS.md
@@ -89,13 +89,13 @@
 
 ---
 
-## 8. Hidden agenda modifiers incomplete
+## 8. Hidden agenda modifiers incomplete — **PARTIAL** (tech_thief, envy build/research)
 
 **Spec:** SPEC/ai/hidden-agendas.md — Behavior modifiers per agenda: war declaration, peace acceptance, alliance acceptance, build/order choice (e.g. tech_thief: spy/research; envy: mirror human), treaty breaking.
 
-**Current:** `hidden_agenda.dart` implements `agendaConquerModifier` and `agendaDiplomacyModifier` for warmonger, peacemaker, backstabber, isolationist. **tech_thief** and **envy** have no modifiers. No modifiers for peace acceptance, alliance acceptance, or treaty breaking; no build/order choice weighting for tech_thief or envy.
+**Current:** `hidden_agenda.dart` implements `agendaConquerModifier`, `agendaDiplomacyModifier`, **`agendaResearchModifier`** (tech_thief +35), and **`agendaBuildOrderModifier`** (envy +20). Domain planners use them: tech_thief lowers the research domain threshold so research is chosen more often; envy lowers the economy threshold so build orders are chosen more often. No modifiers for peace acceptance, alliance acceptance, or treaty breaking; no spy-order type yet (research boost only). Envy "mirror human" is expressed as build-order tendency boost; full mirroring of human builds/targets can use this weight when visibility exists.
 
-**Missing:** Define and use modifiers for tech_thief (spy/research order boost) and envy (orders mirroring human builds/targets). Optionally add peace/alliance/treaty-breaking thresholds or weights used by a diplomacy planner.
+**Missing:** Peace/alliance/treaty-breaking thresholds or weights for diplomacy planner. Spy order type and tech_thief boost for spy when available.
 
 ---
 
@@ -138,7 +138,7 @@
 | 5 | Tactical Quick Battle state-aware | Missing | Medium |
 | 6 | Perception (threats/opportunities) | Partial | Medium |
 | 7 | Diplomacy domain planner + API | Missing | High |
-| 8 | Hidden agenda (tech_thief, envy; peace/alliance/treaty) | Partial | Medium |
+| 8 | Hidden agenda (tech_thief, envy; peace/alliance/treaty) | Partial (tech_thief/envy research/build) | Medium |
 | 9 | Personality thresholds (war/peace/alliance/research) | Missing | Medium |
 | 10 | Behavior tree vs weighted random | Design choice | Low |
 | 11 | OrderSuggestionAPI diplomatic | Implemented | High (for #7) |

--- a/packages/colonizethis_ai/lib/src/domain_planners.dart
+++ b/packages/colonizethis_ai/lib/src/domain_planners.dart
@@ -6,6 +6,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 
 import 'ai_config.dart';
 import 'goal_manager.dart';
+import 'hidden_agenda.dart';
 import 'perception.dart';
 import 'seed_bundle.dart';
 
@@ -36,7 +37,8 @@ Orders runDomainPlanners({
     final idx = rng.nextInt(workCandidates.length);
     orders = _appendWorkOrders(orders, nationId, [workCandidates[idx]]);
   }
-  if (buildCandidates.isNotEmpty && domainWeights.economy >= 30) {
+  final buildThreshold = 30 - agendaBuildOrderModifier(config.hiddenAgendaId);
+  if (buildCandidates.isNotEmpty && domainWeights.economy >= buildThreshold) {
     final rng = math.Random(seeds.economySeed + 1);
     final idx = rng.nextInt(buildCandidates.length);
     orders = _appendBuildOrders(orders, nationId, [buildCandidates[idx]]);
@@ -82,9 +84,11 @@ Orders runDomainPlanners({
     suggestionAPI: suggestionAPI,
   );
 
-  // Research: suggest research; weight by tech domain.
+  // Research: suggest research; weight by tech domain and agenda (tech_thief boost).
   final researchCandidates = suggestionAPI.suggestResearchOrders(view, game, topology, orders);
-  if (researchCandidates.isNotEmpty && (primaryGoal == StrategicGoal.tech || domainWeights.research >= 40)) {
+  final researchThreshold = 40 - agendaResearchModifier(config.hiddenAgendaId);
+  if (researchCandidates.isNotEmpty &&
+      (primaryGoal == StrategicGoal.tech || domainWeights.research >= researchThreshold)) {
     final rng = math.Random(seeds.researchSeed);
     final idx = rng.nextInt(researchCandidates.length);
     orders = _appendResearchOrders(orders, nationId, [researchCandidates[idx]]);

--- a/packages/colonizethis_ai/lib/src/hidden_agenda.dart
+++ b/packages/colonizethis_ai/lib/src/hidden_agenda.dart
@@ -60,3 +60,25 @@ int agendaDiplomacyModifier(String agendaId) {
       return 0;
   }
 }
+
+/// Returns modifier for research/spy order tendency (positive = more likely to pick research).
+/// SPEC: tech_thief "prioritizes espionage tech; high spy usage".
+int agendaResearchModifier(String agendaId) {
+  switch (agendaId) {
+    case 'tech_thief':
+      return 35;
+    default:
+      return 0;
+  }
+}
+
+/// Returns modifier for build/order choice when mirroring human (positive = boost build tendency).
+/// SPEC: envy "mirrors player builds and objectives".
+int agendaBuildOrderModifier(String agendaId) {
+  switch (agendaId) {
+    case 'envy':
+      return 20;
+    default:
+      return 0;
+  }
+}

--- a/packages/colonizethis_ai/test/hidden_agenda_test.dart
+++ b/packages/colonizethis_ai/test/hidden_agenda_test.dart
@@ -99,4 +99,24 @@ void main() {
       expect(agendaDiplomacyModifier('backstabber'), 0);
     });
   });
+
+  group('agendaResearchModifier', () {
+    test('tech_thief positive', () {
+      expect(agendaResearchModifier('tech_thief'), 35);
+    });
+    test('others return 0', () {
+      expect(agendaResearchModifier('warmonger'), 0);
+      expect(agendaResearchModifier('envy'), 0);
+    });
+  });
+
+  group('agendaBuildOrderModifier', () {
+    test('envy positive', () {
+      expect(agendaBuildOrderModifier('envy'), 20);
+    });
+    test('others return 0', () {
+      expect(agendaBuildOrderModifier('tech_thief'), 0);
+      expect(agendaBuildOrderModifier('warmonger'), 0);
+    });
+  });
 }


### PR DESCRIPTION
Implements **gap #8** (Hidden agenda modifiers for tech_thief and envy) from `.github/ISSUE_AI_SPEC_GAPS.md`.

- **agendaResearchModifier(agendaId):** tech_thief returns +35; used in domain planners to lower the research domain threshold so tech_thief AI picks research more often (SPEC: prioritizes espionage tech / research).
- **agendaBuildOrderModifier(agendaId):** envy returns +20; used to lower the economy threshold so envy AI picks build orders more often (SPEC: mirrors player builds; full mirroring can use this weight when human build visibility exists).
- Domain planners: research block uses `40 - agendaResearchModifier`; build block uses `30 - agendaBuildOrderModifier` so agenda boosts effectively lower the bar.
- Tests for both new modifiers in `hidden_agenda_test.dart`.
- `ISSUE_AI_SPEC_GAPS.md`: gap #8 section and summary table updated.

Part of **#18** (AI: Align implementation with SPEC Phase 6 gaps).

**Spec refs:** SPEC/ai/hidden-agendas.md (behavior modifiers per agenda).

Made with [Cursor](https://cursor.com)