### PR TITLE
chore(tool): align test_coverage.py LOG_FILTER with ctdev-logging prefixes

### DIFF
--- a/tool/test_coverage.py
+++ b/tool/test_coverage.py
@@ -16,8 +16,10 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parent.parent
+# Filter test output: box-drawing, common emoji, and ctdev-logging prefixes (SPEC/program/ctdev-logging.md).
 LOG_FILTER = re.compile(
-    r"[\u250c\u251c\u2500\u2514\u2502]|\u2139|\u1f41b|\u26a0\ufe0f|save: |logic: |map: "
+    r"[\u250c\u251c\u2500\u2514\u2502]|\u2139|\u1f41b|\u26a0\ufe0f"
+    r"|ctdev: |logic: |ai: |data: |map: |save: "
 )
 
 PACKAGES = [


### PR DESCRIPTION
Aligns `tool/test_coverage.py` LOG_FILTER with all prefixes from SPEC/program/ctdev-logging.md (ctdev, logic, ai, data, map, save). Adds a short comment documenting the spec ref.

Optional follow-up from #130 (not done in PR #146).

Made with [Cursor](https://cursor.com)