### PR TITLE
fix: build_road adjacency for capital/port

### DIFF
--- a/SPEC/program/sim-scenarios.md
+++ b/SPEC/program/sim-scenarios.md
@@ -105,6 +105,11 @@ Each turn specifies orders for one or more players:
 
 Supported order types: `move`, `build`, `work`, `diplomatic`, `research`, `naval_move`, `naval_mission`.
 
+- **work orders:** Use `type: "work"` with:
+  - `unit` — unit id in the game state.
+  - `workType` — work target id (`explore`, `prospect`, `build_improvement`, `build_road`, `build_port`, `build_fort`, `build_rail`, `steal_tech`, `counter_spy`, `purchase_land`).
+  - `targetTileKey` (optional but **required** for tile-level work such as `build_improvement`, `build_road`, `build_port`, `build_fort`, `build_rail`): tile key string in format `regionId|provinceId|x|y`. When omitted, the runner uses the work target’s own default behaviour (e.g. province-level `explore`).
+
 Each turn may optionally include **workerAssignments** (production phase): a list of `{ "recipeId": "<id>", "assignedLabour": <n> }`. These are passed as default production assignments for that turn so the Production phase can run recipes; see SPEC/game/production-recipes.md. Scenario setup may include **initialStockpile** and **initialWorkers** per player (map from player id to commodity quantities or worker counts) to set economy state before turns run.
 
 ### Diplomatic orders
@@ -185,6 +190,8 @@ Assertion fields:
 **Fog/exploration assertions** (SPEC/game/fog-and-exploration.md): use `player`, `tileKey` (format `regionId|provinceId|x|y`), and optionally `tileVisibility` (expected level: `unknown`, `revealed`, `fogged`, `fullyVisible`) and/or `tileProspected` (boolean). Example: `{"turn": 1, "player": "gp1", "tileKey": "oldWorld|p1|0|0", "tileVisibility": "fullyVisible"}`; `{"player": "gp1", "tileKey": "oldWorld|p2|2|0", "tileVisibility": "fogged", "tileProspected": false}`.
 
 **Improvement naming assertions** (SPEC/game/extraction-and-improvements.md): when the scenario runner exposes a UI-facing view for tiles, use `tileKey` (format `regionId|provinceId|x|y`) with `tileImprovementName` (expected string) to verify that the improvement naming table is applied correctly. Example: `{"turn": 1, "tileKey": "oldWorld|p1|0|0", "tileImprovementName": "Farm"}` for a tile whose resource id is `grain` and improvement level is between 1 and 4 inclusive.
