### PR TITLE
GDD scenario coverage: civilian-units.md

### DIFF
--- a/SPEC/program/sim-scenarios.md
+++ b/SPEC/program/sim-scenarios.md
@@ -49,13 +49,16 @@ Two initialization types:
 
 **From-topology (connectivity scenarios)** — Builds game from a fixed Old World (and optional New World) topology and grid. Used for connectivity and capital assertions. `init.type`: `"fromTopology"`. `init.config`: optional `greatPowers`, `seed`, `tribeCount` (for NW). `init.oldWorld` / `init.newWorld`: `{ "grid": [[...]], "nodes": [...], "edges": [...] }`. **Behaviour:** No Minor Nations (minor count and min provinces per minor are forced to 0) so that province assignment only assigns to Great Powers and, when present, Tribes on the New World. Aligns with [game-setup.md](../game/game-setup.md) (config from scenario).
 
-For saved games, optional `setup` block injects units for specific test scenarios:
+For saved games (or fresh/fromTopology), optional `setup` block can inject units and add stockpile commodities:
+- **units** — list of unit placements (player, type, province, count).
+- **stockpileAdditions** — per-player commodity deltas (e.g. `{"gp1": {"paper": 2}}`) applied after init so scenarios can give a player resources (e.g. paper for civilian build).
 ```json
 {
   "setup": {
     "units": [
       {"player": "france", "type": "infantry", "province": "normandy", "count": 3}
-    ]
+    ],
+    "stockpileAdditions": {"gp1": {"paper": 2}}
   }
 }
 ```

