### PR TITLE
Align province overlay widgetbook bottom-sheet with spec

### DIFF
--- a/SPEC/ui/province-sea-zone-detail-overlay.md
+++ b/SPEC/ui/province-sea-zone-detail-overlay.md
@@ -22,10 +22,10 @@ When the user taps/clicks a tile on the map widget, the in-game shell displays a
 
 ## Layout and Responsiveness
 
-- **Max height:** Overlay never occupies more than one-third of the screen height.
-- **Desktop / larger screens:** Overlay appears as a side panel (e.g. right side). Content scrolls if needed.
-- **Mobile / narrow viewports:** Overlay appears as a bottom sheet. Content is organized in **tabs** (Political, Economic, Military, Civilian, Naval) so each tab fits within the one-third height constraint.
-- **Tabs:** Political | Economic | Military | Civilian | Naval. On desktop, tabs may be shown as sections in a single scrollable panel if space allows.
+- **Max height:** Overlay never occupies more than one-third of the screen height in the main game shell; Widgetbook map+overlay mock may use a fixed fraction (e.g. bottom half of the story area) to clearly demonstrate the interaction.
+- **Desktop / larger screens:** In the main game shell, overlay appears as a side panel (e.g. right side). Content scrolls if needed.
+- **Mobile / narrow viewports:** Overlay appears as a bottom sheet on top of the map. Content is organized in **tabs** (Political, Economic, Military, Civilian, Naval) so each tab fits within the one-third height constraint.
+- **Tabs:** Political | Economic | Military | Civilian | Naval. On desktop, tabs may be shown as sections in a single scrollable panel if space allows; in Widgetbook, the "With map" story uses a simple bottom overlay to showcase interaction rather than full tab chrome.
 
 ---
 
@@ -101,7 +101,7 @@ When the overlay lists tile coordinates (e.g. improvements built/available), hov
 
 - **Given** the Province Overlay Widgetbook story "Standalone — province", **when** the story renders, **then** the overlay displays province content (Political, Economic, Military, Civilian, Naval) with demo data.
 - **Given** the Province Overlay Widgetbook story "Standalone — sea zone", **when** the story renders, **then** the overlay displays sea zone content (Political, Naval).
-- **Given** the Province Overlay Widgetbook story "With map — province selected", **when** the story renders, **then** the map and overlay appear side by side; the overlay shows the selected province; tapping the map toggles or updates selection.
+- **Given** the Province Overlay Widgetbook story "With map — province selected", **when** the story renders, **then** the map fills the story area and, when a province is selected, a province detail overlay appears as a bottom sheet covering roughly the lower half of the map; tapping the same province again or the close button hides the overlay; tapping a different province updates the overlay content.
 - **Given** the Province Overlay Widgetbook story "Standalone (mobile)", **when** the story renders, **then** the overlay uses tabs and does not exceed one-third of viewport height.
 
 ---

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -953,79 +953,88 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
     final game = initResult.game;
     final mapViewData = debugMapViewDataWithVisibilityForFirstPlayer();
     final region = mapViewData.oldWorld;
