### PR TITLE
sim-combat-montecarlo: define required battle keys and validate (Fixes #251)

### DIFF
--- a/SPEC/program/sim-combat-montecarlo.md
+++ b/SPEC/program/sim-combat-montecarlo.md
@@ -13,8 +13,15 @@
 
 ## Script Format and Validation
 
-- Script format is the same as [sim-combat.md](sim-combat.md): `metadata`, `battles` array; each battle has `id`, `attacker`, `defender`, `province`, and optional `defenderFaction`. Attacker and defender each have `units` and optional `generalMedals`.
-- **Validation:** As in sim-combat, validation errors abort the run with non-zero exit and a clear error message. Invalid inputs: unknown unit type (not in regiment catalog), fortLevel outside 0–3, malformed script (e.g. missing required keys or wrong types).
+- Script format is the same as [sim-combat.md](sim-combat.md): top-level `metadata` (optional string), `battles` (required array of battle objects).
+- **Per-battle required keys:** Each battle object **must** have:
+  - `id`: string (battle identifier).
+  - `attacker`: object (may be empty `{}`; may contain `units` array and optional `generalMedals` int).
+  - `defender`: object (same structure as attacker).
+  - `province`: object (may contain `fortLevel` 0–3, `terrain` string; see defaults below).
+- **Optional:** `defenderFaction` (accepted for script parity; not used for resolver level in this tool).
+- **Defaults when optional fields are missing:** Within `attacker`/`defender`: `units` defaults to `[]`, `generalMedals` to 0. Within `province`: `fortLevel` defaults to 0, `terrain` to `plains`. Unit objects default `type` to `peasant_levies`, `medals` to 0.
+- **Validation:** Validation errors abort the run with non-zero exit and a clear error message. Invalid inputs: missing or wrong-type required battle key (`id`, `attacker`, `defender`, `province`), unknown unit type (not in regiment catalog), fortLevel outside 0–3, or other malformed script (e.g. battle not an object, `battles` not an array).
 
 ---
 

--- a/SPEC/program/sim-combat.md
+++ b/SPEC/program/sim-combat.md
@@ -32,13 +32,13 @@ Top-level keys:
 - `metadata`: scenario name.
 - `battles`: array of battle objects.
 
-Each battle object:
+Each battle object (required keys: `id`, `attacker`, `defender`, `province`; missing or wrong type = validation error):
 
 - `id`: string identifier.
 - `attacker`: `{ "units": [ { "type": string, "medals": int } ], "generalMedals": int (optional) }`.
 - `defender`: same structure. `type` must match regiment ids from [military-units.md](../game/military-units.md).
 - `province`: `{ "fortLevel": 0|1|2|3, "terrain": string }` (terrain from config: e.g. plains, mountain, forest).
-- `defenderFaction`: `"greatPower" | "minorNation" | "tribe"` for parity rules.
+- `defenderFaction`: optional; `"greatPower" | "minorNation" | "tribe"` for parity rules.
 
 ---
 

--- a/tool/sim_combat_montecarlo/bin/sim_combat_montecarlo.dart
+++ b/tool/sim_combat_montecarlo/bin/sim_combat_montecarlo.dart
@@ -108,10 +108,11 @@ void main(List<String> arguments) {
       _errExit('logic: sim_combat_montecarlo: battle $idx must be an object');
     }
     final b = Map<String, dynamic>.from(entry as Map);
-    final id = b['id'] as String? ?? 'battle_$idx';
-    final attackerRaw = b['attacker'] as Map<String, dynamic>? ?? {};
-    final defenderRaw = b['defender'] as Map<String, dynamic>? ?? {};
-    final provinceRaw = b['province'] as Map<String, dynamic>? ?? {};
+    _validateBattleKeys(b, idx);
+    final id = b['id'] as String;
+    final attackerRaw = b['attacker'] as Map<String, dynamic>;
+    final defenderRaw = b['defender'] as Map<String, dynamic>;
+    final provinceRaw = b['province'] as Map<String, dynamic>;
     final attackerGeneralMedals = (attackerRaw['generalMedals'] as int?) ?? 0;
     // Defender generalMedals parsed for script format parity; resolver uses attacker's only.
 
@@ -199,6 +200,34 @@ void main(List<String> arguments) {
   if (jsonOutputPath != null && jsonOutputPath.isNotEmpty) {
     File(jsonOutputPath).writeAsStringSync(jsonEncode(aggregatedResults));
     _log.i('logic: sim_combat_montecarlo: wrote JSON log to ${File(jsonOutputPath).absolute.path}');
+  }
+}
+
+/// Validates required battle keys per SPEC/program/sim-combat-montecarlo.md.
+void _validateBattleKeys(Map<String, dynamic> b, int idx) {
+  final idVal = b['id'];
+  if (idVal == null || idVal is! String) {
+    _errExit(
+      'logic: sim_combat_montecarlo: battle $idx: required key "id" missing or not a string',
+    );
+  }
+  final att = b['attacker'];
+  if (att == null || att is! Map) {
+    _errExit(
+      'logic: sim_combat_montecarlo: battle $idx: required key "attacker" missing or not an object',
+    );
+  }
+  final def = b['defender'];
+  if (def == null || def is! Map) {
+    _errExit(
+      'logic: sim_combat_montecarlo: battle $idx: required key "defender" missing or not an object',
+    );
+  }
+  final prov = b['province'];
+  if (prov == null || prov is! Map) {
+    _errExit(
+      'logic: sim_combat_montecarlo: battle $idx: required key "province" missing or not an object',
+    );
   }
 }
 

--- a/tool/sim_combat_montecarlo/test/fixtures/malformed_battle.json
+++ b/tool/sim_combat_montecarlo/test/fixtures/malformed_battle.json
@@ -1,0 +1,1 @@
+{"metadata":"Malformed battle","battles":[{}]}

--- a/tool/sim_combat_montecarlo/test/sim_combat_montecarlo_test.dart
+++ b/tool/sim_combat_montecarlo/test/sim_combat_montecarlo_test.dart
@@ -160,5 +160,29 @@ void main() {
       final out = result.stdout.toString() + result.stderr.toString();
       expect(out, contains('fortLevel'));
     });
