### PR TITLE
feat(app): province/sea zone detail overlay with Widgetbook and tests

### DIFF
--- a/SPEC/ui/province-sea-zone-detail-overlay.md
+++ b/SPEC/ui/province-sea-zone-detail-overlay.md
@@ -1,0 +1,100 @@
+# Province and Sea Zone Detail Overlay
+
+**SPEC/ui** — Detail overlay shown when the user selects a province or sea zone on the map. Integrates with [map-widget.md](map-widget.md) and [empire-overview.md](empire-overview.md). Province/sea zone identity: [world-model-identity.md](../game/world-model-identity.md).
+
+---
+
+## Purpose
+
+When the user taps/clicks a tile on the map widget, the in-game shell displays a detail overlay for the province (land) or sea zone (water) containing that tile. The overlay shows essential information; it is toggleable (tap again or close button) and responsive (side panel on desktop, bottom sheet with tabs on mobile).
+
+---
+
+## Interaction
+
+- **Open:** User taps/clicks a province or sea zone on the map. The overlay appears. Tapping the same selection again toggles the overlay closed.
+- **Close:** User taps the close button, or taps the same selection again.
+- **Switch:** Tapping a different province/sea zone updates the overlay content to the new selection.
+- **Data context:** All data is from the human player's view (visibility, prospecting, etc.).
+
+---
+
+## Layout and Responsiveness
+
+- **Max height:** Overlay never occupies more than one-third of the screen height.
+- **Desktop / larger screens:** Overlay appears as a side panel (e.g. right side). Content scrolls if needed.
+- **Mobile / narrow viewports:** Overlay appears as a bottom sheet. Content is organized in **tabs** (Political, Economic, Military, Civilian, Naval) so each tab fits within the one-third height constraint.
+- **Tabs:** Political | Economic | Military | Civilian | Naval. On desktop, tabs may be shown as sections in a single scrollable panel if space allows.
+
+---
+
+## Province Overlay Content
+
+### Political
+
+- Province name (or prefixed id fallback)
+- Owner (Great Power, Minor Nation, Tribe, or "Unclaimed")
+
+### Economic
+
+- **Resources available:** List of resource ids present on tiles in the province (from `WorldState.resourceByTileKey` and `tileKeysByRegionAndProvince`).
+- **Tiles yet to be prospected:** Count and list of tile coordinates `(x, y)` for mineral tiles (iron, copper, tin, coal, silver, gold, gems, diamonds) that are not in `playerProspectedTiles[humanPlayerId]`.
+- **Improvements built:** List of tile coordinates `(x, y)` with improvement level > 0; show improvement type (Farm, Mine, etc.) and level per [extraction-and-improvements.md](../game/extraction-and-improvements.md) naming.
+- **Improvements available:** List of tile coordinates `(x, y)` where the human player can build (tile has resource, improvement level < 4, tech allows, connectivity). Hover over a coordinate shows a secondary cursor/highlight on the map over that tile.
+
+### Military
+
+- **Regiments present:** Units in the province where `unitRoleForType(u.type) == UnitRole.military`. Show type and count (or list).
+
+### Civilian
+
+- **Civilian units present:** Units in the province that are not military (Explorer, Builder, Engineer, etc.). Show unit type, id, and **status** (idle, working, done; from `Unit.status` and `currentWork` if present).
+
+### Naval
+
+- **Ships in port:** Fleets in sea zones adjacent to the province's port(s). Per [ships-and-naval.md](../game/ships-and-naval.md): home fleet and sea-going fleets in the capital port sea zone or other port sea zones count as "in port" at that province. Implementation uses `portsByProvinceSeaboard` and `WorldState.fleets`; see ships-in-port helper in colonizethis_logic.
+
+---
+
+## Sea Zone Overlay Content
+
+Similar structure where applicable:
+
+- **Political:** Sea zone id/name (or prefixed id).
+- **Economic:** N/A for sea zones.
+- **Military:** N/A (land units only).
+- **Civilian:** N/A.
+- **Naval:** Fleets in this sea zone (owner, ship types, mission).
+
+---
+
+## Tile Coordinate Hover
+
+When the overlay lists tile coordinates (e.g. improvements built/available), hovering over a coordinate entry causes a **secondary highlight** on the map: a cursor or outline appears over the corresponding tile. The map widget must support an optional `highlightedTileKey` (or `highlightedTileX`, `highlightedTileY`) prop and render the highlight. The overlay passes the hovered coordinate to the parent, which updates the map's highlight.
+
+---
+
+## Acceptance Criteria
+
+- **Given** the user taps a province on the map, **when** the overlay is not shown, **then** the overlay appears with province content (Political, Economic, Military, Civilian, Naval).
+- **Given** the overlay is shown for a province, **when** the user taps the same province again or the close button, **then** the overlay closes.
+- **Given** the overlay is shown, **when** the user taps a different province, **then** the overlay content updates to the new province.
+- **Given** the user taps a sea zone, **when** the overlay is not shown, **then** the overlay appears with sea zone content (Political, Naval).
+- **Given** the overlay lists tile coordinates, **when** the user hovers over a coordinate, **then** a secondary highlight appears on the map over that tile.
+- **Given** a mobile viewport, **when** the overlay is shown, **then** it appears as a bottom sheet with tabs and does not exceed one-third of screen height.
+- **Given** a desktop viewport, **when** the overlay is shown, **then** it appears as a side panel.
+
+### Widgetbook
+
+- **Given** the Province Overlay Widgetbook story "Standalone — province", **when** the story renders, **then** the overlay displays province content (Political, Economic, Military, Civilian, Naval) with demo data.
+- **Given** the Province Overlay Widgetbook story "Standalone — sea zone", **when** the story renders, **then** the overlay displays sea zone content (Political, Naval).
+- **Given** the Province Overlay Widgetbook story "With map — province selected", **when** the story renders, **then** the map and overlay appear side by side; the overlay shows the selected province; tapping the map toggles or updates selection.
+- **Given** the Province Overlay Widgetbook story "Standalone (mobile)", **when** the story renders, **then** the overlay uses tabs and does not exceed one-third of viewport height.
+
+---
+
+## Integration
+
+- **Map widget:** [map-widget.md](map-widget.md). Uses `onProvinceSelected`; selection may be province or sea zone (regionCellId). Map widget supports `highlightedTileKey` for coordinate hover.
+- **Ships in port:** Helper in colonizethis_logic returns fleets in port at a province.
+- **Catalog:** Register overlay component in app widget catalog when implemented.

--- a/app/lib/core/services/game_service.dart
+++ b/app/lib/core/services/game_service.dart
@@ -7,9 +7,14 @@ import 'package:hive/hive.dart';
 
 /// Cached map data for a game (topology and tile maps for turn resolution).
 class _GameMapCache {
-  _GameMapCache({required this.combinedTopology, required this.tileMapByRegion});
+  _GameMapCache({
+    required this.combinedTopology,
+    required this.tileMapByRegion,
+    required this.topologyByRegion,
+  });
   final MapTopology combinedTopology;
   final Map<String, TileMapResult> tileMapByRegion;
+  final Map<String, MapTopology> topologyByRegion;
 }
 
 /// Loads/saves games and advances turn. SPEC/project/phase-1: app invokes TurnResolver and persists via colonizethis_save.
