### PR TITLE
feat(logic,ctterm): build_improvement only on player-controlled tiles (owned or purchased)

### DIFF
--- a/ctterm/lib/screens/development_screen.dart
+++ b/ctterm/lib/screens/development_screen.dart
@@ -784,12 +784,9 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
       final regionId = parts[0];
       final provinceId = parts[1];
 
-      // Get province owner - only allow player's own provinces.
-      final provinces = regionId == 'oldWorld'
-          ? world.oldWorld.provinces
-          : world.newWorld.provinces;
-      final province = provinces.where((p) => p.id == provinceId).firstOrNull;
-      if (province?.ownerId != playerId) {
+      // Only allow tiles that are under the player's control (owned province or
+      // purchased tile), matching core logic's isTileControlledByPlayer rule.
+      if (!isTileControlledByPlayer(game, playerId, tileKey)) {
         continue;
       }
 

--- a/packages/colonizethis_logic/lib/colonizethis_logic.dart
+++ b/packages/colonizethis_logic/lib/colonizethis_logic.dart
@@ -72,3 +72,4 @@ export 'src/world/movement.dart';
 export 'src/world/naval.dart';
 export 'src/world/player_view.dart';
 export 'src/world/province_lookup.dart';
+export 'src/world/tile_control.dart';

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -6,6 +6,7 @@ import '../diplomacy/diplomacy_resolver.dart';
 import '../world/movement.dart';
 import '../world/naval.dart';
 import '../world/province_lookup.dart';
+import '../world/tile_control.dart';
 import 'order_engine.dart';
 import 'order_suggestion_helpers.dart';
 import 'order_visibility.dart';
@@ -228,8 +229,14 @@ List<WorkOrder> suggestWorkOrders(
       continue;
     }
 
-    // Civilian workers: only work in owned provinces.
-    if (ownerId != null && ownerId != playerId) {
+    // Civilian workers: only work on tiles under player control (owned province
+    // or purchased tile).
+    final provinceControlled = ownerId == null ||
+        ownerId == playerId ||
+        tilesInProvince.any(
+          (tk) => game.worldState.purchasedTilesByTileKey[tk] == playerId,
+        );
+    if (!provinceControlled) {
       continue;
     }
 
@@ -240,7 +247,13 @@ List<WorkOrder> suggestWorkOrders(
           final existing = existingTargetsByUnit[unit.id];
           if (existing != null && existing.contains(target)) continue;
 
-          final targetTileKey = tilesInProvince.first;
+          final targetTileKey = tilesInProvince.firstWhere(
+            (tk) => isTileControlledByPlayer(game, playerId, tk),
+            orElse: () => '',
+          );
+          if (targetTileKey.isEmpty) {
+            continue;
+          }
           final candidate = WorkOrder(
               unitId: unit.id, target: target, targetTileKey: targetTileKey);
           if (_isWorkOrderAccepted(

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -11,6 +11,7 @@ import 'orders_application_helpers.dart';
 import '../world/naval.dart';
 import '../world/player_view.dart';
 import '../world/province_lookup.dart';
+import '../world/tile_control.dart';
 import '../world/unit_lookup.dart';
 
 final Logger _log = Logger();
@@ -394,21 +395,15 @@ Game applyBuildAndWorkOrders(
             'logic: work cancelled unit=${u.id} reason=tile no longer owned tileKey=${cw.tileKey}');
         continue;
       }
-      // Cancel work if province containing target tile is no longer owned (conquest). SPEC #376.
-      // Skip for counter_spy and steal_tech: those work targets are in enemy/other territory by design.
+      // Cancel work if tile no longer under player control (conquest or purchase reverted). SPEC #376.
+      // Use same rule as validation: owned province or purchased tile; skip for counter_spy/steal_tech.
       if (cw.workTarget != 'counter_spy' && cw.workTarget != 'steal_tech') {
-        final targetProvinceId = Unit.provinceIdFromTileKey(cw.tileKey);
-        if (targetProvinceId != null) {
-          final provinces = getProvinces();
-          final targetProvince =
-              provinces.where((p) => p.id == targetProvinceId).firstOrNull;
-          if (targetProvince != null && targetProvince.ownerId != u.ownerId) {
-            unitsById[entry.key] =
-                u.copyWith(status: UnitStatus.idle, clearCurrentWork: true);
-            _log.d(
-                'logic: work cancelled unit=${u.id} reason=province conquered provinceId=$targetProvinceId tileKey=${cw.tileKey}');
-            continue;
-          }
+        if (!isTileControlledByPlayer(s.game, u.ownerId, cw.tileKey)) {
+          unitsById[entry.key] =
+              u.copyWith(status: UnitStatus.idle, clearCurrentWork: true);
+          _log.d(
+              'logic: work cancelled unit=${u.id} reason=tile no longer under control tileKey=${cw.tileKey}');
+          continue;
         }
       }
       if (cw.workTarget == 'counter_spy') {

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../world/player_view.dart';
 import '../../world/province_lookup.dart';
+import '../../world/tile_control.dart';
 import '../order_visibility.dart';
 import '../order_validation_result.dart';
 import 'work_order_cost_calculator.dart';
@@ -200,6 +201,14 @@ class WorkOrderValidator {
         );
       }
     } else if (o.target == 'build_improvement') {
+      final controlled =
+          isTileControlledByPlayer(_game, _playerId, o.targetTileKey);
+      if (!controlled) {
+        return const OrderValidationResult(
+          status: OrderValidationStatus.rejected,
+          reason: 'Cannot build improvement in foreign or uncontrolled province',
+        );
+      }
       final resourceId = _game.worldState.resourceByTileKey[o.targetTileKey];
       if (resourceId == null || resourceId.isEmpty) {
         return const OrderValidationResult(
@@ -225,7 +234,9 @@ class WorkOrderValidator {
         );
       }
     } else if (!isExplorerUnit(type)) {
-      if (ownerId != null && ownerId != _playerId) {
+      final controlled =
+          isTileControlledByPlayer(_game, _playerId, o.targetTileKey);
+      if (!controlled) {
         return const OrderValidationResult(
           status: OrderValidationStatus.rejected,
           reason: 'Cannot work in foreign province',

--- a/packages/colonizethis_logic/lib/src/world/tile_control.dart
+++ b/packages/colonizethis_logic/lib/src/world/tile_control.dart
@@ -1,0 +1,28 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'province_lookup.dart';
+
+/// Returns true when [tileKey] is under [playerId]'s control for purposes of
+/// civilian development work.
+///
+/// A tile is controlled when:
+/// - It lies in a province owned by the player, or
+/// - It appears in [WorldState.purchasedTilesByTileKey] with buyer [playerId]
+///   (Merchant purchase_land).
+bool isTileControlledByPlayer(
+  Game game,
+  String playerId,
+  String tileKey,
+) {
+  final purchased = game.worldState.purchasedTilesByTileKey;
+  if (purchased[tileKey] == playerId) return true;
+
+  final provinceId = Unit.provinceIdFromTileKey(tileKey);
+  if (provinceId == null) return false;
+
+  final province = tryGetProvince(game.worldState, provinceId);
+  if (province == null) return false;
+
+  return province.ownerId == playerId;
+}
+

--- a/packages/colonizethis_logic/test/order_engine_test.dart
+++ b/packages/colonizethis_logic/test/order_engine_test.dart
@@ -1927,7 +1927,7 @@ void main() {
                 foreignProvinceId: [foreignTileKey],
               },
             },
-            playerVisibilityByTile: const {
+            playerVisibilityByTile: {
               'p1': {
                 tileKey: 'fullyVisible',
                 foreignTileKey: 'fullyVisible',
@@ -2005,7 +2005,7 @@ void main() {
                 foreignProvinceId: [foreignTileKey],
               },
             },
-            playerVisibilityByTile: const {
+            playerVisibilityByTile: {
               'p1': {
                 tileKey: 'fullyVisible',
                 foreignTileKey: 'fullyVisible',

--- a/packages/colonizethis_logic/test/order_engine_test.dart
+++ b/packages/colonizethis_logic/test/order_engine_test.dart
@@ -1891,6 +1891,159 @@ void main() {
             engine.validatePlayerOrdersWithContext(game, topology, 'p1');
         expect(results.single.status, OrderValidationStatus.accepted);
       });
+
+      test('rejects build_improvement in foreign, unpurchased province', () {
+        final foreignProvinceId = '$ow|P2';
+        final foreignTileKey = '$foreignProvinceId|0|0';
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState:
+                const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: provinceId, regionId: ow, ownerId: 'p1'),
+                Province(id: foreignProvinceId, regionId: ow, ownerId: 'p2'),
+              ],
+              units: [
+                Unit(
+                  id: 'builder1',
+                  type: 'Builder',
+                  ownerId: 'p1',
+                  provinceId: provinceId,
+                  tileKey: tileKey,
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            resourceByTileKey: {
+              tileKey: 'grain',
+              foreignTileKey: 'grain',
+            },
+            tileState: const TileMapState(),
+            tileKeysByRegionAndProvince: {
+              ow: {
+                provinceId: [tileKey],
+                foreignProvinceId: [foreignTileKey],
+              },
+            },
+            playerVisibilityByTile: const {
+              'p1': {
+                tileKey: 'fullyVisible',
+                foreignTileKey: 'fullyVisible',
+              },
+            },
+          ),
+          players: [
+            Player(
+              id: 'p1',
+              displayName: 'P1',
+              isHuman: true,
+              capitalProvinceId: provinceId,
+              stockpile: Stockpile()
+                  .applyDelta(CommodityCatalog.lumber.id, 2)
+                  .applyDelta(CommodityCatalog.castIron.id, 2),
+              techUnlocked: const {'gathering_3': true},
+            ),
+            const Player(
+              id: 'p2',
+              displayName: 'P2',
+              isHuman: false,
+            ),
+          ],
+        );
+        final engine = OrderEngine();
+        engine.addWorkOrder(
+          'p1',
+          WorkOrder(
+            unitId: 'builder1',
+            target: 'build_improvement',
+            targetTileKey: foreignTileKey,
+          ),
+        );
+        final results =
+            engine.validatePlayerOrdersWithContext(game, topology, 'p1');
+        expect(results.single.status, OrderValidationStatus.rejected);
+        expect(
+          results.single.reason,
+          contains('foreign or uncontrolled province'),
+        );
+      });
+
+      test('accepts build_improvement on purchased tile in foreign province', () {
+        final foreignProvinceId = '$ow|P2';
+        final foreignTileKey = '$foreignProvinceId|0|0';
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState:
+                const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: provinceId, regionId: ow, ownerId: 'p1'),
+                Province(id: foreignProvinceId, regionId: ow, ownerId: 'p2'),
+              ],
+              units: [
+                Unit(
+                  id: 'builder1',
+                  type: 'Builder',
+                  ownerId: 'p1',
+                  provinceId: provinceId,
+                  tileKey: tileKey,
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            resourceByTileKey: {
+              tileKey: 'grain',
+              foreignTileKey: 'grain',
+            },
+            tileState: const TileMapState(),
+            tileKeysByRegionAndProvince: {
+              ow: {
+                provinceId: [tileKey],
+                foreignProvinceId: [foreignTileKey],
+              },
+            },
+            playerVisibilityByTile: const {
+              'p1': {
+                tileKey: 'fullyVisible',
+                foreignTileKey: 'fullyVisible',
+              },
+            },
+            purchasedTilesByTileKey: {foreignTileKey: 'p1'},
+          ),
+          players: [
+            Player(
+              id: 'p1',
+              displayName: 'P1',
+              isHuman: true,
+              capitalProvinceId: provinceId,
+              stockpile: Stockpile()
+                  .applyDelta(CommodityCatalog.lumber.id, 2)
+                  .applyDelta(CommodityCatalog.castIron.id, 2),
+              techUnlocked: const {'gathering_3': true},
+            ),
+            const Player(
+              id: 'p2',
+              displayName: 'P2',
+              isHuman: false,
+            ),
+          ],
+        );
+        final engine = OrderEngine();
+        engine.addWorkOrder(
+          'p1',
+          WorkOrder(
+            unitId: 'builder1',
+            target: 'build_improvement',
+            targetTileKey: foreignTileKey,
+          ),
+        );
+        final results =
+            engine.validatePlayerOrdersWithContext(game, topology, 'p1');
+        expect(results.single.status, OrderValidationStatus.accepted);
+      });
     });
 
     group('validateWork (build_fort tech)', () {

--- a/packages/colonizethis_logic/test/tile_control_test.dart
+++ b/packages/colonizethis_logic/test/tile_control_test.dart
@@ -1,0 +1,69 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:test/test.dart';
+
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+
+void main() {
+  group('isTileControlledByPlayer', () {
+    const ow = 'oldWorld';
+    const ownedProvinceId = '$ow|P1';
+    const foreignProvinceId = '$ow|P2';
+    const ownedTile = '$ownedProvinceId|0|0';
+    const foreignTile = '$foreignProvinceId|0|0';
+
+    Game _game({
+      String? ownerP1 = 'p1',
+      String? ownerP2 = 'p2',
+      Map<String, String>? purchased,
+    }) {
+      return Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState:
+              const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: ownedProvinceId, regionId: ow, ownerId: ownerP1),
+              Province(id: foreignProvinceId, regionId: ow, ownerId: ownerP2),
+            ],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: {
+            ow: {
+              ownedProvinceId: [ownedTile],
+              foreignProvinceId: [foreignTile],
+            },
+          },
+          purchasedTilesByTileKey: purchased ?? const {},
+        ),
+        players: const [],
+      );
+    }
+
+    test('returns true for tile in province owned by player', () {
+      final game = _game();
+      expect(isTileControlledByPlayer(game, 'p1', ownedTile), isTrue);
+    });
+
+    test('returns false for foreign, unpurchased tile', () {
+      final game = _game();
+      expect(isTileControlledByPlayer(game, 'p1', foreignTile), isFalse);
+    });
+
+    test('returns true for tile purchased in foreign province', () {
+      final game = _game(
+        purchased: {foreignTile: 'p1'},
+      );
+      expect(isTileControlledByPlayer(game, 'p1', foreignTile), isTrue);
+    });
+
+    test('returns false when tileKey does not map to a province', () {
+      final game = _game();
+      expect(
+        isTileControlledByPlayer(game, 'p1', 'oldWorld|UNKNOWN|0|0'),
+        isFalse,
+      );
+    });
+  });
+}
+

--- a/packages/colonizethis_logic/test/tile_control_test.dart
+++ b/packages/colonizethis_logic/test/tile_control_test.dart
@@ -1,7 +1,6 @@
-import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:test/test.dart';
-
+import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
 
 void main() {
   group('isTileControlledByPlayer', () {

--- a/tool/sim_scenarios/lib/scenario.dart
+++ b/tool/sim_scenarios/lib/scenario.dart
@@ -63,6 +63,7 @@ class ScenarioSetup {
     this.initialTech,
     this.initialTreasury,
     this.defaultCombatMode,
+    this.purchasedTilesByTileKey,
   });
 
   final List<UnitPlacement>? units;
@@ -91,6 +92,9 @@ class ScenarioSetup {
 
   /// "quickBattle" or "autoResolve". Overrides Game.defaultCombatMode. SPEC/game/quick-battle.md.
   final String? defaultCombatMode;
+
+  /// Tile key → player id. Overrides WorldState.purchasedTilesByTileKey for build_improvement on purchased foreign tiles. SPEC/game/civilian-units.md, SPEC/program/orders.md.
+  final Map<String, String>? purchasedTilesByTileKey;
 }
 
 /// One production assignment: recipe id and labour to assign. Converted to AssignedRecipe in runner.
@@ -511,7 +515,18 @@ ScenarioSetup _parseScenarioSetup(Map<String, dynamic> json) {
     initialTech: _parseInitialTech(json['initialTech']),
     initialTreasury: _parseInitialTreasury(json['initialTreasury']),
     defaultCombatMode: json['defaultCombatMode'] as String?,
+    purchasedTilesByTileKey: _parsePurchasedTilesByTileKey(json['purchasedTilesByTileKey']),
   );
+}
+
+Map<String, String>? _parsePurchasedTilesByTileKey(dynamic raw) {
+  if (raw is! Map<String, dynamic>) return null;
+  final out = <String, String>{};
+  for (final e in raw.entries) {
+    final v = e.value;
+    if (v != null && v.toString().isNotEmpty) out[e.key] = v.toString();
+  }
+  return out.isEmpty ? null : out;
 }
 
 Map<String, int>? _parseInitialTreasury(dynamic value) {

--- a/tool/sim_scenarios/lib/scenario_runner.dart
+++ b/tool/sim_scenarios/lib/scenario_runner.dart
@@ -397,6 +397,15 @@ class ScenarioRunner {
       }
       game = game.copyWith(players: updatedPlayers);
     }
+    if (setup.purchasedTilesByTileKey != null &&
+        setup.purchasedTilesByTileKey!.isNotEmpty) {
+      final purchased = Map<String, String>.from(
+        game.worldState.purchasedTilesByTileKey,
+      )..addAll(setup.purchasedTilesByTileKey!);
+      game = game.copyWith(
+        worldState: game.worldState.copyWith(purchasedTilesByTileKey: purchased),
+      );
+    }
     return game;
   }
 

--- a/tool/sim_scenarios/scenarios/build_improvement_accept_purchased_foreign.json
+++ b/tool/sim_scenarios/scenarios/build_improvement_accept_purchased_foreign.json
@@ -12,17 +12,17 @@
       "tribeCount": 0
     },
     "oldWorld": {
-      "grid": [["p1", "p2", "sea1"]],
+      "grid": [["p1", "sea1"], ["p2", "sea1"]],
       "nodes": [
         {"id": "p1", "regionId": "oldWorld", "type": "province"},
         {"id": "p2", "regionId": "oldWorld", "type": "province"},
         {"id": "sea1", "regionId": "oldWorld", "type": "seaZone"}
       ],
       "edges": [
-        {"id1": "p1", "id2": "p2"},
+        {"id1": "p1", "id2": "sea1"},
         {"id1": "p2", "id2": "sea1"}
       ],
-      "resourceGrid": [["grain", "grain", null]]
+      "resourceGrid": [["grain", null], ["grain", null]]
     }
   },
   "setup": {
@@ -30,10 +30,10 @@
     "initialStockpile": {"gp1": {"lumber": 2, "castIron": 2}},
     "initialTileState": {
       "oldWorld|p1|0|0": {"improvementLevel": 0, "roadLevel": 1},
-      "oldWorld|p2|1|0": {"improvementLevel": 0, "roadLevel": 1}
+      "oldWorld|p2|0|1": {"improvementLevel": 0, "roadLevel": 1}
     },
     "purchasedTilesByTileKey": {
-      "oldWorld|p2|1|0": "gp1"
+      "oldWorld|p2|0|1": "gp1"
     }
   },
   "turns": [
@@ -43,9 +43,9 @@
         {
           "player": "gp1",
           "type": "work",
-          "unit": "gp1_builder_0",
+          "unit": "gp1_builder_1",
           "workType": "build_improvement",
-          "targetTileKey": "oldWorld|p2|1|0"
+          "targetTileKey": "oldWorld|p2|0|1"
         }
       ]
     },
@@ -54,7 +54,7 @@
   "assertions": [
     {
       "turn": 2,
-      "tileKey": "oldWorld|p2|1|0",
+      "tileKey": "oldWorld|p2|0|1",
       "tileImprovementLevel": 1
     }
   ]

--- a/tool/sim_scenarios/scenarios/build_improvement_accept_purchased_foreign.json
+++ b/tool/sim_scenarios/scenarios/build_improvement_accept_purchased_foreign.json
@@ -1,0 +1,62 @@
+{
+  "name": "build_improvement_accept_purchased_foreign",
+  "description": "SPEC/game/extraction-and-improvements.md, SPEC/program/development-resolution.md, SPEC/program/orders.md: build_improvement work order accepted when target tile is in a foreign province that has been purchased by the player (under player control via purchasedTilesByTileKey). Order engine must accept; after resolution the tile shows an improvement.",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "greatPowers": ["england", "france"],
+      "seed": 42,
+      "minorNationCount": 0,
+      "numProvincesOldWorld": 2,
+      "numProvincesNewWorld": 0,
+      "tribeCount": 0
+    },
+    "oldWorld": {
+      "grid": [["p1", "p2", "sea1"]],
+      "nodes": [
+        {"id": "p1", "regionId": "oldWorld", "type": "province"},
+        {"id": "p2", "regionId": "oldWorld", "type": "province"},
+        {"id": "sea1", "regionId": "oldWorld", "type": "seaZone"}
+      ],
+      "edges": [
+        {"id1": "p1", "id2": "p2"},
+        {"id1": "p2", "id2": "sea1"}
+      ],
+      "resourceGrid": [["grain", "grain", null]]
+    }
+  },
+  "setup": {
+    "initialTech": {"gp1": ["gathering_3"]},
+    "initialStockpile": {"gp1": {"lumber": 2, "castIron": 2}},
+    "initialTileState": {
+      "oldWorld|p1|0|0": {"improvementLevel": 0, "roadLevel": 1},
+      "oldWorld|p2|1|0": {"improvementLevel": 0, "roadLevel": 1}
+    },
+    "purchasedTilesByTileKey": {
+      "oldWorld|p2|1|0": "gp1"
+    }
+  },
+  "turns": [
+    {
+      "turn": 1,
+      "orders": [
+        {
+          "player": "gp1",
+          "type": "work",
+          "unit": "gp1_builder_0",
+          "workType": "build_improvement",
+          "targetTileKey": "oldWorld|p2|1|0"
+        }
+      ]
+    },
+    { "turn": 2, "orders": [] }
+  ],
+  "assertions": [
+    {
+      "turn": 2,
+      "tileKey": "oldWorld|p2|1|0",
+      "tileImprovementLevel": 1
+    }
+  ]
+}
+

