### PR TITLE
Production resolution: log when unknown recipe id is skipped (ctdev-logging)

### DIFF
--- a/packages/colonizethis_logic/lib/src/economy/economy_production.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_production.dart
@@ -52,7 +52,8 @@ ProductionResult resolveProduction({
   for (final assignment in assignments) {
     final recipe = ProductionRecipesCatalog.byId[assignment.recipeId];
     if (recipe == null) {
-      continue; // unknown recipe id; ignore
+      _log.w('logic: production skip unknown recipe id ${assignment.recipeId}');
+      continue;
     }
     if (assignment.assignedLabour <= 0) continue;
 


### PR DESCRIPTION
Fixes #496.

SPEC/program/ctdev-logging.md requires production (logic scope) to log key operations including rejections/skips. When an assignment references an unknown recipe id, the resolver now logs:

`logic: production skip unknown recipe id <id>`

at warning level so it appears in ctdev logs and can be grepped.

Made with [Cursor](https://cursor.com)