### PR TITLE
fix: Unknown diplomatic state for undiscovered factions

### DIFF
--- a/packages/colonizethis_logic/lib/src/setup/game_setup.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup.dart
@@ -156,14 +156,19 @@ GameSetupResult createGameFromGeneratedMaps({
       Tribe(id: tribeIds[i], displayName: 'Tribe ${i + 1}'),
   ];
 
-  // Initial GP–GP relations per SPEC/game/diplomacy.md: all Great Powers
+  // Initial diplomatic relations per SPEC/game/diplomacy.md: all factions
   // start at peace with neutral relations and turn index 0 metadata.
+  final allFactionIds = [
+    ...gpIds,
+    ...minorIds,
+    ...tribeIds,
+  ];
   final diplomacyRelations = <DiplomacyRelation>[
-    for (var i = 0; i < players.length; i++)
-      for (var j = i + 1; j < players.length; j++)
+    for (var i = 0; i < allFactionIds.length; i++)
+      for (var j = i + 1; j < allFactionIds.length; j++)
         DiplomacyRelation(
-          factionId1: players[i].id,
-          factionId2: players[j].id,
+          factionId1: allFactionIds[i],
+          factionId2: allFactionIds[j],
           score: 50,
           level: RelationLevel.neutral,
           state: RelationState.atPeace,


### PR DESCRIPTION
## Summary

Fixes initialization bug where factions (especially minors and tribes) had unknown diplomatic state instead of peace at game start.

## Changes

- Initialize diplomatic relations for ALL factions at game start (GPs ↔ Minors, GPs ↔ Tribes, Minors ↔ Tribes)
- Previously only GP-GP relations were initialized, causing unknown state for all other faction pairs

## Testing

- All factions now have defined diplomatic state at game start
- Minors and tribes properly initialized at peace with all other factions

Fixes waigore/colonizethisv3#973