### PR TITLE
fix(data): spec paths and cross-refs in resource.dart, terrain_type.dart

### DIFF
--- a/packages/colonizethis_data/lib/src/resource.dart
+++ b/packages/colonizethis_data/lib/src/resource.dart
@@ -1,5 +1,5 @@
-/// Map resource (raw commodity on a tile). SPEC/game/tile-map-and-generation, GDD 04b.
-/// Full set per Imperialism II Terrain and Development table; see SPEC/game/resource-terrain-region-rules.md.
+/// Map resource (raw commodity on a tile).
+/// Full set per Imperialism II Terrain and Development table; see SPEC/game/resource-terrain-region-rules.md for resource/terrain table and spawn weights.
 enum Resource {
   grain,
   meat,

--- a/packages/colonizethis_data/lib/src/terrain_type.dart
+++ b/packages/colonizethis_data/lib/src/terrain_type.dart
@@ -1,5 +1,5 @@
-/// Terrain type for a land tile. SPEC/game/tile-map-and-generation, GDD 04b.
-/// Minimal set for Phase 1; extend per ruleset later.
+/// Terrain type for a land tile.
+/// Minimal set for Phase 1; extend per ruleset later. See SPEC/game/resource-terrain-region-rules.md for terrain types and SPEC/game/tile-map-and-generation.md for map generation.
 enum TerrainType {
   plains,
   forest,


### PR DESCRIPTION
Fixes #423.

- In `resource.dart`: removed "GDD 04b" and incomplete path; doc now references `SPEC/game/resource-terrain-region-rules.md` for resource/terrain table and spawn weights.
- In `terrain_type.dart`: removed "GDD 04b"; added cross-refs to `SPEC/game/resource-terrain-region-rules.md` and `SPEC/game/tile-map-and-generation.md` with `.md` extension.

Acceptance: no "GDD 04b" or "TDD 04b" in these files; all spec references use existing SPEC paths with `.md`.

Made with [Cursor](https://cursor.com)