### PR TITLE
Adjust cast iron recipe to be early-game (no coal)

### DIFF
--- a/SPEC/game/production-recipes.md
+++ b/SPEC/game/production-recipes.md
@@ -26,7 +26,7 @@ The following recipes are defined for MVP:
 | Lumber | lumber (1) | timber ×2 | 2 |
 | Fabric (wool) | fabric (1) | wool ×2 | 2 |
 | Fabric (cotton) | fabric (1) | cotton ×2 | 2 |
-| Cast Iron | castIron (1) | timber ×2, iron ×2, coal ×1 | 5 |
+| Cast Iron | castIron (1) | timber ×2, iron ×2 | 5 |
 | Refined Sugar | refinedSugar (1) | sugarCane ×2 | 2 |
 | Cigars | cigars (1) | tobacco ×3 | 3 |
 | Fur Hats | furHats (1) | furs ×2 | 2 |
@@ -38,7 +38,7 @@ The following recipes are defined for MVP:
 
 ## Examples
 
-- Timber ×2, Iron ×2, Coal ×1 → Cast Iron (labour per unit from constants).
+- Timber ×2, Iron ×2 → Cast Iron (labour per unit from constants).
 - Wool or Cotton ×2 → Fabric.
 - Sugar Cane ×2 → Refined Sugar.
 

--- a/ctterm/lib/screens/production_screen.dart
+++ b/ctterm/lib/screens/production_screen.dart
@@ -57,11 +57,11 @@ const _productionRecipes = [
     labourRequired: 2,
   ),
   ProductionRecipe(
-    id: 'iron_to_cast_iron',
-    name: 'Iron + Coal to Cast Iron',
-    inputs: {'iron': 2, 'coal': 1},
+    id: 'timber_iron_to_cast_iron',
+    name: 'Timber + Iron to Cast Iron',
+    inputs: {'timber': 2, 'iron': 2},
     outputs: {'castIron': 1},
-    labourRequired: 3,
+    labourRequired: 5,
   ),
   ProductionRecipe(
     id: 'wool_to_fabric',

--- a/packages/colonizethis_data/lib/src/production_recipes.dart
+++ b/packages/colonizethis_data/lib/src/production_recipes.dart
@@ -30,7 +30,7 @@ class ProductionRecipe {
 }
 
 class ProductionRecipesCatalog {
-  /// 2 timber + 2 iron + 1 coal → 1 castIron.
+  /// 2 timber + 2 iron → 1 castIron.
   static final ProductionRecipe castIronFromTimberIronCoal = ProductionRecipe(
     id: 'castIron_from_timber_iron_coal',
     outputCommodityId: CommodityCatalog.castIron.id,
@@ -38,7 +38,6 @@ class ProductionRecipesCatalog {
     inputQuantities: {
       CommodityCatalog.timber.id: 2,
       CommodityCatalog.iron.id: 2,
-      CommodityCatalog.coal.id: 1,
     },
     labourPerOutput: 5,
   );

--- a/packages/colonizethis_data/test/commodity_and_recipe_catalog_test.dart
+++ b/packages/colonizethis_data/test/commodity_and_recipe_catalog_test.dart
@@ -95,8 +95,8 @@ void main() {
         2,
       );
       expect(
-        castIron.inputQuantities[CommodityCatalog.coal.id],
-        1,
+        castIron.inputQuantities.containsKey(CommodityCatalog.coal.id),
+        isFalse,
       );
     });
   });

--- a/packages/colonizethis_logic/test/economy_logic_test.dart
+++ b/packages/colonizethis_logic/test/economy_logic_test.dart
@@ -64,7 +64,7 @@ void main() {
 
   group('resolveProduction', () {
     test('consumes inputs and produces outputs', () {
-      // Start with enough timber, iron, and coal.
+      // Start with enough timber and iron; coal is present but not consumed.
       var stockpile = const Stockpile()
           .applyDelta(CommodityCatalog.timber.id, 10)
           .applyDelta(CommodityCatalog.iron.id, 10)
@@ -84,11 +84,12 @@ void main() {
 
       // labourPerOutput = 5, assigned 20, but effective labour from 10 peasants
       // is 10 → max 2 runs.
-      // Inputs per run: 2 timber, 2 iron, 1 coal.
+      // Inputs per run: 2 timber, 2 iron (no coal).
       expect(result.stockpile.quantityOf(CommodityCatalog.castIron.id), 2);
       expect(result.stockpile.quantityOf(CommodityCatalog.timber.id), 10 - 2 * 2);
       expect(result.stockpile.quantityOf(CommodityCatalog.iron.id), 10 - 2 * 2);
-      expect(result.stockpile.quantityOf(CommodityCatalog.coal.id), 5 - 1 * 2);
+      // Cast iron recipe no longer consumes coal; coal remains unchanged.
+      expect(result.stockpile.quantityOf(CommodityCatalog.coal.id), 5);
     });
 
     test('effective labour counts only trained workers with luxury', () {

--- a/packages/colonizethis_logic/test/economy_production_test.dart
+++ b/packages/colonizethis_logic/test/economy_production_test.dart
@@ -28,7 +28,8 @@ void main() {
       expect(result.stockpile.quantityOf(CommodityCatalog.castIron.id), 4);
       expect(result.stockpile.quantityOf(CommodityCatalog.timber.id), 2);
       expect(result.stockpile.quantityOf(CommodityCatalog.iron.id), 2);
-      expect(result.stockpile.quantityOf(CommodityCatalog.coal.id), 1);
+      // Cast iron no longer consumes coal; coal remains unchanged.
+      expect(result.stockpile.quantityOf(CommodityCatalog.coal.id), 5);
     });
 
     test('limits runs by available inputs', () {


### PR DESCRIPTION
## Summary
- Update SPEC and data catalog so cast iron uses only timber ×2 and iron ×2 (no coal), keeping it an early-game manufactured good.
- Align ctterm production screen recipe display and requirements with the updated cast iron recipe.
- Update tests that assert the cast iron recipe structure to match the new inputs (no coal).

## Test plan
- [ ] Run data and logic tests: \ (or package-level tests) to ensure production recipes and economy logic still pass.
- [ ] In ctterm, open Production screen and verify the cast iron recipe shows  with inputs  and labour 5.
- [ ] In the app production UI, confirm cast iron production behaves correctly and no UI mentions coal for cast iron.

Made with [Cursor](https://cursor.com)