### PR TITLE
Clarify combat province ids and production labour model

### DIFF
--- a/SPEC/game/combat.md
+++ b/SPEC/game/combat.md
@@ -6,7 +6,7 @@ Auto-resolved combat triggers when units move into enemy-controlled provinces. B
 
 ## Rules
 
-**Trigger:** A unit's move ending in an enemy-owned province constitutes an attack. Only Great Powers initiate; Minor Nations and Tribes defend only.
+**Trigger:** A unit's move ending in an enemy-owned province constitutes an attack. Only Great Powers initiate; Minor Nations and Tribes defend only. Province ids used in conflict detection, battle context construction, and combat resolution follow [world-model-identity.md](world-model-identity.md): all province ids are the prefixed `regionId|localId` form, not bare local ids.
 
 **Attacker / Defender:** Attacker = faction that moved in. Defender = province owner (tie-break: lowest faction id). One defender per province; multiple attackers possible.
 
@@ -102,6 +102,7 @@ Casualty counts are derived by applying these loss fractions to the number of de
 - Siege rules: [siege-mechanics.md](siege-mechanics.md)
 - Factions / minor parity: [factions.md](factions.md)
 - Ruleset config: [ruleset-config.md](ruleset-config.md)
+- Province identity and lookup: [world-model-identity.md](world-model-identity.md) — defines the `regionId|localId` prefixed province id format used by conflict detection, BattleContext, and combat resolution.
 - Resolution pipeline: [../program/combat-resolution.md](../program/combat-resolution.md)
 
 ## Open Questions

--- a/SPEC/game/stockpiles-and-production.md
+++ b/SPEC/game/stockpiles-and-production.md
@@ -13,7 +13,7 @@ Per Imperialism II: "commodities produced in these terrain tiles move to your wa
 ### Production Flow
 1. **Extraction:** Terrain tiles in owned provinces produce resources per improvement level. Resources are transported (auto-transport) to the player's stockpile.
 2. **Riches-to-treasury:** Riches (e.g. gold) in the stockpile convert to treasury at base price and are removed from the stockpile. Phase order: Extraction → Riches-to-treasury → Production → Consumption (see [economy-models.md](../program/economy-models.md) and [turn-resolution-phases.md](../program/turn-resolution-phases.md)).
-3. **Production:** Industry consumes commodities (inputs) from stockpile and labour from the WorkerPool to produce materials. Outputs added to stockpile.
+3. **Production:** Industry consumes commodities (inputs) from stockpile and uses labour from the WorkerPool to produce materials. Outputs are added to stockpile. Labour is **not** removed from the WorkerPool by production itself; instead, each turn’s production is capped by **assigned labour** and by the worker pool’s effective labour (per [workers-and-population.md](workers-and-population.md) and [economy-models.md](../program/economy-models.md)).
 4. **Consumption:** Workers, military, and navy consume food and materials from stockpile.
 
 ### Capacity
@@ -22,7 +22,7 @@ Capacity for all commodities is infinite; no limit on the amount of each commodi
 ### Relations
 - **Player** → **Stockpile** (commodity quantities).
 - Extraction in provinces → owning player's stockpile (via transport network). Province and tile identity (owned provinces, extraction locations) follow [world-model-identity.md](world-model-identity.md) for province id format and region-scoped lookup.
-- Production: stockpile inputs (commodities) + WorkerPool labour → stockpile outputs.
+- Production: stockpile inputs (commodities) + WorkerPool labour capacity (via per-turn assignments and effective labour) → stockpile outputs; WorkerPool population is not decremented by running production.
 
 ---
 
@@ -36,9 +36,9 @@ Capacity for all commodities is infinite; no limit on the amount of each commodi
   When any phase (Extraction, Riches-to-treasury, Production, or Consumption) adjusts stockpile quantities during a turn  
   Then the System allows stockpile quantities to grow without applying any hard caps, discards, or automatic market sales, and ensures all adjustments preserve non-negative integer quantities for each commodity.
 
