### PR TITLE
fix(#311): build_fort validate Mine Engineering / Modern Forts

### DIFF
--- a/packages/colonizethis_data/lib/src/tech_extraction.dart
+++ b/packages/colonizethis_data/lib/src/tech_extraction.dart
@@ -12,6 +12,7 @@ const List<String> techIds = [
   'gathering_1',
   'gathering_2',
   'gathering_3',
+  'mine_engineering',
   'organised_regiments',
   'improved_iron_weapons',
   'improved_infantry_tactics',
@@ -86,6 +87,13 @@ const Map<String, TechDefinition> techCatalog = {
     cost: 160,
     prerequisiteIds: ['gathering_2'],
   ),
+  // SPEC/game/tech-tree-gathering.md. Fort level 2 prerequisite per siege-mechanics.md.
+  'mine_engineering': TechDefinition(
+    id: 'mine_engineering',
+    era: 1,
+    category: 'gathering',
+    cost: 80,
+  ),
   // Military (SPEC/game/tech-tree-military.md). Prereqs simplified for MVP.
   'organised_regiments': TechDefinition(
     id: 'organised_regiments',
@@ -138,6 +146,13 @@ const Map<String, TechDefinition> techCatalog = {
     category: 'military',
     cost: 120,
     regimentUnlockIds: ['royal_artillery'],
+  ),
+  'modern_forts': TechDefinition(
+    id: 'modern_forts',
+    era: 3,
+    category: 'military',
+    cost: 160,
+    prerequisiteIds: ['siege_engineering', 'university'],
   ),
   // Labour/economy (SPEC/game/tech-tree-labour-economy.md). University grants 4th research slot.
   'university': TechDefinition(

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -756,6 +756,20 @@ class OrderEngine {
                     'Road Construction tech required for transport level 2');
           }
         }
+        if (o.target == 'build_fort') {
+          if (fortLevel == 1 &&
+              player.techUnlocked?['mine_engineering'] != true) {
+            return const OrderValidationResult(
+                status: OrderValidationStatus.rejected,
+                reason: 'Mine Engineering tech required for fort level 2');
+          }
+          if (fortLevel == 2 &&
+              player.techUnlocked?['modern_forts'] != true) {
+            return const OrderValidationResult(
+                status: OrderValidationStatus.rejected,
+                reason: 'Modern Forts tech required for fort level 3');
+          }
+        }
         final costMap = workOrderMaterialCost(
           o.target,
           improvementLevel: improvementLevel,

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -789,6 +789,20 @@ Game applyBuildAndWorkOrders(
         if (applyStandardWorkOrder('build_port')) continue;
       }
       if (workTarget == 'build_fort') {
+        final prov = provinceById(u.locationProvinceId);
+        final fortLevel = prov?.fortLevel ?? 0;
+        if (fortLevel == 1 &&
+            player.techUnlocked?['mine_engineering'] != true) {
+          _log.d(
+              'logic: build_fort skipped - Mine Engineering required for fort level 2');
+          continue;
+        }
+        if (fortLevel == 2 &&
+            player.techUnlocked?['modern_forts'] != true) {
+          _log.d(
+              'logic: build_fort skipped - Modern Forts required for fort level 3');
+          continue;
+        }
         if (applyStandardWorkOrder('build_fort')) continue;
       }
       if (workTarget == 'build_rail') {

--- a/packages/colonizethis_logic/test/order_engine_test.dart
+++ b/packages/colonizethis_logic/test/order_engine_test.dart
@@ -1659,6 +1659,117 @@ void main() {
       });
     });
 
+    group('validateWork (build_fort tech)', () {
+      const ow = 'oldWorld';
+      const provinceId = '$ow|P1';
+      const tileKey = '$provinceId|0|0';
+
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
+        ],
+        edges: const [],
+      );
+
+      test('rejects build_fort to level 2 without Mine Engineering', () {
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [
+                Province(
+                    id: provinceId, regionId: ow, ownerId: 'p1', fortLevel: 1),
+              ],
+              units: [
+                Unit(
+                    id: 'eng1',
+                    type: 'Engineer',
+                    ownerId: 'p1',
+                    provinceId: provinceId,
+                    tileKey: tileKey),
+              ],
+            ),
+            newWorld: const RegionData(),
+            tileKeysByRegionAndProvince: {ow: {provinceId: [tileKey]}},
+            playerVisibilityByTile: const {'p1': {tileKey: 'fullyVisible'}},
+          ),
+          players: [
+            Player(
+              id: 'p1',
+              displayName: 'P1',
+              isHuman: true,
+              capitalProvinceId: provinceId,
+              stockpile: Stockpile()
+                  .applyDelta(CommodityCatalog.lumber.id, 4)
+                  .applyDelta(CommodityCatalog.bronze.id, 4),
+              techUnlocked: {},
+            ),
+          ],
+        );
+        final engine = OrderEngine();
+        engine.addWorkOrder(
+            'p1',
+            const WorkOrder(
+                unitId: 'eng1',
+                target: 'build_fort',
+                targetTileKey: tileKey));
+        final results =
+            engine.validatePlayerOrdersWithContext(game, topology, 'p1');
+        expect(results.single.status, OrderValidationStatus.rejected);
+        expect(results.single.reason, contains('Mine Engineering'));
+      });
+
+      test('rejects build_fort to level 3 without Modern Forts', () {
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [
+                Province(
+                    id: provinceId, regionId: ow, ownerId: 'p1', fortLevel: 2),
+              ],
+              units: [
+                Unit(
+                    id: 'eng1',
+                    type: 'Engineer',
+                    ownerId: 'p1',
+                    provinceId: provinceId,
+                    tileKey: tileKey),
+              ],
+            ),
+            newWorld: const RegionData(),
+            tileKeysByRegionAndProvince: {ow: {provinceId: [tileKey]}},
+            playerVisibilityByTile: const {'p1': {tileKey: 'fullyVisible'}},
+          ),
+          players: [
+            Player(
+              id: 'p1',
+              displayName: 'P1',
+              isHuman: true,
+              capitalProvinceId: provinceId,
+              stockpile: Stockpile()
+                  .applyDelta(CommodityCatalog.steel.id, 5)
+                  .applyDelta(CommodityCatalog.lumber.id, 5),
+              techUnlocked: const {'mine_engineering': true},
+            ),
+          ],
+        );
+        final engine = OrderEngine();
+        engine.addWorkOrder(
+            'p1',
+            const WorkOrder(
+                unitId: 'eng1',
+                target: 'build_fort',
+                targetTileKey: tileKey));
+        final results =
+            engine.validatePlayerOrdersWithContext(game, topology, 'p1');
+        expect(results.single.status, OrderValidationStatus.rejected);
+        expect(results.single.reason, contains('Modern Forts'));
+      });
+    });
+
     group('validateDiplomatic', () {
       final emptyTopology = MapTopology(nodes: const [], edges: const []);
 

--- a/packages/colonizethis_logic/test/orders_application_test.dart
+++ b/packages/colonizethis_logic/test/orders_application_test.dart
@@ -1734,6 +1734,98 @@ void main() {
       }
     });
 
