### PR TITLE
Tech tree: right-angled connectors, layout slots, locked tech dialog, widget tests

### DIFF
--- a/SPEC/ui/tech-tree-widget.md
+++ b/SPEC/ui/tech-tree-widget.md
@@ -11,7 +11,7 @@
 
 - **Graph:** All techs from the global catalog in a single graph. **Left to right:** starting techs (no prerequisites) at the left; end-game techs at the right. Nodes are arranged in **topological layers** (by distance from roots); within a layer, nodes may be grouped or spaced to reduce edge crossings.
 - **Column rule:** If tech A has a prerequisite tech B, then A must be in a column strictly to the right of B. Thus when there is both a chain (A→B→C) and a direct edge (A→C), there is necessarily a gap between A and C, because B occupies the column in between.
-- **Edges:** **Direct lines** from each prerequisite tech to the tech that requires it. No vertical segments: edges run in a straight line from the source node’s right edge to the target node’s left edge (diagonal when source and target are in different rows). Edges are drawn **behind nodes** so they do not obscure node labels or node bodies.
+- **Edges:** **Right-angled connectors** from each prerequisite tech to the tech that requires it. Each edge is drawn as three segments: horizontal from the source node’s right edge into the inter-column gap; vertical at that X to the target row; horizontal to the target node’s left edge. The bend X is placed just to the right of the source column (e.g. source right + half the layer gap minus node width) so the vertical segment never passes through other columns’ nodes. Edges are drawn **behind nodes** so they do not obscure node labels or node bodies. For edges that span multiple columns, the layout reserves a row slot in each intermediate column for the connector (as if a tech occupied that slot); other techs in those columns are shifted down so connectors never pass through nodes.
 - **Scroll:** The graph can be long; the content is inside a **scrollable** viewport (e.g. `SingleChildScrollView` with both axes, or scrollable region). No zoom or pan required for MVP.
 - **Categories:** One graph shows **all** techs. Each node is **color-coded by category** (gathering, transport, labour, civilian, diplomacy, naval, military; new-world if present). Category colours are distinct and consistent (e.g. gathering = green, transport = blue, labour = amber, etc.; exact palette in theme or widget).
 
@@ -35,8 +35,8 @@ States are mutually exclusive; “in progress” takes precedence over “availa
 
 ## Description dialog
 
-- **Trigger:** Tap/click on a tech node opens a **dialog** (or bottom sheet on narrow viewports) with a brief description.
-- **Content (no prerequisite list):** Display name, era (I–IV), category label, RP cost, and **effect summary** (e.g. “Unlocks Halberdiers”, “Extraction cap +1 for Ore”, “Road level 2”, “Fourth research slot”). Prerequisites are **not** listed in the dialog; the tree layout and edges make them obvious.
+- **Trigger:** Tap/click on any tech node (including locked) opens a **dialog** (or bottom sheet on narrow viewports) with a brief description, so players can see benefits and effects for locked techs too.
+- **Content:** Display name, era (I–IV), category label, RP cost, **prerequisites** (list of prerequisite tech display names), and **effect summary** (e.g. “Unlocks Halberdiers”, “Extraction cap +1 for Ore”, “Road level 2”, “Fourth research slot”). Prerequisites are listed clearly in the dialog.
 - **Interaction:** Dialog is read-only. No “Assign to slot” from the dialog; assignment stays in the slots tab.
 
 ## Data
@@ -52,7 +52,7 @@ States are mutually exclusive; “in progress” takes precedence over “availa
 
 - **Given** the current player has some techs researched, **when** the tech tree is displayed, **then** each tech node shows the correct state: researched (filled/bright), in progress (e.g. progress indicator), available (all prereqs met, not unlocked), or locked (prereqs missing), with distinct visuals for each.
 
-- **Given** the tech tree is displayed, **when** the user taps or clicks a tech node, **then** a dialog (or bottom sheet on narrow) opens showing that tech’s display name, era, category, RP cost, and effect summary; the dialog does **not** list prerequisites.
+- **Given** the tech tree is displayed, **when** the user taps or clicks a tech node (including a locked one), **then** a dialog opens showing that tech’s display name, era, category, RP cost, prerequisites list (when any), and effect summary.
 
 - **Given** the tech tree is displayed, **when** the user views any node, **then** the node is color-coded by its category (gathering, transport, labour, civilian, diplomacy, naval, military, or new-world) with consistent colours across the tree.
 

