### PR TITLE
feat(ai): close gap 12 — war declaration relation threshold, target scoring, movement filter/prefer

### DIFF
--- a/.github/ISSUE_AI_SPEC_GAPS.md
+++ b/.github/ISSUE_AI_SPEC_GAPS.md
@@ -116,6 +116,20 @@ Tests in `perception_test.dart` cover threats (including neighbor/capital with t
 
 ---
 
+## 12. War declaration and attack target selection — **IMPLEMENTED** (relation threshold; target-specific scoring; movement filter and prefer)
+
+**Spec:**  
+- **SPEC/ai/hidden-agendas.md** — **War declaration:** "Warmonger: **lower relation threshold** to declare war; Peacemaker: strong negative modifier; **Backstabber: bonus if target is ally**." Agenda table: warmonger "**Attacks weaker neighbors**"; backstabber "**Attacks allies when weak**".  
+- **SPEC/ai/ai-architecture.md** — **Movement:** "**Prefer** contested or enemy territory (at war); avoid factions at peace."
+
+**Current:**  
+- **Relation threshold:** Implemented in `_runDiplomacyPlanner`. Declare-war candidates are scored 0 when relation score > `getDeclareWarMaxRelationScore(agendaId)` (default 50; warmonger 70; peacemaker 30; backstabber 100). Config in `colonizethis_data/hidden_agenda_config.dart`.  
+- **Target-specific scoring:** When scoring declare-war, warmonger receives `getDeclareWarTargetBonusWeakerNeighbor` (+30) when target is in `snapshot.opportunities.weakNeighbors`; backstabber receives `getDeclareWarTargetBonusAlly` (+25) when target relation level is allied.  
+- **Movement filter:** `filterMoveOrdersByDiplomacy(game, playerId, orders)` in `order_suggestion.dart` drops moves to at-peace or minor-without-war destinations. Used by both simple heuristics and full-AI `_runMovePlanner`.  
+- **Movement prefer enemy:** Full-AI move planner scores filtered moves with `kMovePreferEnemyTerritoryBonus` (+20) when destination owner is at war with the mover; weighted random selection prefers enemy territory.
+
+---
+
 ## Summary table
 
 | # | Area | Status | Priority |
@@ -131,3 +145,4 @@ Tests in `perception_test.dart` cover threats (including neighbor/capital with t
 | 9 | Personality thresholds (war/peace/alliance/research) | Implemented | Medium |
 | 10 | Goal selection (weighted choice vs behavior tree) | Documented | Low |
 | 11 | OrderSuggestionAPI diplomatic | Implemented | High (for #7) |
+| 12 | War declaration / attack target (relation threshold; target-specific scoring; movement filter and prefer) | Implemented | Medium |

--- a/SPEC/ai/ai-architecture.md
+++ b/SPEC/ai/ai-architecture.md
@@ -44,6 +44,8 @@ Behavior trees pick top-level goals; utility AI scores and selects concrete obje
 ### Strategic Behavior Preferences
 AI uses the order suggestion API and applies:
 - **Movement:** Prefer contested or enemy territory (at war); avoid factions at peace.
+  - **Filter:** All AI paths (simple heuristics and full-AI domain planner) must drop move orders whose destination is owned by a faction at peace with the mover (or by a Minor with no war). No move into at-peace or minor-without-war territory.
+  - **Prefer enemy:** When choosing among valid move candidates, score moves into enemy (at-war) territory higher than moves into unowned or own territory; weighted selection then prefers enemy/contested. Default bonus +20 to score when destination owner is at war with the mover.
 - **Build/work:** Prefer cheaper orders improving owned, visible provinces.
 - **Research:** Prefer lower-era, cheaper techs unlocking core capabilities.
 - **Province identity:** Movement targets, build provinces, and visibility use the **prefixed** form `regionId|localId` per [world-model-identity.md](../game/world-model-identity.md).
@@ -71,4 +73,5 @@ AI order generation runs so that orders are available for the **Orders** phase o
 - **Turn pipeline:** AI emits orders that are merged with human orders in the Orders phase; phase sequence and application order per [turn-resolution-phases.md](../program/turn-resolution-phases.md), [turn-resolution-phase-details.md](../program/turn-resolution-phase-details.md).
 - **Goal selection and domains:** Behavior tree or weighted goal selection drives strategy; utility AI (economy, military, diplomacy, research) scores candidates; personality and hidden agendas bias selection per § Rules.
 - **Province identity:** Movement targets, build provinces, and visibility use prefixed form `regionId|localId` per [world-model-identity.md](../game/world-model-identity.md).
+- **Movement (filter and prefer):** Move orders are filtered by diplomacy (no move to at-peace or minor-without-war). Among valid moves, selection prefers moves into enemy/contested territory via configurable score bonus.
 - **Difficulty:** Difficulty affects starting parameters and ruleset modifiers only, not AI logic or personality.

--- a/SPEC/ai/hidden-agendas.md
+++ b/SPEC/ai/hidden-agendas.md
@@ -41,6 +41,8 @@ At game start, for each AI Great Power `P`:
 Agenda applies **additive or multiplicative modifiers** to the same quantities that personality uses:
 
 - **War declaration** — Warmonger: lower relation threshold to declare war; Peacemaker: strong negative modifier; Backstabber: bonus if target is ally.
+  - **Relation threshold:** AI only considers declaring war on a faction when relation score ≤ max score for that agenda. Default (base) 50; Warmonger 70 (more willing); Peacemaker 30 (only when hostile); Backstabber 100 (can declare on allies).
+  - **Target-specific scoring:** When scoring declare-war candidates, add bonus when target is a weaker neighbor (Warmonger) or when target is allied (Backstabber). Config: `declareWarTargetBonusWeakerNeighbor` (warmonger default +30), `declareWarTargetBonusAlly` (backstabber default +25).
 - **Peace acceptance** — Peacemaker: accept at lower war-score threshold; Warmonger: higher threshold.
 - **Alliance acceptance** — Isolationist: high decline chance; others unchanged or positive.
 - **Build/order choice** — Tech Thief: boost spy/research orders; Envy: boost orders that mirror human’s recent builds or targets.
@@ -69,6 +71,7 @@ When the game or AI performs an action, **evidence rules** (defined per agenda) 
 - **Assignment and immutability:** One agenda per AI; assigned at game start from `agendaSeed[P]` (derived from global game seed and `aiSeed[P]`). Stored in game state; no mid-game change.
 - **Determinism:** Same global game seed and `aiSeed[P]` yield the same agenda. Same observable actions yield the same evidence points (replay- and save/load-consistent).
 - **Behavior modifiers:** Each agenda type has defined effects in the spec categories: war declaration, peace acceptance, alliance acceptance, build/order choice, treaty breaking. Expressed as weights or thresholds in config.
+- **War declaration (relation threshold and target scoring):** Declare-war candidates are scored only when relation score ≤ agenda’s `declareWarMaxRelationScore` (default 50; warmonger 70; peacemaker 30). When scoring declare-war, warmonger receives bonus for target in weakNeighbors; backstabber receives bonus for allied target. Implementation uses config for thresholds and bonuses; diplomacy planner filters or zero-scores out-of-threshold declare-war and applies target bonuses.
 - **Evidence and suspicion:** Evidence rules add points per (observer nation, subject AI, agenda type). Suspicion bands (Unknown, Possible, Likely, Almost certain, Confirmed) map total evidence score; display uses bands only. True agenda is never exposed to the player. Evidence rule coverage: MVP (war declaration, peace offer, land/naval battle victory) is implemented; deferred (spy, alliance decline, treaty break, mirror-build) is documented and not in scope for MVP.
 - **Dossier contract:** Only suspicion scores and capped evidence log are exposed (PlayerView-safe). See [ai-dossier.md](ai-dossier.md) and [ai-events-and-dossier.md](../program/ai-events-and-dossier.md).
 

--- a/packages/colonizethis_ai/lib/src/domain_planners.dart
+++ b/packages/colonizethis_ai/lib/src/domain_planners.dart
@@ -95,6 +95,7 @@ Orders runDomainPlanners({
     game: game,
     topology: topology,
     orders: orders,
+    snapshot: snapshot,
     config: config,
     primaryGoal: primaryGoal,
     seeds: seeds,
@@ -147,6 +148,8 @@ Orders _runMovePlanner({
 }) {
   final moveCandidates = suggestionAPI.suggestMoveOrders(view, game, topology, orders);
   if (moveCandidates.isEmpty) return orders;
+  final filtered = filterMoveOrdersByDiplomacy(game, nationId, moveCandidates);
+  if (filtered.isEmpty) return orders;
   final domainWeights = getDomainWeightsForLeader(config.leaderId);
   final weight = primaryGoal == StrategicGoal.conquer || primaryGoal == StrategicGoal.defend
       ? domainWeights.military
@@ -154,11 +157,24 @@ Orders _runMovePlanner({
           ? domainWeights.economy
           : 50;
   if (weight < 20) return orders;
+  final provinceOwner = getProvinceOwnerMap(game);
+  final scores = filtered.map((m) {
+    final destOwner = provinceOwner[m.destinationProvinceId];
+    if (destOwner == null || destOwner == nationId) return 1.0;
+    final rel = getRelation(game, nationId, destOwner);
+    final atWar = rel != null && rel.atWar;
+    return 1.0 + (atWar ? kMovePreferEnemyTerritoryBonus.toDouble() : 0);
+  }).toList();
+  final total = scores.reduce((a, b) => a + b);
+  if (total <= 0) return orders;
   final rng = math.Random(seeds.militarySeed);
-  final cap = (moveCandidates.length.clamp(0, 5));
-  final take = cap > 0 ? 1 + rng.nextInt(cap) : 0;
-  if (take <= 0) return orders;
-  final selected = moveCandidates.take(take).toList();
+  var r = rng.nextDouble() * total;
+  var idx = 0;
+  for (; idx < filtered.length && r > scores[idx]; idx++) {
+    r -= scores[idx];
+  }
+  if (idx >= filtered.length) idx = filtered.length - 1;
+  final selected = [filtered[idx]];
   return _appendMoveOrders(orders, nationId, selected);
 }
 
@@ -313,6 +329,7 @@ Orders _runDiplomacyPlanner({
   required Game game,
   required MapTopology topology,
   required Orders orders,
+  required AIWorldSnapshot snapshot,
   required AIConfig config,
   required StrategicGoal primaryGoal,
   required AISeedBundle seeds,
@@ -331,6 +348,7 @@ Orders _runDiplomacyPlanner({
 
   final agendaId = config.hiddenAgendaId;
   final thresholds = getThresholdsForLeader(config.leaderId);
+  final maxRelationForDeclareWar = getDeclareWarMaxRelationScore(agendaId);
   final scores = diploCandidates.map((o) {
     var s = 50;
     switch (o.type) {
@@ -342,17 +360,31 @@ Orders _runDiplomacyPlanner({
         s += agendaAllianceAcceptanceModifier(agendaId);
         s += (thresholds.allianceTendency - 50);
         break;
-      case DiplomaticOrderType.declareWar:
-        s += agendaConquerModifier(agendaId);
-        s += agendaTreatyBreakingModifier(agendaId);
-        s += (thresholds.warLikelihood - 50);
+      case DiplomaticOrderType.declareWar: {
+        final rel = snapshot.relations[o.targetFactionId];
+        final relationScore = rel?.score ?? 50;
+        if (relationScore > maxRelationForDeclareWar) {
+          s = 0;
+        } else {
+          s += agendaConquerModifier(agendaId);
+          s += agendaTreatyBreakingModifier(agendaId);
+          s += (thresholds.warLikelihood - 50);
+          if (snapshot.opportunities.weakNeighbors.contains(o.targetFactionId)) {
+            s += getDeclareWarTargetBonusWeakerNeighbor(agendaId);
+          }
+          if (rel?.level == RelationLevel.allied) {
+            s += getDeclareWarTargetBonusAlly(agendaId);
+          }
+        }
         break;
+      }
       default:
         break;
     }
-    return math.max(1, s);
+    return s == 0 ? 0 : math.max(1, s);
   }).toList();
   final total = scores.reduce((a, b) => a + b);
+  if (total <= 0) return orders;
   final rng = math.Random(seeds.diplomacySeed);
   var r = rng.nextDouble() * total;
   var idx = 0;

--- a/packages/colonizethis_ai/test/domain_planners_test.dart
+++ b/packages/colonizethis_ai/test/domain_planners_test.dart
@@ -544,4 +544,271 @@ void main() {
       expect(build1, build2, reason: 'same seed and economyPlan should yield same build choice');
     });
   });
+
+  group('war declaration relation threshold and target scoring', () {
+    test('peacemaker scores declareWar 0 when relation above threshold so does not pick it when another candidate exists', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'A', isHuman: false, leaderKey: 'victoria'),
+          Player(id: 'gp2', displayName: 'B', isHuman: false),
+          Player(id: 'gp3', displayName: 'C', isHuman: false),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp2', score: 60, level: RelationLevel.neutral, state: RelationState.atPeace),
+          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp3', score: 20, level: RelationLevel.hostile, state: RelationState.atPeace),
+        ],
+      );
+      const topology = MapTopology(nodes: [], edges: []);
+      final view = buildPlayerView(game, topology, 'gp1');
+      final snapshot = AIWorldSnapshot.fromPlayerView(view);
+      const config = AIConfig(
+        leaderId: 'victoria',
+        personalityId: 'victoria',
+        hiddenAgendaId: 'peacemaker',
+      );
+      final seeds = AISeedBundle.fromTurnSeed(111);
+      const fakeApi = _FakeOrderSuggestionAPI(
+        work: [],
+        build: [],
+        move: [],
+        research: [],
+        navalMove: [],
+        navalMission: [],
+        diplomatic: [
+          DiplomaticOrder(type: DiplomaticOrderType.declareWar, targetFactionId: 'gp2'),
+          DiplomaticOrder(type: DiplomaticOrderType.declareWar, targetFactionId: 'gp3'),
+        ],
+      );
+      const economyPlan = EconomyPlan(productionAssignments: [], cargoPreference: CargoPreference.none);
+
+      final orders = runDomainPlanners(
+        game: game,
+        topology: topology,
+        nationId: 'gp1',
+        view: view,
+        snapshot: snapshot,
+        config: config,
+        primaryGoal: StrategicGoal.conquer,
+        seeds: seeds,
+        suggestionAPI: fakeApi,
+        economyPlan: economyPlan,
+      );
+
+      final diplo = orders.diplomaticOrdersByPlayerId['gp1'];
+      expect(diplo, isNotNull);
+      expect(diplo!.single.targetFactionId, 'gp3', reason: 'peacemaker max relation 30; gp2 has 60 so score 0; only gp3 has positive score');
+    });
+
+    test('warmonger gets bonus for weakNeighbors target', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'oldWorld|p1', regionId: 'oldWorld', ownerId: 'gp1'),
+              Province(id: 'oldWorld|p2', regionId: 'oldWorld', ownerId: 'gp2'),
+              Province(id: 'oldWorld|p3', regionId: 'oldWorld', ownerId: 'gp3'),
+            ],
+            units: [],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'A', isHuman: false, leaderKey: 'napoleon', militaryLevel: 3),
+          Player(id: 'gp2', displayName: 'B', isHuman: false, militaryLevel: 1),
+          Player(id: 'gp3', displayName: 'C', isHuman: false, militaryLevel: 5),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp2', score: 50, state: RelationState.atPeace),
+          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp3', score: 50, state: RelationState.atPeace),
+        ],
+      );
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 'p2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 'p3', regionId: 'oldWorld', type: TopologyNodeType.province),
+        ],
+        edges: const [
+          TopologyEdge(id1: 'p1', id2: 'p2'),
+          TopologyEdge(id1: 'p1', id2: 'p3'),
+        ],
+      );
+      final view = buildPlayerView(game, topology, 'gp1');
+      final snapshot = AIWorldSnapshot.fromPlayerView(view, topology: topology);
+      expect(snapshot.opportunities.weakNeighbors, contains('gp2'), reason: 'gp2 owns p2 adjacent to gp1 p1');
+      expect(snapshot.opportunities.weakNeighbors, contains('gp3'));
+      const config = AIConfig(
+        leaderId: 'napoleon',
+        personalityId: 'napoleon',
+        hiddenAgendaId: 'warmonger',
+      );
+      final seeds = AISeedBundle.fromTurnSeed(222);
+      const fakeApi = _FakeOrderSuggestionAPI(
+        work: [],
+        build: [],
+        move: [],
+        research: [],
+        navalMove: [],
+        navalMission: [],
+        diplomatic: [
+          DiplomaticOrder(type: DiplomaticOrderType.declareWar, targetFactionId: 'gp2'),
+        ],
+      );
+      const economyPlan = EconomyPlan(productionAssignments: [], cargoPreference: CargoPreference.none);
+
+      final orders = runDomainPlanners(
+        game: game,
+        topology: topology,
+        nationId: 'gp1',
+        view: view,
+        snapshot: snapshot,
+        config: config,
+        primaryGoal: StrategicGoal.conquer,
+        seeds: seeds,
+        suggestionAPI: fakeApi,
+        economyPlan: economyPlan,
+      );
+
+      final diplo = orders.diplomaticOrdersByPlayerId['gp1'];
+      expect(diplo, isNotNull);
+      expect(diplo!.single.type, DiplomaticOrderType.declareWar);
+      expect(diplo.single.targetFactionId, 'gp2', reason: 'only candidate is gp2 (weak neighbor); warmonger applies +30 bonus');
+    });
+
+    test('backstabber prefers allied target when it is the only declare-war candidate', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'A', isHuman: false, leaderKey: 'napoleon'),
+          Player(id: 'gp2', displayName: 'B', isHuman: false),
+          Player(id: 'gp3', displayName: 'C', isHuman: false),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp2', score: 80, level: RelationLevel.allied, state: RelationState.atPeace),
+          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp3', score: 50, level: RelationLevel.neutral, state: RelationState.atPeace),
+        ],
+      );
+      const topology = MapTopology(nodes: [], edges: []);
+      final view = buildPlayerView(game, topology, 'gp1');
+      final snapshot = AIWorldSnapshot.fromPlayerView(view);
+      const config = AIConfig(
+        leaderId: 'napoleon',
+        personalityId: 'napoleon',
+        hiddenAgendaId: 'backstabber',
+      );
+      final seeds = AISeedBundle.fromTurnSeed(333);
+      const fakeApi = _FakeOrderSuggestionAPI(
+        work: [],
+        build: [],
+        move: [],
+        research: [],
+        navalMove: [],
+        navalMission: [],
+        diplomatic: [
+          DiplomaticOrder(type: DiplomaticOrderType.declareWar, targetFactionId: 'gp2'),
+        ],
+      );
+      const economyPlan = EconomyPlan(productionAssignments: [], cargoPreference: CargoPreference.none);
+
+      final orders = runDomainPlanners(
+        game: game,
+        topology: topology,
+        nationId: 'gp1',
+        view: view,
+        snapshot: snapshot,
+        config: config,
+        primaryGoal: StrategicGoal.conquer,
+        seeds: seeds,
+        suggestionAPI: fakeApi,
+        economyPlan: economyPlan,
+      );
+
+      final diplo = orders.diplomaticOrdersByPlayerId['gp1'];
+      expect(diplo, isNotNull);
+      expect(diplo!.single.type, DiplomaticOrderType.declareWar);
+      expect(diplo.single.targetFactionId, 'gp2', reason: 'only candidate is gp2 (allied); backstabber applies +25 bonus');
+    });
+  });
+
+  group('move planner diplomacy filter', () {
+    test('full-AI move planner drops moves to at-peace destinations', () {
+      const ow = 'oldWorld';
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'p1', regionId: ow, ownerId: 'gp1'),
+              Province(id: 'p2', regionId: ow, ownerId: 'gp2'),
+              Province(id: 'p3', regionId: ow, ownerId: 'gp3'),
+            ],
+            units: [],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'A', isHuman: false, leaderKey: 'napoleon'),
+          Player(id: 'gp2', displayName: 'B', isHuman: false),
+          Player(id: 'gp3', displayName: 'C', isHuman: false),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp2', score: 0, state: RelationState.atWar),
+          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp3', score: 50, state: RelationState.atPeace),
+        ],
+      );
+      const topology = MapTopology(nodes: [], edges: []);
+      final view = buildPlayerView(game, topology, 'gp1');
+      final snapshot = AIWorldSnapshot.fromPlayerView(view);
+      const config = AIConfig(
+        leaderId: 'napoleon',
+        personalityId: 'napoleon',
+        hiddenAgendaId: 'warmonger',
+      );
+      final seeds = AISeedBundle.fromTurnSeed(444);
+      const fakeApi = _FakeOrderSuggestionAPI(
+        work: [],
+        build: [],
+        move: [
+          MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|p2'),
+          MoveOrder(unitId: 'u2', destinationProvinceId: 'oldWorld|p3'),
+        ],
+        research: [],
+        navalMove: [],
+        navalMission: [],
+        diplomatic: [],
+      );
+      const economyPlan = EconomyPlan(productionAssignments: [], cargoPreference: CargoPreference.none);
+
+      final orders = runDomainPlanners(
+        game: game,
+        topology: topology,
+        nationId: 'gp1',
+        view: view,
+        snapshot: snapshot,
+        config: config,
+        primaryGoal: StrategicGoal.conquer,
+        seeds: seeds,
+        suggestionAPI: fakeApi,
+        economyPlan: economyPlan,
+      );
+
+      final moves = orders.moveOrdersByPlayerId['gp1'] ?? [];
+      expect(moves.length, 1, reason: 'move to gp3 at peace should be filtered out');
+      expect(moves.single.destinationProvinceId, 'oldWorld|p2');
+    });
+  });
 }