--- a/tool/sim_scenarios/scenarios/build_improvement_reject_foreign_unpurchased.json
+++ b/tool/sim_scenarios/scenarios/build_improvement_reject_foreign_unpurchased.json
@@ -12,17 +12,17 @@
       "tribeCount": 0
     },
     "oldWorld": {
-      "grid": [["p1", "p2", "sea1"]],
+      "grid": [["p1", "sea1"], ["p2", "sea1"]],
       "nodes": [
         {"id": "p1", "regionId": "oldWorld", "type": "province"},
         {"id": "p2", "regionId": "oldWorld", "type": "province"},
         {"id": "sea1", "regionId": "oldWorld", "type": "seaZone"}
       ],
       "edges": [
-        {"id1": "p1", "id2": "p2"},
+        {"id1": "p1", "id2": "sea1"},
         {"id1": "p2", "id2": "sea1"}
       ],
-      "resourceGrid": [["grain", "grain", null]]
+      "resourceGrid": [["grain", null], ["grain", null]]
     }
   },
   "setup": {
@@ -30,7 +30,7 @@
     "initialStockpile": {"gp1": {"lumber": 2, "castIron": 2}},
     "initialTileState": {
       "oldWorld|p1|0|0": {"improvementLevel": 0, "roadLevel": 1},
-      "oldWorld|p2|1|0": {"improvementLevel": 0, "roadLevel": 1}
+      "oldWorld|p2|0|1": {"improvementLevel": 0, "roadLevel": 1}
     }
   },
   "turns": [
@@ -42,7 +42,7 @@
           "type": "work",
           "unit": "gp1_builder_0",
           "workType": "build_improvement",
-          "targetTileKey": "oldWorld|p2|1|0"
+          "targetTileKey": "oldWorld|p2|0|1"
         }
       ]
     }
