### PR TITLE
Event dialogue: derive battle result era from turn-time mapping (Fixes #542)

### DIFF
--- a/SPEC/ai/dialogue-and-mood.md
+++ b/SPEC/ai/dialogue-and-mood.md
@@ -31,7 +31,7 @@ Emitted when a dialogue line should be shown. Consumed by UI or tooling.
 | leaderId | string | Which leader is speaking. |
 | category | string | One of the categories above. |
 | situation | string | Sub-context (e.g. declare_war, peace_offer, battle_won). |
-| era | string | discovery \| earlyModern \| imperial \| industrial (for era-appropriate phrasing). |
+| era | string | discovery \| earlyModern \| imperial \| industrial (for era-appropriate phrasing). For events tied to a specific turn (e.g. battle_won / battle_lost, forts_on_border), the system derives this from the game’s turn-time mapping as `eraFromYear(mapping.yearAtTurn(turnNumber))` (see SPEC/game/turn-time-mapping.md). For era_change events, this is the new era value. |
 | mood | string? | Optional; e.g. for negotiation. |
 | variables | map string→string | Fill-in for templates (e.g. otherNation, province). When the key is `province` (or any province id), the value MUST be in prefixed form per [world-model-identity.md](../game/world-model-identity.md). |
 

--- a/SPEC/program/ai-events-and-dossier.md
+++ b/SPEC/program/ai-events-and-dossier.md
@@ -8,7 +8,7 @@ Event data models and data flows for dialogue, mood, evidence, and dossier. Beha
 ## Data Model
 
 ### DialogueEvent
-Fields: `leaderId`, `category`, `situation`, `era`, `mood?`, `variables` (map string→string). Categories and situations per [dialogue-and-mood.md](../ai/dialogue-and-mood.md). When `variables` includes a `province` key (e.g. from event_dialogue), its value must be a **prefixed** province id per [world-model-identity.md](../game/world-model-identity.md); never a bare local id.
+Fields: `leaderId`, `category`, `situation`, `era`, `mood?`, `variables` (map string→string). Categories and situations per [dialogue-and-mood.md](../ai/dialogue-and-mood.md). When `variables` includes a `province` key (e.g. from event_dialogue), its value must be a **prefixed** province id per [world-model-identity.md](../game/world-model-identity.md); never a bare local id. For battle result and reactive border events that are tied to a specific turn, the emitter derives `era` from the game’s turn-time mapping as `eraFromYear(mapping.yearAtTurn(turnNumber))`; for era_change events, `era` is the new era value.
 
 ### PortraitMoodEvent
 Fields: `leaderId`, `fromMood`, `toMood`, `durationMs`. Mood values per [dialogue-and-mood.md](../ai/dialogue-and-mood.md).

--- a/packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
+++ b/packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
@@ -9,8 +9,6 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import '../world/movement.dart';
 import 'evidence_rules.dart';
 
-const String _eraDefault = 'earlyModern';
-
 /// Era names for dialogue (SPEC/ai/dialogue-and-mood.md: discovery | earlyModern | imperial | industrial).
 const List<String> kDialogueEras = ['discovery', 'earlyModern', 'imperial', 'industrial'];
 
@@ -56,12 +54,15 @@ List<DialogueEvent> dialogueEventsForLandBattleResult(
   int seed,
 ) {
   final events = <DialogueEvent>[];
+  final mapping = game.turnTimeMapping ?? TurnTimeMapping.gdd01;
+  final year = mapping.yearAtTurn(turnNumber);
+  final era = eraFromYear(year);
   if (isAiControlledForEvidence(game, victorId)) {
     events.add(DialogueEvent(
       leaderId: victorId,
       category: 'event',
       situation: 'battle_won',
-      era: _eraDefault,
+      era: era,
       variables: {'otherNation': loserId, 'province': provinceId},
     ));
   }
@@ -70,7 +71,7 @@ List<DialogueEvent> dialogueEventsForLandBattleResult(
       leaderId: loserId,
       category: 'event',
       situation: 'battle_lost',
-      era: _eraDefault,
+      era: era,
       variables: {'otherNation': victorId, 'province': provinceId},
     ));
   }
@@ -87,12 +88,15 @@ List<DialogueEvent> dialogueEventsForNavalBattleResult(
   int seed,
 ) {
   final events = <DialogueEvent>[];
+  final mapping = game.turnTimeMapping ?? TurnTimeMapping.gdd01;
+  final year = mapping.yearAtTurn(turnNumber);
+  final era = eraFromYear(year);
   if (isAiControlledForEvidence(game, victorId)) {
     events.add(DialogueEvent(
       leaderId: victorId,
       category: 'event',
       situation: 'battle_won',
-      era: _eraDefault,
+      era: era,
       variables: {'otherNation': loserId},
     ));
   }
@@ -101,7 +105,7 @@ List<DialogueEvent> dialogueEventsForNavalBattleResult(
       leaderId: loserId,
       category: 'event',
       situation: 'battle_lost',
-      era: _eraDefault,
+      era: era,
       variables: {'otherNation': victorId},
     ));
   }

--- a/packages/colonizethis_logic/test/event_dialogue_test.dart
+++ b/packages/colonizethis_logic/test/event_dialogue_test.dart
@@ -7,7 +7,8 @@ import 'package:colonizethis_test/test.dart';
 
 void main() {
   group('dialogueEventsForLandBattleResult', () {
-    test('AI victor and AI loser both emit event', () {
+    test('AI victor and AI loser both emit event with era from turn-time mapping', () {
+      const mapping = TurnTimeMapping.gdd01;
       final game = Game(
         id: 'g1',
         worldState: WorldState(
@@ -21,6 +22,7 @@ void main() {
           Player(id: 'gp3', displayName: 'AI Loser', isHuman: false),
         ],
       );
+      final expectedEra = eraFromYear(mapping.yearAtTurn(2));
       final events = dialogueEventsForLandBattleResult(
         game, 'gp2', 'gp3', 'ow|prov1', 2, 12345,
       );
@@ -31,7 +33,7 @@ void main() {
       expect(lost.length, 1);
       expect(won.first.leaderId, 'gp2');
       expect(won.first.category, 'event');
-      expect(won.first.era, 'earlyModern');
+      expect(won.first.era, expectedEra);
       expect(won.first.variables['otherNation'], 'gp3');
       expect(won.first.variables['province'], 'ow|prov1');
       expect(lost.first.leaderId, 'gp3');


### PR DESCRIPTION
## Summary

- Use the game’s turn-time mapping () together with  to select the  for land and naval battle result dialogue events, rather than a hard-coded default.
- Update  and  to document that battle and reactive border dialogue derive  from , keeping era-change events as the source of truth for their own era.
- Extend  so battle dialogue tests assert the derived era from the default mapping, and run the full  test suite.

Fixes #542.

Made with [Cursor](https://cursor.com)