### PR TITLE
Capital-and-connectivity GDD: add world-model-identity cross-ref (Fixes #428)

### DIFF
--- a/SPEC/game/capital-and-connectivity.md
+++ b/SPEC/game/capital-and-connectivity.md
@@ -1,8 +1,10 @@
 # Capital and Connectivity
 
-**SPEC/game** — Capital definition, setup, and connectivity rules for extraction. Reference: Imperialism II 02-economy. Flow: [stockpiles-and-production.md](stockpiles-and-production.md), [auto-transport.md](../program/auto-transport.md).
+**SPEC/game** — Capital definition, setup, and connectivity rules for extraction. Reference: Imperialism II 02-economy. Flow: [stockpiles-and-production.md](stockpiles-and-production.md), [auto-transport.md](../program/auto-transport.md). Province and tile identity (capital province, town keys, connectivity state) use prefixed province ids and tile keys per [world-model-identity.md](world-model-identity.md).
 
 Connectivity in this document applies **only to extraction**: it determines which tiles contribute to resource extraction and flow to the player's stockpile. It is a **tile-level** concept — each tile is either connected or not for a given player. Connectivity output is consumed by the extraction pipeline; see [extraction-pipeline.md](../program/extraction-pipeline.md).
+
+**Province and tile identity:** All province ids in game state and in capital/town/connectivity logic use **prefixed** form (`regionId|localId`). Tile keys use the 4-part format `regionId|localId|x|y`. See [world-model-identity.md](world-model-identity.md).
 
 ---
 


### PR DESCRIPTION
Fixes #428

Docs-only: add cross-reference to SPEC/game/world-model-identity.md in SPEC/game/capital-and-connectivity.md.

- Opening paragraph: province and tile identity (capital, town keys, connectivity state) use prefixed ids and tile keys per world-model-identity.md.
- **Province and tile identity** note: prefixed province ids (`regionId|localId`), tile keys 4-part `regionId|localId|x|y`, with link to world-model-identity.md.

Made with [Cursor](https://cursor.com)