### PR TITLE
ctterm: fix shipyard layout and diplomacy declare war state

### DIFF
--- a/ctterm/lib/screens/diplomacy_screen.dart
+++ b/ctterm/lib/screens/diplomacy_screen.dart
@@ -289,6 +289,27 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
     });
   }
 
+  void _updateSelectedFactionRelationState(RelationState newState) {
+    if (_selectedFaction == null || _factions.isEmpty) {
+      return;
+    }
+    setState(() {
+      final index = _selectedIndex.clamp(0, _factions.length - 1);
+      final current = _factions[index];
+      final updated = FactionDisplayInfo(
+        id: current.id,
+        name: current.name,
+        type: current.type,
+        relationState: newState,
+        relationLevel: current.relationLevel,
+        relationScore: current.relationScore,
+        overtureStage: current.overtureStage,
+      );
+      _factions[index] = updated;
+      _selectedFaction = updated;
+    });
+  }
+
   // Get current orders for human player
   List<DiplomaticOrder> get _diplomaticOrders {
     return component.orders.diplomaticOrdersByPlayerId[_humanPlayerId] ?? [];
@@ -324,6 +345,7 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
       type: DiplomaticOrderType.declareWar,
       targetFactionId: targetId,
     ));
+    _updateSelectedFactionRelationState(RelationState.atWar);
     _setStatus('Declared war on ${_selectedFaction!.name}');
     _log.d('tui:diplomacy: declared war on $targetId');
   }

--- a/ctterm/lib/screens/shipyard_screen.dart
+++ b/ctterm/lib/screens/shipyard_screen.dart
@@ -229,43 +229,154 @@ class _ShipyardScreenState extends State<ShipyardScreen> {
             const Text(' Shipyard ', style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
             const Text('[b]uild [c]ancel [h]ome [Esc]back', style: TextStyle(color: Colors.grey)),
           ])),
