### PR TITLE
feat(ai): state-aware Quick Battle tactical decisions (gap #5)

### DIFF
--- a/.github/ISSUE_AI_SPEC_GAPS.md
+++ b/.github/ISSUE_AI_SPEC_GAPS.md
@@ -54,13 +54,11 @@
 
 ---
 
-## 5. Tactical (Quick Battle) not state-aware
+## 5. Tactical (Quick Battle) not state-aware — **IMPLEMENTED**
 
 **Spec:** SPEC/ai/ai-architecture.md — Tactical behavior rules: prefer good terrain (hill, town, woods) with high-value units; avoid fragile units in swamp; use Volley Fire / Defend when outmatched or holding key lanes; use Maneuver / Fall Back to rotate damaged units; use Assault / Charge when enemy lane disrupted and terrain favorable. SPEC/program/ai-systems-impl.md — `decideQuickBattleActions(QuickBattleState, nationId, config, tacticalSeed)` returns CP-based actions per lane; deterministic given state and seed.
 
-**Current:** `decideQuickBattleActions` in `colonizethis_ai/lib/src/tactical_ai.dart` takes `QuickBattleInput` (and nationId, config, tacticalSeed) but **ignores** input state. It picks a random strategy from a fixed list of action lists. No use of lane state, strength, terrain, or unit health.
-
-**Missing:** Use `QuickBattleInput` (and any extended state) to choose actions per spec: e.g. when outmatched or holding center → Volley Fire / Defend; when damaged → Maneuver / Fall Back; when enemy disrupted and terrain favorable → Assault / Charge. Remain deterministic via `tacticalSeed`.
+**Current:** `decideQuickBattleActions` in `colonizethis_ai/lib/src/tactical_ai.dart` uses `QuickBattleInput` and `nationId` to identify our vs enemy deployment, computes effective strength (mirroring resolver formula with terrain and cohesion), and chooses actions by situation: **damaged** → Maneuver / Fall Back; **enemy disrupted and terrain favorable** → Assault / Charge; **outmatched or holding center** → Volley Fire / Defend; else weighted mix. Deterministic given `tacticalSeed`. Tests cover outmatched, damaged, and assault-favorable cases.
 
 ---
 
@@ -129,7 +127,7 @@
 | 2 | Evidence accumulation | Implemented (diplomacy) | High |
 | 3 | Dossier (basic intel, behavioral notes, timeline) | Implemented | Medium |
 | 4 | Dialogue and mood | Stub only | Medium |
-| 5 | Tactical Quick Battle state-aware | Missing | Medium |
+| 5 | Tactical Quick Battle state-aware | Implemented | Medium |
 | 6 | Perception (threats/opportunities) | Partial | Medium |
 | 7 | Diplomacy domain planner + API | Missing | High |
 | 8 | Hidden agenda (tech_thief, envy; peace/alliance/treaty) | Implemented | Medium |

--- a/packages/colonizethis_ai/lib/src/tactical_ai.dart
+++ b/packages/colonizethis_ai/lib/src/tactical_ai.dart
@@ -1,12 +1,18 @@
 import 'dart:math' as math;
 
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'ai_config.dart';
 
-/// Tactical (Quick Battle) decisions for full AI. SPEC/program/ai-systems-impl.md.
+/// Tactical (Quick Battle) decisions for full AI. SPEC/ai/ai-architecture.md,
+/// SPEC/program/ai-systems-impl.md.
 ///
-/// Returns CP-based actions for one round for the AI side. Deterministic given [input] and [tacticalSeed].
+/// Returns CP-based actions for one round for the AI side. Deterministic given
+/// [input] and [tacticalSeed]. Uses input state (our vs enemy strength, terrain,
+/// cohesion) to choose actions per spec: Volley Fire/Defend when outmatched or
+/// holding key lanes; Maneuver/Fall Back when damaged; Assault/Charge when
+/// enemy disrupted and terrain favorable.
 QuickBattleRoundActions decideQuickBattleActions({
   required QuickBattleInput input,
   required String nationId,
@@ -14,7 +20,66 @@ QuickBattleRoundActions decideQuickBattleActions({
   required int tacticalSeed,
 }) {
   final rng = math.Random(tacticalSeed);
-  // Simple heuristic: choose from a few strategies (1–2 CP total).
+  final ourDeploy = nationId == input.attackerFactionId
+      ? input.attackerDeployment
+      : input.defenderDeployment;
+  final enemyDeploy = nationId == input.attackerFactionId
+      ? input.defenderDeployment
+      : input.attackerDeployment;
+  final ourMult = nationId == input.attackerFactionId
+      ? input.attackerLeaderMultiplier
+      : input.defenderLeaderMultiplier;
+  final enemyMult = nationId == input.attackerFactionId
+      ? input.defenderLeaderMultiplier
+      : input.attackerLeaderMultiplier;
+
+  final ourStrength =
+      _effectiveStrength(ourDeploy.groups, ourDeploy.laneTerrain) * ourMult;
+  final enemyStrength =
+      _effectiveStrength(enemyDeploy.groups, enemyDeploy.laneTerrain) * enemyMult;
+  final outmatched = ourStrength > 0 && enemyStrength >= ourStrength * 1.15;
+  final holdingCenter = _hasGroupInLane(ourDeploy.groups, QuickBattleLane.center);
+  final weHaveDamaged = _hasDamagedGroups(ourDeploy.groups);
+  final enemyDisrupted =
+      enemyStrength <= ourStrength * 0.7 || _hasDamagedGroups(enemyDeploy.groups);
+  final terrainFavorable = _terrainFavorableForUs(ourDeploy, enemyDeploy);
+
+  // SPEC: Maneuver / Fall Back to rotate damaged units (prioritize over holding).
+  if (weHaveDamaged) {
+    final options = [
+      [QuickBattleAction.maneuver],
+      [QuickBattleAction.fallBackRefuseFlank],
+      [QuickBattleAction.volleyFire, QuickBattleAction.maneuver],
+    ];
+    return QuickBattleRoundActions(
+      actions: options[rng.nextInt(options.length)],
+    );
+  }
+
+  // SPEC: Assault / Charge when enemy lane is disrupted and terrain is favorable.
+  if (enemyDisrupted && terrainFavorable) {
+    final options = [
+      [QuickBattleAction.assaultCharge],
+      [QuickBattleAction.volleyFire, QuickBattleAction.assaultCharge],
+    ];
+    return QuickBattleRoundActions(
+      actions: options[rng.nextInt(options.length)],
+    );
+  }
+
+  // SPEC: Volley Fire / Defend when outmatched or holding key lanes (especially center).
+  if (outmatched || holdingCenter) {
+    final options = [
+      [QuickBattleAction.volleyFire],
+      [QuickBattleAction.defendEntrench],
+      [QuickBattleAction.volleyFire, QuickBattleAction.defendEntrench],
+    ];
+    return QuickBattleRoundActions(
+      actions: options[rng.nextInt(options.length)],
+    );
+  }
+
+  // Default: mix of volley/defend/maneuver/assault by seed.
   final strategies = [
     [QuickBattleAction.volleyFire],
     [QuickBattleAction.defendEntrench],
@@ -23,4 +88,76 @@ QuickBattleRoundActions decideQuickBattleActions({
   ];
   final idx = rng.nextInt(strategies.length);
   return QuickBattleRoundActions(actions: strategies[idx]);
+}
+
+/// Effective strength for groups; mirrors resolver formula for consistency.
+double _effectiveStrength(
+  List<QuickBattleGroup> groups,
+  Map<String, QuickBattleLaneTerrain> laneTerrain,
+) {
+  var total = 0.0;
+  for (final g in groups) {
+    if (g.unitIds.isEmpty || g.cohesion <= 0) continue;
+    final cohesionScale = g.cohesion / quickBattleMaxCohesion;
+    final terrainKey = '${g.lane.name}_${g.line.name}';
+    final terr = laneTerrain[terrainKey] ?? QuickBattleLaneTerrain.open;
+    var mod = 1.0;
+    switch (terr) {
+      case QuickBattleLaneTerrain.hill:
+      case QuickBattleLaneTerrain.town:
+        mod = 1.1;
+        break;
+      case QuickBattleLaneTerrain.woods:
+        mod = 0.95;
+        break;
+      case QuickBattleLaneTerrain.swamp:
+        mod = 0.8;
+        break;
+      case QuickBattleLaneTerrain.open:
+        break;
+    }
+    total += g.unitIds.length * cohesionScale * mod;
+  }
+  return total;
+}
+
+bool _hasGroupInLane(List<QuickBattleGroup> groups, QuickBattleLane lane) {
+  return groups.any((g) => g.lane == lane && g.unitIds.isNotEmpty);
+}
+
+bool _hasDamagedGroups(List<QuickBattleGroup> groups) {
+  return groups.any(
+    (g) => g.unitIds.isNotEmpty && g.cohesion < quickBattleMaxCohesion,
+  );
+}
+
+/// True if our deployment has better terrain (good lanes) than enemy or we hold good terrain.
+bool _terrainFavorableForUs(
+  QuickBattleDeployment ourDeploy,
+  QuickBattleDeployment enemyDeploy,
+) {
+  final ourGood = _countGoodTerrainLanes(ourDeploy.laneTerrain);
+  final ourSwamp = _countSwampLanes(ourDeploy.laneTerrain);
+  final enemyGood = _countGoodTerrainLanes(enemyDeploy.laneTerrain);
+  final enemySwamp = _countSwampLanes(enemyDeploy.laneTerrain);
+  if (ourSwamp > 0 && ourGood == 0) return false;
+  return ourGood >= enemyGood || enemySwamp > ourSwamp;
+}
+
+int _countGoodTerrainLanes(Map<String, QuickBattleLaneTerrain> laneTerrain) {
+  var n = 0;
+  for (final t in laneTerrain.values) {
+    if (t == QuickBattleLaneTerrain.hill ||
+        t == QuickBattleLaneTerrain.town ||
+        t == QuickBattleLaneTerrain.woods) {
+      n++;
+    }
+  }
+  return n;
+}
+
+int _countSwampLanes(Map<String, QuickBattleLaneTerrain> laneTerrain) {
+  return laneTerrain.values
+      .where((t) => t == QuickBattleLaneTerrain.swamp)
+      .length;
 }

--- a/packages/colonizethis_ai/test/tactical_ai_test.dart
+++ b/packages/colonizethis_ai/test/tactical_ai_test.dart
@@ -69,5 +69,161 @@ void main() {
       );
       expect(a.actions, b.actions);
     });
+    test('prefers Volley Fire or Defend when outmatched (we are defender, weaker)', () {
+      const input = QuickBattleInput(
+        attackerFactionId: 'att',
+        defenderFactionId: 'def',
+        provinceId: 'p1',
+        regionId: 'oldWorld',
+        attackerDeployment: QuickBattleDeployment(
+          groups: [
+            QuickBattleGroup(
+              lane: QuickBattleLane.center,
+              line: QuickBattleLine.front,
+              unitIds: ['a1', 'a2', 'a3', 'a4', 'a5'],
+              cohesion: 3,
+            ),
+          ],
+          laneTerrain: {'center_front': QuickBattleLaneTerrain.open},
+        ),
+        defenderDeployment: QuickBattleDeployment(
+          groups: [
+            QuickBattleGroup(
+              lane: QuickBattleLane.center,
+              line: QuickBattleLine.front,
+              unitIds: ['d1', 'd2'],
+              cohesion: 3,
+            ),
+          ],
+          laneTerrain: {'center_front': QuickBattleLaneTerrain.open},
+        ),
+        fortLevel: 0,
+        provinceTerrain: 'plains',
+        seed: 0,
+        maxRounds: 10,
+        attackerLeaderMultiplier: 1.0,
+        defenderLeaderMultiplier: 1.0,
+      );
+      const config = AIConfig(
+        leaderId: 'test',
+        personalityId: 'militant',
+        hiddenAgendaId: 'warmonger',
+      );
+      for (var i = 0; i < 20; i++) {
+        final actions = decideQuickBattleActions(
+          input: input,
+          nationId: 'def',
+          config: config,
+          tacticalSeed: 1000 + i,
+        );
+        expect(actions.actions, isNotEmpty);
+        final hasDefensive = actions.actions.any((a) =>
+            a == QuickBattleAction.volleyFire ||
+            a == QuickBattleAction.defendEntrench);
+        expect(hasDefensive, isTrue);
+      }
+    });
+    test('prefers Maneuver or Fall Back when we have damaged groups', () {
+      const input = QuickBattleInput(
+        attackerFactionId: 'att',
+        defenderFactionId: 'def',
+        provinceId: 'p1',
+        regionId: 'oldWorld',
+        attackerDeployment: QuickBattleDeployment(
+          groups: [
+            QuickBattleGroup(
+              lane: QuickBattleLane.center,
+              line: QuickBattleLine.front,
+              unitIds: ['a1', 'a2'],
+              cohesion: 2,
+            ),
+          ],
+          laneTerrain: {'center_front': QuickBattleLaneTerrain.open},
+        ),
+        defenderDeployment: QuickBattleDeployment(
+          groups: [
+            QuickBattleGroup(
+              lane: QuickBattleLane.center,
+              line: QuickBattleLine.front,
+              unitIds: ['d1', 'd2', 'd3'],
+              cohesion: 1,
+            ),
+          ],
+          laneTerrain: {'center_front': QuickBattleLaneTerrain.open},
+        ),
+        fortLevel: 0,
+        provinceTerrain: 'plains',
+        seed: 0,
+        maxRounds: 10,
+      );
+      const config = AIConfig(
+        leaderId: 'test',
+        personalityId: 'militant',
+        hiddenAgendaId: 'warmonger',
+      );
+      for (var i = 0; i < 20; i++) {
+        final actions = decideQuickBattleActions(
+          input: input,
+          nationId: 'def',
+          config: config,
+          tacticalSeed: 2000 + i,
+        );
+        final hasManeuverOrFallBack = actions.actions.any((a) =>
+            a == QuickBattleAction.maneuver ||
+            a == QuickBattleAction.fallBackRefuseFlank);
+        expect(hasManeuverOrFallBack, isTrue);
+      }
+    });
+    test('prefers Assault/Charge when enemy disrupted and terrain favorable', () {
+      const input = QuickBattleInput(
+        attackerFactionId: 'att',
+        defenderFactionId: 'def',
+        provinceId: 'p1',
+        regionId: 'oldWorld',
+        attackerDeployment: QuickBattleDeployment(
+          groups: [
+            QuickBattleGroup(
+              lane: QuickBattleLane.center,
+              line: QuickBattleLine.front,
+              unitIds: ['a1', 'a2', 'a3', 'a4'],
+              cohesion: 3,
+            ),
+          ],
+          laneTerrain: {'center_front': QuickBattleLaneTerrain.hill},
+        ),
+        defenderDeployment: QuickBattleDeployment(
+          groups: [
+            QuickBattleGroup(
+              lane: QuickBattleLane.center,
+              line: QuickBattleLine.front,
+              unitIds: ['d1'],
+              cohesion: 1,
+            ),
+          ],
+          laneTerrain: {'center_front': QuickBattleLaneTerrain.open},
+        ),
+        fortLevel: 0,
+        provinceTerrain: 'plains',
+        seed: 0,
+        maxRounds: 10,
+      );
+      const config = AIConfig(
+        leaderId: 'test',
+        personalityId: 'militant',
+        hiddenAgendaId: 'warmonger',
+      );
+      for (var i = 0; i < 20; i++) {
+        final actions = decideQuickBattleActions(
+          input: input,
+          nationId: 'att',
+          config: config,
+          tacticalSeed: 3000 + i,
+        );
+        expect(
+          actions.actions.contains(QuickBattleAction.assaultCharge),
+          isTrue,
+        );
+      }
+    });
   });
 }


### PR DESCRIPTION
Implements **gap #5** from `.github/ISSUE_AI_SPEC_GAPS.md`: make `decideQuickBattleActions` use Quick Battle input state (our vs enemy strength, terrain, cohesion) to choose actions per spec.

## Changes

- **tactical_ai.dart**: `decideQuickBattleActions` now identifies our vs enemy deployment from `nationId`, computes effective strength (same formula as resolver: units × cohesion scale × terrain mod), and selects actions by situation:
  - **Damaged** (low cohesion) → Maneuver / Fall Back
  - **Enemy disrupted and terrain favorable** → Assault / Charge
  - **Outmatched or holding center** → Volley Fire / Defend
  - Else → weighted mix (deterministic via `tacticalSeed`)
- **Tests**: outmatched prefers volley/defend; damaged prefers maneuver/fall back; assault when we have good terrain and enemy is weak.
- **ISSUE_AI_SPEC_GAPS.md**: Gap #5 section and summary table updated to **Implemented**.

Part of **#18** (AI: Align implementation with SPEC Phase 6 gaps).

**Spec refs:** SPEC/ai/ai-architecture.md, SPEC/program/ai-systems-impl.md.

Made with [Cursor](https://cursor.com)