### PR TITLE
GDD scenario coverage: military-units.md

### DIFF
--- a/SPEC/program/sim-scenarios.md
+++ b/SPEC/program/sim-scenarios.md
@@ -70,6 +70,7 @@ For saved games (or after fresh/fromTopology init), optional `setup` block injec
 - **productionAssignments:** Optional. List of `{ "recipeId": "<id>", "assignedLabour": <n> }`. Passed to the Production phase for each turn so scenarios can verify SPEC/game/stockpiles-and-production.md (inputs consumed, outputs added to central stockpile). Same list is used for every turn in the scenario. Recipe ids are from the program-level catalog (e.g. `lumber_from_timber`, `castIron_from_timber_iron_coal`).
 - **initialTileState:** Optional. Map tile key (e.g. `"oldWorld|p1|0|0"`) → `{ "improvementLevel": 0–4, "roadLevel": 0|1|2|4 }`. Applied to `worldState.tileState` before the first turn. Used for extraction scenarios (SPEC/game/extraction-and-improvements.md).
 - **leaderKeys:** Optional. Map player id → leaderKey (string). Overrides each Great Power’s `Player.leaderKey` after init. Used for leader-bonus scenarios (SPEC/game/leader-bonuses.md).
+- **initialTech:** Optional. Map player id → list of tech ids. Overrides that player’s `Player.techUnlocked` (each listed tech id set to true) before the first turn. Used for regiment buildability scenarios (SPEC/game/military-units.md, tech-tree).
 
 ---
 

--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -18,7 +18,7 @@
     "connectivity_no_road_to_port.json"
   ],
   "game/military-generals.md": [],
-  "game/military-units.md": [],
+  "game/military-units.md": ["military_units_buildability.json"],
   "game/naming.md": [],
   "game/production-recipes.md": ["production_recipes_basic.json"],
   "game/quick-battle.md": [],

--- a/tool/sim_scenarios/lib/order_script.dart
+++ b/tool/sim_scenarios/lib/order_script.dart
@@ -1,5 +1,6 @@
 // Order script parser - converts OrderCommand to Orders objects.
 
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'scenario.dart';
@@ -25,9 +26,8 @@ Orders parseOrderCommands(List<OrderCommand> commands, Game game) {
         break;
 
       case 'build':
-        // Infer isMilitary from unit type (simplified)
         final unitType = cmd.unitType ?? 'infantry';
-        final isMilitary = _isMilitaryUnit(unitType);
+        final isMilitary = buildUnitCategoryForUnitType(unitType) == BuildUnitCategory.military;
         final buildOrder = BuildUnitOrder(
           unitType: unitType,
           isMilitary: isMilitary,
@@ -110,21 +110,4 @@ Orders parseOrderCommands(List<OrderCommand> commands, Game game) {
     navalMoveOrdersByPlayerId: navalMoveOrdersByPlayerId,
     navalMissionOrdersByPlayerId: navalMissionOrdersByPlayerId,
   );
-}
-
-/// Heuristic to determine if a unit type is military.
-bool _isMilitaryUnit(String unitType) {
-  // Common military unit types
-  const militaryUnits = [
-    'infantry',
-    'cavalry',
-    'artillery',
-    'grenadiers',
-    'hussars',
-    'cuirassiers',
-    'dragoons',
-    'musketeers',
-    'line_infantry',
-  ];
-  return militaryUnits.contains(unitType.toLowerCase());
 }

--- a/tool/sim_scenarios/lib/scenario.dart
+++ b/tool/sim_scenarios/lib/scenario.dart
@@ -46,6 +46,7 @@ class ScenarioInit {
 /// initialWorkers / initialStockpile apply after init (fresh or fromTopology).
 /// initialTileState: tileKey → { improvementLevel, roadLevel } for extraction scenarios. SPEC/game/extraction-and-improvements.md.
 /// leaderKeys: player id → leaderKey (SPEC/game/leader-bonuses.md); applied to Player.leaderKey after init.
+/// initialTech: player id → list of tech ids. Overrides Player.techUnlocked for buildability scenarios. SPEC/game/military-units.md.
 class ScenarioSetup {
   const ScenarioSetup({
     this.units,
@@ -55,6 +56,7 @@ class ScenarioSetup {
     this.productionAssignments,
     this.initialTileState,
     this.leaderKeys,
+    this.initialTech,
   });
 
   final List<UnitPlacement>? units;
@@ -69,6 +71,8 @@ class ScenarioSetup {
   final Map<String, Map<String, int>>? initialTileState;
   /// Player id → leaderKey. Overrides Player.leaderKey for leader-bonus scenarios. SPEC/game/leader-bonuses.md.
   final Map<String, String>? leaderKeys;
+  /// Player id → list of tech ids. Overrides Player.techUnlocked (map techId → true). SPEC/game/military-units.md, tech-tree.
+  final Map<String, List<String>>? initialTech;
 }
 
 /// One production assignment: recipe id and labour to assign. Converted to AssignedRecipe in runner.
@@ -388,7 +392,20 @@ ScenarioSetup _parseScenarioSetup(Map<String, dynamic> json) {
     productionAssignments: _parseProductionAssignments(json['productionAssignments']),
     initialTileState: _parseInitialTileState(json['initialTileState']),
     leaderKeys: _parseLeaderKeys(json['leaderKeys']),
+    initialTech: _parseInitialTech(json['initialTech']),
   );
+}
+
+Map<String, List<String>>? _parseInitialTech(dynamic raw) {
+  if (raw is! Map<String, dynamic>) return null;
+  final out = <String, List<String>>{};
+  for (final entry in raw.entries) {
+    final list = entry.value;
+    if (list is List<dynamic>) {
+      out[entry.key] = list.map((e) => e.toString()).toList();
+    }
+  }
+  return out.isEmpty ? null : out;
 }
 
 Map<String, String>? _parseLeaderKeys(dynamic raw) {

--- a/tool/sim_scenarios/lib/scenario_runner.dart
+++ b/tool/sim_scenarios/lib/scenario_runner.dart
@@ -347,6 +347,22 @@ class ScenarioRunner {
       }
       game = game.copyWith(players: updatedPlayers);
     }
+    if (setup.initialTech != null && setup.initialTech!.isNotEmpty) {
+      final updatedPlayers = <Player>[];
+      for (final player in game.players) {
+        final techIds = setup.initialTech![player.id];
+        if (techIds == null || techIds.isEmpty) {
+          updatedPlayers.add(player);
+          continue;
+        }
+        final techUnlocked = Map<String, bool>.from(player.techUnlocked ?? {});
+        for (final tid in techIds) {
+          techUnlocked[tid] = true;
+        }
+        updatedPlayers.add(player.copyWith(techUnlocked: techUnlocked));
+      }
+      game = game.copyWith(players: updatedPlayers);
+    }
     return game;
   }
 

--- a/tool/sim_scenarios/scenarios/military_units_buildability.json
+++ b/tool/sim_scenarios/scenarios/military_units_buildability.json
@@ -1,0 +1,43 @@
+{
+  "name": "military_units_buildability",
+  "description": "SPEC/game/military-units.md AC2: regiment buildable iff unlocking tech in techUnlocked. GP1 with initialTech [organised_regiments] and resources builds lancers in capital; assert unit count increases. Province id prefixed (regionId|localId).",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "greatPowers": ["england"],
+      "seed": 42,
+      "minorNationCount": 0
+    },
+    "oldWorld": {
+      "grid": [["p1", "sea1"]],
+      "nodes": [
+        {"id": "p1", "regionId": "oldWorld", "type": "province"},
+        {"id": "sea1", "regionId": "oldWorld", "type": "seaZone"}
+      ],
+      "edges": [{"id1": "p1", "id2": "sea1"}]
+    }
+  },
+  "setup": {
+    "initialTech": {
+      "gp1": ["organised_regiments"]
+    },
+    "initialWorkers": {
+      "gp1": {"peasants": 1, "apprentices": 0, "journeymen": 0, "masters": 0}
+    },
+    "initialStockpile": {
+      "gp1": {"grain": 5, "fabric": 2, "castIron": 2}
+    }
+  },
+  "turns": [
+    {
+      "turn": 1,
+      "orders": [
+        {"player": "gp1", "type": "build", "unitType": "lancers", "in": "oldWorld|p1"}
+      ]
+    }
+  ],
+  "assertions": [
+    {"turn": 1, "province": "oldWorld|p1", "owner": "gp1"},
+    {"turn": 1, "province": "oldWorld|p1", "unitCount": 6, "matchType": "atLeast"}
+  ]
+}

