### PR TITLE
Fix fog decay owner lookup to use full province id (Fixes #220)

### DIFF
--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -438,10 +438,10 @@ Map<String, Map<String, String>> _applyFogDecay(Game game) {
     for (final tileKey in visibility.keys.toList()) {
       final parts = tileKey.split('|');
       if (parts.length != 4) continue;
-      final provinceId = parts[1];
-      final ownerId = owOwnerByProvince[provinceId] ?? nwOwnerByProvince[provinceId];
+      final fullProvinceId = ProvinceId.full(parts[0], parts[1]);
+      final ownerId = owOwnerByProvince[fullProvinceId] ?? nwOwnerByProvince[fullProvinceId];
       if (ownerId == null || ownerId == playerId) continue;
-      if (!hasExplorerIn.contains(provinceId)) {
+      if (!hasExplorerIn.contains(parts[1])) {
         visibility[tileKey] = VisibilityLevel.fogged.name;
       }
     }

--- a/packages/colonizethis_logic/test/turn_resolver_test.dart
+++ b/packages/colonizethis_logic/test/turn_resolver_test.dart
@@ -1322,8 +1322,8 @@ void main() {
           turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 1),
           oldWorld: RegionData(
             provinces: [
-              Province(id: 'P1', regionId: ow, ownerId: 'p1'),
-              Province(id: 'P2', regionId: ow, ownerId: 'p2'),
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
             ],
             units: [],
           ),
@@ -1362,15 +1362,15 @@ void main() {
           turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 1),
           oldWorld: RegionData(
             provinces: [
-              Province(id: 'P1', regionId: ow, ownerId: 'p1'),
-              Province(id: 'P2', regionId: ow, ownerId: 'p2'),
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
             ],
             units: [
               Unit(
                 id: 'explorer1',
                 type: 'Explorer',
                 ownerId: 'p1',
-                provinceId: 'P2',
+                provinceId: '$ow|P2',
               ),
             ],
           ),


### PR DESCRIPTION
## Summary
In `_applyFogDecay` (turn_resolver.dart), owner lookup used the **local** province id (`parts[1]`) from the tile key. Per SPEC/game/world-model-identity.md, game-state province ids use the **prefixed** form `regionId|localId`. `owOwnerByProvince` / `nwOwnerByProvince` are keyed by `p.id` (full id), so using local id only could produce wrong or null lookups in a multi-region world.

## Changes
- **turn_resolver.dart:** Derive `fullProvinceId = ProvinceId.full(parts[0], parts[1])` from the tile key and use it for owner lookup. `hasExplorerIn` continues to use local id (`parts[1]`) as before.
- **turn_resolver_test.dart:** Fog decay tests updated to use prefixed province ids (`oldWorld|P1`, `oldWorld|P2`) and `Unit.provinceId: '$ow|P2'` so test data aligns with world-model-identity and the fix is exercised.

Fixes #220

Made with [Cursor](https://cursor.com)