### PR TITLE
chore(ci): enforce dev source for build/widgetbook

### DIFF
--- a/.github/workflows/enforce-build-widgetbook-source.yml
+++ b/.github/workflows/enforce-build-widgetbook-source.yml
@@ -1,0 +1,18 @@
+name: Enforce dev source for build/widgetbook
+
+on:
+  pull_request:
+    branches:
+      - build/widgetbook
+
+jobs:
+  enforce-dev-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if PR is not from dev
+        run: |
+          echo "Base ref: ${{ github.base_ref }}, head ref: ${{ github.head_ref }}"
+          if [ "${{ github.head_ref }}" != "dev" ]; then
+            echo "Only PRs from dev are allowed into build/widgetbook."
+            exit 1
+          fi

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - dev
-      - 'build/**'
 
 jobs:
   quality:
@@ -16,15 +15,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Enforce dev to build/widgetbook PRs only
-        if: ${{ github.base_ref == 'build/widgetbook' }}
-        run: |
-          echo "Base ref: ${{ github.base_ref }}, head ref: ${{ github.head_ref }}"
-          if [ "${{ github.head_ref }}" != "dev" ]; then
-            echo "Only PRs from dev are allowed into build/widgetbook."
-            exit 1
-          fi
 
       # CI quality scope: packages, app (Flutter widget tests), tool packages. Full scope via tool/run_quality_gate_tests.sh locally.
       - name: Detect source changes


### PR DESCRIPTION
Separate enforcement of dev → build/widgetbook PR source from the quality workflow and keep the quality gate scoped to main/dev only.

Made with [Cursor](https://cursor.com)