### PR TITLE
feat(diplomacy): add persistent diplomatic history log

### DIFF
--- a/SPEC/game/diplomacy.md
+++ b/SPEC/game/diplomacy.md
@@ -225,3 +225,31 @@ Default values for the parameters above are given in this table; the table is th
 - Turn sequence: see program/turn-resolution-phases.md
 - Combat validation: [combat.md](combat.md)
 - Province identity (prefixed ids, region-scoped lookup in state and orders): [world-model-identity.md](world-model-identity.md)
+
+---
+
+## Diplomatic History
+
+The game maintains a **diplomatic history log** for each Great Power, consisting of **structured events** involving that GP and any other faction (GP, Minor, or Tribe). Events are stored in game state as data and rendered as **human-readable** entries by the UI.
+
+- **Scope (who logs what):**
+  - Only **Great Powers** initiate diplomatic actions, but the history log records all events where any Great Power is a **party**: GP–GP, GP–Minor, GP–Tribe.
+  - For a given Great Power `A`, the **per-faction history view** in the diplomacy panel shows only events where `A` and the selected faction `B` are both parties.
+- **Event types (what is recorded):**
+  - **State changes:** Declarations of war, transitions to peace, alliances formed or broken, Join Empire/Colony resolutions (including removal of a Minor/Tribe), intervention outcomes (Intervene, Do Nothing, Protest).
+  - **Overtures and treaties:** Consulate established, Embassy established, NAP signed, Join Empire/Colony overture accepted. Failed overtures (rejected by human/AI GP, or rejected for validation reasons) are recorded as **attempted but not applied** if they reach diplomacy resolution.
+  - **War side-effects:** Overtures cleared due to war, subsidies cancelled due to war.
+  - **Economic diplomacy:** GrantAid applications and SetSubsidy creations, updates, and cancellations that successfully apply.
+  - **AI vs human symmetry:** Events are recorded for both **human** and **AI-controlled** Great Powers; the history is a world-level log, not per-controller.
+- **Time and ordering:**
+  - Each event stores the **turn number** when it occurred (integer, same as `worldState.turnState.turnNumber`).
+  - Events are **ordered** by (turn, within-turn index) in a way that preserves resolution order; the history is effectively append-only.
+  - UI displays events grouped and sorted by **newest first**, using a **year label** derived from turn via the game calendar mapping (e.g. `Year 1505 (Turn 12)`), per the program-level time mapping spec.
+- **Visibility and “unknown faction”:**
+  - The underlying history is a **global** world log (all Great Power events), but **PlayerView-safe** projections for a given human player **substitute undiscovered factions** with `Unknown faction`:
+    - If a faction in an event is not yet discovered by the viewing player (no relation and outside visibility rules), the UI renders that party as `Unknown faction` while keeping the rest of the event text intact.
+    - When the same event involves the viewing player’s GP directly, the viewing player is always allowed to see their **own** identity; only other, still-undiscovered factions are substituted.
+  - All human players see the **same underlying event list**, but with party names filtered/substituted per their own discovery state.
+- **Retention:**
+  - Diplomatic history is **unbounded** within a campaign: there is no cap on the number of events persisted in a save.
+  - Old saves created before this feature may have an empty or partial history; the game shows **whatever history exists** in the saved Game state without backfilling from current relations.

--- a/SPEC/program/diplomacy-resolution.md
+++ b/SPEC/program/diplomacy-resolution.md
@@ -12,6 +12,16 @@ Resolves diplomatic orders, manages overture state machine, updates relation sco
 
 **Overture state** (per Minor/Tribe per GP): current stage (none, TradeConsulate, Embassy, NAP, JoinEmpire/Colony). Costs and turn delays per game rules. Stored in world state; serialized in save/load.
 
+**Diplomatic history event** (per Great-Power-centric world log): structured record of notable diplomatic actions and state changes involving at least one Great Power. Stored in world state on `Game` as a **flat, append-only list** and serialized in save/load. Each event includes:
+
+- **turn** (int, same domain as `worldState.turnState.turnNumber`).
+- **intraTurnIndex** (int, monotonically increasing for events created in the same turn, to preserve resolution order).
+- **participants**: set of faction ids involved in the event (always includes at least one Great Power id).
+- **primaryType**: enum describing the main event (e.g. `declareWar`, `peace`, `allianceFormed`, `allianceBroken`, `overtureAccepted`, `overtureRejected`, `joinEmpireResolved`, `grantAidApplied`, `subsidySet`, `subsidyUpdated`, `subsidyCancelled`, `interventionIntervene`, `interventionProtest`, `interventionDoNothing`, `agreementsClearedOnWar`).
+- **details**: structured payload fields specific to the primaryType (e.g. `fromFactionId`, `toFactionId`, `overtureStage`, `amount`, `reason`, `wasAiInitiator`).
+
+Rendering of human-readable strings (including year labels derived from turn) is delegated to UI/TUI layers based on this structured event model.
+
 ---
 
 ## Algorithm / Flow
@@ -25,6 +35,16 @@ Diplomacy phase runs before Movement. Resolution steps in order:
 5. **Process Declare War and Peace** — Update relationState, sinceTurn, lastInteractionTurn.
 6. **Apply relation modifiers** — From trade, grants (GrantAid), subsidies (SetSubsidy), war, broken treaties per game rules. SetSubsidy: valid if consulate/embassy exists; deducts payer treasury; if target is GP adds to target treasury, else (Minor/Tribe) improves relation.
 7. **Update relation scores** — Recompute from modifiers; clamp 0–100; derive level.
+
+At the same hook points where relation state, overtures, or economic diplomacy are mutated, the resolver **appends one or more Diplomatic history events** to the flat world log:
+
+- When an overture is **accepted or rejected** and reaches a new stage (including Join Empire/Colony), an event with primaryType `overtureAccepted` or `overtureRejected` is appended.
+- When **war** is successfully declared (relationState flips to AT_WAR), an event with primaryType `declareWar` is appended, and any overture/subsidy cancellations caused by that war append `agreementsClearedOnWar` / `subsidyCancelled` events.
+- When **peace** takes effect between a pair (GP–GP mutual offer, or GP–Minor/Tribe), an event with primaryType `peace` is appended.
+- When an **alliance** is formed or broken, events with primaryType `allianceFormed` / `allianceBroken` are appended.
+- When **GrantAid** is applied, an event with primaryType `grantAidApplied` is appended.
+- When a **subsidy** is created, updated, or cancelled (including automatic cancellation on war or insufficient funds), events with primaryType `subsidySet`, `subsidyUpdated`, or `subsidyCancelled` are appended.
+- When an **Intervention** decision is applied (Intervene, Do Nothing, Protest), events with primaryType `interventionIntervene`, `interventionDoNothing`, or `interventionProtest` are appended.
 
 **Order validation:** Each diplomatic order type (see game/diplomacy.md § Diplomatic Order Types) is validated by the order engine — preconditions (AT_PEACE/AT_WAR, overture stage, treasury) checked at submission and again at resolution. Establish Overture may target Minor, Tribe, or Great Power. At most one Establish Overture per (player, target faction) per turn; a second such order for the same target is rejected at validation (see game/diplomacy.md, program/orders.md).
 
