### PR TITLE
feat(app): clear map highlight when province overlay closes

### DIFF
--- a/SPEC/ui/province-sea-zone-detail-overlay.md
+++ b/SPEC/ui/province-sea-zone-detail-overlay.md
@@ -15,6 +15,7 @@ When the user taps/clicks a tile on the map widget, the in-game shell displays a
 - **Open:** User taps/clicks a province or sea zone on the map. The overlay appears.
 - **Close (desktop and mobile):** User taps/clicks the close button (or an explicit dismiss control provided by the shell). **Tapping the same province/sea zone again does not close the overlay;** it remains visible until explicitly dismissed.
 - **Switch:** Tapping/clicking a different province/sea zone updates the overlay content to the new selection while keeping the overlay visible.
+- **Map highlight (orange cursor):** When the overlay is closed (via its close control or equivalent shell action), the in-game shell must also **clear any map `highlightedTileKey`** so that the secondary/orange cursor disappears from the map.
 - **Hover (pointer devices):** When the overlay is open, hovering over the map immediately updates the overlay to show the hovered province and, in the Tile section, the hovered tile’s details (coordinates, terrain, resources, prospected, improvements, roads/railroads, civilian units in province).
 - **Tap-as-hover (touch/mobile):** On touch-only/mobile viewports where pointer hover is not available, tapping a tile acts as “hover” for the purposes of the Tile section and province display:
   - The map widget drives `onTileHovered` / `onProvinceHovered` for the tapped tile/province.
@@ -119,6 +120,8 @@ When the overlay lists tile coordinates (e.g. improvements built/available), hov
 - **Given** a mobile viewport, **when** the overlay is shown, **then** it appears as a bottom sheet with tabs and does not exceed one-third of screen height.
 - **Given** a desktop viewport, **when** the overlay is shown, **then** it appears as a side panel.
 - **Given** a touch/mobile viewport where pointer hover is not available and the overlay is open, **when** the user taps a non-`unrevealed` tile on the map, **then** the overlay’s Tile section and province header update to show that tile’s province and tile information while the overlay remains visible.
+
+- **Given** the overlay is shown and a tile coordinate hover or other UI has caused the map to display a secondary/orange cursor via `highlightedTileKey`, **when** the user closes the overlay, **then** the in-game shell clears the map’s `highlightedTileKey` so that the secondary/orange cursor is no longer shown on the map.
 
 - **Given** the map widget is in player-constrained visibility mode and the user hovers a tile whose `CellViewData.visibility` is `unrevealed`, **when** the overlay’s Tile section is rendered, **then** the UI layer shows the heading "Tile" and replaces all Tile data fields (coordinates, terrain, resource, prospected, improvement, road/railroad, civilian units in province) with the literal text `???`.
 

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -885,8 +885,10 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
                                 hoveredTileKey: _hoveredTileKey,
                                 onHighlightTile: (k) =>
                                     setState(() => _highlightedTileKey = k),
-                                onClose: () =>
-                                    setState(() => _selectedDetailId = null),
+                                onClose: () => setState(() {
+                                  _selectedDetailId = null;
+                                  _highlightedTileKey = null;
+                                }),
                               ),
                             ),
                         ],
@@ -911,7 +913,10 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
               humanPlayerId: _humanPlayerId,
               hoveredTileKey: _hoveredTileKey,
               onHighlightTile: (k) => setState(() => _highlightedTileKey = k),
-              onClose: () => setState(() => _selectedDetailId = null),
+              onClose: () => setState(() {
+                _selectedDetailId = null;
+                _highlightedTileKey = null;
+              }),
             ),
           ),
       ],

