### PR TITLE
Wire up game loading and turn processing in ctterm

### DIFF
--- a/ctterm/lib/ctterm_app.dart
+++ b/ctterm/lib/ctterm_app.dart
@@ -5,6 +5,7 @@ import 'package:nocterm/nocterm.dart';
 
 import 'package:ctterm/ctterm_routes.dart';
 import 'package:ctterm/screens/shell_screen.dart';
+import 'package:ctterm/save_service.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 final log_pkg.Logger _log = log_pkg.Logger();
@@ -29,13 +30,29 @@ class _CttermAppState extends State<CttermApp> {
 
   /// Loads a game by ID and navigates to in-game shell.
   Future<void> _loadGame(String gameId) async {
-    // TODO: Actually load the game using save_service
-    // For now, this is a placeholder - full implementation would:
-    // 1. Call loadGame(gameId, dataDirOverride) from save_service
-    // 2. Store the loaded game in _currentGame
-    // 3. Navigate to inGameShell
-    _log.d('tui:app: load game $gameId (stub)');
-    setState(() => _route = CttermRoute.inGameShell);
+    _log.d('tui:app: loading game $gameId');
+    final game = await loadGame(gameId, component.dataDirOverride);
+    if (game == null) {
+      _log.e('tui:app: failed to load game $gameId');
+      return;
+    }
+    _log.i('tui:app: loaded game $gameId, turn ${game.worldState.turnState.turnNumber}');
+    setState(() {
+      _currentGame = game;
+      _route = CttermRoute.inGameShell;
+    });
+  }
+
+  /// Callback when turn is processed, updates game state.
+  void _onTurnProcessed(Game updatedGame) {
+    _log.d('tui:app: turn processed, now turn ${updatedGame.worldState.turnState.turnNumber}');
+    setState(() => _currentGame = updatedGame);
+  }
+
+  /// Clears game state (e.g., when returning to main menu).
+  void _clearGame() {
+    _log.d('tui:app: clearing game state');
+    setState(() => _currentGame = null);
   }
 
   void _exit() {
@@ -52,6 +69,9 @@ class _CttermAppState extends State<CttermApp> {
         game: _currentGame,
         onNavigate: _navigateTo,
         onExit: _exit,
+        onTurnProcessed: _onTurnProcessed,
+        onClearGame: _clearGame,
+        onLoadGame: _loadGame,
       ),
     );
   }

--- a/ctterm/lib/screens/shell_screen.dart
+++ b/ctterm/lib/screens/shell_screen.dart
@@ -16,6 +16,8 @@ import 'package:ctterm/screens/stub_screen.dart';
 import 'package:ctterm/screens/victory_progress_screen.dart';
 import 'package:ctterm/screens/victory_screen.dart';
 import 'package:ctterm/save_service.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 final log_pkg.Logger _log = log_pkg.Logger();
@@ -29,6 +31,9 @@ class ShellScreen extends StatefulComponent {
     required this.onExit,
     this.dataDirOverride,
     this.game,
+    this.onTurnProcessed,
+    this.onClearGame,
+    this.onLoadGame,
   });
 
   final CttermRoute route;
