### PR TITLE
Tech-and-extraction-cap: document MVP scalar cap mapping (Fixes #371)

### DIFF
--- a/SPEC/game/tech-and-extraction-cap.md
+++ b/SPEC/game/tech-and-extraction-cap.md
@@ -16,7 +16,15 @@ The **max effective extraction level** (1–4) per resource or improvement type 
 
 **MVP:** The implementation uses a **single scalar** cap per player (one value for all resources) as a temporary simplification; the catalog is program-level (e.g. gathering_1/2/3). The full model will use **per-resource** caps from the category sub-docs (e.g. [tech-tree-gathering.md](tech-tree-gathering.md)).
 
-**Fallback:** When the full tech model is not yet loaded or a resource has no tech-gated cap, use a **constant cap** (e.g. 4) per player from config so extraction resolution can run. Full model derives cap from [tech-tree.md](tech-tree.md) and category sub-docs. Ruleset: MVP program-level constants; future ruleset per [ruleset-config.md](../program/ruleset-config.md).
+**MVP scalar mapping:** For the MVP scalar cap, the **gathering** techs map to max effective extraction levels as follows (highest unlocked applies):
+
+- `gathering_1` → max effective extraction level **2**
+- `gathering_2` → max effective extraction level **3**
+- `gathering_3` → max effective extraction level **4**
+
+If a player has multiple gathering techs unlocked, the System uses the maximum cap implied by any unlocked gathering tech for that player.
+
+**Fallback:** When the full tech model is not yet loaded, when the tech table is missing or empty, or when a player has no gathering tech unlocked (null or all false), the System uses a **constant fallback cap of 4** per player so extraction resolution can run. The full model derives caps from [tech-tree.md](tech-tree.md) and category sub-docs. Ruleset: MVP program-level constants (including the fallback cap); future ruleset per [ruleset-config.md](../program/ruleset-config.md).
 
 ---
 


### PR DESCRIPTION
## Summary

- Document the MVP scalar extraction cap mapping from gathering techs: gathering_1→2, gathering_2→3, gathering_3→4 with highest unlocked applying.
- Specify the constant fallback extraction cap of 4 when no gathering tech is unlocked or tech data is missing, aligning the spec with the existing implementation in tech_extraction.dart.

## Test plan

- Docs-only change in SPEC/game/tech-and-extraction-cap.md; no code or tests modified.


Made with [Cursor](https://cursor.com)