### PR TITLE
Add ctterm agent-tui automation scripts

### DIFF
--- a/SPEC/tui/ctterm.md
+++ b/SPEC/tui/ctterm.md
@@ -179,7 +179,7 @@ This section records development decisions for ctterm. Package placement is defi
 - **Navigation:** Full navigation structure with stubs for all panels: Main Menu, Game Setup, Load Game, Generating World, Settings, In-game shell, Units, Development, Production, Academy, Shipyard, Diplomacy, Technology, Victory/Progress, Defeat, Pause/Options.
 - **Map TUI mapping:** Ctterm defines its own TUI-specific mapping (terrain/ownership → characters or styles). Document in [SPEC/tui/map-tui-mapping.md](map-tui-mapping.md). Base map layer uses the same data as [SPEC/program/map-visualization.md](../program/map-visualization.md); ctterm is a consumer.
 - **Logging:** Use multiple log prefixes for easy identification: `tui:`, `tui:menu:`, `tui:save:`, `tui:nav:` (and later `tui:map:`, `tui:event:`). Use Dart `logger`; no `print` for operational output. See [SPEC/program/ctdev-logging.md](../program/ctdev-logging.md) for level and prefix conventions.
-- **Project tools:** Ctterm is documented in [docs/project-tools.md](../../docs/project-tools.md) (invocation, optional `--data-dir`, link to this spec).
+- **Project tools:** Ctterm is documented in [docs/project-tools.md](../../docs/project-tools.md) (invocation, optional `--data-dir`, link to this spec and ready-to-run `agent-tui` automation scripts for starting games, driving panels such as Development, taking screenshots, and related test flows).
 
 ### 5.2 TUI automation testing with `agent-tui`
 

--- a/ctterm/scripts/agent_tui_assign_all_civilians_improvement.sh
+++ b/ctterm/scripts/agent_tui_assign_all_civilians_improvement.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Scenario script: open Development and assign work to all civilian units.
+#
+# Behaviour (best-effort, per SPEC/tui/screens/development.md):
+# - Assumes an existing ctterm session currently in the in-game shell (100006).
+# - Opens the Development screen (100009) via 'D'.
+# - For a bounded number of rows, repeatedly:
+#   - Selects the current civilian unit (Enter/Space).
+#   - Presses 'i' (Build Improvement) to start work-type selection.
+#   - Accepts the default province (Enter).
+#   - Accepts the default tile (Enter).
+#   - Moves to the next unit row (ArrowDown).
+# - Returns to the in-game shell (Escape) when done.
+#
+# Usage (from repo root, after starting a game and reaching in-game shell):
+#   ./ctterm/scripts/agent_tui_assign_all_civilians_improvement.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${ROOT_DIR}"
+
+source "${SCRIPT_DIR}/agent_tui_ctterm_common.sh"
+
+ctterm_agent_assign_all_civilians_improvement
+
+printf 'Attempted to assign build_improvement work to all civilian units via Development screen.\n' >&2
+