-          Expanded(child: Row(children: [
-            Expanded(flex: 2, child: Container(padding: const EdgeInsets.all(1), child: Column(children: [
-              const Text('Available Ships:', style: TextStyle(color: Colors.yellow, fontWeight: FontWeight.bold)),
-              const SizedBox(height: 1),
-              Expanded(child: ListView(children: [for (var i = 0; i < ships.length; i++) _shipRow(ships[i], i == _selectedIndex)])),
-            ]))),
-            Container(width: 40, padding: const EdgeInsets.all(1), child: Column(children: [
-              const Text('Details:', style: TextStyle(color: Colors.yellow, fontWeight: FontWeight.bold)),
-              const SizedBox(height: 1),
-              if (selected != null) ...[
-                Text(selected.name, style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
-                Text('Category: ${selected.category}', style: const TextStyle(color: Colors.grey)),
-                Text('Cost: ${selected.cost}g', style: const TextStyle(color: Colors.white)),
-                const Text('Stats:', style: TextStyle(color: Colors.cyan)),
-                Text('  FRP:${selected.firepower} RNG:${selected.range}', style: const TextStyle(color: Colors.white)),
-                Text('  ARM:${selected.armour} HULL:${selected.hull}', style: const TextStyle(color: Colors.white)),
-                Text('  MV:${selected.movement}', style: const TextStyle(color: Colors.white)),
-                Text(selected.isAvailable ? '[b]uild' : 'Locked', style: TextStyle(color: selected.isAvailable ? Colors.green : Colors.red)),
-              ] else const Text('No selection', style: TextStyle(color: Colors.grey)),
-            ])),
-            Container(width: 40, padding: const EdgeInsets.all(1), child: Column(children: [
-              Text(_showHomeFleet ? 'Home Fleet:' : 'Build Queue:', style: const TextStyle(color: Colors.yellow, fontWeight: FontWeight.bold)),
-              const SizedBox(height: 1),
-              if (_showHomeFleet) ...[
-                if (homeFleet.isEmpty) const Text('No ships', style: TextStyle(color: Colors.grey))
-                else ...homeFleet.map((u) => Text(_fmtShip(u.type), style: const TextStyle(color: Colors.white))),
-                Text('Ports: ${ports.length}', style: const TextStyle(color: Colors.grey)),
-              ] else ...[
-              if (buildOrders.isEmpty) const Text('No orders', style: TextStyle(color: Colors.grey))
-              else ...buildOrders.asMap().entries.map((e) => Text(
-                    '${e.key + 1}.${e.value.shipName}>${_provinceLabel(e.value.provinceId)}',
-                    style: TextStyle(
-                        color: e.key == _selectedIndex ? Colors.green : Colors.white),
-                  )),
+          Expanded(
+            child: Row(
+              children: [
+                Expanded(
+                  flex: 3,
+                  child: Container(
+                    padding: const EdgeInsets.all(1),
+                    child: Column(
+                      children: [
+                        const Text(
+                          'Available Ships:',
+                          style: TextStyle(
+                            color: Colors.yellow,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 1),
+                        Expanded(
+                          child: ListView(
+                            children: [
+                              for (var i = 0; i < ships.length; i++)
+                                _shipRow(ships[i], i == _selectedIndex),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                Expanded(
+                  flex: 2,
+                  child: Container(
+                    padding: const EdgeInsets.all(1),
+                    child: Column(
+                      children: [
+                        const Text(
+                          'Details:',
+                          style: TextStyle(
+                            color: Colors.yellow,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 1),
+                        if (selected != null) ...[
+                          Text(
+                            selected.name,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          Text(
+                            'Category: ${selected.category}',
+                            style: const TextStyle(color: Colors.grey),
+                          ),
+                          Text(
+                            'Cost: ${selected.cost}g',
+                            style: const TextStyle(color: Colors.white),
+                          ),
+                          const Text(
+                            'Stats:',
+                            style: TextStyle(color: Colors.cyan),
+                          ),
+                          Text(
+                            '  FRP:${selected.firepower} RNG:${selected.range}',
+                            style: const TextStyle(color: Colors.white),
+                          ),
+                          Text(
+                            '  ARM:${selected.armour} HULL:${selected.hull}',
+                            style: const TextStyle(color: Colors.white),
+                          ),
+                          Text(
+                            '  MV:${selected.movement}',
+                            style: const TextStyle(color: Colors.white),
+                          ),
+                          Text(
+                            selected.isAvailable ? '[b]uild' : 'Locked',
+                            style: TextStyle(
+                              color: selected.isAvailable
+                                  ? Colors.green
+                                  : Colors.red,
+                            ),
+                          ),
+                        ] else
+                          const Text(
+                            'No selection',
+                            style: TextStyle(color: Colors.grey),
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+                Expanded(
+                  flex: 2,
+                  child: Container(
+                    padding: const EdgeInsets.all(1),
+                    child: Column(
+                      children: [
+                        Text(
+                          _showHomeFleet ? 'Home Fleet:' : 'Build Queue:',
+                          style: const TextStyle(
+                            color: Colors.yellow,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 1),
+                        if (_showHomeFleet) ...[
+                          if (homeFleet.isEmpty)
+                            const Text(
+                              'No ships',
+                              style: TextStyle(color: Colors.grey),
+                            )
+                          else
+                            ...homeFleet.map(
+                              (u) => Text(
+                                _fmtShip(u.type),
+                                style: const TextStyle(color: Colors.white),
+                              ),
+                            ),
+                          Text(
+                            'Ports: ${ports.length}',
+                            style: const TextStyle(color: Colors.grey),
+                          ),
+                        ] else ...[
+                          if (buildOrders.isEmpty)
+                            const Text(
+                              'No orders',
+                              style: TextStyle(color: Colors.grey),
+                            )
+                          else
+                            ...buildOrders.asMap().entries.map(
+                              (e) => Text(
+                                '${e.key + 1}.${e.value.shipName}>${_provinceLabel(e.value.provinceId)}',
+                                style: TextStyle(
+                                  color: e.key == _selectedIndex
+                                      ? Colors.green
+                                      : Colors.white,
+                                ),
+                              ),
+                            ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
               ],
-            ])),
-          ])),
+            ),
+          ),
           Container(padding: const EdgeInsets.all(1), color: Colors.grey, child: Row(children: [
             if (_inputMode == 'province') ...[
               Text(_provinceInput.isEmpty ? 'Province: ' : _provinceInput, style: TextStyle(color: _feedbackColor)),


### PR DESCRIPTION
## Summary
- Fix Shipyard screen layout so three panels share width using flex instead of fixed 40-column side panels, avoiding garbled text at 80x24.
- Update Diplomacy screen to immediately reflect a Declare War order in the faction list by updating the selected faction's relation state to AT_WAR after queuing the order.

## Testing
- \ (no new errors; only existing warnings/infos remain).

## Note
This replaces closed PR #914, and is correctly targeted at \ as the base branch.

Made with [Cursor](https://cursor.com)