--- a/packages/colonizethis_data/lib/src/hidden_agenda_config.dart
+++ b/packages/colonizethis_data/lib/src/hidden_agenda_config.dart
@@ -53,6 +53,29 @@ const Map<String, int> agendaTreatyBreakingModifiers = {
   'warmonger': 20,
 };
 
+/// Max relation score (0–100) below or equal to which declare-war is considered.
+/// Warmonger: 70 (declare even when friendlier); Peacemaker: 30 (only when hostile); default 50.
+/// SPEC/ai/hidden-agendas.md war declaration relation threshold.
+const Map<String, int> declareWarMaxRelationScoreByAgenda = {
+  'warmonger': 70,
+  'peacemaker': 30,
+  'backstabber': 100,
+};
+const int kDeclareWarMaxRelationScoreDefault = 50;
+
+/// Bonus added to declare-war candidate score when target is a weaker neighbor (Warmonger). SPEC/ai/hidden-agendas.md.
+const Map<String, int> declareWarTargetBonusWeakerNeighborByAgenda = {
+  'warmonger': 30,
+};
+
+/// Bonus added to declare-war candidate score when target is allied (Backstabber). SPEC/ai/hidden-agendas.md.
+const Map<String, int> declareWarTargetBonusAllyByAgenda = {
+  'backstabber': 25,
+};
+
+/// Score bonus when scoring a move whose destination is owned by a faction at war with the mover. SPEC/ai/ai-architecture.md.
+const int kMovePreferEnemyTerritoryBonus = 20;
+
 /// Spy-type work order modifier (positive = more likely to pick steal_tech / counter_spy).
 /// SPEC: tech_thief "high spy usage". Used when spy work candidates exist; no effect if no spy order type.
 const Map<String, int> agendaSpyOrderModifiers = {
@@ -92,6 +115,21 @@ int getAgendaAllianceAcceptanceModifier(String agendaId) {
 /// Returns modifier for treaty/peace breaking (positive = more likely to declare war or break treaties).
 int getAgendaTreatyBreakingModifier(String agendaId) {
   return agendaTreatyBreakingModifiers[agendaId] ?? 0;
+}
+
+/// Returns max relation score (≤) for which declare-war is considered for this agenda.
+int getDeclareWarMaxRelationScore(String agendaId) {
+  return declareWarMaxRelationScoreByAgenda[agendaId] ?? kDeclareWarMaxRelationScoreDefault;
+}
+
+/// Returns bonus to declare-war score when target is a weaker neighbor.
+int getDeclareWarTargetBonusWeakerNeighbor(String agendaId) {
+  return declareWarTargetBonusWeakerNeighborByAgenda[agendaId] ?? 0;
+}
+
+/// Returns bonus to declare-war score when target is allied.
+int getDeclareWarTargetBonusAlly(String agendaId) {
+  return declareWarTargetBonusAllyByAgenda[agendaId] ?? 0;
 }
 
 /// Returns modifier for spy-type work orders (positive = more likely to pick steal_tech / counter_spy).

--- a/packages/colonizethis_data/test/hidden_agenda_config_test.dart
+++ b/packages/colonizethis_data/test/hidden_agenda_config_test.dart
@@ -150,4 +150,37 @@ void main() {
       expect(getAgendaSpyOrderModifier('warmonger'), 0);
     });
   });
