### PR TITLE
Resolve AI personality leader identity for variant leaderKey (Fixes #557, Fixes #558)

### DIFF
--- a/SPEC/ai/ai-personalities.md
+++ b/SPEC/ai/ai-personalities.md
@@ -73,6 +73,15 @@ In MVP, **AIConfig** fields related to personality have the following contract:
 - `leaderId` — canonical leader id (e.g. `victoria`, `napoleon`). This is the **only** id used by `colonizethis_ai` for personality lookups: domain weights, goal weights, and behavioral thresholds in `colonizethis_data/lib/src/ai_personality_config.dart` are all keyed by canonical leader id. Dossier/archetype display also derives from `leaderId` via that config.
 - `personalityId` — optional personality archetype id (e.g. an archetype handle in future rulesets). In MVP, `colonizethis_ai` does **not** read this field; callers SHOULD pass the same canonical id as `leaderId`. Future ruleset-configurable personality bundles may use `personalityId` as an override handle; when that happens, this spec and [ruleset-config.md](../program/ruleset-config.md) must be updated first.
 
+### Leader identity and `Player.leaderKey` (MVP)
+
+- Game state stores the chosen leader per Great Power on `Player.leaderKey` (string), set from the ruleset naming config (`LeaderVariant.leaderKey` in `naming_rules.dart`, e.g. `england_leader`, `france_leader`, `spain_leader`, `portugal_leader`, `netherlands_leader`, `prussia_leader`, `prussia_reserve_leader`, `sweden_leader`). This is the value serialized in the `Game` model and used by combat for leader bonuses per [leader-bonuses.md](../game/leader-bonuses.md).
+- For AI personality lookups and dossier/archetype display, `leaderId` in **AIConfig** MUST be a **canonical leader id** from § Canonical leaders (e.g. `victoria`, `napoleon`, `isabella`, `henry`, `deruyter`, `frederick`, `gustavus`). `colonizethis_logic` therefore resolves `Player.leaderKey` to a canonical id **before** constructing `AIConfig`, using a resolver in `colonizethis_data` (see `ai_personality_config.dart`).
+- The resolver accepts either a canonical id or a variant `leaderKey` and behaves as follows:
+  - If the input already matches a canonical id present in the personality tables, it is returned unchanged.
+  - If the input is a known variant key from the default naming config (e.g. `england_leader`, `france_leader`, `spain_leader`, `portugal_leader`, `netherlands_leader`, `prussia_leader`, `prussia_reserve_leader`, `sweden_leader`), it returns the corresponding canonical id (`victoria`, `napoleon`, `isabella`, `henry`, `deruyter`, `frederick`, `frederick`, `gustavus` respectively).
+  - If the input is unknown (e.g. a scenario-specific leader key not in the mapping), the canonical id used for lookups is the input string itself; `colonizethis_ai` then falls back to the **default** neutral personality weights and thresholds for that id per `ai_personality_config.dart`.
+
 ---
 
 ## Acceptance criteria
@@ -82,3 +91,4 @@ In MVP, **AIConfig** fields related to personality have the following contract:
 - **Domain weights:** Each leader has a defined domain-weight vector (economy, military, diplomacy, research). The vector biases behavior-tree goal selection and planner utility scores; relative weights matter.
 - **Behavioral modifiers:** Thresholds (war likelihood, peace tendency, alliance tendency, research preference) are applied when scoring actions (e.g. declare war, accept peace, choose research). Modifiers combine with hidden agendas per [hidden-agendas.md](hidden-agendas.md).
 - **Difficulty:** Difficulty level does not change personality or the AI algorithm; it only affects starting parameters and ruleset modifiers (e.g. resources, production, unit strength).
+- **Leader identity resolution:** Given a game where a Great Power’s `Player.leaderKey` is a known variant key from the naming config (e.g. `england_leader`), when the AI agent builds **AIConfig** for that Great Power, then `AIConfig.leaderId` equals the corresponding canonical leader id from § Canonical leaders (e.g. `victoria`) and `colonizethis_ai` uses that canonical id for all personality lookups (domain weights, goal weights, thresholds, and archetype display).

--- a/SPEC/program/ai-systems-impl.md
+++ b/SPEC/program/ai-systems-impl.md
@@ -41,6 +41,12 @@ Personality-related fields in **AIConfig** follow [ai-personalities.md](../ai/ai
 - `leaderId` is the canonical leader id and is the only id used for personality lookups and dossier/archetype display.
 - `personalityId` is an optional archetype handle; in MVP it is not read by `colonizethis_ai`, and callers typically pass the same value as `leaderId`.
 
+When `ai_planner.generateOrdersForPlayerFullAI` constructs **AIConfig** for an AI-controlled Great Power, it:
+
+- Reads `Player.leaderKey` from the `Game` model (variant key from the naming ruleset, e.g. `england_leader`, `france_leader`, `prussia_reserve_leader`).
+- Calls into `colonizethis_data` to resolve this value to a **canonical leader id** for personality lookups (see `ai_personality_config.dart` and [ai-personalities.md](../ai/ai-personalities.md) § Leader identity and `Player.leaderKey`).
+- Passes the resolved canonical id as both `leaderId` and (in MVP) `personalityId` when creating **AIConfig**, so that domain planners, goal selection, and dossier projection all use the same canonical identity regardless of which variant leader key is stored on the Player.
+
 ### Tactical (Quick Battle)
 
 ```dart

--- a/packages/colonizethis_data/lib/src/ai_personality_config.dart
+++ b/packages/colonizethis_data/lib/src/ai_personality_config.dart
@@ -96,6 +96,37 @@ const PersonalityDomainWeights defaultDomainWeights = PersonalityDomainWeights()
 const PersonalityGoalWeights defaultGoalWeights = PersonalityGoalWeights();
 const PersonalityThresholds defaultThresholds = PersonalityThresholds();
 
+/// Resolves a leader key or id to the canonical leader id used for personality
+/// lookups.
+///
+/// - If [leaderKeyOrId] already matches a canonical id present in the
+///   personality tables (e.g. `victoria`, `napoleon`), it is returned
+///   unchanged.
+/// - If [leaderKeyOrId] is a known variant key from the default naming config
+///   (e.g. `england_leader`, `france_leader`, `spain_leader`, `portugal_leader`,
+///   `netherlands_leader`, `prussia_leader`, `prussia_reserve_leader`,
+///   `sweden_leader`), the corresponding canonical id is returned.
+/// - Otherwise the input is returned as-is so callers fall back to the default
+///   neutral personality weights and thresholds for unknown ids.
+String canonicalLeaderIdForPersonality(String leaderKeyOrId) {
+  if (personalityDomainWeights.containsKey(leaderKeyOrId)) {
+    return leaderKeyOrId;
+  }
+
+  const variantToCanonical = <String, String>{
+    'england_leader': 'victoria',
+    'france_leader': 'napoleon',
+    'spain_leader': 'isabella',
+    'portugal_leader': 'henry',
+    'netherlands_leader': 'deruyter',
+    'prussia_leader': 'frederick',
+    'prussia_reserve_leader': 'frederick',
+    'sweden_leader': 'gustavus',
+  };
+
+  return variantToCanonical[leaderKeyOrId] ?? leaderKeyOrId;
+}
+
 PersonalityDomainWeights getDomainWeightsForLeader(String leaderId) {
   return personalityDomainWeights[leaderId] ?? defaultDomainWeights;
 }

--- a/packages/colonizethis_data/test/ai_personality_config_test.dart
+++ b/packages/colonizethis_data/test/ai_personality_config_test.dart
@@ -45,6 +45,28 @@ void main() {
     });
   });
 
+  group('canonicalLeaderIdForPersonality', () {
+    test('returns canonical id unchanged when already canonical', () {
+      expect(canonicalLeaderIdForPersonality('victoria'), 'victoria');
+      expect(canonicalLeaderIdForPersonality('napoleon'), 'napoleon');
+    });
+
+    test('maps variant leader keys from naming config to canonical ids', () {
+      expect(canonicalLeaderIdForPersonality('england_leader'), 'victoria');
+      expect(canonicalLeaderIdForPersonality('france_leader'), 'napoleon');
+      expect(canonicalLeaderIdForPersonality('spain_leader'), 'isabella');
+      expect(canonicalLeaderIdForPersonality('portugal_leader'), 'henry');
+      expect(canonicalLeaderIdForPersonality('netherlands_leader'), 'deruyter');
+      expect(canonicalLeaderIdForPersonality('prussia_leader'), 'frederick');
+      expect(canonicalLeaderIdForPersonality('prussia_reserve_leader'), 'frederick');
+      expect(canonicalLeaderIdForPersonality('sweden_leader'), 'gustavus');
+    });
+
+    test('falls back to input for unknown ids so defaults apply', () {
+      expect(canonicalLeaderIdForPersonality('unknown_leader'), 'unknown_leader');
+    });
+  });
+
   group('PersonalityThresholds', () {
     test('default constructor uses 50 for all fields', () {
       const t = PersonalityThresholds();

--- a/packages/colonizethis_logic/lib/src/ai/ai_planner.dart
+++ b/packages/colonizethis_logic/lib/src/ai/ai_planner.dart
@@ -94,7 +94,8 @@ Orders generateOrdersForPlayerFullAI(
   final turn = game.worldState.turnState.turnNumber;
   final turnSeed = turnSeedForPlayer(game, player.id, turn);
   final seeds = AISeedBundle.fromTurnSeed(turnSeed);
-  final leaderId = player.leaderKey ?? player.id;
+  final leaderKeyOrId = player.leaderKey ?? player.id;
+  final leaderId = canonicalLeaderIdForPersonality(leaderKeyOrId);
   final agendaId = game.hiddenAgendaByGpId[playerId] ?? 'peacemaker';
   final config = AIConfig(
     leaderId: leaderId,


### PR DESCRIPTION
## Summary
- Documented AI leader identity vs variant Player.leaderKey in `SPEC/ai/ai-personalities.md` and clarified that AIConfig.leaderId must use canonical leader ids, with resolution via colonizethis_data before AIConfig construction.
- Updated `SPEC/program/ai-systems-impl.md` to describe how ai_planner builds AIConfig using a canonicalized leader id for personality lookups and dossier/archetype display.
- Added `canonicalLeaderIdForPersonality` to `ai_personality_config.dart` (with tests) and wired `ai_planner.generateOrdersForPlayerFullAI` to resolve variant Player.leaderKey values (e.g. `england_leader`) to canonical ids (e.g. `victoria`) before passing them to colonizethis_ai.

## Testing
- `dart test packages/colonizethis_data`
- `dart test packages/colonizethis_logic`
- `dart test packages/colonizethis_ai`

Made with [Cursor](https://cursor.com)