### PR TITLE
Fog-and-exploration: document Spy fog decay turns in Configurable Values (Fixes #613)

### DIFF
--- a/SPEC/game/fog-and-exploration.md
+++ b/SPEC/game/fog-and-exploration.md
@@ -14,7 +14,7 @@ Four levels per player per tile. Visibility state is keyed by player and by prov
 
 - **Unknown:** No knowledge; exploration/prospecting impossible. New World tiles start here for all GPs.
 - **Revealed:** Province boundary and owner known; terrain and resources unknown.
-- **Fogged:** Terrain, non-prospect resources, and last-known improvements visible. Applies to other-faction provinces only when no Explorer/Spy is working there. Decay: immediate when the last Explorer leaves; for Spy, a 5-turn timer applies (see Fog Decay).
+- **Fogged:** Terrain, non-prospect resources, and last-known improvements visible. Applies to other-faction provinces only when no Explorer/Spy is working there. Decay: immediate when the last Explorer leaves; for Spy, a timer (Spy fog decay turns, default 5) applies (see Fog Decay).
 - **Fully Visible:** Everything known except unprospected minerals. Own provinces are always fully visible.
 
 ### Own vs Other Provinces
@@ -45,7 +45,7 @@ Mineral-eligible terrain: swamp, hills, mountain, desert (for diamonds). See [re
 ### Fog Decay
 
 - **Explorer:** When the last Explorer leaves an other-faction province, tiles in that province immediately revert to fogged (retaining last-known state).
-- **Spy:** When a Spy leaves an other-faction province, a 5-turn timer starts for (player, province); at end of each turn the timer is decremented; when it reaches 0, that province's tiles are set to fogged. Until then, the player retains full visibility of that province.
+- **Spy:** When a Spy leaves an other-faction province, a timer (Spy fog decay turns, default 5; see Configurable Values) starts for (player, province); at end of each turn the timer is decremented; when it reaches 0, that province's tiles are set to fogged. Until then, the player retains full visibility of that province.
 
 Own provinces never decay.
 
@@ -84,6 +84,7 @@ Mineral resources may only be extracted from tiles that are (a) connected and (b
 |---|---|---|
 | Explore max turns | 3 | Scaled by province size |
 | Prospect turns per tile | 1 | |
+| Spy fog decay turns | 5 | When Spy leaves other-faction province, turns until that province's tiles revert to fogged |
 | Old World initial visibility | fogged | Own = fully visible |
 | New World initial visibility | unknown | |
 
@@ -106,7 +107,7 @@ Mineral resources may only be extracted from tiles that are (a) connected and (b
 - **Initial visibility:** Old World starts fogged (own fully visible); New World starts unknown; coastal tiles reveal when ships enter adjacent sea zones per ships-and-naval.
 - **Exploration:** Explorer work `explore` uses region-scoped formula: turns = `ceil(3 * tilesInProvince / maxTilesInAnyProvinceInRegion)` (max 3). On completion, all tiles in the province become fully visible for that player only.
 - **Prospecting:** Explorer work `prospect` is one turn per tile; minerals require prospecting before extraction; mineral-eligible terrain and prospect-required vs terrain-known resources are as listed in Rules.
-- **Fog decay:** Explorer: when the last Explorer leaves an other-faction province, tiles there immediately revert to fogged. Spy: when a Spy leaves, a 5-turn timer starts for (player, province); at timer 0, that province's tiles set to fogged for that player. Own provinces never decay.
+- **Fog decay:** Explorer: when the last Explorer leaves an other-faction province, tiles there immediately revert to fogged. Spy: when a Spy leaves, a timer (Spy fog decay turns, default 5) starts for (player, province); at timer 0, that province's tiles set to fogged for that player. Own provinces never decay.
 - **Order visibility:** Move orders require source and destination each with at least one tile not unknown. Work orders require minimum visibility per unit type and target (e.g. explore ≥ revealed, prospect ≥ fogged, build_* ≥ fogged); province and tile identity use prefixed form per world-model-identity.
 - **Extraction gating:** Minerals extractable only from connected, prospected tiles for that player; non-minerals unchanged.
 - **Implementation:** Visibility resolution, Spy timer, and PlayerView construction: [fog-and-exploration-resolution.md](../program/fog-and-exploration-resolution.md).

--- a/SPEC/program/fog-and-exploration-resolution.md
+++ b/SPEC/program/fog-and-exploration-resolution.md
@@ -12,7 +12,7 @@ Maintains per-player visibility and prospected state on world state; resolves ex
 
 **Prospected state:** `Map<playerId, Set<tileKey>>` — tiles the player has prospected. Only mineral-eligible terrain per game rules.
 
-**Spy reveal timer:** `Map<playerId, Map<provinceKey, int>>` — for each player, provinces that were previously revealed by a Spy and are now fog-decaying: value = turns left until tiles in that province are set back to fogged (0 = already fogged). When a Spy **leaves** a non-owner province, set timer to 5 for (Spy owner, that province). Stored on WorldState.
+**Spy reveal timer:** `Map<playerId, Map<provinceKey, int>>` — for each player, provinces that were previously revealed by a Spy and are now fog-decaying: value = turns left until tiles in that province are set back to fogged (0 = already fogged). When a Spy **leaves** a non-owner province, set timer to the Spy fog decay turns (default 5; see [fog-and-exploration.md](../game/fog-and-exploration.md) § Configurable Values) for (Spy owner, that province). Stored on WorldState.
 
 **Source province:** A unit's source province is derived from its tileKey (for civilians) or provinceId. Must not be unknown; raises exception if so.
 
@@ -33,7 +33,7 @@ Maintains per-player visibility and prospected state on world state; resolves ex
 
 **Spy presence reveal:** When building visibility (or PlayerView), for each Spy in a **non-owner** province, that province's tiles are treated as **fully visible** for the Spy's owner for as long as the Spy is there.
 
-**Fog decay (Spy):** When a Spy **leaves** a province (move or removal), start a 5-turn timer for (Spy owner, that province). At end of turn: decrement all spy-reveal timers; for each (player, province) where timer reaches 0, set all tiles in that province to fogged for that player. (Explorer/Spy fog decay: if no Explorer/Spy remain in an other-faction province, also set tiles to fogged unless a Spy timer is active.)
+**Fog decay (Spy):** When a Spy **leaves** a province (move or removal), start a timer for (Spy owner, that province) with duration = Spy fog decay turns (default 5; see GDD § Configurable Values). At end of turn: decrement all spy-reveal timers; for each (player, province) where timer reaches 0, set all tiles in that province to fogged for that player. (Explorer/Spy fog decay: if no Explorer/Spy remain in an other-faction province, also set tiles to fogged unless a Spy timer is active.)
 
 **Fog decay** (End-of-turn phase):
 
@@ -80,6 +80,6 @@ Maintains per-player visibility and prospected state on world state; resolves ex
 
 - **Exploration timing and scope:** Exploration work orders use the region-scoped timing formula (`ceil(3 * tilesInP / maxTilesInAnyProvinceInRegion)`) and, on completion, set all tiles in the target province to fullyVisible for the exploring player only.
 - **Prospecting:** Prospect work orders validate that the target tile is mineral-eligible per game rules; on completion the tile is added to the player's prospected set in WorldState and does not change visibility by itself.
-- **Spy reveal and decay:** While a Spy is present in a non-owner province, that province is fully visible to the Spy's owner via PlayerView; when the Spy leaves, a 5-turn per-(player, province) timer is started and, when it reaches 0, tiles in that province decay to fogged for that player (other-faction provinces only; own provinces never decay).
+- **Spy reveal and decay:** While a Spy is present in a non-owner province, that province is fully visible to the Spy's owner via PlayerView; when the Spy leaves, a per-(player, province) timer (duration = Spy fog decay turns, default 5 per GDD Configurable Values) is started and, when it reaches 0, tiles in that province decay to fogged for that player (other-faction provinces only; own provinces never decay).
 - **Explorer/Spy fog decay:** At end of turn, for each other-faction province where the player previously had Explorer/Spy presence, if no Explorer/Spy remains and no Spy timer is active, all tiles in that province decay to fogged while preserving last-known state.
 - **Ship reveal and integration:** When a fleet enters a sea zone, coastal tiles of adjacent provinces become revealed for that player, delegated to naval-movement-resolution; PlayerView construction (including Spy invisibility rules) is the single source for AI and order-suggestion visibility, never reading visibility directly from WorldState.


### PR DESCRIPTION
Fixes #613

- **GDD** (`SPEC/game/fog-and-exploration.md`): Added "Spy fog decay turns" row to Configurable Values table (default 5). Rules § Visibility Levels, § Fog Decay, and Acceptance criteria now refer to this parameter by name.
- **TDD** (`SPEC/program/fog-and-exploration-resolution.md`): Data Model (Spy reveal timer) and Fog decay (Spy) cite GDD § Configurable Values for the default; Acceptance criteria use "Spy fog decay turns, default 5 per GDD Configurable Values".

Docs-only.

Made with [Cursor](https://cursor.com)