### PR TITLE
Diplomacy: document where relation thresholds and overture costs are defined (Fixes #474)

### DIFF
--- a/SPEC/game/diplomacy.md
+++ b/SPEC/game/diplomacy.md
@@ -101,6 +101,10 @@ The following Given–When–Then criteria are testable conditions for diplomacy
 | Consulate cost | £500 | |
 | Embassy cost | £1000 | |
 
+### Where defined (MVP)
+
+Default values for the parameters above are given in this table; the table is the **source of truth** for design defaults. In the current (MVP) implementation, the program does **not** read these from the ruleset. Relation thresholds (Hostile/Neutral/Friendly/Allied bands) and overture costs (Consulate, Embassy) are implemented as **code constants** in `colonizethis_logic` (see `diplomacy_resolver.dart`: `overtureConsulateCost`, `overtureEmbassyCost`, and the thresholds used in `scoreToLevel`). Ruleset-driven override for diplomacy parameters is **deferred**; when added, the key path and loader contract will be specified in this document and in [ruleset-config.md](ruleset-config.md); program loading: [ruleset-config.md](../program/ruleset-config.md).
+
 ---
 
 ## Interactions

--- a/SPEC/program/diplomacy-resolution.md
+++ b/SPEC/program/diplomacy-resolution.md
@@ -73,6 +73,12 @@ Rejections and validation failures are logged by the order engine; diplomacy res
 
 ---
 
+## Config source (MVP)
+
+Relation thresholds (score-to-level bands) and overture costs (Consulate £500, Embassy £1000) are currently **code constants** in the diplomacy resolver (`colonizethis_logic`: `overtureConsulateCost`, `overtureEmbassyCost`, `scoreToLevel`). The **default values** are defined in [diplomacy.md](../game/diplomacy.md) § Configurable Values; that table is the source of truth for design. Ruleset loading for these parameters is **not implemented** in MVP. When ruleset-driven config is added, the resolver will read from the resolved ruleset per [ruleset-config.md](ruleset-config.md) and the key path will be specified in the GDD and here.
+
+---
+
 ## Constraints
 
 - All diplomatic rules (relation thresholds, overture chain, order preconditions) are defined in game/diplomacy.md; this module references, not restates, them.


### PR DESCRIPTION
Fixes #474

**Specs:** SPEC/game/diplomacy.md, SPEC/program/diplomacy-resolution.md

- **GDD:** Added § Where defined (MVP) under Configurable Values: table remains source of truth for default values; implementation currently uses code constants in `colonizethis_logic` (`diplomacy_resolver.dart`); ruleset override deferred with cross-ref to ruleset-config when added.
- **TDD:** Added § Config source (MVP): relation thresholds and overture costs are code constants in the resolver; default values from game/diplomacy.md; ruleset loading not in MVP; future key path to be specified here and in GDD.

Docs-only; no code changes.

Made with [Cursor](https://cursor.com)