### PR TITLE
docs(#524,#544,#545,#571,#562): Clarify AI and military specs

### DIFF
--- a/SPEC/ai/ai-architecture.md
+++ b/SPEC/ai/ai-architecture.md
@@ -25,7 +25,7 @@ Characterful, deterministic AI using only observable game state. Difficulty affe
 
 Behavior trees pick top-level goals; utility AI scores and selects concrete objectives; tactical layer produces combat and movement orders.
 
-**Goal selection implementation:** Goal selection may be implemented as **weighted choice** over strategic goals (expand, defend, trade, conquer, tech, diplomacy) using personality weights, agenda modifiers, and situational snapshot. This satisfies the "behavior tree" requirement when interpreted as hierarchical goal selection. Strict behavior-tree node structure (sequences, selectors) is optional and may be used where designer-editable trees are desired.
+**Goal selection implementation:** Goal selection may be implemented as **weighted choice** over strategic goals (expand, defend, trade, conquer, tech, diplomacy) using personality weights, agenda modifiers, and situational snapshot. This satisfies the "behavior tree" requirement when interpreted as hierarchical goal selection. Strict behavior-tree node structure (sequences, selectors) is optional and may be used where designer-editable trees are desired. **Weighted choice is the current implemented approach**; strict behavior-tree structure is deferred to future phases when designer-editable AI trees are required (e.g. for mod support or external AI editors).
 
 ### Turn Pipeline (per AI Great Power)
 1. **Perception** — Derive observable snapshot: threats, opportunities, economy, relations. All from PlayerView; no hidden data.

--- a/SPEC/ai/ai-personalities.md
+++ b/SPEC/ai/ai-personalities.md
@@ -43,6 +43,8 @@ Each personality defines **domain weights** (economy, military, diplomacy, resea
 
 Exact numbers live in config data; SPEC does not mandate values, only that each leader has a defined vector and that it biases goal selection and utility scores.
 
+**Config source:** Personality config (domain weights, goal weights, behavioral thresholds) lives in program-level config (`colonizethis_data/lib/src/ai_personality_config.dart`) per [ruleset-config.md](../program/ruleset-config.md). Ruleset-configurable personality bundles are deferred to a future phase when the ruleset loader supports JSON merge. The `personalityId` field in AIConfig is reserved for future ruleset-driven personality overrides.
+
 ---
 
 ## Behavioral modifiers

--- a/SPEC/ai/dialogue-and-mood.md
+++ b/SPEC/ai/dialogue-and-mood.md
@@ -28,7 +28,7 @@ Emitted when a dialogue line should be shown. Consumed by UI or tooling.
 
 | Field | Type | Meaning |
 |-------|------|---------|
-| leaderId | string | Which leader is speaking. |
+| leaderId | string | Which leader is speaking. **leaderId is the player (Great Power) id of the speaking faction** (e.g. 'gp1', 'gp2', or canonical leader id like 'victoria', 'napoleon'). This is the same as the player/faction id in game state. |
 | category | string | One of the categories above. |
 | situation | string | Sub-context (e.g. declare_war, peace_offer, battle_won). |
 | era | string | discovery \| earlyModern \| imperial \| industrial (for era-appropriate phrasing). For events tied to a specific turn (e.g. battle_won / battle_lost, forts_on_border), the system derives this from the game’s turn-time mapping as `eraFromYear(mapping.yearAtTurn(turnNumber))` (see SPEC/game/turn-time-mapping.md). For era_change events, this is the new era value. |
@@ -51,14 +51,40 @@ Used when:
 
 Mood state machine (logic): given current mood, offerQualityDelta (-1..1), and stallCounter, compute next mood; on transition, emit event. All inputs must be deterministic (seeded or from game state).
 
+### Mood State Machine Transition Rules
+
+The mood state machine uses **stallCounter** (number of negotiation stalls with no progress) and **offerQualityDelta** (-1 to 1, positive = offer improved, negative = offer worsened) to compute the next mood. When the computed mood differs from current mood, emit a `PortraitMoodEvent`. Tie-breaking uses a seed for deterministic results.
+
+| Condition | Next Mood | Notes |
+|-----------|-----------|-------|
+| `stallCounter >= 4` | `impatient` or `skeptical` | High stall count; random via seed |
+| `stallCounter >= 2` | `calculating` | Medium stall count |
+| `offerQualityDelta >= 0.5` | `pleased` or `gracious` | Strong positive offer; random via seed |
+| `offerQualityDelta <= -0.5` | `irritated` or `dismissive` | Strong negative offer; random via seed |
+| `offerQualityDelta <= -0.2` | `skeptical` | Moderate negative offer |
+| `offerQualityDelta >= 0.2` | `considering` | Moderate positive offer |
+| Otherwise (near zero) | `calculating` or `considering` | Default: if current is `calculating` or seed % 3 == 0 → `calculating`; else `considering` |
+
+The default mood when opening diplomacy (no prior negotiation context) is `considering` (see `kDefaultMood` in implementation).
+
+### Dialogue Seed Injection
+
+The **dialogue seed** is derived from the per-turn seed hierarchy: `seeds.dialogueSeed = hash(globalGameSeed, aiSeed[P], T)` per the seeding rules in [ai-architecture.md](ai-architecture.md) § Seeding. This seed drives:
+- **Strategic cadence:** Whether to emit optional agenda-flavoured commentary (checked via `dialogueSeed % kDialogueTurnsBetweenComments == 0`).
+- **Mood tie-breaking:** When multiple moods are possible (e.g. stall >= 4 → impatient/skeptical), the LSB of the seed determines which.
+
+When multiple events can be emitted in one turn (e.g. era change + battle results), each event source independently uses the same dialogue seed; there is no combination rule—the seed is simply consumed by each decision point.
+
+### Agenda Dialogue Cadence
+
+Agenda-flavoured dialogue (optional commentary on a leader's hidden agenda) is emitted on a deterministic schedule: **once every `kDialogueTurnsBetweenComments` turns per AI leader**, where `kDialogueTurnsBetweenComments = 7`. Concretely, when the strategic AI layer runs for a leader and `dialogueSeed % kDialogueTurnsBetweenComments == 0`, it may emit a single `DialogueEvent(category: 'agenda', situation: 'comment')` and a matching `PortraitMoodEvent` with base mood `considering`. This schedule is deterministic given the seed and may be made ruleset-configurable in a later phase.
+
 ---
 
 ## When to emit
 
-- **DialogueEvent:** When AI performs a diplomatic action (declare war, offer peace, etc.), when a game event triggers commentary (battle result, era change), when player action triggers reactive banter, or when agenda-flavoured line is chosen (e.g. at dialogue seed interval).
+- **DialogueEvent:** When AI performs a diplomatic action (declare war, offer peace, etc.), when a game event triggers commentary (battle result, era change), when player action triggers reactive banter, or when agenda-flavoured line is chosen (see § Agenda Dialogue Cadence).
 - **PortraitMoodEvent:** When negotiation mood transitions; optionally when opening/closing diplomacy screen with a base mood.
-
-- **Strategic AI cadence (agenda/comment + base mood):** Strategic AI may emit **optional** agenda-flavoured commentary and a matching base PortraitMoodEvent on a **deterministic schedule** derived from the dialogue seed. For MVP, this schedule is: _once every `kDialogueTurnsBetweenComments` turns per AI leader_, where `kDialogueTurnsBetweenComments = 7` (defined in `colonizethis_data` dialogue catalog). Concretely, when the strategic AI layer runs for a leader and `dialogueSeed % kDialogueTurnsBetweenComments == 0`, it may emit a single `DialogueEvent(category: 'agenda', situation: 'comment')` and a `PortraitMoodEvent` with base mood `considering`. This schedule is deterministic given the seed and may be made ruleset-configurable in a later phase.
 
 Emission is synchronous from AI turn or from resolution hooks; no async side effects. Order of events is deterministic for replay.
 
@@ -68,7 +94,7 @@ Emission is synchronous from AI turn or from resolution hooks; no async side eff
 
 - **Emission by category:** DialogueEvent and PortraitMoodEvent are emitted per spec categories/situations: event, reactive, diplomatic, negotiation, agenda (see § Dialogue categories and § When to emit).
 - **Determinism:** Same game state and dialogue seed produce the same sequence of events; replay and save/load restore or recompute consistently.
-- **Strategic cadence:** Optional strategic agenda/comment lines and base PortraitMoodEvent emissions follow the documented cadence: they are emitted only when `dialogueSeed % kDialogueTurnsBetweenComments == 0` for the current leader, with `kDialogueTurnsBetweenComments` defined in the dialogue catalog (MVP = 7).
+- **Strategic cadence:** Optional strategic agenda/comment lines and base PortraitMoodEvent emissions follow the documented cadence: they are emitted only when `dialogueSeed % kDialogueTurnsBetweenComments == 0` for the current leader, with `kDialogueTurnsBetweenComments = 7` (defined in the dialogue catalog).
 - **Province identity:** When DialogueEvent (or any event) variables include a province id, the value MUST be in prefixed form per [world-model-identity.md](../game/world-model-identity.md).
 - **Mood values:** PortraitMoodEvent and DialogueEvent mood fields use only the fixed set: considering, pleased, gracious, calculating, skeptical, impatient, irritated, dismissive.
 - **UI contract:** UI resolves event fields (leaderId, category, situation, era, mood, variables) to dialogue keys and localized text only; no asset paths or image references in events.

--- a/SPEC/game/military-generals.md
+++ b/SPEC/game/military-generals.md
@@ -27,6 +27,8 @@ Generals are **not** assigned to provinces or stacks by default. Assignment is *
 - **When attacking:** A faction that orders an attack (move into an enemy province) must commit one general to that attack. The system chooses **one general at random** from that faction’s generals who are not already committed to another battle this turn. That general is “assigned” to that attacking force for the **duration of that battle only**. This **caps the number of attacks** a faction can make in one turn: at most one attack per general (so at most general cap attacks per turn).
 - **When defending:** When a province owned by the faction is attacked, the system automatically assigns **one general at random** from that faction’s generals who are not already committed to another battle this turn. If the faction has **no uncommitted general**, the province **may still be defended**, but **without a general** (defender general medals = 0 for that battle).
 
+**Defender general modeling:** Currently, defender generals are **not modeled** in combat resolution—defender general medals are treated as 0. This means the defender side does not receive +1 per defender general medal to the deployment limit, and no defender morale aura or initiative bonus is applied. When defender general state is added in a future phase, the defender side should symmetrically receive +1 per defender general medal to the deployment limit (matching attacker behavior).
+
 **Commitment lifetime:** A general is committed only for the duration of one battle. When that battle’s resolution completes, the generals assigned to that battle (attacker and defender) are **freed**. If there is a subsequent battle in the same turn (e.g. another province), the assignment process runs again and any general may be assigned, including one who was just in a previous battle.
 
 Assignment is only for applying general bonuses in combat (deployment limit, initiative, morale aura). It does not imply any map location.
@@ -41,7 +43,7 @@ Each general has **medals** 0–4.
 Medal effects in combat (see [combat.md](combat.md) and [combat-resolution.md](../program/combat-resolution.md)):
 
 - **Deployment:** +1 regiment per general medal to the per-side deployment limit (base 10; Nationalism tech → 12).
-- **Morale aura:** Regiments on that side receive a strength bonus of **5% per general medal**, up to a maximum of **20%** (at 4 medals). Configurable via ruleset; default 5% per medal, cap 20%.
+- **Morale aura:** Regiments on that side receive a strength bonus of **5% per general medal**, up to a maximum of **20%** (at 4 medals). These values are program-level constants; ruleset-configurable morale aura is deferred to a future phase.
 - **Initiative:** Army initiative uses `cavalryShare × W_cav + generalMedals × W_medal` for ordering multi-attacker chains.
 
 Defender without a general uses 0 general medals for deployment, morale, and initiative.
@@ -52,12 +54,14 @@ Defender without a general uses 0 general medals for deployment, morale, and ini
 
 ## Regiment Economy (Training & Upkeep)
 
-Each regiment type has **training cost** and **food upkeep** defined in ruleset config:
+Each regiment type has **training cost** and **food upkeep** defined in **program-level config**:
 
 - **Training cost:** Cash + material inputs (fabric, cast iron, lumber, steel, bronze) + **one worker** consumed from the player's WorkerPool at construction time. Cavalry and artillery cost more than line infantry; late-era elites are most expensive.
 - **Upkeep (food):** Per-turn food demand per regiment, consumed during the Consumption phase. Light infantry and early-era units have lower upkeep; cavalry, artillery, and late-era elites have higher upkeep.
 
 Per-regiment values follow the same era/category progression as the tactical stats table in [military-units.md](military-units.md).
+
+**Config source:** Regiment economy values (training cost, food upkeep) live in program-level config (`colonizethis_data/lib/src/regiment_economy.dart`) per [ruleset-config.md](../program/ruleset-config.md). Ruleset-configurable regiment economy is deferred to a future phase when the ruleset loader supports JSON merge.
 
 **Implementation:** Training cost (cash, materials, worker) is applied at build time when BuildUnitOrder (military) is resolved per [orders.md](../program/orders.md). Food upkeep is consumed during the Consumption phase per [turn-resolution-phase-details.md](../program/turn-resolution-phase-details.md) § Consumption and [economy-models.md](../program/economy-models.md).
 


### PR DESCRIPTION
## Summary

- **#545**: Clarify `DialogueEvent.leaderId` is the player (Great Power) id of the speaking faction, not a distinct leader entity
- **#544**: Document mood state machine transition rules (stall thresholds, offerQualityDelta bands), dialogue seed injection point, and agenda dialogue cadence in SPEC/ai/dialogue-and-mood.md
- **#524**: Clarify regiment economy and morale aura are MVP program-level config (ruleset-configurable deferred); document that defender general medals are treated as 0 (future symmetric deployment limit deferred)
- **#571**: Clarify strict behavior-tree structure is deferred to future phases when designer-editable AI trees are needed
- **#562**: Clarify personality config is MVP program-level; ruleset-configurable personality is deferred to future phases

## Changes

- SPEC/ai/dialogue-and-mood.md: Added leaderId clarification, mood state machine table, dialogue seed section, agenda cadence section
- SPEC/game/military-generals.md: Added MVP program-level notes for regiment economy and morale aura; added defender general modeling note
- SPEC/ai/ai-architecture.md: Clarified weighted choice is MVP implementation; strict behavior-tree deferred
- SPEC/ai/ai-personalities.md: Added MVP program-level note for personality config