### PR TITLE
Production-recipes GDD: SPEC cross-refs instead of GDD/TDD (Fixes #494)

### DIFF
--- a/SPEC/game/production-recipes.md
+++ b/SPEC/game/production-recipes.md
@@ -1,6 +1,6 @@
 # Production Recipes
 
-**SPEC/game** — Recipe structure and location. Derived from GDD 04, TDD 04. Commodities: [commodity-catalog.md](commodity-catalog.md). Labour: [workers-and-population.md](workers-and-population.md).
+**SPEC/game** — Recipe structure and location. Cross-refs: [stockpiles-and-production.md](stockpiles-and-production.md), [economy-models.md](../program/economy-models.md), [order-projections.md](../program/order-projections.md). Commodities: [commodity-catalog.md](commodity-catalog.md). Labour: [workers-and-population.md](workers-and-population.md).
 
 ---
 
@@ -17,7 +17,7 @@ Industry consumes inputs and labour from stockpile and WorkerPool; produces outp
 
 ---
 
-## Examples (GDD 04)
+## Examples
 
 - Timber ×2, Iron ×2, Coal ×1 → Cast Iron (labour per unit from constants).
 - Wool or Cotton ×2 → Fabric.


### PR DESCRIPTION
## Summary
- Update `SPEC/game/production-recipes.md` header to replace the legacy `Derived from GDD 04, TDD 04` text with explicit SPEC cross-refs.
- Point the GDD header at `SPEC/game/stockpiles-and-production.md`, `SPEC/program/economy-models.md`, and `SPEC/program/order-projections.md` as the authoritative sources for production flow, data structures, and projections.
- Remove the `(GDD 04)` suffix from the examples section title so the document consistently relies on in-repo SPEC paths instead of external GDD/TDD numbering.

## Testing
- Docs-only change; no code or behavior touched.
- No automated tests required; references and paths verified locally.

Fixes #494.

Made with [Cursor](https://cursor.com)