### PR TITLE
Hidden-agendas: document evidence rule coverage (MVP vs deferred)

### DIFF
--- a/SPEC/ai/hidden-agendas.md
+++ b/SPEC/ai/hidden-agendas.md
@@ -58,6 +58,10 @@ When the game or AI performs an action, **evidence rules** (defined per agenda) 
 - **Suspicion levels** map total evidence score to a band: Unknown (0–2), Possible (3–5), Likely (6–8), Almost certain (9–10), Confirmed (10+). Display labels in dossier use these bands; “Confirmed” is a threshold, not revelation of true agenda.
 - Evidence is deterministic (same actions → same evidence). Dossier projection is PlayerView-safe: only suspicion scores and capped evidence log exposed. See [ai-dossier.md](ai-dossier.md).
 
+**Evidence rule coverage (MVP vs deferred)**  
+- **MVP (in scope):** Evidence rules are implemented for: war declaration → warmonger/backstabber; peace offer → peacemaker; land battle victory → warmonger; naval battle victory → warmonger. Implementation: evidence rules evaluated during turn resolution (see [ai-events-and-dossier.md](../program/ai-events-and-dossier.md)).
+- **Deferred (not yet implemented):** Evidence rules for the following are not in MVP scope: Tech Thief (spy usage); Isolationist (alliance decline); Backstabber (treaty-breaking events); Envy (mirror-build detection). Until implemented, suspicion for those agenda types is not incremented by evidence rules; they may be added in a later release.
+
 ---
 
 ## Acceptance criteria
@@ -65,7 +69,7 @@ When the game or AI performs an action, **evidence rules** (defined per agenda) 
 - **Assignment and immutability:** One agenda per AI; assigned at game start from `agendaSeed[P]` (derived from global game seed and `aiSeed[P]`). Stored in game state; no mid-game change.
 - **Determinism:** Same global game seed and `aiSeed[P]` yield the same agenda. Same observable actions yield the same evidence points (replay- and save/load-consistent).
 - **Behavior modifiers:** Each agenda type has defined effects in the spec categories: war declaration, peace acceptance, alliance acceptance, build/order choice, treaty breaking. Expressed as weights or thresholds in config.
-- **Evidence and suspicion:** Evidence rules add points per (observer nation, subject AI, agenda type). Suspicion bands (Unknown, Possible, Likely, Almost certain, Confirmed) map total evidence score; display uses bands only. True agenda is never exposed to the player.
+- **Evidence and suspicion:** Evidence rules add points per (observer nation, subject AI, agenda type). Suspicion bands (Unknown, Possible, Likely, Almost certain, Confirmed) map total evidence score; display uses bands only. True agenda is never exposed to the player. Evidence rule coverage: MVP (war declaration, peace offer, land/naval battle victory) is implemented; deferred (spy, alliance decline, treaty break, mirror-build) is documented and not in scope for MVP.
 - **Dossier contract:** Only suspicion scores and capped evidence log are exposed (PlayerView-safe). See [ai-dossier.md](ai-dossier.md) and [ai-events-and-dossier.md](../program/ai-events-and-dossier.md).
 
 ## Implementation

--- a/SPEC/program/ai-events-and-dossier.md
+++ b/SPEC/program/ai-events-and-dossier.md
@@ -25,7 +25,7 @@ Internal record appended when an action matches an evidence rule. Fields: observ
 4. UI subscribes and resolves to text/portrait assets. No asset paths in events.
 
 ### Evidence and Dossier
-1. Evidence rules evaluated when actions are applied (turn resolution or post-resolution hook). Rules per [hidden-agendas.md](../ai/hidden-agendas.md).
+1. Evidence rules evaluated when actions are applied (turn resolution or post-resolution hook). Rules per [hidden-agendas.md](../ai/hidden-agendas.md). Which triggers are in scope (MVP) vs deferred is defined in that doc (§ Evidence rule coverage).
 2. Storage: per (observer, subject, agenda type) counter + optional (turn, description) list. Deterministic: same actions → same evidence.
 3. Dossier projection: read API returning PlayerView-safe data (basic intel, suspicion levels, evidence list, behavioral notes). True hidden agenda never exposed.
 4. **Confidence % mapping:** Best-guess agenda confidence (display %) is derived from the highest suspicion score for that agenda. Mapping: score 0–2 → 0%; 3–5 → 25%; 6–8 → 60%; 9–10 → 85%; 11+ → 100%. Implementation must use this mapping for consistency with display bands (see [ai-dossier.md](../ai/ai-dossier.md) § PlayerView-safe rules).


### PR DESCRIPTION
Fixes #577.

**Summary**
- **GDD** (`SPEC/ai/hidden-agendas.md`): Added § Evidence rule coverage (MVP vs deferred). MVP = war declaration, peace offer, land/naval battle victory; deferred = tech_thief (spy), isolationist (alliance decline), backstabber (treaty break), envy (mirror-build). Extended acceptance criteria to mention coverage.
- **TDD** (`SPEC/program/ai-events-and-dossier.md`): Cross-ref to GDD § Evidence rule coverage in Evidence and Dossier step.

Docs-only; no code changes.

Made with [Cursor](https://cursor.com)