@@ -50,7 +50,7 @@
   "assertions": [
     {
       "turn": 1,
-      "tileKey": "oldWorld|p2|1|0",
+      "tileKey": "oldWorld|p2|0|1",
       "tileImprovementLevel": 0
     }
   ]

--- a/tool/sim_scenarios/scenarios/build_improvement_reject_foreign_unpurchased.json
+++ b/tool/sim_scenarios/scenarios/build_improvement_reject_foreign_unpurchased.json
@@ -1,0 +1,58 @@
+{
+  "name": "build_improvement_reject_foreign_unpurchased",
+  "description": "SPEC/game/extraction-and-improvements.md, SPEC/program/development-resolution.md, SPEC/program/orders.md: build_improvement work order rejected when target tile is in a foreign province that has not been purchased by the player (not under player control). Order engine must reject; tile improvement level remains 0.",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "greatPowers": ["england", "france"],
+      "seed": 42,
+      "minorNationCount": 0,
+      "numProvincesOldWorld": 2,
+      "numProvincesNewWorld": 0,
+      "tribeCount": 0
+    },
+    "oldWorld": {
+      "grid": [["p1", "p2", "sea1"]],
+      "nodes": [
+        {"id": "p1", "regionId": "oldWorld", "type": "province"},
+        {"id": "p2", "regionId": "oldWorld", "type": "province"},
+        {"id": "sea1", "regionId": "oldWorld", "type": "seaZone"}
+      ],
+      "edges": [
+        {"id1": "p1", "id2": "p2"},
+        {"id1": "p2", "id2": "sea1"}
+      ],
+      "resourceGrid": [["grain", "grain", null]]
+    }
+  },
+  "setup": {
+    "initialTech": {"gp1": ["gathering_3"]},
+    "initialStockpile": {"gp1": {"lumber": 2, "castIron": 2}},
+    "initialTileState": {
+      "oldWorld|p1|0|0": {"improvementLevel": 0, "roadLevel": 1},
+      "oldWorld|p2|1|0": {"improvementLevel": 0, "roadLevel": 1}
+    }
+  },
+  "turns": [
+    {
+      "turn": 1,
+      "orders": [
+        {
+          "player": "gp1",
+          "type": "work",
+          "unit": "gp1_builder_0",
+          "workType": "build_improvement",
+          "targetTileKey": "oldWorld|p2|1|0"
+        }
+      ]
+    }
+  ],
+  "assertions": [
+    {
+      "turn": 1,
+      "tileKey": "oldWorld|p2|1|0",
+      "tileImprovementLevel": 0
+    }
+  ]
+}
+


### PR DESCRIPTION
## Summary
- **Rule:** build_improvement (and other non-Explorer development work) is only allowed on tiles under player control: owned province **or** tile in `purchasedTilesByTileKey` for that player.
- **Logic:** Added `isTileControlledByPlayer(game, playerId, tileKey)` in `packages/colonizethis_logic`, used in `WorkOrderValidator` and order suggestion so valid tiles and order validation match the rule.
- **ctterm:** Development screen now uses `isTileControlledByPlayer` instead of `province.ownerId == playerId`, so purchased foreign tiles are offered (aligned with app).
- **Tests:** `tile_control_test.dart`, extra `order_engine_test.dart` cases (reject foreign unpurchased, accept purchased foreign).
- **Scenarios:** `build_improvement_reject_foreign_unpurchased.json`, `build_improvement_accept_purchased_foreign.json`; sim scenario setup supports `purchasedTilesByTileKey` in JSON and runner.

SPEC refs: civilian-units.md, orders.md, development-resolution.md.

Made with [Cursor](https://cursor.com)