### PR TITLE
Add AGENTS.md and condense Cursor rules

### DIFF
--- a/.cursor/rules/colonizethis-assets.mdc
+++ b/.cursor/rules/colonizethis-assets.mdc
@@ -6,23 +6,7 @@ alwaysApply: false
 
 # Asset Structure
 
-## Directories
-
-- **`assets/images/`** — Sprites, textures, UI images. Optionally split into `assets/sprites/`, `assets/ui/`.
-- **`assets/audio/`** — Music and SFX (e.g. subdirs `music/`, `sfx/`).
-- **`assets/data/`** — JSON or other data (e.g. rulesets) if not code-generated from spec.
-
-## Naming
-
-- **Snake_case**, descriptive. Optional prefixes by domain: `unit_`, `terrain_`, `ui_`.
-- Example: `wizard_attack_frame0.png`, `unit_swordmaster_idle.png`.
-
-## pubspec.yaml
-
-- List asset directories under `flutter: assets:`.
-- Do not commit unnecessarily large binaries; use `.gitignore` for generated or temporary assets if needed.
-
-## Flame loading
-
-- Load assets in **`onLoad()`** via Flame asset APIs (e.g. `Images.load`, `Sprite.load`) and cache.
-- Do not load the same asset every frame. Use Flame’s caches and reuse loaded resources.
+- **Dirs:** `assets/images/` (sprites, UI; optional `sprites/`, `ui/`); `assets/audio/` (e.g. `music/`, `sfx/`); `assets/data/` (e.g. rulesets).
+- **Naming:** Snake_case; optional domain prefix (`unit_`, `terrain_`, `ui_`). Example: `unit_swordmaster_idle.png`.
+- **pubspec.yaml:** List dirs under `flutter: assets:`; don’t commit large binaries; `.gitignore` generated/temp as needed.
+- **Flame:** Load in `onLoad()` via Flame APIs; cache and reuse — never load same asset every frame.

--- a/.cursor/rules/colonizethis-code-review.mdc
+++ b/.cursor/rules/colonizethis-code-review.mdc
@@ -6,18 +6,16 @@ alwaysApply: false
 
 # ColonizeThis Code Review
 
-When reviewing or generating Dart/Flutter/Flame code, run this checklist. Principles and details live in other rules; this rule adds concrete thresholds and repo paths.
+When reviewing or generating code, apply this checklist. Details in other rules.
 
-## Checklist
-
-- **Function length:** > 20 lines → refactor (extract helpers, move to service/component).
-- **Widget/screen size:** > ~60 lines → split; move business logic out of `build` (see core-principles, component-structure).
-- **UI vs data:** Class does both UI and domain logic → split; keep UI in widget/screen/component, logic in service/provider/Flame component (see core-principles).
-- **Hardcoded strings:** User-facing or repeated strings → move to constants. Use `app/lib/config/constants.dart`, `app/lib/config/routes.dart`, or feature constants (e.g. `HiveBoxNames`, `Routes`).
-- **Types:** Explicit types; no `dynamic` (see core-principles).
-- **Spec:** New/changed behavior must be authorized by GDD/TDD/UI spec (see colonizethis-spec-required).
-- **Logging:** Verify sufficiency and level of log statements (key operations: start/end of flows, rejections, errors; appropriate debug/info/warn/error). Follow project conventions (see core-principles Logging, SPEC/program/ctdev-logging.md).
-- **Flame/Flutter:** Respect division; no game logic in Flutter build (see core-principles, ui-design).
-- **Reuse:** Before new utils/widgets, check `app/lib/core/utils/`, `app/lib/widgets/`, `app/lib/config/`, `packages/*/lib/src/` (see reuse-before-new-code, component-structure).
-- **New Flutter widgets:** Register in catalog + Widgetbook (see component-structure, ui-design).
-- **Tests:** Critical paths and logic covered; test layout per colonizethis-testing.
+- **Function:** > 20 lines → refactor (extract, move to service/component).
+- **Widget/screen:** > ~60 lines → split; move logic out of `build`.
+- **UI vs data:** Split if class does both; UI in widget/screen/component, logic in service/provider/Flame.
+- **Strings:** User-facing or repeated → constants (`app/lib/config/constants.dart`, `routes.dart`, or feature constants).
+- **Types:** Explicit; no `dynamic`.
+- **Spec:** New/changed behavior authorized by GDD/TDD/UI spec (spec-required).
+- **Logging:** Key flows, rejections, errors logged; appropriate levels; see core-principles and `SPEC/program/ctdev-logging.md`.
+- **Flame/Flutter:** No game logic in Flutter `build`; respect division (core-principles, ui-design).
+- **Reuse:** Check `app/lib/core/utils/`, `app/lib/widgets/`, `app/lib/config/`, `packages/*/lib/src/` before adding.
+- **New widgets:** Catalog + Widgetbook (component-structure, ui-design).
+- **Tests:** Critical paths covered; layout per testing rule.

