### PR TITLE
Fog-and-exploration spec: Spy 5-turn decay and exploration region

### DIFF
--- a/SPEC/game/fog-and-exploration.md
+++ b/SPEC/game/fog-and-exploration.md
@@ -14,7 +14,7 @@ Four levels per player per tile:
 
 - **Unknown:** No knowledge; exploration/prospecting impossible. New World tiles start here for all GPs.
 - **Revealed:** Province boundary and owner known; terrain and resources unknown.
-- **Fogged:** Terrain, non-prospect resources, and last-known improvements visible. Applies to other-faction provinces only when no Explorer/Spy is working there. Decay is immediate when units leave.
+- **Fogged:** Terrain, non-prospect resources, and last-known improvements visible. Applies to other-faction provinces only when no Explorer/Spy is working there. Decay: immediate when the last Explorer leaves; for Spy, a 5-turn timer applies (see Fog Decay).
 - **Fully Visible:** Everything known except unprospected minerals. Own provinces are always fully visible.
 
 ### Own vs Other Provinces
@@ -44,7 +44,10 @@ Mineral-eligible terrain: swamp, hills, mountain, desert (for diamonds). See [re
 
 ### Fog Decay
 
-When a player's last Explorer/Spy leaves another faction's province, all tiles in that province immediately revert to fogged (retaining last-known state). Own provinces never decay.
+- **Explorer:** When the last Explorer leaves an other-faction province, tiles in that province immediately revert to fogged (retaining last-known state).
+- **Spy:** When a Spy leaves an other-faction province, a 5-turn timer starts for (player, province); at end of each turn the timer is decremented; when it reaches 0, that province's tiles are set to fogged. Until then, the player retains full visibility of that province.
+
+Own provinces never decay.
 
 ### Explorer vs Spy
 

--- a/SPEC/program/fog-and-exploration-resolution.md
+++ b/SPEC/program/fog-and-exploration-resolution.md
@@ -23,7 +23,7 @@ Maintains per-player visibility and prospected state on world state; resolves ex
 **Exploration resolution** (Build/Work phase):
 
 1. For each Explorer with work order `explore` in province P, accumulate progress.
-2. Turns required per game rules: `ceil(3 * tilesInP / maxTilesInAnyProvince)`.
+2. Turns required per game rules: `ceil(3 * tilesInP / maxTilesInAnyProvinceInRegion)`, where `maxTilesInAnyProvinceInRegion` is the maximum tile count in any province **in the same region** as the Explorer's province.
 3. On completion, set all tiles in P to fullyVisible for that player.
 
 **Prospect resolution** (Build/Work phase):


### PR DESCRIPTION
Fixes #219

## Summary
Spec doc updates so fog/exploration behaviour is unambiguous and aligned with implementation.

### 1. GDD (SPEC/game/fog-and-exploration.md) — Fog Decay
- **Explorer:** When the last Explorer leaves an other-faction province, tiles immediately revert to fogged.
- **Spy:** When a Spy leaves, a 5-turn timer starts for (player, province); at end of each turn the timer is decremented; when it reaches 0, that province's tiles are set to fogged. Until then, the player retains full visibility.
- Fogged visibility bullet updated to reference this (immediate for Explorer; 5-turn for Spy).

### 2. TDD (SPEC/program/fog-and-exploration-resolution.md) — Exploration formula
- Exploration turns formula now explicitly states that `maxTilesInAnyProvinceInRegion` is the maximum tile count in any province **in the same region** as the Explorer's province, aligning with implementation and GDD.

Made with [Cursor](https://cursor.com)