### PR TITLE
Align ctdev logging file naming and tests

### DIFF
--- a/SPEC/program/ctdev-logging.md
+++ b/SPEC/program/ctdev-logging.md
@@ -21,6 +21,7 @@
   - **File:** Logs at **debug** and above (default).
   - **In-memory Sim Log (UI):** Logs at **info** and above; shows the **last 10 lines** only; **cleared at the start of every turn** (when resolving a turn or stepping a full turn).
 - **Exception capture:** All log calls use `error` and `stackTrace` parameters where applicable. Uncaught errors are handled in `runZonedGuarded` and logged with stack trace. The file format appends error and stack trace when present (e.g. on following lines).
+  - **CLI tools:** Init-game, map generation, and sim tools use the same logger configuration for **operational and diagnostic** output (`logic:`, `map:`, etc.). They may still write **usage, help text, and human-readable reports** to `stdout`/`print` as part of their CLI contract; these are exempt from the “no print for logging” rule.
 
 ---
 

--- a/ctdev/lib/ctdev_log.dart
+++ b/ctdev/lib/ctdev_log.dart
@@ -92,9 +92,12 @@ void startSimSession(String id) {
   if (!dir.existsSync()) {
     dir.createSync(recursive: true);
   }
+  final now = DateTime.now().toLocal();
+  final dateStr =
+      '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
   final basicLogger = BasicLogger('ctdev');
   basicLogger.attachLogger(FileOutputLogger(
-    basicLogger.name,
+    dateStr,
     dir: logsDir,
     ext: '.log',
     bufferSize: 50,
@@ -118,4 +121,14 @@ void initCtdevLogging() {
       addUiLine(lines.first);
     }
   });
+}
+
+/// Test-only helper to reset in-memory ctdev logging state between tests.
+/// Not used by production code.
+void resetCtdevLoggingForTest() {
+  _preSimBuffer.clear();
+  _sessionId = null;
+  _fileLogger = null;
+  _logsDir = null;
+  _uiLogLines.clear();
 }

--- a/ctdev/test/ctdev_log_test.dart
+++ b/ctdev/test/ctdev_log_test.dart
@@ -1,0 +1,49 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:logger/logger.dart';
+
+import 'package:ctdev/ctdev_log.dart';
+
+void main() {
+  group('ctdev_log', () {
+    setUp(resetCtdevLoggingForTest);
+
+    test('formatLogEvent formats message, error, and stack trace', () {
+      final error = StateError('boom');
+      final stack = StackTrace.current;
+      final event = LogEvent(
+        Level.info,
+        'logic: test message',
+        error: error,
+        stackTrace: stack,
+      );
+
+      final lines = formatLogEvent(event);
+
+      expect(lines, isNotEmpty);
+      expect(lines.first, contains('INFO'));
+      expect(lines.first, contains('logic: test message'));
+      expect(lines.any((l) => l.contains('error:')), isTrue);
+      expect(lines.any((l) => l.contains('stackTrace:')), isTrue);
+    });
+
+    test('UI log keeps last N lines and can be cleared', () {
+      for (var i = 0; i < 15; i++) {
+        addUiLine('line $i');
+      }
+
+      final lastLines = getLastUiLogLines();
+      expect(lastLines.length, lessThanOrEqualTo(10));
+      expect(lastLines.first, contains('line 5'));
+      expect(lastLines.last, contains('line 14'));
+
+      clearUiLog();
+      expect(getLastUiLogLines(), isEmpty);
+    });
+
+    test('sessionId and sessionLogPath are null before session starts', () {
+      expect(sessionId, isNull);
+      expect(sessionLogPath, isNull);
+    });
+  });
+}
+


### PR DESCRIPTION
Fixes #118.

- Align ctdev file naming behaviour with ctdev-logging spec (one file per calendar day under logs/).
- Add ctdev_log unit tests for formatting and UI log buffer behaviour.
- Document CLI tool exemptions for usage/help/report output (while keeping logger-based operational/diagnostic logging).

Made with [Cursor](https://cursor.com)