### PR TITLE
GDD scenario coverage: extraction-and-improvements.md

### DIFF
--- a/SPEC/program/sim-scenarios.md
+++ b/SPEC/program/sim-scenarios.md
@@ -47,7 +47,7 @@ Two initialization types:
 }
 ```
 
-**From-topology (connectivity scenarios)** — Builds game from a fixed Old World (and optional New World) topology and grid. Used for connectivity and capital assertions. `init.type`: `"fromTopology"`. `init.config`: optional `greatPowers`, `seed`, `tribeCount` (for NW). `init.oldWorld` / `init.newWorld`: `{ "grid": [[...]], "nodes": [...], "edges": [...] }`. **Behaviour:** No Minor Nations (minor count and min provinces per minor are forced to 0) so that province assignment only assigns to Great Powers and, when present, Tribes on the New World. Aligns with [game-setup.md](../game/game-setup.md) (config from scenario).
+**From-topology (connectivity scenarios)** — Builds game from a fixed Old World (and optional New World) topology and grid. Used for connectivity and capital assertions. `init.type`: `"fromTopology"`. `init.config`: optional `greatPowers`, `seed`, `tribeCount` (for NW). `init.oldWorld` / `init.newWorld`: `{ "grid": [[...]], "nodes": [...], "edges": [...] }`. Optional **resourceGrid**: same dimensions as grid; each cell is a resource name (e.g. `"grain"`) or null; used for extraction scenarios (SPEC/game/extraction-and-improvements.md). **Behaviour:** No Minor Nations (minor count and min provinces per minor are forced to 0) so that province assignment only assigns to Great Powers and, when present, Tribes on the New World. Aligns with [game-setup.md](../game/game-setup.md) (config from scenario).
 
 For saved games (or after fresh/fromTopology init), optional `setup` block injects units and can override player economy for specific test scenarios:
 ```json
@@ -68,6 +68,7 @@ For saved games (or after fresh/fromTopology init), optional `setup` block injec
 - **initialWorkers:** Optional. Map player id → `{ "peasants", "apprentices", "journeymen", "masters" }`. Overrides that player's worker pool before the first turn. Used for consumption/starvation scenarios (SPEC/game/workers-and-population.md).
 - **initialStockpile:** Optional. Map player id → `{ commodityId: quantity, ... }`. Overrides that player's stockpile (replaces) before the first turn. Commodity ids are canonical (e.g. `grain`, `meat`).
 - **productionAssignments:** Optional. List of `{ "recipeId": "<id>", "assignedLabour": <n> }`. Passed to the Production phase for each turn so scenarios can verify SPEC/game/stockpiles-and-production.md (inputs consumed, outputs added to central stockpile). Same list is used for every turn in the scenario. Recipe ids are from the program-level catalog (e.g. `lumber_from_timber`, `castIron_from_timber_iron_coal`).
+- **initialTileState:** Optional. Map tile key (e.g. `"oldWorld|p1|0|0"`) → `{ "improvementLevel": 0–4, "roadLevel": 0|1|2|4 }`. Applied to `worldState.tileState` before the first turn. Used for extraction scenarios (SPEC/game/extraction-and-improvements.md).
 
 ---
 

--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -5,7 +5,7 @@
   "game/combat.md": ["combat_basic.json"],
   "game/commodity-catalog.md": ["commodity_riches_to_treasury.json"],
   "game/diplomacy.md": ["diplomacy_initial_relations.json", "diplomacy_gp_gp_war_and_mutual_peace.json"],
-  "game/extraction-and-improvements.md": [],
+  "game/extraction-and-improvements.md": ["extraction_basic.json"],
   "game/factions.md": [],
   "game/fog-and-exploration.md": [],
   "game/game-setup.md": ["basic_turn_1.json"],

--- a/tool/sim_scenarios/lib/game_factory.dart
+++ b/tool/sim_scenarios/lib/game_factory.dart
@@ -151,7 +151,28 @@ class GameFactory {
         .toList();
     final height = grid.length;
     final width = height > 0 ? grid[0].length : 0;
-    return TileMapResult(width: width, height: height, grid: grid);
+
+    List<List<Resource?>>? resourceGrid;
+    final rg = json['resourceGrid'] as List<dynamic>?;
+    if (rg != null && rg.length == height) {
+      resourceGrid = rg
+          .map((row) => (row as List<dynamic>)
+              .map((e) => e == null || e == ''
+                  ? null
+                  : Resource.values.byName(e as String))
+              .toList())
+          .toList();
+      if (resourceGrid!.any((row) => row.length != width)) {
+        resourceGrid = null;
+      }
+    }
+
+    return TileMapResult(
+      width: width,
+      height: height,
+      grid: grid,
+      resourceGrid: resourceGrid,
+    );
   }
 
   /// Loads a saved game by ID.

