### PR TITLE
feat(ui): improve technology panel slots and tech effects

### DIFF
--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -64,11 +64,18 @@ class GameScreen extends ConsumerWidget {
                       final player =
                           game.players.isNotEmpty ? game.players.first : null;
                       if (player != null) {
+                        final orders = ref.read(currentOrdersProvider);
                         Navigator.of(context).push<void>(
                           MaterialPageRoute<void>(
                             builder: (ctx) => TechnologyScreen(
                               game: game,
                               player: player,
+                              currentOrders: orders,
+                              onOrdersChanged: (newOrders) {
+                                ref
+                                    .read(currentOrdersProvider.notifier)
+                                    .state = newOrders;
+                              },
                             ),
                           ),
                         );

--- a/app/lib/features/game/widgets/tech_tree_widget.dart
+++ b/app/lib/features/game/widgets/tech_tree_widget.dart
@@ -253,17 +253,57 @@ class TechTreeWidget extends StatelessWidget {
         list.add('Fort level 2');
         break;
       case 'national_bureaucracy':
-        list.add('Builder upgrade_town');
+        list.add('Builders can upgrade provincial towns');
+        list.add('Helps increase general cap');
         break;
       case 'merchant_companies':
-        list.add('Merchant unit');
+        list.add('Unlocks Merchant civilian unit');
+        list.add('Allows purchasing land in Minor Nations (with embassy)');
+        break;
+      case 'printing_press':
+        list.add('Enables Trained Journeymen and advanced tactics');
+        break;
+      case 'money_lending':
+        list.add('Improves borrowing: more credit at lower interest');
+        list.add('Prerequisite for National Bureaucracy');
+        break;
+      case 'apprentice_workers':
+        list.add('Unlocks Apprentice Workers (4× labour; consume refined sugar)');
+        break;
+      case 'trained_journeymen':
+        list.add('Unlocks Trained Journeymen (6× labour; consume cigars)');
+        break;
+      case 'master_artisans':
+        list.add('Unlocks Master Artisans (8× labour; consume fur hats)');
+        break;
+      case 'trade_fairs':
+        list.add('Can bid on 6 commodities instead of 3');
+        break;
+      case 'banking':
+        list.add('Enables advanced banking: lower interest and larger negative spending');
+        break;
+      case 'diplomatic_expertise':
+        list.add('Unlocks embassies with Minor Nations');
+        list.add('Civilian units may work in Minors with an embassy');
+        break;
+      case 'propaganda':
+        list.add('Decreases diplomatic penalties for declaring war');
+        break;
+      case 'nationalism':
+        list.add('Increases battle deployment limit to 12 regiments');
+        list.add('Helps raise general cap');
+        break;
+      case 'empire_building':
+        list.add('Allows asking Great Powers to join your empire peacefully');
         break;
       case 'land_enclosure':
       case 'hat_production':
-        list.add('Labour / economy');
+        list.add('Improves labour and economy output');
         break;
       default:
-        if (list.isEmpty) list.add('See GDD');
+        if (list.isEmpty) {
+          list.add('Improves ${_categoryLabel(tech.category)} capabilities');
+        }
     }
     return list;
   }

--- a/app/lib/features/game/widgets/technology_panel.dart
+++ b/app/lib/features/game/widgets/technology_panel.dart
@@ -1,3 +1,4 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
@@ -7,10 +8,14 @@ class TechnologyPanel extends StatelessWidget {
     super.key,
     required this.game,
     required this.player,
+    this.currentOrders = const Orders(),
+    this.onOrdersChanged,
   });
 
   final Game game;
   final Player player;
