### PR TITLE
test(app): full lcov for coverage gate; more widget tests

### DIFF
--- a/app/lib/features/game/dialogue/game_start_intro_overlay.dart
+++ b/app/lib/features/game/dialogue/game_start_intro_overlay.dart
@@ -15,11 +15,14 @@ class GameStartIntroOverlay extends StatefulWidget {
     required this.onDismissed,
     required this.child,
     this.logger,
+    /// When set (e.g. in tests), used to load the Yarn asset instead of [rootBundle].
+    this.assetBundle,
   });
 
   final VoidCallback onDismissed;
   final Widget child;
   final Logger? logger;
+  final AssetBundle? assetBundle;
 
   @override
   State<GameStartIntroOverlay> createState() => _GameStartIntroOverlayState();
@@ -43,7 +46,8 @@ class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
   Future<void> _loadAndRun() async {
     final log = widget.logger ?? Logger();
     try {
-      final text = await rootBundle.loadString(_kIntroAsset);
+      final bundle = widget.assetBundle ?? rootBundle;
+      final text = await bundle.loadString(_kIntroAsset);
       final project = YarnProject();
       project.parse(text);
       if (!project.nodes.containsKey(_kIntroNode)) {

--- a/app/lib/widgetbook/catalog.dart
+++ b/app/lib/widgetbook/catalog.dart
@@ -1,3 +1,5 @@
+// coverage:ignore-file
+// Dev-only Widgetbook catalog; excluded from app coverage gate via instrumentation.
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';

--- a/app/test/dialogue_acceptance_test.dart
+++ b/app/test/dialogue_acceptance_test.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/dialogue/game_start_intro_overlay.dart';
@@ -10,10 +11,42 @@ import 'package:colonizethis_app/features/game/dialogue/overture_dialogue_overla
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 
+class _ThrowingAssetBundle extends Fake implements AssetBundle {
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async {
+    throw Exception('missing asset');
+  }
+}
+
 void main() {
   suppressLogsForTests();
 
   group('GameStartIntroOverlay — SPEC/ai/dialogue-management.md § First dialogue emission point', () {
+    testWidgets(
+      'AC: asset load failure shows error shell; Continue invokes onDismissed',
+      (WidgetTester tester) async {
+        var dismissed = false;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: GameStartIntroOverlay(
+              assetBundle: _ThrowingAssetBundle(),
+              onDismissed: () => dismissed = true,
+              child: const SizedBox(),
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+        expect(
+          find.textContaining('Could not load intro dialogue'),
+          findsOneWidget,
+        );
+        await tester.tap(find.text('Continue'));
+        await tester.pump();
+        expect(dismissed, isTrue);
+      },
+    );
+
     testWidgets('AC: modal uses CtDialogShell and blocks; intro text and Continue present',
         (WidgetTester tester) async {
       var dismissed = false;

--- a/app/test/diplomacy_format_diplomatic_event_test.dart
+++ b/app/test/diplomacy_format_diplomatic_event_test.dart
@@ -1,0 +1,238 @@
+// formatDiplomaticEvent — all [DiplomaticEventType] branches. SPEC/ui/diplomacy-panel.md.
+import 'package:colonizethis_app/features/game/widgets/diplomacy_detail_screen.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  const humanId = 'human_gp';
+  const otherId = 'other_gp';
+
+  Game minimalGame({List<DiplomaticEvent> history = const []}) {
+    return Game(
+      id: 'fmt',
+      worldState: const WorldState(
+        turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: RegionData(),
+        newWorld: RegionData(),
+      ),
+      turnTimeMapping: TurnTimeMapping.gdd01,
+      players: const [
+        Player(
+          id: humanId,
+          displayName: 'England',
+          isHuman: true,
+          treasury: 0,
+        ),
+        Player(
+          id: otherId,
+          displayName: 'France',
+          isHuman: false,
+          treasury: 0,
+        ),
+      ],
+      diplomacyRelations: [
+        DiplomacyRelation(
+          factionId1: humanId,
+          factionId2: otherId,
+          score: 50,
+          state: RelationState.atPeace,
+        ),
+      ],
+      diplomaticHistoryEvents: history,
+    );
+  }
+
+  DiplomaticEvent ev(
+    DiplomaticEventType type, {
+    String? fromId,
+    String? toId,
+    OvertureStage? stage,
+    int? amount,
+    String? reason,
+  }) {
+    return DiplomaticEvent(
+      turn: 1,
+      intraTurnIndex: 0,
+      type: type,
+      participants: {humanId, otherId},
+      fromFactionId: fromId ?? humanId,
+      toFactionId: toId ?? otherId,
+      overtureStage: stage,
+      amount: amount,
+      reason: reason,
+    );
+  }
+
+  test('declareWar', () {
+    final g = minimalGame();
+    final s = formatDiplomaticEvent(
+      ev(DiplomaticEventType.declareWar),
+      g,
+      humanId,
+    );
+    expect(s, contains('declared war'));
+  });
+
+  test('peace', () {
+    final g = minimalGame();
+    expect(
+      formatDiplomaticEvent(ev(DiplomaticEventType.peace), g, humanId),
+      contains('peace'),
+    );
+  });
+
+  test('allianceFormed', () {
+    final g = minimalGame();
+    expect(
+      formatDiplomaticEvent(ev(DiplomaticEventType.allianceFormed), g, humanId),
+      contains('alliance'),
+    );
+  });
+
+  test('allianceBroken', () {
+    final g = minimalGame();
+    expect(
+      formatDiplomaticEvent(ev(DiplomaticEventType.allianceBroken), g, humanId),
+      contains('Alliance'),
+    );
+  });
+
+  test('overtureAccepted with stage', () {
+    final g = minimalGame();
+    final s = formatDiplomaticEvent(
+      ev(
+        DiplomaticEventType.overtureAccepted,
+        stage: OvertureStage.embassy,
+      ),
+      g,
+      humanId,
+    );
+    expect(s, contains('Embassy'));
+  });
+
+  test('overtureRejected', () {
+    final g = minimalGame();
+    expect(
+      formatDiplomaticEvent(
+        ev(DiplomaticEventType.overtureRejected, stage: OvertureStage.nap),
+        g,
+        humanId,
+      ),
+      contains('rejected'),
+    );
+  });
+
+  test('joinEmpireResolved', () {
+    final g = minimalGame();
+    expect(
+      formatDiplomaticEvent(
+        ev(DiplomaticEventType.joinEmpireResolved),
+        g,
+        humanId,
+      ),
+      contains('absorbed'),
+    );
+  });
+
+  test('grantAidApplied', () {
+    final g = minimalGame();
+    expect(
+      formatDiplomaticEvent(
+        ev(DiplomaticEventType.grantAidApplied, amount: 100),
+        g,
+        humanId,
+      ),
+      contains('100'),
+    );
+  });
+
+  test('subsidySet', () {
+    final g = minimalGame();
+    expect(
+      formatDiplomaticEvent(
+        ev(DiplomaticEventType.subsidySet, amount: 5),
+        g,
+        humanId,
+      ),
+      contains('5'),
+    );
+  });
+
+  test('subsidyUpdated', () {
+    final g = minimalGame();
+    expect(
+      formatDiplomaticEvent(
+        ev(DiplomaticEventType.subsidyUpdated, amount: 7),
+        g,
+        humanId,
+      ),
+      contains('7'),
+    );
+  });
+
+  test('subsidyCancelled', () {
+    final g = minimalGame();
+    expect(
+      formatDiplomaticEvent(
+        ev(
+          DiplomaticEventType.subsidyCancelled,
+          reason: 'treasury',
+        ),
+        g,
+        humanId,
+      ),
+      contains('treasury'),
+    );
+  });
+
+  test('interventionIntervene', () {
+    final g = minimalGame();
+    expect(
+      formatDiplomaticEvent(
+        ev(DiplomaticEventType.interventionIntervene),
+        g,
+        humanId,
+      ),
+      contains('intervened'),
+    );
+  });
+
+  test('interventionDoNothing', () {
+    final g = minimalGame();
+    expect(
+      formatDiplomaticEvent(
+        ev(DiplomaticEventType.interventionDoNothing),
+        g,
+        humanId,
+      ),
+      contains('did not intervene'),
+    );
+  });
+
+  test('interventionProtest', () {
+    final g = minimalGame();
+    expect(
+      formatDiplomaticEvent(
+        ev(DiplomaticEventType.interventionProtest),
+        g,
+        humanId,
+      ),
+      contains('protested'),
+    );
+  });
+
+  test('agreementsClearedOnWar', () {
+    final g = minimalGame();
+    expect(
+      formatDiplomaticEvent(
+        ev(DiplomaticEventType.agreementsClearedOnWar),
+        g,
+        humanId,
+      ),
+      contains('war'),
+    );
+  });
+}

--- a/app/test/diplomacy_panel_orders_test.dart
+++ b/app/test/diplomacy_panel_orders_test.dart
@@ -1,0 +1,179 @@
+// DiplomacyPanel order UI: empty state, confirm dialog, pending cancel.
+import 'package:colonizethis_app/features/game/widgets/diplomacy_panel.dart';
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/widgets/debug_init_game.dart';
+
+class _PendingOrderShell extends StatefulWidget {
+  const _PendingOrderShell({
+    required this.game,
+    required this.humanPlayerId,
+    required this.topology,
+  });
+
+  final Game game;
+  final String humanPlayerId;
+  final MapTopology topology;
+
+  @override
+  State<_PendingOrderShell> createState() => _PendingOrderShellState();
+}
+
+class _PendingOrderShellState extends State<_PendingOrderShell> {
+  late Orders _orders;
+
+  Orders get ordersSnapshot => _orders;
+
+  @override
+  void initState() {
+    super.initState();
+    final targetId = widget.game.players
+        .firstWhere((p) => p.id != widget.humanPlayerId)
+        .id;
+    _orders = Orders(
+      diplomaticOrdersByPlayerId: {
+        widget.humanPlayerId: [
+          DiplomaticOrder(
+            type: DiplomaticOrderType.declareWar,
+            targetFactionId: targetId,
+          ),
+        ],
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: DiplomacyPanel(
+          game: widget.game,
+          humanPlayerId: widget.humanPlayerId,
+          topology: widget.topology,
+          currentOrders: _orders,
+          onOrdersChanged: (o) => setState(() => _orders = o),
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  suppressLogsForTests();
+
+  testWidgets('DiplomacyPanel shows empty state when no factions discovered', (
+    WidgetTester tester,
+  ) async {
+    const humanId = 'solo';
+    final game = Game(
+      id: 'solo_game',
+      worldState: const WorldState(
+        turnState: TurnState(phase: TurnPhase.orders, turnNumber: 0),
+        oldWorld: RegionData(),
+        newWorld: RegionData(),
+      ),
+      players: const [
+        Player(
+          id: humanId,
+          displayName: 'Only',
+          isHuman: true,
+          treasury: 0,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DiplomacyPanel(
+            game: game,
+            humanPlayerId: humanId,
+            topology: MapTopology(),
+            currentOrders: const Orders(),
+            onOrdersChanged: (_) {},
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('No other factions discovered yet.'), findsOneWidget);
+  });
+
+  testWidgets(
+    'DiplomacyPanel Declare War opens confirm dialog; Cancel dismisses',
+    (WidgetTester tester) async {
+      final r = getDebugInitGameResult();
+      final game = r.game;
+      final humanId = game.players.firstWhere((p) => p.isHuman).id;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: DiplomacyPanel(
+              game: game,
+              humanPlayerId: humanId,
+              topology: r.combinedTopology,
+              currentOrders: const Orders(),
+              onOrdersChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final declareWar = find.text('Declare War');
+      if (declareWar.evaluate().isEmpty) {
+        return;
+      }
+
+      await tester.ensureVisible(declareWar.first);
+      await tester.tap(declareWar.first);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Confirm'), findsWidgets);
+      await tester.tap(find.text('Cancel').last);
+      await tester.pumpAndSettle();
+    },
+  );
+
+  testWidgets(
+    'DiplomacyPanel pending order shows Cancel on CtNinePatchButton; tap clears',
+    (WidgetTester tester) async {
+      final r = getDebugInitGameResult();
+      final game = r.game;
+      final humanId = game.players.firstWhere((p) => p.isHuman).id;
+
+      await tester.pumpWidget(
+        _PendingOrderShell(
+          game: game,
+          humanPlayerId: humanId,
+          topology: r.combinedTopology,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final state =
+          tester.state<_PendingOrderShellState>(find.byType(_PendingOrderShell));
+      expect(
+        state.ordersSnapshot.diplomaticOrdersByPlayerId[humanId],
+        isNotEmpty,
+      );
+
+      final cancelOnPatch = find.widgetWithText(CtNinePatchButton, 'Cancel');
+      expect(cancelOnPatch, findsWidgets);
+      await tester.tap(cancelOnPatch.first);
+      await tester.pumpAndSettle();
+
+      expect(
+        state.ordersSnapshot.diplomaticOrdersByPlayerId[humanId] ?? [],
+        isEmpty,
+      );
+    },
+  );
+}

--- a/app/test/game_screen_turn_resolution_branches_test.dart
+++ b/app/test/game_screen_turn_resolution_branches_test.dart
@@ -1,0 +1,108 @@
+// Covers GameScreen turn / overture branches when map view is suppressed (Flame overlay).
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/config/themes.dart';
+import 'package:colonizethis_app/core/services/game_service.dart';
+import 'package:colonizethis_app/features/game/flame/game_screen.dart';
+import 'package:colonizethis_app/providers/game_service_provider.dart';
+import 'package:colonizethis_app/providers/games_box_provider.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_app/providers/map_view_provider.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_save/colonizethis_save.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+class _PendingTurnGameService extends GameService {
+  _PendingTurnGameService(super.box, super.adapter);
+
+  @override
+  TurnResolutionResult runTurnResolution(
+    Game current, {
+    Orders? orders,
+    Orders? aiOrders,
+    MapTopology? topology,
+    Map<String, TileMapResult>? tileMapByRegion,
+    void Function(GameEvent)? onGameEvent,
+  }) {
+    final humanId = current.players.firstWhere((p) => p.isHuman).id;
+    return TurnResolutionPendingOvertures(
+      game: current,
+      pendingOvertures: [
+        OvertureOffer(
+          offererGpId: 'offerer_gp',
+          targetFactionId: humanId,
+          stage: OvertureStage.tradeConsulate,
+        ),
+      ],
+    );
+  }
+}
+
+void main() {
+  suppressLogsForTests();
+
+  late Box<dynamic> box;
+
+  setUpAll(() async {
+    Hive.init('./.dart_tool/test_hive_game_screen_turn_branches');
+    box = await Hive.openBox<dynamic>(HiveBoxNames.games);
+  });
+
+  testWidgets(
+    'GameScreen overlay Next turn sets pending overtures when resolution returns pending',
+    (WidgetTester tester) async {
+      final game = Game(
+        id: 'turn_pending_ui',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [
+          Player(
+            id: 'gp_human',
+            displayName: 'Human',
+            isHuman: true,
+            treasury: 0,
+          ),
+        ],
+      );
+
+      final service = _PendingTurnGameService(box, GameSaveAdapter());
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gamesBoxProvider.overrideWith((ref) => box),
+            gameServiceProvider.overrideWith((ref) => service),
+            currentGameProvider.overrideWith((ref) => game),
+            mapViewDataProvider.overrideWith((ref) => null),
+            gameIdsWithIntroShownProvider.overrideWith((ref) => {game.id}),
+          ],
+          child: MaterialApp(
+            theme: AppThemes.colonial,
+            home: const GameScreen(),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      await tester.tap(find.textContaining('Next turn').last);
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final container =
+          ProviderScope.containerOf(tester.element(find.byType(GameScreen)));
+      final pending = container.read(pendingOverturesProvider);
+      expect(pending, isNotNull);
+      expect(pending, isNotEmpty);
+    },
+    timeout: const Timeout(Duration(seconds: 30)),
+  );
+}

--- a/app/test/game_side_menu_test.dart
+++ b/app/test/game_side_menu_test.dart
@@ -1,7 +1,17 @@
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/config/routes.dart';
+import 'package:colonizethis_app/core/services/game_service.dart';
 import 'package:colonizethis_app/features/game/flame/game_side_menu.dart';
+import 'package:colonizethis_app/features/game/widgets/diplomacy_screen.dart';
+import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart';
+import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
+import 'package:colonizethis_app/features/game/widgets/civilian_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/production_screen.dart';
+import 'package:colonizethis_app/providers/game_service_provider.dart';
+import 'package:colonizethis_app/providers/games_box_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
+import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
@@ -14,12 +24,14 @@ void main() {
 
   late Game game;
 
+  late Box<dynamic> gamesBox;
+
   setUpAll(() async {
     final result = getDebugInitGameResult();
     game = result.game;
 
     Hive.init('./.dart_tool/test_hive_side_menu');
-    await Hive.openBox<dynamic>('games');
+    gamesBox = await Hive.openBox<dynamic>(HiveBoxNames.games);
   });
 
   testWidgets('GameSideMenu builds empire buttons and close button calls onClose',
@@ -33,8 +45,15 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
+          gamesBoxProvider.overrideWith((ref) => gamesBox),
+          gameServiceProvider.overrideWith(
+            (ref) => GameService(gamesBox, GameSaveAdapter()),
+          ),
           currentGameProvider.overrideWith((ref) => game),
           currentOrdersProvider.overrideWith((ref) => const Orders()),
+          availableWorkTargetsProvider.overrideWith(
+            (ref) => <String, List<String>>{},
+          ),
         ],
         child: MaterialApp(
           home: Scaffold(
@@ -80,8 +99,15 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
+          gamesBoxProvider.overrideWith((ref) => gamesBox),
+          gameServiceProvider.overrideWith(
+            (ref) => GameService(gamesBox, GameSaveAdapter()),
+          ),
           currentGameProvider.overrideWith((ref) => game),
           currentOrdersProvider.overrideWith((ref) => const Orders()),
+          availableWorkTargetsProvider.overrideWith(
+            (ref) => <String, List<String>>{},
+          ),
         ],
         child: MaterialApp(
           home: Scaffold(
@@ -123,8 +149,15 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
+          gamesBoxProvider.overrideWith((ref) => gamesBox),
+          gameServiceProvider.overrideWith(
+            (ref) => GameService(gamesBox, GameSaveAdapter()),
+          ),
           currentGameProvider.overrideWith((ref) => game),
           currentOrdersProvider.overrideWith((ref) => const Orders()),
+          availableWorkTargetsProvider.overrideWith(
+            (ref) => <String, List<String>>{},
+          ),
         ],
         child: MaterialApp(
           home: Scaffold(
@@ -154,6 +187,322 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Technology'), findsOneWidget);
+  });
+
+  testWidgets('GameSideMenu opens Military Units panel', (
+    WidgetTester tester,
+  ) async {
+    final humanPlayerId = game.players.where((p) => p.isHuman).isNotEmpty
+        ? game.players.where((p) => p.isHuman).first.id
+        : game.players.first.id;
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(size: Size(480, 1600)),
+        child: ProviderScope(
+          overrides: [
+            gamesBoxProvider.overrideWith((ref) => gamesBox),
+            gameServiceProvider.overrideWith(
+              (ref) => GameService(gamesBox, GameSaveAdapter()),
+            ),
+            currentGameProvider.overrideWith((ref) => game),
+            currentOrdersProvider.overrideWith((ref) => const Orders()),
+            availableWorkTargetsProvider.overrideWith(
+              (ref) => <String, List<String>>{},
+            ),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: Stack(
+                children: [
+                  GameSideMenu(
+                    game: game,
+                    humanPlayerId: humanPlayerId,
+                    sideMenuOpen: true,
+                    onClose: () {},
+                    onPanelDismissed: () {},
+                    onLocateCivilianUnit: (_) {},
+                    onLocateMilitaryTile: (_, __) {},
+                    onLocateNavalFleet: (_, __) {},
+                    onCancelUnitWork: (_) {},
+                    onStartWorkTargetSelection: (_, __) {},
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(find.text('Military Units'));
+    await tester.tap(find.text('Military Units'));
+    await tester.pumpAndSettle();
+    expect(find.byType(MilitaryUnitsPanel), findsOneWidget);
+  });
+
+  testWidgets('GameSideMenu opens Naval Units panel', (
+    WidgetTester tester,
+  ) async {
+    final humanPlayerId = game.players.where((p) => p.isHuman).isNotEmpty
+        ? game.players.where((p) => p.isHuman).first.id
+        : game.players.first.id;
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(size: Size(480, 1600)),
+        child: ProviderScope(
+          overrides: [
+            gamesBoxProvider.overrideWith((ref) => gamesBox),
+            gameServiceProvider.overrideWith(
+              (ref) => GameService(gamesBox, GameSaveAdapter()),
+            ),
+            currentGameProvider.overrideWith((ref) => game),
+            currentOrdersProvider.overrideWith((ref) => const Orders()),
+            availableWorkTargetsProvider.overrideWith(
+              (ref) => <String, List<String>>{},
+            ),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: Stack(
+                children: [
+                  GameSideMenu(
+                    game: game,
+                    humanPlayerId: humanPlayerId,
+                    sideMenuOpen: true,
+                    onClose: () {},
+                    onPanelDismissed: () {},
+                    onLocateCivilianUnit: (_) {},
+                    onLocateMilitaryTile: (_, __) {},
+                    onLocateNavalFleet: (_, __) {},
+                    onCancelUnitWork: (_) {},
+                    onStartWorkTargetSelection: (_, __) {},
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(find.text('Naval Units'));
+    await tester.tap(find.text('Naval Units'));
+    await tester.pumpAndSettle();
+    expect(find.byType(NavalUnitsPanel), findsOneWidget);
+  });
+
+  testWidgets('GameSideMenu opens Civilian Units sheet', (
+    WidgetTester tester,
+  ) async {
+    final humanPlayerId = game.players.where((p) => p.isHuman).isNotEmpty
+        ? game.players.where((p) => p.isHuman).first.id
+        : game.players.first.id;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          gamesBoxProvider.overrideWith((ref) => gamesBox),
+          gameServiceProvider.overrideWith(
+            (ref) => GameService(gamesBox, GameSaveAdapter()),
+          ),
+          currentGameProvider.overrideWith((ref) => game),
+          currentOrdersProvider.overrideWith((ref) => const Orders()),
+          availableWorkTargetsProvider.overrideWith(
+            (ref) => <String, List<String>>{},
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: Stack(
+              children: [
+                GameSideMenu(
+                  game: game,
+                  humanPlayerId: humanPlayerId,
+                  sideMenuOpen: true,
+                  onClose: () {},
+                  onPanelDismissed: () {},
+                  onLocateCivilianUnit: (_) {},
+                  onLocateMilitaryTile: (_, __) {},
+                  onLocateNavalFleet: (_, __) {},
+                  onCancelUnitWork: (_) {},
+                  onStartWorkTargetSelection: (_, __) {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Civilian Units'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CivilianUnitsPanel), findsOneWidget);
+  });
+
+  testWidgets('GameSideMenu Diplomacy pushes DiplomacyScreen', (
+    WidgetTester tester,
+  ) async {
+    final humanPlayerId = game.players.where((p) => p.isHuman).isNotEmpty
+        ? game.players.where((p) => p.isHuman).first.id
+        : game.players.first.id;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          gamesBoxProvider.overrideWith((ref) => gamesBox),
+          gameServiceProvider.overrideWith(
+            (ref) => GameService(gamesBox, GameSaveAdapter()),
+          ),
+          currentGameProvider.overrideWith((ref) => game),
+          currentOrdersProvider.overrideWith((ref) => const Orders()),
+          availableWorkTargetsProvider.overrideWith(
+            (ref) => <String, List<String>>{},
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: Stack(
+              children: [
+                GameSideMenu(
+                  game: game,
+                  humanPlayerId: humanPlayerId,
+                  sideMenuOpen: true,
+                  onClose: () {},
+                  onPanelDismissed: () {},
+                  onLocateCivilianUnit: (_) {},
+                  onLocateMilitaryTile: (_, __) {},
+                  onLocateNavalFleet: (_, __) {},
+                  onCancelUnitWork: (_) {},
+                  onStartWorkTargetSelection: (_, __) {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Diplomacy'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(DiplomacyScreen), findsOneWidget);
+  });
+
+  testWidgets('GameSideMenu Debug log navigates to named route', (
+    WidgetTester tester,
+  ) async {
+    final humanPlayerId = game.players.where((p) => p.isHuman).isNotEmpty
+        ? game.players.where((p) => p.isHuman).first.id
+        : game.players.first.id;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          gamesBoxProvider.overrideWith((ref) => gamesBox),
+          gameServiceProvider.overrideWith(
+            (ref) => GameService(gamesBox, GameSaveAdapter()),
+          ),
+          currentGameProvider.overrideWith((ref) => game),
+          currentOrdersProvider.overrideWith((ref) => const Orders()),
+          availableWorkTargetsProvider.overrideWith(
+            (ref) => <String, List<String>>{},
+          ),
+        ],
+        child: MaterialApp(
+          routes: {
+            Routes.debugLog: (_) => const Scaffold(
+                  body: Center(child: Text('debug-route-marker')),
+                ),
+          },
+          home: Scaffold(
+            body: Stack(
+              children: [
+                GameSideMenu(
+                  game: game,
+                  humanPlayerId: humanPlayerId,
+                  sideMenuOpen: true,
+                  onClose: () {},
+                  onPanelDismissed: () {},
+                  onLocateCivilianUnit: (_) {},
+                  onLocateMilitaryTile: (_, __) {},
+                  onLocateNavalFleet: (_, __) {},
+                  onCancelUnitWork: (_) {},
+                  onStartWorkTargetSelection: (_, __) {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Debug log'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('debug-route-marker'), findsOneWidget);
+  });
+
+  testWidgets('GameSideMenu horizontal drag left invokes onClose', (
+    WidgetTester tester,
+  ) async {
+    final humanPlayerId = game.players.where((p) => p.isHuman).isNotEmpty
+        ? game.players.where((p) => p.isHuman).first.id
+        : game.players.first.id;
+
+    var closed = false;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          gamesBoxProvider.overrideWith((ref) => gamesBox),
+          gameServiceProvider.overrideWith(
+            (ref) => GameService(gamesBox, GameSaveAdapter()),
+          ),
+          currentGameProvider.overrideWith((ref) => game),
+          currentOrdersProvider.overrideWith((ref) => const Orders()),
+          availableWorkTargetsProvider.overrideWith(
+            (ref) => <String, List<String>>{},
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: Stack(
+              children: [
+                GameSideMenu(
+                  game: game,
+                  humanPlayerId: humanPlayerId,
+                  sideMenuOpen: true,
+                  onClose: () => closed = true,
+                  onPanelDismissed: () {},
+                  onLocateCivilianUnit: (_) {},
+                  onLocateMilitaryTile: (_, __) {},
+                  onLocateNavalFleet: (_, __) {},
+                  onCancelUnitWork: (_) {},
+                  onStartWorkTargetSelection: (_, __) {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.drag(
+      find.byType(GameSideMenu),
+      const Offset(-40, 0),
+    );
+    await tester.pumpAndSettle();
+
+    expect(closed, isTrue);
   });
 }
 

--- a/app/test/naval_units_panel_test.dart
+++ b/app/test/naval_units_panel_test.dart
@@ -797,5 +797,77 @@ void main() {
 
       expect(find.byType(Checkbox), findsNothing);
     });
+
+    testWidgets('AC: Beachhead mission appears in status line', (
+      WidgetTester tester,
+    ) async {
+      const playerId = 'p_beach';
+      final gameBeach = Game(
+        id: 'beach_test',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(units: []),
+          newWorld: const RegionData(),
+          fleets: [
+            Fleet(
+              id: 'bf1',
+              ownerId: playerId,
+              regionId: 'oldWorld',
+              seaZoneId: 'atlantic',
+              shipTypeIds: const ['carrack'],
+              mission: FleetMission.beachhead,
+            ),
+          ],
+          portsByProvinceSeaboard: {
+            'oldWorld|lisbon|atlantic': 'oldWorld|lisbon|0|0',
+          },
+          tileKeysByRegionAndProvince: {
+            'oldWorld': {
+              'oldWorld|lisbon': ['oldWorld|lisbon|0|0'],
+            },
+          },
+        ),
+        players: const [
+          Player(id: playerId, displayName: 'P', isHuman: true),
+        ],
+      );
+
+      await tester.pumpWidget(
+        buildPanel(game: gameBeach, humanPlayerId: playerId),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Beachhead'), findsWidgets);
+    });
+
+    testWidgets('AC: No fleets and no capital shows empty naval message', (
+      WidgetTester tester,
+    ) async {
+      const playerId = 'p_empty';
+      final emptyGame = Game(
+        id: 'empty_naval',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: [
+          const Player(
+            id: playerId,
+            displayName: 'Solo',
+            isHuman: true,
+            treasury: 0,
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        buildPanel(game: emptyGame, humanPlayerId: playerId),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('No naval units'), findsOneWidget);
+    });
+
   });
 }

--- a/tool/check_coverage_threshold.sh
+++ b/tool/check_coverage_threshold.sh
@@ -27,25 +27,12 @@ for dir in "${TARGETS[@]}"; do
     echo "Skip $dir (no coverage/lcov.info — run tool/test_coverage.py first)"
     continue
   fi
-  # For the app target, exclude trivial/glue files from coverage to keep
-  # the gate focused on real behavior.
+  # App: use full lcov (widgetbook/catalog.dart uses Dart coverage:ignore-file).
+  # Copy so consumers of lcov.filtered.info always get a fresh file.
   filtered_lcov="$lcov_file"
   if [ "$dir" = "app" ]; then
     filtered_lcov="$ROOT/$dir/coverage/lcov.filtered.info"
-    # Always regenerate so changes to the exclude list apply (no stale filter).
-    lcov --remove "$lcov_file" \
-      "lib/widgetbook/catalog.dart" \
-      "lib/features/game/flame/game_screen.dart" \
-      "lib/features/game/widgets/naval_units_panel.dart" \
-      "lib/features/game/flame/game_side_menu.dart" \
-      "lib/features/game/widgets/diplomacy_detail_screen.dart" \
-      "lib/features/game/dialogue/game_start_intro_overlay.dart" \
-      "lib/features/game/widgets/diplomacy_panel.dart" \
-      -o "$filtered_lcov" >/dev/null 2>&1 || true
-    if [ ! -f "$filtered_lcov" ]; then
-      echo "Failed to generate $filtered_lcov for app coverage gate."
-      exit 1
-    fi
+    cp "$lcov_file" "$filtered_lcov"
   fi
 
   summary=$(lcov --summary "$filtered_lcov" 2>/dev/null) || true


### PR DESCRIPTION
## Summary
Removes per-file `lcov --remove` filtering for the **app** package so the 80% line gate runs on the full instrumented tree. Adds tests and a small test hook so coverage stays above the threshold (~83.6% lines in a recent `flutter test --coverage` run).

## Key changes
- **`tool/check_coverage_threshold.sh`**: For `app`, copy `lcov.info` → `lcov.filtered.info` (no excludes).
- **`app/lib/widgetbook/catalog.dart`**: `// coverage:ignore-file` so the dev catalog is not instrumented (replaces excluding it in the shell script).
- **`GameStartIntroOverlay`**: Optional `assetBundle` for loading the Yarn file; default remains `rootBundle`.
- **Tests**: GameScreen pending overtures via overlay Next turn; `formatDiplomaticEvent` branches; DiplomacyPanel empty / confirm / pending cancel; GameSideMenu military, naval, civilian, diplomacy, debug route, drag-to-close; naval beachhead + empty state; intro load-failure UI.

## Verification
- `flutter test` in `app/` — **377** tests passed.

Targets **dev**.

Made with [Cursor](https://cursor.com)