### PR TITLE
fix(#868,#867): Escape from in-game panels; clear Units error on selection change

### DIFF
--- a/ctterm/lib/screens/shell_screen.dart
+++ b/ctterm/lib/screens/shell_screen.dart
@@ -123,8 +123,7 @@ class _ShellScreenState extends State<ShellScreen> {
     return KeyboardListener(
       onKeyEvent: (LogicalKey key) {
         if (key == LogicalKey.escape) {
-          // Let in-game routes handle their own escape (pause menu, etc.)
-          // Only handle escape at shell level for routes outside game flow
+          // Routes outside game flow: Esc -> main menu
           if (component.route == CttermRoute.mainMenu ||
               component.route == CttermRoute.gameSetup ||
               component.route == CttermRoute.loadGame ||
@@ -134,7 +133,21 @@ class _ShellScreenState extends State<ShellScreen> {
             component.onNavigate(CttermRoute.mainMenu);
             return true;
           }
-          // For in-game routes, let them handle escape themselves
+          // In-game panels: Esc -> back to in-game shell (so Escape works even if panel does not receive key)
+          if (component.route == CttermRoute.mapContext ||
+              component.route == CttermRoute.units ||
+              component.route == CttermRoute.development ||
+              component.route == CttermRoute.production ||
+              component.route == CttermRoute.academy ||
+              component.route == CttermRoute.shipyard ||
+              component.route == CttermRoute.diplomacy ||
+              component.route == CttermRoute.technology ||
+              component.route == CttermRoute.victoryProgress ||
+              component.route == CttermRoute.pauseOptions) {
+            _log.d('tui:nav: Esc -> in-game shell');
+            component.onNavigate(CttermRoute.inGameShell);
+            return true;
+          }
           return false;
         }
         return false;

--- a/ctterm/lib/screens/units_screen.dart
+++ b/ctterm/lib/screens/units_screen.dart
@@ -176,13 +176,19 @@ class _UnitsScreenState extends State<UnitsScreen> {
       return false;
     }
 
-    // Navigation: arrow keys / j/k to navigate unit list
+    // Navigation: arrow keys / j/k to navigate unit list (clear non-blocking error when selection changes)
     if (key == LogicalKey.arrowUp || c == 'k') {
-      setState(() => _selectedIndex = (_selectedIndex - 1).clamp(0, units.length - 1));
+      setState(() {
+        _selectedIndex = (_selectedIndex - 1).clamp(0, units.length - 1);
+        _feedbackMessage = '';
+      });
       return true;
     }
     if (key == LogicalKey.arrowDown || c == 'j') {
-      setState(() => _selectedIndex = (_selectedIndex + 1).clamp(0, units.length - 1));
+      setState(() {
+        _selectedIndex = (_selectedIndex + 1).clamp(0, units.length - 1);
+        _feedbackMessage = '';
+      });
       return true;
     }
 


### PR DESCRIPTION
## Summary
- **#868:** Escape key now navigates back from Technology (and other in-game panels) to the in-game shell. The shell handles Escape for all in-game panel routes so it works even when the panel's key handler does not receive the event.
- **#867:** Units screen clears the "Selected unit cannot attack" (and other non-blocking) error message when the user changes selection with arrow keys or j/k, per SPEC/tui/screens/units.md.

## #866 (V key → Victory/Progress)
Verified: `in_game_shell_screen.dart` correctly maps `c == 'v'` to `CttermRoute.victoryProgress` (and `c == 't'` to Technology). No code change made; if the bug persists it may be environment- or terminal-specific.

Made with [Cursor](https://cursor.com)