--- a/.cursor/rules/colonizethis-component-structure.mdc
+++ b/.cursor/rules/colonizethis-component-structure.mdc
@@ -6,24 +6,11 @@ alwaysApply: false
 
 # Component Structure
 
-## Folder layout
+**Folder layout:**
+- `lib/game/` — Flame game, world, camera. `lib/game/components/` — Flame components (optional: `units/`, `map/`, `ui/`).
+- `lib/widgets/` or `lib/ui/` — Shared Flutter widgets. `lib/screens/` or `lib/pages/` — Full screens.
+- `lib/state/` or `lib/providers/` — State (e.g. Riverpod). `lib/services/` — Save/load, API, audio. `lib/models/` — Domain models, DTOs.
 
-- **`lib/game/`** — Flame game, world, camera; high-level game assembly.
-- **`lib/game/components/`** — Flame components (entities, effects, HUD). Optional subdirs: `units/`, `map/`, `ui/`.
-- **`lib/widgets/`** or **`lib/ui/`** — Shared Flutter widgets for overlays and menus.
-- **`lib/screens/`** or **`lib/pages/`** — Full Flutter screens (menus, settings, lobby).
-- **`lib/state/`** or **`lib/providers/`** — State management (e.g. Riverpod).
-- **`lib/services/`** — Non-Flame services (save/load, API, audio).
-- **`lib/models/`** — Domain models and DTOs (aligned with GDD where applicable).
+**Reuse:** Extract at 2+ places or when testable in isolation. Flame: small components, mixins (e.g. `Tappable`); keep rendering in components. Flutter: reusable widgets for loading/error/empty/list; thin screens. New Flutter widgets: catalog + Widgetbook (see UI design rule).
 
-## Reuse
-
-- Extract when a pattern appears in **2+ places** or when logic is **testable in isolation**.
-- **Flame:** Compose small components; use mixins for behavior (e.g. `Tappable`, `DragCallbacks`). Keep rendering in components.
-- **Flutter:** Shared patterns (loading, error, empty, list item) as reusable widgets; thin screens that delegate to widgets and state/providers.
-- New Flutter widgets must be registered in the widget catalog and have a Widgetbook story (see UI design rule).
-
-## Naming
-
-- **Flame:** `*Component` suffix where it clarifies (e.g. `UnitComponent`, `MapTileComponent`).
-- **Flutter:** `*Widget`, `*Screen`, or `*Page` where it clarifies intent.
+**Naming:** Flame: `*Component` when clarifying. Flutter: `*Widget`, `*Screen`, `*Page` when clarifying.

--- a/.cursor/rules/colonizethis-core-principles.mdc
+++ b/.cursor/rules/colonizethis-core-principles.mdc
@@ -5,36 +5,9 @@ alwaysApply: true
 
 # Core Principles
 