-    final isNarrow = MediaQuery.sizeOf(context).width < 600;
-    return SizedBox(
-      width: 800,
-      height: 500,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                ChoiceChip(
-                  label: const Text('Full visibility'),
-                  selected: _visibilityMode == CtMapVisibilityMode.full,
-                  onSelected: (_) {
-                    setState(() {
-                      _visibilityMode = CtMapVisibilityMode.full;
-                    });
-                  },
-                ),
-                const SizedBox(width: 8),
-                ChoiceChip(
-                  label: const Text('Player-constrained'),
-                  selected:
-                      _visibilityMode == CtMapVisibilityMode.playerConstrained,
-                  onSelected: (_) {
-                    setState(() {
-                      _visibilityMode = CtMapVisibilityMode.playerConstrained;
-                    });
-                  },
-                ),
-              ],
-            ),
-          ),
-          Expanded(
-            child: Row(
-              children: [
-                Expanded(
-                  flex: 2,
-                  child: CtRegionMap(
-                    region: region,
-                    cellSizePx: 28,
-                    visibilityMode: _visibilityMode,
-                    onProvinceSelected: (id) => setState(
-                        () => _selectedId = _selectedId == id ? '' : id),
-                    onProvinceHovered: (id) =>
-                        setState(() => _hoveredDetailId = id),
-                    onTileHovered: (key) =>
-                        setState(() => _hoveredTileKey = key),
-                    highlightedTileKey: _highlightedTileKey,
-                  ),
-                ),
-                if (!isNarrow && _selectedId.isNotEmpty)
-                  SizedBox(
-                    width: 320,
-                    child: ProvinceSeaZoneDetailOverlay(
-                      game: game,
-                      region: region,
-                      selectedId: _selectedId,
-                      displayId: _displayId,
-                      humanPlayerId: 'gp1',
-                      hoveredTileKey: _hoveredTileKey,
-                      onHighlightTile: (k) =>
-                          setState(() => _highlightedTileKey = k),
-                      onClose: () => setState(() => _selectedId = ''),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final totalHeight = constraints.maxHeight > 0 ? constraints.maxHeight : 500;
+        final overlayHeight = totalHeight / 2;
+        return SizedBox(
+          width: 800,
+          height: totalHeight,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ChoiceChip(
+                      label: const Text('Full visibility'),
+                      selected: _visibilityMode == CtMapVisibilityMode.full,
+                      onSelected: (_) {
+                        setState(() {
+                          _visibilityMode = CtMapVisibilityMode.full;
+                        });
+                      },
                     ),
-                  ),
-              ],
-            ),
+                    const SizedBox(width: 8),
+                    ChoiceChip(
+                      label: const Text('Player-constrained'),
+                      selected: _visibilityMode ==
+                          CtMapVisibilityMode.playerConstrained,
+                      onSelected: (_) {
+                        setState(() {
+                          _visibilityMode =
+                              CtMapVisibilityMode.playerConstrained;
+                        });
+                      },
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: Stack(
+                  children: [
+                    Positioned.fill(
+                      child: CtRegionMap(
+                        region: region,
+                        cellSizePx: 28,
+                        visibilityMode: _visibilityMode,
+                        onProvinceSelected: (id) => setState(
+                            () => _selectedId = _selectedId == id ? '' : id),
+                        onProvinceHovered: (id) =>
+                            setState(() => _hoveredDetailId = id),
+                        onTileHovered: (key) =>
+                            setState(() => _hoveredTileKey = key),
+                        highlightedTileKey: _highlightedTileKey,
+                      ),
+                    ),
+                    if (_selectedId.isNotEmpty)
+                      Align(
+                        alignment: Alignment.bottomCenter,
+                        child: SizedBox(
+                          height: overlayHeight,
+                          width: double.infinity,
+                          child: ProvinceSeaZoneDetailOverlay(
+                            game: game,
+                            region: region,
+                            selectedId: _selectedId,
+                            displayId: _displayId,
+                            humanPlayerId: 'gp1',
+                            hoveredTileKey: _hoveredTileKey,
+                            onHighlightTile: (k) =>
+                                setState(() => _highlightedTileKey = k),
+                            onClose: () => setState(() => _selectedId = ''),
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 }

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -955,7 +955,7 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
     final region = mapViewData.oldWorld;
     return LayoutBuilder(
       builder: (context, constraints) {
-        final totalHeight = constraints.maxHeight > 0 ? constraints.maxHeight : 500;
+        final totalHeight = constraints.maxHeight > 0 ? constraints.maxHeight : 500.0;
         final overlayHeight = totalHeight / 2;
         return SizedBox(
           width: 800,


### PR DESCRIPTION
## Summary
- Update Widgetbook "With map — province selected" story to render province overlay as a bottom sheet covering the lower half of the map while keeping tap-to-toggle behavior on province selection.
- Adjust province/sea zone overlay UI spec and Widgetbook acceptance criteria to describe the bottom overlay behavior for the map+overlay mock, while keeping desktop side-panel vs mobile bottom-sheet behavior for the main game shell.

## Testing
- Ran `flutter test` in repo root (fails with: "Test directory \"test\" not found.").
- Manually verified Widgetbook scenario on mobile-style viewport: map fills the story area; tapping a province shows bottom-half overlay; tapping same province or close button hides overlay; tapping another province updates overlay content.
