### PR TITLE
refactor(#290)+docs(#288): MoveValidator, WorkOrderCostCalculator, SPEC alignment (subsumes #984, #987)

### DIFF
--- a/SPEC/program/order-engine.md
+++ b/SPEC/program/order-engine.md
@@ -22,6 +22,16 @@ The order engine (colonizethis_logic) maintains the **current-turn order list pe
 
 Returns validation results (accepted / rejected with reason) for UI feedback.
 
+### Validation components
+
+Move and work-order validation are delegated to dedicated components for single-responsibility and reuse:
+
+- **MoveValidator** (`validators/move_validator.dart`): Validates move orders per [orders.md](orders.md) § Move orders. Checks unit ownership, region/adjacency, civilian vs Great Power (Spy allowed), civilian vs Minor/Tribe (Explorer/Merchant/Spy allowed), war declaration for GP provinces, war declaration for military into Minor/Tribe provinces, and visibility. Used by OrderEngine in `validatePlayerOrdersWithContext` when validating move orders.
+
+- **WorkOrderCostCalculator** (`validators/work_order_cost_calculator.dart`): Computes work order material costs for a given target and tile (improvement/fort/road level). Returns null for steal_tech, counter_spy, purchase_land. Used by OrderEngine for work-order cost validation and for projecting work-order costs in the same validation pass.
+
+**Build validation (naval):** Build orders for naval units are validated for treasury, stockpile, and the **unlocking tech** for that ship type when applicable (see [tech-tree-naval.md](../game/tech-tree-naval.md)); starting ships such as Carrack have no prerequisite. OrderEngine validates before accepting.
+
 ---
 
 ## Per-Player Scope
@@ -98,6 +108,8 @@ The OrderEngine validates and stores **move, build, work, diplomatic, naval move
 - **Merge:** Human + AI orders merged with human over AI for conflicts; ordering is stable for deterministic replay (player id, then conflict key / order type as specified).
 - **Projected effects:** Dry-run returns worker count, treasury delta, and when implemented unit locations and stockpile deltas for UI; no mutation of the passed-in game from the caller's perspective.
 - **No application:** Order engine does not apply orders to world state; TurnResolver applies after merge.
+- **Move validation (extracted):** Given a move order that violates civilian-into-GP or civilian-into-Minor/Tribe rules (per [orders.md](orders.md)), when validated with context, the result is rejected with reason "Civilian cannot enter other Great Power territory" or "Civilian cannot enter Minor/Tribe territory" as applicable. Military moves into GP or Minor/Tribe provinces without war (or same-turn declareWar) are rejected with the appropriate "Must declare war before attacking..." reason.
+- **Work order cost (single source):** Given work orders with material costs, when validated and when projecting effects in the same pass, the same cost calculation is used via WorkOrderCostCalculator (single source of truth).
 
 ---
 

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -3,7 +3,6 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
 
 import '../economy/economy_production.dart';
-import '../world/movement.dart';
 import '../world/naval.dart';
 import 'order_visibility.dart';
 import 'order_projections.dart';
@@ -12,26 +11,15 @@ import '../constants.dart';
 import '../world/province_lookup.dart';
 import 'projected_effects.dart';
 import '../diplomacy/diplomacy_resolver.dart';
+import 'order_validation_result.dart';
+export 'order_validation_result.dart';
+import 'validators/move_validator.dart';
+import 'validators/work_order_cost_calculator.dart';
 
 final Logger _log = Logger();
 
 /// Order engine: current-turn orders per player, validation, projected effects.
 /// SPEC/program/order-engine.md. Does not mutate world state.
-
-/// Validation result for one order. First invalid + all subsequent rejected.
-enum OrderValidationStatus { accepted, rejected }
-
-class OrderValidationResult {
-  const OrderValidationResult({
-    required this.status,
-    this.reason,
-  });
-
-  final OrderValidationStatus status;
-  final String? reason;
-
-  bool get isAccepted => status == OrderValidationStatus.accepted;
-}
 
 /// Order engine: holds per-player orders, validates in submission order,
 /// exposes projected effects. No world state mutation.
@@ -365,118 +353,12 @@ class OrderEngine {
       }
     }
 
