### PR TITLE
Fix #913: Units screen Move command uses same target selection UI as Attack

### DIFF
--- a/ctterm/lib/ctterm_app.dart
+++ b/ctterm/lib/ctterm_app.dart
@@ -1,4 +1,4 @@
-// Root ctterm app: navigation shell and main menu. SPEC/tui/ctterm.md.
+// Root ctterm app: navigation shell and main menu. SPEC/tui/ctterm.md. /// CTTerm application entry point
 
 import 'package:logger/logger.dart' as log_pkg;
 import 'package:nocterm/nocterm.dart';

--- a/ctterm/lib/screens/units_screen.dart
+++ b/ctterm/lib/screens/units_screen.dart
@@ -251,10 +251,56 @@ class _UnitsScreenState extends State<UnitsScreen> {
     return neighbours.map((n) => ProvinceId.full(regionId, n)).toList();
   }
 
+  /// Get adjacent enemy-controlled provinces for attack targeting.
+  List<String> _getAdjacentEnemyProvinces(Unit unit) {
+    final allAdj = _getAdjacentProvinces(unit);
+    if (allAdj.isEmpty) return const [];
+
+    final playerId = _getHumanPlayerId();
+    if (playerId == null) return const [];
+
+    final world = component.game.worldState;
+    final enemyProvinces = <String>[];
+
+    for (final provinceId in allAdj) {
+      String? ownerId;
+      // Check old world
+      for (final p in world.oldWorld.provinces) {
+        if (p.id == provinceId) {
+          ownerId = p.ownerId;
+          break;
+        }
+      }
+      // Check new world if not found
+      if (ownerId == null) {
+        for (final p in world.newWorld.provinces) {
+          if (p.id == provinceId) {
+            ownerId = p.ownerId;
+            break;
+          }
+        }
+      }
+      // Add if enemy (not owned by player)
+      if (ownerId != null && ownerId != playerId) {
+        enemyProvinces.add(provinceId);
+      }
+    }
+
+    return enemyProvinces;
+  }
+
   int _selectedAdjacentIndex = 0;
 
