### PR TITLE
Fix dead null-aware expression warnings in map_context_screen.dart

### DIFF
--- a/ctterm/lib/screens/map_context_screen.dart
+++ b/ctterm/lib/screens/map_context_screen.dart
@@ -245,7 +245,7 @@ class _MapContextScreenState extends State<MapContextScreen> {
                 
                 if (idx < provinces.length) {
                   final prov = provinces[idx];
-                  final name = prov.displayName ?? prov.id ?? '???';
+                  final name = prov.displayName ?? prov.id;
                   // Shorten to 2 chars for the grid cell
                   cellChar = name.length > 2 ? name.substring(0, 2) : name;
                 } else {
@@ -306,7 +306,7 @@ class _MapContextScreenState extends State<MapContextScreen> {
       if (ownerId == null) return 'Unclaimed';
       for (final player in game.players) {
         if (player.id == ownerId) {
-          return player.displayName ?? ownerId;
+          return player.displayName;
         }
       }
       return ownerId;
@@ -327,7 +327,7 @@ class _MapContextScreenState extends State<MapContextScreen> {
             Text('No data available', style: TextStyle(color: Colors.gray))
           else ...[
             // Name
-            Text('Name: ${prov.displayName ?? prov.id ?? "Unknown"}'),
+            Text('Name: ${prov.displayName ?? prov.id}'),
             const SizedBox(height: 1),
             
             // Owner
@@ -335,15 +335,15 @@ class _MapContextScreenState extends State<MapContextScreen> {
             const SizedBox(height: 1),
             
             // Terrain
-            Text('Terrain: ${_showTerrain ? (prov.terrain ?? "Unknown") : "[hidden]"}'),
+            Text('Terrain: ${_showTerrain ? prov.terrain : "[hidden]"}'),
             const SizedBox(height: 1),
             
             // Fort Level
-            Text('Fort: ${_showTowns ? (prov.fortLevel ?? 0) : "[hidden]"}'),
+            Text('Fort: ${_showTowns ? prov.fortLevel : "[hidden]"}'),
             const SizedBox(height: 1),
             
             // Town Development
-            Text('Town Dev: ${_showTowns ? (prov.townDevelopmentLevel ?? 0) : "[hidden]"}'),
+            Text('Town Dev: ${_showTowns ? prov.townDevelopmentLevel : "[hidden]"}'),
             const SizedBox(height: 1),
             
             // Visibility (placeholder - would come from PlayerView)


### PR DESCRIPTION
## Summary

Fixed 6 dead null-aware expression warnings in  where the analyzer determined the left operand can never be null, making the ?? fallback dead code:

-  → 
-  →   
-  → 
-  → 
-  → 
-  → 

## Verification

- All 6 ctterm tests pass
- Analyzing ctterm...

   info - lib/screens/diplomacy_screen.dart:62:10 - The private field _interventionMinorId could be 'final'. Try making the field 'final'. - prefer_final_fields
   info - lib/screens/production_screen.dart:450:19 - Unnecessary braces in a string interpolation. Try removing the braces. - unnecessary_brace_in_string_interps
   info - lib/screens/production_screen.dart:475:61 - Unnecessary braces in a string interpolation. Try removing the braces. - unnecessary_brace_in_string_interps
   info - lib/screens/technology_screen.dart:297:48 - Unnecessary braces in a string interpolation. Try removing the braces. - unnecessary_brace_in_string_interps
   info - lib/screens/technology_screen.dart:349:16 - Unnecessary braces in a string interpolation. Try removing the braces. - unnecessary_brace_in_string_interps
   info - lib/screens/technology_screen.dart:349:28 - Unnecessary braces in a string interpolation. Try removing the braces. - unnecessary_brace_in_string_interps
   info - lib/screens/victory_progress_screen.dart:141:25 - Use interpolation to compose strings and values. Try using string interpolation to build the composite string. - prefer_interpolation_to_compose_strings
   info - lib/screens/victory_progress_screen.dart:141:46 - Use interpolation to compose strings and values. Try using string interpolation to build the composite string. - prefer_interpolation_to_compose_strings

8 issues found. now shows only info-level hints (no warnings)