### PR TITLE
Turn resolution spec: add world-model-identity cross-ref for province id

### DIFF
--- a/SPEC/program/turn-resolution.md
+++ b/SPEC/program/turn-resolution.md
@@ -1,6 +1,6 @@
 # Turn Resolution
 
-**SPEC/program** — Turn phases, state, and resolution sequence. Implementation: colonizethis_logic. World state: [SPEC/game/world-model.md](../game/world-model.md).
+**SPEC/program** — Turn phases, state, and resolution sequence. Implementation: colonizethis_logic. World state: [SPEC/game/world-model.md](../game/world-model.md). Province ids in turn state and phase resolution use the prefixed format and lookup rules in [SPEC/game/world-model-identity.md](../game/world-model-identity.md).
 
 ---
 


### PR DESCRIPTION
Fixes #313.

Adds a cross-reference in SPEC/program/turn-resolution.md to SPEC/game/world-model-identity.md for province id format and lookup rules used in turn state and phase resolution.

Made with [Cursor](https://cursor.com)