### PR TITLE
fix(ctterm): pause screen input and hotkey

### DIFF
--- a/SPEC/tui/screens/in-game-shell.md
+++ b/SPEC/tui/screens/in-game-shell.md
@@ -79,7 +79,7 @@ The map area is a **topology graph** of the current region’s **land provinces*
 
 ### G7: Pause/Options
 - **Given** the player is in the in-game shell
-- **When** pressing `Escape`, `O`, or `P`
+- **When** pressing `Escape`, `O`, or `X`
 - **Then** navigate to Pause/Options screen
 
 ### G8: Main Menu Exit

--- a/SPEC/tui/screens/pause-options.md
+++ b/SPEC/tui/screens/pause-options.md
@@ -18,7 +18,7 @@
 
 | Action | Keys | Result |
 |--------|------|--------|
-| Open Pause (from in-game shell only) | `Escape`, `O`, or `P` | Pause/Options screen is shown; game state preserved. |
+| Open Pause (from in-game shell only) | `Escape`, `O`, or `X` | Pause/Options screen is shown; game state preserved. |
 | Close Pause and resume game | `Escape` or `B` | Pause closes; in-game shell (100006) is shown again. |
 | Confirm selected menu item | `Enter` | Runs the action for the currently selected item (see §4). |
 
@@ -77,7 +77,7 @@ No other menu items are required for MVP. Additional options (e.g. Help) may be 
 | `Escape` | Pause menu | Back to game. |
 | `Escape` | Exit confirmation | Cancel exit (stay in Pause). |
 | `O` | In-game shell | Open Pause. |
-| `P` | In-game shell | Open Pause. |
+| `X` | In-game shell | Open Pause. |
 | `B` | Pause menu | Back to game. |
 | `W` / `Up` | Pause menu | Previous menu item. |
 | `S` / `Down` | Pause menu | Next menu item. |

--- a/ctterm/lib/screens/in_game_shell_screen.dart
+++ b/ctterm/lib/screens/in_game_shell_screen.dart
@@ -277,7 +277,7 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
           _handleEndTurn();
           return true;
         }
-        if (c == 'o' || c == 'p' || key == LogicalKey.escape) {
+        if (c == 'o' || c == 'x' || key == LogicalKey.escape) {
           component.onNavigate(CttermRoute.pauseOptions);
           return true;
         }

--- a/ctterm/lib/screens/pause_options_screen.dart
+++ b/ctterm/lib/screens/pause_options_screen.dart
@@ -32,8 +32,8 @@ class _PauseOptionsScreenState extends State<PauseOptionsScreen> {
 
   @override
   Component build(BuildContext context) {
-    return KeyboardListener(
-      autofocus: true,
+    return Focusable(
+      focused: true,
       onKeyEvent: _handleKeyEvent,
       child: _showExitConfirm ? _buildExitConfirm() : _buildMenu(),
     );


### PR DESCRIPTION
## Summary
- Align ctterm pause/options hotkeys and specs with the in-game shell, switching from `P` to `X` so Production keeps `P`.
- Fix the pause screen so it receives keyboard focus via `Focusable`, allowing Esc/B to return to the in-game shell and Enter/Y/N to work in the confirmation dialog.

## Test plan
- Run `dart test` in `ctterm/` (all existing tests pass).
- Manually: start a game in ctterm, open pause with Esc/O/X, navigate menu with W/S and arrows, press Esc/B to return to game, and verify Exit to Main Menu shows confirmation and responds to Y/N/Enter as specified.

Made with [Cursor](https://cursor.com)