### PR TITLE
feat(app): add home-to-capital map button

### DIFF
--- a/SPEC/ui/empire-overview.md
+++ b/SPEC/ui/empire-overview.md
@@ -34,6 +34,12 @@
 - **Default at game start:** When the player enters the in-game shell (after init or load), the base layer display mode is **terrain + resources + improvements** (full letters).
 - **Spec reference:** [map-widget.md](map-widget.md) § Base layer display mode.
 
+### Home-to-capital button (in-game map only)
+
+- **Overlay:** A second toggle button is overlaid at the **top-left** of the map area, directly **beneath** the base-layer cycle button. Icon only: the letter **h**. The button is shown only on the in-game Empire overview map, not in Widgetbook or debug map stories.
+- **Target:** Always uses the **current human player** (same rule as for visibility and panels). If multiple players are marked `isHuman`, use the first; if none are marked, fall back to the first player in the list.
+- **Behavior:** When tapped, the button **switches the active region** (Old World / New World) if necessary so that the map shows the human player's **capital region**, then **centers the camera** on the human player's **capital tile** and moves the **selection/highlight cursor** onto that tile. Capital identity comes from `Player.capitalTile` (tile key format `regionId|provinceId|x|y` per [world-model-identity.md](../game/world-model-identity.md) and [map-visualization.md](../program/map-visualization.md)).
+
 ---
 
 ## Wireframe (conceptual)
@@ -66,6 +72,9 @@ On mobile: same tab row; map area fills available space; one region visible at a
 - **Given** the player has just entered the in-game shell (after init or load), **when** the map area is first shown, **then** the base layer display mode is terrain + resources + improvements (full letters visible).
 - **Given** the Empire overview map is visible, **when** the user taps the base-layer cycle button (letter r) at the top-left of the map area, **then** the map advances to the next mode in order: terrain only → terrain + resources → terrain + resources + improvements → terrain only (repeating).
 - **Given** the Empire overview map is visible, **then** the base-layer cycle button is visible at the top-left of the map area and displays the letter r (icon-only).
+
+- **Given** the Empire overview map is visible, **then** a second icon-only button with the letter h is visible directly beneath the base-layer cycle button at the top-left of the map area.
+- **Given** the Empire overview map is visible and the human player has a defined capital tile, **when** the user taps the h button, **then** the active region switches (if needed) to the human player's capital region and the map centers on the human player's capital tile with the selection/highlight cursor placed on that tile.
 
 ---
 

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -32,6 +32,9 @@ const double kInGameNarrowBreakpoint = 600;
 /// Key for the base layer cycle button (for tests). SPEC/ui/empire-overview.md § Base layer display cycle.
 const Key kBaseLayerCycleButtonKey = Key('base_layer_cycle_button');
 
+/// Key for the home-to-capital button (for tests). SPEC/ui/empire-overview.md § Home-to-capital button.
+const Key kHomeToCapitalButtonKey = Key('home_to_capital_button');
+
 /// Shows the in-game pause menu (Debug log, Resume). SPEC/program/debug-log-viewer.md.
 void _showPauseMenu(BuildContext context) {
   showModalBottomSheet<void>(
@@ -204,6 +207,53 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
         ),
       ),
     );
+  }
+
+  /// Home-to-capital button (letter h). SPEC/ui/empire-overview.md § Home-to-capital button.
+  Widget _buildHomeToCapitalButton() {
+    return Material(
+      key: kHomeToCapitalButtonKey,
+      color: Colors.white.withValues(alpha: 0.9),
+      child: Tooltip(
+        message: 'Center on capital',
+        child: InkWell(
+          onTap: _centerOnHumanCapital,
+          child: const Padding(
+            padding: EdgeInsets.all(10),
+            child: Text(
+              'h',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _centerOnHumanCapital() {
+    final player = widget.game.players.where((p) => p.isHuman).firstOrNull ??
+        widget.game.players.first;
+    final capital = player.capitalTile;
+    if (capital == null) {
+      return;
+    }
+    final tileKey = capital.toTileKey();
+    final regionId = capital.regionId;
+    setState(() {
+      _highlightedTileKey = tileKey;
+      _centerOnTileKey = tileKey;
+      if (regionId == 'newWorld') {
+        _regionIndex = 1;
+      } else if (regionId == 'oldWorld') {
+        _regionIndex = 0;
+      }
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      setState(() {
+        _centerOnTileKey = null;
+      });
+    });
   }
 
   /// Province/sea zone to show in overlay (hover when overlay open, else selection). Prefixed id.
@@ -812,7 +862,15 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
                       Positioned(
                         left: 0,
                         top: 0,
-                        child: _buildBaseLayerCycleButton(),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            _buildBaseLayerCycleButton(),
+                            const SizedBox(height: 4),
+                            _buildHomeToCapitalButton(),
+                          ],
+                        ),
                       ),
                       if (isNarrow && !_sideMenuOpen)
                         Positioned(
@@ -895,7 +953,15 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
                     Positioned(
                       left: 0,
                       top: 0,
-                      child: _buildBaseLayerCycleButton(),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          _buildBaseLayerCycleButton(),
+                          const SizedBox(height: 4),
+                          _buildHomeToCapitalButton(),
+                        ],
+                      ),
                     ),
                   ],
                 ),

--- a/app/test/game_screen_narrow_test.dart
+++ b/app/test/game_screen_narrow_test.dart
@@ -93,6 +93,31 @@ void main() {
       timeout: const Timeout(Duration(seconds: 15)),
     );
 
+    testWidgets(
+      'AC: home-to-capital button (h) is visible beneath base layer button and tappable (SPEC/ui/empire-overview.md)',
+      (WidgetTester tester) async {
+        final dpr = tester.view.devicePixelRatio;
+        tester.view.physicalSize = Size(1500 * dpr, 700 * dpr);
+        addTearDown(tester.view.reset);
+        await tester.pumpWidget(buildGameScreen(width: 1500, height: 700));
+        await tester.pump();
+
+        final baseButtonFinder = find.byKey(kBaseLayerCycleButtonKey);
+        final homeButtonFinder = find.byKey(kHomeToCapitalButtonKey);
+
+        expect(baseButtonFinder, findsOneWidget);
+        expect(homeButtonFinder, findsOneWidget);
+
+        await tester.tap(homeButtonFinder);
+        await tester.pump();
+
+        // No additional assertions here; behavior (centering on capital tile)
+        // is covered by CtRegionMap's centerOnTileKey tests and capitalTile specs.
+        expect(homeButtonFinder, findsOneWidget);
+      },
+      timeout: const Timeout(Duration(seconds: 15)),
+    );
+
     // ACs for opening/closing the side menu (swipe/hamburger/×/tap-outside/Escape)
     // and its modal behaviour over the map widget are covered by manual or higher-
     // level integration tests; opening the menu in this widget test would require


### PR DESCRIPTION
## Summary
- Add spec and UI button (letter h) on the Empire overview map to center on the current human player's capital tile, switching regions if needed.
- Wire the button to use Player.capitalTile via CtRegionMap.centerOnTileKey and highlight the capital tile.
- Extend GameScreen narrow tests to cover presence and tap of the new button in line with SPEC/ui/empire-overview.md.

## Test plan
- [x] flutter test app/test/game_screen_narrow_test.dart


Made with [Cursor](https://cursor.com)