@@ -20,12 +25,55 @@ class GameService {
   final Box<dynamic> _box;
   final GameSaveAdapter _adapter;
 
-  /// In-memory cache: game id -> map data for resolveTurnForGame (extraction, movement).
-  /// Populated when creating a new game; not persisted (loaded games have no map data unless re-created).
+  /// In-memory cache: game id -> map data for resolveTurnForGame and map rendering.
+  /// Populated when creating a new game or when loading a game with persisted map data.
   final Map<String, _GameMapCache> _mapCache = {};
 
   /// Loads game by id. Returns null if not found.
-  Game? loadGame(String gameId) => _adapter.load(_box, gameId);
+  /// When map data exists in storage, populates _mapCache so map rendering works.
+  Game? loadGame(String gameId) {
+    final game = _adapter.load(_box, gameId);
+    if (game == null) return null;
+    final cached = _mapCache[gameId];
+    if (cached != null) return game;
+    final mapData = _adapter.loadMapData(_box, gameId);
+    if (mapData != null) {
+      _mapCache[gameId] = _GameMapCache(
+        combinedTopology: mapData.combinedTopology,
+        tileMapByRegion: mapData.tileMapByRegion,
+        topologyByRegion: mapData.topologyByRegion,
+      );
+    }
+    return game;
+  }
+
+  /// Returns map data for [gameId] from cache or storage. Null if not available (legacy save).
+  ({
+    MapTopology combinedTopology,
+    Map<String, TileMapResult> tileMapByRegion,
+    Map<String, MapTopology> topologyByRegion,
+  })? getMapData(String gameId) {
+    final cached = _mapCache[gameId];
+    if (cached != null) {
+      return (
+        combinedTopology: cached.combinedTopology,
+        tileMapByRegion: cached.tileMapByRegion,
+        topologyByRegion: cached.topologyByRegion,
+      );
+    }
+    final mapData = _adapter.loadMapData(_box, gameId);
+    if (mapData == null) return null;
+    _mapCache[gameId] = _GameMapCache(
+      combinedTopology: mapData.combinedTopology,
+      tileMapByRegion: mapData.tileMapByRegion,
+      topologyByRegion: mapData.topologyByRegion,
+    );
+    return (
+      combinedTopology: mapData.combinedTopology,
+      tileMapByRegion: mapData.tileMapByRegion,
+      topologyByRegion: mapData.topologyByRegion,
+    );
+  }
 
   /// Saves game to storage.
   void saveGame(Game game) => _adapter.save(_box, game);
@@ -112,6 +160,14 @@ class GameService {
     _mapCache[gameId] = _GameMapCache(
       combinedTopology: result.combinedTopology,
       tileMapByRegion: result.tileMapByRegion,
+      topologyByRegion: result.topologyByRegion,
+    );
+    _adapter.saveMapData(
+      _box,
+      gameId,
+      tileMapByRegion: result.tileMapByRegion,
+      topologyByRegion: result.topologyByRegion,
+      combinedTopology: result.combinedTopology,
     );
     saveGame(result.game);
     return result.game;

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
 import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
@@ -6,21 +7,31 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../providers/game_service_provider.dart';
 import '../../../../providers/games_provider.dart';
+import '../../../../providers/map_view_provider.dart';
+import '../../../../widgets/region_map_debug.dart';
+import '../widgets/province_sea_zone_detail_overlay.dart';
 import '../widgets/technology_panel.dart';
 import 'game_canvas.dart';
 
-/// Hosts the Flame game canvas. Phase 1: Next turn invokes TurnResolver and persists.
+/// Hosts the Flame game canvas or map. When map data exists, shows map + province/sea zone overlay.
 class GameScreen extends ConsumerWidget {
   const GameScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final game = ref.watch(currentGameProvider);
+    final mapViewData = ref.watch(mapViewDataProvider);
     final victory = game?.victory;
     return Scaffold(
       body: Stack(
         children: [
-          GameWidget(game: ColonizeThisGame()),
+          if (mapViewData != null && game != null)
+            _GameMapArea(
+              game: game,
+              mapViewData: mapViewData,
+            )
+          else
+            GameWidget(game: ColonizeThisGame()),
           if (game != null && victory == null) ...[
             Positioned(
               right: 16,
@@ -69,6 +80,105 @@ class GameScreen extends ConsumerWidget {
             ),
         ],
       ),
+    );
+  }
+}
+
+/// Map area with region tabs and province/sea zone detail overlay. SPEC/ui/province-sea-zone-detail-overlay.md.
+class _GameMapArea extends StatefulWidget {
+  const _GameMapArea({
+    required this.game,
+    required this.mapViewData,
+  });
+
+  final ct_models.Game game;
+  final InitGameMapViewData mapViewData;
+
+  @override
+  State<_GameMapArea> createState() => _GameMapAreaState();
+}
+
+class _GameMapAreaState extends State<_GameMapArea> {
+  int _regionIndex = 0;
+  String? _selectedDetailId;
+  String? _highlightedTileKey;
+
+  String get _humanPlayerId =>
+      widget.game.players.where((p) => p.isHuman).map((p) => p.id).firstOrNull ??
+      widget.game.players.first.id;
+
+  RegionMapViewData get _currentRegion =>
+      _regionIndex == 0 ? widget.mapViewData.oldWorld : widget.mapViewData.newWorld;
+
+  void _onProvinceSelected(String provinceId) {
+    setState(() {
+      _selectedDetailId = _selectedDetailId == provinceId ? null : provinceId;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isNarrow = MediaQuery.sizeOf(context).width < 600;
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ChoiceChip(
+                label: const Text('Old World'),
+                selected: _regionIndex == 0,
+                onSelected: (_) => setState(() => _regionIndex = 0),
+              ),
+              const SizedBox(width: 8),
+              ChoiceChip(
+                label: const Text('New World'),
+                selected: _regionIndex == 1,
+                onSelected: (_) => setState(() => _regionIndex = 1),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: Row(
+            children: [
+              Expanded(
+                child: CtRegionMapDebug(
+                  region: _currentRegion,
+                  cellSizePx: 24,
+                  onProvinceSelected: _onProvinceSelected,
+                  highlightedTileKey: _highlightedTileKey,
+                ),
+              ),
+              if (!isNarrow && _selectedDetailId != null)
+                SizedBox(
+                  width: 320,
+                  child: ProvinceSeaZoneDetailOverlay(
+                    game: widget.game,
+                    region: _currentRegion,
+                    selectedId: _selectedDetailId!,
+                    humanPlayerId: _humanPlayerId,
+                    onHighlightTile: (k) => setState(() => _highlightedTileKey = k),
+                    onClose: () => setState(() => _selectedDetailId = null),
+                  ),
+                ),
+            ],
+          ),
+        ),
+        if (isNarrow && _selectedDetailId != null)
+          SizedBox(
+            height: MediaQuery.sizeOf(context).height * 0.33,
+            child: ProvinceSeaZoneDetailOverlay(
+              game: widget.game,
+              region: _currentRegion,
+              selectedId: _selectedDetailId!,
+              humanPlayerId: _humanPlayerId,
+              onHighlightTile: (k) => setState(() => _highlightedTileKey = k),
+              onClose: () => setState(() => _selectedDetailId = null),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/app/lib/features/game/widgets/province_overlay_demo_data.dart
+++ b/app/lib/features/game/widgets/province_overlay_demo_data.dart
@@ -4,7 +4,7 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 
-import 'region_map_demo_data.dart';
+import 'package:colonizethis_app/widgets/region_map_demo_data.dart';
 
 /// Builds a minimal Game for overlay demo. Region 'demo' with provinces p1–p4, units, fleets.
 Game buildDemoGameForOverlay() {

--- a/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
+++ b/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
@@ -1,0 +1,434 @@
+// Province and sea zone detail overlay. SPEC/ui/province-sea-zone-detail-overlay.md.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+
+/// Overlay showing province or sea zone details. Toggleable; responsive; max 1/3 screen.
+class ProvinceSeaZoneDetailOverlay extends StatelessWidget {
+  const ProvinceSeaZoneDetailOverlay({
+    super.key,
+    required this.game,
+    required this.region,
+    required this.selectedId,
+    required this.humanPlayerId,
+    this.onHighlightTile,
+    this.onClose,
+  });
+
+  final Game game;
+  final RegionMapViewData region;
+  final String selectedId;
+  final String humanPlayerId;
+  final void Function(String? tileKey)? onHighlightTile;
+  final VoidCallback? onClose;
+
+  bool get _isSeaZone {
+    final parts = selectedId.split('|');
+    if (parts.length < 2) return false;
+    if (parts[0] != region.regionId) return false;
+    final localId = parts.skip(1).join('|');
+    for (final cell in region.cells) {
+      if (cell.regionCellId == localId) return cell.isSea;
+    }
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isNarrow = MediaQuery.sizeOf(context).width < 600;
+    final maxHeight = MediaQuery.sizeOf(context).height * 0.33;
+    final content = _isSeaZone
+        ? _seaZoneContent(
+            game: game,
+            region: region,
+            seaZoneId: selectedId,
+          )
+        : _provinceContent(
+            game: game,
+            region: region,
+            provinceId: selectedId,
+            humanPlayerId: humanPlayerId,
+            onHighlightTile: onHighlightTile,
+          );
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxHeight: maxHeight),
+      child: Card(
+        margin: const EdgeInsets.all(8),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(left: 12, right: 8, top: 8),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      _isSeaZone ? 'Sea zone' : 'Province',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    onPressed: onClose,
+                    tooltip: 'Close',
+                  ),
+                ],
+              ),
+            ),
+            Flexible(
+              child: isNarrow
+                  ? DefaultTabController(
+                      length: content.tabCount,
+                      child: Column(
+                        children: [
+                          TabBar(
+                            tabs: content.tabs,
+                            isScrollable: true,
+                          ),
+                          Expanded(
+                            child: TabBarView(
+                              children: content.tabViews,
+                            ),
+                          ),
+                        ],
+                      ),
+                    )
+                  : SingleChildScrollView(
+                      padding: const EdgeInsets.all(12),
+                      child: content.sections,
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _OverlayContent {
+  _OverlayContent({
+    required this.tabCount,
+    required this.tabs,
+    required this.tabViews,
+    required this.sections,
+  });
+  final int tabCount;
+  final List<Widget> tabs;
+  final List<Widget> tabViews;
+  final Widget sections;
+}
+
+_OverlayContent _provinceContent({
+  required Game game,
+  required RegionMapViewData region,
+  required String provinceId,
+  required String humanPlayerId,
+  void Function(String?)? onHighlightTile,
+}) {
+  final province = _findProvince(game, provinceId);
+  final regionData = provinceId.startsWith('newWorld')
+      ? game.worldState.newWorld
+      : game.worldState.oldWorld;
+  final units = regionData.units.where((u) => u.provinceId == provinceId).toList();
+  final military = units.where((u) => isMilitaryUnit(u.type)).toList();
+  final civilian = units.where((u) => !isMilitaryUnit(u.type)).toList();
+  final fleetsInPort = fleetsInPortAtProvince(game.worldState, provinceId);
+  final tileKeys = game.worldState.tileKeysByRegionAndProvince[region.regionId]?[provinceId] ?? [];
+  final resourceByTile = game.worldState.resourceByTileKey;
+  final tileState = game.worldState.tileState;
+  final prospected = game.worldState.playerProspectedTiles[humanPlayerId] ?? {};
+  const mineralResources = {'iron', 'copper', 'tin', 'coal', 'silver', 'gold', 'gems', 'diamonds'};
+
+  final tilesToProspect = <String>[];
+  final improvementsBuilt = <({String tileKey, int x, int y, String name, int level})>[];
+  final improvementsAvailable = <({String tileKey, int x, int y})>[];
+  final resources = <String>{};
+
+  for (final tk in tileKeys) {
+    final res = resourceByTile[tk];
+    if (res != null) resources.add(res);
+    final parts = tk.split('|');
+    if (parts.length < 4) continue;
+    final x = int.tryParse(parts[2]) ?? 0;
+    final y = int.tryParse(parts[3]) ?? 0;
+    if (mineralResources.contains(res) && !prospected.contains(tk)) {
+      tilesToProspect.add(tk);
+    }
+    final imp = tileState.improvementLevel(tk);
+    if (imp > 0) {
+      improvementsBuilt.add((
+        tileKey: tk,
+        x: x,
+        y: y,
+        name: _improvementNameForResource(res),
+        level: imp,
+      ));
+    } else if (res != null && imp < 4) {
+      improvementsAvailable.add((tileKey: tk, x: x, y: y));
+    }
+  }
+
+  final political = _buildPoliticalSection(
+    name: province?.displayName ?? provinceId,
+    ownerName: _ownerName(game, province?.ownerId),
+  );
+  final economic = _buildEconomicSection(
+    resources: resources.toList(),
+    tilesToProspect: tilesToProspect,
+    improvementsBuilt: improvementsBuilt,
+    improvementsAvailable: improvementsAvailable,
+    region: region,
+    onHighlightTile: onHighlightTile,
+  );
+  final militarySection = _buildMilitarySection(military);
+  final civilianSection = _buildCivilianSection(civilian);
+  final naval = _buildNavalSection(game, fleetsInPort);
+
+  final tabs = [
+    const Tab(text: 'Political'),
+    const Tab(text: 'Economic'),
+    const Tab(text: 'Military'),
+    const Tab(text: 'Civilian'),
+    const Tab(text: 'Naval'),
+  ];
+  final tabViews = [
+    political,
+    economic,
+    militarySection,
+    civilianSection,
+    naval,
+  ];
+  final sections = Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      political,
+      economic,
+      militarySection,
+      civilianSection,
+      naval,
+    ],
+  );
+  return _OverlayContent(tabCount: 5, tabs: tabs, tabViews: tabViews, sections: sections);
+}
+
+_OverlayContent _seaZoneContent({
+  required Game game,
+  required RegionMapViewData region,
+  required String seaZoneId,
+}) {
+  final parts = seaZoneId.split('|');
+  final regionId = parts.isNotEmpty ? parts[0] : 'oldWorld';
+  final localSeaZoneId = parts.length >= 2 ? parts[1] : seaZoneId;
+  final fleets = game.worldState.fleets
+      .where((f) => f.regionId == regionId && f.seaZoneId == localSeaZoneId)
+      .toList();
+
+  final political = _buildSection(
+    'Political',
+    Text('Sea zone: $seaZoneId'),
+  );
+  final naval = _buildNavalSection(game, fleets);
+
+  final tabs = [const Tab(text: 'Political'), const Tab(text: 'Naval')];
+  final tabViews = [political, naval];
+  final sections = Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    mainAxisSize: MainAxisSize.min,
+    children: [political, naval],
+  );
+  return _OverlayContent(tabCount: 2, tabs: tabs, tabViews: tabViews, sections: sections);
+}
+
+Province? _findProvince(Game game, String provinceId) {
+  for (final p in game.worldState.oldWorld.provinces) {
+    if (p.id == provinceId) return p;
+  }
+  for (final p in game.worldState.newWorld.provinces) {
+    if (p.id == provinceId) return p;
+  }
+  return null;
+}
+
+String _ownerName(Game game, String? ownerId) {
+  if (ownerId == null || ownerId.isEmpty) return 'Unclaimed';
+  for (final p in game.players) {
+    if (p.id == ownerId) return p.displayName;
+  }
+  for (final m in game.minorNations) {
+    if (m.id == ownerId) return m.displayName ?? m.id;
+  }
+  for (final t in game.tribes) {
+    if (t.id == ownerId) return t.displayName ?? t.id;
+  }
+  return ownerId;
+}
+
+String _improvementNameForResource(String? resourceId) {
+  if (resourceId == null) return 'Improvement';
+  switch (resourceId) {
+    case 'grain':
+      return 'Farm';
+    case 'meat':
+    case 'horses':
+      return 'Ranch';
+    case 'wool':
+      return 'Pasture';
+    case 'timber':
+      return 'Lumber camp';
+    case 'sugarCane':
+    case 'tobacco':
+    case 'cotton':
+    case 'spices':
+      return 'Plantation';
+    case 'furs':
+      return 'Fur post';
+    case 'iron':
+    case 'copper':
+    case 'tin':
+    case 'coal':
+    case 'silver':
+    case 'gold':
+    case 'gems':
+    case 'diamonds':
+      return 'Mine';
+    default:
+      return 'Improvement';
+  }
+}
+
+Widget _buildPoliticalSection({required String name, required String ownerName}) {
+  return _buildSection('Political', Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      Text('Name: $name'),
+      Text('Owner: $ownerName'),
+    ],
+  ));
+}
+
+Widget _buildEconomicSection({
+  required List<String> resources,
+  required List<String> tilesToProspect,
+  required List<({String tileKey, int x, int y, String name, int level})> improvementsBuilt,
+  required List<({String tileKey, int x, int y})> improvementsAvailable,
+  required RegionMapViewData region,
+  void Function(String?)? onHighlightTile,
+}) {
+  return _buildSection('Economic', Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      Text('Resources: ${resources.isEmpty ? "—" : resources.join(", ")}'),
+      Text('Tiles to prospect: ${tilesToProspect.length}'),
+      if (tilesToProspect.isNotEmpty)
+        Wrap(
+          spacing: 4,
+          children: tilesToProspect.take(10).map((tk) {
+            final parts = tk.split('|');
+            final x = parts.length >= 4 ? parts[2] : '?';
+            final y = parts.length >= 4 ? parts[3] : '?';
+            final tileKey = tk;
+            return MouseRegion(
+              cursor: SystemMouseCursors.click,
+              onEnter: (_) => onHighlightTile?.call(tileKey),
+              onExit: (_) => onHighlightTile?.call(null),
+              child: Text('($x,$y)', style: const TextStyle(decoration: TextDecoration.underline)),
+            );
+          }).toList(),
+        ),
+      Text('Improvements built:'),
+      ...improvementsBuilt.take(8).map((e) => MouseRegion(
+            cursor: SystemMouseCursors.click,
+            onEnter: (_) => onHighlightTile?.call(e.tileKey),
+            onExit: (_) => onHighlightTile?.call(null),
+            child: Padding(
+              padding: const EdgeInsets.only(left: 8),
+              child: Text('${e.name} L${e.level} at (${e.x},${e.y})'),
+            ),
+          )),
+      if (improvementsBuilt.isEmpty) const Padding(padding: EdgeInsets.only(left: 8), child: Text('—')),
+      Text('Improvements available:'),
+      ...improvementsAvailable.take(8).map((e) => MouseRegion(
+            cursor: SystemMouseCursors.click,
+            onEnter: (_) => onHighlightTile?.call(e.tileKey),
+            onExit: (_) => onHighlightTile?.call(null),
+            child: Padding(
+              padding: const EdgeInsets.only(left: 8),
+              child: Text('(${e.x},${e.y})'),
+            ),
+          )),
+      if (improvementsAvailable.isEmpty) const Padding(padding: EdgeInsets.only(left: 8), child: Text('—')),
+    ],
+  ));
+}
+
+Widget _buildMilitarySection(List<Unit> units) {
+  final byType = <String, int>{};
+  for (final u in units) {
+    byType[u.type] = (byType[u.type] ?? 0) + 1;
+  }
+  return _buildSection('Military', Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      if (units.isEmpty)
+        const Text('—')
+      else
+        ...byType.entries.map((e) => Text('${e.key}: ${e.value}')),
+    ],
+  ));
+}
+
+Widget _buildCivilianSection(List<Unit> units) {
+  return _buildSection('Civilian', Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      if (units.isEmpty)
+        const Text('—')
+      else
+        ...units.map((u) => Text('${u.type} (${u.id}): ${u.status.name}')),
+    ],
+  ));
+}
+
+Widget _buildNavalSection(Game game, List<Fleet> fleets) {
+  return _buildSection('Naval', Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      if (fleets.isEmpty)
+        const Text('—')
+      else
+        ...fleets.map((f) {
+          final ownerName = _ownerName(game, f.ownerId);
+          final ships = f.shipTypeIds;
+          final byType = <String, int>{};
+          for (final s in ships) {
+            byType[s] = (byType[s] ?? 0) + 1;
+          }
+          return Text('$ownerName: ${byType.entries.map((e) => '${e.key}×${e.value}').join(', ')}');
+        }),
+    ],
+  ));
+}
+
+Widget _buildSection(String title, Widget child) {
+  return Padding(
+    padding: const EdgeInsets.only(bottom: 12),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(title, style: const TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 4),
+        child,
+      ],
+    ),
+  );
+}