@@ -73,6 +93,13 @@ Rejections and validation failures are logged by the order engine; diplomacy res
 - **Order validation:** Preconditions for each diplomatic order type (AT_PEACE/AT_WAR, overture stage, treasury, etc.) are checked at order submission by the order engine and again at resolution; invalid orders are rejected and not applied. In particular, when relationState between a GP and a Minor/Tribe is `AT_WAR`, `Establish Overture` orders targeting that faction are invalid and must not create or advance overture state or deduct overture costs. See game/diplomacy.md § Diplomatic Order Types.
 - **Save/load:** Relation records (per faction-pair) and overture state (per Minor/Tribe per GP) are serialized in the game save and restored on load so that relation scores, levels, sinceTurn, lastInteractionTurn, relationState, and overture stages are preserved.
 - **Logging:** Phase start and end at debug with `logic:` prefix; key outcomes at info (overture applied, join empire, alliance formed, war declared, peace offered, agreements terminated, GrantAid/SetSubsidy applied). Rejections and validation failures are logged by the order engine only.
+
+- **Diplomatic history events — creation:** Given the Diplomacy phase resolves an action that changes diplomatic state or applies economic diplomacy (war/peace, alliance formed/broken, overture accepted/rejected including Join Empire/Colony, GrantAid applied, subsidy set/updated/cancelled, intervention decisions, overtures cleared on war), when that change is applied to `Game`, then the resolver appends at least one `DiplomaticEvent` to the flat diplomatic history list on `Game` with:
+  - `turn` equal to the current turn index;
+  - `participants` including all factions directly affected by the change (at least one Great Power);
+  - `primaryType` matching the kind of change (e.g. `declareWar` when relationState flips to AT_WAR).
+- **Diplomatic history events — ordering:** Given the resolver appends multiple diplomatic history events during a single turn, when the turn completes and the game is saved, then all `DiplomaticEvent` entries for that turn have strictly increasing `intraTurnIndex` values that preserve the order in which the underlying changes were applied.
+- **Diplomatic history events — save/load:** Given a Game whose diplomatic history list contains one or more `DiplomaticEvent` entries, when the system saves and reloads that Game, then the reloaded Game contains the same diplomatic history entries with identical `turn`, `intraTurnIndex`, `participants`, `primaryType`, and `details` values.
 
 ---
 

--- a/SPEC/ui/diplomacy-panel.md
+++ b/SPEC/ui/diplomacy-panel.md
@@ -32,6 +32,23 @@ A faction is **discovered** iff the player has a **diplomatic relation** with th
 - **Left:** Faction name (displayName or id), type badge (GP / Minor / Tribe), current **diplomatic state**: relation state (AT_PEACE / AT_WAR), **one-word relation state** (Hostile / Unfriendly / Cordial / Friendly) derived from the hidden relation score per [diplomacy.md](../game/diplomacy.md) § Player-facing relation display. The numeric relation score is **not** shown. For Minor/Tribe: overture stage (none, Trade Consulate, Embassy, NAP, Join Empire) if any. For **Great Powers:** the **power score** per [diplomacy.md](../game/diplomacy.md) § Great Power power score is shown; if the GP’s score is higher than the player’s, the score is shown in **red**, otherwise in **green**.
 - **Right:** **Available diplomatic actions** for the player toward that faction. Actions are those explicitly in SPEC/game/diplomacy.md and SPEC/program/orders.md: Declare War, Offer Peace, Alliance (GP only), Establish Overture (stage), Grant Aid, Set Subsidy. Only show actions that are **valid** per the diplomatic order validator (same rules as order submission).
 
+Tapping anywhere on a faction row (or an explicit “Details” affordance in that row) opens a **Diplomacy Detail** view for that faction, scoped to the current player’s Great Power.
+
+---
+
+## Diplomacy Detail view (per faction)
+
+When the user opens the detail view for a faction `B` while controlling Great Power `A`, the UI shows:
+
+- **Header:** Faction name and type (GP / Minor / Tribe), and the same current relation summary as the row (relation state, one-word relation).
+- **History panel:** A vertical list of **diplomatic history events** involving `A` and `B`, newest first. Each entry renders:
+  - A **year label** derived from the event’s `turn` using the game calendar mapping (e.g. `1505 (Turn 12)`).
+  - A human-readable sentence describing the event (e.g. `We declared war on Spain.`, `We established an Embassy with Bavaria.`, `Our subsidies to Bavaria were cancelled when war began.`).
+  - If an event involves a faction that is not yet discovered by the current player (no relation, outside visibility rules), that faction’s name is shown as `Unknown faction` in the text.
+- **Dossier subpanel (Great Powers only):** When `B` is a Great Power, a secondary panel or tab within the detail view shows the **AI dossier** for `B` from the perspective of `A`, per [SPEC/ai/ai-dossier.md](../ai/ai-dossier.md). The dossier uses only PlayerView-safe data.
+
+Events are read from the flat diplomatic history list on `Game`, filtered to those whose `participants` include both `A` and `B`, and ordered by `(turn desc, intraTurnIndex desc)`.
+
 ---
 
 ## Actions