-## Stack
-
-- **Flutter** for UI and overlays (menus, HUD, screens).
-- **Flame** for game world, simulation, and entities.
-- **Dart** throughout. Keep UI and game-loop concerns **separated**.
-- For UI implementation (Widgetbook, catalog, style), see the UI design rule.
-
-## Typing and null safety
-
-- Strict Dart; no implicit `dynamic`.
-- Explicit null handling; use `?` and `!` deliberately; prefer early returns over defensive `!`.
-- Guard clauses and early returns; avoid deep nesting (extract when beyond ~2 levels).
-
-## Single responsibility and delegation
-
-- **Thin screens/pages:** orchestrate only; delegate data, state, and logic to services, controllers, or Flame components.
-- One main concern per file/class. Extract when a pattern appears in 2+ places or logic can be tested in isolation.
-
-## Logging
-
-- **Required:** All code must use Dart's `logger` package for logging; no `print` for operational or diagnostic output.
-- Follow project conventions: message prefixes (e.g. `logic:`, `ai:`, `data:`, `map:`, `save:`), appropriate levels (debug, info, warn, error), and `error`/`stackTrace` for exceptions.
-- See **SPEC/program/ctdev-logging.md** for scope, naming, and configuration.
-
-## Spec alignment
-
-- Game and AI behavior: follow the **GDD** (`SPEC/game/`).
-- Architecture and modules: follow the **TDD** (`SPEC/program/`).
-- See `colonizethis-spec-required.mdc` for SPEC structure and source-of-truth.
-
-## Province lookup (multi-region)
-
-- When locating provinces in logic, always use **(regionId, provinceId)** or a **prefixed** province id (`regionId|localId`). Never use province id alone; never assume oldWorld/newWorld as a default region. See **SPEC/game/world-model.md** (Province identity and lookup).
+- **Stack:** Flutter (UI, overlays, menus, HUD); Flame (game world, simulation, entities); Dart throughout. Keep UI and game-loop **separated**. UI details: see UI design rule.
+- **Typing:** Strict Dart; no implicit `dynamic`. Explicit null handling; early returns over defensive `!`; guard clauses; avoid nesting beyond ~2 levels (extract).
+- **Delegation:** Thin screens/pages — orchestrate only; delegate to services, controllers, or Flame components. One main concern per file/class; extract at 2+ uses or when testable in isolation.
+- **Logging:** Required: use Dart `logger`; no `print` for operational/diagnostic output. Use prefixes (e.g. `logic:`, `ai:`, `data:`, `map:`, `save:`), appropriate levels, and `error`/`stackTrace` for exceptions. See `SPEC/program/ctdev-logging.md`.
+- **Spec alignment:** Game/AI → GDD (`SPEC/game/`); architecture → TDD (`SPEC/program/`). See spec-required rule.
+- **Province lookup:** Always **(regionId, provinceId)** or **prefixed** id (`regionId|localId`). Never province id alone; never assume a default region. See `SPEC/game/world-model.md`.

--- a/.cursor/rules/colonizethis-lifecycle.mdc
+++ b/.cursor/rules/colonizethis-lifecycle.mdc
@@ -6,21 +6,8 @@ alwaysApply: false
 
 # Lifecycle Conventions
 
-## Flame components
+**Flame:** `onLoad()` — one-time init (assets, children); don’t subscribe here if component can be removed/re-added. `onMount()` — subscriptions (Riverpod, game state); pair with `onRemove()` to cancel/dispose. `update(dt)` — per-tick only; keep cheap. `render()` — painting only; prefer built-ins (e.g. `SpriteComponent`).
 
