### PR TITLE
Implement Generating World screen for ctterm

### DIFF
--- a/SPEC/tui/screens/generating-world.md
+++ b/SPEC/tui/screens/generating-world.md
@@ -1,0 +1,58 @@
+# Generating World Screen
+
+**Spec:** SPEC/tui/ctterm.md  
+**Source:** SPEC/program/game-setup-pipeline.md (adaptations in ctterm.md)  
+**UXD:** 03b
+
+## Overview
+
+The Generating World screen is shown while the game world is being initialized. It displays progress feedback and allows the user to cancel (return to Main Menu).
+
+## Layout
+
+- Centered content
+- Title: "Generating World"
+- Status line(s): shows current generation phase
+- Progress indicator (animated or static text)
+- Cancel option: "Press [B] or [Escape] to cancel"
+
+## Interaction
+
+| Input | Action |
+|-------|--------|
+| B | Cancel generation, return to Main Menu |
+| Escape | Cancel generation, return to Main Menu |
+
+## Navigation
+
+- **From:** Game Setup screen (when user confirms start game)
+- **To:** In-game shell (on success) or Main Menu (on cancel/failure)
+
+## Acceptance Criteria
+
+### Happy path
+- **Given** the user has completed Game Setup and presses Start
+- **When** the app begins world generation
+- **Then** the Generating World screen is displayed with status "Generating world..."
+- **And** the user can wait for generation to complete
+- **When** generation completes successfully
+- **Then** the app navigates to the In-game shell
+
+### Cancel path
+- **Given** the Generating World screen is displayed
+- **When** the user presses B or Escape
+- **Then** generation is cancelled (if possible)
+- **And** the app navigates to the Main Menu
+
+### Error path
+- **Given** the Generating World screen is displayed
+- **When** generation fails with an error
+- **Then** an error message is displayed
+- **And** the user can press any key to return to Main Menu
+
+## Technical notes
+
+- This is a blocking screen - user waits while game is generated
+- In MVP, the actual game initialization may be async; screen shows until complete
+- For now, use a brief delay to simulate generation before navigating to in-game shell
+- Full implementation will call the actual game initialization logic from colonizethis_logic

