### PR TITLE
Create pause-options.md TUI screen spec

### DIFF
--- a/SPEC/tui/screens/pause-options.md
+++ b/SPEC/tui/screens/pause-options.md
@@ -1,0 +1,131 @@
+# Pause/Options Screen — TUI Spec
+
+**SPEC/tui/screens** — Pause menu and options panel in ctterm. Full specification for TUI layout, navigation, and Given–When–Then acceptance criteria. Source of truth for pause/options screen behavior; adapts from SPEC/ui/main-menu.md return flow.
+
+---
+
+## Layout
+
+```
+┌─────────────────────────────────────────┐
+│            === PAUSE ===                │
+│                                         │
+│  ┌───────────────────────────────────┐  │
+│  │ > Exit to Main Menu               │  │
+│  │   Settings                        │  │
+│  │   (more options coming soon)      │  │
+│  └───────────────────────────────────┘  │
+│                                         │
+│  [Esc/B] Back to Game  [Enter] Select   │
+└─────────────────────────────────────────┘
+```
+
+### Layout Details
+
+- **Header:** Title "=== PAUSE ===", centered
+- **Menu Items:** Vertical list of options:
+  - "Exit to Main Menu" (primary, with `>` indicator for selected)
+  - "Settings" (future: terminal theme settings)
+- **Selection Indicator:** `>` prefix on selected item
+- **Footer:** Keyboard shortcuts
+
+### Responsive Behavior
+
+- **Narrow terminal (<60 cols):** Same vertical layout; reduce padding; items remain selectable
+- **Short terminal (<18 rows):** Scrollable if more options added; ensure "Exit to Main Menu" always visible
+
+---
+
+## Navigation
+
+| From → To | Trigger | Behavior |
+| ---------- | ------- | -------- |
+| Shell → Pause | `Escape` or `P` key (global hotkey) | Open Pause/Options as overlay or screen |
+| Pause → Shell | `Escape` or `B` | Close pause, resume game |
+| Select item | `Up`/`Down` or `W`/`S` | Navigate menu items |
+| Confirm | `Enter` | Execute selected action |
+| Exit to Main Menu | Confirm on "Exit to Main Menu" | Navigate to Main Menu, clear game state |
+
+---
+
+## Given–When–Then Acceptance Criteria
+
+### Opening Pause Menu
+
+- **Given** the player is in the in-game shell with the game map visible
+- **When** the player presses `Escape` or `P`
+- **Then** the Pause/Options screen appears overlaying or replacing the map
+- **And** the game state is preserved (paused)
+
+- **Given** the terminal is narrow (e.g., 40 columns)
+- **When** the player opens Pause menu
+- **Then** the menu renders without horizontal overflow
+- **And** all menu items remain selectable
+
+### Navigating Menu
+
+- **Given** the Pause menu is open with "Exit to Main Menu" selected
+- **When** the player presses `Down` or `S`
+- **Then** "Settings" becomes the selected item
+- **And** the `>` indicator moves to "Settings"
+
+- **Given** "Settings" is selected
+- **When** the player presses `Up` or `W`
+- **Then** "Exit to Main Menu" becomes selected again
+
+### Exiting to Main Menu
+
+- **Given** the Pause menu is open with "Exit to Main Menu" selected
+- **When** the player presses `Enter`
+- **Then** the game displays a confirmation prompt: "Exit to Main Menu? Any unsaved progress will be lost. [Y] Yes / [N] No"
+- **And** the game waits for confirmation
+
+- **Given** the confirmation prompt is shown
+- **When** the player presses `Y` or `Enter`
+- **Then** the game navigates to the Main Menu
+- **And** the in-memory game state is cleared
+- **And** any active saves remain unaffected
+
+- **Given** the confirmation prompt is shown
+- **When** the player presses `N` or `Escape`
+- **Then** the confirmation prompt closes
+- **And** the Pause menu remains open with "Exit to Main Menu" selected
+
+### Returning to Game
+
+- **Given** the Pause menu is open
+- **When** the player presses `Escape` or `B`
+- **Then** the Pause menu closes
+- **And** the in-game shell resumes with the map visible
+- **And** the game continues from where it left off
+
+---
+
+## Game State
+
+- **Paused state:** When Pause menu is open, turn resolution does not advance. Orders remain queued but not processed.
+- **Clear on exit:** When exiting to Main Menu, the shell clears `WorldState`, `Game`, and any loaded player data from memory. Save files on disk are not modified.
+
+---
+
+## Future Options (Not in MVP)
+
+- Terminal theme selection (light/dark/palette name)
+- Sound toggle (if TUI supports audio)
+- Display mode (fullscreen terminal, etc.)
+- Help/controls reference
+
+---
+
+## Keyboard Shortcuts Summary
+
+| Key | Action |
+| -----| ------- |
+| `Escape` | Open Pause menu (from game) / Back (from pause) |
+| `P` | Alternative: Open Pause menu |
+| `B` | Alternative: Back to game |
+| `Up` / `W` | Select previous menu item |
+| `Down` / `S` | Select next menu item |
+| `Enter` | Confirm / Execute selected action |
+| `Y` | Confirm exit to Main Menu |
+| `N` | Cancel exit to Main Menu |


