### PR TITLE
feat(map): map display options dialog + borders toggle

### DIFF
--- a/SPEC/ui/empire-overview.md
+++ b/SPEC/ui/empire-overview.md
@@ -40,6 +40,14 @@
 - **Target:** Always uses the **current human player** (same rule as for visibility and panels). If multiple players are marked `isHuman`, use the first; if none are marked, fall back to the first player in the list.
 - **Behavior:** When tapped, the button **switches the active region** (Old World / New World) if necessary so that the map shows the human player's **capital region**, then **centers the camera** on the human player's **capital tile** and moves the **selection/highlight cursor** onto that tile. Capital identity comes from `Player.capitalTile` (tile key format `regionId|provinceId|x|y` per [world-model-identity.md](../game/world-model-identity.md) and [map-visualization.md](../program/map-visualization.md)).
 
+### Map display options button and dialog (in-game map only)
+
+- **Overlay:** A third button is overlaid at the **top-left** of the map area, directly **beneath** the home-to-capital button. The button uses a compact text label such as `Map options` inside a light rectangular chip (no custom pixel-art icon required). The button is shown only on the in-game Empire overview map, not in Widgetbook or debug map stories.
+- **Dialog type:** Tapping the button opens a modal **“Map display options”** dialog that blocks interaction with the underlying map and closes when the user taps the dialog’s **Close** button, taps outside the dialog, or presses the back key.
+- **Borders toggle:** The dialog contains a single toggle control labelled **“Show borders”** (switch or checkbox). The toggle controls the global **borders layer visibility** for all in-game Empire overview maps in the current app session (Old World and New World).
+- **Default behavior:** At the start of a game session (after init or load), the **Show borders** toggle is **ON** by default. When the user changes it, the new value is remembered for the remainder of the session and is reflected every time the dialog is reopened.
+- **Effect on rendering:** When **Show borders** is ON, the map widget draws province and sea-zone boundary strokes per [map-widget.md](map-widget.md) § Layer model. When OFF, province and sea-zone boundary strokes are not drawn; hover selectors, hover province glows, capitals, ports, and warp zone indicators remain visible.
+
 ---
 
 ## Wireframe (conceptual)
@@ -75,6 +83,12 @@ On mobile: same tab row; map area fills available space; one region visible at a
 
 - **Given** the Empire overview map is visible, **then** a second icon-only button with the home/flag icon is visible directly beneath the base-layer cycle button at the top-left of the map area.
 - **Given** the Empire overview map is visible and the human player has a defined capital tile, **when** the user taps the h button, **then** the active region switches (if needed) to the human player's capital region and the map centers on the human player's capital tile with the selection/highlight cursor placed on that tile.
+
+- **Given** the Empire overview map is visible, **then** a third button with a compact text label (e.g. `Map options`) is visible directly beneath the home-to-capital button at the top-left of the map area.
+- **Given** the Empire overview map is visible, **when** the user taps the third map display options button, **then** the UI layer shows a modal dialog titled `Map display options` with a dismiss action and the underlying map is not interactive until the dialog is closed.
+- **Given** the Map display options dialog is visible for the first time in a game session, **then** the dialog shows a single toggle control labelled `Show borders` in the ON state.
+- **Given** the Map display options dialog is visible, **when** the user toggles `Show borders` OFF, **then** the UI layer updates the global borders visibility state so that all in-game Empire overview maps stop drawing province and sea-zone boundary strokes until `Show borders` is toggled ON again.
+- **Given** the user has toggled `Show borders` OFF in the Map display options dialog and then closed the dialog, **when** the user reopens the Map display options dialog in the same app session, **then** the `Show borders` toggle appears in the OFF state and the in-game maps continue to omit province and sea-zone boundary strokes.
 
 ---
 

--- a/SPEC/ui/map-widget.md
+++ b/SPEC/ui/map-widget.md
@@ -20,7 +20,8 @@
 | Layer | Content | Togglable |
 |-------|---------|-----------|
 | **Base (tile)** | Terrain, resources, improvements, towns, capitals. | Optional per-sublayer if needed; at minimum base is always on. |
