### PR TITLE
fix(#323): require prefixed province id only for lookup

### DIFF
--- a/SPEC/game/world-model-identity.md
+++ b/SPEC/game/world-model-identity.md
@@ -36,9 +36,7 @@ When turning topology/tile maps into view models (ownership fill, per-player map
 
 Province lookup **MUST** be by **full disambiguated id** (`regionId|localId`). Resolution is **region-scoped**: the system resolves the province only within the region indicated by that id. Logic must never locate a province by bare local id when the region is unknown. Do **not** infer region by searching regions in sequence or by string heuristics. If a province cannot be found in the given region, treat it as a logic error; do not fall back to another region.
 
-**API (required):** `getProvince` and `tryGetProvince` accept a full, prefixed province id and resolve **only within that region**. `getProvinceByRegion` and `tryGetProvinceByRegion` accept explicit `(regionId, localId)` for region-scoped lookup. New code must use full id or the region-scoped API only.
-
-**Legacy (deprecated):** `resolveToFullProvinceId` may accept short (unprefixed) ids by searching oldWorld then newWorld; that behavior is not region-scoped and is deprecated. New code must not depend on it—always pass a prefixed id or explicit `(regionId, localId)`.
+**API (required):** `getProvince` and `tryGetProvince` **require** a full, prefixed province id and resolve only within that region. Non-prefixed ids are invalid: `getProvince` throws; `tryGetProvince` returns null. There is no legacy short-id resolution—do not search regions by bare local id. `getProvinceByRegion` and `tryGetProvinceByRegion` accept explicit `(regionId, localId)` for region-scoped lookup. `resolveToFullProvinceId` accepts only prefixed ids and returns the id as-is; non-prefixed id throws.
 
 ---
 
@@ -71,4 +69,4 @@ Province lookup **MUST** be by **full disambiguated id** (`regionId|localId`). R
 
 **Modules:** colonizethis_models (Game, WorldState, Province, Unit, Player, ProvinceId); colonizethis_logic province_lookup (getProvince, tryGetProvince, getProvinceByRegion, tryGetProvinceByRegion, resolveToFullProvinceId). Map and province identity in program layer: [map-data.md](../program/map-data.md).
 
-**Contract:** Lookup is by full disambiguated id or explicit (regionId, localId). New code must not look up province by bare local id when region is unknown. Use prefixed id (`regionId|localId`) or `getProvinceByRegion`/`tryGetProvinceByRegion`. Resolution is region-scoped: the implementation resolves only within the given region and does not search other regions.
+**Contract:** Lookup requires full disambiguated id or explicit (regionId, localId). No short-id resolution: `getProvince`, `tryGetProvince`, and `resolveToFullProvinceId` accept only prefixed ids (non-prefixed: getProvince/resolveToFullProvinceId throw, tryGetProvince returns null). Use prefixed id (`regionId|localId`) or `getProvinceByRegion`/`tryGetProvinceByRegion`. Resolution is region-scoped within the given region; the implementation does not search other regions.

--- a/packages/colonizethis_logic/lib/src/world/province_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/world/province_lookup.dart
@@ -6,33 +6,16 @@ import '../constants.dart';
 /// and is **region-scoped**: resolution happens only within the given region.
 /// SPEC/game/world-model-identity.md.
 ///
-/// Prefer [getProvince]/[tryGetProvince] with a prefixed id or [getProvinceByRegion]/[tryGetProvinceByRegion]
-/// with explicit (regionId, localId). Do not rely on short-id resolution for new code.
+/// [getProvince], [tryGetProvince], and [resolveToFullProvinceId] **require** prefixed id only;
+/// non-prefixed ids are invalid (no short-id resolution). Use [getProvinceByRegion]/[tryGetProvinceByRegion]
+/// for explicit (regionId, localId) lookup.
 
-/// Resolves [provinceId] to full form (regionId|localId). If already prefixed, returns as-is.
-/// **Legacy (deprecated):** Accepts short (unprefixed) id by searching oldWorld then newWorld;
-/// that is not region-scoped. New code must use prefixed id only. SPEC/game/world-model-identity.md.
+/// Returns [provinceId] unchanged if it is prefixed (regionId|localId). Throws if not prefixed.
+/// No short-id resolution; SPEC/game/world-model-identity.md.
 String resolveToFullProvinceId(WorldState world, String provinceId) {
   if (ProvinceId.isPrefixed(provinceId)) return provinceId;
-  final r = _resolveShort(world, provinceId);
-  if (r == null) throw StateError('Province not found: $provinceId');
-  return r;
-}
-
-String? _resolveShort(WorldState world, String provinceId) {
-  for (final p in world.oldWorld.provinces) {
-    final localId = ProvinceId.isPrefixed(p.id) ? ProvinceId.localIdFrom(p.id) : p.id;
-    if (p.id == provinceId || localId == provinceId) {
-      return ProvinceId.full(kRegionOldWorld, localId);
-    }
-  }
-  for (final p in world.newWorld.provinces) {
-    final localId = ProvinceId.isPrefixed(p.id) ? ProvinceId.localIdFrom(p.id) : p.id;
-    if (p.id == provinceId || localId == provinceId) {
-      return ProvinceId.full(kRegionNewWorld, localId);
-    }
-  }
-  return null;
+  throw StateError(
+      'Province id must be prefixed (regionId|localId); short id not allowed: $provinceId');
 }
 
 /// Region-scoped lookup: returns the province in [regionId] with local id [localId]. Looks only in that region.
@@ -66,19 +49,16 @@ Province? tryGetProvinceByRegion(WorldState world, String regionId, String local
   return region.provinces[idx];
 }
 
-/// Returns the province for [fullProvinceId]. Use full disambiguated id (regionId|localId); resolution is
-/// region-scoped within the region implied by the id. Legacy: accepts short id via [resolveToFullProvinceId].
-/// Throws [StateError] if the id cannot be resolved or the province is not found.
+/// Returns the province for [fullProvinceId]. Requires full disambiguated id (regionId|localId);
+/// resolution is region-scoped. Throws [StateError] if id is not prefixed or province is not found.
 Province getProvince(WorldState world, String fullProvinceId) {
   final resolved = resolveToFullProvinceId(world, fullProvinceId);
   return getProvinceByRegion(world, ProvinceId.regionIdFrom(resolved), ProvinceId.localIdFrom(resolved));
 }
 
-/// Optional lookup by full id. Prefer prefixed id; resolution is region-scoped. Legacy: accepts short id.
+/// Optional lookup by full id. Requires prefixed id; non-prefixed returns null. Region-scoped.
 Province? tryGetProvince(WorldState world, String fullProvinceId) {
-  final resolved = ProvinceId.isPrefixed(fullProvinceId)
-      ? fullProvinceId
-      : _resolveShort(world, fullProvinceId);
-  if (resolved == null) return null;
-  return tryGetProvinceByRegion(world, ProvinceId.regionIdFrom(resolved), ProvinceId.localIdFrom(resolved));
+  if (!ProvinceId.isPrefixed(fullProvinceId)) return null;
+  return tryGetProvinceByRegion(
+      world, ProvinceId.regionIdFrom(fullProvinceId), ProvinceId.localIdFrom(fullProvinceId));
 }

--- a/packages/colonizethis_logic/test/ai_planner_test.dart
+++ b/packages/colonizethis_logic/test/ai_planner_test.dart
@@ -61,15 +61,15 @@ void main() {
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
           oldWorld: RegionData(
             provinces: const [
-              Province(id: 'P1', regionId: 'oldWorld', ownerId: 'gp1'),
-              Province(id: 'P2', regionId: 'oldWorld', ownerId: 'gp2'),
+              Province(id: 'oldWorld|P1', regionId: 'oldWorld', ownerId: 'gp1'),
+              Province(id: 'oldWorld|P2', regionId: 'oldWorld', ownerId: 'gp2'),
             ],
             units: const [
               Unit(
                 id: 'u1',
                 type: 'grenadiers',
                 ownerId: 'gp1',
-                provinceId: 'P1',
+                provinceId: 'oldWorld|P1',
               ),
             ],
           ),
@@ -97,15 +97,15 @@ void main() {
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
           oldWorld: RegionData(
             provinces: const [
-              Province(id: 'P1', regionId: 'oldWorld', ownerId: 'gp1'),
-              Province(id: 'P2', regionId: 'oldWorld', ownerId: 'minor1'),
+              Province(id: 'oldWorld|P1', regionId: 'oldWorld', ownerId: 'gp1'),
+              Province(id: 'oldWorld|P2', regionId: 'oldWorld', ownerId: 'minor1'),
             ],
             units: const [
               Unit(
                 id: 'u1',
                 type: 'grenadiers',
                 ownerId: 'gp1',
-                provinceId: 'P1',
+                provinceId: 'oldWorld|P1',
               ),
             ],
           ),
@@ -131,7 +131,7 @@ void main() {
       final moves = orders.moveOrdersByPlayerId['gp1'] ?? const [];
       // AI should not emit attacks against Minor1 because there is no war relation.
       expect(
-        moves.where((m) => m.destinationProvinceId == 'P2'),
+        moves.where((m) => m.destinationProvinceId == 'oldWorld|P2'),
         isEmpty,
       );
     });
@@ -151,7 +151,7 @@ void main() {
         worldState: WorldState(
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
           oldWorld: RegionData(provinces: const [
-            Province(id: 'P1', regionId: 'oldWorld', ownerId: 'gp1'),
+            Province(id: 'oldWorld|P1', regionId: 'oldWorld', ownerId: 'gp1'),
           ]),
           newWorld: const RegionData(),
         ),
@@ -170,10 +170,10 @@ void main() {
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
           oldWorld: RegionData(
             provinces: const [
-              Province(id: 'P1', regionId: 'oldWorld', ownerId: 'gp1'),
+              Province(id: 'oldWorld|P1', regionId: 'oldWorld', ownerId: 'gp1'),
             ],
             units: const [
-              Unit(id: 'u1', type: 'grenadiers', ownerId: 'gp1', provinceId: 'P1'),
+              Unit(id: 'u1', type: 'grenadiers', ownerId: 'gp1', provinceId: 'oldWorld|P1'),
             ],
           ),
           newWorld: const RegionData(),
@@ -227,10 +227,10 @@ void main() {
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
           oldWorld: RegionData(
             provinces: const [
-              Province(id: 'P1', regionId: 'oldWorld', ownerId: 'gp1'),
+              Province(id: 'oldWorld|P1', regionId: 'oldWorld', ownerId: 'gp1'),
             ],
             units: const [
-              Unit(id: 'u1', type: 'grenadiers', ownerId: 'gp1', provinceId: 'P1'),
+              Unit(id: 'u1', type: 'grenadiers', ownerId: 'gp1', provinceId: 'oldWorld|P1'),
             ],
           ),
           newWorld: const RegionData(),

--- a/packages/colonizethis_logic/test/order_engine_test.dart
+++ b/packages/colonizethis_logic/test/order_engine_test.dart
@@ -8,7 +8,7 @@ void main() {
     test('add order and validate', () {
       final engine = OrderEngine();
       final result = engine.addMoveOrder(
-          'p1', const MoveOrder(unitId: 'u1', destinationProvinceId: 'P2'));
+          'p1', const MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|P2'));
       expect(result.status, OrderValidationStatus.accepted);
       expect(engine.orders.moveOrdersByPlayerId['p1']?.length, 1);
     });
@@ -16,9 +16,9 @@ void main() {
     test('removeMoveOrder removes order at index', () {
       final engine = OrderEngine();
       engine.addMoveOrder(
-          'p1', const MoveOrder(unitId: 'u1', destinationProvinceId: 'P2'));
+          'p1', const MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|P2'));
       engine.addMoveOrder(
-          'p1', const MoveOrder(unitId: 'u2', destinationProvinceId: 'P3'));
+          'p1', const MoveOrder(unitId: 'u2', destinationProvinceId: 'oldWorld|P3'));
       expect(engine.orders.moveOrdersByPlayerId['p1']!.length, 2);
       engine.removeMoveOrder('p1', 0);
       expect(engine.orders.moveOrdersByPlayerId['p1']!.length, 1);

--- a/packages/colonizethis_logic/test/order_projections_test.dart
+++ b/packages/colonizethis_logic/test/order_projections_test.dart
@@ -75,7 +75,7 @@ void main() {
       final orders = Orders(
         moveOrdersByPlayerId: {
           'p1': const [
-            MoveOrder(unitId: 'u1', destinationProvinceId: 'P2'),
+            MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|P2'),
           ],
         },
       );

--- a/packages/colonizethis_logic/test/province_lookup_test.dart
+++ b/packages/colonizethis_logic/test/province_lookup_test.dart
@@ -35,8 +35,12 @@ void main() {
       expect(tryGetProvince(world, 'unknownRegion|p1'), isNull);
     });
 
-    test('returns null for empty id', () {
+    test('returns null for empty id (non-prefixed)', () {
       expect(tryGetProvince(world, ''), isNull);
+    });
+
+    test('returns null for short id (prefixed required)', () {
+      expect(tryGetProvince(world, 'p1'), isNull);
     });
   });
 
@@ -53,9 +57,11 @@ void main() {
       );
     });
 
-    test('resolves short id (legacy) by searching oldWorld first', () {
-      final p = getProvince(world, 'p1');
-      expect(p.displayName, 'Alpha');
+    test('throws StateError for short id (prefixed required)', () {
+      expect(
+        () => getProvince(world, 'p1'),
+        throwsStateError,
+      );
     });
   });
 
@@ -65,29 +71,11 @@ void main() {
       expect(resolveToFullProvinceId(world, 'newWorld|n1'), 'newWorld|n1');
     });
 
-    test('resolves short id to full (oldWorld first)', () {
-      expect(resolveToFullProvinceId(world, 'p1'), 'oldWorld|p1');
-    });
-
-    test('when same local id in both regions, short id resolves to first match (oldWorld)', () {
-      final worldBoth = WorldState(
-        turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-        oldWorld: RegionData(provinces: [
-          Province(id: 'oldWorld|p1', regionId: 'oldWorld', displayName: 'OW p1'),
-        ]),
-        newWorld: RegionData(provinces: [
-          Province(id: 'newWorld|p1', regionId: 'newWorld', displayName: 'NW p1'),
-        ]),
+    test('throws StateError for short id (no short-id resolution)', () {
+      expect(
+        () => resolveToFullProvinceId(world, 'p1'),
+        throwsStateError,
       );
-      expect(resolveToFullProvinceId(worldBoth, 'p1'), 'oldWorld|p1');
-      expect(tryGetProvince(worldBoth, 'p1')!.displayName, 'OW p1');
-    });
-  });
-
-  group('tryGetProvince short id', () {
-    test('resolves short id (legacy)', () {
-      expect(tryGetProvince(world, 'p1'), isNotNull);
-      expect(tryGetProvince(world, 'p1')!.displayName, 'Alpha');
     });
   });
 

--- a/packages/colonizethis_logic/test/sim_game_ai_test.dart
+++ b/packages/colonizethis_logic/test/sim_game_ai_test.dart
@@ -24,22 +24,22 @@ void main() {
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
           oldWorld: RegionData(
             provinces: const [
-              Province(id: 'P1', regionId: 'oldWorld', ownerId: 'p1'),
-              Province(id: 'P2', regionId: 'oldWorld', ownerId: 'p2'),
-              Province(id: 'P3', regionId: 'oldWorld', ownerId: 'p3'),
+              Province(id: 'oldWorld|P1', regionId: 'oldWorld', ownerId: 'p1'),
+              Province(id: 'oldWorld|P2', regionId: 'oldWorld', ownerId: 'p2'),
+              Province(id: 'oldWorld|P3', regionId: 'oldWorld', ownerId: 'p3'),
             ],
             units: const [
               Unit(
                 id: 'u1',
                 type: 'grenadiers',
                 ownerId: 'p1',
-                provinceId: 'P1',
+                provinceId: 'oldWorld|P1',
               ),
               Unit(
                 id: 'u2',
                 type: 'grenadiers',
                 ownerId: 'p1',
-                provinceId: 'P2',
+                provinceId: 'oldWorld|P2',
               ),
             ],
           ),
@@ -100,15 +100,15 @@ void main() {
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
           oldWorld: RegionData(
             provinces: const [
-              Province(id: 'P1', regionId: 'oldWorld', ownerId: 'p1'),
-              Province(id: 'P2', regionId: 'oldWorld', ownerId: 'p2'),
+              Province(id: 'oldWorld|P1', regionId: 'oldWorld', ownerId: 'p1'),
+              Province(id: 'oldWorld|P2', regionId: 'oldWorld', ownerId: 'p2'),
             ],
             units: const [
               Unit(
                 id: 'u1',
                 type: 'grenadiers',
                 ownerId: 'p1',
-                provinceId: 'P1',
+                provinceId: 'oldWorld|P1',
               ),
             ],
           ),

--- a/packages/colonizethis_logic/test/simple_ai_heuristics_test.dart
+++ b/packages/colonizethis_logic/test/simple_ai_heuristics_test.dart
@@ -104,15 +104,15 @@ void main() {
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
           oldWorld: RegionData(
             provinces: const [
-              Province(id: 'P1', regionId: 'oldWorld', ownerId: 'gp1'),
-              Province(id: 'P2', regionId: 'oldWorld', ownerId: 'gp2'),
+              Province(id: 'oldWorld|P1', regionId: 'oldWorld', ownerId: 'gp1'),
+              Province(id: 'oldWorld|P2', regionId: 'oldWorld', ownerId: 'gp2'),
             ],
             units: const [
               Unit(
                 id: 'u1',
                 type: 'grenadiers',
                 ownerId: 'gp1',
-                provinceId: 'P1',
+                provinceId: 'oldWorld|P1',
               ),
             ],
           ),
@@ -297,7 +297,7 @@ void main() {
             id: 'gp1',
             displayName: 'AI',
             isHuman: false,
-            capitalProvinceId: 'P1',
+            capitalProvinceId: 'oldWorld|P1',
             capitalTile: CapitalTile(regionId: ow, provinceId: 'P1', x: 0, y: 0),
           ),
         ],


### PR DESCRIPTION
Implements owner decision on #323: **require prefixed ids only**; no legacy short-id resolution.

## Spec (SPEC/game/world-model-identity.md)
- Lookup **requires** full disambiguated id (`regionId|localId`). Non-prefixed ids are invalid.
- `getProvince` / `tryGetProvince` / `resolveToFullProvinceId` accept only prefixed ids.
- Removed legacy/deprecated short-id resolution wording; contract states non-prefixed: getProvince/resolveToFullProvinceId throw, tryGetProvince returns null.

## Implementation (province_lookup.dart)
- `resolveToFullProvinceId`: returns id as-is if prefixed; **throws** `StateError` if not prefixed (no search).
- `getProvince`: unchanged (delegates to resolve then getProvinceByRegion; throws for non-prefixed via resolve).
- `tryGetProvince`: returns **null** for non-prefixed id; no short-id fallback.
- Removed `_resolveShort` (oldWorld-then-newWorld search).

## Tests
- province_lookup_test: short id causes throw (getProvince, resolveToFullProvinceId) or null (tryGetProvince); removed legacy short-id resolution tests.
- order_projections_test, order_engine_test, ai_planner_test, sim_game_ai_test, simple_ai_heuristics_test: use prefixed province ids in game state (Unit.provinceId, Province.id, MoveOrder.destinationProvinceId, Player.capitalProvinceId) so resolution paths receive valid ids.

Closes #323.

Made with [Cursor](https://cursor.com)