+  
+**Road / transport-level assertions** (SPEC/game/capital-and-connectivity.md, SPEC/program/development-resolution.md): use `tileKey` with `tileRoadLevel` (expected integer in `{0,1,2,4}`) to verify the per-tile road/transport level in `worldState.tileState`. Example: `{"turn": 2, "tileKey": "oldWorld|p1|1|1", "tileRoadLevel": 2}` for a tile that should have been upgraded by a `build_road` work order and any adjacency propagation rules.
 
 **Leader assertions** (SPEC/game/leader-bonuses.md): use `player` (Great Power id) and `leaderKey` (expected leader key, e.g. `napoleon`, `frederick`, `reserve`). Example: `{"turn": 1, "player": "gp1", "leaderKey": "napoleon"}`.
 

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -158,7 +158,7 @@ Game applyBuildAndWorkOrders(
           tileState = tileState.setRoadLevel(cw.tileKey, nextLevel);
 
           // Propagate transport level to adjacent capital/port tiles per
-          // SPEC/program/development-resolution.md and SPEC/game/capital-and-connectivity.md
+          // SPEC/program/development-resolution.md and SPEC/game/capital-and-connectivity.md.
           final tileMap = tileMapByRegion;
           if (tileMap != null) {
             _propagateRoadToAdjacentCapitalOrPort(
@@ -167,6 +167,7 @@ Game applyBuildAndWorkOrders(
               player: player,
               worldState: gameForPlayer.worldState,
               tileMapByRegion: tileMap,
+              tileState: tileState,
               setTileState: (newTileState) => tileState = newTileState,
             );
           }
@@ -249,8 +250,8 @@ Game applyBuildAndWorkOrders(
       final purchasedByTile = gameForPlayer.worldState.purchasedTilesByTileKey;
       if (purchasedByTile.containsKey(cw.tileKey) &&
           purchasedByTile[cw.tileKey] != u.ownerId) {
-        unitsById[entry.key] = u.copyWith(
-            status: UnitStatus.idle, clearCurrentWork: true);
+        unitsById[entry.key] =
+            u.copyWith(status: UnitStatus.idle, clearCurrentWork: true);
         _log.d(
             'logic: work cancelled unit=${u.id} reason=tile no longer owned tileKey=${cw.tileKey}');
         continue;
@@ -262,8 +263,8 @@ Game applyBuildAndWorkOrders(
         final targetProvince =
             provinces.where((p) => p.id == targetProvinceId).firstOrNull;
         if (targetProvince != null && targetProvince.ownerId != u.ownerId) {
-          unitsById[entry.key] = u.copyWith(
-              status: UnitStatus.idle, clearCurrentWork: true);
+          unitsById[entry.key] =
+              u.copyWith(status: UnitStatus.idle, clearCurrentWork: true);
           _log.d(
               'logic: work cancelled unit=${u.id} reason=province conquered provinceId=$targetProvinceId tileKey=${cw.tileKey}');
           continue;
@@ -335,8 +336,8 @@ Game applyBuildAndWorkOrders(
           applyCompletedWorkTarget(
               u, cw, getProvinces, setProvinces, currentGame);
         }
-        unitsById[entry.key] = u.copyWith(
-            status: UnitStatus.idle, clearCurrentWork: true);
+        unitsById[entry.key] =
+            u.copyWith(status: UnitStatus.idle, clearCurrentWork: true);
       } else {
         unitsById[entry.key] = u.copyWith(
           currentWork: cw.copyWith(remainingTurns: nextRemaining),
@@ -549,34 +550,44 @@ Game applyBuildAndWorkOrders(
       // cost computation, and unit update logic.
       // Special targets (purchase_land, prospect, explore, steal_tech, counter_spy)
       // are handled separately due to their unique logic.
-      ({String target, bool Function(String) allowedForUnitType, WorkOrderCost? Function() costFn, int Function() totalTurnsFn})
-          workTargetConfig(String target) {
+      ({
+        String target,
+        bool Function(String) allowedForUnitType,
+        WorkOrderCost? Function() costFn,
+        int Function() totalTurnsFn
+      }) workTargetConfig(String target) {
         switch (target) {
           case 'build_improvement':
             return (
               target: target,
-              allowedForUnitType: (t) => isWorkOrderTargetAllowedForUnitType(t, target),
-              costFn: () => workOrderMaterialCost(target, improvementLevel: tileState.improvementLevel(targetTileKey)),
-              totalTurnsFn: () => totalTurnsForWork(target, improvementLevel: tileState.improvementLevel(targetTileKey)),
+              allowedForUnitType: (t) =>
+                  isWorkOrderTargetAllowedForUnitType(t, target),
+              costFn: () => workOrderMaterialCost(target,
+                  improvementLevel: tileState.improvementLevel(targetTileKey)),
+              totalTurnsFn: () => totalTurnsForWork(target,
+                  improvementLevel: tileState.improvementLevel(targetTileKey)),
             );
           case 'build_road':
             return (
               target: target,
-              allowedForUnitType: (t) => isWorkOrderTargetAllowedForUnitType(t, target),
+              allowedForUnitType: (t) =>
+                  isWorkOrderTargetAllowedForUnitType(t, target),
               costFn: () => workOrderMaterialCost(target),
               totalTurnsFn: () => totalTurnsForWork(target),
             );
           case 'build_port':
             return (
               target: target,
-              allowedForUnitType: (t) => isWorkOrderTargetAllowedForUnitType(t, target),
+              allowedForUnitType: (t) =>
+                  isWorkOrderTargetAllowedForUnitType(t, target),
               costFn: () => workOrderMaterialCost(target),
               totalTurnsFn: () => totalTurnsForWork(target),
             );
           case 'build_fort':
             return (
               target: target,
-              allowedForUnitType: (t) => isWorkOrderTargetAllowedForUnitType(t, target),
+              allowedForUnitType: (t) =>
+                  isWorkOrderTargetAllowedForUnitType(t, target),
               costFn: () {
                 final prov = provinceById(u.locationProvinceId);
                 final fortLevel = prov?.fortLevel ?? 0;
@@ -591,14 +602,16 @@ Game applyBuildAndWorkOrders(
           case 'build_rail':
             return (
               target: target,
-              allowedForUnitType: (t) => isWorkOrderTargetAllowedForUnitType(t, target),
+              allowedForUnitType: (t) =>
+                  isWorkOrderTargetAllowedForUnitType(t, target),
               costFn: () => workOrderMaterialCost(target),
               totalTurnsFn: () => totalTurnsForWork(target),
             );
           case 'upgrade_town':
             return (
               target: target,
-              allowedForUnitType: (t) => isWorkOrderTargetAllowedForUnitType(t, target),
+              allowedForUnitType: (t) =>
+                  isWorkOrderTargetAllowedForUnitType(t, target),
               costFn: () => workOrderMaterialCost(target),
               totalTurnsFn: () => totalTurnsForWork(target),
             );
@@ -848,6 +861,7 @@ void _propagateRoadToAdjacentCapitalOrPort({
   Player? player,
   required WorldState worldState,
   required Map<String, TileMapResult> tileMapByRegion,
+  required TileMapState tileState,
   required void Function(TileMapState) setTileState,
 }) {
   if (player == null) return;
@@ -898,10 +912,10 @@ void _propagateRoadToAdjacentCapitalOrPort({
     if (isCapital || isPort) {
       _log.d(
           'logic: build_road propagating level $nextLevel to adjacent ${isCapital ? "capital" : "port"} tile $adjacentTileKey');
-      final currentLevel = worldState.tileState.roadLevel(adjacentTileKey);
-      // Only upgrade, never downgrade
+      final currentLevel = tileState.roadLevel(adjacentTileKey);
+      // Only upgrade, never downgrade.
       if (nextLevel > currentLevel) {
-        setTileState(worldState.tileState.setRoadLevel(adjacentTileKey, nextLevel));
+        setTileState(tileState.setRoadLevel(adjacentTileKey, nextLevel));
       }
     }
   }

--- a/packages/colonizethis_logic/test/orders_application_test.dart
+++ b/packages/colonizethis_logic/test/orders_application_test.dart
@@ -420,6 +420,18 @@ void main() {
           buildUnitOrdersByPlayerId: {'p1': <BuildUnitOrder>[]},
         );
 
+    TileMapResult _simpleTileMap() {
+      return TileMapResult(
+        width: 3,
+        height: 3,
+        grid: const [
+          ['P1', 'P1', 'P1'],
+          ['P1', 'P1', 'P1'],
+          ['P1', 'P1', 'P1'],
+        ],
+      );
+    }
+
     test(
         'build_improvement completion increases improvement level and clears currentWork',
         () {
@@ -455,7 +467,8 @@ void main() {
       expect(next.worldState.tileState.improvementLevel(tileKey), 1);
     });
 
-    test('work cancelled when province containing target tile is conquered (#376)',
+    test(
+        'work cancelled when province containing target tile is conquered (#376)',
         () {
       // Unit p1 is working on a tile in P1; province P1 is conquered by p2.
       final tileState = TileMapState().setImprovement(tileKey, 0);
@@ -607,8 +620,127 @@ void main() {
         ),
         players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
       );
-      final next = applyBuildAndWorkOrders(game, _ordersToTriggerProcessWork());
+      final next = applyBuildAndWorkOrders(
+        game,
+        _ordersToTriggerProcessWork(),
+        tileMapByRegion: const {},
+      );
       expect(next.worldState.tileState.roadLevel(tileKey), 1);
+    });
+
+    test(
+        'build_road completion propagates transport level to adjacent capital tile (no downgrade)',
+        () {
+      const capitalTileKey = 'oldWorld|P1|1|0';
+      final initialTileState = TileMapState()
+          .setRoadLevel(tileKey, 0)
+          .setRoadLevel(capitalTileKey, 2);
+      final unit = Unit(
+        id: 'u1',
+        type: 'Engineer',
+        ownerId: 'p1',
+        provinceId: provinceId,
+        tileKey: tileKey,
+        status: UnitStatus.working,
+        currentWork: const CurrentWork(
+          workTarget: 'build_road',
+          tileKey: tileKey,
+          totalTurns: 1,
+          remainingTurns: 1,
+        ),
+      );
+      final player = Player(
+        id: 'p1',
+        displayName: 'P1',
+        isHuman: true,
+        capitalProvinceId: provinceId,
+        capitalTile: const CapitalTile(
+          regionId: ow,
+          provinceId: provinceId,
+          x: 1,
+          y: 0,
+        ),
+      );
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [Province(id: provinceId, regionId: ow, ownerId: 'p1')],
+            units: [unit],
+          ),
+          newWorld: const RegionData(),
+          tileState: initialTileState,
+        ),
+        players: [player],
+      );
+      final next = applyBuildAndWorkOrders(
+        game,
+        _ordersToTriggerProcessWork(),
+        tileMapByRegion: {ow: _simpleTileMap()},
+      );
+
+      // Road built on target tile.
+      expect(next.worldState.tileState.roadLevel(tileKey), 1);
+      // Capital tile was already at level 2 and should remain 2 (no downgrade).
+      expect(next.worldState.tileState.roadLevel(capitalTileKey), 2);
+    });
+
+    test(
+        'build_road completion propagates transport level to adjacent port tile and upgrades it',
+        () {
+      const portTileKey = 'oldWorld|P1|1|0';
+      final initialTileState =
+          TileMapState().setRoadLevel(tileKey, 1).setRoadLevel(portTileKey, 1);
+      final unit = Unit(
+        id: 'u1',
+        type: 'Engineer',
+        ownerId: 'p1',
+        provinceId: provinceId,
+        tileKey: tileKey,
+        status: UnitStatus.working,
+        currentWork: const CurrentWork(
+          workTarget: 'build_road',
+          tileKey: tileKey,
+          totalTurns: 1,
+          remainingTurns: 1,
+        ),
+      );
+      final player = Player(
+        id: 'p1',
+        displayName: 'P1',
+        isHuman: true,
+        capitalProvinceId: provinceId,
+        techUnlocked: const {'road_construction': true},
+      );
+      final world = WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+        oldWorld: RegionData(
+          provinces: [Province(id: provinceId, regionId: ow, ownerId: 'p1')],
+          units: [unit],
+        ),
+        newWorld: const RegionData(),
+        tileState: initialTileState,
+        portsByProvinceSeaboard: const {
+          '$provinceId|sea1': portTileKey,
+        },
+      );
+      final game = Game(
+        id: 'g',
+        worldState: world,
+        players: [player],
+      );
+
+      final next = applyBuildAndWorkOrders(
+        game,
+        _ordersToTriggerProcessWork(),
+        tileMapByRegion: {ow: _simpleTileMap()},
+      );
+
+      // Road on target tile upgraded from 1 -> 2.
+      expect(next.worldState.tileState.roadLevel(tileKey), 2);
+      // Adjacent port tile upgraded from 1 -> 2.
+      expect(next.worldState.tileState.roadLevel(portTileKey), 2);
     });
 
     test(
@@ -747,7 +879,8 @@ void main() {
       );
     }
 
-    test('prospect adds tile to playerProspectedTiles when terrain eligible', () {
+    test('prospect adds tile to playerProspectedTiles when terrain eligible',
+        () {
       final unit = Unit(
         id: 'u1',
         type: 'Explorer',
@@ -976,8 +1109,7 @@ void main() {
             provinces: [
               const Province(
                   id: provinceId, regionId: ow, ownerId: 'p1'), // owner
-              const Province(
-                  id: targetProvinceId, regionId: ow, ownerId: 'p2'),
+              const Province(id: targetProvinceId, regionId: ow, ownerId: 'p2'),
             ],
             units: [spy],
           ),
@@ -1376,8 +1508,7 @@ void main() {
       expect(next.players.single.treasury, game.players.single.treasury);
     });
 
-    test(
-        'purchase_land rejected when at war with province owner (Minor/Tribe)',
+    test('purchase_land rejected when at war with province owner (Minor/Tribe)',
         () {
       const minorProvinceId = 'oldWorld|M1';
       const tileKeyMinor = 'oldWorld|M1|0|0';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -420,10 +420,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:

--- a/tool/sim_scenarios/lib/order_script.dart
+++ b/tool/sim_scenarios/lib/order_script.dart
@@ -27,21 +27,25 @@ Orders parseOrderCommands(List<OrderCommand> commands, Game game) {
 
       case 'build':
         final unitType = cmd.unitType ?? 'infantry';
-        final isMilitary = buildUnitCategoryForUnitType(unitType) == BuildUnitCategory.military;
+        final isMilitary = buildUnitCategoryForUnitType(unitType) ==
+            BuildUnitCategory.military;
         final buildOrder = BuildUnitOrder(
           unitType: unitType,
           isMilitary: isMilitary,
           spawnProvinceId: cmd.inProvince ?? '',
         );
-        buildUnitOrdersByPlayerId.putIfAbsent(cmd.player, () => []).add(buildOrder);
+        buildUnitOrdersByPlayerId
+            .putIfAbsent(cmd.player, () => [])
+            .add(buildOrder);
         break;
 
       case 'work':
-        // Work orders need unit ID and target - simplified
+        // Work orders need unit ID and target. For tile-level work the scenario
+        // should provide targetTileKey; otherwise empty string is used.
         final workOrder = WorkOrder(
           unitId: cmd.unit ?? '',
           target: cmd.workType ?? 'explore',
-          targetTileKey: '',
+          targetTileKey: cmd.targetTileKey ?? '',
         );
         workOrdersByPlayerId.putIfAbsent(cmd.player, () => []).add(workOrder);
         break;
@@ -64,7 +68,9 @@ Orders parseOrderCommands(List<OrderCommand> commands, Game game) {
           amount: cmd.amount,
           overtureStage: overtureStage,
         );
-        diplomaticOrdersByPlayerId.putIfAbsent(cmd.player, () => []).add(diploOrder);
+        diplomaticOrdersByPlayerId
+            .putIfAbsent(cmd.player, () => [])
+            .add(diploOrder);
         break;
 
       case 'research':
@@ -74,7 +80,9 @@ Orders parseOrderCommands(List<OrderCommand> commands, Game game) {
           techId: cmd.techId ?? '',
           funding: ResearchFundingLevel.low,
         );
-        researchOrdersByPlayerId.putIfAbsent(cmd.player, () => []).add(researchOrder);
+        researchOrdersByPlayerId
+            .putIfAbsent(cmd.player, () => [])
+            .add(researchOrder);
         break;
 
       case 'naval_move':
@@ -82,7 +90,9 @@ Orders parseOrderCommands(List<OrderCommand> commands, Game game) {
           fleetId: cmd.fleetId ?? '',
           destinationSeaZoneId: cmd.destinationSeaZoneId ?? '',
         );
-        navalMoveOrdersByPlayerId.putIfAbsent(cmd.player, () => []).add(navalMoveOrder);
+        navalMoveOrdersByPlayerId
+            .putIfAbsent(cmd.player, () => [])
+            .add(navalMoveOrder);
         break;
 
       case 'naval_mission':
@@ -92,7 +102,9 @@ Orders parseOrderCommands(List<OrderCommand> commands, Game game) {
           targetPortId: cmd.targetPortId,
           targetProvinceId: cmd.targetProvinceId,
         );
-        navalMissionOrdersByPlayerId.putIfAbsent(cmd.player, () => []).add(navalMissionOrder);
+        navalMissionOrdersByPlayerId
+            .putIfAbsent(cmd.player, () => [])
+            .add(navalMissionOrder);
         break;
 
       default:

--- a/tool/sim_scenarios/lib/scenario.dart
+++ b/tool/sim_scenarios/lib/scenario.dart
@@ -36,8 +36,10 @@ class ScenarioInit {
   final String type;
   final Map<String, dynamic>? config;
   final String? gameId;
+
   /// For fromTopology: { grid, nodes, edges } for Old World.
   final Map<String, dynamic>? oldWorld;
+
   /// For fromTopology: { grid, nodes, edges } for New World (optional).
   final Map<String, dynamic>? newWorld;
 }
@@ -65,20 +67,28 @@ class ScenarioSetup {
 
   final List<UnitPlacement>? units;
   final Map<String, int>? stockpileOverrides;
+
   /// Player id → { peasants, apprentices, journeymen, masters }. SPEC/game/workers-and-population.md.
   final Map<String, Map<String, int>>? initialWorkers;
+
   /// Player id → { commodityId: quantity }. Replaces player stockpile.
   final Map<String, Map<String, int>>? initialStockpile;
+
   /// Recipe assignments for Production phase (each turn). SPEC/game/stockpiles-and-production.md.
   final List<ProductionAssignment>? productionAssignments;
+
   /// Tile key → { improvementLevel: 0-4, roadLevel: 0|1|2|4 }. Applied to worldState.tileState for extraction scenarios.
   final Map<String, Map<String, int>>? initialTileState;
+
   /// Player id → leaderKey. Overrides Player.leaderKey for leader-bonus scenarios. SPEC/game/leader-bonuses.md.
   final Map<String, String>? leaderKeys;
+
   /// Player id → list of tech ids. Overrides Player.techUnlocked (map techId → true). SPEC/game/military-units.md, SPEC/game/military-generals.md, tech-tree.
   final Map<String, List<String>>? initialTech;
+
   /// Player id → treasury (pounds). Overrides Player.treasury for Join Empire etc. SPEC/game/diplomacy.md.
   final Map<String, int>? initialTreasury;
+
   /// "quickBattle" or "autoResolve". Overrides Game.defaultCombatMode. SPEC/game/quick-battle.md.
   final String? defaultCombatMode;
 }
@@ -130,6 +140,7 @@ class TurnScript {
 
   final int turn;
   final List<OrderCommand> orders;
+
   /// Production phase: recipe assignments for this turn (defaultAssignments).
   final List<WorkerAssignment>? workerAssignments;
 }
@@ -156,10 +167,12 @@ class OrderCommand {
     this.mission,
     this.targetPortId,
     this.targetProvinceId,
+    this.targetTileKey,
   });
 
   final String player;
-  final String type; // move, build, work, diplomatic, research, naval_move, naval_mission
+  final String
+      type; // move, build, work, diplomatic, research, naval_move, naval_mission
   // Move fields
   final String? unit;
   final String? to;
@@ -184,6 +197,9 @@ class OrderCommand {
   final String? mission;
   final String? targetPortId;
   final String? targetProvinceId;
+
+  /// Optional explicit tile key for work orders (tile-level targets).
+  final String? targetTileKey;
 }
 
 /// Assertion for state verification.
@@ -232,35 +248,44 @@ class Assertion {
     this.leaderKey,
     this.techUnlocked,
     this.provinceDisplayName,
+    this.tileRoadLevel,
   });
 
   /// Which turn to check (null = final state)
   final int? turn;
+
   /// Region ID (e.g., "oldWorld", "newWorld") - optional, used with province
   final String? region;
   final String? province;
+
   /// Province display name (SPEC/game/naming.md). Use with [province]: expected Province.displayName.
   final String? provinceDisplayName;
   final String? player;
   final String? owner;
+
   /// Negative assertion: province must not be owned by this player id.
   final String? notOwner;
   final int? unitCount;
   final String? hasUnit;
   final String? hasPlayerUnits;
   final int? stockpile;
+
   /// With [player] and [commodity]: expected quantity of that commodity in stockpile. SPEC/game/production-recipes.md.
   final int? stockpileCommodity;
+
   /// Commodity id for [stockpileCommodity] assertion.
   final String? commodity;
   final int? treasury;
   final int? matchMin;
   final int? matchMax;
   final MatchType matchType;
+
   /// With region: no tile in region has this resource (regionHasNoResource). SPEC/game/resource-terrain-region-rules.md.
   final String? resource;
+
   /// With region: fraction of placed resources that are "both" must be <= this (resourcePlacementCap).
   final double? maxBothFraction;
+
   /// Every tile's resource is allowed in its region per resource rules. Optional region scopes to one region.
   final bool? everyTileResourceAllowedInRegion;
 
@@ -272,19 +297,25 @@ class Assertion {
   final String? relationLevel;
   final int? relationSinceTurn;
   final int? relationLastInteractionTurn;
+
   /// Overture stage between GP [player] and Minor/Tribe [relationWith].
   final String? overtureStage;
+
   /// Capital province for [player] (Great Power). Full province id, e.g. oldWorld|p1. SPEC/game/capital-choice-phase.md.
   final String? capitalProvince;
+
   /// Capital assertion: expected capital province id (full id, e.g. oldWorld|p1). Used with player (faction id).
   final String? capitalProvinceId;
+
   /// Capital assertion: expected capital tile key (regionId|provinceId|x|y). Optional.
   final String? capitalTileKey;
+
   /// Worker pool assertions (SPEC/game/workers-and-population.md). Require [player].
   final int? workerPeasants;
   final int? workerApprentices;
   final int? workerJourneymen;
   final int? workerMasters;
+
   /// Faction count assertions (SPEC/game/factions.md). After game setup, assert counts of Great Powers, Minor Nations, Tribes.
   final int? greatPowerCount;
   final int? minorNationCount;
@@ -308,6 +339,10 @@ class Assertion {
 
   /// Research-state assertion (SPEC/game/research-state.md). With [player]: list of tech ids that must be in techUnlocked (true).
   final List<String>? techUnlocked;
+
+  /// Road / transport-level assertion (SPEC/game/capital-and-connectivity.md, SPEC/program/development-resolution.md).
+  /// With [tileKey]: expected road/transport level on that tile (0, 1, 2, or 4).
+  final int? tileRoadLevel;
 }
 
 /// Type of value matching for assertions.
@@ -422,7 +457,8 @@ ScenarioSetup _parseScenarioSetup(Map<String, dynamic> json) {
         ?.map((k, v) => MapEntry(k as String, (v as num).toInt())),
     initialWorkers: _parseInitialWorkers(json['initialWorkers']),
     initialStockpile: _parseInitialStockpile(json['initialStockpile']),
-    productionAssignments: _parseProductionAssignments(json['productionAssignments']),
+    productionAssignments:
+        _parseProductionAssignments(json['productionAssignments']),
     initialTileState: _parseInitialTileState(json['initialTileState']),
     leaderKeys: _parseLeaderKeys(json['leaderKeys']),
     initialTech: _parseInitialTech(json['initialTech']),
@@ -561,6 +597,7 @@ OrderCommand _parseOrderCommand(Map<String, dynamic> json) {
     mission: json['mission'] as String?,
     targetPortId: json['targetPortId'] as String?,
     targetProvinceId: json['targetProvinceId'] as String?,
+    targetTileKey: json['targetTileKey'] as String?,
   );
 }
 
@@ -584,7 +621,8 @@ Assertion _parseAssertion(Map<String, dynamic> json) {
     matchType: _parseMatchType(json['matchType'] as String?),
     resource: json['resource'] as String?,
     maxBothFraction: (json['maxBothFraction'] as num?)?.toDouble(),
-    everyTileResourceAllowedInRegion: json['everyTileResourceAllowedInRegion'] as bool?,
+    everyTileResourceAllowedInRegion:
+        json['everyTileResourceAllowedInRegion'] as bool?,
     capitalProvinceId: json['capitalProvinceId'] as String?,
     capitalTileKey: json['capitalTileKey'] as String?,
     relationWith: json['relationWith'] as String?,
@@ -611,6 +649,7 @@ Assertion _parseAssertion(Map<String, dynamic> json) {
         ?.map((e) => e.toString())
         .toList(),
     provinceDisplayName: json['provinceDisplayName'] as String?,
+    tileRoadLevel: json['tileRoadLevel'] as int?,
   );
 }
 
@@ -631,9 +670,11 @@ MatchType _parseMatchType(String? value) {
 List<Scenario> parseScenarioFile(File file) {
   final content = file.readAsStringSync();
   final json = jsonDecode(content) as dynamic;
-  
+
   if (json is List<dynamic>) {
-    return json.map((e) => parseScenarioFromJson(e as Map<String, dynamic>)).toList();
+    return json
+        .map((e) => parseScenarioFromJson(e as Map<String, dynamic>))
+        .toList();
   }
   return [parseScenarioFromJson(json as Map<String, dynamic>)];
 }
@@ -642,7 +683,7 @@ List<Scenario> parseScenarioFile(File file) {
 List<Scenario> discoverScenarios(Directory dir) {
   final scenarios = <Scenario>[];
   if (!dir.existsSync()) return scenarios;
-  
+
   for (final entity in dir.listSync()) {
     if (entity is File && entity.path.endsWith('.json')) {
       try {

--- a/tool/sim_scenarios/lib/state_verifier.dart
+++ b/tool/sim_scenarios/lib/state_verifier.dart
@@ -29,7 +29,9 @@ class StateVerifier {
 
     for (final assertion in assertions) {
       // Filter by turn if specified
-      if (atTurn != null && assertion.turn != null && assertion.turn != atTurn) {
+      if (atTurn != null &&
+          assertion.turn != null &&
+          assertion.turn != atTurn) {
         continue;
       }
 
@@ -49,8 +51,10 @@ class StateVerifier {
     final failures = <String>[];
 
     // Resource-placement assertions (SPEC/game/resource-terrain-region-rules.md)
-    if (assertion.region != null && assertion.resource != null &&
-        assertion.province == null && assertion.player == null) {
+    if (assertion.region != null &&
+        assertion.resource != null &&
+        assertion.province == null &&
+        assertion.player == null) {
       final bad = _tilesInRegionWithResource(
         game.worldState.resourceByTileKey,
         assertion.region!,
@@ -68,8 +72,10 @@ class StateVerifier {
         assertion.region,
       );
       failures.addAll(ruleFailures);
-    } else if (assertion.region != null && assertion.maxBothFraction != null &&
-        assertion.province == null && assertion.player == null) {
+    } else if (assertion.region != null &&
+        assertion.maxBothFraction != null &&
+        assertion.province == null &&
+        assertion.player == null) {
       final result = _checkResourcePlacementCap(
         game.worldState.resourceByTileKey,
         assertion.region!,
@@ -106,9 +112,11 @@ class StateVerifier {
 
     // Province-based assertions
     if (assertion.province != null) {
-      final province = _findProvince(game, assertion.region, assertion.province!);
+      final province =
+          _findProvince(game, assertion.region, assertion.province!);
       if (province == null) {
-        final regionStr = assertion.region != null ? '${assertion.region}:' : '';
+        final regionStr =
+            assertion.region != null ? '${assertion.region}:' : '';
         failures.add('Province "$regionStr${assertion.province}" not found');
         return VerificationResult(passed: false, failures: failures);
       }
@@ -142,9 +150,12 @@ class StateVerifier {
       }
 
       // Check unit count
-      if (assertion.unitCount != null || assertion.hasUnit != null || assertion.hasPlayerUnits != null) {
-        final units = _getUnitsInProvince(game, assertion.region, assertion.province!);
-        
+      if (assertion.unitCount != null ||
+          assertion.hasUnit != null ||
+          assertion.hasPlayerUnits != null) {
+        final units =
+            _getUnitsInProvince(game, assertion.region, assertion.province!);
+
         if (assertion.unitCount != null) {
           final matchResult = _matchCount(
             units.length,
@@ -172,7 +183,8 @@ class StateVerifier {
 
         // Check player units
         if (assertion.hasPlayerUnits != null) {
-          final hasPlayerUnits = units.any((u) => u.ownerId == assertion.hasPlayerUnits);
+          final hasPlayerUnits =
+              units.any((u) => u.ownerId == assertion.hasPlayerUnits);
           if (!hasPlayerUnits) {
             failures.add(
               'Province ${assertion.province}: no units found for player "${assertion.hasPlayerUnits}"',
@@ -184,7 +196,8 @@ class StateVerifier {
 
     // Capital assertions (player/minor/tribe faction id + capitalProvinceId / capitalTileKey)
     if (assertion.player != null &&
-        (assertion.capitalProvinceId != null || assertion.capitalTileKey != null)) {
+        (assertion.capitalProvinceId != null ||
+            assertion.capitalTileKey != null)) {
       final factionId = assertion.player!;
       String? actualProvinceId;
       String? actualTileKey;
@@ -201,7 +214,8 @@ class StateVerifier {
         actualProvinceId = t.capitalProvinceId;
         actualTileKey = t.capitalTile?.toTileKey();
       } else {
-        failures.add('Faction "$factionId" not found (players, minorNations, tribes)');
+        failures.add(
+            'Faction "$factionId" not found (players, minorNations, tribes)');
       }
       if (actualProvinceId != null || actualTileKey != null) {
         if (assertion.capitalProvinceId != null &&
@@ -216,7 +230,8 @@ class StateVerifier {
             'Faction $factionId: expected capitalTileKey "${assertion.capitalTileKey}", got "$actualTileKey"',
           );
         }
-      } else if (assertion.capitalProvinceId != null || assertion.capitalTileKey != null) {
+      } else if (assertion.capitalProvinceId != null ||
+          assertion.capitalTileKey != null) {
         failures.add(
           'Faction $factionId: expected capital but capitalProvinceId/capitalTile are null',
         );
@@ -233,7 +248,8 @@ class StateVerifier {
 
       if (assertion.stockpile != null) {
         // Sum all commodity quantities in stockpile
-        final totalStockpile = player.stockpile.quantities.values.fold<int>(0, (a, b) => a + b);
+        final totalStockpile =
+            player.stockpile.quantities.values.fold<int>(0, (a, b) => a + b);
         final matchResult = _matchCount(
           totalStockpile,
           assertion.stockpile!,
@@ -333,7 +349,8 @@ class StateVerifier {
 
       // Diplomacy relation assertions between [player] and [relationWith]
       if (assertion.relationWith != null) {
-        final rel = _findRelation(game, assertion.player!, assertion.relationWith!);
+        final rel =
+            _findRelation(game, assertion.player!, assertion.relationWith!);
         if (rel == null) {
           failures.add(
             'Relation between ${assertion.player} and ${assertion.relationWith} not found',
@@ -368,7 +385,8 @@ class StateVerifier {
             );
           }
           if (assertion.relationLastInteractionTurn != null &&
-              rel.lastInteractionTurn != assertion.relationLastInteractionTurn) {
+              rel.lastInteractionTurn !=
+                  assertion.relationLastInteractionTurn) {
             failures.add(
               'Relation ${assertion.player}-${assertion.relationWith}: '
               'expected lastInteractionTurn ${assertion.relationLastInteractionTurn}, '
@@ -379,7 +397,8 @@ class StateVerifier {
 
         // Overture stage (GP–Minor/Tribe) between [player] and [relationWith]
         if (assertion.overtureStage != null) {
-          final overture = _findOverture(game, assertion.player!, assertion.relationWith!);
+          final overture =
+              _findOverture(game, assertion.player!, assertion.relationWith!);
           if (overture == null) {
             failures.add(
               'Overture between ${assertion.player} and ${assertion.relationWith} not found',
@@ -396,7 +415,8 @@ class StateVerifier {
 
     // Fog/exploration assertions (SPEC/game/fog-and-exploration.md)
     if (assertion.player != null &&
-        (assertion.tileVisibility != null || assertion.tileProspected != null) &&
+        (assertion.tileVisibility != null ||
+            assertion.tileProspected != null) &&
         assertion.tileKey != null) {
       final playerId = assertion.player!;
       final tileKey = assertion.tileKey!;
@@ -433,6 +453,18 @@ class StateVerifier {
       }
     }
 
+    // Road / transport-level assertions (SPEC/game/capital-and-connectivity.md, SPEC/program/development-resolution.md)
+    if (assertion.tileRoadLevel != null && assertion.tileKey != null) {
+      final tileKey = assertion.tileKey!;
+      final expectedLevel = assertion.tileRoadLevel!;
+      final actualLevel = game.worldState.tileState.roadLevel(tileKey);
+      if (actualLevel != expectedLevel) {
+        failures.add(
+          'Tile $tileKey roadLevel: expected $expectedLevel, got $actualLevel',
+        );
+      }
+    }
+
     // Leader assertion (SPEC/game/leader-bonuses.md): player's leaderKey
     if (assertion.player != null && assertion.leaderKey != null) {
       try {
@@ -445,7 +477,8 @@ class StateVerifier {
           );
         }
       } on StateError {
-        failures.add('Player ${assertion.player} not found for leaderKey assertion');
+        failures.add(
+            'Player ${assertion.player} not found for leaderKey assertion');
       }
     }
 
@@ -564,7 +597,7 @@ class StateVerifier {
     // If provinceId contains '|', it includes the region prefix (e.g., "oldWorld|p1")
     // The province.id stored in game is already in format "regionId|provinceId"
     // So we just search by the full ID
-    
+
     // If region is specified, search only that region
     if (regionId != null) {
       final regionData = _getRegionData(game, regionId);
@@ -575,7 +608,7 @@ class StateVerifier {
       }
       return null;
     }
-    
+
     // If no region specified, search both oldWorld and newWorld by full ID
     // The province.id includes region prefix (e.g., "oldWorld|p1")
     for (final province in game.worldState.oldWorld.provinces) {
@@ -593,9 +626,10 @@ class StateVerifier {
     return null;
   }
 
-  List<Unit> _getUnitsInProvince(Game game, String? regionId, String provinceId) {
+  List<Unit> _getUnitsInProvince(
+      Game game, String? regionId, String provinceId) {
     final units = <Unit>[];
-    
+
     // If region is specified, only check that region's units
     if (regionId != null) {
       final regionData = _getRegionData(game, regionId);
@@ -608,20 +642,20 @@ class StateVerifier {
       }
       return units;
     }
-    
+
     // If no region, check both oldWorld and newWorld units
     for (final unit in game.worldState.oldWorld.units) {
       if (unit.provinceId == provinceId) {
         units.add(unit);
       }
     }
-    
+
     for (final unit in game.worldState.newWorld.units) {
       if (unit.provinceId == provinceId) {
         units.add(unit);
       }
     }
-    
+
     return units;
   }
 
@@ -638,29 +672,21 @@ class StateVerifier {
     switch (matchType) {
       case MatchType.exact:
         passed = actual == expected;
-        message = passed 
-          ? 'ok' 
-          : 'expected $expected, got $actual';
+        message = passed ? 'ok' : 'expected $expected, got $actual';
         break;
       case MatchType.range:
         final min = matchMin ?? 0;
         final max = matchMax ?? expected;
         passed = actual >= min && actual <= max;
-        message = passed 
-          ? 'ok' 
-          : 'expected $min-$max, got $actual';
+        message = passed ? 'ok' : 'expected $min-$max, got $actual';
         break;
       case MatchType.atLeast:
         passed = actual >= expected;
-        message = passed 
-          ? 'ok' 
-          : 'expected >=$expected, got $actual';
+        message = passed ? 'ok' : 'expected >=$expected, got $actual';
         break;
       case MatchType.atMost:
         passed = actual <= expected;
-        message = passed 
-          ? 'ok' 
-          : 'expected <=$expected, got $actual';
+        message = passed ? 'ok' : 'expected <=$expected, got $actual';
         break;
     }
 

--- a/tool/sim_scenarios/scenarios/connectivity_road_adjacent_capital_and_port.json
+++ b/tool/sim_scenarios/scenarios/connectivity_road_adjacent_capital_and_port.json
@@ -1,0 +1,43 @@
+{
+  "name": "connectivity_road_adjacent_capital_and_port",
+  "description": "Capital port and transport: after init the capital tile for gp1 is coastal, has a port, and its road/transport level is 4 (SPEC/game/capital-and-connectivity.md § Capital Setup).",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "greatPowers": ["england"],
+      "seed": 42,
+      "minorNationCount": 0
+    },
+    "oldWorld": {
+      "grid": [
+        ["p1", "p1", "p1"],
+        ["p1", "p1", "p1"],
+        ["sea1", "p1", "p1"]
+      ],
+      "nodes": [
+        { "id": "p1", "regionId": "oldWorld", "type": "province" },
+        { "id": "sea1", "regionId": "oldWorld", "type": "seaZone" }
+      ],
+      "edges": [
+        { "id1": "p1", "id2": "sea1" }
+      ]
+    }
+  },
+  "setup": {
+    "initialTech": {
+      "gp1": ["road_construction"]
+    }
+  },
+  "turns": [
+    {
+      "turn": 1,
+      "orders": []
+    }
+  ],
+  "assertions": [
+    { "turn": 1, "province": "oldWorld|p1", "owner": "gp1" },
+    { "turn": 1, "player": "gp1", "capitalProvinceId": "oldWorld|p1", "capitalTileKey": "oldWorld|p1|0|1" },
+    { "turn": 1, "tileKey": "oldWorld|p1|0|1", "tileRoadLevel": 4 }
+  ]
+}
+


### PR DESCRIPTION
## Summary
- Implement `build_road` transport propagation to adjacent capital/port tiles per SPEC/program/development-resolution.md and SPEC/game/capital-and-connectivity.md.
- Extend sim_scenarios SPEC, parser, and state verifier to support tile-level road/transport assertions and tile-targeted work orders.
- Add unit tests around build_road adjacency and a connectivity scenario (`connectivity_road_adjacent_capital_and_port`) to enforce capital port transport levels.

## Test plan
- `cd packages/colonizethis_logic && dart test test/orders_application_test.dart`
- `cd tool/sim_scenarios && dart test`
- `cd . && ~/.pub-cache/bin/melos run sim_scenarios -- --scenario=tool/sim_scenarios/scenarios/connectivity_road_adjacent_capital_and_port.json`

Made with [Cursor](https://cursor.com)