### PR TITLE
Order engine spec: gaps, ProjectedEffects, merge refactor, tests (Fixes #161)

### DIFF
--- a/SPEC/program/order-engine.md
+++ b/SPEC/program/order-engine.md
@@ -14,6 +14,8 @@ The order engine (colonizethis_logic) maintains the **current-turn order list pe
 
 **Trigger:** On every add/remove, re-validates the entire list for that player against world state (costs, caps, adjacency, tech per [orders.md](orders.md)).
 
+**Scope:** The engine validates **move**, **build**, **work**, **naval move**, and **naval mission** orders. **Research** orders are validated in the research phase (TurnResolver), not in the engine. **Diplomatic** orders are not validated or added by the engine; they are merge-only (see Turn Resolution Integration).
+
 **Rule:** Validate in **submission order**. First failure rejects that order and all after it. Orders 1..N-1 remain.
 
 **With context:** Uses a PlayerView for visibility rules (move/work orders). Source province = unit's location; need not be owned by player. See [fog-and-exploration-resolution.md](fog-and-exploration-resolution.md).
@@ -30,19 +32,28 @@ Validation is per-player only. No cross-player conflict resolution at this stage
 
 ## Projected Effects
 
-Supports a **dry-run**: apply orders to a copy of world state, return projected effects for UI (worker count, unit locations, stockpile deltas). No mutation of real state.
+Supports a **dry-run**: apply orders via the resolver (which returns **new** state); return projected effects for UI (worker count, treasury delta, unit locations, stockpile deltas). The engine does **not** mutate the passed-in game; the caller may pass the live game. No mutation of real state.
 
 ---
 
 ## Turn Resolution Integration
 
-Before applying orders, TurnResolver runs a **merge** step: combine per-player lists (human + AI) with **human over AI** precedence for conflicts. Then resolve cross-player effects (conflict detection, diplomacy). Then apply in phase order per [turn-resolution-phases.md](turn-resolution-phases.md). The order engine does not perform merge or application.
+Before applying orders, TurnResolver runs a **merge** step: combine per-player lists (human + AI) with **human over AI** precedence for conflicts. Merge includes **diplomatic** orders (human over AI per type+target); the order engine does not add or validate diplomatic orders. Then resolve cross-player effects (conflict detection, diplomacy). Then apply in phase order per [turn-resolution-phases.md](turn-resolution-phases.md). The order engine does not perform merge or application.
 
 ---
 
 ## Determinism
 
 Submission order is stable. Merge uses stable ordering (player id, order type, order id) for deterministic replay.
+
+---
+
+## Acceptance criteria
+
+- **Validation:** On add/remove with context, the full list for that player is validated in submission order; first rejection rejects that order and all subsequent; validation results (accepted/rejected + reason) are returned for UI.
+- **Merge:** Human + AI orders merged with human over AI for conflicts; ordering is stable for deterministic replay (player id, then conflict key / order type as specified).
+- **Projected effects:** Dry-run returns worker count, treasury delta, and when implemented unit locations and stockpile deltas for UI; no mutation of the passed-in game from the caller's perspective.
+- **No application:** Order engine does not apply orders to world state; TurnResolver applies after merge.
 
 ---
 

--- a/packages/colonizethis_logic/lib/colonizethis_logic.dart
+++ b/packages/colonizethis_logic/lib/colonizethis_logic.dart
@@ -36,6 +36,7 @@ export 'src/economy/sea_transport.dart';
 // Orders
 export 'src/orders/order_engine.dart';
 export 'src/orders/order_merge.dart';
+export 'src/orders/projected_effects.dart';
 export 'src/orders/order_projections.dart';
 export 'src/orders/order_suggestion.dart';
 export 'src/orders/order_suggestion_api_impl.dart';

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -6,10 +6,11 @@ import '../economy/economy_production.dart';
 import '../world/movement.dart';
 import '../world/naval.dart';
 import 'order_visibility.dart';
+import 'order_projections.dart';
 import '../world/player_view.dart';
 import '../constants.dart';
 import '../world/province_lookup.dart';
-import '../turn/turn_resolver.dart';
+import 'projected_effects.dart';
 
 final Logger _log = Logger();
 
@@ -29,21 +30,6 @@ class OrderValidationResult {
   final String? reason;
 
   bool get isAccepted => status == OrderValidationStatus.accepted;
-}
-
-/// Projected effects after dry-run of orders. For UI feedback.
-class ProjectedEffects {
-  const ProjectedEffects({
-    this.workerCount,
-    this.unitLocations,
-    this.stockpileDeltas,
-    this.treasuryDelta,
-  });
-
-  final int? workerCount;
-  final Map<String, String>? unitLocations;
-  final Map<String, int>? stockpileDeltas;
-  final int? treasuryDelta;
 }
 
 /// Order engine: holds per-player orders, validates in submission order,
@@ -117,6 +103,7 @@ class OrderEngine {
     String orderLabel,
   ) {
     _appendOrder(playerId, order, getter, updater);
+    _log.d('logic: validating orders with context player=$playerId');
     final results = validatePlayerOrdersWithContext(game, topology, playerId);
     if (results.isEmpty) {
       return const OrderValidationResult(status: OrderValidationStatus.accepted);
@@ -561,7 +548,8 @@ class OrderEngine {
     return results;
   }
 
-  /// Dry-run: apply orders to copy of game, return projected effects.
+  /// Dry-run: apply orders via resolver (no mutation of [game]); return projected effects.
+  /// Uses [projectOrderEffects] for worker count, treasury delta, unit locations, stockpile deltas.
   ProjectedEffects projectedEffects(
     Game game,
     MapTopology topology,
@@ -569,22 +557,14 @@ class OrderEngine {
     List<AssignedRecipe> defaultAssignments = const [],
   }) {
     final orders = _copyOrders(_orders);
-    final tileMapByRegion = <String, TileMapResult>{};
-    final next = resolveTurnForGame(
+    const tileMapByRegion = <String, TileMapResult>{};
+    return projectOrderEffects(
       game: game,
-      topology: topology,
       orders: orders,
-      tileMapByRegion: tileMapByRegion.isEmpty ? null : tileMapByRegion,
+      topology: topology,
+      tileMapByRegion: tileMapByRegion,
+      playerId: playerId,
       defaultAssignments: defaultAssignments,
-    );
-    final player = next.playerById(playerId);
-    if (player == null) return const ProjectedEffects();
-
-    final origPlayer = game.playerById(playerId);
-
-    return ProjectedEffects(
-      workerCount: player.workerPool.totalWorkers,
-      treasuryDelta: origPlayer != null ? player.treasury - origPlayer.treasury : null,
     );
   }
 }

--- a/packages/colonizethis_logic/lib/src/orders/order_merge.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_merge.dart
@@ -58,28 +58,8 @@ bool _isEmpty(Orders o) =>
 Map<String, List<MoveOrder>> _mergeMoveOrders(
   Map<String, List<MoveOrder>> human,
   Map<String, List<MoveOrder>> ai,
-) {
-  final allPlayerIds = {...human.keys, ...ai.keys}.toList()..sort();
-  final result = <String, List<MoveOrder>>{};
-  final humanUnitsWithMove = <String>{};
-  for (final playerId in allPlayerIds) {
-    final humanList = human[playerId] ?? [];
-    final aiList = ai[playerId] ?? [];
-    humanUnitsWithMove.clear();
-    for (final o in humanList) {
-      humanUnitsWithMove.add(o.unitId);
-    }
-    final merged = [...humanList];
-    for (final o in aiList) {
-      if (!humanUnitsWithMove.contains(o.unitId)) {
-        merged.add(o);
-        humanUnitsWithMove.add(o.unitId);
-      }
-    }
-    if (merged.isNotEmpty) result[playerId] = merged;
-  }
-  return result;
-}
+) =>
+    _mergeByConflictKey(human, ai, (o) => o.unitId);
 
 Map<String, List<BuildUnitOrder>> _mergeBuildOrders(
   Map<String, List<BuildUnitOrder>> human,
@@ -104,28 +84,8 @@ Map<String, List<BuildUnitOrder>> _mergeBuildOrders(
 Map<String, List<WorkOrder>> _mergeWorkOrders(
   Map<String, List<WorkOrder>> human,
   Map<String, List<WorkOrder>> ai,
-) {
-  final allPlayerIds = {...human.keys, ...ai.keys}.toList()..sort();
-  final result = <String, List<WorkOrder>>{};
-  final humanUnitsWithWork = <String>{};
-  for (final playerId in allPlayerIds) {
-    final humanList = human[playerId] ?? [];
-    final aiList = ai[playerId] ?? [];
-    humanUnitsWithWork.clear();
-    for (final o in humanList) {
-      humanUnitsWithWork.add(o.unitId);
-    }
-    final merged = [...humanList];
-    for (final o in aiList) {
-      if (!humanUnitsWithWork.contains(o.unitId)) {
-        merged.add(o);
-        humanUnitsWithWork.add(o.unitId);
-      }
-    }
-    if (merged.isNotEmpty) result[playerId] = merged;
-  }
-  return result;
-}
+) =>
+    _mergeByConflictKey(human, ai, (o) => o.unitId);
 
 Map<String, List<DiplomaticOrder>> _mergeDiplomaticOrders(
   Map<String, List<DiplomaticOrder>> human,
@@ -175,48 +135,35 @@ Map<String, List<ResearchOrder>> _mergeResearchOrders(
 Map<String, List<NavalMoveOrder>> _mergeNavalMoveOrders(
   Map<String, List<NavalMoveOrder>> human,
   Map<String, List<NavalMoveOrder>> ai,
-) {
-  final allPlayerIds = {...human.keys, ...ai.keys}.toList()..sort();
-  final result = <String, List<NavalMoveOrder>>{};
-  final humanFleetIds = <String>{};
-  for (final playerId in allPlayerIds) {
-    final humanList = human[playerId] ?? [];
-    final aiList = ai[playerId] ?? [];
-    humanFleetIds.clear();
-    for (final o in humanList) {
-      humanFleetIds.add(o.fleetId);
-    }
-    final merged = [...humanList];
-    for (final o in aiList) {
-      if (!humanFleetIds.contains(o.fleetId)) {
-        merged.add(o);
-        humanFleetIds.add(o.fleetId);
-      }
-    }
-    if (merged.isNotEmpty) result[playerId] = merged;
-  }
-  return result;
-}
+) =>
+    _mergeByConflictKey(human, ai, (o) => o.fleetId);
 
 Map<String, List<NavalMissionOrder>> _mergeNavalMissionOrders(
   Map<String, List<NavalMissionOrder>> human,
   Map<String, List<NavalMissionOrder>> ai,
+) =>
+    _mergeByConflictKey(human, ai, (o) => o.fleetId);
+
+Map<String, List<T>> _mergeByConflictKey<T>(
+  Map<String, List<T>> human,
+  Map<String, List<T>> ai,
+  String Function(T) conflictKey,
 ) {
   final allPlayerIds = {...human.keys, ...ai.keys}.toList()..sort();
-  final result = <String, List<NavalMissionOrder>>{};
-  final humanFleetIds = <String>{};
+  final result = <String, List<T>>{};
+  final humanKeys = <String>{};
   for (final playerId in allPlayerIds) {
     final humanList = human[playerId] ?? [];
     final aiList = ai[playerId] ?? [];
-    humanFleetIds.clear();
+    humanKeys.clear();
     for (final o in humanList) {
-      humanFleetIds.add(o.fleetId);
+      humanKeys.add(conflictKey(o));
     }
-    final merged = [...humanList];
+    final merged = List<T>.from(humanList);
     for (final o in aiList) {
-      if (!humanFleetIds.contains(o.fleetId)) {
+      if (!humanKeys.contains(conflictKey(o))) {
         merged.add(o);
-        humanFleetIds.add(o.fleetId);
+        humanKeys.add(conflictKey(o));
       }
     }
     if (merged.isNotEmpty) result[playerId] = merged;

--- a/packages/colonizethis_logic/lib/src/orders/order_projections.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_projections.dart
@@ -3,7 +3,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../economy/economy_production.dart';
 import '../constants.dart';
-import 'order_engine.dart';
+import 'projected_effects.dart';
 import '../turn/turn_resolver.dart';
 
 /// Projects effects of unresolved orders. SPEC/program/order-projections.md.

--- a/packages/colonizethis_logic/lib/src/orders/projected_effects.dart
+++ b/packages/colonizethis_logic/lib/src/orders/projected_effects.dart
@@ -1,0 +1,15 @@
+/// Projected effects after dry-run of orders. For UI feedback.
+/// SPEC/program/order-engine.md (Projected Effects).
+class ProjectedEffects {
+  const ProjectedEffects({
+    this.workerCount,
+    this.unitLocations,
+    this.stockpileDeltas,
+    this.treasuryDelta,
+  });
+
+  final int? workerCount;
+  final Map<String, String>? unitLocations;
+  final Map<String, int>? stockpileDeltas;
+  final int? treasuryDelta;
+}

--- a/packages/colonizethis_logic/test/order_engine_test.dart
+++ b/packages/colonizethis_logic/test/order_engine_test.dart
@@ -83,6 +83,65 @@ void main() {
       expect(effects.workerCount, isNotNull);
     });
 
+    test('projectedEffects returns unitLocations when engine has move order', () {
+      const ow = 'oldWorld';
+      final topology = MapTopology(
+        nodes: [
+          const TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
+          const TopologyNode(id: 'P2', regionId: ow, type: TopologyNodeType.province),
+        ],
+        edges: [const TopologyEdge(id1: 'P1', id2: 'P2')],
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p1'),
+            ],
+            units: [
+              Unit(id: 'u1', type: 'musketeers', ownerId: 'p1', provinceId: '$ow|P1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+      );
+      final engine = OrderEngine();
+      engine.addMoveOrder('p1', const MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P2'));
+      final effects = engine.projectedEffects(game, topology, 'p1');
+      expect(effects.unitLocations, isNotNull);
+      expect(effects.unitLocations!['u1'], '$ow|P2');
+    });
+
+    test('projectedEffects does not mutate passed-in game', () {
+      const ow = 'oldWorld';
+      final topology = MapTopology(
+        nodes: [
+          const TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
+        ],
+        edges: [],
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
+            units: [],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+      );
+      final turnBefore = game.worldState.turnState.turnNumber;
+      final engine = OrderEngine();
+      engine.projectedEffects(game, topology, 'p1');
+      expect(game.worldState.turnState.turnNumber, turnBefore);
+    });
+
     test('addMoveOrderWithContext uses world-state validation', () {
       const ow = 'oldWorld';
       final topology = MapTopology(

--- a/packages/colonizethis_logic/test/order_engine_test.dart
+++ b/packages/colonizethis_logic/test/order_engine_test.dart
@@ -12,6 +12,58 @@ void main() {
       expect(engine.orders.moveOrdersByPlayerId['p1']?.length, 1);
     });
 
+    test('removeMoveOrder removes order at index', () {
+      final engine = OrderEngine();
+      engine.addMoveOrder('p1', const MoveOrder(unitId: 'u1', destinationProvinceId: 'P2'));
+      engine.addMoveOrder('p1', const MoveOrder(unitId: 'u2', destinationProvinceId: 'P3'));
+      expect(engine.orders.moveOrdersByPlayerId['p1']!.length, 2);
+      engine.removeMoveOrder('p1', 0);
+      expect(engine.orders.moveOrdersByPlayerId['p1']!.length, 1);
+      expect(engine.orders.moveOrdersByPlayerId['p1']!.first.unitId, 'u2');
+    });
+
+    test('removeBuildOrder removes order at index', () {
+      final engine = OrderEngine();
+      engine.addBuildOrder('p1', BuildUnitOrder(
+        unitType: 'peasant_levies',
+        isMilitary: true,
+        spawnProvinceId: 'oldWorld|P1',
+      ));
+      expect(engine.orders.buildUnitOrdersByPlayerId['p1']!.length, 1);
+      engine.removeBuildOrder('p1', 0);
+      expect(engine.orders.buildUnitOrdersByPlayerId['p1'], isEmpty);
+    });
+
+    test('addWorkOrderWithContext returns rejected when order invalid', () {
+      const ow = 'oldWorld';
+      final topology = MapTopology(
+        nodes: const [TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province)],
+        edges: const [],
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
+            units: [
+              Unit(id: 'u1', type: 'Builder', ownerId: 'p1', provinceId: '$ow|P1', tileKey: 'oldWorld|P1|0|0'),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+      );
+      final engine = OrderEngine();
+      final result = engine.addWorkOrderWithContext(
+        game,
+        topology,
+        'p1',
+        const WorkOrder(unitId: 'u1', target: 'unknown_target', targetTileKey: 'oldWorld|P1|0|0'),
+      );
+      expect(result.status, OrderValidationStatus.rejected);
+    });
+
     test('first invalid order plus subsequent rejected', () {
       const ow = 'oldWorld';
       final topology = MapTopology(

--- a/packages/colonizethis_logic/test/order_merge_test.dart
+++ b/packages/colonizethis_logic/test/order_merge_test.dart
@@ -287,6 +287,24 @@ void main() {
       expect(merged.moveOrdersByPlayerId['p1']!.map((o) => o.unitId), containsAll(['u1', 'u1b']));
       expect(merged.moveOrdersByPlayerId['p2']!.map((o) => o.unitId), containsAll(['u2', 'u2b']));
     });
+
+    test('merge uses stable player ordering', () {
+      final human = Orders(
+        moveOrdersByPlayerId: {
+          'p2': [const MoveOrder(unitId: 'u2', destinationProvinceId: 'D2')],
+          'p1': [const MoveOrder(unitId: 'u1', destinationProvinceId: 'D1')],
+        },
+      );
+      final ai = Orders(
+        moveOrdersByPlayerId: {
+          'p2': [const MoveOrder(unitId: 'u2b', destinationProvinceId: 'D2b')],
+          'p1': [const MoveOrder(unitId: 'u1b', destinationProvinceId: 'D1b')],
+        },
+      );
+      final merged = mergeOrderLists(humanOrders: human, aiOrders: ai);
+      final playerIds = merged.moveOrdersByPlayerId.keys.toList();
+      expect(playerIds, ['p1', 'p2']);
+    });
   });
 }
 


### PR DESCRIPTION
Fixes #161

- **SPEC/program/order-engine.md:** Clarify validation scope (research validated in research phase; diplomatic orders merge-only), dry-run does not mutate passed-in game, add acceptance criteria.
- **ProjectedEffects:** Move to `projected_effects.dart` to break order_engine ↔ order_projections cycle; `OrderEngine.projectedEffects()` delegates to `projectOrderEffects` so `unitLocations` and `stockpileDeltas` are populated.
- **order_merge:** Add generic `_mergeByConflictKey` for move, work, naval move, naval mission (reduces duplication).
- **order_engine:** Debug log when validating with context (logic:); remove unused `turn_resolver` import.
- **Tests:** `projectedEffects` returns `unitLocations` when engine has move order; dry-run does not mutate passed-in game; merge uses stable player ordering.

Made with [Cursor](https://cursor.com)