+  final Orders currentOrders;
+  final void Function(Orders orders)? onOrdersChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -19,9 +24,21 @@ class TechnologyPanel extends StatelessWidget {
         .where((e) => e.value)
         .map((e) => e.key)
         .toList()
-      ..sort();
+      ..sort((a, b) {
+        final ta = techById(a);
+        final tb = techById(b);
+        final eraA = ta?.era ?? 999;
+        final eraB = tb?.era ?? 999;
+        final eraCmp = eraA.compareTo(eraB);
+        if (eraCmp != 0) return eraCmp;
+        return techDisplayName(a).compareTo(techDisplayName(b));
+      });
     final progress = player.researchProgressByTechId ?? {};
     final slots = player.researchSlots ?? 3;
+    final humanPlayerId = player.id;
+    final researchOrdersForPlayer =
+        currentOrders.researchOrdersByPlayerId[humanPlayerId] ??
+            const <ResearchOrder>[];
 
     return Card(
       margin: const EdgeInsets.all(16),
@@ -39,6 +56,79 @@ class TechnologyPanel extends StatelessWidget {
             Text('Research slots: $slots'),
             const SizedBox(height: 8),
             Text(
+              'Research slots',
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+            const SizedBox(height: 4),
+            Column(
+              children: List.generate(slots, (index) {
+                ResearchOrder? order;
+                for (final o in researchOrdersForPlayer) {
+                  if (o.slotIndex == index) {
+                    order = o;
+                  }
+                }
+                final techId = order?.techId.isNotEmpty == true
+                    ? order!.techId
+                    : null;
+                final tech = techId != null ? techById(techId) : null;
+                final displayName = techId != null
+                    ? techDisplayName(techId)
+                    : 'Empty';
+                final techProgress =
+                    techId != null ? (progress[techId] ?? 0) : 0;
+                final cost = tech?.cost ?? 0;
+                final hasTech = techId != null;
+                final canEdit = onOrdersChanged != null;
+                return ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: Text('Slot ${index + 1}'),
+                  subtitle: hasTech
+                      ? Text(
+                          '$displayName · ${techProgress}/${cost > 0 ? cost : '—'} RP',
+                        )
+                      : const Text('No tech assigned'),
+                  trailing: canEdit
+                      ? Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            if (hasTech)
+                              TextButton(
+                                onPressed: () {
+                                  _cancelSlot(
+                                    context: context,
+                                    slotIndex: index,
+                                    humanPlayerId: humanPlayerId,
+                                    currentOrders: currentOrders,
+                                    onOrdersChanged: onOrdersChanged!,
+                                  );
+                                },
+                                child: const Text('Cancel'),
+                              ),
+                            const SizedBox(width: 4),
+                            FilledButton.tonal(
+                              onPressed: () {
+                                _showAssignDialog(
+                                  context: context,
+                                  slotIndex: index,
+                                  humanPlayerId: humanPlayerId,
+                                  currentOrders: currentOrders,
+                                  player: player,
+                                  onOrdersChanged: onOrdersChanged!,
+                                );
+                              },
+                              child: const Text('Choose tech'),
+                            ),
+                          ],
+                        )
+                      : null,
+                );
+              }),
+            ),
+            const SizedBox(height: 12),
+            Divider(color: Theme.of(context).dividerColor),
+            const SizedBox(height: 8),
+            Text(
               'Researched (${researchedIds.length}):',
               style: Theme.of(context).textTheme.labelLarge,
             ),
@@ -50,10 +140,12 @@ class TechnologyPanel extends StatelessWidget {
                 spacing: 4,
                 runSpacing: 4,
                 children: researchedIds
-                    .map((id) => Chip(
-                          label: Text(id),
-                          labelStyle: Theme.of(context).textTheme.bodySmall,
-                        ))
+                    .map(
+                      (id) => Chip(
+                        label: Text(techDisplayName(id)),
+                        labelStyle: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    )
                     .toList(),
               ),
             if (progress.isNotEmpty) ...[
@@ -67,7 +159,7 @@ class TechnologyPanel extends StatelessWidget {
                 (e) => Padding(
                   padding: const EdgeInsets.only(bottom: 4),
                   child: Text(
-                    '${e.key}: ${e.value} pts',
+                    '${techDisplayName(e.key)}: ${e.value} RP',
                     style: Theme.of(context).textTheme.bodySmall,
                   ),
                 ),
@@ -78,4 +170,163 @@ class TechnologyPanel extends StatelessWidget {
       ),
     );
   }
+}
+
+void _showAssignDialog({
+  required BuildContext context,
+  required int slotIndex,
+  required String humanPlayerId,
+  required Orders currentOrders,
+  required Player player,
+  required void Function(Orders orders) onOrdersChanged,
+}) {
+  final techUnlocked = player.techUnlocked ?? {};
+  final existingOrders =
+      currentOrders.researchOrdersByPlayerId[humanPlayerId] ??
+          const <ResearchOrder>[];
+  final currentlyAssignedIds = existingOrders
+      .where((o) => o.techId.isNotEmpty)
+      .map((o) => o.techId)
+      .toSet();
+
+  final availableTechs = techCatalog.values.where((tech) {
+    if (techUnlocked[tech.id] == true) return false;
+    if (currentlyAssignedIds.contains(tech.id)) return false;
+    return true;
+  }).toList()
+    ..sort((a, b) {
+      final eraCmp = a.era.compareTo(b.era);
+      if (eraCmp != 0) return eraCmp;
+      return techDisplayName(a.id).compareTo(techDisplayName(b.id));
+    });
+
+  showModalBottomSheet<void>(
+    context: context,
+    builder: (ctx) {
+      if (availableTechs.isEmpty) {
+        return const Padding(
+          padding: EdgeInsets.all(16),
+          child: Text('No techs available to research'),
+        );
+      }
+      return ListView.builder(
+        itemCount: availableTechs.length,
+        itemBuilder: (context, index) {
+          final tech = availableTechs[index];
+          return ListTile(
+            title: Text(techDisplayName(tech.id)),
+            subtitle: Text(
+              'Era ${_eraRoman(tech.era)} · ${_categoryLabel(tech.category)} · ${tech.cost} RP',
+            ),
+            onTap: () {
+              final unlocked = techUnlocked;
+              final missing = <String>[];
+              for (final prereqId in tech.prerequisiteIds) {
+                if (unlocked[prereqId] != true) {
+                  missing.add(techDisplayName(prereqId));
+                }
+              }
+              if (missing.isNotEmpty) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text(
+                      'Prerequisites not met: ${missing.join(', ')}',
+                    ),
+                  ),
+                );
+                return;
+              }
+
+              final updatedOrders = _assignTechToSlot(
+                currentOrders: currentOrders,
+                humanPlayerId: humanPlayerId,
+                slotIndex: slotIndex,
+                techId: tech.id,
+                existingOrders: existingOrders,
+              );
+              onOrdersChanged(updatedOrders);
+              Navigator.of(ctx).pop();
+            },
+          );
+        },
+      );
+    },
+  );
+}
+
+Orders _assignTechToSlot({
+  required Orders currentOrders,
+  required String humanPlayerId,
+  required int slotIndex,
+  required String techId,
+  required List<ResearchOrder> existingOrders,
+}) {
+  final ordersForPlayer = List<ResearchOrder>.from(existingOrders);
+  final existingIndex =
+      ordersForPlayer.indexWhere((o) => o.slotIndex == slotIndex);
+  final funding = existingIndex >= 0
+      ? ordersForPlayer[existingIndex].funding
+      : ResearchFundingLevel.medium;
+  final newOrder = ResearchOrder(
+    slotIndex: slotIndex,
+    techId: techId,
+    funding: funding,
+  );
+  if (existingIndex >= 0) {
+    ordersForPlayer[existingIndex] = newOrder;
+  } else {
+    ordersForPlayer.add(newOrder);
+  }
+
+  final updatedMap = {
+    ...currentOrders.researchOrdersByPlayerId,
+    humanPlayerId: ordersForPlayer,
+  };
+  return currentOrders.copyWith(researchOrdersByPlayerId: updatedMap);
+}
+
+void _cancelSlot({
+  required BuildContext context,
+  required int slotIndex,
+  required String humanPlayerId,
+  required Orders currentOrders,
+  required void Function(Orders orders) onOrdersChanged,
+}) {
+  final existingOrders =
+      currentOrders.researchOrdersByPlayerId[humanPlayerId] ??
+          const <ResearchOrder>[];
+  final remaining = existingOrders
+      .where((o) => o.slotIndex != slotIndex)
+      .toList(growable: false);
+  final updatedMap = {
+    ...currentOrders.researchOrdersByPlayerId,
+    humanPlayerId: remaining,
+  };
+  final updated = currentOrders.copyWith(
+    researchOrdersByPlayerId: updatedMap,
+  );
+  final messenger = ScaffoldMessenger.maybeOf(context);
+  messenger?.showSnackBar(
+    const SnackBar(content: Text('Research slot cancelled')),
+  );
+  onOrdersChanged(updated);
+}
+
+String _categoryLabel(String category) {
+  const labels = {
+    'gathering': 'Gathering',
+    'transport': 'Transport',
+    'labour': 'Labour',
+    'civilian': 'Civilian',
+    'diplomacy': 'Diplomacy',
+    'naval': 'Naval',
+    'military': 'Military',
+    'new-world': 'New World',
+  };
+  return labels[category] ?? category;
+}
+
+String _eraRoman(int era) {
+  const romans = ['I', 'II', 'III', 'IV'];
+  return era >= 1 && era <= romans.length ? romans[era - 1] : '$era';
 }

