### PR TITLE
feat(ctterm): map grid widget in in-game shell with visibility and layer legend

### DIFF
--- a/SPEC/tui/map-tui-mapping.md
+++ b/SPEC/tui/map-tui-mapping.md
@@ -65,6 +65,8 @@ The mapping is implemented in `ctterm/lib/map_tui_mapping.dart`:
 - `ownerToChar(String? ownerId, PlayerType? playerType)` - converts owner to character
 - `getTileDisplay(String tileKey, TileMapResult tileMap, Province? province, String? ownerId, bool isVisible)` - assembles full tile display
 - `renderRegionMap(TileMapResult tileMap, Map<String, Province> provincesById, Map<String, String> playerVisibility, bool showTerrain, bool showOwnership)` - renders complete ASCII map
+- `renderRegionMapViewport(regionId, tileMap, ..., offsetX, offsetY, viewportWidth, viewportHeight, layer, unitSymbolByTileKey?)` - renders a viewport for the in-game shell map grid; **layer** is `MapGridLayer` (terrain, political, resources, units)
+- `MapGridLayer` enum; `makeFullTileKey(regionId, localId, x, y)` for full tile keys per world-model-identity
 
 ### Color palette (terminal)
 

--- a/SPEC/tui/screens/in-game-shell.md
+++ b/SPEC/tui/screens/in-game-shell.md
@@ -120,15 +120,49 @@ The map area is a **topology graph** of the current region’s **land provinces*
 +----------------------------------------------------------+
 | Turn: 3 | Year: 1850 | Treasury: $5000 | Region: OW [R] |
 +----------------------------------------------------------+
