### PR TITLE
fix: production panel updates when allocation state changes

### DIFF
--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -522,7 +522,6 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
     final orders = ref.read(currentOrdersProvider);
     final mapData = ref.read(gameServiceProvider).getMapData(widget.game.id);
     final topology = mapData?.combinedTopology ?? const MapTopology();
-    final desired = ref.read(productionDesiredOutputProvider);
     return [
       _empireButton(
         context,
@@ -535,11 +534,6 @@ class _GameMapAreaState extends ConsumerState<_GameMapArea> {
               builder: (ctx) => ProductionScreen(
                 game: widget.game,
                 player: player,
-                desiredOutputByRecipe: desired,
-                onDesiredOutputChanged: (newMap) {
-                  ref.read(productionDesiredOutputProvider.notifier).state =
-                      newMap;
-                },
               ),
             ),
           );

--- a/app/lib/features/game/widgets/production_screen.dart
+++ b/app/lib/features/game/widgets/production_screen.dart
@@ -2,26 +2,26 @@
 
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../providers/production_allocation_provider.dart';
 import '../../../widgets/ct_screen_shell.dart';
 import 'production_panel.dart';
 
-class ProductionScreen extends StatelessWidget {
+class ProductionScreen extends ConsumerWidget {
   const ProductionScreen({
     super.key,
     required this.game,
     required this.player,
-    required this.desiredOutputByRecipe,
-    required this.onDesiredOutputChanged,
   });
 
   final Game game;
   final Player player;
-  final Map<String, int> desiredOutputByRecipe;
-  final ValueChanged<Map<String, int>> onDesiredOutputChanged;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final desiredOutputByRecipe = ref.watch(productionDesiredOutputProvider);
+
     return CtScreenShell(
       title: 'Production',
       showBackButton: true,
@@ -29,7 +29,9 @@ class ProductionScreen extends StatelessWidget {
         game: game,
         player: player,
         desiredOutputByRecipe: desiredOutputByRecipe,
-        onDesiredOutputChanged: onDesiredOutputChanged,
+        onDesiredOutputChanged: (next) {
+          ref.read(productionDesiredOutputProvider.notifier).state = next;
+        },
       ),
     );
   }

--- a/app/test/production_screen_integration_test.dart
+++ b/app/test/production_screen_integration_test.dart
@@ -1,0 +1,92 @@
+// Integration tests for ProductionScreen + productionDesiredOutputProvider.
+// SPEC/ui/production-panel.md.
+
+import 'package:colonizethis_app/features/game/widgets/production_panel_demo_data.dart';
+import 'package:colonizethis_app/features/game/widgets/province_overlay_demo_data.dart';
+import 'package:colonizethis_app/features/game/widgets/production_screen.dart';
+import 'package:colonizethis_app/widgets/ct_slider.dart';
+import 'package:colonizethis_app/providers/production_allocation_provider.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  late Game demoGame;
+  late Player fullPlayer;
+
+  setUpAll(() {
+    demoGame = demoGameForOverlay;
+    fullPlayer = fullAvailabilityProductionPlayer();
+  });
+
+  Widget _buildScreen({
+    Map<String, int>? initialDesiredOutput,
+    double width = 800,
+    double height = 500,
+  }) {
+    return ProviderScope(
+      overrides: [
+        if (initialDesiredOutput != null)
+          productionDesiredOutputProvider
+              .overrideWith((ref) => initialDesiredOutput),
+      ],
+      child: MaterialApp(
+        home: MediaQuery(
+          data: MediaQueryData(size: Size(width, height)),
+          child: ProductionScreen(game: demoGame, player: fullPlayer),
+        ),
+      ),
+    );
+  }
+
+  group('ProductionScreen + provider integration', () {
+    testWidgets(
+      'preseeded provider state is reflected in Available net changes',
+      (WidgetTester tester) async {
+        // 5 runs of lumber_from_timber consume 10 timber and produce 5 lumber,
+        // matching expectations from ProductionPanel tests.
+        await tester.pumpWidget(
+          _buildScreen(initialDesiredOutput: {'lumber_from_timber': 5}),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('Timber:'), findsOneWidget);
+        expect(find.textContaining(RegExp(r'\(-10\)')), findsOneWidget);
+        expect(find.textContaining('Lumber:'), findsOneWidget);
+        expect(find.textContaining(r'(+5)'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'moving a slider updates derived values via provider rebuild',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(_buildScreen());
+        await tester.pumpAndSettle();
+
+        // Initially there should be no net change annotations like "(-" or "(+"
+        // for timber; after dragging a slider, they should appear.
+        expect(find.textContaining('Timber:'), findsOneWidget);
+
+        final sliders = find.byType(CtSlider);
+        expect(sliders, findsNWidgets(ProductionRecipesCatalog.all.length));
+
+        await tester.drag(sliders.first, const Offset(80, 0));
+        await tester.pumpAndSettle();
+
+        // After the drag, the provider has been updated and the screen rebuilt,
+        // so net changes should now be visible.
+        expect(find.textContaining('Timber:'), findsOneWidget);
+        expect(
+          find.textContaining(RegExp(r'\(|\+|-')),
+          findsWidgets,
+        );
+      },
+    );
+  });
+}
+


### PR DESCRIPTION
## Summary
Production panel was not updating the Available resources list or slider values when the user changed allocations; data only refreshed after leaving and re-entering the panel.

## Changes
- **ProductionScreen** is now a `ConsumerWidget` that **watches** `productionDesiredOutputProvider`. When the provider updates (slider drag or Reset), the screen rebuilds and passes the new map into `ProductionPanel`, so net changes and slider caps/values update immediately.
- **Game screen** no longer passes a one-time snapshot of `desiredOutputByRecipe` into `ProductionScreen`; the screen takes only `game` and `player` and reads/writes the provider itself.
- **Integration tests** (`app/test/production_screen_integration_test.dart`):
  - Preseeded provider state is reflected in Available net changes.
  - Moving a slider updates derived values via provider rebuild (net change text appears after drag).

## Spec
SPEC/ui/production-panel.md — behaviour: sliders and net changes update as allocations change.

Made with [Cursor](https://cursor.com)