### PR TITLE
Workers: luxury consumption and effective production labour

### DIFF
--- a/SPEC/game/workers-and-population.md
+++ b/SPEC/game/workers-and-population.md
@@ -52,7 +52,16 @@ Per Imperialism II 02-economy: workers "in your city" supply labour for industry
 
 Data structures in [economy-models.md](../program/economy-models.md). Worker model distinct from Unit; workers live in economy (TDD 04), not unit model (TDD 05). Config is program-level (no JSON rulesets).
 
-**Current scope:** Food consumption and starvation are implemented in economy_consumption.dart (peasant 1 food, trained 2 food; starvation order: peasants first, then apprentices, journeymen, masters). Luxury consumption (sugar, cigars, fur hats) and worker tier training (paper + cash → next tier) are deferred until Recruiting/Training quantities are defined or a simplification is chosen.
+**Current scope:** Food consumption and starvation are implemented in economy_consumption.dart (peasant 1 food, trained 2 food; starvation order: peasants first, then apprentices, journeymen, masters). **Luxury consumption** is in scope: trained workers consume one unit of their tier luxury per turn (refinedSugar / cigars / furHats); shortage reduces that worker's labour contribution to zero for that turn (worker is not removed). Worker tier training (paper + cash → next tier) remains deferred until Recruiting/Training quantities are defined or a simplification is chosen.
+
+---
+
+## Luxury consumption (in scope)
+
+- **Commodity per tier:** Apprentice → 1 refinedSugar; Journeyman → 1 cigars; Master → 1 furHats. Commodity ids per [commodity-catalog.md](commodity-catalog.md).
+- **Deduction:** During the Consumption phase, the System deducts from the player stockpile up to one unit of the tier luxury per trained worker of that tier (e.g. 3 apprentices → deduct min(3, stockpile.refinedSugar)).
+- **Order:** Luxury deduction happens after food deduction and starvation; order by tier is implementation-defined (e.g. apprentices, then journeymen, then masters).
+- **Labour effect:** When computing available labour for the Production phase, a trained worker contributes labour only if that worker's tier luxury was available and deducted for them (or equivalently: effective labour = peasants×1 + min(apprentices, refinedSugar)×4 + min(journeymen, cigars)×6 + min(masters, furHats)×8). Workers without luxury remain in the WorkerPool and contribute zero labour that turn.
 
 ---
 
@@ -62,9 +71,13 @@ Data structures in [economy-models.md](../program/economy-models.md). Worker mod
   When the System executes the Consumption phase for that player  
   Then the System deducts the required food quantities for each worker tier from the stockpile in the specified order, removes workers that starve when their required food cannot be met starting with Peasants and proceeding up through Apprentices, Journeymen, and Masters, and does not reduce any worker count below zero.
 
-- Given a trained worker (Apprentice, Journeyman, or Master) remains alive after the Consumption phase but the required luxury commodity for that tier is not fully available in the stockpile  
+- Given a player has at least one trained worker (Apprentice, Journeyman, or Master) and a non-zero stockpile quantity of that tier's luxury commodity (refinedSugar, cigars, or furHats respectively)  
+  When the System executes the Consumption phase for that player  
+  Then the System deducts from the stockpile one unit of that luxury per trained worker of that tier, up to the available stockpile quantity (e.g. 2 apprentices and 1 refinedSugar → deduct 1 refinedSugar; 2 apprentices and 3 refinedSugar → deduct 2 refinedSugar), and does not deduct more than the number of workers in that tier or more than the stockpile quantity.
+
+- Given a trained worker (Apprentice, Journeyman, or Master) remains alive after the Consumption phase but the required luxury commodity for that tier was not fully available in the stockpile (so fewer units were deducted than workers in that tier)  
   When the System computes available labour for the Production phase  