+
+  group('getDeclareWarMaxRelationScore', () {
+    test('returns 70 for warmonger', () {
+      expect(getDeclareWarMaxRelationScore('warmonger'), 70);
+    });
+    test('returns 30 for peacemaker', () {
+      expect(getDeclareWarMaxRelationScore('peacemaker'), 30);
+    });
+    test('returns 100 for backstabber', () {
+      expect(getDeclareWarMaxRelationScore('backstabber'), 100);
+    });
+    test('returns default 50 for unknown', () {
+      expect(getDeclareWarMaxRelationScore('tech_thief'), kDeclareWarMaxRelationScoreDefault);
+    });
+  });
+
+  group('getDeclareWarTargetBonusWeakerNeighbor', () {
+    test('returns 30 for warmonger', () {
+      expect(getDeclareWarTargetBonusWeakerNeighbor('warmonger'), 30);
+    });
+    test('returns 0 for others', () {
+      expect(getDeclareWarTargetBonusWeakerNeighbor('peacemaker'), 0);
+    });
+  });
+
+  group('getDeclareWarTargetBonusAlly', () {
+    test('returns 25 for backstabber', () {
+      expect(getDeclareWarTargetBonusAlly('backstabber'), 25);
+    });
+    test('returns 0 for others', () {
+      expect(getDeclareWarTargetBonusAlly('warmonger'), 0);
+    });
+  });
 }

