### PR TITLE
refactor(logic): dedup work_order _reject, regionDataForId, movement toFullProvinceId

### DIFF
--- a/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
+++ b/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
@@ -4,6 +4,7 @@ import 'package:logger/logger.dart';
 
 import '../constants.dart';
 import '../world/connectivity_resolver.dart';
+import '../world/province_lookup.dart';
 
 final Logger _log = Logger();
 
@@ -73,11 +74,7 @@ Map<String, ExtractionTotals> computeExtraction({
       }
       // Province lookup must be region-scoped. SPEC/game/world-model-identity.md.
       final provinceId = '$regionId|${parts[1]}';
-      final regionData = regionId == kRegionOldWorld
-          ? game.worldState.oldWorld
-          : regionId == kRegionNewWorld
-              ? game.worldState.newWorld
-              : null;
+      final regionData = regionDataForId(game.worldState, regionId);
       final province = regionData?.provinces.where((p) => p.id == provinceId).firstOrNull;
       final townDevelopmentCap = province?.townDevelopmentLevel ?? 4;
 

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
@@ -55,6 +55,11 @@ class WorkOrderValidator {
       target == 'build_fort' ||
       target == 'purchase_land';
 
+  OrderValidationResult _reject(String reason) => OrderValidationResult(
+        status: OrderValidationStatus.rejected,
+        reason: reason,
+      );
+
   /// Validates one [WorkOrder]. When accepted, deducts cost from internal
   /// stockpile/treasury and may add to [devExclusiveTiles]. Caller should sync
   /// stockpile/treasury back after the work loop.
@@ -67,29 +72,17 @@ class WorkOrderValidator {
       body: () {
         final unit = _unitsById[o.unitId];
         if (unit == null || unit.ownerId != _playerId) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Unit not found',
-          );
+          return _reject('Unit not found');
         }
         if (unit.currentWork != null) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Unit already has a work order; cancel first',
-          );
+          return _reject('Unit already has a work order; cancel first');
         }
         final type = unit.type;
         if (!isWorkOrderTargetAllowedForUnitType(type, o.target)) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Invalid work target for unit type',
-          );
+          return _reject('Invalid work target for unit type');
         }
         if (o.targetTileKey.isEmpty) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Work order requires a target tile',
-          );
+          return _reject('Work order requires a target tile');
         }
 
         final targetProvinceId = Unit.provinceIdFromTileKey(o.targetTileKey);
@@ -100,53 +93,37 @@ class WorkOrderValidator {
 
         if (o.target == 'steal_tech') {
           if (targetProvinceId == null) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'Invalid target for steal_tech',
-            );
+            return _reject('Invalid target for steal_tech');
           }
           final otherPlayer = _game.players
               .where((p) =>
                   p.id != _playerId && p.capitalProvinceId == targetProvinceId)
               .firstOrNull;
           if (otherPlayer == null) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason:
-                  'steal_tech target must be another Great Power capital province',
-            );
+            return _reject(
+                'steal_tech target must be another Great Power capital province');
           }
           final ourTech = _player.techUnlocked ?? {};
           final theirTech = otherPlayer.techUnlocked ?? {};
           final hasTechWeLack = theirTech.entries
               .any((e) => e.value == true && ourTech[e.key] != true);
           if (!hasTechWeLack) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'Target has no technology you lack',
-            );
+            return _reject('Target has no technology you lack');
           }
         } else if (o.target == 'counter_spy') {
           if (ownerId != _playerId) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'counter_spy target must be your own province',
-            );
+            return _reject('counter_spy target must be your own province');
           }
         } else if (o.target == 'purchase_land') {
           if (ownerId == null || ownerId == _playerId) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'purchase_land target must be a Minor or Tribe province',
-            );
+            return _reject(
+                'purchase_land target must be a Minor or Tribe province');
           }
           final isMinor = _game.minorNations.any((m) => m.id == ownerId);
           final isTribe = _game.tribes.any((t) => t.id == ownerId);
           if (!isMinor && !isTribe) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'purchase_land target must be a Minor or Tribe province',
-            );
+            return _reject(
+                'purchase_land target must be a Minor or Tribe province');
           }
           final rel = _game.diplomacyRelations
               .where((r) =>
@@ -154,107 +131,73 @@ class WorkOrderValidator {
                   (r.factionId2 == _playerId && r.factionId1 == ownerId))
               .firstOrNull;
           if (rel != null && rel.atWar) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'Cannot purchase land: at war with that faction',
-            );
+            return _reject('Cannot purchase land: at war with that faction');
           }
           final overture = _game.overtureStates
               .where((ov) => ov.gpId == _playerId && ov.targetId == ownerId)
               .firstOrNull;
           if (overture == null || !overture.hasEmbassy) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason:
