### PR TITLE
feat(ai,logic): full AI decision and eval debug logging

### DIFF
--- a/SPEC/program/ctdev-logging.md
+++ b/SPEC/program/ctdev-logging.md
@@ -20,6 +20,7 @@
 - **Levels:** Standard levels: debug, info, warn, error.
   - **File:** Logs at **debug** and above (default).
   - **In-memory Sim Log (UI):** Logs at **info** and above; shows the **last 10 lines** only; **cleared at the start of every turn** (when resolving a turn or stepping a full turn).
+  - **AI:** **Info** for major decisions (e.g. selected goal, chosen order type, economy plan summary); **debug** for full evals (candidate lists, scores, weights, snapshot, dossier).
 - **Exception capture:** All log calls use `error` and `stackTrace` parameters where applicable. Uncaught errors are handled in `runZonedGuarded` and logged with stack trace. The file format appends error and stack trace when present (e.g. on following lines).
   - **CLI tools:** Init-game, map generation, and sim tools use the same logger configuration for **operational and diagnostic** output (`logic:`, `map:`, etc.). They may still write **usage, help text, and human-readable reports** to `stdout`/`print` as part of their CLI contract; these are exempt from the “no print for logging” rule.
 
@@ -27,8 +28,8 @@
 
 ## Logger naming
 
-- Convention: message prefix or logger name for **ctdev**, **logic**, **ai**, **data**, **map**, **save**. No models logger.
-- Enables grep-friendly logs (e.g. `logic: phase extraction start`).
+- **Prefix:** By package / subpackage-or-file (class): e.g. `ai/strategic_ai`, `ai/goal_manager`, `ai/domain_planners`, `ai/economy_planner`, `ai/perception`, `ai/dossier`, `logic/order_suggestion`. Enables grep-friendly logs (e.g. `ai/goal_manager: selected primaryGoal=conquer`).
+- Packages: **ctdev**, **logic**, **ai**, **data**, **map**, **save**. No models logger.
 
 ---
 
@@ -36,7 +37,7 @@
 
 - **ctdev:** App lifecycle, init game submit, start sim (session id), turn steps, exceptions in turn handlers.
 - **logic:** Turn resolution (phases), order engine (validation, rejections), order suggestion API (all suggestion functions and results), movement, combat, naval, extraction, production, consumption, research, diplomacy, init game orchestration, game setup.
-- **ai:** Order generation, planner, goals/candidates.
+- **ai:** Order generation, planner, goals/candidates. Info = major decisions; debug = full evals (goal weights, candidate scores, perception snapshot, dossier, economy recipe scores).
 - **data:** Catalog/config lookups; fallbacks and defaults.
 - **map:** Map generation (tile map, topology), init game map view build, load savegame view build.
 - **save:** Save/load calls (path, gameId, success); errors on failure.

--- a/packages/colonizethis_ai/lib/src/domain_planners.dart
+++ b/packages/colonizethis_ai/lib/src/domain_planners.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:logger/logger.dart';
 
 import 'ai_config.dart';
 import 'economy_planner.dart';
@@ -12,6 +13,8 @@ import 'perception.dart';
 import 'seed_bundle.dart';
 
 // Domain planners (utility AI). SPEC/ai/ai-architecture.md, ai-systems-impl.md, economy-planner.md.
+
+const String _kDomainLogPrefix = 'ai/domain_planners';
 
 /// Runs economy, military, diplomacy, and research planners; returns combined orders
 /// for [nationId]. Uses [suggestionAPI] and [economyPlan] (cargo preference) to score
