### PR TITLE
Fix #306: Set InitGameResult.greatPowerColorOverride in Load Savegame

### DIFF
--- a/ctdev/lib/screens/load_savegame_screen.dart
+++ b/ctdev/lib/screens/load_savegame_screen.dart
@@ -71,12 +71,13 @@ class _LoadSavegameScreenState extends State<LoadSavegameScreen> {
       );
       return;
     }
+    final greatPowerColorOverride = greatPowerColorOverrideFromGame(game);
     final viewData = buildInitGameMapViewData(
       game: game,
       tileMapByRegion: mapData.tileMapByRegion,
       topologyByRegion: mapData.topologyByRegion,
       cellSize: 24,
-      greatPowerColorOverride: greatPowerColorOverrideFromGame(game),
+      greatPowerColorOverride: greatPowerColorOverride,
     );
     final initResult = InitGameResult(
       game: game,
@@ -86,6 +87,7 @@ class _LoadSavegameScreenState extends State<LoadSavegameScreen> {
       tileMapByRegion: mapData.tileMapByRegion,
       topologyByRegion: mapData.topologyByRegion,
       combinedTopology: mapData.combinedTopology,
+      greatPowerColorOverride: greatPowerColorOverride,
     );
     final baseSeed = game.globalGameSeed ?? 0;
     await Navigator.of(context).push(


### PR DESCRIPTION
When loading a saved game in ctdev, the InitGameResult was not being given the greatPowerColorOverride from the loaded game. This means the Running Game screen and Init Game Map Debug screen would not use the same GP colors that were chosen at game setup.

Now passes greatPowerColorOverrideFromGame(game) to both the map view data builder and the InitGameResult constructor.

Fixes #306