### PR TITLE
Fix null safety error in startup_check.dart

### DIFF
--- a/ctterm/lib/startup_check.dart
+++ b/ctterm/lib/startup_check.dart
@@ -11,7 +11,7 @@ Future<bool> runStartupSaveCheck(
 }) async {
   ensureReady ??= ensureSaveServiceReady;
   try {
-    await ensureReady(dataDirOverride);
+    await ensureReady!(dataDirOverride);
     return false;
   } on StaleLockException {
     return true;


### PR DESCRIPTION
Fixes a null safety error in ctterm/lib/startup_check.dart where the ensureReady function parameter has nullable type but is assigned a default value via ??= operator.

The Dart analyzer doesn't narrow the type after ??= assignment, so using the null assertion operator (!) is needed to call the function.

Per SPEC/tui/ctterm.md §5.1 for lock-prompt screen.