### PR TITLE
feat(ctterm): add unique 6-digit screen IDs for easy identification

### DIFF
--- a/SPEC/tui/ctterm.md
+++ b/SPEC/tui/ctterm.md
@@ -66,6 +66,10 @@ Layouts must work on small terminals (e.g. Termux, Termius). Constraints: narrow
 - **Identity:** Province and tile keys follow [SPEC/game/world-model-identity.md](../game/world-model-identity.md) (prefixed province id, tile key format `regionId|localId|x|y`). Logic must never locate a province by province id alone.
 - **Smartphone map:** Provide a way to scroll the map and/or cycle between regions (e.g. Old World / New World) so the full map is usable on a small terminal.
 
+### Screen IDs
+
+Each top-level screen has a unique **6-digit screen ID** shown in a bar at the top-right of the screen for easy identification (e.g. when discussing which screen is meant). Source of truth: `CttermRoute.screenId` in `ctterm/lib/ctterm_routes.dart`. IDs: Main Menu 100001, Game Setup 100002, Load Game 100003, Generating World 100004, Settings 100005, In-game shell 100006, Map context 100007, Units 100008, Development 100009, Production 100010, Academy 100011, Shipyard 100012, Diplomacy 100013, Technology 100014, Victory/Progress 100015, Victory 100016, Defeat 100017, Pause/Options 100018.
+
 ### Acceptance criteria format
 
 All ctterm acceptance criteria MUST be written as **Given–When–Then** per project rules. Include TUI-specific cases where applicable (e.g. "Given the terminal is 80×24, when the user opens the Units panel, then the panel is shown and the map remains in the shell.").

--- a/SPEC/tui/screens/academy.md
+++ b/SPEC/tui/screens/academy.md
@@ -2,6 +2,8 @@
 
 **SPEC/tui/screens/academy.md** — TUI-specific Academy screen per SPEC/tui/ctterm.md.
 
+**Screen ID:** 100011
+
 ## Overview
 
 Academy screen for training military regiments. Displays available regiment types (based on researched tech), allows recruiting new units, and shows the training queue. Reference: [SPEC/game/military-units.md](../../game/military-units.md), [SPEC/game/research-state.md](../../game/research-state.md).

--- a/SPEC/tui/screens/defeat.md
+++ b/SPEC/tui/screens/defeat.md
@@ -2,6 +2,8 @@
 
 **SPEC/tui/screens/defeat.md** — TUI-specific Defeat screen per SPEC/tui/ctterm.md.
 
+**Screen ID:** 100017
+
 ## Overview
 
 Defeat screen shown when another Great Power wins the game (human player loses). Reference: [SPEC/game/victory.md](../../game/victory.md).

--- a/SPEC/tui/screens/development.md
+++ b/SPEC/tui/screens/development.md
@@ -2,6 +2,8 @@
 
 **SPEC/tui/screens/development.md** — TUI-specific Development screen per SPEC/tui/ctterm.md.
 
+**Screen ID:** 100009
+
 ## Overview
 
 Development screen for managing civilian unit work orders (Builders, Engineers). Displays working units, allows assigning work tasks (improvements, roads, ports, forts, rails), and shows work progress. Reference: [SPEC/program/development-resolution.md](../../program/development-resolution.md), [SPEC/game/civilian-units.md](../../game/civilian-units.md).

--- a/SPEC/tui/screens/diplomacy.md
+++ b/SPEC/tui/screens/diplomacy.md
@@ -2,6 +2,8 @@
 
 **SPEC/tui/screens/diplomacy.md** — TUI-specific Diplomacy screen per SPEC/tui/ctterm.md.
 
+**Screen ID:** 100013
+
 ## Overview
 
 Diplomacy screen for managing relations with other Great Powers, Minor Nations, and Tribes. Allows issuing diplomatic orders (war, peace, alliances, overtures), viewing relation states, and responding to diplomatic events. Reference: [SPEC/game/diplomacy.md](../../game/diplomacy.md), [SPEC/program/diplomacy-resolution.md](../../program/diplomacy-resolution.md).

--- a/SPEC/tui/screens/game-setup.md
+++ b/SPEC/tui/screens/game-setup.md
@@ -2,6 +2,8 @@
 
 **SPEC/tui/screens** — Game Setup screen for ctterm. Reference: SPEC/tui/ctterm.md §1, SPEC/ui/game-setup.md.
 
+**Screen ID:** 100002
+
 ---
 
 ## Widget contract

