### PR TITLE
feat(app): Diplomacy panel (full-page, toolbar, Widgetbook, tests)

### DIFF
--- a/SPEC/ui/diplomacy-panel.md
+++ b/SPEC/ui/diplomacy-panel.md
@@ -1,0 +1,64 @@
+# Diplomacy Panel
+
+**SPEC/ui** — Full-page diplomacy screen. Source: SPEC/game/diplomacy.md, SPEC/game/factions.md.
+
+---
+
+## Purpose
+
+The player can view all **discovered** factions (Great Powers, Minor Nations, Tribes), see current diplomatic state with each, and take **diplomatic actions** (declare war, offer peace, alliance, establish overture, grant aid, set subsidy) per SPEC/game/diplomacy.md.
+
+---
+
+## Access
+
+- **Toolbar:** New icon (dove) in the in-game toolbar. Tapping opens the Diplomacy panel as a **full-page** screen (modal or pushed route).
+- **Single-player vs AI only.** No multiplayer-specific UI.
+
+---
+
+## Discovered factions
+
+A faction is **discovered** iff the player has a **diplomatic relation** with that faction (i.e. a `DiplomacyRelation` exists between player and faction). Relations are only possible when the faction is discovered. At game start: same-region (GP–GP, GP–Minor) relations are initialized; cross-region (GP–Tribe) are not, so Tribes appear when the player first gains a relation (e.g. after establishing consulate).
+
+- **List contents:** All GPs (except the player), all Minors, and only Tribes that are discovered.
+- **Grouping:** Sections by type — Great Powers, Minor Nations, Tribes.
+- **Sort:** Great Powers by **military power** (desc), then by **number of provinces** (desc). Minors and Tribes: implementation-defined (e.g. by name or id).
+
+---
+
+## Per-faction row
+
+- **Left:** Faction name (displayName or id), type badge (GP / Minor / Tribe), current **diplomatic state**: relation state (AT_PEACE / AT_WAR), relation level (Hostile / Neutral / Friendly / Allied), relation score (0–100). For Minor/Tribe: overture stage (none, Trade Consulate, Embassy, NAP, Join Empire) if any.
+- **Right:** **Available diplomatic actions** for the player toward that faction. Actions are those explicitly in SPEC/game/diplomacy.md and SPEC/program/orders.md: Declare War, Offer Peace, Alliance (GP only), Establish Overture (stage), Grant Aid, Set Subsidy. Only show actions that are **valid** per the diplomatic order validator (same rules as order submission).
+
+---
+
+## Actions
+
+- **No parameters:** Submit the overture/order immediately (e.g. Declare War, Offer Peace, Alliance).
+- **Parameters required:** Open a **dialog** to collect amount (Grant Aid, Set Subsidy) or overture stage (Establish Overture); on confirm, submit the order.
+- Orders are submitted into the current turn’s order set; resolution happens on Next Turn. The panel does not resolve orders itself.
+
+---
+
+## Layout
+
+- Full-page: list is scrollable; sections (GPs, Minors, Tribes) with headers.
+- Actions shown to the right of each faction row (inline buttons or compact actions). No 1-to-1 sub-panel for now; multi-party treaties deferred.
+
+---
+
+## Widgetbook
+
+At least one story that shows the Diplomacy panel using a **real game** (e.g. from init-game or debug init). Ensures the panel works with actual Game/PlayerView data and diplomacy state.
+
+---
+
+## Acceptance criteria
+
+- Given the user is in-game and taps the dove icon in the toolbar, the UI opens the Diplomacy panel as a full-page screen.
+- Given the Diplomacy panel is open, it lists only discovered factions, grouped as Great Powers, Minor Nations, Tribes; GPs sorted by military power then province count.
+- Given a faction row, the panel shows current relation state and level and, for Minor/Tribe, overture stage; to the right it shows only valid diplomatic actions for that faction.
+- Given the user taps an action that requires no parameters, the UI submits that diplomatic order for the current turn.
+- Given the user taps an action that requires parameters (amount or overture stage), the UI shows a dialog; on confirm, the UI submits the order with the chosen parameters.

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -11,6 +11,7 @@ import '../../../../providers/games_provider.dart';
 import '../../../../providers/map_view_provider.dart';
 import '../../../../widgets/region_map_debug.dart';
 import '../widgets/civilian_units_panel.dart';
