### PR TITLE
fix(app): remove unnecessary null assertions and unused import

### DIFF
--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -64,8 +64,8 @@ class GameScreen extends ConsumerWidget {
           ],
           if (game != null && victory != null)
             _VictoryOverlay(
-              game: game!,
-              victory: victory!,
+              game: game,
+              victory: victory,
             ),
         ],
       ),

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -2,7 +2,6 @@
 import 'package:colonizethis_test/test.dart' as _;
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:colonizethis_app/app.dart';


### PR DESCRIPTION
Fix flutter analyze warnings by removing unnecessary null assertions and unused import.