### PR TITLE
feat: GP power score on diplomacy panel + run app tests with Flutter

### DIFF
--- a/.cursor/rules/colonizethis-testing.mdc
+++ b/.cursor/rules/colonizethis-testing.mdc
@@ -7,6 +7,7 @@ alwaysApply: false
 # Testing
 
 - **Coverage:** 90% per package (enforce in CI, e.g. `tool/test_coverage.py`). **App:** 80% line coverage for **widget-unit code only** (`lib/widgets/`); entry points, config, providers, and features are excluded. Enforced by `tool/run_quality_gate_tests.sh` and `tool/check_coverage_threshold.sh 80 app` (see SPEC/program/test-logging.md).
+- **How to run:** App and ctdev use Flutter widget tests. Run with **`flutter test`** from the package dir (e.g. `cd app && flutter test`) or `melos run test_app`. Do **not** use `dart test app/test/...` — that breaks (Flutter bindings missing).
 - **Layers:** **Unit** — pure logic, models, services (no Flutter/Flame); mock deps. **Widget** — Flutter; `flutter_test`, `pumpWidget`; mock state/providers. **Game/component** — Flame in isolation (minimal `FlameGame` + component); test `onLoad`, `update`, removal.
 - **Layout:** `test/` mirrors `lib/`; **`*_test.dart`**; group by feature or class.
 - **Mocks:** mockito or mocktail; for Flame use minimal game or mock `Game`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Apply these when working in the indicated areas (by path or topic).
 2. **Code style:** Strict Dart, logger (no `print`), thin screens, single responsibility. Province lookup: always `(regionId, provinceId)` or prefixed id.
 3. **When touching UI:** Wireframes in spec; Widgetbook + catalog; pixel art per UXD (exact prompts in spec; check assets first, don’t regenerate if suitable asset exists); Flame for canvas, Flutter for shell/overlays/menus.
 4. **When adding a tool:** Thin facade in `tool/<name>`; logic in packages; Melos script and `docs/project-tools.md` updated.
-5. **When writing tests:** 90% per package; unit/widget/game-component layers; cover combat, economy, save/load, ruleset loading.
+5. **When writing tests:** 90% per package; unit/widget/game-component layers; cover combat, economy, save/load, ruleset loading. **App/ctdev widget tests:** run with `flutter test` from app/ (or `melos run test_app`); do not use `dart test app/...`.
 6. **When file logging:** Use **basic_logger_file** (BasicLogger + FileOutputLogger); do not implement custom file logging.
 7. **When reviewing/generating code:** Use the code-review checklist (lengths, types, spec, logging, reuse, tests).
 

--- a/SPEC/game/diplomacy.md
+++ b/SPEC/game/diplomacy.md
@@ -167,6 +167,14 @@ The following Given–When–Then criteria are testable conditions for diplomacy
 - **Relation thresholds and config:** Relation level (Hostile, Neutral, Friendly, Allied) is derived from relation score using the thresholds in Configurable Values; the table in this document is the source of truth for default values; ruleset overrides apply when specified.
 - **Implementation:** Order validation and resolution flow: [diplomacy-resolution.md](../program/diplomacy-resolution.md). Phase order: [turn-resolution-phases.md](../program/turn-resolution-phases.md).
 
+- Given the user views the diplomacy panel (app or TUI) for a discovered faction with a diplomatic relation  
+  When the panel displays the current relation  
+  Then the system shows the **one-word relation state** (Hostile, Unfriendly, Cordial, or Friendly) derived from the relation score per the Player-facing relation display table (0–29 Hostile, 30–49 Unfriendly, 50–69 Cordial, 70–100 Friendly), and does **not** display the numeric relation score.
+
+- Given the user views the diplomacy panel and the list includes at least one other Great Power  
+  When the panel displays each Great Power row  
+  Then the system shows that GP’s **power score** per the Great Power power score formula (province count, regiment strength, ship count with default weights). If that GP’s score is **greater** than the human player’s power score, the value is shown in **red**; otherwise in **green**.
+
 ## Configurable Values
 
 | Parameter | Default | Notes |
