### PR TITLE
feat(app): add Flutter localization layer and CI untranslated gate

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -151,6 +151,24 @@ jobs:
             (cd app && flutter test --coverage --reporter=compact)
           fi
 
+      - name: App localization gate (flutter gen-l10n untranslated check)
+        if: steps.changes.outputs.tests == 'true'
+        run: |
+          set -e
+          if [ -d app ]; then
+            cd app
+            flutter gen-l10n
+            if [ -f lib/l10n/untranslated.json ]; then
+              # Fail if untranslated.json is non-empty (more than just {} or whitespace)
+              content=$(cat lib/l10n/untranslated.json | tr -d '[:space:]')
+              if [ "$content" != "{}" ] && [ "$content" != "" ]; then
+                echo "Untranslated localization messages detected:"
+                cat lib/l10n/untranslated.json
+                exit 1
+              fi
+            fi
+          fi
+
       - name: Compile app entrypoints (Flutter analyze)
         if: steps.changes.outputs.tests == 'true'
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -148,7 +148,11 @@ jobs:
         run: |
           set -e
           if [ -d app ]; then
-            (cd app && flutter test --coverage --reporter=compact)
+            (
+              cd app
+              flutter gen-l10n
+              flutter test --coverage --reporter=compact
+            )
           fi
 
       - name: App localization gate (flutter gen-l10n untranslated check)

--- a/SPEC/program/localization.md
+++ b/SPEC/program/localization.md
@@ -1,0 +1,34 @@
+# Localization (Flutter app)
+
+## Scope
+- **Applies to:** `app/` (Flutter/Flame app shell + overlays + menus + screens).
+- **Locales:** `en` only initially.
+- **Fallback:** `en` is the fallback locale.
+- **What is localized:** **All user-visible UI copy** emitted by `app/lib/**`, including:
+  - Screen titles, buttons, labels, tooltips, dialogs, error messages.
+  - Dynamic strings (interpolated values, plurals where applicable).
+  - UI-visible game content surfaced by the app (e.g., resources, units, tech names/descriptions) when displayed as UI copy.
+
+## Mechanism (built-in Flutter i18n)
+- Use Flutter `gen_l10n` + ARB files to generate `AppLocalizations`.
+- Use `flutter_localizations` to localize built-in Material/Cupertino widgets.
+- Generated localization access is via `AppLocalizations.of(context)` (or an app helper that returns the same instance).
+
+## File layout
+- **Config:** `app/l10n.yaml`
+- **ARB directory:** `app/lib/l10n/`
+- **Generated output:** default Flutter generated location (Flutter toolchain); app code imports from `package:flutter_gen/gen_l10n/app_localizations.dart`.
+- **Maintainability:** Keys are namespaced/prefixed by feature (e.g. `mainMenu_newGame`, `victory_titleMilitary`), and messages include ARB metadata for translator context.
+
+## CI quality gate (GitHub)
+- The Quality workflow must run `flutter gen-l10n` for `app/` and produce an **untranslated / missing messages report** via `untranslated-messages-file`.
+- CI **fails** if the untranslated report contains **any** missing/untranslated messages for any locale.
+- CI runs this gate when the existing Quality workflow is already running tests for `app/**` changes.
+
+## Acceptance criteria
+- **AC1:** `app/` builds with `flutter gen-l10n` enabled and `flutter_localizations` configured.
+- **AC2:** `MaterialApp` declares `localizationsDelegates` and `supportedLocales` from `AppLocalizations`.
+- **AC3:** All user-visible UI copy in `app/lib/**` is sourced from `AppLocalizations` (including dynamic strings and tooltips).
+- **AC4:** The Quality workflow fails if the untranslated report produced by `untranslated-messages-file` contains any entries.
+- **AC5:** `en` is the default/fallback locale.
+