@@ -62,3 +79,9 @@ At least one story that shows the Diplomacy panel using a **real game** (e.g. fr
 - Given a faction row, the panel shows current relation state (Peace/War) and the **one-word relation state** (Hostile, Unfriendly, Cordial, Friendly) derived from the hidden score per SPEC/game/diplomacy.md § Player-facing relation display; it does **not** show the numeric relation score. For Minor/Tribe it shows overture stage. For Great Powers it shows the **power score** (SPEC/game/diplomacy.md § Great Power power score) in **red** when the GP’s score is higher than the player’s, otherwise in **green**. To the right it shows only valid diplomatic actions for that faction.
 - Given the user taps an action that requires no parameters, the UI submits that diplomatic order for the current turn.
 - Given the user taps an action that requires parameters (amount or overture stage), the UI shows a dialog; on confirm, the UI submits the order with the chosen parameters.
+
+- **Diplomacy Detail — open:** Given the Diplomacy panel is open and shows at least one faction row, when the user taps that row (or its Details affordance), then the UI opens a Diplomacy Detail view scoped to the current player’s Great Power and the tapped faction.
+- **Diplomacy Detail — history contents:** Given the Diplomacy Detail view is open for Great Power `A` and faction `B`, when the UI renders the history panel, then it shows all and only those `DiplomaticEvent` entries from the Game’s diplomatic history whose `participants` include both `A` and `B`, ordered by newest first (highest `turn`, then highest `intraTurnIndex`).
+- **Diplomacy Detail — year and turn:** Given a `DiplomaticEvent` in the history panel, when the UI renders its timestamp, then it shows a year label derived from the event’s `turn` using the game calendar mapping and includes the raw turn number in parentheses (e.g. `1505 (Turn 12)`).
+- **Diplomacy Detail — unknown faction substitution:** Given a `DiplomaticEvent` in the history panel that involves a third faction `C` that is not discovered by the current player, when the UI renders that event, then the faction `C` is shown as `Unknown faction` while `A` and `B` (if discovered) are shown by their normal display names.
+- **Diplomacy Detail — dossier subpanel:** Given the Diplomacy Detail view is open for Great Power `B` (and the current player controls Great Power `A`), when the UI renders the dossier subpanel, then it shows dossier sections for `B` per SPEC/ai/ai-dossier.md using only PlayerView-safe data and does not expose hidden agenda values directly.

--- a/app/lib/features/game/widgets/diplomacy_detail_screen.dart
+++ b/app/lib/features/game/widgets/diplomacy_detail_screen.dart
@@ -1,0 +1,273 @@
+// Diplomacy detail: history + dossier for one faction. SPEC/ui/diplomacy-panel.md.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+
+import 'diplomacy_panel.dart';
+
+/// Human-readable sentence for a diplomatic event. Unknown factions shown as "Unknown faction".
+String formatDiplomaticEvent(
+  DiplomaticEvent e,
+  Game game,
+  String humanPlayerId,
+) {
+  String name(String factionId) {
+    if (factionId == humanPlayerId) return 'We';
+    if (getRelation(game, humanPlayerId, factionId) == null) return 'Unknown faction';
+    final p = game.playerById(factionId);
+    if (p != null) return p.displayName;
+    for (final m in game.minorNations) {
+      if (m.id == factionId) return m.displayName ?? factionId;
+    }
+    for (final t in game.tribes) {
+      if (t.id == factionId) return t.displayName ?? factionId;
+    }
+    return factionId;
+  }
+
+  final from = e.fromFactionId != null ? name(e.fromFactionId!) : null;
+  final to = e.toFactionId != null ? name(e.toFactionId!) : null;
+  final stage = e.overtureStage != null ? _overtureLabel(e.overtureStage!) : null;
+
+  switch (e.type) {
+    case DiplomaticEventType.declareWar:
+      return '${from ?? 'Unknown'} declared war on ${to ?? 'Unknown'}.';
+    case DiplomaticEventType.peace:
+      return '${from ?? 'Unknown'} made peace with ${to ?? 'Unknown'}.';
+    case DiplomaticEventType.allianceFormed:
+      return '${from ?? 'Unknown'} formed an alliance with ${to ?? 'Unknown'}.';
+    case DiplomaticEventType.allianceBroken:
+      return 'Alliance between ${from ?? 'Unknown'} and ${to ?? 'Unknown'} ended.';
+    case DiplomaticEventType.overtureAccepted:
+      return '${from ?? 'Unknown'} established ${stage ?? 'overture'} with ${to ?? 'Unknown'}.';
+    case DiplomaticEventType.overtureRejected:
+      return '${to ?? 'Unknown'} rejected ${stage ?? 'overture'} from ${from ?? 'Unknown'}.';
+    case DiplomaticEventType.joinEmpireResolved:
+      return '${from ?? 'Unknown'} absorbed ${to ?? 'Unknown'} (Join Empire).';
+    case DiplomaticEventType.grantAidApplied:
+      final amt = e.amount ?? 0;
+      return '${from ?? 'Unknown'} granted £$amt aid to ${to ?? 'Unknown'}.';
+    case DiplomaticEventType.subsidySet:
+      return '${from ?? 'Unknown'} set subsidy of £${e.amount ?? 0}/turn to ${to ?? 'Unknown'}.';
+    case DiplomaticEventType.subsidyUpdated:
+      return '${from ?? 'Unknown'} updated subsidy to £${e.amount ?? 0}/turn to ${to ?? 'Unknown'}.';
+    case DiplomaticEventType.subsidyCancelled:
+      return 'Subsidy ${from ?? 'Unknown'} → ${to ?? 'Unknown'} ended (${e.reason ?? 'cancelled'}).';
+    case DiplomaticEventType.interventionIntervene:
+      return '${from ?? 'Unknown'} intervened in war (against ${to ?? 'Unknown'}).';
+    case DiplomaticEventType.interventionDoNothing:
+      return '${from ?? 'Unknown'} did not intervene (against ${to ?? 'Unknown'}).';
+    case DiplomaticEventType.interventionProtest:
+      return '${from ?? 'Unknown'} protested (against ${to ?? 'Unknown'}).';
+    case DiplomaticEventType.agreementsClearedOnWar:
+      return 'Overtures between ${from ?? 'Unknown'} and ${to ?? 'Unknown'} ended due to war.';
+  }
+}
+
+String _overtureLabel(OvertureStage s) {
+  return switch (s) {
+    OvertureStage.none => 'overture',
+    OvertureStage.tradeConsulate => 'Trade Consulate',
+    OvertureStage.embassy => 'Embassy',
+    OvertureStage.nap => 'Non-Aggression Pact',
+    OvertureStage.joinEmpire => 'Join Empire',
+  };
+}
+
+/// Full-screen diplomacy detail: history list (newest first) and dossier for GP.
+class DiplomacyDetailScreen extends StatelessWidget {
+  const DiplomacyDetailScreen({
+    super.key,
+    required this.game,
+    required this.humanPlayerId,
+    required this.factionId,
+    required this.factionDisplayName,
+    required this.kind,
+    required this.relation,
+  });
+
+  final Game game;
+  final String humanPlayerId;
+  final String factionId;
+  final String factionDisplayName;
+  final FactionKind kind;
+  final DiplomacyRelation? relation;
+
+  @override
+  Widget build(BuildContext context) {
+    final history = diplomaticHistoryForPair(game, humanPlayerId, factionId);
+    final year = (int turn) => turnToYear(turn, game.turnTimeMapping);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(factionDisplayName),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        children: [
+          _relationSummary(context),
+          const SizedBox(height: 16),
+          Text(
+            'Diplomatic history',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          const SizedBox(height: 8),
+          if (history.isEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 16),
+              child: Text(
+                'No recorded events with this faction.',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+              ),
+            )
+          else
+            ...history.map((e) => Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Card(
+                    child: Padding(
+                      padding: const EdgeInsets.all(12),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '${year(e.turn)} (Turn ${e.turn})',
+                            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                                  color: Theme.of(context).colorScheme.primary,
+                                ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            formatDiplomaticEvent(e, game, humanPlayerId),
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                )),
+          if (kind == FactionKind.greatPower) ...[
+            const SizedBox(height: 24),
+            Text(
+              'Dossier',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            _DossierSection(
+              game: game,
+              observerId: humanPlayerId,
+              subjectId: factionId,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _relationSummary(BuildContext context) {
+    final stateLabel = relation == null
+        ? '—'
+        : relation!.atWar
+            ? 'War'
+            : 'Peace';
+    final relationLabel = relation == null
+        ? ''
+        : relationScoreToDisplayLabel(relation!.score);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Current relation',
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              relationLabel.isEmpty ? stateLabel : '$stateLabel · $relationLabel',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DossierSection extends StatelessWidget {
+  const _DossierSection({
+    required this.game,
+    required this.observerId,
+    required this.subjectId,
+  });
+
+  final Game game;
+  final String observerId;
+  final String subjectId;
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = game.dossierEvidenceEntries
+        .where((e) => e.observerId == observerId && e.subjectId == subjectId)
+        .toList();
+    entries.sort((a, b) {
+      final t = b.turnNumber.compareTo(a.turnNumber);
+      if (t != 0) return t;
+      return a.description.compareTo(b.description);
+    });
+
+    if (entries.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.only(bottom: 16),
+        child: Text(
+          'No dossier evidence yet.',
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: entries.map((e) => Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Turn ${e.turnNumber}:',
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      e.description,
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ),
+                ],
+              ),
+            )).toList(),
+      ),
+    );
+  }
+}

--- a/app/lib/features/game/widgets/diplomacy_panel.dart
+++ b/app/lib/features/game/widgets/diplomacy_panel.dart
@@ -6,6 +6,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
 import 'diplomacy_dialogs.dart';
+import 'diplomacy_detail_screen.dart';
 
 /// Faction type for display. SPEC/game/factions.md.
 enum FactionKind { greatPower, minor, tribe }
@@ -165,6 +166,7 @@ class DiplomacyPanel extends StatelessWidget {
           ...gps.map((r) => _DiplomacyRow(
                 data: r,
                 onAction: (order) => _submitOrDialog(context, order),
+                onTap: () => _openDetail(context, r),
               )),
         ],
         if (minors.isNotEmpty) ...[
@@ -172,6 +174,7 @@ class DiplomacyPanel extends StatelessWidget {
           ...minors.map((r) => _DiplomacyRow(
                 data: r,
                 onAction: (order) => _submitOrDialog(context, order),
+                onTap: () => _openDetail(context, r),
               )),
         ],
         if (tribes.isNotEmpty) ...[
@@ -179,6 +182,7 @@ class DiplomacyPanel extends StatelessWidget {
           ...tribes.map((r) => _DiplomacyRow(
                 data: r,
                 onAction: (order) => _submitOrDialog(context, order),
+                onTap: () => _openDetail(context, r),
               )),
         ],
         if (rows.isEmpty)
@@ -240,6 +244,21 @@ class DiplomacyPanel extends StatelessWidget {
     }
   }
 
+  void _openDetail(BuildContext context, DiplomacyRowData row) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (context) => DiplomacyDetailScreen(
+          game: game,
+          humanPlayerId: humanPlayerId,
+          factionId: row.factionId,
+          factionDisplayName: row.displayName,
+          kind: row.kind,
+          relation: row.relation,
+        ),
+      ),
+    );
+  }
+
   void _appendOrder(DiplomaticOrder order) {
     final list = List<DiplomaticOrder>.from(
       currentOrders.diplomaticOrdersByPlayerId[humanPlayerId] ?? [],
@@ -257,10 +276,12 @@ class _DiplomacyRow extends StatelessWidget {
   const _DiplomacyRow({
     required this.data,
     required this.onAction,
+    this.onTap,
   });
 
   final DiplomacyRowData data;
   final void Function(DiplomaticOrder) onAction;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -276,15 +297,11 @@ class _DiplomacyRow extends StatelessWidget {
         ? ''
         : ' · ${_overtureStageLabel(data.overture!.stage)}';
 
-    return Card(
-      margin: const EdgeInsets.only(bottom: 8),
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Expanded(
-              child: Column(
+    final content = Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -323,17 +340,27 @@ class _DiplomacyRow extends StatelessWidget {
                 ],
               ),
             ),
-            Wrap(
-              spacing: 6,
-              runSpacing: 6,
-              children: data.actions.map((order) {
-                return _ActionButton(
-                  order: order,
-                  onPressed: () => onAction(order),
-                );
-              }).toList(),
-            ),
-          ],
+        Wrap(
+          spacing: 6,
+          runSpacing: 6,
+          children: data.actions.map((order) {
+            return _ActionButton(
+              order: order,
+              onPressed: () => onAction(order),
+            );
+          }).toList(),
+        ),
+      ],
+    );
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: content,
         ),
       ),
     );

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
@@ -166,3 +166,22 @@ Player? getPlayer(Game game, String playerId) {
   }
   return null;
 }
