### PR TITLE
Leader-bonuses GDD: clarify land combat only, not naval (Fixes #508)

### DIFF
--- a/SPEC/game/leader-bonuses.md
+++ b/SPEC/game/leader-bonuses.md
@@ -14,10 +14,12 @@
 
 ## When Bonuses Apply
 
-Leader bonuses apply in:
+Leader bonuses apply to **land combat only** (not naval):
 
-- **Auto-resolve combat** (main game turn resolution): when resolving a BattleContext, the combat resolver reads the defender’s and each attacker’s GP, looks up each player’s leaderKey, and applies the corresponding bonus to that side’s strength (or modifiers) before resolving the engagement.
+- **Auto-resolve combat** (main game turn resolution): when resolving a land BattleContext, the combat resolver reads the defender’s and each attacker’s GP, looks up each player’s leaderKey, and applies the corresponding bonus to that side’s strength (or modifiers) before resolving the engagement.
 - **Quick Battle** (ctdev or in-game quick battle): same rule; both sides get their GP’s leader bonus.
+
+Naval combat is resolved per [ships-and-naval.md](ships-and-naval.md) and [naval-combat-resolution.md](../program/naval-combat-resolution.md); leader bonuses are **not** applied there (medal and tech modifiers only).
 
 Bonuses are **combat-only** (no economy or research bonus from leader).
 
@@ -50,7 +52,7 @@ Modifiers are applied as multipliers to the side’s effective strength (e.g. 1.
 ## Acceptance criteria
 
 - **Leader selection:** Each Great Power has exactly one leader for the game, chosen at game start (human via UI or default; AI from config). Leader is stored as leaderKey on the Player and serialized; no mid-game change.
-- **Combat-only:** Leader bonuses apply only in auto-resolve combat and Quick Battle; no economy or research effect.
+- **Combat-only (land):** Leader bonuses apply only in land auto-resolve combat and Quick Battle; they do not apply to naval combat. No economy or research effect.
 - **Bonus table:** The leaderKey → modifier mapping (e.g. napoleon +25%, frederick +15%, reserve/default 0%) is the source of truth. Unknown leaderKey is treated as no bonus. Variant ids (e.g. france_napoleon_leader) are matched per § LeaderKey format and matching (exact first, then case-insensitive substring).
 - **Application:** Defender uses province owner's GP leader (province lookup prefixed and region-scoped per [world-model-identity.md](world-model-identity.md)); each attacker side uses that side's GP leader. Bonuses are applied as multipliers to effective strength before resolution.
 - **Implementation:** Combat resolver and quick battle apply leader bonuses per [combat-resolution.md](../program/combat-resolution.md) and [quick-battle-resolution.md](../program/quick-battle-resolution.md).

--- a/SPEC/game/ships-and-naval.md
+++ b/SPEC/game/ships-and-naval.md
@@ -140,7 +140,7 @@ raidEfficiency = 0.3 to 0.7 depending on relative strength
 
 - Given two opposing fleets with known ship stats (FRP, RNG, ARM, HULL, MV) and medals occupy the same sea zone and a naval battle is triggered  
   When the System computes naval combat strength and resolves the battle  
-  Then the System uses the aggregation and durability formulas in this document (including RNG weighting and HULL × (1 + ARM/10)), applies any leader and tech modifiers as specified in related specs, and produces deterministic outcomes (winner, casualties, and possible retreats) for identical inputs across multiple runs.
+  Then the System uses the aggregation and durability formulas in this document (including RNG weighting and HULL × (1 + ARM/10)), applies tech modifiers as specified in related specs (leader bonuses do not apply to naval combat; see [leader-bonuses.md](leader-bonuses.md) § When Bonuses Apply), and produces deterministic outcomes (winner, casualties, and possible retreats) for identical inputs across multiple runs.
 
 - Given a Great Power’s home fleet carries overseas cargo during Extraction/Trade and hostile fleets at war with that Great Power are patrolling or blockading relevant sea zones  
   When the System resolves overseas transport and trade for that turn  

--- a/SPEC/program/naval-combat-resolution.md
+++ b/SPEC/program/naval-combat-resolution.md
@@ -22,7 +22,7 @@ Detects naval conflicts per sea zone and auto-resolves fleet engagements, produc
 
 1. Compute firepower score from FRP and RNG (RNG weighted highest per [ships-and-naval.md](../game/ships-and-naval.md) § Naval Combat).
 2. Compute durability score from ARM and HULL.
-3. Apply medal multipliers and tech modifiers.
+3. Apply medal multipliers and tech modifiers (leader bonuses from [leader-bonuses.md](../game/leader-bonuses.md) do not apply to naval combat).
 4. Aggregate into side-level `navalStrength`. Weights from config, tunable per ruleset.
 
 **Per-Engagement Resolution:**


### PR DESCRIPTION
Fixes #508

**Summary:** Document that leader bonuses apply to land combat only; they do not apply to naval combat (matches current implementation: combat_resolver and quick_battle use leader bonuses; naval_combat_resolver does not).

**Changes:**
- **SPEC/game/leader-bonuses.md:** § When Bonuses Apply — explicit "land combat only (not naval)"; land BattleContext; new sentence that naval combat (ships-and-naval, naval-combat-resolution) does not apply leader bonuses (medal and tech only). AC Combat-only updated to "Combat-only (land)".
- **SPEC/game/ships-and-naval.md:** Acceptance criterion for naval battle resolution — "tech modifiers" and "leader bonuses do not apply to naval combat" with cross-ref to leader-bonuses.md.
- **SPEC/program/naval-combat-resolution.md:** Strength aggregation step 3 — note that leader bonuses (leader-bonuses.md) do not apply to naval combat.

Docs-only; no code changes.

Made with [Cursor](https://cursor.com)