### PR TITLE
feat(ui): pixel-art UI, ban material

### DIFF
--- a/SPEC/ui/buttons-nine-patch.md
+++ b/SPEC/ui/buttons-nine-patch.md
@@ -24,9 +24,11 @@
 - **API:** `onPressed`, `child` (label/icon), optional `enabled`, optional `padding`, optional `destTileSize` (default matches theme min height). Sizing: width/height from constraints or child; minimum touch target 44 dp per UXD.
 - **Fallback:** If the nine-patch asset is missing, show a solid background (theme primary colour) so the app remains usable.
 
-## Theme integration
+## Theme and framework integration
 
-Button theme (e.g. `ElevatedButtonThemeData`) continues to define colors and typography. Screens that want nine-patch visuals use `CtNinePatchButton` explicitly or a wrapper that supplies the same semantics (e.g. `ButtonStyle` is not used for the background; the nine-patch widget is the background).
+- **Material shell only:** Material and Cupertino widgets are **not used for user-facing chrome** (no `ElevatedButton`, `TextButton`, `FilledButton`, `AlertDialog`, `Card`, `ChoiceChip`, `Slider`, `DropdownButton`, etc.). They may be used only as invisible plumbing (e.g. `MaterialApp`, `DefaultTabController`) where required by Flutter.
+- **Button catalog:** All tappable controls (primary, secondary, toolbar, dialog actions) are built from `CtNinePatchButton` or components that wrap it (e.g. `CtDropdown`, `CtSlider`, `CtChoiceChip`, `CtScreenShell` headers). No new button-like components may be introduced without reusing this nine-patch canon.
+- **Pixel-art first:** Every interactive component must either (a) use nine-patch assets for its frame/chrome or (b) be explicitly specified in SPEC/ui as a pixel-art friendly primitive (e.g. 1-px borders, hard-edged fills) with no Material elevation, ripples, or rounded-corner cards.
 
 ## References
 

--- a/SPEC/ui/game-setup.md
+++ b/SPEC/ui/game-setup.md
@@ -10,7 +10,7 @@ The CtGameSetup widget is presentational and accepts the following parameters. T
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `variant` | `plain` \| `pixelArt` | **plain:** standard Flutter/colonial theme. **pixelArt:** reuses main menu button asset per UXD 02. |
+| `variant` | `plain` \| `pixelArt` | Both variants use the **same pixel-art component catalog** (CtNinePatchButton, CtDropdown, CtScreenShell). **plain:** colonial colour theme only (no background illustration). **pixelArt:** reuses main menu pixel-art background and button assets per UXD 02/03a. |
 | `state` | `default` \| `loading` | **default:** Start Game and dropdowns enabled. **loading:** Start disabled, optional loading indicator; Back remains enabled. |
 | `naming` | `ResolvedNamingConfig` | All GP country names and leader variants (colonizethis_data). Used to populate nation and leader dropdowns. |
 | `initialOrderedGpIds` | `List<String>` | Length 6. Initial nation (gpId) per slot; **empty string denotes unselected**. When the screen loads with all entries empty (e.g. `["", "", "", "", "", ""]`), all nation/leader choices are unselected; the shell should pass this for a fresh setup. |
@@ -26,7 +26,7 @@ The CtGameSetup widget is presentational and accepts the following parameters. T
 
 **Acceptance criteria (Given–When–Then).**
 
-- **Visibility:** Given the user navigated from Main Menu via New Game, the UI layer shows the Game Setup screen with title, six player-slot rows, Start Game button, and Back button. Slot 1 is labeled as the human player (e.g. "Player 1 (You)"); slots 2–6 are labeled as AI (e.g. "Player 2 (AI)" … "Player 6 (AI)"). Each row has a nation dropdown and a leader dropdown.
+- **Visibility:** Given the user navigated from Main Menu via New Game, the UI layer shows the Game Setup screen with title, six player-slot rows, Start Game button, and Back button. Slot 1 is labeled as the human player (e.g. "Player 1 (You)"); slots 2–6 are labeled as AI (e.g. "Player 2 (AI)" … "Player 6 (AI)"). Each row has a nation dropdown and a leader dropdown rendered with pixel-art compatible components (CtDropdown, CtNinePatchButton); **no Material buttons or dropdowns are used.**
 - **Initial state unselected:** Given the screen is loaded with all nation/leader choices unselected (e.g. `initialOrderedGpIds` is six empty strings and `initialLeaderVariantByGpId` is empty), the UI layer shows each slot with no nation and no leader selected (e.g. nation dropdown shows "Select nation", leader dropdown shows "Select leader" or is disabled). Start Game is disabled.
 - **Start disabled until complete:** Given state is default, when one or more slots have no nation selected or no leader selected (or leader not yet chosen for a selected nation), the UI layer keeps Start Game disabled. When the user has selected a nation and a leader for all six slots, the UI layer enables Start Game.
 - **No duplicate nations:** Given the current slot selections, when the user opens the nation dropdown for any slot, the dropdown lists only nations not already selected in another slot. Selecting a nation in one slot removes it from the nation options in every other slot.

--- a/SPEC/ui/main-menu.md
+++ b/SPEC/ui/main-menu.md
@@ -10,7 +10,7 @@ The CtMainMenu widget is presentational and accepts the following parameters. Th
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `variant` | `plain` \| `pixelArt` | **plain:** standard Flutter/colonial theme (no pixel-art assets). **pixelArt:** pixel-art assets per table below. |
+| `variant` | `plain` \| `pixelArt` | Both variants use the **pixel-art component catalog** (CtNinePatchButton, CtScreenShell). **plain:** colonial colour theme only (no background illustration). **pixelArt:** pixel-art assets per table below. |
 | `state` | `default` \| `afterVictory` \| `noSaves` | **default:** no subtitle; Load Game enabled when saves exist. **afterVictory:** show subtitle "Congratulations, you won your last game." **noSaves:** Load Game disabled with explanatory tooltip/helper text. |
 | `version` | string | Version text shown in footer (e.g. `v1.0.0`). |
 | `onNewGame` | callback | Invoked when user taps New Game. |
@@ -58,7 +58,7 @@ Positions, layout, and hierarchy (per UXD 03a; 44dp min touch targets).
 
 **Regions (UXD 07–style):** canvas full-screen; logo_region (top, title + optional subtitle); buttons_region (column: New Game, Load Game, Settings); footer_region (version text, Quit button).
 
-**Layout (pixel-art variant):** The menu content column is constrained to a **maximum width of 400 dp** (content only; padding is additional). Buttons and logo area use this width so that the button asset is never upscaled on typical screens. Content is **centered** (e.g. `Center` + `ConstrainedBox(maxWidth: 400)` in code).
+**Layout (pixel-art variant):** The menu content column is constrained to a **maximum width of 400 dp** (content only; padding is additional). Buttons and logo area use this width so that the button asset is never upscaled on typical screens. Content is **centered** (e.g. `Center` + `ConstrainedBox(maxWidth: 400)` in code). All buttons use `CtNinePatchButton`; **Material buttons (ElevatedButton, TextButton, etc.) are not permitted for this screen.**
 
 **Mobile:** See [mobile-adaptation.md](mobile-adaptation.md). The main menu scrolls when the viewport is short (wrap content in `SingleChildScrollView`). No breakpoint layout change; vertical list suits narrow width. Safe area and 44 dp touch targets apply.
 

--- a/SPEC/ui/pixel-art-ui-catalog.md
+++ b/SPEC/ui/pixel-art-ui-catalog.md
@@ -1,0 +1,47 @@
+# Pixel-art UI catalog and Material ban
+
+**SPEC/ui** — Source of truth for UI component catalog when building the Flutter shell for ColonizeThis. Derives from GDD/TDD and UI design rules (UXD 02/03/07).
+
+---
+
+## Material design ban
+
+- **No Material chrome:** The app **must not** use Material or Cupertino widgets for visible chrome: no `ElevatedButton`, `FilledButton`, `TextButton`, `OutlinedButton`, `AlertDialog`, `Dialog`, `Card`, `ChoiceChip`, `Chip`, `Slider`, `DropdownButton`, `ListTile`, `AppBar`, or Material theming for these.
+- **Plumbing only:** Material is allowed **only** where Flutter requires it for plumbing (e.g. `MaterialApp`, `DefaultTabController`, `ThemeData`, focus/overlay internals). These must not leak default Material visuals into the UI.
+- **CI/test enforcement:** Widget tests should assert against the Ct-* catalog types (e.g. `CtNinePatchButton`, `CtDropdown`, `CtSlider`, `CtScreenShell`) rather than Material button/slider types.
+
+---
+
+## Pixel-art component catalog (Flutter shell)
+
+- **CtNinePatchButton:** Primary/secondary/action button. Uses Flame `NineTileBoxWidget` with `ui_button_nine_patch.png`. All tappable controls must be built from this (or a component that wraps it).
+- **CtDialogShell:** Pixel-art dialog frame (nine-patch border, solid interior). Replaces `AlertDialog`/`Dialog` for all popups.
+- **CtPanel:** Pixel-art framed panel for in-screen sections (production, technology, diplomacy, victory overlays, unit panels). Replaces `Card`.
+- **CtChoiceChip:** Small, pixel-friendly toggle chip used for region/visibility toggles and similar controls. Replaces `ChoiceChip`.
+- **CtSlider:** Pixel-art slider (rectangular track, square handle) for integer values. Used in Production Allocation; replaces `Slider`.
+- **CtDropdown:** Pixel-art dropdown (nine-patch button + modal list inside `CtDialogShell`). Replaces `DropdownButton`.
+- **CtScreenShell:** Full-screen pixel-art shell: background + framed content area + title bar text. Replaces visible use of `Scaffold`/`AppBar` in user-facing screens.
+
+Any new UI component must either:
+
+1. Be built from this catalog, or
+2. Extend it in this spec first (new Ct-* widget with props, behavior, and pixel-art requirements) before implementation.
+
+---
+
+## Pixel-art requirements for components
+
+- **Assets:** All framed components (buttons, dialogs, panels, shells) must use nine-patch or explicit pixel borders; no Material shadows, rounded corners, or elevation.
+- **Typography:** Follow UXD 02 for fonts and sizes; no default Material typography without explicit spec.
+- **States:** Hover/pressed/disabled states are implemented via palette shifts, bobbing, or overlays as described in per-component specs (e.g. `main-menu.md`, `buttons-nine-patch.md`), not Material ink ripples.
+
+---
+
+## References
+
+- [buttons-nine-patch.md](buttons-nine-patch.md)
+- [main-menu.md](main-menu.md)
+- [game-setup.md](game-setup.md)
+- [production-panel.md](production-panel.md)
+- [province-sea-zone-detail-overlay.md](province-sea-zone-detail-overlay.md)
+

