### PR TITLE
Deduplicate regionIdForUnit (Fixes #302)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -11,23 +11,6 @@ import '../world/player_view.dart';
 
 final Logger _log = Logger();
 
-/// Resolves regionId for [unit]: from tileKey, or from compound provinceId, or by
-/// looking up [unit].provinceId in [view].provincesById (handles short province ids).
-String _regionIdForUnit(PlayerView view, Unit unit) {
-  if (unit.tileKey != null && unit.tileKey!.isNotEmpty) {
-    return Unit.requireRegionIdFromTileKey(unit.tileKey);
-  }
-  if (ProvinceId.isPrefixed(unit.provinceId)) {
-    return ProvinceId.regionIdFrom(unit.provinceId);
-  }
-  for (final key in view.provincesById.keys) {
-    if (key == unit.provinceId || key.endsWith('|${unit.provinceId}')) {
-      return ProvinceId.regionIdFrom(key);
-    }
-  }
-  return ProvinceId.regionIdFrom(unit.provinceId);
-}
-
 /// Suggests candidate move orders that are information-legal (per [PlayerView])
 /// and rules-legal (per [OrderEngine]) for [view.playerId].
 List<MoveOrder> suggestMoveOrders(
@@ -49,7 +32,7 @@ List<MoveOrder> suggestMoveOrders(
   }
 
   for (final unit in view.ownUnits) {
-    final unitRegion = _regionIdForUnit(view, unit);
+    final unitRegion = regionIdForUnit(view, unit);
     final fromProvinceId = unit.locationProvinceId;
     final fromLocalId = ProvinceId.localIdFrom(fromProvinceId);
 
@@ -161,7 +144,7 @@ List<WorkOrder> suggestWorkOrders(
     final isMerchant = isMerchantUnit(type);
     if (!isExplorer && !isWorker && !isSpy && !isMerchant) continue;
 
-    final regionId = _regionIdForUnit(view, unit);
+    final regionId = regionIdForUnit(view, unit);
     final provinceId = unit.locationProvinceId;
     final localId = ProvinceId.localIdFrom(provinceId);
     final province = view.provinceByRegionAndId(regionId, provinceId);

--- a/packages/colonizethis_logic/lib/src/orders/order_visibility.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_visibility.dart
@@ -62,8 +62,9 @@ bool moveDestVisibilityOk(
   return provinceHasAtLeastVisibility(view, regionId, provinceId, min);
 }
 
-/// Resolves regionId for [unit] when no tileKey: from compound provinceId, [view].provincesById, or visibility tile keys.
-String _regionIdForUnit(PlayerView view, Unit unit) {
+/// Resolves regionId for [unit]: from tileKey, compound provinceId, [view].provincesById, or visibility tile keys.
+/// Shared by order_suggestion and order_visibility (SPEC/program/order-suggestions.md, fog-and-exploration-resolution.md).
+String regionIdForUnit(PlayerView view, Unit unit) {
   if (unit.tileKey != null && unit.tileKey!.isNotEmpty) {
     return Unit.requireRegionIdFromTileKey(unit.tileKey);
   }
@@ -87,7 +88,7 @@ String _regionIdForUnit(PlayerView view, Unit unit) {
 bool workOrderVisibilityOk(PlayerView view, Unit unit, String workTarget, [String? targetTileKey]) {
   final regionId = targetTileKey != null && targetTileKey.isNotEmpty
       ? Unit.requireRegionIdFromTileKey(targetTileKey)
-      : _regionIdForUnit(view, unit);
+      : regionIdForUnit(view, unit);
   final provinceId = targetTileKey != null && targetTileKey.isNotEmpty
       ? (Unit.provinceIdFromTileKey(targetTileKey) ?? unit.locationProvinceId)
       : unit.locationProvinceId;


### PR DESCRIPTION
Fixes #302

- Single implementation in `order_visibility.dart` as public `regionIdForUnit` (includes visibility tile-key fallback for local province ids).
- `order_suggestion.dart` now uses the shared `regionIdForUnit`; removed the duplicate implementation that lacked the visibility fallback.

Made with [Cursor](https://cursor.com)