--- a/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
+++ b/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
@@ -38,26 +38,6 @@ enum _SuggestionCategory {
   research,
 }
 
-/// Builds a map from full province id (regionId|localId) to owner faction id.
-/// Keys must match [MoveOrder.destinationProvinceId] format from the order
-/// suggestion API (SPEC/game/world-model-identity.md).
-Map<String, String> _provinceOwnerMap(Game game) {
-  final out = <String, String>{};
-  for (final p in game.worldState.oldWorld.provinces) {
-    if (p.ownerId != null && p.ownerId!.isNotEmpty) {
-      final key = ProvinceId.full(p.regionId, ProvinceId.localIdFrom(p.id));
-      out[key] = p.ownerId!;
-    }
-  }
-  for (final p in game.worldState.newWorld.provinces) {
-    if (p.ownerId != null && p.ownerId!.isNotEmpty) {
-      final key = ProvinceId.full(p.regionId, ProvinceId.localIdFrom(p.id));
-      out[key] = p.ownerId!;
-    }
-  }
-  return out;
-}
-
 /// Generates orders for a single player using the shared simple heuristics:
 /// PlayerView, order suggestion API, category order (move → work → build →
 /// research), seeded random choice within category, and diplomacy post-filter.
@@ -73,7 +53,6 @@ Orders generateOrdersWithSimpleHeuristics(
     return const Orders();
   }
 
