### PR TITLE
Align sim_scenarios melos script with spec (Fixes #342)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ melos:
       run: dart run sim_combat_montecarlo
     sim_scenarios:
       description: Batch scenario test driver for game integration testing. SPEC/program/sim-scenarios.md.
-      run: dart run tool/sim_scenarios/bin/sim_scenarios.dart
+      run: dart run sim_scenarios
     show_tech:
       description: Technology tree diagram and query (SPEC/program/show-tech-tool.md).
       run: dart run show_tech


### PR DESCRIPTION
Fixes #342.

- Change `sim_scenarios` melos script from path form (`dart run tool/sim_scenarios/bin/sim_scenarios.dart`) to executable name form (`dart run sim_scenarios`) so it matches other tools and SPEC/program/repo-and-packages.md / .cursor/rules/colonizethis-tools.mdc.
- Verified `dart run sim_scenarios` works from workspace root.

Made with [Cursor](https://cursor.com)