### PR TITLE
GDD scenario coverage: commodity-catalog.md

### DIFF
--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -3,7 +3,7 @@
   "game/capital-choice-phase.md": ["capital_choice_phase_basic.json"],
   "game/civilian-units.md": ["civilian_units_starting.json"],
   "game/combat.md": ["combat_basic.json"],
-  "game/commodity-catalog.md": [],
+  "game/commodity-catalog.md": ["commodity_riches_to_treasury.json"],
   "game/diplomacy.md": [],
   "game/extraction-and-improvements.md": [],
   "game/factions.md": [],

--- a/tool/sim_scenarios/scenarios/commodity_riches_to_treasury.json
+++ b/tool/sim_scenarios/scenarios/commodity_riches_to_treasury.json
@@ -1,0 +1,39 @@
+{
+  "name": "commodity_riches_to_treasury",
+  "description": "SPEC/game/commodity-catalog.md: Riches-to-treasury phase converts spices in stockpile to treasury at fixed base price 50; riches removed from stockpile.",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "greatPowers": ["england"],
+      "seed": 42,
+      "minorNationCount": 0
+    },
+    "oldWorld": {
+      "grid": [["p1", "sea1", "p2"], ["p1", "p1", "p2"]],
+      "nodes": [
+        {"id": "p1", "regionId": "oldWorld", "type": "province"},
+        {"id": "p2", "regionId": "oldWorld", "type": "province"},
+        {"id": "sea1", "regionId": "oldWorld", "type": "seaZone"}
+      ],
+      "edges": [
+        {"id1": "p1", "id2": "sea1"},
+        {"id1": "p1", "id2": "p2"}
+      ]
+    }
+  },
+  "setup": {
+    "initialWorkers": {
+      "gp1": {"peasants": 0, "apprentices": 0, "journeymen": 0, "masters": 0}
+    },
+    "initialStockpile": {
+      "gp1": {"spices": 4, "grain": 0}
+    }
+  },
+  "turns": [
+    {"turn": 1, "orders": []}
+  ],
+  "assertions": [
+    {"turn": 1, "player": "gp1", "commodity": "spices", "stockpileCommodity": 0},
+    {"turn": 1, "player": "gp1", "treasury": 5200}
+  ]
+}


### PR DESCRIPTION
Adds sim_scenarios coverage for `SPEC/game/commodity-catalog.md` (riches-to-treasury AC).

- **Scenario:** `commodity_riches_to_treasury.json` — fromTopology init with one GP, setup `initialStockpile` gp1 spices: 4, run turn 1; assertions: spices stockpile 0, treasury 5200 (riches-to-treasury at fixed base price 50).
- **Mapping:** `gdd-scenario-coverage.json` entry for `game/commodity-catalog.md` set to `["commodity_riches_to_treasury.json"]`.

All 18 sim_scenarios pass; `check_gdd_coverage` reports 10 covered (commodity-catalog now covered).

Made with [Cursor](https://cursor.com)