### PR TITLE
GDD: leader-bonuses world-model-identity cross-ref (Fixes #502)

### DIFF
--- a/SPEC/game/leader-bonuses.md
+++ b/SPEC/game/leader-bonuses.md
@@ -1,6 +1,6 @@
 # Leader Bonuses
 
-**SPEC/game** — Per–Great Power leader selection and combat bonuses. Reference: GDD 09.
+**SPEC/game** — Per–Great Power leader selection and combat bonuses. Reference: GDD 09. Province identity (defender / province owner): [world-model-identity.md](world-model-identity.md).
 
 ---
 
@@ -39,6 +39,6 @@ Modifiers are applied as multipliers to the side’s effective strength (e.g. 1.
 
 ## Application Rule
 
-- **Defender:** Use defender faction’s GP player (province owner); apply that player’s leader bonus to defender strength.
+- **Defender:** Use defender faction’s GP player (province owner); apply that player’s leader bonus to defender strength. Province owner lookup uses prefixed province ids and region-scoped lookup; see [world-model-identity.md](world-model-identity.md).
 - **Attacker:** For each attacking side, use that side’s GP player; apply that player’s leader bonus to that attacker’s strength.
 - Bonuses are symmetric (same multiplier type for attacker and defender); only the owning player’s leader matters for each side.


### PR DESCRIPTION
Fixes #502

In SPEC/game/leader-bonuses.md:
- **Header:** Add province identity (defender / province owner) cross-ref to world-model-identity.md.
- **Application Rule:** State that province owner lookup uses prefixed province ids and region-scoped lookup per world-model-identity.

Docs-only; aligns with world-model-identity cross-ref pattern (e.g. military-generals #521, extraction-and-improvements #450).

Made with [Cursor](https://cursor.com)