### PR TITLE
refactor(logic): unify diplomatic validation loop with state helper

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -42,6 +42,26 @@ bool _appendValidationResults<T>(
   return r;
 }
 
+/// Like [_appendValidationResults] for validators that also return updated state (e.g. treasury).
+/// Appends each result to [results], propagates [rejected], and returns (rejected, finalState).
+({bool rejected, S state}) _appendValidationResultsWithState<T, S>(
+  List<OrderValidationResult> results,
+  List<T> orders,
+  bool rejected,
+  S initialState,
+  ({OrderValidationResult result, S state}) Function(T order, bool previousRejected) validate,
+) {
+  var r = rejected;
+  var s = initialState;
+  for (final o in orders) {
+    final res = validate(o, r);
+    results.add(res.result);
+    if (!res.result.isAccepted) r = true;
+    s = res.state;
+  }
+  return (rejected: r, state: s);
+}
+
 /// Deep-copy of order maps: new map and new list per player. Used by constructor and _copyOrders.
 Map<String, List<T>> _copyMapOfOrderLists<T>(
   Map<String, List<T>> map,
@@ -427,15 +447,18 @@ class OrderEngine {
       playerId: playerId,
       initialTreasury: treasury,
     );
-    for (final o in diplomatic) {
-      final r = diplomaticValidator.validate(
-        o,
-        previousRejected: rejected,
-      );
-      results.add(r.result);
-      treasury = r.treasury;
-      if (!r.result.isAccepted) rejected = true;
-    }
+    final afterDiplomatic = _appendValidationResultsWithState<DiplomaticOrder, int>(
+      results,
+      diplomatic,
+      rejected,
+      treasury,
+      (o, prev) {
+        final r = diplomaticValidator.validate(o, previousRejected: prev);
+        return (result: r.result, state: r.treasury);
+      },
+    );
+    rejected = afterDiplomatic.rejected;
+    treasury = afterDiplomatic.state;
 
     final navalValidator = NavalOrderValidator(
       game: game,


### PR DESCRIPTION
## Summary
Repeats the logic-package refactoring procedure: one additional dedup.

## Change
- **Unify diplomatic validation loop:** `OrderEngine.validatePlayerOrdersWithContext` had a manual `for` loop for diplomatic orders (updating `results`, `treasury`, `rejected`) while other order types use `_appendValidationResults`.
- Added `_appendValidationResultsWithState<T, S>` for validators that return `(result, state)` (e.g. `DiplomaticOrderValidator` returns `(result, treasury)`).
- Replaced the diplomatic loop with a call to this helper so the pattern matches move/build/work/naval.

## Testing
- `dart test` in `packages/colonizethis_logic` — all tests pass.

Made with [Cursor](https://cursor.com)