+
+/// Diplomatic history events involving both [factionA] and [factionB], newest first.
+/// SPEC/ui/diplomacy-panel.md § Diplomacy Detail — history contents.
+List<DiplomaticEvent> diplomaticHistoryForPair(
+  Game game,
+  String factionA,
+  String factionB,
+) {
+  final list = game.diplomaticHistoryEvents
+      .where((e) =>
+          e.participants.contains(factionA) && e.participants.contains(factionB))
+      .toList();
+  list.sort((a, b) {
+    final turnCmp = b.turn.compareTo(a.turn);
+    if (turnCmp != 0) return turnCmp;
+    return b.intraTurnIndex.compareTo(a.intraTurnIndex);
+  });
+  return list;
+}

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -17,6 +17,38 @@ export 'diplomacy_relation_lookup.dart';
 
 final Logger _diploLog = Logger();
 
+/// Appends one diplomatic history event. intraTurnIndex = count of events already in this turn.
+Game _appendDiplomaticEvent(
+  Game game,
+  int turn,
+  DiplomaticEventType type,
+  Set<String> participants, {
+  String? fromFactionId,
+  String? toFactionId,
+  OvertureStage? overtureStage,
+  int? amount,
+  String? reason,
+  bool wasAiInitiator = false,
+}) {
+  final events = game.diplomaticHistoryEvents;
+  final intraTurnIndex = events.where((e) => e.turn == turn).length;
+  final event = DiplomaticEvent(
+    turn: turn,
+    intraTurnIndex: intraTurnIndex,
+    type: type,
+    participants: participants,
+    fromFactionId: fromFactionId,
+    toFactionId: toFactionId,
+    overtureStage: overtureStage,
+    amount: amount,
+    reason: reason,
+    wasAiInitiator: wasAiInitiator,
+  );
+  return game.copyWith(
+    diplomaticHistoryEvents: [...events, event],
+  );
+}
+
 bool isMinorOrTribe(Game game, String factionId) {
   return game.minorNations.any((m) => m.id == factionId) ||
       game.tribes.any((t) => t.id == factionId);
@@ -208,7 +240,21 @@ _OverturePaymentsResult _processOverturePayments(
         }
       }
 
