### PR TITLE
feat(ai): personality thresholds for war/peace/alliance and research (gap #9)

### DIFF
--- a/.github/ISSUE_AI_SPEC_GAPS.md
+++ b/.github/ISSUE_AI_SPEC_GAPS.md
@@ -97,13 +97,11 @@
 
 ---
 
-## 9. Personality thresholds not implemented
+## 9. Personality thresholds not implemented — **IMPLEMENTED**
 
 **Spec:** SPEC/ai/ai-personalities.md — Personality also adjusts **thresholds**: War likelihood, Peace tendency, Alliance tendency, Research preference (weights per tech category). "Applied when scoring actions (e.g. declare war, accept peace, choose research slot)."
 
-**Current:** Personality config in `colonizethis_data` provides only **domain weights** (economy, military, diplomacy, research) and **goal weights** (defend, expand, conquer, trade, tech, diplomacy). No war likelihood, peace tendency, alliance tendency, or per-category research preference.
-
-**Missing:** Add personality (and optionally agenda) threshold/weight config for war, peace, alliance, and research category; use them in goal selection and in diplomacy/research planners when scoring actions.
+**Current:** `colonizethis_data` defines `PersonalityThresholds` (warLikelihood, peaceTendency, allianceTendency, researchNaval/Military/Economic/Exploration) and `personalityThresholds` map per leader; `getThresholdsForLeader(leaderId)` returns thresholds or defaults. **Goal manager:** conquer weight is adjusted by (warLikelihood - 50), diplomacy weight by (peaceTendency + allianceTendency)/2 - 50. **Diplomacy planner:** offerPeace/declareWar/alliance order scores are adjusted by the corresponding threshold. **Research planner:** research candidates are weighted by tech category (transport→naval, military→military, gathering→economic, else→exploration) and selected by weighted random. Tests in `ai_personality_config_test.dart`.
 
 ---
 
@@ -137,6 +135,6 @@
 | 6 | Perception (threats/opportunities) | Partial | Medium |
 | 7 | Diplomacy domain planner + API | Missing | High |
 | 8 | Hidden agenda (tech_thief, envy; peace/alliance/treaty) | Implemented | Medium |
-| 9 | Personality thresholds (war/peace/alliance/research) | Missing | Medium |
+| 9 | Personality thresholds (war/peace/alliance/research) | Implemented | Medium |
 | 10 | Behavior tree vs weighted random | Design choice | Low |
 | 11 | OrderSuggestionAPI diplomatic | Implemented | High (for #7) |

--- a/packages/colonizethis_ai/lib/src/domain_planners.dart
+++ b/packages/colonizethis_ai/lib/src/domain_planners.dart
@@ -92,13 +92,32 @@ Orders runDomainPlanners({
     suggestionAPI: suggestionAPI,
   );
 
-  // Research: suggest research; weight by tech domain and agenda (tech_thief boost).
+  // Research: suggest research; weight by tech domain, agenda (tech_thief boost), and personality research preference.
   final researchCandidates = suggestionAPI.suggestResearchOrders(view, game, topology, orders);
   final researchThreshold = 40 - agendaResearchModifier(config.hiddenAgendaId);
   if (researchCandidates.isNotEmpty &&
       (primaryGoal == StrategicGoal.tech || domainWeights.research >= researchThreshold)) {
+    final thresholds = getThresholdsForLeader(config.leaderId);
+    final scores = researchCandidates.map((o) {
+      final tech = techById(o.techId);
+      final category = tech?.category ?? '';
+      final w = category == 'transport'
+          ? thresholds.researchNaval
+          : category == 'military'
+              ? thresholds.researchMilitary
+              : category == 'gathering'
+                  ? thresholds.researchEconomic
+                  : thresholds.researchExploration;
+      return math.max(1, w);
+    }).toList();
+    final total = scores.reduce((a, b) => a + b);
     final rng = math.Random(seeds.researchSeed);
-    final idx = rng.nextInt(researchCandidates.length);
+    var r = rng.nextInt(total);
+    var idx = 0;
+    for (; idx < scores.length && r >= scores[idx]; idx++) {
+      r -= scores[idx];
+    }
+    if (idx >= researchCandidates.length) idx = researchCandidates.length - 1;
     orders = _appendResearchOrders(orders, nationId, [researchCandidates[idx]]);
   }
 
@@ -241,17 +260,21 @@ Orders _runDiplomacyPlanner({
   if (diploCandidates.isEmpty) return orders;
 
   final agendaId = config.hiddenAgendaId;
+  final thresholds = getThresholdsForLeader(config.leaderId);
   final scores = diploCandidates.map((o) {
     var s = 50;
     switch (o.type) {
       case DiplomaticOrderType.offerPeace:
         s += agendaPeaceAcceptanceModifier(agendaId);
+        s += (thresholds.peaceTendency - 50);
         break;
       case DiplomaticOrderType.alliance:
         s += agendaAllianceAcceptanceModifier(agendaId);
+        s += (thresholds.allianceTendency - 50);
         break;
       case DiplomaticOrderType.declareWar:
         s += agendaTreatyBreakingModifier(agendaId);
+        s += (thresholds.warLikelihood - 50);
         break;
       default:
         break;

--- a/packages/colonizethis_ai/lib/src/goal_manager.dart
+++ b/packages/colonizethis_ai/lib/src/goal_manager.dart
@@ -26,6 +26,7 @@ StrategicGoal selectPrimaryGoal(
   int goalSeed,
 ) {
   final weights = getGoalWeightsForLeader(config.leaderId);
+  final thresholds = getThresholdsForLeader(config.leaderId);
 
   // Situational modifiers from snapshot.
   int defend = weights.defend;
@@ -37,6 +38,9 @@ StrategicGoal selectPrimaryGoal(
 
   conquer += agendaConquerModifier(config.hiddenAgendaId);
   diplomacy += agendaDiplomacyModifier(config.hiddenAgendaId);
+  // Personality thresholds: war likelihood boosts conquer; peace/alliance boost diplomacy goal.
+  conquer += (thresholds.warLikelihood - 50);
+  diplomacy += ((thresholds.peaceTendency + thresholds.allianceTendency) ~/ 2) - 50;
 
   if (snapshot.threats.atWarWith.isNotEmpty) {
     defend += 30;

--- a/packages/colonizethis_data/lib/src/ai_personality_config.dart
+++ b/packages/colonizethis_data/lib/src/ai_personality_config.dart
@@ -34,6 +34,29 @@ class PersonalityGoalWeights {
   final int diplomacy;
 }
 
+/// Thresholds applied when scoring actions (declare war, accept peace, alliance, research).
+/// SPEC/ai/ai-personalities.md — "Behavioral modifiers": war likelihood, peace tendency,
+/// alliance tendency, research preference per category.
+class PersonalityThresholds {
+  const PersonalityThresholds({
+    this.warLikelihood = 50,
+    this.peaceTendency = 50,
+    this.allianceTendency = 50,
+    this.researchNaval = 50,
+    this.researchMilitary = 50,
+    this.researchEconomic = 50,
+    this.researchExploration = 50,
+  });
+
+  final int warLikelihood;
+  final int peaceTendency;
+  final int allianceTendency;
+  final int researchNaval;
+  final int researchMilitary;
+  final int researchEconomic;
+  final int researchExploration;
+}
+
 /// Personality config per leader id. Used by colonizethis_ai for goal and utility scoring.
 const Map<String, PersonalityDomainWeights> personalityDomainWeights = {
   'victoria': PersonalityDomainWeights(economy: 70, military: 30, diplomacy: 80, research: 50),
@@ -56,9 +79,22 @@ const Map<String, PersonalityGoalWeights> personalityGoalWeights = {
   'gustavus': PersonalityGoalWeights(defend: 50, expand: 50, conquer: 60, trade: 40, tech: 60, diplomacy: 50),
 };
 
+/// Thresholds per leader (war/peace/alliance tendency; research category weights).
+/// Used when scoring diplomatic actions and research slot choice. See SPEC/ai/ai-personalities.md.
+const Map<String, PersonalityThresholds> personalityThresholds = {
+  'victoria': PersonalityThresholds(warLikelihood: 20, peaceTendency: 80, allianceTendency: 80, researchMilitary: 40, researchNaval: 70, researchEconomic: 50, researchExploration: 60),
+  'napoleon': PersonalityThresholds(warLikelihood: 80, peaceTendency: 35, allianceTendency: 25, researchMilitary: 90, researchNaval: 40, researchEconomic: 50, researchExploration: 40),
+  'isabella': PersonalityThresholds(warLikelihood: 50, peaceTendency: 50, allianceTendency: 40, researchMilitary: 50, researchNaval: 60, researchEconomic: 60, researchExploration: 80),
+  'henry': PersonalityThresholds(warLikelihood: 10, peaceTendency: 70, allianceTendency: 75, researchMilitary: 30, researchNaval: 80, researchEconomic: 50, researchExploration: 80),
+  'deruyter': PersonalityThresholds(warLikelihood: 25, peaceTendency: 65, allianceTendency: 70, researchMilitary: 35, researchNaval: 60, researchEconomic: 85, researchExploration: 50),
+  'frederick': PersonalityThresholds(warLikelihood: 55, peaceTendency: 45, allianceTendency: 50, researchMilitary: 85, researchNaval: 45, researchEconomic: 40, researchExploration: 45),
+  'gustavus': PersonalityThresholds(warLikelihood: 55, peaceTendency: 50, allianceTendency: 50, researchMilitary: 75, researchNaval: 55, researchEconomic: 50, researchExploration: 55),
+};
+
 /// Default when leader id is unknown.
 const PersonalityDomainWeights defaultDomainWeights = PersonalityDomainWeights();
 const PersonalityGoalWeights defaultGoalWeights = PersonalityGoalWeights();
+const PersonalityThresholds defaultThresholds = PersonalityThresholds();
 
 PersonalityDomainWeights getDomainWeightsForLeader(String leaderId) {
   return personalityDomainWeights[leaderId] ?? defaultDomainWeights;
@@ -66,4 +102,8 @@ PersonalityDomainWeights getDomainWeightsForLeader(String leaderId) {
 
 PersonalityGoalWeights getGoalWeightsForLeader(String leaderId) {
   return personalityGoalWeights[leaderId] ?? defaultGoalWeights;
+}
+
+PersonalityThresholds getThresholdsForLeader(String leaderId) {
+  return personalityThresholds[leaderId] ?? defaultThresholds;
 }

--- a/packages/colonizethis_data/test/ai_personality_config_test.dart
+++ b/packages/colonizethis_data/test/ai_personality_config_test.dart
@@ -1,0 +1,49 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('getThresholdsForLeader', () {
+    test('returns default for unknown leader', () {
+      final t = getThresholdsForLeader('unknown_leader');
+      expect(t.warLikelihood, 50);
+      expect(t.peaceTendency, 50);
+      expect(t.allianceTendency, 50);
+      expect(t.researchNaval, 50);
+      expect(t.researchMilitary, 50);
+      expect(t.researchEconomic, 50);
+      expect(t.researchExploration, 50);
+    });
+
+    test('returns configured thresholds for victoria (low war, high peace/alliance)', () {
+      final t = getThresholdsForLeader('victoria');
+      expect(t.warLikelihood, lessThan(50));
+      expect(t.peaceTendency, greaterThan(50));
+      expect(t.allianceTendency, greaterThan(50));
+    });
+
+    test('returns configured thresholds for napoleon (high war, lower peace/alliance)', () {
+      final t = getThresholdsForLeader('napoleon');
+      expect(t.warLikelihood, greaterThan(50));
+      expect(t.peaceTendency, lessThan(50));
+      expect(t.allianceTendency, lessThan(50));
+    });
+
+    test('returns configured thresholds for henry (very low war)', () {
+      final t = getThresholdsForLeader('henry');
+      expect(t.warLikelihood, lessThan(30));
+    });
+  });
+
+  group('PersonalityThresholds', () {
+    test('default constructor uses 50 for all fields', () {
+      const t = PersonalityThresholds();
+      expect(t.warLikelihood, 50);
+      expect(t.peaceTendency, 50);
+      expect(t.allianceTendency, 50);
+      expect(t.researchNaval, 50);
+      expect(t.researchMilitary, 50);
+      expect(t.researchEconomic, 50);
+      expect(t.researchExploration, 50);
+    });
+  });
+}


### PR DESCRIPTION
Implements **gap #9** from `.github/ISSUE_AI_SPEC_GAPS.md`: personality thresholds (war likelihood, peace tendency, alliance tendency, research preference per tech category) and their use in goal selection, diplomacy planner, and research planner.

## Changes

- **colonizethis_data** (`ai_personality_config.dart`): `PersonalityThresholds` class (warLikelihood, peaceTendency, allianceTendency, researchNaval/Military/Economic/Exploration); `personalityThresholds` map per leader; `getThresholdsForLeader(leaderId)`.
- **goal_manager**: Conquer goal weight += (warLikelihood - 50); diplomacy goal weight += (peace + alliance tendency)/2 - 50.
- **domain_planners**: Diplomacy planner adds personality threshold to offerPeace / declareWar / alliance order scores. Research planner weights candidates by tech category (transport→naval, military→military, gathering→economic, else→exploration) and selects by weighted random.
- **Tests**: `packages/colonizethis_data/test/ai_personality_config_test.dart` for `getThresholdsForLeader` and default thresholds.
- **ISSUE_AI_SPEC_GAPS.md**: Gap #9 section and summary table updated to **Implemented**.

Part of **#18** (AI: Align implementation with SPEC Phase 6 gaps).

**Spec refs:** SPEC/ai/ai-personalities.md (Behavioral modifiers: thresholds applied when scoring actions).

Made with [Cursor](https://cursor.com)