### PR TITLE
refactor(logic): dedup province iteration in tests, ownership transfer in diplomacy

### DIFF
--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -362,6 +362,19 @@ Game _resolveJoinEmpireColony(
   return game;
 }
 
+List<Province> _transferProvinceOwnership(
+    List<Province> provinces, String fromId, String toId) {
+  return provinces
+      .map((p) => p.ownerId == fromId ? p.copyWith(ownerId: toId) : p)
+      .toList();
+}
+
+List<Unit> _transferUnitOwnership(List<Unit> units, String fromId, String toId) {
+  return units
+      .map((u) => u.ownerId == fromId ? u.copyWith(ownerId: toId) : u)
+      .toList();
+}
+
 /// Transfers all provinces, units, and fleets owned by [targetId] to [gpId],
 /// deducts Join Empire cost from GP treasury, removes the Minor/Tribe and
 /// cleans overtures/relations. SPEC/game/diplomacy.md.
@@ -375,20 +388,16 @@ Game _absorbMinorOrTribeIntoGp(Game game, String gpId, String targetId, int turn
   }
 
   // Transfer provinces: ownerId targetId -> gpId
-  final owProvinces = game.worldState.oldWorld.provinces
-      .map((p) => p.ownerId == targetId ? p.copyWith(ownerId: gpId) : p)
-      .toList();
-  final nwProvinces = game.worldState.newWorld.provinces
-      .map((p) => p.ownerId == targetId ? p.copyWith(ownerId: gpId) : p)
-      .toList();
+  final owProvinces =
+      _transferProvinceOwnership(game.worldState.oldWorld.provinces, targetId, gpId);
+  final nwProvinces =
+      _transferProvinceOwnership(game.worldState.newWorld.provinces, targetId, gpId);
 
   // Transfer units: ownerId targetId -> gpId
-  final owUnits = game.worldState.oldWorld.units
-      .map((u) => u.ownerId == targetId ? u.copyWith(ownerId: gpId) : u)
-      .toList();
-  final nwUnits = game.worldState.newWorld.units
-      .map((u) => u.ownerId == targetId ? u.copyWith(ownerId: gpId) : u)
-      .toList();
+  final owUnits =
+      _transferUnitOwnership(game.worldState.oldWorld.units, targetId, gpId);
+  final nwUnits =
+      _transferUnitOwnership(game.worldState.newWorld.units, targetId, gpId);
 
   // Transfer fleets
   final fleets = game.worldState.fleets

--- a/packages/colonizethis_logic/test/game_setup_test.dart
+++ b/packages/colonizethis_logic/test/game_setup_test.dart
@@ -84,14 +84,12 @@ void main() {
 
       // Province naming: mandatory; GP capital gets capital city name, others from pool.
       expect(result.game.players.first.displayName, 'England');
-      final owProvinces = result.game.worldState.oldWorld.provinces;
-      final nwProvinces = result.game.worldState.newWorld.provinces;
       for (final p in allProvinces(result.game.worldState)) {
         expect(p.displayName, isNotNull, reason: 'province ${p.id} must have displayName');
       }
-      final p1 = owProvinces.firstWhere((p) => p.id == 'oldWorld|p1');
+      final p1 = result.game.worldState.oldWorld.provinces.firstWhere((p) => p.id == 'oldWorld|p1');
       expect(p1.displayName, 'London');
-      final nw1 = nwProvinces.firstWhere((p) => p.id == 'newWorld|nw1');
+      final nw1 = result.game.worldState.newWorld.provinces.firstWhere((p) => p.id == 'newWorld|nw1');
       expect(nw1.displayName, 'Mexica');
       expect(result.game.tribes.first.displayName, 'Aztec');
 


### PR DESCRIPTION
## Summary
Deduplication and small refactors in the logic package: test cleanup and diplomacy absorption helpers.

## Changes

### Stage 1 – Test (game_setup_test.dart)
- Removed redundant `owProvinces` and `nwProvinces` locals in the province-naming test.
- Use inline `result.game.worldState.oldWorld.provinces.firstWhere(...)` and `newWorld.provinces.firstWhere(...)` for the p1/nw1 lookups after the existing `allProvinces` loop.

### Stage 2 – Lib (diplomacy_resolver.dart)
- Added private helpers:
  - `_transferProvinceOwnership(List<Province>, fromId, toId)`
  - `_transferUnitOwnership(List<Unit>, fromId, toId)`
- `_absorbMinorOrTribeIntoGp` now uses these for OW/NW province and unit lists instead of duplicating the same `.map(...).toList()` logic four times.

## Notes
- All colonizethis_logic tests pass (722 tests, `dart test`).
- No behavior change; spec alignment unchanged.