-      if (!accepted) continue;
+      if (!accepted) {
+        if (targetIsGp) {
+          state = _appendDiplomaticEvent(
+            state,
+            turn,
+            DiplomaticEventType.overtureRejected,
+            {gpId, targetId},
+            fromFactionId: gpId,
+            toFactionId: targetId,
+            overtureStage: stage,
+            wasAiInitiator: isAiControlledForEvidence(state, gpId),
+          );
+        }
+        continue;
+      }
 
       if (cost > 0) {
         player = player.copyWith(treasury: player.treasury - cost);
@@ -228,6 +274,17 @@ _OverturePaymentsResult _processOverturePayments(
               gpId: gpId, targetId: targetId, stage: stage, sinceTurn: turn)
         ];
       }
+      state = state.copyWith(players: players, overtureStates: overtures);
+      state = _appendDiplomaticEvent(
+        state,
+        turn,
+        DiplomaticEventType.overtureAccepted,
+        {gpId, targetId},
+        fromFactionId: gpId,
+        toFactionId: targetId,
+        overtureStage: stage,
+        wasAiInitiator: isAiControlledForEvidence(state, gpId),
+      );
       _diploLog.i('logic: diplomacy overture $gpId -> $targetId $stage (accepted)');
     }
   }
@@ -288,6 +345,17 @@ Game _resolveJoinEmpireColony(
 
       // Absorb Minor/Tribe: transfer provinces, units, fleets to GP; remove faction.
       game = _absorbMinorOrTribeIntoGp(game, gpId, targetId, turn);
+      game = _appendDiplomaticEvent(
+        game,
+        turn,
+        DiplomaticEventType.joinEmpireResolved,
+        {gpId, targetId},
+        fromFactionId: gpId,
+        toFactionId: targetId,
+        overtureStage: OvertureStage.joinEmpire,
+        amount: cost,
+        wasAiInitiator: isAiControlledForEvidence(game, gpId),
+      );
       _diploLog.i('logic: diplomacy join empire $gpId $targetId cost=$cost');
     }
   }
@@ -420,6 +488,15 @@ Game _processAlliances(
               ),
       );
       game = game.copyWith(diplomacyRelations: relations);
+      game = _appendDiplomaticEvent(
+        game,
+        turn,
+        DiplomaticEventType.allianceFormed,
+        {gpId, targetId},
+        fromFactionId: gpId,
+        toFactionId: targetId,
+        wasAiInitiator: isAiControlledForEvidence(game, gpId),
+      );
       _diploLog.i('logic: diplomacy alliance $gpId-$targetId');
     }
   }
@@ -478,15 +555,19 @@ Game _processWarAndPeace(
           
           // Cancel any active subsidies between these factions
           var subsidyStates = List<SubsidyState>.from(game.subsidyStates);
-          final beforeCount = subsidyStates.length;
+          final cancelledSubsidies = subsidyStates
+              .where((s) =>
+                  (s.payerId == gpId && s.targetId == targetId) ||
+                  (s.payerId == targetId && s.targetId == gpId))
+              .toList();
           subsidyStates = subsidyStates
               .where((s) => !((s.payerId == gpId && s.targetId == targetId) ||
                   (s.payerId == targetId && s.targetId == gpId)))
               .toList();
-          if (subsidyStates.length < beforeCount) {
+          if (cancelledSubsidies.isNotEmpty) {
             _diploLog.i('logic: diplomacy subsidies cancelled due to war $gpId vs $targetId');
           }
-          
+
           game = game.copyWith(
             diplomacyRelations: relations,
             subsidyStates: subsidyStates,
@@ -495,6 +576,27 @@ Game _processWarAndPeace(
               ...evidence
             ],
           );
+          game = _appendDiplomaticEvent(
+            game,
+            turn,
+            DiplomaticEventType.declareWar,
+            {gpId, targetId},
+            fromFactionId: gpId,
+            toFactionId: targetId,
+            wasAiInitiator: isAiControlledForEvidence(game, gpId),
+          );
+          for (final s in cancelledSubsidies) {
+            game = _appendDiplomaticEvent(
+              game,
+              turn,
+              DiplomaticEventType.subsidyCancelled,
+              {s.payerId, s.targetId},
+              fromFactionId: s.payerId,
+              toFactionId: s.targetId,
+              reason: 'war',
+              wasAiInitiator: isAiControlledForEvidence(game, s.payerId),
+            );
+          }
           _diploLog.i('logic: diplomacy war declared $gpId vs $targetId (scores reset to 20)');
         }
       } else if (order.type == DiplomaticOrderType.offerPeace) {
@@ -546,6 +648,15 @@ Game _processWarAndPeace(
                 ...evidence,
               ],
             );
