### PR TITLE
Implement In-game shell screen for ctterm

### DIFF
--- a/SPEC/tui/screens/in-game-shell.md
+++ b/SPEC/tui/screens/in-game-shell.md
@@ -1,0 +1,79 @@
+# In-Game Shell Screen Specification
+
+**SPEC/tui** — In-game shell for ctterm. Reference: [ctterm.md](../ctterm.md).
+
+## Overview
+
+Display the main game view with ASCII map, HUD, and navigation to panels (units, development, production, academy, shipyard, diplomacy, technology, victory/progress).
+
+## Acceptance Criteria (Given-When-Then)
+
+### G1: Map Display
+- **Given** the player is in the in-game shell
+- **When** the screen renders
+- **Then** display an ASCII representation of the game map showing:
+  - Land provinces (letters/numbers for owned territories)
+  - Sea (dots or spaces)
+  - Region borders (ASCII lines where applicable)
+  - Province names for player's territories
+
+### G2: HUD (Heads-Up Display)
+- **Given** the player is in the in-game shell
+- **When** the screen renders
+- **Then** show at the top:
+  - Current turn number and year
+  - Selected province info (if any)
+  - Player's treasury/resources summary
+
+### G3: Panel Navigation
+- **Given** the player is in the in-game shell
+- **When** pressing keyboard shortcuts
+- **Then** navigate to respective panels:
+  - `U` → Units screen
+  - `D` → Development screen
+  - `P` → Production screen
+  - `A` → Academy screen
+  - `S` → Shipyard screen
+  - `I` → Diplomacy screen (I for Intl/Relations)
+  - `T` → Technology screen
+  - `V` → Victory/Progress screen
+
+### G4: End Turn
+- **Given** the player is in the in-game shell
+- **When** pressing `Enter` or `E` to end turn
+- **Then** simulate turn processing and update the display (show turn progress, then refresh map/HUD)
+
+### G5: Pause/Options
+- **Given** the player is in the in-game shell
+- **When** pressing `Escape` or `O`
+- **Then** navigate to Pause/Options screen
+
+### G6: Main Menu Exit
+- **Given** the player is in Pause/Options
+- **When** selecting "Return to Main Menu"
+- **Then** clear in-memory game state and navigate to Main Menu
+
+## UI Layout (ASCII)
+
+```
++----------------------------------------------------------+
+| Turn: 3 | Year: 1850 | Treasury: $5000 | [Selected: None]|
++----------------------------------------------------------+
+|                                                          |
+|  [ASCII MAP AREA]                                        |
+|                                                          |
+|     Province map with ownership indicators              |
+|                                                          |
++----------------------------------------------------------+
+| Commands: [U]nits [D]ev [P]rod [A]cademy [S]hipyard     |
+|           [I]ntl [T]ech [V]ictory [E]nd Turn [O]ptions  |
++----------------------------------------------------------+
+```
+
+## Implementation Notes
+
+- Use `Nocterm` for rendering (like other ctterm screens)
+- Map rendering: simplified ASCII grid, focus on player-owned provinces
+- For MVP: static map display with province indicators
+- Panel screens remain stubs for now
+- Keyboard-first navigation per ctterm conventions

