### PR TITLE
Diplomacy resolution: add logging per ctdev-logging (phase start/end, key outcomes)

### DIFF
--- a/SPEC/program/diplomacy-resolution.md
+++ b/SPEC/program/diplomacy-resolution.md
@@ -46,6 +46,17 @@ Diplomacy phase runs before Movement. Resolution steps in order:
 
 ---
 
+## Logging
+
+Per [ctdev-logging.md](ctdev-logging.md): diplomacy is in **logic** scope. Phase start/end are logged by the turn resolver (`logic: phase diplomacy start` / `logic: phase diplomacy end`). The diplomacy resolver logs **key outcomes** with the `logic:` prefix so that flows and state changes are grep-friendly:
+
+- **Phase boundaries:** Diplomacy resolver logs phase start and end at debug (redundant with turn resolver but allows filtering by file).
+- **Key outcomes (info):** Overture payment applied (gpId, targetId, stage); Join Empire/Colony applied; alliance formed (faction pair); war declared (faction pair); peace offered (faction pair); agreements terminated due to war; GrantAid/SetSubsidy applied when modifier changes relation or treasury.
+
+Rejections and validation failures are logged by the order engine; diplomacy resolution logs only applied state changes.
+
+---
+
 ## Constraints
 
 - All diplomatic rules (relation thresholds, overture chain, order preconditions) are defined in game/diplomacy.md; this module references, not restates, them.

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -3,9 +3,12 @@
 /// alliance proposals, Declare War/Peace, relation modifiers, score update.
 
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
 
 import '../combat/conflict_detection.dart';
 import '../dossier/evidence_rules.dart';
+
+final Logger _diploLog = Logger();
 
 /// Overture costs per diplomacy-resolution. Consulate £500, Embassy £1000.
 const int overtureConsulateCost = 500;
@@ -94,6 +97,7 @@ Game resolveDiplomacyPhase(
   Orders orders, {
   void Function(DialogueEvent)? onDialogue,
 }) {
+  _diploLog.d('logic: diplomacy phase start');
   final turn = game.worldState.turnState.turnNumber;
   var state = game;
 
@@ -120,6 +124,7 @@ Game resolveDiplomacyPhase(
   // 7. Apply relation modifiers (grants, etc.) and update scores
   state = _applyRelationModifiersAndUpdateScores(state, diploByPlayer, turn);
 
+  _diploLog.d('logic: diplomacy phase end');
   return state;
 }
 
@@ -180,6 +185,7 @@ Game _processOverturePayments(
       } else {
         overtures = [...overtures, OvertureState(gpId: gpId, targetId: targetId, stage: stage, sinceTurn: turn)];
       }
+      _diploLog.i('logic: diplomacy overture $gpId -> $targetId $stage');
     }
   }
 
@@ -236,6 +242,7 @@ Game _resolveJoinEmpireColony(
         overtures = List<OvertureState>.from(overtures);
         overtures[idx] = overtures[idx].copyWith(stage: OvertureStage.joinEmpire, sinceTurn: turn);
         game = game.copyWith(overtureStates: overtures);
+        _diploLog.i('logic: diplomacy join empire $gpId $targetId');
       }
     }
   }
@@ -277,6 +284,7 @@ Game _processAlliances(
               ),
       );
       game = game.copyWith(diplomacyRelations: relations);
+      _diploLog.i('logic: diplomacy alliance $gpId-$targetId');
     }
   }
   return game;
@@ -334,6 +342,7 @@ Game _processWarAndPeace(
             diplomacyRelations: relations,
             dossierEvidenceEntries: [...game.dossierEvidenceEntries, ...evidence],
           );
+          _diploLog.i('logic: diplomacy war declared $gpId vs $targetId');
         }
       } else if (order.type == DiplomaticOrderType.offerPeace) {
         final targetId = order.targetFactionId;
@@ -360,6 +369,7 @@ Game _processWarAndPeace(
             diplomacyRelations: relations,
             dossierEvidenceEntries: [...game.dossierEvidenceEntries, ...evidence],
           );
+          _diploLog.i('logic: diplomacy peace $gpId-$targetId');
         }
       }
     }
@@ -379,6 +389,7 @@ Game _terminateAgreementsOnWar(Game game) {
   }
   if (overtures.length != game.overtureStates.length) {
     game = game.copyWith(overtureStates: overtures);
+    _diploLog.i('logic: diplomacy agreements terminated (war)');
   }
   return game;
 }
@@ -428,6 +439,7 @@ Game _applyRelationModifiersAndUpdateScores(
         return existing.copyWith(score: newScore, level: newLevel, lastInteractionTurn: turn);
       });
       game = game.copyWith(players: players, diplomacyRelations: relations);
+      _diploLog.i('logic: diplomacy GrantAid $gpId -> $targetId amount $amount');
     }
   }
 
@@ -457,6 +469,7 @@ Game _applyRelationModifiersAndUpdateScores(
         if (receiverIdx >= 0) {
           players[receiverIdx] = players[receiverIdx].copyWith(treasury: players[receiverIdx].treasury + amount);
         }
+        _diploLog.i('logic: diplomacy SetSubsidy $gpId -> $targetId amount $amount (treasury)');
       } else {
         // Minor/Tribe: no treasury; apply relation modifier (+3 per subsidy per diplomacy.md-style)
         final ids = _pairIds(gpId, targetId);
@@ -474,6 +487,7 @@ Game _applyRelationModifiersAndUpdateScores(
           }
           return existing.copyWith(score: newScore, level: newLevel, lastInteractionTurn: turn);
         });
+        _diploLog.i('logic: diplomacy SetSubsidy $gpId -> $targetId amount $amount (relation)');
       }
       game = game.copyWith(players: players, diplomacyRelations: relations);
     }


### PR DESCRIPTION
Adds logging for the diplomacy phase per SPEC/program/ctdev-logging.md.

**Spec**
- SPEC/program/diplomacy-resolution.md: new **Logging** section referencing ctdev-logging; documents phase start/end (turn resolver) and key outcomes logged by the diplomacy resolver with `logic:` prefix.

**Code**
- packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart:
  - Phase start/end at debug.
  - Key outcomes at info: overture payment (gpId, targetId, stage), join empire, alliance, war declared, peace, agreements terminated (war), GrantAid, SetSubsidy (treasury or relation).

Fixes #477

Made with [Cursor](https://cursor.com)