### PR TITLE
Clarify AIConfig leader vs personality id semantics (Fixes #560)

### DIFF
--- a/SPEC/ai/ai-personalities.md
+++ b/SPEC/ai/ai-personalities.md
@@ -68,6 +68,11 @@ Difficulty does **not** change personality or AI strength. It only affects **sta
 
 Personality is loaded as config and supplied via **AIConfig** when the AI generates orders. [ai-systems-impl.md](../program/ai-systems-impl.md) defines where config holds personality and where domain planners and goal selection use it; [ai-planner.md](../program/ai-planner.md) describes integration and where AIConfig is built and supplied for order generation.
 
+In MVP, **AIConfig** fields related to personality have the following contract:
+
+- `leaderId` — canonical leader id (e.g. `victoria`, `napoleon`). This is the **only** id used by `colonizethis_ai` for personality lookups: domain weights, goal weights, and behavioral thresholds in `colonizethis_data/lib/src/ai_personality_config.dart` are all keyed by canonical leader id. Dossier/archetype display also derives from `leaderId` via that config.
+- `personalityId` — optional personality archetype id (e.g. an archetype handle in future rulesets). In MVP, `colonizethis_ai` does **not** read this field; callers SHOULD pass the same canonical id as `leaderId`. Future ruleset-configurable personality bundles may use `personalityId` as an override handle; when that happens, this spec and [ruleset-config.md](../program/ruleset-config.md) must be updated first.
+
 ---
 
 ## Acceptance criteria

--- a/SPEC/program/ai-systems-impl.md
+++ b/SPEC/program/ai-systems-impl.md
@@ -36,6 +36,11 @@ Orders generateStrategicOrders({
 
 `view` is the only visibility source; `config` holds personality, hidden agenda, difficulty modifiers; `seeds` per [ai-planner.md](ai-planner.md). Output: valid Orders. Callbacks for deterministic dialogue/mood events.
 
+Personality-related fields in **AIConfig** follow [ai-personalities.md](../ai/ai-personalities.md):
+
+- `leaderId` is the canonical leader id and is the only id used for personality lookups and dossier/archetype display.
+- `personalityId` is an optional archetype handle; in MVP it is not read by `colonizethis_ai`, and callers typically pass the same value as `leaderId`.
+
 ### Tactical (Quick Battle)
 
 ```dart

--- a/packages/colonizethis_ai/lib/src/ai_config.dart
+++ b/packages/colonizethis_ai/lib/src/ai_config.dart
@@ -1,7 +1,9 @@
 // AI configuration per nation: personality, hidden agenda, difficulty. SPEC/program/ai-systems-impl.md.
 
 /// Configuration passed to full AI for one Great Power.
-/// Holds leader personality id, assigned hidden agenda, and difficulty-derived modifiers.
+/// Holds canonical leader id for personality lookups, optional personality archetype
+/// id for future ruleset overrides, assigned hidden agenda, and difficulty-derived
+/// modifiers.
 class AIConfig {
   const AIConfig({
     required this.leaderId,
@@ -10,10 +12,15 @@ class AIConfig {
     this.difficultyModifiers = const {},
   });
 
-  /// Leader id (e.g. 'victoria', 'napoleon').
+  /// Canonical leader id (e.g. 'victoria', 'napoleon').
+  /// Used as the key for personality config lookups and dossier/archetype display.
   final String leaderId;
 
-  /// Personality archetype id for goal and utility weighting.
+  /// Optional personality archetype id for goal and utility weighting.
+  ///
+  /// In MVP, colonizethis_ai does not read this field; callers should typically
+  /// pass the same canonical id as [leaderId]. Future ruleset-configurable
+  /// personality bundles may use this as an override handle.
   final String personalityId;
 
   /// Assigned hidden agenda id (never exposed to player; used only for modifiers).

--- a/packages/colonizethis_ai/test/ai_config_test.dart
+++ b/packages/colonizethis_ai/test/ai_config_test.dart
@@ -6,18 +6,18 @@ void main() {
     test('holds leaderId personalityId hiddenAgendaId', () {
       const config = AIConfig(
         leaderId: 'victoria',
-        personalityId: 'industrial_trader',
+        personalityId: 'victoria',
         hiddenAgendaId: 'peacemaker',
       );
       expect(config.leaderId, 'victoria');
-      expect(config.personalityId, 'industrial_trader');
+      expect(config.personalityId, 'victoria');
       expect(config.hiddenAgendaId, 'peacemaker');
       expect(config.difficultyModifiers, isEmpty);
     });
     test('accepts difficultyModifiers', () {
       const config = AIConfig(
         leaderId: 'napoleon',
-        personalityId: 'militant',
+        personalityId: 'napoleon',
         hiddenAgendaId: 'warmonger',
         difficultyModifiers: {'resourceBonus': 1.2},
       );

--- a/packages/colonizethis_ai/test/domain_planners_test.dart
+++ b/packages/colonizethis_ai/test/domain_planners_test.dart
@@ -107,7 +107,7 @@ void main() {
       final snapshot = AIWorldSnapshot.fromPlayerView(view);
       const config = AIConfig(
         leaderId: 'victoria',
-        personalityId: 'industrial_trader',
+        personalityId: 'victoria',
         hiddenAgendaId: 'peacemaker',
       );
       final seeds = AISeedBundle.fromTurnSeed(999);
@@ -175,7 +175,7 @@ void main() {
       final snapshot = AIWorldSnapshot.fromPlayerView(view);
       const config = AIConfig(
         leaderId: 'victoria',
-        personalityId: 'industrial_trader',
+        personalityId: 'victoria',
         hiddenAgendaId: 'peacemaker',
       );
       final seeds = AISeedBundle.fromTurnSeed(100);
@@ -246,7 +246,7 @@ void main() {
       final snapshot = AIWorldSnapshot.fromPlayerView(view);
       const config = AIConfig(
         leaderId: 'victoria',
-        personalityId: 'industrial_trader',
+        personalityId: 'victoria',
         hiddenAgendaId: 'peacemaker',
       );
       final seeds = AISeedBundle.fromTurnSeed(123);
@@ -290,7 +290,7 @@ void main() {
       final snapshot = AIWorldSnapshot.fromPlayerView(view);
       const config = AIConfig(
         leaderId: 'victoria',
-        personalityId: 'industrial_trader',
+        personalityId: 'victoria',
         hiddenAgendaId: 'peacemaker',
       );
       final seeds = AISeedBundle.fromTurnSeed(456);

--- a/packages/colonizethis_ai/test/goal_manager_test.dart
+++ b/packages/colonizethis_ai/test/goal_manager_test.dart
@@ -15,7 +15,7 @@ void main() {
       );
       const config = AIConfig(
         leaderId: 'victoria',
-        personalityId: 'industrial_trader',
+        personalityId: 'victoria',
         hiddenAgendaId: 'peacemaker',
       );
       final goal = selectPrimaryGoal(snapshot, config, 42);
@@ -33,7 +33,7 @@ void main() {
       );
       const config = AIConfig(
         leaderId: 'victoria',
-        personalityId: 'industrial_trader',
+        personalityId: 'victoria',
         hiddenAgendaId: 'peacemaker',
       );
       final goal = selectPrimaryGoal(snapshot, config, 1);
@@ -50,7 +50,7 @@ void main() {
       );
       const config = AIConfig(
         leaderId: 'victoria',
-        personalityId: 'industrial_trader',
+        personalityId: 'victoria',
         hiddenAgendaId: 'peacemaker',
       );
       final goal = selectPrimaryGoal(snapshot, config, 2);
@@ -67,7 +67,7 @@ void main() {
       );
       const config = AIConfig(
         leaderId: 'victoria',
-        personalityId: 'industrial_trader',
+        personalityId: 'victoria',
         hiddenAgendaId: 'peacemaker',
       );
       final goal = selectPrimaryGoal(snapshot, config, 3);
@@ -84,7 +84,7 @@ void main() {
       );
       const config = AIConfig(
         leaderId: 'victoria',
-        personalityId: 'industrial_trader',
+        personalityId: 'victoria',
         hiddenAgendaId: 'peacemaker',
       );
       final goal = selectPrimaryGoal(snapshot, config, 4);

--- a/packages/colonizethis_ai/test/strategic_ai_test.dart
+++ b/packages/colonizethis_ai/test/strategic_ai_test.dart
@@ -28,7 +28,7 @@ void main() {
       final view = buildPlayerView(game, topology, 'gp1');
       final config = const AIConfig(
         leaderId: 'victoria',
-        personalityId: 'industrial_trader',
+        personalityId: 'victoria',
         hiddenAgendaId: 'peacemaker',
       );
       final seeds = AISeedBundle.fromTurnSeed(999);
@@ -64,7 +64,7 @@ void main() {
       final view = buildPlayerView(game, topology, 'gp1');
       const config = AIConfig(
         leaderId: 'victoria',
-        personalityId: 'industrial_trader',
+        personalityId: 'victoria',
         hiddenAgendaId: 'peacemaker',
       );
       final base = AISeedBundle.fromTurnSeed(0);
@@ -113,7 +113,7 @@ void main() {
       final view = buildPlayerView(game, topology, 'gp1');
       const config = AIConfig(
         leaderId: 'victoria',
-        personalityId: 'industrial_trader',
+        personalityId: 'victoria',
         hiddenAgendaId: 'peacemaker',
       );
       final base = AISeedBundle.fromTurnSeed(0);

--- a/packages/colonizethis_ai/test/tactical_ai_test.dart
+++ b/packages/colonizethis_ai/test/tactical_ai_test.dart
@@ -25,7 +25,7 @@ void main() {
       );
       const config = AIConfig(
         leaderId: 'test',
-        personalityId: 'militant',
+        personalityId: 'test',
         hiddenAgendaId: 'warmonger',
       );
       final actions = decideQuickBattleActions(
@@ -52,7 +52,7 @@ void main() {
       );
       const config = AIConfig(
         leaderId: 'test',
-        personalityId: 'militant',
+        personalityId: 'test',
         hiddenAgendaId: 'warmonger',
       );
       final a = decideQuickBattleActions(
@@ -106,7 +106,7 @@ void main() {
       );
       const config = AIConfig(
         leaderId: 'test',
-        personalityId: 'militant',
+        personalityId: 'test',
         hiddenAgendaId: 'warmonger',
       );
       for (var i = 0; i < 20; i++) {
@@ -158,7 +158,7 @@ void main() {
       );
       const config = AIConfig(
         leaderId: 'test',
-        personalityId: 'militant',
+        personalityId: 'test',
         hiddenAgendaId: 'warmonger',
       );
       for (var i = 0; i < 20; i++) {


### PR DESCRIPTION
## Summary
- Clarified in SPEC/ai/ai-personalities.md and SPEC/program/ai-systems-impl.md that AIConfig.leaderId is the canonical leader id used for all personality config lookups and dossier/archetype display, and that personalityId is an optional archetype handle not read by colonizethis_ai in MVP (callers should pass the same canonical id as leaderId).
- Updated ai_config.dart documentation to match the spec by describing leaderId as the canonical personality key and personalityId as a reserved archetype id for future ruleset overrides.
- Aligned colonizethis_ai tests (AIConfig, strategic_ai, goal_manager, domain_planners, tactical_ai) to pass canonical leader ids for personalityId so tests and code now exercise the documented contract without changing runtime behavior.

## Test plan
- Ran `dart test packages/colonizethis_ai`.

Made with [Cursor](https://cursor.com)