+import '../widgets/diplomacy_panel.dart';
 import '../widgets/military_units_panel.dart';
 import '../widgets/province_sea_zone_detail_overlay.dart';
 import '../widgets/technology_panel.dart';
@@ -293,6 +294,38 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
                 },
                 icon: const Icon(Icons.military_tech_outlined, size: 20),
                 label: const Text('Military Units'),
+              ),
+              const SizedBox(width: 8),
+              TextButton.icon(
+                onPressed: () {
+                  final orders = ref.read(currentOrdersProvider);
+                  final mapData = ref.read(gameServiceProvider).getMapData(widget.game.id);
+                  final topology = mapData?.combinedTopology ?? const MapTopology();
+                  Navigator.of(context).push<void>(
+                    MaterialPageRoute<void>(
+                      builder: (ctx) => Scaffold(
+                        appBar: AppBar(
+                          title: const Text('Diplomacy'),
+                          leading: IconButton(
+                            icon: const Icon(Icons.close),
+                            onPressed: () => Navigator.of(ctx).pop(),
+                          ),
+                        ),
+                        body: DiplomacyPanel(
+                          game: widget.game,
+                          humanPlayerId: _humanPlayerId,
+                          topology: topology,
+                          currentOrders: orders,
+                          onOrdersChanged: (newOrders) {
+                            ref.read(currentOrdersProvider.notifier).state = newOrders;
+                          },
+                        ),
+                      ),
+                    ),
+                  );
+                },
+                icon: const Icon(Icons.handshake_outlined, size: 20),
+                label: const Text('Diplomacy'),
               ),
             ],
           ),

--- a/app/lib/features/game/widgets/diplomacy_dialogs.dart
+++ b/app/lib/features/game/widgets/diplomacy_dialogs.dart
@@ -1,0 +1,62 @@
+// Dialogs for diplomacy actions that require parameters. SPEC/ui/diplomacy-panel.md.
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+
+/// Shows a dialog to enter amount for Grant Aid or Set Subsidy, then calls [onSubmitted].
+void showGrantOrSubsidyDialog({
+  required BuildContext context,
+  required Game game,
+  required String humanPlayerId,
+  required String targetFactionId,
+  required bool isSubsidy,
+  required void Function(int amount) onSubmitted,
+}) {
+  final treasury = _treasuryFor(game, humanPlayerId);
+  final title = isSubsidy ? 'Set subsidy' : 'Grant aid';
+  final hint = 'Amount (£). Treasury: £$treasury';
+
+  final controller = TextEditingController(text: '100');
+
+  void doSubmit(BuildContext ctx) {
+    final text = controller.text.trim();
+    final amount = int.tryParse(text);
+    if (amount == null || amount <= 0) return;
+    if (amount > treasury) return;
+    Navigator.of(ctx).pop();
+    onSubmitted(amount);
+  }
+
+  showDialog<void>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: Text(title),
+      content: TextField(
+        controller: controller,
+        keyboardType: TextInputType.number,
+        decoration: InputDecoration(
+          labelText: 'Amount',
+          hintText: hint,
+        ),
+        onSubmitted: (_) => doSubmit(ctx),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => doSubmit(ctx),
+          child: const Text('Submit'),
+        ),
+      ],
+    ),
+  );
+}
+
+int _treasuryFor(Game game, String playerId) {
+  for (final p in game.players) {
+    if (p.id == playerId) return p.treasury;
+  }
+  return 0;
+}

