### PR TITLE
Lighten fogged visibility on map widget

### DIFF
--- a/SPEC/ui/map-widget.md
+++ b/SPEC/ui/map-widget.md
@@ -109,7 +109,7 @@ When the widget is in **player-constrained visibility mode**, it maps `CellViewD
 
 - **`visible`:** The tile is rendered unmodified (full terrain color, resource/improvement/road letters, and borders).
 - **`fogged`:** The tile is rendered with the same content as `visible` but visually muted:
-  - The base terrain color is blended towards a **darker gray or black** with a consistent opacity factor (e.g. at least 60% of the way towards black) so fogged tiles are noticeably darker than fully visible tiles.
+  - The base terrain color is blended towards a **darker gray or black** with a consistent, moderate darkening (e.g. ~40% toward black / 40% overlay) so fogged tiles are noticeably darker than fully visible tiles but remain readable.
   - Resource/improvement/road letters remain readable but appear on the muted background.
 - **`unrevealed`:** The tile is rendered as a solid black square:
   - No terrain color or letters are shown.
@@ -201,7 +201,7 @@ Tilesets are stored in `assets/images/terrain/`:
 
 When rendering in **player-constrained visibility mode**:
 - **visible tiles:** Render full tileset tiles
-- **fogged tiles:** Apply 70% black overlay to tile
+- **fogged tiles:** Apply a moderate black overlay to tile (e.g. 40% opacity) so fogged areas stay readable
 - **unrevealed tiles:** Render solid black (no tile)
 
 ### Fallback Behavior

--- a/app/lib/features/game/flame/region_map_component.dart
+++ b/app/lib/features/game/flame/region_map_component.dart
@@ -10,6 +10,11 @@ import 'terrain_tileset.dart';
 
 final _log = Logger();
 
+/// Fog strength for fogged tiles: lerp toward black (0 = no fog, 1 = full black).
+const double _fogLerp = 0.4;
+/// Fog overlay opacity when drawing a dark rect over tiles (0 = no overlay, 1 = full black).
+const double _fogOverlayOpacity = 0.4;
+
 /// Check if a terrain type uses L2+ standalone tile rendering (features).
 /// L0: Sea (Wang). L1: Plains/Desert (Wang). L2+: Features (standalone).
 bool _isFeatureTerrain(TerrainType terrain) {
@@ -287,7 +292,7 @@ class CtRegionMapComponent extends PositionComponent {
           case TileVisibility.visible:
             break;
           case TileVisibility.fogged:
-            finalColor = Color.lerp(baseColor, Colors.black, 0.7)!;
+            finalColor = Color.lerp(baseColor, Colors.black, _fogLerp)!;
             break;
           case TileVisibility.unrevealed:
             finalColor = Colors.black;
@@ -355,7 +360,7 @@ class CtRegionMapComponent extends PositionComponent {
       final foggedColor =
           visibilityMode == CtMapVisibilityMode.playerConstrained &&
               cell.visibility == TileVisibility.fogged
-          ? Color.lerp(baseColor, Colors.black, 0.7)!
+          ? Color.lerp(baseColor, Colors.black, _fogLerp)!
           : baseColor;
       canvas.drawRect(
         Rect.fromLTWH(left, top, cellSize, cellSize),
@@ -378,7 +383,7 @@ class CtRegionMapComponent extends PositionComponent {
             cell.visibility == TileVisibility.fogged) {
           canvas.drawRect(
             dstRect,
-            Paint()..color = const Color.fromRGBO(0, 0, 0, 0.7),
+            Paint()..color = Color.fromRGBO(0, 0, 0, _fogOverlayOpacity),
           );
         }
       }
@@ -513,8 +518,8 @@ class CtRegionMapComponent extends PositionComponent {
         final paint = Paint();
         if (visibilityMode == CtMapVisibilityMode.playerConstrained &&
             cell.visibility == TileVisibility.fogged) {
-          paint.colorFilter = const ColorFilter.mode(
-            Color.fromRGBO(0, 0, 0, 0.7),
+          paint.colorFilter = ColorFilter.mode(
+            Color.fromRGBO(0, 0, 0, _fogOverlayOpacity),
             BlendMode.darken,
           );
         }
@@ -541,8 +546,8 @@ class CtRegionMapComponent extends PositionComponent {
   void _applyVisibilityFilter(CellViewData cell, Paint paint) {
     if (visibilityMode == CtMapVisibilityMode.playerConstrained &&
         cell.visibility == TileVisibility.fogged) {
-      paint.colorFilter = const ColorFilter.mode(
-        Color.fromRGBO(0, 0, 0, 0.7),
+      paint.colorFilter = ColorFilter.mode(
+        Color.fromRGBO(0, 0, 0, _fogOverlayOpacity),
         BlendMode.darken,
       );
     }
@@ -551,7 +556,7 @@ class CtRegionMapComponent extends PositionComponent {
   Color _applyFog(CellViewData cell, Color baseColor) {
     if (visibilityMode == CtMapVisibilityMode.playerConstrained &&
         cell.visibility == TileVisibility.fogged) {
-      return Color.lerp(baseColor, Colors.black, 0.7)!;
+      return Color.lerp(baseColor, Colors.black, _fogLerp)!;
     }
     return baseColor;
   }
@@ -700,7 +705,7 @@ class CtRegionMapComponent extends PositionComponent {
         cell.visibility == TileVisibility.fogged) {
       canvas.drawRect(
         dstRect,
-        Paint()..color = const Color.fromRGBO(0, 0, 0, 0.7),
+        Paint()..color = Color.fromRGBO(0, 0, 0, _fogOverlayOpacity),
       );
     }
     return true;


### PR DESCRIPTION
## Summary
Fogged tiles on the app map were too dark. This PR lightens the fog so previously seen areas stay readable while still clearly distinct from fully visible tiles.

## Changes
- **app:** Reduced fog strength from 70% to 40% (both lerp toward black and overlay opacity) in `region_map_component.dart`. Introduced `_fogLerp` and `_fogOverlayOpacity` constants so fog strength can be tuned in one place.
- **SPEC/ui/map-widget.md:** Updated fog description to "moderate darkening (~40% toward black / 40% overlay)" and "Apply a moderate black overlay (e.g. 40% opacity)" so the spec matches implementation.

## Spec alignment
- `SPEC/ui/map-widget.md` § Tile rendering semantics per visibility and § Visibility Integration now describe the lighter fog; `SPEC/ui/layered-terrain-rendering.md` already says "appropriate darkening" (unchanged).

Made with [Cursor](https://cursor.com)