### PR TITLE
feat(ui): move empire buttons to side menu for all viewports

### DIFF
--- a/SPEC/ui/empire-buttons.md
+++ b/SPEC/ui/empire-buttons.md
@@ -1,12 +1,12 @@
 # Empire buttons
 
-**SPEC/ui** — In-game actions for the human player (Production, Civilian Units, Military Units, Diplomacy, Technology). Display depends on viewport width. Authority: [empire-overview.md](empire-overview.md); [in-game-shell-narrow.md](in-game-shell-narrow.md) for narrow layout.
+**SPEC/ui** — In-game actions for the human player (Production, Civilian Units, Military Units, Diplomacy, Technology). All empire buttons are accessed via the side menu (hamburger menu) at all viewport sizes. Authority: [empire-overview.md](empire-overview.md); [in-game-shell-narrow.md](in-game-shell-narrow.md) for side menu implementation.
 
 ---
 
 ## Definition
 
-**Empire buttons** are the set of in-game toolbar actions that open panels or full-screen screens. They are the same set in all viewport sizes; only their **placement** changes.
+**Empire buttons** are the set of in-game toolbar actions that open panels or full-screen screens.
 
 | Order | Id | Label | Action |
 |-------|-----|--------|--------|
@@ -16,16 +16,28 @@
 | 4 | diplomacy | Diplomacy | Opens Diplomacy screen |
 | 5 | technology | Technology | Opens Technology screen |
 
-Icons and assets: [game-toolbar-icons.md](game-toolbar-icons.md) (`ui_icon_<id>.png`, 32×32; display at 20×20 in buttons).
+Icons and assets: [game-toolbar-icons.md](game-toolbar-icons.md) (`ui_icon_<id>.png`,32×32; display at 20×20 in buttons).
 
 ---
 
-## Display by viewport
+## Display
 
-- **Wide viewport (width ≥ 600 dp):** Empire buttons are shown in the **top bar** (toolbar row) with region tabs, in the order above. No side menu.
-- **Narrow viewport (width < 600 dp):** Empire buttons are **not** shown in the top bar. They are shown only inside the **side menu** (see [in-game-shell-narrow.md](in-game-shell-narrow.md)). Top bar on narrow shows only hamburger (menu trigger) and turn counter.
+- **All viewports:** Empire buttons are shown **only** in the **side menu** (opened via hamburger menu). The side menu is available at all viewport sizes (both narrow and wide). No empire buttons appear in the top bar.
+- **Top bar:** Shows hamburger (menu trigger) on the left, turn counter/button on the right, and region tabs centered below. No empire buttons.
 
-Breakpoint: **600 dp** (same as production panel, military units panel).
+---
+
+## Side menu
+
+The side menu contains all empire buttons and is accessible at all viewport sizes.
+
+- **Open:** Tap the hamburger menu in the top bar, or swipe in from the left edge.
+- **Close:** Tap outside the menu (on scrim), swipe left, tap the close (×) button, or press Escape.
+- **Content:** All empire buttons in order (Production, Civilian Units, Military Units, Diplomacy, Technology).
+- **Layout:** Pixel-art layout with CtPanel and CtNinePatchButton.
+- **Modal:** When open, the map underneath is non-interactive.
+
+See [in-game-shell-narrow.md](in-game-shell-narrow.md) for full side menu specification.
 
 ---
 
@@ -33,13 +45,13 @@ Breakpoint: **600 dp** (same as production panel, military units panel).
 
 - All empire buttons use **CtNinePatchButton** with pixel-art icon + label.
 - Icon: `Image.asset('assets/images/ui_icon_<id>.png', width: 20, height: 20)`; 8 dp gap; then `Text(label)`.
-- Same visual style in top bar (wide) and in side menu (narrow). No Material buttons.
+- Same visual style in side menu at all viewport sizes. No Material buttons.
 
 ---
 
 ## References
 
 - [game-toolbar-icons.md](game-toolbar-icons.md) — icon assets and prompts