-- **`onLoad()`** — One-time async init: load assets, add children. Use as “constructor-like” setup. Do not subscribe to streams/providers here if the component can be removed and re-added.
-- **`onMount()`** — Runs every time the component is added to the tree. Use for subscriptions (e.g. Riverpod, game state); ensures cleanup when removed.
-- **`onRemove()`** — Always pair with `onMount()`: cancel subscriptions, dispose controllers, release references.
-- **`update(dt)`** — Per-tick logic only; keep cheap (no heavy allocations). Defer heavy work to systems or services.
-- **`render()`** — No game logic; painting only. Prefer Flame built-in rendering (e.g. `SpriteComponent`) over custom `render()` when possible.
+**Flutter:** `initState()` — one-time init; if subscribing, cancel in `dispose()`. `dispose()` — cancel subscriptions, dispose controllers.
 
-## Flutter widgets (overlays, menus, HUD)
-
-- **`initState()`** — One-time init. If subscribing to game/state, cancel in `dispose()`.
-- **`dispose()`** — Cancel subscriptions and dispose any controllers.
-
-## Rule of thumb
-
-- **One-time init:** `onLoad()` (Flame) or `initState()` (Flutter).
-- **Subscribe:** `onMount()` (Flame).
-- **Clean up:** `onRemove()` (Flame) or `dispose()` (Flutter).
+**Rule of thumb:** Init → `onLoad()` (Flame) or `initState()` (Flutter). Subscribe → `onMount()` (Flame). Clean up → `onRemove()` (Flame) or `dispose()` (Flutter).

--- a/.cursor/rules/colonizethis-spec-required.mdc
+++ b/.cursor/rules/colonizethis-spec-required.mdc
@@ -5,12 +5,8 @@ alwaysApply: true
 
 # SPEC Required
 
-## SPEC-first
-
-- All game and technical behavior must be **specified before implementation**.
-- Implement only what the specs describe. No behavior that contradicts the GDD or TDD.
-
-## SPEC layout
+- **SPEC-first:** Specify all game and technical behavior before implementation. Implement only what specs describe; no behavior that contradicts GDD or TDD.
+- **Layout:** Sub-specs only; max 500 words per document.
 
 | Domain | Path | Source of truth |
 |--------|------|-----------------|
@@ -19,29 +15,7 @@ alwaysApply: true
 | AI | `SPEC/ai/` | Derives from GDD/TDD |
 | UI | `SPEC/ui/` | Derives from GDD/TDD |
 
-- Use **sub-specs only**; split large topics. **Max 500 words per document.**
-- GDD: player interaction, calculation logic, rules (configurable vs fixed), single vs multiplayer, core model (units, production, terrain, stats/modifiers/constraints). Use diagrams where useful.
-- TDD: modules/submodules, key variables and lifecycles/storage, component flows, frontend–server (multiplayer).
-- AI spec: how AI uses game constraints; what game state the AI can access.
-- UI spec: screen design, map layers.
-
-## Source of truth
-
-- **Game and AI logic:** GDD is ultimate source of truth.
-- **Technical architecture:** TDD is ultimate source of truth.
-- AI and UI specs must derive from GDD/TDD.
-
-## Inconsistencies
-
-- If specs conflict, **flag and resolve** before coding.
-- Resolve by updating GDD or TDD first, then derived specs (AI, UI).
-
-## Rulesets
-
-- Game stats, modifiers, and constraints are **configurable via distinct rulesets**.
-- GDD and TDD must specify **where** ruleset configuration is defined and **how** it is loaded.
-
-## When adding behavior
-
-- Point to the spec section (and sub-spec file) that authorizes it.
-- If no such section exists, **add or extend the spec first**, then implement.
+- **Source of truth:** GDD for game/AI logic; TDD for architecture. AI and UI specs derive from GDD/TDD.
+- **Conflicts:** Flag and resolve before coding. Update GDD or TDD first, then AI/UI specs.
+- **Rulesets:** Stats, modifiers, constraints are configurable via distinct rulesets. GDD/TDD must specify where and how ruleset config is defined and loaded.
+- **Adding behavior:** Point to the spec (section/file) that authorizes it. If none exists, add or extend the spec first, then implement.

--- a/.cursor/rules/colonizethis-testing.mdc
+++ b/.cursor/rules/colonizethis-testing.mdc
@@ -6,25 +6,8 @@ alwaysApply: false
 
 # Testing
 
