### PR TITLE
refactor(logic): centralize fog, topology, worker economy, AI control

### DIFF
--- a/packages/colonizethis_logic/lib/colonizethis_logic.dart
+++ b/packages/colonizethis_logic/lib/colonizethis_logic.dart
@@ -36,6 +36,7 @@ export 'src/economy/economy_production.dart';
 export 'src/economy/economy_riches_to_treasury.dart';
 export 'src/economy/resource_extractor.dart';
 export 'src/economy/sea_transport.dart';
+export 'src/economy/worker_economy.dart';
 
 // Orders
 export 'src/orders/order_engine.dart';
@@ -56,6 +57,7 @@ export 'src/dossier/event_dialogue.dart';
 
 // AI
 export 'src/ai/ai_planner.dart';
+export 'src/ai/ai_control.dart';
 export 'src/ai/sim_game_ai.dart';
 export 'src/ai/simple_ai_heuristics.dart';
 

--- a/packages/colonizethis_logic/lib/src/ai/ai_control.dart
+++ b/packages/colonizethis_logic/lib/src/ai/ai_control.dart
@@ -1,0 +1,16 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../constants.dart';
+
+/// AI control helpers: which GPs are AI-controlled, seeds, and config wiring.
+/// SPEC/program/ai-planner.md, SPEC/ai/economy-planner.md.
+
+/// Returns true if [gpId] is AI-controlled. Uses [Game.aiControlByGpId] when
+/// present, otherwise !player.isHuman.
+bool isAiControlled(Game game, String gpId) {
+  final explicit = game.aiControlByGpId[gpId];
+  if (explicit != null) return explicit;
+  final player = game.playerById(gpId);
+  return player != null && !player.isHuman;
+}
+

--- a/packages/colonizethis_logic/lib/src/ai/ai_planner.dart
+++ b/packages/colonizethis_logic/lib/src/ai/ai_planner.dart
@@ -7,16 +7,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import '../constants.dart';
 import '../world/player_view.dart';
 import '../orders/order_suggestion_api_impl.dart';
+import 'ai_control.dart';
 import 'simple_ai_heuristics.dart';
-
-/// Returns true if [gpId] is AI-controlled. Uses aiControlByGpId when present,
-/// otherwise !player.isHuman.
-bool isAiControlled(Game game, String gpId) {
-  final explicit = game.aiControlByGpId[gpId];
-  if (explicit != null) return explicit;
-  final player = game.playerById(gpId);
-  return player != null && !player.isHuman;
-}
 
 /// Generates orders for a single AI-controlled GP. Deterministic given game
 /// state and seeds. Respects diplomacy: no attacks against factions at peace.

--- a/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../world/fog_resolution.dart';
 import 'conflict_detection.dart';
 import 'leader_bonus_helpers.dart';
 import 'military_strength.dart';
@@ -172,24 +173,66 @@ Game resolveBattleContext(
     }
   }
 