--- a/app/lib/features/game/widgets/tech_tree_widget.dart
+++ b/app/lib/features/game/widgets/tech_tree_widget.dart
@@ -41,6 +41,8 @@ const double _nodeHeight = 44;
 const double _layerGap = 140;
 const double _rowGap = 52;
 const double _edgeStrokeWidth = 2;
+/// Offset from source right edge for the vertical segment so it stays in the inter-column gap (never through nodes).
+const double _edgeBendOffset = (_layerGap - _nodeWidth) / 2;
 
 /// Full-screen tech tree graph. Left-to-right layout, explicit edges, scrollable.
 /// SPEC/ui/tech-tree-widget.md.
@@ -124,6 +126,8 @@ class TechTreeWidget extends StatelessWidget {
   }
 
   /// Computes topological layout: each tech in a column strictly right of all its prerequisites.
+  /// For edges that span multiple columns, reserves a row slot in each intermediate column for the
+  /// connector (so the horizontal segment does not pass through nodes); other techs are shifted down.
   /// Used by the widget and by tests (column rule: A→B→C and A→C ⇒ B occupies column between A and C).
   static List<TechNodePosition> computeLayout(Map<String, TechDefinition> catalog) {
     if (catalog.isEmpty) return [];
@@ -160,17 +164,59 @@ class TechTreeWidget extends StatelessWidget {
       list.sort((a, b) => a.compareTo(b));
     }
 
+    // Place layers from right to left so we know target rows when reserving connector slots.
+    final positionsByLayer = <int, List<TechNodePosition>>{};
+    for (var layer = maxLayer; layer >= 0; layer--) {
+      final ids = byLayer[layer] ?? [];
+      final x = 24.0 + layer * _layerGap;
+      final list = <TechNodePosition>[];
+
+      if (layer == maxLayer) {
+        for (var i = 0; i < ids.length; i++) {
+          list.add(TechNodePosition(
+            techId: ids[i],
+            x: x,
+            y: 24 + i * _rowGap,
+            layer: layer,
+          ));
+        }
+      } else {
+        // Reserved row indices: rows that must be left free for connectors from left layers to right layers.
+        final reserved = <int>{};
+        for (var rightLayer = layer + 1; rightLayer <= maxLayer; rightLayer++) {
+          for (final pos in positionsByLayer[rightLayer]!) {
+            final tech = catalog[pos.techId];
+            if (tech == null) continue;
+            final hasPrereqLeft = tech.prerequisiteIds.any((pr) => (layerByTech[pr] ?? -1) < layer);
+            if (hasPrereqLeft) {
+              final rowIndex = ((pos.y - 24) / _rowGap).round();
+              reserved.add(rowIndex);
+            }
+          }
+        }
+        final totalRows = reserved.isEmpty
+            ? ids.length
+            : math.max(ids.length + reserved.length, reserved.reduce(math.max) + 1);
+        final nonReserved = List<int>.generate(totalRows, (i) => i)
+            .where((i) => !reserved.contains(i))
+            .toList()
+          ..sort();
+        for (var i = 0; i < ids.length; i++) {
+          final rowIndex = nonReserved[i];
+          list.add(TechNodePosition(
+            techId: ids[i],
+            x: x,
+            y: 24 + rowIndex * _rowGap,
+            layer: layer,
+          ));
+        }
+      }
+      positionsByLayer[layer] = list;
+    }
+
     final positions = <TechNodePosition>[];
     for (var layer = 0; layer <= maxLayer; layer++) {
-      final ids = byLayer[layer] ?? [];
-      for (var i = 0; i < ids.length; i++) {
-        positions.add(TechNodePosition(
-          techId: ids[i],
-          x: 24 + layer * _layerGap,
-          y: 24 + i * _rowGap,
-          layer: layer,
-        ));
-      }
+      positions.addAll(positionsByLayer[layer]!);
     }
     return positions;
   }
@@ -204,6 +250,19 @@ class TechTreeWidget extends StatelessWidget {
                     ),
                     const SizedBox(height: 4),
                     Text('${tech.cost} RP', style: theme.textTheme.bodyMedium),