-                  'Cannot purchase land: embassy required with that Minor/Tribe',
-            );
+            return _reject(
+                'Cannot purchase land: embassy required with that Minor/Tribe');
           }
           final resourceId = _game.worldState.resourceByTileKey[o.targetTileKey];
           if (resourceId == null || resourceId.isEmpty) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'Tile has no resource',
-            );
+            return _reject('Tile has no resource');
           }
           if (kMineralResourceIds.contains(resourceId)) {
             final prospected =
                 _game.worldState.playerProspectedTiles[_playerId] ?? const <String>{};
             if (!prospected.contains(o.targetTileKey)) {
-              return const OrderValidationResult(
-                status: OrderValidationStatus.rejected,
-                reason: 'Mineral tile must be prospected first',
-              );
+              return _reject('Mineral tile must be prospected first');
             }
           }
           final cost = purchaseLandCost(resourceId);
           if (_treasury < cost) {
-            return OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'Insufficient treasury for purchase_land (need $cost)',
-            );
+            return _reject(
+                'Insufficient treasury for purchase_land (need $cost)');
           }
           final existingBuyer =
               _game.worldState.purchasedTilesByTileKey[o.targetTileKey];
           if (existingBuyer != null) {
-            return OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: existingBuyer == _playerId
-                  ? 'You already own this tile'
-                  : 'Tile already purchased by another power',
-            );
+            return _reject(existingBuyer == _playerId
+                ? 'You already own this tile'
+                : 'Tile already purchased by another power');
           }
         } else if (o.target == 'build_improvement') {
           final controlled =
               isTileControlledByPlayer(_game, _playerId, o.targetTileKey);
           if (!controlled) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'Cannot build improvement in foreign or uncontrolled province',
-            );
+            return _reject(
+                'Cannot build improvement in foreign or uncontrolled province');
           }
           final resourceId = _game.worldState.resourceByTileKey[o.targetTileKey];
           if (resourceId == null || resourceId.isEmpty) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason:
-                  'Tile has no resource; build_improvement requires a resource on the tile',
-            );
+            return _reject(
+                'Tile has no resource; build_improvement requires a resource on the tile');
           }
           final currentLevel =
               _game.worldState.tileState.improvementLevel(o.targetTileKey);
           if (currentLevel >= 4) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'Improvement level already at maximum (4)',
-            );
+            return _reject('Improvement level already at maximum (4)');
           }
           final techCap = extractionCapForUnlocked(_player.techUnlocked);
           if (currentLevel + 1 > techCap) {
-            return OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason:
-                  'Insufficient tech to build next improvement level (cap $techCap)',
-            );
+            return _reject(
+                'Insufficient tech to build next improvement level (cap $techCap)');
           }
         } else if (!isExplorerUnit(type)) {
           final controlled =
               isTileControlledByPlayer(_game, _playerId, o.targetTileKey);
           if (!controlled) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'Cannot work in foreign province',
-            );
+            return _reject('Cannot work in foreign province');
           }
         }
 
         if (isDevExclusiveUnitType(type) &&
             _isDevExclusiveTarget(o.target) &&
             _devExclusiveTiles.contains(o.targetTileKey)) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason:
