### PR TITLE
Implement Load Savegame flow and GP colour override (Fixes #164)

### DIFF
--- a/SPEC/game/world-model.md
+++ b/SPEC/game/world-model.md
@@ -26,7 +26,7 @@ Each province **contains** terrain tiles (terrain type, optional resource, impro
 
 | Entity | Responsibility |
 |--------|----------------|
-| **Game** | Top-level. Game id, metadata, current **WorldState**, **Player**s (Great Powers), **Minor Nation**s, **Tribe**s, optional resolved config. |
+| **Game** | Top-level. Game id, metadata, current **WorldState**, **Player**s (Great Powers), **Minor Nation**s, **Tribe**s, optional resolved config. May carry optional **greatPowerColorOverride** (setup-time GP map colours) for display; when present, map visualizers and ctdev use it; when absent, GDD default colours apply. |
 | **WorldState** | Snapshot. Turn state (phase, turn), region data (provinces, units), player visibility, prospected tiles, **spy reveal timers** (playerId → provinceKey → turns until fog returns), optional **purchased tiles** (tileKey → buyer playerId for Minor/Tribe tiles purchased by GP). See [fog-and-exploration.md](fog-and-exploration.md). |
 | **Province** | Land region. Id, region id, **owner** (faction id). Optional **townTileKey** (tile key of province's town for extraction). Tiles; neighbours from topology. |
 | **SeaZone** | Water region. Id, region id. Adjacency from topology. |

--- a/SPEC/program/ctdev-app.md
+++ b/SPEC/program/ctdev-app.md
@@ -14,7 +14,7 @@
 ## Main Flows
 
 - **Init Game:** Home → Init Game Config Screen (form mirrors `GameSetupConfig`). On submit: validate, call `runInitGame`, save game, navigate to Init Game Map Debug. See [ctdev-app-init-map.md](ctdev-app-init-map.md).
-- **Load Savegame:** Select saved game, load via colonizethis_save, build `InitGameMapViewData`, navigate to Init Game Map Debug.
+- **Load Savegame:** Select saved game, load via colonizethis_save, build `InitGameMapViewData` with the game's `greatPowerColorOverride` (if any) so ownership colours match the setup that was used when the game was created; when the save has no override (legacy), GDD default colours are used. Navigate to Init Game Map Debug. Saves created by ctdev Init Game include map data (tile maps, topology); legacy saves without map data show a message and cannot open the map view.
 - **Start Game (Sim):** From Init Game Map Debug, press Start Game → creates Sim Game controller, navigates to Running Game Screen. See [ctdev-app-running-game.md](ctdev-app-running-game.md).
 
 ---

--- a/ctdev/lib/main.dart
+++ b/ctdev/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:logger/logger.dart';
 
 import 'ctdev_log.dart';
 import 'screens/init_game_screen.dart';
+import 'screens/load_savegame_screen.dart';
 
 void main() {
   initCtdevLogging();
@@ -55,7 +56,11 @@ class CtDevHomeScreen extends StatelessWidget {
             const SizedBox(height: 16),
             ElevatedButton(
               onPressed: () {
-                // Placeholder for Load Savegame flow.
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const LoadSavegameScreen(),
+                  ),
+                );
               },
               child: const Text('Load Savegame'),
             ),

--- a/ctdev/lib/save_service.dart
+++ b/ctdev/lib/save_service.dart
@@ -1,0 +1,63 @@
+// Ctdev save/load: Hive box and GameSaveAdapter. SPEC/program/ctdev-app.md, plan-update-gp-colours-save-load.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_save/colonizethis_save.dart';
+import 'package:hive/hive.dart';
+import 'package:logger/logger.dart';
+import 'package:path_provider/path_provider.dart';
+
+final Logger _log = Logger();
+
+Box<dynamic>? _box;
+
+/// Ensures Hive is initialized and the games box is open. Call before list/load/save.
+Future<Box<dynamic>> _ensureBox() async {
+  if (_box != null && _box!.isOpen) return _box!;
+  final dir = await getApplicationDocumentsDirectory();
+  Hive.init(dir.path);
+  _box = await Hive.openBox<dynamic>('games');
+  _log.d('map: Hive box opened at ${dir.path}');
+  return _box!;
+}
+
+final _adapter = GameSaveAdapter();
+
+/// Lists stored game ids. Returns [] if box not yet opened or empty.
+Future<List<String>> listGameIds() async {
+  final box = await _ensureBox();
+  final ids = _adapter.listGameIds(box);
+  _log.d('map: listGameIds count=${ids.length}');
+  return ids;
+}
+
+/// Loads game by id. Returns null if not found or invalid.
+Future<Game?> loadGame(String gameId) async {
+  final box = await _ensureBox();
+  return _adapter.load(box, gameId);
+}
+
+/// Loads map data for [gameId]. Returns null for legacy saves (no map data stored).
+Future<({
+  Map<String, TileMapResult> tileMapByRegion,
+  Map<String, MapTopology> topologyByRegion,
+  MapTopology combinedTopology,
+})?> loadMapData(String gameId) async {
+  final box = await _ensureBox();
+  return _adapter.loadMapData(box, gameId);
+}
+
+/// Saves [game] and optional [result] map data so Load Savegame can show the map.
+Future<void> saveGameAndMapData(Game game, InitGameResult result) async {
+  final box = await _ensureBox();
+  _adapter.save(box, game);
+  _adapter.saveMapData(
+    box,
+    game.id,
+    tileMapByRegion: result.tileMapByRegion,
+    topologyByRegion: result.topologyByRegion,
+    combinedTopology: result.combinedTopology,
+  );
+  _log.i('map: saved gameId=${game.id} with map data');
+}

--- a/ctdev/lib/screens/init_game_screen.dart
+++ b/ctdev/lib/screens/init_game_screen.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:flutter/material.dart';
 
+import '../save_service.dart';
 import 'init_game_debug_map_screen.dart';
 
 class InitGameScreen extends StatefulWidget {
@@ -128,11 +129,14 @@ class _InitGameScreenState extends State<InitGameScreen> {
         options: options,
       );
       if (!mounted) return;
+      await saveGameAndMapData(result.game, result);
+      if (!mounted) return;
+      final baseSeed = result.game.globalGameSeed ?? _seed;
       await Navigator.of(context).push(
         MaterialPageRoute(
           builder: (_) => InitGameDebugMapScreen(
             initResult: result,
-            baseSeed: _seed,
+            baseSeed: baseSeed,
           ),
         ),
       );

--- a/ctdev/lib/screens/load_savegame_screen.dart
+++ b/ctdev/lib/screens/load_savegame_screen.dart
@@ -1,0 +1,149 @@
+// Load Savegame: list saved games, load and navigate to Init Game Map Debug with GP colours from save.
+// SPEC/program/ctdev-app.md, SPEC/project/plan-update-gp-colours-save-load.
+
+import 'dart:typed_data';
+
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:flutter/material.dart';
+
+import '../save_service.dart';
+import 'init_game_debug_map_screen.dart';
+
+class LoadSavegameScreen extends StatefulWidget {
+  const LoadSavegameScreen({super.key});
+
+  @override
+  State<LoadSavegameScreen> createState() => _LoadSavegameScreenState();
+}
+
+class _LoadSavegameScreenState extends State<LoadSavegameScreen> {
+  List<String> _gameIds = [];
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadList();
+  }
+
+  Future<void> _loadList() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final ids = await listGameIds();
+      if (!mounted) return;
+      setState(() {
+        _gameIds = ids;
+        _loading = false;
+      });
+    } catch (e, _) {
+      if (!mounted) return;
+      setState(() {
+        _error = e.toString();
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _onSelectGameId(String gameId) async {
+    final game = await loadGame(gameId);
+    if (!mounted || game == null) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to load game')),
+        );
+      }
+      return;
+    }
+    final mapData = await loadMapData(gameId);
+    if (!mounted) return;
+    if (mapData == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Map view not available for this save (tile map data not stored).',
+          ),
+        ),
+      );
+      return;
+    }
+    final viewData = buildInitGameMapViewData(
+      game: game,
+      tileMapByRegion: mapData.tileMapByRegion,
+      topologyByRegion: mapData.topologyByRegion,
+      cellSize: 24,
+      greatPowerColorOverride: greatPowerColorOverrideFromGame(game),
+    );
+    final initResult = InitGameResult(
+      game: game,
+      mapPngBytes: Uint8List(0),
+      markdown: '',
+      mapViewData: viewData,
+      tileMapByRegion: mapData.tileMapByRegion,
+      topologyByRegion: mapData.topologyByRegion,
+      combinedTopology: mapData.combinedTopology,
+    );
+    final baseSeed = game.globalGameSeed ?? 0;
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => InitGameDebugMapScreen(
+          initResult: initResult,
+          baseSeed: baseSeed,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Load Savegame'),
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _error != null
+              ? Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          _error!,
+                          style: TextStyle(
+                            color: Theme.of(context).colorScheme.error,
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        FilledButton(
+                          onPressed: _loadList,
+                          child: const Text('Retry'),
+                        ),
+                      ],
+                    ),
+                  ),
+                )
+              : _gameIds.isEmpty
+                  ? const Center(
+                      child: Text(
+                        'No saved games. Run Init Game to create one (saved with map data for this app).',
+                      ),
+                    )
+                  : ListView.builder(
+                      itemCount: _gameIds.length,
+                      itemBuilder: (context, index) {
+                        final id = _gameIds[index];
+                        return ListTile(
+                          title: Text(id),
+                          onTap: () => _onSelectGameId(id),
+                        );
+                      },
+                    ),
+    );
+  }
+}