-- Given a player has enough input commodities and available labour in the WorkerPool to run one or more production recipes defined in [production-recipes.md](production-recipes.md)  
+- Given a player has enough input commodities and available labour capacity in the WorkerPool to run one or more production recipes defined in [production-recipes.md](production-recipes.md)  
   When the System executes the Production phase for that player  
-  Then the System consumes the required input quantities and labour from the stockpile and WorkerPool, adds the recipe outputs to the same central stockpile, and records which recipes ran so that a subsequent inspection can verify that input and output quantities satisfy each recipe’s definitions.
+  Then the System consumes the required input quantities from the stockpile, uses assigned labour (capped by effective WorkerPool labour for that turn) to limit the number of recipe runs **without decrementing the WorkerPool**, adds the recipe outputs to the same central stockpile, and records which recipes ran so that a subsequent inspection can verify that input and output quantities satisfy each recipe’s definitions.
 
 - Given a player has workers and other consumers (such as army and navy) that require food and materials as described in [workers-and-population.md](workers-and-population.md)  
   When the System executes the Consumption phase  

--- a/SPEC/program/combat-resolution.md
+++ b/SPEC/program/combat-resolution.md
@@ -6,7 +6,7 @@ Conflict detection, auto-resolve pipeline, and application of combat outcomes to
 
 ## Data Model
 
-**BattleContext:** Province id, defender side (faction id + unit ids), list of attacking sides (each: faction id + unit ids + optional general id), battle type (field / siege), province terrain and fort level snapshot.
+**BattleContext:** Province id, defender side (faction id + unit ids), list of attacking sides (each: faction id + unit ids + optional general id), battle type (field / siege), province terrain and fort level snapshot. Province ids in BattleContext and in all conflict-detection inputs (unit locations, move-order destinations) are always the **prefixed** form `regionId|localId` per [../game/world-model-identity.md](../game/world-model-identity.md); conflict detection and resolution MUST NOT use bare local province ids.
 
 **EngagementResult:** Winner side (attacker / defender / stalemate / mutual annihilation), casualty unit ids per side.
 
@@ -22,7 +22,7 @@ For each province with units from multiple factions:
 2. Determine defender and attacker sides per game/combat.md § Rules (Attacker / Defender).
 3. If ≥ 1 attacker and a defender exist, create a BattleContext.
 
-**Output:** List of BattleContexts, ordered deterministically by province id.
+**Output:** List of BattleContexts, ordered deterministically by province id (the prefixed `regionId|localId` form).
 
 ### 2. Initiative Ordering
 
@@ -89,5 +89,5 @@ Separate resolver for simulation and Monte Carlo analysis; **not** used in the m
 
 - Resolver is a pure function: same inputs (including seed) → same output.
 - No global RNG access; callers provide explicit seed when randomness is needed.
-- Province battles are independent; processing order is deterministic (province id).
+- Province battles are independent; processing order is deterministic (prefixed province id `regionId|localId`).
 - Results applied in a single pass after full chain resolution per BattleContext.


### PR DESCRIPTION
## Summary
- Cross-reference the combat GDD and combat-resolution TDD to , making it explicit that all combat province ids (conflict detection, BattleContext, ordering) use the prefixed  form.
- Confirm that the combat GDD already includes a full Acceptance criteria section and keep it as the single source of truth for combat behaviour.
- Clarify the production phase model so that labour is treated as a per-turn capacity: production consumes stockpile inputs and uses assigned/worked labour capped by effective WorkerPool labour, without decrementing the WorkerPool population.

## Test plan
- [ ] Run combat-related tests to ensure conflict-detection and resolution behaviour remains consistent with the documented province id format.
- [ ] Run economy production tests to confirm that stockpile inputs are consumed and WorkerPool remains unchanged while effective labour and assignments cap production.

Fixes #353
Fixes #352
Fixes #350


Made with [Cursor](https://cursor.com)