### PR TITLE
Align SPEC and code for kDebugMapScale (0.25)

### DIFF
--- a/SPEC/program/ctdev-app-init-map.md
+++ b/SPEC/program/ctdev-app-init-map.md
@@ -21,7 +21,7 @@ On submit: validate constraints; call `runInitGame(config, options)` with fixed 
 
 **Input:** `InitGameMapViewData` plus optional seed/config summary.
 
-**Layout:** OW and NW regions side by side. `CustomPainter` over `RegionMapViewData`, `InteractiveViewer` for pan/zoom. `kDebugMapScale` 1.0.
+**Layout:** OW and NW regions side by side. `CustomPainter` over `RegionMapViewData`, `InteractiveViewer` for pan/zoom. `kDebugMapScale` 0.25 (fits both regions in view; zoom min 0.25).
 
 **Overlays:** Ownership (GP/Tribes vibrant, Minor Nations grey); legend as `displayName (factionId)`; province/sea borders; capitals (gold circles), ports (teal squares). Geographic view: terrain palette, resource glyphs (g, t, i, etc.) at tile centres; compact glyph reference and per-region counts (OW/NW). Per-cell inspection: tap/hover shows region, tile coords, Province, owner, terrain, resource; capital tiles show "Capital of [faction]." Toggleable layers: ownership, borders, capitals, ports, on-tile labels.
 

--- a/SPEC/program/ctdev-app.md
+++ b/SPEC/program/ctdev-app.md
@@ -32,7 +32,7 @@
 ## Common Patterns
 
 - **Loading state:** Init-game and sim runs wrap work in a busy overlay; submit/controls disabled during resolution.
-- **Map rendering:** `CustomPainter` over `RegionMapViewData`, `InteractiveViewer` for pan/zoom; `kDebugMapScale` 1.0; ownership from `greatPowerColorOverride` when present.
+- **Map rendering:** `CustomPainter` over `RegionMapViewData`, `InteractiveViewer` for pan/zoom; `kDebugMapScale` 0.25 (default so both regions fit side-by-side; zoom min 0.25); ownership from `greatPowerColorOverride` when present.
 - **Data source:** All screens read from `InitGameResult`, loaded `Game`, or `SimGameController.game` / `SimGameController.pendingOrdersByPlayerId`.
 
 ---

--- a/ctdev/lib/debug_map_painter.dart
+++ b/ctdev/lib/debug_map_painter.dart
@@ -5,8 +5,7 @@ import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:flutter/material.dart';
 
 /// Visual scale factor applied to logical cellSize from RegionMapViewData.
-/// Keeps tiles readable while fitting more of the map in a typical viewport.
-/// In ctdev, we default this to 1.0 so tiles are easy to inspect without zooming.
+/// Default 0.25 so both regions fit side-by-side in a typical viewport; zoom min 0.25.
 const double kDebugMapScale = 0.25;
 
 


### PR DESCRIPTION
Doc/code alignment: SPEC stated `kDebugMapScale` 1.0; code uses 0.25.

- **SPEC/program/ctdev-app.md**, **ctdev-app-init-map.md:** Document `kDebugMapScale` 0.25 and rationale (default so both regions fit side-by-side; zoom min 0.25).
- **ctdev/lib/debug_map_painter.dart:** Fix comment to match value and spec (was incorrectly saying 1.0).

Fixes #256

Made with [Cursor](https://cursor.com)