### PR TITLE
Align commodity capacity/overflow wording for MVP (Fixes #533)

### DIFF
--- a/SPEC/game/commodity-catalog.md
+++ b/SPEC/game/commodity-catalog.md
@@ -39,7 +39,7 @@ The **commodity catalog** (id list, category per commodity, default price for sp
 
 ## Overflow and Capacity
 
-Capacity limits may apply per commodity or to total stockpile; configurable per era. **Overflow rules:** excess sold at market or discarded, per design. Details in [stockpiles-and-production.md](stockpiles-and-production.md). Implementation may stub capacity (e.g. unlimited) until design is fixed.
+For the **MVP ruleset**, capacity for all commodities is effectively infinite: there is no per-commodity or total stockpile cap, and the System does **not** apply any overflow behavior such as discarding excess or auto-selling to market. Any future per-era capacity limits or overflow rules are **deferred**; if and when they are introduced, their authoritative behavior and acceptance criteria will be defined in [stockpiles-and-production.md](stockpiles-and-production.md), and this section will cross-reference that definition.
 
 ---
 


### PR DESCRIPTION
## Summary
- Clarify that the MVP ruleset uses effectively infinite stockpile capacity with no overflow behavior (no discards or auto-market sales).
- Update `SPEC/game/commodity-catalog.md` to align its narrative text with `SPEC/game/stockpiles-and-production.md` and existing acceptance criteria, explicitly deferring per-era capacity/overflow rules to the stockpiles spec.

## Test plan
- Docs-only change; no code or data files modified.
- Rely on CI `quality` workflow (format/lints) to validate the updated spec.

Made with [Cursor](https://cursor.com)