--- a/ctterm/lib/screens/generating_world_screen.dart
+++ b/ctterm/lib/screens/generating_world_screen.dart
@@ -1,0 +1,152 @@
+// Generating World screen. SPEC/tui/screens/generating-world.md.
+
+import 'dart:async';
+
+import 'package:logger/logger.dart' as log_pkg;
+import 'package:nocterm/nocterm.dart' hide Logger;
+
+final log_pkg.Logger _log = log_pkg.Logger();
+
+/// Screen shown while the game world is being generated.
+/// SPEC/tui/screens/generating-world.md.
+class GeneratingWorldScreen extends StatefulComponent {
+  const GeneratingWorldScreen({
+    super.key,
+    required this.onComplete,
+    required this.onCancel,
+  });
+
+  /// Called when world generation completes successfully.
+  final void Function() onComplete;
+
+  /// Called when user cancels generation.
+  final void Function() onCancel;
+
+  @override
+  State<GeneratingWorldScreen> createState() => _GeneratingWorldScreenState();
+}
+
+class _GeneratingWorldScreenState extends State<GeneratingWorldScreen> {
+  String _status = 'Initializing...';
+  int _dots = 0;
+  Timer? _timer;
+  bool _cancelled = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _startGeneration();
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  void _startGeneration() {
+    // Simulate world generation with progress updates
+    // In full implementation, this would call the actual game init logic
+    _timer = Timer.periodic(const Duration(milliseconds: 500), (timer) {
+      if (_cancelled) {
+        timer.cancel();
+        return;
+      }
+
+      setState(() {
+        _dots = (_dots + 1) % 4;
+        _updateStatus(timer.tick);
+      });
+
+      // Simulate generation complete after ~3 seconds
+      if (timer.tick >= 6) {
+        timer.cancel();
+        _onGenerationComplete();
+      }
+    });
+  }
+
+  void _updateStatus(int tick) {
+    switch (tick) {
+      case 1:
+        _status = 'Loading ruleset...';
+      case 2:
+        _status = 'Generating Old World map...';
+      case 3:
+        _status = 'Generating New World map...';
+      case 4:
+        _status = 'Assigning provinces...';
+      case 5:
+        _status = 'Placing capitals and towns...';
+      default:
+        _status = 'Finalizing...';
+    }
+  }
+
+  void _onGenerationComplete() {
+    if (_cancelled) return;
+    _log.d('tui:nav: World generation complete -> in-game shell');
+    component.onComplete();
+  }
+
+  void _handleCancel() {
+    if (_error != null) {
+      // After error, any key returns to main menu
+      _log.d('tui:nav: Generation error acknowledged -> main menu');
+      component.onCancel();
+      return;
+    }
+
+    _cancelled = true;
+    _log.d('tui:nav: Generation cancelled by user -> main menu');
+    component.onCancel();
+  }
+
+  @override
+  Component build(BuildContext context) {
+    final dotsStr = '.' * _dots;
+    final statusText = _error ?? '$_status$dotsStr';
+
+    return Focusable(
+      focused: true,
+      onKeyEvent: (event) {
+        final key = event.logicalKey;
+        if (key == LogicalKey.escape || key == LogicalKey.keyB) {
+          _handleCancel();
+          return true;
+        }
+        // After error, any key dismisses
+        if (_error != null) {
+          _handleCancel();
+          return true;
+        }
+        return false;
+      },
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text(
+              'Generating World',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 2),
+            Text(statusText),
+            const SizedBox(height: 2),
+            if (_error == null)
+              Text(
+                'Press [B] or [Escape] to cancel',
+                style: TextStyle(color: Colors.gray),
+              )
+            else
+              Text(
+                'Press any key to continue',
+                style: TextStyle(color: Colors.gray),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/ctterm/lib/screens/shell_screen.dart
+++ b/ctterm/lib/screens/shell_screen.dart
@@ -5,6 +5,7 @@ import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
 import 'package:ctterm/screens/game_setup_screen.dart';
+import 'package:ctterm/screens/generating_world_screen.dart';
 import 'package:ctterm/screens/load_game_screen.dart';
 import 'package:ctterm/screens/main_menu_screen.dart';
 import 'package:ctterm/screens/settings_screen.dart';
@@ -85,7 +86,10 @@ class _ShellScreenState extends State<ShellScreen> {
           onBack: () => component.onNavigate(CttermRoute.mainMenu),
         );
       case CttermRoute.generatingWorld:
-        return const StubScreen(title: 'Generating World');
+        return GeneratingWorldScreen(
+          onComplete: () => component.onNavigate(CttermRoute.inGameShell),
+          onCancel: () => component.onNavigate(CttermRoute.mainMenu),
+        );
       case CttermRoute.settings:
         return SettingsScreen(
           onBack: () => component.onNavigate(CttermRoute.mainMenu),


### PR DESCRIPTION
## Summary

Implements the Generating World screen as specified in SPEC/tui/ctterm.md.

## Changes

- **Spec:** Added  with Given-When-Then acceptance criteria
- **Screen:** Created  with:
  - Animated progress status during generation (simulated phases)
  - Cancel via B or Escape key (returns to Main Menu)
  - Navigation to in-game shell on completion
- **Wiring:** Updated  to use the new screen

## Spec reference

- SPEC/tui/ctterm.md (Generating World: blocking state; optional cancel)
- SPEC/program/game-setup-pipeline.md (source for generation phases)
- UXD 03b

## Testing

- All existing ctterm tests pass (5 tests)
- Dart analyze clean

## Notes

- Currently uses simulated generation with timer (for MVP)
- Full implementation will integrate with actual game initialization logic from colonizethis_logic
- Error path is scaffolded but not fully wired to real error handling