@@ -180,6 +188,30 @@ The following Given–When–Then criteria are testable conditions for diplomacy
 | Embassy cost | £1000 | |
 | Join Empire base cost | £5000 | One-time cost when enacting Join Empire. |
 | Join Empire per-province cost | £2000 | Added for each province owned by the target Minor/Tribe. Total cost = base + (province count × per-province). |
+
+### Player-facing relation display
+
+The **relation score** (0–100) is a **hidden variable**: it is not shown to the player in the diplomacy UI (app or TUI). Validation and game logic continue to use the internal score and relation level (Hostile/Neutral/Friendly/Allied) per the thresholds above.
+
+The diplomacy panel (app and ctterm) shows instead a **one-word relation state** derived from the score:
+
+| Score range | Display label |
+|-------------|---------------|
+| 0–29 | Hostile |
+| 30–49 | Unfriendly |
+| 50–69 | Cordial |
+| 70–100 | Friendly |
+
+Same mapping for both Flutter app and TUI. Game logic (e.g. Join Empire ≥ 51, Alliance ≥ 76) uses the internal score and level; only the displayed label uses these bands.
+
+### Great Power power score
+
+An **absolute power score** is computed for each Great Power for display on the diplomacy panel. It reflects territorial, land, and naval strength.
+
+- **Formula:** `powerScore = provinceCount × W_province + round(regimentStrength) × W_regiment + shipCount × W_ship`
+- **Definitions:** `provinceCount` = number of provinces owned by that GP (Old + New World). `regimentStrength` = same aggregation as [military-strength](../program/military-strength.md) (FPN+FPM, era downgrade, medal multiplier). `shipCount` = total number of ships (sum of `shipTypeIds.length` over all fleets owned by that GP).
+- **Default weights:** W_province = 10, W_regiment = 1, W_ship = 5. So one province = 10, one point of army strength = 1, one ship = 5.
+- **Display:** The diplomacy panel shows this score for each GP. If the GP’s score is **higher** than the human player’s score, the value is shown in **red**; otherwise in **green**. Same formula and display rule for app and TUI where applicable.
 
 ### Where defined (MVP)
 

--- a/SPEC/tui/screens/diplomacy.md
+++ b/SPEC/tui/screens/diplomacy.md
@@ -24,7 +24,8 @@ Diplomacy screen for managing relations with other Great Powers, Minor Nations, 
 - **Then** display all factions showing:
   - Faction name and type (Great Power / Minor Nation / Tribe)
   - Relation state (AT_PEACE / AT_WAR) with the player
-  - Relation level (Hostile / Neutral / Friendly / Allied)
+  - **One-word relation state** (Hostile, Unfriendly, Cordial, Friendly) derived from the hidden relation score per SPEC/game/diplomacy.md § Player-facing relation display. The numeric relation score is **not** shown.
+  - **For Great Powers:** **power score** per SPEC/game/diplomacy.md § Great Power power score; if the GP’s score is higher than the player’s, shown in **red**, otherwise in **green**.
   - Overture stage (for Minors/Tribes: none, Consulate, Embassy, NAP, Join Empire/Colony)
 
 ### Great Power Relations
@@ -32,8 +33,9 @@ Diplomacy screen for managing relations with other Great Powers, Minor Nations, 
 - **Given** the user selects a Great Power
 - **When** viewing the relation details
 - **Then** show:
-  - Current relation state and score (0-100)
-  - Relation level derived from score
+  - Current relation state (AT_PEACE / AT_WAR)
+  - **One-word relation state** (Hostile, Unfriendly, Cordial, Friendly) derived from the hidden relation score per SPEC/game/diplomacy.md § Player-facing relation display. Do **not** show the numeric score or internal relation level.
+  - **Power score** per SPEC/game/diplomacy.md § Great Power power score; if the GP’s score is higher than the player’s, shown in **red**, otherwise in **green**.
   - SinceTurn (when current state began)
   - LastInteractionTurn
 
@@ -127,7 +129,7 @@ Diplomacy screen for managing relations with other Great Powers, Minor Nations, 
 - [ ] Diplomacy screen displays title
 - [ ] All factions are listed with type, name, relation state
 - [ ] User can select a faction via keyboard