-| **Political** | Political borders (ownership). Drawn on top of base. | Yes. User can turn political overlay on/off. |
+| **Borders** | Province and sea-zone boundaries (topology edges P–P, P–S, S–S). | Yes. User can turn the borders layer on/off. |
+| **Political** | Political borders (ownership differences between adjacent land provinces). Drawn on top of base and borders. | Yes. User can turn political overlay on/off. |
 
 Data source for tiles and ownership: shared view model (e.g. `RegionMapViewData` / game + tile maps per [map-visualization.md](../program/map-visualization.md)). Province and tile identity: [world-model-identity.md](../game/world-model-identity.md).
 
@@ -274,8 +275,10 @@ If a tileset fails to load, the widget falls back to solid color rendering using
 ## Acceptance criteria
 
 - **Given** a map widget with a region's data, **when** the widget is laid out, **then** the viewport matches the widget size and shows the base tile layer (terrain, resources, improvements, towns, capitals) at the current zoom level.
-- **When** the political overlay is enabled, **then** political borders are drawn on top of the base layer (including province and sea-zone boundaries); when disabled, they are not.
-- **When** the map renders province/sea-zone boundaries, **then** land↔sea-zone edges use a subtle/fainter stroke (instead of a solid black line); other political borders are also rendered subtly (not solid black).
+- **Given** the borders layer is enabled, **when** the map renders province and sea-zone boundaries, **then** land↔sea-zone edges use a subtle/fainter stroke (instead of a solid black line) and other province/sea-zone borders are rendered subtly (not solid black).
+- **Given** the borders layer is disabled, **when** the map renders the region, **then** province and sea-zone boundary strokes are not drawn while hover selectors, hover glows, capitals, ports, and warp zone indicators remain visible.
+- **Given** the political overlay is enabled while the borders layer is enabled, **when** two adjacent land tiles belong to different owning factions, **then** a thicker political border stroke is drawn between them on top of the province/sea-zone boundary stroke.
+- **Given** the political overlay is disabled, **when** the map renders adjacent land tiles with different owning factions, **then** no political border stroke is drawn between them regardless of the borders layer setting.
 - **When** the user pans, **then** the visible portion of the map updates; the full map remains pannable within the fixed scale.
 - **When** the user zooms, **then** only fixed zoom levels are used and zooming is smooth between levels.
 - **When** the user taps/clicks a province, **then** the widget invokes the provided province-selection callback with an identifier (e.g. prefixed province id); the widget does not render province details itself.

--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -243,6 +243,7 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
 
   @override
   Widget build(BuildContext context) {
+    final showBorders = ref.watch(mapBordersVisibleProvider);
     final isNarrow = MediaQuery.sizeOf(context).width < kInGameNarrowBreakpoint;
     final nextTurnText =
         'Next turn (${widget.game.worldState.turnState.turnNumber} / ${turnToYear(widget.game.worldState.turnState.turnNumber, widget.game.turnTimeMapping)})';
@@ -277,6 +278,7 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
                   game: widget.game,
                   region: _currentRegion,
                   baseLayerDisplayMode: _baseLayerDisplayMode,
+                  showBordersLayer: showBorders,
                   humanPlayerId: _humanPlayerId,
                   selectedDetailId: _selectedDetailId,
                   displayId: _displayId,
@@ -310,6 +312,39 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
                   child: GameMapCornerControls(
                     onCycleBaseLayerDisplayMode: _cycleBaseLayerDisplayMode,
                     onCenterOnHomeCapital: _centerOnHumanCapital,
+                    onOpenMapDisplayOptions: () {
+                      showDialog<void>(
+                        context: context,
+                        builder: (context) {
+                          return AlertDialog(
+                            title: const Text('Map display options'),
+                            content: Consumer(
+                              builder: (context, ref, _) {
+                                final bordersVisible =
+                                    ref.watch(mapBordersVisibleProvider);
+                                return SwitchListTile(
+                                  title: const Text('Show borders'),
+                                  value: bordersVisible,
+                                  onChanged: (value) {
+                                    ref
+                                        .read(mapBordersVisibleProvider
+                                            .notifier)
+                                        .state = value;
+                                  },
+                                );
+                              },
+                            ),
+                            actions: [
+                              TextButton(
+                                onPressed: () =>
+                                    Navigator.of(context).maybePop(),
+                                child: const Text('Close'),
+                              ),
+                            ],
+                          );
+                        },
+                      );
+                    },
                   ),
                 ),
                 if (!_sideMenuOpen)