+
+    test('CLI aborts with non-zero exit on malformed battle (missing required keys)',
+        () async {
+      final cwd = Directory.current.path;
+      final scriptPath =
+          p.join(cwd, 'test', 'fixtures', 'malformed_battle.json');
+      final binPath = p.join(cwd, 'bin', 'sim_combat_montecarlo.dart');
+      final result = await Process.run(
+        Platform.executable,
+        [
+          'run',
+          binPath,
+          '--script',
+          scriptPath,
+          '--trials',
+          '10',
+        ],
+        runInShell: false,
+        workingDirectory: cwd,
+      );
+      expect(result.exitCode, isNot(0));
+      final out = result.stdout.toString() + result.stderr.toString();
+      expect(out, contains('required key'));
+    });
   });
 }


### PR DESCRIPTION
Fixes #251

- **Spec:** SPEC/program/sim-combat-montecarlo.md now defines required per-battle keys (`id`, `attacker`, `defender`, `province`), optional keys and defaults, and states that missing/wrong-type required keys cause validation error and abort. SPEC/program/sim-combat.md updated to state required keys and validation behaviour.
- **Implementation:** tool/sim_combat_montecarlo validates each battle object has required keys with correct types; aborts with a clear message (e.g. `required key "id" missing or not a string`) instead of defaulting.
- **Test:** New fixture `malformed_battle.json` (battles: [{}]) and test that CLI aborts with non-zero exit and message containing "required key".

Aligns spec and implementation so "malformed script" is unambiguous.

Made with [Cursor](https://cursor.com)