### PR TITLE
fix(logic): add extraction pipeline logging per ctdev-logging (Fixes #190)

### DIFF
--- a/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
+++ b/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
@@ -1,7 +1,10 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
 
 import '../world/connectivity_resolver.dart';
+
+final Logger _log = Logger();
 
 /// Per-player extraction totals: land (same region as capital) vs overseas.
 class ExtractionTotals {
@@ -27,6 +30,7 @@ Map<String, ExtractionTotals> computeExtraction({
   required Map<String, ConnectivityResult> connectivityResult,
   int Function(String playerId) techCapForPlayer = _defaultTechCap,
 }) {
+  _log.d('logic: extraction compute start players=${game.players.length}');
   final out = <String, ExtractionTotals>{};
   for (final player in game.players) {
     final cr = connectivityResult[player.id];
@@ -98,6 +102,9 @@ Map<String, ExtractionTotals> computeExtraction({
 
     out[player.id] = ExtractionTotals(land: landTotals, overseas: overseasTotals);
   }
+  final landSum = out.values.fold<int>(0, (s, t) => s + t.land.values.fold(0, (a, b) => a + b));
+  final overseasSum = out.values.fold<int>(0, (s, t) => s + t.overseas.values.fold(0, (a, b) => a + b));
+  _log.d('logic: extraction compute end players=${out.length} landTotal=$landSum overseasTotal=$overseasSum');
   return out;
 }
 

--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -1,7 +1,10 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
 
 import '../constants.dart';
+
+final Logger _log = Logger();
 
 /// Result of connectivity resolution: connected tile set and per-tile path transport cap.
 /// SPEC/game/capital-and-connectivity, extraction-and-improvements: effective yield is
@@ -32,12 +35,14 @@ Map<String, ConnectivityResult> resolveConnectivity({
   required Map<String, TileMapResult> tileMapByRegion,
   required MapTopology topology,
 }) {
+  _log.d('logic: connectivity resolve start players=${game.players.length} regions=${tileMapByRegion.keys.join(",")}');
   final provinceIdsByType = _provinceIdsFromTopology(topology);
   final result = <String, ConnectivityResult>{};
 
   for (final player in game.players) {
     final capital = player.capitalTile;
     if (capital == null || player.capitalProvinceId == null) {
+      _log.d('logic: connectivity resolve player=${player.id} skipped (no capital)');
       result[player.id] = ConnectivityResult(connected: {});
       continue;
     }
@@ -53,6 +58,10 @@ Map<String, ConnectivityResult> resolveConnectivity({
     result[player.id] = cr;
   }
 
+  final summary = result.entries
+      .map((e) => '${e.key}:${e.value.connected.length}')
+      .join(' ');
+  _log.d('logic: connectivity resolve end $summary');
   return result;
 }
 


### PR DESCRIPTION
## Summary
Adds logging in the extraction pipeline per **SPEC/program/ctdev-logging.md**: `logic:` prefix, start/end of flows, and key outcomes.

## Changes
- **connectivity_resolver.dart**: Log `logic: connectivity resolve start` (players, regions); log when a player is skipped (no capital); log `logic: connectivity resolve end` with per-player connected tile counts.
- **resource_extractor.dart**: Log `logic: extraction compute start` (player count); log `logic: extraction compute end` (players, landTotal, overseasTotal).

Fixes #190

Made with [Cursor](https://cursor.com)