### PR TITLE
Game setup pipeline TDD: add world-model-identity cross-ref for province id (Fixes #396)

### DIFF
--- a/SPEC/program/game-setup-pipeline.md
+++ b/SPEC/program/game-setup-pipeline.md
@@ -10,6 +10,7 @@ Orchestrates game creation from config through map generation, province/capital 
 - **Effective seed:** if `config.seed ≠ 0`, use directly; if 0 or absent, derive from `DateTime.now().millisecondsSinceEpoch`.
 - **Game / WorldState:** RegionData per region (OW, NW), Province list (id, regionId, ownerId), faction records (Players, Minor Nations, Tribes).
 - **InitGameResult:** Game, mapPngBytes, markdown, InitGameMapViewData.
+- **Province identity:** Province ids in Game, WorldState, InitGameResult, and capital/town assignment use the prefixed form (`regionId|localId`); topology and map lookups during setup are per-region. See [world-model-identity.md](../game/world-model-identity.md).
 
 ## Algorithm / Flow
 


### PR DESCRIPTION
Adds a cross-reference in SPEC/program/game-setup-pipeline.md to SPEC/game/world-model-identity.md in the Data Model section: province ids in Game, WorldState, InitGameResult, and capital/town assignment use prefixed form (`regionId|localId`); topology and map lookups during setup are per-region.

Fixes #396.

Made with [Cursor](https://cursor.com)