--- a/tool/sim_scenarios/lib/scenario.dart
+++ b/tool/sim_scenarios/lib/scenario.dart
@@ -44,6 +44,7 @@ class ScenarioInit {
 
 /// Setup for saved-game scenarios (unit injection, resource overrides).
 /// initialWorkers / initialStockpile apply after init (fresh or fromTopology).
+/// initialTileState: tileKey → { improvementLevel, roadLevel } for extraction scenarios. SPEC/game/extraction-and-improvements.md.
 class ScenarioSetup {
   const ScenarioSetup({
     this.units,
@@ -51,6 +52,7 @@ class ScenarioSetup {
     this.initialWorkers,
     this.initialStockpile,
     this.productionAssignments,
+    this.initialTileState,
   });
 
   final List<UnitPlacement>? units;
@@ -61,6 +63,8 @@ class ScenarioSetup {
   final Map<String, Map<String, int>>? initialStockpile;
   /// Recipe assignments for Production phase (each turn). SPEC/game/stockpiles-and-production.md.
   final List<ProductionAssignment>? productionAssignments;
+  /// Tile key → { improvementLevel: 0-4, roadLevel: 0|1|2|4 }. Applied to worldState.tileState for extraction scenarios.
+  final Map<String, Map<String, int>>? initialTileState;
 }
 
 /// One production assignment: recipe id and labour to assign. Converted to AssignedRecipe in runner.
@@ -331,6 +335,22 @@ ScenarioSetup _parseScenarioSetup(Map<String, dynamic> json) {
     return result.isEmpty ? null : result;
   }
 
+  Map<String, Map<String, int>>? _parseInitialTileState(dynamic raw) {
+    if (raw is! Map<String, dynamic>) return null;
+    final result = <String, Map<String, int>>{};
+    for (final entry in raw.entries) {
+      if (entry.value is Map) {
+        final inner = <String, int>{};
+        for (final e in (entry.value as Map).entries) {
+          final v = e.value;
+          inner[e.key.toString()] = v is int ? v : (int.tryParse('$v') ?? 0);
+        }
+        result[entry.key] = inner;
+      }
+    }
+    return result.isEmpty ? null : result;
+  }
+
   return ScenarioSetup(
     units: (json['units'] as List<dynamic>?)
         ?.map((u) => _parseUnitPlacement(u as Map<String, dynamic>))
@@ -340,6 +360,7 @@ ScenarioSetup _parseScenarioSetup(Map<String, dynamic> json) {
     initialWorkers: _parseInitialWorkers(json['initialWorkers']),
     initialStockpile: _parseInitialStockpile(json['initialStockpile']),
     productionAssignments: _parseProductionAssignments(json['productionAssignments']),
+    initialTileState: _parseInitialTileState(json['initialTileState']),
   );
 }
 

--- a/tool/sim_scenarios/lib/scenario_runner.dart
+++ b/tool/sim_scenarios/lib/scenario_runner.dart
@@ -321,6 +321,20 @@ class ScenarioRunner {
       }
       game = game.copyWith(players: updatedPlayers);
     }
+    if (setup.initialTileState != null && setup.initialTileState!.isNotEmpty) {
+      var tileState = game.worldState.tileState;
+      for (final entry in setup.initialTileState!.entries) {
+        final tileKey = entry.key;
+        final opts = entry.value;
+        final imp = opts['improvementLevel'];
+        final road = opts['roadLevel'];
+        if (imp != null) tileState = tileState.setImprovement(tileKey, imp);
+        if (road != null) tileState = tileState.setRoadLevel(tileKey, road);
+      }
+      game = game.copyWith(
+        worldState: game.worldState.copyWith(tileState: tileState),
+      );
+    }
     return game;
   }
 

--- a/tool/sim_scenarios/scenarios/extraction_basic.json
+++ b/tool/sim_scenarios/scenarios/extraction_basic.json
@@ -1,0 +1,31 @@
+{
+  "name": "extraction_basic",
+  "description": "SPEC/game/extraction-and-improvements.md: Extraction phase adds effective yield from connected tile with improvement and resource to owner stockpile. Given one owned tile with grain, improvement level 1, road level 1, after turn 1: gp1 grain stockpile +1.",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "greatPowers": ["england"],
+      "seed": 42,
+      "minorNationCount": 0
+    },
+    "oldWorld": {
+      "grid": [["p1", "sea1"]],
+      "nodes": [
+        {"id": "p1", "regionId": "oldWorld", "type": "province"},
+        {"id": "sea1", "regionId": "oldWorld", "type": "seaZone"}
+      ],
+      "edges": [{"id1": "p1", "id2": "sea1"}],
+      "resourceGrid": [["grain", null]]
+    }
+  },
+  "setup": {
+    "initialStockpile": {"gp1": {"grain": 0}},
+    "initialTileState": {
+      "oldWorld|p1|0|0": {"improvementLevel": 1, "roadLevel": 1}
+    }
+  },
+  "turns": [{"turn": 1, "orders": []}],
+  "assertions": [
+    {"turn": 1, "player": "gp1", "commodity": "grain", "stockpileCommodity": 1}
+  ]
+}


### PR DESCRIPTION
## Summary
- **Add scenario** `extraction_basic.json`: fromTopology with one province (grain resource), `initialTileState` (improvement 1, road 1); assert gp1 grain stockpile +1 after turn 1. Verifies SPEC/game/extraction-and-improvements.md extraction formula (effective yield from connected tile to stockpile).
- **fromTopology**: support optional `resourceGrid` in oldWorld/newWorld JSON (same dimensions as grid; resource name or null per cell).
- **Scenario setup**: add `initialTileState` (tileKey → improvementLevel / roadLevel) for extraction scenarios.
- **SPEC/program/sim-scenarios.md**: document resourceGrid and initialTileState.
- **Coverage mapping**: `game/extraction-and-improvements.md` → `["extraction_basic.json"]`.

## Tests
- All 26 sim_scenarios pass (including `extraction_basic`).
- `colonizethis_logic` tests pass.
- Coverage tool: extraction-and-improvements.md is covered (14 covered specs).

Made with [Cursor](https://cursor.com)