### PR TITLE
Fix issues #931 and #932: Missing Upgrade Town and corrupted faction names

### DIFF
--- a/ctterm/lib/screens/development_screen.dart
+++ b/ctterm/lib/screens/development_screen.dart
@@ -1062,7 +1062,6 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
                       if (workOrder == null) ...[
                         const Text(' Available Work: ',
                             style: TextStyle(color: Colors.white)),
-                        const SizedBox(height: 1),
                         for (final entry in _validWorkTargets.entries)
                           Padding(
                             padding: const EdgeInsets.only(left: 1),

--- a/ctterm/lib/screens/diplomacy_screen.dart
+++ b/ctterm/lib/screens/diplomacy_screen.dart
@@ -465,8 +465,10 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
       targetFactionId: targetId,
       overtureStage: stage,
     ));
+    // Capture name before update to ensure correct display in status message
+    final factionName = _selectedFaction!.name;
     _updateSelectedFactionOvertureStage(stage);
-    _setStatus('Established $stage with ${_selectedFaction!.name}');
+    _setStatus('Established $stage with $factionName');
     _log.d('tui:diplomacy: established $stage with $targetId');
   }
 


### PR DESCRIPTION
## Summary

This PR fixes two bugs:

### Issue #931: Missing [u] Upgrade Town option in Development screen Available Work section
- **Problem**: The Available Work section only displayed 5 options instead of 6. The [u] Upgrade Town option was being clipped because the layout didn't fit in the 80x24 terminal constraint.
- **Fix**: Removed the unnecessary blank line (SizedBox) after the "Available Work:" header to make the layout more compact, allowing all 6 work targets to fit in the viewport.

### Issue #932: Diplomacy overture success messages show corrupted faction names
- **Problem**: When establishing Embassy or NAP overtures with Minor Nations, the success messages displayed corrupted faction names (e.g., "Italyire" instead of "Italy").
- **Fix**: Capture the faction name BEFORE calling  to ensure the status message displays the correct name at the time of establishment.

## Changes
- : Removed blank line in Available Work rendering
- : Capture faction name before updating overture stage

## Testing
- All 113 ctterm tests pass
- Flutter analyze shows no new issues

## Issues addressed
- Fixes #931
- Fixes #932