### PR TITLE
feat(app): Base layer display cycle toggle on in-game map

### DIFF
--- a/SPEC/ui/empire-overview.md
+++ b/SPEC/ui/empire-overview.md
@@ -23,9 +23,16 @@
 ## Map area
 
 - **Content:** One instance of the map widget per active view. When the user switches tabs, the map widget is updated or swapped to show the selected region's map.
-- **Layers:** Base tile layer always; political overlay (borders) togglable by the user (layer controls on this screen or in a shared toolbar).
+- **Layers:** Base tile layer always; political overlay (borders) togglable by the user (layer controls on this screen or in a shared toolbar). **Base layer display mode** is controlled by a cycle button overlaid at the top-left of the map (see below).
 - **Interaction:** Pan, zoom (fixed levels, smooth), tap/click for province selection. Map widget fires `onProvinceSelected`; the Empire overview screen responds (e.g. show province details in a panel or bottom sheet; content TBD).
 - **Data:** Region map data from game state / view model (PlayerView or equivalent for human player). Province identity: prefixed id per [world-model-identity.md](../game/world-model-identity.md).
+
+### Base layer display cycle (in-game map only)
+
+- **Overlay:** A single toggle button is overlaid at the **top-left** of the map area. Icon only: the letter **r** (stand-in; asset or icon may be replaced later). The button cycles the map's base layer display mode; it is shown only on the in-game Empire overview map, not in Widgetbook or debug map stories.
+- **Modes (cycle order):** 1) **terrain only** — no resource or improvement/road letters; 2) **terrain + resources** — resource letters (g, t, i, …) only; 3) **terrain + resources + improvements** — resource letters plus improvement and road labels (I0, R0, …). Each tap advances to the next mode; after the third, the next tap returns to the first.
+- **Default at game start:** When the player enters the in-game shell (after init or load), the base layer display mode is **terrain + resources + improvements** (full letters).
+- **Spec reference:** [map-widget.md](map-widget.md) § Base layer display mode.
 
 ---
 
@@ -35,13 +42,12 @@
 +------------------------------------------------------------------+
 |  [ Old World ]  [ New World ]   (region tabs)    [ Layers ▼ ] …  |
 +------------------------------------------------------------------+
-|                                                                  |
-|                    Map widget (viewport = this area)              |
-|                    – base: terrain, resources, improvements,    |
-|                      towns, capitals                             |
-|                    – overlay: political borders (if enabled)      |
-|                    – pan / zoom / tap province                   |
-|                                                                  |
+| [r]                                                              |
+|     Map widget (viewport = this area)                             |
+|     – base: terrain [+ resources + improvements per cycle]       |
+|     – overlay: political borders (if enabled)                     |
+|     – pan / zoom / tap province                                   |
+|     – [r] = base layer cycle (top-left overlay, in-game only)    |
 +------------------------------------------------------------------+
 |  (HUD / province details / panels — layout and content TBD)       |
 +------------------------------------------------------------------+
@@ -57,6 +63,9 @@ On mobile: same tab row; map area fills available space; one region visible at a
 - **When** the user selects a different region tab, **then** the map area shows that region's map (one region per map; no side-by-side on mobile).
 - **Given** the map widget is visible, **then** the user can pan, zoom (fixed levels, smooth), and toggle the political overlay; tap/click on a province invokes the selection callback and the screen can show province details (details content TBD).
 - **Desktop and mobile:** Both use the same tab-based region switching; on mobile, one region per map and tab system only.
+- **Given** the player has just entered the in-game shell (after init or load), **when** the map area is first shown, **then** the base layer display mode is terrain + resources + improvements (full letters visible).
+- **Given** the Empire overview map is visible, **when** the user taps the base-layer cycle button (letter r) at the top-left of the map area, **then** the map advances to the next mode in order: terrain only → terrain + resources → terrain + resources + improvements → terrain only (repeating).
+- **Given** the Empire overview map is visible, **then** the base-layer cycle button is visible at the top-left of the map area and displays the letter r (icon-only).
 
 ---
 

