### PR TITLE
feat(ui): align civilian units panel bottom sheet and stories

### DIFF
--- a/SPEC/ui/civilian-units-panel.md
+++ b/SPEC/ui/civilian-units-panel.md
@@ -21,8 +21,9 @@ The civilian units panel gives the player a single place to see every civilian u
 ## Panel placement and opening
 
 - **Access:** The panel is opened from the in-game shell **toolbar**, in the same way as the Production panel (e.g. a toolbar button such as "Civilian Units" or "Units" that opens the panel).
-- **Desktop / wide viewport:** Panel appears as a side panel (e.g. right side) or bottom sheet so the map remains visible. Max height or scroll so content fits.
-- **Mobile / narrow viewport:** Panel appears as a bottom sheet or full-width overlay so it is usable on small screens. See [mobile-adaptation.md](mobile-adaptation.md) for touch targets.
+- **Presentation:** The panel **appears from the bottom** as a **bottom sheet** that slides up from the bottom edge (same pattern as the province/sea zone detail overlay on narrow viewports; see [province-sea-zone-detail-overlay.md](province-sea-zone-detail-overlay.md)). This applies on both desktop and narrow viewports so behaviour is consistent and the map remains visible above.
+- **Max height:** Bottom sheet is constrained (e.g. up to one-third of screen height on narrow, or similar cap on wide) so the map stays visible; content scrolls inside the sheet.
+- **Mobile / narrow viewport:** Same bottom-sheet presentation; touch targets per [mobile-adaptation.md](mobile-adaptation.md).
 
 ---
 
@@ -88,7 +89,7 @@ For each civilian unit, the panel shows:
 
 - **Given** the panel is displayed, **when** there are civilian units in more than one region, **then** the UI layer groups units by region with a region heading for each group and lists units within each group in a stable order (e.g. by province name, then unit type, then unit id).
 
-- **Given** the user opens the Civilian Units panel on a narrow viewport (e.g. width < 600 dp), **when** the panel is displayed, **then** the UI layer presents the panel in a layout appropriate for mobile (e.g. bottom sheet or full-width overlay) per [mobile-adaptation.md](mobile-adaptation.md).
+- **Given** the user opens the Civilian Units panel, **when** the panel is displayed, **then** the UI layer presents it as a **bottom sheet** that appears from the bottom edge (slides up), so the map remains visible above; on narrow viewports layout and touch targets follow [mobile-adaptation.md](mobile-adaptation.md).
 
 - **Given** the Civilian Units panel is open and a unit has `Unit.status == idle` and no pending work order for the human player this turn, **when** the user views that unit's row, **then** the UI layer shows an **Assign** button (or equivalent control).
 
@@ -116,7 +117,9 @@ For each civilian unit, the panel shows:
 ## Widgetbook
 
 - **Standalone story:** A Widgetbook use case shows the Civilian Units panel **standalone** (panel only, no map). Uses demo data (e.g. a game with a subset of civilian units) so the list, grouping, status, location (province name + region), and assigned-to content can be reviewed in isolation.
-- **With map story:** A Widgetbook use case shows the Civilian Units panel **in tandem with the map** using a **real generated map and initialized game** (e.g. `getDebugInitGameResult()`). The story demonstrates: opening the panel; listing units grouped by region with province name and region; clicking a unit to highlight and pan/center the map and switch region tab; **Assign** for an idle unit (order menu → select order → map shows valid tiles with subtle glow → click valid tile to assign or click elsewhere to cancel); **Cancel** for a unit with work (confirm dialog → confirm to cancel pending or in-progress work).
+- **With map story:** A Widgetbook use case shows the Civilian Units panel **in tandem with the map** with the panel **at the bottom** (same placement as province overlay "With map"): map above, panel below in a column, using a real generated map and initialized game (e.g. `getDebugInitGameResult()`). The story demonstrates: listing units grouped by region with province name and region; clicking a unit to highlight and pan/center the map and switch region tab; **Assign** and **Cancel** flows.
+- **As bottom sheet story:** A Widgetbook use case shows a toolbar button that opens the Civilian Units panel as a **modal bottom sheet** (slide up from the bottom), matching in-game shell behaviour.
 - **Acceptance criteria (Widgetbook):**
   - **Given** the Widgetbook "Civilian Units Panel" folder is open, **when** the user selects the "Standalone" use case, **then** the UI layer displays only the Civilian Units panel (no map) with demo data, so that layout and row content (status, location as province name + region, assigned-to) can be verified.
