### PR TITLE
ctterm: centered in-game shell topology graph

### DIFF
--- a/SPEC/tui/screens/in-game-shell.md
+++ b/SPEC/tui/screens/in-game-shell.md
@@ -10,30 +10,39 @@ Display the main game view with a **topology-graph map area** (province graph wi
 
 ## Map Area: Topology Graph
 
-The map area is a **topology graph** of the current region’s **land provinces**, arranged in a grid-like pattern.
+The map area is a **topology graph** of the current region’s **land provinces**, rendered as a **centered province + neighbour list** view.
 
 - **Nodes:** Each node is one **province** (land only; sea zones are not shown as nodes).
 - **Edges:** Two provinces are connected by an edge if and only if they are **land-adjacent** (P–P) in the topology per [SPEC/game/map-topology.md](../../game/map-topology.md). Provinces separated by sea have no edge between them.
-- **Layout:** The graph is arrayed in a **grid-like pattern** so that nodes occupy positions in a grid; connections between adjacent land provinces are shown (e.g. lines or explicit connection list).
-- **Data source:** Topology comes from the game’s map data (e.g. combined topology from save/init). If topology is missing, the map area shows a fallback (e.g. “No topology” or a simple province list).
+- **Layout (centered view):**
+  - One province is the **center** (the “currently viewed” province).
+  - All **land neighbours** (P–P edges from the center) are listed to the **right** of the center as a **vertical neighbour list** (one neighbour per line).
+  - Each neighbour entry shows a **hotkey index** (1–9) and the neighbour province name.
+  - If a province is **sea-bound** (has at least one P–S edge in the topology per [SPEC/game/capital-choice-phase.md](../../game/capital-choice-phase.md)), its name in the graph has a trailing `*` (asterisk).
+- **Colouring:** Province names in the graph are **colour-coded** by the owning Great Power’s colour:
+  - When `Game.greatPowerColorOverride` provides a colour for the owner’s player id, the TUI uses a **nearest terminal colour** to that RGB triple (per [SPEC/program/map-visualization.md](../../program/map-visualization.md) ownership colours).
+  - When no override is present, the TUI may fall back to a neutral default colour (e.g. gray/white) for that owner.
+- **Data source:** Topology comes from the game’s map data (combined topology from save/init). If topology is missing, the map area shows a fallback (e.g. “No topology” plus a simple province count) so the screen remains usable.
 
 ## Province Selection and Navigation
 
-- The user can **navigate** the province graph: one province is **selected** (highlighted).
-- **Movement:** The user moves the selection to a **neighbour** of the current province (a province connected by a land edge). Keys (e.g. arrow keys, number keys for neighbour index, or next/previous neighbour) move selection along the graph. If the current province has no land neighbours, movement does nothing.
-- **Initial selection:** When the screen loads or the region changes, the first province (by a deterministic order) or the human player’s capital is selected, if any.
+- The user can **navigate** the province graph: one province is **selected** (highlighted as the center of the view).
+- **Movement (neighbour cycling):** The user moves the selection to a **neighbour** of the current province (a province connected by a land edge). Keys `j` / `←` move to the **previous** neighbour; `l` / `→` move to the **next** neighbour around the neighbour list. If the current province has no land neighbours, these movement keys do nothing.
+- **Movement (direct neighbour hotkeys):** Each neighbour in the list is assigned a **number key** `1`–`9` corresponding to its index in the list; pressing that digit moves selection directly to that neighbour province (if it exists).
+- **Initial selection:** When the screen loads or the region changes, the **human player’s capital** in the current region is selected if it exists and is present in the land graph; otherwise the first province (by a deterministic order) is selected.
 
 ## Province Information Panel
 
 - When a province is selected, the shell shows **basic information** for that province.
 - **Content:** Reuse the same information as the Map Context screen’s province panel per [SPEC/tui/screens/map-context.md](map-context.md): province name (or prefixed id), owner (Great Power name or “Unclaimed”), terrain type, fort level, town/settlement level, visibility status (fog/revealed/fully visible). Omit tile-level detail; province-level only.
+- **Sea-bound indicator:** The panel shows whether the selected province is **sea-bound** (has at least one P–S edge in the topology within the current region). When sea-bound, the panel labels it clearly (e.g. `Seabound: Yes (coastal)`); this matches the `*` marker used in the graph view.
 
 ## Acceptance Criteria (Given-When-Then)
 
 ### G1: Topology Graph Map Area
 - **Given** the player is in the in-game shell and topology is available for the current region
 - **When** the screen renders
-- **Then** the map area displays a topology graph of land provinces in a grid-like pattern, with edges only between land-adjacent provinces (no connections across sea).
+- **Then** the map area displays a topology graph of land provinces as a **centered province + neighbour list** view, with edges only between land-adjacent provinces (no connections across sea), and the selected province is rendered at the center with its neighbours listed to the right.
 - **Given** the player is in the in-game shell and topology is missing or empty
 - **When** the screen renders
 - **Then** the map area shows a fallback (e.g. “No topology” or a simple province list) so the screen remains usable.
@@ -41,15 +50,18 @@ The map area is a **topology graph** of the current region’s **land provinces*
 ### G2: Province Graph Navigation
 - **Given** a province is selected in the in-game shell
 - **When** the user presses the key(s) to move to a neighbour
-- **Then** the selection moves to a land-adjacent province (if any); if there are multiple neighbours, keys choose among them (e.g. next/previous or 1–4).
+- **Then** the selection moves to a land-adjacent province (if any); if there are multiple neighbours, `j` / `←` move to the previous neighbour and `l` / `→` move to the next neighbour in the neighbour list.
 - **Given** the selected province has no land neighbours
 - **When** the user presses a neighbour-move key
 - **Then** the selection does not change.
+- **Given** a province is selected in the in-game shell and it has N land neighbours (1 ≤ N ≤ 9)
+- **When** the user presses number key `k` where 1 ≤ k ≤ N
+- **Then** the selection moves directly to the neighbour at index `k` in the neighbour list and the centered province updates accordingly.
 
 ### G3: Province Information Panel
 - **Given** a province is selected in the in-game shell
 - **When** the screen renders
-- **Then** the province information panel shows that province’s name/id, owner, terrain, fort level, town development level, and visibility (same content as Map Context province panel, province-level only).
+- **Then** the province information panel shows that province’s name/id, owner, terrain, fort level, town development level, a **sea-bound indicator** (Yes/No, based on presence of at least one P–S edge in the topology for the current region), and visibility (same content as Map Context province panel, province-level only).
 
 ### G4: HUD (Heads-Up Display)
 - **Given** the player is in the in-game shell
@@ -106,7 +118,9 @@ The map area is a **topology graph** of the current region’s **land provinces*
 ## Implementation Notes
 
 - Use `Nocterm` for rendering (like other ctterm screens).
-- **Topology:** Use combined topology from game/save (passed into the screen). Filter to current region; use only province nodes and P–P edges for the graph. Province identity: [SPEC/game/world-model-identity.md](../../game/world-model-identity.md) (prefixed id, region-scoped lookup).
-- **Layout:** Place province nodes in a grid (e.g. by row/column); draw or list connections between land-adjacent provinces. Neighbour-based navigation uses the same adjacency as movement (e.g. `neighborProvinceIdsInRegion` from colonizethis_logic).
+- **Topology:** Use combined topology from game/save (passed into the screen). Filter to current region; use only province nodes and P–P edges for the land graph. Province identity: [SPEC/game/world-model-identity.md](../../game/world-model-identity.md) (prefixed id, region-scoped lookup).
+- **Layout:** Render a centered view: compute the selected province (human capital when available, otherwise first province) and show it as the center; compute its neighbours via `neighborProvinceIdsInRegion` from colonizethis_logic and render them to the right with index keys `1`–`9`. Neighbour-based navigation uses the same adjacency as movement.
+- **Sea-bound detection:** A province is sea-bound when, in the combined topology, its node has at least one P–S edge to a sea zone node in the same region (per [SPEC/game/capital-choice-phase.md](../../game/capital-choice-phase.md)). The graph view appends `*` to the province name and the panel shows `Seabound: Yes` when this is true.
+- **Great Power colours:** When `Game.greatPowerColorOverride` provides RGB triples for Great Powers, the TUI maps those colours to the nearest terminal palette colours and uses them to colour province names in the graph. When no override is present for an owner, the TUI may fall back to a neutral colour.
 - **Province info:** Reuse the same fields and layout as Map Context province panel (name, owner, terrain, fort, town dev, visibility); see [map-context.md](map-context.md).
 - Keyboard-first navigation per ctterm conventions.

--- a/ctterm/lib/screens/in_game_shell_screen.dart
+++ b/ctterm/lib/screens/in_game_shell_screen.dart
@@ -193,6 +193,22 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
     });
   }
 
