### PR TITLE
docs(extraction): align improvement cost scaling configurable

### DIFF
--- a/SPEC/game/extraction-and-improvements.md
+++ b/SPEC/game/extraction-and-improvements.md
@@ -79,7 +79,7 @@ Extractable commodities are exactly the same as in Imp2. See [commodity-catalog.
 |---|---|---|
 | Max improvement level | 4 | |
 | Transport levels | 0, 1, 2, 4 | |
-| Improvement cost scaling | ×2 per level | lumber + cast iron |
+| Improvement cost scaling | 1, 4, 8, 16 per level | lumber + cast iron |
 | Road cost | 1 lumber + 1 cast iron | Per tile |
 
 ---


### PR DESCRIPTION
Fixes #451.

- Treat the Extraction-and-improvements GDD "Improvement Build Costs (Builder)" table (1, 4, 8, 16) as authoritative for improvement material costs.
- Update the Configurable Values row for "Improvement cost scaling" to explicitly describe the same 1, 4, 8, 16 pattern instead of the ambiguous "×2 per level".

Made with [Cursor](https://cursor.com)