### PR TITLE
Order projections: use Unit.locationProvinceId for unitLocations (Fixes #212)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_projections.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_projections.dart
@@ -38,13 +38,13 @@ ProjectedEffects projectOrderEffects({
 
   final origPlayer = game.playerById(playerId);
 
-  // Unit locations after resolution.
+  // Unit locations after resolution (province identity: use locationProvinceId per SPEC/game/world-model.md).
   final unitLocations = <String, String>{};
   for (final u in next.worldState.oldWorld.units) {
-    if (u.ownerId == playerId) unitLocations[u.id] = u.provinceId;
+    if (u.ownerId == playerId) unitLocations[u.id] = u.locationProvinceId;
   }
   for (final u in next.worldState.newWorld.units) {
-    if (u.ownerId == playerId) unitLocations[u.id] = u.provinceId;
+    if (u.ownerId == playerId) unitLocations[u.id] = u.locationProvinceId;
   }
 
   // Stockpile deltas (quantities after - quantities before).


### PR DESCRIPTION
Fixes #212.

Order projections now populate `unitLocations` with `Unit.locationProvinceId` instead of `Unit.provinceId`, so province identity is correct per SPEC/game/world-model.md (prefixed `regionId|localId` for civilians with tileKey; `provinceId` for military/naval).

- `packages/colonizethis_logic/lib/src/orders/order_projections.dart`: use `u.locationProvinceId` in both oldWorld and newWorld unit loops.
- All `colonizethis_logic` tests pass; `check_test_imports.sh` passes.

Made with [Cursor](https://cursor.com)