### PR TITLE
GDD scenario coverage: victory.md

### DIFF
--- a/SPEC/program/sim-scenarios.md
+++ b/SPEC/program/sim-scenarios.md
@@ -199,6 +199,8 @@ Assertion fields:
 
 **Research-state assertions** (SPEC/game/research-state.md): use `player` and `techUnlocked` (array of tech ids that must be true in that player’s techUnlocked map). Example: `{"turn": 1, "player": "gp1", "techUnlocked": ["gathering_1", "road_construction"]}`.
 
+**Victory assertions** (SPEC/game/victory.md): use `victoryWinner` (expected winner player id), `victoryType` (e.g. `military`), and optionally `victoryTurn` (turn number when victory was set). Verifies `Game.victory` after end-of-turn. Example: `{"turn": 1, "victoryWinner": "gp1", "victoryType": "military", "victoryTurn": 0}`.
+
 ---
 
 ## Execution Flow

--- a/SPEC/project/gdd-scenario-coverage.json
+++ b/SPEC/project/gdd-scenario-coverage.json
@@ -53,7 +53,7 @@
   "game/tech-tree-transport.md": [],
   "game/tile-map-and-generation.md": [],
   "game/turn-time-mapping.md": [],
-  "game/victory.md": [],
+  "game/victory.md": ["victory_basic.json"],
   "game/workers-and-population.md": ["workers_consumption_starvation.json", "workers_luxury_consumption.json", "workers_luxury_zero_labour.json"],
   "game/world-model.md": [],
   "game/world-model-identity.md": ["world_model_identity_prefixed_provinces.json"]

--- a/tool/sim_scenarios/lib/scenario.dart
+++ b/tool/sim_scenarios/lib/scenario.dart
@@ -252,6 +252,9 @@ class Assertion {
     this.tileImprovementLevel,
     this.generalCount,
     this.effectiveMilitaryLevel,
+    this.victoryWinner,
+    this.victoryType,
+    this.victoryTurn,
   });
 
   /// Which turn to check (null = final state)
@@ -355,6 +358,11 @@ class Assertion {
 
   /// Faction effective military level (SPEC/game/factions.md). With [player] (Minor or Tribe faction id): expected effectiveMilitaryLevel (minors get parity; tribes always 1).
   final int? effectiveMilitaryLevel;
+
+  /// Victory assertions (SPEC/game/victory.md). [victoryWinner]: expected winner player id; [victoryType]: e.g. military; [victoryTurn]: turn when victory was set.
+  final String? victoryWinner;
+  final String? victoryType;
+  final int? victoryTurn;
 }
 
 /// Type of value matching for assertions.
@@ -627,6 +635,9 @@ Assertion _parseAssertion(Map<String, dynamic> json) {
     tileImprovementLevel: json['tileImprovementLevel'] as int?,
     generalCount: json['generalCount'] as int?,
     effectiveMilitaryLevel: json['effectiveMilitaryLevel'] as int?,
+    victoryWinner: json['victoryWinner'] as String?,
+    victoryType: json['victoryType'] as String?,
+    victoryTurn: json['victoryTurn'] as int?,
   );
 }
 

--- a/tool/sim_scenarios/lib/state_verifier.dart
+++ b/tool/sim_scenarios/lib/state_verifier.dart
@@ -525,6 +525,34 @@ class StateVerifier {
       }
     }
 
