### PR TITLE
fix: spec and docs for #334, #330, #332

### DIFF
--- a/SPEC/program/military-strength.md
+++ b/SPEC/program/military-strength.md
@@ -1,6 +1,6 @@
 # Military Strength Aggregation
 
-**SPEC/program** — API for computing a faction's total military strength for display (e.g. Game Overview tab in ctdev). Uses the same formula as the auto-resolve combat simulator. Reference: [combat-resolution.md](combat-resolution.md), [military-units.md](../game/military-units.md), [combat_resolver.dart](../../packages/colonizethis_logic/lib/src/combat_resolver.dart). This API uses **faction id** for ownership only and does **not** use province id (no province lookup); for identity rules see [world-model-identity.md](../game/world-model-identity.md).
+**SPEC/program** — API for computing a faction's total military strength for display (e.g. Game Overview tab in ctdev). Uses the same formula as the auto-resolve combat simulator. Reference: [combat-resolution.md](combat-resolution.md), [military-units.md](../game/military-units.md). Implementation: colonizethis_logic (combat resolver, `aggregateMilitaryStrengthForPlayer`). This API uses **faction id** for ownership only and does **not** use province id (no province lookup); for identity rules see [world-model-identity.md](../game/world-model-identity.md).
 
 ---
 

--- a/SPEC/program/sim-game.md
+++ b/SPEC/program/sim-game.md
@@ -47,6 +47,18 @@ After each resolved turn: turn number, calendar year (if [turn-time-mapping.md](
 
 ---
 
+## Acceptance criteria
+
+- Given the same initial `Game` and `baseSeed`, when sim_game runs in any mode, then the sequence of game states is identical (determinism).
+- Given any simulation mode (player-by-player, turn-by-turn, fast-forward 10), when the user triggers resolution, then the system calls `resolveTurnForGame` with combined per-player orders for the full phase sequence including Combat.
+- Given player-by-player mode, when the user advances, then the system generates orders for one GP at a time and resolves the turn only after all GPs have orders.
+- Given turn-by-turn mode, when the user advances, then the system generates all GP orders and resolves one full turn.
+- Given fast-forward 10 mode, when the user triggers it, then the system runs 10 full turns and shows an aggregated summary.
+- Given a resolved turn, when the system updates output, then it includes turn number, calendar year (if turn-time-mapping in use), combat events (province, attacker, defender, casualties, flips), and optional metrics (province counts, stockpile deltas).
+- Entry from ctdev Running Game screen; depends on [game-setup-pipeline.md](game-setup-pipeline.md) for init and [order-engine.md](order-engine.md) for validation as stated in Integration.
+
+---
+
 ## Integration
 
 - Entry: ctdev Running Game screen (see [ctdev-app-running-game.md](ctdev-app-running-game.md))

--- a/docs/project-tools.md
+++ b/docs/project-tools.md
@@ -147,6 +147,33 @@ melos run generate_map -- --interactive
 
 ---
 
+## sim_economy
+
+Standalone Phase 2 economy simulation (extraction, riches, production, consumption) over N turns. No map, movement, combat, or trade. Spec: [SPEC/program/sim-economy.md](../SPEC/program/sim-economy.md).
+
+**Invocation**
+
+```bash
+melos run sim_economy -- [--script <path>] [--turns <N>] [--seed <int>] [--output <path>] [--json-output <path>]
+```
+
+**Options**
+
+- `--script <path>` — JSON script with initial state and per-turn instructions (optional)
+- `--turns <N>` — Turns to simulate (when no script)
+- `--seed <int>` — RNG seed for reproducibility (optional)
+- `--output <path>` — Markdown report path (default: sim_economy.md in cwd)
+- `--json-output <path>` — Per-turn JSON log path (optional)
+
+**Examples**
+
+```bash
+melos run sim_economy -- --turns 10 --seed 42
+melos run sim_economy -- --script tmp/economy_script.json --output report.md
+```
+
+---
+
 ## sim_combat
 
 Probabilistic combat simulation on scripted scenarios. Up to 5 rounds per engagement, clamped hit odds, strength-weighted casualties. Outputs detailed per-round formula and probability stats. Spec: [SPEC/program/sim-combat.md](../SPEC/program/sim-combat.md).


### PR DESCRIPTION
## Summary
Addresses three bug-labeled issues with spec and documentation changes.

### #334 — Military strength spec: reference only SPEC docs
- **SPEC/program/military-strength.md**: Removed direct file path to `combat_resolver.dart` from the Reference line (SPEC is source of truth; implementation path is brittle).
- Kept references to [combat-resolution.md](combat-resolution.md) and [military-units.md](../game/military-units.md).
- Added short implementation hint: `colonizethis_logic (combat resolver, aggregateMilitaryStrengthForPlayer)` without full path.

### #330 — Sim game spec: add acceptance criteria
- **SPEC/program/sim-game.md**: Added an **Acceptance criteria** section with testable conditions:
  - Determinism (same initial Game and baseSeed → same state sequence).
  - All modes call `resolveTurnForGame` with combined per-player orders.
  - Player-by-player, turn-by-turn, and fast-forward 10 behaviour.
  - Output includes turn number, calendar year, combat events, optional metrics.
  - Entry and dependencies (ctdev Running Game, game-setup-pipeline, order-engine).

### #332 — Sim economy: clarify melos script and project-tools docs
- **docs/project-tools.md**: Added a **sim_economy** section so all sim CLI tools (sim_economy, sim_combat, sim_combat_montecarlo, sim_scenarios) are discoverable in one place.
- Documented invocation (`melos run sim_economy`), options (script, turns, seed, output, json-output), and examples.
- Root `pubspec.yaml` already defines the `sim_economy` melos script; this PR only adds the missing project-tools documentation.

Closes #334, #330, #332.

Made with [Cursor](https://cursor.com)