@@ -37,6 +42,12 @@ class ShellScreen extends StatefulComponent {
   final Game? game;
   final void Function(CttermRoute) onNavigate;
   final void Function() onExit;
+  /// Callback when turn is processed, receives updated game state.
+  final void Function(Game)? onTurnProcessed;
+  /// Callback to clear game state (e.g., when returning to main menu).
+  final void Function()? onClearGame;
+  /// Callback to load a game by ID.
+  final Future<void> Function(String gameId)? onLoadGame;
 
   @override
   State<ShellScreen> createState() => _ShellScreenState();
@@ -102,9 +113,10 @@ class _ShellScreenState extends State<ShellScreen> {
       case CttermRoute.loadGame:
         return LoadGameScreen(
           dataDirOverride: component.dataDirOverride,
-          onLoad: (gameId) {
-            _log.d('tui:nav: Load gameId=$gameId -> in-game shell');
-            component.onNavigate(CttermRoute.inGameShell);
+          onLoad: (gameId) async {
+            _log.d('tui:nav: Load gameId=$gameId');
+            // Use the app's loadGame callback to load and navigate
+            await component.onLoadGame?.call(gameId);
           },
           onDelete: (gameId) async {
             _log.i('tui:save: deleting gameId=$gameId');
@@ -127,18 +139,32 @@ class _ShellScreenState extends State<ShellScreen> {
           game: component.game,
           onNavigate: component.onNavigate,
           onEndTurn: () async {
-            // TODO: Actually process turn when game logic is wired up
-            // For now, this is a stub. Full turn processing requires:
-            // - MapTopology from loadMapData
-            // - Orders from player input
-            // - Calling resolveTurnForGame from colonizethis_logic
-            // After processing, check game.victory and navigate accordingly.
-            _log.d('tui:game: end turn (stub)');
+            final game = component.game;
+            if (game == null) {
+              _log.w('tui:game: no game to process turn');
+              return;
+            }
+            _log.d('tui:game: processing turn ${game.worldState.turnState.turnNumber}');
+            
+            // Process turn with minimal topology and empty orders for MVP
+            // Full implementation would load map data and collect player orders
+            const emptyOrders = Orders();
+            const emptyTopology = MapTopology();
+            final nextGame = resolveTurnForGame(
+              game: game,
+              topology: emptyTopology,
+              orders: emptyOrders,
+            );
+            
+            // Notify parent of updated game state
+            component.onTurnProcessed?.call(nextGame);
+            _log.i('tui:game: turn processed, now turn ${nextGame.worldState.turnState.turnNumber}');
           },
           onVictory: _triggerVictory,
           onDefeat: _triggerDefeat,
           onExitToMainMenu: () {
             _log.d('tui:nav: exit to main menu');
+            component.onClearGame?.call();
             component.onNavigate(CttermRoute.mainMenu);
           },
         );


### PR DESCRIPTION
## Summary

Implements the remaining ctterm integration tasks from SPEC/tui/ctterm.md:

1. **Game Loading**: Connect  to  via  callback in  →  →  flow.

2. **Turn Processing**: Wire up turn processing in  callback - now calls  from  with:
   - Current game state
   - Empty  and  (MVP; full implementation would load map data and collect player orders)

3. **State Management**:
   - Added  callback to propagate updated game state from turn resolution back to 
   - Added  callback to clear game state when returning to main menu

## Changes

- : Added  import, implemented , ,  methods, pass callbacks to 
- : Added imports for  and , added  and  props, wire up  in 

## Validation

- Analyzing ctterm...

   info - lib/screens/map_context_screen.dart:297:48 - Use the '??' operator rather than '?:' when testing for 'null'. Try rewriting the code to use '??'. - prefer_if_null_operators
   info - lib/screens/victory_progress_screen.dart:141:25 - Use interpolation to compose strings and values. Try using string interpolation to build the composite string. - prefer_interpolation_to_compose_strings
   info - lib/screens/victory_progress_screen.dart:141:46 - Use interpolation to compose strings and values. Try using string interpolation to build the composite string. - prefer_interpolation_to_compose_strings

3 issues found. - passes with only info-level hints (no errors/warnings)
- 00:00 +0: loading ctterm/test/menu_logic_test.dart
00:00 +0: ctterm/test/menu_logic_test.dart: isLoadGameEnabled returns false when no saves exist
00:00 +1: ctterm/test/menu_logic_test.dart: isLoadGameEnabled returns true when at least one save exists
00:00 +2: loading ctterm/test/save_service_test.dart
00:00 +2: ctterm/test/save_service_test.dart: getCttermDataDir returns override when provided and non-empty
00:00 +3: ctterm/test/save_service_test.dart: getCttermDataDir uses default when override is null
00:00 +4: ctterm/test/save_service_test.dart: listGameIds returns empty list when data dir has no saves
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   _ensureBox (package:ctterm/save_service.dart:43:8)
│ #1   <asynchronous suspension>
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 tui:save: Hive box opened at /tmp/ctterm_test_AWTZJX
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   listGameIds (package:ctterm/save_service.dart:54:8)
│ #1   <asynchronous suspension>
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 tui:save: listGameIds count=0
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
00:00 +5: All tests passed! - all 5 tests pass

## Notes

- MVP uses empty topology/orders; full implementation would load map data via  and collect player orders from UI panels
- InGameShellScreen still has its own local HUD state (, , ) - these update on re-render when parent passes new game prop
- Victory/defeat detection already wired in  checks 