--- a/ctdev/pubspec.yaml
+++ b/ctdev/pubspec.yaml
@@ -13,6 +13,8 @@ dependencies:
   basic_logger_file: ^0.1.3
   logger: ^2.0.2
   path: ^1.9.0
+  path_provider: ^2.1.0
+  hive: ^2.2.3
   colonizethis_ai: any
   colonizethis_logic: any
   colonizethis_models: any

--- a/packages/colonizethis_data/lib/src/tile_map_result.dart
+++ b/packages/colonizethis_data/lib/src/tile_map_result.dart
@@ -57,4 +57,55 @@ class TileMapResult {
 
   static String _pairKey(String a, String b) =>
       a.compareTo(b) < 0 ? '$a|$b' : '$b|$a';
+
+  /// Serializes for save/load (e.g. ctdev Load Savegame). SPEC/project/plan-update-gp-colours-save-load.
+  Map<String, dynamic> toJson() {
+    return {
+      'width': width,
+      'height': height,
+      'grid': grid,
+      if (terrainGrid != null)
+        'terrainGrid': terrainGrid!
+            .map((row) => row.map((t) => t?.name).toList())
+            .toList(),
+      if (resourceGrid != null)
+        'resourceGrid': resourceGrid!
+            .map((row) => row.map((r) => r?.name).toList())
+            .toList(),
+    };
+  }
+
+  /// Deserializes from JSON. Returns a valid [TileMapResult] or throws.
+  static TileMapResult fromJson(Map<String, dynamic> json) {
+    final width = json['width'] as int;
+    final height = json['height'] as int;
+    final grid = (json['grid'] as List<dynamic>)
+        .map((row) => (row as List<dynamic>).map((e) => e as String).toList())
+        .toList();
+    List<List<TerrainType?>>? terrainGrid;
+    final tg = json['terrainGrid'] as List<dynamic>?;
+    if (tg != null) {
+      terrainGrid = tg
+          .map((row) => (row as List<dynamic>)
+              .map((e) => e == null ? null : TerrainType.values.byName(e as String))
+              .toList())
+          .toList();
+    }
+    List<List<Resource?>>? resourceGrid;
+    final rg = json['resourceGrid'] as List<dynamic>?;
+    if (rg != null) {
+      resourceGrid = rg
+          .map((row) => (row as List<dynamic>)
+              .map((e) => e == null ? null : Resource.values.byName(e as String))
+              .toList())
+          .toList();
+    }
+    return TileMapResult(
+      width: width,
+      height: height,
+      grid: grid,
+      terrainGrid: terrainGrid,
+      resourceGrid: resourceGrid,
+    );
+  }
 }