--- a/app/lib/features/game/widgets/diplomacy_panel.dart
+++ b/app/lib/features/game/widgets/diplomacy_panel.dart
@@ -1,0 +1,407 @@
+// Diplomacy panel. SPEC/ui/diplomacy-panel.md.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+
+import 'diplomacy_dialogs.dart';
+
+/// Faction type for display. SPEC/game/factions.md.
+enum FactionKind { greatPower, minor, tribe }
+
+/// One row of data for the diplomacy list.
+class DiplomacyRowData {
+  const DiplomacyRowData({
+    required this.factionId,
+    required this.displayName,
+    required this.kind,
+    required this.relation,
+    this.overture,
+    required this.actions,
+  });
+
+  final String factionId;
+  final String displayName;
+  final FactionKind kind;
+  final DiplomacyRelation? relation;
+  final OvertureState? overture;
+  final List<DiplomaticOrder> actions;
+}
+
+/// Builds list of discovered factions and their available actions.
+/// Discovered = has a relation with the player. SPEC/ui/diplomacy-panel.md.
+List<DiplomacyRowData> buildDiplomacyRows(
+  Game game,
+  MapTopology topology,
+  String humanPlayerId,
+  Orders currentOrders,
+) {
+  final view = buildPlayerView(game, topology, humanPlayerId);
+  final discoveredIds = view.diplomacyByOtherId.keys.toList();
+  final suggestions = suggestDiplomaticOrders(view, game, topology, currentOrders);
+  final actionsByTarget = <String, List<DiplomaticOrder>>{};
+  for (final order in suggestions) {
+    actionsByTarget.putIfAbsent(order.targetFactionId, () => []).add(order);
+  }
+
+  final gpIds = <String>[];
+  final minorIds = <String>[];
+  final tribeIds = <String>[];
+  for (final id in discoveredIds) {
+    if (id == humanPlayerId) continue;
+    if (game.players.any((p) => p.id == id)) {
+      gpIds.add(id);
+    } else if (game.minorNations.any((m) => m.id == id)) {
+      minorIds.add(id);
+    } else if (game.tribes.any((t) => t.id == id)) {
+      tribeIds.add(id);
+    }
+  }
+
+  // GPs: sort by military power desc, then province count desc. SPEC/ui/diplomacy-panel.md.
+  gpIds.sort((a, b) {
+    final strA = aggregateMilitaryStrengthForPlayer(game, a);
+    final strB = aggregateMilitaryStrengthForPlayer(game, b);
+    final cmp = strB.compareTo(strA);
+    if (cmp != 0) return cmp;
+    final provA = provinceCountOwnedBy(game, a);
+    final provB = provinceCountOwnedBy(game, b);
+    return provB.compareTo(provA);
+  });
+
+  String displayNameFor(String id) {
+    final p = game.playerById(id);
+    if (p != null) return p.displayName;
+    for (final m in game.minorNations) {
+      if (m.id == id) return m.displayName ?? id;
+    }
+    for (final t in game.tribes) {
+      if (t.id == id) return t.displayName ?? id;
+    }
+    return id;
+  }
+
+  List<DiplomacyRowData> rows = [];
+  for (final id in gpIds) {
+    rows.add(DiplomacyRowData(
+      factionId: id,
+      displayName: displayNameFor(id),
+      kind: FactionKind.greatPower,
+      relation: view.diplomacyByOtherId[id],
+      overture: getOverture(game, humanPlayerId, id),
+      actions: actionsByTarget[id] ?? [],
+    ));
+  }
+  minorIds.sort((a, b) => (displayNameFor(a)).compareTo(displayNameFor(b)));
+  for (final id in minorIds) {
+    rows.add(DiplomacyRowData(
+      factionId: id,
+      displayName: displayNameFor(id),
+      kind: FactionKind.minor,
+      relation: view.diplomacyByOtherId[id],
+      overture: getOverture(game, humanPlayerId, id),
+      actions: actionsByTarget[id] ?? [],
+    ));
+  }
+  tribeIds.sort((a, b) => (displayNameFor(a)).compareTo(displayNameFor(b)));
+  for (final id in tribeIds) {
+    rows.add(DiplomacyRowData(
+      factionId: id,
+      displayName: displayNameFor(id),
+      kind: FactionKind.tribe,
+      relation: view.diplomacyByOtherId[id],
+      overture: getOverture(game, humanPlayerId, id),
+      actions: actionsByTarget[id] ?? [],
+    ));
+  }
+  return rows;
+}
+
+/// Full-page diplomacy panel. SPEC/ui/diplomacy-panel.md.
+class DiplomacyPanel extends StatelessWidget {
+  const DiplomacyPanel({
+    super.key,
+    required this.game,
+    required this.humanPlayerId,
+    required this.topology,
+    required this.currentOrders,
+    required this.onOrdersChanged,
+    this.onClose,
+  });
+
+  final Game game;
+  final String humanPlayerId;
+  final MapTopology topology;
+  final Orders currentOrders;
+  final void Function(Orders) onOrdersChanged;
+  final VoidCallback? onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final rows = buildDiplomacyRows(game, topology, humanPlayerId, currentOrders);
+    final gps = rows.where((r) => r.kind == FactionKind.greatPower).toList();
+    final minors = rows.where((r) => r.kind == FactionKind.minor).toList();
+    final tribes = rows.where((r) => r.kind == FactionKind.tribe).toList();
+
+    return ListView(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      children: [
+        if (gps.isNotEmpty) ...[
+          _sectionHeader(context, 'Great Powers'),
+          ...gps.map((r) => _DiplomacyRow(
+                data: r,
+                onAction: (order) => _submitOrDialog(context, order),
+              )),
+        ],
+        if (minors.isNotEmpty) ...[
+          _sectionHeader(context, 'Minor Nations'),
+          ...minors.map((r) => _DiplomacyRow(
+                data: r,
+                onAction: (order) => _submitOrDialog(context, order),
+              )),
+        ],
+        if (tribes.isNotEmpty) ...[
+          _sectionHeader(context, 'Tribes'),
+          ...tribes.map((r) => _DiplomacyRow(
+                data: r,
+                onAction: (order) => _submitOrDialog(context, order),
+              )),
+        ],
+        if (rows.isEmpty)
+          Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(
+              'No other factions discovered yet.',
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _sectionHeader(BuildContext context, String title) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 16, bottom: 8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+      ),
+    );
+  }
+
+  void _submitOrDialog(BuildContext context, DiplomaticOrder order) {
+    final needsParams = order.type == DiplomaticOrderType.grantAid ||
+        order.type == DiplomaticOrderType.setSubsidy ||
+        (order.type == DiplomaticOrderType.establishOverture &&
+            order.overtureStage != null);
+    if (needsParams) {
+      _showDialogForOrder(context, order);
+    } else {
+      _appendOrder(order);
+    }
+  }
+
+  void _showDialogForOrder(BuildContext context, DiplomaticOrder order) {
+    if (order.type == DiplomaticOrderType.grantAid ||
+        order.type == DiplomaticOrderType.setSubsidy) {
+      showGrantOrSubsidyDialog(
+        context: context,
+        game: game,
+        humanPlayerId: humanPlayerId,
+        targetFactionId: order.targetFactionId,
+        isSubsidy: order.type == DiplomaticOrderType.setSubsidy,
+        onSubmitted: (amount) {
+          _appendOrder(DiplomaticOrder(
+            type: order.type,
+            targetFactionId: order.targetFactionId,
+            amount: amount,
+          ));
+        },
+      );
+    } else if (order.type == DiplomaticOrderType.establishOverture &&
+        order.overtureStage != null) {
+      _appendOrder(order);
+    }
+  }
+
+  void _appendOrder(DiplomaticOrder order) {
+    final list = List<DiplomaticOrder>.from(
+      currentOrders.diplomaticOrdersByPlayerId[humanPlayerId] ?? [],
+    )..add(order);
+    onOrdersChanged(currentOrders.copyWith(
+      diplomaticOrdersByPlayerId: {
+        ...currentOrders.diplomaticOrdersByPlayerId,
+        humanPlayerId: list,
+      },
+    ));
+  }
+}
+
+class _DiplomacyRow extends StatelessWidget {
+  const _DiplomacyRow({
+    required this.data,
+    required this.onAction,
+  });
+
+  final DiplomacyRowData data;
+  final void Function(DiplomaticOrder) onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    final rel = data.relation;
+    final stateLabel = rel == null
+        ? '—'
+        : rel.atWar
+            ? 'War'
+            : 'Peace';
+    final levelLabel = rel == null ? '' : _relationLevelLabel(rel.level);
+    final scoreLabel = rel == null ? '' : ' (${rel.score})';
+    final overtureLabel = data.overture == null
+        ? ''
+        : ' · ${_overtureStageLabel(data.overture!.stage)}';
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Row(
+                    children: [
+                      Text(
+                        data.displayName,
+                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                              fontWeight: FontWeight.w600,
+                            ),
+                      ),
+                      const SizedBox(width: 8),
+                      _kindChip(context, data.kind),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '$stateLabel$levelLabel$scoreLabel$overtureLabel',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ],
+              ),
+            ),
+            Wrap(
+              spacing: 6,
+              runSpacing: 6,
+              children: data.actions.map((order) {
+                return _ActionButton(
+                  order: order,
+                  onPressed: () => onAction(order),
+                );
+              }).toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _kindChip(BuildContext context, FactionKind kind) {
+    final (label, color) = switch (kind) {
+      FactionKind.greatPower => ('GP', Colors.blue),
+      FactionKind.minor => ('Minor', Colors.grey),
+      FactionKind.tribe => ('Tribe', Colors.orange),
+    };
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.2),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: color,
+              fontWeight: FontWeight.w600,
+            ),
+      ),
+    );
+  }
+
+  String _relationLevelLabel(RelationLevel level) {
+    return switch (level) {
+      RelationLevel.hostile => 'Hostile',
+      RelationLevel.neutral => 'Neutral',
+      RelationLevel.friendly => 'Friendly',
+      RelationLevel.allied => 'Allied',
+    };
+  }
+
+  String _overtureStageLabel(OvertureStage stage) {
+    return switch (stage) {
+      OvertureStage.none => 'None',
+      OvertureStage.tradeConsulate => 'Consulate',
+      OvertureStage.embassy => 'Embassy',
+      OvertureStage.nap => 'NAP',
+      OvertureStage.joinEmpire => 'Join Empire',
+    };
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({
+    required this.order,
+    required this.onPressed,
+  });
+
+  final DiplomaticOrder order;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = _actionLabel(order);
+    return FilledButton.tonal(
+      onPressed: onPressed,
+      style: FilledButton.styleFrom(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        minimumSize: Size.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      ),
+      child: Text(label, style: const TextStyle(fontSize: 12)),
+    );
+  }
+
+  String _actionLabel(DiplomaticOrder o) {
+    switch (o.type) {
+      case DiplomaticOrderType.declareWar:
+        return 'Declare War';
+      case DiplomaticOrderType.offerPeace:
+        return 'Offer Peace';
+      case DiplomaticOrderType.alliance:
+        return 'Alliance';
+      case DiplomaticOrderType.establishOverture:
+        return o.overtureStage != null
+            ? _overtureStageShort(o.overtureStage!)
+            : 'Overture';
+      case DiplomaticOrderType.grantAid:
+        return o.amount != null ? 'Grant Aid (£${o.amount})' : 'Grant Aid';
+      case DiplomaticOrderType.setSubsidy:
+        return o.amount != null ? 'Subsidy (£${o.amount})' : 'Set Subsidy';
+    }
+  }
+
+  String _overtureStageShort(OvertureStage s) {
+    return switch (s) {
+      OvertureStage.none => 'Overture',
+      OvertureStage.tradeConsulate => 'Consulate',
+      OvertureStage.embassy => 'Embassy',
+      OvertureStage.nap => 'NAP',
+      OvertureStage.joinEmpire => 'Join Empire',
+    };
+  }
+}

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -6,6 +6,7 @@ import 'package:widgetbook/widgetbook.dart';
 
 import 'config/themes.dart';
 import 'features/game/widgets/civilian_units_panel.dart';
