### PR TITLE
Capital-and-connectivity GDD: add Implementation cross-ref after AC (Fixes #427)

### DIFF
--- a/SPEC/game/capital-and-connectivity.md
+++ b/SPEC/game/capital-and-connectivity.md
@@ -144,3 +144,5 @@ If a player no longer owns their capital province (e.g. after conquest), a new c
 - Given a player has no owned provinces remaining in the original capital region after capital loss  
   When the system executes capital loss and reassignment during turn resolution  
   Then the system sets the player’s capital province and capital tile to `null`, performs no new port or road setup, and in the subsequent extraction phase treats all tiles for that player as not connected for extraction until a new capital is defined by later rules.
+
+- **Implementation:** Capital choice and init: [capital-choice-phase.md](capital-choice-phase.md). Connectivity and extraction: [extraction-pipeline.md](../program/extraction-pipeline.md). Capital reassignment on loss: [turn-resolution-phase-details.md](../program/turn-resolution-phase-details.md) § Combat.


### PR DESCRIPTION
Fixes #427

The Acceptance criteria section was already added in #621. This PR adds an **Implementation** bullet after the AC list (aligned with other GDDs) pointing to:
- [capital-choice-phase.md](SPEC/game/capital-choice-phase.md) for capital choice and init
- [extraction-pipeline.md](SPEC/program/extraction-pipeline.md) for connectivity and extraction
- [turn-resolution-phase-details.md](SPEC/program/turn-resolution-phase-details.md) § Combat for capital reassignment on loss

Docs-only.

Made with [Cursor](https://cursor.com)