### PR TITLE
GDD: acceptance criteria rule and expanded core specs

### DIFF
--- a/.cursor/rules/colonizethis-acceptance-criteria.mdc
+++ b/.cursor/rules/colonizethis-acceptance-criteria.mdc
@@ -1,0 +1,127 @@
+---
+description: Standard for writing machine-testable acceptance criteria in SPEC docs
+globs: "SPEC/ai/**,SPEC/game/**,SPEC/program/**,SPEC/ui/**"
+alwaysApply: false
+---
+
+# Acceptance Criteria for SPEC
+
+- **Scope:** Applies to all specs under `SPEC/game/`, `SPEC/program/`, `SPEC/ai/`, and `SPEC/ui/` whenever behavior is defined or changed.
+- **Goal:** Make every acceptance criterion (AC) unambiguous, machine-testable, and suitable for automated verification by AI agents and test frameworks.
+
+## Given–When–Then structure
+
+- **Format:** Each AC MUST be written as a single **Given–When–Then** triplet:
+  - **Given**: The initial state or context.
+  - **When**: The specific action or trigger.
+  - **Then**: The expected, measurable outcome.
+- **One behavior per AC:** If you describe more than one outcome, split into multiple ACs.
+- **Subjects are explicit:** Use `The Player`, `The System`, `The AI agent`, `The UI layer`, etc. Do NOT use ambiguous pronouns like `it` or `they`.
+
+Example (game rule):
+
+- Given the player controls a province with 10 food stored  
+  When the player ends the turn with consumption of 4 food  
+  Then the system reduces the stored food to 6 and records a turn log entry with type `food_consumption`
+
+Example (UI):
+
+- Given the user is on the login screen and the email field is empty  
+  When the user presses the “Log in” button  
+  Then the UI layer highlights the email field and shows the message `Email is required` under that field
+
+## Concrete data definitions
+
+AI agents cannot infer what “valid” means. Every AC MUST define inputs and state in concrete, checkable terms:
+
+- **Ranges:** Specify numeric constraints (e.g., “integer between 1 and 100 inclusive”, “population ≥ 0”).
+- **Formats:** Specify data formats (e.g., “ISO 8601 date `YYYY-MM-DD`”, “UUID v4 string”, “enum: `idle`, `moving`, `attacking`”).
+- **Null / empty / zero:** Explicitly define behavior when a field is blank, zero, or `null` according to the spec.
+
+Bad:
+
+- “The system accepts a valid turn number.”
+
+Good:
+
+- “The system accepts a turn index as an integer between 0 and 9999 inclusive. Given a value outside this range, the system rejects the request with error code `turn_index_out_of_range`.”
+
+## Explicit success vs. failure states
+
+- **Objective outcomes only:** Avoid subjective terms such as “fast”, “user-friendly”, or “intuitive” in ACs.
+- **Binary pass/fail:** Each AC MUST describe conditions that can clearly pass or fail.
+- **Make outcomes measurable:** Use numeric thresholds, exact messages, specific status codes, flags, or state changes.
+
+Prefer formulations like:
+
+- “Then the page reaches time-to-interactive in under 200 ms on target test hardware.”
+- “Then the system returns HTTP 400 with error code `invalid_email_format` and message `Invalid email format`.”
+- “Then the search results contain only provinces whose name or metadata include the search keyword (case-insensitive).”
+
+## Deterministic side effects
+
+Whenever an action changes state or triggers background work, ACs MUST state the expected side effects so integration tests can verify them:
+
+- **Data changes:**
+  - “Then the system creates a record in the `save_slots` table with `status = active` and `turn = 12`.”
+  - “Then the province’s stored food decreases by 4 and the region’s total food is updated accordingly.”
+- **External calls / integrations:**
+  - “Then the system sends a POST request to the `analytics/turn-ended` endpoint with `{ playerId, turnNumber }`.”
+- **State persistence:**
+  - “Then reloading the game from this save slot restores the same player resources and province ownership.”
+  - “Then refreshing the UI does not clear the unsaved form values for this screen.”
+
+Side effects MUST be deterministic: the same Given and When should always produce the same Then.
+
+## Best practices for AI readability
+
+- **Atomic criteria:** Each AC should describe exactly one behavior. If an AC mentions multiple independent behaviors (e.g., UI feedback AND database writes AND analytics), split into separate ACs that share the same Given–When but different Then clauses.
+- **Negative ACs:** For critical behaviors, include explicit negative or error-path ACs:
+  - “Given an invalid password, the system does not reveal whether the email exists and returns a generic `Invalid credentials` error.”
+  - “Given a province is not connected to the capital, when the player attempts to send trade, then the system rejects the action with reason `no_capital_connection`.”
+- **No ambiguous pronouns:** Always repeat the subject (`The Player`, `The System`, `The AI agent`, `The UI layer`) rather than `it` or `they` so the agent can track who acts and who reacts.
+
+## Examples by SPEC domain
+
+### Game (`SPEC/game/`)
+
+- Given the player owns a capital city and a province connected to that capital  
+  When the player assigns 20 units of grain to be transported from the capital to that province in a single turn  
+  Then the system decreases the capital’s stored grain by 20, increases the province’s stored grain by 20, and records a movement entry tagged `grain_transport`
+
+### AI (`SPEC/ai/`)
+
+- Given the AI agent controls three provinces with threat scores 10, 30, and 50, and total available militia of 40 units  
+  When the AI agent evaluates where to deploy new defenses  
+  Then the AI agent assigns at least 60% of the available militia to the province with threat score 50 and never assigns more than 20% to the province with threat score 10
+
+### Program / technical (`SPEC/program/`)
+
+- Given the player finishes turn 25 and the in-memory game state is marked as “dirty”  
+  When the system performs an autosave  
+  Then the system writes a save file with `turn = 25` and a monotonically increasing `saveVersion`, and a subsequent load from that file restores the same player resources, province ownership, and AI state present at autosave time
+
+### UI (`SPEC/ui/`)
+
+- Given the user is on the province detail screen with a province that has 0 available workers  
+  When the user attempts to increase the “assigned workers” slider above 0  
+  Then the UI layer prevents the slider from moving above 0 and shows a non-blocking warning message `No available workers to assign` within the screen
+
+## Integration with other rules
+
+- **SPEC-required:** This rule refines how behavior in `SPEC/game/`, `SPEC/program/`, `SPEC/ai/`, and `SPEC/ui/` must be expressed so it can be implemented and tested faithfully.
+- **Source of truth:** When there is a conflict between narrative text and ACs inside a SPEC document, the ACs are the authoritative description of expected behavior.
+- **Rulesets:** When behavior depends on configurable rulesets (e.g., difficulty levels, economy parameters), ACs MUST specify which ruleset is active and how it affects the Given–When–Then.
+- **Unclear or underspecified outcomes:** If a SPEC section does not clearly state what constitutes a correct outcome, the author or agent MUST first update the SPEC to define a **simple, sensible default behavior** (aligned with existing design and rulesets), and then update or add ACs to reflect that behavior in clear, testable terms.
+
+## Author checklist
+
+Before finalizing or updating a SPEC document under `SPEC/`, ensure:
+
+- Each important behavior has at least one AC written as Given–When–Then.
+- Inputs and state in ACs have explicit ranges, formats, and null/empty/zero behavior.
+- Success and failure outcomes are objectively testable with clear pass/fail conditions.
+- Deterministic side effects (data changes, integrations, persistence) are fully described.
+- Each AC is atomic (one behavior per AC), with negative/error-path ACs added where relevant.
+- Subjects are explicit; ACs avoid ambiguous pronouns like `it` or `they`.
+

--- a/.cursor/rules/colonizethis-spec-required.mdc
+++ b/.cursor/rules/colonizethis-spec-required.mdc
@@ -6,7 +6,7 @@ alwaysApply: true
 # SPEC Required
 
 - **SPEC-first:** Specify all game and technical behavior before implementation. Implement only what specs describe; no behavior that contradicts GDD or TDD.
-- **Layout:** Sub-specs only; max 500 words per document.
+- **Layout:** Sub-specs only; max 1000 words per document.
 
 | Domain | Path | Source of truth |
 |--------|------|-----------------|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ These rules are applied in every context; follow them for all changes.
 
 | Rule file | Summary |
 |-----------|---------|
-| **colonizethis-spec-required.mdc** | SPEC-first: specify before implementing; no behavior that contradicts specs. GDD `SPEC/game/`, TDD `SPEC/program/`, AI `SPEC/ai/`, UI `SPEC/ui/` (sub-specs, max 500 words). Source of truth: GDD for game/AI, TDD for architecture. Conflicts: resolve GDD/TDD first. Rulesets: configurable; specify where/how in GDD/TDD. New behavior: point to authorizing spec or add/extend spec first. |
+| **colonizethis-spec-required.mdc** | SPEC-first: specify before implementing; no behavior that contradicts specs. GDD `SPEC/game/`, TDD `SPEC/program/`, AI `SPEC/ai/`, UI `SPEC/ui/` (sub-specs, max 1000 words). Source of truth: GDD for game/AI, TDD for architecture. Conflicts: resolve GDD/TDD first. Rulesets: configurable; specify where/how in GDD/TDD. New behavior: point to authorizing spec or add/extend spec first. |
 | **colonizethis-core-principles.mdc** | Stack: Flutter (UI), Flame (game/simulation), Dart. Strict typing, null safety, logger (no `print`). Thin screens; delegate to services/controllers/Flame. Province lookup: always use `(regionId, provinceId)` or prefixed id; never province id alone. |
 
 ## Context-specific rules

--- a/SPEC/game/capital-and-connectivity.md
+++ b/SPEC/game/capital-and-connectivity.md
@@ -74,3 +74,71 @@ A province is **overseas** for a player if it is in a **different region** from 
 ## Capital loss and reassignment
 
 If a player no longer owns their capital province (e.g. after conquest), a new capital is chosen during turn resolution (see [turn-resolution-phase-details.md](../program/turn-resolution-phase-details.md) § Combat). New capital is in the player's **original region** (region of the previous capital) from the player's **owned provinces** in that region. Prefer **seaboard** provinces; place capital along the seaboard when possible. If the player has no seaboard provinces in that region, choose any remaining owned province (inland capital). Apply port/road setup per § Capital Setup. Reference capital-choice heuristics (e.g. border-avoidance) for tile choice where applicable. If the player has no owned provinces in the original region, leave capital (and capital tile) null; no port/road setup is applied.