-## Coverage
-
-- **90% per package.** Enforce in CI where applicable (e.g. `tool/test_coverage.py` and fail if any package is below threshold).
-
-## Layers
-
-- **Unit** — Pure logic, models, services (no Flutter/Flame). Fast; mock external deps (file, network, game refs).
-- **Widget** — Flutter widgets and screens. Use `flutter_test` and `pumpWidget`; mock state/providers and game if needed.
-- **Game/component** — Flame components in isolation (e.g. minimal `FlameGame` + component under test). Test `onLoad`, behavior in `update`, removal. Avoid depending on full game when not needed.
-
-## Layout and naming
-
-- **`test/`** mirrors **`lib/`**. Use **`*_test.dart`** naming. Group by feature or class.
-
-## Mocks
-
-- Use **mockito** or **mocktail** for interfaces and services.
-- For Flame: mock `Game` or use a minimal game instance so component tests do not depend on the full world.
-
-## Critical paths
-
-- Combat, economy, save/load, and **ruleset loading** should have tests. Prioritize coverage on these when approaching the 90% target.
+- **Coverage:** 90% per package (enforce in CI, e.g. `tool/test_coverage.py`).
+- **Layers:** **Unit** — pure logic, models, services (no Flutter/Flame); mock deps. **Widget** — Flutter; `flutter_test`, `pumpWidget`; mock state/providers. **Game/component** — Flame in isolation (minimal `FlameGame` + component); test `onLoad`, `update`, removal.
+- **Layout:** `test/` mirrors `lib/`; **`*_test.dart`**; group by feature or class.
+- **Mocks:** mockito or mocktail; for Flame use minimal game or mock `Game`.
+- **Critical paths:** Combat, economy, save/load, **ruleset loading** — prioritize coverage here.

--- a/.cursor/rules/colonizethis-tools.mdc
+++ b/.cursor/rules/colonizethis-tools.mdc
@@ -6,42 +6,11 @@ alwaysApply: false
 
 # Tools as Thin Facades
 
-## Principle
+- **Principle:** `tool/` = thin facades only: parse args, load config/input, call into packages, output results. No core logic (e.g. map description, tile counts) in the tool; add helpers/types in the appropriate package and call from the tool.
+- **Run from root:** All tools run via **Melos** from project root: `melos run <tool_name> -- [args]`. Paths in args are relative to repo root. Document in **`docs/project-tools.md`** (command, args, options, examples).
 
