### PR TITLE
refactor(logic): single-source economy, setup, turn events, diplomacy, order suggestion

### DIFF
--- a/packages/colonizethis_data/lib/src/riches_prices.dart
+++ b/packages/colonizethis_data/lib/src/riches_prices.dart
@@ -51,3 +51,9 @@ int landPurchaseBasePrice(CommodityId id) {
   if (richesPrice > 0) return richesPrice;
   return landPurchaseDefaultBasePrice;
 }
+
+/// Total treasury cost for purchase_land on a tile with [resourceId]. SPEC/game/civilian-units.md.
+/// Formula: 15 × base price (single source of truth for validation and application).
+int purchaseLandCost(String resourceId) {
+  return 15 * landPurchaseBasePrice(resourceId);
+}

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
@@ -1,0 +1,89 @@
+/// Relation and overture lookup helpers for diplomacy. SPEC/program/diplomacy-resolution.md.
+/// Shared by diplomacy_resolver and order validators.
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Overture costs per diplomacy-resolution. Consulate £500, Embassy £1000.
+const int overtureConsulateCost = 500;
+const int overtureEmbassyCost = 1000;
+
+/// Join Empire cost: base + per-province. SPEC/game/diplomacy.md.
+const int joinEmpireBaseCost = 5000;
+const int joinEmpirePerProvinceCost = 2000;
+
+/// Returns the number of provinces owned by [factionId] (Minor or Tribe) in [game].
+int provinceCountOwnedBy(Game game, String factionId) {
+  int count = 0;
+  for (final p in game.worldState.oldWorld.provinces) {
+    if (p.ownerId == factionId) count++;
+  }
+  for (final p in game.worldState.newWorld.provinces) {
+    if (p.ownerId == factionId) count++;
+  }
+  return count;
+}
+
+/// Join Empire cost in pounds for absorbing [targetId] (Minor or Tribe).
+int joinEmpireCostForMinorOrTribe(Game game, String targetId) {
+  final n = provinceCountOwnedBy(game, targetId);
+  return joinEmpireBaseCost + n * joinEmpirePerProvinceCost;
+}
+
+/// Relation score thresholds for level. 0–25 Hostile, 26–50 Neutral, 51–75 Friendly, 76–100 Allied.
+RelationLevel scoreToLevel(int score) {
+  if (score <= 25) return RelationLevel.hostile;
+  if (score <= 50) return RelationLevel.neutral;
+  if (score <= 75) return RelationLevel.friendly;
+  return RelationLevel.allied;
+}
+
+/// Normalizes faction pair for lookup (consistent ordering).
+String pairKey(String a, String b) =>
+    a.compareTo(b) <= 0 ? '$a|$b' : '$b|$a';
+
+/// Returns relation for faction pair, or null if not found.
+DiplomacyRelation? getRelation(
+    Game game, String factionId1, String factionId2) {
+  final key = pairKey(factionId1, factionId2);
+  for (final r in game.diplomacyRelations) {
+    if (pairKey(r.factionId1, r.factionId2) == key) return r;
+  }
+  return null;
+}
+
+/// Finds the relation, passes it (or null) to [updater], and replaces or appends the result.
+List<DiplomacyRelation> upsertRelation(
+  List<DiplomacyRelation> relations,
+  String factionId1,
+  String factionId2,
+  DiplomacyRelation Function(DiplomacyRelation?) updater,
+) {
+  final key = pairKey(factionId1, factionId2);
+  final idx =
+      relations.indexWhere((r) => pairKey(r.factionId1, r.factionId2) == key);
+  final existing = idx >= 0 ? relations[idx] : null;
+  final updated = updater(existing);
+  final result = List<DiplomacyRelation>.from(relations);
+  if (idx >= 0) {
+    result[idx] = updated;
+  } else {
+    result.add(updated);
+  }
+  return result;
+}
+
+/// Returns overture state for GP–Minor/Tribe, or null.
+OvertureState? getOverture(Game game, String gpId, String targetId) {
+  for (final o in game.overtureStates) {
+    if (o.gpId == gpId && o.targetId == targetId) return o;
+  }
+  return null;
+}
+
+/// Returns player by id, or null.
+Player? getPlayer(Game game, String playerId) {
+  for (final p in game.players) {
+    if (p.id == playerId) return p;
+  }
+  return null;
+}

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -5,103 +5,21 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
 
+import '../constants.dart';
 import '../combat/conflict_detection.dart';
 import '../dossier/evidence_rules.dart';
 import '../turn/turn_resolution_result.dart';
+import 'diplomacy_relation_lookup.dart';
+
+export 'diplomacy_relation_lookup.dart';
 
 final Logger _diploLog = Logger();
 
