### PR TITLE
Implement Load Game screen for ctterm

### DIFF
--- a/SPEC/tui/screens/load-game.md
+++ b/SPEC/tui/screens/load-game.md
@@ -1,0 +1,66 @@
+# Load Game
+
+**SPEC/tui/screens** — Load Game screen for ctterm. Reference: SPEC/tui/ctterm.md §1, SPEC/ui/main-menu.md (Load Game), SPEC/program/save-load.md.
+
+---
+
+## Widget contract
+
+The Load Game screen is presentational and receives the following parameters. The **shell** supplies callbacks and handles navigation.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `saves` | `List<SaveSummary>` | List of available saves (may be empty). |
+| `onLoad` | `void Function(String gameId)` | Invoked when user selects a save and confirms Load. |
+| `onDelete` | `void Function(String gameId)` | Invoked when user selects a save and confirms Delete. |
+| `onBack` | callback | Invoked when user presses Back. |
+
+`SaveSummary` contains: `gameId` (String), `turnNumber` (int), `year` (int), `humanPlayerName` (String), `lastPlayedAt` (DateTime?).
+
+---
+
+## How this spec satisfies the TUI spec
+
+**User stories.** The user navigates here from Main Menu "Load Game" (only enabled when saves exist). They see a list of saved games with metadata (turn, year, human player's nation/leader). They can select one and Load or Delete it. Back returns to Main Menu.
+
+**Keyboard-first.** Navigation: arrow keys to move selection up/down, Enter to confirm action, Escape for back. Actions: L key to Load selected save, D key to Delete selected save (with confirmation), B or Escape to go Back.
+
+**Acceptance criteria (Given–When–Then).**
+
+- **Empty state:** Given no saves exist (should not happen if Main Menu disables Load correctly), the screen shows "No saved games" message and Back button.
+- **Save list displayed:** Given saves exist, when the screen loads, the UI shows each save with: game id (or "Game 1", "Game 2" in order), turn number, year, human player's nation/leader name. Most recent save is first (or sorted by lastPlayedAt descending).
+- **Selection:** Given a save is highlighted/selected, when the user presses L (or Enter while Load is focused), the widget invokes `onLoad` with that save's gameId.
+- **Delete:** Given a save is highlighted/selected, when the user presses D, the widget shows a confirmation prompt "Delete save? (y/n)". If user confirms (y), invokes `onDelete` with that gameId and removes the save from the list. If user declines (n), returns to list.
+- **Back:** When the user presses B or Escape, the widget invokes `onBack` once; the shell navigates to Main Menu.
+- **TUI-specific:** Given the terminal is narrow (< 80 columns), the save info is truncated or wrapped; layout adapts to available width.
+
+---
+
+## Wireframe
+
+```
++------------------------------------------+
+|              Load Game                   |
+|                                          |
+|  > Game 1   Turn 12, 1650   England      |
+|    Game 2   Turn 8, 1648    France       |
+|    Game 3   Turn 5, 1645    Spain        |
+|                                          |
+|  [L] Load  [D] Delete  [B] Back          |
++------------------------------------------+
+```
+
+- `>` indicates selected row.
+- `L` = Load selected, `D` = Delete selected (with confirm), `B` = Back.
+
+---
+
+## Interaction
+
+The widget maintains selected index state. It does not perform routing; it exposes `onLoad(gameId)`, `onDelete(gameId)`, and `onBack`. No routing logic lives in the widget.
+
+---
+
+## Logging
+
+Log prefix: `tui:save:` for load/delete operations. `tui:menu:` for navigation.

--- a/ctterm/lib/save_service.dart
+++ b/ctterm/lib/save_service.dart
@@ -88,3 +88,62 @@ Future<void> saveGameAndMapData(
   );
   _log.i('tui:save: saved gameId=${game.id} with map data');
 }