--- a/app/lib/providers/map_view_provider.dart
+++ b/app/lib/providers/map_view_provider.dart
@@ -1,0 +1,22 @@
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'game_service_provider.dart';
+import 'games_provider.dart';
+
+/// Map view data for the current game. Null when no game, no map data (legacy save), or loading.
+final mapViewDataProvider = Provider<InitGameMapViewData?>((ref) {
+  final game = ref.watch(currentGameProvider);
+  if (game == null) return null;
+  final service = ref.watch(gameServiceProvider);
+  final mapData = service.getMapData(game.id);
+  if (mapData == null) return null;
+  final colorOverride = greatPowerColorOverrideFromGame(game);
+  return buildInitGameMapViewData(
+    game: game,
+    tileMapByRegion: mapData.tileMapByRegion,
+    topologyByRegion: mapData.topologyByRegion,
+    cellSize: 24,
+    greatPowerColorOverride: colorOverride,
+  );
+});

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -3,8 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:widgetbook/widgetbook.dart';
 
 import 'config/themes.dart';
+import 'features/game/widgets/province_sea_zone_detail_overlay.dart';
 import 'widgets/game_setup.dart';
 import 'widgets/main_menu.dart';
+import 'widgets/province_overlay_demo_data.dart';
 import 'widgets/region_map_debug.dart';
 import 'widgets/region_map_demo_data.dart';
 
