### PR TITLE
feat(tui): ctterm stub app with main menu and full navigation stubs

### DIFF
--- a/.cursor/rules/colonizethis-tui.mdc
+++ b/.cursor/rules/colonizethis-tui.mdc
@@ -1,0 +1,15 @@
+---
+description: TUI (ctterm) source of truth, Nocterm usage, and TUI-specific conventions.
+globs: "SPEC/tui/**", "ctterm/**"
+alwaysApply: false
+---
+
+# TUI (ctterm) Rules
+
+- **Source of truth:** [SPEC/tui/ctterm.md](SPEC/tui/ctterm.md) and SPEC/tui/screens/ define behaviour, layout, and navigation. Implement only what specs describe.
+- **Acceptance criteria:** All TUI AC MUST be Given–When–Then; include TUI-specific cases (e.g. terminal size 80×24).
+- **Keyboard-first:** Input is keyboard-first; touch optional per Nocterm docs. No swipe/gesture requirement for MVP.
+- **Nocterm:** Use Nocterm for all TUI components. Detect terminal size and resize elements responsively. Reference: <https://docs.nocterm.dev/docs>.
+- **Logging:** Use Dart `logger` with prefixes `tui:*` (e.g. `tui:`, `tui:menu:`, `tui:save:`, `tui:nav:`, `tui:map:`, `tui:event:`). No `print` for operational output.
+- **Province identity:** Always use prefixed province id (`regionId|localId`) or (regionId, provinceId); never province id alone. See SPEC/game/world-model-identity.md.
+- **No Flutter in ctterm:** ctterm is pure Dart; no Flutter SDK dependency. Use `dart:io` and `path` for storage paths (e.g. Hive data dir).

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -24,6 +24,7 @@ jobs:
           filters: |
             tests:
               - 'packages/**'
+              - 'ctterm/**'
               - 'tool/sim_scenarios/**'
               - 'tool/sim_combat_montecarlo/**'
               - 'tool/sim_combat/**'
