### PR TITLE
GDD scenario coverage: stockpiles-and-production.md

### DIFF
--- a/SPEC/program/sim-scenarios.md
+++ b/SPEC/program/sim-scenarios.md
@@ -67,6 +67,7 @@ For saved games (or after fresh/fromTopology init), optional `setup` block injec
 ```
 - **initialWorkers:** Optional. Map player id → `{ "peasants", "apprentices", "journeymen", "masters" }`. Overrides that player's worker pool before the first turn. Used for consumption/starvation scenarios (SPEC/game/workers-and-population.md).
 - **initialStockpile:** Optional. Map player id → `{ commodityId: quantity, ... }`. Overrides that player's stockpile (replaces) before the first turn. Commodity ids are canonical (e.g. `grain`, `meat`).
+- **productionAssignments:** Optional. List of `{ "recipeId": "<id>", "assignedLabour": <n> }`. Passed to the Production phase for each turn so scenarios can verify SPEC/game/stockpiles-and-production.md (inputs consumed, outputs added to central stockpile). Same list is used for every turn in the scenario. Recipe ids are from the program-level catalog (e.g. `lumber_from_timber`, `castIron_from_timber_iron_coal`).
 
 ---
 

--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -27,7 +27,7 @@
   "game/ruleset-config.md": [],
   "game/ships-and-naval.md": [],
   "game/siege-mechanics.md": [],
-  "game/stockpiles-and-production.md": [],
+  "game/stockpiles-and-production.md": ["stockpiles_production_central.json"],
   "game/tech-and-extraction-cap.md": [],
   "game/tech-tree.md": [],
   "game/tech-tree-diplomacy-civilian.md": [],

--- a/tool/sim_scenarios/lib/scenario.dart
+++ b/tool/sim_scenarios/lib/scenario.dart
@@ -50,6 +50,7 @@ class ScenarioSetup {
     this.stockpileOverrides,
     this.initialWorkers,
     this.initialStockpile,
+    this.productionAssignments,
   });
 
   final List<UnitPlacement>? units;
@@ -58,6 +59,19 @@ class ScenarioSetup {
   final Map<String, Map<String, int>>? initialWorkers;
   /// Player id → { commodityId: quantity }. Replaces player stockpile.
   final Map<String, Map<String, int>>? initialStockpile;
+  /// Recipe assignments for Production phase (each turn). SPEC/game/stockpiles-and-production.md.
+  final List<ProductionAssignment>? productionAssignments;
+}
+
+/// One production assignment: recipe id and labour to assign. Converted to AssignedRecipe in runner.
+class ProductionAssignment {
+  const ProductionAssignment({
+    required this.recipeId,
+    required this.assignedLabour,
+  });
+
+  final String recipeId;
+  final int assignedLabour;
 }
 
 /// Placement of a unit in a province for scenario setup.
@@ -266,7 +280,24 @@ ScenarioSetup _parseScenarioSetup(Map<String, dynamic> json) {
         ?.map((k, v) => MapEntry(k as String, (v as num).toInt())),
     initialWorkers: _parseInitialWorkers(json['initialWorkers']),
     initialStockpile: _parseInitialStockpile(json['initialStockpile']),
+    productionAssignments: _parseProductionAssignments(json['productionAssignments']),
   );
+}
+
+List<ProductionAssignment>? _parseProductionAssignments(dynamic raw) {
+  if (raw is! List<dynamic> || raw.isEmpty) return null;
+  final out = <ProductionAssignment>[];
+  for (final e in raw) {
+    if (e is! Map<String, dynamic>) continue;
+    final recipeId = e['recipeId'] as String?;
+    final labour = e['assignedLabour'];
+    if (recipeId == null || recipeId.isEmpty || labour == null) continue;
+    out.add(ProductionAssignment(
+      recipeId: recipeId,
+      assignedLabour: (labour as num).toInt(),
+    ));
+  }
+  return out.isEmpty ? null : out;
 }
 
 Map<String, Map<String, int>>? _parseInitialWorkers(dynamic raw) {

--- a/tool/sim_scenarios/lib/scenario_runner.dart
+++ b/tool/sim_scenarios/lib/scenario_runner.dart
@@ -120,7 +120,7 @@ class ScenarioRunner {
         final orders = parseOrderCommands(turnScript.orders, currentContext.game);
         
         // Resolve turn (returns updated game)
-        final nextGame = _resolveTurn(currentContext, orders);
+        final nextGame = _resolveTurn(currentContext, orders, scenario);
         currentContext = ScenarioContext(
           game: nextGame,
           topology: currentContext.topology,
@@ -313,12 +313,14 @@ class ScenarioRunner {
   }
 
   /// Resolves one turn and returns the updated game.
-  Game _resolveTurn(ScenarioContext context, Orders orders) {
+  Game _resolveTurn(ScenarioContext context, Orders orders, Scenario scenario) {
     final topology = context.topology;
     if (topology == null) {
       throw StateError('Topology required for turn resolution');
     }
-    
+
+    final defaultAssignments = _productionAssignments(scenario);
+
     final orderEngine = OrderEngine(initialOrders: orders);
     return resolveTurnForGameFromOrderEngine(
       game: context.game,
@@ -326,7 +328,20 @@ class ScenarioRunner {
       orderEngine: orderEngine,
       aiOrders: null,
       tileMapByRegion: context.tileMapByRegion,
+      defaultAssignments: defaultAssignments,
     );
+  }
+
+  /// Converts scenario setup productionAssignments to AssignedRecipe list for resolver.
+  List<AssignedRecipe> _productionAssignments(Scenario scenario) {
+    final list = scenario.setup?.productionAssignments;
+    if (list == null || list.isEmpty) return const [];
+    return list
+        .map((a) => AssignedRecipe(
+              recipeId: a.recipeId,
+              assignedLabour: a.assignedLabour,
+            ))
+        .toList();
   }
 
   List<AssertionResult> _verifyTurnAssertions(

--- a/tool/sim_scenarios/scenarios/stockpiles_production_central.json
+++ b/tool/sim_scenarios/scenarios/stockpiles_production_central.json
@@ -1,0 +1,41 @@
+{
+  "name": "stockpiles_production_central",
+  "description": "SPEC/game/stockpiles-and-production.md: Production phase consumes inputs and labour from central stockpile/WorkerPool and adds recipe output to same stockpile. Given 4 timber, 4 labour (lumber_from_timber), after turn 1: timber 0, lumber 2.",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "greatPowers": ["england"],
+      "seed": 42,
+      "minorNationCount": 0
+    },
+    "oldWorld": {
+      "grid": [["p1", "sea1", "p2"], ["p1", "p1", "p2"]],
+      "nodes": [
+        {"id": "p1", "regionId": "oldWorld", "type": "province"},
+        {"id": "p2", "regionId": "oldWorld", "type": "province"},
+        {"id": "sea1", "regionId": "oldWorld", "type": "seaZone"}
+      ],
+      "edges": [
+        {"id1": "p1", "id2": "sea1"},
+        {"id1": "p1", "id2": "p2"}
+      ]
+    }
+  },
+  "setup": {
+    "initialWorkers": {
+      "gp1": {"peasants": 0, "apprentices": 2, "journeymen": 0, "masters": 0}
+    },
+    "initialStockpile": {
+      "gp1": {"timber": 4, "grain": 4, "lumber": 0}
+    },
+    "productionAssignments": [
+      {"recipeId": "lumber_from_timber", "assignedLabour": 4}
+    ]
+  },
+  "turns": [{"turn": 1, "orders": []}],
+  "assertions": [
+    {"turn": 1, "player": "gp1", "commodity": "timber", "stockpileCommodity": 0},
+    {"turn": 1, "player": "gp1", "commodity": "lumber", "stockpileCommodity": 2},
+    {"turn": 1, "player": "gp1", "workerApprentices": 2}
+  ]
+}

--- a/tool/sim_scenarios/test/sim_scenarios_test.dart
+++ b/tool/sim_scenarios/test/sim_scenarios_test.dart
@@ -188,6 +188,29 @@ void main() {
         expect(scenario.assertions[1].commodity, 'grain');
         expect(scenario.assertions[1].stockpileCommodity, 0);
       });
+
+      test('parses setup productionAssignments', () {
+        final json = {
+          'name': 'production_setup',
+          'init': {'type': 'fromTopology', 'config': {'greatPowers': ['england']}},
+          'setup': {
+            'productionAssignments': [
+              {'recipeId': 'lumber_from_timber', 'assignedLabour': 4},
+              {'recipeId': 'castIron_from_timber_iron_coal', 'assignedLabour': 5},
+            ],
+          },
+          'turns': [],
+          'assertions': [],
+        };
+
+        final scenario = parseScenarioFromJson(json);
+
+        expect(scenario.setup!.productionAssignments!.length, 2);
+        expect(scenario.setup!.productionAssignments![0].recipeId, 'lumber_from_timber');
+        expect(scenario.setup!.productionAssignments![0].assignedLabour, 4);
+        expect(scenario.setup!.productionAssignments![1].recipeId, 'castIron_from_timber_iron_coal');
+        expect(scenario.setup!.productionAssignments![1].assignedLabour, 5);
+      });
     });
 
     group('parseScenarioFile', () {


### PR DESCRIPTION
## Summary
Adds sim_scenarios coverage for `SPEC/game/stockpiles-and-production.md` (central stockpile, Production phase consumes inputs/labour and adds outputs).

## Changes
- **Scenario format:** `setup.productionAssignments` (list of `{ recipeId, assignedLabour }`) so Production phase runs in scenarios; documented in `SPEC/program/sim-scenarios.md`.
- **Scenario** `stockpiles_production_central.json`: one GP, 4 timber + 4 labour (lumber_from_timber) → after turn 1: timber 0, lumber 2; asserts central stockpile behaviour.
- **Coverage mapping:** `game/stockpiles-and-production.md` → `["stockpiles_production_central.json"]`.
- **Tests:** Unit test for `productionAssignments` parsing in `tool/sim_scenarios`.

All 17 scenarios pass (including the new one); `colonizethis_logic` tests pass.

Made with [Cursor](https://cursor.com)