+  /// Select neighbour at [index] (0-based) in the current province's neighbour list.
+  void _selectNeighbourByIndex(int index) {
+    final cur = _selectedProvinceLocalId;
+    if (cur == null) return;
+    if (index < 0) return;
+    final neighbours = _neighboursOf(cur);
+    if (index >= neighbours.length) return;
+    final newId = neighbours[index];
+    final newNeighbours = _neighboursOf(newId);
+    final backIdx = newNeighbours.indexOf(cur);
+    setState(() {
+      _selectedProvinceLocalId = newId;
+      _neighbourIndex = backIdx >= 0 ? backIdx : 0;
+    });
+  }
+
   Future<void> _handleEndTurn() async {
     if (_isEndingTurn) return;
     setState(() => _isEndingTurn = true);
@@ -273,6 +289,13 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
           _selectNextNeighbour();
           return true;
         }
+        // Direct neighbour selection via number keys 1–9.
+        if (c != null && c.length == 1 && c.codeUnitAt(0) >= '1'.codeUnitAt(0) &&
+            c.codeUnitAt(0) <= '9'.codeUnitAt(0)) {
+          final index = c.codeUnitAt(0) - '1'.codeUnitAt(0);
+          _selectNeighbourByIndex(index);
+          return true;
+        }
         if (c == 'e' || key == LogicalKey.enter) {
           _handleEndTurn();
           return true;
@@ -333,10 +356,11 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
       );
     }
 
