### PR TITLE
init-game-tool: send all error messages to stderr

### DIFF
--- a/tool/init_game/bin/init_game.dart
+++ b/tool/init_game/bin/init_game.dart
@@ -52,14 +52,14 @@ Future<void> main(List<String> arguments) async {
     } else if (arg == '--seed' && i + 1 < arguments.length) {
       final v = int.tryParse(arguments[++i]);
       if (v == null) {
-        print('Error: --seed requires an integer');
+        stderr.writeln('Error: --seed requires an integer');
         exit(1);
       }
       seedOverride = v;
     } else if (arg.startsWith('--seed=')) {
       final v = int.tryParse(arg.substring(7).trim());
       if (v == null) {
-        print('Error: --seed requires an integer');
+        stderr.writeln('Error: --seed requires an integer');
         exit(1);
       }
       seedOverride = v;
@@ -107,7 +107,7 @@ Future<void> main(List<String> arguments) async {
   if (configPath != null && configPath.isNotEmpty) {
     final f = File(configPath);
     if (!f.existsSync()) {
-      print('Error: config file not found: $configPath');
+      stderr.writeln('Error: config file not found: $configPath');
       exit(1);
     }
     final json = jsonDecode(f.readAsStringSync()) as Map<String, dynamic>;
@@ -170,7 +170,7 @@ Future<void> main(List<String> arguments) async {
           prussiaLeaderOverride == prussiaVariantFrederickWilliam) {
         leaderVariantByGpId = {...leaderVariantByGpId, 'prussia': prussiaLeaderOverride};
       } else {
-        print('Error: --prussia-leader must be $prussiaVariantFrederickTheGreat or $prussiaVariantFrederickWilliam');
+        stderr.writeln('Error: --prussia-leader must be $prussiaVariantFrederickTheGreat or $prussiaVariantFrederickWilliam');
         exit(1);
       }
     }

--- a/tool/init_game/test/cli_error_test.dart
+++ b/tool/init_game/test/cli_error_test.dart
@@ -46,8 +46,8 @@ void main() {
         stdoutEncoding: utf8,
       );
       expect(result.exitCode, 1);
-      expect(result.stdout, contains('Error:'));
-      expect(result.stdout, contains('not found'));
+      expect(result.stderr, contains('Error:'));
+      expect(result.stderr, contains('not found'));
     });
   });
 }


### PR DESCRIPTION
Fixes #263

Per SPEC/program/init-game-tool.md § Constraints: on validation or setup failure the CLI must print a short user-facing message to **stderr** and exit with non-zero code.

**Changes:**
- Early validation errors (config file not found, invalid `--seed`, invalid `--prussia-leader`) now use `stderr.writeln` instead of `print()`.
- `tool/init_game/test/cli_error_test.dart`: "config file not found" test now asserts on `result.stderr` instead of `result.stdout`.

Made with [Cursor](https://cursor.com)