### PR TITLE
refactor(logic): three dedups — war check, shortCircuit, toFullProvinceId

### DIFF
--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
@@ -159,6 +159,22 @@ bool factionsAtWar(Game game, String a, String b) {
   return rel?.atWar ?? false;
 }
 
+/// True if [playerId] may attack [targetOwnerId]: at war or declaring war this turn.
+/// Used by move validator for GP and Minor/Tribe attack checks. SPEC/program/orders.md.
+bool canAttackWithWarOrDeclaring(
+  Game game,
+  String playerId,
+  String targetOwnerId,
+  List<DiplomaticOrder> diplomaticOrders,
+) {
+  final rel = getRelation(game, playerId, targetOwnerId);
+  final atWar = rel?.atWar ?? false;
+  final declaringWarThisTurn = diplomaticOrders.any((o) =>
+      o.type == DiplomaticOrderType.declareWar &&
+      o.targetFactionId == targetOwnerId);
+  return atWar || declaringWarThisTurn;
+}
+
 /// Returns player by id, or null.
 Player? getPlayer(Game game, String playerId) {
   for (final p in game.players) {

--- a/packages/colonizethis_logic/lib/src/orders/validators/build_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/build_order_validator.dart
@@ -31,43 +31,44 @@ class BuildOrderValidator {
     BuildUnitOrder o, {
     required bool previousRejected,
   }) {
-    if (previousRejected) {
-      return previousInvalidOrderResult;
-    }
+    return shortCircuitIfPreviousRejected(
+      previousRejected: previousRejected,
+      body: () {
+        if (_player.capitalProvinceId == null) {
+          return const OrderValidationResult(
+            status: OrderValidationStatus.rejected,
+            reason: 'No capital to spawn unit',
+          );
+        }
 
-    if (_player.capitalProvinceId == null) {
-      return const OrderValidationResult(
-        status: OrderValidationStatus.rejected,
-        reason: 'No capital to spawn unit',
-      );
-    }
+        final check = canAffordBuild(
+          _player,
+          o,
+          _workers,
+          _stockpile,
+          _treasury,
+        );
+        if (!check.canAfford) {
+          return OrderValidationResult(
+            status: OrderValidationStatus.rejected,
+            reason: check.reason ?? 'Insufficient resources',
+          );
+        }
 
-    final check = canAffordBuild(
-      _player,
-      o,
-      _workers,
-      _stockpile,
-      _treasury,
-    );
-    if (!check.canAfford) {
-      return OrderValidationResult(
-        status: OrderValidationStatus.rejected,
-        reason: check.reason ?? 'Insufficient resources',
-      );
-    }
-
-    final after = applyBuildCostDeduction(
-      _player,
-      o,
-      _workers,
-      _stockpile,
-      _treasury,
-    );
-    _workers = after.workers;
-    _stockpile = after.stockpile;
-    _treasury = after.treasury;
-    return const OrderValidationResult(
-      status: OrderValidationStatus.accepted,
+        final after = applyBuildCostDeduction(
+          _player,
+          o,
+          _workers,
+          _stockpile,
+          _treasury,
+        );
+        _workers = after.workers;
+        _stockpile = after.stockpile;
+        _treasury = after.treasury;
+        return const OrderValidationResult(
+          status: OrderValidationStatus.accepted,
+        );
+      },
     );
   }
 }

--- a/packages/colonizethis_logic/lib/src/orders/validators/move_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/move_validator.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../../diplomacy/diplomacy_relation_lookup.dart';
 import '../../diplomacy/diplomacy_resolver.dart';
 import '../../world/movement.dart';
 import '../../world/player_view.dart';
@@ -74,37 +75,25 @@ class MoveValidator {
     // Attack validation: GP province requires war or same-turn declareWar.
     if (destOwnerId != null &&
         destOwnerId != playerId &&
-        isGreatPower(game, destOwnerId)) {
-      final rel = getRelation(game, playerId, destOwnerId);
-      final atWar = rel?.atWar ?? false;
-      final declaringWarThisTurn = diplomaticOrders.any((o) =>
-          o.type == DiplomaticOrderType.declareWar &&
-          o.targetFactionId == destOwnerId);
-      if (!atWar && !declaringWarThisTurn) {
-        return const OrderValidationResult(
-          status: OrderValidationStatus.rejected,
-          reason: 'Must declare war before attacking Great Power province',
-        );
-      }
+        isGreatPower(game, destOwnerId) &&
+        !canAttackWithWarOrDeclaring(game, playerId, destOwnerId, diplomaticOrders)) {
+      return const OrderValidationResult(
+        status: OrderValidationStatus.rejected,
+        reason: 'Must declare war before attacking Great Power province',
+      );
     }
 
     // Attack validation: Minor/Tribe province requires war for military units.
     if (destOwnerId != null &&
         destOwnerId != playerId &&
         isMinorOrTribe(game, destOwnerId) &&
-        isMilitaryUnit(unit.type)) {
-      final rel = getRelation(game, playerId, destOwnerId);
-      final atWar = rel?.atWar ?? false;
-      final declaringWarThisTurn = diplomaticOrders.any((o) =>
-          o.type == DiplomaticOrderType.declareWar &&
-          o.targetFactionId == destOwnerId);
-      if (!atWar && !declaringWarThisTurn) {
-        return const OrderValidationResult(
-          status: OrderValidationStatus.rejected,
-          reason:
-              'Must declare war before attacking Minor Nation or Tribe province',
-        );
-      }
+        isMilitaryUnit(unit.type) &&
+        !canAttackWithWarOrDeclaring(game, playerId, destOwnerId, diplomaticOrders)) {
+      return const OrderValidationResult(
+        status: OrderValidationStatus.rejected,
+        reason:
+            'Must declare war before attacking Minor Nation or Tribe province',
+      );
     }
 
     if (!moveSourceVisibilityOk(view, unitRegion, unit.locationProvinceId) ||

--- a/packages/colonizethis_logic/lib/src/world/player_view.dart
+++ b/packages/colonizethis_logic/lib/src/world/player_view.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import 'province_lookup.dart';
 import 'unit_lookup.dart';
 
 /// Visibility level for a tile from a single player's perspective.
@@ -52,10 +53,10 @@ class PlayerView {
 
   /// Lookup province by region and id. [provinceId] may be full (regionId|localId) or local; [regionId] is used when [provinceId] is local.
   Province? provinceByRegionAndId(String regionId, String provinceId) =>
-      provincesById[ProvinceId.isPrefixed(provinceId) ? provinceId : ProvinceId.full(regionId, provinceId)];
+      provincesById[toFullProvinceId(regionId, provinceId)];
 
   Iterable<Unit> unitsInProvince(String regionId, String provinceId) {
-    final fullId = ProvinceId.isPrefixed(provinceId) ? provinceId : ProvinceId.full(regionId, provinceId);
+    final fullId = toFullProvinceId(regionId, provinceId);
     return ownUnits.where((u) => u.provinceId == fullId);
   }
 
@@ -84,12 +85,10 @@ PlayerView buildPlayerView(
   // Provinces: key by full id (p.id is regionId|localId).
   final provincesById = <String, Province>{};
   for (final p in game.worldState.oldWorld.provinces) {
-    final key = ProvinceId.isPrefixed(p.id) ? p.id : ProvinceId.full(p.regionId, p.id);
-    provincesById[key] = p;
+    provincesById[toFullProvinceId(p.regionId, p.id)] = p;
   }
   for (final p in game.worldState.newWorld.provinces) {
-    final key = ProvinceId.isPrefixed(p.id) ? p.id : ProvinceId.full(p.regionId, p.id);
-    provincesById[key] = p;
+    provincesById[toFullProvinceId(p.regionId, p.id)] = p;
   }
 
   // Units owned by this player across both regions.

--- a/packages/colonizethis_logic/lib/src/world/province_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/world/province_lookup.dart
@@ -18,6 +18,12 @@ String resolveToFullProvinceId(WorldState world, String provinceId) {
       'Province id must be prefixed (regionId|localId); short id not allowed: $provinceId');
 }
 
+/// Returns [provinceId] if already prefixed, otherwise [ProvinceId.full](regionId, provinceId).
+/// Use when keying or looking up by an id that may be local or full (e.g. player view).
+String toFullProvinceId(String regionId, String provinceId) {
+  return ProvinceId.isPrefixed(provinceId) ? provinceId : ProvinceId.full(regionId, provinceId);
+}
+
 /// Region-scoped lookup: returns the province in [regionId] with local id [localId]. Looks only in that region.
 /// Throws [StateError] if the region is unknown or the province is not found.
 Province getProvinceByRegion(WorldState world, String regionId, String localId) {


### PR DESCRIPTION
## Summary
Three incremental dedup/refactors in `colonizethis_logic`, tests passing after each stage.

### 1. MoveValidator — war/declare check
- **Added** `canAttackWithWarOrDeclaring()` in `diplomacy_relation_lookup.dart` (at war or same-turn declareWar).
- **Updated** `move_validator.dart` to use it for both Great Power and Minor/Tribe attack validation, removing duplicated relation/order checks.

### 2. BuildOrderValidator — shortCircuit helper
- **Updated** `build_order_validator.dart` to use `shortCircuitIfPreviousRejected` instead of manual `if (previousRejected) return previousInvalidOrderResult`.
- Aligns with `NavalOrderValidator` and `WorkOrderValidator`.

### 3. PlayerView — full province id normalization
- **Added** `toFullProvinceId(regionId, provinceId)` in `province_lookup.dart` (prefixed as-is, else `ProvinceId.full`).
- **Updated** `player_view.dart` to use it in `provinceByRegionAndId`, `unitsInProvince`, and `buildPlayerView` (4 call sites).

## Testing
`dart test` in `packages/colonizethis_logic` run after each stage; all pass.

Made with [Cursor](https://cursor.com)