-    const cols = 5;
-    final rows = (land.length / cols).ceil();
     final selected = _selectedProvinceLocalId;
-    final neighbours = selected != null ? _neighboursOf(selected) : <String>[];
+    final selectedProv =
+        selected != null ? _provinceByLocalId(selected) : null;
+    final neighbours =
+        selected != null ? _neighboursOf(selected) : <String>[];
 
     return Container(
       padding: const EdgeInsets.all(1),
@@ -345,46 +369,51 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
         children: [
           Text('=== $_regionDisplayName (land graph) ===',
               style: TextStyle(color: Colors.cyan)),
-          Text('Select: j/l or ←/→ move to neighbour',
+          Text(
+              'Center = current province; 1–9: neighbour, j/l or ←/→: cycle',
               style: TextStyle(color: Colors.gray)),
           const SizedBox(height: 1),
-          ...List.generate(rows, (row) {
-            return Row(
-              children: List.generate(cols, (col) {
-                final idx = row * cols + col;
-                if (idx >= land.length) {
-                  return const Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 2, vertical: 0),
-                    child: Text('   '),
-                  );
-                }
-                final localId = land[idx];
-                final prov = _provinceByLocalId(localId);
-                final name = prov?.displayName ?? prov?.id ?? localId;
-                final short = name.length > 6 ? name.substring(0, 6) : name;
-                final isSelected = localId == selected;
-                return Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 1, vertical: 0),
-                  child: Text(
-                    isSelected ? '[$short]' : ' $short ',
-                    style: isSelected
-                        ? TextStyle(
-                            backgroundColor: Colors.cyan,
-                            color: Colors.black,
-                            fontWeight: FontWeight.bold,
-                          )
-                        : TextStyle(color: Colors.gray),
+          if (selected == null || selectedProv == null)
+            Text('No province selected', style: TextStyle(color: Colors.gray))
+          else ...[
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  _provinceLabel(selectedProv, selected),
+                  style: TextStyle(
+                    color: _provinceTextColor(selectedProv),
+                    fontWeight: FontWeight.bold,
                   ),
-                );
-              }),
-            );
-          }),
-          const SizedBox(height: 1),
-          if (selected != null && neighbours.isNotEmpty)
-            Text(
-              'Neighbours: ${neighbours.map((n) => _provinceByLocalId(n)?.displayName ?? n).join(", ")}',
-              style: TextStyle(color: Colors.yellow),
+                ),
+                const SizedBox(width: 2),
+                Text('->', style: TextStyle(color: Colors.gray)),
+                const SizedBox(width: 1),
+                if (neighbours.isEmpty)
+                  Text('No neighbours', style: TextStyle(color: Colors.gray))
+                else
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        for (var i = 0; i < neighbours.length; i++)
+                          Padding(
+                            padding: const EdgeInsets.only(bottom: 1),
+                            child: Text(
+                              _neighbourLabel(neighbours[i], i),
+                              style: TextStyle(
+                                color: _provinceTextColor(
+                                  _provinceByLocalId(neighbours[i]),
+                                ),
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+              ],
             ),
+          ],
         ],
       ),
     );
@@ -395,6 +424,8 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
         ? _provinceByLocalId(_selectedProvinceLocalId!)
         : null;
     final game = component.game;
