### PR TITLE
Fix wrong spec path in colonizethis_data (tile-map-generation.md)

### DIFF
--- a/packages/colonizethis_data/lib/src/resource_rules.dart
+++ b/packages/colonizethis_data/lib/src/resource_rules.dart
@@ -9,7 +9,7 @@ enum ResourceRegionRule {
 }
 
 /// Resource–region and resource–terrain rules plus default market price for spawn weights.
-/// SPEC/program/tile-map-generation.md, TDD 04b. SPEC/game/resource-terrain-region-rules.md.
+/// SPEC/program/tile-map-gen-resources.md, SPEC/game/resource-terrain-region-rules.md.
 class ResourceRules {
   ResourceRules({
     required this.regionRule,

--- a/packages/colonizethis_data/lib/src/terrain_region_rules.dart
+++ b/packages/colonizethis_data/lib/src/terrain_region_rules.dart
@@ -1,4 +1,4 @@
-/// Allowed terrain types per region. TDD 04b, SPEC/program/tile-map-generation.md.
+/// Allowed terrain types per region. SPEC/program/tile-map-gen-resources.md, SPEC/game/resource-terrain-region-rules.md.
 /// Canonical source: Imperialism II Terrain and Development table (OW-only, NW-only, Both).
 /// Phase 1: minimal mapping from current TerrainType enum; extend when terrain enum is expanded.
 

--- a/packages/colonizethis_data/lib/src/tile_map_result.dart
+++ b/packages/colonizethis_data/lib/src/tile_map_result.dart
@@ -1,7 +1,7 @@
 import 'terrain_type.dart';
 import 'resource.dart';
 
-/// Result of tile-based map generation. SPEC/program/tile-map-generation.md.
+/// Result of tile-based map generation. SPEC/program/tile-map-gen-resources.md, SPEC/program/map-data.md.
 /// Per-region 2D grid: each cell has a region id (province or sea zone).
 /// Optionally terrain and resource per cell (Phase 1+).
 class TileMapResult {


### PR DESCRIPTION
## Summary
Replace non-existent `SPEC/program/tile-map-generation.md` with correct TDD paths in three files under `packages/colonizethis_data`:

- **terrain_region_rules.dart**: point to `tile-map-gen-resources.md`, `resource-terrain-region-rules.md`
- **resource_rules.dart**: point to `tile-map-gen-resources.md`, `resource-terrain-region-rules.md`
- **tile_map_result.dart**: point to `tile-map-gen-resources.md`, `map-data.md`

Fixes #308

Made with [Cursor](https://cursor.com)