### PR TITLE
GDD: clarify exploration turn formula uses per-region max

### DIFF
--- a/SPEC/game/fog-and-exploration.md
+++ b/SPEC/game/fog-and-exploration.md
@@ -28,7 +28,7 @@ Own provinces are always fully visible and never decay. Fogged applies only to o
 
 ### Exploration (Province-Level)
 
-Explorer with work order target `explore` reveals all tiles in a province. Turns required: `ceil(3 * tilesInProvince / maxTilesInAnyProvince)` (up to 3 turns). On completion, all tiles set to fully visible for that player.
+Explorer with work order target `explore` reveals all tiles in a province. **Turns required:** `ceil(3 * tilesInProvince / maxTilesInAnyProvinceInRegion)` (up to 3 turns), where the scale is the maximum tile count in any province **in that region** (so exploration time is comparable within the same region). On completion, all tiles set to fully visible for that player.
 
 ### Prospecting (Tile-Level)
 


### PR DESCRIPTION
Fixes #205

**Summary**
- SPEC/game/fog-and-exploration.md: clarify that the exploration turn formula scale is **per region** (max tiles in any province in that region), matching the implementation in `orders_application.dart`.
- No code change; keeps current region-scoped behaviour and documents it.

Made with [Cursor](https://cursor.com)