### PR TITLE
init-game-tool: spec alignment, CLI error handling, tests

### DIFF
--- a/SPEC/program/init-game-tool.md
+++ b/SPEC/program/init-game-tool.md
@@ -6,7 +6,7 @@ CLI entry point for game creation. Thin facade over the setup pipeline in [game-
 
 ## Data Model
 
-- **InitGameOptions:** `cellSize` (int, default 24), `skipFillLakes` (bool, default false), `renderPng` (bool, default true).
+- **InitGameOptions:** `cellSize` (int, default 24), `skipFillLakes` (bool, default false), `renderPng` (bool, default true). Implementation may extend options (e.g. `greatPowerColorOverride` for ctdev).
 - CLI sets `renderPng` based on whether `--output-map` is provided.
 
 ## CLI Interface
@@ -18,17 +18,18 @@ CLI entry point for game creation. Thin facade over the setup pipeline in [game-
 | `--config <path>` | JSON config overriding GameSetupConfig. Optional. |
 | `--output-map <path>` | Path for combined OW+NW map PNG. Optional. |
 | `--output-markdown <path>` | Path for faction setup markdown. Optional. |
-| `--output-game <path>` | Path for saving the game (colonizethis_save). Optional. |
-| `--no-save` | Skip saving the game. Overrides `--output-game`. |
+| `--output-game <path>` | Path for saving the game (colonizethis_save). Optional. Save is written when this is set unless `--no-save` is given. |
+| `--no-save` | Do not save the game. Overrides `--output-game`. |
 | `--seed <int>` | RNG seed; overrides config seed. Non-zero = reproducible; 0/absent = time-based. |
 | `--great-powers id1,id2,...` | Comma-separated GP semantic ids. Overrides selectedGreatPowerIds. |
 | `--great-power-count N` | First N default GP ids (backward compat; superseded by `--great-powers`). |
+| `--prussia-leader ID` | When prussia is selected: leader variant (e.g. frederick_the_great \| frederick_william). |
 | `--minor-nation-count N` | Override Minor Nation count. |
 | `--tribe-count N` | Override Tribe count. |
 | `--num-provinces-old-world N` | Override OW province count. |
 | `--num-provinces-new-world N` | Override NW province count. |
 
-JSON config supports `selectedGreatPowerIds` (array) and `greatPowerCount` (fallback). Paths relative to repo root.
+**JSON config** (single source for CLI): supported keys are `selectedGreatPowerIds` (array), `greatPowerCount` (fallback), `leaderVariantByGpId` (map GP id → leader variant), `continentCount`, `minorNationCount`, `tribeCount`, `numProvincesOldWorld`, `numProvincesNewWorld`, `seed`. Keys not listed (e.g. `minProvincesPerMinor`) are not read. Paths (config and outputs) are relative to the **current working directory** unless absolute.
 
 ## Output Artifacts
 
@@ -45,5 +46,5 @@ JSON config supports `selectedGreatPowerIds` (array) and `greatPowerCount` (fall
 
 ## Constraints
 
-- Validation errors abort with clear messages.
+- **Error handling:** On validation or setup failure the CLI catches errors from `runInitGame` (and downstream), prints a short user-facing message to stderr, and exits with a non-zero code. No raw stack trace is shown to the user.
 - Seed handling delegated to `runInitGame`; CLI passes through to GameSetupConfig.seed.

--- a/packages/colonizethis_logic/test/init_game_orchestrator_test.dart
+++ b/packages/colonizethis_logic/test/init_game_orchestrator_test.dart
@@ -62,6 +62,52 @@ void main() {
       expect(viewOverride, isNotNull);
       expect(viewOverride![overriddenPlayer.id], overrideColor);
     });
+
+    test('markdown contains Faction Setup and Starting State tables', () {
+      final config = GameSetupConfig.defaultConfig;
+      final result = runInitGame(
+        config: config,
+        options: const InitGameOptions(cellSize: 8, renderPng: false),
+      );
+      expect(result.markdown, contains('## Faction Setup'));
+      expect(result.markdown, contains('## Faction Starting State'));
+      expect(result.markdown, contains('| Faction | Type | Capital Province | Provinces Owned |'));
+      expect(result.markdown, contains('| Faction | Stockpile | Workers | Treasury | Units |'));
+    });
+
+    test('skipFillLakes=true runs without throwing', () {
+      final config = GameSetupConfig.defaultConfig;
+      final result = runInitGame(
+        config: config,
+        options: const InitGameOptions(
+          cellSize: 8,
+          renderPng: false,
+          skipFillLakes: true,
+        ),
+      );
+      expect(result.game, isNotNull);
+      expect(result.markdown, isNotEmpty);
+    });
+
+    test('throws ArgumentError when OW provinces fewer than Great Powers', () {
+      // Config with 6 GPs but only 2 OW provinces: createGameFromGeneratedMaps throws.
+      final config = GameSetupConfig(
+        selectedGreatPowerIds: GameSetupConfig.defaultConfig.selectedGreatPowerIds,
+        numProvincesOldWorld: 2,
+        numProvincesNewWorld: 5,
+      );
+      expect(
+        () => runInitGame(
+          config: config,
+          options: const InitGameOptions(cellSize: 8, renderPng: false),
+        ),
+        throwsA(isA<ArgumentError>().having(
+          (e) => e.message,
+          'message',
+          contains('Great Powers need at least one each'),
+        )),
+      );
+    });
   });
 }
 

