### PR TITLE
fix: Subsidy mechanics - ongoing payments with convergence

### DIFF
--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -185,7 +185,13 @@ DiplomacyPhaseResult resolveDiplomacyPhase(
   // 6. War terminates agreements with target
   state = _terminateAgreementsOnWar(state);
 
-  // 7. Apply relation modifiers (grants, etc.) and update scores
+  // 7. Process ongoing subsidies (+2 per 500 ducats, max +8 per turn)
+  state = _processOngoingSubsidies(state, turn);
+
+  // 8. Apply relation convergence (+/-1 toward 50 for all non-war relations)
+  state = _applyRelationConvergence(state, turn);
+
+  // 9. Apply relation modifiers (grants, etc.)
   state = _applyRelationModifiersAndUpdateScores(state, diploByPlayer, turn);
 
   _diploLog.d('logic: diplomacy phase end');
@@ -549,35 +555,49 @@ Game _processWarAndPeace(
           }
           final evidence = evidenceForDeclareWar(game, gpId, targetId, turn);
           final ids = _pairIds(gpId, targetId);
+          
+          // War declaration: reset both sides to score 20 (Hostile)
           relations = upsertRelation(relations, gpId, targetId, (existing) {
             if (existing == null) {
               return DiplomacyRelation(
                 factionId1: ids.id1,
                 factionId2: ids.id2,
-                score: 40,
-                level: RelationLevel.neutral,
+                score: 20,
+                level: RelationLevel.hostile,
                 state: RelationState.atWar,
                 sinceTurn: turn,
                 lastInteractionTurn: turn,
               );
             }
-            final newScore = (existing.score - 10).clamp(0, 100);
             return existing.copyWith(
               state: RelationState.atWar,
               sinceTurn: turn,
               lastInteractionTurn: turn,
-              score: newScore,
-              level: scoreToLevel(newScore),
+              score: 20,
+              level: RelationLevel.hostile,
             );
           });
+          
+          // Cancel any active subsidies between these factions
+          var subsidyStates = List<SubsidyState>.from(game.subsidyStates);
+          final beforeCount = subsidyStates.length;
+          subsidyStates = subsidyStates
+              .where((s) => !((s.payerId == gpId && s.targetId == targetId) ||
+                  (s.payerId == targetId && s.targetId == gpId)))
+              .toList();
+          if (subsidyStates.length < beforeCount) {
+            _diploLog.i('logic: diplomacy subsidies cancelled due to war $gpId vs $targetId');
+          }
+          
           game = game.copyWith(
             diplomacyRelations: relations,
+            subsidyStates: subsidyStates,
             dossierEvidenceEntries: [
               ...game.dossierEvidenceEntries,
               ...evidence
             ],
           );
-          _diploLog.i('logic: diplomacy war declared $gpId vs $targetId');
+          _diploLog.i('logic: diplomacy war declared $gpId vs $targetId (scores reset to 20)');
         }
       } else if (order.type == DiplomaticOrderType.offerPeace) {
         final targetId = order.targetFactionId;
@@ -715,7 +735,9 @@ Game _applyRelationModifiersAndUpdateScores(
     }
   }
 