-- [ ] Selected faction shows relation details (score, level, sinceTurn, overture)
+- [ ] Selected faction shows relation details (one-word relation state, sinceTurn, overture); numeric score is not shown.
 - [ ] User can issue Declare War order to GP at AT_PEACE
 - [ ] User can issue Offer Peace order to GP at AT_WAR
 - [ ] User can propose/accept Alliance with GP at Allied level

--- a/SPEC/ui/diplomacy-panel.md
+++ b/SPEC/ui/diplomacy-panel.md
@@ -29,7 +29,7 @@ A faction is **discovered** iff the player has a **diplomatic relation** with th
 
 ## Per-faction row
 
-- **Left:** Faction name (displayName or id), type badge (GP / Minor / Tribe), current **diplomatic state**: relation state (AT_PEACE / AT_WAR), relation level (Hostile / Neutral / Friendly / Allied), relation score (0–100). For Minor/Tribe: overture stage (none, Trade Consulate, Embassy, NAP, Join Empire) if any.
+- **Left:** Faction name (displayName or id), type badge (GP / Minor / Tribe), current **diplomatic state**: relation state (AT_PEACE / AT_WAR), **one-word relation state** (Hostile / Unfriendly / Cordial / Friendly) derived from the hidden relation score per [diplomacy.md](../game/diplomacy.md) § Player-facing relation display. The numeric relation score is **not** shown. For Minor/Tribe: overture stage (none, Trade Consulate, Embassy, NAP, Join Empire) if any. For **Great Powers:** the **power score** per [diplomacy.md](../game/diplomacy.md) § Great Power power score is shown; if the GP’s score is higher than the player’s, the score is shown in **red**, otherwise in **green**.
 - **Right:** **Available diplomatic actions** for the player toward that faction. Actions are those explicitly in SPEC/game/diplomacy.md and SPEC/program/orders.md: Declare War, Offer Peace, Alliance (GP only), Establish Overture (stage), Grant Aid, Set Subsidy. Only show actions that are **valid** per the diplomatic order validator (same rules as order submission).
 
 ---
@@ -59,6 +59,6 @@ At least one story that shows the Diplomacy panel using a **real game** (e.g. fr
 
 - Given the user is in-game and taps the dove icon in the toolbar, the UI opens the Diplomacy panel as a full-page screen.
 - Given the Diplomacy panel is open, it lists only discovered factions, grouped as Great Powers, Minor Nations, Tribes; GPs sorted by military power then province count.
-- Given a faction row, the panel shows current relation state and level and, for Minor/Tribe, overture stage; to the right it shows only valid diplomatic actions for that faction.
+- Given a faction row, the panel shows current relation state (Peace/War) and the **one-word relation state** (Hostile, Unfriendly, Cordial, Friendly) derived from the hidden score per SPEC/game/diplomacy.md § Player-facing relation display; it does **not** show the numeric relation score. For Minor/Tribe it shows overture stage. For Great Powers it shows the **power score** (SPEC/game/diplomacy.md § Great Power power score) in **red** when the GP’s score is higher than the player’s, otherwise in **green**. To the right it shows only valid diplomatic actions for that faction.
 - Given the user taps an action that requires no parameters, the UI submits that diplomatic order for the current turn.
 - Given the user taps an action that requires parameters (amount or overture stage), the UI shows a dialog; on confirm, the UI submits the order with the chosen parameters.

--- a/app/lib/features/game/widgets/diplomacy_panel.dart
+++ b/app/lib/features/game/widgets/diplomacy_panel.dart
@@ -19,6 +19,8 @@ class DiplomacyRowData {
     required this.relation,
     this.overture,
     required this.actions,
+    this.powerScore,
+    this.playerPowerScore,
   });
 
   final String factionId;
@@ -27,6 +29,10 @@ class DiplomacyRowData {
   final DiplomacyRelation? relation;
   final OvertureState? overture;
   final List<DiplomaticOrder> actions;
+  /// Great Power power score (SPEC/game/diplomacy.md). Only set for GP rows.
+  final int? powerScore;
+  /// Human player's power score for comparison (red if GP score > this). Only set for GP rows.
+  final int? playerPowerScore;
 }
 
 /// Builds list of discovered factions and their available actions.
