### PR TITLE
fix: Subsidy option shown in Diplomacy UI without prerequisite

### DIFF
--- a/ctterm/lib/screens/diplomacy_screen.dart
+++ b/ctterm/lib/screens/diplomacy_screen.dart
@@ -877,7 +877,7 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
             _buildActionHint('g', 'Grant Aid (£1000)', 
               faction.overtureStage == OvertureStage.embassy || faction.overtureStage == OvertureStage.nap),
             _buildActionHint('s', 'Set Subsidy (£500)', 
-              faction.overtureStage != OvertureStage.none),
+              faction.overtureStage != null && faction.overtureStage != OvertureStage.none),
           ],
         ],
       ),


### PR DESCRIPTION
## Summary

Fixes UI bug where [s] Set Subsidy option was shown for Minor Nations and Tribes even when no Consulate or Embassy existed.

## Changes

- Fixed condition to check for both null and OvertureStage.none
- Subsidy option now only appears when a valid overture exists

## Testing

- Start new game, open Diplomacy (I)
- Select Minor Nation without overture
- Verify [s] Set Subsidy is NOT shown
- Establish Consulate, verify [s] Set Subsidy IS shown

Fixes waigore/colonizethisv3#960