### PR TITLE
Movement TDD: acceptance criteria, world-model-identity, prefixed province id

### DIFF
--- a/SPEC/program/movement.md
+++ b/SPEC/program/movement.md
@@ -1,6 +1,12 @@
 # Movement
 
-**SPEC/program** — Movement rules and validation. Reference: [SPEC/game/map-topology.md](../game/map-topology.md), [turn-resolution.md](turn-resolution.md).
+**SPEC/program** — Movement rules and validation. Reference: [SPEC/game/map-topology.md](../game/map-topology.md), [turn-resolution.md](turn-resolution.md), [world-model-identity.md](../game/world-model-identity.md).
+
+---
+
+## Province identity (world-model-identity)
+
+MoveOrder `destinationProvinceId` and unit `provinceId` (game state) must use **prefixed** form (`regionId|localId`). See [SPEC/game/world-model-identity.md](../game/world-model-identity.md). The map `tileKeysByRegionAndProvince[regionId]` is keyed by **prefixed** province id (as built in game setup). Validation uses **local** ids for topology lookups; game state and orders use **prefixed** ids.
 
 ---
 
@@ -34,8 +40,16 @@ Invalid moves are rejected; unit location unchanged.
 
 ## Resolution
 
-TurnResolver runs a **movement** step that applies validated move orders. Order of application (e.g. by player, by unit) is deterministic. See [turn-resolution-phases.md](turn-resolution-phases.md).
+TurnResolver runs a **movement** step that applies validated move orders. **Application order:** Deterministic. Orders are applied by **player** (iteration order of `moveOrdersByPlayerId`), then by **order list index** within each player. This defines determinism and replay. See [turn-resolution-phases.md](turn-resolution-phases.md).
 
-- **Civilian units:** Set the unit’s **tileKey** to a valid tile in the **destination province** (e.g. first tile in `tileKeysByRegionAndProvince[regionId][order.destinationProvinceId]`); province is derived from tileKey.
-- **Military units:** Update the unit’s **provinceId** to the destination (no tileKey).
+- **Civilian units:** Set the unit’s **tileKey** to a valid tile in the **destination province** (e.g. first tile in `tileKeysByRegionAndProvince[regionId][fullProvinceId]` where destination is in prefixed form); set unit **provinceId** to that prefixed id.
+- **Military units:** Update the unit’s **provinceId** to the destination (prefixed; no tileKey).
 - **Naval:** Movement remains at sea zone / fleet level; no tileKey for ships.
+
+---
+
+## Acceptance criteria
+
+- **Land movement:** Destination is adjacent (P–P); unit `provinceId` is updated to the destination (prefixed). For civilian units, `tileKey` is set to a tile in the destination when `tileKeysByRegionAndProvince` and `regionId` are provided. Invalid moves leave unit location unchanged.
+- **Validation (order engine):** Rejects non-adjacent, wrong unit/owner, and visibility violations; uses the same topology as resolution. Province id: validation uses **local** ids for topology; game state and orders use **prefixed** ids (see [world-model-identity.md](../game/world-model-identity.md)).
+- **Province id:** Stored and looked up using prefixed form; `tileKeysByRegionAndProvince[regionId]` is keyed by prefixed province id.

--- a/packages/colonizethis_logic/lib/src/world/movement.dart
+++ b/packages/colonizethis_logic/lib/src/world/movement.dart
@@ -96,9 +96,13 @@ RegionData applyMoveOrdersToRegion(
           ProvinceId.regionIdFrom(destProvinceId) != regionId) {
         continue; // Land move cannot cross regions.
       }
+      // Normalize to prefixed form when regionId known (SPEC/game/world-model-identity.md).
+      final destFullId = regionId != null && !ProvinceId.isPrefixed(destProvinceId)
+          ? ProvinceId.full(regionId, destProvinceId)
+          : destProvinceId;
       // Topology uses local province ids; validate using region-scoped adjacency when region known.
       final fromLocal = ProvinceId.localIdFrom(currentProvinceId);
-      final toLocal = ProvinceId.localIdFrom(destProvinceId);
+      final toLocal = ProvinceId.localIdFrom(destFullId);
       final valid = regionId != null
           ? isValidLandMoveInRegion(topology, regionId!, fromLocal, toLocal)
           : isValidLandMove(topology, fromLocal, toLocal);
