### PR TITLE
refactor(logic): unit lookup, build/work, order filtering

### DIFF
--- a/packages/colonizethis_logic/lib/colonizethis_logic.dart
+++ b/packages/colonizethis_logic/lib/colonizethis_logic.dart
@@ -63,6 +63,7 @@ export 'src/ai/simple_ai_heuristics.dart';
 
 // World
 export 'src/world/connectivity_resolver.dart';
+export 'src/world/unit_lookup.dart';
 export 'src/world/minor_military_parity.dart';
 export 'src/world/movement.dart';
 export 'src/world/naval.dart';

--- a/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
 import '../world/fog_resolution.dart';
+import '../world/unit_lookup.dart';
 import 'conflict_detection.dart';
 import 'leader_bonus_helpers.dart';
 import 'military_strength.dart';
@@ -46,7 +47,7 @@ Game resolveBattleContext(
     region = game.worldState.newWorld;
   }
 
-  final unitsById = {for (final u in region.units) u.id: u};
+  final unitsById = unitsByIdFromRegion(region);
   var defenderUnitIds = ctx.defenderUnitIds.toList();
   var defenderFactionId = ctx.defenderFactionId;
   var provinceOwnerId = ctx.defenderFactionId;

--- a/packages/colonizethis_logic/lib/src/combat/military_strength.dart
+++ b/packages/colonizethis_logic/lib/src/combat/military_strength.dart
@@ -4,6 +4,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../world/unit_lookup.dart';
+
 /// Military strength aggregation for display (e.g., Game Overview tab).
 /// SPEC/program/military-strength.md.
 ///
