### PR TITLE
Turn-resolution-phases TDD: add acceptance criteria section

### DIFF
--- a/SPEC/program/turn-resolution-phases.md
+++ b/SPEC/program/turn-resolution-phases.md
@@ -32,3 +32,12 @@ Extraction → riches to treasury → production → consumption **must** run be
 ## Determinism
 
 Same TurnResolver and phase order used in main game and ctdev sim_game; identical development and exploration rules for reproducible simulations.
+
+---
+
+## Acceptance criteria
+
+- **Phase sequence:** Given any run of TurnResolver, the system executes exactly the phases 1–12 above in that order (Orders → Diplomacy → Extraction → Riches to treasury → Production → Consumption → Research → Movement → Naval Interception & Naval Combat → Combat → Build / work → End-of-turn). No phase is skipped or reordered; no additional phases mutate game state between these steps.
+- **Dependency order:** Extraction runs before Riches to treasury; Riches to treasury before Production; Production before Consumption. Extraction through Consumption complete before Movement and before Build / work. Research runs after Consumption so treasury is current. Build vs Movement relative order is implementation-defined subject to that constraint. Given a resolver run, the system does not apply extraction/riches/production/consumption effects after movement or build has started.
+- **Determinism:** Given the same starting WorldState, merged orders, ruleset, and random seeds, TurnResolver produces the same resulting WorldState (and victory state) in main game and in ctdev sim_game; phase order is identical in both.
+- **Implementation contract:** Per-phase behaviour is specified in [turn-resolution-phase-details.md](turn-resolution-phase-details.md); this document is the single source of truth for phase sequence and ordering. Tests may assert phase order and dependency rules by inspecting resolver behaviour or by comparing outcomes across runs.


### PR DESCRIPTION
Fixes #401

Adds § Acceptance criteria to SPEC/program/turn-resolution-phases.md:
- Phase sequence (fixed order 1–12)
- Dependency order (extraction→riches→production→consumption before movement/build; research after consumption)
- Determinism (same resolver/order and outcome in main game and ctdev)
- Implementation contract (cross-ref to turn-resolution-phase-details.md, single source of truth for sequence)

Made with [Cursor](https://cursor.com)