### PR TITLE
feat(app): Province overlay non-Material for pixel art

### DIFF
--- a/SPEC/ui/province-sea-zone-detail-overlay.md
+++ b/SPEC/ui/province-sea-zone-detail-overlay.md
@@ -32,6 +32,12 @@ When the user taps/clicks a tile on the map widget, the in-game shell displays a
 
 ---
 
+## Style / Implementation
+
+- Overlay uses **non-Material, pixel-art friendly** components: CtPanel, custom tab strip (CtTabStrip), explicit text styles. No Material Card, TabBar, or IconButton (UXD 02).
+
+---
+
 ## Province Overlay Content
 
 ### Tile (hovered tile details)

--- a/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
+++ b/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
@@ -4,6 +4,8 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_app/widgets/ct_panel.dart';
+import 'package:colonizethis_app/widgets/ct_tab_strip.dart';
 import 'package:flutter/material.dart';
 
 /// Overlay showing province or sea zone details. Toggleable; responsive; max 1/3 screen.
@@ -69,56 +71,44 @@ class ProvinceSeaZoneDetailOverlay extends StatelessWidget {
         final maxHeight = isNarrow
             ? MediaQuery.sizeOf(context).height * 0.33
             : constraints.maxHeight;
-        return ConstrainedBox(
-          constraints: BoxConstraints(maxHeight: maxHeight),
-          child: Card(
-            margin: const EdgeInsets.all(8),
-            child: Column(
-              mainAxisSize: isNarrow ? MainAxisSize.min : MainAxisSize.max,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.only(left: 12, right: 8, top: 8),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: Text(
-                          _isSeaZone(displayId) ? 'Sea zone' : 'Province',
-                          style: Theme.of(context).textTheme.titleMedium,
-                        ),
-                      ),
-                      IconButton(
-                        icon: const Icon(Icons.close),
-                        onPressed: onClose,
-                        tooltip: 'Close',
-                      ),
-                    ],
-                  ),
-                ),
-                Flexible(
-                  child: isNarrow
-                      ? DefaultTabController(
-                          length: content.tabCount,
-                          child: Column(
-                            children: [
-                              TabBar(
-                                tabs: content.tabs,
-                                isScrollable: true,
-                              ),
-                              Expanded(
-                                child: TabBarView(
-                                  children: content.tabViews,
-                                ),
-                              ),
-                            ],
+        return Padding(
+          padding: const EdgeInsets.all(8),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: maxHeight),
+            child: CtPanel(
+              padding: EdgeInsets.zero,
+              child: Column(
+                mainAxisSize: isNarrow ? MainAxisSize.min : MainAxisSize.max,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(left: 12, right: 8, top: 8),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            _isSeaZone(displayId) ? 'Sea zone' : 'Province',
+                            style: _kOverlayTitleStyle,
                           ),
-                        )
-                      : SingleChildScrollView(
-                          padding: const EdgeInsets.all(12),
-                          child: content.sections,
                         ),
-                ),
-              ],
+                        _OverlayCloseButton(onClose: onClose),
+                      ],
+                    ),
+                  ),
+                  Flexible(
+                    child: isNarrow
+                        ? CtTabStrip(
+                            tabLabels: content.tabLabels,
+                            tabViews: content.tabViews,
+                            contentPadding: const EdgeInsets.all(12),
+                          )
+                        : SingleChildScrollView(
+                            padding: const EdgeInsets.all(12),
+                            child: content.sections,
+                          ),
+                  ),
+                ],
+              ),
             ),
           ),
         );
@@ -127,17 +117,45 @@ class ProvinceSeaZoneDetailOverlay extends StatelessWidget {
   }
 }
 
