### PR TITLE
Main menu: use logger instead of debugPrint for asset fallback

### DIFF
--- a/app/lib/widgets/main_menu.dart
+++ b/app/lib/widgets/main_menu.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:logger/logger.dart';
 
 /// Visual variant of the main menu. SPEC/ui/main-menu.md; UXD 03a.
 enum MainMenuVariant {
@@ -198,7 +199,7 @@ class _PixelArtButton extends StatelessWidget {
                 _kAssetButton,
                 fit: BoxFit.cover,
                 errorBuilder: (_, __, ___) {
-                  debugPrint('main_menu: button asset not found, using fallback');
+                  Logger().w('ctdev: main_menu button asset not found, using fallback');
                   return Container(
                     color: const Color(0xFF5D3A1A),
                   );

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   flame: ^1.18.0
+  logger: ^2.0.2
   flutter_riverpod: ^2.6.1
   hive: ^2.2.3
   hive_flutter: ^1.1.0


### PR DESCRIPTION
Fixes #516

- Add `logger` dependency to app package
- Replace `debugPrint` with `Logger().w()` and `ctdev:` prefix per SPEC/program/ctdev-logging.md

Made with [Cursor](https://cursor.com)