### PR TITLE
refactor(logic): dedup order validation and orders copy

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -15,6 +15,7 @@ import 'validators/diplomatic_order_validator.dart';
 import 'validators/build_order_validator.dart';
 import 'validators/work_order_validator.dart';
 import 'validators/naval_order_validator.dart';
+import 'unit_type_helpers.dart';
 
 final Logger _log = Logger();
 
@@ -23,6 +24,30 @@ final Logger _log = Logger();
 
 /// Order engine: holds per-player orders, validates in submission order,
 /// exposes projected effects. No world state mutation.
+
+/// Appends one [OrderValidationResult] per order; short-circuits when [rejected].
+/// Returns the new rejected flag (true if any result was rejected).
+bool _appendValidationResults<T>(
+  List<OrderValidationResult> results,
+  List<T> orders,
+  bool rejected,
+  OrderValidationResult Function(T order, bool previousRejected) validate,
+) {
+  var r = rejected;
+  for (final o in orders) {
+    final res = validate(o, r);
+    results.add(res);
+    if (!res.isAccepted) r = true;
+  }
+  return r;
+}
+
+/// Deep-copy of order maps: new map and new list per player. Used by constructor and _copyOrders.
+Map<String, List<T>> _copyMapOfOrderLists<T>(
+  Map<String, List<T>> map,
+) =>
+    Map.from(map)..updateAll((_, v) => List<T>.from(v));
+
 class _OrderSlot<T> {
   const _OrderSlot({
     required this.getter,
@@ -39,25 +64,20 @@ class OrderEngine {
   OrderEngine({
     Orders initialOrders = const Orders(),
   }) : _orders = Orders(
-          moveOrdersByPlayerId: Map.from(initialOrders.moveOrdersByPlayerId)
-            ..updateAll((_, v) => List.from(v)),
+          moveOrdersByPlayerId:
+              _copyMapOfOrderLists(initialOrders.moveOrdersByPlayerId),
           buildUnitOrdersByPlayerId:
-              Map.from(initialOrders.buildUnitOrdersByPlayerId)
-                ..updateAll((_, v) => List.from(v)),
-          workOrdersByPlayerId: Map.from(initialOrders.workOrdersByPlayerId)
-            ..updateAll((_, v) => List.from(v)),
+              _copyMapOfOrderLists(initialOrders.buildUnitOrdersByPlayerId),
+          workOrdersByPlayerId:
+              _copyMapOfOrderLists(initialOrders.workOrdersByPlayerId),
           diplomaticOrdersByPlayerId:
-              Map.from(initialOrders.diplomaticOrdersByPlayerId)
-                ..updateAll((_, v) => List.from(v)),
+              _copyMapOfOrderLists(initialOrders.diplomaticOrdersByPlayerId),
           researchOrdersByPlayerId:
-              Map.from(initialOrders.researchOrdersByPlayerId)
-                ..updateAll((_, v) => List.from(v)),
+              _copyMapOfOrderLists(initialOrders.researchOrdersByPlayerId),
           navalMoveOrdersByPlayerId:
-              Map.from(initialOrders.navalMoveOrdersByPlayerId)
-                ..updateAll((_, v) => List<NavalMoveOrder>.from(v)),
+              _copyMapOfOrderLists(initialOrders.navalMoveOrdersByPlayerId),
           navalMissionOrdersByPlayerId:
-              Map.from(initialOrders.navalMissionOrdersByPlayerId)
-                ..updateAll((_, v) => List<NavalMissionOrder>.from(v)),
+              _copyMapOfOrderLists(initialOrders.navalMissionOrdersByPlayerId),
         );
 
   Orders _orders;
@@ -65,27 +85,18 @@ class OrderEngine {
   Orders get orders => _copyOrders(_orders);
 
   Orders _copyOrders(Orders o) => Orders(
-        moveOrdersByPlayerId: o.moveOrdersByPlayerId.map(
-          (k, v) => MapEntry(k, List<MoveOrder>.from(v)),
-        ),
-        buildUnitOrdersByPlayerId: o.buildUnitOrdersByPlayerId.map(
-          (k, v) => MapEntry(k, List<BuildUnitOrder>.from(v)),
-        ),
-        workOrdersByPlayerId: o.workOrdersByPlayerId.map(
-          (k, v) => MapEntry(k, List<WorkOrder>.from(v)),
-        ),
-        diplomaticOrdersByPlayerId: o.diplomaticOrdersByPlayerId.map(
-          (k, v) => MapEntry(k, List<DiplomaticOrder>.from(v)),
-        ),
-        researchOrdersByPlayerId: o.researchOrdersByPlayerId.map(
-          (k, v) => MapEntry(k, List<ResearchOrder>.from(v)),
-        ),
-        navalMoveOrdersByPlayerId: o.navalMoveOrdersByPlayerId.map(
-          (k, v) => MapEntry(k, List<NavalMoveOrder>.from(v)),
-        ),
-        navalMissionOrdersByPlayerId: o.navalMissionOrdersByPlayerId.map(
-          (k, v) => MapEntry(k, List<NavalMissionOrder>.from(v)),
-        ),
+        moveOrdersByPlayerId: _copyMapOfOrderLists(o.moveOrdersByPlayerId),
+        buildUnitOrdersByPlayerId:
+            _copyMapOfOrderLists(o.buildUnitOrdersByPlayerId),
+        workOrdersByPlayerId: _copyMapOfOrderLists(o.workOrdersByPlayerId),
+        diplomaticOrdersByPlayerId:
+            _copyMapOfOrderLists(o.diplomaticOrdersByPlayerId),
+        researchOrdersByPlayerId:
+            _copyMapOfOrderLists(o.researchOrdersByPlayerId),
+        navalMoveOrdersByPlayerId:
+            _copyMapOfOrderLists(o.navalMoveOrdersByPlayerId),
+        navalMissionOrdersByPlayerId:
+            _copyMapOfOrderLists(o.navalMissionOrdersByPlayerId),
       );
 
   // -- Generic helpers for add/remove --
@@ -372,25 +383,23 @@ class OrderEngine {
       );
     }
 
-    for (final o in moves) {
-      if (rejected) {
-        results.add(previousInvalidOrderResult);
-        continue;
-      }
-      final r = validateMove(o);
-      results.add(r);
-      if (!r.isAccepted) rejected = true;
-    }
+    rejected = _appendValidationResults(
+      results,
+      moves,
+      rejected,
+      (o, prev) => prev ? previousInvalidOrderResult : validateMove(o),
+    );
 
     var stockpile = player.stockpile;
     var treasury = player.treasury;
 
     final buildValidator = BuildOrderValidator(game: game, player: player);
-    for (final o in builds) {
-      final r = buildValidator.validate(o, previousRejected: rejected);
-      results.add(r);
-      if (!r.isAccepted) rejected = true;
-    }
+    rejected = _appendValidationResults(
+      results,
+      builds,
+      rejected,
+      (o, prev) => buildValidator.validate(o, previousRejected: prev),
+    );
     stockpile = buildValidator.stockpile;
     treasury = buildValidator.treasury;
 
@@ -404,11 +413,12 @@ class OrderEngine {
       stockpile: stockpile,
       treasury: treasury,
     );
-    for (final o in works) {
-      final r = workValidator.validate(o, previousRejected: rejected);
-      results.add(r);
-      if (!r.isAccepted) rejected = true;
-    }
+    rejected = _appendValidationResults(
+      results,
+      works,
+      rejected,
+      (o, prev) => workValidator.validate(o, previousRejected: prev),
+    );
     stockpile = workValidator.stockpile;
     treasury = workValidator.treasury;
 
@@ -424,9 +434,7 @@ class OrderEngine {
       );
       results.add(r.result);
       treasury = r.treasury;
-      if (!r.result.isAccepted) {
-        rejected = true;
-      }
+      if (!r.result.isAccepted) rejected = true;
     }
 
     final navalValidator = NavalOrderValidator(
@@ -434,17 +442,19 @@ class OrderEngine {
       topology: topology,
       playerId: playerId,
     );
-    for (final o in navals) {
-      final r = navalValidator.validateNavalMove(o, previousRejected: rejected);
-      results.add(r);
-      if (!r.isAccepted) rejected = true;
-    }
-    for (final o in missions) {
-      final r =
-          navalValidator.validateNavalMission(o, previousRejected: rejected);
-      results.add(r);
-      if (!r.isAccepted) rejected = true;
-    }
+    rejected = _appendValidationResults(
+      results,
+      navals,
+      rejected,
+      (o, prev) => navalValidator.validateNavalMove(o, previousRejected: prev),
+    );
+    rejected = _appendValidationResults(
+      results,
+      missions,
+      rejected,
+      (o, prev) =>
+          navalValidator.validateNavalMission(o, previousRejected: prev),
+    );
     return results;
   }
 

--- a/packages/colonizethis_logic/lib/src/orders/order_validation_result.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_validation_result.dart
@@ -45,3 +45,16 @@ OrderValidationResult shortCircuitIfPreviousRejected({
   }
   return body();
 }
+
+/// Like [shortCircuitIfPreviousRejected] for validators that also return updated treasury.
+/// When [previousRejected], returns (previousInvalidOrderResult, currentTreasury); else [body]().
+({OrderValidationResult result, int treasury}) shortCircuitIfPreviousRejectedWithTreasury({
+  required bool previousRejected,
+  required int currentTreasury,
+  required ({OrderValidationResult result, int treasury}) Function() body,
+}) {
+  if (previousRejected) {
+    return (result: previousInvalidOrderResult, treasury: currentTreasury);
+  }
+  return body();
+}

--- a/packages/colonizethis_logic/lib/src/orders/unit_type_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/orders/unit_type_helpers.dart
@@ -1,0 +1,6 @@
+/// Shared unit-type predicates for orders. SPEC/program/orders.md § Work orders.
+/// Used by WorkOrderValidator and OrderEngine for dev-exclusive tile tracking.
+
+/// True for Builder, Engineer, Merchant: at most one work order per tile per player.
+bool isDevExclusiveUnitType(String type) =>
+    type == 'Builder' || type == 'Engineer' || type == 'Merchant';

--- a/packages/colonizethis_logic/lib/src/orders/validators/diplomatic_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/diplomatic_order_validator.dart
@@ -46,13 +46,16 @@ class DiplomaticOrderValidator {
     DiplomaticOrder order, {
     required bool previousRejected,
   }) {
-    if (previousRejected) {
-      return (
-        result: previousInvalidOrderResult,
-        treasury: _treasury,
-      );
-    }
+    return shortCircuitIfPreviousRejectedWithTreasury(
+      previousRejected: previousRejected,
+      currentTreasury: _treasury,
+      body: () => _validateOne(order),
+    );
+  }
 
+  ({OrderValidationResult result, int treasury}) _validateOne(
+    DiplomaticOrder order,
+  ) {
     final targetId = order.targetFactionId;
 
     if (targetId == _playerId) {

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
@@ -7,10 +7,8 @@ import '../../world/province_lookup.dart';
 import '../../world/tile_control.dart';
 import '../order_visibility.dart';
 import '../order_validation_result.dart';
+import '../unit_type_helpers.dart';
 import 'work_order_cost_calculator.dart';
-
-bool isDevExclusiveUnitType(String type) =>
-    type == 'Builder' || type == 'Engineer' || type == 'Merchant';
 
 /// Validates work orders for a single player in submission order.
 /// Mutates internal economy state (stockpile, treasury) and [devExclusiveTiles]


### PR DESCRIPTION
## Summary
Deduplication and refactoring in `packages/colonizethis_logic` (orders/validation). All changes applied in phases with tests passing after each.

## Changes

### Phase 1: Shared unit-type helper
- **`unit_type_helpers.dart`** – New shared module with `isDevExclusiveUnitType` (Builder, Engineer, Merchant).
- **`work_order_validator.dart`** – Removed local definition; imports from `unit_type_helpers`.
- **`order_engine.dart`** – Imports `unit_type_helpers` for dev-exclusive tile tracking (no longer from validator).

### Phase 2: Diplomatic short-circuit
- **`order_validation_result.dart`** – Added `shortCircuitIfPreviousRejectedWithTreasury` for validators that return (result, treasury).
- **`diplomatic_order_validator.dart`** – Uses the helper; validation body moved to `_validateOne`.

### Phase 3: Validation loop helper
- **`order_engine.dart`** – `_appendValidationResults<T>` runs a list of orders through a validator and appends results; used for moves, builds, works, naval moves, naval missions (diplomatic loop kept as-is because it updates treasury).

### Phase 4: Orders deep-copy helper
- **`order_engine.dart`** – `_copyMapOfOrderLists<T>` deep-copies `Map<String, List<T>>`; used in constructor and `_copyOrders`.

## Testing
- `dart test packages/colonizethis_logic` – **723 tests passed** after each phase.


Made with [Cursor](https://cursor.com)