-/// Overture costs per diplomacy-resolution. Consulate £500, Embassy £1000.
-const int overtureConsulateCost = 500;
-const int overtureEmbassyCost = 1000;
-
-/// Join Empire cost: base + per-province. SPEC/game/diplomacy.md.
-const int joinEmpireBaseCost = 5000;
-const int joinEmpirePerProvinceCost = 2000;
-
-/// Returns the number of provinces owned by [factionId] (Minor or Tribe) in [game].
-int provinceCountOwnedBy(Game game, String factionId) {
-  int count = 0;
-  for (final p in game.worldState.oldWorld.provinces) {
-    if (p.ownerId == factionId) count++;
-  }
-  for (final p in game.worldState.newWorld.provinces) {
-    if (p.ownerId == factionId) count++;
-  }
-  return count;
-}
-
-/// Join Empire cost in pounds for absorbing [targetId] (Minor or Tribe).
-/// Cost = base + (provinceCount * perProvince). SPEC/game/diplomacy.md.
-int joinEmpireCostForMinorOrTribe(Game game, String targetId) {
-  final n = provinceCountOwnedBy(game, targetId);
-  return joinEmpireBaseCost + n * joinEmpirePerProvinceCost;
-}
-
-/// Relation score thresholds for level. 0–25 Hostile, 26–50 Neutral, 51–75 Friendly, 76–100 Allied.
-RelationLevel scoreToLevel(int score) {
-  if (score <= 25) return RelationLevel.hostile;
-  if (score <= 50) return RelationLevel.neutral;
-  if (score <= 75) return RelationLevel.friendly;
-  return RelationLevel.allied;
-}
-
-/// Normalizes faction pair for lookup (consistent ordering).
-String _pairKey(String a, String b) => a.compareTo(b) <= 0 ? '$a|$b' : '$b|$a';
-
-/// Returns relation for faction pair, or null if not found.
-DiplomacyRelation? getRelation(
-    Game game, String factionId1, String factionId2) {
-  final key = _pairKey(factionId1, factionId2);
-  for (final r in game.diplomacyRelations) {
-    if (_pairKey(r.factionId1, r.factionId2) == key) return r;
-  }
-  return null;
-}
-
-/// Finds the relation between [factionId1] and [factionId2] in [relations],
-/// passes it (or null if absent) to [updater], and replaces or appends the result.
-List<DiplomacyRelation> upsertRelation(
-  List<DiplomacyRelation> relations,
-  String factionId1,
-  String factionId2,
-  DiplomacyRelation Function(DiplomacyRelation?) updater,
-) {
-  final key = _pairKey(factionId1, factionId2);
-  final idx =
-      relations.indexWhere((r) => _pairKey(r.factionId1, r.factionId2) == key);
-  final existing = idx >= 0 ? relations[idx] : null;
-  final updated = updater(existing);
-  final result = List<DiplomacyRelation>.from(relations);
-  if (idx >= 0) {
-    result[idx] = updated;
-  } else {
-    result.add(updated);
-  }
-  return result;
-}
-
 /// Canonical faction pair IDs for a pair key.
 ({String id1, String id2}) _pairIds(String a, String b) {
-  final key = _pairKey(a, b);
+  final key = pairKey(a, b);
   final parts = key.split('|');
   return (id1: parts[0], id2: parts[1]);
-}
-
-/// Returns overture state for GP–Minor/Tribe, or null.
-OvertureState? getOverture(Game game, String gpId, String targetId) {
-  for (final o in game.overtureStates) {
-    if (o.gpId == gpId && o.targetId == targetId) return o;
-  }
-  return null;
-}
-
-/// Returns player by id, or null.
-Player? getPlayer(Game game, String playerId) {
-  for (final p in game.players) {
-    if (p.id == playerId) return p;
-  }
-  return null;
 }
 
 bool _isMinorOrTribe(Game game, String factionId) {
@@ -115,7 +33,7 @@ bool _isGreatPower(Game game, String factionId) {
 
 /// True if [factionId] is a GP whose player is human-controlled.
 bool _isTargetHumanGp(Game game, String factionId) {
-  final p = getPlayer(game, factionId);
+  final p = game.playerById(factionId);
   return p != null && p.isHuman;
 }
 
@@ -360,7 +278,7 @@ Game _resolveJoinEmpireColony(
       final targetId = order.targetFactionId;
       if (!_isMinorOrTribe(game, targetId)) continue;
 
-      final player = getPlayer(game, gpId);
+      final player = game.playerById(gpId);
       if (player == null) continue;
 
       final existing = getOverture(game, gpId, targetId);
@@ -531,7 +449,7 @@ Game _processWarAndPeace(
       final targetId = order.targetFactionId;
       if (!_isGreatPower(game, gpId) || !_isGreatPower(game, targetId))
         continue;
-      final key = _pairKey(gpId, targetId);
+      final key = pairKey(gpId, targetId);
       final offerers = peaceOffersByPairKey.putIfAbsent(key, () => <String>{});
       offerers.add(gpId);
     }
@@ -603,7 +521,7 @@ Game _processWarAndPeace(
       } else if (order.type == DiplomaticOrderType.offerPeace) {
         final targetId = order.targetFactionId;
         final rel = getRelation(game, gpId, targetId);
-        final key = _pairKey(gpId, targetId);
+        final key = pairKey(gpId, targetId);
         final bothGreatPowers =
             _isGreatPower(game, gpId) && _isGreatPower(game, targetId);
         final hasMutualOffer = bothGreatPowers
@@ -616,7 +534,7 @@ Game _processWarAndPeace(
           var bothSidesAgreed = true;
           final isGpTarget = _isGreatPower(game, targetId);
           if (isGpTarget && _isGreatPower(game, gpId)) {
-            final key = _pairKey(gpId, targetId);
+            final key = pairKey(gpId, targetId);
             final offerers = peaceOffersByPairKey[key] ?? const <String>{};
             bothSidesAgreed =
                 offerers.contains(gpId) && offerers.contains(targetId);
@@ -695,7 +613,7 @@ Game _applyRelationModifiersAndUpdateScores(
   // GrantAid: deduct treasury, add relation modifier (+5 per grant). Requires Embassy.
   for (final entry in diploByPlayer.entries) {
     final gpId = entry.key;
-    final player = getPlayer(game, gpId);
+    final player = game.playerById(gpId);
     if (player == null) continue;
 
     for (final order in entry.value) {
@@ -745,7 +663,7 @@ Game _applyRelationModifiersAndUpdateScores(
     for (final order in entry.value) {
       if (order.type != DiplomaticOrderType.setSubsidy) continue;
       final amount = order.amount ?? 0;
-      final player = getPlayer(game, gpId);
+      final player = game.playerById(gpId);
       if (player == null || amount <= 0 || player.treasury < amount) continue;
 
       final targetId = order.targetFactionId;
@@ -776,7 +694,7 @@ Game _applyRelationModifiersAndUpdateScores(
         ));
       }
 
-      final targetPlayer = getPlayer(game, targetId);
+      final targetPlayer = game.playerById(targetId);
       if (targetPlayer != null) {
         _diploLog.i(
             'logic: diplomacy SetSubsidy $gpId -> $targetId amount $amount/turn (ongoing)');
@@ -805,7 +723,7 @@ Game _processOngoingSubsidies(Game game, int turn) {
     final amount = subsidy.amountPerTurn;
 
     // Check if payer can afford subsidy
-    final payer = getPlayer(game, payerId);
+    final payer = game.playerById(payerId);
     if (payer == null || payer.treasury < amount) {
       // Cancel subsidy if payer can't afford it
       subsidyStates = subsidyStates

--- a/packages/colonizethis_logic/lib/src/economy/build_cost.dart
+++ b/packages/colonizethis_logic/lib/src/economy/build_cost.dart
@@ -1,0 +1,119 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Shared build-order cost and eligibility. Single source of truth for validation
+/// and application. SPEC/program/orders.md § Build orders.
+/// Used by BuildOrderValidator and orders_application.
+
+/// Result of checking whether a player can afford a build order.
+({bool canAfford, String? reason}) canAffordBuild(
+  Player player,
+  BuildUnitOrder order,
+  WorkerPool workers,
+  Stockpile stockpile,
+  int treasury,
+) {
+  final category = buildUnitCategoryForUnitType(order.unitType);
+  switch (category) {
+    case BuildUnitCategory.civilian:
+      final econ = CivilianEconomyCatalog.byId[order.unitType];
+      if (econ == null) return (canAfford: false, reason: 'Insufficient resources');
+      final unlockingTechId = unlockingTechByCivilianId[order.unitType];
+      if (unlockingTechId != null &&
+          (player.techUnlocked?[unlockingTechId] != true)) {
+        return (canAfford: false, reason: 'Insufficient resources');
+      }
+      if (treasury < econ.buildTreasuryCost) {
+        return (canAfford: false, reason: 'Insufficient treasury');
+      }
+      for (final e in econ.buildInputs.entries) {
+        if (stockpile.quantityOf(e.key) < e.value) {
+          return (canAfford: false, reason: 'Insufficient materials');
+        }
+      }
+      return (canAfford: true, reason: null);
+
+    case BuildUnitCategory.military:
+      final econ = RegimentEconomyCatalog.byId[order.unitType];
+      if (econ == null) return (canAfford: false, reason: 'Insufficient resources');
+      final regimentUnlockTech = unlockingTechByRegimentId[order.unitType];
+      if (regimentUnlockTech != null &&
+          (player.techUnlocked?[regimentUnlockTech] != true)) {
+        return (canAfford: false, reason: 'Insufficient resources');
+      }
+      if (workers.peasants <= 0) {
+        return (canAfford: false, reason: 'Insufficient resources');
+      }
+      if (treasury < econ.buildTreasuryCost) {
+        return (canAfford: false, reason: 'Insufficient treasury');
+      }
+      for (final e in econ.buildInputs.entries) {
+        if (stockpile.quantityOf(e.key) < e.value) {
+          return (canAfford: false, reason: 'Insufficient materials');
+        }
+      }
+      return (canAfford: true, reason: null);
+
+    case BuildUnitCategory.naval:
+      final shipEcon = ShipEconomyCatalog.byId[order.unitType];
+      if (shipEcon == null) return (canAfford: false, reason: 'Insufficient resources');
+      final shipUnlockTech = unlockingTechByShipId[order.unitType];
+      if (shipUnlockTech != null &&
+          (player.techUnlocked?[shipUnlockTech] != true)) {
+        return (canAfford: false, reason: 'Insufficient tech');
+      }
+      if (treasury < shipEcon.buildTreasuryCost) {
+        return (canAfford: false, reason: 'Insufficient treasury');
+      }
+      for (final e in shipEcon.buildInputs.entries) {
+        if (stockpile.quantityOf(e.key) < e.value) {
+          return (canAfford: false, reason: 'Insufficient materials');
+        }
+      }
+      return (canAfford: true, reason: null);
+
+    case BuildUnitCategory.unknown:
+      return (canAfford: false, reason: 'Insufficient resources');
+  }
+}
+
+/// Applies cost deduction for [order]. Call only when [canAffordBuild] returned true.
+/// Returns updated workers, stockpile, and treasury.
+({WorkerPool workers, Stockpile stockpile, int treasury}) applyBuildCostDeduction(
+  Player player,
+  BuildUnitOrder order,
+  WorkerPool workers,
+  Stockpile stockpile,
+  int treasury,
+) {
+  final category = buildUnitCategoryForUnitType(order.unitType);
+  switch (category) {
+    case BuildUnitCategory.civilian:
+      final econ = CivilianEconomyCatalog.byId[order.unitType]!;
+      treasury -= econ.buildTreasuryCost;
+      for (final e in econ.buildInputs.entries) {
+        stockpile = stockpile.applyDelta(e.key, -e.value);
+      }
+      return (workers: workers, stockpile: stockpile, treasury: treasury);
+
+    case BuildUnitCategory.military:
+      final econ = RegimentEconomyCatalog.byId[order.unitType]!;
+      treasury -= econ.buildTreasuryCost;
+      for (final e in econ.buildInputs.entries) {
+        stockpile = stockpile.applyDelta(e.key, -e.value);
+      }
+      workers = workers.copyWith(peasants: workers.peasants - 1);
+      return (workers: workers, stockpile: stockpile, treasury: treasury);
+
+    case BuildUnitCategory.naval:
+      final shipEcon = ShipEconomyCatalog.byId[order.unitType]!;
+      treasury -= shipEcon.buildTreasuryCost;
+      for (final e in shipEcon.buildInputs.entries) {
+        stockpile = stockpile.applyDelta(e.key, -e.value);
+      }
+      return (workers: workers, stockpile: stockpile, treasury: treasury);
+
+    case BuildUnitCategory.unknown:
+      return (workers: workers, stockpile: stockpile, treasury: treasury);
+  }
+}

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -6,55 +6,13 @@ import '../diplomacy/diplomacy_resolver.dart';
 import '../world/movement.dart';
 import '../world/naval.dart';
 import 'order_engine.dart';
+import 'order_suggestion_helpers.dart';
 import 'order_visibility.dart';
 import '../world/player_view.dart';
 
+export 'order_suggestion_helpers.dart';
+
 final Logger _log = Logger();
-
-/// Builds a map from full province id (regionId|localId) to owner faction id.
-/// Used by AI to filter move orders by diplomacy. SPEC/ai/ai-architecture.md.
-Map<String, String> getProvinceOwnerMap(Game game) {
-  final out = <String, String>{};
-  for (final p in game.worldState.oldWorld.provinces) {
-    if (p.ownerId != null && p.ownerId!.isNotEmpty) {
-      final key = ProvinceId.full(p.regionId, ProvinceId.localIdFrom(p.id));
-      out[key] = p.ownerId!;
-    }
-  }
-  for (final p in game.worldState.newWorld.provinces) {
-    if (p.ownerId != null && p.ownerId!.isNotEmpty) {
-      final key = ProvinceId.full(p.regionId, ProvinceId.localIdFrom(p.id));
-      out[key] = p.ownerId!;
-    }
-  }
-  return out;
-}
-
-/// Filters move orders to those allowed by diplomacy: no move into province of
-/// a faction at peace with [playerId], or into Minor territory without war.
-/// SPEC/ai/ai-architecture.md movement filter.
-List<MoveOrder> filterMoveOrdersByDiplomacy(
-  Game game,
-  String playerId,
-  List<MoveOrder> orders,
-) {
-  final provinceOwner = getProvinceOwnerMap(game);
-  final filtered = <MoveOrder>[];
-  for (final m in orders) {
-    final destOwner = provinceOwner[m.destinationProvinceId];
-    if (destOwner == null || destOwner == playerId) {
-      filtered.add(m);
-      continue;
-    }
-    final rel = getRelation(game, playerId, destOwner);
-    if (rel != null && rel.atPeace) continue;
-    if (rel == null) {
-      if (game.minorNations.any((mn) => mn.id == destOwner)) continue;
-    }
-    filtered.add(m);
-  }
-  return filtered;
-}
 
 /// Suggests candidate move orders that are information-legal (per [PlayerView])
 /// and rules-legal (per [OrderEngine]) for [view.playerId].

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_helpers.dart
@@ -1,0 +1,50 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../diplomacy/diplomacy_resolver.dart';
+
+/// Shared helpers for order suggestion. SPEC/ai/ai-architecture.md.
+/// Used by order_suggestion and AI planners.
+
+/// Builds a map from full province id (regionId|localId) to owner faction id.
+/// Used by AI to filter move orders by diplomacy.
+Map<String, String> getProvinceOwnerMap(Game game) {
+  final out = <String, String>{};
+  for (final p in game.worldState.oldWorld.provinces) {
+    if (p.ownerId != null && p.ownerId!.isNotEmpty) {
+      final key = ProvinceId.full(p.regionId, ProvinceId.localIdFrom(p.id));
+      out[key] = p.ownerId!;
+    }
+  }
+  for (final p in game.worldState.newWorld.provinces) {
+    if (p.ownerId != null && p.ownerId!.isNotEmpty) {
+      final key = ProvinceId.full(p.regionId, ProvinceId.localIdFrom(p.id));
+      out[key] = p.ownerId!;
+    }
+  }
+  return out;
+}
+
+/// Filters move orders to those allowed by diplomacy: no move into province of
+/// a faction at peace with [playerId], or into Minor territory without war.
+List<MoveOrder> filterMoveOrdersByDiplomacy(
+  Game game,
+  String playerId,
+  List<MoveOrder> orders,
+) {
+  final provinceOwner = getProvinceOwnerMap(game);
+  final filtered = <MoveOrder>[];
+  for (final m in orders) {
+    final destOwner = provinceOwner[m.destinationProvinceId];
+    if (destOwner == null || destOwner == playerId) {
+      filtered.add(m);
+      continue;
+    }
+    final rel = getRelation(game, playerId, destOwner);
+    if (rel != null && rel.atPeace) continue;
+    if (rel == null) {
+      if (game.minorNations.any((mn) => mn.id == destOwner)) continue;
+    }
+    filtered.add(m);
+  }
+  return filtered;
+}

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -6,6 +6,8 @@ import 'package:logger/logger.dart';
 
 import '../constants.dart';
 import '../dossier/event_dialogue.dart';
+import '../economy/build_cost.dart';
+import 'orders_application_helpers.dart';
 import '../world/naval.dart';
 import '../world/player_view.dart';
 import '../world/province_lookup.dart';
@@ -54,47 +56,6 @@ Game applyBuildAndWorkOrders(
       Map<String, String>.from(game.worldState.purchasedTilesByTileKey);
   var oldProvinces = List<Province>.from(game.worldState.oldWorld.provinces);
   var newProvinces = List<Province>.from(game.worldState.newWorld.provinces);
-
-  bool isMineralEligibleTile(String tileKey) {
-    const mineralTerrains = {
-      TerrainType.swamp,
-      TerrainType.hills,
-      TerrainType.mountain,
-      TerrainType.desert,
-    };
-
-    if (tileMapByRegion != null && tileMapByRegion.isNotEmpty) {
-      final parts = tileKey.split('|');
-      if (parts.length == 4) {
-        final regionId = parts[0];
-        final x = int.tryParse(parts[2]);
-        final y = int.tryParse(parts[3]);
-        final tileMap = tileMapByRegion[regionId];
-        if (tileMap != null && x != null && y != null) {
-          final terrain = tileMap.terrainAt(x, y);
-          if (terrain != null) {
-            return mineralTerrains.contains(terrain);
-          }
-        }
-      }
-    }
-
-    final resourceId = game.worldState.resourceByTileKey[tileKey];
-    if (resourceId == null || resourceId.isEmpty) {
-      return false;
-    }
-    const mineralIds = {
-      'iron',
-      'copper',
-      'tin',
-      'coal',
-      'silver',
-      'gold',
-      'gems',
-      'diamonds',
-    };
-    return mineralIds.contains(resourceId);
-  }
 
   void applyExploreCompletion(Unit u, String regionId) {
     final cw = u.currentWork!;
@@ -358,63 +319,28 @@ Game applyBuildAndWorkOrders(
     var workers = player.workerPool;
     var treasury = player.treasury;
 
-    // Build units for this player. Branch on unit type category (civilian / military / naval).
+    // Build units for this player. Shared cost rules: build_cost.canAffordBuild / applyBuildCostDeduction.
     for (final order in buildOrders[player.id] ?? const []) {
       final category = buildUnitCategoryForUnitType(order.unitType);
       if (category == BuildUnitCategory.unknown) continue;
 
-      if (category == BuildUnitCategory.military) {
-        final econ = RegimentEconomyCatalog.byId[order.unitType];
-        if (econ == null) continue;
+      final check = canAffordBuild(player, order, workers, stockpile, treasury);
+      if (!check.canAfford) continue;
 
-        final techUnlocked = player.techUnlocked ?? const {};
-        final unlockingTechId = unlockingTechByRegimentId[order.unitType];
-        if (unlockingTechId != null && techUnlocked[unlockingTechId] != true) {
-          continue;
-        }
+      final after = applyBuildCostDeduction(
+        player,
+        order,
+        workers,
+        stockpile,
+        treasury,
+      );
+      workers = after.workers;
+      stockpile = after.stockpile;
+      treasury = after.treasury;
 
-        if (workers.peasants <= 0) continue;
-        if (treasury < econ.buildTreasuryCost) continue;
-
-        var hasAllInputs = true;
-        for (final entry in econ.buildInputs.entries) {
-          if (stockpile.quantityOf(entry.key) < entry.value) {
-            hasAllInputs = false;
-            break;
-          }
-        }
-        if (!hasAllInputs) continue;
-
-        treasury -= econ.buildTreasuryCost;
-        for (final entry in econ.buildInputs.entries) {
-          stockpile = stockpile.applyDelta(entry.key, -entry.value);
-        }
-        workers = workers.copyWith(peasants: workers.peasants - 1);
-      } else if (category == BuildUnitCategory.naval) {
-        final shipEcon = ShipEconomyCatalog.byId[order.unitType];
-        if (shipEcon == null) continue;
-        final shipUnlockTechId = unlockingTechByShipId[order.unitType];
-        if (shipUnlockTechId != null &&
-            (player.techUnlocked?[shipUnlockTechId] != true)) {
-          continue;
-        }
+      if (category == BuildUnitCategory.naval) {
         final capProvinceId = player.capitalProvinceId;
         if (capProvinceId == null) continue;
-        if (treasury < shipEcon.buildTreasuryCost) continue;
-        var hasAllInputs = true;
-        for (final entry in shipEcon.buildInputs.entries) {
-          if (stockpile.quantityOf(entry.key) < entry.value) {
-            hasAllInputs = false;
-            break;
-          }
-        }
-        if (!hasAllInputs) continue;
-
-        treasury -= shipEcon.buildTreasuryCost;
-        for (final entry in shipEcon.buildInputs.entries) {
-          stockpile = stockpile.applyDelta(entry.key, -entry.value);
-        }
-
         final regionId = ProvinceId.regionIdFrom(capProvinceId);
         final seaZoneId = topology != null
             ? seaZoneIdForProvince(
@@ -448,29 +374,6 @@ Game applyBuildAndWorkOrders(
           worldState: game.worldState.copyWith(fleets: fleets),
         );
         continue;
-      } else if (category == BuildUnitCategory.civilian) {
-        final econ = CivilianEconomyCatalog.byId[order.unitType];
-        if (econ == null) continue;
-
-        final unlockingTechId = unlockingTechByCivilianId[order.unitType];
-        if (unlockingTechId != null &&
-            (player.techUnlocked?[unlockingTechId] != true)) {
-          continue;
-        }
-        if (treasury < econ.buildTreasuryCost) continue;
-        var hasAllInputs = true;
-        for (final entry in econ.buildInputs.entries) {
-          if (stockpile.quantityOf(entry.key) < entry.value) {
-            hasAllInputs = false;
-            break;
-          }
-        }
-        if (!hasAllInputs) continue;
-
-        treasury -= econ.buildTreasuryCost;
-        for (final entry in econ.buildInputs.entries) {
-          stockpile = stockpile.applyDelta(entry.key, -entry.value);
-        }
       }
 
       // Spawn unit for military and civilian (naval already continued above).
@@ -680,7 +583,7 @@ Game applyBuildAndWorkOrders(
             continue;
           }
 
-          final cost = 15 * landPurchaseBasePrice(resourceId);
+          final cost = purchaseLandCost(resourceId);
           if (treasury >= cost) {
             treasury -= cost;
             purchasedTilesByTileKey[targetTileKey] = player.id;
@@ -736,7 +639,7 @@ Game applyBuildAndWorkOrders(
       if (order.target == 'prospect' &&
           hasValidTarget &&
           isExplorerUnit(u.type) &&
-          isMineralEligibleTile(targetTileKey)) {
+          isMineralEligibleTile(game, tileMapByRegion, targetTileKey)) {
         final existing =
             game.worldState.playerProspectedTiles[player.id] ?? const {};
         final newProspected = Set<String>.from(existing)..add(targetTileKey);

--- a/packages/colonizethis_logic/lib/src/orders/orders_application_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_helpers.dart
@@ -1,0 +1,52 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Helpers for order application. SPEC/program/orders.md, development-resolution.
+/// Used by orders_application for work and build phases.
+
+/// Whether the tile is eligible for mineral-related work (prospect, build_improvement).
+/// Uses terrain from [tileMapByRegion] when available; otherwise resource id from [game].
+bool isMineralEligibleTile(
+  Game game,
+  Map<String, TileMapResult>? tileMapByRegion,
+  String tileKey,
+) {
+  const mineralTerrains = {
+    TerrainType.swamp,
+    TerrainType.hills,
+    TerrainType.mountain,
+    TerrainType.desert,
+  };
+
+  if (tileMapByRegion != null && tileMapByRegion.isNotEmpty) {
+    final parts = tileKey.split('|');
+    if (parts.length == 4) {
+      final regionId = parts[0];
+      final x = int.tryParse(parts[2]);
+      final y = int.tryParse(parts[3]);
+      final tileMap = tileMapByRegion[regionId];
+      if (tileMap != null && x != null && y != null) {
+        final terrain = tileMap.terrainAt(x, y);
+        if (terrain != null) {
+          return mineralTerrains.contains(terrain);
+        }
+      }
+    }
+  }
+
+  final resourceId = game.worldState.resourceByTileKey[tileKey];
+  if (resourceId == null || resourceId.isEmpty) {
+    return false;
+  }
+  const mineralIds = {
+    'iron',
+    'copper',
+    'tin',
+    'coal',
+    'silver',
+    'gold',
+    'gems',
+    'diamonds',
+  };
+  return mineralIds.contains(resourceId);
+}

--- a/packages/colonizethis_logic/lib/src/orders/validators/build_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/build_order_validator.dart
@@ -1,14 +1,12 @@
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../../economy/economy_production.dart';
+import '../../economy/build_cost.dart';
 import '../order_validation_result.dart';
 
 /// Validates build unit orders for a single player in submission order.
 /// Mutates internal economy state (workers, stockpile, treasury) when an order
 /// is accepted. SPEC/program/orders.md § Build orders.
 class BuildOrderValidator {
-  final Game _game;
   final Player _player;
 
   WorkerPool _workers;
@@ -18,8 +16,7 @@ class BuildOrderValidator {
   BuildOrderValidator({
     required Game game,
     required Player player,
-  })  : _game = game,
-        _player = player,
+  })  : _player = player,
         _workers = player.workerPool,
         _stockpile = player.stockpile,
         _treasury = player.treasury;
@@ -48,134 +45,32 @@ class BuildOrderValidator {
       );
     }
 
-    final category = buildUnitCategoryForUnitType(o.unitType);
-    switch (category) {
-      case BuildUnitCategory.civilian:
-        final econ = CivilianEconomyCatalog.byId[o.unitType];
-        if (econ == null) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Insufficient resources',
-          );
-        }
-        final unlockingTechId = unlockingTechByCivilianId[o.unitType];
-        if (unlockingTechId != null &&
-            (_player.techUnlocked?[unlockingTechId] != true)) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Insufficient resources',
-          );
-        }
-        if (_treasury < econ.buildTreasuryCost) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Insufficient treasury',
-          );
-        }
-        for (final e in econ.buildInputs.entries) {
-          if (_stockpile.quantityOf(e.key) < e.value) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'Insufficient materials',
-            );
-          }
-        }
-        _treasury -= econ.buildTreasuryCost;
-        for (final e in econ.buildInputs.entries) {
-          _stockpile = _stockpile.applyDelta(e.key, -e.value);
-        }
-        return const OrderValidationResult(
-          status: OrderValidationStatus.accepted,
-        );
-
-      case BuildUnitCategory.military:
-        final econ = RegimentEconomyCatalog.byId[o.unitType];
-        if (econ == null) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Insufficient resources',
-          );
-        }
-        final regimentUnlockTech = unlockingTechByRegimentId[o.unitType];
-        if (regimentUnlockTech != null &&
-            (_player.techUnlocked?[regimentUnlockTech] != true)) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Insufficient resources',
-          );
-        }
-        if (_workers.peasants <= 0) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Insufficient resources',
-          );
-        }
-        if (_treasury < econ.buildTreasuryCost) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Insufficient treasury',
-          );
-        }
-        for (final e in econ.buildInputs.entries) {
-          if (_stockpile.quantityOf(e.key) < e.value) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'Insufficient materials',
-            );
-          }
-        }
-        _treasury -= econ.buildTreasuryCost;
-        for (final e in econ.buildInputs.entries) {
-          _stockpile = _stockpile.applyDelta(e.key, -e.value);
-        }
-        _workers = _workers.copyWith(peasants: _workers.peasants - 1);
-        return const OrderValidationResult(
-          status: OrderValidationStatus.accepted,
-        );
-
-      case BuildUnitCategory.naval:
-        final shipEcon = ShipEconomyCatalog.byId[o.unitType];
-        if (shipEcon == null) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Insufficient resources',
-          );
-        }
-        final shipUnlockTech = unlockingTechByShipId[o.unitType];
-        if (shipUnlockTech != null &&
-            (_player.techUnlocked?[shipUnlockTech] != true)) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Insufficient tech',
-          );
-        }
-        if (_treasury < shipEcon.buildTreasuryCost) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Insufficient treasury',
-          );
-        }
-        for (final e in shipEcon.buildInputs.entries) {
-          if (_stockpile.quantityOf(e.key) < e.value) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'Insufficient materials',
-            );
-          }
-        }
-        _treasury -= shipEcon.buildTreasuryCost;
-        for (final e in shipEcon.buildInputs.entries) {
-          _stockpile = _stockpile.applyDelta(e.key, -e.value);
-        }
-        return const OrderValidationResult(
-          status: OrderValidationStatus.accepted,
-        );
-
-      case BuildUnitCategory.unknown:
-        return const OrderValidationResult(
-          status: OrderValidationStatus.rejected,
-          reason: 'Insufficient resources',
-        );
+    final check = canAffordBuild(
+      _player,
+      o,
+      _workers,
+      _stockpile,
+      _treasury,
+    );
+    if (!check.canAfford) {
+      return OrderValidationResult(
+        status: OrderValidationStatus.rejected,
+        reason: check.reason ?? 'Insufficient resources',
+      );
     }
