### PR TITLE
docs(spec): replace TDD 04b with GDD cross-ref for spawn weight in tile-map-gen-resources

### DIFF
--- a/SPEC/program/tile-map-gen-resources.md
+++ b/SPEC/program/tile-map-gen-resources.md
@@ -12,7 +12,7 @@ Assign resources and provinces to land, subdivide sea zones, infer topology.
 
 ## Algorithm (Passes 7–11)
 
-7. **Pass 7 — Resource assignment:** For each land cell with terrain, assign at most one resource from allowed set (map region + terrain). Weights per TDD 04b. **Multi-region resource cap:** when both-count/total ≥ cap (default 0.30), restrict to region-only when possible.
+7. **Pass 7 — Resource assignment:** For each land cell with terrain, assign at most one resource from allowed set (map region + terrain). Weights per [resource-terrain-region-rules.md](../game/resource-terrain-region-rules.md): spawn weight = 1 / default market price (higher price = rarer). **Multi-region resource cap:** when both-count/total ≥ cap (default 0.30), restrict to region-only when possible.
 
 8. **Pass 8 — Province seed placement:** One seed per province (p1..pN) on land. Seeds per continent using province-to-continent map; some near coast for P–S adjacencies.
 


### PR DESCRIPTION
Pass 7 in `SPEC/program/tile-map-gen-resources.md` now references `SPEC/game/resource-terrain-region-rules.md` for the spawn weight formula (1 / default market price) instead of the legacy "TDD 04b" reference.

Fixes #309

Refs: SPEC/program/tile-map-gen-resources.md, SPEC/game/resource-terrain-region-rules.md

Made with [Cursor](https://cursor.com)