### PR TITLE
fix(research): add University to catalog and set researchSlots to 4 when unlocked (Fixes #173)

### DIFF
--- a/packages/colonizethis_data/lib/src/tech_extraction.dart
+++ b/packages/colonizethis_data/lib/src/tech_extraction.dart
@@ -19,6 +19,7 @@ const List<String> techIds = [
   'recruit_steppe_horsemen',
   'horse_artillery',
   'siege_engineering',
+  'university',
 ];
 
 /// Default max effective extraction level when player has no tech or no extraction-cap tech.
@@ -137,6 +138,14 @@ const Map<String, TechDefinition> techCatalog = {
     category: 'military',
     cost: 120,
     regimentUnlockIds: ['royal_artillery'],
+  ),
+  // Labour/economy (SPEC/game/tech-tree-labour-economy.md). University grants 4th research slot.
+  'university': TechDefinition(
+    id: 'university',
+    era: 3,
+    category: 'labour',
+    cost: 200,
+    prerequisiteIds: const [],
   ),
 };
 

--- a/packages/colonizethis_logic/lib/src/turn/research_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/research_resolver.dart
@@ -146,6 +146,9 @@ Game resolveResearchPhase(Game game, Orders orders) {
 
     final nextUnlockedForLevel = nextUnlocked ?? workingUnlocked;
     final militaryLevel = militaryLevelForUnlocked(nextUnlockedForLevel);
+    // SPEC/game/tech-tree.md: 4 slots with University tech.
+    final nextResearchSlots =
+        (nextUnlockedForLevel['university'] == true) ? 4 : null;
 
     updatedPlayers.add(
       player.copyWith(
@@ -153,6 +156,7 @@ Game resolveResearchPhase(Game game, Orders orders) {
         techUnlocked: nextUnlocked,
         researchProgressByTechId: nextProgress,
         militaryLevel: militaryLevel,
+        researchSlots: nextResearchSlots ?? player.researchSlots,
       ),
     );
   }

--- a/packages/colonizethis_logic/test/research_phase_test.dart
+++ b/packages/colonizethis_logic/test/research_phase_test.dart
@@ -229,6 +229,33 @@ void main() {
       expect(next.players.single.techUnlocked!['gathering_2'], isTrue);
     });
 
+    test('completing University sets researchSlots to 4', () {
+      // SPEC/game/tech-tree.md: 3 slots by default, 4 with University tech.
+      final game = _baseGame(
+        treasury: 3000,
+        techUnlocked: const {},
+      );
+      final orders = Orders(
+        researchOrdersByPlayerId: {
+          'p1': const [
+            ResearchOrder(
+              slotIndex: 0,
+              techId: 'university',
+              funding: ResearchFundingLevel.maximum,
+            ),
+          ],
+        },
+      );
+      final next = resolveTurnForGame(
+        game: game,
+        topology: const MapTopology(),
+        orders: orders,
+      );
+      final player = next.players.single;
+      expect(player.techUnlocked!['university'], isTrue);
+      expect(player.researchSlots, 4);
+    });
+
     test('duplicate slotIndex: only one order per slot applied (last wins), no double spend', () {
       // SPEC: one assignment per slot. If list has two orders for same slot, resolver uses one (last wins).
       final game = _baseGame(treasury: 2000, techUnlocked: const {});


### PR DESCRIPTION
## Summary

Implements the University 4th research slot per **SPEC/game/tech-tree.md** and **SPEC/game/tech-tree-labour-economy.md**.

## Changes

- **colonizethis_data (tech_extraction.dart):** Add `university` to `techIds` and `techCatalog` (era 3, category labour, cost 200). MVP: no prereqs in catalog so the tech is researchable; full prereqs are in the SPEC.
- **colonizethis_logic (research_resolver.dart):** When building the updated player after the research phase, set `researchSlots: 4` when `university` is in `techUnlocked`; otherwise preserve existing `researchSlots`.
- **research_phase_test.dart:** New test `completing University sets researchSlots to 4` (research university with max funding for one turn, assert `techUnlocked['university']` and `researchSlots == 4`).

## Out of scope (issue #173)

- **Cancel slot clearing progress:** Spec/model clarification still needed; not changed.
- **Wrong spec reference:** Grep found no `tech-tree-catalog.md` reference in repo; comment in tech_extraction already points to tech-tree.md and category sub-docs.

Fixes #173

Made with [Cursor](https://cursor.com)