### PR TITLE
Add tests for ctterm screens to improve coverage

### DIFF
--- a/ctterm/test/main_menu_test.dart
+++ b/ctterm/test/main_menu_test.dart
@@ -1,0 +1,61 @@
+// Tests for MainMenuScreen. SPEC/tui/ctterm.md, SPEC/ui/main-menu.md.
+
+import 'package:ctterm/screens/main_menu_screen.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MainMenuScreen (SPEC/tui/ctterm.md)', () {
+    test('can be constructed with required callbacks', () {
+      final screen = MainMenuScreen(
+        onNewGame: () {},
+        onLoadGame: () {},
+        onSettings: () {},
+        onQuit: () {},
+      );
+
+      expect(screen.onNewGame, isNotNull);
+      expect(screen.onLoadGame, isNotNull);
+      expect(screen.onSettings, isNotNull);
+      expect(screen.onQuit, isNotNull);
+      expect(screen.dataDirOverride, isNull);
+    });
+
+    test('can be constructed with dataDirOverride', () {
+      final screen = MainMenuScreen(
+        onNewGame: () {},
+        onLoadGame: () {},
+        onSettings: () {},
+        onQuit: () {},
+        dataDirOverride: '/custom/path',
+      );
+
+      expect(screen.dataDirOverride, '/custom/path');
+    });
+
+    test('callbacks are invoked correctly', () {
+      var newGameCount = 0;
+      var loadGameCount = 0;
+      var settingsCount = 0;
+      var quitCount = 0;
+
+      final screen = MainMenuScreen(
+        onNewGame: () => newGameCount++,
+        onLoadGame: () => loadGameCount++,
+        onSettings: () => settingsCount++,
+        onQuit: () => quitCount++,
+      );
+
+      screen.onNewGame();
+      expect(newGameCount, 1);
+
+      screen.onLoadGame();
+      expect(loadGameCount, 1);
+
+      screen.onSettings();
+      expect(settingsCount, 1);
+
+      screen.onQuit();
+      expect(quitCount, 1);
+    });
+  });
+}

--- a/ctterm/test/more_screens_test.dart
+++ b/ctterm/test/more_screens_test.dart
@@ -1,0 +1,143 @@
+// Tests for more ctterm screens. SPEC/tui/ctterm.md.
+
+import 'package:ctterm/screens/stub_screen.dart';
+import 'package:ctterm/screens/generating_world_screen.dart';
+import 'package:ctterm/screens/game_setup_screen.dart';
+import 'package:ctterm/screens/load_game_screen.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('StubScreen (SPEC/tui/ctterm.md)', () {
+    test('can be constructed with title', () {
+      final screen = StubScreen(title: 'Test Screen');
+      expect(screen.title, 'Test Screen');
+    });
+
+    test('can be constructed with different titles', () {
+      final screen1 = StubScreen(title: 'Units');
+      expect(screen1.title, 'Units');
+
+      final screen2 = StubScreen(title: 'Diplomacy');
+      expect(screen2.title, 'Diplomacy');
+    });
+  });
+
+  group('GeneratingWorldScreen (SPEC/tui/screens/generating-world.md)', () {
+    test('can be constructed with required callbacks', () {
+      final screen = GeneratingWorldScreen(
+        onComplete: () {},
+        onCancel: () {},
+      );
+
+      expect(screen.onComplete, isNotNull);
+      expect(screen.onCancel, isNotNull);
+      expect(screen.runGeneration, isNull);
+    });
+
+    test('callbacks are invoked correctly', () {
+      var completeCount = 0;
+      var cancelCount = 0;
+
+      final screen = GeneratingWorldScreen(
+        onComplete: () => completeCount++,
+        onCancel: () => cancelCount++,
+      );
+
+      screen.onComplete();
+      expect(completeCount, 1);
+
+      screen.onCancel();
+      expect(cancelCount, 1);
+    });
+
+    test('can be constructed with runGeneration callback', () {
+      final screen = GeneratingWorldScreen(
+        onComplete: () {},
+        onCancel: () {},
+        runGeneration: () {},
+      );
+
+      expect(screen.runGeneration, isNotNull);
+    });
+  });
+
+  group('GameSetupScreen (SPEC/tui/screens/game-setup.md)', () {
+    test('can be constructed with required callbacks', () {
+      final screen = GameSetupScreen(
+        onStartGame: (gpIds, leaders) {},
+        onBack: () {},
+      );
+
+      expect(screen.onStartGame, isNotNull);
+      expect(screen.onBack, isNotNull);
+    });
+
+    test('callbacks are invoked correctly', () {
+      var startGpIds = <String>[];
+      var startLeaders = <String, String>{};
+      var backCount = 0;
+
+      final screen = GameSetupScreen(
+        onStartGame: (gpIds, leaders) {
+          startGpIds = gpIds;
+          startLeaders = leaders;
+        },
+        onBack: () => backCount++,
+      );
+
+      screen.onBack();
+      expect(backCount, 1);
+
+      screen.onStartGame(['gp1', 'gp2'], {'gp1': 'leader1'});
+      expect(startGpIds, ['gp1', 'gp2']);
+      expect(startLeaders['gp1'], 'leader1');
+    });
+  });
+
+  group('LoadGameScreen (SPEC/tui/screens/load-game.md)', () {
+    test('can be constructed with required callbacks', () {
+      final screen = LoadGameScreen(
+        onLoad: (saveId) {},
+        onBack: () {},
+        onDelete: (saveId) {},
+      );
+
+      expect(screen.onLoad, isNotNull);
+      expect(screen.onBack, isNotNull);
+      expect(screen.onDelete, isNotNull);
+      expect(screen.dataDirOverride, isNull);
+    });
+
+    test('callbacks are invoked correctly', () {
+      var loadSaveId = '';
+      var backCount = 0;
+      var deleteSaveId = '';
+
+      final screen = LoadGameScreen(
+        onLoad: (saveId) => loadSaveId = saveId,
+        onBack: () => backCount++,
+        onDelete: (saveId) => deleteSaveId = saveId,
+      );
+
+      screen.onLoad('game_001');
+      expect(loadSaveId, 'game_001');
+
+      screen.onBack();
+      expect(backCount, 1);
+
+      screen.onDelete('game_001');
+      expect(deleteSaveId, 'game_001');
+    });
+
+    test('can be constructed with dataDirOverride', () {
+      final screen = LoadGameScreen(
+        onLoad: (saveId) {},
+        onBack: () {},
+        onDelete: (saveId) {},
+        dataDirOverride: '/custom/path',
+      );
+
+      expect(screen.dataDirOverride, '/custom/path');
+    });
+  });
+}