+
+---
+
+## Acceptance Criteria
+
+- Given a Great Power player selects a capital province and a capital tile `(regionId, provinceId, x, y)` that is adjacent to a sea tile in that region  
+  When the system initializes the game at the end of the capital-choice phase  
+  Then the system marks that tile as the player’s capital tile and creates a capital port on that tile, and sets the capital province’s `townTileKey` to that tile.
+
+- Given a Great Power player selects a capital province and a capital tile `(regionId, provinceId, x, y)` that is not adjacent to sea and the province contains at least one sea-adjacent land tile  
+  When the system initializes the game at the end of the capital-choice phase  
+  Then the system creates a port on the sea-adjacent tile in that province with the shortest path (by number of province tiles) to the capital tile and auto-builds a road along that shortest path from the port tile to the capital tile.
+
+- Given a Great Power player has a capital province with a capital tile already placed  
+  When the system initializes towns for all provinces  
+  Then the capital province’s `townTileKey` is set to the capital tile and every other owned province has exactly one `townTileKey` set to the tile in that province with the shortest valid road or rail path to either the capital tile in the same region or a port in that province for an overseas province.
+
+- Given a Great Power player has a capital province in region `R1` and an owned province `P2` in the same region `R1` with at least one tile reachable by a road or rail path to the capital tile  
+  When the system assigns a town for `P2`  
+  Then the system selects as `P2`’s `townTileKey` the tile in `P2` whose shortest road or rail path to the capital tile is minimal among tiles in `P2`, breaking ties deterministically according to the map-topology rules.
+
+- Given a Great Power player has an owned province `P3` in region `R2` that is overseas (region `R2` is different from the capital region `R1`) and at least one port tile in `P3` whose sea zone is reachable from the capital’s seaboard via sea-zone and warp-zone edges  
+  When the system assigns a town for `P3`  
+  Then the system selects as `P3`’s `townTileKey` the tile in `P3` with the shortest road or rail path to any such connected port in `P3`, and marks that port as used for extraction connectivity for that province.
+
+- Given a Great Power player has a capital tile and a port tile `portA` in the same region  
+  When the system evaluates whether `portA` is connected to the capital  
+  Then `portA` is considered connected if and only if either the capital tile is adjacent to sea or there exists a road or railroad path from the capital tile to `portA` using only tiles in that region.
+
+- Given a Great Power player has a capital tile on the seaboard with sea zone `S_cap` and a port tile `portB` in the same region with sea zone `S_port`  
+  When the system evaluates whether `portB` is connected to the capital by sea topology  
+  Then `portB` is considered sea-connected to the capital if and only if `S_port` is equal to `S_cap` or reachable from `S_cap` by following sea–sea edges in that region’s sea-topology graph.
+
+- Given a Great Power player has a capital tile in region `R1` with sea zone `S_cap`, a port `portC` in region `R2`, and a multi-region sea topology with warp-zone links  
+  When the system evaluates whether `portC` is connected to the capital  
+  Then `portC` is considered connected if and only if its sea zone is reachable from `S_cap` by a path that may cross warp-zone edges between regions and sea–sea edges within each region.
+
+- Given a tile `T` in a land province owned by a Great Power player and that province has a `townTileKey` with a valid path to the capital according to the connectivity rules  
+  When the system evaluates whether `T` is connected to the capital for extraction  
+  Then `T` is considered connected if and only if either `T` is the capital tile or directly edge-adjacent to the capital tile, or `T` lies on or is edge-adjacent to a road or rail tile that has a road or rail path to the province’s town tile, and the town tile has a path to the capital tile.
+
+- Given a tile `T_overseas` in an overseas province owned by a Great Power player, and that province has a port `P_over` that is road or rail connected to `T_overseas` and is itself connected to the capital by sea and land per the port-connection and sea-path rules  
+  When the system evaluates whether `T_overseas` is connected to the capital for extraction  
+  Then `T_overseas` is considered connected if and only if there exists a road or rail path from `T_overseas` to `P_over` and `P_over` is marked as connected to the capital.
+
+- Given a connected tile `T_conn` with base production `P`, technology cap `TechCap`, a town development level `TownLvl` for its province’s town tile, and a set of transport levels along the chosen connectivity path with minimum value `MinTransport`  
+  When the system computes the effective extracted yield for `T_conn`  
+  Then the effective yield is `min(P, TechCap, TownLvl, MinTransport)` and is attributed to the player’s stockpile for that turn.
+
+- Given a tile `T_multi` that has two or more distinct valid connectivity paths to the capital with per-path minimum transport levels `MinPath1`, `MinPath2`, …, `MinPathN`  
+  When the system computes the transport-limited cap for `T_multi`  
+  Then the system selects `max(MinPath1, MinPath2, …, MinPathN)` as the transport constraint used in the effective-yield calculation for that tile.
+
+- Given a Great Power player has a connected province chain from the capital to a remote province and then loses ownership of a province `P_cut` that lies on all road or rail paths between the capital and some other province’s town tile  
+  When the system recomputes connectivity during the next extraction phase  
+  Then every tile whose only paths to its town or to the capital passed through `P_cut` is marked as not connected and no longer contributes extraction to the player’s stockpile.
+
+- Given a previously disconnected province `P_retake` becomes owned again by a Great Power player during turn resolution, restoring at least one full path from remote tiles through `P_retake` to the capital  
+  When the system recomputes connectivity during the next extraction phase  
+  Then all tiles in provinces that now have a valid path via `P_retake` to their town and to the capital are marked as connected again and resume contributing extraction according to the normal yield rules.
+
+- Given a player’s capital province is conquered so the player owns zero tiles in that province at the end of combat resolution  
+  When the system executes capital loss and reassignment during turn resolution  
+  Then the system selects a new capital province from the player’s owned provinces in the original capital region, preferring seaboard provinces when available, assigns a new capital tile using the capital-choice heuristics, applies capital port and road setup per the capital-setup rules, and updates all towns and connectivity based on the new capital before the next extraction phase.
+
+- Given a player has no owned provinces remaining in the original capital region after capital loss  
+  When the system executes capital loss and reassignment during turn resolution  
+  Then the system sets the player’s capital province and capital tile to `null`, performs no new port or road setup, and in the subsequent extraction phase treats all tiles for that player as not connected for extraction until a new capital is defined by later rules.

--- a/SPEC/game/capital-choice-phase.md
+++ b/SPEC/game/capital-choice-phase.md
@@ -39,6 +39,44 @@ The border-avoidance heuristic is purely aesthetic; it does not affect connectiv
 
 ---
 
+## Acceptance Criteria
+
+- Given a Great Power owns at least one province marked as sea-bound in the map topology (has at least one P–S edge)  
+  When the system runs the capital auto-choice phase for that Great Power during game setup  
+  Then the system selects the first sea-bound owned province by sorted province id and marks that province as the capital province for that Great Power
+
+- Given a Great Power owns no provinces marked as sea-bound in the map topology (no P–S edges on any owned province)  
+  When the system runs the capital auto-choice phase for that Great Power during game setup  
+  Then the system marks game setup as invalid for that game configuration and surfaces an error reason `no_sea_bound_capital_province` for that Great Power
+
+- Given a Minor Nation or Tribe owns at least one sea-bound province and at least one inland province  
+  When the system runs the capital auto-choice phase for that faction during game setup  
+  Then the system filters to sea-bound owned provinces first, selects the first by sorted province id, and marks that province as the capital province for that faction
+
+- Given a Minor Nation or Tribe owns no sea-bound provinces but owns at least one inland province  
+  When the system runs the capital auto-choice phase for that faction during game setup  
+  Then the system selects the first inland owned province by sorted province id and marks that province as the capital province for that faction
+
+- Given the system has selected a capital province for a Great Power that is sea-bound and the province contains at least one tile in Class A (coastal tiles not adjacent to any other province)  
+  When the system selects the capital tile for that Great Power during game setup  
+  Then the system selects the first tile in Class A in row-major order and sets that tile as the capital tile
+
+- Given the system has selected a capital province for a Great Power that is sea-bound and the province contains no tiles in Class A but contains at least one coastal tile in Class C (remaining tiles)  
+  When the system selects the capital tile for that Great Power during game setup  
+  Then the system selects the first coastal tile in Class C in row-major order and sets that tile as the capital tile
+
+- Given the system has selected a capital province for a Minor Nation or Tribe and classified its tiles into Class A (coastal, no foreign border), Class B (interior, no foreign border), and Class C (remaining)  
+  When the system selects the capital tile for that faction during game setup  
+  Then the system selects the first available tile in Class A in row-major order, or if Class A is empty the first tile in Class B, or if Class B is also empty the first tile in Class C
+
+- Given the system has set a sea-bound capital province and capital tile for any faction during game setup  
+  When the capital-choice phase completes for that faction  
+  Then the system applies port and road auto-build for that capital exactly once according to `capital-and-connectivity.md` § Capital Setup and records the resulting connectivity in the map data
+
+- Given the system has set an inland capital province and capital tile for a Minor Nation or Tribe during game setup  
+  When the capital-choice phase completes for that faction  
+  Then the system does not create any port structures or sea connections for that capital and leaves existing road topology unchanged
+
 ## Interactions
 
 - [capital-and-connectivity.md](capital-and-connectivity.md) — capital setup rules, connectivity

--- a/SPEC/game/civilian-units.md
+++ b/SPEC/game/civilian-units.md
@@ -61,6 +61,50 @@ Multi-turn progress for all civilian work is tracked in the model and resolved d
 
 ---
 
