### PR TITLE
GDD scenario coverage: workers-and-population.md

### DIFF
--- a/SPEC/program/sim-scenarios.md
+++ b/SPEC/program/sim-scenarios.md
@@ -49,16 +49,24 @@ Two initialization types:
 
 **From-topology (connectivity scenarios)** — Builds game from a fixed Old World (and optional New World) topology and grid. Used for connectivity and capital assertions. `init.type`: `"fromTopology"`. `init.config`: optional `greatPowers`, `seed`, `tribeCount` (for NW). `init.oldWorld` / `init.newWorld`: `{ "grid": [[...]], "nodes": [...], "edges": [...] }`. **Behaviour:** No Minor Nations (minor count and min provinces per minor are forced to 0) so that province assignment only assigns to Great Powers and, when present, Tribes on the New World. Aligns with [game-setup.md](../game/game-setup.md) (config from scenario).
 
-For saved games, optional `setup` block injects units for specific test scenarios:
+For saved games (or after fresh/fromTopology init), optional `setup` block injects units and can override player economy for specific test scenarios:
 ```json
 {
   "setup": {
     "units": [
       {"player": "france", "type": "infantry", "province": "normandy", "count": 3}
-    ]
+    ],
+    "initialWorkers": {
+      "gp1": { "peasants": 2, "apprentices": 0, "journeymen": 0, "masters": 0 }
+    },
+    "initialStockpile": {
+      "gp1": { "grain": 1, "meat": 0 }
+    }
   }
 }
 ```
+- **initialWorkers:** Optional. Map player id → `{ "peasants", "apprentices", "journeymen", "masters" }`. Overrides that player's worker pool before the first turn. Used for consumption/starvation scenarios (SPEC/game/workers-and-population.md).
+- **initialStockpile:** Optional. Map player id → `{ commodityId: quantity, ... }`. Overrides that player's stockpile (replaces) before the first turn. Commodity ids are canonical (e.g. `grain`, `meat`).
 
 ---
 
@@ -110,6 +118,8 @@ Assertion fields:
 - `stockpile` — Resource stockpile amount (sum of all commodities in player stockpile)
 - `treasury` — Treasury amount
 - `matchType` — `exact` (default), `range`, `atLeast`, `atMost`
+
+**Worker and stockpile assertions** (SPEC/game/workers-and-population.md): use `player` with optional `workerPeasants`, `workerApprentices`, `workerJourneymen`, `workerMasters` (expected count each). Use `player` with `commodity` (commodity id, e.g. `grain`) and `stockpileCommodity` (expected quantity) for per-commodity stockpile checks.
 
 **Capital assertions** (SPEC/game/capital-choice-phase.md):
 - Use `player` (Great Power id, e.g. `gp1`) with `capitalProvince` — expected full province id (e.g. `oldWorld|p1`) for that player’s capital. Verifies the capital-choice phase selected the expected province.

--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -40,7 +40,7 @@
   "game/tile-map-and-generation.md": [],
   "game/turn-time-mapping.md": [],
   "game/victory.md": [],
-  "game/workers-and-population.md": [],
+  "game/workers-and-population.md": ["workers_consumption_starvation.json"],
   "game/world-model.md": [],
   "game/world-model-identity.md": []
 }