--- a/SPEC/tui/screens/generating-world.md
+++ b/SPEC/tui/screens/generating-world.md
@@ -4,6 +4,8 @@
 **Source:** SPEC/program/game-setup-pipeline.md (adaptations in ctterm.md)  
 **UXD:** 03b
 
+**Screen ID:** 100004
+
 ## Overview
 
 The Generating World screen is shown while the game world is being initialized. It displays progress feedback and allows the user to cancel (return to Main Menu).

--- a/SPEC/tui/screens/in-game-shell.md
+++ b/SPEC/tui/screens/in-game-shell.md
@@ -2,6 +2,8 @@
 
 **SPEC/tui** — In-game shell for ctterm. Reference: [ctterm.md](../ctterm.md).
 
+**Screen ID:** 100006
+
 ## Overview
 
 Display the main game view with ASCII map, HUD, and navigation to panels (units, development, production, academy, shipyard, diplomacy, technology, victory/progress).

--- a/SPEC/tui/screens/load-game.md
+++ b/SPEC/tui/screens/load-game.md
@@ -2,6 +2,8 @@
 
 **SPEC/tui/screens** — Load Game screen for ctterm. Reference: SPEC/tui/ctterm.md §1, SPEC/ui/main-menu.md (Load Game), SPEC/program/save-load.md.
 
+**Screen ID:** 100003
+
 ---
 
 ## Widget contract

--- a/SPEC/tui/screens/map-context.md
+++ b/SPEC/tui/screens/map-context.md
@@ -2,6 +2,8 @@
 
 **SPEC/tui/screens/map-context.md** — TUI-specific Map/Province Context screen per SPEC/tui/ctterm.md.
 
+**Screen ID:** 100007
+
 ## Overview
 
 Map context screen showing detailed province information, map layers, visibility, and region navigation. Reference: [SPEC/program/player-view.md](../../program/player-view.md), [SPEC/program/map-visualization.md](../../program/map-visualization.md), [SPEC/game/world-model-identity.md](../../game/world-model-identity.md).

--- a/SPEC/tui/screens/pause-options.md
+++ b/SPEC/tui/screens/pause-options.md
@@ -2,6 +2,8 @@
 
 **SPEC/tui/screens** — Pause menu and options panel in ctterm. Full specification for TUI layout, navigation, and Given–When–Then acceptance criteria. Source of truth for pause/options screen behavior; adapts from SPEC/ui/main-menu.md return flow.
 
+**Screen ID:** 100018
+
 ---
 
 ## Layout

--- a/SPEC/tui/screens/production.md
+++ b/SPEC/tui/screens/production.md
@@ -2,6 +2,8 @@
 
 **SPEC/tui/screens/production.md** — TUI-specific Production screen per SPEC/tui/ctterm.md.
 
+**Screen ID:** 100010
+
 ## Overview
 
 Production screen for managing resource extraction, stockpile viewing, and industry production. Displays connected extraction tiles, current stockpile contents, production recipes, and worker allocation. Reference: [SPEC/game/stockpiles-and-production.md](../../game/stockpiles-and-production.md), [SPEC/program/extraction-pipeline.md](../../program/extraction-pipeline.md).

--- a/SPEC/tui/screens/settings.md
+++ b/SPEC/tui/screens/settings.md
@@ -2,6 +2,8 @@
 
 **SPEC/tui/screens/settings.md** — TUI-specific Settings screen per SPEC/tui/ctterm.md.
 
+**Screen ID:** 100005
+
 ## Overview
 
 Settings screen for terminal-specific options. MVP includes only terminal theme selection.

--- a/SPEC/tui/screens/shipyard.md
+++ b/SPEC/tui/screens/shipyard.md
@@ -2,6 +2,8 @@
 
 **SPEC/tui/screens/shipyard.md** — TUI-specific Shipyard screen per SPEC/tui/ctterm.md.
 
+**Screen ID:** 100012
+
 ## Overview
 
 Shipyard screen for constructing naval units. Displays available ship types (merchant and warship based on researched tech), allows building new ships, and shows the construction queue. Reference: [SPEC/game/ships-and-naval.md](../../game/ships-and-naval.md), [SPEC/game/tech-tree-naval.md](../../game/tech-tree-naval.md).

--- a/SPEC/tui/screens/technology.md
+++ b/SPEC/tui/screens/technology.md
@@ -2,6 +2,8 @@
 
 **SPEC/tui/screens** — Technology research panel in ctterm. Full specification for TUI layout, navigation, and Given–When–Then acceptance criteria. Source of truth for technology screen behavior; adapts from SPEC/game/research-state.md, SPEC/game/tech-tree.md, and SPEC/program/research-resolution.md.
 
