### PR TITLE
Fix #280: correct spec path in topology_inference.dart

### DIFF
--- a/packages/colonizethis_map/lib/src/topology_inference.dart
+++ b/packages/colonizethis_map/lib/src/topology_inference.dart
@@ -1,8 +1,8 @@
-// SPEC/program/tile-map-generation.md § Topology inference.
+// SPEC/program/tile-map-gen-resources.md § Topology inference.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 
-/// Infers MapTopology from a tile map result. SPEC/program/tile-map-generation.md § Topology inference.
+/// Infers MapTopology from a tile map result. SPEC/program/tile-map-gen-resources.md § Topology inference.
 /// Collects unique region ids from grid; classifies province vs sea zone; builds edges from adjacencies.
 MapTopology inferTopologyFromTileMap(
   TileMapResult result,


### PR DESCRIPTION
Fixes #280.

Update the two spec references in `packages/colonizethis_map/lib/src/topology_inference.dart` from the non-existent `SPEC/program/tile-map-generation.md` to the authoritative `SPEC/program/tile-map-gen-resources.md` (§ Topology inference).

Made with [Cursor](https://cursor.com)