### PR TITLE
Fixes #507: Leader-bonuses: document bonus table MVP (code constants), ruleset deferred

### DIFF
--- a/SPEC/game/leader-bonuses.md
+++ b/SPEC/game/leader-bonuses.md
@@ -39,6 +39,8 @@ Modifiers are applied as multipliers to the side’s effective strength (e.g. 1.
 
 **LeaderKey format and matching:** The value stored on the Player may be an exact key (`napoleon`, `frederick`, `reserve`) or a variant id (e.g. `france_napoleon_leader`, `prussia_frederick_leader`). Lookup is: (1) exact key in the table first; (2) if no exact match, case-insensitive substring: key containing `napoleon` → +25%, containing `frederick` → +15%. Any other or unknown key receives no bonus (multiplier 1.0).
 
+**Where defined (MVP):** The leaderKey → melee multiplier table above is the **source of truth** for design defaults. In the current (MVP) implementation, the program does **not** read this table from the ruleset. The mapping is implemented as **code constants** in `colonizethis_logic` (e.g. `leader_bonuses.dart`: `_leaderMeleeBonus` or equivalent). Ruleset-driven override for the leader bonus table is **deferred**. When added, the key path and loader contract will be specified in this document and in [ruleset-config.md](ruleset-config.md); program loading: [ruleset-config.md](../program/ruleset-config.md).
+
 ---
 
 ## Application Rule

--- a/SPEC/game/ruleset-config.md
+++ b/SPEC/game/ruleset-config.md
@@ -6,7 +6,7 @@ Data-driven game parameters organized in categories and layers, fixed at game cr
 ## Rules
 
 ### Categories
-Parameters are grouped into: **units** (movement, strength, caps, costs), **map** (terrain costs, adjacency, starting provinces), **economy** (price modifiers, capacity, credit limits, turn timers), **combat** (FPN, FPM, RNG, DEF, MVR; terrain/fort/difficulty modifiers; initiative weights; medal multipliers), **victory** (thresholds, score weights, custom win conditions), **AI** (difficulty resource modifiers, personality weights), **scenario** (starting units, treasury, relations, powers enabled), **game/setup** (Great Power count, continent count, Minor Nation count, Tribe count, minimum provinces per Minor Nation, Old World/New World province counts).
+Parameters are grouped into: **units** (movement, strength, caps, costs), **map** (terrain costs, adjacency, starting provinces), **economy** (price modifiers, capacity, credit limits, turn timers), **combat** (FPN, FPM, RNG, DEF, MVR; terrain/fort/difficulty modifiers; initiative weights; medal multipliers; leader bonus table — MVP: not in ruleset, see [leader-bonuses.md](leader-bonuses.md) § Where defined (MVP)), **victory** (thresholds, score weights, custom win conditions), **AI** (difficulty resource modifiers, personality weights), **scenario** (starting units, treasury, relations, powers enabled), **game/setup** (Great Power count, continent count, Minor Nation count, Tribe count, minimum provinces per Minor Nation, Old World/New World province counts).
 
 **Map:** Adjacency from topology graph ([world-model.md](world-model.md), [map-topology.md](map-topology.md)). Terrain, resources, and improvements may come from tile map or config overlays.
 


### PR DESCRIPTION
Fixes #507

**Summary:** Document where the leader bonus table (leaderKey → melee multiplier) is defined for MVP and that ruleset override is deferred.

- **SPEC/game/leader-bonuses.md:** Added § **Where defined (MVP):** table is source of truth; implementation uses code constants in `colonizethis_logic` (e.g. `leader_bonuses.dart`); ruleset-driven override deferred; when added, document key path here and in ruleset-config.
- **SPEC/game/ruleset-config.md:** In combat category, note that leader bonus table is MVP not in ruleset, cross-ref leader-bonuses.md § Where defined (MVP).

Docs-only.

Made with [Cursor](https://cursor.com)