### PR TITLE
Align combat spec with initiative tuning and diplomacy blocker

### DIFF
--- a/SPEC/game/combat.md
+++ b/SPEC/game/combat.md
@@ -72,15 +72,29 @@ Auto-resolved combat triggers when units move into enemy-controlled provinces. B
 
 | Parameter | Default | Notes |
 |---|---|---|
-| W_cav | 1.0 | Initiative cavalry weight — **CLARIFICATION NEEDED:** verify against Imperialism II |
-| W_medal | 0.5 | Initiative medal weight — **CLARIFICATION NEEDED:** verify against Imperialism II |
+| W_cav | 50.0 | Initiative cavalry weight; tuned to make high-cavalry forces reliably win initiative. Matches `initiativeCavalryShareWeight` in `combat_config.dart`. |
+| W_medal | 10.0 | Initiative medal weight; tuned so each general medal gives a noticeable but smaller boost than full cavalry share. Matches `initiativeGeneralMedalWeight` in `combat_config.dart`. |
 | Medal multipliers | 1.0 / 1.1 / 1.2 / 1.3 / 1.4 | Per medal level 0–4 |
 | DEF divisor | 9 | Durability scaling |
 | Recovery % | 20% (ceil) | Mutual-annihilation garrison |
-| Feeding modifiers | 1.0 / 0.75 / 0.5 | Coverage ≥ 1.0 / 0.5–1.0 / < 0.5 |
+| Feeding modifiers | 1.0 / 0.75 / 0.5 | Coverage ≥ 1.0 / 0.5–1.0 / < 0.5; implemented via morale multiplier and **adopted as the intended rule** (no open question). |
 | Terrain modifiers | Per terrain type | In ruleset config |
 | Fort modifiers | Per fort level 0–3 | In ruleset config |
 | Difficulty modifiers | Per difficulty level | In ruleset config |
+
+### Auto-resolve ratio bands and loss fractions
+
+Auto-resolve currently uses deterministic ratio bands and loss fractions to select a winner and assign casualties when resolving engagements by strength ratio:
+
+| Ratio band (attacker strength ÷ defender strength after modifiers) | Attacker morale relative to defender | Attacker loss fraction | Defender loss fraction | Outcome when both sides lose all regiments |
+|---|---|---|---|---|
+| `ratio >= 1.5` and `< 4.0` | Attacker has **lower** morale | 0.6 | 0.4 | Attacker victory is **blunted**: if all defending regiments are eliminated, result is a stalemate rather than attacker victory. |
+| `ratio >= 1.5` | Any (including higher/equal morale) | 0.15 | 1.0 | Attacker victory (defender eliminated) if both sides lose all regiments. |
+| `ratio <= 0.67` | Any | 1.0 | 0.15 | Defender victory if both sides lose all regiments. |
+| `1.0 <= ratio < 1.5` | Any | 0.3 | 0.6 | Attacker victory if both sides lose all regiments. |
+| `0.67 < ratio < 1.0` | Any | 0.5 | 0.4 | Stalemate if both sides lose all regiments. |
+
+Casualty counts are derived by applying these loss fractions to the number of deployed regiments on each side (with ceilings and clamping), and casualties are selected from the deployed regiment lists in deterministic order.
 
 ## Interactions
 
@@ -92,7 +106,5 @@ Auto-resolved combat triggers when units move into enemy-controlled provinces. B
 
 ## Open Questions
 
-1. W_cav / W_medal values — Imp2 confirms factors, no numeric weights.
-2. FPN + FPM blending — simple sum or range/melee phase weighting.
-3. Auto-resolve formula details: (a) strength ratio → winner, (b) casualties from differential + DEF/9, (c) unit-by-unit vs proportional casualties.
-4. Feeding modifier — provisional; Imp2 has no unfed penalty. Confirm mechanic and thresholds.
+1. FPN + FPM blending — **Owner decision:** For the current auto-resolve implementation we use simple `FPN + FPM` aggregation per regiment (with medal multiplier and global modifiers) as described above. If we later introduce explicit ranged/melee phases, this blending rule MAY be revisited and moved into the ruleset as a configurable weighting between phases.
+2. Auto-resolve formula future evolution — **Owner decision:** The ratio bands and loss fractions documented above are the single source of truth for the current implementation. Future changes (for example, modelling DEF/9 durability and damaged-unit health scaling explicitly) MUST update this section and corresponding tests but do not block the current implementation.

--- a/SPEC/project/outstanding-tasks.md
+++ b/SPEC/project/outstanding-tasks.md
@@ -150,6 +150,8 @@ No outstanding P0 tasks.
 
 **Gap:** `DiplomacyResolver` exists but many diplomatic actions are incomplete:
 
+**Prerequisite:** Resolve [#233](https://github.com/waigore/colonizethisv3/issues/233) so the diplomacy phase receives `diplomaticOrdersByPlayerId` (OrderEngine/turn filter must pass diplomatic orders into turn resolution); otherwise player diplomacy actions cannot be exercised.
+
 | Missing Action | Spec Reference | Status |
 |----------------|----------------|--------|
 | Join Empire (GP absorbing GP) | `diplomacy.md` | Not implemented |


### PR DESCRIPTION
## Summary
- Document the actual combat initiative weights (W_cav = 50.0, W_medal = 10.0) and spell out the deterministic auto-resolve ratio bands and loss fractions so the GDD matches the current implementation.
- Clarify that the feeding morale modifiers (1.0 / 0.75 / 0.5) are the intended design and narrow the Open Questions section to future evolution notes rather than missing decisions.
- Add an explicit prerequisite note on the P1 task "Complete Diplomacy Full Actions" in  that references #233 as a blocker until diplomatic orders flow into the diplomacy phase.

## Test plan
- [ ] Run combat-related tests to ensure no behaviour changes were introduced by spec-only edits.
- [ ] Sanity-check initiative ordering in a scenario with high-cavalry vs low-cavalry forces to confirm initiative behaviour matches the documented weights.
- [ ] Verify the diplomacy P1 task now calls out #233 as a prerequisite so planners understand the dependency.

Fixes #356
Fixes #355
Fixes #354


Made with [Cursor](https://cursor.com)