--- a/SPEC/ui/map-widget.md
+++ b/SPEC/ui/map-widget.md
@@ -26,6 +26,22 @@ Data source for tiles and ownership: shared view model (e.g. `RegionMapViewData`
 
 ---
 
+## Base layer display mode
+
+The base (tile) layer can show terrain only, terrain plus resource letters, or terrain plus resource and improvement/road letters. The widget accepts an optional **base layer display mode**; when provided, the map draws the letters overlay according to that mode. When not provided (e.g. Widgetbook, debug stories), the widget uses **full** mode so all letters are shown for backward compatibility.
+
+| Mode | Terrain | Resource letter (g, t, i, …) | Improvement/road (I0, R0, …) |
+|------|---------|-------------------------------|-------------------------------|
+| **terrainOnly** | Yes | No | No |
+| **terrainAndResources** | Yes | Yes | No |
+| **terrainResourcesImprovements** | Yes | Yes | Yes |
+
+Implementation: a single letters pass draws per-cell text; the mode controls which parts of that text are included. Capitals and ports are always drawn regardless of mode.
+
+The **in-game shell** (Empire overview) may overlay a cycle button that toggles this mode; see [empire-overview.md](empire-overview.md).
+
+---
+
 ## Viewport, scale, pan, zoom
 
 - **Viewport:** Exactly the size of the map widget in the layout. No intrinsic minimum; parent constrains the widget.
@@ -211,6 +227,9 @@ If a tileset fails to load, the widget falls back to solid color rendering using
 - **Given** a map widget with `CellViewData.visibility` populated and the visibility mode set to **player-constrained**, **when** the widget renders a tile whose visibility is `unrevealed`, **then** the tile area is drawn as solid black, no terrain or resource/improvement/road letters are shown, and hover callbacks are not fired for that tile while tap/click selection still invokes province-selection callbacks.
 
 - **Given** the map widget is in work target selection mode (non-null **validTileKeys** and **onTileSelected** provided), **when** the widget renders a tile whose key is in **validTileKeys** and in the current region, **then** that tile is drawn with a subtle glow (overlay or outline). When the user taps a tile in **validTileKeys**, **then** the widget invokes **onTileSelected** with that tile key; when the user taps a tile not in **validTileKeys** or empty area, **then** the widget does not invoke **onTileSelected**.
+- **Given** the map widget is given **base layer display mode** `terrainOnly`, **when** the widget renders the base layer, **then** terrain (and capitals, ports) is drawn and no resource or improvement/road letters are drawn on tiles.
+- **Given** the map widget is given **base layer display mode** `terrainAndResources`, **when** the widget renders the base layer, **then** terrain and resource letters (g, t, i, …) are drawn per cell where present, and improvement/road labels (I0, R0, …) are not drawn.
+- **Given** the map widget is given **base layer display mode** `terrainResourcesImprovements` (or the parameter is omitted), **when** the widget renders the base layer, **then** terrain, resource letters, and improvement/road labels are all drawn per cell where present.
 
 ---
 

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -11,7 +11,8 @@ import '../../../../providers/game_service_provider.dart';
 import '../../../../providers/games_provider.dart';
 import '../../../../providers/map_view_provider.dart';
 import '../../../../providers/production_allocation_provider.dart';
-import '../../../../widgets/ct_region_map.dart';
+import '../../../../widgets/ct_region_map.dart'
+    show BaseLayerDisplayMode, CtRegionMap, CtMapVisibilityMode;
 import '../widgets/civilian_units_panel.dart';
 import '../widgets/diplomacy_screen.dart';
 import '../widgets/military_units_panel.dart';
@@ -26,6 +27,9 @@ import 'game_canvas.dart';
 
 /// Breakpoint for in-game narrow layout (side menu, reduced top bar). SPEC/ui/in-game-shell-narrow.md.
 const double kInGameNarrowBreakpoint = 600;
+
+/// Key for the base layer cycle button (for tests). SPEC/ui/empire-overview.md § Base layer display cycle.
+const Key kBaseLayerCycleButtonKey = Key('base_layer_cycle_button');
 
 /// Shows the in-game pause menu (Debug log, Resume). SPEC/program/debug-log-viewer.md.
 void _showPauseMenu(BuildContext context) {
@@ -132,6 +136,9 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
   String? _centerOnTileKey;
   ({ct_models.Unit unit, String workTarget})? _workTargetSelection;
   bool _sideMenuOpen = false;
+  /// Base layer display mode for map letters. SPEC/ui/empire-overview.md § Base layer display cycle.
+  BaseLayerDisplayMode _baseLayerDisplayMode =
+      BaseLayerDisplayMode.terrainResourcesImprovements;
 
   String get _humanPlayerId =>
       widget.game.players
@@ -163,6 +170,43 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
       currentOrders: orders,
     );
     return valid.where((k) => k.startsWith('$_currentRegionId|')).toSet();
+  }
+
+  void _cycleBaseLayerDisplayMode() {
+    setState(() {
+      _baseLayerDisplayMode = switch (_baseLayerDisplayMode) {
+        BaseLayerDisplayMode.terrainOnly =>
+          BaseLayerDisplayMode.terrainAndResources,
+        BaseLayerDisplayMode.terrainAndResources =>
+          BaseLayerDisplayMode.terrainResourcesImprovements,
+        BaseLayerDisplayMode.terrainResourcesImprovements =>
+          BaseLayerDisplayMode.terrainOnly,
+      };
+    });
+  }
+
+  /// Base layer cycle button (letter r). SPEC/ui/empire-overview.md § Base layer display cycle.
+  Widget _buildBaseLayerCycleButton() {
+    return Material(
+      key: kBaseLayerCycleButtonKey,
+      color: Colors.white.withValues(alpha: 0.9),
+      child: Tooltip(
+        message: 'Base layer: terrain / +resources / +improvements',
+        child: InkWell(
+          onTap: _cycleBaseLayerDisplayMode,
+          child: const Padding(
+            padding: EdgeInsets.all(10),
+            child: Text(
+              'r',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
   }
 
   /// Province/sea zone to show in overlay (hover when overlay open, else selection). Prefixed id.
@@ -731,6 +775,7 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
                         region: _currentRegion,
                         cellSizePx: 24,
                         visibilityMode: CtMapVisibilityMode.playerConstrained,
+                        baseLayerDisplayMode: _baseLayerDisplayMode,
                         onProvinceSelected: _onProvinceSelected,
                         onProvinceHovered: (id) =>
                             setState(() => _hoveredDetailId = id),
@@ -748,6 +793,11 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
                                     setState(() => _workTargetSelection = null)
                                 : null,
                       ),
+                    ),
+                    Positioned(
+                      left: 0,
+                      top: 0,
+                      child: _buildBaseLayerCycleButton(),
                     ),
                     if (isNarrow && !_sideMenuOpen)
                       Positioned(
@@ -767,43 +817,58 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
                     if (_sideMenuOpen) _buildSideMenu(context),
                   ],
                 )
-              : Row(
+              : Stack(
             children: [
-              Expanded(
-                child: CtRegionMap(
-                  region: _currentRegion,
-                  cellSizePx: 24,
-                  visibilityMode: CtMapVisibilityMode.playerConstrained,
-                  onProvinceSelected: _onProvinceSelected,
-                  onProvinceHovered: (id) =>
-                      setState(() => _hoveredDetailId = id),
-                  onTileHovered: (key) => setState(() => _hoveredTileKey = key),
-                  highlightedTileKey: _highlightedTileKey,
-                  centerOnTileKey: _centerOnTileKey,
-                  validTileKeys: _validTileKeysForSelection,
-                  onTileSelected: _workTargetSelection != null
-                      ? _onTileSelectedForWork
-                      : null,
-                  onWorkTargetSelectionCancelled: _workTargetSelection != null
-                      ? () => setState(() => _workTargetSelection = null)
-                      : null,
+              Positioned.fill(
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: CtRegionMap(
+                        region: _currentRegion,
+                        cellSizePx: 24,
+                        visibilityMode: CtMapVisibilityMode.playerConstrained,
+                        baseLayerDisplayMode: _baseLayerDisplayMode,
+                        onProvinceSelected: _onProvinceSelected,
+                        onProvinceHovered: (id) =>
+                            setState(() => _hoveredDetailId = id),
+                        onTileHovered: (key) =>
+                            setState(() => _hoveredTileKey = key),
+                        highlightedTileKey: _highlightedTileKey,
+                        centerOnTileKey: _centerOnTileKey,
+                        validTileKeys: _validTileKeysForSelection,
+                        onTileSelected: _workTargetSelection != null
+                            ? _onTileSelectedForWork
+                            : null,
+                        onWorkTargetSelectionCancelled:
+                            _workTargetSelection != null
+                                ? () =>
+                                    setState(() => _workTargetSelection = null)
+                                : null,
+                      ),
+                    ),
+                    if (!isNarrow && _selectedDetailId != null)
+                      SizedBox(
+                        width: 320,
+                        child: ProvinceSeaZoneDetailOverlay(
+                          game: widget.game,
+                          region: _currentRegion,
+                          selectedId: _selectedDetailId!,
+                          displayId: _displayId,
+                          humanPlayerId: _humanPlayerId,
+                          hoveredTileKey: _hoveredTileKey,
+                          onHighlightTile: (k) =>
+                              setState(() => _highlightedTileKey = k),
+                          onClose: () => setState(() => _selectedDetailId = null),
+                        ),
+                      ),
+                  ],
                 ),
               ),
-              if (!isNarrow && _selectedDetailId != null)
-                SizedBox(
-                  width: 320,
-                  child: ProvinceSeaZoneDetailOverlay(
-                    game: widget.game,
-                    region: _currentRegion,
-                    selectedId: _selectedDetailId!,
-                    displayId: _displayId,
-                    humanPlayerId: _humanPlayerId,
-                    hoveredTileKey: _hoveredTileKey,
-                    onHighlightTile: (k) =>
-                        setState(() => _highlightedTileKey = k),
-                    onClose: () => setState(() => _selectedDetailId = null),
-                  ),
-                ),
+              Positioned(
+                left: 0,
+                top: 0,
+                child: _buildBaseLayerCycleButton(),
+              ),
             ],
           ),
         ),

--- a/app/lib/features/game/flame/region_map_component.dart
+++ b/app/lib/features/game/flame/region_map_component.dart
@@ -31,6 +31,18 @@ enum CtMapVisibilityMode {
   playerConstrained,
 }
 
+/// Base layer display mode: which tile letters are drawn. SPEC/ui/map-widget.md § Base layer display mode.
+enum BaseLayerDisplayMode {
+  /// Terrain only; no resource or improvement/road letters.
+  terrainOnly,
+
+  /// Terrain + resource letters (g, t, i, …).
+  terrainAndResources,
+
+  /// Terrain + resource letters + improvement/road labels (I0, R0, …).
+  terrainResourcesImprovements,
+}
+
 /// Flame-based region map component. Renders one RegionMapViewData and exposes
 /// hover/selection state via callbacks. SPEC/ui/map-widget.md.
 class CtRegionMapComponent extends PositionComponent {
@@ -39,6 +51,7 @@ class CtRegionMapComponent extends PositionComponent {
     required this.cellSize,
     required this.showPoliticalOverlay,
     required this.visibilityMode,
+    this.baseLayerDisplayMode = BaseLayerDisplayMode.terrainResourcesImprovements,
     this.onProvinceSelected,
     this.onProvinceHovered,
     this.onTileHovered,
@@ -50,6 +63,7 @@ class CtRegionMapComponent extends PositionComponent {
   double cellSize;
   bool showPoliticalOverlay;
   CtMapVisibilityMode visibilityMode;
+  BaseLayerDisplayMode baseLayerDisplayMode;
   void Function(String provinceId)? onProvinceSelected;
   void Function(String? provinceId)? onProvinceHovered;
   void Function(String? tileKey)? onTileHovered;
@@ -520,6 +534,10 @@ class CtRegionMapComponent extends PositionComponent {
   }
 
   void _paintLetters(Canvas canvas) {
+    final showResources = baseLayerDisplayMode == BaseLayerDisplayMode.terrainAndResources ||
+        baseLayerDisplayMode == BaseLayerDisplayMode.terrainResourcesImprovements;
+    final showImprovements = baseLayerDisplayMode == BaseLayerDisplayMode.terrainResourcesImprovements;
+
     final double fontSize = math.max(10.0, cellSize * 0.35);
     final textPainter = TextPainter(textDirection: TextDirection.ltr);
     for (final cell in region.cells) {
@@ -529,13 +547,18 @@ class CtRegionMapComponent extends PositionComponent {
         continue;
       }
       final parts = <String>[];
-      final letter = resourceIdToLegendLetter(cell.resourceId);
-      if (letter != null) parts.add(letter);
-      final imp = cell.improvementLevel ?? 0;
-      parts.add('I$imp');
-      final road = cell.roadLevel ?? 0;
-      parts.add('R$road');
+      if (showResources) {
+        final letter = resourceIdToLegendLetter(cell.resourceId);
+        if (letter != null) parts.add(letter);
+      }
+      if (showImprovements) {
+        final imp = cell.improvementLevel ?? 0;
+        parts.add('I$imp');
+        final road = cell.roadLevel ?? 0;
+        parts.add('R$road');
+      }
       final text = parts.join(' ');
+      if (text.isEmpty) continue;
       final cx = cell.x * cellSize + cellSize / 2;
       final cy = cell.y * cellSize + cellSize / 2;
       textPainter.text = TextSpan(

--- a/app/lib/widgets/ct_region_map.dart
+++ b/app/lib/widgets/ct_region_map.dart
@@ -8,7 +8,8 @@ import 'package:flutter/services.dart';
 
 import '../features/game/flame/region_map_component.dart';
 
-export '../features/game/flame/region_map_component.dart' show CtMapVisibilityMode;
+export '../features/game/flame/region_map_component.dart'
+    show BaseLayerDisplayMode, CtMapVisibilityMode;
 
 /// FlameGame host for the region map, with basic tap/drag/pinch wiring.
 class _CtRegionMapGame extends FlameGame with TapDetector {
@@ -17,6 +18,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
     required double cellSizePx,
     required bool showPoliticalOverlay,
     required CtMapVisibilityMode visibilityMode,
+    BaseLayerDisplayMode baseLayerDisplayMode = BaseLayerDisplayMode.terrainResourcesImprovements,
     required void Function(String provinceId)? onProvinceSelected,
     required VoidCallback? onRegionViewChanged,
     required void Function(String? provinceId)? onProvinceHovered,
@@ -29,6 +31,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
         cellSizePx = cellSizePx,
         showPoliticalOverlay = showPoliticalOverlay,
         visibilityMode = visibilityMode,
+        baseLayerDisplayMode = baseLayerDisplayMode,
         onProvinceSelected = onProvinceSelected,
         onRegionViewChanged = onRegionViewChanged,
         onProvinceHovered = onProvinceHovered,
@@ -42,6 +45,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
   final double cellSizePx;
   bool showPoliticalOverlay;
   CtMapVisibilityMode visibilityMode;
+  BaseLayerDisplayMode baseLayerDisplayMode;
   final void Function(String provinceId)? onProvinceSelected;
   final VoidCallback? onRegionViewChanged;
   final void Function(String? provinceId)? onProvinceHovered;
@@ -65,6 +69,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
       cellSize: cellSizePx,
       showPoliticalOverlay: showPoliticalOverlay,
       visibilityMode: visibilityMode,
+      baseLayerDisplayMode: baseLayerDisplayMode,
       onProvinceSelected: onProvinceSelected,
       onProvinceHovered: onProvinceHovered,
       onTileHovered: (tileKey) {
@@ -96,6 +101,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
     RegionMapViewData? region,
     bool? showPoliticalOverlay,
     CtMapVisibilityMode? visibilityMode,
+    BaseLayerDisplayMode? baseLayerDisplayMode,
     String? highlightedTileKey,
     Set<String>? validTileKeys,
   }) {
@@ -107,6 +113,9 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
     }
     if (visibilityMode != null) {
       this.visibilityMode = visibilityMode;
+    }
+    if (baseLayerDisplayMode != null) {
+      this.baseLayerDisplayMode = baseLayerDisplayMode;
     }
     if (highlightedTileKey != null) {
       this.highlightedTileKey = highlightedTileKey;
@@ -121,6 +130,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
         ..cellSize = cellSizePx
         ..showPoliticalOverlay = this.showPoliticalOverlay
         ..visibilityMode = this.visibilityMode
+        ..baseLayerDisplayMode = this.baseLayerDisplayMode
         ..highlightedTileKey = this.highlightedTileKey
         ..validTileKeys = this.validTileKeys;
     }
@@ -285,6 +295,7 @@ class CtRegionMap extends StatefulWidget {
     this.showPoliticalOverlay = true,
     this.cellSizePx = 32,
     this.visibilityMode = CtMapVisibilityMode.full,
+    this.baseLayerDisplayMode,
     this.onProvinceSelected,
     this.onRegionViewChanged,
     this.onProvinceHovered,
@@ -300,6 +311,8 @@ class CtRegionMap extends StatefulWidget {
   final bool showPoliticalOverlay;
   final double cellSizePx;
   final CtMapVisibilityMode visibilityMode;
+  /// When null, full letters (terrain + resources + improvements) for backward compatibility.
+  final BaseLayerDisplayMode? baseLayerDisplayMode;
   final void Function(String provinceId)? onProvinceSelected;
   final VoidCallback? onRegionViewChanged;
   final void Function(String? provinceId)? onProvinceHovered;
@@ -329,12 +342,15 @@ class _CtRegionMapState extends State<CtRegionMap> {
     if (widget.region != oldWidget.region ||
         widget.showPoliticalOverlay != oldWidget.showPoliticalOverlay ||
         widget.visibilityMode != oldWidget.visibilityMode ||
+        widget.baseLayerDisplayMode != oldWidget.baseLayerDisplayMode ||
         widget.validTileKeys != oldWidget.validTileKeys ||
         widget.highlightedTileKey != oldWidget.highlightedTileKey) {
       _game.updateProps(
         region: widget.region,
         showPoliticalOverlay: widget.showPoliticalOverlay,
         visibilityMode: widget.visibilityMode,
+        baseLayerDisplayMode: widget.baseLayerDisplayMode ??
+            BaseLayerDisplayMode.terrainResourcesImprovements,
         highlightedTileKey: widget.highlightedTileKey,
         validTileKeys: widget.validTileKeys,
       );
@@ -353,6 +369,8 @@ class _CtRegionMapState extends State<CtRegionMap> {
       cellSizePx: widget.cellSizePx,
       showPoliticalOverlay: widget.showPoliticalOverlay,
       visibilityMode: widget.visibilityMode,
+      baseLayerDisplayMode:
+          widget.baseLayerDisplayMode ?? BaseLayerDisplayMode.terrainResourcesImprovements,
       onProvinceSelected: widget.onProvinceSelected,
       onRegionViewChanged: widget.onRegionViewChanged,
       onProvinceHovered: widget.onProvinceHovered,

--- a/app/test/ct_region_map_test.dart
+++ b/app/test/ct_region_map_test.dart
@@ -5,7 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:colonizethis_app/widgets/ct_region_map.dart';
+import 'package:colonizethis_app/widgets/ct_region_map.dart'
+    show BaseLayerDisplayMode, CtRegionMap, CtMapVisibilityMode;
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
 
 void main() {
@@ -59,6 +60,7 @@ void main() {
     double cellSizePx = 24,
     bool showPoliticalOverlay = true,
     CtMapVisibilityMode visibilityMode = CtMapVisibilityMode.full,
+    BaseLayerDisplayMode? baseLayerDisplayMode,
     String? centerOnTileKey,
     void Function(String)? onProvinceSelected,
     void Function(String?)? onProvinceHovered,
@@ -76,6 +78,7 @@ void main() {
               cellSizePx: cellSizePx,
               showPoliticalOverlay: showPoliticalOverlay,
               visibilityMode: visibilityMode,
+              baseLayerDisplayMode: baseLayerDisplayMode,
               centerOnTileKey: centerOnTileKey,
               onProvinceSelected: onProvinceSelected,
               onProvinceHovered: onProvinceHovered,
@@ -120,6 +123,28 @@ void main() {
         expect(find.byType(CtRegionMap), findsOneWidget);
       },
       timeout: const Timeout(Duration(seconds: 5)),
+    );
+
+    testWidgets(
+      'builds with each base layer display mode (SPEC/ui/map-widget.md § Base layer display mode)',
+      (WidgetTester tester) async {
+        final region = _oldWorldRegion();
+        for (final mode in BaseLayerDisplayMode.values) {
+          await tester.pumpWidget(
+            _buildCtRegionMap(
+              region: region,
+              baseLayerDisplayMode: mode,
+            ),
+          );
+          await tester.pump();
+          expect(find.byType(CtRegionMap), findsOneWidget);
+        }
+        // Omitted baseLayerDisplayMode defaults to full letters
+        await tester.pumpWidget(_buildCtRegionMap(region: region));
+        await tester.pump();
+        expect(find.byType(CtRegionMap), findsOneWidget);
+      },
+      timeout: const Timeout(Duration(seconds: 10)),
     );
 
     testWidgets(
@@ -201,16 +226,18 @@ void main() {
           _buildCtRegionMap(
             region: region,
             visibilityMode: CtMapVisibilityMode.full,
+            baseLayerDisplayMode: BaseLayerDisplayMode.terrainResourcesImprovements,
           ),
         );
         await tester.pump();
 
-        // Rebuild with changed visibility and political overlay flags.
+        // Rebuild with changed visibility, political overlay, and base layer display mode.
         await tester.pumpWidget(
           _buildCtRegionMap(
             region: region,
             showPoliticalOverlay: false,
             visibilityMode: CtMapVisibilityMode.playerConstrained,
+            baseLayerDisplayMode: BaseLayerDisplayMode.terrainOnly,
           ),
         );
         await tester.pump();

--- a/app/test/game_screen_narrow_test.dart
+++ b/app/test/game_screen_narrow_test.dart
@@ -71,6 +71,28 @@ void main() {
       timeout: const Timeout(Duration(seconds: 15)),
     );
 
+    testWidgets(
+      'AC: base layer cycle button (r) is visible at top-left of map; tap cycles mode (SPEC/ui/empire-overview.md)',
+      (WidgetTester tester) async {
+        final dpr = tester.view.devicePixelRatio;
+        tester.view.physicalSize = Size(1500 * dpr, 700 * dpr);
+        addTearDown(tester.view.reset);
+        await tester.pumpWidget(buildGameScreen(width: 1500, height: 700));
+        await tester.pump();
+
+        final buttonFinder = find.byKey(kBaseLayerCycleButtonKey);
+        expect(buttonFinder, findsOneWidget);
+        await tester.tap(buttonFinder);
+        await tester.pump();
+        await tester.tap(buttonFinder);
+        await tester.pump();
+        await tester.tap(buttonFinder);
+        await tester.pump();
+        expect(buttonFinder, findsOneWidget);
+      },
+      timeout: const Timeout(Duration(seconds: 15)),
+    );
+
     // ACs for opening side menu (swipe/hamburger) and close (swipe/×) are covered by
     // manual testing or integration tests; opening the menu in widget test requires
     // gameServiceProvider which depends on Hive (not available in widget test).


### PR DESCRIPTION
## Summary
Adds a toggle overlay at the top-left of the in-game map that cycles through three base layer display modes: terrain only, terrain + resources, terrain + resources + improvements (default at game start).

## Spec / ACs
- **SPEC/ui/map-widget.md**: Base layer display mode section and ACs for `terrainOnly`, `terrainAndResources`, `terrainResourcesImprovements`.
- **SPEC/ui/empire-overview.md**: Base layer display cycle (in-game only), overlay button (letter r), default at start, wireframe and ACs.

## Implementation
- `BaseLayerDisplayMode` enum and optional param on `CtRegionMap` / `CtRegionMapComponent`; `_paintLetters` respects mode.
- Game screen: `_baseLayerDisplayMode` state, `_cycleBaseLayerDisplayMode()`, `_buildBaseLayerCycleButton()` (key `kBaseLayerCycleButtonKey` for tests). Overlay on narrow and wide layouts.
- Widgetbook/debug stories unchanged (param omitted ⇒ full letters).

## Tests
- `ct_region_map_test.dart`: Build with each `BaseLayerDisplayMode` and omitted; `didUpdateWidget` includes `baseLayerDisplayMode`.
- `game_screen_narrow_test.dart`: Base layer cycle button visible, tap three times (cycle), no throw.

## Coverage
App coverage remains at or above 80% (widget-unit); `tool/check_coverage_threshold.sh 80 app` passes.

Made with [Cursor](https://cursor.com)