### PR TITLE
fix(sea-transport): remove unused luxury category from priority order

### DIFF
--- a/packages/colonizethis_logic/lib/src/economy/sea_transport.dart
+++ b/packages/colonizethis_logic/lib/src/economy/sea_transport.dart
@@ -9,18 +9,19 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 /// Default cargo holds per player when no ships (Phase 2 stub).
 const int defaultCargoHoldsStub = 24;
 
-/// Priority order for filling cargo: food, raw materials, riches, then manufactured/luxury/advanced.
+/// Priority order for filling cargo: food, raw materials, riches, then manufactured/advanced.
+/// Note: CommodityCategory.luxury exists but no commodity currently has that category assigned,
+/// so it's excluded from priority until luxury is defined in the commodity catalog.
 final List<CommodityCategory> _seaPriorityOrder = [
   CommodityCategory.food,
   CommodityCategory.rawMaterial,
   CommodityCategory.riches,
   CommodityCategory.manufactured,
-  CommodityCategory.luxury,
   CommodityCategory.advanced,
 ];
 
 /// Allocates [overseasTotals] to delivered amounts, filling up to [cargoHolds] units total
-/// by [priorityOrder] (default: food, raw, riches, manufactured, luxury, advanced).
+/// by [priorityOrder] (default: food, raw, riches, manufactured, advanced).
 /// Returns the map of commodity id → quantity to add to stockpile.
 Map<CommodityId, int> allocateOverseasToStockpile(
   Map<CommodityId, int> overseasTotals, {


### PR DESCRIPTION
## Summary

Fixes issue #535: Sea transport priority includes luxury category but no commodity in the catalog has that category assigned.

## Changes

- Remove luxury from _seaPriorityOrder list in sea_transport.dart
- Update comment documentation to reflect actual priority order (food, raw, riches, manufactured, advanced)

## Why

The luxury category exists in the enum and is referenced in the transport priority logic, but no actual commodities have this category. This means the luxury slot in the transport priority is never used. The fix removes it until luxury is properly defined in the commodity catalog (tracked in issue #344).

## Testing

- All sea_transport tests pass (8 tests)
- Static analysis passes with no issues