--- a/tool/sim_scenarios/bin/sim_scenarios.dart
+++ b/tool/sim_scenarios/bin/sim_scenarios.dart
@@ -208,6 +208,12 @@ String _formatAssertion(Assertion assertion) {
   if (assertion.stockpile != null) {
     return 'stockpile ${assertion.stockpile}';
   }
+  if (assertion.workerPeasants != null) {
+    return 'player.${assertion.player}.workerPeasants == ${assertion.workerPeasants}';
+  }
+  if (assertion.commodity != null && assertion.stockpileCommodity != null) {
+    return 'player.${assertion.player}.stockpile.${assertion.commodity} == ${assertion.stockpileCommodity}';
+  }
   if (assertion.treasury != null) {
     return 'treasury ${assertion.treasury}';
   }

--- a/tool/sim_scenarios/lib/scenario.dart
+++ b/tool/sim_scenarios/lib/scenario.dart
@@ -43,14 +43,21 @@ class ScenarioInit {
 }
 
 /// Setup for saved-game scenarios (unit injection, resource overrides).
+/// initialWorkers / initialStockpile apply after init (fresh or fromTopology).
 class ScenarioSetup {
   const ScenarioSetup({
     this.units,
     this.stockpileOverrides,
+    this.initialWorkers,
+    this.initialStockpile,
   });
 
   final List<UnitPlacement>? units;
   final Map<String, int>? stockpileOverrides;
+  /// Player id → { peasants, apprentices, journeymen, masters }. SPEC/game/workers-and-population.md.
+  final Map<String, Map<String, int>>? initialWorkers;
+  /// Player id → { commodityId: quantity }. Replaces player stockpile.
+  final Map<String, Map<String, int>>? initialStockpile;
 }
 
 /// Placement of a unit in a province for scenario setup.
@@ -153,6 +160,12 @@ class Assertion {
     this.relationLastInteractionTurn,
     this.overtureStage,
     this.capitalProvince,
+    this.workerPeasants,
+    this.workerApprentices,
+    this.workerJourneymen,
+    this.workerMasters,
+    this.commodity,
+    this.stockpileCommodity,
   });
 
   /// Which turn to check (null = final state)
@@ -191,6 +204,14 @@ class Assertion {
   final String? overtureStage;
   /// Capital province for [player] (Great Power). Full province id, e.g. oldWorld|p1. SPEC/game/capital-choice-phase.md.
   final String? capitalProvince;
+  /// Worker pool assertions (SPEC/game/workers-and-population.md). Require [player].
+  final int? workerPeasants;
+  final int? workerApprentices;
+  final int? workerJourneymen;
+  final int? workerMasters;
+  /// Per-commodity stockpile: [player] + [commodity] (id) + [stockpileCommodity] (expected quantity).
+  final String? commodity;
+  final int? stockpileCommodity;
 }
 
 /// Type of value matching for assertions.
@@ -242,8 +263,36 @@ ScenarioSetup _parseScenarioSetup(Map<String, dynamic> json) {
         ?.map((u) => _parseUnitPlacement(u as Map<String, dynamic>))
         .toList(),
     stockpileOverrides: (json['stockpileOverrides'] as Map<String, dynamic>?)
-        ?.map((k, v) => MapEntry(k, v as int)),
+        ?.map((k, v) => MapEntry(k as String, (v as num).toInt())),
+    initialWorkers: _parseInitialWorkers(json['initialWorkers']),
+    initialStockpile: _parseInitialStockpile(json['initialStockpile']),
   );
+}
+
+Map<String, Map<String, int>>? _parseInitialWorkers(dynamic raw) {
+  if (raw is! Map<String, dynamic>) return null;
+  final out = <String, Map<String, int>>{};
+  for (final entry in raw.entries) {
+    final inner = entry.value;
+    if (inner is! Map<String, dynamic>) continue;
+    out[entry.key] = {
+      for (final e in inner.entries) e.key: (e.value as num).toInt(),
+    };
+  }
+  return out.isEmpty ? null : out;
+}
+
+Map<String, Map<String, int>>? _parseInitialStockpile(dynamic raw) {
+  if (raw is! Map<String, dynamic>) return null;
+  final out = <String, Map<String, int>>{};
+  for (final entry in raw.entries) {
+    final inner = entry.value;
+    if (inner is! Map<String, dynamic>) continue;
+    out[entry.key] = {
+      for (final e in inner.entries) e.key: (e.value as num).toInt(),
+    };
+  }
+  return out.isEmpty ? null : out;
 }
 
 UnitPlacement _parseUnitPlacement(Map<String, dynamic> json) {
@@ -313,6 +362,12 @@ Assertion _parseAssertion(Map<String, dynamic> json) {
     relationLastInteractionTurn: json['relationLastInteractionTurn'] as int?,
     overtureStage: json['overtureStage'] as String?,
     capitalProvince: json['capitalProvince'] as String?,
+    workerPeasants: json['workerPeasants'] as int?,
+    workerApprentices: json['workerApprentices'] as int?,
+    workerJourneymen: json['workerJourneymen'] as int?,
+    workerMasters: json['workerMasters'] as int?,
+    commodity: json['commodity'] as String?,
+    stockpileCommodity: json['stockpileCommodity'] as int?,
   );
 }
 

