### PR TITLE
GDD scenario coverage: civilian-units.md

### DIFF
--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -1,7 +1,7 @@
 {
   "game/capital-and-connectivity.md": ["capital_and_connectivity_init.json"],
   "game/capital-choice-phase.md": ["capital_choice_phase_basic.json"],
-  "game/civilian-units.md": [],
+  "game/civilian-units.md": ["civilian_units_starting.json"],
   "game/combat.md": ["combat_basic.json"],
   "game/commodity-catalog.md": [],
   "game/diplomacy.md": [],

--- a/tool/sim_scenarios/scenarios/civilian_units_starting.json
+++ b/tool/sim_scenarios/scenarios/civilian_units_starting.json
@@ -1,0 +1,27 @@
+{
+  "name": "civilian_units_starting",
+  "description": "Verifies fresh game initialization spawns starting civilian units (2 Explorers, 2 Builders, 1 Engineer) for gp1 in its capital province per SPEC/game/civilian-units.md and StartingResourcesConfig.",
+  "init": {
+    "type": "fresh",
+    "config": {
+      "seed": 42,
+      "greatPowers": ["england", "france"],
+      "continentCount": 4,
+      "minorNationCount": 6,
+      "tribeCount": 10
+    }
+  },
+  "turns": [
+    {
+      "turn": 1,
+      "orders": []
+    }
+  ],
+  "assertions": [
+    { "turn": 1, "province": "oldWorld|p1", "hasUnit": "gp1_explorer_1" },
+    { "turn": 1, "province": "oldWorld|p1", "hasUnit": "gp1_explorer_2" },
+    { "turn": 1, "province": "oldWorld|p1", "hasUnit": "gp1_builder_1" },
+    { "turn": 1, "province": "oldWorld|p1", "hasUnit": "gp1_builder_2" },
+    { "turn": 1, "province": "oldWorld|p1", "hasUnit": "gp1_engineer_1" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add  sim_scenarios JSON to verify fresh init spawns starting civilian units per  (2 Explorers, 2 Builders, 1 Engineer) for gp1 in its capital province.
- Wire  into  so the coverage tool now treats this GDD spec as covered by the new scenario.

## Details
- Scenario uses  with the same config as  and asserts that  (gp1 capital) contains , , , , and , matching the naming logic in .
- No game logic changes; only spec mapping and scenario JSON were added.

## Testing
-  is referenced in the specs but  is not available in this environment (), so I could not run the coverage tool here.
-  from the repo root exits with code 65 because there is no top-level  directory; package-level tests were not invoked in this session.

Made with [Cursor](https://cursor.com)