### PR TITLE
GDD scenario coverage: production-recipes.md

### DIFF
--- a/SPEC/program/sim-scenarios.md
+++ b/SPEC/program/sim-scenarios.md
@@ -49,13 +49,20 @@ Two initialization types:
 
 **From-topology (connectivity scenarios)** — Builds game from a fixed Old World (and optional New World) topology and grid. Used for connectivity and capital assertions. `init.type`: `"fromTopology"`. `init.config`: optional `greatPowers`, `seed`, `tribeCount` (for NW). `init.oldWorld` / `init.newWorld`: `{ "grid": [[...]], "nodes": [...], "edges": [...] }`. **Behaviour:** No Minor Nations (minor count and min provinces per minor are forced to 0) so that province assignment only assigns to Great Powers and, when present, Tribes on the New World. Aligns with [game-setup.md](../game/game-setup.md) (config from scenario).
 
-For saved games, optional `setup` block injects units for specific test scenarios:
+For saved games (or fresh/fromTopology), optional `setup` block can inject units and/or set economy state:
+- `units` — list of unit placements (player, type, province, count).
+- `initialStockpile` — map from player id to map of commodity id → quantity; sets that player's central stockpile before turns.
+- `initialWorkers` — map from player id to worker counts (e.g. `{ "peasants": 2, "apprentices": 1 }`); sets that player's WorkerPool before turns.
+
+Example:
 ```json
 {
   "setup": {
     "units": [
       {"player": "france", "type": "infantry", "province": "normandy", "count": 3}
-    ]
+    ],
+    "initialStockpile": { "england": { "timber": 10, "wool": 5 } },
+    "initialWorkers": { "england": { "peasants": 2 } }
   }
 }
 ```
