### PR TITLE
fix(ctterm): show mini-map during province selection in Development screen (fixes #883)

### DIFF
--- a/ctterm/lib/screens/development_screen.dart
+++ b/ctterm/lib/screens/development_screen.dart
@@ -742,6 +742,7 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
   /// Returns the tile key that should be shown in the mini-map, based on the
   /// current mode and selection (selection takes precedence over existing work).
   String? _currentHighlightedTileKey(Unit unit, WorkOrder? workOrder) {
+    // During tile selection, show the currently selected tile.
     if (_inputMode == _DevelopmentInputMode.selectingTile &&
         _candidateProvinces.isNotEmpty &&
         _candidateTilesByProvince.isNotEmpty) {
@@ -753,6 +754,20 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
         final tileIndex =
             _selectedTileIndexWithinProvince.clamp(0, tiles.length - 1);
         return tiles[tileIndex];
+      }
+    }
+    // During province selection, show the first tile of the selected province
+    // to give context about where we're selecting work.
+    if (_inputMode == _DevelopmentInputMode.selectingProvince &&
+        _candidateProvinces.isNotEmpty &&
+        _candidateTilesByProvince.isNotEmpty) {
+      final provinceIndex =
+          _selectedProvinceIndex.clamp(0, _candidateProvinces.length - 1);
+      final provinceId = _candidateProvinces[provinceIndex];
+      final tiles = _candidateTilesByProvince[provinceId];
+      if (tiles != null && tiles.isNotEmpty) {
+        // Show the first tile of the selected province as the mini-map center.
+        return tiles.first;
       }
     }
     if (workOrder != null && workOrder.targetTileKey.isNotEmpty) {


### PR DESCRIPTION
## Summary

This PR fixes issue #883 where the mini-map context panel was not displayed during work order assignment in the Development screen.

## Changes

- Modified `_currentHighlightedTileKey()` in `ctterm/lib/screens/development_screen.dart` to return a tile key during province selection mode (not just tile selection mode)
- During province selection, shows the first tile of the selected province as the mini-map center to provide visual context

## Verification

- All existing tests pass (113 tests)
- Dart analyze shows no new issues related to this change

## Testing

To verify manually:
1. Start ctterm with a new game
2. Navigate to Development screen (press D)
3. Select an idle Builder unit and press Enter
4. Press 'i' for Build Improvement
5. Observe: Mini-map now appears showing the selected province's first tile
6. Press Enter to select province, observe: Mini-map shows the selected tile

---
Fixes #883