### PR TITLE
docs(save-load): document gameId format constraints (fixes #727)

### DIFF
--- a/SPEC/program/save-load.md
+++ b/SPEC/program/save-load.md
@@ -16,6 +16,7 @@
 - **Storage backend:** Hive box. One box per store; keys are strings.
 - **Key convention:**
   - **Game:** key = `gameId`; value = `Game.toJson()`. Schema is the Game model (no separate version field in MVP).
+  - **gameId constraints:** The `gameId` must be a non-empty string. It may contain any characters except those that would create ambiguity with map-data keys (see below). For clarity, avoid gameIds that end with `_tileMapByRegion`, `_topologyByRegion`, or `_combinedTopology` unless you intentionally want the game to be treated as a potential map-data key (see listGameIds behavior).
   - **Optional map data:** keys = `gameId + suffix`; suffixes: `_tileMapByRegion`, `_topologyByRegion`, `_combinedTopology`. Values = JSON produced by the respective model `toJson()` (e.g. `TileMapResult`, `MapTopology`).
 - **Province/region identity:** Province and region ids stored in the saved payload are whatever the model stores; for consistency with [world-model-identity.md](../game/world-model-identity.md), any province or region id in saved state follows the same prefixed form and lookup rules as at runtime (no separate serialization format).
 


### PR DESCRIPTION
## Summary

This PR addresses issue #727 by documenting gameId format constraints in SPEC/program/save-load.md.

### Changes
- Added gameId constraint documentation: must be non-empty string, should avoid ending with map-data suffixes

### Issue Context
Issue #727 asked two questions:
1. **gameId format**: Should the spec document constraints on gameId? → This PR answers YES and documents the constraints
2. **listGameIds exclusion**: Was already implemented correctly in the code and covered by tests

### Testing
- All existing tests pass (15 tests in colonizethis_save, 8 tests in app)
- Dart analyzer shows no new issues

### Reviewers
- Please review the spec change for clarity and completeness