### PR TITLE
fix(analyzer): remove unnecessary non-null assertions

### DIFF
--- a/tool/init_game/bin/init_game.dart
+++ b/tool/init_game/bin/init_game.dart
@@ -163,10 +163,10 @@ Future<void> main(List<String> arguments) async {
       numProvincesOldWorld != null ||
       numProvincesNewWorld != null) {
     List<String> selectedIds = config.selectedGreatPowerIds;
-    if (greatPowersOverride != null && greatPowersOverride!.isNotEmpty) {
-      selectedIds = greatPowersOverride!;
-    } else     if (greatPowerCount != null && greatPowerCount! > 0) {
-      selectedIds = allGreatPowerIds.take(greatPowerCount!).toList();
+    if (greatPowersOverride != null && greatPowersOverride.isNotEmpty) {
+      selectedIds = greatPowersOverride;
+    } else     if (greatPowerCount != null && greatPowerCount > 0) {
+      selectedIds = allGreatPowerIds.take(greatPowerCount).toList();
     }
     Map<String, String> leaderVariantByGpId = config.leaderVariantByGpId;
     if (prussiaLeaderOverride != null && selectedIds.contains('prussia')) {

--- a/tool/sim_scenarios/lib/game_factory.dart
+++ b/tool/sim_scenarios/lib/game_factory.dart
@@ -162,7 +162,7 @@ class GameFactory {
                   : Resource.values.byName(e as String))
               .toList())
           .toList();
-      if (resourceGrid!.any((row) => row.length != width)) {
+      if (resourceGrid.any((row) => row.length != width)) {
         resourceGrid = null;
       }
     }


### PR DESCRIPTION
Remove unnecessary non-null assertions (!) that were flagged by the Dart analyzer. These were in conditional blocks that already guaranteed the values were non-null, making the assertions redundant.

## Changes
- **packages/colonizethis_logic/lib/src/world/movement.dart**: Removed unnecessary ! on regionId
- **packages/colonizethis_map/lib/src/tile_map_visualization.dart**: Removed unnecessary ! on landSeedPositions, landSeedContinentIndices, continentSeedPositions
- **tool/init_game/bin/init_game.dart**: Removed unnecessary ! on greatPowersOverride, greatPowerCount
- **tool/sim_scenarios/lib/game_factory.dart**: Removed unnecessary ! on resourceGrid

## Testing
All tests pass:
- colonizethis_map: 98 tests passed
- colonizethis_logic: 539 tests passed
- colonizethis_data: 132 tests passed
- colonizethis_ai: 77 tests passed
- tool/sim_scenarios: 16 tests passed

The Dart analyzer now reports no unnecessary_non_null_assertion warnings.