+            game = _appendDiplomaticEvent(
+              game,
+              turn,
+              DiplomaticEventType.peace,
+              {gpId, targetId},
+              fromFactionId: gpId,
+              toFactionId: targetId,
+              wasAiInitiator: isAiControlledForEvidence(game, gpId),
+            );
             _diploLog.i('logic: diplomacy peace $gpId-$targetId');
           } else {
             game = game.copyWith(
@@ -563,6 +674,7 @@ Game _processWarAndPeace(
 }
 
 Game _terminateAgreementsOnWar(Game game) {
+  final turn = game.worldState.turnState.turnNumber;
   var overtures = game.overtureStates;
   for (final rel in game.diplomacyRelations) {
     if (!rel.atWar) continue;
@@ -574,7 +686,23 @@ Game _terminateAgreementsOnWar(Game game) {
         .toList();
   }
   if (overtures.length != game.overtureStates.length) {
+    final removed = game.overtureStates
+        .where((o) =>
+            !overtures.any((n) =>
+                n.gpId == o.gpId && n.targetId == o.targetId))
+        .toList();
     game = game.copyWith(overtureStates: overtures);
+    for (final o in removed) {
+      game = _appendDiplomaticEvent(
+        game,
+        turn,
+        DiplomaticEventType.agreementsClearedOnWar,
+        {o.gpId, o.targetId},
+        fromFactionId: o.gpId,
+        toFactionId: o.targetId,
+        reason: 'war',
+      );
+    }
     _diploLog.i('logic: diplomacy agreements terminated (war)');
   }
   return game;
@@ -617,6 +745,16 @@ Game _applyRelationModifiersAndUpdateScores(
         turn: turn,
       );
       game = game.copyWith(players: players, diplomacyRelations: relations);
+      game = _appendDiplomaticEvent(
+        game,
+        turn,
+        DiplomaticEventType.grantAidApplied,
+        {gpId, targetId},
+        fromFactionId: gpId,
+        toFactionId: targetId,
+        amount: amount,
+        wasAiInitiator: isAiControlledForEvidence(game, gpId),
+      );
       _diploLog
           .i('logic: diplomacy GrantAid $gpId -> $targetId amount $amount');
     }
@@ -649,12 +787,11 @@ Game _applyRelationModifiersAndUpdateScores(
       // Store/update ongoing subsidy state
       final existingSubsidyIdx = subsidyStates.indexWhere(
           (s) => s.payerId == gpId && s.targetId == targetId);
-      if (existingSubsidyIdx >= 0) {
-        // Update existing subsidy
+      final isUpdate = existingSubsidyIdx >= 0;
+      if (isUpdate) {
         subsidyStates[existingSubsidyIdx] = subsidyStates[existingSubsidyIdx]
             .copyWith(amountPerTurn: amount);
       } else {
-        // Create new subsidy
         subsidyStates.add(SubsidyState(
           payerId: gpId,
           targetId: targetId,
@@ -662,6 +799,17 @@ Game _applyRelationModifiersAndUpdateScores(
         ));
       }
 
+      game = game.copyWith(players: players, subsidyStates: subsidyStates);
+      game = _appendDiplomaticEvent(
+        game,
+        turn,
+        isUpdate ? DiplomaticEventType.subsidyUpdated : DiplomaticEventType.subsidySet,
+        {gpId, targetId},
+        fromFactionId: gpId,
+        toFactionId: targetId,
+        amount: amount,
+        wasAiInitiator: isAiControlledForEvidence(game, gpId),
+      );
       final targetPlayer = game.playerById(targetId);
       if (targetPlayer != null) {
         _diploLog.i(
@@ -670,7 +818,6 @@ Game _applyRelationModifiersAndUpdateScores(
         _diploLog.i(
             'logic: diplomacy SetSubsidy $gpId -> $targetId amount $amount/turn (ongoing relation boost)');
       }
-      game = game.copyWith(players: players, subsidyStates: subsidyStates);
     }
   }
 
@@ -693,7 +840,16 @@ Game _processOngoingSubsidies(Game game, int turn) {
     // Check if payer can afford subsidy
     final payer = game.playerById(payerId);
     if (payer == null || payer.treasury < amount) {
-      // Cancel subsidy if payer can't afford it
+      game = _appendDiplomaticEvent(
+        game,
+        turn,
+        DiplomaticEventType.subsidyCancelled,
+        {payerId, targetId},
+        fromFactionId: payerId,
+        toFactionId: targetId,
+        reason: 'insufficient funds',
+        wasAiInitiator: isAiControlledForEvidence(game, payerId),
+      );
       subsidyStates = subsidyStates
           .where((s) => s.payerId != payerId || s.targetId != targetId)
           .toList();
@@ -704,7 +860,16 @@ Game _processOngoingSubsidies(Game game, int turn) {
     // Check if still at peace (subsidies cancel on war)
     final rel = getRelation(game, payerId, targetId);
     if (rel != null && rel.atWar) {
-      // Cancel subsidy when war declared
+      game = _appendDiplomaticEvent(
+        game,
+        turn,
+        DiplomaticEventType.subsidyCancelled,
+        {payerId, targetId},
+        fromFactionId: payerId,
+        toFactionId: targetId,
+        reason: 'war declared',
+        wasAiInitiator: isAiControlledForEvidence(game, payerId),
+      );
       subsidyStates = subsidyStates
           .where((s) => s.payerId != payerId || s.targetId != targetId)
           .toList();
@@ -837,9 +1002,24 @@ Game applyInterventionChoice(
   String gpIdWithEmbassy,
   InterventionChoice choice,
 ) {
-  if (choice == InterventionChoice.doNothing) return game;
-
   final turn = game.worldState.turnState.turnNumber;
+  if (choice == InterventionChoice.doNothing) {
+    var g = game;
+    for (final a in ctx.attackers) {
+      final attackerId = a.factionId;
+      if (!isGreatPower(game, attackerId)) continue;
+      g = _appendDiplomaticEvent(
+        g,
+        turn,
+        DiplomaticEventType.interventionDoNothing,
+        {gpIdWithEmbassy, attackerId},
+        fromFactionId: gpIdWithEmbassy,
+        toFactionId: attackerId,
+      );
+    }
+    return g;
+  }
+
   var relations = List<DiplomacyRelation>.from(game.diplomacyRelations);
 
   for (final a in ctx.attackers) {
@@ -891,5 +1071,21 @@ Game applyInterventionChoice(
       });
     }
   }
-  return game.copyWith(diplomacyRelations: relations);
+  game = game.copyWith(diplomacyRelations: relations);
+  final eventType = choice == InterventionChoice.intervene
+      ? DiplomaticEventType.interventionIntervene
+      : DiplomaticEventType.interventionProtest;
+  for (final a in ctx.attackers) {
+    final attackerId = a.factionId;
+    if (!isGreatPower(game, attackerId)) continue;
+    game = _appendDiplomaticEvent(
+      game,
+      turn,
+      eventType,
+      {gpIdWithEmbassy, attackerId},
+      fromFactionId: gpIdWithEmbassy,
+      toFactionId: attackerId,
+    );
+  }
+  return game;
 }

--- a/packages/colonizethis_logic/test/diplomacy_resolver_test.dart
+++ b/packages/colonizethis_logic/test/diplomacy_resolver_test.dart
@@ -1430,5 +1430,86 @@ void main() {
       expect(gpId, 'gp1');
     });
   });
+
+  group('diplomatic history', () {
+    test('declare war appends declareWar event', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 5),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'A', isHuman: true),
+          Player(id: 'gp2', displayName: 'B', isHuman: false),
+        ],
+        diplomacyRelations: const [
+          DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'gp2',
+            score: 50,
+            level: RelationLevel.neutral,
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      final orders = Orders(
+        diplomaticOrdersByPlayerId: {
+          'gp1': const [
+            DiplomaticOrder(type: DiplomaticOrderType.declareWar, targetFactionId: 'gp2'),
+          ],
+        },
+      );
+      final after = resolveDiplomacyPhase(game, orders).game;
+      expect(after.diplomaticHistoryEvents, isNotEmpty);
+      final warEvent = after.diplomaticHistoryEvents
+          .where((e) => e.type == DiplomaticEventType.declareWar)
+          .toList();
+      expect(warEvent.length, 1);
+      expect(warEvent.first.participants, contains('gp1'));
+      expect(warEvent.first.participants, contains('gp2'));
+      expect(warEvent.first.turn, 5);
+    });
+
+    test('diplomaticHistoryForPair returns events for pair newest first', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 10),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'A', isHuman: true),
+          Player(id: 'gp2', displayName: 'B', isHuman: false),
+        ],
+        diplomaticHistoryEvents: [
+          DiplomaticEvent(
+            turn: 1,
+            intraTurnIndex: 0,
+            type: DiplomaticEventType.declareWar,
+            participants: {'gp1', 'gp2'},
+            fromFactionId: 'gp1',
+            toFactionId: 'gp2',
+          ),
+          DiplomaticEvent(
+            turn: 5,
+            intraTurnIndex: 0,
+            type: DiplomaticEventType.peace,
+            participants: {'gp1', 'gp2'},
+            fromFactionId: 'gp1',
+            toFactionId: 'gp2',
+          ),
+        ],
+      );
+      final list = diplomaticHistoryForPair(game, 'gp1', 'gp2');
+      expect(list.length, 2);
+      expect(list[0].type, DiplomaticEventType.peace);
+      expect(list[0].turn, 5);
+      expect(list[1].type, DiplomaticEventType.declareWar);
+      expect(list[1].turn, 1);
+    });
+  });
 }
 

