### PR TITLE
Ruleset-config GDD: include turn-time mapping in resolved ruleset (Fixes #411)

### DIFF
--- a/SPEC/game/ruleset-config.md
+++ b/SPEC/game/ruleset-config.md
@@ -33,6 +33,12 @@ The ruleset includes a **naming** section for historically inspired names:
 
 Setup names all provinces owned by each faction at creation. Provinces acquired during play retain existing display name. Scenarios may override naming while keeping the same structure.
 
+### Turn-time mapping
+
+The resolved ruleset includes a **turn-time mapping** section that defines how turn numbers map to calendar years for narrative and UI; see [turn-time-mapping.md](turn-time-mapping.md) for structure and defaults (`startYear`, `cutoffYear`, `yearsPerTurnBeforeCutoff`, `yearsPerTurnAfterCutoff`).
+
+- **MVP default:** When the resolved ruleset does not supply turn-time mapping, game setup uses the default GDD 01 mapping (`TurnTimeMapping.gdd01`) when initializing `Game.turnTimeMapping`. See [turn-time-mapping.md](turn-time-mapping.md) and [game-setup-pipeline.md](../program/game-setup-pipeline.md) step 7e.
+
 ## Configurable Values
 
 | Parameter | Default | Layer |
@@ -44,6 +50,8 @@ Setup names all provinces owned by each faction at creation. Provinces acquired 
 | Old World provinces | ≈60 | Base, Scenario |
 | New World provinces | ≈80 | Base, Scenario |
 | Continent count | 3–4 | Base, Scenario |
+
+Turn-time mapping parameters are part of the resolved ruleset but documented in [turn-time-mapping.md](turn-time-mapping.md). Scenarios or future ruleset layers may override the mapping as a whole; when no mapping is present in the resolved ruleset, the System uses the default described there.
 
 ## Interactions
 - [world-model.md](world-model.md), [map-topology.md](map-topology.md) — adjacency, terrain


### PR DESCRIPTION
## Summary

- Aligns SPEC/game/ruleset-config.md with SPEC/program/ruleset-config.md by stating that the resolved ruleset includes a turn-time mapping section alongside naming.
- Notes that when the resolved ruleset does not provide turn-time mapping, game setup uses the default GDD 01 mapping (TurnTimeMapping.gdd01) as already described in game-setup-pipeline step 7e and turn-time-mapping.md.
- Clarifies that turn-time mapping parameters live in turn-time-mapping.md and are part of the ruleset contract, while scenarios or future ruleset layers may override the mapping as a whole.

Fixes #411.

Made with [Cursor](https://cursor.com)