-  - **Given** the Widgetbook "Civilian Units Panel" folder is open, **when** the user selects the "With map" use case, **then** the UI layer displays the panel alongside a map built from a real generated map and initialized game (`getDebugInitGameResult()`), and the user can locate units, assign work (order menu → valid tiles glow → tile click to assign or click elsewhere to cancel), and cancel work (confirm dialog) so that the full assign/cancel flow is demonstrable with a real game and map.
+  - **Given** the Widgetbook "Civilian Units Panel" folder is open, **when** the user selects the "With map" use case, **then** the UI layer displays the map above and the Civilian Units panel **at the bottom** (bottom placement like province overlay), built from a real generated map and initialized game (`getDebugInitGameResult()`), and the user can locate units, assign work, and cancel work so that the full flow is demonstrable.
+  - **Given** the Widgetbook "Civilian Units Panel" folder is open, **when** the user selects the "As bottom sheet" use case and taps the button, **then** the panel opens as a bottom sheet that slides up from the bottom edge.

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -266,31 +266,41 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
                   final orders = ref.read(currentOrdersProvider);
                   showModalBottomSheet<void>(
                     context: context,
-                    builder: (ctx) => CivilianUnitsPanel(
-                      game: ref.read(currentGameProvider) ?? widget.game,
-                      humanPlayerId: _humanPlayerId,
-                      currentOrders: orders,
-                      onLocateUnit: _onLocateCivilianUnit,
-                      onRemoveWorkOrder: (playerId, index) {
-                        final o = ref.read(currentOrdersProvider);
-                        final list = List<ct_models.WorkOrder>.from(
-                          o.workOrdersByPlayerId[playerId] ?? [],
-                        )..removeAt(index);
-                        ref.read(currentOrdersProvider.notifier).state =
-                            o.copyWith(
-                          workOrdersByPlayerId: {
-                            ...o.workOrdersByPlayerId,
-                            playerId: list
+                    isScrollControlled: true,
+                    builder: (ctx) {
+                      final isNarrow =
+                          MediaQuery.sizeOf(ctx).width < 600;
+                      final maxHeight = MediaQuery.sizeOf(ctx).height *
+                          (isNarrow ? 0.33 : 0.5);
+                      return ConstrainedBox(
+                        constraints: BoxConstraints(maxHeight: maxHeight),
+                        child: CivilianUnitsPanel(
+                          game: ref.read(currentGameProvider) ?? widget.game,
+                          humanPlayerId: _humanPlayerId,
+                          currentOrders: orders,
+                          onLocateUnit: _onLocateCivilianUnit,
+                          onRemoveWorkOrder: (playerId, index) {
+                            final o = ref.read(currentOrdersProvider);
+                            final list = List<ct_models.WorkOrder>.from(
+                              o.workOrdersByPlayerId[playerId] ?? [],
+                            )..removeAt(index);
+                            ref.read(currentOrdersProvider.notifier).state =
+                                o.copyWith(
+                              workOrdersByPlayerId: {
+                                ...o.workOrdersByPlayerId,
+                                playerId: list
+                              },
+                            );
                           },
-                        );
-                      },
-                      onCancelUnitWork: _cancelUnitWork,
-                      onStartWorkTargetSelection: (unit, workTarget) {
-                        Navigator.of(ctx).pop();
-                        setState(() => _workTargetSelection =
-                            (unit: unit, workTarget: workTarget));
-                      },
-                    ),
+                          onCancelUnitWork: _cancelUnitWork,
+                          onStartWorkTargetSelection: (unit, workTarget) {
+                            Navigator.of(ctx).pop();
+                            setState(() => _workTargetSelection =
+                                (unit: unit, workTarget: workTarget));
+                          },
+                        ),
+                      );
+                    },
                   );
                 },
                 icon: const Icon(Icons.people_outline, size: 20),

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -283,6 +283,10 @@ List<WidgetbookNode> get civilianUnitsPanelDirectories => [
             name: 'With map',
             builder: (context) => const _CivilianPanelWithMapStory(),
           ),
+          WidgetbookUseCase(
+            name: 'As bottom sheet',
+            builder: (context) => const _CivilianPanelAsBottomSheetStory(),
+          ),
         ],
       ),
     ];
@@ -717,69 +721,65 @@ class _CivilianPanelWithMapStoryState
         : baseResult.mapViewData;
     final region =
         _regionIndex == 0 ? mapViewData.oldWorld : mapViewData.newWorld;
