### PR TITLE
Refactor shared logic validators and diplomacy helpers

### DIFF
--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -17,12 +17,12 @@ export 'diplomacy_relation_lookup.dart';
 
 final Logger _diploLog = Logger();
 
-bool _isMinorOrTribe(Game game, String factionId) {
+bool isMinorOrTribe(Game game, String factionId) {
   return game.minorNations.any((m) => m.id == factionId) ||
       game.tribes.any((t) => t.id == factionId);
 }
 
-bool _isGreatPower(Game game, String factionId) {
+bool isGreatPower(Game game, String factionId) {
   return game.players.any((p) => p.id == factionId);
 }
 
@@ -155,8 +155,8 @@ _OverturePaymentsResult _processOverturePayments(
       if (stage == null || stage == OvertureStage.none) continue;
 
       final targetId = order.targetFactionId;
-      final targetIsMinorOrTribe = _isMinorOrTribe(state, targetId);
-      final targetIsGp = _isGreatPower(state, targetId);
+      final targetIsMinorOrTribe = isMinorOrTribe(state, targetId);
+      final targetIsGp = isGreatPower(state, targetId);
       if (!targetIsMinorOrTribe && !targetIsGp) continue;
 
       // SPEC/game/diplomacy.md: While relationState is AT_WAR, no new overtures.
@@ -271,7 +271,7 @@ Game _resolveJoinEmpireColony(
       if (stage != OvertureStage.joinEmpire) continue;
 
       final targetId = order.targetFactionId;
-      if (!_isMinorOrTribe(game, targetId)) continue;
+      if (!isMinorOrTribe(game, targetId)) continue;
 
       final player = game.playerById(gpId);
       if (player == null) continue;
@@ -396,7 +396,7 @@ Game _processAlliances(
       if (order.type != DiplomaticOrderType.alliance) continue;
 
       final targetId = order.targetFactionId;
-      if (!_isGreatPower(game, targetId)) continue;
+      if (!isGreatPower(game, targetId)) continue;
 
       final ids = canonicalPairIds(gpId, targetId);
       final relations = upsertRelation(
@@ -442,7 +442,7 @@ Game _processWarAndPeace(
     for (final order in entry.value) {
       if (order.type != DiplomaticOrderType.offerPeace) continue;
       final targetId = order.targetFactionId;
-      if (!_isGreatPower(game, gpId) || !_isGreatPower(game, targetId))
+      if (!isGreatPower(game, gpId) || !isGreatPower(game, targetId))
         continue;
       final key = pairKey(gpId, targetId);
       final offerers = peaceOffersByPairKey.putIfAbsent(key, () => <String>{});
@@ -502,7 +502,7 @@ Game _processWarAndPeace(
         final rel = getRelation(game, gpId, targetId);
         final key = pairKey(gpId, targetId);
         final bothGreatPowers =
-            _isGreatPower(game, gpId) && _isGreatPower(game, targetId);
+            isGreatPower(game, gpId) && isGreatPower(game, targetId);
         final hasMutualOffer = bothGreatPowers
             ? (peaceOffersByPairKey[key]?.length ?? 0) >= 2
             : true;
@@ -511,8 +511,8 @@ Game _processWarAndPeace(
           // - GP–GP peace: both sides must agree (both offer peace in this phase).
           // - Minors never refuse peace offers.
           var bothSidesAgreed = true;
-          final isGpTarget = _isGreatPower(game, targetId);
-          if (isGpTarget && _isGreatPower(game, gpId)) {
+          final isGpTarget = isGreatPower(game, targetId);
+          if (isGpTarget && isGreatPower(game, gpId)) {
             final key = pairKey(gpId, targetId);
             final offerers = peaceOffersByPairKey[key] ?? const <String>{};
             bothSidesAgreed =
@@ -724,7 +724,7 @@ Game _processOngoingSubsidies(Game game, int turn) {
     final boost = ((amount ~/ 500) * 2).clamp(0, 8);
 
     // Apply relation boost (only for Minors/Tribes - GPs get treasury transfer)
-    if (_isMinorOrTribe(game, targetId)) {
+    if (isMinorOrTribe(game, targetId)) {
       relations = applySubsidyBoost(
         relations: relations,
         payerId: payerId,
@@ -805,8 +805,8 @@ bool _gpHasPurchasedLandInFactionProvinces(
 /// choice is needed before combat.
 String? needsInterventionChoice(Game game, BattleContext ctx) {
   final defenderId = ctx.defenderFactionId;
-  final isMinorOrTribe = _isMinorOrTribe(game, defenderId);
-  if (!isMinorOrTribe) return null;
+  final defenderIsMinorOrTribe = isMinorOrTribe(game, defenderId);
+  if (!defenderIsMinorOrTribe) return null;
 
   final attackerIds = ctx.attackers.map((a) => a.factionId).toSet();
   final attackerIsGp =
@@ -843,7 +843,7 @@ Game applyInterventionChoice(
 
   for (final a in ctx.attackers) {
     final attackerId = a.factionId;
-    if (!_isGreatPower(game, attackerId)) continue;
+    if (!isGreatPower(game, attackerId)) continue;
 
     if (choice == InterventionChoice.intervene) {
       final ids = canonicalPairIds(gpIdWithEmbassy, attackerId);

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -316,10 +316,8 @@ class OrderEngine {
     final missions = _orders.navalMissionOrdersByPlayerId[playerId] ?? [];
     var rejected = false;
 
-    final unitsById = Map<String, Unit>.from(unitsByIdFromWorld(game.worldState));
-
-    bool _isDevExclusiveUnitType(String type) =>
-        type == 'Builder' || type == 'Engineer' || type == 'Merchant';
+    final unitsById =
+        Map<String, Unit>.from(unitsByIdFromWorld(game.worldState));
 
     // Per-player tile exclusivity (SPEC/game/civilian-units.md, SPEC/program/orders.md):
     // track tiles already reserved by this player's Builder/Engineer/Merchant work
@@ -327,8 +325,8 @@ class OrderEngine {
     final devExclusiveTiles = <String>{};
     for (final u in allUnitsFromWorld(game.worldState)) {
       final w = u.currentWork;
-      if (u.ownerId == playerId &&
-          _isDevExclusiveUnitType(u.type) &&
+          if (u.ownerId == playerId &&
+          isDevExclusiveUnitType(u.type) &&
           w != null &&
           w.tileKey.isNotEmpty) {
         devExclusiveTiles.add(w.tileKey);
@@ -345,9 +343,7 @@ class OrderEngine {
 
     for (final o in moves) {
       if (rejected) {
-        results.add(const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Previous invalid'));
+        results.add(previousInvalidOrderResult);
         continue;
       }
       final r = validateMove(o);

--- a/packages/colonizethis_logic/lib/src/orders/order_validation_result.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_validation_result.dart
@@ -15,3 +15,10 @@ class OrderValidationResult {
 
   bool get isAccepted => status == OrderValidationStatus.accepted;
 }
+
+/// Shared constant result used when a previous order in the sequence
+/// has already been rejected and all subsequent orders must be rejected.
+const OrderValidationResult previousInvalidOrderResult = OrderValidationResult(
+  status: OrderValidationStatus.rejected,
+  reason: 'Previous invalid',
+);

--- a/packages/colonizethis_logic/lib/src/orders/validators/build_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/build_order_validator.dart
@@ -32,10 +32,7 @@ class BuildOrderValidator {
     required bool previousRejected,
   }) {
     if (previousRejected) {
-      return const OrderValidationResult(
-        status: OrderValidationStatus.rejected,
-        reason: 'Previous invalid',
-      );
+      return previousInvalidOrderResult;
     }
 
     if (_player.capitalProvinceId == null) {

--- a/packages/colonizethis_logic/lib/src/orders/validators/diplomatic_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/diplomatic_order_validator.dart
@@ -25,13 +25,6 @@ class DiplomaticOrderValidator {
 
   int get treasury => _treasury;
 
-  bool _factionIsGreatPower(String id) =>
-      _game.players.any((p) => p.id == id);
-
-  bool _factionIsMinorOrTribe(String id) =>
-      _game.minorNations.any((m) => m.id == id) ||
-      _game.tribes.any((t) => t.id == id);
-
   /// Validate a single [DiplomaticOrder], given whether a previous order
   /// for this player in this turn has already been rejected.
   ///
@@ -45,10 +38,7 @@ class DiplomaticOrderValidator {
   }) {
     if (previousRejected) {
       return (
-        result: const OrderValidationResult(
-          status: OrderValidationStatus.rejected,
-          reason: 'Previous invalid',
-        ),
+        result: previousInvalidOrderResult,
         treasury: _treasury,
       );
     }
@@ -66,7 +56,7 @@ class DiplomaticOrderValidator {
     }
 
     final targetExists =
-        _factionIsGreatPower(targetId) || _factionIsMinorOrTribe(targetId);
+        isGreatPower(_game, targetId) || isMinorOrTribe(_game, targetId);
     if (!targetExists) {
       return (
         result: const OrderValidationResult(
@@ -117,7 +107,7 @@ class DiplomaticOrderValidator {
         );
 
       case DiplomaticOrderType.alliance:
-        if (!_factionIsGreatPower(targetId)) {
+        if (!isGreatPower(_game, targetId)) {
           return (
             result: const OrderValidationResult(
               status: OrderValidationStatus.rejected,
@@ -153,8 +143,8 @@ class DiplomaticOrderValidator {
             treasury: _treasury,
           );
         }
-        if (!_factionIsMinorOrTribe(targetId) &&
-            !_factionIsGreatPower(targetId)) {
+        if (!isMinorOrTribe(_game, targetId) &&
+            !isGreatPower(_game, targetId)) {
           return (
             result: const OrderValidationResult(
               status: OrderValidationStatus.rejected,

--- a/packages/colonizethis_logic/lib/src/orders/validators/move_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/move_validator.dart
@@ -56,12 +56,12 @@ class MoveValidator {
     if (!isMilitaryUnit(unit.type) &&
         destOwnerId != null &&
         destOwnerId != playerId) {
-      if (_ownerIsGreatPower(game, destOwnerId) && !isSpyUnit(unit.type)) {
+      if (isGreatPower(game, destOwnerId) && !isSpyUnit(unit.type)) {
         return const OrderValidationResult(
             status: OrderValidationStatus.rejected,
             reason: 'Civilian cannot enter other Great Power territory');
       }
-      if (_ownerIsMinorOrTribe(game, destOwnerId) &&
+      if (isMinorOrTribe(game, destOwnerId) &&
           !isExplorerUnit(unit.type) &&
           !isMerchantUnit(unit.type) &&
           !isSpyUnit(unit.type)) {
@@ -74,7 +74,7 @@ class MoveValidator {
     // Attack validation: GP province requires war or same-turn declareWar.
     if (destOwnerId != null &&
         destOwnerId != playerId &&
-        _ownerIsGreatPower(game, destOwnerId)) {
+        isGreatPower(game, destOwnerId)) {
       final rel = getRelation(game, playerId, destOwnerId);
       final atWar = rel?.atWar ?? false;
       final declaringWarThisTurn = diplomaticOrders.any((o) =>
@@ -91,7 +91,7 @@ class MoveValidator {
     // Attack validation: Minor/Tribe province requires war for military units.
     if (destOwnerId != null &&
         destOwnerId != playerId &&
-        _ownerIsMinorOrTribe(game, destOwnerId) &&
+        isMinorOrTribe(game, destOwnerId) &&
         isMilitaryUnit(unit.type)) {
       final rel = getRelation(game, playerId, destOwnerId);
       final atWar = rel?.atWar ?? false;
@@ -115,14 +115,5 @@ class MoveValidator {
           reason: 'Source or destination not visible');
     }
     return const OrderValidationResult(status: OrderValidationStatus.accepted);
-  }
-
-  bool _ownerIsGreatPower(Game game, String ownerId) {
-    return game.players.any((p) => p.id == ownerId);
-  }
-
-  bool _ownerIsMinorOrTribe(Game game, String ownerId) {
-    return game.minorNations.any((m) => m.id == ownerId) ||
-        game.tribes.any((t) => t.id == ownerId);
   }
 }

--- a/packages/colonizethis_logic/lib/src/orders/validators/naval_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/naval_order_validator.dart
@@ -29,10 +29,7 @@ class NavalOrderValidator {
     required bool previousRejected,
   }) {
     if (previousRejected) {
-      return const OrderValidationResult(
-        status: OrderValidationStatus.rejected,
-        reason: 'Previous invalid',
-      );
+      return previousInvalidOrderResult;
     }
     final fleet = _fleetById[o.fleetId];
     final homeFleetId = 'fleet_$_playerId';
@@ -107,10 +104,7 @@ class NavalOrderValidator {
     required bool previousRejected,
   }) {
     if (previousRejected) {
-      return const OrderValidationResult(
-        status: OrderValidationStatus.rejected,
-        reason: 'Previous invalid',
-      );
+      return previousInvalidOrderResult;
     }
     final fleet = _fleetById[o.fleetId];
     final homeFleetId = 'fleet_$_playerId';

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
@@ -8,6 +8,9 @@ import '../order_visibility.dart';
 import '../order_validation_result.dart';
 import 'work_order_cost_calculator.dart';
 
+bool isDevExclusiveUnitType(String type) =>
+    type == 'Builder' || type == 'Engineer' || type == 'Merchant';
+
 /// Validates work orders for a single player in submission order.
 /// Mutates internal economy state (stockpile, treasury) and [devExclusiveTiles]
 /// when an order is accepted. SPEC/program/orders.md § Work orders.
@@ -43,9 +46,6 @@ class WorkOrderValidator {
   Stockpile get stockpile => _stockpile;
   int get treasury => _treasury;
 
-  static bool _isDevExclusiveUnitType(String type) =>
-      type == 'Builder' || type == 'Engineer' || type == 'Merchant';
-
   static bool _isDevExclusiveTarget(String target) =>
       target == 'build_improvement' ||
       target == 'upgrade_town' ||
@@ -62,10 +62,7 @@ class WorkOrderValidator {
     required bool previousRejected,
   }) {
     if (previousRejected) {
-      return const OrderValidationResult(
-        status: OrderValidationStatus.rejected,
-        reason: 'Previous invalid',
-      );
+      return previousInvalidOrderResult;
     }
 
     final unit = _unitsById[o.unitId];
@@ -254,7 +251,7 @@ class WorkOrderValidator {
       }
     }
 
-    if (_isDevExclusiveUnitType(type) &&
+    if (isDevExclusiveUnitType(type) &&
         _isDevExclusiveTarget(o.target) &&
         _devExclusiveTiles.contains(o.targetTileKey)) {
       return const OrderValidationResult(
@@ -324,7 +321,7 @@ class WorkOrderValidator {
       );
     }
 
-    if (_isDevExclusiveUnitType(type) && _isDevExclusiveTarget(o.target)) {
+    if (isDevExclusiveUnitType(type) && _isDevExclusiveTarget(o.target)) {
       _devExclusiveTiles.add(o.targetTileKey);
     }
 


### PR DESCRIPTION
## Summary
- Centralize a shared `previousInvalidOrderResult` constant for order validators and `OrderEngine` when a prior order was invalid.
- Extract a reusable `isDevExclusiveUnitType` helper to avoid duplicated Builder/Engineer/Merchant logic between `OrderEngine` and `WorkOrderValidator`.
- Reuse `isGreatPower` / `isMinorOrTribe` faction classification helpers across `MoveValidator`, `DiplomaticOrderValidator`, and diplomacy resolution to keep behavior in one place.

## Test plan
- `dart test packages/colonizethis_logic`

Made with [Cursor](https://cursor.com)