### PR TITLE
ctterm: New Game creates real game, file logging via basic_logger_file

### DIFF
--- a/.cursor/rules/colonizethis-logging-file.mdc
+++ b/.cursor/rules/colonizethis-logging-file.mdc
@@ -1,0 +1,10 @@
+---
+description: Whenever file logging is needed, use basic_logger_file. Do not implement custom file logging.
+alwaysApply: true
+---
+
+# File logging
+
+- **Library:** Use [basic_logger_file](https://pub.dev/packages/basic_logger_file) for any file logging (e.g. writing logs to a file such as `ctterm.log`).
+- **Do not:** Implement your own file logging (e.g. raw `dart:io` `File`/`IOSink`, or manual `Logger.addLogListener` that writes to a file). Use the library instead.
+- **Usage:** `BasicLogger` + `FileOutputLogger` from `basic_logger` and `basic_logger_file`. Attach `FileOutputLogger` with `dir`, `ext`, and optional `bufferSize`; forward app log events to the BasicLogger so the library handles buffering and writing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ These rules are applied in every context; follow them for all changes.
 |-----------|---------|
 | **colonizethis-spec-required.mdc** | SPEC-first: specify before implementing; no behavior that contradicts specs. GDD `SPEC/game/`, TDD `SPEC/program/`, AI `SPEC/ai/`, UI `SPEC/ui/` (sub-specs, max 1000 words). Source of truth: GDD for game/AI, TDD for architecture. Conflicts: resolve GDD/TDD first. Rulesets: configurable; specify where/how in GDD/TDD. New behavior: point to authorizing spec or add/extend spec first. |
 | **colonizethis-core-principles.mdc** | Stack: Flutter (UI), Flame (game/simulation), Dart. Strict typing, null safety, logger (no `print`). Thin screens; delegate to services/controllers/Flame. Province lookup: always use `(regionId, provinceId)` or prefixed id; never province id alone. |
+| **colonizethis-logging-file.mdc** | Whenever file logging is needed, use **basic_logger_file** (BasicLogger + FileOutputLogger). Do not implement custom file logging (e.g. raw File/IOSink or manual log-to-file). |
 
 ## Context-specific rules
 
@@ -38,6 +39,7 @@ Apply these when working in the indicated areas (by path or topic).
 3. **When touching UI:** Wireframes in spec; Widgetbook + catalog; pixel art per UXD (exact prompts in spec; check assets first, don’t regenerate if suitable asset exists); Flame for canvas, Flutter for shell/overlays/menus.
 4. **When adding a tool:** Thin facade in `tool/<name>`; logic in packages; Melos script and `docs/project-tools.md` updated.
 5. **When writing tests:** 90% per package; unit/widget/game-component layers; cover combat, economy, save/load, ruleset loading.
-6. **When reviewing/generating code:** Use the code-review checklist (lengths, types, spec, logging, reuse, tests).
+6. **When file logging:** Use **basic_logger_file** (BasicLogger + FileOutputLogger); do not implement custom file logging.
+7. **When reviewing/generating code:** Use the code-review checklist (lengths, types, spec, logging, reuse, tests).
 
 For full text of each rule, read the files in `.cursor/rules/`.

--- a/ctterm/bin/ctterm.dart
+++ b/ctterm/bin/ctterm.dart
@@ -9,9 +9,6 @@ import 'package:ctterm/ctterm_log.dart';
 final log_pkg.Logger _log = log_pkg.Logger();
 
 void main(List<String> args) async {
-  initCttermLogging();
-  _log.i('tui: ctterm starting');
-
   String? dataDirOverride;
   for (var i = 0; i < args.length; i++) {
     if (args[i] == '--data-dir' && i + 1 < args.length) {
@@ -20,6 +17,9 @@ void main(List<String> args) async {
       break;
     }
   }
+
+  initCttermLogging(dataDirOverride);
+  _log.i('tui: ctterm starting');
 
   runApp(CttermApp(dataDirOverride: dataDirOverride));
 }

--- a/ctterm/lib/ctterm_app.dart
+++ b/ctterm/lib/ctterm_app.dart
@@ -6,9 +6,31 @@ import 'package:nocterm/nocterm.dart';
 import 'package:ctterm/ctterm_routes.dart';
 import 'package:ctterm/screens/shell_screen.dart';
 import 'package:ctterm/save_service.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 final log_pkg.Logger _log = log_pkg.Logger();
+
+/// Pending setup data when user has completed Game Setup and we are about to generate the world.
+class _PendingNewGameConfig {
+  const _PendingNewGameConfig({
+    required this.orderedGpIdsForSlots,
+    required this.leaderVariantByGpId,
+  });
+  final List<String> orderedGpIdsForSlots;
+  final Map<String, String> leaderVariantByGpId;
+}
+
+/// Map data cached after new game creation for turn resolution (extraction, movement).
+class _MapCache {
+  const _MapCache({
+    required this.combinedTopology,
+    required this.tileMapByRegion,
+  });
+  final MapTopology combinedTopology;
+  final Map<String, TileMapResult> tileMapByRegion;
+}
 
 /// Root component. Holds current screen and shows Main Menu or a stub.
 class CttermApp extends StatefulComponent {
@@ -24,9 +46,66 @@ class _CttermAppState extends State<CttermApp> {
   CttermRoute _route = CttermRoute.mainMenu;
   Game? _currentGame;
   Orders _currentOrders = const Orders();
+  _PendingNewGameConfig? _pendingNewGameConfig;
+  _MapCache? _mapCache;
 
   void _navigateTo(CttermRoute route) {
     setState(() => _route = route);
+  }
+
+  /// Stores setup data and navigates to Generating World. Called from Game Setup when user presses Start.
+  void _onPrepareNewGame(List<String> orderedGpIdsForSlots, Map<String, String> leaderVariantByGpId) {
+    _log.d('tui:app: prepare new game with ${orderedGpIdsForSlots.length} players');
+    setState(() {
+      _pendingNewGameConfig = _PendingNewGameConfig(
+        orderedGpIdsForSlots: orderedGpIdsForSlots,
+        leaderVariantByGpId: leaderVariantByGpId,
+      );
+      _route = CttermRoute.generatingWorld;
+    });
+  }
+
+  /// Runs world generation (runInitGame) with pending config, then sets game and navigates to in-game shell.
+  /// Called by GeneratingWorldScreen when it mounts. Game is never null after this for a new-game flow.
+  void _runGeneration() {
+    final pending = _pendingNewGameConfig;
+    if (pending == null) {
+      _log.w('tui:app: runGeneration called with no pending config');
+      return;
+    }
+    final config = GameSetupConfig(
+      selectedGreatPowerIds: List<String>.from(pending.orderedGpIdsForSlots),
+      leaderVariantByGpId: Map<String, String>.from(pending.leaderVariantByGpId),
+      seed: GameSetupConfig.defaultConfig.seed,
+      continentCount: GameSetupConfig.defaultConfig.continentCount,
+      minorNationCount: GameSetupConfig.defaultConfig.minorNationCount,
+      tribeCount: GameSetupConfig.defaultConfig.tribeCount,
+      numProvincesOldWorld: GameSetupConfig.defaultConfig.numProvincesOldWorld,
+      numProvincesNewWorld: GameSetupConfig.defaultConfig.numProvincesNewWorld,
+      minProvincesPerMinor: GameSetupConfig.defaultConfig.minProvincesPerMinor,
+    );
+    try {
+      _log.i('tui:app: running init game');
+      final result = runInitGame(
+        config: config,
+        options: const InitGameOptions(renderPng: false),
+      );
+      _log.i('tui:app: init game complete, turn ${result.game.worldState.turnState.turnNumber}');
+      // Set game and route in one setState so no rebuild can see inGameShell with null game.
+      setState(() {
+        _currentGame = result.game;
+        _mapCache = _MapCache(
+          combinedTopology: result.combinedTopology,
+          tileMapByRegion: result.tileMapByRegion,
+        );
+        _pendingNewGameConfig = null;
+        _route = CttermRoute.inGameShell;
+      });
+    } catch (e, st) {
+      _log.e('tui:app: init game failed', error: e, stackTrace: st);
+      setState(() => _pendingNewGameConfig = null);
+      _navigateTo(CttermRoute.mainMenu);
+    }
   }
 
   /// Loads a game by ID and navigates to in-game shell.
@@ -59,6 +138,8 @@ class _CttermAppState extends State<CttermApp> {
     setState(() {
       _currentGame = null;
       _currentOrders = const Orders();
+      _mapCache = null;
+      _pendingNewGameConfig = null;
     });
   }
 
@@ -81,8 +162,12 @@ class _CttermAppState extends State<CttermApp> {
         dataDirOverride: component.dataDirOverride,
         game: _currentGame,
         orders: _currentOrders,
+        combinedTopology: _mapCache?.combinedTopology,
+        tileMapByRegion: _mapCache?.tileMapByRegion,
         onNavigate: _navigateTo,
         onExit: _exit,
+        onPrepareNewGame: _onPrepareNewGame,
+        runGeneration: _route == CttermRoute.generatingWorld ? _runGeneration : null,
         onTurnProcessed: _onTurnProcessed,
         onOrdersChanged: _updateOrders,
         onGameUpdated: (game) {

--- a/ctterm/lib/ctterm_log.dart
+++ b/ctterm/lib/ctterm_log.dart
@@ -1,9 +1,80 @@
 // ctterm logging. SPEC/tui/ctterm.md §5. Use prefixes tui:, tui:menu:, tui:save:, tui:nav:, etc.
+// File output via basic_logger_file (ctterm.log in the ctterm data directory).
 
+import 'dart:io';
+
+import 'package:basic_logger/basic_logger.dart';
+import 'package:basic_logger_file/basic_logger_file.dart';
 import 'package:logger/logger.dart';
+import 'package:path/path.dart' as path;
+
+/// Resolves ctterm data directory. Same convention as save_service (SPEC/tui/ctterm.md §5).
+String _cttermDataDir(String? override) {
+  if (override != null && override.isNotEmpty) return override;
+  final env = Platform.environment;
+  if (Platform.isLinux && env.containsKey('XDG_DATA_HOME')) {
+    return path.join(env['XDG_DATA_HOME']!, 'colonizethis_ctterm');
+  }
+  final home = env['HOME'] ?? env['USERPROFILE'] ?? '.';
+  return path.join(home, '.colonizethis_ctterm');
+}
+
+/// Path to ctterm.log after init. Null until [initCttermLogging] is called.
+String? get cttermLogPath => _logFilePath;
+
+String? _logFilePath;
+BasicLogger? _fileLogger;
+
+/// Formats a [LogEvent] to one or more lines (message + optional error/stackTrace).
+List<String> _formatLogEvent(LogEvent e) {
+  final time = e.time.toUtc().toIso8601String();
+  final levelName = e.level.name.toUpperCase();
+  final msg = e.message is String ? e.message as String : e.message.toString();
+  final lines = <String>['$time $levelName $msg'];
+  if (e.error != null) {
+    lines.add('  error: ${e.error}');
+  }
+  if (e.stackTrace != null) {
+    lines.add('  stackTrace: ${e.stackTrace}');
+  }
+  return lines;
+}
 
 /// Initializes ctterm logging. Call from main() before runApp.
-/// Use loggers with prefix names in code, e.g. Logger('tui:save:').
-void initCttermLogging() {
+/// [dataDirOverride] is the same as --data-dir (ctterm data dir); ctterm.log is created there.
+/// Console: standard [Logger]. File: [BasicLogger] + [FileOutputLogger] (buffered, non-blocking).
+void initCttermLogging([String? dataDirOverride]) {
   Logger.level = Level.debug;
+
+  final dir = _cttermDataDir(dataDirOverride);
+  final dirFile = Directory(dir);
+  if (!dirFile.existsSync()) {
+    dirFile.createSync(recursive: true);
+  }
+  _logFilePath = path.join(dir, 'ctterm.log');
+
+  try {
+    _fileLogger = BasicLogger('ctterm');
+    _fileLogger!.attachLogger(FileOutputLogger(
+      'ctterm',
+      dir: dir,
+      ext: '.log',
+      bufferSize: 20,
+    ));
+  } catch (_) {
+    _fileLogger = null;
+    _logFilePath = null;
+    return;
+  }
+
+  Logger.addLogListener((LogEvent e) {
+    try {
+      final lines = _formatLogEvent(e);
+      for (final line in lines) {
+        _fileLogger!.info(line);
+      }
+    } catch (_) {
+      // Ignore so file logging never blocks or breaks the app.
+    }
+  });
 }

--- a/ctterm/lib/screens/generating_world_screen.dart
+++ b/ctterm/lib/screens/generating_world_screen.dart
@@ -14,6 +14,7 @@ class GeneratingWorldScreen extends StatefulComponent {
     super.key,
     required this.onComplete,
     required this.onCancel,
+    this.runGeneration,
   });
 
   /// Called when world generation completes successfully.
@@ -21,6 +22,9 @@ class GeneratingWorldScreen extends StatefulComponent {
 
   /// Called when user cancels generation.
   final void Function() onCancel;
+
+  /// When set, run real init (runInitGame) instead of simulated progress. Called once on mount; when done, app navigates to in-game shell.
+  final void Function()? runGeneration;
 
   @override
   State<GeneratingWorldScreen> createState() => _GeneratingWorldScreenState();
@@ -36,6 +40,11 @@ class _GeneratingWorldScreenState extends State<GeneratingWorldScreen> {
   @override
   void initState() {
     super.initState();
+    if (component.runGeneration != null) {
+      // Run real init; runGeneration will set game state and navigate when done.
+      scheduleMicrotask(() => component.runGeneration!());
+      return;
+    }
     _startGeneration();
   }
 

--- a/ctterm/lib/screens/shell_screen.dart
+++ b/ctterm/lib/screens/shell_screen.dart
@@ -38,6 +38,10 @@ class ShellScreen extends StatefulComponent {
     this.dataDirOverride,
     this.game,
     this.orders,
+    this.combinedTopology,
+    this.tileMapByRegion,
+    this.onPrepareNewGame,
+    this.runGeneration,
     this.onTurnProcessed,
     this.onOrdersChanged,
     this.onGameUpdated,
@@ -51,8 +55,15 @@ class ShellScreen extends StatefulComponent {
   final Game? game;
   /// Current orders for the human player.
   final Orders? orders;
+  /// Topology and tile maps for turn resolution (set after new game creation).
+  final MapTopology? combinedTopology;
+  final Map<String, TileMapResult>? tileMapByRegion;
   final void Function(CttermRoute) onNavigate;
   final void Function() onExit;
+  /// Called with setup data before navigating to Generating World. When set, Game Setup uses it.
+  final void Function(List<String> orderedGpIdsForSlots, Map<String, String> leaderVariantByGpId)? onPrepareNewGame;
+  /// When set, Generating World screen runs this instead of simulated progress (runs real init then navigates).
+  final void Function()? runGeneration;
   /// Callback when turn is processed, receives updated game state.
   final void Function(Game)? onTurnProcessed;
   /// Callback when orders are changed in a panel.
@@ -119,9 +130,8 @@ class _ShellScreenState extends State<ShellScreen> {
         return GameSetupScreen(
           onStartGame: (orderedGpIdsForSlots, leaderVariantByGpId) {
             _log.d('tui:nav: Game Setup complete -> generating world');
-            // TODO: Create game with config and navigate to in-game shell
-            // For now, navigate to generating world (stub will be replaced)
-            component.onNavigate(CttermRoute.generatingWorld);
+            component.onPrepareNewGame?.call(orderedGpIdsForSlots, leaderVariantByGpId);
+            // App's onPrepareNewGame sets route to generatingWorld; no separate navigate needed.
           },
           onBack: () => component.onNavigate(CttermRoute.mainMenu),
         );
@@ -144,6 +154,7 @@ class _ShellScreenState extends State<ShellScreen> {
         return GeneratingWorldScreen(
           onComplete: () => component.onNavigate(CttermRoute.inGameShell),
           onCancel: () => component.onNavigate(CttermRoute.mainMenu),
+          runGeneration: component.runGeneration,
         );
       case CttermRoute.settings:
         return SettingsScreen(
@@ -164,11 +175,13 @@ class _ShellScreenState extends State<ShellScreen> {
             // Process turn with current orders and minimal topology
             // Full implementation would load map data and use real topology
             final currentOrders = component.orders ?? const Orders();
-            const emptyTopology = MapTopology();
+            final topology = component.combinedTopology ?? const MapTopology();
+            final tileMapByRegion = component.tileMapByRegion;
             final nextGame = resolveTurnForGame(
               game: game,
-              topology: emptyTopology,
+              topology: topology,
               orders: currentOrders,
+              tileMapByRegion: tileMapByRegion,
             );
             
             // Notify parent of updated game state
@@ -193,7 +206,6 @@ class _ShellScreenState extends State<ShellScreen> {
           orders: component.orders ?? const Orders(),
           onNavigate: component.onNavigate,
           onOrdersChanged: (Orders orders) {
-            // Propagate orders change to parent
             component.onOrdersChanged?.call(orders);
           },
         );

--- a/ctterm/pubspec.yaml
+++ b/ctterm/pubspec.yaml
@@ -10,6 +10,8 @@ environment:
 dependencies:
   nocterm: ^0.4.2
   logger: ^2.0.2
+  basic_logger: ^0.2.2
+  basic_logger_file: ^0.1.3
   path: ^1.9.0
   hive: ^2.2.3
   colonizethis_ai: any

--- a/ctterm/test/playthrough_test.dart
+++ b/ctterm/test/playthrough_test.dart
@@ -1,0 +1,59 @@
+// Short playthrough test: New Game flow (runInitGame) then one End Turn.
+// Mirrors ctterm: Game Setup → Generating World → In-game shell → End Turn.
+// SPEC/tui/ctterm.md.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ctterm playthrough', () {
+    test('New Game → generate world → in-game shell has game; End Turn advances turn', () {
+      // Same config as CttermApp._runGeneration() would build from Game Setup (6 slots filled with default nations).
+      final orderedGpIds = List<String>.from(GameSetupConfig.defaultConfig.selectedGreatPowerIds);
+      expect(orderedGpIds.length, 6, reason: 'default has 6 GPs');
+
+      final leaderVariantByGpId = <String, String>{};
+      for (final gpId in orderedGpIds) {
+        final gp = defaultNamingConfig.gpById(gpId);
+        if (gp != null && gp.leaderVariants.isNotEmpty) {
+          leaderVariantByGpId[gpId] = gp.defaultLeaderVariantId;
+        }
+      }
+
+      final config = GameSetupConfig(
+        selectedGreatPowerIds: orderedGpIds,
+        leaderVariantByGpId: leaderVariantByGpId,
+        seed: 42,
+        continentCount: GameSetupConfig.defaultConfig.continentCount,
+        minorNationCount: GameSetupConfig.defaultConfig.minorNationCount,
+        tribeCount: GameSetupConfig.defaultConfig.tribeCount,
+        numProvincesOldWorld: GameSetupConfig.defaultConfig.numProvincesOldWorld,
+        numProvincesNewWorld: GameSetupConfig.defaultConfig.numProvincesNewWorld,
+        minProvincesPerMinor: GameSetupConfig.defaultConfig.minProvincesPerMinor,
+      );
+
+      // Generating World: run init (game never null after this).
+      final result = runInitGame(
+        config: config,
+        options: const InitGameOptions(renderPng: false),
+      );
+
+      expect(result.game, isNotNull);
+      expect(result.game.players.length, 6);
+      expect(result.game.worldState.turnState.turnNumber, 0, reason: 'game starts at turn 0');
+
+      // In-game shell: End Turn.
+      final nextGame = resolveTurnForGame(
+        game: result.game,
+        topology: result.combinedTopology,
+        orders: const Orders(),
+        tileMapByRegion: result.tileMapByRegion,
+      );
+
+      expect(nextGame.worldState.turnState.turnNumber, 1);
+      expect(nextGame.victory, isNull, reason: 'no victory on turn 1');
+    });
+  });
+}

--- a/docs/project-tools.md
+++ b/docs/project-tools.md
@@ -29,6 +29,7 @@ melos run ctterm
 **Behaviour**
 
 - Shows Main Menu first (New Game, Load Game, Settings, Quit). Load Game is enabled only when at least one save exists in the ctterm data directory. Saves are separate from app/ctdev.
+- Logs to **ctterm.log** in the ctterm data directory (same as `--data-dir` when set). All logger output (tui:*, logic:*, etc.) is appended to this file.
 
 ---
 


### PR DESCRIPTION
## Summary
- **New Game flow:** Game Setup → Generating World now runs `runInitGame` with the six-slot config; game and map cache are set in a single `setState` so the in-game shell never sees a null game. Turn resolution uses `combinedTopology` / `tileMapByRegion`.
- **File logging:** `ctterm.log` in the ctterm data dir via **basic_logger_file** (BasicLogger + FileOutputLogger). `--data-dir` is parsed before `initCttermLogging` so the log path respects the override. Documented in `docs/project-tools.md`.
- **Cursor rule:** `.cursor/rules/colonizethis-logging-file.mdc` — whenever file logging is needed, use basic_logger_file; do not implement custom file logging. Referenced in AGENTS.md.
- **Playthrough test:** `ctterm/test/playthrough_test.dart` — New Game → `runInitGame` → End Turn advances turn.

## Quality gate
- `tool/run_quality_gate_tests.sh` run locally: all test steps and coverage gate passed. The only failure was `melos: command not found` at the sim_scenarios step (use `dart run melos run sim_scenarios` if melos is not on PATH). CI should have melos available.

Made with [Cursor](https://cursor.com)