+## Acceptance Criteria
+
+- Given the player has sufficient treasury cash and stockpile paper for a civilian unit type in the Civilian Types and Roles table  
+  When the player issues a build order for that civilian unit and the order is accepted  
+  Then the system creates a civilian `Unit` with `type` equal to the requested civilian type, deducts the listed cash from the player's treasury, deducts the listed paper from the player's stockpile, and does not change any worker counts or food consumption.
+
+- Given the player submits a `WorkOrder` with `unitId` referencing a civilian unit and `action` equal to one of the Work Order Summary targets that is allowed for that unit type  
+  When the system applies Build/Work orders for the turn and the player has all required materials in treasury/stockpile  
+  Then the system marks that civilian unit's `status` as `working`, reserves or deducts the listed materials once at order application time, and starts multi-turn progress for that work without applying any improvement until progress completes.
+
+- Given a civilian unit has an active multi-turn `WorkOrder` and its work duration expires at the end of the current Build/Work phase  
+  When the system resolves development for that phase  
+  Then the system applies exactly one level of the specified effect to the `targetTileKey` (e.g., improvement level increase, road/rail/fort/port construction), sets the unit's `status` to `idle`, and clears the unit's active work so it does not continue on the next turn.
+
+- Given an Explorer civilian unit with `status = idle` is located in a province that still has fogged tiles  
+  When the player assigns an `explore` `WorkOrder` to that Explorer  
+  Then the system starts a multi-turn exploration process for that province and, on completion, reveals all tiles in that province to the Explorer's owner according to [fog-and-exploration-resolution.md](../program/fog-and-exploration-resolution.md).
+
+- Given a Spy civilian unit controlled by the player is present in a province that is not owned by that player  
+  When the system evaluates visibility for that player's map each turn  
+  Then the system treats that province as fully visible for that player, and when the Spy leaves that province, the system starts a 5-turn countdown after which all tiles in that province revert to fogged unless revealed by another source.
+
+- Given a Spy civilian unit controlled by the player has an active `counter_spy` `WorkOrder` targeting an owned province and an enemy Spy is present in the same province  
+  When the system resolves counter-spy checks at end of turn  
+  Then the system computes a per-turn kill chance equal to 5% per friendly Spy in that province, capped at 30%, and removes the enemy Spy from the game if the random roll succeeds while leaving all friendly Spies in place.
+
+- Given a Merchant civilian unit controlled by the player has an active `purchase_land` `WorkOrder` targeting a tile in a Minor Nation or Tribe province that has a resource, the player is not at war with that Minor/Tribe, the player has an embassy with that Minor/Tribe, and any mineral resource on that tile has already been prospected by that player  
+  When the system resolves that `purchase_land` order  
+  Then the system deducts treasury cash equal to 15 times the resource base price, transfers ownership of that tile (and its resource) to the player, and leaves diplomatic status with that Minor/Tribe unchanged.
+
+- Given a Rail Builder civilian unit controlled by the player has an active `build_rail` `WorkOrder` targeting a tile that currently has a road and the required transport technology is unlocked  
+  When the system completes that work after the configured duration  
+  Then the system upgrades the tile's transport level to railroad (transport level 4), deducts the specified steel and lumber once for that work, and does not allow another `build_rail` order on that tile while it already has transport level 4.
+
+- Given a civilian `Unit` of any type exists on the map  
+  When the system evaluates that unit's `location` and any `WorkOrder.targetTileKey` for rules that depend on province or region identity  
+  Then the system derives province and region solely from the prefixed tile key format `regionId|provinceId|x|y` and never treats a bare `provinceId` without its `regionId` as a valid reference.
+
+- Given the system resolves the Build/Work phase for all civilians in a turn  
+  When it completes processing of all active `WorkOrder`s for that turn  
+  Then every civilian unit has `status` equal to either `idle` or `working` (no other values), with `working` only for units that still have an active, incomplete multi-turn `WorkOrder`.
+
+---
+
 ## Relations
 
 - **Unit** (type = civilian) → has owner (player id) and **location** = **tileKey** only (required, format `regionId|provinceId|x|y`); province and region are derived from tileKey. Work is ordered via WorkOrder (unitId, action, targetTileKey). Military and naval units do not have tileKey. See [fog-and-exploration.md](fog-and-exploration.md).

--- a/SPEC/game/combat.md
+++ b/SPEC/game/combat.md
@@ -26,6 +26,48 @@ Auto-resolved combat triggers when units move into enemy-controlled provinces. B
 
 **Province Flip:** Immediate on defender elimination, before later same-province battles. Connectivity/extraction recompute next turn.
 
+## Acceptance Criteria
+
+- Given a province owned by a defending faction with fort level between 0 and 3 inclusive and at least one defending regiment  
+  When a Great Power moves at least one attacking regiment into that province and the move ends in that province  
+  Then the system starts a combat resolution for that province, designates the moving faction as the attacker, designates the province owner (or, on ownership ties, the lowest faction id) as the defender, and selects `Field` battle mode when fort level = 0 or `Siege` battle mode when fort level ≥ 1.
+
+- Given one defender and two or more attacking factions each with at least one regiment in the same province  
+  When the system resolves combat for that province  
+  Then the system computes initiative for each attacker as `initiative = cavalryShare × W_cav + generalMedals × W_medal`, breaks ties by ascending faction id, and orders the attackers from highest to lowest initiative for the multi-attacker chain.
+
+- Given a defender and an ordered list of attackers as defined above, each with at least one regiment remaining  
+  When the system executes the multi-attacker chain for that province  
+  Then the system first resolves a battle between the defender and the highest-initiative attacker, and for each subsequent attacker it resolves a new battle between the previous battle’s winner (without healing or regenerating regiments) and the next attacker in the ordered list until either all attackers are eliminated or the defender side is eliminated.
+
+- Given a defender and one or more attackers with regiment-level stats (FPN, FPM, medals, DEF) and combat modifiers (terrain, fort, difficulty, leaders, feeding coverage) defined in the active ruleset  
+  When the system computes side strength for auto-resolve combat in that province  
+  Then the system aggregates each side’s strength as the sum over that side’s regiments of `(FPN + FPM) × medalMultiplier`, applies the configured combat modifiers to the aggregated totals, and uses these modified totals as the only inputs to decide the winner and casualty distribution for the current auto-resolve implementation (deferring DEF/9 and damaged-unit health scaling until unit health is introduced into the model).
+
+- Given a combat where the aggregated attacker strength after modifiers is strictly greater than the aggregated defender strength  
+  When the system completes combat resolution for that province  
+  Then the system declares an attacker victory, eliminates all defending regiments, flips province ownership to the attacker faction that was last in the chain, and marks the province as owned by that attacker for subsequent turns while leaving connectivity and extraction recomputation to the next turn-processing step.
+
+- Given a combat where the aggregated defender strength after modifiers is greater than or equal to the aggregated attacker strength and the defender still has at least one regiment remaining at the end of resolution  
+  When the system completes combat resolution for that province  
+  Then the system declares a defender victory, eliminates all attacking regiments in that province, keeps province ownership with the defending faction, and does not trigger a province flip.
+
+- Given a combat where both the attacker side and the defender side lose all regiments in the final exchange, and there is at least one additional attacker faction remaining in the multi-attacker chain for that province  
+  When the system completes the current attacker–defender exchange  
+  Then the system records a mutual annihilation outcome for that exchange, restores a new defending garrison equal to 20% of the defender’s initial regiment count in that battle rounded up, and continues the multi-attacker chain using this restored defending garrison against the next attacker faction.
+
+- Given a combat where both the attacker side and the defender side lose all regiments in the final exchange and there are no further attackers remaining in the multi-attacker chain  
+  When the system completes combat resolution for that province  
+  Then the system records a mutual annihilation outcome for the province, keeps the original defending faction as the province owner, and leaves the province ungarrisoned with zero defending regiments.
+
+- Given a combat where both the attacker side and the defender side have at least one regiment remaining after applying casualties for the final exchange  
+  When the system completes combat resolution for that province  
+  Then the system records a stalemate outcome for the province, preserves the existing province owner, and leaves all surviving attacker and defender regiments in place without flipping province ownership.
+
+- Given two combat resolutions for the same province in the same game state with identical unit compositions, stats, modifiers, and move orders  
+  When the system executes combat resolution for that province both times  
+  Then the system produces the same ordered sequence of battle pairings, the same winner for the overall province combat, the same casualty counts per faction and side, and the same province ownership outcome in both executions.
+
 ## Configurable Values
 
 | Parameter | Default | Notes |