--- a/SPEC/ui/localization.md
+++ b/SPEC/ui/localization.md
@@ -1,0 +1,27 @@
+# Localization (UI copy)
+
+## Goal
+All user-visible copy in the Flutter app is localized via Flutter’s built-in i18n mechanism (`gen_l10n` → `AppLocalizations`), with `en` as the initial and fallback locale.
+
+## Scope
+- **Applies to:** `app/lib/**` UI (Flutter widgets, Flame overlays implemented as Flutter widgets, menus, dialogs, tooltips).
+- **Includes:**
+  - Buttons, tabs, headers, section labels.
+  - Tooltips and helper text.
+  - Dialog titles/bodies/action labels.
+  - User-visible error strings.
+  - Dynamic UI strings with inserted values (turn numbers, names, counts).
+  - UI-visible “game content” strings as presented to the user (resource/unit/tech labels and descriptions shown in UI).
+- **Excludes:** internal logs, debug-only developer diagnostics not shown to the user (unless they are displayed in UI).
+
+## Usage rules
+- **No hard-coded UI copy** in widgets: do not write string literals directly into `Text(...)`, `Tooltip.message`, `AlertDialog` titles/actions, etc.
+- UI copy must come from `AppLocalizations` methods/getters.
+- Dynamic UI copy must be localized using parameterized messages (e.g. `endTurnConfirm(turnNumber)`), not string interpolation in the widget.
+- Where the same phrasing appears in multiple places, reuse the same localization key.
+
+## Acceptance criteria
+- **AC1:** Any visible UI string in `app/lib/**` is sourced from `AppLocalizations`.
+- **AC2:** Parameterized/dynamic UI copy uses `AppLocalizations` parameters (no in-widget interpolation for user-visible strings).
+- **AC3:** Tooltips, dialogs, and screen titles are localized.
+

--- a/app/l10n.yaml
+++ b/app/l10n.yaml
@@ -1,0 +1,6 @@
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart
+untranslated-messages-file: lib/l10n/untranslated.json
+required-resource-attributes: true
+

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:colonizethis_app/l10n/app_localizations.dart';
+import 'package:colonizethis_app/l10n/l10n.dart';
 
 import 'config/routes.dart';
 import 'config/themes.dart';
