### PR TITLE
fix(data): extraction cap fallback 4 when no gathering tech; fix spec ref

### DIFF
--- a/packages/colonizethis_data/lib/src/tech_extraction.dart
+++ b/packages/colonizethis_data/lib/src/tech_extraction.dart
@@ -48,8 +48,9 @@ class TechDefinition {
 
 /// Minimal tech catalog backing extraction and research for Phase 5.
 ///
-/// The full catalog is described in SPEC/game/tech-tree-catalog.md; this
-/// structure is a program-level representation.
+/// The full catalog is defined in SPEC/game/tech-tree.md and category sub-docs
+/// (e.g. SPEC/game/tech-tree-gathering.md); this structure is a program-level
+/// representation.
 const Map<String, TechDefinition> techCatalog = {
   'road_construction': TechDefinition(
     id: 'road_construction',
@@ -148,9 +149,16 @@ TechDefinition? techById(String id) => techCatalog[id];
 /// - gathering_2 => cap 3
 /// - gathering_3 => cap 4
 ///
-/// When no gathering tech is unlocked, [defaultExtractionCap] is used.
+/// When no gathering tech is unlocked (null, empty, or only non-gathering techs),
+/// [defaultExtractionCap] is used per SPEC/game/tech-and-extraction-cap.md.
 int extractionCapForUnlocked(Map<String, bool>? techUnlocked) {
   if (techUnlocked == null || techUnlocked.isEmpty) {
+    return defaultExtractionCap;
+  }
+  final hasGathering = techUnlocked['gathering_1'] == true ||
+      techUnlocked['gathering_2'] == true ||
+      techUnlocked['gathering_3'] == true;
+  if (!hasGathering) {
     return defaultExtractionCap;
   }
   var cap = 1;
@@ -162,9 +170,6 @@ int extractionCapForUnlocked(Map<String, bool>? techUnlocked) {
   }
   if (techUnlocked['gathering_3'] == true) {
     cap = cap < 4 ? 4 : cap;
-  }
-  if (cap <= 0) {
-    return defaultExtractionCap;
   }
   return cap;
 }

--- a/packages/colonizethis_data/test/tech_extraction_test.dart
+++ b/packages/colonizethis_data/test/tech_extraction_test.dart
@@ -1,0 +1,64 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('extractionCapForUnlocked', () {
+    test('null returns defaultExtractionCap (4)', () {
+      expect(extractionCapForUnlocked(null), equals(defaultExtractionCap));
+    });
+
+    test('empty map returns defaultExtractionCap (4)', () {
+      expect(extractionCapForUnlocked({}), equals(defaultExtractionCap));
+    });
+
+    test('only non-gathering techs returns defaultExtractionCap (4)', () {
+      expect(
+        extractionCapForUnlocked({'organised_regiments': true}),
+        equals(defaultExtractionCap),
+      );
+      expect(
+        extractionCapForUnlocked({
+          'road_construction': true,
+          'early_steam_engine': true,
+          'improved_iron_weapons': true,
+        }),
+        equals(defaultExtractionCap),
+      );
+    });
+
+    test('gathering_1 gives cap 2', () {
+      expect(
+        extractionCapForUnlocked({'gathering_1': true}),
+        equals(2),
+      );
+    });
+
+    test('gathering_2 gives cap 3', () {
+      expect(
+        extractionCapForUnlocked({'gathering_1': true, 'gathering_2': true}),
+        equals(3),
+      );
+    });
+
+    test('gathering_3 gives cap 4', () {
+      expect(
+        extractionCapForUnlocked({
+          'gathering_1': true,
+          'gathering_2': true,
+          'gathering_3': true,
+        }),
+        equals(4),
+      );
+    });
+
+    test('gathering with other techs still uses gathering level', () {
+      expect(
+        extractionCapForUnlocked({
+          'gathering_1': true,
+          'organised_regiments': true,
+        }),
+        equals(2),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- When `techUnlocked` has only non-gathering techs (or null/empty), return `defaultExtractionCap` (4) per SPEC/game/tech-and-extraction-cap.md instead of 1.
- Update comment: catalog is in SPEC/game/tech-tree.md and category sub-docs (e.g. tech-tree-gathering.md), not the non-existent tech-tree-catalog.md.
- Add `tech_extraction_test.dart` for `extractionCapForUnlocked`.

Fixes #180

Made with [Cursor](https://cursor.com)