@@ -36,6 +39,11 @@ Orders runDomainPlanners({
   final buildCandidates = suggestionAPI.suggestBuildOrders(view, game, topology, orders);
   final hasSpyWork = workCandidates.any((o) => o.target == 'steal_tech' || o.target == 'counter_spy');
   final workThreshold = 40 - (hasSpyWork ? agendaSpyOrderModifier(config.hiddenAgendaId) : 0);
+  Logger().d(
+    '$_kDomainLogPrefix: work eval nationId=$nationId workThreshold=$workThreshold '
+    'domainWeights.economy=${domainWeights.economy} primaryGoal=$primaryGoal '
+    'workCandidates=${workCandidates.map((o) => "${o.unitId}:${o.target}").toList()}',
+  );
   if (workCandidates.isNotEmpty &&
       (primaryGoal == StrategicGoal.expand || domainWeights.economy >= workThreshold)) {
     final agendaId = config.hiddenAgendaId;
@@ -45,9 +53,17 @@ Orders runDomainPlanners({
     final list = pickFrom.isNotEmpty ? pickFrom : workCandidates;
     final rng = math.Random(seeds.economySeed);
     final idx = rng.nextInt(list.length);
-    orders = _appendWorkOrders(orders, nationId, [list[idx]]);
+    final chosen = list[idx];
+    Logger().i('$_kDomainLogPrefix: work chosen nationId=$nationId unitId=${chosen.unitId} target=${chosen.target}');
+    orders = _appendWorkOrders(orders, nationId, [chosen]);
+  } else if (workCandidates.isNotEmpty) {
+    Logger().d('$_kDomainLogPrefix: work skipped nationId=$nationId weight below threshold');
   }
   final buildThreshold = 30 - agendaBuildOrderModifier(config.hiddenAgendaId);
+  Logger().d(
+    '$_kDomainLogPrefix: build eval nationId=$nationId buildThreshold=$buildThreshold '
+    'buildCandidates=${buildCandidates.map((o) => o.unitType).toList()}',
+  );
   if (buildCandidates.isNotEmpty && domainWeights.economy >= buildThreshold) {
     final chosen = _pickBuildOrder(
       buildCandidates: buildCandidates,
@@ -55,10 +71,14 @@ Orders runDomainPlanners({
       primaryGoal: primaryGoal,
       config: config,
       seed: seeds.economySeed + 1,
+      nationId: nationId,
     );
     if (chosen != null) {
+      Logger().i('$_kDomainLogPrefix: build chosen nationId=$nationId unitType=${chosen.unitType}');
       orders = _appendBuildOrders(orders, nationId, [chosen]);
     }
+  } else if (buildCandidates.isNotEmpty) {
+    Logger().d('$_kDomainLogPrefix: build skipped nationId=$nationId weight below threshold');
   }
 
   // Movement: suggest moves; weight by military/expand.
@@ -120,6 +140,10 @@ Orders runDomainPlanners({
                   : thresholds.researchExploration;
       return math.max(1, w);
     }).toList();
+    Logger().d(
+      '$_kDomainLogPrefix: research eval nationId=$nationId researchThreshold=$researchThreshold '
+      'candidates=${researchCandidates.map((o) => o.techId).toList()} scores=$scores',
+    );
     final total = scores.reduce((a, b) => a + b);
     final rng = math.Random(seeds.researchSeed);
     var r = rng.nextInt(total);
@@ -128,7 +152,11 @@ Orders runDomainPlanners({
       r -= scores[idx];
     }
     if (idx >= researchCandidates.length) idx = researchCandidates.length - 1;
-    orders = _appendResearchOrders(orders, nationId, [researchCandidates[idx]]);
+    final chosen = researchCandidates[idx];
+    Logger().i('$_kDomainLogPrefix: research chosen nationId=$nationId techId=${chosen.techId} score=${scores[idx]}');
+    orders = _appendResearchOrders(orders, nationId, [chosen]);
+  } else if (researchCandidates.isNotEmpty) {
+    Logger().d('$_kDomainLogPrefix: research skipped nationId=$nationId threshold not met or no candidates');
   }
 
   return orders;
@@ -156,7 +184,15 @@ Orders _runMovePlanner({
       : primaryGoal == StrategicGoal.expand
           ? domainWeights.economy
           : 50;
-  if (weight < 20) return orders;
+  Logger().d(
+    '$_kDomainLogPrefix: move eval nationId=$nationId weight=$weight '
+    'filteredCount=${filtered.length} '
+    'candidates=${filtered.map((m) => "${m.unitId}->${m.destinationProvinceId}").toList()}',
+  );
+  if (weight < 20) {
+    Logger().d('$_kDomainLogPrefix: move skipped nationId=$nationId weight < 20');
+    return orders;
+  }
   final provinceOwner = getProvinceOwnerMap(game);
   final scores = filtered.map((m) {
     final destOwner = provinceOwner[m.destinationProvinceId];
@@ -165,6 +201,7 @@ Orders _runMovePlanner({
     final atWar = rel != null && rel.atWar;
     return 1.0 + (atWar ? kMovePreferEnemyTerritoryBonus.toDouble() : 0);
   }).toList();
+  Logger().d('$_kDomainLogPrefix: move scores nationId=$nationId scores=$scores');
   final total = scores.reduce((a, b) => a + b);
   if (total <= 0) return orders;
   final rng = math.Random(seeds.militarySeed);
@@ -175,6 +212,10 @@ Orders _runMovePlanner({
   }
   if (idx >= filtered.length) idx = filtered.length - 1;
   final selected = [filtered[idx]];
+  Logger().i(
+    '$_kDomainLogPrefix: move chosen nationId=$nationId '
+    'unitId=${selected.first.unitId} destinationProvinceId=${selected.first.destinationProvinceId}',
+  );
   return _appendMoveOrders(orders, nationId, selected);
 }
 
@@ -200,6 +241,7 @@ BuildUnitOrder? _pickBuildOrder({
   required StrategicGoal primaryGoal,
   required AIConfig config,
   required int seed,
+  required String nationId,
 }) {
   if (buildCandidates.isEmpty) return null;
   final thresholds = getThresholdsForLeader(config.leaderId);
@@ -241,6 +283,12 @@ BuildUnitOrder? _pickBuildOrder({
 
     return 1.0 + cargoBonus + militaryBonus + personalityBonus;
   }).toList();
+
+  Logger().d(
+    '$_kDomainLogPrefix: build scores nationId=$nationId '
+    'candidates=${buildCandidates.map((o) => o.unitType).toList()} '
+    'scores=$scores',
+  );
 
   final total = scores.reduce((a, b) => a + b);
   if (total <= 0) return buildCandidates.first;
@@ -284,26 +332,46 @@ Orders _runNavalPlanner({
       primaryGoal == StrategicGoal.expand
       ? domainWeights.military
       : 40;
-  if (weight < 25) return orders;
+  if (weight < 25) {
+    Logger().d('$_kDomainLogPrefix: naval skipped nationId=$nationId weight=$weight < 25');
+    return orders;
+  }
 
   var o = orders;
 
   final navalMoveCandidates = suggestionAPI.suggestNavalMoveOrders(view, game, topology, o);
+  Logger().d(
+    '$_kDomainLogPrefix: naval move eval nationId=$nationId '
+    'candidatesCount=${navalMoveCandidates.length}',
+  );
   if (navalMoveCandidates.isNotEmpty) {
     final rng = math.Random(seeds.militarySeed + 1000);
     final cap = (navalMoveCandidates.length.clamp(0, 3));
     final take = cap > 0 ? 1 + rng.nextInt(cap) : 0;
     if (take > 0) {
       final selected = navalMoveCandidates.take(take).toList();
+      Logger().i(
+        '$_kDomainLogPrefix: naval move chosen nationId=$nationId '
+        'take=$take selected=${selected.map((m) => "fleetId=${m.fleetId} destSea=${m.destinationSeaZoneId} destPort=${m.destinationPortProvinceId}").toList()}',
+      );
       o = _appendNavalMoveOrders(o, nationId, selected);
     }
   }
 
   final navalMissionCandidates = suggestionAPI.suggestNavalMissionOrders(view, game, topology, o);
+  Logger().d(
+    '$_kDomainLogPrefix: naval mission eval nationId=$nationId '
+    'candidatesCount=${navalMissionCandidates.length}',
+  );
   if (navalMissionCandidates.isNotEmpty) {
     final rng = math.Random(seeds.militarySeed + 1001);
     final idx = rng.nextInt(navalMissionCandidates.length);
-    o = _appendNavalMissionOrders(o, nationId, [navalMissionCandidates[idx]]);
+    final chosen = navalMissionCandidates[idx];
+    Logger().i(
+      '$_kDomainLogPrefix: naval mission chosen nationId=$nationId '
+      'mission=${chosen.mission} fleetId=${chosen.fleetId}',
+    );
+    o = _appendNavalMissionOrders(o, nationId, [chosen]);
   }
 
   return o;
@@ -341,7 +409,10 @@ Orders _runDiplomacyPlanner({
       primaryGoal == StrategicGoal.trade
       ? domainWeights.diplomacy
       : 40;
-  if (weight < 25) return orders;
+  if (weight < 25) {
+    Logger().d('$_kDomainLogPrefix: diplomacy skipped nationId=$nationId weight=$weight < 25');
+    return orders;
+  }
 
   final diploCandidates = suggestionAPI.suggestDiplomaticOrders(view, game, topology, orders);
   if (diploCandidates.isEmpty) return orders;
@@ -383,6 +454,15 @@ Orders _runDiplomacyPlanner({
     }
     return s == 0 ? 0 : math.max(1, s);
   }).toList();
+
+  final candidateDesc = diploCandidates
+      .map((o) => '${o.type.name}${o.type == DiplomaticOrderType.declareWar ? ":${o.targetFactionId}" : ""}')
+      .toList();
+  Logger().d(
+    '$_kDomainLogPrefix: diplomacy eval nationId=$nationId hiddenAgendaId=$agendaId '
+    'candidates=$candidateDesc scores=$scores',
+  );
+
   final total = scores.reduce((a, b) => a + b);
   if (total <= 0) return orders;
   final rng = math.Random(seeds.diplomacySeed);
@@ -392,7 +472,12 @@ Orders _runDiplomacyPlanner({
     r -= scores[idx];
   }
   if (idx >= diploCandidates.length) idx = diploCandidates.length - 1;
-  return _appendDiplomaticOrders(orders, nationId, [diploCandidates[idx]]);
+  final chosen = diploCandidates[idx];
+  Logger().i(
+    '$_kDomainLogPrefix: diplomacy chosen nationId=$nationId '
+    'type=${chosen.type}${chosen.type == DiplomaticOrderType.declareWar ? " targetFactionId=${chosen.targetFactionId}" : ""} score=${scores[idx]}',
+  );
+  return _appendDiplomaticOrders(orders, nationId, [chosen]);
 }
 
 Orders _appendDiplomaticOrders(Orders o, String playerId, List<DiplomaticOrder> list) {

--- a/packages/colonizethis_ai/lib/src/dossier.dart
+++ b/packages/colonizethis_ai/lib/src/dossier.dart
@@ -3,6 +3,9 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
+
+const String _kDossierLogPrefix = 'ai/dossier';
 
 /// Suspicion band for display. Never exposes true agenda.
 /// Bands defined by [dossierScoreUnknownMax], [dossierScorePossibleMax], etc. SPEC/ai/ai-dossier.md.
@@ -208,13 +211,25 @@ DossierView getDossierForSubject(
   final timeline = cappedEntries
       .map((e) => 'Turn ${e.turnNumber}: ${e.description}')
       .toList();
+  final basicIntel = _buildBasicIntel(game, observerId, subjectId);
+  final bestGuess = _buildBestGuessAgenda(scoreByAgenda);
+  final behavioralNotes = _buildBehavioralNotes(cappedEntries);
+
+  Logger().d(
+    '$_kDossierLogPrefix: getDossierForSubject observerId=$observerId subjectId=$subjectId '
+    'scoreByAgenda=$scoreByAgenda suspicionByAgendaType=${suspicionByAgendaType.map((k, v) => MapEntry(k, v.name))} '
+    'bestGuessAgenda=${bestGuess?.agendaType} confidencePercent=${bestGuess?.confidencePercent} '
+    'evidenceCount=${evidenceList.length} behavioralNotes=$behavioralNotes '
+    'basicIntel.relationLevel=${basicIntel?.relationLevel} personalityArchetype=${basicIntel?.personalityArchetype}',
+  );
+
   return DossierView(
     subjectId: subjectId,
     suspicionByAgendaType: suspicionByAgendaType,
     evidenceList: evidenceList,
-    basicIntel: _buildBasicIntel(game, observerId, subjectId),
-    bestGuessAgenda: _buildBestGuessAgenda(scoreByAgenda),
-    behavioralNotes: _buildBehavioralNotes(cappedEntries),
+    basicIntel: basicIntel,
+    bestGuessAgenda: bestGuess,
+    behavioralNotes: behavioralNotes,
     timeline: timeline,
   );
 }

--- a/packages/colonizethis_ai/lib/src/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/economy_planner.dart
@@ -10,6 +10,8 @@ import 'seed_bundle.dart';
 
 final Logger _log = Logger();
 
+const String _kEconomyLogPrefix = 'ai/economy_planner';
+
 /// Cargo preference for naval/build planners. SPEC/ai/economy-planner.md.
 enum CargoPreference {
   none,
@@ -54,7 +56,7 @@ EconomyPlan runEconomyPlanner({
 }) {
   final player = game.playerById(view.playerId);
   if (player == null) {
-    _log.w('ai: economy planner no player for ${view.playerId}');
+    _log.w('$_kEconomyLogPrefix: no player for ${view.playerId}');
     return const EconomyPlan(
       productionAssignments: [],
       cargoPreference: CargoPreference.none,
@@ -83,9 +85,14 @@ EconomyPlan runEconomyPlanner({
     seeds: seeds,
   );
 
+  final cargoPref = _cargoPreference(game, view.playerId, config);
+  _log.i(
+    '$_kEconomyLogPrefix: economy plan playerId=${view.playerId} '
+    'cargoPreference=$cargoPref productionAssignmentsCount=${assignments.length}',
+  );
   return EconomyPlan(
     productionAssignments: assignments,
-    cargoPreference: _cargoPreference(game, view.playerId, config),
+    cargoPreference: cargoPref,
   );
 }
 
@@ -94,16 +101,26 @@ CargoPreference _cargoPreference(Game game, String playerId, AIConfig config) {
   final agendaId = config.hiddenAgendaId;
   // Trade-oriented agendas/personalities favour cargo.
   final economyWeight = domainWeights.economy;
-  if (economyWeight < 30) return CargoPreference.none;
+  if (economyWeight < 30) {
+    _log.d('$_kEconomyLogPrefix: cargoPreference none economyWeight=$economyWeight');
+    return CargoPreference.none;
+  }
   // Strong when economy is high and agenda is trade-related.
   final tradeBias = agendaId == 'industrial_trader' || agendaId == 'merchant'
       ? 20
       : agendaId == 'navigator'
           ? 15
           : 0;
-  if (economyWeight >= 70 + tradeBias) return CargoPreference.strongCargo;
-  if (economyWeight >= 50 + tradeBias) return CargoPreference.preferCargo;
-  return CargoPreference.none;
+  final pref = economyWeight >= 70 + tradeBias
+      ? CargoPreference.strongCargo
+      : economyWeight >= 50 + tradeBias
+          ? CargoPreference.preferCargo
+          : CargoPreference.none;
+  _log.d(
+    '$_kEconomyLogPrefix: cargoPreference eval playerId=$playerId '
+    'economyWeight=$economyWeight agendaId=$agendaId tradeBias=$tradeBias result=$pref',
+  );
+  return pref;
 }
 
 List<AssignedRecipe> _allocateLabour({
@@ -149,6 +166,11 @@ List<AssignedRecipe> _allocateLabour({
 
   if (candidates.isEmpty) return result;
 
+  _log.d(
+    '$_kEconomyLogPrefix: recipe eval playerId=${config.leaderId} effectiveLabour=$effectiveLabour '
+    'candidates=${candidates.map((c) => "${c.recipe.id}:${c.score.toStringAsFixed(2)}").toList()}',
+  );
+
   // Sort by score descending; use seed for tie-break.
   candidates.sort((a, b) {
     final c = b.score.compareTo(a.score);
@@ -191,7 +213,8 @@ List<AssignedRecipe> _allocateLabour({
   }
 
   _log.d(
-    'ai: economy planner effectiveLabour=$effectiveLabour assignments=${result.length}',
+    '$_kEconomyLogPrefix: allocation effectiveLabour=$effectiveLabour '
+    'labourByRecipe=$labourByRecipe assignmentsCount=${result.length}',
   );
   return result;
 }

--- a/packages/colonizethis_ai/lib/src/goal_manager.dart
+++ b/packages/colonizethis_ai/lib/src/goal_manager.dart
@@ -1,12 +1,15 @@
 import 'dart:math' as math;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:logger/logger.dart';
 
 import 'ai_config.dart';
 import 'hidden_agenda.dart';
 import 'perception.dart';
 
 // Goal selection (behavior tree). SPEC/ai/ai-architecture.md, ai-personalities.md.
+
+const String _kGoalLogPrefix = 'ai/goal_manager';
 
 /// Top-level strategy goals for the AI.
 enum StrategicGoal {
@@ -64,13 +67,23 @@ StrategicGoal selectPrimaryGoal(
     StrategicGoal.diplomacy: diplomacy,
   };
 
+  Logger().d(
+    '$_kGoalLogPrefix: eval leaderId=${config.leaderId} hiddenAgendaId=${config.hiddenAgendaId} goalSeed=$goalSeed '
+    'weights defend=$defend expand=$expand conquer=$conquer trade=$trade tech=$tech diplomacy=$diplomacy',
+  );
+
   // Weighted random choice using goalSeed.
   final total = candidates.values.fold<int>(0, (a, b) => a + b);
   if (total <= 0) return StrategicGoal.expand;
   var r = math.Random(goalSeed).nextInt(total);
+  StrategicGoal selected = StrategicGoal.expand;
   for (final e in candidates.entries) {
     r -= e.value;
-    if (r < 0) return e.key;
+    if (r < 0) {
+      selected = e.key;
+      break;
+    }
   }
-  return StrategicGoal.expand;
+  Logger().i('$_kGoalLogPrefix: selected primaryGoal=$selected');
+  return selected;
 }

--- a/packages/colonizethis_ai/lib/src/perception.dart
+++ b/packages/colonizethis_ai/lib/src/perception.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:logger/logger.dart';
 
 // Perception: PlayerView → AIWorldSnapshot. SPEC/ai/ai-architecture.md.
 // All data derived from PlayerView only; no hidden state.
@@ -70,13 +71,27 @@ class AIWorldSnapshot {
     final threats = _buildThreatSummary(view, topology);
     final opportunities = _buildOpportunitySummary(view, topology);
     final economy = _buildEconomySummary(view);
-    return AIWorldSnapshot(
+    final snapshot = AIWorldSnapshot(
       playerId: view.playerId,
       threats: threats,
       opportunities: opportunities,
       economy: economy,
       relations: Map<String, DiplomacyRelation>.from(view.diplomacyByOtherId),
     );
+    Logger().d(
+      'ai/perception: snapshot playerId=${snapshot.playerId} '
+      'atWarWith=${snapshot.threats.atWarWith} '
+      'neighborProvincesHostile=${snapshot.threats.neighborProvincesHostile} '
+      'capitalThreatened=${snapshot.threats.capitalThreatened} '
+      'weakNeighbors=${snapshot.opportunities.weakNeighbors} '
+      'richUnexploitedProvinces=${snapshot.opportunities.richUnexploitedProvinces} '
+      'unclaimedProvinces=${snapshot.opportunities.unclaimedProvinces} '
+      'workerCount=${snapshot.economy.workerCount} '
+      'treasury=${snapshot.economy.treasury} '
+      'ownProvinceCount=${snapshot.economy.ownProvinceCount} '
+      'relationsKeys=${snapshot.relations.keys.toList()}',
+    );
+    return snapshot;
   }
 
   static ThreatSummary _buildThreatSummary(PlayerView view, MapTopology? topology) {

--- a/packages/colonizethis_ai/lib/src/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/strategic_ai.dart
@@ -37,10 +37,10 @@ StrategicOrderResult generateStrategicOrders({
   void Function(PortraitMoodEvent)? onMood,
 }) {
   final turn = game.worldState.turnState.turnNumber;
-  Logger().i('ai: generateStrategicOrders nationId=$nationId turn=$turn');
+  Logger().i('ai/strategic_ai: generateStrategicOrders nationId=$nationId turn=$turn');
   final snapshot = AIWorldSnapshot.fromPlayerView(view, topology: topology);
   final primaryGoal = selectPrimaryGoal(snapshot, config, seeds.goalSeed);
-  Logger().d('ai: primaryGoal=$primaryGoal');
+  Logger().d('ai/strategic_ai: primaryGoal=$primaryGoal');
   final economyPlan = runEconomyPlanner(
     game: game,
     view: view,
@@ -63,7 +63,7 @@ StrategicOrderResult generateStrategicOrders({
   final buildCount = orders.buildUnitOrdersByPlayerId[nationId]?.length ?? 0;
   final workCount = orders.workOrdersByPlayerId[nationId]?.length ?? 0;
   final researchCount = orders.researchOrdersByPlayerId[nationId]?.length ?? 0;
-  Logger().i('ai: generated orders nationId=$nationId move=$moveCount build=$buildCount work=$workCount research=$researchCount');
+  Logger().i('ai/strategic_ai: generated orders nationId=$nationId move=$moveCount build=$buildCount work=$workCount research=$researchCount');
   _emitDialogueAndMood(
     config: config,
     seeds: seeds,

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -16,6 +16,8 @@ export 'order_suggestion_helpers.dart';
 
 final Logger _log = Logger();
 
+const String _kOrderSuggestionLogPrefix = 'logic/order_suggestion';
+
 /// Suggests candidate move orders that are information-legal (per [PlayerView])
 /// and rules-legal (per [OrderEngine]) for [view.playerId].
 List<MoveOrder> suggestMoveOrders(
@@ -24,7 +26,7 @@ List<MoveOrder> suggestMoveOrders(
   MapTopology topology,
   Orders currentOrders,
 ) {
-  _log.d('logic: suggestMoveOrders player=${view.playerId}');
+  _log.d('$_kOrderSuggestionLogPrefix: suggestMoveOrders player=${view.playerId}');
   final playerId = view.playerId;
   final suggestions = <MoveOrder>[];
 
@@ -119,9 +121,11 @@ List<MoveOrder> suggestMoveOrders(
   });
 
   _log.d(
-      'logic: suggestMoveOrders player=$playerId candidates=${suggestions.length}');
+      '$_kOrderSuggestionLogPrefix: suggestMoveOrders player=$playerId candidates=${suggestions.length}');
+  _log.d(
+      '$_kOrderSuggestionLogPrefix: suggestMoveOrders full list ${suggestions.map((m) => "${m.unitId}->${m.destinationProvinceId}").toList()}');
   if (suggestions.isEmpty)
-    _log.w('logic: suggestMoveOrders no candidates player=$playerId');
+    _log.w('$_kOrderSuggestionLogPrefix: suggestMoveOrders no candidates player=$playerId');
   return suggestions;
 }
 
@@ -135,7 +139,7 @@ List<WorkOrder> suggestWorkOrders(
   MapTopology topology,
   Orders currentOrders,
 ) {
-  _log.d('logic: suggestWorkOrders player=${view.playerId}');
+  _log.d('$_kOrderSuggestionLogPrefix: suggestWorkOrders player=${view.playerId}');
   final playerId = view.playerId;
   final suggestions = <WorkOrder>[];
 
@@ -167,7 +171,7 @@ List<WorkOrder> suggestWorkOrders(
     final tilesInProvince = tileKeysByRegion[regionId]?[provinceId] ?? const [];
 
     _log.d(
-        'logic: suggestWorkOrders unit=${unit.id} provinceId=$provinceId provinceName=${province?.displayName} ownerId=$ownerId regionId=$regionId tilesInProvince=${tilesInProvince.length}');
+        '$_kOrderSuggestionLogPrefix: suggestWorkOrders unit=${unit.id} provinceId=$provinceId provinceName=${province?.displayName} ownerId=$ownerId regionId=$regionId tilesInProvince=${tilesInProvince.length}');
 
     // Explorers: explore/prospect in their current province only; visibility rules apply.
     if (isExplorer) {
@@ -257,10 +261,10 @@ List<WorkOrder> suggestWorkOrders(
               unitId: unit.id, target: target, targetTileKey: targetTileKey);
           if (_isWorkOrderAccepted(
               game, topology, playerId, currentOrders, candidate)) {
-            _log.d('logic: suggestWorkOrders candidate=$candidate');
+            _log.d('$_kOrderSuggestionLogPrefix: suggestWorkOrders candidate=$candidate');
             suggestions.add(candidate);
           } else {
-            _log.d('logic: suggestWorkOrders rejected candidate=$candidate');
+            _log.d('$_kOrderSuggestionLogPrefix: suggestWorkOrders rejected candidate=$candidate');
           }
         }
       }
@@ -339,9 +343,11 @@ List<WorkOrder> suggestWorkOrders(
   });
 
   _log.d(
-      'logic: suggestWorkOrders player=$playerId candidates=${suggestions.length}');
+      '$_kOrderSuggestionLogPrefix: suggestWorkOrders player=$playerId candidates=${suggestions.length}');
+  _log.d(
+      '$_kOrderSuggestionLogPrefix: suggestWorkOrders full list ${suggestions.map((o) => "${o.unitId}:${o.target}").toList()}');
   if (suggestions.isEmpty)
-    _log.w('logic: suggestWorkOrders no candidates player=$playerId');
+    _log.w('$_kOrderSuggestionLogPrefix: suggestWorkOrders no candidates player=$playerId');
   return suggestions;
 }
 
@@ -352,14 +358,14 @@ List<BuildUnitOrder> suggestBuildOrders(
   MapTopology topology,
   Orders currentOrders,
 ) {
-  _log.d('logic: suggestBuildOrders player=${view.playerId}');
+  _log.d('$_kOrderSuggestionLogPrefix: suggestBuildOrders player=${view.playerId}');
   final playerId = view.playerId;
   final player = view.player;
   final suggestions = <BuildUnitOrder>[];
 
   final capitalId = player.capitalProvinceId;
   if (capitalId == null) {
-    _log.w('logic: suggestBuildOrders no capital player=$playerId');
+    _log.w('$_kOrderSuggestionLogPrefix: suggestBuildOrders no capital player=$playerId');
     return suggestions;
   }
 
@@ -397,9 +403,11 @@ List<BuildUnitOrder> suggestBuildOrders(
   suggestions.sort((a, b) => a.unitType.compareTo(b.unitType));
 
   _log.d(
-      'logic: suggestBuildOrders player=$playerId candidates=${suggestions.length}');
+      '$_kOrderSuggestionLogPrefix: suggestBuildOrders player=$playerId candidates=${suggestions.length}');
+  _log.d(
+      '$_kOrderSuggestionLogPrefix: suggestBuildOrders full list ${suggestions.map((o) => o.unitType).toList()}');
   if (suggestions.isEmpty)
-    _log.w('logic: suggestBuildOrders no candidates player=$playerId');
+    _log.w('$_kOrderSuggestionLogPrefix: suggestBuildOrders no candidates player=$playerId');
   return suggestions;
 }
 
@@ -412,7 +420,7 @@ List<ResearchOrder> suggestResearchOrders(
   MapTopology topology,
   Orders currentOrders,
 ) {
-  _log.d('logic: suggestResearchOrders player=${view.playerId}');
+  _log.d('$_kOrderSuggestionLogPrefix: suggestResearchOrders player=${view.playerId}');
   final playerId = view.playerId;
   final player = view.player;
   final suggestions = <ResearchOrder>[];
@@ -461,7 +469,9 @@ List<ResearchOrder> suggestResearchOrders(
   }
 
   _log.d(
-      'logic: suggestResearchOrders player=$playerId candidates=${suggestions.length}');
+      '$_kOrderSuggestionLogPrefix: suggestResearchOrders player=$playerId candidates=${suggestions.length}');
+  _log.d(
+      '$_kOrderSuggestionLogPrefix: suggestResearchOrders full list ${suggestions.map((o) => "slot${o.slotIndex}:${o.techId}").toList()}');
   return suggestions;
 }
 
@@ -532,7 +542,7 @@ Set<String> getValidWorkOrderTileKeys(
     }
   }
   _log.d(
-      'logic: getValidWorkOrderTileKeys unit=$unitId target=$workTarget count=${valid.length}');
+      '$_kOrderSuggestionLogPrefix: getValidWorkOrderTileKeys unit=$unitId target=$workTarget count=${valid.length}');
   return valid;
 }
 
@@ -557,21 +567,21 @@ Set<String> getValidWorkOrderTileKeysWithVisibility({
       .firstOrNull;
   if (unit == null || unit.ownerId != view.playerId) {
     _log.d(
-        'getValidWorkOrderTileKeysWithVisibility: unit not found or not owned by player');
+        '$_kOrderSuggestionLogPrefix: getValidWorkOrderTileKeysWithVisibility unit not found or not owned by player');
     return {};
   }
   if (unit.currentWork != null) {
-    _log.d('getValidWorkOrderTileKeysWithVisibility: unit has current work');
+    _log.d('$_kOrderSuggestionLogPrefix: getValidWorkOrderTileKeysWithVisibility unit has current work');
     return {};
   }
   if (!isWorkOrderTargetAllowedForUnitType(unit.type, workTarget)) {
     _log.d(
-        'getValidWorkOrderTileKeysWithVisibility: target $workTarget not allowed for unit type ${unit.type}');
+        '$_kOrderSuggestionLogPrefix: getValidWorkOrderTileKeysWithVisibility target $workTarget not allowed for unit type ${unit.type}');
     return {};
   }
 
   _log.d(
-      'getValidWorkOrderTileKeysWithVisibility: unit=${unit.id} type=${unit.type} workTarget=$workTarget');
+      '$_kOrderSuggestionLogPrefix: getValidWorkOrderTileKeysWithVisibility unit=${unit.id} type=${unit.type} workTarget=$workTarget');
 
   final tileKeysByRegion = game.worldState.tileKeysByRegionAndProvince;
   final visibleTileKeys = <String>{};
@@ -589,7 +599,7 @@ Set<String> getValidWorkOrderTileKeysWithVisibility({
   }
 
   _log.d(
-      'getValidWorkOrderTileKeysWithVisibility: visible tiles count=${visibleTileKeys.length}');
+      '$_kOrderSuggestionLogPrefix: getValidWorkOrderTileKeysWithVisibility visible tiles count=${visibleTileKeys.length}');
 
   final valid = <String>{};
   for (final tileKey in visibleTileKeys) {
@@ -610,7 +620,7 @@ Set<String> getValidWorkOrderTileKeysWithVisibility({
   }
 
   _log.d(
-      'logic: getValidWorkOrderTileKeysWithVisibility unit=$unitId target=$workTarget count=${valid.length} (filtered from ${visibleTileKeys.length} visible tiles)');
+      '$_kOrderSuggestionLogPrefix: getValidWorkOrderTileKeysWithVisibility unit=$unitId target=$workTarget count=${valid.length} (filtered from ${visibleTileKeys.length} visible tiles)');
   return valid;
 }
 
@@ -634,7 +644,7 @@ List<NavalMoveOrder> suggestNavalMoveOrders(
   MapTopology topology,
   Orders currentOrders,
 ) {
-  _log.d('logic: suggestNavalMoveOrders player=${view.playerId}');
+  _log.d('$_kOrderSuggestionLogPrefix: suggestNavalMoveOrders player=${view.playerId}');
   final playerId = view.playerId;
   final suggestions = <NavalMoveOrder>[];
   final existingByFleet = <String, Set<String>>{};
@@ -719,7 +729,9 @@ List<NavalMoveOrder> suggestNavalMoveOrders(
     return keyA.compareTo(keyB);
   });
   _log.d(
-      'logic: suggestNavalMoveOrders player=$playerId candidates=${suggestions.length}');
+      '$_kOrderSuggestionLogPrefix: suggestNavalMoveOrders player=$playerId candidates=${suggestions.length}');
+  _log.d(
+      '$_kOrderSuggestionLogPrefix: suggestNavalMoveOrders full list ${suggestions.map((o) => "fleetId=${o.fleetId} destSea=${o.destinationSeaZoneId} destPort=${o.destinationPortProvinceId}").toList()}');
   return suggestions;
 }
 
@@ -730,7 +742,7 @@ List<NavalMissionOrder> suggestNavalMissionOrders(
   MapTopology topology,
   Orders currentOrders,
 ) {
-  _log.d('logic: suggestNavalMissionOrders player=${view.playerId}');
+  _log.d('$_kOrderSuggestionLogPrefix: suggestNavalMissionOrders player=${view.playerId}');
   final playerId = view.playerId;
   final suggestions = <NavalMissionOrder>[];
   final existingByFleet = <String>{};
@@ -758,7 +770,9 @@ List<NavalMissionOrder> suggestNavalMissionOrders(
     return a.mission.compareTo(b.mission);
   });
   _log.d(
-      'logic: suggestNavalMissionOrders player=$playerId candidates=${suggestions.length}');
+      '$_kOrderSuggestionLogPrefix: suggestNavalMissionOrders player=$playerId candidates=${suggestions.length}');
+  _log.d(
+      '$_kOrderSuggestionLogPrefix: suggestNavalMissionOrders full list ${suggestions.map((o) => "fleetId=${o.fleetId} mission=${o.mission}").toList()}');
   return suggestions;
 }
 
@@ -812,7 +826,7 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
   MapTopology topology,
   Orders currentOrders,
 ) {
-  _log.d('logic: suggestDiplomaticOrders player=${view.playerId}');
+  _log.d('$_kOrderSuggestionLogPrefix: suggestDiplomaticOrders player=${view.playerId}');
   final playerId = view.playerId;
   final suggestions = <DiplomaticOrder>[];
   final player = view.player;
@@ -897,7 +911,9 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
     return a.targetFactionId.compareTo(b.targetFactionId);
   });
   _log.d(
-      'logic: suggestDiplomaticOrders player=$playerId candidates=${suggestions.length}');
+      '$_kOrderSuggestionLogPrefix: suggestDiplomaticOrders player=$playerId candidates=${suggestions.length}');
+  _log.d(
+      '$_kOrderSuggestionLogPrefix: suggestDiplomaticOrders full list ${suggestions.map((o) => "${o.type.name}:${o.targetFactionId}").toList()}');
   return suggestions;
 }
 


### PR DESCRIPTION
## Summary
Adds full AI decision and evaluation logging at debug level, and major-decision logging at info level, with `package/subpackage/class`-style prefixes for grep-friendly logs.

## Changes
- **Prefixes:** `ai/strategic_ai`, `ai/goal_manager`, `ai/domain_planners`, `ai/economy_planner`, `ai/perception`, `ai/dossier`, `logic/order_suggestion`
- **Info:** Major decisions (selected goal, chosen work/build/move/naval/diplomacy/research, economy plan summary)
- **Debug:** Full evals (goal weights, candidate lists and scores, perception snapshot, dossier, economy recipe scores, cargo preference)
- **Perception:** Snapshot (threats, opportunities, economy, relations)
- **Goal manager:** Weights and selected primary goal
- **Domain planners:** Candidates + scores + chosen for each planner; skip reasons when weight below threshold
- **Economy planner:** Recipe candidates/scores, allocation, cargo eval
- **Dossier:** `getDossierForSubject` (scoreByAgenda, suspicion, bestGuess, evidence, behavioral notes, basic intel)
- **Order suggestion (logic):** Full candidate list at debug for each `suggest*` function
- **SPEC:** `ctdev-logging.md` updated with prefix convention and AI info vs debug levels

Target: **dev**

Made with [Cursor](https://cursor.com)