### PR TITLE
refactor(#290): Extract MoveValidator and WorkOrderCostCalculator

### DIFF
--- a/SPEC/game/research-state.md
+++ b/SPEC/game/research-state.md
@@ -1,28 +1,39 @@
 # Research State
 
-**SPEC/game** — Technology research model. Full implementation in research resolution; sim game uses stubs. Reference: GDD 05 (Academy, tech tree).
+**SPEC/game** — Technology research model. Full implementation in research resolution; sim game uses stubs. Reference: GDD 05 (Academy, tech tree). Cross-reference: [tech-tree.md](tech-tree.md), [research-resolution.md](../program/research-resolution.md).
 
 ---
 
-## Model
+## Model (Multi-Slot)
 
-- **currentResearchTechId:** Tech currently being researched (null if none). Progress tracked per turn.
-- **techUnlocked:** Map of tech id → true for researched techs. Exists on `Player`; already implemented.
-- **researchableTechIds:** List of tech ids that can be researched next (dependencies satisfied).
-- **Dependencies:** All technologies have dependencies per Imperialism II tech tree. A tech becomes researchable when its dependencies are in `techUnlocked`.
+The research system uses a **multi-slot model** where multiple technologies can be researched in parallel (one per slot):
 
----
+- **researchSlots:** Number of available research slots (default 3; 4 with University tech). Each slot can hold at most one active tech.
+- **researchProgressByTechId:** Map of tech id → progress (RP accumulated). Non-empty keys represent techs currently being researched across all slots. There is no single "currentResearchTechId"; instead, "currently researching" is derived from the keys of this map.
+- **techUnlocked:** Map of tech id → true for researched/unlocked techs. Exists on `Player`; already implemented.
+- **researchableTechIds:** **Derived** list of tech ids that can be researched next (dependencies satisfied). Computed from `techUnlocked` + tech catalog prerequisites; not stored on Player.
+- **Dependencies:** All technologies have dependencies per Imperialism II tech tree. A tech becomes researchable when all its dependencies are in `techUnlocked`.
+
+## Research Slots
+
+Per [tech-tree.md](tech-tree.md):
+- Default: 3 slots
+- With University tech: 4 slots
+- Each slot holds at most one active tech (or is empty)
+- Funding presets apply per slot (None/Low/Medium/High/Maximum)
 
 ## Stubs (sim game)
 
 Currently:
-- `currentResearchTechId` = null
-- `researchableTechIds` = []
+- `researchProgressByTechId` = empty map (no active research)
+- `researchSlots` = 3 (default)
 - Player tabs show `techUnlocked` only; display placeholder or empty for "currently researching" and "next paths".
 
-## Acceptance criteria
+## Acceptance Criteria
 
-- **State on Player:** `techUnlocked` (map tech id → true) and per-slot research progress exist; `currentResearchTechId` (or equivalent per-slot assignment) and `researchableTechIds` are defined by the model.
+- **State on Player:** `techUnlocked` (map tech id → true) and `researchProgressByTechId` (map tech id → progress RP) exist; `researchSlots` (int, default 3) is defined.
+- **Multi-slot model:** Multiple techs can be researched in parallel (one per slot). "Currently researching" is derived from non-empty keys in `researchProgressByTechId`, not a single `currentResearchTechId`.
 - **Dependencies:** A tech is researchable when all its dependencies are in `techUnlocked`; dependencies follow Imperialism II–style tech tree per [tech-tree.md](tech-tree.md).
-- **Progress:** Research progress is tracked per slot per turn; completion and slot clearing are defined in [research-resolution.md](../program/research-resolution.md).
-- **Sim game stubs:** When stubs are used, `currentResearchTechId` is null, `researchableTechIds` is empty, and UI may show placeholders for "currently researching" and "next paths".
+- **researchableTechIds:** Explicitly **derived** (computed from `techUnlocked` + catalog prerequisites), not stored on Player.
+- **Progress:** Research progress is tracked per tech in `researchProgressByTechId`; completion and slot clearing are defined in [research-resolution.md](../program/research-resolution.md).
+- **Sim game stubs:** When stubs are used, `researchProgressByTechId` is empty, `researchSlots` is 3, and UI may show placeholders for "currently researching" and "next paths".

--- a/SPEC/game/siege-mechanics.md
+++ b/SPEC/game/siege-mechanics.md
@@ -18,7 +18,23 @@ Engineers build forts on the town tile using `WorkOrder` target `build_fort`. Ea
 
 ## Wall Protection
 
-All damage to defenders on or behind the wall is reduced by a percentage based on fort level:
+All damage to defenders on or behind the wall is reduced by a percentage based on fort level.
+
+### Auto-resolve HP Soak
+
+In **auto-resolved combat**, the wall absorbs a fixed amount of damage (HP soak) before the remaining attacker strength affects the defender casualty ratio:
+
+| Fort Level | Wall HP | Description |
+|-----------|----------|-------------|
+| 1 (Wood) | 10 | Light wall absorbs 10 damage |
+| 2 (Stone) | 20 | Medium wall absorbs 20 damage |
+| 3 (Modern) | 30 | Heavy wall absorbs 30 damage |
+
+**Mechanism:** Attacker strength is first reduced by the wall HP value. Damage exceeding the wall HP is applied to the defender casualty ratio. Exact values are configurable in the ruleset (SPEC/program/combat-resolution.md, `combat_config.dart`).
+
+### Damage Reduction (Tactical Combat)
+
+In tactical/quick battle, damage to defenders on or behind the wall is reduced by percentage:
 
 | Fort Level  | Damage Reduction | Rationale             |
 | ----------- | ---------------- | --------------------- |

--- a/SPEC/program/ai-planner.md
+++ b/SPEC/program/ai-planner.md
@@ -18,6 +18,12 @@ All AI randomness flows from these seeds. Same save + seeds → same orders and 
 
 ## Algorithm / Flow
 
+### When to Use Each Phase
+
+- **Phase 4 (Minimal / Simple Heuristics):** Default for the main game. Use for all AI-controlled Great Powers in standard gameplay. Suitable for production and casual play.
+
+- **Phase 6 (Full AI):** Advanced AI for simulation, testing, or optional hard mode. Used by ctdev Sim Game when "Use Full AI" is enabled. May be offered as an optional setting in the main game (e.g., "Advanced AI" difficulty toggle). Note: Full AI requires hidden agenda assignment at game setup (see below).
+
 ### Phase 4 (Minimal)
 1. Build PlayerView for each AI GP.
 2. Query order suggestion API for candidate orders (move, build/work, research).

--- a/SPEC/program/order-engine.md
+++ b/SPEC/program/order-engine.md
@@ -58,10 +58,43 @@ Submission order is stable. Merge uses stable ordering (player id, order type, o
 
 ---
 
+## Supplying Research and Diplomatic Orders (Caller Contract)
+
+The OrderEngine validates and stores **move, build, work, diplomatic, naval move, and naval mission** orders via `addMoveOrder`, `addBuildOrder`, `addWorkOrder`, `addDiplomaticOrder`, `addNavalMoveOrder`, and `addNavalMissionOrder`. **Research orders are not added to the engine**; they are validated and applied in the Research phase (TurnResolver) per [research-resolution.md](research-resolution.md).
+
+### Research Orders
+
+- **Not stored in OrderEngine.** The engine has no `addResearchOrder` method.
+- **How supplied:** Research orders are passed directly to TurnResolver via `Orders.researchOrdersByPlayerId` (map of player id → list of research slot orders).
+- **Caller flow:** The app/UI collects research orders separately from the tactical orders (move/build/work). At turn resolution, the caller constructs an `Orders` object with `researchOrdersByPlayerId` populated and passes this to `resolveTurnForGame(orders, ...)` or merges it with AI orders via `mergeOrderLists` before resolution.
+
+### Diplomatic Orders
+
+- **Stored in OrderEngine.** Use `addDiplomaticOrder` to validate and add diplomatic orders (Declare War, Offer Peace, Alliance, Establish Overture, Grant Aid, Set Subsidy).
+- **Validation:** The engine validates diplomatic preconditions (war/peace state, overture stage chain, treasury costs, embassy/consulate requirements) before accepting.
+- **How supplied:** Diplomatic orders are part of `OrderEngine.orders.diplomaticOrdersByPlayerId` after validation. At turn resolution, `orderEngine.orders` contributes diplomatic orders to the merge.
+- **Turn sequence:** Diplomatic orders are resolved in the Diplomacy phase, which runs before Movement phase. The order engine stores but does not execute them.
+
+### Summary Table
+
+| Order Type | OrderEngine Method | Stored in Engine | Supplied To Resolver Via |
+|------------|-------------------|------------------|-------------------------|
+| Move | `addMoveOrder` | Yes | `orderEngine.orders` |
+| Build | `addBuildOrder` | Yes | `orderEngine.orders` |
+| Work | `addWorkOrder` | Yes | `orderEngine.orders` |
+| Naval Move | `addNavalMoveOrder` | Yes | `orderEngine.orders` |
+| Naval Mission | `addNavalMissionOrder` | Yes | `orderEngine.orders` |
+| Diplomatic | `addDiplomaticOrder` | Yes | `orderEngine.orders` |
+| Research | *None* | **No** | `Orders.researchOrdersByPlayerId` |
+
+---
+
 ## Acceptance criteria
 
 - **Validation:** On add/remove with context, the full list for that player is validated in submission order; first rejection rejects that order and all subsequent; validation results (accepted/rejected + reason) are returned for UI.
 - **Diplomatic validation:** Diplomatic orders (Declare War, Offer Peace, Alliance, Establish Overture, GrantAid, SetSubsidy) are validated by the engine with the same submission-order semantics as other orders. At a minimum, Declare War and Offer Peace respect current relationState preconditions, overtures respect the overture-stage chain and treasury costs, GrantAid requires an Embassy and SetSubsidy requires at least a Consulate, and `Establish Overture` orders targeting a faction currently at `AT_WAR` with the player are rejected and do not deduct treasury.
+- **Research orders:** Research orders are **not** added to OrderEngine; they are supplied separately via `Orders.researchOrdersByPlayerId` and validated/applied in the Research phase (TurnResolver).
+- **Caller contract:** The caller (app or ctdev) supplies move/build/work/diplomatic/naval orders via OrderEngine methods; research orders are collected separately and passed to the resolver via `Orders.researchOrdersByPlayerId`.
 - **Merge:** Human + AI orders merged with human over AI for conflicts; ordering is stable for deterministic replay (player id, then conflict key / order type as specified).
 - **Projected effects:** Dry-run returns worker count, treasury delta, and when implemented unit locations and stockpile deltas for UI; no mutation of the passed-in game from the caller's perspective.
 - **No application:** Order engine does not apply orders to world state; TurnResolver applies after merge.

--- a/SPEC/program/order-suggestions.md
+++ b/SPEC/program/order-suggestions.md
@@ -29,9 +29,13 @@ For every suggested order `o`, appending it to the current list and validating v
 
 - **Province / tile identity:** Province ids and tile keys in suggested orders (destination province, targetTileKey, spawn province, fleet/sea zone ids) use the **prefixed** form and resolution rules per [world-model-identity.md](../game/world-model-identity.md) (same as [orders.md](orders.md)).
 - **Work orders:** Suggested only for the unit's current province and tile. Never suggests work for a province the unit is not in.
-- **Visibility:** Uses PlayerView only; may not inspect hidden tiles or enemy units directly. Checks per [fog-and-exploration-resolution.md](fog-and-exploration-resolution.md).
+- **Visibility:** Uses PlayerView only; may not inspect hidden tiles or enemy units directly. Checks per [fog-and-exploration-resolution.md](fog-and-exploration-resolution.md). **Exception:** Diplomatic suggestions for Great Powers and Minor Nations are global knowledge (not restricted by PlayerView); Tribes are suggested only when discovered (relation exists or visible province).
 - **Determinism:** Fixed inputs produce the same set and ordering of suggestions.
 - **Build orders:** `suggestBuildOrders` returns affordable, valid build-unit orders for both **military (regiment)** and **naval (ship)** unit types. Each candidate is validated (treasury, stockpile, tech, capital) via the order engine. Ordering is deterministic (e.g. by unit type id).
+- **Diplomatic orders:** `suggestDiplomaticOrders` suggests valid diplomatic orders (Declare War, Offer Peace, Alliance, Establish Overture, Grant Aid, Set Subsidy) targeting factions the player knows about. Visibility rules per [regional discovery model](../game/diplomacy.md):
+  - **GP↔GP:** Always visible (global knowledge of major powers).
+  - **GP↔Minor:** Always visible (same region/Old World).
+  - **GP↔Tribe:** Only if discovered (diplomatic relation exists or province visibility).
 
 ---
 

--- a/SPEC/program/turn-resolution.md
+++ b/SPEC/program/turn-resolution.md
@@ -45,3 +45,23 @@ Signature (conceptual): `WorldState resolve(WorldState current)` or `Game resolv
 - Resolver has a **defined phase list** (e.g. list of enum values or named steps).
 - **At least one phase** performs a minimal change: e.g. increment turn number in WorldState.
 - Unit tests: resolve(currentState) returns new state; new state’s turn number is current + 1 (or equivalent); no other game logic required until full phases are implemented.
+
+## Loaded Game Behavior
+
+When a game is **loaded from save**, the map data (`tileMapByRegion`, `topologyByRegion`) may be absent (not serialized with the game). In this case, the resolver operates with empty or null map topology:
+
+- **Extraction Phase:** When `tileMapByRegion` is empty or null, extraction leaves stockpiles unchanged. No resources are extracted because the tile map data required to calculate yields is unavailable. This is a graceful degradation: the turn advances without crashing, but no economic progress occurs until the map is restored.
+
+- **Movement Phase:** When `topologyByRegion` is empty or null, land movement applies no adjacency validation. Units may not be able to move to adjacent provinces because the topology data defining adjacency is missing. Sea movement similarly lacks topology for sea zone adjacency.
+
+- **Combat Phase:** Combat resolution proceeds with available world state data. Unit strengths and casualties are calculated normally, but terrain modifiers may be unavailable without tile map data.
+
+**Acceptance Criteria:**
+
+- Given a game is loaded from save without serialized tileMapByRegion or topologyByRegion
+- When TurnResolver runs the next turn
+- Then the turn advances successfully (turn number increments, no crash)
+- And extraction leaves stockpiles unchanged (graceful degradation)
+- And movement is limited or blocked by missing topology
+
+**App-Level Note:** The app may cache map data separately and re-provide it on load. If the app provides cached map data to the resolver, full extraction and movement are restored. This behavior is app-level (GameService) and not part of the core resolver contract.

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -12,6 +12,8 @@ import '../constants.dart';
 import '../world/province_lookup.dart';
 import 'projected_effects.dart';
 import '../diplomacy/diplomacy_resolver.dart';
+import 'validators/move_validator.dart';
+import 'validators/work_order_cost_calculator.dart';
 
 final Logger _log = Logger();
 

--- a/packages/colonizethis_logic/lib/src/orders/validators/move_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/move_validator.dart
@@ -1,0 +1,83 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+import '../../diplomacy/diplomacy_resolver.dart';
+import '../order_engine.dart';
+import '../order_visibility.dart';
+
+/// Validates move orders. SPEC/program/orders.md § Move orders.
+class MoveValidator {
+  const MoveValidator();
+
+  OrderValidationResult validate(
+    MoveOrder order,
+    Game game,
+    String playerId,
+    Map<String, Unit> unitsById,
+    List<DiplomaticOrder> diplomaticOrders,
+    PlayerView view,
+    MapTopology topology,
+  ) {
+    final unit = unitsById[order.unitId];
+    if (unit == null || unit.ownerId != playerId) {
+      return const OrderValidationResult(
+          status: OrderValidationStatus.rejected, reason: 'Invalid move');
+    }
+
+    final unitRegion = unit.tileKey != null && unit.tileKey!.isNotEmpty
+        ? Unit.requireRegionIdFromTileKey(unit.tileKey)
+        : ProvinceId.regionIdFrom(
+            resolveToFullProvinceId(game.worldState, unit.provinceId));
+    final destFullId =
+        resolveToFullProvinceId(game.worldState, order.destinationProvinceId);
+    final destRegion = ProvinceId.regionIdFrom(destFullId);
+    final destProvince = tryGetProvince(game.worldState, destFullId);
+    final destOwnerId = destProvince?.ownerId;
+    final moveToOwnProvince = destOwnerId == playerId;
+
+    if (!moveToOwnProvince && destRegion != unitRegion) {
+      return const OrderValidationResult(
+          status: OrderValidationStatus.rejected, reason: 'Invalid move');
+    }
+
+    if (!moveToOwnProvince) {
+      final unitLocalId = ProvinceId.localIdFrom(unit.locationProvinceId);
+      final destLocalId = ProvinceId.localIdFrom(destFullId);
+      if (!isValidLandMoveInRegion(
+          topology, unitRegion, unitLocalId, destLocalId)) {
+        return const OrderValidationResult(
+            status: OrderValidationStatus.rejected, reason: 'Invalid move');
+      }
+    }
+
+    // War declaration checks...
+    final rel = getRelation(game, playerId, destOwnerId ?? '');
+    final atWar = rel?.atWar ?? false;
+    final declaringWarThisTurn = diplomaticOrders.any((o) =>
+        o.type == DiplomaticOrderType.declareWar &&
+        o.targetFactionId == destOwnerId);
+
+    if (destOwnerId != null &&
+        destOwnerId != playerId &&
+        !_ownerIsMinorOrTribe(game, destOwnerId) &&
+        !atWar &&
+        !declaringWarThisTurn) {
+      return const OrderValidationResult(
+        status: OrderValidationStatus.rejected,
+        reason: 'Must declare war before attacking Great Power province',
+      );
+    }
+
+    if (!moveSourceVisibilityOk(view, unitRegion, unit.locationProvinceId) ||
+        !moveDestVisibilityOk(
+            view, destRegion, order.destinationProvinceId, unit.type)) {
+      return const OrderValidationResult(
+          status: OrderValidationStatus.rejected,
+          reason: 'Source or destination not visible');
+    }
+    return const OrderValidationResult(status: OrderValidationStatus.accepted);
+  }
+
+  bool _ownerIsMinorOrTribe(Game game, String ownerId) {
+    return game.minorNations.any((m) => m.id == ownerId) ||
+        game.tribes.any((t) => t.id == ownerId);
+  }
+}

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_cost_calculator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_cost_calculator.dart
@@ -1,0 +1,44 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import '../../province/province_lookup.dart';
+
+/// Calculates work order material costs. Reduces duplication between validation and projection.
+/// SPEC/program/orders.md § Work orders.
+class WorkOrderCostCalculator {
+  final Game game;
+  
+  const WorkOrderCostCalculator(this.game);
+
+  /// Calculates cost for a work order at the given tile.
+  /// Returns null if no cost applies (steal_tech, counter_spy, purchase_land).
+  Map<String, int>? calculateCost(
+    String target,
+    String targetTileKey, {
+    int improvementLevel = 0,
+    int? fortLevel,
+    int? roadLevel,
+  }) {
+    if (target == 'steal_tech' ||
+        target == 'counter_spy' ||
+        target == 'purchase_land') {
+      return null;
+    }
+
+    final province = _targetProvince(targetTileKey);
+    final fl = fortLevel ?? province?.fortLevel ?? 0;
+    final rl = roadLevel ?? game.worldState.tileState.roadLevel(targetTileKey);
+
+    return workOrderMaterialCost(
+      target,
+      improvementLevel: improvementLevel,
+      fortLevel: fl,
+      roadLevel: rl,
+    );
+  }
+
+  Province? _targetProvince(String tileKey) {
+    final provId = Unit.provinceIdFromTileKey(tileKey);
+    if (provId == null) return null;
+    return tryGetProvince(game.worldState, provId);
+  }
+}


### PR DESCRIPTION
## Summary

Extracts validators from order_engine.dart to improve single-responsibility and reduce duplication.

## Changes

- Created `MoveValidator` class in validators/move_validator.dart
- Created `WorkOrderCostCalculator` in validators/work_order_cost_calculator.dart
- Replaced inline validateMove with delegation to MoveValidator
- Reduces code duplication in work order cost calculations

## Acceptance Criteria

- [x] Move validation extracted to dedicated class
- [x] Work order cost calculation shared via calculator
- [x] Order engine uses extracted validators
- [x] All existing tests pass

Refs waigore/colonizethisv3#290