### PR TITLE
fix(ui): province overlay map tap on Android / mobile

### DIFF
--- a/app/lib/features/game/flame/region_map_component.dart
+++ b/app/lib/features/game/flame/region_map_component.dart
@@ -89,6 +89,8 @@ class CtRegionMapComponent extends PositionComponent {
   }
 
   /// Handles a tap at the given world-space position.
+  /// Reports province selection and the tapped tile (so overlay can show tile
+  /// details on mobile where hover is unavailable). SPEC/ui/province-sea-zone-detail-overlay.md.
   void handleTapAtWorld(Vector2 worldPosition) {
     final local = worldPosition - absoluteTopLeftPosition;
     final x = (local.x / cellSize).floor();
@@ -112,6 +114,8 @@ class CtRegionMapComponent extends PositionComponent {
     }
     final provinceId = '${region.regionId}|${cell.regionCellId}';
     onProvinceSelected?.call(provinceId);
+    // So overlay Tile section shows tapped tile on mobile (no hover).
+    onTileHovered?.call(tileKey);
   }
 
   @override

--- a/app/lib/widgets/ct_region_map.dart
+++ b/app/lib/widgets/ct_region_map.dart
@@ -227,7 +227,11 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
 
   @override
   void onTapUp(TapUpInfo info) {
-    final world = info.eventPosition.global;
+    // Use same widget→world conversion as hover so tap works with camera zoom/pan
+    // and on mobile (where hover is unavailable). SPEC/ui/province-sea-zone-detail-overlay.md.
+    final widgetPos = info.eventPosition.widget;
+    final halfView = size / 2;
+    final world = camera.viewfinder.position + (widgetPos - halfView) / _zoom;
     _mapComponent.handleTapAtWorld(world);
     onRegionViewChanged?.call();
   }

--- a/app/test/ct_region_map_test.dart
+++ b/app/test/ct_region_map_test.dart
@@ -24,6 +24,8 @@ void main() {
     CtMapVisibilityMode visibilityMode = CtMapVisibilityMode.full,
     String? centerOnTileKey,
     void Function(String)? onProvinceSelected,
+    void Function(String?)? onProvinceHovered,
+    void Function(String?)? onTileHovered,
     VoidCallback? onRegionViewChanged,
   }) {
     return MaterialApp(
@@ -39,6 +41,8 @@ void main() {
               visibilityMode: visibilityMode,
               centerOnTileKey: centerOnTileKey,
               onProvinceSelected: onProvinceSelected,
+              onProvinceHovered: onProvinceHovered,
+              onTileHovered: onTileHovered,
               onRegionViewChanged: onRegionViewChanged,
             ),
           ),
@@ -344,6 +348,63 @@ void main() {
         await tester.pump();
 
         expect(mapFinder, findsOneWidget);
+      },
+      timeout: const Timeout(Duration(seconds: 5)),
+    );
+
+    testWidgets(
+      'tap on map invokes onProvinceSelected with prefixed province id (mobile/touch)',
+      (WidgetTester tester) async {
+        final region = _oldWorldRegion();
+        String? selectedId;
+        await tester.pumpWidget(
+          _buildCtRegionMap(
+            region: region,
+            onProvinceSelected: (id) => selectedId = id,
+          ),
+        );
+        await tester.pump();
+
+        final mapFinder = find.byType(CtRegionMap);
+        expect(mapFinder, findsOneWidget);
+        await tester.tap(mapFinder);
+        await tester.pump();
+
+        expect(selectedId, isNotNull);
+        expect(selectedId!, startsWith('${region.regionId}|'));
+        expect(selectedId!.split('|').length, 2);
+      },
+      timeout: const Timeout(Duration(seconds: 5)),
+    );
+
+    testWidgets(
+      'tap invokes onTileHovered with tapped tile key so overlay shows tile on mobile',
+      (WidgetTester tester) async {
+        final region = _oldWorldRegion();
+        String? selectedId;
+        String? hoveredTileKey;
+        await tester.pumpWidget(
+          _buildCtRegionMap(
+            region: region,
+            onProvinceSelected: (id) => selectedId = id,
+            onTileHovered: (key) => hoveredTileKey = key,
+          ),
+        );
+        await tester.pump();
+
+        final mapFinder = find.byType(CtRegionMap);
+        expect(mapFinder, findsOneWidget);
+        await tester.tap(mapFinder);
+        await tester.pump();
+
+        expect(selectedId, isNotNull);
+        expect(hoveredTileKey, isNotNull);
+        final parts = hoveredTileKey!.split('|');
+        expect(parts.length, 4);
+        expect(parts[0], region.regionId);
+        expect(parts[1], selectedId!.split('|').last);
+        expect(int.tryParse(parts[2]), isNotNull);
+        expect(int.tryParse(parts[3]), isNotNull);
       },
       timeout: const Timeout(Duration(seconds: 5)),
     );


### PR DESCRIPTION
## Summary
Widgetbook province overlay "With map" scenario: tapping tiles on Android did nothing (province panel did not update) because hover is not available on touch. This adds a mobile-friendly path.

## Changes
- **CtRegionMap**: Tap now uses the same widget→world coordinate conversion as hover (`eventPosition.widget` + camera viewfinder/zoom) instead of `eventPosition.global`, so tap is correct with zoom/pan and on touch devices.
- **CtRegionMapComponent**: On tap, in addition to `onProvinceSelected`, call `onTileHovered(tileKey)` so the overlay Tile section shows the tapped tile (avoids "Hover a tile to see details" on mobile).
- **Tests**: Tap invokes `onProvinceSelected` with prefixed province id; tap invokes `onTileHovered` with tile key when provided.

## Spec
SPEC/ui/province-sea-zone-detail-overlay.md

## Tests
`flutter test test/ct_region_map_test.dart test/province_overlay_test.dart` (and full app suite) pass.

Made with [Cursor](https://cursor.com)