### PR TITLE
feat(naval): allow splitting the Home Fleet

### DIFF
--- a/SPEC/ui/naval-units-fleet-management.md
+++ b/SPEC/ui/naval-units-fleet-management.md
@@ -66,7 +66,7 @@ Each non-Home Fleet row in the expanded state shows a **"Combine"** button.
 
 ### Trigger
 
-Each non-Home Fleet row in the expanded state shows a **"Split Fleet"** button.
+Each fleet row in the expanded state shows a **"Split Fleet"** button, including the Home Fleet.
 
 ### Dialog
 
@@ -112,7 +112,7 @@ Clicking "Split Fleet" opens a modal dialog: **Split Fleet Dialog**.
 |------|-------------|
 | Same location | New fleet spawns at the same port province or sea zone as the original. |
 | Minimum ships | Original fleet must retain at least 1 ship (unless it's the Home Fleet). |
-| Home Fleet | Home Fleet **cannot be split**. |
+| Home Fleet | Home Fleet **can be split** — all newly built ships appear in the Home Fleet, so players must be able to split off a detachment. |
 | Naming | New fleet is assigned the next available number: "Fleet N" where N is the next unused integer. |
 | Region | New fleet has the same `regionId` as the original. |
 | Mission | New fleet has `mission = FleetMission.none`. |
@@ -173,7 +173,7 @@ After any fleet operation (split or combine):
 
 - **Given** a fleet with 4 ships, **when** the user moves all 4 ships to the new fleet in the split dialog, **then** the Confirm button is disabled and the original fleet cannot be split.
 
-- **Given** the Home Fleet is present, **when** the user views fleet options, **then** the Home Fleet does not show a Split Fleet button.
+- **Given** the Home Fleet is present with ships, **when** the user expands the Home Fleet row, **then** the Home Fleet shows a Split Fleet button, allowing the player to split off a detachment.
 
 ### Empty Fleet Cleanup
 

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -658,8 +658,9 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
                                   onCombineToggle: () =>
                                       _toggleFleetForCombine(group.homeFleet!),
                                   onCombineConfirm: () => _confirmCombine(),
-                                  onSplitFleet: null,
-                                  isSplitAllowed: false,
+                                  onSplitFleet: () =>
+                                      _openSplitDialog(group.homeFleet!),
+                                  isSplitAllowed: true,
                                 ),
                               for (final loc in group.locations) ...[
                                 _LocationHeader(

--- a/app/lib/features/game/widgets/split_fleet_dialog.dart
+++ b/app/lib/features/game/widgets/split_fleet_dialog.dart
@@ -58,7 +58,6 @@ class _SplitFleetDialogState extends State<SplitFleetDialog> {
   }
 
   bool get _canConfirm {
-    if (widget.isHomeFleet) return false;
     return _totalOriginal >= 1;
   }
 
@@ -209,7 +208,7 @@ class _SplitFleetDialogState extends State<SplitFleetDialog> {
                       }
                     }
                   },
-                  enabled: _totalOriginal > 0 && !widget.isHomeFleet,
+                  enabled: _totalOriginal > 0,
                   child: const Icon(Icons.arrow_back),
                 ),
                 const SizedBox(width: 16),

--- a/app/test/naval_units_panel_test.dart
+++ b/app/test/naval_units_panel_test.dart
@@ -511,7 +511,7 @@ void main() {
       },
     );
 
-    testWidgets('AC: Split button is not shown for Home Fleet', (
+    testWidgets('AC: Split button is shown for Home Fleet with ships', (
       WidgetTester tester,
     ) async {
       final humanId = humanPlayerIdWithFleets;
@@ -524,11 +524,18 @@ void main() {
         return;
       }
 
+      final homeFleet = game.worldState.fleets.where(
+        (f) => f.ownerId == humanId && f.shipTypeIds.isNotEmpty,
+      );
+      if (homeFleet.isEmpty) {
+        return;
+      }
+
       await tester.ensureVisible(homeFleetFinder);
       await tester.tap(homeFleetFinder);
       await tester.pumpAndSettle();
 
-      expect(find.text('Split'), findsNothing);
+      expect(find.text('Split'), findsOneWidget);
     });
 
     testWidgets('AC: Combine button is not shown for Home Fleet', (
@@ -827,9 +834,7 @@ void main() {
             },
           },
         ),
-        players: const [
-          Player(id: playerId, displayName: 'P', isHuman: true),
-        ],
+        players: const [Player(id: playerId, displayName: 'P', isHuman: true)],
       );
 
       await tester.pumpWidget(
@@ -868,6 +873,5 @@ void main() {
 
       expect(find.text('No naval units'), findsOneWidget);
     });
-
   });
 }