-|  [TOPOLOGY GRAPH]          |  Province Info              |
-|  Nodes = provinces,        |  Name: ...                  |
-|  edges = land-adjacent     |  Owner: ...                 |
+|  [MAP GRID viewport]         |  Province Info              |
+|  Layer: Terrain [ ]=layer; centered on selected province |  Name: ...                  |
+|  [TOPOLOGY GRAPH]             |  Owner: ...                  |
 |  (grid-like layout)        |  Terrain / Fort / Town      |
 |  Selected node highlighted |  Visibility: ...            |
 +----------------------------------------------------------+
 |  [M]ap Context [R]egion [U]nits [D]ev [P]rod ...        |
 +----------------------------------------------------------+
 ```
+
+## Map Grid Widget (Empire Overview)
+
+The map area **complements** the topology graph with a **map grid widget** that shows the current region as an ASCII tile grid. The grid uses a **viewport** that **centers on the selected province** (the same province shown as the center of the topology graph). Scrolling is **indirect**: when the user switches province via the graph (j/l or arrows to cycle neighbours, **1–9** to jump to a neighbour), the grid viewport updates to center on the newly selected province. There are **no keys for manual viewport scrolling**.
+
+### Behaviour
+
+- **Content:** The widget displays the **entire** region's tile map in ASCII (one character per tile). Data source: same as [SPEC/tui/map-tui-mapping.md](../map-tui-mapping.md) (terrain, ownership, resources, visibility). Province and tile identity: [SPEC/game/world-model-identity.md](../../game/world-model-identity.md) (prefixed province id, tile key `regionId|localId|x|y`).
+- **Viewport:** The visible area is a rectangle of fixed size (e.g. terminal lines × columns). The full region may be larger. The viewport **centers on the selected province** when possible: the selected province’s tile centroid (from `tileKeysByRegionAndProvince`) is used to compute viewport offset so that province appears centered; offset is clamped so the viewport never shows out-of-bounds cells. When the user changes the selected province (via topology graph navigation), the grid viewport updates to center on the new province. There are **no manual scroll keys**.
+- **Layers:** The user can switch between **four** display layers:
+  - **Terrain** — terrain type per tile (sea, plains, forest, hills, mountain, swamp, desert) per map-tui-mapping.
+  - **Political** — province ownership (Great Power / minor / tribe / unclaimed) per map-tui-mapping.
+  - **Resources** — resource type per tile (when present) using resource glyphs per map-tui-mapping; empty tiles show terrain as fallback.
+  - **Unit locations** — tiles that contain at least one unit show a unit symbol (e.g. `U` or type initial); other tiles show terrain as fallback. Units with `tileKey` are placed at that tile; units without `tileKey` use a representative tile of their province (e.g. first tile in `tileKeysByRegionAndProvince`).
+- **Layer switching:** Keys **[** and **]** cycle the active layer (Terrain → Political → Resources → Units → Terrain). The current layer is indicated in the widget (e.g. "Layer: Terrain"). The topology graph uses **j**/**l** or **arrow keys** for neighbour cycle and **1–9** for direct neighbour selection so key bindings do not conflict.
+- **Placement:** The map grid is shown **above** the topology graph in the same map area column so both are visible without switching screens.
+
+### Acceptance criteria (Given–When–Then)
+
+- **Given** the player is in the in-game shell and the current region has a tile map  
+  **When** the screen renders  
+  **Then** the map area shows the map grid widget above the topology graph, with the viewport displaying a subset of the region's tiles in ASCII centered (as much as possible) on the selected province, and the current layer label.
+
+- **Given** the player is in the in-game shell with a province selected and the map grid is visible  
+  **When** the user changes the selected province via the topology graph (e.g. j/l or arrows to cycle neighbours, or **1–9** to select a neighbour)  
+  **Then** the map grid viewport updates to center on the newly selected province (using that province’s tile centroid from `tileKeysByRegionAndProvince`), so that the grid and graph stay in sync with no manual scroll keys.
+
+- **Given** the user is viewing the map grid  
+  **When** the user presses **[** or **]** to cycle layer  
+  **Then** the active layer changes (Terrain → Political → Resources → Units → Terrain), and the grid and layer label update accordingly.
+
+- **Given** the user is on the unit locations layer  
+  **When** a tile contains one or more units  
+  **Then** that tile displays a unit symbol (e.g. `U`); tiles without units show the terrain character.
 
 ## Implementation Notes
 

--- a/ctterm/lib/map_tui_mapping.dart
+++ b/ctterm/lib/map_tui_mapping.dart
@@ -165,6 +165,19 @@ String makeTileKey(String regionId, int x, int y) {
   return '$regionId|$x|$y';
 }
 
+/// Full tile key per SPEC/game/world-model-identity.md: regionId|localId|x|y.
+String makeFullTileKey(String regionId, String localId, int x, int y) {
+  return '$regionId|$localId|$x|$y';
+}
+
+/// Map grid display layer for the in-game shell map grid widget. SPEC/tui/screens/in-game-shell.md.
+enum MapGridLayer {
+  terrain,
+  political,
+  resources,
+  units,
+}
+
 /// Renders a single tile for display.
 /// Returns a tuple: [character, isFogged, isCapital, isPort]
 ({String char, bool fogged, bool capital, bool port}) getTileDisplay({
@@ -296,7 +309,75 @@ List<String> renderRegionMap({
   return lines;
 }
 
-/// Gets province coordinates (min x, min y) from the tile map.
+/// Renders a viewport of the region map for the in-game shell map grid widget.
+/// [offsetX], [offsetY] are the top-left cell of the viewport; [viewportWidth] and [viewportHeight] are the visible size.
+/// [layer] selects which layer to display (terrain, political, resources, units).
+/// [unitSymbolByTileKey] maps full tile key (regionId|localId|x|y) to a character for the units layer; only used when [layer] is [MapGridLayer.units].
+/// Visibility is from [playerVisibilityByTile] (game setup gives the human player visibility of their own provinces).
+/// Returns one line per viewport row; each line is one character per column (no padding).
+List<String> renderRegionMapViewport({
+  required String regionId,
+  required TileMapResult tileMap,
+  required Map<String, Province> provincesById,
+  required Map<String, String>? playerVisibilityByTile,
+  required List<Player> players,
+  required Set<String> capitalTiles,
+  required Set<String> portTiles,
+  required int offsetX,
+  required int offsetY,
+  required int viewportWidth,
+  required int viewportHeight,
+  required MapGridLayer layer,
+  Map<String, String>? unitSymbolByTileKey,
+}) {
+  final lines = <String>[];
+  final endX = (offsetX + viewportWidth).clamp(0, tileMap.width);
+  final endY = (offsetY + viewportHeight).clamp(0, tileMap.height);
+  final startX = offsetX.clamp(0, tileMap.width);
+  final startY = offsetY.clamp(0, tileMap.height);
+
+  for (var y = startY; y < endY; y++) {
+    final buffer = StringBuffer();
+    for (var x = startX; x < endX; x++) {
+      final localId = tileMap.cell(x, y);
+      final fullTileKey = makeFullTileKey(regionId, localId, x, y);
+      final fullProvinceId = '$regionId|$localId';
+      final visibility = getTileVisibility(fullTileKey, playerVisibilityByTile);
+      final isVisible = visibility != TileVisibility.unexplored;
+
+      String char = ' ';
+      if (!isVisible) {
+        // Unexplored: show distinct character so visibility is clear (e.g. New World at game start).
+        buffer.write('?');
+        continue;
+      }
+
+      final terrain = tileMap.terrainAt(x, y);
+      switch (layer) {
+        case MapGridLayer.terrain:
+          char = terrainToChar(terrain);
+          break;
+        case MapGridLayer.political:
+          final province = provincesById[fullProvinceId];
+          final ownerId = province?.ownerId;
+          final playerType = getPlayerType(ownerId, players);
+          char = ownerToChar(ownerId, playerType);
+          break;
+        case MapGridLayer.resources:
+          final resource = tileMap.resourceAt(x, y);
+          char = resource != null ? resourceToChar(resource) : terrainToChar(terrain);
+          break;
+        case MapGridLayer.units:
+          final unitChar = unitSymbolByTileKey?[fullTileKey];
+          char = unitChar ?? terrainToChar(terrain);
+          break;
+      }
+      buffer.write(char);
+    }
+    lines.add(buffer.toString());
+  }
+  return lines;
+}
 ({int x, int y })? getProvinceTilePosition(
   TileMapResult tileMap,
   String provinceId,

--- a/ctterm/lib/screens/in_game_shell_screen.dart
+++ b/ctterm/lib/screens/in_game_shell_screen.dart
@@ -6,8 +6,10 @@ import 'package:logger/logger.dart' as log_pkg;
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
+import 'package:ctterm/widgets/map_grid_widget.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:ctterm/map_tui_mapping.dart';
 
 final log_pkg.Logger _log = log_pkg.Logger();
 
@@ -54,6 +56,8 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
   bool _isEndingTurn = false;
   bool _isConfirmingEndTurn = false;
   int _idleCivilianCountForPrompt = 0;
+  /// Map grid layer only; viewport is derived from selected province (SPEC/tui/screens/in-game-shell.md § Map Grid Widget).
+  MapGridLayer _mapGridLayer = MapGridLayer.terrain;
 
   int get _turn => component.game?.worldState.turnState.turnNumber ?? 1;
   int get _year => inGameShellHudYear(component.game, _turn);
@@ -84,7 +88,7 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
     for (final entry in game.aiControlByGpId.entries) {
       if (!entry.value) return entry.key;
     }
-    return game.players.isNotEmpty ? game.players.first.id : null;
+    return null;
   }
 
   bool _isCivilianUnit(Unit unit) {
@@ -267,6 +271,45 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
     });
   }
 
+  /// Viewport (viewX, viewY) to center the map grid on the selected province when possible.
+  /// Tile key format per SPEC/game/world-model-identity.md: regionId|localId|x|y.
+  (int, int) _mapGridViewportFromSelectedProvince(
+    TileMapResult tileMap,
+    int viewportWidth,
+    int viewportHeight,
+  ) {
+    final localId = _selectedProvinceLocalId;
+    if (localId == null) return (0, 0);
+    final game = component.game;
+    if (game == null) return (0, 0);
+    final fullProvinceId = '$_selectedRegion|$localId';
+    final byProvince =
+        game.worldState.tileKeysByRegionAndProvince[_selectedRegion];
+    final tileKeys = byProvince?[fullProvinceId];
+    if (tileKeys == null || tileKeys.isEmpty) return (0, 0);
+
+    int sumX = 0;
+    int sumY = 0;
+    for (final key in tileKeys) {
+      final parts = key.split('|');
+      if (parts.length >= 4) {
+        final x = int.tryParse(parts[2]) ?? 0;
+        final y = int.tryParse(parts[3]) ?? 0;
+        sumX += x;
+        sumY += y;
+      }
+    }
+    final count = tileKeys.length;
+    if (count == 0) return (0, 0);
+    final centerX = sumX ~/ count;
+    final centerY = sumY ~/ count;
+    final maxX = (tileMap.width - viewportWidth).clamp(0, tileMap.width);
+    final maxY = (tileMap.height - viewportHeight).clamp(0, tileMap.height);
+    final viewX = (centerX - viewportWidth ~/ 2).clamp(0, maxX);
+    final viewY = (centerY - viewportHeight ~/ 2).clamp(0, maxY);
+    return (viewX, viewY);
+  }
+
   Future<void> _handleEndTurn() async {
     if (_isEndingTurn) return;
     setState(() => _isEndingTurn = true);
@@ -361,7 +404,49 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
           _cycleRegion();
           return true;
         }
-        // Graph navigation: next/prev neighbour (j/k or left/right)
+        // Map grid: [ / ] cycle layer (Terrain→Political→Resources→Units). Viewport centers on selected province. 1–9 = graph. SPEC/tui/screens/in-game-shell.md § Map Grid Widget.
+        final tileMap = component.tileMapByRegion?[_selectedRegion];
+        if (tileMap != null) {
+          if (c == '[') {
+            setState(() {
+              switch (_mapGridLayer) {
+                case MapGridLayer.terrain:
+                  _mapGridLayer = MapGridLayer.units;
+                  break;
+                case MapGridLayer.political:
+                  _mapGridLayer = MapGridLayer.terrain;
+                  break;
+                case MapGridLayer.resources:
+                  _mapGridLayer = MapGridLayer.political;
+                  break;
+                case MapGridLayer.units:
+                  _mapGridLayer = MapGridLayer.resources;
+                  break;
+              }
+            });
+            return true;
+          }
+          if (c == ']') {
+            setState(() {
+              switch (_mapGridLayer) {
+                case MapGridLayer.terrain:
+                  _mapGridLayer = MapGridLayer.political;
+                  break;
+                case MapGridLayer.political:
+                  _mapGridLayer = MapGridLayer.resources;
+                  break;
+                case MapGridLayer.resources:
+                  _mapGridLayer = MapGridLayer.units;
+                  break;
+                case MapGridLayer.units:
+                  _mapGridLayer = MapGridLayer.terrain;
+                  break;
+              }
+            });
+            return true;
+          }
+        }
+        // Graph navigation: next/prev neighbour (j/l, arrows). Direct selection 1–9.
         if (c == 'j' || key == LogicalKey.arrowLeft) {
           _selectPrevNeighbour();
           return true;
@@ -370,7 +455,7 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
           _selectNextNeighbour();
           return true;
         }
-        // Direct neighbour selection via number keys 1–9.
+        // Direct neighbour selection via number keys 1–9 (indices 0–8). Map layers use t/p/r/u.
         if (c != null && c.length == 1 && c.codeUnitAt(0) >= '1'.codeUnitAt(0) &&
             c.codeUnitAt(0) <= '9'.codeUnitAt(0)) {
           final index = c.codeUnitAt(0) - '1'.codeUnitAt(0);
@@ -431,80 +516,124 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
   Component _buildMapArea() {
     final top = component.combinedTopology;
     final land = _landProvinceLocalIds;
-    if (top == null || top.nodes.isEmpty || land.isEmpty) {
+    final tileMap = component.tileMapByRegion?[_selectedRegion];
+    const viewportWidth = 24;
+    const viewportHeight = 8;
+
+    final topologySection = (top == null || top.nodes.isEmpty || land.isEmpty)
+        ? Container(
+            padding: const EdgeInsets.all(1),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text('No topology', style: TextStyle(color: Colors.gray)),
+                Text('Provinces in region: ${_provinces.length}',
+                    style: TextStyle(color: Colors.gray)),
+              ],
+            ),
+          )
+        : _buildTopologyContent();
+
+    if (tileMap == null || component.game == null) {
       return Container(
         padding: const EdgeInsets.all(1),
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('No topology', style: TextStyle(color: Colors.gray)),
-            Text('Provinces in region: ${_provinces.length}',
-                style: TextStyle(color: Colors.gray)),
+            Text('=== $_regionDisplayName (land graph) ===',
+                style: TextStyle(color: Colors.cyan)),
+            topologySection,
           ],
         ),
       );
     }
 
-    final selected = _selectedProvinceLocalId;
-    final selectedProv =
-        selected != null ? _provinceByLocalId(selected) : null;
-    final neighbours =
-        selected != null ? _neighboursOf(selected) : <String>[];
+    final (viewX, viewY) = _mapGridViewportFromSelectedProvince(
+      tileMap,
+      viewportWidth,
+      viewportHeight,
+    );
 
     return Container(
       padding: const EdgeInsets.all(1),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          MapGridWidget(
+            regionId: _selectedRegion,
+            tileMap: tileMap,
+            game: component.game!,
+            viewportWidth: viewportWidth,
+            viewportHeight: viewportHeight,
+            viewX: viewX,
+            viewY: viewY,
+            layer: _mapGridLayer,
+          ),
+          const SizedBox(height: 1),
           Text('=== $_regionDisplayName (land graph) ===',
               style: TextStyle(color: Colors.cyan)),
           Text(
-              'Center = current province; 1–9: neighbour, j/l or ←/→: cycle',
+              'Center = current province; 1–9: neighbour, j/l or arrows: cycle',
               style: TextStyle(color: Colors.gray)),
           const SizedBox(height: 1),
-          if (selected == null || selectedProv == null)
-            Text('No province selected', style: TextStyle(color: Colors.gray))
-          else ...[
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  _provinceLabel(selectedProv, selected),
-                  style: TextStyle(
-                    color: _provinceTextColor(selectedProv),
-                    fontWeight: FontWeight.bold,
-                  ),
+          Expanded(child: topologySection),
+        ],
+      ),
+    );
+  }
+
+  Component _buildTopologyContent() {
+    final selected = _selectedProvinceLocalId;
+    final selectedProv =
+        selected != null ? _provinceByLocalId(selected) : null;
+    final neighbours =
+        selected != null ? _neighboursOf(selected) : <String>[];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (selected == null || selectedProv == null)
+          Text('No province selected', style: TextStyle(color: Colors.gray))
+        else
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                _provinceLabel(selectedProv, selected),
+                style: TextStyle(
+                  color: _provinceTextColor(selectedProv),
+                  fontWeight: FontWeight.bold,
                 ),
-                const SizedBox(width: 2),
-                Text('->', style: TextStyle(color: Colors.gray)),
-                const SizedBox(width: 1),
-                if (neighbours.isEmpty)
-                  Text('No neighbours', style: TextStyle(color: Colors.gray))
-                else
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        for (var i = 0; i < neighbours.length; i++)
-                          Padding(
-                            padding: const EdgeInsets.only(bottom: 1),
-                            child: Text(
-                              _neighbourLabel(neighbours[i], i),
-                              style: TextStyle(
-                                color: _provinceTextColor(
-                                  _provinceByLocalId(neighbours[i]),
-                                ),
+              ),
+              const SizedBox(width: 2),
+              Text('->', style: TextStyle(color: Colors.gray)),
+              const SizedBox(width: 1),
+              if (neighbours.isEmpty)
+                Text('No neighbours', style: TextStyle(color: Colors.gray))
+              else
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      for (var i = 0; i < neighbours.length; i++)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 1),
+                          child: Text(
+                            _neighbourLabel(neighbours[i], i),
+                            style: TextStyle(
+                              color: _provinceTextColor(
+                                _provinceByLocalId(neighbours[i]),
                               ),
                             ),
                           ),
-                      ],
-                    ),
+                        ),
+                    ],
                   ),
-              ],
-            ),
-          ],
-        ],
-      ),
+                ),
+            ],
+          ),
+      ],
     );
   }
 
@@ -547,7 +676,7 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
             Text('Visibility: full', style: TextStyle(color: Colors.gray)),
           ],
           const Spacer(),
-          Text('1–9: neighbour, j/l or ←/→: cycle',
+          Text('1–9: neighbour, j/l or arrows: cycle',
               style: TextStyle(color: Colors.gray)),
         ],
       ),

--- a/ctterm/lib/widgets/map_grid_widget.dart
+++ b/ctterm/lib/widgets/map_grid_widget.dart
@@ -1,0 +1,145 @@
+// Map grid widget for in-game shell: ASCII viewport with layer switching and scroll.
+// SPEC/tui/screens/in-game-shell.md § Map Grid Widget.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:nocterm/nocterm.dart';
+
+import 'package:ctterm/map_tui_mapping.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Map grid widget showing a viewport of the region tile map with layer switching (terrain, political, resources, units) and scroll.
+/// Scroll offset and layer are controlled by the parent (in-game shell) so the shell can share key handling with the topology graph.
+class MapGridWidget extends StatelessComponent {
+  const MapGridWidget({
+    super.key,
+    required this.regionId,
+    required this.tileMap,
+    required this.game,
+    required this.viewportWidth,
+    required this.viewportHeight,
+    required this.viewX,
+    required this.viewY,
+    required this.layer,
+  });
+
+  final String regionId;
+  final TileMapResult tileMap;
+  final Game game;
+  final int viewportWidth;
+  final int viewportHeight;
+  final int viewX;
+  final int viewY;
+  final MapGridLayer layer;
+
+  /// Builds map from full tile key to unit symbol for the units layer.
+  static Map<String, String> buildUnitSymbolByTileKey(
+    Game game,
+    String regionId,
+  ) {
+    final units = regionId == 'oldWorld'
+        ? game.worldState.oldWorld.units
+        : game.worldState.newWorld.units;
+    final tileKeysByProv = game.worldState.tileKeysByRegionAndProvince;
+    final regionTiles = tileKeysByProv[regionId];
+    final result = <String, String>{};
+
+    for (final unit in units) {
+      String? tileKey;
+      if (unit.tileKey != null && unit.tileKey!.isNotEmpty) {
+        tileKey = unit.tileKey;
+      } else if (regionTiles != null) {
+        final provTiles = regionTiles[unit.locationProvinceId];
+        tileKey = provTiles?.isNotEmpty == true ? provTiles!.first : null;
+      }
+      if (tileKey != null) {
+        final symbol = unit.type.isNotEmpty ? unit.type.substring(0, 1).toUpperCase() : 'U';
+        result[tileKey] = symbol;
+      }
+    }
+    return result;
+  }
+
+  @override
+  Component build(BuildContext context) {
+    final game = this.game;
+    final tileMap = this.tileMap;
+    final regionId = this.regionId;
+    final provinces = regionId == 'oldWorld'
+        ? game.worldState.oldWorld.provinces
+        : game.worldState.newWorld.provinces;
+    final provincesById = buildProvincesMap(provinces);
+    String? humanPlayerId;
+    for (final entry in game.aiControlByGpId.entries) {
+      if (!entry.value) {
+        humanPlayerId = entry.key;
+        break;
+      }
+    }
+    final playerVisibilityByTile = humanPlayerId != null
+        ? game.worldState.playerVisibilityByTile[humanPlayerId]
+        : null;
+    final capitalTiles = getCapitalTiles(game);
+    final portTiles = getPortTiles(game.worldState);
+    final unitSymbolByTileKey = layer == MapGridLayer.units
+        ? buildUnitSymbolByTileKey(game, regionId)
+        : null;
+
+    final lines = renderRegionMapViewport(
+      regionId: regionId,
+      tileMap: tileMap,
+      provincesById: provincesById,
+      playerVisibilityByTile: playerVisibilityByTile,
+      players: game.players,
+      capitalTiles: capitalTiles,
+      portTiles: portTiles,
+      offsetX: viewX,
+      offsetY: viewY,
+      viewportWidth: viewportWidth,
+      viewportHeight: viewportHeight,
+      layer: layer,
+      unitSymbolByTileKey: unitSymbolByTileKey,
+    );
+
+    final layerLabel = switch (layer) {
+      MapGridLayer.terrain => 'Terrain',
+      MapGridLayer.political => 'Political',
+      MapGridLayer.resources => 'Resources',
+      MapGridLayer.units => 'Units',
+    };
+
+    final legend = _legendForLayer(layer);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 1),
+          child: Text(
+              'Map [Layer: $layerLabel]  [ ]=layer (scroll follows province)',
+              style: TextStyle(color: Colors.cyan),
+            ),
+        ),
+        ...lines.map((line) => Text(line)),
+        Padding(
+          padding: const EdgeInsets.only(top: 1),
+          child: Text(legend, style: TextStyle(color: Colors.gray)),
+        ),
+      ],
+    );
+  }
+
+  /// One-line legend for the current layer to disambiguate symbols.
+  static String _legendForLayer(MapGridLayer layer) {
+    switch (layer) {
+      case MapGridLayer.terrain:
+        return '?=unexplored ~sea .plains ♣forest ^hills ▲mt ≈swamp ▒desert';
+      case MapGridLayer.political:
+        return '?=unexplored ·unclaimed A–Z=GP mX=minor tX=tribe';
+      case MapGridLayer.resources:
+        return '?=unexplored g=gra m=meat w=wool h=horse t=timber i=iron c=copper k=coal G=gold … (empty=terrain)';
+      case MapGridLayer.units:
+        return '?=unexplored Letter=unit type (1st letter); no letter=terrain';
+    }
+  }
+}

--- a/ctterm/test/in_game_shell_end_turn_test.dart
+++ b/ctterm/test/in_game_shell_end_turn_test.dart
@@ -7,15 +7,10 @@ import 'package:ctterm/screens/in_game_shell_screen.dart';
 import 'package:test/test.dart';
 
 String _humanPlayerId(Game game) {
-  if (game.aiControlByGpId.isNotEmpty) {
-    for (final entry in game.aiControlByGpId.entries) {
-      if (!entry.value) return entry.key;
-    }
+  for (final entry in game.aiControlByGpId.entries) {
+    if (!entry.value) return entry.key;
   }
-  if (game.players.isNotEmpty) {
-    return game.players.first.id;
-  }
-  throw StateError('Game has no players');
+  throw StateError('Game has no human player (aiControlByGpId has no false entry)');
 }
 
 void main() {

--- a/ctterm/test/map_grid_widget_test.dart
+++ b/ctterm/test/map_grid_widget_test.dart
@@ -1,0 +1,117 @@
+// Tests for MapGridWidget. SPEC/tui/screens/in-game-shell.md § Map Grid Widget.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:ctterm/map_tui_mapping.dart';
+import 'package:ctterm/widgets/map_grid_widget.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MapGridWidget', () {
+    late Game minimalGame;
+    late TileMapResult tileMap;
+
+    setUp(() {
+      tileMap = TileMapResult(
+        width: 4,
+        height: 2,
+        grid: [
+          ['p1', 'p1', 'sea1', 'sea1'],
+          ['p1', 'p2', 'p2', 'sea1'],
+        ],
+        terrainGrid: [
+          [TerrainType.plains, TerrainType.plains, null, null],
+          [TerrainType.plains, TerrainType.forest, TerrainType.forest, null],
+        ],
+        resourceGrid: null,
+      );
+      minimalGame = Game(
+        id: 'test',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'oldWorld|p1', regionId: 'oldWorld', ownerId: 'gp1'),
+              Province(id: 'oldWorld|p2', regionId: 'oldWorld', ownerId: 'gp2'),
+            ],
+          ),
+          newWorld: const RegionData(provinces: []),
+          tileKeysByRegionAndProvince: {
+            'oldWorld': {
+              'oldWorld|p1': ['oldWorld|p1|0|0', 'oldWorld|p1|1|0', 'oldWorld|p1|0|1'],
+              'oldWorld|p2': ['oldWorld|p2|1|1', 'oldWorld|p2|2|1'],
+            },
+          },
+          playerVisibilityByTile: {
+            'gp1': {
+              'oldWorld|p1|0|0': 'fullyVisible',
+              'oldWorld|p1|1|0': 'fullyVisible',
+              'oldWorld|p1|0|1': 'fullyVisible',
+              'oldWorld|p2|1|1': 'fogged',
+              'oldWorld|p2|2|1': 'fogged',
+              'oldWorld|sea1|2|0': 'fullyVisible',
+              'oldWorld|sea1|3|0': 'fullyVisible',
+              'oldWorld|sea1|3|1': 'fullyVisible',
+            },
+          },
+        ),
+        players: [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true),
+          Player(id: 'gp2', displayName: 'AI', isHuman: false),
+        ],
+        aiControlByGpId: {'gp1': false, 'gp2': true},
+      );
+    });
+
+    test('can be constructed with required parameters', () {
+      final widget = MapGridWidget(
+        regionId: 'oldWorld',
+        tileMap: tileMap,
+        game: minimalGame,
+        viewportWidth: 4,
+        viewportHeight: 2,
+        viewX: 0,
+        viewY: 0,
+        layer: MapGridLayer.terrain,
+      );
+      expect(widget.regionId, 'oldWorld');
+      expect(widget.layer, MapGridLayer.terrain);
+      expect(widget.viewportWidth, 4);
+      expect(widget.viewportHeight, 2);
+    });
+
+    group('buildUnitSymbolByTileKey', () {
+      test('returns empty map when no units in region', () {
+        final result = MapGridWidget.buildUnitSymbolByTileKey(
+          minimalGame,
+          'oldWorld',
+        );
+        expect(result.length, 0);
+      });
+
+      test('maps unit tileKey to symbol when units exist', () {
+        const unit = Unit(
+          id: 'u1',
+          ownerId: 'gp1',
+          type: 'Builder',
+          provinceId: 'oldWorld|p1',
+          tileKey: 'oldWorld|p1|0|0',
+        );
+        final oldWorldWithUnit = RegionData(
+          provinces: minimalGame.worldState.oldWorld.provinces,
+          units: [unit],
+        );
+        final gameWithUnit = minimalGame.copyWith(
+          worldState: minimalGame.worldState.copyWith(
+            oldWorld: oldWorldWithUnit,
+          ),
+        );
+        final result = MapGridWidget.buildUnitSymbolByTileKey(
+          gameWithUnit,
+          'oldWorld',
+        );
+        expect(result['oldWorld|p1|0|0'], 'B');
+      });
+    });
+  });
+}

--- a/ctterm/test/map_tui_mapping_test.dart
+++ b/ctterm/test/map_tui_mapping_test.dart
@@ -1,0 +1,194 @@
+// Tests for map TUI mapping (visibility, tile keys, viewport rendering). SPEC/tui/map-tui-mapping.md.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:ctterm/map_tui_mapping.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('makeFullTileKey', () {
+    test('produces regionId|localId|x|y format', () {
+      expect(makeFullTileKey('oldWorld', 'p1', 0, 0), 'oldWorld|p1|0|0');
+      expect(makeFullTileKey('newWorld', 'nw2', 10, 5), 'newWorld|nw2|10|5');
+    });
+  });
+
+  group('getTileVisibility', () {
+    test('returns unexplored when map is null', () {
+      expect(
+        getTileVisibility('oldWorld|p1|0|0', null),
+        TileVisibility.unexplored,
+      );
+    });
+
+    test('returns unexplored when key is absent', () {
+      expect(
+        getTileVisibility('oldWorld|p1|0|0', {'other|key': 'fullyVisible'}),
+        TileVisibility.unexplored,
+      );
+    });
+
+    test('returns level when key is present', () {
+      const tileKey = 'oldWorld|p1|0|0';
+      expect(
+        getTileVisibility(tileKey, {tileKey: 'fullyVisible'}),
+        TileVisibility.fullyVisible,
+      );
+      expect(
+        getTileVisibility(tileKey, {tileKey: 'fogged'}),
+        TileVisibility.fogged,
+      );
+      expect(
+        getTileVisibility(tileKey, {tileKey: 'revealed'}),
+        TileVisibility.revealed,
+      );
+    });
+  });
+
+  group('renderRegionMapViewport', () {
+    late TileMapResult tileMap;
+    late Map<String, Province> provincesById;
+    late List<Player> players;
+
+    setUp(() {
+      // 3x2 grid: (0,0)=(p1), (1,0)=(p1), (2,0)=(sea), (0,1)=(sea), (1,1)=(p2), (2,1)=(p2)
+      tileMap = TileMapResult(
+        width: 3,
+        height: 2,
+        grid: [
+          ['p1', 'p1', 'sea1'],
+          ['sea1', 'p2', 'p2'],
+        ],
+        terrainGrid: [
+          [TerrainType.plains, TerrainType.plains, null],
+          [null, TerrainType.forest, TerrainType.forest],
+        ],
+        resourceGrid: null,
+      );
+      players = [
+        Player(id: 'gp1', displayName: 'GP1', isHuman: true),
+        Player(id: 'gp2', displayName: 'GP2', isHuman: false),
+      ];
+      provincesById = {
+        'oldWorld|p1': Province(
+          id: 'oldWorld|p1',
+          regionId: 'oldWorld',
+          ownerId: 'gp1',
+        ),
+        'oldWorld|p2': Province(
+          id: 'oldWorld|p2',
+          regionId: 'oldWorld',
+          ownerId: 'gp2',
+        ),
+      };
+    });
+
+    test('respects visibility: unexplored tiles show as ?', () {
+      const regionId = 'oldWorld';
+      final lines = renderRegionMapViewport(
+        regionId: regionId,
+        tileMap: tileMap,
+        provincesById: provincesById,
+        playerVisibilityByTile: null,
+        players: players,
+        capitalTiles: {},
+        portTiles: {},
+        offsetX: 0,
+        offsetY: 0,
+        viewportWidth: 3,
+        viewportHeight: 2,
+        layer: MapGridLayer.terrain,
+      );
+      expect(lines.length, 2);
+      expect(lines[0].length, 3);
+      expect(lines[1].length, 3);
+      expect(lines[0], '???');
+      expect(lines[1], '???');
+    });
+
+    test('visible tiles show terrain layer', () {
+      const regionId = 'oldWorld';
+      final visibility = {
+        'oldWorld|p1|0|0': 'fullyVisible',
+        'oldWorld|p1|1|0': 'fullyVisible',
+        'oldWorld|sea1|2|0': 'fullyVisible',
+        'oldWorld|sea1|0|1': 'fullyVisible',
+        'oldWorld|p2|1|1': 'fullyVisible',
+        'oldWorld|p2|2|1': 'fullyVisible',
+      };
+      final lines = renderRegionMapViewport(
+        regionId: regionId,
+        tileMap: tileMap,
+        provincesById: provincesById,
+        playerVisibilityByTile: visibility,
+        players: players,
+        capitalTiles: {},
+        portTiles: {},
+        offsetX: 0,
+        offsetY: 0,
+        viewportWidth: 3,
+        viewportHeight: 2,
+        layer: MapGridLayer.terrain,
+      );
+      expect(lines.length, 2);
+      expect(lines[0], '..~'); // plains, plains, sea -> . . ~
+      expect(lines[0].length, 3);
+      expect(lines[1].length, 3);
+      expect(lines[1][0], '~');
+      expect(lines[1][1], '♣');
+      expect(lines[1][2], '♣');
+    });
+
+    test('viewport offset and size clamp correctly', () {
+      const regionId = 'oldWorld';
+      final visibility = {
+        'oldWorld|p2|1|1': 'fullyVisible',
+        'oldWorld|p2|2|1': 'fullyVisible',
+      };
+      final lines = renderRegionMapViewport(
+        regionId: regionId,
+        tileMap: tileMap,
+        provincesById: provincesById,
+        playerVisibilityByTile: visibility,
+        players: players,
+        capitalTiles: {},
+        portTiles: {},
+        offsetX: 1,
+        offsetY: 1,
+        viewportWidth: 2,
+        viewportHeight: 1,
+        layer: MapGridLayer.terrain,
+      );
+      expect(lines.length, 1);
+      expect(lines[0].length, 2);
+      expect(lines[0][0], '♣');
+      expect(lines[0][1], '♣');
+    });
+
+    test('political layer uses owner character', () {
+      const regionId = 'oldWorld';
+      final visibility = {
+        'oldWorld|p1|0|0': 'fullyVisible',
+        'oldWorld|p2|1|1': 'fullyVisible',
+      };
+      final lines = renderRegionMapViewport(
+        regionId: regionId,
+        tileMap: tileMap,
+        provincesById: provincesById,
+        playerVisibilityByTile: visibility,
+        players: players,
+        capitalTiles: {},
+        portTiles: {},
+        offsetX: 0,
+        offsetY: 0,
+        viewportWidth: 3,
+        viewportHeight: 2,
+        layer: MapGridLayer.political,
+      );
+      expect(lines.length, 2);
+      // gp1 is human -> Great Power -> first letter uppercase G; gp2 is AI -> minor -> m + g
+      expect(lines[0][0], 'G');
+      expect(lines[1][1], 'm'); // minor nation prefix
+    });
+  });
+}

--- a/packages/colonizethis_logic/lib/src/setup/game_setup.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup.dart
@@ -187,6 +187,10 @@ GameSetupResult createGameFromGeneratedMaps({
         ),
   ];
 
+  /// Explicit designation of which Great Power is human-controlled (respects game setup: slot 0 = human).
+  /// Used by ctterm and other clients for visibility and input; AI uses true, human uses false.
+  final aiControlByGpId = {for (final p in players) p.id: !p.isHuman};
+
   var game = Game(
     id: gameId,
     worldState: worldState,
@@ -195,6 +199,7 @@ GameSetupResult createGameFromGeneratedMaps({
     tribes: tribes,
     turnTimeMapping: TurnTimeMapping.gdd01,
     diplomacyRelations: diplomacyRelations,
+    aiControlByGpId: aiControlByGpId,
   );
 
   // Capital auto-choice: GPs (OW), then minors (OW), then tribes (NW). Must run before naming.


### PR DESCRIPTION
## Summary
- **Map grid widget** in in-game shell (Empire Overview): ASCII viewport above topology graph; viewport centers on selected province (scroll is indirect via graph selection). Layers: terrain, political, resources, units; **\[** / **\]** to cycle layer; **1–9** for graph neighbour selection.
- **Visibility**: Map grid respects `playerVisibilityByTile`; unexplored tiles show **?** (e.g. New World at game start).
- **Human player**: Game setup sets `aiControlByGpId` from `player.isHuman` so the human is explicit; removed legacy fallbacks. Players always have visibility of own provinces via setup.
- **Specs**: SPEC/tui/screens/in-game-shell.md, SPEC/tui/map-tui-mapping.md updated.
- **Tests**: `map_tui_mapping_test.dart` (makeFullTileKey, getTileVisibility, renderRegionMapViewport), `map_grid_widget_test.dart` (construction, buildUnitSymbolByTileKey). `in_game_shell_end_turn_test` uses `aiControlByGpId` only for human.

All ctterm tests pass (111).

Made with [Cursor](https://cursor.com)