+
+/// Summary of a saved game for display in Load Game list.
+class SaveSummary {
+  const SaveSummary({
+    required this.gameId,
+    required this.turnNumber,
+    required this.year,
+    required this.humanPlayerName,
+    this.lastPlayedAt,
+  });
+
+  final String gameId;
+  final int turnNumber;
+  final int year;
+  final String humanPlayerName;
+  final DateTime? lastPlayedAt;
+}
+
+/// Lists saved games with metadata. Returns empty list if none or on error.
+Future<List<SaveSummary>> listSaves([String? dataDirOverride]) async {
+  final box = await _ensureBox(dataDirOverride);
+  final ids = _adapter.listGameIds(box);
+  if (ids.isEmpty) return [];
+
+  final summaries = <SaveSummary>[];
+  for (final id in ids) {
+    final game = _adapter.load(box, id);
+    if (game == null) continue;
+
+    // Get human player name (first player is human)
+    String humanName = 'Unknown';
+    if (game.players.isNotEmpty) {
+      humanName = game.players.first.displayName;
+    }
+
+    // Calculate year from turn (default mapping: turn 0 = 1600)
+    final year = 1600 + (game.worldState.turnState.turnNumber ~/ 2);
+
+    summaries.add(SaveSummary(
+      gameId: id,
+      turnNumber: game.worldState.turnState.turnNumber,
+      year: year,
+      humanPlayerName: humanName,
+    ));
+  }
+
+  // Sort by turn number descending (most recent first)
+  summaries.sort((a, b) => b.turnNumber.compareTo(a.turnNumber));
+
+  _log.d('tui:save: listSaves count=${summaries.length}');
+  return summaries;
+}
+
+/// Deletes a saved game by id.
+Future<void> deleteSave(String gameId, [String? dataDirOverride]) async {
+  final box = await _ensureBox(dataDirOverride);
+  _adapter.delete(box, gameId);
+  _log.i('tui:save: deleted gameId=$gameId');
+}