--- a/packages/colonizethis_save/lib/src/game_save_adapter.dart
+++ b/packages/colonizethis_save/lib/src/game_save_adapter.dart
@@ -1,11 +1,16 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:hive/hive.dart';
 import 'package:logger/logger.dart';
 
 final Logger _log = Logger();
 
+const String _suffixTileMapByRegion = '_tileMapByRegion';
+const String _suffixTopologyByRegion = '_topologyByRegion';
+const String _suffixCombinedTopology = '_combinedTopology';
+
 /// Saves and loads [Game] state to/from a Hive box. One entry per game, keyed by [Game.id].
-/// SPEC/project/phase-1: save format and adapter.
+/// Optional map data (tile maps, topology) can be stored per game for Load Savegame view. SPEC/project/phase-1, plan-update-gp-colours-save-load.
 class GameSaveAdapter {
   /// Saves [game] to [box]. Key = game.id, value = game.toJson().
   void save(Box<dynamic> box, Game game) {
@@ -33,13 +38,81 @@ class GameSaveAdapter {
     }
   }
 
-  /// Lists all game ids stored in [box].
+  /// Lists all game ids stored in [box]. Excludes internal map-data keys.
   List<String> listGameIds(Box<dynamic> box) {
-    return box.keys.whereType<String>().toList();
+    return box.keys
+        .whereType<String>()
+        .where((k) =>
+            !k.endsWith(_suffixTileMapByRegion) &&
+            !k.endsWith(_suffixTopologyByRegion) &&
+            !k.endsWith(_suffixCombinedTopology))
+        .toList();
   }
 
-  /// Deletes game [gameId] from [box]. No-op if not present.
+  /// Saves map data for [gameId] so Load Savegame can build InitGameMapViewData. Optional; legacy saves have none.
+  void saveMapData(
+    Box<dynamic> box,
+    String gameId, {
+    required Map<String, TileMapResult> tileMapByRegion,
+    required Map<String, MapTopology> topologyByRegion,
+    required MapTopology combinedTopology,
+  }) {
+    _log.d('save: saving map data gameId=$gameId');
+    box.put(
+      gameId + _suffixTileMapByRegion,
+      tileMapByRegion.map((k, v) => MapEntry(k, v.toJson())),
+    );
+    box.put(
+      gameId + _suffixTopologyByRegion,
+      topologyByRegion.map((k, v) => MapEntry(k, v.toJson())),
+    );
+    box.put(gameId + _suffixCombinedTopology, combinedTopology.toJson());
+    _log.d('save: saved map data gameId=$gameId');
+  }
+
+  /// Loads map data for [gameId]. Returns null if any key is missing (legacy save).
+  ({Map<String, TileMapResult> tileMapByRegion,
+    Map<String, MapTopology> topologyByRegion,
+    MapTopology combinedTopology})? loadMapData(Box<dynamic> box, String gameId) {
+    final tileRaw = box.get(gameId + _suffixTileMapByRegion);
+    final topoRaw = box.get(gameId + _suffixTopologyByRegion);
+    final combinedRaw = box.get(gameId + _suffixCombinedTopology);
+    if (tileRaw == null || topoRaw == null || combinedRaw == null) {
+      return null;
+    }
+    try {
+      final tileMapByRegion = (tileRaw as Map).map<String, TileMapResult>(
+        (k, v) => MapEntry(
+          k as String,
+          TileMapResult.fromJson(Map<String, dynamic>.from(v as Map)),
+        ),
+      );
+      final topologyByRegion = (topoRaw as Map).map<String, MapTopology>(
+        (k, v) => MapEntry(
+          k as String,
+          MapTopology.fromJson(Map<String, dynamic>.from(v as Map)),
+        ),
+      );
+      final combinedTopology =
+          MapTopology.fromJson(Map<String, dynamic>.from(combinedRaw as Map));
+      _log.d('save: loaded map data gameId=$gameId');
+      return (
+        tileMapByRegion: tileMapByRegion,
+        topologyByRegion: topologyByRegion,
+        combinedTopology: combinedTopology,
+      );
+    } catch (e, st) {
+      _log.e('save: load map data failed gameId=$gameId',
+          error: e, stackTrace: st);
+      return null;
+    }
+  }
+
+  /// Deletes game [gameId] from [box]. No-op if not present. Also removes map data keys.
   void delete(Box<dynamic> box, String gameId) {
     box.delete(gameId);
+    box.delete(gameId + _suffixTileMapByRegion);
+    box.delete(gameId + _suffixTopologyByRegion);
+    box.delete(gameId + _suffixCombinedTopology);
   }
 }

