### PR TITLE
Leader-bonuses GDD: document leaderKey variant-id semantics (Fixes #506)

### DIFF
--- a/SPEC/game/leader-bonuses.md
+++ b/SPEC/game/leader-bonuses.md
@@ -35,6 +35,8 @@ Leaders are identified by **leaderKey** (string). Each key maps to a **combat mo
 
 Modifiers are applied as multipliers to the side’s effective strength (e.g. 1.25 for +25% melee) before the combat formula. If a leaderKey is unknown, treat as no bonus.
 
+**LeaderKey format and matching:** The value stored on the Player may be an exact key (`napoleon`, `frederick`, `reserve`) or a variant id (e.g. `france_napoleon_leader`, `prussia_frederick_leader`). Lookup is: (1) exact key in the table first; (2) if no exact match, case-insensitive substring: key containing `napoleon` → +25%, containing `frederick` → +15%. Any other or unknown key receives no bonus (multiplier 1.0).
+
 ---
 
 ## Application Rule
@@ -49,6 +51,6 @@ Modifiers are applied as multipliers to the side’s effective strength (e.g. 1.
 
 - **Leader selection:** Each Great Power has exactly one leader for the game, chosen at game start (human via UI or default; AI from config). Leader is stored as leaderKey on the Player and serialized; no mid-game change.
 - **Combat-only:** Leader bonuses apply only in auto-resolve combat and Quick Battle; no economy or research effect.
-- **Bonus table:** The leaderKey → modifier mapping (e.g. napoleon +25%, frederick +15%, reserve/default 0%) is the source of truth. Unknown leaderKey is treated as no bonus.
+- **Bonus table:** The leaderKey → modifier mapping (e.g. napoleon +25%, frederick +15%, reserve/default 0%) is the source of truth. Unknown leaderKey is treated as no bonus. Variant ids (e.g. france_napoleon_leader) are matched per § LeaderKey format and matching (exact first, then case-insensitive substring).
 - **Application:** Defender uses province owner's GP leader (province lookup prefixed and region-scoped per [world-model-identity.md](world-model-identity.md)); each attacker side uses that side's GP leader. Bonuses are applied as multipliers to effective strength before resolution.
 - **Implementation:** Combat resolver and quick battle apply leader bonuses per [combat-resolution.md](../program/combat-resolution.md) and [quick-battle-resolution.md](../program/quick-battle-resolution.md).


### PR DESCRIPTION
Fixes #506

Documents in SPEC/game/leader-bonuses.md:
- **LeaderKey format and matching:** Player may store exact key (napoleon, frederick, reserve) or variant id (e.g. france_napoleon_leader). Lookup: exact first, then case-insensitive substring for napoleon/frederick; unknown keys get no bonus.
- Acceptance criteria: variant ids matched per new paragraph.

Docs-only; aligns GDD with existing behaviour in leader_bonuses.dart.

Made with [Cursor](https://cursor.com)