--- a/tool/sim_scenarios/lib/scenario_runner.dart
+++ b/tool/sim_scenarios/lib/scenario_runner.dart
@@ -274,16 +274,42 @@ class ScenarioRunner {
         ),
       );
     }
-    if (setup.stockpileOverrides != null) {
-      for (final player in game.players) {
-        final override = setup.stockpileOverrides![player.id];
-        if (override != null) {
-          // Note: Player stockpile is final, need to create new instance
-          // This is a simplified implementation
-        }
-      }
+    // Apply initialWorkers and initialStockpile (SPEC/game/workers-and-population.md).
+    var players = game.players;
+    if (setup.initialWorkers != null || setup.initialStockpile != null) {
+      players = [
+        for (final player in game.players)
+          _applyPlayerEconomyOverrides(player, setup),
+      ];
+    }
+    if (players != game.players) {
+      game = game.copyWith(players: players);
     }
     return game;
+  }
+
+  Player _applyPlayerEconomyOverrides(Player player, ScenarioSetup setup) {
+    var p = player;
+    if (setup.initialWorkers != null) {
+      final w = setup.initialWorkers![player.id];
+      if (w != null) {
+        p = p.copyWith(
+          workerPool: WorkerPool(
+            peasants: w['peasants'] ?? 0,
+            apprentices: w['apprentices'] ?? 0,
+            journeymen: w['journeymen'] ?? 0,
+            masters: w['masters'] ?? 0,
+          ),
+        );
+      }
+    }
+    if (setup.initialStockpile != null) {
+      final s = setup.initialStockpile![player.id];
+      if (s != null && s.isNotEmpty) {
+        p = p.copyWith(stockpile: Stockpile(quantities: Map<String, int>.from(s)));
+      }
+    }
+    return p;
   }
 
   /// Resolves one turn and returns the updated game.

--- a/tool/sim_scenarios/lib/state_verifier.dart
+++ b/tool/sim_scenarios/lib/state_verifier.dart
@@ -187,6 +187,47 @@ class StateVerifier {
         }
       }
 
+      // Worker pool assertions (SPEC/game/workers-and-population.md)
+      if (assertion.workerPeasants != null) {
+        if (player.workerPool.peasants != assertion.workerPeasants) {
+          failures.add(
+            'Player ${assertion.player} workerPeasants: expected ${assertion.workerPeasants}, got ${player.workerPool.peasants}',
+          );
+        }
+      }
+      if (assertion.workerApprentices != null) {
+        if (player.workerPool.apprentices != assertion.workerApprentices) {
+          failures.add(
+            'Player ${assertion.player} workerApprentices: expected ${assertion.workerApprentices}, got ${player.workerPool.apprentices}',
+          );
+        }
+      }
+      if (assertion.workerJourneymen != null) {
+        if (player.workerPool.journeymen != assertion.workerJourneymen) {
+          failures.add(
+            'Player ${assertion.player} workerJourneymen: expected ${assertion.workerJourneymen}, got ${player.workerPool.journeymen}',
+          );
+        }
+      }
+      if (assertion.workerMasters != null) {
+        if (player.workerPool.masters != assertion.workerMasters) {
+          failures.add(
+            'Player ${assertion.player} workerMasters: expected ${assertion.workerMasters}, got ${player.workerPool.masters}',
+          );
+        }
+      }
+
+      // Per-commodity stockpile (SPEC/game/workers-and-population.md)
+      if (assertion.commodity != null && assertion.stockpileCommodity != null) {
+        final actual = player.stockpile.quantityOf(assertion.commodity!);
+        final expected = assertion.stockpileCommodity!;
+        if (actual != expected) {
+          failures.add(
+            'Player ${assertion.player} stockpile ${assertion.commodity}: expected $expected, got $actual',
+          );
+        }
+      }
+
       // Capital assertion (SPEC/game/capital-choice-phase.md): player's capital province
       if (assertion.capitalProvince != null) {
         final expected = assertion.capitalProvince!;

--- a/tool/sim_scenarios/scenarios/workers_consumption_starvation.json
+++ b/tool/sim_scenarios/scenarios/workers_consumption_starvation.json
@@ -1,0 +1,34 @@
+{
+  "name": "workers_consumption_starvation",
+  "description": "SPEC/game/workers-and-population.md: Consumption phase deducts food for workers; insufficient food causes starvation (peasants first). Given 2 peasants and 1 grain, one peasant is fed and one starves.",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "greatPowers": ["england"],
+      "seed": 42,
+      "minorNationCount": 0
+    },
+    "oldWorld": {
+      "grid": [["p1", "sea1", "p2"], ["p1", "p1", "p2"]],
+      "nodes": [
+        {"id": "p1", "regionId": "oldWorld", "type": "province"},
+        {"id": "p2", "regionId": "oldWorld", "type": "province"},
+        {"id": "sea1", "regionId": "oldWorld", "type": "seaZone"}
+      ],
+      "edges": [{"id1": "p1", "id2": "sea1"}, {"id1": "p1", "id2": "p2"}]
+    }
+  },
+  "setup": {
+    "initialWorkers": {
+      "gp1": { "peasants": 2, "apprentices": 0, "journeymen": 0, "masters": 0 }
+    },
+    "initialStockpile": {
+      "gp1": { "grain": 1, "meat": 0 }
+    }
+  },
+  "turns": [{ "turn": 1, "orders": [] }],
+  "assertions": [
+    { "turn": 1, "player": "gp1", "workerPeasants": 1 },
+    { "turn": 1, "player": "gp1", "commodity": "grain", "stockpileCommodity": 0 }
+  ]
+}

