### PR TITLE
Fix #912: Layer cycling order in in-game shell

### DIFF
--- a/ctterm/lib/screens/in_game_shell_screen.dart
+++ b/ctterm/lib/screens/in_game_shell_screen.dart
@@ -503,16 +503,16 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
             setState(() {
               switch (_mapGridLayer) {
                 case MapGridLayer.terrain:
-                  _mapGridLayer = MapGridLayer.units;
-                  break;
-                case MapGridLayer.political:
-                  _mapGridLayer = MapGridLayer.terrain;
-                  break;
-                case MapGridLayer.resources:
                   _mapGridLayer = MapGridLayer.political;
                   break;
-                case MapGridLayer.units:
+                case MapGridLayer.political:
                   _mapGridLayer = MapGridLayer.resources;
+                  break;
+                case MapGridLayer.resources:
+                  _mapGridLayer = MapGridLayer.units;
+                  break;
+                case MapGridLayer.units:
+                  _mapGridLayer = MapGridLayer.terrain;
                   break;
               }
             });


### PR DESCRIPTION
## Summary
Fixes issue #912: Layer cycling order is incorrect in in-game shell.

## Changes
- Modified  to fix the layer cycling order for the  key
- The  key now cycles in the correct order: Terrain → Political → Resources → Units → Terrain (matching the  key and the spec)

## Spec Alignment
Per SPEC/tui/screens/in-game-shell.md §"Layer switching":
- Keys **[** and **]** cycle the active layer (Terrain → Political → Resources → Units → Terrain)

The  key was incorrectly cycling in reverse order. This fix aligns both keys with the spec.

## Testing
- All 113 ctterm tests pass
- Dart analyzer shows no new issues

## Issues
- Fixes #912