### PR TITLE
Turn-resolution-phase-details: document richesCashMultiplier in Riches to treasury

### DIFF
--- a/SPEC/program/turn-resolution-phase-details.md
+++ b/SPEC/program/turn-resolution-phase-details.md
@@ -24,7 +24,7 @@ Full resolution per [diplomacy-resolution.md](diplomacy-resolution.md): overture
 
 ## Riches to treasury
 
-For each riches commodity (gold, silver, gems, diamonds, spices): add quantity × basePrice to treasury; remove from stockpile. Base prices: spices = 50; others from spawn weights. Reference: Imperialism II 02-economy, GDD 04.
+For each riches commodity (gold, silver, gems, diamonds, spices): add quantity × basePrice × **richesCashMultiplier** to treasury; remove from stockpile. Base prices: spices = 50; others from spawn weights. **richesCashMultiplier** is optional (default 1.0); scenario or ruleset may override (e.g. Search for El Dorado 1.5). Where the value is defined: [ruleset-config.md](ruleset-config.md) (economy.riches_cash_multiplier). Reference: Imperialism II 02-economy, GDD 04.
 
 ---
 


### PR DESCRIPTION
Fixes #534.

Add to Riches to treasury section:
- **richesCashMultiplier** in treasury formula (quantity × basePrice × richesCashMultiplier); default 1.0; scenario or ruleset may override (e.g. Search for El Dorado 1.5).
- Cross-ref [ruleset-config.md](SPEC/program/ruleset-config.md) for where the value is defined (economy.riches_cash_multiplier).

Docs-only. Keeps phase-details as the single place that describes the phase behaviour including the multiplier.

Made with [Cursor](https://cursor.com)