### PR TITLE
Fix #891: Attack order validation - cannot attack own provinces

### DIFF
--- a/ctterm/lib/screens/units_screen.dart
+++ b/ctterm/lib/screens/units_screen.dart
@@ -369,15 +369,41 @@ class _UnitsScreenState extends State<UnitsScreen> {
   }
 
   void _issueAttackOrder(Unit unit, String targetProvince) {
-    // For MVP, just accept the attack order with simplified validation
-    // Full implementation would check enemy ownership and visibility
-    
+    // Validate: target must be enemy-controlled province
     final playerId = _getHumanPlayerId();
     if (playerId == null) {
       setState(() {
         _feedbackMessage = 'Error: no human player';
         _feedbackColor = Colors.red;
       });
+      return;
+    }
+
+    // Find target province and check ownership
+    final world = component.game.worldState;
+    String? targetOwnerId;
+    for (final p in world.oldWorld.provinces) {
+      if (p.id == targetProvince) {
+        targetOwnerId = p.ownerId;
+        break;
+      }
+    }
+    if (targetOwnerId == null) {
+      for (final p in world.newWorld.provinces) {
+        if (p.id == targetProvince) {
+          targetOwnerId = p.ownerId;
+          break;
+        }
+      }
+    }
+
+    // Reject if target is owned by the player (cannot attack own province)
+    if (targetOwnerId == playerId) {
+      setState(() {
+        _feedbackMessage = 'Invalid: cannot attack your own province';
+        _feedbackColor = Colors.red;
+      });
+      _log.w('tui:units: attack rejected - target ${targetProvince} owned by player ${playerId}');
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes issue #891: Attack order validation missing - can attack own provinces.

## Changes

In `ctterm/lib/screens/units_screen.dart`:
- Added validation in `_issueAttackOrder` method to check if target province is owned by the same player
- If the target is owned by the player, the attack order is rejected with error message: "Invalid: cannot attack your own province"
- Added appropriate logging for rejected attacks

## Testing

- All 113 existing ctterm tests pass
- Dart analyzer passes (only style warnings)