@@ -56,13 +58,9 @@ int effectiveEraForFaction(Game game, String factionId) {
 ///
 /// Spec: SPEC/program/military-strength.md
 double aggregateMilitaryStrengthForPlayer(Game game, String playerId) {
-  final owUnits = game.worldState.oldWorld.units
-      .where((u) => u.ownerId == playerId)
-      .toList();
-  final nwUnits = game.worldState.newWorld.units
+  final units = allUnitsFromWorld(game.worldState)
       .where((u) => u.ownerId == playerId)
       .toList();
   final effectiveEra = effectiveEraForFaction(game, playerId);
-  return aggregateStrength(owUnits, effectiveEra) +
-      aggregateStrength(nwUnits, effectiveEra);
+  return aggregateStrength(units, effectiveEra);
 }

--- a/packages/colonizethis_logic/lib/src/combat/quick_battle_input_builder.dart
+++ b/packages/colonizethis_logic/lib/src/combat/quick_battle_input_builder.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../world/unit_lookup.dart';
 import 'conflict_detection.dart';
 import 'leader_bonus_helpers.dart';
 
@@ -16,7 +17,7 @@ QuickBattleInput buildQuickBattleInput(
   final region = ctx.regionId == kRegionOldWorld
       ? game.worldState.oldWorld
       : game.worldState.newWorld;
-  final unitsById = {for (final u in region.units) u.id: u};
+  final unitsById = unitsByIdFromRegion(region);
 
   final defGroups = [
     QuickBattleGroup(

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -5,6 +5,7 @@ import 'package:logger/logger.dart';
 import '../economy/economy_production.dart';
 import 'order_projections.dart';
 import '../world/player_view.dart';
+import '../world/unit_lookup.dart';
 import '../constants.dart';
 import 'projected_effects.dart';
 import 'order_validation_result.dart';
@@ -315,8 +316,7 @@ class OrderEngine {
     final missions = _orders.navalMissionOrdersByPlayerId[playerId] ?? [];
     var rejected = false;
 
-    final unitsById = {for (final u in game.worldState.oldWorld.units) u.id: u}
-      ..addAll({for (final u in game.worldState.newWorld.units) u.id: u});
+    final unitsById = Map<String, Unit>.from(unitsByIdFromWorld(game.worldState));
 
     bool _isDevExclusiveUnitType(String type) =>
         type == 'Builder' || type == 'Engineer' || type == 'Merchant';
@@ -325,16 +325,7 @@ class OrderEngine {
     // track tiles already reserved by this player's Builder/Engineer/Merchant work
     // (existing multi-turn currentWork and newly accepted work orders in this validation pass).
     final devExclusiveTiles = <String>{};
-    for (final u in game.worldState.oldWorld.units) {
-      final w = u.currentWork;
-      if (u.ownerId == playerId &&
-          _isDevExclusiveUnitType(u.type) &&
-          w != null &&
-          w.tileKey.isNotEmpty) {
-        devExclusiveTiles.add(w.tileKey);
-      }
-    }
-    for (final u in game.worldState.newWorld.units) {
+    for (final u in allUnitsFromWorld(game.worldState)) {
       final w = u.currentWork;
       if (u.ownerId == playerId &&
           _isDevExclusiveUnitType(u.type) &&

--- a/packages/colonizethis_logic/lib/src/orders/order_projections.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_projections.dart
@@ -4,6 +4,7 @@ import 'package:logger/logger.dart';
 
 import '../economy/economy_production.dart';
 import '../constants.dart';
+import '../world/unit_lookup.dart';
 import 'projected_effects.dart';
 import '../turn/turn_resolver.dart';
 
@@ -44,10 +45,7 @@ ProjectedEffects projectOrderEffects({
 
   // Unit locations after resolution (province identity: use locationProvinceId per SPEC/game/world-model.md).
   final unitLocations = <String, String>{};
-  for (final u in next.worldState.oldWorld.units) {
-    if (u.ownerId == playerId) unitLocations[u.id] = u.locationProvinceId;
-  }
-  for (final u in next.worldState.newWorld.units) {
+  for (final u in allUnitsFromWorld(next.worldState)) {
     if (u.ownerId == playerId) unitLocations[u.id] = u.locationProvinceId;
   }
 

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -9,6 +9,7 @@ import 'order_engine.dart';
 import 'order_suggestion_helpers.dart';
 import 'order_visibility.dart';
 import '../world/player_view.dart';
+import '../world/unit_lookup.dart';
 
 export 'order_suggestion_helpers.dart';
 
@@ -448,11 +449,9 @@ Set<String> getValidWorkOrderTileKeys(
   String workTarget,
   Orders currentOrders,
 ) {
-  final units = [
-    ...game.worldState.oldWorld.units,
-    ...game.worldState.newWorld.units,
-  ];
-  final unit = units.where((u) => u.id == unitId).firstOrNull;
+  final unit = allUnitsFromWorld(game.worldState)
+      .where((u) => u.id == unitId)
+      .firstOrNull;
   if (unit == null || unit.ownerId != playerId) return {};
   if (unit.currentWork != null) return {};
   if (!isWorkOrderTargetAllowedForUnitType(unit.type, workTarget)) return {};

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -11,6 +11,7 @@ import 'orders_application_helpers.dart';
 import '../world/naval.dart';
 import '../world/player_view.dart';
 import '../world/province_lookup.dart';
+import '../world/unit_lookup.dart';
 
 final Logger _log = Logger();
 
@@ -51,6 +52,146 @@ Game clearUnitCurrentWork(Game game, String unitId) {
   }
 }
 
+/// Mutable state shared by build phase, work phase, and processWorkUnits.
+class _BuildWorkState {
+  _BuildWorkState({
+    required this.game,
+    required this.buildOrders,
+    required this.workOrders,
+    this.topology,
+    this.tileMapByRegion,
+    this.onDialogue,
+    required this.oldUnitsById,
+    required this.newUnitsById,
+    required this.tileState,
+    required this.visibilityByTile,
+    required this.portsByProvinceSeaboard,
+    required this.purchasedTilesByTileKey,
+    required this.oldProvinces,
+    required this.newProvinces,
+  });
+
+  Game game;
+  final Map<String, List<BuildUnitOrder>> buildOrders;
+  final Map<String, List<WorkOrder>> workOrders;
+  final MapTopology? topology;
+  final Map<String, TileMapResult>? tileMapByRegion;
+  final void Function(DialogueEvent)? onDialogue;
+  final Map<String, Unit> oldUnitsById;
+  final Map<String, Unit> newUnitsById;
+  TileMapState tileState;
+  Map<String, Map<String, String>> visibilityByTile;
+  final Map<String, String> portsByProvinceSeaboard;
+  final Map<String, String> purchasedTilesByTileKey;
+  List<Province> oldProvinces;
+  List<Province> newProvinces;
+  final List<Player> updatedPlayers = [];
+}
+
+/// Applies build orders for all players. Mutates [state.game], [state.oldUnitsById], [state.newUnitsById].
+void _runBuildPhase(_BuildWorkState state) {
+  for (final player in state.game.players) {
+    var workers = player.workerPool;
+    var stockpile = player.stockpile;
+    var treasury = player.treasury;
+
+    for (final order in state.buildOrders[player.id] ?? const []) {
+      final category = buildUnitCategoryForUnitType(order.unitType);
+      if (category == BuildUnitCategory.unknown) continue;
+
+      final check = canAffordBuild(player, order, workers, stockpile, treasury);
+      if (!check.canAfford) continue;
+
+      final after = applyBuildCostDeduction(
+        player,
+        order,
+        workers,
+        stockpile,
+        treasury,
+      );
+      workers = after.workers;
+      stockpile = after.stockpile;
+      treasury = after.treasury;
+
+      if (category == BuildUnitCategory.naval) {
+        final capProvinceId = player.capitalProvinceId;
+        if (capProvinceId == null) continue;
+        final regionId = ProvinceId.regionIdFrom(capProvinceId);
+        final seaZoneId = state.topology != null
+            ? seaZoneIdForProvince(
+                state.topology!,
+                ProvinceId.localIdFrom(capProvinceId),
+                regionId: regionId)
+            : null;
+        if (seaZoneId == null) continue;
+
+        var fleets = List<Fleet>.from(state.game.worldState.fleets);
+        final homeFleetId = 'fleet_${player.id}';
+        final existing = fleets
+            .indexWhere((f) => f.id == homeFleetId && f.ownerId == player.id);
+        if (existing >= 0) {
+          final f = fleets[existing];
+          fleets = List<Fleet>.from(fleets)
+            ..[existing] =
+                f.copyWith(shipTypeIds: [...f.shipTypeIds, order.unitType]);
+        } else {
+          fleets = [
+            ...fleets,
+            Fleet(
+              id: homeFleetId,
+              ownerId: player.id,
+              seaZoneId: seaZoneId,
+              regionId: regionId,
+              shipTypeIds: [order.unitType],
+            )
+          ];
+        }
+        state.game = state.game.copyWith(
+          worldState: state.game.worldState.copyWith(fleets: fleets),
+        );
+        continue;
+      }
+
+      final spawnProvinceId = order.spawnProvinceId;
+      final regionId = ProvinceId.regionIdFrom(spawnProvinceId);
+      final tileKeysByRegion =
+          state.game.worldState.tileKeysByRegionAndProvince;
+      final firstTileInSpawn =
+          tileKeysByRegion[regionId]?[spawnProvinceId]?.isNotEmpty == true
+              ? tileKeysByRegion[regionId]![spawnProvinceId]!.first
+              : null;
+
+      final newUnit = Unit(
+        id: _buildUnitId(player.id, order),
+        type: order.unitType,
+        ownerId: player.id,
+        provinceId: spawnProvinceId,
+        tileKey:
+            category == BuildUnitCategory.civilian ? firstTileInSpawn : null,
+      );
+
+      if (regionId == kRegionNewWorld) {
+        state.newUnitsById[newUnit.id] = newUnit;
+      } else {
+        state.oldUnitsById[newUnit.id] = newUnit;
+      }
+    }
+
+    // Apply build-phase deductions to this player so _runWorkPhase sees updated state.
+    state.game = state.game.copyWith(
+      players: state.game.players
+          .map((p) => p.id == player.id
+              ? p.copyWith(
+                  stockpile: stockpile,
+                  workerPool: workers,
+                  treasury: treasury,
+                )
+              : p)
+          .toList(),
+    );
+  }
+}
+
 /// Applies BuildUnitOrder and WorkOrder for all players in [game].
 ///
 /// When [topology] is provided, ship builds spawn in home fleet.
@@ -73,25 +214,32 @@ Game applyBuildAndWorkOrders(
     return game;
   }
 
-  // Index units by id for oldWorld and newWorld.
-  final oldUnitsById = {
-    for (final u in game.worldState.oldWorld.units) u.id: u
-  };
-  final newUnitsById = {
-    for (final u in game.worldState.newWorld.units) u.id: u
-  };
+  final state = _BuildWorkState(
+    game: game,
+    buildOrders: buildOrders,
+    workOrders: workOrders,
+    topology: topology,
+    tileMapByRegion: tileMapByRegion,
+    onDialogue: onDialogue,
+    oldUnitsById: Map<String, Unit>.from(
+        unitsByIdFromRegion(game.worldState.oldWorld)),
+    newUnitsById: Map<String, Unit>.from(
+        unitsByIdFromRegion(game.worldState.newWorld)),
+    tileState: game.worldState.tileState,
+    visibilityByTile: Map<String, Map<String, String>>.from(
+        game.worldState.playerVisibilityByTile.map(
+            (k, v) => MapEntry(k, Map<String, String>.from(v)))),
+    portsByProvinceSeaboard:
+        Map<String, String>.from(game.worldState.portsByProvinceSeaboard),
+    purchasedTilesByTileKey:
+        Map<String, String>.from(game.worldState.purchasedTilesByTileKey),
+    oldProvinces: List<Province>.from(game.worldState.oldWorld.provinces),
+    newProvinces: List<Province>.from(game.worldState.newWorld.provinces),
+  );
 
-  // Development progress: all units with currentWork (one pass). SPEC/development-resolution.md.
-  var tileState = game.worldState.tileState;
-  var visibilityByTile = game.worldState.playerVisibilityByTile;
-  var portsByProvinceSeaboard =
-      Map<String, String>.from(game.worldState.portsByProvinceSeaboard);
-  var purchasedTilesByTileKey =
-      Map<String, String>.from(game.worldState.purchasedTilesByTileKey);
-  var oldProvinces = List<Province>.from(game.worldState.oldWorld.provinces);
-  var newProvinces = List<Province>.from(game.worldState.newWorld.provinces);
+  _runBuildPhase(state);
 
-  void applyExploreCompletion(Unit u, String regionId) {
+  void applyExploreCompletion(_BuildWorkState s, Unit u, String regionId) {
     final cw = u.currentWork!;
     final parts = cw.tileKey.split('|');
     final regionIdFromWork = parts.isNotEmpty ? parts[0] : regionId;
@@ -101,31 +249,31 @@ Game applyBuildAndWorkOrders(
     final fullProvinceId = parts.length > 1
         ? ProvinceId.full(regionIdFromWork, provinceId)
         : u.locationProvinceId;
-    final tileKeys = game.worldState
+    final tileKeys = s.game.worldState
             .tileKeysByRegionAndProvince[regionIdFromWork]?[fullProvinceId] ??
         [];
     final playerId = u.ownerId;
-    final vis = Map<String, String>.from(visibilityByTile[playerId] ?? {});
+    final vis = Map<String, String>.from(s.visibilityByTile[playerId] ?? {});
     for (final tk in tileKeys) {
       vis[tk] = VisibilityLevel.fullyVisible.name;
     }
-    visibilityByTile = Map<String, Map<String, String>>.from(visibilityByTile)
+    s.visibilityByTile = Map<String, Map<String, String>>.from(s.visibilityByTile)
       ..[playerId] = vis;
   }
 
   void applyCompletedWorkTarget(
+      _BuildWorkState s,
       Unit u,
       CurrentWork cw,
       List<Province> Function() getProvinces,
-      void Function(List<Province>) setProvinces,
-      Game gameForPlayer) {
+      void Function(List<Province>) setProvinces) {
     _log.d(
         'logic: work completed unit=${u.id} workTarget=${cw.workTarget} tileKey=${cw.tileKey}');
     switch (cw.workTarget) {
       case 'build_improvement':
-        final level = tileState.improvementLevel(cw.tileKey);
-        tileState =
-            tileState.setImprovement(cw.tileKey, (level + 1).clamp(0, 4));
+        final level = s.tileState.improvementLevel(cw.tileKey);
+        s.tileState =
+            s.tileState.setImprovement(cw.tileKey, (level + 1).clamp(0, 4));
         break;
       case 'upgrade_town':
         final provinces = getProvinces();
@@ -140,37 +288,35 @@ Game applyBuildAndWorkOrders(
         break;
       case 'explore':
         applyExploreCompletion(
-            u, ProvinceId.regionIdFrom(u.locationProvinceId));
+            s, u, ProvinceId.regionIdFrom(u.locationProvinceId));
         break;
       case 'build_road':
         {
-          final roadLevel = tileState.roadLevel(cw.tileKey);
+          final roadLevel = s.tileState.roadLevel(cw.tileKey);
           final player =
-              gameForPlayer.players.where((p) => p.id == u.ownerId).firstOrNull;
+              s.game.players.where((p) => p.id == u.ownerId).firstOrNull;
           final hasRoadConstruction =
               player?.techUnlocked?['road_construction'] == true;
           final nextLevel =
               (roadLevel + 1).clamp(0, hasRoadConstruction ? 2 : 1);
-          tileState = tileState.setRoadLevel(cw.tileKey, nextLevel);
+          s.tileState = s.tileState.setRoadLevel(cw.tileKey, nextLevel);
 
-          // Propagate transport level to adjacent capital/port tiles per
-          // SPEC/program/development-resolution.md and SPEC/game/capital-and-connectivity.md.
-          final tileMap = tileMapByRegion;
+          final tileMap = s.tileMapByRegion;
           if (tileMap != null) {
             _propagateRoadToAdjacentCapitalOrPort(
               tileKey: cw.tileKey,
               nextLevel: nextLevel,
               player: player,
-              worldState: gameForPlayer.worldState,
+              worldState: s.game.worldState,
               tileMapByRegion: tileMap,
-              tileState: tileState,
-              setTileState: (newTileState) => tileState = newTileState,
+              tileState: s.tileState,
+              setTileState: (newTileState) => s.tileState = newTileState,
             );
           }
           break;
         }
       case 'build_port':
-        if (topology != null) {
+        if (s.topology != null) {
           final parts = cw.tileKey.split('|');
           final regionIdFromTile = parts.isNotEmpty
               ? parts[0]
@@ -179,11 +325,11 @@ Game applyBuildAndWorkOrders(
               ? parts[1]
               : ProvinceId.localIdFrom(u.locationProvinceId);
           final fullProvinceId = ProvinceId.full(regionIdFromTile, localId);
-          final seaZoneId = seaZoneIdForProvince(topology, localId,
+          final seaZoneId = seaZoneIdForProvince(s.topology!, localId,
               regionId: regionIdFromTile);
           if (seaZoneId != null) {
-            portsByProvinceSeaboard['$fullProvinceId|$seaZoneId'] = cw.tileKey;
-            tileState = tileState.setRoadLevel(cw.tileKey, 4);
+            s.portsByProvinceSeaboard['$fullProvinceId|$seaZoneId'] = cw.tileKey;
+            s.tileState = s.tileState.setRoadLevel(cw.tileKey, 4);
           }
         }
         break;
@@ -196,46 +342,42 @@ Game applyBuildAndWorkOrders(
             setProvinces(List<Province>.from(provinces)
               ..[idx] = p.copyWith(fortLevel: (p.fortLevel + 1).clamp(0, 3)));
           }
-          if (topology != null && onDialogue != null) {
-            final seed = ((gameForPlayer.globalGameSeed ?? 0) ^
-                    (gameForPlayer.worldState.turnState.turnNumber *
+          if (s.topology != null && s.onDialogue != null) {
+            final seed = ((s.game.globalGameSeed ?? 0) ^
+                    (s.game.worldState.turnState.turnNumber *
                         0x9E3779B1))
                 .toInt();
             final events = dialogueEventsForReactiveFortsOnBorder(
-              gameForPlayer,
-              topology,
+              s.game,
+              s.topology!,
               u.ownerId,
               u.locationProvinceId,
               seed,
             );
-            for (final e in events) onDialogue(e);
+            for (final e in events) s.onDialogue!(e);
           }
           break;
         }
       case 'build_rail':
-        tileState = tileState.setRoadLevel(cw.tileKey, 4);
+        s.tileState = s.tileState.setRoadLevel(cw.tileKey, 4);
         break;
       case 'steal_tech':
-        // Resolved in processWorkUnits with roll and tech grant
-        break;
       case 'counter_spy':
-        // Ongoing; per-turn kill resolved in processWorkUnits
         break;
       default:
         break;
     }
   }
 
-  Game processWorkUnits(
-    Game gameForPlayer,
+  void processWorkUnits(
+    _BuildWorkState s,
     Map<String, Unit> unitsById,
     List<Province> Function() getProvinces,
     void Function(List<Province>) setProvinces,
   ) {
-    var currentGame = gameForPlayer;
-    final rand = gameForPlayer.globalGameSeed != null
-        ? Random(gameForPlayer.globalGameSeed! +
-            (gameForPlayer.worldState.turnState.turnNumber * 1000))
+    final rand = s.game.globalGameSeed != null
+        ? Random(s.game.globalGameSeed! +
+            (s.game.worldState.turnState.turnNumber * 1000))
         : Random();
     // Iterate over a snapshot to allow updating unitsById during the loop.
     for (final entry in unitsById.entries.toList()) {
@@ -243,7 +385,7 @@ Game applyBuildAndWorkOrders(
       if (u.currentWork == null) continue;
       final cw = u.currentWork!;
       // Cancel work if tile no longer owned by this player (SPEC: unit dead / tile no longer owned).
-      final purchasedByTile = gameForPlayer.worldState.purchasedTilesByTileKey;
+      final purchasedByTile = s.game.worldState.purchasedTilesByTileKey;
       if (purchasedByTile.containsKey(cw.tileKey) &&
           purchasedByTile[cw.tileKey] != u.ownerId) {
         unitsById[entry.key] =
@@ -300,13 +442,13 @@ Game applyBuildAndWorkOrders(
       if (nextRemaining <= 0) {
         if (cw.workTarget == 'steal_tech') {
           final targetProvinceId = Unit.provinceIdFromTileKey(cw.tileKey);
-          final otherPlayer = currentGame.players
+          final otherPlayer = s.game.players
               .where((p) =>
                   p.id != u.ownerId && p.capitalProvinceId == targetProvinceId)
               .firstOrNull;
           if (otherPlayer != null) {
             final ourTech =
-                currentGame.playerById(u.ownerId)?.techUnlocked ?? {};
+                s.game.playerById(u.ownerId)?.techUnlocked ?? {};
             final theirTech = otherPlayer.techUnlocked ?? {};
             final missing = theirTech.entries
                 .where((e) => e.value == true && ourTech[e.key] != true)
@@ -314,15 +456,15 @@ Game applyBuildAndWorkOrders(
                 .toList();
             if (missing.isNotEmpty && rand.nextDouble() < 0.08) {
               final granted = missing[rand.nextInt(missing.length)];
-              final player = currentGame.players
+              final player = s.game.players
                   .where((p) => p.id == u.ownerId)
                   .firstOrNull;
               if (player != null) {
                 final updated =
                     Map<String, bool>.from(player.techUnlocked ?? {})
                       ..[granted] = true;
-                currentGame = currentGame.copyWith(
-                  players: currentGame.players
+                s.game = s.game.copyWith(
+                  players: s.game.players
                       .map((p) => p.id == u.ownerId
                           ? p.copyWith(techUnlocked: updated)
                           : p)
@@ -332,8 +474,7 @@ Game applyBuildAndWorkOrders(
             }
           }
         } else {
-          applyCompletedWorkTarget(
-              u, cw, getProvinces, setProvinces, currentGame);
+          applyCompletedWorkTarget(s, u, cw, getProvinces, setProvinces);
         }
         unitsById[entry.key] =
             u.copyWith(status: UnitStatus.idle, clearCurrentWork: true);
@@ -343,97 +484,60 @@ Game applyBuildAndWorkOrders(
         );
       }
     }
-    return currentGame;
   }
 
-  final updatedPlayers = <Player>[];
+  _runWorkPhase(state, applyExploreCompletion, applyCompletedWorkTarget);
 
-  for (final player in game.players) {
+  processWorkUnits(
+      state, state.oldUnitsById, () => state.oldProvinces, (p) => state.oldProvinces = p);
+  processWorkUnits(
+      state, state.newUnitsById, () => state.newProvinces, (p) => state.newProvinces = p);
+
+  state.game = state.game.copyWith(
+    worldState: state.game.worldState.copyWith(
+      tileState: state.tileState,
+      playerVisibilityByTile: state.visibilityByTile,
+      portsByProvinceSeaboard: state.portsByProvinceSeaboard,
+      purchasedTilesByTileKey: state.purchasedTilesByTileKey,
+      oldWorld: RegionData(
+          provinces: state.oldProvinces,
+          units: state.oldUnitsById.values.toList()),
+      newWorld: RegionData(
+          provinces: state.newProvinces,
+          units: state.newUnitsById.values.toList()),
+    ),
+  );
+
+  return state.game.copyWith(
+    players: state.updatedPlayers,
+    worldState: state.game.worldState.copyWith(
+      purchasedTilesByTileKey: state.purchasedTilesByTileKey,
+      oldWorld: RegionData(
+          provinces: state.game.worldState.oldWorld.provinces,
+          units: state.oldUnitsById.values.toList()),
+      newWorld: RegionData(
+          provinces: state.game.worldState.newWorld.provinces,
+          units: state.newUnitsById.values.toList()),
+    ),
+  );
+}
+
+void _runWorkPhase(
+  _BuildWorkState state,
+  void Function(_BuildWorkState, Unit, String) applyExploreCompletion,
+  void Function(_BuildWorkState, Unit, CurrentWork,
+      List<Province> Function(), void Function(List<Province>)) applyCompletedWorkTarget,
+) {
+  final workOrders = state.workOrders;
+  final tileState = state.tileState;
+  final oldUnitsById = state.oldUnitsById;
+  final newUnitsById = state.newUnitsById;
+  final purchasedTilesByTileKey = state.purchasedTilesByTileKey;
+
+  for (final player in state.game.players) {
     var stockpile = player.stockpile;
     var workers = player.workerPool;
     var treasury = player.treasury;
-
-    // Build units for this player. Shared cost rules: build_cost.canAffordBuild / applyBuildCostDeduction.
-    for (final order in buildOrders[player.id] ?? const []) {
-      final category = buildUnitCategoryForUnitType(order.unitType);
-      if (category == BuildUnitCategory.unknown) continue;
-
-      final check = canAffordBuild(player, order, workers, stockpile, treasury);
-      if (!check.canAfford) continue;
-
-      final after = applyBuildCostDeduction(
-        player,
-        order,
-        workers,
-        stockpile,
-        treasury,
-      );
-      workers = after.workers;
-      stockpile = after.stockpile;
-      treasury = after.treasury;
-
-      if (category == BuildUnitCategory.naval) {
-        final capProvinceId = player.capitalProvinceId;
-        if (capProvinceId == null) continue;
-        final regionId = ProvinceId.regionIdFrom(capProvinceId);
-        final seaZoneId = topology != null
-            ? seaZoneIdForProvince(
-                topology, ProvinceId.localIdFrom(capProvinceId),
-                regionId: regionId)
-            : null;
-        if (seaZoneId == null) continue;
-
-        var fleets = List<Fleet>.from(game.worldState.fleets);
-        final homeFleetId = 'fleet_${player.id}';
-        final existing = fleets
-            .indexWhere((f) => f.id == homeFleetId && f.ownerId == player.id);
-        if (existing >= 0) {
-          final f = fleets[existing];
-          fleets = List<Fleet>.from(fleets)
-            ..[existing] =
-                f.copyWith(shipTypeIds: [...f.shipTypeIds, order.unitType]);
-        } else {
-          fleets = [
-            ...fleets,
-            Fleet(
-              id: homeFleetId,
-              ownerId: player.id,
-              seaZoneId: seaZoneId,
-              regionId: regionId,
-              shipTypeIds: [order.unitType],
-            )
-          ];
-        }
-        game = game.copyWith(
-          worldState: game.worldState.copyWith(fleets: fleets),
-        );
-        continue;
-      }
-
-      // Spawn unit for military and civilian (naval already continued above).
-      final spawnProvinceId = order.spawnProvinceId;
-      final regionId = ProvinceId.regionIdFrom(spawnProvinceId);
-      final tileKeysByRegion = game.worldState.tileKeysByRegionAndProvince;
-      final firstTileInSpawn =
-          tileKeysByRegion[regionId]?[spawnProvinceId]?.isNotEmpty == true
-              ? tileKeysByRegion[regionId]![spawnProvinceId]!.first
-              : null;
-
-      final newUnit = Unit(
-        id: _buildUnitId(player.id, order),
-        type: order.unitType,
-        ownerId: player.id,
-        provinceId: spawnProvinceId,
-        tileKey:
-            category == BuildUnitCategory.civilian ? firstTileInSpawn : null,
-      );
-
-      if (regionId == kRegionNewWorld) {
-        newUnitsById[newUnit.id] = newUnit;
-      } else {
-        oldUnitsById[newUnit.id] = newUnit;
-      }
-    }
 
     Unit? lookupUnit(String unitId) =>
         oldUnitsById[unitId] ?? newUnitsById[unitId];
@@ -450,7 +554,7 @@ Game applyBuildAndWorkOrders(
         oldUnitsById.containsKey(unitId) ? kRegionOldWorld : kRegionNewWorld;
 
     Province? provinceById(String id) =>
-        tryGetProvince(game.worldState, id);
+        tryGetProvince(state.game.worldState, id);
 
     bool canAffordMaterialCost(WorkOrderCost cost) {
       for (final e in cost.entries) {
@@ -590,7 +694,7 @@ Game applyBuildAndWorkOrders(
           hasValidTarget) {
         // SPEC/game/diplomacy.md (GP–Minor/Tribe Rules): purchase_land requires an Embassy
         // with the Minor/Tribe and the buyer must not be at war with that faction.
-        final resourceId = game.worldState.resourceByTileKey[targetTileKey];
+        final resourceId = state.game.worldState.resourceByTileKey[targetTileKey];
         if (resourceId != null) {
           final provinceId =
               Unit.provinceIdFromTileKey(targetTileKey) ?? u.locationProvinceId;
@@ -600,14 +704,14 @@ Game applyBuildAndWorkOrders(
             continue;
           }
 
-          final hasEmbassy = game.overtureStates.any(
+          final hasEmbassy = state.game.overtureStates.any(
             (o) => o.gpId == player.id && o.targetId == ownerId && o.hasEmbassy,
           );
           if (!hasEmbassy) {
             continue;
           }
 
-          final atWar = game.diplomacyRelations.any((rel) {
+          final atWar = state.game.diplomacyRelations.any((rel) {
             final ids = {rel.factionId1, rel.factionId2};
             return ids.contains(player.id) &&
                 ids.contains(ownerId) &&
@@ -673,14 +777,14 @@ Game applyBuildAndWorkOrders(
       if (order.target == 'prospect' &&
           hasValidTarget &&
           isExplorerUnit(u.type) &&
-          isMineralEligibleTile(game, tileMapByRegion, targetTileKey)) {
+          isMineralEligibleTile(state.game, state.tileMapByRegion, targetTileKey)) {
         final existing =
-            game.worldState.playerProspectedTiles[player.id] ?? const {};
+            state.game.worldState.playerProspectedTiles[player.id] ?? const {};
         final newProspected = Set<String>.from(existing)..add(targetTileKey);
-        game = game.copyWith(
-          worldState: game.worldState.copyWith(
+        state.game = state.game.copyWith(
+          worldState: state.game.worldState.copyWith(
             playerProspectedTiles: {
-              ...game.worldState.playerProspectedTiles,
+              ...state.game.worldState.playerProspectedTiles,
               player.id: newProspected,
             },
           ),
@@ -697,7 +801,7 @@ Game applyBuildAndWorkOrders(
         final provinceId =
             Unit.provinceIdFromTileKey(targetTileKey) ?? u.locationProvinceId;
         final byProvince =
-            game.worldState.tileKeysByRegionAndProvince[regionId];
+            state.game.worldState.tileKeysByRegionAndProvince[regionId];
         final tilesInP = byProvince?[provinceId]?.length ?? 0;
         if (tilesInP > 0 && byProvince != null && byProvince.isNotEmpty) {
           var maxTiles = 0;
@@ -755,7 +859,7 @@ Game applyBuildAndWorkOrders(
       }
     }
 
-    updatedPlayers.add(
+    state.updatedPlayers.add(
       player.copyWith(
         stockpile: stockpile,
         workerPool: workers,
@@ -763,43 +867,6 @@ Game applyBuildAndWorkOrders(
       ),
     );
   }
-
-  // Process work (decrement remainingTurns, apply effects when 0) after applying
-  // new work orders from Orders so same-turn assignments can complete. SPEC/program/development-resolution.md.
-  game = processWorkUnits(
-      game, oldUnitsById, () => oldProvinces, (p) => oldProvinces = p);
-  game = processWorkUnits(
-      game, newUnitsById, () => newProvinces, (p) => newProvinces = p);
-  game = game.copyWith(
-    worldState: game.worldState.copyWith(
-      tileState: tileState,
-      playerVisibilityByTile: visibilityByTile,
-      portsByProvinceSeaboard: portsByProvinceSeaboard,
-      purchasedTilesByTileKey: purchasedTilesByTileKey,
-      oldWorld: RegionData(
-          provinces: oldProvinces, units: oldUnitsById.values.toList()),
-      newWorld: RegionData(
-          provinces: newProvinces, units: newUnitsById.values.toList()),
-    ),
-  );
-
-  final updatedOldWorld = RegionData(
-    provinces: game.worldState.oldWorld.provinces,
-    units: oldUnitsById.values.toList(),
-  );
-  final updatedNewWorld = RegionData(
-    provinces: game.worldState.newWorld.provinces,
-    units: newUnitsById.values.toList(),
-  );
-
-  return game.copyWith(
-    players: updatedPlayers,
-    worldState: game.worldState.copyWith(
-      purchasedTilesByTileKey: purchasedTilesByTileKey,
-      oldWorld: updatedOldWorld,
-      newWorld: updatedNewWorld,
-    ),
-  );
 }
 
 String _buildUnitId(String playerId, BuildUnitOrder order) {

--- a/packages/colonizethis_logic/lib/src/setup/init_game_orchestrator.dart
+++ b/packages/colonizethis_logic/lib/src/setup/init_game_orchestrator.dart
@@ -9,6 +9,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
 
 import '../constants.dart';
+import '../world/unit_lookup.dart';
 import 'game_setup.dart';
 import 'warp_zone_generator.dart';
 
@@ -256,10 +257,9 @@ String formatInitGameSetupMarkdown(Game game) {
         .map((e) => '${e.key}:${e.value}')
         .join(', ');
     final workers = '${p.workerPool.peasants}p/${p.workerPool.apprentices}a/${p.workerPool.journeymen}j/${p.workerPool.masters}m';
-    final units = game.worldState.oldWorld.units
-            .where((u) => u.ownerId == p.id)
-            .length +
-        game.worldState.newWorld.units.where((u) => u.ownerId == p.id).length;
+    final units = allUnitsFromWorld(game.worldState)
+        .where((u) => u.ownerId == p.id)
+        .length;
     buf.writeln('| ${p.displayName} (${p.id}) | ${stock.isEmpty ? "—" : stock} | $workers | ${p.treasury} | $units |');
   }
   for (final m in game.minorNations) {

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -27,6 +27,7 @@ import '../dossier/evidence_rules.dart';
 import '../dossier/event_dialogue.dart';
 import '../world/player_view.dart';
 import '../world/province_lookup.dart';
+import '../world/unit_lookup.dart';
 import '../world/capital_and_gp_fall.dart';
 import 'combat_phase_helpers.dart';
 import 'end_of_turn_resolver.dart';
@@ -395,6 +396,35 @@ TurnResolutionResult resumeTurnResolutionWithOvertureDecisions({
   );
 }
 
+/// Filters [orders] by validation [results] (consuming via [idxBox]).
+/// Accepted orders are added via [addAccepted]; rejected emit [OrderRejectedEvent] when [onGameEvent] is set.
+void _filterOrderList<T>(
+  String playerId,
+  List<T> orders,
+  List<OrderValidationResult> results,
+  List<int> idxBox,
+  void Function(String playerId, T order) addAccepted,
+  String Function(T order) orderSummary,
+  void Function(GameEvent)? onGameEvent,
+) {
+  for (final order in orders) {
+    final r = idxBox[0] >= results.length
+        ? const OrderValidationResult(
+            status: OrderValidationStatus.accepted,
+          )
+        : results[idxBox[0]++];
+    if (r.isAccepted) {
+      addAccepted(playerId, order);
+    } else if (onGameEvent != null && r.reason != null) {
+      onGameEvent(OrderRejectedEvent(
+        playerId: playerId,
+        orderSummary: orderSummary(order),
+        reasonCode: r.reason!,
+      ));
+    }
+  }
+}
+
 Orders _filterAcceptedOrdersForAllPlayers({
   required OrderEngine engine,
   required Game game,
@@ -427,57 +457,39 @@ Orders _filterAcceptedOrdersForAllPlayers({
 
     final results =
         engine.validatePlayerOrdersWithContext(game, topology, playerId);
-    var idx = 0;
+    final idxBox = [0];
 
-    OrderValidationResult _next() {
-      if (idx >= results.length) {
-        return const OrderValidationResult(
-          status: OrderValidationStatus.accepted,
-        );
-      }
-      final r = results[idx];
-      idx++;
-      return r;
-    }
+    _filterOrderList<MoveOrder>(
+      playerId,
+      moves,
+      results,
+      idxBox,
+      (pid, m) =>
+          moveByPlayer.putIfAbsent(pid, () => <MoveOrder>[]).add(m),
+      (m) => 'Move order: ${m.unitId} -> ${m.destinationProvinceId}',
+      onGameEvent,
+    );
+    _filterOrderList<BuildUnitOrder>(
+      playerId,
+      builds,
+      results,
+      idxBox,
+      (pid, b) =>
+          buildByPlayer.putIfAbsent(pid, () => <BuildUnitOrder>[]).add(b),
+      (b) => 'Build unit: ${b.unitType}',
+      onGameEvent,
+    );
+    _filterOrderList<WorkOrder>(
+      playerId,
+      works,
+      results,
+      idxBox,
+      (pid, w) =>
+          workByPlayer.putIfAbsent(pid, () => <WorkOrder>[]).add(w),
+      (w) => 'Work order: ${w.target}',
+      onGameEvent,
+    );
 
-    for (final m in moves) {
-      final r = _next();
-      if (r.isAccepted) {
-        moveByPlayer.putIfAbsent(playerId, () => <MoveOrder>[]).add(m);
-      } else if (onGameEvent != null && r.reason != null) {
-        onGameEvent(OrderRejectedEvent(
-          playerId: playerId,
-          orderSummary: 'Move order: ${m.unitId} -> ${m.destinationProvinceId}',
-          reasonCode: r.reason!,
-        ));
-      }
-    }
-    for (final b in builds) {
-      final r = _next();
-      if (r.isAccepted) {
-        buildByPlayer.putIfAbsent(playerId, () => <BuildUnitOrder>[]).add(b);
-      } else if (onGameEvent != null && r.reason != null) {
-        onGameEvent(OrderRejectedEvent(
-          playerId: playerId,
-          orderSummary: 'Build unit: ${b.unitType}',
-          reasonCode: r.reason!,
-        ));
-      }
-    }
-    for (final w in works) {
-      final r = _next();
-      if (r.isAccepted) {
-        workByPlayer.putIfAbsent(playerId, () => <WorkOrder>[]).add(w);
-      } else if (onGameEvent != null && r.reason != null) {
-        onGameEvent(OrderRejectedEvent(
-          playerId: playerId,
-          orderSummary: 'Work order: ${w.target}',
-          reasonCode: r.reason!,
-        ));
-      }
-    }
-
-    // Diplomacy orders are not yet validated contextually; include all.
     if (diplo.isNotEmpty) {
       diploByPlayer[playerId] = List<DiplomaticOrder>.from(diplo);
     }
@@ -784,10 +796,7 @@ Game _runMovementPhase(
     for (final u in oldUnits) u.id: kRegionOldWorld,
     for (final u in newUnits) u.id: kRegionNewWorld,
   };
-  final unitsById = <String, Unit>{
-    for (final u in oldUnits) u.id: u,
-    for (final u in newUnits) u.id: u,
-  };
+  final unitsById = Map<String, Unit>.from(unitsByIdFromWorld(game.worldState));
 
   String? _firstTileFor(String regionId, String fullProvinceId) {
     final byProvince = tileKeysByRegionAndProvince[regionId];

--- a/packages/colonizethis_logic/lib/src/world/fog_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/fog_resolution.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
 import 'player_view.dart';
+import 'unit_lookup.dart';
 
 /// Spy 5-turn fog decay: decrement timers; when they expire, set other-faction
 /// provinces back to fogged for that player. Timers MUST NOT affect a player's
@@ -67,7 +68,7 @@ Map<String, Map<String, String>> applyFogDecay(Game game) {
   };
 
   final provincesWithExplorerByPlayer = <String, Set<String>>{};
-  for (final u in game.worldState.oldWorld.units) {
+  for (final u in allUnitsFromWorld(game.worldState)) {
     if (explorerTypes.contains(u.type.toLowerCase())) {
       provincesWithExplorerByPlayer
           .putIfAbsent(u.ownerId, () => <String>{})
@@ -80,13 +81,6 @@ Map<String, Map<String, String>> applyFogDecay(Game game) {
     final provinces = entry.value.keys;
     if (provinces.isEmpty) continue;
     provincesWithSpyTimerByPlayer[playerId] = provinces.toSet();
-  }
-  for (final u in game.worldState.newWorld.units) {
-    if (explorerTypes.contains(u.type.toLowerCase())) {
-      provincesWithExplorerByPlayer
-          .putIfAbsent(u.ownerId, () => <String>{})
-          .add(u.locationProvinceId);
-    }
   }
 
   final result = <String, Map<String, String>>{};

--- a/packages/colonizethis_logic/lib/src/world/movement.dart
+++ b/packages/colonizethis_logic/lib/src/world/movement.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'topology_helpers.dart';
+import 'unit_lookup.dart';
 
 /// Movement validation and application.
 /// SPEC/program/movement.md
@@ -93,9 +94,7 @@ RegionData applyMoveOrdersToRegion(
     return regionData;
   }
 
-  final unitsById = {
-    for (final u in regionData.units) u.id: u,
-  };
+  final unitsById = Map<String, Unit>.from(unitsByIdFromRegion(regionData));
 
   for (final entry in moveOrdersByPlayerId.entries) {
     final playerId = entry.key;

--- a/packages/colonizethis_logic/lib/src/world/player_view.dart
+++ b/packages/colonizethis_logic/lib/src/world/player_view.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import 'unit_lookup.dart';
 
 /// Visibility level for a tile from a single player's perspective.
 /// Mirrors SPEC/game/fog-and-exploration.md.
@@ -93,12 +94,7 @@ PlayerView buildPlayerView(
 
   // Units owned by this player across both regions.
   final ownUnitsById = <String, Unit>{};
-  for (final u in game.worldState.oldWorld.units) {
-    if (u.ownerId == playerId) {
-      ownUnitsById[u.id] = u;
-    }
-  }
-  for (final u in game.worldState.newWorld.units) {
+  for (final u in allUnitsFromWorld(game.worldState)) {
     if (u.ownerId == playerId) {
       ownUnitsById[u.id] = u;
     }

--- a/packages/colonizethis_logic/lib/src/world/unit_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/world/unit_lookup.dart
@@ -1,0 +1,27 @@
+import 'package:colonizethis_models/colonizethis_models.dart' show RegionData, Unit, WorldState;
+
+/// Central unit lookup. Units live in [WorldState.oldWorld] and [WorldState.newWorld];
+/// lookup is by unit id. SPEC/game/world-model-identity.md.
+///
+/// Use [unitsByIdFromWorld] for combined read-only or mutable copy across both regions.
+/// Use [unitsByIdFromRegion] for a single region (e.g. combat, movement within region).
+
+/// Returns a new map from unit id to unit for [region]. Callers that need to mutate
+/// (add/update units) should use [Map.from](unitsByIdFromRegion(region)).
+Map<String, Unit> unitsByIdFromRegion(RegionData region) {
+  return {for (final u in region.units) u.id: u};
+}
+
+/// Returns a new map from unit id to unit for all units in [world] (both regions).
+/// Callers that need to mutate should use [Map.from](unitsByIdFromWorld(world)).
+Map<String, Unit> unitsByIdFromWorld(WorldState world) {
+  return <String, Unit>{
+    ...unitsByIdFromRegion(world.oldWorld),
+    ...unitsByIdFromRegion(world.newWorld),
+  };
+}
+
+/// Returns all units from both regions in [world]. For iteration over every unit.
+List<Unit> allUnitsFromWorld(WorldState world) {
+  return [...world.oldWorld.units, ...world.newWorld.units];
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -460,10 +460,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- Centralize `WorldState`/`RegionData` unit lookup into shared helpers reused across logic modules.
- Split build/work order application into dedicated phased helpers backed by a shared mutable state object.
- Simplify turn order validation by introducing a generic order filtering helper to reduce duplication.

## Test plan
- `cd packages/colonizethis_logic && dart test`

Made with [Cursor](https://cursor.com)