--- a/app/lib/features/game/widgets/technology_screen.dart
+++ b/app/lib/features/game/widgets/technology_screen.dart
@@ -13,10 +13,14 @@ class TechnologyScreen extends StatelessWidget {
     super.key,
     required this.game,
     required this.player,
+    this.currentOrders = const Orders(),
+    this.onOrdersChanged,
   });
 
   final Game game;
   final Player player;
+  final Orders currentOrders;
+  final void Function(Orders orders)? onOrdersChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -34,7 +38,12 @@ class TechnologyScreen extends StatelessWidget {
         ),
         body: TabBarView(
           children: [
-            _SlotsTab(game: game, player: player),
+            _SlotsTab(
+              game: game,
+              player: player,
+              currentOrders: currentOrders,
+              onOrdersChanged: onOrdersChanged,
+            ),
             _TreeTab(game: game, player: player),
           ],
         ),
@@ -44,16 +53,28 @@ class TechnologyScreen extends StatelessWidget {
 }
 
 class _SlotsTab extends StatelessWidget {
-  const _SlotsTab({required this.game, required this.player});
+  const _SlotsTab({
+    required this.game,
+    required this.player,
+    this.currentOrders = const Orders(),
+    this.onOrdersChanged,
+  });
 
   final Game game;
   final Player player;
+  final Orders currentOrders;
+  final void Function(Orders orders)? onOrdersChanged;
 
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
-      child: TechnologyPanel(game: game, player: player),
+      child: TechnologyPanel(
+        game: game,
+        player: player,
+        currentOrders: currentOrders,
+        onOrdersChanged: onOrdersChanged,
+      ),
     );
   }
 }