-  final provinceOwner = _provinceOwnerMap(game);
   final rng = math.Random(turnSeed);
   var current = const Orders();
   final view = buildPlayerView(game, topology, player.id);
@@ -187,24 +166,7 @@ Orders generateOrdersWithSimpleHeuristics(
 
   final rawMoves = current.moveOrdersByPlayerId[player.id];
   if (rawMoves != null && rawMoves.isNotEmpty) {
-    final filtered = <MoveOrder>[];
-    for (final m in rawMoves) {
-      final destOwner = provinceOwner[m.destinationProvinceId];
-      if (destOwner == null || destOwner == player.id) {
-        filtered.add(m);
-        continue;
-      }
-      final rel = getRelation(game, player.id, destOwner);
-      if (rel != null && rel.atPeace) {
-        continue;
-      }
-      if (rel == null) {
-        final isMinor =
-            game.minorNations.any((mn) => mn.id == destOwner);
-        if (isMinor) continue;
-      }
-      filtered.add(m);
-    }
+    final filtered = filterMoveOrdersByDiplomacy(game, player.id, rawMoves);
     if (filtered.isNotEmpty) {
       moveByPlayer[player.id] = filtered;
     }

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -11,6 +11,51 @@ import '../world/player_view.dart';
 
 final Logger _log = Logger();
 
+/// Builds a map from full province id (regionId|localId) to owner faction id.
+/// Used by AI to filter move orders by diplomacy. SPEC/ai/ai-architecture.md.
+Map<String, String> getProvinceOwnerMap(Game game) {
+  final out = <String, String>{};
+  for (final p in game.worldState.oldWorld.provinces) {
+    if (p.ownerId != null && p.ownerId!.isNotEmpty) {
+      final key = ProvinceId.full(p.regionId, ProvinceId.localIdFrom(p.id));
+      out[key] = p.ownerId!;
+    }
+  }
+  for (final p in game.worldState.newWorld.provinces) {
+    if (p.ownerId != null && p.ownerId!.isNotEmpty) {
+      final key = ProvinceId.full(p.regionId, ProvinceId.localIdFrom(p.id));
+      out[key] = p.ownerId!;
+    }
+  }
+  return out;
+}
+
+/// Filters move orders to those allowed by diplomacy: no move into province of
+/// a faction at peace with [playerId], or into Minor territory without war.
+/// SPEC/ai/ai-architecture.md movement filter.
+List<MoveOrder> filterMoveOrdersByDiplomacy(
+  Game game,
+  String playerId,
+  List<MoveOrder> orders,
+) {
+  final provinceOwner = getProvinceOwnerMap(game);
+  final filtered = <MoveOrder>[];
+  for (final m in orders) {
+    final destOwner = provinceOwner[m.destinationProvinceId];
+    if (destOwner == null || destOwner == playerId) {
+      filtered.add(m);
+      continue;
+    }
+    final rel = getRelation(game, playerId, destOwner);
+    if (rel != null && rel.atPeace) continue;
+    if (rel == null) {
+      if (game.minorNations.any((mn) => mn.id == destOwner)) continue;
+    }
+    filtered.add(m);
+  }
+  return filtered;
+}
+
 /// Suggests candidate move orders that are information-legal (per [PlayerView])
 /// and rules-legal (per [OrderEngine]) for [view.playerId].
 List<MoveOrder> suggestMoveOrders(

--- a/packages/colonizethis_logic/test/order_suggestion_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_test.dart
@@ -562,5 +562,90 @@ void main() {
       expect(suggestions, isA<List<NavalMissionOrder>>());
     });
   });
