### PR TITLE
Fog-and-exploration GDD: add acceptance criteria section (Fixes #611)

### DIFF
--- a/SPEC/game/fog-and-exploration.md
+++ b/SPEC/game/fog-and-exploration.md
@@ -97,3 +97,16 @@ Mineral resources may only be extracted from tiles that are (a) connected and (b
 - Extraction gating: [extraction-and-improvements.md](extraction-and-improvements.md)
 - World model (tile positioning): [world-model.md](world-model.md)
 - Province and tile identity (prefixed ids, tile keys): [world-model-identity.md](world-model-identity.md)
+
+---
+
+## Acceptance criteria
+
+- **Visibility levels:** Four levels per player per tile (unknown, revealed, fogged, fully visible). Own provinces are always fully visible and never decay; fogged applies only to other factions' provinces.
+- **Initial visibility:** Old World starts fogged (own fully visible); New World starts unknown; coastal tiles reveal when ships enter adjacent sea zones per ships-and-naval.
+- **Exploration:** Explorer work `explore` uses region-scoped formula: turns = `ceil(3 * tilesInProvince / maxTilesInAnyProvinceInRegion)` (max 3). On completion, all tiles in the province become fully visible for that player only.
+- **Prospecting:** Explorer work `prospect` is one turn per tile; minerals require prospecting before extraction; mineral-eligible terrain and prospect-required vs terrain-known resources are as listed in Rules.
+- **Fog decay:** Explorer: when the last Explorer leaves an other-faction province, tiles there immediately revert to fogged. Spy: when a Spy leaves, a 5-turn timer starts for (player, province); at timer 0, that province's tiles set to fogged for that player. Own provinces never decay.
+- **Order visibility:** Move orders require source and destination each with at least one tile not unknown. Work orders require minimum visibility per unit type and target (e.g. explore ≥ revealed, prospect ≥ fogged, build_* ≥ fogged); province and tile identity use prefixed form per world-model-identity.
+- **Extraction gating:** Minerals extractable only from connected, prospected tiles for that player; non-minerals unchanged.
+- **Implementation:** Visibility resolution, Spy timer, and PlayerView construction: [fog-and-exploration-resolution.md](../program/fog-and-exploration-resolution.md).


### PR DESCRIPTION
Fixes #611

- **Acceptance criteria:** Visibility levels, initial visibility, exploration formula (region-scoped), prospecting, fog decay (Explorer immediate / Spy 5-turn), order visibility, extraction gating; province/tile identity per world-model-identity.
- **Implementation:** Cross-ref to fog-and-exploration-resolution.md.

Docs-only.

Made with [Cursor](https://cursor.com)