### PR TITLE
feat(app): province overlay tile info and hover-driven update

### DIFF
--- a/SPEC/ui/province-sea-zone-detail-overlay.md
+++ b/SPEC/ui/province-sea-zone-detail-overlay.md
@@ -12,9 +12,10 @@ When the user taps/clicks a tile on the map widget, the in-game shell displays a
 
 ## Interaction
 
-- **Open:** User taps/clicks a province or sea zone on the map. The overlay appears. Tapping the same selection again toggles the overlay closed.
-- **Close:** User taps the close button, or taps the same selection again.
+- **Open:** User taps/clicks a province or sea zone on the map. The overlay appears and stays open.
+- **Close:** User taps the close button, or taps the same province/sea zone again to toggle the overlay closed.
 - **Switch:** Tapping a different province/sea zone updates the overlay content to the new selection.
+- **Hover:** When the overlay is open, hovering over the map immediately updates the overlay to show the hovered province and, in the Tile section, the hovered tile’s details (coordinates, terrain, resources, prospected, improvements, roads/railroads, civilian units in province).
 - **Data context:** All data is from the human player's view (visibility, prospecting, etc.).
 
 ---
@@ -29,6 +30,18 @@ When the user taps/clicks a tile on the map widget, the in-game shell displays a
 ---
 
 ## Province Overlay Content