@@ -83,6 +89,7 @@ List<DiplomacyRowData> buildDiplomacyRows(
   }
 
   List<DiplomacyRowData> rows = [];
+  final playerPower = greatPowerPowerScore(game, humanPlayerId);
   for (final id in gpIds) {
     rows.add(DiplomacyRowData(
       factionId: id,
@@ -91,6 +98,8 @@ List<DiplomacyRowData> buildDiplomacyRows(
       relation: view.diplomacyByOtherId[id],
       overture: getOverture(game, humanPlayerId, id),
       actions: actionsByTarget[id] ?? [],
+      powerScore: greatPowerPowerScore(game, id),
+      playerPowerScore: playerPower,
     ));
   }
   minorIds.sort((a, b) => (displayNameFor(a)).compareTo(displayNameFor(b)));
@@ -102,6 +111,8 @@ List<DiplomacyRowData> buildDiplomacyRows(
       relation: view.diplomacyByOtherId[id],
       overture: getOverture(game, humanPlayerId, id),
       actions: actionsByTarget[id] ?? [],
+      powerScore: null,
+      playerPowerScore: null,
     ));
   }
   tribeIds.sort((a, b) => (displayNameFor(a)).compareTo(displayNameFor(b)));
@@ -113,6 +124,8 @@ List<DiplomacyRowData> buildDiplomacyRows(
       relation: view.diplomacyByOtherId[id],
       overture: getOverture(game, humanPlayerId, id),
       actions: actionsByTarget[id] ?? [],
+      powerScore: null,
+      playerPowerScore: null,
     ));
   }
   return rows;
@@ -257,8 +270,8 @@ class _DiplomacyRow extends StatelessWidget {
         : rel.atWar
             ? 'War'
             : 'Peace';
-    final levelLabel = rel == null ? '' : _relationLevelLabel(rel.level);
-    final scoreLabel = rel == null ? '' : ' (${rel.score})';
+    // SPEC/game/diplomacy.md § Player-facing relation display: show one-word state, hide score.
+    final relationStateLabel = rel == null ? '' : relationScoreToDisplayLabel(rel.score);
     final overtureLabel = data.overture == null
         ? ''
         : ' · ${_overtureStageLabel(data.overture!.stage)}';
@@ -285,11 +298,26 @@ class _DiplomacyRow extends StatelessWidget {
                       ),
                       const SizedBox(width: 8),
                       _kindChip(context, data.kind),
+                      if (data.powerScore != null) ...[
+                        const SizedBox(width: 8),
+                        Text(
+                          'Power: ${data.powerScore}',
+                          style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                                color: data.playerPowerScore != null &&
+                                        data.powerScore! > data.playerPowerScore!
+                                    ? Colors.red
+                                    : Colors.green,
+                                fontWeight: FontWeight.w600,
+                              ),
+                        ),
+                      ],
                     ],
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    '$stateLabel$levelLabel$scoreLabel$overtureLabel',
+                    relationStateLabel.isEmpty
+                        ? '$stateLabel$overtureLabel'
+                        : '$stateLabel · $relationStateLabel$overtureLabel',
                     style: Theme.of(context).textTheme.bodySmall,
                   ),
                 ],
@@ -331,15 +359,6 @@ class _DiplomacyRow extends StatelessWidget {
             ),
       ),
     );
-  }
-
-  String _relationLevelLabel(RelationLevel level) {
-    return switch (level) {
-      RelationLevel.hostile => 'Hostile',
-      RelationLevel.neutral => 'Neutral',
-      RelationLevel.friendly => 'Friendly',
-      RelationLevel.allied => 'Allied',
-    };
   }
 
   String _overtureStageLabel(OvertureStage stage) {

--- a/app/test/diplomacy_panel_test.dart
+++ b/app/test/diplomacy_panel_test.dart
@@ -94,6 +94,28 @@ void main() {
       );
     });
 
