### PR TITLE
GDD/TDD: resolve ctdev log file naming conflict, add ctdev-logging acceptance criteria (Fixes #118)

### DIFF
--- a/SPEC/program/ctdev-app-init-map.md
+++ b/SPEC/program/ctdev-app-init-map.md
@@ -35,6 +35,6 @@ Map, legend, toggles, **AI selector** (Sim Game AI | AI Planner; when AI Planner
 
 ## Start Game Action
 
-On Start Game: (1) Generate sim session ID; create `logs/ctdev-sim-<sessionId>.log`; flush buffered logs. (2) Take `Game` from InitGameResult or loaded save. (3) Set `aiControlByGpId` true for all GPs. (4) Capture `MapTopology` and tile-map data. (5) Choose deterministic `baseSeed` (from init seed; optionally overridable). (6) Ensure `aiSeedByGpId` populated for all GPs (for `turnSeed[P, T]`). (7) Create Sim Game controller (Game, MapTopology, baseSeed, per-turn log). (8) Navigate to Running Game Screen.
+On Start Game: (1) Generate sim session ID; replay pre-sim buffer to the day file, then log to current day file per [ctdev-logging.md](ctdev-logging.md) (`logs/YYYY-MM-DD.log`). (2) Take `Game` from InitGameResult or loaded save. (3) Set `aiControlByGpId` true for all GPs. (4) Capture `MapTopology` and tile-map data. (5) Choose deterministic `baseSeed` (from init seed; optionally overridable). (6) Ensure `aiSeedByGpId` populated for all GPs (for `turnSeed[P, T]`). (7) Create Sim Game controller (Game, MapTopology, baseSeed, per-turn log). (8) Navigate to Running Game Screen.
 
 **Turn resolution:** `resolveTurnForGame` runs full TurnResolver ([turn-resolution-phases.md](turn-resolution-phases.md)), including Naval Interception & Naval Combat when naval is in scope.

--- a/SPEC/program/ctdev-app-running-game.md
+++ b/SPEC/program/ctdev-app-running-game.md
@@ -8,7 +8,7 @@
 
 Reached via Start Game (Sim) from Init Game Map Debug. User may navigate back to Init Map Debug.
 
-**Control bar:** Session ID and log path (`logs/ctdev-sim-<sessionId>.log`). Next Player | Resolve Turn | Next Turn | Fast-forward 10. Disabled while resolving.
+**Control bar:** Session ID and log path (current day file per [ctdev-logging.md](ctdev-logging.md): `logs/YYYY-MM-DD.log`). Next Player | Resolve Turn | Next Turn | Fast-forward 10. Disabled while resolving.
 
 ---
 

--- a/SPEC/program/ctdev-logging.md
+++ b/SPEC/program/ctdev-logging.md
@@ -41,3 +41,15 @@
 - **save:** Save/load calls (path, gameId, success); errors on failure.
 
 See [ctdev-app.md](ctdev-app.md) for UI behaviour (session ID display, Sim Log panel).
+
+---
+
+## Acceptance criteria
+
+- **Log directory:** `logs/` under project root (repo root when run from ctdev or root); created if missing.
+- **Log file:** One per calendar day: `logs/YYYY-MM-DD.log`; multiple sim sessions on the same day append.
+- **Session ID:** Generated at Start Game (Sim); displayed on Running Game screen; **Log:** shows path to the current day file.
+- **Pre-sim:** Events before Start Game buffered in memory; on Start Game replayed to the day file, then all subsequent events go to file.
+- **Levels:** File at debug and above; in-memory Sim Log at info and above, last 10 lines, cleared at start of every turn (resolve/step).
+- **Exceptions:** Log calls use `error` and `stackTrace` where applicable; uncaught errors in `runZonedGuarded` logged with stack.
+- **Scope:** ctdev, logic, ai, data, map, save each log key operations (start/end of flows, rejections, errors) with the specified prefixes; no `print` for operational/diagnostic output in ctdev and in-scope flows (or document exemptions).


### PR DESCRIPTION
Fixes #118 (partial: spec conflict + acceptance criteria).

- **Spec conflict:** ctdev-logging.md is source of truth for file naming (one file per calendar day: `logs/YYYY-MM-DD.log`). Updated ctdev-app-running-game.md and ctdev-app-init-map.md to reference the day file and ctdev-logging.md instead of session-based `logs/ctdev-sim-<sessionId>.log`.
- **Acceptance criteria:** Added an explicit acceptance criteria section to SPEC/program/ctdev-logging.md for directory, file naming, session ID, pre-sim buffer, levels, exceptions, and scope.

Remaining work for #118 (implementation, scope logging, CLI print→logger, tests) can be follow-up PRs.

Made with [Cursor](https://cursor.com)