### PR TITLE
Spec: Railroad costs section — name Rail Builder, not Engineer (Fixes #367)

### DIFF
--- a/SPEC/game/extraction-and-improvements.md
+++ b/SPEC/game/extraction-and-improvements.md
@@ -53,7 +53,7 @@ Connected tiles' effective yields are summed by commodity. **Same-region:** adde
 
 1 lumber + 1 cast iron per tile (transport level 1). **Improved road (level 2):** requires **Road Construction** tech; validation and completion must check tech before setting road level to 2.
 
-### Railroad Costs (Engineer)
+### Railroad Costs (Rail Builder)
 
 2 lumber + 2 cast iron per tile
 


### PR DESCRIPTION
Fixes #367.

**Change:** In `SPEC/game/extraction-and-improvements.md`, the "Railroad Costs" section heading referred to Engineer. Railroads are built by the **Rail Builder** unit per `civilian-units.md` and `orders.md`. Updated the heading to "Railroad Costs (Rail Builder)".

Made with [Cursor](https://cursor.com)