--- a/app/test/split_fleet_dialog_test.dart
+++ b/app/test/split_fleet_dialog_test.dart
@@ -22,120 +22,117 @@ void main() {
         newWorld: const RegionData(),
       ),
       players: const [
-        Player(
-          id: 'gp1',
-          displayName: 'Human',
-          isHuman: true,
-          treasury: 0,
-        ),
+        Player(id: 'gp1', displayName: 'Human', isHuman: true, treasury: 0),
       ],
     );
   }
 
-  testWidgets('SplitFleetDialog at sea shows region label and can confirm split', (
-    WidgetTester tester,
-  ) async {
-    List<String>? captured;
-    final fleet = Fleet(
-      id: 'f1',
-      ownerId: 'gp1',
-      regionId: 'oldWorld',
-      seaZoneId: 'oldWorld|s1',
-      shipTypeIds: const ['carrack', 'carrack', 'fluyte'],
-    );
-    final game = _minimalGame(provinces: const []);
+  testWidgets(
+    'SplitFleetDialog at sea shows region label and can confirm split',
+    (WidgetTester tester) async {
+      List<String>? captured;
+      final fleet = Fleet(
+        id: 'f1',
+        ownerId: 'gp1',
+        regionId: 'oldWorld',
+        seaZoneId: 'oldWorld|s1',
+        shipTypeIds: const ['carrack', 'carrack', 'fluyte'],
+      );
+      final game = _minimalGame(provinces: const []);
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Builder(
-            builder: (context) {
-              return _openDialogButton(() {
-                showDialog<void>(
-                  context: context,
-                  builder: (ctx) => SplitFleetDialog(
-                    originalFleet: fleet,
-                    game: game,
-                    humanPlayerId: 'gp1',
-                    isHomeFleet: false,
-                    onConfirm: (ships) => captured = ships,
-                  ),
-                );
-              });
-            },
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                return _openDialogButton(() {
+                  showDialog<void>(
+                    context: context,
+                    builder: (ctx) => SplitFleetDialog(
+                      originalFleet: fleet,
+                      game: game,
+                      humanPlayerId: 'gp1',
+                      isHomeFleet: false,
+                      onConfirm: (ships) => captured = ships,
+                    ),
+                  );
+                });
+              },
+            ),
           ),
         ),
-      ),
-    );
-    await tester.tap(find.text('open'));
-    await tester.pumpAndSettle();
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
 
-    expect(find.textContaining('Region'), findsWidgets);
+      expect(find.textContaining('Region'), findsWidgets);
 
-    await tester.tap(find.byIcon(Icons.arrow_forward).first);
-    await tester.pump();
-    await tester.tap(find.text('Confirm Split'));
-    await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.arrow_forward).first);
+      await tester.pump();
+      await tester.tap(find.text('Confirm Split'));
+      await tester.pumpAndSettle();
 
-    expect(captured, isNotNull);
-    expect(captured!.length, 1);
-  });
+      expect(captured, isNotNull);
+      expect(captured!.length, 1);
+    },
+  );
 
