### PR TITLE
fix(orders): OrderEngine optional tileMapByRegion, projection logging, optional outputs (Fixes #183)

### DIFF
--- a/SPEC/program/order-engine.md
+++ b/SPEC/program/order-engine.md
@@ -34,6 +34,8 @@ Validation is per-player only. No cross-player conflict resolution at this stage
 
 Supports a **dry-run**: apply orders via the resolver (which returns **new** state); return projected effects for UI (worker count, treasury delta, unit locations, stockpile deltas). The engine does **not** mutate the passed-in game; the caller may pass the live game. No mutation of real state.
 
+`projectedEffects` accepts an optional `tileMapByRegion`. When omitted or empty, the dry-run uses no tile maps and **expected extraction is zero**; callers (e.g. SimGameController) may pass tile maps when available so projected extraction is non-zero. See [order-projections.md](order-projections.md).
+
 ---
 
 ## Turn Resolution Integration

--- a/SPEC/program/order-projections.md
+++ b/SPEC/program/order-projections.md
@@ -37,7 +37,7 @@ colonizethis_logic (extend OrderEngine or a dedicated service) provides an API t
 - `stockpile` or `stockpileDeltas` — commodity quantities (or deltas) after resolution
 - `unitLocations` — map of unit id → province id after movement
 
-Optionally, when feasible:
+Optionally, when feasible (currently deferred; fields exist on `ProjectedEffects` but are not yet populated):
 
 - `extractionByCommodity` — projected extraction per commodity
 - `productionByRecipe` — projected production outputs

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -550,19 +550,25 @@ class OrderEngine {
 
   /// Dry-run: apply orders via resolver (no mutation of [game]); return projected effects.
   /// Uses [projectOrderEffects] for worker count, treasury delta, unit locations, stockpile deltas.
+  /// When [tileMapByRegion] is null or omitted, an empty map is used and projected extraction is zero
+  /// (caller may pass tile maps when available so expected extraction is non-zero).
   ProjectedEffects projectedEffects(
     Game game,
     MapTopology topology,
     String playerId, {
     List<AssignedRecipe> defaultAssignments = const [],
+    Map<String, TileMapResult>? tileMapByRegion,
   }) {
     final orders = _copyOrders(_orders);
-    const tileMapByRegion = <String, TileMapResult>{};
+    final tileMaps = tileMapByRegion ?? <String, TileMapResult>{};
+    if (tileMaps.isEmpty) {
+      _log.d('logic: projectedEffects called with no tileMapByRegion; expected extraction will be zero');
+    }
     return projectOrderEffects(
       game: game,
       orders: orders,
       topology: topology,
-      tileMapByRegion: tileMapByRegion,
+      tileMapByRegion: tileMaps,
       playerId: playerId,
       defaultAssignments: defaultAssignments,
     );

--- a/packages/colonizethis_logic/lib/src/orders/order_projections.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_projections.dart
@@ -1,10 +1,13 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
 
 import '../economy/economy_production.dart';
 import '../constants.dart';
 import 'projected_effects.dart';
 import '../turn/turn_resolver.dart';
+
+final Logger _log = Logger();
 
 /// Projects effects of unresolved orders. SPEC/program/order-projections.md.
 /// Dry-run of resolveTurnForGame; no world state mutation.
@@ -19,6 +22,10 @@ ProjectedEffects projectOrderEffects({
   required String playerId,
   List<AssignedRecipe> defaultAssignments = const [],
 }) {
+  _log.d('logic: projectOrderEffects run for player $playerId');
+  if (tileMapByRegion.isEmpty) {
+    _log.d('logic: projectOrderEffects with empty tileMapByRegion; extraction will be zero');
+  }
   final next = resolveTurnForGame(
     game: game,
     topology: topology,

--- a/packages/colonizethis_logic/lib/src/orders/projected_effects.dart
+++ b/packages/colonizethis_logic/lib/src/orders/projected_effects.dart
@@ -1,15 +1,23 @@
 /// Projected effects after dry-run of orders. For UI feedback.
-/// SPEC/program/order-engine.md (Projected Effects).
+/// SPEC/program/order-engine.md (Projected Effects), order-projections.md.
 class ProjectedEffects {
   const ProjectedEffects({
     this.workerCount,
     this.unitLocations,
     this.stockpileDeltas,
     this.treasuryDelta,
+    this.extractionByCommodity,
+    this.productionByRecipe,
   });
 
   final int? workerCount;
   final Map<String, String>? unitLocations;
   final Map<String, int>? stockpileDeltas;
   final int? treasuryDelta;
+
+  /// Optional; when feasible. See SPEC/program/order-projections.md (Output).
+  final Map<String, int>? extractionByCommodity;
+
+  /// Optional; when feasible. See SPEC/program/order-projections.md (Output).
+  final Map<String, int>? productionByRecipe;
 }


### PR DESCRIPTION
Fixes #183.

**Spec:** SPEC/program/order-projections.md, order-engine.md.

**Changes:**
1. **OrderEngine.projectedEffects** accepts optional `tileMapByRegion`. When omitted, an empty map is used and projected extraction is zero; callers (e.g. SimGameController) can pass tile maps when available. Debug log when no tile maps are passed.
2. **order_projections.dart** and projection path: added `logic:`-prefixed debug logging per ctdev-logging (run + empty tileMapByRegion).
3. **ProjectedEffects**: added optional `extractionByCommodity` and `productionByRecipe` (deferred — not yet populated). Specs updated to state they are optional / future work.

Made with [Cursor](https://cursor.com)