### PR TITLE
fix(#863): L key and Load Game row always navigate to Load Game screen

### DIFF
--- a/ctterm/lib/screens/main_menu_screen.dart
+++ b/ctterm/lib/screens/main_menu_screen.dart
@@ -8,7 +8,7 @@ import 'package:ctterm/save_service.dart';
 
 final log_pkg.Logger _log = log_pkg.Logger();
 
-/// Main menu: New Game, Load Game (enabled only when saves exist), Settings, Quit.
+/// Main menu: New Game, Load Game (L always navigates; list empty when no saves), Settings, Quit.
 class MainMenuScreen extends StatefulComponent {
   const MainMenuScreen({
     super.key,
@@ -76,7 +76,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
           component.onNewGame();
           return true;
         }
-        if (c == 'l' && _loadGameEnabled) {
+        if (c == 'l') {
           component.onLoadGame();
           return true;
         }
@@ -97,7 +97,7 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
             Text('ColonizeThis', style: TextStyle(fontWeight: FontWeight.bold)),
             const SizedBox(height: 2),
             _menuRow('N', 'New Game', true, component.onNewGame),
-            _menuRow('L', 'Load Game', _loadGameEnabled, component.onLoadGame),
+            _menuRow('L', 'Load Game', true, component.onLoadGame),
             if (!_savesChecked)
               Padding(
                 padding: const EdgeInsets.only(left: 4),


### PR DESCRIPTION
## Summary
Fixes #863: Load Game key (L) and menu row now always navigate to the Load Game screen. When no saves exist, that screen shows "No saved games" and [B] Back per SPEC/tui/screens/load-game.md empty state.

## Changes
- **main_menu_screen.dart**: L key triggers `onLoadGame()` regardless of `_loadGameEnabled` so the user can reach the Load Game screen and see the empty state.
- Load Game menu row is always tappable (enabled) so the [L] hint is not misleading when there are no saves.
- Doc comment updated to reflect that L always navigates and the list is empty when no saves.

Made with [Cursor](https://cursor.com)