### PR TITLE
GDD scenario coverage: fog-and-exploration.md

### DIFF
--- a/SPEC/program/sim-scenarios.md
+++ b/SPEC/program/sim-scenarios.md
@@ -168,6 +168,8 @@ Assertion fields:
 
 **Faction count assertions** (SPEC/game/factions.md): use `greatPowerCount`, `minorNationCount`, `tribeCount` (expected integer counts) to verify that game setup created the configured Great Powers, Minor Nations, and Tribes. Example: `{"turn": 1, "greatPowerCount": 1, "minorNationCount": 1, "tribeCount": 1}`.
 
+**Fog/exploration assertions** (SPEC/game/fog-and-exploration.md): use `player`, `tileKey` (format `regionId|provinceId|x|y`), and optionally `tileVisibility` (expected level: `unknown`, `revealed`, `fogged`, `fullyVisible`) and/or `tileProspected` (boolean). Example: `{"turn": 1, "player": "gp1", "tileKey": "oldWorld|p1|0|0", "tileVisibility": "fullyVisible"}`; `{"player": "gp1", "tileKey": "oldWorld|p2|2|0", "tileVisibility": "fogged", "tileProspected": false}`.
+
 ---
 
 ## Execution Flow

--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -7,7 +7,7 @@
   "game/diplomacy.md": ["diplomacy_initial_relations.json", "diplomacy_gp_gp_war_and_mutual_peace.json"],
   "game/extraction-and-improvements.md": ["extraction_basic.json"],
   "game/factions.md": ["factions_basic.json"],
-  "game/fog-and-exploration.md": [],
+  "game/fog-and-exploration.md": ["fog_and_exploration_basic.json"],
   "game/game-setup.md": ["basic_turn_1.json"],
   "game/leader-bonuses.md": [],
   "game/map-topology.md": [

--- a/tool/sim_scenarios/bin/sim_scenarios.dart
+++ b/tool/sim_scenarios/bin/sim_scenarios.dart
@@ -232,5 +232,14 @@ String _formatAssertion(Assertion assertion) {
   if (assertion.region != null && assertion.maxBothFraction != null) {
     return 'region.${assertion.region}.maxBothFraction <= ${assertion.maxBothFraction}';
   }
+  // Fog/exploration (SPEC/game/fog-and-exploration.md)
+  if (assertion.player != null && assertion.tileKey != null) {
+    if (assertion.tileVisibility != null) {
+      return 'player.${assertion.player}.tile.${assertion.tileKey}.visibility == ${assertion.tileVisibility}';
+    }
+    if (assertion.tileProspected != null) {
+      return 'player.${assertion.player}.tile.${assertion.tileKey}.prospected == ${assertion.tileProspected}';
+    }
+  }
   return 'unknown';
 }

--- a/tool/sim_scenarios/lib/scenario.dart
+++ b/tool/sim_scenarios/lib/scenario.dart
@@ -209,6 +209,9 @@ class Assertion {
     this.greatPowerCount,
     this.minorNationCount,
     this.tribeCount,
+    this.tileKey,
+    this.tileVisibility,
+    this.tileProspected,
   });
 
   /// Which turn to check (null = final state)
@@ -264,6 +267,14 @@ class Assertion {
   final int? greatPowerCount;
   final int? minorNationCount;
   final int? tribeCount;
+
+  /// Fog/exploration assertions (SPEC/game/fog-and-exploration.md). Require [player].
+  /// [tileKey]: format regionId|provinceId|x|y.
+  /// [tileVisibility]: expected visibility level for that player at tileKey (unknown, revealed, fogged, fullyVisible).
+  /// [tileProspected]: true iff that player has prospected the tile at tileKey.
+  final String? tileKey;
+  final String? tileVisibility;
+  final bool? tileProspected;
 }
 
 /// Type of value matching for assertions.
@@ -510,6 +521,9 @@ Assertion _parseAssertion(Map<String, dynamic> json) {
     greatPowerCount: json['greatPowerCount'] as int?,
     minorNationCount: json['minorNationCount'] as int?,
     tribeCount: json['tribeCount'] as int?,
+    tileKey: json['tileKey'] as String?,
+    tileVisibility: json['tileVisibility'] as String?,
+    tileProspected: json['tileProspected'] as bool?,
   );
 }
 

--- a/tool/sim_scenarios/lib/state_verifier.dart
+++ b/tool/sim_scenarios/lib/state_verifier.dart
@@ -384,6 +384,33 @@ class StateVerifier {
       }
     }
 
