### PR TITLE
feat(ui): Game Setup screen (CtGameSetup) per SPEC/ui/game-setup.md

### DIFF
--- a/SPEC/ui/game-setup.md
+++ b/SPEC/ui/game-setup.md
@@ -1,0 +1,80 @@
+# Game Setup
+
+**SPEC/ui** — Game Setup screen. Authority: UXD 03b (Game Setup). Catalog widget: CtGameSetup.
+
+---
+
+## Widget contract
+
+The CtGameSetup widget is presentational and accepts the following parameters. The **shell** (or parent) supplies config and naming and handles navigation. There are **six player slots**; slot 0 is the **human player**, slots 1–5 are **AI**. For each slot the user selects **nation (GP)** then **leader**; leaders are tied to the selected nation. Nations and leaders already chosen in one slot are not available in another (no duplicate nations).
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `variant` | `plain` \| `pixelArt` | **plain:** standard Flutter/colonial theme. **pixelArt:** reuses main menu button asset per UXD 02. |
+| `state` | `default` \| `loading` | **default:** Start Game and dropdowns enabled. **loading:** Start disabled, optional loading indicator; Back remains enabled. |
+| `naming` | `ResolvedNamingConfig` | All GP country names and leader variants (colonizethis_data). Used to populate nation and leader dropdowns. |
+| `initialOrderedGpIds` | `List<String>` | Length 6. Initial nation (gpId) per slot; **empty string denotes unselected**. When the screen loads with all entries empty (e.g. `["", "", "", "", "", ""]`), all nation/leader choices are unselected; the shell should pass this for a fresh setup. |
+| `initialLeaderVariantByGpId` | `Map<String, String>` | Initial leader variant per gpId (gpId → variantId). When the screen loads with all choices unselected, this is empty. When a slot’s nation changes, leader resets to default for that nation. |
+| `onStartGame` | `void Function(List<String> orderedGpIdsForSlots, Map<String, String> leaderVariantByGpId)` | Invoked when user taps Start Game. Widget passes ordered list of 6 gpIds (slot 0 = human, 1–5 = AI) and leader map; shell builds GameSetupConfig and creates game. |
+| `onBack` | callback | Invoked when user taps Back; shell navigates to Main Menu. |
+
+---
+
+## How this spec satisfies UXD 03b
+
+**User stories.** The user lands here from Main Menu "New Game". **On load, all nation and leader choices are unselected** (each slot shows e.g. "Select nation" / "Select leader"). They see six player slots: **Player 1 (You)** (human) and **Players 2–6 (AI)**. For each slot they select a **nation** (GP) from a dropdown, then a **leader** for that nation. **Start Game is disabled until every slot has both a nation and a leader selected.** Nations/leaders already selected in another slot are excluded from other dropdowns so no two players share a nation. Changing a slot’s nation updates that slot’s leader options to that nation’s variants (and resets to the default leader for that nation). Tapping **Start Game** creates the game with slot 0 as human and slots 1–5 as AI; **Back** returns to Main Menu. Shell wires callbacks and owns navigation. Config semantics: [SPEC/game/game-setup.md](../game/game-setup.md), [game-setup-pipeline.md](../program/game-setup-pipeline.md).
+
+**Acceptance criteria (Given–When–Then).**
+
+- **Visibility:** Given the user navigated from Main Menu via New Game, the UI layer shows the Game Setup screen with title, six player-slot rows, Start Game button, and Back button. Slot 1 is labeled as the human player (e.g. "Player 1 (You)"); slots 2–6 are labeled as AI (e.g. "Player 2 (AI)" … "Player 6 (AI)"). Each row has a nation dropdown and a leader dropdown.
+- **Initial state unselected:** Given the screen is loaded with all nation/leader choices unselected (e.g. `initialOrderedGpIds` is six empty strings and `initialLeaderVariantByGpId` is empty), the UI layer shows each slot with no nation and no leader selected (e.g. nation dropdown shows "Select nation", leader dropdown shows "Select leader" or is disabled). Start Game is disabled.
+- **Start disabled until complete:** Given state is default, when one or more slots have no nation selected or no leader selected (or leader not yet chosen for a selected nation), the UI layer keeps Start Game disabled. When the user has selected a nation and a leader for all six slots, the UI layer enables Start Game.
+- **No duplicate nations:** Given the current slot selections, when the user opens the nation dropdown for any slot, the dropdown lists only nations not already selected in another slot. Selecting a nation in one slot removes it from the nation options in every other slot.
+- **Leader follows nation:** Given a slot has a selected nation, when the user changes that slot’s nation, the UI layer updates the leader dropdown to that nation’s leader variants and sets the selected leader to the default variant for that nation. The previous nation’s leader selection is no longer shown for that slot.
+- **Leader uniqueness:** Leaders are per nation; once a nation is assigned to a slot, the leader dropdown for that slot shows only that nation’s variants. No separate “leader taken” rule across slots because each slot has a distinct nation.
+- **Start:** Given state is default and **all six slots have both a nation and a leader selected**, when the user taps Start Game, the widget invokes `onStartGame` once with (1) a list of six gpIds in slot order (index 0 = human, 1–5 = AI) and (2) a map gpId → leaderVariantId for each of those gpIds. The shell builds GameSetupConfig (e.g. selectedGreatPowerIds = that list, leaderVariantByGpId = that map), creates the game, and navigates.
+- **Back:** When the user taps Back, the widget invokes `onBack` once; the shell navigates to Main Menu.
+- **Loading:** Given state is loading, the Start Game control is disabled and (optionally) a loading indicator is visible; nation and leader dropdowns may be disabled; tapping Back remains enabled.
+
+**Interaction.** The widget holds per-slot state (ordered list of six gpIds and leader variant per gpId) and exposes it via `onStartGame(orderedGpIdsForSlots, leaderVariantByGpId)`. No routing logic lives in the widget.
+
+---
+
+## Wireframe
+
+Positions, layout, and hierarchy (per UXD 03b; 44 dp min touch targets).
+
+**Default:**
+
+```text
++------------------------------------------------------+
+|                  Game Setup                          |
+|                                                      |
+|  Player 1 (You)    [ Select nation ▼ ] [ Select leader ▼ ] |
+|  Player 2 (AI)     [ Select nation ▼ ] [ Select leader ▼ ] |
+|  ... (all six slots initially unselected)            |
+|                                                      |
+|  [ Start Game ]  (disabled until all slots complete)  |
+|  [ Back ]                                            |
++------------------------------------------------------+
+```
+
+When the user has selected a nation and leader for every slot, Start Game becomes enabled. Nation dropdown for a slot lists "Select nation" (empty) plus GPs not selected in other slots. Leader dropdown lists "Select leader" (empty) until a nation is chosen, then that nation’s variants. When nation changes, leader resets to that nation’s default.
+
+**Loading:** Same layout; Start Game disabled; optional "Starting…" or spinner; Back enabled.
+
+**Regions (UXD 07–style):** canvas full-screen; title_region ("Game Setup"); slots_region (scrollable: six rows, each with slot label, nation dropdown, leader dropdown); buttons_region (Start Game, Back); optional loading_region when state is loading.
+
+**Layout (pixel-art variant):** Content column constrained to **max width 400 dp**; Start/Back use main menu button asset. Content centered. Slots may scroll on small screens.
+
+---
+
+## Pixel-art assets
+
+For MVP, reuse main menu assets: `ui_main_menu_button.png` for Start Game and Back. Dropdowns and list use theme styling. If a dedicated game-setup panel is added later, add a row here and PixelLab prompts. Style lock: UXD 02.
+
+---
+
+## Widget catalog
+
+Once implemented, register in `app/widget_catalog.json` as CtGameSetup (category: screen, source: pipeline), with `dart_file_path` and `widgetbook_story_path`: "Game Setup".

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -1,7 +1,9 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:flutter/material.dart';
 import 'package:widgetbook/widgetbook.dart';
 
 import 'config/themes.dart';