+    final isSeabound = _selectedProvinceLocalId != null &&
+        _isProvinceSeaBound(_selectedProvinceLocalId!);
 
     String ownerName(String? ownerId) {
       if (ownerId == null) return 'Unclaimed';
@@ -425,13 +456,97 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
             Text('Terrain: ${prov.terrain}'),
             Text('Fort: ${prov.fortLevel}'),
             Text('Town Dev: ${prov.townDevelopmentLevel}'),
+            Text('Seabound: ${isSeabound ? "Yes" : "No"}'),
             Text('Visibility: full', style: TextStyle(color: Colors.gray)),
           ],
           const Spacer(),
-          Text('j/l or ←/→: neighbour', style: TextStyle(color: Colors.gray)),
+          Text('1–9: neighbour, j/l or ←/→: cycle', style: TextStyle(color: Colors.gray)),
         ],
       ),
     );
+  }
+
+  /// Returns true when the province with [localId] in the current region has at
+  /// least one P–S edge (sea-bound) in the combined topology.
+  bool _isProvinceSeaBound(String localId) {
+    final top = component.combinedTopology;
+    if (top == null || top.nodes.isEmpty) return false;
+    final regionId = _selectedRegion;
+
+    final provinceNodeIds = top.nodes
+        .where((n) =>
+            n.regionId == regionId &&
+            n.type == TopologyNodeType.province &&
+            ProvinceId.localIdFrom(n.id) == localId)
+        .map((n) => n.id)
+        .toSet();
+    if (provinceNodeIds.isEmpty) return false;
+
+    final seaNodeIds = top.nodes
+        .where((n) =>
+            n.regionId == regionId && n.type == TopologyNodeType.seaZone)
+        .map((n) => n.id)
+        .toSet();
+    if (seaNodeIds.isEmpty) return false;
+
+    for (final edge in top.edges) {
+      final id1 = edge.id1;
+      final id2 = edge.id2;
+      String? provinceSide;
+      if (provinceNodeIds.contains(id1)) {
+        provinceSide = id1;
+      } else if (provinceNodeIds.contains(id2)) {
+        provinceSide = id2;
+      }
+      if (provinceSide == null) continue;
+      final other = provinceSide == id1 ? id2 : id1;
+      if (seaNodeIds.contains(other)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// Province label for the centered view, including seabound marker.
+  String _provinceLabel(Province? prov, String localId) {
+    final base = prov?.displayName ?? prov?.id ?? localId;
+    final seabound = _isProvinceSeaBound(localId);
+    return seabound ? '$base*' : base;
+  }
+
+  /// Label for neighbour [localId] at [index] (0-based), including hotkey index and seabound marker.
+  String _neighbourLabel(String localId, int index) {
+    final prov = _provinceByLocalId(localId);
+    final name = _provinceLabel(prov, localId);
+    final keyIndex = index + 1;
+    final keyPart = keyIndex <= 9 ? '$keyIndex' : '-';
+    return '$keyPart:$name';
+  }
+
+  /// Text colour for a province based on owning Great Power colour override (when present).
+  Color _provinceTextColor(Province? prov) {
+    if (prov == null) return Colors.gray;
+    final ownerId = prov.ownerId;
+    final game = component.game;
+    if (ownerId == null || game == null) return Colors.gray;
+    final override = game.greatPowerColorOverride;
+    final rgb = override?[ownerId];
+    if (rgb == null || rgb.length < 3) return Colors.gray;
+    final r = rgb[0];
+    final g = rgb[1];
+    final b = rgb[2];
+
+    if (r == g && g == b) {
+      return r > 200 ? Colors.white : Colors.gray;
+    }
+    final max = [r, g, b].reduce((a, b) => a > b ? a : b);
+    if (max == r && max == g) return Colors.yellow;
+    if (max == r && max == b) return Colors.magenta;
+    if (max == g && max == b) return Colors.cyan;
+    if (max == r) return Colors.red;
+    if (max == g) return Colors.green;
+    if (max == b) return Colors.blue;
+    return Colors.gray;
   }
 
   String _formatEvent(GameEvent event) {


### PR DESCRIPTION
## Summary
- Center the ctterm in-game shell topology map on the selected province with a vertical neighbour list driven by topology adjacency.
- Add seabound detection from P–S edges, mark seabound provinces with a trailing * in the graph, and show a seabound flag in the province info panel.
- Colour province labels by Great Power ownership using Game.greatPowerColorOverride where available, and update SPEC/tui/screens/in-game-shell.md to describe the new layout and hotkeys.

## Test plan
- [x] Run `dart test` in `ctterm` (note: existing suite currently reports failures unrelated to the new in-game shell graph helpers; CI should re-verify).
- [ ] Manually exercise ctterm in-game shell: verify centered province label, vertical neighbour list, number-key navigation, and seabound marker/flag for coastal capitals.


Made with [Cursor](https://cursor.com)