### PR TITLE
feat(ui): tech tree legend and orthogonal edges

### DIFF
--- a/SPEC/ui/tech-tree-widget.md
+++ b/SPEC/ui/tech-tree-widget.md
@@ -10,9 +10,14 @@
 ## Layout
 
 - **Graph:** All techs from the global catalog in a single graph. **Left to right:** starting techs (no prerequisites) at the left; end-game techs at the right. Nodes are arranged in **topological layers** (by distance from roots); within a layer, nodes may be grouped or spaced to reduce edge crossings.
-- **Edges:** **Explicit lines** (e.g. arrows or segments) from each prerequisite tech to the tech that requires it. Edges do not obscure node labels.
+- **Edges:** **Explicit right‑angled lines** (orthogonal segments) from each prerequisite tech to the tech that requires it. Edges run horizontally out from the source node, then vertically, then horizontally into the target node, and are drawn **behind nodes** so they do not obscure node labels or node bodies.
 - **Scroll:** The graph can be long; the content is inside a **scrollable** viewport (e.g. `SingleChildScrollView` with both axes, or scrollable region). No zoom or pan required for MVP.
 - **Categories:** One graph shows **all** techs. Each node is **color-coded by category** (gathering, transport, labour, civilian, diplomacy, naval, military; new-world if present). Category colours are distinct and consistent (e.g. gathering = green, transport = blue, labour = amber, etc.; exact palette in theme or widget).
+
+### Legend
+
+- **Category legend:** The tree screen shows a compact legend explaining the colour for each tech category (e.g. gathering = green, transport = blue, etc.), using the same palette as the nodes.
+- **State legend:** The legend also explains node state visuals for the current player (Researched, In progress, Available, Locked), matching the styles in the Node states section below.
 
 ## Node states (current player only)
 

--- a/app/lib/features/game/widgets/tech_tree_widget.dart
+++ b/app/lib/features/game/widgets/tech_tree_widget.dart
@@ -62,45 +62,57 @@ class TechTreeWidget extends StatelessWidget {
     final inProgress = player.researchProgressByTechId?.keys.toSet() ?? {};
     final researchable = researchableTechIds(unlocked);
 
-    return SingleChildScrollView(
-      scrollDirection: Axis.vertical,
-      child: SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        child: SizedBox(
-          width: width,
-          height: height,
-          child: Stack(
-            children: [
-              CustomPaint(
-                size: Size(width, height),
-                painter: _TechTreeEdgePainter(
-                  positions: positions,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: _TechTreeLegend(),
+        ),
+        const Divider(height: 1),
+        Expanded(
+          child: SingleChildScrollView(
+            scrollDirection: Axis.vertical,
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: SizedBox(
+                width: width,
+                height: height,
+                child: Stack(
+                  children: [
+                    CustomPaint(
+                      size: Size(width, height),
+                      painter: _TechTreeEdgePainter(
+                        positions: positions,
+                      ),
+                    ),
+                    ...positions.map((pos) {
+                      final tech = techById(pos.techId);
+                      if (tech == null) return const SizedBox.shrink();
+                      final state = _TechNodeState(
+                        researched: unlocked[pos.techId] == true,
+                        inProgress: inProgress.contains(pos.techId),
+                        available: researchable.contains(pos.techId),
+                      );
+                      return Positioned(
+                        left: pos.x,
+                        top: pos.y,
+                        width: _nodeWidth,
+                        height: _nodeHeight,
+                        child: _TechNode(
+                          tech: tech,
+                          state: state,
+                          onTap: () => _showTechDialog(context, tech),
+                        ),
+                      );
+                    }),
+                  ],
                 ),
               ),
-              ...positions.map((pos) {
-                final tech = techById(pos.techId);
-                if (tech == null) return const SizedBox.shrink();
-                final state = _TechNodeState(
-                  researched: unlocked[pos.techId] == true,
-                  inProgress: inProgress.contains(pos.techId),
-                  available: researchable.contains(pos.techId),
-                );
-                return Positioned(
-                  left: pos.x,
-                  top: pos.y,
-                  width: _nodeWidth,
-                  height: _nodeHeight,
-                  child: _TechNode(
-                    tech: tech,
-                    state: state,
-                    onTap: () => _showTechDialog(context, tech),
-                  ),
-                );
-              }),
-            ],
+            ),
           ),
         ),
-      ),
+      ],
     );
   }
 