-  testWidgets('SplitFleetDialog in port shows province name and home fleet blocks moves', (
-    WidgetTester tester,
-  ) async {
-    const ow = 'oldWorld';
-    final province = Province(
-      id: '$ow|p1',
-      regionId: ow,
-      displayName: 'TestPort',
-      ownerId: 'gp1',
-    );
-    final game = _minimalGame(provinces: [province]);
-    final fleet = Fleet(
-      id: 'f2',
-      ownerId: 'gp1',
-      regionId: ow,
-      inPortAtProvinceId: province.id,
-      shipTypeIds: const ['fluyte'],
-    );
+  testWidgets(
+    'SplitFleetDialog in port shows province name and home fleet blocks moves',
+    (WidgetTester tester) async {
+      const ow = 'oldWorld';
+      final province = Province(
+        id: '$ow|p1',
+        regionId: ow,
+        displayName: 'TestPort',
+        ownerId: 'gp1',
+      );
+      final game = _minimalGame(provinces: [province]);
+      final fleet = Fleet(
+        id: 'f2',
+        ownerId: 'gp1',
+        regionId: ow,
+        inPortAtProvinceId: province.id,
+        shipTypeIds: const ['fluyte'],
+      );
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Builder(
-            builder: (context) {
-              return _openDialogButton(() {
-                showDialog<void>(
-                  context: context,
-                  builder: (ctx) => SplitFleetDialog(
-                    originalFleet: fleet,
-                    game: game,
-                    humanPlayerId: 'gp1',
-                    isHomeFleet: false,
-                    onConfirm: (_) {},
-                  ),
-                );
-              });
-            },
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                return _openDialogButton(() {
+                  showDialog<void>(
+                    context: context,
+                    builder: (ctx) => SplitFleetDialog(
+                      originalFleet: fleet,
+                      game: game,
+                      humanPlayerId: 'gp1',
+                      isHomeFleet: false,
+                      onConfirm: (_) {},
+                    ),
+                  );
+                });
+              },
+            ),
           ),
         ),
-      ),
-    );
-    await tester.tap(find.text('open'));
-    await tester.pumpAndSettle();
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
 
-    expect(find.text('TestPort — Old World'), findsNWidgets(2));
+      expect(find.text('TestPort — Old World'), findsNWidgets(2));
 
-    await tester.tap(find.byIcon(Icons.arrow_back));
-    await tester.pump();
-    await tester.tap(find.byIcon(Icons.arrow_forward));
-    await tester.pump();
-    await tester.tap(find.text('Cancel'));
-    await tester.pumpAndSettle();
-  });
+      await tester.tap(find.byIcon(Icons.arrow_back));
+      await tester.pump();
+      await tester.tap(find.byIcon(Icons.arrow_forward));
+      await tester.pump();
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+    },
+  );
 
-  testWidgets('SplitFleetDialog home fleet disables confirm and bulk transfer', (
+  testWidgets('SplitFleetDialog home fleet can be split', (
     WidgetTester tester,
   ) async {
     final fleet = Fleet(
@@ -175,7 +172,7 @@ void main() {
     final confirm = tester.widget<CtNinePatchButton>(
       find.widgetWithText(CtNinePatchButton, 'Confirm Split'),
     );
-    expect(confirm.enabled, isFalse);
+    expect(confirm.enabled, isTrue);
 
     final bulkBack = find.descendant(
       of: find.byType(SplitFleetDialog),
@@ -186,7 +183,7 @@ void main() {
             (w.child! as Icon).icon == Icons.arrow_back,
       ),
     );
-    expect(tester.widget<CtNinePatchButton>(bulkBack.first).enabled, isFalse);
+    expect(tester.widget<CtNinePatchButton>(bulkBack.first).enabled, isTrue);
   });
 
   testWidgets('SplitFleetDialog long-press moves all of one type', (


### PR DESCRIPTION
## Summary
- Enable split functionality for Home Fleet in Naval Units Panel
- Home Fleet now shows Split button when expanded (was blocked before)
- All newly built ships appear in Home Fleet, so players must be able to split off a detachment

## Changes
- **Spec**: Updated `naval-units-fleet-management.md` to allow Home Fleet splitting
- **Impl**: `naval_units_panel.dart` - enabled `onSplitFleet` for Home Fleet
- **Impl**: `split_fleet_dialog.dart` - removed Home Fleet block in `_canConfirm` and bulk move
- **Tests**: Updated tests to reflect new behavior (24 tests passing)

## Testing
All 24 related tests pass:
- `flutter test test/naval_units_panel_test.dart test/split_fleet_dialog_test.dart`