--- a/app/test/province_overlay_test.dart
+++ b/app/test/province_overlay_test.dart
@@ -304,43 +304,59 @@ void main() {
   });
 
   group('ProvinceSeaZoneDetailOverlay with map', () {
-    testWidgets('AC: Map and overlay appear side by side when province selected',
-        (WidgetTester tester) async {
-      final game = demoGameForOverlay;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: Row(
-              children: [
-                Expanded(
-                  child: CtRegionMap(
-                    region: demoRegionForOverlay,
-                    cellSizePx: 28,
-                    onProvinceSelected: (_) {},
-                    highlightedTileKey: null,
+    testWidgets(
+      'AC: Map and overlay appear side by side when province selected; closing overlay clears map highlight (orange cursor)',
+      (WidgetTester tester) async {
+        final game = demoGameForOverlay;
+        String? highlightedTileKey = 'oldWorld|p0|0|0';
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: StatefulBuilder(
+              builder: (context, setState) {
+                return Scaffold(
+                  body: Row(
+                    children: [
+                      Expanded(
+                        child: CtRegionMap(
+                          region: demoRegionForOverlay,
+                          cellSizePx: 28,
+                          onProvinceSelected: (_) {},
+                          highlightedTileKey: highlightedTileKey,
+                        ),
+                      ),
+                      SizedBox(
+                        width: 320,
+                        child: ProvinceSeaZoneDetailOverlay(
+                          game: game,
+                          region: demoRegionForOverlay,
+                          selectedId: sampleProvinceIdForOverlay,
+                          displayId: sampleProvinceIdForOverlay,
+                          humanPlayerId: game.players.first.id,
+                          onClose: () => setState(() {
+                            highlightedTileKey = null;
+                          }),
+                        ),
+                      ),
+                    ],
                   ),
-                ),
-                SizedBox(
-                  width: 320,
-                  child: ProvinceSeaZoneDetailOverlay(
-                    game: game,
-                    region: demoRegionForOverlay,
-                    selectedId: sampleProvinceIdForOverlay,
-                    displayId: sampleProvinceIdForOverlay,
-                    humanPlayerId: game.players.first.id,
-                    onClose: () {},
-                  ),
-                ),
-              ],
+                );
+              },
             ),
           ),
-        ),
-      );
-      await tester.pump();
+        );
+        await tester.pump();
 
-      expect(find.byType(CtRegionMap), findsOneWidget);
-      expect(find.byType(ProvinceSeaZoneDetailOverlay), findsOneWidget);
-    });
+        expect(find.byType(CtRegionMap), findsOneWidget);
+        expect(find.byType(ProvinceSeaZoneDetailOverlay), findsOneWidget);
+        expect(highlightedTileKey, isNotNull);
+
+        await tester.tap(find.byKey(const Key('overlay_close')));
+        await tester.pumpAndSettle();
+
+        expect(highlightedTileKey, isNull);
+      },
+    );
 
     testWidgets('AC: Map tap invokes onProvinceSelected; overlay can show selection and stays open until closed',
         (WidgetTester tester) async {


### PR DESCRIPTION
## Summary
- Clarify in the province/sea-zone overlay spec that closing the overlay must clear any map \ (orange cursor).
- Update the in-game shell so that overlay close handlers clear both the selected detail id and the map highlight.
- Extend the ProvinceSeaZoneDetailOverlay-with-map widget test to assert that closing the overlay clears the orange cursor highlight.

## Test plan
- [ ] Run existing app widget tests: \Resolving dependencies in `/home/clawd/colonizethisv3_2`...
Downloading packages...
  _fe_analyzer_shared 93.0.0 (97.0.0 available)
  analyzer 10.0.1 (11.0.0 available)
  ansi_escape_codes 2.2.1 (3.0.2 available)
  cli_launcher 0.3.2+1 (0.3.3 available)
  flutter_riverpod 2.6.1 (3.3.1 available)
  google_fonts 6.3.3 (8.0.2 available)
  logger 2.6.2 (2.7.0 available)
  matcher 0.12.18 (0.12.19 available)
  meta 1.18.0 (1.18.1 available)
  nocterm 0.4.4 (0.6.0 available)
  riverpod 2.6.1 (3.2.1 available)
  test 1.29.0 (1.30.0 available)
  test_api 0.7.9 (0.7.10 available)
  test_core 0.6.15 (0.6.16 available)
Got dependencies in `/home/clawd/colonizethisv3_2`!
14 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
00:00 +0: loading /home/clawd/colonizethisv3_2/app/test/province_overlay_test.dart\
00:00 +0 -1: loading /home/clawd/colonizethisv3_2/app/test/province_overlay_test.dart\ [E]
  Failed to load "/home/clawd/colonizethisv3_2/app/test/province_overlay_test.dart\": Does not exist.
00:00 +0 -1: Some tests failed.
- [ ] Manually verify in-game that closing the province overlay clears the orange cursor on the map.

Made with [Cursor](https://cursor.com)