-  Then the System counts that worker’s labour contribution as zero for that turn while still leaving the worker in the WorkerPool for future turns.
+  Then the System counts that worker's labour contribution as zero for that turn while still leaving the worker in the WorkerPool for future turns (effective labour formula: peasants×1 + min(apprentices, refinedSugar_available_at_production)×4 + min(journeymen, cigars_available)×6 + min(masters, furHats_available)×8, where "available" is the stockpile quantity at the start of Production phase before luxury is deducted).
 
 - Given a player has sufficient fabric (and, when defined, paper and cash) in the stockpile to recruit or train a worker according to the recruiting and training rules for a particular era  
   When the System resolves a recruit or train action for that worker  

--- a/SPEC/program/turn-resolution-phase-details.md
+++ b/SPEC/program/turn-resolution-phase-details.md
@@ -36,7 +36,7 @@ Per recipe: consume inputs and labour from stockpile and WorkerPool; add outputs
 
 ## Consumption
 
-Military regiments consume food upkeep **before** workers and navy. Per player: (1) Compute regiment food demand. (2) Consume food from stockpile (military-first). (3) Derive feeding coverage ratio → morale/strength modifier for Combat (coverage ≥ 1.0 → 1.0; 0.5–<1.0 → 0.75; <0.5 → 0.5). (4) Workers/navy consume remainder per [workers-and-population.md](../game/workers-and-population.md); starvation removes workers. Upkeep shortfall for military affects morale/strength, not unit count.
+Military regiments consume food upkeep **before** workers and navy. Per player: (1) Compute regiment food demand. (2) Consume food from stockpile (military-first). (3) Derive feeding coverage ratio → morale/strength modifier for Combat (coverage ≥ 1.0 → 1.0; 0.5–<1.0 → 0.75; <0.5 → 0.5). (4) Workers/navy consume remainder per [workers-and-population.md](../game/workers-and-population.md): food first, then starvation removes workers; then **luxury deduction** (one unit per trained worker of that tier: refinedSugar/apprentices, cigars/journeymen, furHats/masters), up to stockpile. Upkeep shortfall for military affects morale/strength, not unit count.
 
 ---
 

--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -40,7 +40,7 @@
   "game/tile-map-and-generation.md": [],
   "game/turn-time-mapping.md": [],
   "game/victory.md": [],
-  "game/workers-and-population.md": ["workers_consumption_starvation.json"],
+  "game/workers-and-population.md": ["workers_consumption_starvation.json", "workers_luxury_consumption.json", "workers_luxury_zero_labour.json"],
   "game/world-model.md": [],
   "game/world-model-identity.md": ["world_model_identity_prefixed_provinces.json"]
 }

--- a/SPEC/project/outstanding-tasks.md
+++ b/SPEC/project/outstanding-tasks.md
@@ -92,15 +92,15 @@ No outstanding P0 tasks.
 
 ### Task: Verify and Complete Worker/Population Model
 
-**Status:** Food consumption and starvation verified and tested (economy_consumption_test, economy_logic_test). Luxury and training deferred per spec.
+**Status:** Food consumption and starvation verified and tested (economy_consumption_test, economy_logic_test). Luxury consumption is in scope per spec (AC and scenarios added) and now implemented in logic (consumption + effective labour). Training remains deferred per spec.
 
-**Gap:** Worker model exists (`WorkerPool`). Food and starvation implemented; luxury and training deferred.
+**Gap:** Worker model exists (`WorkerPool`). Food and starvation implemented; luxury consumption specified and scenarios added (workers_luxury_consumption.json, workers_luxury_zero_labour.json) and now wired into `economy_consumption.dart` (tier luxuries) and `economy_production.dart` (effective labour). Training remains deferred.
 
 | Component | Spec Reference | Status |
 |-----------|----------------|--------|
 | Worker tiers (Peasant/Journeyman/Master) | `workers-and-population.md` | **Done** — model and consumption |
 | Food consumption | `workers-and-population.md` | **Done** — 1/2 food per tier, tested |
