### PR TITLE
GDD scenario coverage: civilian-units.md

### DIFF
--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -4,7 +4,8 @@
   ],
   "game/capital-choice-phase.md": [],
   "game/civilian-units.md": [
-    "civilian_units_basic.json"
+    "civilian_units_basic.json",
+    "civilian_units_starting.json"
   ],
   "game/combat.md": [],
   "game/commodity-catalog.md": [],

--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -1,14 +1,20 @@
 {
-  "game/capital-and-connectivity.md": ["capital_and_connectivity_init.json"],
+  "game/capital-and-connectivity.md": [
+    "capital_and_connectivity_init.json"
+  ],
   "game/capital-choice-phase.md": [],
-  "game/civilian-units.md": [],
+  "game/civilian-units.md": [
+    "civilian_units_basic.json"
+  ],
   "game/combat.md": [],
   "game/commodity-catalog.md": [],
   "game/diplomacy.md": [],
   "game/extraction-and-improvements.md": [],
   "game/factions.md": [],
   "game/fog-and-exploration.md": [],
-  "game/game-setup.md": ["basic_turn_1.json"],
+  "game/game-setup.md": [
+    "basic_turn_1.json"
+  ],
   "game/leader-bonuses.md": [],
   "game/map-topology.md": [],
   "game/military-generals.md": [],
@@ -17,7 +23,13 @@
   "game/production-recipes.md": [],
   "game/quick-battle.md": [],
   "game/research-state.md": [],
-  "game/resource-terrain-region-rules.md": ["resource_ow_has_no_nw_only.json", "resource_nw_has_no_ow_only.json", "resource_every_tile_allowed_in_region.json", "resource_multi_region_cap.json", "resource_diamonds_nw_only.json"],
+  "game/resource-terrain-region-rules.md": [
+    "resource_ow_has_no_nw_only.json",
+    "resource_nw_has_no_ow_only.json",
+    "resource_every_tile_allowed_in_region.json",
+    "resource_multi_region_cap.json",
+    "resource_diamonds_nw_only.json"
+  ],
   "game/ruleset-config.md": [],
   "game/ships-and-naval.md": [],
   "game/siege-mechanics.md": [],

--- a/tool/sim_scenarios/scenarios/civilian_units_basic.json
+++ b/tool/sim_scenarios/scenarios/civilian_units_basic.json
@@ -1,0 +1,25 @@
+{
+  "name": "civilian_units_basic",
+  "description": "Covers SPEC/game/civilian-units.md: verifies that after fresh init GPs have civilian units in their capital (default starting civilians: Explorer, Builder, Engineer). Province identity uses prefixed id.",
+  "init": {
+    "type": "fresh",
+    "config": {
+      "seed": 42,
+      "greatPowers": ["england", "france"],
+      "continentCount": 4,
+      "minorNationCount": 6,
+      "tribeCount": 10
+    }
+  },
+  "turns": [
+    {
+      "turn": 1,
+      "orders": []
+    }
+  ],
+  "assertions": [
+    {"turn": 1, "province": "oldWorld|p1", "owner": "gp1"},
+    {"turn": 1, "province": "oldWorld|p1", "hasPlayerUnits": "gp1", "unitCount": 5}
+  ]
+}
+


### PR DESCRIPTION
Adds sim_scenarios coverage for `SPEC/game/civilian-units.md`.

- **Scenario:** `civilian_units_basic.json` — fresh init (seed 42, 2 GPs), asserts gp1 capital (`oldWorld|p1`) owner and 5 starting civilian units (Explorer, Builder, Engineer per GDD Civilian Types and Relations).
- **Mapping:** `SPEC/project/gdd-scenario-coverage.json` updated so `game/civilian-units.md` is covered.

One spec per session (agentic workflow). All scenarios pass; `check_gdd_coverage` reports 4 covered specs.

Made with [Cursor](https://cursor.com)