### PR TITLE
feat(ai): peace/alliance/treaty-breaking and spy-order modifiers (gap #8 remaining)

### DIFF
--- a/.github/ISSUE_AI_SPEC_GAPS.md
+++ b/.github/ISSUE_AI_SPEC_GAPS.md
@@ -89,13 +89,11 @@
 
 ---
 
-## 8. Hidden agenda modifiers incomplete — **PARTIAL** (tech_thief, envy build/research)
+## 8. Hidden agenda modifiers incomplete — **IMPLEMENTED**
 
 **Spec:** SPEC/ai/hidden-agendas.md — Behavior modifiers per agenda: war declaration, peace acceptance, alliance acceptance, build/order choice (e.g. tech_thief: spy/research; envy: mirror human), treaty breaking.
 
-**Current:** `hidden_agenda.dart` implements `agendaConquerModifier`, `agendaDiplomacyModifier`, **`agendaResearchModifier`** (tech_thief +35), and **`agendaBuildOrderModifier`** (envy +20). Domain planners use them: tech_thief lowers the research domain threshold so research is chosen more often; envy lowers the economy threshold so build orders are chosen more often. No modifiers for peace acceptance, alliance acceptance, or treaty breaking; no spy-order type yet (research boost only). Envy "mirror human" is expressed as build-order tendency boost; full mirroring of human builds/targets can use this weight when visibility exists.
-
-**Missing:** Peace/alliance/treaty-breaking thresholds or weights for diplomacy planner. Spy order type and tech_thief boost for spy when available.
+**Current:** `hidden_agenda.dart` implements `agendaConquerModifier`, `agendaDiplomacyModifier`, `agendaResearchModifier` (tech_thief +35), `agendaBuildOrderModifier` (envy +20), **`agendaPeaceAcceptanceModifier`** (peacemaker +30, warmonger -25), **`agendaAllianceAcceptanceModifier`** (isolationist -40, peacemaker +10), **`agendaTreatyBreakingModifier`** (backstabber +25, warmonger +20), and **`agendaSpyOrderModifier`** (tech_thief +25). Domain planners: research and build use existing modifiers; diplomacy planner scores offer peace / alliance / declare war by these modifiers (weighted choice); work planner lowers threshold when spy work (steal_tech, counter_spy) exists and tech_thief prefers spy work. Envy "mirror human" remains build-order tendency boost; full mirroring can use this when visibility exists.
 
 ---
 
@@ -138,7 +136,7 @@
 | 5 | Tactical Quick Battle state-aware | Missing | Medium |
 | 6 | Perception (threats/opportunities) | Partial | Medium |
 | 7 | Diplomacy domain planner + API | Missing | High |
-| 8 | Hidden agenda (tech_thief, envy; peace/alliance/treaty) | Partial (tech_thief/envy research/build) | Medium |
+| 8 | Hidden agenda (tech_thief, envy; peace/alliance/treaty) | Implemented | Medium |
 | 9 | Personality thresholds (war/peace/alliance/research) | Missing | Medium |
 | 10 | Behavior tree vs weighted random | Design choice | Low |
 | 11 | OrderSuggestionAPI diplomatic | Implemented | High (for #7) |

--- a/packages/colonizethis_ai/lib/src/domain_planners.dart
+++ b/packages/colonizethis_ai/lib/src/domain_planners.dart
@@ -32,10 +32,18 @@ Orders runDomainPlanners({
   // Economy: build/work suggestions weighted by economy domain.
   final workCandidates = suggestionAPI.suggestWorkOrders(view, game, topology, orders);
   final buildCandidates = suggestionAPI.suggestBuildOrders(view, game, topology, orders);
-  if (workCandidates.isNotEmpty && (primaryGoal == StrategicGoal.expand || domainWeights.economy >= 40)) {
+  final hasSpyWork = workCandidates.any((o) => o.target == 'steal_tech' || o.target == 'counter_spy');
+  final workThreshold = 40 - (hasSpyWork ? agendaSpyOrderModifier(config.hiddenAgendaId) : 0);
+  if (workCandidates.isNotEmpty &&
+      (primaryGoal == StrategicGoal.expand || domainWeights.economy >= workThreshold)) {
+    final agendaId = config.hiddenAgendaId;
+    final pickFrom = (agendaId == 'tech_thief' && hasSpyWork)
+        ? workCandidates.where((o) => o.target == 'steal_tech' || o.target == 'counter_spy').toList()
+        : workCandidates;
+    final list = pickFrom.isNotEmpty ? pickFrom : workCandidates;
     final rng = math.Random(seeds.economySeed);
-    final idx = rng.nextInt(workCandidates.length);
-    orders = _appendWorkOrders(orders, nationId, [workCandidates[idx]]);
+    final idx = rng.nextInt(list.length);
+    orders = _appendWorkOrders(orders, nationId, [list[idx]]);
   }
   final buildThreshold = 30 - agendaBuildOrderModifier(config.hiddenAgendaId);
   if (buildCandidates.isNotEmpty && domainWeights.economy >= buildThreshold) {
@@ -232,8 +240,32 @@ Orders _runDiplomacyPlanner({
   final diploCandidates = suggestionAPI.suggestDiplomaticOrders(view, game, topology, orders);
   if (diploCandidates.isEmpty) return orders;
 
+  final agendaId = config.hiddenAgendaId;
+  final scores = diploCandidates.map((o) {
+    var s = 50;
+    switch (o.type) {
+      case DiplomaticOrderType.offerPeace:
+        s += agendaPeaceAcceptanceModifier(agendaId);
+        break;
+      case DiplomaticOrderType.alliance:
+        s += agendaAllianceAcceptanceModifier(agendaId);
+        break;
+      case DiplomaticOrderType.declareWar:
+        s += agendaTreatyBreakingModifier(agendaId);
+        break;
+      default:
+        break;
+    }
+    return math.max(1, s);
+  }).toList();
+  final total = scores.reduce((a, b) => a + b);
   final rng = math.Random(seeds.diplomacySeed);
-  final idx = rng.nextInt(diploCandidates.length);
+  var r = rng.nextDouble() * total;
+  var idx = 0;
+  for (; idx < scores.length && r > scores[idx]; idx++) {
+    r -= scores[idx];
+  }
+  if (idx >= diploCandidates.length) idx = diploCandidates.length - 1;
   return _appendDiplomaticOrders(orders, nationId, [diploCandidates[idx]]);
 }
 

--- a/packages/colonizethis_ai/lib/src/hidden_agenda.dart
+++ b/packages/colonizethis_ai/lib/src/hidden_agenda.dart
@@ -82,3 +82,53 @@ int agendaBuildOrderModifier(String agendaId) {
       return 0;
   }
 }
+
+/// Returns modifier for peace acceptance / offer peace (positive = more likely to offer or accept peace).
+/// SPEC: Peacemaker "offers peace earlier"; Warmonger "higher threshold" to accept peace.
+int agendaPeaceAcceptanceModifier(String agendaId) {
+  switch (agendaId) {
+    case 'peacemaker':
+      return 30;
+    case 'warmonger':
+      return -25;
+    default:
+      return 0;
+  }
+}
+
+/// Returns modifier for alliance acceptance (positive = more likely to form/accept alliances).
+/// SPEC: Isolationist "high decline chance" for alliances.
+int agendaAllianceAcceptanceModifier(String agendaId) {
+  switch (agendaId) {
+    case 'isolationist':
+      return -40;
+    case 'peacemaker':
+      return 10;
+    default:
+      return 0;
+  }
+}
+
+/// Returns modifier for treaty/peace breaking (positive = more likely to declare war or break treaties).
+/// SPEC: Backstabber "more likely to break when beneficial"; Warmonger "more likely to break peace early".
+int agendaTreatyBreakingModifier(String agendaId) {
+  switch (agendaId) {
+    case 'backstabber':
+      return 25;
+    case 'warmonger':
+      return 20;
+    default:
+      return 0;
+  }
+}
+
+/// Returns modifier for spy-type work orders (positive = more likely to pick steal_tech / counter_spy).
+/// SPEC: tech_thief "high spy usage". Used when spy work candidates exist; no effect if no spy order type.
+int agendaSpyOrderModifier(String agendaId) {
+  switch (agendaId) {
+    case 'tech_thief':
+      return 25;
+    default:
+      return 0;
+  }
+}

--- a/packages/colonizethis_ai/test/hidden_agenda_test.dart
+++ b/packages/colonizethis_ai/test/hidden_agenda_test.dart
@@ -119,4 +119,50 @@ void main() {
       expect(agendaBuildOrderModifier('warmonger'), 0);
     });
   });
+
+  group('agendaPeaceAcceptanceModifier', () {
+    test('peacemaker positive', () {
+      expect(agendaPeaceAcceptanceModifier('peacemaker'), 30);
+    });
+    test('warmonger negative', () {
+      expect(agendaPeaceAcceptanceModifier('warmonger'), -25);
+    });
+    test('others return 0', () {
+      expect(agendaPeaceAcceptanceModifier('tech_thief'), 0);
+    });
+  });
+
+  group('agendaAllianceAcceptanceModifier', () {
+    test('isolationist negative', () {
+      expect(agendaAllianceAcceptanceModifier('isolationist'), -40);
+    });
+    test('peacemaker positive', () {
+      expect(agendaAllianceAcceptanceModifier('peacemaker'), 10);
+    });
+    test('others return 0', () {
+      expect(agendaAllianceAcceptanceModifier('warmonger'), 0);
+    });
+  });
+
+  group('agendaTreatyBreakingModifier', () {
+    test('backstabber positive', () {
+      expect(agendaTreatyBreakingModifier('backstabber'), 25);
+    });
+    test('warmonger positive', () {
+      expect(agendaTreatyBreakingModifier('warmonger'), 20);
+    });
+    test('others return 0', () {
+      expect(agendaTreatyBreakingModifier('peacemaker'), 0);
+    });
+  });
+
+  group('agendaSpyOrderModifier', () {
+    test('tech_thief positive', () {
+      expect(agendaSpyOrderModifier('tech_thief'), 25);
+    });
+    test('others return 0', () {
+      expect(agendaSpyOrderModifier('warmonger'), 0);
+      expect(agendaSpyOrderModifier('envy'), 0);
+    });
+  });
 }


### PR DESCRIPTION
Implements the **remaining gap #8** items from `.github/ISSUE_AI_SPEC_GAPS.md`: peace/alliance/treaty-breaking modifiers and spy-order boost for tech_thief.

## Changes

- **hidden_agenda.dart**
  - `agendaPeaceAcceptanceModifier(agendaId)`: peacemaker +30, warmonger -25 (offer/accept peace).
  - `agendaAllianceAcceptanceModifier(agendaId)`: isolationist -40, peacemaker +10.
  - `agendaTreatyBreakingModifier(agendaId)`: backstabber +25, warmonger +20 (declare war / break peace).
  - `agendaSpyOrderModifier(agendaId)`: tech_thief +25 (steal_tech / counter_spy work).
- **domain_planners.dart**
  - Diplomacy planner: scores each diplomatic candidate by order type and applies the new modifiers; selection is weighted by score instead of random.
  - Work planner: when spy work candidates (steal_tech, counter_spy) exist, effective work threshold is lowered by `agendaSpyOrderModifier`; tech_thief prefers spy work when choosing.
- **Tests**: New tests for all four modifiers in `hidden_agenda_test.dart`.
- **ISSUE_AI_SPEC_GAPS.md**: Gap #8 section and summary table updated to **Implemented**.

Part of **#18** (AI: Align implementation with SPEC Phase 6 gaps).

**Spec refs:** SPEC/ai/hidden-agendas.md (behavior modifiers per agenda).

Made with [Cursor](https://cursor.com)