-                'Tile already has development or purchase work for this player',
-          );
+          return _reject(
+              'Tile already has development or purchase work for this player');
         }
 
         if (o.target != 'steal_tech' &&
@@ -269,26 +212,19 @@ class WorkOrderValidator {
             final hasRoadConstruction =
                 _player.techUnlocked?['road_construction'] == true;
             if (!hasRoadConstruction) {
-              return const OrderValidationResult(
-                status: OrderValidationStatus.rejected,
-                reason: 'Road Construction tech required for transport level 2',
-              );
+              return _reject(
+                  'Road Construction tech required for transport level 2');
             }
           }
           if (o.target == 'build_fort') {
             if (fortLevel == 1 &&
                 _player.techUnlocked?['mine_engineering'] != true) {
-              return const OrderValidationResult(
-                status: OrderValidationStatus.rejected,
-                reason: 'Mine Engineering tech required for fort level 2',
-              );
+              return _reject(
+                  'Mine Engineering tech required for fort level 2');
             }
             if (fortLevel == 2 &&
                 _player.techUnlocked?['modern_forts'] != true) {
-              return const OrderValidationResult(
-                status: OrderValidationStatus.rejected,
-                reason: 'Modern Forts tech required for fort level 3',
-              );
+              return _reject('Modern Forts tech required for fort level 3');
             }
           }
           final costMap = WorkOrderCostCalculator(_game).calculateCost(
@@ -301,20 +237,14 @@ class WorkOrderValidator {
           if (costMap != null) {
             for (final entry in costMap.entries) {
               if (_stockpile.quantityOf(entry.key) < entry.value) {
-                return const OrderValidationResult(
-                  status: OrderValidationStatus.rejected,
-                  reason: 'Insufficient materials for work order',
-                );
+                return _reject('Insufficient materials for work order');
               }
             }
           }
         }
 
         if (!workOrderVisibilityOk(_view, unit, o.target, o.targetTileKey)) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Province or tile not visible for this work',
-          );
+          return _reject('Province or tile not visible for this work');
         }
 
         if (isDevExclusiveUnitType(type) && _isDevExclusiveTarget(o.target)) {

--- a/packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
+++ b/packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
@@ -20,9 +20,8 @@ Game applyCapitalReassignmentAfterCombat(
     if (capProvinceId == null || player.capitalTile == null) continue;
     final regionId = ProvinceId.regionIdFrom(capProvinceId);
     final regionTopology = topologyByRegion?[regionId] ?? topology;
-    final region = regionId == kRegionOldWorld
-        ? state.worldState.oldWorld
-        : state.worldState.newWorld;
+    final region = regionDataForId(state.worldState, regionId);
+    if (region == null) continue;
     final province =
         region.provinces.where((p) => p.id == capProvinceId).firstOrNull;
     if (province == null) continue;

--- a/packages/colonizethis_logic/lib/src/world/movement.dart
+++ b/packages/colonizethis_logic/lib/src/world/movement.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'province_lookup.dart';
 import 'topology_helpers.dart';
 import 'unit_lookup.dart';
 
@@ -109,7 +110,7 @@ RegionData applyMoveOrdersToRegion(
       }
       // Normalize to prefixed form when regionId known (SPEC/game/world-model-identity.md).
       final destFullId = regionId != null && !ProvinceId.isPrefixed(destProvinceId)
-          ? ProvinceId.full(regionId, destProvinceId)
+          ? toFullProvinceId(regionId, destProvinceId)
           : destProvinceId;
       // Topology uses local province ids; validate using region-scoped adjacency when region known.
       // Movement within own provinces: no adjacency required. SPEC/program/movement.md.

--- a/packages/colonizethis_logic/lib/src/world/province_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/world/province_lookup.dart
@@ -20,6 +20,11 @@ Province? _findProvinceInRegion(
   return region.provinces[idx];
 }
 
+/// Returns the region data for [regionId], or null if unknown.
+/// Use when callers need [RegionData] (e.g. to iterate provinces) without full province lookup.
+RegionData? regionDataForId(WorldState world, String regionId) =>
+    _regionForId(world, regionId);
+
 /// Central province lookup. Lookup is by **full disambiguated id** (`regionId|localId`)
 /// and is **region-scoped**: resolution happens only within the given region.
 /// SPEC/game/world-model-identity.md.


### PR DESCRIPTION
Three incremental dedup/refactors in `colonizethis_logic`; tests pass after each stage. Branch based on latest `origin/dev`.

1. **work_order_validator**
   - Added private `_reject(String reason)` returning `OrderValidationResult(rejected, reason)`.
   - Replaced 25+ repetitive `return const OrderValidationResult(status: rejected, reason: ...)` with `return _reject('...')`.

2. **province_lookup + resource_extractor + capital_and_gp_fall**
   - Added public `regionDataForId(WorldState world, String regionId)` returning `RegionData?` (delegates to existing `_regionForId`).
   - **resource_extractor:** Replaced inline `regionId == kRegionOldWorld ? game.worldState.oldWorld : regionId == kRegionNewWorld ? game.worldState.newWorld : null` with `regionDataForId(game.worldState, regionId)`.
   - **capital_and_gp_fall:** Replaced `regionId == kRegionOldWorld ? state.worldState.oldWorld : state.worldState.newWorld` with `regionDataForId(state.worldState, regionId)` and added null check before using `region`.

3. **movement.dart**
   - Replaced `regionId != null && !ProvinceId.isPrefixed(destProvinceId) ? ProvinceId.full(regionId, destProvinceId) : destProvinceId` with `toFullProvinceId(regionId, destProvinceId)` when normalizing destination province id (import `province_lookup`).

Made with [Cursor](https://cursor.com)