### PR TITLE
Fixes #529: Tech-tree-military: document where cheaper-attack applies (owner decision)

### DIFF
--- a/SPEC/game/tech-tree-military.md
+++ b/SPEC/game/tech-tree-military.md
@@ -73,9 +73,16 @@ The following effect types appear in the tech table above but are **deferred** f
 
 | Tech id | Effect text | Where it would apply when implemented |
 |---------|-------------|----------------------------------------|
-| industrial_machinery | 25% cheaper military attack | Attack cost or strength modifier per [combat-resolution.md](../program/combat-resolution.md) or [orders.md](../program/orders.md) (e.g. BuildUnitOrder / tactical cost). |
+| industrial_machinery | 25% cheaper military attack | See **Cheaper attack (owner decision)** below. |
 | modern_military_funding | Cheaper attack | Same as above. |
 | industrial_funding_of_research | Research efficiency; military/naval tech | Research points or cost modifier for military/naval tech per [research-resolution.md](../program/research-resolution.md). |
+
+**Cheaper attack (owner decision):** The exact application point for *industrial_machinery* (25% cheaper military attack) and *modern_military_funding* (Cheaper attack) is **not yet decided**. Candidate application points:
+
+- **Treasury cost** when issuing an attack order (e.g. declaring war, launching attack) — modifier would apply in order validation or cost resolution per [orders.md](../program/orders.md).
+- **Combat strength or damage** in auto-resolve / Quick Battle — modifier would apply in [combat-resolution.md](../program/combat-resolution.md) or [quick-battle-resolution.md](../program/quick-battle-resolution.md).
+
+The magnitude (e.g. 25% for industrial_machinery, and the value for modern_military_funding) may be fixed in design or configurable via ruleset per [ruleset-config.md](../program/ruleset-config.md); owner decision required. Once decided, document the chosen application point and configurability here and in the relevant TDD.
 
 **Implementation status:** No TDD or code path currently applies these modifiers. The table in this doc remains the GDD source of truth for tech id, prerequisites, and regiment unlocks; the deferred effects are documented here so contributors can distinguish implemented behaviour (regiment/fort unlocks) from deferred behaviour (cost/efficiency modifiers). See [tech-tree.md](tech-tree.md) § Effect Types for the general effect taxonomy.
 


### PR DESCRIPTION
Fixes #529

**Summary:** Document in the GDD where "25% cheaper military attack" (industrial_machinery) and "Cheaper attack" (modern_military_funding) would apply when implemented, and that the decision is owner-driven.

**Changes:**
- **SPEC/game/tech-tree-military.md:** Deferred effect types table now references a new subsection for the two cheaper-attack techs.
- Added **Cheaper attack (owner decision)** subsection: lists candidate application points (treasury cost when issuing attack order vs combat strength/damage in resolution), and notes that magnitude/percentage may be fixed or ruleset-configurable; owner decision required. Cross-refs to orders.md, combat-resolution.md, quick-battle-resolution.md, ruleset-config.md.

Docs-only; no code changes.

Made with [Cursor](https://cursor.com)