### PR TITLE
build_port and ship build: sea zone lookup uses full province id (Fixes #232)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -94,7 +94,7 @@ Game applyBuildAndWorkOrders(
           final regionIdFromTile = parts.isNotEmpty ? parts[0] : ProvinceId.regionIdFrom(u.locationProvinceId);
           final localId = parts.length > 1 ? parts[1] : ProvinceId.localIdFrom(u.locationProvinceId);
           final fullProvinceId = ProvinceId.full(regionIdFromTile, localId);
-          final seaZoneId = seaZoneIdForProvince(topology, localId);
+          final seaZoneId = seaZoneIdForProvince(topology, localId, regionId: regionIdFromTile);
           if (seaZoneId != null) {
             portsByProvinceSeaboard['$fullProvinceId|$seaZoneId'] = cw.tileKey;
             tileState = tileState.setRoadLevel(cw.tileKey, 4);
@@ -279,7 +279,7 @@ Game applyBuildAndWorkOrders(
 
         final regionId = ProvinceId.regionIdFrom(capProvinceId);
         final seaZoneId = topology != null
-            ? seaZoneIdForProvince(topology, ProvinceId.localIdFrom(capProvinceId))
+            ? seaZoneIdForProvince(topology, ProvinceId.localIdFrom(capProvinceId), regionId: regionId)
             : null;
         if (seaZoneId == null) continue;
 

--- a/packages/colonizethis_logic/lib/src/world/naval.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval.dart
@@ -29,8 +29,29 @@ String? firstAdjacentSeaZone(MapTopology topology, String seaZoneId) {
   return null;
 }
 
-/// First sea zone id adjacent to [provinceId], or null if none. Used for home fleet location.
-String? seaZoneIdForProvince(MapTopology topology, String provinceId) {
+/// First sea zone id adjacent to [provinceId], or null if none. Used for home fleet and build_port.
+///
+/// [provinceId] is the local province id (e.g. p1). When [regionId] is provided, lookup is
+/// region-scoped per SPEC/game/world-model-identity.md (required for multi-region world).
+/// When [regionId] is null, uses first matching node (single-region or legacy).
+String? seaZoneIdForProvince(MapTopology topology, String provinceId, {String? regionId}) {
+  if (regionId != null) {
+    final nodesByRegionAndId = <String, Map<String, TopologyNode>>{};
+    for (final n in topology.nodes) {
+      nodesByRegionAndId.putIfAbsent(n.regionId, () => {})[n.id] = n;
+    }
+    final regionNodes = nodesByRegionAndId[regionId];
+    if (regionNodes == null) return null;
+    final provinceNode = regionNodes[provinceId];
+    if (provinceNode == null || provinceNode.type != TopologyNodeType.province) return null;
+    for (final e in topology.edges) {
+      if (e.id1 != provinceId && e.id2 != provinceId) continue;
+      final other = e.id1 == provinceId ? e.id2 : e.id1;
+      final otherNode = regionNodes[other];
+      if (otherNode?.type == TopologyNodeType.seaZone) return other;
+    }
+    return null;
+  }
   final nodesById = {for (final n in topology.nodes) n.id: n};
   for (final e in topology.edges) {
     if (e.id1 != provinceId && e.id2 != provinceId) continue;

--- a/packages/colonizethis_logic/test/naval_test.dart
+++ b/packages/colonizethis_logic/test/naval_test.dart
@@ -49,6 +49,24 @@ void main() {
         expect(seaZoneIdForProvince(topology, 'p2'), 'sea1');
       });
 
+      test('when regionId is provided, lookup is region-scoped (world-model-identity)', () {
+        final multiRegion = MapTopology(
+          nodes: const [
+            TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+            TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+            TopologyNode(id: 'p1', regionId: 'newWorld', type: TopologyNodeType.province),
+            TopologyNode(id: 'sea2', regionId: 'newWorld', type: TopologyNodeType.seaZone),
+          ],
+          edges: const [
+            TopologyEdge(id1: 'p1', id2: 'sea1'),
+            TopologyEdge(id1: 'p1', id2: 'sea2'),
+          ],
+        );
+        expect(seaZoneIdForProvince(multiRegion, 'p1', regionId: 'oldWorld'), 'sea1');
+        expect(seaZoneIdForProvince(multiRegion, 'p1', regionId: 'newWorld'), 'sea2');
+        expect(seaZoneIdForProvince(multiRegion, 'p1'), isNotNull);
+      });
+
       test('returns null for province with no sea edge', () {
         final inland = MapTopology(
           nodes: const [


### PR DESCRIPTION
Fixes #232

**Summary**
Development resolution (build_port completion and naval ship build home-fleet placement) was resolving sea zone by local province id only. In a multi-region world the same local id can exist in more than one region, so lookup must be region-scoped per SPEC/game/world-model-identity.md.

**Changes**
- `seaZoneIdForProvince` (naval.dart): added optional `regionId`; when set, lookup is region-scoped (only province and sea nodes in that region).
- `orders_application.dart`: build_port completion and ship build (home fleet) now pass `regionId` when calling `seaZoneIdForProvince`.
- `naval_test.dart`: added test for multi-region topology (same local id `p1` in oldWorld and newWorld with different sea zones; assert region-scoped lookup returns the correct sea zone per region).

**Refs:** SPEC/game/world-model-identity.md

Made with [Cursor](https://cursor.com)