+import 'features/game/widgets/diplomacy_panel.dart';
 import 'features/game/widgets/military_units_panel.dart';
 import 'features/game/widgets/production_panel.dart';
 import 'features/game/widgets/production_panel_demo_data.dart';
@@ -51,6 +52,7 @@ class CtWidgetbookApp extends StatelessWidget {
         ...productionPanelDirectories,
         ...civilianUnitsPanelDirectories,
         ...militaryUnitsPanelDirectories,
+        ...diplomacyPanelDirectories,
       ],
       lightTheme: AppThemes.colonial,
       darkTheme: AppThemes.colonial,
@@ -276,6 +278,35 @@ List<WidgetbookNode> get civilianUnitsPanelDirectories => [
       WidgetbookUseCase(
         name: 'With map',
         builder: (context) => const _CivilianPanelWithMapStory(),
+      ),
+    ],
+  ),
+];
+
+/// Diplomacy Panel stories. SPEC/ui/diplomacy-panel.md.
+List<WidgetbookNode> get diplomacyPanelDirectories => [
+  WidgetbookFolder(
+    name: 'Diplomacy Panel',
+    children: [
+      WidgetbookUseCase(
+        name: 'With real game',
+        builder: (context) {
+          final result = getDebugInitGameResult();
+          final game = result.game;
+          final humanPlayerId = game.players.isNotEmpty
+              ? game.players.first.id
+              : 'gp1';
+          return ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 800, maxHeight: 600),
+            child: DiplomacyPanel(
+              game: game,
+              humanPlayerId: humanPlayerId,
+              topology: result.combinedTopology,
+              currentOrders: const Orders(),
+              onOrdersChanged: (_) {},
+            ),
+          );
+        },
       ),
     ],
   ),

