### PR TITLE
Clarify naval beachhead lifecycle and trade interception

### DIFF
--- a/SPEC/game/ships-and-naval.md
+++ b/SPEC/game/ships-and-naval.md
@@ -17,7 +17,7 @@ Each fleet can either **move** or perform **one mission** per turn, never both:
 - **Move:** P<->S or S<->S along topology edges; resolves in the Movement phase.
 - **Patrol:** Fleet remains in its current sea zone and attempts to **intercept hostile fleets** moving through that sea zone (including enemy patrols/blockaders).
 - **Blockade:** Fleet targets a specific enemy port in its sea zone and attempts to **intercept hostile fleets entering or leaving that port**; higher interception chance than Patrol, but no reach to other ports or zones.
-- **Beachhead:** Fleet establishes a landing site on a hostile coastal province, enabling overseas invasion on the following turn; the fleet is exposed to interception while on beachhead duty.
+- **Beachhead:** Fleet establishes a landing site on a hostile coastal province, enabling overseas invasion on the following turn; the fleet is exposed to interception while on beachhead duty. A beachhead is **valid for exactly one full turn after it is created**: during the next turn's Movement and Combat phases, land units of the same faction may invade that province from eligible adjacent tiles or sea zones; after the associated invasion is resolved (or if no invasion occurs that turn), the beachhead marker for that province expires.
 - **Defend (no mission):** Fleet stays in place and avoids actively seeking combat; it can still be attacked or drawn into combat if enemy fleets patrol/blockade the same zone.
 
 Mission choice is per fleet and stored with the fleet state; details of interception and retreat are specified below and in [naval-movement-resolution.md](../program/naval-movement-resolution.md).
@@ -145,6 +145,11 @@ Only **home fleet** ships (in the capital port sea zone) carry a faction's trans
 - Patrolling or blockading fleets in relevant sea zones can intercept **cargo** (reducing delivered quantities) and **civilian ships** (higher vulnerability than warships).
 - Escorts: warships accompanying the home fleet reduce both cargo and ship loss probabilities.
 