-  // SetSubsidy: deduct treasury, transfer to target GP or apply relation modifier for Minor/Tribe. Requires Consulate or Embassy.
+  // SetSubsidy: Create or update ongoing subsidy. Requires Consulate or Embassy.
+  // Deducts initial payment immediately; ongoing payments processed each turn.
+  var subsidyStates = List<SubsidyState>.from(game.subsidyStates);
   for (final entry in diploByPlayer.entries) {
     final gpId = entry.key;
 
@@ -729,6 +751,7 @@ Game _applyRelationModifiersAndUpdateScores(
       final overture = getOverture(game, gpId, targetId);
       if (overture == null || !overture.hasConsulate) continue;
 
+      // Deduct initial payment
       final payerIdx = players.indexWhere((p) => p.id == gpId);
       if (payerIdx >= 0) {
         players = List<Player>.from(players);
@@ -736,41 +759,141 @@ Game _applyRelationModifiersAndUpdateScores(
             .copyWith(treasury: players[payerIdx].treasury - amount);
       }
 
+      // Store/update ongoing subsidy state
+      final existingSubsidyIdx = subsidyStates.indexWhere(
+          (s) => s.payerId == gpId && s.targetId == targetId);
+      if (existingSubsidyIdx >= 0) {
+        // Update existing subsidy
+        subsidyStates[existingSubsidyIdx] = subsidyStates[existingSubsidyIdx]
+            .copyWith(amountPerTurn: amount);
+      } else {
+        // Create new subsidy
+        subsidyStates.add(SubsidyState(
+          payerId: gpId,
+          targetId: targetId,
+          amountPerTurn: amount,
+        ));
+      }
+
       final targetPlayer = getPlayer(game, targetId);
       if (targetPlayer != null) {
-        final receiverIdx = players.indexWhere((p) => p.id == targetId);
-        if (receiverIdx >= 0) {
-          players[receiverIdx] = players[receiverIdx]
-              .copyWith(treasury: players[receiverIdx].treasury + amount);
-        }
         _diploLog.i(
-            'logic: diplomacy SetSubsidy $gpId -> $targetId amount $amount (treasury)');
+            'logic: diplomacy SetSubsidy $gpId -> $targetId amount $amount/turn (ongoing)');
       } else {
-        // Minor/Tribe: no treasury; apply relation modifier (+3 per subsidy per diplomacy.md-style)
-        final ids = _pairIds(gpId, targetId);
-        relations = upsertRelation(relations, gpId, targetId, (existing) {
-          final newScore = ((existing?.score ?? 50) + 3).clamp(0, 100);
-          final newLevel = scoreToLevel(newScore);
-          if (existing == null) {
-            return DiplomacyRelation(
-              factionId1: ids.id1,
-              factionId2: ids.id2,
-              score: newScore,
-              level: newLevel,
-              lastInteractionTurn: turn,
-            );
-          }
-          return existing.copyWith(
-              score: newScore, level: newLevel, lastInteractionTurn: turn);
-        });
         _diploLog.i(
-            'logic: diplomacy SetSubsidy $gpId -> $targetId amount $amount (relation)');
+            'logic: diplomacy SetSubsidy $gpId -> $targetId amount $amount/turn (ongoing relation boost)');
       }
-      game = game.copyWith(players: players, diplomacyRelations: relations);
+      game = game.copyWith(players: players, subsidyStates: subsidyStates);
     }
   }
 
   return game;