@@ -81,6 +88,8 @@ Each turn specifies orders for one or more players:
 ```
 
 Supported order types: `move`, `build`, `work`, `diplomatic`, `research`, `naval_move`, `naval_mission`.
+
+Each turn may optionally include **workerAssignments** (production phase): a list of `{ "recipeId": "<id>", "assignedLabour": <n> }`. These are passed as default production assignments for that turn so the Production phase can run recipes; see SPEC/game/production-recipes.md. Scenario setup may include **initialStockpile** and **initialWorkers** per player (map from player id to commodity quantities or worker counts) to set economy state before turns run.
 
 ---
 
@@ -108,6 +117,7 @@ Assertion fields:
 - `hasUnit` — Specific unit ID that must be present
 - `hasPlayerUnits` — Any units belonging to player must be present
 - `stockpile` — Resource stockpile amount (sum of all commodities in player stockpile)
+- `stockpileCommodity` — With `player` and `commodity` (commodity id): expected quantity of that commodity in the player's central stockpile. Supports `matchType`.
 - `treasury` — Treasury amount
 - `matchType` — `exact` (default), `range`, `atLeast`, `atMost`
 
@@ -127,6 +137,8 @@ Assertion fields:
 - `region` + `resource` (no `province`/`player`) — **regionHasNoResource:** no tile in the given region has this resource (negative). Example: `{"region": "oldWorld", "resource": "sugarCane"}`.
 - `everyTileResourceAllowedInRegion` — For each tile in `resourceByTileKey`, the resource is allowed in that tile’s region per resource rules. Optional `region` restricts to one region.
 - `region` + `maxBothFraction` — **resourcePlacementCap:** in the given region, the fraction of placed resources that are “both” (timber, iron, copper, tin, coal) is ≤ this value (default 0.30). Example: `{"region": "oldWorld", "maxBothFraction": 0.30}`.
+
+**Economy / production assertions** (SPEC/game/production-recipes.md): use `player`, `commodity` (commodity id), and `stockpileCommodity` (expected quantity) to assert per-commodity stockpile after a turn or final state; supports `matchType`.
 
 ---
 

--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -20,7 +20,7 @@
   "game/military-generals.md": [],
   "game/military-units.md": [],
   "game/naming.md": [],
-  "game/production-recipes.md": [],
+  "game/production-recipes.md": ["production_recipes_basic.json"],
   "game/quick-battle.md": [],
   "game/research-state.md": [],
   "game/resource-terrain-region-rules.md": ["resource_ow_has_no_nw_only.json", "resource_nw_has_no_ow_only.json", "resource_every_tile_allowed_in_region.json", "resource_multi_region_cap.json", "resource_diamonds_nw_only.json"],

--- a/tool/sim_scenarios/lib/scenario.dart
+++ b/tool/sim_scenarios/lib/scenario.dart
@@ -42,15 +42,21 @@ class ScenarioInit {
   final Map<String, dynamic>? newWorld;
 }
 
-/// Setup for saved-game scenarios (unit injection, resource overrides).
+/// Setup for saved-game scenarios (unit injection, economy state).
 class ScenarioSetup {
   const ScenarioSetup({
     this.units,
     this.stockpileOverrides,
+    this.initialStockpile,
+    this.initialWorkers,
   });
 
   final List<UnitPlacement>? units;
   final Map<String, int>? stockpileOverrides;
+  /// Player id → commodity id → quantity. Applied to player stockpile before turns.
+  final Map<String, Map<String, int>>? initialStockpile;
+  /// Player id → worker counts (peasants, apprentices, journeymen, masters). Applied to WorkerPool before turns.
+  final Map<String, Map<String, int>>? initialWorkers;
 }
 
 /// Placement of a unit in a province for scenario setup.
@@ -68,15 +74,29 @@ class UnitPlacement {
   final int count;
 }
 
+/// Production assignment for one recipe in a turn. SPEC/game/production-recipes.md.
+class WorkerAssignment {
+  const WorkerAssignment({
+    required this.recipeId,
+    required this.assignedLabour,
+  });
+
+  final String recipeId;
+  final int assignedLabour;
+}
+
 /// Scripted orders for a single turn.
 class TurnScript {
   const TurnScript({
     required this.turn,
     required this.orders,
+    this.workerAssignments,
   });
 
   final int turn;
   final List<OrderCommand> orders;
+  /// Production phase: recipe assignments for this turn (defaultAssignments).
+  final List<WorkerAssignment>? workerAssignments;
 }
 
 /// A single order command from a scenario.
@@ -138,6 +158,8 @@ class Assertion {
     this.hasUnit,
     this.hasPlayerUnits,
     this.stockpile,
+    this.stockpileCommodity,
+    this.commodity,
     this.treasury,
     this.matchMin,
     this.matchMax,
@@ -168,6 +190,10 @@ class Assertion {
   final String? hasUnit;
   final String? hasPlayerUnits;
   final int? stockpile;
+  /// With [player] and [commodity]: expected quantity of that commodity in stockpile. SPEC/game/production-recipes.md.
+  final int? stockpileCommodity;
+  /// Commodity id for [stockpileCommodity] assertion.
+  final String? commodity;
   final int? treasury;
   final int? matchMin;
   final int? matchMax;
@@ -237,12 +263,46 @@ ScenarioInit _parseScenarioInit(Map<String, dynamic>? json) {
 }
 
 ScenarioSetup _parseScenarioSetup(Map<String, dynamic> json) {
+  Map<String, Map<String, int>>? _parseInitialStockpile(dynamic raw) {
+    if (raw is! Map) return null;
+    final result = <String, Map<String, int>>{};
+    for (final entry in (raw as Map<String, dynamic>).entries) {
+      if (entry.value is Map) {
+        final inner = <String, int>{};
+        for (final e in (entry.value as Map).entries) {
+          final v = e.value;
+          inner[e.key.toString()] = v is int ? v : (int.tryParse('$v') ?? 0);
+        }
+        result[entry.key] = inner;
+      }
+    }
+    return result.isEmpty ? null : result;
+  }
+
+  Map<String, Map<String, int>>? _parseInitialWorkers(dynamic raw) {
+    if (raw is! Map) return null;
+    final result = <String, Map<String, int>>{};
+    for (final entry in (raw as Map<String, dynamic>).entries) {
+      if (entry.value is Map) {
+        final inner = <String, int>{};
+        for (final e in (entry.value as Map).entries) {
+          final v = e.value;
+          inner[e.key.toString()] = v is int ? v : (int.tryParse('$v') ?? 0);
+        }
+        result[entry.key] = inner;
+      }
+    }
+    return result.isEmpty ? null : result;
+  }
+
   return ScenarioSetup(
     units: (json['units'] as List<dynamic>?)
         ?.map((u) => _parseUnitPlacement(u as Map<String, dynamic>))
         .toList(),
     stockpileOverrides: (json['stockpileOverrides'] as Map<String, dynamic>?)
         ?.map((k, v) => MapEntry(k, v as int)),
+    initialStockpile: _parseInitialStockpile(json['initialStockpile']),
+    initialWorkers: _parseInitialWorkers(json['initialWorkers']),
   );
 }
 
@@ -256,12 +316,28 @@ UnitPlacement _parseUnitPlacement(Map<String, dynamic> json) {
 }
 
 TurnScript _parseTurnScript(Map<String, dynamic> json) {
+  List<WorkerAssignment>? _parseWorkerAssignments(dynamic raw) {
+    if (raw is! List) return null;
+    final list = <WorkerAssignment>[];
+    for (final e in raw) {
+      if (e is! Map) continue;
+      final m = Map<String, dynamic>.from(e);
+      final recipeId = m['recipeId'] as String?;
+      final labour = m['assignedLabour'] as int? ?? 0;
+      if (recipeId != null && recipeId.isNotEmpty && labour > 0) {
+        list.add(WorkerAssignment(recipeId: recipeId, assignedLabour: labour));
+      }
+    }
+    return list.isEmpty ? null : list;
+  }
+
   return TurnScript(
     turn: json['turn'] as int,
     orders: (json['orders'] as List<dynamic>?)
             ?.map((o) => _parseOrderCommand(o as Map<String, dynamic>))
             .toList() ??
         [],
+    workerAssignments: _parseWorkerAssignments(json['workerAssignments']),
   );
 }
 
@@ -298,6 +374,8 @@ Assertion _parseAssertion(Map<String, dynamic> json) {
     hasUnit: json['hasUnit'] as String?,
     hasPlayerUnits: json['hasPlayerUnits'] as String?,
     stockpile: json['stockpile'] as int?,
+    stockpileCommodity: json['stockpileCommodity'] as int?,
+    commodity: json['commodity'] as String?,
     treasury: json['treasury'] as int?,
     matchMin: json['matchMin'] as int?,
     matchMax: json['matchMax'] as int?,

--- a/tool/sim_scenarios/lib/scenario_runner.dart
+++ b/tool/sim_scenarios/lib/scenario_runner.dart
@@ -119,8 +119,12 @@ class ScenarioRunner {
         // Parse orders
         final orders = parseOrderCommands(turnScript.orders, currentContext.game);
         
-        // Resolve turn (returns updated game)
-        final nextGame = _resolveTurn(currentContext, orders);
+        // Resolve turn (returns updated game); pass production assignments if specified
+        final nextGame = _resolveTurn(
+          currentContext,
+          orders,
+          turnScript.workerAssignments,
+        );
         currentContext = ScenarioContext(
           game: nextGame,
           topology: currentContext.topology,
@@ -278,21 +282,71 @@ class ScenarioRunner {
       for (final player in game.players) {
         final override = setup.stockpileOverrides![player.id];
         if (override != null) {
-          // Note: Player stockpile is final, need to create new instance
-          // This is a simplified implementation
+          // Legacy: single-value override not applied per-commodity; use initialStockpile instead.
         }
       }
+    }
+    if (setup.initialStockpile != null && setup.initialStockpile!.isNotEmpty) {
+      final updatedPlayers = <Player>[];
+      for (final player in game.players) {
+        final quantities = setup.initialStockpile![player.id];
+        if (quantities == null || quantities.isEmpty) {
+          updatedPlayers.add(player);
+          continue;
+        }
+        var stockpile = const Stockpile();
+        for (final entry in quantities.entries) {
+          if (entry.value > 0) {
+            stockpile = stockpile.applyDelta(entry.key, entry.value);
+          }
+        }
+        updatedPlayers.add(player.copyWith(stockpile: stockpile));
+      }
+      game = game.copyWith(players: updatedPlayers);
+    }
+    if (setup.initialWorkers != null && setup.initialWorkers!.isNotEmpty) {
+      final updatedPlayers = <Player>[];
+      for (final player in game.players) {
+        final counts = setup.initialWorkers![player.id];
+        if (counts == null || counts.isEmpty) {
+          updatedPlayers.add(player);
+          continue;
+        }
+        final pool = WorkerPool(
+          peasants: counts['peasants'] ?? 0,
+          apprentices: counts['apprentices'] ?? 0,
+          journeymen: counts['journeymen'] ?? 0,
+          masters: counts['masters'] ?? 0,
+        );
+        updatedPlayers.add(player.copyWith(workerPool: pool));
+      }
+      game = game.copyWith(players: updatedPlayers);
     }
     return game;
   }
 
   /// Resolves one turn and returns the updated game.
-  Game _resolveTurn(ScenarioContext context, Orders orders) {
+  Game _resolveTurn(
+    ScenarioContext context,
+    Orders orders, [
+    List<WorkerAssignment>? workerAssignments,
+  ]) {
     final topology = context.topology;
     if (topology == null) {
       throw StateError('Topology required for turn resolution');
     }
-    
+
+    final defaultAssignments = workerAssignments != null
+        ? workerAssignments
+            .map(
+              (w) => AssignedRecipe(
+                recipeId: w.recipeId,
+                assignedLabour: w.assignedLabour,
+              ),
+            )
+            .toList()
+        : <AssignedRecipe>[];
+
     final orderEngine = OrderEngine(initialOrders: orders);
     return resolveTurnForGameFromOrderEngine(
       game: context.game,
@@ -300,6 +354,7 @@ class ScenarioRunner {
       orderEngine: orderEngine,
       aiOrders: null,
       tileMapByRegion: context.tileMapByRegion,
+      defaultAssignments: defaultAssignments,
     );
   }
 

--- a/tool/sim_scenarios/lib/state_verifier.dart
+++ b/tool/sim_scenarios/lib/state_verifier.dart
@@ -172,6 +172,22 @@ class StateVerifier {
         }
       }
 
+      if (assertion.commodity != null && assertion.stockpileCommodity != null) {
+        final quantity = player.stockpile.quantityOf(assertion.commodity!);
+        final matchResult = _matchCount(
+          quantity,
+          assertion.stockpileCommodity!,
+          assertion.matchType,
+          assertion.matchMin,
+          assertion.matchMax,
+        );
+        if (!matchResult.passed) {
+          failures.add(
+            'Player ${assertion.player} commodity ${assertion.commodity}: ${matchResult.message}',
+          );
+        }
+      }
+
       if (assertion.treasury != null) {
         final matchResult = _matchCount(
           player.treasury,

--- a/tool/sim_scenarios/scenarios/production_recipes_basic.json
+++ b/tool/sim_scenarios/scenarios/production_recipes_basic.json
@@ -1,0 +1,35 @@
+{
+  "name": "production_recipes_basic",
+  "description": "SPEC/game/production-recipes.md: Production phase runs recipe (lumber_from_timber: 2 timber + 2 labour -> 1 lumber); assert stockpile inputs consumed and output added.",
+  "init": {
+    "type": "fresh",
+    "config": {
+      "seed": 42,
+      "greatPowers": ["england"],
+      "continentCount": 1,
+      "minorNationCount": 0,
+      "tribeCount": 0
+    }
+  },
+  "setup": {
+    "initialStockpile": {
+      "gp1": { "timber": 10 }
+    },
+    "initialWorkers": {
+      "gp1": { "peasants": 2 }
+    }
+  },
+  "turns": [
+    {
+      "turn": 1,
+      "orders": [],
+      "workerAssignments": [
+        { "recipeId": "lumber_from_timber", "assignedLabour": 2 }
+      ]
+    }
+  ],
+  "assertions": [
+    { "turn": 1, "player": "gp1", "commodity": "lumber", "stockpileCommodity": 1 },
+    { "turn": 1, "player": "gp1", "commodity": "timber", "stockpileCommodity": 8 }
+  ]
+}


### PR DESCRIPTION
Adds sim_scenarios support for production phase and one scenario covering SPEC/game/production-recipes.md.

**Changes:**
- **SPEC/program/sim-scenarios.md**: Document `workerAssignments` per turn, `initialStockpile` / `initialWorkers` in setup, and `stockpileCommodity` + `commodity` assertion for per-commodity stockpile checks.
- **tool/sim_scenarios**: New types `WorkerAssignment`, `TurnScript.workerAssignments`, `ScenarioSetup.initialStockpile` / `initialWorkers`, `Assertion.stockpileCommodity` / `commodity`; parsing and application in runner (setup applies stockpile/workers, turn resolution receives `defaultAssignments` from `workerAssignments`); `StateVerifier` checks per-commodity quantity with `matchType`.
- **production_recipes_basic.json**: Fresh init with one GP; setup gives gp1 timber 10 and 2 peasants (2 labour); turn 1 runs `lumber_from_timber` with 2 labour; assertions: lumber 1, timber 8.
- **gdd-scenario-coverage.json**: `game/production-recipes.md` → `["production_recipes_basic.json"]`.

Scenario runs and passes; package tests (sim_scenarios, colonizethis_logic, colonizethis_data, colonizethis_models) pass.

Made with [Cursor](https://cursor.com)