### PR TITLE
fix(test): align test imports with SPEC/program/test-logging.md, add CI check

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install lcov
         run: sudo apt-get update && sudo apt-get install -y lcov
 
+      - name: Check test import convention (SPEC/program/test-logging.md)
+        run: tool/check_test_imports.sh
+
       - name: Run tests with coverage
         run: python3 tool/test_coverage.py
 

--- a/app/test/config_test.dart
+++ b/app/test/config_test.dart
@@ -1,7 +1,11 @@
+// Log suppression first (SPEC/program/test-logging.md); then Flutter test API.
+import 'package:colonizethis_test/test.dart' as _;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter/material.dart';
+
 import 'package:colonizethis_app/config/constants.dart';
 import 'package:colonizethis_app/config/routes.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('HiveBoxNames', () {

--- a/app/test/game_service_integration_test.dart
+++ b/app/test/game_service_integration_test.dart
@@ -1,4 +1,7 @@
+// Log suppression first (SPEC/program/test-logging.md); then Flutter test API.
+import 'package:colonizethis_test/test.dart' as _;
 import 'package:flutter_test/flutter_test.dart';
+
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -1,6 +1,9 @@
+// Log suppression first (SPEC/program/test-logging.md); then Flutter test API.
+import 'package:colonizethis_test/test.dart' as _;
+import 'package:flutter_test/flutter_test.dart';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/app.dart';
 

--- a/packages/colonizethis_ai/test/mood_state_machine_test.dart
+++ b/packages/colonizethis_ai/test/mood_state_machine_test.dart
@@ -1,5 +1,6 @@
+import 'package:colonizethis_test/test.dart';
+
 import 'package:colonizethis_ai/colonizethis_ai.dart';
-import 'package:test/test.dart';
 
 void main() {
   group('computeNextNegotiationMood', () {

--- a/packages/colonizethis_data/test/dialogue_catalog_test.dart
+++ b/packages/colonizethis_data/test/dialogue_catalog_test.dart
@@ -1,7 +1,8 @@
 // Tests for dialogue key catalog. SPEC/ai/dialogue-and-mood.md.
 
+import 'package:colonizethis_test/test.dart';
+
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:test/test.dart';
 
 void main() {
   group('dialogueKeyForEvent', () {

--- a/tool/check_test_imports.sh
+++ b/tool/check_test_imports.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPEC/program/test-logging.md — enforce test import convention:
+# - No direct "package:test/test.dart"; use "package:colonizethis_test/test.dart".
+# - Flutter test files must import colonizethis_test first, then flutter_test.
+# Exit 0 if all checks pass, 1 otherwise.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+FAIL=0
+
+for f in $(find app packages ctdev tool -name '*_test.dart' -type f 2>/dev/null | sort); do
+  # Forbid direct package:test/test.dart
+  if grep -q "package:test/test\.dart" "$f"; then
+    echo "ERROR: $f must not import package:test/test.dart; use package:colonizethis_test/test.dart first (see SPEC/program/test-logging.md)"
+    FAIL=1
+  fi
+  # If uses flutter_test, must have colonizethis_test first (lower line number)
+  if grep -q "package:flutter_test/flutter_test\.dart" "$f"; then
+    if ! grep -q "package:colonizethis_test/test\.dart" "$f"; then
+      echo "ERROR: $f uses flutter_test but does not import package:colonizethis_test/test.dart first (see SPEC/program/test-logging.md)"
+      FAIL=1
+    else
+      LN_CT=$(grep -n "package:colonizethis_test/test\.dart" "$f" | head -1 | cut -d: -f1)
+      LN_FLUTTER=$(grep -n "package:flutter_test/flutter_test\.dart" "$f" | head -1 | cut -d: -f1)
+      if [[ -n "${LN_CT:-}" && -n "${LN_FLUTTER:-}" && "$LN_CT" -gt "$LN_FLUTTER" ]]; then
+        echo "ERROR: $f must import package:colonizethis_test/test.dart before package:flutter_test/flutter_test.dart (see SPEC/program/test-logging.md)"
+        FAIL=1
+      fi
+    fi
+  fi
+done
+
+if [[ $FAIL -eq 1 ]]; then
+  exit 1
+fi
+echo "Test import convention check passed."
+exit 0


### PR DESCRIPTION
Aligns all test files with SPEC/program/test-logging.md and adds CI enforcement.

**Changes:**
- **Dart tests:** `mood_state_machine_test.dart` and `dialogue_catalog_test.dart` now import `package:colonizethis_test/test.dart` instead of `package:test/test.dart`.
- **Flutter tests:** `widget_test.dart`, `config_test.dart`, `game_service_integration_test.dart` import `package:colonizethis_test/test.dart` first (as `_` for log suppression only), then `package:flutter_test/flutter_test.dart` to avoid symbol clash.
- **Enforcement:** `tool/check_test_imports.sh` fails if any test file uses `package:test/test.dart` or uses `flutter_test` without `colonizethis_test` first; added to `.github/workflows/quality.yml`.

Fixes #130

Made with [Cursor](https://cursor.com)