-- [in-game-shell-narrow.md](in-game-shell-narrow.md) — narrow layout, side menu
+- [in-game-shell-narrow.md](in-game-shell-narrow.md) — side menu implementation
 - [empire-overview.md](empire-overview.md) — in-game shell
 - [pixel-art-ui-catalog.md](pixel-art-ui-catalog.md) — CtNinePatchButton

--- a/SPEC/ui/in-game-shell-narrow.md
+++ b/SPEC/ui/in-game-shell-narrow.md
@@ -1,35 +1,29 @@
-# In-game shell: narrow viewport (side menu)
+# In-game shell: side menu
 
-**SPEC/ui** — When the in-game viewport width is below the breakpoint, the top bar shows only the menu trigger and turn counter; empire buttons move into a side menu opened by swipe or hamburger. Authority: [empire-overview.md](empire-overview.md), [empire-buttons.md](empire-buttons.md), [mobile-adaptation.md](mobile-adaptation.md).
-
----
-
-## Breakpoint
-
-- **Narrow:** viewport width **< 600 dp**. Side menu and reduced top bar apply.
-- **Wide:** viewport width **≥ 600 dp**. No side menu; empire buttons remain in the top bar (current behaviour).
+**SPEC/ui** — The in-game screen has a side menu (accessed via hamburger menu) that contains empire buttons. Available at all viewport sizes. Authority: [empire-overview.md](empire-overview.md), [empire-buttons.md](empire-buttons.md).
 
 ---
 
-## Top bar (narrow only)
+## Top bar
 
-When width < 600 dp:
+The top bar shows:
 
-- **Left:** Hamburger control (menu trigger). Same control as the existing pause-menu trigger; on narrow it opens the **side menu** (which contains empire buttons). Pause menu options (e.g. Debug log, Resume) may be included in the side menu or kept behind a secondary action; spec: hamburger opens the side menu.
-- **Center/right:** Turn counter only (e.g. "Next turn (N / year)" or equivalent). No empire buttons in the top bar.
-- Empire buttons are **not** shown in this row; they appear only in the side menu.
+- **Left:** Hamburger control (menu trigger). Opens the side menu.
+- **Center/right:** Turn counter/button (e.g. "Next turn (N / year)").
+- **Below:** Region tabs (Old World / New World).
+
+**No empire buttons in the top bar.** Empire buttons appear only in the side menu.
 
 ---
 
-## Side menu (narrow only)
+## Side menu
 
-- **Visibility:** Shown only when viewport is narrow (width < 600 dp). Not present on wide.
+- **Availability:** Available at all viewport sizes (both narrow and wide).
 - **Open:** Swipe in from the **left** edge, or tap the **hamburger** in the top bar.
-- **Close:** Swipe the menu to the **left** (drag to close), or tap a **close (cross)** button in the menu.
-- **Content:** All [empire buttons](empire-buttons.md) in order: Production, Civilian Units, Military Units, Diplomacy, Technology. Same behaviour as in the wide top bar (each opens the same panel/screen).
-- **Layout:** Pixel-art layout. Uses the same styling as the rest of the UI: **CtPanel** (or equivalent framed container), **CtNinePatchButton** for each empire button, same icons and labels as [game-toolbar-icons.md](game-toolbar-icons.md). No Material chrome.
-- **Width:** Menu has a fixed or max width (e.g. 280 dp or 80% of viewport) so the map remains partially visible or dimmed when open; implementation may use a drawer or custom overlay.
-- **Optional:** The side menu may include secondary actions (e.g. Debug log, Resume) at the bottom so the same hamburger serves both empire actions and pause menu.
+- **Close:** Swipe the menu to the **left** (drag to close), tap a **close (×)** button in the menu, tap outside the menu (on scrim), or press **Escape**.
+- **Content:** All [empire buttons](empire-buttons.md) in order: Production, Civilian Units, Military Units, Diplomacy, Technology. Same behaviour in all viewports (each opens the same panel/screen).
+- **Layout:** Pixel-art layout. Uses **CtPanel** (or equivalent framed container), **CtNinePatchButton** for each empire button, same icons and labels as [game-toolbar-icons.md](game-toolbar-icons.md). No Material chrome.
+- **Width:** Menu has a fixed width (280 dp) so the map remains partially visible or dimmed when open; implementation uses a drawer-like overlay.
 
 ---
 
