### PR TITLE
feat: debug log viewer in app and ctterm

### DIFF
--- a/SPEC/program/debug-log-viewer.md
+++ b/SPEC/program/debug-log-viewer.md
@@ -1,0 +1,77 @@
+# Debug log viewer
+
+**SPEC/program** — In-app viewer for all runtime logs from the current session. Available in the Flutter app and in ctterm. Coexists with existing Sim Log (ctdev); this viewer shows full debug traces from all packages, not just game events.
+
+---
+
+## 1. Purpose and scope
+
+- **Purpose:** Let developers inspect all log output (debug and above) from the current run in one place, with simple filtering by package (prefix) and level.
+- **Scope:** Flutter app (macOS + mobile) and ctterm. Session-only; no persistence or export. Same data source contract in both UIs.
+
+---
+
+## 2. Data source and buffer
+
+- **Source:** The single global `Logger` (Dart `logger` package). All packages log via `Logger()`; they do not configure outputs.
+- **Session buffer:** Each host (app, ctterm) registers a **session log buffer** at startup. One `Logger.addLogListener` callback appends every `LogEvent` (debug and above) to an in-memory buffer for the lifetime of the process. Format per event: timestamp (UTC ISO8601), level name, message; when present, error and stackTrace on following lines (same convention as [ctdev-logging.md](ctdev-logging.md) `formatLogEvent`).
+- **Capacity:** Buffer is bounded (e.g. last N lines or last M bytes). When full, oldest entries are dropped. Exact cap is implementation-defined; sufficient for a typical dev session.
+- **No persistence:** Buffer is cleared on process exit. No file write, no export requirement in this spec.
+
+---
+
+## 3. Filters
+
+- **Package (prefix):** Multiselect. Options are the known log prefixes used in the project: **ctdev**, **logic**, **ai**, **data**, **map**, **save**, and for ctterm **tui** (and sub-prefixes such as `tui:menu:`, `tui:nav:`). A line is shown if its message or logger name matches any of the selected prefixes (prefix match). Default: all selected (show all).
+- **Level:** Multiselect. Options: **debug**, **info**, **warn**, **error**. A line is shown if its level is in the selected set. Default: all selected (show all).
+- Filtering is applied to the in-memory buffer when rendering; changing filters updates the visible list without altering the buffer.
+
+---
+
+## 4. Entry points
+
+### 4.1 Flutter app
+
+- **macOS:** Application menubar. One top-level or sub-menu item that opens the debug log viewer (e.g. **View → Debug log** or **Developer → Debug log**). Shown only when the app has a menubar (desktop).
+- **Mobile:** In-game pause menu. One menu item (e.g. **Debug log**) that opens the viewer. When the user does not have a pause menu (e.g. main menu only), the viewer is not required to be reachable from that context; implementation may also expose it from a main-menu or settings entry on mobile if desired.
+- **Other platforms (e.g. web):** Optional; at least one way to open the viewer (e.g. from a menu or overflow) so that web dev sessions can use it.
+
+### 4.2 ctterm
+
+- **Main Menu:** One selectable item (e.g. **Debug log**) that navigates to the Debug log viewer screen. Available even when no game is loaded.
+- **Pause/Options:** One menu item (e.g. **Debug log**) that navigates to the Debug log viewer screen. When the user leaves the viewer (Back), they return to Pause/Options (or in-game shell if that is the defined back target). See [SPEC/tui/screens/pause-options.md](../tui/screens/pause-options.md); add the new item to the table in §4.
+- **Screen ID:** Assign a 6-digit screen ID for the Debug log viewer in ctterm (e.g. 100020); register in `CttermRoute` and the screen-ID extension per [SPEC/tui/ctterm.md](../tui/ctterm.md).
+
+---
+
+## 5. Viewer behaviour
+
+- **Content:** Scrollable list of log lines (newest at bottom or top per platform convention). Each line shows timestamp, level, and message; error/stack lines follow their parent log line.
+- **Filters:** UI controls for multiselect package and multiselect level; applied live to the visible list.
+- **Close:** Obvious way to close the viewer and return to the previous screen (menubar closes window/overlay; pause menu returns to pause; ctterm Back returns to Pause or Main Menu as appropriate).
+
+---
+
+## 6. Coexistence with Sim Log
+
+- The ctdev **Sim Log** (last 10 lines, info+, cleared each turn) is unchanged and remains on the Running Game screen. The debug log viewer is separate: it shows the full session buffer with no turn-based clear and includes debug level. No behavioural change to Sim Log.
+
+---
+
+## 7. Acceptance criteria (Given–When–Then)
+
+- **Given** the Flutter app is running on macOS with a menubar, **when** the user chooses the Debug log menu item, **then** the debug log viewer opens and displays session logs with package and level filters available.
+- **Given** the Flutter app is in-game on mobile, **when** the user opens the pause menu and selects Debug log, **then** the debug log viewer opens and displays session logs with package and level filters available.
+- **Given** ctterm is at the Main Menu, **when** the user selects Debug log and confirms, **then** the Debug log viewer screen is shown and displays session logs.
+- **Given** ctterm is at the Pause/Options screen, **when** the user selects Debug log and confirms, **then** the Debug log viewer screen is shown; when the user exits the viewer, **then** the app returns to the Pause/Options screen.
+- **Given** the debug log viewer is open with all packages and all levels selected, **when** the user deselects one package (e.g. **logic**), **then** lines whose prefix matches **logic** are hidden; when the user reselects **logic**, **then** those lines are shown again.
+- **Given** the debug log viewer is open with all levels selected, **when** the user deselects **debug**, **then** only info, warn, and error lines are shown.
+- **Given** the app or ctterm process exits, **when** the user starts a new process, **then** the new session’s viewer shows only logs from that process; no previous-session logs are shown.
+
+---
+
+## 8. References
+
+- Logger and prefixes: [ctdev-logging.md](ctdev-logging.md). Ctterm prefixes: [ctterm.md](../tui/ctterm.md) §5 (tui:, tui:menu:, etc.).
+- Flutter app shell/menus: [ctdev-app.md](ctdev-app.md); [SPEC/ui/main-menu.md](../ui/main-menu.md).
+- Ctterm Pause/Options: [SPEC/tui/screens/pause-options.md](../tui/screens/pause-options.md). Screen IDs: [SPEC/tui/ctterm.md](../tui/ctterm.md).

