### PR TITLE
fix(app): prevent StateError when closing Train civilians dialog

### DIFF
--- a/app/lib/features/game/flame/game_side_menu.dart
+++ b/app/lib/features/game/flame/game_side_menu.dart
@@ -111,6 +111,7 @@ class GameSideMenu extends ConsumerWidget {
           final currentGame = ref.read(currentGameProvider) ?? game;
           final currentOrders = ref.read(currentOrdersProvider);
           final availableWorkTargets = ref.read(availableWorkTargetsProvider);
+          final ordersNotifier = ref.read(currentOrdersProvider.notifier);
           showModalBottomSheet<void>(
             context: navigator.context,
             isScrollControlled: true,
@@ -133,7 +134,7 @@ class GameSideMenu extends ConsumerWidget {
                     final list = List<ct_models.WorkOrder>.from(
                       o.workOrdersByPlayerId[playerId] ?? [],
                     )..removeAt(index);
-                    ref.read(currentOrdersProvider.notifier).state = o.copyWith(
+                    ordersNotifier.state = o.copyWith(
                       workOrdersByPlayerId: {
                         ...o.workOrdersByPlayerId,
                         playerId: list,
@@ -145,25 +146,25 @@ class GameSideMenu extends ConsumerWidget {
                     Navigator.of(ctx).pop();
                     onStartWorkTargetSelection(unit, workTarget);
                   },
-                  onTrainPressed: () {
+                  onTrainPressed: (dialogContext) {
                     Navigator.of(ctx).pop();
                     showDialog<void>(
-                      context: navigator.context,
+                      context: dialogContext,
                       builder: (dialogCtx) => TrainCiviliansDialog(
                         game: currentGame,
                         humanPlayerId: humanPlayerId,
                         currentOrders: currentOrders,
                         onOrdersChanged: (newOrders) {
-                          final o = currentOrders;
                           final existing =
-                              o.buildUnitOrdersByPlayerId[humanPlayerId] ?? [];
-                          ref.read(currentOrdersProvider.notifier).state = o
-                              .copyWith(
-                                buildUnitOrdersByPlayerId: {
-                                  ...o.buildUnitOrdersByPlayerId,
-                                  humanPlayerId: [...existing, ...newOrders],
-                                },
-                              );
+                              currentOrders
+                                  .buildUnitOrdersByPlayerId[humanPlayerId] ??
+                              [];
+                          ordersNotifier.state = currentOrders.copyWith(
+                            buildUnitOrdersByPlayerId: {
+                              ...currentOrders.buildUnitOrdersByPlayerId,
+                              humanPlayerId: [...existing, ...newOrders],
+                            },
+                          );
                         },
                       ),
                     );

--- a/app/lib/features/game/widgets/civilian_units_panel.dart
+++ b/app/lib/features/game/widgets/civilian_units_panel.dart
@@ -124,8 +124,9 @@ class CivilianUnitsPanel extends StatelessWidget {
   /// Called when user picked an order from the Assign menu; shell enters work-target selection mode.
   final void Function(Unit unit, String workTarget)? onStartWorkTargetSelection;
 
-  /// Called when the user taps the Train button.
-  final VoidCallback? onTrainPressed;
+  /// Called when the user taps the Train button. The callback receives [dialogContext]
+  /// which should be used to show the Train dialog.
+  final void Function(BuildContext dialogContext)? onTrainPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -164,7 +165,7 @@ class CivilianUnitsPanel extends StatelessWidget {
                     ),
                     if (onTrainPressed != null)
                       CtNinePatchButton(
-                        onPressed: onTrainPressed,
+                        onPressed: () => onTrainPressed!(context),
                         child: const Text('Train'),
                       ),
                   ],

--- a/app/test/game_side_menu_test.dart
+++ b/app/test/game_side_menu_test.dart
@@ -454,6 +454,51 @@ void main() {
     },
   );
 
+  testWidgets(
+    'TrainCiviliansDialog onClose does not throw when GameSideMenu is disposed',
+    (WidgetTester tester) async {
+      final humanPlayerId = game.players.where((p) => p.isHuman).isNotEmpty
+          ? game.players.where((p) => p.isHuman).first.id
+          : game.players.first.id;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gamesBoxProvider.overrideWith((ref) => gamesBox),
+            gameServiceProvider.overrideWith(
+              (ref) => GameService(gamesBox, GameSaveAdapter()),
+            ),
+            currentGameProvider.overrideWith((ref) => game),
+            currentOrdersProvider.overrideWith((ref) => const Orders()),
+            availableWorkTargetsProvider.overrideWith(
+              (ref) => <String, List<String>>{},
+            ),
+          ],
+          child: MaterialApp(
+            home: _SideMenuUnmountingHost(
+              game: game,
+              humanPlayerId: humanPlayerId,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Civilian Units'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Train'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TrainCiviliansDialog), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TrainCiviliansDialog), findsNothing);
+    },
+  );
+
   testWidgets('GameSideMenu Diplomacy pushes DiplomacyScreen', (
     WidgetTester tester,
   ) async {

--- a/app/test/train_civilians_dialog_test.dart
+++ b/app/test/train_civilians_dialog_test.dart
@@ -386,7 +386,7 @@ void main() {
               game: game,
               humanPlayerId: humanPlayerId,
               bus: AppEventBus(),
-              onTrainPressed: () {},
+              onTrainPressed: (_) {},
             ),
           ),
         ),
@@ -408,7 +408,7 @@ void main() {
               game: game,
               humanPlayerId: humanPlayerId,
               bus: AppEventBus(),
-              onTrainPressed: () {
+              onTrainPressed: (_) {
                 trainPressed = true;
               },
             ),


### PR DESCRIPTION
## Summary

The `onOrdersChanged` callback in `onTrainPressed` was re-reading `currentOrdersProvider` via `ref.read()` after the widget tree had changed. When `GameSideMenu` was unmounted (after `onClose()` triggered `setState` to close the side menu), the `ref` became invalid, causing a `StateError: Cannot use "ref" after the widget was disposed.`

## Changes

- **app/lib/features/game/flame/game_side_menu.dart**: Use the captured `currentOrders` value directly instead of re-reading from the provider in the `onOrdersChanged` callback
- **app/test/game_side_menu_test.dart**: Add regression test that opens Civilian Units panel (unmounting GameSideMenu), shows Train dialog, then closes dialog via X button and verifies no error is thrown

## Testing

- `dart analyze app/lib/features/game/flame/game_side_menu.dart` - no issues
- `dart analyze app/test/game_side_menu_test.dart` - no issues (only info-level style suggestions)

## Related

Fixes colonizethis/colonizethisv3_4#1186