### PR TITLE
GDD scenario coverage: civilian-units.md

### DIFF
--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -1,7 +1,7 @@
 {
   "game/capital-and-connectivity.md": ["capital_and_connectivity_init.json"],
   "game/capital-choice-phase.md": [],
-  "game/civilian-units.md": [],
+  "game/civilian-units.md": ["civilian_units_basic.json"],
   "game/combat.md": [],
   "game/commodity-catalog.md": [],
   "game/diplomacy.md": [],

--- a/tool/sim_scenarios/scenarios/civilian_units_basic.json
+++ b/tool/sim_scenarios/scenarios/civilian_units_basic.json
@@ -1,0 +1,21 @@
+{
+  "name": "civilian_units_basic",
+  "description": "SPEC/game/civilian-units.md: after fresh init each GP has starting civilian units in capital (default config: 2 Explorer, 2 Builder, 1 Engineer = 5 per GP). Asserts gp1 capital province owner and unit count.",
+  "init": {
+    "type": "fresh",
+    "config": {
+      "seed": 42,
+      "greatPowers": ["england", "france"],
+      "continentCount": 4,
+      "minorNationCount": 6,
+      "tribeCount": 10
+    }
+  },
+  "turns": [
+    { "turn": 1, "orders": [] }
+  ],
+  "assertions": [
+    { "turn": 1, "province": "oldWorld|p1", "owner": "gp1" },
+    { "turn": 1, "province": "oldWorld|p1", "unitCount": 5 }
+  ]
+}


### PR DESCRIPTION
Adds sim_scenarios coverage for `SPEC/game/civilian-units.md`.

- **civilian_units_basic.json**: Fresh init (seed 42, 2 GPs); asserts gp1 capital province `oldWorld|p1` owner and 5 starting civilian units (default config: 2 Explorer, 2 Builder, 1 Engineer per GDD / StartingResourcesConfig).
- **gdd-scenario-coverage.json**: `game/civilian-units.md` now maps to `civilian_units_basic.json`.

All 13 sim_scenarios pass; check_gdd_coverage reports 4 covered specs (civilian-units newly covered).

Made with [Cursor](https://cursor.com)