### PR TITLE
feat(app): map widget hover with selector and province border glow

### DIFF
--- a/SPEC/ui/map-widget.md
+++ b/SPEC/ui/map-widget.md
@@ -10,7 +10,7 @@
 - **Viewport:** The visible area is the widget's layout size. Map extent is the full 2D tile grid; user pans and zooms to see it.
 - **Base layer:** Single 2D tile layer: terrain, resources, improvements, towns, capitals.
 - **Overlays:** Political ownership (borders) as a **separate overlay** on top; user can toggle overlay visibility.
-- **Interaction:** Pan; fixed zoom levels with smooth zooming; tap/click to select a province (callbacks; province details content TBD elsewhere).
+- **Interaction:** Pan; fixed zoom levels with smooth zooming; tap/click to select a province (callbacks; province details content TBD elsewhere). **Hover:** When the pointer is over a tile, a selector (e.g. a simple square) is shown on that tile with a subtle bouncing animation; the hovered tile's province (or sea zone) borders glow and use a subtle animation (e.g. pulse).
 - **Animation:** Widget supports animation of individual tiles and other assets (e.g. highlights, build progress); Flame is the implementation fit.
 
 ---
@@ -44,8 +44,17 @@ The map widget exposes callbacks so the parent (e.g. Empire overview) can react;
 |----------|---------|
 | **onProvinceSelected** | Invoked when the user taps/clicks a province (e.g. with prefixed province id). Province details (what to show, where) are defined by the parent/screen; the map widget only reports selection. |
 | **onRegionViewChanged** | Optional: viewport or zoom level changed (e.g. for syncing with sidebar or URL). |
+| **onProvinceHovered** | Optional: invoked when hover enters or leaves a province (prefixed province id, or null when leaving). Enables e.g. tooltips. |
 
 Details of what “province details” shows are **not** defined in this spec; the screen that embeds the map defines that. The map widget only supports selection via these callbacks.
+
+---
+
+## Hover
+
+- **Selector:** When the pointer hovers over a tile, the widget shows a selector on that tile (e.g. a simple square outline). The selector has a **subtle bouncing animation** (e.g. scale or position) so it is clearly visible and responsive.
+- **Province border highlight:** The province (or sea zone) that contains the hovered tile is highlighted: its borders **glow** and use a **subtle animation** (e.g. opacity or stroke pulse). This applies to both land provinces and sea zones.
+- **Optional callback:** The widget may expose **onProvinceHovered**(prefixed province id, or null when hover leaves) so the parent can show tooltips or other feedback.
 
 ---
 
@@ -71,6 +80,8 @@ Details of what “province details” shows are **not** defined in this spec; t
 - **When** the user pans, **then** the visible portion of the map updates; the full map remains pannable within the fixed scale.
 - **When** the user zooms, **then** only fixed zoom levels are used and zooming is smooth between levels.
 - **When** the user taps/clicks a province, **then** the widget invokes the provided province-selection callback with an identifier (e.g. prefixed province id); the widget does not render province details itself.
+- **When** the user hovers over a tile, **then** a selector (e.g. simple square) is shown on that tile with a subtle bouncing animation.
+- **When** the user hovers over a tile, **then** the borders of that tile's province (or sea zone) glow and have a subtle animation; when hover leaves, the highlight is removed.
 - **Given** the component is implemented with Flame, **then** it is possible to drive per-tile or per-asset animations from external events or timers.
 
 ---

--- a/app/lib/widgets/region_map_debug.dart
+++ b/app/lib/widgets/region_map_debug.dart
@@ -13,7 +13,8 @@ import 'package:flutter/material.dart';
 /// - Single letters for resources (g, t, i, etc.), improvement level (I0–I4), road (R0/R1/R2/R4).
 /// - Solid lines: province borders (black), faction borders when [showPoliticalOverlay] (darker/thicker).
 /// Pan/zoom via [InteractiveViewer]; tap reports province via [onProvinceSelected].
