### PR TITLE
refactor(logic,ai): constants for subsidy boost, spy tech steal, dossier bands

### DIFF
--- a/packages/colonizethis_ai/lib/src/dossier.dart
+++ b/packages/colonizethis_ai/lib/src/dossier.dart
@@ -5,13 +5,27 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 /// Suspicion band for display. Never exposes true agenda.
+/// Bands defined by [dossierScoreUnknownMax], [dossierScorePossibleMax], etc. SPEC/ai/ai-dossier.md.
 enum SuspicionBand {
-  unknown,   // 0–2
-  possible, // 3–5
-  likely,   // 6–8
-  almostCertain, // 9–10
-  confirmed, // 10+
+  unknown,   // 0–dossierScoreUnknownMax
+  possible, // dossierScoreUnknownMax+1 – dossierScorePossibleMax
+  likely,   // dossierScorePossibleMax+1 – dossierScoreLikelyMax
+  almostCertain, // dossierScoreLikelyMax+1 – dossierScoreAlmostCertainMax
+  confirmed, // dossierScoreAlmostCertainMax+1+
 }
+
+/// Score band thresholds for suspicion (inclusive max per band). SPEC/ai/ai-dossier.md.
+const int dossierScoreUnknownMax = 2;
+const int dossierScorePossibleMax = 5;
+const int dossierScoreLikelyMax = 8;
+const int dossierScoreAlmostCertainMax = 10;
+
+/// Confidence percent for display per band (unknown→0, possible→25, likely→60, almostCertain→85, confirmed→100).
+const int dossierConfidenceUnknown = 0;
+const int dossierConfidencePossible = 25;
+const int dossierConfidenceLikely = 60;
+const int dossierConfidenceAlmostCertain = 85;
+const int dossierConfidenceConfirmed = 100;
 
 /// Relative strength for basic intel (observer vs subject).
 enum RelativeStrength {
@@ -70,22 +84,22 @@ class DossierView {
   final List<String> timeline;
 }
 
-/// Returns suspicion band for a raw score (0–2 unknown, 3–5 possible, etc.).
+/// Returns suspicion band for a raw score (0–2 unknown, 3–5 possible, etc.). SPEC/ai/ai-dossier.md.
 SuspicionBand suspicionBandFromScore(int score) {
-  if (score <= 2) return SuspicionBand.unknown;
-  if (score <= 5) return SuspicionBand.possible;
-  if (score <= 8) return SuspicionBand.likely;
-  if (score <= 10) return SuspicionBand.almostCertain;
+  if (score <= dossierScoreUnknownMax) return SuspicionBand.unknown;
+  if (score <= dossierScorePossibleMax) return SuspicionBand.possible;
+  if (score <= dossierScoreLikelyMax) return SuspicionBand.likely;
+  if (score <= dossierScoreAlmostCertainMax) return SuspicionBand.almostCertain;
   return SuspicionBand.confirmed;
 }
 
 /// Confidence % for display from raw suspicion score. SPEC/ai/ai-dossier.md bands.
 int confidencePercentFromScore(int score) {
-  if (score <= 2) return 0;
-  if (score <= 5) return 25;
-  if (score <= 8) return 60;
-  if (score <= 10) return 85;
-  return 100;
+  if (score <= dossierScoreUnknownMax) return dossierConfidenceUnknown;
+  if (score <= dossierScorePossibleMax) return dossierConfidencePossible;
+  if (score <= dossierScoreLikelyMax) return dossierConfidenceLikely;
+  if (score <= dossierScoreAlmostCertainMax) return dossierConfidenceAlmostCertain;
+  return dossierConfidenceConfirmed;
 }
 
 Player? _player(Game game, String playerId) {

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
@@ -87,6 +87,11 @@ const int relationScoreWarDelta = 10;
 /// Suggested grant/subsidy amount for AI order suggestion when GP has embassy/consulate.
 const int suggestedGrantOrSubsidyAmount = 100;
 
+/// Subsidy relation boost: +[subsidyBoostRelationPerStep] per [subsidyBoostDucatsPerStep] ducats, cap [subsidyBoostMax].
+const int subsidyBoostDucatsPerStep = 500;
+const int subsidyBoostRelationPerStep = 2;
+const int subsidyBoostMax = 8;
+
 /// Relation score thresholds for level. 0–25 Hostile, 26–50 Neutral, 51–75 Friendly, 76–100 Allied.
 RelationLevel scoreToLevel(int score) {
   if (score <= relationScoreLevelHostileMax) return RelationLevel.hostile;

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -720,8 +720,9 @@ Game _processOngoingSubsidies(Game game, int turn) {
           .copyWith(treasury: players[payerIdx].treasury - amount);
     }
 
-    // Calculate relation boost: +2 per 500 ducats, max +8
-    final boost = ((amount ~/ 500) * 2).clamp(0, 8);
+    // Calculate relation boost: +subsidyBoostRelationPerStep per subsidyBoostDucatsPerStep ducats, max subsidyBoostMax
+    final boost = ((amount ~/ subsidyBoostDucatsPerStep) * subsidyBoostRelationPerStep)
+        .clamp(0, subsidyBoostMax);
 
     // Apply relation boost (only for Minors/Tribes - GPs get treasury transfer)
     if (isMinorOrTribe(game, targetId)) {

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -21,6 +21,9 @@ final Logger _log = Logger();
 const int counterSpyKillChancePercentPerSpy = 5;
 const int counterSpyKillChanceCapPercent = 30;
 
+/// Per-turn chance (0–1) that a spy on steal_tech work successfully steals one tech from target.
+const double spyTechStealChance = 0.08;
+
 /// Order application helpers for build and work phases.
 /// SPEC/program/orders.md
 
@@ -456,7 +459,7 @@ Game applyBuildAndWorkOrders(
                 .where((e) => e.value == true && ourTech[e.key] != true)
                 .map((e) => e.key)
                 .toList();
-            if (missing.isNotEmpty && rand.nextDouble() < 0.08) {
+            if (missing.isNotEmpty && rand.nextDouble() < spyTechStealChance) {
               final granted = missing[rand.nextInt(missing.length)];
               final player = s.game.players
                   .where((p) => p.id == u.ownerId)


### PR DESCRIPTION
## Summary
Replaces more hardcoded values with named constants (refactor → test). Follow-up constant refactoring.

### 1. Subsidy relation boost (logic)
- **File:** `packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart`
- Added: `subsidyBoostDucatsPerStep = 500`, `subsidyBoostRelationPerStep = 2`, `subsidyBoostMax = 8`
- **Updated:** `diplomacy_resolver.dart` uses these when computing relation boost from subsidy amount (was `(amount ~/ 500) * 2` clamped to 8).

### 2. Spy tech steal chance (logic)
- **File:** `packages/colonizethis_logic/lib/src/orders/orders_application.dart`
- Added: `spyTechStealChance = 0.08`
- Spy `steal_tech` work order now uses this constant instead of literal `0.08`.

### 3. Dossier suspicion bands (ai)
- **File:** `packages/colonizethis_ai/lib/src/dossier.dart`
- Added: score band thresholds `dossierScoreUnknownMax`, `dossierScorePossibleMax`, `dossierScoreLikelyMax`, `dossierScoreAlmostCertainMax` (2, 5, 8, 10) and confidence constants `dossierConfidenceUnknown`, `dossierConfidencePossible`, `dossierConfidenceLikely`, `dossierConfidenceAlmostCertain`, `dossierConfidenceConfirmed` (0, 25, 60, 85, 100).
- `suspicionBandFromScore()` and `confidencePercentFromScore()` use these. SPEC: `SPEC/ai/ai-dossier.md`.

### Tests
- Logic: full suite (720 tests) passed.
- AI: `dossier_test.dart` (15 tests) passed.

Made with [Cursor](https://cursor.com)