### PR TITLE
Orders spec: add province id cross-reference (world-model-identity)

### DIFF
--- a/SPEC/program/orders.md
+++ b/SPEC/program/orders.md
@@ -1,6 +1,8 @@
 # Orders
 
-**SPEC/program** — Order types, validation, and resolution. Reference: [movement.md](movement.md), [civilian-units.md](../game/civilian-units.md), [military-units.md](../game/military-units.md).
+**SPEC/program** — Order types, validation, and resolution. Reference: [movement.md](movement.md), [civilian-units.md](../game/civilian-units.md), [military-units.md](../game/military-units.md), [world-model-identity.md](../game/world-model-identity.md).
+
+**Province identity:** Province ids in order payloads (e.g. destination province, spawn province, tile keys) use the **prefixed** form `regionId|localId` and must be resolved per [world-model-identity.md](../game/world-model-identity.md). Do not use bare province ids for lookup.
 
 ---
 


### PR DESCRIPTION
Adds a cross-reference in SPEC/program/orders.md to world-model-identity.md and a short note that province ids in order payloads use the prefixed form (`regionId|localId`) and must be resolved per that spec.

Fixes #285

Made with [Cursor](https://cursor.com)