@@ -108,16 +112,16 @@ RegionData applyMoveOrdersToRegion(
       final isCivilian = unit.tileKey != null && unit.tileKey!.isNotEmpty;
       final firstTileInDest = regionId != null &&
               tileKeysByRegionAndProvince != null &&
-              (tileKeysByRegionAndProvince[regionId]?[destProvinceId]?.isNotEmpty ?? false)
-          ? tileKeysByRegionAndProvince[regionId]![destProvinceId]!.first
+              (tileKeysByRegionAndProvince[regionId]?[destFullId]?.isNotEmpty ?? false)
+          ? tileKeysByRegionAndProvince[regionId]![destFullId]!.first
           : null;
       if (isCivilian && firstTileInDest != null) {
         unitsById[unit.id] = unit.copyWith(
-          provinceId: destProvinceId,
+          provinceId: destFullId,
           tileKey: firstTileInDest,
         );
       } else {
-        unitsById[unit.id] = unit.copyWith(provinceId: destProvinceId);
+        unitsById[unit.id] = unit.copyWith(provinceId: destFullId);
       }
     }
   }

--- a/packages/colonizethis_logic/test/movement_test.dart
+++ b/packages/colonizethis_logic/test/movement_test.dart
@@ -109,6 +109,7 @@ void main() {
         ],
       );
       const destTileKey = 'oldWorld|P2|0|0';
+      final destFullId = ProvinceId.full(regionId, 'P2');
       final region = RegionData(
         provinces: const [
           Province(id: 'P1', regionId: regionId, ownerId: 'p1'),
@@ -119,7 +120,7 @@ void main() {
             id: 'u1',
             type: 'Merchant',
             ownerId: 'p1',
-            provinceId: 'P1',
+            provinceId: 'oldWorld|P1',
             tileKey: 'oldWorld|P1|0|0',
           ),
         ],
@@ -135,10 +136,10 @@ void main() {
         orders,
         regionId: regionId,
         tileKeysByRegionAndProvince: {
-          regionId: {'P2': [destTileKey]},
+          regionId: {destFullId: [destTileKey]},
         },
       );
-      expect(updated.units.single.provinceId, 'P2');
+      expect(updated.units.single.provinceId, destFullId);
       expect(updated.units.single.tileKey, destTileKey);
     });
   });

--- a/packages/colonizethis_logic/test/order_projections_test.dart
+++ b/packages/colonizethis_logic/test/order_projections_test.dart
@@ -62,7 +62,7 @@ void main() {
                 id: 'u1',
                 type: 'Regiment',
                 ownerId: 'p1',
-                provinceId: 'P1',
+                provinceId: 'oldWorld|P1',
               ),
             ],
           ),
@@ -88,7 +88,7 @@ void main() {
       );
       expect(effects.workerCount, isNotNull);
       expect(effects.unitLocations, isNotNull);
-      expect(effects.unitLocations!['u1'], 'P2');
+      expect(effects.unitLocations!['u1'], 'oldWorld|P2');
     });
 
     test('returns ProjectedEffects with workerCount and unitLocations after full resolve', () {


### PR DESCRIPTION
Fixes #419, Fixes #420

## #419 — Movement TDD updates (SPEC/program/movement.md)
- **Province identity:** Added cross-ref to world-model-identity; state that MoveOrder `destinationProvinceId` and unit `provinceId` use prefixed form; `tileKeysByRegionAndProvince[regionId]` is keyed by prefixed province id.
- **Application order:** Replaced vague "deterministic" with: by player (iteration order of `moveOrdersByPlayerId`), then by order list index within each player.
- **Acceptance criteria:** New section for land movement, validation (order engine), and province id (prefixed storage/lookup).

## #420 — Movement resolution (prefixed province id)
- In `applyMoveOrdersToRegion` (movement.dart): when `regionId` is known, normalize destination to prefixed form (`ProvinceId.full(regionId, dest)`) before lookup and before updating unit `provinceId`/`tileKey`.
- Ensures game state always stores prefixed province ids; `tileKeysByRegionAndProvince` lookup uses same key format as game_setup.
- Tests: movement_test civilian test uses prefixed keys and expects prefixed `provinceId`; order_projections_test expects `oldWorld|P2` after resolve.

Made with [Cursor](https://cursor.com)