-| Luxury consumption | `workers-and-population.md` | Deferred |
+| Luxury consumption | `workers-and-population.md` | **Done** — AC and sim_scenarios added; implemented and tested (`economy_consumption.dart`, `economy_production.dart`, sim_scenarios workers_luxury_*.json) |
 | Starvation (worker death) | `workers-and-population.md` | **Done** — order peasants first, tested |
 | Training (tier upgrade) | `workers-and-population.md` | Deferred (CLARIFICATION NEEDED) |
 
@@ -108,12 +108,9 @@ No outstanding P0 tasks.
 - [SPEC/game/workers-and-population.md](SPEC/game/workers-and-population.md)
 
 **What needs to be done:**
-1. Verify food consumption in `economy_consumption.dart` matches spec (1 grain+meat per tier)
-2. Verify luxury consumption for trained workers (sugar, cigars, furs)
-3. Verify starvation removes workers when food cannot be met
-4. Implement worker training (fabric + paper + cash → next tier)
+1. Implement worker training (fabric + paper + cash → next tier) once quantities and tech gates are clarified in spec.
 
-**Acceptance criteria:** Done when economy_consumption_test (and related tests) assert food per tier, starvation order, and luxury/training behavior per workers-and-population.md; training implementation or deferral documented.
+**Acceptance criteria:** Done when training behaviour (recruit/upgrade costs, tier changes) is specified in `workers-and-population.md`, implemented in logic, and covered by tests, or explicitly deferred with AC updated.
 
 **Complexity:** Medium
 

