### PR TITLE
Hidden-agendas GDD: add acceptance criteria section

### DIFF
--- a/SPEC/ai/hidden-agendas.md
+++ b/SPEC/ai/hidden-agendas.md
@@ -57,3 +57,13 @@ When the game or AI performs an action, **evidence rules** (defined per agenda) 
 - Counters are **per (observer nation, subject AI, agenda type)**. Only the human observer’s view is stored; AI does not observe other AI’s evidence.
 - **Suspicion levels** map total evidence score to a band: Unknown (0–2), Possible (3–5), Likely (6–8), Almost certain (9–10), Confirmed (10+). Display labels in dossier use these bands; “Confirmed” is a threshold, not revelation of true agenda.
 - Evidence is deterministic (same actions → same evidence). Dossier projection is PlayerView-safe: only suspicion scores and capped evidence log exposed. See [ai-dossier.md](ai-dossier.md).
+
+---
+
+## Acceptance criteria
+
+- **Assignment and immutability:** One agenda per AI; assigned at game start from `agendaSeed[P]` (derived from global game seed and `aiSeed[P]`). Stored in game state; no mid-game change.
+- **Determinism:** Same global game seed and `aiSeed[P]` yield the same agenda. Same observable actions yield the same evidence points (replay- and save/load-consistent).
+- **Behavior modifiers:** Each agenda type has defined effects in the spec categories: war declaration, peace acceptance, alliance acceptance, build/order choice, treaty breaking. Expressed as weights or thresholds in config.
+- **Evidence and suspicion:** Evidence rules add points per (observer nation, subject AI, agenda type). Suspicion bands (Unknown, Possible, Likely, Almost certain, Confirmed) map total evidence score; display uses bands only. True agenda is never exposed to the player.
+- **Dossier contract:** Only suspicion scores and capped evidence log are exposed (PlayerView-safe). See [ai-dossier.md](ai-dossier.md) and [ai-events-and-dossier.md](../program/ai-events-and-dossier.md).


### PR DESCRIPTION
Fixes #574.

Add an explicit Acceptance criteria section to SPEC/ai/hidden-agendas.md covering assignment and immutability, determinism, behavior modifiers, evidence and suspicion, and dossier contract.

Docs-only.

Made with [Cursor](https://cursor.com)