### PR TITLE
Fix #922: Diplomacy peace offer updates UI relation state

### DIFF
--- a/ctterm/lib/screens/diplomacy_screen.dart
+++ b/ctterm/lib/screens/diplomacy_screen.dart
@@ -364,6 +364,7 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
       type: DiplomaticOrderType.offerPeace,
       targetFactionId: targetId,
     ));
+    _updateSelectedFactionRelationState(RelationState.atPeace);
     _setStatus('Offered peace to ${_selectedFaction!.name}');
     _log.d('tui:diplomacy: offered peace to $targetId');
   }


### PR DESCRIPTION
## Summary

Fixes issue #922: When offering peace to a Great Power at war via the Diplomacy screen, the success message appears but the relation state in the UI was not updated (continued to show "WAR" state).

## Root Cause

The `_handleOfferPeace()` function in `ctterm/lib/screens/diplomacy_screen.dart` did not call `_updateSelectedFactionRelationState()` after adding the peace offer order, unlike `_handleDeclareWar()` which correctly calls it.

## Fix

Added call to `_updateSelectedFactionRelationState(RelationState.atPeace)` after adding the peace offer order, matching the pattern used in `_handleDeclareWar()`. This gives user feedback that the peace offer was placed by updating the relation state in the UI from WAR to PEACE.

## Testing

- All 113 ctterm tests pass
- Dart analysis passes on the modified file

## Issues Fixed

- Fixes #922: [ctterm] [bug] Diplomacy: Peace offer shows message but relation remains at War