### PR TITLE
feat: military/naval buildability tests and ship tech gating

### DIFF
--- a/packages/colonizethis_data/lib/src/tech_extraction.dart
+++ b/packages/colonizethis_data/lib/src/tech_extraction.dart
@@ -28,7 +28,7 @@ const List<String> techIds = [
 const int defaultExtractionCap = 4;
 
 /// Simple tech definition used by the MVP tech catalog.
-/// Effects: regimentUnlockIds = regiment types this tech unlocks (buildability).
+/// Effects: regimentUnlockIds / shipUnlockIds = unit types this tech unlocks (buildability).
 class TechDefinition {
   const TechDefinition({
     required this.id,
@@ -37,6 +37,7 @@ class TechDefinition {
     required this.cost,
     this.prerequisiteIds = const [],
     this.regimentUnlockIds = const [],
+    this.shipUnlockIds = const [],
   });
 
   final String id;
@@ -46,6 +47,8 @@ class TechDefinition {
   final List<String> prerequisiteIds;
   /// Regiment ids this tech unlocks. SPEC/game/tech-tree-military.md.
   final List<String> regimentUnlockIds;
+  /// Ship type ids this tech unlocks. SPEC/game/tech-tree-naval.md.
+  final List<String> shipUnlockIds;
 }
 
 /// Minimal tech catalog backing extraction and research for Phase 5.
@@ -162,6 +165,14 @@ const Map<String, TechDefinition> techCatalog = {
     cost: 200,
     prerequisiteIds: const [],
   ),
+  // Naval (SPEC/game/tech-tree-naval.md). Fluytes require Superior Hull Design; carrack is baseline (no tech).
+  'superior_hull_design': TechDefinition(
+    id: 'superior_hull_design',
+    era: 1,
+    category: 'naval',
+    cost: 100,
+    shipUnlockIds: ['fluyte'],
+  ),
 };
 
 TechDefinition? techById(String id) => techCatalog[id];
@@ -205,6 +216,18 @@ Map<String, String> get unlockingTechByRegimentId {
   for (final t in techCatalog.values) {
     for (final rid in t.regimentUnlockIds) {
       m[rid] = t.id;
+    }
+  }
+  return m;
+}
+
+/// Ship type id -> tech id that unlocks it. Derived from catalog. Absent = buildable without tech (e.g. carrack).
+/// SPEC/game/tech-tree-naval.md.
+Map<String, String> get unlockingTechByShipId {
+  final m = <String, String>{};
+  for (final t in techCatalog.values) {
+    for (final sid in t.shipUnlockIds) {
+      m[sid] = t.id;
     }
   }
   return m;

--- a/packages/colonizethis_data/test/tech_extraction_test.dart
+++ b/packages/colonizethis_data/test/tech_extraction_test.dart
@@ -61,4 +61,13 @@ void main() {
       );
     });
   });
+
+  group('unlockingTechByShipId', () {
+    test('fluyte requires superior_hull_design', () {
+      expect(unlockingTechByShipId['fluyte'], 'superior_hull_design');
+    });
+    test('carrack has no unlocking tech (buildable from start)', () {
+      expect(unlockingTechByShipId['carrack'], isNull);
+    });
+  });
 }

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -580,6 +580,13 @@ class OrderEngine {
                 status: OrderValidationStatus.rejected,
                 reason: 'Insufficient resources');
           }
