### PR TITLE
GDD: add world-model-identity cross-ref to civilian-units (Fixes #374)

### DIFF
--- a/SPEC/game/civilian-units.md
+++ b/SPEC/game/civilian-units.md
@@ -64,6 +64,7 @@ Multi-turn progress for all civilian work is tracked in the model and resolved d
 ## Relations
 
 - **Unit** (type = civilian) → has owner (player id) and **location** = **tileKey** only (required, format `regionId|provinceId|x|y`); province and region are derived from tileKey. Work is ordered via WorkOrder (unitId, action, targetTileKey). Military and naval units do not have tileKey. See [fog-and-exploration.md](fog-and-exploration.md).
+- **Province identity:** Civilian **location** (tileKey) and WorkOrder **targetTileKey** use the prefixed tile key format `regionId|provinceId|x|y`. Province and region for a civilian are derived from tileKey; any province lookup (e.g. for work cancel, build_port, steal_tech target) must use the full province id (`regionId|localId`). See [world-model-identity.md](world-model-identity.md).
 - Civilian units have a **training cost**: cash is deducted from the player's **treasury** and paper from the player's **stockpile** when the unit is built. Work orders consume materials (lumber, metal, etc.) as defined in extraction-and-improvements and siege-mechanics. Materials are deducted when the work is **assigned** (during Build/Work phase application of WorkOrder); validation checks treasury/stockpile at order submit time.
 - Civilian units do not eat food; they do not consume workers when built (unlike military/naval).
 


### PR DESCRIPTION
Fixes #374

In SPEC/game/civilian-units.md § Relations, added an explicit cross-reference to SPEC/game/world-model-identity.md:
- Civilian **location** (tileKey) and WorkOrder **targetTileKey** use the prefixed tile key format `regionId|provinceId|x|y`.
- Province and region for a civilian are derived from tileKey; any province lookup (e.g. for work cancel, build_port, steal_tech target) must use the full province id (`regionId|localId`).

Made with [Cursor](https://cursor.com)