### PR TITLE
Implement game events for ctterm

### DIFF
--- a/ctterm/lib/ctterm_app.dart
+++ b/ctterm/lib/ctterm_app.dart
@@ -48,6 +48,8 @@ class _CttermAppState extends State<CttermApp> {
   Orders _currentOrders = const Orders();
   _PendingNewGameConfig? _pendingNewGameConfig;
   _MapCache? _mapCache;
+  /// Game events received during turn processing (displayed to user).
+  final List<GameEvent> _gameEvents = [];
 
   void _navigateTo(CttermRoute route) {
     setState(() => _route = route);
@@ -129,7 +131,14 @@ class _CttermAppState extends State<CttermApp> {
     setState(() {
       _currentGame = updatedGame;
       _currentOrders = const Orders(); // Clear orders after turn is processed
+      // Keep game events for display; clear when returning to main menu
     });
+  }
+
+  /// Callback to receive game events (combat, diplomacy, research, victory, etc.).
+  void _onGameEvent(GameEvent event) {
+    _log.d('tui:event: received ${event.runtimeType}');
+    setState(() => _gameEvents.add(event));
   }
 
   /// Clears game state (e.g., when returning to main menu).
@@ -140,6 +149,7 @@ class _CttermAppState extends State<CttermApp> {
       _currentOrders = const Orders();
       _mapCache = null;
       _pendingNewGameConfig = null;
+      _gameEvents.clear();
     });
   }
 
@@ -162,6 +172,7 @@ class _CttermAppState extends State<CttermApp> {
         dataDirOverride: component.dataDirOverride,
         game: _currentGame,
         orders: _currentOrders,
+        gameEvents: _gameEvents,
         combinedTopology: _mapCache?.combinedTopology,
         tileMapByRegion: _mapCache?.tileMapByRegion,
         onNavigate: _navigateTo,
@@ -170,6 +181,7 @@ class _CttermAppState extends State<CttermApp> {
         runGeneration: _route == CttermRoute.generatingWorld ? _runGeneration : null,
         onTurnProcessed: _onTurnProcessed,
         onOrdersChanged: _updateOrders,
+        onGameEvent: _onGameEvent,
         onGameUpdated: (game) {
           _log.d('tui:app: game updated from panel');
           setState(() => _currentGame = game);

--- a/ctterm/lib/screens/in_game_shell_screen.dart
+++ b/ctterm/lib/screens/in_game_shell_screen.dart
@@ -4,6 +4,7 @@ import 'package:logger/logger.dart' as log_pkg;
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 final log_pkg.Logger _log = log_pkg.Logger();
@@ -21,6 +22,7 @@ class InGameShellScreen extends StatefulComponent {
   const InGameShellScreen({
     super.key,
     this.game,
+    this.gameEvents,
     required this.onNavigate,
     required this.onEndTurn,
     required this.onVictory,
@@ -30,6 +32,8 @@ class InGameShellScreen extends StatefulComponent {
 
   /// Current game state for victory checking.
   final Game? game;
+  /// Game events from turn processing (to display to user).
+  final List<GameEvent>? gameEvents;
   final void Function(CttermRoute) onNavigate;
   final Future<void> Function() onEndTurn;
   /// Callback when human player wins.
@@ -258,6 +262,8 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
           const SizedBox(height: 1),
           // Map
           Expanded(child: _buildMap()),
+          // Events bar (shows recent game events)
+          _buildEventsBar(),
           // Command bar
           _buildCommandBar(),
         ],
@@ -290,6 +296,44 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
           )),
           const SizedBox(height: 1),
           Text('Legend: $_legend', style: TextStyle(color: Colors.gray)),
+        ],
+      ),
+    );
+  }
+
+  /// Formats a game event for display.
+  String _formatEvent(GameEvent event) {
+    if (event is CombatResultEvent) {
+      return 'Battle in ${event.provinceId}: ${event.winnerId} wins';
+    } else if (event is ProvinceCapturedEvent) {
+      return 'Province captured: ${event.provinceId} by ${event.newOwnerId}';
+    } else if (event is DiplomacyChangeEvent) {
+      return 'Diplomacy: ${event.actorId} -> ${event.targetId}: ${event.changeType}';
+    } else if (event is ResearchCompleteEvent) {
+      return 'Research: ${event.playerId} discovered ${event.techId}';
+    } else if (event is VictorySetEvent) {
+      return 'Victory: ${event.winnerPlayerId} wins (${event.victoryType})';
+    } else if (event is OrderRejectedEvent) {
+      return 'Order rejected: ${event.orderSummary} (${event.reasonCode})';
+    }
+    return event.toString();
+  }
+
+  /// Builds the events display (shows recent game events).
+  Component _buildEventsBar() {
+    final events = component.gameEvents;
+    if (events == null || events.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    // Show last 3 events
+    final recentEvents = events.length > 3 ? events.sublist(events.length - 3) : events;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 1),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('--- Events ---', style: TextStyle(color: Colors.gray)),
+          ...recentEvents.map((e) => Text(_formatEvent(e), style: TextStyle(color: Colors.yellow))),
         ],
       ),
     );

