### PR TITLE
Fixes #444: Fog-and-exploration GDD/TDD world-model-identity cross-ref

### DIFF
--- a/SPEC/game/fog-and-exploration.md
+++ b/SPEC/game/fog-and-exploration.md
@@ -76,6 +76,14 @@ Own provinces never decay.
 
 Mineral resources may only be extracted from tiles that are (a) connected and (b) prospected by that player. Non-minerals unchanged.
 
+### Province and tile identity
+
+Per [world-model-identity.md](world-model-identity.md):
+
+- **Tile keys** (visibility map, prospected set) use the 4-part format `regionId|provinceId|x|y`; the second segment is the local province id within the region; full province id is `regionId|localId`.
+- **Province keys** (e.g. Spy reveal timer `provinceKey`) must be **full province id** (`regionId|localId`), not bare local id, so that lookups and multi-region consistency are correct.
+- **Ship coastal reveal** and **fog decay** logic resolve provinces by `(regionId, provinceId)` or prefixed id only.
+
 ---
 
 ## Configurable Values

--- a/SPEC/program/fog-and-exploration-resolution.md
+++ b/SPEC/program/fog-and-exploration-resolution.md
@@ -8,7 +8,7 @@ Maintains per-player visibility and prospected state on world state; resolves ex
 
 ## Data Model
 
-**Visibility state:** `Map<playerId, Map<tileKey, VisibilityLevel>>` — enum: unknown, revealed, fogged, fullyVisible. Tile key format: `regionId|provinceId|x|y`. Province and tile key formats: [world-model-identity.md](../game/world-model-identity.md). Any province id used in visibility or Spy timer state (e.g. keys keyed by province) must be the **prefixed** form (`regionId|localId`) per world-model-identity.md for multi-region correctness. Stored on WorldState.
+**Visibility state:** `Map<playerId, Map<tileKey, VisibilityLevel>>` — enum: unknown, revealed, fogged, fullyVisible. Tile key format: `regionId|provinceId|x|y` (second segment = local province id; full province id = `regionId|localId` per [world-model-identity.md](../game/world-model-identity.md)). Any province id used in visibility or Spy timer state (e.g. keys keyed by province) must be the **prefixed** form (`regionId|localId`) per world-model-identity.md for multi-region correctness. Stored on WorldState.
 
 **Prospected state:** `Map<playerId, Set<tileKey>>` — tiles the player has prospected. Only mineral-eligible terrain per game rules.
 
@@ -71,6 +71,7 @@ Maintains per-player visibility and prospected state on world state; resolves ex
 ## Constraints
 
 - Visibility and prospected state are authoritative on WorldState; PlayerView is derived (read-only).
+- Ship coastal reveal and fog decay logic resolve provinces by `(regionId, provinceId)` or prefixed id only; see [world-model-identity.md](../game/world-model-identity.md).
 - Extraction gating (mineral prospecting + connectivity) is enforced by the extraction pipeline, not this module.
 - Order visibility rules are defined in game/fog-and-exploration.md; this module enforces them at validation time via PlayerView.
 


### PR DESCRIPTION
Fixes #444

**Summary**
- **GDD** (SPEC/game/fog-and-exploration.md): Added § Province and tile identity with explicit cross-ref to world-model-identity.md: tile keys 4-part format and second segment = local province id; province keys (e.g. Spy timer) must be full province id; ship coastal reveal and fog decay resolve provinces by (regionId, provinceId) or prefixed id only.
- **TDD** (SPEC/program/fog-and-exploration-resolution.md): Data Model — clarified tile key second segment = local province id, full province id = regionId|localId. Constraints — added bullet that ship coastal reveal and fog decay resolve provinces by (regionId, provinceId) or prefixed id only.

Docs-only; no code changes.

Made with [Cursor](https://cursor.com)