+
+### Tile (hovered tile details)
+
+When the user hovers a tile on the map (with overlay open), this section shows that tile’s information. When no tile is hovered, it shows “Hover a tile to see details.”
+
+- **Tile coordinates:** (x, y) in the region grid.
+- **Terrain type:** From the tile map (e.g. plains, forest, hills).
+- **Resource:** Resource id on that tile (or —).
+- **Prospected:** Yes/no for the human player.
+- **Improvement:** Improvement name and level (e.g. Farm L2) or —.
+- **Road / railroad:** Road level (none, primitive, improved, port or railroad).
+- **Civilian units (province):** Count of civilian units in the tile’s province.
 
 ### Political
 

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -101,6 +101,8 @@ class _GameMapArea extends StatefulWidget {
 class _GameMapAreaState extends State<_GameMapArea> {
   int _regionIndex = 0;
   String? _selectedDetailId;
+  String? _hoveredDetailId;
+  String? _hoveredTileKey;
   String? _highlightedTileKey;
 
   String get _humanPlayerId =>
@@ -109,6 +111,17 @@ class _GameMapAreaState extends State<_GameMapArea> {
 
   RegionMapViewData get _currentRegion =>
       _regionIndex == 0 ? widget.mapViewData.oldWorld : widget.mapViewData.newWorld;
+
+  /// Province/sea zone to show in overlay (hover when overlay open, else selection). Prefixed id.
+  String get _displayId {
+    if (_hoveredTileKey != null) {
+      final parts = _hoveredTileKey!.split('|');
+      if (parts.length >= 2) {
+        return '${parts[0]}|${parts[1]}';
+      }
+    }
+    return _hoveredDetailId ?? _selectedDetailId ?? '';
+  }
 
   void _onProvinceSelected(String provinceId) {
     setState(() {
@@ -148,6 +161,8 @@ class _GameMapAreaState extends State<_GameMapArea> {
                   region: _currentRegion,
                   cellSizePx: 24,
                   onProvinceSelected: _onProvinceSelected,
+                  onProvinceHovered: (id) => setState(() => _hoveredDetailId = id),
+                  onTileHovered: (key) => setState(() => _hoveredTileKey = key),
                   highlightedTileKey: _highlightedTileKey,
                 ),
               ),
@@ -158,7 +173,9 @@ class _GameMapAreaState extends State<_GameMapArea> {
                     game: widget.game,
                     region: _currentRegion,
                     selectedId: _selectedDetailId!,
+                    displayId: _displayId,
                     humanPlayerId: _humanPlayerId,
+                    hoveredTileKey: _hoveredTileKey,
                     onHighlightTile: (k) => setState(() => _highlightedTileKey = k),
                     onClose: () => setState(() => _selectedDetailId = null),
                   ),
@@ -173,7 +190,9 @@ class _GameMapAreaState extends State<_GameMapArea> {
               game: widget.game,
               region: _currentRegion,
               selectedId: _selectedDetailId!,
+              displayId: _displayId,
               humanPlayerId: _humanPlayerId,
+              hoveredTileKey: _hoveredTileKey,
               onHighlightTile: (k) => setState(() => _highlightedTileKey = k),
               onClose: () => setState(() => _selectedDetailId = null),
             ),

--- a/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
+++ b/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
@@ -7,26 +7,35 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
 /// Overlay showing province or sea zone details. Toggleable; responsive; max 1/3 screen.
+/// When [hoveredTileKey] is set, overlay shows that tile's info and uses its province for content;
+/// otherwise shows [displayId]. Hover updates content immediately when overlay is open.
 class ProvinceSeaZoneDetailOverlay extends StatelessWidget {
   const ProvinceSeaZoneDetailOverlay({
     super.key,
     required this.game,
     required this.region,
     required this.selectedId,
+    required this.displayId,
     required this.humanPlayerId,
+    this.hoveredTileKey,
     this.onHighlightTile,
     this.onClose,
   });
 
   final Game game;
   final RegionMapViewData region;
+  /// Pinned selection (click-to-toggle close).
   final String selectedId;
+  /// Province or sea zone id to display (hovered when overlay open, else selected).
+  final String displayId;
   final String humanPlayerId;
+  /// When set, tile section shows this tile's coords, terrain, resources, prospected, improvements, roads, civilian units.
+  final String? hoveredTileKey;
   final void Function(String? tileKey)? onHighlightTile;
   final VoidCallback? onClose;
 
-  bool get _isSeaZone {
-    final parts = selectedId.split('|');
+  bool _isSeaZone(String id) {
+    final parts = id.split('|');
     if (parts.length < 2) return false;
     if (parts[0] != region.regionId) return false;
     final localId = parts.skip(1).join('|');
@@ -39,17 +48,19 @@ class ProvinceSeaZoneDetailOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isNarrow = MediaQuery.sizeOf(context).width < 600;
-    final content = _isSeaZone
+    final content = _isSeaZone(displayId)
         ? _seaZoneContent(
             game: game,
             region: region,
-            seaZoneId: selectedId,
+            seaZoneId: displayId,
+            hoveredTileKey: hoveredTileKey,
           )
         : _provinceContent(
             game: game,
             region: region,
-            provinceId: selectedId,
+            provinceId: displayId,
             humanPlayerId: humanPlayerId,
+            hoveredTileKey: hoveredTileKey,
             onHighlightTile: onHighlightTile,
           );
     return LayoutBuilder(
@@ -71,7 +82,7 @@ class ProvinceSeaZoneDetailOverlay extends StatelessWidget {
                     children: [
                       Expanded(
                         child: Text(
-                          _isSeaZone ? 'Sea zone' : 'Province',
+                          _isSeaZone(displayId) ? 'Sea zone' : 'Province',
                           style: Theme.of(context).textTheme.titleMedium,
                         ),
                       ),
@@ -133,6 +144,7 @@ _OverlayContent _provinceContent({
   required RegionMapViewData region,
   required String provinceId,
   required String humanPlayerId,
+  String? hoveredTileKey,
   void Function(String?)? onHighlightTile,
 }) {
   final province = _findProvince(game, provinceId);
@@ -178,6 +190,14 @@ _OverlayContent _provinceContent({
     }
   }
 
+  final tileSection = _buildTileSection(
+    game: game,
+    region: region,
+    provinceId: provinceId,
+    humanPlayerId: humanPlayerId,
+    civilianCount: civilian.length,
+    hoveredTileKey: hoveredTileKey,
+  );
   final political = _buildPoliticalSection(
     name: province?.displayName ?? provinceId,
     ownerName: _ownerName(game, province?.ownerId),
@@ -195,6 +215,7 @@ _OverlayContent _provinceContent({
   final naval = _buildNavalSection(game, fleetsInPort);
 
   final tabs = [
+    const Tab(text: 'Tile'),
     const Tab(text: 'Political'),
     const Tab(text: 'Economic'),
     const Tab(text: 'Military'),
@@ -202,6 +223,7 @@ _OverlayContent _provinceContent({
     const Tab(text: 'Naval'),
   ];
   final tabViews = [
+    tileSection,
     political,
     economic,
     militarySection,
@@ -212,6 +234,7 @@ _OverlayContent _provinceContent({
     crossAxisAlignment: CrossAxisAlignment.start,
     mainAxisSize: MainAxisSize.min,
     children: [
+      tileSection,
       political,
       economic,
       militarySection,
@@ -219,13 +242,71 @@ _OverlayContent _provinceContent({
       naval,
     ],
   );
-  return _OverlayContent(tabCount: 5, tabs: tabs, tabViews: tabViews, sections: sections);
+  return _OverlayContent(tabCount: 6, tabs: tabs, tabViews: tabViews, sections: sections);
+}
+
+Widget _buildTileSection({
+  required Game game,
+  required RegionMapViewData region,
+  required String provinceId,
+  required String humanPlayerId,
+  required int civilianCount,
+  String? hoveredTileKey,
+}) {
+  if (hoveredTileKey == null) {
+    return _buildSection('Tile', const Text('Hover a tile to see details.'));
+  }
+  final parts = hoveredTileKey.split('|');
+  if (parts.length < 4 || parts[0] != region.regionId) {
+    return _buildSection('Tile', const Text('—'));
+  }
+  final x = int.tryParse(parts[2]) ?? 0;
+  final y = int.tryParse(parts[3]) ?? 0;
+  if (x < 0 || x >= region.width || y < 0 || y >= region.height) {
+    return _buildSection('Tile', const Text('—'));
+  }
+  final cell = region.cellAt(x, y);
+  final tileState = game.worldState.tileState;
+  final resourceByTile = game.worldState.resourceByTileKey;
+  final prospected = game.worldState.playerProspectedTiles[humanPlayerId] ?? {};
+  final terrainStr = cell.terrainType?.name ?? cell.terrainTypeId ?? '—';
+  final resource = resourceByTile[hoveredTileKey] ?? cell.resourceId ?? '—';
+  final isProspected = prospected.contains(hoveredTileKey);
+  final impLevel = tileState.improvementLevel(hoveredTileKey);
+  final roadLevel = cell.isSea ? null : tileState.roadLevel(hoveredTileKey);
+  final roadLabel = roadLevel == null
+      ? '—'
+      : switch (roadLevel) {
+          0 => 'none',
+          1 => 'primitive',
+          2 => 'improved',
+          4 => 'port or railroad',
+          _ => 'level $roadLevel',
+        };
+  final improvementName = impLevel > 0 && resource != '—'
+      ? _improvementNameForResource(resource)
+      : null;
+
+  return _buildSection('Tile', Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    mainAxisSize: MainAxisSize.min,
+    children: [
+      Text('Coordinates: ($x, $y)'),
+      Text('Terrain: $terrainStr'),
+      Text('Resource: $resource'),
+      Text('Prospected: ${isProspected ? 'yes' : 'no'}'),
+      Text('Improvement: ${improvementName != null ? '$improvementName L$impLevel' : '—'}'),
+      Text('Road / railroad: $roadLabel'),
+      Text('Civilian units (province): $civilianCount'),
+    ],
+  ));
 }
 
 _OverlayContent _seaZoneContent({
   required Game game,
   required RegionMapViewData region,
   required String seaZoneId,
+  String? hoveredTileKey,
 }) {
   final parts = seaZoneId.split('|');
   final regionId = parts.isNotEmpty ? parts[0] : 'oldWorld';

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -282,6 +282,7 @@ List<WidgetbookNode> get provinceOverlayDirectories => [
                   game: game,
                   region: region,
                   selectedId: sampleProvinceIdForOverlay,
+                  displayId: sampleProvinceIdForOverlay,
                   humanPlayerId: game.players.first.id,
                   onClose: () {},
                 ),
@@ -300,6 +301,7 @@ List<WidgetbookNode> get provinceOverlayDirectories => [
                   game: game,
                   region: region,
                   selectedId: sampleSeaZoneIdForOverlay,
+                  displayId: sampleSeaZoneIdForOverlay,
                   humanPlayerId: game.players.first.id,
                   onClose: () {},
                 ),
@@ -318,6 +320,7 @@ List<WidgetbookNode> get provinceOverlayDirectories => [
                     game: game,
                     region: region,
                     selectedId: sampleProvinceIdForOverlay,
+                    displayId: sampleProvinceIdForOverlay,
                     humanPlayerId: game.players.first.id,
                     onClose: () {},
                   );
@@ -351,7 +354,19 @@ class _MapWithOverlayStory extends StatefulWidget {
 
 class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
   late String _selectedId;
+  String? _hoveredDetailId;
+  String? _hoveredTileKey;
   String? _highlightedTileKey;
+
+  String get _displayId {
+    if (_hoveredTileKey != null) {
+      final parts = _hoveredTileKey!.split('|');
+      if (parts.length >= 2) {
+        return '${parts[0]}|${parts[1]}';
+      }
+    }
+    return _hoveredDetailId ?? _selectedId;
+  }
 
   @override
   void initState() {
@@ -384,6 +399,8 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
               cellSizePx: 28,
               onProvinceSelected: (id) =>
                   setState(() => _selectedId = _selectedId == id ? '' : id),
+              onProvinceHovered: (id) => setState(() => _hoveredDetailId = id),
+              onTileHovered: (key) => setState(() => _hoveredTileKey = key),
               highlightedTileKey: _highlightedTileKey,
             ),
           ),
@@ -394,7 +411,9 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
                 game: game,
                 region: region,
                 selectedId: _selectedId,
+                displayId: _displayId,
                 humanPlayerId: 'gp1',
+                hoveredTileKey: _hoveredTileKey,
                 onHighlightTile: (k) =>
                     setState(() => _highlightedTileKey = k),
                 onClose: () => setState(() => _selectedId = ''),

--- a/app/lib/widgets/region_map_debug.dart
+++ b/app/lib/widgets/region_map_debug.dart
@@ -25,6 +25,7 @@ class CtRegionMapDebug extends StatefulWidget {
     this.onProvinceSelected,
     this.onRegionViewChanged,
     this.onProvinceHovered,
+    this.onTileHovered,
     this.highlightedTileKey,
   });
 
@@ -34,6 +35,8 @@ class CtRegionMapDebug extends StatefulWidget {
   final void Function(String provinceId)? onProvinceSelected;
   final VoidCallback? onRegionViewChanged;
   final void Function(String? provinceId)? onProvinceHovered;
+  /// When set, overlay can show tile details. Called with tile key (regionId|provinceId|x|y) or null on exit.
+  final void Function(String? tileKey)? onTileHovered;
   /// When set, shows a secondary highlight over the tile (e.g. from overlay coordinate hover).
   /// Format: regionId|provinceId|x|y. Only used when regionId matches and x,y are in bounds.
   final String? highlightedTileKey;
@@ -232,6 +235,10 @@ class _CtRegionMapDebugState extends State<CtRegionMapDebug>
     if (prevId != nextId) {
       widget.onProvinceHovered?.call(nextId);
     }
+    final nextTileKey = nx != null && ny != null
+        ? '${region.regionId}|${region.cellAt(nx, ny).regionCellId}|$nx|$ny'
+        : null;
+    widget.onTileHovered?.call(nextTileKey);
     setState(() {
       _hoveredTileX = nx;
       _hoveredTileY = ny;
@@ -323,7 +330,7 @@ class _CtRegionMapDebugState extends State<CtRegionMapDebug>
                     transformationController: _transformationController,
                     panEnabled: false,
                     minScale: 0.25,
-                    maxScale: 4,
+                    maxScale: 1,
                     child: SizedBox(
                       width: mapWidth,
                       height: mapHeight,

--- a/app/test/province_overlay_test.dart
+++ b/app/test/province_overlay_test.dart
@@ -37,6 +37,7 @@ void main() {
             game: game,
             region: region,
             selectedId: selectedId,
+            displayId: selectedId,
             humanPlayerId: game.players.first.id,
             onHighlightTile: onHighlightTile,
             onClose: onClose,
@@ -52,6 +53,7 @@ void main() {
 
       expect(find.byType(ProvinceSeaZoneDetailOverlay), findsOneWidget);
       expect(find.text('Province'), findsOneWidget);
+      expect(find.text('Tile'), findsOneWidget);
       expect(find.text('Political'), findsOneWidget);
       expect(find.text('Economic'), findsOneWidget);
       expect(find.text('Military'), findsOneWidget);
@@ -127,6 +129,7 @@ void main() {
                 game: demoGameForOverlay,
                 region: demoRegionForOverlay,
                 selectedId: sampleProvinceIdForOverlay,
+                displayId: sampleProvinceIdForOverlay,
                 humanPlayerId: demoGameForOverlay.players.first.id,
                 onClose: () {},
               ),
@@ -155,6 +158,7 @@ void main() {
                 game: demoGameForOverlay,
                 region: demoRegionForOverlay,
                 selectedId: sampleProvinceIdForOverlay,
+                displayId: sampleProvinceIdForOverlay,
                 humanPlayerId: demoGameForOverlay.players.first.id,
                 onClose: () {},
               ),
@@ -196,6 +200,7 @@ void main() {
                     game: game,
                     region: demoRegionForOverlay,
                     selectedId: sampleProvinceIdForOverlay,
+                    displayId: sampleProvinceIdForOverlay,
                     humanPlayerId: game.players.first.id,
                     onClose: () {},
                   ),
@@ -240,6 +245,7 @@ void main() {
                           game: demoGameForOverlay,
                           region: demoRegionForOverlay,
                           selectedId: selectedId!,
+                          displayId: selectedId!,
                           humanPlayerId: demoGameForOverlay.players.first.id,
                           onClose: () => setState(() => selectedId = null),
                         ),


### PR DESCRIPTION
## Summary
- **Map widget:** Max zoom capped at 1x (was 4x). Added `onTileHovered(tileKey)` callback for overlay.
- **Province overlay:** New **Tile** section showing hovered tile: coordinates, terrain, resource, prospected, improvement, road/railroad, civilian units (province count).
- **Hover:** When overlay is open, hovering the map immediately updates the overlay (displayed province and Tile section).
- **Toggle:** Click opens overlay; same province click or close button dismisses. Overlay stays open until dismissed.

## Spec
- `SPEC/ui/province-sea-zone-detail-overlay.md` updated with Tile section and hover-driven interaction.

## Tests
- Province overlay tests updated (displayId, Tile tab); all 9 tests pass.

Made with [Cursor](https://cursor.com)