### PR TITLE
feat(ai): ship building in planners — suggest ships, score by cargo/goal/personality

### DIFF
--- a/SPEC/ai/economy-planner.md
+++ b/SPEC/ai/economy-planner.md
@@ -24,7 +24,7 @@ All inputs are observable; no cheats.
 ## Outputs
 
 1. **Production assignments** — `List<AssignedRecipe>` (recipe id, assigned labour). Total assigned labour must not exceed the player's **effective labour** (luxury-capped). Assignments are passed to the Production phase as that player's default assignments (see [turn-resolution-phases.md](../program/turn-resolution-phases.md)); resolver must support per-player assignments when multiple players are AI.
-2. **Cargo preference** (optional) — one of: `none`, `prefer_cargo`, `strong_cargo`. Used by the naval planner to bias **join home fleet** vs patrol/blockade when a fleet is in the capital port; and optionally by build preference (prefer merchant ships when `strong_cargo` and economy goal).
+2. **Cargo preference** (optional) — one of: `none`, `prefer_cargo`, `strong_cargo`. Used by the naval planner to bias **join home fleet** vs patrol/blockade when a fleet is in the capital port; and by the **build planner** when choosing among build orders (ships vs regiments): it scores candidates and may prefer cargo-capable ships when `prefer_cargo` or `strong_cargo`.
 
 ---
 
@@ -83,7 +83,7 @@ Naval planner and build planner consume this preference; the economy planner onl
 
 ## Integration
 
-- **Caller:** Strategic AI (e.g. `generateStrategicOrders` or domain planners) calls the economy planner for each AI GP after or alongside other domain planners. Production assignments are collected per player and passed to the turn resolver as **per-player default production assignments** (resolver must accept `Map<String, List<AssignedRecipe>>` or equivalent for multi-player).
+- **Caller:** Strategic AI (e.g. `generateStrategicOrders`) calls the economy planner for each AI GP first, then passes the resulting **economy plan** (including `cargoPreference`) into the domain planners so the build step can weight ship vs land builds. Production assignments are collected per player and passed to the turn resolver as **per-player default production assignments** (resolver must accept `Map<String, List<AssignedRecipe>>` or equivalent for multi-player).
 - **Human players:** Production assignments for human players come from UI or saved choices; the economy planner is not used.
 - **Determinism:** Same PlayerView, game state, config, and economy seed → same production assignments and cargo preference.
 

