### PR TITLE
Implement Technology and Pause/Options panels (PR #810)

### DIFF
--- a/ctterm/lib/screens/pause_options_screen.dart
+++ b/ctterm/lib/screens/pause_options_screen.dart
@@ -1,0 +1,145 @@
+// Pause/Options screen. SPEC/tui/screens/pause-options.md.
+
+import 'package:logger/logger.dart' as log_pkg;
+import 'package:nocterm/nocterm.dart' hide Logger;
+
+import 'package:ctterm/ctterm_routes.dart';
+
+final _log = log_pkg.Logger();
+
+/// Pause menu with exit to main menu and settings options.
+class PauseOptionsScreen extends StatefulComponent {
+  const PauseOptionsScreen({
+    super.key,
+    required this.onNavigate,
+    required this.onExitToMainMenu,
+  });
+
+  final void Function(CttermRoute) onNavigate;
+  final void Function() onExitToMainMenu;
+
+  @override
+  State<PauseOptionsScreen> createState() => _PauseOptionsScreenState();
+}
+
+class _PauseOptionsScreenState extends State<PauseOptionsScreen> {
+  // Selected menu item (0 = Exit to Main Menu, 1 = Settings)
+  int _selectedIndex = 0;
+  // Show exit confirmation
+  bool _showExitConfirm = false;
+
+  static const _menuItems = ['Exit to Main Menu', 'Settings'];
+
+  @override
+  Component build(BuildContext context) {
+    return KeyboardListener(
+      autofocus: true,
+      onKeyEvent: _handleKeyEvent,
+      child: _showExitConfirm ? _buildExitConfirm() : _buildMenu(),
+    );
+  }
+
+  Component _buildExitConfirm() {
+    return Container(
+      padding: const EdgeInsets.all(1),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Text('Exit to Main Menu?'),
+          const Text('Any unsaved progress will be lost.'),
+          const SizedBox(height: 1),
+          const Text('[Y] Yes  [N] No'),
+        ],
+      ),
+    );
+  }
+
+  Component _buildMenu() {
+    return Container(
+      padding: const EdgeInsets.all(1),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const SizedBox(height: 2),
+          const Text('=== PAUSE ===', style: TextStyle(fontWeight: FontWeight.bold)),
+          const SizedBox(height: 2),
+          ..._buildMenuItems(),
+          const SizedBox(height: 2),
+          const Text('[Esc/B] Back to Game  [Enter] Select'),
+          const Text('[W/S or Up/Down] Navigate'),
+        ],
+      ),
+    );
+  }
+
+  List<Component> _buildMenuItems() {
+    return List.generate(_menuItems.length, (index) {
+      final isSelected = index == _selectedIndex;
+      final prefix = isSelected ? '> ' : '  ';
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 0),
+        child: Text('$prefix${_menuItems[index]}'),
+      );
+    });
+  }
+
+  // ignore: strict_top_level_inference
+  bool _handleKeyEvent(event) {
+    final key = event.logicalKey;
+    final c = event.character?.toLowerCase();
+
+    // Handle exit confirmation
+    if (_showExitConfirm) {
+      if (c == 'y' || key == LogicalKey.enter) {
+        _log.d('tui:nav: exiting to main menu from pause');
+        component.onExitToMainMenu();
+        return true;
+      } else if (c == 'n' || key == LogicalKey.escape) {
+        setState(() => _showExitConfirm = false);
+        return true;
+      }
+      return false;
+    }
+
+    // Escape or B - back to game
+    if (key == LogicalKey.escape || c == 'b') {
+      component.onNavigate(CttermRoute.inGameShell);
+      return true;
+    }
+
+    // W or Up - previous item
+    if (c == 'w' || key == LogicalKey.arrowUp) {
+      setState(() {
+        if (_selectedIndex > 0) {
+          _selectedIndex--;
+        }
+      });
+      return true;
+    }
+
+    // S or Down - next item
+    if (c == 's' || key == LogicalKey.arrowDown) {
+      setState(() {
+        if (_selectedIndex < _menuItems.length - 1) {
+          _selectedIndex++;
+        }
+      });
+      return true;
+    }
+
+    // Enter - execute selected action
+    if (key == LogicalKey.enter) {
+      if (_selectedIndex == 0) {
+        // Exit to Main Menu
+        setState(() => _showExitConfirm = true);
+        return true;
+      } else if (_selectedIndex == 1) {
+        // Settings (navigate to settings screen)
+        component.onNavigate(CttermRoute.settings);
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/ctterm/lib/screens/shell_screen.dart
+++ b/ctterm/lib/screens/shell_screen.dart
@@ -12,7 +12,6 @@ import 'package:ctterm/screens/load_game_screen.dart';
 import 'package:ctterm/screens/main_menu_screen.dart';
 import 'package:ctterm/screens/map_context_screen.dart';
 import 'package:ctterm/screens/settings_screen.dart';
-import 'package:ctterm/screens/stub_screen.dart';
 import 'package:ctterm/screens/victory_progress_screen.dart';
 import 'package:ctterm/screens/units_screen.dart';
 import 'package:ctterm/screens/development_screen.dart';
@@ -21,6 +20,8 @@ import 'package:ctterm/screens/academy_screen.dart';
 import 'package:ctterm/screens/shipyard_screen.dart';
 import 'package:ctterm/screens/victory_screen.dart';
 import 'package:ctterm/screens/diplomacy_screen.dart';
+import 'package:ctterm/screens/technology_screen.dart';
+import 'package:ctterm/screens/pause_options_screen.dart';
 import 'package:ctterm/save_service.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
@@ -93,11 +94,19 @@ class _ShellScreenState extends State<ShellScreen> {
     return KeyboardListener(
       onKeyEvent: (LogicalKey key) {
         if (key == LogicalKey.escape) {
-          if (component.route != CttermRoute.mainMenu) {
+          // Let in-game routes handle their own escape (pause menu, etc.)
+          // Only handle escape at shell level for routes outside game flow
+          if (component.route == CttermRoute.mainMenu ||
+              component.route == CttermRoute.gameSetup ||
+              component.route == CttermRoute.loadGame ||
+              component.route == CttermRoute.settings ||
+              component.route == CttermRoute.generatingWorld) {
             _log.d('tui:nav: Esc -> main menu');
             component.onNavigate(CttermRoute.mainMenu);
+            return true;
           }
-          return true;
+          // For in-game routes, let them handle escape themselves
+          return false;
         }
         return false;
       },
@@ -239,7 +248,14 @@ class _ShellScreenState extends State<ShellScreen> {
           },
         );
       case CttermRoute.technology:
-        return const StubScreen(title: 'Technology');
+        return TechnologyScreen(
+          game: component.game!,
+          orders: component.orders ?? const Orders(),
+          onNavigate: component.onNavigate,
+          onOrdersChanged: (Orders orders) {
+            component.onOrdersChanged?.call(orders);
+          },
+        );
       case CttermRoute.victoryProgress:
         return VictoryProgressScreen(
           onNavigate: component.onNavigate,
@@ -278,7 +294,14 @@ class _ShellScreenState extends State<ShellScreen> {
           finalStandings: standings,
         );
       case CttermRoute.pauseOptions:
-        return const StubScreen(title: 'Pause / Options');
+        return PauseOptionsScreen(
+          onNavigate: component.onNavigate,
+          onExitToMainMenu: () {
+            _log.d('tui:nav: exit to main menu from pause');
+            component.onClearGame?.call();
+            component.onNavigate(CttermRoute.mainMenu);
+          },
+        );
     }
   }
 }

--- a/ctterm/lib/screens/technology_screen.dart
+++ b/ctterm/lib/screens/technology_screen.dart
@@ -1,0 +1,525 @@
+// Technology screen — research panel. SPEC/tui/screens/technology.md.
+
+import 'package:logger/logger.dart' as log_pkg;
+import 'package:nocterm/nocterm.dart' hide Logger;
+
+import 'package:ctterm/ctterm_routes.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+final _log = log_pkg.Logger();
+
+/// Technology research panel.
+/// Shows research slots, available techs, and allows assigning research.
+class TechnologyScreen extends StatefulComponent {
+  const TechnologyScreen({
+    super.key,
+    required this.game,
+    required this.orders,
+    required this.onNavigate,
+    required this.onOrdersChanged,
+  });
+
+  final Game game;
+  final Orders orders;
+  final void Function(CttermRoute) onNavigate;
+  final void Function(Orders orders) onOrdersChanged;
+
+  @override
+  State<TechnologyScreen> createState() => _TechnologyScreenState();
+}
+
+class _TechnologyScreenState extends State<TechnologyScreen> {
+  // Selected slot (0-based index)
+  int _selectedSlot = 0;
+  // Selected tech in available list
+  int _selectedTechIndex = 0;
+  // Category filter
+  String _categoryFilter = 'all';
+  // Show cancel confirmation
+  bool _showCancelConfirm = false;
+
+  // Categories for filtering
+  static const _categories = [
+    'all',
+    'gathering',
+    'transport',
+    'labour',
+    'diplomacy',
+    'naval',
+    'military',
+    'newWorld',
+  ];
+
+  // Get human player ID
+  String get _humanPlayerId {
+    for (final entry in component.game.aiControlByGpId.entries) {
+      if (entry.value == false) return entry.key;
+    }
+    return component.game.players.isNotEmpty ? component.game.players.first.id : '';
+  }
+
+  // Get human player
+  Player? get _humanPlayer {
+    final humanId = _humanPlayerId;
+    for (final player in component.game.players) {
+      if (player.id == humanId) return player;
+    }
+    return null;
+  }
+
+  // Get research slots (default 3)
+  int get _researchSlots => _humanPlayer?.researchSlots ?? 3;
+
+  // Get tech unlocked map
+  Map<String, bool> get _techUnlocked => _humanPlayer?.techUnlocked ?? {};
+
+  // Get research progress map
+  Map<String, int> get _researchProgress =>
+      _humanPlayer?.researchProgressByTechId ?? {};
+
+  // Get current research orders for human player
+  List<ResearchOrder> get _researchOrders {
+    return component.orders.researchOrdersByPlayerId[_humanPlayerId] ?? [];
+  }
+
+  // Get funding level for a slot
+  ResearchFundingLevel _getFundingForSlot(int slotIndex) {
+    for (final order in _researchOrders) {
+      if (order.slotIndex == slotIndex) return order.funding;
+    }
+    return ResearchFundingLevel.none;
+  }
+
+  // Get tech assigned to a slot
+  String? _getTechForSlot(int slotIndex) {
+    for (final order in _researchOrders) {
+      if (order.slotIndex == slotIndex) {
+        return order.techId.isNotEmpty ? order.techId : null;
+      }
+    }
+    return null;
+  }
+
+  // Get filtered available techs
+  List<TechDefinition> get _availableTechs {
+    final techs = <TechDefinition>[];
+    final unlocked = _techUnlocked;
+    final currentResearch = _researchOrders.map((o) => o.techId).toSet();
+
+    for (final tech in techCatalog.values) {
+      // Skip if category doesn't match
+      if (_categoryFilter != 'all' && tech.category != _categoryFilter) {
+        continue;
+      }
+
+      // Skip if already unlocked
+      if (unlocked[tech.id] == true) continue;
+
+      // Skip if already being researched
+      if (currentResearch.contains(tech.id)) continue;
+
+      techs.add(tech);
+    }
+
+    // Sort by era, then name
+    techs.sort((a, b) {
+      final eraComp = a.era.compareTo(b.era);
+      if (eraComp != 0) return eraComp;
+      return a.id.compareTo(b.id);
+    });
+
+    return techs;
+  }
+
+  // Get unlocked tech count
+  int get _unlockedCount {
+    int count = 0;
+    for (final unlocked in _techUnlocked.values) {
+      if (unlocked) count++;
+    }
+    return count;
+  }
+
+  // Total tech count
+  int get _totalTechCount => techCatalog.length;
+
+  // Assign tech to slot
+  void _assignTech(String techId) {
+    if (techId.isEmpty) return;
+
+    final humanId = _humanPlayerId;
+    final currentOrders = List<ResearchOrder>.from(_researchOrders);
+
+    // Find existing order for this slot
+    final existingIndex = currentOrders.indexWhere((o) => o.slotIndex == _selectedSlot);
+
+    final newOrder = ResearchOrder(
+      slotIndex: _selectedSlot,
+      techId: techId,
+      funding: existingIndex >= 0 ? currentOrders[existingIndex].funding : ResearchFundingLevel.medium,
+    );
+
+    if (existingIndex >= 0) {
+      currentOrders[existingIndex] = newOrder;
+    } else {
+      currentOrders.add(newOrder);
+    }
+
+    final newOrdersByPlayerId = Map<String, List<ResearchOrder>>.from(
+      component.orders.researchOrdersByPlayerId,
+    );
+    newOrdersByPlayerId[humanId] = currentOrders;
+
+    final newOrders = Orders(
+      moveOrdersByPlayerId: component.orders.moveOrdersByPlayerId,
+      buildUnitOrdersByPlayerId: component.orders.buildUnitOrdersByPlayerId,
+      workOrdersByPlayerId: component.orders.workOrdersByPlayerId,
+      diplomaticOrdersByPlayerId: component.orders.diplomaticOrdersByPlayerId,
+      researchOrdersByPlayerId: newOrdersByPlayerId,
+      navalMoveOrdersByPlayerId: component.orders.navalMoveOrdersByPlayerId,
+      navalMissionOrdersByPlayerId: component.orders.navalMissionOrdersByPlayerId,
+    );
+
+    component.onOrdersChanged(newOrders);
+    _log.d('tui:tech: assigned $techId to slot ${_selectedSlot + 1}');
+  }
+
+  // Set funding level for slot
+  void _setFunding(ResearchFundingLevel level) {
+    final humanId = _humanPlayerId;
+    final currentOrders = List<ResearchOrder>.from(_researchOrders);
+
+    final existingIndex = currentOrders.indexWhere((o) => o.slotIndex == _selectedSlot);
+    if (existingIndex < 0) return; // No tech in slot
+
+    final existing = currentOrders[existingIndex];
+    final updated = ResearchOrder(
+      slotIndex: existing.slotIndex,
+      techId: existing.techId,
+      funding: level,
+    );
+    currentOrders[existingIndex] = updated;
+
+    final newOrdersByPlayerId = Map<String, List<ResearchOrder>>.from(
+      component.orders.researchOrdersByPlayerId,
+    );
+    newOrdersByPlayerId[humanId] = currentOrders;
+
+    final newOrders = Orders(
+      moveOrdersByPlayerId: component.orders.moveOrdersByPlayerId,
+      buildUnitOrdersByPlayerId: component.orders.buildUnitOrdersByPlayerId,
+      workOrdersByPlayerId: component.orders.workOrdersByPlayerId,
+      diplomaticOrdersByPlayerId: component.orders.diplomaticOrdersByPlayerId,
+      researchOrdersByPlayerId: newOrdersByPlayerId,
+      navalMoveOrdersByPlayerId: component.orders.navalMoveOrdersByPlayerId,
+      navalMissionOrdersByPlayerId: component.orders.navalMissionOrdersByPlayerId,
+    );
+
+    component.onOrdersChanged(newOrders);
+    _log.d('tui:tech: set funding ${level.name} for slot ${_selectedSlot + 1}');
+  }
+
+  // Cancel research in slot
+  void _cancelResearch() {
+    final humanId = _humanPlayerId;
+    final currentOrders = List<ResearchOrder>.from(_researchOrders);
+
+    currentOrders.removeWhere((o) => o.slotIndex == _selectedSlot);
+
+    final newOrdersByPlayerId = Map<String, List<ResearchOrder>>.from(
+      component.orders.researchOrdersByPlayerId,
+    );
+    newOrdersByPlayerId[humanId] = currentOrders;
+
+    final newOrders = Orders(
+      moveOrdersByPlayerId: component.orders.moveOrdersByPlayerId,
+      buildUnitOrdersByPlayerId: component.orders.buildUnitOrdersByPlayerId,
+      workOrdersByPlayerId: component.orders.workOrdersByPlayerId,
+      diplomaticOrdersByPlayerId: component.orders.diplomaticOrdersByPlayerId,
+      researchOrdersByPlayerId: newOrdersByPlayerId,
+      navalMoveOrdersByPlayerId: component.orders.navalMoveOrdersByPlayerId,
+      navalMissionOrdersByPlayerId: component.orders.navalMissionOrdersByPlayerId,
+    );
+
+    component.onOrdersChanged(newOrders);
+    setState(() => _showCancelConfirm = false);
+    _log.d('tui:tech: cancelled slot ${_selectedSlot + 1}');
+  }
+
+  @override
+  Component build(BuildContext context) {
+    final techs = _availableTechs;
+    final slots = _researchSlots;
+
+    // Clamp selected indices
+    if (_selectedSlot >= slots) _selectedSlot = slots - 1;
+    if (_selectedSlot < 0) _selectedSlot = 0;
+    if (_selectedTechIndex >= techs.length) _selectedTechIndex = techs.isEmpty ? 0 : techs.length - 1;
+
+    return KeyboardListener(
+      autofocus: true,
+      onKeyEvent: _handleKeyEvent,
+      child: _showCancelConfirm
+          ? _buildCancelConfirm()
+          : _buildMainPanel(techs, slots),
+    );
+  }
+
+  Component _buildCancelConfirm() {
+    return Container(
+      padding: const EdgeInsets.all(1),
+      child: Column(
+        children: [
+          const Text('Cancel research? Progress will be lost.'),
+          const SizedBox(height: 1),
+          const Text('[Y] Yes  [N] No'),
+        ],
+      ),
+    );
+  }
+
+  Component _buildMainPanel(List<TechDefinition> techs, int slots) {
+    return Container(
+      padding: const EdgeInsets.all(1),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Header
+          Row(children: [
+            const Text('Technology'),
+            const Spacer(),
+            const Text('[Esc: Back]'),
+          ]),
+          Text('─' * 60),
+
+          // Research Slots
+          Text('Research Slots ($_selectedSlot/${slots})'),
+          _buildSlotsTable(slots),
+          const SizedBox(height: 1),
+
+          // Available Techs with filter
+          Row(children: [
+            Text('Available Techs (filter: ${_categoryFilter.toUpperCase()})'),
+            const Spacer(),
+            const Text('[Tab]'),
+          ]),
+          _buildTechsList(techs),
+          const SizedBox(height: 1),
+
+          // Footer
+          Text('Unlocked: $_unlockedCount/$_totalTechCount'),
+          const Text('[F1-F4: Slot] [Enter: Assign] [1-5: Funding] [Del: Cancel] [Tab: Filter] [W/S: Scroll]'),
+        ],
+      ),
+    );
+  }
+
+  Component _buildSlotsTable(int slots) {
+    final rows = <Component>[];
+
+    // Header row
+    rows.add(Row(children: [
+      const Text('Slot ', style: TextStyle(fontWeight: FontWeight.bold)),
+      const Text('Tech ', style: TextStyle(fontWeight: FontWeight.bold)),
+      const Text('Funding ', style: TextStyle(fontWeight: FontWeight.bold)),
+      const Text('Progress ', style: TextStyle(fontWeight: FontWeight.bold)),
+    ]));
+
+    // Slot rows
+    for (int i = 0; i < slots; i++) {
+      final techId = _getTechForSlot(i);
+      final funding = _getFundingForSlot(i);
+      final isSelected = i == _selectedSlot;
+
+      final techDef = techId != null ? techById(techId) : null;
+      final progress = techId != null ? (_researchProgress[techId] ?? 0) : 0;
+      final cost = techDef?.cost ?? 0;
+      final progressBar = _renderProgressBar(progress, cost);
+
+      final label = isSelected ? '▶ ' : '  ';
+
+      rows.add(Row(children: [
+        Text('$label${i + 1} '),
+        Text(techId ?? '— Empty —'),
+        Text(' '),
+        Text(_fundingLabel(funding)),
+        Text(' '),
+        Text(progressBar),
+        Text(' ${progress}/${cost} RP'),
+      ]));
+    }
+
+    return Column(children: rows);
+  }
+
+  String _renderProgressBar(int progress, int cost) {
+    if (cost == 0) return '—';
+    final percent = (progress / cost).clamp(0.0, 1.0);
+    final filled = (percent * 10).round();
+    final empty = 10 - filled;
+    return '█' * filled + '░' * empty;
+  }
+
+  String _fundingLabel(ResearchFundingLevel level) {
+    switch (level) {
+      case ResearchFundingLevel.none:
+        return 'None';
+      case ResearchFundingLevel.low:
+        return 'Low';
+      case ResearchFundingLevel.medium:
+        return 'Medium';
+      case ResearchFundingLevel.high:
+        return 'High';
+      case ResearchFundingLevel.maximum:
+        return 'Maximum';
+    }
+  }
+
+  Component _buildTechsList(List<TechDefinition> techs) {
+    if (techs.isEmpty) {
+      return const Text('  (no available techs in this category)');
+    }
+
+    final rows = <Component>[];
+
+    // Header
+    rows.add(Row(children: [
+      const Text('Era ', style: TextStyle(fontWeight: FontWeight.bold)),
+      const Text('Tech ', style: TextStyle(fontWeight: FontWeight.bold)),
+      const Text('Cost ', style: TextStyle(fontWeight: FontWeight.bold)),
+      const Text('Prereqs ', style: TextStyle(fontWeight: FontWeight.bold)),
+    ]));
+
+    // Tech rows (limit to 10 for now)
+    final displayTechs = techs.take(10).toList();
+    for (int i = 0; i < displayTechs.length; i++) {
+      final tech = displayTechs[i];
+      final isSelected = i == _selectedTechIndex;
+
+      final label = isSelected ? '▶ ' : '  ';
+      final prereqStr = tech.prerequisiteIds.isEmpty
+          ? '—'
+          : tech.prerequisiteIds.map((p) => techById(p)?.id ?? p).join(', ');
+
+      rows.add(Row(children: [
+        Text('$label${tech.era} '),
+        Text(tech.id.replaceAll('_', ' ')),
+        Text(' ${tech.cost} '),
+        Text(prereqStr),
+      ]));
+    }
+
+    if (techs.length > 10) {
+      rows.add(Text('  ... (${techs.length - 10} more)'));
+    }
+
+    return Column(children: rows);
+  }
+
+  // ignore: strict_top_level_inference
+  bool _handleKeyEvent(event) {
+    final key = event.logicalKey;
+    final c = event.character?.toLowerCase();
+
+    // Handle cancel confirmation
+    if (_showCancelConfirm) {
+      if (c == 'y') {
+        _cancelResearch();
+        return true;
+      } else if (c == 'n' || key == LogicalKey.escape) {
+        setState(() => _showCancelConfirm = false);
+        return true;
+      }
+      return false;
+    }
+
+    // Escape or Q - back
+    if (key == LogicalKey.escape || c == 'q') {
+      component.onNavigate(CttermRoute.inGameShell);
+      return true;
+    }
+
+    // F1-F4 - select slot
+    if (key == LogicalKey.f1) {
+      setState(() => _selectedSlot = 0);
+      return true;
+    } else if (key == LogicalKey.f2) {
+      setState(() => _selectedSlot = 1);
+      return true;
+    } else if (key == LogicalKey.f3) {
+      setState(() => _selectedSlot = 2);
+      return true;
+    } else if (key == LogicalKey.f4) {
+      if (_researchSlots >= 4) {
+        setState(() => _selectedSlot = 3);
+      }
+      return true;
+    }
+
+    // 1-5 - funding levels
+    if (c == '1') {
+      _setFunding(ResearchFundingLevel.none);
+      return true;
+    } else if (c == '2') {
+      _setFunding(ResearchFundingLevel.low);
+      return true;
+    } else if (c == '3') {
+      _setFunding(ResearchFundingLevel.medium);
+      return true;
+    } else if (c == '4') {
+      _setFunding(ResearchFundingLevel.high);
+      return true;
+    } else if (c == '5') {
+      _setFunding(ResearchFundingLevel.maximum);
+      return true;
+    }
+
+    // Delete or C - cancel research
+    if (key == LogicalKey.delete || c == 'c') {
+      final techId = _getTechForSlot(_selectedSlot);
+      if (techId != null) {
+        setState(() => _showCancelConfirm = true);
+      }
+      return true;
+    }
+
+    // Tab - cycle category
+    if (key == LogicalKey.tab) {
+      final currentIdx = _categories.indexOf(_categoryFilter);
+      final nextIdx = (currentIdx + 1) % _categories.length;
+      setState(() {
+        _categoryFilter = _categories[nextIdx];
+        _selectedTechIndex = 0;
+      });
+      return true;
+    }
+
+    // Up/Down or W/S - navigate tech list
+    if (c == 'w' || key == LogicalKey.arrowUp) {
+      setState(() {
+        if (_selectedTechIndex > 0) _selectedTechIndex--;
+      });
+      return true;
+    } else if (c == 's' || key == LogicalKey.arrowDown) {
+      final techs = _availableTechs;
+      setState(() {
+        if (_selectedTechIndex < techs.length - 1 && _selectedTechIndex < 9) {
+          _selectedTechIndex++;
+        }
+      });
+      return true;
+    }
+
+    // Enter - assign tech
+    if (key == LogicalKey.enter) {
+      final techs = _availableTechs;
+      if (_selectedTechIndex < techs.length) {
+        _assignTech(techs[_selectedTechIndex].id);
+      }
+      return true;
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the final two remaining panel stubs in ctterm:

### Technology Screen ()
- Research slots display (1-4 based on University unlock)
- Available techs list with era, cost, prerequisites
- Category filtering (All → Gathering → Transport → Labour → Diplomacy → Naval → Military → New World)
- Funding level control (None/Low/Medium/High/Maximum)
- Progress bars for ongoing research
- Assign tech with Enter, cancel with Delete/C
- Keyboard shortcuts: F1-F4 (slot), 1-5 (funding), Tab (filter), W/S (scroll), Enter (assign), Del/C (cancel)

### Pause/Options Screen ()
- Pause menu with Exit to Main Menu and Settings options
- Confirmation dialog when exiting
- Keyboard navigation (W/S or arrows to move, Enter to select)
- Escape or B to return to game

### Additional Changes
- Fixed  to let in-game routes (like in-game shell) handle Escape key themselves for pause menu, instead of routing directly to main menu.

## Tests
- All ctterm tests pass (5 tests)
- Dart analyze clean (info-level suggestions only)

## Spec References
- SPEC/tui/screens/technology.md
- SPEC/tui/screens/pause-options.md