### PR TITLE
Create remaining TUI screen specs: map-context, victory-progress, defeat

### DIFF
--- a/SPEC/tui/screens/defeat.md
+++ b/SPEC/tui/screens/defeat.md
@@ -1,0 +1,92 @@
+# Defeat Screen
+
+**SPEC/tui/screens/defeat.md** — TUI-specific Defeat screen per SPEC/tui/ctterm.md.
+
+## Overview
+
+Defeat screen shown when another Great Power wins the game (human player loses). Reference: [SPEC/game/victory.md](../../game/victory.md).
+
+## UI/UX
+
+- **Layout:** Centered content with defeat message, winner info, and options.
+- **Navigation:** Keyboard selection between options.
+- **Keyboard-first:** All actions via keyboard shortcuts.
+
+## Functionality
+
+### G1: Defeat Message
+
+- **Given** the game ends with an AI victory
+- **When** the Defeat screen displays
+- **Then** show:
+  - "DEFEAT" banner (red color)
+  - "You have been defeated!" message
+  - Winner's name and that they conquered the New World
+
+### G2: Victory Information
+
+- **Given** the Defeat screen displays
+- **When** showing winner information
+- **Then** display:
+  - Winner's display name
+  - Victory type (e.g., "Military Victory")
+  - Turn number when achieved
+
+### G3: Final Standings
+
+- **Given** the Defeat screen displays
+- **When** showing final standings
+- **Then** list all Great Powers:
+  - Sorted by province count (descending)
+  - Show rank, name, and province count
+  - Highlight the winner (human is defeated)
+
+### G4: Option Selection
+
+- **Given** the Defeat screen displays
+- **When** user navigates options
+- **Then** allow selection between:
+  - View Final Map
+  - Return to Main Menu
+
+### G5: Confirm Selection
+
+- **Given** the user has selected an option
+- **When** pressing Enter
+- **Then** execute the selected action:
+  - "View Final Map" → navigate to In-Game Shell
+  - "Return to Main Menu" → exit to Main Menu and clear game state
+
+### G6: Escape Navigation
+
+- **Given** the Defeat screen displays
+- **When** pressing Escape
+- **Then** navigate to In-Game Shell (View Final Map)
+
+## Acceptance Criteria
+
+- [ ] Defeat screen displays "DEFEAT" banner in red
+- [ ] Shows "You have been defeated!" message
+- [ ] Displays winner's name and victory type
+- [ ] Shows turn number when achieved
+- [ ] Displays final standings (all GPs sorted by provinces)
+- [ ] User can select "View Final Map" option
+- [ ] User can select "Return to Main Menu" option
+- [ ] Enter key confirms selection
+- [ ] Escape key returns to In-Game Shell
+- [ ] Game state is cleared when returning to Main Menu
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| v | Select "View Final Map" |
+| m | Select "Return to Main Menu" |
+| Enter / e | Confirm selection |
+| Escape | Back to In-Game Shell |
+
+## Data Source
+
+- Winner information comes from `Game.victory` state set during End-of-turn phase per [SPEC/game/victory.md](../../game/victory.md)
+- Final standings calculated from province ownership counts
+- Tie-breaking uses lexicographically smallest player id per SPEC/game/victory.md

--- a/SPEC/tui/screens/map-context.md
+++ b/SPEC/tui/screens/map-context.md
@@ -1,0 +1,97 @@
+# Map Context Screen
+
+**SPEC/tui/screens/map-context.md** — TUI-specific Map/Province Context screen per SPEC/tui/ctterm.md.
+
+## Overview
+
+Map context screen showing detailed province information, map layers, visibility, and region navigation. Reference: [SPEC/program/player-view.md](../../program/player-view.md), [SPEC/program/map-visualization.md](../../program/map-visualization.md), [SPEC/game/world-model-identity.md](../../game/world-model-identity.md).
+
+## UI/UX
+
+- **Layout:** Split view - map on left/top, context panel on right/bottom (or stacked on narrow terminals).
+- **Navigation:** Back to In-Game Shell via Escape key.
+- **Keyboard-first:** All actions via keyboard shortcuts.
+
+## Functionality
+
+### G1: Province Selection
+
+- **Given** the user is on the Map Context screen
+- **When** navigating to a province on the map
+- **Then** display province information:
+  - Province name (using prefixed province id per SPEC/game/world-model-identity.md)
+  - Owner (Great Power name or "Unclaimed")
+  - Terrain type
+  - Resource extraction (if any)
+  - Town/settlement level (if any)
+  - Visibility status (fog/revealed/fully visible)
+
+### G2: Map Layers
+
+- **Given** the user is on the Map Context screen
+- **When** toggling map layers
+- **Then** show/hide:
+  - Terrain layer (default on)
+  - Ownership layer (shows province control by Great Power)
+  - Town/settlement markers (default on)
+  - Visibility fog of war
+
+### G3: Visibility Display
+
+- **Given** the user is viewing a province
+- **When** the province is in fog of war
+- **Then** show "???" for unknown information and indicate fog status
+- **When** the province is revealed but not owned
+- **Then** show terrain and owner but indicate "revealed only"
+- **When** the province is fully visible
+- **Then** show all available information
+
+### G4: Region Cycling
+
+- **Given** the user is on a narrow terminal
+- **When** cycling between regions
+- **Then** allow navigation between:
+  - Old World
+  - New World
+  - Any other defined regions
+- **And** show current region indicator
+
+### G5: Map Scrolling
+
+- **Given** the user is on the Map Context screen
+- **When** using arrow keys or vi keys (h/j/k/l)
+- **Then** scroll the map viewport
+- **And** maintain province selection if within visible area
+
+### G6: Tile Information
+
+- **Given** the user is viewing a specific tile within a province
+- **When** selecting a tile
+- **Then** display:
+  - Tile coordinates (x, y within province)
+  - Terrain type
+  - Improvement (if any: roads, farms, mines)
+  - Visible units on tile (if any)
+
+## Acceptance Criteria
+
+- [ ] Map Context screen displays ASCII/Unicode map
+- [ ] User can navigate to provinces via keyboard
+- [ ] Selected province shows detailed information
+- [ ] Map layers can be toggled (terrain, ownership, towns, fog)
+- [ ] Fog of war correctly shows/unshows information
+- [ ] Region cycling works (Old World, New World, etc.)
+- [ ] Map scrolling works on narrow terminals
+- [ ] Tile-level information is displayable
+- [ ] Escape key returns to In-Game Shell
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| Arrow keys / h/j/k/l | Navigate/scroll map |
+| Tab / w/s | Cycle selection (province/tile) |
+| 1-4 | Toggle map layers |
+| r | Cycle regions (OW/NW) |
+| Enter / Space | Select province/tile |
+| Escape | Back to In-Game Shell |

