### PR TITLE
Fixes #464: Tile-map-generation archive spec non-normative and code refs

### DIFF
--- a/SPEC/archive/tile-based-map-generation.md
+++ b/SPEC/archive/tile-based-map-generation.md
@@ -1,3 +1,7 @@
+**Non-normative historical background.** This document describes an early graph-first tile map design (input = topology graph G; map generation enforces adjacency iff edges exist). It is **not** the source of truth. The canonical specs for tile map generation are: [tile-map-gen-algorithm.md](../program/tile-map-gen-algorithm.md), [tile-map-gen-resources.md](../program/tile-map-gen-resources.md), [tile-map-gen-config.md](../program/tile-map-gen-config.md), [map-data.md](../program/map-data.md), and [tile-map-and-generation.md](../game/tile-map-and-generation.md). Current GDD/TDD use a **map-first** design: input is province/continent counts and region params; topology is inferred from the grid. Implementation and tests follow the program and game specs only.
+
+---
+
 Below is a detailed design for a tile-based map generation algorithm tailored to your Imperialism II redesign. The algorithm generates a semi-random tile map (e.g., a 2D grid of tiles) that respects the given world topology graph. It ensures:
 
 - **Topology Respect**: Two regions (provinces or sea zones) in the generated map are adjacent (i.e., have at least one pair of tiles that share an edge) **if and only if** they are connected in the input graph. This prevents unwanted adjacencies while guaranteeing required ones.

--- a/SPEC/program/tile-map-gen-config.md
+++ b/SPEC/program/tile-map-gen-config.md
@@ -48,4 +48,4 @@ Implemented in colonizethis_map. Consumed by App (game/scenario load), tools. Ti
 
 ## Constraints
 
-- Grid dimensions derived; no topology input. Reference: ideas/tile-based-map-generation.md (archived) was sample only; this spec is authoritative.
+- Grid dimensions derived; no topology input. The archived document [SPEC/archive/tile-based-map-generation.md](../archive/tile-based-map-generation.md) is non-normative historical background; this spec and tile-map-gen-algorithm.md are authoritative.

--- a/packages/colonizethis_map/lib/src/tile_map_generator.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator.dart
@@ -1,4 +1,4 @@
-// SPEC/program/tile-map-gen-algorithm.md, tile-map-gen-resources.md, tile-map-gen-config.md. Reference: SPEC/archive/tile-based-map-generation.md.
+// SPEC/program/tile-map-gen-algorithm.md, tile-map-gen-resources.md, tile-map-gen-config.md.
 
 import 'dart:math';
 


### PR DESCRIPTION
Fixes #464

- **SPEC/archive/tile-based-map-generation.md:** Add header marking it as non-normative historical background; point to canonical specs (tile-map-gen-algorithm, tile-map-gen-resources, tile-map-gen-config, map-data, tile-map-and-generation).
- **tile_map_generator.dart:** Drop normative Reference to archive; keep only current TDD refs.
- **tile-map-gen-config.md:** Reference archive as non-normative historical background; this spec and tile-map-gen-algorithm authoritative.

Docs and comment-only; no behavior change.

Made with [Cursor](https://cursor.com)