### PR TITLE
GDD scenario coverage: diplomacy.md (initial GP–GP relations)

### DIFF
--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -4,7 +4,7 @@
   "game/civilian-units.md": ["civilian_units_starting.json"],
   "game/combat.md": ["combat_basic.json"],
   "game/commodity-catalog.md": ["commodity_riches_to_treasury.json"],
-  "game/diplomacy.md": [],
+  "game/diplomacy.md": ["diplomacy_initial_relations.json"],
   "game/extraction-and-improvements.md": [],
   "game/factions.md": [],
   "game/fog-and-exploration.md": [],

--- a/packages/colonizethis_logic/lib/src/setup/game_setup.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup.dart
@@ -221,6 +221,9 @@ GameSetupResult createGameFromGeneratedMaps({
     namingSeed: namingSeed ?? config.seed,
   );
 
+  // Initial GP–GP relations per SPEC/game/diplomacy.md: AT_PEACE, score 50, Neutral, sinceTurn/lastInteractionTurn 0.
+  game = _applyInitialGpGpDiplomacy(game: game);
+
   // Spawn starting units for each Great Power in their capital provinces.
   game = _addStartingUnits(game: game, config: config);
 
@@ -278,6 +281,31 @@ List<String> _provinceIdsFromTopology(MapTopology topology) {
       .where((n) => n.type == TopologyNodeType.province)
       .map((n) => n.id)
       .toList();
+}
+
+/// Initial GP–GP relations per SPEC/game/diplomacy.md: each unordered GP pair
+/// AT_PEACE, score 50, Neutral, sinceTurn 0, lastInteractionTurn 0.
+Game _applyInitialGpGpDiplomacy({required Game game}) {
+  final gpIds = game.players.map((p) => p.id).toList();
+  if (gpIds.length < 2) return game;
+  final relations = <DiplomacyRelation>[];
+  for (var i = 0; i < gpIds.length; i++) {
+    for (var j = i + 1; j < gpIds.length; j++) {
+      final a = gpIds[i];
+      final b = gpIds[j];
+      final (id1, id2) = a.compareTo(b) <= 0 ? (a, b) : (b, a);
+      relations.add(DiplomacyRelation(
+        factionId1: id1,
+        factionId2: id2,
+        score: 50,
+        level: RelationLevel.neutral,
+        state: RelationState.atPeace,
+        sinceTurn: 0,
+        lastInteractionTurn: 0,
+      ));
+    }
+  }
+  return game.copyWith(diplomacyRelations: relations);
 }
 
 Game _applyInitialVisibility({

--- a/tool/sim_scenarios/scenarios/diplomacy_initial_relations.json
+++ b/tool/sim_scenarios/scenarios/diplomacy_initial_relations.json
@@ -1,0 +1,18 @@
+{
+  "name": "diplomacy_initial_relations",
+  "description": "SPEC/game/diplomacy.md: Given a new game with at least two Great Powers, when the system initializes diplomatic relations at turn index 0, then each unordered GP pair has relation state atPeace, relation score 50, relation level neutral, sinceTurn 0, lastInteractionTurn 0.",
+  "init": {
+    "type": "fresh",
+    "config": {
+      "seed": 42,
+      "greatPowers": ["england", "france"],
+      "continentCount": 4,
+      "minorNationCount": 0,
+      "tribeCount": 0
+    }
+  },
+  "turns": [{"turn": 1, "orders": []}],
+  "assertions": [
+    {"turn": 1, "player": "gp1", "relationWith": "gp2", "relationState": "atPeace", "relationScore": 50, "relationLevel": "neutral", "relationSinceTurn": 0, "relationLastInteractionTurn": 0}
+  ]
+}


### PR DESCRIPTION
## Summary
- **Initialize GP–GP diplomacy relations in game setup** per SPEC/game/diplomacy.md first AC: when the system initializes diplomatic relations at turn index 0, each unordered Great Power pair is set to relation state `AT_PEACE`, relation score `50`, relation level `Neutral`, `sinceTurn = 0`, `lastInteractionTurn = 0`.
- **Add scenario** `diplomacy_initial_relations.json`: fresh init with two GPs (england, france), no minors/tribes; assert gp1–gp2 relation state, score, level, sinceTurn, lastInteractionTurn after turn 1.
- **Coverage mapping**: `game/diplomacy.md` → `["diplomacy_initial_relations.json"]` in `SPEC/project/gdd-scenario-coverage.json`.

## Tests
- All 19 sim_scenarios pass (including `diplomacy_initial_relations`).
- `colonizethis_logic` tests pass.
- Coverage tool: diplomacy.md is covered (11 covered specs total).

Made with [Cursor](https://cursor.com)