--- a/SPEC/game/commodity-catalog.md
+++ b/SPEC/game/commodity-catalog.md
@@ -40,3 +40,27 @@ The **commodity catalog** (id list, category per commodity, default price for sp
 ## Overflow and Capacity
 
 Capacity limits may apply per commodity or to total stockpile; configurable per era. **Overflow rules:** excess sold at market or discarded, per design. Details in [stockpiles-and-production.md](stockpiles-and-production.md). Implementation may stub capacity (e.g. unlimited) until design is fixed.
+
+---
+
+## Acceptance Criteria
+
+- Given the active ruleset config defines a commodity list where each commodity id is a non-empty string and unique within that list  
+  When the system loads the ruleset at game start or when starting a new scenario  
+  Then the system builds an in-memory commodity catalog that contains exactly the same set of commodity ids, with each id mapped to exactly one category from the set `food`, `rawMaterial`, `manufactured`, `luxury`, `riches`, `advanced`, and rejects any ruleset that defines duplicate ids with error code `duplicate_commodity_id`
+
+- Given the in-memory commodity catalog has been successfully loaded from the ruleset config  
+  When the system queries the category for a known commodity id such as `grain`, `timber`, `castIron`, or `gold`  
+  Then the system returns the category defined in the table under "Commodity List" for that id and returns an error with code `unknown_commodity_id` when the id is not present in the catalog
+
+- Given a player owns a province that has a non-negative integer quantity of riches commodities (for example `gold` and `silver`) stored in its stockpile, and the active ruleset defines a non-negative base price in treasury units for each of those riches  
+  When the system runs the riches-to-treasury phase for turn \(N\)  
+  Then the system decreases the stored quantity of each riches commodity in that province to 0, increases the player treasury by the sum over all riches of `quantity * basePrice`, and records a turn log entry tagged `riches_to_treasury` that lists, for each riches commodity, its id, quantity consumed, base price, and treasury gained
+
+- Given the active ruleset uses the standard economy profile for ColonizeThis  
+  When the system runs the riches-to-treasury phase for any turn and converts stored `spices` from any province into treasury  
+  Then the system uses a fixed base price of exactly 50 treasury units per unit of `spices` regardless of any other price modifiers, and includes this price in the `riches_to_treasury` turn log entry for that turn
+
+- Given a game is running with a ruleset era that has not defined per-commodity or total stockpile capacity limits  
+  When any game logic (such as production, trade, or riches conversion) increases a province’s stockpile for any commodity to a non-negative integer amount  
+  Then the system does not discard or sell any overflow for that commodity in that era, and tests that attempt to store arbitrarily large quantities (within engine integer limits) complete without triggering overflow-related discard or market-sale behavior

--- a/SPEC/game/diplomacy.md
+++ b/SPEC/game/diplomacy.md
@@ -54,6 +54,36 @@ Diplomacy phase runs before Movement. Declarations and peace take effect for the
 
 ---
 
+## Acceptance Criteria
+
+- Given a new game has started with at least two Great Powers  
+  When the system initializes diplomatic relations at turn index 0  
+  Then the system sets each unordered Great Power pair to relation state `AT_PEACE`, relation score `50`, relation level `Neutral`, and records `sinceTurn = 0` and `lastInteractionTurn = 0`.
+
+- Given the Player is a Great Power at relation state `AT_PEACE` with a target Great Power and the current turn index is an integer `t ≥ 0`  
+  When the Player issues a `Declare War` diplomatic order targeting that Great Power in the Diplomacy phase of turn `t` and the order is valid  
+  Then the system changes the relation state between the two Great Powers to `AT_WAR` with `sinceTurn = t`, updates `lastInteractionTurn = t`, and uses this `AT_WAR` state for all Movement and Combat validation during turn `t`.
+
+- Given the Player is a Great Power at relation state `AT_WAR` with a target Great Power and the current turn index is `t`  
+  When both sides have accepted a peace offer between those two Great Powers in the Diplomacy phase of turn `t`  
+  Then the system changes the relation state between the two Great Powers to `AT_PEACE` with `sinceTurn = t`, updates `lastInteractionTurn = t`, leaves all province ownership unchanged, and uses `AT_PEACE` for Movement and Combat validation during turn `t`.
+
+- Given the Player controls a Great Power with a valid treasury balance in pounds as a non-negative integer and has no existing consulate or embassy with a target Minor Nation  
+  When the Player issues an `Establish Overture` order for a `Consulate` with that Minor and the treasury is greater than or equal to `Consulate cost` for the active ruleset  
+  Then the system deducts exactly the `Consulate cost` from the Player treasury, records a Consulate overture between the Great Power and that Minor, and unlocks the ability for the Player to offer an Embassy to that same Minor in later turns.
+
+- Given the Player controls a Great Power that already has an Embassy with a target Minor Nation or Tribe, is not at relation state `AT_WAR` with that faction, and has a Merchant unit assigned a `purchase_land` work order targeting a tile in that Minor or Tribe province  
+  When the system validates the `purchase_land` work order during turn resolution  
+  Then the system accepts the work order for execution and does not reject it for missing diplomatic prerequisites.
+
+- Given the Player controls a Great Power with an Embassy in a Minor Nation that is currently being attacked by a different Great Power in turn `t`  
+  When the system presents the Player with an Intervention choice and the Player selects **Intervene**  
+  Then the system changes the relation state between the Player’s Great Power and the attacking Great Power to `AT_WAR` with `sinceTurn = t`, adds the Minor’s provinces and units to the Player’s side in that war, and uses this war state for all Movement and Combat validation during turn `t`.
+
+- Given the Player controls a Great Power with an Embassy in a Minor Nation that is currently being attacked by a different Great Power in turn `t`  
+  When the system presents the Player with an Intervention choice and the Player selects **Do Nothing**  
+  Then the system does not change the relation state between the Player’s Great Power and the attacking Great Power in turn `t`, allows combat between the attacker and the Minor to proceed, and, if the Minor is eliminated, clears all diplomatic relations between the Player and that Minor from the game state.
+
 ## Configurable Values
 
 | Parameter | Default | Notes |

--- a/SPEC/game/factions.md
+++ b/SPEC/game/factions.md
@@ -56,3 +56,19 @@ A **faction** is an entity that owns provinces (in any region) and has a defined
 | Provinces count to victory | OW yes | Yes (for controller) | No |
 
 Extraction and ownership apply per faction; only Great Powers have stockpiles and receive extraction in the economy phase. Minors and Tribes' production may feed trade/market per economy spec.
+
+---
+
+## Acceptance Criteria
+
+- Given a new game is created with at least one Great Power, one Minor Nation, and one Tribe configured in the ruleset  
+  When the System runs the game-setup pipeline per [game-setup.md](game-setup.md)  
+  Then the System creates Faction records for each configured Great Power, Minor Nation, and Tribe, assigns them the correct faction type, and sets their capabilities (such as ability to submit orders, own provinces in specific regions, and win the game) according to the summary table in this document.
+
+- Given the combat system needs to compute `maxGreatPowerMilitaryLevel` and `effectiveMilitaryLevel` for Minors and Tribes as described under Minor Nations  
+  When the System starts a Combat phase per [turn-resolution-phases.md](../program/turn-resolution-phases.md)  
+  Then the System scans all Great Powers’ buildable regiment types per [military-units.md](military-units.md) and tech state, derives the highest available regiment era as `maxGreatPowerMilitaryLevel`, and sets each Minor Nation and Tribe’s `effectiveMilitaryLevel` to that value before resolving any battles that involve those factions.
+
+- Given a Minor Nation or Tribe’s `effectiveMilitaryLevel` increases because `maxGreatPowerMilitaryLevel` increased at the start of a Combat phase  
+  When the System generates or updates that faction’s unit templates for use in battles during that phase  
+  Then the System upgrades existing regiments to the appropriate higher-tier versions consistent with the new effective level while preserving any damage state those regiments already had, so that parity affects unit quality but not unit counts or general bonuses.

--- a/SPEC/game/game-setup.md
+++ b/SPEC/game/game-setup.md
@@ -47,3 +47,19 @@ Pre-game phases that configure, generate, and populate the game world before tur
 - Capital auto-choice and capital-choice phase: [capital-choice-phase.md](capital-choice-phase.md)
 - Ruleset configuration: [ruleset-config.md](ruleset-config.md)
 - Province naming: [naming.md](naming.md)
+
+---
+
+## Acceptance Criteria
+
+- Given a ruleset or scenario defines Great Power count, continent count, Minor Nation count, Tribe count, and target province counts per region  
+  When the System runs the Config phase of game setup  
+  Then the System loads these values, validates that they are non-negative integers within sensible bounds, and either proceeds with world generation using them or surfaces a clear configuration error if validation fails.
+
+- Given Old World and New World province counts and continent count are loaded and the tile-map generation and topology specs in [tile-map-and-generation.md](tile-map-and-generation.md) and [map-topology.md](map-topology.md) are implemented  
+  When the System runs the World Generation phase  
+  Then the System generates exactly one tile map per region with the requested total province counts (within tolerances), infers topology from those grids, and produces contiguous landmasses and province graphs suitable for GP, Minor, and Tribe assignment.
+
+- Given world generation has completed successfully and Great Power, Minor Nation, and Tribe counts are known  
+  When the System runs the GP Assignment, Minor Nation Assignment, Tribe Assignment, and Faction & Initial State phases  
+  Then the System assigns contiguous clusters of Old World provinces to Great Powers and Minor Nations and New World provinces to Tribes as described in this document, ensures that each Great Power has at least one sea-bound province, sets up faction records and ownership, invokes the capital-choice phase per [capital-choice-phase.md](capital-choice-phase.md), applies naming per [naming.md](naming.md), and creates an initial `Game` and `WorldState` that satisfy all invariants in [world-model.md](world-model.md) and [world-model-identity.md](world-model-identity.md).

--- a/SPEC/game/military-units.md
+++ b/SPEC/game/military-units.md
@@ -63,3 +63,19 @@ Stats are configurable per [ruleset-config.md](ruleset-config.md). Experience (m
 | Siege Guns | 17 | 2 | 12 | 3 | 3 | Heavy Artillery | 4 |
 
 Bowmen, Knights, Lancers: no upgrade path; obsolete in later eras.
+
+---
+
+## Acceptance Criteria
+
+- Given the regiment table in this document and the global unit catalog in the implementation  
+  When the System loads or validates regiment definitions at startup  
+  Then the System ensures that each regiment id or type has exactly one entry with FPN, FPM, RNG, DEF, MVR, category, and era matching this table, and rejects any configuration that omits a listed regiment or defines duplicate regiment entries.
+
+- Given a player’s `techUnlocked` set on the Player object and the military tech table in [tech-tree-military.md](tech-tree-military.md) that maps tech ids to regiment unlocks  
+  When the System evaluates which regiment types the player may build during the build phase  
+  Then a regiment type is considered buildable if and only if its unlocking tech id is present in `techUnlocked` (or requires no tech), regardless of era, and regiment types whose unlocking tech is not in `techUnlocked` are not buildable.
+
+- Given a combat resolution or Quick Battle needs to compute land combat strength for a side using this regiment table and medal levels per unit  
+  When the System aggregates strength per side as described in [combat.md](combat.md) and [quick-battle.md](quick-battle.md)  
+  Then the System uses each regiment’s FPN and FPM values from this table, multiplies them by the appropriate medal multiplier, and never assumes or infers stats that contradict the values specified here.

--- a/SPEC/game/naming.md
+++ b/SPEC/game/naming.md
@@ -59,3 +59,19 @@ When a faction has no matching entry in the naming config (e.g. tribe count > 10
 
 - **Fallback algorithm:** Combine a **word stub** (e.g. Tan, Ver, Ash) with a **place suffix** (e.g. ton, ville, ford) using a RNG seeded from the naming seed and faction/province context so the same setup yields the same names.
 - **Uniqueness:** During naming, all **generated** names are added to an in-memory set; when generating a new name, the implementation must ensure the name is not already in that set (re-roll or append ordinal until unique). Names from the ruleset (pool/capital) may repeat across factions; only procedural names are guaranteed unique.
+
+---
+
+## Acceptance Criteria
+
+- Given a naming config for the active ruleset that defines Great Power, Minor Nation, and Tribe entries as described in this document  
+  When the System loads naming data during game setup  
+  Then the System validates that each Great Power id has at least one leader variant, that province name pools and capital names (when present) are non-empty strings, and that Minor Nation and Tribe entries provide at least one province name each, rejecting the ruleset if required naming data is structurally invalid.
+
+- Given provinces have been assigned to factions during game setup per [game-setup.md](game-setup.md) and naming data has been loaded successfully  
+  When the System assigns names in the Naming phase  
+  Then every province receives a non-null `Province.displayName`, capital provinces receive the configured capital city name for their faction or the first entry from the province name pool as specified, and other provinces draw names from their faction’s pool using a RNG seeded from the setup seed so that identical seeds yield identical name assignments.
+
+- Given a faction or province lacks a matching entry or usable name pool in the naming config (for example, when there are more tribes than configured entries)  
+  When the System assigns names for that faction’s provinces  
+  Then the System invokes the deterministic fallback algorithm described here to generate unique, reproducible names per province using a naming seed and faction/province context, ensures that generated names are not reused across procedural names in the same game, and still guarantees that every province ends the setup process with a non-empty `Province.displayName`.

--- a/SPEC/game/production-recipes.md
+++ b/SPEC/game/production-recipes.md
@@ -30,3 +30,19 @@ Worker tiers supply labour: Peasant 1, Apprentice 4, Journeyman 6, Master 8 per 
 ## Where Stored
 
 **Production recipes** are program-level constants defined in config (list or map of recipe definitions). Program-level config only; no JSON rulesets.
+
+---
+
+## Acceptance Criteria
+
+- Given the program-level config defines a list or map of production recipes where each recipe has a non-empty output commodity id, a non-negative integer output quantity, a map of input commodity ids to non-negative integer quantities, and a non-negative integer labour requirement  
+  When the System loads the economy configuration at game start  
+  Then the System builds an in-memory recipe catalog that contains exactly those recipes, rejects any configuration that refers to an unknown commodity id in inputs or outputs with an error code such as `unknown_commodity_id_in_recipe`, and makes the loaded recipes available to the Production phase.
+
+- Given a player has a central stockpile and WorkerPool state as described in [stockpiles-and-production.md](stockpiles-and-production.md) and [workers-and-population.md](workers-and-population.md), and there exists a recipe whose input commodity quantities and labour requirement are fully satisfied by the current stockpile and WorkerPool  
+  When the System executes the Production phase for that player  
+  Then the System may run that recipe one or more times, consuming the required inputs and labour per run, adding the specified output quantity per run to the stockpile, and never allowing any input commodity or labour count to drop below zero.
+
+- Given a player has insufficient input commodities or insufficient available labour to satisfy the full input and labour requirements of a recipe for even a single run  
+  When the System evaluates which recipes to execute during the Production phase  
+  Then the System does not execute that recipe (i.e. it produces zero units of the recipe’s output for that phase) and does not partially consume inputs in a way that leaves the recipe half-complete.

--- a/SPEC/game/quick-battle.md
+++ b/SPEC/game/quick-battle.md
@@ -99,3 +99,19 @@ Quick Battle does **not** change the underlying combat formula; it supplies stru
 
 The game then applies casualties and province ownership changes using the same world-state update logic as auto-resolve.
 
+---
+
+## Acceptance Criteria
+
+- Given a Quick Battle is initiated for a province with one attacking stack and one defending stack and the combat context includes terrain and lane assignments as described in this spec  
+  When the System sets up the Quick Battle battlefield  
+  Then the System assigns each side’s regiments to lanes and lines (`LEFT`, `CENTER`, `RIGHT`, `RESERVE` × `FRONT`/`SUPPORT`), tags each lane with a single terrain type from the allowed set (`OPEN`, `HILL`, `WOODS`, `TOWN`, `SWAMP`), and initializes each battalion group’s cohesion to 3 (Fresh).
+
+- Given a Quick Battle round begins and both sides have defined tech, regiment stats, medal levels, and lane terrain  
+  When the System computes effective combat power for each battalion group and side for that round  
+  Then the System uses `basePower = Σ(FPN_eff + FPM_eff) × medalMult` for the regiments in each group, multiplies by the terrain and cohesion multipliers from the tables in this spec, and uses these adjusted values to resolve fire, charges, casualties, and cohesion changes for that round.
+
+- Given a Quick Battle proceeds for up to 3 rounds or until a collapse condition is met  
+  When the System checks outcome conditions at the end of each round  
+  Then the System ends the battle immediately when the attacker collapse, defender collapse, or mutual exhaustion conditions from this spec are satisfied, computes casualties per side and a final battle result (decisive attacker win, decisive defender hold, or mutual exhaustion), and passes these results into the same province-flip and casualty application pipeline used by auto-resolve.
+

--- a/SPEC/game/resource-terrain-region-rules.md
+++ b/SPEC/game/resource-terrain-region-rules.md
@@ -44,3 +44,23 @@ On each map (oldWorld and newWorld), at most 30% of placed resources may be mult
 - **Fish:** Water tiles only. Pass 7 assigns resources to land cells only. Fish is future scope (water-resource pass or separate handling).
 - **Diamonds:** Spawn on desert terrain (New World only). Imperialism II Terrain and Development table.
 - **Riches:** silver, gold, gems, diamonds, spices align with riches-to-treasury base prices (defined in ruleset config).
+
+---
+
+## Acceptance Criteria
+
+- Given the active ruleset defines a resource–terrain–region table where each row specifies a resource id, a region scope (`OW only`, `NW only`, or `both`), a non-empty set of terrain types, and a default market price  
+  When the System loads this table at game start  
+  Then the System validates that each resource id is unique, that terrain types listed for each row are valid terrain types for the specified region, and that default prices are positive integers, rejecting the ruleset with a clear error if any of these conditions fail.
+
+- Given a tile map for a region such as `oldWorld` with terrain types assigned to each land cell and the resource–terrain–region rules have been loaded successfully  
+  When the System assigns resources to land tiles according to these rules  
+  Then the System only assigns a resource to a tile if the tile’s region and terrain type match at least one table row for that resource, and it never places a resource on a tile whose region or terrain is not allowed by the table.
+
+- Given a map for `oldWorld` and `newWorld` and a configured multi-region cap of 30% for resources whose region scope is `both`  
+  When the System runs the resource placement pass that can choose between resources with scope `both` and resources with region-exclusive scope for a candidate tile  
+  Then the System ensures that no more than 30% of all placed resources on that map are `both`-scope resources, and when the cap has been reached it only considers region-exclusive resources for tiles that have both options available.
+
+- Given a land tile in the New World with desert terrain and no Old World-only resources that are legal on desert tiles in that region  
+  When the System assigns resources to land tiles for the New World  
+  Then the System may assign `diamonds` to that tile even if the multi-region cap for `both` resources has already been reached, because the cap is applied only when there is a choice between `both` and region-exclusive resources.

--- a/SPEC/game/ships-and-naval.md
+++ b/SPEC/game/ships-and-naval.md
@@ -125,3 +125,23 @@ shipLossChance = baseShipLoss × (1 - escortFactor) × civilianPenalty
 civilianPenalty = 2.0 # Civilian ships twice as vulnerable
 raidEfficiency = 0.3 to 0.7 depending on relative strength
 ```
+
+---
+
+## Acceptance Criteria
+
+- Given a fleet moves into a sea zone during the Movement phase per [map-topology.md](map-topology.md) and that sea zone is adjacent to one or more coastal provinces  
+  When the System updates fog-of-war state for the moving player per [fog-and-exploration.md](fog-and-exploration.md)  
+  Then the System sets all coastal tiles of provinces adjacent to that sea zone to at least `revealed` for that player, enabling Explorer deployment into those provinces.
+
+- Given a fleet is assigned one of the missions `Move`, `Patrol`, `Blockade`, `Beachhead`, or `Defend` for a turn and the naval movement resolver runs per [naval-movement-resolution.md](../program/naval-movement-resolution.md)  
+  When the System processes that fleet’s orders  
+  Then the System either moves the fleet along valid P–S or S–S edges for `Move`, leaves it in place and evaluates interception chances for `Patrol` and `Blockade` using the base and modified probabilities in the interception table, or treats it as stationary and vulnerable for `Beachhead` and `Defend` while still allowing it to be attacked by enemy fleets in the same sea zone.
+
+- Given two opposing fleets with known ship stats (FRP, RNG, ARM, HULL, MV) and medals occupy the same sea zone and a naval battle is triggered  
+  When the System computes naval combat strength and resolves the battle  
+  Then the System uses the aggregation and durability formulas in this document (including RNG weighting and HULL × (1 + ARM/10)), applies any leader and tech modifiers as specified in related specs, and produces deterministic outcomes (winner, casualties, and possible retreats) for identical inputs across multiple runs.
+
+- Given a Great Power’s home fleet carries overseas cargo during Extraction/Trade and hostile fleets at war with that Great Power are patrolling or blockading relevant sea zones  
+  When the System resolves overseas transport and trade for that turn  
+  Then the System uses the interception probabilities and escort protection formulas in this document to determine whether cargo and civilian ships are lost, reduces delivered quantities and ship counts accordingly, and applies at most the documented maximum loss reduction from escorts.

--- a/SPEC/game/siege-mechanics.md
+++ b/SPEC/game/siege-mechanics.md
@@ -62,3 +62,19 @@ There is no separate “unfortified siege” mode: the presence or absence of a 
 Forts have three gates. Friendly units can sortie or retreat through gates. Enemy units cannot use gates; walls must be breached to enter.
 
 **Quick Battle (lane-based) interpretation:** In the current lane-based Quick Battle resolver, all defender units are treated as benefiting from wall damage reduction and emplaced artillery. Explicit "units on the wall" vs "units behind the wall" targeting (artillery-only damage to behind-wall) and gate/sortie actions are deferred to a future tactical expansion when lane/position model supports it.
+
+---
+
+## Acceptance Criteria
+
+- Given a province has a fort level of 0, 1, 2, or 3 stored in the world model and the combat resolver creates a BattleContext for a battle in that province  
+  When the System chooses the battle mode per [combat.md](combat.md)  
+  Then the System selects field battle rules when `fortLevel == 0` and siege rules from this document (including wall damage reduction and emplaced artillery) when `fortLevel ≥ 1`.
+
+- Given defenders are in a province with a fort level of 1, 2, or 3 and an incoming attack triggers siege combat  
+  When the System computes damage to defenders that are on or behind the wall  
+  Then the System reduces incoming damage by the percentage in the Wall Protection table for the current fort level and only allows non-artillery units with RNG 1 to inflict damage if defenders have sortie’d out of the fort according to the tactical rules.
+
+- Given a fort with level 1, 2, or 3 is present in a province and a siege battle is resolved there  
+  When the System initializes the battle  
+  Then the System creates 1, 2, or 3 emplaced artillery guns respectively, applies a +1 RNG bonus to those guns relative to comparable heavy artillery of the same era, excludes emplaced guns from the deployment limit, and automatically downgrades the fort by one level if all emplaced guns are destroyed during the battle even if the attackers lose.

--- a/SPEC/game/stockpiles-and-production.md
+++ b/SPEC/game/stockpiles-and-production.md
@@ -24,6 +24,27 @@ Capacity for all commodities is infinite; no limit on the amount of each commodi
 - Extraction in provinces → owning player's stockpile (via transport network). Province and tile identity (owned provinces, extraction locations) follow [world-model-identity.md](world-model-identity.md) for province id format and region-scoped lookup.
 - Production: stockpile inputs (commodities) + WorkerPool labour → stockpile outputs.
 
+---
+
+## Acceptance Criteria
+
+- Given a player owns one or more provinces and has at least one extractable resource tile connected to the capital as described in [extraction-and-improvements.md](extraction-and-improvements.md)  
+  When the System runs the Extraction phase of turn resolution  
+  Then the System sums the effective yields from all connected tiles for that player by commodity id and increases the player’s central stockpile quantities by exactly those sums without storing any additional per-province stockpile values.
+
+- Given a player has a non-negative integer quantity of each commodity in the central stockpile and the active ruleset does not define any stockpile capacity limits  
+  When any phase (Extraction, Riches-to-treasury, Production, or Consumption) adjusts stockpile quantities during a turn  
+  Then the System allows stockpile quantities to grow without applying any hard caps, discards, or automatic market sales, and ensures all adjustments preserve non-negative integer quantities for each commodity.
+
+- Given a player has enough input commodities and available labour in the WorkerPool to run one or more production recipes defined in [production-recipes.md](production-recipes.md)  
+  When the System executes the Production phase for that player  
+  Then the System consumes the required input quantities and labour from the stockpile and WorkerPool, adds the recipe outputs to the same central stockpile, and records which recipes ran so that a subsequent inspection can verify that input and output quantities satisfy each recipe’s definitions.
+
+- Given a player has workers and other consumers (such as army and navy) that require food and materials as described in [workers-and-population.md](workers-and-population.md)  
+  When the System executes the Consumption phase  
+  Then the System deducts required food and materials from the player’s central stockpile in the specified order, removes workers that starve when their required food cannot be met, and does not attempt to deduct from any non-existent per-province storage.
+
+---
 
 ## Interactions
 - [commodity-catalog.md](commodity-catalog.md) — commodity definitions

--- a/SPEC/game/tech-and-extraction-cap.md
+++ b/SPEC/game/tech-and-extraction-cap.md
@@ -17,3 +17,19 @@ The **max effective extraction level** (1–4) per resource or improvement type 
 **MVP:** The implementation uses a **single scalar** cap per player (one value for all resources) as a temporary simplification; the catalog is program-level (e.g. gathering_1/2/3). The full model will use **per-resource** caps from the category sub-docs (e.g. [tech-tree-gathering.md](tech-tree-gathering.md)).
 
 **Fallback:** When the full tech model is not yet loaded or a resource has no tech-gated cap, use a **constant cap** (e.g. 4) per player from config so extraction resolution can run. Full model derives cap from [tech-tree.md](tech-tree.md) and category sub-docs. Ruleset: MVP program-level constants; future ruleset per [ruleset-config.md](../program/ruleset-config.md).
+
+---
+
+## Acceptance Criteria
+
+- Given a player has a tech table where each tech id is either unlocked or locked and a program-level catalog that maps tech ids to extraction caps per resource  
+  When the System computes the player’s current extraction caps from the tech table  
+  Then the System derives, for each relevant resource, a non-negative integer cap between 1 and 4 inclusive based only on the unlocked techs and the catalog, and does not assign any cap that contradicts the catalog.
+
+- Given the implementation is running in the MVP mode where a single scalar extraction cap is used per player for all resources  
+  When the System evaluates extraction for any tile owned by that player as described in [extraction-and-improvements.md](extraction-and-improvements.md)  
+  Then the System sets the production for that tile to the minimum of the tile’s improvement level and that player’s scalar cap and applies this same cap regardless of which resource is present on the tile.
+
+- Given the full tech model is not yet loaded or a resource does not have any associated tech-gated cap in the catalog  
+  When the System computes extraction caps for that resource for any player  
+  Then the System uses the configured constant fallback cap (for example 4) so that extraction resolution can run, and applies this fallback in the same way as a tech-derived cap when computing per-tile production.

--- a/SPEC/game/tech-tree-labour-economy.md
+++ b/SPEC/game/tech-tree-labour-economy.md
@@ -23,3 +23,19 @@
 
 - Cigar Production and Hat Production are listed under New World (discovery/luxury); Trained Journeymen and Master Artisans depend on them.
 - Labour effects drive production/consumption and worker pool tiers; see economy specs.
+
+---
+
+## Acceptance Criteria
+
+- Given the Labour and Economy tech table in this doc and the global tech catalog built from all tech-tree docs  
+  When the System validates the catalog at startup  
+  Then the System ensures that each id in this table is unique, that its prerequisites refer to techs present in the global catalog, and that the effects (worker tiers, trade slots, research slots, banking) are consistent with the economy specs that consume them.
+
+- Given a player has `apprentice_workers`, `trained_journeymen`, or `master_artisans` in `techUnlocked` as defined in this table  
+  When the System computes available labour for Production and food and luxury consumption for the Consumption phase per [workers-and-population.md](workers-and-population.md)  
+  Then the System uses the labour-per-turn and consumption patterns in the worker tiers table and allows the presence of these techs to unlock the corresponding worker tiers and luxury dependencies.
+
+- Given a player has unlocked `university` via this table  
+  When the System sets up or updates the player’s research model per [tech-tree.md](tech-tree.md) and [research-state.md](research-state.md)  
+  Then the System increases the player’s number of active research slots from three to four and allows that extra slot to hold a separate tech with its own funding preset and progress.

--- a/SPEC/game/tech-tree-naval.md
+++ b/SPEC/game/tech-tree-naval.md
@@ -37,3 +37,19 @@
 - Ship categories:
   - **Fast interceptors:** Sloops, Frigates, Raiders — higher base intercept and flee ratings; best on Patrol/Blockade.
   - **Battle ships:** Galleons, Ships-of-the-Line, Ironclads — high FRP/ARM/HULL; stronger in decisive fleet battles but weaker at chasing fast raiders.
+
+---
+
+## Acceptance Criteria
+
+- Given the naval tech table in this doc and the global tech catalog  
+  When the System validates the catalog at startup  
+  Then the System ensures that each naval tech id is unique, that its prerequisites refer to techs present in the catalog, and that each ship type unlocked by these techs has a corresponding ship definition in the naval unit specs referenced by [ships-and-naval.md](ships-and-naval.md).
+
+- Given a player has unlocked a naval tech such as `superior_hull_design`, `improved_sail_design`, `convoying`, `large_hulls`, `clipper_ships`, `paddlewheels`, `merchant_steamships`, `advanced_hull_design`, `ship_of_the_line`, `privateering_companies`, or `advanced_iron_working`  
+  When the System evaluates which ship types are buildable for that player during a build phase per [ships-and-naval.md](ships-and-naval.md)  
+  Then the System allows the player to build exactly the ship types listed in this table as effects of the unlocked techs (plus any baseline ships that require no tech) and forbids building ship types whose unlocking tech is not yet in the player’s `techUnlocked` set.
+
+- Given a player has unlocked `privateering_companies`  
+  When the System computes naval interception and trade-raid chances for that player’s fleets on Patrol or Blockade missions as described in the naval combat specs  
+  Then the System applies the privateering bonuses defined in the naval rules only when this tech is present in the player’s `techUnlocked` set and does not apply those bonuses when the tech is locked.

--- a/SPEC/game/tech-tree-new-world.md
+++ b/SPEC/game/tech-tree-new-world.md
@@ -43,3 +43,19 @@
 
 - Discovery techs may be gated by game events (Explorer finds resource in a province); implementation may treat them as no-prereq until discovery condition is met.
 - Labour techs (Trained Journeymen, Master Artisans) depend on cigar_production and hat_production from this category.
+
+---
+
+## Acceptance Criteria
+
+- Given the New World tech table in this doc and a global tech catalog that includes all categories  
+  When the System validates the catalog at startup  
+  Then the System ensures that each New World tech id is unique, that its prerequisites (including discovery techs and cross-category techs such as `seed_drill`, `trained_journeymen`, and `early_steam_engine`) are present in the catalog, and that the effects in this table (resource levels, luxury unlocks) are consistent with [resource-terrain-region-rules.md](resource-terrain-region-rules.md) and [workers-and-population.md](workers-and-population.md).
+
+- Given a player has unlocked a New World extraction tech such as `sugar_planting`, `large_tobacco_plantations`, `cotton_gin`, `riverboats`, or `excessive_fur_harvesting`  
+  When the System computes extraction caps and effective yields for the corresponding resources in New World provinces per [tech-and-extraction-cap.md](tech-and-extraction-cap.md) and [extraction-and-improvements.md](extraction-and-improvements.md)  
+  Then the System increases the maximum effective improvement level for those resources in line with the numeric effects described in this table (for example, `Sugar 3` for `large_sugar_plantations`) and applies those caps only after the required discovery tech and extraction tech are both unlocked.
+
+- Given a player has unlocked `sugar_refining`, `cigar_production`, or `hat_production` as listed in this table  
+  When the System computes which luxuries can be consumed by Apprentices, Journeymen, and Masters during the Consumption phase per [workers-and-population.md](workers-and-population.md)  
+  Then the System allows the corresponding luxury commodities (refined sugar, cigars, fur hats) to be produced via recipes and consumed by the appropriate worker tiers, and does not allow those luxuries to be consumed before the relevant tech has been unlocked.

--- a/SPEC/game/tech-tree-transport.md
+++ b/SPEC/game/tech-tree-transport.md
@@ -19,3 +19,19 @@
 
 - **Transport level 2:** Engineer can build improved roads (transport level 2) only when Road Construction is researched.
 - **Railroad (level 4):** Rail Builder can build railroads when Early Steam Engine (flat), Later Steam Engine (hills/swamps), or Dynamite (mountains) is researched as applicable. Ports also give transport level 4 and are built by Engineers per topology.
+
+---
+
+## Acceptance Criteria
+
+- Given the Transport and Infrastructure tech table in this doc and the global tech catalog  
+  When the System validates the catalog at startup  
+  Then the System ensures that each transport tech id is unique, that its prerequisites refer to techs present in the catalog, and that the effects listed here (road and rail build permissions) line up with the transport levels and terrain rules described in [extraction-and-improvements.md](extraction-and-improvements.md).
+
+- Given a player has `road_construction` in `techUnlocked`  
+  When the System validates or executes Engineer work orders that build roads on land tiles per [extraction-and-improvements.md](extraction-and-improvements.md) and [development-resolution.md](../program/development-resolution.md)  
+  Then the System allows the Engineer to set the road level on a tile to 2 only if `road_construction` is unlocked and otherwise restricts newly built roads to level 1, leaving existing road levels unchanged unless a valid upgrade is applied.
+
+- Given a player has unlocked `early_steam_engine`, `later_steam_engine`, or `dynamite`  
+  When the System validates or executes Rail Builder work orders on tiles of various terrain types  
+  Then the System allows railroads (transport level 4) to be built on flat tiles once `early_steam_engine` is unlocked, on hills and swamps once `later_steam_engine` is unlocked, and on mountains only after `dynamite` is unlocked, and prevents building railroads on terrain types that are not yet enabled by the player’s unlocked transport techs.

--- a/SPEC/game/tech-tree.md
+++ b/SPEC/game/tech-tree.md
@@ -76,3 +76,19 @@ Techs grant **effects** when researched (no separate "apply" step):
 | Maximum | 1000      | 2500    | 2.5 RP/gold (efficiency bonus) |
 
 **Goal slot:** Optional goal tech for UI sorting only; no spending. **Cancel:** Clearing a slot **loses all progress** (per Imp2). Research phase runs after Production and Consumption; see [research-resolution.md](../program/research-resolution.md).
+
+---
+
+## Acceptance Criteria
+
+- Given a global tech catalog constructed from this doc and its category sub-docs, where each tech has an id, category, era, prerequisites list, and effect set  
+  When the System validates the catalog at startup  
+  Then the System ensures that every tech id is unique, that every prerequisite id refers to a tech present in the catalog, and that the directed graph formed by prerequisite edges is acyclic (a DAG), rejecting the catalog if any of these conditions fail.
+
+- Given a player has a `techUnlocked` set on the Player object as described in [research-state.md](research-state.md) and a current research slot assigned to a tech id whose prerequisites are all present in `techUnlocked`  
+  When the System completes research on that tech in the Research phase  
+  Then the System adds that tech id to `techUnlocked`, clears the research slot (losing any remaining progress if the slot is cancelled), and updates `researchableTechIds` to include any tech whose prerequisites are now all in `techUnlocked`.
+
+- Given a research slot is configured with one of the funding presets defined in the table above and a tech that has not yet been unlocked  
+  When the System advances the game by one turn and executes the Research phase  
+  Then the System deducts the configured gold-per-turn from the player treasury for that slot unless the preset is `None`, adds the configured RP-per-turn to that tech’s research progress, and, when the accumulated RP reaches or exceeds that tech’s cost, marks the tech as completed and unlocked at the end of that phase.

--- a/SPEC/game/tile-map-and-generation.md
+++ b/SPEC/game/tile-map-and-generation.md
@@ -32,3 +32,19 @@ Input: province count (N), continent count (C), region, map params (target tiles
 ## Algorithm spec
 
 Generation is a **multi-pass pipeline**: **land seeds** = one **continent seed** per continent plus a **cluster** of land-shape seeds around it (count derived from province count; **Gaussian jitter** by default, cluster shape configurable). **Per-continent land budget** and optional **Voronoi noise** for irregular boundaries. Fill lakes; terrain and resources by **map region** (before provinces); **province seeds on land**; **province assignment** (Pass 9) uses the same **Voronoi assignment** as sea zones. Optional **join step** after Pass 9 when a continent has multiple land components (carve land bridges). **Sea zone subdivision** (Pass 11) uses the same Voronoi assignment; sea zones are capped at a max fraction of total sea (e.g. 5%). **Topology inference** runs after all passes (including join). Full pass list: [tile-map-gen-algorithm.md](../program/tile-map-gen-algorithm.md) and [tile-map-gen-resources.md](../program/tile-map-gen-resources.md). Config: [tile-map-gen-config.md](../program/tile-map-gen-config.md).
+
+---
+
+## Acceptance Criteria
+
+- Given map-generation input that specifies a region id, a province count `N`, a continent count `C`, and map parameters including a target tiles-per-province range  
+  When the System runs the tile-map generation pipeline for that region  
+  Then the System produces one 2D grid for that region, assigns each grid cell to either a province id or a sea zone id, and achieves an average number of land tiles per province that lies within the configured tiles-per-province range.
+
+- Given resource–terrain–region rules from [resource-terrain-region-rules.md](resource-terrain-region-rules.md) and a chosen region  
+  When the System assigns terrain and at most one resource per land tile during generation for that region  
+  Then the System uses only terrain types allowed for that region, places resources only on tiles whose terrain type and region are allowed for that resource, and enforces the multi-region resource cap so that no more than the configured percentage of resources on the map are multi-region compatible.
+
+- Given generation input with a province count `N` and a continent count `C` for a region  
+  When the System generates continents, places province seeds, and assigns provinces as described in [tile-map-gen-algorithm.md](../program/tile-map-gen-algorithm.md)  
+  Then the System produces continents whose number of provinces is approximately `N/C` per continent (within a small integer tolerance) and derives province and sea-zone topology directly from the resulting grid without any separate hand-authored topology file.

--- a/SPEC/game/turn-time-mapping.md
+++ b/SPEC/game/turn-time-mapping.md
@@ -72,3 +72,19 @@ Calendar year is derived from `WorldState.turnState.turnNumber` using the game's
 - Imperialism II 01-game-fundamentals (Obsidian).
 - [world-model.md](world-model.md) — Game holds optional turnTimeMapping.
 - [ruleset-config.md](../program/ruleset-config.md) — turnTimeMapping in config contract.
+
+---
+
+## Acceptance Criteria
+
+- Given a `TurnTimeMapping` configuration with `startYear = 1500`, `cutoffYear = 1700`, `yearsPerTurnBeforeCutoff = 2`, and `yearsPerTurnAfterCutoff = 1`  
+  When the System maps turn numbers to calendar years for display  
+  Then the System maps turn 1 to year 1500, maps turn 100 to year 1700, uses 2 years per turn for turns 1–100 inclusive, and uses 1 year per turn for all turns greater than 100.
+
+- Given a `TurnTimeMapping` object with integer fields `startYear`, `cutoffYear`, `yearsPerTurnBeforeCutoff`, and `yearsPerTurnAfterCutoff` that satisfy the constraints implied by the table in this doc  
+  When the System serializes a Game that includes this `turnTimeMapping` and later reloads it from storage  
+  Then the System restores the same mapping values and continues to derive calendar years from `WorldState.turnState.turnNumber` using the restored mapping without recalculating or changing the parameters mid-campaign.
+
+- Given a caller passes a turn number less than 1 to the calendar-year mapping function  
+  When the System applies the `TurnTimeMapping` formula  
+  Then the System may return a year outside the intended 1500–1850 range but does not throw an error or mutate game state, and callers that need meaningful years for narrative or UI only invoke the mapping with turn numbers greater than or equal to 1.

--- a/SPEC/game/workers-and-population.md
+++ b/SPEC/game/workers-and-population.md
@@ -53,3 +53,19 @@ Per Imperialism II 02-economy: workers "in your city" supply labour for industry
 Data structures in [economy-models.md](../program/economy-models.md). Worker model distinct from Unit; workers live in economy (TDD 04), not unit model (TDD 05). Config is program-level (no JSON rulesets).
 
 **Current scope:** Food consumption and starvation are implemented in economy_consumption.dart (peasant 1 food, trained 2 food; starvation order: peasants first, then apprentices, journeymen, masters). Luxury consumption (sugar, cigars, fur hats) and worker tier training (paper + cash → next tier) are deferred until Recruiting/Training quantities are defined or a simplification is chosen.
+
+---
+
+## Acceptance Criteria
+
+- Given a player has a WorkerPool with non-negative integer counts for each worker tier and a central stockpile as described in [stockpiles-and-production.md](stockpiles-and-production.md)  
+  When the System executes the Consumption phase for that player  
+  Then the System deducts the required food quantities for each worker tier from the stockpile in the specified order, removes workers that starve when their required food cannot be met starting with Peasants and proceeding up through Apprentices, Journeymen, and Masters, and does not reduce any worker count below zero.
+
+- Given a trained worker (Apprentice, Journeyman, or Master) remains alive after the Consumption phase but the required luxury commodity for that tier is not fully available in the stockpile  
+  When the System computes available labour for the Production phase  
+  Then the System counts that worker’s labour contribution as zero for that turn while still leaving the worker in the WorkerPool for future turns.
+
+- Given a player has sufficient fabric (and, when defined, paper and cash) in the stockpile to recruit or train a worker according to the recruiting and training rules for a particular era  
+  When the System resolves a recruit or train action for that worker  
+  Then the System consumes the specified commodity quantities from the stockpile, updates the WorkerPool counts by adding the new or upgraded worker to the correct tier and removing the source worker in the case of training, and ensures that no stockpile quantity or worker count becomes negative as a result of the action.

--- a/SPEC/game/world-model-identity.md
+++ b/SPEC/game/world-model-identity.md
@@ -35,3 +35,27 @@ When turning topology/tile maps into view models (ownership fill, per-player map
 ## Lookup Rule
 
 Logic must never locate a province by province id alone. Use (regionId, provinceId) or a prefixed full id, and resolve the province only within that region. Do **not** infer region by searching regions in sequence or by string heuristics. If a province cannot be found, treat it as a logic error; do not fall back to a default region.
+
+---
+
+## Acceptance Criteria
+
+- Given a WorldState with at least one region `oldWorld` and one region `newWorld`, and each region has a province with local id `p1`  
+  When the System constructs or stores province identifiers in game state  
+  Then the System represents the Old World province as `oldWorld|p1`, represents the New World province as `newWorld|p1`, and never stores or emits a bare province id `p1` without its region prefix in any field that refers to a province.
+
+- Given a WorldState that stores a military Unit whose location is a province, and that province belongs to region `oldWorld` with local id `p3`  
+  When the System serializes or deserializes the Unit’s location  
+  Then the System stores the Unit location as the full id `oldWorld|p3`, and on load it resolves `oldWorld|p3` only within the `oldWorld` region without scanning other regions for a matching local id.
+
+- Given a tile key such as `newWorld|nw7|12|5` stored in WorldState or a save file  
+  When the System interprets that tile key  
+  Then the System treats `newWorld` as the region id, `nw7` as the local province id, and `12` and `5` as tile coordinates, and it derives the full province id `newWorld|nw7` from the first two segments for any province-level lookup.
+
+- Given a map visualizer that is rendering a per-region tile map for region `oldWorld` and encounters a tile whose local province id is `p4`  
+  When the visualizer queries ownership, province name, or unit markers for that tile  
+  Then the visualizer first constructs the full province id `oldWorld|p4`, uses that full id to look up the Province and its owner in game state, and does not attempt to resolve `p4` in any other region.
+
+- Given any game logic that is asked to resolve a province identifier and provided with a string that does not contain a `|` prefix separator or a pair of `(regionId, provinceId)` values that match a known province  
+  When the System attempts to perform the lookup  
+  Then the System treats the request as a logic error and does not fall back to a default region, does not guess a region by name pattern, and does not silently resolve the identifier to a different region’s province.

--- a/SPEC/game/world-model.md
+++ b/SPEC/game/world-model.md
@@ -57,3 +57,27 @@ All entities support JSON (or equivalent) for persistence; save layer reads/writ
 - Province lookup: always regionId + provinceId (or prefixed id). See [world-model-identity.md](world-model-identity.md).
 - Resource per tile only where region/terrain allows.
 - Turn state in WorldState; resolution takes WorldState in, returns new out. See [turn-resolution.md](../program/turn-resolution.md).
+
+---
+
+## Acceptance Criteria
+
+- Given a game with at least one region configured with a stable region id such as `oldWorld` or `newWorld`  
+  When the System creates or loads the Game entity for that world  
+  Then the System stores the Game with a WorldState that contains region data scoped by region id, and the System keeps region ids stable across saves and loads so that any reference to `oldWorld` or `newWorld` resolves to the same logical region.
+
+- Given a WorldState that contains at least one Province and one SeaZone for a region  
+  When the System loads or serializes the WorldState  
+  Then the System ensures that each Province and SeaZone has both a region id and a local id, that Provinces are marked as land regions and SeaZones as water regions, and that province neighbours and sea-zone adjacencies are derived from the topology for that region as described in [map-topology.md](map-topology.md).
+
+- Given a WorldState with a Tile map for a region and at least one Province that owns tiles in that region  
+  When the System computes effective extraction for that Province  
+  Then the System uses the tiles assigned to that Province in the per-region 2D grid, applies terrain, resource, and improvement data from those tiles, and caps extraction for each tile at the owning Player’s tech cap as defined in the active ruleset.
+
+- Given a Game entity that has Players, Minor Nations, Tribes, and a WorldState with provinces and units  
+  When the System serializes the Game to JSON and later reloads it by game id  
+  Then the System restores the same WorldState (including province ownership, unit locations, and world-level metadata), the same set of Players, Minor Nations, and Tribes, and preserves the turn state so that a subsequent turn resolution produces the same outcomes as if the game had not been unloaded.
+
+- Given a WorldState with a valid turn state and region blobs (provinces and units)  
+  When the System executes turn resolution as described in [turn-resolution.md](../program/turn-resolution.md)  
+  Then the System treats the incoming WorldState as immutable input, produces a new WorldState with updated provinces and units according to the game rules, and keeps the invariant that each province has a region id and each unit has both an owner and a location in the resulting WorldState.

--- a/SPEC/project/agentic-gdd-scenario-coverage.md
+++ b/SPEC/project/agentic-gdd-scenario-coverage.md
@@ -6,13 +6,13 @@
 
 ## Role: Coder only
 
-**You are the coder.** You implement or amend game logic, add or extend scenarios, and update the coverage mapping. You do **not** perform the verifier’s audit (line-by-line check of covered specs and writing of `verifierIssues`). When you see `verifierIssues` in the tool output or in the mapping for a spec, you should rectify those issues (add assertions, fix implementation) and then clear or update the `verifierIssues` list for that spec.
+**You are the coder.** You change game logic, add or extend scenarios, and update the coverage mapping. You do **not** perform the verifier’s audit (line-by-line check of covered specs and writing of `verifierIssues`). When you see `verifierIssues` for a spec, fix the implementation or assertions and then clear or update that list.
 
 ---
 
 ## Goal
 
-Ensure every rule in SPEC/game that is testable via full-game scenarios has at least one sim_scenarios test. The agent works **one GDD spec at a time** (at most), adds or extends scenarios and assertions, then updates coverage so the next run can pick another uncovered spec.
+Ensure every testable acceptance criterion (AC) in `SPEC/game` has at least one `sim_scenarios` scenario. Work on **one GDD spec at a time**: pick its ACs, align the implementation with the spec if needed, then add or extend scenarios and coverage so the next run can pick another uncovered spec.
 
 ---
 
@@ -28,13 +28,13 @@ Ensure every rule in SPEC/game that is testable via full-game scenarios has at l
 
 ## Single-session workflow (coder, one spec at a time)
 
-1. **Open the chosen GDD spec** (e.g. SPEC/game/combat.md). Read it fully. If the mapping has **verifierIssues** for this spec, address those first (add missing assertions, fix implementation to match the spec), then re-run scenarios and clear or update the issues in the mapping. Otherwise, identify 1–3 concrete, testable behaviours (e.g. “attacker strength affects casualties”, “province flips to attacker when defender eliminated”).
+1. **Open the chosen GDD spec** (e.g. `SPEC/game/combat.md`). Read it fully, then locate its **acceptance criteria (ACs)** written as Given–When–Then. If the mapping has **verifierIssues** for this spec, address those first (add missing assertions, fix implementation to match the spec), then re-run scenarios and clear or update the issues in the mapping. Otherwise, select 1–3 concrete ACs or behaviours to cover (e.g. “attacker strength affects casualties”, “province flips to attacker when defender eliminated”).
 2. **Check existing code** that implements that behaviour (e.g. combat resolution in colonizethis_logic). If the implementation does not align with the spec, **extend or amend the game logic** so it matches the GDD; then add scenarios that verify the spec. Do not lock in behaviour that contradicts the spec. If the spec is ambiguous, clarify the GDD first, then implement and test.
 3. **Add or extend scenarios** under `tool/sim_scenarios/scenarios/`:
    - Reuse existing scenario JSON format (init, setup, turns, assertions). Use fresh init or saved-game init as needed.
-   - **Derive expected outcomes from the GDD text**, not from the current implementation—so the scenario detects misalignment.
+   - **Derive Given, When, and Then from the chosen ACs in the GDD**, not from the current implementation—so the scenario detects misalignment.
    - Script the minimal orders needed to trigger the behaviour (e.g. move into enemy province, build unit, run work order).
-   - Add assertions that verify the spec’s rules (owner, unitCount, stockpile, treasury, etc. as in [sim-scenarios.md](../program/sim-scenarios.md)).
+   - Add assertions that verify the spec’s rules and AC outcomes (owner, unitCount, stockpile, treasury, etc. as in [sim-scenarios.md](../program/sim-scenarios.md)).
 4. **Run** the new/updated scenario(s): `melos run sim_scenarios -- --scenario=tool/sim_scenarios/scenarios/<name>.json`. Fix any failures (assertions or scenario structure).
 5. **Update the coverage mapping** (see gdd-scenario-coverage.md): add the scenario filename(s) to the entry for the spec you covered. If you resolved verifier issues for this spec, **clear or shorten the `verifierIssues` list** for that entry (use object form `{ "scenarios": [...], "verifierIssues": [] }` if needed). Do not add coverage for other specs in the same session unless they were already in scope.
 6. **Run the coverage tool again**: `melos run check_gdd_coverage`. Confirm the spec you targeted is now listed as covered.
@@ -44,7 +44,7 @@ Ensure every rule in SPEC/game that is testable via full-game scenarios has at l
 
 ## When implementation and spec disagree
 
-**GDD is source of truth.** The agent must extend or amend the game logic so that behaviour matches the spec; only then add a scenario that verifies it. Do not write a scenario that asserts incorrect (spec-violating) behaviour. Permitted actions:
+**GDD is source of truth.** Extend or amend the game logic so behaviour matches the spec, then add scenarios that verify it. Do not write scenarios that assert incorrect (spec-violating) behaviour. Permitted actions:
 
 - **Amend implementation** in colonizethis_logic (or other packages) to match the GDD. Add or adjust tests (unit/widget) as needed.
 - **Update TDD/program specs** (SPEC/program) if the change affects architecture or module contracts.
@@ -57,6 +57,7 @@ Do not leave implementation and spec in conflict; fix the implementation within 
 ## Constraints
 
 - **One spec per session (at most).** Do not attempt to cover multiple GDD specs in one prompt or one PR unless explicitly asked.
+- **AC-driven scenarios.** When defining `sim_scenarios`, base Given, When, and Then on the acceptance criteria in the chosen `SPEC/game` document (see `.cursor/rules/colonizethis-acceptance-criteria.mdc`). If ACs are missing or unclear, update the spec and ACs first, then write the scenario.
 - **SPEC-first.** Do not add behaviour that contradicts the GDD. If the implementation disagrees with the spec, **change the implementation** to match the spec (and update TDD/program specs if needed); then add the scenario. The agent may extend or amend game logic in colonizethis_logic (or related packages) to achieve alignment.
 - **Thin scenarios.** Prefer the smallest init/setup and fewest turns that still verify the spec. One scenario per main behaviour is enough; avoid duplicate coverage for the same rule.
 - **Province identity.** Use full province id (regionId|localId) per [world-model-identity.md](../game/world-model-identity.md) and core principles.


### PR DESCRIPTION
## Summary
- Add dedicated acceptance-criteria Cursor rule and wire it into agent instructions
- Expand GDD core specs across capitals, tech trees, world model, units, and economy with additional rules and scenarios
- Update scenario coverage document to reference new GDD sections

## Test plan
- [ ] Specs and rules render correctly in Markdown
- [ ] Confirm agents pick up new acceptance-criteria rule and updated GDD guidance


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/spec-only changes (Cursor rules + SPEC markdown) with no runtime code modifications; primary risk is process churn or inconsistencies in newly added acceptance criteria.
> 
> **Overview**
> Introduces a new Cursor rule (`colonizethis-acceptance-criteria.mdc`) that standardizes **machine-testable Given–When–Then acceptance criteria** across `SPEC/game`, `SPEC/program`, `SPEC/ai`, and `SPEC/ui`.
> 
> Expands a large set of `SPEC/game` documents by adding explicit **Acceptance Criteria** sections covering capitals/connectivity, game setup, factions, units, combat/siege/quick battle, economy (commodities, stockpiles, recipes, workers), naming, map/resource placement, naval rules, and turn-time mapping.
> 
> Updates agent guidance to be **AC-driven** (scenario work derives Given/When/Then from SPEC ACs) and relaxes the SPEC size rule from **500 → 1000 words** in `colonizethis-spec-required.mdc`, reflecting this in `AGENTS.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f24a6c48739bd6a30ed26a6c92e6a16ad5e47ba6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->