+  final post = _buildPostBattleRegion(
+    region: region,
+    ctx: ctx,
+    allCasualties: allCasualties,
+    unitsById: unitsById,
+    provinceOwnerId: provinceOwnerId,
+    defenderFactionId: ctx.defenderFactionId,
+    survivingAttackerFactionId: survivingAttackerFactionId,
+    defenderUnitIds: defenderUnitIds,
+  );
+
+  var newWorldState = ctx.regionId == kRegionOldWorld
+      ? game.worldState.copyWith(oldWorld: post.region)
+      : game.worldState.copyWith(newWorld: post.region);
+
+  if (post.provinceChangedOwner && survivingAttackerFactionId != null) {
+    final timers = clearSpyRevealTimersForProvince(
+      game.worldState.spyRevealTurnsByPlayer,
+      survivingAttackerFactionId,
+      ctx.provinceId,
+    );
+    newWorldState = newWorldState.copyWith(spyRevealTurnsByPlayer: timers);
+  }
+
+  return game.copyWith(worldState: newWorldState);
+}
+
+/// Builds post-battle region state: applies casualties, garrison recovery,
+/// province ownership change, and civilian cleanup when province changes hands.
+({RegionData region, bool provinceChangedOwner}) _buildPostBattleRegion({
+  required RegionData region,
+  required BattleContext ctx,
+  required List<String> allCasualties,
+  required Map<String, Unit> unitsById,
+  required String provinceOwnerId,
+  required String defenderFactionId,
+  required String? survivingAttackerFactionId,
+  required List<String> defenderUnitIds,
+}) {
   final survivingUnits =
       region.units.where((u) => !allCasualties.contains(u.id)).toList();
 
   var updatedProvinces = region.provinces;
-  bool provinceChangedOwner = false;
+  var ownerId = provinceOwnerId;
+  var provinceChangedOwner = false;
   if (defenderUnitIds.isEmpty && survivingAttackerFactionId != null) {
     final idx = updatedProvinces.indexWhere((p) => p.id == ctx.provinceId);
     if (idx >= 0) {
       final p = updatedProvinces[idx];
       updatedProvinces = List<Province>.from(updatedProvinces)
         ..[idx] = p.copyWith(ownerId: survivingAttackerFactionId);
+      ownerId = survivingAttackerFactionId;
       provinceChangedOwner = true;
     }
   }
 
   final recoveredUnits = unitsById.values
       .where(
-          (u) => u.id.startsWith('recover_') && !allCasualties.contains(u.id))
+        (u) => u.id.startsWith('recover_') && !allCasualties.contains(u.id),
+      )
       .toList();
   var finalUnits = [
     ...survivingUnits,
@@ -198,8 +241,8 @@ Game resolveBattleContext(
 
   // If the province changed hands during this battle, remove civilian units
   // in that province that do not belong to the new owner.
-  if (provinceOwnerId != ctx.defenderFactionId) {
-    final victorId = provinceOwnerId;
+  if (ownerId != defenderFactionId) {
+    final victorId = ownerId;
     finalUnits = finalUnits.where((u) {
       if (u.provinceId != ctx.provinceId) return true;
       // Military units remain; civilians of non-victor factions are removed.
@@ -212,41 +255,7 @@ Game resolveBattleContext(
     provinces: updatedProvinces,
     units: finalUnits,
   );
-
-  if (ctx.regionId == kRegionOldWorld) {
-    var newWorldState = game.worldState.copyWith(oldWorld: newRegion);
-    if (provinceChangedOwner && survivingAttackerFactionId != null) {
-      // Clear Spy timers for (newOwner, province) when province changes hands.
-      final timers = <String, Map<String, int>>{};
-      game.worldState.spyRevealTurnsByPlayer.forEach((playerId, byProv) {
-        final inner = Map<String, int>.from(byProv);
-        if (playerId == survivingAttackerFactionId) {
-          inner.remove(ctx.provinceId);
-        }
-        if (inner.isNotEmpty) {
-          timers[playerId] = inner;
-        }
-      });
-      newWorldState = newWorldState.copyWith(spyRevealTurnsByPlayer: timers);
-    }
-    return game.copyWith(worldState: newWorldState);
-  } else {
-    var newWorldState = game.worldState.copyWith(newWorld: newRegion);
-    if (provinceChangedOwner && survivingAttackerFactionId != null) {
-      final timers = <String, Map<String, int>>{};
-      game.worldState.spyRevealTurnsByPlayer.forEach((playerId, byProv) {
-        final inner = Map<String, int>.from(byProv);
-        if (playerId == survivingAttackerFactionId) {
-          inner.remove(ctx.provinceId);
-        }
-        if (inner.isNotEmpty) {
-          timers[playerId] = inner;
-        }
-      });
-      newWorldState = newWorldState.copyWith(spyRevealTurnsByPlayer: timers);
-    }
-    return game.copyWith(worldState: newWorldState);
-  }
+  return (region: newRegion, provinceChangedOwner: provinceChangedOwner);
 }
 
 void _sortAttackersByInitiative(

--- a/packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
@@ -4,6 +4,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../world/fog_resolution.dart';
 import 'conflict_detection.dart';
 
 /// Quick Battle resolution pipeline. SPEC/program/quick-battle-resolution.md.
@@ -354,16 +355,11 @@ Game applyQuickBattleResultToGame(
       result.winner == QuickBattleWinner.attacker &&
       ctx.attackers.isNotEmpty) {
     final attackerFactionId = ctx.attackers.first.factionId;
-    final timers = <String, Map<String, int>>{};
-    game.worldState.spyRevealTurnsByPlayer.forEach((playerId, byProv) {
-      final inner = Map<String, int>.from(byProv);
-      if (playerId == attackerFactionId) {
-        inner.remove(ctx.provinceId);
-      }
-      if (inner.isNotEmpty) {
-        timers[playerId] = inner;
-      }
-    });
+    final timers = clearSpyRevealTimersForProvince(
+      game.worldState.spyRevealTurnsByPlayer,
+      attackerFactionId,
+      ctx.provinceId,
+    );
     newWorldState = newWorldState.copyWith(spyRevealTurnsByPlayer: timers);
   }
 

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
@@ -80,6 +80,12 @@ OvertureState? getOverture(Game game, String gpId, String targetId) {
   return null;
 }
 
+/// True when [a] and [b] are at war according to [game.diplomacyRelations].
+bool factionsAtWar(Game game, String a, String b) {
+  final rel = getRelation(game, a, b);
+  return rel?.atWar ?? false;
+}
+
 /// Returns player by id, or null.
 Player? getPlayer(Game game, String playerId) {
   for (final p in game.players) {

--- a/packages/colonizethis_logic/lib/src/economy/economy_production.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_production.dart
@@ -2,37 +2,9 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
 
+import 'worker_economy.dart';
+
 final Logger _log = Logger();
-
-/// Computes effective available labour for production, capped by luxury
-/// availability per SPEC/program/economy-models.md and
-/// SPEC/game/workers-and-population.md.
-/// Public for use by AI economy planner. SPEC/ai/economy-planner.md.
-int effectiveLabourForWorkers({
-  required WorkerPool workers,
-  required Stockpile stockpile,
-}) {
-  final peasantsLabour = workers.peasants * 1;
-
-  final refinedSugar = stockpile.quantityOf(CommodityCatalog.refinedSugar.id);
-  final cigars = stockpile.quantityOf(CommodityCatalog.cigars.id);
-  final furHats = stockpile.quantityOf(CommodityCatalog.furHats.id);
-
-  final apprenticesWithLuxury = workers.apprentices <= 0
-      ? 0
-      : (refinedSugar < workers.apprentices ? refinedSugar : workers.apprentices);
-  final journeymenWithLuxury = workers.journeymen <= 0
-      ? 0
-      : (cigars < workers.journeymen ? cigars : workers.journeymen);
-  final mastersWithLuxury = workers.masters <= 0
-      ? 0
-      : (furHats < workers.masters ? furHats : workers.masters);
-
-  return peasantsLabour +
-      apprenticesWithLuxury * 4 +
-      journeymenWithLuxury * 6 +
-      mastersWithLuxury * 8;
-}
 
 int _effectiveLabourForWorkers({
   required WorkerPool workers,

--- a/packages/colonizethis_logic/lib/src/economy/worker_economy.dart
+++ b/packages/colonizethis_logic/lib/src/economy/worker_economy.dart
@@ -1,0 +1,37 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Worker economy primitives (labour and luxuries).
+/// SPEC/program/economy-models.md, SPEC/game/workers-and-population.md.
+///
+/// Public for use by AI economy planner and production/consumption pipelines.
+
+/// Computes effective available labour for production, capped by luxury
+/// availability per SPEC/program/economy-models.md and
+/// SPEC/game/workers-and-population.md.
+int effectiveLabourForWorkers({
+  required WorkerPool workers,
+  required Stockpile stockpile,
+}) {
+  final peasantsLabour = workers.peasants * 1;
+
+  final refinedSugar = stockpile.quantityOf(CommodityCatalog.refinedSugar.id);
+  final cigars = stockpile.quantityOf(CommodityCatalog.cigars.id);
+  final furHats = stockpile.quantityOf(CommodityCatalog.furHats.id);
+
+  final apprenticesWithLuxury = workers.apprentices <= 0
+      ? 0
+      : (refinedSugar < workers.apprentices ? refinedSugar : workers.apprentices);
+  final journeymenWithLuxury = workers.journeymen <= 0
+      ? 0
+      : (cigars < workers.journeymen ? cigars : workers.journeymen);
+  final mastersWithLuxury = workers.masters <= 0
+      ? 0
+      : (furHats < workers.masters ? furHats : workers.masters);
+
+  return peasantsLabour +
+      apprenticesWithLuxury * 4 +
+      journeymenWithLuxury * 6 +
+      mastersWithLuxury * 8;
+}
+

--- a/packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
@@ -6,7 +6,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
 
 import '../dossier/event_dialogue.dart';
-import '../world/player_view.dart';
+import '../world/fog_resolution.dart';
 
 final Logger _log = Logger();
 
@@ -63,117 +63,6 @@ void _emitEraChangeDialogue(
   final events = dialogueEventsForEraChange(game, previousEra, newEra, seed);
   for (final e in events) onDialogue(e);
 }
-
-/// Spy 5-turn fog decay: decrement timers; when they expire, set other-faction
-/// provinces back to fogged for that player. Timers MUST NOT affect a player's
-/// own provinces; own provinces remain fully visible. SPEC/program/fog-and-exploration-resolution.md.
-(Map<String, Map<String, String>>, Map<String, Map<String, int>>)
-    applySpyRevealTimerDecay(Game game) {
-  final world = game.worldState;
-  final tileKeysByRegion = world.tileKeysByRegionAndProvince;
-  var visibilityByTile = Map<String, Map<String, String>>.from(
-    world.playerVisibilityByTile.map(
-      (k, v) => MapEntry(k, Map<String, String>.from(v)),
-    ),
-  );
-
-  // Province ownership lookup so we can ensure timers only affect other-faction provinces.
-  final ownerByProvinceId = <String, String?>{
-    for (final p in world.oldWorld.provinces) p.id: p.ownerId,
-    for (final p in world.newWorld.provinces) p.id: p.ownerId,
-  };
-
-  final nextSpyTimers = <String, Map<String, int>>{};
-  for (final entry in world.spyRevealTurnsByPlayer.entries) {
-    final playerId = entry.key;
-    final byProvince = entry.value;
-    final newByProvince = <String, int>{};
-    final vis = Map<String, String>.from(visibilityByTile[playerId] ?? {});
-    for (final provEntry in byProvince.entries) {
-      final provinceId = provEntry.key;
-      final turns = provEntry.value;
-
-      // Never apply Spy timers to a player's own provinces; clear any such timers without changing visibility.
-      final ownerId = ownerByProvinceId[provinceId];
-      if (ownerId == playerId) {
-        continue;
-      }
-
-      final nextTurns = turns - 1;
-      if (nextTurns <= 0) {
-        final regionId = ProvinceId.regionIdFrom(provinceId);
-        final tileKeys = tileKeysByRegion[regionId]?[provinceId] ?? [];
-        for (final tk in tileKeys) {
-          vis[tk] = VisibilityLevel.fogged.name;
-        }
-      } else {
-        newByProvince[provinceId] = nextTurns;
-      }
-    }
-    if (newByProvince.isNotEmpty) nextSpyTimers[playerId] = newByProvince;
-    visibilityByTile[playerId] = vis;
-  }
-  return (visibilityByTile, nextSpyTimers);
-}
-
-/// For each player, set tiles in other-faction provinces to fogged when no Explorer/Spy in that province.
-/// SPEC/program/fog-and-exploration-resolution.md.
-Map<String, Map<String, String>> applyFogDecay(Game game) {
-  const explorerTypes = {'explorer', 'spy'};
-  final owOwnerByProvince = {
-    for (final p in game.worldState.oldWorld.provinces) p.id: p.ownerId,
-  };
-  final nwOwnerByProvince = {
-    for (final p in game.worldState.newWorld.provinces) p.id: p.ownerId,
-  };
-
-  final provincesWithExplorerByPlayer = <String, Set<String>>{};
-  for (final u in game.worldState.oldWorld.units) {
-    if (explorerTypes.contains(u.type.toLowerCase())) {
-      provincesWithExplorerByPlayer
-          .putIfAbsent(u.ownerId, () => <String>{})
-          .add(u.locationProvinceId);
-    }
-  }
-  final provincesWithSpyTimerByPlayer = <String, Set<String>>{};
-  for (final entry in game.worldState.spyRevealTurnsByPlayer.entries) {
-    final playerId = entry.key;
-    final provinces = entry.value.keys;
-    if (provinces.isEmpty) continue;
-    provincesWithSpyTimerByPlayer[playerId] = provinces.toSet();
-  }
-  for (final u in game.worldState.newWorld.units) {
-    if (explorerTypes.contains(u.type.toLowerCase())) {
-      provincesWithExplorerByPlayer
-          .putIfAbsent(u.ownerId, () => <String>{})
-          .add(u.locationProvinceId);
-    }
-  }
-
-  final result = <String, Map<String, String>>{};
-  for (final entry in game.worldState.playerVisibilityByTile.entries) {
-    final playerId = entry.key;
-    final visibility = Map<String, String>.from(entry.value);
-    final hasExplorerIn = provincesWithExplorerByPlayer[playerId] ?? const {};
-    final hasSpyTimerIn = provincesWithSpyTimerByPlayer[playerId] ?? const {};
-
-    for (final tileKey in visibility.keys.toList()) {
-      final parts = tileKey.split('|');
-      if (parts.length != 4) continue;
-      final fullProvinceId = ProvinceId.full(parts[0], parts[1]);
-      final ownerId = owOwnerByProvince[fullProvinceId] ??
-          nwOwnerByProvince[fullProvinceId];
-      if (ownerId == null || ownerId == playerId) continue;
-      if (!hasExplorerIn.contains(fullProvinceId) &&
-          !hasSpyTimerIn.contains(fullProvinceId)) {
-        visibility[tileKey] = VisibilityLevel.fogged.name;
-      }
-    }
-    result[playerId] = visibility;
-  }
-  return result;
-}
-
 /// Returns the id of a Great Power that controls 31+ Old World provinces, or null.
 String? findMilitaryVictoryWinner(Game game) {
   const int requiredProvinces = 31;

--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -3,6 +3,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
 
 import 'province_lookup.dart';
+import 'topology_helpers.dart';
+import '../diplomacy/diplomacy_relation_lookup.dart';
 
 final Logger _log = Logger();
 
@@ -41,7 +43,6 @@ Map<String, Set<String>> computeBlockadedPortProvincesByPlayer(Game game) {
     result[player.id] = {};
   }
   final fleets = game.worldState.fleets;
-  final relations = game.diplomacyRelations;
   for (final fleet in fleets) {
     if (fleet.mission != FleetMission.blockade) continue;
     final targetProvinceId = fleet.targetProvinceId;
@@ -52,12 +53,7 @@ Map<String, Set<String>> computeBlockadedPortProvincesByPlayer(Game game) {
     if (ownerId == null) continue;
     final blockaderId = fleet.ownerId;
     // Only factions at war with the province owner can blockade it.
-    final atWar = relations.any((rel) =>
-        rel.atWar &&
-        rel.factionId1 != rel.factionId2 &&
-        {rel.factionId1, rel.factionId2}.contains(blockaderId) &&
-        {rel.factionId1, rel.factionId2}.contains(ownerId));
-    if (!atWar) continue;
+    if (!factionsAtWar(game, blockaderId, ownerId)) continue;
     result[ownerId] ??= {};
     result[ownerId]!.add(targetProvinceId);
   }
@@ -74,7 +70,7 @@ Map<String, ConnectivityResult> resolveConnectivity({
   Map<String, Set<String>>? blockadedPortProvincesByPlayerId,
 }) {
   _log.d('logic: connectivity resolve start players=${game.players.length} regions=${tileMapByRegion.keys.join(",")}');
-  final provinceIdsByType = _provinceIdsFromTopology(topology);
+  final provinceIdsByType = provinceNodeIds(topology);
   final blockadedByPlayer =
       blockadedPortProvincesByPlayerId ?? computeBlockadedPortProvincesByPlayer(game);
   final result = <String, ConnectivityResult>{};

--- a/packages/colonizethis_logic/lib/src/world/fog_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/fog_resolution.dart
@@ -1,0 +1,136 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../constants.dart';
+import 'player_view.dart';
+
+/// Spy 5-turn fog decay: decrement timers; when they expire, set other-faction
+/// provinces back to fogged for that player. Timers MUST NOT affect a player's
+/// own provinces; own provinces remain fully visible. SPEC/program/fog-and-exploration-resolution.md.
+(Map<String, Map<String, String>>, Map<String, Map<String, int>>)
+    applySpyRevealTimerDecay(Game game) {
+  final world = game.worldState;
+  final tileKeysByRegion = world.tileKeysByRegionAndProvince;
+  var visibilityByTile = Map<String, Map<String, String>>.from(
+    world.playerVisibilityByTile.map(
+      (k, v) => MapEntry(k, Map<String, String>.from(v)),
+    ),
+  );
+
+  // Province ownership lookup so we can ensure timers only affect other-faction provinces.
+  final ownerByProvinceId = <String, String?>{
+    for (final p in world.oldWorld.provinces) p.id: p.ownerId,
+    for (final p in world.newWorld.provinces) p.id: p.ownerId,
+  };
+
+  final nextSpyTimers = <String, Map<String, int>>{};
+  for (final entry in world.spyRevealTurnsByPlayer.entries) {
+    final playerId = entry.key;
+    final byProvince = entry.value;
+    final newByProvince = <String, int>{};
+    final vis = Map<String, String>.from(visibilityByTile[playerId] ?? {});
+    for (final provEntry in byProvince.entries) {
+      final provinceId = provEntry.key;
+      final turns = provEntry.value;
+
+      // Never apply Spy timers to a player's own provinces; clear any such timers without changing visibility.
+      final ownerId = ownerByProvinceId[provinceId];
+      if (ownerId == playerId) {
+        continue;
+      }
+
+      final nextTurns = turns - 1;
+      if (nextTurns <= 0) {
+        final regionId = ProvinceId.regionIdFrom(provinceId);
+        final tileKeys = tileKeysByRegion[regionId]?[provinceId] ?? [];
+        for (final tk in tileKeys) {
+          vis[tk] = VisibilityLevel.fogged.name;
+        }
+      } else {
+        newByProvince[provinceId] = nextTurns;
+      }
+    }
+    if (newByProvince.isNotEmpty) nextSpyTimers[playerId] = newByProvince;
+    visibilityByTile[playerId] = vis;
+  }
+  return (visibilityByTile, nextSpyTimers);
+}
+
+/// For each player, set tiles in other-faction provinces to fogged when no Explorer/Spy in that province.
+/// SPEC/program/fog-and-exploration-resolution.md.
+Map<String, Map<String, String>> applyFogDecay(Game game) {
+  const explorerTypes = {'explorer', 'spy'};
+  final owOwnerByProvince = {
+    for (final p in game.worldState.oldWorld.provinces) p.id: p.ownerId,
+  };
+  final nwOwnerByProvince = {
+    for (final p in game.worldState.newWorld.provinces) p.id: p.ownerId,
+  };
+
+  final provincesWithExplorerByPlayer = <String, Set<String>>{};
+  for (final u in game.worldState.oldWorld.units) {
+    if (explorerTypes.contains(u.type.toLowerCase())) {
+      provincesWithExplorerByPlayer
+          .putIfAbsent(u.ownerId, () => <String>{})
+          .add(u.locationProvinceId);
+    }
+  }
+  final provincesWithSpyTimerByPlayer = <String, Set<String>>{};
+  for (final entry in game.worldState.spyRevealTurnsByPlayer.entries) {
+    final playerId = entry.key;
+    final provinces = entry.value.keys;
+    if (provinces.isEmpty) continue;
+    provincesWithSpyTimerByPlayer[playerId] = provinces.toSet();
+  }
+  for (final u in game.worldState.newWorld.units) {
+    if (explorerTypes.contains(u.type.toLowerCase())) {
+      provincesWithExplorerByPlayer
+          .putIfAbsent(u.ownerId, () => <String>{})
+          .add(u.locationProvinceId);
+    }
+  }
+
+  final result = <String, Map<String, String>>{};
+  for (final entry in game.worldState.playerVisibilityByTile.entries) {
+    final playerId = entry.key;
+    final visibility = Map<String, String>.from(entry.value);
+    final hasExplorerIn = provincesWithExplorerByPlayer[playerId] ?? const {};
+    final hasSpyTimerIn = provincesWithSpyTimerByPlayer[playerId] ?? const {};
+
+    for (final tileKey in visibility.keys.toList()) {
+      final parts = tileKey.split('|');
+      if (parts.length != 4) continue;
+      final fullProvinceId = ProvinceId.full(parts[0], parts[1]);
+      final ownerId =
+          owOwnerByProvince[fullProvinceId] ?? nwOwnerByProvince[fullProvinceId];
+      if (ownerId == null || ownerId == playerId) continue;
+      if (!hasExplorerIn.contains(fullProvinceId) &&
+          !hasSpyTimerIn.contains(fullProvinceId)) {
+        visibility[tileKey] = VisibilityLevel.fogged.name;
+      }
+    }
+    result[playerId] = visibility;
+  }
+  return result;
+}
+
+/// Clears Spy reveal timers for [playerId] in [provinceId]. Used when a province
+/// changes hands or becomes owned by [playerId] so that own provinces never
+/// decay via Spy timers. SPEC/program/fog-and-exploration-resolution.md.
+Map<String, Map<String, int>> clearSpyRevealTimersForProvince(
+  Map<String, Map<String, int>> existing,
+  String playerId,
+  String provinceId,
+) {
+  final timers = <String, Map<String, int>>{};
+  existing.forEach((pid, byProv) {
+    final inner = Map<String, int>.from(byProv);
+    if (pid == playerId) {
+      inner.remove(provinceId);
+    }
+    if (inner.isNotEmpty) {
+      timers[pid] = inner;
+    }
+  });
+  return timers;
+}
+

--- a/packages/colonizethis_logic/lib/src/world/movement.dart
+++ b/packages/colonizethis_logic/lib/src/world/movement.dart
@@ -1,6 +1,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'topology_helpers.dart';
+
 /// Movement validation and application.
 /// SPEC/program/movement.md
 /// Adjacency is region-scoped when topology has multiple regions (SPEC/game/world-model-identity.md).
@@ -13,11 +15,7 @@ Iterable<String> neighborProvinceIdsInRegion(
   String regionId,
   String localProvinceId,
 ) sync* {
-  final nodeIdsInRegion = topology.nodes
-      .where((n) =>
-          n.regionId == regionId && n.type == TopologyNodeType.province)
-      .map((n) => n.id)
-      .toSet();
+  final nodeIdsInRegion = provinceNodeIdsForRegion(topology, regionId);
   final localIdsInRegion = nodeIdsInRegion
       .map((id) => ProvinceId.localIdFrom(id))
       .toSet();

--- a/packages/colonizethis_logic/lib/src/world/topology_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/world/topology_helpers.dart
@@ -1,0 +1,78 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+
+/// Topology helpers shared by movement and connectivity. SPEC/game/map-topology.md.
+
+/// All province node ids in [topology].
+Set<String> provinceNodeIds(MapTopology topology) {
+  return topology.nodes
+      .where((n) => n.type == TopologyNodeType.province)
+      .map((n) => n.id)
+      .toSet();
+}
+
+/// Province node ids in [regionId] in [topology].
+Set<String> provinceNodeIdsForRegion(MapTopology topology, String regionId) {
+  return topology.nodes
+      .where((n) =>
+          n.regionId == regionId && n.type == TopologyNodeType.province)
+      .map((n) => n.id)
+      .toSet();
+}
+
+/// True when any topology node id uses prefixed form (regionId|localId).
+bool topologyUsesPrefixedIds(MapTopology topology) {
+  return topology.nodes.any((n) => n.id.contains('|'));
+}
+
+/// All sea zone node ids in [topology].
+Set<String> seaZoneNodeIds(MapTopology topology) {
+  return topology.nodes
+      .where((n) => n.type == TopologyNodeType.seaZone)
+      .map((n) => n.id)
+      .toSet();
+}
+
+/// Sea zones reachable from [startSeaZoneIds] by following S–S edges in [topology].
+/// SPEC/game/map-topology.md, capital-and-connectivity § Sea paths.
+Set<String> seaZonesReachableBySeaPath(
+  MapTopology topology,
+  Set<String> startSeaZoneIds,
+) {
+  final seaZoneIds = seaZoneNodeIds(topology);
+  final neighbours = <String, Set<String>>{};
+  for (final e in topology.edges) {
+    final a = e.id1;
+    final b = e.id2;
+    if (seaZoneIds.contains(a) && seaZoneIds.contains(b)) {
+      neighbours.putIfAbsent(a, () => {}).add(b);
+      neighbours.putIfAbsent(b, () => {}).add(a);
+    }
+  }
+  final reachable = Set<String>.from(startSeaZoneIds);
+  final queue = List<String>.from(startSeaZoneIds);
+  while (queue.isNotEmpty) {
+    final z = queue.removeAt(0);
+    for (final n in neighbours[z] ?? {}) {
+      if (reachable.contains(n)) continue;
+      reachable.add(n);
+      queue.add(n);
+    }
+  }
+  return reachable;
+}
+
+/// Sea zone ids adjacent to province [provinceNodeId] in topology (P–S edges).
+Set<String> seaZonesAdjacentToProvince(
+  MapTopology topology,
+  String provinceNodeId,
+) {
+  final seaZoneIds = seaZoneNodeIds(topology);
+  final out = <String>{};
+  for (final edge in topology.edges) {
+    if (edge.id1 != provinceNodeId && edge.id2 != provinceNodeId) continue;
+    final other = edge.id1 == provinceNodeId ? edge.id2 : edge.id1;
+    if (seaZoneIds.contains(other)) out.add(other);
+  }
+  return out;
+}
+

--- a/packages/colonizethis_logic/test/fog_resolution_test.dart
+++ b/packages/colonizethis_logic/test/fog_resolution_test.dart
@@ -1,0 +1,246 @@
+import 'package:colonizethis_logic/src/world/fog_resolution.dart';
+import 'package:colonizethis_logic/src/world/player_view.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('applySpyRevealTimerDecay', () {
+    test('decrements timers for other-faction provinces when timer expires', () {
+      const ow = 'oldWorld';
+      const tileKeyP2 = 'oldWorld|P2|0|0';
+
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            'p1': {tileKeyP2: 'fullyVisible'},
+          },
+          tileKeysByRegionAndProvince: const {
+            ow: {
+              'P2': [tileKeyP2],
+            },
+          },
+          spyRevealTurnsByPlayer: const {
+            'p1': {
+              '$ow|P2': 1,
+            },
+          },
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+          Player(id: 'p2', displayName: 'P2', isHuman: false),
+        ],
+      );
+
+      final (visibility, timers) = applySpyRevealTimerDecay(game);
+
+      // Timer should be removed after reaching zero.
+      expect(timers['p1'], isNull);
+      // Visibility change is handled by the subsequent fog-decay pass, not here.
+      expect(visibility['p1']?[tileKeyP2], 'fullyVisible');
+    });
+
+    test('never applies timers to own provinces', () {
+      const ow = 'oldWorld';
+      const tileKeyP1 = 'oldWorld|P1|0|0';
+
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            'p1': {tileKeyP1: 'fullyVisible'},
+          },
+          tileKeysByRegionAndProvince: const {
+            ow: {
+              'P1': [tileKeyP1],
+            },
+          },
+          // Spy timer mistakenly applied to own province; helper must ignore it.
+          spyRevealTurnsByPlayer: const {
+            'p1': {
+              '$ow|P1': 1,
+            },
+          },
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+        ],
+      );
+
+      final (visibility, timers) = applySpyRevealTimerDecay(game);
+
+      // Own-province timer should be dropped without affecting visibility.
+      expect(timers['p1'], isNull);
+      expect(
+        visibility['p1']?[tileKeyP1],
+        VisibilityLevel.fullyVisible.name,
+      );
+    });
+  });
+
+  group('applyFogDecay', () {
+    test('fogs tiles in other-faction provinces when no Explorer or Spy timer', () {
+      const ow = 'oldWorld';
+      const tileKeyP2 = 'oldWorld|P2|0|0';
+
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            'p1': {tileKeyP2: 'fullyVisible'},
+          },
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+          Player(id: 'p2', displayName: 'P2', isHuman: false),
+        ],
+      );
+
+      final nextVisibility = applyFogDecay(game);
+
+      expect(
+        nextVisibility['p1']?[tileKeyP2],
+        VisibilityLevel.fogged.name,
+      );
+    });
+
+    test('preserves visibility when Explorer is present in other-faction province', () {
+      const ow = 'oldWorld';
+      const tileKeyP2 = 'oldWorld|P2|0|0';
+
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+            ],
+            units: const [
+              Unit(
+                id: 'explorer1',
+                type: 'Explorer',
+                ownerId: 'p1',
+                provinceId: '$ow|P2',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            'p1': {tileKeyP2: 'fullyVisible'},
+          },
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+          Player(id: 'p2', displayName: 'P2', isHuman: false),
+        ],
+      );
+
+      final nextVisibility = applyFogDecay(game);
+
+      expect(
+        nextVisibility['p1']?[tileKeyP2],
+        VisibilityLevel.fullyVisible.name,
+      );
+    });
+
+    test('preserves visibility when Spy timer is active in other-faction province', () {
+      const ow = 'oldWorld';
+      const tileKeyP2 = 'oldWorld|P2|0|0';
+
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            'p1': {tileKeyP2: 'fullyVisible'},
+          },
+          spyRevealTurnsByPlayer: const {
+            'p1': {
+              '$ow|P2': 3,
+            },
+          },
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'P1', isHuman: true),
+          Player(id: 'p2', displayName: 'P2', isHuman: false),
+        ],
+      );
+
+      final nextVisibility = applyFogDecay(game);
+
+      expect(
+        nextVisibility['p1']?[tileKeyP2],
+        VisibilityLevel.fullyVisible.name,
+      );
+    });
+  });
+
+  group('clearSpyRevealTimersForProvince', () {
+    test('removes timers only for the given player and province', () {
+      const ow = 'oldWorld';
+      final existing = <String, Map<String, int>>{
+        'p1': {
+          '$ow|P1': 3,
+          '$ow|P2': 2,
+        },
+        'p2': {
+          '$ow|P2': 4,
+        },
+      };
+
+      final next = clearSpyRevealTimersForProvince(existing, 'p1', '$ow|P2');
+
+      expect(next['p1'], isNotNull);
+      expect(next['p1']!.containsKey('$ow|P1'), isTrue);
+      expect(next['p1']!.containsKey('$ow|P2'), isFalse);
+      // Other players' timers untouched.
+      expect(next['p2']!.containsKey('$ow|P2'), isTrue);
+    });
+
+    test('drops empty inner map when last timer is removed', () {
+      const ow = 'oldWorld';
+      final existing = <String, Map<String, int>>{
+        'p1': {
+          '$ow|P2': 1,
+        },
+        'p2': {
+          '$ow|P2': 2,
+        },
+      };
+
+      final next = clearSpyRevealTimersForProvince(existing, 'p1', '$ow|P2');
+
+      expect(next.containsKey('p1'), isFalse);
+      expect(next['p2']!.containsKey('$ow|P2'), isTrue);
+    });
+  });
+}
+

