### PR TITLE
fix(combat): deployment limit per side, spec updates, tests (Fixes #195)

### DIFF
--- a/SPEC/game/military-generals.md
+++ b/SPEC/game/military-generals.md
@@ -32,3 +32,13 @@ Per-regiment values follow the same era/category progression as the tactical sta
 - **Army definition:** An army is a set of regiments in a province led by exactly one general. Units are always part of armies; armies are always headed by a general. Armies are inferred by grouping units in a province by owner and matching to the general in that province.
 - **Location invariant:** Armies are always located in a province. A player's armies must always be located within provinces they own. When at peace, a player's units remain in their owned provinces.
 - **Movement into non-owned province:** Moving an army into a province the player does not own is an act of war. War declaration is triggered during turn resolution (Diplomacy phase) before Movement; the combat and province-flip logic then applies when units enter enemy-held territory. See [combat.md](combat.md) and [movement.md](../program/movement.md).
+
+---
+
+## Acceptance criteria
+
+1. **Deployment limit:** Participating regiments per side in each engagement are capped to base (10, or 12 with Nationalism tech) + general medals; excess units do not participate in that engagement.
+2. **Initiative:** Ordering uses general medals and cavalry share per [combat.md](combat.md) when general/medal state is populated.
+3. **General morale aura:** Applies when general/medal state exists (deferred until modelled).
+4. **Army / no general:** Army = units in province under one general; no general = no army for field forces (enforcement deferred).
+5. **GDD 05 (era-based general caps):** External; general count/cap is out of scope until modelled.

--- a/SPEC/program/combat-resolution.md
+++ b/SPEC/program/combat-resolution.md
@@ -28,21 +28,27 @@ For each province with units from multiple factions:
 
 Per BattleContext, compute initiative per attacking side per game/combat.md § Rules (Initiative). Sort descending; tie-break by faction id.
 
-### 3. Per-Engagement Resolver
+### 3. Deployment Limit (per side)
 
-**Input:** One attacker side, current defender side, province snapshot, ruleset config, optional RNG seed.
+Before running the per-engagement resolver, cap each side’s participating regiments to the deployment limit per [military-generals.md](../game/military-generals.md): **base 10** (or **12** if the faction has Nationalism tech) **+1 per general medal**. Only the capped subset participates in strength and casualty computation; excess units do not take or deal damage in that engagement. Defender general medals are not yet modelled (treated as 0).
+
+### 4. Per-Engagement Resolver
+
+**Input:** One attacker side (capped unit list), current defender side (capped unit list), province snapshot, ruleset config, optional RNG seed.
 
 Steps:
 
 1. Aggregate strength per side per game/combat.md § Rules (Strength).
 2. For Minor Nation / Tribe defenders, apply effective military level per [factions.md](../game/factions.md).
 3. Apply siege modifiers if fort present per [siege-mechanics.md](../game/siege-mechanics.md).
-4. Apply terrain, difficulty, general, and feeding modifiers per game/combat.md § Rules (Modifiers).
+4. Apply terrain, difficulty, general, and feeding modifiers per game/combat.md § Rules (Modifiers). **General morale aura** (bonus scaling with general medals) is deferred until general/medal state is modelled.
 5. Compute winner and casualties. Pure function; no side effects.
 
 **Output:** EngagementResult.
 
-### 4. Resolution Chain
+**Deferred:** General medals are not yet read from game state (conflict detection passes 0); initiative still uses cavalry share. When general/medal state exists, populate `AttackingSide.generalMedals` in conflict detection and apply general morale aura in step 4.
+
+### 5. Resolution Chain
 
 Per BattleContext:
 
@@ -56,7 +62,7 @@ Per BattleContext:
    - Remove casualty units.
    - Flip province ownership if defender eliminated per game/combat.md § Rules (Province Flip).
 
-### 5. Probabilistic Resolver (Simulation Only)
+### 6. Probabilistic Resolver (Simulation Only)
 
 Separate resolver for simulation and Monte Carlo analysis; **not** used in the main game loop.
 

--- a/packages/colonizethis_data/lib/src/combat_config.dart
+++ b/packages/colonizethis_data/lib/src/combat_config.dart
@@ -401,3 +401,10 @@ const Map<DifficultyLevel, double> difficultyDefenderMultiplier = {
 /// generalMedalWeight: weight per general medal.
 const double initiativeCavalryShareWeight = 50.0;
 const double initiativeGeneralMedalWeight = 10.0;
+
+/// Deployment limit per side in battle. SPEC/game/military-generals.md.
+/// Base regiments per side; +1 per general medal (added in resolver).
+const int deploymentLimitBase = 10;
+const int deploymentLimitWithNationalism = 12;
+/// Tech id that raises base deployment to [deploymentLimitWithNationalism]. SPEC/game/tech-tree-diplomacy-civilian.md.
+const String kTechIdNationalism = 'nationalism';

--- a/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
@@ -80,6 +80,12 @@ Game resolveBattleContext(
       break;
     }
 
+    // Deployment limit per side. SPEC/game/military-generals.md.
+    final attackerLimit = _deploymentLimitForFaction(game, attacker.factionId, attacker.generalMedals);
+    final defenderLimit = _deploymentLimitForFaction(game, defenderFactionId, 0);
+    final cappedAttackerUnits = attackerUnits.take(attackerLimit).toList();
+    final cappedDefenderUnits = defenderUnits.take(defenderLimit).toList();
+
     final defenderEffectiveLevel = _defenderEffectiveLevel(game, defenderFactionId);
     final attackerCoverage =
         feedingCoverageByPlayerId[attacker.factionId] ?? 1.0;
@@ -88,8 +94,8 @@ Game resolveBattleContext(
     final attackerLeaderMult = _leaderBonusForFaction(game, attacker.factionId);
     final defenderLeaderMult = _leaderBonusForFaction(game, defenderFactionId);
     final outcome = resolveEngagement(
-      attackerUnits: attackerUnits,
-      defenderUnits: defenderUnits,
+      attackerUnits: cappedAttackerUnits,
+      defenderUnits: cappedDefenderUnits,
       generalMedals: attacker.generalMedals,
       fortLevel: ctx.fortLevel,
       terrain: ctx.terrain,
@@ -107,6 +113,7 @@ Game resolveBattleContext(
       allCasualties.add(id);
     }
 
+    // Casualties apply to full defender list; engagement was fought with capped subset.
     defenderUnitIds =
         defenderUnits.map((u) => u.id).where((id) => !outcome.defenderCasualties.contains(id)).toList();
 
@@ -240,6 +247,15 @@ int _defenderEffectiveLevel(Game game, String defenderFactionId) {
     if (t.id == defenderFactionId) return t.effectiveMilitaryLevel;
   }
   return 4;
+}
+
+/// Max regiments that can participate per side in one engagement.
+/// SPEC/game/military-generals.md: base 10; Nationalism tech → 12; +1 per general medal.
+int _deploymentLimitForFaction(Game game, String factionId, int generalMedals) {
+  final baseLimit = game.playerById(factionId)?.techUnlocked?[kTechIdNationalism] == true
+      ? deploymentLimitWithNationalism
+      : deploymentLimitBase;
+  return baseLimit + generalMedals;
 }
 
 /// Leader combat bonus for a faction. GPs use Player.leaderKey; minors/tribes get 1.0.

--- a/packages/colonizethis_logic/test/combat_resolver_test.dart
+++ b/packages/colonizethis_logic/test/combat_resolver_test.dart
@@ -245,5 +245,116 @@ void main() {
         reason: 'attacker should win and have at least one surviving unit',
       );
     });
+
+    test('deployment limit caps participating regiments per side (base 10, no Nationalism)', () {
+      // 15 attackers, 15 defenders; deployment limit 10 per side without Nationalism.
+      final attackerUnits = List.generate(
+        15,
+        (i) => Unit(
+          id: 'a$i',
+          type: 'grenadiers',
+          ownerId: 'att',
+          provinceId: 'p',
+          medals: 1,
+        ),
+      );
+      final defenderUnits = List.generate(
+        15,
+        (i) => Unit(
+          id: 'd$i',
+          type: 'peasant_levies',
+          ownerId: 'def',
+          provinceId: 'p',
+          medals: 0,
+        ),
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: const [Province(id: 'p', regionId: 'oldWorld', ownerId: 'def')],
+            units: [...attackerUnits, ...defenderUnits],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'att', displayName: 'Att', isHuman: true),
+          Player(id: 'def', displayName: 'Def', isHuman: false),
+        ],
+      );
+      final ctx = BattleContext(
+        provinceId: 'p',
+        regionId: 'oldWorld',
+        defenderFactionId: 'def',
+        defenderUnitIds: defenderUnits.map((u) => u.id).toList(),
+        attackers: [
+          AttackingSide(
+            factionId: 'att',
+            unitIds: attackerUnits.map((u) => u.id).toList(),
+            generalMedals: 0,
+          ),
+        ],
+        fortLevel: 0,
+        terrain: 'plains',
+      );
+      final result = resolveBattleContext(game, ctx);
+      final survivingAtt = result.worldState.oldWorld.units.where((u) => u.ownerId == 'att').length;
+      final survivingDef = result.worldState.oldWorld.units.where((u) => u.ownerId == 'def').length;
+      // Only 10 per side participate; so at least 5 attackers never participated and must survive.
+      expect(survivingAtt, greaterThanOrEqualTo(5), reason: 'deployment limit 10: at most 10 attackers participate, so ≥5 must remain');
+      // Defender had 15; at most 10 in engagement; so ≥5 defenders could survive if they win or stalemate.
+      expect(survivingAtt + survivingDef, greaterThanOrEqualTo(5), reason: 'at least one side has non-participants');
+    });
+
+    test('deployment limit with Nationalism tech is 12 (attacker has 13 units, ≥1 does not participate)', () {
+      final attackerUnits = List.generate(
+        13,
+        (i) => Unit(
+          id: 'a$i',
+          type: 'grenadiers',
+          ownerId: 'att',
+          provinceId: 'p',
+          medals: 0,
+        ),
+      );
+      final defenderUnits = [
+        Unit(id: 'd1', type: 'peasant_levies', ownerId: 'def', provinceId: 'p', medals: 0),
+      ];
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: const [Province(id: 'p', regionId: 'oldWorld', ownerId: 'def')],
+            units: [...attackerUnits, ...defenderUnits],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'att', displayName: 'Att', isHuman: true, techUnlocked: {'nationalism': true}),
+          Player(id: 'def', displayName: 'Def', isHuman: false),
+        ],
+      );
+      final ctx = BattleContext(
+        provinceId: 'p',
+        regionId: 'oldWorld',
+        defenderFactionId: 'def',
+        defenderUnitIds: ['d1'],
+        attackers: [
+          AttackingSide(
+            factionId: 'att',
+            unitIds: attackerUnits.map((u) => u.id).toList(),
+            generalMedals: 0,
+          ),
+        ],
+        fortLevel: 0,
+        terrain: 'plains',
+      );
+      final result = resolveBattleContext(game, ctx);
+      final survivingAtt = result.worldState.oldWorld.units.where((u) => u.ownerId == 'att').length;
+      // With Nationalism, limit 12; 13 attackers so ≥1 does not participate and must survive.
+      expect(survivingAtt, greaterThanOrEqualTo(1), reason: 'deployment limit 12 with Nationalism: at most 12 participate');
+    });
   });
 }


### PR DESCRIPTION
Fixes #195

## Summary

- **Deployment limit:** Cap participating regiments per side to base 10 (or 12 with Nationalism tech) + general medals per SPEC/game/military-generals.md. Only the capped subset participates in each engagement.
- **Constants:** `deploymentLimitBase`, `deploymentLimitWithNationalism`, `kTechIdNationalism` in colonizethis_data combat_config.
- **combat_resolver:** `_deploymentLimitForFaction(Game, factionId, generalMedals)`; cap attacker and defender unit lists before `resolveEngagement`.
- **SPEC/program/combat-resolution.md:** New step 3 (Deployment limit); step 4 (Per-Engagement) documents deferred general morale aura; deferred note for general medals from game state.
- **SPEC/game/military-generals.md:** Acceptance criteria; GDD 05 (era-based general caps) out of scope until modelled.
- **Tests:** `deployment limit caps participating regiments per side (base 10, no Nationalism)`; `deployment limit with Nationalism tech is 12`.

## Out of scope (per issue)

- generalMedals from game state (conflict detection still passes 0)
- General morale aura (deferred in TDD)
- GDD 05 general caps

Made with [Cursor](https://cursor.com)