### PR TITLE
Align AI dossier evidence ordering and cap (Fixes #602)

### DIFF
--- a/SPEC/ai/ai-dossier.md
+++ b/SPEC/ai/ai-dossier.md
@@ -16,7 +16,7 @@ The **dossier** is the player’s intelligence view of another (e.g. AI) nation.
 |---------|----------|--------|
 | **Basic intel** | Visible personality/archetype (e.g. Fortifier), current relation with observer, relative military/economic strength. | Game state, visibility rules. Updated every turn or when relation/strength changes. |
 | **Hidden agenda analysis** | Per-agenda **suspicion score** (0–10+); display band: Unknown, Possible, Likely, Almost certain, Confirmed. Best-guess agenda id and confidence % for display. | Evidence accumulation (see [hidden-agendas.md](hidden-agendas.md)). Updated when evidence is added. |
-| **Evidence list** | Capped, chronological list of evidence entries the observer has seen (e.g. “Declared war on weaker neighbor, Turn 34”). No raw counter; only human-readable summary. | Evidence log for (observerId, subjectId). |
+| **Evidence list** | Capped, chronological list of evidence entries the observer has seen (e.g. “Declared war on weaker neighbor, Turn 34”). No raw counter; only human-readable summary. When new entries would exceed the cap, the system drops the oldest entries so the list remains capped and chronological. | Evidence log for (observerId, subjectId). |
 | **Behavioral notes** | War history (who they declared on, when, outcome), diplomatic pattern (alliances accepted/broken), military buildup (e.g. fort focus). | Derived from game events and visibility. |
 | **Timeline** | Chronological list of notable actions (wars, treaties, visible builds) relevant to dossier. | Same as behavioral notes, optionally more granular. |
 
@@ -47,7 +47,7 @@ Storage:
 
 ## Evidence list cap
 
-- **MVP cap:** The maximum number of evidence entries kept per dossier (per `(observerId, subjectId)` pair) is defined by a program-level constant in `colonizethis_data`. When the list would exceed this cap, the system drops the oldest entries so that the list remains capped and chronological.
+- **MVP cap:** The maximum number of evidence entries kept per dossier (per `(observerId, subjectId)` pair) is defined by a program-level constant in `colonizethis_data` (`kMaxDossierEvidenceEntries`, default `50`). When the list would exceed this cap, the system drops the oldest entries so that the list remains capped and chronological.
 - **Post-MVP ruleset:** Future releases may promote this cap to a ruleset-configurable value (for example per scenario or difficulty). When that happens, this document and the TDD implementation spec (`ai-events-and-dossier.md` § Evidence and Dossier) are the source of truth for how the cap is read and applied.
 
 ---

--- a/SPEC/program/ai-events-and-dossier.md
+++ b/SPEC/program/ai-events-and-dossier.md
@@ -29,6 +29,7 @@ Internal record appended when an action matches an evidence rule. Fields: observ
 2. Storage: per (observer, subject, agenda type) counter + optional (turn, description) list. Deterministic: same actions → same evidence.
 3. Dossier projection: read API returning PlayerView-safe data (basic intel, suspicion levels, evidence list, behavioral notes). True hidden agenda never exposed.
 4. **Confidence % mapping:** Best-guess agenda confidence (display %) is derived from the highest suspicion score for that agenda. Mapping: score 0–2 → 0%; 3–5 → 25%; 6–8 → 60%; 9–10 → 85%; 11+ → 100%. Implementation must use this mapping for consistency with display bands (see [ai-dossier.md](../ai/ai-dossier.md) § PlayerView-safe rules).
+5. **Evidence ordering and cap:** For each `(observerId, subjectId)` pair, dossier evidence entries are sorted by `turn` ascending and then capped to the most recent `kMaxDossierEvidenceEntries` items as defined in `colonizethis_data`. When the list would exceed this cap, the system drops the oldest entries so that both the evidence list and timeline remain capped and chronological.
 
 ## Integration
 

--- a/packages/colonizethis_ai/lib/src/dossier.dart
+++ b/packages/colonizethis_ai/lib/src/dossier.dart
@@ -176,19 +176,22 @@ DossierView getDossierForSubject(
   final entries = game.dossierEvidenceEntries
       .where((e) => e.observerId == observerId && e.subjectId == subjectId)
       .toList();
+  entries.sort((a, b) => a.turnNumber.compareTo(b.turnNumber));
+  final cappedEntries = entries.length > kMaxDossierEvidenceEntries
+      ? entries.sublist(entries.length - kMaxDossierEvidenceEntries)
+      : entries;
   final scoreByAgenda = <String, int>{};
-  for (final e in entries) {
+  for (final e in cappedEntries) {
     scoreByAgenda[e.agendaType] = (scoreByAgenda[e.agendaType] ?? 0) + e.scoreDelta;
   }
   final suspicionByAgendaType = <String, SuspicionBand>{};
   for (final e in scoreByAgenda.entries) {
     suspicionByAgendaType[e.key] = suspicionBandFromScore(e.value);
   }
-  final evidenceList = entries
+  final evidenceList = cappedEntries
       .map((e) => 'Turn ${e.turnNumber}: ${e.description}')
       .toList();
-  entries.sort((a, b) => a.turnNumber.compareTo(b.turnNumber));
-  final timeline = entries
+  final timeline = cappedEntries
       .map((e) => 'Turn ${e.turnNumber}: ${e.description}')
       .toList();
   return DossierView(
@@ -197,7 +200,7 @@ DossierView getDossierForSubject(
     evidenceList: evidenceList,
     basicIntel: _buildBasicIntel(game, observerId, subjectId),
     bestGuessAgenda: _buildBestGuessAgenda(scoreByAgenda),
-    behavioralNotes: _buildBehavioralNotes(entries),
+    behavioralNotes: _buildBehavioralNotes(cappedEntries),
     timeline: timeline,
   );
 }

--- a/packages/colonizethis_ai/test/dossier_test.dart
+++ b/packages/colonizethis_ai/test/dossier_test.dart
@@ -231,5 +231,25 @@ void main() {
       final d = getDossierForSubject(game, 'obs', 'subj');
       expect(d.timeline, ['Turn 2: A', 'Turn 5: B']);
     });
+
+    test('evidence list is chronological and capped to most recent entries', () {
+      const cap = 50; // kMaxDossierEvidenceEntries in colonizethis_data.
+      final entries = <DossierEvidenceEntry>[];
+      for (var turn = 1; turn <= cap + 10; turn++) {
+        entries.add(DossierEvidenceEntry(
+          observerId: 'obs',
+          subjectId: 'subj',
+          agendaType: 'warmonger',
+          turnNumber: turn,
+          description: 'E$turn',
+          scoreDelta: 1,
+        ));
+      }
+      final game = _gameWithEvidence(entries);
+      final d = getDossierForSubject(game, 'obs', 'subj');
+      expect(d.evidenceList.length, cap);
+      expect(d.evidenceList.first, 'Turn 11: E11');
+      expect(d.evidenceList.last, 'Turn 60: E60');
+    });
   });
 }

--- a/packages/colonizethis_data/lib/src/ai_personality_config.dart
+++ b/packages/colonizethis_data/lib/src/ai_personality_config.dart
@@ -124,3 +124,9 @@ const Map<String, String> personalityArchetypeDisplayName = {
 String? getArchetypeDisplayNameForLeader(String leaderId) {
   return personalityArchetypeDisplayName[leaderId];
 }
+
+/// Maximum number of evidence entries kept per dossier (per (observer, subject)).
+/// When the list would exceed this cap, the oldest entries are dropped so that
+/// the evidence list remains capped and chronological.
+/// SPEC/ai/ai-dossier.md § Evidence list cap.
+const int kMaxDossierEvidenceEntries = 50;


### PR DESCRIPTION
## Summary
- Fix  to build the evidence list from a sorted, capped set of evidence entries so evidence is truly chronological and bounded per (observer, subject).
- Introduce  in \ and wire both the GDD () and TDD () to describe ordering and cap behavior.
- Add a unit test to assert that the dossier evidence list is chronological and capped to the most recent entries, keeping behavior aligned with the specs.

## Testing
-  in .


Made with [Cursor](https://cursor.com)