### PR TITLE
fix(spec): update auto-transport.md to exclude luxury from priority (Fixes #535)

### DIFF
--- a/SPEC/program/auto-transport.md
+++ b/SPEC/program/auto-transport.md
@@ -35,9 +35,8 @@ All **same-region** extracted goods are added to the player's stockpile. Extract
 | 3        | Food Variety       | Fish, Dairy        | Morale/health bonuses   |
 | 4        | Riches             | Gold, Silver, Gems | Trade income            |
 | 5        | Trade Goods        | Textiles, Spices   | Discretionary income    |
-| 6        | Luxury             | Wine, Tobacco      | Nice to have            |
 
-**Note:** Implementation uses `CommodityCategory` order (food, rawMaterial, riches, manufactured, luxury, advanced). Grain and meat are the only food commodities in the catalog; Critical Food vs Food Variety sub-ordering applies when fish/dairy are added. Cargo-hold limit uses a fixed stub per player; sum-of-ships can be wired when fleet cargo capacity is available.
+**Note:** Implementation uses `CommodityCategory` order (food, rawMaterial, riches, manufactured, advanced). The luxury category is excluded from priority until luxury is properly defined in the commodity catalog (see [commodity-catalog](../game/commodity-catalog.md) and issue #344). Grain and meat are the only food commodities in the catalog; Critical Food vs Food Variety sub-ordering applies when fish/dairy are added. Cargo-hold limit uses a fixed stub per player; sum-of-ships can be wired when fleet cargo capacity is available.
 
 ---
 


### PR DESCRIPTION
## Summary

Completes fix for issue #535: The code was previously updated to exclude luxury category from sea transport priority since no commodity has that category assigned. This updates the SPEC to match the implementation.

## Changes

- Remove Luxury row from priority table in SPEC/program/auto-transport.md
- Update note to reflect actual CommodityCategory order (food, rawMaterial, riches, manufactured, advanced)
- Add reference to commodity-catalog.md and issue #344 for future luxury definition

## Why

The implementation excludes luxury because no commodity in the catalog has that category. The SPEC should reflect this to avoid confusion.

## Testing

- No code changes, only SPEC documentation update
- Static analysis passes (no Dart files modified)