### PR TITLE
AI spec: add world-model-identity cross-ref for province id in AI context

### DIFF
--- a/SPEC/ai/ai-architecture.md
+++ b/SPEC/ai/ai-architecture.md
@@ -46,6 +46,7 @@ AI uses the order suggestion API and applies:
 - **Movement:** Prefer contested or enemy territory (at war); avoid factions at peace.
 - **Build/work:** Prefer cheaper orders improving owned, visible provinces.
 - **Research:** Prefer lower-era, cheaper techs unlocking core capabilities.
+- **Province identity:** Movement targets, build provinces, and visibility use the **prefixed** form `regionId|localId` per [world-model-identity.md](../game/world-model-identity.md).
 
 Seeded randomness selects among acceptable candidates; personality weights bias selection.
 
@@ -56,5 +57,6 @@ Per-turn seed: `turnSeed[P, T] = hash(globalGameSeed, aiSeed[P], T)`. Sub-seeds:
 - [ai-personalities.md](ai-personalities.md) — per-leader weights
 - [hidden-agendas.md](hidden-agendas.md) — agenda modifiers
 - [dialogue-and-mood.md](dialogue-and-mood.md) — event emission
+- [world-model-identity.md](../game/world-model-identity.md) — province identity (prefixed id) in AI context
 - Program: [ai-planner.md](../program/ai-planner.md) — control rules, order merge
 - Program: [ai-systems-impl.md](../program/ai-systems-impl.md) — module boundaries, APIs

--- a/SPEC/program/ai-systems-impl.md
+++ b/SPEC/program/ai-systems-impl.md
@@ -50,7 +50,7 @@ QuickBattleDecisions decideQuickBattleActions({
 Returns CP-based actions per lane. Deterministic given state and seed.
 
 ### Order Suggestion API Usage
-AI calls the suggestion API with PlayerView and current orders, scores candidates via utility AI (personality + agenda weights), selects a subset, and repeats. When naval is in scope, API also exposes naval candidates. AI does not construct raw orders; all go through the suggestion API for validation.
+AI calls the suggestion API with PlayerView and current orders, scores candidates via utility AI (personality + agenda weights), selects a subset, and repeats. When naval is in scope, API also exposes naval candidates. AI does not construct raw orders; all go through the suggestion API for validation. Province identifiers in API inputs and returned candidates use the **prefixed** form `regionId|localId` per [world-model-identity.md](../game/world-model-identity.md).
 
 ## Integration
 
@@ -62,3 +62,4 @@ AI calls the suggestion API with PlayerView and current orders, scores candidate
 - AI reads only via PlayerView; no hidden data access.
 - All decisions deterministic given seeds.
 - No Flutter or platform dependencies.
+- Province ids (suggestion API and AI): full id (`regionId|localId`) per [world-model-identity.md](../game/world-model-identity.md).


### PR DESCRIPTION
Adds cross-references in the AI specs so province identity in AI context (movement targets, build provinces, suggestion API) is explicitly tied to **SPEC/game/world-model-identity.md** (prefixed `regionId|localId`).

- **SPEC/ai/ai-architecture.md:** Strategic Behavior Preferences bullet and Interactions ref for province identity.
- **SPEC/program/ai-systems-impl.md:** Order Suggestion API Usage sentence and Constraints line for full province id.

Fixes #295

Made with [Cursor](https://cursor.com)