+import 'widgets/game_setup.dart';
 import 'widgets/main_menu.dart';
 
 /// Widgetbook entry point. Run with: flutter run -t lib/widgetbook.dart
@@ -9,14 +11,14 @@ void main() {
   runApp(const CtWidgetbookApp());
 }
 
-/// Widgetbook app with colonial theme. SPEC/ui/main-menu.md; UXD 03a.
+/// Widgetbook app with colonial theme. SPEC/ui/main-menu.md; UXD 03a. SPEC/ui/game-setup.md; UXD 03b.
 class CtWidgetbookApp extends StatelessWidget {
   const CtWidgetbookApp({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Widgetbook.material(
-      directories: mainMenuDirectories,
+      directories: [...mainMenuDirectories, ...gameSetupDirectories],
       lightTheme: AppThemes.colonial,
       darkTheme: AppThemes.colonial,
     );
@@ -86,6 +88,66 @@ List<WidgetbookNode> get mainMenuDirectories => [
               onLoadGame: () {},
               onSettings: () {},
               onQuit: () {},
+            ),
+          ),
+        ],
+      ),
+    ];
+
+/// All choices unselected on load. SPEC/ui/game-setup.md.
+List<String> _unselectedInitialOrderedGpIds() => List.filled(6, '');
+
+/// Game Setup stories. SPEC/ui/game-setup.md; UXD 03b.
+List<WidgetbookNode> get gameSetupDirectories => [
+      WidgetbookFolder(
+        name: 'Game Setup',
+        children: [
+          WidgetbookUseCase(
+            name: 'Default',
+            builder: (context) => CtGameSetup(
+              variant: GameSetupVariant.plain,
+              state: GameSetupState.default_,
+              naming: defaultNamingConfig,
+              initialOrderedGpIds: _unselectedInitialOrderedGpIds(),
+              initialLeaderVariantByGpId: {},
+              onStartGame: (_, __) {},
+              onBack: () {},
+            ),
+          ),
+          WidgetbookUseCase(
+            name: 'Loading',
+            builder: (context) => CtGameSetup(
+              variant: GameSetupVariant.plain,
+              state: GameSetupState.loading,
+              naming: defaultNamingConfig,
+              initialOrderedGpIds: _unselectedInitialOrderedGpIds(),
+              initialLeaderVariantByGpId: {},
+              onStartGame: (_, __) {},
+              onBack: () {},
+            ),
+          ),
+          WidgetbookUseCase(
+            name: 'Default (pixel)',
+            builder: (context) => CtGameSetup(
+              variant: GameSetupVariant.pixelArt,
+              state: GameSetupState.default_,
+              naming: defaultNamingConfig,
+              initialOrderedGpIds: _unselectedInitialOrderedGpIds(),
+              initialLeaderVariantByGpId: {},
+              onStartGame: (_, __) {},
+              onBack: () {},
+            ),
+          ),
+          WidgetbookUseCase(
+            name: 'Loading (pixel)',
+            builder: (context) => CtGameSetup(
+              variant: GameSetupVariant.pixelArt,
+              state: GameSetupState.loading,
+              naming: defaultNamingConfig,
+              initialOrderedGpIds: _unselectedInitialOrderedGpIds(),
+              initialLeaderVariantByGpId: {},
+              onStartGame: (_, __) {},
+              onBack: () {},
             ),
           ),
         ],

--- a/app/lib/widgets/game_setup.dart
+++ b/app/lib/widgets/game_setup.dart
@@ -1,0 +1,396 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:flutter/material.dart';
+import 'package:logger/logger.dart';
+
+/// Visual variant of the Game Setup screen. SPEC/ui/game-setup.md; UXD 03b.
+enum GameSetupVariant {
+  /// Standard Flutter widgets with colonial theme.
+  plain,
+
+  /// Same layout with pixel-art button assets from main menu (reused).
+  pixelArt,
+}
+
+/// Content state of the Game Setup screen. SPEC/ui/game-setup.md; UXD 03b.
+enum GameSetupState {
+  /// Start Game and dropdowns enabled.
+  default_,
+
+  /// Start disabled, loading indicator; Back remains enabled.
+  loading,
+}
+
+/// Number of player slots. Slot 0 = human, 1..5 = AI. SPEC/ui/game-setup.md.
+const int _kNumSlots = 6;
+
+/// Asset path for pixel-art variant (reuse main menu). SPEC/ui/game-setup.md.
+const String _kAssetButton = 'assets/images/ui_main_menu_button.png';
+
+/// Game Setup screen. Six player slots; slot 0 = human, 1–5 = AI.
+/// Per slot: nation (GP) dropdown, then leader dropdown for that nation.
+/// Nations/leaders chosen in one slot are excluded from others. Min 44 dp touch targets.
+class CtGameSetup extends StatefulWidget {
+  const CtGameSetup({
+    super.key,
+    required this.variant,
+    required this.state,
+    required this.naming,
+    required this.initialOrderedGpIds,
+    required this.initialLeaderVariantByGpId,
+    required this.onStartGame,
+    required this.onBack,
+  });
+
+  final GameSetupVariant variant;
+  final GameSetupState state;
+  final ResolvedNamingConfig naming;
+  final List<String> initialOrderedGpIds;
+  final Map<String, String> initialLeaderVariantByGpId;
+  final void Function(List<String> orderedGpIdsForSlots, Map<String, String> leaderVariantByGpId) onStartGame;
+  final VoidCallback onBack;
+
+  @override
+  State<CtGameSetup> createState() => _CtGameSetupState();
+}
+
+class _CtGameSetupState extends State<CtGameSetup> {
+  late List<String> _orderedGpIdsBySlot;
+  late Map<String, String> _leaderVariantByGpId;
+
+  List<String> get _allGpIds => widget.naming.greatPowers.map((g) => g.id).toList();
+
+  @override
+  void initState() {
+    super.initState();
+    final all = widget.naming.greatPowers.map((g) => g.id).toList();
+    _orderedGpIdsBySlot = List<String>.from(widget.initialOrderedGpIds);
+    if (_orderedGpIdsBySlot.length != _kNumSlots) {
+      _orderedGpIdsBySlot = _padOrTrimToSlots(_orderedGpIdsBySlot, all);
+    } else if (_orderedGpIdsBySlot.every((id) => id.isEmpty)) {
+      _orderedGpIdsBySlot = List.filled(_kNumSlots, '');
+    }
+    _leaderVariantByGpId = Map<String, String>.from(widget.initialLeaderVariantByGpId);
+  }
+
+  @override
+  void didUpdateWidget(covariant CtGameSetup oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.initialOrderedGpIds != widget.initialOrderedGpIds ||
+        oldWidget.initialLeaderVariantByGpId != widget.initialLeaderVariantByGpId) {
+      final all = widget.naming.greatPowers.map((g) => g.id).toList();
+      _orderedGpIdsBySlot = List<String>.from(widget.initialOrderedGpIds);
+      if (_orderedGpIdsBySlot.length != _kNumSlots) {
+        _orderedGpIdsBySlot = _padOrTrimToSlots(_orderedGpIdsBySlot, all);
+      } else if (_orderedGpIdsBySlot.every((id) => id.isEmpty)) {
+        _orderedGpIdsBySlot = List.filled(_kNumSlots, '');
+      }
+      _leaderVariantByGpId = Map<String, String>.from(widget.initialLeaderVariantByGpId);
+    }
+  }
+
+  /// GP ids available for this slot: empty string (unselected) plus nations not selected in other slots, or current.
+  List<String> _availableGpIdsForSlot(int slotIndex) {
+    final others = _allGpIds.where((id) {
+      final indexOf = _orderedGpIdsBySlot.indexOf(id);
+      return indexOf == -1 || indexOf == slotIndex;
+    }).toList();
+    return ['', ...others];
+  }
+
+  bool get _isLoading => widget.state == GameSetupState.loading;
+  bool get _startEnabled =>
+      !_isLoading && _orderedGpIdsBySlot.every((id) => id.isNotEmpty);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 400),
+              child: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const SizedBox(height: 24),
+                    Text(
+                      'Game Setup',
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
+                    const SizedBox(height: 24),
+                    _buildSlots(context),
+                    const SizedBox(height: 24),
+                    if (_isLoading)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 12),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            const SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              'Starting…',
+                              style: Theme.of(context).textTheme.bodySmall,
+                            ),
+                          ],
+                        ),
+                      ),
+                    _GameSetupMenuButton(
+                      label: 'Start Game',
+                      variant: widget.variant,
+                      enabled: _startEnabled,
+                      onPressed: _startEnabled ? _onStartGame : null,
+                    ),
+                    const SizedBox(height: 12),
+                    _GameSetupMenuButton(
+                      label: 'Back',
+                      variant: widget.variant,
+                      enabled: true,
+                      onPressed: widget.onBack,
+                    ),
+                    const SizedBox(height: 24),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSlots(BuildContext context) {
+    final rows = <Widget>[];
+    for (var i = 0; i < _kNumSlots; i++) {
+      final label = i == 0 ? 'Player 1 (You)' : 'Player ${i + 1} (AI)';
+      rows.add(_buildSlotRow(context, i, label));
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: rows,
+    );
+  }
+
+  Widget _buildSlotRow(BuildContext context, int slotIndex, String slotLabel) {
+    final gpId = _orderedGpIdsBySlot[slotIndex];
+    final gp = gpId.isEmpty ? null : widget.naming.gpById(gpId);
+    final availableGpIds = _availableGpIdsForSlot(slotIndex);
+    final variants = gp?.leaderVariants ?? <LeaderVariant>[];
+    final currentVariantId = gp != null
+        ? (_leaderVariantByGpId[gpId] ?? gp.defaultLeaderVariantId)
+        : '';
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          SizedBox(
+            width: 100,
+            child: Text(
+              slotLabel,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    fontWeight: slotIndex == 0 ? FontWeight.w600 : null,
+                  ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            flex: 1,
+            child: DropdownButton<String>(
+              value: availableGpIds.contains(gpId) ? gpId : (availableGpIds.isNotEmpty ? availableGpIds.first : null),
+              isExpanded: true,
+              items: [
+                for (final id in availableGpIds)
+                  DropdownMenuItem(
+                    value: id,
+                    child: Text(
+                      id.isEmpty ? 'Select nation' : (widget.naming.gpById(id)?.countryName ?? id),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+              ],
+              onChanged: _isLoading
+                  ? null
+                  : (value) {
+                      if (value != null) {
+                        if (value.isEmpty) {
+                          setState(() {
+                            _orderedGpIdsBySlot[slotIndex] = '';
+                          });
+                          return;
+                        }
+                        final newGp = widget.naming.gpById(value);
+                        if (newGp != null) {
+                          setState(() {
+                            _orderedGpIdsBySlot[slotIndex] = value;
+                            _leaderVariantByGpId[value] = newGp.defaultLeaderVariantId;
+                          });
+                        }
+                      }
+                    },
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            flex: 1,
+            child: gpId.isEmpty
+                ? DropdownButton<String>(
+                    value: '',
+                    isExpanded: true,
+                    items: const [
+                      DropdownMenuItem(value: '', child: Text('Select leader')),
+                    ],
+                    onChanged: null,
+                  )
+                : DropdownButton<String>(
+                    value: variants.any((v) => v.id == currentVariantId) ? currentVariantId : (variants.isNotEmpty ? variants.first.id : null),
+                    isExpanded: true,
+                    items: [
+                      for (final v in variants)
+                        DropdownMenuItem(
+                          value: v.id,
+                          child: Text(v.name, overflow: TextOverflow.ellipsis),
+                        ),
+                    ],
+                    onChanged: _isLoading
+                        ? null
+                        : (value) {
+                            if (value != null) {
+                              setState(() => _leaderVariantByGpId[gpId] = value);
+                            }
+                          },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _onStartGame() {
+    final leaderMap = <String, String>{};
+    for (final gpId in _orderedGpIdsBySlot) {
+      final variantId = _leaderVariantByGpId[gpId];
+      if (variantId != null && variantId.isNotEmpty) {
+        leaderMap[gpId] = variantId;
+      } else {
+        final gp = widget.naming.gpById(gpId);
+        if (gp != null && gp.leaderVariants.isNotEmpty) {
+          leaderMap[gpId] = gp.defaultLeaderVariantId;
+        }
+      }
+    }
+    widget.onStartGame(List<String>.from(_orderedGpIdsBySlot), leaderMap);
+  }
+}
+
+/// Pads or trims [list] to 6 slots using [allGpIds] for fill; no duplicates.
+List<String> _padOrTrimToSlots(List<String> list, List<String> allGpIds) {
+  const kNumSlots = 6;
+  final result = <String>[];
+  final used = <String>{};
+  for (var i = 0; i < kNumSlots; i++) {
+    if (i < list.length && list[i].isNotEmpty && !used.contains(list[i])) {
+      result.add(list[i]);
+      used.add(list[i]);
+    } else {
+      for (final id in allGpIds) {
+        if (!used.contains(id)) {
+          result.add(id);
+          used.add(id);
+          break;
+        }
+      }
+    }
+  }
+  return result.length == kNumSlots ? result : allGpIds.take(kNumSlots).toList();
+}
+
+class _GameSetupMenuButton extends StatelessWidget {
+  const _GameSetupMenuButton({
+    required this.label,
+    required this.variant,
+    required this.enabled,
+    required this.onPressed,
+  });
+
+  final String label;
+  final GameSetupVariant variant;
+  final bool enabled;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    if (variant == GameSetupVariant.pixelArt) {
+      return _GameSetupPixelArtButton(
+        label: label,
+        enabled: enabled,
+        onPressed: onPressed,
+      );
+    }
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        child: Text(label),
+      ),
+    );
+  }
+}
+
+class _GameSetupPixelArtButton extends StatelessWidget {
+  const _GameSetupPixelArtButton({
+    required this.label,
+    required this.enabled,
+    required this.onPressed,
+  });
+
+  final String label;
+  final bool enabled;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 48,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: enabled ? onPressed : null,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              Image.asset(
+                _kAssetButton,
+                centerSlice: const Rect.fromLTWH(24, 18, 75, 21),
+                fit: BoxFit.fill,
+                filterQuality: FilterQuality.none,
+                errorBuilder: (_, __, ___) {
+                  Logger().w('ctdev: game_setup button asset not found, using fallback');
+                  return Container(color: const Color(0xFF5D3A1A));
+                },
+              ),
+              Center(
+                child: Text(
+                  label,
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        color: enabled ? const Color(0xFFF5F5DC) : Colors.grey,
+                      ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/widget_catalog.json
+++ b/app/widget_catalog.json
@@ -7,5 +7,14 @@
     "category": "screen",
     "source": "pipeline",
     "widgetbook_story_path": "Main Menu"
+  },
+  {
+    "id": "ct_game_setup",
+    "name": "CtGameSetup",
+    "dart_file_path": "lib/widgets/game_setup.dart",
+    "constructor_props": "variant: GameSetupVariant, state: GameSetupState, naming: ResolvedNamingConfig, initialOrderedGpIds: List<String>, initialLeaderVariantByGpId: Map<String, String>, onStartGame: void Function(List<String>, Map<String, String>), onBack: VoidCallback",
+    "category": "screen",
+    "source": "pipeline",
+    "widgetbook_story_path": "Game Setup"
   }
 ]


### PR DESCRIPTION
## Summary
Adds the Game Setup screen per `SPEC/ui/game-setup.md` (UXD 03b).

## Changes
- **SPEC/ui/game-setup.md** — UI spec: widget contract, wireframe, acceptance criteria, pixel-art reuse
- **app/lib/widgets/game_setup.dart** — `CtGameSetup`: six player slots (slot 0 human, 1–5 AI), nation + leader dropdowns per slot, `plain` and `pixelArt` variants, loading state; no duplicate nations across slots
- **app/lib/widgetbook.dart** — Game Setup stories (default, loading, pixel)
- **app/widget_catalog.json** — Register CtGameSetup (screen, pipeline)

## Quality
- `tool/check_test_imports.sh` ✅
- `dart analyze` (app) ✅
- CI scope: app/spec-only changes → test import check runs; package/tool tests not in scope for this PR

Made with [Cursor](https://cursor.com)