+**Screen ID:** 100014
+
 ---
 
 ## Layout

--- a/SPEC/tui/screens/units.md
+++ b/SPEC/tui/screens/units.md
@@ -2,6 +2,8 @@
 
 **SPEC/tui/screens/units.md** — TUI-specific Units screen per SPEC/tui/ctterm.md.
 
+**Screen ID:** 100008
+
 ## Overview
 
 Units screen for managing military and civilian unit orders. Displays unit stacks, allows issuing Move/Attack/Clear orders, and shows order validation feedback. Reference: [SPEC/program/order-engine.md](../../program/order-engine.md), [SPEC/game/combat.md](../../game/combat.md).

--- a/SPEC/tui/screens/victory-progress.md
+++ b/SPEC/tui/screens/victory-progress.md
@@ -2,6 +2,8 @@
 
 **SPEC/tui/screens/victory-progress.md** — TUI-specific Victory/Progress screen per SPEC/tui/ctterm.md.
 
+**Screen ID:** 100015
+
 ## Overview
 
 Victory/Progress screen showing human player's progress toward victory and standings of all Great Powers. Reference: [SPEC/game/victory.md](../../game/victory.md).

--- a/ctterm/lib/ctterm_routes.dart
+++ b/ctterm/lib/ctterm_routes.dart
@@ -21,3 +21,48 @@ enum CttermRoute {
   defeat,
   pauseOptions,
 }
+
+/// Unique 6-digit screen ID for each route. Displayed at top of each screen for identification.
+/// SPEC/tui/ctterm.md § Screen IDs.
+extension CttermRouteScreenId on CttermRoute {
+  String get screenId {
+    switch (this) {
+      case CttermRoute.mainMenu:
+        return '100001';
+      case CttermRoute.gameSetup:
+        return '100002';
+      case CttermRoute.loadGame:
+        return '100003';
+      case CttermRoute.generatingWorld:
+        return '100004';
+      case CttermRoute.settings:
+        return '100005';
+      case CttermRoute.inGameShell:
+        return '100006';
+      case CttermRoute.mapContext:
+        return '100007';
+      case CttermRoute.units:
+        return '100008';
+      case CttermRoute.development:
+        return '100009';
+      case CttermRoute.production:
+        return '100010';
+      case CttermRoute.academy:
+        return '100011';
+      case CttermRoute.shipyard:
+        return '100012';
+      case CttermRoute.diplomacy:
+        return '100013';
+      case CttermRoute.technology:
+        return '100014';
+      case CttermRoute.victoryProgress:
+        return '100015';
+      case CttermRoute.victory:
+        return '100016';
+      case CttermRoute.defeat:
+        return '100017';
+      case CttermRoute.pauseOptions:
+        return '100018';
+    }
+  }
+}

--- a/ctterm/lib/screens/shell_screen.dart
+++ b/ctterm/lib/screens/shell_screen.dart
@@ -121,7 +121,34 @@ class _ShellScreenState extends State<ShellScreen> {
         }
         return false;
       },
-      child: _buildScreen(),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _buildScreenIdBar(),
+          Expanded(child: _buildScreen()),
+        ],
+      ),
+    );
+  }
+
+  /// Top bar showing unique 6-digit screen ID for easy identification. SPEC/tui/ctterm.md § Screen IDs.
+  Component _buildScreenIdBar() {
+    final id = component.route.screenId;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 1),
+      color: Colors.grey,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          Text(
+            'Screen $id',
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              color: Colors.cyan,
+            ),
+          ),
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary
Adds a unique 6-digit screen ID for each ctterm screen, displayed in a top bar for easy identification when discussing or reporting on a specific screen.

## Changes
- **ctterm_routes.dart:** `CttermRouteScreenId` extension with `screenId` (100001–100018) per route.
- **shell_screen.dart:** Top bar (grey, right-aligned) showing "Screen XXXXXX" in bold cyan on every screen.
- **SPEC/tui/ctterm.md:** New § Screen IDs with full ID list and source-of-truth reference.
- **SPEC/tui/screens/*.md:** `**Screen ID:** XXXXXX` added to each of the 16 screen specs.

## IDs
Main Menu 100001, Game Setup 100002, Load Game 100003, Generating World 100004, Settings 100005, In-game shell 100006, Map context 100007, Units 100008, Development 100009, Production 100010, Academy 100011, Shipyard 100012, Diplomacy 100013, Technology 100014, Victory/Progress 100015, Victory 100016, Defeat 100017, Pause/Options 100018.

Made with [Cursor](https://cursor.com)