### PR TITLE
fix(map): enforce Wang tileset loading and add coverage

### DIFF
--- a/app/lib/features/game/flame/region_map_component.dart
+++ b/app/lib/features/game/flame/region_map_component.dart
@@ -501,34 +501,36 @@ class CtRegionMapComponent extends PositionComponent {
     final terrain = cell.terrainType;
     if (terrain == null || !_isFeatureTerrain(terrain)) return;
 
-    // All features use standalone tiles; plains base is already drawn in pass 1
+    // All features use standalone tiles; plains base is already drawn in pass 1.
+    // If a standalone tile is missing (e.g. asset regression), skip drawing the
+    // overlay rather than failing the entire map render. Wang tilesets remain
+    // strict (they must exist), but L2+ overlays are best-effort.
     final standaloneTile = terrainTilesetCache.getStandaloneTile(terrain);
-
-    if (standaloneTile != null) {
-      final paint = Paint();
-      if (visibilityMode == CtMapVisibilityMode.playerConstrained &&
-          cell.visibility == TileVisibility.fogged) {
-        paint.colorFilter = ColorFilter.mode(
-          Color.fromRGBO(0, 0, 0, _fogOverlayOpacity),
-          BlendMode.darken,
-        );
-      }
-
-      final srcRect = Rect.fromLTWH(
-        0,
-        0,
-        standaloneTile.image.width.toDouble(),
-        standaloneTile.image.height.toDouble(),
+    if (standaloneTile == null) {
+      _log.w(
+        'Standalone tile missing for terrain=$terrain; '
+        'skipping feature overlay for cell (${cell.x}, ${cell.y})',
       );
-      final dstRect = Rect.fromLTWH(left, top, cellSize, cellSize);
-      canvas.drawImageRect(standaloneTile.image, srcRect, dstRect, paint);
       return;
     }
 
-    throw StateError(
-      'Standalone tile not found for terrain=$terrain - '
-      'terrain tileset failed to load',
+    final paint = Paint();
+    if (visibilityMode == CtMapVisibilityMode.playerConstrained &&
+        cell.visibility == TileVisibility.fogged) {
+      paint.colorFilter = ColorFilter.mode(
+        Color.fromRGBO(0, 0, 0, _fogOverlayOpacity),
+        BlendMode.darken,
+      );
+    }
+
+    final srcRect = Rect.fromLTWH(
+      0,
+      0,
+      standaloneTile.image.width.toDouble(),
+      standaloneTile.image.height.toDouble(),
     );
+    final dstRect = Rect.fromLTWH(left, top, cellSize, cellSize);
+    canvas.drawImageRect(standaloneTile.image, srcRect, dstRect, paint);
   }
 
   _CornerValues _getCornerValues(

--- a/app/lib/features/game/flame/terrain_tileset.dart
+++ b/app/lib/features/game/flame/terrain_tileset.dart
@@ -139,49 +139,42 @@ class TerrainTilesetCache {
     if (_isLoaded || _isLoading) return;
     _isLoading = true;
 
-    final loadFutures = <Future<void>>[];
-
-    // L0/L1 Wang tilesets for coastline and land transitions
-    loadFutures.add(
-      _loadWangTileset(
-        'sea_plains',
-        seaTerrainId,
-        plainsTerrainId,
-        (tileset) => _seaPlainsTileset = tileset,
-      ),
-    );
-    loadFutures.add(
-      _loadWangTileset(
-        'sea_desert',
-        seaTerrainId,
-        desertTerrainId,
-        (tileset) => _seaDesertTileset = tileset,
-      ),
-    );
-    loadFutures.add(
-      _loadWangTileset(
-        'plains_desert',
-        plainsTerrainId,
-        desertTerrainId,
-        (tileset) => _plainsDesertTileset = tileset,
-      ),
-    );
-
-    // L2+ Standalone tiles for features (forest, hills, mountain, swamp)
-    // Note: Desert is now L1, not a standalone feature
-    for (final feature in [
-      TerrainType.forest,
-      TerrainType.hills,
-      TerrainType.mountain,
-      TerrainType.swamp,
-    ]) {
-      loadFutures.add(
-        _loadStandaloneTile('${feature.name}_standalone', feature.name),
-      );
-    }
-
     try {
-      await Future.wait(loadFutures);
+      // Load L0/L1 Wang tilesets for coastline and land transitions.
+      await Future.wait([
+        _loadWangTileset(
+          'sea_plains',
+          seaTerrainId,
+          plainsTerrainId,
+          (tileset) => _seaPlainsTileset = tileset,
+        ),
+        _loadWangTileset(
+          'sea_desert',
+          seaTerrainId,
+          desertTerrainId,
+          (tileset) => _seaDesertTileset = tileset,
+        ),
+        _loadWangTileset(
+          'plains_desert',
+          plainsTerrainId,
+          desertTerrainId,
+          (tileset) => _plainsDesertTileset = tileset,
+        ),
+      ]);
+
+      // L2+ standalone feature tiles are best-effort and loaded in the background.
+      // Failures must not block base terrain or map rendering. Desert is now L1.
+      for (final feature in [
+        TerrainType.forest,
+        TerrainType.hills,
+        TerrainType.mountain,
+        TerrainType.swamp,
+      ]) {
+        // Intentionally not awaited; errors are logged inside _loadStandaloneTile.
+        // ignore: discarded_futures
+        _loadStandaloneTile('${feature.name}_standalone', feature.name);
+      }
+
       _isLoaded = true;
     } catch (e) {
       _log.e('One or more terrain tilesets failed to load', error: e);
@@ -260,12 +253,11 @@ class TerrainTilesetCache {
         image: image,
       );
     } catch (e, stackTrace) {
-      _log.e(
-        'Failed to load standalone tile: $name',
+      _log.w(
+        'Failed to load standalone tile (non-fatal): $name',
         error: e,
         stackTrace: stackTrace,
       );
-      rethrow;
     }
   }
 

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -37,5 +37,6 @@ flutter:
   assets:
     - assets/images/
     - assets/images/terrain/
+    - assets/images/terrain/tilesets/
     - assets/dialogue/
 

--- a/app/test/ct_region_map_test.dart
+++ b/app/test/ct_region_map_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:colonizethis_app/features/game/flame/terrain_tileset.dart';
 import 'package:colonizethis_app/widgets/ct_region_map.dart'
     show BaseLayerDisplayMode, CtRegionMap, CtMapVisibilityMode;
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
@@ -92,6 +93,51 @@ void main() {
   }
 
   group('CtRegionMap (Flame map widget)', () {
+    testWidgets(
+      'required Wang tileset asset files are present in test asset bundle',
+      (WidgetTester tester) async {
+        // Pump a minimal widget tree so the test binding and asset bundle are initialized.
+        await tester.pumpWidget(const SizedBox.shrink());
+
+        const pngPaths = [
+          'assets/images/terrain/tilesets/tileset_sea_plains.png',
+          'assets/images/terrain/tilesets/tileset_sea_desert.png',
+          'assets/images/terrain/tilesets/tileset_plains_desert.png',
+        ];
+        const jsonPaths = [
+          'assets/images/terrain/tilesets/tileset_sea_plains.json',
+          'assets/images/terrain/tilesets/tileset_sea_desert.json',
+          'assets/images/terrain/tilesets/tileset_plains_desert.json',
+        ];
+
+        for (final path in [...pngPaths, ...jsonPaths]) {
+          final data = await rootBundle.load(path);
+          expect(data.lengthInBytes, greaterThan(0), reason: 'Asset $path is empty');
+        }
+      },
+      timeout: const Timeout(Duration(seconds: 10)),
+    );
+
+    testWidgets(
+      'loads required Wang tilesets before rendering map',
+      (WidgetTester tester) async {
+        await tester.runAsync(() async {
+          await terrainTilesetCache.load();
+        });
+
+        expect(terrainTilesetCache.isLoaded, isTrue);
+        expect(terrainTilesetCache.getSeaPlainsTileset(), isNotNull);
+        expect(terrainTilesetCache.getSeaDesertTileset(), isNotNull);
+        expect(terrainTilesetCache.getPlainsDesertTileset(), isNotNull);
+
+        final region = _oldWorldRegion();
+        await tester.pumpWidget(_buildCtRegionMap(region: region));
+        await tester.pump();
+
+        expect(find.byType(CtRegionMap), findsOneWidget);
+      },
+      timeout: const Timeout(Duration(seconds: 10)),
+    );
     testWidgets(
       'builds without throwing for old world region',
       (WidgetTester tester) async {


### PR DESCRIPTION
## Summary
- Ensure Wang tilesets are treated as required base assets: if any Wang tileset fails to load, the map does not render silently.
- Make standalone feature tiles (forest/hills/mountain/swamp) best-effort: failures no longer blank the map or fail tests.
- Fix Flutter asset configuration so Wang tileset PNG/JSON files under `assets/images/terrain/tilesets/` are available in tests and on mobile.
- Add CtRegionMap widget tests that assert tileset assets are in the bundle and that the global terrain tileset cache successfully loads Wang tilesets before rendering.

## Test plan
- `cd app && flutter test test/ct_region_map_test.dart`
- Manual smoke test on device/emulator: open in-game map and verify terrain tiles render; break a tileset asset path to see tests fail.

Made with [Cursor](https://cursor.com)