### PR TITLE
Deduplicate kPortraitMoodValues (colonizethis_data as source of truth)

### DIFF
--- a/packages/colonizethis_ai/lib/colonizethis_ai.dart
+++ b/packages/colonizethis_ai/lib/colonizethis_ai.dart
@@ -1,5 +1,6 @@
 // AI behavior, planning, personalities. SPEC/ai/ai-architecture.md, SPEC/program/ai-systems-impl.md.
 
+export 'package:colonizethis_data/colonizethis_data.dart' show kPortraitMoodValues;
 export 'src/ai_config.dart';
 export 'src/dossier.dart';
 export 'src/domain_planners.dart';

--- a/packages/colonizethis_ai/lib/src/mood_state_machine.dart
+++ b/packages/colonizethis_ai/lib/src/mood_state_machine.dart
@@ -1,17 +1,7 @@
 // Negotiation mood state machine. SPEC/ai/dialogue-and-mood.md, SPEC/program/ai-events-and-dossier.md.
 // Given current mood, offerQualityDelta (-1..1), and stallCounter, compute next mood; deterministic given seed.
 
-/// Valid portrait mood values per SPEC/ai/dialogue-and-mood.md.
-const List<String> kPortraitMoodValues = [
-  'considering',
-  'pleased',
-  'gracious',
-  'calculating',
-  'skeptical',
-  'impatient',
-  'irritated',
-  'dismissive',
-];
+import 'package:colonizethis_data/colonizethis_data.dart' show kPortraitMoodValues;
 
 /// Default mood when no negotiation context (e.g. opening diplomacy).
 const String kDefaultMood = 'considering';


### PR DESCRIPTION
Fixes #543

**Summary:** Single source of truth for portrait mood values per code-review.

- **colonizethis_data** (dialogue_catalog.dart): keeps `kPortraitMoodValues` (already exported via package).
- **colonizethis_ai** (mood_state_machine.dart): removed duplicate definition; imports from colonizethis_data; package re-exports `kPortraitMoodValues` for API stability so existing consumers (e.g. tests) unchanged.

Tests: colonizethis_data and colonizethis_ai tests pass.

Made with [Cursor](https://cursor.com)