### PR TITLE
fix(colonizethis_map): correct spec paths (tile-map-generation → tile-map-gen-*)

### DIFF
--- a/packages/colonizethis_map/lib/colonizethis_map.dart
+++ b/packages/colonizethis_map/lib/colonizethis_map.dart
@@ -1,5 +1,5 @@
 /// Topology and tile map generation and visualization.
-/// SPEC/program/tile-map-generation.md, SPEC/program/map-data.md.
+/// SPEC/program/tile-map-gen-algorithm.md, SPEC/program/tile-map-gen-resources.md, SPEC/program/map-data.md.
 library colonizethis_map;
 
 export 'src/grid_voronoi.dart';

--- a/packages/colonizethis_map/lib/src/grid_voronoi.dart
+++ b/packages/colonizethis_map/lib/src/grid_voronoi.dart
@@ -1,4 +1,4 @@
-// Reusable Voronoi assignment for grid cells. SPEC/program/tile-map-generation.md § Voronoi assignment.
+// Reusable Voronoi assignment for grid cells. SPEC/program/tile-map-gen-algorithm.md § Voronoi assignment.
 
 /// Deterministic noise in [-1, 1] for Voronoi boundary irregularity.
 /// Same formula as tile_map_generator so land/province/sea boundaries behave consistently.

--- a/packages/colonizethis_map/lib/src/tile_map_topology_validation.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_topology_validation.dart
@@ -1,8 +1,8 @@
-// SPEC/program/tile-map-generation.md § Topology verification.
+// SPEC/program/tile-map-gen-resources.md § Topology inference.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 
-/// Result of comparing grid adjacencies to topology. SPEC/program/tile-map-generation.md § Topology verification.
+/// Result of comparing grid adjacencies to topology. SPEC/program/tile-map-gen-resources.md § Topology inference.
 class TileMapTopologyValidationResult {
   TileMapTopologyValidationResult({
     required this.missing,
@@ -23,7 +23,7 @@ String _pairKey(String a, String b) =>
     a.compareTo(b) < 0 ? '$a|$b' : '$b|$a';
 
 /// Compares grid adjacencies to topology edges. Returns missing and extra pairs.
-/// SPEC/program/tile-map-generation.md § Topology verification.
+/// SPEC/program/tile-map-gen-resources.md § Topology inference.
 TileMapTopologyValidationResult validateTileMapTopology(
   MapTopology topology,
   TileMapResult result,


### PR DESCRIPTION
Follow-up to #308 (which was limited to colonizethis_data). Fix the same wrong spec path in `packages/colonizethis_map`:

- **colonizethis_map.dart:** `tile-map-generation.md` → `tile-map-gen-algorithm.md`, `tile-map-gen-resources.md`, `map-data.md`
- **tile_map_topology_validation.dart:** `tile-map-generation.md` § Topology verification → `tile-map-gen-resources.md` § Topology inference
- **grid_voronoi.dart:** `tile-map-generation.md` § Voronoi assignment → `tile-map-gen-algorithm.md` § Voronoi assignment

`SPEC/program/tile-map-generation.md` does not exist; the actual specs are `tile-map-gen-algorithm.md`, `tile-map-gen-resources.md`, `tile-map-gen-config.md`.

Refs: SPEC/program/tile-map-gen-resources.md, SPEC/program/tile-map-gen-algorithm.md, SPEC/program/map-data.md.

Made with [Cursor](https://cursor.com)