### PR DESCRIPTION
## Summary

Creates the TUI screen spec for the Pause/Options screen per SPEC/tui/ctterm.md.

## Changes

- Added  with:
  - Layout specification (Exit to Main Menu, Settings options)
  - Navigation table (Escape/P to open, B/Esc to close, Enter to select)
  - Given-When-Then acceptance criteria for all interactions
  - Confirmation prompt before exiting to Main Menu
  - Responsive behavior for narrow/short terminals
  - Keyboard shortcuts summary

## Testing

- Analyzing colonizethisv3...

warning - packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart:11:8 - Unused import: '../diplomacy/diplomacy_resolver.dart'. Try removing the import directive. - unused_import
   info - ctdev/lib/ctdev_log.dart:5:8 - The imported package 'basic_logger' isn't a dependency of the importing package. Try adding a dependency for 'basic_logger' in the 'pubspec.yaml' file. - depend_on_referenced_packages
   info - ctdev/lib/ctdev_log.dart:8:8 - The imported package 'logging' isn't a dependency of the importing package. Try adding a dependency for 'logging' in the 'pubspec.yaml' file. - depend_on_referenced_packages
   info - ctdev/lib/screens/init_game_screen.dart:135:26 - Don't use 'BuildContext's across async gaps, guarded by an unrelated 'mounted' check. Guard a 'State.context' use with a 'mounted' check on the State, and other BuildContext use with a 'mounted' check on the BuildContext. - use_build_context_synchronously
   info - ctterm/lib/screens/shell_screen.dart:42:7 - The private field _currentTurn could be 'final'. Try making the field 'final'. - prefer_final_fields
   info - ctterm/lib/screens/victory_progress_screen.dart:141:25 - Use interpolation to compose strings and values. Try using string interpolation to build the composite string. - prefer_interpolation_to_compose_strings
   info - ctterm/lib/screens/victory_progress_screen.dart:141:46 - Use interpolation to compose strings and values. Try using string interpolation to build the composite string. - prefer_interpolation_to_compose_strings
   info - packages/colonizethis_ai/test/dossier_test.dart:29:10 - The local variable '_gameWithEvidence' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_ai/test/perception_test.dart:9:16 - The local variable '_view' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_data/lib/colonizethis_data.dart:3:9 - Library names are not necessary. Remove the library name. - unnecessary_library_name
   info - packages/colonizethis_data/lib/src/great_power_colors.dart:2:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - packages/colonizethis_data/lib/src/leader_bonuses.dart:2:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - packages/colonizethis_data/lib/src/naming_rules.dart:1:8 - The imported package 'meta' isn't a dependency of the importing package. Try adding a dependency for 'meta' in the 'pubspec.yaml' file. - depend_on_referenced_packages
   info - packages/colonizethis_data/lib/src/tech_extraction.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - packages/colonizethis_data/lib/src/tech_extraction.dart:148:22 - Unnecessary 'const' keyword. Try removing the keyword. - unnecessary_const
   info - packages/colonizethis_data/lib/src/terrain_region_rules.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - packages/colonizethis_logic/lib/colonizethis_logic.dart:2:9 - Library names are not necessary. Remove the library name. - unnecessary_library_name
   info - packages/colonizethis_logic/lib/src/ai/ai_planner.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - packages/colonizethis_logic/lib/src/constants.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart:441:9 - Statements in an if should be enclosed in a block. Try wrapping the statement in a block. - curly_braces_in_flow_control_structures
   info - packages/colonizethis_logic/lib/src/economy/economy_consumption.dart:148:7 - The local variable '_deductLuxury' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/lib/src/economy/sea_transport.dart:56:46 - Angle brackets will be interpreted as HTML. Try using backticks around the content with angle brackets, or try replacing `<` with `&lt;` and `>` with `&gt;`. - unintended_html_in_doc_comment
   info - packages/colonizethis_logic/lib/src/orders/order_engine.dart:124:7 - Statements in an if should be enclosed in a block. Try wrapping the statement in a block. - curly_braces_in_flow_control_structures
   info - packages/colonizethis_logic/lib/src/orders/order_engine.dart:334:10 - The local variable '_ownerIsGreatPower' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/lib/src/orders/order_engine.dart:339:10 - The local variable '_ownerIsMinorOrTribe' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/lib/src/orders/order_engine.dart:765:10 - The local variable '_factionIsGreatPower' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/lib/src/orders/order_engine.dart:766:10 - The local variable '_factionIsMinorOrTribe' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/lib/src/orders/orders_application.dart:215:37 - Statements in a for should be enclosed in a block. Try wrapping the statement in a block. - curly_braces_in_flow_control_structures
   info - packages/colonizethis_logic/lib/src/setup/province_assignment.dart:2:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - packages/colonizethis_logic/lib/src/setup/province_name_fallback.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - packages/colonizethis_logic/lib/src/turn/combat_phase_helpers.dart:115:29 - Statements in a for should be enclosed in a block. Try wrapping the statement in a block. - curly_braces_in_flow_control_structures
   info - packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart:64:27 - Statements in a for should be enclosed in a block. Try wrapping the statement in a block. - curly_braces_in_flow_control_structures
   info - packages/colonizethis_logic/lib/src/turn/research_resolver.dart:39:9 - The local variable '_pointsForFunding' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/lib/src/turn/research_resolver.dart:55:9 - The local variable '_treasuryForFunding' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/lib/src/turn/turn_resolver.dart:278:27 - The local variable '_next' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/lib/src/turn/turn_resolver.dart:618:11 - The local variable '_firstTileFor' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/lib/src/turn/turn_resolver.dart:789:67 - Statements in an if should be enclosed in a block. Try wrapping the statement in a block. - curly_braces_in_flow_control_structures
   info - packages/colonizethis_logic/lib/src/turn/turn_resolver.dart:879:33 - Statements in a for should be enclosed in a block. Try wrapping the statement in a block. - curly_braces_in_flow_control_structures
   info - packages/colonizethis_logic/lib/src/turn/turn_resolver.dart:1050:16 - The local variable '_transferRegion' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/test/ai_planner_test.dart:45:17 - The local variable '_simpleTopology' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/test/ai_planner_test.dart:57:10 - The local variable '_baseGame' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/test/diplomacy_resolver_test.dart:55:10 - The local variable '_baseGame' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/test/order_engine_test.dart:1198:12 - The local variable '_baseGame' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/test/order_engine_test.dart:1432:12 - The local variable '_gpMinorBaseGame' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/test/order_visibility_test.dart:6:14 - The local variable '_view' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/test/orders_application_test.dart:8:10 - The local variable '_baseGame' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/test/orders_application_test.dart:35:12 - The local variable '_ordersFor' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/test/orders_application_test.dart:272:10 - The local variable '_civilianGame' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/test/orders_application_test.dart:419:12 - The local variable '_ordersToTriggerProcessWork' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/test/orders_application_test.dart:423:19 - The local variable '_simpleTileMap' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/test/orders_application_test.dart:869:19 - The local variable '_tileMapWithTerrain' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_logic/test/research_phase_test.dart:8:10 - The local variable '_baseGame' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_map/lib/colonizethis_map.dart:3:9 - Library names are not necessary. Remove the library name. - unnecessary_library_name
   info - packages/colonizethis_map/lib/src/game_world_state_map_visualizer.dart:293:13 - The local variable '_renderRegion' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_map/lib/src/init_game_map_view_builder.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - packages/colonizethis_map/lib/src/init_game_map_view_data.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - packages/colonizethis_map/lib/src/map_format_util.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - packages/colonizethis_map/lib/src/tile_map_generator.dart:643:14 - Use the null-aware operator '?.' rather than an explicit 'null' comparison. Try using '?.'. - prefer_null_aware_operators
   info - packages/colonizethis_map/lib/src/tile_map_generator.dart:644:14 - Use the null-aware operator '?.' rather than an explicit 'null' comparison. Try using '?.'. - prefer_null_aware_operators
   info - packages/colonizethis_map/lib/src/tile_map_generator.dart:2181:45 - Statements in a for should be enclosed in a block. Try wrapping the statement in a block. - curly_braces_in_flow_control_structures
   info - packages/colonizethis_map/lib/src/tile_map_generator.dart:2326:21 - Statements in a while should be enclosed in a block. Try wrapping the statement in a block. - curly_braces_in_flow_control_structures
   info - packages/colonizethis_map/lib/src/tile_map_generator.dart:2563:66 - Statements in an if should be enclosed in a block. Try wrapping the statement in a block. - curly_braces_in_flow_control_structures
   info - packages/colonizethis_models/lib/colonizethis_models.dart:2:9 - Library names are not necessary. Remove the library name. - unnecessary_library_name
   info - packages/colonizethis_models/lib/src/diplomacy.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - packages/colonizethis_models/lib/src/player.dart:75:15 - The local variable '_readStockpile' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_models/lib/src/player.dart:86:16 - The local variable '_readWorkerPool' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_models/lib/src/player.dart:97:9 - The local variable '_readTreasury' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_models/lib/src/player.dart:103:18 - The local variable '_readCapitalTile' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_models/lib/src/player.dart:110:24 - The local variable '_readTechUnlocked' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_models/lib/src/player.dart:118:23 - The local variable '_readResearchProgress' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_models/lib/src/quick_battle.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - packages/colonizethis_models/lib/src/worker_pool.dart:50:9 - The local variable '_read' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - packages/colonizethis_save/lib/colonizethis_save.dart:2:9 - Library names are not necessary. Remove the library name. - unnecessary_library_name
   info - tool/init_game/bin/init_game.dart:2:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - tool/init_game/bin/init_game.dart:12:8 - The imported package 'hive' isn't a dependency of the importing package. Try adding a dependency for 'hive' in the 'pubspec.yaml' file. - depend_on_referenced_packages
   info - tool/sim_combat/bin/sim_combat.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - tool/sim_economy/bin/sim_economy.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - tool/sim_economy/bin/sim_economy.dart:719:14 - Invalid use of a private type in a public API. Try making the private type public, or making the API that uses the private type also be private. - library_private_types_in_public_api
   info - tool/sim_scenarios/lib/game_factory.dart:58:29 - Angle brackets will be interpreted as HTML. Try using backticks around the content with angle brackets, or try replacing `<` with `&lt;` and `>` with `&gt;`. - unintended_html_in_doc_comment
   info - tool/sim_scenarios/lib/scenario.dart:400:34 - The local variable '_parseInitialStockpile' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - tool/sim_scenarios/lib/scenario.dart:416:34 - The local variable '_parseInitialWorkers' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - tool/sim_scenarios/lib/scenario.dart:432:34 - The local variable '_parseInitialTileState' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - tool/sim_scenarios/lib/scenario.dart:448:30 - The local variable '_parseInitialTech' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - tool/sim_scenarios/lib/scenario.dart:524:27 - The local variable '_parseWorkerAssignments' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers
   info - tool/sim_scenarios/lib/state_verifier.dart:640:55 - Unnecessary braces in a string interpolation. Try removing the braces. - unnecessary_brace_in_string_interps
   info - tool/sim_scenarios/lib/state_verifier.dart:751:12 - The local variable '_pairKey' starts with an underscore. Try renaming the variable to not start with an underscore. - no_leading_underscores_for_local_identifiers

88 issues found. clean (info-level hints only in existing code)
-  passes (5 tests in ctterm)

## Spec reference

Per SPEC/tui/ctterm.md §4 table, Pause/Options screen spec was missing. This spec documents the TUI behavior for the pause menu.