--- a/packages/colonizethis_models/lib/src/diplomacy.dart
+++ b/packages/colonizethis_models/lib/src/diplomacy.dart
@@ -201,7 +201,6 @@ class DiplomaticOrder {
           overtureStage == other.overtureStage;
 
   @override
-  @override
   int get hashCode => Object.hash(type, targetFactionId, amount, overtureStage);
 }
 
@@ -258,4 +257,124 @@ class SubsidyState {
 
   @override
   int get hashCode => Object.hash(payerId, targetId, amountPerTurn);
+}
+
+/// Primary type for a diplomatic history event. SPEC/program/diplomacy-resolution.md.
+enum DiplomaticEventType {
+  declareWar,
+  peace,
+  allianceFormed,
+  allianceBroken,
+  overtureAccepted,
+  overtureRejected,
+  joinEmpireResolved,
+  grantAidApplied,
+  subsidySet,
+  subsidyUpdated,
+  subsidyCancelled,
+  interventionIntervene,
+  interventionDoNothing,
+  interventionProtest,
+  agreementsClearedOnWar,
+}
+
+/// Diplomatic history event stored on Game.diplomaticHistoryEvents.
+class DiplomaticEvent {
+  const DiplomaticEvent({
+    required this.turn,
+    required this.intraTurnIndex,
+    required this.type,
+    required this.participants,
+    this.fromFactionId,
+    this.toFactionId,
+    this.overtureStage,
+    this.amount,
+    this.reason,
+    this.wasAiInitiator = false,
+  });
+
+  final int turn;
+  final int intraTurnIndex;
+  final DiplomaticEventType type;
+  final Set<String> participants;
+  final String? fromFactionId;
+  final String? toFactionId;
+  final OvertureStage? overtureStage;
+  final int? amount;
+  final String? reason;
+  final bool wasAiInitiator;
+
+  Map<String, dynamic> toJson() => {
+        'turn': turn,
+        'intraTurnIndex': intraTurnIndex,
+        'type': type.name,
+        'participants': participants.toList(),
+        if (fromFactionId != null) 'fromFactionId': fromFactionId,
+        if (toFactionId != null) 'toFactionId': toFactionId,
+        if (overtureStage != null) 'overtureStage': overtureStage!.name,
+        if (amount != null) 'amount': amount,
+        if (reason != null) 'reason': reason,
+        if (wasAiInitiator) 'wasAiInitiator': wasAiInitiator,
+      };
+
+  static DiplomaticEvent fromJson(Map<String, dynamic> json) {
+    final participantsList = json['participants'] as List<dynamic>? ?? [];
+    return DiplomaticEvent(
+      turn: (json['turn'] as num).toInt(),
+      intraTurnIndex: (json['intraTurnIndex'] as num).toInt(),
+      type: DiplomaticEventType.values.firstWhere(
+        (e) => e.name == json['type'],
+        orElse: () => DiplomaticEventType.declareWar,
+      ),
+      participants: participantsList.map((e) => e.toString()).toSet(),
+      fromFactionId: json['fromFactionId'] as String?,
+      toFactionId: json['toFactionId'] as String?,
+      overtureStage: json['overtureStage'] != null
+          ? OvertureStage.values.firstWhere(
+              (e) => e.name == json['overtureStage'],
+              orElse: () => OvertureStage.none,
+            )
+          : null,
+      amount: json['amount'] as int?,
+      reason: json['reason'] as String?,
+      wasAiInitiator: json['wasAiInitiator'] == true,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DiplomaticEvent &&
+          turn == other.turn &&
+          intraTurnIndex == other.intraTurnIndex &&
+          type == other.type &&
+          _setEquals(participants, other.participants) &&
+          fromFactionId == other.fromFactionId &&
+          toFactionId == other.toFactionId &&
+          overtureStage == other.overtureStage &&
+          amount == other.amount &&
+          reason == other.reason &&
+          wasAiInitiator == other.wasAiInitiator;
+
+  @override
+  int get hashCode => Object.hash(
+        turn,
+        intraTurnIndex,
+        type,
+        Object.hashAll(participants),
+        fromFactionId,
+        toFactionId,
+        overtureStage,
+        amount,
+        reason,
+        wasAiInitiator,
+      );
+
+  static bool _setEquals<T>(Set<T> a, Set<T> b) {
+    if (a.length != b.length) return false;
+    for (final value in a) {
+      if (!b.contains(value)) return false;
+    }
+    return true;
+  }
 }

--- a/packages/colonizethis_models/lib/src/game.dart
+++ b/packages/colonizethis_models/lib/src/game.dart
@@ -82,6 +82,7 @@ class Game {
     this.aiSeedByGpId = const {},
     this.hiddenAgendaByGpId = const {},
     this.dossierEvidenceEntries = const [],
+    this.diplomaticHistoryEvents = const [],
     this.globalGameSeed,
     this.greatPowerColorOverride,
     this.victory,
@@ -128,6 +129,9 @@ class Game {
   /// Evidence entries for dossier (observer, subject, agenda, turn, description). Phase 6.
   final List<DossierEvidenceEntry> dossierEvidenceEntries;
 
+  /// Flat, append-only list of diplomatic history events. Phase 6.
+  final List<DiplomaticEvent> diplomaticHistoryEvents;
+
   /// Global game seed for AI determinism. Phase 4.
   final int? globalGameSeed;
 
@@ -168,6 +172,9 @@ class Game {
         if (hiddenAgendaByGpId.isNotEmpty) 'hiddenAgendaByGpId': hiddenAgendaByGpId,
         if (dossierEvidenceEntries.isNotEmpty)
           'dossierEvidenceEntries': dossierEvidenceEntries.map((e) => e.toJson()).toList(),
+        if (diplomaticHistoryEvents.isNotEmpty)
+          'diplomaticHistoryEvents':
+              diplomaticHistoryEvents.map((e) => e.toJson()).toList(),
         if (globalGameSeed != null) 'globalGameSeed': globalGameSeed,
         if (greatPowerColorOverride != null && greatPowerColorOverride!.isNotEmpty)
           'greatPowerColorOverride': greatPowerColorOverride!.map((k, v) => MapEntry(k, v)),
@@ -219,6 +226,10 @@ class Game {
     final dossierEvidenceEntries = evidenceList
         .map((e) => DossierEvidenceEntry.fromJson(Map<String, dynamic>.from(e as Map)))
         .toList();
+    final diploHistoryList = json['diplomaticHistoryEvents'] as List<dynamic>? ?? [];
+    final diplomaticHistoryEvents = diploHistoryList
+        .map((e) => DiplomaticEvent.fromJson(Map<String, dynamic>.from(e as Map)))
+        .toList();
     final globalGameSeed = json['globalGameSeed'] as int?;
     final greatPowerColorOverrideRaw = json['greatPowerColorOverride'] as Map<dynamic, dynamic>?;
     final greatPowerColorOverride = greatPowerColorOverrideRaw?.map(
@@ -267,6 +278,7 @@ class Game {
       aiSeedByGpId: aiSeedByGpId,
       hiddenAgendaByGpId: hiddenAgendaByGpId,
       dossierEvidenceEntries: dossierEvidenceEntries,
+      diplomaticHistoryEvents: diplomaticHistoryEvents,
       globalGameSeed: globalGameSeed,
       greatPowerColorOverride: greatPowerColorOverride,
       victory: json['victory'] is Map<String, dynamic>
@@ -296,6 +308,7 @@ class Game {
     Map<String, int>? aiSeedByGpId,
     Map<String, String>? hiddenAgendaByGpId,
     List<DossierEvidenceEntry>? dossierEvidenceEntries,
+    List<DiplomaticEvent>? diplomaticHistoryEvents,
     int? globalGameSeed,
     Map<String, List<int>>? greatPowerColorOverride,
     VictoryState? victory,
@@ -319,6 +332,8 @@ class Game {
       aiSeedByGpId: aiSeedByGpId ?? this.aiSeedByGpId,
       hiddenAgendaByGpId: hiddenAgendaByGpId ?? this.hiddenAgendaByGpId,
       dossierEvidenceEntries: dossierEvidenceEntries ?? this.dossierEvidenceEntries,
+      diplomaticHistoryEvents:
+          diplomaticHistoryEvents ?? this.diplomaticHistoryEvents,
       globalGameSeed: globalGameSeed ?? this.globalGameSeed,
       greatPowerColorOverride: greatPowerColorOverride ?? this.greatPowerColorOverride,
       victory: victory ?? this.victory,
@@ -349,6 +364,7 @@ class Game {
           _mapEquals(aiSeedByGpId, other.aiSeedByGpId) &&
           _mapEquals(hiddenAgendaByGpId, other.hiddenAgendaByGpId) &&
           _listEquals(dossierEvidenceEntries, other.dossierEvidenceEntries) &&
+          _listEquals(diplomaticHistoryEvents, other.diplomaticHistoryEvents) &&
           globalGameSeed == other.globalGameSeed &&
           _mapListEquals(greatPowerColorOverride, other.greatPowerColorOverride) &&
           victory == other.victory &&
@@ -372,7 +388,7 @@ class Game {
         Object.hashAll(aiControlByGpId.entries),
         Object.hashAll(aiSeedByGpId.entries),
         Object.hashAll(hiddenAgendaByGpId.entries),
-        Object.hashAll(dossierEvidenceEntries),
+        Object.hash(Object.hashAll(dossierEvidenceEntries), Object.hashAll(diplomaticHistoryEvents)),
         globalGameSeed,
         greatPowerColorOverride != null ? Object.hashAll(greatPowerColorOverride!.entries) : null,
         victory,

--- a/packages/colonizethis_models/test/game_test.dart
+++ b/packages/colonizethis_models/test/game_test.dart
@@ -178,5 +178,36 @@ void main() {
       final fromLegacy = Game.fromJson(legacy);
       expect(fromLegacy.richesCashMultiplier, 1.0);
     });
+    test('diplomaticHistoryEvents round-trip and backward compat', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'gp1', displayName: 'A', isHuman: true)],
+        diplomaticHistoryEvents: [
+          DiplomaticEvent(
+            turn: 1,
+            intraTurnIndex: 0,
+            type: DiplomaticEventType.declareWar,
+            participants: {'gp1', 'gp2'},
+            fromFactionId: 'gp1',
+            toFactionId: 'gp2',
+          ),
+        ],
+      );
+      final round = Game.fromJson(game.toJson());
+      expect(round.diplomaticHistoryEvents.length, 1);
+      expect(round.diplomaticHistoryEvents.first.type, DiplomaticEventType.declareWar);
+      expect(round.diplomaticHistoryEvents.first.participants, contains('gp1'));
+      expect(round.diplomaticHistoryEvents.first.turn, 1);
+      // Backward compat: missing key => empty list
+      final json = game.toJson();
+      final legacy = Map<String, dynamic>.from(json)..remove('diplomaticHistoryEvents');
+      final fromLegacy = Game.fromJson(legacy);
+      expect(fromLegacy.diplomaticHistoryEvents, isEmpty);
+    });
   });
 }


### PR DESCRIPTION
## Summary
Adds a full, persistent diplomatic history log: all treaties/overtures and diplomatic state changes (war/peace, alliances, Join Empire, interventions, subsidies, grants) as structured events, with UI and fog-of-war handling.

## Changes
- **SPEC**: GDD (`SPEC/game/diplomacy.md`), TDD (`SPEC/program/diplomacy-resolution.md`), UI (`SPEC/ui/diplomacy-panel.md`) for scope, event types, time/ordering, visibility (unknown faction), retention, and detail view behaviour.
- **Models**: `DiplomaticEvent` + `DiplomaticEventType` in colonizethis_models; `Game.diplomaticHistoryEvents` with save/load and backward compat (empty list for legacy saves).
- **Logic**: Diplomacy resolver appends events at all relevant points (declare war, peace, overture accepted/rejected, subsidies, interventions, Join Empire, etc.); `diplomaticHistoryForPair()` for filtered, newest-first history.
- **App**: New `DiplomacyDetailScreen` (history list + dossier subpanel for GPs); tapping a faction row in the diplomacy panel opens it. Events shown as year (turn in brackets); undiscovered factions shown as "Unknown faction".

## Testing
- `colonizethis_models`: game round-trip and backward compat for `diplomaticHistoryEvents`.
- `colonizethis_logic`: resolver appends `declareWar` event; `diplomaticHistoryForPair` filtering and ordering.

Made with [Cursor](https://cursor.com)