### PR TITLE
Development resolution TDD: add acceptance criteria section

### DIFF
--- a/SPEC/program/development-resolution.md
+++ b/SPEC/program/development-resolution.md
@@ -64,3 +64,12 @@ Exploration and prospecting (`explore`, `prospect`) follow [fog-and-exploration-
   - Updated visibility and prospected tiles for exploration/prospecting.
 - This guarantees that simulations exercise identical development rules and multi-turn timing as regular play.
 
+---
+
+### Acceptance criteria
+
+- **Work assign:** Validation covers unit type, target tile (exists, ownership, terrain eligibility), tech prerequisites, and material availability; on accept, materials are deducted at assign (no refund if work is later cancelled); unit gets `currentWork` set and `status = working`.
+- **Build/Work phase loop:** Each turn, for each working civilian: if unit is dead or the tile is no longer owned by the player (e.g. conquest; see #376), cancel work (clear `currentWork`, set `status = idle`); otherwise decrement `remainingTurns`; when it reaches 0, apply the action effect then set `status = idle` and clear `currentWork`.
+- **build_port:** Completion requires topology to be defined (topology-null behaviour is documented in a dedicated issue); port key uses full province id per [world-model-identity.md](../game/world-model-identity.md).
+- **Shared use:** The same TurnResolver and development resolution logic are used in the main game and in sim_game.
+


### PR DESCRIPTION
Fixes #385.

Adds an **Acceptance criteria** section to SPEC/program/development-resolution.md covering:
- Work assign: validation (unit type, target tile, tech, materials), material deduction at assign, `currentWork` and `status = working` set.
- Build/Work phase loop: decrement `remainingTurns`; on 0 apply effect; cancel when unit dead or tile no longer owned by player (#376).
- `build_port`: completion requires topology; port key uses full province id per world-model-identity.
- Shared use: same TurnResolver and development resolution logic in main game and sim_game.

Made with [Cursor](https://cursor.com)