--- a/packages/colonizethis_save/pubspec.yaml
+++ b/packages/colonizethis_save/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   logger: ^2.0.2
+  colonizethis_data:
   colonizethis_models:
   hive: ^2.2.3
 

--- a/packages/colonizethis_save/test/game_save_adapter_test.dart
+++ b/packages/colonizethis_save/test/game_save_adapter_test.dart
@@ -1,3 +1,4 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
@@ -51,7 +52,7 @@ void main() {
       expect(adapter.load(box, 'missing'), isNull);
     });
 
-    test('listGameIds returns saved ids', () {
+    test('listGameIds returns saved ids and excludes map-data keys', () {
       final game = Game(
         id: 'g1',
         worldState: WorldState(
@@ -63,7 +64,74 @@ void main() {
       );
       adapter.save(box, game);
       adapter.save(box, game.copyWith(id: 'g2'));
+      final tileMap = TileMapResult(width: 2, height: 2, grid: [
+        ['p1', 'p1'],
+        ['p2', 's1'],
+      ]);
+      final topo = MapTopology(
+        nodes: [
+          TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 'p2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 's1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+        ],
+        edges: [],
+      );
+      adapter.saveMapData(
+        box,
+        'g1',
+        tileMapByRegion: {'oldWorld': tileMap, 'newWorld': tileMap},
+        topologyByRegion: {'oldWorld': topo, 'newWorld': topo},
+        combinedTopology: topo,
+      );
       expect(adapter.listGameIds(box), containsAll(['g1', 'g2']));
+      expect(adapter.listGameIds(box).length, 2);
+    });
+
+    test('saveMapData then loadMapData returns same data', () {
+      final tileMap = TileMapResult(
+        width: 2,
+        height: 2,
+        grid: [
+          ['p1', 'p2'],
+          ['s1', 's1'],
+        ],
+        terrainGrid: [
+          [TerrainType.plains, TerrainType.forest],
+          [null, null],
+        ],
+        resourceGrid: [
+          [Resource.grain, null],
+          [null, null],
+        ],
+      );
+      final topo = MapTopology(
+        nodes: [
+          TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 'p2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 's1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+        ],
+        edges: [TopologyEdge(id1: 'p1', id2: 'p2')],
+      );
+      adapter.saveMapData(
+        box,
+        'mapGame',
+        tileMapByRegion: {'oldWorld': tileMap, 'newWorld': tileMap},
+        topologyByRegion: {'oldWorld': topo, 'newWorld': topo},
+        combinedTopology: topo,
+      );
+      final loaded = adapter.loadMapData(box, 'mapGame');
+      expect(loaded, isNotNull);
+      expect(loaded!.tileMapByRegion['oldWorld']!.width, 2);
+      expect(loaded.tileMapByRegion['oldWorld']!.height, 2);
+      expect(loaded.tileMapByRegion['oldWorld']!.cell(0, 0), 'p1');
+      expect(loaded.tileMapByRegion['oldWorld']!.terrainAt(0, 0), TerrainType.plains);
+      expect(loaded.tileMapByRegion['oldWorld']!.resourceAt(0, 0), Resource.grain);
+      expect(loaded.combinedTopology.nodes.length, 3);
+      expect(loaded.combinedTopology.edges.length, 1);
+    });
+
+    test('loadMapData returns null for legacy save without map data', () {
+      expect(adapter.loadMapData(box, 'noMapData'), isNull);
     });
 
     test('delete removes game', () {


### PR DESCRIPTION
Fixes #164

## Summary
- **Load Savegame flow:** ctdev lists saved games, loads via colonizethis_save, builds `InitGameMapViewData` with `greatPowerColorOverrideFromGame(loadedGame)`, navigates to Init Game Map Debug. Legacy saves without map data show a message.
- **Save after init:** ctdev saves game + map data (tile maps, topology) after runInitGame so Load Savegame can open the map view for ctdev-created games.
- **Save adapter:** `saveMapData` / `loadMapData` for tile maps and topology; `listGameIds` excludes map-data keys.
- **colonizethis_data:** `TileMapResult` `toJson`/`fromJson` for persistence.
- **Specs:** ctdev-app.md Load Savegame bullet updated; world-model.md notes optional `greatPowerColorOverride` on Game.

## Acceptance criteria (from issue)
- [x] Load Savegame flow in ctdev: load game → build InitGameMapViewData with greatPowerColorOverride → navigate to Init Game Map Debug.
- [x] Legacy saves (no greatPowerColorOverride) use GDD defaults via null override.
- [x] SPEC/program/ctdev-app.md: Load Savegame bullet updated.
- [x] Optional: SPEC/game/world-model.md notes Game may carry greatPowerColorOverride.

Made with [Cursor](https://cursor.com)