+    // Victory assertions (SPEC/game/victory.md)
+    if (assertion.victoryWinner != null ||
+        assertion.victoryType != null ||
+        assertion.victoryTurn != null) {
+      final v = game.victory;
+      if (v == null) {
+        failures.add(
+          'Victory: expected victory to be set (winner=${assertion.victoryWinner}, type=${assertion.victoryType}, turn=${assertion.victoryTurn}), but Game.victory is null',
+        );
+      } else {
+        if (assertion.victoryWinner != null && v.winnerPlayerId != assertion.victoryWinner) {
+          failures.add(
+            'Victory winner: expected "${assertion.victoryWinner}", got "${v.winnerPlayerId}"',
+          );
+        }
+        if (assertion.victoryType != null && v.type.name != assertion.victoryType) {
+          failures.add(
+            'Victory type: expected "${assertion.victoryType}", got "${v.type.name}"',
+          );
+        }
+        if (assertion.victoryTurn != null && v.turnNumber != assertion.victoryTurn) {
+          failures.add(
+            'Victory turn: expected ${assertion.victoryTurn}, got ${v.turnNumber}',
+          );
+        }
+      }
+    }
+
     // Faction effective military level (SPEC/game/factions.md): Minor or Tribe [player] must have expected effectiveMilitaryLevel.
     if (assertion.player != null && assertion.effectiveMilitaryLevel != null) {
       final factionId = assertion.player!;

--- a/tool/sim_scenarios/scenarios/victory_basic.json
+++ b/tool/sim_scenarios/scenarios/victory_basic.json
@@ -1,0 +1,90 @@
+{
+  "name": "victory_basic",
+  "description": "SPEC/game/victory.md: military victory when one GP controls ≥31 OW provinces. End-of-turn phase sets Game.victory; idempotence and tie-break covered in unit tests.",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "greatPowers": ["england"],
+      "seed": 42,
+      "minorNationCount": 0
+    },
+    "oldWorld": {
+      "grid": [
+        ["sea1", "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9", "p10", "p11", "p12", "p13", "p14", "p15", "p16", "p17", "p18", "p19", "p20", "p21", "p22", "p23", "p24", "p25", "p26", "p27", "p28", "p29", "p30", "p31"]
+      ],
+      "nodes": [
+        {"id": "sea1", "regionId": "oldWorld", "type": "seaZone"},
+        {"id": "p1", "regionId": "oldWorld", "type": "province"},
+        {"id": "p2", "regionId": "oldWorld", "type": "province"},
+        {"id": "p3", "regionId": "oldWorld", "type": "province"},
+        {"id": "p4", "regionId": "oldWorld", "type": "province"},
+        {"id": "p5", "regionId": "oldWorld", "type": "province"},
+        {"id": "p6", "regionId": "oldWorld", "type": "province"},
+        {"id": "p7", "regionId": "oldWorld", "type": "province"},
+        {"id": "p8", "regionId": "oldWorld", "type": "province"},
+        {"id": "p9", "regionId": "oldWorld", "type": "province"},
+        {"id": "p10", "regionId": "oldWorld", "type": "province"},
+        {"id": "p11", "regionId": "oldWorld", "type": "province"},
+        {"id": "p12", "regionId": "oldWorld", "type": "province"},
+        {"id": "p13", "regionId": "oldWorld", "type": "province"},
+        {"id": "p14", "regionId": "oldWorld", "type": "province"},
+        {"id": "p15", "regionId": "oldWorld", "type": "province"},
+        {"id": "p16", "regionId": "oldWorld", "type": "province"},
+        {"id": "p17", "regionId": "oldWorld", "type": "province"},
+        {"id": "p18", "regionId": "oldWorld", "type": "province"},
+        {"id": "p19", "regionId": "oldWorld", "type": "province"},
+        {"id": "p20", "regionId": "oldWorld", "type": "province"},
+        {"id": "p21", "regionId": "oldWorld", "type": "province"},
+        {"id": "p22", "regionId": "oldWorld", "type": "province"},
+        {"id": "p23", "regionId": "oldWorld", "type": "province"},
+        {"id": "p24", "regionId": "oldWorld", "type": "province"},
+        {"id": "p25", "regionId": "oldWorld", "type": "province"},
+        {"id": "p26", "regionId": "oldWorld", "type": "province"},
+        {"id": "p27", "regionId": "oldWorld", "type": "province"},
+        {"id": "p28", "regionId": "oldWorld", "type": "province"},
+        {"id": "p29", "regionId": "oldWorld", "type": "province"},
+        {"id": "p30", "regionId": "oldWorld", "type": "province"},
+        {"id": "p31", "regionId": "oldWorld", "type": "province"}
+      ],
+      "edges": [
+        {"id1": "sea1", "id2": "p1"},
+        {"id1": "p1", "id2": "p2"},
+        {"id1": "p2", "id2": "p3"},
+        {"id1": "p3", "id2": "p4"},
+        {"id1": "p4", "id2": "p5"},
+        {"id1": "p5", "id2": "p6"},
+        {"id1": "p6", "id2": "p7"},
+        {"id1": "p7", "id2": "p8"},
+        {"id1": "p8", "id2": "p9"},
+        {"id1": "p9", "id2": "p10"},
+        {"id1": "p10", "id2": "p11"},
+        {"id1": "p11", "id2": "p12"},
+        {"id1": "p12", "id2": "p13"},
+        {"id1": "p13", "id2": "p14"},
+        {"id1": "p14", "id2": "p15"},
+        {"id1": "p15", "id2": "p16"},
+        {"id1": "p16", "id2": "p17"},
+        {"id1": "p17", "id2": "p18"},
+        {"id1": "p18", "id2": "p19"},
+        {"id1": "p19", "id2": "p20"},
+        {"id1": "p20", "id2": "p21"},
+        {"id1": "p21", "id2": "p22"},
+        {"id1": "p22", "id2": "p23"},
+        {"id1": "p23", "id2": "p24"},
+        {"id1": "p24", "id2": "p25"},
+        {"id1": "p25", "id2": "p26"},
+        {"id1": "p26", "id2": "p27"},
+        {"id1": "p27", "id2": "p28"},
+        {"id1": "p28", "id2": "p29"},
+        {"id1": "p29", "id2": "p30"},
+        {"id1": "p30", "id2": "p31"}
+      ]
+    }
+  },
+  "turns": [
+    { "turn": 1, "orders": [] }
+  ],
+  "assertions": [
+    { "turn": 1, "victoryWinner": "gp1", "victoryType": "military", "victoryTurn": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds sim_scenarios coverage for **SPEC/game/victory.md** (military victory, end-of-turn check).

## Changes
- **Victory assertions** in sim_scenarios: `victoryWinner`, `victoryType`, `victoryTurn` in `Assertion` and `StateVerifier`
- **Scenario** `victory_basic.json`: fromTopology with 31 OW provinces + 1 sea zone, one GP; one turn with no orders; end-of-turn sets military victory for gp1; assertions verify `Game.victory`
- **SPEC/program/sim-scenarios.md**: document victory assertions
- **SPEC/project/gdd-scenario-coverage.json**: map `game/victory.md` to `victory_basic.json`

## Verification
- `dart run sim_scenarios`: all scenarios pass (including victory_basic)
- `dart run check_gdd_coverage`: victory.md now covered (24 covered, 14 uncovered)

Made with [Cursor](https://cursor.com)