+
+  group('filterMoveOrdersByDiplomacy and getProvinceOwnerMap', () {
+    test('getProvinceOwnerMap returns owner by full province id', () {
+      const ow = 'oldWorld';
+      final p1 = Province(id: 'p1', regionId: ow, ownerId: 'gp1');
+      final p2 = Province(id: 'p2', regionId: ow, ownerId: 'gp2');
+      final world = WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: RegionData(provinces: [p1, p2], units: []),
+        newWorld: const RegionData(),
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: world,
+        players: const [
+          Player(id: 'gp1', displayName: 'A', isHuman: false),
+          Player(id: 'gp2', displayName: 'B', isHuman: false),
+        ],
+      );
+      final map = getProvinceOwnerMap(game);
+      expect(map['oldWorld|p1'], 'gp1');
+      expect(map['oldWorld|p2'], 'gp2');
+    });
+
+    test('filterMoveOrdersByDiplomacy drops move to at-peace faction', () {
+      const ow = 'oldWorld';
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'p1', regionId: ow, ownerId: 'gp1'),
+              Province(id: 'p2', regionId: ow, ownerId: 'gp2'),
+            ],
+            units: [],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'A', isHuman: false),
+          Player(id: 'gp2', displayName: 'B', isHuman: false),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp2', score: 50, state: RelationState.atPeace),
+        ],
+      );
+      final orders = [
+        MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|p2'),
+      ];
+      final filtered = filterMoveOrdersByDiplomacy(game, 'gp1', orders);
+      expect(filtered, isEmpty, reason: 'move to gp2 at peace should be dropped');
+    });
+
+    test('filterMoveOrdersByDiplomacy keeps move to at-war faction', () {
+      const ow = 'oldWorld';
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'p1', regionId: ow, ownerId: 'gp1'),
+              Province(id: 'p2', regionId: ow, ownerId: 'gp2'),
+            ],
+            units: [],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'A', isHuman: false),
+          Player(id: 'gp2', displayName: 'B', isHuman: false),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp2', score: 0, state: RelationState.atWar),
+        ],
+      );
+      final orders = [
+        MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|p2'),
+      ];
+      final filtered = filterMoveOrdersByDiplomacy(game, 'gp1', orders);
+      expect(filtered.length, 1);
+      expect(filtered.first.destinationProvinceId, 'oldWorld|p2');
+    });
+  });
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -428,10 +428,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
Implements ISSUE_AI_SPEC_GAPS.md item 12: war declaration relation threshold, target-specific scoring (warmonger weaker neighbor, backstabber allied), and movement filter + prefer enemy territory.

