### PR TITLE
feat(terrain): sea/map Wang fallbacks (from sea-tile-visibility)

### DIFF
--- a/app/lib/features/game/flame/region_map_component.dart
+++ b/app/lib/features/game/flame/region_map_component.dart
@@ -277,12 +277,77 @@ class CtRegionMapComponent extends PositionComponent {
   }
 
   void _paintTiles(Canvas canvas) {
-    // Guard: if tilesets not loaded yet, render nothing (will render on next frame after load)
-    // This can happen when render() is called before onLoad() completes due to Flame's sync rendering
+    // If Wang tilesets are not ready yet, still paint visibility-aware solid colors so the
+    // map never flashes empty (Flame can render before onLoad completes).
     if (!terrainTilesetCache.isLoaded) {
+      _paintTilesFallback(canvas);
       return;
     }
     _paintTilesWithTilesets(canvas);
+  }
+
+  /// Solid-colour fallback for all cells; honours [CtMapVisibilityMode.playerConstrained].
+  void _paintTilesFallback(Canvas canvas) {
+    final paint = Paint()..style = PaintingStyle.fill;
+    for (final cell in region.cells) {
+      final left = cell.x * cellSize;
+      final top = cell.y * cellSize;
+      final rect = Rect.fromLTWH(left, top, cellSize, cellSize);
+
+      if (visibilityMode == CtMapVisibilityMode.playerConstrained &&
+          cell.visibility == TileVisibility.unrevealed) {
+        paint.color = Colors.black;
+        canvas.drawRect(rect, paint);
+        continue;
+      }
+
+      final Color baseColor;
+      if (cell.isSea) {
+        baseColor = const Color(0xFF003366);
+      } else {
+        final terrain = _terrainTypeForCell(cell);
+        final rgb = terrain != null
+            ? (region.terrainColors[terrain] ?? (128, 128, 128))
+            : (128, 128, 128);
+        baseColor = Color.fromARGB(255, rgb.$1, rgb.$2, rgb.$3);
+      }
+
+      paint.color = _fogAdjustedSolidColor(cell, baseColor);
+      canvas.drawRect(rect, paint);
+    }
+  }
+
+  TerrainType? _terrainTypeForCell(CellViewData cell) {
+    if (cell.terrainType != null) return cell.terrainType;
+    final id = cell.terrainTypeId;
+    if (id == null) return null;
+    try {
+      return TerrainType.values.byName(id);
+    } on ArgumentError {
+      return null;
+    }
+  }
+
+  Color _fogAdjustedSolidColor(CellViewData cell, Color baseColor) {
+    if (visibilityMode == CtMapVisibilityMode.playerConstrained &&
+        cell.visibility == TileVisibility.fogged) {
+      return Color.lerp(baseColor, Colors.black, 0.7)!;
+    }
+    return baseColor;
+  }
+
+  void _paintSeaSolidFallback(
+    Canvas canvas,
+    CellViewData cell,
+    double left,
+    double top,
+  ) {
+    const baseColor = Color(0xFF1e3a5f);
+    final rect = Rect.fromLTWH(left, top, cellSize, cellSize);
+    canvas.drawRect(
+      rect,
+      Paint()..color = _fogAdjustedSolidColor(cell, baseColor),
+    );
   }
 
   void _paintTilesWithTilesets(Canvas canvas) {
@@ -336,10 +401,12 @@ class CtRegionMapComponent extends PositionComponent {
         : terrainTilesetCache.getSeaPlainsTileset();
 
     if (tileset == null) {
-      throw StateError(
-        'Sea tileset is null for dominantLandType=$dominantLandType - '
-        'terrain tileset failed to load',
+      _log.w(
+        'Sea Wang tileset missing for dominantLandType=$dominantLandType; '
+        'using solid sea fallback',
       );
+      _paintSeaSolidFallback(canvas, cell, left, top);
+      return;
     }
 
     if (landCorner.same) {
@@ -359,11 +426,13 @@ class CtRegionMapComponent extends PositionComponent {
             Paint()..color = Color.fromRGBO(0, 0, 0, _fogOverlayOpacity),
           );
         }
+      } else {
+        _paintSeaSolidFallback(canvas, cell, left, top);
       }
       return;
     }
 
-    _drawTile(
+    if (!_drawTile(
       canvas,
       tileset,
       left,
@@ -373,7 +442,9 @@ class CtRegionMapComponent extends PositionComponent {
       sw: landCorner.sw,
       se: landCorner.se,
       cell: cell,
-    );
+    )) {
+      _paintSeaSolidFallback(canvas, cell, left, top);
+    }
   }
 
   void _paintLandBaseCell(Canvas canvas, CellViewData cell) {

--- a/app/test/ct_region_map_test.dart
+++ b/app/test/ct_region_map_test.dart
@@ -646,26 +646,17 @@ void main() {
     );
 
     testWidgets(
-      'map throws StateError when terrain tileset fails to load (no silent fallback)',
+      'map builds when Wang tilesets load; uses visibility-aware solid fallback until loaded',
       (WidgetTester tester) async {
-        // This test verifies that the map fails loudly instead of falling back to solid colors
-        // when terrain tilesets cannot be loaded. The behavior is:
-        // - region_map_component.dart throws StateError when tileset is null
-        // - This ensures missing tilesets are visible as errors, not silently rendered as solid colors
-
-        // The global terrainTilesetCache must be loaded for the map to render properly.
-        // If it fails to load (e.g., missing assets), the component will throw.
-        // This test documents the expected behavior: map should NOT silently fall back.
+        // TerrainTilesetCache logs and leaves isLoaded false if Wang assets fail to load.
+        // CtRegionMapComponent then paints [_paintTilesFallback] (no blank frame) until
+        // tilesets succeed. Sea Wang lookup failures at paint time log and use a sea solid
+        // fallback instead of throwing.
         final region = _oldWorldRegion();
 
-        // Build map - if tileset loading failed, this would throw a StateError
-        // rather than rendering solid color fallback
         await tester.pumpWidget(_buildCtRegionMap(region: region));
         await tester.pump();
 
-        // If we reach here, tilesets loaded successfully.
-        // The test verifies that if tilesets failed to load, an error would be thrown
-        // rather than silently falling back to solid colors.
         expect(find.byType(CtRegionMap), findsOneWidget);
       },
       timeout: const Timeout(Duration(seconds: 10)),


### PR DESCRIPTION
## Summary
`feature/sea-tile-visibility` is **not** merged into `dev` (tip `7aa94fa` is not an ancestor of `origin/dev`). A straight cherry-pick conflicts heavily: `dev` already has Wang tilesets, layered terrain, resource icons, coastal sea-zone full visibility, and `colonizethis_logger`.

This PR ports the **safe** rendering pieces aligned with that branch’s intent:

- **While `TerrainTilesetCache` is not loaded:** paint visibility-aware solid colours for all tiles (no blank first frames).
- **Sea Wang missing or sea tile lookup fails at paint time:** log a warning and draw a **fog-aware** solid sea colour instead of throwing.

## Intentionally not included
- Removal of `applyCoastalSeaZoneFullVisibility` from `initial_visibility.dart` (would contradict `SPEC/program/fog-and-exploration-resolution.md` and current `game_setup_test` expectations).
- Logger regressions / older map shell from `7aa94fa`.

## Tests
- `flutter test` (subset): `app/test/features/game/flame/terrain_tileset_test.dart`, `app/test/ct_region_map_test.dart`
- `dart test packages/colonizethis_logic/test/game_setup_test.dart --name sea` (sea visibility)


Made with [Cursor](https://cursor.com)