### PR TITLE
docs(spec): fix sim_economy Phase 2 wording to phases 3–6

### DIFF
--- a/SPEC/program/sim-economy.md
+++ b/SPEC/program/sim-economy.md
@@ -1,7 +1,7 @@
 # sim_economy — Economy Simulation Tool
 
 ## Responsibility
-Standalone CLI tool to simulate a single player's economy loop over N turns using Phase 2 rules. No map, movement, combat, diplomacy, AI, or trade. Game rules: [stockpiles-and-production.md](../game/stockpiles-and-production.md), [workers-and-population.md](../game/workers-and-population.md).
+Standalone CLI tool to simulate a single player's economy loop over N turns using phases 3–6 (Extraction, Riches to treasury, Production, Consumption) per [turn-resolution-phases.md](turn-resolution-phases.md). No map, movement, combat, diplomacy, AI, or trade. Game rules: [stockpiles-and-production.md](../game/stockpiles-and-production.md), [workers-and-population.md](../game/workers-and-population.md).
 
 ## Data Model
 
@@ -26,7 +26,7 @@ Top-level: `metadata`, `initialState` (stockpile, workers, optional military/tre
 
 ## Algorithm / Flow
 
-Per turn, runs the Phase 2 economy sequence per [turn-resolution-phases.md](turn-resolution-phases.md):
+Per turn, runs the economy sequence (phases 3–6) per [turn-resolution-phases.md](turn-resolution-phases.md):
 
 1. **Actions** — Recruit/train workers, optional build unit.
 2. **Extraction** — Add to stockpile (auto-transport semantics).


### PR DESCRIPTION
Align `sim_economy` spec with [turn-resolution-phases.md](SPEC/program/turn-resolution-phases.md): the tool runs Extraction, Riches to treasury, Production, Consumption (phases 3–6), not "Phase 2".

Fixes #325

Made with [Cursor](https://cursor.com)