### PR TITLE
refactor(map,ai): dedup and extract helpers in map and AI packages

### DIFF
--- a/packages/colonizethis_logic/lib/src/ai/ai_planner.dart
+++ b/packages/colonizethis_logic/lib/src/ai/ai_planner.dart
@@ -29,6 +29,15 @@ Orders generateOrdersForPlayer(Game game, MapTopology topology, String playerId)
   );
 }
 
+/// Merges a per-player order list into an aggregate map when non-null and non-empty.
+void _addOrdersIfNonEmpty<T>(
+  Map<String, List<T>> aggregate,
+  String playerId,
+  List<T>? list,
+) {
+  if (list != null && list.isNotEmpty) aggregate[playerId] = list;
+}
+
 /// Generates orders for all AI-controlled GPs. Deterministic given game state and seeds.
 /// Respects diplomacy: no attacks against factions at peace.
 Orders generateOrdersForGame(Game game, MapTopology topology) {
@@ -40,23 +49,10 @@ Orders generateOrdersForGame(Game game, MapTopology topology) {
   for (final player in game.players) {
     if (!isAiControlled(game, player.id)) continue;
     final ordersForPlayer = generateOrdersForPlayer(game, topology, player.id);
-    final moves = ordersForPlayer.moveOrdersByPlayerId[player.id];
-    final builds = ordersForPlayer.buildUnitOrdersByPlayerId[player.id];
-    final works = ordersForPlayer.workOrdersByPlayerId[player.id];
-    final research = ordersForPlayer.researchOrdersByPlayerId[player.id];
-
-    if (moves != null && moves.isNotEmpty) {
-      moveByPlayer[player.id] = moves;
-    }
-    if (builds != null && builds.isNotEmpty) {
-      buildByPlayer[player.id] = builds;
-    }
-    if (works != null && works.isNotEmpty) {
-      workByPlayer[player.id] = works;
-    }
-    if (research != null && research.isNotEmpty) {
-      researchByPlayer[player.id] = research;
-    }
+    _addOrdersIfNonEmpty(moveByPlayer, player.id, ordersForPlayer.moveOrdersByPlayerId[player.id]);
+    _addOrdersIfNonEmpty(buildByPlayer, player.id, ordersForPlayer.buildUnitOrdersByPlayerId[player.id]);
+    _addOrdersIfNonEmpty(workByPlayer, player.id, ordersForPlayer.workOrdersByPlayerId[player.id]);
+    _addOrdersIfNonEmpty(researchByPlayer, player.id, ordersForPlayer.researchOrdersByPlayerId[player.id]);
   }
 
   return Orders(
@@ -152,16 +148,13 @@ FullAIResult generateOrdersForGameFullAI(
       onMood: onMood,
     );
     economyPlansByPlayerId[player.id] = result.economyPlan;
-    void add<T>(Map<String, List<T>> map, String pid, List<T>? list) {
-      if (list != null && list.isNotEmpty) map[pid] = list;
-    }
-    add(moveByPlayer, player.id, result.orders.moveOrdersByPlayerId[player.id]);
-    add(buildByPlayer, player.id, result.orders.buildUnitOrdersByPlayerId[player.id]);
-    add(workByPlayer, player.id, result.orders.workOrdersByPlayerId[player.id]);
-    add(researchByPlayer, player.id, result.orders.researchOrdersByPlayerId[player.id]);
-    add(diploByPlayer, player.id, result.orders.diplomaticOrdersByPlayerId[player.id]);
-    add(navalByPlayer, player.id, result.orders.navalMoveOrdersByPlayerId[player.id]);
-    add(missionByPlayer, player.id, result.orders.navalMissionOrdersByPlayerId[player.id]);
+    _addOrdersIfNonEmpty(moveByPlayer, player.id, result.orders.moveOrdersByPlayerId[player.id]);
+    _addOrdersIfNonEmpty(buildByPlayer, player.id, result.orders.buildUnitOrdersByPlayerId[player.id]);
+    _addOrdersIfNonEmpty(workByPlayer, player.id, result.orders.workOrdersByPlayerId[player.id]);
+    _addOrdersIfNonEmpty(researchByPlayer, player.id, result.orders.researchOrdersByPlayerId[player.id]);
+    _addOrdersIfNonEmpty(diploByPlayer, player.id, result.orders.diplomaticOrdersByPlayerId[player.id]);
+    _addOrdersIfNonEmpty(navalByPlayer, player.id, result.orders.navalMoveOrdersByPlayerId[player.id]);
+    _addOrdersIfNonEmpty(missionByPlayer, player.id, result.orders.navalMissionOrdersByPlayerId[player.id]);
   }
 
   return FullAIResult(

--- a/packages/colonizethis_map/lib/src/tile_map_visualization.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_visualization.dart
@@ -6,7 +6,12 @@ import 'dart:typed_data';
 import 'package:image/image.dart' as img;
 import 'package:colonizethis_data/colonizethis_data.dart';
 
-import 'tile_map_visualization_shared.dart';
+import 'tile_map_visualization_shared.dart'
+    show colorMapFromIds, continentSeedMarkerRgb, drawBorders,
+        drawLegendContinentSeedMarker, drawLegendLandSeedMarker,
+        drawLegendSwatch, landSeedMarkerRgb, legendLineHeight, legendPadding,
+        regionPalette, resourceToLegendLabel, resourceToLegendLetter,
+        seaColorRgb, seaZoneBorderRgb, swatchGap, swatchSize, terrainColorRgb;
 
 /// Deep blue for sea zones. SPEC/program/map-visualization.md § Tile map PNG export.
 const (int, int, int) seaColorRgb = (20, 60, 140);
@@ -18,6 +23,87 @@ const (int, int, int) seaZoneBorderRgb = (173, 216, 230);
 const (int, int, int) regionIdLabelRgb = (220, 0, 0);
 
 const int _titleLines = 2;
+
+/// Draws optional legend sections (continent seeds, land seeds, resources). Returns updated row.
+int _drawOptionalLegendSections(
+  img.Image image,
+  int legendY0,
+  int row, {
+  required bool showContinentSeeds,
+  required bool showLandSeeds,
+  required bool useLandSeedByContinent,
+  List<int>? landSeedContinentIndices,
+  required bool hasResourceGrid,
+}) {
+  final black = image.getColor(0, 0, 0);
+  if (showContinentSeeds) {
+    final y = legendY0 + row * legendLineHeight;
+    drawLegendContinentSeedMarker(image, y);
+    img.drawString(
+      image,
+      'Continent seeds (one per continent)',
+      font: img.arial14,
+      x: legendPadding + swatchSize + swatchGap,
+      y: y,
+      color: black,
+    );
+    row++;
+  }
+  if (showLandSeeds) {
+    if (useLandSeedByContinent && landSeedContinentIndices != null) {
+      final maxContinent = landSeedContinentIndices.reduce((a, b) => a > b ? a : b);
+      for (var c = 0; c <= maxContinent; c++) {
+        final y = legendY0 + row * legendLineHeight;
+        final (r, g, b) = regionPalette[c % regionPalette.length];
+        drawLegendSwatch(image, y, r, g, b);
+        img.drawString(
+          image,
+          'Continent $c',
+          font: img.arial14,
+          x: legendPadding + swatchSize + swatchGap,
+          y: y,
+          color: black,
+        );
+        row++;
+      }
+    } else {
+      final y = legendY0 + row * legendLineHeight;
+      drawLegendLandSeedMarker(image, y);
+      img.drawString(
+        image,
+        'Land seeds (cluster per continent)',
+        font: img.arial14,
+        x: legendPadding + swatchSize + swatchGap,
+        y: y,
+        color: black,
+      );
+      row++;
+    }
+  }
+  if (hasResourceGrid) {
+    for (final r in Resource.values) {
+      final y = legendY0 + row * legendLineHeight;
+      img.drawString(
+        image,
+        resourceToLegendLetter(r),
+        font: img.arial14,
+        x: legendPadding,
+        y: y,
+        color: black,
+      );
+      img.drawString(
+        image,
+        '  ${resourceToLegendLabel(r)}',
+        font: img.arial14,
+        x: legendPadding + swatchSize + swatchGap,
+        y: y,
+        color: black,
+      );
+      row++;
+    }
+  }
+  return row;
+}
 
 Iterable<String> _regionIdsFromResult(TileMapResult result) sync* {
   for (var y = 0; y < result.height; y++) {
@@ -175,7 +261,7 @@ Uint8List renderTileMapToPng(
       for (var x = 0; x < result.width; x++) {
         final r = result.resourceAt(x, y);
         if (r == null) continue;
-        final letter = _resourceLetter(r);
+        final letter = resourceToLegendLetter(r);
         final cx = x * cellSize + cellSize ~/ 2;
         final cy = y * cellSize + cellSize ~/ 2;
         final px = cx - letterOffsetX;
@@ -208,44 +294,23 @@ Uint8List renderTileMapToPng(
     drawLegendSwatch(image, legendY0 + row * legendLineHeight, seaColorRgb.$1, seaColorRgb.$2, seaColorRgb.$3);
     img.drawString(image, 'Sea', font: img.arial14, x: legendPadding + swatchSize + swatchGap, y: legendY0 + row * legendLineHeight, color: black);
     row++;
-    for (final t in TerrainType.values) {
+      for (final t in TerrainType.values) {
       final (r, g, b) = terrainColorRgb[t]!;
       drawLegendSwatch(image, legendY0 + row * legendLineHeight, r, g, b);
       final label = _terrainLabel(t);
       img.drawString(image, label, font: img.arial14, x: legendPadding + swatchSize + swatchGap, y: legendY0 + row * legendLineHeight, color: black);
       row++;
     }
-    if (showContinentSeeds) {
-      final y = legendY0 + row * legendLineHeight;
-      drawLegendContinentSeedMarker(image, y);
-      img.drawString(image, 'Continent seeds (one per continent)', font: img.arial14, x: legendPadding + swatchSize + swatchGap, y: y, color: black);
-      row++;
-    }
-    if (showLandSeeds) {
-      if (useLandSeedByContinent) {
-        final maxContinent = landSeedContinentIndices.reduce((a, b) => a > b ? a : b);
-        for (var c = 0; c <= maxContinent; c++) {
-          final y = legendY0 + row * legendLineHeight;
-          final (r, g, b) = regionPalette[c % regionPalette.length];
-          drawLegendSwatch(image, y, r, g, b);
-          img.drawString(image, 'Continent $c', font: img.arial14, x: legendPadding + swatchSize + swatchGap, y: y, color: black);
-          row++;
-        }
-      } else {
-        final y = legendY0 + row * legendLineHeight;
-        drawLegendLandSeedMarker(image, y);
-        img.drawString(image, 'Land seeds (cluster per continent)', font: img.arial14, x: legendPadding + swatchSize + swatchGap, y: y, color: black);
-        row++;
-      }
-    }
-    if (result.resourceGrid != null) {
-      for (final r in Resource.values) {
-        final y = legendY0 + row * legendLineHeight;
-        img.drawString(image, _resourceLetter(r), font: img.arial14, x: legendPadding, y: y, color: black);
-        img.drawString(image, '  ${_resourceLabel(r)}', font: img.arial14, x: legendPadding + swatchSize + swatchGap, y: y, color: black);
-        row++;
-      }
-    }
+    row = _drawOptionalLegendSections(
+      image,
+      legendY0,
+      row,
+      showContinentSeeds: showContinentSeeds,
+      showLandSeeds: showLandSeeds,
+      useLandSeedByContinent: useLandSeedByContinent,
+      landSeedContinentIndices: landSeedContinentIndices,
+      hasResourceGrid: result.resourceGrid != null,
+    );
   } else {
     img.drawString(
       image,
@@ -275,37 +340,16 @@ Uint8List renderTileMapToPng(
       img.drawString(image, label, font: img.arial14, x: legendPadding + swatchSize + swatchGap, y: y, color: black);
       row++;
     }
-    if (showContinentSeeds) {
-      final y = legendY0 + row * legendLineHeight;
-      drawLegendContinentSeedMarker(image, y);
-      img.drawString(image, 'Continent seeds (one per continent)', font: img.arial14, x: legendPadding + swatchSize + swatchGap, y: y, color: black);
-      row++;
-    }
-    if (showLandSeeds) {
-      if (useLandSeedByContinent) {
-        final maxContinent = landSeedContinentIndices.reduce((a, b) => a > b ? a : b);
-        for (var c = 0; c <= maxContinent; c++) {
-          final y = legendY0 + row * legendLineHeight;
-          final (r, g, b) = regionPalette[c % regionPalette.length];
-          drawLegendSwatch(image, y, r, g, b);
-          img.drawString(image, 'Continent $c', font: img.arial14, x: legendPadding + swatchSize + swatchGap, y: y, color: black);
-          row++;
-        }
-      } else {
-        final y = legendY0 + row * legendLineHeight;
-        drawLegendLandSeedMarker(image, y);
-        img.drawString(image, 'Land seeds (cluster per continent)', font: img.arial14, x: legendPadding + swatchSize + swatchGap, y: y, color: black);
-        row++;
-      }
-    }
-    if (result.resourceGrid != null) {
-      for (final r in Resource.values) {
-        final y = legendY0 + row * legendLineHeight;
-        img.drawString(image, _resourceLetter(r), font: img.arial14, x: legendPadding, y: y, color: black);
-        img.drawString(image, '  ${_resourceLabel(r)}', font: img.arial14, x: legendPadding + swatchSize + swatchGap, y: y, color: black);
-        row++;
-      }
-    }
+    row = _drawOptionalLegendSections(
+      image,
+      legendY0,
+      row,
+      showContinentSeeds: showContinentSeeds,
+      showLandSeeds: showLandSeeds,
+      useLandSeedByContinent: useLandSeedByContinent,
+      landSeedContinentIndices: landSeedContinentIndices,
+      hasResourceGrid: result.resourceGrid != null,
+    );
   }
 
   return img.encodePng(image);
@@ -325,88 +369,6 @@ String _terrainLabel(TerrainType t) {
       return 'Swamp';
     case TerrainType.desert:
       return 'Desert';
-  }
-}
-
-String _resourceLetter(Resource r) {
-  switch (r) {
-    case Resource.grain:
-      return 'g';
-    case Resource.meat:
-      return 'm';
-    case Resource.wool:
-      return 'w';
-    case Resource.horses:
-      return 'h';
-    case Resource.timber:
-      return 't';
-    case Resource.iron:
-      return 'i';
-    case Resource.copper:
-      return 'c';
-    case Resource.tin:
-      return 'n';
-    case Resource.coal:
-      return 'k';
-    case Resource.sugarCane:
-      return 's';
-    case Resource.tobacco:
-      return 'b';
-    case Resource.cotton:
-      return 'u';
-    case Resource.furs:
-      return 'f';
-    case Resource.spices:
-      return 'p';
-    case Resource.silver:
-      return 'v';
-    case Resource.gold:
-      return 'a';
-    case Resource.gems:
-      return 'e';
-    case Resource.diamonds:
-      return 'd';
-  }
-}
-
-String _resourceLabel(Resource r) {
-  switch (r) {
-    case Resource.grain:
-      return 'Grain';
-    case Resource.meat:
-      return 'Meat';
-    case Resource.wool:
-      return 'Wool';
-    case Resource.horses:
-      return 'Horses';
-    case Resource.timber:
-      return 'Timber';
-    case Resource.iron:
-      return 'Iron';
-    case Resource.copper:
-      return 'Copper';
-    case Resource.tin:
-      return 'Tin';
-    case Resource.coal:
-      return 'Coal';
-    case Resource.sugarCane:
-      return 'Sugar Cane';
-    case Resource.tobacco:
-      return 'Tobacco';
-    case Resource.cotton:
-      return 'Cotton';
-    case Resource.furs:
-      return 'Furs';
-    case Resource.spices:
-      return 'Spices';
-    case Resource.silver:
-      return 'Silver';
-    case Resource.gold:
-      return 'Gold';
-    case Resource.gems:
-      return 'Gems';
-    case Resource.diamonds:
-      return 'Diamonds';
   }
 }
 

--- a/packages/colonizethis_map/lib/src/tile_map_visualization_shared.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_visualization_shared.dart
@@ -41,49 +41,99 @@ const Map<TerrainType, (int r, int g, int b)> terrainColorRgb = {
   TerrainType.desert: (210, 190, 140),
 };
 
+/// Single-letter legend glyph for a resource (e.g. grain → 'g').
+/// Matches SPEC/program/map-visualization.md legend; see SPEC/game/resource-terrain-region-rules.md.
+String resourceToLegendLetter(Resource r) {
+  switch (r) {
+    case Resource.grain:
+      return 'g';
+    case Resource.meat:
+      return 'm';
+    case Resource.wool:
+      return 'w';
+    case Resource.horses:
+      return 'h';
+    case Resource.timber:
+      return 't';
+    case Resource.iron:
+      return 'i';
+    case Resource.copper:
+      return 'c';
+    case Resource.tin:
+      return 'n';
+    case Resource.coal:
+      return 'k';
+    case Resource.sugarCane:
+      return 's';
+    case Resource.tobacco:
+      return 'b';
+    case Resource.cotton:
+      return 'u';
+    case Resource.furs:
+      return 'f';
+    case Resource.spices:
+      return 'p';
+    case Resource.silver:
+      return 'v';
+    case Resource.gold:
+      return 'a';
+    case Resource.gems:
+      return 'e';
+    case Resource.diamonds:
+      return 'd';
+  }
+}
+
+/// Display label for a resource in the legend (e.g. grain → 'Grain').
+String resourceToLegendLabel(Resource r) {
+  switch (r) {
+    case Resource.grain:
+      return 'Grain';
+    case Resource.meat:
+      return 'Meat';
+    case Resource.wool:
+      return 'Wool';
+    case Resource.horses:
+      return 'Horses';
+    case Resource.timber:
+      return 'Timber';
+    case Resource.iron:
+      return 'Iron';
+    case Resource.copper:
+      return 'Copper';
+    case Resource.tin:
+      return 'Tin';
+    case Resource.coal:
+      return 'Coal';
+    case Resource.sugarCane:
+      return 'Sugar Cane';
+    case Resource.tobacco:
+      return 'Tobacco';
+    case Resource.cotton:
+      return 'Cotton';
+    case Resource.furs:
+      return 'Furs';
+    case Resource.spices:
+      return 'Spices';
+    case Resource.silver:
+      return 'Silver';
+    case Resource.gold:
+      return 'Gold';
+    case Resource.gems:
+      return 'Gems';
+    case Resource.diamonds:
+      return 'Diamonds';
+  }
+}
+
 /// Returns the single-letter legend glyph for a resource id (e.g. grain → 'g'), or null if unknown.
 /// Matches SPEC/program/map-visualization.md legend; see SPEC/game/resource-terrain-region-rules.md.
 String? resourceIdToLegendLetter(String? resourceId) {
   if (resourceId == null || resourceId.isEmpty) return null;
-  switch (resourceId) {
-    case 'grain':
-      return 'g';
-    case 'meat':
-      return 'm';
-    case 'wool':
-      return 'w';
-    case 'horses':
-      return 'h';
-    case 'timber':
-      return 't';
-    case 'iron':
-      return 'i';
-    case 'copper':
-      return 'c';
-    case 'tin':
-      return 'n';
-    case 'coal':
-      return 'k';
-    case 'sugarCane':
-      return 's';
-    case 'tobacco':
-      return 'b';
-    case 'cotton':
-      return 'u';
-    case 'furs':
-      return 'f';
-    case 'spices':
-      return 'p';
-    case 'silver':
-      return 'v';
-    case 'gold':
-      return 'a';
-    case 'gems':
-      return 'e';
-    case 'diamonds':
-      return 'd';
-    default:
-      return null;
+  try {
+    return resourceToLegendLetter(Resource.values.byName(resourceId));
+  } catch (_) {
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary
Deduplication and refactoring in `colonizethis_map` and `colonizethis_logic` (AI) packages. All existing tests pass.

## Map (colonizethis_map)
- **Resource legend single source of truth:** `resourceToLegendLetter(Resource)` and `resourceToLegendLabel(Resource)` in `tile_map_visualization_shared.dart`; `resourceIdToLegendLetter(String?)` delegates to them. Removed duplicate `_resourceLetter` / `_resourceLabel` from `tile_map_visualization.dart`.
- **Legend optional sections:** Extracted `_drawOptionalLegendSections` to remove duplicated legend drawing (continent seeds, land seeds, resources) between terrain and region legend branches.

## AI (colonizethis_logic)
- **Order aggregation helper:** `_addOrdersIfNonEmpty<T>` in `ai_planner.dart` merges per-player order lists into aggregate maps; used in both `generateOrdersForGame` and `generateOrdersForGameFullAI`.

## Testing
- `dart test packages/colonizethis_map/test/` — all map tests pass
- `dart test packages/colonizethis_logic/test/ai_planner_test.dart` and related AI tests — pass

Made with [Cursor](https://cursor.com)