+/// Pixel-art overlay title text style (non-Material).
+const TextStyle _kOverlayTitleStyle = TextStyle(
+  fontSize: 16,
+  fontWeight: FontWeight.bold,
+);
+
 class _OverlayContent {
   _OverlayContent({
-    required this.tabCount,
-    required this.tabs,
+    required this.tabLabels,
     required this.tabViews,
     required this.sections,
   });
-  final int tabCount;
-  final List<Widget> tabs;
+  final List<String> tabLabels;
   final List<Widget> tabViews;
   final Widget sections;
+}
+
+/// Pixel-art close control (non-Material). Key [kOverlayCloseKey] for tests.
+class _OverlayCloseButton extends StatelessWidget {
+  const _OverlayCloseButton({this.onClose});
+
+  static const Key kOverlayCloseKey = Key('overlay_close');
+
+  final VoidCallback? onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      key: kOverlayCloseKey,
+      onTap: onClose,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          border: Border.all(color: Theme.of(context).colorScheme.outline),
+        ),
+        child: const Text('×', style: TextStyle(fontSize: 18)),
+      ),
+    );
+  }
 }
 
 _OverlayContent _provinceContent({
@@ -187,13 +205,13 @@ _OverlayContent _provinceContent({
         Text('???'),
       ],
     );
-    final tabs = const [
-      Tab(text: 'Tile'),
-      Tab(text: 'Political'),
-      Tab(text: 'Economic'),
-      Tab(text: 'Military'),
-      Tab(text: 'Civilian'),
-      Tab(text: 'Naval'),
+    const tabLabels = [
+      'Tile',
+      'Political',
+      'Economic',
+      'Military',
+      'Civilian',
+      'Naval',
     ];
     final tabViews = [
       placeholder,
@@ -204,8 +222,7 @@ _OverlayContent _provinceContent({
       const _ObfuscatedSection(),
     ];
     return _OverlayContent(
-      tabCount: 6,
-      tabs: tabs,
+      tabLabels: tabLabels,
       tabViews: tabViews,
       sections: sections,
     );
@@ -277,13 +294,13 @@ _OverlayContent _provinceContent({
   final civilianSection = _buildCivilianSection(civilian);
   final naval = _buildNavalSection(game, fleetsInPort);
 
-  final tabs = [
-    const Tab(text: 'Tile'),
-    const Tab(text: 'Political'),
-    const Tab(text: 'Economic'),
-    const Tab(text: 'Military'),
-    const Tab(text: 'Civilian'),
-    const Tab(text: 'Naval'),
+  const tabLabels = [
+    'Tile',
+    'Political',
+    'Economic',
+    'Military',
+    'Civilian',
+    'Naval',
   ];
   final tabViews = [
     tileSection,
@@ -305,7 +322,7 @@ _OverlayContent _provinceContent({
       naval,
     ],
   );
-  return _OverlayContent(tabCount: 6, tabs: tabs, tabViews: tabViews, sections: sections);
+  return _OverlayContent(tabLabels: tabLabels, tabViews: tabViews, sections: sections);
 }
 
 Widget _buildTileSection({
@@ -402,14 +419,14 @@ _OverlayContent _seaZoneContent({
   );
   final naval = _buildNavalSection(game, fleets);
 
-  final tabs = [const Tab(text: 'Political'), const Tab(text: 'Naval')];
+  const tabLabels = ['Political', 'Naval'];
   final tabViews = [political, naval];
   final sections = Column(
     crossAxisAlignment: CrossAxisAlignment.start,
     mainAxisSize: MainAxisSize.min,
     children: [political, naval],
   );
-  return _OverlayContent(tabCount: 2, tabs: tabs, tabViews: tabViews, sections: sections);
+  return _OverlayContent(tabLabels: tabLabels, tabViews: tabViews, sections: sections);
 }
 
 Province? _findProvince(Game game, String provinceId) {

--- a/app/lib/widgets/ct_tab_strip.dart
+++ b/app/lib/widgets/ct_tab_strip.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+/// Pixel-art friendly tab strip (non-Material). Labels in a row; selected index
+/// shows content in an [IndexedStack]. Use for overlays/panels where Material
+/// TabBar does not fit the aesthetic.
+class CtTabStrip extends StatefulWidget {
+  CtTabStrip({
+    super.key,
+    required this.tabLabels,
+    required this.tabViews,
+    EdgeInsets? contentPadding,
+  })  : assert(tabLabels.length == tabViews.length),
+        assert(tabLabels.isNotEmpty),
+        contentPadding = contentPadding ?? EdgeInsets.zero;
+
+  final List<String> tabLabels;
+  final List<Widget> tabViews;
+  /// Padding around the tab content (IndexedStack).
+  final EdgeInsets contentPadding;
+
+  @override
+  State<CtTabStrip> createState() => _CtTabStripState();
+}
+
+class _CtTabStripState extends State<CtTabStrip> {
+  int _selectedIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textStyle = theme.textTheme.bodySmall ?? const TextStyle(fontSize: 12);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: List.generate(widget.tabLabels.length, (i) {
+              final selected = i == _selectedIndex;
+              final bg = selected
+                  ? colorScheme.primary.withValues(alpha: 0.25)
+                  : colorScheme.surface.withValues(alpha: 0.5);
+              final border = selected ? colorScheme.primary : colorScheme.outline;
+              return Padding(
+                padding: EdgeInsets.only(right: i < widget.tabLabels.length - 1 ? 4 : 0),
+                child: GestureDetector(
+                  onTap: () => setState(() => _selectedIndex = i),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                    decoration: BoxDecoration(
+                      color: bg,
+                      border: Border.all(color: border, width: 1),
+                    ),
+                    child: DefaultTextStyle(
+                      style: textStyle,
+                      child: Text(widget.tabLabels[i]),
+                    ),
+                  ),
+                ),
+              );
+            }),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Expanded(
+          child: Padding(
+            padding: widget.contentPadding,
+            child: IndexedStack(
+              index: _selectedIndex,
+              sizing: StackFit.expand,
+              children: widget.tabViews,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/app/test/ct_tab_strip_test.dart
+++ b/app/test/ct_tab_strip_test.dart
@@ -1,0 +1,78 @@
+// Tests for CtTabStrip. lib/widgets/ct_tab_strip.dart.
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/widgets/ct_tab_strip.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  testWidgets('CtTabStrip builds and shows first tab label and content', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 200,
+            child: CtTabStrip(
+              tabLabels: const ['A', 'B', 'C'],
+              tabViews: const [
+                Text('Content A'),
+                Text('Content B'),
+                Text('Content C'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(find.text('A'), findsOneWidget);
+    expect(find.text('B'), findsOneWidget);
+    expect(find.text('C'), findsOneWidget);
+    expect(find.text('Content A'), findsOneWidget);
+  });
+
+  testWidgets('CtTabStrip tap switches to second tab content', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 200,
+            child: CtTabStrip(
+              tabLabels: const ['First', 'Second'],
+              tabViews: const [
+                Text('View 1'),
+                Text('View 2'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(find.text('View 1'), findsOneWidget);
+
+    await tester.tap(find.text('Second'));
+    await tester.pump();
+
+    expect(find.text('View 2'), findsOneWidget);
+  });
+
+  testWidgets('CtTabStrip applies contentPadding', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 200,
+            child: CtTabStrip(
+              tabLabels: const ['X'],
+              tabViews: const [Text('Padded')],
+              contentPadding: const EdgeInsets.all(16),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(find.text('Padded'), findsOneWidget);
+  });
+}

--- a/app/test/province_overlay_test.dart
+++ b/app/test/province_overlay_test.dart
@@ -60,7 +60,7 @@ void main() {
       expect(find.text('Military'), findsOneWidget);
       expect(find.text('Civilian'), findsOneWidget);
       expect(find.text('Naval'), findsOneWidget);
-      expect(find.byIcon(Icons.close), findsOneWidget);
+      expect(find.byKey(const Key('overlay_close')), findsOneWidget);
     });
 
     testWidgets('AC: Province overlay shows province name and owner',
@@ -111,7 +111,7 @@ void main() {
       ));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byIcon(Icons.close));
+      await tester.tap(find.byKey(const Key('overlay_close')));
       await tester.pumpAndSettle();
 
       expect(closed, isTrue);
@@ -400,7 +400,7 @@ void main() {
       expect(selectedId, isNotNull);
 
       // Close via the overlay and verify it clears selection.
-      await tester.tap(find.byIcon(Icons.close));
+      await tester.tap(find.byKey(const Key('overlay_close')));
       await tester.pump();
       expect(selectedId, isNull);
     });

--- a/docs/plan-province-overlay-non-material.md
+++ b/docs/plan-province-overlay-non-material.md
@@ -1,0 +1,98 @@
+# Plan: Convert Province/Sea Zone Detail Overlay to Non-Material (Pixel-Art Friendly)
+
+**Goal:** Remove Material design from `ProvinceSeaZoneDetailOverlay` so it works well with pixel art (UXD 02). The overlay will use only non-Material widgets and explicit styling.
+
+**Scope:** Single file `app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart` plus one new reusable widget for tabs; spec and tests updated as needed.
+
+---
+
+## 1. Current Material Usage (to remove)
+
+| Location | Current | Replacement |
+|----------|---------|-------------|
+| Import | `flutter/material.dart` | `flutter/widgets.dart` (+ keep material only if `CtPanel`/theme need it; see below) |
+| Shell | `Card` (margin 8, child: Column…) | `CtPanel` (pixel-art nine-patch). Wrap in `Padding(padding: 8)` or add margin in parent. |
+| Header title | `Theme.of(context).textTheme.titleMedium` | Explicit `TextStyle` constant (e.g. bold, size 16) for pixel-art consistency. |
+| Close control | `IconButton(icon: Icons.close, …)` | Custom close control: `GestureDetector` + `Container` + label (e.g. `Text('×')` or small sprite). Use `Key('overlay_close')` for tests. |
+| Narrow layout tabs | `DefaultTabController` + `TabBar` + `TabBarView` + `Tab` | Custom tab strip + content: see §2. |
+| Section titles | `TextStyle(fontWeight: FontWeight.bold)` | Keep (not Material-specific); can centralize in a constant. |
+
+**Note on imports:** `CtPanel` and `CtNinePatchButton` currently use `Theme.of(context)` and some still use `Material`/`InkWell`. For the **overlay only**, we stop using Material widgets and use explicit styling where possible. We can keep `material.dart` in this file if the app still wraps the overlay in `MaterialApp` (so `CtPanel`’s theme fallback works), or we pass a fallback color into `CtPanel` later. Plan: keep `material.dart` for now only for `Theme.of(context)` used by `CtPanel` (or refactor `CtPanel` to accept an optional `Color? fallbackSurface` and use it when no theme).
+
+---
+
+## 2. Custom Tab Strip (narrow layout)
+
+- **Remove:** `DefaultTabController`, `TabBar`, `TabBarView`, `Tab`.
+- **Add:** A small, reusable **tab strip** widget that:
+  - Takes `List<String> tabLabels` and `List<Widget> tabViews`.
+  - Holds `selectedIndex` (state). So the overlay’s narrow branch will use a **StatefulWidget** for the tabbed area only (e.g. `_OverlayTabbedContent`), or a reusable `CtTabStrip` in `app/lib/widgets/`.
+- **Layout:** One row of tab labels (each a `GestureDetector` + `Container`/`DecoratedBox` for border/background when selected) + `Expanded(IndexedStack(children: tabViews, index: selectedIndex))`.
+- **Styling:** Explicit colors and text style (no `Theme` for the strip if we want to be strict), or use `Theme.of(context)` for colors only. Pixel-art friendly: simple rectangles, 1px border, no Material ripple.
+- **Data change:** `_OverlayContent` currently has `tabs` (List of `Tab` widgets) and `tabViews`. Change to `tabLabels` (List<String>) and keep `tabViews`. All call sites that build `tabs` (e.g. `Tab(text: 'Tile')`) become `'Tile'`, etc.
+
+**Recommendation:** Implement `CtTabStrip` in `app/lib/widgets/ct_tab_strip.dart` (reusable for other panels) with: `tabLabels`, `tabViews`, optional `selectedIndex`/`onChanged` if we want controlled mode, or internal state. For overlay, internal state is enough.
+
+---
+
+## 3. Replace Card with CtPanel
+
+- Root of overlay build: replace `Card(margin: 8, child: Column(…))` with `Padding(padding: EdgeInsets.all(8), child: CtPanel(padding: …, child: Column(…)))`.
+- Preserve existing padding (header has `EdgeInsets.only(left: 12, right: 8, top: 8)`; content has `EdgeInsets.all(12)`). CtPanel has a `padding` parameter; use it for the inner content and add the header padding inside the Column, or set CtPanel padding to zero and wrap content in a Padding that matches current insets. Prefer: CtPanel with padding that matches the current content padding (e.g. 12), and keep the header row’s own padding as is.
+
+---
+
+## 4. Close Button
+
+- New: `GestureDetector(onTap: onClose, child: Container(… decoration… child: Text('×')))` with a `Key('overlay_close')` for tests.
+- Or use `CtNinePatchButton` with `Text('×')` if we accept that CtNinePatchButton still uses Material internally (then we only remove IconButton from overlay). **Plan:** Prefer a minimal custom close control in this file (GestureDetector + Container + Text) so the overlay is fully free of Material widgets; no Icon, no IconButton.
+
+---
+
+## 5. Text Styling
+
+- Define local constants or a small `_OverlayStyles` with:
+  - Title: e.g. `TextStyle(fontSize: 16, fontWeight: FontWeight.bold)`.
+  - Section header: already `FontWeight.bold`; keep or use same constant.
+- Replace `Theme.of(context).textTheme.titleMedium` with the title style constant.
+
+---
+
+## 6. Spec Update
+
+- In `SPEC/ui/province-sea-zone-detail-overlay.md`, add a short **Style** or **Implementation notes** bullet:
+  - “Overlay uses non-Material, pixel-art friendly components: CtPanel, custom tab strip, explicit text styles (no Material Card/TabBar/IconButton).”
+
+---
+
+## 7. Tests
+
+- `app/test/province_overlay_test.dart`:
+  - Replace `find.byIcon(Icons.close)` with `find.byKey(Key('overlay_close'))` (or `find.text('×')` if unique). Prefer key for stability.
+  - If any test asserts on `TabBar`/`Tab`/`TabBarView`, remove or change to assert on the new tab strip (e.g. by label text or by key).
+  - Keep `MaterialApp` in test harness so that `Theme.of(context)` still works for `CtPanel` until/unless we refactor CtPanel to not require theme.
+
+---
+
+## 8. Implementation Order
+
+1. **Spec:** Update `SPEC/ui/province-sea-zone-detail-overlay.md` with the style note.
+2. **CtTabStrip:** Add `app/lib/widgets/ct_tab_strip.dart` (stateful: tabLabels, tabViews, internal selectedIndex; pixel-art styling).
+3. **Overlay data:** Change `_OverlayContent` to use `List<String> tabLabels` instead of `List<Widget> tabs`; update `_provinceContent` and `_seaZoneContent` to pass labels and same `tabViews`.
+4. **Overlay shell:** Replace Card with Padding + CtPanel; replace header title style with constant; replace IconButton with custom close (Key); in narrow branch, use CtTabStrip(tabLabels, tabViews) instead of DefaultTabController/TabBar/TabBarView.
+5. **Imports:** Use `flutter/widgets.dart` for core widgets; keep `material.dart` only if CtPanel/the test harness need Theme (or remove once theme is not used in overlay).
+6. **Tests:** Update province_overlay_test to use Key for close button and adjust any tab-related finds.
+
+---
+
+## 9. Out of Scope (for this plan)
+
+- Changing other screens or panels to non-Material.
+- Refactoring `CtPanel`/`CtNinePatchButton` to be theme-optional (can be done later).
+- Adding new assets (e.g. close icon sprite) unless we decide to use one; Text('×') is sufficient for the plan.
+
+---
+
+## 10. Acceptance (from spec, unchanged)
+
+All existing overlay AC in `SPEC/ui/province-sea-zone-detail-overlay.md` still hold; the only behavioral change is that the close control and tabs are non-Material and pixel-art friendly. No change to open/close/switch/hover behavior or content.


### PR DESCRIPTION
## Summary
Convert the province/sea zone detail overlay to non-Material widgets so it works well with pixel art (UXD 02).

## Changes
- **Overlay shell:** `Card` → `CtPanel`; `IconButton(Icons.close)` → custom close control (`×`, key `overlay_close`); title uses explicit `_kOverlayTitleStyle`.
- **Tabs (narrow):** `DefaultTabController` / `TabBar` / `TabBarView` / `Tab` → **CtTabStrip** (new widget): `tabLabels` + `tabViews` + `IndexedStack`, pixel-art styling.
- **_OverlayContent:** `tabLabels` (`List<String>`) instead of `tabs` (`List<Tab>`); `tabCount` removed.
- **Spec:** `SPEC/ui/province-sea-zone-detail-overlay.md` — added Style/Implementation note (non-Material components).
- **Tests:** `province_overlay_test.dart` — close button found by `Key('overlay_close')`; new `ct_tab_strip_test.dart` for CtTabStrip (build, tap switch, contentPadding).
- **Docs:** `docs/plan-province-overlay-non-material.md` — conversion plan for reference.

## Coverage
- App widgets coverage gate (≥80% for `lib/widgets/`) passes.
- CtTabStrip covered by dedicated widget tests; overlay covered by existing province_overlay_test.

## Checklist
- [x] SPEC updated
- [x] No Material Card/TabBar/IconButton in overlay
- [x] Tests updated and added; all app tests pass

Made with [Cursor](https://cursor.com)