+  /// Get the list of adjacent provinces based on current input mode.
+  List<String> _getAdjacentProvincesForMode(Unit unit) {
+    if (_inputMode == 'attackTarget') {
+      return _getAdjacentEnemyProvinces(unit);
+    }
+    return _getAdjacentProvinces(unit);
+  }
+
   void _selectAdjacentProvince(int delta) {
-    final adj = _getAdjacentProvinces(_playerUnits[_selectedIndex]);
+    final adj = _getAdjacentProvincesForMode(_playerUnits[_selectedIndex]);
     if (adj.isEmpty) return;
     setState(() {
       _selectedAdjacentIndex = (_selectedAdjacentIndex + delta).clamp(0, adj.length - 1);
@@ -266,7 +312,7 @@ class _UnitsScreenState extends State<UnitsScreen> {
     if (_selectedIndex >= units.length) return;
     
     final unit = units[_selectedIndex];
-    final adj = _getAdjacentProvinces(unit);
+    final adj = _getAdjacentProvincesForMode(unit);
     if (_selectedAdjacentIndex >= adj.length) return;
     
     final targetProvince = adj[_selectedAdjacentIndex];
@@ -294,7 +340,7 @@ class _UnitsScreenState extends State<UnitsScreen> {
     setState(() {
       _inputMode = 'moveTarget';
       _selectedAdjacentIndex = 0;
-      _feedbackMessage = 'Select target province (y/n)';
+      _feedbackMessage = 'Move to province:';
       _feedbackColor = Colors.yellow;
     });
     _log.d('tui:units: start move order for ${unit.id}');
@@ -309,7 +355,8 @@ class _UnitsScreenState extends State<UnitsScreen> {
       _log.w('tui:units: startAttackOrder called for non-combat unit ${unit.id} (${unit.type})');
       return;
     }
-    final adj = _getAdjacentProvinces(unit);
+    // Use only enemy-controlled adjacent provinces for attack targeting
+    final adj = _getAdjacentEnemyProvinces(unit);
     if (adj.isEmpty) {
       setState(() {
         _feedbackMessage = 'No enemy provinces in range';
@@ -320,7 +367,7 @@ class _UnitsScreenState extends State<UnitsScreen> {
     setState(() {
       _inputMode = 'attackTarget';
       _selectedAdjacentIndex = 0;
-      _feedbackMessage = 'Select enemy province to attack (y/n)';
+      _feedbackMessage = 'Select enemy province to attack:';
       _feedbackColor = Colors.yellow;
     });
     _log.d('tui:units: start attack order for ${unit.id}');
@@ -631,7 +678,7 @@ class _UnitsScreenState extends State<UnitsScreen> {
           ? Row(
               children: [
                 Text(
-                  'Target: ${_getAdjacentProvinces(selectedUnit!).isNotEmpty ? _provinceLabelFor(_getAdjacentProvinces(selectedUnit)[_selectedAdjacentIndex]) : "none"}',
+                  'Target: ${_getAdjacentProvincesForMode(selectedUnit!).isNotEmpty ? _provinceLabelFor(_getAdjacentProvincesForMode(selectedUnit)[_selectedAdjacentIndex]) : "none"}',
                   style: const TextStyle(color: Colors.yellow),
                 ),
                 const Text(' [Y]es [N]o '),

--- a/ctterm/lib/screens/units_screen.dart
+++ b/ctterm/lib/screens/units_screen.dart
@@ -252,6 +252,7 @@ class _UnitsScreenState extends State<UnitsScreen> {
   }
 
   /// Get adjacent enemy-controlled provinces for attack targeting.
+  /// Filters to only include provinces not owned by the human player.
   List<String> _getAdjacentEnemyProvinces(Unit unit) {
     final allAdj = _getAdjacentProvinces(unit);
     if (allAdj.isEmpty) return const [];


### PR DESCRIPTION
Fixes #913

## Summary
This PR fixes the bug where the Move command uses the same target selection UI as the Attack command in the Units screen.

## Changes
1. **Changed Move feedback message**: From "Select target province (y/n)" to "Move to province:" to distinguish from Attack
2. **Changed Attack feedback message**: From "Select enemy province to attack (y/n)" to "Select enemy province to attack:" (removed "(y/n)" as it's now implied)
3. **Added  method**: Filters adjacent provinces to only include enemy-controlled ones for attack targeting
4. **Added  method**: Returns the appropriate list based on input mode (moveTarget vs attackTarget)
5. **Updated **: Now uses the filtered enemy provinces list
6. **Updated  and **: Use mode-specific lists
7. **Updated UI command bar**: Uses mode-specific lists to display correct targets

## Testing
- Ran Analyzing units_screen.dart...

   info - units_screen.dart:453:51 - Unnecessary braces in a string interpolation. Try removing the braces. - unnecessary_brace_in_string_interps
   info - units_screen.dart:453:85 - Unnecessary braces in a string interpolation. Try removing the braces. - unnecessary_brace_in_string_interps

2 issues found. - passed with only 2 minor info warnings
- Ran 00:00 +0: loading ctterm/test/units_movement_test.dart
00:00 +0: movement without movement points London move is governed by movement rules, not movement points
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   new GameSetupConfig (package:colonizethis_data/src/game_setup_config.dart:27:10)
│ #1   GameSetupConfig.defaultConfig (package:colonizethis_data/src/game_setup_config.dart:59:48)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 data: GameSetupConfig created OW=60 NW=80
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   new GameSetupConfig (package:colonizethis_data/src/game_setup_config.dart:27:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:23:22)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 data: GameSetupConfig created OW=60 NW=80
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
[38;5;12m┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m│ #0   runInitGame (package:colonizethis_logic/src/setup/init_game_orchestrator.dart:73:8)[0m
[38;5;12m│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:36:26)[0m
[38;5;12m├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄[0m
[38;5;12m│ 💡 logic: init game start OW:60 NW:80[0m
[38;5;12m└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   runInitGame (package:colonizethis_logic/src/setup/init_game_orchestrator.dart:93:8)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:36:26)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: init game generating OW map
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
[38;5;12m┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m│ #0   TileMapGenerator.generate (package:colonizethis_map/src/tile_map_generator.dart:336:14)[0m
[38;5;12m│ #1   runInitGame (package:colonizethis_logic/src/setup/init_game_orchestrator.dart:94:66)[0m
[38;5;12m├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄[0m
[38;5;12m│ 💡 map: TileMapGenerator.generate start regionId=oldWorld numProvinces=60 seed=42[0m
[38;5;12m└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m│ #0   TileMapGenerator.generate (package:colonizethis_map/src/tile_map_generator.dart:481:14)[0m
[38;5;12m│ #1   runInitGame (package:colonizethis_logic/src/setup/init_game_orchestrator.dart:94:66)[0m
[38;5;12m├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄[0m
[38;5;12m│ 💡 map: TileMapGenerator.generate end regionId=oldWorld provinces=60[0m
[38;5;12m└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   runInitGame (package:colonizethis_logic/src/setup/init_game_orchestrator.dart:101:8)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:36:26)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: init game generating NW map
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
[38;5;12m┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m│ #0   TileMapGenerator.generate (package:colonizethis_map/src/tile_map_generator.dart:336:14)[0m
[38;5;12m│ #1   runInitGame (package:colonizethis_logic/src/setup/init_game_orchestrator.dart:110:66)[0m
[38;5;12m├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄[0m
[38;5;12m│ 💡 map: TileMapGenerator.generate start regionId=newWorld numProvinces=80 seed=43[0m
[38;5;12m└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m│ #0   TileMapGenerator.generate (package:colonizethis_map/src/tile_map_generator.dart:481:14)[0m
[38;5;12m│ #1   runInitGame (package:colonizethis_logic/src/setup/init_game_orchestrator.dart:110:66)[0m
[38;5;12m├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄[0m
[38;5;12m│ 💡 map: TileMapGenerator.generate end regionId=newWorld provinces=80[0m
[38;5;12m└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   generateWarpZones (package:colonizethis_logic/src/setup/warp_zone_generator.dart:68:8)
│ #1   runInitGame (package:colonizethis_logic/src/setup/init_game_orchestrator.dart:117:21)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: warp zones: 10 links (OW edge=12, NW edge=10)
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
[38;5;12m┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m│ #0   createGameFromGeneratedMaps (package:colonizethis_logic/src/setup/game_setup.dart:52:8)[0m
[38;5;12m│ #1   runInitGame (package:colonizethis_logic/src/setup/init_game_orchestrator.dart:127:23)[0m
[38;5;12m├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄[0m
[38;5;12m│ 💡 logic: game setup start gameId=game_1772728247219[0m
[38;5;12m└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m│ #0   createGameFromGeneratedMaps (package:colonizethis_logic/src/setup/game_setup.dart:276:8)[0m
[38;5;12m│ #1   runInitGame (package:colonizethis_logic/src/setup/init_game_orchestrator.dart:127:23)[0m
[38;5;12m├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄[0m
[38;5;12m│ 💡 logic: game setup end gameId=game_1772728247219[0m
[38;5;12m└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m│ #0   buildInitGameMapViewData (package:colonizethis_map/src/init_game_map_view_builder.dart:23:12)[0m
[38;5;12m│ #1   runInitGame (package:colonizethis_logic/src/setup/init_game_orchestrator.dart:163:23)[0m
[38;5;12m├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄[0m
[38;5;12m│ 💡 map: buildInitGameMapViewData start gameId=game_1772728247219[0m
[38;5;12m└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m│ #0   buildInitGameMapViewData (package:colonizethis_map/src/init_game_map_view_builder.dart:48:12)[0m
[38;5;12m│ #1   runInitGame (package:colonizethis_logic/src/setup/init_game_orchestrator.dart:163:23)[0m
[38;5;12m├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄[0m
[38;5;12m│ 💡 map: buildInitGameMapViewData end[0m
[38;5;12m└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m│ #0   runInitGame (package:colonizethis_logic/src/setup/init_game_orchestrator.dart:195:8)[0m
[38;5;12m│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:36:26)[0m
[38;5;12m├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄[0m
[38;5;12m│ 💡 logic: init game end seed=42 gameId=game_1772728247219[0m
[38;5;12m└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:181:8)[0m
[38;5;12m│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)[0m
[38;5;12m├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄[0m
[38;5;12m│ 💡 logic: turn 0 resolve start[0m
[38;5;12m└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:186:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase orders start
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:342:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase orders end
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:186:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase extraction start
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveConnectivity (package:colonizethis_logic/src/world/connectivity_resolver.dart:76:8)
│ #1   _runExtractionPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:474:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: connectivity resolve start players=6 regions=oldWorld,newWorld
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveConnectivity (package:colonizethis_logic/src/world/connectivity_resolver.dart:105:8)
│ #1   _runExtractionPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:474:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: connectivity resolve end gp1:1 gp2:1 gp3:1 gp4:1 gp5:1 gp6:1
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   computeExtraction (package:colonizethis_logic/src/economy/resource_extractor.dart:34:8)
│ #1   _runExtractionPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:479:22)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: extraction compute start players=6
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   computeExtraction (package:colonizethis_logic/src/economy/resource_extractor.dart:113:8)
│ #1   _runExtractionPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:479:22)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: extraction compute end players=6 landTotal=0 overseasTotal=0
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:342:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase extraction end
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:186:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase richesToTreasury start
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveRichesToTreasury (package:colonizethis_logic/src/economy/economy_riches_to_treasury.dart:46:8)
│ #1   _runRichesToTreasuryPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:604:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: riches-to-treasury treasuryDelta=0 multiplier=1.0
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveRichesToTreasury (package:colonizethis_logic/src/economy/economy_riches_to_treasury.dart:46:8)
│ #1   _runRichesToTreasuryPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:604:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: riches-to-treasury treasuryDelta=0 multiplier=1.0
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveRichesToTreasury (package:colonizethis_logic/src/economy/economy_riches_to_treasury.dart:46:8)
│ #1   _runRichesToTreasuryPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:604:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: riches-to-treasury treasuryDelta=0 multiplier=1.0
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveRichesToTreasury (package:colonizethis_logic/src/economy/economy_riches_to_treasury.dart:46:8)
│ #1   _runRichesToTreasuryPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:604:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: riches-to-treasury treasuryDelta=0 multiplier=1.0
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveRichesToTreasury (package:colonizethis_logic/src/economy/economy_riches_to_treasury.dart:46:8)
│ #1   _runRichesToTreasuryPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:604:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: riches-to-treasury treasuryDelta=0 multiplier=1.0
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveRichesToTreasury (package:colonizethis_logic/src/economy/economy_riches_to_treasury.dart:46:8)
│ #1   _runRichesToTreasuryPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:604:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: riches-to-treasury treasuryDelta=0 multiplier=1.0
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:342:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase richesToTreasury end
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:186:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase production start
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveProduction (package:colonizethis_logic/src/economy/economy_production.dart:154:8)
│ #1   _runProductionPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:534:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: production assignments=0 effectiveLabour=4
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveProduction (package:colonizethis_logic/src/economy/economy_production.dart:154:8)
│ #1   _runProductionPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:534:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: production assignments=0 effectiveLabour=4
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveProduction (package:colonizethis_logic/src/economy/economy_production.dart:154:8)
│ #1   _runProductionPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:534:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: production assignments=0 effectiveLabour=4
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveProduction (package:colonizethis_logic/src/economy/economy_production.dart:154:8)
│ #1   _runProductionPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:534:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: production assignments=0 effectiveLabour=4
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveProduction (package:colonizethis_logic/src/economy/economy_production.dart:154:8)
│ #1   _runProductionPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:534:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: production assignments=0 effectiveLabour=4
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveProduction (package:colonizethis_logic/src/economy/economy_production.dart:154:8)
│ #1   _runProductionPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:534:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: production assignments=0 effectiveLabour=4
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:342:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase production end
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:186:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase consumption start
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveConsumption (package:colonizethis_logic/src/economy/economy_consumption.dart:184:8)
│ #1   _runConsumptionPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:573:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: consumption totalRegiments=10 fullyFedRegiments=10
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveConsumption (package:colonizethis_logic/src/economy/economy_consumption.dart:184:8)
│ #1   _runConsumptionPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:573:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: consumption totalRegiments=10 fullyFedRegiments=10
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveConsumption (package:colonizethis_logic/src/economy/economy_consumption.dart:184:8)
│ #1   _runConsumptionPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:573:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: consumption totalRegiments=10 fullyFedRegiments=10
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveConsumption (package:colonizethis_logic/src/economy/economy_consumption.dart:184:8)
│ #1   _runConsumptionPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:573:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: consumption totalRegiments=10 fullyFedRegiments=10
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveConsumption (package:colonizethis_logic/src/economy/economy_consumption.dart:184:8)
│ #1   _runConsumptionPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:573:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: consumption totalRegiments=10 fullyFedRegiments=10
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveConsumption (package:colonizethis_logic/src/economy/economy_consumption.dart:184:8)
│ #1   _runConsumptionPhase (package:colonizethis_logic/src/turn/turn_resolver.dart:573:20)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: consumption totalRegiments=10 fullyFedRegiments=10
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:342:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase consumption end
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:186:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase research start
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:342:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase research end
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:186:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase diplomacy start
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveDiplomacyPhase (package:colonizethis_logic/src/diplomacy/diplomacy_resolver.dart:123:13)
│ #1   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:255:17)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: diplomacy phase start
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveDiplomacyPhase (package:colonizethis_logic/src/diplomacy/diplomacy_resolver.dart:151:13)
│ #1   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:255:17)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: diplomacy phase end
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:342:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase diplomacy end
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:186:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase movement start
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:342:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase movement end
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:186:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase navalInterceptionCombat start
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:342:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase navalInterceptionCombat end
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:186:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase combat start
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:342:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase combat end
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:186:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase buildWork start
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:342:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase buildWork end
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:186:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase endOfTurn start
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:342:10)
│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)
├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
│ 🐛 logic: phase endOfTurn end
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
[38;5;12m┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
[38;5;12m│ #0   resolveTurnForGame (package:colonizethis_logic/src/turn/turn_resolver.dart:345:8)[0m
[38;5;12m│ #1   main.<anonymous closure>.<anonymous closure> (file:///home/clawd/colonizethisv3_3/ctterm/test/units_movement_test.dart:96:24)[0m
[38;5;12m├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄[0m
[38;5;12m│ 💡 logic: turn 0 resolve end[0m
[38;5;12m└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
00:03 +1: All tests passed! - all tests passed

## Verification
Per the issue, the fix ensures:
- **Move**: Shows all adjacent provinces (friendly, neutral, or enemy) with prompt "Move to province:"
- **Attack**: Shows only enemy-controlled provinces with prompt "Select enemy province to attack:"