-    bool _ownerIsGreatPower(String? ownerId) {
-      if (ownerId == null) return false;
-      return game.players.any((p) => p.id == ownerId);
-    }
-
-    bool _ownerIsMinorOrTribe(String? ownerId) {
-      if (ownerId == null) return false;
-      return game.minorNations.any((m) => m.id == ownerId) ||
-          game.tribes.any((t) => t.id == ownerId);
-    }
+    const _moveValidator = MoveValidator();
 
     OrderValidationResult validateMove(MoveOrder o) {
-      final unit = unitsById[o.unitId];
-      if (unit == null || unit.ownerId != playerId) {
-        return const OrderValidationResult(
-            status: OrderValidationStatus.rejected, reason: 'Invalid move');
-      }
-      final unitRegion = unit.tileKey != null && unit.tileKey!.isNotEmpty
-          ? Unit.requireRegionIdFromTileKey(unit.tileKey)
-          : ProvinceId.regionIdFrom(
-              resolveToFullProvinceId(game.worldState, unit.provinceId));
-      final destFullId =
-          resolveToFullProvinceId(game.worldState, o.destinationProvinceId);
-      final destRegion = ProvinceId.regionIdFrom(destFullId);
-      final destProvince = tryGetProvince(game.worldState, destFullId);
-      final destOwnerId = destProvince?.ownerId;
-      // Movement within own provinces: always allowed (no adjacency, no cargo, no region restriction). SPEC/program/movement.md.
-      final moveToOwnProvince = destOwnerId == playerId;
-      if (!moveToOwnProvince && destRegion != unitRegion) {
-        return const OrderValidationResult(
-            status: OrderValidationStatus.rejected, reason: 'Invalid move');
-      }
-      if (!moveToOwnProvince) {
-        final unitLocalId = ProvinceId.localIdFrom(unit.locationProvinceId);
-        final destLocalId = ProvinceId.localIdFrom(destFullId);
-        if (!isValidLandMoveInRegion(
-            topology, unitRegion, unitLocalId, destLocalId)) {
-          return const OrderValidationResult(
-              status: OrderValidationStatus.rejected, reason: 'Invalid move');
-        }
-      }
-      if (!isMilitaryUnit(unit.type) &&
-          destOwnerId != null &&
-          destOwnerId != playerId) {
-        if (_ownerIsGreatPower(destOwnerId) && !isSpyUnit(unit.type)) {
-          return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'Civilian cannot enter other Great Power territory');
-        }
-        if (_ownerIsMinorOrTribe(destOwnerId) &&
-            !isExplorerUnit(unit.type) &&
-            !isMerchantUnit(unit.type) &&
-            !isSpyUnit(unit.type)) {
-          return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'Civilian cannot enter Minor/Tribe territory');
-        }
-      }
-
-      // Attack validation: cannot move into another Great Power's province
-      // without war declared. SPEC/game/diplomacy.md: "Declare War: Requires
-      // AT_PEACE. Sets AT_WAR; takes effect before Movement in same turn."
-      // Validation allows either an existing AT_WAR relation or a same-turn
-      // declareWar diplomatic order targeting that faction.
-      if (destOwnerId != null &&
-          destOwnerId != playerId &&
-          _ownerIsGreatPower(destOwnerId)) {
-        final rel = getRelation(game, playerId, destOwnerId);
-        final atWar = rel?.atWar ?? false;
-        final declaringWarThisTurn = diplomatic.any((o) =>
-            o.type == DiplomaticOrderType.declareWar &&
-            o.targetFactionId == destOwnerId);
-        if (!atWar && !declaringWarThisTurn) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason:
-                'Must declare war before attacking Great Power province',
-          );
-        }
-      }
-
-      // Attack validation for Minor Nations and Tribes: war declaration required for military units
-      // SPEC/game/diplomacy.md line 19: "Minor Nations (Old World): Declaration of
-      // war required before attacking provinces or units."
-      // Civilian units (Explorer, Merchant, Spy) can enter without war declaration.
-      if (destOwnerId != null &&
-          destOwnerId != playerId &&
-          _ownerIsMinorOrTribe(destOwnerId) &&
-          isMilitaryUnit(unit.type)) {
-        final rel = getRelation(game, playerId, destOwnerId);
-        final atWar = rel?.atWar ?? false;
-        final declaringWarThisTurn = diplomatic.any((o) =>
-            o.type == DiplomaticOrderType.declareWar &&
-            o.targetFactionId == destOwnerId);
-        if (!atWar && !declaringWarThisTurn) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason:
-                'Must declare war before attacking Minor Nation or Tribe province',
-          );
-        }
-      }
-
-      if (!moveSourceVisibilityOk(view, unitRegion, unit.locationProvinceId) ||
-          !moveDestVisibilityOk(
-              view, destRegion, o.destinationProvinceId, unit.type)) {
-        return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Source or destination not visible');
-      }
-      return const OrderValidationResult(
-          status: OrderValidationStatus.accepted);
+      return _moveValidator.validate(
+        o, game, playerId, unitsById, diplomatic, view, topology,
+      );
     }
 
     for (final o in moves) {
@@ -822,8 +704,9 @@ class OrderEngine {
                 reason: 'Modern Forts tech required for fort level 3');
           }
         }
