### PR TITLE
Map-data/save-load: clarify tile map persistence (Fixes #482)

### DIFF
--- a/SPEC/program/map-data.md
+++ b/SPEC/program/map-data.md
@@ -32,7 +32,9 @@ Define topology format, tile map data structures, province identity, and tile ke
 
 ## Tile map format
 
-**Per-region 2D grid (static per scenario).** Each cell: region id (province or sea zone), type (land/water), **terrain type** (land), **resource** (optional; at most one). Resource must be allowed for region and terrain; rules in colonizethis_data. Extraction level and road are **mutable** game state (keyed by tile), not part of static tile map. Produced by [tile-map-gen-*](tile-map-gen-algorithm.md) or loaded from data. Not persisted in game save.
+**Per-region 2D grid (static per scenario).** Each cell: region id (province or sea zone), type (land/water), **terrain type** (land), **resource** (optional; at most one). Resource must be allowed for region and terrain; rules in colonizethis_data. Extraction level and road are **mutable** game state (keyed by tile), not part of static tile map. Produced by [tile-map-gen-*](tile-map-gen-algorithm.md) or loaded from data.
+
+**Persistence (MVP):** The tile map is **not** part of the mandatory game save payload; only world state (e.g. province ownership) is required to load a game. When a save is created by **ctdev** or **init_game** with map output, tile maps may be stored as **optional map data** per [save-load.md](save-load.md) (keys `_tileMapByRegion`, etc.). That serialization uses the same TileMapResult JSON format and is for **ctdev/init tooling** (e.g. Load Savegame map view); the main game does not require map data to load. Format and semantics of the tile map are defined in this spec; the save/load contract for optional map data is in save-load.md.
 
 ---
 

--- a/SPEC/program/save-load.md
+++ b/SPEC/program/save-load.md
@@ -31,7 +31,7 @@
 
 ## Optional map data
 
-- Map data (tile maps per region, topology per region, combined topology) is optional. Saves created by ctdev Init Game or init_game with map output include it; legacy saves may have none.
+- Map data (tile maps per region, topology per region, combined topology) is optional. Saves created by ctdev Init Game or init_game with map output include it; legacy saves may have none. Tile map structure and semantics are defined in [map-data.md](map-data.md) § Tile map format; this serialization is for **ctdev/init tooling** (e.g. Load Savegame map view). The main game does not require map data to load.
 - **saveMapData:** Writes the three map-data keys for the given `gameId`. Caller supplies `tileMapByRegion`, `topologyByRegion`, `combinedTopology`.
 - **loadMapData:** Returns the three maps for `gameId`, or **null** if any of the three keys is missing (legacy save). Ctdev Load Savegame shows a message when map data is absent and cannot open the map view; see [ctdev-app.md](ctdev-app.md) § Load Savegame.
 

--- a/packages/colonizethis_data/lib/src/tile_map_result.dart
+++ b/packages/colonizethis_data/lib/src/tile_map_result.dart
@@ -58,7 +58,7 @@ class TileMapResult {
   static String _pairKey(String a, String b) =>
       a.compareTo(b) < 0 ? '$a|$b' : '$b|$a';
 
-  /// Serializes for save/load (e.g. ctdev Load Savegame). SPEC/project/plan-update-gp-colours-save-load.
+  /// Serializes when optional map data is saved (ctdev, init_game). See SPEC/program/save-load.md, SPEC/program/map-data.md.
   Map<String, dynamic> toJson() {
     return {
       'width': width,


### PR DESCRIPTION
Clarifies the spec and implementation comment so contributors can tell whether changes to TileMapResult are user-visible save-format changes or internal tooling.

**Changes:**
- **SPEC/program/map-data.md** § Tile map format: State that the tile map is not part of the mandatory game save payload; when saved by ctdev or init_game, tile maps are stored as optional map data per save-load.md. Distinguish game save format (save-load) vs ctdev/init tooling serialization (map-data).
- **SPEC/program/save-load.md** § Optional map data: Cross-ref map-data.md for tile map structure/semantics; note serialization is for ctdev/init tooling; main game does not require map data to load.
- **packages/colonizethis_data/lib/src/tile_map_result.dart**: Align `toJson()` comment with specs (save-load.md, map-data.md).

Fixes #482

Made with [Cursor](https://cursor.com)