### PR TITLE
fix(#319): enforce blockade at-war rule

### DIFF
--- a/SPEC/game/capital-and-connectivity.md
+++ b/SPEC/game/capital-and-connectivity.md
@@ -81,6 +81,8 @@ A province is **overseas** for a player if it is in a **different region** from 
 
 Blockade affects **connectivity** for extraction. It is determined by enemy fleets on **Blockade** mission targeting a specific port (see [ships-and-naval.md](ships-and-naval.md) § Missions and Movement).
 
+- **At war only:** A player may only **order** or **maintain** a blockade against a nation they are **at war** with. Submitting or validating a blockade order requires the fleet owner to be at war with the target province owner; otherwise the order is rejected. Existing blockade missions are not applied (or are cleared) when the two nations are not at war—e.g. after peace is declared.
+
 - **Blockaded port province:** A port province is **blockaded** for a player when an enemy fleet (at war with that player) is on Blockade mission and targets that province's port (the fleet's sea zone is adjacent to that port). For connectivity, a **blockaded port is not connected** to the capital: the connection between that port province and the capital is **severed**. No tiles in that province contribute to extraction for that player via that port (overseas provinces that relied on that port for sea connection are also cut off for that path).
 
 - **Capital province blockaded:** If the **capital province** itself is blockaded (an enemy fleet is blockading the capital's port), then for that player **all overseas** provinces and **all same-region provinces that are only reachable via sea** (i.e. no land path from capital) are **not** connected. In effect, the entire sea-based connectivity is severed; only tiles reachable by land (road/rail) from the capital remain connected.

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -1108,16 +1108,44 @@ class OrderEngine {
       }
       final fleet = fleetById[o.fleetId];
       final homeFleetId = 'fleet_$playerId';
-      final valid = fleet != null &&
+      var valid = fleet != null &&
           fleet.ownerId == playerId &&
           (o.mission == 'join_home_fleet' || fleet.id != homeFleetId);
+      String? rejectReason =
+          valid ? null : (fleet == null ? 'Fleet not found' : 'Fleet not owned by player');
+
+      // Blockade: only allowed against nations at war. SPEC/game/capital-and-connectivity.md § Blockade.
+      if (valid && o.mission == 'blockade') {
+        final targetProvinceId = o.targetProvinceId;
+        if (targetProvinceId == null ||
+            targetProvinceId.isEmpty ||
+            !ProvinceId.isPrefixed(targetProvinceId)) {
+          valid = false;
+          rejectReason = 'Blockade requires a target province';
+        } else {
+          final province = tryGetProvince(game.worldState, targetProvinceId);
+          final ownerId = province?.ownerId;
+          if (province == null || ownerId == null || ownerId.isEmpty) {
+            valid = false;
+            rejectReason = 'Blockade target province not found or unowned';
+          } else if (ownerId == playerId) {
+            valid = false;
+            rejectReason = 'Cannot blockade own province';
+          } else {
+            final rel = getRelation(game, playerId, ownerId);
+            if (rel?.atWar != true) {
+              valid = false;
+              rejectReason = 'Blockade only allowed against nations at war';
+            }
+          }
+        }
+      }
+
       results.add(OrderValidationResult(
         status: valid
             ? OrderValidationStatus.accepted
             : OrderValidationStatus.rejected,
-        reason: valid
-            ? null
-            : (fleet == null ? 'Fleet not found' : 'Fleet not owned by player'),
+        reason: rejectReason,
       ));
       if (!valid) rejected = true;
     }

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -708,9 +708,8 @@ Game _runMovementPhase(
 
   // Naval mission assignment. Phase 6. Apply after moves so fleet position is final.
   final missionOrders = orders.navalMissionOrdersByPlayerId;
-  if (missionOrders.isNotEmpty) {
-    state = _applyNavalMissionOrders(state, missionOrders);
-  }
+  // Always apply so we run the clearing pass for blockades when not at war.
+  state = _applyNavalMissionOrders(state, missionOrders);
 
   return state;
 }
@@ -867,6 +866,35 @@ Game _applyNavalMissionOrders(
           break;
         }
       }
+
+      // Blockade only applies when at war with the target province owner. SPEC/game/capital-and-connectivity.md § Blockade.
+      if (mission == FleetMission.blockade) {
+        final targetProvinceId = order.targetProvinceId;
+        final province = targetProvinceId != null &&
+                targetProvinceId.isNotEmpty &&
+                ProvinceId.isPrefixed(targetProvinceId)
+            ? tryGetProvince(game.worldState, targetProvinceId)
+            : null;
+        final ownerId = province?.ownerId;
+        final atWar = ownerId != null &&
+            ownerId != playerId &&
+            getRelation(game, playerId, ownerId)?.atWar == true;
+        if (!atWar) {
+          // Do not apply blockade: leave fleet mission unchanged (or clear blockade if they made peace).
+          final cleared = fleet.copyWith(
+            mission: FleetMission.none,
+            targetPortId: null,
+            targetProvinceId: null,
+          );
+          final idx = fleets.indexWhere((f) => f.id == fleet.id);
+          if (idx >= 0) {
+            fleets = List<Fleet>.from(fleets)..[idx] = cleared;
+            fleetById[fleet.id] = cleared;
+          }
+          continue;
+        }
+      }
+
       final newFleet = fleet.copyWith(
         mission: mission,
         targetPortId: order.targetPortId,
@@ -877,6 +905,29 @@ Game _applyNavalMissionOrders(
         fleets = List<Fleet>.from(fleets)..[idx] = newFleet;
         fleetById[fleet.id] = newFleet;
       }
+    }
+  }
+
+  // Clear blockade from any fleet whose owner is no longer at war with the target province owner.
+  for (var i = 0; i < fleets.length; i++) {
+    final f = fleets[i];
+    if (f.mission != FleetMission.blockade) continue;
+    final targetProvinceId = f.targetProvinceId;
+    if (targetProvinceId == null || targetProvinceId.isEmpty) continue;
+    final province = ProvinceId.isPrefixed(targetProvinceId)
+        ? tryGetProvince(game.worldState, targetProvinceId)
+        : null;
+    final ownerId = province?.ownerId;
+    final atWar = ownerId != null &&
+        ownerId != f.ownerId &&
+        getRelation(game, f.ownerId, ownerId)?.atWar == true;
+    if (!atWar) {
+      fleets = List<Fleet>.from(fleets)
+        ..[i] = f.copyWith(
+          mission: FleetMission.none,
+          targetPortId: null,
+          targetProvinceId: null,
+        );
     }
   }
 