@@ -13,9 +14,10 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final rootL10n = lookupAppLocalizations(const Locale('en'));
     final app = MaterialApp(
       navigatorKey: appNavigatorKey,
-      onGenerateTitle: (context) => AppLocalizations.of(context)!.app_title,
+      onGenerateTitle: (context) => appL10n(context).app_title,
       localizationsDelegates: const [
         AppLocalizations.delegate,
         GlobalMaterialLocalizations.delegate,
@@ -30,10 +32,10 @@ class App extends StatelessWidget {
     return PlatformMenuBar(
       menus: <PlatformMenuItem>[
         PlatformMenu(
-          label: AppLocalizations.of(context)!.menu_view,
+          label: rootL10n.menu_view,
           menus: <PlatformMenuItem>[
             PlatformMenuItem(
-              label: AppLocalizations.of(context)!.menu_debugLog,
+              label: rootL10n.menu_debugLog,
               onSelected: () {
                 appNavigatorKey.currentState?.pushNamed(Routes.debugLog);
               },

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'config/routes.dart';
 import 'config/themes.dart';
@@ -13,7 +15,14 @@ class App extends StatelessWidget {
   Widget build(BuildContext context) {
     final app = MaterialApp(
       navigatorKey: appNavigatorKey,
-      title: 'Colonize This',
+      onGenerateTitle: (context) => AppLocalizations.of(context)!.app_title,
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
       theme: AppThemes.light,
       initialRoute: Routes.shell,
       onGenerateRoute: Routes.generate,
@@ -21,10 +30,10 @@ class App extends StatelessWidget {
     return PlatformMenuBar(
       menus: <PlatformMenuItem>[
         PlatformMenu(
-          label: 'View',
+          label: AppLocalizations.of(context)!.menu_view,
           menus: <PlatformMenuItem>[
             PlatformMenuItem(
-              label: 'Debug log',
+              label: AppLocalizations.of(context)!.menu_debugLog,
               onSelected: () {
                 appNavigatorKey.currentState?.pushNamed(Routes.debugLog);
               },

--- a/app/lib/features/debug_log/debug_log_viewer_screen.dart
+++ b/app/lib/features/debug_log/debug_log_viewer_screen.dart
@@ -3,7 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
 import 'package:session_log_buffer/session_log_buffer.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:colonizethis_app/l10n/l10n.dart';
 
 /// Full-screen viewer for session logs with multiselect filters by package and level.
 class DebugLogViewerScreen extends StatefulWidget {
@@ -25,7 +25,7 @@ class _DebugLogViewerScreenState extends State<DebugLogViewerScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = appL10n(context);
     return Scaffold(
       appBar: AppBar(
         title: Text(l10n.debugLog_title),
@@ -50,7 +50,7 @@ class _DebugLogViewerScreenState extends State<DebugLogViewerScreen> {
 
   Widget _buildFilters(BuildContext context) {
     final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = appL10n(context);
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),

--- a/app/lib/features/debug_log/debug_log_viewer_screen.dart
+++ b/app/lib/features/debug_log/debug_log_viewer_screen.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
 import 'package:session_log_buffer/session_log_buffer.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 /// Full-screen viewer for session logs with multiselect filters by package and level.
 class DebugLogViewerScreen extends StatefulWidget {
@@ -24,14 +25,15 @@ class _DebugLogViewerScreenState extends State<DebugLogViewerScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Debug log'),
+        title: Text(l10n.debugLog_title),
         actions: [
           IconButton(
             icon: const Icon(Icons.close),
             onPressed: () => Navigator.of(context).pop(),
-            tooltip: 'Close',
+            tooltip: l10n.common_close,
           ),
         ],
       ),
@@ -48,13 +50,14 @@ class _DebugLogViewerScreenState extends State<DebugLogViewerScreen> {
 
   Widget _buildFilters(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('Package:', style: theme.textTheme.titleSmall),
+          Text(l10n.debugLog_filter_package, style: theme.textTheme.titleSmall),
           const SizedBox(width: 8),
           Wrap(
             spacing: 4,
@@ -77,7 +80,7 @@ class _DebugLogViewerScreenState extends State<DebugLogViewerScreen> {
             }).toList(),
           ),
           const SizedBox(width: 16),
-          Text('Level:', style: theme.textTheme.titleSmall),
+          Text(l10n.debugLog_filter_level, style: theme.textTheme.titleSmall),
           const SizedBox(width: 8),
           Wrap(
             spacing: 4,

--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -7,6 +7,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
 import 'package:colonizethis_map/colonizethis_map.dart'
     show InitGameMapViewData, MapTopology, RegionMapViewData;
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../../../widgets/ct_region_map.dart' show BaseLayerDisplayMode;
 
@@ -256,8 +257,14 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
   Widget build(BuildContext context) {
     final showBorders = ref.watch(mapBordersVisibleProvider);
     final isNarrow = MediaQuery.sizeOf(context).width < kInGameNarrowBreakpoint;
-    final nextTurnText =
-        'Next turn (${widget.game.worldState.turnState.turnNumber} / ${turnToYear(widget.game.worldState.turnState.turnNumber, widget.game.turnTimeMapping)})';
+    final l10n = AppLocalizations.of(context)!;
+    final nextTurnText = l10n.game_nextTurnButton(
+      widget.game.worldState.turnState.turnNumber,
+      turnToYear(
+        widget.game.worldState.turnState.turnNumber,
+        widget.game.turnTimeMapping,
+      ),
+    );
     return Column(
       children: [
         GameMapControls(
@@ -328,14 +335,14 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
                         context: context,
                         builder: (context) {
                           return AlertDialog(
-                            title: const Text('Map display options'),
+                            title: Text(l10n.map_displayOptions_title),
                             content: Consumer(
                               builder: (context, ref, _) {
                                 final bordersVisible = ref.watch(
                                   mapBordersVisibleProvider,
                                 );
                                 return SwitchListTile(
-                                  title: const Text('Show borders'),
+                                  title: Text(l10n.map_displayOptions_showBorders),
                                   value: bordersVisible,
                                   onChanged: (value) {
                                     ref
@@ -353,7 +360,7 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
                               TextButton(
                                 onPressed: () =>
                                     Navigator.of(context).maybePop(),
-                                child: const Text('Close'),
+                                child: Text(l10n.common_close),
                               ),
                             ],
                           );

--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -7,7 +7,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
 import 'package:colonizethis_map/colonizethis_map.dart'
     show InitGameMapViewData, MapTopology, RegionMapViewData;
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:colonizethis_app/l10n/l10n.dart';
 
 import '../../../../widgets/ct_region_map.dart' show BaseLayerDisplayMode;
 
@@ -257,7 +257,7 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
   Widget build(BuildContext context) {
     final showBorders = ref.watch(mapBordersVisibleProvider);
     final isNarrow = MediaQuery.sizeOf(context).width < kInGameNarrowBreakpoint;
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = appL10n(context);
     final nextTurnText = l10n.game_nextTurnButton(
       widget.game.worldState.turnState.turnNumber,
       turnToYear(

--- a/app/lib/features/game/flame/game_map_controls.dart
+++ b/app/lib/features/game/flame/game_map_controls.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:colonizethis_app/l10n/l10n.dart';
 import '../../../widgets/ct_choice_chip.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 
@@ -24,7 +24,7 @@ class GameMapControls extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = appL10n(context);
     return Column(
       children: [
         Padding(

--- a/app/lib/features/game/flame/game_map_controls.dart
+++ b/app/lib/features/game/flame/game_map_controls.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import '../../../widgets/ct_choice_chip.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 
@@ -24,6 +24,7 @@ class GameMapControls extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     return Column(
       children: [
         Padding(
@@ -33,7 +34,7 @@ class GameMapControls extends StatelessWidget {
               IconButton(
                 icon: const Icon(Icons.menu),
                 onPressed: onToggleSideMenu,
-                tooltip: 'Menu',
+                tooltip: l10n.gameMap_menuTooltip,
               ),
               Expanded(
                 child: CtNinePatchButton(
@@ -50,13 +51,13 @@ class GameMapControls extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               CtChoiceChip(
-                label: const Text('Old World'),
+                label: Text(l10n.region_oldWorld),
                 selected: regionIndex == 0,
                 onSelected: (_) => onRegionIndexChanged(0),
               ),
               const SizedBox(width: 8),
               CtChoiceChip(
-                label: const Text('New World'),
+                label: Text(l10n.region_newWorld),
                 selected: regionIndex == 1,
                 onSelected: (_) => onRegionIndexChanged(1),
               ),

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -5,7 +5,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
 import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../config/routes.dart';
@@ -31,7 +31,7 @@ void _showPauseMenu(BuildContext context) {
         children: [
           ListTile(
             leading: const Icon(Icons.bug_report),
-            title: Text(AppLocalizations.of(ctx)!.debugLog_title),
+            title: Text(appL10n(ctx).debugLog_title),
             onTap: () {
               Navigator.of(ctx).pop();
               Navigator.of(context).pushNamed(Routes.debugLog);
@@ -39,7 +39,7 @@ void _showPauseMenu(BuildContext context) {
           ),
           ListTile(
             leading: const Icon(Icons.play_arrow),
-            title: Text(AppLocalizations.of(ctx)!.game_pauseMenu_resume),
+            title: Text(appL10n(ctx).game_pauseMenu_resume),
             onTap: () => Navigator.of(ctx).pop(),
           ),
         ],
@@ -75,7 +75,7 @@ class GameScreen extends ConsumerWidget {
             child: IconButton(
               icon: const Icon(Icons.menu),
               onPressed: () => _showPauseMenu(context),
-              tooltip: AppLocalizations.of(context)!.game_pauseMenu_tooltip,
+              tooltip: appL10n(context).game_pauseMenu_tooltip,
             ),
           ),
           Positioned(
@@ -98,7 +98,7 @@ class GameScreen extends ConsumerWidget {
                 }
               },
               child: Text(
-                AppLocalizations.of(context)!.game_nextTurnButton(
+                appL10n(context).game_nextTurnButton(
                   game!.worldState.turnState.turnNumber,
                   turnToYear(
                     game.worldState.turnState.turnNumber,
@@ -156,7 +156,7 @@ class GameScreen extends ConsumerWidget {
     }
 
     return CtScreenShell(
-      title: AppLocalizations.of(context)!.game_screenTitle,
+      title: appL10n(context).game_screenTitle,
       child: content,
     );
   }

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
 import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../config/routes.dart';
@@ -30,7 +31,7 @@ void _showPauseMenu(BuildContext context) {
         children: [
           ListTile(
             leading: const Icon(Icons.bug_report),
-            title: const Text('Debug log'),
+            title: Text(AppLocalizations.of(ctx)!.debugLog_title),
             onTap: () {
               Navigator.of(ctx).pop();
               Navigator.of(context).pushNamed(Routes.debugLog);
@@ -38,7 +39,7 @@ void _showPauseMenu(BuildContext context) {
           ),
           ListTile(
             leading: const Icon(Icons.play_arrow),
-            title: const Text('Resume'),
+            title: Text(AppLocalizations.of(ctx)!.game_pauseMenu_resume),
             onTap: () => Navigator.of(ctx).pop(),
           ),
         ],
@@ -74,7 +75,7 @@ class GameScreen extends ConsumerWidget {
             child: IconButton(
               icon: const Icon(Icons.menu),
               onPressed: () => _showPauseMenu(context),
-              tooltip: 'Pause menu',
+              tooltip: AppLocalizations.of(context)!.game_pauseMenu_tooltip,
             ),
           ),
           Positioned(
@@ -97,8 +98,13 @@ class GameScreen extends ConsumerWidget {
                 }
               },
               child: Text(
-                'Next turn (${game!.worldState.turnState.turnNumber} / '
-                '${turnToYear(game.worldState.turnState.turnNumber, game.turnTimeMapping)})',
+                AppLocalizations.of(context)!.game_nextTurnButton(
+                  game!.worldState.turnState.turnNumber,
+                  turnToYear(
+                    game.worldState.turnState.turnNumber,
+                    game.turnTimeMapping,
+                  ),
+                ),
               ),
             ),
           ),
@@ -149,6 +155,9 @@ class GameScreen extends ConsumerWidget {
       );
     }
 
-    return CtScreenShell(title: 'Game', child: content);
+    return CtScreenShell(
+      title: AppLocalizations.of(context)!.game_screenTitle,
+      child: content,
+    );
   }
 }

--- a/app/lib/features/game/flame/next_turn_confirmation_dialog.dart
+++ b/app/lib/features/game/flame/next_turn_confirmation_dialog.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import '../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 
@@ -15,21 +15,26 @@ Future<bool?> showNextTurnConfirmationDialog(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('End turn?', style: Theme.of(ctx).textTheme.titleMedium),
+          Text(
+            AppLocalizations.of(ctx)!.game_nextTurnConfirm_title,
+            style: Theme.of(ctx).textTheme.titleMedium,
+          ),
           const SizedBox(height: 8),
-          Text('Turn $currentTurn will end. Continue?'),
+          Text(
+            AppLocalizations.of(ctx)!.game_nextTurnConfirm_body(currentTurn),
+          ),
           const SizedBox(height: 16),
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
               CtNinePatchButton(
                 onPressed: () => Navigator.of(ctx).pop(false),
-                child: const Text('No'),
+                child: Text(AppLocalizations.of(ctx)!.common_no),
               ),
               const SizedBox(width: 8),
               CtNinePatchButton(
                 onPressed: () => Navigator.of(ctx).pop(true),
-                child: const Text('Yes'),
+                child: Text(AppLocalizations.of(ctx)!.common_yes),
               ),
             ],
           ),

--- a/app/lib/features/game/flame/next_turn_confirmation_dialog.dart
+++ b/app/lib/features/game/flame/next_turn_confirmation_dialog.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:colonizethis_app/l10n/l10n.dart';
 import '../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 
@@ -16,12 +16,12 @@ Future<bool?> showNextTurnConfirmationDialog(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            AppLocalizations.of(ctx)!.game_nextTurnConfirm_title,
+            appL10n(ctx).game_nextTurnConfirm_title,
             style: Theme.of(ctx).textTheme.titleMedium,
           ),
           const SizedBox(height: 8),
           Text(
-            AppLocalizations.of(ctx)!.game_nextTurnConfirm_body(currentTurn),
+            appL10n(ctx).game_nextTurnConfirm_body(currentTurn),
           ),
           const SizedBox(height: 16),
           Row(
@@ -29,12 +29,12 @@ Future<bool?> showNextTurnConfirmationDialog(
             children: [
               CtNinePatchButton(
                 onPressed: () => Navigator.of(ctx).pop(false),
-                child: Text(AppLocalizations.of(ctx)!.common_no),
+                child: Text(appL10n(ctx).common_no),
               ),
               const SizedBox(width: 8),
               CtNinePatchButton(
                 onPressed: () => Navigator.of(ctx).pop(true),
-                child: Text(AppLocalizations.of(ctx)!.common_yes),
+                child: Text(appL10n(ctx).common_yes),
               ),
             ],
           ),

--- a/app/lib/features/shell/shell_screen.dart
+++ b/app/lib/features/shell/shell_screen.dart
@@ -2,7 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:colonizethis_app/l10n/l10n.dart';
 import '../../config/routes.dart';
 import '../../providers/game_service_provider.dart';
 import '../../providers/games_provider.dart';
@@ -117,7 +117,7 @@ class _LeaderSelectionDialogState extends State<_LeaderSelectionDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = appL10n(context);
     final children = <Widget>[
       Text(
         l10n.shell_leaderDialog_intro,

--- a/app/lib/features/shell/shell_screen.dart
+++ b/app/lib/features/shell/shell_screen.dart
@@ -2,7 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
-
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import '../../config/routes.dart';
 import '../../providers/game_service_provider.dart';
 import '../../providers/games_provider.dart';
@@ -117,10 +117,11 @@ class _LeaderSelectionDialogState extends State<_LeaderSelectionDialog> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     final children = <Widget>[
-      const Text(
-        'Select leader for each Great Power (or keep default).',
-        style: TextStyle(fontSize: 14),
+      Text(
+        l10n.shell_leaderDialog_intro,
+        style: const TextStyle(fontSize: 14),
       ),
       const SizedBox(height: 16),
     ];
@@ -143,7 +144,7 @@ class _LeaderSelectionDialogState extends State<_LeaderSelectionDialog> {
                 child: CtDropdown<String>(
                   value: currentVariantId,
                   items: gp.leaderVariants.map((v) => v.id).toList(),
-                  hint: 'Select leader',
+                  hint: l10n.shell_leaderDialog_selectLeaderHint,
                   itemLabel: (id) =>
                       gp.leaderVariants.firstWhere((v) => v.id == id).name,
                   onChanged: (value) {
@@ -166,12 +167,12 @@ class _LeaderSelectionDialogState extends State<_LeaderSelectionDialog> {
         children: [
           CtNinePatchButton(
             onPressed: widget.onCancel,
-            child: const Text('Cancel'),
+            child: Text(l10n.common_cancel),
           ),
           const SizedBox(width: 8),
           CtNinePatchButton(
             onPressed: () => widget.onStart(_leaderByGpId),
-            child: const Text('Start'),
+            child: Text(l10n.common_start),
           ),
         ],
       ),
@@ -185,7 +186,7 @@ class _LeaderSelectionDialogState extends State<_LeaderSelectionDialog> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'New game — Leaders',
+            l10n.shell_leaderDialog_title,
             style: Theme.of(context).textTheme.titleMedium,
           ),
           const SizedBox(height: 8),

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -80,7 +80,7 @@
         "description": "Current turn number."
       },
       "year": {
-        "type": "String",
+        "type": "int",
         "description": "Calendar year derived from the turn."
       }
     }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1,0 +1,185 @@
+{
+  "@@locale": "en",
+
+  "app_title": "Colonize This",
+  "@app_title": {
+    "description": "Window title / application title."
+  },
+
+  "menu_view": "View",
+  "@menu_view": {
+    "description": "Top-level platform menu label for View menu."
+  },
+
+  "menu_debugLog": "Debug log",
+  "@menu_debugLog": {
+    "description": "Platform menu item label that navigates to the debug log viewer."
+  },
+
+  "mainMenu_title": "ColonizeThis V3",
+  "@mainMenu_title": {
+    "description": "Main menu title text when not using the pixel-art logo."
+  },
+
+  "mainMenu_subtitleAfterVictory": "Congratulations, you won your last game.",
+  "@mainMenu_subtitleAfterVictory": {
+    "description": "Subtitle shown on the main menu after the player has won their last game."
+  },
+
+  "mainMenu_newGame": "New Game",
+  "@mainMenu_newGame": {
+    "description": "Main menu button label to start a new game."
+  },
+
+  "mainMenu_loadGame": "Load Game",
+  "@mainMenu_loadGame": {
+    "description": "Main menu button label to load an existing game."
+  },
+
+  "mainMenu_settings": "Settings",
+  "@mainMenu_settings": {
+    "description": "Main menu button label to open settings."
+  },
+
+  "mainMenu_quit": "Quit",
+  "@mainMenu_quit": {
+    "description": "Main menu button label to quit the app."
+  },
+
+  "mainMenu_noSavesTooltip": "No saved games. Start a new game first.",
+  "@mainMenu_noSavesTooltip": {
+    "description": "Tooltip explaining why Load Game is disabled when there are no saves."
+  },
+
+  "game_pauseMenu_debugLog": "Debug log",
+  "@game_pauseMenu_debugLog": {
+    "description": "Pause menu option label to open the debug log screen."
+  },
+
+  "game_pauseMenu_resume": "Resume",
+  "@game_pauseMenu_resume": {
+    "description": "Pause menu option label to resume the game."
+  },
+
+  "game_pauseMenu_tooltip": "Pause menu",
+  "@game_pauseMenu_tooltip": {
+    "description": "Tooltip for the pause menu button in the in-game UI."
+  },
+
+  "game_screenTitle": "Game",
+  "@game_screenTitle": {
+    "description": "Title used for the main game screen shell."
+  },
+
+  "game_nextTurnButton": "Next turn ({turn} / {year})",
+  "@game_nextTurnButton": {
+    "description": "Label for the Next Turn button showing current turn and year.",
+    "placeholders": {
+      "turn": {
+        "type": "int",
+        "description": "Current turn number."
+      },
+      "year": {
+        "type": "String",
+        "description": "Calendar year derived from the turn."
+      }
+    }
+  },
+
+  "game_nextTurnConfirm_title": "End turn?",
+  "@game_nextTurnConfirm_title": {
+    "description": "Title of the dialog asking the user to confirm ending the current turn."
+  },
+
+  "game_nextTurnConfirm_body": "Turn {turn} will end. Continue?",
+  "@game_nextTurnConfirm_body": {
+    "description": "Body text of the end-turn confirmation dialog.",
+    "placeholders": {
+      "turn": {
+        "type": "int",
+        "description": "Current turn number."
+      }
+    }
+  },
+
+  "common_no": "No",
+  "@common_no": {
+    "description": "Generic 'No' button label."
+  },
+
+  "common_yes": "Yes",
+  "@common_yes": {
+    "description": "Generic 'Yes' button label."
+  },
+
+  "map_displayOptions_title": "Map display options",
+  "@map_displayOptions_title": {
+    "description": "Dialog title for map display options."
+  },
+
+  "map_displayOptions_showBorders": "Show borders",
+  "@map_displayOptions_showBorders": {
+    "description": "Toggle label for showing map borders."
+  },
+
+  "common_close": "Close",
+  "@common_close": {
+    "description": "Generic Close button label or tooltip."
+  },
+
+  "gameMap_menuTooltip": "Menu",
+  "@gameMap_menuTooltip": {
+    "description": "Tooltip for the side menu button in the map controls."
+  },
+
+  "region_oldWorld": "Old World",
+  "@region_oldWorld": {
+    "description": "Label for the Old World region tab."
+  },
+
+  "region_newWorld": "New World",
+  "@region_newWorld": {
+    "description": "Label for the New World region tab."
+  },
+
+  "debugLog_title": "Debug log",
+  "@debugLog_title": {
+    "description": "Title of the debug log viewer screen and related actions."
+  },
+
+  "debugLog_filter_package": "Package:",
+  "@debugLog_filter_package": {
+    "description": "Label for the package filter section in the debug log viewer."
+  },
+
+  "debugLog_filter_level": "Level:",
+  "@debugLog_filter_level": {
+    "description": "Label for the log level filter section in the debug log viewer."
+  },
+
+  "shell_leaderDialog_intro": "Select leader for each Great Power (or keep default).",
+  "@shell_leaderDialog_intro": {
+    "description": "Intro text for the leader selection dialog in the new-game flow."
+  },
+
+  "shell_leaderDialog_selectLeaderHint": "Select leader",
+  "@shell_leaderDialog_selectLeaderHint": {
+    "description": "Hint text for the leader dropdown in the leader selection dialog."
+  },
+
+  "common_cancel": "Cancel",
+  "@common_cancel": {
+    "description": "Generic Cancel button label."
+  },
+
+  "common_start": "Start",
+  "@common_start": {
+    "description": "Generic Start button label used when beginning a flow."
+  },
+
+  "shell_leaderDialog_title": "New game — Leaders",
+  "@shell_leaderDialog_title": {
+    "description": "Title of the leader selection dialog in the new-game flow."
+  }
+}
+

--- a/app/lib/l10n/l10n.dart
+++ b/app/lib/l10n/l10n.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/widgets.dart';
+
+import 'app_localizations.dart';
+
+/// Returns app localizations with an English fallback for widget tests
+/// that mount widgets without full MaterialApp localization delegates.
+AppLocalizations appL10n(BuildContext context) {
+  return AppLocalizations.of(context) ??
+      lookupAppLocalizations(const Locale('en'));
+}
+

--- a/app/lib/widgets/main_menu.dart
+++ b/app/lib/widgets/main_menu.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:colonizethis_app/l10n/l10n.dart';
 import '../config/themes.dart';
 import 'ct_nine_patch_button.dart';
 
@@ -56,7 +56,7 @@ class CtMainMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = appL10n(context);
     final Widget content = SafeArea(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 24),
@@ -148,7 +148,7 @@ class CtMainMenu extends StatelessWidget {
   Widget _buildLogo(BuildContext context) {
     if (variant == MainMenuVariant.plain) {
       return Text(
-        AppLocalizations.of(context)!.mainMenu_title,
+        appL10n(context).mainMenu_title,
         style: Theme.of(context).textTheme.headlineMedium,
         textAlign: TextAlign.center,
       );
@@ -299,7 +299,7 @@ class _LoadGameButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = appL10n(context);
     if (variant == MainMenuVariant.pixelArt) {
       return Tooltip(
         message: enabled ? '' : l10n.mainMenu_noSavesTooltip,

--- a/app/lib/widgets/main_menu.dart
+++ b/app/lib/widgets/main_menu.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import '../config/themes.dart';
 import 'ct_nine_patch_button.dart';
 
@@ -56,6 +56,7 @@ class CtMainMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     final Widget content = SafeArea(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 24),
@@ -72,7 +73,7 @@ class CtMainMenu extends StatelessWidget {
                 if (_showAfterVictorySubtitle) ...[
                   const SizedBox(height: 12),
                   Text(
-                    'Congratulations, you won your last game.',
+                    l10n.mainMenu_subtitleAfterVictory,
                     style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                           fontStyle: FontStyle.italic,
                         ),
@@ -81,7 +82,7 @@ class CtMainMenu extends StatelessWidget {
                 ],
                 const SizedBox(height: 32),
                 _MenuButton(
-                  label: 'New Game',
+                  label: l10n.mainMenu_newGame,
                   variant: variant,
                   onPressed: onNewGame,
                 ),
@@ -93,7 +94,7 @@ class CtMainMenu extends StatelessWidget {
                 ),
                 const SizedBox(height: 12),
                 _MenuButton(
-                  label: 'Settings',
+                  label: l10n.mainMenu_settings,
                   variant: variant,
                   onPressed: onSettings,
                 ),
@@ -104,7 +105,7 @@ class CtMainMenu extends StatelessWidget {
                 ),
                 const SizedBox(height: 8),
                 _MenuButton(
-                  label: 'Quit',
+                  label: l10n.mainMenu_quit,
                   variant: variant,
                   onPressed: onQuit,
                 ),
@@ -147,7 +148,7 @@ class CtMainMenu extends StatelessWidget {
   Widget _buildLogo(BuildContext context) {
     if (variant == MainMenuVariant.plain) {
       return Text(
-        'ColonizeThis V3',
+        AppLocalizations.of(context)!.mainMenu_title,
         style: Theme.of(context).textTheme.headlineMedium,
         textAlign: TextAlign.center,
       );
@@ -298,24 +299,25 @@ class _LoadGameButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     if (variant == MainMenuVariant.pixelArt) {
       return Tooltip(
-        message: enabled ? '' : 'No saved games. Start a new game first.',
+        message: enabled ? '' : l10n.mainMenu_noSavesTooltip,
         child: _PixelArtButton(
-          label: 'Load Game',
+          label: l10n.mainMenu_loadGame,
           enabled: enabled,
           onPressed: onPressed,
         ),
       );
     }
     return Tooltip(
-      message: enabled ? '' : 'No saved games. Start a new game first.',
+      message: enabled ? '' : l10n.mainMenu_noSavesTooltip,
       child: SizedBox(
         width: double.infinity,
         child: CtNinePatchButton(
           onPressed: enabled ? onPressed : null,
           enabled: enabled,
-          child: const Text('Load Game'),
+          child: Text(l10n.mainMenu_loadGame),
         ),
       ),
     );

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -10,6 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   flame: ^1.36.0
   jenny: ^1.5.1
   logger: ^2.0.2
@@ -33,6 +35,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
 
 flutter:
+  generate: true
   uses-material-design: true
   assets:
     - assets/images/

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -254,6 +254,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_riverpod:
     dependency: transitive
     description:
@@ -376,6 +381,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
@@ -484,10 +497,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- Add SPEC definitions for app localization scope and acceptance criteria in `SPEC/program/localization.md` and `SPEC/ui/localization.md`.
- Configure Flutter built-in `gen_l10n` in `app/` (`l10n.yaml`, `app_en.arb`, `flutter_localizations`, `MaterialApp` delegates/supported locales) and migrate key app UI copy paths to `AppLocalizations`.
- Add a quality workflow gate that runs `flutter gen-l10n` and fails when `lib/l10n/untranslated.json` contains missing/untranslated messages.

## Test plan
- [x] `cd app && flutter gen-l10n`
- [ ] `cd app && flutter test --reporter=compact`
- [ ] Verify CI `Quality` workflow passes and localization gate fails if untranslated entries are introduced.

Made with [Cursor](https://cursor.com)