### PR TITLE
fix: Missing Diplomacy and Civilian Techs from Tech Catalog

### DIFF
--- a/packages/colonizethis_data/lib/src/tech_extraction.dart
+++ b/packages/colonizethis_data/lib/src/tech_extraction.dart
@@ -20,6 +20,13 @@ const List<String> techIds = [
   'horse_artillery',
   'siege_engineering',
   'university',
+  // Diplomacy/Civilian techs (SPEC/game/tech-tree-diplomacy-civilian.md)
+  'diplomatic_expertise',
+  'merchant_companies',
+  'national_bureaucracy',
+  'propaganda',
+  'nationalism',
+  'empire_building',
 ];
 
 /// Default max effective extraction level when player has no tech or no extraction-cap tech.
@@ -146,6 +153,45 @@ const Map<String, TechDefinition> techCatalog = {
     category: 'labour',
     cost: 200,
     prerequisiteIds: const [],
+  ),
+  // Diplomacy/Civilian techs (SPEC/game/tech-tree-diplomacy-civilian.md)
+  'diplomatic_expertise': TechDefinition(
+    id: 'diplomatic_expertise',
+    era: 1,
+    category: 'diplomacy',
+    cost: 100,
+  ),
+  'merchant_companies': TechDefinition(
+    id: 'merchant_companies',
+    era: 1,
+    category: 'civilian',
+    cost: 100,
+    prerequisiteIds: ['diplomatic_expertise'],
+  ),
+  'national_bureaucracy': TechDefinition(
+    id: 'national_bureaucracy',
+    era: 2,
+    category: 'civilian',
+    cost: 150,
+  ),
+  'propaganda': TechDefinition(
+    id: 'propaganda',
+    era: 3,
+    category: 'diplomacy',
+    cost: 150,
+  ),
+  'nationalism': TechDefinition(
+    id: 'nationalism',
+    era: 3,
+    category: 'diplomacy',
+    cost: 200,
+  ),
+  'empire_building': TechDefinition(
+    id: 'empire_building',
+    era: 4,
+    category: 'diplomacy',
+    cost: 250,
+    prerequisiteIds: ['nationalism'],
   ),
 };
 


### PR DESCRIPTION
## Summary

Adds 6 missing diplomacy/civilian techs that were defined in SPEC but not in the game catalog.

## Techs Added

| Tech ID | Name | Era | Category |
|---------|------|-----|----------|
| diplomatic_expertise | Diplomatic Expertise | 1 | diplomacy |
| merchant_companies | Merchant Companies | 1 | civilian |
| national_bureaucracy | National Bureaucracy | 2 | civilian |
| propaganda | Propaganda | 3 | diplomacy |
| nationalism | Nationalism | 3 | diplomacy |
| empire_building | Empire Building | 4 | diplomacy |

## Testing

- show_tech tool can now find all 6 techs
- Tech catalog now complete per SPEC/game/tech-tree-diplomacy-civilian.md

Fixes waigore/colonizethisv3#956