+    test('build_fort to level 2 is skipped without Mine Engineering', () {
+      final unit = Unit(
+        id: 'u1',
+        type: 'Engineer',
+        ownerId: 'p1',
+        provinceId: provinceId,
+        tileKey: tileKey,
+      );
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(
+                  id: provinceId, regionId: ow, ownerId: 'p1', fortLevel: 1),
+            ],
+            units: [unit],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: [
+          const Player(
+            id: 'p1',
+            displayName: 'P1',
+            isHuman: true,
+            techUnlocked: {},
+          ),
+        ],
+      );
+      final orders = Orders(
+        workOrdersByPlayerId: {
+          'p1': [
+            WorkOrder(
+              unitId: 'u1',
+              target: 'build_fort',
+              targetTileKey: tileKey,
+            ),
+          ],
+        },
+      );
+      final next = applyBuildAndWorkOrders(game, orders);
+      expect(next.worldState.oldWorld.provinces.single.fortLevel, 1);
+      expect(next.worldState.oldWorld.units.single.currentWork, isNull);
+    });
+
+    test('build_fort to level 3 is skipped without Modern Forts', () {
+      final unit = Unit(
+        id: 'u1',
+        type: 'Engineer',
+        ownerId: 'p1',
+        provinceId: provinceId,
+        tileKey: tileKey,
+      );
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(
+                  id: provinceId, regionId: ow, ownerId: 'p1', fortLevel: 2),
+            ],
+            units: [unit],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: [
+          const Player(
+            id: 'p1',
+            displayName: 'P1',
+            isHuman: true,
+            techUnlocked: {'mine_engineering': true},
+          ),
+        ],
+      );
+      final orders = Orders(
+        workOrdersByPlayerId: {
+          'p1': [
+            WorkOrder(
+              unitId: 'u1',
+              target: 'build_fort',
+              targetTileKey: tileKey,
+            ),
+          ],
+        },
+      );
+      final next = applyBuildAndWorkOrders(game, orders);
+      expect(next.worldState.oldWorld.provinces.single.fortLevel, 2);
+      expect(next.worldState.oldWorld.units.single.currentWork, isNull);
+    });
+
     test('upgrade_town completion increases province townDevelopmentLevel', () {
       final unit = Unit(
         id: 'u1',


### PR DESCRIPTION
Fixes #311.

**Summary**
- **Tech catalog:** Added `mine_engineering` (gathering, era 1) and `modern_forts` (military, era 3; prereqs siege_engineering, university) to colonizethis_data so they can be researched/unlocked.
- **Order validation:** build_fort to level 2 requires Mine Engineering; build_fort to level 3 requires Modern Forts. Rejection reason strings match the pattern used for Road Construction.
- **Orders application:** When applying work orders, build_fort is skipped (and logged) if the player lacks the required tech, so behaviour is correct even if validation is bypassed.
- **Tests:** orders_application_test (skip without tech); order_engine_test (rejected for level 2 without mine_engineering, level 3 without modern_forts).

Per SPEC/game/siege-mechanics.md and SPEC/program/development-resolution.md.

Made with [Cursor](https://cursor.com)