--- a/ctterm/lib/screens/in_game_shell_screen.dart
+++ b/ctterm/lib/screens/in_game_shell_screen.dart
@@ -1,0 +1,212 @@
+// In-Game Shell: map + HUD + panel navigation. SPEC/tui/ctterm.md, SPEC/tui/screens/in-game-shell.md.
+
+import 'package:logger/logger.dart' as log_pkg;
+import 'package:nocterm/nocterm.dart' hide Logger;
+
+import 'package:ctterm/ctterm_routes.dart';
+
+final log_pkg.Logger _log = log_pkg.Logger();
+
+/// In-game shell: main game view with ASCII map, HUD, and navigation to panels.
+/// 
+/// Features:
+/// - ASCII map display (simplified for MVP)
+/// - HUD with turn/year, treasury
+/// - Keyboard navigation to panels (U, D, P, A, S, I, T, V)
+/// - End turn (E or Enter)
+/// - Pause/Options (O or Escape)
+class InGameShellScreen extends StatefulComponent {
+  const InGameShellScreen({
+    super.key,
+    required this.onNavigate,
+    required this.onEndTurn,
+    required this.onExitToMainMenu,
+  });
+
+  final void Function(CttermRoute) onNavigate;
+  final Future<void> Function() onEndTurn;
+  final void Function() onExitToMainMenu;
+
+  @override
+  State<InGameShellScreen> createState() => _InGameShellScreenState();
+}
+
+class _InGameShellScreenState extends State<InGameShellScreen> {
+  // Game state (MVP: static values)
+  int _turn = 1;
+  int _year = 1850;
+  int _treasury = 5000;
+  final String _selectedProvince = 'None';
+  bool _isEndingTurn = false;
+
+  static const List<String> _mapGrid = [
+    '  ~~~  ~~~  ',
+    ' ~~~  ~~~  ',
+    '~~~~  ~~~~ ',
+    ' +++  +++  ',
+    ' +A+  +B+  ',
+    ' +++  +++  ',
+    ' ~~~  ~~~  ',
+    ' ~~~  ~~~  ',
+  ];
+
+  Future<void> _handleEndTurn() async {
+    if (_isEndingTurn) return;
+    setState(() => _isEndingTurn = true);
+    _log.d('tui:game: ending turn $_turn');
+    
+    await component.onEndTurn();
+    
+    setState(() {
+      _turn++;
+      _year += 5; // Each turn = 5 years
+      _treasury += 100; // Simplified income
+      _isEndingTurn = false;
+    });
+    _log.d('tui:game: now turn $_turn, year $_year');
+  }
+
+  @override
+  Component build(BuildContext context) {
+    return Focusable(
+      focused: true,
+      onKeyEvent: (event) {
+        final key = event.logicalKey;
+        final c = event.character?.toLowerCase();
+        
+        // Navigation keys
+        if (c == 'u') {
+          component.onNavigate(CttermRoute.units);
+          return true;
+        }
+        if (c == 'd') {
+          component.onNavigate(CttermRoute.development);
+          return true;
+        }
+        if (c == 'p') {
+          component.onNavigate(CttermRoute.production);
+          return true;
+        }
+        if (c == 'a') {
+          component.onNavigate(CttermRoute.academy);
+          return true;
+        }
+        if (c == 's') {
+          component.onNavigate(CttermRoute.shipyard);
+          return true;
+        }
+        if (c == 'i') {
+          component.onNavigate(CttermRoute.diplomacy);
+          return true;
+        }
+        if (c == 't') {
+          component.onNavigate(CttermRoute.technology);
+          return true;
+        }
+        if (c == 'v') {
+          component.onNavigate(CttermRoute.victoryProgress);
+          return true;
+        }
+        
+        // End turn
+        if (c == 'e' || key == LogicalKey.enter) {
+          _handleEndTurn();
+          return true;
+        }
+        
+        // Pause/Options
+        if (c == 'o' || key == LogicalKey.escape) {
+          component.onNavigate(CttermRoute.pauseOptions);
+          return true;
+        }
+        
+        return false;
+      },
+      child: Column(
+        children: [
+          // HUD
+          _buildHUD(),
+          const SizedBox(height: 1),
+          // Map
+          Expanded(child: _buildMap()),
+          // Command bar
+          _buildCommandBar(),
+        ],
+      ),
+    );
+  }
+
+  Component _buildHUD() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 1),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Turn: $_turn | Year: $_year | Treasury: \$$_treasury '),
+          Text('[$_selectedProvince]', style: TextStyle(color: Colors.gray)),
+        ],
+      ),
+    );
+  }
+
+  Component _buildMap() {
+    return Container(
+      padding: const EdgeInsets.all(1),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text('--- Map ---', style: TextStyle(color: Colors.gray)),
+          const SizedBox(height: 1),
+          ..._mapGrid.map((row) => Padding(
+            padding: const EdgeInsets.symmetric(vertical: 0),
+            child: Text(row),
+          )),
+          const SizedBox(height: 1),
+          Text('Legend: ~ sea  + land  A/B prov owner', style: TextStyle(color: Colors.gray)),
+        ],
+      ),
+    );
+  }
+
+  Component _buildCommandBar() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 1),
+      child: _isEndingTurn
+          ? Text('Processing turn...', style: TextStyle(color: Colors.yellow))
+          : Row(
+              children: [
+                const Text('['),
+                Text('U', style: TextStyle(color: Colors.cyan)),
+                const Text(']nits '),
+                const Text('['),
+                Text('D', style: TextStyle(color: Colors.cyan)),
+                const Text(']ev '),
+                const Text('['),
+                Text('P', style: TextStyle(color: Colors.cyan)),
+                const Text(']rod '),
+                const Text('['),
+                Text('A', style: TextStyle(color: Colors.cyan)),
+                const Text(']cademy '),
+                const Text('['),
+                Text('S', style: TextStyle(color: Colors.cyan)),
+                const Text(']hipyard '),
+                const Text('['),
+                Text('I', style: TextStyle(color: Colors.cyan)),
+                const Text(']ntl '),
+                const Text('['),
+                Text('T', style: TextStyle(color: Colors.cyan)),
+                const Text(']ech '),
+                const Text('['),
+                Text('V', style: TextStyle(color: Colors.cyan)),
+                const Text(']ictory '),
+                const Text('['),
+                Text('E', style: TextStyle(color: Colors.cyan)),
+                const Text(']nd Turn '),
+                const Text('['),
+                Text('O', style: TextStyle(color: Colors.cyan)),
+                const Text(']ptions'),
+              ],
+            ),
+    );
+  }
+}