@@ -295,14 +307,24 @@ class _TechTreeEdgePainter extends CustomPainter {
     for (final tech in techCatalog.values) {
       final toPos = posByTech[tech.id];
       if (toPos == null) continue;
-      final toCenterX = toPos.x + _centerX;
+      final toLeftX = toPos.x;
       final toCenterY = toPos.y + _centerY;
       for (final prereqId in tech.prerequisiteIds) {
         final fromPos = posByTech[prereqId];
         if (fromPos == null) continue;
-        final fromCenterX = fromPos.x + _centerX;
+        final fromRightX = fromPos.x + _nodeWidth;
         final fromCenterY = fromPos.y + _centerY;
-        canvas.drawLine(Offset(fromCenterX, fromCenterY), Offset(toCenterX, toCenterY), paint);
+
+        // Orthogonal (right-angled) path: out from right edge, over horizontally, then into left edge.
+        final midX = (fromRightX + toLeftX) / 2;
+
+        final path = Path()
+          ..moveTo(fromRightX, fromCenterY)
+          ..lineTo(midX, fromCenterY)
+          ..lineTo(midX, toCenterY)
+          ..lineTo(toLeftX, toCenterY);
+
+        canvas.drawPath(path, paint);
       }
     }
   }
@@ -378,6 +400,118 @@ class _TechNode extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _TechTreeLegend extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Technology tree legend',
+          style: theme.textTheme.labelLarge,
+        ),
+        const SizedBox(height: 4),
+        Wrap(
+          spacing: 8,
+          runSpacing: 4,
+          children: _categoryColors.entries
+              .map(
+                (e) => _LegendChip(
+                  color: e.value,
+                  label: TechTreeWidget._categoryLabel(e.key),
+                ),
+              )
+              .toList(),
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 4,
+          children: const [
+            _StateLegendSample(
+              label: 'Researched',
+              state: _TechNodeState(researched: true, inProgress: false, available: false),
+            ),
+            _StateLegendSample(
+              label: 'In progress',
+              state: _TechNodeState(researched: false, inProgress: true, available: false),
+            ),
+            _StateLegendSample(
+              label: 'Available',
+              state: _TechNodeState(researched: false, inProgress: false, available: true),
+            ),
+            _StateLegendSample(
+              label: 'Locked',
+              state: _TechNodeState(researched: false, inProgress: false, available: false),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _LegendChip extends StatelessWidget {
+  const _LegendChip({required this.color, required this.label});
+
+  final Color color;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Chip(
+      label: Text(label),
+      backgroundColor: color.withValues(alpha: 0.2),
+      side: BorderSide(color: color, width: 1.5),
+      labelStyle: Theme.of(context).textTheme.bodySmall,
+      visualDensity: VisualDensity.compact,
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+    );
+  }
+}
+
+class _StateLegendSample extends StatelessWidget {
+  const _StateLegendSample({required this.label, required this.state});
+
+  final String label;
+  final _TechNodeState state;
+
+  @override
+  Widget build(BuildContext context) {
+    // Use a dummy tech with neutral category just to render the style.
+    const dummyTech = TechDefinition(
+      id: 'legend_dummy',
+      era: 1,
+      category: 'gathering',
+      cost: 0,
+      prerequisiteIds: <String>[],
+      regimentUnlockIds: <String>[],
+      shipUnlockIds: <String>[],
+    );
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: 72,
+          height: 24,
+          child: _TechNode(
+            tech: dummyTech,
+            state: state,
+            onTap: () {},
+          ),
+        ),
+        const SizedBox(width: 4),
+        Text(
+          label,
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+      ],
     );
   }
 }

--- a/app/test/tech_tree_widget_test.dart
+++ b/app/test/tech_tree_widget_test.dart
@@ -180,6 +180,45 @@ void main() {
     expect(find.byType(TechTreeWidget), findsOneWidget);
     expect(find.byType(SingleChildScrollView), findsWidgets);
   });
