### PR TITLE
Add nightly dev→android PR script and docs

### DIFF
--- a/docs/project-tools.md
+++ b/docs/project-tools.md
@@ -300,3 +300,33 @@ tool/run_quality_gate_tests.sh
 ```
 
 Requires `dart`, `flutter`, and `lcov` (e.g. `sudo apt-get install lcov`).
+
+---
+
+## scripts/nightly_dev_to_android_pr.sh (nightly APK PR)
+
+Creates a PR from `dev` → `build/app/android` for nightly APK builds. Merging that PR triggers the app Android build. The PR **source** is always `dev` (per GitHub workflow rules).
+
+**Invocation**
+
+```bash
+export REPO_DIR=/path/to/colonizethisv3
+./scripts/nightly_dev_to_android_pr.sh
+```
+
+**Environment**
+
+- **REPO_DIR** (required) — path to the repo root.
+- **BASE_BRANCH** (optional) — PR base/target branch (default: `build/app/android`).
+- **HEAD_BRANCH** (optional) — PR head/source branch (default: `dev`).
+- **REMOTE_NAME** (optional) — git remote (default: `origin`).
+
+**Behaviour**
+
+- Fetches and updates local `dev` and `build/app/android`. If there are no commits to merge, exits without creating a PR. If an open PR from `dev` to `build/app/android` already exists, skips creating a duplicate. Otherwise runs `gh pr create` with `--head dev --base build/app/android`. Requires `gh` CLI to be installed and authenticated (e.g. `gh auth login`).
+
+**Cron (e.g. 02:00 daily)**
+
+```cron
+0 2 * * * REPO_DIR=/home/clawd/colonizethisv3 /home/clawd/colonizethisv3/scripts/nightly_dev_to_android_pr.sh >> /home/clawd/nightly_dev_to_android.log 2>&1
+```

--- a/scripts/nightly_dev_to_android_pr.sh
+++ b/scripts/nightly_dev_to_android_pr.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Creates a PR from dev -> build/app/android for nightly APK builds.
+# Requires: REPO_DIR set in environment (path to repo root).
+# Optional: BASE_BRANCH, HEAD_BRANCH, REMOTE_NAME (defaults below).
+# Run from cron or manually after: export REPO_DIR=/path/to/colonizethisv3
+
+set -euo pipefail
+
+BASE_BRANCH="${BASE_BRANCH:-build/app/android}"
+HEAD_BRANCH="${HEAD_BRANCH:-dev}"
+REMOTE_NAME="${REMOTE_NAME:-origin}"
+
+if [[ -z "${REPO_DIR:-}" ]]; then
+  echo "REPO_DIR must be set (e.g. export REPO_DIR=/path/to/colonizethisv3)" >&2
+  exit 1
+fi
+
+log() {
+  echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] $*"
+}
+
+cd "$REPO_DIR"
+
+log "Fetching latest from remote..."
+git fetch "$REMOTE_NAME"
+
+log "Ensuring local $HEAD_BRANCH is up to date..."
+git checkout "$HEAD_BRANCH"
+git pull --ff-only "$REMOTE_NAME" "$HEAD_BRANCH"
+
+log "Ensuring local $BASE_BRANCH is up to date..."
+git checkout "$BASE_BRANCH"
+git pull --ff-only "$REMOTE_NAME" "$BASE_BRANCH"
+
+log "Checking for differences between $HEAD_BRANCH and $BASE_BRANCH..."
+if git diff --quiet "$BASE_BRANCH".."$HEAD_BRANCH"; then
+  log "No differences; nothing to PR."
+  exit 0
+fi
+
+# PR source must be dev (HEAD_BRANCH) per workflow rules
+log "Creating PR $HEAD_BRANCH -> $BASE_BRANCH..."
+existing=$(gh pr list --base "$BASE_BRANCH" --head "$HEAD_BRANCH" --state open --json number --jq '.[0].number // empty')
+if [[ -n "$existing" ]]; then
+  log "Open PR already exists: #$existing"
+  exit 0
+fi
+
+gh pr create \
+  --base "$BASE_BRANCH" \
+  --head "$HEAD_BRANCH" \
+  --title "Nightly $HEAD_BRANCH → $BASE_BRANCH ($(date -u +"%Y-%m-%d"))" \
+  --body "Automated nightly PR from \`$HEAD_BRANCH\` into \`$BASE_BRANCH\`."
+
+log "Done."


### PR DESCRIPTION
Adds `scripts/nightly_dev_to_android_pr.sh` to create a PR from `dev` → `build/app/android` for nightly APK builds (merge triggers build). Config via env: `REPO_DIR` required; `BASE_BRANCH`, `HEAD_BRANCH`, `REMOTE_NAME` optional. Documents in `docs/project-tools.md` with cron example (e.g. 02:00 daily).

Made with [Cursor](https://cursor.com)