### PR TITLE
fix(colonizethis_map): remove agent debug logging; fix spec paths to map-visualization (Fixes #488)

### DIFF
--- a/packages/colonizethis_map/lib/src/game_world_state_map_visualizer.dart
+++ b/packages/colonizethis_map/lib/src/game_world_state_map_visualizer.dart
@@ -1,9 +1,7 @@
 // Game world state map visualization: ownership overlay and capital markers.
-// SPEC/program/map-data.md § Game world state map visualizer.
+// SPEC/program/map-visualization.md § Game world state map visualizer.
 
-import 'dart:convert';
 import 'dart:typed_data';
-import 'dart:io';
 
 import 'package:image/image.dart' as img;
 import 'package:colonizethis_data/colonizethis_data.dart';
@@ -16,39 +14,6 @@ import 'init_game_map_view_data.dart';
 
 const String _regionOldWorld = 'oldWorld';
 const String _regionNewWorld = 'newWorld';
-
-// #region agent log
-const String _agentDebugLogPath =
-    '/Users/waigore/Documents/GitHub/colonizethisv3/.cursor/debug-9f02df.log';
-
-void _agentDebugLog({
-  required String runId,
-  required String hypothesisId,
-  required String location,
-  required String message,
-  required Map<String, Object?> data,
-}) {
-  try {
-    final payload = <String, Object?>{
-      'sessionId': '9f02df',
-      'runId': runId,
-      'hypothesisId': hypothesisId,
-      'location': location,
-      'message': message,
-      'data': data,
-      'timestamp': DateTime.now().millisecondsSinceEpoch,
-    };
-    final line = '${jsonEncode(payload)}\n';
-    File(_agentDebugLogPath).writeAsStringSync(
-      line,
-      mode: FileMode.append,
-      flush: false,
-    );
-  } catch (_) {
-    // Swallow all errors in debug logger.
-  }
-}
-// #endregion
 
 /// Capital marker color (gold/yellow, distinct from terrain).
 const (int, int, int) capitalMarkerRgb = (255, 215, 0);
@@ -253,7 +218,7 @@ Uint8List renderSingleRegionGameStateMapToPng({
 }
 
 /// Renders the combined Old World + New World map with ownership and capitals.
-/// SPEC/program/map-data.md § Game world state map visualizer, Multi-region rendering.
+/// SPEC/program/map-visualization.md § Game world state map visualizer, Multi-region rendering.
 Uint8List renderInitGameMapToPng({
   required Game game,
   required Map<String, TileMapResult> tileMapByRegion,
@@ -425,31 +390,6 @@ Uint8List renderInitGameMapToPngFromViewData({
         color: color,
       );
     }
-
-    // #region agent log
-    final ownerIds = <String>{};
-    for (final cell in region.cells) {
-      if (!cell.isSea && (cell.ownerFactionId ?? '').isNotEmpty) {
-        ownerIds.add(cell.ownerFactionId!);
-      }
-    }
-    _agentDebugLog(
-      runId: 'pre-fix-1',
-      hypothesisId: 'H1-H2-H5',
-      location: 'game_world_state_map_visualizer.dart:_renderRegion',
-      message: 'Region render ownership summary',
-      data: {
-        'regionId': region.regionId,
-        'geographicMode': geographicMode,
-        'cellCount': region.cells.length,
-        'ownedLandCellCount': region.cells
-            .where((c) => !c.isSea && (c.ownerFactionId ?? '').isNotEmpty)
-            .length,
-        'uniqueOwnerIdsOnCells': ownerIds.toList(),
-        'factionColorKeys': region.factionColors.keys.toList(),
-      },
-    );
-    // #endregion
 
     // Reconstruct a minimal TileMapResult-like structure for border drawing.
     final tmpResult = TileMapResult(

--- a/packages/colonizethis_map/lib/src/init_game_map_view_builder.dart
+++ b/packages/colonizethis_map/lib/src/init_game_map_view_builder.dart
@@ -1,8 +1,5 @@
 /// Builder for InitGameMapViewData from game + tile maps + topology.
-/// SPEC/program/map-data.md § Map view model for tools.
-
-import 'dart:convert';
-import 'dart:io';
+/// SPEC/program/map-visualization.md § Map view model for tools.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -13,39 +10,6 @@ import 'tile_map_visualization_shared.dart';
 
 const String _regionOldWorld = 'oldWorld';
 const String _regionNewWorld = 'newWorld';
-
-// #region agent log
-const String _agentDebugLogPath =
-    '/Users/waigore/Documents/GitHub/colonizethisv3/.cursor/debug-9f02df.log';
-
-void _agentDebugLog({
-  required String runId,
-  required String hypothesisId,
-  required String location,
-  required String message,
-  required Map<String, Object?> data,
-}) {
-  try {
-    final payload = <String, Object?>{
-      'sessionId': '9f02df',
-      'runId': runId,
-      'hypothesisId': hypothesisId,
-      'location': location,
-      'message': message,
-      'data': data,
-      'timestamp': DateTime.now().millisecondsSinceEpoch,
-    };
-    final line = '${jsonEncode(payload)}\n';
-    File(_agentDebugLogPath).writeAsStringSync(
-      line,
-      mode: FileMode.append,
-      flush: false,
-    );
-  } catch (_) {
-    // Swallow all errors in debug logger.
-  }
-}
-// #endregion
 
 InitGameMapViewData buildInitGameMapViewData({
   required Game game,
@@ -118,23 +82,6 @@ RegionMapViewData _buildRegionViewData({
       provinceDisplayNameById[p.id] = p.displayName!;
     }
   }
-
-  // #region agent log
-  _agentDebugLog(
-    runId: 'pre-fix-1',
-    hypothesisId: 'H1-H2-H5',
-    location: 'init_game_map_view_builder.dart:_buildRegionViewData',
-    message: 'Province ownership mapping built for region',
-    data: {
-      'regionId': regionId,
-      'isOldWorld': isOldWorld,
-      'provinceCount': provinces.length,
-      'ownedProvinceCount': ownerByProvinceId.length,
-      'sampleProvinceIds': provinces.take(5).map((p) => p.id).toList(),
-      'sampleOwnerProvinceKeys': ownerByProvinceId.keys.take(5).toList(),
-    },
-  );
-  // #endregion
 
   // Collect faction ids by type for ownership colours.
   final greatPowerIds = <String>[];

--- a/packages/colonizethis_map/lib/src/init_game_map_view_data.dart
+++ b/packages/colonizethis_map/lib/src/init_game_map_view_data.dart
@@ -1,5 +1,5 @@
 /// View models for init_game map visualization (PNG and ctdev debug app).
-/// SPEC/program/map-data.md § Tile map visualizers, Map view model for tools.
+/// SPEC/program/map-visualization.md § Tile map visualizers, Map view model for tools.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 

--- a/packages/colonizethis_map/lib/src/multi_region_map_rendering.dart
+++ b/packages/colonizethis_map/lib/src/multi_region_map_rendering.dart
@@ -1,5 +1,5 @@
 // Multi-region map composition: Old World + New World side by side.
-// SPEC/program/map-data.md § Multi-region rendering.
+// SPEC/program/map-visualization.md § Multi-region rendering.
 
 import 'dart:typed_data';
 

--- a/packages/colonizethis_map/lib/src/tile_map_visualization.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_visualization.dart
@@ -1,4 +1,4 @@
-// Tile map to PNG with legend. SPEC/program/map-data.md § Tile map PNG export.
+// Tile map to PNG with legend. SPEC/program/map-visualization.md § Tile map PNG export.
 
 import 'dart:io';
 import 'dart:typed_data';
@@ -8,13 +8,13 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 
 import 'tile_map_visualization_shared.dart';
 
-/// Deep blue for sea zones. SPEC/program/map-data.md § Tile map PNG export.
+/// Deep blue for sea zones. SPEC/program/map-visualization.md § Tile map PNG export.
 const (int, int, int) seaColorRgb = (20, 60, 140);
 
-/// Light blue for sea zone borders (sea–sea). SPEC/program/map-data.md § Tile map PNG export.
+/// Light blue for sea zone borders (sea–sea). SPEC/program/map-visualization.md § Tile map PNG export.
 const (int, int, int) seaZoneBorderRgb = (173, 216, 230);
 
-/// Red for on-map region id labels (e.g. p1, s1). SPEC/program/map-data.md § Tile map PNG export.
+/// Red for on-map region id labels (e.g. p1, s1). SPEC/program/map-visualization.md § Tile map PNG export.
 const (int, int, int) regionIdLabelRgb = (220, 0, 0);
 
 const int _titleLines = 2;
@@ -31,7 +31,7 @@ Iterable<String> _regionIdsFromResult(TileMapResult result) sync* {
 /// When [result.terrainGrid] is present: fill by terrain (sea = deep blue), draw province/sea borders in black, terrain legend. Otherwise: region-colored fill and region legend.
 /// When [landSeedPositions] is provided, draws a marker at each cell center and adds a legend row for land seeds.
 /// When [landSeedContinentIndices] is provided and same length as [landSeedPositions], land seeds are colored by continent and the legend lists one row per continent.
-/// When [continentSeedPositions] is provided, draws a distinct marker at each and adds a legend row for continent seeds. SPEC/program/map-data.md § Tile map PNG export.
+/// When [continentSeedPositions] is provided, draws a distinct marker at each and adds a legend row for continent seeds. SPEC/program/map-visualization.md § Tile map PNG export.
 Uint8List renderTileMapToPng(
   TileMapResult result,
   MapTopology topology, {

--- a/packages/colonizethis_map/lib/src/tile_map_visualization_shared.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_visualization_shared.dart
@@ -1,5 +1,5 @@
 // Shared helpers for tile map and game world state visualization.
-// SPEC/program/map-data.md § Tile map visualizers, Legend layout abstraction.
+// SPEC/program/map-visualization.md § Tile map visualizers, Legend layout abstraction.
 
 import 'package:image/image.dart' as img;
 import 'package:colonizethis_data/colonizethis_data.dart';
@@ -31,7 +31,7 @@ const List<(int r, int g, int b)> regionPalette = [
 ];
 
 /// Fixed RGB per terrain type for map fill and legend. Shared by base tile map visualizer and map view builder.
-/// SPEC/program/map-data.md § Map view model for tools, Tile map PNG export.
+/// SPEC/program/map-visualization.md § Map view model for tools, Tile map PNG export.
 const Map<TerrainType, (int r, int g, int b)> terrainColorRgb = {
   TerrainType.plains: (200, 220, 160),
   TerrainType.forest: (34, 100, 34),
@@ -42,7 +42,7 @@ const Map<TerrainType, (int r, int g, int b)> terrainColorRgb = {
 };
 
 /// Returns the single-letter legend glyph for a resource id (e.g. grain → 'g'), or null if unknown.
-/// Matches SPEC/program/map-data.md legend; see SPEC/game/resource-terrain-region-rules.md.
+/// Matches SPEC/program/map-visualization.md legend; see SPEC/game/resource-terrain-region-rules.md.
 String? resourceIdToLegendLetter(String? resourceId) {
   if (resourceId == null || resourceId.isEmpty) return null;
   switch (resourceId) {


### PR DESCRIPTION
Fixes #488.

**1) Agent debug code removed**
- `game_world_state_map_visualizer.dart` and `init_game_map_view_builder.dart`: removed `_agentDebugLog` and all `#region agent log` blocks that wrote to a hardcoded path. No file I/O; aligns with SPEC/program/ctdev-logging.md and core principles (logger only, no print).

**2) Spec path in comments corrected**
- Comments that refer to **Tile map PNG export**, **Game world state map visualizer**, **Multi-region rendering**, **Tile map visualizers**, **Legend layout**, and **Map view model** now point to `SPEC/program/map-visualization.md` (not `map-data.md`). Updated in:
  - `tile_map_visualization.dart`
  - `tile_map_visualization_shared.dart`
  - `game_world_state_map_visualizer.dart`
  - `init_game_map_view_builder.dart`
  - `init_game_map_view_data.dart`
  - `multi_region_map_rendering.dart`
- `topology_generator.dart` and package-level `colonizethis_map.dart` keep `map-data.md` refs (data model / topology generation).

Refs: #132, ctdev-logging, colonizethis-core-principles.

Made with [Cursor](https://cursor.com)