--- a/ctterm/test/pause_settings_test.dart
+++ b/ctterm/test/pause_settings_test.dart
@@ -1,0 +1,76 @@
+// Tests for pause options and settings screens. SPEC/tui/ctterm.md.
+
+import 'package:ctterm/screens/pause_options_screen.dart';
+import 'package:ctterm/screens/settings_screen.dart';
+import 'package:ctterm/ctterm_routes.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PauseOptionsScreen (SPEC/tui/screens/pause-options.md)', () {
+    test('can be constructed with required callbacks', () {
+      final screen = PauseOptionsScreen(
+        onNavigate: (route) {},
+        onExitToMainMenu: () {},
+      );
+
+      expect(screen.onNavigate, isNotNull);
+      expect(screen.onExitToMainMenu, isNotNull);
+    });
+
+    test('callbacks are invoked correctly', () {
+      var navigateRoute = CttermRoute.mainMenu;
+      var exitCount = 0;
+
+      final screen = PauseOptionsScreen(
+        onNavigate: (route) => navigateRoute = route,
+        onExitToMainMenu: () => exitCount++,
+      );
+
+      screen.onNavigate(CttermRoute.mainMenu);
+      expect(navigateRoute, CttermRoute.mainMenu);
+
+      screen.onExitToMainMenu();
+      expect(exitCount, 1);
+    });
+  });
+
+  group('SettingsScreen (SPEC/tui/screens/settings.md)', () {
+    test('can be constructed with required callbacks', () {
+      final screen = SettingsScreen(
+        onBack: () {},
+        initialTheme: TerminalTheme.dark,
+      );
+
+      expect(screen.onBack, isNotNull);
+      expect(screen.initialTheme, TerminalTheme.dark);
+      expect(screen.onThemeChanged, isNull);
+    });
+
+    test('callbacks are invoked correctly', () {
+      var backCount = 0;
+      var changedTheme = TerminalTheme.dark;
+
+      final screen = SettingsScreen(
+        onBack: () => backCount++,
+        initialTheme: TerminalTheme.dark,
+        onThemeChanged: (theme) => changedTheme = theme,
+      );
+
+      screen.onBack();
+      expect(backCount, 1);
+
+      // Test that onThemeChanged can be called when provided
+      screen.onThemeChanged?.call(TerminalTheme.light);
+      expect(changedTheme, TerminalTheme.light);
+    });
+
+    test('can be constructed with light theme', () {
+      final screen = SettingsScreen(
+        onBack: () {},
+        initialTheme: TerminalTheme.light,
+      );
+
+      expect(screen.initialTheme, TerminalTheme.light);
+    });
+  });
+}