-class CtRegionMapDebug extends StatelessWidget {
+/// Hover: selector (square) with subtle bounce; hovered province borders glow with subtle animation.
+class CtRegionMapDebug extends StatefulWidget {
   const CtRegionMapDebug({
     super.key,
     required this.region,
@@ -21,6 +22,7 @@ class CtRegionMapDebug extends StatelessWidget {
     this.cellSizePx = 32,
     this.onProvinceSelected,
     this.onRegionViewChanged,
+    this.onProvinceHovered,
   });
 
   final RegionMapViewData region;
@@ -28,40 +30,134 @@ class CtRegionMapDebug extends StatelessWidget {
   final double cellSizePx;
   final void Function(String provinceId)? onProvinceSelected;
   final VoidCallback? onRegionViewChanged;
+  final void Function(String? provinceId)? onProvinceHovered;
+
+  @override
+  State<CtRegionMapDebug> createState() => _CtRegionMapDebugState();
+}
+
+class _CtRegionMapDebugState extends State<CtRegionMapDebug>
+    with SingleTickerProviderStateMixin {
+  int? _hoveredTileX;
+  int? _hoveredTileY;
+  late AnimationController _hoverAnimationController;
+
+  static const int _hoverAnimationDurationMs = 800;
+
+  @override
+  void initState() {
+    super.initState();
+    _hoverAnimationController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: _hoverAnimationDurationMs),
+    );
+    _hoverAnimationController.addListener(_onHoverAnimationTick);
+  }
+
+  void _onHoverAnimationTick() {
+    if (_hoveredTileX != null && _hoveredTileY != null) {
+      setState(() {});
+    }
+  }
+
+  void _startHoverAnimationIfNeeded() {
+    if (_hoveredTileX != null && _hoveredTileY != null) {
+      if (!_hoverAnimationController.isAnimating) {
+        _hoverAnimationController.repeat(reverse: true);
+      }
+    } else {
+      _hoverAnimationController.stop();
+      _hoverAnimationController.reset();
+    }
+  }
+
+  @override
+  void dispose() {
+    _hoverAnimationController.removeListener(_onHoverAnimationTick);
+    _hoverAnimationController.dispose();
+    super.dispose();
+  }
+
+  void _updateHover(Offset? local) {
+    final region = widget.region;
+    final cellSizePx = widget.cellSizePx;
+    int? nx;
+    int? ny;
+    if (local != null) {
+      final x = (local.dx / cellSizePx).floor();
+      final y = (local.dy / cellSizePx).floor();
+      if (x >= 0 && x < region.width && y >= 0 && y < region.height) {
+        nx = x;
+        ny = y;
+      }
+    }
+    final prevId = _hoveredTileX != null && _hoveredTileY != null
+        ? '${region.regionId}|${region.cellAt(_hoveredTileX!, _hoveredTileY!).regionCellId}'
+        : null;
+    final nextId = nx != null && ny != null
+        ? '${region.regionId}|${region.cellAt(nx, ny).regionCellId}'
+        : null;
+    if (prevId != nextId) {
+      widget.onProvinceHovered?.call(nextId);
+    }
+    setState(() {
+      _hoveredTileX = nx;
+      _hoveredTileY = ny;
+    });
+    _startHoverAnimationIfNeeded();
+  }
+
+  void _handleTap(Offset local, double mapWidth, double mapHeight) {
+    final region = widget.region;
+    final cellSizePx = widget.cellSizePx;
+    final x = (local.dx / cellSizePx).floor();
+    final y = (local.dy / cellSizePx).floor();
+    if (x >= 0 && x < region.width && y >= 0 && y < region.height) {
+      final cell = region.cellAt(x, y);
+      final provinceId = '${region.regionId}|${cell.regionCellId}';
+      widget.onProvinceSelected?.call(provinceId);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    final mapWidth = region.width * cellSizePx;
-    final mapHeight = region.height * cellSizePx;
+    final region = widget.region;
+    final mapWidth = region.width * widget.cellSizePx;
+    final mapHeight = region.height * widget.cellSizePx;
+    final animationT = _hoverAnimationController.value;
+    final hoveredProvinceId = _hoveredTileX != null && _hoveredTileY != null
+        ? region.cellAt(_hoveredTileX!, _hoveredTileY!).regionCellId
+        : null;
+
     return InteractiveViewer(
       minScale: 0.25,
       maxScale: 4,
       child: SizedBox(
         width: mapWidth,
         height: mapHeight,
-        child: GestureDetector(
-          onTapUp: (details) => _handleTap(details.localPosition, mapWidth, mapHeight),
-          child: CustomPaint(
-            size: Size(mapWidth, mapHeight),
-            painter: _RegionMapDebugPainter(
-              region: region,
-              cellSize: cellSizePx,
-              showPoliticalOverlay: showPoliticalOverlay,
+        child: MouseRegion(
+          hitTestBehavior: HitTestBehavior.opaque,
+          onHover: (event) => _updateHover(event.localPosition),
+          onExit: (_) => _updateHover(null),
+          child: GestureDetector(
+            onTapUp: (details) =>
+                _handleTap(details.localPosition, mapWidth, mapHeight),
+            child: CustomPaint(
+              size: Size(mapWidth, mapHeight),
+              painter: _RegionMapDebugPainter(
+                region: region,
+                cellSize: widget.cellSizePx,
+                showPoliticalOverlay: widget.showPoliticalOverlay,
+                hoveredTileX: _hoveredTileX,
+                hoveredTileY: _hoveredTileY,
+                hoveredProvinceId: hoveredProvinceId,
+                hoverAnimationT: animationT,
+              ),
             ),
           ),
         ),
       ),
     );
-  }
-
-  void _handleTap(Offset local, double mapWidth, double mapHeight) {
-    final x = (local.dx / cellSizePx).floor();
-    final y = (local.dy / cellSizePx).floor();
-    if (x >= 0 && x < region.width && y >= 0 && y < region.height) {
-      final cell = region.cellAt(x, y);
-      final provinceId = '${region.regionId}|${cell.regionCellId}';
-      onProvinceSelected?.call(provinceId);
-    }
   }
 }
 
@@ -70,26 +166,48 @@ class _RegionMapDebugPainter extends CustomPainter {
     required this.region,
     required this.cellSize,
     required this.showPoliticalOverlay,
+    this.hoveredTileX,
+    this.hoveredTileY,
+    this.hoveredProvinceId,
+    this.hoverAnimationT = 0.0,
   });
 
   final RegionMapViewData region;
   final double cellSize;
   final bool showPoliticalOverlay;
+  final int? hoveredTileX;
+  final int? hoveredTileY;
+  final String? hoveredProvinceId;
+  final double hoverAnimationT;
 
   static const Color _seaColor = Color(0xFF003366);
   static const Color _provinceBorderColor = Colors.black;
   static const Color _factionBorderColor = Color(0xFF1A237E);
   static const double _provinceBorderWidth = 1.0;
   static const double _factionBorderWidth = 2.0;
+  static const Color _selectorColor = Color(0xFFFFFFFF);
+  static const Color _hoverGlowColor = Color(0x88FFFFFF);
+  static const double _selectorInset = 2.0;
+  static const double _selectorStrokeWidth = 2.0;
+  static const double _hoverGlowStrokeWidth = 3.0;
+  static const double _bounceScaleAmplitude = 0.04;
+  static const double _glowOpacityMin = 0.5;
+  static const double _glowOpacityAmplitude = 0.25;
 
   @override
   void paint(Canvas canvas, Size size) {
     _paintTiles(canvas);
     _paintLetters(canvas);
     _paintProvinceBorders(canvas);
+    if (hoveredProvinceId != null) {
+      _paintHoveredProvinceGlow(canvas);
+    }
     if (showPoliticalOverlay) _paintFactionBorders(canvas);
     _paintCapitals(canvas);
     _paintPorts(canvas);
+    if (hoveredTileX != null && hoveredTileY != null) {
+      _paintSelector(canvas);
+    }
   }
 
   void _paintTiles(Canvas canvas) {
@@ -146,6 +264,63 @@ class _RegionMapDebugPainter extends CustomPainter {
         Offset(cx - textPainter.width / 2, cy - textPainter.height / 2),
       );
     }
+  }
+
+  void _paintHoveredProvinceGlow(Canvas canvas) {
+    final t = hoverAnimationT;
+    final opacity =
+        _glowOpacityMin + _glowOpacityAmplitude * math.sin(t * 2 * math.pi);
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = _hoverGlowStrokeWidth
+      ..color = _hoverGlowColor.withValues(alpha: opacity);
+    final provinceId = hoveredProvinceId!;
+    for (var y = 0; y < region.height; y++) {
+      for (var x = 0; x < region.width; x++) {
+        final cell = region.cellAt(x, y);
+        if (cell.regionCellId != provinceId) continue;
+        if (x + 1 < region.width) {
+          final right = region.cellAt(x + 1, y);
+          if (right.regionCellId != provinceId) {
+            final xEdge = (x + 1) * cellSize;
+            canvas.drawLine(
+              Offset(xEdge, y * cellSize),
+              Offset(xEdge, (y + 1) * cellSize),
+              paint,
+            );
+          }
+        }
+        if (y + 1 < region.height) {
+          final bottom = region.cellAt(x, y + 1);
+          if (bottom.regionCellId != provinceId) {
+            final yEdge = (y + 1) * cellSize;
+            canvas.drawLine(
+              Offset(x * cellSize, yEdge),
+              Offset((x + 1) * cellSize, yEdge),
+              paint,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  void _paintSelector(Canvas canvas) {
+    final x = hoveredTileX!;
+    final y = hoveredTileY!;
+    final bounce = 1.0 + _bounceScaleAmplitude * math.sin(hoverAnimationT * 2 * math.pi);
+    final cx = x * cellSize + cellSize / 2;
+    final cy = y * cellSize + cellSize / 2;
+    final half = (cellSize / 2 - _selectorInset) * bounce;
+    final left = cx - half;
+    final top = cy - half;
+    final size = half * 2;
+    final rect = Rect.fromLTWH(left, top, size, size);
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = _selectorStrokeWidth
+      ..color = _selectorColor;
+    canvas.drawRect(rect, paint);
   }
 
   void _paintProvinceBorders(Canvas canvas) {
@@ -255,6 +430,10 @@ class _RegionMapDebugPainter extends CustomPainter {
   bool shouldRepaint(covariant _RegionMapDebugPainter old) {
     return old.region != region ||
         old.cellSize != cellSize ||
-        old.showPoliticalOverlay != showPoliticalOverlay;
+        old.showPoliticalOverlay != showPoliticalOverlay ||
+        old.hoveredTileX != hoveredTileX ||
+        old.hoveredTileY != hoveredTileY ||
+        old.hoveredProvinceId != hoveredProvinceId ||
+        old.hoverAnimationT != hoverAnimationT;
   }
 }

--- a/app/test/region_map_debug_test.dart
+++ b/app/test/region_map_debug_test.dart
@@ -60,6 +60,7 @@ void main() {
       bool showPoliticalOverlay = true,
       double cellSizePx = 28,
       void Function(String)? onProvinceSelected,
+      void Function(String?)? onProvinceHovered,
     }) {
       return MaterialApp(
         home: Scaffold(
@@ -71,6 +72,7 @@ void main() {
               showPoliticalOverlay: showPoliticalOverlay,
               cellSizePx: cellSizePx,
               onProvinceSelected: onProvinceSelected,
+              onProvinceHovered: onProvinceHovered,
             ),
           ),
         ),
@@ -153,6 +155,33 @@ void main() {
       await tester.tapAt(center);
       await tester.pumpAndSettle();
       // No throw; callback is optional.
+    });
+
+    testWidgets('contains MouseRegion for hover', (WidgetTester tester) async {
+      final region = buildDemoRegionMapViewData();
+      await tester.pumpWidget(buildMap(region: region));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.descendant(
+          of: find.byType(CtRegionMapDebug),
+          matching: find.byType(MouseRegion),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('builds with onProvinceHovered callback', (WidgetTester tester) async {
+      final region = buildDemoRegionMapViewData();
+      String? lastHoveredId;
+      await tester.pumpWidget(buildMap(
+        region: region,
+        onProvinceHovered: (id) => lastHoveredId = id,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CtRegionMapDebug), findsOneWidget);
+      expect(lastHoveredId, isNull);
     });
   });
 }

--- a/app/widget_catalog.json
+++ b/app/widget_catalog.json
@@ -21,7 +21,7 @@
     "id": "ct_region_map_debug",
     "name": "CtRegionMapDebug",
     "dart_file_path": "lib/widgets/region_map_debug.dart",
-    "constructor_props": "region: RegionMapViewData, showPoliticalOverlay: bool, cellSizePx: double, onProvinceSelected: void Function(String)?, onRegionViewChanged: VoidCallback?",
+    "constructor_props": "region: RegionMapViewData, showPoliticalOverlay: bool, cellSizePx: double, onProvinceSelected: void Function(String)?, onRegionViewChanged: VoidCallback?, onProvinceHovered: void Function(String?)?",
     "category": "game/map",
     "source": "pipeline",
     "widgetbook_story_path": "Map Widget / Debug mode"


### PR DESCRIPTION
Adds hover support to the debug map widget (SPEC/ui/map-widget.md).

**Spec**
- New **Hover** section: selector (simple square) with subtle bouncing animation; hovered province/sea-zone borders glow with subtle pulse; optional `onProvinceHovered` callback.
- Responsibility and acceptance criteria updated.

**Implementation** (`CtRegionMapDebug`)
- `StatefulWidget` with `MouseRegion`: hover updates hovered cell and calls `onProvinceHovered(prefixedId)` / `onProvinceHovered(null)` on exit.
- Selector: white square outline on hovered tile with scale bounce (4% amplitude).
- Province/sea-zone border glow: semi-transparent white stroke with opacity pulse on the hovered region’s borders.
- Animation controller runs only while a tile is hovered so `pumpAndSettle` in tests can complete.

**Tests**
- Contains `MouseRegion` for hover.
- Builds with `onProvinceHovered` callback.

**Catalog**
- `constructor_props` updated to include `onProvinceHovered`.

Made with [Cursor](https://cursor.com)