### PR TITLE
Map-data TDD: align generate_map CLI options with spec (Fixes #483)

### DIFF
--- a/SPEC/program/map-data.md
+++ b/SPEC/program/map-data.md
@@ -38,7 +38,44 @@ Define topology format, tile map data structures, province identity, and tile ke
 
 ## Map generation tool
 
-**Place:** `tool/generate_map/`. **Mode:** Generate from N and C via `--provinces`, `--continents`. Infer topology. Output: graph, summary, tile map PNG, topology DOT/PNG. **Options:** `--provinces`, `--continents`, `--region`, `--tiles-per-province`, `--sea-fraction`, `--interactive`, `--tile-map`, `--tile-map-image`, `--seed`, `--world-state`, `--join-continents`, `--seed-before-assignment`, `--skip-fill-lakes`, `--continent-buffer`. Topology graph: DOT export; map-aligned layout when tile map available. **Run:** `melos run generate_map -- [options]`. **Logging:** Operational and diagnostic output follows [ctdev-logging.md](ctdev-logging.md) (logger with `map:` prefix; errors to stderr and non-zero exit).
+**Place:** `tool/generate_map/`. **Mode:** Generate from N and C via `--provinces`, `--continents`. Infer topology. Always output: topology graph description and map summary on stdout. Optionally: tile map PNG (via `--tile-map-image`), topology DOT and PNG (when `--tile-map-image` or `--topology-graph` is used). **Run:** `melos run generate_map -- [options]`. **Logging:** Operational and diagnostic output follows [ctdev-logging.md](ctdev-logging.md) (logger with `map:` prefix; errors to stderr and non-zero exit).
+
+### CLI options (MVP)
+
+| Option | Form | Default | Validation / semantics |
+|--------|------|---------|------------------------|
+| `--provinces` | `--provinces N` or `--provinces=N` | 60 | Positive integer; invalid → stderr message, exit 1 |
+| `--continents` | `--continents M` or `--continents=M` | 3 | Integer in [2, 4]; invalid → stderr message, exit 1 |
+| `--region` | `--region id` or `--region=id` | oldWorld | `oldWorld` or `newWorld` only; invalid → stderr message, exit 1 |
+| `--tiles-per-province` | `--tiles-per-province N` or `=N` | 35 | Positive integer; invalid → stderr, exit 1 |
+| `--sea-fraction` | `--sea-fraction F` or `=F` | 0.6 | Double in [0, 1); invalid → stderr, exit 1 |
+| `--interactive` | flag | off | Prompt for province id and show detail; type `q` to quit. With `--world-state`, province detail includes owner. |
+| `--tile-map-image` | `--tile-map-image` or `--tile-map-image=path` | — | If no path: write PNG to temp file, path printed. If path given: write PNG there. Tries to open in default viewer. |
+| `--tile-size` | `--tile-size N` or `=N` | 24 (when PNG exported) | Pixels per cell in tile map PNG; positive integer; invalid → stderr, exit 1 |
+| `--topology-graph` | `--topology-graph` or `--topology-graph=path` | — | Export topology as DOT (and PNG via neato when Graphviz installed). When only `--tile-map-image` is used (no `--topology-graph`), DOT is written to a temp path (printed on stdout). When `--topology-graph` is used with empty path and `--tile-map-image=path` is set, DOT path is derived from PNG path (e.g. `foo.png` → `foo_topology.dot`). When `--topology-graph=path` is set, that path is used. |
+| `--seed` | `--seed N` or `=N` | random | Integer; invalid → stderr, exit 1 |
+| `--world-state` | `--world-state path` | — | Path to world state JSON; used for ownership in interactive province detail. File must exist; missing file → stderr, exit 1 |
+| `--join-continents` | flag | off | Enable join step (Pass 10) |
+| `--seed-before-assignment` | flag or `=true|false` | off | Use legacy land assignment |
+| `--skip-fill-lakes` | flag or `=true|false` | off | Skip Pass 4 (fill lakes) |
+| `--continent-buffer` | `--continent-buffer N` or `=N` | 2 | Non-negative integer; invalid → stderr, exit 1 |
+
+There is no separate `--tile-map` flag: topology and map summary are always produced; PNG export is requested only via `--tile-map-image`.
+
+### Output and file semantics
+
+- **Stdout:** Topology graph text, map summary (province and sea-zone counts from topology/tile-count helpers). With `--tile-map-image`, the PNG path is printed. With `--topology-graph` (or when writing DOT), the DOT path is printed.
+- **Tile map PNG:** Only when `--tile-map-image` is present. Path: explicit path if `=path` given; otherwise temp file. Cell size: `--tile-size` or 24.
+- **Topology graph:** DOT file written when `--tile-map-image` or `--topology-graph` is used. PNG from DOT via `neato` when Graphviz is installed; otherwise a warning to stderr.
+
+### Acceptance criteria
+
+- Given valid options and no invalid numeric/range values, when the user runs `melos run generate_map -- [options]`, then the tool exits with code 0 and stdout contains the topology graph section and map summary with province and sea-zone counts.
+- Given `--provinces` with a non-positive value (or non-integer), when the user runs the CLI, then the tool exits with code 1 and writes an error message to stderr.
+- Given `--continents` outside [2, 4], when the user runs the CLI, then the tool exits with code 1 and writes an error message to stderr (e.g. indicating the valid range).
+- Given `--region` with a value other than `oldWorld` or `newWorld`, when the user runs the CLI, then the tool exits with code 1 and writes an error message to stderr.
+- Given `--tile-map-image=path` and a valid run, when the tool completes, then the file at `path` exists and is a PNG; if topology graph is written, the DOT path is printed and the DOT file exists.
+- Given `--world-state path` and a non-existent file, when the user runs the CLI, then the tool exits with code 1 and writes an error message to stderr.
 
 ---
 

--- a/docs/project-tools.md
+++ b/docs/project-tools.md
@@ -63,10 +63,11 @@ melos run generate_map -- [options]
 - `--tiles-per-province N` (default: 35)
 - `--sea-fraction F` (default: 0.6; sea fraction 0–1)
 - `--interactive` — prompt for province id and show detail; type `q` to quit
-- `--tile-map` — generate tile map and print map summary
 - `--tile-map-image[=path]` — export tile map as PNG. If path given, write there; otherwise temp file. Tries to open in default viewer.
+- `--tile-size N` — pixels per cell in PNG (default: 24).
+- `--topology-graph[=path]` — export topology as DOT (and PNG when Graphviz installed). Path derived from tile-map-image path when omitted.
 - `--seed <n>` — seed for map generation (default: random)
-- `--world-state <path>` — load world state JSON for owner in province detail (path relative to repo root)
+- `--world-state <path>` — load world state JSON for owner in province detail (path must exist)
 - `--join-continents` — enable join step (Pass 10); default off
 - `--seed-before-assignment` — use legacy land assignment; default off
 - `--skip-fill-lakes` — skip Pass 4 (fill lakes); default off

--- a/tool/generate_map/test/generate_map_cli_test.dart
+++ b/tool/generate_map/test/generate_map_cli_test.dart
@@ -186,7 +186,7 @@ void main() {
       expect(result.stderr, contains('oldWorld or newWorld'));
     });
 