## Spec and defaults
- **SPEC/ai/hidden-agendas.md**: Relation threshold for declare-war (default 50; warmonger 70; peacemaker 30; backstabber 100). Target bonuses: warmonger +30 weaker neighbor, backstabber +25 allied. AC updated.
- **SPEC/ai/ai-architecture.md**: Movement filter (no move to at-peace/minor-without-war) and prefer enemy territory (+20 score bonus). AC updated.

## Config (colonizethis_data)
- `declareWarMaxRelationScoreByAgenda`, `kDeclareWarMaxRelationScoreDefault`
- `declareWarTargetBonusWeakerNeighborByAgenda`, `declareWarTargetBonusAllyByAgenda`
- `kMovePreferEnemyTerritoryBonus`
- Getters for all of the above.

## Implementation
- **order_suggestion**: `getProvinceOwnerMap()`, `filterMoveOrdersByDiplomacy()`
- **simple_ai_heuristics**: uses shared filter instead of inline loop
- **domain_planners**: diplomacy planner applies relation threshold (score 0 when above max) and target bonuses (weakNeighbors, allied). Move planner filters by diplomacy and scores by prefer-enemy; single weighted random pick.

## Tests
- order_suggestion_test: getProvinceOwnerMap, filterMoveOrdersByDiplomacy
- hidden_agenda_config_test: new getters and backstabber max relation
- domain_planners_test: peacemaker relation threshold, warmonger weakNeighbor, backstabber allied, full-AI move filter

## Gaps doc
`.github/ISSUE_AI_SPEC_GAPS.md`: section 12 marked **Implemented**.

Made with [Cursor](https://cursor.com)