### PR TITLE
Add colonizethis_logger package for prefixed logging

### DIFF
--- a/SPEC/program/colonizethis-logger.md
+++ b/SPEC/program/colonizethis-logger.md
@@ -1,0 +1,141 @@
+# colonizethis-logger
+
+**SPEC/program** — Prefixed logger utility for consistent log categorization in the debug log viewer.
+
+---
+
+## 1. Purpose
+
+Provide a utility logger (`ct_logger`) that auto-prefixes all log messages with a known category prefix (e.g. `map:`, `logic:`, `ai:`). This ensures:
+
+- All logs are properly categorized for filtering in the debug log viewer
+- No developer forgets to add a prefix manually
+- Consistent prefix format across the codebase
+
+---
+
+## 2. Design
+
+### 2.1 Logger prefix constants
+
+Package-scoped constants define valid prefixes matching `knownPrefixes` in `session_log_buffer.dart`:
+
+```dart
+const String kLogPrefixLogic = 'logic';
+const String kLogPrefixAi = 'ai';
+const String kLogPrefixData = 'data';
+const String kLogPrefixMap = 'map';
+const String kLogPrefixSave = 'save';
+const String kLogPrefixTui = 'tui';
+const String kLogPrefixGame = 'game';
+```
+
+### 2.2 CtLogger class
+
+```dart
+class CtLogger {
+  final Logger _log;
+  final String prefix;
+
+  const CtLogger(this.prefix) : _log = Logger(prefix);
+
+  void d(String msg) => _log.d('$prefix: $msg');
+  void i(String msg) => _log.i('$prefix: $msg');
+  void w(String msg) => _log.w('$prefix: $msg');
+  void e(String msg, {Object? error, StackTrace? stackTrace}) =>
+      _log.e('$prefix: $msg', error: error, stackTrace: stackTrace);
+}
+```
+
+- Uses `Logger(loggerName: prefix)` to set the logger name (useful for tooling that reads logger names)
+- Prepends `$prefix: ` to every message
+- Delegates all other `Logger` methods via `_log`
+
+### 2.3 Global instance factories (optional convenience)
+
+For packages that use a single logger:
+
+```dart
+CtLogger logicLogger([String? subPrefix]) =>
+    subPrefix != null ? CtLogger('$kLogPrefixLogic.$subPrefix') : CtLogger(kLogPrefixLogic);
+
+CtLogger aiLogger([String? subPrefix]) =>
+    subPrefix != null ? CtLogger('$kLogPrefixAi.$subPrefix') : CtLogger(kLogPrefixAi);
+
+// etc.
+```
+
+---
+
+## 3. Package structure
+
+```
+packages/colonizethis_logger/
+  lib/
+    colonizethis_logger.dart      # exports
+    src/
+      ct_logger.dart              # CtLogger class
+      prefixes.dart               # prefix constants
+  pubspec.yaml
+  test/
+    ct_logger_test.dart
+```
+
+---
+
+## 4. Adoption
+
+### 4.1 Migration
+
+Replace raw `Logger()` usage with `CtLogger(prefix)`:
+
+| Before | After |
+|--------|-------|
+| `final _log = Logger();` | `final _log = CtLogger(kLogPrefixMap);` |
+| `_log.i('Loading tileset');` | `_log.i('Loading tileset');` → outputs `map: Loading tileset` |
+
+### 4.2 Packages to migrate (in order)
+
+1. **colonizethis_logic** — prefix `logic`
+2. **colonizethis_ai** — prefix `ai`
+3. **colonizethis_map** — prefix `map`
+4. **colonizethis_data** — prefix `data`
+5. **colonizethis_save** — prefix `save`
+6. **app/lib/features/game/flame/** — prefix `game` (Flame components)
+7. **app/lib/features/debug_log/** — prefix `app` (not `tui`, which is ctterm-only)
+
+ctterm and ctdev have their own logging setups (`ctterm_log.dart`, `ctdev_log.dart`) using `basic_logger_file`; they may optionally adopt `CtLogger` internally but are not required for the debug viewer (they don't use `SessionLogBuffer`).
+
+### 4.3 SessionLogBuffer knownPrefixes update
+
+Add `game` to `knownPrefixes` in `session_log_buffer.dart`:
+
+```dart
+const List<String> knownPrefixes = [
+  'ctdev',
+  'logic',
+  'ai',
+  'data',
+  'map',
+  'save',
+  'game',  // <-- Flame/UI components
+  'tui',
+];
+```
+
+---
+
+## 5. Acceptance criteria
+
+- **Prefix consistency:** All `CtLogger` instances auto-prefix messages with `prefix: ` format.
+- **Debug viewer integration:** Logs from migrated packages appear in the debug viewer under the correct prefix filter.
+- **No manual prefixing needed:** Developers call `_log.i('message')` not `_log.i('prefix: message')`.
+- **Backward compatible:** Raw `Logger()` still works; `CtLogger` is additive.
+
+---
+
+## 6. References
+
+- Debug log viewer: [SPEC/program/debug-log-viewer.md](debug-log-viewer.md)
+- Session log buffer: `packages/session_log_buffer/lib/session_log_buffer.dart`
+- Existing prefixes: `ctdev`, `logic`, `ai`, `data`, `map`, `save`, `tui` (per `session_log_buffer.dart`)

--- a/app/lib/features/game/flame/region_map_component.dart
+++ b/app/lib/features/game/flame/region_map_component.dart
@@ -1,15 +1,15 @@
 import 'dart:math' as math;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:flame/components.dart';
 import 'package:flutter/material.dart';
-import 'package:logger/logger.dart';
 
 import 'resource_icon_cache.dart';
 import 'terrain_tileset.dart';
 
-final _log = Logger();
+final _log = gameLogger();
 
 /// Fog overlay opacity when drawing a dark rect over tiles (0 = no overlay, 1 = full black).
 const double _fogOverlayOpacity = 0.4;

--- a/app/lib/features/game/flame/resource_icon_cache.dart
+++ b/app/lib/features/game/flame/resource_icon_cache.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 import 'dart:ui' as ui;
 
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:flutter/services.dart';
-import 'package:logger/logger.dart';
 
-final _log = Logger();
+final _log = gameLogger();
 
 /// Resource IDs for which icons exist (excludes commodities without tile resources).
 const Set<String> kResourceIconIds = {

--- a/app/lib/features/game/flame/terrain_tileset.dart
+++ b/app/lib/features/game/flame/terrain_tileset.dart
@@ -3,10 +3,10 @@ import 'dart:convert';
 import 'dart:ui' as ui;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:flutter/services.dart';
-import 'package:logger/logger.dart';
 
-final _log = Logger();
+final _log = gameLogger();
 
 /// Sea terrain identifier (not in TerrainType enum).
 const String seaTerrainId = 'sea';

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   hive: ^2.2.3
   hive_flutter: ^1.1.0
   session_log_buffer:
+  colonizethis_logger:
   colonizethis_map:
   colonizethis_models:
   colonizethis_data:

--- a/packages/colonizethis_ai/lib/src/domain_planners.dart
+++ b/packages/colonizethis_ai/lib/src/domain_planners.dart
@@ -1,9 +1,9 @@
 import 'dart:math' as math;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
-import 'package:logger/logger.dart';
 
 import 'ai_config.dart';
 import 'economy_planner.dart';
@@ -12,9 +12,9 @@ import 'hidden_agenda.dart';
 import 'perception.dart';
 import 'seed_bundle.dart';
 
-// Domain planners (utility AI). SPEC/ai/ai-architecture.md, ai-systems-impl.md, economy-planner.md.
+final _log = aiLogger();
 
-const String _kDomainLogPrefix = 'ai/domain_planners';
+// Domain planners (utility AI). SPEC/ai/ai-architecture.md, ai-systems-impl.md, economy-planner.md.
 
 /// Runs economy, military, diplomacy, and research planners; returns combined orders
 /// for [nationId]. Uses [suggestionAPI] and [economyPlan] (cargo preference) to score
@@ -35,33 +35,53 @@ Orders runDomainPlanners({
   final domainWeights = getDomainWeightsForLeader(config.leaderId);
 
   // Economy: build/work suggestions weighted by economy domain.
-  final workCandidates = suggestionAPI.suggestWorkOrders(view, game, topology, orders);
-  final buildCandidates = suggestionAPI.suggestBuildOrders(view, game, topology, orders);
-  final hasSpyWork = workCandidates.any((o) => o.target == 'steal_tech' || o.target == 'counter_spy');
-  final workThreshold = 40 - (hasSpyWork ? agendaSpyOrderModifier(config.hiddenAgendaId) : 0);
-  Logger().d(
-    '$_kDomainLogPrefix: work eval nationId=$nationId workThreshold=$workThreshold '
+  final workCandidates = suggestionAPI.suggestWorkOrders(
+    view,
+    game,
+    topology,
+    orders,
+  );
+  final buildCandidates = suggestionAPI.suggestBuildOrders(
+    view,
+    game,
+    topology,
+    orders,
+  );
+  final hasSpyWork = workCandidates.any(
+    (o) => o.target == 'steal_tech' || o.target == 'counter_spy',
+  );
+  final workThreshold =
+      40 - (hasSpyWork ? agendaSpyOrderModifier(config.hiddenAgendaId) : 0);
+  _log.d(
+    'work eval nationId=$nationId workThreshold=$workThreshold '
     'domainWeights.economy=${domainWeights.economy} primaryGoal=$primaryGoal '
     'workCandidates=${workCandidates.map((o) => "${o.unitId}:${o.target}").toList()}',
   );
   if (workCandidates.isNotEmpty &&
-      (primaryGoal == StrategicGoal.expand || domainWeights.economy >= workThreshold)) {
+      (primaryGoal == StrategicGoal.expand ||
+          domainWeights.economy >= workThreshold)) {
     final agendaId = config.hiddenAgendaId;
     final pickFrom = (agendaId == 'tech_thief' && hasSpyWork)
-        ? workCandidates.where((o) => o.target == 'steal_tech' || o.target == 'counter_spy').toList()
+        ? workCandidates
+              .where(
+                (o) => o.target == 'steal_tech' || o.target == 'counter_spy',
+              )
+              .toList()
         : workCandidates;
     final list = pickFrom.isNotEmpty ? pickFrom : workCandidates;
     final rng = math.Random(seeds.economySeed);
     final idx = rng.nextInt(list.length);
     final chosen = list[idx];
-    Logger().i('$_kDomainLogPrefix: work chosen nationId=$nationId unitId=${chosen.unitId} target=${chosen.target}');
+    _log.i(
+      'work chosen nationId=$nationId unitId=${chosen.unitId} target=${chosen.target}',
+    );
     orders = _appendWorkOrders(orders, nationId, [chosen]);
   } else if (workCandidates.isNotEmpty) {
-    Logger().d('$_kDomainLogPrefix: work skipped nationId=$nationId weight below threshold');
+    _log.d('work skipped nationId=$nationId weight below threshold');
   }
   final buildThreshold = 30 - agendaBuildOrderModifier(config.hiddenAgendaId);
-  Logger().d(
-    '$_kDomainLogPrefix: build eval nationId=$nationId buildThreshold=$buildThreshold '
+  _log.d(
+    'build eval nationId=$nationId buildThreshold=$buildThreshold '
     'buildCandidates=${buildCandidates.map((o) => o.unitType).toList()}',
   );
   if (buildCandidates.isNotEmpty && domainWeights.economy >= buildThreshold) {
@@ -74,11 +94,11 @@ Orders runDomainPlanners({
       nationId: nationId,
     );
     if (chosen != null) {
-      Logger().i('$_kDomainLogPrefix: build chosen nationId=$nationId unitType=${chosen.unitType}');
+      _log.i('build chosen nationId=$nationId unitType=${chosen.unitType}');
       orders = _appendBuildOrders(orders, nationId, [chosen]);
     }
   } else if (buildCandidates.isNotEmpty) {
-    Logger().d('$_kDomainLogPrefix: build skipped nationId=$nationId weight below threshold');
+    _log.d('build skipped nationId=$nationId weight below threshold');
   }
 
   // Movement: suggest moves; weight by military/expand.
@@ -123,10 +143,16 @@ Orders runDomainPlanners({
   );
 
   // Research: suggest research; weight by tech domain, agenda (tech_thief boost), and personality research preference.
-  final researchCandidates = suggestionAPI.suggestResearchOrders(view, game, topology, orders);
+  final researchCandidates = suggestionAPI.suggestResearchOrders(
+    view,
+    game,
+    topology,
+    orders,
+  );
   final researchThreshold = 40 - agendaResearchModifier(config.hiddenAgendaId);
   if (researchCandidates.isNotEmpty &&
-      (primaryGoal == StrategicGoal.tech || domainWeights.research >= researchThreshold)) {
+      (primaryGoal == StrategicGoal.tech ||
+          domainWeights.research >= researchThreshold)) {
     final thresholds = getThresholdsForLeader(config.leaderId);
     final scores = researchCandidates.map((o) {
       final tech = techById(o.techId);
@@ -134,14 +160,14 @@ Orders runDomainPlanners({
       final w = category == 'transport'
           ? thresholds.researchNaval
           : category == 'military'
-              ? thresholds.researchMilitary
-              : category == 'gathering'
-                  ? thresholds.researchEconomic
-                  : thresholds.researchExploration;
+          ? thresholds.researchMilitary
+          : category == 'gathering'
+          ? thresholds.researchEconomic
+          : thresholds.researchExploration;
       return math.max(1, w);
     }).toList();
-    Logger().d(
-      '$_kDomainLogPrefix: research eval nationId=$nationId researchThreshold=$researchThreshold '
+    _log.d(
+      'research eval nationId=$nationId researchThreshold=$researchThreshold '
       'candidates=${researchCandidates.map((o) => o.techId).toList()} scores=$scores',
     );
     final total = scores.reduce((a, b) => a + b);
@@ -153,10 +179,14 @@ Orders runDomainPlanners({
     }
     if (idx >= researchCandidates.length) idx = researchCandidates.length - 1;
     final chosen = researchCandidates[idx];
-    Logger().i('$_kDomainLogPrefix: research chosen nationId=$nationId techId=${chosen.techId} score=${scores[idx]}');
+    _log.i(
+      'research chosen nationId=$nationId techId=${chosen.techId} score=${scores[idx]}',
+    );
     orders = _appendResearchOrders(orders, nationId, [chosen]);
   } else if (researchCandidates.isNotEmpty) {
-    Logger().d('$_kDomainLogPrefix: research skipped nationId=$nationId threshold not met or no candidates');
+    _log.d(
+      'research skipped nationId=$nationId threshold not met or no candidates',
+    );
   }
 
   return orders;
@@ -174,23 +204,30 @@ Orders _runMovePlanner({
   required AISeedBundle seeds,
   required OrderSuggestionAPI suggestionAPI,
 }) {
-  final moveCandidates = suggestionAPI.suggestMoveOrders(view, game, topology, orders);
+  final moveCandidates = suggestionAPI.suggestMoveOrders(
+    view,
+    game,
+    topology,
+    orders,
+  );
   if (moveCandidates.isEmpty) return orders;
   final filtered = filterMoveOrdersByDiplomacy(game, nationId, moveCandidates);
   if (filtered.isEmpty) return orders;
   final domainWeights = getDomainWeightsForLeader(config.leaderId);
-  final weight = primaryGoal == StrategicGoal.conquer || primaryGoal == StrategicGoal.defend
+  final weight =
+      primaryGoal == StrategicGoal.conquer ||
+          primaryGoal == StrategicGoal.defend
       ? domainWeights.military
       : primaryGoal == StrategicGoal.expand
-          ? domainWeights.economy
-          : 50;
-  Logger().d(
-    '$_kDomainLogPrefix: move eval nationId=$nationId weight=$weight '
+      ? domainWeights.economy
+      : 50;
+  _log.d(
+    'move eval nationId=$nationId weight=$weight '
     'filteredCount=${filtered.length} '
     'candidates=${filtered.map((m) => "${m.unitId}->${m.destinationProvinceId}").toList()}',
   );
   if (weight < 20) {
-    Logger().d('$_kDomainLogPrefix: move skipped nationId=$nationId weight < 20');
+    _log.d('move skipped nationId=$nationId weight < 20');
     return orders;
   }
   final provinceOwner = getProvinceOwnerMap(game);
@@ -201,7 +238,7 @@ Orders _runMovePlanner({
     final atWar = rel != null && rel.atWar;
     return 1.0 + (atWar ? kMovePreferEnemyTerritoryBonus.toDouble() : 0);
   }).toList();
-  Logger().d('$_kDomainLogPrefix: move scores nationId=$nationId scores=$scores');
+  _log.d('move scores nationId=$nationId scores=$scores');
   final total = scores.reduce((a, b) => a + b);
   if (total <= 0) return orders;
   final rng = math.Random(seeds.militarySeed);
@@ -212,8 +249,8 @@ Orders _runMovePlanner({
   }
   if (idx >= filtered.length) idx = filtered.length - 1;
   final selected = [filtered[idx]];
-  Logger().i(
-    '$_kDomainLogPrefix: move chosen nationId=$nationId '
+  _log.i(
+    'move chosen nationId=$nationId '
     'unitId=${selected.first.unitId} destinationProvinceId=${selected.first.destinationProvinceId}',
   );
   return _appendMoveOrders(orders, nationId, selected);
@@ -222,14 +259,24 @@ Orders _runMovePlanner({
 Orders _appendMoveOrders(Orders o, String playerId, List<MoveOrder> list) {
   final existing = o.moveOrdersByPlayerId[playerId] ?? const [];
   return o.copyWith(
-    moveOrdersByPlayerId: {...o.moveOrdersByPlayerId, playerId: [...existing, ...list]},
+    moveOrdersByPlayerId: {
+      ...o.moveOrdersByPlayerId,
+      playerId: [...existing, ...list],
+    },
   );
 }
 
-Orders _appendBuildOrders(Orders o, String playerId, List<BuildUnitOrder> list) {
+Orders _appendBuildOrders(
+  Orders o,
+  String playerId,
+  List<BuildUnitOrder> list,
+) {
   final existing = o.buildUnitOrdersByPlayerId[playerId] ?? const [];
   return o.copyWith(
-    buildUnitOrdersByPlayerId: {...o.buildUnitOrdersByPlayerId, playerId: [...existing, ...list]},
+    buildUnitOrdersByPlayerId: {
+      ...o.buildUnitOrdersByPlayerId,
+      playerId: [...existing, ...list],
+    },
   );
 }
 
@@ -266,7 +313,8 @@ BuildUnitOrder? _pickBuildOrder({
     }
 
     double militaryBonus = 0.0;
-    if (primaryGoal == StrategicGoal.conquer || primaryGoal == StrategicGoal.defend) {
+    if (primaryGoal == StrategicGoal.conquer ||
+        primaryGoal == StrategicGoal.defend) {
       if (isRegiment) {
         militaryBonus = 1.0;
       } else if (isShip && cargoHold == 0) {
@@ -284,8 +332,8 @@ BuildUnitOrder? _pickBuildOrder({
     return 1.0 + cargoBonus + militaryBonus + personalityBonus;
   }).toList();
 
-  Logger().d(
-    '$_kDomainLogPrefix: build scores nationId=$nationId '
+  _log.d(
+    'build scores nationId=$nationId '
     'candidates=${buildCandidates.map((o) => o.unitType).toList()} '
     'scores=$scores',
   );
@@ -304,14 +352,24 @@ BuildUnitOrder? _pickBuildOrder({
 Orders _appendWorkOrders(Orders o, String playerId, List<WorkOrder> list) {
   final existing = o.workOrdersByPlayerId[playerId] ?? const [];
   return o.copyWith(
-    workOrdersByPlayerId: {...o.workOrdersByPlayerId, playerId: [...existing, ...list]},
+    workOrdersByPlayerId: {
+      ...o.workOrdersByPlayerId,
+      playerId: [...existing, ...list],
+    },
   );
 }
 
-Orders _appendResearchOrders(Orders o, String playerId, List<ResearchOrder> list) {
+Orders _appendResearchOrders(
+  Orders o,
+  String playerId,
+  List<ResearchOrder> list,
+) {
   final existing = o.researchOrdersByPlayerId[playerId] ?? const [];
   return o.copyWith(
-    researchOrdersByPlayerId: {...o.researchOrdersByPlayerId, playerId: [...existing, ...list]},
+    researchOrdersByPlayerId: {
+      ...o.researchOrdersByPlayerId,
+      playerId: [...existing, ...list],
+    },
   );
 }
 
@@ -327,21 +385,27 @@ Orders _runNavalPlanner({
   required OrderSuggestionAPI suggestionAPI,
 }) {
   final domainWeights = getDomainWeightsForLeader(config.leaderId);
-  final weight = primaryGoal == StrategicGoal.conquer ||
-      primaryGoal == StrategicGoal.defend ||
-      primaryGoal == StrategicGoal.expand
+  final weight =
+      primaryGoal == StrategicGoal.conquer ||
+          primaryGoal == StrategicGoal.defend ||
+          primaryGoal == StrategicGoal.expand
       ? domainWeights.military
       : 40;
   if (weight < 25) {
-    Logger().d('$_kDomainLogPrefix: naval skipped nationId=$nationId weight=$weight < 25');
+    _log.d('naval skipped nationId=$nationId weight=$weight < 25');
     return orders;
   }
 
   var o = orders;
 
-  final navalMoveCandidates = suggestionAPI.suggestNavalMoveOrders(view, game, topology, o);
-  Logger().d(
-    '$_kDomainLogPrefix: naval move eval nationId=$nationId '
+  final navalMoveCandidates = suggestionAPI.suggestNavalMoveOrders(
+    view,
+    game,
+    topology,
+    o,
+  );
+  _log.d(
+    'naval move eval nationId=$nationId '
     'candidatesCount=${navalMoveCandidates.length}',
   );
   if (navalMoveCandidates.isNotEmpty) {
@@ -350,25 +414,30 @@ Orders _runNavalPlanner({
     final take = cap > 0 ? 1 + rng.nextInt(cap) : 0;
     if (take > 0) {
       final selected = navalMoveCandidates.take(take).toList();
-      Logger().i(
-        '$_kDomainLogPrefix: naval move chosen nationId=$nationId '
+      _log.i(
+        'naval move chosen nationId=$nationId '
         'take=$take selected=${selected.map((m) => "fleetId=${m.fleetId} destSea=${m.destinationSeaZoneId} destPort=${m.destinationPortProvinceId}").toList()}',
       );
       o = _appendNavalMoveOrders(o, nationId, selected);
     }
   }
 
-  final navalMissionCandidates = suggestionAPI.suggestNavalMissionOrders(view, game, topology, o);
-  Logger().d(
-    '$_kDomainLogPrefix: naval mission eval nationId=$nationId '
+  final navalMissionCandidates = suggestionAPI.suggestNavalMissionOrders(
+    view,
+    game,
+    topology,
+    o,
+  );
+  _log.d(
+    'naval mission eval nationId=$nationId '
     'candidatesCount=${navalMissionCandidates.length}',
   );
   if (navalMissionCandidates.isNotEmpty) {
     final rng = math.Random(seeds.militarySeed + 1001);
     final idx = rng.nextInt(navalMissionCandidates.length);
     final chosen = navalMissionCandidates[idx];
-    Logger().i(
-      '$_kDomainLogPrefix: naval mission chosen nationId=$nationId '
+    _log.i(
+      'naval mission chosen nationId=$nationId '
       'mission=${chosen.mission} fleetId=${chosen.fleetId}',
     );
     o = _appendNavalMissionOrders(o, nationId, [chosen]);
@@ -377,17 +446,31 @@ Orders _runNavalPlanner({
   return o;
 }
 
-Orders _appendNavalMoveOrders(Orders o, String playerId, List<NavalMoveOrder> list) {
+Orders _appendNavalMoveOrders(
+  Orders o,
+  String playerId,
+  List<NavalMoveOrder> list,
+) {
   final existing = o.navalMoveOrdersByPlayerId[playerId] ?? const [];
   return o.copyWith(
-    navalMoveOrdersByPlayerId: {...o.navalMoveOrdersByPlayerId, playerId: [...existing, ...list]},
+    navalMoveOrdersByPlayerId: {
+      ...o.navalMoveOrdersByPlayerId,
+      playerId: [...existing, ...list],
+    },
   );
 }
 
-Orders _appendNavalMissionOrders(Orders o, String playerId, List<NavalMissionOrder> list) {
+Orders _appendNavalMissionOrders(
+  Orders o,
+  String playerId,
+  List<NavalMissionOrder> list,
+) {
   final existing = o.navalMissionOrdersByPlayerId[playerId] ?? const [];
   return o.copyWith(
-    navalMissionOrdersByPlayerId: {...o.navalMissionOrdersByPlayerId, playerId: [...existing, ...list]},
+    navalMissionOrdersByPlayerId: {
+      ...o.navalMissionOrdersByPlayerId,
+      playerId: [...existing, ...list],
+    },
   );
 }
 
@@ -404,17 +487,23 @@ Orders _runDiplomacyPlanner({
   required OrderSuggestionAPI suggestionAPI,
 }) {
   final domainWeights = getDomainWeightsForLeader(config.leaderId);
-  final weight = primaryGoal == StrategicGoal.diplomacy ||
-      primaryGoal == StrategicGoal.conquer ||
-      primaryGoal == StrategicGoal.trade
+  final weight =
+      primaryGoal == StrategicGoal.diplomacy ||
+          primaryGoal == StrategicGoal.conquer ||
+          primaryGoal == StrategicGoal.trade
       ? domainWeights.diplomacy
       : 40;
   if (weight < 25) {
-    Logger().d('$_kDomainLogPrefix: diplomacy skipped nationId=$nationId weight=$weight < 25');
+    _log.d('diplomacy skipped nationId=$nationId weight=$weight < 25');
     return orders;
   }
 
-  final diploCandidates = suggestionAPI.suggestDiplomaticOrders(view, game, topology, orders);
+  final diploCandidates = suggestionAPI.suggestDiplomaticOrders(
+    view,
+    game,
+    topology,
+    orders,
+  );
   if (diploCandidates.isEmpty) return orders;
 
   final agendaId = config.hiddenAgendaId;
@@ -431,24 +520,27 @@ Orders _runDiplomacyPlanner({
         s += agendaAllianceAcceptanceModifier(agendaId);
         s += (thresholds.allianceTendency - 50);
         break;
-      case DiplomaticOrderType.declareWar: {
-        final rel = snapshot.relations[o.targetFactionId];
-        final relationScore = rel?.score ?? 50;
-        if (relationScore > maxRelationForDeclareWar) {
-          s = 0;
-        } else {
-          s += agendaConquerModifier(agendaId);
-          s += agendaTreatyBreakingModifier(agendaId);
-          s += (thresholds.warLikelihood - 50);
-          if (snapshot.opportunities.weakNeighbors.contains(o.targetFactionId)) {
-            s += getDeclareWarTargetBonusWeakerNeighbor(agendaId);
+      case DiplomaticOrderType.declareWar:
+        {
+          final rel = snapshot.relations[o.targetFactionId];
+          final relationScore = rel?.score ?? 50;
+          if (relationScore > maxRelationForDeclareWar) {
+            s = 0;
+          } else {
+            s += agendaConquerModifier(agendaId);
+            s += agendaTreatyBreakingModifier(agendaId);
+            s += (thresholds.warLikelihood - 50);
+            if (snapshot.opportunities.weakNeighbors.contains(
+              o.targetFactionId,
+            )) {
+              s += getDeclareWarTargetBonusWeakerNeighbor(agendaId);
+            }
+            if (rel?.level == RelationLevel.allied) {
+              s += getDeclareWarTargetBonusAlly(agendaId);
+            }
           }
-          if (rel?.level == RelationLevel.allied) {
-            s += getDeclareWarTargetBonusAlly(agendaId);
-          }
+          break;
         }
-        break;
-      }
       default:
         break;
     }
@@ -456,10 +548,13 @@ Orders _runDiplomacyPlanner({
   }).toList();
 
   final candidateDesc = diploCandidates
-      .map((o) => '${o.type.name}${o.type == DiplomaticOrderType.declareWar ? ":${o.targetFactionId}" : ""}')
+      .map(
+        (o) =>
+            '${o.type.name}${o.type == DiplomaticOrderType.declareWar ? ":${o.targetFactionId}" : ""}',
+      )
       .toList();
-  Logger().d(
-    '$_kDomainLogPrefix: diplomacy eval nationId=$nationId hiddenAgendaId=$agendaId '
+  _log.d(
+    'diplomacy eval nationId=$nationId hiddenAgendaId=$agendaId '
     'candidates=$candidateDesc scores=$scores',
   );
 
@@ -473,16 +568,23 @@ Orders _runDiplomacyPlanner({
   }
   if (idx >= diploCandidates.length) idx = diploCandidates.length - 1;
   final chosen = diploCandidates[idx];
-  Logger().i(
-    '$_kDomainLogPrefix: diplomacy chosen nationId=$nationId '
+  _log.i(
+    'diplomacy chosen nationId=$nationId '
     'type=${chosen.type}${chosen.type == DiplomaticOrderType.declareWar ? " targetFactionId=${chosen.targetFactionId}" : ""} score=${scores[idx]}',
   );
   return _appendDiplomaticOrders(orders, nationId, [chosen]);
 }
 
-Orders _appendDiplomaticOrders(Orders o, String playerId, List<DiplomaticOrder> list) {
+Orders _appendDiplomaticOrders(
+  Orders o,
+  String playerId,
+  List<DiplomaticOrder> list,
+) {
   final existing = o.diplomaticOrdersByPlayerId[playerId] ?? const [];
   return o.copyWith(
-    diplomaticOrdersByPlayerId: {...o.diplomaticOrdersByPlayerId, playerId: [...existing, ...list]},
+    diplomaticOrdersByPlayerId: {
+      ...o.diplomaticOrdersByPlayerId,
+      playerId: [...existing, ...list],
+    },
   );
 }

--- a/packages/colonizethis_ai/lib/src/dossier.dart
+++ b/packages/colonizethis_ai/lib/src/dossier.dart
@@ -1,18 +1,18 @@
 // Dossier projection: PlayerView-safe read API. SPEC/ai/ai-dossier.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
-const String _kDossierLogPrefix = 'ai/dossier';
+final _log = aiLogger();
 
 /// Suspicion band for display. Never exposes true agenda.
 /// Bands defined by [dossierScoreUnknownMax], [dossierScorePossibleMax], etc. SPEC/ai/ai-dossier.md.
 enum SuspicionBand {
-  unknown,   // 0–dossierScoreUnknownMax
+  unknown, // 0–dossierScoreUnknownMax
   possible, // dossierScoreUnknownMax+1 – dossierScorePossibleMax
-  likely,   // dossierScorePossibleMax+1 – dossierScoreLikelyMax
+  likely, // dossierScorePossibleMax+1 – dossierScoreLikelyMax
   almostCertain, // dossierScoreLikelyMax+1 – dossierScoreAlmostCertainMax
   confirmed, // dossierScoreAlmostCertainMax+1+
 }
@@ -31,11 +31,7 @@ const int dossierConfidenceAlmostCertain = 85;
 const int dossierConfidenceConfirmed = 100;
 
 /// Relative strength for basic intel (observer vs subject).
-enum RelativeStrength {
-  weaker,
-  even,
-  stronger,
-}
+enum RelativeStrength { weaker, even, stronger }
 
 /// Basic intel section: personality/archetype, relation, relative strength. PlayerView-safe.
 class DossierBasicIntel {
@@ -51,6 +47,7 @@ class DossierBasicIntel {
   final RelationState? relationState;
   final RelativeStrength? relativeMilitaryStrength;
   final RelativeStrength? relativeEconomicStrength;
+
   /// Human-readable archetype (e.g. "Fortifier"). From config; never exposes true agenda.
   final String? personalityArchetype;
 }
@@ -101,7 +98,8 @@ int confidencePercentFromScore(int score) {
   if (score <= dossierScoreUnknownMax) return dossierConfidenceUnknown;
   if (score <= dossierScorePossibleMax) return dossierConfidencePossible;
   if (score <= dossierScoreLikelyMax) return dossierConfidenceLikely;
-  if (score <= dossierScoreAlmostCertainMax) return dossierConfidenceAlmostCertain;
+  if (score <= dossierScoreAlmostCertainMax)
+    return dossierConfidenceAlmostCertain;
   return dossierConfidenceConfirmed;
 }
 
@@ -119,13 +117,20 @@ RelativeStrength _relativeStrength(int observerValue, int subjectValue) {
 }
 
 /// Builds basic intel from game state (relation, relative strength, personality archetype).
-DossierBasicIntel? _buildBasicIntel(Game game, String observerId, String subjectId) {
+DossierBasicIntel? _buildBasicIntel(
+  Game game,
+  String observerId,
+  String subjectId,
+) {
   final rel = getRelation(game, observerId, subjectId);
   final obs = _player(game, observerId);
   final subj = _player(game, subjectId);
   if (obs == null || subj == null) {
-    final archetype = getArchetypeDisplayNameForLeader(subjectId) ??
-        (subj?.leaderKey != null ? getArchetypeDisplayNameForLeader(subj!.leaderKey!) : null);
+    final archetype =
+        getArchetypeDisplayNameForLeader(subjectId) ??
+        (subj?.leaderKey != null
+            ? getArchetypeDisplayNameForLeader(subj!.leaderKey!)
+            : null);
     return DossierBasicIntel(
       relationLevel: rel?.level,
       relationState: rel?.state,
@@ -136,7 +141,8 @@ DossierBasicIntel? _buildBasicIntel(Game game, String observerId, String subject
   final militarySubj = subj.militaryLevel ?? 0;
   final economicObs = obs.treasury;
   final economicSubj = subj.treasury;
-  final archetype = getArchetypeDisplayNameForLeader(subjectId) ??
+  final archetype =
+      getArchetypeDisplayNameForLeader(subjectId) ??
       getArchetypeDisplayNameForLeader(subj.leaderKey ?? '');
   return DossierBasicIntel(
     relationLevel: rel?.level,
@@ -173,8 +179,12 @@ List<String> _buildBehavioralNotes(List<DossierEvidenceEntry> entries) {
     byDesc[key] = (byDesc[key] ?? 0) + 1;
   }
   final notes = <String>[];
-  if ((byDesc['declared war on weaker neighbor'] ?? 0) + (byDesc['declared war on ally'] ?? 0) > 0) {
-    final n = (byDesc['declared war on weaker neighbor'] ?? 0) + (byDesc['declared war on ally'] ?? 0);
+  if ((byDesc['declared war on weaker neighbor'] ?? 0) +
+          (byDesc['declared war on ally'] ?? 0) >
+      0) {
+    final n =
+        (byDesc['declared war on weaker neighbor'] ?? 0) +
+        (byDesc['declared war on ally'] ?? 0);
     notes.add('Declared war ($n).');
   }
   if ((byDesc['offered peace'] ?? 0) > 0) {
@@ -199,7 +209,8 @@ DossierView getDossierForSubject(
       : entries;
   final scoreByAgenda = <String, int>{};
   for (final e in cappedEntries) {
-    scoreByAgenda[e.agendaType] = (scoreByAgenda[e.agendaType] ?? 0) + e.scoreDelta;
+    scoreByAgenda[e.agendaType] =
+        (scoreByAgenda[e.agendaType] ?? 0) + e.scoreDelta;
   }
   final suspicionByAgendaType = <String, SuspicionBand>{};
   for (final e in scoreByAgenda.entries) {
@@ -215,8 +226,8 @@ DossierView getDossierForSubject(
   final bestGuess = _buildBestGuessAgenda(scoreByAgenda);
   final behavioralNotes = _buildBehavioralNotes(cappedEntries);
 
-  Logger().d(
-    '$_kDossierLogPrefix: getDossierForSubject observerId=$observerId subjectId=$subjectId '
+  _log.d(
+    'getDossierForSubject observerId=$observerId subjectId=$subjectId '
     'scoreByAgenda=$scoreByAgenda suspicionByAgendaType=${suspicionByAgendaType.map((k, v) => MapEntry(k, v.name))} '
     'bestGuessAgenda=${bestGuess?.agendaType} confidencePercent=${bestGuess?.confidencePercent} '
     'evidenceCount=${evidenceList.length} behavioralNotes=$behavioralNotes '

--- a/packages/colonizethis_ai/lib/src/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/economy_planner.dart
@@ -1,23 +1,19 @@
 // Economy planner: worker allocation and cargo preference. SPEC/ai/economy-planner.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import 'ai_config.dart';
 import 'seed_bundle.dart';
 
-final Logger _log = Logger();
+final _log = aiLogger();
 
 const String _kEconomyLogPrefix = 'ai/economy_planner';
 
 /// Cargo preference for naval/build planners. SPEC/ai/economy-planner.md.
-enum CargoPreference {
-  none,
-  preferCargo,
-  strongCargo,
-}
+enum CargoPreference { none, preferCargo, strongCargo }
 
 /// Result of the economy planner for one AI player.
 class EconomyPlan {
@@ -102,20 +98,22 @@ CargoPreference _cargoPreference(Game game, String playerId, AIConfig config) {
   // Trade-oriented agendas/personalities favour cargo.
   final economyWeight = domainWeights.economy;
   if (economyWeight < 30) {
-    _log.d('$_kEconomyLogPrefix: cargoPreference none economyWeight=$economyWeight');
+    _log.d(
+      '$_kEconomyLogPrefix: cargoPreference none economyWeight=$economyWeight',
+    );
     return CargoPreference.none;
   }
   // Strong when economy is high and agenda is trade-related.
   final tradeBias = agendaId == 'industrial_trader' || agendaId == 'merchant'
       ? 20
       : agendaId == 'navigator'
-          ? 15
-          : 0;
+      ? 15
+      : 0;
   final pref = economyWeight >= 70 + tradeBias
       ? CargoPreference.strongCargo
       : economyWeight >= 50 + tradeBias
-          ? CargoPreference.preferCargo
-          : CargoPreference.none;
+      ? CargoPreference.preferCargo
+      : CargoPreference.none;
   _log.d(
     '$_kEconomyLogPrefix: cargoPreference eval playerId=$playerId '
     'economyWeight=$economyWeight agendaId=$agendaId tradeBias=$tradeBias result=$pref',
@@ -205,11 +203,16 @@ List<AssignedRecipe> _allocateLabour({
     for (final entry in recipe.inputQuantities.entries) {
       virtual = virtual.applyDelta(entry.key, -entry.value * runs);
     }
-    virtual = virtual.applyDelta(recipe.outputCommodityId, recipe.outputQuantity * runs);
+    virtual = virtual.applyDelta(
+      recipe.outputCommodityId,
+      recipe.outputQuantity * runs,
+    );
   }
 
   for (final entry in labourByRecipe.entries) {
-    result.add(AssignedRecipe(recipeId: entry.key, assignedLabour: entry.value));
+    result.add(
+      AssignedRecipe(recipeId: entry.key, assignedLabour: entry.value),
+    );
   }
 
   _log.d(
@@ -271,5 +274,7 @@ double _scoreRecipe({
     agenda = 0.5;
   }
 
-  return shortage * _kShortageWeight + chain * _kChainWeight + agenda * _kAgendaWeight;
+  return shortage * _kShortageWeight +
+      chain * _kChainWeight +
+      agenda * _kAgendaWeight;
 }

--- a/packages/colonizethis_ai/lib/src/goal_manager.dart
+++ b/packages/colonizethis_ai/lib/src/goal_manager.dart
@@ -1,25 +1,18 @@
 import 'dart:math' as math;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:logger/logger.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 import 'ai_config.dart';
 import 'hidden_agenda.dart';
 import 'perception.dart';
 
+final _log = aiLogger();
+
 // Goal selection (behavior tree). SPEC/ai/ai-architecture.md, ai-personalities.md.
 
-const String _kGoalLogPrefix = 'ai/goal_manager';
-
 /// Top-level strategy goals for the AI.
-enum StrategicGoal {
-  defend,
-  expand,
-  conquer,
-  trade,
-  tech,
-  diplomacy,
-}
+enum StrategicGoal { defend, expand, conquer, trade, tech, diplomacy }
 
 /// Selects primary strategic goal from snapshot, personality, and agenda modifiers.
 /// Deterministic given [snapshot], [config], and [goalSeed].
@@ -43,7 +36,8 @@ StrategicGoal selectPrimaryGoal(
   diplomacy += agendaDiplomacyModifier(config.hiddenAgendaId);
   // Personality thresholds: war likelihood boosts conquer; peace/alliance boost diplomacy goal.
   conquer += (thresholds.warLikelihood - 50);
-  diplomacy += ((thresholds.peaceTendency + thresholds.allianceTendency) ~/ 2) - 50;
+  diplomacy +=
+      ((thresholds.peaceTendency + thresholds.allianceTendency) ~/ 2) - 50;
 
   if (snapshot.threats.atWarWith.isNotEmpty) {
     defend += 30;
@@ -67,8 +61,8 @@ StrategicGoal selectPrimaryGoal(
     StrategicGoal.diplomacy: diplomacy,
   };
 
-  Logger().d(
-    '$_kGoalLogPrefix: eval leaderId=${config.leaderId} hiddenAgendaId=${config.hiddenAgendaId} goalSeed=$goalSeed '
+  _log.d(
+    'eval leaderId=${config.leaderId} hiddenAgendaId=${config.hiddenAgendaId} goalSeed=$goalSeed '
     'weights defend=$defend expand=$expand conquer=$conquer trade=$trade tech=$tech diplomacy=$diplomacy',
   );
 
@@ -84,6 +78,6 @@ StrategicGoal selectPrimaryGoal(
       break;
     }
   }
-  Logger().i('$_kGoalLogPrefix: selected primaryGoal=$selected');
+  _log.i('selected primaryGoal=$selected');
   return selected;
 }

--- a/packages/colonizethis_ai/lib/src/perception.dart
+++ b/packages/colonizethis_ai/lib/src/perception.dart
@@ -1,7 +1,9 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
-import 'package:logger/logger.dart';
+
+final _log = aiLogger();
 
 // Perception: PlayerView → AIWorldSnapshot. SPEC/ai/ai-architecture.md.
 // All data derived from PlayerView only; no hidden state.
@@ -67,7 +69,10 @@ class AIWorldSnapshot {
   /// Builds snapshot from [view]. When [topology] is provided, computes
   /// neighborProvincesHostile, capitalThreatened, weakNeighbors, and
   /// richUnexploitedProvinces from view + topology. Deterministic: same view → same snapshot.
-  static AIWorldSnapshot fromPlayerView(PlayerView view, {MapTopology? topology}) {
+  static AIWorldSnapshot fromPlayerView(
+    PlayerView view, {
+    MapTopology? topology,
+  }) {
     final threats = _buildThreatSummary(view, topology);
     final opportunities = _buildOpportunitySummary(view, topology);
     final economy = _buildEconomySummary(view);
@@ -78,8 +83,8 @@ class AIWorldSnapshot {
       economy: economy,
       relations: Map<String, DiplomacyRelation>.from(view.diplomacyByOtherId),
     );
-    Logger().d(
-      'ai/perception: snapshot playerId=${snapshot.playerId} '
+    _log.d(
+      'snapshot playerId=${snapshot.playerId} '
       'atWarWith=${snapshot.threats.atWarWith} '
       'neighborProvincesHostile=${snapshot.threats.neighborProvincesHostile} '
       'capitalThreatened=${snapshot.threats.capitalThreatened} '
@@ -94,7 +99,10 @@ class AIWorldSnapshot {
     return snapshot;
   }
 
-  static ThreatSummary _buildThreatSummary(PlayerView view, MapTopology? topology) {
+  static ThreatSummary _buildThreatSummary(
+    PlayerView view,
+    MapTopology? topology,
+  ) {
     final atWarWith = <String>[];
     for (final e in view.diplomacyByOtherId.entries) {
       final rel = e.value;
@@ -110,12 +118,17 @@ class AIWorldSnapshot {
       if (p.value.ownerId == view.playerId) ownedIds.add(p.key);
     }
     int neighborProvincesHostile = 0;
-    final neighborProvinceIds = _neighborProvinceIdsFromTopology(topology, ownedIds, view);
+    final neighborProvinceIds = _neighborProvinceIdsFromTopology(
+      topology,
+      ownedIds,
+      view,
+    );
     for (final neighborFullId in neighborProvinceIds) {
       final prov = view.provincesById[neighborFullId];
       if (prov == null) continue;
       final ownerId = prov.ownerId;
-      if (ownerId == null || ownerId.isEmpty || ownerId == view.playerId) continue;
+      if (ownerId == null || ownerId.isEmpty || ownerId == view.playerId)
+        continue;
       final rel = view.diplomacyByOtherId[ownerId];
       if (rel != null && rel.state == RelationState.atWar) {
         neighborProvincesHostile++;
@@ -123,17 +136,18 @@ class AIWorldSnapshot {
     }
     bool capitalThreatened = false;
     final capitalId = view.player.capitalProvinceId;
-    if (capitalId != null && capitalId.isNotEmpty && ownedIds.contains(capitalId)) {
-      final capitalNeighbors = _neighborProvinceIdsFromTopology(
-        topology,
-        {capitalId},
-        view,
-      );
+    if (capitalId != null &&
+        capitalId.isNotEmpty &&
+        ownedIds.contains(capitalId)) {
+      final capitalNeighbors = _neighborProvinceIdsFromTopology(topology, {
+        capitalId,
+      }, view);
       for (final neighborFullId in capitalNeighbors) {
         final prov = view.provincesById[neighborFullId];
         if (prov == null) continue;
         final ownerId = prov.ownerId;
-        if (ownerId == null || ownerId.isEmpty || ownerId == view.playerId) continue;
+        if (ownerId == null || ownerId.isEmpty || ownerId == view.playerId)
+          continue;
         final rel = view.diplomacyByOtherId[ownerId];
         if (rel != null && rel.state == RelationState.atWar) {
           capitalThreatened = true;
@@ -173,16 +187,24 @@ class AIWorldSnapshot {
             break;
           }
         }
-        if (neighborNode == null || neighborNode.type != TopologyNodeType.province) continue;
+        if (neighborNode == null ||
+            neighborNode.type != TopologyNodeType.province)
+          continue;
         if (neighborNode.regionId != regionId) continue;
-        final neighborFullId = ProvinceId.full(neighborNode.regionId, neighborNode.id);
+        final neighborFullId = ProvinceId.full(
+          neighborNode.regionId,
+          neighborNode.id,
+        );
         if (!ownedFullIds.contains(neighborFullId)) out.add(neighborFullId);
       }
     }
     return out;
   }
 
-  static OpportunitySummary _buildOpportunitySummary(PlayerView view, MapTopology? topology) {
+  static OpportunitySummary _buildOpportunitySummary(
+    PlayerView view,
+    MapTopology? topology,
+  ) {
     int unclaimed = 0;
     int richUnexploited = 0;
     for (final p in view.provincesById.values) {
@@ -199,7 +221,11 @@ class AIWorldSnapshot {
       for (final p in view.provincesById.entries) {
         if (p.value.ownerId == view.playerId) ownedIds.add(p.key);
       }
-      final neighborIds = _neighborProvinceIdsFromTopology(topology, ownedIds, view);
+      final neighborIds = _neighborProvinceIdsFromTopology(
+        topology,
+        ownedIds,
+        view,
+      );
       for (final fid in neighborIds) {
         final prov = view.provincesById[fid];
         if (prov == null) continue;

--- a/packages/colonizethis_ai/lib/src/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/strategic_ai.dart
@@ -1,7 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
-import 'package:logger/logger.dart';
 
 import 'ai_config.dart';
 import 'domain_planners.dart';
@@ -11,12 +11,11 @@ import 'mood_state_machine.dart';
 import 'perception.dart';
 import 'seed_bundle.dart';
 
+final _log = aiLogger();
+
 /// Result of strategic order generation: orders and economy plan. SPEC/ai/economy-planner.md.
 class StrategicOrderResult {
-  const StrategicOrderResult({
-    required this.orders,
-    required this.economyPlan,
-  });
+  const StrategicOrderResult({required this.orders, required this.economyPlan});
   final Orders orders;
   final EconomyPlan economyPlan;
 }
@@ -37,10 +36,10 @@ StrategicOrderResult generateStrategicOrders({
   void Function(PortraitMoodEvent)? onMood,
 }) {
   final turn = game.worldState.turnState.turnNumber;
-  Logger().i('ai/strategic_ai: generateStrategicOrders nationId=$nationId turn=$turn');
+  _log.i('generateStrategicOrders nationId=$nationId turn=$turn');
   final snapshot = AIWorldSnapshot.fromPlayerView(view, topology: topology);
   final primaryGoal = selectPrimaryGoal(snapshot, config, seeds.goalSeed);
-  Logger().d('ai/strategic_ai: primaryGoal=$primaryGoal');
+  _log.d('primaryGoal=$primaryGoal');
   final economyPlan = runEconomyPlanner(
     game: game,
     view: view,
@@ -63,7 +62,9 @@ StrategicOrderResult generateStrategicOrders({
   final buildCount = orders.buildUnitOrdersByPlayerId[nationId]?.length ?? 0;
   final workCount = orders.workOrdersByPlayerId[nationId]?.length ?? 0;
   final researchCount = orders.researchOrdersByPlayerId[nationId]?.length ?? 0;
-  Logger().i('ai/strategic_ai: generated orders nationId=$nationId move=$moveCount build=$buildCount work=$workCount research=$researchCount');
+  _log.i(
+    'generated orders nationId=$nationId move=$moveCount build=$buildCount work=$workCount research=$researchCount',
+  );
   _emitDialogueAndMood(
     config: config,
     seeds: seeds,
@@ -86,21 +87,25 @@ void _emitDialogueAndMood({
   // `dialogueSeed % kDialogueTurnsBetweenComments == 0`.
   if (onDialogue != null &&
       seeds.dialogueSeed % kDialogueTurnsBetweenComments == 0) {
-    onDialogue(DialogueEvent(
-      leaderId: config.leaderId,
-      category: 'agenda',
-      situation: 'comment',
-      era: 'earlyModern',
-      variables: const {},
-    ));
+    onDialogue(
+      DialogueEvent(
+        leaderId: config.leaderId,
+        category: 'agenda',
+        situation: 'comment',
+        era: 'earlyModern',
+        variables: const {},
+      ),
+    );
   }
   if (onMood != null &&
       seeds.dialogueSeed % kDialogueTurnsBetweenComments == 0) {
-    onMood(PortraitMoodEvent(
-      leaderId: config.leaderId,
-      fromMood: kDefaultMood,
-      toMood: kDefaultMood,
-      durationMs: 0,
-    ));
+    onMood(
+      PortraitMoodEvent(
+        leaderId: config.leaderId,
+        fromMood: kDefaultMood,
+        toMood: kDefaultMood,
+        durationMs: 0,
+      ),
+    );
   }
 }

--- a/packages/colonizethis_ai/pubspec.yaml
+++ b/packages/colonizethis_ai/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   logger: ^2.0.2
+  colonizethis_logger:
   colonizethis_data:
   colonizethis_logic:
   colonizethis_models:

--- a/packages/colonizethis_data/lib/src/game_setup_config.dart
+++ b/packages/colonizethis_data/lib/src/game_setup_config.dart
@@ -1,8 +1,8 @@
-import 'package:logger/logger.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 import 'starting_resources_config.dart';
 
-final Logger _log = Logger();
+final _log = dataLogger();
 
 /// Game setup parameters. SPEC/game/game-setup.md, SPEC/game/ruleset-config.md.
 /// Program-level config only (no JSON in MVP).
@@ -18,13 +18,18 @@ class GameSetupConfig {
     this.minProvincesPerMinor = 3,
     this.seed = 42,
     this.startingResources = const StartingResourcesConfig(),
-  })  : assert(selectedGreatPowerIds.isNotEmpty, 'At least one Great Power required'),
-        assert(continentCount >= 1),
-        assert(minorNationCount >= 0),
-        assert(tribeCount >= 0),
-        assert(minProvincesPerMinor >= 0),
-        assert(numProvincesNewWorld >= 1) {
-    _log.d('data: GameSetupConfig created OW=$numProvincesOldWorld NW=$numProvincesNewWorld');
+  }) : assert(
+         selectedGreatPowerIds.isNotEmpty,
+         'At least one Great Power required',
+       ),
+       assert(continentCount >= 1),
+       assert(minorNationCount >= 0),
+       assert(tribeCount >= 0),
+       assert(minProvincesPerMinor >= 0),
+       assert(numProvincesNewWorld >= 1) {
+    _log.d(
+      'data: GameSetupConfig created OW=$numProvincesOldWorld NW=$numProvincesNewWorld',
+    );
   }
 
   static const List<String> _defaultSelectedGreatPowerIds = [
@@ -50,6 +55,7 @@ class GameSetupConfig {
   final int tribeCount;
   final int numProvincesOldWorld;
   final int numProvincesNewWorld;
+
   /// Minimum provinces the ruleset attempts to reserve per Minor Nation on the Old World map.
   final int minProvincesPerMinor;
   final int seed;

--- a/packages/colonizethis_data/pubspec.yaml
+++ b/packages/colonizethis_data/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   logger: ^2.0.2
+  colonizethis_logger:
   colonizethis_models:
 
 dev_dependencies:

--- a/packages/colonizethis_logger/lib/colonizethis_logger.dart
+++ b/packages/colonizethis_logger/lib/colonizethis_logger.dart
@@ -1,0 +1,4 @@
+library colonizethis_logger;
+
+export 'src/ct_logger.dart';
+export 'src/prefixes.dart';

--- a/packages/colonizethis_logger/lib/src/ct_logger.dart
+++ b/packages/colonizethis_logger/lib/src/ct_logger.dart
@@ -1,0 +1,62 @@
+import 'package:logger/logger.dart';
+
+class CtLogger {
+  final Logger _log;
+  final String prefix;
+
+  CtLogger(this.prefix) : _log = Logger();
+
+  void d(String msg, {Object? error, StackTrace? stackTrace}) =>
+      _log.d('$prefix: $msg', error: error, stackTrace: stackTrace);
+  void i(String msg, {Object? error, StackTrace? stackTrace}) =>
+      _log.i('$prefix: $msg', error: error, stackTrace: stackTrace);
+  void w(String msg, {Object? error, StackTrace? stackTrace}) =>
+      _log.w('$prefix: $msg', error: error, stackTrace: stackTrace);
+  void e(String msg, {Object? error, StackTrace? stackTrace}) =>
+      _log.e('$prefix: $msg', error: error, stackTrace: stackTrace);
+  void t(String msg, {Object? error, StackTrace? stackTrace}) =>
+      _log.t('$prefix: $msg', error: error, stackTrace: stackTrace);
+  void f(String msg, {Object? error, StackTrace? stackTrace}) =>
+      _log.f('$prefix: $msg', error: error, stackTrace: stackTrace);
+  void log(Level level, String msg, {Object? error, StackTrace? stackTrace}) =>
+      _log.log(level, '$prefix: $msg', error: error, stackTrace: stackTrace);
+  void trace(String msg, {Object? error, StackTrace? stackTrace}) =>
+      _log.t('$prefix: $msg', error: error, stackTrace: stackTrace);
+  void debug(String msg, {Object? error, StackTrace? stackTrace}) =>
+      _log.d('$prefix: $msg', error: error, stackTrace: stackTrace);
+  void info(String msg, {Object? error, StackTrace? stackTrace}) =>
+      _log.i('$prefix: $msg', error: error, stackTrace: stackTrace);
+  void warning(String msg, {Object? error, StackTrace? stackTrace}) =>
+      _log.w('$prefix: $msg', error: error, stackTrace: stackTrace);
+  void error(String msg, {Object? error, StackTrace? stackTrace}) =>
+      _log.e('$prefix: $msg', error: error, stackTrace: stackTrace);
+  void fatal(String msg, {Object? error, StackTrace? stackTrace}) =>
+      _log.f('$prefix: $msg', error: error, stackTrace: stackTrace);
+
+  static Level get level => Logger.level;
+  static set level(Level value) => Logger.level = value;
+}
+
+CtLogger logicLogger([String? subPrefix]) =>
+    subPrefix != null ? CtLogger('logic.$subPrefix') : CtLogger('logic');
+
+CtLogger aiLogger([String? subPrefix]) =>
+    subPrefix != null ? CtLogger('ai.$subPrefix') : CtLogger('ai');
+
+CtLogger dataLogger([String? subPrefix]) =>
+    subPrefix != null ? CtLogger('data.$subPrefix') : CtLogger('data');
+
+CtLogger mapLogger([String? subPrefix]) =>
+    subPrefix != null ? CtLogger('map.$subPrefix') : CtLogger('map');
+
+CtLogger saveLogger([String? subPrefix]) =>
+    subPrefix != null ? CtLogger('save.$subPrefix') : CtLogger('save');
+
+CtLogger tuiLogger([String? subPrefix]) =>
+    subPrefix != null ? CtLogger('tui.$subPrefix') : CtLogger('tui');
+
+CtLogger gameLogger([String? subPrefix]) =>
+    subPrefix != null ? CtLogger('game.$subPrefix') : CtLogger('game');
+
+CtLogger appLogger([String? subPrefix]) =>
+    subPrefix != null ? CtLogger('app.$subPrefix') : CtLogger('app');

--- a/packages/colonizethis_logger/lib/src/prefixes.dart
+++ b/packages/colonizethis_logger/lib/src/prefixes.dart
@@ -1,0 +1,19 @@
+const String kLogPrefixLogic = 'logic';
+const String kLogPrefixAi = 'ai';
+const String kLogPrefixData = 'data';
+const String kLogPrefixMap = 'map';
+const String kLogPrefixSave = 'save';
+const String kLogPrefixTui = 'tui';
+const String kLogPrefixGame = 'game';
+const String kLogPrefixApp = 'app';
+
+const List<String> allLogPrefixes = [
+  kLogPrefixLogic,
+  kLogPrefixAi,
+  kLogPrefixData,
+  kLogPrefixMap,
+  kLogPrefixSave,
+  kLogPrefixTui,
+  kLogPrefixGame,
+  kLogPrefixApp,
+];

--- a/packages/colonizethis_logger/pubspec.yaml
+++ b/packages/colonizethis_logger/pubspec.yaml
@@ -1,5 +1,5 @@
-name: colonizethis_save
-description: Save format, schema, migrations for Colonize This.
+name: colonizethis_logger
+description: Prefixed logger utility for consistent log categorization in the debug log viewer.
 version: 0.0.1
 publish_to: none
 repository: https://github.com/colonizethisv3/colonizethisv3
@@ -10,10 +10,6 @@ environment:
 
 dependencies:
   logger: ^2.0.2
-  colonizethis_logger:
-  colonizethis_data:
-  colonizethis_models:
-  hive: ^2.2.3
 
 dev_dependencies:
   colonizethis_test:

--- a/packages/colonizethis_logger/test/ct_logger_test.dart
+++ b/packages/colonizethis_logger/test/ct_logger_test.dart
@@ -1,0 +1,128 @@
+import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:logger/logger.dart';
+
+void main() {
+  group('CtLogger', () {
+    late List<LogEvent> capturedEvents;
+    late void Function(LogEvent) listener;
+
+    setUp(() {
+      capturedEvents = [];
+      listener = (e) => capturedEvents.add(e);
+      Logger.addLogListener(listener);
+      Logger.level = Level.debug;
+    });
+
+    tearDown(() {
+      Logger.removeLogListener(listener);
+      capturedEvents.clear();
+      Logger.level = Level.info;
+    });
+
+    test('prefixes message with info level', () {
+      final log = CtLogger('logic');
+      log.i('test message');
+
+      expect(capturedEvents.length, 1);
+      expect(capturedEvents[0].message, 'logic: test message');
+      expect(capturedEvents[0].level, Level.info);
+    });
+
+    test('prefixes message with debug level', () {
+      final log = CtLogger('ai');
+      log.d('decision made');
+
+      expect(capturedEvents.length, 1);
+      expect(capturedEvents[0].message, 'ai: decision made');
+      expect(capturedEvents[0].level, Level.debug);
+    });
+
+    test('prefixes message with warning level', () {
+      final log = CtLogger('map');
+      log.w('missing tile');
+
+      expect(capturedEvents.length, 1);
+      expect(capturedEvents[0].message, 'map: missing tile');
+      expect(capturedEvents[0].level, Level.warning);
+    });
+
+    test('prefixes message with error level', () {
+      final log = CtLogger('save');
+      log.e('failed to save');
+
+      expect(capturedEvents.length, 1);
+      expect(capturedEvents[0].message, 'save: failed to save');
+      expect(capturedEvents[0].level, Level.error);
+    });
+
+    test('handles error and stackTrace parameters', () {
+      final log = CtLogger('logic');
+      final error = Exception('test error');
+      final stackTrace = StackTrace.current;
+      log.e('operation failed', error: error, stackTrace: stackTrace);
+
+      expect(capturedEvents.length, 1);
+      expect(capturedEvents[0].message, 'logic: operation failed');
+      expect(capturedEvents[0].error, error);
+      expect(capturedEvents[0].stackTrace, stackTrace);
+    });
+
+    test('warning with error and stackTrace', () {
+      final log = CtLogger('game');
+      final error = Exception('test warning');
+      final stackTrace = StackTrace.current;
+      log.w('operation warning', error: error, stackTrace: stackTrace);
+
+      expect(capturedEvents.length, 1);
+      expect(capturedEvents[0].message, 'game: operation warning');
+      expect(capturedEvents[0].level, Level.warning);
+      expect(capturedEvents[0].error, error);
+      expect(capturedEvents[0].stackTrace, stackTrace);
+    });
+
+    test('factory functions create loggers with correct prefixes', () {
+      expect(logicLogger().prefix, 'logic');
+      expect(aiLogger().prefix, 'ai');
+      expect(dataLogger().prefix, 'data');
+      expect(mapLogger().prefix, 'map');
+      expect(saveLogger().prefix, 'save');
+      expect(tuiLogger().prefix, 'tui');
+      expect(gameLogger().prefix, 'game');
+      expect(appLogger().prefix, 'app');
+    });
+
+    test(
+      'factory functions with subPrefix create loggers with compound prefixes',
+      () {
+        expect(logicLogger('turn').prefix, 'logic.turn');
+        expect(aiLogger('planner').prefix, 'ai.planner');
+        expect(mapLogger('tileset').prefix, 'map.tileset');
+      },
+    );
+  });
+
+  group('prefixes', () {
+    test('allLogPrefixes contains expected prefixes', () {
+      expect(allLogPrefixes, contains('logic'));
+      expect(allLogPrefixes, contains('ai'));
+      expect(allLogPrefixes, contains('data'));
+      expect(allLogPrefixes, contains('map'));
+      expect(allLogPrefixes, contains('save'));
+      expect(allLogPrefixes, contains('tui'));
+      expect(allLogPrefixes, contains('game'));
+      expect(allLogPrefixes, contains('app'));
+    });
+
+    test('kLogPrefix constants have correct values', () {
+      expect(kLogPrefixLogic, 'logic');
+      expect(kLogPrefixAi, 'ai');
+      expect(kLogPrefixData, 'data');
+      expect(kLogPrefixMap, 'map');
+      expect(kLogPrefixSave, 'save');
+      expect(kLogPrefixTui, 'tui');
+      expect(kLogPrefixGame, 'game');
+      expect(kLogPrefixApp, 'app');
+    });
+  });
+}

--- a/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
+++ b/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
@@ -4,13 +4,15 @@
 import 'dart:math' as math;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import '../constants.dart';
 import '../diplomacy/diplomacy_resolver.dart';
 import '../orders/order_suggestion.dart';
 import '../world/player_view.dart';
+
+final _log = logicLogger();
 
 /// Derives turn seed per ai-planner: turnSeed = hash(globalGameSeed, aiSeed[P], T).
 /// When [fallbackAiSeed] is provided and [game.aiSeedByGpId] has no entry for
@@ -22,21 +24,15 @@ int turnSeedForPlayer(
   int? fallbackAiSeed,
 }) {
   final global = game.globalGameSeed ?? 0;
-  final aiSeed = game.aiSeedByGpId[playerId] ??
-      fallbackAiSeed ??
-      playerId.hashCode;
+  final aiSeed =
+      game.aiSeedByGpId[playerId] ?? fallbackAiSeed ?? playerId.hashCode;
   const int prime = 0x9E3779B1;
   var h = global ^ (turnNumber * prime);
   h ^= aiSeed * prime;
   return h & 0x7fffffff;
 }
 
-enum _SuggestionCategory {
-  moves,
-  work,
-  build,
-  research,
-}
+enum _SuggestionCategory { moves, work, build, research }
 
 /// Generates orders for a single player using the shared simple heuristics:
 /// PlayerView, order suggestion API, category order (move → work → build →
@@ -64,8 +60,12 @@ Orders generateOrdersWithSimpleHeuristics(
     final moveSuggestions = suggestMoveOrders(view, game, topology, current);
     final workSuggestions = suggestWorkOrders(view, game, topology, current);
     final buildSuggestions = suggestBuildOrders(view, game, topology, current);
-    final researchSuggestions =
-        suggestResearchOrders(view, game, topology, current);
+    final researchSuggestions = suggestResearchOrders(
+      view,
+      game,
+      topology,
+      current,
+    );
 
     final categories = <_SuggestionCategory>[];
     if (moveSuggestions.isNotEmpty) {
@@ -172,23 +172,28 @@ Orders generateOrdersWithSimpleHeuristics(
     }
   }
   if (current.buildUnitOrdersByPlayerId.containsKey(player.id)) {
-    buildByPlayer[player.id] =
-        List<BuildUnitOrder>.from(current.buildUnitOrdersByPlayerId[player.id]!);
+    buildByPlayer[player.id] = List<BuildUnitOrder>.from(
+      current.buildUnitOrdersByPlayerId[player.id]!,
+    );
   }
   if (current.workOrdersByPlayerId.containsKey(player.id)) {
-    workByPlayer[player.id] =
-        List<WorkOrder>.from(current.workOrdersByPlayerId[player.id]!);
+    workByPlayer[player.id] = List<WorkOrder>.from(
+      current.workOrdersByPlayerId[player.id]!,
+    );
   }
   if (current.researchOrdersByPlayerId.containsKey(player.id)) {
-    researchByPlayer[player.id] =
-        List<ResearchOrder>.from(current.researchOrdersByPlayerId[player.id]!);
+    researchByPlayer[player.id] = List<ResearchOrder>.from(
+      current.researchOrdersByPlayerId[player.id]!,
+    );
   }
 
   final m = moveByPlayer[player.id]?.length ?? 0;
   final b = buildByPlayer[player.id]?.length ?? 0;
   final w = workByPlayer[player.id]?.length ?? 0;
   final r = researchByPlayer[player.id]?.length ?? 0;
-  Logger().i('ai: simple heuristics generated orders player=${player.id} move=$m build=$b work=$w research=$r');
+  _log.i(
+    'simple heuristics generated orders player=${player.id} move=$m build=$b work=$w research=$r',
+  );
 
   return Orders(
     moveOrdersByPlayerId: moveByPlayer,

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -2,8 +2,8 @@
 /// Steps: overture payments (two-way accept/reject), advance overtures,
 /// Join Empire/Colony, alliance proposals, Declare War/Peace, relation modifiers, score update.
 
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import '../constants.dart';
 import '../combat/conflict_detection.dart';
@@ -15,7 +15,7 @@ import 'diplomacy_relation_updates.dart';
 
 export 'diplomacy_relation_lookup.dart';
 
-final Logger _diploLog = Logger();
+final _diploLog = logicLogger();
 
 /// Appends one diplomatic history event. intraTurnIndex = count of events already in this turn.
 Game _appendDiplomaticEvent(
@@ -44,9 +44,7 @@ Game _appendDiplomaticEvent(
     reason: reason,
     wasAiInitiator: wasAiInitiator,
   );
-  return game.copyWith(
-    diplomaticHistoryEvents: [...events, event],
-  );
+  return game.copyWith(diplomaticHistoryEvents: [...events, event]);
 }
 
 bool isMinorOrTribe(Game game, String factionId) {
@@ -110,7 +108,9 @@ DiplomacyPhaseResult resolveDiplomacyPhase(
   state = overtureResult.game;
   if (overtureResult.pendingOvertures != null &&
       overtureResult.pendingOvertures!.isNotEmpty) {
-    _diploLog.d('logic: diplomacy phase suspended (pending overture decisions)');
+    _diploLog.d(
+      'logic: diplomacy phase suspended (pending overture decisions)',
+    );
     return DiplomacyPhaseResult(state, overtureResult.pendingOvertures);
   }
 
@@ -124,8 +124,12 @@ DiplomacyPhaseResult resolveDiplomacyPhase(
   state = _processAlliances(state, diploByPlayer, turn);
 
   // 5. Process Declare War and Peace
-  state =
-      _processWarAndPeace(state, diploByPlayer, turn, onDialogue: onDialogue);
+  state = _processWarAndPeace(
+    state,
+    diploByPlayer,
+    turn,
+    onDialogue: onDialogue,
+  );
 
   // 6. War terminates agreements with target
   state = _terminateAgreementsOnWar(state);
@@ -205,7 +209,7 @@ _OverturePaymentsResult _processOverturePayments(
       final prevStage = _previousStage(stage);
       final atPrevStage =
           (existing == null && prevStage == OvertureStage.none) ||
-              (existing != null && existing.stage == prevStage);
+          (existing != null && existing.stage == prevStage);
       if (!atPrevStage) continue;
 
       int cost;
@@ -227,12 +231,23 @@ _OverturePaymentsResult _processOverturePayments(
         accepted = _minorOrTribeAcceptsByRule(stage);
       } else {
         // Target is GP.
-        final decision = _findDecision(overtureDecisions, gpId, targetId, stage);
+        final decision = _findDecision(
+          overtureDecisions,
+          gpId,
+          targetId,
+          stage,
+        );
         if (decision != null) {
           accepted = decision.accepted;
         } else if (_isTargetHumanGp(state, targetId)) {
           // Suspend: need human response.
-          final pending = [OvertureOffer(offererGpId: gpId, targetFactionId: targetId, stage: stage)];
+          final pending = [
+            OvertureOffer(
+              offererGpId: gpId,
+              targetFactionId: targetId,
+              stage: stage,
+            ),
+          ];
           state = state.copyWith(players: players, overtureStates: overtures);
           return _OverturePaymentsResult(state, pending);
         } else {
@@ -261,17 +276,24 @@ _OverturePaymentsResult _processOverturePayments(
         players[playerIdx] = player;
       }
 
-      final osIdx =
-          overtures.indexWhere((o) => o.gpId == gpId && o.targetId == targetId);
+      final osIdx = overtures.indexWhere(
+        (o) => o.gpId == gpId && o.targetId == targetId,
+      );
       if (osIdx >= 0) {
         overtures = List<OvertureState>.from(overtures);
-        overtures[osIdx] =
-            overtures[osIdx].copyWith(stage: stage, sinceTurn: turn);
+        overtures[osIdx] = overtures[osIdx].copyWith(
+          stage: stage,
+          sinceTurn: turn,
+        );
       } else {
         overtures = [
           ...overtures,
           OvertureState(
-              gpId: gpId, targetId: targetId, stage: stage, sinceTurn: turn)
+            gpId: gpId,
+            targetId: targetId,
+            stage: stage,
+            sinceTurn: turn,
+          ),
         ];
       }
       state = state.copyWith(players: players, overtureStates: overtures);
@@ -285,7 +307,9 @@ _OverturePaymentsResult _processOverturePayments(
         overtureStage: stage,
         wasAiInitiator: isAiControlledForEvidence(state, gpId),
       );
-      _diploLog.i('logic: diplomacy overture $gpId -> $targetId $stage (accepted)');
+      _diploLog.i(
+        'logic: diplomacy overture $gpId -> $targetId $stage (accepted)',
+      );
     }
   }
 
@@ -338,7 +362,8 @@ Game _resolveJoinEmpireColony(
 
       final rel = getRelation(game, gpId, targetId);
       final score = rel?.score ?? relationScoreNeutral;
-      if (score < relationScoreMinFriendly) continue; // Must be Friendly or Allied
+      if (score < relationScoreMinFriendly)
+        continue; // Must be Friendly or Allied
 
       final cost = joinEmpireCostForMinorOrTribe(game, targetId);
       if (player.treasury < cost) continue;
@@ -363,13 +388,20 @@ Game _resolveJoinEmpireColony(
 }
 
 List<Province> _transferProvinceOwnership(
-    List<Province> provinces, String fromId, String toId) {
+  List<Province> provinces,
+  String fromId,
+  String toId,
+) {
   return provinces
       .map((p) => p.ownerId == fromId ? p.copyWith(ownerId: toId) : p)
       .toList();
 }
 
-List<Unit> _transferUnitOwnership(List<Unit> units, String fromId, String toId) {
+List<Unit> _transferUnitOwnership(
+  List<Unit> units,
+  String fromId,
+  String toId,
+) {
   return units
       .map((u) => u.ownerId == fromId ? u.copyWith(ownerId: toId) : u)
       .toList();
@@ -378,26 +410,45 @@ List<Unit> _transferUnitOwnership(List<Unit> units, String fromId, String toId) 
 /// Transfers all provinces, units, and fleets owned by [targetId] to [gpId],
 /// deducts Join Empire cost from GP treasury, removes the Minor/Tribe and
 /// cleans overtures/relations. SPEC/game/diplomacy.md.
-Game _absorbMinorOrTribeIntoGp(Game game, String gpId, String targetId, int turn) {
+Game _absorbMinorOrTribeIntoGp(
+  Game game,
+  String gpId,
+  String targetId,
+  int turn,
+) {
   final cost = joinEmpireCostForMinorOrTribe(game, targetId);
   var players = List<Player>.from(game.players);
   final gpIdx = players.indexWhere((p) => p.id == gpId);
   if (gpIdx >= 0) {
     players = List<Player>.from(players);
-    players[gpIdx] = players[gpIdx].copyWith(treasury: players[gpIdx].treasury - cost);
+    players[gpIdx] = players[gpIdx].copyWith(
+      treasury: players[gpIdx].treasury - cost,
+    );
   }
 
   // Transfer provinces: ownerId targetId -> gpId
-  final owProvinces =
-      _transferProvinceOwnership(game.worldState.oldWorld.provinces, targetId, gpId);
-  final nwProvinces =
-      _transferProvinceOwnership(game.worldState.newWorld.provinces, targetId, gpId);
+  final owProvinces = _transferProvinceOwnership(
+    game.worldState.oldWorld.provinces,
+    targetId,
+    gpId,
+  );
+  final nwProvinces = _transferProvinceOwnership(
+    game.worldState.newWorld.provinces,
+    targetId,
+    gpId,
+  );
 
   // Transfer units: ownerId targetId -> gpId
-  final owUnits =
-      _transferUnitOwnership(game.worldState.oldWorld.units, targetId, gpId);
-  final nwUnits =
-      _transferUnitOwnership(game.worldState.newWorld.units, targetId, gpId);
+  final owUnits = _transferUnitOwnership(
+    game.worldState.oldWorld.units,
+    targetId,
+    gpId,
+  );
+  final nwUnits = _transferUnitOwnership(
+    game.worldState.newWorld.units,
+    targetId,
+    gpId,
+  );
 
   // Transfer fleets
   final fleets = game.worldState.fleets
@@ -492,7 +543,10 @@ Game _processAlliances(
               )
             : existing.copyWith(
                 level: RelationLevel.allied,
-                score: existing.score.clamp(relationScoreMinAllied, relationScoreMax),
+                score: existing.score.clamp(
+                  relationScoreMinAllied,
+                  relationScoreMax,
+                ),
                 lastInteractionTurn: turn,
               ),
       );
@@ -528,8 +582,7 @@ Game _processWarAndPeace(
     for (final order in entry.value) {
       if (order.type != DiplomaticOrderType.offerPeace) continue;
       final targetId = order.targetFactionId;
-      if (!isGreatPower(game, gpId) || !isGreatPower(game, targetId))
-        continue;
+      if (!isGreatPower(game, gpId) || !isGreatPower(game, targetId)) continue;
       final key = pairKey(gpId, targetId);
       final offerers = peaceOffersByPairKey.putIfAbsent(key, () => <String>{});
       offerers.add(gpId);
@@ -545,13 +598,15 @@ Game _processWarAndPeace(
         final atPeace = rel == null || rel.atPeace;
         if (atPeace) {
           if (onDialogue != null && isAiControlledForEvidence(game, gpId)) {
-            onDialogue(DialogueEvent(
-              leaderId: gpId,
-              category: 'diplomatic',
-              situation: 'declare_war',
-              era: 'earlyModern',
-              variables: {'otherNation': targetId},
-            ));
+            onDialogue(
+              DialogueEvent(
+                leaderId: gpId,
+                category: 'diplomatic',
+                situation: 'declare_war',
+                era: 'earlyModern',
+                variables: {'otherNation': targetId},
+              ),
+            );
           }
           final evidence = evidenceForDeclareWar(game, gpId, targetId, turn);
 
@@ -561,20 +616,27 @@ Game _processWarAndPeace(
             targetId: targetId,
             turn: turn,
           );
-          
+
           // Cancel any active subsidies between these factions
           var subsidyStates = List<SubsidyState>.from(game.subsidyStates);
           final cancelledSubsidies = subsidyStates
-              .where((s) =>
-                  (s.payerId == gpId && s.targetId == targetId) ||
-                  (s.payerId == targetId && s.targetId == gpId))
+              .where(
+                (s) =>
+                    (s.payerId == gpId && s.targetId == targetId) ||
+                    (s.payerId == targetId && s.targetId == gpId),
+              )
               .toList();
           subsidyStates = subsidyStates
-              .where((s) => !((s.payerId == gpId && s.targetId == targetId) ||
-                  (s.payerId == targetId && s.targetId == gpId)))
+              .where(
+                (s) =>
+                    !((s.payerId == gpId && s.targetId == targetId) ||
+                        (s.payerId == targetId && s.targetId == gpId)),
+              )
               .toList();
           if (cancelledSubsidies.isNotEmpty) {
-            _diploLog.i('logic: diplomacy subsidies cancelled due to war $gpId vs $targetId');
+            _diploLog.i(
+              'logic: diplomacy subsidies cancelled due to war $gpId vs $targetId',
+            );
           }
 
           game = game.copyWith(
@@ -582,7 +644,7 @@ Game _processWarAndPeace(
             subsidyStates: subsidyStates,
             dossierEvidenceEntries: [
               ...game.dossierEvidenceEntries,
-              ...evidence
+              ...evidence,
             ],
           );
           game = _appendDiplomaticEvent(
@@ -606,7 +668,9 @@ Game _processWarAndPeace(
               wasAiInitiator: isAiControlledForEvidence(game, s.payerId),
             );
           }
-          _diploLog.i('logic: diplomacy war declared $gpId vs $targetId (scores reset to 20)');
+          _diploLog.i(
+            'logic: diplomacy war declared $gpId vs $targetId (scores reset to 20)',
+          );
         }
       } else if (order.type == DiplomaticOrderType.offerPeace) {
         final targetId = order.targetFactionId;
@@ -634,13 +698,15 @@ Game _processWarAndPeace(
           }
 
           if (onDialogue != null && isAiControlledForEvidence(game, gpId)) {
-            onDialogue(DialogueEvent(
-              leaderId: gpId,
-              category: 'diplomatic',
-              situation: 'peace_offer',
-              era: 'earlyModern',
-              variables: {'otherNation': targetId},
-            ));
+            onDialogue(
+              DialogueEvent(
+                leaderId: gpId,
+                category: 'diplomatic',
+                situation: 'peace_offer',
+                era: 'earlyModern',
+                variables: {'otherNation': targetId},
+              ),
+            );
           }
           final evidence = evidenceForOfferPeace(game, gpId, targetId, turn);
           if (hasMutualOffer) {
@@ -690,15 +756,20 @@ Game _terminateAgreementsOnWar(Game game) {
     final id1 = rel.factionId1;
     final id2 = rel.factionId2;
     overtures = overtures
-        .where((o) => !((o.gpId == id1 && o.targetId == id2) ||
-            (o.gpId == id2 && o.targetId == id1)))
+        .where(
+          (o) =>
+              !((o.gpId == id1 && o.targetId == id2) ||
+                  (o.gpId == id2 && o.targetId == id1)),
+        )
         .toList();
   }
   if (overtures.length != game.overtureStates.length) {
     final removed = game.overtureStates
-        .where((o) =>
-            !overtures.any((n) =>
-                n.gpId == o.gpId && n.targetId == o.targetId))
+        .where(
+          (o) => !overtures.any(
+            (n) => n.gpId == o.gpId && n.targetId == o.targetId,
+          ),
+        )
         .toList();
     game = game.copyWith(overtureStates: overtures);
     for (final o in removed) {
@@ -743,8 +814,9 @@ Game _applyRelationModifiersAndUpdateScores(
       final playerIdx = players.indexWhere((p) => p.id == gpId);
       if (playerIdx >= 0) {
         players = List<Player>.from(players);
-        players[playerIdx] = players[playerIdx]
-            .copyWith(treasury: players[playerIdx].treasury - amount);
+        players[playerIdx] = players[playerIdx].copyWith(
+          treasury: players[playerIdx].treasury - amount,
+        );
       }
 
       relations = applyGrantAidModifier(
@@ -764,8 +836,9 @@ Game _applyRelationModifiersAndUpdateScores(
         amount: amount,
         wasAiInitiator: isAiControlledForEvidence(game, gpId),
       );
-      _diploLog
-          .i('logic: diplomacy GrantAid $gpId -> $targetId amount $amount');
+      _diploLog.i(
+        'logic: diplomacy GrantAid $gpId -> $targetId amount $amount',
+      );
     }
   }
 
@@ -789,30 +862,36 @@ Game _applyRelationModifiersAndUpdateScores(
       final payerIdx = players.indexWhere((p) => p.id == gpId);
       if (payerIdx >= 0) {
         players = List<Player>.from(players);
-        players[payerIdx] = players[payerIdx]
-            .copyWith(treasury: players[payerIdx].treasury - amount);
+        players[payerIdx] = players[payerIdx].copyWith(
+          treasury: players[payerIdx].treasury - amount,
+        );
       }
 
       // Store/update ongoing subsidy state
       final existingSubsidyIdx = subsidyStates.indexWhere(
-          (s) => s.payerId == gpId && s.targetId == targetId);
+        (s) => s.payerId == gpId && s.targetId == targetId,
+      );
       final isUpdate = existingSubsidyIdx >= 0;
       if (isUpdate) {
         subsidyStates[existingSubsidyIdx] = subsidyStates[existingSubsidyIdx]
             .copyWith(amountPerTurn: amount);
       } else {
-        subsidyStates.add(SubsidyState(
-          payerId: gpId,
-          targetId: targetId,
-          amountPerTurn: amount,
-        ));
+        subsidyStates.add(
+          SubsidyState(
+            payerId: gpId,
+            targetId: targetId,
+            amountPerTurn: amount,
+          ),
+        );
       }
 
       game = game.copyWith(players: players, subsidyStates: subsidyStates);
       game = _appendDiplomaticEvent(
         game,
         turn,
-        isUpdate ? DiplomaticEventType.subsidyUpdated : DiplomaticEventType.subsidySet,
+        isUpdate
+            ? DiplomaticEventType.subsidyUpdated
+            : DiplomaticEventType.subsidySet,
         {gpId, targetId},
         fromFactionId: gpId,
         toFactionId: targetId,
@@ -822,10 +901,12 @@ Game _applyRelationModifiersAndUpdateScores(
       final targetPlayer = game.playerById(targetId);
       if (targetPlayer != null) {
         _diploLog.i(
-            'logic: diplomacy SetSubsidy $gpId -> $targetId amount $amount/turn (ongoing)');
+          'logic: diplomacy SetSubsidy $gpId -> $targetId amount $amount/turn (ongoing)',
+        );
       } else {
         _diploLog.i(
-            'logic: diplomacy SetSubsidy $gpId -> $targetId amount $amount/turn (ongoing relation boost)');
+          'logic: diplomacy SetSubsidy $gpId -> $targetId amount $amount/turn (ongoing relation boost)',
+        );
       }
     }
   }
@@ -862,7 +943,9 @@ Game _processOngoingSubsidies(Game game, int turn) {
       subsidyStates = subsidyStates
           .where((s) => s.payerId != payerId || s.targetId != targetId)
           .toList();
-      _diploLog.i('logic: diplomacy subsidy cancelled $payerId -> $targetId (insufficient funds)');
+      _diploLog.i(
+        'logic: diplomacy subsidy cancelled $payerId -> $targetId (insufficient funds)',
+      );
       continue;
     }
 
@@ -882,7 +965,9 @@ Game _processOngoingSubsidies(Game game, int turn) {
       subsidyStates = subsidyStates
           .where((s) => s.payerId != payerId || s.targetId != targetId)
           .toList();
-      _diploLog.i('logic: diplomacy subsidy cancelled $payerId -> $targetId (war declared)');
+      _diploLog.i(
+        'logic: diplomacy subsidy cancelled $payerId -> $targetId (war declared)',
+      );
       continue;
     }
 
@@ -890,13 +975,15 @@ Game _processOngoingSubsidies(Game game, int turn) {
     final payerIdx = players.indexWhere((p) => p.id == payerId);
     if (payerIdx >= 0) {
       players = List<Player>.from(players);
-      players[payerIdx] = players[payerIdx]
-          .copyWith(treasury: players[payerIdx].treasury - amount);
+      players[payerIdx] = players[payerIdx].copyWith(
+        treasury: players[payerIdx].treasury - amount,
+      );
     }
 
     // Calculate relation boost: +subsidyBoostRelationPerStep per subsidyBoostDucatsPerStep ducats, max subsidyBoostMax
-    final boost = ((amount ~/ subsidyBoostDucatsPerStep) * subsidyBoostRelationPerStep)
-        .clamp(0, subsidyBoostMax);
+    final boost =
+        ((amount ~/ subsidyBoostDucatsPerStep) * subsidyBoostRelationPerStep)
+            .clamp(0, subsidyBoostMax);
 
     // Apply relation boost (only for Minors/Tribes - GPs get treasury transfer)
     if (isMinorOrTribe(game, targetId)) {
@@ -907,19 +994,28 @@ Game _processOngoingSubsidies(Game game, int turn) {
         boost: boost,
         turn: turn,
       );
-      _diploLog.i('logic: diplomacy subsidy processed $payerId -> $targetId amount=$amount boost=+$boost');
+      _diploLog.i(
+        'logic: diplomacy subsidy processed $payerId -> $targetId amount=$amount boost=+$boost',
+      );
     } else {
       // GP target: transfer treasury
       final targetIdx = players.indexWhere((p) => p.id == targetId);
       if (targetIdx >= 0) {
-        players[targetIdx] = players[targetIdx]
-            .copyWith(treasury: players[targetIdx].treasury + amount);
+        players[targetIdx] = players[targetIdx].copyWith(
+          treasury: players[targetIdx].treasury + amount,
+        );
       }
-      _diploLog.i('logic: diplomacy subsidy processed $payerId -> $targetId amount=$amount (treasury transfer)');
+      _diploLog.i(
+        'logic: diplomacy subsidy processed $payerId -> $targetId amount=$amount (treasury transfer)',
+      );
     }
   }
 
-  return game.copyWith(players: players, diplomacyRelations: relations, subsidyStates: subsidyStates);
+  return game.copyWith(
+    players: players,
+    diplomacyRelations: relations,
+    subsidyStates: subsidyStates,
+  );
 }
 
 /// Apply relation convergence: all non-war relations move +/-1 toward neutral.
@@ -984,8 +1080,9 @@ String? needsInterventionChoice(Game game, BattleContext ctx) {
   if (!defenderIsMinorOrTribe) return null;
 
   final attackerIds = ctx.attackers.map((a) => a.factionId).toSet();
-  final attackerIsGp =
-      attackerIds.any((id) => game.players.any((p) => p.id == id));
+  final attackerIsGp = attackerIds.any(
+    (id) => game.players.any((p) => p.id == id),
+  );
   if (!attackerIsGp) return null;
 
   for (final p in game.players) {
@@ -994,8 +1091,11 @@ String? needsInterventionChoice(Game game, BattleContext ctx) {
 
     final o = getOverture(game, p.id, defenderId);
     final hasEmbassy = o != null && o.hasEmbassy;
-    final hasInvestment =
-        _gpHasPurchasedLandInFactionProvinces(game, p.id, defenderId);
+    final hasInvestment = _gpHasPurchasedLandInFactionProvinces(
+      game,
+      p.id,
+      defenderId,
+    );
     if (hasEmbassy || hasInvestment) return p.id;
   }
   return null;
@@ -1037,8 +1137,9 @@ Game applyInterventionChoice(
 
     if (choice == InterventionChoice.intervene) {
       final ids = canonicalPairIds(gpIdWithEmbassy, attackerId);
-      relations =
-          upsertRelation(relations, gpIdWithEmbassy, attackerId, (existing) {
+      relations = upsertRelation(relations, gpIdWithEmbassy, attackerId, (
+        existing,
+      ) {
         if (existing == null) {
           return DiplomacyRelation(
             factionId1: ids.id1,
@@ -1051,7 +1152,10 @@ Game applyInterventionChoice(
           );
         }
         if (!existing.atPeace) return existing;
-        final newScore = (existing.score - relationScoreWarDelta).clamp(relationScoreMin, relationScoreMax);
+        final newScore = (existing.score - relationScoreWarDelta).clamp(
+          relationScoreMin,
+          relationScoreMax,
+        );
         return existing.copyWith(
           state: RelationState.atWar,
           sinceTurn: turn,
@@ -1062,9 +1166,12 @@ Game applyInterventionChoice(
       });
     } else if (choice == InterventionChoice.protest) {
       final ids = canonicalPairIds(gpIdWithEmbassy, attackerId);
-      relations =
-          upsertRelation(relations, gpIdWithEmbassy, attackerId, (existing) {
-        final newScore = ((existing?.score ?? relationScoreNeutral) - relationScoreWarDelta).clamp(relationScoreMin, relationScoreMax);
+      relations = upsertRelation(relations, gpIdWithEmbassy, attackerId, (
+        existing,
+      ) {
+        final newScore =
+            ((existing?.score ?? relationScoreNeutral) - relationScoreWarDelta)
+                .clamp(relationScoreMin, relationScoreMax);
         final newLevel = scoreToLevel(newScore);
         if (existing == null) {
           return DiplomacyRelation(
@@ -1076,7 +1183,10 @@ Game applyInterventionChoice(
           );
         }
         return existing.copyWith(
-            score: newScore, level: newLevel, lastInteractionTurn: turn);
+          score: newScore,
+          level: newLevel,
+          lastInteractionTurn: turn,
+        );
       });
     }
   }

--- a/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+++ b/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
@@ -2,20 +2,17 @@
 // When diplomatic (or other) actions are applied, evidence rules add suspicion points per agenda type.
 // Evidence is stored per (observer, subject, agenda type); only human observers receive entries.
 
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import '../constants.dart';
 import '../diplomacy/diplomacy_relation_lookup.dart';
 
-final _log = Logger();
+final _log = logicLogger();
 
 /// Human Great Power ids (observers for whom we store evidence).
 List<String> _humanObserverIds(Game game) {
-  return game.players
-      .where((p) => p.isHuman)
-      .map((p) => p.id)
-      .toList();
+  return game.players.where((p) => p.isHuman).map((p) => p.id).toList();
 }
 
 /// True if [playerId] is AI-controlled (evidence/dialogue only for AI subjects).
@@ -56,28 +53,34 @@ List<DossierEvidenceEntry> evidenceForDeclareWar(
   final entries = <DossierEvidenceEntry>[];
   for (final observerId in observers) {
     if (wasAllied) {
-      entries.add(DossierEvidenceEntry(
-        observerId: observerId,
-        subjectId: actorGpId,
-        agendaType: 'backstabber',
-        turnNumber: turnNumber,
-        description: 'declared war on ally',
-        scoreDelta: 2,
-      ));
+      entries.add(
+        DossierEvidenceEntry(
+          observerId: observerId,
+          subjectId: actorGpId,
+          agendaType: 'backstabber',
+          turnNumber: turnNumber,
+          description: 'declared war on ally',
+          scoreDelta: 2,
+        ),
+      );
     }
     if (weaker) {
-      entries.add(DossierEvidenceEntry(
-        observerId: observerId,
-        subjectId: actorGpId,
-        agendaType: 'warmonger',
-        turnNumber: turnNumber,
-        description: 'declared war on weaker neighbor',
-        scoreDelta: 2,
-      ));
+      entries.add(
+        DossierEvidenceEntry(
+          observerId: observerId,
+          subjectId: actorGpId,
+          agendaType: 'warmonger',
+          turnNumber: turnNumber,
+          description: 'declared war on weaker neighbor',
+          scoreDelta: 2,
+        ),
+      );
     }
   }
   if (entries.isNotEmpty) {
-    _log.d('data: evidence for declareWar actor=$actorGpId target=$targetFactionId entries=${entries.length}');
+    _log.d(
+      'data: evidence for declareWar actor=$actorGpId target=$targetFactionId entries=${entries.length}',
+    );
   }
   return entries;
 }
@@ -95,16 +98,20 @@ List<DossierEvidenceEntry> evidenceForOfferPeace(
 
   final entries = <DossierEvidenceEntry>[];
   for (final observerId in observers) {
-    entries.add(DossierEvidenceEntry(
-      observerId: observerId,
-      subjectId: actorGpId,
-      agendaType: 'peacemaker',
-      turnNumber: turnNumber,
-      description: 'offered peace',
-      scoreDelta: 1,
-    ));
+    entries.add(
+      DossierEvidenceEntry(
+        observerId: observerId,
+        subjectId: actorGpId,
+        agendaType: 'peacemaker',
+        turnNumber: turnNumber,
+        description: 'offered peace',
+        scoreDelta: 1,
+      ),
+    );
   }
-  _log.d('data: evidence for offerPeace actor=$actorGpId target=$targetFactionId entries=${entries.length}');
+  _log.d(
+    'data: evidence for offerPeace actor=$actorGpId target=$targetFactionId entries=${entries.length}',
+  );
   return entries;
 }
 
@@ -126,17 +133,23 @@ List<DossierEvidenceEntry> evidenceForLandBattleVictory(
 
   final entries = <DossierEvidenceEntry>[];
   for (final observerId in observers) {
-    entries.add(DossierEvidenceEntry(
-      observerId: observerId,
-      subjectId: victorGpId,
-      agendaType: 'warmonger',
-      turnNumber: turnNumber,
-      description: weaker ? 'won battle vs weaker neighbor' : 'won battle as attacker',
-      scoreDelta: scoreDelta,
-    ));
+    entries.add(
+      DossierEvidenceEntry(
+        observerId: observerId,
+        subjectId: victorGpId,
+        agendaType: 'warmonger',
+        turnNumber: turnNumber,
+        description: weaker
+            ? 'won battle vs weaker neighbor'
+            : 'won battle as attacker',
+        scoreDelta: scoreDelta,
+      ),
+    );
   }
   if (entries.isNotEmpty) {
-    _log.d('data: evidence for land battle victory victor=$victorGpId defender=$defenderFactionId entries=${entries.length}');
+    _log.d(
+      'data: evidence for land battle victory victor=$victorGpId defender=$defenderFactionId entries=${entries.length}',
+    );
   }
   return entries;
 }
@@ -154,17 +167,21 @@ List<DossierEvidenceEntry> evidenceForNavalBattleVictory(
 
   final entries = <DossierEvidenceEntry>[];
   for (final observerId in observers) {
-    entries.add(DossierEvidenceEntry(
-      observerId: observerId,
-      subjectId: victorOwnerId,
-      agendaType: 'warmonger',
-      turnNumber: turnNumber,
-      description: 'won naval battle',
-      scoreDelta: 1,
-    ));
+    entries.add(
+      DossierEvidenceEntry(
+        observerId: observerId,
+        subjectId: victorOwnerId,
+        agendaType: 'warmonger',
+        turnNumber: turnNumber,
+        description: 'won naval battle',
+        scoreDelta: 1,
+      ),
+    );
   }
   if (entries.isNotEmpty) {
-    _log.d('data: evidence for naval battle victory victor=$victorOwnerId loser=$loserOwnerId entries=${entries.length}');
+    _log.d(
+      'data: evidence for naval battle victory victor=$victorOwnerId loser=$loserOwnerId entries=${entries.length}',
+    );
   }
   return entries;
 }

--- a/packages/colonizethis_logic/lib/src/economy/economy_consumption.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_consumption.dart
@@ -1,10 +1,10 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import 'worker_economy.dart';
 
-final Logger _log = Logger();
+final _log = logicLogger();
 
 /// Consumption resolution helpers.
 /// SPEC/game/workers-and-population.md
@@ -43,10 +43,7 @@ ConsumptionResult resolveConsumption({
 }) {
   Stockpile current = stockpile;
 
-  int feedGroup({
-    required int count,
-    required int foodPerUnit,
-  }) {
+  int feedGroup({required int count, required int foodPerUnit}) {
     if (count <= 0 || foodPerUnit <= 0) return count;
     final requiredFood = count * foodPerUnit;
     final (nextStockpile, consumed) = consumeFoodUnits(
@@ -119,10 +116,7 @@ ConsumptionResult resolveConsumption({
     masters: fedMasters,
   );
 
-  current = deductLuxuryForWorkers(
-    stockpile: current,
-    workers: updatedWorkers,
-  );
+  current = deductLuxuryForWorkers(stockpile: current, workers: updatedWorkers);
 
   _log.d(
     'logic: consumption totalRegiments=$totalRegiments fullyFedRegiments=$fullyFedRegiments',

--- a/packages/colonizethis_logic/lib/src/economy/economy_production.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_production.dart
@@ -1,26 +1,23 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import 'worker_economy.dart';
 
-final Logger _log = Logger();
+final _log = logicLogger();
 
 int _effectiveLabourForWorkers({
   required WorkerPool workers,
   required Stockpile stockpile,
-}) =>
-    effectiveLabourForWorkers(workers: workers, stockpile: stockpile);
+}) => effectiveLabourForWorkers(workers: workers, stockpile: stockpile);
 
 /// Production resolution helpers.
 /// SPEC/game/production-recipes.md
 /// SPEC/game/workers-and-population.md
 
 class AssignedRecipe {
-  const AssignedRecipe({
-    required this.recipeId,
-    required this.assignedLabour,
-  }) : assert(assignedLabour >= 0, 'assignedLabour must be non-negative');
+  const AssignedRecipe({required this.recipeId, required this.assignedLabour})
+    : assert(assignedLabour >= 0, 'assignedLabour must be non-negative');
 
   final String recipeId;
   final int assignedLabour;
@@ -80,7 +77,8 @@ ProductionResult resolveProduction({
       continue;
     }
 
-    final labourBudgetForAssignment = assignment.assignedLabour <= remainingEffectiveLabour
+    final labourBudgetForAssignment =
+        assignment.assignedLabour <= remainingEffectiveLabour
         ? assignment.assignedLabour
         : remainingEffectiveLabour;
     if (labourBudgetForAssignment <= 0) continue;
@@ -132,4 +130,3 @@ ProductionResult resolveProduction({
     productionByRecipe: productionByRecipe,
   );
 }
-

--- a/packages/colonizethis_logic/lib/src/economy/economy_riches_to_treasury.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_riches_to_treasury.dart
@@ -1,8 +1,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
-final Logger _log = Logger();
+final _log = logicLogger();
 
 /// Riches-to-treasury phase: convert riches in stockpile to treasury at base price.
 /// SPEC/program/turn-resolution-phases.md (Riches to treasury).
@@ -43,7 +43,9 @@ RichesToTreasuryResult resolveRichesToTreasury({
     updatedStockpile = updatedStockpile.applyDelta(id, -qty);
   }
 
-  _log.d('logic: riches-to-treasury treasuryDelta=$totalCash multiplier=$richesCashMultiplier');
+  _log.d(
+    'logic: riches-to-treasury treasuryDelta=$totalCash multiplier=$richesCashMultiplier',
+  );
   return RichesToTreasuryResult(
     stockpile: updatedStockpile,
     treasuryDelta: totalCash,

--- a/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
+++ b/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
@@ -1,19 +1,16 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import '../constants.dart';
 import '../world/connectivity_resolver.dart';
 import '../world/province_lookup.dart';
 
-final Logger _log = Logger();
+final _log = logicLogger();
 
 /// Per-player extraction totals: land (same region as capital) vs overseas.
 class ExtractionTotals {
-  const ExtractionTotals({
-    this.land = const {},
-    this.overseas = const {},
-  });
+  const ExtractionTotals({this.land = const {}, this.overseas = const {}});
 
   final Map<CommodityId, int> land;
   final Map<CommodityId, int> overseas;
@@ -49,7 +46,8 @@ Map<String, ExtractionTotals> computeExtraction({
     final landTotals = <CommodityId, int>{};
     final overseasTotals = <CommodityId, int>{};
 
-    final prospected = game.worldState.playerProspectedTiles[player.id] ?? const <String>{};
+    final prospected =
+        game.worldState.playerProspectedTiles[player.id] ?? const <String>{};
 
     for (final tileKey in connected) {
       final parts = tileKey.split('|');
@@ -75,32 +73,57 @@ Map<String, ExtractionTotals> computeExtraction({
       // Province lookup must be region-scoped. SPEC/game/world-model-identity.md.
       final provinceId = '$regionId|${parts[1]}';
       final regionData = regionDataForId(game.worldState, regionId);
-      final province = regionData?.provinces.where((p) => p.id == provinceId).firstOrNull;
+      final province = regionData?.provinces
+          .where((p) => p.id == provinceId)
+          .firstOrNull;
       final townDevelopmentCap = province?.townDevelopmentLevel ?? 4;
 
-      final improvementLevel = game.worldState.tileState.improvementLevel(tileKey).clamp(0, 4);
+      final improvementLevel = game.worldState.tileState
+          .improvementLevel(tileKey)
+          .clamp(0, 4);
       final roadLevel = game.worldState.tileState.roadLevel(tileKey);
-      final isPort = game.worldState.portsByProvinceSeaboard.values.contains(tileKey);
+      final isPort = game.worldState.portsByProvinceSeaboard.values.contains(
+        tileKey,
+      );
       final tileTransportLevel = isPort ? 4 : (roadLevel > 0 ? roadLevel : 0);
       final pathCap = pathTransportCap[tileKey] ?? tileTransportLevel;
 
-      final production = (improvementLevel < techCap ? improvementLevel : techCap).clamp(0, 4);
-      final effective = (production < pathCap ? production : pathCap).clamp(0, 4);
-      final effectiveCapped = (effective < townDevelopmentCap ? effective : townDevelopmentCap).clamp(0, 4);
+      final production =
+          (improvementLevel < techCap ? improvementLevel : techCap).clamp(0, 4);
+      final effective = (production < pathCap ? production : pathCap).clamp(
+        0,
+        4,
+      );
+      final effectiveCapped =
+          (effective < townDevelopmentCap ? effective : townDevelopmentCap)
+              .clamp(0, 4);
       if (effectiveCapped <= 0) continue;
 
       if (regionId == capitalRegionId) {
-        landTotals[commodityId] = (landTotals[commodityId] ?? 0) + effectiveCapped;
+        landTotals[commodityId] =
+            (landTotals[commodityId] ?? 0) + effectiveCapped;
       } else {
-        overseasTotals[commodityId] = (overseasTotals[commodityId] ?? 0) + effectiveCapped;
+        overseasTotals[commodityId] =
+            (overseasTotals[commodityId] ?? 0) + effectiveCapped;
       }
     }
 
-    out[player.id] = ExtractionTotals(land: landTotals, overseas: overseasTotals);
+    out[player.id] = ExtractionTotals(
+      land: landTotals,
+      overseas: overseasTotals,
+    );
   }
-  final landSum = out.values.fold<int>(0, (s, t) => s + t.land.values.fold(0, (a, b) => a + b));
-  final overseasSum = out.values.fold<int>(0, (s, t) => s + t.overseas.values.fold(0, (a, b) => a + b));
-  _log.d('logic: extraction compute end players=${out.length} landTotal=$landSum overseasTotal=$overseasSum');
+  final landSum = out.values.fold<int>(
+    0,
+    (s, t) => s + t.land.values.fold(0, (a, b) => a + b),
+  );
+  final overseasSum = out.values.fold<int>(
+    0,
+    (s, t) => s + t.overseas.values.fold(0, (a, b) => a + b),
+  );
+  _log.d(
+    'logic: extraction compute end players=${out.length} landTotal=$landSum overseasTotal=$overseasSum',
+  );
   return out;
 }
 

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -1,6 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import '../economy/economy_production.dart';
 import 'order_projections.dart';
@@ -17,7 +17,7 @@ import 'validators/work_order_validator.dart';
 import 'validators/naval_order_validator.dart';
 import 'unit_type_helpers.dart';
 
-final Logger _log = Logger();
+final _log = logicLogger();
 
 /// Order engine: current-turn orders per player, validation, projected effects.
 /// SPEC/program/order-engine.md. Does not mutate world state.
@@ -49,7 +49,11 @@ bool _appendValidationResults<T>(
   List<T> orders,
   bool rejected,
   S initialState,
-  ({OrderValidationResult result, S state}) Function(T order, bool previousRejected) validate,
+  ({OrderValidationResult result, S state}) Function(
+    T order,
+    bool previousRejected,
+  )
+  validate,
 ) {
   var r = rejected;
   var s = initialState;
@@ -63,9 +67,7 @@ bool _appendValidationResults<T>(
 }
 
 /// Deep-copy of order maps: new map and new list per player. Used by constructor and _copyOrders.
-Map<String, List<T>> _copyMapOfOrderLists<T>(
-  Map<String, List<T>> map,
-) =>
+Map<String, List<T>> _copyMapOfOrderLists<T>(Map<String, List<T>> map) =>
     Map.from(map)..updateAll((_, v) => List<T>.from(v));
 
 class _OrderSlot<T> {
@@ -81,43 +83,52 @@ class _OrderSlot<T> {
 }
 
 class OrderEngine {
-  OrderEngine({
-    Orders initialOrders = const Orders(),
-  }) : _orders = Orders(
-          moveOrdersByPlayerId:
-              _copyMapOfOrderLists(initialOrders.moveOrdersByPlayerId),
-          buildUnitOrdersByPlayerId:
-              _copyMapOfOrderLists(initialOrders.buildUnitOrdersByPlayerId),
-          workOrdersByPlayerId:
-              _copyMapOfOrderLists(initialOrders.workOrdersByPlayerId),
-          diplomaticOrdersByPlayerId:
-              _copyMapOfOrderLists(initialOrders.diplomaticOrdersByPlayerId),
-          researchOrdersByPlayerId:
-              _copyMapOfOrderLists(initialOrders.researchOrdersByPlayerId),
-          navalMoveOrdersByPlayerId:
-              _copyMapOfOrderLists(initialOrders.navalMoveOrdersByPlayerId),
-          navalMissionOrdersByPlayerId:
-              _copyMapOfOrderLists(initialOrders.navalMissionOrdersByPlayerId),
-        );
+  OrderEngine({Orders initialOrders = const Orders()})
+    : _orders = Orders(
+        moveOrdersByPlayerId: _copyMapOfOrderLists(
+          initialOrders.moveOrdersByPlayerId,
+        ),
+        buildUnitOrdersByPlayerId: _copyMapOfOrderLists(
+          initialOrders.buildUnitOrdersByPlayerId,
+        ),
+        workOrdersByPlayerId: _copyMapOfOrderLists(
+          initialOrders.workOrdersByPlayerId,
+        ),
+        diplomaticOrdersByPlayerId: _copyMapOfOrderLists(
+          initialOrders.diplomaticOrdersByPlayerId,
+        ),
+        researchOrdersByPlayerId: _copyMapOfOrderLists(
+          initialOrders.researchOrdersByPlayerId,
+        ),
+        navalMoveOrdersByPlayerId: _copyMapOfOrderLists(
+          initialOrders.navalMoveOrdersByPlayerId,
+        ),
+        navalMissionOrdersByPlayerId: _copyMapOfOrderLists(
+          initialOrders.navalMissionOrdersByPlayerId,
+        ),
+      );
 
   Orders _orders;
 
   Orders get orders => _copyOrders(_orders);
 
   Orders _copyOrders(Orders o) => Orders(
-        moveOrdersByPlayerId: _copyMapOfOrderLists(o.moveOrdersByPlayerId),
-        buildUnitOrdersByPlayerId:
-            _copyMapOfOrderLists(o.buildUnitOrdersByPlayerId),
-        workOrdersByPlayerId: _copyMapOfOrderLists(o.workOrdersByPlayerId),
-        diplomaticOrdersByPlayerId:
-            _copyMapOfOrderLists(o.diplomaticOrdersByPlayerId),
-        researchOrdersByPlayerId:
-            _copyMapOfOrderLists(o.researchOrdersByPlayerId),
-        navalMoveOrdersByPlayerId:
-            _copyMapOfOrderLists(o.navalMoveOrdersByPlayerId),
-        navalMissionOrdersByPlayerId:
-            _copyMapOfOrderLists(o.navalMissionOrdersByPlayerId),
-      );
+    moveOrdersByPlayerId: _copyMapOfOrderLists(o.moveOrdersByPlayerId),
+    buildUnitOrdersByPlayerId: _copyMapOfOrderLists(
+      o.buildUnitOrdersByPlayerId,
+    ),
+    workOrdersByPlayerId: _copyMapOfOrderLists(o.workOrdersByPlayerId),
+    diplomaticOrdersByPlayerId: _copyMapOfOrderLists(
+      o.diplomaticOrdersByPlayerId,
+    ),
+    researchOrdersByPlayerId: _copyMapOfOrderLists(o.researchOrdersByPlayerId),
+    navalMoveOrdersByPlayerId: _copyMapOfOrderLists(
+      o.navalMoveOrdersByPlayerId,
+    ),
+    navalMissionOrdersByPlayerId: _copyMapOfOrderLists(
+      o.navalMissionOrdersByPlayerId,
+    ),
+  );
 
   // -- Generic helpers for add/remove --
 
@@ -130,7 +141,7 @@ class OrderEngine {
     final list = getter(_orders)[playerId] ?? [];
     _orders = updater(_orders, {
       ...getter(_orders),
-      playerId: [...list, order]
+      playerId: [...list, order],
     });
   }
 
@@ -152,7 +163,8 @@ class OrderEngine {
     final r = results.last;
     if (!r.isAccepted)
       _log.w(
-          'logic: $orderLabel order rejected player=$playerId reason=${r.reason}');
+        'logic: $orderLabel order rejected player=$playerId reason=${r.reason}',
+      );
     return r;
   }
 
@@ -179,8 +191,9 @@ class OrderEngine {
   static Map<String, List<BuildUnitOrder>> _buildOrders(Orders o) =>
       o.buildUnitOrdersByPlayerId;
   static Orders _withBuildOrders(
-          Orders o, Map<String, List<BuildUnitOrder>> m) =>
-      o.copyWith(buildUnitOrdersByPlayerId: m);
+    Orders o,
+    Map<String, List<BuildUnitOrder>> m,
+  ) => o.copyWith(buildUnitOrdersByPlayerId: m);
 
   static Map<String, List<WorkOrder>> _workOrders(Orders o) =>
       o.workOrdersByPlayerId;
@@ -190,20 +203,23 @@ class OrderEngine {
   static Map<String, List<DiplomaticOrder>> _diplomaticOrders(Orders o) =>
       o.diplomaticOrdersByPlayerId;
   static Orders _withDiplomaticOrders(
-          Orders o, Map<String, List<DiplomaticOrder>> m) =>
-      o.copyWith(diplomaticOrdersByPlayerId: m);
+    Orders o,
+    Map<String, List<DiplomaticOrder>> m,
+  ) => o.copyWith(diplomaticOrdersByPlayerId: m);
 
   static Map<String, List<NavalMoveOrder>> _navalMoveOrders(Orders o) =>
       o.navalMoveOrdersByPlayerId;
   static Orders _withNavalMoveOrders(
-          Orders o, Map<String, List<NavalMoveOrder>> m) =>
-      o.copyWith(navalMoveOrdersByPlayerId: m);
+    Orders o,
+    Map<String, List<NavalMoveOrder>> m,
+  ) => o.copyWith(navalMoveOrdersByPlayerId: m);
 
   static Map<String, List<NavalMissionOrder>> _navalMissionOrders(Orders o) =>
       o.navalMissionOrdersByPlayerId;
   static Orders _withNavalMissionOrders(
-          Orders o, Map<String, List<NavalMissionOrder>> m) =>
-      o.copyWith(navalMissionOrdersByPlayerId: m);
+    Orders o,
+    Map<String, List<NavalMissionOrder>> m,
+  ) => o.copyWith(navalMissionOrdersByPlayerId: m);
 
   // -- Public add/remove methods --
 
@@ -215,10 +231,10 @@ class OrderEngine {
 
   static const _OrderSlot<BuildUnitOrder> _buildSlot =
       _OrderSlot<BuildUnitOrder>(
-    getter: _buildOrders,
-    updater: _withBuildOrders,
-    label: 'build',
-  );
+        getter: _buildOrders,
+        updater: _withBuildOrders,
+        label: 'build',
+      );
 
   static const _OrderSlot<WorkOrder> _workSlot = _OrderSlot<WorkOrder>(
     getter: _workOrders,
@@ -228,24 +244,24 @@ class OrderEngine {
 
   static const _OrderSlot<DiplomaticOrder> _diplomaticSlot =
       _OrderSlot<DiplomaticOrder>(
-    getter: _diplomaticOrders,
-    updater: _withDiplomaticOrders,
-    label: 'diplomatic',
-  );
+        getter: _diplomaticOrders,
+        updater: _withDiplomaticOrders,
+        label: 'diplomatic',
+      );
 
   static const _OrderSlot<NavalMoveOrder> _navalMoveSlot =
       _OrderSlot<NavalMoveOrder>(
-    getter: _navalMoveOrders,
-    updater: _withNavalMoveOrders,
-    label: 'naval move',
-  );
+        getter: _navalMoveOrders,
+        updater: _withNavalMoveOrders,
+        label: 'naval move',
+      );
 
   static const _OrderSlot<NavalMissionOrder> _navalMissionSlot =
       _OrderSlot<NavalMissionOrder>(
-    getter: _navalMissionOrders,
-    updater: _withNavalMissionOrders,
-    label: 'naval mission',
-  );
+        getter: _navalMissionOrders,
+        updater: _withNavalMissionOrders,
+        label: 'naval mission',
+      );
 
   OrderValidationResult _addOrder<T>(
     String playerId,
@@ -274,11 +290,7 @@ class OrderEngine {
     );
   }
 
-  void _removeOrderAtSlot<T>(
-    String playerId,
-    int index,
-    _OrderSlot<T> slot,
-  ) {
+  void _removeOrderAtSlot<T>(String playerId, int index, _OrderSlot<T> slot) {
     _removeOrderAt(playerId, index, slot.getter, slot.updater);
   }
 
@@ -286,68 +298,80 @@ class OrderEngine {
       _addOrder(playerId, order, _moveSlot);
 
   OrderValidationResult addMoveOrderWithContext(
-          Game game, MapTopology topology, String playerId, MoveOrder order) =>
-      _addOrderWithContextSlot(game, topology, playerId, order, _moveSlot);
+    Game game,
+    MapTopology topology,
+    String playerId,
+    MoveOrder order,
+  ) => _addOrderWithContextSlot(game, topology, playerId, order, _moveSlot);
 
   OrderValidationResult addBuildOrder(String playerId, BuildUnitOrder order) =>
       _addOrder(playerId, order, _buildSlot);
 
-  OrderValidationResult addBuildOrderWithContext(Game game,
-          MapTopology topology, String playerId, BuildUnitOrder order) =>
-      _addOrderWithContextSlot(game, topology, playerId, order, _buildSlot);
+  OrderValidationResult addBuildOrderWithContext(
+    Game game,
+    MapTopology topology,
+    String playerId,
+    BuildUnitOrder order,
+  ) => _addOrderWithContextSlot(game, topology, playerId, order, _buildSlot);
 
   OrderValidationResult addWorkOrder(String playerId, WorkOrder order) =>
       _addOrder(playerId, order, _workSlot);
 
   OrderValidationResult addWorkOrderWithContext(
-          Game game, MapTopology topology, String playerId, WorkOrder order) =>
-      _addOrderWithContextSlot(game, topology, playerId, order, _workSlot);
+    Game game,
+    MapTopology topology,
+    String playerId,
+    WorkOrder order,
+  ) => _addOrderWithContextSlot(game, topology, playerId, order, _workSlot);
 
   OrderValidationResult addDiplomaticOrder(
-          String playerId, DiplomaticOrder order) =>
-      _addOrder(playerId, order, _diplomaticSlot);
+    String playerId,
+    DiplomaticOrder order,
+  ) => _addOrder(playerId, order, _diplomaticSlot);
 
   OrderValidationResult addDiplomaticOrderWithContext(
     Game game,
     MapTopology topology,
     String playerId,
     DiplomaticOrder order,
-  ) =>
-      _addOrderWithContextSlot(
-        game,
-        topology,
-        playerId,
-        order,
-        _diplomaticSlot,
-      );
+  ) => _addOrderWithContextSlot(
+    game,
+    topology,
+    playerId,
+    order,
+    _diplomaticSlot,
+  );
 
   OrderValidationResult addNavalMoveOrder(
-          String playerId, NavalMoveOrder order) =>
-      _addOrder(playerId, order, _navalMoveSlot);
+    String playerId,
+    NavalMoveOrder order,
+  ) => _addOrder(playerId, order, _navalMoveSlot);
 
-  OrderValidationResult addNavalMoveOrderWithContext(Game game,
-          MapTopology topology, String playerId, NavalMoveOrder order) =>
-      _addOrderWithContextSlot(
-        game,
-        topology,
-        playerId,
-        order,
-        _navalMoveSlot,
-      );
+  OrderValidationResult addNavalMoveOrderWithContext(
+    Game game,
+    MapTopology topology,
+    String playerId,
+    NavalMoveOrder order,
+  ) =>
+      _addOrderWithContextSlot(game, topology, playerId, order, _navalMoveSlot);
 
   OrderValidationResult addNavalMissionOrder(
-          String playerId, NavalMissionOrder order) =>
-      _addOrder(playerId, order, _navalMissionSlot);
+    String playerId,
+    NavalMissionOrder order,
+  ) => _addOrder(playerId, order, _navalMissionSlot);
 
-  OrderValidationResult addNavalMissionOrderWithContext(Game game,
-          MapTopology topology, String playerId, NavalMissionOrder order) =>
-      _addOrderWithContextSlot(
-        game,
-        topology,
-        playerId,
-        order,
-        _navalMissionSlot,
-      );
+  OrderValidationResult addNavalMissionOrderWithContext(
+    Game game,
+    MapTopology topology,
+    String playerId,
+    NavalMissionOrder order,
+  ) => _addOrderWithContextSlot(
+    game,
+    topology,
+    playerId,
+    order,
+    _navalMissionSlot,
+  );
 
   void removeMoveOrder(String playerId, int index) =>
       _removeOrderAtSlot(playerId, index, _moveSlot);
@@ -378,17 +402,26 @@ class OrderEngine {
     final missions = _orders.navalMissionOrdersByPlayerId[playerId] ?? [];
     var rejected = false;
 
-    final unitsById =
-        Map<String, Unit>.from(unitsByIdFromWorld(game.worldState));
+    final unitsById = Map<String, Unit>.from(
+      unitsByIdFromWorld(game.worldState),
+    );
 
-    final devExclusiveTiles =
-        devExclusiveTilesFromWorld(game.worldState, playerId);
+    final devExclusiveTiles = devExclusiveTilesFromWorld(
+      game.worldState,
+      playerId,
+    );
 
     const _moveValidator = MoveValidator();
 
     OrderValidationResult validateMove(MoveOrder o) {
       return _moveValidator.validate(
-        o, game, playerId, unitsById, diplomatic, view, topology,
+        o,
+        game,
+        playerId,
+        unitsById,
+        diplomatic,
+        view,
+        topology,
       );
     }
 
@@ -436,16 +469,17 @@ class OrderEngine {
       playerId: playerId,
       initialTreasury: treasury,
     );
-    final afterDiplomatic = _appendValidationResultsWithState<DiplomaticOrder, int>(
-      results,
-      diplomatic,
-      rejected,
-      treasury,
-      (o, prev) {
-        final r = diplomaticValidator.validate(o, previousRejected: prev);
-        return (result: r.result, state: r.treasury);
-      },
-    );
+    final afterDiplomatic =
+        _appendValidationResultsWithState<DiplomaticOrder, int>(
+          results,
+          diplomatic,
+          rejected,
+          treasury,
+          (o, prev) {
+            final r = diplomaticValidator.validate(o, previousRejected: prev);
+            return (result: r.result, state: r.treasury);
+          },
+        );
     rejected = afterDiplomatic.rejected;
     treasury = afterDiplomatic.state;
 
@@ -485,7 +519,8 @@ class OrderEngine {
     final tileMaps = tileMapByRegion ?? <String, TileMapResult>{};
     if (tileMaps.isEmpty) {
       _log.d(
-          'logic: projectedEffects called with no tileMapByRegion; expected extraction will be zero');
+        'logic: projectedEffects called with no tileMapByRegion; expected extraction will be zero',
+      );
     }
     return projectOrderEffects(
       game: game,

--- a/packages/colonizethis_logic/lib/src/orders/order_projections.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_projections.dart
@@ -1,6 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import '../economy/economy_production.dart';
 import '../constants.dart';
@@ -8,7 +8,7 @@ import '../world/unit_lookup.dart';
 import 'projected_effects.dart';
 import '../turn/turn_resolver.dart';
 
-final Logger _log = Logger();
+final _log = logicLogger();
 
 /// Projects effects of unresolved orders. SPEC/program/order-projections.md.
 /// Dry-run of resolveTurnForGame; no world state mutation.
@@ -25,19 +25,23 @@ ProjectedEffects projectOrderEffects({
 }) {
   _log.d('logic: projectOrderEffects run for player $playerId');
   if (tileMapByRegion.isEmpty) {
-    _log.d('logic: projectOrderEffects with empty tileMapByRegion; extraction will be zero');
+    _log.d(
+      'logic: projectOrderEffects with empty tileMapByRegion; extraction will be zero',
+    );
   }
   Map<String, Map<String, int>>? productionByRecipeByPlayerId;
-  final next = requireTurnResolutionComplete(resolveTurnForGame(
-    game: game,
-    topology: topology,
-    orders: orders,
-    tileMapByRegion: tileMapByRegion,
-    defaultAssignments: defaultAssignments,
-    onProductionComplete: defaultAssignments.isNotEmpty
-        ? (map) => productionByRecipeByPlayerId = map
-        : null,
-  ));
+  final next = requireTurnResolutionComplete(
+    resolveTurnForGame(
+      game: game,
+      topology: topology,
+      orders: orders,
+      tileMapByRegion: tileMapByRegion,
+      defaultAssignments: defaultAssignments,
+      onProductionComplete: defaultAssignments.isNotEmpty
+          ? (map) => productionByRecipeByPlayerId = map
+          : null,
+    ),
+  );
   final player = next.playerById(playerId);
   if (player == null) return const ProjectedEffects();
 
@@ -68,10 +72,13 @@ ProjectedEffects projectOrderEffects({
 
   return ProjectedEffects(
     workerCount: player.workerPool.totalWorkers,
-    treasuryDelta: origPlayer != null ? player.treasury - origPlayer.treasury : null,
+    treasuryDelta: origPlayer != null
+        ? player.treasury - origPlayer.treasury
+        : null,
     unitLocations: unitLocations,
     stockpileDeltas: stockpileDeltas.isNotEmpty ? stockpileDeltas : null,
-    productionByRecipe: productionByRecipe != null && productionByRecipe.isNotEmpty
+    productionByRecipe:
+        productionByRecipe != null && productionByRecipe.isNotEmpty
         ? productionByRecipe
         : null,
   );

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -1,6 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import '../diplomacy/diplomacy_resolver.dart';
 import '../world/movement.dart';
@@ -14,7 +14,7 @@ import '../world/unit_lookup.dart';
 
 export 'order_suggestion_helpers.dart';
 
-final Logger _log = Logger();
+final _log = logicLogger();
 
 const String _kOrderSuggestionLogPrefix = 'logic/order_suggestion';
 

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_api_impl.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_api_impl.dart
@@ -1,11 +1,11 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import 'order_suggestion.dart' as suggestion;
 import '../world/player_view.dart';
 
-final Logger _log = Logger();
+final _log = logicLogger();
 
 /// Default implementation of [OrderSuggestionAPI] using the top-level suggest* functions.
 class DefaultOrderSuggestionAPI implements suggestion.OrderSuggestionAPI {
@@ -18,7 +18,9 @@ class DefaultOrderSuggestionAPI implements suggestion.OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    _log.i('logic: order suggestion API suggestMoveOrders player=${view.playerId} turn=${game.worldState.turnState.turnNumber}');
+    _log.i(
+      'logic: order suggestion API suggestMoveOrders player=${view.playerId} turn=${game.worldState.turnState.turnNumber}',
+    );
     return suggestion.suggestMoveOrders(view, game, topology, currentOrders);
   }
 
@@ -29,7 +31,9 @@ class DefaultOrderSuggestionAPI implements suggestion.OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    _log.i('logic: order suggestion API suggestWorkOrders player=${view.playerId}');
+    _log.i(
+      'logic: order suggestion API suggestWorkOrders player=${view.playerId}',
+    );
     return suggestion.suggestWorkOrders(view, game, topology, currentOrders);
   }
 
@@ -40,7 +44,9 @@ class DefaultOrderSuggestionAPI implements suggestion.OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    _log.i('logic: order suggestion API suggestBuildOrders player=${view.playerId}');
+    _log.i(
+      'logic: order suggestion API suggestBuildOrders player=${view.playerId}',
+    );
     return suggestion.suggestBuildOrders(view, game, topology, currentOrders);
   }
 
@@ -51,8 +57,15 @@ class DefaultOrderSuggestionAPI implements suggestion.OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    _log.i('logic: order suggestion API suggestResearchOrders player=${view.playerId}');
-    return suggestion.suggestResearchOrders(view, game, topology, currentOrders);
+    _log.i(
+      'logic: order suggestion API suggestResearchOrders player=${view.playerId}',
+    );
+    return suggestion.suggestResearchOrders(
+      view,
+      game,
+      topology,
+      currentOrders,
+    );
   }
 
   @override
@@ -62,8 +75,15 @@ class DefaultOrderSuggestionAPI implements suggestion.OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    _log.i('logic: order suggestion API suggestNavalMoveOrders player=${view.playerId}');
-    return suggestion.suggestNavalMoveOrders(view, game, topology, currentOrders);
+    _log.i(
+      'logic: order suggestion API suggestNavalMoveOrders player=${view.playerId}',
+    );
+    return suggestion.suggestNavalMoveOrders(
+      view,
+      game,
+      topology,
+      currentOrders,
+    );
   }
 
   @override
@@ -73,8 +93,15 @@ class DefaultOrderSuggestionAPI implements suggestion.OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    _log.i('logic: order suggestion API suggestNavalMissionOrders player=${view.playerId}');
-    return suggestion.suggestNavalMissionOrders(view, game, topology, currentOrders);
+    _log.i(
+      'logic: order suggestion API suggestNavalMissionOrders player=${view.playerId}',
+    );
+    return suggestion.suggestNavalMissionOrders(
+      view,
+      game,
+      topology,
+      currentOrders,
+    );
   }
 
   @override
@@ -84,7 +111,14 @@ class DefaultOrderSuggestionAPI implements suggestion.OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) {
-    _log.i('logic: order suggestion API suggestDiplomaticOrders player=${view.playerId}');
-    return suggestion.suggestDiplomaticOrders(view, game, topology, currentOrders);
+    _log.i(
+      'logic: order suggestion API suggestDiplomaticOrders player=${view.playerId}',
+    );
+    return suggestion.suggestDiplomaticOrders(
+      view,
+      game,
+      topology,
+      currentOrders,
+    );
   }
 }

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -1,8 +1,8 @@
 import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import '../constants.dart';
 import '../dossier/event_dialogue.dart';
@@ -14,7 +14,7 @@ import '../world/province_lookup.dart';
 import '../world/tile_control.dart';
 import '../world/unit_lookup.dart';
 
-final Logger _log = Logger();
+final _log = logicLogger();
 
 /// Counter-spy: per-turn kill chance = (friendlySpies * [counterSpyKillChancePercentPerSpy])%,
 /// capped at [counterSpyKillChanceCapPercent]%. SPEC: work order resolution.
@@ -38,8 +38,10 @@ Game clearUnitCurrentWork(Game game, String unitId) {
   final inNew = newUnits.where((u) => u.id == unitId).firstOrNull;
   final unit = inOld ?? inNew;
   if (unit == null || unit.currentWork == null) return game;
-  final cleared =
-      unit.copyWith(clearCurrentWork: true, status: UnitStatus.idle);
+  final cleared = unit.copyWith(
+    clearCurrentWork: true,
+    status: UnitStatus.idle,
+  );
   if (inOld != null) {
     final list = oldUnits.map((u) => u.id == unitId ? cleared : u).toList();
     final newOldWorld = RegionData(
@@ -129,19 +131,23 @@ void _runBuildPhase(_BuildWorkState state) {
         // Only add ship when capital is sea-bound (has a port). SPEC/game/ships-and-naval.md.
         if (state.topology == null) continue;
         final seaZoneAtCap = seaZoneIdForProvince(
-            state.topology!, ProvinceId.localIdFrom(capProvinceId),
-            regionId: regionId);
+          state.topology!,
+          ProvinceId.localIdFrom(capProvinceId),
+          regionId: regionId,
+        );
         if (seaZoneAtCap == null) continue;
 
         var fleets = List<Fleet>.from(state.game.worldState.fleets);
         final homeFleetId = homeFleetIdFor(player.id);
-        final existing = fleets
-            .indexWhere((f) => f.id == homeFleetId && f.ownerId == player.id);
+        final existing = fleets.indexWhere(
+          (f) => f.id == homeFleetId && f.ownerId == player.id,
+        );
         if (existing >= 0) {
           final f = fleets[existing];
           fleets = List<Fleet>.from(fleets)
-            ..[existing] =
-                f.copyWith(shipTypeIds: [...f.shipTypeIds, order.unitType]);
+            ..[existing] = f.copyWith(
+              shipTypeIds: [...f.shipTypeIds, order.unitType],
+            );
         } else {
           fleets = [
             ...fleets,
@@ -152,7 +158,7 @@ void _runBuildPhase(_BuildWorkState state) {
               inPortAtProvinceId: capProvinceId,
               regionId: regionId,
               shipTypeIds: [order.unitType],
-            )
+            ),
           ];
         }
         state.game = state.game.copyWith(
@@ -167,16 +173,17 @@ void _runBuildPhase(_BuildWorkState state) {
           state.game.worldState.tileKeysByRegionAndProvince;
       final firstTileInSpawn =
           tileKeysByRegion[regionId]?[spawnProvinceId]?.isNotEmpty == true
-              ? tileKeysByRegion[regionId]![spawnProvinceId]!.first
-              : null;
+          ? tileKeysByRegion[regionId]![spawnProvinceId]!.first
+          : null;
 
       final newUnit = Unit(
         id: _buildUnitId(player.id, order),
         type: order.unitType,
         ownerId: player.id,
         provinceId: spawnProvinceId,
-        tileKey:
-            category == BuildUnitCategory.civilian ? firstTileInSpawn : null,
+        tileKey: category == BuildUnitCategory.civilian
+            ? firstTileInSpawn
+            : null,
       );
 
       if (regionId == kRegionNewWorld) {
@@ -189,13 +196,15 @@ void _runBuildPhase(_BuildWorkState state) {
     // Apply build-phase deductions to this player so _runWorkPhase sees updated state.
     state.game = state.game.copyWith(
       players: state.game.players
-          .map((p) => p.id == player.id
-              ? p.copyWith(
-                  stockpile: stockpile,
-                  workerPool: workers,
-                  treasury: treasury,
-                )
-              : p)
+          .map(
+            (p) => p.id == player.id
+                ? p.copyWith(
+                    stockpile: stockpile,
+                    workerPool: workers,
+                    treasury: treasury,
+                  )
+                : p,
+          )
           .toList(),
     );
   }
@@ -231,17 +240,23 @@ Game applyBuildAndWorkOrders(
     tileMapByRegion: tileMapByRegion,
     onDialogue: onDialogue,
     oldUnitsById: Map<String, Unit>.from(
-        unitsByIdFromRegion(game.worldState.oldWorld)),
+      unitsByIdFromRegion(game.worldState.oldWorld),
+    ),
     newUnitsById: Map<String, Unit>.from(
-        unitsByIdFromRegion(game.worldState.newWorld)),
+      unitsByIdFromRegion(game.worldState.newWorld),
+    ),
     tileState: game.worldState.tileState,
     visibilityByTile: Map<String, Map<String, String>>.from(
-        game.worldState.playerVisibilityByTile.map(
-            (k, v) => MapEntry(k, Map<String, String>.from(v)))),
-    portsByProvinceSeaboard:
-        Map<String, String>.from(game.worldState.portsByProvinceSeaboard),
-    purchasedTilesByTileKey:
-        Map<String, String>.from(game.worldState.purchasedTilesByTileKey),
+      game.worldState.playerVisibilityByTile.map(
+        (k, v) => MapEntry(k, Map<String, String>.from(v)),
+      ),
+    ),
+    portsByProvinceSeaboard: Map<String, String>.from(
+      game.worldState.portsByProvinceSeaboard,
+    ),
+    purchasedTilesByTileKey: Map<String, String>.from(
+      game.worldState.purchasedTilesByTileKey,
+    ),
     oldProvinces: List<Province>.from(game.worldState.oldWorld.provinces),
     newProvinces: List<Province>.from(game.worldState.newWorld.provinces),
   );
@@ -258,7 +273,10 @@ Game applyBuildAndWorkOrders(
     final fullProvinceId = parts.length > 1
         ? ProvinceId.full(regionIdFromWork, provinceId)
         : u.locationProvinceId;
-    final tileKeys = s.game.worldState
+    final tileKeys =
+        s
+            .game
+            .worldState
             .tileKeysByRegionAndProvince[regionIdFromWork]?[fullProvinceId] ??
         [];
     final playerId = u.ownerId;
@@ -266,48 +284,61 @@ Game applyBuildAndWorkOrders(
     for (final tk in tileKeys) {
       vis[tk] = VisibilityLevel.fullyVisible.name;
     }
-    s.visibilityByTile = Map<String, Map<String, String>>.from(s.visibilityByTile)
-      ..[playerId] = vis;
+    s.visibilityByTile = Map<String, Map<String, String>>.from(
+      s.visibilityByTile,
+    )..[playerId] = vis;
   }
 
   void applyCompletedWorkTarget(
-      _BuildWorkState s,
-      Unit u,
-      CurrentWork cw,
-      List<Province> Function() getProvinces,
-      void Function(List<Province>) setProvinces) {
+    _BuildWorkState s,
+    Unit u,
+    CurrentWork cw,
+    List<Province> Function() getProvinces,
+    void Function(List<Province>) setProvinces,
+  ) {
     _log.d(
-        'logic: work completed unit=${u.id} workTarget=${cw.workTarget} tileKey=${cw.tileKey}');
+      'logic: work completed unit=${u.id} workTarget=${cw.workTarget} tileKey=${cw.tileKey}',
+    );
     switch (cw.workTarget) {
       case 'build_improvement':
         final level = s.tileState.improvementLevel(cw.tileKey);
-        s.tileState =
-            s.tileState.setImprovement(cw.tileKey, (level + 1).clamp(0, 4));
+        s.tileState = s.tileState.setImprovement(
+          cw.tileKey,
+          (level + 1).clamp(0, 4),
+        );
         break;
       case 'upgrade_town':
         final provinces = getProvinces();
         final idx = provinces.indexWhere((p) => p.id == u.locationProvinceId);
         if (idx >= 0) {
           final p = provinces[idx];
-          setProvinces(List<Province>.from(provinces)
-            ..[idx] = p.copyWith(
-                townDevelopmentLevel:
-                    (p.townDevelopmentLevel + 1).clamp(0, 4)));
+          setProvinces(
+            List<Province>.from(provinces)
+              ..[idx] = p.copyWith(
+                townDevelopmentLevel: (p.townDevelopmentLevel + 1).clamp(0, 4),
+              ),
+          );
         }
         break;
       case 'explore':
         applyExploreCompletion(
-            s, u, ProvinceId.regionIdFrom(u.locationProvinceId));
+          s,
+          u,
+          ProvinceId.regionIdFrom(u.locationProvinceId),
+        );
         break;
       case 'build_road':
         {
           final roadLevel = s.tileState.roadLevel(cw.tileKey);
-          final player =
-              s.game.players.where((p) => p.id == u.ownerId).firstOrNull;
+          final player = s.game.players
+              .where((p) => p.id == u.ownerId)
+              .firstOrNull;
           final hasRoadConstruction =
               player?.techUnlocked?['road_construction'] == true;
-          final nextLevel =
-              (roadLevel + 1).clamp(0, hasRoadConstruction ? 2 : 1);
+          final nextLevel = (roadLevel + 1).clamp(
+            0,
+            hasRoadConstruction ? 2 : 1,
+          );
           s.tileState = s.tileState.setRoadLevel(cw.tileKey, nextLevel);
 
           final tileMap = s.tileMapByRegion;
@@ -334,10 +365,14 @@ Game applyBuildAndWorkOrders(
               ? parts[1]
               : ProvinceId.localIdFrom(u.locationProvinceId);
           final fullProvinceId = ProvinceId.full(regionIdFromTile, localId);
-          final seaZoneId = seaZoneIdForProvince(s.topology!, localId,
-              regionId: regionIdFromTile);
+          final seaZoneId = seaZoneIdForProvince(
+            s.topology!,
+            localId,
+            regionId: regionIdFromTile,
+          );
           if (seaZoneId != null) {
-            s.portsByProvinceSeaboard['$fullProvinceId|$seaZoneId'] = cw.tileKey;
+            s.portsByProvinceSeaboard['$fullProvinceId|$seaZoneId'] =
+                cw.tileKey;
             s.tileState = s.tileState.setRoadLevel(cw.tileKey, 4);
           }
         }
@@ -348,14 +383,16 @@ Game applyBuildAndWorkOrders(
           final idx = provinces.indexWhere((p) => p.id == u.locationProvinceId);
           if (idx >= 0) {
             final p = provinces[idx];
-            setProvinces(List<Province>.from(provinces)
-              ..[idx] = p.copyWith(fortLevel: (p.fortLevel + 1).clamp(0, 3)));
+            setProvinces(
+              List<Province>.from(provinces)
+                ..[idx] = p.copyWith(fortLevel: (p.fortLevel + 1).clamp(0, 3)),
+            );
           }
           if (s.topology != null && s.onDialogue != null) {
-            final seed = ((s.game.globalGameSeed ?? 0) ^
-                    (s.game.worldState.turnState.turnNumber *
-                        0x9E3779B1))
-                .toInt();
+            final seed =
+                ((s.game.globalGameSeed ?? 0) ^
+                        (s.game.worldState.turnState.turnNumber * 0x9E3779B1))
+                    .toInt();
             final events = dialogueEventsForReactiveFortsOnBorder(
               s.game,
               s.topology!,
@@ -385,8 +422,10 @@ Game applyBuildAndWorkOrders(
     void Function(List<Province>) setProvinces,
   ) {
     final rand = s.game.globalGameSeed != null
-        ? Random(s.game.globalGameSeed! +
-            (s.game.worldState.turnState.turnNumber * 1000))
+        ? Random(
+            s.game.globalGameSeed! +
+                (s.game.worldState.turnState.turnNumber * 1000),
+          )
         : Random();
     // Iterate over a snapshot to allow updating unitsById during the loop.
     for (final entry in unitsById.entries.toList()) {
@@ -397,20 +436,26 @@ Game applyBuildAndWorkOrders(
       final purchasedByTile = s.game.worldState.purchasedTilesByTileKey;
       if (purchasedByTile.containsKey(cw.tileKey) &&
           purchasedByTile[cw.tileKey] != u.ownerId) {
-        unitsById[entry.key] =
-            u.copyWith(status: UnitStatus.idle, clearCurrentWork: true);
+        unitsById[entry.key] = u.copyWith(
+          status: UnitStatus.idle,
+          clearCurrentWork: true,
+        );
         _log.d(
-            'logic: work cancelled unit=${u.id} reason=tile no longer owned tileKey=${cw.tileKey}');
+          'logic: work cancelled unit=${u.id} reason=tile no longer owned tileKey=${cw.tileKey}',
+        );
         continue;
       }
       // Cancel work if tile no longer under player control (conquest or purchase reverted). SPEC #376.
       // Use same rule as validation: owned province or purchased tile; skip for counter_spy/steal_tech.
       if (cw.workTarget != 'counter_spy' && cw.workTarget != 'steal_tech') {
         if (!isTileControlledByPlayer(s.game, u.ownerId, cw.tileKey)) {
-          unitsById[entry.key] =
-              u.copyWith(status: UnitStatus.idle, clearCurrentWork: true);
+          unitsById[entry.key] = u.copyWith(
+            status: UnitStatus.idle,
+            clearCurrentWork: true,
+          );
           _log.d(
-              'logic: work cancelled unit=${u.id} reason=tile no longer under control tileKey=${cw.tileKey}');
+            'logic: work cancelled unit=${u.id} reason=tile no longer under control tileKey=${cw.tileKey}',
+          );
           continue;
         }
       }
@@ -418,14 +463,19 @@ Game applyBuildAndWorkOrders(
         // Per-turn: N% per friendly spy (cap M%) to kill one enemy spy in province
         final provinceId = u.locationProvinceId;
         final friendlySpies = unitsById.values
-            .where((x) =>
-                x.ownerId == u.ownerId &&
-                isSpyUnit(x.type) &&
-                x.currentWork?.workTarget == 'counter_spy' &&
-                x.locationProvinceId == provinceId)
+            .where(
+              (x) =>
+                  x.ownerId == u.ownerId &&
+                  isSpyUnit(x.type) &&
+                  x.currentWork?.workTarget == 'counter_spy' &&
+                  x.locationProvinceId == provinceId,
+            )
             .length;
-        final killChance = (friendlySpies * counterSpyKillChancePercentPerSpy)
-            .clamp(0, counterSpyKillChanceCapPercent) /
+        final killChance =
+            (friendlySpies * counterSpyKillChancePercentPerSpy).clamp(
+              0,
+              counterSpyKillChanceCapPercent,
+            ) /
             100.0;
         final enemySpies = unitsById.entries.where((e) {
           final x = e.value;
@@ -448,12 +498,14 @@ Game applyBuildAndWorkOrders(
         if (cw.workTarget == 'steal_tech') {
           final targetProvinceId = Unit.provinceIdFromTileKey(cw.tileKey);
           final otherPlayer = s.game.players
-              .where((p) =>
-                  p.id != u.ownerId && p.capitalProvinceId == targetProvinceId)
+              .where(
+                (p) =>
+                    p.id != u.ownerId &&
+                    p.capitalProvinceId == targetProvinceId,
+              )
               .firstOrNull;
           if (otherPlayer != null) {
-            final ourTech =
-                s.game.playerById(u.ownerId)?.techUnlocked ?? {};
+            final ourTech = s.game.playerById(u.ownerId)?.techUnlocked ?? {};
             final theirTech = otherPlayer.techUnlocked ?? {};
             final missing = theirTech.entries
                 .where((e) => e.value == true && ourTech[e.key] != true)
@@ -465,14 +517,16 @@ Game applyBuildAndWorkOrders(
                   .where((p) => p.id == u.ownerId)
                   .firstOrNull;
               if (player != null) {
-                final updated =
-                    Map<String, bool>.from(player.techUnlocked ?? {})
-                      ..[granted] = true;
+                final updated = Map<String, bool>.from(
+                  player.techUnlocked ?? {},
+                )..[granted] = true;
                 s.game = s.game.copyWith(
                   players: s.game.players
-                      .map((p) => p.id == u.ownerId
-                          ? p.copyWith(techUnlocked: updated)
-                          : p)
+                      .map(
+                        (p) => p.id == u.ownerId
+                            ? p.copyWith(techUnlocked: updated)
+                            : p,
+                      )
                       .toList(),
                 );
               }
@@ -481,8 +535,10 @@ Game applyBuildAndWorkOrders(
         } else {
           applyCompletedWorkTarget(s, u, cw, getProvinces, setProvinces);
         }
-        unitsById[entry.key] =
-            u.copyWith(status: UnitStatus.idle, clearCurrentWork: true);
+        unitsById[entry.key] = u.copyWith(
+          status: UnitStatus.idle,
+          clearCurrentWork: true,
+        );
       } else {
         unitsById[entry.key] = u.copyWith(
           currentWork: cw.copyWith(remainingTurns: nextRemaining),
@@ -494,9 +550,17 @@ Game applyBuildAndWorkOrders(
   _runWorkPhase(state, applyExploreCompletion, applyCompletedWorkTarget);
 
   processWorkUnits(
-      state, state.oldUnitsById, () => state.oldProvinces, (p) => state.oldProvinces = p);
+    state,
+    state.oldUnitsById,
+    () => state.oldProvinces,
+    (p) => state.oldProvinces = p,
+  );
   processWorkUnits(
-      state, state.newUnitsById, () => state.newProvinces, (p) => state.newProvinces = p);
+    state,
+    state.newUnitsById,
+    () => state.newProvinces,
+    (p) => state.newProvinces = p,
+  );
 
   state.game = state.game.copyWith(
     worldState: state.game.worldState.copyWith(
@@ -505,11 +569,13 @@ Game applyBuildAndWorkOrders(
       portsByProvinceSeaboard: state.portsByProvinceSeaboard,
       purchasedTilesByTileKey: state.purchasedTilesByTileKey,
       oldWorld: RegionData(
-          provinces: state.oldProvinces,
-          units: state.oldUnitsById.values.toList()),
+        provinces: state.oldProvinces,
+        units: state.oldUnitsById.values.toList(),
+      ),
       newWorld: RegionData(
-          provinces: state.newProvinces,
-          units: state.newUnitsById.values.toList()),
+        provinces: state.newProvinces,
+        units: state.newUnitsById.values.toList(),
+      ),
     ),
   );
 
@@ -518,11 +584,13 @@ Game applyBuildAndWorkOrders(
     worldState: state.game.worldState.copyWith(
       purchasedTilesByTileKey: state.purchasedTilesByTileKey,
       oldWorld: RegionData(
-          provinces: state.game.worldState.oldWorld.provinces,
-          units: state.oldUnitsById.values.toList()),
+        provinces: state.game.worldState.oldWorld.provinces,
+        units: state.oldUnitsById.values.toList(),
+      ),
       newWorld: RegionData(
-          provinces: state.game.worldState.newWorld.provinces,
-          units: state.newUnitsById.values.toList()),
+        provinces: state.game.worldState.newWorld.provinces,
+        units: state.newUnitsById.values.toList(),
+      ),
     ),
   );
 }
@@ -530,8 +598,14 @@ Game applyBuildAndWorkOrders(
 void _runWorkPhase(
   _BuildWorkState state,
   void Function(_BuildWorkState, Unit, String) applyExploreCompletion,
-  void Function(_BuildWorkState, Unit, CurrentWork,
-      List<Province> Function(), void Function(List<Province>)) applyCompletedWorkTarget,
+  void Function(
+    _BuildWorkState,
+    Unit,
+    CurrentWork,
+    List<Province> Function(),
+    void Function(List<Province>),
+  )
+  applyCompletedWorkTarget,
 ) {
   final workOrders = state.workOrders;
   final tileState = state.tileState;
@@ -589,18 +663,23 @@ void _runWorkPhase(
         String target,
         bool Function(String) allowedForUnitType,
         WorkOrderCost? Function() costFn,
-        int Function() totalTurnsFn
-      }) workTargetConfig(String target) {
+        int Function() totalTurnsFn,
+      })
+      workTargetConfig(String target) {
         switch (target) {
           case 'build_improvement':
             return (
               target: target,
               allowedForUnitType: (t) =>
                   isWorkOrderTargetAllowedForUnitType(t, target),
-              costFn: () => workOrderMaterialCost(target,
-                  improvementLevel: tileState.improvementLevel(targetTileKey)),
-              totalTurnsFn: () => totalTurnsForWork(target,
-                  improvementLevel: tileState.improvementLevel(targetTileKey)),
+              costFn: () => workOrderMaterialCost(
+                target,
+                improvementLevel: tileState.improvementLevel(targetTileKey),
+              ),
+              totalTurnsFn: () => totalTurnsForWork(
+                target,
+                improvementLevel: tileState.improvementLevel(targetTileKey),
+              ),
             );
           case 'build_road':
             return (
@@ -678,19 +757,21 @@ void _runWorkPhase(
         final totalTurns = config.totalTurnsFn();
 
         _log.d(
-            'logic: work order accepted and assigned unit=${order.unitId} target=$orderTarget targetTileKey=$targetTileKey totalTurns=$totalTurns');
+          'logic: work order accepted and assigned unit=${order.unitId} target=$orderTarget targetTileKey=$targetTileKey totalTurns=$totalTurns',
+        );
         updateUnit(
-            order.unitId,
-            u.copyWith(
-              status: UnitStatus.working,
+          order.unitId,
+          u.copyWith(
+            status: UnitStatus.working,
+            tileKey: targetTileKey,
+            currentWork: CurrentWork(
+              workTarget: orderTarget,
               tileKey: targetTileKey,
-              currentWork: CurrentWork(
-                workTarget: orderTarget,
-                tileKey: targetTileKey,
-                totalTurns: totalTurns,
-                remainingTurns: totalTurns,
-              ),
-            ));
+              totalTurns: totalTurns,
+              remainingTurns: totalTurns,
+            ),
+          ),
+        );
         return true;
       }
 
@@ -699,7 +780,8 @@ void _runWorkPhase(
           hasValidTarget) {
         // SPEC/game/diplomacy.md (GP–Minor/Tribe Rules): purchase_land requires an Embassy
         // with the Minor/Tribe and the buyer must not be at war with that faction.
-        final resourceId = state.game.worldState.resourceByTileKey[targetTileKey];
+        final resourceId =
+            state.game.worldState.resourceByTileKey[targetTileKey];
         if (resourceId != null) {
           final provinceId =
               Unit.provinceIdFromTileKey(targetTileKey) ?? u.locationProvinceId;
@@ -744,19 +826,21 @@ void _runWorkPhase(
           hasValidTarget) {
         const totalTurns = 5;
         _log.d(
-            'logic: work order accepted and assigned unit=${order.unitId} target=steal_tech targetTileKey=$targetTileKey totalTurns=$totalTurns');
+          'logic: work order accepted and assigned unit=${order.unitId} target=steal_tech targetTileKey=$targetTileKey totalTurns=$totalTurns',
+        );
         updateUnit(
-            order.unitId,
-            u.copyWith(
-              status: UnitStatus.working,
+          order.unitId,
+          u.copyWith(
+            status: UnitStatus.working,
+            tileKey: targetTileKey,
+            currentWork: CurrentWork(
+              workTarget: 'steal_tech',
               tileKey: targetTileKey,
-              currentWork: CurrentWork(
-                workTarget: 'steal_tech',
-                tileKey: targetTileKey,
-                totalTurns: totalTurns,
-                remainingTurns: totalTurns,
-              ),
-            ));
+              totalTurns: totalTurns,
+              remainingTurns: totalTurns,
+            ),
+          ),
+        );
         continue;
       }
 
@@ -766,26 +850,32 @@ void _runWorkPhase(
           hasValidTarget) {
         const totalTurns = 0;
         _log.d(
-            'logic: work order accepted and assigned unit=${order.unitId} target=counter_spy targetTileKey=$targetTileKey totalTurns=$totalTurns');
+          'logic: work order accepted and assigned unit=${order.unitId} target=counter_spy targetTileKey=$targetTileKey totalTurns=$totalTurns',
+        );
         updateUnit(
-            order.unitId,
-            u.copyWith(
-              status: UnitStatus.working,
+          order.unitId,
+          u.copyWith(
+            status: UnitStatus.working,
+            tileKey: targetTileKey,
+            currentWork: CurrentWork(
+              workTarget: 'counter_spy',
               tileKey: targetTileKey,
-              currentWork: CurrentWork(
-                workTarget: 'counter_spy',
-                tileKey: targetTileKey,
-                totalTurns: totalTurns,
-                remainingTurns: 1,
-              ),
-            ));
+              totalTurns: totalTurns,
+              remainingTurns: 1,
+            ),
+          ),
+        );
         continue;
       }
 
       if (order.target == 'prospect' &&
           hasValidTarget &&
           isExplorerUnit(u.type) &&
-          isMineralEligibleTile(state.game, state.tileMapByRegion, targetTileKey)) {
+          isMineralEligibleTile(
+            state.game,
+            state.tileMapByRegion,
+            targetTileKey,
+          )) {
         final existing =
             state.game.worldState.playerProspectedTiles[player.id] ?? const {};
         final newProspected = Set<String>.from(existing)..add(targetTileKey);
@@ -819,19 +909,21 @@ void _runWorkPhase(
           if (maxTiles < 1) maxTiles = 1;
           final totalTurns = (3 * tilesInP / maxTiles).ceil().clamp(1, 999);
           _log.d(
-              'logic: work order accepted and assigned unit=${order.unitId} target=explore targetTileKey=$targetTileKey totalTurns=$totalTurns');
+            'logic: work order accepted and assigned unit=${order.unitId} target=explore targetTileKey=$targetTileKey totalTurns=$totalTurns',
+          );
           updateUnit(
-              order.unitId,
-              u.copyWith(
-                status: UnitStatus.working,
+            order.unitId,
+            u.copyWith(
+              status: UnitStatus.working,
+              tileKey: targetTileKey,
+              currentWork: CurrentWork(
+                workTarget: 'explore',
                 tileKey: targetTileKey,
-                currentWork: CurrentWork(
-                  workTarget: 'explore',
-                  tileKey: targetTileKey,
-                  totalTurns: totalTurns,
-                  remainingTurns: totalTurns,
-                ),
-              ));
+                totalTurns: totalTurns,
+                remainingTurns: totalTurns,
+              ),
+            ),
+          );
           continue;
         }
       }
@@ -848,13 +940,14 @@ void _runWorkPhase(
         if (fortLevel == 1 &&
             player.techUnlocked?['mine_engineering'] != true) {
           _log.d(
-              'logic: build_fort skipped - Mine Engineering required for fort level 2');
+            'logic: build_fort skipped - Mine Engineering required for fort level 2',
+          );
           continue;
         }
-        if (fortLevel == 2 &&
-            player.techUnlocked?['modern_forts'] != true) {
+        if (fortLevel == 2 && player.techUnlocked?['modern_forts'] != true) {
           _log.d(
-              'logic: build_fort skipped - Modern Forts required for fort level 3');
+            'logic: build_fort skipped - Modern Forts required for fort level 3',
+          );
           continue;
         }
         if (applyStandardWorkOrder('build_fort')) continue;
@@ -936,8 +1029,12 @@ void _propagateRoadToAdjacentCapitalOrPort({
     final cellId = tileMap.cell(nx, ny);
 
     // Build the adjacent tile key
-    final adjacentTileKey =
-        CapitalTile.tileKey(targetRegionId, '$targetRegionId|$cellId', nx, ny);
+    final adjacentTileKey = CapitalTile.tileKey(
+      targetRegionId,
+      '$targetRegionId|$cellId',
+      nx,
+      ny,
+    );
 
     // Check if adjacent tile is the player's capital or a port
     final isCapital = adjacentTileKey == capitalTileKey;
@@ -945,7 +1042,8 @@ void _propagateRoadToAdjacentCapitalOrPort({
 
     if (isCapital || isPort) {
       _log.d(
-          'logic: build_road propagating level $nextLevel to adjacent ${isCapital ? "capital" : "port"} tile $adjacentTileKey');
+        'logic: build_road propagating level $nextLevel to adjacent ${isCapital ? "capital" : "port"} tile $adjacentTileKey',
+      );
       final currentLevel = tileState.roadLevel(adjacentTileKey);
       // Only upgrade, never downgrade.
       if (nextLevel > currentLevel) {

--- a/packages/colonizethis_logic/lib/src/setup/game_setup.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup.dart
@@ -5,8 +5,8 @@
 import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import 'capital_choice.dart';
 import '../constants.dart';
@@ -16,7 +16,7 @@ import '../world/naval.dart';
 import 'province_assignment.dart';
 import 'province_name_fallback.dart';
 
-final Logger _log = Logger();
+final _log = logicLogger();
 
 /// Result of game setup: the Game and the map data needed for turn resolution.
 class GameSetupResult {

--- a/packages/colonizethis_logic/lib/src/setup/init_game_orchestrator.dart
+++ b/packages/colonizethis_logic/lib/src/setup/init_game_orchestrator.dart
@@ -4,16 +4,16 @@ import 'dart:typed_data';
 
 import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import '../constants.dart';
 import '../world/unit_lookup.dart';
 import 'game_setup.dart';
 import 'warp_zone_generator.dart';
 
-final Logger _log = Logger();
+final _log = logicLogger();
 
 /// Result of running init game.
 class InitGameResult {
@@ -33,14 +33,19 @@ class InitGameResult {
   final Uint8List mapPngBytes;
   final String markdown;
   final InitGameMapViewData mapViewData;
+
   /// Tile maps per region (e.g. 'oldWorld', 'newWorld'); needed for extraction.
   final Map<String, TileMapResult> tileMapByRegion;
+
   /// Topology per region; used by visualizers and debug tooling.
   final Map<String, MapTopology> topologyByRegion;
+
   /// Single topology with prefixed node ids and warp edges for resolveTurnForGame.
   final MapTopology combinedTopology;
+
   /// Warp zone links between OW and NW. SPEC/game/map-topology.md.
   final List<WarpLink> warpLinks;
+
   /// GP id → (r, g, b) used for map view; ctdev uses this when rebuilding view data.
   final Map<String, (int r, int g, int b)>? greatPowerColorOverride;
 }
@@ -55,12 +60,15 @@ class InitGameOptions {
   });
 
   final int cellSize;
+
   /// When true, forward skipFillLakes to TileMapParams so Pass 4 (fill lakes)
   /// is skipped in tile-map generation for both Old World and New World.
   final bool skipFillLakes;
+
   /// When false, skips PNG rendering inside runInitGame; mapViewData and
   /// markdown are still produced.
   final bool renderPng;
+
   /// Optional GP id → (r, g, b) for map ownership colours; stored on Game and in result.
   final Map<String, (int r, int g, int b)>? greatPowerColorOverride;
 }
@@ -78,7 +86,9 @@ InitGameResult runInitGame({
     );
   }
 
-  _log.i('logic: init game start OW:${config.numProvincesOldWorld} NW:${config.numProvincesNewWorld}');
+  _log.i(
+    'logic: init game start OW:${config.numProvincesOldWorld} NW:${config.numProvincesNewWorld}',
+  );
   // Derive an effective seed: non-zero config seeds are used as-is for
   // reproducible runs; a zero seed means "choose a time-based seed".
   final effectiveSeed = config.seed == 0
@@ -90,7 +100,10 @@ InitGameResult runInitGame({
     seed: effectiveSeed,
     seaFraction: 0.6,
   );
-  final sizeOW = computeGridSizeFromParams(config.numProvincesOldWorld, mapGenParams);
+  final sizeOW = computeGridSizeFromParams(
+    config.numProvincesOldWorld,
+    mapGenParams,
+  );
   final paramsOW = TileMapParams(
     width: sizeOW.width,
     height: sizeOW.height,
@@ -107,7 +120,10 @@ InitGameResult runInitGame({
   );
 
   _log.d('logic: init game generating NW map');
-  final sizeNW = computeGridSizeFromParams(config.numProvincesNewWorld, mapGenParams);
+  final sizeNW = computeGridSizeFromParams(
+    config.numProvincesNewWorld,
+    mapGenParams,
+  );
   final paramsNW = TileMapParams(
     width: sizeNW.width,
     height: sizeNW.height,
@@ -181,9 +197,7 @@ InitGameResult runInitGame({
   );
 
   final mapPngBytes = options.renderPng
-      ? renderInitGameMapToPngFromViewData(
-          viewData: mapViewData,
-        )
+      ? renderInitGameMapToPngFromViewData(viewData: mapViewData)
       : Uint8List(0);
 
   final markdown = formatInitGameSetupMarkdown(setupResult.game);
@@ -195,7 +209,9 @@ InitGameResult runInitGame({
   );
   game = game.copyWith(
     globalGameSeed: effectiveSeed,
-    aiSeedByGpId: {for (final p in game.players) p.id: effectiveSeed + p.id.hashCode},
+    aiSeedByGpId: {
+      for (final p in game.players) p.id: effectiveSeed + p.id.hashCode,
+    },
     greatPowerColorOverride: gpColorOverrideList,
   );
   // Phase 6 full AI: populate hidden agendas before first AI order generation. SPEC: game-setup-pipeline.md step 9, ai-planner.md § Phase 6.
@@ -226,31 +242,40 @@ String formatInitGameSetupMarkdown(Game game) {
   buf.writeln('|---------|------|------------------|-----------------|');
 
   for (final p in game.players) {
-    final owned = game.worldState.oldWorld.provinces
-        .where((pr) => pr.ownerId == p.id)
-        .map((pr) => pr.id)
-        .toList()
-      ..sort();
+    final owned =
+        game.worldState.oldWorld.provinces
+            .where((pr) => pr.ownerId == p.id)
+            .map((pr) => pr.id)
+            .toList()
+          ..sort();
     final capital = p.capitalProvinceId ?? '—';
-    buf.writeln('| ${p.displayName} (${p.id}) | Great Power | $capital | ${owned.join(", ")} |');
+    buf.writeln(
+      '| ${p.displayName} (${p.id}) | Great Power | $capital | ${owned.join(", ")} |',
+    );
   }
   for (final m in game.minorNations) {
-    final owned = game.worldState.oldWorld.provinces
-        .where((pr) => pr.ownerId == m.id)
-        .map((pr) => pr.id)
-        .toList()
-      ..sort();
+    final owned =
+        game.worldState.oldWorld.provinces
+            .where((pr) => pr.ownerId == m.id)
+            .map((pr) => pr.id)
+            .toList()
+          ..sort();
     final capital = m.capitalProvinceId ?? '—';
-    buf.writeln('| ${m.displayName ?? m.id} (${m.id}) | Minor Nation | $capital | ${owned.join(", ")} |');
+    buf.writeln(
+      '| ${m.displayName ?? m.id} (${m.id}) | Minor Nation | $capital | ${owned.join(", ")} |',
+    );
   }
   for (final t in game.tribes) {
-    final owned = game.worldState.newWorld.provinces
-        .where((pr) => pr.ownerId == t.id)
-        .map((pr) => pr.id)
-        .toList()
-      ..sort();
+    final owned =
+        game.worldState.newWorld.provinces
+            .where((pr) => pr.ownerId == t.id)
+            .map((pr) => pr.id)
+            .toList()
+          ..sort();
     final capital = t.capitalProvinceId ?? '—';
-    buf.writeln('| ${t.displayName ?? t.id} (${t.id}) | Tribe | $capital | ${owned.join(", ")} |');
+    buf.writeln(
+      '| ${t.displayName ?? t.id} (${t.id}) | Tribe | $capital | ${owned.join(", ")} |',
+    );
   }
 
   buf.writeln();
@@ -264,11 +289,14 @@ String formatInitGameSetupMarkdown(Game game) {
         .where((e) => e.value > 0)
         .map((e) => '${e.key}:${e.value}')
         .join(', ');
-    final workers = '${p.workerPool.peasants}p/${p.workerPool.apprentices}a/${p.workerPool.journeymen}j/${p.workerPool.masters}m';
-    final units = allUnitsFromWorld(game.worldState)
-        .where((u) => u.ownerId == p.id)
-        .length;
-    buf.writeln('| ${p.displayName} (${p.id}) | ${stock.isEmpty ? "—" : stock} | $workers | ${p.treasury} | $units |');
+    final workers =
+        '${p.workerPool.peasants}p/${p.workerPool.apprentices}a/${p.workerPool.journeymen}j/${p.workerPool.masters}m';
+    final units = allUnitsFromWorld(
+      game.worldState,
+    ).where((u) => u.ownerId == p.id).length;
+    buf.writeln(
+      '| ${p.displayName} (${p.id}) | ${stock.isEmpty ? "—" : stock} | $workers | ${p.treasury} | $units |',
+    );
   }
   for (final m in game.minorNations) {
     buf.writeln('| ${m.displayName ?? m.id} (${m.id}) | — | — | — | — |');

--- a/packages/colonizethis_logic/lib/src/setup/warp_zone_generator.dart
+++ b/packages/colonizethis_logic/lib/src/setup/warp_zone_generator.dart
@@ -4,9 +4,9 @@
 import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:logger/logger.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
-final Logger _log = Logger();
+final _log = logicLogger();
 
 /// Picks one representative sea zone per map edge (top, bottom, left, right).
 /// Returns a map of edge name ('top', 'bottom', 'left', 'right') to sea zone id.
@@ -95,14 +95,18 @@ List<WarpLink> generateWarpZones({
 
   final links = <WarpLink>[];
   for (final edge in commonEdges) {
-    links.add(WarpLink(
-      regionId: regionIdOld,
-      seaZoneId: owZones[edge]!,
-      otherRegionId: regionIdNew,
-      otherSeaZoneId: nwZones[edge]!,
-    ));
+    links.add(
+      WarpLink(
+        regionId: regionIdOld,
+        seaZoneId: owZones[edge]!,
+        otherRegionId: regionIdNew,
+        otherSeaZoneId: nwZones[edge]!,
+      ),
+    );
   }
 
-  _log.d('logic: warp zones: ${links.length} links on edges ${commonEdges.join(", ")}');
+  _log.d(
+    'logic: warp zones: ${links.length} links on edges ${commonEdges.join(", ")}',
+  );
   return links;
 }

--- a/packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
@@ -3,13 +3,13 @@
 // Called from turn_resolver.resolveTurnForGame.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import '../dossier/event_dialogue.dart';
 import '../world/fog_resolution.dart';
 
-final Logger _log = Logger();
+final _log = logicLogger();
 
 /// Runs the end-of-turn phase: victory check, era-change dialogue, Spy timers, fog decay,
 /// coastal sea zone full visibility, advance turn.
@@ -64,7 +64,9 @@ Game runEndOfTurnPhase(
 }
 
 void _emitEraChangeDialogue(
-    Game game, void Function(DialogueEvent)? onDialogue) {
+  Game game,
+  void Function(DialogueEvent)? onDialogue,
+) {
   if (onDialogue == null) return;
   final currentTurn = game.worldState.turnState.turnNumber;
   final nextTurn = currentTurn + 1;
@@ -76,6 +78,7 @@ void _emitEraChangeDialogue(
   final events = dialogueEventsForEraChange(game, previousEra, newEra, seed);
   for (final e in events) onDialogue(e);
 }
+
 /// Returns the id of a Great Power that controls 31+ Old World provinces, or null.
 String? findMilitaryVictoryWinner(Game game) {
   const int requiredProvinces = 31;

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -1,6 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import '../event_bus/game_event_bus.dart';
 import '../game_events.dart';
@@ -35,7 +35,7 @@ import 'end_of_turn_resolver.dart';
 import 'turn_resolution_events.dart';
 import 'turn_resolution_result.dart';
 
-final Logger _log = Logger();
+final _log = logicLogger();
 
 /// Resolution sequence. SPEC/program/turn-resolution-phases.md
 const List<TurnPhase> turnResolutionSequence = [

--- a/packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
+++ b/packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
@@ -1,12 +1,12 @@
-import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:logger/logger.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
 import '../setup/capital_choice.dart';
 import '../world/province_lookup.dart';
 
-final Logger _log = Logger();
+final _log = logicLogger();
 
 Game applyCapitalReassignmentAfterCombat(
   Game state,
@@ -22,8 +22,9 @@ Game applyCapitalReassignmentAfterCombat(
     final regionTopology = topologyByRegion?[regionId] ?? topology;
     final region = regionDataForId(state.worldState, regionId);
     if (region == null) continue;
-    final province =
-        region.provinces.where((p) => p.id == capProvinceId).firstOrNull;
+    final province = region.provinces
+        .where((p) => p.id == capProvinceId)
+        .firstOrNull;
     if (province == null) continue;
     if (province.ownerId == player.id) continue;
 
@@ -38,7 +39,8 @@ Game applyCapitalReassignmentAfterCombat(
       }).toList();
       game = game.copyWith(players: updatedPlayers);
       _log.i(
-          'logic: player ${player.id} lost capital and has no provinces in $regionId; capital cleared');
+        'logic: player ${player.id} lost capital and has no provinces in $regionId; capital cleared',
+      );
       continue;
     }
     final tileMap = tileMapByRegion[regionId];
@@ -60,10 +62,14 @@ Game applyCapitalReassignmentAfterCombat(
         tileMapByRegion: tileMapByRegion,
       );
       _log.i(
-          'logic: player ${player.id} capital reassigned to $newProvinceId after loss');
+        'logic: player ${player.id} capital reassigned to $newProvinceId after loss',
+      );
     } catch (e, st) {
-      _log.w('logic: capital reassignment failed for ${player.id}',
-          error: e, stackTrace: st);
+      _log.w(
+        'logic: capital reassignment failed for ${player.id}',
+        error: e,
+        stackTrace: st,
+      );
     }
   }
   return game;
@@ -110,15 +116,14 @@ Game applyGreatPowerFall(
 
     RegionData transferRegion(RegionData region) {
       final updatedProvinces = region.provinces
-          .map((p) =>
-              p.ownerId == playerId ? p.copyWith(ownerId: conquerorId) : p)
+          .map(
+            (p) => p.ownerId == playerId ? p.copyWith(ownerId: conquerorId) : p,
+          )
           .toList();
-      final remainingUnits =
-          region.units.where((u) => u.ownerId != playerId).toList();
-      return RegionData(
-        provinces: updatedProvinces,
-        units: remainingUnits,
-      );
+      final remainingUnits = region.units
+          .where((u) => u.ownerId != playerId)
+          .toList();
+      return RegionData(provinces: updatedProvinces, units: remainingUnits);
     }
 
     final newOldWorld = transferRegion(game.worldState.oldWorld);
@@ -135,13 +140,14 @@ Game applyGreatPowerFall(
         fleets: remainingFleets,
       ),
       players: game.players
-          .map((p) => p.id == playerId
-              ? p.copyWith(capitalProvinceId: null, capitalTile: null)
-              : p)
+          .map(
+            (p) => p.id == playerId
+                ? p.copyWith(capitalProvinceId: null, capitalTile: null)
+                : p,
+          )
           .toList(),
     );
   }
 
   return game;
 }
-

--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -1,13 +1,13 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import 'naval.dart';
 import 'province_lookup.dart';
 import 'topology_helpers.dart';
 import '../diplomacy/diplomacy_relation_lookup.dart';
 
-final Logger _log = Logger();
+final _log = logicLogger();
 
 /// Result of connectivity resolution: connected tile set and per-tile path transport cap.
 /// SPEC/game/capital-and-connectivity, extraction-and-improvements: effective yield is
@@ -36,7 +36,10 @@ class ConnectivityResult {
 /// A province is blockaded for its owner when an **enemy fleet at sea** (at war) is on Blockade
 /// mission targeting it and the fleet's sea zone is **adjacent to that province's port**.
 /// SPEC/game/capital-and-connectivity.md § Blockade.
-Map<String, Set<String>> computeBlockadedPortProvincesByPlayer(Game game, MapTopology topology) {
+Map<String, Set<String>> computeBlockadedPortProvincesByPlayer(
+  Game game,
+  MapTopology topology,
+) {
   final result = <String, Set<String>>{};
   for (final player in game.players) {
     result[player.id] = {};
@@ -48,7 +51,10 @@ Map<String, Set<String>> computeBlockadedPortProvincesByPlayer(Game game, MapTop
     final targetProvinceId = fleet.targetProvinceId;
     if (targetProvinceId == null || targetProvinceId.isEmpty) continue;
     if (!ProvinceId.isPrefixed(targetProvinceId)) continue;
-    final adjacentSeaZones = seaZoneIdsAdjacentToProvince(topology, targetProvinceId);
+    final adjacentSeaZones = seaZoneIdsAdjacentToProvince(
+      topology,
+      targetProvinceId,
+    );
     if (!adjacentSeaZones.contains(fleet.seaZoneId)) continue;
     final province = tryGetProvince(game.worldState, targetProvinceId);
     final ownerId = province?.ownerId;
@@ -70,16 +76,21 @@ Map<String, ConnectivityResult> resolveConnectivity({
   required MapTopology topology,
   Map<String, Set<String>>? blockadedPortProvincesByPlayerId,
 }) {
-  _log.d('logic: connectivity resolve start players=${game.players.length} regions=${tileMapByRegion.keys.join(",")}');
+  _log.d(
+    'logic: connectivity resolve start players=${game.players.length} regions=${tileMapByRegion.keys.join(",")}',
+  );
   final provinceIdsByType = provinceNodeIds(topology);
   final blockadedByPlayer =
-      blockadedPortProvincesByPlayerId ?? computeBlockadedPortProvincesByPlayer(game, topology);
+      blockadedPortProvincesByPlayerId ??
+      computeBlockadedPortProvincesByPlayer(game, topology);
   final result = <String, ConnectivityResult>{};
 
   for (final player in game.players) {
     final capital = player.capitalTile;
     if (capital == null || player.capitalProvinceId == null) {
-      _log.d('logic: connectivity resolve player=${player.id} skipped (no capital)');
+      _log.d(
+        'logic: connectivity resolve player=${player.id} skipped (no capital)',
+      );
       result[player.id] = ConnectivityResult(connected: {});
       continue;
     }
@@ -146,7 +157,10 @@ Set<String> _seaZonesReachableBySeaPath(
 }
 
 /// Sea zone ids adjacent to province [localProvinceId] in topology (P–S edges).
-Set<String> _seaZonesAdjacentToProvince(MapTopology topology, String localProvinceId) {
+Set<String> _seaZonesAdjacentToProvince(
+  MapTopology topology,
+  String localProvinceId,
+) {
   final seaZoneIds = topology.nodes
       .where((n) => n.type == TopologyNodeType.seaZone)
       .map((n) => n.id)
@@ -255,13 +269,21 @@ ConnectivityResult _connectedTilesForPlayer({
     final map = tileMapByRegion[regionId];
     if (map == null) continue;
 
-    final hasRoadOrPort = (tileState.roadLevel(key) > 0) || portInfo.containsKey(key);
+    final hasRoadOrPort =
+        (tileState.roadLevel(key) > 0) || portInfo.containsKey(key);
     final canExpand = (key == capitalKey) || hasRoadOrPort;
 
     if (!canExpand) continue;
 
     final bottleneckU = pathCap[key] ?? 0;
-    for (final n in _adjacentTileKeys(regionId, localProvinceId, x, y, map, provinceIdsByType)) {
+    for (final n in _adjacentTileKeys(
+      regionId,
+      localProvinceId,
+      x,
+      y,
+      map,
+      provinceIdsByType,
+    )) {
       final transportN = _transportLevelAtTile(worldState, n);
       final candidate = bottleneckU < transportN ? bottleneckU : transportN;
       final existing = pathCap[n] ?? -1;
@@ -292,7 +314,9 @@ ConnectivityResult _connectedTilesForPlayer({
   }
 
   final seaConnectedPortKeys = <String>{};
-  final capitalProvinceBlockaded = blockadedPortProvinces.contains(capital.provinceId);
+  final capitalProvinceBlockaded = blockadedPortProvinces.contains(
+    capital.provinceId,
+  );
   final capitalOnSeaboard = _isCapitalTileOnSeaboard(
     capital,
     tileMapByRegion,
@@ -303,14 +327,21 @@ ConnectivityResult _connectedTilesForPlayer({
     final provinceIdForLookup = prefixedTopology
         ? capital.provinceId
         : ProvinceId.localIdFrom(capital.provinceId);
-    final capitalSeaZones = _seaZonesAdjacentToProvince(topology, provinceIdForLookup);
+    final capitalSeaZones = _seaZonesAdjacentToProvince(
+      topology,
+      provinceIdForLookup,
+    );
     final seaReachable = _seaZonesReachableBySeaPath(topology, capitalSeaZones);
     for (final e in worldState.portsByProvinceSeaboard.entries) {
       final provSea = e.key;
       final tileKey = e.value;
       final parts = provSea.split('|');
-      final seaZoneId = parts.length >= 3 ? parts[2] : (parts.length >= 2 ? parts[1] : null);
-      final fullProvinceId = parts.length >= 3 ? '${parts[0]}|${parts[1]}' : (parts.length >= 2 ? parts[0] : null);
+      final seaZoneId = parts.length >= 3
+          ? parts[2]
+          : (parts.length >= 2 ? parts[1] : null);
+      final fullProvinceId = parts.length >= 3
+          ? '${parts[0]}|${parts[1]}'
+          : (parts.length >= 2 ? parts[0] : null);
       if (seaZoneId == null || fullProvinceId == null) continue;
       if (blockadedPortProvinces.contains(fullProvinceId)) continue;
       final seaZoneIdForReachable = prefixedTopology && parts.length >= 3
@@ -324,7 +355,9 @@ ConnectivityResult _connectedTilesForPlayer({
     for (final portKey in capitalRegionPortKeys) {
       final parts = portKey.split('|');
       if (parts.length >= 2) {
-        final fullProvinceId = parts.length >= 3 ? '${parts[0]}|${parts[1]}' : parts[0];
+        final fullProvinceId = parts.length >= 3
+            ? '${parts[0]}|${parts[1]}'
+            : parts[0];
         if (!blockadedPortProvinces.contains(fullProvinceId)) {
           seaConnectedPortKeys.add(portKey);
         }
@@ -363,7 +396,8 @@ ConnectivityResult _connectedTilesForPlayer({
     final y = int.tryParse(parts[3]) ?? -1;
     if (x < 0 || y < 0) continue;
 
-    final hasRoadOrPort = (tileState.roadLevel(key) > 0) || portInfo.containsKey(key);
+    final hasRoadOrPort =
+        (tileState.roadLevel(key) > 0) || portInfo.containsKey(key);
     final canExpand = hasRoadOrPort;
 
     if (!canExpand) continue;
@@ -372,7 +406,14 @@ ConnectivityResult _connectedTilesForPlayer({
     if (map == null) continue;
 
     final bottleneckU = pathCap[key] ?? 0;
-    for (final n in _adjacentTileKeys(regionId, provinceId, x, y, map, provinceIdsByType)) {
+    for (final n in _adjacentTileKeys(
+      regionId,
+      provinceId,
+      x,
+      y,
+      map,
+      provinceIdsByType,
+    )) {
       final transportN = _transportLevelAtTile(worldState, n);
       final candidate = bottleneckU < transportN ? bottleneckU : transportN;
       final existing = pathCap[n] ?? -1;
@@ -397,8 +438,9 @@ ConnectivityResult _connectedTilesForPlayer({
     for (final key in connected.toList()) {
       final parts = key.split('|');
       if (parts.length >= 2) {
-        final fullProvinceId =
-            parts.length >= 3 ? '${parts[0]}|${parts[1]}' : parts[0];
+        final fullProvinceId = parts.length >= 3
+            ? '${parts[0]}|${parts[1]}'
+            : parts[0];
         if (blockadedPortProvinces.contains(fullProvinceId) &&
             fullProvinceId != capital.provinceId) {
           connected.remove(key);
@@ -423,12 +465,7 @@ List<String> _adjacentTileKeys(
   final out = <String>[];
   final w = map.width;
   final h = map.height;
-  for (final d in [
-    (0, -1),
-    (1, 0),
-    (0, 1),
-    (-1, 0),
-  ]) {
+  for (final d in [(0, -1), (1, 0), (0, 1), (-1, 0)]) {
     final nx = x + d.$1;
     final ny = y + d.$2;
     if (nx < 0 || nx >= w || ny < 0 || ny >= h) continue;

--- a/packages/colonizethis_logic/pubspec.yaml
+++ b/packages/colonizethis_logic/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   logger: ^2.0.2
+  colonizethis_logger:
   colonizethis_ai:
   colonizethis_data:
   colonizethis_map:

--- a/packages/colonizethis_map/lib/src/init_game_map_view_builder.dart
+++ b/packages/colonizethis_map/lib/src/init_game_map_view_builder.dart
@@ -2,11 +2,13 @@
 /// SPEC/program/map-visualization.md § Map view model for tools.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
 import 'init_game_map_view_data.dart';
 import 'tile_map_visualization_shared.dart';
+
+final _log = mapLogger();
 
 const String _regionOldWorld = 'oldWorld';
 const String _regionNewWorld = 'newWorld';
@@ -19,14 +21,16 @@ InitGameMapViewData buildInitGameMapViewData({
   int? seed,
   String? configSummary,
   Map<String, (int r, int g, int b)>? greatPowerColorOverride,
+
   /// Optional per-tile visibility for the current player view, keyed by tile
   /// key `regionId|provinceId|x|y`. When omitted, all tiles are treated as
   /// [TileVisibility.visible] in the view data.
   Map<String, TileVisibility>? visibilityByTile,
+
   /// Optional warp links for rendering warp zone indicators.
   List<WarpLink>? warpLinks,
 }) {
-  Logger().i('map: buildInitGameMapViewData start gameId=${game.id}');
+  _log.i('buildInitGameMapViewData start gameId=${game.id}');
   final owTileMap = tileMapByRegion[_regionOldWorld]!;
   final nwTileMap = tileMapByRegion[_regionNewWorld]!;
   final owTopology = topologyByRegion[_regionOldWorld]!;
@@ -55,7 +59,7 @@ InitGameMapViewData buildInitGameMapViewData({
     warpLinks: warpLinks,
   );
 
-  Logger().i('map: buildInitGameMapViewData end');
+  _log.i('buildInitGameMapViewData end');
   return InitGameMapViewData(
     oldWorld: owRegion,
     newWorld: nwRegion,
@@ -77,7 +81,7 @@ RegionMapViewData _buildRegionViewData({
 }) {
   final seaZoneIds = {
     for (final n in topology.nodes)
-      if (n.type == TopologyNodeType.seaZone) n.id
+      if (n.type == TopologyNodeType.seaZone) n.id,
   };
 
   // Owner and province display name by province id.
@@ -139,10 +143,10 @@ RegionMapViewData _buildRegionViewData({
       final tileKey = '$regionId|$localId|$x|$y';
       final improvement = isSea ? null : tileState.improvementLevel(tileKey);
       final road = isSea ? null : tileState.roadLevel(tileKey);
-      final visibility =
-          visibilityByTile != null ? (visibilityByTile[tileKey] ?? TileVisibility.visible) : TileVisibility.visible;
-      final fullProvinceId =
-          isSea ? null : ProvinceId.full(regionId, localId);
+      final visibility = visibilityByTile != null
+          ? (visibilityByTile[tileKey] ?? TileVisibility.visible)
+          : TileVisibility.visible;
+      final fullProvinceId = isSea ? null : ProvinceId.full(regionId, localId);
       cells.add(
         CellViewData(
           x: x,
@@ -152,13 +156,14 @@ RegionMapViewData _buildRegionViewData({
           terrainTypeId: terrain?.name,
           terrainType: terrain,
           resourceId: resource?.name,
-          ownerFactionId:
-              fullProvinceId != null ? ownerByProvinceId[fullProvinceId] : null,
+          ownerFactionId: fullProvinceId != null
+              ? ownerByProvinceId[fullProvinceId]
+              : null,
           provinceDisplayName: isSea
               ? null
               : (fullProvinceId != null
-                  ? provinceDisplayNameById[fullProvinceId]
-                  : null),
+                    ? provinceDisplayNameById[fullProvinceId]
+                    : null),
           improvementLevel: isSea ? null : improvement,
           roadLevel: isSea ? null : road,
           visibility: visibility,
@@ -232,11 +237,9 @@ RegionMapViewData _buildRegionViewData({
   for (final u in regionUnits) {
     final tile = provinceToTile[u.provinceId];
     if (tile != null) {
-      unitMarkers.add(UnitMarkerView(
-        x: tile.$1,
-        y: tile.$2,
-        ownerFactionId: u.ownerId,
-      ));
+      unitMarkers.add(
+        UnitMarkerView(x: tile.$1, y: tile.$2, ownerFactionId: u.ownerId),
+      );
     }
   }
 
@@ -292,25 +295,29 @@ RegionMapViewData _buildRegionViewData({
         // This region is the source of the warp link.
         final tile = seaZoneToTile[link.seaZoneId];
         if (tile != null) {
-          warpMarkers.add(WarpMarkerView(
-            x: tile.$1,
-            y: tile.$2,
-            seaZoneId: link.seaZoneId,
-            otherRegionId: link.otherRegionId,
-            otherSeaZoneId: link.otherSeaZoneId,
-          ));
+          warpMarkers.add(
+            WarpMarkerView(
+              x: tile.$1,
+              y: tile.$2,
+              seaZoneId: link.seaZoneId,
+              otherRegionId: link.otherRegionId,
+              otherSeaZoneId: link.otherSeaZoneId,
+            ),
+          );
         }
       } else if (link.otherRegionId == regionId) {
         // This region is the destination of the warp link (reverse direction).
         final tile = seaZoneToTile[link.otherSeaZoneId];
         if (tile != null) {
-          warpMarkers.add(WarpMarkerView(
-            x: tile.$1,
-            y: tile.$2,
-            seaZoneId: link.otherSeaZoneId,
-            otherRegionId: link.regionId,
-            otherSeaZoneId: link.seaZoneId,
-          ));
+          warpMarkers.add(
+            WarpMarkerView(
+              x: tile.$1,
+              y: tile.$2,
+              seaZoneId: link.otherSeaZoneId,
+              otherRegionId: link.regionId,
+              otherSeaZoneId: link.seaZoneId,
+            ),
+          );
         }
       }
     }
@@ -330,4 +337,3 @@ RegionMapViewData _buildRegionViewData({
     warpMarkers: warpMarkers,
   );
 }
-

--- a/packages/colonizethis_map/lib/src/tile_map_generator.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator.dart
@@ -3,7 +3,7 @@
 import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:logger/logger.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 import 'grid_voronoi.dart';
 import 'topology_inference.dart';
@@ -12,11 +12,7 @@ import 'topology_inference.dart';
 const String _landSentinel = '_land';
 
 /// How land-shape seeds are placed around each continent seed. SPEC/program/tile-map-gen-algorithm.md § Pass 2.
-enum LandSeedClusterShape {
-  gaussian,
-  uniformDisk,
-  uniformAnnulus,
-}
+enum LandSeedClusterShape { gaussian, uniformDisk, uniformAnnulus }
 
 /// Centralized map generation parameters. SPEC/program/tile-map-gen-config.md § Grid size derivation.
 class MapGenerationParams {
@@ -33,32 +29,41 @@ class MapGenerationParams {
     this.skipFillLakes = false,
     this.joinContinents = true,
     this.seedBeforeAssignment = false,
-  })  : assert(targetTilesPerProvince >= 1),
-        assert(seaFraction >= 0 && seaFraction < 1),
-        assert(numContinents >= 1),
-        assert(voronoiNoiseScale >= 0),
-        assert(continentBufferTiles >= 0);
+  }) : assert(targetTilesPerProvince >= 1),
+       assert(seaFraction >= 0 && seaFraction < 1),
+       assert(numContinents >= 1),
+       assert(voronoiNoiseScale >= 0),
+       assert(continentBufferTiles >= 0);
 
   /// Average land tiles per province; used to derive total land and grid size.
   final int targetTilesPerProvince;
+
   /// Fraction of grid that is sea (0–1); e.g. 0.6 for 60:40 sea:land.
   final double seaFraction;
+
   /// Number of continents; used when deriving grid size (e.g. when loading topology from file).
   final int numContinents;
   final int seed;
+
   /// 0–1; 0 = no border noise.
   final double borderNoise;
   final int maxEnforceIterations;
+
   /// How land-shape seeds are clustered around each continent seed.
   final LandSeedClusterShape clusterShape;
+
   /// Voronoi noise scale (0 = off). When > 0, perturb distance in Pass 3 for irregular boundaries.
   final double voronoiNoiseScale;
+
   /// Minimum Manhattan distance from another continent when assigning land (organic). 0 = legacy 1-tile.
   final int continentBufferTiles;
+
   /// When true, skip Pass 4 (no lake-to-land conversion).
   final bool skipFillLakes;
+
   /// When true, run join step after Pass 9 if a topology continent has multiple land components.
   final bool joinContinents;
+
   /// When true, use legacy land assignment (place all seeds first, then one Voronoi).
   /// When false (default), use organic land growing.
   final bool seedBeforeAssignment;
@@ -84,7 +89,10 @@ class MapGenerationParams {
 
 /// Builds province-to-continent map by partitioning p1..pN across C continents.
 /// Each continent gets a similar number of provinces (≈ N/C, remainder distributed).
-Map<String, int> buildProvinceToContinentMap(int numProvinces, int numContinents) {
+Map<String, int> buildProvinceToContinentMap(
+  int numProvinces,
+  int numContinents,
+) {
   if (numProvinces <= 0 || numContinents <= 0) return {};
   final result = <String, int>{};
   final continentSize = numProvinces ~/ numContinents;
@@ -180,51 +188,65 @@ class TileMapParams {
     this.jitterNeighborSupportThreshold = 2,
     // Pass 7 — multi-region resource cap
     this.multiRegionResourceCapFraction = 0.30,
-  })  : assert(seaFraction >= 0 && seaFraction < 1),
-        assert(voronoiNoiseScale >= 0),
-        assert(continentBufferTiles >= 0),
-        assert(maxSeaZoneFraction > 0 && maxSeaZoneFraction <= 1),
-        assert(mountainRangesFactor >= 0),
-        assert(mountainRangesMin >= 0),
-        assert(mountainRangesMax >= mountainRangesMin),
-        assert(mountainRangeMinLength >= 0),
-        assert(terrainSeedsFactor >= 0),
-        assert(terrainSeedsMin >= 0),
-        assert(terrainSeedsMax >= terrainSeedsMin),
-        assert(terrainMacroFraction >= 0 && terrainMacroFraction <= 1),
-        assert(patternMinBlobSize >= 0),
-        assert(patternMaxFractionPerBlob >= 0 && patternMaxFractionPerBlob <= 1),
-        assert(patternSeedFactor >= 0),
-        assert(patternMaxSeedsPerBlob >= 0),
-        assert(patternMaxChangesPerSeed >= 0),
-        assert(patternMaxRadius >= 0),
-        assert(jitterHomogeneityThreshold >= 0 && jitterHomogeneityThreshold <= 1),
-        assert(jitterMaxFraction >= 0 && jitterMaxFraction <= 1),
-        assert(jitterProbability >= 0 && jitterProbability <= 1),
-        assert(jitterMinProvinceSize >= 0),
-        assert(jitterNeighborSupportThreshold >= 0),
-        assert(multiRegionResourceCapFraction >= 0 && multiRegionResourceCapFraction <= 1);
+  }) : assert(seaFraction >= 0 && seaFraction < 1),
+       assert(voronoiNoiseScale >= 0),
+       assert(continentBufferTiles >= 0),
+       assert(maxSeaZoneFraction > 0 && maxSeaZoneFraction <= 1),
+       assert(mountainRangesFactor >= 0),
+       assert(mountainRangesMin >= 0),
+       assert(mountainRangesMax >= mountainRangesMin),
+       assert(mountainRangeMinLength >= 0),
+       assert(terrainSeedsFactor >= 0),
+       assert(terrainSeedsMin >= 0),
+       assert(terrainSeedsMax >= terrainSeedsMin),
+       assert(terrainMacroFraction >= 0 && terrainMacroFraction <= 1),
+       assert(patternMinBlobSize >= 0),
+       assert(patternMaxFractionPerBlob >= 0 && patternMaxFractionPerBlob <= 1),
+       assert(patternSeedFactor >= 0),
+       assert(patternMaxSeedsPerBlob >= 0),
+       assert(patternMaxChangesPerSeed >= 0),
+       assert(patternMaxRadius >= 0),
+       assert(
+         jitterHomogeneityThreshold >= 0 && jitterHomogeneityThreshold <= 1,
+       ),
+       assert(jitterMaxFraction >= 0 && jitterMaxFraction <= 1),
+       assert(jitterProbability >= 0 && jitterProbability <= 1),
+       assert(jitterMinProvinceSize >= 0),
+       assert(jitterNeighborSupportThreshold >= 0),
+       assert(
+         multiRegionResourceCapFraction >= 0 &&
+             multiRegionResourceCapFraction <= 1,
+       );
 
   final int width;
   final int height;
   final int seed;
+
   /// Fraction of grid that is sea (0–1); used for land budget in Pass 3.
   final double seaFraction;
+
   /// 0–1; 0 = no border noise.
   final double borderNoise;
   final int maxEnforceIterations;
+
   /// How land-shape seeds are clustered around each continent seed.
   final LandSeedClusterShape clusterShape;
+
   /// Voronoi noise scale (0 = off). When > 0, perturb distance in Pass 3.
   final double voronoiNoiseScale;
+
   /// Minimum Manhattan distance from another continent when assigning land (organic). 0 = legacy 1-tile.
   final int continentBufferTiles;
+
   /// When true, skip Pass 4 (no lake-to-land conversion).
   final bool skipFillLakes;
+
   /// When true, run join step after Pass 9 when needed.
   final bool joinContinents;
+
   /// When true, use legacy land assignment (place all seeds first, then one Voronoi).
   final bool seedBeforeAssignment;
+
   /// Max fraction of total sea tiles per sea zone (Pass 11); e.g. 0.05 = 5%.
   final double maxSeaZoneFraction;
 
@@ -293,10 +315,12 @@ class _MultiRegionCapState {
   bool shouldRestrictToRegionOnly(List<Resource> allowed) {
     if (totalCount == 0) return false;
     if (bothCount / totalCount < capFraction) return false;
-    final hasBoth =
-        allowed.any((r) => rules.regionRule[r] == ResourceRegionRule.both);
-    final hasRegionOnly =
-        allowed.any((r) => rules.regionRule[r] != ResourceRegionRule.both);
+    final hasBoth = allowed.any(
+      (r) => rules.regionRule[r] == ResourceRegionRule.both,
+    );
+    final hasRegionOnly = allowed.any(
+      (r) => rules.regionRule[r] != ResourceRegionRule.both,
+    );
     return hasBoth && hasRegionOnly;
   }
 
@@ -316,6 +340,7 @@ class TileMapGenerator {
   TileMapGenerator({this.params = const TileMapParams()});
 
   final TileMapParams params;
+  final _log = mapLogger();
 
   /// Generate a tile map from province/continent count. Returns (TileMapResult, inferred MapTopology).
   /// Optional [onLog] receives one line per pass.
@@ -330,17 +355,23 @@ class TileMapGenerator {
     String seaZoneId = 's1',
     ResourceRules? resourceRules,
     void Function(String)? onLog,
-    void Function(List<(int x, int y)> landSeeds, List<int> continentIndices)? onLandSeedsPlaced,
+    void Function(List<(int x, int y)> landSeeds, List<int> continentIndices)?
+    onLandSeedsPlaced,
     void Function(List<(int x, int y)> continentSeeds)? onContinentSeedsPlaced,
   }) {
-    Logger().i('map: TileMapGenerator.generate start regionId=$regionId numProvinces=$numProvinces seed=${params.seed}');
+    _log.i(
+      'TileMapGenerator.generate start regionId=$regionId numProvinces=$numProvinces seed=${params.seed}',
+    );
     if (numProvinces < 1) {
       throw ArgumentError('numProvinces must be at least 1');
     }
     if (numContinents < 1) {
       throw ArgumentError('numContinents must be at least 1');
     }
-    final provinceToContinent = buildProvinceToContinentMap(numProvinces, numContinents);
+    final provinceToContinent = buildProvinceToContinentMap(
+      numProvinces,
+      numContinents,
+    );
     final rnd = Random(params.seed);
 
     // Pass 1: Initialize grid (all sea)
@@ -348,7 +379,9 @@ class TileMapGenerator {
       params.height,
       (_) => List.filled(params.width, seaZoneId),
     );
-    onLog?.call('Pass 1: Grid initialized (${params.width}x${params.height}), all sea');
+    onLog?.call(
+      'Pass 1: Grid initialized (${params.width}x${params.height}), all sea',
+    );
 
     List<(int x, int y)> continentSeeds;
     List<(int x, int y)> landSeeds;
@@ -360,16 +393,31 @@ class TileMapGenerator {
       continentSeeds = placed.$1;
       landSeeds = placed.$2;
       continentBySeedIndex = placed.$3;
-      onLog?.call('Pass 2: Continent seeds ${continentSeeds.length}, land seeds ${landSeeds.length}');
-      grid = _assignLandByLandSeeds(grid, landSeeds, continentBySeedIndex, provinceToContinent, seaZoneId);
+      onLog?.call(
+        'Pass 2: Continent seeds ${continentSeeds.length}, land seeds ${landSeeds.length}',
+      );
+      grid = _assignLandByLandSeeds(
+        grid,
+        landSeeds,
+        continentBySeedIndex,
+        provinceToContinent,
+        seaZoneId,
+      );
     } else {
       // Organic: interleaved seed placement + small Voronoi + coastline growth
-      final organic = _placeLandSeedsOrganic(grid, provinceToContinent, seaZoneId, rnd);
+      final organic = _placeLandSeedsOrganic(
+        grid,
+        provinceToContinent,
+        seaZoneId,
+        rnd,
+      );
       continentSeeds = organic.$1;
       landSeeds = organic.$2;
       continentBySeedIndex = organic.$3;
       grid = organic.$4;
-      onLog?.call('Pass 2–3 (organic): Continent seeds ${continentSeeds.length}, land seeds ${landSeeds.length}');
+      onLog?.call(
+        'Pass 2–3 (organic): Continent seeds ${continentSeeds.length}, land seeds ${landSeeds.length}',
+      );
     }
 
     if (landSeeds.isNotEmpty) {
@@ -388,7 +436,9 @@ class TileMapGenerator {
         if (grid[y][x] == _landSentinel) landCount++;
       }
     }
-    onLog?.call('Pass 3: Land assignment complete ($landCount land, ${params.width * params.height - landCount} sea)');
+    onLog?.call(
+      'Pass 3: Land assignment complete ($landCount land, ${params.width * params.height - landCount} sea)',
+    );
 
     // Pass 4: Fill lakes (ocean = sea connected to edge; lake → land; optional coastal swap)
     if (params.skipFillLakes) {
@@ -425,13 +475,23 @@ class TileMapGenerator {
       onLog?.call('Pass 6: Terrain assigned ($terrainCount land cells)');
       onLog?.call('Pass 7: Resources placed ($resourceCount cells)');
     } else {
-      onLog?.call('Pass 6–7: Terrain/resources skipped (no rules or no provinces)');
+      onLog?.call(
+        'Pass 6–7: Terrain/resources skipped (no rules or no provinces)',
+      );
     }
 
     // Pass 8: Province seeds on land (one per province, per continent)
     final provinceSeeds = _placeProvinceSeedsOnLand(
-        grid, provinceToContinent, landSeeds, continentBySeedIndex, seaZoneId, rnd);
-    onLog?.call('Pass 8: Province seeds on land (${provinceSeeds.length} provinces)');
+      grid,
+      provinceToContinent,
+      landSeeds,
+      continentBySeedIndex,
+      seaZoneId,
+      rnd,
+    );
+    onLog?.call(
+      'Pass 8: Province seeds on land (${provinceSeeds.length} provinces)',
+    );
 
     // Pass 9: Province assignment (Voronoi on land; replace sentinel with province id)
     grid = _assignProvincesFromSeeds(grid, provinceSeeds, seaZoneId);
@@ -465,9 +525,15 @@ class TileMapGenerator {
     // Pass 11: Sea zone subdivision with size cap (max fraction of total sea per zone).
     final totalSea = _countSeaCells(grid, seaZoneId);
     if (totalSea > 0) {
-      final (newGrid, numSeaZones) = _subdivideSeaZonesWithCap(grid, seaZoneId, totalSea);
+      final (newGrid, numSeaZones) = _subdivideSeaZonesWithCap(
+        grid,
+        seaZoneId,
+        totalSea,
+      );
       grid = newGrid;
-      onLog?.call('Pass 11: Sea zone subdivision ($numSeaZones sea zones, cap ${(params.maxSeaZoneFraction * 100).toInt()}% of sea)');
+      onLog?.call(
+        'Pass 11: Sea zone subdivision ($numSeaZones sea zones, cap ${(params.maxSeaZoneFraction * 100).toInt()}% of sea)',
+      );
     }
 
     final result = TileMapResult(
@@ -478,7 +544,9 @@ class TileMapGenerator {
       resourceGrid: resourceGrid,
     );
     final topology = inferTopologyFromTileMap(result, regionId, seaZoneId);
-    Logger().i('map: TileMapGenerator.generate end regionId=$regionId provinces=${topology.nodes.where((n) => n.type == TopologyNodeType.province).length}');
+    _log.i(
+      'TileMapGenerator.generate end regionId=$regionId provinces=${topology.nodes.where((n) => n.type == TopologyNodeType.province).length}',
+    );
     return (result, topology);
   }
 
@@ -492,9 +560,9 @@ class TileMapGenerator {
     String regionId,
     Random rnd,
   ) {
-    final allowedNonMountain = allowedTerrainsForRegion(regionId)
-        .where((t) => t != TerrainType.mountain)
-        .toList();
+    final allowedNonMountain = allowedTerrainsForRegion(
+      regionId,
+    ).where((t) => t != TerrainType.mountain).toList();
     if (allowedNonMountain.isEmpty) return;
 
     final height = grid.length;
@@ -513,12 +581,7 @@ class TileMapGenerator {
     }
     if (tilesByProvince.isEmpty) return;
 
-    const directions4 = <(int dx, int dy)>[
-      (0, -1),
-      (1, 0),
-      (0, 1),
-      (-1, 0),
-    ];
+    const directions4 = <(int dx, int dy)>[(0, -1), (1, 0), (0, 1), (-1, 0)];
     const directions8 = <(int dx, int dy)>[
       (0, -1),
       (1, 0),
@@ -605,7 +668,8 @@ class TileMapGenerator {
           if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
           if (grid[ny][nx] != entry.key) continue; // same province only
           final nt = terrainGrid[ny][nx];
-          if (nt == null || nt == dominant || nt == TerrainType.mountain) continue;
+          if (nt == null || nt == dominant || nt == TerrainType.mountain)
+            continue;
           neighborCounts[nt] = (neighborCounts[nt] ?? 0) + 1;
         }
 
@@ -626,7 +690,8 @@ class TileMapGenerator {
   }
 
   /// Join step: for each continent with >1 land component, connect two by a shortest path of sea cells. Returns (grid, terrainGrid, resourceGrid, didJoin).
-  (List<List<String>>, List<List<TerrainType?>>?, List<List<Resource?>>?, bool) _joinContinents(
+  (List<List<String>>, List<List<TerrainType?>>?, List<List<Resource?>>?, bool)
+  _joinContinents(
     List<List<String>> grid,
     List<List<TerrainType?>>? terrainGrid,
     List<List<Resource?>>? resourceGrid,
@@ -636,15 +701,21 @@ class TileMapGenerator {
     ResourceRules? resourceRules,
     Random rnd,
   ) {
-    if (provinceToContinent.isEmpty) return (grid, terrainGrid, resourceGrid, false);
+    if (provinceToContinent.isEmpty)
+      return (grid, terrainGrid, resourceGrid, false);
     final numContinents = provinceToContinent.values.toSet().length;
     var didJoin = false;
     var g = grid.map((row) => row.toList()).toList();
-    var tg = terrainGrid != null ? terrainGrid.map((row) => row.toList()).toList() : null;
-    var rg = resourceGrid != null ? resourceGrid.map((row) => row.toList()).toList() : null;
+    var tg = terrainGrid != null
+        ? terrainGrid.map((row) => row.toList()).toList()
+        : null;
+    var rg = resourceGrid != null
+        ? resourceGrid.map((row) => row.toList()).toList()
+        : null;
     final ocean = _oceanCells(g, seaZoneId);
 
-    final capState = (tg != null &&
+    final capState =
+        (tg != null &&
             rg != null &&
             mapRegionId != null &&
             resourceRules != null &&
@@ -659,7 +730,12 @@ class TileMapGenerator {
 
     for (var c = 0; c < numContinents; c++) {
       while (true) {
-        final landCells = _landCellsForContinent(g, provinceToContinent, c, seaZoneId);
+        final landCells = _landCellsForContinent(
+          g,
+          provinceToContinent,
+          c,
+          seaZoneId,
+        );
         final components = _connectedComponentsOfLand(landCells);
         if (components.length <= 1) break;
         didJoin = true;
@@ -670,7 +746,10 @@ class TileMapGenerator {
         final provinceId = _provinceIdAdjacentToSeaPath(g, compA, path);
         for (final (x, y) in path) {
           g[y][x] = provinceId;
-          if (tg != null && rg != null && mapRegionId != null && resourceRules != null) {
+          if (tg != null &&
+              rg != null &&
+              mapRegionId != null &&
+              resourceRules != null) {
             _assignTerrainAndResourceForCell(
               tg,
               rg,
@@ -706,7 +785,9 @@ class TileMapGenerator {
     return out;
   }
 
-  List<Set<(int x, int y)>> _connectedComponentsOfLand(Set<(int x, int y)> landCells) {
+  List<Set<(int x, int y)>> _connectedComponentsOfLand(
+    Set<(int x, int y)> landCells,
+  ) {
     if (landCells.isEmpty) return [];
     final result = <Set<(int x, int y)>>[];
     final remaining = Set<(int x, int y)>.from(landCells);
@@ -798,7 +879,8 @@ class TileMapGenerator {
       final K = (size / maxPerZone).ceil().clamp(1, size);
       final seeds = _placeSeaSeedsFarthestPoint(component, K);
       final seedMap = <String, (int x, int y)>{
-        for (var i = 0; i < seeds.length; i++) 's${nextSeaZoneIndex + i}': seeds[i],
+        for (var i = 0; i < seeds.length; i++)
+          's${nextSeaZoneIndex + i}': seeds[i],
       };
       final assignment = assignCellsToNearestSeed(
         component,
@@ -816,7 +898,10 @@ class TileMapGenerator {
   }
 
   /// Place K well-spread seeds in [cells] using farthest-point sampling.
-  List<(int x, int y)> _placeSeaSeedsFarthestPoint(Set<(int x, int y)> cells, int K) {
+  List<(int x, int y)> _placeSeaSeedsFarthestPoint(
+    Set<(int x, int y)> cells,
+    int K,
+  ) {
     if (cells.isEmpty || K <= 0) return [];
     final list = cells.toList();
     if (K >= list.length) return list;
@@ -859,7 +944,10 @@ class TileMapGenerator {
       for (final (dx, dy) in [(0, -1), (0, 1), (-1, 0), (1, 0)]) {
         final nx = x + dx;
         final ny = y + dy;
-        if (nx >= 0 && nx < params.width && ny >= 0 && ny < params.height &&
+        if (nx >= 0 &&
+            nx < params.width &&
+            ny >= 0 &&
+            ny < params.height &&
             grid[ny][nx] == seaZoneId) {
           seaAdjacentToA.add((nx, ny));
         }
@@ -870,7 +958,10 @@ class TileMapGenerator {
       for (final (dx, dy) in [(0, -1), (0, 1), (-1, 0), (1, 0)]) {
         final nx = x + dx;
         final ny = y + dy;
-        if (nx >= 0 && nx < params.width && ny >= 0 && ny < params.height &&
+        if (nx >= 0 &&
+            nx < params.width &&
+            ny >= 0 &&
+            ny < params.height &&
             grid[ny][nx] == seaZoneId) {
           seaAdjacentToB.add((nx, ny));
         }
@@ -893,7 +984,8 @@ class TileMapGenerator {
       for (final (dx, dy) in [(0, -1), (0, 1), (-1, 0), (1, 0)]) {
         final nx = x + dx;
         final ny = y + dy;
-        if (nx < 0 || nx >= params.width || ny < 0 || ny >= params.height) continue;
+        if (nx < 0 || nx >= params.width || ny < 0 || ny >= params.height)
+          continue;
         if (grid[ny][nx] != seaZoneId) continue;
         final n = (nx, ny);
         if (prev.containsKey(n)) continue;
@@ -920,7 +1012,10 @@ class TileMapGenerator {
       for (final (dx, dy) in [(0, -1), (0, 1), (-1, 0), (1, 0)]) {
         final nx = px + dx;
         final ny = py + dy;
-        if (nx >= 0 && nx < params.width && ny >= 0 && ny < params.height &&
+        if (nx >= 0 &&
+            nx < params.width &&
+            ny >= 0 &&
+            ny < params.height &&
             compA.contains((nx, ny))) {
           return grid[ny][nx];
         }
@@ -945,9 +1040,11 @@ class TileMapGenerator {
     terrainGrid[y][x] = landTerrains[rnd.nextInt(landTerrains.length)];
     final terrain = terrainGrid[y][x]!;
     var allowed = Resource.values
-        .where((r) =>
-            rules.isAllowedInRegion(r, mapRegionId) &&
-            rules.isAllowedOnTerrain(r, terrain))
+        .where(
+          (r) =>
+              rules.isAllowedInRegion(r, mapRegionId) &&
+              rules.isAllowedOnTerrain(r, terrain),
+        )
         .toList();
     if (allowed.isEmpty) return;
     if (capState != null &&
@@ -983,31 +1080,55 @@ class TileMapGenerator {
     for (var y = 0; y < params.height; y++) {
       for (var x = 0; x < params.width; x++) {
         if (grid[y][x] == seaZoneId) continue;
-        final oceanNeighbours = [
-          (x - 1, y),
-          (x + 1, y),
-          (x, y - 1),
-          (x, y + 1),
-        ].where((p) => p.$1 >= 0 && p.$1 < params.width && p.$2 >= 0 && p.$2 < params.height &&
-            grid[p.$2][p.$1] == seaZoneId && ocean.contains(p)).length;
+        final oceanNeighbours = [(x - 1, y), (x + 1, y), (x, y - 1), (x, y + 1)]
+            .where(
+              (p) =>
+                  p.$1 >= 0 &&
+                  p.$1 < params.width &&
+                  p.$2 >= 0 &&
+                  p.$2 < params.height &&
+                  grid[p.$2][p.$1] == seaZoneId &&
+                  ocean.contains(p),
+            )
+            .length;
         if (oceanNeighbours >= 1) coastal.add((x, y));
       }
     }
     coastal.sort((a, b) {
-      final na = [
-        (a.$1 - 1, a.$2),
-        (a.$1 + 1, a.$2),
-        (a.$1, a.$2 - 1),
-        (a.$1, a.$2 + 1),
-      ].where((p) => p.$1 >= 0 && p.$1 < params.width && p.$2 >= 0 && p.$2 < params.height &&
-          grid[p.$2][p.$1] == seaZoneId && ocean.contains(p)).length;
-      final nb = [
-        (b.$1 - 1, b.$2),
-        (b.$1 + 1, b.$2),
-        (b.$1, b.$2 - 1),
-        (b.$1, b.$2 + 1),
-      ].where((p) => p.$1 >= 0 && p.$1 < params.width && p.$2 >= 0 && p.$2 < params.height &&
-          grid[p.$2][p.$1] == seaZoneId && ocean.contains(p)).length;
+      final na =
+          [
+                (a.$1 - 1, a.$2),
+                (a.$1 + 1, a.$2),
+                (a.$1, a.$2 - 1),
+                (a.$1, a.$2 + 1),
+              ]
+              .where(
+                (p) =>
+                    p.$1 >= 0 &&
+                    p.$1 < params.width &&
+                    p.$2 >= 0 &&
+                    p.$2 < params.height &&
+                    grid[p.$2][p.$1] == seaZoneId &&
+                    ocean.contains(p),
+              )
+              .length;
+      final nb =
+          [
+                (b.$1 - 1, b.$2),
+                (b.$1 + 1, b.$2),
+                (b.$1, b.$2 - 1),
+                (b.$1, b.$2 + 1),
+              ]
+              .where(
+                (p) =>
+                    p.$1 >= 0 &&
+                    p.$1 < params.width &&
+                    p.$2 >= 0 &&
+                    p.$2 < params.height &&
+                    grid[p.$2][p.$1] == seaZoneId &&
+                    ocean.contains(p),
+              )
+              .length;
       return nb.compareTo(na);
     });
     for (var i = 0; i < count && i < coastal.length; i++) {
@@ -1079,9 +1200,11 @@ class TileMapGenerator {
         final terrain = terrainGrid[y][x];
         if (terrain == null) continue;
         var allowed = Resource.values
-            .where((r) =>
-                rules.isAllowedInRegion(r, mapRegionId) &&
-                rules.isAllowedOnTerrain(r, terrain))
+            .where(
+              (r) =>
+                  rules.isAllowedInRegion(r, mapRegionId) &&
+                  rules.isAllowedOnTerrain(r, terrain),
+            )
             .toList();
         if (allowed.isEmpty) continue;
         // Multi-region cap: when at cap, restrict to region-only where possible.
@@ -1119,16 +1242,15 @@ class TileMapGenerator {
   ) {
     final totalLand = landCells.length;
     if (totalLand == 0) return;
-    final targetMountain =
-        (distribution.mountainFraction * totalLand).round().clamp(0, totalLand);
+    final targetMountain = (distribution.mountainFraction * totalLand)
+        .round()
+        .clamp(0, totalLand);
     if (targetMountain <= 0) return;
 
     // Determine number of ranges based on target mountain tiles.
-    final suggestedRanges =
-        (params.mountainRangesFactor * sqrt(targetMountain)).round().clamp(
-              params.mountainRangesMin,
-              params.mountainRangesMax,
-            );
+    final suggestedRanges = (params.mountainRangesFactor * sqrt(targetMountain))
+        .round()
+        .clamp(params.mountainRangesMin, params.mountainRangesMax);
     final numRanges = suggestedRanges.clamp(1, targetMountain);
     if (numRanges <= 0) return;
 
@@ -1154,12 +1276,7 @@ class TileMapGenerator {
     }
 
     // 4-connected directions: up, right, down, left.
-    const directions = <(int dx, int dy)>[
-      (0, -1),
-      (1, 0),
-      (0, 1),
-      (-1, 0),
-    ];
+    const directions = <(int dx, int dy)>[(0, -1), (1, 0), (0, 1), (-1, 0)];
 
     for (var r = 0; r < numRanges && remainingMountain > 0; r++) {
       final start = pickStart();
@@ -1206,10 +1323,7 @@ class TileMapGenerator {
           final nx = x + dir.$1;
           final ny = y + dir.$2;
           attempts++;
-          if (nx < 0 ||
-              nx >= params.width ||
-              ny < 0 ||
-              ny >= params.height) {
+          if (nx < 0 || nx >= params.width || ny < 0 || ny >= params.height) {
             continue;
           }
           if (grid[ny][nx] != _landSentinel) continue;
@@ -1249,10 +1363,7 @@ class TileMapGenerator {
         for (final (dx, dy) in directions) {
           final nx = x + dx;
           final ny = y + dy;
-          if (nx < 0 ||
-              nx >= params.width ||
-              ny < 0 ||
-              ny >= params.height) {
+          if (nx < 0 || nx >= params.width || ny < 0 || ny >= params.height) {
             continue;
           }
           if (grid[ny][nx] != _landSentinel) continue;
@@ -1305,9 +1416,9 @@ class TileMapGenerator {
     Random rnd,
   ) {
     // Allowed non-mountain terrains for this region.
-    final allowed = allowedTerrainsForRegion(mapRegionId)
-        .where((t) => t != TerrainType.mountain)
-        .toList();
+    final allowed = allowedTerrainsForRegion(
+      mapRegionId,
+    ).where((t) => t != TerrainType.mountain).toList();
     if (allowed.isEmpty) return;
 
     // Collect remaining land cells (not sea, not mountain).
@@ -1326,12 +1437,7 @@ class TileMapGenerator {
     final components = _connectedComponentsOfLand(remainingLand.toSet());
     if (components.isEmpty) return;
 
-    const directions = <(int dx, int dy)>[
-      (0, -1),
-      (1, 0),
-      (0, 1),
-      (-1, 0),
-    ];
+    const directions = <(int dx, int dy)>[(0, -1), (1, 0), (0, 1), (-1, 0)];
 
     for (final component in components) {
       if (component.isEmpty) continue;
@@ -1448,10 +1554,7 @@ class TileMapGenerator {
         for (final (dx, dy) in dirs) {
           final nx = cx + dx;
           final ny = cy + dy;
-          if (nx < 0 ||
-              nx >= params.width ||
-              ny < 0 ||
-              ny >= params.height) {
+          if (nx < 0 || nx >= params.width || ny < 0 || ny >= params.height) {
             continue;
           }
           if (!cellSet.contains((nx, ny))) continue;
@@ -1552,10 +1655,7 @@ class TileMapGenerator {
           for (final (dx, dy) in dirs) {
             final nx = cx + dx;
             final ny = cy + dy;
-            if (nx < 0 ||
-                nx >= params.width ||
-                ny < 0 ||
-                ny >= params.height) {
+            if (nx < 0 || nx >= params.width || ny < 0 || ny >= params.height) {
               continue;
             }
             if (!cellSet.contains((nx, ny))) continue;
@@ -1577,10 +1677,7 @@ class TileMapGenerator {
         for (final (dx, dy) in directions) {
           final nx = x + dx;
           final ny = y + dy;
-          if (nx < 0 ||
-              nx >= params.width ||
-              ny < 0 ||
-              ny >= params.height) {
+          if (nx < 0 || nx >= params.width || ny < 0 || ny >= params.height) {
             continue;
           }
           if (!cellSet.contains((nx, ny))) continue;
@@ -1649,12 +1746,7 @@ class TileMapGenerator {
     }
 
     // Neighbour directions for interior tests and BFS (4-connected).
-    const directions = <(int dx, int dy)>[
-      (0, -1),
-      (1, 0),
-      (0, 1),
-      (-1, 0),
-    ];
+    const directions = <(int dx, int dy)>[(0, -1), (1, 0), (0, 1), (-1, 0)];
 
     for (final terrain in allowedNonMountain) {
       final blobs = blobsForTerrain(terrain);
@@ -1665,8 +1757,9 @@ class TileMapGenerator {
         if (size < params.patternMinBlobSize) continue;
 
         // Budget: how many tiles in this blob we may convert away from [terrain].
-        final maxChangesForBlob =
-            (params.patternMaxFractionPerBlob * size).floor().clamp(0, size);
+        final maxChangesForBlob = (params.patternMaxFractionPerBlob * size)
+            .floor()
+            .clamp(0, size);
         if (maxChangesForBlob <= 0) continue;
 
         // Identify interior cells: all 4-neighbors are also in this blob.
@@ -1700,15 +1793,22 @@ class TileMapGenerator {
           ),
         ).clamp(1, maxChangesForBlob);
 
-        final interiorShuffled = List<(int x, int y)>.from(interior)..shuffle(rnd);
+        final interiorShuffled = List<(int x, int y)>.from(interior)
+          ..shuffle(rnd);
         final seeds = <(int x, int y, TerrainType target)>[];
         var interiorIndex = 0;
 
-        for (var i = 0; i < seedCount && interiorIndex < interiorShuffled.length; i++) {
+        for (
+          var i = 0;
+          i < seedCount && interiorIndex < interiorShuffled.length;
+          i++
+        ) {
           final (sx, sy) = interiorShuffled[interiorIndex++];
           // Choose a target terrain different from the blob terrain, optionally
           // preferring underrepresented terrains according to distribution.
-          final options = allowedNonMountain.where((t) => t != terrain).toList();
+          final options = allowedNonMountain
+              .where((t) => t != terrain)
+              .toList();
           if (options.isEmpty) break;
 
           // Weight by desired fraction heuristic (simplified).
@@ -1778,10 +1878,15 @@ class TileMapGenerator {
   }
 
   /// One continent seed per continent; then a cluster of land-shape seeds per continent (K from province count). No province seeds yet.
-  (List<(int x, int y)>, List<(int x, int y)>, List<int>) _placeLandSeeds(Map<String, int> provinceToContinent, Random rnd) {
-    if (provinceToContinent.isEmpty) return (<(int x, int y)>[], <(int x, int y)>[], <int>[]);
+  (List<(int x, int y)>, List<(int x, int y)>, List<int>) _placeLandSeeds(
+    Map<String, int> provinceToContinent,
+    Random rnd,
+  ) {
+    if (provinceToContinent.isEmpty)
+      return (<(int x, int y)>[], <(int x, int y)>[], <int>[]);
     final numContinents = provinceToContinent.values.toSet().length;
-    if (numContinents < 1) return (<(int x, int y)>[], <(int x, int y)>[], <int>[]);
+    if (numContinents < 1)
+      return (<(int x, int y)>[], <(int x, int y)>[], <int>[]);
     final provincesByContinent = <int, List<String>>{};
     for (final e in provinceToContinent.entries) {
       provincesByContinent.putIfAbsent(e.value, () => []).add(e.key);
@@ -1837,7 +1942,8 @@ class TileMapGenerator {
             break;
           case LandSeedClusterShape.uniformAnnulus:
             final angle = rnd.nextDouble() * 2 * pi;
-            final r = annulusInner + rnd.nextDouble() * (annulusOuter - annulusInner);
+            final r =
+                annulusInner + rnd.nextDouble() * (annulusOuter - annulusInner);
             dx = (cos(angle) * r).round();
             dy = (sin(angle) * r).round();
             break;
@@ -1853,15 +1959,18 @@ class TileMapGenerator {
 
   /// Organic land growing: interleaved seed placement + small Voronoi + coastline growth.
   /// Returns (continentSeeds, landSeeds, continentBySeedIndex, grid).
-  (List<(int x, int y)>, List<(int x, int y)>, List<int>, List<List<String>>) _placeLandSeedsOrganic(
+  (List<(int x, int y)>, List<(int x, int y)>, List<int>, List<List<String>>)
+  _placeLandSeedsOrganic(
     List<List<String>> grid,
     Map<String, int> provinceToContinent,
     String seaZoneId,
     Random rnd,
   ) {
-    if (provinceToContinent.isEmpty) return (<(int x, int y)>[], <(int x, int y)>[], <int>[], grid);
+    if (provinceToContinent.isEmpty)
+      return (<(int x, int y)>[], <(int x, int y)>[], <int>[], grid);
     final numContinents = provinceToContinent.values.toSet().length;
-    if (numContinents < 1) return (<(int x, int y)>[], <(int x, int y)>[], <int>[], grid);
+    if (numContinents < 1)
+      return (<(int x, int y)>[], <(int x, int y)>[], <int>[], grid);
 
     final provincesByContinent = <int, List<String>>{};
     for (final e in provinceToContinent.entries) {
@@ -1875,13 +1984,17 @@ class TileMapGenerator {
     final seedsPerContinent = <int>[];
     for (var c = 0; c < numContinents; c++) {
       final pc = provincesByContinent[c]!.length;
-      seedsPerContinent.add(minSeedsPerContinent > pc ? minSeedsPerContinent : pc);
+      seedsPerContinent.add(
+        minSeedsPerContinent > pc ? minSeedsPerContinent : pc,
+      );
     }
     final totalSeeds = seedsPerContinent.reduce((a, b) => a + b);
     final totalRounds = (totalSeeds / numContinents).ceil().clamp(1, 999);
 
-    final landBudgetTotal = ((1 - params.seaFraction) * params.width * params.height).round();
-    if (landBudgetTotal <= 0) return (<(int x, int y)>[], <(int x, int y)>[], <int>[], grid);
+    final landBudgetTotal =
+        ((1 - params.seaFraction) * params.width * params.height).round();
+    if (landBudgetTotal <= 0)
+      return (<(int x, int y)>[], <(int x, int y)>[], <int>[], grid);
 
     // Step 0: Place continent seeds
     final continentSeeds = <(int x, int y)>[];
@@ -1908,7 +2021,10 @@ class TileMapGenerator {
     const awayPenalty = 0.7;
 
     // Per-round land budget: reserve totalSeeds for seed positions, rest for Voronoi
-    final voronoiBudgetTotal = (landBudgetTotal - totalSeeds).clamp(0, landBudgetTotal);
+    final voronoiBudgetTotal = (landBudgetTotal - totalSeeds).clamp(
+      0,
+      landBudgetTotal,
+    );
     final totalProvinces = provinceToContinent.length;
 
     final seedCountsPerContinent = List<int>.filled(numContinents, 0);
@@ -1920,7 +2036,10 @@ class TileMapGenerator {
           : (voronoiBudgetTotal / totalRounds).round();
       final budgetPerContinent = <int>[];
       for (var c = 0; c < numContinents; c++) {
-        budgetPerContinent.add((roundBudget * provincesByContinent[c]!.length / totalProvinces).round());
+        budgetPerContinent.add(
+          (roundBudget * provincesByContinent[c]!.length / totalProvinces)
+              .round(),
+        );
       }
       var roundUsed = 0;
       for (var c = 0; c < numContinents; c++) {
@@ -1981,7 +2100,14 @@ class TileMapGenerator {
     }
     if (usedTotal < landBudgetTotal) {
       final remaining = landBudgetTotal - usedTotal;
-      final (g2, _) = _growCoastlines(g, continentGrid, remaining, provinceToContinent, seaZoneId, rnd);
+      final (g2, _) = _growCoastlines(
+        g,
+        continentGrid,
+        remaining,
+        provinceToContinent,
+        seaZoneId,
+        rnd,
+      );
       g = g2;
     }
 
@@ -2024,8 +2150,14 @@ class TileMapGenerator {
     if (candidates.isEmpty) {
       final (cx, cy) = continentSeed;
       const jitter = 2;
-      final jx = (cx + rnd.nextInt(jitter * 2 + 1) - jitter).clamp(0, params.width - 1);
-      final jy = (cy + rnd.nextInt(jitter * 2 + 1) - jitter).clamp(0, params.height - 1);
+      final jx = (cx + rnd.nextInt(jitter * 2 + 1) - jitter).clamp(
+        0,
+        params.width - 1,
+      );
+      final jy = (cy + rnd.nextInt(jitter * 2 + 1) - jitter).clamp(
+        0,
+        params.height - 1,
+      );
       return (jx, jy);
     }
     var bestScore = -1e100;
@@ -2113,7 +2245,8 @@ class TileMapGenerator {
             if (dd < d2) d2 = dd;
           }
           final noise = params.voronoiNoiseScale > 0
-              ? _deterministicNoise(params.seed, x, y) * params.voronoiNoiseScale
+              ? _deterministicNoise(params.seed, x, y) *
+                    params.voronoiNoiseScale
               : 0.0;
           final effective = d2.toDouble() + noise;
           if (effective < bestD2) {
@@ -2129,7 +2262,9 @@ class TileMapGenerator {
     final next = grid.map((row) => row.toList()).toList();
     final nextContinent = continentGrid.map((row) => row.toList()).toList();
     final used = List<int>.filled(numContinents, 0);
-    final buffer = params.continentBufferTiles == 0 ? 1 : params.continentBufferTiles;
+    final buffer = params.continentBufferTiles == 0
+        ? 1
+        : params.continentBufferTiles;
     final offsets = _bufferOffsets(buffer);
     for (final (_, x, y, c) in entries) {
       if (next[y][x] == _landSentinel) continue;
@@ -2188,7 +2323,10 @@ class TileMapGenerator {
         for (final (dx, dy) in [(0, -1), (0, 1), (-1, 0), (1, 0)]) {
           final nx = x + dx;
           final ny = y + dy;
-          if (nx >= 0 && nx < params.width && ny >= 0 && ny < params.height &&
+          if (nx >= 0 &&
+              nx < params.width &&
+              ny >= 0 &&
+              ny < params.height &&
               g[ny][nx] == seaZoneId) {
             coastalByContinent[c]!.add((nx, ny));
             break;
@@ -2200,14 +2338,19 @@ class TileMapGenerator {
     final budgetPerContinent = List<int>.filled(numContinents, 0);
     var allocated = 0;
     for (var c = 0; c < numContinents; c++) {
-      budgetPerContinent[c] = (remaining * provincesByContinent[c]!.length / totalProvinces).round();
+      budgetPerContinent[c] =
+          (remaining * provincesByContinent[c]!.length / totalProvinces)
+              .round();
       allocated += budgetPerContinent[c];
     }
-    if (allocated < remaining && numContinents > 0) budgetPerContinent[0] += remaining - allocated;
+    if (allocated < remaining && numContinents > 0)
+      budgetPerContinent[0] += remaining - allocated;
 
     // Radius for local land-neighbour scoring when picking coastal cells.
     const scoreRadius = 3;
-    final buffer = params.continentBufferTiles == 0 ? 1 : params.continentBufferTiles;
+    final buffer = params.continentBufferTiles == 0
+        ? 1
+        : params.continentBufferTiles;
     final bufferOffsets = _bufferOffsets(buffer);
 
     // Local helper: score a coastal sea cell for continent [continentIndex].
@@ -2336,7 +2479,8 @@ class TileMapGenerator {
     String seaZoneId,
   ) {
     if (landSeeds.isEmpty) return grid;
-    final landBudgetTotal = ((1 - params.seaFraction) * params.width * params.height).round();
+    final landBudgetTotal =
+        ((1 - params.seaFraction) * params.width * params.height).round();
     if (landBudgetTotal <= 0) return grid;
 
     if (provinceToContinent.isEmpty) return grid;
@@ -2393,7 +2537,8 @@ class TileMapGenerator {
             if (dd < d2) d2 = dd;
           }
           final noise = params.voronoiNoiseScale > 0
-              ? _deterministicNoise(params.seed, x, y) * params.voronoiNoiseScale
+              ? _deterministicNoise(params.seed, x, y) *
+                    params.voronoiNoiseScale
               : 0.0;
           final effective = d2.toDouble() + noise;
           if (effective < bestD2) {
@@ -2445,7 +2590,8 @@ class TileMapGenerator {
         ocean.add((0, y));
         queue.add((0, y));
       }
-      if (params.width > 1 && grid[y][params.width - 1] == seaZoneId &&
+      if (params.width > 1 &&
+          grid[y][params.width - 1] == seaZoneId &&
           !ocean.contains((params.width - 1, y))) {
         ocean.add((params.width - 1, y));
         queue.add((params.width - 1, y));
@@ -2453,14 +2599,13 @@ class TileMapGenerator {
     }
     while (queue.isNotEmpty) {
       final (x, y) = queue.removeLast();
-      for (final (nx, ny) in [
-        (x - 1, y),
-        (x + 1, y),
-        (x, y - 1),
-        (x, y + 1),
-      ]) {
-        if (nx >= 0 && nx < params.width && ny >= 0 && ny < params.height &&
-            grid[ny][nx] == seaZoneId && !ocean.contains((nx, ny))) {
+      for (final (nx, ny) in [(x - 1, y), (x + 1, y), (x, y - 1), (x, y + 1)]) {
+        if (nx >= 0 &&
+            nx < params.width &&
+            ny >= 0 &&
+            ny < params.height &&
+            grid[ny][nx] == seaZoneId &&
+            !ocean.contains((nx, ny))) {
           ocean.add((nx, ny));
           queue.add((nx, ny));
         }
@@ -2516,7 +2661,10 @@ class TileMapGenerator {
         for (final (dx, dy) in [(0, -1), (0, 1), (-1, 0), (1, 0)]) {
           final nx = x + dx;
           final ny = y + dy;
-          if (nx >= 0 && nx < params.width && ny >= 0 && ny < params.height &&
+          if (nx >= 0 &&
+              nx < params.width &&
+              ny >= 0 &&
+              ny < params.height &&
               grid[ny][nx] != seaZoneId) {
             borderingLand.add((nx, ny));
           }
@@ -2524,7 +2672,9 @@ class TileMapGenerator {
       }
       final continentsBordering = <int>{};
       for (final (lx, ly) in borderingLand) {
-        continentsBordering.add(_continentForLandCell(lx, ly, landSeeds, continentBySeedIndex));
+        continentsBordering.add(
+          _continentForLandCell(lx, ly, landSeeds, continentBySeedIndex),
+        );
       }
       if (continentsBordering.length >= 2) continue;
       for (final (x, y) in component) {
@@ -2533,7 +2683,10 @@ class TileMapGenerator {
         for (final (dx, dy) in [(0, -1), (0, 1), (-1, 0), (1, 0)]) {
           final nx = x + dx;
           final ny = y + dy;
-          if (nx >= 0 && nx < params.width && ny >= 0 && ny < params.height &&
+          if (nx >= 0 &&
+              nx < params.width &&
+              ny >= 0 &&
+              ny < params.height &&
               next[ny][nx] == seaZoneId &&
               _oceanNeighbourCount(next, nx, ny, seaZoneId, ocean) >= 1) {
             coastalLandCandidates.add((nx, ny));
@@ -2553,14 +2706,24 @@ class TileMapGenerator {
     return next;
   }
 
-  int _oceanNeighbourCount(List<List<String>> grid, int x, int y, String seaZoneId,
-      Set<(int x, int y)> ocean) {
+  int _oceanNeighbourCount(
+    List<List<String>> grid,
+    int x,
+    int y,
+    String seaZoneId,
+    Set<(int x, int y)> ocean,
+  ) {
     var n = 0;
     for (final (dx, dy) in [(0, -1), (0, 1), (-1, 0), (1, 0)]) {
       final nx = x + dx;
       final ny = y + dy;
-      if (nx >= 0 && nx < params.width && ny >= 0 && ny < params.height &&
-          grid[ny][nx] == seaZoneId && ocean.contains((nx, ny))) n++;
+      if (nx >= 0 &&
+          nx < params.width &&
+          ny >= 0 &&
+          ny < params.height &&
+          grid[ny][nx] == seaZoneId &&
+          ocean.contains((nx, ny)))
+        n++;
     }
     return n;
   }
@@ -2594,7 +2757,7 @@ class TileMapGenerator {
         final neighbouringContinents = <int>{};
         final sameContinentDirectionCounts = <int, int>{};
 
-    for (final (dx, dy) in const <(int, int)>[
+        for (final (dx, dy) in const <(int, int)>[
           (0, -1), // N
           (1, 0), // E
           (0, 1), // S
@@ -2606,14 +2769,20 @@ class TileMapGenerator {
             continue;
           }
           if (next[ny][nx] == seaZoneId) continue;
-          final continent = _continentForLandCell(nx, ny, landSeeds, continentBySeedIndex);
+          final continent = _continentForLandCell(
+            nx,
+            ny,
+            landSeeds,
+            continentBySeedIndex,
+          );
           neighbouringContinents.add(continent);
           sameContinentDirectionCounts[continent] =
               (sameContinentDirectionCounts[continent] ?? 0) + 1;
         }
 
         if (neighbouringContinents.isEmpty) continue;
-        if (neighbouringContinents.length > 1) continue; // multi-continent strait, keep as sea
+        if (neighbouringContinents.length > 1)
+          continue; // multi-continent strait, keep as sea
 
         final c = neighbouringContinents.single;
         final dirCount = sameContinentDirectionCounts[c] ?? 0;
@@ -2631,14 +2800,7 @@ class TileMapGenerator {
 
     // Preserve overall sea fraction by converting an equal number of coastal
     // land tiles back to sea, using the existing helper.
-    _preserveSeaFraction(
-      next,
-      null,
-      null,
-      seaZoneId,
-      ocean,
-      moatCells.length,
-    );
+    _preserveSeaFraction(next, null, null, seaZoneId, ocean, moatCells.length);
 
     return next;
   }
@@ -2686,22 +2848,30 @@ class TileMapGenerator {
   ) {
     if (provinceToContinent.isEmpty) return {};
     final numContinents = provinceToContinent.values.toSet().length;
-    final byContinent = _landCellsByContinent(grid, landSeeds, continentBySeedIndex);
+    final byContinent = _landCellsByContinent(
+      grid,
+      landSeeds,
+      continentBySeedIndex,
+    );
     final seeds = <String, (int x, int y)>{};
     const minDist = 3;
     for (var c = 0; c < numContinents; c++) {
       final cells = byContinent[c] ?? [];
       if (cells.isEmpty) continue;
-      final provinceIds = provinceToContinent.entries
-          .where((e) => e.value == c)
-          .map((e) => e.key)
-          .toList()
-        ..sort();
+      final provinceIds =
+          provinceToContinent.entries
+              .where((e) => e.value == c)
+              .map((e) => e.key)
+              .toList()
+            ..sort();
       final used = <(int x, int y)>{};
       for (final provinceId in provinceIds) {
         final shuffled = List<(int x, int y)>.from(cells)..shuffle(rnd);
         for (final (x, y) in shuffled) {
-          if (used.any((p) => (p.$1 - x).abs() < minDist && (p.$2 - y).abs() < minDist)) continue;
+          if (used.any(
+            (p) => (p.$1 - x).abs() < minDist && (p.$2 - y).abs() < minDist,
+          ))
+            continue;
           seeds[provinceId] = (x, y);
           used.add((x, y));
           break;
@@ -2744,21 +2914,21 @@ class TileMapGenerator {
   }
 
   /// Border noise: swap only at land/sea boundary (sentinel vs seaZoneId).
-  List<List<String>> _borderNoise(List<List<String>> grid, String seaZoneId, Random rnd) {
+  List<List<String>> _borderNoise(
+    List<List<String>> grid,
+    String seaZoneId,
+    Random rnd,
+  ) {
     final next = grid.map((row) => row.toList()).toList();
     for (var y = 1; y < params.height - 1; y++) {
       for (var x = 1; x < params.width - 1; x++) {
         if (rnd.nextDouble() >= params.borderNoise) continue;
         final id = grid[y][x];
-        final neighbors = [
-          (x - 1, y),
-          (x + 1, y),
-          (x, y - 1),
-          (x, y + 1),
-        ];
+        final neighbors = [(x - 1, y), (x + 1, y), (x, y - 1), (x, y + 1)];
         for (final (nx, ny) in neighbors) {
           final nid = grid[ny][nx];
-          final atBoundary = (id == _landSentinel && nid == seaZoneId) ||
+          final atBoundary =
+              (id == _landSentinel && nid == seaZoneId) ||
               (id == seaZoneId && nid == _landSentinel);
           if (atBoundary) {
             next[ny][nx] = id;
@@ -2771,4 +2941,3 @@ class TileMapGenerator {
     return next;
   }
 }
-

--- a/packages/colonizethis_map/pubspec.yaml
+++ b/packages/colonizethis_map/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   logger: ^2.0.2
+  colonizethis_logger:
   colonizethis_data:
   colonizethis_models:
   image: ^4.7.2

--- a/packages/colonizethis_save/lib/src/game_save_adapter.dart
+++ b/packages/colonizethis_save/lib/src/game_save_adapter.dart
@@ -1,9 +1,9 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:hive/hive.dart';
-import 'package:logger/logger.dart';
 
-final Logger _log = Logger();
+final _log = saveLogger();
 
 const String _suffixTileMapByRegion = '_tileMapByRegion';
 const String _suffixTopologyByRegion = '_topologyByRegion';
@@ -49,31 +49,38 @@ class GameSaveAdapter {
     final allKeys = box.keys.whereType<String>().toSet();
 
     final definiteGameIds = allKeys
-        .where((k) =>
-            !k.endsWith(_suffixTileMapByRegion) &&
-            !k.endsWith(_suffixTopologyByRegion) &&
-            !k.endsWith(_suffixCombinedTopology) &&
-            !k.endsWith(_suffixWarpLinks))
+        .where(
+          (k) =>
+              !k.endsWith(_suffixTileMapByRegion) &&
+              !k.endsWith(_suffixTopologyByRegion) &&
+              !k.endsWith(_suffixCombinedTopology) &&
+              !k.endsWith(_suffixWarpLinks),
+        )
         .toSet();
 
     final result = <String>[...definiteGameIds];
 
     for (final key in allKeys) {
       if (key.endsWith(_suffixTileMapByRegion)) {
-        final prefix =
-            key.substring(0, key.length - _suffixTileMapByRegion.length);
+        final prefix = key.substring(
+          0,
+          key.length - _suffixTileMapByRegion.length,
+        );
         if (!definiteGameIds.contains(prefix)) result.add(key);
       } else if (key.endsWith(_suffixTopologyByRegion)) {
-        final prefix =
-            key.substring(0, key.length - _suffixTopologyByRegion.length);
+        final prefix = key.substring(
+          0,
+          key.length - _suffixTopologyByRegion.length,
+        );
         if (!definiteGameIds.contains(prefix)) result.add(key);
       } else if (key.endsWith(_suffixCombinedTopology)) {
-        final prefix =
-            key.substring(0, key.length - _suffixCombinedTopology.length);
+        final prefix = key.substring(
+          0,
+          key.length - _suffixCombinedTopology.length,
+        );
         if (!definiteGameIds.contains(prefix)) result.add(key);
       } else if (key.endsWith(_suffixWarpLinks)) {
-        final prefix =
-            key.substring(0, key.length - _suffixWarpLinks.length);
+        final prefix = key.substring(0, key.length - _suffixWarpLinks.length);
         if (!definiteGameIds.contains(prefix)) result.add(key);
       }
     }
@@ -111,10 +118,13 @@ class GameSaveAdapter {
 
   /// Loads map data for [gameId]. Returns null if any key is missing (legacy save).
   /// Warp links are optional for backward compatibility with legacy saves.
-  ({Map<String, TileMapResult> tileMapByRegion,
+  ({
+    Map<String, TileMapResult> tileMapByRegion,
     Map<String, MapTopology> topologyByRegion,
     MapTopology combinedTopology,
-    List<WarpLink>? warpLinks})? loadMapData(Box<dynamic> box, String gameId) {
+    List<WarpLink>? warpLinks,
+  })?
+  loadMapData(Box<dynamic> box, String gameId) {
     final tileRaw = box.get(gameId + _suffixTileMapByRegion);
     final topoRaw = box.get(gameId + _suffixTopologyByRegion);
     final combinedRaw = box.get(gameId + _suffixCombinedTopology);
@@ -134,8 +144,9 @@ class GameSaveAdapter {
           MapTopology.fromJson(Map<String, dynamic>.from(v as Map)),
         ),
       );
-      final combinedTopology =
-          MapTopology.fromJson(Map<String, dynamic>.from(combinedRaw as Map));
+      final combinedTopology = MapTopology.fromJson(
+        Map<String, dynamic>.from(combinedRaw as Map),
+      );
       // Warp links are optional for backward compatibility.
       final warpRaw = box.get(gameId + _suffixWarpLinks);
       List<WarpLink>? warpLinks;
@@ -152,8 +163,11 @@ class GameSaveAdapter {
         warpLinks: warpLinks,
       );
     } catch (e, st) {
-      _log.e('save: load map data failed gameId=$gameId',
-          error: e, stackTrace: st);
+      _log.e(
+        'save: load map data failed gameId=$gameId',
+        error: e,
+        stackTrace: st,
+      );
       return null;
     }
   }

--- a/packages/session_log_buffer/lib/session_log_buffer.dart
+++ b/packages/session_log_buffer/lib/session_log_buffer.dart
@@ -5,7 +5,7 @@ import 'package:logger/logger.dart';
 /// Default maximum number of log entries to retain (oldest dropped when exceeded).
 const int defaultMaxEntries = 5000;
 
-/// Known log prefixes used in the project (ctdev, logic, ai, data, map, save, tui).
+/// Known log prefixes used in the project (ctdev, logic, ai, data, map, save, tui, game).
 /// Used for filter options in the viewer.
 const List<String> knownPrefixes = [
   'ctdev',
@@ -14,6 +14,7 @@ const List<String> knownPrefixes = [
   'data',
   'map',
   'save',
+  'game',
   'tui',
 ];
 
@@ -69,9 +70,26 @@ class SessionLogEntry {
   }
 }
 
+class _DebugLevelFilter implements LogFilter {
+  @override
+  Level? level;
+
+  @override
+  Future<void> init() async {}
+
+  @override
+  Future<void> destroy() async {}
+
+  @override
+  bool shouldLog(LogEvent event) {
+    return event.level >= Logger.level;
+  }
+}
+
 /// In-memory session log buffer. Thread-safe for single-threaded Dart; call [init] once at startup.
 class SessionLogBuffer {
-  SessionLogBuffer({int maxEntries = defaultMaxEntries}) : _maxEntries = maxEntries;
+  SessionLogBuffer({int maxEntries = defaultMaxEntries})
+    : _maxEntries = maxEntries;
 
   final int _maxEntries;
   final List<SessionLogEntry> _entries = [];
@@ -79,7 +97,9 @@ class SessionLogBuffer {
 
   /// Adds a log event to the buffer. Drops oldest entries when over [maxEntries].
   void add(LogEvent e) {
-    final msg = e.message is String ? e.message as String : e.message.toString();
+    final msg = e.message is String
+        ? e.message as String
+        : e.message.toString();
     final entry = SessionLogEntry(
       time: e.time,
       level: e.level,
@@ -128,6 +148,7 @@ class SessionLogBuffer {
     if (_instance._initialized) return;
     _instance._initialized = true;
     Logger.level = Level.debug;
+    Logger.defaultFilter = () => _DebugLevelFilter();
     Logger.addLogListener((LogEvent e) {
       _instance.add(e);
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ workspace:
   - ctdev
   - ctterm
   - packages/session_log_buffer
+  - packages/colonizethis_logger
   - packages/colonizethis_models
   - packages/colonizethis_data
   - packages/colonizethis_save


### PR DESCRIPTION
## Summary

- **New package:** `colonizethis_logger` with `CtLogger` utility that auto-prefixes all log messages
- **Migrated packages:** logic, ai, map, data, save, and Flame components to use typed loggers
- **Prefixes:** `logic:`, `ai:`, `map:`, `data:`, `save:`, `game:`, `app:`
- **Spec:** `SPEC/program/colonizethis-logger.md`

## Changes

### New package: `packages/colonizethis_logger/`
- `CtLogger` class wraps `Logger()` and auto-prefixes all messages
- Factory functions: `logicLogger()`, `aiLogger()`, `dataLogger()`, `mapLogger()`, `saveLogger()`, `gameLogger()`, `appLogger()`

### Migrated packages
| Package | Prefix | Files |
|---------|--------|-------|
| colonizethis_logic | `logic:` | 17 |
| colonizethis_ai | `ai:` | 6 |
| colonizethis_map | `map:` | 2 |
| colonizethis_data | `data:` | 1 |
| colonizethis_save | `save:` | 1 |
| app Flame components | `game:` | 3 |

### Updated session_log_buffer
- Added `'game'` to `knownPrefixes`

## Testing

- `dart test packages/colonizethis_logger` - 10 tests pass
- `dart test packages/session_log_buffer` - 8 tests pass
- `dart analyze` - all packages pass (only info-level issues, no errors)