### PR TITLE
docs(spec): tech-tree-gathering catalog, scalar cap, cross-refs, acceptance (Fixes #166)

### DIFF
--- a/SPEC/game/tech-and-extraction-cap.md
+++ b/SPEC/game/tech-and-extraction-cap.md
@@ -14,4 +14,6 @@ Each player has a **tech table**: a map from tech id to unlocked (e.g. `Map<Stri
 
 The **max effective extraction level** (1–4) per resource or improvement type is **derived from the tech tree catalog**: which techs grant which max improvement level for each resource (grain, timber, iron, coal, etc.). Effective extraction per tile = min(improvement level, **owner’s tech cap** for that resource). The improvement level on the tile is unchanged; only the amount that counts for extraction is capped.
 
-**Fallback:** When the full tech model is not yet loaded or a resource has no tech-gated cap, use a **constant cap** (e.g. 4) per player from config so extraction resolution can run. Full model derives cap from [tech-tree.md](tech-tree.md) and category sub-docs.
+**MVP:** The implementation uses a **single scalar** cap per player (one value for all resources) as a temporary simplification; the catalog is program-level (e.g. gathering_1/2/3). The full model will use **per-resource** caps from the category sub-docs (e.g. [tech-tree-gathering.md](tech-tree-gathering.md)).
+
+**Fallback:** When the full tech model is not yet loaded or a resource has no tech-gated cap, use a **constant cap** (e.g. 4) per player from config so extraction resolution can run. Full model derives cap from [tech-tree.md](tech-tree.md) and category sub-docs. Ruleset: MVP program-level constants; future ruleset per [ruleset-config.md](../program/ruleset-config.md).

--- a/SPEC/game/tech-tree-gathering.md
+++ b/SPEC/game/tech-tree-gathering.md
@@ -4,6 +4,12 @@
 
 ---
 
+## Catalog and implementation
+
+The **gathering table below is the GDD source of truth** for ids, effects, and prerequisites. Prerequisites may reference techs defined in **other category docs** (e.g. [tech-tree-labour-economy.md](tech-tree-labour-economy.md) for `university`, [tech-tree-transport.md](tech-tree-transport.md) for `dynamite`, [tech-tree-new-world.md](tech-tree-new-world.md) for `precious_stone_mining` / `precious_metals_mining`, [tech-tree-military.md](tech-tree-military.md) for artillery-related techs). **MVP:** The program-level catalog lives in code (e.g. `colonizethis_data` tech extraction module); it uses **simplified ids** (`gathering_1`, `gathering_2`, `gathering_3`) and a **single scalar** extraction cap. The full per-resource cap model and GDD table ids (e.g. `crop_rotation`, `saw_mill`) are the design target; migration to a full catalog is documented in [tech-and-extraction-cap.md](tech-and-extraction-cap.md). Tech table source is **MVP program-level** (constants); future ruleset-driven catalog per [ruleset-config.md](../program/ruleset-config.md).
+
+---
+
 ## Tech Table
 
 | id | name | era | prerequisites | effects |
@@ -11,7 +17,7 @@
 | crop_rotation | Crop Rotation | 1 | — | Cattle herds; leads to sheep, cattle, horse |
 | saw_mill | Saw Mill | 1 | — | Timber 2 (forested land) |
 | land_enclosure | Land Enclosure | 1 | — | Grain 2 |
-| mine_engineering | Mine Engineering | 1 | — | Fort level 2; leads to mining |
+| mine_engineering | Mine Engineering | 1 | — | Fort level 2 (see [siege-mechanics.md](siege-mechanics.md)); leads to mining |
 | iron_mining | Iron Mining | 1 | mine_engineering | Iron 2 |
 | copper_and_tin_mining | Copper and Tin Mining | 1 | mine_engineering | Copper/tin 2; required for Horse Artillery, Weapon Craftsmanship |
 | coal_mining | Coal Mining | 1 | mine_engineering | Coal 1 (construct) |
@@ -39,5 +45,13 @@
 
 ## Notes
 
-- Numeric effects (e.g. Timber 2) denote max improvement level for that resource; builders apply improvements; effective extraction = min(improvement, tech cap, transport level).
+- Numeric effects (e.g. Timber 2) denote max improvement level for that resource; builders apply improvements; effective extraction = min(improvement, tech cap, transport level) per [extraction-and-improvements.md](extraction-and-improvements.md).
 - Copper and Tin Mining appears in both gathering and military (artillery); same tech id.
+
+---
+
+## Acceptance criteria
+
+- **Table:** Each row has a unique id; prerequisite ids reference techs defined in this doc or other category docs.
+- **Extraction cap:** In the full model, per-resource cap is derived from unlocked gathering techs (max level per resource from the table). MVP uses a single scalar cap; see [tech-and-extraction-cap.md](tech-and-extraction-cap.md).
+- **Tests:** Unit tests for cap resolution (scalar MVP; future per-resource); extraction pipeline respects player cap; research unlocking gathering tech increases cap.

--- a/SPEC/game/tech-tree.md
+++ b/SPEC/game/tech-tree.md
@@ -25,7 +25,7 @@ Techs are grouped by **category**: gathering, transport, labour, diplomatic, nav
 
 ## Prerequisites
 
-The tree is a **DAG**. Each tech lists zero or more **prerequisite tech ids**. A tech is available for research only when all prerequisites are in the player's `techUnlocked` set. A tech cannot start in the same turn its prerequisite completes.
+The tree is a **DAG**. Each tech lists zero or more **prerequisite tech ids**. Prerequisites may be techs from **any category** (defined in this doc’s category sub-docs). A tech is available for research only when all prerequisites are in the player's `techUnlocked` set. A tech cannot start in the same turn its prerequisite completes.
 
 ---
 


### PR DESCRIPTION
Fixes #166

## Summary

- **SPEC/game/tech-tree-gathering.md:** Added "Catalog and implementation" section: gathering table is GDD source; MVP uses simplified ids (gathering_1/2/3) and single scalar cap; program-level catalog; cross-category prerequisites with links to other category docs; ruleset note (MVP program-level, future ruleset). Cross-ref for mine_engineering "Fort level 2" to siege-mechanics.md. "Acceptance criteria" subsection (table uniqueness, extraction cap, tests). Link to extraction-and-improvements in Notes.
- **SPEC/game/tech-and-extraction-cap.md:** MVP paragraph (single scalar cap, full model per-resource); ruleset alignment in Fallback.
- **SPEC/game/tech-tree.md:** One sentence that prerequisites may be techs from any category.

## Code

No code change: repo already references SPEC/game/tech-tree.md and category sub-docs (e.g. tech-tree-gathering.md); no `tech-tree-catalog.md` reference found.

Made with [Cursor](https://cursor.com)