+    testWidgets('AC: One-word relation state shown (Hostile/Unfriendly/Cordial/Friendly), score hidden',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildPanel(
+        game: gameWithFactions,
+        humanPlayerId: humanPlayerId,
+        topology: topology,
+      ));
+      await tester.pumpAndSettle();
+
+      // SPEC/game/diplomacy.md § Player-facing relation display: panel shows one-word state.
+      final displayLabels = ['Hostile', 'Unfriendly', 'Cordial', 'Friendly'];
+      final hasDisplayLabel = displayLabels.any(
+        (label) => find.textContaining(label).evaluate().isNotEmpty,
+      );
+      expect(hasDisplayLabel, isTrue, reason: 'Panel must show one of $displayLabels');
+
+      // Numeric relation score must not be shown (hidden variable). Old UI showed " (50)" for score.
+      expect(find.textContaining(' (50)'), findsNothing);
+      // Old level labels (internal) must not appear as relation label.
+      expect(find.text('Neutral'), findsNothing);
+    });
+
     testWidgets('AC: Action buttons present for factions',
         (WidgetTester tester) async {
       await tester.pumpWidget(buildPanel(
@@ -165,6 +187,17 @@ void main() {
   });
 
   group('buildDiplomacyRows', () {
+    test('display mapping aligned with SPEC (relationScoreToDisplayLabel bands)', () {
+      expect(relationScoreToDisplayLabel(0), 'Hostile');
+      expect(relationScoreToDisplayLabel(29), 'Hostile');
+      expect(relationScoreToDisplayLabel(30), 'Unfriendly');
+      expect(relationScoreToDisplayLabel(49), 'Unfriendly');
+      expect(relationScoreToDisplayLabel(50), 'Cordial');
+      expect(relationScoreToDisplayLabel(69), 'Cordial');
+      expect(relationScoreToDisplayLabel(70), 'Friendly');
+      expect(relationScoreToDisplayLabel(100), 'Friendly');
+    });
+
     test('returns empty list when player has no relations', () {
       final rows = buildDiplomacyRows(
         gameWithNoDiscovered,
@@ -190,6 +223,25 @@ void main() {
         final strB = aggregateMilitaryStrengthForPlayer(
             gameWithFactions, gpRows[i + 1].factionId);
         expect(strA >= strB, isTrue);
+      }
+    });
+
+    test('GP rows have power score and player power score set', () {
+      final rows = buildDiplomacyRows(
+        gameWithFactions,
+        topology,
+        humanPlayerId,
+        const Orders(),
+      );
+      final gpRows = rows.where((r) => r.kind == FactionKind.greatPower).toList();
+      for (final r in gpRows) {
+        expect(r.powerScore, isNotNull, reason: 'GP row ${r.displayName}');
+        expect(r.playerPowerScore, isNotNull, reason: 'GP row ${r.displayName}');
+      }
+      final nonGp = rows.where((r) => r.kind != FactionKind.greatPower);
+      for (final r in nonGp) {
+        expect(r.powerScore, isNull);
+        expect(r.playerPowerScore, isNull);
       }
     });
   });

--- a/ctterm/lib/screens/diplomacy_screen.dart
+++ b/ctterm/lib/screens/diplomacy_screen.dart
@@ -4,6 +4,7 @@ import 'package:logger/logger.dart' as log_pkg;
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 final _log = log_pkg.Logger();
@@ -21,6 +22,10 @@ class FactionDisplayInfo {
   final int? relationScore;
   final OvertureStage? overtureStage;
   final int? relationLastInteractionTurn;
+  /// Great Power power score. Only set for GP rows. SPEC/game/diplomacy.md § Great Power power score.
+  final int? powerScore;
+  /// Human player's power score for red/green comparison. Only set for GP rows.
+  final int? playerPowerScore;
 
   const FactionDisplayInfo({
     required this.id,
@@ -31,6 +36,8 @@ class FactionDisplayInfo {
     this.relationScore,
     this.overtureStage,
     this.relationLastInteractionTurn,
+    this.powerScore,
+    this.playerPowerScore,
   });
 }
 
@@ -81,6 +88,7 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
   void _loadFactions() {
     final factions = <FactionDisplayInfo>[];
     final humanId = _humanPlayerId;
+    final playerPower = greatPowerPowerScore(component.game, humanId);
 
     // Add Great Powers (exclude human player from list, show others)
     for (final player in component.game.players) {
@@ -95,6 +103,8 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
         relationLevel: relation?.level,
         relationScore: relation?.score,
         relationLastInteractionTurn: relation?.lastInteractionTurn,
+        powerScore: greatPowerPowerScore(component.game, player.id),
+        playerPowerScore: playerPower,
       ));
     }
 
@@ -796,6 +806,18 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
                               ),
                               const SizedBox(width: 1),
                               _buildRelationIndicator(faction),
+                              if (faction.powerScore != null) ...[
+                                const SizedBox(width: 1),
+                                Text(
+                                  'P:${faction.powerScore}',
+                                  style: TextStyle(
+                                    color: faction.playerPowerScore != null &&
+                                            faction.powerScore! > faction.playerPowerScore!
+                                        ? Colors.red
+                                        : Colors.green,
+                                  ),
+                                ),
+                              ],
                             ],
                           ),
                         ),
