### PR TITLE
fix(#322,#318,#317): spec acceptance criteria and extraction phase table

### DIFF
--- a/SPEC/game/world-model-identity.md
+++ b/SPEC/game/world-model-identity.md
@@ -59,3 +59,12 @@ Logic must never locate a province by province id alone. Use (regionId, province
 - Given any game logic that is asked to resolve a province identifier and provided with a string that does not contain a `|` prefix separator or a pair of `(regionId, provinceId)` values that match a known province  
   When the System attempts to perform the lookup  
   Then the System treats the request as a logic error and does not fall back to a default region, does not guess a region by name pattern, and does not silently resolve the identifier to a different region’s province.
+
+
+---
+
+## Implementation (TDD)
+
+**Modules:** colonizethis_models (Game, WorldState, Province, Unit, Player, ProvinceId); colonizethis_logic province_lookup (getProvince, tryGetProvince, resolveToFullProvinceId). Map and province identity in program layer: [map-data.md](../program/map-data.md).
+
+**Contract:** New code must not look up province by bare local id when region is unknown. Use prefixed id (\`regionId|localId\`) or an explicit (regionId, localId) pair. Resolution is region-scoped only within the given region.

--- a/SPEC/program/extraction-pipeline.md
+++ b/SPEC/program/extraction-pipeline.md
@@ -53,11 +53,22 @@ Computes per-player resource extraction each turn by resolving tile connectivity
 
 | Aspect | Detail |
 |---|---|
-| Phase | Extraction (after Build/Work, before Production) |
+| Phase | Extraction runs **after Orders and Diplomacy, before Riches to treasury and Production** per [turn-resolution-phases.md](turn-resolution-phases.md). |
 | Upstream | World state, connectivity resolver, prospected state (fog module) |
 | Downstream | Player stockpiles, overseas transport ([auto-transport.md](auto-transport.md)) |
 
 Read-only with respect to terrain: extraction consumes improvement/road/port state produced by setup and development resolution; it does not mutate terrain.
+
+---
+
+## Acceptance criteria
+
+- **Phase order:** Extraction runs in the position defined in [turn-resolution-phases.md](turn-resolution-phases.md) (after Orders and Diplomacy, before Riches to treasury and Production).
+- **Connectivity:** Recomputed every turn; no caching across turns. Input: world state, topology, tile maps; output: per-player connected tile set and path transport cap.
+- **Province lookup:** Town development cap lookup is **region-scoped**: resolve province only within the tile's region ([world-model-identity.md](../game/world-model-identity.md)). Do not search regions in sequence.
+- **Mineral gating:** Mineral resources only from tiles in the player's prospected set (fog-and-exploration). Non-minerals do not require prospecting.
+- **Land vs overseas:** Same-region totals added to stockpile; overseas totals allocated by priority, cargo cap (stub), then to stockpile.
+- **Logging:** Extraction and connectivity resolution log per [ctdev-logging.md](ctdev-logging.md) (e.g. `logic: extraction compute start/end`, `logic: connectivity resolve start/end`).
 
 ---
 


### PR DESCRIPTION
## Summary
- **#322:** Add Implementation (TDD) subsection to world-model-identity.md (modules, contract, cross-ref to map-data.md).
- **#318:** Add Acceptance criteria section to extraction-pipeline.md (phase order, connectivity, province lookup, mineral gating, land vs overseas, logging).
- **#317:** Fix extraction Integration phase table: Extraction runs after Orders and Diplomacy, before Riches to treasury and Production per turn-resolution-phases.md.

Closes #322, Closes #318, Closes #317.

Made with [Cursor](https://cursor.com)