### PR TITLE
Extraction: use region-scoped province lookup (Fixes #271)

### DIFF
--- a/SPEC/program/extraction-pipeline.md
+++ b/SPEC/program/extraction-pipeline.md
@@ -34,8 +34,9 @@ Computes per-player resource extraction each turn by resolving tile connectivity
 
 1. Check mineral gating: if mineral resource, tile must be in player's prospected set (per game/fog-and-exploration.md). Skip if not.
 2. Production = min(improvement level, owner tech cap).
-3. Effective yield = min(production, transport level) — transport level is the tile's road level (or 4 for port); per game/extraction-and-improvements.md.
-4. Sum by commodity; split same-region vs overseas using player's capital region.
+3. Province lookup for town development cap must be **region-scoped**: resolve province only within the tile's region (game/world-model-identity.md). Do not search regions in sequence.
+4. Effective yield = min(production, transport level, town development level) — transport level is the tile's road level (or 4 for port); per game/extraction-and-improvements.md.
+5. Sum by commodity; split same-region vs overseas using player's capital region.
 
 **Output:** Per player, land totals and overseas totals (commodity → quantity).
 

--- a/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
+++ b/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
 
+import '../constants.dart';
 import '../world/connectivity_resolver.dart';
 
 final Logger _log = Logger();
@@ -77,9 +78,14 @@ Map<String, ExtractionTotals> computeExtraction({
       if (isMineral && !prospected.contains(tileKey)) {
         continue;
       }
+      // Province lookup must be region-scoped. SPEC/game/world-model-identity.md.
       final provinceId = '$regionId|${parts[1]}';
-      final province = game.worldState.oldWorld.provinces.where((p) => p.id == provinceId).firstOrNull ??
-          game.worldState.newWorld.provinces.where((p) => p.id == provinceId).firstOrNull;
+      final regionData = regionId == kRegionOldWorld
+          ? game.worldState.oldWorld
+          : regionId == kRegionNewWorld
+              ? game.worldState.newWorld
+              : null;
+      final province = regionData?.provinces.where((p) => p.id == provinceId).firstOrNull;
       final townDevelopmentCap = province?.townDevelopmentLevel ?? 4;
 
       final improvementLevel = game.worldState.tileState.improvementLevel(tileKey).clamp(0, 4);


### PR DESCRIPTION
Fixes #271

- **resource_extractor:** Resolve province only within the tile's region (oldWorld/newWorld) per SPEC/game/world-model-identity.md. Do not search regions in sequence.
- **SPEC/program/extraction-pipeline.md:** Document that province lookup for town development cap must be region-scoped and reference world-model-identity.

All extraction tests pass (resource_extractor_test, economy_extraction_test).

Made with [Cursor](https://cursor.com)