### PR TITLE
Game world state map visualizer: reduce duplication between PNG render paths

### DIFF
--- a/packages/colonizethis_map/lib/src/game_world_state_map_visualizer.dart
+++ b/packages/colonizethis_map/lib/src/game_world_state_map_visualizer.dart
@@ -15,9 +15,6 @@ import 'init_game_map_view_data.dart';
 const String _regionOldWorld = 'oldWorld';
 const String _regionNewWorld = 'newWorld';
 
-/// Capital marker color (gold/yellow, distinct from terrain).
-const (int, int, int) capitalMarkerRgb = (255, 215, 0);
-
 /// Resolves terrain RGB for a cell (geographic fill). Uses terrainType or parses terrainTypeId.
 (int r, int g, int b) _terrainRgbForCell(
   CellViewData cell,
@@ -31,9 +28,6 @@ const (int, int, int) capitalMarkerRgb = (255, 215, 0);
   final rgb = region.terrainColors[terrain];
   return rgb ?? (128, 128, 128);
 }
-
-/// Port marker color (teal, distinct from capitals).
-const (int, int, int) portMarkerRgb = (0, 100, 140);
 
 /// Renders a single region (OW or NW) with ownership and capitals to PNG bytes.
 /// Used by renderInitGameMapToPng to render each region before composition.