+
+  testWidgets('TechTreeWidget shows legend with category and state labels', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TechTreeWidget(game: game, player: player),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Technology tree legend'), findsOneWidget);
+    expect(find.text('Gathering'), findsAtLeastNWidgets(1));
+    expect(find.text('Researched'), findsOneWidget);
+    expect(find.text('In progress'), findsOneWidget);
+    expect(find.text('Available'), findsOneWidget);
+    expect(find.text('Locked'), findsOneWidget);
+  });
+
+  testWidgets('Tapping locked tech node does not open dialog', (WidgetTester tester) async {
+    final emptyPlayer = player.copyWith(techUnlocked: <String, bool>{});
+    final gameWithEmptyPlayer = game.copyWith(
+      players: [emptyPlayer, ...game.players.skip(1)],
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TechTreeWidget(game: gameWithEmptyPlayer, player: emptyPlayer),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsNothing);
+    // Gathering 2 has prerequisite gathering_1; with no techs unlocked it is locked.
+    final gathering2Find = find.text('Gathering 2');
+    await tester.ensureVisible(gathering2Find.first);
+    await tester.tap(gathering2Find.first);
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsNothing);
+  });
 }
 
 Player _dummyPlayer() {

--- a/app/test/technology_panel_test.dart
+++ b/app/test/technology_panel_test.dart
@@ -1,0 +1,130 @@
+// Tests for TechnologyPanel. UXD 03k — research slots and researched techs.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/features/game/widgets/technology_panel.dart';
+import 'package:colonizethis_app/widgets/debug_init_game.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  late Game game;
+  late Player player;
+
+  setUpAll(() {
+    final result = getDebugInitGameResult();
+    game = result.game;
+    player = game.players.isNotEmpty ? game.players.first : _dummyPlayer();
+  });
+
+  testWidgets('TechnologyPanel builds and shows player name and research slots', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: TechnologyPanel(game: game, player: player),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byType(TechnologyPanel), findsOneWidget);
+    expect(find.textContaining(player.displayName), findsOneWidget);
+    expect(find.textContaining('Research slots:'), findsOneWidget);
+    expect(find.text('Researched (0):'), findsOneWidget);
+  });
+
+  testWidgets('TechnologyPanel shows None yet when no researched techs', (WidgetTester tester) async {
+    final emptyPlayer = player.copyWith(techUnlocked: <String, bool>{});
+    final gameWithEmpty = game.copyWith(
+      players: [emptyPlayer, ...game.players.skip(1)],
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: TechnologyPanel(game: gameWithEmpty, player: emptyPlayer),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('None yet'), findsOneWidget);
+    expect(find.byType(Chip), findsNothing);
+  });
+
+  testWidgets('TechnologyPanel shows researched tech chips when player has techs', (WidgetTester tester) async {
+    final ids = techCatalog.keys.take(3).toList();
+    final techUnlocked = {for (final id in ids) id: true};
+    final withTechs = player.copyWith(techUnlocked: techUnlocked);
+    final gameWithTechs = game.copyWith(
+      players: [withTechs, ...game.players.skip(1)],
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: TechnologyPanel(game: gameWithTechs, player: withTechs),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Researched (3):'), findsOneWidget);
+    expect(find.byType(Chip), findsNWidgets(3));
+  });
+
+  testWidgets('TechnologyPanel shows in progress section when player has research progress', (WidgetTester tester) async {
+    final techId = techCatalog.keys.first;
+    final withProgress = player.copyWith(
+      researchProgressByTechId: {techId: 50},
+    );
+    final gameWithProgress = game.copyWith(
+      players: [withProgress, ...game.players.skip(1)],
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: TechnologyPanel(game: gameWithProgress, player: withProgress),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('In progress:'), findsOneWidget);
+    expect(find.textContaining('pts'), findsOneWidget);
+  });
+
+  testWidgets('TechnologyPanel shows custom research slots when set', (WidgetTester tester) async {
+    const slots = 4;
+    final withSlots = player.copyWith(researchSlots: slots);
+    final gameWithSlots = game.copyWith(
+      players: [withSlots, ...game.players.skip(1)],
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: TechnologyPanel(game: gameWithSlots, player: withSlots),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Research slots: $slots'), findsOneWidget);
+  });
+}
+
+Player _dummyPlayer() {
+  return Player(
+    id: 'dummy',
+    displayName: 'Dummy',
+    isHuman: true,
+  );
+}


### PR DESCRIPTION
## Summary
- Add category and state legend to Technology tree tab to explain node colours and statuses.
- Change tech tree edges to right-angled orthogonal paths drawn behind nodes (per SPEC/ui/tech-tree-widget.md).
- Extend TechTreeWidget tests for legend and locked node behaviour; add TechnologyPanel widget tests for researched techs, in-progress list, and slots.

## Test plan
- flutter test app/test/tech_tree_widget_test.dart
- flutter test app/test/technology_panel_test.dart (note: current environment hit a 12-minute timeout while loading; the test file matches existing debug-init patterns used elsewhere).

Made with [Cursor](https://cursor.com)