### PR TITLE
refactor(logic): dedup validation results, province iteration, player lookup

### DIFF
--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
@@ -4,6 +4,7 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../combat/military_strength.dart';
+import '../world/province_lookup.dart';
 
 /// Overture costs per diplomacy-resolution. Consulate £500, Embassy £1000.
 const int overtureConsulateCost = 500;
@@ -15,11 +16,8 @@ const int joinEmpirePerProvinceCost = 2000;
 
 /// Returns the number of provinces owned by [factionId] (Minor or Tribe) in [game].
 int provinceCountOwnedBy(Game game, String factionId) {
-  int count = 0;
-  for (final p in game.worldState.oldWorld.provinces) {
-    if (p.ownerId == factionId) count++;
-  }
-  for (final p in game.worldState.newWorld.provinces) {
+  var count = 0;
+  for (final p in allProvinces(game.worldState)) {
     if (p.ownerId == factionId) count++;
   }
   return count;
@@ -173,14 +171,6 @@ bool canAttackWithWarOrDeclaring(
       o.type == DiplomaticOrderType.declareWar &&
       o.targetFactionId == targetOwnerId);
   return atWar || declaringWarThisTurn;
-}
-
-/// Returns player by id, or null.
-Player? getPlayer(Game game, String playerId) {
-  for (final p in game.players) {
-    if (p.id == playerId) return p;
-  }
-  return null;
 }
 
 /// Diplomatic history events involving both [factionA] and [factionB], newest first.

--- a/packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
+++ b/packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
@@ -7,6 +7,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../world/movement.dart';
+import '../world/province_lookup.dart';
 import 'evidence_rules.dart';
 
 /// Era names for dialogue (SPEC/ai/dialogue-and-mood.md: discovery | earlyModern | imperial | industrial).
@@ -118,10 +119,7 @@ List<String> neighborProvinceLocalIds(MapTopology topology, String regionId, Str
 }
 
 String? _ownerOfProvince(Game game, String fullProvinceId) {
-  for (final p in game.worldState.oldWorld.provinces) {
-    if (p.id == fullProvinceId) return p.ownerId;
-  }
-  for (final p in game.worldState.newWorld.provinces) {
+  for (final p in allProvinces(game.worldState)) {
     if (p.id == fullProvinceId) return p.ownerId;
   }
   return null;

--- a/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+++ b/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
@@ -5,6 +5,7 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
 
+import '../constants.dart';
 import '../diplomacy/diplomacy_relation_lookup.dart';
 
 final _log = Logger();
@@ -22,14 +23,14 @@ List<String> _humanObserverIds(Game game) {
 bool isAiControlledForEvidence(Game game, String playerId) {
   final explicit = game.aiControlByGpId[playerId];
   if (explicit != null) return explicit;
-  final p = getPlayer(game, playerId);
+  final p = game.playerById(playerId);
   return p != null && !p.isHuman;
 }
 
 /// Returns true if [targetId] is a weaker GP than [actorId] by military level (for warmonger evidence).
 bool _isWeakerGp(Game game, String actorId, String targetId) {
-  final actor = getPlayer(game, actorId);
-  final target = getPlayer(game, targetId);
+  final actor = game.playerById(actorId);
+  final target = game.playerById(targetId);
   if (actor == null || target == null) return false;
   final aLevel = actor.militaryLevel ?? 0;
   final tLevel = target.militaryLevel ?? 0;
@@ -49,7 +50,7 @@ List<DossierEvidenceEntry> evidenceForDeclareWar(
 
   final rel = getRelation(game, actorGpId, targetFactionId);
   final wasAllied = rel != null && rel.level == RelationLevel.allied;
-  final targetIsGp = getPlayer(game, targetFactionId) != null;
+  final targetIsGp = game.playerById(targetFactionId) != null;
   final weaker = targetIsGp && _isWeakerGp(game, actorGpId, targetFactionId);
 
   final entries = <DossierEvidenceEntry>[];
@@ -119,7 +120,7 @@ List<DossierEvidenceEntry> evidenceForLandBattleVictory(
   final observers = _humanObserverIds(game);
   if (observers.isEmpty) return [];
 
-  final targetIsGp = getPlayer(game, defenderFactionId) != null;
+  final targetIsGp = game.playerById(defenderFactionId) != null;
   final weaker = targetIsGp && _isWeakerGp(game, victorGpId, defenderFactionId);
   final scoreDelta = weaker ? 2 : 1;
 

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -116,8 +116,7 @@ class OrderEngine {
     _log.d('logic: validating orders with context player=$playerId');
     final results = validatePlayerOrdersWithContext(game, topology, playerId);
     if (results.isEmpty) {
-      return const OrderValidationResult(
-          status: OrderValidationStatus.accepted);
+      return OrderValidationResult.accepted();
     }
     final r = results.last;
     if (!r.isAccepted)
@@ -223,7 +222,7 @@ class OrderEngine {
     _OrderSlot<T> slot,
   ) {
     _appendOrder(playerId, order, slot.getter, slot.updater);
-    return const OrderValidationResult(status: OrderValidationStatus.accepted);
+    return OrderValidationResult.accepted();
   }
 
   OrderValidationResult _addOrderWithContextSlot<T>(

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -312,10 +312,7 @@ List<WorkOrder> suggestWorkOrders(
       if (allowedTargets != null && allowedTargets.contains('purchase_land')) {
         final resourceByTile = game.worldState.resourceByTileKey;
         final playerIds = game.players.map((p) => p.id).toSet();
-        for (final p in [
-          ...game.worldState.oldWorld.provinces,
-          ...game.worldState.newWorld.provinces
-        ]) {
+        for (final p in allProvinces(game.worldState)) {
           if (p.ownerId == null || playerIds.contains(p.ownerId!)) continue;
           final regionId = p.regionId;
           final tiles = tileKeysByRegion[regionId]?[p.id] ?? const [];

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_helpers.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../diplomacy/diplomacy_resolver.dart';
+import '../world/province_lookup.dart';
 
 /// Shared helpers for order suggestion. SPEC/ai/ai-architecture.md.
 /// Used by order_suggestion and AI planners.
@@ -9,13 +10,7 @@ import '../diplomacy/diplomacy_resolver.dart';
 /// Used by AI to filter move orders by diplomacy.
 Map<String, String> getProvinceOwnerMap(Game game) {
   final out = <String, String>{};
-  for (final p in game.worldState.oldWorld.provinces) {
-    if (p.ownerId != null && p.ownerId!.isNotEmpty) {
-      final key = ProvinceId.full(p.regionId, ProvinceId.localIdFrom(p.id));
-      out[key] = p.ownerId!;
-    }
-  }
-  for (final p in game.worldState.newWorld.provinces) {
+  for (final p in allProvinces(game.worldState)) {
     if (p.ownerId != null && p.ownerId!.isNotEmpty) {
       final key = ProvinceId.full(p.regionId, ProvinceId.localIdFrom(p.id));
       out[key] = p.ownerId!;

--- a/packages/colonizethis_logic/lib/src/orders/order_validation_result.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_validation_result.dart
@@ -14,6 +14,16 @@ class OrderValidationResult {
   final String? reason;
 
   bool get isAccepted => status == OrderValidationStatus.accepted;
+
+  /// Factory for rejected result with optional reason.
+  factory OrderValidationResult.rejected(String reason) =>
+      OrderValidationResult(status: OrderValidationStatus.rejected, reason: reason);
+
+  /// Factory for accepted result.
+  factory OrderValidationResult.accepted() => _accepted;
+
+  static const _accepted =
+      OrderValidationResult(status: OrderValidationStatus.accepted);
 }
 
 /// Shared constant result used when a previous order in the sequence

--- a/packages/colonizethis_logic/lib/src/orders/validators/build_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/build_order_validator.dart
@@ -35,10 +35,7 @@ class BuildOrderValidator {
       previousRejected: previousRejected,
       body: () {
         if (_player.capitalProvinceId == null) {
-          return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'No capital to spawn unit',
-          );
+          return OrderValidationResult.rejected('No capital to spawn unit');
         }
 
         final check = canAffordBuild(
@@ -49,9 +46,8 @@ class BuildOrderValidator {
           _treasury,
         );
         if (!check.canAfford) {
-          return OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: check.reason ?? 'Insufficient resources',
+          return OrderValidationResult.rejected(
+            check.reason ?? 'Insufficient resources',
           );
         }
 
@@ -65,9 +61,7 @@ class BuildOrderValidator {
         _workers = after.workers;
         _stockpile = after.stockpile;
         _treasury = after.treasury;
-        return const OrderValidationResult(
-          status: OrderValidationStatus.accepted,
-        );
+        return OrderValidationResult.accepted();
       },
     );
   }

--- a/packages/colonizethis_logic/lib/src/orders/validators/diplomatic_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/diplomatic_order_validator.dart
@@ -26,15 +26,12 @@ class DiplomaticOrderValidator {
   int get treasury => _treasury;
 
   ({OrderValidationResult result, int treasury}) _reject(String reason) => (
-        result: OrderValidationResult(
-          status: OrderValidationStatus.rejected,
-          reason: reason,
-        ),
+        result: OrderValidationResult.rejected(reason),
         treasury: _treasury,
       );
 
   ({OrderValidationResult result, int treasury}) _accept() => (
-        result: const OrderValidationResult(status: OrderValidationStatus.accepted),
+        result: OrderValidationResult.accepted(),
         treasury: _treasury,
       );
 

--- a/packages/colonizethis_logic/lib/src/orders/validators/move_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/move_validator.dart
@@ -25,8 +25,7 @@ class MoveValidator {
   ) {
     final unit = unitsById[order.unitId];
     if (unit == null || unit.ownerId != playerId) {
-      return const OrderValidationResult(
-          status: OrderValidationStatus.rejected, reason: 'Invalid move');
+      return OrderValidationResult.rejected('Invalid move');
     }
     final unitRegion = unit.tileKey != null && unit.tileKey!.isNotEmpty
         ? Unit.requireRegionIdFromTileKey(unit.tileKey)
@@ -40,16 +39,14 @@ class MoveValidator {
     // Movement within own provinces: always allowed. SPEC/program/movement.md.
     final moveToOwnProvince = destOwnerId == playerId;
     if (!moveToOwnProvince && destRegion != unitRegion) {
-      return const OrderValidationResult(
-          status: OrderValidationStatus.rejected, reason: 'Invalid move');
+      return OrderValidationResult.rejected('Invalid move');
     }
     if (!moveToOwnProvince) {
       final unitLocalId = ProvinceId.localIdFrom(unit.locationProvinceId);
       final destLocalId = ProvinceId.localIdFrom(destFullId);
       if (!isValidLandMoveInRegion(
           topology, unitRegion, unitLocalId, destLocalId)) {
-        return const OrderValidationResult(
-            status: OrderValidationStatus.rejected, reason: 'Invalid move');
+        return OrderValidationResult.rejected('Invalid move');
       }
     }
 
@@ -58,17 +55,15 @@ class MoveValidator {
         destOwnerId != null &&
         destOwnerId != playerId) {
       if (isGreatPower(game, destOwnerId) && !isSpyUnit(unit.type)) {
-        return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Civilian cannot enter other Great Power territory');
+        return OrderValidationResult.rejected(
+            'Civilian cannot enter other Great Power territory');
       }
       if (isMinorOrTribe(game, destOwnerId) &&
           !isExplorerUnit(unit.type) &&
           !isMerchantUnit(unit.type) &&
           !isSpyUnit(unit.type)) {
-        return const OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: 'Civilian cannot enter Minor/Tribe territory');
+        return OrderValidationResult.rejected(
+            'Civilian cannot enter Minor/Tribe territory');
       }
     }
 
@@ -77,9 +72,8 @@ class MoveValidator {
         destOwnerId != playerId &&
         isGreatPower(game, destOwnerId) &&
         !canAttackWithWarOrDeclaring(game, playerId, destOwnerId, diplomaticOrders)) {
-      return const OrderValidationResult(
-        status: OrderValidationStatus.rejected,
-        reason: 'Must declare war before attacking Great Power province',
+      return OrderValidationResult.rejected(
+        'Must declare war before attacking Great Power province',
       );
     }
 
@@ -89,20 +83,17 @@ class MoveValidator {
         isMinorOrTribe(game, destOwnerId) &&
         isMilitaryUnit(unit.type) &&
         !canAttackWithWarOrDeclaring(game, playerId, destOwnerId, diplomaticOrders)) {
-      return const OrderValidationResult(
-        status: OrderValidationStatus.rejected,
-        reason:
-            'Must declare war before attacking Minor Nation or Tribe province',
+      return OrderValidationResult.rejected(
+        'Must declare war before attacking Minor Nation or Tribe province',
       );
     }
 
     if (!moveSourceVisibilityOk(view, unitRegion, unit.locationProvinceId) ||
         !moveDestVisibilityOk(
             view, destRegion, order.destinationProvinceId, unit.type)) {
-      return const OrderValidationResult(
-          status: OrderValidationStatus.rejected,
-          reason: 'Source or destination not visible');
+      return OrderValidationResult.rejected(
+          'Source or destination not visible');
     }
-    return const OrderValidationResult(status: OrderValidationStatus.accepted);
+    return OrderValidationResult.accepted();
   }
 }

--- a/packages/colonizethis_logic/lib/src/orders/validators/naval_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/naval_order_validator.dart
@@ -34,9 +34,8 @@ class NavalOrderValidator {
         final fleet = _fleetById[o.fleetId];
         final homeFleetId = homeFleetIdFor(_playerId);
         if (fleet == null || fleet.ownerId != _playerId || fleet.id == homeFleetId) {
-          return OrderValidationResult(
-            status: OrderValidationStatus.rejected,
-            reason: fleet == null ? 'Fleet not found' : 'Invalid naval move',
+          return OrderValidationResult.rejected(
+            fleet == null ? 'Fleet not found' : 'Invalid naval move',
           );
         }
 
@@ -44,32 +43,26 @@ class NavalOrderValidator {
           // Dock: fleet must be at sea; current sea zone adjacent to province; province owned by player. SPEC/game/ships-and-naval.md.
           final portProvinceId = o.destinationPortProvinceId!;
           if (!fleet.isAtSea || fleet.seaZoneId == null) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'Dock only allowed when fleet is at sea',
+            return OrderValidationResult.rejected(
+              'Dock only allowed when fleet is at sea',
             );
           }
           final fullProvinceId =
               toFullProvinceId(fleet.regionId, portProvinceId);
           final province = tryGetProvince(_game.worldState, fullProvinceId);
           if (province == null) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'Port province not found',
-            );
+            return OrderValidationResult.rejected('Port province not found');
           }
           if (province.ownerId != _playerId) {
-            return const OrderValidationResult(
-              status: OrderValidationStatus.rejected,
-              reason: 'Can only dock at own province',
+            return OrderValidationResult.rejected(
+              'Can only dock at own province',
             );
           }
           final adjacentSeaZones = seaZoneIdsAdjacentToProvince(_topology, fullProvinceId);
           final valid = adjacentSeaZones.contains(fleet.seaZoneId);
-          return OrderValidationResult(
-            status: valid ? OrderValidationStatus.accepted : OrderValidationStatus.rejected,
-            reason: valid ? null : 'Invalid naval move',
-          );
+          return valid
+              ? OrderValidationResult.accepted()
+              : OrderValidationResult.rejected('Invalid naval move');
         }
 
         // Move to sea zone: destination must be adjacent.
@@ -79,8 +72,7 @@ class NavalOrderValidator {
         } else {
           final inPortProvinceId = fleet.inPortAtProvinceId;
           if (inPortProvinceId == null) {
-            return const OrderValidationResult(
-                status: OrderValidationStatus.rejected, reason: 'Invalid naval move');
+            return OrderValidationResult.rejected('Invalid naval move');
           }
           final parts = inPortProvinceId.split('|');
           final regionId = parts.isNotEmpty ? parts.first : fleet.regionId;
@@ -92,10 +84,9 @@ class NavalOrderValidator {
             destZone != null &&
             destZone.isNotEmpty &&
             (currentZone == destZone || isAdjacentSeaZone(_topology, currentZone, destZone));
-        return OrderValidationResult(
-          status: valid ? OrderValidationStatus.accepted : OrderValidationStatus.rejected,
-          reason: valid ? null : 'Invalid naval move',
-        );
+        return valid
+            ? OrderValidationResult.accepted()
+            : OrderValidationResult.rejected('Invalid naval move');
       },
     );
   }
@@ -143,12 +134,9 @@ class NavalOrderValidator {
           }
         }
 
-        return OrderValidationResult(
-          status: valid
-              ? OrderValidationStatus.accepted
-              : OrderValidationStatus.rejected,
-          reason: rejectReason,
-        );
+        return valid
+            ? OrderValidationResult.accepted()
+            : OrderValidationResult.rejected(rejectReason ?? 'Invalid naval mission');
       },
     );
   }

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
@@ -55,11 +55,6 @@ class WorkOrderValidator {
       target == 'build_fort' ||
       target == 'purchase_land';
 
-  OrderValidationResult _reject(String reason) => OrderValidationResult(
-        status: OrderValidationStatus.rejected,
-        reason: reason,
-      );
-
   /// Validates one [WorkOrder]. When accepted, deducts cost from internal
   /// stockpile/treasury and may add to [devExclusiveTiles]. Caller should sync
   /// stockpile/treasury back after the work loop.
@@ -72,17 +67,17 @@ class WorkOrderValidator {
       body: () {
         final unit = _unitsById[o.unitId];
         if (unit == null || unit.ownerId != _playerId) {
-          return _reject('Unit not found');
+          return OrderValidationResult.rejected('Unit not found');
         }
         if (unit.currentWork != null) {
-          return _reject('Unit already has a work order; cancel first');
+          return OrderValidationResult.rejected('Unit already has a work order; cancel first');
         }
         final type = unit.type;
         if (!isWorkOrderTargetAllowedForUnitType(type, o.target)) {
-          return _reject('Invalid work target for unit type');
+          return OrderValidationResult.rejected('Invalid work target for unit type');
         }
         if (o.targetTileKey.isEmpty) {
-          return _reject('Work order requires a target tile');
+          return OrderValidationResult.rejected('Work order requires a target tile');
         }
 
         final targetProvinceId = Unit.provinceIdFromTileKey(o.targetTileKey);
@@ -93,14 +88,14 @@ class WorkOrderValidator {
 
         if (o.target == 'steal_tech') {
           if (targetProvinceId == null) {
-            return _reject('Invalid target for steal_tech');
+            return OrderValidationResult.rejected('Invalid target for steal_tech');
           }
           final otherPlayer = _game.players
               .where((p) =>
                   p.id != _playerId && p.capitalProvinceId == targetProvinceId)
               .firstOrNull;
           if (otherPlayer == null) {
-            return _reject(
+            return OrderValidationResult.rejected(
                 'steal_tech target must be another Great Power capital province');
           }
           final ourTech = _player.techUnlocked ?? {};
@@ -108,21 +103,21 @@ class WorkOrderValidator {
           final hasTechWeLack = theirTech.entries
               .any((e) => e.value == true && ourTech[e.key] != true);
           if (!hasTechWeLack) {
-            return _reject('Target has no technology you lack');
+            return OrderValidationResult.rejected('Target has no technology you lack');
           }
         } else if (o.target == 'counter_spy') {
           if (ownerId != _playerId) {
-            return _reject('counter_spy target must be your own province');
+            return OrderValidationResult.rejected('counter_spy target must be your own province');
           }
         } else if (o.target == 'purchase_land') {
           if (ownerId == null || ownerId == _playerId) {
-            return _reject(
+            return OrderValidationResult.rejected(
                 'purchase_land target must be a Minor or Tribe province');
           }
           final isMinor = _game.minorNations.any((m) => m.id == ownerId);
           final isTribe = _game.tribes.any((t) => t.id == ownerId);
           if (!isMinor && !isTribe) {
-            return _reject(
+            return OrderValidationResult.rejected(
                 'purchase_land target must be a Minor or Tribe province');
           }
           final rel = _game.diplomacyRelations
@@ -131,35 +126,35 @@ class WorkOrderValidator {
                   (r.factionId2 == _playerId && r.factionId1 == ownerId))
               .firstOrNull;
           if (rel != null && rel.atWar) {
-            return _reject('Cannot purchase land: at war with that faction');
+            return OrderValidationResult.rejected('Cannot purchase land: at war with that faction');
           }
           final overture = _game.overtureStates
               .where((ov) => ov.gpId == _playerId && ov.targetId == ownerId)
               .firstOrNull;
           if (overture == null || !overture.hasEmbassy) {
-            return _reject(
+            return OrderValidationResult.rejected(
                 'Cannot purchase land: embassy required with that Minor/Tribe');
           }
           final resourceId = _game.worldState.resourceByTileKey[o.targetTileKey];
           if (resourceId == null || resourceId.isEmpty) {
-            return _reject('Tile has no resource');
+            return OrderValidationResult.rejected('Tile has no resource');
           }
           if (kMineralResourceIds.contains(resourceId)) {
             final prospected =
                 _game.worldState.playerProspectedTiles[_playerId] ?? const <String>{};
             if (!prospected.contains(o.targetTileKey)) {
-              return _reject('Mineral tile must be prospected first');
+              return OrderValidationResult.rejected('Mineral tile must be prospected first');
             }
           }
           final cost = purchaseLandCost(resourceId);
           if (_treasury < cost) {
-            return _reject(
+            return OrderValidationResult.rejected(
                 'Insufficient treasury for purchase_land (need $cost)');
           }
           final existingBuyer =
               _game.worldState.purchasedTilesByTileKey[o.targetTileKey];
           if (existingBuyer != null) {
-            return _reject(existingBuyer == _playerId
+            return OrderValidationResult.rejected(existingBuyer == _playerId
                 ? 'You already own this tile'
                 : 'Tile already purchased by another power');
           }
@@ -167,36 +162,36 @@ class WorkOrderValidator {
           final controlled =
               isTileControlledByPlayer(_game, _playerId, o.targetTileKey);
           if (!controlled) {
-            return _reject(
+            return OrderValidationResult.rejected(
                 'Cannot build improvement in foreign or uncontrolled province');
           }
           final resourceId = _game.worldState.resourceByTileKey[o.targetTileKey];
           if (resourceId == null || resourceId.isEmpty) {
-            return _reject(
+            return OrderValidationResult.rejected(
                 'Tile has no resource; build_improvement requires a resource on the tile');
           }
           final currentLevel =
               _game.worldState.tileState.improvementLevel(o.targetTileKey);
           if (currentLevel >= 4) {
-            return _reject('Improvement level already at maximum (4)');
+            return OrderValidationResult.rejected('Improvement level already at maximum (4)');
           }
           final techCap = extractionCapForUnlocked(_player.techUnlocked);
           if (currentLevel + 1 > techCap) {
-            return _reject(
+            return OrderValidationResult.rejected(
                 'Insufficient tech to build next improvement level (cap $techCap)');
           }
         } else if (!isExplorerUnit(type)) {
           final controlled =
               isTileControlledByPlayer(_game, _playerId, o.targetTileKey);
           if (!controlled) {
-            return _reject('Cannot work in foreign province');
+            return OrderValidationResult.rejected('Cannot work in foreign province');
           }
         }
 
         if (isDevExclusiveUnitType(type) &&
             _isDevExclusiveTarget(o.target) &&
             _devExclusiveTiles.contains(o.targetTileKey)) {
-          return _reject(
+          return OrderValidationResult.rejected(
               'Tile already has development or purchase work for this player');
         }
 
@@ -212,19 +207,19 @@ class WorkOrderValidator {
             final hasRoadConstruction =
                 _player.techUnlocked?['road_construction'] == true;
             if (!hasRoadConstruction) {
-              return _reject(
+              return OrderValidationResult.rejected(
                   'Road Construction tech required for transport level 2');
             }
           }
           if (o.target == 'build_fort') {
             if (fortLevel == 1 &&
                 _player.techUnlocked?['mine_engineering'] != true) {
-              return _reject(
+              return OrderValidationResult.rejected(
                   'Mine Engineering tech required for fort level 2');
             }
             if (fortLevel == 2 &&
                 _player.techUnlocked?['modern_forts'] != true) {
-              return _reject('Modern Forts tech required for fort level 3');
+              return OrderValidationResult.rejected('Modern Forts tech required for fort level 3');
             }
           }
           final costMap = WorkOrderCostCalculator(_game).calculateCost(
@@ -237,14 +232,14 @@ class WorkOrderValidator {
           if (costMap != null) {
             for (final entry in costMap.entries) {
               if (_stockpile.quantityOf(entry.key) < entry.value) {
-                return _reject('Insufficient materials for work order');
+                return OrderValidationResult.rejected('Insufficient materials for work order');
               }
             }
           }
         }
 
         if (!workOrderVisibilityOk(_view, unit, o.target, o.targetTileKey)) {
-          return _reject('Province or tile not visible for this work');
+          return OrderValidationResult.rejected('Province or tile not visible for this work');
         }
 
         if (isDevExclusiveUnitType(type) && _isDevExclusiveTarget(o.target)) {
@@ -276,9 +271,7 @@ class WorkOrderValidator {
           }
         }
 
-        return const OrderValidationResult(
-          status: OrderValidationStatus.accepted,
-        );
+        return OrderValidationResult.accepted();
       },
     );
   }

--- a/packages/colonizethis_logic/lib/src/setup/initial_visibility.dart
+++ b/packages/colonizethis_logic/lib/src/setup/initial_visibility.dart
@@ -6,6 +6,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
 import '../world/player_view.dart';
+import '../world/province_lookup.dart';
 
 /// Applies initial visibility and tile metadata to [game] using [tileMapByRegion].
 /// Own provinces: fullyVisible (OW) or unknown (NW). Others: fogged (OW).
@@ -18,11 +19,9 @@ Game applyInitialVisibility({
   final nwMap = tileMapByRegion[kRegionNewWorld];
   if (owMap == null || nwMap == null) return game;
 
-  final owOwnerById = <String, String?>{
-    for (final p in game.worldState.oldWorld.provinces) p.id: p.ownerId,
-  };
-  final nwOwnerById = <String, String?>{
-    for (final p in game.worldState.newWorld.provinces) p.id: p.ownerId,
+  final ownerById = <String, String?>{
+    for (final p in allProvinces(game.worldState))
+      ProvinceId.full(p.regionId, ProvinceId.localIdFrom(p.id)): p.ownerId,
   };
 
   final playerVisibilityByTile = <String, Map<String, String>>{};
@@ -37,7 +36,7 @@ Game applyInitialVisibility({
     for (var x = 0; x < owMap.width; x++) {
       final localId = owMap.cell(x, y);
       final fullId = ProvinceId.full(kRegionOldWorld, localId);
-      final ownerId = owOwnerById[fullId];
+      final ownerId = ownerById[fullId];
       if (ownerId == null) continue;
       final tileKey = '$kRegionOldWorld|$localId|$x|$y';
       tileKeysByRegionAndProvince[kRegionOldWorld]!
@@ -51,7 +50,7 @@ Game applyInitialVisibility({
     for (var x = 0; x < nwMap.width; x++) {
       final localId = nwMap.cell(x, y);
       final fullId = ProvinceId.full(kRegionNewWorld, localId);
-      final ownerId = nwOwnerById[fullId];
+      final ownerId = ownerById[fullId];
       if (ownerId == null) continue;
       final tileKey = '$kRegionNewWorld|$localId|$x|$y';
       tileKeysByRegionAndProvince[kRegionNewWorld]!
@@ -70,7 +69,7 @@ Game applyInitialVisibility({
       for (var x = 0; x < owMap.width; x++) {
         final localId = owMap.cell(x, y);
         final fullId = ProvinceId.full(kRegionOldWorld, localId);
-        final ownerId = owOwnerById[fullId];
+        final ownerId = ownerById[fullId];
         if (ownerId == null) continue;
         final tileKey = '$kRegionOldWorld|$localId|$x|$y';
         visibility[tileKey] =

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -409,9 +409,7 @@ void _filterOrderList<T>(
 ) {
   for (final order in orders) {
     final r = idxBox[0] >= results.length
-        ? const OrderValidationResult(
-            status: OrderValidationStatus.accepted,
-          )
+        ? OrderValidationResult.accepted()
         : results[idxBox[0]++];
     if (r.isAccepted) {
       addAccepted(playerId, order);
@@ -690,8 +688,7 @@ Game _runMovementPhase(
   if (moveOrders.isNotEmpty) {
     // Province ownership lookup for Spy timers (other-faction only).
     final ownerByProvinceId = <String, String?>{
-      for (final p in state.worldState.oldWorld.provinces) p.id: p.ownerId,
-      for (final p in state.worldState.newWorld.provinces) p.id: p.ownerId,
+      for (final p in allProvinces(state.worldState)) p.id: p.ownerId,
     };
     // Movement within own provinces: no adjacency and no region restriction. SPEC/program/movement.md.
     bool isDestinationOwnedByPlayer(

--- a/packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
+++ b/packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
@@ -76,8 +76,7 @@ Game applyGreatPowerFall(
   var game = state;
 
   final provinceOwnerById = <String, String?>{
-    for (final p in game.worldState.oldWorld.provinces) p.id: p.ownerId,
-    for (final p in game.worldState.newWorld.provinces) p.id: p.ownerId,
+    for (final p in allProvinces(game.worldState)) p.id: p.ownerId,
   };
 
   final portsByProvince = <String, List<String>>{};

--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -182,10 +182,7 @@ bool _isCapitalTileOnSeaboard(
 
 Set<String> _ownedProvinceIdsForPlayer(Game game, String playerId) {
   final owned = <String>{};
-  for (final p in game.worldState.oldWorld.provinces) {
-    if (p.ownerId == playerId) owned.add(p.id);
-  }
-  for (final p in game.worldState.newWorld.provinces) {
+  for (final p in allProvinces(game.worldState)) {
     if (p.ownerId == playerId) owned.add(p.id);
   }
   return owned;

--- a/packages/colonizethis_logic/lib/src/world/fog_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/fog_resolution.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
 import 'player_view.dart';
+import 'province_lookup.dart';
 import 'unit_lookup.dart';
 
 /// Spy 5-turn fog decay: decrement timers; when they expire, set other-faction
@@ -19,8 +20,7 @@ import 'unit_lookup.dart';
 
   // Province ownership lookup so we can ensure timers only affect other-faction provinces.
   final ownerByProvinceId = <String, String?>{
-    for (final p in world.oldWorld.provinces) p.id: p.ownerId,
-    for (final p in world.newWorld.provinces) p.id: p.ownerId,
+    for (final p in allProvinces(world)) p.id: p.ownerId,
   };
 
   final nextSpyTimers = <String, Map<String, int>>{};
@@ -60,11 +60,8 @@ import 'unit_lookup.dart';
 /// SPEC/program/fog-and-exploration-resolution.md.
 Map<String, Map<String, String>> applyFogDecay(Game game) {
   const explorerTypes = {'explorer', 'spy'};
-  final owOwnerByProvince = {
-    for (final p in game.worldState.oldWorld.provinces) p.id: p.ownerId,
-  };
-  final nwOwnerByProvince = {
-    for (final p in game.worldState.newWorld.provinces) p.id: p.ownerId,
+  final ownerByProvince = <String, String?>{
+    for (final p in allProvinces(game.worldState)) p.id: p.ownerId,
   };
 
   final provincesWithExplorerByPlayer = <String, Set<String>>{};
@@ -94,8 +91,7 @@ Map<String, Map<String, String>> applyFogDecay(Game game) {
       final parts = tileKey.split('|');
       if (parts.length != 4) continue;
       final fullProvinceId = ProvinceId.full(parts[0], parts[1]);
-      final ownerId =
-          owOwnerByProvince[fullProvinceId] ?? nwOwnerByProvince[fullProvinceId];
+      final ownerId = ownerByProvince[fullProvinceId];
       if (ownerId == null || ownerId == playerId) continue;
       if (!hasExplorerIn.contains(fullProvinceId) &&
           !hasSpyTimerIn.contains(fullProvinceId)) {

--- a/packages/colonizethis_logic/lib/src/world/player_view.dart
+++ b/packages/colonizethis_logic/lib/src/world/player_view.dart
@@ -84,10 +84,7 @@ PlayerView buildPlayerView(
 
   // Provinces: key by full id (p.id is regionId|localId).
   final provincesById = <String, Province>{};
-  for (final p in game.worldState.oldWorld.provinces) {
-    provincesById[toFullProvinceId(p.regionId, p.id)] = p;
-  }
-  for (final p in game.worldState.newWorld.provinces) {
+  for (final p in allProvinces(game.worldState)) {
     provincesById[toFullProvinceId(p.regionId, p.id)] = p;
   }
 

--- a/packages/colonizethis_logic/lib/src/world/province_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/world/province_lookup.dart
@@ -25,6 +25,13 @@ Province? _findProvinceInRegion(
 RegionData? regionDataForId(WorldState world, String regionId) =>
     _regionForId(world, regionId);
 
+/// All provinces in both regions (old world first, then new world).
+/// Use when iterating over every province without needing region separation.
+Iterable<Province> allProvinces(WorldState world) sync* {
+  yield* world.oldWorld.provinces;
+  yield* world.newWorld.provinces;
+}
+
 /// Central province lookup. Lookup is by **full disambiguated id** (`regionId|localId`)
 /// and is **region-scoped**: resolution happens only within the given region.
 /// SPEC/game/world-model-identity.md.

--- a/packages/colonizethis_logic/test/diplomacy_resolver_test.dart
+++ b/packages/colonizethis_logic/test/diplomacy_resolver_test.dart
@@ -113,7 +113,7 @@ void main() {
       expect(overture, isNotNull);
       expect(overture!.hasEmbassy, isTrue);
       // Treasury reduced by consulate + embassy cost.
-      final player = getPlayer(after, 'gp1')!;
+      final player = after.playerById('gp1')!;
       expect(player.treasury, lessThan(2000));
     });
 
@@ -298,7 +298,7 @@ void main() {
       expect(p1?.ownerId, 'gp1');
       expect(p2?.ownerId, 'gp1');
       // Cost = 5000 + 2*2000 = 9000
-      expect(getPlayer(after, 'gp1')!.treasury, 15000 - 9000);
+      expect(after.playerById('gp1')!.treasury, 15000 - 9000);
     });
 
     test('join empire clears Spy timers for provinces that become owned by GP', () {
@@ -430,7 +430,7 @@ void main() {
           .where((p) => p.id == '$ow|m1')
           .first
           .ownerId, 'minor1');
-      expect(getPlayer(after, 'gp1')!.treasury, 5000);
+      expect(after.playerById('gp1')!.treasury, 5000);
     });
 
     test('grantAid without embassy does not change relation or treasury', () {
@@ -458,7 +458,7 @@ void main() {
       final after = resolveDiplomacyPhase(game, orders).game;
       final rel = getRelation(after, 'gp1', 'minor1')!;
       expect(rel.score, 50);
-      expect(getPlayer(after, 'gp1')!.treasury, 2000);
+      expect(after.playerById('gp1')!.treasury, 2000);
     });
 
     test('setSubsidy to Minor creates ongoing subsidy and deducts initial payment', () {
@@ -493,7 +493,7 @@ void main() {
       );
       final after = resolveDiplomacyPhase(game, orders).game;
       // Initial payment deducted
-      expect(getPlayer(after, 'gp1')!.treasury, 2000 - 500);
+      expect(after.playerById('gp1')!.treasury, 2000 - 500);
       // Ongoing subsidy created
       expect(after.subsidyStates.length, 1);
       expect(after.subsidyStates.first.payerId, 'gp1');
@@ -535,7 +535,7 @@ void main() {
       );
       final after = resolveDiplomacyPhase(game, orders).game;
       // Initial payment deducted from payer
-      expect(getPlayer(after, 'gp1')!.treasury, 800);
+      expect(after.playerById('gp1')!.treasury, 800);
       // Ongoing subsidy created (treasury transfer happens each turn during processing)
       expect(after.subsidyStates.length, 1);
       expect(after.subsidyStates.first.payerId, 'gp1');
@@ -570,7 +570,7 @@ void main() {
       
       // Turn 1: Process ongoing subsidy
       final afterTurn1 = resolveDiplomacyPhase(game, orders).game;
-      expect(getPlayer(afterTurn1, 'gp1')!.treasury, 2000 - 500); // Payment deducted
+      expect(afterTurn1.playerById('gp1')!.treasury, 2000 - 500); // Payment deducted
       final relAfterTurn1 = getRelation(afterTurn1, 'gp1', 'minor1')!;
       expect(relAfterTurn1.score, 51); // +2 subsidy, -1 convergence = +1 net // +2 per 500 ducats
       expect(afterTurn1.subsidyStates.length, 1); // Subsidy still active
@@ -597,7 +597,7 @@ void main() {
       
       final after = resolveDiplomacyPhase(game, orders).game;
       expect(after.subsidyStates, isEmpty); // Subsidy cancelled
-      expect(getPlayer(after, 'gp1')!.treasury, 400); // No deduction
+      expect(after.playerById('gp1')!.treasury, 400); // No deduction
     });
 
     test('ongoing subsidy cancels when war declared', () {
@@ -754,7 +754,7 @@ void main() {
         },
       );
       final after = resolveDiplomacyPhase(game, orders).game;
-      expect(getPlayer(after, 'gp1')!.treasury, 2000);
+      expect(after.playerById('gp1')!.treasury, 2000);
     });
   });
 
@@ -1076,7 +1076,7 @@ void main() {
       expect(result.pendingOvertures!.first.stage, OvertureStage.tradeConsulate);
 
       // Resume with accept: overture should be applied.
-      final gp1Before = getPlayer(game, 'gp1')!;
+      final gp1Before = game.playerById('gp1')!;
       final afterAccept = resolveDiplomacyPhase(
         game,
         orders,
@@ -1093,7 +1093,7 @@ void main() {
       final overture = getOverture(afterAccept.game, 'gp1', 'gp2');
       expect(overture, isNotNull);
       expect(overture!.stage, OvertureStage.tradeConsulate);
-      final gp1After = getPlayer(afterAccept.game, 'gp1')!;
+      final gp1After = afterAccept.game.playerById('gp1')!;
       expect(gp1After.treasury, gp1Before.treasury - overtureConsulateCost);
     });
   });

--- a/packages/colonizethis_logic/test/turn_resolver_test.dart
+++ b/packages/colonizethis_logic/test/turn_resolver_test.dart
@@ -2682,7 +2682,7 @@ void main() {
       expect(overture, isNotNull);
       expect(overture!.hasConsulate, isTrue);
       // Treasury should be reduced by consulate cost.
-      final player = getPlayer(next, 'p1')!;
+      final player = next.playerById('p1')!;
       expect(player.treasury, lessThan(2000));
     });
 


### PR DESCRIPTION
## Summary
Dedup and refactor in the logic package (colonizethis_logic) in three stages. All 722 package tests pass after each stage.

## Changes

### Stage 1: OrderValidationResult factories
- Added `OrderValidationResult.rejected(String reason)` and `OrderValidationResult.accepted()` factory constructors in `order_validation_result.dart`.
- Replaced repeated `OrderValidationResult(status: ..., reason: ...)` and `const OrderValidationResult(status: OrderValidationStatus.accepted)` across:
  - `move_validator`, `build_order_validator`, `naval_order_validator`, `work_order_validator`, `diplomatic_order_validator`
  - `order_engine`, `turn_resolver`
- Removed local `_reject(reason)` helper from `work_order_validator` in favor of the shared factory.

### Stage 2: allProvinces(WorldState) and province iteration dedup
- Added `allProvinces(WorldState world)` in `province_lookup.dart` (sync\* over oldWorld + newWorld provinces).
- Replaced duplicated “loop oldWorld.provinces then newWorld.provinces” patterns with `allProvinces(game.worldState)` in:
  - `order_suggestion_helpers` (getProvinceOwnerMap)
  - `diplomacy_relation_lookup` (provinceCountOwnedBy)
  - `player_view` (buildPlayerView provincesById)
  - `fog_resolution` (owner maps in applySpyRevealTimerDecay and applyFogDecay)
  - `initial_visibility` (ownerById)
  - `capital_and_gp_fall` (provinceOwnerById)
  - `connectivity_resolver` (_ownedProvinceIdsForPlayer)
  - `event_dialogue` (_ownerOfProvince)
  - `turn_resolver` (ownerByProvinceId)
  - `order_suggestion` (purchase_land suggestion loop)

### Stage 3: getPlayer → Game.playerById
- Removed `getPlayer(Game, String)` from `diplomacy_relation_lookup.dart` in favor of the existing `Game.playerById` extension in `constants.dart`.
- Updated `evidence_rules.dart` to use `game.playerById(...)` and added `constants` import.
- Updated tests: `diplomacy_resolver_test.dart` and `turn_resolver_test.dart` to use `game.playerById(...)` / `after.playerById(...)` etc.

## Testing
- `dart test` in `packages/colonizethis_logic`: **722 tests passed** after each stage.