+    // Panel at bottom, like province overlay "With map" story. SPEC/ui/civilian-units-panel.md.
+    const panelHeight = 220.0;
     return SizedBox(
       width: 900,
       height: 550,
-      child: Row(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Expanded(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: Wrap(
+              spacing: 8,
+              runSpacing: 4,
               children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 8),
-                  child: Wrap(
-                    spacing: 8,
-                    runSpacing: 4,
-                    children: [
-                      ChoiceChip(
-                        label: const Text('Old World'),
-                        selected: _regionIndex == 0,
-                        onSelected: (_) => setState(() => _regionIndex = 0),
-                      ),
-                      ChoiceChip(
-                        label: const Text('New World'),
-                        selected: _regionIndex == 1,
-                        onSelected: (_) => setState(() => _regionIndex = 1),
-                      ),
-                      ChoiceChip(
-                        label: const Text('Full visibility'),
-                        selected: _visibilityMode == CtMapVisibilityMode.full,
-                        onSelected: (_) => setState(
-                            () => _visibilityMode = CtMapVisibilityMode.full),
-                      ),
-                      ChoiceChip(
-                        label: const Text('Player-constrained'),
-                        selected: _visibilityMode ==
-                            CtMapVisibilityMode.playerConstrained,
-                        onSelected: (_) => setState(() => _visibilityMode =
-                            CtMapVisibilityMode.playerConstrained),
-                      ),
-                    ],
-                  ),
+                ChoiceChip(
+                  label: const Text('Old World'),
+                  selected: _regionIndex == 0,
+                  onSelected: (_) => setState(() => _regionIndex = 0),
                 ),
-                Expanded(
-                  child: CtRegionMap(
-                    region: region,
-                    cellSizePx: 24,
-                    visibilityMode: _visibilityMode,
-                    onProvinceSelected: (_) {},
-                    highlightedTileKey: _highlightedTileKey,
-                    centerOnTileKey: _centerOnTileKey,
-                    validTileKeys: _validTileKeys,
-                    onTileSelected: _workTargetSelection != null
-                        ? _onTileSelectedForWork
-                        : null,
-                    onWorkTargetSelectionCancelled: _workTargetSelection != null
-                        ? () => setState(() => _workTargetSelection = null)
-                        : null,
-                  ),
+                ChoiceChip(
+                  label: const Text('New World'),
+                  selected: _regionIndex == 1,
+                  onSelected: (_) => setState(() => _regionIndex = 1),
+                ),
+                ChoiceChip(
+                  label: const Text('Full visibility'),
+                  selected: _visibilityMode == CtMapVisibilityMode.full,
+                  onSelected: (_) => setState(
+                      () => _visibilityMode = CtMapVisibilityMode.full),
+                ),
+                ChoiceChip(
+                  label: const Text('Player-constrained'),
+                  selected: _visibilityMode ==
+                      CtMapVisibilityMode.playerConstrained,
+                  onSelected: (_) => setState(() => _visibilityMode =
+                      CtMapVisibilityMode.playerConstrained),
                 ),
               ],
             ),
           ),
+          Expanded(
+            child: CtRegionMap(
+              region: region,
+              cellSizePx: 24,
+              visibilityMode: _visibilityMode,
+              onProvinceSelected: (_) {},
+              highlightedTileKey: _highlightedTileKey,
+              centerOnTileKey: _centerOnTileKey,
+              validTileKeys: _validTileKeys,
+              onTileSelected: _workTargetSelection != null
+                  ? _onTileSelectedForWork
+                  : null,
+              onWorkTargetSelectionCancelled: _workTargetSelection != null
+                  ? () => setState(() => _workTargetSelection = null)
+                  : null,
+            ),
+          ),
           SizedBox(
-            width: 360,
+            height: panelHeight,
             child: CivilianUnitsPanel(
               game: _game,
               humanPlayerId: _humanPlayerId,
@@ -805,6 +805,63 @@ class _CivilianPanelWithMapStoryState
                 setState(() => _workTargetSelection =
                     (unit: unit, workTarget: workTarget));
               },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Civilian Units Panel opened as bottom sheet (slide up from bottom). SPEC/ui/civilian-units-panel.md.
+class _CivilianPanelAsBottomSheetStory extends StatelessWidget {
+  const _CivilianPanelAsBottomSheetStory();
+
+  @override
+  Widget build(BuildContext context) {
+    final result = getDebugInitGameResult();
+    final game = result.game;
+    final humanPlayerId =
+        game.players.isNotEmpty ? game.players.first.id : 'gp1';
+    return SizedBox(
+      width: 600,
+      height: 400,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: TextButton.icon(
+              onPressed: () {
+                showModalBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  builder: (ctx) {
+                    final maxHeight =
+                        MediaQuery.sizeOf(ctx).height * 0.5;
+                    return ConstrainedBox(
+                      constraints: BoxConstraints(maxHeight: maxHeight),
+                      child: CivilianUnitsPanel(
+                        game: game,
+                        humanPlayerId: humanPlayerId,
+                      ),
+                    );
+                  },
+                );
+              },
+              icon: const Icon(Icons.people_outline, size: 20),
+              label: const Text('Civilian Units'),
+            ),
+          ),
+          const Expanded(
+            child: ColoredBox(
+              color: Color(0xFFE0E0E0),
+              child: Center(
+                child: Text(
+                  'Tap button to open panel from bottom',
+                  style: TextStyle(color: Color(0xFF616161)),
+                ),
+              ),
             ),
           ),
         ],


### PR DESCRIPTION
## Summary
- Align `SPEC/ui/civilian-units-panel.md` with bottom-sheet behaviour: civilian units panel always appears from the bottom, with height caps matching the province/sea zone detail overlay.
- Update in-game shell to open the civilian units panel as a constrained bottom sheet (33% height on narrow, 50% on wide) so the map remains visible above.
- Rework Widgetbook civilian panel stories so the "With map" story shows the panel at the bottom (like the province overlay) and add an "As bottom sheet" story that demonstrates the slide-up modal behaviour.

## Test plan
- `cd app && flutter test test/civilian_units_panel_test.dart`
  - Confirms panel layout, empty state, grouping, assign/cancel flows, and scrollability still pass.

Made with [Cursor](https://cursor.com)