--- a/SPEC/tui/screens/victory-progress.md
+++ b/SPEC/tui/screens/victory-progress.md
@@ -1,0 +1,88 @@
+# Victory/Progress Screen
+
+**SPEC/tui/screens/victory-progress.md** — TUI-specific Victory/Progress screen per SPEC/tui/ctterm.md.
+
+## Overview
+
+Victory/Progress screen showing human player's progress toward victory and standings of all Great Powers. Reference: [SPEC/game/victory.md](../../game/victory.md).
+
+## UI/UX
+
+- **Layout:** Progress table and legend, stacked on narrow terminals.
+- **Navigation:** Back to In-Game Shell via Escape key.
+- **Keyboard-first:** All actions via keyboard shortcuts.
+
+## Functionality
+
+### G1: Victory Condition Display
+
+- **Given** the user opens the Victory/Progress screen
+- **When** viewing the victory condition
+- **Then** display:
+  - Victory type (Military victory for MVP)
+  - Threshold: 31 or more Old World provinces controlled
+
+### G2: Great Power Progress Table
+
+- **Given** the user is on the Victory/Progress screen
+- **When** viewing the progress table
+- **Then** show for each Great Power:
+  - Great Power name
+  - Number of Old World provinces controlled
+  - Progress bar toward 31 threshold
+  - Percentage complete
+
+### G3: Progress Sorting
+
+- **Given** the user is on the Victory/Progress screen
+- **When** the progress table is displayed
+- **Then** sort Great Powers by province count (descending)
+- **And** highlight the human player
+
+### G4: Human Player Highlight
+
+- **Given** the user is on the Victory/Progress screen
+- **When** displaying the progress table
+- **Then** highlight the human player's row (e.g., different color)
+- **And** indicate if the human is leading
+
+### G5: Victory Detection
+
+- **Given** the user is on the Victory/Progress screen
+- **When** any Great Power reaches 31+ Old World provinces
+- **Then** trigger the appropriate end-game screen:
+  - If human wins → Victory Screen
+  - If AI wins → Defeat Screen
+
+### G6: Turn End Check
+
+- **Given** a turn ends
+- **When** victory conditions are checked per SPEC/game/victory.md
+- **Then** display game events for victory/defeat
+- **And** navigate to appropriate screen when triggered
+
+## Acceptance Criteria
+
+- [ ] Victory/Progress screen displays title
+- [ ] Victory condition (31 OW provinces) is shown
+- [ ] Progress table shows all Great Powers
+- [ ] Each GP shows province count and progress bar
+- [ ] Table is sorted by province count (descending)
+- [ ] Human player is highlighted
+- [ ] Leading GP is indicated
+- [ ] Escape key returns to In-Game Shell
+- [ ] Works on narrow terminals (stacked layout fallback)
+- [ ] Victory triggers Victory Screen when human wins
+- [ ] Defeat triggers Defeat Screen when AI wins
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| Escape / b | Back to In-Game Shell |
+
+## Data Source
+
+- Province counts come from game state during End-of-turn phase per [SPEC/program/turn-resolution-phase-details.md](../../program/turn-resolution-phase-details.md)
+- Victory check runs once per turn after all phases complete
+- Use prefixed province id (`regionId|localId`) per [SPEC/game/world-model-identity.md](../../game/world-model-identity.md)


### PR DESCRIPTION
Per SPEC/tui/ctterm.md §4 table, these complete all TUI screen specs:

- **SPEC/tui/screens/map-context.md** - Province context, layers, visibility, region cycling, tile information
- **SPEC/tui/screens/victory-progress.md** - Progress toward 31 OW provinces, GP standings, victory detection
- **SPEC/tui/screens/defeat.md** - Defeat screen when AI wins, final standings, navigation options

All specs follow Given-When-Then format per project rules (colonizethis-spec-required.mdc).

This completes all TUI screen specs required by SPEC/tui/ctterm.md §4.