### PR TITLE
Combat resolution: GDD strength formula gaps doc + test province id (Fixes #229)

### DIFF
--- a/SPEC/game/combat.md
+++ b/SPEC/game/combat.md
@@ -16,9 +16,9 @@ Auto-resolved combat triggers when units move into enemy-controlled provinces. B
 
 **Multi-Attacker Chain:** Sort attackers by initiative descending (tie-break: faction id). Resolve sequentially: defender vs highest-initiative attacker; winner (no heal) vs next attacker; repeat until no attackers remain or defender eliminated.
 
-**Strength:** Per-regiment FPN + FPM (from [military-units.md](military-units.md)). Medals (0–4) multiply by 1.0–1.4. DEF durability = DEF / 9. Damaged units: firepower ∝ remaining / starting health. Side strength = `Σ (FPN_eff + FPM_eff) × medalMult`, adjusted by modifiers.
+**Strength:** Per-regiment FPN + FPM (from [military-units.md](military-units.md)). Medals (0–4) multiply by 1.0–1.4. DEF durability = DEF / 9. Damaged units: firepower ∝ remaining / starting health. Side strength = `Σ (FPN_eff + FPM_eff) × medalMult`, adjusted by modifiers. **Current auto-resolve:** Strength aggregation uses (FPN + FPM) × medalMult only; DEF/9 and damaged-unit health scaling are deferred (no unit health field; casualty selection uses strength-weighted choice).
 
-**Modifiers:** Terrain (province type), fort (level 0–3; damage reduction + emplaced guns per [siege-mechanics.md](siege-mechanics.md)), difficulty (scales attacker/defender), general (+1 deployment per medal + initiative contribution), feeding coverage (see table below).
+**Modifiers:** Terrain (province type), fort (level 0–3; damage reduction + emplaced guns per [siege-mechanics.md](siege-mechanics.md)), difficulty (scales attacker/defender; deferred in auto-resolve until difficulty is wired from game config), general (+1 deployment per medal + initiative contribution), feeding coverage (see table below).
 
 **Resolution:** Compare total attacker vs defender strength after modifiers. Deterministic output: winner + casualties per side.
 

--- a/SPEC/program/combat-resolution.md
+++ b/SPEC/program/combat-resolution.md
@@ -41,12 +41,12 @@ Steps:
 1. Aggregate strength per side per game/combat.md § Rules (Strength).
 2. For Minor Nation / Tribe defenders, apply effective military level per [factions.md](../game/factions.md).
 3. Apply siege modifiers if fort present per [siege-mechanics.md](../game/siege-mechanics.md).
-4. Apply terrain, difficulty, general, and feeding modifiers per game/combat.md § Rules (Modifiers). **General morale aura** (bonus scaling with general medals) is deferred until general/medal state is modelled.
+4. Apply terrain, difficulty, general, and feeding modifiers per game/combat.md § Rules (Modifiers). **General morale aura** (bonus scaling with general medals) is deferred until general/medal state is modelled. **Difficulty** is not yet passed into the resolver; when game/config provides difficulty, apply it in this step. **Strength aggregation** (step 1): currently (FPN + FPM) × medalMult per unit only; DEF/9 and damaged-unit health scaling are deferred per GDD.
 5. Compute winner and casualties. Pure function; no side effects.
 
 **Output:** EngagementResult.
 
-**Deferred:** General medals are not yet read from game state (conflict detection passes 0); initiative still uses cavalry share. When general/medal state exists, populate `AttackingSide.generalMedals` in conflict detection and apply general morale aura in step 4.
+**Deferred:** General medals are not yet read from game state (conflict detection passes 0); initiative still uses cavalry share. When general/medal state exists, populate `AttackingSide.generalMedals` in conflict detection and apply general morale aura in step 4. DEF/9 in strength/casualties and unit health scaling are deferred. Difficulty is not wired from game config into the resolver.
 
 ### 5. Resolution Chain
 

--- a/packages/colonizethis_logic/test/conflict_detection_test.dart
+++ b/packages/colonizethis_logic/test/conflict_detection_test.dart
@@ -227,7 +227,7 @@ void main() {
       final orders = Orders(
         moveOrdersByPlayerId: {
           'player1': [
-            MoveOrder(unitId: 'u1', destinationProvinceId: 'P1'),
+            MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P1'),
           ],
         },
       );


### PR DESCRIPTION
Fixes #229

## Summary

Aligns GDD/TDD with current combat implementation and fixes one test to use full province id.

### 1. GDD (SPEC/game/combat.md)
- **Strength:** Document current auto-resolve scope: strength = (FPN + FPM) × medalMult only; DEF/9 and damaged-unit health scaling deferred (no unit health field; casualty selection remains strength-weighted).
- **Modifiers:** Note that difficulty is deferred until wired from game config.

### 2. TDD (SPEC/program/combat-resolution.md)
- Step 4: Clarify that difficulty is not yet passed into the resolver; strength aggregation (step 1) uses (FPN+FPM)×medalMult only; DEF/9 and health scaling deferred.
- Deferred: Add DEF/9, unit health scaling, and difficulty not wired.

### 3. Test (conflict_detection_test.dart)
- **civilians alone do not trigger battles:** Use full province id `$ow|P1` in `MoveOrder.destinationProvinceId` per SPEC/game/world-model-identity.md (order fields use prefixed `regionId|localId`).

No implementation changes to the resolver; spec and test only.

Made with [Cursor](https://cursor.com)