### PR TITLE
fix: spec docs for #331, #328, #335 (item 4)

### DIFF
--- a/SPEC/game/ships-and-naval.md
+++ b/SPEC/game/ships-and-naval.md
@@ -38,6 +38,8 @@ Tech unlocks per [tech-tree-naval.md](tech-tree-naval.md). Cargo holds determine
 
 When a fleet **enters** a sea zone (move order), all **coastal land tiles** of provinces adjacent to that sea zone are set to **revealed** for that player. This enables Explorer deployment to New World (at least one coastal tile must be revealed first). Reference: I2 03-units-civilian — "first terrain tile is uncovered when a ship enters a sea zone adjacent to the New World."
 
+Province identity for visibility updates must use **full** province id (`regionId|localId`) and **region-scoped** lookup (only provinces in the destination sea zone's region); see [world-model-identity.md](world-model-identity.md).
+
 ---
 
 ## Home Fleet

--- a/SPEC/program/naval-movement-resolution.md
+++ b/SPEC/program/naval-movement-resolution.md
@@ -20,7 +20,7 @@ Resolves fleet movement orders, triggers ship-reveal for coastal provinces, and 
 
 **Ship Reveal:**
 
-On fleet entering sea zone S: for each province P with a P↔S edge, set coastal tiles of P to `revealed` for fleet owner. Updates visibility state per [fog-and-exploration-resolution.md](fog-and-exploration-resolution.md).
+On fleet entering sea zone S: for each province P with a P↔S edge (within the **destination sea zone's region** only), set coastal tiles of P to `revealed` for fleet owner. Province identity for which tiles to reveal must use full province id (`regionId|localId`) and region-scoped lookup per [world-model-identity.md](../game/world-model-identity.md). Updates visibility state per [fog-and-exploration-resolution.md](fog-and-exploration-resolution.md).
 
 **Interception Checks:**
 

--- a/SPEC/program/sim-combat.md
+++ b/SPEC/program/sim-combat.md
@@ -38,7 +38,9 @@ Each battle object (required keys: `id`, `attacker`, `defender`, `province`; mis
 - `attacker`: `{ "units": [ { "type": string, "medals": int } ], "generalMedals": int (optional) }`.
 - `defender`: same structure. `type` must match regiment ids from [military-units.md](../game/military-units.md).
 - `province`: `{ "fortLevel": 0|1|2|3, "terrain": string }` (terrain from config: e.g. plains, mountain, forest).
-- `defenderFaction`: optional; `"greatPower" | "minorNation" | "tribe"` for parity rules.
+- `defenderFaction`: optional; `"greatPower" | "minorNation" | "tribe"` (accepted for script format parity; see below).
+
+**Defender effective level:** The sim_combat tool uses a **fixed defender effective military level** (4) for all battles. The script field `defenderFaction` is accepted for script format parity (e.g. with [sim-combat-montecarlo.md](sim-combat-montecarlo.md) and battle script reuse) but does not change the effective level in this tool; in-game parity rules for minor/tribe are defined in [factions.md](../game/factions.md).
 
 ---
 

--- a/SPEC/program/sim-scenarios.md
+++ b/SPEC/program/sim-scenarios.md
@@ -25,7 +25,9 @@ Run composite integration tests that verify game systems work correctly together
 |------|-------------|
 | **Single scenario** | Run one scenario file (`--scenario=path.json`) |
 | **Batch** | Run all JSON files in directory (`--directory=scenarios/`) |
-| **Generate** | Run scenario and output current state as assertions (`--generate-assertions`) |
+| **Generate** | Run scenario and output current state as assertions (`--generate-assertions`); **not yet implemented** (see below) |
+
+**Generate mode (`--generate-assertions`):** The CLI accepts the flag but this mode is **not yet implemented**. The tool does not currently serialize the current game state to assertion JSON. When implemented, it will run the scenario (or a subset of turns) and output the resulting state in the assertion format for use as a scaffold in scenario authoring.
 
 ---
 


### PR DESCRIPTION
## Summary
Addresses three bug-labeled issues with spec/documentation changes.

### #331 — Sim combat: document defenderFaction as script-parity only
- **SPEC/program/sim-combat.md**: Added **Defender effective level** paragraph stating that sim_combat uses a **fixed defender effective military level** (4) for all battles. The script field `defenderFaction` is accepted for script format parity (e.g. with sim-combat-montecarlo and battle script reuse) but does not change the effective level in this tool. Cross-reference to [factions.md](../game/factions.md) for in-game parity rules.
- Aligns sim-combat.md with the existing wording in sim-combat-montecarlo.md.

### #328 — Sim scenarios: document --generate-assertions as not yet implemented
- **SPEC/program/sim-scenarios.md**: In Supported Modes table, marked **Generate** mode as "**not yet implemented** (see below)". Added a short paragraph stating that the CLI accepts `--generate-assertions` but the mode is not yet implemented; when implemented, it will run the scenario and output state as assertion JSON for scenario authoring.
- Resolves the spec/code mismatch without removing the CLI flag.

### #335 (item 4 only) — Naval specs: add world-model-identity cross-ref
- **SPEC/game/ships-and-naval.md** § Ship Reveal Mechanic: Added sentence that province identity for visibility updates must use **full** province id (`regionId|localId`) and **region-scoped** lookup, with cross-reference to [world-model-identity.md](../game/world-model-identity.md).
- **SPEC/program/naval-movement-resolution.md** § Ship Reveal: Clarified that provinces are considered only within the **destination sea zone's region**; added cross-reference to world-model-identity.md for full province id and region-scoped lookup.

Note: #335 acceptance criteria 1–3 (region-scoped `provinceIdsAdjacentToSeaZone`, fleet `regionId` update on move, `regionIdForSeaZone` no default) require code changes in naval.dart and turn_resolver.dart and are **not** included in this PR.

Closes #331, #328. Partially addresses #335 (spec cross-refs only).

Made with [Cursor](https://cursor.com)