### PR TITLE
Spec: define improvement naming and sim_scenarios wiring

### DIFF
--- a/SPEC/game/extraction-and-improvements.md
+++ b/SPEC/game/extraction-and-improvements.md
@@ -21,6 +21,40 @@ Each land tile in an owned province may have one extraction improvement (mine, f
 
 Tech caps first, then transport caps. Example: level 4 farm, tech cap 3, transport 2 → 2 units/turn. The improvement stays at level 4; tech/transport upgrades or conquest can unlock more later.
 
+### Improvement Naming
+
+Improvement **names** are purely descriptive; they do **not** change extraction rules or yields, which continue to follow the formula above. The UI derives the displayed name from the tile's **resource id**, independent of improvement level:
+
+| Resource id (or group) | Default improvement name |
+|------------------------|--------------------------|
+| `grain`                | Farm                     |
+| `meat`, `horses`       | Ranch                    |
+| `wool`                 | Pasture                  |
+| `timber`               | Lumber camp              |
+| `sugarCane`, `tobacco`, `cotton`, `spices` | Plantation  |
+| `furs`                 | Fur post                 |
+| `iron`, `copper`, `tin`, `coal`, `silver`, `gold`, `gems`, `diamonds` | Mine |
+
+If a tile has **no resource id** (e.g. development-only tile in a future ruleset), the improvement name is `Improvement` by default. UI layers **may** append the numeric level for clarity (e.g. `Farm (L2)`), but the canonical base name is given by the table above.
+
+Acceptance criteria (naming only):
+
+- Given a land tile with resource id `gold` and improvement level \(N\) where \(N\) is an integer between 1 and 4 inclusive  
+  When the UI layer queries the tile's improvement name for display  
+  Then the UI layer uses the base name `Mine` for that tile, regardless of the value of \(N\)
+
+- Given a land tile with resource id `grain` and improvement level \(N\) where \(N\) is an integer between 1 and 4 inclusive  
+  When the UI layer queries the tile's improvement name for display  
+  Then the UI layer uses the base name `Farm` for that tile, regardless of the value of \(N\)
+
+- Given a land tile with resource id `furs` and improvement level \(N\) where \(N\) is an integer between 1 and 4 inclusive  
+  When the UI layer queries the tile's improvement name for display  
+  Then the UI layer uses the base name `Fur post` for that tile, regardless of the value of \(N\)
+
+- Given a land tile with no resource id and improvement level \(N\) where \(N\) is an integer between 1 and 4 inclusive  
+  When the UI layer queries the tile's improvement name for display  
+  Then the UI layer uses the base name `Improvement` for that tile
+
 ### Town and extraction
 
 Each province has one **town** tile assigned at game init (see [capital-and-connectivity.md](capital-and-connectivity.md) § Town per province). A tile's resources are extractable only if the tile is **connected to the province's town** (path of road/rail/port to the town) and the town is connected to the capital. **Town development level** (raised by Builder `upgrade_town` work) and the **transport level** along the path limit extraction. If multiple paths exist from a tile to the capital, the **maximum** transport level path determines the cap.

--- a/SPEC/program/sim-scenarios.md
+++ b/SPEC/program/sim-scenarios.md
@@ -184,6 +184,8 @@ Assertion fields:
 
 **Fog/exploration assertions** (SPEC/game/fog-and-exploration.md): use `player`, `tileKey` (format `regionId|provinceId|x|y`), and optionally `tileVisibility` (expected level: `unknown`, `revealed`, `fogged`, `fullyVisible`) and/or `tileProspected` (boolean). Example: `{"turn": 1, "player": "gp1", "tileKey": "oldWorld|p1|0|0", "tileVisibility": "fullyVisible"}`; `{"player": "gp1", "tileKey": "oldWorld|p2|2|0", "tileVisibility": "fogged", "tileProspected": false}`.
 
+**Improvement naming assertions** (SPEC/game/extraction-and-improvements.md): when the scenario runner exposes a UI-facing view for tiles, use `tileKey` (format `regionId|provinceId|x|y`) with `tileImprovementName` (expected string) to verify that the improvement naming table is applied correctly. Example: `{"turn": 1, "tileKey": "oldWorld|p1|0|0", "tileImprovementName": "Farm"}` for a tile whose resource id is `grain` and improvement level is between 1 and 4 inclusive.
+
 **Leader assertions** (SPEC/game/leader-bonuses.md): use `player` (Great Power id) and `leaderKey` (expected leader key, e.g. `napoleon`, `frederick`, `reserve`). Example: `{"turn": 1, "player": "gp1", "leaderKey": "napoleon"}`.
 
 **Research-state assertions** (SPEC/game/research-state.md): use `player` and `techUnlocked` (array of tech ids that must be true in that player’s techUnlocked map). Example: `{"turn": 1, "player": "gp1", "techUnlocked": ["gathering_1", "road_construction"]}`.

--- a/tool/sim_scenarios/lib/scenario.dart
+++ b/tool/sim_scenarios/lib/scenario.dart
@@ -228,6 +228,7 @@ class Assertion {
     this.tileKey,
     this.tileVisibility,
     this.tileProspected,
+    this.tileImprovementName,
     this.leaderKey,
     this.techUnlocked,
     this.provinceDisplayName,
@@ -296,6 +297,11 @@ class Assertion {
   final String? tileKey;
   final String? tileVisibility;
   final bool? tileProspected;
+
+  /// Improvement naming assertion (SPEC/game/extraction-and-improvements.md).
+  /// With [tileKey]: expected improvement display name derived from the tile's resource id.
+  /// Example: tile with resource `grain` and improvementLevel 1-4 → `Farm`.
+  final String? tileImprovementName;
 
   /// Leader assertion (SPEC/game/leader-bonuses.md). With [player]: expected leaderKey for that Great Power.
   final String? leaderKey;
@@ -599,6 +605,7 @@ Assertion _parseAssertion(Map<String, dynamic> json) {
     tileKey: json['tileKey'] as String?,
     tileVisibility: json['tileVisibility'] as String?,
     tileProspected: json['tileProspected'] as bool?,
+    tileImprovementName: json['tileImprovementName'] as String?,
     leaderKey: json['leaderKey'] as String?,
     techUnlocked: (json['techUnlocked'] as List<dynamic>?)
         ?.map((e) => e.toString())

--- a/tool/sim_scenarios/lib/state_verifier.dart
+++ b/tool/sim_scenarios/lib/state_verifier.dart
@@ -421,6 +421,18 @@ class StateVerifier {
       }
     }
 
+    // Improvement naming assertions (SPEC/game/extraction-and-improvements.md)
+    if (assertion.tileImprovementName != null && assertion.tileKey != null) {
+      final tileKey = assertion.tileKey!;
+      final expectedName = assertion.tileImprovementName!;
+      final actualName = _improvementNameForTile(game, tileKey);
+      if (actualName != expectedName) {
+        failures.add(
+          'Tile $tileKey improvementName: expected "$expectedName", got "$actualName"',
+        );
+      }
+    }
+
     // Leader assertion (SPEC/game/leader-bonuses.md): player's leaderKey
     if (assertion.player != null && assertion.leaderKey != null) {
       try {
@@ -679,6 +691,42 @@ class StateVerifier {
       if (o.gpId == gpId && o.targetId == targetId) return o;
     }
     return null;
+  }
+}
+
+/// Derives the improvement display name for a tile based on its resource id.
+/// Mirrors SPEC/game/extraction-and-improvements.md (Improvement Naming table).
+String _improvementNameForTile(Game game, String tileKey) {
+  final resourceId = game.worldState.resourceByTileKey[tileKey];
+  final normalized = resourceId ?? '';
+  switch (normalized) {
+    case 'grain':
+      return 'Farm';
+    case 'meat':
+    case 'horses':
+      return 'Ranch';
+    case 'wool':
+      return 'Pasture';
+    case 'timber':
+      return 'Lumber camp';
+    case 'sugarCane':
+    case 'tobacco':
+    case 'cotton':
+    case 'spices':
+      return 'Plantation';
+    case 'furs':
+      return 'Fur post';
+    case 'iron':
+    case 'copper':
+    case 'tin':
+    case 'coal':
+    case 'silver':
+    case 'gold':
+    case 'gems':
+    case 'diamonds':
+      return 'Mine';
+    default:
+      return 'Improvement';
   }
 }
 

--- a/tool/sim_scenarios/scenarios/extraction_improvement_naming.json
+++ b/tool/sim_scenarios/scenarios/extraction_improvement_naming.json
@@ -1,0 +1,39 @@
+{
+  "name": "extraction_improvement_naming",
+  "description": "Improvement naming (SPEC/game/extraction-and-improvements.md § Improvement Naming): tiles with resources map to Farm, Mine, Fur post, or Improvement based on resource id; level does not affect the base name.",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "greatPowers": ["england"],
+      "seed": 42,
+      "minorNationCount": 0,
+      "numProvincesOldWorld": 1,
+      "numProvincesNewWorld": 0,
+      "tribeCount": 0
+    },
+    "oldWorld": {
+      "grid": [["p1", "sea1", "p1", "p1"]],
+      "nodes": [
+        { "id": "p1", "regionId": "oldWorld", "type": "province" },
+        { "id": "sea1", "regionId": "oldWorld", "type": "seaZone" }
+      ],
+      "edges": [
+        { "id1": "p1", "id2": "sea1" }
+      ],
+      "resourceGrid": [["grain", null, "furs", "gold"]]
+    }
+  },
+  "setup": {
+    "initialTileState": {
+      "oldWorld|p1|0|0": { "improvementLevel": 1, "roadLevel": 0 },
+      "oldWorld|p1|1|0": { "improvementLevel": 1, "roadLevel": 0 },
+      "oldWorld|p1|2|0": { "improvementLevel": 1, "roadLevel": 0 },
+      "oldWorld|p1|3|0": { "improvementLevel": 1, "roadLevel": 0 }
+    }
+  },
+  "turns": [
+    { "turn": 1, "orders": [] }
+  ],
+  "assertions": []
+}
+


### PR DESCRIPTION
## Summary
- Define canonical improvement naming table in \ and add ACs for naming behavior.
- Extend sim_scenarios assertion model/state verifier with \ helper, wired to a resource→name mapping that mirrors the spec.
- Add a minimal \ scenario shell (no assertions yet) and ensure all existing scenarios pass.

## Test plan
- \00:00 +0: loading tool/sim_scenarios/test/sim_scenarios_test.dart
00:00 +0: tool/sim_scenarios/test/sim_scenarios_test.dart: sim_scenarios parseScenarioFromJson parses fresh init scenario
00:00 +1: tool/sim_scenarios/test/sim_scenarios_test.dart: sim_scenarios parseScenarioFromJson parses saved init scenario
00:00 +2: tool/sim_scenarios/test/sim_scenarios_test.dart: sim_scenarios parseScenarioFromJson parses scenario with setup
00:00 +3: tool/sim_scenarios/test/sim_scenarios_test.dart: sim_scenarios parseScenarioFromJson parses all order types
00:00 +4: tool/sim_scenarios/test/sim_scenarios_test.dart: sim_scenarios parseScenarioFromJson parses assertions with all match types
00:00 +5: tool/sim_scenarios/test/sim_scenarios_test.dart: sim_scenarios parseScenarioFromJson parses assertion with capitalProvince
00:00 +6: tool/sim_scenarios/test/sim_scenarios_test.dart: sim_scenarios parseScenarioFromJson parses capital assertions
00:00 +7: tool/sim_scenarios/test/sim_scenarios_test.dart: sim_scenarios parseScenarioFromJson parses setup initialWorkers and initialStockpile
00:00 +8: tool/sim_scenarios/test/sim_scenarios_test.dart: sim_scenarios parseScenarioFromJson parses setup productionAssignments
00:00 +9: tool/sim_scenarios/test/sim_scenarios_test.dart: sim_scenarios parseScenarioFromJson parses setup leaderKeys and assertion leaderKey
00:00 +10: tool/sim_scenarios/test/sim_scenarios_test.dart: sim_scenarios parseScenarioFromJson parses setup initialTech
00:00 +11: tool/sim_scenarios/test/sim_scenarios_test.dart: sim_scenarios parseScenarioFromJson parses assertion techUnlocked
00:00 +12: tool/sim_scenarios/test/sim_scenarios_test.dart: sim_scenarios parseScenarioFromJson parses assertion provinceDisplayName
00:00 +13: tool/sim_scenarios/test/sim_scenarios_test.dart: sim_scenarios parseScenarioFromJson parses setup defaultCombatMode
00:00 +14: tool/sim_scenarios/test/sim_scenarios_test.dart: sim_scenarios parseScenarioFile parses single scenario from file
00:00 +15: tool/sim_scenarios/test/sim_scenarios_test.dart: sim_scenarios discoverScenarios finds all JSON files in directory
00:00 +16: All tests passed!
- \ (43/43 scenarios passing)


Made with [Cursor](https://cursor.com)