--- a/app/lib/features/game/combat/combat_mode_choice_dialog.dart
+++ b/app/lib/features/game/combat/combat_mode_choice_dialog.dart
@@ -1,6 +1,9 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../../../widgets/ct_dialog_shell.dart';
+import '../../../widgets/ct_nine_patch_button.dart';
+
 /// Dialog for choosing combat mode (Auto-Resolve vs Quick Battle).
 /// SPEC/program/quick-battle-resolution. Capital sieges force Quick Battle.
 class CombatModeChoiceDialog extends StatelessWidget {
@@ -33,26 +36,42 @@ class CombatModeChoiceDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
-      title: Text('Combat at $provinceName'),
-      content: isCapitalSiege
-          ? const Text(
+    return CtDialogShell(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Combat at $provinceName',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          if (isCapitalSiege)
+            const Text(
               'Capital siege — Quick Battle only (no auto-resolve).',
             )
-          : const Text(
-              'Choose combat mode:',
-            ),
-      actions: [
-        if (!isCapitalSiege)
-          TextButton(
-            onPressed: () => Navigator.pop(context, CombatMode.autoResolve),
-            child: const Text('Auto-Resolve'),
+          else
+            const Text('Choose combat mode:'),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              if (!isCapitalSiege)
+                CtNinePatchButton(
+                  onPressed: () =>
+                      Navigator.pop(context, CombatMode.autoResolve),
+                  child: const Text('Auto-Resolve'),
+                ),
+              if (!isCapitalSiege) const SizedBox(width: 8),
+              CtNinePatchButton(
+                onPressed: () =>
+                    Navigator.pop(context, CombatMode.quickBattle),
+                child: const Text('Quick Battle'),
+              ),
+            ],
           ),
-        TextButton(
-          onPressed: () => Navigator.pop(context, CombatMode.quickBattle),
-          child: const Text('Quick Battle'),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/app/lib/features/game/combat/quick_battle_action_selector.dart
+++ b/app/lib/features/game/combat/quick_battle_action_selector.dart
@@ -1,6 +1,8 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../../../widgets/ct_nine_patch_button.dart';
+
 /// CP-based action selector for Quick Battle. SPEC/game/quick-battle.md.
 class QuickBattleActionSelector extends StatelessWidget {
   const QuickBattleActionSelector({
@@ -42,7 +44,7 @@ class QuickBattleActionSelector extends StatelessWidget {
     String label,
   ) {
     final enabled = cpRemaining >= cost;
-    return FilledButton.tonal(
+    return CtNinePatchButton(
       onPressed: enabled ? () => onActionSelected(action) : null,
       child: Text('$label ($cost CP)'),
     );

--- a/app/lib/features/game/combat/quick_battle_deployment_view.dart
+++ b/app/lib/features/game/combat/quick_battle_deployment_view.dart
@@ -1,6 +1,8 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../../../widgets/ct_panel.dart';
+
 /// Displays Quick Battle deployment (units per lane/line).
 /// SPEC/game/quick-battle.md: LEFT/CENTER/RIGHT/RESERVE, FRONT/SUPPORT.
 class QuickBattleDeploymentView extends StatelessWidget {
@@ -35,25 +37,20 @@ class QuickBattleDeploymentView extends StatelessWidget {
   }
 
   Widget _buildSideDeployment(BuildContext context, QuickBattleDeployment d) {
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Wrap(
-          spacing: 12,
-          runSpacing: 8,
-          children: d.groups.map((g) {
-            final label = '${_laneLabel(g.lane)} ${_lineLabel(g.line)}';
-            return Chip(
-              label: Text('$label: ${g.unitIds.length} units'),
-              avatar: g.cohesion > 0
-                  ? CircleAvatar(
-                      backgroundColor: Theme.of(context).colorScheme.primary,
-                      child: Text('${g.cohesion}', style: const TextStyle(fontSize: 12)),
-                    )
-                  : null,
-            );
-          }).toList(),
-        ),
+    return CtPanel(
+      padding: const EdgeInsets.all(12),
+      child: Wrap(
+        spacing: 12,
+        runSpacing: 8,
+        children: d.groups.map((g) {
+          final label = '${_laneLabel(g.lane)} ${_lineLabel(g.line)}';
+          final text =
+              '$label: ${g.unitIds.length} units${g.cohesion > 0 ? ' (Cohesion ${g.cohesion})' : ''}';
+          return Text(
+            text,
+            style: Theme.of(context).textTheme.bodySmall,
+          );
+        }).toList(),
       ),
     );
   }

--- a/app/lib/features/game/combat/quick_battle_result_dialog.dart
+++ b/app/lib/features/game/combat/quick_battle_result_dialog.dart
@@ -1,6 +1,9 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../../../widgets/ct_dialog_shell.dart';
+import '../../../widgets/ct_nine_patch_button.dart';
+
 /// Displays Quick Battle result. SPEC/program/quick-battle-resolution.
 class QuickBattleResultDialog extends StatelessWidget {
   const QuickBattleResultDialog({
@@ -37,25 +40,38 @@ class QuickBattleResultDialog extends StatelessWidget {
       QuickBattleWinner.defender => '$defenderName holds',
       QuickBattleWinner.mutualExhaustion => 'Mutual exhaustion',
     };
-    return AlertDialog(
-      title: Text('Battle Result: $winnerText'),
-      content: Column(
+    return CtDialogShell(
+      child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (result.provinceFlips)
-            const Text('Province captured.', style: TextStyle(fontWeight: FontWeight.bold)),
+          Text(
+            'Battle Result: $winnerText',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
           const SizedBox(height: 8),
-          Text('$attackerName casualties: ${result.attackerCasualties.length}'),
-          Text('$defenderName casualties: ${result.defenderCasualties.length}'),
+          if (result.provinceFlips)
+            const Text(
+              'Province captured.',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+          const SizedBox(height: 8),
+          Text(
+            '$attackerName casualties: ${result.attackerCasualties.length}',
+          ),
+          Text(
+            '$defenderName casualties: ${result.defenderCasualties.length}',
+          ),
+          const SizedBox(height: 16),
+          Align(
+            alignment: Alignment.centerRight,
+            child: CtNinePatchButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('OK'),
+            ),
+          ),
         ],
       ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: const Text('OK'),
-        ),
-      ],
     );
   }
 }

--- a/app/lib/features/game/combat/quick_battle_screen.dart
+++ b/app/lib/features/game/combat/quick_battle_screen.dart
@@ -2,6 +2,8 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../../../widgets/ct_dialog_shell.dart';
+import '../../../widgets/ct_nine_patch_button.dart';
 import 'quick_battle_action_selector.dart';
 import 'quick_battle_deployment_view.dart';
 
@@ -57,50 +59,49 @@ class _QuickBattleScreenState extends State<QuickBattleScreen> {
   @override
   Widget build(BuildContext context) {
     if (_result != null) {
-      return _ResultView(result: _result!, onDismiss: () {
-        widget.onComplete(_result!);
-      });
+      return _ResultView(
+        result: _result!,
+        onDismiss: () {
+          widget.onComplete(_result!);
+        },
+      );
     }
-    return Dialog(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Text(
-                'Quick Battle — Round $_round / ${widget.input.maxRounds}',
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              const SizedBox(height: 12),
-              Expanded(
-                child: SingleChildScrollView(
-                  child: QuickBattleDeploymentView(
-                    attackerDeployment: widget.input.attackerDeployment,
-                    defenderDeployment: widget.input.defenderDeployment,
-                    attackerName: widget.input.attackerFactionId,
-                    defenderName: widget.input.defenderFactionId,
-                  ),
-                ),
-              ),
-              if (widget.interactive) ...[
-                const SizedBox(height: 12),
-                QuickBattleActionSelector(
-                  cpRemaining: 3,
-                  onActionSelected: _onActionSelected,
-                ),
-              ] else ...[
-                const SizedBox(height: 12),
-                FilledButton(
-                  onPressed: _runWithDefaults,
-                  child: const Text('Resolve (Auto)'),
-                ),
-              ],
-            ],
+    return CtDialogShell(
+      maxWidth: 400,
+      maxHeight: 500,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'Quick Battle — Round $_round / ${widget.input.maxRounds}',
+            style: Theme.of(context).textTheme.titleMedium,
           ),
-        ),
+          const SizedBox(height: 12),
+          Expanded(
+            child: SingleChildScrollView(
+              child: QuickBattleDeploymentView(
+                attackerDeployment: widget.input.attackerDeployment,
+                defenderDeployment: widget.input.defenderDeployment,
+                attackerName: widget.input.attackerFactionId,
+                defenderName: widget.input.defenderFactionId,
+              ),
+            ),
+          ),
+          if (widget.interactive) ...[
+            const SizedBox(height: 12),
+            QuickBattleActionSelector(
+              cpRemaining: 3,
+              onActionSelected: _onActionSelected,
+            ),
+          ] else ...[
+            const SizedBox(height: 12),
+            CtNinePatchButton(
+              onPressed: _runWithDefaults,
+              child: const Text('Resolve (Auto)'),
+            ),
+          ],
+        ],
       ),
     );
   }
@@ -119,25 +120,35 @@ class _ResultView extends StatelessWidget {
       QuickBattleWinner.defender => 'Defender holds',
       QuickBattleWinner.mutualExhaustion => 'Mutual exhaustion',
     };
-    return AlertDialog(
-      title: Text('Battle Result: $winnerText'),
-      content: Column(
+    return CtDialogShell(
+      child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          Text(
+            'Battle Result: $winnerText',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
           if (result.provinceFlips)
-            const Text('Province captured.', style: TextStyle(fontWeight: FontWeight.bold)),
+            const Text(
+              'Province captured.',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
           const SizedBox(height: 8),
           Text('Attacker casualties: ${result.attackerCasualties.length}'),
           Text('Defender casualties: ${result.defenderCasualties.length}'),
+          Text('Defender casualties: ${result.defenderCasualties.length}'),
+          const SizedBox(height: 16),
+          Align(
+            alignment: Alignment.centerRight,
+            child: CtNinePatchButton(
+              onPressed: onDismiss,
+              child: const Text('Continue'),
+            ),
+          ),
         ],
       ),
-      actions: [
-        FilledButton(
-          onPressed: onDismiss,
-          child: const Text('Continue'),
-        ),
-      ],
     );
   }
 }

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -15,7 +15,10 @@ import '../widgets/diplomacy_panel.dart';
 import '../widgets/military_units_panel.dart';
 import '../widgets/province_sea_zone_detail_overlay.dart';
 import '../widgets/technology_screen.dart';
+import '../../../widgets/ct_choice_chip.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
+import '../../../widgets/ct_panel.dart';
+import '../../../widgets/ct_screen_shell.dart';
 import 'game_canvas.dart';
 
 /// Hosts the Flame game canvas or map. When map data exists, shows map + province/sea zone overlay.
@@ -27,8 +30,9 @@ class GameScreen extends ConsumerWidget {
     final game = ref.watch(currentGameProvider);
     final mapViewData = ref.watch(mapViewDataProvider);
     final victory = game?.victory;
-    return Scaffold(
-      body: Stack(
+    return CtScreenShell(
+      title: 'Game',
+      child: Stack(
         children: [
           if (mapViewData != null && game != null)
             _GameMapArea(
@@ -264,19 +268,19 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              ChoiceChip(
+              CtChoiceChip(
                 label: const Text('Old World'),
                 selected: _regionIndex == 0,
                 onSelected: (_) => setState(() => _regionIndex = 0),
               ),
               const SizedBox(width: 8),
-              ChoiceChip(
+              CtChoiceChip(
                 label: const Text('New World'),
                 selected: _regionIndex == 1,
                 onSelected: (_) => setState(() => _regionIndex = 1),
               ),
               const SizedBox(width: 16),
-              TextButton.icon(
+              CtNinePatchButton(
                 onPressed: () {
                   final orders = ref.read(currentOrdersProvider);
                   showModalBottomSheet<void>(
@@ -318,11 +322,17 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
                     },
                   );
                 },
-                icon: const Icon(Icons.people_outline, size: 20),
-                label: const Text('Civilian Units'),
+                child: const Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.people_outline, size: 20),
+                    SizedBox(width: 8),
+                    Text('Civilian Units'),
+                  ],
+                ),
               ),
               const SizedBox(width: 8),
-              TextButton.icon(
+              CtNinePatchButton(
                 onPressed: () {
                   showModalBottomSheet<void>(
                     context: context,
@@ -333,11 +343,17 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
                     ),
                   );
                 },
-                icon: const Icon(Icons.military_tech_outlined, size: 20),
-                label: const Text('Military Units'),
+                child: const Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.military_tech_outlined, size: 20),
+                    SizedBox(width: 8),
+                    Text('Military Units'),
+                  ],
+                ),
               ),
               const SizedBox(width: 8),
-              TextButton.icon(
+              CtNinePatchButton(
                 onPressed: () {
                   final orders = ref.read(currentOrdersProvider);
                   final mapData =
@@ -368,8 +384,14 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
                     ),
                   );
                 },
-                icon: const Icon(Icons.handshake_outlined, size: 20),
-                label: const Text('Diplomacy'),
+                child: const Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.handshake_outlined, size: 20),
+                    SizedBox(width: 8),
+                    Text('Diplomacy'),
+                  ],
+                ),
               ),
             ],
           ),
@@ -489,9 +511,9 @@ class _VictoryPanel extends StatelessWidget {
       ct_models.VictoryType.military => 'Military victory',
     };
 
-    return Card(
-      margin: const EdgeInsets.all(24),
-      child: Padding(
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: CtPanel(
         padding: const EdgeInsets.all(24),
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -510,14 +532,14 @@ class _VictoryPanel extends StatelessWidget {
             Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                ElevatedButton(
+                CtNinePatchButton(
                   onPressed: () {
                     Navigator.of(context).popUntil((route) => route.isFirst);
                   },
                   child: const Text('Return to main menu'),
                 ),
                 const SizedBox(width: 12),
-                TextButton(
+                CtNinePatchButton(
                   onPressed: () {
                     onViewFinalState?.call();
                   },

--- a/app/lib/features/game/widgets/civilian_units_panel.dart
+++ b/app/lib/features/game/widgets/civilian_units_panel.dart
@@ -4,6 +4,10 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../../../widgets/ct_dialog_shell.dart';
+import '../../../widgets/ct_nine_patch_button.dart';
+import '../../../widgets/ct_panel.dart';
+
 /// Human-readable label for work target ids. SPEC/ui/civilian-units-panel.md.
 const Map<String, String> _workTargetLabels = {
   'explore': 'Explore',
@@ -124,9 +128,11 @@ class CivilianUnitsPanel extends StatelessWidget {
 
     return ConstrainedBox(
       constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
-      child: Card(
-        margin: const EdgeInsets.all(8),
-        child: Column(
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: CtPanel(
+          padding: EdgeInsets.zero,
+          child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
@@ -350,21 +356,36 @@ class _UnitRow extends StatelessWidget {
   Future<void> _confirmCancel(BuildContext context) async {
     final ok = await showDialog<bool>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Cancel work order?'),
-        content: const Text(
-          'This will cancel the current or pending work for this unit. Materials are not refunded.',
+      builder: (ctx) => CtDialogShell(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Cancel work order?',
+              style: Theme.of(ctx).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'This will cancel the current or pending work for this unit. Materials are not refunded.',
+            ),
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                CtNinePatchButton(
+                  onPressed: () => Navigator.of(ctx).pop(false),
+                  child: const Text('No'),
+                ),
+                const SizedBox(width: 8),
+                CtNinePatchButton(
+                  onPressed: () => Navigator.of(ctx).pop(true),
+                  child: const Text('Yes'),
+                ),
+              ],
+            ),
+          ],
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('No'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: const Text('Yes'),
-          ),
-        ],
       ),
     );
     if (ok != true || !context.mounted) return;
@@ -400,13 +421,13 @@ class _UnitRow extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           if (_isIdleNoPending && onStartWorkTargetSelection != null)
-            TextButton(
+            CtNinePatchButton(
               onPressed: () => _showOrderMenu(context),
               child: const Text('Assign'),
             ),
           if (_hasWork &&
               (onRemoveWorkOrder != null || onCancelUnitWork != null))
-            TextButton(
+            CtNinePatchButton(
               onPressed: () => _confirmCancel(context),
               child: const Text('Cancel'),
             ),

--- a/app/lib/features/game/widgets/civilian_units_panel.dart
+++ b/app/lib/features/game/widgets/civilian_units_panel.dart
@@ -133,80 +133,87 @@ class CivilianUnitsPanel extends StatelessWidget {
         child: CtPanel(
           padding: EdgeInsets.zero,
           child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(12, 8, 8, 4),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      'Civilian Units',
-                      style: Theme.of(context).textTheme.titleMedium,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Flexible(
-              child: hasAny
-                  ? ListView(
-                      shrinkWrap: true,
-                      padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
-                      children: [
-                        if (ow.isNotEmpty) ...[
-                          _RegionHeader(label: _regionLabel('oldWorld')),
-                          ...ow.map((u) => _UnitRow(
-                                unit: u,
-                                provinceNames: provinceNames,
-                                currentOrders: currentOrders,
-                                humanPlayerId: humanPlayerId,
-                                onTap: onLocateUnit != null && u.tileKey != null
-                                    ? () => onLocateUnit!(u)
-                                    : null,
-                                onAddWorkOrder: onAddWorkOrder,
-                                onRemoveWorkOrder: onRemoveWorkOrder,
-                                onCancelUnitWork: onCancelUnitWork,
-                                onStartWorkTargetSelection:
-                                    onStartWorkTargetSelection,
-                              )),
-                        ],
-                        if (nw.isNotEmpty) ...[
-                          _RegionHeader(label: _regionLabel('newWorld')),
-                          ...nw.map((u) => _UnitRow(
-                                unit: u,
-                                provinceNames: provinceNames,
-                                currentOrders: currentOrders,
-                                humanPlayerId: humanPlayerId,
-                                onTap: onLocateUnit != null && u.tileKey != null
-                                    ? () => onLocateUnit!(u)
-                                    : null,
-                                onAddWorkOrder: onAddWorkOrder,
-                                onRemoveWorkOrder: onRemoveWorkOrder,
-                                onCancelUnitWork: onCancelUnitWork,
-                                onStartWorkTargetSelection:
-                                    onStartWorkTargetSelection,
-                              )),
-                        ],
-                      ],
-                    )
-                  : Padding(
-                      padding: const EdgeInsets.all(24),
-                      child: Center(
-                        child: Text(
-                          'No civilian units',
-                          style:
-                              Theme.of(context).textTheme.bodyMedium?.copyWith(
-                                    color: Theme.of(context)
-                                        .colorScheme
-                                        .onSurfaceVariant,
-                                  ),
-                        ),
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(12, 8, 8, 4),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        'Civilian Units',
+                        style: Theme.of(context).textTheme.titleMedium,
                       ),
                     ),
-            ),
-          ],
+                  ],
+                ),
+              ),
+              Flexible(
+                child: hasAny
+                    ? ListView(
+                        shrinkWrap: true,
+                        padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+                        children: [
+                          if (ow.isNotEmpty) ...[
+                            _RegionHeader(label: _regionLabel('oldWorld')),
+                            ...ow.map(
+                              (u) => _UnitRow(
+                                unit: u,
+                                provinceNames: provinceNames,
+                                currentOrders: currentOrders,
+                                humanPlayerId: humanPlayerId,
+                                onTap: onLocateUnit != null && u.tileKey != null
+                                    ? () => onLocateUnit!(u)
+                                    : null,
+                                onAddWorkOrder: onAddWorkOrder,
+                                onRemoveWorkOrder: onRemoveWorkOrder,
+                                onCancelUnitWork: onCancelUnitWork,
+                                onStartWorkTargetSelection:
+                                    onStartWorkTargetSelection,
+                              ),
+                            ),
+                          ],
+                          if (nw.isNotEmpty) ...[
+                            _RegionHeader(label: _regionLabel('newWorld')),
+                            ...nw.map(
+                              (u) => _UnitRow(
+                                unit: u,
+                                provinceNames: provinceNames,
+                                currentOrders: currentOrders,
+                                humanPlayerId: humanPlayerId,
+                                onTap: onLocateUnit != null && u.tileKey != null
+                                    ? () => onLocateUnit!(u)
+                                    : null,
+                                onAddWorkOrder: onAddWorkOrder,
+                                onRemoveWorkOrder: onRemoveWorkOrder,
+                                onCancelUnitWork: onCancelUnitWork,
+                                onStartWorkTargetSelection:
+                                    onStartWorkTargetSelection,
+                              ),
+                            ),
+                          ],
+                        ],
+                      )
+                    : Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: Center(
+                          child: Text(
+                            'No civilian units',
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
+                                ?.copyWith(
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSurfaceVariant,
+                                ),
+                          ),
+                        ),
+                      ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/app/lib/features/game/widgets/diplomacy_detail_screen.dart
+++ b/app/lib/features/game/widgets/diplomacy_detail_screen.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../../../widgets/ct_panel.dart';
 import 'diplomacy_panel.dart';
 
 /// Human-readable sentence for a diplomatic event. Unknown factions shown as "Unknown faction".
@@ -184,25 +185,23 @@ class DiplomacyDetailScreen extends StatelessWidget {
     final relationLabel = relation == null
         ? ''
         : relationScoreToDisplayLabel(relation!.score);
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'Current relation',
-              style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  ),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              relationLabel.isEmpty ? stateLabel : '$stateLabel · $relationLabel',
-              style: Theme.of(context).textTheme.titleSmall,
-            ),
-          ],
-        ),
+    return CtPanel(
+      padding: const EdgeInsets.all(12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Current relation',
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            relationLabel.isEmpty ? stateLabel : '$stateLabel · $relationLabel',
+            style: Theme.of(context).textTheme.titleSmall,
+          ),
+        ],
       ),
     );
   }

--- a/app/lib/features/game/widgets/diplomacy_dialogs.dart
+++ b/app/lib/features/game/widgets/diplomacy_dialogs.dart
@@ -3,6 +3,9 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../../../widgets/ct_dialog_shell.dart';
+import '../../../widgets/ct_nine_patch_button.dart';
+
 /// Shows a dialog to enter amount for Grant Aid or Set Subsidy, then calls [onSubmitted].
 void showGrantOrSubsidyDialog({
   required BuildContext context,
@@ -29,27 +32,42 @@ void showGrantOrSubsidyDialog({
 
   showDialog<void>(
     context: context,
-    builder: (ctx) => AlertDialog(
-      title: Text(title),
-      content: TextField(
-        controller: controller,
-        keyboardType: TextInputType.number,
-        decoration: InputDecoration(
-          labelText: 'Amount',
-          hintText: hint,
-        ),
-        onSubmitted: (_) => doSubmit(ctx),
+    builder: (ctx) => CtDialogShell(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: Theme.of(ctx).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: controller,
+            keyboardType: TextInputType.number,
+            decoration: InputDecoration(
+              labelText: 'Amount',
+              hintText: hint,
+            ),
+            onSubmitted: (_) => doSubmit(ctx),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              CtNinePatchButton(
+                onPressed: () => Navigator.of(ctx).pop(),
+                child: const Text('Cancel'),
+              ),
+              const SizedBox(width: 8),
+              CtNinePatchButton(
+                onPressed: () => doSubmit(ctx),
+                child: const Text('Submit'),
+              ),
+            ],
+          ),
+        ],
       ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(ctx).pop(),
-          child: const Text('Cancel'),
-        ),
-        FilledButton(
-          onPressed: () => doSubmit(ctx),
-          child: const Text('Submit'),
-        ),
-      ],
     ),
   );
 }

--- a/app/lib/features/game/widgets/diplomacy_panel.dart
+++ b/app/lib/features/game/widgets/diplomacy_panel.dart
@@ -5,6 +5,8 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../../../widgets/ct_nine_patch_button.dart';
+import '../../../widgets/ct_panel.dart';
 import 'diplomacy_dialogs.dart';
 import 'diplomacy_detail_screen.dart';
 
@@ -353,12 +355,11 @@ class _DiplomacyRow extends StatelessWidget {
       ],
     );
 
-    return Card(
-      margin: const EdgeInsets.only(bottom: 8),
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
       child: InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(12),
-        child: Padding(
+        child: CtPanel(
           padding: const EdgeInsets.all(12),
           child: content,
         ),
@@ -411,14 +412,13 @@ class _ActionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final label = _actionLabel(order);
-    return FilledButton.tonal(
-      onPressed: onPressed,
-      style: FilledButton.styleFrom(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-        minimumSize: Size.zero,
-        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+    return SizedBox(
+      height: 32,
+      child: CtNinePatchButton(
+        onPressed: onPressed,
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        child: Text(label, style: const TextStyle(fontSize: 12)),
       ),
-      child: Text(label, style: const TextStyle(fontSize: 12)),
     );
   }
 

--- a/app/lib/features/game/widgets/military_units_panel.dart
+++ b/app/lib/features/game/widgets/military_units_panel.dart
@@ -314,72 +314,84 @@ class MilitaryUnitsPanel extends StatelessWidget {
         child: CtPanel(
           padding: EdgeInsets.zero,
           child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(12, 8, 8, 4),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      'Military Units',
-                      style: Theme.of(context).textTheme.titleMedium,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Flexible(
-              child: hasAny
-                  ? ListView(
-                      shrinkWrap: true,
-                      padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
-                      children: [
-                        for (final group in tree) ...[
-                          _RegionHeader(
-                              label: _regionLabel(group.regionId)),
-                          for (final loc in group.locations) ...[
-                            _LocationHeader(
-                                label: loc.displayLabel,
-                                regionLabel: _regionLabel(loc.regionId)),
-                            if (loc is _ProvinceLocationNode)
-                              for (final row in loc.rows)
-                                _RegimentRow(
-                                  row: row,
-                                  onTap: row.tileKey != null &&
-                                          onLocateTile != null
-                                      ? () => onLocateTile!(
-                                          row.tileKey!, row.regionId)
-                                      : null,
-                                ),
-                            if (loc is _SeaZoneLocationNode)
-                              for (final row in loc.rows)
-                                _ShipRow(
-                                  row: row,
-                                  onTap: row.tileKey != null &&
-                                          onLocateTile != null
-                                      ? () => onLocateTile!(
-                                          row.tileKey!, row.regionId)
-                                      : null,
-                                ),
-                          ],
-                        ],
-                      ],
-                    )
-                  : Padding(
-                      padding: const EdgeInsets.all(24),
-                      child: Center(
-                        child: Text(
-                          'No military units',
-                          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                              color: Theme.of(context)
-                                  .colorScheme.onSurfaceVariant),
-                        ),
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(12, 8, 8, 4),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        'Military Units',
+                        style: Theme.of(context).textTheme.titleMedium,
                       ),
                     ),
-            ),
-          ],
+                  ],
+                ),
+              ),
+              Flexible(
+                child: hasAny
+                    ? ListView(
+                        shrinkWrap: true,
+                        padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+                        children: [
+                          for (final group in tree) ...[
+                            _RegionHeader(
+                              label: _regionLabel(group.regionId),
+                            ),
+                            for (final loc in group.locations) ...[
+                              _LocationHeader(
+                                label: loc.displayLabel,
+                                regionLabel: _regionLabel(loc.regionId),
+                              ),
+                              if (loc is _ProvinceLocationNode)
+                                for (final row in loc.rows)
+                                  _RegimentRow(
+                                    row: row,
+                                    onTap: row.tileKey != null &&
+                                            onLocateTile != null
+                                        ? () => onLocateTile!(
+                                              row.tileKey!,
+                                              row.regionId,
+                                            )
+                                        : null,
+                                  ),
+                              if (loc is _SeaZoneLocationNode)
+                                for (final row in loc.rows)
+                                  _ShipRow(
+                                    row: row,
+                                    onTap: row.tileKey != null &&
+                                            onLocateTile != null
+                                        ? () => onLocateTile!(
+                                              row.tileKey!,
+                                              row.regionId,
+                                            )
+                                        : null,
+                                  ),
+                            ],
+                          ],
+                        ],
+                      )
+                    : Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: Center(
+                          child: Text(
+                            'No military units',
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
+                                ?.copyWith(
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSurfaceVariant,
+                                ),
+                          ),
+                        ),
+                      ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/app/lib/features/game/widgets/military_units_panel.dart
+++ b/app/lib/features/game/widgets/military_units_panel.dart
@@ -4,6 +4,8 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../../../widgets/ct_panel.dart';
+
 /// Region id to display label. SPEC/ui/military-units-panel.md.
 String _regionLabel(String regionId) {
   switch (regionId) {
@@ -307,9 +309,11 @@ class MilitaryUnitsPanel extends StatelessWidget {
 
     return ConstrainedBox(
       constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
-      child: Card(
-        margin: const EdgeInsets.all(8),
-        child: Column(
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: CtPanel(
+          padding: EdgeInsets.zero,
+          child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [

--- a/app/lib/features/game/widgets/production_panel.dart
+++ b/app/lib/features/game/widgets/production_panel.dart
@@ -3,6 +3,10 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../../../widgets/ct_nine_patch_button.dart';
+import '../../../widgets/ct_panel.dart';
+import '../../../widgets/ct_slider.dart';
+
 /// Production panel: available resources/workers and allocation sliders per recipe.
 /// SPEC/ui/production-panel.md.
 class ProductionPanel extends StatelessWidget {
@@ -146,9 +150,9 @@ class _AvailableSubpanel extends StatelessWidget {
         .where((c) => c.category == CommodityCategory.food)
         .toList();
 
-    return Card(
+    return CtPanel(
+      padding: const EdgeInsets.all(12),
       child: SingleChildScrollView(
-        padding: const EdgeInsets.all(12),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -332,9 +336,9 @@ class _AllocationSubpanel extends StatelessWidget {
     );
     final labourInsufficient = totalRequiredLabour > effectiveLabour;
 
-    return Card(
+    return CtPanel(
+      padding: const EdgeInsets.all(12),
       child: SingleChildScrollView(
-        padding: const EdgeInsets.all(12),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -348,7 +352,7 @@ class _AllocationSubpanel extends StatelessWidget {
                     style: theme.textTheme.titleSmall,
                   ),
                 ),
-                TextButton(
+                CtNinePatchButton(
                   onPressed: () => onDesiredOutputChanged({}),
                   child: const Text('Reset'),
                 ),
@@ -384,7 +388,7 @@ class _AllocationSubpanel extends StatelessWidget {
                     Row(
                       children: [
                         Expanded(
-                          child: Slider(
+                          child: CtSlider(
                             value: desired.clamp(0, maxAchievable).toDouble(),
                             min: 0,
                             max: sliderMax,
@@ -392,7 +396,6 @@ class _AllocationSubpanel extends StatelessWidget {
                                 ? 1
                                 : maxAchievable.clamp(
                                     1, _absoluteMaxSliderOutput),
-                            label: '$desired',
                             onChanged: (v) {
                               final next =
                                   Map<String, int>.from(desiredOutputByRecipe);

--- a/app/lib/features/game/widgets/tech_tree_widget.dart
+++ b/app/lib/features/game/widgets/tech_tree_widget.dart
@@ -6,6 +6,9 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../../../widgets/ct_dialog_shell.dart';
+import '../../../widgets/ct_nine_patch_button.dart';
+
 /// Node position for layout.
 class _TechNodePosition {
   const _TechNodePosition({
@@ -172,33 +175,55 @@ class TechTreeWidget extends StatelessWidget {
     final theme = Theme.of(context);
     showDialog<void>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text(techDisplayName(tech.id)),
-        content: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text('Era ${_eraRoman(tech.era)} · ${_categoryLabel(tech.category)}', style: theme.textTheme.bodySmall),
-              const SizedBox(height: 4),
-              Text('${tech.cost} RP', style: theme.textTheme.bodyMedium),
-              if (effects.isNotEmpty) ...[
-                const SizedBox(height: 8),
-                Text('Effects', style: theme.textTheme.labelLarge),
-                ...effects.map((e) => Padding(
-                      padding: const EdgeInsets.only(top: 2),
-                      child: Text('• $e', style: theme.textTheme.bodySmall),
-                    )),
-              ],
-            ],
-          ),
+      builder: (ctx) => CtDialogShell(
+        maxWidth: 420,
+        maxHeight: 520,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              techDisplayName(tech.id),
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Expanded(
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      'Era ${_eraRoman(tech.era)} · ${_categoryLabel(tech.category)}',
+                      style: theme.textTheme.bodySmall,
+                    ),
+                    const SizedBox(height: 4),
+                    Text('${tech.cost} RP', style: theme.textTheme.bodyMedium),
+                    if (effects.isNotEmpty) ...[
+                      const SizedBox(height: 8),
+                      Text('Effects', style: theme.textTheme.labelLarge),
+                      ...effects.map(
+                        (e) => Padding(
+                          padding: const EdgeInsets.only(top: 2),
+                          child:
+                              Text('• $e', style: theme.textTheme.bodySmall),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: CtNinePatchButton(
+                onPressed: () => Navigator.of(ctx).pop(),
+                child: const Text('Close'),
+              ),
+            ),
+          ],
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(),
-            child: const Text('Close'),
-          ),
-        ],
       ),
     );
   }

--- a/app/lib/features/game/widgets/technology_panel.dart
+++ b/app/lib/features/game/widgets/technology_panel.dart
@@ -2,6 +2,9 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../../../widgets/ct_nine_patch_button.dart';
+import '../../../widgets/ct_panel.dart';
+
 /// Technology panel (UXD 03k). Shows researched techs and research slots for a player.
 class TechnologyPanel extends StatelessWidget {
   const TechnologyPanel({
@@ -40,9 +43,9 @@ class TechnologyPanel extends StatelessWidget {
         currentOrders.researchOrdersByPlayerId[humanPlayerId] ??
             const <ResearchOrder>[];
 
-    return Card(
-      margin: const EdgeInsets.all(16),
-      child: Padding(
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: CtPanel(
         padding: const EdgeInsets.all(16),
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -93,7 +96,7 @@ class TechnologyPanel extends StatelessWidget {
                           mainAxisSize: MainAxisSize.min,
                           children: [
                             if (hasTech)
-                              TextButton(
+                              CtNinePatchButton(
                                 onPressed: () {
                                   _cancelSlot(
                                     context: context,
@@ -106,7 +109,7 @@ class TechnologyPanel extends StatelessWidget {
                                 child: const Text('Cancel'),
                               ),
                             const SizedBox(width: 4),
-                            FilledButton.tonal(
+                            CtNinePatchButton(
                               onPressed: () {
                                 _showAssignDialog(
                                   context: context,

--- a/app/lib/features/game/widgets/technology_screen.dart
+++ b/app/lib/features/game/widgets/technology_screen.dart
@@ -3,7 +3,7 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
-import '../../widgets/ct_screen_shell.dart';
+import '../../../widgets/ct_screen_shell.dart';
 import 'technology_panel.dart';
 import 'tech_tree_widget.dart';
 

--- a/app/lib/features/game/widgets/technology_screen.dart
+++ b/app/lib/features/game/widgets/technology_screen.dart
@@ -3,6 +3,7 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../../widgets/ct_screen_shell.dart';
 import 'technology_panel.dart';
 import 'tech_tree_widget.dart';
 
@@ -26,25 +27,31 @@ class TechnologyScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return DefaultTabController(
       length: 2,
-      child: Scaffold(
-        appBar: AppBar(
-          title: const Text('Technology'),
-          bottom: const TabBar(
-            tabs: [
-              Tab(text: 'Slots', icon: Icon(Icons.list_alt)),
-              Tab(text: 'Tree', icon: Icon(Icons.account_tree)),
-            ],
-          ),
-        ),
-        body: TabBarView(
+      child: CtScreenShell(
+        title: 'Technology',
+        child: Column(
           children: [
-            _SlotsTab(
-              game: game,
-              player: player,
-              currentOrders: currentOrders,
-              onOrdersChanged: onOrdersChanged,
+            const TabBar(
+              tabs: [
+                Tab(text: 'Slots'),
+                Tab(text: 'Tree'),
+              ],
             ),
-            _TreeTab(game: game, player: player),
+            const SizedBox(height: 8),
+            const Divider(height: 1),
+            Expanded(
+              child: TabBarView(
+                children: [
+                  _SlotsTab(
+                    game: game,
+                    player: player,
+                    currentOrders: currentOrders,
+                    onOrdersChanged: onOrdersChanged,
+                  ),
+                  _TreeTab(game: game, player: player),
+                ],
+              ),
+            ),
           ],
         ),
       ),

--- a/app/lib/features/shell/shell_screen.dart
+++ b/app/lib/features/shell/shell_screen.dart
@@ -5,6 +5,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../config/routes.dart';
 import '../../providers/game_service_provider.dart';
 import '../../providers/games_provider.dart';
+import '../../widgets/ct_dialog_shell.dart';
+import '../../widgets/ct_dropdown.dart';
+import '../../widgets/ct_nine_patch_button.dart';
+import '../../widgets/ct_screen_shell.dart';
 
 /// App shell. New game creates game, sets current, navigates to game. Phase 1: wired to resolve and persist.
 class ShellScreen extends ConsumerWidget {
@@ -12,31 +16,36 @@ class ShellScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Colonize This')),
-      body: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ElevatedButton(
-              onPressed: () => _showNewGameFlow(context, ref),
-              child: const Text('New game'),
-            ),
-            const SizedBox(height: 8),
-            ElevatedButton(
-              onPressed: () async {
-                final service = ref.read(gameServiceProvider);
-                final ids = service.listGameIds();
-                if (ids.isEmpty || !context.mounted) return;
-                final game = service.loadGame(ids.first);
-                if (game != null && context.mounted) {
-                  ref.read(currentGameProvider.notifier).state = game;
-                  if (context.mounted) Navigator.pushNamed(context, Routes.game);
-                }
-              },
-              child: const Text('Load last saved'),
-            ),
-          ],
+    return CtScreenShell(
+      title: 'Colonize This',
+      child: Center(
+        child: SizedBox(
+          width: 260,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CtNinePatchButton(
+                onPressed: () => _showNewGameFlow(context, ref),
+                child: const Text('New game'),
+              ),
+              const SizedBox(height: 8),
+              CtNinePatchButton(
+                onPressed: () async {
+                  final service = ref.read(gameServiceProvider);
+                  final ids = service.listGameIds();
+                  if (ids.isEmpty || !context.mounted) return;
+                  final game = service.loadGame(ids.first);
+                  if (game != null && context.mounted) {
+                    ref.read(currentGameProvider.notifier).state = game;
+                    if (context.mounted) {
+                      Navigator.pushNamed(context, Routes.game);
+                    }
+                  }
+                },
+                child: const Text('Load last saved'),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -141,16 +150,13 @@ class _LeaderSelectionDialogState extends State<_LeaderSelectionDialog> {
               ),
               const SizedBox(width: 8),
               Expanded(
-                child: DropdownButton<String>(
+                child: CtDropdown<String>(
                   value: currentVariantId,
-                  isExpanded: true,
-                  items: [
-                    for (final v in gp.leaderVariants)
-                      DropdownMenuItem(
-                        value: v.id,
-                        child: Text(v.name, overflow: TextOverflow.ellipsis),
-                      ),
-                  ],
+                  items: gp.leaderVariants.map((v) => v.id).toList(),
+                  hint: 'Select leader',
+                  itemLabel: (id) => gp.leaderVariants
+                      .firstWhere((v) => v.id == id)
+                      .name,
                   onChanged: (value) {
                     if (value != null) {
                       setState(() => _leaderByGpId[gpId] = value);
@@ -169,12 +175,12 @@ class _LeaderSelectionDialogState extends State<_LeaderSelectionDialog> {
       Row(
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
-          TextButton(
+          CtNinePatchButton(
             onPressed: widget.onCancel,
             child: const Text('Cancel'),
           ),
           const SizedBox(width: 8),
-          FilledButton(
+          CtNinePatchButton(
             onPressed: () => widget.onStart(_leaderByGpId),
             child: const Text('Start'),
           ),
@@ -182,14 +188,28 @@ class _LeaderSelectionDialogState extends State<_LeaderSelectionDialog> {
       ),
     ]);
 
-    return AlertDialog(
-      title: const Text('New game — Leaders'),
-      content: SingleChildScrollView(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: children,
-        ),
+    return CtDialogShell(
+      maxWidth: 480,
+      maxHeight: 560,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'New game — Leaders',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: children,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -15,6 +15,7 @@ import 'features/game/widgets/province_overlay_demo_data.dart';
 import 'features/game/widgets/tech_tree_widget.dart';
 import 'features/game/widgets/technology_screen.dart';
 import 'widgets/debug_init_game.dart';
+import 'widgets/ct_choice_chip.dart';
 import 'widgets/debug_map_visibility_story.dart';
 import 'widgets/game_setup.dart';
 import 'widgets/main_menu.dart';
@@ -778,23 +779,23 @@ class _CivilianPanelWithMapStoryState
               spacing: 8,
               runSpacing: 4,
               children: [
-                ChoiceChip(
+                CtChoiceChip(
                   label: const Text('Old World'),
                   selected: _regionIndex == 0,
                   onSelected: (_) => setState(() => _regionIndex = 0),
                 ),
-                ChoiceChip(
+                CtChoiceChip(
                   label: const Text('New World'),
                   selected: _regionIndex == 1,
                   onSelected: (_) => setState(() => _regionIndex = 1),
                 ),
-                ChoiceChip(
+                CtChoiceChip(
                   label: const Text('Full visibility'),
                   selected: _visibilityMode == CtMapVisibilityMode.full,
                   onSelected: (_) => setState(
                       () => _visibilityMode = CtMapVisibilityMode.full),
                 ),
-                ChoiceChip(
+                CtChoiceChip(
                   label: const Text('Player-constrained'),
                   selected: _visibilityMode ==
                       CtMapVisibilityMode.playerConstrained,
@@ -874,7 +875,7 @@ class _CivilianPanelAsBottomSheetStory extends StatelessWidget {
         children: [
           Padding(
             padding: const EdgeInsets.all(8),
-            child: TextButton.icon(
+            child: CtNinePatchButton(
               onPressed: () {
                 showModalBottomSheet<void>(
                   context: context,
@@ -892,8 +893,14 @@ class _CivilianPanelAsBottomSheetStory extends StatelessWidget {
                   },
                 );
               },
-              icon: const Icon(Icons.people_outline, size: 20),
-              label: const Text('Civilian Units'),
+              child: const Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.people_outline, size: 20),
+                  SizedBox(width: 8),
+                  Text('Civilian Units'),
+                ],
+              ),
             ),
           ),
           const Expanded(

--- a/app/lib/widgets/ct_choice_chip.dart
+++ b/app/lib/widgets/ct_choice_chip.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+/// Pixel-art friendly toggle chip (non-Material).
+class CtChoiceChip extends StatelessWidget {
+  const CtChoiceChip({
+    super.key,
+    required this.label,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  final Widget label;
+  final bool selected;
+  final ValueChanged<bool> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final bg = selected
+        ? colorScheme.primary.withValues(alpha: 0.25)
+        : colorScheme.surface.withValues(alpha: 0.5);
+    final border = selected ? colorScheme.primary : colorScheme.outline;
+
+    return InkWell(
+      onTap: () => onSelected(!selected),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: bg,
+          border: Border.all(color: border, width: 1),
+        ),
+        child: DefaultTextStyle(
+          style: theme.textTheme.bodySmall ??
+              const TextStyle(fontSize: 12),
+          child: label,
+        ),
+      ),
+    );
+  }
+}
+

--- a/app/lib/widgets/ct_dialog_shell.dart
+++ b/app/lib/widgets/ct_dialog_shell.dart
@@ -1,0 +1,117 @@
+import 'package:flame/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:logger/logger.dart';
+
+/// Pixel-art dialog shell using a nine-patch frame. SPEC/ui/buttons-nine-patch.md (reuse canon).
+///
+/// Wraps arbitrary [child] content inside a constrained, centered dialog with
+/// a transparent backdrop and nine-patch chrome. Use this instead of
+/// [AlertDialog] or [Dialog] for all app dialogs.
+class CtDialogShell extends StatelessWidget {
+  const CtDialogShell({
+    super.key,
+    required this.child,
+    this.maxWidth = 480,
+    this.maxHeight = 600,
+    this.destTileSize = 16,
+    this.padding =
+        const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+  });
+
+  /// Dialog body content (title, text, actions column/rows).
+  final Widget child;
+
+  /// Maximum width of the dialog content area.
+  final double maxWidth;
+
+  /// Maximum height of the dialog content area.
+  final double maxHeight;
+
+  /// Rendered size of each tile edge (Flame destTileSize).
+  final double destTileSize;
+
+  /// Inner padding between nine-patch frame and [child].
+  final EdgeInsetsGeometry padding;
+
+  static const String _kAssetPath = 'ui_button_nine_patch.png';
+  static const double _tileSize = 16;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color fallbackColor = theme.colorScheme.surface;
+
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      elevation: 0,
+      insetPadding: const EdgeInsets.all(16),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: maxWidth,
+            maxHeight: maxHeight,
+          ),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final double width = constraints.maxWidth;
+              final double height = constraints.maxHeight;
+              return NineTileBoxWidget.asset(
+                path: _kAssetPath,
+                tileSize: _tileSize,
+                destTileSize: destTileSize,
+                width: width,
+                height: height,
+                padding: padding,
+                child: DefaultTextStyle(
+                  style: theme.textTheme.bodyMedium ??
+                      const TextStyle(color: Colors.white),
+                  child: child,
+                ),
+                loadingBuilder: (_) => _FallbackDialogFrame(
+                  color: fallbackColor,
+                  padding: padding,
+                  child: child,
+                ),
+                errorBuilder: (_) {
+                  Logger().w(
+                    'ui: dialog nine-patch asset not found, using fallback frame',
+                  );
+                  return _FallbackDialogFrame(
+                    color: fallbackColor,
+                    padding: padding,
+                    child: child,
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FallbackDialogFrame extends StatelessWidget {
+  const _FallbackDialogFrame({
+    required this.color,
+    required this.padding,
+    required this.child,
+  });
+
+  final Color color;
+  final EdgeInsetsGeometry padding;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: padding,
+      decoration: BoxDecoration(
+        color: color,
+        border: Border.all(color: Colors.black87, width: 2),
+      ),
+      child: child,
+    );
+  }
+}
+

--- a/app/lib/widgets/ct_dropdown.dart
+++ b/app/lib/widgets/ct_dropdown.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+
+import 'ct_dialog_shell.dart';
+import 'ct_nine_patch_button.dart';
+
+/// Pixel-art dropdown: nine-patch button + modal list of options.
+class CtDropdown<T> extends StatelessWidget {
+  const CtDropdown({
+    super.key,
+    required this.value,
+    required this.items,
+    required this.onChanged,
+    this.hint,
+    this.isExpanded = true,
+    this.itemLabel,
+  });
+
+  final T? value;
+  final List<T> items;
+  final ValueChanged<T?> onChanged;
+  final String? hint;
+  final bool isExpanded;
+  final String Function(T value)? itemLabel;
+
+  String _labelFor(T v) => itemLabel != null ? itemLabel!(v) : v.toString();
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = value != null && items.contains(value)
+        ? _labelFor(value as T)
+        : (hint ?? 'Select');
+
+    Widget buttonChild = Text(
+      selected,
+      overflow: TextOverflow.ellipsis,
+    );
+
+    if (isExpanded) {
+      buttonChild = Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Expanded(
+            child: Text(
+              selected,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 8),
+          const Icon(Icons.expand_more, size: 16),
+        ],
+      );
+    }
+
+    return CtNinePatchButton(
+      onPressed: () async {
+        final chosen = await showDialog<T>(
+          context: context,
+          builder: (ctx) => CtDialogShell(
+            maxWidth: 320,
+            maxHeight: 400,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                if (hint != null) ...[
+                  Text(
+                    hint!,
+                    style: Theme.of(ctx).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                ],
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: items.length,
+                    itemBuilder: (context, index) {
+                      final v = items[index];
+                      final label = _labelFor(v);
+                      final selected = v == value;
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 4),
+                        child: CtNinePatchButton(
+                          onPressed: () {
+                            Navigator.of(ctx).pop(v);
+                          },
+                          enabled: true,
+                          child: Align(
+                            alignment: Alignment.centerLeft,
+                            child: Text(
+                              label,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+        if (chosen != null) {
+          onChanged(chosen);
+        }
+      },
+      child: buttonChild,
+    );
+  }
+}
+

--- a/app/lib/widgets/ct_panel.dart
+++ b/app/lib/widgets/ct_panel.dart
@@ -1,0 +1,87 @@
+import 'package:flame/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:logger/logger.dart';
+
+/// Pixel-art panel using the same nine-patch as buttons/dialogs.
+/// Replace [Card] with this for framed content sections.
+class CtPanel extends StatelessWidget {
+  const CtPanel({
+    super.key,
+    required this.child,
+    this.padding = const EdgeInsets.all(12),
+    this.destTileSize = 16,
+  });
+
+  final Widget child;
+  final EdgeInsetsGeometry padding;
+  final double destTileSize;
+
+  static const String _kAssetPath = 'ui_button_nine_patch.png';
+  static const double _tileSize = 16;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final fallbackColor = theme.colorScheme.surface;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth.isFinite
+            ? constraints.maxWidth
+            : null;
+        final height = constraints.maxHeight.isFinite
+            ? constraints.maxHeight
+            : null;
+        return NineTileBoxWidget.asset(
+          path: _kAssetPath,
+          tileSize: _tileSize,
+          destTileSize: destTileSize,
+          width: width,
+          height: height,
+          padding: padding,
+          child: child,
+          loadingBuilder: (_) => _FallbackPanel(
+            color: fallbackColor,
+            padding: padding,
+            child: child,
+          ),
+          errorBuilder: (_) {
+            Logger().w(
+              'ui: panel nine-patch asset not found, using fallback',
+            );
+            return _FallbackPanel(
+              color: fallbackColor,
+              padding: padding,
+              child: child,
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class _FallbackPanel extends StatelessWidget {
+  const _FallbackPanel({
+    required this.color,
+    required this.padding,
+    required this.child,
+  });
+
+  final Color color;
+  final EdgeInsetsGeometry padding;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: padding,
+      decoration: BoxDecoration(
+        color: color,
+        border: Border.all(color: Colors.black87, width: 2),
+      ),
+      child: child,
+    );
+  }
+}
+

--- a/app/lib/widgets/ct_screen_shell.dart
+++ b/app/lib/widgets/ct_screen_shell.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+import 'ct_panel.dart';
+
+/// Full-screen pixel-art shell: background + framed content area.
+class CtScreenShell extends StatelessWidget {
+  const CtScreenShell({
+    super.key,
+    required this.title,
+    required this.child,
+  });
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      backgroundColor: theme.colorScheme.surface,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: CtPanel(
+            padding: const EdgeInsets.all(8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  color: theme.colorScheme.primary.withValues(alpha: 0.8),
+                  child: Text(
+                    title,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      color: theme.colorScheme.onPrimary,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Expanded(child: child),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/app/lib/widgets/ct_slider.dart
+++ b/app/lib/widgets/ct_slider.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+/// Pixel-art friendly slider for integer values.
+/// Replaces Material [Slider] in production allocation.
+class CtSlider extends StatelessWidget {
+  const CtSlider({
+    super.key,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.divisions,
+    required this.onChanged,
+  });
+
+  final double value;
+  final double min;
+  final double max;
+  final int divisions;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final t = ((value - min) / (max - min)).clamp(0, 1);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        final trackHeight = 6.0;
+        final handleSize = 14.0;
+        final handleX = t * (width - handleSize);
+
+        void handleTapOrDrag(Offset localPos) {
+          final x = localPos.dx.clamp(0, width - handleSize);
+          final ratio = x / (width - handleSize);
+          final raw = min + ratio * (max - min);
+          if (divisions > 0) {
+            final step = (max - min) / divisions;
+            final snapped = (raw / step).round() * step + min;
+            onChanged(snapped.clamp(min, max));
+          } else {
+            onChanged(raw.clamp(min, max));
+          }
+        }
+
+        return GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onTapDown: (d) => handleTapOrDrag(d.localPosition),
+          onHorizontalDragUpdate: (d) => handleTapOrDrag(d.localPosition),
+          child: SizedBox(
+            height: 24,
+            child: Stack(
+              alignment: Alignment.centerLeft,
+              children: [
+                // Track
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  top: (24 - trackHeight) / 2,
+                  child: Container(
+                    height: trackHeight,
+                    decoration: BoxDecoration(
+                      color: colorScheme.surface.withValues(alpha: 0.7),
+                      border: Border.all(
+                        color: colorScheme.outline,
+                        width: 1,
+                      ),
+                    ),
+                  ),
+                ),
+                // Filled portion
+                Positioned(
+                  left: 1,
+                  top: (24 - trackHeight + 2) / 2,
+                  width: handleX + handleSize / 2,
+                  child: Container(
+                    height: trackHeight - 2,
+                    color: colorScheme.primary.withValues(alpha: 0.5),
+                  ),
+                ),
+                // Handle (square, pixel-ish)
+                Positioned(
+                  left: handleX,
+                  top: (24 - handleSize) / 2,
+                  child: Container(
+                    width: handleSize,
+                    height: handleSize,
+                    decoration: BoxDecoration(
+                      color: colorScheme.primary,
+                      border: Border.all(
+                        color: colorScheme.onPrimary,
+                        width: 1,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+

--- a/app/lib/widgets/debug_map_visibility_story.dart
+++ b/app/lib/widgets/debug_map_visibility_story.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:flutter/material.dart';
 
+import 'ct_choice_chip.dart';
 import 'ct_region_map.dart';
 import 'debug_init_game.dart';
 
@@ -84,7 +85,7 @@ class _DebugMapVisibilityStoryState extends State<DebugMapVisibilityStory> {
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                ChoiceChip(
+                CtChoiceChip(
                   label: const Text('Full visibility'),
                   selected: _visibilityMode == CtMapVisibilityMode.full,
                   onSelected: (_) {
@@ -94,7 +95,7 @@ class _DebugMapVisibilityStoryState extends State<DebugMapVisibilityStory> {
                   },
                 ),
                 const SizedBox(width: 8),
-                ChoiceChip(
+                CtChoiceChip(
                   label: const Text('Player-constrained'),
                   selected:
                       _visibilityMode == CtMapVisibilityMode.playerConstrained,

--- a/app/lib/widgets/game_setup.dart
+++ b/app/lib/widgets/game_setup.dart
@@ -241,6 +241,7 @@ class _CtGameSetupState extends State<CtGameSetup> {
             value: '',
             items: const [''],
             hint: 'Select leader',
+            itemLabel: (_) => 'Select leader',
             onChanged: (_) {},
           )
         : CtDropdown<String>(

--- a/app/lib/widgets/game_setup.dart
+++ b/app/lib/widgets/game_setup.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:flutter/material.dart';
 
+import 'ct_dropdown.dart';
 import 'ct_nine_patch_button.dart';
 
 /// Visual variant of the Game Setup screen. SPEC/ui/game-setup.md; UXD 03b.
@@ -204,21 +205,17 @@ class _CtGameSetupState extends State<CtGameSetup> {
           ),
     );
 
-    final Widget nationDropdown = DropdownButton<String>(
-      value: availableGpIds.contains(gpId) ? gpId : (availableGpIds.isNotEmpty ? availableGpIds.first : null),
-      isExpanded: true,
-      items: [
-        for (final id in availableGpIds)
-          DropdownMenuItem(
-            value: id,
-            child: Text(
-              id.isEmpty ? 'Select nation' : (widget.naming.gpById(id)?.countryName ?? id),
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-      ],
+    final Widget nationDropdown = CtDropdown<String>(
+      value: availableGpIds.contains(gpId)
+          ? gpId
+          : (availableGpIds.isNotEmpty ? availableGpIds.first : null),
+      items: availableGpIds,
+      hint: 'Select nation',
+      itemLabel: (id) => id.isEmpty
+          ? 'Select nation'
+          : (widget.naming.gpById(id)?.countryName ?? id),
       onChanged: _isLoading
-          ? null
+          ? (_) {}
           : (value) {
               if (value != null) {
                 if (value.isEmpty) {
@@ -231,7 +228,8 @@ class _CtGameSetupState extends State<CtGameSetup> {
                 if (newGp != null) {
                   setState(() {
                     _orderedGpIdsBySlot[slotIndex] = value;
-                    _leaderVariantByGpId[value] = newGp.defaultLeaderVariantId;
+                    _leaderVariantByGpId[value] =
+                        newGp.defaultLeaderVariantId;
                   });
                 }
               }
@@ -239,26 +237,22 @@ class _CtGameSetupState extends State<CtGameSetup> {
     );
 
     final Widget leaderDropdown = gpId.isEmpty
-        ? DropdownButton<String>(
+        ? CtDropdown<String>(
             value: '',
-            isExpanded: true,
-            items: const [
-              DropdownMenuItem(value: '', child: Text('Select leader')),
-            ],
-            onChanged: null,
+            items: const [''],
+            hint: 'Select leader',
+            onChanged: (_) {},
           )
-        : DropdownButton<String>(
-            value: variants.any((v) => v.id == currentVariantId) ? currentVariantId : (variants.isNotEmpty ? variants.first.id : null),
-            isExpanded: true,
-            items: [
-              for (final v in variants)
-                DropdownMenuItem(
-                  value: v.id,
-                  child: Text(v.name, overflow: TextOverflow.ellipsis),
-                ),
-            ],
+        : CtDropdown<String>(
+            value: variants.any((v) => v.id == currentVariantId)
+                ? currentVariantId
+                : (variants.isNotEmpty ? variants.first.id : null),
+            items: variants.map((v) => v.id).toList(),
+            hint: 'Select leader',
+            itemLabel: (id) =>
+                variants.firstWhere((v) => v.id == id).name,
             onChanged: _isLoading
-                ? null
+                ? (_) {}
                 : (value) {
                     if (value != null) {
                       setState(() => _leaderVariantByGpId[gpId] = value);
@@ -355,20 +349,11 @@ class _GameSetupMenuButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (variant == GameSetupVariant.pixelArt) {
-      return SizedBox(
-        width: double.infinity,
-        child: CtNinePatchButton(
-          onPressed: onPressed,
-          enabled: enabled && onPressed != null,
-          child: Text(label),
-        ),
-      );
-    }
     return SizedBox(
       width: double.infinity,
-      child: ElevatedButton(
+      child: CtNinePatchButton(
         onPressed: onPressed,
+        enabled: enabled && onPressed != null,
         child: Text(label),
       ),
     );

--- a/app/test/diplomacy_panel_test.dart
+++ b/app/test/diplomacy_panel_test.dart
@@ -4,10 +4,10 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/diplomacy_panel.dart';
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
 
 void main() {
@@ -125,7 +125,7 @@ void main() {
       ));
       await tester.pumpAndSettle();
 
-      expect(find.byType(FilledButton), findsAtLeastNWidgets(1));
+      expect(find.byType(CtNinePatchButton), findsAtLeastNWidgets(1));
       expect(
         find.text('Declare War').evaluate().isNotEmpty ||
             find.text('Offer Peace').evaluate().isNotEmpty ||

--- a/app/test/diplomacy_panel_test.dart
+++ b/app/test/diplomacy_panel_test.dart
@@ -4,10 +4,12 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/diplomacy_panel.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+import 'package:colonizethis_app/widgets/ct_panel.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
 
 void main() {
@@ -69,7 +71,7 @@ void main() {
       ));
       await tester.pumpAndSettle();
 
-      expect(find.byType(Card), findsAtLeastNWidgets(1));
+      expect(find.byType(CtPanel), findsAtLeastNWidgets(1));
       final firstGp = gameWithFactions.players
           .where((p) => p.id != humanPlayerId)
           .map((p) => p.displayName)

--- a/app/test/military_units_panel_test.dart
+++ b/app/test/military_units_panel_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart';
+import 'package:colonizethis_app/widgets/ct_panel.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
 
 void main() {
@@ -115,14 +116,14 @@ void main() {
       expect(find.textContaining(' — '), findsAtLeastNWidgets(1));
     });
 
-    testWidgets('panel is wrapped in Card', (WidgetTester tester) async {
+    testWidgets('panel is wrapped in CtPanel', (WidgetTester tester) async {
       await tester.pumpWidget(buildPanel(
         game: game,
         humanPlayerId: humanPlayerIdWithUnits,
       ));
       await tester.pumpAndSettle();
 
-      expect(find.byType(Card), findsOneWidget);
+      expect(find.byType(CtPanel), findsOneWidget);
     });
 
     testWidgets('AC: Tapping a row invokes onLocateTile with tileKey and regionId',

--- a/app/test/production_panel_test.dart
+++ b/app/test/production_panel_test.dart
@@ -3,6 +3,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/production_panel.dart';

--- a/app/test/production_panel_test.dart
+++ b/app/test/production_panel_test.dart
@@ -3,10 +3,10 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/production_panel.dart';
+import 'package:colonizethis_app/widgets/ct_slider.dart';
 import 'package:colonizethis_app/features/game/widgets/production_panel_demo_data.dart';
 import 'package:colonizethis_app/features/game/widgets/province_overlay_demo_data.dart';
 
@@ -76,7 +76,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Allocation'), findsOneWidget);
-      expect(find.byType(Slider),
+      expect(find.byType(CtSlider),
           findsNWidgets(ProductionRecipesCatalog.all.length));
       expect(find.textContaining('Lumber'), findsWidgets);
       expect(find.textContaining('Fabric'), findsWidgets);
@@ -109,7 +109,7 @@ void main() {
       ));
       await tester.pumpAndSettle();
 
-      final sliders = find.byType(Slider);
+      final sliders = find.byType(CtSlider);
       expect(sliders, findsNWidgets(ProductionRecipesCatalog.all.length));
       await tester.drag(sliders.first, const Offset(80, 0));
       await tester.pumpAndSettle();
@@ -172,7 +172,7 @@ void main() {
       await tester.pumpWidget(buildPanel(player: partialPlayer));
       await tester.pumpAndSettle();
 
-      expect(find.byType(Slider),
+      expect(find.byType(CtSlider),
           findsNWidgets(ProductionRecipesCatalog.all.length));
       expect(find.text('Available'), findsOneWidget);
       expect(find.textContaining('Effective labour: 2'), findsOneWidget);

--- a/app/test/screen_spec_acceptance_test.dart
+++ b/app/test/screen_spec_acceptance_test.dart
@@ -2,6 +2,7 @@
 // Screens match Widgetbook mockups (CtMainMenu, CtGameSetup). SPEC/ui/main-menu.md, SPEC/ui/game-setup.md.
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/config/themes.dart';

--- a/app/test/screen_spec_acceptance_test.dart
+++ b/app/test/screen_spec_acceptance_test.dart
@@ -2,10 +2,11 @@
 // Screens match Widgetbook mockups (CtMainMenu, CtGameSetup). SPEC/ui/main-menu.md, SPEC/ui/game-setup.md.
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/config/themes.dart';
+import 'package:colonizethis_app/widgets/ct_dropdown.dart';
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/game_setup.dart';
 import 'package:colonizethis_app/widgets/main_menu.dart';
 
@@ -275,14 +276,12 @@ void main() {
 
       expect(find.text('Select nation'), findsNWidgets(6));
       expect(find.text('Select leader'), findsNWidgets(6));
-      final startFinder = find.byWidgetPredicate(
-        (Widget w) =>
-            w is ElevatedButton &&
-            w.child is Text &&
-            (w.child as Text).data == 'Start Game',
-      );
+      final startFinder = find.widgetWithText(CtNinePatchButton, 'Start Game');
       expect(startFinder, findsOneWidget);
-      expect(tester.widget<ElevatedButton>(startFinder).onPressed, isNull);
+      expect(
+        tester.widget<CtNinePatchButton>(startFinder).enabled,
+        isFalse,
+      );
     });
 
     testWidgets('AC Start disabled until complete: all six slots filled enables Start',
@@ -302,14 +301,12 @@ void main() {
       ));
       await tester.pumpAndSettle();
 
-      final startFinder = find.byWidgetPredicate(
-        (Widget w) =>
-            w is ElevatedButton &&
-            w.child is Text &&
-            (w.child as Text).data == 'Start Game',
-      );
+      final startFinder = find.widgetWithText(CtNinePatchButton, 'Start Game');
       expect(startFinder, findsOneWidget);
-      expect(tester.widget<ElevatedButton>(startFinder).onPressed, isNotNull);
+      expect(
+        tester.widget<CtNinePatchButton>(startFinder).enabled,
+        isTrue,
+      );
     });
 
     testWidgets('AC No duplicate nations: selecting nation in slot 0 removes it from slot 1',
@@ -333,7 +330,7 @@ void main() {
       await tester.pumpWidget(buildGameSetup());
       await tester.pumpAndSettle();
 
-      final nationDropdowns = find.byType(DropdownButton<String>);
+      final nationDropdowns = find.byType(CtDropdown<String>);
       await tester.tap(nationDropdowns.first);
       await tester.pumpAndSettle();
       await tester.tap(find.text('England').last);
@@ -396,13 +393,11 @@ void main() {
       await tester.pump();
 
       expect(find.text('Starting…'), findsOneWidget);
-      final startFinder = find.byWidgetPredicate(
-        (Widget w) =>
-            w is ElevatedButton &&
-            w.child is Text &&
-            (w.child as Text).data == 'Start Game',
+      final startFinder = find.widgetWithText(CtNinePatchButton, 'Start Game');
+      expect(
+        tester.widget<CtNinePatchButton>(startFinder).enabled,
+        isFalse,
       );
-      expect(tester.widget<ElevatedButton>(startFinder).onPressed, isNull);
       await tester.tap(find.text('Back'));
       await tester.pump();
       expect(backCalled, isTrue);
@@ -472,13 +467,11 @@ void main() {
       ));
       await tester.pumpAndSettle();
 
-      final startFinder = find.byWidgetPredicate(
-        (Widget w) =>
-            w is ElevatedButton &&
-            w.child is Text &&
-            (w.child as Text).data == 'Start Game',
+      final startFinder = find.widgetWithText(CtNinePatchButton, 'Start Game');
+      expect(
+        tester.widget<CtNinePatchButton>(startFinder).enabled,
+        isTrue,
       );
-      expect(tester.widget<ElevatedButton>(startFinder).onPressed, isNotNull);
     });
 
     testWidgets('Coverage: clear nation in slot hits empty value branch',
@@ -491,7 +484,7 @@ void main() {
       await tester.tap(find.text('England').last);
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(DropdownButton<String>).first);
+      await tester.tap(find.byType(CtDropdown<String>).first);
       await tester.pumpAndSettle();
       await tester.ensureVisible(find.text('Select nation').first);
       await tester.tap(find.text('Select nation').first, warnIfMissed: false);
@@ -503,12 +496,12 @@ void main() {
       await tester.pumpWidget(buildGameSetup());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(DropdownButton<String>).first);
+      await tester.tap(find.byType(CtDropdown<String>).first);
       await tester.pumpAndSettle();
       await tester.tap(find.text('England').last);
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(DropdownButton<String>).at(1));
+      await tester.tap(find.byType(CtDropdown<String>).at(1));
       await tester.pumpAndSettle();
       final leaderOptions = find.text('Queen Victoria');
       if (leaderOptions.evaluate().length > 1) {

--- a/app/test/tech_tree_widget_test.dart
+++ b/app/test/tech_tree_widget_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/tech_tree_widget.dart';
 import 'package:colonizethis_app/features/game/widgets/technology_screen.dart';
+import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
 
 void main() {
@@ -101,10 +102,10 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    expect(find.byType(AlertDialog), findsNothing);
+    expect(find.byType(CtDialogShell), findsNothing);
     await tester.tap(find.text('Gathering 1'));
     await tester.pumpAndSettle();
-    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.byType(CtDialogShell), findsOneWidget);
     expect(find.text('Gathering 1'), findsWidgets); // title and node
   });
 
@@ -124,6 +125,7 @@ void main() {
     await tester.tap(find.text('Gathering 1'));
     await tester.pumpAndSettle();
     // SPEC: display name, era, category, RP cost, effect summary; no prerequisites.
+    expect(find.byType(CtDialogShell), findsOneWidget);
     expect(find.text('Gathering 1'), findsWidgets);
     expect(find.textContaining('Era'), findsOneWidget);
     expect(find.textContaining('Gathering'), findsWidgets);
@@ -148,10 +150,10 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.text('Gathering 1'));
     await tester.pumpAndSettle();
-    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.byType(CtDialogShell), findsOneWidget);
     await tester.tap(find.text('Close'));
     await tester.pumpAndSettle();
-    expect(find.byType(AlertDialog), findsNothing);
+    expect(find.byType(CtDialogShell), findsNothing);
     expect(find.byType(TechTreeWidget), findsOneWidget);
   });
 
@@ -211,13 +213,13 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    expect(find.byType(AlertDialog), findsNothing);
+    expect(find.byType(CtDialogShell), findsNothing);
     // Gathering 2 has prerequisite gathering_1; with no techs unlocked it is locked.
     final gathering2Find = find.text('Gathering 2');
     await tester.ensureVisible(gathering2Find.first);
     await tester.tap(gathering2Find.first);
     await tester.pumpAndSettle();
-    expect(find.byType(AlertDialog), findsNothing);
+    expect(find.byType(CtDialogShell), findsNothing);
   });
 }
 


### PR DESCRIPTION
## Summary
- Replace Material buttons, dialogs, cards, sliders, dropdowns, and shells with pixel-art Ct-* components.
- Introduce CtDialogShell, CtPanel, CtChoiceChip, CtSlider, CtDropdown, and CtScreenShell and wire them through main menu, game setup, in-game panels, and combat flows.
- Update UI specs to ban Material design chrome and define a pixel-art UI catalog; adjust widget tests to target the new Ct-* components.

## Test plan
- [ ] Run app main menu and verify nine-patch buttons and CtScreenShell frame.
- [ ] Walk through game setup flow and ensure CtDropdown and CtNinePatchButton behave correctly.
- [ ] Exercise in-game panels (production, tech, diplomacy, units) and combat dialogs to confirm all buttons/sliders/dialogs render with pixel-art chrome.
- [ ] Run existing widget tests under  to confirm they pass with Ct-* components.


Made with [Cursor](https://cursor.com)