--- a/tool/sim_scenarios/test/sim_scenarios_test.dart
+++ b/tool/sim_scenarios/test/sim_scenarios_test.dart
@@ -256,6 +256,23 @@ void main() {
         expect(scenario.assertions[1].player, 'gp2');
         expect(scenario.assertions[1].leaderKey, 'frederick');
       });
+
+      test('parses setup initialTech', () {
+        final json = {
+          'name': 'tech_setup',
+          'init': {'type': 'fromTopology', 'config': {'greatPowers': ['england']}},
+          'setup': {
+            'initialTech': {'gp1': ['organised_regiments', 'weapon_craftsmanship']},
+          },
+          'turns': [],
+          'assertions': [],
+        };
+
+        final scenario = parseScenarioFromJson(json);
+
+        expect(scenario.setup!.initialTech, isNotNull);
+        expect(scenario.setup!.initialTech!['gp1'], ['organised_regiments', 'weapon_craftsmanship']);
+      });
     });
 
     group('parseScenarioFile', () {


### PR DESCRIPTION
Adds scenario coverage for **SPEC/game/military-units.md** (AC2: regiment buildable iff unlocking tech in techUnlocked).

## Changes
- **Scenario setup `initialTech`**: Map player id → list of tech ids; overrides `Player.techUnlocked` after init. Documented in SPEC/program/sim-scenarios.md; applied in scenario_runner.
- **order_script**: Use `buildUnitCategoryForUnitType` from colonizethis_data so regiment ids (e.g. `lancers`) are treated as military builds.
- **military_units_buildability.json**: fromTopology with one GP; setup sets `initialTech` [organised_regiments], 1 peasant, grain/fabric/castIron; turn 1 build lancers in capital; assert province owner gp1 and unitCount ≥ 6 (5 starting civilians + 1 lancers). Province id prefixed (`oldWorld|p1`).
- **Tests**: Parse and assert `initialTech` in sim_scenarios_test.
- **Coverage**: gdd-scenario-coverage.json updated for game/military-units.md.

All 30 sim_scenarios pass; logic tests pass; coverage tool reports 18 covered (military-units.md now covered).

Made with [Cursor](https://cursor.com)