### PR TITLE
fix(map): soften province/sea-zone political borders

### DIFF
--- a/SPEC/ui/map-widget.md
+++ b/SPEC/ui/map-widget.md
@@ -273,7 +273,8 @@ If a tileset fails to load, the widget falls back to solid color rendering using
 ## Acceptance criteria
 
 - **Given** a map widget with a region's data, **when** the widget is laid out, **then** the viewport matches the widget size and shows the base tile layer (terrain, resources, improvements, towns, capitals) at the current zoom level.
-- **When** the political overlay is enabled, **then** political borders are drawn on top of the base layer; when disabled, they are not.
+- **When** the political overlay is enabled, **then** political borders are drawn on top of the base layer (including province and sea-zone boundaries); when disabled, they are not.
+- **When** the map renders province/sea-zone boundaries, **then** land↔sea-zone edges use a subtle/fainter stroke (instead of a solid black line); other political borders are also rendered subtly (not solid black).
 - **When** the user pans, **then** the visible portion of the map updates; the full map remains pannable within the fixed scale.
 - **When** the user zooms, **then** only fixed zoom levels are used and zooming is smooth between levels.
 - **When** the user taps/clicks a province, **then** the widget invokes the provided province-selection callback with an identifier (e.g. prefixed province id); the widget does not render province details itself.

--- a/app/lib/features/game/flame/region_map_component.dart
+++ b/app/lib/features/game/flame/region_map_component.dart
@@ -14,6 +14,12 @@ final _log = Logger();
 /// Fog overlay opacity when drawing a dark rect over tiles (0 = no overlay, 1 = full black).
 const double _fogOverlayOpacity = 0.4;
 
+/// Political border stroke colors.
+/// These are intentionally subtle so they don't overpower the terrain art.
+const Color _provinceBorderLandColor = Color.fromRGBO(0, 0, 0, 0.35);
+const Color _provinceBorderSeaLandColor = Color.fromRGBO(0, 0, 0, 0.25);
+const Color _provinceBorderSeaZoneColor = Color.fromRGBO(130, 200, 255, 0.55);
+
 /// Check if a terrain type uses L2+ standalone tile rendering (features).
 /// L0: Sea (Wang). L1: Plains/Desert (Wang). L2+: Features (standalone).
 bool _isFeatureTerrain(TerrainType terrain) {
@@ -775,13 +781,14 @@ class CtRegionMapComponent extends PositionComponent {
     final paint = Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = 1.0
-      ..color = Colors.black;
+      ..color = _provinceBorderLandColor;
     for (var y = 0; y < region.height; y++) {
       for (var x = 0; x < region.width; x++) {
         final cell = region.cellAt(x, y);
         if (x + 1 < region.width) {
           final right = region.cellAt(x + 1, y);
           if (cell.regionCellId != right.regionCellId) {
+            paint.color = _provinceBorderColor(cell, right);
             final xEdge = (x + 1) * cellSize;
             canvas.drawLine(
               Offset(xEdge, y * cellSize),
@@ -793,6 +800,7 @@ class CtRegionMapComponent extends PositionComponent {
         if (y + 1 < region.height) {
           final bottom = region.cellAt(x, y + 1);
           if (cell.regionCellId != bottom.regionCellId) {
+            paint.color = _provinceBorderColor(cell, bottom);
             final yEdge = (y + 1) * cellSize;
             canvas.drawLine(
               Offset(x * cellSize, yEdge),
@@ -803,6 +811,15 @@ class CtRegionMapComponent extends PositionComponent {
         }
       }
     }
+  }
+
+  Color _provinceBorderColor(CellViewData a, CellViewData b) {
+    final aIsSea = a.isSea;
+    final bIsSea = b.isSea;
+    if (aIsSea && bIsSea) return _provinceBorderSeaZoneColor;
+    if (!aIsSea && !bIsSea) return _provinceBorderLandColor;
+    // Mixed land/sea edge.
+    return _provinceBorderSeaLandColor;
   }
 
   void _paintFactionBorders(Canvas canvas) {


### PR DESCRIPTION
## Summary
- Province/sea-zone boundaries in the app map widget are now rendered with a fainter stroke (no solid black lines).
- Updated  acceptance criteria to match the new styling.

## Test plan
- Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 93.0.0 (98.0.0 available)
  analyzer 10.0.1 (12.0.0 available)
  ansi_escape_codes 2.2.1 (3.0.2 available)
  cli_launcher 0.3.2+1 (0.3.3 available)
  flutter_riverpod 2.6.1 (3.3.1 available)
  google_fonts 6.3.3 (8.0.2 available)
  logger 2.6.2 (2.7.0 available)
  matcher 0.12.18 (0.12.19 available)
> meta 1.18.0 (was 1.17.0) (1.18.2 available)
  nocterm 0.4.4 (0.6.0 available)
  riverpod 2.6.1 (3.2.1 available)
  test 1.29.0 (1.30.0 available)
  test_api 0.7.9 (0.7.10 available)
  test_core 0.6.15 (0.6.16 available)
Changed 1 dependency!
14 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
00:00 +0: loading /home/clawd/colonizethisv3/test/ct_region_map_test.dart
00:00 +0 -1: loading /home/clawd/colonizethisv3/test/ct_region_map_test.dart [E]
  Failed to load "/home/clawd/colonizethisv3/test/ct_region_map_test.dart": Does not exist.
00:00 +0 -1: Some tests failed. (app)

Made with [Cursor](https://cursor.com)