### PR TITLE
refactor(logic): use allProvinces in tests for dual OW/NW loops

### DIFF
--- a/packages/colonizethis_logic/test/characterization/game_setup_snapshot_test.dart
+++ b/packages/colonizethis_logic/test/characterization/game_setup_snapshot_test.dart
@@ -148,17 +148,11 @@ void main() {
     });
 
     test('naming is applied to all provinces', () {
-      for (final p in result.game.worldState.oldWorld.provinces) {
+      for (final p in allProvinces(result.game.worldState)) {
         expect(p.displayName, isNotNull,
-            reason: 'OW ${p.id} must have name');
+            reason: '${p.id} must have name');
         expect(p.displayName, isNotEmpty,
-            reason: 'OW ${p.id} must have non-empty name');
-      }
-      for (final p in result.game.worldState.newWorld.provinces) {
-        expect(p.displayName, isNotNull,
-            reason: 'NW ${p.id} must have name');
-        expect(p.displayName, isNotEmpty,
-            reason: 'NW ${p.id} must have non-empty name');
+            reason: '${p.id} must have non-empty name');
       }
     });
 

--- a/packages/colonizethis_logic/test/game_setup_test.dart
+++ b/packages/colonizethis_logic/test/game_setup_test.dart
@@ -76,11 +76,8 @@ void main() {
 
       // SPEC capital-and-connectivity § Town per province: every province has townTileKey set.
       final gp = result.game.players.first;
-      for (final p in result.game.worldState.oldWorld.provinces) {
-        expect(p.townTileKey, isNotNull, reason: 'OW province ${p.id} must have townTileKey');
-      }
-      for (final p in result.game.worldState.newWorld.provinces) {
-        expect(p.townTileKey, isNotNull, reason: 'NW province ${p.id} must have townTileKey');
+      for (final p in allProvinces(result.game.worldState)) {
+        expect(p.townTileKey, isNotNull, reason: 'province ${p.id} must have townTileKey');
       }
       final capitalProvince = result.game.worldState.oldWorld.provinces.firstWhere((p) => p.id == gp.capitalProvinceId);
       expect(capitalProvince.townTileKey, gp.capitalTile?.toTileKey(), reason: 'Capital province townTileKey must equal capital tile key');
@@ -88,15 +85,12 @@ void main() {
       // Province naming: mandatory; GP capital gets capital city name, others from pool.
       expect(result.game.players.first.displayName, 'England');
       final owProvinces = result.game.worldState.oldWorld.provinces;
-      for (final p in owProvinces) {
-        expect(p.displayName, isNotNull, reason: 'OW province ${p.id} must have displayName');
+      final nwProvinces = result.game.worldState.newWorld.provinces;
+      for (final p in allProvinces(result.game.worldState)) {
+        expect(p.displayName, isNotNull, reason: 'province ${p.id} must have displayName');
       }
       final p1 = owProvinces.firstWhere((p) => p.id == 'oldWorld|p1');
       expect(p1.displayName, 'London');
-      final nwProvinces = result.game.worldState.newWorld.provinces;
-      for (final p in nwProvinces) {
-        expect(p.displayName, isNotNull, reason: 'NW province ${p.id} must have displayName');
-      }
       final nw1 = nwProvinces.firstWhere((p) => p.id == 'newWorld|nw1');
       expect(nw1.displayName, 'Mexica');
       expect(result.game.tribes.first.displayName, 'Aztec');
@@ -623,15 +617,11 @@ void main() {
         gameId: 'fallback-test',
       );
 
-      for (final p in result.game.worldState.oldWorld.provinces) {
-        expect(p.displayName, isNotNull, reason: 'OW ${p.id}');
-        expect(p.displayName!.isNotEmpty, isTrue, reason: 'OW ${p.id}');
+      for (final p in allProvinces(result.game.worldState)) {
+        expect(p.displayName, isNotNull, reason: '${p.id}');
+        expect(p.displayName!.isNotEmpty, isTrue, reason: '${p.id}');
       }
       final nwProvinces = result.game.worldState.newWorld.provinces;
-      for (final p in nwProvinces) {
-        expect(p.displayName, isNotNull, reason: 'NW ${p.id}');
-        expect(p.displayName!.isNotEmpty, isTrue, reason: 'NW ${p.id}');
-      }
       expect(result.game.tribes.length, 11);
       final tribe11 = result.game.tribes.firstWhere((t) => t.id == 'tribe11');
       final tribe11Provinces = nwProvinces.where((p) => p.ownerId == tribe11.id).toList();


### PR DESCRIPTION
## Summary
Deduplicate test code that iterated over `oldWorld.provinces` and `newWorld.provinces` separately when the same assertion applied to all provinces.

## Changes
- **game_setup_test.dart**: Replaced dual OW/NW loops with a single `allProvinces(result.game.worldState)` loop in three places (townTileKey check, displayName checks, fallback naming test).
- **game_setup_snapshot_test.dart**: Replaced dual OW/NW loops in the "naming is applied to all provinces" test with one `allProvinces(result.game.worldState)` loop.

## Notes
- Logic package already had `OrderValidationResult.rejected/accepted` factories, `allProvinces(WorldState)` in `province_lookup`, and `Game.playerById` in use; no further lib dedup was needed.
- `allProvinces` is exported from `colonizethis_logic` via `province_lookup.dart`.
- All colonizethis_logic tests pass (`dart test`).