### PR TITLE
General model and regiment_economy: fix SPEC references (Fixes #522)

### DIFF
--- a/packages/colonizethis_data/lib/src/regiment_economy.dart
+++ b/packages/colonizethis_data/lib/src/regiment_economy.dart
@@ -3,10 +3,11 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'commodities.dart';
 
 /// Regiment training and upkeep configuration.
-/// SPEC/game/unit-types.md
-/// SPEC/game/military-units.md
-/// SPEC/program/orders.md
-/// SPEC/program/economy-models.md
+/// Training cost and food upkeep: SPEC/game/military-generals.md § Regiment Economy.
+/// Era/category progression aligns with tactical stats in SPEC/game/military-units.md.
+/// Worker consumed at build time is enforced in order application (orders.md BuildUnitOrder,
+/// development-resolution), not in this catalog.
+/// SPEC/program/orders.md, SPEC/program/economy-models.md.
 class RegimentEconomy {
   const RegimentEconomy({
     required this.id,

--- a/packages/colonizethis_models/lib/src/general.dart
+++ b/packages/colonizethis_models/lib/src/general.dart
@@ -1,5 +1,6 @@
-/// General leading an army. SPEC/game/military-units.md.
-/// Phase 3: minimal model for initiative and combat.
+/// General leading an army. Generals, medals, and army definition:
+/// SPEC/game/military-generals.md. Regiment types and tactical stats:
+/// SPEC/game/military-units.md. Phase 3: minimal model for initiative and combat.
 class General {
   const General({
     required this.id,
@@ -11,10 +12,11 @@ class General {
   final String id;
   final String ownerId;
 
-  /// Experience medals (0–4); affects initiative and deployment. SPEC/game/military-units.md.
+  /// Experience medals (0–4); affects initiative and deployment. SPEC/game/military-generals.md.
   final int medals;
 
   /// Province where general is attached to an army. Null if unassigned.
+  /// When set, must be prefixed province id per world-model-identity.md.
   final String? provinceId;
 
   Map<String, dynamic> toJson() => {


### PR DESCRIPTION
Fixes #522

- **general.dart:** Class and medals comment now reference SPEC/game/military-generals.md for generals, medals, and army definition; military-units.md for regiment types and tactical stats. Documented that `provinceId` when set must be prefixed province id per world-model-identity.md.
- **regiment_economy.dart:** Removed non-existent SPEC/game/unit-types.md; added military-generals.md § Regiment Economy for training cost and food upkeep; kept military-units.md for era/category progression. Added note that one worker consumed at build time is enforced in order application (orders.md BuildUnitOrder, development-resolution), not in this catalog.

Made with [Cursor](https://cursor.com)