### PR TITLE
Fix #937: Technology Screen - Prerequisite validation not working when assigning techs

### DIFF
--- a/ctterm/lib/screens/technology_screen.dart
+++ b/ctterm/lib/screens/technology_screen.dart
@@ -38,6 +38,8 @@ class _TechnologyScreenState extends State<TechnologyScreen> {
   String _categoryFilter = 'all';
   // Show cancel confirmation
   bool _showCancelConfirm = false;
+  // Feedback message (for errors, etc.)
+  String _feedbackMessage = '';
 
   // Categories for filtering
   static const _categories = [
@@ -147,6 +149,30 @@ class _TechnologyScreenState extends State<TechnologyScreen> {
   // Assign tech to slot
   void _assignTech(String techId) {
     if (techId.isEmpty) return;
+
+    // Validate prerequisites per SPEC/tui/screens/technology.md lines 118-120
+    final techDef = techCatalog[techId];
+    if (techDef != null && techDef.prerequisiteIds.isNotEmpty) {
+      final unlocked = _techUnlocked;
+      final missing = <String>[];
+      for (final prereqId in techDef.prerequisiteIds) {
+        if (unlocked[prereqId] != true) {
+          missing.add(techById(prereqId)?.id ?? prereqId);
+        }
+      }
+      if (missing.isNotEmpty) {
+        setState(() {
+          _feedbackMessage = 'Prerequisites not met: ${missing.join(', ')}';
+        });
+        _log.d('tui:tech: failed to assign $techId - missing prerequisites: $missing');
+        return;
+      }
+    }
+
+    // Clear any previous feedback
+    setState(() {
+      _feedbackMessage = '';
+    });
 
     final humanId = _humanPlayerId;
     final currentOrders = List<ResearchOrder>.from(_researchOrders);
@@ -299,6 +325,16 @@ class _TechnologyScreenState extends State<TechnologyScreen> {
             ],
           ),
           Text('─' * 60),
+
+          // Feedback message
+          if (_feedbackMessage.isNotEmpty)
+            Container(
+              padding: const EdgeInsets.symmetric(vertical: 1),
+              child: Text(
+                _feedbackMessage,
+                style: const TextStyle(color: Colors.red),
+              ),
+            ),
 
           // Research Slots
           Text('Research Slots (${_selectedSlot + 1}/$slots)'),


### PR DESCRIPTION
## Summary

Fixes issue #937: Technology screen was allowing tech assignment without validating prerequisites.

## Changes

- Added prerequisite validation in  method to check if the player has all required techs unlocked before assigning a tech to a research slot
- When prerequisites are not met, displays error message "Prerequisites not met: [list]" in red
- Added  state variable for displaying error messages in the UI
- Validation follows SPEC/tui/screens/technology.md lines 118-120

## Testing

- All 113 ctterm tests pass
- Dart analyzer reports no issues

## Notes

- The bug was that techs could be assigned without checking if prerequisite techs were unlocked
- Example: "improved_iron_weapons" requires "organised_regiments" to be researched first