### PR TITLE
ci: split quality gate into separate test steps, compact reporter

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -51,19 +51,59 @@ jobs:
         if: steps.changes.outputs.tests == 'true'
         run: sudo apt-get update && sudo apt-get install -y lcov
 
+      - name: Resolve dependencies
+        if: steps.changes.outputs.tests == 'true'
+        run: dart pub get
+
       - name: Check test import convention (SPEC/program/test-logging.md)
         run: tool/check_test_imports.sh
 
-      - name: Run tests with coverage
+      # Same scope as tool/test_coverage.py; split steps, compact reporter (pass/fail only, no logger).
+      - name: Test packages (Dart)
         if: steps.changes.outputs.tests == 'true'
-        #run: python3 tool/test_coverage.py
-        run: echo disabled
+        env:
+          SUPPRESS_IMAGE_VIEWER: "1"
+        run: |
+          set -e
+          for dir in packages/colonizethis_models packages/colonizethis_data packages/colonizethis_save packages/colonizethis_logic packages/colonizethis_ai packages/colonizethis_map; do
+            [ -d "$dir/test" ] || continue
+            (cd "$dir" && dart test --coverage=coverage -j 4 --reporter=compact)
+            (cd "$dir" && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
+          done
+
+      - name: Test app (Flutter)
+        if: steps.changes.outputs.tests == 'true'
+        env:
+          SUPPRESS_IMAGE_VIEWER: "1"
+        run: |
+          if [ -d app ]; then
+            (cd app && flutter test --coverage --reporter=compact)
+          fi
+
+      - name: Test ctdev (Flutter)
+        if: steps.changes.outputs.tests == 'true'
+        env:
+          SUPPRESS_IMAGE_VIEWER: "1"
+        run: |
+          if [ -d ctdev/test ]; then
+            (cd ctdev && flutter test --coverage --reporter=compact)
+          fi
+
+      - name: Test tool packages (Dart)
+        if: steps.changes.outputs.tests == 'true'
+        env:
+          SUPPRESS_IMAGE_VIEWER: "1"
+        run: |
+          set -e
+          for dir in tool/sim_scenarios tool/sim_combat_montecarlo tool/sim_combat tool/generate_map tool/init_game tool/sim_economy tool/show_tech; do
+            [ -d "$dir/test" ] || continue
+            (cd "$dir" && dart test --coverage=coverage -j 4 --reporter=compact)
+            (cd "$dir" && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
+          done
 
       - name: Coverage gate (logic/map/ai >= 90%)
         if: steps.changes.outputs.tests == 'true'
-        #run: tool/check_coverage_threshold.sh 90 packages/colonizethis_logic packages/colonizethis_map packages/colonizethis_ai
-        run: echo disabled
-
+        run: tool/check_coverage_threshold.sh 90 packages/colonizethis_logic packages/colonizethis_map packages/colonizethis_ai
 
       - name: sim_scenarios integration gate (all scenarios must pass)
         if: steps.changes.outputs.tests == 'true'

--- a/SPEC/program/test-logging.md
+++ b/SPEC/program/test-logging.md
@@ -28,7 +28,9 @@ When tests are run (e.g. via `tool/test_coverage.py` or `dart test` / `flutter t
 
 Any package or app that has tests adds **colonizethis_test** as a **dev_dependency**. Dart test files use only `package:colonizethis_test/test.dart`. Flutter test files use that import first, then `package:flutter_test/flutter_test.dart`.
 
-**If log output still appears:** Some test runners may load dependencies in an order where logger-using packages are initialized before colonizethis_test. The package sets both `Logger.level = Level.off` and `Logger.defaultFilter` to a no-op filter so that any Logger created after the init will not output. For CI or coverage runs, you can pipe test output and filter out logger-style lines (e.g. lines containing `│` or `logic:`/`map:`/`save:`).
+**If log output still appears:** Some test runners may load dependencies in an order where logger-using packages are initialized before colonizethis_test. The package sets both `Logger.level = Level.off` and `Logger.defaultFilter` to a no-op filter so that any Logger created after the init will not output.
+
+**test_coverage.py:** When running tests via `tool/test_coverage.py`, console output is **whitelisted**: only lines that look like Dart/Flutter test runner output (pass/fail counts, test names, Expected/Actual/Which, summary) are printed. All other lines (logger, print, loading chatter) are suppressed so only test results are visible.
 
 ---
 
@@ -36,3 +38,13 @@ Any package or app that has tests adds **colonizethis_test** as a **dev_dependen
 
 - Run **`tool/test_coverage.py`** to run all package and app tests with coverage. Output is written to each package’s `coverage/` and optionally merged to `coverage_merged/` when `lcov` is installed. The script prints a per-package and overall line-coverage summary.
 - To enforce a minimum line coverage (e.g. 90%), run **`tool/check_coverage_threshold.sh [threshold] [dir1 [dir2 ...]]`** after `tool/test_coverage.py`. If no directories are given, all app, ctdev, and packages are checked. Example: `tool/check_coverage_threshold.sh 90`. To check only a specific target: `tool/check_coverage_threshold.sh 90 packages/colonizethis_logic`. It exits with code 1 if any checked target is below the threshold.
+
+---
+
+## Verifying the quality gate
+
+The GitHub workflow **.github/workflows/quality.yml** runs the same test scope as `tool/test_coverage.py` but in split steps with `--reporter=compact` (pass/fail only). You can verify it locally in either of these ways:
+
+1. **Run the same steps locally:** From the repo root, run **`tool/run_quality_gate_tests.sh`**. This runs the same commands as the workflow (packages Dart, app Flutter, ctdev Flutter, tool packages Dart, coverage gate, sim_scenarios). Requires `dart`, `flutter`, and `lcov`.
+2. **Run the workflow with act:** If [act](https://github.com/nektos/act) is installed, run `act pull_request -n` (dry run) or `act pull_request` to execute the Quality job locally.
+3. **Trigger CI:** Push to a branch and open a PR against `main` or `dev`; the Quality job runs on the push.

--- a/docs/project-tools.md
+++ b/docs/project-tools.md
@@ -190,3 +190,17 @@ melos run check_gdd_coverage
 - Warns if a scenario file listed in the mapping is missing from tool/sim_scenarios/scenarios/.
 - Exit 0 if all specs covered; exit 1 if any uncovered (for CI).
 - If the mapping uses the extended format with `verifierIssues` for a covered spec, the tool prints those issues so the **coder** can rectify them (see [agentic-gdd-verifier.md](../SPEC/project/agentic-gdd-verifier.md) and [agentic-gdd-scenario-coverage.md](../SPEC/project/agentic-gdd-scenario-coverage.md)).
+
+---
+
+## run_quality_gate_tests.sh (CI verification)
+
+Runs the same test and coverage steps as the GitHub Quality workflow (`.github/workflows/quality.yml`): packages (Dart), app (Flutter), ctdev (Flutter), tool packages (Dart), coverage gate (logic/map/ai ≥ 90%), and sim_scenarios. Use this to verify the quality gate locally before pushing. Spec: [SPEC/program/test-logging.md](../SPEC/program/test-logging.md).
+
+**Invocation**
+
+```bash
+tool/run_quality_gate_tests.sh
+```
+
+Requires `dart`, `flutter`, and `lcov` (e.g. `sudo apt-get install lcov`).

--- a/tool/run_quality_gate_tests.sh
+++ b/tool/run_quality_gate_tests.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Run the same test steps as .github/workflows/quality.yml (split steps, compact reporter).
+# Use this to verify the quality gate locally before pushing. Requires: dart, flutter, lcov.
+# See SPEC/program/test-logging.md and tool/test_coverage.py for scope.
+set -e
+export SUPPRESS_IMAGE_VIEWER=1
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+echo "=== Resolve dependencies ==="
+dart pub get
+
+echo ""
+echo "=== Test packages (Dart) ==="
+for dir in packages/colonizethis_models packages/colonizethis_data packages/colonizethis_save packages/colonizethis_logic packages/colonizethis_ai packages/colonizethis_map; do
+  [ -d "$dir/test" ] || continue
+  (cd "$dir" && dart test --coverage=coverage -j 4 --reporter=compact)
+  (cd "$dir" && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
+done
+
+echo ""
+echo "=== Test app (Flutter) ==="
+if [ -d app ]; then
+  (cd app && flutter test --coverage --reporter=compact)
+fi
+
+echo ""
+echo "=== Test ctdev (Flutter) ==="
+if [ -d ctdev/test ]; then
+  (cd ctdev && flutter test --coverage --reporter=compact)
+fi
+
+echo ""
+echo "=== Test tool packages (Dart) ==="
+for dir in tool/sim_scenarios tool/sim_combat_montecarlo tool/sim_combat tool/generate_map tool/init_game tool/sim_economy tool/show_tech; do
+  [ -d "$dir/test" ] || continue
+  (cd "$dir" && dart test --coverage=coverage -j 4 --reporter=compact)
+  (cd "$dir" && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
+done
+
+echo ""
+echo "=== Coverage gate (logic/map/ai >= 90%) ==="
+"$ROOT/tool/check_coverage_threshold.sh" 90 packages/colonizethis_logic packages/colonizethis_map packages/colonizethis_ai
+
+echo ""
+echo "=== sim_scenarios integration gate ==="
+melos run sim_scenarios
+
+echo ""
+echo "All quality-gate steps passed."


### PR DESCRIPTION
Same scope as `tool/test_coverage.py`; split into separate workflow steps and use `--reporter=compact` so only pass/fail output is shown (logger suppressed).

**Changes:**
- **.github/workflows/quality.yml:** Replace single test step with: Test packages (Dart), Test app (Flutter), Test ctdev (Flutter), Test tool packages (Dart). Add Resolve dependencies step. Re-enable coverage gate (logic/map/ai ≥ 90%). All test steps use `SUPPRESS_IMAGE_VIEWER=1` and `--reporter=compact`.
- **tool/run_quality_gate_tests.sh:** New script to run the same steps locally for verification.
- **SPEC/program/test-logging.md:** Add "Verifying the quality gate" section (local script, act, or trigger CI).
- **docs/project-tools.md:** Document `run_quality_gate_tests.sh`.

Made with [Cursor](https://cursor.com)