### PR TITLE
GDD scenario coverage: capital-choice-phase.md (replaces #633)

### DIFF
--- a/SPEC/program/sim-scenarios.md
+++ b/SPEC/program/sim-scenarios.md
@@ -124,6 +124,7 @@ Assertion fields:
 
 **Capital assertions** (SPEC/game/capital-choice-phase.md):
 - Use `player` (Great Power id, e.g. `gp1`) with `capitalProvince` — expected full province id (e.g. `oldWorld|p1`) for that player’s capital. Verifies the capital-choice phase selected the expected province.
+- `player` (faction id: `gp1`, `minor1`, `tribe1`, etc.) + `capitalProvinceId` — the faction's capital province must equal this full province id (e.g. `oldWorld|p1`). Optional `capitalTileKey` — the faction's capital tile must equal this key (format `regionId|provinceId|x|y`). Example: `{"turn": 1, "player": "gp1", "capitalProvinceId": "oldWorld|p1", "capitalTileKey": "oldWorld|p1|0|0"}`.
 
 **Diplomacy assertions** (SPEC/game/diplomacy.md):
 - Use `player` for the first faction (typically a Great Power) and `relationWith` for the other faction id.

--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -1,6 +1,6 @@
 {
   "game/capital-and-connectivity.md": ["capital_and_connectivity_init.json"],
-  "game/capital-choice-phase.md": ["capital_choice_phase_basic.json"],
+  "game/capital-choice-phase.md": ["capital_choice_phase_basic.json", "capital_choice_gp_seabound.json", "capital_choice_tribe_inland.json"],
   "game/civilian-units.md": ["civilian_units_starting.json"],
   "game/combat.md": ["combat_basic.json"],
   "game/commodity-catalog.md": ["commodity_riches_to_treasury.json"],

--- a/tool/sim_scenarios/lib/scenario.dart
+++ b/tool/sim_scenarios/lib/scenario.dart
@@ -166,6 +166,8 @@ class Assertion {
     this.resource,
     this.maxBothFraction,
     this.everyTileResourceAllowedInRegion,
+    this.capitalProvinceId,
+    this.capitalTileKey,
     this.relationWith,
     this.relationState,
     this.relationScore,
@@ -218,6 +220,10 @@ class Assertion {
   final String? overtureStage;
   /// Capital province for [player] (Great Power). Full province id, e.g. oldWorld|p1. SPEC/game/capital-choice-phase.md.
   final String? capitalProvince;
+  /// Capital assertion: expected capital province id (full id, e.g. oldWorld|p1). Used with player (faction id).
+  final String? capitalProvinceId;
+  /// Capital assertion: expected capital tile key (regionId|provinceId|x|y). Optional.
+  final String? capitalTileKey;
   /// Worker pool assertions (SPEC/game/workers-and-population.md). Require [player].
   final int? workerPeasants;
   final int? workerApprentices;
@@ -385,6 +391,8 @@ Assertion _parseAssertion(Map<String, dynamic> json) {
     resource: json['resource'] as String?,
     maxBothFraction: (json['maxBothFraction'] as num?)?.toDouble(),
     everyTileResourceAllowedInRegion: json['everyTileResourceAllowedInRegion'] as bool?,
+    capitalProvinceId: json['capitalProvinceId'] as String?,
+    capitalTileKey: json['capitalTileKey'] as String?,
     relationWith: json['relationWith'] as String?,
     relationState: json['relationState'] as String?,
     relationScore: json['relationScore'] as int?,

--- a/tool/sim_scenarios/lib/state_verifier.dart
+++ b/tool/sim_scenarios/lib/state_verifier.dart
@@ -148,8 +148,50 @@ class StateVerifier {
       }
     }
 
-    // Player-based assertions (stockpile, treasury, diplomacy)
-    if (assertion.player != null) {
+    // Capital assertions (player/minor/tribe faction id + capitalProvinceId / capitalTileKey)
+    if (assertion.player != null &&
+        (assertion.capitalProvinceId != null || assertion.capitalTileKey != null)) {
+      final factionId = assertion.player!;
+      String? actualProvinceId;
+      String? actualTileKey;
+      if (game.players.any((p) => p.id == factionId)) {
+        final p = game.players.firstWhere((x) => x.id == factionId);
+        actualProvinceId = p.capitalProvinceId;
+        actualTileKey = p.capitalTile?.toTileKey();
+      } else if (game.minorNations.any((m) => m.id == factionId)) {
+        final m = game.minorNations.firstWhere((x) => x.id == factionId);
+        actualProvinceId = m.capitalProvinceId;
+        actualTileKey = m.capitalTile?.toTileKey();
+      } else if (game.tribes.any((t) => t.id == factionId)) {
+        final t = game.tribes.firstWhere((x) => x.id == factionId);
+        actualProvinceId = t.capitalProvinceId;
+        actualTileKey = t.capitalTile?.toTileKey();
+      } else {
+        failures.add('Faction "$factionId" not found (players, minorNations, tribes)');
+      }
+      if (actualProvinceId != null || actualTileKey != null) {
+        if (assertion.capitalProvinceId != null &&
+            actualProvinceId != assertion.capitalProvinceId) {
+          failures.add(
+            'Faction $factionId: expected capitalProvinceId "${assertion.capitalProvinceId}", got "$actualProvinceId"',
+          );
+        }
+        if (assertion.capitalTileKey != null &&
+            actualTileKey != assertion.capitalTileKey) {
+          failures.add(
+            'Faction $factionId: expected capitalTileKey "${assertion.capitalTileKey}", got "$actualTileKey"',
+          );
+        }
+      } else if (assertion.capitalProvinceId != null || assertion.capitalTileKey != null) {
+        failures.add(
+          'Faction $factionId: expected capital but capitalProvinceId/capitalTile are null',
+        );
+      }
+    }
+
+    // Player-based assertions (stockpile, treasury, diplomacy) — only for game.players
+    if (assertion.player != null &&
+        (assertion.stockpile != null || assertion.treasury != null)) {
       final player = game.players.firstWhere(
         (p) => p.id == assertion.player,
         orElse: () => throw StateError('Player ${assertion.player} not found'),

--- a/tool/sim_scenarios/scenarios/capital_choice_gp_seabound.json
+++ b/tool/sim_scenarios/scenarios/capital_choice_gp_seabound.json
@@ -1,0 +1,30 @@
+{
+  "name": "capital_choice_gp_seabound",
+  "description": "Capital choice phase (SPEC/game/capital-choice-phase.md): Great Power with one sea-bound province; system selects that province as capital and first Class A tile (coastal, no foreign border) in row-major order.",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "greatPowers": ["england"],
+      "seed": 42,
+      "minorNationCount": 0
+    },
+    "oldWorld": {
+      "grid": [
+        ["p1", "p1"],
+        ["p1", "sea1"]
+      ],
+      "nodes": [
+        {"id": "p1", "regionId": "oldWorld", "type": "province"},
+        {"id": "sea1", "regionId": "oldWorld", "type": "seaZone"}
+      ],
+      "edges": [
+        {"id1": "p1", "id2": "sea1"}
+      ]
+    }
+  },
+  "turns": [{"turn": 1, "orders": []}],
+  "assertions": [
+    {"turn": 1, "province": "oldWorld|p1", "owner": "gp1"},
+    {"turn": 1, "player": "gp1", "capitalProvinceId": "oldWorld|p1", "capitalTileKey": "oldWorld|p1|1|0"}
+  ]
+}

--- a/tool/sim_scenarios/scenarios/capital_choice_tribe_inland.json
+++ b/tool/sim_scenarios/scenarios/capital_choice_tribe_inland.json
@@ -1,0 +1,39 @@
+{
+  "name": "capital_choice_tribe_inland",
+  "description": "Capital choice phase (SPEC/game/capital-choice-phase.md): Tribe with no sea-bound province; system selects first inland owned province by sorted id and does not apply port/road.",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "greatPowers": ["england"],
+      "seed": 42,
+      "minorNationCount": 0,
+      "tribeCount": 1
+    },
+    "oldWorld": {
+      "grid": [
+        ["p1", "sea1"],
+        ["p1", "p1"]
+      ],
+      "nodes": [
+        {"id": "p1", "regionId": "oldWorld", "type": "province"},
+        {"id": "sea1", "regionId": "oldWorld", "type": "seaZone"}
+      ],
+      "edges": [
+        {"id1": "p1", "id2": "sea1"}
+      ]
+    },
+    "newWorld": {
+      "grid": [["p2"]],
+      "nodes": [
+        {"id": "p2", "regionId": "newWorld", "type": "province"}
+      ],
+      "edges": []
+    }
+  },
+  "turns": [{"turn": 1, "orders": []}],
+  "assertions": [
+    {"turn": 1, "province": "oldWorld|p1", "owner": "gp1"},
+    {"turn": 1, "province": "newWorld|p2", "owner": "tribe1"},
+    {"turn": 1, "player": "tribe1", "capitalProvinceId": "newWorld|p2", "capitalTileKey": "newWorld|p2|0|0"}
+  ]
+}

--- a/tool/sim_scenarios/test/sim_scenarios_test.dart
+++ b/tool/sim_scenarios/test/sim_scenarios_test.dart
@@ -161,6 +161,27 @@ void main() {
         expect(scenario.assertions[0].capitalProvince, 'oldWorld|p1');
       });
 
+      test('parses capital assertions', () {
+        final json = {
+          'name': 'capital_assertions',
+          'init': {'type': 'fresh', 'config': {'seed': 42}},
+          'turns': [],
+          'assertions': [
+            {'turn': 1, 'player': 'gp1', 'capitalProvinceId': 'oldWorld|p1', 'capitalTileKey': 'oldWorld|p1|0|0'},
+            {'turn': 1, 'player': 'tribe1', 'capitalProvinceId': 'newWorld|p2'},
+          ],
+        };
+
+        final scenario = parseScenarioFromJson(json);
+
+        expect(scenario.assertions[0].player, 'gp1');
+        expect(scenario.assertions[0].capitalProvinceId, 'oldWorld|p1');
+        expect(scenario.assertions[0].capitalTileKey, 'oldWorld|p1|0|0');
+        expect(scenario.assertions[1].player, 'tribe1');
+        expect(scenario.assertions[1].capitalProvinceId, 'newWorld|p2');
+        expect(scenario.assertions[1].capitalTileKey, isNull);
+      });
+
       test('parses setup initialWorkers and initialStockpile', () {
         final json = {
           'name': 'workers_setup',


### PR DESCRIPTION
Adds sim_scenarios coverage for `SPEC/game/capital-choice-phase.md`.

**Changes:**
- **Capital assertions** in sim_scenarios: `player` (faction id: gp1, minor1, tribe1) + `capitalProvinceId` and optional `capitalTileKey`. Documented in SPEC/program/sim-scenarios.md; implemented in scenario.dart and state_verifier.dart.
- **capital_choice_gp_seabound.json**: fromTopology, 1 GP, one sea-bound OW province; asserts gp1 capital province and first Class A tile (coastal, no foreign border).
- **capital_choice_tribe_inland.json**: fromTopology, 1 GP (OW) + 1 tribe (NW with no sea); asserts tribe1 capital on inland province and capital tile.
- **gdd-scenario-coverage.json**: `game/capital-choice-phase.md` lists capital_choice_phase_basic, capital_choice_gp_seabound, capital_choice_tribe_inland.
- Unit test for parsing capital assertions.

Branch is based on latest `dev`; no merge conflicts. Supersedes PR #633.

Made with [Cursor](https://cursor.com)