### PR TITLE
Victory GDD: add world-model-identity and world-model cross-refs (Fixes #404)

### DIFF
--- a/SPEC/game/victory.md
+++ b/SPEC/game/victory.md
@@ -7,6 +7,7 @@
 ## Current scope: Military Victory Only
 
 - **Condition:** A Great Power controls **31 or more Old World provinces**. Control means the province’s owner is that Great Power (i.e. the province’s `ownerId` equals the GP’s player id).
+- **Province identity:** Ownership and counting of provinces for the victory check use the same province identity and lookup rules as the rest of the game: prefixed province id (`regionId|localId`) and region-scoped lookup. See [world-model-identity.md](world-model-identity.md). The **Old World** region identity (e.g. `oldWorld`) is defined in [world-model.md](world-model.md) (§ Regions).
 - **Eligibility:** Only Great Powers are eligible. Minor Nations and Tribes do not win.
 - **Tie-breaking:** If two or more GPs each control ≥31 OW provinces in the same turn, the winner is the one with the lexicographically smallest player id (deterministic).
 


### PR DESCRIPTION
Adds cross-references in SPEC/game/victory.md so that:

- **Province identity:** Ownership and counting of provinces for the victory check are documented to use the same province identity and lookup rules as the rest of the game (prefixed province id `regionId|localId`, region-scoped lookup). Links to [world-model-identity.md](SPEC/game/world-model-identity.md).
- **Old World:** The Old World region identity (e.g. `oldWorld`) is clarified via link to [world-model.md](SPEC/game/world-model.md) (§ Regions).

Fixes #404.

Made with [Cursor](https://cursor.com)