--- a/app/test/technology_panel_test.dart
+++ b/app/test/technology_panel_test.dart
@@ -1,7 +1,6 @@
 // Tests for TechnologyPanel. UXD 03k — research slots and researched techs.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
@@ -27,7 +26,10 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: SingleChildScrollView(
-            child: TechnologyPanel(game: game, player: player),
+            child: TechnologyPanel(
+              game: game,
+              player: player,
+            ),
           ),
         ),
       ),
@@ -48,7 +50,10 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: SingleChildScrollView(
-            child: TechnologyPanel(game: gameWithEmpty, player: emptyPlayer),
+            child: TechnologyPanel(
+              game: gameWithEmpty,
+              player: emptyPlayer,
+            ),
           ),
         ),
       ),
@@ -69,7 +74,10 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: SingleChildScrollView(
-            child: TechnologyPanel(game: gameWithTechs, player: withTechs),
+            child: TechnologyPanel(
+              game: gameWithTechs,
+              player: withTechs,
+            ),
           ),
         ),
       ),
@@ -91,14 +99,17 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: SingleChildScrollView(
-            child: TechnologyPanel(game: gameWithProgress, player: withProgress),
+            child: TechnologyPanel(
+              game: gameWithProgress,
+              player: withProgress,
+            ),
           ),
         ),
       ),
     );
     await tester.pumpAndSettle();
     expect(find.text('In progress:'), findsOneWidget);
-    expect(find.textContaining('pts'), findsOneWidget);
+    expect(find.textContaining('RP'), findsOneWidget);
   });
 
   testWidgets('TechnologyPanel shows custom research slots when set', (WidgetTester tester) async {
@@ -111,7 +122,10 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: SingleChildScrollView(
-            child: TechnologyPanel(game: gameWithSlots, player: withSlots),
+            child: TechnologyPanel(
+              game: gameWithSlots,
+              player: withSlots,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- Improve Technology Slots tab with explicit research slots list above researched techs, using user-friendly tech names and era-ordered list.
- Wire Technology screen into Orders so slot assignment/cancellation updates research orders and survives until turn resolution.
- Expand tech tree dialog effect summaries to show concrete, spec-backed benefits for each MVP tech instead of 'See GDD'.

## Test plan
- flutter test app/test/technology_panel_test.dart
- flutter test app/test/tech_tree_widget_test.dart
- flutter test


Made with [Cursor](https://cursor.com)