### PR TITLE
fix(docs): fog-and-exploration SPEC path in PlayerView and TurnResolver

### DIFF
--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -357,7 +357,7 @@ Game _runEndOfTurnPhase(Game game, {void Function(DialogueEvent)? onDialogue}) {
     for (final e in events) onDialogue(e);
   }
 
-  // Spy 5-turn fog decay: decrement timers; where 0, set that province's tiles to fogged. SPEC/fog-and-exploration-resolution.md.
+  // Spy 5-turn fog decay: decrement timers; where 0, set that province's tiles to fogged. SPEC/program/fog-and-exploration-resolution.md.
   var visibilityByTile = Map<String, Map<String, String>>.from(
     game.worldState.playerVisibilityByTile.map(
       (k, v) => MapEntry(k, Map<String, String>.from(v)),
@@ -392,7 +392,7 @@ Game _runEndOfTurnPhase(Game game, {void Function(DialogueEvent)? onDialogue}) {
       spyRevealTurnsByPlayer: nextSpyTimers,
     ),
   );
-  // Fog decay: other-faction provinces with no Explorer/Spy → fogged. SPEC/fog-and-exploration-resolution.md.
+  // Fog decay: other-faction provinces with no Explorer/Spy → fogged. SPEC/program/fog-and-exploration-resolution.md.
   final nextVisibility = _applyFogDecay(stateForFog);
 
   return game.copyWith(
@@ -656,7 +656,7 @@ Game _runMovementPhase(
       regionId: kRegionNewWorld,
       tileKeysByRegionAndProvince: tileKeysByRegion,
     );
-    // Spy leave province: set 5-turn reveal timer for (owner, left province). SPEC/fog-and-exploration-resolution.md.
+    // Spy leave province: set 5-turn reveal timer for (owner, left province). SPEC/program/fog-and-exploration-resolution.md.
     final spyTimers = Map<String, Map<String, int>>.from(
       state.worldState.spyRevealTurnsByPlayer.map(
         (k, v) => MapEntry(k, Map<String, int>.from(v)),

--- a/packages/colonizethis_logic/lib/src/world/player_view.dart
+++ b/packages/colonizethis_logic/lib/src/world/player_view.dart
@@ -126,7 +126,7 @@ PlayerView buildPlayerView(
     visibilityByTile[tileKey] = level;
   });
 
-  // Spy presence reveal: while a Spy is in a non-owner province, that province is fully visible. SPEC/fog-and-exploration-resolution.md.
+  // Spy presence reveal: while a Spy is in a non-owner province, that province is fully visible. SPEC/program/fog-and-exploration-resolution.md.
   for (final u in ownUnitsById.values) {
     if (!isSpyUnit(u.type)) continue;
     final provId = u.locationProvinceId;


### PR DESCRIPTION
Fixes #446

- **PlayerView:** Spy presence reveal comment now points to `SPEC/program/fog-and-exploration-resolution.md` (was `SPEC/fog-and-exploration-resolution.md`).
- **TurnResolver:** Three comments (Spy 5-turn fog decay, fog decay, Spy leave province) updated to the same path.
- Grep confirms no remaining bare `SPEC/fog-and-exploration-resolution.md` in repo.

Documentation/architecture alignment only; no behaviour change.

Made with [Cursor](https://cursor.com)