### PR TITLE
ci: add build/app/android workflows (enforce dev source + release APK)

### DIFF
--- a/.github/workflows/app-android-release.yml
+++ b/.github/workflows/app-android-release.yml
@@ -1,0 +1,50 @@
+name: App Android Release
+
+on:
+  push:
+    branches:
+      - build/app/android
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        working-directory: app
+        run: flutter pub get
+
+      - name: Build App APK
+        working-directory: app
+        run: flutter build apk --release
+
+      - name: Compute release metadata
+        id: meta
+        run: |
+          DATE=$(date +"%Y%m%d")
+          HASH=$(git rev-parse --short HEAD)
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+          echo "tag=app-android-${DATE}.${HASH}" >> "$GITHUB_OUTPUT"
+          echo "name=App Android (${DATE}.${HASH})" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.name }}
+          files: app/build/app/outputs/flutter-apk/app-release.apk

--- a/.github/workflows/enforce-build-app-android-source.yml
+++ b/.github/workflows/enforce-build-app-android-source.yml
@@ -1,0 +1,18 @@
+name: Enforce dev source for build/app/android
+
+on:
+  pull_request:
+    branches:
+      - build/app/android
+
+jobs:
+  enforce-dev-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if PR is not from dev
+        run: |
+          echo "Base ref: ${{ github.base_ref }}, head ref: ${{ github.head_ref }}"
+          if [ "${{ github.head_ref }}" != "dev" ]; then
+            echo "Only PRs from dev are allowed into build/app/android."
+            exit 1
+          fi


### PR DESCRIPTION
Adds GitHub Actions for the `build/app/android` branch, mirroring the `build/widgetbook` setup:

- **Enforce workflow**: Only PRs from `dev` are allowed into `build/app/android`.
- **Release workflow**: On push to `build/app/android`, builds the app under `app/` with Flutter and creates a GitHub release with the APK (tag `app-android-YYYYMMDD.<hash>`).

Made with [Cursor](https://cursor.com)