### PR TITLE
fix(app): Train civilians dialog when opened from empire menu

### DIFF
--- a/app/lib/features/game/flame/game_side_menu.dart
+++ b/app/lib/features/game/flame/game_side_menu.dart
@@ -98,6 +98,10 @@ class GameSideMenu extends ConsumerWidget {
         iconAsset: 'assets/images/ui_icon_civilian_units.png',
         label: 'Civilian Units',
         onPressed: () {
+          // Capture navigator before onClose(): GameSideMenu is removed from
+          // the tree when the sheet opens; Train's showDialog must not use this
+          // widget's BuildContext (it would be unmounted).
+          final navigator = Navigator.of(context);
           onClose();
           // Capture values before showing bottom sheet to avoid using
           // disposed ref when widget rebuilds during work target selection.
@@ -105,7 +109,7 @@ class GameSideMenu extends ConsumerWidget {
           final currentOrders = ref.read(currentOrdersProvider);
           final availableWorkTargets = ref.read(availableWorkTargetsProvider);
           showModalBottomSheet<void>(
-            context: context,
+            context: navigator.context,
             isScrollControlled: true,
             builder: (ctx) {
               final isNarrowCtx =
@@ -140,7 +144,7 @@ class GameSideMenu extends ConsumerWidget {
                   onTrainPressed: () {
                     Navigator.of(ctx).pop();
                     showDialog<void>(
-                      context: context,
+                      context: navigator.context,
                       builder: (dialogCtx) => TrainCiviliansDialog(
                         game: currentGame,
                         humanPlayerId: humanPlayerId,

--- a/app/test/game_side_menu_test.dart
+++ b/app/test/game_side_menu_test.dart
@@ -7,6 +7,7 @@ import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart
 import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/civilian_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/production_screen.dart';
+import 'package:colonizethis_app/features/game/widgets/train_civilians_dialog.dart';
 import 'package:colonizethis_app/providers/game_service_provider.dart';
 import 'package:colonizethis_app/providers/games_box_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
@@ -345,6 +346,50 @@ void main() {
     expect(find.byType(CivilianUnitsPanel), findsOneWidget);
   });
 
+  testWidgets(
+    'GameSideMenu Train presents dialog when side menu was unmounted (regression)',
+    (WidgetTester tester) async {
+      final humanPlayerId = game.players.where((p) => p.isHuman).isNotEmpty
+          ? game.players.where((p) => p.isHuman).first.id
+          : game.players.first.id;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gamesBoxProvider.overrideWith((ref) => gamesBox),
+            gameServiceProvider.overrideWith(
+              (ref) => GameService(gamesBox, GameSaveAdapter()),
+            ),
+            currentGameProvider.overrideWith((ref) => game),
+            currentOrdersProvider.overrideWith((ref) => const Orders()),
+            availableWorkTargetsProvider.overrideWith(
+              (ref) => <String, List<String>>{},
+            ),
+          ],
+          child: MaterialApp(
+            home: _SideMenuUnmountingHost(
+              game: game,
+              humanPlayerId: humanPlayerId,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Civilian Units'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(GameSideMenu), findsNothing);
+      expect(find.byType(CivilianUnitsPanel), findsOneWidget);
+
+      await tester.tap(find.text('Train'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TrainCiviliansDialog), findsOneWidget);
+      expect(find.text('Train Civilians'), findsOneWidget);
+    },
+  );
+
   testWidgets('GameSideMenu Diplomacy pushes DiplomacyScreen', (
     WidgetTester tester,
   ) async {
@@ -504,5 +549,48 @@ void main() {
 
     expect(closed, isTrue);
   });
+}
+
+/// Mirrors [GameMapArea]: opening Civilian Units calls [GameSideMenu.onClose],
+/// which removes the menu from the tree before the bottom sheet is shown.
+class _SideMenuUnmountingHost extends ConsumerStatefulWidget {
+  const _SideMenuUnmountingHost({
+    required this.game,
+    required this.humanPlayerId,
+  });
+
+  final Game game;
+  final String humanPlayerId;
+
+  @override
+  ConsumerState<_SideMenuUnmountingHost> createState() =>
+      _SideMenuUnmountingHostState();
+}
+
+class _SideMenuUnmountingHostState extends ConsumerState<_SideMenuUnmountingHost> {
+  bool _sideMenuOpen = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          if (_sideMenuOpen)
+            GameSideMenu(
+              game: widget.game,
+              humanPlayerId: widget.humanPlayerId,
+              sideMenuOpen: true,
+              onClose: () => setState(() => _sideMenuOpen = false),
+              onPanelDismissed: () {},
+              onLocateCivilianUnit: (_) {},
+              onLocateMilitaryTile: (_, __) {},
+              onLocateNavalFleet: (_, __) {},
+              onCancelUnitWork: (_) {},
+              onStartWorkTargetSelection: (_, __) {},
+            ),
+        ],
+      ),
+    );
+  }
 }
 


### PR DESCRIPTION
## Problem
Tapping **Train** on the Civilian Units bottom sheet did nothing in-game because `GameSideMenu` is removed from the tree when opening the sheet (`onClose()` runs first). `onTrainPressed` still used that widget's `BuildContext` for `showDialog`, which is unmounted by then.

## Fix
- Capture `Navigator.of(context)` **before** `onClose()`.
- Use `navigator.context` for `showModalBottomSheet` and for `showDialog` in the Train handler.

## Test
- Regression widget test: `_SideMenuUnmountingHost` mirrors `GameMapArea` (menu unmounts, sheet opens, Train shows `TrainCiviliansDialog`).

Made with [Cursor](https://cursor.com)