+For trade/transport interception:
+
+- **escortStrength** is defined as the sum of `HULL` values for all **warships** assigned as escorts to the home fleet's transport route during Extraction/Trade.
+- **cargoStrength** is defined as the sum of `HULL` values for all **merchant ships** in the home fleet that are carrying overseas cargo during Extraction/Trade.
+
 Escort protection
 
 ```
@@ -173,7 +178,7 @@ raidEfficiency = 0.3 to 0.7 depending on relative strength
 
 - Given a fleet is assigned one of the missions `Move`, `Patrol`, `Blockade`, `Beachhead`, or `Defend` for a turn and the naval movement resolver runs per [naval-movement-resolution.md](../program/naval-movement-resolution.md)  
   When the System processes that fleet’s orders  
-  Then the System either moves the fleet along valid P–S or S–S edges for `Move`, leaves it in place and evaluates interception chances for `Patrol` and `Blockade` using the base and modified probabilities in the interception table, or treats it as stationary and vulnerable for `Beachhead` and `Defend` while still allowing it to be attacked by enemy fleets in the same sea zone.
+  Then the System either moves the fleet along valid P–S or S–S edges for `Move`, leaves it in place and evaluates interception chances for `Patrol` and `Blockade` using the base and modified probabilities in the interception table, or treats it as stationary and vulnerable for `Beachhead` and `Defend` while still allowing it to be attacked by enemy fleets in the same sea zone, and for `Beachhead` additionally marks the targeted hostile coastal province with a one-turn beachhead that permits associated land invasions during the next turn before expiring.
 
 - Given two opposing fleets with known ship stats (FRP, RNG, ARM, HULL, MV) and medals occupy the same sea zone and a naval battle is triggered  
   When the System computes naval combat strength and resolves the battle  
@@ -181,4 +186,12 @@ raidEfficiency = 0.3 to 0.7 depending on relative strength
 
 - Given a Great Power’s home fleet carries overseas cargo during Extraction/Trade and hostile fleets at war with that Great Power are patrolling or blockading relevant sea zones  
   When the System resolves overseas transport and trade for that turn  
-  Then the System uses the interception probabilities and escort protection formulas in this document to determine whether cargo and civilian ships are lost, reduces delivered quantities and ship counts accordingly, and applies at most the documented maximum loss reduction from escorts.
+  Then the System uses the interception probabilities and escort protection formulas in this document (including the definitions of `escortStrength` and `cargoStrength`) to determine whether cargo and civilian ships are lost, reduces delivered quantities and ship counts accordingly, and applies at most the documented maximum loss reduction from escorts.
+
+---
+
+## Testing Approach
+
+- **Unit tests:** Cover naval strength aggregation, retreat probability, interception probability, and the trade/transport interception formulas (including use of `escortStrength` and `cargoStrength`) with deterministic inputs and expected outputs.
+- **Integration tests:** Use sim_game or focused scenarios to verify ship reveal on movement into a sea zone, mission handling (Move/Patrol/Blockade/Beachhead/Defend), one-turn beachhead lifecycle and its interaction with land invasions, and trade/transport raids during Extraction/Trade.
+- **Scenario tests:** Construct scenario data for edge cases (e.g. minimal escorts, overwhelming escorts, symmetric and asymmetric naval strength) to validate that interception and raid outcomes remain within documented clamps and respect war/peace conditions.

--- a/SPEC/program/naval-movement-resolution.md
+++ b/SPEC/program/naval-movement-resolution.md
@@ -42,9 +42,10 @@ During Extraction/Trade phase, overseas cargo on home-fleet ships may be raided.
 
 1. Only evaluated when intercepting faction is at war with home fleet owner.
 2. Compute `base` as above. Civilian-only targets may receive a `civilianTargetBonus` (e.g. ×1.25–1.5).
-3. `P_cargo_intercept = clamp(1.2 × base, 0.1, 0.9)`.
-4. `P_ship_sunk = clamp(0.4 × base, 0.02, 0.5)`.
-5. Reduce delivered quantities; remove sunk merchant ships from home fleet.
+3. Compute `escortStrength` and `cargoStrength` exactly as defined in [ships-and-naval.md](../game/ships-and-naval.md) and derive `escortFactor` from the documented `lossReduction` formula.
+4. `P_cargo_intercept = clamp(1.2 × base × (1 - escortFactor), 0.1, 0.9)`.
+5. `P_ship_sunk = clamp(0.4 × base × (1 - escortFactor), 0.02, 0.5)`.
+6. Reduce delivered quantities; remove sunk merchant ships from home fleet.
 
 **Build Ship:**
 

--- a/SPEC/program/turn-resolution-phase-details.md
+++ b/SPEC/program/turn-resolution-phase-details.md
@@ -54,7 +54,7 @@ Apply validated land MoveOrders; naval MoveOrders and mission assignments (ship 
 
 ## Naval Interception & Naval Combat
 
-(1) Resolve patrol/blockade interceptions, trade/transport raids, conflicts between hostile fleets per [naval-movement-resolution.md](naval-movement-resolution.md). (2) For contested sea zones: build BattleContextSea; resolve per [naval-combat-resolution.md](naval-combat-resolution.md); update fleet compositions and locations. (3) Beachhead fleets resolved before associated land invasions.
+(1) Resolve patrol/blockade interceptions, trade/transport raids, conflicts between hostile fleets per [naval-movement-resolution.md](naval-movement-resolution.md). (2) For contested sea zones: build BattleContextSea; resolve per [naval-combat-resolution.md](naval-combat-resolution.md); update fleet compositions and locations. (3) Beachhead fleets resolved before associated land invasions; when a fleet successfully completes a `Beachhead` mission against a hostile coastal province, the System records a **beachhead marker** for that province that lasts for exactly the next turn and is consulted by land movement/combat resolution to permit associated coastal invasions; after that turn's invasions resolve (or if no invasions occur), the marker is removed.
 
 ---
 


### PR DESCRIPTION
## Summary

- Clarifies the Ships-and-naval GDD beachhead mission to have a one-turn lifecycle, and records how beachhead markers are created/consumed in the turn-resolution phase details.
- Defines  and  for trade/transport interception and wires those definitions into the naval-movement-resolution TDD.
- Adds explicit acceptance criteria and a Testing Approach section for naval behaviour (missions, ship reveal, trade interception) in the GDD.

Fixes #337
Fixes #336

## Test plan

- Spec-only change: run existing naval movement/combat and sim_game tests to confirm no behavioural regressions.
- For future work, add unit tests that exercise the documented trade/transport interception formulas and beachhead lifecycle as described in the new Testing Approach section.

Made with [Cursor](https://cursor.com)