### PR TITLE
fix(#979): Regional faction discovery - same-region relations only

### DIFF
--- a/SPEC/game/diplomacy.md
+++ b/SPEC/game/diplomacy.md
@@ -86,6 +86,13 @@ The following Given–When–Then criteria are testable conditions for diplomacy
   When the system initializes diplomatic relations at turn index 0  
   Then the system sets each unordered Great Power pair to relation state `AT_PEACE`, relation score `50`, relation level `Neutral`, and records `sinceTurn = 0` and `lastInteractionTurn = 0`.
 
+- Given a new game has started with Great Powers, Minor Nations, and Tribes  
+  When the system initializes diplomatic relations at turn index 0  
+  Then the system sets diplomatic relations **only between factions in the same region**:
+  - Old World: all pairs among Great Powers and Minor Nations (GP↔GP, GP↔Minor, Minor↔Minor) at `AT_PEACE`, score `50`
+  - New World: all pairs among Tribes (Tribe↔Tribe) at `AT_PEACE`, score `50`
+  - Cross-region pairs (GP/Minor ↔ Tribe) are **not initialized** (undiscovered/unknown)
+
 - Given the Player is a Great Power at relation state `AT_PEACE` with a target Great Power and the current turn index is an integer `t ≥ 0`  
   When the Player issues a `Declare War` diplomatic order targeting that Great Power in the Diplomacy phase of turn `t` and the order is valid  
   Then the system changes the relation state between the two Great Powers to `AT_WAR` with `sinceTurn = t`, updates `lastInteractionTurn = t`, and uses this `AT_WAR` state for all Movement and Combat validation during turn `t`.

--- a/packages/colonizethis_logic/lib/src/setup/game_setup.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup.dart
@@ -171,14 +171,32 @@ GameSetupResult createGameFromGeneratedMaps({
       Tribe(id: tribeIds[i], displayName: 'Tribe ${i + 1}'),
   ];
 
-  // Initial GP–GP relations per SPEC/game/diplomacy.md: all Great Powers
-  // start at peace with neutral relations and turn index 0 metadata.
+  // Initial diplomatic relations per SPEC/game/diplomacy.md:
+  // - All factions start at peace with neutral relations within the SAME region
+  // - Cross-region relations (Old World vs New World) are undiscovered at game start
+  // - This means: GP↔GP, GP↔Minor, Minor↔Minor (Old World); Tribe↔Tribe (New World)
+  final allOldWorldIds = [...gpIds, ...minorIds];
+  final allNewWorldIds = [...tribeIds];
+  
   final diplomacyRelations = <DiplomacyRelation>[
-    for (var i = 0; i < players.length; i++)
-      for (var j = i + 1; j < players.length; j++)
+    // Old World: GP ↔ GP, GP ↔ Minor, Minor ↔ Minor
+    for (var i = 0; i < allOldWorldIds.length; i++)
+      for (var j = i + 1; j < allOldWorldIds.length; j++)
         DiplomacyRelation(
-          factionId1: players[i].id,
-          factionId2: players[j].id,
+          factionId1: allOldWorldIds[i],
+          factionId2: allOldWorldIds[j],
+          score: 50,
+          level: RelationLevel.neutral,
+          state: RelationState.atPeace,
+          sinceTurn: 0,
+          lastInteractionTurn: 0,
+        ),
+    // New World: Tribe ↔ Tribe only
+    for (var i = 0; i < allNewWorldIds.length; i++)
+      for (var j = i + 1; j < allNewWorldIds.length; j++)
+        DiplomacyRelation(
+          factionId1: allNewWorldIds[i],
+          factionId2: allNewWorldIds[j],
           score: 50,
           level: RelationLevel.neutral,
           state: RelationState.atPeace,

--- a/packages/colonizethis_logic/test/game_setup_test.dart
+++ b/packages/colonizethis_logic/test/game_setup_test.dart
@@ -641,5 +641,83 @@ void main() {
         expect(p.displayName!.isNotEmpty, isTrue, reason: 'tribe11 fallback must produce non-empty name');
       }
     });
+
+    test('regional faction discovery - same-region relations initialized, cross-region undiscovered', () {
+      // OW: 2 provinces for 1 GP, 1 Minor
+      final owTopology = MapTopology(
+        nodes: const [
+          TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(id: 'p2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 'p3', regionId: 'oldWorld', type: TopologyNodeType.province),
+        ],
+        edges: const [
+          TopologyEdge(id1: 'p2', id2: 'p1'),
+          TopologyEdge(id1: 'p2', id2: 'p3'),
+        ],
+      );
+      final owTileMap = TileMapResult(
+        width: 2,
+        height: 2,
+        grid: const [
+          ['p2', 'p3'],
+          ['p1', 'p1'],
+        ],
+      );
+
+      // NW: 1 province for 1 Tribe
+      final nwTopology = MapTopology(
+        nodes: const [
+          TopologyNode(id: 'nw1', regionId: 'newWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(id: 'nw2', regionId: 'newWorld', type: TopologyNodeType.province),
+        ],
+        edges: const [TopologyEdge(id1: 'nw2', id2: 'nw1')],
+      );
+      final nwTileMap = TileMapResult(
+        width: 1,
+        height: 2,
+        grid: const [
+          ['nw2'],
+          ['nw1'],
+        ],
+      );
+
+      final config = GameSetupConfig(
+        selectedGreatPowerIds: ['england'],
+        continentCount: 1,
+        minorNationCount: 1,
+        tribeCount: 1,
+        numProvincesOldWorld: 2,
+        numProvincesNewWorld: 1,
+        minProvincesPerMinor: 0,
+      );
+
+      final result = createGameFromGeneratedMaps(
+        config: config,
+        tileMapOldWorld: owTileMap,
+        topologyOldWorld: owTopology,
+        tileMapNewWorld: nwTileMap,
+        topologyNewWorld: nwTopology,
+        gameId: 'regional-discovery',
+      );
+
+      // Old World pairs should have relations initialized
+      // gp1-minor1 (OW-OW) should have a relation
+      final owRelation = result.game.diplomacyRelations.firstWhere(
+        (r) => (r.factionId1 == 'gp1' && r.factionId2 == 'minor1') ||
+               (r.factionId1 == 'minor1' && r.factionId2 == 'gp1'),
+        orElse: () => throw Exception('GP-Minor relation not found'),
+      );
+      expect(owRelation.state, RelationState.atPeace);
+      expect(owRelation.score, 50);
+
+      // Cross-region pairs should be absent (undiscovered)
+      final crossRelationCount = result.game.diplomacyRelations.where(
+        (r) => (r.factionId1 == 'gp1' && r.factionId2 == 'tribe1') ||
+               (r.factionId2 == 'gp1' && r.factionId1 == 'tribe1') ||
+               (r.factionId1 == 'minor1' && r.factionId2 == 'tribe1') ||
+               (r.factionId2 == 'minor1' && r.factionId1 == 'tribe1'),
+      ).length;
+      expect(crossRelationCount, 0, reason: 'No cross-region relations should exist');
+    });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #979 - Factions only discover other factions in the same region at game start.

## Changes

### Implementation
- Old World: Initialize diplomatic relations between all pairs (GP↔GP, GP↔Minor, Minor↔Minor)
- New World: Initialize diplomatic relations between all Tribe↔Tribe pairs
- Cross-region pairs (GP/Minor ↔ Tribe): **Not initialized** (undiscovered/unknown)

### SPEC Update
- Added acceptance criterion in diplomacy.md documenting regional discovery rules

## Testing
- All 9 game setup tests pass
- Creates expected same-region initial relations
- Cross-region relations return NULL (undiscovered)

## Acceptance Criteria Added

> Given a new game has started with Great Powers, Minor Nations, and Tribes
> When the system initializes diplomatic relations at turn index 0
> Then the system sets diplomatic relations **only between factions in the same region**

Fixes waigore/colonizethisv3#979