### PR TITLE
Strategic AI: document and centralize dialogue emission cadence (Fixes #570)

### DIFF
--- a/SPEC/ai/ai-architecture.md
+++ b/SPEC/ai/ai-architecture.md
@@ -31,7 +31,7 @@ Behavior trees pick top-level goals; utility AI scores and selects concrete obje
 1. **Perception** — Derive observable snapshot: threats, opportunities, economy, relations. All from PlayerView; no hidden data.
 2. **Goal selection** — Choose strategy (e.g. weighted choice over goals) using personality weights and hidden agenda modifiers.
 3. **Domain planning** — Economy, military, diplomacy, research planners score candidates via personality and agenda weights; each emits candidate orders.
-4. **Execution** — Combine, cap, and validate orders; emit dialogue/mood events.
+4. **Execution** — Combine, cap, and validate orders; emit dialogue/mood events. Strategic AI may emit **optional** agenda-flavoured dialogue and a matching base PortraitMoodEvent for each AI leader on a deterministic cadence derived from the dialogue seed (see [dialogue-and-mood.md](dialogue-and-mood.md) § When to emit for `kDialogueTurnsBetweenComments` and cadence rules).
 5. **Tactical** — Quick Battle: CP-based actions per lane, deterministic given state and seed.
 
 ### Tactical Behavior Rules

--- a/SPEC/ai/dialogue-and-mood.md
+++ b/SPEC/ai/dialogue-and-mood.md
@@ -58,6 +58,8 @@ Mood state machine (logic): given current mood, offerQualityDelta (-1..1), and s
 - **DialogueEvent:** When AI performs a diplomatic action (declare war, offer peace, etc.), when a game event triggers commentary (battle result, era change), when player action triggers reactive banter, or when agenda-flavoured line is chosen (e.g. at dialogue seed interval).
 - **PortraitMoodEvent:** When negotiation mood transitions; optionally when opening/closing diplomacy screen with a base mood.
 
+- **Strategic AI cadence (agenda/comment + base mood):** Strategic AI may emit **optional** agenda-flavoured commentary and a matching base PortraitMoodEvent on a **deterministic schedule** derived from the dialogue seed. For MVP, this schedule is: _once every `kDialogueTurnsBetweenComments` turns per AI leader_, where `kDialogueTurnsBetweenComments = 7` (defined in `colonizethis_data` dialogue catalog). Concretely, when the strategic AI layer runs for a leader and `dialogueSeed % kDialogueTurnsBetweenComments == 0`, it may emit a single `DialogueEvent(category: 'agenda', situation: 'comment')` and a `PortraitMoodEvent` with base mood `considering`. This schedule is deterministic given the seed and may be made ruleset-configurable in a later phase.
+
 Emission is synchronous from AI turn or from resolution hooks; no async side effects. Order of events is deterministic for replay.
 
 ---
@@ -66,6 +68,7 @@ Emission is synchronous from AI turn or from resolution hooks; no async side eff
 
 - **Emission by category:** DialogueEvent and PortraitMoodEvent are emitted per spec categories/situations: event, reactive, diplomatic, negotiation, agenda (see § Dialogue categories and § When to emit).
 - **Determinism:** Same game state and dialogue seed produce the same sequence of events; replay and save/load restore or recompute consistently.
+- **Strategic cadence:** Optional strategic agenda/comment lines and base PortraitMoodEvent emissions follow the documented cadence: they are emitted only when `dialogueSeed % kDialogueTurnsBetweenComments == 0` for the current leader, with `kDialogueTurnsBetweenComments` defined in the dialogue catalog (MVP = 7).
 - **Province identity:** When DialogueEvent (or any event) variables include a province id, the value MUST be in prefixed form per [world-model-identity.md](../game/world-model-identity.md).
 - **Mood values:** PortraitMoodEvent and DialogueEvent mood fields use only the fixed set: considering, pleased, gracious, calculating, skeptical, impatient, irritated, dismissive.
 - **UI contract:** UI resolves event fields (leaderId, category, situation, era, mood, variables) to dialogue keys and localized text only; no asset paths or image references in events.

--- a/packages/colonizethis_ai/lib/src/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/strategic_ai.dart
@@ -47,8 +47,12 @@ Orders generateStrategicOrders({
   final researchCount = orders.researchOrdersByPlayerId[nationId]?.length ?? 0;
   Logger().i('ai: generated orders nationId=$nationId move=$moveCount build=$buildCount work=$workCount research=$researchCount');
   // Optional dialogue/mood emission (deterministic from dialogueSeed).
-  // SPEC/ai/dialogue-and-mood.md: PortraitMoodEvent optionally when opening/closing diplomacy with base mood.
-  if (onDialogue != null && seeds.dialogueSeed % 7 == 0) {
+  // SPEC/ai/dialogue-and-mood.md § When to emit:
+  // Strategic AI may emit optional agenda/comment and base mood once every
+  // kDialogueTurnsBetweenComments turns per leader, when
+  // `dialogueSeed % kDialogueTurnsBetweenComments == 0`.
+  if (onDialogue != null &&
+      seeds.dialogueSeed % kDialogueTurnsBetweenComments == 0) {
     onDialogue(DialogueEvent(
       leaderId: config.leaderId,
       category: 'agenda',
@@ -57,7 +61,8 @@ Orders generateStrategicOrders({
       variables: const {},
     ));
   }
-  if (onMood != null && seeds.dialogueSeed % 7 == 0) {
+  if (onMood != null &&
+      seeds.dialogueSeed % kDialogueTurnsBetweenComments == 0) {
     onMood(PortraitMoodEvent(
       leaderId: config.leaderId,
       fromMood: kDefaultMood,

--- a/packages/colonizethis_ai/test/strategic_ai_test.dart
+++ b/packages/colonizethis_ai/test/strategic_ai_test.dart
@@ -48,7 +48,7 @@ void main() {
       expect(orders.buildUnitOrdersByPlayerId.isEmpty, isTrue);
     });
 
-    test('invokes onDialogue when dialogueSeed % 7 == 0', () {
+    test('invokes onDialogue at configured dialogue cadence', () {
       final game = Game(
         id: 'g1',
         worldState: WorldState(
@@ -76,7 +76,7 @@ void main() {
         diplomacySeed: base.diplomacySeed,
         researchSeed: base.researchSeed,
         tacticalSeed: base.tacticalSeed,
-        dialogueSeed: 7,
+        dialogueSeed: kDialogueTurnsBetweenComments,
         agendaSeed: base.agendaSeed,
       );
       const api = DefaultOrderSuggestionAPI();
@@ -97,7 +97,7 @@ void main() {
       expect(captured!.category, 'agenda');
     });
 
-    test('invokes onMood when dialogueSeed % 7 == 0', () {
+    test('invokes onMood at configured dialogue cadence', () {
       final game = Game(
         id: 'g1',
         worldState: WorldState(
@@ -125,7 +125,7 @@ void main() {
         diplomacySeed: base.diplomacySeed,
         researchSeed: base.researchSeed,
         tacticalSeed: base.tacticalSeed,
-        dialogueSeed: 7,
+        dialogueSeed: kDialogueTurnsBetweenComments,
         agendaSeed: base.agendaSeed,
       );
       const api = DefaultOrderSuggestionAPI();

--- a/packages/colonizethis_data/lib/src/dialogue_catalog.dart
+++ b/packages/colonizethis_data/lib/src/dialogue_catalog.dart
@@ -20,6 +20,14 @@ const List<String> kDialogueEras = [
   'industrial',
 ];
 
+/// Strategic AI agenda/comment cadence in turns (MVP).
+///
+/// SPEC/ai/dialogue-and-mood.md § When to emit:
+/// Strategic AI may emit optional agenda-flavoured commentary and a matching
+/// base PortraitMoodEvent once every [kDialogueTurnsBetweenComments] turns
+/// for each AI leader, when `dialogueSeed % kDialogueTurnsBetweenComments == 0`.
+const int kDialogueTurnsBetweenComments = 7;
+
 /// Portrait mood values per spec (negotiation and base mood).
 const List<String> kPortraitMoodValues = [
   'considering',


### PR DESCRIPTION
## Summary

- Documented the strategic AI dialogue/mood emission cadence in SPEC/ai/dialogue-and-mood.md and referenced it from SPEC/ai/ai-architecture.md, defining a deterministic schedule derived from the dialogue seed (MVP: once every kDialogueTurnsBetweenComments turns per leader).
- Introduced kDialogueTurnsBetweenComments in the dialogue catalog (colonizethis_data) as the single source of truth for the cadence and refactored generateStrategicOrders in strategic_ai.dart to use this constant instead of a magic number.
- Updated strategic_ai_test.dart to assert behaviour in terms of the shared constant, keeping tests aligned with the documented cadence and data-level configuration.

## Test plan

- dart test packages/colonizethis_ai

Made with [Cursor](https://cursor.com)