@@ -842,15 +864,20 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
       }
     }
     
+    // SPEC/game/diplomacy.md § Player-facing relation display: one-word state from score.
+    final displayLabel = faction.relationScore != null
+        ? relationScoreToDisplayLabel(faction.relationScore!)
+        : null;
+    
     Color color;
     if (faction.relationState == RelationState.atWar) {
       color = Colors.red;
-    } else if (faction.relationLevel == RelationLevel.allied) {
-      color = Colors.cyan;
-    } else if (faction.relationLevel == RelationLevel.friendly) {
+    } else if (displayLabel == 'Friendly') {
       color = Colors.green;
-    } else if (faction.relationLevel == RelationLevel.hostile) {
+    } else if (displayLabel == 'Hostile') {
       color = Colors.red;
+    } else if (displayLabel == 'Cordial') {
+      color = Colors.cyan;
     } else {
       color = Colors.gray;
     }
@@ -877,12 +904,19 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
           const SizedBox(height: 1),
           if (faction.type == FactionType.greatPower) ...[
             Text('Relation: ${faction.relationState?.name ?? "unknown"}'),
-            Text('Score: ${faction.relationScore ?? 50}'),
-            Text('Level: ${faction.relationLevel?.name ?? "neutral"}'),
+            Text('State: ${faction.relationScore != null ? relationScoreToDisplayLabel(faction.relationScore!) : "unknown"}'),
+            Text(
+              'Power: ${faction.powerScore ?? "—"}',
+              style: TextStyle(
+                color: faction.powerScore != null && faction.playerPowerScore != null &&
+                        faction.powerScore! > faction.playerPowerScore!
+                    ? Colors.red
+                    : Colors.green,
+              ),
+            ),
           ] else ...[
             Text('Relation: ${faction.relationState?.name ?? "unknown"}'),
-            Text('Score: ${faction.relationScore ?? "unknown"}'),
-            Text('Level: ${faction.relationLevel?.name ?? "neutral"}'),
+            Text('State: ${faction.relationScore != null ? relationScoreToDisplayLabel(faction.relationScore!) : "unknown"}'),
             Text('Overture: ${_formatOvertureStage(faction.overtureStage)}'),
           ],
           const SizedBox(height: 1),