-Tools under **`tool/`** are **thin facades** (drivers) over library code. They do **orchestration only**: parse CLI args, load config or input files, call into packages (e.g. colonizethis_data, colonizethis_models), and print or write results. They must **not** contain core logic (e.g. map description, tile count computation, formatting of province detail).
-
-## Where logic lives
-
-Implementation belongs in the appropriate **package** (e.g. colonizethis_map for topology/tile map generation and visualization, colonizethis_data for static map data/helpers, colonizethis_models for game state). If a tool needs behaviour that does not yet exist, **add the required helpers or types in the library** and have the tool call them.
-
-## Benefits
-
-- Library code is testable without running the CLI.
-- Logic is reused by the app or other tools.
-- Tools stay small and easy to reason about.
-
-## Run from root (requirement)
-
-All tools under **`tool/`** must be runnable from the **project root** via **Melos**. Do not require `cd` into `tool/<name>`.
-
-- **Command:** `melos run <tool_name> -- [args]` (or `dart run melos run <tool_name> -- [args]` if Melos is not on PATH).
-- **Paths:** File paths in args are **relative to the repo root** (e.g. `path/to/topology.json` or generate_map output path).
-- **Centralized CLI:** Melos is the single, CLI-friendly way to run these tools.
-
-## Tool usage (project tools doc)
-
-**What tools are available** and **how to invoke each** (command, args, options, examples) are documented in the **project tools** markdown file: **`docs/project-tools.md`**. Contributors and users should look there for the list of tools and invocation details.
-
-## Adding a new tool
-
-1. Add a new Dart package under **`tool/<name>`** (thin facade; logic in packages; see principle above).
-2. In the package: `pubspec.yaml` with `resolution: workspace`, and an **executable** whose name matches `<name>` (e.g. `executables: <name>: bin/<name>.dart`).
-3. In the **root** `pubspec.yaml`: add `tool/<name>` to the **`workspace:`** list.
-4. In the **root** `pubspec.yaml` under **`melos.scripts`**: add a script with the same name, e.g. `run: dart run <name>`. The executable name must match so the script stays trivial.
-5. **Update the project tools doc** (`docs/project-tools.md`): add a section for the new tool with name, description, invocation (`melos run <name> -- ...`), options, and an example.
-
-After that, the tool is run from root with `melos run <name> -- [args]`.
-
-## Apply to
-
-Any new or existing tool under `tool/` (e.g. generate_map, future generate_tile_map or similar). When adding a tool, implement the minimal orchestration in the tool and the real logic in a package.
+**Adding a new tool:**
+1. New package under `tool/<name>` (thin facade; logic in packages).
+2. Package: `resolution: workspace`, executable name = `<name>` (e.g. `executables: <name>: bin/<name>.dart`).
+3. Root `pubspec.yaml`: add `tool/<name>` to `workspace:` and to `melos.scripts` (e.g. `<name>: run: dart run <name>`).
+4. Update `docs/project-tools.md` with section for the new tool.

--- a/.cursor/rules/colonizethis-ui-design.mdc
+++ b/.cursor/rules/colonizethis-ui-design.mdc
@@ -6,43 +6,12 @@ alwaysApply: false
 
 # UI Design
 
-UI specs live in `SPEC/ui/` and derive from GDD/TDD per the spec-required rule. In addition:
+UI specs in `SPEC/ui/` derive from GDD/TDD (spec-required rule).
 