+    // Fog/exploration assertions (SPEC/game/fog-and-exploration.md)
+    if (assertion.player != null &&
+        (assertion.tileVisibility != null || assertion.tileProspected != null) &&
+        assertion.tileKey != null) {
+      final playerId = assertion.player!;
+      final tileKey = assertion.tileKey!;
+      final visByTile = game.worldState.playerVisibilityByTile[playerId];
+      if (assertion.tileVisibility != null) {
+        final expected = assertion.tileVisibility!;
+        final actual = visByTile?[tileKey];
+        if (actual != expected) {
+          failures.add(
+            'Player $playerId tile $tileKey visibility: expected "$expected", got "${actual ?? "absent/unknown"}"',
+          );
+        }
+      }
+      if (assertion.tileProspected != null) {
+        final prospected = game.worldState.playerProspectedTiles[playerId];
+        final isProspected = prospected?.contains(tileKey) ?? false;
+        if (isProspected != assertion.tileProspected!) {
+          failures.add(
+            'Player $playerId tile $tileKey prospected: expected ${assertion.tileProspected}, got $isProspected',
+          );
+        }
+      }
+    }
+
     return VerificationResult(
       passed: failures.isEmpty,
       failures: failures,

--- a/tool/sim_scenarios/scenarios/fog_and_exploration_basic.json
+++ b/tool/sim_scenarios/scenarios/fog_and_exploration_basic.json
@@ -1,0 +1,41 @@
+{
+  "name": "fog_and_exploration_basic",
+  "description": "SPEC/game/fog-and-exploration.md: Initial visibility — Old World own provinces fully visible, other-faction provinces fogged; New World unknown. Assert gp1 sees own tile fullyVisible and other GP's tile fogged; prospected set empty.",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "greatPowers": ["england", "france"],
+      "seed": 42,
+      "minorNationCount": 0
+    },
+    "oldWorld": {
+      "grid": [
+        ["p1", "sea1", "p2"],
+        ["p1", "p1", "p2"],
+        ["sea2", "sea2", "sea2"]
+      ],
+      "nodes": [
+        {"id": "p1", "regionId": "oldWorld", "type": "province"},
+        {"id": "p2", "regionId": "oldWorld", "type": "province"},
+        {"id": "sea1", "regionId": "oldWorld", "type": "seaZone"},
+        {"id": "sea2", "regionId": "oldWorld", "type": "seaZone"}
+      ],
+      "edges": [
+        {"id1": "p1", "id2": "sea1"},
+        {"id1": "p1", "id2": "p2"},
+        {"id1": "p2", "id2": "sea2"}
+      ]
+    }
+  },
+  "turns": [
+    {"turn": 1, "orders": []}
+  ],
+  "assertions": [
+    {"turn": 1, "province": "oldWorld|p1", "owner": "gp1"},
+    {"turn": 1, "province": "oldWorld|p2", "owner": "gp2"},
+    {"turn": 1, "player": "gp1", "tileKey": "oldWorld|p1|0|0", "tileVisibility": "fullyVisible"},
+    {"turn": 1, "player": "gp1", "tileKey": "oldWorld|p2|2|0", "tileVisibility": "fogged", "tileProspected": false},
+    {"turn": 1, "player": "gp2", "tileKey": "oldWorld|p2|2|0", "tileVisibility": "fullyVisible"},
+    {"turn": 1, "player": "gp2", "tileKey": "oldWorld|p1|0|0", "tileVisibility": "fogged", "tileProspected": false}
+  ]
+}


### PR DESCRIPTION
Adds scenario coverage for **SPEC/game/fog-and-exploration.md**.

**Changes:**
- **Assertion types:** `tileVisibility` (player + tileKey + level: unknown/revealed/fogged/fullyVisible) and `tileProspected` (player + tileKey + bool). Documented in SPEC/program/sim-scenarios.md; implemented in state_verifier and scenario parser.
- **Scenario:** `fog_and_exploration_basic.json` — fromTopology with two GPs (two sea-bound provinces); asserts initial visibility: own province tiles `fullyVisible`, other-faction tiles `fogged`; prospected set empty.
- **Coverage mapping:** `game/fog-and-exploration.md` → `["fog_and_exploration_basic.json"]`.

**Verification:** All 28 sim_scenarios pass; colonizethis_logic tests pass; coverage tool reports 16 covered, 22 uncovered (fog-and-exploration no longer in uncovered list).

Made with [Cursor](https://cursor.com)