--- a/SPEC/tui/ctterm.md
+++ b/SPEC/tui/ctterm.md
@@ -72,7 +72,7 @@ Layouts must work on small terminals (e.g. Termux, Termius). Constraints: narrow
 
 ### Screen IDs
 
-Each top-level screen has a unique **6-digit screen ID** shown in a bar at the top-right of the screen for easy identification (e.g. when discussing which screen is meant). Source of truth: `CttermRoute.screenId` in `ctterm/lib/ctterm_routes.dart`. IDs: Main Menu 100001, Game Setup 100002, Load Game 100003, Generating World 100004, Settings 100005, In-game shell 100006, Map context 100007, Units 100008, Development 100009, Production 100010, Academy 100011, Shipyard 100012, Diplomacy 100013, Technology 100014, Victory/Progress 100015, Victory 100016, Defeat 100017, Pause/Options 100018, Pending Overtures 100019.
+Each top-level screen has a unique **6-digit screen ID** shown in a bar at the top-right of the screen for easy identification (e.g. when discussing which screen is meant). Source of truth: `CttermRoute.screenId` in `ctterm/lib/ctterm_routes.dart`. IDs: Main Menu 100001, Game Setup 100002, Load Game 100003, Generating World 100004, Settings 100005, In-game shell 100006, Map context 100007, Units 100008, Development 100009, Production 100010, Academy 100011, Shipyard 100012, Diplomacy 100013, Technology 100014, Victory/Progress 100015, Victory 100016, Defeat 100017, Pause/Options 100018, Pending Overtures 100019, Debug log viewer 100020.
 
 ### Acceptance criteria format
 
@@ -144,6 +144,7 @@ PlayerView and save/load contracts are unchanged; ctterm uses the same PlayerVie
 | Victory / Progress     | [SPEC/game/victory.md](../game/victory.md)                                                                                                                   | [SPEC/tui/screens/victory-progress.md](screens/victory-progress.md) | 03l   | Progress overview; Victory screen when human wins              |
 | Defeat                 | [SPEC/game/victory.md](../game/victory.md) (extended)                                                                                                        | [SPEC/tui/screens/defeat.md](screens/defeat.md) | —     | New: when other GP wins; View Final Map / Main Menu            |
 | Pause/Options          | [SPEC/ui/main-menu.md](../ui/main-menu.md) (return flow)                                                                                                     | [SPEC/tui/screens/pause-options.md](screens/pause-options.md) | 03a   | Exit to Main Menu                                              |
+| Debug log viewer       | [SPEC/program/debug-log-viewer.md](../program/debug-log-viewer.md)                                                                                          | — (adaptations in ctterm.md)      | —     | Session logs; filters by package and level; Main Menu + Pause  |
 
 ### Summary
 

--- a/SPEC/tui/screens/pause-options.md
+++ b/SPEC/tui/screens/pause-options.md
@@ -40,6 +40,7 @@
 |---|--------|--------------------------------------|
 | 1 | **Exit to Main Menu** | Show the exit-confirmation prompt (§5). Does not exit immediately. |
 | 2 | **Settings** | Navigate to the Settings screen (100005). When the user leaves Settings (Back), they return to the Pause menu (game still paused). |
+| 3 | **Debug log** | Navigate to the Debug log viewer screen (100020). Per [SPEC/program/debug-log-viewer.md](../../program/debug-log-viewer.md). When the user leaves the viewer (Back), they return to the Pause menu. |
 
 No other menu items are required for MVP. Additional options (e.g. Help) may be added later; see §9.
 
@@ -139,6 +140,16 @@ No other menu items are required for MVP. Additional options (e.g. Help) may be 
 - **Given** the terminal is narrow (e.g. 40 columns)  
 - **When** the Pause menu is open  
 - **Then** the menu renders without horizontal overflow and all items remain selectable.
+
+### Debug log
+
+- **Given** the Pause menu is open  
+- **When** the player selects "Debug log" and presses **Enter**  
+- **Then** the Debug log viewer screen (100020) is shown.
+
+- **Given** the player opened the Debug log viewer from the Pause menu  
+- **When** the player exits the viewer (Back)  
+- **Then** the app returns to the Pause menu (100018) and the game remains paused.
 
 ---
 

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -3,16 +3,42 @@ import 'package:flutter/material.dart';
 import 'config/routes.dart';
 import 'config/themes.dart';
 