--- a/ctterm/lib/screens/load_game_screen.dart
+++ b/ctterm/lib/screens/load_game_screen.dart
@@ -1,0 +1,201 @@
+// Load Game screen. SPEC/tui/screens/load-game.md, SPEC/tui/ctterm.md.
+
+import 'package:logger/logger.dart' as log_pkg;
+import 'package:nocterm/nocterm.dart' hide Logger;
+
+import 'package:ctterm/save_service.dart';
+
+final log_pkg.Logger _log = log_pkg.Logger();
+
+/// Load Game: lists saved games, allows load or delete.
+class LoadGameScreen extends StatefulComponent {
+  const LoadGameScreen({
+    super.key,
+    required this.onLoad,
+    required this.onDelete,
+    required this.onBack,
+    this.dataDirOverride,
+  });
+
+  final void Function(String gameId) onLoad;
+  final void Function(String gameId) onDelete;
+  final void Function() onBack;
+  final String? dataDirOverride;
+
+  @override
+  State<LoadGameScreen> createState() => _LoadGameScreenState();
+}
+
+class _LoadGameScreenState extends State<LoadGameScreen> {
+  List<SaveSummary> _saves = [];
+  int _selectedIndex = 0;
+  bool _loading = true;
+  bool _confirmingDelete = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSaves();
+  }
+
+  Future<void> _loadSaves() async {
+    final saves = await listSaves(component.dataDirOverride);
+    setState(() {
+      _saves = saves;
+      _loading = false;
+      if (_saves.isNotEmpty && _selectedIndex >= _saves.length) {
+        _selectedIndex = 0;
+      }
+    });
+  }
+
+  void _handleKey(String c) {
+    if (_confirmingDelete) {
+      if (c == 'y' || c == 'Y') {
+        _doDelete();
+      }
+      setState(() => _confirmingDelete = false);
+      return;
+    }
+
+    if (_saves.isEmpty) {
+      if (c == 'b' || c == 'B' || c == 'escape') {
+        component.onBack();
+      }
+      return;
+    }
+
+    switch (c) {
+      case 'arrowup':
+        setState(() {
+          _selectedIndex =
+              (_selectedIndex - 1 + _saves.length) % _saves.length;
+        });
+        break;
+      case 'arrowdown':
+        setState(() {
+          _selectedIndex = (_selectedIndex + 1) % _saves.length;
+        });
+        break;
+      case 'l':
+      case 'L':
+        _doLoad();
+        break;
+      case 'd':
+      case 'D':
+        setState(() => _confirmingDelete = true);
+        break;
+      case 'b':
+      case 'B':
+      case 'escape':
+        component.onBack();
+        break;
+    }
+  }
+
+  void _doLoad() {
+    if (_saves.isEmpty || _selectedIndex >= _saves.length) return;
+    final gameId = _saves[_selectedIndex].gameId;
+    _log.d('tui:save: load gameId=$gameId');
+    component.onLoad(gameId);
+  }
+
+  void _doDelete() {
+    if (_saves.isEmpty || _selectedIndex >= _saves.length) return;
+    final gameId = _saves[_selectedIndex].gameId;
+    _log.i('tui:save: delete gameId=$gameId');
+    component.onDelete(gameId);
+    setState(() {
+      _saves.removeAt(_selectedIndex);
+      if (_selectedIndex >= _saves.length && _saves.isNotEmpty) {
+        _selectedIndex = _saves.length - 1;
+      }
+    });
+  }
+
+  @override
+  Component build(BuildContext context) {
+    return Focusable(
+      focused: true,
+      onKeyEvent: (event) {
+        if (_loading) return false;
+        final key = event.logicalKey;
+        if (key == LogicalKey.arrowUp) {
+          _handleKey('arrowup');
+          return true;
+        }
+        if (key == LogicalKey.arrowDown) {
+          _handleKey('arrowdown');
+          return true;
+        }
+        final c = event.character?.toLowerCase();
+        if (c != null) {
+          _handleKey(c);
+          return true;
+        }
+        if (key == LogicalKey.escape) {
+          _handleKey('escape');
+          return true;
+        }
+        return false;
+      },
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text('Load Game', style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 2),
+            if (_loading)
+              Text('Loading...', style: TextStyle(color: Colors.gray))
+            else if (_saves.isEmpty)
+              Text('No saved games', style: TextStyle(color: Colors.gray))
+            else ...[
+              // Confirmation prompt for delete
+              if (_confirmingDelete)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 1),
+                  child: Text(
+                    'Delete save? (y/n)',
+                    style: TextStyle(color: Colors.red),
+                  ),
+                )
+              else
+                // List saves
+                ...List.generate(_saves.length, (i) {
+                  final save = _saves[i];
+                  final isSelected = i == _selectedIndex;
+                  final style = isSelected
+                      ? TextStyle(
+                          color: Colors.cyan,
+                          fontWeight: FontWeight.bold,
+                        )
+                      : null;
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 1),
+                    child: Text(
+                      '${isSelected ? "> " : "  "}Turn ${save.turnNumber}, ${save.year}  ${save.humanPlayerName}',
+                      style: style,
+                    ),
+                  );
+                }),
+              const SizedBox(height: 2),
+              // Action hints
+              Text(
+                '[L] Load  [D] Delete  [B] Back  [↑↓] Select',
+                style: TextStyle(color: Colors.gray),
+              ),
+            ],
+            if (_saves.isEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 2),
+                child: Text(
+                  '[B] Back',
+                  style: TextStyle(color: Colors.gray),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/ctterm/lib/screens/shell_screen.dart
+++ b/ctterm/lib/screens/shell_screen.dart
@@ -4,9 +4,11 @@ import 'package:logger/logger.dart' as log_pkg;
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
+import 'package:ctterm/screens/load_game_screen.dart';
 import 'package:ctterm/screens/main_menu_screen.dart';
 import 'package:ctterm/screens/settings_screen.dart';
 import 'package:ctterm/screens/stub_screen.dart';
+import 'package:ctterm/save_service.dart';
 
 final log_pkg.Logger _log = log_pkg.Logger();
 
@@ -60,7 +62,19 @@ class _ShellScreenState extends State<ShellScreen> {
       case CttermRoute.gameSetup:
         return const StubScreen(title: 'Game Setup');
       case CttermRoute.loadGame:
-        return const StubScreen(title: 'Load Game');
+        return LoadGameScreen(
+          dataDirOverride: component.dataDirOverride,
+          onLoad: (gameId) {
+            _log.d('tui:nav: Load gameId=$gameId -> in-game shell');
+            component.onNavigate(CttermRoute.inGameShell);
+          },
+          onDelete: (gameId) async {
+            _log.i('tui:save: deleting gameId=$gameId');
+            // Import is already at top, just use deleteSave
+            await deleteSave(gameId, component.dataDirOverride);
+          },
+          onBack: () => component.onNavigate(CttermRoute.mainMenu),
+        );
       case CttermRoute.generatingWorld:
         return const StubScreen(title: 'Generating World');
       case CttermRoute.settings:


### PR DESCRIPTION
## Summary

Implements the Load Game screen for the ctterm TUI as specified in SPEC/tui/ctterm.md.

## Changes

- Created  with TUI-specific requirements in Given-When-Then format
- Added  class and / functions to 
- Implemented  with full keyboard navigation:
  - Arrow keys to navigate save list
  - L to load selected save
  - D to delete (with y/n confirmation)
  - B/Escape to go back
- Wired up in  with proper callbacks

## Keyboard controls

- ↑/↓ - Select save
- L - Load selected save
- D - Delete selected save (prompts for confirmation)
- B / Escape - Back to main menu

## Tests

- All existing ctterm tests pass
- Dart analyze clean