### PR TITLE
feat(ai): emit DialogueEvent on AI declare war/peace (gap #4 partial)

### DIFF
--- a/.github/ISSUE_AI_SPEC_GAPS.md
+++ b/.github/ISSUE_AI_SPEC_GAPS.md
@@ -39,16 +39,16 @@
 
 ---
 
-## 4. Dialogue and mood mostly stubs
+## 4. Dialogue and mood — **PARTIAL** (diplomatic dialogue implemented)
 
 **Spec:** SPEC/ai/dialogue-and-mood.md — Dialogue categories: diplomatic, reactive, event, agenda, negotiation. Emit `DialogueEvent` on diplomatic actions, game events, reactive banter, agenda-flavour (keys + context; content in data assets). Emit `PortraitMoodEvent` on negotiation mood transition (mood state machine: current mood, offerQualityDelta, stallCounter → next mood).
 
 **Current:**  
-- **Dialogue:** Only one emission in `generateStrategicOrders`: when `dialogueSeed % 7 == 0`, a single generic `DialogueEvent(leaderId, category: 'agenda', situation: 'comment', era: 'earlyModern')`. No diplomatic, reactive, event, or negotiation dialogue; no use of actual situation/era/variables from context.  
+- **Dialogue:** (1) In `generateStrategicOrders`: when `dialogueSeed % 7 == 0`, a generic `DialogueEvent(leaderId, category: 'agenda', situation: 'comment', era: 'earlyModern')`. (2) **Diplomatic:** When an AI applies declare war or offer peace in the diplomacy phase, `resolveDiplomacyPhase` invokes optional `onDialogue` with `DialogueEvent(leaderId: gpId, category: 'diplomatic', situation: 'declare_war' | 'peace_offer', era: 'earlyModern', variables: {'otherNation': targetId})`. Callback is threaded via `resolveTurnForGame` / `resolveTurnForGameFromOrderEngine` / `validateOrdersAndResolveTurn`.  
 - **Mood:** `PortraitMoodEvent` is never emitted. No mood state machine, no negotiation offer/quality/stall inputs.
 
 **Missing:**  
-- Emit dialogue on actual events (declare war, peace offer, battle result, etc.) with correct category/situation/era/variables.  
+- Emit dialogue on reactive/event/negotiation (battle result, era change, reactive banter) with correct category/situation/era/variables.  
 - Implement negotiation mood state machine and emit `PortraitMoodEvent` on transition.  
 - (Optional) Dialogue content keys/catalog in data package per spec.
 
@@ -126,7 +126,7 @@
 | 1 | Naval mission orders dropped in full-AI aggregation | Fixed | High |
 | 2 | Evidence accumulation | Implemented (diplomacy) | High |
 | 3 | Dossier (basic intel, behavioral notes, timeline) | Implemented | Medium |
-| 4 | Dialogue and mood | Stub only | Medium |
+| 4 | Dialogue and mood | Partial (diplomatic) | Medium |
 | 5 | Tactical Quick Battle state-aware | Implemented | Medium |
 | 6 | Perception (threats/opportunities) | Partial | Medium |
 | 7 | Diplomacy domain planner + API | Missing | High |

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -87,7 +87,13 @@ bool _isGreatPower(Game game, String factionId) {
 }
 
 /// Resolves Diplomacy phase. Runs before Movement per turn-resolution-phases.
-Game resolveDiplomacyPhase(Game game, Orders orders) {
+/// When an AI applies declare war or offer peace, [onDialogue] is invoked with
+/// a [DialogueEvent] (SPEC/ai/dialogue-and-mood.md).
+Game resolveDiplomacyPhase(
+  Game game,
+  Orders orders, {
+  void Function(DialogueEvent)? onDialogue,
+}) {
   final turn = game.worldState.turnState.turnNumber;
   var state = game;
 
@@ -106,7 +112,7 @@ Game resolveDiplomacyPhase(Game game, Orders orders) {
   state = _processAlliances(state, diploByPlayer, turn);
 
   // 5. Process Declare War and Peace
-  state = _processWarAndPeace(state, diploByPlayer, turn);
+  state = _processWarAndPeace(state, diploByPlayer, turn, onDialogue: onDialogue);
 
   // 6. War terminates agreements with target
   state = _terminateAgreementsOnWar(state);
@@ -279,8 +285,9 @@ Game _processAlliances(
 Game _processWarAndPeace(
   Game game,
   Map<String, List<DiplomaticOrder>> diploByPlayer,
-  int turn,
-) {
+  int turn, {
+  void Function(DialogueEvent)? onDialogue,
+}) {
   var relations = List<DiplomacyRelation>.from(game.diplomacyRelations);
 
   for (final entry in diploByPlayer.entries) {
@@ -291,6 +298,15 @@ Game _processWarAndPeace(
         final rel = getRelation(game, gpId, targetId);
         final atPeace = rel == null || rel.atPeace;
         if (atPeace) {
+          if (onDialogue != null && isAiControlledForEvidence(game, gpId)) {
+            onDialogue(DialogueEvent(
+              leaderId: gpId,
+              category: 'diplomatic',
+              situation: 'declare_war',
+              era: 'earlyModern',
+              variables: {'otherNation': targetId},
+            ));
+          }
           final evidence = evidenceForDeclareWar(game, gpId, targetId, turn);
           final ids = _pairIds(gpId, targetId);
           relations = upsertRelation(relations, gpId, targetId, (existing) {
@@ -323,6 +339,15 @@ Game _processWarAndPeace(
         final targetId = order.targetFactionId;
         final rel = getRelation(game, gpId, targetId);
         if (rel != null && rel.atWar) {
+          if (onDialogue != null && isAiControlledForEvidence(game, gpId)) {
+            onDialogue(DialogueEvent(
+              leaderId: gpId,
+              category: 'diplomatic',
+              situation: 'peace_offer',
+              era: 'earlyModern',
+              variables: {'otherNation': targetId},
+            ));
+          }
           final evidence = evidenceForOfferPeace(game, gpId, targetId, turn);
           relations = upsertRelation(relations, gpId, targetId, (existing) {
             return existing!.copyWith(

--- a/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+++ b/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
@@ -15,8 +15,9 @@ List<String> _humanObserverIds(Game game) {
       .toList();
 }
 
-/// True if [playerId] is AI-controlled (evidence is only for AI subjects).
-bool _isAiControlled(Game game, String playerId) {
+/// True if [playerId] is AI-controlled (evidence/dialogue only for AI subjects).
+/// Named to avoid export clash with ai_planner.isAiControlled.
+bool isAiControlledForEvidence(Game game, String playerId) {
   final explicit = game.aiControlByGpId[playerId];
   if (explicit != null) return explicit;
   final p = _getPlayer(game, playerId);
@@ -56,7 +57,7 @@ List<DossierEvidenceEntry> evidenceForDeclareWar(
   String targetFactionId,
   int turnNumber,
 ) {
-  if (!_isAiControlled(game, actorGpId)) return [];
+  if (!isAiControlledForEvidence(game, actorGpId)) return [];
   final observers = _humanObserverIds(game);
   if (observers.isEmpty) return [];
 
@@ -101,7 +102,7 @@ List<DossierEvidenceEntry> evidenceForOfferPeace(
   String targetFactionId,
   int turnNumber,
 ) {
-  if (!_isAiControlled(game, actorGpId)) return [];
+  if (!isAiControlledForEvidence(game, actorGpId)) return [];
   final observers = _humanObserverIds(game);
   if (observers.isEmpty) return [];
 

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -89,6 +89,7 @@ Game resolveTurnForGameFromOrderEngine({
   Map<String, TileMapResult>? tileMapByRegion,
   Map<String, Map<CommodityId, int>> extractedByPlayerId = const {},
   List<AssignedRecipe> defaultAssignments = const [],
+  void Function(DialogueEvent)? onDialogue,
 }) {
   final merged = mergeOrderLists(
     humanOrders: orderEngine.orders,
@@ -98,6 +99,7 @@ Game resolveTurnForGameFromOrderEngine({
     game: game,
     topology: topology,
     orders: merged,
+    onDialogue: onDialogue,
     tileMapByRegion: tileMapByRegion,
     extractedByPlayerId: extractedByPlayerId,
     defaultAssignments: defaultAssignments,
@@ -120,6 +122,7 @@ Game validateOrdersAndResolveTurn({
   Map<String, TileMapResult>? tileMapByRegion,
   Map<String, Map<CommodityId, int>> extractedByPlayerId = const {},
   List<AssignedRecipe> defaultAssignments = const [],
+  void Function(DialogueEvent)? onDialogue,
 }) {
   final engine = OrderEngine(initialOrders: orders);
   final filtered = _filterAcceptedOrdersForAllPlayers(
@@ -129,6 +132,7 @@ Game validateOrdersAndResolveTurn({
   );
   return resolveTurnForGame(
     game: game,
+    onDialogue: onDialogue,
     topology: topology,
     orders: filtered,
     tileMapByRegion: tileMapByRegion,
@@ -144,6 +148,7 @@ Game resolveTurnForGame({
   Map<String, TileMapResult>? tileMapByRegion,
   Map<String, Map<CommodityId, int>> extractedByPlayerId = const {},
   List<AssignedRecipe> defaultAssignments = const [],
+  void Function(DialogueEvent)? onDialogue,
 }) {
   final turn = game.worldState.turnState.turnNumber;
   _log.i('logic: turn $turn resolve start');
@@ -177,7 +182,7 @@ Game resolveTurnForGame({
         state = resolveResearchPhase(state, orders);
         break;
       case TurnPhase.diplomacy:
-        state = resolveDiplomacyPhase(state, orders);
+        state = resolveDiplomacyPhase(state, orders, onDialogue: onDialogue);
         break;
       case TurnPhase.movement:
         state = _runMovementPhase(state, topology, orders);

--- a/packages/colonizethis_logic/test/diplomacy_resolver_test.dart
+++ b/packages/colonizethis_logic/test/diplomacy_resolver_test.dart
@@ -536,6 +536,121 @@ void main() {
     });
   });
 
+  group('dialogue (Phase 6)', () {
+    test('AI declare war invokes onDialogue with diplomatic declare_war', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true),
+          Player(id: 'gp2', displayName: 'AI', isHuman: false),
+          Player(id: 'gp3', displayName: 'Other', isHuman: false),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'gp2',
+            factionId2: 'gp3',
+            score: 50,
+            level: RelationLevel.neutral,
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      final orders = Orders(
+        diplomaticOrdersByPlayerId: {
+          'gp2': const [
+            DiplomaticOrder(type: DiplomaticOrderType.declareWar, targetFactionId: 'gp3'),
+          ],
+        },
+      );
+      DialogueEvent? captured;
+      resolveDiplomacyPhase(game, orders, onDialogue: (e) => captured = e);
+      expect(captured, isNotNull);
+      expect(captured!.leaderId, 'gp2');
+      expect(captured!.category, 'diplomatic');
+      expect(captured!.situation, 'declare_war');
+      expect(captured!.era, 'earlyModern');
+      expect(captured!.variables['otherNation'], 'gp3');
+    });
+
+    test('AI offer peace invokes onDialogue with diplomatic peace_offer', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true),
+          Player(id: 'gp2', displayName: 'AI', isHuman: false),
+          Player(id: 'gp3', displayName: 'Other', isHuman: false),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'gp2',
+            factionId2: 'gp3',
+            score: 40,
+            level: RelationLevel.neutral,
+            state: RelationState.atWar,
+          ),
+        ],
+      );
+      final orders = Orders(
+        diplomaticOrdersByPlayerId: {
+          'gp2': const [
+            DiplomaticOrder(type: DiplomaticOrderType.offerPeace, targetFactionId: 'gp3'),
+          ],
+        },
+      );
+      DialogueEvent? captured;
+      resolveDiplomacyPhase(game, orders, onDialogue: (e) => captured = e);
+      expect(captured, isNotNull);
+      expect(captured!.leaderId, 'gp2');
+      expect(captured!.category, 'diplomatic');
+      expect(captured!.situation, 'peace_offer');
+      expect(captured!.variables['otherNation'], 'gp3');
+    });
+
+    test('human declare war does not invoke onDialogue', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true),
+          Player(id: 'gp2', displayName: 'AI', isHuman: false),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'gp2',
+            score: 50,
+            level: RelationLevel.neutral,
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      final orders = Orders(
+        diplomaticOrdersByPlayerId: {
+          'gp1': const [
+            DiplomaticOrder(type: DiplomaticOrderType.declareWar, targetFactionId: 'gp2'),
+          ],
+        },
+      );
+      var callCount = 0;
+      resolveDiplomacyPhase(game, orders, onDialogue: (_) => callCount++);
+      expect(callCount, 0);
+    });
+  });
+
   group('intervention helpers', () {
     test('needsInterventionChoice returns gp id with embassy for attacked minor', () {
       final game = Game(


### PR DESCRIPTION
Implements **gap #4** (partial) from `.github/ISSUE_AI_SPEC_GAPS.md`: emit `DialogueEvent` when an AI performs diplomatic actions (declare war, offer peace) with correct category/situation/era/variables per SPEC/ai/dialogue-and-mood.md.

## Changes

- **diplomacy_resolver.dart**: `resolveDiplomacyPhase` accepts optional `onDialogue` callback. When an AI applies declare war or offer peace, invokes callback with `DialogueEvent(leaderId: gpId, category: 'diplomatic', situation: 'declare_war' | 'peace_offer', era: 'earlyModern', variables: {'otherNation': targetId})`.
- **turn_resolver.dart**: `resolveTurnForGame`, `validateOrdersAndResolveTurn`, `resolveTurnForGameFromOrderEngine` accept optional `onDialogue` and pass it to the diplomacy phase.
- **evidence_rules.dart**: Renamed `isAiControlled` to `isAiControlledForEvidence` to avoid export clash with `ai_planner.isAiControlled`.
- **Tests**: New `dialogue (Phase 6)` group in `diplomacy_resolver_test.dart`: AI declare war/offer peace invoke callback with expected event; human declare war does not invoke callback.
- **ISSUE_AI_SPEC_GAPS.md**: Gap 4 section and summary table updated to **Partial (diplomatic)**.

**Still missing for gap 4:** reactive/event/negotiation dialogue, mood state machine, `PortraitMoodEvent` (follow-up).

Part of **#18** (AI: Align implementation with SPEC Phase 6 gaps).

**Spec refs:** SPEC/ai/dialogue-and-mood.md, SPEC/program/ai-events-and-dossier.md.

Made with [Cursor](https://cursor.com)