### PR TITLE
refactor(logic): extract devExclusiveTilesFromWorld to unit_type_helpers

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -381,19 +381,8 @@ class OrderEngine {
     final unitsById =
         Map<String, Unit>.from(unitsByIdFromWorld(game.worldState));
 
-    // Per-player tile exclusivity (SPEC/game/civilian-units.md, SPEC/program/orders.md):
-    // track tiles already reserved by this player's Builder/Engineer/Merchant work
-    // (existing multi-turn currentWork and newly accepted work orders in this validation pass).
-    final devExclusiveTiles = <String>{};
-    for (final u in allUnitsFromWorld(game.worldState)) {
-      final w = u.currentWork;
-          if (u.ownerId == playerId &&
-          isDevExclusiveUnitType(u.type) &&
-          w != null &&
-          w.tileKey.isNotEmpty) {
-        devExclusiveTiles.add(w.tileKey);
-      }
-    }
+    final devExclusiveTiles =
+        devExclusiveTilesFromWorld(game.worldState, playerId);
 
     const _moveValidator = MoveValidator();
 

--- a/packages/colonizethis_logic/lib/src/orders/unit_type_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/orders/unit_type_helpers.dart
@@ -1,3 +1,7 @@
+import 'package:colonizethis_models/colonizethis_models.dart' show WorldState;
+
+import '../world/unit_lookup.dart' show allUnitsFromWorld;
+
 /// Shared unit-type and work-target predicates for orders. SPEC/program/orders.md § Work orders.
 /// Used by WorkOrderValidator and OrderEngine for dev-exclusive tile tracking.
 
@@ -14,3 +18,19 @@ bool isDevExclusiveWorkTarget(String target) =>
     target == 'build_port' ||
     target == 'build_fort' ||
     target == 'purchase_land';
+
+/// Tile keys already reserved by [playerId]'s Builder/Engineer/Merchant currentWork.
+/// Used for per-player tile exclusivity (SPEC/game/civilian-units.md, SPEC/program/orders.md).
+Set<String> devExclusiveTilesFromWorld(WorldState world, String playerId) {
+  final tiles = <String>{};
+  for (final u in allUnitsFromWorld(world)) {
+    final w = u.currentWork;
+    if (u.ownerId == playerId &&
+        isDevExclusiveUnitType(u.type) &&
+        w != null &&
+        w.tileKey.isNotEmpty) {
+      tiles.add(w.tileKey);
+    }
+  }
+  return tiles;
+}


### PR DESCRIPTION
## Summary
Extract the logic that collects tile keys reserved by a player's Builder/Engineer/Merchant `currentWork` into a shared helper in `unit_type_helpers.dart`.

## Changes
- **unit_type_helpers.dart**: Add `devExclusiveTilesFromWorld(WorldState world, String playerId)` returning `Set<String>`. Imports `WorldState` and `allUnitsFromWorld` for the iteration.
- **order_engine.dart**: Replace the inline loop that built `devExclusiveTiles` with a call to `devExclusiveTilesFromWorld(game.worldState, playerId)`.

## Rationale
- Keeps dev-exclusive tile logic next to `isDevExclusiveUnitType` and `isDevExclusiveWorkTarget`.
- Single place for the "tiles already reserved by dev units' currentWork" concept (SPEC/game/civilian-units.md, SPEC/program/orders.md).
- Simplifies `validatePlayerOrdersWithContext`.

## Testing
- `dart test` in `packages/colonizethis_logic` (all tests passed).

Made with [Cursor](https://cursor.com)