-- When **implementing** UI: create a **Widgetbook** mockup for each new or changed component/screen so it is visually reviewable; register the widget in the **widget catalog** so it is discoverable. Maintain the catalog (e.g. Ct-prefixed widgets with name, category, path or story) so the team knows what is already designed/implemented and available for reuse.
-
-## Wireframe
-
-- Every UI spec must define a **wireframe** for the screen or flow.
-- **Positions, layout, and hierarchy** must be **visually accessible** to a human reviewer (e.g. diagram, ASCII, or structured spec with regions, positions, hierarchy).
-- Prefer the schema used in UXD 07 Layout Designer (canvas, regions, positions, hierarchy) so tooling and pipeline stay aligned.
-
-## Components
-
-- Define **which components** each screen uses. Follow **UXD 03 (UI Interaction Flows)** and **UXD 07 (UI Mockup Pipeline)**.
-- Use the **widget catalog** (Ct-prefix; reference by `library_id` or `generate_new` with a short spec). Prefer reuse; when adding new components, specify name, category, props and register in the catalog.
-- Components must be **reusable** where the same pattern appears in 2+ places.
-
-## Widgetbook and catalog
-
-- **Widgetbook:** When implementing UI, create a Widgetbook story for each catalog widget (or screen) so mockups are runnable and reviewable before wiring to full app.
-- **Widget catalog:** Maintain a single catalog (e.g. `widget_catalog.json` or equivalent per UXD 07) listing designed/implemented widgets: name (Ct-prefix), category, dart path, optional Widgetbook story path. Update it when adding or changing widgets so existing components are discoverable and reused.
-
-## Functional behaviors
-
-- Define the **functional behavior** of each component: inputs, outputs, callbacks, and user-visible outcomes (e.g. tap → navigate, onAdjust → update state).
-- Document in the UI spec or in an **interaction manifest** (per UXD 07) so reviewers can verify behavior before implementation.
-
-## Pixel art and PixelLab
-
-- When **new components** require pixel art, the spec must define **what images are required** and the **spec for generation** (e.g. for PixelLab MCP: subject, size, pixellab_type).
-- **Exact prompts:** For every pixel art asset generated via PixelLab (or similar), the UI spec must record the **exact wording** used for generation (e.g. the full PixelLab `description` and, if used, outline/shading/detail). Record **layout constraints** (e.g. max content width in dp) and **asset pixel dimensions** (width×height) that match the layout so assets are not upscaled and stay crisp.
-- **Ration generation:** Pixel art generation (e.g. PixelLab MCP) is expensive. **Check the assets folder first**; if a suitable asset already exists, **do not regenerate**. Only request generation for missing or intentionally replaced assets.
-- Follow UXD 04 (workflow, 0→1 vs 1→N), UXD 05 (PixelLab technical spec), and UXD 07 (asset manifest, post-approval phase).
-
-## Stylistic conventions
-
-- **Design and pixel art** must follow **UXD 02 (Stylistic Conventions)**: pixel art canon (1x grid, no anti-aliasing), 16th/17th century aesthetic, color palette, UI frames and buttons, typography in pixel context. Apply UXD 02 when designing components and when generating or selecting pixel art (PixelLab, fallback, or existing assets).
-
-## Flame/Flutter division
-
-- When implementing UI, respect the **Flame/Flutter division of labour**: **Flutter** for app shell, routes, overlays, menus, and list/form screens; **Flame** for game canvas and in-game pixel-art UI; communication via state and callbacks only. See core-principles and TDD 15 (or SPEC/program/repo-and-packages.md) for structure.
+- **Implementing UI:** Widgetbook story per new/changed component/screen; register in **widget catalog** (Ct-prefix, name, category, path/story). Keep catalog up to date for reuse.
+- **Wireframe:** Every UI spec has a wireframe; positions, layout, hierarchy visible to reviewers. Prefer UXD 07 schema (canvas, regions, positions, hierarchy).
+- **Components:** Define which components each screen uses (UXD 03, UXD 07). Use catalog; prefer reuse; new components: name, category, props, register. Reusable where pattern appears 2+ times.
+- **Behavior:** Define inputs, outputs, callbacks, user-visible outcomes; document in spec or interaction manifest (UXD 07).
+- **Pixel art:** Spec must define required images and generation spec (e.g. PixelLab: subject, size, type). Record **exact prompts** and asset dimensions in spec. **Check assets first** — do not regenerate if suitable asset exists (UXD 04, 05, 07).
+- **Style:** Follow UXD 02 (pixel canon, 1x grid, no AA, 16th/17th c. aesthetic, palette, typography).
+- **Flame/Flutter:** Flutter = shell, routes, overlays, menus, list/form screens; Flame = game canvas and in-game pixel UI. Communicate via state and callbacks only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Agent instructions (ColonizeThis)
+
+This project uses **Cursor rules** as the source of truth for how to work in the codebase. Agents (including Cursor AI) should follow these rules when editing code, adding features, or reviewing.
+
+## Where the rules live
+
+- **Path:** `.cursor/rules/`
+- **Format:** Markdown with optional front matter (`.mdc`). Each file describes one concern (SPEC, testing, UI, tools, etc.).
+
+## Always-applied rules
+
+These rules are applied in every context; follow them for all changes.
+
+| Rule file | Summary |
+|-----------|---------|
+| **colonizethis-spec-required.mdc** | SPEC-first: specify before implementing; no behavior that contradicts specs. GDD `SPEC/game/`, TDD `SPEC/program/`, AI `SPEC/ai/`, UI `SPEC/ui/` (sub-specs, max 500 words). Source of truth: GDD for game/AI, TDD for architecture. Conflicts: resolve GDD/TDD first. Rulesets: configurable; specify where/how in GDD/TDD. New behavior: point to authorizing spec or add/extend spec first. |
+| **colonizethis-core-principles.mdc** | Stack: Flutter (UI), Flame (game/simulation), Dart. Strict typing, null safety, logger (no `print`). Thin screens; delegate to services/controllers/Flame. Province lookup: always use `(regionId, provinceId)` or prefixed id; never province id alone. |
+
+## Context-specific rules
+
+Apply these when working in the indicated areas (by path or topic).
+
+| Rule file | When to apply | Summary |
+|-----------|----------------|---------|
+| **colonizethis-tools.mdc** | `tool/**` | Tools are thin facades; logic lives in packages. Run from root via Melos: `melos run <tool_name> -- [args]`. Document in `docs/project-tools.md`. |
+| **colonizethis-testing.mdc** | `**/*_test.dart`, `**/test/**/*.dart` | 90% per-package coverage. Unit / widget / game-component layers. Mocks (mockito/mocktail). Critical paths: combat, economy, save/load, ruleset loading. |
+| **colonizethis-ui-design.mdc** | `SPEC/ui/**`, `**/lib/widgets/**`, `**/lib/ui/**` | Wireframes in UI spec; Widgetbook + widget catalog for components; pixel art via spec and PixelLab; UXD 02/03/04/05/07. Flame vs Flutter division. |
+| **colonizethis-component-structure.mdc** | `**/*.dart` | Folder layout: `lib/game/`, `lib/widgets/`, `lib/screens/`, etc. Reuse at 2+ places; Flame `*Component`, Flutter catalog + Widgetbook. |
+| **colonizethis-code-review.mdc** | `**/*.dart` | Checklist: function &lt; 20 lines, widget &lt; ~60 lines, no UI+logic mix, constants for strings, explicit types, spec alignment, logging, reuse, tests. |
+| **colonizethis-lifecycle.mdc** | `**/*.dart` | Flame: `onLoad` (init), `onMount`/`onRemove` (subscribe/cleanup), `update`/`render` (tick/paint). Flutter: `initState`/`dispose`. |
+| **colonizethis-assets.mdc** | `**/*.dart`, `**/pubspec.yaml`, `**/assets/**` | Asset dirs: `assets/images/`, `assets/audio/`, `assets/data/`. Snake_case naming. Load in Flame `onLoad()`; use caches. |
+
+## Quick reference for agents
+
+1. **Before implementing:** Check GDD/TDD/UI spec; implement only what is specified; if missing, add or extend the spec first.
+2. **Code style:** Strict Dart, logger (no `print`), thin screens, single responsibility. Province lookup: always `(regionId, provinceId)` or prefixed id.
+3. **When touching UI:** Wireframes in spec; Widgetbook + catalog; pixel art per UXD (exact prompts in spec; check assets first, don’t regenerate if suitable asset exists); Flame for canvas, Flutter for shell/overlays/menus.
+4. **When adding a tool:** Thin facade in `tool/<name>`; logic in packages; Melos script and `docs/project-tools.md` updated.
+5. **When writing tests:** 90% per package; unit/widget/game-component layers; cover combat, economy, save/load, ruleset loading.
+6. **When reviewing/generating code:** Use the code-review checklist (lengths, types, spec, logging, reuse, tests).
+
+For full text of each rule, read the files in `.cursor/rules/`.


### PR DESCRIPTION
## Summary
- **AGENTS.md** added at repo root so agents (including Cursor AI) can follow project Cursor rules. It points to `.cursor/rules/`, summarizes always-applied and context-specific rules, and gives a quick reference.

- **Cursor rules condensed**: all nine `.cursor/rules/*.mdc` files were shortened without dropping required boundaries (paths, thresholds, SPEC/UXD refs, checklists). Removed redundancy, long explanations, and duplicate examples.

## Changes
- `AGENTS.md` (new): agent instructions, rule map, quick reference.
- `.cursor/rules/colonizethis-*.mdc` (9 files): concise rewrites; same constraints and references preserved.

Made with [Cursor](https://cursor.com)