### PR TITLE
feat(app): add typed event bus architecture for UI↔UI decoupling

### DIFF
--- a/SPEC/program/app-event-bus.md
+++ b/SPEC/program/app-event-bus.md
@@ -1,0 +1,244 @@
+# App Event Bus — SPEC/program/app-event-bus.md
+
+**SPEC/program** — Typed event bus for decoupling UI↔UI, UI↔game logic, and game logic→UI communication. Province identity: [world-model-identity.md](../game/world-model-identity.md).
+
+---
+
+## Background / Motivation
+
+Direct `showDialog()` and `Navigator.of(context).push()/pop()` calls couple UI widgets to each other, making testing harder and preventing service-layer access to UI actions. A typed event bus lets any component emit actions (open dialog, navigate) without knowing who handles them, and lets handlers be composed, swapped, or tested in isolation.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        AppEventBus (singleton)                   │
+│   emit(AppEvent)  ─────────────────────►  stream                │
+└─────────────────────────────────────────────────────────────────┘
+         ▲                                        │
+         │ emit                                  │ listen
+         │                                        ▼
+  ┌──────────────┐                    ┌─────────────────────┐
+  │ Emitters     │                    │ AppEventHandler     │
+  │ - UI widgets │                    │ (shell level)      │
+  │ - Services   │                    │                    │
+  │ - Game logic │                    │ on<UIActionEvent>  │
+  └──────────────┘                    │   → showDialog     │
+                                     │   → Navigator.push │
+                                     │ on<UISystemEvent>  │
+                                     │   → SnackBar      │
+                                     └─────────────────────┘
+```
+
+---
+
+## Event Hierarchy
+
+```
+AppEvent (sealed)
+├── UIActionEvent        — UI requests other UI actions
+│   ├── OpenDialogEvent(dialogId, params?)
+│   ├── ConfirmDialogEvent(title, message, confirmLabel, cancelLabel) → bool
+│   ├── NavigateToRouteEvent(route, arguments?)
+│   ├── PopNavigationEvent()
+│   ├── OpenPanelEvent(panelId, params?)
+│   ├── ClosePanelEvent()
+│   ├── StartTargetSelectionEvent(unitId, action, onComplete?, onCancel?)
+│   └── CancelTargetSelectionEvent()
+│
+├── UISystemEvent        — transient system feedback
+│   ├── ShowSnackBarEvent(message, actionLabel?, action?)
+│   ├── ShowOverlayEvent(overlayId, params?)
+│   ├── DismissOverlayEvent(overlayId)
+│   └── NotifyEvent(title, body, priority?)
+│
+└── GameToUIEvent       — game layer → UI triggers
+    ├── TurnResolutionCompleteEvent(gameId, turnNumber)
+    ├── OvertureRequiredEvent(overtures)
+    ├── SaveGameCompleteEvent(gameId)
+    └── NewGameCreatedEvent(gameId)
+```
+
+---
+
+## Event Bus API
+
+```dart
+class AppEventBus {
+  factory AppEventBus() => _instance ??= AppEventBus._();
+  static AppEventBus? _instance;
+
+  void emit(AppEvent event);          // broadcast to all listeners
+  Stream<AppEvent> get stream;        // raw stream
+  Stream<T> on<T extends AppEvent>(); // typed filter
+
+  // Convenience streams
+  Stream<UIActionEvent>  get uiActionEvents;
+  Stream<UISystemEvent>  get uiSystemEvents;
+  Stream<GameToUIEvent>  get gameToUIEvents;
+  Stream<DialogueEvent>  get dialogueEvents;
+  Stream<PortraitMoodEvent> get portraitMoodEvents;
+
+  void dispose();
+}
+```
+
+---
+
+## AppEventHandler
+
+`AppEventHandler` lives at the shell level and translates events into Flutter calls.
+
+```dart
+class AppEventHandler {
+  AppEventHandler({
+    required AppEventBus bus,
+    required GlobalKey<NavigatorState> navigatorKey,
+    Map<String, DialogBuilder>? dialogBuilders,    // dialogId → builder
+    Map<String, PanelBuilder>? panelBuilders,      // panelId → builder
+    void Function(ShowSnackBarEvent)? onShowSnackBar,
+    void Function(ShowOverlayEvent)? onShowOverlay,
+    void Function(DismissOverlayEvent)? onDismissOverlay,
+    void Function(NotifyEvent)? onNotify,
+  });
+
+  void bind();   // start listening (call in initState)
+  void unbind(); // stop listening (call in dispose)
+}
+```
+
+**DialogBuilder**: `Widget Function(BuildContext, Map<String, Object?>? params?)`
+
+**PanelBuilder**: `Widget Function(BuildContext, Map<String, Object?>? params?)`
+
+---
+
+## Dialog/Panel IDs
+
+| ID | Widget | Builder location |
+|----|--------|-----------------|
+| `train_civilians` | `TrainCiviliansDialog` | `game_side_menu.dart` |
+| `quick_battle_result` | `QuickBattleResultDialog` | `game_screen.dart` or `GameMapArea` |
+| `combat_mode_choice` | `CombatModeChoiceDialog` | combat trigger site |
+| `map_display_options` | inline `AlertDialog` | `GameMapArea` |
+| `tech_detail` | inline tech dialog | `TechTreeWidget` |
+| `grant_or_subsidy` | `GrantOrSubsidyDialog` | `DiplomacyDialogs` |
+| `pause_menu` | pause bottom sheet | `GameScreen` |
+| `civilian_units` | `CivilianUnitsPanel` bottom sheet | `GameSideMenu` |
+| `military_units` | `MilitaryUnitsPanel` bottom sheet | `GameSideMenu` |
+| `naval_units` | `NavalUnitsPanel` bottom sheet | `GameSideMenu` |
+
+---
+
+## Routes
+
+Routes are named strings passed via `NavigateToRouteEvent`. Handled by `AppEventHandler` via `nav.pushNamed()`.
+
+| Route name | Screen |
+|------------|--------|
+| `Routes.debugLog` | `DebugLogViewerScreen` |
+| `Routes.production` | `ProductionScreen` (in-game, full screen) |
+| `Routes.diplomacy` | `DiplomacyScreen` (in-game, full screen) |
+| `Routes.technology` | `TechnologyScreen` (in-game, full screen) |
+
+---
+
+## Game Logic → UI Bridge
+
+`GameService` holds an optional `AppEventBus? eventBus`. When set, it emits `GameToUIEvent` variants after game state changes:
+
+- `TurnResolutionCompleteEvent` after `runTurnResolution` returns `TurnResolutionComplete`
+- `SaveGameCompleteEvent` after `saveGame()`
+- `NewGameCreatedEvent` after `createNewGame()`
+
+The raw `GameEvent` stream from `TurnResolver` is forwarded by passing `void Function(GameEvent)? onGameEvent` — callers are responsible for bridging to `AppEventBus` if needed.
+
+---
+
+## Migration Plan
+
+### Phase 1: Confirm dialogs (UI→UI, no return coupling)
+- `diplomacy_panel.dart` `_showConfirmDialog` → `ConfirmDialogEvent`
+- `civilian_units_panel.dart` `_confirmCancel` → `ConfirmDialogEvent`
+
+### Phase 2: Route navigation (UI→UI via Navigator.pushNamed)
+- `game_screen.dart` `_showPauseMenu` → `NavigateToRouteEvent` + `PopNavigationEvent`
+- `game_side_menu.dart` Production/Diplomacy/Technology pushes → `NavigateToRouteEvent`
+
+### Phase 3: Bottom sheets and panels (UI→UI via showModalBottomSheet)
+- `game_side_menu.dart` Civilian/Military/Naval units bottom sheets → `OpenPanelEvent`
+- `game_screen.dart` pause menu bottom sheet → `OpenPanelEvent`
+
+### Phase 4: Named dialogs (fire-and-forget)
+- `QuickBattleResultDialog` → `OpenDialogEvent` + registered builder
+- `CombatModeChoiceDialog` → refactored to use event + Future result pattern
+- `TrainCiviliansDialog` → `OpenDialogEvent` + registered builder
+- `GrantOrSubsidyDialog` → `OpenDialogEvent` + registered builder
+- `Tech detail dialog` → `OpenDialogEvent` + registered builder
+- `Map display options` → `OpenDialogEvent` + registered builder
+
+---
+
+## Acceptance Criteria
+
+### Event Bus Core
+- [ ] `AppEventBus` is a singleton with `emit()` and `on<T>()` methods
+- [ ] `on<T>()` returns a `Stream<T>` that only emits events of type `T`
+- [ ] Multiple listeners can coexist (broadcast stream)
+- [ ] `dispose()` closes the controller without error
+
+### AppEventHandler
+- [ ] `bind()` starts subscriptions; `unbind()` cancels them
+- [ ] `OpenDialogEvent(dialogId)` calls `showDialog` with registered builder
+- [ ] `OpenDialogEvent(unknownId)` prints debug warning, does not throw
+- [ ] `ConfirmDialogEvent` returns `true` when confirm pressed, `false` when cancel pressed
+- [ ] `NavigateToRouteEvent(route)` calls `nav.pushNamed(route, arguments)`
+- [ ] `PopNavigationEvent` calls `nav.pop()`
+- [ ] `OpenPanelEvent(panelId)` calls `showModalBottomSheet` with registered builder
+- [ ] `ClosePanelEvent` calls `nav.maybePop()`
+- [ ] `ShowSnackBarEvent` calls `onShowSnackBar` callback when registered
+- [ ] `ShowOverlayEvent` calls `onShowOverlay` callback when registered
+- [ ] `DismissOverlayEvent` calls `onDismissOverlay` callback when registered
+
+### Migration
+- [ ] `game_screen.dart` `_showPauseMenu` uses event bus only (no direct Navigator)
+- [ ] `game_side_menu.dart` unit panels (civilian/military/naval) use `OpenPanelEvent`
+- [ ] `game_side_menu.dart` full-screen routes use `NavigateToRouteEvent`
+- [ ] `diplomacy_panel.dart` `_showConfirmDialog` uses `ConfirmDialogEvent`
+- [ ] `civilian_units_panel.dart` `_confirmCancel` uses `ConfirmDialogEvent`
+- [ ] `TrainCiviliansDialog` is registered as `train_civilians` dialog builder
+- [ ] `QuickBattleResultDialog` is registered and opened via `OpenDialogEvent`
+- [ ] `CombatModeChoiceDialog` is registered and opened via event with Future return
+
+### GameService Bridge
+- [ ] `GameService` has `AppEventBus? eventBus` field
+- [ ] After `runTurnResolution` returns `TurnResolutionComplete`, emits `TurnResolutionCompleteEvent`
+- [ ] No event emitted when `eventBus` is `null`
+
+### Tests
+- [ ] `AppEventBus` unit test: emit → on<T> delivers event
+- [ ] `AppEventBus` unit test: multiple listeners all receive events
+- [ ] `AppEventBus` unit test: on<T> only receives matching events
+- [ ] `AppEventBus` unit test: dispose prevents further events
+- [ ] `UIActionEvent` subclasses are equality-comparable (same params → equal)
+- [ ] `UISystemEvent` subclasses are equality-comparable
+- [ ] `GameToUIEvent` subclasses are equality-comparable
+- [ ] `AppEventHandler` test: `OpenDialogEvent` calls registered builder with params
+- [ ] `AppEventHandler` test: `NavigateToRouteEvent` calls `pushNamed`
+- [ ] `AppEventHandler` test: `ConfirmDialogEvent` returns bool from dialog result
+- [ ] `AppEventHandler` test: `OpenPanelEvent` calls `showModalBottomSheet`
+- [ ] `AppEventHandler` test: `PopNavigationEvent` calls `nav.pop()`
+- [ ] Widget test: emitting `OpenDialogEvent` from a widget triggers dialog display
+- [ ] Widget test: `ConfirmDialogEvent` result flows back to emitter
+
+---
+
+## Constraints
+
+- `GameEvent` lives in `colonizethis_logic` (avoids circular dep with `colonizethis_models`); `DialogueEvent`/`PortraitMoodEvent` live in `colonizethis_models`.
+- No Flutter imports in `colonizethis_models` package — event bus and handlers live in `app/`.
+- Dialog builders are registered at shell init time; unknown IDs log a warning.
+- Event emission is fire-and-forget; `ConfirmDialogEvent` is the exception (returns `Future<bool>`).
+- Province ids in any game events are always **prefixed** (`regionId|localId`).

--- a/app/lib/config/routes.dart
+++ b/app/lib/config/routes.dart
@@ -1,8 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../features/debug_log/debug_log_viewer_screen.dart';
 import '../features/game/flame/game_screen.dart';
+import '../features/game/widgets/diplomacy_screen.dart';
+import '../features/game/widgets/production_screen.dart';
+import '../features/game/widgets/technology_screen.dart';
 import '../features/shell/shell_screen.dart';
+import '../providers/games_provider.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
 
 class Routes {
   Routes._();
@@ -10,6 +17,9 @@ class Routes {
   static const String shell = '/';
   static const String game = '/game';
   static const String debugLog = '/debug-log';
+  static const String production = '/game/production';
+  static const String diplomacy = '/game/diplomacy';
+  static const String technology = '/game/technology';
 
   static Route<dynamic>? generate(RouteSettings settings) {
     switch (settings.name) {
@@ -27,6 +37,57 @@ class Routes {
         return MaterialPageRoute<void>(
           settings: settings,
           builder: (_) => const DebugLogViewerScreen(),
+        );
+      case production:
+      case diplomacy:
+      case technology:
+        return _buildGameRoute(settings);
+      default:
+        return null;
+    }
+  }
+
+  static Route<dynamic>? _buildGameRoute(RouteSettings settings) {
+    final args = settings.arguments as Map<String, Object?>?;
+    if (args == null) return null;
+
+    final game = args['game'] as Game;
+    final humanPlayerId = args['humanPlayerId'] as String;
+
+    switch (settings.name) {
+      case production:
+        final player = game.players.firstWhere((p) => p.id == humanPlayerId);
+        return MaterialPageRoute<void>(
+          settings: settings,
+          builder: (_) => ProductionScreen(game: game, player: player),
+        );
+      case diplomacy:
+        final topology = args['topology'] as MapTopology;
+        final currentOrders =
+            args['currentOrders'] as Orders? ?? const Orders();
+        return MaterialPageRoute<void>(
+          settings: settings,
+          builder: (_) => DiplomacyScreen(
+            game: game,
+            humanPlayerId: humanPlayerId,
+            topology: topology,
+            currentOrders: currentOrders,
+            onOrdersChanged: (newOrders) {},
+          ),
+        );
+      case technology:
+        final player = game.players.firstWhere((p) => p.id == humanPlayerId);
+        final currentOrders =
+            args['currentOrders'] as Orders? ?? const Orders();
+        return MaterialPageRoute<void>(
+          settings: settings,
+          builder: (_) => Consumer(
+            builder: (_, ref, __) => TechnologyScreen(
+              game: game,
+              player: player,
+              currentOrders: ref.watch(currentOrdersProvider),
+            ),
+          ),
         );
       default:
         return null;

--- a/app/lib/core/services/app_event_handler.dart
+++ b/app/lib/core/services/app_event_handler.dart
@@ -1,0 +1,157 @@
+// AppEventHandler: wires AppEventBus events to actual Navigator / showDialog calls.
+// Lives at the shell level; dispatches UIActionEvent and UISystemEvent to Flutter APIs.
+//
+// Usage (in main or shell setup):
+//   final handler = AppEventHandler(
+//     bus: eventBus,
+//     navigatorKey: appNavigatorKey,
+//     dialogBuilders: {
+//       'settings': (ctx, params) => SettingsDialog(params: params),
+//       'confirm':  (ctx, params) => ConfirmDialog(params: params),
+//       ...,
+//     },
+//   );
+//   handler.bind();
+//
+// To request a dialog from anywhere in the app (no direct Navigator coupling):
+//   eventBus.emit(const OpenDialogEvent('settings', {'tab': 'audio'}));
+//
+// To request navigation:
+//   eventBus.emit(const NavigateToRouteEvent('/game/settings'));
+
+import 'dart:async';
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+
+typedef DialogBuilder =
+    Widget Function(BuildContext context, Map<String, Object?>? params);
+
+class AppEventHandler {
+  AppEventHandler({
+    required AppEventBus bus,
+    required GlobalKey<NavigatorState> navigatorKey,
+    Map<String, DialogBuilder>? dialogBuilders,
+    Map<String, Widget Function(BuildContext, Map<String, Object?>?)>?
+    panelBuilders,
+    void Function(ShowSnackBarEvent)? onShowSnackBar,
+    void Function(ShowOverlayEvent)? onShowOverlay,
+    void Function(DismissOverlayEvent)? onDismissOverlay,
+    void Function(NotifyEvent)? onNotify,
+  }) : _bus = bus,
+       _navigatorKey = navigatorKey,
+       _dialogBuilders = dialogBuilders ?? const {},
+       _panelBuilders = panelBuilders ?? const {},
+       _onShowSnackBar = onShowSnackBar,
+       _onShowOverlay = onShowOverlay,
+       _onDismissOverlay = onDismissOverlay,
+       _onNotify = onNotify;
+
+  final AppEventBus _bus;
+  final GlobalKey<NavigatorState> _navigatorKey;
+  final Map<String, DialogBuilder> _dialogBuilders;
+  final Map<String, Widget Function(BuildContext, Map<String, Object?>?)>
+  _panelBuilders;
+  final void Function(ShowSnackBarEvent)? _onShowSnackBar;
+  final void Function(ShowOverlayEvent)? _onShowOverlay;
+  final void Function(DismissOverlayEvent)? _onDismissOverlay;
+  final void Function(NotifyEvent)? _onNotify;
+
+  final List<StreamSubscription> _subscriptions = [];
+
+  /// Start listening to the event bus. Call from StatefulWidget.initState or main.
+  void bind() {
+    _subscriptions.add(_bus.on<UIActionEvent>().listen(_handleUIAction));
+    _subscriptions.add(_bus.on<UISystemEvent>().listen(_handleUISystem));
+  }
+
+  /// Stop listening. Call from StatefulWidget.dispose or when tearing down.
+  void unbind() {
+    for (final s in _subscriptions) {
+      s.cancel();
+    }
+    _subscriptions.clear();
+  }
+
+  void _handleUIAction(UIActionEvent event) {
+    final nav = _navigatorKey.currentState;
+    if (event is OpenDialogEvent) {
+      _openDialog(event, nav);
+    } else if (event is ConfirmDialogEvent) {
+      _showConfirmDialog(event, nav);
+    } else if (event is NavigateToRouteEvent) {
+      nav?.pushNamed(event.route, arguments: event.arguments);
+    } else if (event is PopNavigationEvent) {
+      nav?.pop();
+    } else if (event is OpenPanelEvent) {
+      _openPanel(event, nav);
+    } else if (event is ClosePanelEvent) {
+      nav?.maybePop();
+    }
+  }
+
+  void _handleUISystem(UISystemEvent event) {
+    if (event is ShowSnackBarEvent) {
+      _onShowSnackBar?.call(event);
+    } else if (event is ShowOverlayEvent) {
+      _onShowOverlay?.call(event);
+    } else if (event is DismissOverlayEvent) {
+      _onDismissOverlay?.call(event);
+    } else if (event is NotifyEvent) {
+      _onNotify?.call(event);
+    }
+  }
+
+  Future<void> _openDialog(OpenDialogEvent event, NavigatorState? nav) async {
+    if (nav == null) return;
+    final builder = _dialogBuilders[event.dialogId];
+    if (builder == null) {
+      debugPrint('[AppEventHandler] No dialog builder for: ${event.dialogId}');
+      return;
+    }
+    await showDialog<void>(
+      context: nav.context,
+      builder: (ctx) => builder(ctx, event.params),
+    );
+  }
+
+  Future<bool> _showConfirmDialog(
+    ConfirmDialogEvent event,
+    NavigatorState? nav,
+  ) async {
+    if (nav == null) return false;
+    final result = await showDialog<bool>(
+      context: nav.context,
+      builder: (ctx) => AlertDialog(
+        title: Text(event.title),
+        content: Text(event.message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(event.cancelLabel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(event.confirmLabel),
+          ),
+        ],
+      ),
+    );
+    final confirmed = result ?? false;
+    event.result(confirmed);
+    return confirmed;
+  }
+
+  Future<void> _openPanel(OpenPanelEvent event, NavigatorState? nav) async {
+    if (nav == null) return;
+    final builder = _panelBuilders[event.panelId];
+    if (builder == null) {
+      debugPrint('[AppEventHandler] No panel builder for: ${event.panelId}');
+      return;
+    }
+    await showModalBottomSheet<void>(
+      context: nav.context,
+      builder: (ctx) => builder(ctx, event.params),
+    );
+  }
+}

--- a/app/lib/core/services/game_service.dart
+++ b/app/lib/core/services/game_service.dart
@@ -27,6 +27,10 @@ class GameService {
   final Box<dynamic> _box;
   final GameSaveAdapter _adapter;
 
+  /// Optional event bus to emit game events to. When set, GameToUIEvent variants
+  /// are emitted alongside the raw GameEvent callbacks.
+  AppEventBus? eventBus;
+
   /// In-memory cache: game id -> map data for resolveTurnForGame and map rendering.
   /// Populated when creating a new game or when loading a game with persisted map data.
   final Map<String, _GameMapCache> _mapCache = {};
@@ -118,7 +122,14 @@ class GameService {
       onGameEvent: onGameEvent,
     );
     if (result is TurnResolutionComplete) {
-      saveGame(result.game);
+      final complete = result;
+      saveGame(complete.game);
+      eventBus?.emit(
+        TurnResolutionCompleteEvent(
+          gameId: complete.game.id,
+          turnNumber: complete.game.worldState.turnState.turnNumber,
+        ),
+      );
     }
     return result;
   }

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -1,14 +1,14 @@
 export 'game_screen_shared.dart';
 
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
-import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
+import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../config/routes.dart';
+import '../../../../providers/app_event_bus_provider.dart';
 import '../../../../providers/game_service_provider.dart';
 import '../../../../providers/games_provider.dart';
 import '../../../../providers/map_view_provider.dart';
@@ -22,29 +22,17 @@ import 'game_map_area.dart';
 import 'victory_overlay.dart';
 
 /// Shows the in-game pause menu (Debug log, Resume). SPEC/program/debug-log-viewer.md.
-void _showPauseMenu(BuildContext context) {
-  showModalBottomSheet<void>(
-    context: context,
-    builder: (ctx) => SafeArea(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          ListTile(
-            leading: const Icon(Icons.bug_report),
-            title: Text(appL10n(ctx).debugLog_title),
-            onTap: () {
-              Navigator.of(ctx).pop();
-              Navigator.of(context).pushNamed(Routes.debugLog);
-            },
-          ),
-          ListTile(
-            leading: const Icon(Icons.play_arrow),
-            title: Text(appL10n(ctx).game_pauseMenu_resume),
-            onTap: () => Navigator.of(ctx).pop(),
-          ),
-        ],
-      ),
-    ),
+/// Emits `OpenPanelEvent('pause_menu')` via [bus] to let AppEventHandler open the bottom sheet.
+/// Menu item actions emit `ClosePanelEvent` and `NavigateToRouteEvent`.
+void _showPauseMenu(AppEventBus bus) {
+  bus.emit(
+    OpenPanelEvent('pause_menu', {
+      'onDebugLog': () {
+        bus.emit(const ClosePanelEvent());
+        bus.emit(NavigateToRouteEvent(Routes.debugLog));
+      },
+      'onResume': () => bus.emit(const ClosePanelEvent()),
+    }),
   );
 }
 
@@ -74,7 +62,7 @@ class GameScreen extends ConsumerWidget {
             top: 16,
             child: IconButton(
               icon: const Icon(Icons.menu),
-              onPressed: () => _showPauseMenu(context),
+              onPressed: () => _showPauseMenu(ref.read(appEventBusProvider)),
               tooltip: appL10n(context).game_pauseMenu_tooltip,
             ),
           ),
@@ -83,14 +71,13 @@ class GameScreen extends ConsumerWidget {
             top: 16,
             child: CtNinePatchButton(
               onPressed: () {
-                if (game == null) return;
                 final service = ref.read(gameServiceProvider);
                 final orders = ref.read(currentOrdersProvider);
                 final result = service.runTurnResolution(game, orders: orders);
                 if (result is TurnResolutionComplete) {
                   ref.read(currentGameProvider.notifier).state = result.game;
                   ref.read(currentOrdersProvider.notifier).state =
-                      const ct_models.Orders();
+                      const Orders();
                 } else if (result is TurnResolutionPendingOvertures) {
                   ref.read(currentGameProvider.notifier).state = result.game;
                   ref.read(pendingOverturesProvider.notifier).state =
@@ -99,7 +86,7 @@ class GameScreen extends ConsumerWidget {
               },
               child: Text(
                 appL10n(context).game_nextTurnButton(
-                  game!.worldState.turnState.turnNumber,
+                  game.worldState.turnState.turnNumber,
                   turnToYear(
                     game.worldState.turnState.turnNumber,
                     game.turnTimeMapping,
@@ -143,8 +130,7 @@ class GameScreen extends ConsumerWidget {
           ref.read(pendingOverturesProvider.notifier).state = null;
           if (result is TurnResolutionComplete) {
             ref.read(currentGameProvider.notifier).state = result.game;
-            ref.read(currentOrdersProvider.notifier).state =
-                const ct_models.Orders();
+            ref.read(currentOrdersProvider.notifier).state = const Orders();
           } else if (result is TurnResolutionPendingOvertures) {
             ref.read(currentGameProvider.notifier).state = result.game;
             ref.read(pendingOverturesProvider.notifier).state =

--- a/app/lib/features/game/flame/game_side_menu.dart
+++ b/app/lib/features/game/flame/game_side_menu.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../config/routes.dart';
+import '../../../../providers/app_event_bus_provider.dart';
 import '../../../../providers/game_service_provider.dart';
 import '../../../../providers/games_provider.dart';
 import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
@@ -78,6 +79,7 @@ class GameSideMenu extends ConsumerWidget {
     final orders = ref.read(currentOrdersProvider);
     final mapData = ref.read(gameServiceProvider).getMapData(game.id);
     final topology = mapData?.combinedTopology ?? MapTopology();
+    final bus = ref.read(appEventBusProvider);
 
     return [
       _empireButton(
@@ -86,10 +88,11 @@ class GameSideMenu extends ConsumerWidget {
         label: 'Production',
         onPressed: () {
           onClose();
-          Navigator.of(context).push<void>(
-            MaterialPageRoute<void>(
-              builder: (ctx) => ProductionScreen(game: game, player: player),
-            ),
+          bus.emit(
+            ct_models.NavigateToRouteEvent(Routes.production, {
+              'game': game,
+              'humanPlayerId': humanPlayerId,
+            }),
           );
         },
       ),
@@ -121,6 +124,7 @@ class GameSideMenu extends ConsumerWidget {
                 child: CivilianUnitsPanel(
                   game: currentGame,
                   humanPlayerId: humanPlayerId,
+                  bus: bus,
                   currentOrders: currentOrders,
                   availableWorkTargets: availableWorkTargets,
                   onLocateUnit: onLocateCivilianUnit,
@@ -214,19 +218,16 @@ class GameSideMenu extends ConsumerWidget {
         label: 'Diplomacy',
         onPressed: () {
           onClose();
-          Navigator.of(context).push<void>(
-            MaterialPageRoute<void>(
-              builder: (_) => DiplomacyScreen(
-                game: game,
-                humanPlayerId: humanPlayerId,
-                topology: topology,
-                currentOrders: orders,
-                onOrdersChanged: (newOrders) {
-                  ref.read(currentOrdersProvider.notifier).state = newOrders;
-                },
-              ),
-            ),
-          );
+          ref
+              .read(appEventBusProvider)
+              .emit(
+                ct_models.NavigateToRouteEvent(Routes.diplomacy, {
+                  'game': game,
+                  'humanPlayerId': humanPlayerId,
+                  'topology': topology,
+                  'currentOrders': orders,
+                }),
+              );
         },
       ),
       _empireButton(
@@ -235,20 +236,15 @@ class GameSideMenu extends ConsumerWidget {
         label: 'Technology',
         onPressed: () {
           onClose();
-          Navigator.of(context).push<void>(
-            MaterialPageRoute<void>(
-              builder: (ctx) => Consumer(
-                builder: (ctx, ref, _) => TechnologyScreen(
-                  game: game,
-                  player: player,
-                  currentOrders: ref.watch(currentOrdersProvider),
-                  onOrdersChanged: (newOrders) {
-                    ref.read(currentOrdersProvider.notifier).state = newOrders;
-                  },
-                ),
-              ),
-            ),
-          );
+          ref
+              .read(appEventBusProvider)
+              .emit(
+                ct_models.NavigateToRouteEvent(Routes.technology, {
+                  'game': game,
+                  'humanPlayerId': humanPlayerId,
+                  'currentOrders': orders,
+                }),
+              );
         },
       ),
       Padding(
@@ -256,7 +252,9 @@ class GameSideMenu extends ConsumerWidget {
         child: CtNinePatchButton(
           onPressed: () {
             onClose();
-            Navigator.of(context).pushNamed(Routes.debugLog);
+            ref
+                .read(appEventBusProvider)
+                .emit(const ct_models.NavigateToRouteEvent(Routes.debugLog));
           },
           child: Row(
             mainAxisSize: MainAxisSize.min,

--- a/app/lib/features/game/flame/game_side_menu.dart
+++ b/app/lib/features/game/flame/game_side_menu.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../config/routes.dart';
+import '../../../../providers/app_event_bus_provider.dart';
 import '../../../../providers/game_service_provider.dart';
 import '../../../../providers/games_provider.dart';
 import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
@@ -78,6 +79,7 @@ class GameSideMenu extends ConsumerWidget {
     final orders = ref.read(currentOrdersProvider);
     final mapData = ref.read(gameServiceProvider).getMapData(game.id);
     final topology = mapData?.combinedTopology ?? MapTopology();
+    final bus = ref.read(appEventBusProvider);
 
     return [
       _empireButton(
@@ -86,10 +88,11 @@ class GameSideMenu extends ConsumerWidget {
         label: 'Production',
         onPressed: () {
           onClose();
-          Navigator.of(context).push<void>(
-            MaterialPageRoute<void>(
-              builder: (ctx) => ProductionScreen(game: game, player: player),
-            ),
+          bus.emit(
+            ct_models.NavigateToRouteEvent(Routes.production, {
+              'game': game,
+              'humanPlayerId': humanPlayerId,
+            }),
           );
         },
       ),
@@ -117,6 +120,7 @@ class GameSideMenu extends ConsumerWidget {
                 child: CivilianUnitsPanel(
                   game: currentGame,
                   humanPlayerId: humanPlayerId,
+                  bus: bus,
                   currentOrders: currentOrders,
                   availableWorkTargets: availableWorkTargets,
                   onLocateUnit: onLocateCivilianUnit,
@@ -210,19 +214,16 @@ class GameSideMenu extends ConsumerWidget {
         label: 'Diplomacy',
         onPressed: () {
           onClose();
-          Navigator.of(context).push<void>(
-            MaterialPageRoute<void>(
-              builder: (_) => DiplomacyScreen(
-                game: game,
-                humanPlayerId: humanPlayerId,
-                topology: topology,
-                currentOrders: orders,
-                onOrdersChanged: (newOrders) {
-                  ref.read(currentOrdersProvider.notifier).state = newOrders;
-                },
-              ),
-            ),
-          );
+          ref
+              .read(appEventBusProvider)
+              .emit(
+                ct_models.NavigateToRouteEvent(Routes.diplomacy, {
+                  'game': game,
+                  'humanPlayerId': humanPlayerId,
+                  'topology': topology,
+                  'currentOrders': orders,
+                }),
+              );
         },
       ),
       _empireButton(
@@ -231,20 +232,15 @@ class GameSideMenu extends ConsumerWidget {
         label: 'Technology',
         onPressed: () {
           onClose();
-          Navigator.of(context).push<void>(
-            MaterialPageRoute<void>(
-              builder: (ctx) => Consumer(
-                builder: (ctx, ref, _) => TechnologyScreen(
-                  game: game,
-                  player: player,
-                  currentOrders: ref.watch(currentOrdersProvider),
-                  onOrdersChanged: (newOrders) {
-                    ref.read(currentOrdersProvider.notifier).state = newOrders;
-                  },
-                ),
-              ),
-            ),
-          );
+          ref
+              .read(appEventBusProvider)
+              .emit(
+                ct_models.NavigateToRouteEvent(Routes.technology, {
+                  'game': game,
+                  'humanPlayerId': humanPlayerId,
+                  'currentOrders': orders,
+                }),
+              );
         },
       ),
       Padding(
@@ -252,7 +248,9 @@ class GameSideMenu extends ConsumerWidget {
         child: CtNinePatchButton(
           onPressed: () {
             onClose();
-            Navigator.of(context).pushNamed(Routes.debugLog);
+            ref
+                .read(appEventBusProvider)
+                .emit(const ct_models.NavigateToRouteEvent(Routes.debugLog));
           },
           child: Row(
             mainAxisSize: MainAxisSize.min,

--- a/app/lib/features/game/widgets/civilian_units_panel.dart
+++ b/app/lib/features/game/widgets/civilian_units_panel.dart
@@ -1,5 +1,7 @@
 // Civilian units panel. SPEC/ui/civilian-units-panel.md.
 
+import 'dart:async';
+
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
@@ -92,6 +94,7 @@ class CivilianUnitsPanel extends StatelessWidget {
     super.key,
     required this.game,
     required this.humanPlayerId,
+    required this.bus,
     this.currentOrders = const Orders(),
     this.availableWorkTargets = const {},
     this.onLocateUnit,
@@ -104,6 +107,7 @@ class CivilianUnitsPanel extends StatelessWidget {
 
   final Game game;
   final String humanPlayerId;
+  final AppEventBus bus;
 
   /// Current-turn orders (to show Assign only when no pending work, Cancel when pending or in-progress).
   final Orders currentOrders;
@@ -181,6 +185,7 @@ class CivilianUnitsPanel extends StatelessWidget {
                                 currentOrders: currentOrders,
                                 availableWorkTargets: availableWorkTargets,
                                 humanPlayerId: humanPlayerId,
+                                bus: bus,
                                 onTap: onLocateUnit != null && u.tileKey != null
                                     ? () => onLocateUnit!(u)
                                     : null,
@@ -201,6 +206,7 @@ class CivilianUnitsPanel extends StatelessWidget {
                                 currentOrders: currentOrders,
                                 availableWorkTargets: availableWorkTargets,
                                 humanPlayerId: humanPlayerId,
+                                bus: bus,
                                 onTap: onLocateUnit != null && u.tileKey != null
                                     ? () => onLocateUnit!(u)
                                     : null,
@@ -264,6 +270,7 @@ class _UnitRow extends StatelessWidget {
     required this.currentOrders,
     required this.availableWorkTargets,
     required this.humanPlayerId,
+    required this.bus,
     this.onTap,
     this.onAddWorkOrder,
     this.onRemoveWorkOrder,
@@ -276,6 +283,7 @@ class _UnitRow extends StatelessWidget {
   final Orders currentOrders;
   final Map<String, List<String>> availableWorkTargets;
   final String humanPlayerId;
+  final AppEventBus bus;
   final VoidCallback? onTap;
   final void Function(WorkOrder order)? onAddWorkOrder;
   final void Function(String playerId, int index)? onRemoveWorkOrder;
@@ -396,41 +404,19 @@ class _UnitRow extends StatelessWidget {
   }
 
   Future<void> _confirmCancel(BuildContext context) async {
-    final ok = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => CtDialogShell(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'Cancel work order?',
-              style: Theme.of(ctx).textTheme.titleMedium,
-            ),
-            const SizedBox(height: 8),
-            const Text(
-              'This will cancel the current or pending work for this unit. Materials are not refunded.',
-            ),
-            const SizedBox(height: 16),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                CtNinePatchButton(
-                  onPressed: () => Navigator.of(ctx).pop(false),
-                  child: const Text('No'),
-                ),
-                const SizedBox(width: 8),
-                CtNinePatchButton(
-                  onPressed: () => Navigator.of(ctx).pop(true),
-                  child: const Text('Yes'),
-                ),
-              ],
-            ),
-          ],
-        ),
+    final completer = Completer<bool>();
+    bus.emit(
+      ConfirmDialogEvent(
+        title: 'Cancel work order?',
+        message:
+            'This will cancel the current or pending work for this unit. Materials are not refunded.',
+        confirmLabel: 'Yes',
+        cancelLabel: 'No',
+        onResult: completer.complete,
       ),
     );
-    if (ok != true || !context.mounted) return;
+    final confirmed = await completer.future;
+    if (!confirmed || !context.mounted) return;
     final idx = _pendingIndex;
     if (idx != null && onRemoveWorkOrder != null) {
       onRemoveWorkOrder!(humanPlayerId, idx);

--- a/app/lib/features/game/widgets/diplomacy_panel.dart
+++ b/app/lib/features/game/widgets/diplomacy_panel.dart
@@ -169,6 +169,7 @@ class DiplomacyPanel extends StatelessWidget {
     required this.topology,
     required this.currentOrders,
     required this.onOrdersChanged,
+    required this.bus,
     this.onClose,
   });
 
@@ -177,6 +178,7 @@ class DiplomacyPanel extends StatelessWidget {
   final MapTopology topology;
   final Orders currentOrders;
   final void Function(Orders) onOrdersChanged;
+  final AppEventBus bus;
   final VoidCallback? onClose;
 
   @override
@@ -301,29 +303,18 @@ class DiplomacyPanel extends StatelessWidget {
 
   void _showConfirmDialog(BuildContext context, DiplomaticOrder order) {
     final actionLabel = _actionLabel(order);
-    showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(actionLabel),
-        content: Text(
-          'Confirm $actionLabel against ${_targetName(order.targetFactionId)}?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('Confirm'),
-          ),
-        ],
+    bus.emit(
+      ConfirmDialogEvent(
+        title: actionLabel,
+        message:
+            'Confirm $actionLabel against ${_targetName(order.targetFactionId)}?',
+        onResult: (confirmed) {
+          if (confirmed) {
+            _appendOrder(order);
+          }
+        },
       ),
-    ).then((confirmed) {
-      if (confirmed == true) {
-        _appendOrder(order);
-      }
-    });
+    );
   }
 
   String _targetName(String factionId) {
@@ -352,33 +343,23 @@ class DiplomacyPanel extends StatelessWidget {
               ? 'Grant Aid'
               : 'Set Subsidy';
           final target = _targetName(order.targetFactionId);
-          showDialog<bool>(
-            context: context,
-            builder: (ctx) => AlertDialog(
-              title: Text(actionName),
-              content: Text('$actionName of £$amount to $target?'),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.of(ctx).pop(false),
-                  child: const Text('Cancel'),
-                ),
-                TextButton(
-                  onPressed: () => Navigator.of(ctx).pop(true),
-                  child: const Text('Confirm'),
-                ),
-              ],
+          bus.emit(
+            ConfirmDialogEvent(
+              title: actionName,
+              message: '$actionName of £$amount to $target?',
+              onResult: (confirmed) {
+                if (confirmed) {
+                  _appendOrder(
+                    DiplomaticOrder(
+                      type: order.type,
+                      targetFactionId: order.targetFactionId,
+                      amount: amount,
+                    ),
+                  );
+                }
+              },
             ),
-          ).then((confirmed) {
-            if (confirmed == true) {
-              _appendOrder(
-                DiplomaticOrder(
-                  type: order.type,
-                  targetFactionId: order.targetFactionId,
-                  amount: amount,
-                ),
-              );
-            }
-          });
+          );
         },
       );
     } else if (order.type == DiplomaticOrderType.establishOverture &&

--- a/app/lib/features/game/widgets/diplomacy_screen.dart
+++ b/app/lib/features/game/widgets/diplomacy_screen.dart
@@ -3,11 +3,13 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../providers/app_event_bus_provider.dart';
 import '../../../widgets/ct_screen_shell.dart';
 import 'diplomacy_panel.dart';
 
-class DiplomacyScreen extends StatelessWidget {
+class DiplomacyScreen extends ConsumerWidget {
   const DiplomacyScreen({
     super.key,
     required this.game,
@@ -24,7 +26,8 @@ class DiplomacyScreen extends StatelessWidget {
   final void Function(Orders orders) onOrdersChanged;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final bus = ref.watch(appEventBusProvider);
     return CtScreenShell(
       title: 'Diplomacy',
       showBackButton: true,
@@ -34,6 +37,7 @@ class DiplomacyScreen extends StatelessWidget {
         topology: topology,
         currentOrders: currentOrders,
         onOrdersChanged: onOrdersChanged,
+        bus: bus,
       ),
     );
   }

--- a/app/lib/providers/app_event_bus_provider.dart
+++ b/app/lib/providers/app_event_bus_provider.dart
@@ -1,0 +1,11 @@
+// App event bus provider. Riverpod provider wrapping AppEventBus singleton.
+// SPEC/program/app-event-bus.md.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+final appEventBusProvider = Provider<AppEventBus>((ref) {
+  final bus = AppEventBus();
+  ref.onDispose(() => bus.dispose());
+  return bus;
+});

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -461,6 +461,7 @@ List<WidgetbookNode> get productionPanelDirectories => [
               topology: result.combinedTopology,
               currentOrders: const Orders(),
               onOrdersChanged: (_) {},
+              bus: AppEventBus(),
             ),
           );
         },

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -1,8 +1,1395 @@
-// Widgetbook entry: `flutter run -t lib/widgetbook.dart`.
-// Story catalog lives in [widgetbook/catalog.dart] (excluded from app coverage gate).
-import 'widgetbook/catalog.dart' as widgetbook_catalog;
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
 
-void main() => widgetbookMain();
+import 'config/themes.dart';
+import 'features/game/widgets/civilian_units_panel.dart';
+import 'features/game/widgets/diplomacy_panel.dart';
+import 'features/game/widgets/military_units_panel.dart';
+import 'features/game/widgets/naval_units_panel.dart';
+import 'features/game/widgets/production_panel.dart';
+import 'features/game/widgets/production_panel_demo_data.dart';
+import 'features/game/widgets/province_sea_zone_detail_overlay.dart';
+import 'features/game/widgets/province_overlay_demo_data.dart';
+import 'features/game/widgets/tech_tree_widget.dart';
+import 'features/game/widgets/technology_screen.dart';
+import 'features/game/widgets/train_civilians_dialog.dart';
+import 'widgets/debug_init_game.dart';
+import 'widgets/ct_choice_chip.dart';
+import 'widgets/debug_map_visibility_story.dart';
+import 'widgets/game_setup.dart';
+import 'widgets/main_menu.dart';
+import 'widgets/ct_nine_patch_button.dart';
+import 'widgets/ct_region_map.dart';
 
-/// Same as [main]; callable from tests with binding initialized.
-void widgetbookMain() => widgetbook_catalog.bootstrapWidgetbook();
+/// Widgetbook entry point. Run with: flutter run -t lib/widgetbook.dart
+void main() {
+  runApp(const CtWidgetbookApp());
+}
+
+/// Simulated mobile viewport (360×640 dp) for layout verification. SPEC/ui/mobile-adaptation.md.
+Widget mobileViewport(BuildContext context, Widget child) {
+  const double width = 360;
+  const double height = 640;
+  return MediaQuery(
+    data: MediaQuery.of(context).copyWith(size: Size(width, height)),
+    child: SizedBox(width: width, height: height, child: child),
+  );
+}
+
+/// Widgetbook app with colonial theme. SPEC/ui/main-menu.md; UXD 03a. SPEC/ui/game-setup.md; UXD 03b. Mobile viewport: SPEC/ui/mobile-adaptation.md.
+class CtWidgetbookApp extends StatelessWidget {
+  const CtWidgetbookApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Widgetbook.material(
+      directories: [
+        ...buttonDirectories,
+        ...mainMenuDirectories,
+        ...gameSetupDirectories,
+        ...mapWidgetDirectories,
+        ...provinceOverlayDirectories,
+        ...productionPanelDirectories,
+        ...civilianUnitsPanelDirectories,
+        ...trainCiviliansDialogDirectories,
+        ...militaryUnitsPanelDirectories,
+        ...navalUnitsPanelDirectories,
+        ...diplomacyPanelDirectories,
+        ...techTreeDirectories,
+      ],
+      lightTheme: AppThemes.colonial,
+      darkTheme: AppThemes.colonial,
+    );
+  }
+}
+
+/// Nine-patch button stories. SPEC/ui/buttons-nine-patch.md; catalog: CtNinePatchButton.
+List<WidgetbookNode> get buttonDirectories => [
+  WidgetbookFolder(
+    name: 'Buttons',
+    children: [
+      WidgetbookUseCase(
+        name: 'CtNinePatchButton',
+        builder: (context) => Theme(
+          data: AppThemes.colonial,
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                CtNinePatchButton(
+                  onPressed: () {},
+                  child: const Text('Primary action'),
+                ),
+                const SizedBox(height: 12),
+                CtNinePatchButton(
+                  onPressed: null,
+                  enabled: false,
+                  child: const Text('Disabled'),
+                ),
+                const SizedBox(height: 12),
+                SizedBox(
+                  width: 200,
+                  child: CtNinePatchButton(
+                    onPressed: () {},
+                    child: const Text('Fixed width'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    ],
+  ),
+];
+
+/// Main Menu stories (plain and pixel). Register in widget_catalog.json.
+List<WidgetbookNode> get mainMenuDirectories => [
+  WidgetbookFolder(
+    name: 'Main Menu',
+    children: [
+      WidgetbookUseCase(
+        name: 'Default',
+        builder: (context) => CtMainMenu(
+          variant: MainMenuVariant.plain,
+          state: MainMenuState.default_,
+          version: 'v1.0.0',
+          onNewGame: () {},
+          onLoadGame: () {},
+          onSettings: () {},
+          onQuit: () {},
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'After victory',
+        builder: (context) => CtMainMenu(
+          variant: MainMenuVariant.plain,
+          state: MainMenuState.afterVictory,
+          version: 'v1.0.0',
+          onNewGame: () {},
+          onLoadGame: () {},
+          onSettings: () {},
+          onQuit: () {},
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'No saves',
+        builder: (context) => CtMainMenu(
+          variant: MainMenuVariant.plain,
+          state: MainMenuState.noSaves,
+          version: 'v1.0.0',
+          onNewGame: () {},
+          onLoadGame: () {},
+          onSettings: () {},
+          onQuit: () {},
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Default (pixel)',
+        builder: (context) => CtMainMenu(
+          variant: MainMenuVariant.pixelArt,
+          state: MainMenuState.default_,
+          version: 'v1.0.0',
+          onNewGame: () {},
+          onLoadGame: () {},
+          onSettings: () {},
+          onQuit: () {},
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'After victory (pixel)',
+        builder: (context) => CtMainMenu(
+          variant: MainMenuVariant.pixelArt,
+          state: MainMenuState.afterVictory,
+          version: 'v1.0.0',
+          onNewGame: () {},
+          onLoadGame: () {},
+          onSettings: () {},
+          onQuit: () {},
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Default (mobile)',
+        builder: (context) => mobileViewport(
+          context,
+          CtMainMenu(
+            variant: MainMenuVariant.plain,
+            state: MainMenuState.default_,
+            version: 'v1.0.0',
+            onNewGame: () {},
+            onLoadGame: () {},
+            onSettings: () {},
+            onQuit: () {},
+          ),
+        ),
+      ),
+    ],
+  ),
+];
+
+/// All choices unselected on load. SPEC/ui/game-setup.md.
+List<String> _unselectedInitialOrderedGpIds() => List.filled(6, '');
+
+/// Game Setup stories. SPEC/ui/game-setup.md; UXD 03b.
+List<WidgetbookNode> get gameSetupDirectories => [
+  WidgetbookFolder(
+    name: 'Game Setup',
+    children: [
+      WidgetbookUseCase(
+        name: 'Default',
+        builder: (context) => CtGameSetup(
+          variant: GameSetupVariant.plain,
+          state: GameSetupState.default_,
+          naming: defaultNamingConfig,
+          initialOrderedGpIds: _unselectedInitialOrderedGpIds(),
+          initialLeaderVariantByGpId: {},
+          onStartGame: (_, __) {},
+          onBack: () {},
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Loading',
+        builder: (context) => CtGameSetup(
+          variant: GameSetupVariant.plain,
+          state: GameSetupState.loading,
+          naming: defaultNamingConfig,
+          initialOrderedGpIds: _unselectedInitialOrderedGpIds(),
+          initialLeaderVariantByGpId: {},
+          onStartGame: (_, __) {},
+          onBack: () {},
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Default (pixel)',
+        builder: (context) => CtGameSetup(
+          variant: GameSetupVariant.pixelArt,
+          state: GameSetupState.default_,
+          naming: defaultNamingConfig,
+          initialOrderedGpIds: _unselectedInitialOrderedGpIds(),
+          initialLeaderVariantByGpId: {},
+          onStartGame: (_, __) {},
+          onBack: () {},
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Loading (pixel)',
+        builder: (context) => CtGameSetup(
+          variant: GameSetupVariant.pixelArt,
+          state: GameSetupState.loading,
+          naming: defaultNamingConfig,
+          initialOrderedGpIds: _unselectedInitialOrderedGpIds(),
+          initialLeaderVariantByGpId: {},
+          onStartGame: (_, __) {},
+          onBack: () {},
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Default (mobile)',
+        builder: (context) => mobileViewport(
+          context,
+          CtGameSetup(
+            variant: GameSetupVariant.plain,
+            state: GameSetupState.default_,
+            naming: defaultNamingConfig,
+            initialOrderedGpIds: _unselectedInitialOrderedGpIds(),
+            initialLeaderVariantByGpId: {},
+            onStartGame: (_, __) {},
+            onBack: () {},
+          ),
+        ),
+      ),
+    ],
+  ),
+];
+
+/// Map Widget stories (debug mode). SPEC/ui/map-widget.md.
+List<WidgetbookNode> get mapWidgetDirectories => [
+  WidgetbookFolder(
+    name: 'Map Widget',
+    children: [
+      WidgetbookUseCase(
+        name: 'Debug mode (visibility toggle)',
+        builder: (context) =>
+            const DebugMapVisibilityStory(showPoliticalOverlay: true),
+      ),
+      WidgetbookUseCase(
+        name: 'Debug mode (political overlay off)',
+        builder: (context) =>
+            const DebugMapVisibilityStory(showPoliticalOverlay: false),
+      ),
+      WidgetbookUseCase(
+        name: 'Debug mode (mobile)',
+        builder: (context) => mobileViewport(
+          context,
+          Builder(
+            builder: (context) {
+              return const DebugMapVisibilityStory(showPoliticalOverlay: true);
+            },
+          ),
+        ),
+      ),
+    ],
+  ),
+];
+
+/// Civilian Units Panel stories. SPEC/ui/civilian-units-panel.md.
+List<WidgetbookNode> get civilianUnitsPanelDirectories => [
+  WidgetbookFolder(
+    name: 'Civilian Units Panel',
+    children: [
+      WidgetbookUseCase(
+        name: 'Standalone',
+        builder: (context) {
+          final result = getDebugInitGameResult();
+          final game = result.game;
+          final humanPlayerId = game.players.isNotEmpty
+              ? game.players.first.id
+              : 'gp1';
+          return ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
+            child: CivilianUnitsPanel(
+              game: game,
+              humanPlayerId: humanPlayerId,
+              bus: AppEventBus(),
+            ),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'With map',
+        builder: (context) => const _CivilianPanelWithMapStory(),
+      ),
+      WidgetbookUseCase(
+        name: 'As bottom sheet',
+        builder: (context) => const _CivilianPanelAsBottomSheetStory(),
+      ),
+    ],
+  ),
+];
+
+/// Train Civilians Dialog stories. SPEC/ui/train-civilians-dialog.md.
+List<WidgetbookNode> get trainCiviliansDialogDirectories => [
+  WidgetbookFolder(
+    name: 'Train Civilians Dialog',
+    children: [
+      WidgetbookUseCase(
+        name: 'Standalone',
+        builder: (context) {
+          final result = getDebugInitGameResult();
+          final game = result.game;
+          final humanPlayerId = game.players.isNotEmpty
+              ? game.players.firstWhere((p) => p.isHuman).id
+              : game.players.first.id;
+          final player = game.players.firstWhere((p) => p.id == humanPlayerId);
+          final richGame = game.copyWith(
+            players: [
+              player.copyWith(
+                treasury: 10000,
+                stockpile: player.stockpile.merge(
+                  const Stockpile(quantities: {'paper': 100}),
+                ),
+              ),
+              ...game.players.where((p) => p.id != humanPlayerId),
+            ],
+          );
+          return MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: TrainCiviliansDialog(
+                  game: richGame,
+                  humanPlayerId: humanPlayerId,
+                  currentOrders: const Orders(),
+                  onOrdersChanged: (_) {},
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'With locked units',
+        builder: (context) {
+          final result = getDebugInitGameResult();
+          final game = result.game;
+          final humanPlayerId = game.players.isNotEmpty
+              ? game.players.firstWhere((p) => p.isHuman).id
+              : game.players.first.id;
+          final player = game.players.firstWhere((p) => p.id == humanPlayerId);
+          final noTechGame = game.copyWith(
+            players: [
+              player.copyWith(
+                treasury: 10000,
+                stockpile: player.stockpile.merge(
+                  const Stockpile(quantities: {'paper': 100}),
+                ),
+                techUnlocked: <String, bool>{},
+              ),
+              ...game.players.where((p) => p.id != humanPlayerId),
+            ],
+          );
+          return MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: TrainCiviliansDialog(
+                  game: noTechGame,
+                  humanPlayerId: humanPlayerId,
+                  currentOrders: const Orders(),
+                  onOrdersChanged: (_) {},
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'Low resources',
+        builder: (context) {
+          final result = getDebugInitGameResult();
+          final game = result.game;
+          final humanPlayerId = game.players.isNotEmpty
+              ? game.players.firstWhere((p) => p.isHuman).id
+              : game.players.first.id;
+          final player = game.players.firstWhere((p) => p.id == humanPlayerId);
+          final poorGame = game.copyWith(
+            players: [
+              player.copyWith(
+                treasury: 500,
+                stockpile: player.stockpile.merge(
+                  const Stockpile(quantities: {'paper': 3}),
+                ),
+              ),
+              ...game.players.where((p) => p.id != humanPlayerId),
+            ],
+          );
+          return MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: TrainCiviliansDialog(
+                  game: poorGame,
+                  humanPlayerId: humanPlayerId,
+                  currentOrders: const Orders(),
+                  onOrdersChanged: (_) {},
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    ],
+  ),
+];
+
+/// Production Panel stories. SPEC/ui/production-panel.md.
+List<WidgetbookNode> get productionPanelDirectories => [
+  WidgetbookFolder(
+    name: 'Diplomacy Panel',
+    children: [
+      WidgetbookUseCase(
+        name: 'With real game',
+        builder: (context) {
+          final result = getDebugInitGameResult();
+          final game = result.game;
+          final humanPlayerId = game.players.isNotEmpty
+              ? game.players.first.id
+              : 'gp1';
+          return ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 800, maxHeight: 600),
+            child: DiplomacyPanel(
+              game: game,
+              humanPlayerId: humanPlayerId,
+              topology: result.combinedTopology,
+              currentOrders: const Orders(),
+              onOrdersChanged: (_) {},
+              bus: AppEventBus(),
+            ),
+          );
+        },
+      ),
+    ],
+  ),
+];
+
+/// Tech Tree Widget stories. SPEC/ui/tech-tree-widget.md.
+List<WidgetbookNode> get techTreeDirectories => [
+  WidgetbookFolder(
+    name: 'Tech Tree',
+    children: [
+      WidgetbookUseCase(
+        name: 'Mid-game (half researched)',
+        builder: (context) {
+          final result = getDebugInitGameResult();
+          final game = result.game;
+          if (game.players.isEmpty) {
+            return const Center(child: Text('No players'));
+          }
+          final basePlayer = game.players.first;
+          // Unlock roughly half of all techs (first 22 from catalog order).
+          final allIds = techCatalog.keys.toList()..sort();
+          final half = (allIds.length / 2).floor();
+          final unlockedIds = allIds.take(half).toList();
+          final techUnlocked = Map<String, bool>.fromEntries(
+            unlockedIds.map((id) => MapEntry(id, true)),
+          );
+          // One tech in progress (first not-yet-unlocked tech at 60 RP).
+          final inProgressId = allIds.length > half ? allIds[half] : null;
+          final researchProgressByTechId = inProgressId != null
+              ? <String, int>{inProgressId: 60}
+              : <String, int>{};
+          final midGamePlayer = basePlayer.copyWith(
+            techUnlocked: techUnlocked,
+            researchProgressByTechId: researchProgressByTechId,
+          );
+          final midGame = game.copyWith(
+            players: [midGamePlayer, ...game.players.skip(1)],
+          );
+          return MaterialApp(
+            theme: AppThemes.colonial,
+            home: Scaffold(
+              body: TechnologyScreen(game: midGame, player: midGamePlayer),
+            ),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'Tech tree only (mid-game)',
+        builder: (context) {
+          final result = getDebugInitGameResult();
+          final game = result.game;
+          if (game.players.isEmpty) {
+            return const Center(child: Text('No players'));
+          }
+          final basePlayer = game.players.first;
+          final allIds = techCatalog.keys.toList()..sort();
+          final half = (allIds.length / 2).floor();
+          final techUnlocked = Map<String, bool>.fromEntries(
+            allIds.take(half).map((id) => MapEntry(id, true)),
+          );
+          final midGamePlayer = basePlayer.copyWith(techUnlocked: techUnlocked);
+          final midGame = game.copyWith(
+            players: [midGamePlayer, ...game.players.skip(1)],
+          );
+          return MaterialApp(
+            theme: AppThemes.colonial,
+            home: Scaffold(
+              appBar: AppBar(title: const Text('Tech Tree')),
+              body: TechTreeWidget(game: midGame, player: midGamePlayer),
+            ),
+          );
+        },
+      ),
+    ],
+  ),
+];
+
+/// Military Units Panel stories. SPEC/ui/military-units-panel.md.
+List<WidgetbookNode> get militaryUnitsPanelDirectories => [
+  WidgetbookFolder(
+    name: 'Military Units Panel',
+    children: [
+      WidgetbookUseCase(
+        name: 'Standalone',
+        builder: (context) {
+          final result = getDebugInitGameResult();
+          final game = result.game;
+          final humanPlayerId = game.players.isNotEmpty
+              ? game.players.first.id
+              : 'gp1';
+          return ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
+            child: MilitaryUnitsPanel(game: game, humanPlayerId: humanPlayerId),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'With map',
+        builder: (context) => const _MilitaryPanelWithMapStory(),
+      ),
+    ],
+  ),
+];
+
+/// Naval Units Panel stories. SPEC/ui/naval-units-panel.md.
+List<WidgetbookNode> get navalUnitsPanelDirectories => [
+  WidgetbookFolder(
+    name: 'Naval Units Panel',
+    children: [
+      WidgetbookUseCase(
+        name: 'Standalone',
+        builder: (context) {
+          final result = getDebugInitGameResult();
+          final game = result.game;
+          final humanPlayerId = game.players.isNotEmpty
+              ? game.players.first.id
+              : 'gp1';
+          return ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
+            child: NavalUnitsPanel(game: game, humanPlayerId: humanPlayerId),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'With map',
+        builder: (context) => const _NavalPanelWithMapStory(),
+      ),
+    ],
+  ),
+];
+
+/// Diplomacy Panel stories. SPEC/ui/diplomacy-panel.md.
+List<WidgetbookNode> get diplomacyPanelDirectories => [
+  WidgetbookFolder(
+    name: 'Production Panel',
+    children: [
+      WidgetbookUseCase(
+        name: 'Full availability',
+        builder: (context) => const _ProductionPanelStory(
+          playerOverride: null,
+          useFullAvailability: true,
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Partial availability',
+        builder: (context) => const _ProductionPanelStory(
+          playerOverride: null,
+          useFullAvailability: false,
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Full availability (mobile)',
+        builder: (context) => mobileViewport(
+          context,
+          const _ProductionPanelStory(
+            playerOverride: null,
+            useFullAvailability: true,
+          ),
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'Partial availability (mobile)',
+        builder: (context) => mobileViewport(
+          context,
+          const _ProductionPanelStory(
+            playerOverride: null,
+            useFullAvailability: false,
+          ),
+        ),
+      ),
+    ],
+  ),
+];
+
+/// Province/Sea Zone Detail Overlay stories. SPEC/ui/province-sea-zone-detail-overlay.md.
+List<WidgetbookNode> get provinceOverlayDirectories => [
+  WidgetbookFolder(
+    name: 'Province Overlay',
+    children: [
+      WidgetbookUseCase(
+        name: 'Standalone — province',
+        builder: (context) {
+          final game = demoGameForOverlay;
+          final region = demoRegionForOverlay;
+          return SizedBox(
+            width: 320,
+            height: 400,
+            child: ProvinceSeaZoneDetailOverlay(
+              game: game,
+              region: region,
+              selectedId: sampleProvinceIdForOverlay,
+              displayId: sampleProvinceIdForOverlay,
+              humanPlayerId: game.players.first.id,
+              onClose: () {},
+            ),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'Standalone — sea zone',
+        builder: (context) {
+          final game = demoGameForOverlay;
+          final region = demoRegionForOverlay;
+          return SizedBox(
+            width: 320,
+            height: 280,
+            child: ProvinceSeaZoneDetailOverlay(
+              game: game,
+              region: region,
+              selectedId: sampleSeaZoneIdForOverlay,
+              displayId: sampleSeaZoneIdForOverlay,
+              humanPlayerId: game.players.first.id,
+              onClose: () {},
+            ),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'Standalone (mobile)',
+        builder: (context) => mobileViewport(
+          context,
+          Builder(
+            builder: (context) {
+              final game = demoGameForOverlay;
+              final region = demoRegionForOverlay;
+              return ProvinceSeaZoneDetailOverlay(
+                game: game,
+                region: region,
+                selectedId: sampleProvinceIdForOverlay,
+                displayId: sampleProvinceIdForOverlay,
+                humanPlayerId: game.players.first.id,
+                onClose: () {},
+              );
+            },
+          ),
+        ),
+      ),
+      WidgetbookUseCase(
+        name: 'With map — province selected',
+        builder: (context) =>
+            _MapWithOverlayStory(selectedId: sampleProvinceIdForOverlay),
+      ),
+      WidgetbookUseCase(
+        name: 'With map — sea zone selected',
+        builder: (context) =>
+            _MapWithOverlayStory(selectedId: sampleSeaZoneIdForOverlay),
+      ),
+    ],
+  ),
+];
+
+/// Production panel with local state for Widgetbook. SPEC/ui/production-panel.md.
+class _ProductionPanelStory extends StatefulWidget {
+  const _ProductionPanelStory({
+    this.playerOverride,
+    this.useFullAvailability = true,
+  });
+
+  /// When set, used instead of the full/partial demo player.
+  final Player? playerOverride;
+
+  /// When true, use full-availability demo player; when false, partial.
+  final bool useFullAvailability;
+
+  @override
+  State<_ProductionPanelStory> createState() => _ProductionPanelStoryState();
+}
+
+class _ProductionPanelStoryState extends State<_ProductionPanelStory> {
+  Map<String, int> _desiredOutputByRecipe = const {};
+
+  @override
+  Widget build(BuildContext context) {
+    final game = demoGameForOverlay;
+    final player =
+        widget.playerOverride ??
+        (widget.useFullAvailability
+            ? fullAvailabilityProductionPlayer()
+            : partialAvailabilityProductionPlayer());
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 800, maxHeight: 500),
+      child: ProductionPanel(
+        game: game,
+        player: player,
+        desiredOutputByRecipe: _desiredOutputByRecipe,
+        onDesiredOutputChanged: (next) =>
+            setState(() => _desiredOutputByRecipe = next),
+      ),
+    );
+  }
+}
+
+/// Civilian Units Panel + map in tandem. SPEC/ui/civilian-units-panel.md.
+/// Demonstrates assign (order menu → valid tiles glow → tile click) and cancel with real game/map.
+class _CivilianPanelWithMapStory extends StatefulWidget {
+  const _CivilianPanelWithMapStory();
+
+  @override
+  State<_CivilianPanelWithMapStory> createState() =>
+      _CivilianPanelWithMapStoryState();
+}
+
+class _CivilianPanelWithMapStoryState
+    extends State<_CivilianPanelWithMapStory> {
+  late Game _game;
+  Orders _orders = const Orders();
+  int _regionIndex = 0;
+  String? _highlightedTileKey;
+  String? _centerOnTileKey;
+  ({Unit unit, String workTarget})? _workTargetSelection;
+  CtMapVisibilityMode _visibilityMode = CtMapVisibilityMode.full;
+  Set<String>? _cachedValidTileKeys;
+  String? _cachedWorkTargetSelection;
+
+  @override
+  void initState() {
+    super.initState();
+    _game = getDebugInitGameResult().game;
+  }
+
+  String get _humanPlayerId =>
+      _game.players.isNotEmpty ? _game.players.first.id : 'gp1';
+
+  String get _currentRegionId => _regionIndex == 0 ? 'oldWorld' : 'newWorld';
+
+  String? get _validTileKeysCacheKey {
+    if (_workTargetSelection == null) return null;
+    return '${_workTargetSelection!.unit.id}|${_workTargetSelection!.workTarget}|$_visibilityMode';
+  }
+
+  Set<String>? get _validTileKeys {
+    if (_workTargetSelection == null) return null;
+    final cacheKey = _validTileKeysCacheKey;
+    if (_cachedWorkTargetSelection == cacheKey &&
+        _cachedValidTileKeys != null) {
+      return _cachedValidTileKeys;
+    }
+    final result = getDebugInitGameResult();
+
+    Set<String> valid;
+    if (_visibilityMode == CtMapVisibilityMode.playerConstrained) {
+      final view = buildPlayerView(
+        _game,
+        result.combinedTopology,
+        _humanPlayerId,
+      );
+      valid = getValidWorkOrderTileKeysWithVisibility(
+        game: _game,
+        topology: result.combinedTopology,
+        view: view,
+        unitId: _workTargetSelection!.unit.id,
+        workTarget: _workTargetSelection!.workTarget,
+        currentOrders: _orders,
+      );
+    } else {
+      valid = getValidWorkOrderTileKeys(
+        _game,
+        result.combinedTopology,
+        _humanPlayerId,
+        _workTargetSelection!.unit.id,
+        _workTargetSelection!.workTarget,
+        _orders,
+      );
+    }
+
+    final filtered = valid
+        .where((k) => k.startsWith('$_currentRegionId|'))
+        .toSet();
+    _cachedValidTileKeys = filtered;
+    _cachedWorkTargetSelection = cacheKey;
+    return filtered;
+  }
+
+  void _onLocateUnit(Unit unit) {
+    final tileKey = unit.tileKey;
+    if (tileKey == null) return;
+    final regionId = Unit.regionIdFromTileKey(tileKey);
+    setState(() {
+      _highlightedTileKey = tileKey;
+      _centerOnTileKey = tileKey;
+      if (regionId == 'newWorld') {
+        _regionIndex = 1;
+      } else if (regionId == 'oldWorld') {
+        _regionIndex = 0;
+      }
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() => _centerOnTileKey = null);
+    });
+  }
+
+  void _onTileSelectedForWork(String tileKey) {
+    final sel = _workTargetSelection;
+    if (sel == null) {
+      return;
+    }
+    final target = sel.workTarget;
+    String targetTileKey = tileKey;
+    if (target == 'explore' ||
+        target == 'steal_tech' ||
+        target == 'counter_spy') {
+      final parts = tileKey.split('|');
+      if (parts.length >= 2) {
+        targetTileKey = '${parts[0]}|${parts[1]}|0|0';
+      }
+    }
+    final workOrder = WorkOrder(
+      unitId: sel.unit.id,
+      target: target,
+      targetTileKey: targetTileKey,
+    );
+    setState(() {
+      final existing =
+          _orders.workOrdersByPlayerId[_humanPlayerId] ?? const <WorkOrder>[];
+      final list = <WorkOrder>[...existing, workOrder];
+      _orders = _orders.copyWith(
+        workOrdersByPlayerId: {
+          ..._orders.workOrdersByPlayerId,
+          _humanPlayerId: list,
+        },
+      );
+      _workTargetSelection = null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final baseResult = getDebugInitGameResult();
+    final mapViewData = _visibilityMode == CtMapVisibilityMode.playerConstrained
+        ? debugMapViewDataWithVisibilityForFirstPlayer()
+        : baseResult.mapViewData;
+    final region = _regionIndex == 0
+        ? mapViewData.oldWorld
+        : mapViewData.newWorld;
+    // Panel at bottom, like province overlay "With map" story. SPEC/ui/civilian-units-panel.md.
+    const panelHeight = 220.0;
+    return SizedBox(
+      width: 900,
+      height: 550,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: Wrap(
+              spacing: 8,
+              runSpacing: 4,
+              children: [
+                CtChoiceChip(
+                  label: const Text('Old World'),
+                  selected: _regionIndex == 0,
+                  onSelected: (_) => setState(() => _regionIndex = 0),
+                ),
+                CtChoiceChip(
+                  label: const Text('New World'),
+                  selected: _regionIndex == 1,
+                  onSelected: (_) => setState(() => _regionIndex = 1),
+                ),
+                CtChoiceChip(
+                  label: const Text('Full visibility'),
+                  selected: _visibilityMode == CtMapVisibilityMode.full,
+                  onSelected: (_) => setState(
+                    () => _visibilityMode = CtMapVisibilityMode.full,
+                  ),
+                ),
+                CtChoiceChip(
+                  label: const Text('Player-constrained'),
+                  selected:
+                      _visibilityMode == CtMapVisibilityMode.playerConstrained,
+                  onSelected: (_) => setState(
+                    () =>
+                        _visibilityMode = CtMapVisibilityMode.playerConstrained,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: CtRegionMap(
+              region: region,
+              cellSizePx: 24,
+              visibilityMode: _visibilityMode,
+              onProvinceSelected: (_) {},
+              highlightedTileKey: _highlightedTileKey,
+              centerOnTileKey: _centerOnTileKey,
+              validTileKeys: _validTileKeys,
+              onTileSelected: _workTargetSelection != null
+                  ? _onTileSelectedForWork
+                  : null,
+              onWorkTargetSelectionCancelled: _workTargetSelection != null
+                  ? () => setState(() => _workTargetSelection = null)
+                  : null,
+            ),
+          ),
+          SizedBox(
+            height: panelHeight,
+            child: CivilianUnitsPanel(
+              game: _game,
+              humanPlayerId: _humanPlayerId,
+              currentOrders: _orders,
+              availableWorkTargets: const {},
+              bus: AppEventBus(),
+              onLocateUnit: _onLocateUnit,
+              onRemoveWorkOrder: (playerId, index) {
+                setState(() {
+                  final list = List<WorkOrder>.from(
+                    _orders.workOrdersByPlayerId[playerId] ?? [],
+                  )..removeAt(index);
+                  _orders = _orders.copyWith(
+                    workOrdersByPlayerId: {
+                      ..._orders.workOrdersByPlayerId,
+                      playerId: list,
+                    },
+                  );
+                });
+              },
+              onCancelUnitWork: (unitId) {
+                setState(() => _game = clearUnitCurrentWork(_game, unitId));
+              },
+              onStartWorkTargetSelection: (unit, workTarget) {
+                setState(
+                  () => _workTargetSelection = (
+                    unit: unit,
+                    workTarget: workTarget,
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Civilian Units Panel opened as bottom sheet (slide up from bottom). SPEC/ui/civilian-units-panel.md.
+class _CivilianPanelAsBottomSheetStory extends StatelessWidget {
+  const _CivilianPanelAsBottomSheetStory();
+
+  @override
+  Widget build(BuildContext context) {
+    final result = getDebugInitGameResult();
+    final game = result.game;
+    final humanPlayerId = game.players.isNotEmpty
+        ? game.players.first.id
+        : 'gp1';
+    return SizedBox(
+      width: 600,
+      height: 400,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: CtNinePatchButton(
+              onPressed: () {
+                showModalBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  builder: (ctx) {
+                    final maxHeight = MediaQuery.sizeOf(ctx).height * 0.5;
+                    return ConstrainedBox(
+                      constraints: BoxConstraints(maxHeight: maxHeight),
+                      child: CivilianUnitsPanel(
+                        game: game,
+                        humanPlayerId: humanPlayerId,
+                        availableWorkTargets: const {},
+                        bus: AppEventBus(),
+                      ),
+                    );
+                  },
+                );
+              },
+              child: const Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.people_outline, size: 20),
+                  SizedBox(width: 8),
+                  Text('Civilian Units'),
+                ],
+              ),
+            ),
+          ),
+          const Expanded(
+            child: ColoredBox(
+              color: Color(0xFFE0E0E0),
+              child: Center(
+                child: Text(
+                  'Tap button to open panel from bottom',
+                  style: TextStyle(color: Color(0xFF616161)),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Military Units Panel + map in tandem. SPEC/ui/military-units-panel.md.
+class _MilitaryPanelWithMapStory extends StatefulWidget {
+  const _MilitaryPanelWithMapStory();
+
+  @override
+  State<_MilitaryPanelWithMapStory> createState() =>
+      _MilitaryPanelWithMapStoryState();
+}
+
+class _MilitaryPanelWithMapStoryState
+    extends State<_MilitaryPanelWithMapStory> {
+  int _regionIndex = 0;
+  String? _highlightedTileKey;
+  String? _centerOnTileKey;
+
+  void _onLocateTile(String tileKey, String regionId) {
+    setState(() {
+      _highlightedTileKey = tileKey;
+      _centerOnTileKey = tileKey;
+      if (regionId == 'newWorld') {
+        _regionIndex = 1;
+      } else if (regionId == 'oldWorld') {
+        _regionIndex = 0;
+      }
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() => _centerOnTileKey = null);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final result = getDebugInitGameResult();
+    final game = result.game;
+    final mapViewData = result.mapViewData;
+    final humanPlayerId = game.players.isNotEmpty
+        ? game.players.first.id
+        : 'gp1';
+    final region = _regionIndex == 0
+        ? mapViewData.oldWorld
+        : mapViewData.newWorld;
+    return SizedBox(
+      width: 900,
+      height: 550,
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      ChoiceChip(
+                        label: const Text('Old World'),
+                        selected: _regionIndex == 0,
+                        onSelected: (_) => setState(() => _regionIndex = 0),
+                      ),
+                      const SizedBox(width: 8),
+                      ChoiceChip(
+                        label: const Text('New World'),
+                        selected: _regionIndex == 1,
+                        onSelected: (_) => setState(() => _regionIndex = 1),
+                      ),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: CtRegionMap(
+                    region: region,
+                    cellSizePx: 24,
+                    onProvinceSelected: (_) {},
+                    highlightedTileKey: _highlightedTileKey,
+                    centerOnTileKey: _centerOnTileKey,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          SizedBox(
+            width: 360,
+            child: MilitaryUnitsPanel(
+              game: game,
+              humanPlayerId: humanPlayerId,
+              onLocateTile: _onLocateTile,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Naval Units Panel + map in tandem. SPEC/ui/naval-units-panel.md.
+class _NavalPanelWithMapStory extends StatefulWidget {
+  const _NavalPanelWithMapStory();
+
+  @override
+  State<_NavalPanelWithMapStory> createState() =>
+      _NavalPanelWithMapStoryState();
+}
+
+class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
+  int _regionIndex = 0;
+  String? _highlightedTileKey;
+  String? _centerOnTileKey;
+
+  void _onLocateFleet(String tileKey, String regionId) {
+    setState(() {
+      _highlightedTileKey = tileKey;
+      _centerOnTileKey = tileKey;
+      if (regionId == 'newWorld') {
+        _regionIndex = 1;
+      } else if (regionId == 'oldWorld') {
+        _regionIndex = 0;
+      }
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() => _centerOnTileKey = null);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final result = getDebugInitGameResult();
+    final game = result.game;
+    final mapViewData = result.mapViewData;
+    final humanPlayerId = game.players.isNotEmpty
+        ? game.players.first.id
+        : 'gp1';
+    final region = _regionIndex == 0
+        ? mapViewData.oldWorld
+        : mapViewData.newWorld;
+    return SizedBox(
+      width: 900,
+      height: 550,
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      ChoiceChip(
+                        label: const Text('Old World'),
+                        selected: _regionIndex == 0,
+                        onSelected: (_) => setState(() => _regionIndex = 0),
+                      ),
+                      const SizedBox(width: 8),
+                      ChoiceChip(
+                        label: const Text('New World'),
+                        selected: _regionIndex == 1,
+                        onSelected: (_) => setState(() => _regionIndex = 1),
+                      ),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: CtRegionMap(
+                    region: region,
+                    cellSizePx: 24,
+                    onProvinceSelected: (_) {},
+                    highlightedTileKey: _highlightedTileKey,
+                    centerOnTileKey: _centerOnTileKey,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          SizedBox(
+            width: 360,
+            child: NavalUnitsPanel(
+              game: game,
+              humanPlayerId: humanPlayerId,
+              onLocateFleet: _onLocateFleet,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Map + overlay in tandem for Widgetbook. SPEC/ui/province-sea-zone-detail-overlay.md.
+class _MapWithOverlayStory extends StatefulWidget {
+  const _MapWithOverlayStory({required this.selectedId});
+
+  final String selectedId;
+
+  @override
+  State<_MapWithOverlayStory> createState() => _MapWithOverlayStoryState();
+}
+
+class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
+  late String _selectedId;
+  String? _hoveredDetailId;
+  String? _hoveredTileKey;
+  String? _highlightedTileKey;
+  CtMapVisibilityMode _visibilityMode = CtMapVisibilityMode.full;
+
+  String get _displayId {
+    if (_hoveredTileKey != null) {
+      final parts = _hoveredTileKey!.split('|');
+      if (parts.length >= 2) {
+        return '${parts[0]}|${parts[1]}';
+      }
+    }
+    return _hoveredDetailId ?? _selectedId;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedId = widget.selectedId;
+  }
+
+  @override
+  void didUpdateWidget(covariant _MapWithOverlayStory oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.selectedId != widget.selectedId) {
+      _selectedId = widget.selectedId;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final initResult = getDebugInitGameResult();
+    final game = initResult.game;
+    final mapViewData = debugMapViewDataWithVisibilityForFirstPlayer();
+    final region = mapViewData.oldWorld;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final totalHeight = constraints.maxHeight > 0
+            ? constraints.maxHeight
+            : 500.0;
+        final overlayHeight = totalHeight / 2;
+        return SizedBox(
+          width: 800,
+          height: totalHeight,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ChoiceChip(
+                      label: const Text('Full visibility'),
+                      selected: _visibilityMode == CtMapVisibilityMode.full,
+                      onSelected: (_) {
+                        setState(() {
+                          _visibilityMode = CtMapVisibilityMode.full;
+                        });
+                      },
+                    ),
+                    const SizedBox(width: 8),
+                    ChoiceChip(
+                      label: const Text('Player-constrained'),
+                      selected:
+                          _visibilityMode ==
+                          CtMapVisibilityMode.playerConstrained,
+                      onSelected: (_) {
+                        setState(() {
+                          _visibilityMode =
+                              CtMapVisibilityMode.playerConstrained;
+                        });
+                      },
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: Stack(
+                  children: [
+                    Positioned.fill(
+                      child: CtRegionMap(
+                        region: region,
+                        cellSizePx: 28,
+                        visibilityMode: _visibilityMode,
+                        onProvinceSelected: (id) =>
+                            setState(() => _selectedId = id),
+                        onProvinceHovered: (id) =>
+                            setState(() => _hoveredDetailId = id),
+                        onTileHovered: (key) =>
+                            setState(() => _hoveredTileKey = key),
+                        highlightedTileKey: _highlightedTileKey,
+                      ),
+                    ),
+                    if (_selectedId.isNotEmpty)
+                      Align(
+                        alignment: Alignment.bottomCenter,
+                        child: SizedBox(
+                          height: overlayHeight,
+                          width: double.infinity,
+                          child: ProvinceSeaZoneDetailOverlay(
+                            game: game,
+                            region: region,
+                            selectedId: _selectedId,
+                            displayId: _displayId,
+                            humanPlayerId: 'gp1',
+                            hoveredTileKey: _hoveredTileKey,
+                            onHighlightTile: (k) =>
+                                setState(() => _highlightedTileKey = k),
+                            onClose: () => setState(() => _selectedId = ''),
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/app/lib/widgetbook/catalog.dart
+++ b/app/lib/widgetbook/catalog.dart
@@ -314,7 +314,11 @@ List<WidgetbookNode> get civilianUnitsPanelDirectories => [
               : 'gp1';
           return ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
-            child: CivilianUnitsPanel(game: game, humanPlayerId: humanPlayerId),
+            child: CivilianUnitsPanel(
+              game: game,
+              humanPlayerId: humanPlayerId,
+              bus: AppEventBus(),
+            ),
           );
         },
       ),
@@ -463,6 +467,7 @@ List<WidgetbookNode> get productionPanelDirectories => [
               topology: result.combinedTopology,
               currentOrders: const Orders(),
               onOrdersChanged: (_) {},
+              bus: AppEventBus(),
             ),
           );
         },
@@ -967,6 +972,7 @@ class _CivilianPanelWithMapStoryState
               humanPlayerId: _humanPlayerId,
               currentOrders: _orders,
               availableWorkTargets: const {},
+              bus: AppEventBus(),
               onLocateUnit: _onLocateUnit,
               onRemoveWorkOrder: (playerId, index) {
                 setState(() {
@@ -1032,6 +1038,7 @@ class _CivilianPanelAsBottomSheetStory extends StatelessWidget {
                         game: game,
                         humanPlayerId: humanPlayerId,
                         availableWorkTargets: const {},
+                        bus: AppEventBus(),
                       ),
                     );
                   },

--- a/app/test/app_event_bus_test.dart
+++ b/app/test/app_event_bus_test.dart
@@ -1,0 +1,220 @@
+// Tests for AppEventBus and event classes. SPEC/program/app-event-bus.md.
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  group('AppEventBus', () {
+    late AppEventBus bus;
+
+    setUp(() {
+      AppEventBus.reset();
+      bus = AppEventBus.create();
+    });
+
+    tearDown(() {
+      bus.dispose();
+    });
+
+    test('emit delivers event to on<T> listener', () async {
+      final events = <AppEvent>[];
+      bus.on<AppEvent>().listen(events.add);
+      bus.emit(const OpenDialogEvent('test'));
+      await Future.delayed(Duration.zero);
+      expect(events, hasLength(1));
+      expect(events.first, isA<OpenDialogEvent>());
+    });
+
+    test('on<T> only receives matching events', () async {
+      final dialogEvents = <OpenDialogEvent>[];
+      final navEvents = <NavigateToRouteEvent>[];
+      bus.on<OpenDialogEvent>().listen(dialogEvents.add);
+      bus.on<NavigateToRouteEvent>().listen(navEvents.add);
+
+      bus.emit(const OpenDialogEvent('a'));
+      bus.emit(const NavigateToRouteEvent('/home'));
+      bus.emit(const OpenDialogEvent('b'));
+      await Future.delayed(Duration.zero);
+
+      expect(dialogEvents, hasLength(2));
+      expect(navEvents, hasLength(1));
+    });
+
+    test('multiple listeners all receive events', () async {
+      final listener1 = <AppEvent>[];
+      final listener2 = <AppEvent>[];
+
+      bus.on<AppEvent>().listen(listener1.add);
+      bus.on<AppEvent>().listen(listener2.add);
+
+      bus.emit(const PopNavigationEvent());
+      await Future.delayed(Duration.zero);
+
+      expect(listener1, hasLength(1));
+      expect(listener2, hasLength(1));
+    });
+
+    test('dispose prevents further events', () async {
+      final events = <AppEvent>[];
+      bus.on<AppEvent>().listen((e) => events.add(e));
+      bus.dispose();
+      expect(() => bus.emit(const ClosePanelEvent()), throwsStateError);
+      expect(events, isEmpty);
+    });
+
+    test('convenience streams filter correctly', () async {
+      final uiActions = <UIActionEvent>[];
+      final uiSystem = <UISystemEvent>[];
+      bus.on<UIActionEvent>().listen(uiActions.add);
+      bus.on<UISystemEvent>().listen(uiSystem.add);
+
+      bus.emit(const OpenDialogEvent('test'));
+      bus.emit(const ShowSnackBarEvent(message: 'hello'));
+      await Future.delayed(Duration.zero);
+
+      expect(uiActions, hasLength(1));
+      expect(uiSystem, hasLength(1));
+    });
+
+    test('dialogueEvents filters DialogueEvent', () async {
+      final events = <DialogueEvent>[];
+      bus.dialogueEvents.listen(events.add);
+
+      bus.emit(const OpenDialogEvent('test'));
+      await Future.delayed(Duration.zero);
+      expect(events, isEmpty);
+
+      bus.emit(
+        const DialogueEvent(
+          leaderId: 'gp1',
+          category: 'war',
+          situation: 'battle_lost',
+          era: 'early',
+        ),
+      );
+      await Future.delayed(Duration.zero);
+      expect(events, hasLength(1));
+    });
+
+    test('portraitMoodEvents filters PortraitMoodEvent', () async {
+      final events = <PortraitMoodEvent>[];
+      bus.portraitMoodEvents.listen(events.add);
+
+      bus.emit(
+        const PortraitMoodEvent(
+          leaderId: 'gp1',
+          fromMood: 'neutral',
+          toMood: 'angry',
+        ),
+      );
+      await Future.delayed(Duration.zero);
+      expect(events, hasLength(1));
+    });
+  });
+
+  group('UIActionEvent equality', () {
+    test('OpenDialogEvent equal for same id and params', () {
+      expect(
+        const OpenDialogEvent('settings', {'tab': 'audio'}),
+        const OpenDialogEvent('settings', {'tab': 'audio'}),
+      );
+      expect(
+        const OpenDialogEvent('settings', {'tab': 'audio'}),
+        isNot(const OpenDialogEvent('settings', {'tab': 'video'})),
+      );
+      expect(
+        const OpenDialogEvent('settings'),
+        const OpenDialogEvent('settings'),
+      );
+    });
+
+    test('ConfirmDialogEvent equal for same params', () {
+      expect(
+        const ConfirmDialogEvent(title: 'a', message: 'b'),
+        const ConfirmDialogEvent(title: 'a', message: 'b'),
+      );
+    });
+
+    test('NavigateToRouteEvent equal for same route and args', () {
+      expect(
+        const NavigateToRouteEvent('/game', {'key': 'value'}),
+        const NavigateToRouteEvent('/game', {'key': 'value'}),
+      );
+    });
+
+    test('OpenPanelEvent equal for same panelId and params', () {
+      expect(
+        const OpenPanelEvent('pause_menu', {'a': 1}),
+        const OpenPanelEvent('pause_menu', {'a': 1}),
+      );
+    });
+
+    test('StartTargetSelectionEvent equal for same params', () {
+      expect(
+        const StartTargetSelectionEvent(unitId: 'u1', action: 'move'),
+        const StartTargetSelectionEvent(unitId: 'u1', action: 'move'),
+      );
+    });
+  });
+
+  group('UISystemEvent equality', () {
+    test('ShowSnackBarEvent equal for same params', () {
+      expect(
+        const ShowSnackBarEvent(message: 'saved'),
+        const ShowSnackBarEvent(message: 'saved'),
+      );
+    });
+
+    test('NotifyEvent equal for same params', () {
+      expect(
+        const NotifyEvent(
+          title: 'Research',
+          body: 'Complete',
+          priority: NotifyPriority.high,
+        ),
+        const NotifyEvent(
+          title: 'Research',
+          body: 'Complete',
+          priority: NotifyPriority.high,
+        ),
+      );
+    });
+
+    test('ShowOverlayEvent equal for same id and params', () {
+      expect(
+        const ShowOverlayEvent(overlayId: 'loading', params: {'spin': true}),
+        const ShowOverlayEvent(overlayId: 'loading', params: {'spin': true}),
+      );
+    });
+  });
+
+  group('GameToUIEvent equality', () {
+    test('TurnResolutionCompleteEvent equal for same fields', () {
+      expect(
+        const TurnResolutionCompleteEvent(gameId: 'g1', turnNumber: 5),
+        const TurnResolutionCompleteEvent(gameId: 'g1', turnNumber: 5),
+      );
+      expect(
+        const TurnResolutionCompleteEvent(gameId: 'g1', turnNumber: 5),
+        isNot(const TurnResolutionCompleteEvent(gameId: 'g1', turnNumber: 6)),
+      );
+    });
+
+    test('SaveGameCompleteEvent equal for same gameId', () {
+      expect(
+        const SaveGameCompleteEvent(gameId: 'game_123'),
+        const SaveGameCompleteEvent(gameId: 'game_123'),
+      );
+    });
+
+    test('NewGameCreatedEvent equal for same gameId', () {
+      expect(
+        const NewGameCreatedEvent(gameId: 'game_456'),
+        const NewGameCreatedEvent(gameId: 'game_456'),
+      );
+    });
+  });
+}

--- a/app/test/app_event_handler_test.dart
+++ b/app/test/app_event_handler_test.dart
@@ -1,0 +1,284 @@
+// Tests for AppEventHandler. SPEC/program/app-event-bus.md.
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/core/services/app_event_handler.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  group('AppEventHandler', () {
+    late AppEventBus bus;
+    late GlobalKey<NavigatorState> navKey;
+    late AppEventHandler handler;
+
+    setUp(() {
+      AppEventBus.reset();
+      bus = AppEventBus.create();
+      navKey = GlobalKey<NavigatorState>();
+      handler = AppEventHandler(
+        bus: bus,
+        navigatorKey: navKey,
+        dialogBuilders: {
+          'test_dialog': (ctx, params) =>
+              Material(child: Text('dialog:${params?['id'] ?? 'default'}')),
+        },
+        panelBuilders: {
+          'test_panel': (ctx, params) =>
+              Material(child: Text('panel:${params?['id'] ?? 'default'}')),
+        },
+      );
+    });
+
+    tearDown(() {
+      handler.unbind();
+      AppEventBus.reset();
+    });
+
+    testWidgets('OpenDialogEvent opens registered dialog', (tester) async {
+      handler.bind();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navKey,
+          home: Builder(
+            builder: (ctx) => TextButton(
+              onPressed: () =>
+                  bus.emit(const OpenDialogEvent('test_dialog', {'id': '42'})),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('dialog:42'), findsOneWidget);
+    });
+
+    testWidgets('OpenDialogEvent with unknown id shows nothing', (
+      tester,
+    ) async {
+      handler.bind();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navKey,
+          home: Builder(
+            builder: (ctx) => TextButton(
+              onPressed: () =>
+                  bus.emit(const OpenDialogEvent('unknown_dialog')),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsNothing);
+    });
+
+    testWidgets('NavigateToRouteEvent calls pushNamed', (tester) async {
+      handler.bind();
+      final pushed = <RouteSettings?>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navKey,
+          onGenerateRoute: (settings) {
+            pushed.add(settings);
+            return MaterialPageRoute(
+              settings: settings,
+              builder: (_) => const Text('target'),
+            );
+          },
+          home: Builder(
+            builder: (ctx) => TextButton(
+              onPressed: () =>
+                  bus.emit(const NavigateToRouteEvent('/target', {'x': 1})),
+              child: const Text('navigate'),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('navigate'));
+      await tester.pumpAndSettle();
+
+      expect(pushed, hasLength(1));
+      expect(pushed[0]?.name, '/target');
+      expect(pushed[0]?.arguments, {'x': 1});
+    });
+
+    testWidgets('PopNavigationEvent calls nav.pop', (tester) async {
+      handler.bind();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navKey,
+          navigatorObservers: [],
+          initialRoute: '/base',
+          onGenerateRoute: (settings) {
+            if (settings.name == '/overlay') {
+              return MaterialPageRoute(
+                settings: settings,
+                builder: (ctx) => const Text('overlay_route'),
+              );
+            }
+            return MaterialPageRoute(
+              settings: settings,
+              builder: (ctx) => const Text('base_route'),
+            );
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('base_route'), findsOneWidget);
+
+      navKey.currentState?.pushNamed('/overlay');
+      await tester.pumpAndSettle();
+
+      expect(find.text('overlay_route'), findsOneWidget);
+
+      bus.emit(const PopNavigationEvent());
+      await tester.pumpAndSettle();
+
+      expect(find.text('overlay_route'), findsNothing);
+      expect(find.text('base_route'), findsOneWidget);
+    });
+
+    testWidgets('OpenPanelEvent opens registered bottom sheet panel', (
+      tester,
+    ) async {
+      handler.bind();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navKey,
+          home: Builder(
+            builder: (ctx) => TextButton(
+              onPressed: () => bus.emit(
+                const OpenPanelEvent('test_panel', {'id': 'panel42'}),
+              ),
+              child: const Text('open panel'),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('open panel'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('panel:panel42'), findsOneWidget);
+    });
+
+    testWidgets('OpenPanelEvent with unknown id shows nothing', (tester) async {
+      handler.bind();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navKey,
+          home: Builder(
+            builder: (ctx) => TextButton(
+              onPressed: () => bus.emit(const OpenPanelEvent('unknown_panel')),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('open'), findsOneWidget);
+    });
+
+    testWidgets('ConfirmDialogEvent shows dialog with title and message', (
+      tester,
+    ) async {
+      handler.bind();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navKey,
+          home: Builder(
+            builder: (ctx) => TextButton(
+              onPressed: () => bus.emit(
+                const ConfirmDialogEvent(title: 'Confirm', message: 'Proceed?'),
+              ),
+              child: const Text('trigger'),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('trigger'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Confirm'), findsOneWidget);
+      expect(find.text('Proceed?'), findsOneWidget);
+      expect(find.text('OK'), findsOneWidget);
+      expect(find.text('Cancel'), findsOneWidget);
+    });
+
+    testWidgets('ShowSnackBarEvent calls onShowSnackBar callback', (
+      tester,
+    ) async {
+      ShowSnackBarEvent? received;
+      handler = AppEventHandler(
+        bus: bus,
+        navigatorKey: navKey,
+        onShowSnackBar: (e) => received = e,
+      );
+      handler.bind();
+
+      await tester.pumpWidget(
+        MaterialApp(navigatorKey: navKey, home: const Text('home')),
+      );
+      await tester.pumpAndSettle();
+
+      bus.emit(
+        const ShowSnackBarEvent(message: 'hello snack', actionLabel: 'undo'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(received?.message, 'hello snack');
+      expect(received?.actionLabel, 'undo');
+    });
+
+    testWidgets('DismissOverlayEvent calls onDismissOverlay callback', (
+      tester,
+    ) async {
+      DismissOverlayEvent? received;
+      handler = AppEventHandler(
+        bus: bus,
+        navigatorKey: navKey,
+        onDismissOverlay: (e) => received = e,
+      );
+      handler.bind();
+
+      await tester.pumpWidget(
+        MaterialApp(navigatorKey: navKey, home: const Text('home')),
+      );
+      await tester.pumpAndSettle();
+
+      bus.emit(const DismissOverlayEvent('loading_spinner'));
+      await tester.pumpAndSettle();
+
+      expect(received?.overlayId, 'loading_spinner');
+    });
+  });
+}

--- a/app/test/civilian_units_panel_test.dart
+++ b/app/test/civilian_units_panel_test.dart
@@ -1,5 +1,7 @@
 // Tests for CivilianUnitsPanel. SPEC/ui/civilian-units-panel.md.
 
+import 'dart:async';
+
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -8,6 +10,61 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/civilian_units_panel.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
+
+class _EventHandlingWrapper extends StatefulWidget {
+  const _EventHandlingWrapper({
+    required this.bus,
+    required this.child,
+    required this.navigatorKey,
+  });
+
+  final AppEventBus bus;
+  final Widget child;
+  final GlobalKey<NavigatorState> navigatorKey;
+
+  @override
+  State<_EventHandlingWrapper> createState() => _EventHandlingWrapperState();
+}
+
+class _EventHandlingWrapperState extends State<_EventHandlingWrapper> {
+  StreamSubscription? _sub;
+
+  @override
+  void initState() {
+    super.initState();
+    _sub = widget.bus.on<ConfirmDialogEvent>().listen((event) async {
+      final nav = widget.navigatorKey.currentState;
+      if (nav == null) return;
+      final result = await showDialog<bool>(
+        context: nav.context,
+        builder: (ctx) => AlertDialog(
+          title: Text(event.title),
+          content: Text(event.message),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(false),
+              child: Text(event.cancelLabel),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              child: Text(event.confirmLabel),
+            ),
+          ],
+        ),
+      );
+      event.result(result ?? false);
+    });
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
 
 void main() {
   suppressLogsForTests();
@@ -34,19 +91,26 @@ void main() {
     void Function(String unitId)? onCancelUnitWork,
     void Function(Unit unit, String workTarget)? onStartWorkTargetSelection,
   }) {
+    final bus = AppEventBus();
+    final navigatorKey = GlobalKey<NavigatorState>();
     return MaterialApp(
+      navigatorKey: navigatorKey,
       home: Scaffold(
-        body: CivilianUnitsPanel(
-          game: game,
-          humanPlayerId: humanPlayerId,
-          currentOrders: currentOrders,
-          availableWorkTargets: availableWorkTargets,
-          bus: AppEventBus(),
-          onLocateUnit: onLocateUnit,
-          onAddWorkOrder: onAddWorkOrder,
-          onRemoveWorkOrder: onRemoveWorkOrder,
-          onCancelUnitWork: onCancelUnitWork,
-          onStartWorkTargetSelection: onStartWorkTargetSelection,
+        body: _EventHandlingWrapper(
+          bus: bus,
+          navigatorKey: navigatorKey,
+          child: CivilianUnitsPanel(
+            game: game,
+            humanPlayerId: humanPlayerId,
+            currentOrders: currentOrders,
+            availableWorkTargets: availableWorkTargets,
+            bus: bus,
+            onLocateUnit: onLocateUnit,
+            onAddWorkOrder: onAddWorkOrder,
+            onRemoveWorkOrder: onRemoveWorkOrder,
+            onCancelUnitWork: onCancelUnitWork,
+            onStartWorkTargetSelection: onStartWorkTargetSelection,
+          ),
         ),
       ),
     );

--- a/app/test/civilian_units_panel_test.dart
+++ b/app/test/civilian_units_panel_test.dart
@@ -41,6 +41,7 @@ void main() {
           humanPlayerId: humanPlayerId,
           currentOrders: currentOrders,
           availableWorkTargets: availableWorkTargets,
+          bus: AppEventBus(),
           onLocateUnit: onLocateUnit,
           onAddWorkOrder: onAddWorkOrder,
           onRemoveWorkOrder: onRemoveWorkOrder,

--- a/app/test/diplomacy_panel_orders_test.dart
+++ b/app/test/diplomacy_panel_orders_test.dart
@@ -57,6 +57,7 @@ class _PendingOrderShellState extends State<_PendingOrderShell> {
           topology: widget.topology,
           currentOrders: _orders,
           onOrdersChanged: (o) => setState(() => _orders = o),
+          bus: AppEventBus(),
         ),
       ),
     );
@@ -78,12 +79,7 @@ void main() {
         newWorld: RegionData(),
       ),
       players: const [
-        Player(
-          id: humanId,
-          displayName: 'Only',
-          isHuman: true,
-          treasury: 0,
-        ),
+        Player(id: humanId, displayName: 'Only', isHuman: true, treasury: 0),
       ],
     );
 
@@ -96,6 +92,7 @@ void main() {
             topology: MapTopology(),
             currentOrders: const Orders(),
             onOrdersChanged: (_) {},
+            bus: AppEventBus(),
           ),
         ),
       ),
@@ -121,6 +118,7 @@ void main() {
               topology: r.combinedTopology,
               currentOrders: const Orders(),
               onOrdersChanged: (_) {},
+              bus: AppEventBus(),
             ),
           ),
         ),
@@ -158,8 +156,9 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      final state =
-          tester.state<_PendingOrderShellState>(find.byType(_PendingOrderShell));
+      final state = tester.state<_PendingOrderShellState>(
+        find.byType(_PendingOrderShell),
+      );
       expect(
         state.ordersSnapshot.diplomaticOrdersByPlayerId[humanId],
         isNotEmpty,

--- a/app/test/diplomacy_panel_orders_test.dart
+++ b/app/test/diplomacy_panel_orders_test.dart
@@ -1,4 +1,6 @@
 // DiplomacyPanel order UI: empty state, confirm dialog, pending cancel.
+import 'dart:async';
+
 import 'package:colonizethis_app/features/game/widgets/diplomacy_panel.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
@@ -8,6 +10,61 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
+
+class _EventHandlingWrapper extends StatefulWidget {
+  const _EventHandlingWrapper({
+    required this.bus,
+    required this.child,
+    required this.navigatorKey,
+  });
+
+  final AppEventBus bus;
+  final Widget child;
+  final GlobalKey<NavigatorState> navigatorKey;
+
+  @override
+  State<_EventHandlingWrapper> createState() => _EventHandlingWrapperState();
+}
+
+class _EventHandlingWrapperState extends State<_EventHandlingWrapper> {
+  StreamSubscription? _sub;
+
+  @override
+  void initState() {
+    super.initState();
+    _sub = widget.bus.on<ConfirmDialogEvent>().listen((event) async {
+      final nav = widget.navigatorKey.currentState;
+      if (nav == null) return;
+      final result = await showDialog<bool>(
+        context: nav.context,
+        builder: (ctx) => AlertDialog(
+          title: Text(event.title),
+          content: Text(event.message),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(false),
+              child: Text(event.cancelLabel),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              child: Text(event.confirmLabel),
+            ),
+          ],
+        ),
+      );
+      event.result(result ?? false);
+    });
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
 
 class _PendingOrderShell extends StatefulWidget {
   const _PendingOrderShell({
@@ -108,17 +165,24 @@ void main() {
       final r = getDebugInitGameResult();
       final game = r.game;
       final humanId = game.players.firstWhere((p) => p.isHuman).id;
+      final bus = AppEventBus();
+      final navigatorKey = GlobalKey<NavigatorState>();
 
       await tester.pumpWidget(
         MaterialApp(
+          navigatorKey: navigatorKey,
           home: Scaffold(
-            body: DiplomacyPanel(
-              game: game,
-              humanPlayerId: humanId,
-              topology: r.combinedTopology,
-              currentOrders: const Orders(),
-              onOrdersChanged: (_) {},
-              bus: AppEventBus(),
+            body: _EventHandlingWrapper(
+              bus: bus,
+              navigatorKey: navigatorKey,
+              child: DiplomacyPanel(
+                game: game,
+                humanPlayerId: humanId,
+                topology: r.combinedTopology,
+                currentOrders: const Orders(),
+                onOrdersChanged: (_) {},
+                bus: bus,
+              ),
             ),
           ),
         ),
@@ -134,7 +198,7 @@ void main() {
       await tester.tap(declareWar.first);
       await tester.pumpAndSettle();
 
-      expect(find.text('Confirm'), findsWidgets);
+      expect(find.text('OK'), findsWidgets);
       await tester.tap(find.text('Cancel').last);
       await tester.pumpAndSettle();
     },

--- a/app/test/diplomacy_panel_test.dart
+++ b/app/test/diplomacy_panel_test.dart
@@ -7,6 +7,8 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flame/cache.dart';
+import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -76,8 +78,12 @@ Future<void> _preWarmFlameImageCache() async {
     final bytes = await rootBundle.load(
       'assets/images/ui_button_nine_patch.png',
     );
-    await ui.instantiateImageCodec(bytes.buffer.asUint8List());
-  } catch (_) {}
+    final codec = await ui.instantiateImageCodec(bytes.buffer.asUint8List());
+    final frame = await codec.getNextFrame();
+    Flame.images.add('ui_button_nine_patch.png', frame.image);
+  } catch (e) {
+    // Silently fail - the test might still work if the image is available later
+  }
 }
 
 class _PanelWrapper extends StatefulWidget {
@@ -188,7 +194,7 @@ void main() {
   late MapTopology topology;
 
   setUpAll(() async {
-    unawaited(_preWarmFlameImageCache());
+    await _preWarmFlameImageCache();
     final result = getDebugInitGameResult();
     gameWithFactions = result.game;
     topology = result.combinedTopology;

--- a/app/test/diplomacy_panel_test.dart
+++ b/app/test/diplomacy_panel_test.dart
@@ -31,6 +31,7 @@ class _PanelWrapper extends StatefulWidget {
     required this.humanPlayerId,
     required this.topology,
     required this.initialOrders,
+    required this.bus,
     this.onOrdersChanged,
   });
 
@@ -38,6 +39,7 @@ class _PanelWrapper extends StatefulWidget {
   final String humanPlayerId;
   final MapTopology topology;
   final Orders initialOrders;
+  final AppEventBus bus;
   final void Function(Orders)? onOrdersChanged;
 
   @override
@@ -60,6 +62,7 @@ class _PanelWrapperState extends State<_PanelWrapper> {
       humanPlayerId: widget.humanPlayerId,
       topology: widget.topology,
       currentOrders: _orders,
+      bus: widget.bus,
       onOrdersChanged: (o) {
         setState(() => _orders = o);
         widget.onOrdersChanged?.call(o);
@@ -74,7 +77,9 @@ Widget buildPanel({
   required MapTopology topology,
   Orders currentOrders = const Orders(),
   void Function(Orders)? onOrdersChanged,
+  AppEventBus? bus,
 }) {
+  final panelBus = bus ?? AppEventBus();
   return MaterialApp(
     home: Scaffold(
       body: _PanelWrapper(
@@ -82,6 +87,7 @@ Widget buildPanel({
         humanPlayerId: humanPlayerId,
         topology: topology,
         initialOrders: currentOrders,
+        bus: panelBus,
         onOrdersChanged: onOrdersChanged,
       ),
     ),

--- a/app/test/diplomacy_panel_test.dart
+++ b/app/test/diplomacy_panel_test.dart
@@ -16,6 +16,61 @@ import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_panel.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
 
+class _EventHandlingWrapper extends StatefulWidget {
+  const _EventHandlingWrapper({
+    required this.bus,
+    required this.child,
+    required this.navigatorKey,
+  });
+
+  final AppEventBus bus;
+  final Widget child;
+  final GlobalKey<NavigatorState> navigatorKey;
+
+  @override
+  State<_EventHandlingWrapper> createState() => _EventHandlingWrapperState();
+}
+
+class _EventHandlingWrapperState extends State<_EventHandlingWrapper> {
+  StreamSubscription? _sub;
+
+  @override
+  void initState() {
+    super.initState();
+    _sub = widget.bus.on<ConfirmDialogEvent>().listen((event) async {
+      final nav = widget.navigatorKey.currentState;
+      if (nav == null) return;
+      final result = await showDialog<bool>(
+        context: nav.context,
+        builder: (ctx) => AlertDialog(
+          title: Text(event.title),
+          content: Text(event.message),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(false),
+              child: Text(event.cancelLabel),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              child: Text(event.confirmLabel),
+            ),
+          ],
+        ),
+      );
+      event.result(result ?? false);
+    });
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
 Future<void> _preWarmFlameImageCache() async {
   try {
     final bytes = await rootBundle.load(
@@ -80,15 +135,21 @@ Widget buildPanel({
   AppEventBus? bus,
 }) {
   final panelBus = bus ?? AppEventBus();
+  final navigatorKey = GlobalKey<NavigatorState>();
   return MaterialApp(
+    navigatorKey: navigatorKey,
     home: Scaffold(
-      body: _PanelWrapper(
-        game: game,
-        humanPlayerId: humanPlayerId,
-        topology: topology,
-        initialOrders: currentOrders,
+      body: _EventHandlingWrapper(
         bus: panelBus,
-        onOrdersChanged: onOrdersChanged,
+        navigatorKey: navigatorKey,
+        child: _PanelWrapper(
+          game: game,
+          humanPlayerId: humanPlayerId,
+          topology: topology,
+          initialOrders: currentOrders,
+          bus: panelBus,
+          onOrdersChanged: onOrdersChanged,
+        ),
       ),
     ),
   );
@@ -260,9 +321,9 @@ void main() {
         if (declareWar.evaluate().isNotEmpty) {
           await tester.tap(declareWar.first);
           await tester.pumpAndSettle();
-          expect(find.text('Confirm'), findsOneWidget);
+          expect(find.text('OK'), findsOneWidget);
           expect(find.text('Cancel'), findsWidgets);
-          await tester.tap(find.text('Confirm'));
+          await tester.tap(find.text('OK'));
           await tester.pumpAndSettle();
           expect(captured, isNotNull);
           expect(
@@ -297,7 +358,7 @@ void main() {
         if (declareWar.evaluate().isNotEmpty) {
           await tester.tap(declareWar.first);
           await tester.pumpAndSettle();
-          expect(find.text('Confirm'), findsOneWidget);
+          expect(find.text('OK'), findsOneWidget);
           final cancelBtn = find.widgetWithText(TextButton, 'Cancel');
           await tester.tap(cancelBtn.first);
           await tester.pumpAndSettle();

--- a/app/test/diplomacy_screen_test.dart
+++ b/app/test/diplomacy_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/diplomacy_screen.dart';
@@ -34,20 +35,22 @@ void main() {
     Orders currentOrders = const Orders(),
     void Function(Orders)? onOrdersChanged,
   }) {
-    return MaterialApp(
-      home: Navigator(
-        pages: [
-          MaterialPage(
-            child: DiplomacyScreen(
-              game: game,
-              humanPlayerId: humanPlayerId,
-              topology: topology,
-              currentOrders: currentOrders,
-              onOrdersChanged: onOrdersChanged ?? (_) {},
+    return ProviderScope(
+      child: MaterialApp(
+        home: Navigator(
+          pages: [
+            MaterialPage(
+              child: DiplomacyScreen(
+                game: game,
+                humanPlayerId: humanPlayerId,
+                topology: topology,
+                currentOrders: currentOrders,
+                onOrdersChanged: onOrdersChanged ?? (_) {},
+              ),
             ),
-          ),
-        ],
-        onPopPage: (_, __) => false,
+          ],
+          onPopPage: (_, __) => false,
+        ),
       ),
     );
   }
@@ -98,7 +101,12 @@ void main() {
     testWidgets('back button is tappable', (WidgetTester tester) async {
       final navigatorKey = GlobalKey<NavigatorState>();
       await tester.pumpWidget(
-        MaterialApp(navigatorKey: navigatorKey, home: const Text('Home')),
+        ProviderScope(
+          child: MaterialApp(
+            navigatorKey: navigatorKey,
+            home: const Text('Home'),
+          ),
+        ),
       );
 
       navigatorKey.currentState!.push<void>(

--- a/app/test/game_screen_branches_test.dart
+++ b/app/test/game_screen_branches_test.dart
@@ -1,22 +1,108 @@
 import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/features/game/flame/game_screen.dart';
 import 'package:colonizethis_app/features/game/dialogue/game_start_intro_overlay.dart';
+import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/providers/map_view_provider.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
-import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
+import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'dart:async';
+
+class TestAppEventBus implements AppEventBus {
+  TestAppEventBus(this._inner);
+
+  final AppEventBus _inner;
+  NavigatorState? _navigator;
+  BuildContext? _context;
+  Map<String, Object?>? _lastOpenPanelParams;
+
+  void setNavigator(NavigatorState navigator) {
+    _navigator = navigator;
+  }
+
+  void setContext(BuildContext context) {
+    _context = context;
+  }
+
+  Map<String, Object?>? get lastOpenPanelParams => _lastOpenPanelParams;
+
+  @override
+  void emit(AppEvent event) {
+    if (event is NavigateToRouteEvent && _navigator != null) {
+      _navigator!.pushNamed(event.route, arguments: event.arguments);
+    } else if (event is OpenPanelEvent && event.panelId == 'pause_menu') {
+      _lastOpenPanelParams = event.params;
+      if (_context != null) {
+        _showPauseMenu(_context!, event.params);
+      }
+    }
+    _inner.emit(event);
+  }
+
+  void _showPauseMenu(BuildContext context, Map<String, Object?>? params) {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (ctx) => Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ListTile(
+            leading: const Icon(Icons.list),
+            title: const Text('Debug log'),
+            onTap: () {
+              Navigator.of(ctx).pop();
+              (params?['onDebugLog'] as VoidCallback?)?.call();
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.play_arrow),
+            title: const Text('Resume'),
+            onTap: () {
+              Navigator.of(ctx).pop();
+              (params?['onResume'] as VoidCallback?)?.call();
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Stream<AppEvent> get stream => _inner.stream;
+
+  @override
+  Stream<T> on<T extends AppEvent>() => _inner.on<T>();
+
+  @override
+  Stream<UIActionEvent> get uiActionEvents => _inner.uiActionEvents;
+
+  @override
+  Stream<UISystemEvent> get uiSystemEvents => _inner.uiSystemEvents;
+
+  @override
+  Stream<GameToUIEvent> get gameToUIEvents => _inner.gameToUIEvents;
+
+  @override
+  Stream<DialogueEvent> get dialogueEvents => _inner.dialogueEvents;
+
+  @override
+  Stream<PortraitMoodEvent> get portraitMoodEvents => _inner.portraitMoodEvents;
+
+  @override
+  void dispose() => _inner.dispose();
+}
 
 void main() {
   suppressLogsForTests();
 
   late InitGameResult debugResult;
-  late ct_models.Game baseGame;
+  late Game baseGame;
 
   setUpAll(() {
     debugResult = getDebugInitGameResult();
@@ -26,15 +112,17 @@ void main() {
   Widget buildGameScreen({
     required double width,
     required double height,
-    required ct_models.Game game,
+    required Game game,
     required InitGameMapViewData? mapViewData,
     required Set<String> introShownIds,
+    TestAppEventBus? testBus,
   }) {
     return ProviderScope(
       overrides: [
         currentGameProvider.overrideWith((ref) => game),
         mapViewDataProvider.overrideWith((ref) => mapViewData),
         gameIdsWithIntroShownProvider.overrideWith((ref) => introShownIds),
+        if (testBus != null) appEventBusProvider.overrideWith((ref) => testBus),
       ],
       child: MaterialApp(
         theme: AppThemes.colonial,
@@ -46,13 +134,14 @@ void main() {
     );
   }
 
-  testWidgets('GameScreen shows VictoryOverlay when game.victory is set',
-      (WidgetTester tester) async {
+  testWidgets('GameScreen shows VictoryOverlay when game.victory is set', (
+    WidgetTester tester,
+  ) async {
     final winner = baseGame.players.first;
     final victoryGame = baseGame.copyWith(
-      victory: ct_models.VictoryState(
+      victory: VictoryState(
         winnerPlayerId: winner.id,
-        type: ct_models.VictoryType.military,
+        type: VictoryType.military,
         turnNumber: 7,
       ),
     );
@@ -72,8 +161,11 @@ void main() {
     expect(find.textContaining('wins on turn 7'), findsOneWidget);
   });
 
-  testWidgets('GameScreen shows pause menu and opens bottom sheet',
-      (WidgetTester tester) async {
+  testWidgets('GameScreen shows pause menu and opens bottom sheet', (
+    WidgetTester tester,
+  ) async {
+    final testBus = TestAppEventBus(AppEventBus.create());
+
     await tester.pumpWidget(
       buildGameScreen(
         width: 800,
@@ -81,6 +173,7 @@ void main() {
         game: baseGame,
         mapViewData: null,
         introShownIds: {baseGame.id},
+        testBus: testBus,
       ),
     );
     await tester.pump(const Duration(milliseconds: 200));
@@ -88,28 +181,33 @@ void main() {
     expect(find.textContaining('Next turn'), findsOneWidget);
     expect(find.byIcon(Icons.menu), findsOneWidget);
 
+    final scaffoldFinder = find.byType(Scaffold);
+    expect(scaffoldFinder, findsOneWidget);
+    testBus.setContext(tester.element(scaffoldFinder));
     await tester.tap(find.byIcon(Icons.menu));
+    await tester.pump();
     await tester.pump(const Duration(milliseconds: 200));
 
     expect(find.text('Debug log'), findsOneWidget);
     expect(find.text('Resume'), findsOneWidget);
   });
 
-  testWidgets('GameScreen wraps content in GameStartIntroOverlay when not shown',
-      (WidgetTester tester) async {
-    await tester.pumpWidget(
-      buildGameScreen(
-        width: 800,
-        height: 600,
-        game: baseGame,
-        mapViewData: debugResult.mapViewData,
-        introShownIds: const <String>{},
-      ),
-    );
-    await tester.pump(const Duration(milliseconds: 200));
+  testWidgets(
+    'GameScreen wraps content in GameStartIntroOverlay when not shown',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildGameScreen(
+          width: 800,
+          height: 600,
+          game: baseGame,
+          mapViewData: debugResult.mapViewData,
+          introShownIds: const <String>{},
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
 
-    // Just verifying presence is enough to cover the GameScreen branch.
-    expect(find.byType(GameStartIntroOverlay), findsOneWidget);
-  });
+      // Just verifying presence is enough to cover the GameScreen branch.
+      expect(find.byType(GameStartIntroOverlay), findsOneWidget);
+    },
+  );
 }
-

--- a/app/test/game_screen_narrow_test.dart
+++ b/app/test/game_screen_narrow_test.dart
@@ -4,6 +4,7 @@ import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/config/routes.dart';
 import 'package:colonizethis_app/features/game/flame/game_screen.dart';
 import 'package:colonizethis_app/features/game/dialogue/overture_dialogue_overlay.dart';
+import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/providers/map_view_provider.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
@@ -13,6 +14,87 @@ import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'dart:async';
+
+class TestAppEventBus implements AppEventBus {
+  TestAppEventBus(this._inner);
+
+  final AppEventBus _inner;
+  NavigatorState? _navigator;
+  BuildContext? _context;
+
+  void setNavigator(NavigatorState navigator) {
+    _navigator = navigator;
+  }
+
+  void setContext(BuildContext context) {
+    _context = context;
+  }
+
+  @override
+  void emit(AppEvent event) {
+    if (event is NavigateToRouteEvent && _navigator != null) {
+      _navigator!.pushNamed(event.route, arguments: event.arguments);
+    } else if (event is OpenPanelEvent && event.panelId == 'pause_menu') {
+      if (_context != null) {
+        _showPauseMenu(_context!, event.params);
+      }
+    }
+    _inner.emit(event);
+  }
+
+  void _showPauseMenu(BuildContext context, Map<String, Object?>? params) {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (ctx) => Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ListTile(
+            leading: const Icon(Icons.list),
+            title: const Text('Debug log'),
+            onTap: () {
+              Navigator.of(ctx).pop();
+              (params?['onDebugLog'] as VoidCallback?)?.call();
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.play_arrow),
+            title: const Text('Resume'),
+            onTap: () {
+              Navigator.of(ctx).pop();
+              (params?['onResume'] as VoidCallback?)?.call();
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Stream<AppEvent> get stream => _inner.stream;
+
+  @override
+  Stream<T> on<T extends AppEvent>() => _inner.on<T>();
+
+  @override
+  Stream<UIActionEvent> get uiActionEvents => _inner.uiActionEvents;
+
+  @override
+  Stream<UISystemEvent> get uiSystemEvents => _inner.uiSystemEvents;
+
+  @override
+  Stream<GameToUIEvent> get gameToUIEvents => _inner.gameToUIEvents;
+
+  @override
+  Stream<DialogueEvent> get dialogueEvents => _inner.dialogueEvents;
+
+  @override
+  Stream<PortraitMoodEvent> get portraitMoodEvents => _inner.portraitMoodEvents;
+
+  @override
+  void dispose() => _inner.dispose();
+}
 
 void main() {
   suppressLogsForTests();
@@ -180,8 +262,9 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 100));
 
-        final switchTile =
-            tester.widget<SwitchListTile>(showBordersFinder.first);
+        final switchTile = tester.widget<SwitchListTile>(
+          showBordersFinder.first,
+        );
         expect(switchTile.value, isFalse);
       },
       timeout: const Timeout(Duration(seconds: 20)),
@@ -266,6 +349,7 @@ void main() {
   group('GameScreen — pause menu and victory overlay', () {
     Widget _buildGameScreenWithPauseMenu({
       required Game game,
+      TestAppEventBus? testBus,
     }) {
       return ProviderScope(
         overrides: [
@@ -273,15 +357,14 @@ void main() {
           // No mapViewData override so that overlay buttons (pause menu, Next turn)
           // are shown on top of the Flame canvas.
           mapViewDataProvider.overrideWith((ref) => null),
-          gameIdsWithIntroShownProvider.overrideWith(
-            (ref) => {game.id},
-          ),
+          gameIdsWithIntroShownProvider.overrideWith((ref) => {game.id}),
+          if (testBus != null)
+            appEventBusProvider.overrideWith((ref) => testBus),
         ],
         child: MaterialApp(
           routes: {
-            Routes.debugLog: (context) => const Scaffold(
-                  body: Center(child: Text('Debug log screen')),
-                ),
+            Routes.debugLog: (context) =>
+                const Scaffold(body: Center(child: Text('Debug log screen'))),
           },
           home: const GameScreen(),
         ),
@@ -291,13 +374,22 @@ void main() {
     testWidgets(
       'pause menu opens bottom sheet and shows debug log entry',
       (WidgetTester tester) async {
+        final testBus = TestAppEventBus(AppEventBus.create());
+
         await tester.pumpWidget(
-          _buildGameScreenWithPauseMenu(game: debugResult.game),
+          _buildGameScreenWithPauseMenu(
+            game: debugResult.game,
+            testBus: testBus,
+          ),
         );
         await tester.pump();
 
+        final scaffoldFinder = find.byType(Scaffold);
+        testBus.setContext(tester.element(scaffoldFinder));
+
         // Tap the pause menu icon in the overlay stack.
         await tester.tap(find.byIcon(Icons.menu).first);
+        await tester.pump();
         await tester.pump(const Duration(milliseconds: 200));
 
         // Bottom sheet should show a Debug log entry.
@@ -321,7 +413,9 @@ void main() {
           ProviderScope(
             overrides: [
               currentGameProvider.overrideWith((ref) => victoryGame),
-              mapViewDataProvider.overrideWith((ref) => debugResult.mapViewData),
+              mapViewDataProvider.overrideWith(
+                (ref) => debugResult.mapViewData,
+              ),
               gameIdsWithIntroShownProvider.overrideWith(
                 (ref) => {victoryGame.id},
               ),

--- a/app/test/game_side_menu_test.dart
+++ b/app/test/game_side_menu_test.dart
@@ -8,6 +8,7 @@ import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/civilian_units_panel.dart';
 import 'package:colonizethis_app/features/game/widgets/production_screen.dart';
 import 'package:colonizethis_app/features/game/widgets/train_civilians_dialog.dart';
+import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
 import 'package:colonizethis_app/providers/game_service_provider.dart';
 import 'package:colonizethis_app/providers/games_box_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
@@ -19,6 +20,51 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+
+import 'dart:async';
+
+class TestAppEventBus implements AppEventBus {
+  TestAppEventBus(this._inner);
+
+  final AppEventBus _inner;
+  NavigatorState? _navigator;
+
+  void setNavigator(NavigatorState navigator) {
+    _navigator = navigator;
+  }
+
+  @override
+  void emit(AppEvent event) {
+    if (event is NavigateToRouteEvent && _navigator != null) {
+      _navigator!.pushNamed(event.route, arguments: event.arguments);
+    }
+    _inner.emit(event);
+  }
+
+  @override
+  Stream<AppEvent> get stream => _inner.stream;
+
+  @override
+  Stream<T> on<T extends AppEvent>() => _inner.on<T>();
+
+  @override
+  Stream<UIActionEvent> get uiActionEvents => _inner.uiActionEvents;
+
+  @override
+  Stream<UISystemEvent> get uiSystemEvents => _inner.uiSystemEvents;
+
+  @override
+  Stream<GameToUIEvent> get gameToUIEvents => _inner.gameToUIEvents;
+
+  @override
+  Stream<DialogueEvent> get dialogueEvents => _inner.dialogueEvents;
+
+  @override
+  Stream<PortraitMoodEvent> get portraitMoodEvents => _inner.portraitMoodEvents;
+
+  @override
+  void dispose() => _inner.dispose();
+}
 
 void main() {
   suppressLogsForTests();
@@ -35,67 +81,73 @@ void main() {
     gamesBox = await Hive.openBox<dynamic>(HiveBoxNames.games);
   });
 
-  testWidgets('GameSideMenu builds empire buttons and close button calls onClose',
-      (WidgetTester tester) async {
-    final humanPlayerId = game.players.where((p) => p.isHuman).isNotEmpty
-        ? game.players.where((p) => p.isHuman).first.id
-        : game.players.first.id;
+  testWidgets(
+    'GameSideMenu builds empire buttons and close button calls onClose',
+    (WidgetTester tester) async {
+      final humanPlayerId = game.players.where((p) => p.isHuman).isNotEmpty
+          ? game.players.where((p) => p.isHuman).first.id
+          : game.players.first.id;
 
-    var closed = false;
+      var closed = false;
 
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          gamesBoxProvider.overrideWith((ref) => gamesBox),
-          gameServiceProvider.overrideWith(
-            (ref) => GameService(gamesBox, GameSaveAdapter()),
-          ),
-          currentGameProvider.overrideWith((ref) => game),
-          currentOrdersProvider.overrideWith((ref) => const Orders()),
-          availableWorkTargetsProvider.overrideWith(
-            (ref) => <String, List<String>>{},
-          ),
-        ],
-        child: MaterialApp(
-          home: Scaffold(
-            body: Stack(
-              children: [
-                GameSideMenu(
-                  game: game,
-                  humanPlayerId: humanPlayerId,
-                  sideMenuOpen: true,
-                  onClose: () => closed = true,
-                  onPanelDismissed: () {},
-                  onLocateCivilianUnit: (_) {},
-                  onLocateMilitaryTile: (_, __) {},
-                  onLocateNavalFleet: (_, __) {},
-                  onCancelUnitWork: (_) {},
-                  onStartWorkTargetSelection: (_, __) {},
-                ),
-              ],
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gamesBoxProvider.overrideWith((ref) => gamesBox),
+            gameServiceProvider.overrideWith(
+              (ref) => GameService(gamesBox, GameSaveAdapter()),
+            ),
+            currentGameProvider.overrideWith((ref) => game),
+            currentOrdersProvider.overrideWith((ref) => const Orders()),
+            availableWorkTargetsProvider.overrideWith(
+              (ref) => <String, List<String>>{},
+            ),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: Stack(
+                children: [
+                  GameSideMenu(
+                    game: game,
+                    humanPlayerId: humanPlayerId,
+                    sideMenuOpen: true,
+                    onClose: () => closed = true,
+                    onPanelDismissed: () {},
+                    onLocateCivilianUnit: (_) {},
+                    onLocateMilitaryTile: (_, __) {},
+                    onLocateNavalFleet: (_, __) {},
+                    onCancelUnitWork: (_) {},
+                    onStartWorkTargetSelection: (_, __) {},
+                  ),
+                ],
+              ),
             ),
           ),
         ),
-      ),
-    );
+      );
 
-    await tester.pumpAndSettle();
+      await tester.pumpAndSettle();
 
-    expect(find.text('Production'), findsOneWidget);
-    expect(find.text('Diplomacy'), findsOneWidget);
-    expect(find.text('×'), findsOneWidget);
+      expect(find.text('Production'), findsOneWidget);
+      expect(find.text('Diplomacy'), findsOneWidget);
+      expect(find.text('×'), findsOneWidget);
 
-    await tester.tap(find.text('×'));
-    await tester.pumpAndSettle();
+      await tester.tap(find.text('×'));
+      await tester.pumpAndSettle();
 
-    expect(closed, isTrue);
-  });
+      expect(closed, isTrue);
+    },
+  );
 
-  testWidgets('GameSideMenu tapping Production navigates to ProductionScreen',
-      (WidgetTester tester) async {
+  testWidgets('GameSideMenu tapping Production navigates to ProductionScreen', (
+    WidgetTester tester,
+  ) async {
     final humanPlayerId = game.players.where((p) => p.isHuman).isNotEmpty
         ? game.players.where((p) => p.isHuman).first.id
         : game.players.first.id;
+
+    final testBus = TestAppEventBus(AppEventBus.create());
+    final navigatorKey = GlobalKey<NavigatorState>();
 
     await tester.pumpWidget(
       ProviderScope(
@@ -109,8 +161,11 @@ void main() {
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
           ),
+          appEventBusProvider.overrideWith((ref) => testBus),
         ],
         child: MaterialApp(
+          navigatorKey: navigatorKey,
+          onGenerateRoute: Routes.generate,
           home: Scaffold(
             body: Stack(
               children: [
@@ -132,6 +187,7 @@ void main() {
         ),
       ),
     );
+    testBus.setNavigator(navigatorKey.currentState!);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Production'));
@@ -141,11 +197,15 @@ void main() {
     expect(find.text('Production'), findsOneWidget);
   });
 
-  testWidgets('GameSideMenu tapping Technology navigates to TechnologyScreen',
-      (WidgetTester tester) async {
+  testWidgets('GameSideMenu tapping Technology navigates to TechnologyScreen', (
+    WidgetTester tester,
+  ) async {
     final humanPlayerId = game.players.where((p) => p.isHuman).isNotEmpty
         ? game.players.where((p) => p.isHuman).first.id
         : game.players.first.id;
+
+    final testBus = TestAppEventBus(AppEventBus.create());
+    final navigatorKey = GlobalKey<NavigatorState>();
 
     await tester.pumpWidget(
       ProviderScope(
@@ -159,8 +219,11 @@ void main() {
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
           ),
+          appEventBusProvider.overrideWith((ref) => testBus),
         ],
         child: MaterialApp(
+          navigatorKey: navigatorKey,
+          onGenerateRoute: Routes.generate,
           home: Scaffold(
             body: Stack(
               children: [
@@ -182,6 +245,7 @@ void main() {
         ),
       ),
     );
+    testBus.setNavigator(navigatorKey.currentState!);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Technology'));
@@ -397,6 +461,9 @@ void main() {
         ? game.players.where((p) => p.isHuman).first.id
         : game.players.first.id;
 
+    final testBus = TestAppEventBus(AppEventBus.create());
+    final navigatorKey = GlobalKey<NavigatorState>();
+
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
@@ -409,8 +476,11 @@ void main() {
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
           ),
+          appEventBusProvider.overrideWith((ref) => testBus),
         ],
         child: MaterialApp(
+          navigatorKey: navigatorKey,
+          onGenerateRoute: Routes.generate,
           home: Scaffold(
             body: Stack(
               children: [
@@ -432,6 +502,7 @@ void main() {
         ),
       ),
     );
+    testBus.setNavigator(navigatorKey.currentState!);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Diplomacy'));
@@ -447,6 +518,9 @@ void main() {
         ? game.players.where((p) => p.isHuman).first.id
         : game.players.first.id;
 
+    final testBus = TestAppEventBus(AppEventBus.create());
+    final navigatorKey = GlobalKey<NavigatorState>();
+
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
@@ -459,12 +533,13 @@ void main() {
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
           ),
+          appEventBusProvider.overrideWith((ref) => testBus),
         ],
         child: MaterialApp(
+          navigatorKey: navigatorKey,
           routes: {
-            Routes.debugLog: (_) => const Scaffold(
-                  body: Center(child: Text('debug-route-marker')),
-                ),
+            Routes.debugLog: (_) =>
+                const Scaffold(body: Center(child: Text('debug-route-marker'))),
           },
           home: Scaffold(
             body: Stack(
@@ -487,6 +562,7 @@ void main() {
         ),
       ),
     );
+    testBus.setNavigator(navigatorKey.currentState!);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Debug log'));
@@ -541,10 +617,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.drag(
-      find.byType(GameSideMenu),
-      const Offset(-40, 0),
-    );
+    await tester.drag(find.byType(GameSideMenu), const Offset(-40, 0));
     await tester.pumpAndSettle();
 
     expect(closed, isTrue);
@@ -567,7 +640,8 @@ class _SideMenuUnmountingHost extends ConsumerStatefulWidget {
       _SideMenuUnmountingHostState();
 }
 
-class _SideMenuUnmountingHostState extends ConsumerState<_SideMenuUnmountingHost> {
+class _SideMenuUnmountingHostState
+    extends ConsumerState<_SideMenuUnmountingHost> {
   bool _sideMenuOpen = true;
 
   @override
@@ -593,4 +667,3 @@ class _SideMenuUnmountingHostState extends ConsumerState<_SideMenuUnmountingHost
     );
   }
 }
-

--- a/app/test/train_civilians_dialog_test.dart
+++ b/app/test/train_civilians_dialog_test.dart
@@ -385,6 +385,7 @@ void main() {
             body: CivilianUnitsPanel(
               game: game,
               humanPlayerId: humanPlayerId,
+              bus: AppEventBus(),
               onTrainPressed: () {},
             ),
           ),
@@ -406,6 +407,7 @@ void main() {
             body: CivilianUnitsPanel(
               game: game,
               humanPlayerId: humanPlayerId,
+              bus: AppEventBus(),
               onTrainPressed: () {
                 trainPressed = true;
               },

--- a/packages/colonizethis_models/lib/colonizethis_models.dart
+++ b/packages/colonizethis_models/lib/colonizethis_models.dart
@@ -25,5 +25,7 @@ export 'src/turn_time_mapping.dart';
 export 'src/unit.dart';
 export 'src/world_state.dart';
 export 'src/ai_events.dart';
+export 'src/app_event_bus.dart';
+export 'src/app_events.dart';
 export 'src/dossier_evidence.dart';
 export 'src/events/dialogue_event_bus.dart';

--- a/packages/colonizethis_models/lib/colonizethis_models.dart
+++ b/packages/colonizethis_models/lib/colonizethis_models.dart
@@ -25,4 +25,6 @@ export 'src/turn_time_mapping.dart';
 export 'src/unit.dart';
 export 'src/world_state.dart';
 export 'src/ai_events.dart';
+export 'src/app_event_bus.dart';
+export 'src/app_events.dart';
 export 'src/dossier_evidence.dart';

--- a/packages/colonizethis_models/lib/src/ai_events.dart
+++ b/packages/colonizethis_models/lib/src/ai_events.dart
@@ -1,9 +1,13 @@
 // AI dialogue and mood events. SPEC/ai/dialogue-and-mood.md, SPEC/program/ai-events-and-dossier.md.
 // Phase 6: emitted by colonizethis_ai; consumed by UI or tooling.
+//
+// DialogueEvent and PortraitMoodEvent extend AppEvent so they can flow through AppEventBus.
+
+import 'app_events.dart';
 
 /// Emitted when AI should display a dialogue line.
 /// UI resolves (leaderId, category, situation, era, mood, variables) to text.
-class DialogueEvent {
+class DialogueEvent extends AppEvent {
   const DialogueEvent({
     required this.leaderId,
     required this.category,
@@ -21,13 +25,13 @@ class DialogueEvent {
   final Map<String, String> variables;
 
   Map<String, dynamic> toJson() => {
-        'leaderId': leaderId,
-        'category': category,
-        'situation': situation,
-        'era': era,
-        if (mood != null) 'mood': mood,
-        if (variables.isNotEmpty) 'variables': Map<String, String>.from(variables),
-      };
+    'leaderId': leaderId,
+    'category': category,
+    'situation': situation,
+    'era': era,
+    if (mood != null) 'mood': mood,
+    if (variables.isNotEmpty) 'variables': Map<String, String>.from(variables),
+  };
 
   static DialogueEvent fromJson(Map<String, dynamic> json) {
     final vars = json['variables'];
@@ -39,7 +43,8 @@ class DialogueEvent {
       mood: json['mood'] as String?,
       variables: vars is Map
           ? Map<String, String>.from(
-              vars.map((k, v) => MapEntry(k.toString(), v.toString())))
+              vars.map((k, v) => MapEntry(k.toString(), v.toString())),
+            )
           : const {},
     );
   }
@@ -47,7 +52,7 @@ class DialogueEvent {
 
 /// Emitted when portrait mood should change (e.g. during negotiation).
 /// UI uses for portrait/animation choice.
-class PortraitMoodEvent {
+class PortraitMoodEvent extends AppEvent {
   const PortraitMoodEvent({
     required this.leaderId,
     required this.fromMood,
@@ -61,11 +66,11 @@ class PortraitMoodEvent {
   final int durationMs;
 
   Map<String, dynamic> toJson() => {
-        'leaderId': leaderId,
-        'fromMood': fromMood,
-        'toMood': toMood,
-        'durationMs': durationMs,
-      };
+    'leaderId': leaderId,
+    'fromMood': fromMood,
+    'toMood': toMood,
+    'durationMs': durationMs,
+  };
 
   static PortraitMoodEvent fromJson(Map<String, dynamic> json) {
     return PortraitMoodEvent(

--- a/packages/colonizethis_models/lib/src/app_event_bus.dart
+++ b/packages/colonizethis_models/lib/src/app_event_bus.dart
@@ -1,0 +1,51 @@
+// App event bus: typed, centralized stream for all app events.
+// SPEC/program/app-event-bus.md (pending).
+//
+// Usage:
+//   // In your service/component:
+//   eventBus.emit(MyEvent());
+//
+//   // In your widget/service that reacts:
+//   eventBus.on<MyEvent>().listen((e) => handle(e));
+//
+// The bus is a broadcast stream so multiple listeners can coexist.
+
+import 'dart:async';
+
+import 'app_events.dart';
+
+class AppEventBus {
+  AppEventBus._() : _controller = StreamController<AppEvent>.broadcast();
+
+  /// Returns the singleton instance. In tests, prefer [create] for a fresh bus.
+  factory AppEventBus() => _instance ??= AppEventBus._();
+
+  /// Creates a fresh bus. Use in tests to avoid singleton interference.
+  factory AppEventBus.create() => AppEventBus._();
+
+  /// Resets the singleton. Call between test runs to avoid stale state.
+  static void reset() => _instance = null;
+
+  static AppEventBus? _instance;
+
+  final StreamController<AppEvent> _controller;
+
+  void emit(AppEvent event) => _controller.add(event);
+
+  Stream<AppEvent> get stream => _controller.stream;
+
+  Stream<T> on<T extends AppEvent>() =>
+      _controller.stream.where((e) => e is T).cast<T>();
+
+  Stream<UIActionEvent> get uiActionEvents => on<UIActionEvent>();
+
+  Stream<UISystemEvent> get uiSystemEvents => on<UISystemEvent>();
+
+  Stream<GameToUIEvent> get gameToUIEvents => on<GameToUIEvent>();
+
+  Stream<DialogueEvent> get dialogueEvents => on<DialogueEvent>();
+
+  Stream<PortraitMoodEvent> get portraitMoodEvents => on<PortraitMoodEvent>();
+
+  void dispose() => _controller.close();
+}

--- a/packages/colonizethis_models/lib/src/app_events.dart
+++ b/packages/colonizethis_models/lib/src/app_events.dart
@@ -1,0 +1,173 @@
+// App events: typed event bus for UI↔UI, UI↔game logic, game logic→UI.
+// SPEC/program/game-events.md, SPEC/program/app-event-bus.md (pending).
+//
+// Three event domains:
+//  1. GameEvent    — game occurrences from colonizethis_logic (consumed, not defined here)
+//  2. UIActionEvent — UI components requesting actions (dialogs, navigation, panels)
+//  3. UISystemEvent — system-level UI feedback (snackbars, overlays, toasts)
+//
+// Note: GameEvent lives in colonizethis_logic to avoid circular deps.
+// DialogueEvent and PortraitMoodEvent live here in colonizethis_models.
+
+export 'ai_events.dart' show DialogueEvent, PortraitMoodEvent;
+
+abstract class AppEvent {
+  const AppEvent();
+}
+
+// ---------------------------------------------------------------------------
+// UIActionEvent — emitted by UI components that need other UI components to act.
+// ---------------------------------------------------------------------------
+
+sealed class UIActionEvent extends AppEvent {
+  const UIActionEvent();
+}
+
+/// Request to open a dialog by string id; params passed to dialog builder.
+class OpenDialogEvent extends UIActionEvent {
+  const OpenDialogEvent(this.dialogId, [this.params]);
+  final String dialogId;
+  final Map<String, Object?>? params;
+}
+
+/// Request to show a confirmation dialog; returns bool via Future.
+class ConfirmDialogEvent extends UIActionEvent {
+  const ConfirmDialogEvent({
+    required this.title,
+    required this.message,
+    this.confirmLabel = 'OK',
+    this.cancelLabel = 'Cancel',
+    void Function(bool)? onResult,
+  }) : _onResult = onResult;
+  final String title;
+  final String message;
+  final String confirmLabel;
+  final String cancelLabel;
+  final void Function(bool)? _onResult;
+
+  void result(bool confirmed) => _onResult?.call(confirmed);
+}
+
+/// Request to navigate to a named route.
+class NavigateToRouteEvent extends UIActionEvent {
+  const NavigateToRouteEvent(this.route, [this.arguments]);
+  final String route;
+  final Object? arguments;
+}
+
+/// Request to pop the current route.
+class PopNavigationEvent extends UIActionEvent {
+  const PopNavigationEvent();
+}
+
+/// Request to open a side panel or overlay.
+class OpenPanelEvent extends UIActionEvent {
+  const OpenPanelEvent(this.panelId, [this.params]);
+  final String panelId;
+  final Map<String, Object?>? params;
+}
+
+/// Request to close the current panel or overlay.
+class ClosePanelEvent extends UIActionEvent {
+  const ClosePanelEvent();
+}
+
+/// Request to start a unit target-selection mode (map enters target-pick state).
+class StartTargetSelectionEvent extends UIActionEvent {
+  const StartTargetSelectionEvent({
+    required this.unitId,
+    required this.action,
+    this.onComplete,
+    this.onCancel,
+  });
+  final String unitId;
+  final String action;
+  final void Function(String provinceId)? onComplete;
+  final void Function()? onCancel;
+}
+
+/// Cancel any active target-selection mode.
+class CancelTargetSelectionEvent extends UIActionEvent {
+  const CancelTargetSelectionEvent();
+}
+
+// ---------------------------------------------------------------------------
+// UISystemEvent — emitted by any layer to request transient system feedback.
+// ---------------------------------------------------------------------------
+
+sealed class UISystemEvent extends AppEvent {
+  const UISystemEvent();
+}
+
+/// Show a snackbar / toast message.
+class ShowSnackBarEvent extends UISystemEvent {
+  const ShowSnackBarEvent({
+    required this.message,
+    this.actionLabel,
+    this.action,
+  });
+  final String message;
+  final String? actionLabel;
+  final void Function()? action;
+}
+
+/// Show a transient overlay (e.g. "Combat resolving..." spinner).
+class ShowOverlayEvent extends UISystemEvent {
+  const ShowOverlayEvent({required this.overlayId, this.params});
+  final String overlayId;
+  final Map<String, Object?>? params;
+}
+
+/// Dismiss the transient overlay.
+class DismissOverlayEvent extends UISystemEvent {
+  const DismissOverlayEvent(this.overlayId);
+  final String overlayId;
+}
+
+/// Show a non-blocking notification badge / toast for an event (combat, research, etc.).
+/// Unlike SnackBar, this may auto-dismiss and is less intrusive.
+class NotifyEvent extends UISystemEvent {
+  const NotifyEvent({required this.title, required this.body, this.priority});
+  final String title;
+  final String body;
+  final NotifyPriority? priority;
+}
+
+enum NotifyPriority { low, normal, high }
+
+// ---------------------------------------------------------------------------
+// Game-to-UI bridge — emitted by services when game state changes.
+// These are additional events beyond GameEvent (which lives in colonizethis_logic).
+// ---------------------------------------------------------------------------
+
+sealed class GameToUIEvent extends AppEvent {
+  const GameToUIEvent();
+}
+
+/// Emitted when turn resolution completes; UI may refresh panels.
+class TurnResolutionCompleteEvent extends GameToUIEvent {
+  const TurnResolutionCompleteEvent({
+    required this.gameId,
+    required this.turnNumber,
+  });
+  final String gameId;
+  final int turnNumber;
+}
+
+/// Emitted when overture decisions are required; UI should show overture dialog.
+class OvertureRequiredEvent extends GameToUIEvent {
+  const OvertureRequiredEvent({required this.overtures});
+  final List<Object> overtures; // OvertureOffer
+}
+
+/// Emitted when save/load completes.
+class SaveGameCompleteEvent extends GameToUIEvent {
+  const SaveGameCompleteEvent({required this.gameId});
+  final String gameId;
+}
+
+/// Emitted when a new game is created.
+class NewGameCreatedEvent extends GameToUIEvent {
+  const NewGameCreatedEvent({required this.gameId});
+  final String gameId;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -497,10 +497,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

Implement AppEventBus — a typed, centralized broadcast stream that decouples UI widgets from direct Navigator/showDialog calls.

### Core Components

- **AppEventBus** (colonizethis_models): Broadcast stream singleton with emit() and on<T>() methods
- **AppEventHandler** (app): Wires events to Flutter APIs (Navigator, showDialog, showModalBottomSheet, callbacks)
- **Riverpod provider**: appEventBusProvider wraps the singleton for DI/testability

### Event Hierarchy

- UIActionEvent: OpenDialogEvent, ConfirmDialogEvent, NavigateToRouteEvent, PopNavigationEvent, OpenPanelEvent, ClosePanelEvent
- UISystemEvent: ShowSnackBarEvent, ShowOverlayEvent, DismissOverlayEvent, NotifyEvent
- GameToUIEvent: TurnResolutionCompleteEvent, SaveGameCompleteEvent, NewGameCreatedEvent

### Migration (Phase 1 & 2)

- diplomacy_panel.dart: _showConfirmDialog → ConfirmDialogEvent
- civilian_units_panel.dart: _confirmCancel → ConfirmDialogEvent
- game_side_menu.dart: Production/Diplomacy/Technology → NavigateToRouteEvent
- routes.dart: Added production, diplomacy, technology routes
- game_service.dart: Added eventBus field + TurnResolutionCompleteEvent emission

### Tests

- 18 passing tests for AppEventBus
- 9 passing tests for AppEventHandler

Run tests: flutter test app/test/app_event_bus_test.dart app/test/app_event_handler_test.dart