### PR TITLE
feat(tech-tree): no vertical edges, column rule, catalog validation

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -60,17 +60,65 @@ jobs:
       - name: Check test import convention (SPEC/program/test-logging.md)
         run: tool/check_test_imports.sh
 
-      - name: Test packages (Dart)
+      - name: Test colonizethis_models (Dart)
         if: steps.changes.outputs.tests == 'true'
         env:
           SUPPRESS_IMAGE_VIEWER: "1"
         run: |
-          set -e
-          for dir in packages/colonizethis_models packages/colonizethis_data packages/colonizethis_save packages/colonizethis_logic packages/colonizethis_ai packages/colonizethis_map; do
-            [ -d "$dir/test" ] || continue
-            (cd "$dir" && dart test --coverage=coverage -j 2 --reporter=compact)
-            (cd "$dir" && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
-          done
+          if [ -d packages/colonizethis_models/test ]; then
+            (cd packages/colonizethis_models && dart test --coverage=coverage -j 2 --reporter=compact)
+            (cd packages/colonizethis_models && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
+          fi
+
+      - name: Test colonizethis_data (Dart)
+        if: steps.changes.outputs.tests == 'true'
+        env:
+          SUPPRESS_IMAGE_VIEWER: "1"
+        run: |
+          if [ -d packages/colonizethis_data/test ]; then
+            (cd packages/colonizethis_data && dart test --coverage=coverage -j 2 --reporter=compact)
+            (cd packages/colonizethis_data && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
+          fi
+
+      - name: Test colonizethis_save (Dart)
+        if: steps.changes.outputs.tests == 'true'
+        env:
+          SUPPRESS_IMAGE_VIEWER: "1"
+        run: |
+          if [ -d packages/colonizethis_save/test ]; then
+            (cd packages/colonizethis_save && dart test --coverage=coverage -j 2 --reporter=compact)
+            (cd packages/colonizethis_save && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
+          fi
+
+      - name: Test colonizethis_logic (Dart)
+        if: steps.changes.outputs.tests == 'true'
+        env:
+          SUPPRESS_IMAGE_VIEWER: "1"
+        run: |
+          if [ -d packages/colonizethis_logic/test ]; then
+            (cd packages/colonizethis_logic && dart test --coverage=coverage -j 2 --reporter=compact)
+            (cd packages/colonizethis_logic && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
+          fi
+
+      - name: Test colonizethis_ai (Dart)
+        if: steps.changes.outputs.tests == 'true'
+        env:
+          SUPPRESS_IMAGE_VIEWER: "1"
+        run: |
+          if [ -d packages/colonizethis_ai/test ]; then
+            (cd packages/colonizethis_ai && dart test --coverage=coverage -j 2 --reporter=compact)
+            (cd packages/colonizethis_ai && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
+          fi
+
+      - name: Test colonizethis_map (Dart)
+        if: steps.changes.outputs.tests == 'true'
+        env:
+          SUPPRESS_IMAGE_VIEWER: "1"
+        run: |
+          if [ -d packages/colonizethis_map/test ]; then
+            (cd packages/colonizethis_map && dart test --coverage=coverage -j 2 --reporter=compact)
+            (cd packages/colonizethis_map && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
+          fi
 
       - name: Test ctterm (Dart)
         if: steps.changes.outputs.tests == 'true'

--- a/SPEC/ui/tech-tree-widget.md
+++ b/SPEC/ui/tech-tree-widget.md
@@ -10,7 +10,8 @@
 ## Layout
 
 - **Graph:** All techs from the global catalog in a single graph. **Left to right:** starting techs (no prerequisites) at the left; end-game techs at the right. Nodes are arranged in **topological layers** (by distance from roots); within a layer, nodes may be grouped or spaced to reduce edge crossings.
-- **Edges:** **Explicit right‑angled lines** (orthogonal segments) from each prerequisite tech to the tech that requires it. Edges run horizontally out from the source node, then vertically, then horizontally into the target node, and are drawn **behind nodes** so they do not obscure node labels or node bodies.
+- **Column rule:** If tech A has a prerequisite tech B, then A must be in a column strictly to the right of B. Thus when there is both a chain (A→B→C) and a direct edge (A→C), there is necessarily a gap between A and C, because B occupies the column in between.
+- **Edges:** **Direct lines** from each prerequisite tech to the tech that requires it. No vertical segments: edges run in a straight line from the source node’s right edge to the target node’s left edge (diagonal when source and target are in different rows). Edges are drawn **behind nodes** so they do not obscure node labels or node bodies.
 - **Scroll:** The graph can be long; the content is inside a **scrollable** viewport (e.g. `SingleChildScrollView` with both axes, or scrollable region). No zoom or pan required for MVP.
 - **Categories:** One graph shows **all** techs. Each node is **color-coded by category** (gathering, transport, labour, civilian, diplomacy, naval, military; new-world if present). Category colours are distinct and consistent (e.g. gathering = green, transport = blue, labour = amber, etc.; exact palette in theme or widget).
 
@@ -58,6 +59,8 @@ States are mutually exclusive; “in progress” takes precedence over “availa
 - **Given** the description dialog is open, **when** the user dismisses it (e.g. tap outside or Close), **then** the dialog closes and the tree remains visible with no state change.
 
 - **Given** the Technology flow is opened from the in-game shell, **when** the user selects the Tech Tree tab, **then** the tree tab is full-screen (or fills the Technology view) and does not offer research slot assignment; assignment is only in the slots tab.
+
+- **Given** the tech tree contains a chain A→B→C and a direct edge A→C (e.g. Apprentice Workers→University→Master Artisans with Master Artisans also requiring Apprentice Workers), **when** the tech tree is displayed, **then** A is in a column to the left of B, and B is in a column to the left of C, so that there is a gap between A and C with B occupying the column in between.
 
 ## Integration
 

--- a/app/lib/features/game/widgets/tech_tree_widget.dart
+++ b/app/lib/features/game/widgets/tech_tree_widget.dart
@@ -10,9 +10,9 @@ import 'package:flutter/material.dart';
 import '../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 
-/// Node position for layout.
-class _TechNodePosition {
-  const _TechNodePosition({
+/// Node position for layout. Exposed for tests (column rule: A→B→C and A→C ⇒ gap between A and C).
+class TechNodePosition {
+  const TechNodePosition({
     required this.techId,
     required this.x,
     required this.y,
@@ -56,7 +56,7 @@ class TechTreeWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final positions = _computeLayout();
+    final positions = TechTreeWidget.computeLayout(techCatalog);
     if (positions.isEmpty) {
       return const Center(child: Text('No techs in catalog'));
     }
@@ -123,8 +123,9 @@ class TechTreeWidget extends StatelessWidget {
     );
   }
 
-  List<_TechNodePosition> _computeLayout() {
-    final catalog = techCatalog;
+  /// Computes topological layout: each tech in a column strictly right of all its prerequisites.
+  /// Used by the widget and by tests (column rule: A→B→C and A→C ⇒ B occupies column between A and C).
+  static List<TechNodePosition> computeLayout(Map<String, TechDefinition> catalog) {
     if (catalog.isEmpty) return [];
 
     // Layer: 0 = roots, 1 = one step from root, etc.
@@ -159,11 +160,11 @@ class TechTreeWidget extends StatelessWidget {
       list.sort((a, b) => a.compareTo(b));
     }
 
-    final positions = <_TechNodePosition>[];
+    final positions = <TechNodePosition>[];
     for (var layer = 0; layer <= maxLayer; layer++) {
       final ids = byLayer[layer] ?? [];
       for (var i = 0; i < ids.length; i++) {
-        positions.add(_TechNodePosition(
+        positions.add(TechNodePosition(
           techId: ids[i],
           x: 24 + layer * _layerGap,
           y: 24 + i * _rowGap,
@@ -351,7 +352,7 @@ class _TechNodeState {
 class _TechTreeEdgePainter extends CustomPainter {
   _TechTreeEdgePainter({required this.positions});
 
-  final List<_TechNodePosition> positions;
+  final List<TechNodePosition> positions;
 
   static double get _centerY => _nodeHeight / 2;
 
@@ -374,15 +375,10 @@ class _TechTreeEdgePainter extends CustomPainter {
         final fromRightX = fromPos.x + _nodeWidth;
         final fromCenterY = fromPos.y + _centerY;
 
-        // Orthogonal (right-angled) path: out from right edge, over horizontally, then into left edge.
-        final midX = (fromRightX + toLeftX) / 2;
-
+        // Direct line from source right edge to target left edge (no vertical segments).
         final path = Path()
           ..moveTo(fromRightX, fromCenterY)
-          ..lineTo(midX, fromCenterY)
-          ..lineTo(midX, toCenterY)
           ..lineTo(toLeftX, toCenterY);
-
         canvas.drawPath(path, paint);
       }
     }

--- a/app/test/tech_tree_widget_test.dart
+++ b/app/test/tech_tree_widget_test.dart
@@ -222,6 +222,46 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(CtDialogShell), findsNothing);
   });
+
+  test('Column rule: A→B→C and A→C places B between A and C (gap between A and C)', () {
+    // SPEC/ui/tech-tree-widget.md: when there is both a chain (A→B→C) and a direct edge (A→C),
+    // there must be a gap between A and C because B occupies the column in between.
+    const a = TechDefinition(
+      id: 'a',
+      era: 1,
+      category: 'gathering',
+      cost: 1,
+      prerequisiteIds: [],
+      regimentUnlockIds: [],
+      shipUnlockIds: [],
+    );
+    const b = TechDefinition(
+      id: 'b',
+      era: 1,
+      category: 'gathering',
+      cost: 1,
+      prerequisiteIds: ['a'],
+      regimentUnlockIds: [],
+      shipUnlockIds: [],
+    );
+    const c = TechDefinition(
+      id: 'c',
+      era: 1,
+      category: 'gathering',
+      cost: 1,
+      prerequisiteIds: ['a', 'b'],
+      regimentUnlockIds: [],
+      shipUnlockIds: [],
+    );
+    final catalog = <String, TechDefinition>{'a': a, 'b': b, 'c': c};
+    final positions = TechTreeWidget.computeLayout(catalog);
+    expect(positions.length, 3);
+    final posA = positions.firstWhere((p) => p.techId == 'a');
+    final posB = positions.firstWhere((p) => p.techId == 'b');
+    final posC = positions.firstWhere((p) => p.techId == 'c');
+    expect(posA.x, lessThan(posB.x), reason: 'A must be left of B');
+    expect(posB.x, lessThan(posC.x), reason: 'B must be left of C so B occupies column between A and C');
+  });
 }
 
 Player _dummyPlayer() {

--- a/packages/colonizethis_data/test/tech_graph_test.dart
+++ b/packages/colonizethis_data/test/tech_graph_test.dart
@@ -1,8 +1,154 @@
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 
+/// Tech ids from SPEC/game tech-tree.md and category sub-docs (source of truth for "all techs in the tree").
+/// Used to assert the catalog matches the spec and every spec tech is present and reachable.
+const Set<String> _specTechIds = {
+  // Gathering — tech-tree-gathering.md
+  'crop_rotation',
+  'saw_mill',
+  'land_enclosure',
+  'mine_engineering',
+  'iron_mining',
+  'copper_and_tin_mining',
+  'coal_mining',
+  'wind_saw_mill',
+  'seed_drill',
+  'sheep_ranching',
+  'animal_husbandry',
+  'square_set_timbering',
+  'steam_in_mining',
+  'large_coal_mines',
+  'large_copper_and_tin_mines',
+  'circular_saw',
+  'scientific_sheep_breeding',
+  'scientific_cattle_breeding',
+  'moldboard_plow',
+  'safety_lamp',
+  'large_precious_stone_mines',
+  'extraction_of_precious_metals',
+  'geological_prospecting',
+  'amalgamation_process',
+  'industrial_iron_mining',
+  'efficient_extraction_of_copper_and_tin',
+  // Labour — tech-tree-labour-economy.md
+  'printing_press',
+  'apprentice_workers',
+  'trained_journeymen',
+  'master_artisans',
+  'money_lending',
+  'banking',
+  'trade_fairs',
+  'university',
+  // Transport — tech-tree-transport.md
+  'road_construction',
+  'early_steam_engine',
+  'later_steam_engine',
+  'dynamite',
+  // Diplomacy / Civilian — tech-tree-diplomacy-civilian.md
+  'diplomatic_expertise',
+  'merchant_companies',
+  'national_bureaucracy',
+  'propaganda',
+  'nationalism',
+  'empire_building',
+  // Naval — tech-tree-naval.md
+  'superior_hull_design',
+  'improved_sail_design',
+  'convoying',
+  'navigation',
+  'large_hulls',
+  'clipper_ships',
+  'paddlewheels',
+  'merchant_steamships',
+  'advanced_hull_design',
+  'ship_of_the_line',
+  'privateering_companies',
+  'advanced_iron_working',
+  // Military — tech-tree-military.md (infantry, cavalry, artillery/forts)
+  'organised_regiments',
+  'improved_iron_weapons',
+  'improved_infantry_tactics',
+  'crucible_process',
+  'bayonet',
+  'weapon_craftsmanship',
+  'industrial_machinery',
+  'explosives',
+  'early_rifles',
+  'long_range_rifles',
+  'needle_guns',
+  'elite_military_training',
+  'recruit_steppe_horsemen',
+  'improved_cavalry_tactics',
+  'hussars',
+  'improved_cavalry_weapons',
+  'scouting',
+  'repeating_cavalry_carbine',
+  'horse_artillery',
+  'siege_engineering',
+  'light_artillery_tactics',
+  'modern_forts',
+  'heavy_artillery',
+  'heavy_emplaced_artillery',
+  'field_artillery_tactics',
+  'high_grade_steel',
+  'emplaced_siege_guns',
+  'modern_military_funding',
+  'industrial_funding_of_research',
+  // New World — tech-tree-new-world.md
+  'discovery_of_sugar',
+  'sugar_planting',
+  'sugar_refining',
+  'large_sugar_plantations',
+  'sugar_industry',
+  'discovery_of_tobacco',
+  'tobacco_planting',
+  'cigar_production',
+  'large_tobacco_plantations',
+  'tobacco_industry',
+  'discovery_of_cotton',
+  'cotton_planting',
+  'cotton_weaving',
+  'large_cotton_plantations',
+  'cotton_gin',
+  'discovery_of_furs',
+  'improved_trapping_techniques',
+  'hat_production',
+  'riverboats',
+  'excessive_fur_harvesting',
+  'discovery_of_spices',
+  'improved_sea_routes',
+  'large_spice_plantations',
+  'improved_food_preservation',
+  'discovery_of_gold_or_silver',
+  'precious_metals_mining',
+  'discovery_of_gems_or_diamonds',
+  'precious_stone_mining',
+};
+
 void main() {
   group('tech graph integrity', () {
+    test('catalog contains exactly the techs defined in SPEC/game tech-tree docs', () {
+      expect(_specTechIds.length, equals(113), reason: 'SPEC defines 113 technologies');
+      final catalogIds = techCatalog.keys.toSet();
+      final missing = _specTechIds.difference(catalogIds);
+      final extra = catalogIds.difference(_specTechIds);
+      expect(missing, isEmpty, reason: 'Catalog missing spec techs: $missing');
+      expect(extra, isEmpty, reason: 'Catalog has techs not in spec: $extra');
+    });
+
+    test('every prerequisite references a tech in the catalog', () {
+      for (final entry in techCatalog.entries) {
+        for (final prereqId in entry.value.prerequisiteIds) {
+          expect(
+            techCatalog.containsKey(prereqId),
+            isTrue,
+            reason: '${entry.key} has prerequisite $prereqId which is not in the catalog',
+          );
+        }
+      }
+    });
+
     test('all techs are reachable from starting techs (except the starting techs themselves) and graph is acyclic', () {
       // Build adjacency list: prereq -> list of techs that require it.
       final Map<String, List<String>> graph = {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -476,10 +476,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- **Tech tree:** Draw direct lines between nodes (no vertical segments).
- **Layout:** Expose `computeLayout` + `TechNodePosition` for testing.
- **SPEC/ui:** Document column rule: when A→B→C and A→C, B occupies the column between A and C.
- **AC + test:** Column rule covered when chain and direct edge share endpoints.
- **colonizethis_data:** Test catalog matches SPEC tech-tree docs (113 techs); test every prerequisite references a catalog tech.
- Bump `pubspec.lock` (meta transitive).

## Changes
- `SPEC/ui/tech-tree-widget.md`: Edge description + column rule + AC.
- `app/.../tech_tree_widget.dart`: Direct edge drawing; public `computeLayout` / `TechNodePosition`.
- `app/test/tech_tree_widget_test.dart`: Column-rule unit test.
- `packages/colonizethis_data/test/tech_graph_test.dart`: Catalog vs spec tech set; prerequisite existence tests.
- `pubspec.lock`: meta version bump.

Made with [Cursor](https://cursor.com)