--- a/tool/init_game/bin/init_game.dart
+++ b/tool/init_game/bin/init_game.dart
@@ -186,36 +186,44 @@ Future<void> main(List<String> arguments) async {
     );
   }
 
-  print('=== init_game ===');
-  print('Running game setup...');
-  final shouldRenderPng =
-      outputMapPath != null && outputMapPath.isNotEmpty;
-  final result = runInitGame(
-    config: config,
-    options: InitGameOptions(
-      cellSize: 24,
-      renderPng: shouldRenderPng,
-    ),
-  );
-  print('Game created: ${result.game.id}');
+  try {
+    print('=== init_game ===');
+    print('Running game setup...');
+    final shouldRenderPng =
+        outputMapPath != null && outputMapPath.isNotEmpty;
+    final result = runInitGame(
+      config: config,
+      options: InitGameOptions(
+        cellSize: 24,
+        renderPng: shouldRenderPng,
+      ),
+    );
+    print('Game created: ${result.game.id}');
 
-  if (outputMapPath != null && outputMapPath.isNotEmpty) {
-    File(outputMapPath).writeAsBytesSync(result.mapPngBytes);
-    print('Map PNG: $outputMapPath');
+    if (outputMapPath != null && outputMapPath.isNotEmpty) {
+      File(outputMapPath).writeAsBytesSync(result.mapPngBytes);
+      print('Map PNG: $outputMapPath');
+    }
+
+    if (outputMarkdownPath != null && outputMarkdownPath.isNotEmpty) {
+      File(outputMarkdownPath).writeAsStringSync(result.markdown);
+      print('Markdown: $outputMarkdownPath');
+    }
+
+    if (!noSave && outputGamePath != null && outputGamePath.isNotEmpty) {
+      await _saveGame(result.game, outputGamePath);
+      print('Game saved: $outputGamePath');
+    }
+
+    print('');
+    print(result.markdown);
+  } catch (e) {
+    final message = e is ArgumentError
+        ? (e.message ?? e.toString())
+        : 'Game setup failed: $e';
+    stderr.writeln('Error: $message');
+    exit(1);
   }
-
-  if (outputMarkdownPath != null && outputMarkdownPath.isNotEmpty) {
-    File(outputMarkdownPath).writeAsStringSync(result.markdown);
-    print('Markdown: $outputMarkdownPath');
-  }
-
-  if (!noSave && outputGamePath != null && outputGamePath.isNotEmpty) {
-    await _saveGame(result.game, outputGamePath);
-    print('Game saved: $outputGamePath');
-  }
-
-  print('');
-  print(result.markdown);
 }
 
 Future<void> _saveGame(Game game, String path) async {
@@ -242,7 +250,7 @@ void _printUsage() {
   print('  --config <path>         JSON config (optional)');
   print('  --output-map <path>     Write map PNG');
   print('  --output-markdown <path>  Write faction setup markdown');
-  print('  --output-game <path>    Save game (requires --output-game when not --no-save)');
+  print('  --output-game <path>    Save game to path when set (unless --no-save)');
   print('  --no-save               Do not save game');
   print('  --seed <n>              RNG seed');
   print('  --great-powers id1,id2  Comma-separated Great Power ids (e.g. england,france,spain)');

--- a/tool/init_game/pubspec.yaml
+++ b/tool/init_game/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   colonizethis_save:
 
 dev_dependencies:
+  colonizethis_test:
   test: ^1.24.0
 
 executables:

--- a/tool/init_game/test/cli_error_test.dart
+++ b/tool/init_game/test/cli_error_test.dart
@@ -1,0 +1,53 @@
+// CLI error handling: config that causes runInitGame/setup to throw exits with clear message.
+// SPEC/program/init-game-tool.md (Constraints: error handling).
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  group('init_game CLI', () {
+    test('exits with non-zero and clear message when setup fails (too few OW provinces)', () async {
+      final dir = await Directory.systemTemp.createTemp('init_game_test_');
+      try {
+        // Config with 1 OW province but default 6 GPs: setup may throw (provinces or sea-bound).
+        final configFile = File('${dir.path}/config.json');
+        await configFile.writeAsString('''
+{
+  "numProvincesOldWorld": 1,
+  "numProvincesNewWorld": 5
+}
+''');
+        final result = await Process.run(
+          'dart',
+          ['run', 'bin/init_game.dart', '--config', configFile.path, '--no-save'],
+          runInShell: false,
+          workingDirectory: Directory.current.path,
+          stderrEncoding: utf8,
+          stdoutEncoding: utf8,
+        );
+        expect(result.exitCode, 1, reason: 'CLI should exit 1 on setup failure');
+        final err = result.stderr as String;
+        expect(err, contains('Error:'), reason: 'User-facing error message');
+        expect(err, isNot(contains('package:')), reason: 'No raw stack trace to user');
+      } finally {
+        await dir.delete(recursive: true);
+      }
+    });
+
+    test('config file not found exits 1 with clear message', () async {
+      final result = await Process.run(
+        'dart',
+        ['run', 'bin/init_game.dart', '--config', '/nonexistent/config.json', '--no-save'],
+        runInShell: false,
+        workingDirectory: Directory.current.path,
+        stderrEncoding: utf8,
+        stdoutEncoding: utf8,
+      );
+      expect(result.exitCode, 1);
+      expect(result.stdout, contains('Error:'));
+      expect(result.stdout, contains('not found'));
+    });
+  });
+}

--- a/tool/init_game/test/cli_error_test.dart
+++ b/tool/init_game/test/cli_error_test.dart
@@ -4,7 +4,7 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 void main() {
   group('init_game CLI', () {


### PR DESCRIPTION
Fixes #156

## Summary
- **Spec (SPEC/program/init-game-tool.md):** Paths documented as CWD-relative; InitGameOptions may be extended (e.g. `greatPowerColorOverride`); full JSON config keys listed; `--prussia-leader` and `leaderVariantByGpId` documented; error-handling constraint (catch, stderr, non-zero exit, no stack trace).
- **CLI:** Fixed `--output-game` help text; wrapped `runInitGame` and file writes in try/catch; on failure print short message to stderr and exit(1).
- **Tests:** runInitGame: markdown structure (Faction Setup + Starting State tables), `skipFillLakes`, and ArgumentError when OW provinces < GPs; CLI: setup failure exits 1 with user message (no stack trace), config file not found exits 1.

Made with [Cursor](https://cursor.com)