--- a/packages/colonizethis_logic/test/topology_helpers_test.dart
+++ b/packages/colonizethis_logic/test/topology_helpers_test.dart
@@ -1,0 +1,134 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/src/world/topology_helpers.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('provinceNodeIds / provinceNodeIdsForRegion', () {
+    test('return province ids by topology and region', () {
+      const ow = 'oldWorld';
+      const nw = 'newWorld';
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'p1', regionId: ow, type: TopologyNodeType.province),
+          TopologyNode(id: 'p2', regionId: ow, type: TopologyNodeType.province),
+          TopologyNode(id: 'p3', regionId: nw, type: TopologyNodeType.province),
+          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
+        ],
+        edges: [],
+      );
+
+      final all = provinceNodeIds(topology);
+      expect(all, containsAll(<String>['p1', 'p2', 'p3']));
+      expect(all.contains('sea1'), isFalse);
+
+      final owProvinces = provinceNodeIdsForRegion(topology, ow);
+      final nwProvinces = provinceNodeIdsForRegion(topology, nw);
+
+      expect(owProvinces, containsAll(<String>['p1', 'p2']));
+      expect(owProvinces.contains('p3'), isFalse);
+      expect(nwProvinces, contains('p3'));
+      expect(nwProvinces.contains('p1'), isFalse);
+    });
+  });
+
+  group('topologyUsesPrefixedIds', () {
+    test('is true when any node id is prefixed', () {
+      const topologyWithPrefixed = MapTopology(
+        nodes: [
+          TopologyNode(
+            id: 'oldWorld|p1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'sea1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.seaZone,
+          ),
+        ],
+        edges: [],
+      );
+
+      const topologyWithoutPrefixed = MapTopology(
+        nodes: [
+          TopologyNode(
+            id: 'p1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'sea1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.seaZone,
+          ),
+        ],
+        edges: [],
+      );
+
+      expect(topologyUsesPrefixedIds(topologyWithPrefixed), isTrue);
+      expect(topologyUsesPrefixedIds(topologyWithoutPrefixed), isFalse);
+    });
+  });
+
+  group('seaZoneNodeIds / seaZonesReachableBySeaPath', () {
+    test('returns all sea zones and BFS over S–S edges', () {
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(id: 'sea2', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(id: 'sea3', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+        ],
+        edges: [
+          TopologyEdge(id1: 'sea1', id2: 'sea2'),
+          TopologyEdge(id1: 'sea2', id2: 'sea3'),
+          // Province edge should be ignored by sea path logic.
+          TopologyEdge(id1: 'p1', id2: 'sea1'),
+        ],
+      );
+
+      final seas = seaZoneNodeIds(topology);
+      expect(seas, containsAll(<String>['sea1', 'sea2', 'sea3']));
+      expect(seas.contains('p1'), isFalse);
+
+      final reachableFromSea1 = seaZonesReachableBySeaPath(topology, {'sea1'});
+      expect(reachableFromSea1, containsAll(<String>['sea1', 'sea2', 'sea3']));
+      // Province node must not appear in reachable set.
+      expect(reachableFromSea1.contains('p1'), isFalse);
+    });
+  });
+
+  group('seaZonesAdjacentToProvince', () {
+    test('returns sea zones touching a province via P–S edges only', () {
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 'p2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(id: 'sea2', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(id: 'sea3', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+        ],
+        edges: [
+          // p1 touches sea1 and sea2
+          TopologyEdge(id1: 'p1', id2: 'sea1'),
+          TopologyEdge(id1: 'sea2', id2: 'p1'),
+          // p2 touches sea3 only
+          TopologyEdge(id1: 'p2', id2: 'sea3'),
+          // sea-sea edge should not affect adjacency sets
+          TopologyEdge(id1: 'sea1', id2: 'sea2'),
+        ],
+      );
+
+      final p1Adj = seaZonesAdjacentToProvince(topology, 'p1');
+      final p2Adj = seaZonesAdjacentToProvince(topology, 'p2');
+
+      expect(p1Adj, containsAll(<String>['sea1', 'sea2']));
+      expect(p1Adj.contains('sea3'), isFalse);
+
+      expect(p2Adj, contains('sea3'));
+      expect(p2Adj.contains('sea1'), isFalse);
+      expect(p2Adj.contains('sea2'), isFalse);
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- Centralizes fog-of-war and spy visibility rules into reusable helpers used by end-of-turn, combat, and quick battle resolution paths.
- Introduces shared MapTopology/connectivity helpers for province/sea adjacency and reuses them from movement and connectivity_resolver.
- Extracts worker labour and related economy primitives into a dedicated module and moves AI control checks into ai_control to keep ai_planner as a thin orchestrator.

## Test plan
- dart test packages/colonizethis_logic
- dart test packages/colonizethis_ai

Made with [Cursor](https://cursor.com)