### PR TITLE
refactor(logic): move isDevExclusiveWorkTarget to unit_type_helpers

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/unit_type_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/orders/unit_type_helpers.dart
@@ -1,6 +1,16 @@
-/// Shared unit-type predicates for orders. SPEC/program/orders.md § Work orders.
+/// Shared unit-type and work-target predicates for orders. SPEC/program/orders.md § Work orders.
 /// Used by WorkOrderValidator and OrderEngine for dev-exclusive tile tracking.
 
 /// True for Builder, Engineer, Merchant: at most one work order per tile per player.
 bool isDevExclusiveUnitType(String type) =>
     type == 'Builder' || type == 'Engineer' || type == 'Merchant';
+
+/// True for work targets that participate in per-tile exclusivity (one order per tile per player).
+/// Used with [isDevExclusiveUnitType] to enforce Builder/Engineer/Merchant tile exclusivity.
+bool isDevExclusiveWorkTarget(String target) =>
+    target == 'build_improvement' ||
+    target == 'upgrade_town' ||
+    target == 'build_road' ||
+    target == 'build_port' ||
+    target == 'build_fort' ||
+    target == 'purchase_land';

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
@@ -45,14 +45,6 @@ class WorkOrderValidator {
   Stockpile get stockpile => _stockpile;
   int get treasury => _treasury;
 
-  static bool _isDevExclusiveTarget(String target) =>
-      target == 'build_improvement' ||
-      target == 'upgrade_town' ||
-      target == 'build_road' ||
-      target == 'build_port' ||
-      target == 'build_fort' ||
-      target == 'purchase_land';
-
   /// Validates one [WorkOrder]. When accepted, deducts cost from internal
   /// stockpile/treasury and may add to [devExclusiveTiles]. Caller should sync
   /// stockpile/treasury back after the work loop.
@@ -187,7 +179,7 @@ class WorkOrderValidator {
         }
 
         if (isDevExclusiveUnitType(type) &&
-            _isDevExclusiveTarget(o.target) &&
+            isDevExclusiveWorkTarget(o.target) &&
             _devExclusiveTiles.contains(o.targetTileKey)) {
           return OrderValidationResult.rejected(
               'Tile already has development or purchase work for this player');
@@ -240,7 +232,7 @@ class WorkOrderValidator {
           return OrderValidationResult.rejected('Province or tile not visible for this work');
         }
 
-        if (isDevExclusiveUnitType(type) && _isDevExclusiveTarget(o.target)) {
+        if (isDevExclusiveUnitType(type) && isDevExclusiveWorkTarget(o.target)) {
           _devExclusiveTiles.add(o.targetTileKey);
         }
 


### PR DESCRIPTION
## Summary
Logic-package refactoring pass: deduplicate dev-exclusive work target predicate.

## Change
- **Shared work-target predicate:** `WorkOrderValidator` had a private `_isDevExclusiveTarget(String target)` listing the six work targets that participate in per-tile exclusivity (build_improvement, upgrade_town, build_road, build_port, build_fort, purchase_land). This is the same conceptual family as `isDevExclusiveUnitType` (Builder/Engineer/Merchant).
- Added `isDevExclusiveWorkTarget(String target)` to `unit_type_helpers.dart` alongside `isDevExclusiveUnitType`, and updated `WorkOrderValidator` to use it instead of the private static.

## Testing
- `dart test` in `packages/colonizethis_logic` — all tests pass.

Made with [Cursor](https://cursor.com)