+                    if (tech.prerequisiteIds.isNotEmpty) ...[
+                      const SizedBox(height: 8),
+                      Text('Prerequisites', style: theme.textTheme.labelLarge),
+                      ...tech.prerequisiteIds.map(
+                        (id) => Padding(
+                          padding: const EdgeInsets.only(top: 2),
+                          child: Text(
+                            '• ${techDisplayName(id)}',
+                            style: theme.textTheme.bodySmall,
+                          ),
+                        ),
+                      ),
+                    ],
                     if (effects.isNotEmpty) ...[
                       const SizedBox(height: 8),
                       Text('Effects', style: theme.textTheme.labelLarge),
@@ -375,9 +434,13 @@ class _TechTreeEdgePainter extends CustomPainter {
         final fromRightX = fromPos.x + _nodeWidth;
         final fromCenterY = fromPos.y + _centerY;
 
-        // Direct line from source right edge to target left edge (no vertical segments).
+        // Right-angled connector: horizontal into gap, vertical to target row, horizontal to target.
+        // Layout reserves a row slot in intermediate columns so this segment does not pass through nodes.
+        final bendX = fromRightX + _edgeBendOffset;
         final path = Path()
           ..moveTo(fromRightX, fromCenterY)
+          ..lineTo(bendX, fromCenterY)
+          ..lineTo(bendX, toCenterY)
           ..lineTo(toLeftX, toCenterY);
         canvas.drawPath(path, paint);
       }
@@ -428,7 +491,7 @@ class _TechNode extends StatelessWidget {
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap: locked ? null : onTap,
+        onTap: onTap,
         child: Container(
           width: _nodeWidth,
           height: _nodeHeight,

--- a/app/lib/widgets/ct_dialog_shell.dart
+++ b/app/lib/widgets/ct_dialog_shell.dart
@@ -33,6 +33,7 @@ class CtDialogShell extends StatelessWidget {
   /// Inner padding between nine-patch frame and [child].
   final EdgeInsetsGeometry padding;
 
+  /// Filename only; Flame.images uses prefix 'assets/images/' so full key is assets/images/ui_button_nine_patch.png.
   static const String _kAssetPath = 'ui_button_nine_patch.png';
   static const double _tileSize = 16;
 

--- a/app/lib/widgets/ct_nine_patch_button.dart
+++ b/app/lib/widgets/ct_nine_patch_button.dart
@@ -36,6 +36,7 @@ class CtNinePatchButton extends StatelessWidget {
   /// Minimum height; respects 44 dp touch target.
   final double minHeight;
 
+  /// Filename only; Flame.images uses prefix 'assets/images/' so full key is assets/images/ui_button_nine_patch.png.
   static const String _kAssetPath = 'ui_button_nine_patch.png';
   static const double _tileSize = 16;
 

--- a/app/lib/widgets/ct_panel.dart
+++ b/app/lib/widgets/ct_panel.dart
@@ -16,6 +16,7 @@ class CtPanel extends StatelessWidget {
   final EdgeInsetsGeometry padding;
   final double destTileSize;
 
+  /// Filename only; Flame.images uses prefix 'assets/images/' so full key is assets/images/ui_button_nine_patch.png.
   static const String _kAssetPath = 'ui_button_nine_patch.png';
   static const double _tileSize = 16;
 

--- a/app/macos/Podfile.lock
+++ b/app/macos/Podfile.lock
@@ -1,27 +1,20 @@
 PODS:
   - FlutterMacOS (1.0.0)
-  - path_provider_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
   - url_launcher_macos (0.0.1):
     - FlutterMacOS
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
 
 EXTERNAL SOURCES:
   FlutterMacOS:
     :path: Flutter/ephemeral
-  path_provider_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
   url_launcher_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
   url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009

--- a/app/test/ct_choice_chip_test.dart
+++ b/app/test/ct_choice_chip_test.dart
@@ -1,0 +1,62 @@
+// Tests for CtChoiceChip. lib/widgets/ct_choice_chip.dart.
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/widgets/ct_choice_chip.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  testWidgets('CtChoiceChip builds and shows label', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CtChoiceChip(
+            label: const Text('Option A'),
+            selected: false,
+            onSelected: (_) {},
+          ),
+        ),
+      ),
+    );
+    expect(find.text('Option A'), findsOneWidget);
+  });
+
+  testWidgets('CtChoiceChip tap calls onSelected with toggled value', (WidgetTester tester) async {
+    bool? lastValue;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CtChoiceChip(
+            label: const Text('Option'),
+            selected: false,
+            onSelected: (v) => lastValue = v,
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Option'));
+    await tester.pump();
+    expect(lastValue, isTrue);
+  });
+
+  testWidgets('CtChoiceChip when selected tap calls onSelected false', (WidgetTester tester) async {
+    bool? lastValue;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CtChoiceChip(
+            label: const Text('Option'),
+            selected: true,
+            onSelected: (v) => lastValue = v,
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Option'));
+    await tester.pump();
+    expect(lastValue, isFalse);
+  });
+}

--- a/app/test/tech_tree_widget_test.dart
+++ b/app/test/tech_tree_widget_test.dart
@@ -191,14 +191,13 @@ void main() {
       await tester.ensureVisible(find.text('Saw Mill').first);
       await tester.tap(find.text('Saw Mill').first);
       await tester.pumpAndSettle();
-      // SPEC: display name, era, category, RP cost, effect summary; no prerequisites.
+      // SPEC: display name, era, category, RP cost, prerequisites list (when any), effect summary.
       expect(find.byType(CtDialogShell), findsOneWidget);
       expect(find.text('Saw Mill'), findsWidgets);
       expect(find.textContaining('Era'), findsOneWidget);
       expect(find.textContaining('Gathering'), findsWidgets);
       expect(find.textContaining('RP'), findsOneWidget);
       expect(find.text('Effects'), findsOneWidget);
-      expect(find.textContaining('Prerequisite'), findsNothing);
     },
   );
 
@@ -274,9 +273,9 @@ void main() {
     expect(find.text('Locked'), findsOneWidget);
   });
 
-  testWidgets('Tapping locked tech node does not open dialog', (
-    WidgetTester tester,
-  ) async {
+  testWidgets(
+    'Tapping locked tech node opens dialog with benefits and effects',
+    (WidgetTester tester) async {
     final emptyPlayer = player.copyWith(techUnlocked: <String, bool>{});
     final gameWithEmptyPlayer = game.copyWith(
       players: [emptyPlayer, ...game.players.skip(1)],
@@ -295,7 +294,9 @@ void main() {
     await tester.ensureVisible(lockedTechFind.first);
     await tester.tap(lockedTechFind.first);
     await tester.pumpAndSettle();
-    expect(find.byType(CtDialogShell), findsNothing);
+    expect(find.byType(CtDialogShell), findsOneWidget);
+    expect(find.text('Prerequisites'), findsOneWidget);
+    expect(find.text('Effects'), findsOneWidget);
   });
 
   test(
@@ -344,6 +345,53 @@ void main() {
       );
     },
   );
+
+  test('Connector slot: edge A→C reserves row in middle layer so B is not on same row', () {
+    // SPEC: when an edge spans columns (A→C), the layout reserves that row in intermediate
+    // columns so the connector does not pass through other nodes (e.g. B).
+    const a = TechDefinition(
+      id: 'a',
+      era: 1,
+      category: 'gathering',
+      cost: 1,
+      prerequisiteIds: [],
+      regimentUnlockIds: [],
+      shipUnlockIds: [],
+    );
+    const b = TechDefinition(
+      id: 'b',
+      era: 1,
+      category: 'gathering',
+      cost: 1,
+      prerequisiteIds: ['a'],
+      regimentUnlockIds: [],
+      shipUnlockIds: [],
+    );
+    const c = TechDefinition(
+      id: 'c',
+      era: 1,
+      category: 'gathering',
+      cost: 1,
+      prerequisiteIds: ['a'],
+      regimentUnlockIds: [],
+      shipUnlockIds: [],
+    );
+    final catalog = <String, TechDefinition>{'a': a, 'b': b, 'c': c};
+    final positions = TechTreeWidget.computeLayout(catalog);
+    expect(positions.length, 3);
+    final posB = positions.firstWhere((p) => p.techId == 'b');
+    final posC = positions.firstWhere((p) => p.techId == 'c');
+    const rowGap = 52.0;
+    const baseY = 24.0;
+    final rowB = ((posB.y - baseY) / rowGap).round();
+    final rowC = ((posC.y - baseY) / rowGap).round();
+    expect(
+      rowB,
+      isNot(equals(rowC)),
+      reason:
+          'B must not share row with C so A→C connector has its own slot in middle column',
+    );
+  });
 }
 
 Player _dummyPlayer() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -476,10 +476,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- **Tech tree:** Right-angled connectors; layout reserves row slots for edges across columns so connectors do not pass through nodes (SPEC/ui/tech-tree-widget.md).
- **Tech details dialog:** Shows prerequisites list; opens for locked techs so benefits/effects are visible.
- **Nine-patch:** Use filename-only asset path for Flame Images prefix (ct_panel, ct_dialog_shell, ct_nine_patch_button).
- **Tests:** CtChoiceChip widget tests (build, tap, onSelected); TechTreeWidget connector-slot layout test; merge resolution with dev (CtScreenShell, back button tests).

## Widget test coverage
- Added `app/test/ct_choice_chip_test.dart` for CtChoiceChip (was 0% in lib/widgets/).
- Added connector-slot layout unit test in tech_tree_widget_test.dart.
- App widget coverage remains at or above 80% (check_coverage_threshold.sh).

Made with [Cursor](https://cursor.com)