+          final shipUnlockTech = unlockingTechByShipId[o.unitType];
+          if (shipUnlockTech != null &&
+              (player.techUnlocked?[shipUnlockTech] != true)) {
+            return const OrderValidationResult(
+                status: OrderValidationStatus.rejected,
+                reason: 'Insufficient tech');
+          }
           if (treasury < shipEcon.buildTreasuryCost) {
             return const OrderValidationResult(
                 status: OrderValidationStatus.rejected,

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -393,6 +393,11 @@ Game applyBuildAndWorkOrders(
       } else if (category == BuildUnitCategory.naval) {
         final shipEcon = ShipEconomyCatalog.byId[order.unitType];
         if (shipEcon == null) continue;
+        final shipUnlockTechId = unlockingTechByShipId[order.unitType];
+        if (shipUnlockTechId != null &&
+            (player.techUnlocked?[shipUnlockTechId] != true)) {
+          continue;
+        }
         final capProvinceId = player.capitalProvinceId;
         if (capProvinceId == null) continue;
         if (treasury < shipEcon.buildTreasuryCost) continue;

--- a/packages/colonizethis_logic/lib/src/setup/game_setup.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup.dart
@@ -965,7 +965,7 @@ String _startingShipTypeForPlayer(Player player) {
 
   for (final entry in ShipEconomyCatalog.all) {
     final typeId = entry.shipTypeId;
-    final requiredTech = _unlockingTechForShip(typeId);
+    final requiredTech = unlockingTechByShipId[typeId];
     if (requiredTech != null && !hasTech(requiredTech)) {
       continue;
     }
@@ -978,15 +978,6 @@ String _startingShipTypeForPlayer(Player player) {
 
   // Fallback: baseline carrack if nothing matched.
   return bestTypeId ?? ShipEconomyCatalog.carrack.shipTypeId;
-}
-
-String? _unlockingTechForShip(String shipTypeId) {
-  switch (shipTypeId) {
-    case 'fluyte':
-      return 'superior_hull_design';
-    default:
-      return null;
-  }
 }
 
 /// Builds a map of province id -> neighbouring province ids using only P–P edges.

--- a/packages/colonizethis_logic/test/orders_application_test.dart
+++ b/packages/colonizethis_logic/test/orders_application_test.dart
@@ -163,6 +163,7 @@ void main() {
         stockpile: const Stockpile(),
         workerPool: const WorkerPool(peasants: 0),
         treasury: 100,
+        techUnlocked: {'superior_hull_design': true},
       );
       final world = WorldState(
         turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
@@ -229,6 +230,7 @@ void main() {
         capitalProvinceId: '$ow|P1',
         stockpile: stockpile,
         treasury: shipEcon.buildTreasuryCost * 2 + 10,
+        techUnlocked: {'superior_hull_design': true},
       );
       final world = WorldState(
         turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
@@ -2123,6 +2125,64 @@ void main() {
       expect(next.worldState.oldWorld.units, isEmpty);
     });
 
+    test('skips ship build when tech not unlocked', () {
+      const shipTypeId = 'fluyte';
+      final shipEcon = ShipEconomyCatalog.byId[shipTypeId];
+      if (shipEcon == null ||
+          unlockingTechByShipId[shipTypeId] == null) return;
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(
+              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(
+              id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+        ],
+        edges: const [TopologyEdge(id1: 'P1', id2: 'sea1')],
+      );
+      var stockpile = const Stockpile();
+      for (final e in shipEcon.buildInputs.entries) {
+        stockpile = stockpile.applyDelta(e.key, e.value + 1);
+      }
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(id: 'oldWorld|P1', regionId: 'oldWorld', ownerId: 'p1')
+            ],
+            units: [],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: [
+          Player(
+            id: 'p1',
+            displayName: 'P1',
+            isHuman: true,
+            capitalProvinceId: 'oldWorld|P1',
+            stockpile: stockpile,
+            treasury: shipEcon.buildTreasuryCost + 10,
+            techUnlocked: {}, // fluyte requires superior_hull_design
+          ),
+        ],
+      );
+      final orders = Orders(
+        buildUnitOrdersByPlayerId: {
+          'p1': [
+            BuildUnitOrder(
+              unitType: shipTypeId,
+              isMilitary: buildUnitCategoryForUnitType(shipTypeId) ==
+                  BuildUnitCategory.military,
+              spawnProvinceId: 'oldWorld|P1',
+            ),
+          ],
+        },
+      );
+      final next = applyBuildAndWorkOrders(game, orders, topology: topology);
+      expect(next.worldState.fleets, isEmpty);
+    });
+
     test('ship build with topology null does not add fleet', () {
       final shipEcon = ShipEconomyCatalog.byId['fluyte']!;
       var stockpile = const Stockpile();
@@ -2137,6 +2197,7 @@ void main() {
         stockpile: stockpile,
         workerPool: const WorkerPool(peasants: 0),
         treasury: shipEcon.buildTreasuryCost + 10,
+        techUnlocked: {'superior_hull_design': true},
       );
       final game = Game(
         id: 'g',
@@ -2191,6 +2252,7 @@ void main() {
         stockpile: stockpile,
         workerPool: const WorkerPool(peasants: 0),
         treasury: shipEcon.buildTreasuryCost + 10,
+        techUnlocked: {'superior_hull_design': true},
       );
       final game = Game(
         id: 'g',
@@ -2245,6 +2307,7 @@ void main() {
         stockpile: stockpile,
         workerPool: const WorkerPool(peasants: 0),
         treasury: shipEcon.buildTreasuryCost + 10,
+        techUnlocked: {'superior_hull_design': true},
       );
       final game = Game(
         id: 'g',

--- a/tool/sim_scenarios/lib/scenario.dart
+++ b/tool/sim_scenarios/lib/scenario.dart
@@ -276,6 +276,7 @@ class Assertion {
     this.victoryWinner,
     this.victoryType,
     this.victoryTurn,
+    this.fleetShipCount,
   });
 
   /// Which turn to check (null = final state)
@@ -384,6 +385,9 @@ class Assertion {
   final String? victoryWinner;
   final String? victoryType;
   final int? victoryTurn;
+
+  /// Fleet ship count (SPEC/game/ships-and-naval.md). With [player]: total ships in that player's fleets (sum of shipTypeIds.length). Use [matchType] for atLeast/atMost/exact.
+  final int? fleetShipCount;
 }
 
 /// Type of value matching for assertions.
@@ -683,6 +687,7 @@ Assertion _parseAssertion(Map<String, dynamic> json) {
     victoryWinner: json['victoryWinner'] as String?,
     victoryType: json['victoryType'] as String?,
     victoryTurn: json['victoryTurn'] as int?,
+    fleetShipCount: json['fleetShipCount'] as int?,
   );
 }
 

--- a/tool/sim_scenarios/lib/state_verifier.dart
+++ b/tool/sim_scenarios/lib/state_verifier.dart
@@ -295,6 +295,25 @@ class StateVerifier {
         }
       }
 
+      // Fleet ship count (SPEC/game/ships-and-naval.md): total ships in this player's fleets
+      if (assertion.fleetShipCount != null) {
+        final totalShips = game.worldState.fleets
+            .where((f) => f.ownerId == assertion.player)
+            .fold<int>(0, (n, f) => n + f.shipTypeIds.length);
+        final matchResult = _matchCount(
+          totalShips,
+          assertion.fleetShipCount!,
+          assertion.matchType,
+          assertion.matchMin,
+          assertion.matchMax,
+        );
+        if (!matchResult.passed) {
+          failures.add(
+            'Player ${assertion.player} fleet ship count: ${matchResult.message}',
+          );
+        }
+      }
+
       // Worker pool assertions (SPEC/game/workers-and-population.md)
       if (assertion.workerPeasants != null) {
         if (player.workerPool.peasants != assertion.workerPeasants) {

--- a/tool/sim_scenarios/test/military_units_buildability_test.dart
+++ b/tool/sim_scenarios/test/military_units_buildability_test.dart
@@ -3,10 +3,10 @@
 // For each regiment we run a scenario with the same shape as military_units_buildability.json:
 // grant unlocking tech (if any), workers and stockpile, one build order, assert unit count >= 6.
 
+import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:sim_scenarios/scenario.dart';
 import 'package:sim_scenarios/scenario_runner.dart';
-import 'package:test/test.dart';
 
 void main() {
   group('military units buildability', () {

--- a/tool/sim_scenarios/test/military_units_buildability_test.dart
+++ b/tool/sim_scenarios/test/military_units_buildability_test.dart
@@ -1,0 +1,115 @@
+// Test that every military unit in the game can be built in a normal game.
+// SPEC/game/military-units.md: regiment buildable iff unlocking tech in techUnlocked.
+// For each regiment we run a scenario with the same shape as military_units_buildability.json:
+// grant unlocking tech (if any), workers and stockpile, one build order, assert unit count >= 6.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:sim_scenarios/scenario.dart';
+import 'package:sim_scenarios/scenario_runner.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('military units buildability', () {
+    test('every military unit can be built when tech and resources are available',
+        () async {
+      const capitalProvinceId = 'oldWorld|p1';
+      const playerId = 'gp1';
+
+      // Same assertion as military_units_buildability.json: 5 starting military + 1 built => >= 6.
+      const minUnitCountAfterBuild = 6;
+
+      final unlockMap = unlockingTechByRegimentId;
+      final runner = ScenarioRunner();
+      final failures = <String>[];
+
+      for (final econ in RegimentEconomyCatalog.all) {
+        final regimentId = econ.id;
+        final initialTech = unlockMap[regimentId] != null
+            ? [unlockMap[regimentId]!]
+            : <String>[];
+
+        final stockpile = <String, int>{
+          for (final e in econ.buildInputs.entries) e.key.toString(): e.value,
+          'grain': 5,
+        };
+
+        // Build scenario as JSON (same shape as military_units_buildability.json) then parse.
+        final setup = <String, dynamic>{
+          'initialWorkers': {
+            playerId: {
+              'peasants': 1,
+              'apprentices': 0,
+              'journeymen': 0,
+              'masters': 0,
+            },
+          },
+          'initialStockpile': {playerId: stockpile},
+        };
+        if (initialTech.isNotEmpty) {
+          setup['initialTech'] = {playerId: initialTech};
+        }
+
+        final json = <String, dynamic>{
+          'name': 'military_build_$regimentId',
+          'description':
+              'Build one $regimentId (tech: ${initialTech.isEmpty ? "none" : initialTech.join(",")}).',
+          'init': {
+            'type': 'fromTopology',
+            'config': {
+              'greatPowers': ['england'],
+              'seed': 42,
+              'minorNationCount': 0,
+            },
+            'oldWorld': {
+              'grid': [
+                ['p1', 'sea1']
+              ],
+              'nodes': [
+                {'id': 'p1', 'regionId': 'oldWorld', 'type': 'province'},
+                {'id': 'sea1', 'regionId': 'oldWorld', 'type': 'seaZone'},
+              ],
+              'edges': [
+                {'id1': 'p1', 'id2': 'sea1'},
+              ],
+            },
+          },
+          'setup': setup,
+          'turns': [
+            {
+              'turn': 1,
+              'orders': [
+                {
+                  'player': playerId,
+                  'type': 'build',
+                  'unitType': regimentId,
+                  'in': capitalProvinceId,
+                },
+              ],
+            },
+          ],
+          'assertions': [
+            {'turn': 1, 'province': capitalProvinceId, 'owner': playerId},
+            {
+              'turn': 1,
+              'province': capitalProvinceId,
+              'unitCount': minUnitCountAfterBuild,
+              'matchType': 'atLeast',
+            },
+          ],
+        };
+
+        final scenario = parseScenarioFromJson(json);
+        final result = await runner.run(scenario);
+        if (!result.passed) {
+          failures.add('$regimentId: ${result.failures.join("; ")}');
+        }
+      }
+
+      expect(
+        failures,
+        isEmpty,
+        reason: 'Regiments that failed to build: ${failures.join("\n")}',
+      );
+    });
+  });
+}

--- a/tool/sim_scenarios/test/naval_units_buildability_test.dart
+++ b/tool/sim_scenarios/test/naval_units_buildability_test.dart
@@ -3,10 +3,10 @@
 // when unlocking tech is required, player must have it in techUnlocked.
 // For each ship type we run a scenario: capital sea-bound, treasury and stockpile, one build order, assert fleet ship count increases.
 
+import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:sim_scenarios/scenario.dart';
 import 'package:sim_scenarios/scenario_runner.dart';
-import 'package:test/test.dart';
 
 void main() {
   group('naval units buildability', () {

--- a/tool/sim_scenarios/test/naval_units_buildability_test.dart
+++ b/tool/sim_scenarios/test/naval_units_buildability_test.dart
@@ -1,0 +1,107 @@
+// Test that every naval unit (ship) in the game can be built in a normal game.
+// SPEC/game/ships-and-naval.md, SPEC/game/tech-tree-naval.md: ship buildable with treasury and stockpile;
+// when unlocking tech is required, player must have it in techUnlocked.
+// For each ship type we run a scenario: capital sea-bound, treasury and stockpile, one build order, assert fleet ship count increases.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:sim_scenarios/scenario.dart';
+import 'package:sim_scenarios/scenario_runner.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('naval units buildability', () {
+    test('every naval unit can be built when resources are available', () async {
+      const capitalProvinceId = 'oldWorld|p1';
+      const playerId = 'gp1';
+
+      // Default fromTopology gives initialNavalShips: 3. After building one more => >= 4.
+      const minFleetShipCountAfterBuild = 4;
+
+      final runner = ScenarioRunner();
+      final failures = <String>[];
+
+      final unlockMap = unlockingTechByShipId;
+
+      for (final entry in ShipEconomyCatalog.all) {
+        final shipTypeId = entry.shipTypeId;
+        final initialTech = unlockMap[shipTypeId] != null
+            ? [unlockMap[shipTypeId]!]
+            : <String>[];
+
+        final stockpile = <String, int>{
+          for (final e in entry.buildInputs.entries) e.key.toString(): e.value,
+        };
+
+        // Build scenario as JSON. Naval build uses capital's sea zone; grant unlocking tech when required.
+        final setup = <String, dynamic>{
+          'initialStockpile': {playerId: stockpile},
+          'initialTreasury': {playerId: 500},
+        };
+        if (initialTech.isNotEmpty) {
+          setup['initialTech'] = {playerId: initialTech};
+        }
+
+        final json = <String, dynamic>{
+          'name': 'naval_build_$shipTypeId',
+          'description':
+              'Build one $shipTypeId (tech: ${initialTech.isEmpty ? "none" : initialTech.join(",")}).',
+          'init': {
+            'type': 'fromTopology',
+            'config': {
+              'greatPowers': ['england'],
+              'seed': 42,
+              'minorNationCount': 0,
+            },
+            'oldWorld': {
+              'grid': [
+                ['p1', 'sea1']
+              ],
+              'nodes': [
+                {'id': 'p1', 'regionId': 'oldWorld', 'type': 'province'},
+                {'id': 'sea1', 'regionId': 'oldWorld', 'type': 'seaZone'},
+              ],
+              'edges': [
+                {'id1': 'p1', 'id2': 'sea1'},
+              ],
+            },
+          },
+          'setup': setup,
+          'turns': [
+            {
+              'turn': 1,
+              'orders': [
+                {
+                  'player': playerId,
+                  'type': 'build',
+                  'unitType': shipTypeId,
+                  'in': capitalProvinceId,
+                },
+              ],
+            },
+          ],
+          'assertions': [
+            {'turn': 1, 'province': capitalProvinceId, 'owner': playerId},
+            {
+              'turn': 1,
+              'player': playerId,
+              'fleetShipCount': minFleetShipCountAfterBuild,
+              'matchType': 'atLeast',
+            },
+          ],
+        };
+
+        final scenario = parseScenarioFromJson(json);
+        final result = await runner.run(scenario);
+        if (!result.passed) {
+          failures.add('$shipTypeId: ${result.failures.join("; ")}');
+        }
+      }
+
+      expect(
+        failures,
+        isEmpty,
+        reason: 'Ship types that failed to build: ${failures.join("\n")}',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- **Buildability tests:** Every military unit and every naval unit can be built when tech and resources are available (sim_scenarios; one scenario per type, assert unit/fleet count).
- **Fleet assertion:** `fleetShipCount` assertion added to scenario + state_verifier for naval scenarios.
- **Ship tech gating:** Naval builds gated behind tech: `TechDefinition.shipUnlockIds`, `unlockingTechByShipId`, `superior_hull_design` for fluyte; carrack buildable from start. Order engine and orders_application reject/skip ship build when unlocking tech not in `techUnlocked`.
- **Reject reason:** Ship build rejected with reason `Insufficient tech` (not `Insufficient resources`) when tech is missing.
- **Game setup:** Starting ship choice uses `unlockingTechByShipId` from colonizethis_data (removed duplicate `_unlockingTechForShip`).
- **Tests:** orders_application fluyte tests grant `superior_hull_design`; added `skips ship build when tech not unlocked`; tech_extraction_test for `unlockingTechByShipId`.

Made with [Cursor](https://cursor.com)