### PR TITLE
Movement: region-scoped topology adjacency (Fixes #238)

### DIFF
--- a/SPEC/program/map-data.md
+++ b/SPEC/program/map-data.md
@@ -22,7 +22,7 @@ Define topology format, tile map data structures, province identity, and tile ke
 
 ## Province identity and tile key format
 
-- **Province ids:** Topology and tile maps use **local** ids (e.g. `p1`, `p2`). Game state uses **prefixed** ids (`regionId|localId`). Always resolve by regionId + provinceId; never by province id alone. See [world-model.md](../game/world-model.md).
+- **Province ids:** Topology and tile maps use **local** ids (e.g. `p1`, `p2`). Game state uses **prefixed** ids (`regionId|localId`). Local ids are **not** globally unique across regions (e.g. `p1` can exist in oldWorld and newWorld). Movement and other topology queries (e.g. adjacency, connectivity) must scope by **region** when duplicate local ids exist. Always resolve by regionId + provinceId; never by province id alone. See [world-model.md](../game/world-model.md), [world-model-identity.md](../game/world-model-identity.md).
 - **Tile key format:** `regionId|provinceId|x|y` for mutable game state (extraction, transport, ports). Map visualizers must convert local ids to full province ids before querying ownership.
 
 ---

--- a/SPEC/program/movement.md
+++ b/SPEC/program/movement.md
@@ -16,6 +16,8 @@
 
 **Valid destination:** a province that is **adjacent** to the unit's current province in the **map topology**. Topology (nodes = provinces and sea zones; edges = P–P, P–S) is loaded from **colonizethis_data**. TurnResolver and order validation use the same graph. Armies move only along P–P edges (province to province).
 
+**Multi-region / duplicate local ids:** When topology contains multiple regions, local province ids are not globally unique (e.g. `p1` may exist in both oldWorld and newWorld). Adjacency for land movement is **region-scoped**: neighbors are computed only among nodes in the **same region** as the unit. Use `neighborProvinceIdsInRegion(topology, regionId, localProvinceId)` and `isValidLandMoveInRegion(topology, regionId, fromLocal, toLocal)` so moves are validated and applied per region. See [world-model-identity.md](../game/world-model-identity.md).
+
 ---
 
 ## Validation

--- a/packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
+++ b/packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
@@ -6,6 +6,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../world/movement.dart';
 import 'evidence_rules.dart';
 
 const String _eraDefault = 'earlyModern';
@@ -109,18 +110,7 @@ List<DialogueEvent> dialogueEventsForNavalBattleResult(
 
 /// Neighbor province local ids in [regionId] that share an edge with [localId]. Province nodes only.
 List<String> neighborProvinceLocalIds(MapTopology topology, String regionId, String localId) {
-  final nodesInRegion = topology.nodes
-      .where((n) => n.regionId == regionId && n.type == TopologyNodeType.province)
-      .toList();
-  if (nodesInRegion.any((n) => n.id == localId) == false) return [];
-  final neighborIds = <String>{};
-  for (final edge in topology.edges) {
-    final other = edge.id1 == localId ? edge.id2 : (edge.id2 == localId ? edge.id1 : null);
-    if (other == null) continue;
-    final otherNode = nodesInRegion.where((n) => n.id == other).firstOrNull;
-    if (otherNode != null) neighborIds.add(other);
-  }
-  return neighborIds.toList();
+  return neighborProvinceIdsInRegion(topology, regionId, localId).toList();
 }
 
 String? _ownerOfProvince(Game game, String fullProvinceId) {

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -240,9 +240,14 @@ class OrderEngine {
       final unitRegion = unit.tileKey != null && unit.tileKey!.isNotEmpty
           ? Unit.requireRegionIdFromTileKey(unit.tileKey)
           : ProvinceId.regionIdFrom(resolveToFullProvinceId(game.worldState, unit.provinceId));
+      final destFullId = resolveToFullProvinceId(game.worldState, o.destinationProvinceId);
+      final destRegion = ProvinceId.regionIdFrom(destFullId);
+      if (destRegion != unitRegion) {
+        return const OrderValidationResult(status: OrderValidationStatus.rejected, reason: 'Invalid move');
+      }
       final unitLocalId = ProvinceId.localIdFrom(unit.locationProvinceId);
-      final destLocalId = ProvinceId.localIdFrom(o.destinationProvinceId);
-      if (!isValidLandMove(topology, unitLocalId, destLocalId)) {
+      final destLocalId = ProvinceId.localIdFrom(destFullId);
+      if (!isValidLandMoveInRegion(topology, unitRegion, unitLocalId, destLocalId)) {
         return const OrderValidationResult(status: OrderValidationStatus.rejected, reason: 'Invalid move');
       }
       final destProvince = tryGetProvince(game.worldState, o.destinationProvinceId);

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
 
 import '../diplomacy/diplomacy_resolver.dart';
+import '../world/movement.dart';
 import '../world/naval.dart';
 import 'order_engine.dart';
 import 'order_visibility.dart';
@@ -59,27 +60,9 @@ List<MoveOrder> suggestMoveOrders(
       );
     }
 
-    // Enumerate neighboring provinces via topology (neighbors use local ids in same region).
-    for (final edge in topology.edges) {
-      String? neighborLocalId;
-      if (edge.id1 == fromLocalId) {
-        neighborLocalId = edge.id2;
-      } else if (edge.id2 == fromLocalId) {
-        neighborLocalId = edge.id1;
-      }
-      if (neighborLocalId == null) continue;
-
-      // Only consider neighbors that are provinces.
-      final neighborNode = topology.nodes.firstWhere(
-        (n) => n.id == neighborLocalId,
-        orElse: () => const TopologyNode(
-          id: '',
-          regionId: '',
-          type: TopologyNodeType.seaZone,
-        ),
-      );
-      if (neighborNode.type != TopologyNodeType.province) continue;
-
+    // Enumerate neighboring provinces in unit's region (region-scoped adjacency).
+    for (final neighborLocalId
+        in neighborProvinceIdsInRegion(topology, unitRegion, fromLocalId)) {
       final destinationProvinceId = ProvinceId.full(unitRegion, neighborLocalId);
 
       // Skip duplicates for this unit.

--- a/packages/colonizethis_logic/lib/src/world/movement.dart
+++ b/packages/colonizethis_logic/lib/src/world/movement.dart
@@ -3,50 +3,65 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 /// Movement validation and application.
 /// SPEC/program/movement.md
+/// Adjacency is region-scoped when topology has multiple regions (SPEC/game/world-model-identity.md).
 
-/// Computes neighboring province ids (excluding sea zones) for [provinceId].
-Iterable<String> _neighborProvinceIds(
+/// Province local ids in [regionId] that are adjacent to [localProvinceId] (P–P only).
+/// Use this when topology may have duplicate local ids across regions.
+Iterable<String> neighborProvinceIdsInRegion(
   MapTopology topology,
-  String provinceId,
+  String regionId,
+  String localProvinceId,
 ) sync* {
+  final provinceIdsInRegion = topology.nodes
+      .where((n) =>
+          n.regionId == regionId && n.type == TopologyNodeType.province)
+      .map((n) => n.id)
+      .toSet();
+  if (!provinceIdsInRegion.contains(localProvinceId)) return;
   for (final edge in topology.edges) {
-    if (edge.id1 == provinceId) {
-      final node = topology.nodes.firstWhere(
-        (n) => n.id == edge.id2,
-        orElse: () => TopologyNode(
-          id: edge.id2,
-          regionId: '',
-          type: TopologyNodeType.seaZone,
-        ),
-      );
-      if (node.type == TopologyNodeType.province) {
-        yield node.id;
-      }
-    } else if (edge.id2 == provinceId) {
-      final node = topology.nodes.firstWhere(
-        (n) => n.id == edge.id1,
-        orElse: () => TopologyNode(
-          id: edge.id1,
-          regionId: '',
-          type: TopologyNodeType.seaZone,
-        ),
-      );
-      if (node.type == TopologyNodeType.province) {
-        yield node.id;
-      }
-    }
+    if (edge.id1 != localProvinceId && edge.id2 != localProvinceId) continue;
+    final other = edge.id1 == localProvinceId ? edge.id2 : edge.id1;
+    if (provinceIdsInRegion.contains(other)) yield other;
   }
 }
 
+/// Validates whether a land move from [fromLocal] to [toLocal] is allowed within [regionId].
+/// Use when topology has multiple regions or duplicate local ids (SPEC/game/world-model-identity.md).
+bool isValidLandMoveInRegion(
+  MapTopology topology,
+  String regionId,
+  String fromLocal,
+  String toLocal,
+) {
+  if (fromLocal == toLocal) return false;
+  return neighborProvinceIdsInRegion(topology, regionId, fromLocal)
+      .contains(toLocal);
+}
+
 /// Validates whether a move from [fromProvinceId] to [toProvinceId] is allowed
-/// for a land unit using [topology].
+/// for a land unit using [topology]. Prefer [isValidLandMoveInRegion] when
+/// [regionId] is known (required when topology has duplicate local ids across regions).
 bool isValidLandMove(
   MapTopology topology,
   String fromProvinceId,
   String toProvinceId,
 ) {
   if (fromProvinceId == toProvinceId) return false;
-  return _neighborProvinceIds(topology, fromProvinceId).contains(toProvinceId);
+  final fromNodes = topology.nodes
+      .where((n) =>
+          n.id == fromProvinceId && n.type == TopologyNodeType.province)
+      .toList();
+  if (fromNodes.isEmpty) return false;
+  if (fromNodes.length > 1) {
+    // Duplicate local id across regions; cannot decide without regionId.
+    return false;
+  }
+  return isValidLandMoveInRegion(
+    topology,
+    fromNodes.single.regionId,
+    fromProvinceId,
+    toProvinceId,
+  );
 }
 
 /// Applies all MoveOrders in [orders] to the units in [regionData], returning
@@ -77,10 +92,17 @@ RegionData applyMoveOrdersToRegion(
       if (unit == null || unit.ownerId != playerId) continue;
       final currentProvinceId = unit.locationProvinceId;
       final destProvinceId = order.destinationProvinceId;
-      // Topology uses local province ids; validate using them.
+      if (regionId != null && ProvinceId.isPrefixed(destProvinceId) &&
+          ProvinceId.regionIdFrom(destProvinceId) != regionId) {
+        continue; // Land move cannot cross regions.
+      }
+      // Topology uses local province ids; validate using region-scoped adjacency when region known.
       final fromLocal = ProvinceId.localIdFrom(currentProvinceId);
       final toLocal = ProvinceId.localIdFrom(destProvinceId);
-      if (!isValidLandMove(topology, fromLocal, toLocal)) {
+      final valid = regionId != null
+          ? isValidLandMoveInRegion(topology, regionId!, fromLocal, toLocal)
+          : isValidLandMove(topology, fromLocal, toLocal);
+      if (!valid) {
         continue;
       }
       final isCivilian = unit.tileKey != null && unit.tileKey!.isNotEmpty;

--- a/packages/colonizethis_logic/test/movement_test.dart
+++ b/packages/colonizethis_logic/test/movement_test.dart
@@ -4,6 +4,33 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
 void main() {
+  group('neighborProvinceIdsInRegion and isValidLandMoveInRegion', () {
+    test('duplicate local ids across regions: neighbors are region-scoped', () {
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 'p2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 'p1', regionId: 'newWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 'p2', regionId: 'newWorld', type: TopologyNodeType.province),
+        ],
+        edges: const [
+          TopologyEdge(id1: 'p1', id2: 'p2'), // same local ids in both regions
+        ],
+      );
+      expect(
+        neighborProvinceIdsInRegion(topology, 'oldWorld', 'p1').toList(),
+        ['p2'],
+      );
+      expect(
+        neighborProvinceIdsInRegion(topology, 'newWorld', 'p1').toList(),
+        ['p2'],
+      );
+      expect(isValidLandMoveInRegion(topology, 'oldWorld', 'p1', 'p2'), isTrue);
+      expect(isValidLandMoveInRegion(topology, 'newWorld', 'p1', 'p2'), isTrue);
+      expect(isValidLandMove(topology, 'p1', 'p2'), isFalse); // ambiguous: two nodes p1
+    });
+  });
+
   group('isValidLandMove', () {
     test('allows move to adjacent land province', () {
       final topology = MapTopology(


### PR DESCRIPTION
Fixes #238

When topology has multiple regions and the same local province id (e.g. `p1`) exists in both oldWorld and newWorld, movement validation and resolution previously used adjacency by local id only, which could mix regions and allow or reject moves incorrectly.

**Changes:**
- **movement.dart:** Added `neighborProvinceIdsInRegion(topology, regionId, localProvinceId)` and `isValidLandMoveInRegion(topology, regionId, fromLocal, toLocal)` so neighbors are computed only among nodes in the same region. `isValidLandMove` (no region) returns false when multiple nodes share the same local id (ambiguous). `applyMoveOrdersToRegion` uses region-scoped validation when `regionId` is provided and skips moves whose destination is in a different region.
- **order_engine.dart:** Move validation uses `isValidLandMoveInRegion` with the unit's region and rejects when destination region differs from unit region.
- **order_suggestion.dart** and **event_dialogue.dart:** Use `neighborProvinceIdsInRegion` from movement for region-scoped neighbor enumeration.
- **SPEC/program/movement.md** and **map-data.md:** Document that adjacency is region-scoped when duplicate local ids exist and that movement/topology queries must scope by region.
- **movement_test.dart:** Test for duplicate local ids across regions (`neighborProvinceIdsInRegion`, `isValidLandMoveInRegion`, `isValidLandMove` ambiguous).

Ref: SPEC/game/world-model-identity.md

Made with [Cursor](https://cursor.com)