### PR TITLE
Fix #243: _applyFogDecay use full province id for Explorer/Spy presence

### DIFF
--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -417,21 +417,20 @@ Map<String, Map<String, String>> _applyFogDecay(Game game) {
     for (final p in game.worldState.newWorld.provinces) p.id: p.ownerId,
   };
 
+  // Use full province id (regionId|localId) per SPEC/game/world-model-identity.md.
   final provincesWithExplorerByPlayer = <String, Set<String>>{};
   for (final u in game.worldState.oldWorld.units) {
     if (explorerTypes.contains(u.type.toLowerCase())) {
-      final localId = ProvinceId.localIdFrom(u.locationProvinceId);
       provincesWithExplorerByPlayer
           .putIfAbsent(u.ownerId, () => <String>{})
-          .add(localId);
+          .add(u.locationProvinceId);
     }
   }
   for (final u in game.worldState.newWorld.units) {
     if (explorerTypes.contains(u.type.toLowerCase())) {
-      final localId = ProvinceId.localIdFrom(u.locationProvinceId);
       provincesWithExplorerByPlayer
           .putIfAbsent(u.ownerId, () => <String>{})
-          .add(localId);
+          .add(u.locationProvinceId);
     }
   }
 
@@ -447,7 +446,7 @@ Map<String, Map<String, String>> _applyFogDecay(Game game) {
       final fullProvinceId = ProvinceId.full(parts[0], parts[1]);
       final ownerId = owOwnerByProvince[fullProvinceId] ?? nwOwnerByProvince[fullProvinceId];
       if (ownerId == null || ownerId == playerId) continue;
-      if (!hasExplorerIn.contains(parts[1])) {
+      if (!hasExplorerIn.contains(fullProvinceId)) {
         visibility[tileKey] = VisibilityLevel.fogged.name;
       }
     }

--- a/packages/colonizethis_logic/test/turn_resolver_test.dart
+++ b/packages/colonizethis_logic/test/turn_resolver_test.dart
@@ -1399,5 +1399,73 @@ void main() {
       );
       expect(next.worldState.playerVisibilityByTile['p1']?[tileKeyP2], VisibilityLevel.fullyVisible.name);
     });
+
+    test('endOfTurn fog decay uses full province id: same local id in two regions', () {
+      const ow = 'oldWorld';
+      const nw = 'newWorld';
+      const tileKeyOwP1 = 'oldWorld|P1|0|0';
+      const tileKeyNwP1 = 'newWorld|P1|0|0';
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p2'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+            ],
+            units: [
+              Unit(
+                id: 'explorer1',
+                type: 'Explorer',
+                ownerId: 'p1',
+                provinceId: '$ow|P1',
+              ),
+            ],
+          ),
+          newWorld: RegionData(
+            provinces: [Province(id: '$nw|P1', regionId: nw, ownerId: 'p2')],
+            units: [],
+          ),
+          playerVisibilityByTile: {
+            'p1': {
+              tileKeyOwP1: VisibilityLevel.fullyVisible.name,
+              tileKeyNwP1: VisibilityLevel.fullyVisible.name,
+            },
+            'p2': {},
+          },
+          tileKeysByRegionAndProvince: {
+            ow: {'P1': [tileKeyOwP1], 'P2': ['oldWorld|P2|0|0']},
+            nw: {'P1': [tileKeyNwP1]},
+          },
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+          Player(id: 'p2', displayName: 'P2', isHuman: false),
+        ],
+      );
+      final next = resolveTurnForGame(
+        game: game,
+        topology: MapTopology(
+          nodes: const [
+            TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
+            TopologyNode(id: 'P2', regionId: ow, type: TopologyNodeType.province),
+            TopologyNode(id: 'P1', regionId: nw, type: TopologyNodeType.province),
+          ],
+          edges: const [],
+        ),
+        orders: const Orders(),
+      );
+      expect(
+        next.worldState.playerVisibilityByTile['p1']?[tileKeyOwP1],
+        VisibilityLevel.fullyVisible.name,
+        reason: 'Explorer in oldWorld|P1 keeps that province visible',
+      );
+      expect(
+        next.worldState.playerVisibilityByTile['p1']?[tileKeyNwP1],
+        VisibilityLevel.fogged.name,
+        reason: 'No Explorer in newWorld|P1; must fog (full province id, not local)',
+      );
+    });
   });
 }


### PR DESCRIPTION
Fixes #243

**Summary**
- `_applyFogDecay` was using **local** province id to record and check Explorer/Spy presence. In a multi-region world the same local id can exist in more than one region (e.g. `P1` in oldWorld and newWorld), so an Explorer in `oldWorld|P1` incorrectly prevented fog decay in `newWorld|P1`.
- Per **SPEC/game/world-model-identity.md**, province lookup must use full province id (`regionId|localId`). This change stores and compares full province ids in the Explorer/Spy presence set and when deciding whether to apply fog decay.

**Changes**
- `turn_resolver.dart`: build `provincesWithExplorerByPlayer` with `u.locationProvinceId` (full id) instead of `ProvinceId.localIdFrom(...)`; when applying decay, check `hasExplorerIn.contains(fullProvinceId)` instead of `parts[1]`.
- `turn_resolver_test.dart`: add test `endOfTurn fog decay uses full province id: same local id in two regions` — Explorer in `oldWorld|P1` only keeps that province visible and correctly fogs `newWorld|P1`.

Made with [Cursor](https://cursor.com)