### PR TITLE
fix(sim-game-ai): province id in diplomacy filter, research RNG, spec (Fixes #169)

### DIFF
--- a/SPEC/program/sim-game-default-ai.md
+++ b/SPEC/program/sim-game-default-ai.md
@@ -23,13 +23,8 @@ Orders defaultSimGameAi({
 });
 ```
 
-- **Input:**
-  - `game` — full current game state at the start of the turn.
-  - `player` — the Great Power for whom we are generating orders.
-  - `topology` — map adjacency information for movement validation.
-  - `baseSeed` — used as fallback when computing the turn seed when `game.aiSeedByGpId[player.id]` is missing for that GP (Option A). The function derives `turnSeed = hash(globalGameSeed, aiSeed[P], T)` with the same formula as AIPlanner; if `aiSeedByGpId[player.id]` is absent, `baseSeed` is used so that Option A (same seed when same role) holds.
-- **Output:**
-  - An `Orders` value containing move, build, work, and research orders **for that player only**, all produced by the shared simple heuristics and passing validation.
+- **Input:** `game` (current state), `player` (GP), `topology` (adjacency), `baseSeed` (fallback when `game.aiSeedByGpId[player.id]` is missing; same turnSeed formula as AIPlanner).
+- **Output:** `Orders` for that player only (move, build, work, research from shared heuristics, validated).
 
 The function must be **pure and side-effect free**: it does not mutate `game` or any global state; it only inspects inputs and returns a new `Orders`.
 
@@ -40,8 +35,9 @@ The function must be **pure and side-effect free**: it does not mutate `game` or
 All order types (MoveOrders, BuildUnitOrders, WorkOrders, ResearchOrders) are produced by the **shared simple heuristics** used by both AIPlanner and defaultSimGameAi:
 
 - Build [PlayerView](player-view.md) for the player; call the **order suggestion API** for candidate move, work, build, and research orders.
-- Apply the same category preference (moves → work → build → research) and seeded random choice within category.
-- Apply the **diplomacy post-filter** to moves: drop moves to provinces owned by factions at peace; drop moves to minors when relation is unknown.
+- Apply the same category preference (moves → work → build → research) and **seeded random choice within category** (including research when multiple options exist).
+- Apply the **diplomacy post-filter** to moves: drop moves to provinces owned by factions at peace; drop moves to minors when relation is unknown. Province owner lookup uses full province id (regionId|localId) per [world-model-identity.md](../game/world-model-identity.md).
+- **Iteration cap:** Heuristics cap iterations per player per turn (constant in code, e.g. 32) to avoid unbounded loops.
 - No raw construction from topology; every order comes from the suggestion API and is valid by construction after validation.
 
 ---
@@ -54,10 +50,15 @@ All order types (MoveOrders, BuildUnitOrders, WorkOrders, ResearchOrders) are pr
 
 ---
 
+## Acceptance criteria
+
+- Same `(game, player, topology, baseSeed)` and turn number → same `Orders`.
+- Function does not mutate `game` or global state.
+- Category order (moves → work → build → research) and diplomacy post-filter are applied; province owner lookup uses full province id so moves to GPs at peace or to minors (unknown relation) are dropped correctly.
+- Run-level determinism when sim calls in fixed GP order each turn.
+
+---
+
 ## References
 
-- [sim-game.md](sim-game.md) — Consuming spec; turn loop invokes this behaviour to obtain Orders each turn.
-- [ai-planner.md](ai-planner.md) — Shared simple heuristics and control rules.
-- [order-engine.md](order-engine.md) — Order suggestion API.
-- [player-view.md](player-view.md) — Visibility and world state for the AI.
-- [combat-resolution.md](combat-resolution.md) — Attacker = faction that moved in; defender = province owner.
+[sim-game.md](sim-game.md) · [ai-planner.md](ai-planner.md) · [order-engine.md](order-engine.md) · [player-view.md](player-view.md) · [combat-resolution.md](combat-resolution.md)

--- a/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
+++ b/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
@@ -38,16 +38,21 @@ enum _SuggestionCategory {
   research,
 }
 
+/// Builds a map from full province id (regionId|localId) to owner faction id.
+/// Keys must match [MoveOrder.destinationProvinceId] format from the order
+/// suggestion API (SPEC/game/world-model-identity.md).
 Map<String, String> _provinceOwnerMap(Game game) {
   final out = <String, String>{};
   for (final p in game.worldState.oldWorld.provinces) {
     if (p.ownerId != null && p.ownerId!.isNotEmpty) {
-      out[p.id] = p.ownerId!;
+      final key = ProvinceId.full(p.regionId, ProvinceId.localIdFrom(p.id));
+      out[key] = p.ownerId!;
     }
   }
   for (final p in game.worldState.newWorld.provinces) {
     if (p.ownerId != null && p.ownerId!.isNotEmpty) {
-      out[p.id] = p.ownerId!;
+      final key = ProvinceId.full(p.regionId, ProvinceId.localIdFrom(p.id));
+      out[key] = p.ownerId!;
     }
   }
   return out;
@@ -73,6 +78,8 @@ Orders generateOrdersWithSimpleHeuristics(
   var current = const Orders();
   final view = buildPlayerView(game, topology, player.id);
 
+  /// Max iterations per player per turn (cap to avoid unbounded loops).
+  /// Documented in SPEC/program/sim-game-default-ai.md.
   const maxIterationsPerPlayer = 32;
   for (var i = 0; i < maxIterationsPerPlayer; i++) {
     final moveSuggestions = suggestMoveOrders(view, game, topology, current);
@@ -153,7 +160,8 @@ Orders generateOrdersWithSimpleHeuristics(
         );
         break;
       case _SuggestionCategory.research:
-        final chosen = researchSuggestions.first;
+        final idx = rng.nextInt(researchSuggestions.length);
+        final chosen = researchSuggestions[idx];
         final list = <ResearchOrder>[
           ...current.researchOrdersByPlayerId[player.id] ?? const [],
           chosen,

--- a/packages/colonizethis_logic/test/simple_ai_heuristics_test.dart
+++ b/packages/colonizethis_logic/test/simple_ai_heuristics_test.dart
@@ -319,6 +319,111 @@ void main() {
       expect(orders.researchOrdersByPlayerId['gp1'], isNotNull);
     });
 
+    test('diplomacy filter works when Province has local id (full id used for lookup)', () {
+      // Game state may store Province.id as local id (e.g. P2). Order suggestion
+      // emits full province id (oldWorld|P2). Owner map must key by full id.
+      const ow = 'oldWorld';
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'P1', regionId: ow, ownerId: 'gp1'),
+              Province(id: 'P2', regionId: ow, ownerId: 'gp2'),
+            ],
+            units: const [
+              Unit(
+                id: 'u1',
+                type: 'grenadiers',
+                ownerId: 'gp1',
+                provinceId: '$ow|P1',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            'gp1': {
+              'oldWorld|P1|0|0': 'fullyVisible',
+              'oldWorld|P2|0|0': 'fullyVisible',
+            },
+          },
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'AI', isHuman: false),
+          Player(id: 'gp2', displayName: 'Other', isHuman: true),
+        ],
+        globalGameSeed: 0,
+        aiSeedByGpId: {'gp1': 42},
+        diplomacyRelations: const [
+          DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'gp2',
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
+          TopologyNode(id: 'P2', regionId: ow, type: TopologyNodeType.province),
+        ],
+        edges: [TopologyEdge(id1: 'P1', id2: 'P2')],
+      );
+      final orders = generateOrdersWithSimpleHeuristics(
+        game,
+        topology,
+        'gp1',
+        turnSeedForPlayer(game, 'gp1', 1),
+      );
+      final moves = orders.moveOrdersByPlayerId['gp1'] ?? [];
+      for (final m in moves) {
+        expect(m.destinationProvinceId, isNot('$ow|P2'),
+            reason: 'owner lookup by full id must drop move to GP at peace');
+      }
+    });
+
+    test('does not mutate game', () {
+      const ow = 'oldWorld';
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 7),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'P1', regionId: ow, ownerId: 'gp1'),
+            ],
+            units: const [],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            'gp1': {'oldWorld|P1|0|0': 'fullyVisible'},
+          },
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'AI', isHuman: false),
+        ],
+        globalGameSeed: 0,
+        aiSeedByGpId: {'gp1': 1},
+      );
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
+        ],
+        edges: [],
+      );
+      final turnBefore = game.worldState.turnState.turnNumber;
+      final playersLengthBefore = game.players.length;
+      generateOrdersWithSimpleHeuristics(
+        game,
+        topology,
+        'gp1',
+        turnSeedForPlayer(game, 'gp1', 1),
+      );
+      expect(game.worldState.turnState.turnNumber, equals(turnBefore));
+      expect(game.players.length, equals(playersLengthBefore));
+    });
+
     test('includes newWorld provinces in province owner map', () {
       const nw = 'newWorld';
       final game = Game(


### PR DESCRIPTION
Fixes #169

## Summary

- **Province owner map:** Key by full province id (`regionId|localId`) so lookup matches `MoveOrder.destinationProvinceId` from the order suggestion API (SPEC/game/world-model-identity.md). Fixes diplomacy post-filter when game state uses local province ids.
- **Research choice:** Use seeded random choice within category (was `researchSuggestions.first`); aligns with spec "seeded random choice within category".
- **SPEC sim-game-default-ai.md:** Document iteration cap (constant in code); add acceptance criteria; note full-id for diplomacy filter; trim to meet 500-word rule.
- **Tests:** Diplomacy filter when Province has local id; does not mutate game.

Made with [Cursor](https://cursor.com)