### PR TITLE
Order projections: populate productionByRecipe when production phase runs (Fixes #222)

### DIFF
--- a/SPEC/program/order-projections.md
+++ b/SPEC/program/order-projections.md
@@ -37,10 +37,11 @@ colonizethis_logic (extend OrderEngine or a dedicated service) provides an API t
 - `stockpile` or `stockpileDeltas` — commodity quantities (or deltas) after resolution
 - `unitLocations` — map of unit id → province id after movement
 
+- `productionByRecipe` — when projection runs with production assignments (`defaultAssignments`), recipe id → quantity produced for the projected player (optional; null or empty when no assignments or production skipped).
+
 Optionally, when feasible (currently deferred; fields exist on `ProjectedEffects` but are not yet populated):
 
 - `extractionByCommodity` — projected extraction per commodity
-- `productionByRecipe` — projected production outputs
 
 ---
 

--- a/packages/colonizethis_logic/lib/src/economy/economy_production.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_production.dart
@@ -22,10 +22,14 @@ class ProductionResult {
   const ProductionResult({
     required this.stockpile,
     required this.workerPool,
+    this.productionByRecipe = const {},
   });
 
   final Stockpile stockpile;
   final WorkerPool workerPool;
+
+  /// Recipe id → quantity produced (output units). For projection API. SPEC/program/order-projections.md.
+  final Map<String, int> productionByRecipe;
 }
 
 /// Resolves production for a single player for one turn.
@@ -43,6 +47,7 @@ ProductionResult resolveProduction({
   required List<AssignedRecipe> assignments,
 }) {
   Stockpile current = stockpile;
+  final productionByRecipe = <String, int>{};
 
   for (final assignment in assignments) {
     final recipe = ProductionRecipesCatalog.byId[assignment.recipeId];
@@ -70,6 +75,9 @@ ProductionResult resolveProduction({
     final runs = maxByInputs;
     if (runs <= 0) continue;
 
+    productionByRecipe[assignment.recipeId] =
+        (productionByRecipe[assignment.recipeId] ?? 0) + runs;
+
     // Deduct inputs.
     for (final entry in recipe.inputQuantities.entries) {
       final totalNeeded = entry.value * runs;
@@ -85,6 +93,7 @@ ProductionResult resolveProduction({
   return ProductionResult(
     stockpile: current,
     workerPool: workers,
+    productionByRecipe: productionByRecipe,
   );
 }
 

--- a/packages/colonizethis_logic/lib/src/orders/order_projections.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_projections.dart
@@ -26,12 +26,16 @@ ProjectedEffects projectOrderEffects({
   if (tileMapByRegion.isEmpty) {
     _log.d('logic: projectOrderEffects with empty tileMapByRegion; extraction will be zero');
   }
+  Map<String, Map<String, int>>? productionByRecipeByPlayerId;
   final next = resolveTurnForGame(
     game: game,
     topology: topology,
     orders: orders,
     tileMapByRegion: tileMapByRegion,
     defaultAssignments: defaultAssignments,
+    onProductionComplete: defaultAssignments.isNotEmpty
+        ? (map) => productionByRecipeByPlayerId = map
+        : null,
   );
   final player = next.playerById(playerId);
   if (player == null) return const ProjectedEffects();
@@ -62,10 +66,15 @@ ProjectedEffects projectOrderEffects({
     }
   }
 
+  final productionByRecipe = productionByRecipeByPlayerId?[playerId];
+
   return ProjectedEffects(
     workerCount: player.workerPool.totalWorkers,
     treasuryDelta: origPlayer != null ? player.treasury - origPlayer.treasury : null,
     unitLocations: unitLocations,
     stockpileDeltas: stockpileDeltas.isNotEmpty ? stockpileDeltas : null,
+    productionByRecipe: productionByRecipe != null && productionByRecipe.isNotEmpty
+        ? productionByRecipe
+        : null,
   );
 }

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -151,6 +151,8 @@ Game resolveTurnForGame({
   Map<String, Map<CommodityId, int>> extractedByPlayerId = const {},
   List<AssignedRecipe> defaultAssignments = const [],
   void Function(DialogueEvent)? onDialogue,
+  /// Called after production phase with playerId → (recipeId → quantity produced). For projection API. SPEC/program/order-projections.md.
+  void Function(Map<String, Map<String, int>> productionByRecipeByPlayerId)? onProductionComplete,
 }) {
   final turn = game.worldState.turnState.turnNumber;
   _log.i('logic: turn $turn resolve start');
@@ -175,7 +177,11 @@ Game resolveTurnForGame({
         state = _runRichesToTreasuryPhase(state);
         break;
       case TurnPhase.production:
-        state = _runProductionPhase(state, defaultAssignments);
+        state = _runProductionPhase(
+          state,
+          defaultAssignments,
+          onProductionComplete,
+        );
         break;
       case TurnPhase.consumption:
         state = _runConsumptionPhase(state, feedingCoverageByPlayerId);
@@ -537,8 +543,13 @@ Game _runExtractionPhase(
   return currentState.copyWith(players: updatedPlayers);
 }
 
-Game _runProductionPhase(Game game, List<AssignedRecipe> defaultAssignments) {
+Game _runProductionPhase(
+  Game game,
+  List<AssignedRecipe> defaultAssignments,
+  void Function(Map<String, Map<String, int>> productionByRecipeByPlayerId)? onProductionComplete,
+) {
   final updatedPlayers = <Player>[];
+  final productionByRecipeByPlayerId = <String, Map<String, int>>{};
 
   for (final player in game.players) {
     final result = resolveProduction(
@@ -546,6 +557,10 @@ Game _runProductionPhase(Game game, List<AssignedRecipe> defaultAssignments) {
       workers: player.workerPool,
       assignments: defaultAssignments,
     );
+    if (result.productionByRecipe.isNotEmpty) {
+      productionByRecipeByPlayerId[player.id] =
+          Map<String, int>.from(result.productionByRecipe);
+    }
     updatedPlayers.add(
       player.copyWith(
         stockpile: result.stockpile,
@@ -554,6 +569,7 @@ Game _runProductionPhase(Game game, List<AssignedRecipe> defaultAssignments) {
     );
   }
 
+  onProductionComplete?.call(productionByRecipeByPlayerId);
   return game.copyWith(players: updatedPlayers);
 }
 

--- a/packages/colonizethis_logic/test/order_projections_test.dart
+++ b/packages/colonizethis_logic/test/order_projections_test.dart
@@ -3,6 +3,8 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
+const String _lumberRecipeId = 'lumber_from_timber';
+
 void main() {
   group('projectOrderEffects', () {
     test('returns empty ProjectedEffects when player not in game', () {
@@ -240,6 +242,83 @@ void main() {
       );
       expect(effects.stockpileDeltas, isNotNull);
       expect(effects.stockpileDeltas!['grain'], -1);
+    });
+
+    test('productionByRecipe populated when defaultAssignments provided', () {
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+        ],
+        edges: const [],
+      );
+      // lumber_from_timber: 2 timber → 1 lumber, 2 labour per output. Assign 4 labour → 2 runs.
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'P1', regionId: 'oldWorld', ownerId: 'p1'),
+            ],
+            units: const [],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: [
+          Player(
+            id: 'p1',
+            displayName: 'A',
+            isHuman: true,
+            stockpile: Stockpile(quantities: {'timber': 4}),
+            workerPool: WorkerPool(peasants: 2),
+          ),
+        ],
+      );
+      final effects = projectOrderEffects(
+        game: game,
+        orders: const Orders(),
+        topology: topology,
+        tileMapByRegion: const {},
+        playerId: 'p1',
+        defaultAssignments: const [
+          AssignedRecipe(recipeId: _lumberRecipeId, assignedLabour: 4),
+        ],
+      );
+      expect(effects.productionByRecipe, isNotNull);
+      expect(effects.productionByRecipe![_lumberRecipeId], 2);
+    });
+
+    test('productionByRecipe null when no defaultAssignments', () {
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+        ],
+        edges: const [],
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'P1', regionId: 'oldWorld', ownerId: 'p1'),
+            ],
+            units: const [],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'A', isHuman: true),
+        ],
+      );
+      final effects = projectOrderEffects(
+        game: game,
+        orders: const Orders(),
+        topology: topology,
+        tileMapByRegion: const {},
+        playerId: 'p1',
+      );
+      expect(effects.productionByRecipe, isNull);
     });
   });
 }


### PR DESCRIPTION
## Spec

**SPEC/program/order-projections.md** — Output lists `productionByRecipe` (projected production per recipe). It was deferred; this PR populates it when projection runs with production assignments.

## Changes

- **economy_production.dart:** `ProductionResult` gains `productionByRecipe` (recipe id → quantity produced). `resolveProduction` fills it as it runs each assignment.
- **turn_resolver.dart:** `_runProductionPhase` builds a per-player map and calls an optional `onProductionComplete` callback. `resolveTurnForGame` accepts `onProductionComplete` and passes it through.
- **order_projections.dart:** `projectOrderEffects` passes `onProductionComplete` when `defaultAssignments` is non-empty, captures the map, and sets `ProjectedEffects.productionByRecipe` for the requested player.
- **SPEC/program/order-projections.md:** Document `productionByRecipe` as populated when assignments are provided; leave `extractionByCommodity` as deferred.
- **order_projections_test.dart:** Add test that `productionByRecipe` is populated when `defaultAssignments` is provided (lumber recipe); add test that it is null when no assignments.

## Acceptance criteria

- When projection is run with production assignments (`defaultAssignments`), after the dry-run production phase, `ProjectedEffects.productionByRecipe` is set to recipe id → quantity produced for the projected player.
- When projection runs without assignments, `productionByRecipe` remains null.

Fixes #222

Made with [Cursor](https://cursor.com)