### PR TITLE
feat(ctterm): integrate victory/defeat with game logic

### DIFF
--- a/ctterm/lib/ctterm_app.dart
+++ b/ctterm/lib/ctterm_app.dart
@@ -1,9 +1,13 @@
 // Root ctterm app: navigation shell and main menu. SPEC/tui/ctterm.md.
 
+import 'package:logger/logger.dart' as log_pkg;
 import 'package:nocterm/nocterm.dart';
 
 import 'package:ctterm/ctterm_routes.dart';
 import 'package:ctterm/screens/shell_screen.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+final log_pkg.Logger _log = log_pkg.Logger();
 
 /// Root component. Holds current screen and shows Main Menu or a stub.
 class CttermApp extends StatefulComponent {
@@ -17,9 +21,21 @@ class CttermApp extends StatefulComponent {
 
 class _CttermAppState extends State<CttermApp> {
   CttermRoute _route = CttermRoute.mainMenu;
+  Game? _currentGame;
 
   void _navigateTo(CttermRoute route) {
     setState(() => _route = route);
+  }
+
+  /// Loads a game by ID and navigates to in-game shell.
+  Future<void> _loadGame(String gameId) async {
+    // TODO: Actually load the game using save_service
+    // For now, this is a placeholder - full implementation would:
+    // 1. Call loadGame(gameId, dataDirOverride) from save_service
+    // 2. Store the loaded game in _currentGame
+    // 3. Navigate to inGameShell
+    _log.d('tui:app: load game $gameId (stub)');
+    setState(() => _route = CttermRoute.inGameShell);
   }
 
   void _exit() {
@@ -33,6 +49,7 @@ class _CttermAppState extends State<CttermApp> {
       child: ShellScreen(
         route: _route,
         dataDirOverride: component.dataDirOverride,
+        game: _currentGame,
         onNavigate: _navigateTo,
         onExit: _exit,
       ),

--- a/ctterm/lib/screens/in_game_shell_screen.dart
+++ b/ctterm/lib/screens/in_game_shell_screen.dart
@@ -4,6 +4,7 @@ import 'package:logger/logger.dart' as log_pkg;
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
 
 final log_pkg.Logger _log = log_pkg.Logger();
 
@@ -19,13 +20,22 @@ final log_pkg.Logger _log = log_pkg.Logger();
 class InGameShellScreen extends StatefulComponent {
   const InGameShellScreen({
     super.key,
+    this.game,
     required this.onNavigate,
     required this.onEndTurn,
+    required this.onVictory,
+    required this.onDefeat,
     required this.onExitToMainMenu,
   });
 
+  /// Current game state for victory checking.
+  final Game? game;
   final void Function(CttermRoute) onNavigate;
   final Future<void> Function() onEndTurn;
+  /// Callback when human player wins.
+  final void Function() onVictory;
+  /// Callback when AI player wins (human defeated).
+  final void Function() onDefeat;
   final void Function() onExitToMainMenu;
 
   @override
@@ -58,6 +68,21 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
     
     await component.onEndTurn();
     
+    // Check for victory/defeat after turn processing
+    final game = component.game;
+    if (game?.victory != null) {
+      final winnerId = game!.victory!.winnerPlayerId;
+      final isHumanWinner = _isHumanPlayer(winnerId, game);
+      _log.i('tui:game: victory detected winner=$winnerId isHuman=$isHumanWinner');
+      setState(() => _isEndingTurn = false);
+      if (isHumanWinner) {
+        component.onVictory();
+      } else {
+        component.onDefeat();
+      }
+      return;
+    }
+    
     setState(() {
       _turn++;
       _year += 5; // Each turn = 5 years
@@ -65,6 +90,12 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
       _isEndingTurn = false;
     });
     _log.d('tui:game: now turn $_turn, year $_year');
+  }
+
+  /// Checks if the given playerId is the human player.
+  bool _isHumanPlayer(String playerId, Game game) {
+    // Human player is one where aiControlByGpId is false or not set
+    return !(game.aiControlByGpId[playerId] ?? false);
   }
 
   @override

--- a/ctterm/lib/screens/shell_screen.dart
+++ b/ctterm/lib/screens/shell_screen.dart
@@ -16,6 +16,7 @@ import 'package:ctterm/screens/stub_screen.dart';
 import 'package:ctterm/screens/victory_progress_screen.dart';
 import 'package:ctterm/screens/victory_screen.dart';
 import 'package:ctterm/save_service.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
 
 final log_pkg.Logger _log = log_pkg.Logger();
 
@@ -27,10 +28,13 @@ class ShellScreen extends StatefulComponent {
     required this.onNavigate,
     required this.onExit,
     this.dataDirOverride,
+    this.game,
   });
 
   final CttermRoute route;
   final String? dataDirOverride;
+  /// Current game state. Set when loading or starting a game.
+  final Game? game;
   final void Function(CttermRoute) onNavigate;
   final void Function() onExit;
 
@@ -39,16 +43,22 @@ class ShellScreen extends StatefulComponent {
 }
 
 class _ShellScreenState extends State<ShellScreen> {
-  // Game state for victory/defeat screens
-  final int _currentTurn = 1;
-  
+  /// Triggered when victory condition is met (human wins).
+  /// Uses game.victory data if available, otherwise falls back to defaults.
   void _triggerVictory() {
-    _log.d('tui:game: victory triggered, turn $_currentTurn');
+    final game = component.game;
+    final turn = game?.victory?.turnNumber ?? 1;
+    _log.d('tui:game: victory triggered, turn $turn');
     component.onNavigate(CttermRoute.victory);
   }
-  
+
+  /// Triggered when another player wins (human loses).
+  /// Uses game.victory data if available, otherwise falls back to defaults.
   void _triggerDefeat() {
-    _log.d('tui:game: defeat triggered, turn $_currentTurn');
+    final game = component.game;
+    final turn = game?.victory?.turnNumber ?? 1;
+    final winnerId = game?.victory?.winnerPlayerId;
+    _log.d('tui:game: defeat triggered, turn $turn, winner=$winnerId');
     component.onNavigate(CttermRoute.defeat);
   }
 
@@ -114,11 +124,19 @@ class _ShellScreenState extends State<ShellScreen> {
         );
       case CttermRoute.inGameShell:
         return InGameShellScreen(
+          game: component.game,
           onNavigate: component.onNavigate,
           onEndTurn: () async {
             // TODO: Actually process turn when game logic is wired up
+            // For now, this is a stub. Full turn processing requires:
+            // - MapTopology from loadMapData
+            // - Orders from player input
+            // - Calling resolveTurnForGame from colonizethis_logic
+            // After processing, check game.victory and navigate accordingly.
             _log.d('tui:game: end turn (stub)');
           },
+          onVictory: _triggerVictory,
+          onDefeat: _triggerDefeat,
           onExitToMainMenu: () {
             _log.d('tui:nav: exit to main menu');
             component.onNavigate(CttermRoute.mainMenu);
@@ -149,29 +167,69 @@ class _ShellScreenState extends State<ShellScreen> {
           onDefeat: _triggerDefeat,
         );
       case CttermRoute.victory:
+        // Use game data if available, otherwise fallbacks
+        final victory = component.game?.victory;
         return VictoryScreen(
           onNavigate: component.onNavigate,
           onExitToMainMenu: () {
             _log.d('tui:nav: Victory -> main menu');
             component.onNavigate(CttermRoute.mainMenu);
           },
-          victoryType: 'Military',
-          turnNumber: _currentTurn,
+          victoryType: victory?.type.name ?? 'Military',
+          turnNumber: victory?.turnNumber ?? 1,
           winnerName: 'You',
         );
       case CttermRoute.defeat:
+        // Use game data if available, otherwise fallbacks
+        final victory = component.game?.victory;
+        // Build standings from game state
+        final standings = component.game != null
+            ? _buildStandings(component.game!)
+            : <MapEntry<String, int>>[];
         return DefeatScreen(
           onNavigate: component.onNavigate,
           onExitToMainMenu: () {
             _log.d('tui:nav: Defeat -> main menu');
             component.onNavigate(CttermRoute.mainMenu);
           },
-          winnerName: 'British Empire',
-          victoryType: 'Military',
-          turnNumber: _currentTurn,
+          winnerName: victory?.winnerPlayerId ?? 'AI Player',
+          victoryType: victory?.type.name ?? 'Military',
+          turnNumber: victory?.turnNumber ?? 1,
+          finalStandings: standings,
         );
       case CttermRoute.pauseOptions:
         return const StubScreen(title: 'Pause / Options');
     }
   }
 }
+
+  /// Builds standings from game state for defeat screen.
+  /// Returns list of GP name -> province count, sorted by count descending.
+  List<MapEntry<String, int>> _buildStandings(Game game) {
+    final countsByOwner = <String, int>{};
+    
+    // Count Old World provinces per player
+    for (final province in game.worldState.oldWorld.provinces) {
+      final ownerId = province.ownerId;
+      if (ownerId == null || ownerId.isEmpty) continue;
+      countsByOwner.update(ownerId, (v) => v + 1, ifAbsent: () => 1);
+    }
+    
+    // Get player names
+    final playerNames = <String, String>{};
+    for (final player in game.players) {
+      playerNames[player.id] = player.displayName;
+    }
+    
+    // Build standings list
+    final standings = <MapEntry<String, int>>[];
+    for (final entry in countsByOwner.entries) {
+      final name = playerNames[entry.key] ?? entry.key;
+      standings.add(MapEntry(name, entry.value));
+    }
+    
+    // Sort by province count descending
+    standings.sort((a, b) => b.value.compareTo(a.value));
+    
+    return standings;
+  }


### PR DESCRIPTION
## Summary

Integrates victory/defeat screens with Game.victory state from colonizethis_logic per SPEC/tui/ctterm.md.

## Changes

- **ShellScreen**: Add  parameter, pass to InGameShellScreen and victory/defeat screens
- **InGameShellScreen**: Add  parameter,  and  callbacks; check for victory after turn processing
- **Victory/Defeat screens**: Use actual game data (turn number, winner, victory type) when available
- **Defeat screen**: Build standings from actual game state (OW province counts)
- **CttermApp**: Add  state and placeholder  for future game loading

## Testing

- All ctterm tests pass (5 tests)
- dart analyze shows only info-level hints (no errors)

## Notes

Turn processing is still a stub - full implementation would call  from colonizethis_logic with MapTopology and Orders. The victory/defeat integration is now in place and will work once turn processing is wired up.

See SPEC/tui/ctterm.md §1 (Victory vs Defeat) for the full specification.