### PR TITLE
Sim tools: use logger instead of print (Fixes #327)

### DIFF
--- a/tool/sim_combat/bin/sim_combat.dart
+++ b/tool/sim_combat/bin/sim_combat.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: avoid_print
 /// CLI: simulate combat resolution on scripted scenarios (probabilistic).
 /// SPEC/program/sim-combat.md.
 import 'dart:convert';
@@ -7,6 +6,9 @@ import 'dart:io';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
+
+final _log = Logger();
 
 void main(List<String> arguments) {
   String? scriptPath;
@@ -34,14 +36,14 @@ void main(List<String> arguments) {
     } else if (arg == '--seed' && i + 1 < arguments.length) {
       final v = int.tryParse(arguments[++i]);
       if (v == null) {
-        print('Error: --seed requires an integer');
+        _log.e('logic: sim_combat: Error: --seed requires an integer');
         exit(1);
       }
       seed = v;
     } else if (arg.startsWith('--seed=')) {
       final v = int.tryParse(arg.substring('--seed='.length).trim());
       if (v == null) {
-        print('Error: --seed requires an integer');
+        _log.e('logic: sim_combat: Error: --seed requires an integer');
         exit(1);
       }
       seed = v;
@@ -49,14 +51,14 @@ void main(List<String> arguments) {
   }
 
   if (scriptPath == null || scriptPath.isEmpty) {
-    print('Error: --script <path> is required');
+    _log.e('logic: sim_combat: Error: --script <path> is required');
     _printUsage();
     exit(1);
   }
 
   final file = File(scriptPath);
   if (!file.existsSync()) {
-    print('Error: script file not found: $scriptPath');
+    _log.e('logic: sim_combat: Error: script file not found: $scriptPath');
     exit(1);
   }
 
@@ -82,7 +84,7 @@ void main(List<String> arguments) {
     final terrain = provinceRaw['terrain'] as String? ?? 'plains';
 
     if (fortLevel < 0 || fortLevel > 3) {
-      print('Error: battle $id: fortLevel must be 0-3, got $fortLevel');
+      _log.e('logic: sim_combat: Error: battle $id: fortLevel must be 0-3, got $fortLevel');
       exit(1);
     }
 
@@ -152,7 +154,7 @@ void main(List<String> arguments) {
 
   final outPath = outputPath ?? 'sim_combat.md';
   File(outPath).writeAsStringSync(markdown);
-  print('Wrote Markdown report to ${File(outPath).absolute.path}');
+  _log.i('logic: sim_combat: Wrote Markdown report to ${File(outPath).absolute.path}');
 
   if (jsonOutputPath != null && jsonOutputPath.isNotEmpty) {
     final jsonResults = results.map((r) {
@@ -167,7 +169,7 @@ void main(List<String> arguments) {
       return m;
     }).toList();
     File(jsonOutputPath).writeAsStringSync(jsonEncode(jsonResults));
-    print('Wrote JSON log to ${File(jsonOutputPath).absolute.path}');
+    _log.i('logic: sim_combat: Wrote JSON log to ${File(jsonOutputPath).absolute.path}');
   }
 }
 
@@ -182,7 +184,7 @@ List<Unit> _parseUnits(
     final u = Map<String, dynamic>.from(unitsRaw[i] as Map);
     final type = u['type'] as String? ?? 'peasant_levies';
     if (regimentStatsById(type) == null) {
-      print('Error: battle $battleId: unknown unit type "$type"');
+      _log.e('logic: sim_combat: Error: battle $battleId: unknown unit type "$type"');
       exit(1);
     }
     final medals = (u['medals'] as int?) ?? 0;
@@ -275,8 +277,8 @@ String _buildMarkdownReport({
 }
 
 void _printUsage() {
-  print('Usage:');
-  print('  melos run sim_combat -- --script <path> [--output <path>] [--json-output <path>] [--seed <int>]');
-  print('');
-  print('Simulates probabilistic combat resolution on scripted scenarios. SPEC/program/sim-combat.md.');
+  _log.i('logic: sim_combat: Usage:');
+  _log.i('logic: sim_combat:   melos run sim_combat -- --script <path> [--output <path>] [--json-output <path>] [--seed <int>]');
+  _log.i('logic: sim_combat: ');
+  _log.i('logic: sim_combat: Simulates probabilistic combat resolution on scripted scenarios. SPEC/program/sim-combat.md.');
 }

--- a/tool/sim_combat/pubspec.yaml
+++ b/tool/sim_combat/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: '>=3.5.0 <4.0.0'
 
 dependencies:
+  logger: ^2.0.2
   colonizethis_data:
   colonizethis_logic:
   colonizethis_models:

--- a/tool/sim_economy/bin/sim_economy.dart
+++ b/tool/sim_economy/bin/sim_economy.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: avoid_print
 /// CLI: simulate a single player's economy over N turns.
 /// SPEC/program/sim-economy.md
 import 'dart:convert';
@@ -8,6 +7,9 @@ import 'dart:math';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
+
+final _log = Logger();
 
 void main(List<String> arguments) {
   String? scriptPath;
@@ -29,28 +31,28 @@ void main(List<String> arguments) {
       final value = arguments[++i];
       turns = int.tryParse(value);
       if (turns == null || turns < 1) {
-        print('Error: --turns must be a positive integer, got: $value');
+        _log.e('logic: sim_economy: Error: --turns must be a positive integer, got: $value');
         exit(1);
       }
     } else if (arg.startsWith('--turns=')) {
       final value = arg.substring('--turns='.length).trim();
       turns = int.tryParse(value);
       if (turns == null || turns < 1) {
-        print('Error: --turns must be a positive integer, got: $value');
+        _log.e('logic: sim_economy: Error: --turns must be a positive integer, got: $value');
         exit(1);
       }
     } else if (arg == '--seed' && i + 1 < arguments.length) {
       final value = arguments[++i];
       seed = int.tryParse(value);
       if (seed == null) {
-        print('Error: --seed requires an integer, got: $value');
+        _log.e('logic: sim_economy: Error: --seed requires an integer, got: $value');
         exit(1);
       }
     } else if (arg.startsWith('--seed=')) {
       final value = arg.substring('--seed='.length).trim();
       seed = int.tryParse(value);
       if (seed == null) {
-        print('Error: --seed requires an integer, got: $value');
+        _log.e('logic: sim_economy: Error: --seed requires an integer, got: $value');
         exit(1);
       }
     } else if (arg == '--output' && i + 1 < arguments.length) {
@@ -66,7 +68,7 @@ void main(List<String> arguments) {
 
   final useScript = scriptPath != null && scriptPath.isNotEmpty;
   if (!useScript && turns == null) {
-    print('Error: --turns is required when no --script is provided.');
+    _log.e('logic: sim_economy: Error: --turns is required when no --script is provided.');
     _printUsage();
     exit(1);
   }
@@ -84,7 +86,7 @@ void main(List<String> arguments) {
   if (useScript) {
     final file = File(scriptPath);
     if (!file.existsSync()) {
-      print('Error: script file not found: $scriptPath');
+      _log.e('logic: sim_economy: Error: script file not found: $scriptPath');
       exit(1);
     }
     final decoded = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
@@ -185,21 +187,21 @@ void main(List<String> arguments) {
 
   final markdownFile = File(outputConfig.markdownPath);
   markdownFile.writeAsStringSync(markdown);
-  print('Wrote Markdown report to ${markdownFile.absolute.path}');
+  _log.i('logic: sim_economy: Wrote Markdown report to ${markdownFile.absolute.path}');
 
   if (outputConfig.jsonPath != null) {
     final jsonFile = File(outputConfig.jsonPath!);
     jsonFile.writeAsStringSync(jsonEncode(turnsLog));
-    print('Wrote JSON log to ${jsonFile.absolute.path}');
+    _log.i('logic: sim_economy: Wrote JSON log to ${jsonFile.absolute.path}');
   }
 }
 
 void _printUsage() {
-  print('Usage:');
-  print(
-      '  melos run sim_economy -- [--script path] [--turns N] [--seed S] [--output path] [--json-output path]');
-  print('');
-  print('Simulates a single player economy using Phase 2 rules.');
+  _log.i('logic: sim_economy: Usage:');
+  _log.i(
+      'logic: sim_economy:   melos run sim_economy -- [--script path] [--turns N] [--seed S] [--output path] [--json-output path]');
+  _log.i('logic: sim_economy: ');
+  _log.i('logic: sim_economy: Simulates a single player economy using Phase 2 rules.');
 }
 
 Map<String, int> _quantitiesFromStockpile(Stockpile stockpile) {

--- a/tool/sim_economy/pubspec.yaml
+++ b/tool/sim_economy/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: '>=3.5.0 <4.0.0'
 
 dependencies:
+  logger: ^2.0.2
   colonizethis_models:
   colonizethis_data:
   colonizethis_logic:

--- a/tool/sim_scenarios/bin/sim_scenarios.dart
+++ b/tool/sim_scenarios/bin/sim_scenarios.dart
@@ -8,10 +8,13 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:logger/logger.dart';
 import 'package:path/path.dart' as path;
 
 import 'package:sim_scenarios/scenario.dart';
 import 'package:sim_scenarios/scenario_runner.dart';
+
+final _log = Logger();
 
 void main(List<String> args) async {
   final parser = ArgParser();
@@ -44,15 +47,15 @@ void main(List<String> args) async {
   final results = parser.parse(args);
 
   if (results['help'] == true) {
-    print('sim_scenarios - Batch scenario test driver');
-    print('');
-    print('Usage:');
-    print('  dart run sim_scenarios                          # Run all scenarios');
-    print('  dart run sim_scenarios --scenario=path.json     # Run specific scenario');
-    print('  dart run sim_scenarios --directory=path         # Run from directory');
-    print('  dart run sim_scenarios --verbose                # Verbose output');
-    print('');
-    print(parser.usage);
+    _log.i('logic: sim_scenarios: sim_scenarios - Batch scenario test driver');
+    _log.i('logic: sim_scenarios: ');
+    _log.i('logic: sim_scenarios: Usage:');
+    _log.i('logic: sim_scenarios:   dart run sim_scenarios                          # Run all scenarios');
+    _log.i('logic: sim_scenarios:   dart run sim_scenarios --scenario=path.json     # Run specific scenario');
+    _log.i('logic: sim_scenarios:   dart run sim_scenarios --directory=path         # Run from directory');
+    _log.i('logic: sim_scenarios:   dart run sim_scenarios --verbose                # Verbose output');
+    _log.i('logic: sim_scenarios: ');
+    _log.i('logic: sim_scenarios: ${parser.usage}');
     return;
   }
 
@@ -85,29 +88,27 @@ void main(List<String> args) async {
     // Run single scenario
     final file = File(scenarioPath);
     if (!file.existsSync()) {
-      print('Error: Scenario file not found: $scenarioPath');
+      _log.e('logic: sim_scenarios: Error: Scenario file not found: $scenarioPath');
       exit(1);
     }
     if (verbose) {
-      print('Running scenario: $scenarioPath');
+      _log.i('logic: sim_scenarios: Running scenario: $scenarioPath');
     }
     final result = await runner.runFile(file);
-    print(formatScenarioReport(result));
+    _log.i('logic: sim_scenarios:\n${formatScenarioReport(result)}');
     exit(result.passed ? 0 : 1);
   } else {
     // Run all scenarios in directory
     final dir = Directory(directory);
     if (!dir.existsSync()) {
-      print('Error: Directory not found: $directory');
+      _log.e('logic: sim_scenarios: Error: Directory not found: $directory');
       exit(1);
     }
     if (verbose) {
-      print('Running all scenarios in: $directory');
+      _log.i('logic: sim_scenarios: Running all scenarios in: $directory');
     }
     final batchResult = await runner.runAll(dir);
-    
-    // Print batch results
-    print(formatBatchReport(batchResult));
+    _log.i('logic: sim_scenarios:\n${formatBatchReport(batchResult)}');
     exit(batchResult.failed > 0 ? 1 : 0);
   }
 }

--- a/tool/sim_scenarios/pubspec.yaml
+++ b/tool/sim_scenarios/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: '>=3.5.0 <4.0.0'
 
 dependencies:
+  logger: ^2.0.2
   args:
   path:
   hive:


### PR DESCRIPTION
Fixes #327

**Summary**
- Replaced all `print()` in sim_economy, sim_combat, and sim_scenarios with the project logger (Dart `logger` package).
- Message prefixes: `logic: sim_economy:`, `logic: sim_combat:`, `logic: sim_scenarios:` per SPEC/program/ctdev-logging.md.
- Errors and validation failures use `_log.e()`; usage and success messages use `_log.i()`.
- Removed `ignore_for_file: avoid_print` from sim_economy and sim_combat.
- Added `logger: ^2.0.2` to each tool's pubspec.

**Refs:** SPEC/program/ctdev-logging.md, core principles (no print for operational/diagnostic output).

Made with [Cursor](https://cursor.com)