### PR TITLE
spec(game): clarify world-model-identity in stockpiles GDD

### DIFF
--- a/SPEC/game/stockpiles-and-production.md
+++ b/SPEC/game/stockpiles-and-production.md
@@ -21,7 +21,7 @@ Capacity for all commodities is infinite; no limit on the amount of each commodi
 
 ### Relations
 - **Player** → **Stockpile** (commodity quantities).
-- Extraction in provinces → owning player's stockpile (via transport network).
+- Extraction in provinces → owning player's stockpile (via transport network). Province and tile identity (owned provinces, extraction locations) follow [world-model-identity.md](world-model-identity.md) for province id format and region-scoped lookup.
 - Production: stockpile inputs (commodities) + WorkerPool labour → stockpile outputs.
 
 


### PR DESCRIPTION
Minor clarification to explicitly state that province and tile identity for extraction/transport in stockpiles-and-production follow the multi-region rules in SPEC/game/world-model-identity.md.\n\nRefs #437.

Made with [Cursor](https://cursor.com)