### PR TITLE
fix(ui): map visibility taps and unrevealed overlay

### DIFF
--- a/SPEC/ui/map-widget.md
+++ b/SPEC/ui/map-widget.md
@@ -85,11 +85,11 @@ The map widget supports two visibility modes that determine how each tile is ren
 
 When the widget is in **full visibility mode**, it renders the base layer exactly as today (terrain, resources, improvements, roads, capitals, borders) and does not consider visibility.
 
-When the widget is in **player-constrained visibility mode**, it maps `CellViewData.visibility` to rendering as follows:
+When the widget is in **player-constrained visibility mode**, it maps `CellViewData.visibility` to rendering and interaction as follows:
 
 - **`visible`:** The tile is rendered unmodified (full terrain color, resource/improvement/road letters, and borders).
 - **`fogged`:** The tile is rendered with the same content as `visible` but visually muted:
-  - The base terrain color is blended towards gray or covered with a semi-transparent gray overlay.
+  - The base terrain color is blended towards a **darker gray or black** with a consistent opacity factor (e.g. at least 60% of the way towards black) so fogged tiles are noticeably darker than fully visible tiles.
   - Resource/improvement/road letters remain readable but appear on the muted background.
 - **`unrevealed`:** The tile is rendered as a solid black square:
   - No terrain color or letters are shown.
