### PR TITLE
GDD scenario coverage: map-topology.md

### DIFF
--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -10,7 +10,13 @@
   "game/fog-and-exploration.md": [],
   "game/game-setup.md": ["basic_turn_1.json"],
   "game/leader-bonuses.md": [],
-  "game/map-topology.md": [],
+  "game/map-topology.md": [
+    "connectivity_ow_to_ow.json",
+    "connectivity_ow_separated_by_sea.json",
+    "connectivity_ow_to_nw.json",
+    "connectivity_no_road_to_capital.json",
+    "connectivity_no_road_to_port.json"
+  ],
   "game/military-generals.md": [],
   "game/military-units.md": [],
   "game/naming.md": [],


### PR DESCRIPTION
## Summary

- Link the  GDD spec to existing connectivity sim_scenarios (, , , , ) in .
- This marks the map-topology spec as covered by scenarios that exercise region graphs, OW/NW separation, warp-zone style OW↔NW layouts, and connectivity/no-connectivity cases.

## Testing

- 
-  at repo root fails because there is no root  directory; per-package tests are unchanged in this PR.

Made with [Cursor](https://cursor.com)