### PR TITLE
refactor(logic): mineral IDs, combat strength, OrderEngine DRY

### DIFF
--- a/packages/colonizethis_logic/lib/src/combat/combat_resolver_probabilistic.dart
+++ b/packages/colonizethis_logic/lib/src/combat/combat_resolver_probabilistic.dart
@@ -232,7 +232,7 @@ List<String> _selectCasualtiesWeighted(
 
   final weights = <double>[];
   for (final u in units) {
-    final s = _unitStrength(u, effectiveEra);
+    final s = unitStrength(u, effectiveEra);
     weights.add(1.0 / (s + 0.1));
   }
   final ids = units.map((u) => u.id).toList();
@@ -255,22 +255,11 @@ List<String> _selectCasualtiesWeighted(
   return chosen;
 }
 
-/// Computes strength for a single unit (used in probabilistic combat).
-double _unitStrength(Unit u, int effectiveEra) {
-  var stats = regimentStatsById(u.type);
-  if (stats == null) return 0.0;
-  if (stats.era > effectiveEra) {
-    stats = downgradeToEra(stats, effectiveEra) ?? stats;
-  }
-  final mult = medalMultiplierFor(u.medals.clamp(0, 4));
-  return (stats.fpn + stats.fpm) * mult;
-}
-
 /// Aggregates strength for a list of units (probabilistic version with helper).
 double _aggregateStrength(List<Unit> units, int effectiveEra) {
   var total = 0.0;
   for (final u in units) {
-    total += _unitStrength(u, effectiveEra);
+    total += unitStrength(u, effectiveEra);
   }
   return total;
 }

--- a/packages/colonizethis_logic/lib/src/combat/military_strength.dart
+++ b/packages/colonizethis_logic/lib/src/combat/military_strength.dart
@@ -23,6 +23,18 @@ RegimentStats? downgradeToEra(RegimentStats stats, int era) {
   return sameCategory.isNotEmpty ? sameCategory.first : null;
 }
 
+/// Computes strength for a single unit using the shared formula.
+/// Public so both deterministic and probabilistic resolvers stay in sync.
+double unitStrength(Unit u, int effectiveEra) {
+  var stats = regimentStatsById(u.type);
+  if (stats == null) return 0.0;
+  if (stats.era > effectiveEra) {
+    stats = downgradeToEra(stats, effectiveEra) ?? stats;
+  }
+  final mult = medalMultiplierFor(u.medals.clamp(0, 4));
+  return (stats.fpn + stats.fpm) * mult;
+}
+
 /// Aggregates military strength for a list of units using the given effective
 /// era. Uses the same formula as auto-resolve: sum of (FPN+FPM)*medalMultiplier
 /// per unit, with era downgrade when unit era exceeds effective era.
@@ -30,13 +42,7 @@ RegimentStats? downgradeToEra(RegimentStats stats, int era) {
 double aggregateStrength(List<Unit> units, int effectiveEra) {
   var total = 0.0;
   for (final u in units) {
-    var stats = regimentStatsById(u.type);
-    if (stats == null) continue;
-    if (stats.era > effectiveEra) {
-      stats = downgradeToEra(stats, effectiveEra) ?? stats;
-    }
-    final mult = medalMultiplierFor(u.medals.clamp(0, 4));
-    total += (stats.fpn + stats.fpm) * mult;
+    total += unitStrength(u, effectiveEra);
   }
   return total;
 }

--- a/packages/colonizethis_logic/lib/src/constants.dart
+++ b/packages/colonizethis_logic/lib/src/constants.dart
@@ -5,6 +5,19 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 const String kRegionOldWorld = 'oldWorld';
 const String kRegionNewWorld = 'newWorld';
 
+/// Shared set of mineral resource ids used across extraction, work orders,
+/// and order application helpers. SPEC/game/resources-and-economy.md.
+const Set<String> kMineralResourceIds = {
+  'iron',
+  'copper',
+  'tin',
+  'coal',
+  'silver',
+  'gold',
+  'gems',
+  'diamonds',
+};
+
 /// Safe player lookup by id. Returns null if not found.
 extension GamePlayerLookup on Game {
   Player? playerById(String id) {

--- a/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
+++ b/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
@@ -65,14 +65,7 @@ Map<String, ExtractionTotals> computeExtraction({
       if (resource == null) continue;
 
       final commodityId = _resourceToCommodityId(resource);
-      final isMineral = commodityId == 'iron' ||
-          commodityId == 'copper' ||
-          commodityId == 'tin' ||
-          commodityId == 'coal' ||
-          commodityId == 'silver' ||
-          commodityId == 'gold' ||
-          commodityId == 'gems' ||
-          commodityId == 'diamonds';
+      final isMineral = kMineralResourceIds.contains(commodityId);
 
       // Minerals only from prospected tiles. SPEC/program/fog-and-exploration-resolution.md.
       if (isMineral && !prospected.contains(tileKey)) {

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -23,6 +23,18 @@ final Logger _log = Logger();
 
 /// Order engine: holds per-player orders, validates in submission order,
 /// exposes projected effects. No world state mutation.
+class _OrderSlot<T> {
+  const _OrderSlot({
+    required this.getter,
+    required this.updater,
+    required this.label,
+  });
+
+  final Map<String, List<T>> Function(Orders) getter;
+  final Orders Function(Orders, Map<String, List<T>>) updater;
+  final String label;
+}
+
 class OrderEngine {
   OrderEngine({
     Orders initialOrders = const Orders(),
@@ -132,122 +144,138 @@ class OrderEngine {
   static Map<String, List<MoveOrder>> _moveOrders(Orders o) =>
       o.moveOrdersByPlayerId;
   static Orders _withMoveOrders(Orders o, Map<String, List<MoveOrder>> m) =>
-      Orders(
-        moveOrdersByPlayerId: m,
-        buildUnitOrdersByPlayerId: o.buildUnitOrdersByPlayerId,
-        workOrdersByPlayerId: o.workOrdersByPlayerId,
-        diplomaticOrdersByPlayerId: o.diplomaticOrdersByPlayerId,
-        researchOrdersByPlayerId: o.researchOrdersByPlayerId,
-        navalMoveOrdersByPlayerId: o.navalMoveOrdersByPlayerId,
-        navalMissionOrdersByPlayerId: o.navalMissionOrdersByPlayerId,
-      );
+      o.copyWith(moveOrdersByPlayerId: m);
 
   static Map<String, List<BuildUnitOrder>> _buildOrders(Orders o) =>
       o.buildUnitOrdersByPlayerId;
   static Orders _withBuildOrders(
           Orders o, Map<String, List<BuildUnitOrder>> m) =>
-      Orders(
-        moveOrdersByPlayerId: o.moveOrdersByPlayerId,
-        buildUnitOrdersByPlayerId: m,
-        workOrdersByPlayerId: o.workOrdersByPlayerId,
-        diplomaticOrdersByPlayerId: o.diplomaticOrdersByPlayerId,
-        researchOrdersByPlayerId: o.researchOrdersByPlayerId,
-        navalMoveOrdersByPlayerId: o.navalMoveOrdersByPlayerId,
-        navalMissionOrdersByPlayerId: o.navalMissionOrdersByPlayerId,
-      );
+      o.copyWith(buildUnitOrdersByPlayerId: m);
 
   static Map<String, List<WorkOrder>> _workOrders(Orders o) =>
       o.workOrdersByPlayerId;
   static Orders _withWorkOrders(Orders o, Map<String, List<WorkOrder>> m) =>
-      Orders(
-        moveOrdersByPlayerId: o.moveOrdersByPlayerId,
-        buildUnitOrdersByPlayerId: o.buildUnitOrdersByPlayerId,
-        workOrdersByPlayerId: m,
-        diplomaticOrdersByPlayerId: o.diplomaticOrdersByPlayerId,
-        researchOrdersByPlayerId: o.researchOrdersByPlayerId,
-        navalMoveOrdersByPlayerId: o.navalMoveOrdersByPlayerId,
-        navalMissionOrdersByPlayerId: o.navalMissionOrdersByPlayerId,
-      );
+      o.copyWith(workOrdersByPlayerId: m);
 
   static Map<String, List<DiplomaticOrder>> _diplomaticOrders(Orders o) =>
       o.diplomaticOrdersByPlayerId;
   static Orders _withDiplomaticOrders(
           Orders o, Map<String, List<DiplomaticOrder>> m) =>
-      Orders(
-        moveOrdersByPlayerId: o.moveOrdersByPlayerId,
-        buildUnitOrdersByPlayerId: o.buildUnitOrdersByPlayerId,
-        workOrdersByPlayerId: o.workOrdersByPlayerId,
-        diplomaticOrdersByPlayerId: m,
-        researchOrdersByPlayerId: o.researchOrdersByPlayerId,
-        navalMoveOrdersByPlayerId: o.navalMoveOrdersByPlayerId,
-        navalMissionOrdersByPlayerId: o.navalMissionOrdersByPlayerId,
-      );
+      o.copyWith(diplomaticOrdersByPlayerId: m);
 
   static Map<String, List<NavalMoveOrder>> _navalMoveOrders(Orders o) =>
       o.navalMoveOrdersByPlayerId;
   static Orders _withNavalMoveOrders(
           Orders o, Map<String, List<NavalMoveOrder>> m) =>
-      Orders(
-        moveOrdersByPlayerId: o.moveOrdersByPlayerId,
-        buildUnitOrdersByPlayerId: o.buildUnitOrdersByPlayerId,
-        workOrdersByPlayerId: o.workOrdersByPlayerId,
-        diplomaticOrdersByPlayerId: o.diplomaticOrdersByPlayerId,
-        researchOrdersByPlayerId: o.researchOrdersByPlayerId,
-        navalMoveOrdersByPlayerId: m,
-        navalMissionOrdersByPlayerId: o.navalMissionOrdersByPlayerId,
-      );
+      o.copyWith(navalMoveOrdersByPlayerId: m);
 
   static Map<String, List<NavalMissionOrder>> _navalMissionOrders(Orders o) =>
       o.navalMissionOrdersByPlayerId;
   static Orders _withNavalMissionOrders(
           Orders o, Map<String, List<NavalMissionOrder>> m) =>
-      Orders(
-        moveOrdersByPlayerId: o.moveOrdersByPlayerId,
-        buildUnitOrdersByPlayerId: o.buildUnitOrdersByPlayerId,
-        workOrdersByPlayerId: o.workOrdersByPlayerId,
-        diplomaticOrdersByPlayerId: o.diplomaticOrdersByPlayerId,
-        researchOrdersByPlayerId: o.researchOrdersByPlayerId,
-        navalMoveOrdersByPlayerId: o.navalMoveOrdersByPlayerId,
-        navalMissionOrdersByPlayerId: m,
-      );
+      o.copyWith(navalMissionOrdersByPlayerId: m);
 
   // -- Public add/remove methods --
 
-  OrderValidationResult addMoveOrder(String playerId, MoveOrder order) {
-    _appendOrder(playerId, order, _moveOrders, _withMoveOrders);
+  static const _OrderSlot<MoveOrder> _moveSlot = _OrderSlot<MoveOrder>(
+    getter: _moveOrders,
+    updater: _withMoveOrders,
+    label: 'move',
+  );
+
+  static const _OrderSlot<BuildUnitOrder> _buildSlot =
+      _OrderSlot<BuildUnitOrder>(
+    getter: _buildOrders,
+    updater: _withBuildOrders,
+    label: 'build',
+  );
+
+  static const _OrderSlot<WorkOrder> _workSlot = _OrderSlot<WorkOrder>(
+    getter: _workOrders,
+    updater: _withWorkOrders,
+    label: 'work',
+  );
+
+  static const _OrderSlot<DiplomaticOrder> _diplomaticSlot =
+      _OrderSlot<DiplomaticOrder>(
+    getter: _diplomaticOrders,
+    updater: _withDiplomaticOrders,
+    label: 'diplomatic',
+  );
+
+  static const _OrderSlot<NavalMoveOrder> _navalMoveSlot =
+      _OrderSlot<NavalMoveOrder>(
+    getter: _navalMoveOrders,
+    updater: _withNavalMoveOrders,
+    label: 'naval move',
+  );
+
+  static const _OrderSlot<NavalMissionOrder> _navalMissionSlot =
+      _OrderSlot<NavalMissionOrder>(
+    getter: _navalMissionOrders,
+    updater: _withNavalMissionOrders,
+    label: 'naval mission',
+  );
+
+  OrderValidationResult _addOrder<T>(
+    String playerId,
+    T order,
+    _OrderSlot<T> slot,
+  ) {
+    _appendOrder(playerId, order, slot.getter, slot.updater);
     return const OrderValidationResult(status: OrderValidationStatus.accepted);
   }
+
+  OrderValidationResult _addOrderWithContextSlot<T>(
+    Game game,
+    MapTopology topology,
+    String playerId,
+    T order,
+    _OrderSlot<T> slot,
+  ) {
+    return _addOrderWithContext(
+      game,
+      topology,
+      playerId,
+      order,
+      slot.getter,
+      slot.updater,
+      slot.label,
+    );
+  }
+
+  void _removeOrderAtSlot<T>(
+    String playerId,
+    int index,
+    _OrderSlot<T> slot,
+  ) {
+    _removeOrderAt(playerId, index, slot.getter, slot.updater);
+  }
+
+  OrderValidationResult addMoveOrder(String playerId, MoveOrder order) =>
+      _addOrder(playerId, order, _moveSlot);
 
   OrderValidationResult addMoveOrderWithContext(
           Game game, MapTopology topology, String playerId, MoveOrder order) =>
-      _addOrderWithContext(game, topology, playerId, order, _moveOrders,
-          _withMoveOrders, 'move');
+      _addOrderWithContextSlot(game, topology, playerId, order, _moveSlot);
 
-  OrderValidationResult addBuildOrder(String playerId, BuildUnitOrder order) {
-    _appendOrder(playerId, order, _buildOrders, _withBuildOrders);
-    return const OrderValidationResult(status: OrderValidationStatus.accepted);
-  }
+  OrderValidationResult addBuildOrder(String playerId, BuildUnitOrder order) =>
+      _addOrder(playerId, order, _buildSlot);
 
   OrderValidationResult addBuildOrderWithContext(Game game,
           MapTopology topology, String playerId, BuildUnitOrder order) =>
-      _addOrderWithContext(game, topology, playerId, order, _buildOrders,
-          _withBuildOrders, 'build');
+      _addOrderWithContextSlot(game, topology, playerId, order, _buildSlot);
 
-  OrderValidationResult addWorkOrder(String playerId, WorkOrder order) {
-    _appendOrder(playerId, order, _workOrders, _withWorkOrders);
-    return const OrderValidationResult(status: OrderValidationStatus.accepted);
-  }
+  OrderValidationResult addWorkOrder(String playerId, WorkOrder order) =>
+      _addOrder(playerId, order, _workSlot);
 
   OrderValidationResult addWorkOrderWithContext(
           Game game, MapTopology topology, String playerId, WorkOrder order) =>
-      _addOrderWithContext(game, topology, playerId, order, _workOrders,
-          _withWorkOrders, 'work');
+      _addOrderWithContextSlot(game, topology, playerId, order, _workSlot);
 
   OrderValidationResult addDiplomaticOrder(
-      String playerId, DiplomaticOrder order) {
-    _appendOrder(playerId, order, _diplomaticOrders, _withDiplomaticOrders);
-    return const OrderValidationResult(status: OrderValidationStatus.accepted);
-  }
+          String playerId, DiplomaticOrder order) =>
+      _addOrder(playerId, order, _diplomaticSlot);
 
   OrderValidationResult addDiplomaticOrderWithContext(
     Game game,
@@ -255,46 +283,50 @@ class OrderEngine {
     String playerId,
     DiplomaticOrder order,
   ) =>
-      _addOrderWithContext(
+      _addOrderWithContextSlot(
         game,
         topology,
         playerId,
         order,
-        _diplomaticOrders,
-        _withDiplomaticOrders,
-        'diplomatic',
+        _diplomaticSlot,
       );
 
   OrderValidationResult addNavalMoveOrder(
-      String playerId, NavalMoveOrder order) {
-    _appendOrder(playerId, order, _navalMoveOrders, _withNavalMoveOrders);
-    return const OrderValidationResult(status: OrderValidationStatus.accepted);
-  }
+          String playerId, NavalMoveOrder order) =>
+      _addOrder(playerId, order, _navalMoveSlot);
 
   OrderValidationResult addNavalMoveOrderWithContext(Game game,
           MapTopology topology, String playerId, NavalMoveOrder order) =>
-      _addOrderWithContext(game, topology, playerId, order, _navalMoveOrders,
-          _withNavalMoveOrders, 'naval move');
+      _addOrderWithContextSlot(
+        game,
+        topology,
+        playerId,
+        order,
+        _navalMoveSlot,
+      );
 
   OrderValidationResult addNavalMissionOrder(
-      String playerId, NavalMissionOrder order) {
-    _appendOrder(playerId, order, _navalMissionOrders, _withNavalMissionOrders);
-    return const OrderValidationResult(status: OrderValidationStatus.accepted);
-  }
+          String playerId, NavalMissionOrder order) =>
+      _addOrder(playerId, order, _navalMissionSlot);
 
   OrderValidationResult addNavalMissionOrderWithContext(Game game,
           MapTopology topology, String playerId, NavalMissionOrder order) =>
-      _addOrderWithContext(game, topology, playerId, order, _navalMissionOrders,
-          _withNavalMissionOrders, 'naval mission');
+      _addOrderWithContextSlot(
+        game,
+        topology,
+        playerId,
+        order,
+        _navalMissionSlot,
+      );
 
   void removeMoveOrder(String playerId, int index) =>
-      _removeOrderAt(playerId, index, _moveOrders, _withMoveOrders);
+      _removeOrderAtSlot(playerId, index, _moveSlot);
 
   void removeBuildOrder(String playerId, int index) =>
-      _removeOrderAt(playerId, index, _buildOrders, _withBuildOrders);
+      _removeOrderAtSlot(playerId, index, _buildSlot);
 
   void removeWorkOrder(String playerId, int index) =>
-      _removeOrderAt(playerId, index, _workOrders, _withWorkOrders);
+      _removeOrderAtSlot(playerId, index, _workSlot);
 
   /// Validates with full context. Call this when Game and topology available.
   List<OrderValidationResult> validatePlayerOrdersWithContext(

--- a/packages/colonizethis_logic/lib/src/orders/orders_application_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_helpers.dart
@@ -1,6 +1,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../constants.dart';
+
 /// Helpers for order application. SPEC/program/orders.md, development-resolution.
 /// Used by orders_application for work and build phases.
 
@@ -38,15 +40,5 @@ bool isMineralEligibleTile(
   if (resourceId == null || resourceId.isEmpty) {
     return false;
   }
-  const mineralIds = {
-    'iron',
-    'copper',
-    'tin',
-    'coal',
-    'silver',
-    'gold',
-    'gems',
-    'diamonds',
-  };
-  return mineralIds.contains(resourceId);
+  return kMineralResourceIds.contains(resourceId);
 }

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../../constants.dart';
 import '../../world/player_view.dart';
 import '../../world/province_lookup.dart';
 import '../../world/tile_control.dart';
@@ -176,11 +177,7 @@ class WorkOrderValidator {
           reason: 'Tile has no resource',
         );
       }
-      const mineralIds = {
-        'iron', 'copper', 'tin', 'coal',
-        'silver', 'gold', 'gems', 'diamonds',
-      };
-      if (mineralIds.contains(resourceId)) {
+      if (kMineralResourceIds.contains(resourceId)) {
         final prospected =
             _game.worldState.playerProspectedTiles[_playerId] ?? const <String>{};
         if (!prospected.contains(o.targetTileKey)) {


### PR DESCRIPTION
Three refactors in `colonizethis_logic` (refactor → test each round):

1. **Mineral resource IDs**
   - `kMineralResourceIds` in `constants.dart`; used in `orders_application_helpers`, `work_order_validator`, `resource_extractor`.

2. **Combat strength**
   - `unitStrength(Unit, int)` in `military_strength.dart`; `aggregateStrength` uses it; probabilistic resolver uses `unitStrength` for aggregate and casualty weighting.

3. **OrderEngine**
   - `_withXxxOrders` use `Orders.copyWith`; `_OrderSlot<T>` + generic `_addOrder` / `_addOrderWithContextSlot` / `_removeOrderAtSlot`; public add/remove methods delegate to slots.

Merged latest `dev`; conflicts resolved in `constants.dart` and `work_order_validator.dart` (kept `shortCircuitIfPreviousRejected` from dev and `kMineralResourceIds` usage).
`dart test packages/colonizethis_logic` passes.

Made with [Cursor](https://cursor.com)