### PR TITLE
Implement theme switching in ctterm Settings

### DIFF
--- a/ctterm/lib/ctterm_app.dart
+++ b/ctterm/lib/ctterm_app.dart
@@ -5,6 +5,7 @@ import 'package:nocterm/nocterm.dart';
 
 import 'package:ctterm/ctterm_routes.dart';
 import 'package:ctterm/screens/shell_screen.dart';
+import 'package:ctterm/screens/settings_screen.dart';
 import 'package:ctterm/save_service.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
@@ -50,6 +51,8 @@ class _CttermAppState extends State<CttermApp> {
   _MapCache? _mapCache;
   /// Game events received during turn processing (displayed to user).
   final List<GameEvent> _gameEvents = [];
+  /// Current terminal theme.
+  TerminalTheme _terminalTheme = TerminalTheme.dark;
 
   void _navigateTo(CttermRoute route) {
     setState(() => _route = route);
@@ -163,10 +166,27 @@ class _CttermAppState extends State<CttermApp> {
     shutdownApp(0);
   }
 
+  /// Handles theme change from Settings screen.
+  void _onThemeChanged(TerminalTheme theme) {
+    _log.d('tui:app: theme changed to ${theme.name}');
+    setState(() => _terminalTheme = theme);
+  }
+
+  /// Converts TerminalTheme to Nocterm TuiThemeData.
+  TuiThemeData get _themeData {
+    switch (_terminalTheme) {
+      case TerminalTheme.light:
+        return TuiThemeData.light;
+      case TerminalTheme.dark:
+        return TuiThemeData.dark;
+    }
+  }
+
   @override
   Component build(BuildContext context) {
     return NoctermApp(
       title: 'ColonizeThis',
+      theme: _themeData,
       child: ShellScreen(
         route: _route,
         dataDirOverride: component.dataDirOverride,
@@ -188,6 +208,8 @@ class _CttermAppState extends State<CttermApp> {
         },
         onClearGame: _clearGame,
         onLoadGame: _loadGame,
+        initialTheme: _terminalTheme,
+        onThemeChanged: _onThemeChanged,
       ),
     );
   }

--- a/ctterm/lib/screens/settings_screen.dart
+++ b/ctterm/lib/screens/settings_screen.dart
@@ -21,10 +21,13 @@ class SettingsScreen extends StatefulComponent {
     super.key,
     required this.onBack,
     this.initialTheme,
+    this.onThemeChanged,
   });
 
   final void Function() onBack;
   final TerminalTheme? initialTheme;
+  /// Callback when theme is changed.
+  final void Function(TerminalTheme)? onThemeChanged;
 
   @override
   State<SettingsScreen> createState() => _SettingsScreenState();
@@ -43,8 +46,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
   void _selectTheme(TerminalTheme theme) {
     setState(() => _selectedTheme = theme);
     _log.d('tui:settings: theme selected=${theme.name}');
-    // TODO: Apply theme to NoctermApp (requires passing theme up to CttermApp)
-    // For MVP, we just track the selection.
+    // Notify parent to apply theme
+    component.onThemeChanged?.call(theme);
   }
 
   @override

--- a/ctterm/lib/screens/shell_screen.dart
+++ b/ctterm/lib/screens/shell_screen.dart
@@ -50,6 +50,8 @@ class ShellScreen extends StatefulComponent {
     this.onGameUpdated,
     this.onClearGame,
     this.onLoadGame,
+    this.initialTheme,
+    this.onThemeChanged,
   });
 
   final CttermRoute route;
@@ -81,6 +83,10 @@ class ShellScreen extends StatefulComponent {
   final void Function()? onClearGame;
   /// Callback to load a game by ID.
   final Future<void> Function(String gameId)? onLoadGame;
+  /// Initial terminal theme for settings screen.
+  final TerminalTheme? initialTheme;
+  /// Callback when theme is changed in settings.
+  final void Function(TerminalTheme)? onThemeChanged;
 
   @override
   State<ShellScreen> createState() => _ShellScreenState();
@@ -201,6 +207,8 @@ class _ShellScreenState extends State<ShellScreen> {
       case CttermRoute.settings:
         return SettingsScreen(
           onBack: () => component.onNavigate(CttermRoute.mainMenu),
+          initialTheme: component.initialTheme,
+          onThemeChanged: component.onThemeChanged,
         );
       case CttermRoute.inGameShell:
         return InGameShellScreen(


### PR DESCRIPTION
## Summary

Implements theme switching for the ctterm Settings screen per SPEC/tui/screens/settings.md.

### Changes

- **CttermApp**: Adds  state (dark/light), converts to  and passes to 
- **ShellScreen**: Adds  and  parameters to pass through to Settings
- **SettingsScreen**: Now calls  callback when user selects a theme

### Behavior

- User opens Settings from main menu
- Selects Light or Dark theme via L or D keys
- Theme is immediately applied to the entire application
- Selection is visually indicated with a checkmark

### Tests

- All 6 ctterm tests pass
- dart analyze shows only info-level hints (pre-existing)