@@ -39,7 +33,7 @@ When width < 600 dp:
   - Pointer interaction (tap, drag, scroll, hover) is **captured by the side menu layer** and **does not reach the map widget** or underlying in-game UI.
   - Keyboard interaction that would otherwise affect the map or in-game UI is **ignored by the map** while the menu is open.
   - **OS / platform-level gestures** (system back, platform edge-swipes) continue to work as normal; modality only applies to the app content layer.
-- **Scrim:** A dimmed background (scrim) is shown behind the side menu while it is open so the player understands that the map is temporarily non-interactive.
+- **Scrim:** A dimmed background (scrim) is shown behind the side menu while it is open.
 - **Dismissal:**
   - Pressing **Escape** (or the equivalent back key on desktop/web) closes the side menu.
   - Tapping or clicking **outside** the side menu, on the scrim, closes the side menu and **does not trigger any map interaction** for that tap/click.
@@ -48,13 +42,22 @@ When width < 600 dp:
 
 ---
 
-## Wireframe (narrow)
+## Province/sea zone detail overlay
+
+- **Wide viewport (≥ 600 dp):** Province detail appears as a side panel (width 320 dp) to the right of the map.
+- **Narrow viewport (< 600 dp):** Province detail appears as a bottom sheet (height ~33% of viewport) below the map.
+
+This layout difference is retained because wide viewports have horizontal space for a side panel, while narrow viewports do not.
+
+---
+
+## Wireframe
 
 ```
 +------------------------------------------+
 | [≡]     Next turn (42 / 1650)            |  <- top bar: hamburger + turn counter
 +------------------------------------------+
-| [Old World] [New World]                  |  <- region tabs (unchanged)
+| [Old World] [New World]                  |  <- region tabs
 +------------------------------------------+
 |                                          |
 |              Map area                     |
@@ -77,19 +80,18 @@ Side menu (when open, overlaid from left):
 
 ## Acceptance criteria
 
-- **Given** the in-game shell is shown and viewport width is **≥ 600 dp**, **when** the user looks at the top bar, **then** the empire buttons (Production, Civilian Units, Military Units, Diplomacy, Technology) are visible in the top bar and there is no side menu.
-- **Given** the in-game shell is shown and viewport width is **< 600 dp**, **when** the user looks at the top bar, **then** only the hamburger (menu trigger) and the turn counter are shown; empire buttons are not in the top bar.
-- **Given** viewport width is **< 600 dp** and the side menu is closed, **when** the user swipes in from the left edge, **then** the side menu opens and displays all empire buttons in pixel-art style.
-- **Given** viewport width is **< 600 dp** and the side menu is closed, **when** the user taps the hamburger in the top bar, **then** the side menu opens and displays all empire buttons.
+- **Given** the in-game shell is shown, **when** the user looks at the top bar, **then** the hamburger (menu trigger) and the turn counter/button are shown; empire buttons are **not** in the top bar.
+- **Given** the side menu is closed, **when** the user swipes in from the left edge, **then** the side menu opens and displays all empire buttons in pixel-art style.
+- **Given** the side menu is closed, **when** the user taps the hamburger in the top bar, **then** the side menu opens and displays all empire buttons.
 - **Given** the side menu is open, **when** the user swipes the menu to the left (drag to close), **then** the side menu closes.
 - **Given** the side menu is open, **when** the user taps the close (cross) button in the menu, **then** the side menu closes.
-- **Given** the side menu is open, **when** the user taps an empire button, **then** the same panel or screen opens as when that button is used in the wide top bar, and the side menu closes (or remains open; spec: close on action so the user sees the panel).
-- **Given** viewport width is **< 600 dp**, **when** the side menu is built, **then** it uses pixel-art layout (CtPanel, CtNinePatchButton, same icons as game-toolbar-icons) and no Material buttons or chrome.
+- **Given** the side menu is open, **when** the user taps an empire button, **then** the same panel or screen opens as defined in [empire-buttons.md](empire-buttons.md), and the side menu closes.
+- **Given** the side menu is built, **when** it renders, **then** it uses pixel-art layout (CtPanel, CtNinePatchButton, same icons as game-toolbar-icons) and no Material buttons or chrome.
 
-- **Given** viewport width is **< 600 dp** and the side menu is **open**, **when** the user attempts to interact with the map area (tap, drag, scroll, hover), **then** the map widget does not respond and no province selection or camera movement occurs until the side menu is closed.
-- **Given** viewport width is **< 600 dp** and the side menu is **open**, **when** the user performs a keyboard action that would normally affect the map (e.g. map hotkeys), **then** the map does not react while the menu is open.
-- **Given** viewport width is **< 600 dp** and the side menu is **open**, **when** the user taps or clicks outside the menu (on the dimmed background), **then** the side menu closes and that tap/click is **not** forwarded to the map (no province selection or camera movement is triggered).
-- **Given** viewport width is **< 600 dp** and the side menu is **open**, **when** the user presses **Escape** (or the platform back key where applicable), **then** the side menu closes and focus/input returns to the in-game shell.
+- **Given** the side menu is **open**, **when** the user attempts to interact with the map area (tap, drag, scroll, hover), **then** the map widget does not respond and no province selection or camera movement occurs until the side menu is closed.
+- **Given** the side menu is **open**, **when** the user performs a keyboard action that would normally affect the map (e.g. map hotkeys), **then** the map does not react while the menu is open.
+- **Given** the side menu is **open**, **when** the user taps or clicks outside the menu (on the dimmed background), **then** the side menu closes and that tap/click is **not** forwarded to the map (no province selection or camera movement is triggered).
+- **Given** the side menu is **open**, **when** the user presses **Escape** (or the platform back key where applicable), **then** the side menu closes and focus/input returns to the in-game shell.
 
 ---
 
@@ -97,5 +99,4 @@ Side menu (when open, overlaid from left):
 
 - [empire-buttons.md](empire-buttons.md) — list and order of empire buttons, styling
 - [empire-overview.md](empire-overview.md) — in-game shell
-- [mobile-adaptation.md](mobile-adaptation.md) — breakpoints, touch targets
 - [pixel-art-ui-catalog.md](pixel-art-ui-catalog.md) — CtPanel, CtNinePatchButton

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -73,9 +73,8 @@ class GameScreen extends ConsumerWidget {
     final game = ref.watch(currentGameProvider);
     final mapViewData = ref.watch(mapViewDataProvider);
     final victory = game?.victory;
-    final isNarrow = MediaQuery.sizeOf(context).width < kInGameNarrowBreakpoint;
     final showOverlayButtons =
-        game != null && victory == null && (!isNarrow || mapViewData == null);
+        game != null && victory == null && mapViewData == null;
     final introShownIds = ref.watch(gameIdsWithIntroShownProvider);
     final showIntro = game != null && !introShownIds.contains(game.id);
     final pendingOvertures = ref.watch(pendingOverturesProvider);
@@ -618,9 +617,9 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Image.asset(iconAsset, width: 20, height: 20),
-            const SizedBox(width: 8),
-            Text(label),
+            _buildBaseLayerCycleButton(),
+            const SizedBox(height: 4),
+            _buildHomeToCapitalButton(),
           ],
         ),
       ),
@@ -632,28 +631,26 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
     final isNarrow = MediaQuery.sizeOf(context).width < kInGameNarrowBreakpoint;
     return Column(
       children: [
-        if (isNarrow)
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 4),
-            child: Row(
-              children: [
-                IconButton(
-                  icon: const Icon(Icons.menu),
-                  onPressed: () =>
-                      setState(() => _sideMenuOpen = !_sideMenuOpen),
-                  tooltip: 'Menu',
-                ),
-                Expanded(
-                  child: CtNinePatchButton(
-                    onPressed: _onNextTurn,
-                    child: Text(
-                      'Next turn (${widget.game.worldState.turnState.turnNumber} / ${turnToYear(widget.game.worldState.turnState.turnNumber, widget.game.turnTimeMapping)})',
-                    ),
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: Row(
+            children: [
+              IconButton(
+                icon: const Icon(Icons.menu),
+                onPressed: () => setState(() => _sideMenuOpen = !_sideMenuOpen),
+                tooltip: 'Menu',
+              ),
+              Expanded(
+                child: CtNinePatchButton(
+                  onPressed: _onNextTurn,
+                  child: Text(
+                    'Next turn (${widget.game.worldState.turnState.turnNumber} / ${turnToYear(widget.game.worldState.turnState.turnNumber, widget.game.turnTimeMapping)})',
                   ),
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
+        ),
         Padding(
           padding: const EdgeInsets.symmetric(vertical: 8),
           child: Row(
@@ -670,228 +667,27 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
                 selected: _regionIndex == 1,
                 onSelected: (_) => setState(() => _regionIndex = 1),
               ),
-              if (!isNarrow) ...[
-                const SizedBox(width: 16),
-                CtNinePatchButton(
-                  onPressed: () {
-                    final player =
-                        widget.game.players
-                            .where((p) => p.isHuman)
-                            .firstOrNull ??
-                        widget.game.players.first;
-                    final desired = ref.read(productionDesiredOutputProvider);
-                    Navigator.of(context).push<void>(
-                      MaterialPageRoute<void>(
-                        builder: (ctx) => ProductionScreen(
-                          game: widget.game,
-                          player: player,
-                          desiredOutputByRecipe: desired,
-                          onDesiredOutputChanged: (newMap) {
-                            ref
-                                    .read(
-                                      productionDesiredOutputProvider.notifier,
-                                    )
-                                    .state =
-                                newMap;
-                          },
-                        ),
-                      ),
-                    );
-                  },
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Image.asset(
-                        'assets/images/ui_icon_production.png',
-                        width: 20,
-                        height: 20,
-                      ),
-                      const SizedBox(width: 8),
-                      const Text('Production'),
-                    ],
-                  ),
-                ),
-                const SizedBox(width: 8),
-                CtNinePatchButton(
-                  onPressed: () {
-                    final orders = ref.read(currentOrdersProvider);
-                    showModalBottomSheet<void>(
-                      context: context,
-                      isScrollControlled: true,
-                      builder: (ctx) {
-                        final isNarrow = MediaQuery.sizeOf(ctx).width < 600;
-                        final maxHeight =
-                            MediaQuery.sizeOf(ctx).height *
-                            (isNarrow ? 0.33 : 0.5);
-                        return ConstrainedBox(
-                          constraints: BoxConstraints(maxHeight: maxHeight),
-                          child: CivilianUnitsPanel(
-                            game: ref.read(currentGameProvider) ?? widget.game,
-                            humanPlayerId: _humanPlayerId,
-                            currentOrders: orders,
-                            availableWorkTargets: ref.watch(
-                              availableWorkTargetsProvider,
-                            ),
-                            onLocateUnit: _onLocateCivilianUnit,
-                            onRemoveWorkOrder: (playerId, index) {
-                              final o = ref.read(currentOrdersProvider);
-                              final list = List<ct_models.WorkOrder>.from(
-                                o.workOrdersByPlayerId[playerId] ?? [],
-                              )..removeAt(index);
-                              ref.read(currentOrdersProvider.notifier).state = o
-                                  .copyWith(
-                                    workOrdersByPlayerId: {
-                                      ...o.workOrdersByPlayerId,
-                                      playerId: list,
-                                    },
-                                  );
-                            },
-                            onCancelUnitWork: _cancelUnitWork,
-                            onStartWorkTargetSelection: (unit, workTarget) {
-                              Navigator.of(ctx).pop();
-                              setState(
-                                () => _workTargetSelection = (
-                                  unit: unit,
-                                  workTarget: workTarget,
-                                ),
-                              );
-                            },
-                          ),
-                        );
-                      },
-                    );
-                  },
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Image.asset(
-                        'assets/images/ui_icon_civilian_units.png',
-                        width: 20,
-                        height: 20,
-                      ),
-                      const SizedBox(width: 8),
-                      const Text('Civilian Units'),
-                    ],
-                  ),
-                ),
-                const SizedBox(width: 8),
-                CtNinePatchButton(
-                  onPressed: () {
-                    showModalBottomSheet<void>(
-                      context: context,
-                      builder: (ctx) => MilitaryUnitsPanel(
-                        game: widget.game,
-                        humanPlayerId: _humanPlayerId,
-                        onLocateTile: _onLocateMilitaryTile,
-                      ),
-                    );
-                  },
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Image.asset(
-                        'assets/images/ui_icon_military_units.png',
-                        width: 20,
-                        height: 20,
-                      ),
-                      const SizedBox(width: 8),
-                      const Text('Military Units'),
-                    ],
-                  ),
-                ),
-                const SizedBox(width: 8),
-                CtNinePatchButton(
-                  onPressed: () {
-                    final orders = ref.read(currentOrdersProvider);
-                    final mapData = ref
-                        .read(gameServiceProvider)
-                        .getMapData(widget.game.id);
-                    final topology =
-                        mapData?.combinedTopology ?? const MapTopology();
-                    Navigator.of(context).push<void>(
-                      MaterialPageRoute<void>(
-                        builder: (_) => DiplomacyScreen(
-                          game: widget.game,
-                          humanPlayerId: _humanPlayerId,
-                          topology: topology,
-                          currentOrders: orders,
-                          onOrdersChanged: (newOrders) {
-                            ref.read(currentOrdersProvider.notifier).state =
-                                newOrders;
-                          },
-                        ),
-                      ),
-                    );
-                  },
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Image.asset(
-                        'assets/images/ui_icon_diplomacy.png',
-                        width: 20,
-                        height: 20,
-                      ),
-                      const SizedBox(width: 8),
-                      const Text('Diplomacy'),
-                    ],
-                  ),
-                ),
-                const SizedBox(width: 8),
-                CtNinePatchButton(
-                  onPressed: () {
-                    final orders = ref.read(currentOrdersProvider);
-                    final player =
-                        widget.game.players
-                            .where((p) => p.isHuman)
-                            .firstOrNull ??
-                        widget.game.players.first;
-                    Navigator.of(context).push<void>(
-                      MaterialPageRoute<void>(
-                        builder: (ctx) => TechnologyScreen(
-                          game: widget.game,
-                          player: player,
-                          currentOrders: orders,
-                          onOrdersChanged: (newOrders) {
-                            ref.read(currentOrdersProvider.notifier).state =
-                                newOrders;
-                          },
-                        ),
-                      ),
-                    );
-                  },
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Image.asset(
-                        'assets/images/ui_icon_technology.png',
-                        width: 20,
-                        height: 20,
-                      ),
-                      const SizedBox(width: 8),
-                      const Text('Technology'),
-                    ],
-                  ),
-                ),
-              ],
             ],
           ),
         ),
         Expanded(
-          child: isNarrow
-              ? Focus(
-                  autofocus: true,
-                  onKeyEvent: (node, event) {
-                    if (_sideMenuOpen &&
-                        event is KeyDownEvent &&
-                        event.logicalKey == LogicalKeyboardKey.escape) {
-                      setState(() => _sideMenuOpen = false);
-                      return KeyEventResult.handled;
-                    }
-                    return KeyEventResult.ignored;
-                  },
-                  child: Stack(
+          child: Focus(
+            autofocus: true,
+            onKeyEvent: (node, event) {
+              if (_sideMenuOpen &&
+                  event is KeyDownEvent &&
+                  event.logicalKey == LogicalKeyboardKey.escape) {
+                setState(() => _sideMenuOpen = false);
+                return KeyEventResult.handled;
+              }
+              return KeyEventResult.ignored;
+            },
+            child: Stack(
+              children: [
+                Positioned.fill(
+                  child: Row(
                     children: [
-                      Positioned.fill(
+                      Expanded(
                         child: CtRegionMap(
                           region: _currentRegion,
                           cellSizePx: 24,
@@ -915,114 +711,68 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
                               : null,
                         ),
                       ),
-                      Positioned(
-                        left: 0,
-                        top: 0,
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            _buildBaseLayerCycleButton(),
-                            const SizedBox(height: 4),
-                            _buildHomeToCapitalButton(),
-                          ],
-                        ),
-                      ),
-                      if (isNarrow && !_sideMenuOpen)
-                        Positioned(
-                          left: 0,
-                          top: 0,
-                          bottom: 0,
-                          width: 20,
-                          child: GestureDetector(
-                            behavior: HitTestBehavior.translucent,
-                            onHorizontalDragUpdate: (details) {
-                              if (details.delta.dx > 20) {
-                                setState(() => _sideMenuOpen = true);
-                              }
-                            },
+                      if (!isNarrow && _selectedDetailId != null)
+                        SizedBox(
+                          width: 320,
+                          child: ProvinceSeaZoneDetailOverlay(
+                            game: widget.game,
+                            region: _currentRegion,
+                            selectedId: _selectedDetailId!,
+                            displayId: _displayId,
+                            humanPlayerId: _humanPlayerId,
+                            hoveredTileKey: _hoveredTileKey,
+                            onHighlightTile: (k) =>
+                                setState(() => _highlightedTileKey = k),
+                            onClose: () => setState(() {
+                              _selectedDetailId = null;
+                              _highlightedTileKey = null;
+                            }),
                           ),
                         ),
-                      if (_sideMenuOpen) ...[
-                        Positioned.fill(
-                          child: GestureDetector(
-                            behavior: HitTestBehavior.opaque,
-                            onTap: () => setState(() => _sideMenuOpen = false),
-                            child: Container(color: Colors.black54),
-                          ),
-                        ),
-                        _buildSideMenu(context),
-                      ],
                     ],
                   ),
-                )
-              : Stack(
-                  children: [
-                    Positioned.fill(
-                      child: Row(
-                        children: [
-                          Expanded(
-                            child: CtRegionMap(
-                              region: _currentRegion,
-                              cellSizePx: 24,
-                              visibilityMode:
-                                  CtMapVisibilityMode.playerConstrained,
-                              baseLayerDisplayMode: _baseLayerDisplayMode,
-                              onProvinceSelected: _onProvinceSelected,
-                              onProvinceHovered: (id) =>
-                                  setState(() => _hoveredDetailId = id),
-                              onTileHovered: (key) =>
-                                  setState(() => _hoveredTileKey = key),
-                              highlightedTileKey: _highlightedTileKey,
-                              centerOnTileKey: _centerOnTileKey,
-                              validTileKeys: _validTileKeysForSelection,
-                              onTileSelected: _workTargetSelection != null
-                                  ? _onTileSelectedForWork
-                                  : null,
-                              onWorkTargetSelectionCancelled:
-                                  _workTargetSelection != null
-                                  ? () => setState(
-                                      () => _workTargetSelection = null,
-                                    )
-                                  : null,
-                            ),
-                          ),
-                          if (!isNarrow && _selectedDetailId != null)
-                            SizedBox(
-                              width: 320,
-                              child: ProvinceSeaZoneDetailOverlay(
-                                game: widget.game,
-                                region: _currentRegion,
-                                selectedId: _selectedDetailId!,
-                                displayId: _displayId,
-                                humanPlayerId: _humanPlayerId,
-                                hoveredTileKey: _hoveredTileKey,
-                                onHighlightTile: (k) =>
-                                    setState(() => _highlightedTileKey = k),
-                                onClose: () => setState(() {
-                                  _selectedDetailId = null;
-                                  _highlightedTileKey = null;
-                                }),
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
-                    Positioned(
-                      left: 0,
-                      top: 0,
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          _buildBaseLayerCycleButton(),
-                          const SizedBox(height: 4),
-                          _buildHomeToCapitalButton(),
-                        ],
-                      ),
-                    ),
-                  ],
                 ),
+                Positioned(
+                  left: 0,
+                  top: 0,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _buildBaseLayerCycleButton(),
+                      const SizedBox(height: 4),
+                      _buildHomeToCapitalButton(),
+                    ],
+                  ),
+                ),
+                if (!_sideMenuOpen)
+                  Positioned(
+                    left: 0,
+                    top: 0,
+                    bottom: 0,
+                    width: 20,
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.translucent,
+                      onHorizontalDragUpdate: (details) {
+                        if (details.delta.dx > 20) {
+                          setState(() => _sideMenuOpen = true);
+                        }
+                      },
+                    ),
+                  ),
+                if (_sideMenuOpen) ...[
+                  Positioned.fill(
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTap: () => setState(() => _sideMenuOpen = false),
+                      child: Container(color: Colors.black54),
+                    ),
+                  ),
+                  _buildSideMenu(context),
+                ],
+              ],
+            ),
+          ),
         ),
         if (isNarrow && _selectedDetailId != null)
           SizedBox(

--- a/app/test/game_screen_narrow_test.dart
+++ b/app/test/game_screen_narrow_test.dart
@@ -1,4 +1,4 @@
-// In-game shell narrow viewport and side menu. SPEC/ui/in-game-shell-narrow.md, empire-buttons.md.
+// In-game shell side menu. SPEC/ui/in-game-shell-narrow.md, empire-buttons.md.
 
 import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/flame/game_screen.dart';
@@ -39,7 +39,7 @@ void main() {
 
   group('GameScreen — SPEC/ui/in-game-shell-narrow.md', () {
     testWidgets(
-      'AC: viewport >= 600 dp shows empire buttons in top bar',
+      'AC: top bar shows hamburger menu and turn counter; empire buttons NOT in top bar (wide viewport)',
       (WidgetTester tester) async {
         final dpr = tester.view.devicePixelRatio;
         tester.view.physicalSize = Size(1500 * dpr, 700 * dpr);
@@ -47,21 +47,25 @@ void main() {
         await tester.pumpWidget(buildGameScreen(width: 1500, height: 700));
         await tester.pump();
 
-        expect(find.text('Production'), findsOneWidget);
-        expect(find.text('Civilian Units'), findsOneWidget);
-        expect(find.text('Technology'), findsOneWidget);
+        expect(find.textContaining('Next turn'), findsOneWidget);
+        expect(find.byIcon(Icons.menu), findsOneWidget);
+        // Empire buttons should NOT be visible in top bar
+        expect(find.text('Production'), findsNothing);
+        expect(find.text('Civilian Units'), findsNothing);
+        expect(find.text('Technology'), findsNothing);
       },
       timeout: const Timeout(Duration(seconds: 15)),
     );
 
     testWidgets(
-      'AC: viewport < 600 dp shows only hamburger and turn counter in top bar',
+      'AC: top bar shows hamburger menu and turn counter; empire buttons NOT in top bar (narrow viewport)',
       (WidgetTester tester) async {
         await tester.pumpWidget(buildGameScreen(width: 399, height: 700));
         await tester.pump();
 
         expect(find.textContaining('Next turn'), findsOneWidget);
         expect(find.byIcon(Icons.menu), findsOneWidget);
+        // Empire buttons should NOT be visible in top bar
         expect(find.text('Production'), findsNothing);
       },
       timeout: const Timeout(Duration(seconds: 15)),


### PR DESCRIPTION
## Summary

Empire buttons (Production, Civilian Units, Military Units, Diplomacy, Technology) are now accessible only via the side menu (hamburger menu) for all viewport sizes.

Previously:
- Wide viewports: Empire buttons in top bar
- Narrow viewports: Empire buttons in side menu

Now:
- All viewports: Hamburger menu + turn counter in top bar
- All viewports: Empire buttons only in side menu

## Changes

**Code:**
- Removed empire buttons from wide viewport top bar in `game_screen.dart`
- Side menu now always available (not just narrow)
- Province detail overlay retains narrow/wide layout difference

**Specs:**
- `SPEC/ui/empire-buttons.md` - Updated to reflect buttons always in side menu
- `SPEC/ui/in-game-shell-narrow.md` - Updated to describe side menu for all viewports

**Tests:**
- Updated `game_screen_narrow_test.dart` to verify empire buttons not in top bar for any viewport

## Test

All 4 tests in `game_screen_narrow_test.dart` pass:
- Top bar shows hamburger + turn counter (wide viewport)
- Top bar shows hamburger + turn counter (narrow viewport)
- Empire buttons NOT in top bar
- Base layer cycle button works
- Home-to-capital button works