### PR TITLE
Quick Battle GDD and TDD: add acceptance criteria sections (Fixes #478)

### DIFF
--- a/SPEC/game/quick-battle.md
+++ b/SPEC/game/quick-battle.md
@@ -115,3 +115,19 @@ The game then applies casualties and province ownership changes using the same w
   When the System checks outcome conditions at the end of each round  
   Then the System ends the battle immediately when the attacker collapse, defender collapse, or mutual exhaustion conditions from this spec are satisfied, computes casualties per side and a final battle result (decisive attacker win, decisive defender hold, or mutual exhaustion), and passes these results into the same province-flip and casualty application pipeline used by auto-resolve.
 
+- Given two Quick Battle runs with the same Quick Battle seed and identical battle context, lane composition, and initial cohesion  
+  When the System runs the Quick Battle resolver for both  
+  Then the System produces the same battle result (ATTACKER, DEFENDER, or MUTUAL_EXHAUSTION), the same per-side casualty counts, and the same provinceFlips value in both runs.
+
+- Given a Quick Battle has completed with a decisive attacker win and the resolver returns provinceFlips true  
+  When the combat pipeline applies the Quick Battle result to the game state  
+  Then the System flips province ownership to the attacker and applies casualties using the same world-state update logic as auto-resolve; given a defender hold or mutual exhaustion result, the System does not flip province ownership.
+
+- Given the System computes lane-level effective combat power for a Quick Battle round  
+  When the System applies terrain modifiers for each lane  
+  Then the System uses the attacker and defender percentage adjustments from the Percentage adjustments to combat power table in this spec (OPEN 100% / 100%, HILL 75% / 120%, WOODS 80% / 110%, TOWN 60% / 130%, SWAMP 70% / 90%).
+
+- Given a Quick Battle round is about to begin and both sides have regiments and optional general medals  
+  When the System determines which side acts first in that round  
+  Then the System computes initiative consistent with [combat.md](combat.md) § Rules (Initiative) (cavalryShare × W_cav + generalMedals × W_medal) and uses that ordering (or tie-break by faction id) to decide first-acting side.
+

--- a/SPEC/program/quick-battle-resolution.md
+++ b/SPEC/program/quick-battle-resolution.md
@@ -52,3 +52,21 @@ The resolver does not decide actions; it applies actions provided by the caller.
 - Must use the same config sources as auto-resolve (no divergence between modes).
 - Does not depend on global singletons; all data supplied or derived from shared config.
 - Owned by colonizethis_logic.
+
+## Acceptance criteria
+
+- Given the same Quick Battle seed and identical inputs (battle context, lanes and groups per side, starting round, max rounds)  
+  When the resolver runs to completion twice  
+  Then the resolver returns the same battle outcome (ATTACKER, DEFENDER, or MUTUAL_EXHAUSTION), the same per-side casualties, the same provinceFlips and attackerRouts/defenderRouts flags, and the same final tactical state (surviving composition, cohesion, lane statuses).
+
+- Given the resolver has completed a Quick Battle run  
+  When the caller inspects the resolver output  
+  Then the output conforms to the Data Model § Output: per-side casualties (by unit type or battalion group), battle outcome, provinceFlips boolean, attackerRouts/defenderRouts booleans, and final tactical state with lane statuses INTACT, BROKEN, or EMPTY.
+
+- Given combat phase invokes Quick Battle as an alternative to auto-resolve for a province  
+  When the resolver returns casualty lists and province-flip flag  
+  Then the combat pipeline applies the result via the same integration point as auto-resolve (e.g. applyQuickBattleResultToGame or equivalent); WorldState mutation is performed by the turn resolver per [turn-resolution-phases.md](turn-resolution-phases.md).
+
+- Given the resolver receives battle context that includes a province id  
+  When the resolver or downstream pipeline applies casualties or province flip for that battle  
+  Then the province id is in prefixed form (`regionId|localId`) and any province lookup follows [world-model-identity.md](../game/world-model-identity.md); the resolver does not look up by province id alone or assume a default region.


### PR DESCRIPTION
Fixes #478

- **SPEC/game/quick-battle.md:** Extended Acceptance criteria with: deterministic outcome for same seed; province flip only when attacker win and provinceFlips true; terrain modifiers per GDD table; initiative ordering consistent with combat.md.
- **SPEC/program/quick-battle-resolution.md:** Added Acceptance criteria section: determinism for given seed, output conformance to Data Model, combat-phase integration, province id per world-model-identity.

Docs-only; aligns with pattern used in combat.md, combat-resolution.md, movement.md.

Made with [Cursor](https://cursor.com)