--- a/ctterm/scripts/agent_tui_ctterm_common.sh
+++ b/ctterm/scripts/agent_tui_ctterm_common.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#
+# Common helpers for driving ctterm via agent-tui.
+#
+# Contract (per SPEC/tui/ctterm.md §5.2):
+# - Terminal size: 80x24
+# - cwd: repo root (so `dart run ctterm` works)
+# - One ctterm session per test data-dir
+# - Interaction via `agent-tui press`, `agent-tui type`, `agent-tui wait`, `agent-tui screenshot`
+#
+# Environment variables:
+# - CTTERM_REPO_ROOT      (optional) : repo root; auto-detected from this script when unset
+# - CTTERM_TEST_DATA_DIR  (optional) : Hive data dir for this session; auto-created when unset
+# - CTTERM_AGENT_SESSION  (optional) : agent-tui session id; when set, all commands pass --session
+#
+
+_ctterm_agent_repo_root() {
+  if [[ -n "${CTTERM_REPO_ROOT:-}" ]]; then
+    printf '%s\n' "$CTTERM_REPO_ROOT"
+    return
+  fi
+
+  # Resolve repo root as two levels above this script: ctterm/scripts/ → repo root
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  CTTERM_REPO_ROOT="$(cd "${script_dir}/../.." && pwd)"
+  export CTTERM_REPO_ROOT
+  printf '%s\n' "$CTTERM_REPO_ROOT"
+}
+
+_ctterm_agent_data_dir() {
+  if [[ -n "${CTTERM_TEST_DATA_DIR:-}" ]]; then
+    printf '%s\n' "$CTTERM_TEST_DATA_DIR"
+    return
+  fi
+
+  # Default: create a temporary per-run data directory
+  CTTERM_TEST_DATA_DIR="$(mktemp -d -t ctterm_data_XXXXXX)"
+  export CTTERM_TEST_DATA_DIR
+  printf '%s\n' "$CTTERM_TEST_DATA_DIR"
+}
+
+_ctterm_agent_session_args() {
+  if [[ -n "${CTTERM_AGENT_SESSION:-}" ]]; then
+    printf '%s %s' "--session" "$CTTERM_AGENT_SESSION"
+  fi
+}
+
+ctterm_agent_start_session() {
+  # Starts the agent-tui daemon (idempotent) and launches a ctterm session.
+  # Usage: ctterm_agent_start_session [data_dir]
+  #
+  # When CTTERM_AGENT_SESSION is already set, this function only ensures the
+  # daemon is running and does NOT start another session.
+
+  local data_dir
+  if [[ $# -ge 1 ]]; then
+    data_dir="$1"
+    CTTERM_TEST_DATA_DIR="$data_dir"
+    export CTTERM_TEST_DATA_DIR
+  else
+    data_dir="$(_ctterm_agent_data_dir)"
+  fi
+
+  local repo_root
+  repo_root="$(_ctterm_agent_repo_root)"
+
+  # Ensure daemon is running; ignore error if already started.
+  if ! agent-tui daemon start >/dev/null 2>&1; then
+    # Best-effort; continue even if this fails (daemon may already be running).
+    :
+  fi
+
+  # If the caller provided a session id, assume the session is already running.
+  if [[ -n "${CTTERM_AGENT_SESSION:-}" ]]; then
+    printf 'ctterm_agent_start_session: using existing session "%s" with data-dir "%s"\n' \
+      "$CTTERM_AGENT_SESSION" "$data_dir" >&2
+    return 0
+  fi
+
+  printf 'ctterm_agent_start_session: starting ctterm with data-dir "%s"\n' "$data_dir" >&2
+
+  # Start ctterm in an 80x24 terminal. agent-tui will create a default session;
+  # follow-up commands will target that session implicitly unless the caller
+  # supplies CTTERM_AGENT_SESSION.
+  agent-tui run \
+    --cols 80 \
+    --rows 24 \
+    --cwd "${repo_root}" \
+    dart -- run ctterm --data-dir "${data_dir}"
+}
+
+ctterm_agent_kill_session() {
+  # Kill the current agent-tui session.
+  # If CTTERM_AGENT_SESSION is set, use it; otherwise kill the default session.
+
+  if [[ -n "${CTTERM_AGENT_SESSION:-}" ]]; then
+    agent-tui --session "${CTTERM_AGENT_SESSION}" kill
+  else
+    agent-tui kill
+  fi
+}
+
+ctterm_agent_press() {
+  # Sends one or more keys to ctterm.
+  # Example: ctterm_agent_press N
+  #          ctterm_agent_press ArrowDown Enter
+
+  if [[ $# -lt 1 ]]; then
+    printf 'ctterm_agent_press: expected at least one key\n' >&2
+    return 1
+  fi
+
+  # shellcheck disable=SC2048,SC2086
+  agent-tui $(_ctterm_agent_session_args) press "$@"
+}
+
+ctterm_agent_type() {
+  # Types literal text into ctterm.
+  # Example: ctterm_agent_type "Save 1"
+
+  if [[ $# -ne 1 ]]; then
+    printf 'ctterm_agent_type: expected exactly one argument (text)\n' >&2
+    return 1
+  fi
+
+  local text="$1"
+  # shellcheck disable=SC2048,SC2086
+  agent-tui $(_ctterm_agent_session_args) type "${text}"
+}
+
+ctterm_agent_wait_for_text() {
+  # Waits until the given text appears on screen.
+  # Example: ctterm_agent_wait_for_text "100001"    # Main Menu screen id
+
+  if [[ $# -ne 1 ]]; then
+    printf 'ctterm_agent_wait_for_text: expected exactly one argument (text)\n' >&2
+    return 1
+  fi
+
+  local text="$1"
+  # shellcheck disable=SC2048,SC2086
+  agent-tui $(_ctterm_agent_session_args) wait "${text}" --assert
+}
+
+ctterm_agent_wait_until_gone() {
+  # Waits until the given text disappears from the screen.
+  # Example: ctterm_agent_wait_until_gone "Generating world"
+
+  if [[ $# -ne 1 ]]; then
+    printf 'ctterm_agent_wait_until_gone: expected exactly one argument (text)\n' >&2
+    return 1
+  fi
+
+  local text="$1"
+  # shellcheck disable=SC2048,SC2086
+  agent-tui $(_ctterm_agent_session_args) wait "${text}" --gone
+}
+
+ctterm_agent_wait_for_screen() {
+  # Waits until a screen id (e.g. 100001) is visible.
+  # Example: ctterm_agent_wait_for_screen 100006   # In-game shell
+
+  if [[ $# -ne 1 ]]; then
+    printf 'ctterm_agent_wait_for_screen: expected exactly one argument (screen id)\n' >&2
+    return 1
+  fi
+
+  local id="$1"
+  ctterm_agent_wait_for_text "${id}"
+}
+
+ctterm_agent_screenshot() {
+  # Captures a screenshot (ANSI stripped). If a path is passed, writes to that
+  # file; otherwise prints to stdout.
+  #
+  # Example: ctterm_agent_screenshot                 # prints to stdout
+  #          ctterm_agent_screenshot tmp/snap.txt   # writes to file
+
+  if [[ $# -gt 1 ]]; then
+    printf 'ctterm_agent_screenshot: expected zero or one argument (output path)\n' >&2
+    return 1
+  fi
+
+  local out_path="${1:-}"
+  if [[ -z "${out_path}" ]]; then
+    # shellcheck disable=SC2048,SC2086
+    agent-tui $(_ctterm_agent_session_args) screenshot --strip-ansi
+  else
+    # shellcheck disable=SC2048,SC2086
+    agent-tui $(_ctterm_agent_session_args) screenshot --strip-ansi > "${out_path}"
+  fi
+}
+
+#
+# Higher-level helpers for common flows. These can be used directly when
+# sourcing this file, and are also wrapped by standalone scripts.
+#
+
+ctterm_agent_new_game_default() {
+  # From Main Menu, start a new game with auto-assigned slots and wait until
+  # the in-game shell (100006) is visible.
+  #
+  # Steps:
+  # - Wait for Main Menu (100001)
+  # - Press N to open Game Setup
+  # - Wait for Game Setup (100002)
+  # - Press A to auto-assign nations/leaders
+  # - Press S to Start Game
+  # - Wait for "Generating World"
+  # - Wait until "Generating World" is gone
+  # - Wait for In-game shell (100006)
+
+  ctterm_agent_wait_for_screen 100001
+  ctterm_agent_press N
+  ctterm_agent_wait_for_screen 100002
+  ctterm_agent_press A
+  ctterm_agent_press S
+  ctterm_agent_wait_for_text "Generating World"
+  ctterm_agent_wait_until_gone "Generating World"
+  ctterm_agent_wait_for_screen 100006
+}
+
+ctterm_agent_quit_to_main_menu() {
+  # From in-game shell, open Pause/Options and exit to Main Menu via the
+  # confirmation dialog.
+  #
+  # Steps:
+  # - Assert In-game shell (100006)
+  # - Press Escape to open Pause/Options (100018)
+  # - Ensure "Exit to Main Menu" is visible
+  # - Press Enter to open confirmation
+  # - Press Y to confirm exit
+  # - Wait for Main Menu (100001)
+
+  ctterm_agent_wait_for_screen 100006
+  ctterm_agent_press Escape
+  ctterm_agent_wait_for_screen 100018
+  ctterm_agent_wait_for_text "Exit to Main Menu"
+  ctterm_agent_press Enter
+  ctterm_agent_wait_for_text "Exit to Main Menu?"
+  ctterm_agent_press Y
+  ctterm_agent_wait_for_screen 100001
+}
+
+ctterm_agent_open_development() {
+  # From in-game shell, navigate to the Development screen (100009).
+  ctterm_agent_wait_for_screen 100006
+  ctterm_agent_press D
+  ctterm_agent_wait_for_screen 100009
+}
+
+ctterm_agent_assign_all_civilians_improvement() {
+  # Best-effort helper: opens the Development screen and attempts to assign
+  # a basic build_improvement work order to each civilian unit row by:
+  # - Selecting the current unit (Enter)
+  # - Pressing 'i' (build_improvement)
+  # - Accepting the default province (Enter)
+  # - Accepting the default tile (Enter)
+  # - Moving to the next row (ArrowDown)
+  #
+  # This relies on the Development screen behaviour and hotkeys defined in
+  # SPEC/tui/screens/development.md. It does not introspect the screen; it
+  # simply walks a bounded number of rows, so it is safe even when there
+  # are fewer units.
+
+  ctterm_agent_open_development
+
+  # Try up to 16 rows, which should exceed the number of civilian stacks
+  # in typical games but keeps the loop bounded.
+  local i
+  for i in $(seq 1 16); do
+    # Select unit
+    ctterm_agent_press Enter
+
+    # Choose Build Improvement work type (idle civilians only)
+    ctterm_agent_press i
+
+    # Province selection: accept default province
+    ctterm_agent_press Enter
+
+    # Tile selection: accept default tile
+    ctterm_agent_press Enter
+
+    # Move to next unit row
+    ctterm_agent_press ArrowDown
+  done
+
+  # Return to in-game shell
+  ctterm_agent_press Escape
+  ctterm_agent_wait_for_screen 100006
+}
+
+ctterm_agent_save_game() {
+  # Placeholder for an explicit in-game save flow.
+  #
+  # As of SPEC/tui (ctterm) and current implementation, there is no
+  # dedicated "Save Game" menu item or hotkey exposed from the in-game
+  # shell or Pause/Options. Saves are produced by external tools and
+  # logic via save_service (SPEC/program/save-load.md).
+  #
+  # This helper fails fast so callers know that manual save is not yet
+  # scriptable at the TUI level. When a TUI save flow is specified and
+  # implemented, update this function to drive it via agent-tui.
+
+  printf 'ctterm_agent_save_game: in-game save is not exposed via ctterm TUI yet; no save action was performed.\n' >&2
+  return 1
+}
+
+

--- a/ctterm/scripts/agent_tui_new_game_default.sh
+++ b/ctterm/scripts/agent_tui_new_game_default.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Starts ctterm (if needed), auto-assigns default nations/leaders,
+# and waits until the in-game shell is visible.
+#
+# Usage (from repo root):
+#   ./ctterm/scripts/agent_tui_new_game_default.sh [data_dir]
+#
+# - When [data_dir] is provided, it is used as the ctterm Hive data dir.
+# - When omitted, a temporary data dir is created for this session.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${ROOT_DIR}"
+
+source "${SCRIPT_DIR}/agent_tui_ctterm_common.sh"
+
+DATA_DIR="${1:-}"
+
+if [[ -n "${DATA_DIR}" ]]; then
+  ctterm_agent_start_session "${DATA_DIR}"
+else
+  ctterm_agent_start_session
+fi
+
+# Drive the TUI: New Game -> auto-assign -> start -> in-game shell.
+ctterm_agent_new_game_default
+
+printf 'New game started. Data dir: %s\n' "${CTTERM_TEST_DATA_DIR:-<unknown>}" >&2
+

--- a/ctterm/scripts/agent_tui_quit_to_main_menu.sh
+++ b/ctterm/scripts/agent_tui_quit_to_main_menu.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# From an in-game shell session, open Pause/Options and quit to the Main Menu.
+#
+# Usage (from repo root, with an existing ctterm session already running
+# and showing the in-game shell 100006):
+#   ./ctterm/scripts/agent_tui_quit_to_main_menu.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${ROOT_DIR}"
+
+source "${SCRIPT_DIR}/agent_tui_ctterm_common.sh"
+
+ctterm_agent_quit_to_main_menu
+
+printf 'Returned to Main Menu (100001).\n' >&2
+

--- a/ctterm/scripts/agent_tui_save_game.sh
+++ b/ctterm/scripts/agent_tui_save_game.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Placeholder script for saving a game from ctterm.
+# As of the current ctterm TUI spec/implementation, there is no explicit
+# in-game "Save Game" action exposed via keyboard shortcuts or menus.
+# This script fails fast and documents that limitation.
+#
+# Usage (from repo root, with an existing session running):
+#   ./ctterm/scripts/agent_tui_save_game.sh
+#
+# Exit status:
+#   1 — save action is not available in ctterm TUI yet.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${ROOT_DIR}"
+
+source "${SCRIPT_DIR}/agent_tui_ctterm_common.sh"
+
+ctterm_agent_save_game
+

--- a/ctterm/scripts/agent_tui_screenshot.sh
+++ b/ctterm/scripts/agent_tui_screenshot.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Captures the current ctterm screen via agent-tui.
+#
+# Usage (from repo root, with an existing ctterm session running):
+#   ./ctterm/scripts/agent_tui_screenshot.sh [output_path]
+#
+# - When [output_path] is provided, the screenshot text (ANSI stripped)
+#   is written to that file.
+# - When omitted, the screenshot is printed to stdout.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${ROOT_DIR}"
+
+source "${SCRIPT_DIR}/agent_tui_ctterm_common.sh"
+
+OUT_PATH="${1:-}"
+
+if [[ -n "${OUT_PATH}" ]]; then
+  ctterm_agent_screenshot "${OUT_PATH}"
+  printf 'Screenshot written to %s\n' "${OUT_PATH}" >&2
+else
+  ctterm_agent_screenshot
+fi
+

--- a/docs/project-tools.md
+++ b/docs/project-tools.md
@@ -34,7 +34,30 @@ melos run ctterm
 **TUI automation (agent-tui)**
 
 - Automated TUI tests use [agent-tui](https://github.com/pproenca/agent-tui) per SPEC/tui/ctterm.md §5.2. From repo root, run:
-  - `./ctterm/scripts/agent_tui_builder_improvement_test.sh` — assigns a builder to build_improvement on a tile, ends turn, then asserts the tile is improved (Production screen shows improvement level or name).
+  - `./ctterm/scripts/agent_tui_new_game_default.sh [data_dir]` — starts ctterm (if needed), creates a new game via Main Menu → Game Setup, auto-assigns nations/leaders, and waits until the in-game shell (screen `100006`) is visible. When `data_dir` is omitted, a temporary ctterm data directory is created for the session.
+  - `./ctterm/scripts/agent_tui_assign_all_civilians_improvement.sh` — scenario script that assumes the in-game shell (screen `100006`) is visible, opens the Development screen (`100009` via `D`), and attempts to assign a basic `build_improvement` work order to each civilian unit row by selecting the unit, pressing `i`, and accepting the default province and tile before moving to the next row.
+  - `./ctterm/scripts/agent_tui_quit_to_main_menu.sh` — from an in-game shell session, opens Pause/Options and quits back to the Main Menu (screen `100001`) via the exit confirmation dialog.
+  - `./ctterm/scripts/agent_tui_screenshot.sh [output_path]` — captures the current ctterm screen via `agent-tui screenshot --strip-ansi`. When `output_path` is provided, writes the text snapshot there; otherwise prints to stdout.
+  - `./ctterm/scripts/agent_tui_save_game.sh` — placeholder for an explicit in-game save flow. As of the current ctterm TUI spec/implementation there is no dedicated "Save Game" hotkey or menu item; this script fails fast and documents that limitation so tests do not assume a manual save is available yet.
+
+  Example chained usage from repo root:
+
+  ```bash
+  # Start a fresh game into in-game shell (temp data dir)
+  ./ctterm/scripts/agent_tui_new_game_default.sh
+
+  # Open Development and attempt to assign work to all civilians
+  ./ctterm/scripts/agent_tui_assign_all_civilians_improvement.sh
+
+  # Capture a screenshot of the initial in-game shell
+  ./ctterm/scripts/agent_tui_screenshot.sh tmp/in_game_shell_start.txt
+
+  # (When a TUI save flow exists, this will attempt to save)
+  ./ctterm/scripts/agent_tui_save_game.sh || echo "Save not available yet"
+
+  # Quit back to Main Menu via Pause/Options
+  ./ctterm/scripts/agent_tui_quit_to_main_menu.sh
+  ```
 
 ---
 


### PR DESCRIPTION
## Summary
- Add shared `agent-tui` helper library and scenario scripts under `ctterm/scripts/` to drive ctterm (start new game, open Development, assign civilian work, quit via Pause, and capture screenshots).
- Update `SPEC/tui/ctterm.md` and `docs/project-tools.md` to document the automation contract, script locations, and example chained usage, keeping specs as source of truth.

## Test plan
- Ran `bash ./ctterm/scripts/agent_tui_new_game_default.sh` to start a new game and verified the in-game shell (screen 100006) via screenshot.
- Ran `bash ./ctterm/scripts/agent_tui_assign_all_civilians_improvement.sh` from in-game shell and confirmed it executed cleanly and returned to 100006.
- Ran `bash ./ctterm/scripts/agent_tui_screenshot.sh /tmp/ctterm_after_new_game.txt` and inspected the output.
- Ran `bash ./ctterm/scripts/agent_tui_save_game.sh` and confirmed it fails fast with the documented placeholder message.
- Ran `bash ./ctterm/scripts/agent_tui_quit_to_main_menu.sh` and verified the app returned to Main Menu (screen 100001) via screenshot.


Made with [Cursor](https://cursor.com)