### PR TITLE
Tech-tree-diplomacy-civilian GDD: add world-model-identity cross-ref

### DIFF
--- a/SPEC/game/tech-tree-diplomacy-civilian.md
+++ b/SPEC/game/tech-tree-diplomacy-civilian.md
@@ -1,6 +1,6 @@
 # Tech Tree — Diplomacy and Civilian
 
-**SPEC/game** — Diplomatic options and civilian unit unlocks. Reference: Imperialism II 08-technology (Diplomacy and Civilian). Overview: [tech-tree.md](tech-tree.md). Diplomacy: [diplomacy.md](diplomacy.md). Civilian units: [civilian-units.md](civilian-units.md).
+**SPEC/game** — Diplomatic options and civilian unit unlocks. Reference: Imperialism II 08-technology (Diplomacy and Civilian). Overview: [tech-tree.md](tech-tree.md). Diplomacy: [diplomacy.md](diplomacy.md). Civilian units: [civilian-units.md](civilian-units.md). Province identity (e.g. provincial towns, purchase land): [world-model-identity.md](world-model-identity.md).
 
 ---
 
@@ -22,3 +22,11 @@
 - **Diplomatic Expertise:** Unlocks embassy overture and allows civilian units to work in Minor Nations with embassy.
 - **Merchant Companies:** Unlocks building Merchant civilian unit. **Purchasing land** (Merchant `purchase_land` work order) in a Minor Nation or Tribe requires Merchant Companies **and** an **embassy** with that Minor/Tribe (see [diplomacy.md](diplomacy.md), [civilian-units.md](civilian-units.md)).
 - **Empire Building:** Unlocks Join Empire (GP can ask another GP to join when nearly defeated). See [diplomacy.md](diplomacy.md).
+
+---
+
+## Rules
+
+### Province and tile identity
+
+Effects that reference provinces (e.g. Builder upgrade town, Merchant purchase land) use **prefixed province ids** and **region-scoped lookup**; see [world-model-identity.md](world-model-identity.md).


### PR DESCRIPTION
Fixes #586

- Header: province identity cross-ref to world-model-identity.md (provincial towns, purchase land).
- Rules § Province and tile identity: prefixed province ids and region-scoped lookup for effects that reference provinces.

Docs-only.

Made with [Cursor](https://cursor.com)