### PR TITLE
GDD: add Riches-to-treasury to flow, fix labour source (Fixes #213)

### DIFF
--- a/SPEC/game/stockpiles-and-production.md
+++ b/SPEC/game/stockpiles-and-production.md
@@ -12,8 +12,9 @@ Per Imperialism II: "commodities produced in these terrain tiles move to your wa
 
 ### Production Flow
 1. **Extraction:** Terrain tiles in owned provinces produce resources per improvement level. Resources are transported (auto-transport) to the player's stockpile.
-2. **Production:** Industry consumes commodities (inputs) and labour (workers) from stockpile to produce materials. Outputs added to stockpile.
-3. **Consumption:** Workers, military, and navy consume food and materials from stockpile.
+2. **Riches-to-treasury:** Riches (e.g. gold) in the stockpile convert to treasury at base price and are removed from the stockpile. Phase order: Extraction → Riches-to-treasury → Production → Consumption (see [economy-models.md](../program/economy-models.md) and [turn-resolution-phases.md](../program/turn-resolution-phases.md)).
+3. **Production:** Industry consumes commodities (inputs) from stockpile and labour from the WorkerPool to produce materials. Outputs added to stockpile.
+4. **Consumption:** Workers, military, and navy consume food and materials from stockpile.
 
 ### Capacity
 Capacity for all commodities is infinite; no limit on the amount of each commodity for the player.
@@ -21,7 +22,7 @@ Capacity for all commodities is infinite; no limit on the amount of each commodi
 ### Relations
 - **Player** → **Stockpile** (commodity quantities).
 - Extraction in provinces → owning player's stockpile (via transport network).
-- Production: stockpile inputs + labour → stockpile outputs.
+- Production: stockpile inputs (commodities) + WorkerPool labour → stockpile outputs.
 
 
 ## Interactions


### PR DESCRIPTION
Fixes #213

## Summary
- **Production Flow:** Add Riches-to-treasury as step 2 (between Extraction and Production). Phase order now matches SPEC/program/economy-models.md and turn-resolution-phases.md. Cross-links added.
- **Labour source:** Clarify that industry consumes commodities (inputs) from stockpile and labour from the **WorkerPool** (not from stockpile). Updated Relations bullet accordingly.

Spec-only change; no code changes.

Made with [Cursor](https://cursor.com)