### PR TITLE
test(logic): add #22 fog/exploration coverage

### DIFF
--- a/packages/colonizethis_logic/test/game_setup_test.dart
+++ b/packages/colonizethis_logic/test/game_setup_test.dart
@@ -95,6 +95,18 @@ void main() {
 
       expect(result.tileMapByRegion['oldWorld'], owTileMap);
       expect(result.topologyByRegion['oldWorld'], owTopology);
+
+      // Initial visibility: Old World starts fogged/visible, New World unknown.
+      final visibility = result.game.worldState.playerVisibilityByTile;
+      expect(visibility, isNotEmpty);
+      final gp1Visibility = visibility[result.game.players.first.id] ?? const {};
+      expect(gp1Visibility.keys, isNotEmpty);
+      // All initial visible tiles for the starting GP are in Old World; New
+      // World tiles are unknown (absent from visibility map).
+      expect(
+        gp1Visibility.keys.every((tk) => tk.startsWith('oldWorld|')),
+        isTrue,
+      );
     });
 
     test('each Great Power has enough resources to build 5 improvements (bootstrap)', () {

--- a/packages/colonizethis_logic/test/naval_test.dart
+++ b/packages/colonizethis_logic/test/naval_test.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logic/src/world/naval_resolution.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
@@ -42,6 +43,81 @@ void main() {
         expect(isAdjacentSeaZone(topology, 'p1', 'sea2'), isFalse);
         expect(isAdjacentSeaZone(topology, 'p2', 'sea2'), isFalse);
       });
+    });
+
+    test('ship reveal sets coastal tiles to revealed when fleet enters sea zone',
+        () {
+      // Single coastal province adjacent to a sea zone; moving fleet into that
+      // sea zone should reveal the province's coastal tiles for the fleet owner.
+      const ow = 'oldWorld';
+      const provinceLocalId = 'p1';
+      const fullProvinceId = '$ow|$provinceLocalId';
+      const tileKey = '$fullProvinceId|0|0';
+
+      final revealTopology = MapTopology(
+        nodes: const [
+          TopologyNode(
+              id: provinceLocalId,
+              regionId: ow,
+              type: TopologyNodeType.province),
+          TopologyNode(
+              id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(
+              id: 'sea2', regionId: ow, type: TopologyNodeType.seaZone),
+        ],
+        edges: const [
+          // Province is coastal to the destination sea zone (sea2); sea1 adjacent
+          // to sea2 so fleet can move from sea1 into sea2 and then reveal coast.
+          TopologyEdge(id1: provinceLocalId, id2: 'sea2'),
+          TopologyEdge(id1: 'sea1', id2: 'sea2'),
+        ],
+      );
+
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.movement, turnNumber: 0),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+          fleets: const [
+            Fleet(
+              id: 'f1',
+              ownerId: 'gp1',
+              seaZoneId: 'sea1',
+              regionId: ow,
+              shipTypeIds: ['carrack'],
+            ),
+          ],
+          tileKeysByRegionAndProvince: const {
+            ow: {
+              fullProvinceId: [tileKey],
+            },
+          },
+          playerVisibilityByTile: const {
+            'gp1': {},
+          },
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'GP1', isHuman: true),
+        ],
+      );
+
+      final orders = {
+        'gp1': [
+          const NavalMoveOrder(
+            fleetId: 'f1',
+            destinationSeaZoneId: 'sea2',
+          ),
+        ],
+      };
+
+      final next =
+          applyNavalMovesAndShipReveal(game, revealTopology, orders);
+
+      expect(
+        next.worldState.playerVisibilityByTile['gp1']?[tileKey],
+        VisibilityLevel.revealed.name,
+      );
     });
 
     group('firstAdjacentSeaZone', () {

--- a/packages/colonizethis_logic/test/orders_application_test.dart
+++ b/packages/colonizethis_logic/test/orders_application_test.dart
@@ -1206,6 +1206,79 @@ void main() {
       expect(u.currentWork!.remainingTurns, u.currentWork!.totalTurns - 1);
     });
 
+    test(
+        'explore work order totalTurns uses region-scoped formula ceil(3 * tilesInP / maxTilesInRegion)',
+        () {
+      // Region has two provinces with different tile counts; explorer in the
+      // smaller one should get totalTurns = ceil(3 * tilesInP / maxTilesInRegion).
+      const ow = 'oldWorld';
+      const provinceSmall = '$ow|P1';
+      const provinceLarge = '$ow|P2';
+      const tileSmall1 = '$ow|P1|0|0';
+      const tileSmall2 = '$ow|P1|1|0';
+      const tileLarge1 = '$ow|P2|0|0';
+      const tileLarge2 = '$ow|P2|1|0';
+      const tileLarge3 = '$ow|P2|2|0';
+      const tileLarge4 = '$ow|P2|3|0';
+
+      final unit = Unit(
+        id: 'u1',
+        type: 'Explorer',
+        ownerId: 'p1',
+        provinceId: provinceSmall,
+        tileKey: tileSmall1,
+      );
+
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: provinceSmall, regionId: ow, ownerId: 'p1'),
+              Province(id: provinceLarge, regionId: ow, ownerId: 'p1'),
+            ],
+            units: [unit],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: const {
+            ow: {
+              provinceSmall: [tileSmall1, tileSmall2], // tilesInP = 2
+              provinceLarge: [
+                tileLarge1,
+                tileLarge2,
+                tileLarge3,
+                tileLarge4,
+              ], // maxTilesInRegion = 4
+            },
+          },
+        ),
+        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+      );
+
+      final orders = Orders(
+        workOrdersByPlayerId: {
+          'p1': [
+            const WorkOrder(
+              unitId: 'u1',
+              target: 'explore',
+              targetTileKey: tileSmall1,
+            ),
+          ],
+        },
+      );
+
+      final next = applyBuildAndWorkOrders(game, orders);
+      final u = next.worldState.oldWorld.units.single;
+
+      // tilesInP = 2, maxTilesInRegion = 4 → ceil(3 * 2 / 4) = ceil(1.5) = 2.
+      expect(u.currentWork, isNotNull);
+      expect(u.currentWork!.workTarget, 'explore');
+      expect(u.currentWork!.totalTurns, 2);
+      // One turn processed in same phase after applying.
+      expect(u.currentWork!.remainingTurns, 1);
+    });
+
     test('Engineer build_road work order sets currentWork', () {
       final unit = Unit(
         id: 'u1',


### PR DESCRIPTION
## Summary
- Add regression tests for #22 fog/exploration behavior.
- Cover: initial New World visibility is unknown, explore work order duration formula, and ship coastal reveal when entering a sea zone.

## Test plan
- `cd packages/colonizethis_logic && dart test`

Made with [Cursor](https://cursor.com)