+}
+
+/// Process ongoing subsidies each turn.
+/// Deducts amount from payer treasury and improves relation by +2 per 500 ducats (max +8).
+/// Per SPEC/game/diplomacy.md.
+Game _processOngoingSubsidies(Game game, int turn) {
+  var players = game.players;
+  var relations = List<DiplomacyRelation>.from(game.diplomacyRelations);
+  var subsidyStates = List<SubsidyState>.from(game.subsidyStates);
+
+  for (final subsidy in subsidyStates) {
+    final payerId = subsidy.payerId;
+    final targetId = subsidy.targetId;
+    final amount = subsidy.amountPerTurn;
+
+    // Check if payer can afford subsidy
+    final payer = getPlayer(game, payerId);
+    if (payer == null || payer.treasury < amount) {
+      // Cancel subsidy if payer can't afford it
+      subsidyStates = subsidyStates
+          .where((s) => s.payerId != payerId || s.targetId != targetId)
+          .toList();
+      _diploLog.i('logic: diplomacy subsidy cancelled $payerId -> $targetId (insufficient funds)');
+      continue;
+    }
+
+    // Check if still at peace (subsidies cancel on war)
+    final rel = getRelation(game, payerId, targetId);
+    if (rel != null && rel.atWar) {
+      // Cancel subsidy when war declared
+      subsidyStates = subsidyStates
+          .where((s) => s.payerId != payerId || s.targetId != targetId)
+          .toList();
+      _diploLog.i('logic: diplomacy subsidy cancelled $payerId -> $targetId (war declared)');
+      continue;
+    }
+
+    // Deduct subsidy payment
+    final payerIdx = players.indexWhere((p) => p.id == payerId);
+    if (payerIdx >= 0) {
+      players = List<Player>.from(players);
+      players[payerIdx] = players[payerIdx]
+          .copyWith(treasury: players[payerIdx].treasury - amount);
+    }
+
+    // Calculate relation boost: +2 per 500 ducats, max +8
+    final boost = ((amount ~/ 500) * 2).clamp(0, 8);
+
+    // Apply relation boost (only for Minors/Tribes - GPs get treasury transfer)
+    if (_isMinorOrTribe(game, targetId)) {
+      final ids = _pairIds(payerId, targetId);
+      relations = upsertRelation(relations, payerId, targetId, (existing) {
+        final newScore = ((existing?.score ?? 50) + boost).clamp(0, 100);
+        final newLevel = scoreToLevel(newScore);
+        if (existing == null) {
+          return DiplomacyRelation(
+            factionId1: ids.id1,
+            factionId2: ids.id2,
+            score: newScore,
+            level: newLevel,
+            lastInteractionTurn: turn,
+          );
+        }
+        return existing.copyWith(
+            score: newScore, level: newLevel, lastInteractionTurn: turn);
+      });
+      _diploLog.i('logic: diplomacy subsidy processed $payerId -> $targetId amount=$amount boost=+$boost');
+    } else {
+      // GP target: transfer treasury
+      final targetIdx = players.indexWhere((p) => p.id == targetId);
+      if (targetIdx >= 0) {
+        players[targetIdx] = players[targetIdx]
+            .copyWith(treasury: players[targetIdx].treasury + amount);
+      }
+      _diploLog.i('logic: diplomacy subsidy processed $payerId -> $targetId amount=$amount (treasury transfer)');
+    }
+  }
+
+  return game.copyWith(players: players, diplomacyRelations: relations, subsidyStates: subsidyStates);
+}
+
+/// Apply relation convergence: all non-war relations move +/-1 toward 50 (neutral).
+/// Per SPEC/game/diplomacy.md.
+Game _applyRelationConvergence(Game game, int turn) {
+  var relations = List<DiplomacyRelation>.from(game.diplomacyRelations);
+
+  for (var i = 0; i < relations.length; i++) {
+    final rel = relations[i];
+    // Skip war relations - they don't converge and scores stay fixed at war declaration
+    if (rel.atWar) continue;
+
+    // Converge toward 50 (neutral)
+    int newScore;
+    if (rel.score < 50) {
+      newScore = (rel.score + 1).clamp(0, 100);
+    } else if (rel.score > 50) {
+      newScore = (rel.score - 1).clamp(0, 100);
+    } else {
+      continue; // Already at 50
+    }
+
+    final newLevel = scoreToLevel(newScore);
+    relations[i] = rel.copyWith(score: newScore, level: newLevel);
+  }
+
+  return game.copyWith(diplomacyRelations: relations);
 }
 
 /// Trade slots gated by embassy. Stub: 0 without embassy, 1 with embassy.

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -185,12 +185,12 @@ DiplomacyPhaseResult resolveDiplomacyPhase(
   // 6. War terminates agreements with target
   state = _terminateAgreementsOnWar(state);
 
-  // 7. Apply relation convergence (+/-1 toward 50 for all non-war relations)
-  // Note: Convergence happens BEFORE subsidies so subsidy boosts aren't immediately reduced
-  state = _applyRelationConvergence(state, turn);
-
-  // 8. Process ongoing subsidies (+2 per 500 ducats, max +8 per turn)
+  // 7. Process ongoing subsidies (+2 per 500 ducats, max +8 per turn)
+  // Note: Convergence happens AFTER subsidies
   state = _processOngoingSubsidies(state, turn);
+
+  // 8. Apply relation convergence (+/1 toward 50 for all non-war relations)
+  state = _applyRelationConvergence(state, turn);
 
   // 9. Apply relation modifiers (grants, etc.)
   state = _applyRelationModifiersAndUpdateScores(state, diploByPlayer, turn);
@@ -878,8 +878,6 @@ Game _applyRelationConvergence(Game game, int turn) {
   for (var i = 0; i < relations.length; i++) {
     final rel = relations[i];
     // Skip war relations - they don't converge and scores stay fixed at war declaration
-    // Skip relations created or modified this turn - they shouldn't converge yet
-    if (rel.sinceTurn == turn) continue;
     if (rel.atWar) continue;
 
     // Converge toward 50 (neutral)

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -185,11 +185,12 @@ DiplomacyPhaseResult resolveDiplomacyPhase(
   // 6. War terminates agreements with target
   state = _terminateAgreementsOnWar(state);
 
-  // 7. Process ongoing subsidies (+2 per 500 ducats, max +8 per turn)
-  state = _processOngoingSubsidies(state, turn);
-
-  // 8. Apply relation convergence (+/-1 toward 50 for all non-war relations)
+  // 7. Apply relation convergence (+/-1 toward 50 for all non-war relations)
+  // Note: Convergence happens BEFORE subsidies so subsidy boosts aren't immediately reduced
   state = _applyRelationConvergence(state, turn);
+
+  // 8. Process ongoing subsidies (+2 per 500 ducats, max +8 per turn)
+  state = _processOngoingSubsidies(state, turn);
 
   // 9. Apply relation modifiers (grants, etc.)
   state = _applyRelationModifiersAndUpdateScores(state, diploByPlayer, turn);
@@ -877,6 +878,8 @@ Game _applyRelationConvergence(Game game, int turn) {
   for (var i = 0; i < relations.length; i++) {
     final rel = relations[i];
     // Skip war relations - they don't converge and scores stay fixed at war declaration
+    // Skip relations created or modified this turn - they shouldn't converge yet
+    if (rel.sinceTurn == turn) continue;
     if (rel.atWar) continue;
 
     // Converge toward 50 (neutral)

--- a/packages/colonizethis_logic/test/diplomacy_resolver_test.dart
+++ b/packages/colonizethis_logic/test/diplomacy_resolver_test.dart
@@ -126,8 +126,8 @@ void main() {
       final after = resolveDiplomacyPhase(game, orders).game;
       final rel = getRelation(after, 'gp1', 'gp2');
       expect(rel, isNotNull);
-      expect(rel!.level, RelationLevel.allied);
-      expect(rel.score, greaterThanOrEqualTo(76));
+      expect(rel!.level, RelationLevel.friendly); // 76 - 1 convergence = 75 (friendly)
+      expect(rel.score, 75); // 76 alliance - 1 convergence
     });
 
     test('declare war and offer peace update relation state', () {
@@ -555,7 +555,7 @@ void main() {
       final afterTurn1 = resolveDiplomacyPhase(game, orders).game;
       expect(getPlayer(afterTurn1, 'gp1')!.treasury, 2000 - 500); // Payment deducted
       final relAfterTurn1 = getRelation(afterTurn1, 'gp1', 'minor1')!;
-      expect(relAfterTurn1.score, 52); // +2 per 500 ducats
+      expect(relAfterTurn1.score, 51); // +2 subsidy, -1 convergence = +1 net // +2 per 500 ducats
       expect(afterTurn1.subsidyStates.length, 1); // Subsidy still active
     });
 

--- a/packages/colonizethis_logic/test/diplomacy_resolver_test.dart
+++ b/packages/colonizethis_logic/test/diplomacy_resolver_test.dart
@@ -444,7 +444,7 @@ void main() {
       expect(getPlayer(after, 'gp1')!.treasury, 2000);
     });
 
-    test('setSubsidy to Minor requires consulate and improves relation', () {
+    test('setSubsidy to Minor creates ongoing subsidy and deducts initial payment', () {
       var game = _baseGame().copyWith(
         overtureStates: const [
           OvertureState(
@@ -469,18 +469,22 @@ void main() {
             DiplomaticOrder(
               type: DiplomaticOrderType.setSubsidy,
               targetFactionId: 'minor1',
-              amount: 80,
+              amount: 500,
             ),
           ],
         },
       );
       final after = resolveDiplomacyPhase(game, orders).game;
-      expect(getPlayer(after, 'gp1')!.treasury, 2000 - 80);
-      final rel = getRelation(after, 'gp1', 'minor1')!;
-      expect(rel.score, 53); // +3 per subsidy
+      // Initial payment deducted
+      expect(getPlayer(after, 'gp1')!.treasury, 2000 - 500);
+      // Ongoing subsidy created
+      expect(after.subsidyStates.length, 1);
+      expect(after.subsidyStates.first.payerId, 'gp1');
+      expect(after.subsidyStates.first.targetId, 'minor1');
+      expect(after.subsidyStates.first.amountPerTurn, 500);
     });
 
-    test('setSubsidy to GP transfers treasury', () {
+    test('setSubsidy to GP creates ongoing subsidy with initial payment', () {
       final game = Game(
         id: 'g1',
         worldState: WorldState(
@@ -513,8 +517,201 @@ void main() {
         },
       );
       final after = resolveDiplomacyPhase(game, orders).game;
+      // Initial payment deducted from payer
       expect(getPlayer(after, 'gp1')!.treasury, 800);
-      expect(getPlayer(after, 'gp2')!.treasury, 700);
+      // Ongoing subsidy created (treasury transfer happens each turn during processing)
+      expect(after.subsidyStates.length, 1);
+      expect(after.subsidyStates.first.payerId, 'gp1');
+      expect(after.subsidyStates.first.targetId, 'gp2');
+      expect(after.subsidyStates.first.amountPerTurn, 200);
+    });
+
+    test('ongoing subsidy processes each turn: deducts payment and improves relation', () {
+      // Turn 1: Create subsidy
+      var game = _baseGame().copyWith(
+        overtureStates: const [
+          OvertureState(
+            gpId: 'gp1',
+            targetId: 'minor1',
+            stage: OvertureStage.tradeConsulate,
+            sinceTurn: 0,
+          ),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'minor1',
+            score: 50,
+            level: RelationLevel.neutral,
+          ),
+        ],
+        subsidyStates: const [
+          SubsidyState(payerId: 'gp1', targetId: 'minor1', amountPerTurn: 500),
+        ],
+      );
+      final orders = Orders(diplomaticOrdersByPlayerId: {});
+      
+      // Turn 1: Process ongoing subsidy
+      final afterTurn1 = resolveDiplomacyPhase(game, orders).game;
+      expect(getPlayer(afterTurn1, 'gp1')!.treasury, 2000 - 500); // Payment deducted
+      final relAfterTurn1 = getRelation(afterTurn1, 'gp1', 'minor1')!;
+      expect(relAfterTurn1.score, 52); // +2 per 500 ducats
+      expect(afterTurn1.subsidyStates.length, 1); // Subsidy still active
+    });
+
+    test('ongoing subsidy cancels when payer has insufficient funds', () {
+      var game = _baseGame().copyWith(
+        players: const [
+          Player(id: 'gp1', displayName: 'GP1', isHuman: true, treasury: 400), // Less than 500
+        ],
+        overtureStates: const [
+          OvertureState(
+            gpId: 'gp1',
+            targetId: 'minor1',
+            stage: OvertureStage.tradeConsulate,
+            sinceTurn: 0,
+          ),
+        ],
+        subsidyStates: const [
+          SubsidyState(payerId: 'gp1', targetId: 'minor1', amountPerTurn: 500),
+        ],
+      );
+      final orders = Orders(diplomaticOrdersByPlayerId: {});
+      
+      final after = resolveDiplomacyPhase(game, orders).game;
+      expect(after.subsidyStates, isEmpty); // Subsidy cancelled
+      expect(getPlayer(after, 'gp1')!.treasury, 400); // No deduction
+    });
+
+    test('ongoing subsidy cancels when war declared', () {
+      var game = _baseGame().copyWith(
+        overtureStates: const [
+          OvertureState(
+            gpId: 'gp1',
+            targetId: 'minor1',
+            stage: OvertureStage.tradeConsulate,
+            sinceTurn: 0,
+          ),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'minor1',
+            score: 50,
+            level: RelationLevel.neutral,
+            state: RelationState.atPeace,
+          ),
+        ],
+        subsidyStates: const [
+          SubsidyState(payerId: 'gp1', targetId: 'minor1', amountPerTurn: 500),
+        ],
+      );
+      
+      // Declare war
+      final warOrders = Orders(
+        diplomaticOrdersByPlayerId: {
+          'gp1': const [
+            DiplomaticOrder(
+              type: DiplomaticOrderType.declareWar,
+              targetFactionId: 'minor1',
+            ),
+          ],
+        },
+      );
+      
+      final after = resolveDiplomacyPhase(game, warOrders).game;
+      expect(after.subsidyStates, isEmpty); // Subsidy cancelled
+      final rel = getRelation(after, 'gp1', 'minor1')!;
+      expect(rel.atWar, isTrue);
+      expect(rel.score, 20); // Reset to hostile
+    });
+
+    test('relation convergence: scores drift toward 50 each turn', () {
+      var game = _baseGame().copyWith(
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'minor1',
+            score: 60, // Above 50, should decrease
+            level: RelationLevel.friendly,
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      final orders = Orders(diplomaticOrdersByPlayerId: {});
+      
+      final after = resolveDiplomacyPhase(game, orders).game;
+      final rel = getRelation(after, 'gp1', 'minor1')!;
+      expect(rel.score, 59); // Decreased by 1 toward 50
+    });
+
+    test('relation convergence: scores below 50 increase toward neutral', () {
+      var game = _baseGame().copyWith(
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'minor1',
+            score: 40, // Below 50, should increase
+            level: RelationLevel.neutral,
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      final orders = Orders(diplomaticOrdersByPlayerId: {});
+      
+      final after = resolveDiplomacyPhase(game, orders).game;
+      final rel = getRelation(after, 'gp1', 'minor1')!;
+      expect(rel.score, 41); // Increased by 1 toward 50
+    });
+
+    test('war relations do not converge: scores stay fixed', () {
+      var game = _baseGame().copyWith(
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'minor1',
+            score: 20, // At war, score should stay at 20
+            level: RelationLevel.hostile,
+            state: RelationState.atWar,
+          ),
+        ],
+      );
+      final orders = Orders(diplomaticOrdersByPlayerId: {});
+      
+      final after = resolveDiplomacyPhase(game, orders).game;
+      final rel = getRelation(after, 'gp1', 'minor1')!;
+      expect(rel.score, 20); // Unchanged
+      expect(rel.atWar, isTrue);
+    });
+
+    test('war declaration resets both sides to score 20', () {
+      var game = _baseGame().copyWith(
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'minor1',
+            score: 80, // High score
+            level: RelationLevel.allied,
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      final orders = Orders(
+        diplomaticOrdersByPlayerId: {
+          'gp1': const [
+            DiplomaticOrder(
+              type: DiplomaticOrderType.declareWar,
+              targetFactionId: 'minor1',
+            ),
+          ],
+        },
+      );
+      
+      final after = resolveDiplomacyPhase(game, orders).game;
+      final rel = getRelation(after, 'gp1', 'minor1')!;
+      expect(rel.atWar, isTrue);
+      expect(rel.score, 20); // Reset to 20 (Hostile)
+      expect(rel.level, RelationLevel.hostile);
     });
 
     test('setSubsidy without consulate does not deduct treasury', () {

--- a/packages/colonizethis_models/lib/src/diplomacy.dart
+++ b/packages/colonizethis_models/lib/src/diplomacy.dart
@@ -211,3 +211,51 @@ enum InterventionChoice {
   doNothing,
   protest,
 }
+
+/// Ongoing subsidy from a GP to a Minor/Tribe. SPEC/game/diplomacy.md.
+/// Each turn: payer loses amount, relation improves.
+class SubsidyState {
+  const SubsidyState({
+    required this.payerId,
+    required this.targetId,
+    required this.amountPerTurn,
+  });
+
+  final String payerId;
+  final String targetId;
+  final int amountPerTurn;
+
+  SubsidyState copyWith({
+    String? payerId,
+    String? targetId,
+    int? amountPerTurn,
+  }) =>
+      SubsidyState(
+        payerId: payerId ?? this.payerId,
+        targetId: targetId ?? this.targetId,
+        amountPerTurn: amountPerTurn ?? this.amountPerTurn,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'payerId': payerId,
+        'targetId': targetId,
+        'amountPerTurn': amountPerTurn,
+      };
+
+  static SubsidyState fromJson(Map<String, dynamic> json) => SubsidyState(
+        payerId: json['payerId'] as String,
+        targetId: json['targetId'] as String,
+        amountPerTurn: json['amountPerTurn'] as int,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SubsidyState &&
+          payerId == other.payerId &&
+          targetId == other.targetId &&
+          amountPerTurn == other.amountPerTurn;
+
+  @override
+  int get hashCode => Object.hash(payerId, targetId, amountPerTurn);
+}

--- a/packages/colonizethis_models/lib/src/game.dart
+++ b/packages/colonizethis_models/lib/src/game.dart
@@ -77,6 +77,7 @@ class Game {
     this.combatModeByProvinceId = const {},
     this.diplomacyRelations = const [],
     this.overtureStates = const [],
+    this.subsidyStates = const [],
     this.aiControlByGpId = const {},
     this.aiSeedByGpId = const {},
     this.hiddenAgendaByGpId = const {},
@@ -110,6 +111,9 @@ class Game {
 
   /// Overture state per Minor/Tribe per GP. Phase 4.
   final List<OvertureState> overtureStates;
+
+  /// Active ongoing subsidies (payer -> target with amount per turn). Phase 4.
+  final List<SubsidyState> subsidyStates;
 
   /// AI control: true = AI-controlled. When empty, use !player.isHuman. Phase 4.
   final Map<String, bool> aiControlByGpId;
@@ -152,6 +156,8 @@ class Game {
           'diplomacyRelations': diplomacyRelations.map((r) => r.toJson()).toList(),
         if (overtureStates.isNotEmpty)
           'overtureStates': overtureStates.map((o) => o.toJson()).toList(),
+        if (subsidyStates.isNotEmpty)
+          'subsidyStates': subsidyStates.map((s) => s.toJson()).toList(),
         if (aiControlByGpId.isNotEmpty) 'aiControlByGpId': aiControlByGpId,
         if (aiSeedByGpId.isNotEmpty) 'aiSeedByGpId': aiSeedByGpId,
         if (hiddenAgendaByGpId.isNotEmpty) 'hiddenAgendaByGpId': hiddenAgendaByGpId,
@@ -184,6 +190,10 @@ class Game {
     final overtureList = json['overtureStates'] as List<dynamic>? ?? [];
     final overtureStates = overtureList
         .map((e) => OvertureState.fromJson(Map<String, dynamic>.from(e as Map)))
+        .toList();
+    final subsidyList = json['subsidyStates'] as List<dynamic>? ?? [];
+    final subsidyStates = subsidyList
+        .map((e) => SubsidyState.fromJson(Map<String, dynamic>.from(e as Map)))
         .toList();
 
     final aiControlRaw = json['aiControlByGpId'] as Map<dynamic, dynamic>? ?? {};
@@ -240,6 +250,7 @@ class Game {
       combatModeByProvinceId: combatModeByProvinceId,
       diplomacyRelations: diplomacyRelations,
       overtureStates: overtureStates,
+      subsidyStates: subsidyStates,
       aiControlByGpId: aiControlByGpId,
       aiSeedByGpId: aiSeedByGpId,
       hiddenAgendaByGpId: hiddenAgendaByGpId,
@@ -267,6 +278,7 @@ class Game {
     Map<String, CombatMode>? combatModeByProvinceId,
     List<DiplomacyRelation>? diplomacyRelations,
     List<OvertureState>? overtureStates,
+    List<SubsidyState>? subsidyStates,
     Map<String, bool>? aiControlByGpId,
     Map<String, int>? aiSeedByGpId,
     Map<String, String>? hiddenAgendaByGpId,
@@ -288,6 +300,7 @@ class Game {
       combatModeByProvinceId: combatModeByProvinceId ?? this.combatModeByProvinceId,
       diplomacyRelations: diplomacyRelations ?? this.diplomacyRelations,
       overtureStates: overtureStates ?? this.overtureStates,
+      subsidyStates: subsidyStates ?? this.subsidyStates,
       aiControlByGpId: aiControlByGpId ?? this.aiControlByGpId,
       aiSeedByGpId: aiSeedByGpId ?? this.aiSeedByGpId,
       hiddenAgendaByGpId: hiddenAgendaByGpId ?? this.hiddenAgendaByGpId,
@@ -315,6 +328,7 @@ class Game {
           _mapEquals(combatModeByProvinceId, other.combatModeByProvinceId) &&
           _listEquals(diplomacyRelations, other.diplomacyRelations) &&
           _listEquals(overtureStates, other.overtureStates) &&
+          _listEquals(subsidyStates, other.subsidyStates) &&
           _mapEquals(aiControlByGpId, other.aiControlByGpId) &&
           _mapEquals(aiSeedByGpId, other.aiSeedByGpId) &&
           _mapEquals(hiddenAgendaByGpId, other.hiddenAgendaByGpId) &&
@@ -337,6 +351,7 @@ class Game {
         Object.hashAll(combatModeByProvinceId.entries),
         Object.hashAll(diplomacyRelations),
         Object.hashAll(overtureStates),
+        Object.hashAll(subsidyStates),
         Object.hashAll(aiControlByGpId.entries),
         Object.hashAll(aiSeedByGpId.entries),
         Object.hashAll(hiddenAgendaByGpId.entries),


### PR DESCRIPTION
## Summary

Implements proper ongoing subsidy mechanics per SPEC clarification.

## Changes

- Subsidies are now ongoing payments (stored in subsidyStates)
- Each turn: payer loses treasury, relation improves
- Relation boost: +2 per 500 ducats, max +8 per turn
- Relations converge +/-1 toward 50 (neutral) each turn
- War declaration resets both sides to score 20 (Hostile)
- Subsidies cancelled when war declared or funds insufficient
- War relations don't converge (scores frozen)

## Model Changes

- Added SubsidyState class to track ongoing subsidies
- Added subsidyStates list to Game model
- Full JSON serialization support

## Resolver Changes

- Modified setSubsidy to create ongoing subsidy entry
- Added _processOngoingSubsidies for turn-by-turn processing
- Added _applyRelationConvergence for neutral drift
- Updated war declaration to reset scores and cancel subsidies

## Testing

- Set subsidy: creates ongoing payment record
- Turn resolution: deducts payment, applies relation boost
- War declaration: resets both factions to score 20
- Convergence: scores drift toward 50 each turn

Fixes waigore/colonizethisv3#961