### PR TITLE
TDD: document where hidden agenda assignment is performed (Fixes #567)

### DIFF
--- a/SPEC/program/ai-planner.md
+++ b/SPEC/program/ai-planner.md
@@ -30,6 +30,8 @@ Both AIPlanner and the sim-game default AI share the same simple heuristics core
 ### Phase 6 (Full AI)
 Full hybrid AI in `colonizethis_ai` generates orders via behavior trees, utility AI, and domain planners per [SPEC/ai/](../ai/). Same control rules, seeding, and order merge apply.
 
+**Hidden agenda assignment:** Games using full AI have hidden agendas assigned at setup or init, per [hidden-agendas.md](../ai/hidden-agendas.md). Before the first call to full AI order generation (`generateOrdersForPlayerFullAI`), the caller must invoke `assignHiddenAgendasForGame` (colonizethis_ai) so that `game.hiddenAgendaByGpId` is populated for all AI-controlled GPs. The caller is the game setup pipeline (main game) or the sim controller (ctdev). See [game-setup-pipeline.md](game-setup-pipeline.md) for init flow; ctdev calls assignment when starting a sim game.
+
 ### Order Merge
 Combined human + AI orders into deterministic list for turn resolution:
 - Stable ordering (player id → unit id → order type).
@@ -39,7 +41,7 @@ Combined human + AI orders into deterministic list for turn resolution:
 ## Integration
 
 - **Phase:** AI orders generated before turn resolution each turn.
-- **Upstream:** PlayerView, order suggestion API, game state.
+- **Upstream:** PlayerView, order suggestion API, game state. For Phase 6 full AI: `assignHiddenAgendasForGame` must have been called at setup/init (game setup pipeline or ctdev sim controller) so that hidden agendas are set before first full AI order generation.
 - **Downstream:** Merged orders → TurnResolver.
 - **ctdev:** All GPs are AI-controlled in sim. User chooses Sim Game AI or AI Planner. Turn seed displayed for debugging. AI order history in Orders tab (read-only diagnostic). See [ctdev-app.md](ctdev-app.md).
 
@@ -48,7 +50,7 @@ Combined human + AI orders into deterministic list for turn resolution:
 - **Control rules:** Game state persists per-GP control type; AIPlanner only produces orders for AI-controlled Great Powers; human-controlled units never receive AI orders.
 - **Seeding and determinism:** Per-AI seeds and per-turn `turnSeed` (with documented sub-seeds) are the only randomness inputs; given the same game state and seeds, AIPlanner produces the same strategic and tactical decisions.
 - **Phase 4 behaviour:** Minimal AI uses PlayerView and the order suggestion API with the documented category order and caps; it does not construct raw orders, and Quick Battle actions depend only on `tacticalSeed` and battle state.
-- **Phase 6 delegation:** Full Phase 6 AI delegates order generation to `colonizethis_ai` per [ai-architecture.md](../ai/ai-architecture.md) and [ai-systems-impl.md](ai-systems-impl.md); control rules, seeding, and order merge remain consistent with this spec.
+- **Phase 6 delegation:** Full Phase 6 AI delegates order generation to `colonizethis_ai` per [ai-architecture.md](../ai/ai-architecture.md) and [ai-systems-impl.md](ai-systems-impl.md); control rules, seeding, and order merge remain consistent with this spec. Games using full AI have hidden agendas assigned at setup/init; the caller (game setup or sim controller) invokes `assignHiddenAgendasForGame` before the first `generateOrdersForPlayerFullAI` call.
 - **Order merge:** Merged order list preserves stable ordering (player → unit → type), respects human precedence, emits at most one AI order per unit, and is fully validated and deterministic.
 
 ## Constraints

--- a/SPEC/program/game-setup-pipeline.md
+++ b/SPEC/program/game-setup-pipeline.md
@@ -31,7 +31,7 @@ Steps implement the phases from [game-setup.md](../game/game-setup.md):
    - **7d. Province town assignment** — For each province, set the province's **town** tile: if the province is that faction's capital province, town = capital tile; else town = tile in that province with shortest path (on province tile graph) to (capital if same region, else a port in that province). Store in province (`townTileKey`) or in a region-level map (provinceId → townTileKey). Reference [capital-and-connectivity.md](../game/capital-and-connectivity.md) § Town per province.
    - **7c. Province naming** — Apply naming from active ruleset per [naming.md](../game/naming.md). Applies to all provinces owned at setup; provinces acquired later retain existing display name.
    - **7e. Turn-time mapping** — Set `Game.turnTimeMapping` from the resolved ruleset when present; otherwise default to GDD 01 (`TurnTimeMapping.gdd01`) for MVP. See [turn-time-mapping.md](../game/turn-time-mapping.md) and [ruleset-config.md](ruleset-config.md).
-9. **Persist or pass** — Save via colonizethis_save or hand off to app. Tile maps, topology per region, and warp links are static; store with game or regenerate from seed.
+9. **Persist or pass** — Save via colonizethis_save or hand off to app. Tile maps, topology per region, and warp links are static; store with game or regenerate from seed. When the app or ctdev will use Phase 6 full AI, hidden agenda assignment (`assignHiddenAgendasForGame`) must be performed before the first AI order generation; see [ai-planner.md](ai-planner.md) § Phase 6 (Hidden agenda assignment).
 
 Entry point: `runInitGame(config, options)` in colonizethis_logic. CLI tool: [init-game-tool.md](init-game-tool.md).
 


### PR DESCRIPTION
Fixes #567

- **ai-planner.md:** Phase 6 § Hidden agenda assignment — `assignHiddenAgendasForGame` must be called before first `generateOrdersForPlayerFullAI`; caller is game setup pipeline (main game) or sim controller (ctdev). Integration § Upstream and Phase 6 delegation acceptance criterion updated.
- **game-setup-pipeline.md:** Step 9 (Persist or pass) — cross-ref to ai-planner.md when app/ctdev uses Phase 6 full AI.

Docs-only; no code changes.

Made with [Cursor](https://cursor.com)