### PR TITLE
fix(ctterm): update UI overture stage after establishing Consulate (fixes #880)

### DIFF
--- a/ctterm/lib/screens/diplomacy_screen.dart
+++ b/ctterm/lib/screens/diplomacy_screen.dart
@@ -310,6 +310,27 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
     });
   }
 
+  void _updateSelectedFactionOvertureStage(OvertureStage newStage) {
+    if (_selectedFaction == null || _factions.isEmpty) {
+      return;
+    }
+    setState(() {
+      final index = _selectedIndex.clamp(0, _factions.length - 1);
+      final current = _factions[index];
+      final updated = FactionDisplayInfo(
+        id: current.id,
+        name: current.name,
+        type: current.type,
+        relationState: current.relationState,
+        relationLevel: current.relationLevel,
+        relationScore: current.relationScore,
+        overtureStage: newStage,
+      );
+      _factions[index] = updated;
+      _selectedFaction = updated;
+    });
+  }
+
   // Get current orders for human player
   List<DiplomaticOrder> get _diplomaticOrders {
     return component.orders.diplomaticOrdersByPlayerId[_humanPlayerId] ?? [];
@@ -431,6 +452,7 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
       targetFactionId: targetId,
       overtureStage: stage,
     ));
+    _updateSelectedFactionOvertureStage(stage);
     _setStatus('Established $stage with ${_selectedFaction!.name}');
     _log.d('tui:diplomacy: established $stage with $targetId');
   }


### PR DESCRIPTION
After establishing a Consulate (or other overture) with a Minor Nation or Tribe, the UI now immediately updates to show the new overture stage.

This fixes issue #880 where the detail panel would still show 'Overture: none' after establishing a Consulate, preventing subsequent overture stages from being established.

## Changes
- Add  method to update UI state
- Call the new method in  after adding the order

## Testing
- All 113 ctterm tests pass
- dart analyze shows no issues