--- a/app/lib/features/game/flame/game_map_canvas_stack.dart
+++ b/app/lib/features/game/flame/game_map_canvas_stack.dart
@@ -15,6 +15,7 @@ class GameMapCanvasStack extends StatelessWidget {
     required this.game,
     required this.region,
     required this.baseLayerDisplayMode,
+    required this.showBordersLayer,
     required this.humanPlayerId,
     required this.selectedDetailId,
     required this.displayId,
@@ -36,6 +37,7 @@ class GameMapCanvasStack extends StatelessWidget {
   final ct_models.Game game;
   final RegionMapViewData region;
   final BaseLayerDisplayMode baseLayerDisplayMode;
+  final bool showBordersLayer;
   final String humanPlayerId;
   final String? selectedDetailId;
   final String displayId;
@@ -63,6 +65,7 @@ class GameMapCanvasStack extends StatelessWidget {
             child: CtRegionMap(
               region: region,
               cellSizePx: 24,
+              showBordersLayer: showBordersLayer,
               visibilityMode: CtMapVisibilityMode.playerConstrained,
               baseLayerDisplayMode: baseLayerDisplayMode,
               onProvinceSelected: onProvinceSelected,

--- a/app/lib/features/game/flame/game_map_corner_controls.dart
+++ b/app/lib/features/game/flame/game_map_corner_controls.dart
@@ -7,11 +7,13 @@ class GameMapCornerControls extends StatelessWidget {
   const GameMapCornerControls({
     required this.onCycleBaseLayerDisplayMode,
     required this.onCenterOnHomeCapital,
+    required this.onOpenMapDisplayOptions,
     super.key,
   });
 
   final VoidCallback onCycleBaseLayerDisplayMode;
   final VoidCallback onCenterOnHomeCapital;
+  final VoidCallback onOpenMapDisplayOptions;
 
   @override
   Widget build(BuildContext context) {
@@ -51,6 +53,27 @@ class GameMapCornerControls extends StatelessWidget {
                   'assets/images/ui_icon_home_capital.png',
                   width: 20,
                   height: 20,
+                ),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Material(
+          key: kMapDisplayOptionsButtonKey,
+          color: Colors.white.withValues(alpha: 0.9),
+          child: Tooltip(
+            message: 'Map display options',
+            child: InkWell(
+              onTap: onOpenMapDisplayOptions,
+              child: const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                child: Text(
+                  'Map options',
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w500,
+                  ),
                 ),
               ),
             ),

--- a/app/lib/features/game/flame/game_screen_shared.dart
+++ b/app/lib/features/game/flame/game_screen_shared.dart
@@ -9,3 +9,6 @@ const Key kBaseLayerCycleButtonKey = Key('base_layer_cycle_button');
 /// Key for the home-to-capital button (for tests). SPEC/ui/empire-overview.md § Home-to-capital button.
 const Key kHomeToCapitalButtonKey = Key('home_to_capital_button');
 
+/// Key for the map display options button (for tests). SPEC/ui/empire-overview.md § Map display options button and dialog.
+const Key kMapDisplayOptionsButtonKey = Key('map_display_options_button');
+

--- a/app/lib/features/game/flame/region_map_component.dart
+++ b/app/lib/features/game/flame/region_map_component.dart
@@ -88,6 +88,7 @@ class CtRegionMapComponent extends PositionComponent {
     required this.region,
     required this.cellSize,
     required this.showPoliticalOverlay,
+    required this.showBordersLayer,
     required this.visibilityMode,
     this.baseLayerDisplayMode =
         BaseLayerDisplayMode.terrainResourcesImprovements,
@@ -101,6 +102,7 @@ class CtRegionMapComponent extends PositionComponent {
   RegionMapViewData region;
   double cellSize;
   bool showPoliticalOverlay;
+  bool showBordersLayer;
   CtMapVisibilityMode visibilityMode;
   BaseLayerDisplayMode baseLayerDisplayMode;
   void Function(String provinceId)? onProvinceSelected;
@@ -209,11 +211,15 @@ class CtRegionMapComponent extends PositionComponent {
     super.render(canvas);
     _paintTiles(canvas);
     _paintOverlay(canvas);
-    _paintProvinceBorders(canvas);
+    if (showBordersLayer) {
+      _paintProvinceBorders(canvas);
+    }
     if (_hoveredProvinceId != null) {
       _paintHoveredProvinceGlow(canvas);
     }
-    if (showPoliticalOverlay) _paintFactionBorders(canvas);
+    if (showPoliticalOverlay && showBordersLayer) {
+      _paintFactionBorders(canvas);
+    }
     _paintCapitals(canvas);
     _paintPorts(canvas);
     _paintWarpZones(canvas);

--- a/app/lib/providers/map_view_provider.dart
+++ b/app/lib/providers/map_view_provider.dart
@@ -5,6 +5,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'game_service_provider.dart';
 import 'games_provider.dart';
 
+/// Global borders visibility for in-game Empire overview maps.
+/// Controls whether province and sea-zone boundary strokes are drawn.
+/// Defaults to true at app start; updated via the Map display options dialog.
+final mapBordersVisibleProvider = StateProvider<bool>((ref) => true);
+
 /// Map view data for the current game with player-constrained visibility.
 /// Null when no game, no map data (legacy save), or loading.
 final mapViewDataProvider = Provider<InitGameMapViewData?>((ref) {

--- a/app/lib/widgets/ct_region_map.dart
+++ b/app/lib/widgets/ct_region_map.dart
@@ -17,6 +17,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
     required RegionMapViewData region,
     required double cellSizePx,
     required bool showPoliticalOverlay,
+    required bool showBordersLayer,
     required CtMapVisibilityMode visibilityMode,
     BaseLayerDisplayMode baseLayerDisplayMode =
         BaseLayerDisplayMode.terrainResourcesImprovements,
@@ -31,6 +32,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
   }) : region = region,
        cellSizePx = cellSizePx,
        showPoliticalOverlay = showPoliticalOverlay,
+       showBordersLayer = showBordersLayer,
        visibilityMode = visibilityMode,
        baseLayerDisplayMode = baseLayerDisplayMode,
        onProvinceSelected = onProvinceSelected,
@@ -45,6 +47,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
   RegionMapViewData region;
   final double cellSizePx;
   bool showPoliticalOverlay;
+  bool showBordersLayer;
   CtMapVisibilityMode visibilityMode;
   BaseLayerDisplayMode baseLayerDisplayMode;
   final void Function(String provinceId)? onProvinceSelected;
@@ -69,6 +72,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
       region: region,
       cellSize: cellSizePx,
       showPoliticalOverlay: showPoliticalOverlay,
+      showBordersLayer: showBordersLayer,
       visibilityMode: visibilityMode,
       baseLayerDisplayMode: baseLayerDisplayMode,
       onProvinceSelected: onProvinceSelected,
@@ -106,6 +110,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
   void updateProps({
     RegionMapViewData? region,
     bool? showPoliticalOverlay,
+    bool? showBordersLayer,
     CtMapVisibilityMode? visibilityMode,
     BaseLayerDisplayMode? baseLayerDisplayMode,
     String? highlightedTileKey,
@@ -116,6 +121,9 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
     }
     if (showPoliticalOverlay != null) {
       this.showPoliticalOverlay = showPoliticalOverlay;
+    }
+    if (showBordersLayer != null) {
+      this.showBordersLayer = showBordersLayer;
     }
     if (visibilityMode != null) {
       this.visibilityMode = visibilityMode;
@@ -135,6 +143,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
         ..region = this.region
         ..cellSize = cellSizePx
         ..showPoliticalOverlay = this.showPoliticalOverlay
+        ..showBordersLayer = this.showBordersLayer
         ..visibilityMode = this.visibilityMode
         ..baseLayerDisplayMode = this.baseLayerDisplayMode
         ..highlightedTileKey = this.highlightedTileKey
@@ -302,6 +311,7 @@ class CtRegionMap extends StatefulWidget {
     super.key,
     required this.region,
     this.showPoliticalOverlay = true,
+    this.showBordersLayer = true,
     this.cellSizePx = 32,
     this.visibilityMode = CtMapVisibilityMode.full,
     this.baseLayerDisplayMode,
@@ -318,6 +328,7 @@ class CtRegionMap extends StatefulWidget {
 
   final RegionMapViewData region;
   final bool showPoliticalOverlay;
+  final bool showBordersLayer;
   final double cellSizePx;
   final CtMapVisibilityMode visibilityMode;
 
@@ -351,6 +362,7 @@ class _CtRegionMapState extends State<CtRegionMap> {
     super.didUpdateWidget(oldWidget);
     if (widget.region != oldWidget.region ||
         widget.showPoliticalOverlay != oldWidget.showPoliticalOverlay ||
+        widget.showBordersLayer != oldWidget.showBordersLayer ||
         widget.visibilityMode != oldWidget.visibilityMode ||
         widget.baseLayerDisplayMode != oldWidget.baseLayerDisplayMode ||
         widget.validTileKeys != oldWidget.validTileKeys ||
@@ -358,6 +370,7 @@ class _CtRegionMapState extends State<CtRegionMap> {
       _game.updateProps(
         region: widget.region,
         showPoliticalOverlay: widget.showPoliticalOverlay,
+        showBordersLayer: widget.showBordersLayer,
         visibilityMode: widget.visibilityMode,
         baseLayerDisplayMode:
             widget.baseLayerDisplayMode ??
@@ -379,6 +392,7 @@ class _CtRegionMapState extends State<CtRegionMap> {
       region: widget.region,
       cellSizePx: widget.cellSizePx,
       showPoliticalOverlay: widget.showPoliticalOverlay,
+      showBordersLayer: widget.showBordersLayer,
       visibilityMode: widget.visibilityMode,
       baseLayerDisplayMode:
           widget.baseLayerDisplayMode ??

--- a/app/test/ct_region_map_test.dart
+++ b/app/test/ct_region_map_test.dart
@@ -61,6 +61,7 @@ void main() {
     double height = 320,
     double cellSizePx = 24,
     bool showPoliticalOverlay = true,
+    bool showBordersLayer = true,
     CtMapVisibilityMode visibilityMode = CtMapVisibilityMode.full,
     BaseLayerDisplayMode? baseLayerDisplayMode,
     String? centerOnTileKey,
@@ -79,6 +80,7 @@ void main() {
               region: region,
               cellSizePx: cellSizePx,
               showPoliticalOverlay: showPoliticalOverlay,
+              showBordersLayer: showBordersLayer,
               visibilityMode: visibilityMode,
               baseLayerDisplayMode: baseLayerDisplayMode,
               centerOnTileKey: centerOnTileKey,
@@ -166,11 +168,40 @@ void main() {
           _buildCtRegionMap(
             region: region,
             showPoliticalOverlay: false,
+            showBordersLayer: false,
             visibilityMode: CtMapVisibilityMode.playerConstrained,
           ),
         );
         await tester.pump();
 
+        expect(find.byType(CtRegionMap), findsOneWidget);
+      },
+      timeout: const Timeout(Duration(seconds: 5)),
+    );
+
+    testWidgets(
+      'honors borders layer visibility flag without throwing',
+      (WidgetTester tester) async {
+        final region = _oldWorldRegion();
+
+        // Borders on.
+        await tester.pumpWidget(
+          _buildCtRegionMap(
+            region: region,
+            showBordersLayer: true,
+          ),
+        );
+        await tester.pump();
+        expect(find.byType(CtRegionMap), findsOneWidget);
+
+        // Borders off.
+        await tester.pumpWidget(
+          _buildCtRegionMap(
+            region: region,
+            showBordersLayer: false,
+          ),
+        );
+        await tester.pump();
         expect(find.byType(CtRegionMap), findsOneWidget);
       },
       timeout: const Timeout(Duration(seconds: 5)),

--- a/app/test/game_screen_narrow_test.dart
+++ b/app/test/game_screen_narrow_test.dart
@@ -121,6 +121,70 @@ void main() {
       timeout: const Timeout(Duration(seconds: 15)),
     );
 
+    testWidgets(
+      'AC: map display options button is visible beneath home-to-capital button and opens dialog (SPEC/ui/empire-overview.md)',
+      (WidgetTester tester) async {
+        final dpr = tester.view.devicePixelRatio;
+        tester.view.physicalSize = Size(1500 * dpr, 700 * dpr);
+        addTearDown(tester.view.reset);
+        await tester.pumpWidget(buildGameScreen(width: 1500, height: 700));
+        await tester.pump();
+
+        final optionsButtonFinder = find.byKey(kMapDisplayOptionsButtonKey);
+        expect(optionsButtonFinder, findsOneWidget);
+
+        await tester.tap(optionsButtonFinder);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.text('Map display options'), findsOneWidget);
+        expect(find.text('Show borders'), findsOneWidget);
+      },
+      timeout: const Timeout(Duration(seconds: 20)),
+    );
+
+    testWidgets(
+      'AC: toggling Show borders in dialog updates state and persists within session (SPEC/ui/empire-overview.md)',
+      (WidgetTester tester) async {
+        final dpr = tester.view.devicePixelRatio;
+        tester.view.physicalSize = Size(1500 * dpr, 700 * dpr);
+        addTearDown(tester.view.reset);
+        await tester.pumpWidget(buildGameScreen(width: 1500, height: 700));
+        await tester.pump();
+
+        final optionsButtonFinder = find.byKey(kMapDisplayOptionsButtonKey);
+        expect(optionsButtonFinder, findsOneWidget);
+
+        // Open dialog.
+        await tester.tap(optionsButtonFinder);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        final showBordersFinder = find.byType(SwitchListTile);
+        expect(showBordersFinder, findsOneWidget);
+
+        // Toggle off.
+        await tester.tap(showBordersFinder);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        // Close dialog.
+        await tester.tap(find.text('Close'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        // Re-open and ensure the toggle remains off.
+        await tester.tap(optionsButtonFinder);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        final switchTile =
+            tester.widget<SwitchListTile>(showBordersFinder.first);
+        expect(switchTile.value, isFalse);
+      },
+      timeout: const Timeout(Duration(seconds: 20)),
+    );
+
     // Side menu button content tests require Hive initialization (for gameServiceProvider).
     // The empire buttons implementation uses the correct icons:
     // - Production → ui_icon_production.png

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -484,10 +484,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- Add a third top-left overlay control (“Map options”) that opens a modal Map display options dialog.
- Add a global “Show borders” toggle (default on) that enables/disables the map borders layer.
- Refactor borders rendering into a distinct layer flag and document it in UI specs.

## Test plan
- flutter test test/game_screen_narrow_test.dart (from app/)
- flutter test test/ct_region_map_test.dart (from app/)


Made with [Cursor](https://cursor.com)