### PR TITLE
GDD: extraction-and-improvements world-model-identity cross-ref (Fixes #450)

### DIFF
--- a/SPEC/game/extraction-and-improvements.md
+++ b/SPEC/game/extraction-and-improvements.md
@@ -2,11 +2,15 @@
 
 ## Overview
 
-Per-tile resource extraction using improvements, constrained by tech level and transport infrastructure. Civilian work orders build improvements, roads, ports, and railroads. Province and tile identity (e.g. owned provinces, tile keys, town and port lookup) follow [world-model-identity.md](world-model-identity.md).
+Per-tile resource extraction using improvements, constrained by tech level and transport infrastructure. Civilian work orders build improvements, roads, ports, and railroads. Province and tile identity (e.g. owned provinces, tile keys, town and port lookup) follow [world-model-identity.md](world-model-identity.md): extraction and connectivity use **tile keys** (format `regionId|localId|x|y`) and **province ids** (prefixed `regionId|localId`); province lookup must be region-scoped.
 
 ---
 
 ## Rules
+
+### Province and tile identity
+
+Extraction and connectivity use **tile keys** (format `regionId|localId|x|y`) and **province ids** (prefixed `regionId|localId`). Province lookup must be region-scoped; see [world-model-identity.md](world-model-identity.md).
 
 ### Extraction Formula
 


### PR DESCRIPTION
Fixes #450

- In SPEC/game/extraction-and-improvements.md:
  - **Overview:** Explicitly state that extraction and connectivity use tile keys (`regionId|localId|x|y`), prefixed province ids (`regionId|localId`), and region-scoped province lookup; cross-ref world-model-identity.
  - **Rules:** Add "Province and tile identity" subsection with the same wording so implementers see it in Rules.

Docs-only; aligns with world-model-identity cross-ref pattern (e.g. military-generals, #521).

Made with [Cursor](https://cursor.com)