### PR TITLE
Fix Escape key and keyboard shortcuts in Academy, Shipyard, Technology screens

### DIFF
--- a/ctterm/lib/screens/academy_screen.dart
+++ b/ctterm/lib/screens/academy_screen.dart
@@ -480,7 +480,8 @@ class _AcademyScreenState extends State<AcademyScreen> {
     final regimentList = _getRegimentList();
     final trainingQueue = _getTrainingQueue();
 
-    return KeyboardListener(
+    return Focusable(
+      focused: true,
       onKeyEvent: _handleKeyEvent,
       child: Container(
         color: Colors.black,

--- a/ctterm/lib/screens/shipyard_screen.dart
+++ b/ctterm/lib/screens/shipyard_screen.dart
@@ -220,7 +220,8 @@ class _ShipyardScreenState extends State<ShipyardScreen> {
     final homeFleet = _getHomeFleet();
     final ports = _getPortProvinces();
     final selected = ships.isNotEmpty && _selectedIndex < ships.length ? ships[_selectedIndex] : null;
-    return KeyboardListener(
+    return Focusable(
+      focused: true,
       onKeyEvent: _handleKeyEvent,
       child: Container(
         color: Colors.black,

--- a/ctterm/lib/screens/technology_screen.dart
+++ b/ctterm/lib/screens/technology_screen.dart
@@ -257,8 +257,8 @@ class _TechnologyScreenState extends State<TechnologyScreen> {
     if (_selectedSlot < 0) _selectedSlot = 0;
     if (_selectedTechIndex >= techs.length) _selectedTechIndex = techs.isEmpty ? 0 : techs.length - 1;
 
-    return KeyboardListener(
-      autofocus: true,
+    return Focusable(
+      focused: true,
       onKeyEvent: _handleKeyEvent,
       child: _showCancelConfirm
           ? _buildCancelConfirm()


### PR DESCRIPTION
## Summary

Changed `KeyboardListener` to `Focusable` with `focused: true` in Academy, Shipyard, and Technology screens. This matches how other screens like Production handle keyboard input.

## Root Cause

`KeyboardListener` doesn't properly receive key events without explicit focus management, while `Focusable` (from nocterm) is the standard widget used in ctterm screens for handling keyboard input.

## Changes

- `ctterm/lib/screens/shipyard_screen.dart`: Changed KeyboardListener → Focusable
- `ctterm/lib/screens/academy_screen.dart`: Changed KeyboardListener → Focusable  
- `ctterm/lib/screens/technology_screen.dart`: Changed KeyboardListener (with autofocus) → Focusable

## Issues Fixed

- Fixes #923: Escape key does not exit Shipyard screen
- Fixes #889: Shipyard screen keyboard shortcuts not working in ctterm
- Fixes #888: Academy screen keyboard shortcuts not working in ctterm
- Fixes #887: Technology screen keyboard shortcuts not working in ctterm
- Related to #886: Escape key does not navigate back from Academy, Shipyard, and Technology screens in ctterm

## Testing

- All ctterm tests pass (113 tests)
- Dart analysis passes with no issues