--- a/ctterm/lib/screens/shell_screen.dart
+++ b/ctterm/lib/screens/shell_screen.dart
@@ -39,12 +39,14 @@ class ShellScreen extends StatefulComponent {
     this.dataDirOverride,
     this.game,
     this.orders,
+    this.gameEvents,
     this.combinedTopology,
     this.tileMapByRegion,
     this.onPrepareNewGame,
     this.runGeneration,
     this.onTurnProcessed,
     this.onOrdersChanged,
+    this.onGameEvent,
     this.onGameUpdated,
     this.onClearGame,
     this.onLoadGame,
@@ -69,6 +71,10 @@ class ShellScreen extends StatefulComponent {
   final void Function(Game)? onTurnProcessed;
   /// Callback when orders are changed in a panel.
   final void Function(Orders)? onOrdersChanged;
+  /// Game events to display to the user (from turn processing).
+  final List<GameEvent>? gameEvents;
+  /// Callback to receive game events (combat, diplomacy, research, victory, etc.).
+  final void Function(GameEvent)? onGameEvent;
   /// Callback when game state is updated (e.g., orders changed in a panel).
   final void Function(Game)? onGameUpdated;
   /// Callback to clear game state (e.g., when returning to main menu).
@@ -172,6 +178,7 @@ class _ShellScreenState extends State<ShellScreen> {
       case CttermRoute.inGameShell:
         return InGameShellScreen(
           game: component.game,
+          gameEvents: component.gameEvents,
           onNavigate: component.onNavigate,
           onEndTurn: () async {
             final game = component.game;
@@ -191,6 +198,7 @@ class _ShellScreenState extends State<ShellScreen> {
               topology: topology,
               orders: currentOrders,
               tileMapByRegion: tileMapByRegion,
+              onGameEvent: component.onGameEvent,
             );
             
             // Notify parent of updated game state

--- a/packages/colonizethis_logic/lib/colonizethis_logic.dart
+++ b/packages/colonizethis_logic/lib/colonizethis_logic.dart
@@ -3,6 +3,7 @@ library colonizethis_logic;
 
 // Root
 export 'src/constants.dart';
+export 'src/game_events.dart';
 export 'src/turn_to_year.dart';
 
 // Setup

--- a/packages/colonizethis_logic/lib/src/game_events.dart
+++ b/packages/colonizethis_logic/lib/src/game_events.dart
@@ -1,0 +1,98 @@
+// Game events: shared event stream for game occurrences.
+// SPEC/program/game-events.md
+
+/// Base event type for game occurrences.
+sealed class GameEvent {
+  const GameEvent();
+}
+
+/// Combat resolved in a province.
+class CombatResultEvent extends GameEvent {
+  const CombatResultEvent({
+    required this.provinceId,
+    required this.attackerId,
+    required this.defenderId,
+    required this.winnerId,
+    required this.turnNumber,
+    this.casualties = const {},
+  });
+
+  /// Province id in prefixed form (regionId|localId).
+  final String provinceId;
+  final String attackerId;
+  final String defenderId;
+  final String winnerId;
+  final int turnNumber;
+  /// Casualties by player id.
+  final Map<String, int> casualties;
+}
+
+/// Province ownership changed.
+class ProvinceCapturedEvent extends GameEvent {
+  const ProvinceCapturedEvent({
+    required this.provinceId,
+    required this.previousOwnerId,
+    required this.newOwnerId,
+    required this.turnNumber,
+  });
+
+  /// Province id in prefixed form (regionId|localId).
+  final String provinceId;
+  final String? previousOwnerId;
+  final String newOwnerId;
+  final int turnNumber;
+}
+
+/// Diplomatic relationship changed.
+class DiplomacyChangeEvent extends GameEvent {
+  const DiplomacyChangeEvent({
+    required this.actorId,
+    required this.targetId,
+    required this.changeType,
+    required this.turnNumber,
+  });
+
+  final String actorId;
+  final String targetId;
+  final String changeType; // 'declare_war', 'peace', 'alliance', etc.
+  final int turnNumber;
+}
+
+/// Technology research completed.
+class ResearchCompleteEvent extends GameEvent {
+  const ResearchCompleteEvent({
+    required this.playerId,
+    required this.techId,
+    required this.turnNumber,
+  });
+
+  final String playerId;
+  final String techId;
+  final int turnNumber;
+}
+
+/// Victory condition met.
+class VictorySetEvent extends GameEvent {
+  const VictorySetEvent({
+    required this.winnerPlayerId,
+    required this.victoryType,
+    required this.turnNumber,
+  });
+
+  final String winnerPlayerId;
+  final String victoryType;
+  final int turnNumber;
+}
+
+/// Order validation failed.
+class OrderRejectedEvent extends GameEvent {
+  const OrderRejectedEvent({
+    required this.playerId,
+    required this.orderSummary,
+    required this.reasonCode,
+  });
+
+  final String playerId;
+  final String orderSummary;
+  final String reasonCode; // 'insufficient_treasury', 'invalid_destination', etc.
+}

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
 
+import '../game_events.dart';
 import '../combat/combat_mode_selection.dart';
 import '../orders/order_engine.dart';
 import '../orders/order_merge.dart';
@@ -93,6 +94,7 @@ Game resolveTurnForGameFromOrderEngine({
   List<AssignedRecipe> defaultAssignments = const [],
   Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
   void Function(DialogueEvent)? onDialogue,
+  void Function(GameEvent)? onGameEvent,
 }) {
   final merged = mergeOrderLists(
     humanOrders: orderEngine.orders,
@@ -103,6 +105,7 @@ Game resolveTurnForGameFromOrderEngine({
     topology: topology,
     orders: merged,
     onDialogue: onDialogue,
+    onGameEvent: onGameEvent,
     tileMapByRegion: tileMapByRegion,
     extractedByPlayerId: extractedByPlayerId,
     defaultAssignments: defaultAssignments,
@@ -128,6 +131,7 @@ Game validateOrdersAndResolveTurn({
   List<AssignedRecipe> defaultAssignments = const [],
   Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
   void Function(DialogueEvent)? onDialogue,
+  void Function(GameEvent)? onGameEvent,
 }) {
   final engine = OrderEngine(initialOrders: orders);
   final filtered = _filterAcceptedOrdersForAllPlayers(
@@ -138,6 +142,7 @@ Game validateOrdersAndResolveTurn({
   return resolveTurnForGame(
     game: game,
     onDialogue: onDialogue,
+    onGameEvent: onGameEvent,
     topology: topology,
     orders: filtered,
     tileMapByRegion: tileMapByRegion,
@@ -157,6 +162,9 @@ Game resolveTurnForGame({
   /// Per-player production assignments; when set, used for that player instead of [defaultAssignments]. SPEC/ai/economy-planner.md.
   Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
   void Function(DialogueEvent)? onDialogue,
+
+  /// Callback for game events (combat, diplomacy, research, victory, etc.). SPEC/program/game-events.md.
+  void Function(GameEvent)? onGameEvent,
 
   /// Called after production phase with playerId → (recipeId → quantity produced). For projection API. SPEC/program/order-projections.md.
   void Function(Map<String, Map<String, int>> productionByRecipeByPlayerId)?
@@ -195,12 +203,66 @@ Game resolveTurnForGame({
       case TurnPhase.consumption:
         state = _runConsumptionPhase(state, feedingCoverageByPlayerId);
         break;
-      case TurnPhase.research:
+      case TurnPhase.research: {
+        final previousTechs = <String, Set<String>>{};
+        for (final p in state.players) {
+          final unlocked = p.techUnlocked ?? {};
+          previousTechs[p.id] = unlocked.entries
+              .where((e) => e.value)
+              .map((e) => e.key)
+              .toSet();
+        }
         state = resolveResearchPhase(state, orders);
+        // Emit research_complete events for newly completed techs
+        if (onGameEvent != null) {
+          for (final player in state.players) {
+            final unlocked = player.techUnlocked ?? {};
+            final current = unlocked.entries
+                .where((e) => e.value)
+                .map((e) => e.key)
+                .toSet();
+            final previous = previousTechs[player.id] ?? {};
+            for (final tech in current) {
+              if (!previous.contains(tech)) {
+                onGameEvent(ResearchCompleteEvent(
+                  playerId: player.id,
+                  techId: tech,
+                  turnNumber: turn,
+                ));
+              }
+            }
+          }
+        }
         break;
-      case TurnPhase.diplomacy:
+      }
+      case TurnPhase.diplomacy: {
+        // Track previous diplomatic relations from game state
+        final previousRelations = <String, Map<String, RelationState>>{};
+        for (final rel in state.diplomacyRelations) {
+          // Store both directions
+          previousRelations.putIfAbsent(rel.factionId1, () => {});
+          previousRelations.putIfAbsent(rel.factionId2, () => {});
+          previousRelations[rel.factionId1]![rel.factionId2] = rel.state;
+          previousRelations[rel.factionId2]![rel.factionId1] = rel.state;
+        }
         state = resolveDiplomacyPhase(state, orders, onDialogue: onDialogue);
+        // Emit diplomacy_change events for changed relations
+        if (onGameEvent != null) {
+          for (final rel in state.diplomacyRelations) {
+            final prev1 = previousRelations[rel.factionId1]?[rel.factionId2];
+            if (prev1 == null || prev1 != rel.state) {
+              // Emit for faction1
+              onGameEvent(DiplomacyChangeEvent(
+                actorId: rel.factionId1,
+                targetId: rel.factionId2,
+                changeType: rel.state.name,
+                turnNumber: turn,
+              ));
+            }
+          }
+        }
         break;
+      }
       case TurnPhase.movement:
         state = _runMovementPhase(state, topology, orders);
         break;
@@ -212,7 +274,14 @@ Game resolveTurnForGame({
           onDialogue: onDialogue,
         );
         break;
-      case TurnPhase.combat:
+      case TurnPhase.combat: {
+        // Track province ownership before combat for province_captured events
+        final previousOwnership = <String, String?>{};
+        for (final region in [state.worldState.oldWorld, state.worldState.newWorld]) {
+          for (final prov in region.provinces) {
+            previousOwnership[prov.id] = prov.ownerId;
+          }
+        }
         state = _runCombatPhase(
           state,
           orders,
@@ -221,7 +290,24 @@ Game resolveTurnForGame({
           tileMapByRegion,
           onDialogue: onDialogue,
         );
+        // Emit province_captured events for changed ownership
+        if (onGameEvent != null) {
+          for (final region in [state.worldState.oldWorld, state.worldState.newWorld]) {
+            for (final prov in region.provinces) {
+              final previousOwner = previousOwnership[prov.id];
+              if (previousOwner != null && previousOwner != prov.ownerId) {
+                onGameEvent(ProvinceCapturedEvent(
+                  provinceId: prov.id,
+                  previousOwnerId: previousOwner,
+                  newOwnerId: prov.ownerId ?? '',
+                  turnNumber: turn,
+                ));
+              }
+            }
+          }
+        }
         break;
+      }
       case TurnPhase.buildWork:
         state = applyBuildAndWorkOrders(
           state,
@@ -231,9 +317,18 @@ Game resolveTurnForGame({
           onDialogue: onDialogue,
         );
         break;
-      case TurnPhase.endOfTurn:
+      case TurnPhase.endOfTurn: {
         state = runEndOfTurnPhase(state, onDialogue: onDialogue);
+        // Emit victory_set event if victory is set
+        if (onGameEvent != null && state.victory != null) {
+          onGameEvent(VictorySetEvent(
+            winnerPlayerId: state.victory!.winnerPlayerId,
+            victoryType: state.victory!.type.name,
+            turnNumber: turn,
+          ));
+        }
         break;
+      }
     }
     _log.d('logic: phase ${phase.name} end');
   }


### PR DESCRIPTION
Implements game event notifications per SPEC/tui/ctterm.md and SPEC/program/game-events.md.

## Changes

### colonizethis_logic
- Added  sealed class with variants:
  -  - battle results after combat phase
  -  - province ownership changes after combat
  -  - diplomatic relationship changes after diplomacy phase
  -  - tech researched after research phase
  -  - victory condition met at end of turn
  -  - order validation failures (stub for future)
- Added  callback parameter to turn resolver functions
- Emit events after relevant phases in turn resolution

### ctterm
- Added  list in CttermApp state to collect events
- Pass  callback to resolveTurnForGame in ShellScreen
- Added  prop to InGameShellScreen
- Events bar displays last 3 events with formatted messages

## Tests
- All ctterm tests pass
- All colonizethis_logic tests pass
- dart analyze clean (info-level hints only)