### PR TITLE
Research-resolution TDD and research-state GDD: add acceptance criteria

### DIFF
--- a/SPEC/game/research-state.md
+++ b/SPEC/game/research-state.md
@@ -19,3 +19,10 @@ Currently:
 - `currentResearchTechId` = null
 - `researchableTechIds` = []
 - Player tabs show `techUnlocked` only; display placeholder or empty for "currently researching" and "next paths".
+
+## Acceptance criteria
+
+- **State on Player:** `techUnlocked` (map tech id → true) and per-slot research progress exist; `currentResearchTechId` (or equivalent per-slot assignment) and `researchableTechIds` are defined by the model.
+- **Dependencies:** A tech is researchable when all its dependencies are in `techUnlocked`; dependencies follow Imperialism II–style tech tree per [tech-tree.md](tech-tree.md).
+- **Progress:** Research progress is tracked per slot per turn; completion and slot clearing are defined in [research-resolution.md](../program/research-resolution.md).
+- **Sim game stubs:** When stubs are used, `currentResearchTechId` is null, `researchableTechIds` is empty, and UI may show placeholders for "currently researching" and "next paths".

--- a/SPEC/program/research-resolution.md
+++ b/SPEC/program/research-resolution.md
@@ -33,3 +33,12 @@ Per player, per turn: slot assignments (slot index → tech id) and funding leve
 - Clearing a slot loses all progress for that tech (no partial save).
 - A tech cannot be started in the same turn its prerequisite completes.
 - Total research commitment per turn ≤ player treasury.
+
+## Acceptance criteria
+
+- **Phase order:** Research phase runs after Production and Consumption per [turn-resolution-phases.md](turn-resolution-phases.md); resolver reads merged orders from [order-engine.md](order-engine.md).
+- **One order per slot:** At most one research order per slot index per player; if multiple exist, last in merged list wins; no double spend or dual progress for that slot.
+- **Validation:** Prerequisites, slot limits, treasury, and catalog membership are checked; invalid slots are rejected or reduced before spending.
+- **Spend and progress:** Research spending is deducted from treasury; funding level maps to research points per GDD presets; progress is added to the slot's tech.
+- **Completion:** When progress ≥ tech cost, tech is marked unlocked, slot progress cleared, and derived state (extraction cap, military level) updated.
+- **Persistence:** Updated `techUnlocked`, research progress, and treasury are persisted; clearing a slot loses all progress for that tech (no partial save).


### PR DESCRIPTION
Fixes #511. Fixes #510.

- **SPEC/program/research-resolution.md:** Add *Acceptance criteria* (phase order, one order per slot, validation, spend/progress, completion, persistence).
- **SPEC/game/research-state.md:** Add *Acceptance criteria* (state on Player, dependencies, progress, sim game stubs).

Made with [Cursor](https://cursor.com)