### PR TITLE
AI personalities GDD: add TDD cross-ref (ai-systems-impl, ai-planner)

### DIFF
--- a/SPEC/ai/ai-personalities.md
+++ b/SPEC/ai/ai-personalities.md
@@ -1,6 +1,6 @@
 # AI Personalities (Phase 6)
 
-**SPEC/ai** — Leader-specific behavior config for MVP. Source: GDD 10a. Application: [ai-architecture.md](ai-architecture.md).
+**SPEC/ai** — Leader-specific behavior config for MVP. Source: GDD 10a. Application: [ai-architecture.md](ai-architecture.md). Implementation: [ai-systems-impl.md](../program/ai-systems-impl.md) (config, domain planners, goal selection), [ai-planner.md](../program/ai-planner.md) (AIConfig supplied when generating orders).
 
 ---
 
@@ -61,6 +61,12 @@ These are applied when scoring actions (e.g. declare war, accept peace, choose r
 ## Difficulty
 
 Difficulty does **not** change personality or AI strength. It only affects **starting parameters and ruleset modifiers** (e.g. AI nation’s starting resources, production modifiers, unit strength modifiers). Same personality and same algorithm for all difficulty levels.
+
+---
+
+## Implementation
+
+Personality is loaded as config and supplied via **AIConfig** when the AI generates orders. [ai-systems-impl.md](../program/ai-systems-impl.md) defines where config holds personality and where domain planners and goal selection use it; [ai-planner.md](../program/ai-planner.md) describes integration and where AIConfig is built and supplied for order generation.
 
 ---
 


### PR DESCRIPTION
Fixes #559.

Adds cross-references from SPEC/ai/ai-personalities.md to:
- SPEC/program/ai-systems-impl.md (config holds personality; domain planners, goal selection use weights)
- SPEC/program/ai-planner.md (where AIConfig is built and supplied for order generation)

Implementation subsection and header updated so readers know where personality is loaded and applied in the pipeline. Docs-only.

Made with [Cursor](https://cursor.com)