--- a/ctterm/test/victory_defeat_test.dart
+++ b/ctterm/test/victory_defeat_test.dart
@@ -1,0 +1,113 @@
+// Tests for victory and defeat screens. SPEC/tui/ctterm.md, SPEC/game/victory.md.
+
+import 'package:ctterm/screens/victory_screen.dart';
+import 'package:ctterm/screens/defeat_screen.dart';
+import 'package:ctterm/ctterm_routes.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('VictoryScreen (SPEC/tui/ctterm.md)', () {
+    test('can be constructed with required parameters', () {
+      final screen = VictoryScreen(
+        onNavigate: (route) {},
+        onExitToMainMenu: () {},
+        victoryType: 'Military',
+        turnNumber: 42,
+      );
+
+      expect(screen.onNavigate, isNotNull);
+      expect(screen.onExitToMainMenu, isNotNull);
+      expect(screen.victoryType, 'Military');
+      expect(screen.turnNumber, 42);
+      expect(screen.winnerName, 'You');
+    });
+
+    test('can be constructed with custom winner name', () {
+      final screen = VictoryScreen(
+        onNavigate: (route) {},
+        onExitToMainMenu: () {},
+        victoryType: 'Economic',
+        turnNumber: 100,
+        winnerName: 'Player 1',
+      );
+
+      expect(screen.winnerName, 'Player 1');
+    });
+
+    test('callbacks are invoked correctly', () {
+      var navigateRoute = CttermRoute.mainMenu;
+      var exitCount = 0;
+
+      final screen = VictoryScreen(
+        onNavigate: (route) => navigateRoute = route,
+        onExitToMainMenu: () => exitCount++,
+        victoryType: 'Military',
+        turnNumber: 42,
+      );
+
+      screen.onNavigate(CttermRoute.mainMenu);
+      expect(navigateRoute, CttermRoute.mainMenu);
+
+      screen.onExitToMainMenu();
+      expect(exitCount, 1);
+    });
+  });
+
+  group('DefeatScreen (SPEC/tui/ctterm.md)', () {
+    test('can be constructed with required parameters', () {
+      final screen = DefeatScreen(
+        onNavigate: (route) {},
+        onExitToMainMenu: () {},
+        winnerName: 'England',
+        victoryType: 'Military',
+        turnNumber: 50,
+      );
+
+      expect(screen.onNavigate, isNotNull);
+      expect(screen.onExitToMainMenu, isNotNull);
+      expect(screen.winnerName, 'England');
+      expect(screen.victoryType, 'Military');
+      expect(screen.turnNumber, 50);
+      expect(screen.finalStandings, isEmpty);
+    });
+
+    test('can be constructed with final standings', () {
+      final standings = [
+        const MapEntry('England', 35),
+        const MapEntry('France', 28),
+        const MapEntry('Spain', 15),
+      ];
+
+      final screen = DefeatScreen(
+        onNavigate: (route) {},
+        onExitToMainMenu: () {},
+        winnerName: 'England',
+        victoryType: 'Military',
+        turnNumber: 50,
+        finalStandings: standings,
+      );
+
+      expect(screen.finalStandings.length, 3);
+      expect(screen.finalStandings[0].key, 'England');
+    });
+
+    test('callbacks are invoked correctly', () {
+      var navigateRoute = CttermRoute.mainMenu;
+      var exitCount = 0;
+
+      final screen = DefeatScreen(
+        onNavigate: (route) => navigateRoute = route,
+        onExitToMainMenu: () => exitCount++,
+        winnerName: 'England',
+        victoryType: 'Military',
+        turnNumber: 50,
+      );
+
+      screen.onNavigate(CttermRoute.mapContext);
+      expect(navigateRoute, CttermRoute.mapContext);
+
+      screen.onExitToMainMenu();
+      expect(exitCount, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Add tests for ctterm screens to improve test coverage per SPEC/tui/ctterm.md which requires 90% coverage.

## Changes

- **main_menu_test.dart**: Tests for MainMenuScreen callback interfaces
- **pause_settings_test.dart**: Tests for PauseOptionsScreen and SettingsScreen
- **more_screens_test.dart**: Tests for StubScreen, GeneratingWorldScreen, GameSetupScreen, LoadGameScreen
- **victory_defeat_test.dart**: Tests for VictoryScreen and DefeatScreen

## Tests

- All 38 tests pass
- No warnings in test files (fixed all unused variable warnings)
- Only info-level hints remain in lib files (pre-existing)