### PR TITLE
fix(spec): unify turn-to-year formula, doc MVP and edge cases (Fixes #176)

### DIFF
--- a/SPEC/game/turn-time-mapping.md
+++ b/SPEC/game/turn-time-mapping.md
@@ -41,8 +41,14 @@ Turns before cutoff = `(cutoffYear - startYear) / yearsPerTurnBeforeCutoff` (e.g
 ## Configuration Layers
 
 - **Base:** Default values (GDD 01). Single source for MVP.
+- **MVP:** Default only; turn-time mapping is not read from the ruleset at game creation. Game setup uses `TurnTimeMapping.gdd01`. See [game-setup-pipeline.md](../program/game-setup-pipeline.md) step 7e and [ruleset-config.md](../program/ruleset-config.md).
 - **Scenario:** May override (post-MVP). Scenarios not in MVP scope.
 - **Immutability:** Formula fixed at game creation; cannot change during play.
+
+## Edge cases
+
+- **Turn 1:** Maps to `startYear` (1500 default).
+- **Turn 0 or negative:** Not defined by GDD; implementation may yield values outside the intended calendar range. Callers should use turn ≥ 1 for display or narrative.
 
 ---
 

--- a/packages/colonizethis_logic/lib/src/turn_to_year.dart
+++ b/packages/colonizethis_logic/lib/src/turn_to_year.dart
@@ -2,14 +2,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 /// Maps turn number to calendar year per SPEC/game/turn-time-mapping.
 ///
+/// Single source of truth: delegates to [TurnTimeMapping.yearAtTurn].
 /// Uses [TurnTimeMapping.gdd01] when [mapping] is null (legacy saves).
 int turnToYear(int turnNumber, TurnTimeMapping? mapping) {
-  final m = mapping ?? TurnTimeMapping.gdd01;
-  final turnsBeforeCutoff =
-      (m.cutoffYear - m.startYear) ~/ m.yearsPerTurnBeforeCutoff;
-  if (turnNumber <= turnsBeforeCutoff) {
-    return m.startYear + (turnNumber - 1) * m.yearsPerTurnBeforeCutoff;
-  }
-  return m.cutoffYear +
-      (turnNumber - turnsBeforeCutoff - 1) * m.yearsPerTurnAfterCutoff;
+  return (mapping ?? TurnTimeMapping.gdd01).yearAtTurn(turnNumber);
 }

--- a/packages/colonizethis_logic/test/turn_to_year_test.dart
+++ b/packages/colonizethis_logic/test/turn_to_year_test.dart
@@ -3,6 +3,19 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
 void main() {
+  group('acceptance criteria (SPEC/game/turn-time-mapping.md)', () {
+    test('turn 1 → startYear (1500), turn 100 → 1698, 101 → 1700, 102 → 1701', () {
+      expect(turnToYear(1, TurnTimeMapping.gdd01), 1500);
+      expect(turnToYear(100, TurnTimeMapping.gdd01), 1698);
+      expect(turnToYear(101, TurnTimeMapping.gdd01), 1700);
+      expect(turnToYear(102, TurnTimeMapping.gdd01), 1701);
+    });
+    test('legacy saves (null mapping) behave as GDD 01', () {
+      expect(turnToYear(1, null), 1500);
+      expect(turnToYear(102, null), 1701);
+    });
+  });
+
   group('turnToYear', () {
     test('turn 1 returns 1500 with default mapping', () {
       expect(turnToYear(1, null), 1500);

--- a/packages/colonizethis_models/test/turn_time_mapping_test.dart
+++ b/packages/colonizethis_models/test/turn_time_mapping_test.dart
@@ -21,5 +21,10 @@ void main() {
     test('yearAtTurn turn 102 returns year after cutoff', () {
       expect(TurnTimeMapping.gdd01.yearAtTurn(102), 1701);
     });
+
+    test('yearAtTurn turn 0 (boundary, spec undefined)', () {
+      // Turn 0 not defined by GDD; implementation yields startYear - yearsPerTurnBeforeCutoff.
+      expect(TurnTimeMapping.gdd01.yearAtTurn(0), 1498);
+    });
   });
 }


### PR DESCRIPTION
Fixes #176

- **Unify formula:** `turnToYear` now delegates to `(mapping ?? TurnTimeMapping.gdd01).yearAtTurn(turnNumber)` so the formula lives only in `TurnTimeMapping.yearAtTurn` (single source of truth).
- **SPEC/game/turn-time-mapping.md:** Document MVP as default-only (no ruleset read at game creation); add edge case note for turn 0 / negative.
- **Tests:** Named acceptance-criteria group (turn 1→1500, 100→1698, 101→1700, 102→1701; legacy null → GDD 01); turn 0 boundary test in colonizethis_models.

Does not implement ruleset read for turn-time mapping (left for post-MVP); game-setup-pipeline already documents step 7e.

Made with [Cursor](https://cursor.com)