### PR TITLE
logic: log when military victory is set (Fixes #551)

### DIFF
--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -336,11 +336,13 @@ Game _runEndOfTurnPhase(Game game, {void Function(DialogueEvent)? onDialogue}) {
 
   final winnerId = _findMilitaryVictoryWinner(game);
   if (winnerId != null) {
+    final turnNumber = game.worldState.turnState.turnNumber;
+    _log.i('logic: military victory set winner=$winnerId turn=$turnNumber');
     return game.copyWith(
       victory: VictoryState(
         winnerPlayerId: winnerId,
         type: VictoryType.military,
-        turnNumber: game.worldState.turnState.turnNumber,
+        turnNumber: turnNumber,
       ),
     );
   }


### PR DESCRIPTION
Fixes #551

Turn resolver end-of-turn phase now logs at info level when military victory is set, including winner and turn number, per SPEC/program/ctdev-logging.md (logic scope).

Made with [Cursor](https://cursor.com)