--- a/app/test/diplomacy_panel_test.dart
+++ b/app/test/diplomacy_panel_test.dart
@@ -1,0 +1,225 @@
+// Tests for DiplomacyPanel. SPEC/ui/diplomacy-panel.md.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/features/game/widgets/diplomacy_panel.dart';
+import 'package:colonizethis_app/widgets/debug_init_game.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  late Game gameWithFactions;
+  late Game gameWithNoDiscovered;
+  late String humanPlayerId;
+  late MapTopology topology;
+
+  setUpAll(() {
+    final result = getDebugInitGameResult();
+    gameWithFactions = result.game;
+    topology = result.combinedTopology;
+    humanPlayerId = gameWithFactions.players.isNotEmpty
+        ? gameWithFactions.players.first.id
+        : 'gp1';
+    gameWithNoDiscovered = _gameWithNoDiscoveredFactions();
+  });
+
+  Widget buildPanel({
+    required Game game,
+    required String humanPlayerId,
+    required MapTopology topology,
+    Orders currentOrders = const Orders(),
+    void Function(Orders)? onOrdersChanged,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: DiplomacyPanel(
+          game: game,
+          humanPlayerId: humanPlayerId,
+          topology: topology,
+          currentOrders: currentOrders,
+          onOrdersChanged: onOrdersChanged ?? (_) {},
+        ),
+      ),
+    );
+  }
+
+  group('DiplomacyPanel', () {
+    testWidgets('AC: Great Powers section when player has discovered GPs',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildPanel(
+        game: gameWithFactions,
+        humanPlayerId: humanPlayerId,
+        topology: topology,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Great Powers'), findsOneWidget);
+    });
+
+    testWidgets('AC: Faction rows show name and kind', (WidgetTester tester) async {
+      await tester.pumpWidget(buildPanel(
+        game: gameWithFactions,
+        humanPlayerId: humanPlayerId,
+        topology: topology,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Card), findsAtLeastNWidgets(1));
+      final firstGp = gameWithFactions.players
+          .where((p) => p.id != humanPlayerId)
+          .map((p) => p.displayName)
+          .firstOrNull;
+      if (firstGp != null) {
+        expect(find.text(firstGp), findsAtLeastNWidgets(1));
+      }
+    });
+
+    testWidgets('AC: Relation state shown (Peace or War)', (WidgetTester tester) async {
+      await tester.pumpWidget(buildPanel(
+        game: gameWithFactions,
+        humanPlayerId: humanPlayerId,
+        topology: topology,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('Peace').evaluate().isNotEmpty ||
+            find.textContaining('War').evaluate().isNotEmpty,
+        isTrue,
+      );
+    });
+
+    testWidgets('AC: Action buttons present for factions',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildPanel(
+        game: gameWithFactions,
+        humanPlayerId: humanPlayerId,
+        topology: topology,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FilledButton), findsAtLeastNWidgets(1));
+      expect(
+        find.text('Declare War').evaluate().isNotEmpty ||
+            find.text('Offer Peace').evaluate().isNotEmpty ||
+            find.text('Alliance').evaluate().isNotEmpty,
+        isTrue,
+      );
+    });
+
+    testWidgets('AC: Tapping no-param action calls onOrdersChanged',
+        (WidgetTester tester) async {
+      Orders? captured;
+      await tester.pumpWidget(buildPanel(
+        game: gameWithFactions,
+        humanPlayerId: humanPlayerId,
+        topology: topology,
+        onOrdersChanged: (o) => captured = o,
+      ));
+      await tester.pumpAndSettle();
+
+      final declareWar = find.text('Declare War');
+      if (declareWar.evaluate().isNotEmpty) {
+        await tester.tap(declareWar.first);
+        await tester.pumpAndSettle();
+        expect(captured, isNotNull);
+        expect(
+          captured!.diplomaticOrdersByPlayerId[humanPlayerId] ?? [],
+          hasLength(greaterThanOrEqualTo(1)),
+        );
+        expect(
+          captured!.diplomaticOrdersByPlayerId[humanPlayerId]!
+              .any((o) => o.type == DiplomaticOrderType.declareWar),
+          isTrue,
+        );
+      }
+    });
+
+    testWidgets('AC: Empty state when no factions discovered',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildPanel(
+        game: gameWithNoDiscovered,
+        humanPlayerId: 'gp1',
+        topology: const MapTopology(nodes: [], edges: []),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('No other factions discovered yet.'), findsOneWidget);
+    });
+
+    testWidgets('panel is scrollable', (WidgetTester tester) async {
+      await tester.pumpWidget(buildPanel(
+        game: gameWithFactions,
+        humanPlayerId: humanPlayerId,
+        topology: topology,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ListView), findsOneWidget);
+    });
+  });
+
+  group('buildDiplomacyRows', () {
+    test('returns empty list when player has no relations', () {
+      final rows = buildDiplomacyRows(
+        gameWithNoDiscovered,
+        const MapTopology(nodes: [], edges: []),
+        'gp1',
+        const Orders(),
+      );
+      expect(rows, isEmpty);
+    });
+
+    test('returns GP rows sorted by military power then province count', () {
+      final rows = buildDiplomacyRows(
+        gameWithFactions,
+        topology,
+        humanPlayerId,
+        const Orders(),
+      );
+      final gpRows = rows.where((r) => r.kind == FactionKind.greatPower).toList();
+      if (gpRows.length < 2) return;
+      for (var i = 0; i < gpRows.length - 1; i++) {
+        final strA = aggregateMilitaryStrengthForPlayer(
+            gameWithFactions, gpRows[i].factionId);
+        final strB = aggregateMilitaryStrengthForPlayer(
+            gameWithFactions, gpRows[i + 1].factionId);
+        expect(strA >= strB, isTrue);
+      }
+    });
+  });
+}
+
+/// Minimal game with one player and no diplomacy relations (no discovered factions).
+Game _gameWithNoDiscoveredFactions() {
+  const ow = 'oldWorld';
+  final p1 = Province(
+    id: '$ow|p1',
+    regionId: ow,
+    displayName: 'P1',
+    ownerId: 'gp1',
+  );
+  final world = WorldState(
+    turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+    oldWorld: RegionData(provinces: [p1], units: const []),
+    newWorld: const RegionData(),
+    playerVisibilityByTile: const {},
+    playerProspectedTiles: const {},
+  );
+  const player = Player(
+    id: 'gp1',
+    displayName: 'Solo',
+    isHuman: true,
+  );
+  return Game(
+    id: 'empty-diplo',
+    worldState: world,
+    players: const [player],
+    diplomacyRelations: const [],
+  );
+}


### PR DESCRIPTION
## Summary
Adds a full-page Diplomacy panel to the Flutter app per SPEC/ui/diplomacy-panel.md.

## Changes
- **SPEC:** `SPEC/ui/diplomacy-panel.md` — panel behaviour, discovered factions, actions, GP sort
- **Panel:** `DiplomacyPanel` lists discovered GPs (sorted by military power then provinces), Minor Nations, Tribes; shows relation state and overture; shows only valid diplomatic actions per faction. Grant Aid/Set Subsidy open an amount dialog; other actions submit immediately.
- **Toolbar:** New Diplomacy button (handshake icon) opens the panel as a full-page route; orders update `currentOrdersProvider`.
- **Widgetbook:** Diplomacy Panel → "With real game" story using `getDebugInitGameResult()`.
- **Tests:** `app/test/diplomacy_panel_test.dart` — 9 tests: section headers, faction rows, relation state, action buttons, onOrdersChanged on tap, empty state, scrollable ListView, `buildDiplomacyRows` empty and sort order.

## Testing
`flutter test app/test/diplomacy_panel_test.dart` — all 9 tests pass.

Made with [Cursor](https://cursor.com)