### PR TITLE
Fix #948: War declaration required for Minor Nation/Tribe attacks

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -446,6 +446,28 @@ class OrderEngine {
         }
       }
 
+      // Attack validation for Minor Nations and Tribes: war declaration required for military units
+      // SPEC/game/diplomacy.md line 19: "Minor Nations (Old World): Declaration of
+      // war required before attacking provinces or units."
+      // Civilian units (Explorer, Merchant, Spy) can enter without war declaration.
+      if (destOwnerId != null &&
+          destOwnerId != playerId &&
+          _ownerIsMinorOrTribe(destOwnerId) &&
+          isMilitaryUnit(unit.type)) {
+        final rel = getRelation(game, playerId, destOwnerId);
+        final atWar = rel?.atWar ?? false;
+        final declaringWarThisTurn = diplomatic.any((o) =>
+            o.type == DiplomaticOrderType.declareWar &&
+            o.targetFactionId == destOwnerId);
+        if (!atWar && !declaringWarThisTurn) {
+          return const OrderValidationResult(
+            status: OrderValidationStatus.rejected,
+            reason:
+                'Must declare war before attacking Minor Nation or Tribe province',
+          );
+        }
+      }
+
       if (!moveSourceVisibilityOk(view, unitRegion, unit.locationProvinceId) ||
           !moveDestVisibilityOk(
               view, destRegion, o.destinationProvinceId, unit.type)) {


### PR DESCRIPTION
Fixes #948

Added validation in order_engine.dart to require war declaration before attacking Minor Nation or Tribe provinces. Enforces SPEC/game/diplomacy.md line 19.