-        final costMap = workOrderMaterialCost(
+        final costMap = WorkOrderCostCalculator(game).calculateCost(
           o.target,
+          o.targetTileKey,
           improvementLevel: improvementLevel,
           fortLevel: fortLevel,
           roadLevel: roadLevel,
@@ -877,19 +760,14 @@ class OrderEngine {
         } else if (unit != null &&
             o.target != 'steal_tech' &&
             o.target != 'counter_spy') {
-          final provId = Unit.provinceIdFromTileKey(o.targetTileKey);
-          final province =
-              provId != null ? tryGetProvince(game.worldState, provId) : null;
           final improvementLevel = o.target == 'build_improvement'
               ? game.worldState.tileState.improvementLevel(o.targetTileKey)
               : 0;
-          final fortLevel = province?.fortLevel ?? 0;
-          final roadLevel =
-              game.worldState.tileState.roadLevel(o.targetTileKey);
-          final costMap = workOrderMaterialCost(o.target,
-              improvementLevel: improvementLevel,
-              fortLevel: fortLevel,
-              roadLevel: roadLevel);
+          final costMap = WorkOrderCostCalculator(game).calculateCost(
+            o.target,
+            o.targetTileKey,
+            improvementLevel: improvementLevel,
+          );
           if (costMap != null) {
             for (final entry in costMap.entries) {
               if (stockpile.quantityOf(entry.key) >= entry.value) {

--- a/packages/colonizethis_logic/lib/src/orders/order_validation_result.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_validation_result.dart
@@ -1,0 +1,17 @@
+/// Validation result for one order. First invalid + all subsequent rejected.
+/// Used by OrderEngine and extracted validators (MoveValidator, etc.).
+/// SPEC/program/order-engine.md.
+
+enum OrderValidationStatus { accepted, rejected }
+
+class OrderValidationResult {
+  const OrderValidationResult({
+    required this.status,
+    this.reason,
+  });
+
+  final OrderValidationStatus status;
+  final String? reason;
+
+  bool get isAccepted => status == OrderValidationStatus.accepted;
+}

--- a/packages/colonizethis_logic/lib/src/orders/validators/move_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/move_validator.dart
@@ -1,0 +1,128 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../../diplomacy/diplomacy_resolver.dart';
+import '../../world/movement.dart';
+import '../../world/player_view.dart';
+import '../../world/province_lookup.dart';
+import '../order_validation_result.dart';
+import '../order_visibility.dart';
+
+/// Validates move orders. SPEC/program/orders.md § Move orders.
+/// Used by OrderEngine in validatePlayerOrdersWithContext.
+class MoveValidator {
+  const MoveValidator();
+
+  OrderValidationResult validate(
+    MoveOrder order,
+    Game game,
+    String playerId,
+    Map<String, Unit> unitsById,
+    List<DiplomaticOrder> diplomaticOrders,
+    PlayerView view,
+    MapTopology topology,
+  ) {
+    final unit = unitsById[order.unitId];
+    if (unit == null || unit.ownerId != playerId) {
+      return const OrderValidationResult(
+          status: OrderValidationStatus.rejected, reason: 'Invalid move');
+    }
+    final unitRegion = unit.tileKey != null && unit.tileKey!.isNotEmpty
+        ? Unit.requireRegionIdFromTileKey(unit.tileKey)
+        : ProvinceId.regionIdFrom(
+            resolveToFullProvinceId(game.worldState, unit.provinceId));
+    final destFullId =
+        resolveToFullProvinceId(game.worldState, order.destinationProvinceId);
+    final destRegion = ProvinceId.regionIdFrom(destFullId);
+    final destProvince = tryGetProvince(game.worldState, destFullId);
+    final destOwnerId = destProvince?.ownerId;
+    // Movement within own provinces: always allowed. SPEC/program/movement.md.
+    final moveToOwnProvince = destOwnerId == playerId;
+    if (!moveToOwnProvince && destRegion != unitRegion) {
+      return const OrderValidationResult(
+          status: OrderValidationStatus.rejected, reason: 'Invalid move');
+    }
+    if (!moveToOwnProvince) {
+      final unitLocalId = ProvinceId.localIdFrom(unit.locationProvinceId);
+      final destLocalId = ProvinceId.localIdFrom(destFullId);
+      if (!isValidLandMoveInRegion(
+          topology, unitRegion, unitLocalId, destLocalId)) {
+        return const OrderValidationResult(
+            status: OrderValidationStatus.rejected, reason: 'Invalid move');
+      }
+    }
+
+    // Civilian vs foreign territory
+    if (!isMilitaryUnit(unit.type) &&
+        destOwnerId != null &&
+        destOwnerId != playerId) {
+      if (_ownerIsGreatPower(game, destOwnerId) && !isSpyUnit(unit.type)) {
+        return const OrderValidationResult(
+            status: OrderValidationStatus.rejected,
+            reason: 'Civilian cannot enter other Great Power territory');
+      }
+      if (_ownerIsMinorOrTribe(game, destOwnerId) &&
+          !isExplorerUnit(unit.type) &&
+          !isMerchantUnit(unit.type) &&
+          !isSpyUnit(unit.type)) {
+        return const OrderValidationResult(
+            status: OrderValidationStatus.rejected,
+            reason: 'Civilian cannot enter Minor/Tribe territory');
+      }
+    }
+
+    // Attack validation: GP province requires war or same-turn declareWar.
+    if (destOwnerId != null &&
+        destOwnerId != playerId &&
+        _ownerIsGreatPower(game, destOwnerId)) {
+      final rel = getRelation(game, playerId, destOwnerId);
+      final atWar = rel?.atWar ?? false;
+      final declaringWarThisTurn = diplomaticOrders.any((o) =>
+          o.type == DiplomaticOrderType.declareWar &&
+          o.targetFactionId == destOwnerId);
+      if (!atWar && !declaringWarThisTurn) {
+        return const OrderValidationResult(
+          status: OrderValidationStatus.rejected,
+          reason: 'Must declare war before attacking Great Power province',
+        );
+      }
+    }
+
+    // Attack validation: Minor/Tribe province requires war for military units.
+    if (destOwnerId != null &&
+        destOwnerId != playerId &&
+        _ownerIsMinorOrTribe(game, destOwnerId) &&
+        isMilitaryUnit(unit.type)) {
+      final rel = getRelation(game, playerId, destOwnerId);
+      final atWar = rel?.atWar ?? false;
+      final declaringWarThisTurn = diplomaticOrders.any((o) =>
+          o.type == DiplomaticOrderType.declareWar &&
+          o.targetFactionId == destOwnerId);
+      if (!atWar && !declaringWarThisTurn) {
+        return const OrderValidationResult(
+          status: OrderValidationStatus.rejected,
+          reason:
+              'Must declare war before attacking Minor Nation or Tribe province',
+        );
+      }
+    }
+
+    if (!moveSourceVisibilityOk(view, unitRegion, unit.locationProvinceId) ||
+        !moveDestVisibilityOk(
+            view, destRegion, order.destinationProvinceId, unit.type)) {
+      return const OrderValidationResult(
+          status: OrderValidationStatus.rejected,
+          reason: 'Source or destination not visible');
+    }
+    return const OrderValidationResult(status: OrderValidationStatus.accepted);
+  }
+
+  bool _ownerIsGreatPower(Game game, String ownerId) {
+    return game.players.any((p) => p.id == ownerId);
+  }
+
+  bool _ownerIsMinorOrTribe(Game game, String ownerId) {
+    return game.minorNations.any((m) => m.id == ownerId) ||
+        game.tribes.any((t) => t.id == ownerId);
+  }
+}

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_cost_calculator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_cost_calculator.dart
@@ -1,0 +1,45 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../../world/province_lookup.dart';
+
+/// Calculates work order material costs. Reduces duplication between validation and projection.
+/// SPEC/program/orders.md § Work orders. Used by OrderEngine for work-order cost validation and projection.
+class WorkOrderCostCalculator {
+  final Game game;
+
+  const WorkOrderCostCalculator(this.game);
+
+  /// Calculates cost for a work order at the given tile.
+  /// Returns null if no cost applies (steal_tech, counter_spy, purchase_land).
+  Map<String, int>? calculateCost(
+    String target,
+    String targetTileKey, {
+    int improvementLevel = 0,
+    int? fortLevel,
+    int? roadLevel,
+  }) {
+    if (target == 'steal_tech' ||
+        target == 'counter_spy' ||
+        target == 'purchase_land') {
+      return null;
+    }
+
+    final province = _targetProvince(targetTileKey);
+    final fl = fortLevel ?? province?.fortLevel ?? 0;
+    final rl = roadLevel ?? game.worldState.tileState.roadLevel(targetTileKey);
+
+    return workOrderMaterialCost(
+      target,
+      improvementLevel: improvementLevel,
+      fortLevel: fl,
+      roadLevel: rl,
+    );
+  }
+
+  Province? _targetProvince(String tileKey) {
+    final provId = Unit.provinceIdFromTileKey(tileKey);
+    if (provId == null) return null;
+    return tryGetProvince(game.worldState, provId);
+  }
+}

--- a/packages/colonizethis_logic/test/orders/validators/move_validator_test.dart
+++ b/packages/colonizethis_logic/test/orders/validators/move_validator_test.dart
@@ -1,0 +1,213 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logic/src/orders/validators/move_validator.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('MoveValidator', () {
+    const ow = 'oldWorld';
+    final topology = MapTopology(
+      nodes: const [
+        TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
+        TopologyNode(id: 'P2', regionId: ow, type: TopologyNodeType.province),
+      ],
+      edges: const [TopologyEdge(id1: 'P1', id2: 'P2')],
+    );
+
+    test('civilian cannot move into other GP territory', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+            ],
+            units: [
+              Unit(
+                  id: 'u1',
+                  type: 'Builder',
+                  ownerId: 'p1',
+                  provinceId: '$ow|P1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            'p1': {
+              'oldWorld|P1|0|0': 'fullyVisible',
+              'oldWorld|P2|0|0': 'fogged',
+            },
+          },
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+          Player(id: 'p2', displayName: 'P2', isHuman: true),
+        ],
+      );
+      final unitsById = {for (final u in game.worldState.oldWorld.units) u.id: u};
+      final view = buildPlayerView(game, topology, 'p1');
+      const validator = MoveValidator();
+      final result = validator.validate(
+        const MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|P2'),
+        game,
+        'p1',
+        unitsById,
+        [],
+        view,
+        topology,
+      );
+      expect(result.status, OrderValidationStatus.rejected);
+      expect(result.reason, contains('Civilian cannot enter other Great Power'));
+    });
+
+    test('military cannot move into other GP province without war', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+            ],
+            units: [
+              Unit(
+                  id: 'u1',
+                  type: 'pikemen',
+                  ownerId: 'p1',
+                  provinceId: '$ow|P1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            'p1': {
+              'oldWorld|P1|0|0': 'fullyVisible',
+              'oldWorld|P2|0|0': 'revealed',
+            },
+          },
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+          Player(id: 'p2', displayName: 'P2', isHuman: true),
+        ],
+        diplomacyRelations: const [],
+      );
+      final unitsById = {for (final u in game.worldState.oldWorld.units) u.id: u};
+      final view = buildPlayerView(game, topology, 'p1');
+      const validator = MoveValidator();
+      final result = validator.validate(
+        const MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|P2'),
+        game,
+        'p1',
+        unitsById,
+        [],
+        view,
+        topology,
+      );
+      expect(result.status, OrderValidationStatus.rejected);
+      expect(result.reason, contains('declare war'));
+    });
+
+    test('military may move into other GP province with same-turn declareWar', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+            ],
+            units: [
+              Unit(
+                  id: 'u1',
+                  type: 'pikemen',
+                  ownerId: 'p1',
+                  provinceId: '$ow|P1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            'p1': {
+              'oldWorld|P1|0|0': 'fullyVisible',
+              'oldWorld|P2|0|0': 'revealed',
+            },
+          },
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+          Player(id: 'p2', displayName: 'P2', isHuman: true),
+        ],
+        diplomacyRelations: const [],
+      );
+      final unitsById = {for (final u in game.worldState.oldWorld.units) u.id: u};
+      final view = buildPlayerView(game, topology, 'p1');
+      const validator = MoveValidator();
+      final result = validator.validate(
+        const MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|P2'),
+        game,
+        'p1',
+        unitsById,
+        [
+          DiplomaticOrder(
+              type: DiplomaticOrderType.declareWar, targetFactionId: 'p2'),
+        ],
+        view,
+        topology,
+      );
+      expect(result.status, OrderValidationStatus.accepted);
+    });
+
+    test('military cannot move into Minor/Tribe province without war', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'minor1'),
+            ],
+            units: [
+              Unit(
+                  id: 'u1',
+                  type: 'pikemen',
+                  ownerId: 'p1',
+                  provinceId: '$ow|P1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            'p1': {
+              'oldWorld|P1|0|0': 'fullyVisible',
+              'oldWorld|P2|0|0': 'revealed',
+            },
+          },
+        ),
+        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+        minorNations: const [
+          MinorNation(id: 'minor1', displayName: 'Minor1', capitalProvinceId: 'oldWorld|P2'),
+        ],
+        tribes: const [],
+        diplomacyRelations: const [],
+      );
+      final unitsById = {for (final u in game.worldState.oldWorld.units) u.id: u};
+      final view = buildPlayerView(game, topology, 'p1');
+      const validator = MoveValidator();
+      final result = validator.validate(
+        const MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|P2'),
+        game,
+        'p1',
+        unitsById,
+        [],
+        view,
+        topology,
+      );
+      expect(result.status, OrderValidationStatus.rejected);
+      expect(result.reason, contains('declare war'));
+      expect(result.reason, contains('Minor Nation or Tribe'));
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/orders/validators/work_order_cost_calculator_test.dart
+++ b/packages/colonizethis_logic/test/orders/validators/work_order_cost_calculator_test.dart
@@ -1,0 +1,78 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/src/orders/validators/work_order_cost_calculator.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('WorkOrderCostCalculator', () {
+    test('calculateCost returns null for steal_tech, counter_spy, purchase_land', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [],
+      );
+      final calc = WorkOrderCostCalculator(game);
+      expect(calc.calculateCost('steal_tech', 'oldWorld|P1|0|0'), isNull);
+      expect(calc.calculateCost('counter_spy', 'oldWorld|P1|0|0'), isNull);
+      expect(calc.calculateCost('purchase_land', 'oldWorld|P1|0|0'), isNull);
+    });
+
+    test('calculateCost returns cost map for build_improvement', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'oldWorld|P1', regionId: 'oldWorld', ownerId: 'p1'),
+            ],
+            units: const [],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+      );
+      final calc = WorkOrderCostCalculator(game);
+      final cost = calc.calculateCost(
+        'build_improvement',
+        'oldWorld|P1|0|0',
+        improvementLevel: 0,
+      );
+      expect(cost, isNotNull);
+      expect(cost!.length, 2);
+      expect(cost[CommodityCatalog.lumber.id], 1);
+      expect(cost[CommodityCatalog.castIron.id], 1);
+    });
+
+    test('calculateCost for build_fort uses province fortLevel when not overridden', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(
+                  id: 'oldWorld|P1',
+                  regionId: 'oldWorld',
+                  ownerId: 'p1',
+                  fortLevel: 1),
+            ],
+            units: const [],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+      );
+      final calc = WorkOrderCostCalculator(game);
+      // Fort level 1 -> next build is level 2, cost 4 lumber + 4 bronze
+      final cost = calc.calculateCost('build_fort', 'oldWorld|P1|0|0');
+      expect(cost, isNotNull);
+      expect(cost![CommodityCatalog.lumber.id], 4);
+      expect(cost[CommodityCatalog.bronze.id], 4);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