+/// Used by macOS menubar (View → Debug log) to push the debug log route.
+final GlobalKey<NavigatorState> appNavigatorKey = GlobalKey<NavigatorState>();
+
 class App extends StatelessWidget {
   const App({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    final app = MaterialApp(
+      navigatorKey: appNavigatorKey,
       title: 'Colonize This',
       theme: AppThemes.light,
       initialRoute: Routes.shell,
       onGenerateRoute: Routes.generate,
+    );
+    return PlatformMenuBar(
+      menus: <PlatformMenuItem>[
+        PlatformMenu(
+          label: 'View',
+          menus: <PlatformMenuItem>[
+            PlatformMenuItem(
+              label: 'Debug log',
+              onSelected: () {
+                appNavigatorKey.currentState?.pushNamed(Routes.debugLog);
+              },
+            ),
+          ],
+        ),
+        if (PlatformProvidedMenuItem.hasMenu(
+          PlatformProvidedMenuItemType.quit,
+        ))
+          const PlatformProvidedMenuItem(
+            type: PlatformProvidedMenuItemType.quit,
+          ),
+      ],
+      child: app,
     );
   }
 }

--- a/app/lib/config/routes.dart
+++ b/app/lib/config/routes.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../features/debug_log/debug_log_viewer_screen.dart';
 import '../features/game/flame/game_screen.dart';
 import '../features/shell/shell_screen.dart';
 
@@ -8,6 +9,7 @@ class Routes {
 
   static const String shell = '/';
   static const String game = '/game';
+  static const String debugLog = '/debug-log';
 
   static Route<dynamic>? generate(RouteSettings settings) {
     switch (settings.name) {
@@ -20,6 +22,11 @@ class Routes {
         return MaterialPageRoute<void>(
           settings: settings,
           builder: (_) => const GameScreen(),
+        );
+      case debugLog:
+        return MaterialPageRoute<void>(
+          settings: settings,
+          builder: (_) => const DebugLogViewerScreen(),
         );
       default:
         return null;

--- a/app/lib/features/debug_log/debug_log_viewer_screen.dart
+++ b/app/lib/features/debug_log/debug_log_viewer_screen.dart
@@ -1,0 +1,151 @@
+// Debug log viewer. SPEC/program/debug-log-viewer.md.
+
+import 'package:flutter/material.dart';
+import 'package:logger/logger.dart';
+import 'package:session_log_buffer/session_log_buffer.dart';
+
+/// Full-screen viewer for session logs with multiselect filters by package and level.
+class DebugLogViewerScreen extends StatefulWidget {
+  const DebugLogViewerScreen({super.key});
+
+  @override
+  State<DebugLogViewerScreen> createState() => _DebugLogViewerScreenState();
+}
+
+class _DebugLogViewerScreenState extends State<DebugLogViewerScreen> {
+  Set<String> _selectedPrefixes = Set<String>.from(knownPrefixes);
+  Set<Level> _selectedLevels = Set<Level>.from(knownLevels);
+
+  List<SessionLogEntry> get _filtered =>
+      SessionLogBuffer.instance.getFiltered(
+        selectedPrefixes: _selectedPrefixes,
+        selectedLevels: _selectedLevels,
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Debug log'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: () => Navigator.of(context).pop(),
+            tooltip: 'Close',
+          ),
+        ],
+      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _buildFilters(context),
+          const Divider(height: 1),
+          Expanded(child: _buildLogList(context)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFilters(BuildContext context) {
+    final theme = Theme.of(context);
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Package:', style: theme.textTheme.titleSmall),
+          const SizedBox(width: 8),
+          Wrap(
+            spacing: 4,
+            runSpacing: 4,
+            children: knownPrefixes.map((p) {
+              final selected = _selectedPrefixes.contains(p);
+              return FilterChip(
+                label: Text(p),
+                selected: selected,
+                onSelected: (_) {
+                  setState(() {
+                    if (selected) {
+                      _selectedPrefixes = Set.from(_selectedPrefixes)..remove(p);
+                    } else {
+                      _selectedPrefixes = Set.from(_selectedPrefixes)..add(p);
+                    }
+                  });
+                },
+              );
+            }).toList(),
+          ),
+          const SizedBox(width: 16),
+          Text('Level:', style: theme.textTheme.titleSmall),
+          const SizedBox(width: 8),
+          Wrap(
+            spacing: 4,
+            runSpacing: 4,
+            children: knownLevels.map((l) {
+              final selected = _selectedLevels.contains(l);
+              return FilterChip(
+                label: Text(l.name),
+                selected: selected,
+                onSelected: (_) {
+                  setState(() {
+                    if (selected) {
+                      _selectedLevels = Set.from(_selectedLevels)..remove(l);
+                    } else {
+                      _selectedLevels = Set.from(_selectedLevels)..add(l);
+                    }
+                  });
+                },
+              );
+            }).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLogList(BuildContext context) {
+    final entries = _filtered;
+    final theme = Theme.of(context);
+    return ListView.builder(
+      itemCount: entries.length,
+      itemBuilder: (context, index) {
+        final entry = entries[index];
+        final lines = entry.displayLines;
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
+          children: lines.map((line) {
+            final isFirst = line == lines.first;
+            return Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
+              decoration: BoxDecoration(
+                color: isFirst ? _levelColor(entry.level).withValues(alpha: 0.08) : null,
+              ),
+              child: SelectableText(
+                line,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontFamily: 'monospace',
+                  fontSize: 12,
+                ),
+              ),
+            );
+          }).toList(),
+        );
+      },
+    );
+  }
+
+  Color _levelColor(Level level) {
+    switch (level) {
+      case Level.error:
+        return Colors.red;
+      case Level.warning:
+        return Colors.orange;
+      case Level.info:
+        return Colors.blue;
+      default:
+        return Colors.grey;
+    }
+  }
+}

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -6,6 +6,7 @@ import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../config/routes.dart';
 import '../../../../providers/game_service_provider.dart';
 import '../../../../providers/games_provider.dart';
 import '../../../../providers/map_view_provider.dart';
@@ -20,6 +21,33 @@ import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/ct_panel.dart';
 import '../../../widgets/ct_screen_shell.dart';
 import 'game_canvas.dart';
+
+/// Shows the in-game pause menu (Debug log, Resume). SPEC/program/debug-log-viewer.md.
+void _showPauseMenu(BuildContext context) {
+  showModalBottomSheet<void>(
+    context: context,
+    builder: (ctx) => SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ListTile(
+            leading: const Icon(Icons.bug_report),
+            title: const Text('Debug log'),
+            onTap: () {
+              Navigator.of(ctx).pop();
+              Navigator.of(context).pushNamed(Routes.debugLog);
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.play_arrow),
+            title: const Text('Resume'),
+            onTap: () => Navigator.of(ctx).pop(),
+          ),
+        ],
+      ),
+    ),
+  );
+}
 
 /// Hosts the Flame game canvas or map. When map data exists, shows map + province/sea zone overlay.
 class GameScreen extends ConsumerWidget {
@@ -39,6 +67,15 @@ class GameScreen extends ConsumerWidget {
           else
             GameWidget(game: ColonizeThisGame()),
           if (game != null && victory == null) ...[
+            Positioned(
+              left: 16,
+              top: 16,
+              child: IconButton(
+                icon: const Icon(Icons.menu),
+                onPressed: () => _showPauseMenu(context),
+                tooltip: 'Pause menu',
+              ),
+            ),
             Positioned(
               right: 16,
               top: 16,

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:session_log_buffer/session_log_buffer.dart';
 
 import 'app.dart';
 import 'config/constants.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  SessionLogBuffer.init();
   await Hive.initFlutter();
   try {
     await Hive.openBox(HiveBoxNames.settings);

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   flutter_riverpod: ^2.6.1
   hive: ^2.2.3
   hive_flutter: ^1.1.0
+  session_log_buffer:
   colonizethis_map:
   colonizethis_models:
   colonizethis_data:

--- a/app/test/debug_log_viewer_test.dart
+++ b/app/test/debug_log_viewer_test.dart
@@ -1,0 +1,96 @@
+// Widget tests for debug log viewer. SPEC/program/debug-log-viewer.md.
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+import 'package:session_log_buffer/session_log_buffer.dart';
+
+import 'package:colonizethis_app/config/themes.dart';
+import 'package:colonizethis_app/features/debug_log/debug_log_viewer_screen.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  setUp(() {
+    SessionLogBuffer.resetForTest();
+    SessionLogBuffer.init();
+  });
+
+  tearDown(() {
+    SessionLogBuffer.resetForTest();
+  });
+
+  group('DebugLogViewerScreen', () {
+    testWidgets('shows title and close button', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppThemes.light,
+          home: const DebugLogViewerScreen(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Debug log'), findsOneWidget);
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+
+    testWidgets('shows filter chips for package and level', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppThemes.light,
+          home: const DebugLogViewerScreen(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('logic'), findsOneWidget);
+      expect(find.text('debug'), findsOneWidget);
+    });
+
+    testWidgets('close button pops route', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppThemes.light,
+          home: Builder(
+            builder: (context) => Column(
+              children: [
+                ElevatedButton(
+                  onPressed: () => Navigator.push(
+                    context,
+                    MaterialPageRoute<void>(
+                      builder: (_) => const DebugLogViewerScreen(),
+                    ),
+                  ),
+                  child: const Text('Open'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Debug log'), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Debug log'), findsNothing);
+    });
+
+    testWidgets('displays session log entries when present', (WidgetTester tester) async {
+      SessionLogBuffer.instance.add(LogEvent(Level.info, 'logic: test message'));
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppThemes.light,
+          home: const DebugLogViewerScreen(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('test message'), findsOneWidget);
+    });
+  });
+}

--- a/ctterm/bin/ctterm.dart
+++ b/ctterm/bin/ctterm.dart
@@ -6,6 +6,7 @@ import 'package:nocterm/nocterm.dart' hide Logger;
 import 'package:ctterm/ctterm_app.dart';
 import 'package:ctterm/ctterm_log.dart';
 import 'package:ctterm/save_service.dart';
+import 'package:session_log_buffer/session_log_buffer.dart';
 
 final log_pkg.Logger _log = log_pkg.Logger();
 
@@ -20,6 +21,7 @@ void main(List<String> args) async {
   }
 
   initCttermLogging(dataDirOverride);
+  SessionLogBuffer.init();
   _log.i('tui: ctterm starting');
 
   var initialLockDetected = false;

--- a/ctterm/lib/ctterm_app.dart
+++ b/ctterm/lib/ctterm_app.dart
@@ -353,6 +353,10 @@ class _CttermAppState extends State<CttermApp> {
         settingsReturnRoute: _route == CttermRoute.settings && _previousRoute == CttermRoute.pauseOptions
             ? CttermRoute.pauseOptions
             : null,
+        /// When in Debug log viewer, Back goes to Pause or Main Menu. SPEC/program/debug-log-viewer.md.
+        debugLogViewerReturnRoute: _route == CttermRoute.debugLogViewer
+            ? _previousRoute
+            : null,
       ),
     );
   }

--- a/ctterm/lib/ctterm_routes.dart
+++ b/ctterm/lib/ctterm_routes.dart
@@ -22,6 +22,8 @@ enum CttermRoute {
   pauseOptions,
   /// Shown when turn resolution blocks on human accept/reject of diplomatic overtures. SPEC/program/turn-resolution-phases.md.
   pendingOvertures,
+  /// Debug log viewer. SPEC/program/debug-log-viewer.md.
+  debugLogViewer,
 }
 
 /// Unique 6-digit screen ID for each route. Displayed at top of each screen for identification.
@@ -67,6 +69,8 @@ extension CttermRouteScreenId on CttermRoute {
         return '100018';
       case CttermRoute.pendingOvertures:
         return '100019';
+      case CttermRoute.debugLogViewer:
+        return '100020';
     }
   }
 }

--- a/ctterm/lib/screens/debug_log_viewer_screen.dart
+++ b/ctterm/lib/screens/debug_log_viewer_screen.dart
@@ -1,0 +1,133 @@
+// Debug log viewer. SPEC/program/debug-log-viewer.md. Screen ID 100020.
+
+import 'package:logger/logger.dart' as log_pkg;
+import 'package:nocterm/nocterm.dart' hide Logger;
+import 'package:session_log_buffer/session_log_buffer.dart';
+
+/// Debug log viewer: scrollable session logs with multiselect filters. [B] Back.
+class DebugLogViewerScreen extends StatefulComponent {
+  const DebugLogViewerScreen({
+    super.key,
+    required this.onBack,
+  });
+
+  final void Function() onBack;
+
+  @override
+  State<DebugLogViewerScreen> createState() => _DebugLogViewerScreenState();
+}
+
+class _DebugLogViewerScreenState extends State<DebugLogViewerScreen> {
+  Set<String> _selectedPrefixes = Set<String>.from(knownPrefixes);
+  Set<log_pkg.Level> _selectedLevels = Set<log_pkg.Level>.from(knownLevels);
+  int _scrollOffset = 0;
+
+  List<SessionLogEntry> get _filtered =>
+      SessionLogBuffer.instance.getFiltered(
+        selectedPrefixes: _selectedPrefixes,
+        selectedLevels: _selectedLevels,
+      );
+
+  @override
+  Component build(BuildContext context) {
+    final entries = _filtered;
+    final lines = <String>[];
+    for (final e in entries) {
+      lines.addAll(e.displayLines);
+    }
+    final totalLines = lines.length;
+    if (_scrollOffset > totalLines - 1) {
+      _scrollOffset = totalLines > 0 ? totalLines - 1 : 0;
+    }
+    final visibleStart = _scrollOffset;
+    final visibleEnd = visibleStart + 20;
+    final visible = lines.sublist(
+      visibleStart,
+      visibleEnd > lines.length ? lines.length : visibleEnd,
+    );
+
+    return Focusable(
+      focused: true,
+      onKeyEvent: (event) {
+        final key = event.logicalKey;
+        final c = event.character?.toLowerCase();
+        if (key == LogicalKey.escape || c == 'b') {
+          component.onBack();
+          return true;
+        }
+        if (key == LogicalKey.arrowUp || c == 'w') {
+          setState(() {
+            if (_scrollOffset > 0) _scrollOffset--;
+          });
+          return true;
+        }
+        if (key == LogicalKey.arrowDown || c == 's') {
+          setState(() {
+            if (_scrollOffset < totalLines - 1) _scrollOffset++;
+          });
+          return true;
+        }
+        if (c != null && c.length == 1) {
+          final num = int.tryParse(c);
+          if (num != null && num >= 1 && num <= knownPrefixes.length) {
+            final p = knownPrefixes[num - 1];
+            setState(() {
+              if (_selectedPrefixes.contains(p)) {
+                _selectedPrefixes = Set.from(_selectedPrefixes)..remove(p);
+              } else {
+                _selectedPrefixes = Set.from(_selectedPrefixes)..add(p);
+              }
+            });
+            return true;
+          }
+          final levelKeys = ['d', 'i', 'w', 'e'];
+          final levelIdx = levelKeys.indexOf(c);
+          if (levelIdx >= 0 && levelIdx < knownLevels.length) {
+            final l = knownLevels[levelIdx];
+            setState(() {
+              if (_selectedLevels.contains(l)) {
+                _selectedLevels = Set<log_pkg.Level>.from(_selectedLevels)
+                  ..remove(l);
+              } else {
+                _selectedLevels = Set<log_pkg.Level>.from(_selectedLevels)
+                  ..add(l);
+              }
+            });
+            return true;
+          }
+        }
+        return false;
+      },
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(1),
+            child: Text(
+              'Debug log — [B] Back  [W/S] Scroll  [1-${knownPrefixes.length}] Package  [D/I/W/E] Level',
+              style: TextStyle(color: Colors.cyan, fontWeight: FontWeight.bold),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 1),
+            child: Text(
+              'Package: ${_selectedPrefixes.join(' ')}  Level: ${_selectedLevels.map((log_pkg.Level l) => l.name).join(' ')}',
+              style: TextStyle(color: Colors.gray),
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: visible.length,
+              itemBuilder: (context, index) => Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 1),
+                child: Text(
+                  visible[index],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/ctterm/lib/screens/main_menu_screen.dart
+++ b/ctterm/lib/screens/main_menu_screen.dart
@@ -8,7 +8,7 @@ import 'package:ctterm/save_service.dart';
 
 final log_pkg.Logger _log = log_pkg.Logger();
 
-/// Main menu: New Game, Load Game (L always navigates; list empty when no saves), Settings, Quit.
+/// Main menu: New Game, Load Game (L always navigates; list empty when no saves), Settings, Debug log, Quit.
 class MainMenuScreen extends StatefulComponent {
   const MainMenuScreen({
     super.key,
@@ -16,6 +16,7 @@ class MainMenuScreen extends StatefulComponent {
     required this.onLoadGame,
     required this.onSettings,
     required this.onQuit,
+    this.onDebugLog,
     this.dataDirOverride,
   });
 
@@ -23,6 +24,7 @@ class MainMenuScreen extends StatefulComponent {
   final void Function() onLoadGame;
   final void Function() onSettings;
   final void Function() onQuit;
+  final void Function()? onDebugLog;
   final String? dataDirOverride;
 
   @override
@@ -88,6 +90,10 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
           component.onQuit();
           return true;
         }
+        if (c == 'd' && component.onDebugLog != null) {
+          component.onDebugLog!();
+          return true;
+        }
         return false;
       },
       child: Center(
@@ -115,6 +121,8 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
                 ),
               ),
             _menuRow('S', 'Settings', true, component.onSettings),
+            if (component.onDebugLog != null)
+              _menuRow('D', 'Debug log', true, component.onDebugLog!),
             _menuRow('Q', 'Quit', true, component.onQuit),
             const SizedBox(height: 2),
             Text('v0.1.0', style: TextStyle(color: Colors.gray)),

--- a/ctterm/lib/screens/pause_options_screen.dart
+++ b/ctterm/lib/screens/pause_options_screen.dart
@@ -23,12 +23,16 @@ class PauseOptionsScreen extends StatefulComponent {
 }
 
 class _PauseOptionsScreenState extends State<PauseOptionsScreen> {
-  // Selected menu item (0 = Exit to Main Menu, 1 = Settings)
+  // Selected menu item (0 = Exit to Main Menu, 1 = Settings, 2 = Debug log)
   int _selectedIndex = 0;
   // Show exit confirmation
   bool _showExitConfirm = false;
 
-  static const _menuItems = ['Exit to Main Menu', 'Settings'];
+  static const _menuItems = [
+    'Exit to Main Menu',
+    'Settings',
+    'Debug log',
+  ];
 
   @override
   Component build(BuildContext context) {
@@ -136,6 +140,10 @@ class _PauseOptionsScreenState extends State<PauseOptionsScreen> {
       } else if (_selectedIndex == 1) {
         // Settings (navigate to settings screen)
         component.onNavigate(CttermRoute.settings);
+        return true;
+      } else if (_selectedIndex == 2) {
+        // Debug log (navigate to debug log viewer)
+        component.onNavigate(CttermRoute.debugLogViewer);
         return true;
       }
     }

--- a/ctterm/lib/screens/shell_screen.dart
+++ b/ctterm/lib/screens/shell_screen.dart
@@ -23,6 +23,7 @@ import 'package:ctterm/screens/diplomacy_screen.dart';
 import 'package:ctterm/screens/technology_screen.dart';
 import 'package:ctterm/screens/pause_options_screen.dart';
 import 'package:ctterm/screens/pending_overtures_screen.dart';
+import 'package:ctterm/screens/debug_log_viewer_screen.dart';
 import 'package:ctterm/save_service.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
@@ -55,6 +56,7 @@ class ShellScreen extends StatefulComponent {
     this.initialTheme,
     this.onThemeChanged,
     this.settingsReturnRoute,
+    this.debugLogViewerReturnRoute,
     this.pendingOvertures,
     this.onTurnResolutionPending,
     this.onOvertureDecisions,
@@ -64,6 +66,9 @@ class ShellScreen extends StatefulComponent {
 
   /// When non-null, Settings Back navigates here (e.g. Pause when opened from Pause). SPEC/tui/screens/pause-options.md §7.
   final CttermRoute? settingsReturnRoute;
+
+  /// When non-null, Debug log viewer Back navigates here (e.g. Pause when opened from Pause). SPEC/program/debug-log-viewer.md.
+  final CttermRoute? debugLogViewerReturnRoute;
   final String? dataDirOverride;
 
   /// Current game state. Set when loading or starting a game.
@@ -165,6 +170,12 @@ class _ShellScreenState extends State<ShellScreen> {
             return true;
           }
           // In-game panels: Esc -> back to in-game shell (so Escape works even if panel does not receive key)
+          if (component.route == CttermRoute.debugLogViewer) {
+            _log.d('tui:nav: Esc -> from debug log viewer');
+            component.onNavigate(
+                component.debugLogViewerReturnRoute ?? CttermRoute.mainMenu);
+            return true;
+          }
           if (component.route == CttermRoute.mapContext ||
               component.route == CttermRoute.units ||
               component.route == CttermRoute.development ||
@@ -222,6 +233,7 @@ class _ShellScreenState extends State<ShellScreen> {
           onNewGame: () => component.onNavigate(CttermRoute.gameSetup),
           onLoadGame: () => component.onNavigate(CttermRoute.loadGame),
           onSettings: () => component.onNavigate(CttermRoute.settings),
+          onDebugLog: () => component.onNavigate(CttermRoute.debugLogViewer),
           onQuit: component.onExit,
         );
       case CttermRoute.gameSetup:
@@ -422,6 +434,11 @@ class _ShellScreenState extends State<ShellScreen> {
             component.onClearGame?.call();
             component.onNavigate(CttermRoute.mainMenu);
           },
+        );
+      case CttermRoute.debugLogViewer:
+        return DebugLogViewerScreen(
+          onBack: () => component.onNavigate(
+              component.debugLogViewerReturnRoute ?? CttermRoute.mainMenu),
         );
       case CttermRoute.pendingOvertures:
         final game = component.game;

--- a/ctterm/pubspec.yaml
+++ b/ctterm/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   basic_logger_file: ^0.1.3
   path: ^1.9.0
   hive: ^2.2.3
+  session_log_buffer: any
   colonizethis_ai: any
   colonizethis_logic: any
   colonizethis_models: any

--- a/ctterm/test/ctterm_app_test.dart
+++ b/ctterm/test/ctterm_app_test.dart
@@ -46,7 +46,7 @@ void main() {
     });
 
     test(' CttermRoute enum has all expected values', () {
-      expect(CttermRoute.values.length, equals(19));
+      expect(CttermRoute.values.length, equals(20));
       expect(CttermRoute.mainMenu.screenId, equals('100001'));
       expect(CttermRoute.gameSetup.screenId, equals('100002'));
       expect(CttermRoute.loadGame.screenId, equals('100003'));
@@ -66,6 +66,7 @@ void main() {
       expect(CttermRoute.defeat.screenId, equals('100017'));
       expect(CttermRoute.pauseOptions.screenId, equals('100018'));
       expect(CttermRoute.pendingOvertures.screenId, equals('100019'));
+      expect(CttermRoute.debugLogViewer.screenId, equals('100020'));
     });
   });
 }

--- a/ctterm/test/debug_log_viewer_test.dart
+++ b/ctterm/test/debug_log_viewer_test.dart
@@ -1,0 +1,35 @@
+// Tests for debug log viewer screen. SPEC/program/debug-log-viewer.md.
+
+import 'package:ctterm/screens/debug_log_viewer_screen.dart';
+import 'package:ctterm/screens/pause_options_screen.dart';
+import 'package:ctterm/ctterm_routes.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('DebugLogViewerScreen (SPEC/program/debug-log-viewer.md)', () {
+    test('can be constructed with onBack callback', () {
+      var backCount = 0;
+      final screen = DebugLogViewerScreen(
+        onBack: () => backCount++,
+      );
+
+      expect(screen.onBack, isNotNull);
+      screen.onBack();
+      expect(backCount, 1);
+    });
+  });
+
+  group('PauseOptionsScreen includes Debug log', () {
+    test('navigating to Debug log viewer when third item selected', () {
+      CttermRoute? navigatedRoute;
+      final screen = PauseOptionsScreen(
+        onNavigate: (route) => navigatedRoute = route,
+        onExitToMainMenu: () {},
+      );
+
+      expect(screen.onNavigate, isNotNull);
+      screen.onNavigate(CttermRoute.debugLogViewer);
+      expect(navigatedRoute, CttermRoute.debugLogViewer);
+    });
+  });
+}

--- a/packages/session_log_buffer/lib/session_log_buffer.dart
+++ b/packages/session_log_buffer/lib/session_log_buffer.dart
@@ -1,0 +1,141 @@
+// Session log buffer for debug log viewer. SPEC/program/debug-log-viewer.md.
+
+import 'package:logger/logger.dart';
+
+/// Default maximum number of log entries to retain (oldest dropped when exceeded).
+const int defaultMaxEntries = 5000;
+
+/// Known log prefixes used in the project (ctdev, logic, ai, data, map, save, tui).
+/// Used for filter options in the viewer.
+const List<String> knownPrefixes = [
+  'ctdev',
+  'logic',
+  'ai',
+  'data',
+  'map',
+  'save',
+  'tui',
+];
+
+/// Standard log levels for filter options.
+const List<Level> knownLevels = [
+  Level.debug,
+  Level.info,
+  Level.warning,
+  Level.error,
+];
+
+/// A single log entry stored in the session buffer.
+class SessionLogEntry {
+  const SessionLogEntry({
+    required this.time,
+    required this.level,
+    required this.message,
+    this.error,
+    this.stackTrace,
+  });
+
+  final DateTime time;
+  final Level level;
+  final String message;
+  final Object? error;
+  final StackTrace? stackTrace;
+
+  /// Prefix derived from message (e.g. "logic: foo" -> "logic"). Empty if no colon prefix.
+  String get prefix {
+    final msg = message;
+    final colon = msg.indexOf(':');
+    if (colon <= 0) return '';
+    return msg.substring(0, colon).trim().toLowerCase();
+  }
+
+  /// Formatted main line: timestamp level message.
+  String get formattedLine {
+    final timeStr = time.toUtc().toIso8601String();
+    final levelName = level.name.toUpperCase();
+    return '$timeStr $levelName $message';
+  }
+
+  /// All lines for display (main line + optional error and stackTrace).
+  List<String> get displayLines {
+    final lines = <String>[formattedLine];
+    if (error != null) {
+      lines.add('  error: $error');
+    }
+    if (stackTrace != null) {
+      lines.add('  stackTrace: $stackTrace');
+    }
+    return lines;
+  }
+}
+
+/// In-memory session log buffer. Thread-safe for single-threaded Dart; call [init] once at startup.
+class SessionLogBuffer {
+  SessionLogBuffer({int maxEntries = defaultMaxEntries}) : _maxEntries = maxEntries;
+
+  final int _maxEntries;
+  final List<SessionLogEntry> _entries = [];
+  bool _initialized = false;
+
+  /// Adds a log event to the buffer. Drops oldest entries when over [maxEntries].
+  void add(LogEvent e) {
+    final msg = e.message is String ? e.message as String : e.message.toString();
+    final entry = SessionLogEntry(
+      time: e.time,
+      level: e.level,
+      message: msg,
+      error: e.error,
+      stackTrace: e.stackTrace,
+    );
+    _entries.add(entry);
+    while (_entries.length > _maxEntries) {
+      _entries.removeAt(0);
+    }
+  }
+
+  /// Returns a copy of entries that match the given filters.
+  /// [selectedPrefixes]: empty means all; otherwise entry prefix must be in this set.
+  /// [selectedLevels]: empty means all; otherwise entry level must be in this set.
+  List<SessionLogEntry> getFiltered({
+    Set<String> selectedPrefixes = const {},
+    Set<Level> selectedLevels = const {},
+  }) {
+    final useAllPrefixes = selectedPrefixes.isEmpty;
+    final useAllLevels = selectedLevels.isEmpty;
+    return _entries.where((e) {
+      if (!useAllLevels && !selectedLevels.contains(e.level)) return false;
+      if (!useAllPrefixes) {
+        final p = e.prefix;
+        if (p.isEmpty || !selectedPrefixes.contains(p)) return false;
+      }
+      return true;
+    }).toList();
+  }
+
+  /// Returns all entries (unfiltered). Copy of the list.
+  List<SessionLogEntry> get entries => List<SessionLogEntry>.from(_entries);
+
+  /// Whether [init] has been called.
+  bool get isInitialized => _initialized;
+
+  static final SessionLogBuffer _instance = SessionLogBuffer();
+
+  static SessionLogBuffer get instance => _instance;
+
+  /// Initializes the global session log buffer and registers a [Logger.addLogListener].
+  /// Call once from app/ctterm main(). Logs at [Level.debug] and above are captured.
+  static void init() {
+    if (_instance._initialized) return;
+    _instance._initialized = true;
+    Logger.level = Level.debug;
+    Logger.addLogListener((LogEvent e) {
+      _instance.add(e);
+    });
+  }
+
+  /// Test-only: resets the buffer and initialized state. Not for production.
+  static void resetForTest() {
+    _instance._entries.clear();
+    _instance._initialized = false;
+  }
+}

--- a/packages/session_log_buffer/pubspec.yaml
+++ b/packages/session_log_buffer/pubspec.yaml
@@ -1,0 +1,14 @@
+name: session_log_buffer
+description: In-memory session log buffer for debug log viewer. SPEC/program/debug-log-viewer.md.
+version: 0.0.1
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: '>=3.11.0 <4.0.0'
+
+dependencies:
+  logger: ^2.0.2
+
+dev_dependencies:
+  test: ^1.24.0

--- a/packages/session_log_buffer/pubspec.yaml
+++ b/packages/session_log_buffer/pubspec.yaml
@@ -11,4 +11,5 @@ dependencies:
   logger: ^2.0.2
 
 dev_dependencies:
+  colonizethis_test:
   test: ^1.24.0

--- a/packages/session_log_buffer/test/session_log_buffer_test.dart
+++ b/packages/session_log_buffer/test/session_log_buffer_test.dart
@@ -1,8 +1,8 @@
 // Unit tests for session log buffer. SPEC/program/debug-log-viewer.md.
 
+import 'package:colonizethis_test/test.dart';
 import 'package:logger/logger.dart';
 import 'package:session_log_buffer/session_log_buffer.dart';
-import 'package:test/test.dart';
 
 void main() {
   group('SessionLogBuffer', () {

--- a/packages/session_log_buffer/test/session_log_buffer_test.dart
+++ b/packages/session_log_buffer/test/session_log_buffer_test.dart
@@ -1,0 +1,93 @@
+// Unit tests for session log buffer. SPEC/program/debug-log-viewer.md.
+
+import 'package:logger/logger.dart';
+import 'package:session_log_buffer/session_log_buffer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SessionLogBuffer', () {
+    setUp(() {
+      SessionLogBuffer.resetForTest();
+    });
+
+    test('add stores entry and getFiltered returns it', () {
+      final buffer = SessionLogBuffer.instance;
+      buffer.add(LogEvent(Level.info, 'logic: test'));
+      final filtered = buffer.getFiltered();
+      expect(filtered.length, 1);
+      expect(filtered.first.message, 'logic: test');
+      expect(filtered.first.level, Level.info);
+      expect(filtered.first.prefix, 'logic');
+    });
+
+    test('getFiltered with empty selection returns all (default show all)', () {
+      final buffer = SessionLogBuffer.instance;
+      buffer.add(LogEvent(Level.info, 'logic: test'));
+      final filtered =
+          buffer.getFiltered(selectedPrefixes: {}, selectedLevels: {});
+      expect(filtered.length, 1);
+    });
+
+    test('getFiltered with matching prefix returns entry', () {
+      final buffer = SessionLogBuffer.instance;
+      buffer.add(LogEvent(Level.info, 'logic: test'));
+      final filtered = buffer.getFiltered(
+        selectedPrefixes: {'logic'},
+        selectedLevels: {Level.info},
+      );
+      expect(filtered.length, 1);
+    });
+
+    test('getFiltered with non-matching prefix returns empty', () {
+      final buffer = SessionLogBuffer.instance;
+      buffer.add(LogEvent(Level.info, 'logic: test'));
+      final filtered = buffer.getFiltered(
+        selectedPrefixes: {'ai'},
+        selectedLevels: {Level.info},
+      );
+      expect(filtered, isEmpty);
+    });
+
+    test('getFiltered with non-matching level returns empty', () {
+      final buffer = SessionLogBuffer.instance;
+      buffer.add(LogEvent(Level.debug, 'logic: test'));
+      final filtered = buffer.getFiltered(
+        selectedPrefixes: {'logic'},
+        selectedLevels: {Level.error},
+      );
+      expect(filtered, isEmpty);
+    });
+
+    test('displayLines include error and stackTrace when present', () {
+      final buffer = SessionLogBuffer.instance;
+      final err = StateError('oops');
+      final stack = StackTrace.current;
+      buffer.add(LogEvent(Level.error, 'save: failed',
+          error: err, stackTrace: stack));
+      final filtered = buffer.getFiltered();
+      expect(filtered.length, 1);
+      final lines = filtered.first.displayLines;
+      expect(lines.length, greaterThanOrEqualTo(2));
+      expect(lines.any((l) => l.contains('error:')), isTrue);
+    });
+
+    test('buffer is bounded when over maxEntries', () {
+      final buffer = SessionLogBuffer(maxEntries: 5);
+      for (var i = 0; i < 10; i++) {
+        buffer.add(LogEvent(Level.debug, 'log: $i'));
+      }
+      final entries = buffer.entries;
+      expect(entries.length, 5);
+      expect(entries.first.message, contains('5'));
+      expect(entries.last.message, contains('9'));
+    });
+
+    test('resetForTest clears entries', () {
+      final buffer = SessionLogBuffer.instance;
+      buffer.add(LogEvent(Level.info, 'x: test'));
+      expect(buffer.entries.length, 1);
+      SessionLogBuffer.resetForTest();
+      expect(SessionLogBuffer.instance.entries, isEmpty);
+    });
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -476,10 +476,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ workspace:
   - widgetbook_host
   - ctdev
   - ctterm
+  - packages/session_log_buffer
   - packages/colonizethis_models
   - packages/colonizethis_data
   - packages/colonizethis_save


### PR DESCRIPTION
Implements the debug log viewer per **SPEC/program/debug-log-viewer.md**.

## Summary
- **Session log buffer** (`packages/session_log_buffer`): In-memory buffer (bounded), `getFiltered(selectedPrefixes, selectedLevels)`, `init()` registers `Logger.addLogListener`. Known prefixes: ctdev, logic, ai, data, map, save, tui.
- **Flutter app**: Entry from **View → Debug log** (macOS menubar) and from **in-game pause menu → Debug log**. Full-screen viewer with multiselect filter chips (package + level) and scrollable log list.
- **Ctterm**: Entry from **Main Menu [D] Debug log** and **Pause/Options → Debug log**. TUI viewer (screen 100020) with [B] Back, [W/S] scroll, [1–7] package toggle, [D/I/W/E] level toggle.
- Coexists with existing Sim Log; session-only, no persistence.

## Tests
- `session_log_buffer`: 8 unit tests (add, getFiltered, displayLines, bounded, reset).
- App: 4 widget tests (title/close, filter chips, close pops route, session entries).
- Ctterm: 2 tests (DebugLogViewerScreen onBack, PauseOptionsScreen navigates to viewer).

## Spec updates
- `SPEC/program/debug-log-viewer.md` (new)
- `SPEC/tui/ctterm.md`: screen ID 100020, screens table row
- `SPEC/tui/screens/pause-options.md`: Debug log menu item + AC

Made with [Cursor](https://cursor.com)