@@ -38,6 +40,7 @@ class CtWidgetbookApp extends StatelessWidget {
         ...mainMenuDirectories,
         ...gameSetupDirectories,
         ...mapWidgetDirectories,
+        ...provinceOverlayDirectories,
       ],
       lightTheme: AppThemes.colonial,
       darkTheme: AppThemes.colonial,
@@ -261,3 +264,142 @@ List<WidgetbookNode> get mapWidgetDirectories => [
         ],
       ),
     ];
+
+/// Province/Sea Zone Detail Overlay stories. SPEC/ui/province-sea-zone-detail-overlay.md.
+List<WidgetbookNode> get provinceOverlayDirectories => [
+      WidgetbookFolder(
+        name: 'Province Overlay',
+        children: [
+          WidgetbookUseCase(
+            name: 'Standalone — province',
+            builder: (context) {
+              final game = buildDemoGameForOverlay();
+              final region = demoRegionForOverlay;
+              return SizedBox(
+                width: 320,
+                height: 400,
+                child: ProvinceSeaZoneDetailOverlay(
+                  game: game,
+                  region: region,
+                  selectedId: 'demo|p2',
+                  humanPlayerId: 'gp1',
+                  onClose: () {},
+                ),
+              );
+            },
+          ),
+          WidgetbookUseCase(
+            name: 'Standalone — sea zone',
+            builder: (context) {
+              final game = buildDemoGameForOverlay();
+              final region = demoRegionForOverlay;
+              return SizedBox(
+                width: 320,
+                height: 280,
+                child: ProvinceSeaZoneDetailOverlay(
+                  game: game,
+                  region: region,
+                  selectedId: 'demo|s1',
+                  humanPlayerId: 'gp1',
+                  onClose: () {},
+                ),
+              );
+            },
+          ),
+          WidgetbookUseCase(
+            name: 'Standalone (mobile)',
+            builder: (context) => mobileViewport(
+              context,
+              Builder(
+                builder: (context) {
+                  final game = buildDemoGameForOverlay();
+                  final region = demoRegionForOverlay;
+                  return ProvinceSeaZoneDetailOverlay(
+                    game: game,
+                    region: region,
+                    selectedId: 'demo|p1',
+                    humanPlayerId: 'gp1',
+                    onClose: () {},
+                  );
+                },
+              ),
+            ),
+          ),
+          WidgetbookUseCase(
+            name: 'With map — province selected',
+            builder: (context) => _MapWithOverlayStory(selectedId: 'demo|p2'),
+          ),
+          WidgetbookUseCase(
+            name: 'With map — sea zone selected',
+            builder: (context) => _MapWithOverlayStory(selectedId: 'demo|s1'),
+          ),
+        ],
+      ),
+    ];
+
+/// Map + overlay in tandem for Widgetbook. SPEC/ui/province-sea-zone-detail-overlay.md.
+class _MapWithOverlayStory extends StatefulWidget {
+  const _MapWithOverlayStory({required this.selectedId});
+
+  final String selectedId;
+
+  @override
+  State<_MapWithOverlayStory> createState() => _MapWithOverlayStoryState();
+}
+
+class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
+  late String _selectedId;
+  String? _highlightedTileKey;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedId = widget.selectedId;
+  }
+
+  @override
+  void didUpdateWidget(covariant _MapWithOverlayStory oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.selectedId != widget.selectedId) {
+      _selectedId = widget.selectedId;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final game = buildDemoGameForOverlay();
+    final region = demoRegionForOverlay;
+    final isNarrow = MediaQuery.sizeOf(context).width < 600;
+    return SizedBox(
+      width: 800,
+      height: 500,
+      child: Row(
+        children: [
+          Expanded(
+            flex: 2,
+            child: CtRegionMapDebug(
+              region: region,
+              cellSizePx: 28,
+              onProvinceSelected: (id) =>
+                  setState(() => _selectedId = _selectedId == id ? '' : id),
+              highlightedTileKey: _highlightedTileKey,
+            ),
+          ),
+          if (!isNarrow && _selectedId.isNotEmpty)
+            SizedBox(
+              width: 320,
+              child: ProvinceSeaZoneDetailOverlay(
+                game: game,
+                region: region,
+                selectedId: _selectedId,
+                humanPlayerId: 'gp1',
+                onHighlightTile: (k) =>
+                    setState(() => _highlightedTileKey = k),
+                onClose: () => setState(() => _selectedId = ''),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -6,7 +6,7 @@ import 'config/themes.dart';
 import 'features/game/widgets/province_sea_zone_detail_overlay.dart';
 import 'widgets/game_setup.dart';
 import 'widgets/main_menu.dart';
-import 'widgets/province_overlay_demo_data.dart';
+import 'features/game/widgets/province_overlay_demo_data.dart';
 import 'widgets/region_map_debug.dart';
 import 'widgets/region_map_demo_data.dart';
 

--- a/app/lib/widgets/province_overlay_demo_data.dart
+++ b/app/lib/widgets/province_overlay_demo_data.dart
@@ -1,0 +1,147 @@
+// Demo Game and region data for ProvinceSeaZoneDetailOverlay Widgetbook and tests.
+// Aligns with buildDemoRegionMapViewData (regionId: demo, provinces p1–p4, sea s1–s2).
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_map/colonizethis_map.dart';
+
+import 'region_map_demo_data.dart';
+
+/// Builds a minimal Game for overlay demo. Region 'demo' with provinces p1–p4, units, fleets.
+Game buildDemoGameForOverlay() {
+  const regionId = 'demo';
+  final provinces = [
+    Province(
+      id: '$regionId|p1',
+      regionId: regionId,
+      ownerId: 'gp1',
+      displayName: 'Wessex',
+    ),
+    Province(
+      id: '$regionId|p2',
+      regionId: regionId,
+      ownerId: 'gp1',
+      displayName: 'Kent',
+    ),
+    Province(
+      id: '$regionId|p3',
+      regionId: regionId,
+      ownerId: 'gp2',
+      displayName: 'Northumbria',
+    ),
+    Province(
+      id: '$regionId|p4',
+      regionId: regionId,
+      ownerId: 'gp2',
+      displayName: 'Mercia',
+    ),
+  ];
+  final units = [
+    Unit(
+      id: 'u1',
+      type: 'pikemen',
+      ownerId: 'gp1',
+      provinceId: '$regionId|p1',
+      status: UnitStatus.idle,
+    ),
+    Unit(
+      id: 'u2',
+      type: 'Builder',
+      ownerId: 'gp1',
+      provinceId: '$regionId|p2',
+      status: UnitStatus.working,
+      tileKey: '$regionId|p2|5|4',
+    ),
+    Unit(
+      id: 'u3',
+      type: 'Explorer',
+      ownerId: 'gp1',
+      provinceId: '$regionId|p1',
+      status: UnitStatus.idle,
+      tileKey: '$regionId|p1|2|3',
+    ),
+  ];
+  final tileKeys = <String>[];
+  for (var y = 1; y < 9; y++) {
+    for (var x = 1; x < 13; x++) {
+      String provId;
+      if (x < 4) {
+        provId = 'p1';
+      } else if (x >= 10) {
+        provId = 'p3';
+      } else if (y >= 7) {
+        provId = 'p4';
+      } else {
+        provId = 'p2';
+      }
+      tileKeys.add('$regionId|$provId|$x|$y');
+    }
+  }
+  final byProvince = <String, List<String>>{};
+  for (final tk in tileKeys) {
+    final parts = tk.split('|');
+    if (parts.length >= 2) {
+      final fullId = '${parts[0]}|${parts[1]}';
+      byProvince.putIfAbsent(fullId, () => []).add(tk);
+    }
+  }
+  final resourceByTile = <String, String>{
+    '$regionId|p1|1|1': 'grain',
+    '$regionId|p2|5|3': 'timber',
+    '$regionId|p2|7|4': 'iron',
+  };
+  final improvementByTile = <String, int>{
+    '$regionId|p1|1|1': 1,
+    '$regionId|p2|5|3': 2,
+  };
+  final player = Player(
+    id: 'gp1',
+    displayName: 'England',
+    isHuman: true,
+    stockpile: const Stockpile(),
+    workerPool: const WorkerPool(),
+    treasury: 5000,
+  );
+  return Game(
+    id: 'demo_overlay',
+    worldState: WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: RegionData(
+        provinces: provinces,
+        units: units,
+      ),
+      newWorld: const RegionData(),
+      tileKeysByRegionAndProvince: {regionId: byProvince},
+      resourceByTileKey: resourceByTile,
+      tileState: TileMapState(
+        improvementByTile: improvementByTile,
+        roadLevelByTile: {},
+      ),
+      portsByProvinceSeaboard: {'$regionId|p2|s1': '$regionId|p2|6|8'},
+      fleets: [
+        Fleet(
+          id: 'f1',
+          ownerId: 'gp1',
+          seaZoneId: 's1',
+          regionId: regionId,
+          shipTypeIds: ['carrack', 'carrack'],
+        ),
+      ],
+    ),
+    players: [
+      player,
+      Player(
+        id: 'gp2',
+        displayName: 'Scotland',
+        isHuman: false,
+        stockpile: const Stockpile(),
+        workerPool: const WorkerPool(),
+        treasury: 3000,
+      ),
+    ],
+    minorNations: const [],
+    tribes: const [],
+  );
+}
+
+/// Demo region (from buildDemoRegionMapViewData) for overlay.
+RegionMapViewData get demoRegionForOverlay => buildDemoRegionMapViewData();

--- a/app/lib/widgets/region_map_debug.dart
+++ b/app/lib/widgets/region_map_debug.dart
@@ -23,6 +23,7 @@ class CtRegionMapDebug extends StatefulWidget {
     this.onProvinceSelected,
     this.onRegionViewChanged,
     this.onProvinceHovered,
+    this.highlightedTileKey,
   });
 
   final RegionMapViewData region;
@@ -31,6 +32,9 @@ class CtRegionMapDebug extends StatefulWidget {
   final void Function(String provinceId)? onProvinceSelected;
   final VoidCallback? onRegionViewChanged;
   final void Function(String? provinceId)? onProvinceHovered;
+  /// When set, shows a secondary highlight over the tile (e.g. from overlay coordinate hover).
+  /// Format: regionId|provinceId|x|y. Only used when regionId matches and x,y are in bounds.
+  final String? highlightedTileKey;
 
   @override
   State<CtRegionMapDebug> createState() => _CtRegionMapDebugState();
@@ -152,6 +156,7 @@ class _CtRegionMapDebugState extends State<CtRegionMapDebug>
                 hoveredTileY: _hoveredTileY,
                 hoveredProvinceId: hoveredProvinceId,
                 hoverAnimationT: animationT,
+                highlightedTileKey: widget.highlightedTileKey,
               ),
             ),
           ),
@@ -170,6 +175,7 @@ class _RegionMapDebugPainter extends CustomPainter {
     this.hoveredTileY,
     this.hoveredProvinceId,
     this.hoverAnimationT = 0.0,
+    this.highlightedTileKey,
   });
 
   final RegionMapViewData region;
@@ -179,6 +185,7 @@ class _RegionMapDebugPainter extends CustomPainter {
   final int? hoveredTileY;
   final String? hoveredProvinceId;
   final double hoverAnimationT;
+  final String? highlightedTileKey;
 
   static const Color _seaColor = Color(0xFF003366);
   static const Color _provinceBorderColor = Colors.black;
@@ -187,6 +194,8 @@ class _RegionMapDebugPainter extends CustomPainter {
   static const double _factionBorderWidth = 2.0;
   static const Color _selectorColor = Color(0xFFFFFFFF);
   static const Color _hoverGlowColor = Color(0x88FFFFFF);
+  static const Color _highlightedTileColor = Color(0xFFFFAA00);
+  static const double _highlightedTileStrokeWidth = 2.5;
   static const double _selectorInset = 2.0;
   static const double _selectorStrokeWidth = 2.0;
   static const double _hoverGlowStrokeWidth = 3.0;
@@ -208,6 +217,28 @@ class _RegionMapDebugPainter extends CustomPainter {
     if (hoveredTileX != null && hoveredTileY != null) {
       _paintSelector(canvas);
     }
+    if (highlightedTileKey != null) {
+      _paintHighlightedTile(canvas);
+    }
+  }
+
+  void _paintHighlightedTile(Canvas canvas) {
+    final key = highlightedTileKey!;
+    final parts = key.split('|');
+    if (parts.length < 4) return;
+    if (parts[0] != region.regionId) return;
+    final x = int.tryParse(parts[2]);
+    final y = int.tryParse(parts[3]);
+    if (x == null || y == null) return;
+    if (x < 0 || x >= region.width || y < 0 || y >= region.height) return;
+    final left = x * cellSize;
+    final top = y * cellSize;
+    final rect = Rect.fromLTWH(left, top, cellSize, cellSize);
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = _highlightedTileStrokeWidth
+      ..color = _highlightedTileColor;
+    canvas.drawRect(rect, paint);
   }
 
   void _paintTiles(Canvas canvas) {
@@ -434,6 +465,7 @@ class _RegionMapDebugPainter extends CustomPainter {
         old.hoveredTileX != hoveredTileX ||
         old.hoveredTileY != hoveredTileY ||
         old.hoveredProvinceId != hoveredProvinceId ||
-        old.hoverAnimationT != hoverAnimationT;
+        old.hoverAnimationT != hoverAnimationT ||
+        old.highlightedTileKey != highlightedTileKey;
   }
 }

--- a/app/test/province_overlay_test.dart
+++ b/app/test/province_overlay_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/province_sea_zone_detail_overlay.dart';
-import 'package:colonizethis_app/widgets/province_overlay_demo_data.dart';
+import 'package:colonizethis_app/features/game/widgets/province_overlay_demo_data.dart';
 import 'package:colonizethis_app/widgets/region_map_debug.dart';
 import 'package:colonizethis_app/widgets/region_map_demo_data.dart';
 

--- a/app/test/province_overlay_test.dart
+++ b/app/test/province_overlay_test.dart
@@ -1,0 +1,228 @@
+// Tests for ProvinceSeaZoneDetailOverlay. SPEC/ui/province-sea-zone-detail-overlay.md.
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/features/game/widgets/province_sea_zone_detail_overlay.dart';
+import 'package:colonizethis_app/widgets/province_overlay_demo_data.dart';
+import 'package:colonizethis_app/widgets/region_map_debug.dart';
+import 'package:colonizethis_app/widgets/region_map_demo_data.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  group('buildDemoGameForOverlay', () {
+    test('returns game with demo region provinces and units', () {
+      final game = buildDemoGameForOverlay();
+      expect(game.id, 'demo_overlay');
+      expect(game.players.length, 2);
+      expect(game.worldState.oldWorld.provinces.length, 4);
+      expect(game.worldState.oldWorld.units.length, 3);
+      expect(
+        game.worldState.tileKeysByRegionAndProvince.containsKey('demo'),
+        isTrue,
+      );
+    });
+  });
+
+  group('ProvinceSeaZoneDetailOverlay', () {
+    Widget buildOverlay({
+      required String selectedId,
+      void Function(String?)? onHighlightTile,
+      VoidCallback? onClose,
+    }) {
+      final game = buildDemoGameForOverlay();
+      final region = demoRegionForOverlay;
+      return MaterialApp(
+        home: Scaffold(
+          body: ProvinceSeaZoneDetailOverlay(
+            game: game,
+            region: region,
+            selectedId: selectedId,
+            humanPlayerId: 'gp1',
+            onHighlightTile: onHighlightTile,
+            onClose: onClose,
+          ),
+        ),
+      );
+    }
+
+    testWidgets('AC: Standalone province overlay displays Political, Economic, Military, Civilian, Naval',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildOverlay(selectedId: 'demo|p2'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ProvinceSeaZoneDetailOverlay), findsOneWidget);
+      expect(find.text('Province'), findsOneWidget);
+      expect(find.text('Political'), findsOneWidget);
+      expect(find.text('Economic'), findsOneWidget);
+      expect(find.text('Military'), findsOneWidget);
+      expect(find.text('Civilian'), findsOneWidget);
+      expect(find.text('Naval'), findsOneWidget);
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+
+    testWidgets('AC: Province overlay shows province name and owner',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildOverlay(selectedId: 'demo|p2'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Kent'), findsAtLeastNWidgets(1));
+      expect(find.textContaining('England'), findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('AC: Sea zone overlay displays Political and Naval',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildOverlay(selectedId: 'demo|s1'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ProvinceSeaZoneDetailOverlay), findsOneWidget);
+      expect(find.text('Sea zone'), findsOneWidget);
+      expect(find.text('Political'), findsOneWidget);
+      expect(find.text('Naval'), findsOneWidget);
+    });
+
+    testWidgets('AC: Close button invokes onClose', (WidgetTester tester) async {
+      var closed = false;
+      await tester.pumpWidget(buildOverlay(
+        selectedId: 'demo|p1',
+        onClose: () => closed = true,
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+
+      expect(closed, isTrue);
+    });
+
+    testWidgets('AC: Overlay constrained to max height', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(size: Size(800, 600)),
+          child: MaterialApp(
+            home: Scaffold(
+              body: ProvinceSeaZoneDetailOverlay(
+                game: buildDemoGameForOverlay(),
+                region: demoRegionForOverlay,
+                selectedId: 'demo|p2',
+                humanPlayerId: 'gp1',
+                onClose: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final overlay = tester.widget<ProvinceSeaZoneDetailOverlay>(
+        find.byType(ProvinceSeaZoneDetailOverlay),
+      );
+      expect(overlay.selectedId, 'demo|p2');
+      final constrained = find.byWidgetPredicate(
+        (w) =>
+            w is ConstrainedBox &&
+            w.constraints.maxHeight == 198 &&
+            w.constraints.maxHeight < 600,
+      );
+      expect(constrained, findsAtLeastNWidgets(1));
+    });
+  });
+
+  group('ProvinceSeaZoneDetailOverlay with map', () {
+    testWidgets('AC: Map and overlay appear side by side when province selected',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Row(
+              children: [
+                Expanded(
+                  child: CtRegionMapDebug(
+                    region: buildDemoRegionMapViewData(),
+                    cellSizePx: 28,
+                    onProvinceSelected: (_) {},
+                    highlightedTileKey: null,
+                  ),
+                ),
+                SizedBox(
+                  width: 320,
+                  child: ProvinceSeaZoneDetailOverlay(
+                    game: buildDemoGameForOverlay(),
+                    region: demoRegionForOverlay,
+                    selectedId: 'demo|p2',
+                    humanPlayerId: 'gp1',
+                    onClose: () {},
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CtRegionMapDebug), findsOneWidget);
+      expect(find.byType(ProvinceSeaZoneDetailOverlay), findsOneWidget);
+    });
+
+    testWidgets('AC: Map tap invokes onProvinceSelected; overlay can show selection',
+        (WidgetTester tester) async {
+      String? selectedId;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StatefulBuilder(
+              builder: (context, setState) {
+                return Row(
+                  children: [
+                    SizedBox(
+                      width: 400,
+                      height: 320,
+                      child: CtRegionMapDebug(
+                        region: buildDemoRegionMapViewData(),
+                        cellSizePx: 28,
+                        onProvinceSelected: (id) =>
+                            setState(() => selectedId = id),
+                        highlightedTileKey: null,
+                      ),
+                    ),
+                    if (selectedId != null && selectedId!.isNotEmpty)
+                      SizedBox(
+                        width: 320,
+                        child: ProvinceSeaZoneDetailOverlay(
+                          game: buildDemoGameForOverlay(),
+                          region: demoRegionForOverlay,
+                          selectedId: selectedId!,
+                          humanPlayerId: 'gp1',
+                          onClose: () => setState(() => selectedId = null),
+                        ),
+                      ),
+                  ],
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(selectedId, isNull);
+      final mapFinder = find.byType(CtRegionMapDebug);
+      final element = tester.element(
+        find.descendant(
+          of: mapFinder,
+          matching: find.byType(SizedBox),
+        ).first,
+      );
+      final box = element.renderObject! as RenderBox;
+      final center = box.localToGlobal(box.size.center(Offset.zero));
+      await tester.tapAt(center);
+      await tester.pumpAndSettle();
+
+      expect(selectedId, isNotNull);
+      expect(selectedId!, startsWith('demo|'));
+    });
+  });
+}

--- a/app/test/region_map_debug_test.dart
+++ b/app/test/region_map_debug_test.dart
@@ -1,7 +1,6 @@
 // Widget and unit tests for CtRegionMapDebug and demo map data.
 // SPEC/ui/map-widget.md; coverage for lib/widgets/ (quality gate 80%).
 
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
@@ -61,6 +60,7 @@ void main() {
       double cellSizePx = 28,
       void Function(String)? onProvinceSelected,
       void Function(String?)? onProvinceHovered,
+      String? highlightedTileKey,
     }) {
       return MaterialApp(
         home: Scaffold(
@@ -73,6 +73,7 @@ void main() {
               cellSizePx: cellSizePx,
               onProvinceSelected: onProvinceSelected,
               onProvinceHovered: onProvinceHovered,
+              highlightedTileKey: highlightedTileKey,
             ),
           ),
         ),
@@ -182,6 +183,25 @@ void main() {
 
       expect(find.byType(CtRegionMapDebug), findsOneWidget);
       expect(lastHoveredId, isNull);
+    });
+
+    testWidgets('builds with highlightedTileKey and paints secondary highlight',
+        (WidgetTester tester) async {
+      final region = buildDemoRegionMapViewData();
+      await tester.pumpWidget(buildMap(
+        region: region,
+        highlightedTileKey: '${region.regionId}|p1|2|3',
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CtRegionMapDebug), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(CtRegionMapDebug),
+          matching: find.byType(CustomPaint),
+        ),
+        findsAtLeastNWidgets(1),
+      );
     });
   });
 }

--- a/app/widget_catalog.json
+++ b/app/widget_catalog.json
@@ -25,5 +25,14 @@
     "category": "game/map",
     "source": "pipeline",
     "widgetbook_story_path": "Map Widget / Debug mode"
+  },
+  {
+    "id": "ct_province_sea_zone_detail_overlay",
+    "name": "ProvinceSeaZoneDetailOverlay",
+    "dart_file_path": "lib/features/game/widgets/province_sea_zone_detail_overlay.dart",
+    "constructor_props": "game: Game, region: RegionMapViewData, selectedId: String, humanPlayerId: String, onHighlightTile: void Function(String?)?, onClose: VoidCallback?",
+    "category": "game/overlay",
+    "source": "pipeline",
+    "widgetbook_story_path": "Province Overlay"
   }
 ]

--- a/packages/colonizethis_logic/lib/src/world/naval.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
 
 /// Naval movement helpers. SPEC/program/naval-movement-resolution.md.
 
@@ -96,4 +97,27 @@ Set<String> provinceIdsAdjacentToSeaZone(
 String? regionIdForSeaZone(MapTopology topology, String seaZoneId) {
   final list = topology.nodes.where((n) => n.id == seaZoneId).toList();
   return list.isNotEmpty ? list.first.regionId : null;
+}
+
+/// Fleets in port at [provinceId]. Per SPEC/game/ships-and-naval.md: ships in port
+/// are fleets in sea zones adjacent to the province's port(s). Uses
+/// [worldState.portsByProvinceSeaboard] (key: fullProvinceId|seaZoneId) and
+/// [worldState.fleets]. Returns fleets whose seaZoneId and regionId match a port
+/// of the province.
+List<Fleet> fleetsInPortAtProvince(WorldState worldState, String provinceId) {
+  final regionId = provinceId.contains('|')
+      ? provinceId.split('|').first
+      : 'oldWorld';
+  final seaZones = <String>{};
+  final prefix = '$provinceId|';
+  for (final key in worldState.portsByProvinceSeaboard.keys) {
+    if (key.startsWith(prefix)) {
+      seaZones.add(key.substring(prefix.length));
+    }
+  }
+  if (seaZones.isEmpty) return [];
+  return worldState.fleets
+      .where((f) =>
+          f.regionId == regionId && seaZones.contains(f.seaZoneId))
+      .toList();
 }

--- a/packages/colonizethis_logic/test/naval_test.dart
+++ b/packages/colonizethis_logic/test/naval_test.dart
@@ -1,6 +1,7 @@
-import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
 
 void main() {
   group('Naval', () {
@@ -135,6 +136,48 @@ void main() {
           provinceIdsAdjacentToSeaZone(topology, 'nonexistent'),
           isEmpty,
         );
+      });
+    });
+
+    group('fleetsInPortAtProvince', () {
+      test('returns fleets in sea zones adjacent to province port', () {
+        final worldState = WorldState(
+          turnState: TurnState(phase: TurnPhase.movement, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+          portsByProvinceSeaboard: {'oldWorld|p1|sea1': 'oldWorld|p1|0|0'},
+          fleets: [
+            Fleet(
+              id: 'f1',
+              ownerId: 'gp1',
+              seaZoneId: 'sea1',
+              regionId: 'oldWorld',
+              shipTypeIds: ['carrack', 'carrack'],
+            ),
+            Fleet(
+              id: 'f2',
+              ownerId: 'gp2',
+              seaZoneId: 'sea2',
+              regionId: 'oldWorld',
+              shipTypeIds: ['carrack'],
+            ),
+          ],
+        );
+        final inPort = fleetsInPortAtProvince(worldState, 'oldWorld|p1');
+        expect(inPort.length, 1);
+        expect(inPort.first.id, 'f1');
+        expect(inPort.first.seaZoneId, 'sea1');
+      });
+
+      test('returns empty when province has no port', () {
+        final worldState = WorldState(
+          turnState: TurnState(phase: TurnPhase.movement, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+          portsByProvinceSeaboard: {'oldWorld|p2|sea1': 'oldWorld|p2|0|0'},
+          fleets: const [],
+        );
+        expect(fleetsInPortAtProvince(worldState, 'oldWorld|p1'), isEmpty);
       });
     });
   });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -460,10 +460,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

Adds the province and sea zone detail overlay with Widgetbook stories and acceptance tests.

## Changes

- **ProvinceSeaZoneDetailOverlay** – Overlay with Political, Economic, Military, Civilian, Naval sections for provinces; Political and Naval for sea zones
- **Map integration** – Map data persistence in saves; map tap selection; tile coordinate hover highlight
- **Ships in port** – Helper in colonizethis_logic for fleets in port at a province
- **Widgetbook** – Standalone province/sea zone, mobile (tabs), and map+overlay stories
- **SPEC** – `SPEC/ui/province-sea-zone-detail-overlay.md` with ACs
- **Tests** – 8 widget tests covering overlay ACs and map integration
- **Catalog** – Overlay registered in widget catalog

Made with [Cursor](https://cursor.com)