@@ -70,6 +71,17 @@ jobs:
             (cd "$dir" && dart test --coverage=coverage -j 4 --reporter=compact)
             (cd "$dir" && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
           done
+
+      - name: Test ctterm (Dart)
+        if: steps.changes.outputs.tests == 'true'
+        env:
+          SUPPRESS_IMAGE_VIEWER: "1"
+        run: |
+          set -e
+          if [ -d ctterm/test ]; then
+            (cd ctterm && dart test --coverage=coverage -j 4 --reporter=compact)
+            (cd ctterm && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
+          fi
 
       - name: Test tool packages (Dart)
         if: steps.changes.outputs.tests == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Apply these when working in the indicated areas (by path or topic).
 | **colonizethis-code-review.mdc** | `**/*.dart` | Checklist: function &lt; 20 lines, widget &lt; ~60 lines, no UI+logic mix, constants for strings, explicit types, spec alignment, logging, reuse, tests. |
 | **colonizethis-lifecycle.mdc** | `**/*.dart` | Flame: `onLoad` (init), `onMount`/`onRemove` (subscribe/cleanup), `update`/`render` (tick/paint). Flutter: `initState`/`dispose`. |
 | **colonizethis-assets.mdc** | `**/*.dart`, `**/pubspec.yaml`, `**/assets/**` | Asset dirs: `assets/images/`, `assets/audio/`, `assets/data/`. Snake_case naming. Load in Flame `onLoad()`; use caches. |
+| **colonizethis-tui.mdc** | `SPEC/tui/**`, `ctterm/**` | TUI (ctterm): SPEC/tui and ctterm.md source of truth; Given–When–Then for TUI AC; keyboard-first; Nocterm; log prefixes `tui:*`; province identity (prefixed id); no Flutter in ctterm. |
 
 ## Quick reference for agents
 

--- a/SPEC/program/game-events.md
+++ b/SPEC/program/game-events.md
@@ -1,0 +1,75 @@
+# Game Events — Shared Event Stream
+
+**SPEC/program** — Contract for game events emitted during or after turn resolution and on order validation. Consumed by Flutter app and ctterm so users are clearly notified what is happening. Province identity: [world-model-identity.md](../game/world-model-identity.md).
+
+---
+
+## Responsibility
+
+Define the **contract** of the game event stream: event types, payload shapes, emission points, and determinism. No UI-specific fields in events; consumers (app, ctterm) map events to notifications and UI. Implementation lives in colonizethis_logic (or a shared layer); TurnResolver and OrderEngine (or their caller) emit events.
+
+---
+
+## Purpose
+
+A single event stream for "what happened in the game" consumable by any client (Flutter app, ctterm). Enables status lines, logs, overlays, and notification feeds without each consumer parsing raw resolution output.
+
+---
+
+## Event types (contract)
+
+Events are a union or sealed type (e.g. `GameEvent`) with variants. Payloads use keys/ids only; no UI strings. Province ids in any payload are **prefixed** (`regionId|localId`) per [world-model-identity.md](../game/world-model-identity.md).
+
+| Event type           | When emitted                    | Payload (minimal) |
+|----------------------|----------------------------------|-------------------|
+| `combat_result`      | After Combat phase              | provinceId (prefixed), attackerId, defenderId, winnerId, casualties (or summary). |
+| `province_captured`  | When province owner changes     | provinceId (prefixed), previousOwnerId, newOwnerId, turnNumber. |
+| `diplomacy_change`   | After Diplomacy phase           | actorId, targetId, changeType (e.g. war, peace, alliance), turnNumber. |
+| `research_complete`   | When a tech is researched      | playerId, techId, turnNumber. |
+| `victory_set`        | End-of-turn when victory set    | winnerPlayerId, victoryType, turnNumber. See [victory.md](../game/victory.md). |
+| `order_rejected`     | On validation failure          | playerId, orderSummaryOrId, reasonCode (e.g. insufficient_treasury, invalid_destination). |
+
+Additional event types (e.g. naval_combat_result, extraction_summary) may be added in the same format. Dialogue and mood ([ai-events-and-dossier.md](ai-events-and-dossier.md)) may be a separate channel or folded into this stream; the emitter guarantees a single, ordered stream per game/turn so consumers can present a chronological feed.
+
+---
+
+## Emission points
+
+- **Turn resolution:** During or immediately after each phase in [turn-resolution-phase-details.md](turn-resolution-phase-details.md) (Combat → combat_result, province_captured; Diplomacy → diplomacy_change; Research → research_complete; End-of-turn → victory_set when applicable). Caller or TurnResolver pushes events in phase order.
+- **Order validation:** When [order-engine.md](order-engine.md) validates and rejects an order, an `order_rejected` event is emitted (or the validation layer emits it so that UI and ctterm can show the reason).
+
+The **caller** that owns the order list or invokes TurnResolver is responsible for wiring the event stream to the resolver/engine so that events are emitted in a deterministic order. Same game state and seeds produce the same event sequence (replay and save/load compatibility).
+
+---
+
+## Determinism
+
+- Same initial WorldState, orders, ruleset, and random seeds → same sequence of GameEvents for that turn.
+- Events are emitted in a fixed order (e.g. phase order, then within phase by a defined ordering). No nondeterministic batching or reordering.
+- Replay and save/load must reproduce or recompute the same events from persisted state when the turn is re-resolved.
+
+---
+
+## Acceptance criteria (Given–When–Then)
+
+- **Emission — combat_result.** Given a turn resolution run in which the Combat phase resolves a battle in province P with a winner, when the Combat phase completes, then the system emits exactly one `combat_result` event with provinceId in prefixed form, and the payload includes winnerId and at least one of attackerId or defenderId consistent with the resolved battle.
+- **Emission — victory_set.** Given a turn resolution run in which the End-of-turn phase sets `Game.victory` (winner, type military, turn number), when the End-of-turn phase completes, then the system emits exactly one `victory_set` event with winnerPlayerId, victoryType, and turnNumber equal to the game’s victory state.
+- **Emission — order_rejected.** Given the order engine validates a player’s order list and the first rejection occurs at order N with reason R, when validation returns, then the system has emitted an `order_rejected` event for that order with a reasonCode consistent with R (or the validation layer exposes the same so that a consumer can emit the event).
+- **Determinism.** Given the same Game (and WorldState), same per-player order lists, same ruleset, and same seeds, when the system runs turn resolution and order validation, then the sequence of GameEvents emitted for that run is identical to any other run with the same inputs.
+- **Province identity.** Given any GameEvent that carries a province id, when the event is emitted, then that id is in prefixed form (`regionId|localId`) per [world-model-identity.md](../game/world-model-identity.md).
+
+---
+
+## Integration
+
+- **Upstream:** [turn-resolution-phase-details.md](turn-resolution-phase-details.md), [order-engine.md](order-engine.md), [victory.md](../game/victory.md). Emission is implemented in or alongside colonizethis_logic.
+- **Downstream:** Flutter app, ctterm. Both subscribe to the same stream and present events (e.g. status line, scrollable log, overlay). [SPEC/tui/ctterm.md](../tui/ctterm.md) § UI – game logic – event communication architecture.
+- **Dialogue/mood:** [ai-events-and-dossier.md](ai-events-and-dossier.md) defines DialogueEvent and PortraitMoodEvent. Whether they are part of this stream or a separate channel is an implementation choice; if separate, ctterm and app may subscribe to both for a unified feed.
+
+---
+
+## Constraints
+
+- No asset paths or UI-only strings in event payloads.
+- Province ids in payloads are always prefixed; never bare local id.
+- Event order is part of the contract; consumers may rely on chronological order for display.

--- a/SPEC/program/repo-and-packages.md
+++ b/SPEC/program/repo-and-packages.md
@@ -8,8 +8,9 @@
 
 Monorepo layout:
 
-- **Root:** `SPEC/`, `packages/`, `app/`, optional `assets/`, **`tool/`** (standalone CLI tools), tooling (e.g. `analysis_options.yaml`).
+- **Root:** `SPEC/`, `packages/`, `app/`, **`ctterm/`**, optional `assets/`, **`tool/`** (standalone CLI tools), tooling (e.g. `analysis_options.yaml`).
 - **Flutter app** lives under **`app/`** (not at root). Run and build from `app/` (e.g. `flutter run`, `flutter build macos`). Package work is done in `packages/<name>/`.
+- **ctterm** lives at top-level **`ctterm/`** — standalone Dart TUI (Nocterm). Run via `dart run ctterm` or `melos run ctterm`. Uses its own Hive data directory; see [SPEC/tui/ctterm.md](../tui/ctterm.md).
 - **Standalone CLI tools** (e.g. topology description, map generation) live under **`tool/`**. Run from the **project root** via **Melos**: `melos run <tool_name> -- [args]` (paths in args are relative to repo root). The repo uses a root Dart workspace and Melos for scripts; see [.cursor/rules/colonizethis-tools.mdc](../../.cursor/rules/colonizethis-tools.mdc). Tools may depend on colonizethis_data or a shared reader to load topology.
 - **No `server/`** in current scope.
 

--- a/SPEC/tui/ctterm.md
+++ b/SPEC/tui/ctterm.md
@@ -1,0 +1,167 @@
+# ctterm — Terminal UI (Nocterm)
+
+**SPEC/tui** — Full single-player ColonizeThis experience via a terminal UI. Cross-references only to SPEC; concepts from UXD/GDD/TDD are copied in where required.
+
+---
+
+## 1. High-level UI flow
+
+### Entry
+
+App start → **Main Menu** (ctterm equivalent of UXD 03a). The Main Menu is the first screen shown (except possibly a splash/logo). The menu shows at least: **New Game**, **Load Game**, **Settings**, and **Quit** (or platform-appropriate equivalent). Source: [SPEC/ui/main-menu.md](../ui/main-menu.md).
+
+### Flows
+
+- **Main Menu** → **New Game** → Game Setup (03b) → Generating world → In-game shell.
+- **Main Menu** → **Load Game** → save list (same as 03b: save label, turn, year, GP, last played; no user-editable names for MVP) → Load → In-game shell.
+- **Main Menu** → **Settings** → TUI-only options (terminal theme only for now) → return to Main Menu.
+- **In-game shell** → Pause/Options → Exit to Main Menu (clear in-memory state).
+- **In-game shell** → End of turn with victory → Victory Screen (03l) or **Defeat Screen** (new).
+
+If at least one save exists, **Load Game** is enabled; if none exist, it is disabled with an explanatory tooltip or helper text. Clicking or tapping **New Game** navigates to the Game Setup screen (03b), not directly into play. Clicking or tapping **Load Game** navigates to the Load Game list (03b). Clicking or tapping **Settings** opens the Settings UI (03c) and closing it returns to the Main Menu. From a running game, choosing "Exit to Main Menu" (from pause/options) returns to this screen and clears in-memory game state.
+
+### Victory vs Defeat
+
+Victory condition and check are defined in [SPEC/game/victory.md](../game/victory.md): a Great Power controls **31 or more Old World provinces**; control means the province’s `ownerId` equals that GP’s player id. Province identity and counting use prefixed province id (`regionId|localId`) and region-scoped lookup per [world-model-identity.md](../game/world-model-identity.md). Victory is evaluated once per turn during the End-of-turn phase, after all other phases have run. If `Game.victory` is already set, the check does not overwrite it. When two or more GPs each have ≥31 OW provinces in the same turn, the winner is the one with the lexicographically smallest player id.
+
+- When `Game.victory != null` and the winner **is** the human player: show **Victory screen** (winner’s display name, victory type label e.g. "Military victory", turn number; actions: Return to main menu, View final state). No further orders or turn advancement once victory is set.
+- When `Game.victory != null` and the winner is **not** the human player: show **Defeat screen**. Content: "You have been defeated", winner’s display name, victory type label, final standings. Actions: View Final Map, Return to Main Menu. No further orders or turn advancement.
+
+After a victory or defeat, pressing "Return to Main Menu" returns to the Main Menu. When returning from in-game or from Victory/Defeat screen, the shell clears in-memory game state as needed.
+
+### Screens in the flow
+
+- Main Menu, Game Setup, Load Game, Generating World, Settings
+- In-game shell (map + HUD + empire sidebar + context panel)
+- Units, Development, Production, Academy, Shipyard, Diplomacy, Technology, Victory/Progress panels
+- Victory screen, Defeat screen, Pause/Options
+
+Cross-references: [SPEC/ui/main-menu.md](../ui/main-menu.md), [SPEC/ui/game-setup.md](../ui/game-setup.md), [SPEC/game/victory.md](../game/victory.md), [SPEC/program/save-load.md](../program/save-load.md), [SPEC/program/game-setup-pipeline.md](../program/game-setup-pipeline.md).
+
+---
+
+## 2. TUI design conventions
+
+### Framework
+
+ctterm uses **Nocterm** (Dart, Flutter-like TUI). Reference: <https://docs.nocterm.dev/docs>. ctterm is the first consumer in-repo; no Nocterm-based code exists elsewhere yet.
+
+### Input
+
+**Keyboard-first.** Some UI elements may support touch per Nocterm docs (e.g. list selection). No swipe or gesture requirement for MVP.
+
+### Terminal theme
+
+Only TUI-specific setting for now: terminal theme (e.g. light/dark or palette name). The Settings screen is adapted to TUI-only options; no audio or graphics options from 03c.
+
+### Smartphone form factor
+
+Layouts must work on small terminals (e.g. Termux, Termius). Constraints: narrow width, limited lines, scrollable content; panels are stacked or cycled rather than side-by-side where the UXD uses a sidebar and right panel. Minimum target size for interactive elements: in terminal terms, use a minimum selectable row height or key spacing so that actions are reliably activatable (UXD 03 specifies 44dp minimum for touch; ctterm adapts this for character cells and keyboard).
+
+### Map (ASCII/Unicode art)
+
+- **TUI mapping:** Ctterm defines its own TUI-specific mapping from map/PlayerView data to terminal display (terrain, ownership → characters/styles). See [SPEC/tui/map-tui-mapping.md](map-tui-mapping.md). Base map layer uses the same information as [SPEC/program/map-visualization.md](../program/map-visualization.md); ctterm is a consumer.
+- **Layers:** Multiple layers for terrain, towns, province ownership, and other data. Do not cram all information into one layer. Data source for ownership, capitals, ports, and visibility: [SPEC/program/map-visualization.md](../program/map-visualization.md), [SPEC/program/player-view.md](../program/player-view.md).
+- **Visibility:** Respect per-player visibility. Map rendering for the human player uses the same rules as PlayerView: fog, revealed, fully visible. PlayerView is the channel for information from the map; visibility is taken from the game’s visibility state (e.g. `WorldState.playerVisibilityByTile`). See [SPEC/program/player-view.md](../program/player-view.md).
+- **Identity:** Province and tile keys follow [SPEC/game/world-model-identity.md](../game/world-model-identity.md) (prefixed province id, tile key format `regionId|localId|x|y`). Logic must never locate a province by province id alone.
+- **Smartphone map:** Provide a way to scroll the map and/or cycle between regions (e.g. Old World / New World) so the full map is usable on a small terminal.
+
+### Acceptance criteria format
+
+All ctterm acceptance criteria MUST be written as **Given–When–Then** per project rules. Include TUI-specific cases where applicable (e.g. "Given the terminal is 80×24, when the user opens the Units panel, then the panel is shown and the map remains in the shell.").
+
+---
+
+## 3. UI – game logic – event communication architecture
+
+### Shared event stream
+
+A **game event stream** is consumed by all clients (Flutter app, ctterm). Its contract is defined in [SPEC/program/game-events.md](../program/game-events.md). Events are emitted during or after turn resolution and on order validation (e.g. combat result, province captured, diplomacy change, research complete, victory/defeat, order rejected). No UI-specific fields in events; consumers (app, ctterm) map events to notifications and UI.
+
+### ctterm subscription
+
+ctterm subscribes to the same game event stream. A notifications/event feed in the TUI (e.g. status line, scrollable log, or overlay) displays events to the user so they are clearly notified what is happening. Emission points and determinism are specified in [SPEC/program/game-events.md](../program/game-events.md) and [SPEC/program/turn-resolution-phase-details.md](../program/turn-resolution-phase-details.md). Dialogue and mood events ([SPEC/program/ai-events-and-dossier.md](../program/ai-events-and-dossier.md)) may be a separate channel or folded into the same stream as defined in game-events.md.
+
+### Data flow
+
+```mermaid
+flowchart LR
+  subgraph logic [colonizethis_logic]
+    TR[TurnResolver]
+    OE[OrderEngine]
+  end
+  TR --> GameEvents[GameEvent stream]
+  OE --> GameEvents
+  GameEvents --> App[Flutter app]
+  GameEvents --> Ctterm[ctterm]
+  logic --> PlayerView[PlayerView]
+  Ctterm --> PlayerView
+  App --> PlayerView
+```
+
+PlayerView and save/load contracts are unchanged; ctterm uses the same PlayerView and save-load APIs as the rest of the project.
+
+---
+
+## 4. Reference to all UI screens
+
+### Where SPEC sources live
+
+- **Existing SPEC (current project):** Screens that already have a spec use that document as the behavioural source. Paths are under SPEC/ui/, SPEC/game/, or SPEC/program/ (see table below).
+- **Yet-to-be-written specs for ctterm screens:** Any screen that does not have a dedicated SPEC today, or that needs a ctterm-specific screen spec (layout, TUI-only AC), will have its spec written under **SPEC/tui/screens/** with one file per screen. Naming: `SPEC/tui/screens/<screen-key>.md` where `<screen-key>` is kebab-case (e.g. `main-menu`, `load-game`, `in-game-shell`, `units`, `defeat`). Those docs define layout, navigation, and Given–When–Then for the TUI; they reference existing SPEC/game and SPEC/program for game rules and data.
+
+### Convention for the table
+
+- **SPEC source (existing):** Full path to the existing spec that defines behaviour. Use "—" when there is no existing screen spec (e.g. Settings).
+- **TUI screen spec (to be written):** Path `SPEC/tui/screens/<screen-key>.md` where the ctterm-specific screen spec will be written. Use "— (adaptations in ctterm.md)" when the screen is fully covered by an existing SPEC plus inline TUI adaptations in this document.
+
+### Screens
+
+| Screen                 | SPEC source (existing)                                                                                                                                       | TUI screen spec (to be written)   | UXD  | Note                                                           |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------- | ----- | -------------------------------------------------------------- |
+| Main Menu              | [SPEC/ui/main-menu.md](../ui/main-menu.md)                                                                                                                 | — (adaptations in ctterm.md)      | 03a   | List + keyboard; Load enabled/disabled per save presence       |
+| Game Setup             | [SPEC/ui/game-setup.md](../ui/game-setup.md)                                                                                                               | — (adaptations in ctterm.md)      | 03b   | Six slots, nation/leader; Start when complete; no pixel assets |
+| Load Game              | [SPEC/ui/game-setup.md](../ui/game-setup.md) (Load list)                                                                                                   | [SPEC/tui/screens/load-game.md](screens/load-game.md) | 03b   | Save list as 03b; Back, Load, Delete with confirm              |
+| Generating World       | [SPEC/program/game-setup-pipeline.md](../program/game-setup-pipeline.md)                                                                                   | — (adaptations in ctterm.md)      | 03b   | Blocking state; optional cancel                                |
+| Settings               | —                                                                                                                                                            | [SPEC/tui/screens/settings.md](screens/settings.md) | 03c   | Terminal theme only                                            |
+| In-game shell          | [SPEC/program/player-view.md](../program/player-view.md), [SPEC/program/map-visualization.md](../program/map-visualization.md)                             | [SPEC/tui/screens/in-game-shell.md](screens/in-game-shell.md) | 03d, 03m | ASCII map layers; HUD; sidebar to panels                       |
+| Map / Province context | [SPEC/program/player-view.md](../program/player-view.md), [SPEC/program/map-visualization.md](../program/map-visualization.md)                             | [SPEC/tui/screens/map-context.md](screens/map-context.md) | 03d   | Layers; visibility; scroll/cycle regions                        |
+| Units                  | [SPEC/program/order-engine.md](../program/order-engine.md), [SPEC/game/combat.md](../game/combat.md) (orders)                                               | [SPEC/tui/screens/units.md](screens/units.md) | 03e   | List stacks; detail; Move/Attack/Clear per order-engine          |
+| Development            | [SPEC/program/development-resolution.md](../program/development-resolution.md)                                                                              | [SPEC/tui/screens/development.md](screens/development.md) | 03f   | Builders, engineers                                            |
+| Production             | [SPEC/game/stockpiles-and-production.md](../game/stockpiles-and-production.md), [SPEC/program/extraction-pipeline.md](../program/extraction-pipeline.md)   | [SPEC/tui/screens/production.md](screens/production.md) | 03g   | Extraction, workers                                            |
+| Academy                | [SPEC/game/military-units.md](../game/military-units.md)                                                                                                     | [SPEC/tui/screens/academy.md](screens/academy.md) | 03h   | Military training                                              |
+| Shipyard               | [SPEC/game/ships-and-naval.md](../game/ships-and-naval.md)                                                                                                   | [SPEC/tui/screens/shipyard.md](screens/shipyard.md) | 03i   | Naval construction                                              |
+| Diplomacy              | [SPEC/game/diplomacy.md](../game/diplomacy.md), [SPEC/program/diplomacy-resolution.md](../program/diplomacy-resolution.md)                                   | [SPEC/tui/screens/diplomacy.md](screens/diplomacy.md) | 03j   | War/peace                                                      |
+| Technology             | [SPEC/game/research-state.md](../game/research-state.md), [SPEC/program/research-resolution.md](../program/research-resolution.md)                         | [SPEC/tui/screens/technology.md](screens/technology.md) | 03k   | Research                                                       |
+| Victory / Progress     | [SPEC/game/victory.md](../game/victory.md)                                                                                                                   | [SPEC/tui/screens/victory-progress.md](screens/victory-progress.md) | 03l   | Progress overview; Victory screen when human wins              |
+| Defeat                 | [SPEC/game/victory.md](../game/victory.md) (extended)                                                                                                        | [SPEC/tui/screens/defeat.md](screens/defeat.md) | —     | New: when other GP wins; View Final Map / Main Menu            |
+| Pause/Options          | [SPEC/ui/main-menu.md](../ui/main-menu.md) (return flow)                                                                                                     | [SPEC/tui/screens/pause-options.md](screens/pause-options.md) | 03a   | Exit to Main Menu                                              |
+
+### Summary
+
+All TUI screen specs under SPEC/tui/screens/ will be created when those screens are specified in detail. This document references these paths so that future work knows where each screen’s spec will live. Existing SPEC paths (SPEC/ui/, SPEC/game/, SPEC/program/) are used as-is; no new files there for ctterm except [SPEC/program/game-events.md](../program/game-events.md).
+
+Acceptance criteria carried over from existing SPECs must be restated in Given–When–Then form with TUI adaptations in the corresponding SPEC/tui/screens/<screen-key>.md (or inline in this document where no separate screen file is used).
+
+---
+
+## 5. Development setup
+
+This section records development decisions for ctterm. Package placement is defined here; see also [SPEC/program/repo-and-packages.md](../program/repo-and-packages.md).
+
+- **Package placement:** Top-level **`ctterm/`** at repo root (like ctdev). Pure Dart executable; no Flutter SDK. Run with `dart run ctterm` from repo root (or `melos run ctterm`).
+- **Game events:** The game event stream is implemented in colonizethis_logic first; ctterm only consumes it. Logic has no knowledge of UI display. Events are built progressively as the TUI requires them. See [SPEC/program/game-events.md](../program/game-events.md).
+- **Data flow / dependencies:** Generate map first, then derive topology (same as ctdev). Ctterm depends on: colonizethis_save, colonizethis_logic (and transitively colonizethis_models, colonizethis_data, colonizethis_map, colonizethis_ai). Same package set as ctdev. If colonizethis_save or colonizethis_logic need augmentation for ctterm (e.g. Hive path injection), add minimal API or options in those packages.
+- **Storage:** A **separate Hive directory** is used for ctterm (not shared with app or ctdev). Pure Dart cannot use `path_provider`; use a fixed convention: e.g. `$HOME/.colonizethis_ctterm` (or on Linux, `$XDG_DATA_HOME/colonizethis_ctterm` when set). Implement in ctterm using `dart:io` Platform and the `path` package. Optional CLI flag `--data-dir <path>` overrides the default; document in [docs/project-tools.md](../../docs/project-tools.md).
+- **Nocterm:** Use latest stable (e.g. `nocterm: ^0.4.2`). No extra version constraints. Ctterm must detect terminal size and resize elements responsively.
+- **Testing:** 90% coverage is required for the ctterm package. Use mocks; refer to Nocterm docs (e.g. `testNocterm()`) for TUI component tests. Critical paths: main menu and navigation; load map/empire views; assign units (civilian, military, naval); development; production; academy; shipyard; technology; end turn.
+- **Navigation:** Full navigation structure with stubs for all panels: Main Menu, Game Setup, Load Game, Generating World, Settings, In-game shell, Units, Development, Production, Academy, Shipyard, Diplomacy, Technology, Victory/Progress, Defeat, Pause/Options.
+- **Map TUI mapping:** Ctterm defines its own TUI-specific mapping (terrain/ownership → characters or styles). Document in [SPEC/tui/map-tui-mapping.md](map-tui-mapping.md). Base map layer uses the same data as [SPEC/program/map-visualization.md](../program/map-visualization.md); ctterm is a consumer.
+- **Logging:** Use multiple log prefixes for easy identification: `tui:`, `tui:menu:`, `tui:save:`, `tui:nav:` (and later `tui:map:`, `tui:event:`). Use Dart `logger`; no `print` for operational output. See [SPEC/program/ctdev-logging.md](../program/ctdev-logging.md) for level and prefix conventions.
+- **Project tools:** Ctterm is documented in [docs/project-tools.md](../../docs/project-tools.md) (invocation, optional `--data-dir`, link to this spec).
+
+---
+
+## Package placement
+
+ctterm runs as a standalone Dart executable in the top-level **`ctterm/`** package. See §5 Development setup above for full placement and run instructions.

--- a/SPEC/tui/map-tui-mapping.md
+++ b/SPEC/tui/map-tui-mapping.md
@@ -1,0 +1,39 @@
+# Map TUI mapping
+
+**SPEC/tui** — Ctterm’s mapping from map/PlayerView data to terminal display. Base data comes from [SPEC/program/map-visualization.md](../program/map-visualization.md) and [SPEC/program/player-view.md](../program/player-view.md); ctterm is a consumer and defines only the terminal representation.
+
+---
+
+## Responsibility
+
+- Define how terrain, province ownership, capitals, ports, visibility, and other map data are rendered in the terminal (characters, symbols, colors/styles).
+- Single place for implementors to extend or change the TUI map look without touching game logic.
+
+---
+
+## Data source
+
+- **Base layer data:** Same as map-visualization and player-view: tile keys (`regionId|localId|x|y`), terrain, resources, province ownership, capitals, ports, visibility (fog, revealed, fully visible).
+- **No logic here:** This doc describes only the **display mapping**. Province identity and visibility rules are in world-model-identity and player-view.
+
+---
+
+## Placeholder mapping (to implement)
+
+| Data | Terminal representation (placeholder) |
+|------|----------------------------------------|
+| Terrain (e.g. land, sea) | Character or symbol per terrain type (e.g. `.` land, `~` water). Extend per ruleset. |
+| Province ownership | Color or style per owner (e.g. distinct terminal colors for each GP). |
+| Capital | Symbol or marker (e.g. `*` or `C`) on capital tile. |
+| Port | Symbol (e.g. `#`) on port tile. |
+| Visibility | Fog = dimmed or `?`; revealed = outline; fully visible = full detail. |
+
+Exact characters and palette are implementation choices; document them in ctterm code or comments and keep this spec updated when the mapping is finalized.
+
+---
+
+## Cross-references
+
+- [ctterm.md](ctterm.md) §2 Map (ASCII/Unicode art), §5 Development setup
+- [SPEC/program/map-visualization.md](../program/map-visualization.md) — data contract
+- [SPEC/game/world-model-identity.md](../game/world-model-identity.md) — province/tile keys

--- a/ctterm/bin/ctterm.dart
+++ b/ctterm/bin/ctterm.dart
@@ -1,0 +1,25 @@
+// ctterm entrypoint. SPEC/tui/ctterm.md. Run with: dart run ctterm [--data-dir <path>]
+
+import 'package:logger/logger.dart' as log_pkg;
+import 'package:nocterm/nocterm.dart' hide Logger;
+
+import 'package:ctterm/ctterm_app.dart';
+import 'package:ctterm/ctterm_log.dart';
+
+final log_pkg.Logger _log = log_pkg.Logger();
+
+void main(List<String> args) async {
+  initCttermLogging();
+  _log.i('tui: ctterm starting');
+
+  String? dataDirOverride;
+  for (var i = 0; i < args.length; i++) {
+    if (args[i] == '--data-dir' && i + 1 < args.length) {
+      dataDirOverride = args[i + 1];
+      i++;
+      break;
+    }
+  }
+
+  runApp(CttermApp(dataDirOverride: dataDirOverride));
+}

--- a/ctterm/lib/ctterm_app.dart
+++ b/ctterm/lib/ctterm_app.dart
@@ -1,0 +1,41 @@
+// Root ctterm app: navigation shell and main menu. SPEC/tui/ctterm.md.
+
+import 'package:nocterm/nocterm.dart';
+
+import 'package:ctterm/ctterm_routes.dart';
+import 'package:ctterm/screens/shell_screen.dart';
+
+/// Root component. Holds current screen and shows Main Menu or a stub.
+class CttermApp extends StatefulComponent {
+  const CttermApp({super.key, this.dataDirOverride});
+
+  final String? dataDirOverride;
+
+  @override
+  State<CttermApp> createState() => _CttermAppState();
+}
+
+class _CttermAppState extends State<CttermApp> {
+  CttermRoute _route = CttermRoute.mainMenu;
+
+  void _navigateTo(CttermRoute route) {
+    setState(() => _route = route);
+  }
+
+  void _exit() {
+    shutdownApp(0);
+  }
+
+  @override
+  Component build(BuildContext context) {
+    return NoctermApp(
+      title: 'ColonizeThis',
+      child: ShellScreen(
+        route: _route,
+        dataDirOverride: component.dataDirOverride,
+        onNavigate: _navigateTo,
+        onExit: _exit,
+      ),
+    );
+  }
+}

--- a/ctterm/lib/ctterm_log.dart
+++ b/ctterm/lib/ctterm_log.dart
@@ -1,0 +1,9 @@
+// ctterm logging. SPEC/tui/ctterm.md §5. Use prefixes tui:, tui:menu:, tui:save:, tui:nav:, etc.
+
+import 'package:logger/logger.dart';
+
+/// Initializes ctterm logging. Call from main() before runApp.
+/// Use loggers with prefix names in code, e.g. Logger('tui:save:').
+void initCttermLogging() {
+  Logger.level = Level.debug;
+}

--- a/ctterm/lib/ctterm_routes.dart
+++ b/ctterm/lib/ctterm_routes.dart
@@ -1,0 +1,21 @@
+// Route enum for ctterm navigation. SPEC/tui/ctterm.md.
+
+/// All top-level routes (main menu + stubs). In-game shell has its own sub-routes.
+enum CttermRoute {
+  mainMenu,
+  gameSetup,
+  loadGame,
+  generatingWorld,
+  settings,
+  inGameShell,
+  units,
+  development,
+  production,
+  academy,
+  shipyard,
+  diplomacy,
+  technology,
+  victoryProgress,
+  defeat,
+  pauseOptions,
+}

--- a/ctterm/lib/menu_logic.dart
+++ b/ctterm/lib/menu_logic.dart
@@ -1,0 +1,4 @@
+// Pure logic for main menu state. Testable without Nocterm. SPEC/tui/ctterm.md.
+
+/// Returns true when Load Game should be enabled (at least one save exists).
+bool isLoadGameEnabled(List<String> gameIds) => gameIds.isNotEmpty;

--- a/ctterm/lib/save_service.dart
+++ b/ctterm/lib/save_service.dart
@@ -1,0 +1,90 @@
+// Ctterm save/load: Hive box in ctterm-specific directory. SPEC/tui/ctterm.md §5, SPEC/program/save-load.md.
+
+import 'dart:io';
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_save/colonizethis_save.dart';
+import 'package:hive/hive.dart';
+import 'package:logger/logger.dart' as log_pkg;
+import 'package:path/path.dart' as path;
+
+final log_pkg.Logger _log = log_pkg.Logger();
+
+String? _initDataDir;
+Box<dynamic>? _box;
+
+/// Returns the ctterm data directory. Uses [override] if provided; otherwise
+/// $HOME/.colonizethis_ctterm (or $XDG_DATA_HOME/colonizethis_ctterm on Linux when set).
+String getCttermDataDir([String? override]) {
+  if (override != null && override.isNotEmpty) return override;
+  if (_initDataDir != null) return _initDataDir!;
+  final env = Platform.environment;
+  if (Platform.isLinux && env.containsKey('XDG_DATA_HOME')) {
+    _initDataDir = path.join(env['XDG_DATA_HOME']!, 'colonizethis_ctterm');
+  } else {
+    final home = env['HOME'] ?? env['USERPROFILE'] ?? '.';
+    _initDataDir = path.join(home, '.colonizethis_ctterm');
+  }
+  return _initDataDir!;
+}
+
+/// Ensures Hive is initialized and the games box is open. Call before list/load/save.
+Future<Box<dynamic>> _ensureBox([String? dataDirOverride]) async {
+  if (_box != null && _box!.isOpen) return _box!;
+  final dir = getCttermDataDir(dataDirOverride);
+  final dirFile = Directory(dir);
+  if (!dirFile.existsSync()) {
+    dirFile.createSync(recursive: true);
+  }
+  Hive.init(dir);
+  _box = await Hive.openBox<dynamic>('games');
+  _log.d('tui:save: Hive box opened at $dir');
+  return _box!;
+}
+
+final _adapter = GameSaveAdapter();
+
+/// Lists stored game ids. [dataDirOverride] overrides the default data directory.
+/// Returns [] if box not yet opened or empty.
+Future<List<String>> listGameIds([String? dataDirOverride]) async {
+  final box = await _ensureBox(dataDirOverride);
+  final ids = _adapter.listGameIds(box);
+  _log.d('tui:save: listGameIds count=${ids.length}');
+  return ids;
+}
+
+/// Loads game by id. Returns null if not found or invalid.
+Future<Game?> loadGame(String gameId, [String? dataDirOverride]) async {
+  final box = await _ensureBox(dataDirOverride);
+  return _adapter.load(box, gameId);
+}
+
+/// Loads map data for [gameId]. Returns null for legacy saves (no map data stored).
+Future<({
+  Map<String, TileMapResult> tileMapByRegion,
+  Map<String, MapTopology> topologyByRegion,
+  MapTopology combinedTopology,
+})?> loadMapData(String gameId, [String? dataDirOverride]) async {
+  final box = await _ensureBox(dataDirOverride);
+  return _adapter.loadMapData(box, gameId);
+}
+
+/// Saves [game] and optional [result] map data.
+Future<void> saveGameAndMapData(
+  Game game,
+  InitGameResult result, [
+  String? dataDirOverride,
+]) async {
+  final box = await _ensureBox(dataDirOverride);
+  _adapter.save(box, game);
+  _adapter.saveMapData(
+    box,
+    game.id,
+    tileMapByRegion: result.tileMapByRegion,
+    topologyByRegion: result.topologyByRegion,
+    combinedTopology: result.combinedTopology,
+  );
+  _log.i('tui:save: saved gameId=${game.id} with map data');
+}

--- a/ctterm/lib/screens/main_menu_screen.dart
+++ b/ctterm/lib/screens/main_menu_screen.dart
@@ -1,0 +1,135 @@
+// Main Menu. SPEC/ui/main-menu.md, SPEC/tui/ctterm.md.
+
+import 'package:logger/logger.dart' as log_pkg;
+import 'package:nocterm/nocterm.dart' hide Logger;
+
+import 'package:ctterm/menu_logic.dart';
+import 'package:ctterm/save_service.dart';
+
+final log_pkg.Logger _log = log_pkg.Logger();
+
+/// Main menu: New Game, Load Game (enabled only when saves exist), Settings, Quit.
+class MainMenuScreen extends StatefulComponent {
+  const MainMenuScreen({
+    super.key,
+    required this.onNewGame,
+    required this.onLoadGame,
+    required this.onSettings,
+    required this.onQuit,
+    this.dataDirOverride,
+  });
+
+  final void Function() onNewGame;
+  final void Function() onLoadGame;
+  final void Function() onSettings;
+  final void Function() onQuit;
+  final String? dataDirOverride;
+
+  @override
+  State<MainMenuScreen> createState() => _MainMenuScreenState();
+}
+
+class _MainMenuScreenState extends State<MainMenuScreen> {
+  bool _loadGameEnabled = false;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkSaves();
+  }
+
+  Future<void> _checkSaves() async {
+    final ids = await listGameIds(component.dataDirOverride);
+    _log.d('tui:menu: listGameIds count=${ids.length}');
+    setState(() {
+      _loadGameEnabled = isLoadGameEnabled(ids);
+      _loading = false;
+    });
+  }
+
+  @override
+  Component build(BuildContext context) {
+    return Focusable(
+      focused: true,
+      onKeyEvent: (event) {
+        if (_loading) return false;
+        final key = event.logicalKey;
+        if (key == LogicalKey.enter || key == LogicalKey.space) {
+          // Use current selection (we use shortcuts below instead for simplicity)
+          return false;
+        }
+        // Shortcuts: n, l, s, q
+        final c = event.character?.toLowerCase();
+        if (c == 'n') {
+          component.onNewGame();
+          return true;
+        }
+        if (c == 'l' && _loadGameEnabled) {
+          component.onLoadGame();
+          return true;
+        }
+        if (c == 's') {
+          component.onSettings();
+          return true;
+        }
+        if (c == 'q') {
+          component.onQuit();
+          return true;
+        }
+        return false;
+      },
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text('ColonizeThis', style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 2),
+            if (_loading)
+              Text('Loading...', style: TextStyle(color: Colors.gray))
+            else ...[
+              _menuRow('N', 'New Game', true, component.onNewGame),
+              _menuRow('L', 'Load Game', _loadGameEnabled, component.onLoadGame),
+              if (!_loadGameEnabled)
+                Padding(
+                  padding: const EdgeInsets.only(left: 4),
+                  child: Text(
+                    'No save games found',
+                    style: TextStyle(color: Colors.gray),
+                  ),
+                ),
+              _menuRow('S', 'Settings', true, component.onSettings),
+              _menuRow('Q', 'Quit', true, component.onQuit),
+            ],
+            const SizedBox(height: 2),
+            Text('v0.1.0', style: TextStyle(color: Colors.gray)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Component _menuRow(
+    String key,
+    String label,
+    bool enabled,
+    void Function() onTap,
+  ) {
+    final style = enabled
+        ? null
+        : TextStyle(color: Colors.gray);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 1),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text('[$key] ', style: TextStyle(color: Colors.cyan)),
+          GestureDetector(
+            onTap: enabled ? onTap : null,
+            child: Text(label, style: style),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/ctterm/lib/screens/shell_screen.dart
+++ b/ctterm/lib/screens/shell_screen.dart
@@ -1,0 +1,91 @@
+// Navigation shell: switches on route and shows Main Menu or stub. SPEC/tui/ctterm.md.
+
+import 'package:logger/logger.dart' as log_pkg;
+import 'package:nocterm/nocterm.dart' hide Logger;
+
+import 'package:ctterm/ctterm_routes.dart';
+import 'package:ctterm/screens/main_menu_screen.dart';
+import 'package:ctterm/screens/stub_screen.dart';
+
+final log_pkg.Logger _log = log_pkg.Logger();
+
+/// Displays the current route (Main Menu or a stub) and handles back/exit.
+class ShellScreen extends StatefulComponent {
+  const ShellScreen({
+    super.key,
+    required this.route,
+    required this.onNavigate,
+    required this.onExit,
+    this.dataDirOverride,
+  });
+
+  final CttermRoute route;
+  final String? dataDirOverride;
+  final void Function(CttermRoute) onNavigate;
+  final void Function() onExit;
+
+  @override
+  State<ShellScreen> createState() => _ShellScreenState();
+}
+
+class _ShellScreenState extends State<ShellScreen> {
+  @override
+  Component build(BuildContext context) {
+    return KeyboardListener(
+      onKeyEvent: (LogicalKey key) {
+        if (key == LogicalKey.escape) {
+          if (component.route != CttermRoute.mainMenu) {
+            _log.d('tui:nav: Esc -> main menu');
+            component.onNavigate(CttermRoute.mainMenu);
+          }
+          return true;
+        }
+        return false;
+      },
+      child: _buildScreen(),
+    );
+  }
+
+  Component _buildScreen() {
+    switch (component.route) {
+      case CttermRoute.mainMenu:
+        return MainMenuScreen(
+          dataDirOverride: component.dataDirOverride,
+          onNewGame: () => component.onNavigate(CttermRoute.gameSetup),
+          onLoadGame: () => component.onNavigate(CttermRoute.loadGame),
+          onSettings: () => component.onNavigate(CttermRoute.settings),
+          onQuit: component.onExit,
+        );
+      case CttermRoute.gameSetup:
+        return const StubScreen(title: 'Game Setup');
+      case CttermRoute.loadGame:
+        return const StubScreen(title: 'Load Game');
+      case CttermRoute.generatingWorld:
+        return const StubScreen(title: 'Generating World');
+      case CttermRoute.settings:
+        return const StubScreen(title: 'Settings');
+      case CttermRoute.inGameShell:
+        return const StubScreen(title: 'In-game shell');
+      case CttermRoute.units:
+        return const StubScreen(title: 'Units');
+      case CttermRoute.development:
+        return const StubScreen(title: 'Development');
+      case CttermRoute.production:
+        return const StubScreen(title: 'Production');
+      case CttermRoute.academy:
+        return const StubScreen(title: 'Academy');
+      case CttermRoute.shipyard:
+        return const StubScreen(title: 'Shipyard');
+      case CttermRoute.diplomacy:
+        return const StubScreen(title: 'Diplomacy');
+      case CttermRoute.technology:
+        return const StubScreen(title: 'Technology');
+      case CttermRoute.victoryProgress:
+        return const StubScreen(title: 'Victory / Progress');
+      case CttermRoute.defeat:
+        return const StubScreen(title: 'Defeat');
+      case CttermRoute.pauseOptions:
+        return const StubScreen(title: 'Pause / Options');
+    }
+  }
+}

--- a/ctterm/lib/screens/stub_screen.dart
+++ b/ctterm/lib/screens/stub_screen.dart
@@ -1,0 +1,23 @@
+// Generic stub screen: title + Esc to go back. SPEC/tui/ctterm.md.
+
+import 'package:nocterm/nocterm.dart';
+
+class StubScreen extends StatelessComponent {
+  const StubScreen({super.key, required this.title});
+
+  final String title;
+
+  @override
+  Component build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text('$title (stub)'),
+          const SizedBox(height: 1),
+          Text('Press Esc to go back', style: TextStyle(color: Colors.gray)),
+        ],
+      ),
+    );
+  }
+}

--- a/ctterm/pubspec.yaml
+++ b/ctterm/pubspec.yaml
@@ -1,0 +1,27 @@
+name: ctterm
+description: Terminal UI (Nocterm) for full single-player ColonizeThis. SPEC/tui/ctterm.md.
+publish_to: none
+version: 0.1.0
+resolution: workspace
+
+environment:
+  sdk: '>=3.5.0 <4.0.0'
+
+dependencies:
+  nocterm: ^0.4.2
+  logger: ^2.0.2
+  path: ^1.9.0
+  hive: ^2.2.3
+  colonizethis_ai: any
+  colonizethis_logic: any
+  colonizethis_models: any
+  colonizethis_data: any
+  colonizethis_map: any
+  colonizethis_save: any
+
+dev_dependencies:
+  colonizethis_test:
+  test: ^1.24.0
+
+executables:
+  ctterm: bin/ctterm.dart

--- a/ctterm/test/menu_logic_test.dart
+++ b/ctterm/test/menu_logic_test.dart
@@ -1,0 +1,17 @@
+// Tests for main menu Load Game enabled logic. SPEC/tui/ctterm.md.
+
+import 'package:ctterm/menu_logic.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('isLoadGameEnabled', () {
+    test('returns false when no saves exist', () {
+      expect(isLoadGameEnabled([]), isFalse);
+    });
+
+    test('returns true when at least one save exists', () {
+      expect(isLoadGameEnabled(['game1']), isTrue);
+      expect(isLoadGameEnabled(['a', 'b']), isTrue);
+    });
+  });
+}

--- a/ctterm/test/save_service_test.dart
+++ b/ctterm/test/save_service_test.dart
@@ -1,0 +1,29 @@
+// Tests for ctterm save service data dir and listGameIds. SPEC/tui/ctterm.md.
+
+import 'dart:io';
+
+import 'package:ctterm/save_service.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('getCttermDataDir', () {
+    test('returns override when provided and non-empty', () {
+      expect(getCttermDataDir('/custom/path'), equals('/custom/path'));
+    });
+
+    test('uses default when override is null', () {
+      final dir = getCttermDataDir(null);
+      expect(dir, isNotEmpty);
+      expect(dir, contains('colonizethis_ctterm'));
+    });
+  });
+
+  group('listGameIds', () {
+    test('returns empty list when data dir has no saves', () async {
+      final tempDir = Directory.systemTemp.createTempSync('ctterm_test_');
+      addTearDown(() => tempDir.deleteSync(recursive: true));
+      final ids = await listGameIds(tempDir.path);
+      expect(ids, isEmpty);
+    });
+  });
+}

--- a/docs/project-tools.md
+++ b/docs/project-tools.md
@@ -6,6 +6,32 @@ The list below is the single place for **what tools exist** and **how to invoke 
 
 ---
 
+## ctterm
+
+Terminal UI for the full single-player ColonizeThis experience. Pure Dart (Nocterm); no Flutter. Spec: [SPEC/tui/ctterm.md](../SPEC/tui/ctterm.md).
+
+**Invocation**
+
+```bash
+dart run ctterm
+```
+
+Or from project root with Melos:
+
+```bash
+melos run ctterm
+```
+
+**Options**
+
+- `--data-dir <path>` — Override the default Hive data directory (default: `$HOME/.colonizethis_ctterm`, or `$XDG_DATA_HOME/colonizethis_ctterm` on Linux when set).
+
+**Behaviour**
+
+- Shows Main Menu first (New Game, Load Game, Settings, Quit). Load Game is enabled only when at least one save exists in the ctterm data directory. Saves are separate from app/ctdev.
+
+---
+
 ## init_game
 
 Game creation: generate Old World and New World maps, assign provinces and capitals to Great Powers, Minor Nations, and Tribes, build initial world state. Outputs combined map PNG (with ownership and capitals) and faction setup markdown. Does not advance turns. Spec: [SPEC/program/init-game-tool.md](../SPEC/program/init-game-tool.md).

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,6 +25,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.4.1"
+  ansi_escape_codes:
+    dependency: transitive
+    description:
+      name: ansi_escape_codes
+      sha256: "68dfa36c8858bfdd5d6d9a64e09a88c9cf93d2c8e35c9df0cc0e75bccda9ee23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
   ansi_styles:
     dependency: transitive
     description:
@@ -185,6 +193,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -296,6 +312,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  hotreloader:
+    dependency: transitive
+    description:
+      name: hotreloader
+      sha256: bc167a1163807b03bada490bfe2df25b0d744df359227880220a5cbd04e5734b
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
   http:
     dependency: transitive
     description:
@@ -400,6 +424,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.0"
   matcher:
     dependency: transitive
     description:
@@ -428,10 +460,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -456,6 +488,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  nocterm:
+    dependency: transitive
+    description:
+      name: nocterm
+      sha256: "07e6fc6986a13f774360328acf377f6eea1287217e9246bdd5bbab88a7be2e36"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.4"
   node_preamble:
     dependency: transitive
     description:
@@ -616,6 +656,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
   resizable_widget:
     dependency: transitive
     description:
@@ -717,6 +765,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -933,6 +989,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.4"
+  zmodem:
+    dependency: transitive
+    description:
+      name: zmodem
+      sha256: "3b7e5b29f3a7d8aee472029b05165a68438eff2f3f7766edf13daba1e297adbf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.6"
 sdks:
   dart: ">=3.10.0 <4.0.0"
   flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
 workspace:
   - app
   - ctdev
+  - ctterm
   - packages/colonizethis_models
   - packages/colonizethis_data
   - packages/colonizethis_save
@@ -52,3 +53,6 @@ melos:
     check_gdd_coverage:
       description: Report which GDD specs (SPEC/game) are covered by sim_scenarios. SPEC/project/gdd-scenario-coverage.md.
       run: dart run check_gdd_coverage
+    ctterm:
+      description: Terminal UI for full single-player ColonizeThis. SPEC/tui/ctterm.md.
+      run: dart run ctterm

--- a/tool/run_quality_gate_tests.sh
+++ b/tool/run_quality_gate_tests.sh
@@ -31,6 +31,13 @@ if [ -d ctdev/test ]; then
 fi
 
 echo ""
+echo "=== Test ctterm (Dart) ==="
+if [ -d ctterm/test ]; then
+  (cd ctterm && dart test --coverage=coverage -j 4 --reporter=compact)
+  (cd ctterm && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
+fi
+
+echo ""
 echo "=== Test tool packages (Dart) ==="
 for dir in tool/sim_scenarios tool/sim_combat_montecarlo tool/sim_combat tool/generate_map tool/init_game tool/sim_economy tool/show_tech; do
   [ -d "$dir/test" ] || continue


### PR DESCRIPTION
## Summary

Implements the ctterm setup plan: spec documentation and stub terminal UI app with main menu and full navigation structure.

## Documentation
- **SPEC/tui/ctterm.md** — §5 Development setup (package placement, game events, deps, storage, Nocterm, testing, logging, project tools); map TUI mapping reference
- **SPEC/tui/map-tui-mapping.md** — Ctterm map/PlayerView → terminal display mapping spec
- **SPEC/program/game-events.md** — Game event stream contract consumed by app and ctterm
- **.cursor/rules/colonizethis-tui.mdc** — TUI rule for `SPEC/tui/**` and `ctterm/**`
- **docs/project-tools.md**, **SPEC/program/repo-and-packages.md** — ctterm invocation and repo layout
- **AGENTS.md** — Added colonizethis-tui.mdc to context-specific rules

## Implementation
- **ctterm/** — Top-level pure Dart package (Nocterm ^0.4.2), run via `dart run ctterm` or `melos run ctterm`
  - **Main menu**: ColonizeThis title; [N] New Game, [L] Load Game (enabled only when saves exist), [S] Settings, [Q] Quit; shortcut keys; "No save games found" when no saves
  - **Save service**: Separate Hive directory ($HOME/.colonizethis_ctterm or XDG_DATA_HOME); `listGameIds`, `loadGame`, `loadMapData`, `saveGameAndMapData`; `--data-dir` override
  - **Navigation**: Full route enum and shell; Esc returns to main menu
  - **Stub screens**: Game Setup, Load Game, Generating World, Settings, In-game shell, Units, Development, Production, Academy, Shipyard, Diplomacy, Technology, Victory/Progress, Defeat, Pause/Options
  - **Tests**: `menu_logic` (isLoadGameEnabled), `save_service` (getCttermDataDir, listGameIds); 5 tests
- **Root**: `ctterm` in workspace; `melos run ctterm` script
- **CI / quality**: `tool/run_quality_gate_tests.sh` and `.github/workflows/quality.yml` run ctterm tests when `ctterm/**` or `packages/**` change

## How to run
```bash
dart run ctterm
# or
melos run ctterm
# optional: --data-dir /path/to/hive
```

Made with [Cursor](https://cursor.com)