--- a/tool/sim_scenarios/test/sim_scenarios_test.dart
+++ b/tool/sim_scenarios/test/sim_scenarios_test.dart
@@ -160,6 +160,34 @@ void main() {
         expect(scenario.assertions[0].player, 'gp1');
         expect(scenario.assertions[0].capitalProvince, 'oldWorld|p1');
       });
+
+      test('parses setup initialWorkers and initialStockpile', () {
+        final json = {
+          'name': 'workers_setup',
+          'init': {'type': 'fromTopology', 'config': {'greatPowers': ['england']}},
+          'setup': {
+            'initialWorkers': {
+              'gp1': {'peasants': 2, 'apprentices': 0, 'journeymen': 0, 'masters': 0},
+            },
+            'initialStockpile': {
+              'gp1': {'grain': 1, 'meat': 0},
+            },
+          },
+          'turns': [],
+          'assertions': [
+            {'turn': 1, 'player': 'gp1', 'workerPeasants': 1},
+            {'turn': 1, 'player': 'gp1', 'commodity': 'grain', 'stockpileCommodity': 0},
+          ],
+        };
+
+        final scenario = parseScenarioFromJson(json);
+
+        expect(scenario.setup!.initialWorkers!['gp1']!['peasants'], 2);
+        expect(scenario.setup!.initialStockpile!['gp1']!['grain'], 1);
+        expect(scenario.assertions[0].workerPeasants, 1);
+        expect(scenario.assertions[1].commodity, 'grain');
+        expect(scenario.assertions[1].stockpileCommodity, 0);
+      });
     });
 
     group('parseScenarioFile', () {


### PR DESCRIPTION
Adds sim_scenarios support and a scenario for `SPEC/game/workers-and-population.md` (consumption phase: food deduction and starvation order).

**Changes:**
- **SPEC/program/sim-scenarios.md:** Document `setup.initialWorkers` and `setup.initialStockpile` (per-player), and worker-pool / per-commodity stockpile assertions.
- **tool/sim_scenarios:**  
  - ScenarioSetup: `initialWorkers` (player → peasants/apprentices/journeymen/masters), `initialStockpile` (player → commodity quantities).  
  - Assertion: `workerPeasants`, `workerApprentices`, `workerJourneymen`, `workerMasters`, `commodity` + `stockpileCommodity`.  
  - scenario_runner applies overrides after init; state_verifier checks new assertions.
- **Scenario** `workers_consumption_starvation.json`: fromTopology with 1 GP; setup 2 peasants, 1 grain; turn 1 empty orders → after consumption: 1 peasant fed, 1 starves (grain 0, peasants 1). Covers AC: deduction order and starvation (peasants first).
- **gdd-scenario-coverage.json:** `game/workers-and-population.md` → `["workers_consumption_starvation.json"]`.
- Parse test for new setup/assertion fields; report formatting for new assertion types.

**Tests:** `dart test tool/sim_scenarios/` and `dart test packages/colonizethis_logic/` pass. Single-scenario run exits 0.

Made with [Cursor](https://cursor.com)