### PR TITLE
Respect Spy reveal timers in fog decay

### DIFF
--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -151,8 +151,10 @@ Game resolveTurnForGame({
   Map<String, Map<CommodityId, int>> extractedByPlayerId = const {},
   List<AssignedRecipe> defaultAssignments = const [],
   void Function(DialogueEvent)? onDialogue,
+
   /// Called after production phase with playerId → (recipeId → quantity produced). For projection API. SPEC/program/order-projections.md.
-  void Function(Map<String, Map<String, int>> productionByRecipeByPlayerId)? onProductionComplete,
+  void Function(Map<String, Map<String, int>> productionByRecipeByPlayerId)?
+      onProductionComplete,
 }) {
   final turn = game.worldState.turnState.turnNumber;
   _log.i('logic: turn $turn resolve start');
@@ -254,8 +256,8 @@ Orders _filterAcceptedOrdersForAllPlayers({
     final moves = original.moveOrdersByPlayerId[playerId] ?? const [];
     final builds = original.buildUnitOrdersByPlayerId[playerId] ?? const [];
     final works = original.workOrdersByPlayerId[playerId] ?? const [];
-    final diplo =
-        original.diplomaticOrdersByPlayerId[playerId] ?? const <DiplomaticOrder>[];
+    final diplo = original.diplomaticOrdersByPlayerId[playerId] ??
+        const <DiplomaticOrder>[];
 
     if (moves.isEmpty && builds.isEmpty && works.isEmpty && diplo.isEmpty) {
       continue;
@@ -285,9 +287,7 @@ Orders _filterAcceptedOrdersForAllPlayers({
     for (final b in builds) {
       final r = _next();
       if (r.isAccepted) {
-        buildByPlayer
-            .putIfAbsent(playerId, () => <BuildUnitOrder>[])
-            .add(b);
+        buildByPlayer.putIfAbsent(playerId, () => <BuildUnitOrder>[]).add(b);
       }
     }
     for (final w in works) {
@@ -428,6 +428,16 @@ Map<String, Map<String, String>> _applyFogDecay(Game game) {
           .add(u.locationProvinceId);
     }
   }
+
+  // Provinces with an active Spy reveal timer for each player (timer > 0).
+  // These provinces must remain fully visible until the timer reaches 0 and is cleared.
+  final provincesWithSpyTimerByPlayer = <String, Set<String>>{};
+  for (final entry in game.worldState.spyRevealTurnsByPlayer.entries) {
+    final playerId = entry.key;
+    final provinces = entry.value.keys;
+    if (provinces.isEmpty) continue;
+    provincesWithSpyTimerByPlayer[playerId] = provinces.toSet();
+  }
   for (final u in game.worldState.newWorld.units) {
     if (explorerTypes.contains(u.type.toLowerCase())) {
       provincesWithExplorerByPlayer
@@ -441,14 +451,17 @@ Map<String, Map<String, String>> _applyFogDecay(Game game) {
     final playerId = entry.key;
     final visibility = Map<String, String>.from(entry.value);
     final hasExplorerIn = provincesWithExplorerByPlayer[playerId] ?? const {};
+    final hasSpyTimerIn = provincesWithSpyTimerByPlayer[playerId] ?? const {};
 
     for (final tileKey in visibility.keys.toList()) {
       final parts = tileKey.split('|');
       if (parts.length != 4) continue;
       final fullProvinceId = ProvinceId.full(parts[0], parts[1]);
-      final ownerId = owOwnerByProvince[fullProvinceId] ?? nwOwnerByProvince[fullProvinceId];
+      final ownerId = owOwnerByProvince[fullProvinceId] ??
+          nwOwnerByProvince[fullProvinceId];
       if (ownerId == null || ownerId == playerId) continue;
-      if (!hasExplorerIn.contains(fullProvinceId)) {
+      if (!hasExplorerIn.contains(fullProvinceId) &&
+          !hasSpyTimerIn.contains(fullProvinceId)) {
         visibility[tileKey] = VisibilityLevel.fogged.name;
       }
     }
@@ -514,7 +527,8 @@ Game _runExtractionPhase(
   );
   var currentState = state;
   final updatedPlayers = <Player>[];
-  var extractionSeed = (state.globalGameSeed ?? 0) ^ (state.worldState.turnState.turnNumber * 0x9E3779B1);
+  var extractionSeed = (state.globalGameSeed ?? 0) ^
+      (state.worldState.turnState.turnNumber * 0x9E3779B1);
   for (final player in state.players) {
     var stockpile = player.stockpile;
     final tot = extraction[player.id];
@@ -534,7 +548,8 @@ Game _runExtractionPhase(
         );
         overseasDelivered = interception.reducedDelivered;
         currentState = currentState.copyWith(
-          worldState: currentState.worldState.copyWith(fleets: interception.updatedFleets),
+          worldState: currentState.worldState
+              .copyWith(fleets: interception.updatedFleets),
         );
       }
       stockpile = applyExtractionToStockpile(stockpile, overseasDelivered);
@@ -547,7 +562,8 @@ Game _runExtractionPhase(
 Game _runProductionPhase(
   Game game,
   List<AssignedRecipe> defaultAssignments,
-  void Function(Map<String, Map<String, int>> productionByRecipeByPlayerId)? onProductionComplete,
+  void Function(Map<String, Map<String, int>> productionByRecipeByPlayerId)?
+      onProductionComplete,
 ) {
   final updatedPlayers = <Player>[];
   final productionByRecipeByPlayerId = <String, Map<String, int>>{};
@@ -667,6 +683,7 @@ Game _runMovementPhase(
     void recordSpyLeft(String ownerId, String provinceId) {
       spyTimers.putIfAbsent(ownerId, () => {})[provinceId] = 5;
     }
+
     for (final u in state.worldState.oldWorld.units) {
       if (!isSpyUnit(u.type)) continue;
       final after = oldWorld.units.where((x) => x.id == u.id).firstOrNull;
@@ -750,7 +767,8 @@ Game _applyNavalMovesAndShipReveal(
   Map<String, List<NavalMoveOrder>> navalMoveOrdersByPlayerId,
 ) {
   var fleets = List<Fleet>.from(game.worldState.fleets);
-  var visibilityByTile = Map<String, Map<String, String>>.from(game.worldState.playerVisibilityByTile);
+  var visibilityByTile = Map<String, Map<String, String>>.from(
+      game.worldState.playerVisibilityByTile);
   final fleetById = {for (final f in fleets) f.id: f};
   final nodesById = {for (final n in topology.nodes) n.id: n};
 
@@ -759,7 +777,8 @@ Game _applyNavalMovesAndShipReveal(
     for (final order in entry.value) {
       final fleet = fleetById[order.fleetId];
       if (fleet == null || fleet.ownerId != playerId) continue;
-      if (!isAdjacentSeaZone(topology, fleet.seaZoneId, order.destinationSeaZoneId)) continue;
+      if (!isAdjacentSeaZone(
+          topology, fleet.seaZoneId, order.destinationSeaZoneId)) continue;
 
       final newFleet = fleet.copyWith(seaZoneId: order.destinationSeaZoneId);
       final idx = fleets.indexWhere((f) => f.id == fleet.id);
@@ -769,7 +788,8 @@ Game _applyNavalMovesAndShipReveal(
       }
 
       // Ship reveal: coastal provinces of destination sea zone -> revealed for owner.
-      final provinceIds = provinceIdsAdjacentToSeaZone(topology, order.destinationSeaZoneId);
+      final provinceIds =
+          provinceIdsAdjacentToSeaZone(topology, order.destinationSeaZoneId);
       final vis = Map<String, String>.from(visibilityByTile[playerId] ?? {});
       for (final localProvinceId in provinceIds) {
         final node = nodesById[localProvinceId];
@@ -777,7 +797,9 @@ Game _applyNavalMovesAndShipReveal(
         final regionId = node.regionId;
         if (regionId.isEmpty) continue;
         final fullProvinceId = ProvinceId.full(regionId, localProvinceId);
-        final tileKeys = game.worldState.tileKeysByRegionAndProvince[regionId]?[fullProvinceId] ?? [];
+        final tileKeys = game.worldState.tileKeysByRegionAndProvince[regionId]
+                ?[fullProvinceId] ??
+            [];
         for (final tk in tileKeys) {
           vis[tk] = VisibilityLevel.revealed.name;
         }
@@ -808,7 +830,8 @@ Game _runNavalInterceptionCombatPhase(
     for (final list in navalMoveOrdersByPlayerId.values)
       for (final order in list) order.fleetId,
   };
-  var seed = (game.globalGameSeed ?? 0) ^ (game.worldState.turnState.turnNumber * 0x9E3779B1);
+  var seed = (game.globalGameSeed ?? 0) ^
+      (game.worldState.turnState.turnNumber * 0x9E3779B1);
   battles = filterBattlesByInterception(game, battles, movedFleetIds, seed);
   seed = (seed * 1103515245 + 12345) & 0x7fffffff;
   var state = game;
@@ -818,24 +841,32 @@ Game _runNavalInterceptionCombatPhase(
     final result = resolveSeaBattle(battle, seed);
     seed = (seed * 1103515245 + 12345) & 0x7fffffff;
     final regionId = regionIdForSeaZone(topology, battle.seaZoneId);
-    state = applyNavalBattleResults(state, battle, result, regionId, topology: topology);
+    state = applyNavalBattleResults(state, battle, result, regionId,
+        topology: topology);
     // Evidence: AI won naval battle (one side eliminated). SPEC/ai/hidden-agendas.md, ai-events-and-dossier.md.
     String? victorId;
     String? loserId;
-    if (result.survivingShipTypeIdsSide1.isEmpty && result.survivingShipTypeIdsSide2.isNotEmpty) {
+    if (result.survivingShipTypeIdsSide1.isEmpty &&
+        result.survivingShipTypeIdsSide2.isNotEmpty) {
       victorId = battle.side2.ownerId;
       loserId = battle.side1.ownerId;
-    } else if (result.survivingShipTypeIdsSide2.isEmpty && result.survivingShipTypeIdsSide1.isNotEmpty) {
+    } else if (result.survivingShipTypeIdsSide2.isEmpty &&
+        result.survivingShipTypeIdsSide1.isNotEmpty) {
       victorId = battle.side1.ownerId;
       loserId = battle.side2.ownerId;
     }
     if (victorId != null && loserId != null) {
-      final evidence = evidenceForNavalBattleVictory(state, victorId, loserId, turn);
+      final evidence =
+          evidenceForNavalBattleVictory(state, victorId, loserId, turn);
       if (evidence.isNotEmpty) {
-        state = state.copyWith(dossierEvidenceEntries: [...state.dossierEvidenceEntries, ...evidence]);
+        state = state.copyWith(dossierEvidenceEntries: [
+          ...state.dossierEvidenceEntries,
+          ...evidence
+        ]);
       }
       final dialogueSeed = (seed ^ (battleIndex * 0x9E3779B1)) & 0x7fffffff;
-      final events = dialogueEventsForNavalBattleResult(state, victorId, loserId, turn, dialogueSeed);
+      final events = dialogueEventsForNavalBattleResult(
+          state, victorId, loserId, turn, dialogueSeed);
       if (onDialogue != null && events.isNotEmpty) {
         for (final e in events) onDialogue(e);
       }
@@ -870,7 +901,8 @@ Game _runCombatPhase(
           : null,
     );
     if (mode == CombatMode.quickBattle) {
-      final input = buildQuickBattleInput(state, ctx, seed: state.worldState.turnState.turnNumber);
+      final input = buildQuickBattleInput(state, ctx,
+          seed: state.worldState.turnState.turnNumber);
       final qbResult = resolveQuickBattle(input);
       state = applyQuickBattleResultToGame(state, ctx, qbResult);
       // Evidence: AI won land battle as attacker. SPEC/ai/hidden-agendas.md, ai-events-and-dossier.md.
@@ -878,13 +910,22 @@ Game _runCombatPhase(
           qbResult.provinceFlips &&
           ctx.attackers.isNotEmpty) {
         final victorId = ctx.attackers.first.factionId;
-        final evidence = evidenceForLandBattleVictory(state, victorId, ctx.defenderFactionId, turn);
+        final evidence = evidenceForLandBattleVictory(
+            state, victorId, ctx.defenderFactionId, turn);
         if (evidence.isNotEmpty) {
-          state = state.copyWith(dossierEvidenceEntries: [...state.dossierEvidenceEntries, ...evidence]);
+          state = state.copyWith(dossierEvidenceEntries: [
+            ...state.dossierEvidenceEntries,
+            ...evidence
+          ]);
         }
         final dialogueSeed = (seed ^ (battleIndex * 0x9E3779B1)) & 0x7fffffff;
         final events = dialogueEventsForLandBattleResult(
-          state, victorId, ctx.defenderFactionId, ctx.provinceId, turn, dialogueSeed,
+          state,
+          victorId,
+          ctx.defenderFactionId,
+          ctx.provinceId,
+          turn,
+          dialogueSeed,
         );
         if (onDialogue != null && events.isNotEmpty) {
           for (final e in events) onDialogue(e);
@@ -893,14 +934,22 @@ Game _runCombatPhase(
         // Quick battle ended with defender holding or draw: loser is attacker, victor is defender.
         final victorId = qbResult.winner == QuickBattleWinner.defender
             ? ctx.defenderFactionId
-            : (qbResult.provinceFlips && ctx.attackers.isNotEmpty ? ctx.attackers.first.factionId : null);
-        final loserId = victorId == ctx.defenderFactionId && ctx.attackers.isNotEmpty
-            ? ctx.attackers.first.factionId
-            : (victorId != null ? ctx.defenderFactionId : null);
+            : (qbResult.provinceFlips && ctx.attackers.isNotEmpty
+                ? ctx.attackers.first.factionId
+                : null);
+        final loserId =
+            victorId == ctx.defenderFactionId && ctx.attackers.isNotEmpty
+                ? ctx.attackers.first.factionId
+                : (victorId != null ? ctx.defenderFactionId : null);
         if (victorId != null && loserId != null) {
           final dialogueSeed = (seed ^ (battleIndex * 0x9E3779B1)) & 0x7fffffff;
           final events = dialogueEventsForLandBattleResult(
-            state, victorId, loserId, ctx.provinceId, turn, dialogueSeed,
+            state,
+            victorId,
+            loserId,
+            ctx.provinceId,
+            turn,
+            dialogueSeed,
           );
           if (onDialogue != null && events.isNotEmpty) {
             for (final e in events) onDialogue(e);
@@ -914,22 +963,35 @@ Game _runCombatPhase(
         feedingCoverageByPlayerId: feedingCoverageByPlayerId,
       );
       // Evidence: AI won land battle (province flipped). Same spec refs.
-      final region = ctx.regionId == kRegionOldWorld ? state.worldState.oldWorld : state.worldState.newWorld;
-      final province = region.provinces.where((p) => p.id == ctx.provinceId).firstOrNull;
+      final region = ctx.regionId == kRegionOldWorld
+          ? state.worldState.oldWorld
+          : state.worldState.newWorld;
+      final province =
+          region.provinces.where((p) => p.id == ctx.provinceId).firstOrNull;
       final victorId = province?.ownerId;
       if (victorId != null && victorId != ctx.defenderFactionId) {
-        final evidence = evidenceForLandBattleVictory(state, victorId, ctx.defenderFactionId, turn);
+        final evidence = evidenceForLandBattleVictory(
+            state, victorId, ctx.defenderFactionId, turn);
         if (evidence.isNotEmpty) {
-          state = state.copyWith(dossierEvidenceEntries: [...state.dossierEvidenceEntries, ...evidence]);
+          state = state.copyWith(dossierEvidenceEntries: [
+            ...state.dossierEvidenceEntries,
+            ...evidence
+          ]);
         }
       }
       final effectiveVictorId = victorId ?? ctx.defenderFactionId;
-      final effectiveLoserId = victorId == ctx.defenderFactionId && ctx.attackers.isNotEmpty
-          ? ctx.attackers.first.factionId
-          : ctx.defenderFactionId;
+      final effectiveLoserId =
+          victorId == ctx.defenderFactionId && ctx.attackers.isNotEmpty
+              ? ctx.attackers.first.factionId
+              : ctx.defenderFactionId;
       final dialogueSeed = (seed ^ (battleIndex * 0x9E3779B1)) & 0x7fffffff;
       final events = dialogueEventsForLandBattleResult(
-        state, effectiveVictorId, effectiveLoserId, ctx.provinceId, turn, dialogueSeed,
+        state,
+        effectiveVictorId,
+        effectiveLoserId,
+        ctx.provinceId,
+        turn,
+        dialogueSeed,
       );
       if (onDialogue != null && events.isNotEmpty) {
         for (final e in events) onDialogue(e);
@@ -940,7 +1002,8 @@ Game _runCombatPhase(
   }
   // Capital reassignment: any GP that no longer owns their capital province. SPEC/game/capital-and-connectivity § Capital loss and reassignment.
   if (tileMapByRegion != null && tileMapByRegion.isNotEmpty) {
-    state = _applyCapitalReassignmentAfterCombat(state, topology, tileMapByRegion);
+    state =
+        _applyCapitalReassignmentAfterCombat(state, topology, tileMapByRegion);
   }
   return state;
 }
@@ -959,7 +1022,8 @@ Game _applyCapitalReassignmentAfterCombat(
     final region = regionId == kRegionOldWorld
         ? state.worldState.oldWorld
         : state.worldState.newWorld;
-    final province = region.provinces.where((p) => p.id == capProvinceId).firstOrNull;
+    final province =
+        region.provinces.where((p) => p.id == capProvinceId).firstOrNull;
     if (province == null) continue;
     if (province.ownerId == player.id) continue;
     // Player lost capital. Choose new capital in original region from owned provinces; prefer seaboard.
@@ -973,7 +1037,8 @@ Game _applyCapitalReassignmentAfterCombat(
         return p.copyWith(capitalProvinceId: null, capitalTile: null);
       }).toList();
       game = game.copyWith(players: updatedPlayers);
-      _log.i('logic: player ${player.id} lost capital and has no provinces in $regionId; capital cleared');
+      _log.i(
+          'logic: player ${player.id} lost capital and has no provinces in $regionId; capital cleared');
       continue;
     }
     final tileMap = tileMapByRegion[regionId];
@@ -994,9 +1059,11 @@ Game _applyCapitalReassignmentAfterCombat(
         topology: topology,
         tileMapByRegion: tileMapByRegion,
       );
-      _log.i('logic: player ${player.id} capital reassigned to $newProvinceId after loss');
+      _log.i(
+          'logic: player ${player.id} capital reassigned to $newProvinceId after loss');
     } catch (e, st) {
-      _log.w('logic: capital reassignment failed for ${player.id}', error: e, stackTrace: st);
+      _log.w('logic: capital reassignment failed for ${player.id}',
+          error: e, stackTrace: st);
     }
   }
   return game;

--- a/packages/colonizethis_logic/test/turn_resolver_test.dart
+++ b/packages/colonizethis_logic/test/turn_resolver_test.dart
@@ -37,8 +37,10 @@ void main() {
     test('runs extraction, production, consumption, and movement phases', () {
       final topology = MapTopology(
         nodes: [
-          const TopologyNode(id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          const TopologyNode(id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
         ],
         edges: [
           const TopologyEdge(id1: 'P1', id2: 'P2'),
@@ -119,7 +121,9 @@ void main() {
         worldState: WorldState(
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
           oldWorld: RegionData(
-            provinces: const [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
+            provinces: const [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')
+            ],
             units: const [],
           ),
           newWorld: const RegionData(),
@@ -144,7 +148,9 @@ void main() {
       expect(next.players.single.stockpile.quantityOf('gold'), lessThan(2));
     });
 
-    test('consumption and combat run with feeding coverage when player has no food', () {
+    test(
+        'consumption and combat run with feeding coverage when player has no food',
+        () {
       const ow = 'oldWorld';
       final topology = MapTopology(
         nodes: const [
@@ -163,15 +169,31 @@ void main() {
               Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
             ],
             units: [
-              Unit(id: 'u1', type: 'musketeers', ownerId: 'p1', provinceId: '$ow|P2'),
-              Unit(id: 'u2', type: 'pikemen', ownerId: 'p2', provinceId: '$ow|P1'),
+              Unit(
+                  id: 'u1',
+                  type: 'musketeers',
+                  ownerId: 'p1',
+                  provinceId: '$ow|P2'),
+              Unit(
+                  id: 'u2',
+                  type: 'pikemen',
+                  ownerId: 'p2',
+                  provinceId: '$ow|P1'),
             ],
           ),
           newWorld: const RegionData(),
         ),
         players: [
-          Player(id: 'p1', displayName: 'P1', isHuman: true, stockpile: Stockpile.empty),
-          Player(id: 'p2', displayName: 'P2', isHuman: true, stockpile: Stockpile(quantities: {'grain': 10, 'meat': 10})),
+          Player(
+              id: 'p1',
+              displayName: 'P1',
+              isHuman: true,
+              stockpile: Stockpile.empty),
+          Player(
+              id: 'p2',
+              displayName: 'P2',
+              isHuman: true,
+              stockpile: Stockpile(quantities: {'grain': 10, 'meat': 10})),
         ],
       );
       final orders = Orders(
@@ -188,19 +210,25 @@ void main() {
       expect(next.worldState.oldWorld.units.length, lessThanOrEqualTo(2));
     });
 
-    test('full turn with tileMapByRegion: extraction pipeline, turn advanced', () {
+    test('full turn with tileMapByRegion: extraction pipeline, turn advanced',
+        () {
       final topology = MapTopology(
         nodes: [
-          const TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
         ],
         edges: [],
       );
-      final grid = [['p1']];
+      final grid = [
+        ['p1']
+      ];
       final tileMap = TileMapResult(
         width: 1,
         height: 1,
         grid: grid,
-        resourceGrid: [[Resource.grain]],
+        resourceGrid: [
+          [Resource.grain]
+        ],
       );
       final tileState = TileMapState()
           .setImprovement('oldWorld|p1|0|0', 2)
@@ -243,25 +271,37 @@ void main() {
       expect(next.players.single.stockpile.quantityOf('grain'), 1);
     });
 
-    test('extraction phase with overseas runs allocateOverseasToStockpile and applyTradeInterception path', () {
+    test(
+        'extraction phase with overseas runs allocateOverseasToStockpile and applyTradeInterception path',
+        () {
       final topology = MapTopology(
         nodes: [
-          const TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          const TopologyNode(id: 'n1', regionId: 'newWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'n1', regionId: 'newWorld', type: TopologyNodeType.province),
         ],
         edges: [],
       );
       final tileMapOw = TileMapResult(
         width: 1,
         height: 1,
-        grid: [['p1']],
-        resourceGrid: [[Resource.grain]],
+        grid: [
+          ['p1']
+        ],
+        resourceGrid: [
+          [Resource.grain]
+        ],
       );
       final tileMapNw = TileMapResult(
         width: 1,
         height: 1,
-        grid: [['n1']],
-        resourceGrid: [[Resource.sugarCane]],
+        grid: [
+          ['n1']
+        ],
+        resourceGrid: [
+          [Resource.sugarCane]
+        ],
       );
       final tileState = TileMapState()
           .setImprovement('oldWorld|p1|0|0', 1)
@@ -301,14 +341,19 @@ void main() {
         defaultAssignments: const [],
       );
       expect(next.worldState.turnState.turnNumber, 1);
-      expect(next.players.single.stockpile.quantityOf('grain'), greaterThanOrEqualTo(0));
+      expect(next.players.single.stockpile.quantityOf('grain'),
+          greaterThanOrEqualTo(0));
     });
 
-    test('one full turn with combat: MoveOrder into enemy province, casualties and province flip', () {
+    test(
+        'one full turn with combat: MoveOrder into enemy province, casualties and province flip',
+        () {
       final topology = MapTopology(
         nodes: [
-          const TopologyNode(id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          const TopologyNode(id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
         ],
         edges: [
           const TopologyEdge(id1: 'P1', id2: 'P2'),
@@ -377,11 +422,15 @@ void main() {
       expect(p2!.ownerId, anyOf('p1', 'p2'));
     });
 
-    test('combat with tileMapByRegion runs capital reassignment when defender loses only province', () {
+    test(
+        'combat with tileMapByRegion runs capital reassignment when defender loses only province',
+        () {
       final topology = MapTopology(
         nodes: [
-          const TopologyNode(id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          const TopologyNode(id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
         ],
         edges: [
           const TopologyEdge(id1: 'P1', id2: 'P2'),
@@ -391,8 +440,12 @@ void main() {
       final tileMap = TileMapResult(
         width: 2,
         height: 1,
-        grid: [['P1', 'P2']],
-        resourceGrid: [[Resource.grain, Resource.grain]],
+        grid: [
+          ['P1', 'P2']
+        ],
+        resourceGrid: [
+          [Resource.grain, Resource.grain]
+        ],
       );
       final tileState = TileMapState()
           .setImprovement('$ow|P1|0|0', 1)
@@ -411,17 +464,41 @@ void main() {
               Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
             ],
             units: [
-              Unit(id: 'u1', type: 'grenadiers', ownerId: 'p1', provinceId: '$ow|P1', medals: 2),
-              Unit(id: 'u2', type: 'peasant_levies', ownerId: 'p2', provinceId: '$ow|P2'),
+              Unit(
+                  id: 'u1',
+                  type: 'grenadiers',
+                  ownerId: 'p1',
+                  provinceId: '$ow|P1',
+                  medals: 2),
+              Unit(
+                  id: 'u2',
+                  type: 'peasant_levies',
+                  ownerId: 'p2',
+                  provinceId: '$ow|P2'),
             ],
           ),
           newWorld: const RegionData(),
           tileState: tileState,
-          tileKeysByRegionAndProvince: {ow: {'P1': ['$ow|P1|0|0'], 'P2': ['$ow|P2|0|1']}},
+          tileKeysByRegionAndProvince: {
+            ow: {
+              'P1': ['$ow|P1|0|0'],
+              'P2': ['$ow|P2|0|1']
+            }
+          },
         ),
         players: [
-          Player(id: 'p1', displayName: 'Attacker', isHuman: true, militaryLevel: 3),
-          Player(id: 'p2', displayName: 'Defender', isHuman: true, militaryLevel: 1, capitalProvinceId: '$ow|P2', capitalTile: cap),
+          Player(
+              id: 'p1',
+              displayName: 'Attacker',
+              isHuman: true,
+              militaryLevel: 3),
+          Player(
+              id: 'p2',
+              displayName: 'Defender',
+              isHuman: true,
+              militaryLevel: 1,
+              capitalProvinceId: '$ow|P2',
+              capitalTile: cap),
         ],
         defaultCombatMode: CombatMode.quickBattle,
       );
@@ -437,17 +514,23 @@ void main() {
         tileMapByRegion: {'oldWorld': tileMap},
       );
       expect(next.worldState.turnState.turnNumber, 1);
-      final p2Province = next.worldState.oldWorld.provinces.where((p) => p.id == '$ow|P2').singleOrNull;
+      final p2Province = next.worldState.oldWorld.provinces
+          .where((p) => p.id == '$ow|P2')
+          .singleOrNull;
       expect(p2Province, isNotNull);
       expect(p2Province!.ownerId, anyOf('p1', 'p2'));
       // When defender loses their only province, capital reassignment clears their capital (path covered when RNG flips province).
     });
 
-    test('autoResolve combat with AI players invokes onDialogue with event battle_won/battle_lost', () {
+    test(
+        'autoResolve combat with AI players invokes onDialogue with event battle_won/battle_lost',
+        () {
       final topology = MapTopology(
         nodes: [
-          const TopologyNode(id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          const TopologyNode(id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
         ],
         edges: [
           const TopologyEdge(id1: 'P1', id2: 'P2'),
@@ -484,8 +567,16 @@ void main() {
           newWorld: const RegionData(),
         ),
         players: const [
-          Player(id: 'p1', displayName: 'AI Attacker', isHuman: false, militaryLevel: 3),
-          Player(id: 'p2', displayName: 'AI Defender', isHuman: false, militaryLevel: 1),
+          Player(
+              id: 'p1',
+              displayName: 'AI Attacker',
+              isHuman: false,
+              militaryLevel: 3),
+          Player(
+              id: 'p2',
+              displayName: 'AI Defender',
+              isHuman: false,
+              militaryLevel: 1),
         ],
         defaultCombatMode: CombatMode.autoResolve,
       );
@@ -508,7 +599,9 @@ void main() {
 
       expect(next.worldState.turnState.turnNumber, 1);
       final eventDialogue = dialogueEvents
-          .where((e) => e.category == 'event' && (e.situation == 'battle_won' || e.situation == 'battle_lost'))
+          .where((e) =>
+              e.category == 'event' &&
+              (e.situation == 'battle_won' || e.situation == 'battle_lost'))
           .toList();
       expect(eventDialogue, isNotEmpty);
     });
@@ -516,8 +609,10 @@ void main() {
     test('quick battle mode runs without error and can flip province', () {
       final topology = MapTopology(
         nodes: [
-          const TopologyNode(id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          const TopologyNode(id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
         ],
         edges: [
           const TopologyEdge(id1: 'P1', id2: 'P2'),
@@ -582,11 +677,15 @@ void main() {
       expect(p2!.ownerId, isNotNull);
     });
 
-    test('combat phase with AI players invokes onDialogue with event battle_won/battle_lost', () {
+    test(
+        'combat phase with AI players invokes onDialogue with event battle_won/battle_lost',
+        () {
       final topology = MapTopology(
         nodes: [
-          const TopologyNode(id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          const TopologyNode(id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
         ],
         edges: [
           const TopologyEdge(id1: 'P1', id2: 'P2'),
@@ -622,8 +721,16 @@ void main() {
           newWorld: const RegionData(),
         ),
         players: const [
-          Player(id: 'p1', displayName: 'AI Attacker', isHuman: false, militaryLevel: 3),
-          Player(id: 'p2', displayName: 'AI Defender', isHuman: false, militaryLevel: 1),
+          Player(
+              id: 'p1',
+              displayName: 'AI Attacker',
+              isHuman: false,
+              militaryLevel: 3),
+          Player(
+              id: 'p2',
+              displayName: 'AI Defender',
+              isHuman: false,
+              militaryLevel: 1),
         ],
         defaultCombatMode: CombatMode.quickBattle,
       );
@@ -646,18 +753,24 @@ void main() {
 
       expect(next.worldState.turnState.turnNumber, 1);
       final eventDialogue = dialogueEvents
-          .where((e) => e.category == 'event' && (e.situation == 'battle_won' || e.situation == 'battle_lost'))
+          .where((e) =>
+              e.category == 'event' &&
+              (e.situation == 'battle_won' || e.situation == 'battle_lost'))
           .toList();
       expect(eventDialogue, isNotEmpty);
       expect(eventDialogue.any((e) => e.situation == 'battle_won'), isTrue);
       expect(eventDialogue.any((e) => e.situation == 'battle_lost'), isTrue);
     });
 
-    test('quick battle defender holds: onDialogue receives battle_won for defender and battle_lost for attacker', () {
+    test(
+        'quick battle defender holds: onDialogue receives battle_won for defender and battle_lost for attacker',
+        () {
       final topology = MapTopology(
         nodes: [
-          const TopologyNode(id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          const TopologyNode(id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
         ],
         edges: [
           const TopologyEdge(id1: 'P1', id2: 'P2'),
@@ -676,15 +789,32 @@ void main() {
               Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
             ],
             units: [
-              Unit(id: 'u1', type: 'peasant_levies', ownerId: 'p1', provinceId: '$ow|P1'),
-              Unit(id: 'u2', type: 'grenadiers', ownerId: 'p2', provinceId: '$ow|P2', medals: 2),
+              Unit(
+                  id: 'u1',
+                  type: 'peasant_levies',
+                  ownerId: 'p1',
+                  provinceId: '$ow|P1'),
+              Unit(
+                  id: 'u2',
+                  type: 'grenadiers',
+                  ownerId: 'p2',
+                  provinceId: '$ow|P2',
+                  medals: 2),
             ],
           ),
           newWorld: const RegionData(),
         ),
         players: const [
-          Player(id: 'p1', displayName: 'AI Attacker', isHuman: false, militaryLevel: 1),
-          Player(id: 'p2', displayName: 'AI Defender', isHuman: false, militaryLevel: 3),
+          Player(
+              id: 'p1',
+              displayName: 'AI Attacker',
+              isHuman: false,
+              militaryLevel: 1),
+          Player(
+              id: 'p2',
+              displayName: 'AI Defender',
+              isHuman: false,
+              militaryLevel: 3),
         ],
         defaultCombatMode: CombatMode.quickBattle,
       );
@@ -704,15 +834,20 @@ void main() {
       );
 
       final eventDialogue = dialogueEvents
-          .where((e) => e.category == 'event' && (e.situation == 'battle_won' || e.situation == 'battle_lost'))
+          .where((e) =>
+              e.category == 'event' &&
+              (e.situation == 'battle_won' || e.situation == 'battle_lost'))
           .toList();
       expect(eventDialogue, isNotEmpty);
     });
 
-    test('naval interception combat with AI players invokes onDialogue with event battle_won/battle_lost', () {
+    test(
+        'naval interception combat with AI players invokes onDialogue with event battle_won/battle_lost',
+        () {
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(
+              id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
         ],
         edges: const [],
       );
@@ -762,16 +897,20 @@ void main() {
       expect(next.worldState.turnState.turnNumber, 1);
       // Naval battle may or may not eliminate one side; when it does, event dialogue is emitted.
       final eventDialogue = dialogueEvents
-          .where((e) => e.category == 'event' && (e.situation == 'battle_won' || e.situation == 'battle_lost'))
+          .where((e) =>
+              e.category == 'event' &&
+              (e.situation == 'battle_won' || e.situation == 'battle_lost'))
           .toList();
       expect(eventDialogue.length, lessThanOrEqualTo(2));
     });
 
-    test('endOfTurn era transition invokes onDialogue with event era_change', () {
+    test('endOfTurn era transition invokes onDialogue with event era_change',
+        () {
       // Turn 100 → year 1698 (earlyModern); turn 101 → 1700 (imperial). SPEC/ai/dialogue-and-mood.md.
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(
+              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
         ],
         edges: const [],
       );
@@ -806,11 +945,14 @@ void main() {
       }
     });
 
-    test('resolveTurnForGameFromOrderEngine integrates order engine output', () {
+    test('resolveTurnForGameFromOrderEngine integrates order engine output',
+        () {
       final topology = MapTopology(
         nodes: [
-          const TopologyNode(id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          const TopologyNode(id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
         ],
         edges: [
           const TopologyEdge(id1: 'P1', id2: 'P2'),
@@ -850,7 +992,8 @@ void main() {
       );
 
       final engine = OrderEngine();
-      engine.addMoveOrder('p1', const MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|P2'));
+      engine.addMoveOrder('p1',
+          const MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|P2'));
 
       final next = resolveTurnForGameFromOrderEngine(
         game: game,
@@ -862,11 +1005,15 @@ void main() {
       expect(next.worldState.oldWorld.units.single.provinceId, 'oldWorld|P2');
     });
 
-    test('validateOrdersAndResolveTurn filters invalid order and applies only valid move', () {
+    test(
+        'validateOrdersAndResolveTurn filters invalid order and applies only valid move',
+        () {
       final topology = MapTopology(
         nodes: [
-          const TopologyNode(id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          const TopologyNode(id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
         ],
         edges: [const TopologyEdge(id1: 'P1', id2: 'P2')],
       );
@@ -881,9 +1028,13 @@ void main() {
               Province(id: '$ow|P2', regionId: ow, ownerId: 'p1'),
             ],
             units: [
-              Unit(id: 'u1', type: 'musketeers', ownerId: 'p1', provinceId: '$ow|P1'),
+              Unit(
+                  id: 'u1',
+                  type: 'musketeers',
+                  ownerId: 'p1',
+                  provinceId: '$ow|P1'),
             ],
-            ),
+          ),
           newWorld: const RegionData(),
           playerVisibilityByTile: const {
             'p1': {
@@ -917,7 +1068,8 @@ void main() {
     test('movement phase applies naval mission order', () {
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(
+              id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
         ],
         edges: const [],
       );
@@ -963,8 +1115,10 @@ void main() {
     test('movement phase applies naval move order to adjacent sea zone', () {
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
-          TopologyNode(id: 'sea2', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(
+              id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(
+              id: 'sea2', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
         ],
         edges: const [
           TopologyEdge(id1: 'sea1', id2: 'sea2'),
@@ -1008,10 +1162,12 @@ void main() {
       expect(next.worldState.turnState.turnNumber, 1);
     });
 
-    test('naval interception phase runs when two at-war fleets in same zone', () {
+    test('naval interception phase runs when two at-war fleets in same zone',
+        () {
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(
+              id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
         ],
         edges: const [],
       );
@@ -1064,7 +1220,8 @@ void main() {
     test('full turn with buildWork applies work order', () {
       final topology = MapTopology(
         nodes: [
-          const TopologyNode(id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          const TopologyNode(
+              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
         ],
         edges: [],
       );
@@ -1108,7 +1265,8 @@ void main() {
       expect(next.worldState.playerProspectedTiles['p1'], contains(tileKey));
     });
 
-    test('endOfTurn sets military victory when one GP controls 31+ provinces', () {
+    test('endOfTurn sets military victory when one GP controls 31+ provinces',
+        () {
       const ow = 'oldWorld';
       final provinces = List<Province>.generate(
         32,
@@ -1129,7 +1287,8 @@ void main() {
       final topology = MapTopology(
         nodes: [
           for (var i = 0; i < 32; i++)
-            TopologyNode(id: 'P$i', regionId: ow, type: TopologyNodeType.province),
+            TopologyNode(
+                id: 'P$i', regionId: ow, type: TopologyNodeType.province),
         ],
         edges: const [],
       );
@@ -1143,7 +1302,9 @@ void main() {
       expect(next.victory!.type, VictoryType.military);
     });
 
-    test('endOfTurn sets military victory when one GP controls exactly 31 OW provinces', () {
+    test(
+        'endOfTurn sets military victory when one GP controls exactly 31 OW provinces',
+        () {
       const ow = 'oldWorld';
       final provinces = List<Province>.generate(
         31,
@@ -1164,7 +1325,8 @@ void main() {
       final topology = MapTopology(
         nodes: [
           for (var i = 0; i < 31; i++)
-            TopologyNode(id: 'P$i', regionId: ow, type: TopologyNodeType.province),
+            TopologyNode(
+                id: 'P$i', regionId: ow, type: TopologyNodeType.province),
         ],
         edges: const [],
       );
@@ -1178,11 +1340,15 @@ void main() {
       expect(next.victory!.type, VictoryType.military);
     });
 
-    test('endOfTurn tie-break: two GPs with ≥31 OW provinces wins lexicographically smallest id', () {
+    test(
+        'endOfTurn tie-break: two GPs with ≥31 OW provinces wins lexicographically smallest id',
+        () {
       const ow = 'oldWorld';
       final provinces = <Province>[
-        ...List<Province>.generate(31, (i) => Province(id: '$ow|A$i', regionId: ow, ownerId: 'p1')),
-        ...List<Province>.generate(31, (i) => Province(id: '$ow|B$i', regionId: ow, ownerId: 'p2')),
+        ...List<Province>.generate(
+            31, (i) => Province(id: '$ow|A$i', regionId: ow, ownerId: 'p1')),
+        ...List<Province>.generate(
+            31, (i) => Province(id: '$ow|B$i', regionId: ow, ownerId: 'p2')),
       ];
       final game = Game(
         id: 'g1',
@@ -1198,8 +1364,14 @@ void main() {
       );
       final topology = MapTopology(
         nodes: [
-          ...List.generate(31, (i) => TopologyNode(id: 'A$i', regionId: ow, type: TopologyNodeType.province)),
-          ...List.generate(31, (i) => TopologyNode(id: 'B$i', regionId: ow, type: TopologyNodeType.province)),
+          ...List.generate(
+              31,
+              (i) => TopologyNode(
+                  id: 'A$i', regionId: ow, type: TopologyNodeType.province)),
+          ...List.generate(
+              31,
+              (i) => TopologyNode(
+                  id: 'B$i', regionId: ow, type: TopologyNodeType.province)),
         ],
         edges: const [],
       );
@@ -1233,7 +1405,8 @@ void main() {
       final topology = MapTopology(
         nodes: [
           for (var i = 0; i < 31; i++)
-            TopologyNode(id: 'P$i', regionId: ow, type: TopologyNodeType.province),
+            TopologyNode(
+                id: 'P$i', regionId: ow, type: TopologyNodeType.province),
         ],
         edges: const [],
       );
@@ -1248,8 +1421,10 @@ void main() {
     test('endOfTurn no victory when no GP has ≥31 OW provinces', () {
       const ow = 'oldWorld';
       final provinces = <Province>[
-        ...List<Province>.generate(30, (i) => Province(id: '$ow|A$i', regionId: ow, ownerId: 'p1')),
-        ...List<Province>.generate(30, (i) => Province(id: '$ow|B$i', regionId: ow, ownerId: 'p2')),
+        ...List<Province>.generate(
+            30, (i) => Province(id: '$ow|A$i', regionId: ow, ownerId: 'p1')),
+        ...List<Province>.generate(
+            30, (i) => Province(id: '$ow|B$i', regionId: ow, ownerId: 'p2')),
       ];
       final game = Game(
         id: 'g1',
@@ -1265,8 +1440,14 @@ void main() {
       );
       final topology = MapTopology(
         nodes: [
-          ...List.generate(30, (i) => TopologyNode(id: 'A$i', regionId: ow, type: TopologyNodeType.province)),
-          ...List.generate(30, (i) => TopologyNode(id: 'B$i', regionId: ow, type: TopologyNodeType.province)),
+          ...List.generate(
+              30,
+              (i) => TopologyNode(
+                  id: 'A$i', regionId: ow, type: TopologyNodeType.province)),
+          ...List.generate(
+              30,
+              (i) => TopologyNode(
+                  id: 'B$i', regionId: ow, type: TopologyNodeType.province)),
         ],
         edges: const [],
       );
@@ -1302,7 +1483,10 @@ void main() {
         game: game,
         topology: MapTopology(
           nodes: const [
-            TopologyNode(id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+            TopologyNode(
+                id: 'P1',
+                regionId: 'oldWorld',
+                type: TopologyNodeType.province),
           ],
           edges: const [],
         ),
@@ -1313,7 +1497,9 @@ void main() {
       expect(next.worldState.turnState.turnNumber, 10);
     });
 
-    test('endOfTurn applies fog decay: other-faction tiles become fogged when no Explorer/Spy', () {
+    test(
+        'endOfTurn applies fog decay: other-faction tiles become fogged when no Explorer/Spy',
+        () {
       const ow = 'oldWorld';
       const tileKeyP2 = 'oldWorld|P2|0|0';
       final game = Game(
@@ -1332,7 +1518,12 @@ void main() {
             'p1': {tileKeyP2: VisibilityLevel.fullyVisible.name},
             'p2': {},
           },
-          tileKeysByRegionAndProvince: {ow: {'P1': ['oldWorld|P1|0|0'], 'P2': [tileKeyP2]}},
+          tileKeysByRegionAndProvince: {
+            ow: {
+              'P1': ['oldWorld|P1|0|0'],
+              'P2': [tileKeyP2]
+            }
+          },
         ),
         players: const [
           Player(id: 'p1', displayName: 'P1', isHuman: true),
@@ -1343,17 +1534,22 @@ void main() {
         game: game,
         topology: MapTopology(
           nodes: const [
-            TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
-            TopologyNode(id: 'P2', regionId: ow, type: TopologyNodeType.province),
+            TopologyNode(
+                id: 'P1', regionId: ow, type: TopologyNodeType.province),
+            TopologyNode(
+                id: 'P2', regionId: ow, type: TopologyNodeType.province),
           ],
           edges: const [],
         ),
         orders: const Orders(),
       );
-      expect(next.worldState.playerVisibilityByTile['p1']?[tileKeyP2], VisibilityLevel.fogged.name);
+      expect(next.worldState.playerVisibilityByTile['p1']?[tileKeyP2],
+          VisibilityLevel.fogged.name);
     });
 
-    test('endOfTurn fog decay does not apply when Explorer is in other-faction province', () {
+    test(
+        'endOfTurn fog decay does not apply when Explorer is in other-faction province',
+        () {
       const ow = 'oldWorld';
       const tileKeyP2 = 'oldWorld|P2|0|0';
       final game = Game(
@@ -1379,7 +1575,12 @@ void main() {
             'p1': {tileKeyP2: VisibilityLevel.fullyVisible.name},
             'p2': {},
           },
-          tileKeysByRegionAndProvince: {ow: {'P1': ['oldWorld|P1|0|0'], 'P2': [tileKeyP2]}},
+          tileKeysByRegionAndProvince: {
+            ow: {
+              'P1': ['oldWorld|P1|0|0'],
+              'P2': [tileKeyP2]
+            }
+          },
         ),
         players: const [
           Player(id: 'p1', displayName: 'P1', isHuman: true),
@@ -1390,17 +1591,22 @@ void main() {
         game: game,
         topology: MapTopology(
           nodes: const [
-            TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
-            TopologyNode(id: 'P2', regionId: ow, type: TopologyNodeType.province),
+            TopologyNode(
+                id: 'P1', regionId: ow, type: TopologyNodeType.province),
+            TopologyNode(
+                id: 'P2', regionId: ow, type: TopologyNodeType.province),
           ],
           edges: const [],
         ),
         orders: const Orders(),
       );
-      expect(next.worldState.playerVisibilityByTile['p1']?[tileKeyP2], VisibilityLevel.fullyVisible.name);
+      expect(next.worldState.playerVisibilityByTile['p1']?[tileKeyP2],
+          VisibilityLevel.fullyVisible.name);
     });
 
-    test('endOfTurn fog decay uses full province id: same local id in two regions', () {
+    test(
+        'endOfTurn fog decay uses full province id: same local id in two regions',
+        () {
       const ow = 'oldWorld';
       const nw = 'newWorld';
       const tileKeyOwP1 = 'oldWorld|P1|0|0';
@@ -1435,8 +1641,13 @@ void main() {
             'p2': {},
           },
           tileKeysByRegionAndProvince: {
-            ow: {'P1': [tileKeyOwP1], 'P2': ['oldWorld|P2|0|0']},
-            nw: {'P1': [tileKeyNwP1]},
+            ow: {
+              'P1': [tileKeyOwP1],
+              'P2': ['oldWorld|P2|0|0']
+            },
+            nw: {
+              'P1': [tileKeyNwP1]
+            },
           },
         ),
         players: const [
@@ -1448,9 +1659,12 @@ void main() {
         game: game,
         topology: MapTopology(
           nodes: const [
-            TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
-            TopologyNode(id: 'P2', regionId: ow, type: TopologyNodeType.province),
-            TopologyNode(id: 'P1', regionId: nw, type: TopologyNodeType.province),
+            TopologyNode(
+                id: 'P1', regionId: ow, type: TopologyNodeType.province),
+            TopologyNode(
+                id: 'P2', regionId: ow, type: TopologyNodeType.province),
+            TopologyNode(
+                id: 'P1', regionId: nw, type: TopologyNodeType.province),
           ],
           edges: const [],
         ),
@@ -1464,7 +1678,128 @@ void main() {
       expect(
         next.worldState.playerVisibilityByTile['p1']?[tileKeyNwP1],
         VisibilityLevel.fogged.name,
-        reason: 'No Explorer in newWorld|P1; must fog (full province id, not local)',
+        reason:
+            'No Explorer in newWorld|P1; must fog (full province id, not local)',
+      );
+    });
+
+    test(
+        'endOfTurn preserves visibility when Spy timer is active (no units present)',
+        () {
+      const ow = 'oldWorld';
+      const tileKeyP2 = 'oldWorld|P2|0|0';
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+            ],
+            units: const [],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            'p1': {tileKeyP2: 'fullyVisible'},
+          },
+          tileKeysByRegionAndProvince: const {
+            ow: {
+              'P2': [tileKeyP2],
+            },
+          },
+          spyRevealTurnsByPlayer: const {
+            'p1': {
+              '$ow|P2': 5,
+            },
+          },
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+          Player(id: 'p2', displayName: 'P2', isHuman: false),
+        ],
+      );
+
+      final next = resolveTurnForGame(
+        game: game,
+        topology: MapTopology(
+          nodes: const [
+            TopologyNode(
+                id: 'P1', regionId: ow, type: TopologyNodeType.province),
+            TopologyNode(
+                id: 'P2', regionId: ow, type: TopologyNodeType.province),
+          ],
+          edges: const [],
+        ),
+        orders: const Orders(),
+      );
+
+      // Timer decremented but still present.
+      expect(next.worldState.spyRevealTurnsByPlayer['p1']?['$ow|P2'], 4);
+      // Province remains fully visible while timer > 0.
+      expect(
+        next.worldState.playerVisibilityByTile['p1']?[tileKeyP2],
+        VisibilityLevel.fullyVisible.name,
+      );
+    });
+
+    test(
+        'endOfTurn fogs province when Spy timer reaches zero and no Explorer/Spy remains',
+        () {
+      const ow = 'oldWorld';
+      const tileKeyP2 = 'oldWorld|P2|0|0';
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+            ],
+            units: const [],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            'p1': {tileKeyP2: 'fullyVisible'},
+          },
+          tileKeysByRegionAndProvince: const {
+            ow: {
+              'P2': [tileKeyP2],
+            },
+          },
+          spyRevealTurnsByPlayer: const {
+            'p1': {
+              '$ow|P2': 1,
+            },
+          },
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+          Player(id: 'p2', displayName: 'P2', isHuman: false),
+        ],
+      );
+
+      final next = resolveTurnForGame(
+        game: game,
+        topology: MapTopology(
+          nodes: const [
+            TopologyNode(
+                id: 'P1', regionId: ow, type: TopologyNodeType.province),
+            TopologyNode(
+                id: 'P2', regionId: ow, type: TopologyNodeType.province),
+          ],
+          edges: const [],
+        ),
+        orders: const Orders(),
+      );
+
+      // Timer cleared once it reaches 0.
+      expect(next.worldState.spyRevealTurnsByPlayer['p1']?['$ow|P2'], isNull);
+      // Province tiles decay to fogged.
+      expect(
+        next.worldState.playerVisibilityByTile['p1']?[tileKeyP2],
+        VisibilityLevel.fogged.name,
       );
     });
   });


### PR DESCRIPTION
## Summary
- Respect Spy reveal timers when applying end-of-turn fog decay so provinces with active timers stay fully visible until the timer reaches zero.
- Add unit and turn resolver tests to cover Spy-reveal visibility preservation and decay when the timer expires.
- Minor formatting cleanups in turn resolver and tests for readability.

## Test plan
- dart test packages/colonizethis_logic
- dart test tool/sim_scenarios
- dart run tool/sim_scenarios/bin/sim_scenarios.dart --scenario=tool/sim_scenarios/scenarios/workers_consumption_starvation.json
- dart run tool/sim_scenarios/bin/sim_scenarios.dart --scenario=tool/sim_scenarios/scenarios/workers_luxury_consumption.json
- dart run tool/sim_scenarios/bin/sim_scenarios.dart --scenario=tool/sim_scenarios/scenarios/workers_luxury_zero_labour.json


Made with [Cursor](https://cursor.com)