--- a/ctterm/lib/screens/shell_screen.dart
+++ b/ctterm/lib/screens/shell_screen.dart
@@ -6,6 +6,7 @@ import 'package:nocterm/nocterm.dart' hide Logger;
 import 'package:ctterm/ctterm_routes.dart';
 import 'package:ctterm/screens/game_setup_screen.dart';
 import 'package:ctterm/screens/generating_world_screen.dart';
+import 'package:ctterm/screens/in_game_shell_screen.dart';
 import 'package:ctterm/screens/load_game_screen.dart';
 import 'package:ctterm/screens/main_menu_screen.dart';
 import 'package:ctterm/screens/settings_screen.dart';
@@ -95,7 +96,17 @@ class _ShellScreenState extends State<ShellScreen> {
           onBack: () => component.onNavigate(CttermRoute.mainMenu),
         );
       case CttermRoute.inGameShell:
-        return const StubScreen(title: 'In-game shell');
+        return InGameShellScreen(
+          onNavigate: component.onNavigate,
+          onEndTurn: () async {
+            // TODO: Actually process turn when game logic is wired up
+            _log.d('tui:game: end turn (stub)');
+          },
+          onExitToMainMenu: () {
+            _log.d('tui:nav: exit to main menu');
+            component.onNavigate(CttermRoute.mainMenu);
+          },
+        );
       case CttermRoute.units:
         return const StubScreen(title: 'Units');
       case CttermRoute.development:


### PR DESCRIPTION
Implement the in-game shell screen for ctterm per SPEC/tui/ctterm.md.

## Changes
- Created SPEC/tui/screens/in-game-shell.md with Given-When-Then acceptance criteria
- Created ctterm/lib/screens/in_game_shell_screen.dart with:
  - ASCII map display (simplified MVP grid)
  - HUD with turn/year/treasury
  - Keyboard navigation to panels (U, D, P, A, S, I, T, V)
  - End turn (E or Enter)
  - Pause/Options (O or Escape)
- Wired up in shell_screen.dart (replacing stub)

All tests pass, dart analyze clean.