### PR TITLE
feat(ai): evidence accumulation for combat phase (gap #2)

### DIFF
--- a/.github/ISSUE_AI_SPEC_GAPS.md
+++ b/.github/ISSUE_AI_SPEC_GAPS.md
@@ -23,11 +23,11 @@
 
 ---
 
-## 2. Evidence accumulation — **IMPLEMENTED** (diplomacy phase)
+## 2. Evidence accumulation — **IMPLEMENTED** (diplomacy + combat)
 
 **Spec:** SPEC/ai/hidden-agendas.md — "When the game or AI performs an action, evidence rules may add points to that agenda's suspicion counter". SPEC/program/ai-events-and-dossier.md — "Evidence rules evaluated when actions are applied (turn resolution or post-resolution hook)."
 
-**Current:** `colonizethis_logic/lib/src/dossier/evidence_rules.dart` defines evidence rules. Diplomacy resolver calls them when applying declare war and offer peace: **declare war** → warmonger +2 if target is weaker GP (by military level), backstabber +2 if target was allied; **offer peace** → peacemaker +1. Evidence is appended to `game.dossierEvidenceEntries` per (observer, subject, agenda type); only human observers receive entries, and only when the actor (subject) is AI-controlled. Combat/other actions not yet hooked.
+**Current:** `colonizethis_logic/lib/src/dossier/evidence_rules.dart` defines evidence rules. **Diplomacy:** declare war → warmonger +2 if target is weaker GP, backstabber +2 if target was allied; offer peace → peacemaker +1. **Combat:** Land battle victory (AI wins as attacker, province flips) → warmonger +1, or +2 if defender was weaker GP; naval battle victory (one side eliminated) → warmonger +1. Evidence is appended to `game.dossierEvidenceEntries` per (observer, subject, agenda type); only human observers receive entries, and only when the actor (subject) is AI-controlled. Turn resolver calls evidence after each land battle (quick and auto-resolve) and each naval battle.
 
 ---
 
@@ -119,7 +119,7 @@ Tests in `perception_test.dart` cover threats (including neighbor/capital with t
 | # | Area | Status | Priority |
 |---|------|--------|----------|
 | 1 | Naval mission orders dropped in full-AI aggregation | Fixed | High |
-| 2 | Evidence accumulation | Implemented (diplomacy) | High |
+| 2 | Evidence accumulation | Implemented (diplomacy + combat) | High |
 | 3 | Dossier (basic intel, behavioral notes, timeline) | Implemented | Medium |
 | 4 | Dialogue and mood | Partial (diplomatic + mood machine + base mood) | Medium |
 | 5 | Tactical Quick Battle state-aware | Implemented | Medium |

--- a/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+++ b/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
@@ -120,3 +120,64 @@ List<DossierEvidenceEntry> evidenceForOfferPeace(
   _log.d('data: evidence for offerPeace actor=$actorGpId target=$targetFactionId entries=${entries.length}');
   return entries;
 }
+
+/// Evidence entries for "AI won land battle as attacker". Warmonger; +2 if defender was weaker GP.
+/// SPEC/ai/hidden-agendas.md: observable actions add suspicion (e.g. attacks weaker neighbors).
+List<DossierEvidenceEntry> evidenceForLandBattleVictory(
+  Game game,
+  String victorGpId,
+  String defenderFactionId,
+  int turnNumber,
+) {
+  if (!isAiControlledForEvidence(game, victorGpId)) return [];
+  final observers = _humanObserverIds(game);
+  if (observers.isEmpty) return [];
+
+  final targetIsGp = _getPlayer(game, defenderFactionId) != null;
+  final weaker = targetIsGp && _isWeakerGp(game, victorGpId, defenderFactionId);
+  final scoreDelta = weaker ? 2 : 1;
+
+  final entries = <DossierEvidenceEntry>[];
+  for (final observerId in observers) {
+    entries.add(DossierEvidenceEntry(
+      observerId: observerId,
+      subjectId: victorGpId,
+      agendaType: 'warmonger',
+      turnNumber: turnNumber,
+      description: weaker ? 'won battle vs weaker neighbor' : 'won battle as attacker',
+      scoreDelta: scoreDelta,
+    ));
+  }
+  if (entries.isNotEmpty) {
+    _log.d('data: evidence for land battle victory victor=$victorGpId defender=$defenderFactionId entries=${entries.length}');
+  }
+  return entries;
+}
+
+/// Evidence entries for "AI won naval battle" (one side eliminated). Warmonger tendency.
+List<DossierEvidenceEntry> evidenceForNavalBattleVictory(
+  Game game,
+  String victorOwnerId,
+  String loserOwnerId,
+  int turnNumber,
+) {
+  if (!isAiControlledForEvidence(game, victorOwnerId)) return [];
+  final observers = _humanObserverIds(game);
+  if (observers.isEmpty) return [];
+
+  final entries = <DossierEvidenceEntry>[];
+  for (final observerId in observers) {
+    entries.add(DossierEvidenceEntry(
+      observerId: observerId,
+      subjectId: victorOwnerId,
+      agendaType: 'warmonger',
+      turnNumber: turnNumber,
+      description: 'won naval battle',
+      scoreDelta: 1,
+    ));
+  }
+  if (entries.isNotEmpty) {
+    _log.d('data: evidence for naval battle victory victor=$victorOwnerId loser=$loserOwnerId entries=${entries.length}');
+  }
+  return entries;
+}

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -25,6 +25,7 @@ import '../economy/sea_transport.dart';
 import 'research_resolver.dart';
 import '../world/naval.dart';
 import '../combat/naval_combat_resolver.dart';
+import '../dossier/evidence_rules.dart';
 import '../world/player_view.dart';
 
 final Logger _log = Logger();
@@ -769,11 +770,28 @@ Game _runNavalInterceptionCombatPhase(
   battles = filterBattlesByInterception(game, battles, movedFleetIds, seed);
   seed = (seed * 1103515245 + 12345) & 0x7fffffff;
   var state = game;
+  final turn = game.worldState.turnState.turnNumber;
   for (final battle in battles) {
     final result = resolveSeaBattle(battle, seed);
     seed = (seed * 1103515245 + 12345) & 0x7fffffff;
     final regionId = regionIdForSeaZone(topology, battle.seaZoneId);
     state = applyNavalBattleResults(state, battle, result, regionId, topology: topology);
+    // Evidence: AI won naval battle (one side eliminated). SPEC/ai/hidden-agendas.md, ai-events-and-dossier.md.
+    String? victorId;
+    String? loserId;
+    if (result.survivingShipTypeIdsSide1.isEmpty && result.survivingShipTypeIdsSide2.isNotEmpty) {
+      victorId = battle.side2.ownerId;
+      loserId = battle.side1.ownerId;
+    } else if (result.survivingShipTypeIdsSide2.isEmpty && result.survivingShipTypeIdsSide1.isNotEmpty) {
+      victorId = battle.side1.ownerId;
+      loserId = battle.side2.ownerId;
+    }
+    if (victorId != null && loserId != null) {
+      final evidence = evidenceForNavalBattleVictory(state, victorId, loserId, turn);
+      if (evidence.isNotEmpty) {
+        state = state.copyWith(dossierEvidenceEntries: [...state.dossierEvidenceEntries, ...evidence]);
+      }
+    }
   }
   return state;
 }
@@ -789,6 +807,7 @@ Game _runCombatPhase(
   Game state = applyMinorMilitaryParity(game);
   final battles = detectConflicts(state, orders);
   final defaultMode = game.defaultCombatMode ?? CombatMode.autoResolve;
+  final turn = state.worldState.turnState.turnNumber;
   for (final ctx in battles) {
     final mode = resolveCombatModeForBattle(
       state,
@@ -802,12 +821,32 @@ Game _runCombatPhase(
       final input = buildQuickBattleInput(state, ctx, seed: state.worldState.turnState.turnNumber);
       final qbResult = resolveQuickBattle(input);
       state = applyQuickBattleResultToGame(state, ctx, qbResult);
+      // Evidence: AI won land battle as attacker. SPEC/ai/hidden-agendas.md, ai-events-and-dossier.md.
+      if (qbResult.winner == QuickBattleWinner.attacker &&
+          qbResult.provinceFlips &&
+          ctx.attackers.isNotEmpty) {
+        final victorId = ctx.attackers.first.factionId;
+        final evidence = evidenceForLandBattleVictory(state, victorId, ctx.defenderFactionId, turn);
+        if (evidence.isNotEmpty) {
+          state = state.copyWith(dossierEvidenceEntries: [...state.dossierEvidenceEntries, ...evidence]);
+        }
+      }
     } else {
       state = resolveBattleContext(
         state,
         ctx,
         feedingCoverageByPlayerId: feedingCoverageByPlayerId,
       );
+      // Evidence: AI won land battle (province flipped). Same spec refs.
+      final region = ctx.regionId == kRegionOldWorld ? state.worldState.oldWorld : state.worldState.newWorld;
+      final province = region.provinces.where((p) => p.id == ctx.provinceId).firstOrNull;
+      final victorId = province?.ownerId;
+      if (victorId != null && victorId != ctx.defenderFactionId) {
+        final evidence = evidenceForLandBattleVictory(state, victorId, ctx.defenderFactionId, turn);
+        if (evidence.isNotEmpty) {
+          state = state.copyWith(dossierEvidenceEntries: [...state.dossierEvidenceEntries, ...evidence]);
+        }
+      }
     }
   }
   // Capital reassignment: any GP that no longer owns their capital province. SPEC/game/capital-and-connectivity § Capital loss and reassignment.

--- a/packages/colonizethis_logic/test/evidence_rules_test.dart
+++ b/packages/colonizethis_logic/test/evidence_rules_test.dart
@@ -1,0 +1,129 @@
+// Tests for dossier evidence rules. SPEC/ai/hidden-agendas.md, SPEC/program/ai-events-and-dossier.md.
+
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('evidenceForLandBattleVictory', () {
+    test('AI victor vs defender appends warmonger evidence for human observer', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true),
+          Player(id: 'gp2', displayName: 'AI', isHuman: false, militaryLevel: 4),
+          Player(id: 'gp3', displayName: 'Other', isHuman: false, militaryLevel: 2),
+        ],
+      );
+      final entries = evidenceForLandBattleVictory(game, 'gp2', 'gp3', 2);
+      expect(entries.length, 1);
+      expect(entries.first.observerId, 'gp1');
+      expect(entries.first.subjectId, 'gp2');
+      expect(entries.first.agendaType, 'warmonger');
+      expect(entries.first.scoreDelta, 2);
+      expect(entries.first.description, contains('weaker'));
+    });
+
+    test('AI victor vs non-weaker defender gives scoreDelta 1', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true),
+          Player(id: 'gp2', displayName: 'AI', isHuman: false, militaryLevel: 2),
+          Player(id: 'gp3', displayName: 'Other', isHuman: false, militaryLevel: 4),
+        ],
+      );
+      final entries = evidenceForLandBattleVictory(game, 'gp2', 'gp3', 2);
+      expect(entries.length, 1);
+      expect(entries.first.agendaType, 'warmonger');
+      expect(entries.first.scoreDelta, 1);
+      expect(entries.first.description, contains('attacker'));
+    });
+
+    test('human victor returns no evidence', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true),
+          Player(id: 'gp2', displayName: 'AI', isHuman: false),
+        ],
+      );
+      final entries = evidenceForLandBattleVictory(game, 'gp1', 'gp2', 2);
+      expect(entries, isEmpty);
+    });
+
+    test('no human observer returns no evidence', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'AI1', isHuman: false),
+          Player(id: 'gp2', displayName: 'AI2', isHuman: false),
+        ],
+      );
+      final entries = evidenceForLandBattleVictory(game, 'gp1', 'gp2', 2);
+      expect(entries, isEmpty);
+    });
+  });
+
+  group('evidenceForNavalBattleVictory', () {
+    test('AI victor appends warmonger evidence for human observer', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true),
+          Player(id: 'gp2', displayName: 'AI', isHuman: false),
+          Player(id: 'gp3', displayName: 'Other', isHuman: false),
+        ],
+      );
+      final entries = evidenceForNavalBattleVictory(game, 'gp2', 'gp3', 2);
+      expect(entries.length, 1);
+      expect(entries.first.observerId, 'gp1');
+      expect(entries.first.subjectId, 'gp2');
+      expect(entries.first.agendaType, 'warmonger');
+      expect(entries.first.scoreDelta, 1);
+      expect(entries.first.description, contains('naval'));
+    });
+
+    test('human victor returns no evidence', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true),
+          Player(id: 'gp2', displayName: 'AI', isHuman: false),
+        ],
+      );
+      final entries = evidenceForNavalBattleVictory(game, 'gp1', 'gp2', 2);
+      expect(entries, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Implements evidence accumulation when combat is resolved (land and naval), completing the combat/other-actions part of gap #2. Part of **#18** (AI: Align implementation with SPEC Phase 6 gaps).

## Changes

- **Land battle:** When an AI wins as attacker (province flips), append warmonger evidence: +1 normally, +2 if defender was a weaker GP (by military level). Hooked in `_runCombatPhase` for both quick battle and auto-resolve.
- **Naval battle:** When one side is eliminated in naval combat, append warmonger +1 for the victor. Hooked in `_runNavalInterceptionCombatPhase`.
- **evidence_rules.dart:** `evidenceForLandBattleVictory`, `evidenceForNavalBattleVictory` (same pattern as diplomacy: only AI subjects, only human observers).
- **ISSUE_AI_SPEC_GAPS.md:** Mark evidence as "Implemented (diplomacy + combat)" and update summary table.
- **evidence_rules_test.dart:** Unit tests for the new evidence functions.

Spec: SPEC/ai/hidden-agendas.md, SPEC/program/ai-events-and-dossier.md.

Made with [Cursor](https://cursor.com)