+
+    final after = applyBuildCostDeduction(
+      _player,
+      o,
+      _workers,
+      _stockpile,
+      _treasury,
+    );
+    _workers = after.workers;
+    _stockpile = after.stockpile;
+    _treasury = after.treasury;
+    return const OrderValidationResult(
+      status: OrderValidationStatus.accepted,
+    );
   }
 }

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
@@ -192,7 +192,7 @@ class WorkOrderValidator {
           );
         }
       }
-      final cost = 15 * landPurchaseBasePrice(resourceId);
+      final cost = purchaseLandCost(resourceId);
       if (_treasury < cost) {
         return OrderValidationResult(
           status: OrderValidationStatus.rejected,
@@ -311,7 +311,7 @@ class WorkOrderValidator {
     if (o.target == 'purchase_land') {
       final resourceId = _game.worldState.resourceByTileKey[o.targetTileKey];
       if (resourceId != null && resourceId.isNotEmpty) {
-        final cost = 15 * landPurchaseBasePrice(resourceId);
+        final cost = purchaseLandCost(resourceId);
         _treasury -= cost;
       }
     } else if (o.target != 'steal_tech' && o.target != 'counter_spy') {

--- a/packages/colonizethis_logic/lib/src/setup/game_setup.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup.dart
@@ -10,6 +10,7 @@ import 'package:logger/logger.dart';
 
 import 'capital_choice.dart';
 import '../constants.dart';
+import 'initial_visibility.dart';
 import '../world/naval.dart';
 import '../world/player_view.dart';
 import 'province_assignment.dart';
@@ -260,7 +261,7 @@ GameSetupResult createGameFromGeneratedMaps({
 
   // Apply initial per-player visibility/prospection (knowledge state) after
   // provinces, capitals, and starting units are set.
-  game = _applyInitialVisibility(
+  game = applyInitialVisibility(
     game: game,
     tileMapByRegion: tileMapByRegion,
   );
@@ -404,96 +405,6 @@ List<String> _provinceIdsFromTopology(MapTopology topology) {
       .where((n) => n.type == TopologyNodeType.province)
       .map((n) => n.id)
       .toList();
-}
-
-Game _applyInitialVisibility({
-  required Game game,
-  required Map<String, TileMapResult> tileMapByRegion,
-}) {
-  final owMap = tileMapByRegion[kRegionOldWorld];
-  final nwMap = tileMapByRegion[kRegionNewWorld];
-  if (owMap == null || nwMap == null) return game;
-
-  // Province ownership lookup.
-  final owOwnerById = <String, String?>{
-    for (final p in game.worldState.oldWorld.provinces) p.id: p.ownerId,
-  };
-  final nwOwnerById = <String, String?>{
-    for (final p in game.worldState.newWorld.provinces) p.id: p.ownerId,
-  };
-
-  final playerVisibilityByTile = <String, Map<String, String>>{};
-  final playerProspectedTiles = <String, Set<String>>{};
-
-  // Build tile keys per region and province for explore resolution. SPEC/program/fog-and-exploration-resolution.md.
-  // Build resourceByTileKey from tile map resourceGrid for build_improvement validation and extraction. SPEC/game/extraction-and-improvements.md.
-  final tileKeysByRegionAndProvince = <String, Map<String, List<String>>>{
-    kRegionOldWorld: <String, List<String>>{},
-    kRegionNewWorld: <String, List<String>>{},
-  };
-  final resourceByTileKey = <String, String>{};
-  for (var y = 0; y < owMap.height; y++) {
-    for (var x = 0; x < owMap.width; x++) {
-      final localId = owMap.cell(x, y);
-      final fullId = ProvinceId.full(kRegionOldWorld, localId);
-      final ownerId = owOwnerById[fullId];
-      if (ownerId == null) continue;
-      final tileKey = '$kRegionOldWorld|$localId|$x|$y';
-      tileKeysByRegionAndProvince[kRegionOldWorld]!
-          .putIfAbsent(fullId, () => <String>[])
-          .add(tileKey);
-      final res = owMap.resourceAt(x, y);
-      if (res != null) resourceByTileKey[tileKey] = res.name;
-    }
-  }
-  for (var y = 0; y < nwMap.height; y++) {
-    for (var x = 0; x < nwMap.width; x++) {
-      final localId = nwMap.cell(x, y);
-      final fullId = ProvinceId.full(kRegionNewWorld, localId);
-      final ownerId = nwOwnerById[fullId];
-      if (ownerId == null) continue;
-      final tileKey = '$kRegionNewWorld|$localId|$x|$y';
-      tileKeysByRegionAndProvince[kRegionNewWorld]!
-          .putIfAbsent(fullId, () => <String>[])
-          .add(tileKey);
-      final res = nwMap.resourceAt(x, y);
-      if (res != null) resourceByTileKey[tileKey] = res.name;
-    }
-  }
-
-  for (final player in game.players) {
-    final playerId = player.id;
-    final visibility = <String, String>{};
-
-    // Old World: own provinces fullyVisible, others fogged.
-    for (var y = 0; y < owMap.height; y++) {
-      for (var x = 0; x < owMap.width; x++) {
-        final localId = owMap.cell(x, y);
-        final fullId = ProvinceId.full(kRegionOldWorld, localId);
-        final ownerId = owOwnerById[fullId];
-        if (ownerId == null) {
-          // Sea zone or unowned; skip.
-          continue;
-        }
-        final tileKey = '$kRegionOldWorld|$localId|$x|$y';
-        visibility[tileKey] =
-            ownerId == playerId ? VisibilityLevel.fullyVisible.name : VisibilityLevel.fogged.name;
-      }
-    }
-
-    // New World: start unknown (absence = unknown in PlayerView).
-
-    playerVisibilityByTile[playerId] = visibility;
-    playerProspectedTiles[playerId] = <String>{};
-  }
-
-  final updatedWorldState = game.worldState.copyWith(
-    playerVisibilityByTile: playerVisibilityByTile,
-    playerProspectedTiles: playerProspectedTiles,
-    tileKeysByRegionAndProvince: tileKeysByRegionAndProvince,
-    resourceByTileKey: resourceByTileKey,
-  );
-  return game.copyWith(worldState: updatedWorldState);
 }
 
 /// 7d. Province town assignment. For each province, set townTileKey: capital province = capital tile;

--- a/packages/colonizethis_logic/lib/src/setup/initial_visibility.dart
+++ b/packages/colonizethis_logic/lib/src/setup/initial_visibility.dart
@@ -1,0 +1,94 @@
+// SPEC/program/game-setup-pipeline.md, fog-and-exploration-resolution.md.
+// Initial player visibility and tile/resource indexing from generated maps.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../constants.dart';
+import '../world/player_view.dart';
+
+/// Applies initial visibility and tile metadata to [game] using [tileMapByRegion].
+/// Own provinces: fullyVisible (OW) or unknown (NW). Others: fogged (OW).
+/// Builds tileKeysByRegionAndProvince and resourceByTileKey for resolution.
+Game applyInitialVisibility({
+  required Game game,
+  required Map<String, TileMapResult> tileMapByRegion,
+}) {
+  final owMap = tileMapByRegion[kRegionOldWorld];
+  final nwMap = tileMapByRegion[kRegionNewWorld];
+  if (owMap == null || nwMap == null) return game;
+
+  final owOwnerById = <String, String?>{
+    for (final p in game.worldState.oldWorld.provinces) p.id: p.ownerId,
+  };
+  final nwOwnerById = <String, String?>{
+    for (final p in game.worldState.newWorld.provinces) p.id: p.ownerId,
+  };
+
+  final playerVisibilityByTile = <String, Map<String, String>>{};
+  final playerProspectedTiles = <String, Set<String>>{};
+
+  final tileKeysByRegionAndProvince = <String, Map<String, List<String>>>{
+    kRegionOldWorld: <String, List<String>>{},
+    kRegionNewWorld: <String, List<String>>{},
+  };
+  final resourceByTileKey = <String, String>{};
+  for (var y = 0; y < owMap.height; y++) {
+    for (var x = 0; x < owMap.width; x++) {
+      final localId = owMap.cell(x, y);
+      final fullId = ProvinceId.full(kRegionOldWorld, localId);
+      final ownerId = owOwnerById[fullId];
+      if (ownerId == null) continue;
+      final tileKey = '$kRegionOldWorld|$localId|$x|$y';
+      tileKeysByRegionAndProvince[kRegionOldWorld]!
+          .putIfAbsent(fullId, () => <String>[])
+          .add(tileKey);
+      final res = owMap.resourceAt(x, y);
+      if (res != null) resourceByTileKey[tileKey] = res.name;
+    }
+  }
+  for (var y = 0; y < nwMap.height; y++) {
+    for (var x = 0; x < nwMap.width; x++) {
+      final localId = nwMap.cell(x, y);
+      final fullId = ProvinceId.full(kRegionNewWorld, localId);
+      final ownerId = nwOwnerById[fullId];
+      if (ownerId == null) continue;
+      final tileKey = '$kRegionNewWorld|$localId|$x|$y';
+      tileKeysByRegionAndProvince[kRegionNewWorld]!
+          .putIfAbsent(fullId, () => <String>[])
+          .add(tileKey);
+      final res = nwMap.resourceAt(x, y);
+      if (res != null) resourceByTileKey[tileKey] = res.name;
+    }
+  }
+
+  for (final player in game.players) {
+    final playerId = player.id;
+    final visibility = <String, String>{};
+
+    for (var y = 0; y < owMap.height; y++) {
+      for (var x = 0; x < owMap.width; x++) {
+        final localId = owMap.cell(x, y);
+        final fullId = ProvinceId.full(kRegionOldWorld, localId);
+        final ownerId = owOwnerById[fullId];
+        if (ownerId == null) continue;
+        final tileKey = '$kRegionOldWorld|$localId|$x|$y';
+        visibility[tileKey] =
+            ownerId == playerId
+                ? VisibilityLevel.fullyVisible.name
+                : VisibilityLevel.fogged.name;
+      }
+    }
+
+    playerVisibilityByTile[playerId] = visibility;
+    playerProspectedTiles[playerId] = <String>{};
+  }
+
+  final updatedWorldState = game.worldState.copyWith(
+    playerVisibilityByTile: playerVisibilityByTile,
+    playerProspectedTiles: playerProspectedTiles,
+    tileKeysByRegionAndProvince: tileKeysByRegionAndProvince,
+    resourceByTileKey: resourceByTileKey,
+  );
+  return game.copyWith(worldState: updatedWorldState);
+}

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolution_events.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolution_events.dart
@@ -1,0 +1,95 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../constants.dart';
+import '../game_events.dart';
+
+/// Emits game events after turn resolution phases. SPEC/program/game-events.md.
+/// Keeps turn_resolver switch thin by moving event emission here.
+
+/// Emit research_complete for each tech newly unlocked in [stateAfter] vs [stateBefore].
+void emitResearchCompleteEvents(
+  Game stateBefore,
+  Game stateAfter,
+  int turn,
+  void Function(GameEvent) onGameEvent,
+) {
+  for (final player in stateAfter.players) {
+    final unlocked = player.techUnlocked ?? {};
+    final current = unlocked.entries
+        .where((e) => e.value)
+        .map((e) => e.key)
+        .toSet();
+    final previous = stateBefore.playerById(player.id)?.techUnlocked ?? {};
+    final previousSet =
+        previous.entries.where((e) => e.value).map((e) => e.key).toSet();
+    for (final tech in current) {
+      if (!previousSet.contains(tech)) {
+        onGameEvent(ResearchCompleteEvent(
+          playerId: player.id,
+          techId: tech,
+          turnNumber: turn,
+        ));
+      }
+    }
+  }
+}
+
+/// Emit diplomacy_change for each relation that changed vs [previousRelations].
+void emitDiplomacyChangeEvents(
+  Map<String, Map<String, RelationState>> previousRelations,
+  Game stateAfter,
+  int turn,
+  void Function(GameEvent) onGameEvent,
+) {
+  for (final rel in stateAfter.diplomacyRelations) {
+    final prev1 = previousRelations[rel.factionId1]?[rel.factionId2];
+    if (prev1 == null || prev1 != rel.state) {
+      onGameEvent(DiplomacyChangeEvent(
+        actorId: rel.factionId1,
+        targetId: rel.factionId2,
+        changeType: rel.state.name,
+        turnNumber: turn,
+      ));
+    }
+  }
+}
+
+/// Emit province_captured for each province whose owner changed vs [previousOwnership].
+void emitProvinceCapturedEvents(
+  Map<String, String?> previousOwnership,
+  Game stateAfter,
+  int turn,
+  void Function(GameEvent) onGameEvent,
+) {
+  for (final region in [
+    stateAfter.worldState.oldWorld,
+    stateAfter.worldState.newWorld,
+  ]) {
+    for (final prov in region.provinces) {
+      final previousOwner = previousOwnership[prov.id];
+      if (previousOwner != null && previousOwner != prov.ownerId) {
+        onGameEvent(ProvinceCapturedEvent(
+          provinceId: prov.id,
+          previousOwnerId: previousOwner,
+          newOwnerId: prov.ownerId ?? '',
+          turnNumber: turn,
+        ));
+      }
+    }
+  }
+}
+
+/// Emit victory_set if [state] has victory set.
+void emitVictorySetEvent(
+  Game state,
+  int turn,
+  void Function(GameEvent)? onGameEvent,
+) {
+  if (onGameEvent != null && state.victory != null) {
+    onGameEvent(VictorySetEvent(
+      winnerPlayerId: state.victory!.winnerPlayerId,
+      victoryType: state.victory!.type.name,
+      turnNumber: turn,
+    ));
+  }
+}

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -29,6 +29,7 @@ import '../world/player_view.dart';
 import '../world/province_lookup.dart';
 import 'combat_phase_helpers.dart';
 import 'end_of_turn_resolver.dart';
+import 'turn_resolution_events.dart';
 import 'turn_resolution_result.dart';
 
 final Logger _log = Logger();
@@ -231,34 +232,15 @@ TurnResolutionResult resolveTurnForGame({
         state = _runConsumptionPhase(state, feedingCoverageByPlayerId);
         break;
       case TurnPhase.research: {
-        final previousTechs = <String, Set<String>>{};
-        for (final p in state.players) {
-          final unlocked = p.techUnlocked ?? {};
-          previousTechs[p.id] = unlocked.entries
-              .where((e) => e.value)
-              .map((e) => e.key)
-              .toSet();
-        }
+        final stateBeforeResearch = state;
         state = resolveResearchPhase(state, orders);
-        // Emit research_complete events for newly completed techs
         if (onGameEvent != null) {
-          for (final player in state.players) {
-            final unlocked = player.techUnlocked ?? {};
-            final current = unlocked.entries
-                .where((e) => e.value)
-                .map((e) => e.key)
-                .toSet();
-            final previous = previousTechs[player.id] ?? {};
-            for (final tech in current) {
-              if (!previous.contains(tech)) {
-                onGameEvent(ResearchCompleteEvent(
-                  playerId: player.id,
-                  techId: tech,
-                  turnNumber: turn,
-                ));
-              }
-            }
-          }
+          emitResearchCompleteEvents(
+            stateBeforeResearch,
+            state,
+            turn,
+            onGameEvent,
+          );
         }
         break;
       }
@@ -285,20 +267,13 @@ TurnResolutionResult resolveTurnForGame({
           );
         }
         state = diploResult.game;
-        // Emit diplomacy_change events for changed relations
         if (onGameEvent != null) {
-          for (final rel in state.diplomacyRelations) {
-            final prev1 = previousRelations[rel.factionId1]?[rel.factionId2];
-            if (prev1 == null || prev1 != rel.state) {
-              // Emit for faction1
-              onGameEvent(DiplomacyChangeEvent(
-                actorId: rel.factionId1,
-                targetId: rel.factionId2,
-                changeType: rel.state.name,
-                turnNumber: turn,
-              ));
-            }
-          }
+          emitDiplomacyChangeEvents(
+            previousRelations,
+            state,
+            turn,
+            onGameEvent,
+          );
         }
         break;
       }
@@ -331,21 +306,13 @@ TurnResolutionResult resolveTurnForGame({
           onDialogue: onDialogue,
           onGameEvent: onGameEvent,
         );
-        // Emit province_captured events for changed ownership
         if (onGameEvent != null) {
-          for (final region in [state.worldState.oldWorld, state.worldState.newWorld]) {
-            for (final prov in region.provinces) {
-              final previousOwner = previousOwnership[prov.id];
-              if (previousOwner != null && previousOwner != prov.ownerId) {
-                onGameEvent(ProvinceCapturedEvent(
-                  provinceId: prov.id,
-                  previousOwnerId: previousOwner,
-                  newOwnerId: prov.ownerId ?? '',
-                  turnNumber: turn,
-                ));
-              }
-            }
-          }
+          emitProvinceCapturedEvents(
+            previousOwnership,
+            state,
+            turn,
+            onGameEvent,
+          );
         }
         break;
       }
@@ -360,14 +327,7 @@ TurnResolutionResult resolveTurnForGame({
         break;
       case TurnPhase.endOfTurn: {
         state = runEndOfTurnPhase(state, onDialogue: onDialogue);
-        // Emit victory_set event if victory is set
-        if (onGameEvent != null && state.victory != null) {
-          onGameEvent(VictorySetEvent(
-            winnerPlayerId: state.victory!.winnerPlayerId,
-            victoryType: state.victory!.type.name,
-            turnNumber: turn,
-          ));
-        }
+        emitVictorySetEvent(state, turn, onGameEvent);
         break;
       }
     }


### PR DESCRIPTION
## Summary
Logic package refactor (6 rounds): single source of truth for economy/build/work, thinner orchestration, and extracted helpers. All tests pass (logic, data, ai).

## Changes

### Data
- **riches_prices**: `purchaseLandCost(resourceId)` — 15× base price for purchase_land (validation + application).

### Logic – economy
- **build_cost.dart** (new): `canAffordBuild`, `applyBuildCostDeduction` — shared by `BuildOrderValidator` and `orders_application`.
- **BuildOrderValidator** / **WorkOrderValidator**: use `build_cost` and `purchaseLandCost`; no duplicated cost logic.

### Logic – orders application
- **orders_application_helpers.dart** (new): `isMineralEligibleTile` for work/build phases.

### Logic – turn resolution
- **turn_resolution_events.dart** (new): `emitResearchCompleteEvents`, `emitDiplomacyChangeEvents`, `emitProvinceCapturedEvents`, `emitVictorySetEvent`.
- **turn_resolver**: phase switch delegates event emission to these helpers.

### Logic – setup
- **initial_visibility.dart** (new): `applyInitialVisibility`; **game_setup** delegates visibility there.

### Logic – diplomacy
- **diplomacy_relation_lookup.dart** (new): `pairKey`, `getRelation`, `upsertRelation`, `getOverture`, `getPlayer`, cost/level helpers.
- **diplomacy_resolver**: uses lookup module; re-exports for backward compatibility.

### Logic – order suggestion
- **order_suggestion_helpers.dart** (new): `getProvinceOwnerMap`, `filterMoveOrdersByDiplomacy`.
- **order_suggestion**: uses helpers; re-exports for colonizethis_ai.

## Testing
- `dart test packages/colonizethis_logic` ✅
- `dart test packages/colonizethis_data` ✅
- `dart test packages/colonizethis_ai` ✅

Made with [Cursor](https://cursor.com)