### PR TITLE
docs(ai): clarify goal selection as weighted choice (gap #10)

### DIFF
--- a/.github/ISSUE_AI_SPEC_GAPS.md
+++ b/.github/ISSUE_AI_SPEC_GAPS.md
@@ -101,13 +101,13 @@
 
 ---
 
-## 10. Goal selection is weighted random, not behavior tree
+## 10. Goal selection is weighted random, not behavior tree — **DOCUMENTED**
 
 **Spec:** SPEC/ai/ai-architecture.md — "Behavior trees pick top-level goals"; "Behavior trees pick long-term strategy (expand, defend, trade, conquer, tech, diplomacy)."
 
 **Current:** `goal_manager.dart` implements **weighted random** choice over `StrategicGoal` using personality goal weights, agenda modifiers, and snapshot situational modifiers. No actual behavior tree (nodes, sequences, selectors).
 
-**Note:** This may be acceptable if "behavior tree" is interpreted as "hierarchical goal selection"; the spec also says "utility AI scores and selects concrete objectives". If strict behavior-tree structure is required (e.g. for designer-editable trees), replace weighted random with a small tree (e.g. selector over defend/expand/conquer/trade/tech/diplomacy) that uses the same weights as inputs.
+**Spec clarification (ai-architecture.md):** Goal selection may be implemented as **weighted choice** over strategic goals; this satisfies the "behavior tree" requirement when interpreted as hierarchical goal selection. Strict behavior-tree node structure is optional for designer-editable trees.
 
 ---
 
@@ -132,5 +132,5 @@
 | 7 | Diplomacy domain planner + API | Missing | High |
 | 8 | Hidden agenda (tech_thief, envy; peace/alliance/treaty) | Implemented | Medium |
 | 9 | Personality thresholds (war/peace/alliance/research) | Implemented | Medium |
-| 10 | Behavior tree vs weighted random | Design choice | Low |
+| 10 | Goal selection (weighted choice vs behavior tree) | Documented | Low |
 | 11 | OrderSuggestionAPI diplomatic | Implemented | High (for #7) |

--- a/SPEC/ai/ai-architecture.md
+++ b/SPEC/ai/ai-architecture.md
@@ -25,9 +25,11 @@ Characterful, deterministic AI using only observable game state. Difficulty affe
 
 Behavior trees pick top-level goals; utility AI scores and selects concrete objectives; tactical layer produces combat and movement orders.
 
+**Goal selection implementation:** Goal selection may be implemented as **weighted choice** over strategic goals (expand, defend, trade, conquer, tech, diplomacy) using personality weights, agenda modifiers, and situational snapshot. This satisfies the "behavior tree" requirement when interpreted as hierarchical goal selection. Strict behavior-tree node structure (sequences, selectors) is optional and may be used where designer-editable trees are desired.
+
 ### Turn Pipeline (per AI Great Power)
 1. **Perception** — Derive observable snapshot: threats, opportunities, economy, relations. All from PlayerView; no hidden data.
-2. **Goal selection** — Behavior tree chooses strategy using personality weights and hidden agenda modifiers.
+2. **Goal selection** — Choose strategy (e.g. weighted choice over goals) using personality weights and hidden agenda modifiers.
 3. **Domain planning** — Economy, military, diplomacy, research planners score candidates via personality and agenda weights; each emits candidate orders.
 4. **Execution** — Combine, cap, and validate orders; emit dialogue/mood events.
 5. **Tactical** — Quick Battle: CP-based actions per lane, deterministic given state and seed.


### PR DESCRIPTION
Clarifies **gap #10** from `.github/ISSUE_AI_SPEC_GAPS.md`: goal selection may be implemented as weighted choice over strategic goals; no strict behavior-tree structure required.

## Changes
- **SPEC/ai/ai-architecture.md:** Added "Goal selection implementation" paragraph: weighted choice over goals using personality/agenda/snapshot satisfies the "behavior tree" requirement when interpreted as hierarchical goal selection; strict BT nodes optional for designer-editable trees. Pipeline step 2 wording relaxed to "Choose strategy (e.g. weighted choice over goals)".
- **.github/ISSUE_AI_SPEC_GAPS.md:** Gap 10 section marked **DOCUMENTED**; summary table row updated to "Documented".

Part of **#18** (AI: Align implementation with SPEC Phase 6 gaps).

Made with [Cursor](https://cursor.com)