### PR TITLE
fix(#321): province lookup by full disambiguated id, region-scoped

### DIFF
--- a/SPEC/game/world-model-identity.md
+++ b/SPEC/game/world-model-identity.md
@@ -34,9 +34,11 @@ When turning topology/tile maps into view models (ownership fill, per-player map
 
 ## Lookup Rule
 
-Logic must never locate a province by province id alone. Use (regionId, provinceId) or a prefixed full id, and resolve the province only within that region. Do **not** infer region by searching regions in sequence or by string heuristics. If a province cannot be found, treat it as a logic error; do not fall back to a default region.
+Province lookup **MUST** be by **full disambiguated id** (`regionId|localId`). Resolution is **region-scoped**: the system resolves the province only within the region indicated by that id. Logic must never locate a province by bare local id when the region is unknown. Do **not** infer region by searching regions in sequence or by string heuristics. If a province cannot be found in the given region, treat it as a logic error; do not fall back to another region.
 
-**API:** `getProvince` and `tryGetProvince` accept prefixed ids; legacy short (unprefixed) ids are resolved by searching oldWorld then newWorld. When the same local id exists in both regions, first match (oldWorld) wins. New code should use prefixed id only.
+**API (required):** `getProvince` and `tryGetProvince` accept a full, prefixed province id and resolve **only within that region**. `getProvinceByRegion` and `tryGetProvinceByRegion` accept explicit `(regionId, localId)` for region-scoped lookup. New code must use full id or the region-scoped API only.
+
+**Legacy (deprecated):** `resolveToFullProvinceId` may accept short (unprefixed) ids by searching oldWorld then newWorld; that behavior is not region-scoped and is deprecated. New code must not depend on it—always pass a prefixed id or explicit `(regionId, localId)`.
 
 ---
 
@@ -67,6 +69,6 @@ Logic must never locate a province by province id alone. Use (regionId, province
 
 ## Implementation (TDD)
 
-**Modules:** colonizethis_models (Game, WorldState, Province, Unit, Player, ProvinceId); colonizethis_logic province_lookup (getProvince, tryGetProvince, resolveToFullProvinceId). Map and province identity in program layer: [map-data.md](../program/map-data.md).
+**Modules:** colonizethis_models (Game, WorldState, Province, Unit, Player, ProvinceId); colonizethis_logic province_lookup (getProvince, tryGetProvince, getProvinceByRegion, tryGetProvinceByRegion, resolveToFullProvinceId). Map and province identity in program layer: [map-data.md](../program/map-data.md).
 
-**Contract:** New code must not look up province by bare local id when region is unknown. Use prefixed id (\`regionId|localId\`) or an explicit (regionId, localId) pair. Resolution is region-scoped only within the given region.
+**Contract:** Lookup is by full disambiguated id or explicit (regionId, localId). New code must not look up province by bare local id when region is unknown. Use prefixed id (`regionId|localId`) or `getProvinceByRegion`/`tryGetProvinceByRegion`. Resolution is region-scoped: the implementation resolves only within the given region and does not search other regions.

--- a/packages/colonizethis_logic/lib/src/world/province_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/world/province_lookup.dart
@@ -2,16 +2,16 @@ import 'package:colonizethis_models/colonizethis_models.dart' show Province, Pro
 
 import '../constants.dart';
 
-/// Central province lookup. In a multi-region world, province must be located
-/// using regionId + provinceId (or a prefixed full id). SPEC/game/world-model.
+/// Central province lookup. Lookup is by **full disambiguated id** (`regionId|localId`)
+/// and is **region-scoped**: resolution happens only within the given region.
+/// SPEC/game/world-model-identity.md.
 ///
-/// Use [getProvince] when the province is required; it throws [StateError] if
-/// not found. Do not fall back to oldWorld/newWorld.
+/// Prefer [getProvince]/[tryGetProvince] with a prefixed id or [getProvinceByRegion]/[tryGetProvinceByRegion]
+/// with explicit (regionId, localId). Do not rely on short-id resolution for new code.
 
 /// Resolves [provinceId] to full form (regionId|localId). If already prefixed, returns as-is.
-/// Legacy: accepts short (unprefixed) id and resolves by searching oldWorld then newWorld; when
-/// the same local id exists in both regions, first match (oldWorld) wins. New code should use
-/// prefixed id only. SPEC/game/world-model-identity.md.
+/// **Legacy (deprecated):** Accepts short (unprefixed) id by searching oldWorld then newWorld;
+/// that is not region-scoped. New code must use prefixed id only. SPEC/game/world-model-identity.md.
 String resolveToFullProvinceId(WorldState world, String provinceId) {
   if (ProvinceId.isPrefixed(provinceId)) return provinceId;
   final r = _resolveShort(world, provinceId);
@@ -35,40 +35,50 @@ String? _resolveShort(WorldState world, String provinceId) {
   return null;
 }
 
-/// Returns the province for [fullProvinceId] (prefixed regionId|localId or legacy short id).
-/// Throws [StateError] if the id cannot be resolved or the province is not found.
-Province getProvince(WorldState world, String fullProvinceId) {
-  final resolved = resolveToFullProvinceId(world, fullProvinceId);
-  final regionId = ProvinceId.regionIdFrom(resolved);
-  final localId = ProvinceId.localIdFrom(resolved);
+/// Region-scoped lookup: returns the province in [regionId] with local id [localId]. Looks only in that region.
+/// Throws [StateError] if the region is unknown or the province is not found.
+Province getProvinceByRegion(WorldState world, String regionId, String localId) {
   final region = regionId == kRegionOldWorld
       ? world.oldWorld
       : (regionId == kRegionNewWorld ? world.newWorld : null);
   if (region == null) {
-    throw StateError('Unknown region "$regionId" for province "$fullProvinceId"');
+    throw StateError('Unknown region "$regionId" for province $regionId|$localId');
   }
+  final fullId = ProvinceId.full(regionId, localId);
   final idx = region.provinces.indexWhere((p) =>
-      p.id == resolved || (p.regionId == regionId && p.id == localId));
+      p.id == fullId || (p.regionId == regionId && (p.id == localId || ProvinceId.localIdFrom(p.id) == localId)));
   if (idx < 0) {
-    throw StateError('Province not found: "$fullProvinceId" in region "$regionId"');
+    throw StateError('Province not found: $regionId|$localId in region "$regionId"');
   }
   return region.provinces[idx];
 }
 
-/// Optional lookup. Returns null if province is not found. Accepts prefixed or legacy short id.
+/// Optional region-scoped lookup: province in [regionId] with local id [localId], or null.
+Province? tryGetProvinceByRegion(WorldState world, String regionId, String localId) {
+  final region = regionId == kRegionOldWorld
+      ? world.oldWorld
+      : (regionId == kRegionNewWorld ? world.newWorld : null);
+  if (region == null) return null;
+  final fullId = ProvinceId.full(regionId, localId);
+  final idx = region.provinces.indexWhere((p) =>
+      p.id == fullId || (p.regionId == regionId && (p.id == localId || ProvinceId.localIdFrom(p.id) == localId)));
+  if (idx < 0) return null;
+  return region.provinces[idx];
+}
+
+/// Returns the province for [fullProvinceId]. Use full disambiguated id (regionId|localId); resolution is
+/// region-scoped within the region implied by the id. Legacy: accepts short id via [resolveToFullProvinceId].
+/// Throws [StateError] if the id cannot be resolved or the province is not found.
+Province getProvince(WorldState world, String fullProvinceId) {
+  final resolved = resolveToFullProvinceId(world, fullProvinceId);
+  return getProvinceByRegion(world, ProvinceId.regionIdFrom(resolved), ProvinceId.localIdFrom(resolved));
+}
+
+/// Optional lookup by full id. Prefer prefixed id; resolution is region-scoped. Legacy: accepts short id.
 Province? tryGetProvince(WorldState world, String fullProvinceId) {
   final resolved = ProvinceId.isPrefixed(fullProvinceId)
       ? fullProvinceId
       : _resolveShort(world, fullProvinceId);
   if (resolved == null) return null;
-  final regionId = ProvinceId.regionIdFrom(resolved);
-  final localId = ProvinceId.localIdFrom(resolved);
-  final region = regionId == kRegionOldWorld
-      ? world.oldWorld
-      : (regionId == kRegionNewWorld ? world.newWorld : null);
-  if (region == null) return null;
-  final idx = region.provinces.indexWhere((p) =>
-      p.id == resolved || (p.regionId == regionId && p.id == localId));
-  if (idx < 0) return null;
-  return region.provinces[idx];
+  return tryGetProvinceByRegion(world, ProvinceId.regionIdFrom(resolved), ProvinceId.localIdFrom(resolved));
 }

--- a/packages/colonizethis_logic/test/province_lookup_test.dart
+++ b/packages/colonizethis_logic/test/province_lookup_test.dart
@@ -90,4 +90,25 @@ void main() {
       expect(tryGetProvince(world, 'p1')!.displayName, 'Alpha');
     });
   });
+
+  group('getProvinceByRegion / tryGetProvinceByRegion (region-scoped)', () {
+    test('getProvinceByRegion finds province only in given region', () {
+      expect(getProvinceByRegion(world, 'oldWorld', 'p1').displayName, 'Alpha');
+      expect(getProvinceByRegion(world, 'newWorld', 'n1').displayName, 'Gamma');
+    });
+    test('getProvinceByRegion throws for wrong region', () {
+      expect(
+        () => getProvinceByRegion(world, 'newWorld', 'p1'),
+        throwsStateError,
+      );
+    });
+    test('tryGetProvinceByRegion returns null for missing in region', () {
+      expect(tryGetProvinceByRegion(world, 'oldWorld', 'missing'), isNull);
+      expect(tryGetProvinceByRegion(world, 'unknownRegion', 'p1'), isNull);
+    });
+    test('getProvince(fullId) delegates to region-scoped lookup', () {
+      expect(getProvince(world, 'oldWorld|p1').displayName, 'Alpha');
+      expect(getProvince(world, 'newWorld|n1').displayName, 'Gamma');
+    });
+  });
 }


### PR DESCRIPTION
Addresses #321: province lookup must be by full disambiguated id and region-scoped; spec and implementation aligned.

**Spec (world-model-identity.md)**
- Lookup rule: MUST use full disambiguated id (`regionId|localId`); resolution is region-scoped (only within the region implied by the id).
- API: `getProvince`/`tryGetProvince` accept full prefixed id; `getProvinceByRegion`/`tryGetProvinceByRegion` accept explicit `(regionId, localId)`.
- Legacy short-id resolution in `resolveToFullProvinceId` documented as deprecated (not region-scoped).

**Implementation (province_lookup.dart)**
- `getProvinceByRegion(world, regionId, localId)` and `tryGetProvinceByRegion(world, regionId, localId)`: region-scoped only.
- `getProvince`/`tryGetProvince` by full id delegate to the region-scoped API, so resolution never searches outside the given region.
- Legacy short-id support kept for backward compatibility but documented as deprecated.

**Tests**
- New tests for region-scoped API and that `getProvince(fullId)` delegates to it.

Made with [Cursor](https://cursor.com)