-    test('--tile-map-image outputs topology graph DOT', () async {
+    test('--tile-map-image outputs PNG and topology graph DOT', () async {
       final tmpDir = Directory.systemTemp.createTempSync('generate_map_test_');
       addTearDown(() => tmpDir.deleteSync(recursive: true));
       final mapPath = p.join(tmpDir.path, 'map.png');
@@ -208,7 +208,90 @@ void main() {
       );
       expect(result.exitCode, 0, reason: result.stderr.toString());
       expect(result.stdout, contains('Topology graph (DOT)'));
+      expect(result.stdout, contains('=== Map summary ==='));
       expect(File(mapPath).existsSync(), isTrue);
+    });
+
+    test('--provinces 0 exits with error and message on stderr', () async {
+      final result = await Process.run(
+        'dart',
+        [
+          'run',
+          'generate_map',
+          '--provinces',
+          '0',
+          '--continents',
+          '2',
+        ],
+        runInShell: false,
+        workingDirectory: _packageRoot,
+      );
+      expect(result.exitCode, 1);
+      expect(result.stderr, contains('provinces'));
+    });
+
+    test('--sea-fraction out of range exits with error on stderr', () async {
+      final result = await Process.run(
+        'dart',
+        [
+          'run',
+          'generate_map',
+          '--provinces',
+          '4',
+          '--continents',
+          '2',
+          '--sea-fraction',
+          '1.0',
+        ],
+        runInShell: false,
+        workingDirectory: _packageRoot,
+      );
+      expect(result.exitCode, 1);
+      expect(result.stderr, contains('sea-fraction'));
+    });
+
+    test('--tile-size 0 with tile-map-image exits with error on stderr', () async {
+      final tmpDir = Directory.systemTemp.createTempSync('generate_map_test_');
+      addTearDown(() => tmpDir.deleteSync(recursive: true));
+      final mapPath = p.join(tmpDir.path, 'out.png');
+      final result = await Process.run(
+        'dart',
+        [
+          'run',
+          'generate_map',
+          '--provinces',
+          '3',
+          '--continents',
+          '2',
+          '--tile-map-image=$mapPath',
+          '--tile-size',
+          '0',
+        ],
+        runInShell: false,
+        workingDirectory: _packageRoot,
+      );
+      expect(result.exitCode, 1);
+      expect(result.stderr, contains('tile-size'));
+    });
+
+    test('--world-state with missing file exits with error on stderr', () async {
+      final result = await Process.run(
+        'dart',
+        [
+          'run',
+          'generate_map',
+          '--provinces',
+          '4',
+          '--continents',
+          '2',
+          '--world-state',
+          '/nonexistent/world_state.json',
+        ],
+        runInShell: false,
+        workingDirectory: _packageRoot,
+      );
+      expect(result.exitCode, 1);
+      expect(result.stderr, contains('not found'));
     });
   });
 }


### PR DESCRIPTION
Fixes #483

- **SPEC/program/map-data.md:** Map generation tool subsection expanded with full CLI option table (all options and forms), validation rules (invalid → stderr, exit 1), output and file semantics for `--tile-map-image`, `--tile-size`, `--topology-graph`, interactive mode and `--world-state`. Removed obsolete `--tile-map`; PNG export only via `--tile-map-image`. Added Given–When–Then acceptance criteria for success and error paths.
- **docs/project-tools.md:** Added `--tile-size` and `--topology-graph`; removed `--tile-map`; clarified `--world-state` path must exist.
- **tool/generate_map/test/generate_map_cli_test.dart:** New tests for error paths: `--provinces 0`, `--sea-fraction` out of range, `--tile-size 0` with `--tile-map-image`, `--world-state` missing file. Success path with `--tile-map-image` now asserts map summary on stdout.

Made with [Cursor](https://cursor.com)