This PR subsumes **PR #984** (refactor #290) and **PR #987** (docs #288). It fully integrates extracted validators and aligns SPEC, acceptance criteria, implementation, and tests.

## Changes

- **MoveValidator** (`validators/move_validator.dart`): Extracted move validation with full behavior parity — unit/ownership, region/adjacency, civilian vs GP (Spy allowed), civilian vs Minor/Tribe (Explorer/Merchant/Spy allowed), war declaration for GP and for military into Minor/Tribe, visibility. OrderEngine delegates to it in `validatePlayerOrdersWithContext`.
- **WorkOrderCostCalculator** (`validators/work_order_cost_calculator.dart`): Single source of truth for work-order material costs. Used in order_engine for both validation and projection (no duplicated `workOrderMaterialCost` calls).
- **OrderValidationResult** moved to `order_validation_result.dart`; order_engine and MoveValidator both use it (no circular dependency).
- **SPEC/program/order-engine.md**: New "Validation components" subsection (MoveValidator, WorkOrderCostCalculator), naval build validation note (#288), and ACs for move validation and work-order cost.
- **Tests**: `move_validator_test.dart` and `work_order_cost_calculator_test.dart` added; all existing `order_engine_test` and package tests pass.

## Refs

- #290 (refactor)
- #288 (docs)
- Supersedes #984, #987