### PR TITLE
fix(research): one order per slot in resolver (last wins), no double spend

### DIFF
--- a/SPEC/program/research-resolution.md
+++ b/SPEC/program/research-resolution.md
@@ -11,7 +11,7 @@ Execute the research phase of turn resolution: validate orders, deduct spending,
 - AI research orders from active AI backend (Phase 4 minimal or Phase 6 full).
 
 ### Research Orders Structure
-Per player, per turn: slot assignments (slot index → tech id) and funding level per slot (per [tech-tree.md](../game/tech-tree.md) presets). Merged with other order types per [order-engine.md](order-engine.md).
+Per player, per turn: slot assignments (slot index → tech id) and funding level per slot (per [tech-tree.md](../game/tech-tree.md) presets). Merged with other order types per [order-engine.md](order-engine.md). **One order per slot:** if the merged list contains more than one order for the same slot index, the resolver applies exactly one per slot (last in list wins); no double spend or dual progress for that slot.
 
 ## Algorithm / Flow
 

--- a/packages/colonizethis_logic/lib/src/turn/research_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/research_resolver.dart
@@ -67,8 +67,16 @@ Game resolveResearchPhase(Game game, Orders orders) {
       }
     }
 
-    // 1–4: validate, deduct treasury, and add progress per slot.
+    // One order per slot (SPEC: each slot holds at most one active tech). Duplicate slotIndex
+    // in the list: last wins, so only one assignment per slot is applied and no double spend.
+    final bySlot = <int, ResearchOrder>{};
     for (final order in playerOrders) {
+      bySlot[order.slotIndex] = order;
+    }
+    final ordersPerSlot = bySlot.values.toList();
+
+    // 1–4: validate, deduct treasury, and add progress per slot.
+    for (final order in ordersPerSlot) {
       if (order.slotIndex < 0 || order.slotIndex >= slots) {
         continue;
       }

--- a/packages/colonizethis_logic/test/research_phase_test.dart
+++ b/packages/colonizethis_logic/test/research_phase_test.dart
@@ -228,6 +228,29 @@ void main() {
       expect(next.players.single.treasury, 500);
       expect(next.players.single.techUnlocked!['gathering_2'], isTrue);
     });
+
+    test('duplicate slotIndex: only one order per slot applied (last wins), no double spend', () {
+      // SPEC: one assignment per slot. If list has two orders for same slot, resolver uses one (last wins).
+      final game = _baseGame(treasury: 2000, techUnlocked: const {});
+      final orders = Orders(
+        researchOrdersByPlayerId: {
+          'p1': const [
+            ResearchOrder(slotIndex: 0, techId: 'gathering_1', funding: ResearchFundingLevel.low),
+            ResearchOrder(slotIndex: 0, techId: 'gathering_1', funding: ResearchFundingLevel.maximum),
+          ],
+        },
+      );
+      final next = resolveTurnForGame(
+        game: game,
+        topology: const MapTopology(),
+        orders: orders,
+      );
+      final player = next.players.single;
+      // Last wins => maximum only: 1000 spent, 2500 RP => gathering_1 (cost 80) unlocks.
+      expect(player.treasury, 1000);
+      expect(player.techUnlocked!['gathering_1'], isTrue);
+      // If both were applied we would have 1050 spent and dual progress; so no double spend.
+    });
   });
 }
 


### PR DESCRIPTION
## Summary
Enforce one research order per slot in the research resolver: when the merged order list contains multiple orders for the same `slotIndex`, only one is applied (last in list wins). Prevents double treasury spend and dual progress for a single slot.

## Changes
- **research_resolver.dart:** Deduplicate by `slotIndex` (Map, last wins) before processing; process the deduplicated list.
- **SPEC/program/research-resolution.md:** Document one-order-per-slot behavior and last-wins rule.
- **research_phase_test.dart:** Add test `duplicate slotIndex: only one order per slot applied (last wins), no double spend`.

Fixes #187

Made with [Cursor](https://cursor.com)