@@ -103,97 +97,51 @@ Uint8List renderSingleRegionGameStateMapToPng({
 
   drawBorders(image, result, seaZoneIds, cellSize, seaZoneBorderColor);
 
-  // Port markers (filled square, teal, black outline) — drawn before capitals so capital on same tile stays on top
-  const portHalfSize = 4;
-  final portColor = image.getColor(
-    portMarkerRgb.$1,
-    portMarkerRgb.$2,
-    portMarkerRgb.$3,
+  drawPortMarkersOnImage(image, portTiles, cellSize);
+  drawCapitalMarkersOnImage(
+    image,
+    capitalTiles.map((c) => (x: c.x, y: c.y)),
+    cellSize,
   );
-  for (final pt in portTiles) {
-    final cx = pt.x * cellSize + cellSize ~/ 2;
-    final cy = pt.y * cellSize + cellSize ~/ 2;
-    img.fillRect(
-      image,
-      x1: cx - portHalfSize,
-      y1: cy - portHalfSize,
-      x2: cx + portHalfSize,
-      y2: cy + portHalfSize,
-      color: portColor,
-    );
-    img.drawRect(
-      image,
-      x1: cx - portHalfSize,
-      y1: cy - portHalfSize,
-      x2: cx + portHalfSize,
-      y2: cy + portHalfSize,
-      color: black,
-    );
-  }
-
-  // Capital markers (filled circle, gold, black outline)
-  const capitalRadius = 6;
-  final capitalColor = image.getColor(
-    capitalMarkerRgb.$1,
-    capitalMarkerRgb.$2,
-    capitalMarkerRgb.$3,
-  );
-  for (final cap in capitalTiles) {
-    final cx = cap.x * cellSize + cellSize ~/ 2;
-    final cy = cap.y * cellSize + cellSize ~/ 2;
-    img.fillCircle(image, x: cx, y: cy, radius: capitalRadius, color: capitalColor);
-    img.drawCircle(image, x: cx, y: cy, radius: capitalRadius, color: black);
-  }
 
   // Legend
   final legendY0 = mapH + legendPadding;
+  var legendY = legendY0;
   img.drawString(
     image,
     'Ownership by faction. Black = land borders; light blue = sea borders.',
     font: img.arial14,
     x: legendPadding,
-    y: legendY0,
+    y: legendY,
     color: black,
   );
+  legendY += legendLineHeight;
   img.drawString(
     image,
     'Capitals marked with gold circle.',
     font: img.arial14,
     x: legendPadding,
-    y: legendY0 + legendLineHeight,
+    y: legendY,
     color: black,
   );
+  legendY += legendLineHeight;
   if (portTiles.isNotEmpty) {
-    img.drawString(
-      image,
-      'Ports marked with teal square.',
-      font: img.arial14,
-      x: legendPadding,
-      y: legendY0 + 2 * legendLineHeight,
-      color: black,
-    );
+    legendY = drawPortsLegendLine(image, legendY);
   }
-  var row = titleLines + (portTiles.isNotEmpty ? 1 : 0);
   for (final fid in factionIds) {
-    final y = legendY0 + row * legendLineHeight;
     final c = factionColors[fid]!;
-    drawLegendSwatch(image, y, c.$1, c.$2, c.$3);
-    img.drawString(
-      image,
-      fid,
-      font: img.arial14,
-      x: legendPadding + swatchSize + swatchGap,
-      y: y,
-      color: black,
-    );
-    row++;
+    legendY = drawLegendLine(image, legendY, c.$1, c.$2, c.$3, fid);
   }
   if (capitalTiles.isNotEmpty) {
-    row++;
+    const capitalRadius = 6;
+    final capitalColor = image.getColor(
+      capitalMarkerRgb.$1,
+      capitalMarkerRgb.$2,
+      capitalMarkerRgb.$3,
+    );
     for (final cap in capitalTiles) {
-      final y = legendY0 + row * legendLineHeight;
       final cx = legendPadding + swatchSize ~/ 2;
-      final cy = y + swatchSize ~/ 2;
+      final cy = legendY + swatchSize ~/ 2;
       img.fillCircle(
         image,
         x: cx,
@@ -207,10 +155,10 @@ Uint8List renderSingleRegionGameStateMapToPng({
         'Capital of ${cap.displayName}',
         font: img.arial14,
         x: legendPadding + swatchSize + swatchGap,
-        y: y,
+        y: legendY,
         color: black,
       );
-      row++;
+      legendY += legendLineHeight;
     }
   }
 
@@ -425,59 +373,16 @@ Uint8List renderInitGameMapToPngFromViewData({
       }
     }
 
-    // Ports.
-    const portHalfSize = 4;
-    final portColor = image.getColor(
-      portMarkerRgb.$1,
-      portMarkerRgb.$2,
-      portMarkerRgb.$3,
+    drawPortMarkersOnImage(
+      image,
+      region.portMarkers.map((p) => (x: p.x, y: p.y)),
+      region.cellSize,
     );
-    for (final pt in region.portMarkers) {
-      final cx = pt.x * region.cellSize + region.cellSize ~/ 2;
-      final cy = pt.y * region.cellSize + region.cellSize ~/ 2;
-      img.fillRect(
-        image,
-        x1: cx - portHalfSize,
-        y1: cy - portHalfSize,
-        x2: cx + portHalfSize,
-        y2: cy + portHalfSize,
-        color: portColor,
-      );
-      img.drawRect(
-        image,
-        x1: cx - portHalfSize,
-        y1: cy - portHalfSize,
-        x2: cx + portHalfSize,
-        y2: cy + portHalfSize,
-        color: black,
-      );
-    }
-
-    // Capitals.
-    const capitalRadius = 6;
-    final capitalColor = image.getColor(
-      capitalMarkerRgb.$1,
-      capitalMarkerRgb.$2,
-      capitalMarkerRgb.$3,
+    drawCapitalMarkersOnImage(
+      image,
+      region.capitalMarkers.map((c) => (x: c.x, y: c.y)),
+      region.cellSize,
     );
-    for (final cap in region.capitalMarkers) {
-      final cx = cap.x * region.cellSize + region.cellSize ~/ 2;
-      final cy = cap.y * region.cellSize + region.cellSize ~/ 2;
-      img.fillCircle(
-        image,
-        x: cx,
-        y: cy,
-        radius: capitalRadius,
-        color: capitalColor,
-      );
-      img.drawCircle(
-        image,
-        x: cx,
-        y: cy,
-        radius: capitalRadius,
-        color: black,
-      );
-    }
 
     // Legend.
     var legendY = mapH + legendPadding;
@@ -491,40 +396,23 @@ Uint8List renderInitGameMapToPngFromViewData({
         color: black,
       );
       legendY += legendLineHeight;
-      drawLegendSwatch(
+      legendY = drawLegendLine(
         image,
         legendY,
         seaColorRgb.$1,
         seaColorRgb.$2,
         seaColorRgb.$3,
-      );
-      img.drawString(
-        image,
         'Sea',
-        font: img.arial14,
-        x: legendPadding + swatchSize + swatchGap,
-        y: legendY,
-        color: black,
       );
-      legendY += legendLineHeight;
       for (final entry in region.terrainColors.entries) {
-        final y = legendY;
-        drawLegendSwatch(
+        legendY = drawLegendLine(
           image,
-          y,
+          legendY,
           entry.value.$1,
           entry.value.$2,
           entry.value.$3,
-        );
-        img.drawString(
-          image,
           entry.key.name,
-          font: img.arial14,
-          x: legendPadding + swatchSize + swatchGap,
-          y: y,
-          color: black,
         );
-        legendY += legendLineHeight;
       }
       img.drawString(
         image,
@@ -561,35 +449,18 @@ Uint8List renderInitGameMapToPngFromViewData({
       );
       legendY += legendLineHeight;
       for (final entry in region.factionColors.entries) {
-        final y = legendY;
-        drawLegendSwatch(
+        legendY = drawLegendLine(
           image,
-          y,
+          legendY,
           entry.value.$1,
           entry.value.$2,
           entry.value.$3,
-        );
-        img.drawString(
-          image,
           entry.key,
-          font: img.arial14,
-          x: legendPadding + swatchSize + swatchGap,
-          y: y,
-          color: black,
         );
-        legendY += legendLineHeight;
       }
     }
     if (region.portMarkers.isNotEmpty) {
-      img.drawString(
-        image,
-        'Ports marked with teal square.',
-        font: img.arial14,
-        x: legendPadding,
-        y: legendY,
-        color: black,
-      );
-      legendY += legendLineHeight;
+      legendY = drawPortsLegendLine(image, legendY);
     }
 
     return img.encodePng(image);

--- a/packages/colonizethis_map/lib/src/tile_map_visualization_shared.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_visualization_shared.dart
@@ -237,3 +237,117 @@ void drawLegendLandSeedMarker(img.Image image, int y) {
   img.fillCircle(image, x: cx, y: cy, radius: 4, color: color);
   img.drawCircle(image, x: cx, y: cy, radius: 4, color: black);
 }
+
+// --- Game world state map visualizer: shared marker and legend helpers ---
+// SPEC/program/map-visualization.md § Game world state map visualizer.
+
+/// Capital marker color (gold), distinct from terrain. Used for drawing and legend.
+const (int, int, int) capitalMarkerRgb = (255, 215, 0);
+
+/// Port marker color (teal), distinct from capitals.
+const (int, int, int) portMarkerRgb = (0, 100, 140);
+
+/// Draws port markers (filled teal square with black outline) at cell centres.
+/// Call after fill and borders, before capital markers.
+void drawPortMarkersOnImage(
+  img.Image image,
+  Iterable<({int x, int y})> portTiles,
+  int cellSize,
+) {
+  const portHalfSize = 4;
+  final black = image.getColor(0, 0, 0);
+  final portColor = image.getColor(
+    portMarkerRgb.$1,
+    portMarkerRgb.$2,
+    portMarkerRgb.$3,
+  );
+  for (final pt in portTiles) {
+    final cx = pt.x * cellSize + cellSize ~/ 2;
+    final cy = pt.y * cellSize + cellSize ~/ 2;
+    img.fillRect(
+      image,
+      x1: cx - portHalfSize,
+      y1: cy - portHalfSize,
+      x2: cx + portHalfSize,
+      y2: cy + portHalfSize,
+      color: portColor,
+    );
+    img.drawRect(
+      image,
+      x1: cx - portHalfSize,
+      y1: cy - portHalfSize,
+      x2: cx + portHalfSize,
+      y2: cy + portHalfSize,
+      color: black,
+    );
+  }
+}
+
+/// Draws capital markers (filled gold circle with black outline) at cell centres.
+void drawCapitalMarkersOnImage(
+  img.Image image,
+  Iterable<({int x, int y})> positions,
+  int cellSize,
+) {
+  const capitalRadius = 6;
+  final black = image.getColor(0, 0, 0);
+  final capitalColor = image.getColor(
+    capitalMarkerRgb.$1,
+    capitalMarkerRgb.$2,
+    capitalMarkerRgb.$3,
+  );
+  for (final pos in positions) {
+    final cx = pos.x * cellSize + cellSize ~/ 2;
+    final cy = pos.y * cellSize + cellSize ~/ 2;
+    img.fillCircle(
+      image,
+      x: cx,
+      y: cy,
+      radius: capitalRadius,
+      color: capitalColor,
+    );
+    img.drawCircle(
+      image,
+      x: cx,
+      y: cy,
+      radius: capitalRadius,
+      color: black,
+    );
+  }
+}
+
+/// Draws one legend line: swatch (r,g,b) + label at [y]. Returns y + legendLineHeight.
+int drawLegendLine(
+  img.Image image,
+  int y,
+  int r,
+  int g,
+  int b,
+  String label,
+) {
+  drawLegendSwatch(image, y, r, g, b);
+  final black = image.getColor(0, 0, 0);
+  img.drawString(
+    image,
+    label,
+    font: img.arial14,
+    x: legendPadding + swatchSize + swatchGap,
+    y: y,
+    color: black,
+  );
+  return y + legendLineHeight;
+}
+
+/// Draws the "Ports marked with teal square." legend line at [y]. Returns y + legendLineHeight.
+int drawPortsLegendLine(img.Image image, int y) {
+  final black = image.getColor(0, 0, 0);
+  img.drawString(
+    image,
+    'Ports marked with teal square.',
+    font: img.arial14,
+    x: legendPadding,
+    y: y,
+    color: black,
+  );
+  return y + legendLineHeight;
+}


### PR DESCRIPTION
Adds shared helpers so `renderSingleRegionGameStateMapToPng` and the `_renderRegion` closure in `renderInitGameMapToPngFromViewData` call the same logic for:
- Port markers (drawPortMarkersOnImage)
- Capital markers (drawCapitalMarkersOnImage)
- Legend lines (drawLegendLine, drawPortsLegendLine)

Constants `capitalMarkerRgb` and `portMarkerRgb` moved to `tile_map_visualization_shared.dart`. Render functions stay thin and delegate to shared visualization helpers per colonizethis-core-principles.

Fixes #491.

Made with [Cursor](https://cursor.com)