### PR TITLE
GDD scenario coverage: world-model-identity.md

### DIFF
--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -42,5 +42,5 @@
   "game/victory.md": [],
   "game/workers-and-population.md": ["workers_consumption_starvation.json"],
   "game/world-model.md": [],
-  "game/world-model-identity.md": []
+  "game/world-model-identity.md": ["world_model_identity_prefixed_provinces.json"]
 }

--- a/tool/sim_scenarios/scenarios/world_model_identity_prefixed_provinces.json
+++ b/tool/sim_scenarios/scenarios/world_model_identity_prefixed_provinces.json
@@ -1,0 +1,35 @@
+{
+  "name": "world_model_identity_prefixed_provinces",
+  "description": "SPEC/game/world-model-identity.md: Province ids use prefixed form (regionId|localId). Given OW and NW each with a province, assertions use full id oldWorld|p1 and newWorld|p2; capital and owner checks verify no bare province id.",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "greatPowers": ["england"],
+      "seed": 42,
+      "minorNationCount": 0,
+      "tribeCount": 1
+    },
+    "oldWorld": {
+      "grid": [["p1", "sea1"], ["p1", "p1"]],
+      "nodes": [
+        {"id": "p1", "regionId": "oldWorld", "type": "province"},
+        {"id": "sea1", "regionId": "oldWorld", "type": "seaZone"}
+      ],
+      "edges": [{"id1": "p1", "id2": "sea1"}]
+    },
+    "newWorld": {
+      "grid": [["p1", "sea2"], ["p1", "p1"]],
+      "nodes": [
+        {"id": "p1", "regionId": "newWorld", "type": "province"},
+        {"id": "sea2", "regionId": "newWorld", "type": "seaZone"}
+      ],
+      "edges": [{"id1": "p1", "id2": "sea2"}]
+    }
+  },
+  "turns": [{"turn": 1, "orders": []}],
+  "assertions": [
+    {"turn": 1, "province": "oldWorld|p1", "owner": "gp1"},
+    {"turn": 1, "province": "newWorld|p1", "owner": "tribe1"},
+    {"turn": 1, "player": "gp1", "capitalProvince": "oldWorld|p1"}
+  ]
+}


### PR DESCRIPTION
Adds sim_scenario coverage for `SPEC/game/world-model-identity.md`.

**Scenario:** `world_model_identity_prefixed_provinces.json`
- **Given:** fromTopology init with Old World and New World, each with a province (local id `p1`).
- **When:** Turn 1 runs (no orders).
- **Then:** Province ownership and GP capital are asserted using **prefixed** province ids (`oldWorld|p1`, `newWorld|p1`) per world-model-identity.md (no bare province id).

**Coverage:** `game/world-model-identity.md` linked in `gdd-scenario-coverage.json`.

**Checks:** All 19 sim_scenarios pass; `colonizethis_logic` and `tool/sim_scenarios` unit tests pass.

Made with [Cursor](https://cursor.com)