### PR TITLE
feat(app): Debug log from map side menu + spec

### DIFF
--- a/SPEC/program/debug-log-viewer.md
+++ b/SPEC/program/debug-log-viewer.md
@@ -33,7 +33,9 @@
 ### 4.1 Flutter app
 
 - **macOS:** Application menubar. One top-level or sub-menu item that opens the debug log viewer (e.g. **View → Debug log** or **Developer → Debug log**). Shown only when the app has a menubar (desktop).
-- **Mobile:** In-game pause menu. One menu item (e.g. **Debug log**) that opens the viewer. When the user does not have a pause menu (e.g. main menu only), the viewer is not required to be reachable from that context; implementation may also expose it from a main-menu or settings entry on mobile if desired.
+- **In-game (pre-map):** When the game is running but the map view is not yet shown (Flame canvas only), a pause menu (e.g. bottom sheet) opened via a menu control offers **Debug log** and **Resume**.
+- **In-game (map view):** When the in-game map is shown (region tabs, side menu), the **side menu** (opened via the top-left menu icon) includes a **Debug log** item that opens the viewer. This is the primary way to open the debug log on mobile and in narrow viewports when on the map.
+- **Mobile:** In-game access is via the pause menu (pre-map) or the map side menu (map view). When the user does not have a pause menu (e.g. main menu only), the viewer is not required to be reachable from that context; implementation may also expose it from a main-menu or settings entry on mobile if desired.
 - **Other platforms (e.g. web):** Optional; at least one way to open the viewer (e.g. from a menu or overflow) so that web dev sessions can use it.
 
 ### 4.2 ctterm
@@ -61,7 +63,8 @@
 ## 7. Acceptance criteria (Given–When–Then)
 
 - **Given** the Flutter app is running on macOS with a menubar, **when** the user chooses the Debug log menu item, **then** the debug log viewer opens and displays session logs with package and level filters available.
-- **Given** the Flutter app is in-game on mobile, **when** the user opens the pause menu and selects Debug log, **then** the debug log viewer opens and displays session logs with package and level filters available.
+- **Given** the Flutter app is in-game on mobile (pre-map), **when** the user opens the pause menu and selects Debug log, **then** the debug log viewer opens and displays session logs with package and level filters available.
+- **Given** the Flutter app is in-game with the map view shown (any viewport), **when** the user opens the side menu (menu icon) and selects Debug log, **then** the debug log viewer opens and displays session logs with package and level filters available.
 - **Given** ctterm is at the Main Menu, **when** the user selects Debug log and confirms, **then** the Debug log viewer screen is shown and displays session logs.
 - **Given** ctterm is at the Pause/Options screen, **when** the user selects Debug log and confirms, **then** the Debug log viewer screen is shown; when the user exits the viewer, **then** the app returns to the Pause/Options screen.
 - **Given** the debug log viewer is open with all packages and all levels selected, **when** the user deselects one package (e.g. **logic**), **then** lines whose prefix matches **logic** are hidden; when the user reselects **logic**, **then** those lines are shown again.

--- a/app/lib/features/game/flame/game_side_menu.dart
+++ b/app/lib/features/game/flame/game_side_menu.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../config/routes.dart';
 import '../../../../providers/game_service_provider.dart';
 import '../../../../providers/games_provider.dart';
 import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
@@ -211,6 +212,23 @@ class GameSideMenu extends ConsumerWidget {
             ),
           );
         },
+      ),
+      Padding(
+        padding: const EdgeInsets.only(bottom: 8),
+        child: CtNinePatchButton(
+          onPressed: () {
+            onClose();
+            Navigator.of(context).pushNamed(Routes.debugLog);
+          },
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.bug_report, size: 20),
+              const SizedBox(width: 8),
+              const Text('Debug log'),
+            ],
+          ),
+        ),
       ),
     ];
   }

--- a/app/lib/features/game/flame/game_side_menu.dart
+++ b/app/lib/features/game/flame/game_side_menu.dart
@@ -259,7 +259,6 @@ class GameSideMenu extends ConsumerWidget {
           padding: const EdgeInsets.all(8),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
-            mainAxisSize: MainAxisSize.min,
             children: [
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,
@@ -268,7 +267,13 @@ class GameSideMenu extends ConsumerWidget {
                 ],
               ),
               const SizedBox(height: 8),
-              ..._buildEmpireMenuButtons(context, ref),
+              // When more menu items are present (e.g. Debug log), the panel must
+              // remain within the available height; make the list scrollable.
+              Expanded(
+                child: ListView(
+                  children: _buildEmpireMenuButtons(context, ref),
+                ),
+              ),
             ],
           ),
         ),


### PR DESCRIPTION
## Summary
When the in-game **map** is shown, the top-left menu icon opens the **side menu** (Production, Civilian Units, etc.), not the pause bottom sheet. So Debug log was unreachable on mobile/narrow when on the map.

## Changes
- **App:** Add a **Debug log** entry to `GameSideMenu` so the debug log viewer is reachable from the map view (tap menu icon → Debug log).
- **Spec:** Update `SPEC/program/debug-log-viewer.md` §4.1 and §7:
  - Document pre-map (pause menu) vs map-view (side menu) entry points.
  - Add acceptance criterion for opening the debug log from the side menu.

## Target
`dev`

Made with [Cursor](https://cursor.com)