### PR TITLE
GDD scenario coverage: civilian-units.md (replaces #630)

### DIFF
--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -1,7 +1,7 @@
 {
   "game/capital-and-connectivity.md": ["capital_and_connectivity_init.json"],
   "game/capital-choice-phase.md": ["capital_choice_phase_basic.json"],
-  "game/civilian-units.md": ["civilian_units_starting.json"],
+  "game/civilian-units.md": ["civilian_units_basic.json", "civilian_units_starting.json"],
   "game/combat.md": ["combat_basic.json"],
   "game/commodity-catalog.md": ["commodity_riches_to_treasury.json"],
   "game/diplomacy.md": [],

--- a/tool/sim_scenarios/scenarios/civilian_units_basic.json
+++ b/tool/sim_scenarios/scenarios/civilian_units_basic.json
@@ -1,0 +1,24 @@
+{
+  "name": "civilian_units_basic",
+  "description": "Covers SPEC/game/civilian-units.md: verifies that after fresh init GPs have civilian units in their capital (default starting civilians: Explorer, Builder, Engineer). Province identity uses prefixed id.",
+  "init": {
+    "type": "fresh",
+    "config": {
+      "seed": 42,
+      "greatPowers": ["england", "france"],
+      "continentCount": 4,
+      "minorNationCount": 6,
+      "tribeCount": 10
+    }
+  },
+  "turns": [
+    {
+      "turn": 1,
+      "orders": []
+    }
+  ],
+  "assertions": [
+    {"turn": 1, "province": "oldWorld|p1", "owner": "gp1"},
+    {"turn": 1, "province": "oldWorld|p1", "hasPlayerUnits": "gp1", "unitCount": 5}
+  ]
+}


### PR DESCRIPTION
Adds GDD scenario coverage for `SPEC/game/civilian-units.md`:

- **civilian_units_basic.json**: fresh init, asserts gp1 capital (oldWorld|p1) owner and 5 starting civilian units (Explorer, Builder, Engineer per GDD). Province identity uses prefixed id.
- **gdd-scenario-coverage.json**: `game/civilian-units.md` lists both `civilian_units_basic.json` and `civilian_units_starting.json`.

Branch is based on current `dev`; no merge conflicts. Supersedes PR #630.

Made with [Cursor](https://cursor.com)