--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -1,7 +1,7 @@
 {
   "game/capital-and-connectivity.md": ["capital_and_connectivity_init.json"],
   "game/capital-choice-phase.md": ["capital_choice_phase_basic.json"],
-  "game/civilian-units.md": [],
+  "game/civilian-units.md": ["civilian_units_build_explorer.json"],
   "game/combat.md": [],
   "game/commodity-catalog.md": [],
   "game/diplomacy.md": [],

--- a/tool/sim_scenarios/lib/scenario.dart
+++ b/tool/sim_scenarios/lib/scenario.dart
@@ -47,10 +47,14 @@ class ScenarioSetup {
   const ScenarioSetup({
     this.units,
     this.stockpileOverrides,
+    this.stockpileAdditions,
   });
 
   final List<UnitPlacement>? units;
   final Map<String, int>? stockpileOverrides;
+  /// Per-player commodity additions (playerId -> commodityId -> quantity to add).
+  /// Applied after init so e.g. gp1 can have paper for civilian build scenarios.
+  final Map<String, Map<String, int>>? stockpileAdditions;
 }
 
 /// Placement of a unit in a province for scenario setup.
@@ -237,12 +241,18 @@ ScenarioInit _parseScenarioInit(Map<String, dynamic>? json) {
 }
 
 ScenarioSetup _parseScenarioSetup(Map<String, dynamic> json) {
+  final stockpileAdditionsRaw = json['stockpileAdditions'] as Map<String, dynamic>?;
+  final stockpileAdditions = stockpileAdditionsRaw?.map((playerId, value) {
+    final inner = (value as Map<String, dynamic>).map((k, v) => MapEntry(k, v as int));
+    return MapEntry(playerId, inner);
+  });
   return ScenarioSetup(
     units: (json['units'] as List<dynamic>?)
         ?.map((u) => _parseUnitPlacement(u as Map<String, dynamic>))
         .toList(),
     stockpileOverrides: (json['stockpileOverrides'] as Map<String, dynamic>?)
         ?.map((k, v) => MapEntry(k, v as int)),
+    stockpileAdditions: stockpileAdditions,
   );
 }
 

--- a/tool/sim_scenarios/lib/scenario_runner.dart
+++ b/tool/sim_scenarios/lib/scenario_runner.dart
@@ -93,33 +93,37 @@ class ScenarioRunner {
   Future<ScenarioResult> run(Scenario scenario) async {
     try {
       // 1. Initialize game
-      final context = await _initializeGame(scenario);
-      if (context == null) {
+      final contextOrNull = await _initializeGame(scenario);
+      if (contextOrNull == null) {
         return ScenarioResult(
           scenarioName: scenario.name,
           passed: false,
           failures: ['Failed to initialize game'],
         );
       }
+      var ctx = contextOrNull;
 
-      // 2. Apply setup if specified (for saved-game scenarios)
+      // 2. Apply setup if specified (stockpile additions, unit injection, etc.)
       if (scenario.setup != null) {
-        _applySetup(context.game, scenario.setup!);
+        final gameAfterSetup = _applySetup(ctx.game, scenario.setup!);
+        ctx = ScenarioContext(
+          game: gameAfterSetup,
+          topology: ctx.topology,
+          tileMapByRegion: ctx.tileMapByRegion,
+        );
       }
 
       // 3. Run each turn
       final turnResults = <int, TurnResult>{};
-      
       for (final turnScript in scenario.turns) {
-        // Parse orders
-        final orders = parseOrderCommands(turnScript.orders, context.game);
-        
-        // Resolve turn
-        await _resolveTurn(context, orders);
-        
-        // Verify assertions for this turn
-        final assertionResults = _verifyTurnAssertions(context.game, scenario.assertions, turnScript.turn);
-        
+        final orders = parseOrderCommands(turnScript.orders, ctx.game);
+        final resolvedGame = await _resolveTurn(ctx, orders);
+        ctx = ScenarioContext(
+          game: resolvedGame,
+          topology: ctx.topology,
+          tileMapByRegion: ctx.tileMapByRegion,
+        );
+        final assertionResults = _verifyTurnAssertions(ctx.game, scenario.assertions, turnScript.turn);
         turnResults[turnScript.turn] = TurnResult(
           turnNumber: turnScript.turn,
           assertionResults: assertionResults,
@@ -128,8 +132,7 @@ class ScenarioRunner {
 
       // 4. Verify final assertions (those without turn specified)
       final finalAssertions = scenario.assertions.where((a) => a.turn == null).toList();
-      final finalResult = verifier.verify(context.game, finalAssertions);
-      
+      final finalResult = verifier.verify(ctx.game, finalAssertions);
       final allFailures = <String>[];
       for (final tr in turnResults.values) {
         for (final ar in tr.assertionResults) {
@@ -144,7 +147,7 @@ class ScenarioRunner {
         scenarioName: scenario.name,
         passed: allFailures.isEmpty,
         failures: allFailures,
-        finalState: context.game,
+        finalState: ctx.game,
         turnResults: turnResults,
       );
     } catch (e, stack) {
@@ -218,35 +221,41 @@ class ScenarioRunner {
     return null;
   }
 
-  void _applySetup(Game game, ScenarioSetup setup) {
-    // TODO: Implement unit injection for saved-game scenarios
-    // This would add units to provinces as specified in setup.units
-    if (setup.stockpileOverrides != null) {
+  /// Applies setup (stockpile additions, etc.) and returns updated game.
+  Game _applySetup(Game game, ScenarioSetup setup) {
+    // Stockpile additions: per-player commodity deltas (e.g. paper for civilian build).
+    if (setup.stockpileAdditions != null && setup.stockpileAdditions!.isNotEmpty) {
+      final updatedPlayers = <Player>[];
       for (final player in game.players) {
-        final override = setup.stockpileOverrides![player.id];
-        if (override != null) {
-          // Note: Player stockpile is final, need to create new instance
-          // This is a simplified implementation
+        final additions = setup.stockpileAdditions![player.id];
+        if (additions == null || additions.isEmpty) {
+          updatedPlayers.add(player);
+          continue;
         }
+        var stockpile = player.stockpile;
+        for (final entry in additions.entries) {
+          stockpile = stockpile.applyDelta(entry.key, entry.value);
+        }
+        updatedPlayers.add(player.copyWith(stockpile: stockpile));
       }
+      return game.copyWith(players: updatedPlayers);
     }
+    // TODO: Implement unit injection for saved-game scenarios (setup.units)
+    // TODO: Apply setup.stockpileOverrides if needed
+    return game;
   }
 
-  Future<void> _resolveTurn(ScenarioContext context, Orders orders) async {
+  Future<Game> _resolveTurn(ScenarioContext context, Orders orders) async {
     final topology = context.topology;
     if (topology == null) {
       throw StateError('Topology required for turn resolution');
     }
-    
-    // Create order engine with the orders
     final orderEngine = OrderEngine(initialOrders: orders);
-    
-    // Resolve turn - this modifies context.game in place
-    resolveTurnForGameFromOrderEngine(
+    return resolveTurnForGameFromOrderEngine(
       game: context.game,
       topology: topology,
       orderEngine: orderEngine,
-      aiOrders: null, // Deterministic: no AI orders
+      aiOrders: null,
       tileMapByRegion: context.tileMapByRegion,
     );
   }

--- a/tool/sim_scenarios/scenarios/civilian_units_build_explorer.json
+++ b/tool/sim_scenarios/scenarios/civilian_units_build_explorer.json
@@ -1,0 +1,42 @@
+{
+  "name": "civilian_units_build_explorer",
+  "description": "Civilian training cost: building one Explorer costs 1000 cash and 2 paper without affecting workers (SPEC/game/civilian-units.md, training cost AC).",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "greatPowers": ["england"],
+      "seed": 42,
+      "minorNationCount": 0
+    },
+    "oldWorld": {
+      "grid": [["p1", "p1"], ["p1", "sea1"]],
+      "nodes": [
+        {"id": "p1", "regionId": "oldWorld", "type": "province"},
+        {"id": "sea1", "regionId": "oldWorld", "type": "seaZone"}
+      ],
+      "edges": [{"id1": "p1", "id2": "sea1"}]
+    }
+  },
+  "setup": {
+    "stockpileAdditions": {
+      "gp1": {"paper": 2}
+    }
+  },
+  "turns": [
+    {
+      "turn": 1,
+      "orders": [
+        {
+          "player": "gp1",
+          "type": "build",
+          "unitType": "Explorer",
+          "in": "oldWorld|p1"
+        }
+      ]
+    }
+  ],
+  "assertions": [
+    {"turn": 1, "player": "gp1", "treasury": 4000},
+    {"turn": 1, "province": "oldWorld|p1", "unitCount": 6}
+  ]
+}

--- a/tool/sim_scenarios/test/sim_scenarios_test.dart
+++ b/tool/sim_scenarios/test/sim_scenarios_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:colonizethis_test/test.dart';
 
 import 'package:sim_scenarios/scenario.dart';
+import 'package:sim_scenarios/scenario_runner.dart';
 
 void main() {
   group('sim_scenarios', () {
@@ -86,6 +87,26 @@ void main() {
         expect(scenario.setup!.units![0].playerId, 'france');
         expect(scenario.setup!.units![0].provinceId, 'normandy');
         expect(scenario.setup!.units![0].count, 3);
+      });
+
+      test('parses scenario with stockpileAdditions', () {
+        final json = {
+          'name': 'stockpile_setup',
+          'init': {'type': 'fromTopology', 'config': {'greatPowers': ['england']}},
+          'setup': {
+            'stockpileAdditions': {
+              'gp1': {'paper': 2},
+            },
+          },
+          'turns': [],
+          'assertions': [],
+        };
+
+        final scenario = parseScenarioFromJson(json);
+
+        expect(scenario.setup, isNotNull);
+        expect(scenario.setup!.stockpileAdditions, isNotNull);
+        expect(scenario.setup!.stockpileAdditions!['gp1'], {'paper': 2});
       });
 
       test('parses all order types', () {
@@ -188,6 +209,24 @@ void main() {
         final scenarios = discoverScenarios(dir);
 
         expect(scenarios.length, greaterThan(0));
+      });
+    });
+
+    group('civilian_units_build_explorer', () {
+      test('scenario passes (GDD civilian-units training cost AC)', () async {
+        final file = File('scenarios/civilian_units_build_explorer.json');
+        if (!file.existsSync()) {
+          return;
+        }
+        final scenario = parseScenarioFile(file).single;
+        final runner = ScenarioRunner();
+        final result = await runner.run(scenario);
+        if (!result.passed) {
+          for (final f in result.failures) {
+            print('Failure: $f');
+          }
+        }
+        expect(result.passed, isTrue, reason: result.failures.join('; '));
       });
     });
   });


### PR DESCRIPTION
Adds sim_scenarios coverage for SPEC/game/civilian-units.md (training cost AC: build Explorer costs 1000 cash + 2 paper, no worker change).

- **Scenario:** `civilian_units_build_explorer.json` — fromTopology (1 GP, 1 OW province), setup adds 2 paper to gp1, turn 1 build Explorer in oldWorld|p1; assertions: treasury 4000, unitCount 6.
- **Runner:** Support `setup.stockpileAdditions` (per-player commodity deltas); fix bug where resolved game was not used (turn resolution now updates context with returned game).
- **Spec:** sim-scenarios.md documents stockpileAdditions.
- **Coverage:** gdd-scenario-coverage.json lists civilian_units_build_explorer.json for game/civilian-units.md.
- **Tests:** Parse stockpileAdditions; integration test runs civilian scenario and asserts pass.

Made with [Cursor](https://cursor.com)