### PR TITLE
Fix distance squared typo in _assignLandByLandSeeds (issue #122)

### DIFF
--- a/packages/colonizethis_map/lib/src/tile_map_generator.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator.dart
@@ -2389,7 +2389,7 @@ class TileMapGenerator {
           var d2 = 0x7fffffff;
           for (var i = start; i < end; i++) {
             final (sx, sy) = landSeeds[i];
-            final dd = (x - sx) * (x - sy) * (x - sx) + (y - sy) * (y - sy);
+            final dd = (x - sx) * (x - sx) + (y - sy) * (y - sy);
             if (dd < d2) d2 = dd;
           }
           final noise = params.voronoiNoiseScale > 0


### PR DESCRIPTION
## Summary

Fixes a typo in the Euclidean distance calculation in `tile_map_generator.dart` line 2415.

## Bug

The original code was:
```dart
final dd = (x - sx) * (x - sy) * (x - sx) + (y - sy) * (y - sy);
```

Two bugs:
1. Used `(x - sy)` instead of `(x - sx)`
2. Had an extra `* (x - sx)` factor

## Fix

Changed to the correct formula:
```dart
final dd = (x - sx) * (x - sx) + (y - sy) * (y - sy);
```

This matches the correct implementation in `_assignLandByLandSeedsWithNoJoin` (line 2135).

## Testing

- All 42 tile_map_generator tests pass
- Static analysis shows no new issues

## Issue

Fixes #122