--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -2,6 +2,8 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
 
+import 'province_lookup.dart';
+
 final Logger _log = Logger();
 
 /// Result of connectivity resolution: connected tile set and per-tile path transport cap.
@@ -26,15 +28,55 @@ class ConnectivityResult {
 /// Also computes [ConnectivityResult.pathTransportCap]: for each connected tile,
 /// the maximum over paths from capital of (min road/port level on that path).
 
+/// Blockade state: per player, the set of port province ids (full prefixed) that are blockaded.
+///
+/// A province is blockaded for its owner when an **enemy fleet at war** with that owner is on
+/// Blockade mission targeting it. **Diplomatic state:** only blockaders that are at war with the
+/// province owner count; blockading a faction you are at peace with has no effect. **Same-region**
+/// and **cross-region** blockades are both valid: the fleet's [Fleet.regionId] is where the fleet
+/// is; [targetProvinceId] may be in any region (oldWorld, newWorld, etc.). SPEC/game/capital-and-connectivity.md § Blockade.
+Map<String, Set<String>> computeBlockadedPortProvincesByPlayer(Game game) {
+  final result = <String, Set<String>>{};
+  for (final player in game.players) {
+    result[player.id] = {};
+  }
+  final fleets = game.worldState.fleets;
+  final relations = game.diplomacyRelations;
+  for (final fleet in fleets) {
+    if (fleet.mission != FleetMission.blockade) continue;
+    final targetProvinceId = fleet.targetProvinceId;
+    if (targetProvinceId == null || targetProvinceId.isEmpty) continue;
+    if (!ProvinceId.isPrefixed(targetProvinceId)) continue;
+    final province = tryGetProvince(game.worldState, targetProvinceId);
+    final ownerId = province?.ownerId;
+    if (ownerId == null) continue;
+    final blockaderId = fleet.ownerId;
+    // Only factions at war with the province owner can blockade it.
+    final atWar = relations.any((rel) =>
+        rel.atWar &&
+        rel.factionId1 != rel.factionId2 &&
+        {rel.factionId1, rel.factionId2}.contains(blockaderId) &&
+        {rel.factionId1, rel.factionId2}.contains(ownerId));
+    if (!atWar) continue;
+    result[ownerId] ??= {};
+    result[ownerId]!.add(targetProvinceId);
+  }
+  return result;
+}
+
 /// Returns per player id [ConnectivityResult] (connected set + path transport cap).
 /// Players without capital or with no tile map get an empty result.
+/// When [blockadedPortProvincesByPlayerId] is null, it is computed from [game] (fleets on Blockade mission, at war). SPEC/game/capital-and-connectivity.md § Blockade.
 Map<String, ConnectivityResult> resolveConnectivity({
   required Game game,
   required Map<String, TileMapResult> tileMapByRegion,
   required MapTopology topology,
+  Map<String, Set<String>>? blockadedPortProvincesByPlayerId,
 }) {
   _log.d('logic: connectivity resolve start players=${game.players.length} regions=${tileMapByRegion.keys.join(",")}');
   final provinceIdsByType = _provinceIdsFromTopology(topology);
+  final blockadedByPlayer =
+      blockadedPortProvincesByPlayerId ?? computeBlockadedPortProvincesByPlayer(game);
   final result = <String, ConnectivityResult>{};
 
   for (final player in game.players) {
@@ -52,6 +94,7 @@ Map<String, ConnectivityResult> resolveConnectivity({
       tileMapByRegion: tileMapByRegion,
       topology: topology,
       provinceIdsByType: provinceIdsByType,
+      blockadedPortProvinces: blockadedByPlayer[player.id] ?? const {},
     );
     result[player.id] = cr;
   }
@@ -182,6 +225,7 @@ ConnectivityResult _connectedTilesForPlayer({
   required Map<String, TileMapResult> tileMapByRegion,
   required MapTopology topology,
   required Set<String> provinceIdsByType,
+  Set<String> blockadedPortProvinces = const {},
 }) {
   final worldState = game.worldState;
   final tileState = worldState.tileState;
@@ -254,12 +298,13 @@ ConnectivityResult _connectedTilesForPlayer({
   }
 
   final seaConnectedPortKeys = <String>{};
+  final capitalProvinceBlockaded = blockadedPortProvinces.contains(capital.provinceId);
   final capitalOnSeaboard = _isCapitalTileOnSeaboard(
     capital,
     tileMapByRegion,
     provinceIdsByType,
   );
-  if (capitalOnSeaboard) {
+  if (capitalOnSeaboard && !capitalProvinceBlockaded) {
     final prefixedTopology = _topologyUsesPrefixedIds(topology);
     final provinceIdForLookup = prefixedTopology
         ? capital.provinceId
@@ -273,6 +318,7 @@ ConnectivityResult _connectedTilesForPlayer({
       final seaZoneId = parts.length >= 3 ? parts[2] : (parts.length >= 2 ? parts[1] : null);
       final fullProvinceId = parts.length >= 3 ? '${parts[0]}|${parts[1]}' : (parts.length >= 2 ? parts[0] : null);
       if (seaZoneId == null || fullProvinceId == null) continue;
+      if (blockadedPortProvinces.contains(fullProvinceId)) continue;
       final seaZoneIdForReachable = prefixedTopology && parts.length >= 3
           ? '${parts[0]}|$seaZoneId'
           : seaZoneId;
@@ -280,9 +326,20 @@ ConnectivityResult _connectedTilesForPlayer({
       if (!owned.contains(fullProvinceId)) continue;
       seaConnectedPortKeys.add(tileKey);
     }
-  } else {
-    seaConnectedPortKeys.addAll(capitalRegionPortKeys);
+  } else if (!capitalOnSeaboard) {
+    for (final portKey in capitalRegionPortKeys) {
+      final parts = portKey.split('|');
+      if (parts.length >= 2) {
+        final fullProvinceId = parts.length >= 3 ? '${parts[0]}|${parts[1]}' : parts[0];
+        if (!blockadedPortProvinces.contains(fullProvinceId)) {
+          seaConnectedPortKeys.add(portKey);
+        }
+      } else {
+        seaConnectedPortKeys.add(portKey);
+      }
+    }
   }
+  // When capital province is blockaded, seaConnectedPortKeys stays empty (no sea connectivity). SPEC § Blockade.
 
   for (final portKey in seaConnectedPortKeys) {
     if (connected.contains(portKey)) continue;
@@ -337,6 +394,22 @@ ConnectivityResult _connectedTilesForPlayer({
         connected.add(n);
         pathCap[n] = candidate;
         queue.add(n);
+      }
+    }
+  }
+
+  // SPEC § Blockade: no tiles in a blockaded port province contribute; remove any tile in such a province (except capital province: its tiles remain when it is blockaded, only sea connectivity is severed).
+  if (blockadedPortProvinces.isNotEmpty) {
+    for (final key in connected.toList()) {
+      final parts = key.split('|');
+      if (parts.length >= 2) {
+        final fullProvinceId =
+            parts.length >= 3 ? '${parts[0]}|${parts[1]}' : parts[0];
+        if (blockadedPortProvinces.contains(fullProvinceId) &&
+            fullProvinceId != capital.provinceId) {
+          connected.remove(key);
+          pathCap.remove(key);
+        }
       }
     }
   }

--- a/packages/colonizethis_logic/test/connectivity_resolver_test.dart
+++ b/packages/colonizethis_logic/test/connectivity_resolver_test.dart
@@ -385,5 +385,586 @@ void main() {
       result = resolveConnectivity(game: gameP2Restored, tileMapByRegion: tileMapByRegion, topology: topology);
       expect(result['pl1']!.connected.contains('oldWorld|p3|2|0'), true);
     });
+
+    group('blockade', () {
+      test('blockaded port province excluded from connectivity', () {
+        final oldGrid = [['p1', 'p1'], ['p1', 'p1']];
+        final newGrid = [['p2', 'p2'], ['p2', 'p2']];
+        final topology = MapTopology(
+          nodes: [
+            TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+            TopologyNode(id: 'p2', regionId: 'newWorld', type: TopologyNodeType.province),
+            TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+            TopologyNode(id: 'sea2', regionId: 'newWorld', type: TopologyNodeType.seaZone),
+          ],
+          edges: [
+            TopologyEdge(id1: 'p1', id2: 'sea1'),
+            TopologyEdge(id1: 'p2', id2: 'sea2'),
+            TopologyEdge(id1: 'sea1', id2: 'sea2'),
+          ],
+        );
+        const ow = 'oldWorld', nw = 'newWorld';
+        final cap = CapitalTile(regionId: ow, provinceId: '$ow|p1', x: 0, y: 0);
+        final tileState = TileMapState()
+            .setRoadLevel('oldWorld|p1|0|0', 4)
+            .setRoadLevel('newWorld|p2|0|0', 4);
+        final ports = {
+          '$ow|p1|sea1': 'oldWorld|p1|0|0',
+          '$nw|p2|sea2': 'newWorld|p2|0|0',
+        };
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(provinces: [Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1')]),
+            newWorld: RegionData(provinces: [Province(id: '$nw|p2', regionId: nw, ownerId: 'pl1')]),
+            tileState: tileState,
+            portsByProvinceSeaboard: ports,
+          ),
+          players: [Player(id: 'pl1', displayName: 'Spain', isHuman: true, capitalProvinceId: '$ow|p1', capitalTile: cap)],
+        );
+        final result = resolveConnectivity(
+          game: game,
+          tileMapByRegion: {
+            'oldWorld': TileMapResult(width: 2, height: 2, grid: oldGrid),
+            'newWorld': TileMapResult(width: 2, height: 2, grid: newGrid),
+          },
+          topology: topology,
+          blockadedPortProvincesByPlayerId: {'pl1': {'newWorld|p2'}},
+        );
+        final connected = result['pl1']!.connected;
+        expect(connected.contains('oldWorld|p1|0|0'), true);
+        expect(connected.contains('newWorld|p2|0|0'), false);
+      });
+
+      test('capital province blockaded: no sea connectivity', () {
+        final oldGrid = [['p1', 'p1'], ['p1', 'p1']];
+        final newGrid = [['p2', 'p2'], ['p2', 'p2']];
+        final topology = MapTopology(
+          nodes: [
+            TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+            TopologyNode(id: 'p2', regionId: 'newWorld', type: TopologyNodeType.province),
+            TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+            TopologyNode(id: 'sea2', regionId: 'newWorld', type: TopologyNodeType.seaZone),
+          ],
+          edges: [
+            TopologyEdge(id1: 'p1', id2: 'sea1'),
+            TopologyEdge(id1: 'p2', id2: 'sea2'),
+            TopologyEdge(id1: 'sea1', id2: 'sea2'),
+          ],
+        );
+        const ow = 'oldWorld', nw = 'newWorld';
+        final cap = CapitalTile(regionId: ow, provinceId: '$ow|p1', x: 0, y: 0);
+        final tileState = TileMapState()
+            .setRoadLevel('oldWorld|p1|0|0', 4)
+            .setRoadLevel('newWorld|p2|0|0', 4);
+        final ports = {
+          '$ow|p1|sea1': 'oldWorld|p1|0|0',
+          '$nw|p2|sea2': 'newWorld|p2|0|0',
+        };
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(provinces: [Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1')]),
+            newWorld: RegionData(provinces: [Province(id: '$nw|p2', regionId: nw, ownerId: 'pl1')]),
+            tileState: tileState,
+            portsByProvinceSeaboard: ports,
+          ),
+          players: [Player(id: 'pl1', displayName: 'Spain', isHuman: true, capitalProvinceId: '$ow|p1', capitalTile: cap)],
+        );
+        final result = resolveConnectivity(
+          game: game,
+          tileMapByRegion: {
+            'oldWorld': TileMapResult(width: 2, height: 2, grid: oldGrid),
+            'newWorld': TileMapResult(width: 2, height: 2, grid: newGrid),
+          },
+          topology: topology,
+          blockadedPortProvincesByPlayerId: {'pl1': {'oldWorld|p1'}},
+        );
+        final connected = result['pl1']!.connected;
+        expect(connected.contains('oldWorld|p1|0|0'), true);
+        expect(connected.contains('newWorld|p2|0|0'), false);
+      });
+
+      test('computeBlockadedPortProvincesByPlayer same-region: fleet in OW blockades OW port when at war', () {
+        const ow = 'oldWorld';
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(provinces: [
+              Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1'),
+              Province(id: '$ow|p2', regionId: ow, ownerId: 'pl1'),
+            ]),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'fleet_p2',
+                ownerId: 'p2',
+                seaZoneId: 'sea1',
+                regionId: ow,
+                mission: FleetMission.blockade,
+                targetProvinceId: '$ow|p2',
+              ),
+            ],
+          ),
+          players: [
+            Player(id: 'pl1', displayName: 'Spain', isHuman: true),
+            Player(id: 'p2', displayName: 'France', isHuman: true),
+          ],
+          diplomacyRelations: [
+            DiplomacyRelation(factionId1: 'pl1', factionId2: 'p2', state: RelationState.atWar),
+          ],
+        );
+        final blockaded = computeBlockadedPortProvincesByPlayer(game);
+        expect(blockaded['pl1'], contains('oldWorld|p2'));
+        expect(blockaded['p2'], isEmpty);
+      });
+
+      test('computeBlockadedPortProvincesByPlayer cross-region: fleet in OW blockades NW port when at war', () {
+        const ow = 'oldWorld';
+        const nw = 'newWorld';
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(provinces: [
+              Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1'),
+            ]),
+            newWorld: RegionData(provinces: [
+              Province(id: '$nw|n1', regionId: nw, ownerId: 'pl1'),
+            ]),
+            fleets: [
+              Fleet(
+                id: 'fleet_p2',
+                ownerId: 'p2',
+                seaZoneId: 'sea_ow',
+                regionId: ow,
+                mission: FleetMission.blockade,
+                targetProvinceId: '$nw|n1',
+              ),
+            ],
+          ),
+          players: [
+            Player(id: 'pl1', displayName: 'Spain', isHuman: true),
+            Player(id: 'p2', displayName: 'France', isHuman: true),
+          ],
+          diplomacyRelations: [
+            DiplomacyRelation(factionId1: 'pl1', factionId2: 'p2', state: RelationState.atWar),
+          ],
+        );
+        final blockaded = computeBlockadedPortProvincesByPlayer(game);
+        expect(blockaded['pl1'], contains('newWorld|n1'));
+        expect(blockaded['p2'], isEmpty);
+      });
+
+      test('computeBlockadedPortProvincesByPlayer cross-region: fleet in NW blockades OW port when at war', () {
+        const ow = 'oldWorld';
+        const nw = 'newWorld';
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(provinces: [
+              Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1'),
+              Province(id: '$ow|p2', regionId: ow, ownerId: 'pl1'),
+            ]),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'fleet_p2',
+                ownerId: 'p2',
+                seaZoneId: 'sea_nw',
+                regionId: nw,
+                mission: FleetMission.blockade,
+                targetProvinceId: '$ow|p2',
+              ),
+            ],
+          ),
+          players: [
+            Player(id: 'pl1', displayName: 'Spain', isHuman: true),
+            Player(id: 'p2', displayName: 'France', isHuman: true),
+          ],
+          diplomacyRelations: [
+            DiplomacyRelation(factionId1: 'pl1', factionId2: 'p2', state: RelationState.atWar),
+          ],
+        );
+        final blockaded = computeBlockadedPortProvincesByPlayer(game);
+        expect(blockaded['pl1'], contains('oldWorld|p2'));
+      });
+
+      test('computeBlockadedPortProvincesByPlayer only at-war blockader counts: peace fleet does not add province', () {
+        const ow = 'oldWorld';
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(provinces: [
+              Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1'),
+              Province(id: '$ow|p2', regionId: ow, ownerId: 'pl1'),
+            ]),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'fleet_p2',
+                ownerId: 'p2',
+                seaZoneId: 'sea1',
+                regionId: ow,
+                mission: FleetMission.blockade,
+                targetProvinceId: '$ow|p2',
+              ),
+              Fleet(
+                id: 'fleet_p3',
+                ownerId: 'p3',
+                seaZoneId: 'sea2',
+                regionId: ow,
+                mission: FleetMission.blockade,
+                targetProvinceId: '$ow|p2',
+              ),
+            ],
+          ),
+          players: [
+            Player(id: 'pl1', displayName: 'Spain', isHuman: true),
+            Player(id: 'p2', displayName: 'France', isHuman: true),
+            Player(id: 'p3', displayName: 'England', isHuman: true),
+          ],
+          diplomacyRelations: [
+            DiplomacyRelation(factionId1: 'pl1', factionId2: 'p2', state: RelationState.atWar),
+            DiplomacyRelation(factionId1: 'pl1', factionId2: 'p3', state: RelationState.atPeace),
+          ],
+        );
+        final blockaded = computeBlockadedPortProvincesByPlayer(game);
+        expect(blockaded['pl1'], contains('oldWorld|p2'));
+        expect(blockaded['pl1']!.length, 1);
+      });
+
+      test('computeBlockadedPortProvincesByPlayer returns empty when at peace', () {
+        const ow = 'oldWorld';
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(provinces: [
+              Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1'),
+              Province(id: '$ow|p2', regionId: ow, ownerId: 'pl1'),
+            ]),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'fleet_p2',
+                ownerId: 'p2',
+                seaZoneId: 'sea1',
+                regionId: ow,
+                mission: FleetMission.blockade,
+                targetProvinceId: '$ow|p2',
+              ),
+            ],
+          ),
+          players: [
+            Player(id: 'pl1', displayName: 'Spain', isHuman: true),
+            Player(id: 'p2', displayName: 'France', isHuman: true),
+          ],
+          diplomacyRelations: [
+            DiplomacyRelation(factionId1: 'pl1', factionId2: 'p2', state: RelationState.atPeace),
+          ],
+        );
+        final blockaded = computeBlockadedPortProvincesByPlayer(game);
+        expect(blockaded['pl1'], isEmpty);
+        expect(blockaded['p2'], isEmpty);
+      });
+
+      test('computeBlockadedPortProvincesByPlayer ignores fleet without targetProvinceId', () {
+        const ow = 'oldWorld';
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(provinces: [
+              Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1'),
+              Province(id: '$ow|p2', regionId: ow, ownerId: 'pl1'),
+            ]),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'fleet_p2',
+                ownerId: 'p2',
+                seaZoneId: 'sea1',
+                regionId: ow,
+                mission: FleetMission.blockade,
+                targetProvinceId: null,
+              ),
+            ],
+          ),
+          players: [
+            Player(id: 'pl1', displayName: 'Spain', isHuman: true),
+            Player(id: 'p2', displayName: 'France', isHuman: true),
+          ],
+          diplomacyRelations: [
+            DiplomacyRelation(factionId1: 'pl1', factionId2: 'p2', state: RelationState.atWar),
+          ],
+        );
+        final blockaded = computeBlockadedPortProvincesByPlayer(game);
+        expect(blockaded['pl1'], isEmpty);
+      });
+
+      test('computeBlockadedPortProvincesByPlayer ignores non-blockade missions', () {
+        const ow = 'oldWorld';
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(provinces: [
+              Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1'),
+              Province(id: '$ow|p2', regionId: ow, ownerId: 'pl1'),
+            ]),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'fleet_p2',
+                ownerId: 'p2',
+                seaZoneId: 'sea1',
+                regionId: ow,
+                mission: FleetMission.patrol,
+                targetProvinceId: '$ow|p2',
+              ),
+            ],
+          ),
+          players: [
+            Player(id: 'pl1', displayName: 'Spain', isHuman: true),
+            Player(id: 'p2', displayName: 'France', isHuman: true),
+          ],
+          diplomacyRelations: [
+            DiplomacyRelation(factionId1: 'pl1', factionId2: 'p2', state: RelationState.atWar),
+          ],
+        );
+        final blockaded = computeBlockadedPortProvincesByPlayer(game);
+        expect(blockaded['pl1'], isEmpty);
+      });
+
+      test('computeBlockadedPortProvincesByPlayer returns multiple provinces when two enemies blockade', () {
+        const ow = 'oldWorld';
+        const nw = 'newWorld';
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(provinces: [
+              Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1'),
+              Province(id: '$ow|p2', regionId: ow, ownerId: 'pl1'),
+            ]),
+            newWorld: RegionData(provinces: [
+              Province(id: '$nw|n1', regionId: nw, ownerId: 'pl1'),
+            ]),
+            fleets: [
+              Fleet(
+                id: 'fleet_p2',
+                ownerId: 'p2',
+                seaZoneId: 'sea1',
+                regionId: ow,
+                mission: FleetMission.blockade,
+                targetProvinceId: '$ow|p2',
+              ),
+              Fleet(
+                id: 'fleet_p3',
+                ownerId: 'p3',
+                seaZoneId: 'sea2',
+                regionId: nw,
+                mission: FleetMission.blockade,
+                targetProvinceId: '$nw|n1',
+              ),
+            ],
+          ),
+          players: [
+            Player(id: 'pl1', displayName: 'Spain', isHuman: true),
+            Player(id: 'p2', displayName: 'France', isHuman: true),
+            Player(id: 'p3', displayName: 'England', isHuman: true),
+          ],
+          diplomacyRelations: [
+            DiplomacyRelation(factionId1: 'pl1', factionId2: 'p2', state: RelationState.atWar),
+            DiplomacyRelation(factionId1: 'pl1', factionId2: 'p3', state: RelationState.atWar),
+          ],
+        );
+        final blockaded = computeBlockadedPortProvincesByPlayer(game);
+        expect(blockaded['pl1'], containsAll(['oldWorld|p2', 'newWorld|n1']));
+        expect(blockaded['pl1']!.length, 2);
+      });
+
+      test('resolveConnectivity uses game fleets and diplomacy when blockadedPortProvincesByPlayerId not passed', () {
+        final oldGrid = [['p1', 'p1'], ['p1', 'p1']];
+        final newGrid = [['p2', 'p2'], ['p2', 'p2']];
+        final topology = MapTopology(
+          nodes: [
+            TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+            TopologyNode(id: 'p2', regionId: 'newWorld', type: TopologyNodeType.province),
+            TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+            TopologyNode(id: 'sea2', regionId: 'newWorld', type: TopologyNodeType.seaZone),
+          ],
+          edges: [
+            TopologyEdge(id1: 'p1', id2: 'sea1'),
+            TopologyEdge(id1: 'p2', id2: 'sea2'),
+            TopologyEdge(id1: 'sea1', id2: 'sea2'),
+          ],
+        );
+        const ow = 'oldWorld', nw = 'newWorld';
+        final cap = CapitalTile(regionId: ow, provinceId: '$ow|p1', x: 0, y: 0);
+        final tileState = TileMapState()
+            .setRoadLevel('oldWorld|p1|0|0', 4)
+            .setRoadLevel('newWorld|p2|0|0', 4);
+        final ports = {
+          '$ow|p1|sea1': 'oldWorld|p1|0|0',
+          '$nw|p2|sea2': 'newWorld|p2|0|0',
+        };
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(provinces: [Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1')]),
+            newWorld: RegionData(provinces: [Province(id: '$nw|p2', regionId: nw, ownerId: 'pl1')]),
+            tileState: tileState,
+            portsByProvinceSeaboard: ports,
+            fleets: [
+              Fleet(
+                id: 'fleet_p2',
+                ownerId: 'p2',
+                seaZoneId: 'sea2',
+                regionId: nw,
+                mission: FleetMission.blockade,
+                targetProvinceId: '$nw|p2',
+              ),
+            ],
+          ),
+          players: [
+            Player(id: 'pl1', displayName: 'Spain', isHuman: true, capitalProvinceId: '$ow|p1', capitalTile: cap),
+            Player(id: 'p2', displayName: 'France', isHuman: true),
+          ],
+          diplomacyRelations: [
+            DiplomacyRelation(factionId1: 'pl1', factionId2: 'p2', state: RelationState.atWar),
+          ],
+        );
+        final result = resolveConnectivity(
+          game: game,
+          tileMapByRegion: {
+            'oldWorld': TileMapResult(width: 2, height: 2, grid: oldGrid),
+            'newWorld': TileMapResult(width: 2, height: 2, grid: newGrid),
+          },
+          topology: topology,
+        );
+        final connected = result['pl1']!.connected;
+        expect(connected.contains('oldWorld|p1|0|0'), true);
+        expect(connected.contains('newWorld|p2|0|0'), false);
+      });
+
+      test('same-region two ports: blockaded port excluded, other port and capital connected', () {
+        final grid = [
+          ['p1', 'p1', 'p2', 'p2'],
+          ['p1', 'p1', 'p2', 'p2'],
+        ];
+        final topology = MapTopology(
+          nodes: [
+            TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+            TopologyNode(id: 'p2', regionId: 'oldWorld', type: TopologyNodeType.province),
+            TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+            TopologyNode(id: 'sea2', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          ],
+          edges: [
+            TopologyEdge(id1: 'p1', id2: 'sea1'),
+            TopologyEdge(id1: 'p2', id2: 'sea2'),
+            TopologyEdge(id1: 'sea1', id2: 'sea2'),
+          ],
+        );
+        const ow = 'oldWorld';
+        final cap = CapitalTile(regionId: ow, provinceId: '$ow|p1', x: 0, y: 0);
+        final tileState = TileMapState()
+            .setRoadLevel('oldWorld|p1|0|0', 4)
+            .setRoadLevel('oldWorld|p1|1|0', 4)
+            .setRoadLevel('oldWorld|p2|2|0', 4)
+            .setRoadLevel('oldWorld|p2|3|0', 4);
+        final ports = {
+          '$ow|p1|sea1': 'oldWorld|p1|0|0',
+          '$ow|p2|sea2': 'oldWorld|p2|2|0',
+        };
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1'),
+                Province(id: '$ow|p2', regionId: ow, ownerId: 'pl1'),
+              ],
+            ),
+            newWorld: const RegionData(),
+            tileState: tileState,
+            portsByProvinceSeaboard: ports,
+          ),
+          players: [Player(id: 'pl1', displayName: 'Spain', isHuman: true, capitalProvinceId: '$ow|p1', capitalTile: cap)],
+        );
+        final result = resolveConnectivity(
+          game: game,
+          tileMapByRegion: {'oldWorld': TileMapResult(width: 4, height: 2, grid: grid)},
+          topology: topology,
+          blockadedPortProvincesByPlayerId: {'pl1': {'oldWorld|p2'}},
+        );
+        final connected = result['pl1']!.connected;
+        expect(connected.contains('oldWorld|p1|0|0'), true);
+        expect(connected.contains('oldWorld|p1|1|0'), true);
+        expect(connected.contains('oldWorld|p2|2|0'), false);
+        expect(connected.contains('oldWorld|p2|3|0'), false);
+      });
+
+      test('capital not on seaboard: land-connected port blockaded still excluded', () {
+        final grid = [
+          ['p1', 'p2'],
+          ['p1', 'p2'],
+        ];
+        final topology = MapTopology(
+          nodes: [
+            TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+            TopologyNode(id: 'p2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          ],
+          edges: [],
+        );
+        const ow = 'oldWorld';
+        final cap = CapitalTile(regionId: ow, provinceId: '$ow|p1', x: 0, y: 0);
+        final tileState = TileMapState()
+            .setRoadLevel('oldWorld|p1|0|0', 1)
+            .setRoadLevel('oldWorld|p1|1|0', 1)
+            .setRoadLevel('oldWorld|p2|1|0', 4)
+            .setRoadLevel('oldWorld|p2|1|1', 4);
+        final ports = {'$ow|p2|dummy': 'oldWorld|p2|1|0'};
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1'),
+                Province(id: '$ow|p2', regionId: ow, ownerId: 'pl1'),
+              ],
+            ),
+            newWorld: const RegionData(),
+            tileState: tileState,
+            portsByProvinceSeaboard: ports,
+          ),
+          players: [Player(id: 'pl1', displayName: 'Spain', isHuman: true, capitalProvinceId: '$ow|p1', capitalTile: cap)],
+        );
+        final resultNoBlockade = resolveConnectivity(
+          game: game,
+          tileMapByRegion: {'oldWorld': TileMapResult(width: 2, height: 2, grid: grid)},
+          topology: topology,
+        );
+        expect(resultNoBlockade['pl1']!.connected.contains('oldWorld|p2|1|0'), true);
+
+        final resultBlockade = resolveConnectivity(
+          game: game,
+          tileMapByRegion: {'oldWorld': TileMapResult(width: 2, height: 2, grid: grid)},
+          topology: topology,
+          blockadedPortProvincesByPlayerId: {'pl1': {'oldWorld|p2'}},
+        );
+        expect(resultBlockade['pl1']!.connected.contains('oldWorld|p2|1|0'), false);
+        expect(resultBlockade['pl1']!.connected.contains('oldWorld|p1|0|0'), true);
+      });
+    });
   });
 }

