### PR TITLE
fix(map): correct SPEC path for tile-based-map-generation reference

### DIFF
--- a/packages/colonizethis_map/lib/src/tile_map_generator.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator.dart
@@ -1,4 +1,4 @@
-// SPEC/program/tile-map-gen-algorithm.md, tile-map-gen-resources.md, tile-map-gen-config.md. Reference: SPEC/ideas/tile-based-map-generation.md.
+// SPEC/program/tile-map-gen-algorithm.md, tile-map-gen-resources.md, tile-map-gen-config.md. Reference: SPEC/archive/tile-based-map-generation.md.
 
 import 'dart:math';
 


### PR DESCRIPTION
The tile_map_generator comment referenced `SPEC/ideas/tile-based-map-generation.md`, which does not exist. The design doc lives at `SPEC/archive/tile-based-map-generation.md`.

Fixes #424.

Made with [Cursor](https://cursor.com)