### PR TITLE
chore: update pubspec.lock (meta 1.18, SDK constraint)

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -391,10 +391,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -801,5 +801,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.35.0"


### PR DESCRIPTION
Syncs lockfile with current resolution (meta 1.17→1.18, Dart SDK constraint). No functional change.

Made with [Cursor](https://cursor.com)