--- a/packages/colonizethis_logic/test/order_engine_test.dart
+++ b/packages/colonizethis_logic/test/order_engine_test.dart
@@ -900,6 +900,119 @@ void main() {
       expect(results.single.reason, contains('Fleet not found'));
     });
 
+    test('blockade order rejected when not at war with province owner', () {
+      const ow = 'oldWorld';
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(
+              id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
+        ],
+        edges: const [],
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          fleets: [
+            Fleet(
+              id: 'f1',
+              ownerId: 'p1',
+              seaZoneId: 'sea1',
+              regionId: ow,
+              shipTypeIds: const ['carrack'],
+            ),
+          ],
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+          Player(id: 'p2', displayName: 'P2', isHuman: true),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'p1',
+            factionId2: 'p2',
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      final engine = OrderEngine();
+      final result = engine.addNavalMissionOrderWithContext(
+        game,
+        topology,
+        'p1',
+        NavalMissionOrder(
+          fleetId: 'f1',
+          mission: FleetMission.blockade.name,
+          targetProvinceId: '$ow|P2',
+        ),
+      );
+      expect(result.status, OrderValidationStatus.rejected);
+      expect(result.reason, contains('at war'));
+    });
+
+    test('blockade order accepted when at war with province owner', () {
+      const ow = 'oldWorld';
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(
+              id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
+        ],
+        edges: const [],
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          fleets: [
+            Fleet(
+              id: 'f1',
+              ownerId: 'p1',
+              seaZoneId: 'sea1',
+              regionId: ow,
+              shipTypeIds: const ['carrack'],
+            ),
+          ],
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+          Player(id: 'p2', displayName: 'P2', isHuman: true),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'p1',
+            factionId2: 'p2',
+            state: RelationState.atWar,
+          ),
+        ],
+      );
+      final engine = OrderEngine();
+      final result = engine.addNavalMissionOrderWithContext(
+        game,
+        topology,
+        'p1',
+        NavalMissionOrder(
+          fleetId: 'f1',
+          mission: FleetMission.blockade.name,
+          targetProvinceId: '$ow|P2',
+        ),
+      );
+      expect(result.status, OrderValidationStatus.accepted);
+    });
+
     test('projectedEffects returns treasuryDelta when orders affect treasury',
         () {
       const ow = 'oldWorld';

--- a/packages/colonizethis_logic/test/resource_extractor_test.dart
+++ b/packages/colonizethis_logic/test/resource_extractor_test.dart
@@ -327,6 +327,88 @@ void main() {
       expect(result['pl1']!.land, isEmpty);
     });
 
+    test('blockaded overseas port: connectivity excludes tile so overseas extraction zero', () {
+      final oldGrid = [['p1', 'p1'], ['p1', 'p1']];
+      final newGrid = [['n1', 'n1'], ['n1', 'n1']];
+      final tileMapOw = TileMapResult(
+        width: 2,
+        height: 2,
+        grid: oldGrid,
+        resourceGrid: [[null, null], [null, null]],
+      );
+      final tileMapNw = TileMapResult(
+        width: 2,
+        height: 2,
+        grid: newGrid,
+        resourceGrid: [[Resource.sugarCane, Resource.sugarCane], [null, null]],
+      );
+      final topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 'n1', regionId: 'newWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(id: 'sea2', regionId: 'newWorld', type: TopologyNodeType.seaZone),
+        ],
+        edges: [
+          TopologyEdge(id1: 'p1', id2: 'sea1'),
+          TopologyEdge(id1: 'n1', id2: 'sea2'),
+          TopologyEdge(id1: 'sea1', id2: 'sea2'),
+        ],
+      );
+      const ow = 'oldWorld', nw = 'newWorld';
+      final cap = CapitalTile(regionId: ow, provinceId: '$ow|p1', x: 0, y: 0);
+      final tileState = TileMapState()
+          .setImprovement('newWorld|n1|0|0', 1)
+          .setImprovement('newWorld|n1|1|0', 1)
+          .setRoadLevel('oldWorld|p1|0|0', 4)
+          .setRoadLevel('newWorld|n1|0|0', 4)
+          .setRoadLevel('newWorld|n1|1|0', 4);
+      final ports = {
+        '$ow|p1|sea1': 'oldWorld|p1|0|0',
+        '$nw|n1|sea2': 'newWorld|n1|0|0',
+      };
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+          oldWorld: RegionData(provinces: [Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1')]),
+          newWorld: RegionData(provinces: [
+            Province(id: '$nw|n1', regionId: nw, ownerId: 'pl1', townDevelopmentLevel: 4),
+          ]),
+          tileState: tileState,
+          portsByProvinceSeaboard: ports,
+        ),
+        players: [Player(id: 'pl1', displayName: 'Spain', isHuman: true, capitalProvinceId: '$ow|p1', capitalTile: cap)],
+      );
+      final connectivityBlockaded = resolveConnectivity(
+        game: game,
+        tileMapByRegion: {'oldWorld': tileMapOw, 'newWorld': tileMapNw},
+        topology: topology,
+        blockadedPortProvincesByPlayerId: {'pl1': {'newWorld|n1'}},
+      );
+      final resultBlockaded = computeExtraction(
+        game: game,
+        tileMapByRegion: {'oldWorld': tileMapOw, 'newWorld': tileMapNw},
+        connectivityResult: connectivityBlockaded,
+        techCapForPlayer: (_) => 4,
+      );
+      expect(resultBlockaded['pl1']!.overseas, isEmpty);
+      expect(resultBlockaded['pl1']!.land, isEmpty);
+
+      final connectivityOpen = resolveConnectivity(
+        game: game,
+        tileMapByRegion: {'oldWorld': tileMapOw, 'newWorld': tileMapNw},
+        topology: topology,
+      );
+      final resultOpen = computeExtraction(
+        game: game,
+        tileMapByRegion: {'oldWorld': tileMapOw, 'newWorld': tileMapNw},
+        connectivityResult: connectivityOpen,
+        techCapForPlayer: (_) => 4,
+      );
+      expect(resultOpen['pl1']!.overseas['sugarCane'] ?? 0, greaterThan(0));
+    });
+
     test('effective yield capped by min transport level along path to capital', () {
       // SPEC: effective yield = min(production, tech cap, town dev, min transport along path).
       // When pathTransportCap is provided, it caps yield (e.g. path with road-1 segment → cap 1).

--- a/packages/colonizethis_logic/test/turn_resolver_test.dart
+++ b/packages/colonizethis_logic/test/turn_resolver_test.dart
@@ -1483,6 +1483,125 @@ void main() {
       expect(resultingFleet.shipTypeIds, containsAll(['carrack', 'fluyte']));
     });
 
+    test('blockade order not applied when not at war with province owner', () {
+      const ow = 'oldWorld';
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(
+              id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
+        ],
+        edges: const [],
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          fleets: [
+            Fleet(
+              id: 'f1',
+              ownerId: 'p1',
+              seaZoneId: 'sea1',
+              regionId: ow,
+              shipTypeIds: const ['carrack'],
+            ),
+          ],
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'A', isHuman: true),
+          Player(id: 'p2', displayName: 'B', isHuman: true),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'p1',
+            factionId2: 'p2',
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      final orders = Orders(
+        navalMissionOrdersByPlayerId: {
+          'p1': [
+            NavalMissionOrder(
+              fleetId: 'f1',
+              mission: FleetMission.blockade.name,
+              targetProvinceId: '$ow|P2',
+            ),
+          ],
+        },
+      );
+      final next = resolveTurnForGame(
+        game: game,
+        topology: topology,
+        orders: orders,
+        extractedByPlayerId: const {},
+        defaultAssignments: const [],
+      );
+      final fleet = next.worldState.fleets.singleWhere((f) => f.id == 'f1');
+      expect(fleet.mission, FleetMission.none);
+    });
+
+    test('existing blockade cleared when not at war with target owner', () {
+      const ow = 'oldWorld';
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(
+              id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
+        ],
+        edges: const [],
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          fleets: [
+            Fleet(
+              id: 'f1',
+              ownerId: 'p1',
+              seaZoneId: 'sea1',
+              regionId: ow,
+              mission: FleetMission.blockade,
+              targetProvinceId: '$ow|P2',
+              shipTypeIds: const ['carrack'],
+            ),
+          ],
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'A', isHuman: true),
+          Player(id: 'p2', displayName: 'B', isHuman: true),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'p1',
+            factionId2: 'p2',
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      final next = resolveTurnForGame(
+        game: game,
+        topology: topology,
+        orders: const Orders(),
+        extractedByPlayerId: const {},
+        defaultAssignments: const [],
+      );
+      final fleet = next.worldState.fleets.singleWhere((f) => f.id == 'f1');
+      expect(fleet.mission, FleetMission.none);
+    });
+
     test('naval interception phase runs when two at-war fleets in same zone',
         () {
       final topology = MapTopology(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -460,10 +460,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- Enforce that naval blockade missions can only be ordered when the fleet owner is at war with the target province owner, at both order-validation and turn-resolution time.
- Clear or ignore existing blockade missions when the diplomatic state is not at war, so peace automatically lifts blockades and only at-war fleets contribute to blockade connectivity.
- Extend blockade connectivity, resource extraction, order engine, and turn resolver tests plus GDD spec to cover at-war-only behavior, cross-region/same-region blockades, and peace edge cases.

## Test plan
- dart analyze (workspace root)
- dart test (packages/colonizethis_logic)
- dart test (packages/colonizethis_ai)

Made with [Cursor](https://cursor.com)