--- a/ctterm/test/panel_screens_test.dart
+++ b/ctterm/test/panel_screens_test.dart
@@ -205,6 +205,12 @@ void main() {
   });
 
   group('DiplomacyScreen (SPEC/tui/screens/diplomacy.md)', () {
+    test('display mapping aligned with SPEC (relationScoreToDisplayLabel bands)', () {
+      expect(relationScoreToDisplayLabel(0), 'Hostile');
+      expect(relationScoreToDisplayLabel(50), 'Cordial');
+      expect(relationScoreToDisplayLabel(70), 'Friendly');
+    });
+
     test('can be constructed with required parameters', () {
       final screen = DiplomacyScreen(
         onNavigate: (route) {},

--- a/docs/project-tools.md
+++ b/docs/project-tools.md
@@ -275,6 +275,20 @@ melos run check_gdd_coverage
 
 ---
 
+## test_app (Melos)
+
+Runs Flutter widget tests for the **app** package. Use this (or `cd app && flutter test`) when running app tests. Do **not** run app tests with `dart test app/test/...` from the repo root — that uses the Dart test runner and fails with Flutter binding errors (Size/Rect/invalid-type). See .cursor/rules/colonizethis-testing.mdc.
+
+**Invocation**
+
+```bash
+melos run test_app
+```
+
+Optional: run a single test file: `cd app && flutter test test/diplomacy_panel_test.dart`
+
+---
+
 ## run_quality_gate_tests.sh (CI verification)
 
 Runs the same test and coverage steps as the GitHub Quality workflow (`.github/workflows/quality.yml`): packages (Dart), app (Flutter) with **app widget coverage gate ≥ 80%** (applies to `lib/widgets/` only; see SPEC/program/test-logging.md), ctdev (Flutter), tool packages (Dart), coverage gate (logic/map/ai ≥ 90%), and sim_scenarios. Use this to verify the quality gate locally before pushing. Spec: [SPEC/program/test-logging.md](../SPEC/program/test-logging.md).

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
@@ -3,6 +3,8 @@
 
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../combat/military_strength.dart';
+
 /// Overture costs per diplomacy-resolution. Consulate £500, Embassy £1000.
 const int overtureConsulateCost = 500;
 const int overtureEmbassyCost = 1000;
@@ -23,6 +25,31 @@ int provinceCountOwnedBy(Game game, String factionId) {
   return count;
 }
 
+/// Default weights for Great Power power score. SPEC/game/diplomacy.md § Great Power power score.
+const int powerScoreProvinceWeight = 10;
+const int powerScoreRegimentWeight = 1;
+const int powerScoreShipWeight = 5;
+
+/// Total number of ships (sum of shipTypeIds.length) over all fleets owned by [factionId].
+int shipCountForFaction(Game game, String factionId) {
+  var count = 0;
+  for (final f in game.worldState.fleets) {
+    if (f.ownerId == factionId) count += f.shipTypeIds.length;
+  }
+  return count;
+}
+
+/// Absolute power score for a Great Power. SPEC/game/diplomacy.md § Great Power power score.
+/// Formula: provinceCount×W_province + round(regimentStrength)×W_regiment + shipCount×W_ship.
+int greatPowerPowerScore(Game game, String factionId) {
+  final provinces = provinceCountOwnedBy(game, factionId);
+  final regimentStrength = aggregateMilitaryStrengthForPlayer(game, factionId);
+  final ships = shipCountForFaction(game, factionId);
+  return provinces * powerScoreProvinceWeight +
+      regimentStrength.round() * powerScoreRegimentWeight +
+      ships * powerScoreShipWeight;
+}
+
 /// Join Empire cost in pounds for absorbing [targetId] (Minor or Tribe).
 int joinEmpireCostForMinorOrTribe(Game game, String targetId) {
   final n = provinceCountOwnedBy(game, targetId);
@@ -35,6 +62,16 @@ RelationLevel scoreToLevel(int score) {
   if (score <= 50) return RelationLevel.neutral;
   if (score <= 75) return RelationLevel.friendly;
   return RelationLevel.allied;
+}
+
+/// One-word relation state for UI display. SPEC/game/diplomacy.md § Player-facing relation display.
+/// Score is hidden; UI shows this label: 0–29 Hostile, 30–49 Unfriendly, 50–69 Cordial, 70–100 Friendly.
+String relationScoreToDisplayLabel(int score) {
+  final clamped = score.clamp(0, 100);
+  if (clamped <= 29) return 'Hostile';
+  if (clamped <= 49) return 'Unfriendly';
+  if (clamped <= 69) return 'Cordial';
+  return 'Friendly';
 }
 
 /// Normalizes faction pair for lookup (consistent ordering).

--- a/packages/colonizethis_logic/test/diplomacy_resolver_test.dart
+++ b/packages/colonizethis_logic/test/diplomacy_resolver_test.dart
@@ -51,6 +51,23 @@ void main() {
     });
   });
 
+  group('relationScoreToDisplayLabel', () {
+    test('maps score to display label per SPEC/game/diplomacy.md § Player-facing relation display', () {
+      expect(relationScoreToDisplayLabel(0), 'Hostile');
+      expect(relationScoreToDisplayLabel(29), 'Hostile');
+      expect(relationScoreToDisplayLabel(30), 'Unfriendly');
+      expect(relationScoreToDisplayLabel(49), 'Unfriendly');
+      expect(relationScoreToDisplayLabel(50), 'Cordial');
+      expect(relationScoreToDisplayLabel(69), 'Cordial');
+      expect(relationScoreToDisplayLabel(70), 'Friendly');
+      expect(relationScoreToDisplayLabel(100), 'Friendly');
+    });
+    test('clamps out-of-range score to 0-100', () {
+      expect(relationScoreToDisplayLabel(-1), 'Hostile');
+      expect(relationScoreToDisplayLabel(101), 'Friendly');
+    });
+  });
+
   group('resolveDiplomacyPhase', () {
     Game _baseGame() {
       return Game(

--- a/packages/colonizethis_logic/test/upsert_relation_test.dart
+++ b/packages/colonizethis_logic/test/upsert_relation_test.dart
@@ -21,6 +21,48 @@ void main() {
       );
       expect(provinceCountOwnedBy(game, 'minor1'), 3);
     });
+
+    test('shipCountForFaction sums shipTypeIds length over owned fleets', () {
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+          fleets: [
+            Fleet(id: 'f1', ownerId: 'gp1', regionId: 'oldWorld', shipTypeIds: ['carrack', 'carrack', 'fluyte']),
+            Fleet(id: 'f2', ownerId: 'gp2', regionId: 'oldWorld', shipTypeIds: ['carrack']),
+          ],
+        ),
+        players: const [],
+      );
+      expect(shipCountForFaction(game, 'gp1'), 3);
+      expect(shipCountForFaction(game, 'gp2'), 1);
+      expect(shipCountForFaction(game, 'gp3'), 0);
+    });
+
+    test('greatPowerPowerScore uses provinces, regiment strength, ships per SPEC', () {
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'oldWorld|p1', regionId: 'oldWorld', ownerId: 'gp1'),
+              Province(id: 'oldWorld|p2', regionId: 'oldWorld', ownerId: 'gp1'),
+            ],
+            units: const [],
+          ),
+          newWorld: const RegionData(),
+          fleets: [
+            Fleet(id: 'f1', ownerId: 'gp1', regionId: 'oldWorld', shipTypeIds: ['carrack']),
+          ],
+        ),
+        players: const [Player(id: 'gp1', displayName: 'GP1', isHuman: false)],
+      );
+      // 2 provinces * 10 + 0 regiment + 1 ship * 5 = 25
+      expect(greatPowerPowerScore(game, 'gp1'), 25);
+    });
     test('inserts new relation when pair absent', () {
       final relations = <DiplomacyRelation>[];
       final result = upsertRelation(relations, 'gp1', 'gp2', (existing) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -460,10 +460,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,9 @@ dev_dependencies:
 
 melos:
   scripts:
+    test_app:
+      description: Run Flutter widget tests for the app (use this, not dart test app/...).
+      run: bash -c "cd app && flutter test"
     generate_map:
       description: End-to-end map generation (topology + tile map + PNG) or load topology. SPEC/program/map-data.md.
       run: dart run generate_map


### PR DESCRIPTION
## Summary

- **Great Power power score:** Absolute score per GP (provinces×10 + regiment strength×1 + ship count×5). Shown on diplomacy panel (app & ctterm); **red** when GP score > player, **green** otherwise. SPEC/game/diplomacy.md § Great Power power score; logic in `colonizethis_logic` (`shipCountForFaction`, `greatPowerPowerScore`); tests in `upsert_relation_test`, `diplomacy_panel_test`.
- **App widget tests:** Run with `flutter test` from app/ or `melos run test_app` (not `dart test app/...`). Added `test_app` melos script; documented in testing rule, AGENTS.md, project-tools.md.

## Base branch

`dev` (latest)

Made with [Cursor](https://cursor.com)