--- a/SPEC/program/ai-systems-impl.md
+++ b/SPEC/program/ai-systems-impl.md
@@ -34,7 +34,7 @@ Orders generateStrategicOrders({
 });
 ```
 
-`view` is the only visibility source; `config` holds personality, hidden agenda, difficulty modifiers; `seeds` per [ai-planner.md](ai-planner.md). Output: valid Orders. The strategic AI also produces **production assignments** and **cargo preference** per AI GP when the economy planner runs; see [economy-planner.md](../ai/economy-planner.md). The turn-resolution caller supplies per-player production assignments to the resolver (e.g. `defaultAssignmentsByPlayerId`) and may pass cargo preference into the naval planner. Callbacks for deterministic dialogue/mood events.
+`view` is the only visibility source; `config` holds personality, hidden agenda, difficulty modifiers; `seeds` per [ai-planner.md](ai-planner.md). Output: valid Orders. Strategic AI runs the **economy planner** first, then passes the resulting **economy plan** (including `cargoPreference`) into the domain planners so the build planner can weight ship vs land builds (cargo need, goal, personality). The strategic AI also produces **production assignments** per AI GP; see [economy-planner.md](../ai/economy-planner.md). The turn-resolution caller supplies per-player production assignments to the resolver (e.g. `defaultAssignmentsByPlayerId`). Callbacks for deterministic dialogue/mood events.
 
 Personality-related fields in **AIConfig** follow [ai-personalities.md](../ai/ai-personalities.md):
 

--- a/SPEC/program/order-suggestions.md
+++ b/SPEC/program/order-suggestions.md
@@ -31,6 +31,7 @@ For every suggested order `o`, appending it to the current list and validating v
 - **Work orders:** Suggested only for the unit's current province and tile. Never suggests work for a province the unit is not in.
 - **Visibility:** Uses PlayerView only; may not inspect hidden tiles or enemy units directly. Checks per [fog-and-exploration-resolution.md](fog-and-exploration-resolution.md).
 - **Determinism:** Fixed inputs produce the same set and ordering of suggestions.
+- **Build orders:** `suggestBuildOrders` returns affordable, valid build-unit orders for both **military (regiment)** and **naval (ship)** unit types. Each candidate is validated (treasury, stockpile, tech, capital) via the order engine. Ordering is deterministic (e.g. by unit type id).
 
 ---
 

--- a/packages/colonizethis_ai/lib/src/domain_planners.dart
+++ b/packages/colonizethis_ai/lib/src/domain_planners.dart
@@ -5,16 +5,17 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 
 import 'ai_config.dart';
+import 'economy_planner.dart';
 import 'goal_manager.dart';
 import 'hidden_agenda.dart';
 import 'perception.dart';
 import 'seed_bundle.dart';
 
-// Domain planners (utility AI). SPEC/ai/ai-architecture.md, ai-systems-impl.md.
+// Domain planners (utility AI). SPEC/ai/ai-architecture.md, ai-systems-impl.md, economy-planner.md.
 
 /// Runs economy, military, diplomacy, and research planners; returns combined orders
-/// for [nationId]. Uses [suggestionAPI] and scores with [config] and [snapshot].
-/// Deterministic given seeds.
+/// for [nationId]. Uses [suggestionAPI] and [economyPlan] (cargo preference) to score
+/// build candidates. Deterministic given seeds.
 Orders runDomainPlanners({
   required Game game,
   required MapTopology topology,
@@ -25,6 +26,7 @@ Orders runDomainPlanners({
   required StrategicGoal primaryGoal,
   required AISeedBundle seeds,
   required OrderSuggestionAPI suggestionAPI,
+  required EconomyPlan economyPlan,
 }) {
   var orders = const Orders();
   final domainWeights = getDomainWeightsForLeader(config.leaderId);
@@ -47,9 +49,16 @@ Orders runDomainPlanners({
   }
   final buildThreshold = 30 - agendaBuildOrderModifier(config.hiddenAgendaId);
   if (buildCandidates.isNotEmpty && domainWeights.economy >= buildThreshold) {
-    final rng = math.Random(seeds.economySeed + 1);
-    final idx = rng.nextInt(buildCandidates.length);
-    orders = _appendBuildOrders(orders, nationId, [buildCandidates[idx]]);
+    final chosen = _pickBuildOrder(
+      buildCandidates: buildCandidates,
+      cargoPreference: economyPlan.cargoPreference,
+      primaryGoal: primaryGoal,
+      config: config,
+      seed: seeds.economySeed + 1,
+    );
+    if (chosen != null) {
+      orders = _appendBuildOrders(orders, nationId, [chosen]);
+    }
   }
 
   // Movement: suggest moves; weight by military/expand.
@@ -165,6 +174,67 @@ Orders _appendBuildOrders(Orders o, String playerId, List<BuildUnitOrder> list) 
   return o.copyWith(
     buildUnitOrdersByPlayerId: {...o.buildUnitOrdersByPlayerId, playerId: [...existing, ...list]},
   );
+}
+
+/// Scores build candidates (ships vs regiments) by cargo preference, goal, and personality.
+/// Returns one build order via weighted random, or null if list empty. SPEC/ai/economy-planner.md.
+BuildUnitOrder? _pickBuildOrder({
+  required List<BuildUnitOrder> buildCandidates,
+  required CargoPreference cargoPreference,
+  required StrategicGoal primaryGoal,
+  required AIConfig config,
+  required int seed,
+}) {
+  if (buildCandidates.isEmpty) return null;
+  final thresholds = getThresholdsForLeader(config.leaderId);
+  final scores = buildCandidates.map((o) {
+    final unitType = o.unitType;
+    final isShip = ShipEconomyCatalog.byId.containsKey(unitType);
+    final cargoHold = isShip ? NavalStatsCatalog.get(unitType).cargoHold : 0;
+    final isRegiment = RegimentEconomyCatalog.byId.containsKey(unitType);
+
+    double cargoBonus = 0.0;
+    if (isShip && cargoHold > 0) {
+      switch (cargoPreference) {
+        case CargoPreference.strongCargo:
+          cargoBonus = 2.0;
+          break;
+        case CargoPreference.preferCargo:
+          cargoBonus = 1.0;
+          break;
+        case CargoPreference.none:
+          break;
+      }
+    }
+
+    double militaryBonus = 0.0;
+    if (primaryGoal == StrategicGoal.conquer || primaryGoal == StrategicGoal.defend) {
+      if (isRegiment) {
+        militaryBonus = 1.0;
+      } else if (isShip && cargoHold == 0) {
+        militaryBonus = 1.0;
+      }
+    }
+
+    double personalityBonus = 0.0;
+    if (isShip) {
+      personalityBonus = thresholds.researchNaval / 100.0;
+    } else if (isRegiment) {
+      personalityBonus = thresholds.researchMilitary / 100.0;
+    }
+
+    return 1.0 + cargoBonus + militaryBonus + personalityBonus;
+  }).toList();
+
+  final total = scores.reduce((a, b) => a + b);
+  if (total <= 0) return buildCandidates.first;
+  final rng = math.Random(seed);
+  var r = rng.nextDouble() * total;
+  for (var idx = 0; idx < buildCandidates.length; idx++) {
+    if (r < scores[idx]) return buildCandidates[idx];
+    r -= scores[idx];
+  }
+  return buildCandidates.last;
 }
 
 Orders _appendWorkOrders(Orders o, String playerId, List<WorkOrder> list) {

--- a/packages/colonizethis_ai/lib/src/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/economy_planner.dart
@@ -6,7 +6,6 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
 
 import 'ai_config.dart';
-import 'hidden_agenda.dart';
 import 'seed_bundle.dart';
 
 final Logger _log = Logger();

--- a/packages/colonizethis_ai/lib/src/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/strategic_ai.dart
@@ -57,6 +57,7 @@ StrategicOrderResult generateStrategicOrders({
     primaryGoal: primaryGoal,
     seeds: seeds,
     suggestionAPI: suggestionAPI,
+    economyPlan: economyPlan,
   );
   final moveCount = orders.moveOrdersByPlayerId[nationId]?.length ?? 0;
   final buildCount = orders.buildUnitOrdersByPlayerId[nationId]?.length ?? 0;

--- a/packages/colonizethis_ai/test/domain_planners_test.dart
+++ b/packages/colonizethis_ai/test/domain_planners_test.dart
@@ -113,6 +113,10 @@ void main() {
       final seeds = AISeedBundle.fromTurnSeed(999);
       const api = DefaultOrderSuggestionAPI();
 
+      const economyPlan = EconomyPlan(
+        productionAssignments: [],
+        cargoPreference: CargoPreference.none,
+      );
       final orders = runDomainPlanners(
         game: game,
         topology: topology,
@@ -123,6 +127,7 @@ void main() {
         primaryGoal: StrategicGoal.expand,
         seeds: seeds,
         suggestionAPI: api,
+        economyPlan: economyPlan,
       );
 
       expect(orders.moveOrdersByPlayerId.isEmpty, isTrue);
@@ -181,6 +186,10 @@ void main() {
       final seeds = AISeedBundle.fromTurnSeed(100);
       const api = DefaultOrderSuggestionAPI();
 
+      const economyPlan = EconomyPlan(
+        productionAssignments: [],
+        cargoPreference: CargoPreference.none,
+      );
       final orders = runDomainPlanners(
         game: game,
         topology: topology,
@@ -191,6 +200,7 @@ void main() {
         primaryGoal: StrategicGoal.expand,
         seeds: seeds,
         suggestionAPI: api,
+        economyPlan: economyPlan,
       );
 
       expect(orders, isNotNull);
@@ -250,6 +260,10 @@ void main() {
         hiddenAgendaId: 'peacemaker',
       );
       final seeds = AISeedBundle.fromTurnSeed(123);
+      const economyPlan = EconomyPlan(
+        productionAssignments: [],
+        cargoPreference: CargoPreference.none,
+      );
 
       final orders = runDomainPlanners(
         game: game,
@@ -261,6 +275,7 @@ void main() {
         primaryGoal: StrategicGoal.expand,
         seeds: seeds,
         suggestionAPI: fakeApi,
+        economyPlan: economyPlan,
       );
 
       // Economy: at least one work and build order should be appended.
@@ -307,6 +322,10 @@ void main() {
         navalMission: [],
         diplomatic: [diploOrder],
       );
+      const economyPlan = EconomyPlan(
+        productionAssignments: [],
+        cargoPreference: CargoPreference.none,
+      );
 
       final orders = runDomainPlanners(
         game: game,
@@ -318,6 +337,7 @@ void main() {
         primaryGoal: StrategicGoal.diplomacy,
         seeds: seeds,
         suggestionAPI: fakeApi,
+        economyPlan: economyPlan,
       );
 
       expect(orders.diplomaticOrdersByPlayerId['gp1'], isNotNull);
@@ -358,7 +378,11 @@ void main() {
         research: [],
         navalMove: [],
         navalMission: [],
-        diplomatic: const [],
+        diplomatic: [],
+      );
+      const economyPlan = EconomyPlan(
+        productionAssignments: [],
+        cargoPreference: CargoPreference.none,
       );
 
       final orders = runDomainPlanners(
@@ -371,9 +395,153 @@ void main() {
         primaryGoal: StrategicGoal.diplomacy,
         seeds: seeds,
         suggestionAPI: fakeApi,
+        economyPlan: economyPlan,
       );
 
       expect(orders.diplomaticOrdersByPlayerId['gp1'], isNull);
+    });
+
+    test('with strongCargo and ship candidate picks ship deterministically', () {
+      const regimentBuild = BuildUnitOrder(
+        unitType: 'peasant_levies',
+        isMilitary: true,
+        spawnProvinceId: 'oldWorld|p1',
+      );
+      const shipBuild = BuildUnitOrder(
+        unitType: 'fluyte',
+        isMilitary: false,
+        spawnProvinceId: 'oldWorld|p1',
+      );
+      const fakeApi = _FakeOrderSuggestionAPI(
+        work: [],
+        build: [regimentBuild, shipBuild],
+        move: [],
+        research: [],
+        navalMove: [],
+        navalMission: [],
+        diplomatic: [],
+      );
+      const economyPlanStrongCargo = EconomyPlan(
+        productionAssignments: [],
+        cargoPreference: CargoPreference.strongCargo,
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'A',
+            isHuman: false,
+            leaderKey: 'henry',
+          ),
+        ],
+      );
+      const topology = MapTopology(nodes: [], edges: []);
+      final view = buildPlayerView(game, topology, 'gp1');
+      final snapshot = AIWorldSnapshot.fromPlayerView(view);
+      const config = AIConfig(
+        leaderId: 'henry',
+        personalityId: 'henry',
+        hiddenAgendaId: 'peacemaker',
+      );
+      final seeds = AISeedBundle.fromTurnSeed(42);
+
+      final orders = runDomainPlanners(
+        game: game,
+        topology: topology,
+        nationId: 'gp1',
+        view: view,
+        snapshot: snapshot,
+        config: config,
+        primaryGoal: StrategicGoal.expand,
+        seeds: seeds,
+        suggestionAPI: fakeApi,
+        economyPlan: economyPlanStrongCargo,
+      );
+
+      final builds = orders.buildUnitOrdersByPlayerId['gp1'] ?? [];
+      expect(builds.length, 1);
+      expect(builds.single.unitType, 'fluyte', reason: 'strongCargo should favour cargo ship over regiment');
+    });
+
+    test('build selection is deterministic for same seed and cargoPreference none', () {
+      const regimentBuild = BuildUnitOrder(
+        unitType: 'peasant_levies',
+        isMilitary: true,
+        spawnProvinceId: 'oldWorld|p1',
+      );
+      const shipBuild = BuildUnitOrder(
+        unitType: 'fluyte',
+        isMilitary: false,
+        spawnProvinceId: 'oldWorld|p1',
+      );
+      const fakeApi = _FakeOrderSuggestionAPI(
+        work: [],
+        build: [regimentBuild, shipBuild],
+        move: [],
+        research: [],
+        navalMove: [],
+        navalMission: [],
+        diplomatic: [],
+      );
+      const economyPlan = EconomyPlan(
+        productionAssignments: [],
+        cargoPreference: CargoPreference.none,
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'A', isHuman: false, leaderKey: 'victoria'),
+        ],
+      );
+      const topology = MapTopology(nodes: [], edges: []);
+      final view = buildPlayerView(game, topology, 'gp1');
+      final snapshot = AIWorldSnapshot.fromPlayerView(view);
+      const config = AIConfig(
+        leaderId: 'victoria',
+        personalityId: 'victoria',
+        hiddenAgendaId: 'peacemaker',
+      );
+      final seeds = AISeedBundle.fromTurnSeed(999);
+
+      final orders1 = runDomainPlanners(
+        game: game,
+        topology: topology,
+        nationId: 'gp1',
+        view: view,
+        snapshot: snapshot,
+        config: config,
+        primaryGoal: StrategicGoal.expand,
+        seeds: seeds,
+        suggestionAPI: fakeApi,
+        economyPlan: economyPlan,
+      );
+      final orders2 = runDomainPlanners(
+        game: game,
+        topology: topology,
+        nationId: 'gp1',
+        view: view,
+        snapshot: snapshot,
+        config: config,
+        primaryGoal: StrategicGoal.expand,
+        seeds: seeds,
+        suggestionAPI: fakeApi,
+        economyPlan: economyPlan,
+      );
+
+      final build1 = orders1.buildUnitOrdersByPlayerId['gp1']?.single.unitType;
+      final build2 = orders2.buildUnitOrdersByPlayerId['gp1']?.single.unitType;
+      expect(build1, build2, reason: 'same seed and economyPlan should yield same build choice');
     });
   });
 }

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -311,12 +311,26 @@ List<BuildUnitOrder> suggestBuildOrders(
     return suggestions;
   }
 
-  // For now, suggest only military builds using RegimentEconomyCatalog.
+  // Military (regiment) builds.
   for (final entry in RegimentEconomyCatalog.byId.entries) {
     final unitType = entry.key;
     final candidate = BuildUnitOrder(
       unitType: unitType,
       isMilitary: buildUnitCategoryForUnitType(unitType) == BuildUnitCategory.military,
+      spawnProvinceId: capitalId,
+    );
+
+    if (_isBuildOrderAccepted(game, topology, playerId, currentOrders, candidate)) {
+      suggestions.add(candidate);
+    }
+  }
+
+  // Naval (ship) builds. SPEC/program/order-suggestions.md.
+  for (final entry in ShipEconomyCatalog.byId.entries) {
+    final unitType = entry.key;
+    final candidate = BuildUnitOrder(
+      unitType: unitType,
+      isMilitary: false,
       spawnProvinceId: capitalId,
     );
 

--- a/packages/colonizethis_logic/test/order_suggestion_api_impl_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_api_impl_test.dart
@@ -76,6 +76,43 @@ void main() {
       expect(list, isA<List<BuildUnitOrder>>());
     });
 
+    test('suggestBuildOrders includes ship types when player can afford a ship', () {
+      const api = DefaultOrderSuggestionAPI();
+      const ow = 'oldWorld';
+      final stockpile = const Stockpile()
+          .applyDelta(CommodityCatalog.lumber.id, 2)
+          .applyDelta(CommodityCatalog.fabric.id, 2);
+      final gameWithShip = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [Province(id: '$ow|p1', regionId: ow, ownerId: 'gp1')],
+            units: [],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: [
+          Player(
+            id: 'gp1',
+            displayName: 'A',
+            isHuman: false,
+            capitalProvinceId: '$ow|p1',
+            treasury: 100,
+            stockpile: stockpile,
+          ),
+        ],
+      );
+      final topo = MapTopology(
+        nodes: const [TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province)],
+        edges: const [],
+      );
+      final v = buildPlayerView(gameWithShip, topo, 'gp1');
+      final list = api.suggestBuildOrders(v, gameWithShip, topo, emptyOrders);
+      final shipBuilds = list.where((o) => ShipEconomyCatalog.byId.containsKey(o.unitType)).toList();
+      expect(shipBuilds, isNotEmpty, reason: 'API should suggest ship builds when affordable');
+    });
+
     test('suggestResearchOrders returns list', () {
       const api = DefaultOrderSuggestionAPI();
       final list = api.suggestResearchOrders(view, game, topology, emptyOrders);

--- a/packages/colonizethis_logic/test/order_suggestion_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_test.dart
@@ -339,6 +339,76 @@ void main() {
       expect(suggestions, isA<List<BuildUnitOrder>>());
     });
 
+    test('suggestBuildOrders returns ship when affordable', () {
+      const playerId = 'gp1';
+      const ow = 'oldWorld';
+      final stockpile = const Stockpile()
+          .applyDelta(CommodityCatalog.lumber.id, 2)
+          .applyDelta(CommodityCatalog.fabric.id, 2);
+      final player = Player(
+        id: playerId,
+        displayName: 'GP',
+        isHuman: false,
+        capitalProvinceId: '$ow|p1',
+        treasury: 100,
+        stockpile: stockpile,
+      );
+      final world = WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: RegionData(
+          provinces: [Province(id: '$ow|p1', regionId: ow, ownerId: playerId)],
+          units: [],
+        ),
+        newWorld: const RegionData(),
+      );
+      final game = Game(id: 'g1', worldState: world, players: [player]);
+      final topology = MapTopology(
+        nodes: const [TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province)],
+        edges: const [],
+      );
+      final view = buildPlayerView(game, topology, playerId);
+      final suggestions = suggestBuildOrders(view, game, topology, const Orders());
+      final shipTypes = suggestions.where((o) => ShipEconomyCatalog.byId.containsKey(o.unitType)).toList();
+      expect(shipTypes, isNotEmpty, reason: 'suggestBuildOrders should include ships when player has capital, treasury and stockpile for fluyte/carrack');
+    });
+
+    test('suggestBuildOrders can return both regiment and ship when both affordable', () {
+      const playerId = 'gp1';
+      const ow = 'oldWorld';
+      final stockpile = const Stockpile()
+          .applyDelta(CommodityCatalog.lumber.id, 5)
+          .applyDelta(CommodityCatalog.fabric.id, 5)
+          .applyDelta(CommodityCatalog.castIron.id, 5);
+      final player = Player(
+        id: playerId,
+        displayName: 'GP',
+        isHuman: false,
+        capitalProvinceId: '$ow|p1',
+        workerPool: const WorkerPool(peasants: 2, apprentices: 1),
+        treasury: 500,
+        stockpile: stockpile,
+      );
+      final world = WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: RegionData(
+          provinces: [Province(id: '$ow|p1', regionId: ow, ownerId: playerId)],
+          units: [],
+        ),
+        newWorld: const RegionData(),
+      );
+      final game = Game(id: 'g1', worldState: world, players: [player]);
+      final topology = MapTopology(
+        nodes: const [TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province)],
+        edges: const [],
+      );
+      final view = buildPlayerView(game, topology, playerId);
+      final suggestions = suggestBuildOrders(view, game, topology, const Orders());
+      final hasRegiment = suggestions.any((o) => RegimentEconomyCatalog.byId.containsKey(o.unitType));
+      final hasShip = suggestions.any((o) => ShipEconomyCatalog.byId.containsKey(o.unitType));
+      expect(hasRegiment, isTrue, reason: 'should suggest regiments when affordable');
+      expect(hasShip, isTrue, reason: 'should suggest ships when affordable');
+    });
+
     test('suggestResearchOrders returns list', () {
       const playerId = 'gp1';
       final player = const Player(id: playerId, displayName: 'GP', isHuman: false, treasury: 1000);


### PR DESCRIPTION
## Summary
- **Suggest ships:** `suggestBuildOrders` now returns both regiments and ship types (affordable, tech-validated). SPEC/program/order-suggestions.md updated.
- **Balance land vs naval:** Domain planner receives `EconomyPlan` (cargo preference); build candidates are scored by cargo bonus (strongCargo/preferCargo for cargo ships), military goal (conquer/defend → regiments/warships), and personality (researchNaval/researchMilitary). One build chosen via weighted random. Strategic AI passes economy plan into `runDomainPlanners`.
- **Merchant vs warship:** Uses existing `NavalStatsCatalog.get(unitType).cargoHold` (cargoHold > 0 → cargo bonus; cargoHold == 0 → military bonus when conquer/defend).

## Spec updates
- SPEC/ai/economy-planner.md: build planner uses cargo preference; integration (strategic AI passes economy plan).
- SPEC/program/order-suggestions.md: build orders include regiments and ships.
- SPEC/program/ai-systems-impl.md: strategic AI passes economy plan into domain planners.

## Tests
- order_suggestion_test: ship when affordable; both regiment and ship when both affordable.
- order_suggestion_api_impl_test: ship types when player can afford a ship.
- domain_planners_test: `economyPlan` on all calls; strongCargo picks ship (henry + fluyte); build selection deterministic for same seed.

## Quality
- `dart analyze packages/colonizethis_ai packages/colonizethis_logic` passes (exit 0).
- `dart test packages/colonizethis_ai packages/colonizethis_logic`: 637 tests passed.
- Removed unused `hidden_agenda` import from economy_planner; fixed unnecessary const in domain_planners_test.

Made with [Cursor](https://cursor.com)