### PR TITLE
feat(extraction): align improvement build costs with spec (Fixes #368)

### DIFF
--- a/packages/colonizethis_data/lib/src/work_order_costs.dart
+++ b/packages/colonizethis_data/lib/src/work_order_costs.dart
@@ -39,7 +39,9 @@ int totalTurnsForWork(String workTarget, {int? improvementLevel, int? fortLevel}
 /// Material cost for build_improvement at given current level (cost to raise to level+1).
 /// SPEC: level 1 = 1 lumber + 1 cast iron; 2 = 4+4; 3 = 8+8; 4 = 16+16.
 WorkOrderCost workOrderCostBuildImprovement(int currentLevel) {
-  final scale = currentLevel == 0 ? 1 : (1 << (currentLevel - 1)).clamp(1, 16);
+  final clampedLevel = currentLevel.clamp(0, 3);
+  const scalesByNextLevel = [1, 4, 8, 16];
+  final scale = scalesByNextLevel[clampedLevel];
   return {
     CommodityCatalog.lumber.id: scale,
     CommodityCatalog.castIron.id: scale,

--- a/packages/colonizethis_data/test/work_order_costs_test.dart
+++ b/packages/colonizethis_data/test/work_order_costs_test.dart
@@ -53,25 +53,25 @@ void main() {
       expect(cost[CommodityCatalog.castIron.id], 1);
       expect(cost.length, 2);
     });
-    test('level 1: 1 lumber + 1 cast iron', () {
+    test('level 1: 4 lumber + 4 cast iron (SPEC)', () {
       final cost = workOrderCostBuildImprovement(1);
-      expect(cost[CommodityCatalog.lumber.id], 1);
-      expect(cost[CommodityCatalog.castIron.id], 1);
-    });
-    test('level 2: scale 2 (2 lumber + 2 cast iron)', () {
-      final cost = workOrderCostBuildImprovement(2);
-      expect(cost[CommodityCatalog.lumber.id], 2);
-      expect(cost[CommodityCatalog.castIron.id], 2);
-    });
-    test('level 3: scale 4 (4 lumber + 4 cast iron)', () {
-      final cost = workOrderCostBuildImprovement(3);
       expect(cost[CommodityCatalog.lumber.id], 4);
       expect(cost[CommodityCatalog.castIron.id], 4);
     });
-    test('level 4: scale 8 (8 lumber + 8 cast iron)', () {
-      final cost = workOrderCostBuildImprovement(4);
+    test('level 2: 8 lumber + 8 cast iron (SPEC)', () {
+      final cost = workOrderCostBuildImprovement(2);
       expect(cost[CommodityCatalog.lumber.id], 8);
       expect(cost[CommodityCatalog.castIron.id], 8);
+    });
+    test('level 3: 16 lumber + 16 cast iron (SPEC)', () {
+      final cost = workOrderCostBuildImprovement(3);
+      expect(cost[CommodityCatalog.lumber.id], 16);
+      expect(cost[CommodityCatalog.castIron.id], 16);
+    });
+    test('level 4+: clamped to 16 lumber + 16 cast iron (SPEC max level 4)', () {
+      final cost = workOrderCostBuildImprovement(4);
+      expect(cost[CommodityCatalog.lumber.id], 16);
+      expect(cost[CommodityCatalog.castIron.id], 16);
     });
   });
 
@@ -139,11 +139,11 @@ void main() {
       expect(workOrderMaterialCost('counter_spy'), isNull);
       expect(workOrderMaterialCost('purchase_land'), isNull);
     });
-    test('build_improvement returns cost for improvementLevel', () {
+    test('build_improvement returns cost for improvementLevel (SPEC scaling)', () {
       final cost = workOrderMaterialCost('build_improvement', improvementLevel: 2);
       expect(cost, isNotNull);
-      expect(cost![CommodityCatalog.lumber.id], 2);
-      expect(cost[CommodityCatalog.castIron.id], 2);
+      expect(cost![CommodityCatalog.lumber.id], 8);
+      expect(cost[CommodityCatalog.castIron.id], 8);
     });
     test('build_improvement defaults improvementLevel to 0', () {
       final cost = workOrderMaterialCost('build_improvement');


### PR DESCRIPTION
Aligns Builder improvement material costs with SPEC/game/extraction-and-improvements.md (1, 4, 8, 16 pattern) by updating - workOrderCostBuildImprovement in work_order_costs.dart to use a clamped [1, 4, 8, 16] scale based on current improvement level (cost to raise to next level).- associated tests in work_order_costs_test.dart (including workOrderMaterialCost) to assert the new scaling.All package tests run via:- dart test packages/colonizethis_data- dart test packages/colonizethis_logic

Made with [Cursor](https://cursor.com)