### PR TITLE
Include tool/init_game in test_coverage.py TOOL_PACKAGES

### DIFF
--- a/tool/init_game/pubspec.yaml
+++ b/tool/init_game/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
 
 dev_dependencies:
   colonizethis_test:
+  path: ^1.9.0
   test: ^1.24.0
 
 executables:

--- a/tool/init_game/test/cli_error_test.dart
+++ b/tool/init_game/test/cli_error_test.dart
@@ -5,6 +5,14 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:colonizethis_test/test.dart';
+import 'package:path/path.dart' as p;
+
+/// Package root: tool/init_game. Works when run from package dir or repo root.
+String get _packageRoot {
+  final cwd = Directory.current.path;
+  final inPackage = File(p.join(cwd, 'bin', 'init_game.dart')).existsSync();
+  return inPackage ? cwd : p.join(cwd, 'tool', 'init_game');
+}
 
 void main() {
   group('init_game CLI', () {
@@ -23,7 +31,7 @@ void main() {
           'dart',
           ['run', 'bin/init_game.dart', '--config', configFile.path, '--no-save'],
           runInShell: false,
-          workingDirectory: Directory.current.path,
+          workingDirectory: _packageRoot,
           stderrEncoding: utf8,
           stdoutEncoding: utf8,
         );
@@ -41,7 +49,7 @@ void main() {
         'dart',
         ['run', 'bin/init_game.dart', '--config', '/nonexistent/config.json', '--no-save'],
         runInShell: false,
-        workingDirectory: Directory.current.path,
+        workingDirectory: _packageRoot,
         stderrEncoding: utf8,
         stdoutEncoding: utf8,
       );

--- a/tool/test_coverage.py
+++ b/tool/test_coverage.py
@@ -35,6 +35,7 @@ TOOL_PACKAGES = [
     "tool/sim_combat_montecarlo",
     "tool/sim_combat",
     "tool/generate_map",
+    "tool/init_game",
     "tool/sim_economy",
     "tool/show_tech",
 ]


### PR DESCRIPTION
Fixes #267

- Add `tool/init_game` to `TOOL_PACKAGES` in `tool/test_coverage.py` so init_game tests are run by the full coverage script (SPEC: tool/test_coverage.py runs all package and app tests).
- Fix init_game CLI tests: use a package-root helper for `workingDirectory` so `dart run bin/init_game.dart` runs from `tool/init_game` and finds the script (avoids exit 255 when run from repo root).
- Add `path` dev_dependency to `tool/init_game` for the test’s package root resolution.

Made with [Cursor](https://cursor.com)