### PR TITLE
Tech-tree-diplomacy-civilian: tech costs/prereqs (MVP) and Propaganda deferred (Fixes #589)

### DIFF
--- a/SPEC/game/tech-tree-diplomacy-civilian.md
+++ b/SPEC/game/tech-tree-diplomacy-civilian.md
@@ -23,6 +23,16 @@ The **diplomacy and civilian tech table in this doc is the GDD source of truth**
 
 ---
 
+## Tech costs and prerequisites (MVP)
+
+Tech costs and prerequisite ids for diplomacy/civilian techs are defined by the **tech table in this doc** (source of truth). **Implementation:** The program-level tech catalog (e.g. `colonizethis_data`) uses the same structure as other techs: fixed `cost` and `prerequisiteIds` per this table. When diplomacy/civilian techs are added to the catalog, prerequisite ids such as `printing_press` and `money_lending` are defined there (or in a shared catalog that includes labour/civilian techs). **Ruleset override** for tech costs and prereqs is deferred; when added, document in [ruleset-config.md](ruleset-config.md) and in the program ruleset-config.
+
+## Propaganda effect (deferred)
+
+The **Propaganda** tech effect "Decreases diplomatic penalties for declaring war" is **not implemented** in MVP. When implemented, the application point will be in diplomacy resolution (e.g. relation modifiers when declaring war); formula and magnitude are owner decisions. See [diplomacy-resolution.md](../program/diplomacy-resolution.md).
+
+---
+
 ## Effect Semantics
 
 - **Diplomatic Expertise:** Unlocks embassy overture and allows civilian units to work in Minor Nations with embassy.

--- a/SPEC/program/diplomacy-resolution.md
+++ b/SPEC/program/diplomacy-resolution.md
@@ -77,6 +77,8 @@ Rejections and validation failures are logged by the order engine; diplomacy res
 
 Relation thresholds (score-to-level bands) and overture costs (Consulate £500, Embassy £1000) are currently **code constants** in the diplomacy resolver (`colonizethis_logic`: `overtureConsulateCost`, `overtureEmbassyCost`, `scoreToLevel`). The **default values** are defined in [diplomacy.md](../game/diplomacy.md) § Configurable Values; that table is the source of truth for design. Ruleset loading for these parameters is **not implemented** in MVP. When ruleset-driven config is added, the resolver will read from the resolved ruleset per [ruleset-config.md](ruleset-config.md) and the key path will be specified in the GDD and here.
 
+**Propaganda tech:** The effect "Decreases diplomatic penalties for declaring war" (Propaganda tech per [tech-tree-diplomacy-civilian.md](../game/tech-tree-diplomacy-civilian.md)) is **not implemented** in MVP. When implemented, it would apply in step 6 (Apply relation modifiers) or in a war-declaration-specific modifier.
+
 ---
 
 ## Constraints


### PR DESCRIPTION
Fixes #589

**Spec:** SPEC/game/tech-tree-diplomacy-civilian.md

**1. Tech costs and prerequisites (MVP)**  
- GDD: Added § Tech costs and prerequisites (MVP). Tech table in this doc is source of truth. Implementation uses program-level catalog (e.g. colonizethis_data) with same structure as other techs; when diplomacy/civilian techs are added, prerequisite ids (e.g. `printing_press`, `money_lending`) are defined there. Ruleset override deferred; when added, document in ruleset-config.

**2. Propaganda effect**  
- GDD: Added § Propaganda effect (deferred). Effect "Decreases diplomatic penalties for declaring war" is not implemented in MVP; when implemented, application point in diplomacy resolution; formula and magnitude owner decisions. Cross-ref diplomacy-resolution.md.  
- TDD: In diplomacy-resolution.md § Config source (MVP), added note that Propaganda tech effect is not in MVP; when implemented would apply in step 6 (Apply relation modifiers).

Docs-only.

Made with [Cursor](https://cursor.com)