### PR TITLE
spec(fog): add world-model-identity cross-ref for province and tile identity

### DIFF
--- a/SPEC/game/fog-and-exploration.md
+++ b/SPEC/game/fog-and-exploration.md
@@ -96,3 +96,4 @@ Mineral resources may only be extracted from tiles that are (a) connected and (b
 - Resource/terrain rules: [resource-terrain-region-rules.md](resource-terrain-region-rules.md)
 - Extraction gating: [extraction-and-improvements.md](extraction-and-improvements.md)
 - World model (tile positioning): [world-model.md](world-model.md)
+- Province and tile identity (prefixed ids, tile keys): [world-model-identity.md](world-model-identity.md)

--- a/SPEC/program/fog-and-exploration-resolution.md
+++ b/SPEC/program/fog-and-exploration-resolution.md
@@ -8,7 +8,7 @@ Maintains per-player visibility and prospected state on world state; resolves ex
 
 ## Data Model
 
-**Visibility state:** `Map<playerId, Map<tileKey, VisibilityLevel>>` — enum: unknown, revealed, fogged, fullyVisible. Tile key format: `regionId|provinceId|x|y`. Stored on WorldState.
+**Visibility state:** `Map<playerId, Map<tileKey, VisibilityLevel>>` — enum: unknown, revealed, fogged, fullyVisible. Tile key format: `regionId|provinceId|x|y`. Province and tile key formats: [world-model-identity.md](../game/world-model-identity.md). Stored on WorldState.
 
 **Prospected state:** `Map<playerId, Set<tileKey>>` — tiles the player has prospected. Only mineral-eligible terrain per game rules.
 


### PR DESCRIPTION
Adds cross-references to SPEC/game/world-model-identity.md in the fog-and-exploration GDD and TDD for province and tile identity (prefixed ids, tile keys).

- **GDD** (SPEC/game/fog-and-exploration.md): New bullet in Interactions linking to world-model-identity.
- **TDD** (SPEC/program/fog-and-exploration-resolution.md): Data Model sentence linking tile key / province key formats to world-model-identity.

Fixes #440

Made with [Cursor](https://cursor.com)