--- a/packages/colonizethis_logic/lib/src/economy/economy_consumption.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_consumption.dart
@@ -31,8 +31,8 @@ class ConsumptionResult {
 ///
 /// If food is insufficient, workers **starve** (removed from WorkerPool).
 /// Peasants are removed first, then apprentices, then journeymen, then masters.
-/// Luxury consumption and \"zero labour without luxuries\" are not yet
-/// modelled; they can be layered on top of this food resolution.
+/// After food and starvation, trained workers consume tier luxuries
+/// (refinedSugar/cigars/furHats) per SPEC/game/workers-and-population.md.
 ConsumptionResult resolveConsumption({
   required Stockpile stockpile,
   required WorkerPool workers,
@@ -138,6 +138,47 @@ ConsumptionResult resolveConsumption({
     apprentices: fedApprentices,
     journeymen: fedJourneymen,
     masters: fedMasters,
+  );
+
+  // --- Luxury consumption for trained workers ---
+  // SPEC/game/workers-and-population.md § Luxury consumption:
+  // - Apprentice → refinedSugar, Journeyman → cigars, Master → furHats.
+  // - During the Consumption phase, deduct up to 1 unit of the tier luxury
+  //   per surviving worker of that tier, capped by stockpile.
+  int _deductLuxury({
+    required int workerCount,
+    required CommodityId luxuryId,
+  }) {
+    if (workerCount <= 0) {
+      return 0;
+    }
+    final available = current.quantityOf(luxuryId);
+    if (available <= 0) {
+      return 0;
+    }
+    final toUse = workerCount < available ? workerCount : available;
+    if (toUse <= 0) {
+      return 0;
+    }
+    current = current.applyDelta(luxuryId, -toUse);
+    return toUse;
+  }
+
+  final refinedSugarId = CommodityCatalog.refinedSugar.id;
+  final cigarsId = CommodityCatalog.cigars.id;
+  final furHatsId = CommodityCatalog.furHats.id;
+
+  _deductLuxury(
+    workerCount: updatedWorkers.apprentices,
+    luxuryId: refinedSugarId,
+  );
+  _deductLuxury(
+    workerCount: updatedWorkers.journeymen,
+    luxuryId: cigarsId,
+  );
+  _deductLuxury(
+    workerCount: updatedWorkers.masters,
+    luxuryId: furHatsId,
   );
 
   _log.d(

--- a/packages/colonizethis_logic/lib/src/economy/economy_production.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_production.dart
@@ -4,6 +4,35 @@ import 'package:logger/logger.dart';
 
 final Logger _log = Logger();
 
+/// Computes effective available labour for production, capped by luxury
+/// availability per SPEC/program/economy-models.md and
+/// SPEC/game/workers-and-population.md.
+int _effectiveLabourForWorkers({
+  required WorkerPool workers,
+  required Stockpile stockpile,
+}) {
+  final peasantsLabour = workers.peasants * 1;
+
+  final refinedSugar = stockpile.quantityOf(CommodityCatalog.refinedSugar.id);
+  final cigars = stockpile.quantityOf(CommodityCatalog.cigars.id);
+  final furHats = stockpile.quantityOf(CommodityCatalog.furHats.id);
+
+  final apprenticesWithLuxury = workers.apprentices <= 0
+      ? 0
+      : (refinedSugar < workers.apprentices ? refinedSugar : workers.apprentices);
+  final journeymenWithLuxury = workers.journeymen <= 0
+      ? 0
+      : (cigars < workers.journeymen ? cigars : workers.journeymen);
+  final mastersWithLuxury = workers.masters <= 0
+      ? 0
+      : (furHats < workers.masters ? furHats : workers.masters);
+
+  return peasantsLabour +
+      apprenticesWithLuxury * 4 +
+      journeymenWithLuxury * 6 +
+      mastersWithLuxury * 8;
+}
+
 /// Production resolution helpers.
 /// SPEC/game/production-recipes.md
 /// SPEC/game/workers-and-population.md
@@ -49,6 +78,12 @@ ProductionResult resolveProduction({
   Stockpile current = stockpile;
   final productionByRecipe = <String, int>{};
 
+  final effectiveLabour = _effectiveLabourForWorkers(
+    workers: workers,
+    stockpile: stockpile,
+  );
+  var remainingEffectiveLabour = effectiveLabour;
+
   for (final assignment in assignments) {
     final recipe = ProductionRecipesCatalog.byId[assignment.recipeId];
     if (recipe == null) {
@@ -56,8 +91,22 @@ ProductionResult resolveProduction({
       continue;
     }
     if (assignment.assignedLabour <= 0) continue;
+    if (remainingEffectiveLabour <= 0) break;
 
-    final maxByLabour = assignment.assignedLabour ~/ recipe.labourPerOutput;
+    final labourPerOutput = recipe.labourPerOutput;
+    if (labourPerOutput <= 0) {
+      _log.w(
+        'logic: production recipe ${recipe.id} has non-positive labourPerOutput; skipping',
+      );
+      continue;
+    }
+
+    final labourBudgetForAssignment = assignment.assignedLabour <= remainingEffectiveLabour
+        ? assignment.assignedLabour
+        : remainingEffectiveLabour;
+    if (labourBudgetForAssignment <= 0) continue;
+
+    final maxByLabour = labourBudgetForAssignment ~/ labourPerOutput;
     if (maxByLabour <= 0) continue;
 
     // Compute maximum runs allowed by inputs.
@@ -76,6 +125,11 @@ ProductionResult resolveProduction({
     final runs = maxByInputs;
     if (runs <= 0) continue;
 
+    remainingEffectiveLabour -= runs * labourPerOutput;
+    if (remainingEffectiveLabour < 0) {
+      remainingEffectiveLabour = 0;
+    }
+
     productionByRecipe[assignment.recipeId] =
         (productionByRecipe[assignment.recipeId] ?? 0) + runs;
 
@@ -90,7 +144,9 @@ ProductionResult resolveProduction({
     current = current.applyDelta(recipe.outputCommodityId, totalOutput);
   }
 
-  _log.d('logic: production assignments=${assignments.length}');
+  _log.d(
+    'logic: production assignments=${assignments.length} effectiveLabour=$effectiveLabour',
+  );
   return ProductionResult(
     stockpile: current,
     workerPool: workers,

--- a/packages/colonizethis_logic/test/economy_consumption_test.dart
+++ b/packages/colonizethis_logic/test/economy_consumption_test.dart
@@ -136,5 +136,32 @@ void main() {
       expect(result.totalRegiments, 0);
       expect(result.fullyFedRegiments, 0);
     });
+
+    test('trained workers consume tier luxuries when available', () {
+      var stockpile = const Stockpile()
+          .applyDelta(CommodityCatalog.grain.id, 10)
+          .applyDelta(CommodityCatalog.meat.id, 10)
+          .applyDelta(CommodityCatalog.refinedSugar.id, 2)
+          .applyDelta(CommodityCatalog.cigars.id, 1)
+          .applyDelta(CommodityCatalog.furHats.id, 1);
+      const workers = WorkerPool(
+        peasants: 0,
+        apprentices: 2,
+        journeymen: 1,
+        masters: 1,
+      );
+
+      final result = resolveConsumption(stockpile: stockpile, workers: workers);
+
+      // Food sufficient: no starvation.
+      expect(result.workerPool.apprentices, 2);
+      expect(result.workerPool.journeymen, 1);
+      expect(result.workerPool.masters, 1);
+
+      // Luxury consumption capped by worker count and stockpile.
+      expect(result.stockpile.quantityOf(CommodityCatalog.refinedSugar.id), 0); // 2 apprentices → 2 refinedSugar used.
+      expect(result.stockpile.quantityOf(CommodityCatalog.cigars.id), 0); // 1 journeyman → 1 cigars used.
+      expect(result.stockpile.quantityOf(CommodityCatalog.furHats.id), 0); // 1 master → 1 furHats used.
+    });
   });
 }

--- a/packages/colonizethis_logic/test/economy_logic_test.dart
+++ b/packages/colonizethis_logic/test/economy_logic_test.dart
@@ -73,12 +73,68 @@ void main() {
         ],
       );
 
-      // labourPerOutput = 5, assigned 20 => max 4 runs.
+      // labourPerOutput = 5, assigned 20, but effective labour from 10 peasants
+      // is 10 → max 2 runs.
       // Inputs per run: 2 timber, 2 iron, 1 coal.
-      expect(result.stockpile.quantityOf(CommodityCatalog.castIron.id), 4);
-      expect(result.stockpile.quantityOf(CommodityCatalog.timber.id), 10 - 2 * 4);
-      expect(result.stockpile.quantityOf(CommodityCatalog.iron.id), 10 - 2 * 4);
-      expect(result.stockpile.quantityOf(CommodityCatalog.coal.id), 5 - 1 * 4);
+      expect(result.stockpile.quantityOf(CommodityCatalog.castIron.id), 2);
+      expect(result.stockpile.quantityOf(CommodityCatalog.timber.id), 10 - 2 * 2);
+      expect(result.stockpile.quantityOf(CommodityCatalog.iron.id), 10 - 2 * 2);
+      expect(result.stockpile.quantityOf(CommodityCatalog.coal.id), 5 - 1 * 2);
+    });
+
+    test('effective labour counts only trained workers with luxury', () {
+      // 1 apprentice, 0 peasants, 1 refinedSugar → effective labour = 4.
+      var stockpile = const Stockpile()
+          .applyDelta(CommodityCatalog.timber.id, 10)
+          .applyDelta(CommodityCatalog.refinedSugar.id, 1);
+      const workers = WorkerPool(
+        peasants: 0,
+        apprentices: 1,
+        journeymen: 0,
+        masters: 0,
+      );
+
+      final result = resolveProduction(
+        stockpile: stockpile,
+        workers: workers,
+        assignments: const [
+          AssignedRecipe(
+            recipeId: 'lumber_from_timber',
+            assignedLabour: 4,
+          ),
+        ],
+      );
+
+      // labourPerOutput = 2, effective labour 4 ⇒ 2 runs.
+      expect(result.stockpile.quantityOf(CommodityCatalog.lumber.id), 2);
+      expect(result.stockpile.quantityOf(CommodityCatalog.timber.id), 10 - 2 * 2);
+    });
+
+    test('trained workers without luxury contribute zero effective labour', () {
+      // 1 apprentice, 0 peasants, 0 refinedSugar → effective labour = 0.
+      var stockpile = const Stockpile()
+          .applyDelta(CommodityCatalog.timber.id, 10);
+      const workers = WorkerPool(
+        peasants: 0,
+        apprentices: 1,
+        journeymen: 0,
+        masters: 0,
+      );
+
+      final result = resolveProduction(
+        stockpile: stockpile,
+        workers: workers,
+        assignments: const [
+          AssignedRecipe(
+            recipeId: 'lumber_from_timber',
+            assignedLabour: 4,
+          ),
+        ],
+      );
+
+      // No luxury → no runs, inputs unchanged.
+      expect(result.stockpile.quantityOf(CommodityCatalog.lumber.id), 0);
+      expect(result.stockpile.quantityOf(CommodityCatalog.timber.id), 10);
     });
   });
 

--- a/packages/colonizethis_logic/test/economy_production_test.dart
+++ b/packages/colonizethis_logic/test/economy_production_test.dart
@@ -11,7 +11,8 @@ void main() {
           .applyDelta(CommodityCatalog.timber.id, 10)
           .applyDelta(CommodityCatalog.iron.id, 10)
           .applyDelta(CommodityCatalog.coal.id, 5);
-      const workers = WorkerPool(peasants: 10);
+      // 20 peasants → 20 labour (no luxury gating) so assignedLabour=20 can be fully used.
+      const workers = WorkerPool(peasants: 20);
 
       final result = resolveProduction(
         stockpile: stockpile,
@@ -35,7 +36,8 @@ void main() {
           .applyDelta(CommodityCatalog.timber.id, 4)
           .applyDelta(CommodityCatalog.iron.id, 20)
           .applyDelta(CommodityCatalog.coal.id, 20);
-      const workers = WorkerPool(peasants: 10);
+      // 20 peasants → 20 labour; inputs (timber) are the limiting factor.
+      const workers = WorkerPool(peasants: 20);
 
       final result = resolveProduction(
         stockpile: stockpile,
@@ -137,7 +139,8 @@ void main() {
           .applyDelta(CommodityCatalog.timber.id, 20)
           .applyDelta(CommodityCatalog.iron.id, 20)
           .applyDelta(CommodityCatalog.coal.id, 10);
-      const workers = WorkerPool(peasants: 20);
+      // 25 peasants → 25 labour; first assignment uses 15, second can use remaining 10.
+      const workers = WorkerPool(peasants: 25);
 
       final result = resolveProduction(
         stockpile: stockpile,

--- a/packages/colonizethis_logic/test/order_projections_test.dart
+++ b/packages/colonizethis_logic/test/order_projections_test.dart
@@ -270,7 +270,8 @@ void main() {
             displayName: 'A',
             isHuman: true,
             stockpile: Stockpile(quantities: {'timber': 4}),
-            workerPool: WorkerPool(peasants: 2),
+            // 4 peasants → 4 labour; assignedLabour=4 can be fully used.
+            workerPool: WorkerPool(peasants: 4),
           ),
         ],
       );

--- a/tool/sim_scenarios/scenarios/workers_luxury_consumption.json
+++ b/tool/sim_scenarios/scenarios/workers_luxury_consumption.json
@@ -1,0 +1,28 @@
+{
+  "name": "workers_luxury_consumption",
+  "description": "SPEC/game/workers-and-population.md: Consumption phase deducts luxury (refinedSugar) for trained workers; Production uses effective labour when luxury is available. Given 1 apprentice, food, 1 refinedSugar, 2 labour to lumber_from_timber: after turn 1 refinedSugar 0, lumber 1.",
+  "init": {
+    "type": "fromTopology",
+    "config": {"greatPowers": ["england"], "seed": 42, "minorNationCount": 0},
+    "oldWorld": {
+      "grid": [["p1", "sea1", "p2"], ["p1", "p1", "p2"]],
+      "nodes": [
+        {"id": "p1", "regionId": "oldWorld", "type": "province"},
+        {"id": "p2", "regionId": "oldWorld", "type": "province"},
+        {"id": "sea1", "regionId": "oldWorld", "type": "seaZone"}
+      ],
+      "edges": [{"id1": "p1", "id2": "sea1"}, {"id1": "p1", "id2": "p2"}]
+    }
+  },
+  "setup": {
+    "initialWorkers": {"gp1": {"peasants": 0, "apprentices": 1, "journeymen": 0, "masters": 0}},
+    "initialStockpile": {"gp1": {"grain": 2, "meat": 2, "refinedSugar": 1, "timber": 10}},
+    "productionAssignments": [{"recipeId": "lumber_from_timber", "assignedLabour": 2}]
+  },
+  "turns": [{"turn": 1, "orders": []}],
+  "assertions": [
+    {"turn": 1, "player": "gp1", "commodity": "refinedSugar", "stockpileCommodity": 0},
+    {"turn": 1, "player": "gp1", "commodity": "lumber", "stockpileCommodity": 1},
+    {"turn": 1, "player": "gp1", "workerApprentices": 1}
+  ]
+}

--- a/tool/sim_scenarios/scenarios/workers_luxury_zero_labour.json
+++ b/tool/sim_scenarios/scenarios/workers_luxury_zero_labour.json
@@ -1,0 +1,28 @@
+{
+  "name": "workers_luxury_zero_labour",
+  "description": "SPEC/game/workers-and-population.md: Trained worker without luxury contributes zero effective labour; worker is not removed. Given 1 apprentice, food, 0 refinedSugar, 4 labour assigned to lumber_from_timber: after turn 1 lumber 0, timber unchanged, workerApprentices 1.",
+  "init": {
+    "type": "fromTopology",
+    "config": {"greatPowers": ["england"], "seed": 42, "minorNationCount": 0},
+    "oldWorld": {
+      "grid": [["p1", "sea1", "p2"], ["p1", "p1", "p2"]],
+      "nodes": [
+        {"id": "p1", "regionId": "oldWorld", "type": "province"},
+        {"id": "p2", "regionId": "oldWorld", "type": "province"},
+        {"id": "sea1", "regionId": "oldWorld", "type": "seaZone"}
+      ],
+      "edges": [{"id1": "p1", "id2": "sea1"}, {"id1": "p1", "id2": "p2"}]
+    }
+  },
+  "setup": {
+    "initialWorkers": {"gp1": {"peasants": 0, "apprentices": 1, "journeymen": 0, "masters": 0}},
+    "initialStockpile": {"gp1": {"grain": 2, "meat": 2, "refinedSugar": 0, "timber": 10}},
+    "productionAssignments": [{"recipeId": "lumber_from_timber", "assignedLabour": 4}]
+  },
+  "turns": [{"turn": 1, "orders": []}],
+  "assertions": [
+    {"turn": 1, "player": "gp1", "commodity": "lumber", "stockpileCommodity": 0},
+    {"turn": 1, "player": "gp1", "commodity": "timber", "stockpileCommodity": 10},
+    {"turn": 1, "player": "gp1", "workerApprentices": 1}
+  ]
+}


### PR DESCRIPTION
## Summary

- Implemented worker luxury consumption in  so trained workers (apprentice/journeyman/master) consume their tier luxuries (refinedSugar, cigars, furHats) after food and starvation, matching  and .
- Capped effective production labour by worker luxury in  per , so peasants always contribute and trained tiers only contribute labour when their luxury is available; added unit tests in  /  and two sim_scenarios (, ) plus  wiring.
- Updated  Worker/Population Model task to record luxury behaviour as implemented and leave worker training explicitly deferred with updated acceptance criteria.

## Testing

-  in  for  and .
-  in .


Made with [Cursor](https://cursor.com)