### PR TITLE
docs(spec)+logic: economy-models riches source, cross-refs, acceptance criteria, logging

### DIFF
--- a/SPEC/program/economy-models.md
+++ b/SPEC/program/economy-models.md
@@ -23,9 +23,9 @@ Per-player population for production, distinct from military/civilian units. Tie
 Turn economic phases (in order):
 
 1. **Extraction:** Province tiles produce; resources flow to player stockpile via auto-transport. Per game/extraction-and-improvements.md.
-2. **Riches-to-treasury:** Riches in stockpile convert to treasury at base price; removed from stockpile.
+2. **Riches-to-treasury:** Riches in stockpile convert to treasury at base price; removed from stockpile. The list of riches commodity ids and base prices is defined in package **colonizethis_data** ([riches_prices.dart](../../packages/colonizethis_data/lib/src/riches_prices.dart): `richesCommodityIds`, `richesBasePrice`). Scenario overrides may apply a **richesCashMultiplier** (e.g. 1.5) to the treasury conversion; see [turn-resolution-phase-details.md](turn-resolution-phase-details.md) (Riches to treasury) and resolution API.
 3. **Production:** Consume commodities and labour; produce outputs to stockpile. Per game/stockpiles-and-production.md.
-4. **Consumption:** Military regiments consume food upkeep first, then workers and navy consume food and materials from remainder. Military food shortfalls reduce morale/strength rather than removing regiments.
+4. **Consumption:** Military regiments consume food upkeep first, then workers and navy consume food and materials from remainder. Military food shortfalls reduce morale/strength rather than removing regiments. Feeding coverage (military-first) is converted to a morale/strength modifier used in combat; see [turn-resolution-phase-details.md](turn-resolution-phase-details.md) (Consumption) and [combat-resolution.md](combat-resolution.md), [military-strength.md](military-strength.md).
 
 ---
 
@@ -44,8 +44,20 @@ Turn economic phases (in order):
 
 ---
 
+## Acceptance criteria and testing
+
+- **Phase order:** Extraction → Riches → Production → Consumption is fixed and tested (e.g. turn resolver and integration tests).
+- **Serialization:** Stockpile and WorkerPool are serializable for save/load; tests cover round-trip or snapshot behaviour.
+- **Riches:** Conversion uses base price from colonizethis_data; riches are removed from stockpile; optional richesCashMultiplier scales treasury delta when provided.
+- **Consumption:** Military fed first, then workers/navy; military shortfalls yield feeding coverage used in combat (e.g. ConsumptionResult.fullyFedRegiments / coverage ratio → morale multiplier per turn-resolution-phase-details).
+- **Production:** Inputs and labour consumed; outputs added to stockpile; insufficient input skips or partial per recipe spec.
+
+Unit tests: Stockpile/WorkerPool serialization; resolveRichesToTreasury; resolveConsumption (military-first, worker feeding, starve order); resolveProduction. Integration: turn resolver runs phases in order; consumption result flows to combat morale where applicable.
+
+---
+
 ## Constraints
 
 - Stockpile and WorkerPool types must be serializable for save/load.
 - Worker tier definitions, labour values, recruiting/training rules are defined in game/workers-and-population.md; this module references them.
-- Config is program-level (no JSON rulesets in MVP).
+- **Config:** Program-level in MVP (no JSON rulesets for economy in MVP). Economy-related config (worker tiers, riches list/prices) may move to ruleset per [ruleset-config.md](ruleset-config.md) in a later phase.

--- a/packages/colonizethis_logic/lib/src/economy/economy_consumption.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_consumption.dart
@@ -1,5 +1,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
+
+final Logger _log = Logger();
 
 /// Consumption resolution helpers.
 /// SPEC/game/workers-and-population.md
@@ -137,6 +140,9 @@ ConsumptionResult resolveConsumption({
     masters: fedMasters,
   );
 
+  _log.d(
+    'logic: consumption totalRegiments=$totalRegiments fullyFedRegiments=$fullyFedRegiments',
+  );
   return ConsumptionResult(
     stockpile: current,
     workerPool: updatedWorkers,

--- a/packages/colonizethis_logic/lib/src/economy/economy_production.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_production.dart
@@ -1,5 +1,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
+
+final Logger _log = Logger();
 
 /// Production resolution helpers.
 /// SPEC/game/production-recipes.md
@@ -78,6 +81,7 @@ ProductionResult resolveProduction({
     current = current.applyDelta(recipe.outputCommodityId, totalOutput);
   }
 
+  _log.d('logic: production assignments=${assignments.length}');
   return ProductionResult(
     stockpile: current,
     workerPool: workers,

--- a/packages/colonizethis_logic/lib/src/economy/economy_riches_to_treasury.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_riches_to_treasury.dart
@@ -1,5 +1,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
+
+final Logger _log = Logger();
 
 /// Riches-to-treasury phase: convert riches in stockpile to treasury at base price.
 /// SPEC/program/turn-resolution-phases.md (Riches to treasury).
@@ -40,6 +43,7 @@ RichesToTreasuryResult resolveRichesToTreasury({
     updatedStockpile = updatedStockpile.applyDelta(id, -qty);
   }
 
+  _log.d('logic: riches-to-treasury treasuryDelta=$totalCash multiplier=$richesCashMultiplier');
   return RichesToTreasuryResult(
     stockpile: updatedStockpile,
     treasuryDelta: totalCash,


### PR DESCRIPTION
Fixes #159

## Summary
- **SPEC/program/economy-models.md:** Document where riches commodity ids and base prices are defined (colonizethis_data/riches_prices.dart); document optional richesCashMultiplier (scenario override); add cross-refs from consumption to turn-resolution-phase-details and combat/military-strength for morale application; add Acceptance criteria and testing subsection; align config sentence with ruleset-config.md (MVP vs future).
- **Economy resolution modules:** Add debug-level logging per SPEC/program/ctdev-logging.md in economy_riches_to_treasury.dart (treasury delta, multiplier), economy_consumption.dart (totalRegiments, fullyFedRegiments), economy_production.dart (assignments count).

Made with [Cursor](https://cursor.com)