### PR TITLE
chore(ci): add widgetbook release pipeline

### DIFF
--- a/.github/workflows/enable-automerge.yml
+++ b/.github/workflows/enable-automerge.yml
@@ -3,7 +3,10 @@ name: Enable PR auto-merge
 on:
   pull_request:
     types: [opened, reopened]
-    branches: [main, dev]
+    branches:
+      - main
+      - dev
+      - 'build/**'
 
 permissions:
   pull-requests: write

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev
+      - 'build/**'
 
 jobs:
   quality:
@@ -15,6 +16,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Enforce dev to build/widgetbook PRs only
+        if: ${{ github.base_ref == 'build/widgetbook' }}
+        run: |
+          echo "Base ref: ${{ github.base_ref }}, head ref: ${{ github.head_ref }}"
+          if [ "${{ github.head_ref }}" != "dev" ]; then
+            echo "Only PRs from dev are allowed into build/widgetbook."
+            exit 1
+          fi
 
       # CI quality scope: packages, app (Flutter widget tests), tool packages. Full scope via tool/run_quality_gate_tests.sh locally.
       - name: Detect source changes

--- a/.github/workflows/widgetbook-release.yml
+++ b/.github/workflows/widgetbook-release.yml
@@ -1,0 +1,50 @@
+name: Widgetbook Release
+
+on:
+  push:
+    branches:
+      - build/widgetbook
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        working-directory: widgetbook_host
+        run: flutter pub get
+
+      - name: Build Widgetbook APK
+        working-directory: widgetbook_host
+        run: flutter build apk --release
+
+      - name: Compute release metadata
+        id: meta
+        run: |
+          DATE=$(date +"%Y%m%d")
+          HASH=$(git rev-parse --short HEAD)
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+          echo "tag=widgetbook-${DATE}.${HASH}" >> "$GITHUB_OUTPUT"
+          echo "name=Widgetbook (${DATE}.${HASH})" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.name }}
+          files: widgetbook_host/build/app/outputs/flutter-apk/app-release.apk


### PR DESCRIPTION
Automates Widgetbook APK releases from build/widgetbook and extends CI/auto-merge to build/** branches.

Made with [Cursor](https://cursor.com)