@@ -98,7 +98,7 @@ When the widget is in **player-constrained visibility mode**, it maps `CellViewD
 Hover, selection, and overlay behavior:
 
 - Hover selector and province-border glow only apply to tiles that are not `unrevealed`.
-- Province selection callbacks (`onProvinceSelected`, `onProvinceHovered`) are not invoked for `unrevealed` tiles.
+- Province selection callbacks (`onProvinceSelected`, `onProvinceHovered`) **are invoked** for taps/clicks on tiles whose visibility is `visible`, `fogged`, or `unrevealed`; it is the responsibility of the overlay (see `SPEC/ui/province-sea-zone-detail-overlay.md`) to obfuscate data for fully unrevealed provinces/tiles.
 
 ---
 
@@ -132,7 +132,7 @@ Hover, selection, and overlay behavior:
 - **Given** a map widget with `CellViewData.visibility` populated and the visibility mode set to **full**, **when** the widget renders tiles, **then** tiles whose visibility is `visible`, `fogged`, or `unrevealed` are all drawn as fully visible (no gray or black masking is applied based on visibility).
 - **Given** a map widget with `CellViewData.visibility` populated and the visibility mode set to **player-constrained**, **when** the widget renders a tile whose visibility is `visible`, **then** the tile is drawn identically to the current base behavior (full terrain color and overlays).
 - **Given** a map widget with `CellViewData.visibility` populated and the visibility mode set to **player-constrained**, **when** the widget renders a tile whose visibility is `fogged`, **then** the tile is drawn with the same terrain and overlays as `visible` tiles but with a consistent gray/opacity effect applied so the tile appears muted.
-- **Given** a map widget with `CellViewData.visibility` populated and the visibility mode set to **player-constrained**, **when** the widget renders a tile whose visibility is `unrevealed`, **then** the tile area is drawn as solid black, no terrain or resource/improvement/road letters are shown, and hover/selection callbacks are not fired for that tile.
+- **Given** a map widget with `CellViewData.visibility` populated and the visibility mode set to **player-constrained**, **when** the widget renders a tile whose visibility is `unrevealed`, **then** the tile area is drawn as solid black, no terrain or resource/improvement/road letters are shown, and hover callbacks are not fired for that tile while tap/click selection still invokes province-selection callbacks.
 
 - **Given** the map widget is in work target selection mode (non-null **validTileKeys** and **onTileSelected** provided), **when** the widget renders a tile whose key is in **validTileKeys** and in the current region, **then** that tile is drawn with a subtle glow (overlay or outline). When the user taps a tile in **validTileKeys**, **then** the widget invokes **onTileSelected** with that tile key; when the user taps a tile not in **validTileKeys** or empty area, **then** the widget does not invoke **onTileSelected**.
 

--- a/SPEC/ui/province-sea-zone-detail-overlay.md
+++ b/SPEC/ui/province-sea-zone-detail-overlay.md
@@ -43,6 +43,18 @@ When the user hovers a tile on the map (with overlay open), this section shows t
 - **Road / railroad:** Road level (none, primitive, improved, port or railroad).
 - **Civilian units (province):** Count of civilian units in the tile’s province.
 
+#### Visibility and obfuscation (player-constrained views)
+
+When the map widget is in **player-constrained visibility mode** and the overlay is driven by a tile or province that the human player has never seen, the overlay must obfuscate details rather than leaking information:
+
+- **Per-tile (Tile section):**
+  - For tiles whose `CellViewData.visibility` is `visible` or `fogged`, the Tile section shows full details as listed above.
+  - For tiles whose `CellViewData.visibility` is `unrevealed`, the Tile section still shows the heading "Tile" but replaces all data fields (coordinates, terrain, resource, prospected, improvement, road/railroad, civilian units in province) with the literal placeholder text `???`.
+- **Per-province (all sections):**
+  - A province is treated as **fully unrevealed** when every tile in that province (all cells where `regionCellId` equals the province’s local id) has `visibility == TileVisibility.unrevealed` in the current `RegionMapViewData`.
+  - When a fully unrevealed province is selected, the overlay may still open (taps are allowed), but all content sections (Tile, Political, Economic, Military, Civilian, Naval) must replace data values with the literal placeholder text `???` while still indicating that a province is selected.
+  - Provinces that contain at least one tile with visibility `visible` or `fogged` are treated as **known**; the overlay shows full data for those provinces.
+
 ### Political
 
 - Province name (or prefixed id fallback)
@@ -96,6 +108,12 @@ When the overlay lists tile coordinates (e.g. improvements built/available), hov
 - **Given** the overlay lists tile coordinates, **when** the user hovers over a coordinate, **then** a secondary highlight appears on the map over that tile.
 - **Given** a mobile viewport, **when** the overlay is shown, **then** it appears as a bottom sheet with tabs and does not exceed one-third of screen height.
 - **Given** a desktop viewport, **when** the overlay is shown, **then** it appears as a side panel.
+
+- **Given** the map widget is in player-constrained visibility mode and the user hovers a tile whose `CellViewData.visibility` is `unrevealed`, **when** the overlay’s Tile section is rendered, **then** the UI layer shows the heading "Tile" and replaces all Tile data fields (coordinates, terrain, resource, prospected, improvement, road/railroad, civilian units in province) with the literal text `???`.
+
+- **Given** the map widget is in player-constrained visibility mode and the user taps a province where every tile in that province has `CellViewData.visibility == TileVisibility.unrevealed`, **when** the overlay is shown for that province, **then** the UI layer displays all content sections (Tile, Political, Economic, Military, Civilian, Naval) with data values obfuscated as `???` while still indicating that a province is selected.
+
+- **Given** the map widget is in player-constrained visibility mode and the user taps a province that contains at least one tile with `CellViewData.visibility` equal to `visible` or `fogged`, **when** the overlay is shown for that province, **then** the UI layer displays full province content (Political, Economic, Military, Civilian, Naval) without replacing values with `???`.
 
 ### Widgetbook
 

--- a/app/lib/features/game/flame/region_map_component.dart
+++ b/app/lib/features/game/flame/region_map_component.dart
@@ -97,10 +97,6 @@ class CtRegionMapComponent extends PositionComponent {
     final y = (local.y / cellSize).floor();
     if (x < 0 || x >= region.width || y < 0 || y >= region.height) return;
     final cell = region.cellAt(x, y);
-    if (visibilityMode == CtMapVisibilityMode.playerConstrained &&
-        cell.visibility == TileVisibility.unrevealed) {
-      return;
-    }
     final tileKey = '${region.regionId}|${cell.regionCellId}|$x|$y';
     if (validTileKeys != null && validTileKeys!.isNotEmpty) {
       if (validTileKeys!.contains(tileKey)) {
@@ -206,7 +202,7 @@ class CtRegionMapComponent extends PositionComponent {
           case TileVisibility.visible:
             break;
           case TileVisibility.fogged:
-            finalColor = Color.lerp(baseColor, Colors.grey.shade700, 0.5)!;
+            finalColor = Color.lerp(baseColor, Colors.black, 0.7)!;
             break;
           case TileVisibility.unrevealed:
             finalColor = Colors.black;

--- a/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
+++ b/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
@@ -148,6 +148,68 @@ _OverlayContent _provinceContent({
   String? hoveredTileKey,
   void Function(String?)? onHighlightTile,
 }) {
+  final parts = provinceId.split('|');
+  final regionId = parts.isNotEmpty ? parts[0] : region.regionId;
+  final localProvinceId = parts.length >= 2 ? parts[1] : provinceId;
+  final isFullyUnrevealed = region.regionId == regionId &&
+      !region.cells.any(
+        (c) =>
+            c.regionCellId == localProvinceId &&
+            c.visibility != TileVisibility.unrevealed,
+      );
+  if (isFullyUnrevealed) {
+    final placeholder = _buildSection(
+      'Tile',
+      const Text('???'),
+    );
+    final sections = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: const [
+        Text('Political', style: TextStyle(fontWeight: FontWeight.bold)),
+        SizedBox(height: 4),
+        Text('???'),
+        SizedBox(height: 12),
+        Text('Economic', style: TextStyle(fontWeight: FontWeight.bold)),
+        SizedBox(height: 4),
+        Text('???'),
+        SizedBox(height: 12),
+        Text('Military', style: TextStyle(fontWeight: FontWeight.bold)),
+        SizedBox(height: 4),
+        Text('???'),
+        SizedBox(height: 12),
+        Text('Civilian', style: TextStyle(fontWeight: FontWeight.bold)),
+        SizedBox(height: 4),
+        Text('???'),
+        SizedBox(height: 12),
+        Text('Naval', style: TextStyle(fontWeight: FontWeight.bold)),
+        SizedBox(height: 4),
+        Text('???'),
+      ],
+    );
+    final tabs = const [
+      Tab(text: 'Tile'),
+      Tab(text: 'Political'),
+      Tab(text: 'Economic'),
+      Tab(text: 'Military'),
+      Tab(text: 'Civilian'),
+      Tab(text: 'Naval'),
+    ];
+    final tabViews = [
+      placeholder,
+      const _ObfuscatedSection(),
+      const _ObfuscatedSection(),
+      const _ObfuscatedSection(),
+      const _ObfuscatedSection(),
+      const _ObfuscatedSection(),
+    ];
+    return _OverlayContent(
+      tabCount: 6,
+      tabs: tabs,
+      tabViews: tabViews,
+      sections: sections,
+    );
+  }
   final province = _findProvince(game, provinceId);
   final regionData = provinceId.startsWith('newWorld')
       ? game.worldState.newWorld
@@ -267,6 +329,24 @@ Widget _buildTileSection({
     return _buildSection('Tile', const Text('—'));
   }
   final cell = region.cellAt(x, y);
+   if (cell.visibility == TileVisibility.unrevealed) {
+    return _buildSection(
+      'Tile',
+      const Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text('Coordinates: ???'),
+          Text('Terrain: ???'),
+          Text('Resource: ???'),
+          Text('Prospected: ???'),
+          Text('Improvement: ???'),
+          Text('Road / railroad: ???'),
+          Text('Civilian units (province): ???'),
+        ],
+      ),
+    );
+  }
   final tileState = game.worldState.tileState;
   final resourceByTile = game.worldState.resourceByTileKey;
   final prospected = game.worldState.playerProspectedTiles[humanPlayerId] ?? {};
@@ -520,4 +600,16 @@ Widget _buildSection(String title, Widget child) {
       ],
     ),
   );
+}
+
+class _ObfuscatedSection extends StatelessWidget {
+  const _ObfuscatedSection();
+
+  @override
+  Widget build(BuildContext context) {
+    return _buildSection(
+      '',
+      const Text('???'),
+    );
+  }
 }

--- a/app/test/ct_region_map_test.dart
+++ b/app/test/ct_region_map_test.dart
@@ -408,6 +408,62 @@ void main() {
       },
       timeout: const Timeout(Duration(seconds: 5)),
     );
+
+    testWidgets(
+      'tap still selects province when all tiles are unrevealed in player-constrained mode',
+      (WidgetTester tester) async {
+        final base = _oldWorldRegion();
+        final unrevealedCells = base.cells
+            .map(
+              (c) => CellViewData(
+                x: c.x,
+                y: c.y,
+                regionCellId: c.regionCellId,
+                isSea: c.isSea,
+                terrainTypeId: c.terrainTypeId,
+                terrainType: c.terrainType,
+                resourceId: c.resourceId,
+                ownerFactionId: c.ownerFactionId,
+                provinceDisplayName: c.provinceDisplayName,
+                improvementLevel: c.improvementLevel,
+                roadLevel: c.roadLevel,
+                visibility: TileVisibility.unrevealed,
+              ),
+            )
+            .toList();
+        final region = RegionMapViewData(
+          regionId: base.regionId,
+          width: base.width,
+          height: base.height,
+          cellSize: base.cellSize,
+          cells: unrevealedCells,
+          capitalMarkers: base.capitalMarkers,
+          portMarkers: base.portMarkers,
+          factionColors: base.factionColors,
+          terrainColors: base.terrainColors,
+          unitMarkers: base.unitMarkers,
+        );
+
+        String? selectedId;
+        await tester.pumpWidget(
+          _buildCtRegionMap(
+            region: region,
+            visibilityMode: CtMapVisibilityMode.playerConstrained,
+            onProvinceSelected: (id) => selectedId = id,
+          ),
+        );
+        await tester.pump();
+
+        final mapFinder = find.byType(CtRegionMap);
+        expect(mapFinder, findsOneWidget);
+        await tester.tap(mapFinder);
+        await tester.pump();
+
+        expect(selectedId, isNotNull);
+        expect(selectedId!, startsWith('${region.regionId}|'));
+      },
+      timeout: const Timeout(Duration(seconds: 5)),
+    );
   });
 }
 

--- a/app/test/province_overlay_test.dart
+++ b/app/test/province_overlay_test.dart
@@ -1,6 +1,7 @@
 // Tests for ProvinceSeaZoneDetailOverlay. SPEC/ui/province-sea-zone-detail-overlay.md.
 
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -175,6 +176,131 @@ void main() {
       );
       expect(constrained, findsAtLeastNWidgets(1));
     });
+
+    testWidgets(
+      'Tile section shows ??? for unrevealed tiles in player-constrained view',
+      (WidgetTester tester) async {
+        final baseRegion = demoRegionForOverlay;
+        final cells = <CellViewData>[];
+        for (var i = 0; i < baseRegion.cells.length; i++) {
+          final c = baseRegion.cells[i];
+          cells.add(
+            CellViewData(
+              x: c.x,
+              y: c.y,
+              regionCellId: c.regionCellId,
+              isSea: c.isSea,
+              terrainTypeId: c.terrainTypeId,
+              terrainType: c.terrainType,
+              resourceId: c.resourceId,
+              ownerFactionId: c.ownerFactionId,
+              provinceDisplayName: c.provinceDisplayName,
+              improvementLevel: c.improvementLevel,
+              roadLevel: c.roadLevel,
+              visibility:
+                  i == 0 ? TileVisibility.unrevealed : c.visibility,
+            ),
+          );
+        }
+        final region = RegionMapViewData(
+          regionId: baseRegion.regionId,
+          width: baseRegion.width,
+          height: baseRegion.height,
+          cellSize: baseRegion.cellSize,
+          cells: cells,
+          capitalMarkers: baseRegion.capitalMarkers,
+          portMarkers: baseRegion.portMarkers,
+          factionColors: baseRegion.factionColors,
+          terrainColors: baseRegion.terrainColors,
+          unitMarkers: baseRegion.unitMarkers,
+        );
+
+        final hoveredCell = region.cells.first;
+        final hoveredTileKey =
+            '${region.regionId}|${hoveredCell.regionCellId}|${hoveredCell.x}|${hoveredCell.y}';
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: ProvinceSeaZoneDetailOverlay(
+                game: demoGameForOverlay,
+                region: region,
+                selectedId:
+                    '${region.regionId}|${hoveredCell.regionCellId}',
+                displayId:
+                    '${region.regionId}|${hoveredCell.regionCellId}',
+                humanPlayerId: demoGameForOverlay.players.first.id,
+                hoveredTileKey: hoveredTileKey,
+                onClose: () {},
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('Coordinates: ???'), findsOneWidget);
+        expect(find.textContaining('Terrain: ???'), findsOneWidget);
+        expect(find.textContaining('Resource: ???'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Province sections use ??? when province is fully unrevealed',
+      (WidgetTester tester) async {
+        final baseRegion = demoRegionForOverlay;
+        final cells = baseRegion.cells
+            .map(
+              (c) => CellViewData(
+                x: c.x,
+                y: c.y,
+                regionCellId: c.regionCellId,
+                isSea: c.isSea,
+                terrainTypeId: c.terrainTypeId,
+                terrainType: c.terrainType,
+                resourceId: c.resourceId,
+                ownerFactionId: c.ownerFactionId,
+                provinceDisplayName: c.provinceDisplayName,
+                improvementLevel: c.improvementLevel,
+                roadLevel: c.roadLevel,
+                visibility: TileVisibility.unrevealed,
+              ),
+            )
+            .toList();
+        final region = RegionMapViewData(
+          regionId: baseRegion.regionId,
+          width: baseRegion.width,
+          height: baseRegion.height,
+          cellSize: baseRegion.cellSize,
+          cells: cells,
+          capitalMarkers: baseRegion.capitalMarkers,
+          portMarkers: baseRegion.portMarkers,
+          factionColors: baseRegion.factionColors,
+          terrainColors: baseRegion.terrainColors,
+          unitMarkers: baseRegion.unitMarkers,
+        );
+
+        final provinceId =
+            '${region.regionId}|${region.cells.first.regionCellId}';
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: ProvinceSeaZoneDetailOverlay(
+                game: demoGameForOverlay,
+                region: region,
+                selectedId: provinceId,
+                displayId: provinceId,
+                humanPlayerId: demoGameForOverlay.players.first.id,
+                onClose: () {},
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('???'), findsWidgets);
+      },
+    );
   });
 
   group('ProvinceSeaZoneDetailOverlay with map', () {


### PR DESCRIPTION
## Summary
- Allow province selection taps on unrevealed tiles while keeping hover blocked, per updated map widget visibility semantics.
- Darken fogged tiles in player-constrained mode and add overlay-side obfuscation (??? placeholders) for tiles/provinces that are fully unrevealed.
- Update SPEC/ui map-widget and province-sea-zone-detail-overlay docs plus widget tests to cover the new behavior.

## Test plan
- flutter test app/test/ct_region_map_test.dart
- flutter test app/test/province_overlay_test.dart

Made with [Cursor](https://cursor.com)