### PR TITLE
feat(app): typed panel events, per-screen GameToUI listeners

### DIFF
--- a/SPEC/program/app-event-bus.md
+++ b/SPEC/program/app-event-bus.md
@@ -22,14 +22,20 @@ Direct `showDialog()` and `Navigator.of(context).push()/pop()` calls couple UI w
          │                                        ▼
   ┌──────────────┐                    ┌─────────────────────┐
   │ Emitters     │                    │ AppEventHandler     │
-  │ - UI widgets │                    │ (shell level)      │
-  │ - Services   │                    │                    │
-  │ - Game logic │                    │ on<UIActionEvent>  │
-  └──────────────┘                    │   → showDialog     │
-                                     │   → Navigator.push │
-                                     │ on<UISystemEvent>  │
-                                     │   → SnackBar      │
-                                     └─────────────────────┘
+  │ - UI widgets │                    │ (shell level)       │
+  │ - Services   │                    │                     │
+  │ - Game logic │                    │ typed panel events  │
+  └──────────────┘                    │ → bottom sheets     │
+         │                            │ on<UIActionEvent>   │
+         │                            │ on<UISystemEvent>   │
+         │                            └─────────────────────┘
+         │
+         ▼
+  ┌──────────────────────────────────────────────────────┐
+  │ Screens (GameScreen, Production, Diplomacy, Tech…)   │
+  │ subscribe via bus.on<TurnResolutionCompleteEvent>()  │
+  │ (e.g. GameToUIBusListener) — no central GameToUI hub │
+  └──────────────────────────────────────────────────────┘
 ```
 
 ---
@@ -43,7 +49,11 @@ AppEvent (sealed)
 │   ├── ConfirmDialogEvent(title, message, confirmLabel, cancelLabel) → bool
 │   ├── NavigateToRouteEvent(route, arguments?)
 │   ├── PopNavigationEvent()
-│   ├── OpenPanelEvent(panelId, params?)
+│   ├── OpenPanelEvent(panelId, params?)   // legacy string id
+│   ├── OpenPauseMenuPanelEvent(onDebugLog?, onResume?)
+│   ├── OpenCivilianUnitsPanelEvent(…callbacks…, onPanelDismissed?)
+│   ├── OpenMilitaryUnitsPanelEvent(onLocateTile, onPanelDismissed?)
+│   ├── OpenNavalUnitsPanelEvent(onLocateFleet, onFleetsChanged, onPanelDismissed?)
 │   ├── ClosePanelEvent()
 │   ├── StartTargetSelectionEvent(unitId, action, onComplete?, onCancel?)
 │   └── CancelTargetSelectionEvent()
@@ -115,20 +125,30 @@ class AppEventHandler {
 
 ---
 
-## Dialog/Panel IDs
+## Typed panel events (preferred)
 
-| ID | Widget | Builder location |
-|----|--------|-----------------|
-| `train_civilians` | `TrainCiviliansDialog` | `game_side_menu.dart` |
-| `quick_battle_result` | `QuickBattleResultDialog` | `game_screen.dart` or `GameMapArea` |
-| `combat_mode_choice` | `CombatModeChoiceDialog` | combat trigger site |
-| `map_display_options` | inline `AlertDialog` | `GameMapArea` |
-| `tech_detail` | inline tech dialog | `TechTreeWidget` |
-| `grant_or_subsidy` | `GrantOrSubsidyDialog` | `DiplomacyDialogs` |
-| `pause_menu` | pause bottom sheet | `GameScreen` |
-| `civilian_units` | `CivilianUnitsPanel` bottom sheet | `GameSideMenu` |
-| `military_units` | `MilitaryUnitsPanel` bottom sheet | `GameSideMenu` |
-| `naval_units` | `NavalUnitsPanel` bottom sheet | `GameSideMenu` |
+| Event | Opened by | Handler builds |
+|-------|-----------|----------------|
+| `OpenPauseMenuPanelEvent` | `GameScreen` (pause) | `PauseMenuPanel` |
+| `OpenCivilianUnitsPanelEvent` | `GameSideMenu` | `CivilianUnitsPanel` (+ Riverpod game/orders) |
+| `OpenMilitaryUnitsPanelEvent` | `GameSideMenu` | `MilitaryUnitsPanel` |
+| `OpenNavalUnitsPanelEvent` | `GameSideMenu` | `NavalUnitsPanel` |
+
+`onPanelDismissed` on unit panel events runs when the sheet route completes (e.g. map highlight cleanup).
+
+## Dialog IDs (`OpenDialogEvent`)
+
+| ID | Widget | Registered in |
+|----|--------|----------------|
+| `train_civilians` | `TrainCiviliansDialog` | `app_event_handler_scope.dart` (`trainCiviliansDialogId`) |
+
+| ID | Widget | Status |
+|----|--------|--------|
+| `quick_battle_result` | `QuickBattleResultDialog` | planned |
+| `combat_mode_choice` | `CombatModeChoiceDialog` | planned |
+| `map_display_options` | inline `AlertDialog` | planned |
+| `tech_detail` | tech detail dialog | planned |
+| `grant_or_subsidy` | `GrantOrSubsidyDialog` | planned |
 
 ---
 
@@ -147,91 +167,60 @@ Routes are named strings passed via `NavigateToRouteEvent`. Handled by `AppEvent
 
 ## Game Logic → UI Bridge
 
-`GameService` holds an optional `AppEventBus? eventBus`. When set, it emits `GameToUIEvent` variants after game state changes:
+`GameService` holds an optional `AppEventBus? eventBus` (wired from Riverpod in the app). When set, it emits:
 
-- `TurnResolutionCompleteEvent` after `runTurnResolution` returns `TurnResolutionComplete`
-- `SaveGameCompleteEvent` after `saveGame()`
-- `NewGameCreatedEvent` after `createNewGame()`
+- `TurnResolutionCompleteEvent` after `runTurnResolution` or `resumeOvertureDecisions` completes with `TurnResolutionComplete`
+- `NewGameCreatedEvent` after `createNewGame()` saves
 
-The raw `GameEvent` stream from `TurnResolver` is forwarded by passing `void Function(GameEvent)? onGameEvent` — callers are responsible for bridging to `AppEventBus` if needed.
+**Consumption:** There is no single shell subscriber for `GameToUIEvent`. Each screen that must react mounts its own subscription (e.g. `GameToUIBusListener` wraps `GameScreen`, `ProductionScreen`, `DiplomacyScreen`, `TechnologyScreen` for `TurnResolutionCompleteEvent` and reloads `currentGameProvider` via `GameService.loadGame` when the event’s `gameId` matches the mounted screen’s game and `currentGameProvider` already holds that game).
 
----
-
-## Migration Plan
-
-### Phase 1: Confirm dialogs (UI→UI, no return coupling)
-- `diplomacy_panel.dart` `_showConfirmDialog` → `ConfirmDialogEvent`
-- `civilian_units_panel.dart` `_confirmCancel` → `ConfirmDialogEvent`
-
-### Phase 2: Route navigation (UI→UI via Navigator.pushNamed)
-- `game_screen.dart` `_showPauseMenu` → `NavigateToRouteEvent` + `PopNavigationEvent`
-- `game_side_menu.dart` Production/Diplomacy/Technology pushes → `NavigateToRouteEvent`
-
-### Phase 3: Bottom sheets and panels (UI→UI via showModalBottomSheet)
-- `game_side_menu.dart` Civilian/Military/Naval units bottom sheets → `OpenPanelEvent`
-- `game_screen.dart` pause menu bottom sheet → `OpenPanelEvent`
-
-### Phase 4: Named dialogs (fire-and-forget)
-- `QuickBattleResultDialog` → `OpenDialogEvent` + registered builder
-- `CombatModeChoiceDialog` → refactored to use event + Future result pattern
-- `TrainCiviliansDialog` → `OpenDialogEvent` + registered builder
-- `GrantOrSubsidyDialog` → `OpenDialogEvent` + registered builder
-- `Tech detail dialog` → `OpenDialogEvent` + registered builder
-- `Map display options` → `OpenDialogEvent` + registered builder
+The raw `GameEvent` stream from `TurnResolver` remains available via `void Function(GameEvent)? onGameEvent` for logic-layer consumers.
 
 ---
 
-## Acceptance Criteria
+## Remaining migration
 
-### Event Bus Core
-- [ ] `AppEventBus` is a singleton with `emit()` and `on<T>()` methods
-- [ ] `on<T>()` returns a `Stream<T>` that only emits events of type `T`
-- [ ] Multiple listeners can coexist (broadcast stream)
-- [ ] `dispose()` closes the controller without error
+- Replace remaining inline dialogs with `OpenDialogEvent` + builders (combat, map options, tech detail, grant/subsidy).
+- Prefer new typed panel events over `OpenPanelEvent(panelId)` for any new panels.
+
+---
+
+## Acceptance Criteria (Given–When–Then)
+
+### Event bus core
+
+- Given a fresh `AppEventBus` from `AppEventBus.create()` and a listener on `on<OpenDialogEvent>()`, When the system emits any `OpenDialogEvent`, Then the listener receives exactly that event and no other `UIActionEvent` types on that stream.
+- Given two subscribers on `bus.stream`, When the system emits one `PopNavigationEvent`, Then both subscribers each receive one event.
+- Given a bus on which `dispose()` has been called, When a test calls `emit` again, Then the call throws or fails as defined by the stream contract (no silent delivery).
 
 ### AppEventHandler
-- [ ] `bind()` starts subscriptions; `unbind()` cancels them
-- [ ] `OpenDialogEvent(dialogId)` calls `showDialog` with registered builder
-- [ ] `OpenDialogEvent(unknownId)` prints debug warning, does not throw
-- [ ] `ConfirmDialogEvent` returns `true` when confirm pressed, `false` when cancel pressed
-- [ ] `NavigateToRouteEvent(route)` calls `nav.pushNamed(route, arguments)`
-- [ ] `PopNavigationEvent` calls `nav.pop()`
-- [ ] `OpenPanelEvent(panelId)` calls `showModalBottomSheet` with registered builder
-- [ ] `ClosePanelEvent` calls `nav.maybePop()`
-- [ ] `ShowSnackBarEvent` calls `onShowSnackBar` callback when registered
-- [ ] `ShowOverlayEvent` calls `onShowOverlay` callback when registered
-- [ ] `DismissOverlayEvent` calls `onDismissOverlay` callback when registered
 
-### Migration
-- [ ] `game_screen.dart` `_showPauseMenu` uses event bus only (no direct Navigator)
-- [ ] `game_side_menu.dart` unit panels (civilian/military/naval) use `OpenPanelEvent`
-- [ ] `game_side_menu.dart` full-screen routes use `NavigateToRouteEvent`
-- [ ] `diplomacy_panel.dart` `_showConfirmDialog` uses `ConfirmDialogEvent`
-- [ ] `civilian_units_panel.dart` `_confirmCancel` uses `ConfirmDialogEvent`
-- [ ] `TrainCiviliansDialog` is registered as `train_civilians` dialog builder
-- [ ] `QuickBattleResultDialog` is registered and opened via `OpenDialogEvent`
-- [ ] `CombatModeChoiceDialog` is registered and opened via event with Future return
+- Given `AppEventHandler` is bound with a registered `trainCiviliansDialogId` builder, When the system emits `OpenDialogEvent('train_civilians')`, Then `showDialog` runs and the dialog widget tree is present.
+- Given `AppEventHandler` is bound, When the system emits `OpenPauseMenuPanelEvent`, Then a modal bottom sheet appears listing Debug log and Resume.
+- Given `AppEventHandler` is bound, When the system emits `OpenDialogEvent` with an unknown `dialogId`, Then the handler logs a debug warning and does not throw.
+- Given `ConfirmDialogEvent` with `onResult`, When the user taps confirm, Then `onResult(true)` runs; When the user taps cancel, Then `onResult(false)` runs.
 
-### GameService Bridge
-- [ ] `GameService` has `AppEventBus? eventBus` field
-- [ ] After `runTurnResolution` returns `TurnResolutionComplete`, emits `TurnResolutionCompleteEvent`
-- [ ] No event emitted when `eventBus` is `null`
+### Typed panels and decoupling
 
-### Tests
-- [ ] `AppEventBus` unit test: emit → on<T> delivers event
-- [ ] `AppEventBus` unit test: multiple listeners all receive events
-- [ ] `AppEventBus` unit test: on<T> only receives matching events
-- [ ] `AppEventBus` unit test: dispose prevents further events
-- [ ] `UIActionEvent` subclasses are equality-comparable (same params → equal)
-- [ ] `UISystemEvent` subclasses are equality-comparable
-- [ ] `GameToUIEvent` subclasses are equality-comparable
-- [ ] `AppEventHandler` test: `OpenDialogEvent` calls registered builder with params
-- [ ] `AppEventHandler` test: `NavigateToRouteEvent` calls `pushNamed`
-- [ ] `AppEventHandler` test: `ConfirmDialogEvent` returns bool from dialog result
-- [ ] `AppEventHandler` test: `OpenPanelEvent` calls `showModalBottomSheet`
-- [ ] `AppEventHandler` test: `PopNavigationEvent` calls `nav.pop()`
-- [ ] Widget test: emitting `OpenDialogEvent` from a widget triggers dialog display
-- [ ] Widget test: `ConfirmDialogEvent` result flows back to emitter
+- Given `GameSideMenu` is mounted with a valid `currentGameProvider`, When the user chooses Civilian Units, Then the system emits `OpenCivilianUnitsPanelEvent` (not `showModalBottomSheet` from `GameSideMenu`).
+- Given `CivilianUnitsPanel` is mounted with a bus, When the user taps Train, Then the system emits `OpenDialogEvent(trainCiviliansDialogId)` (panel does not call `showDialog` directly).
+
+### GameToUI and screens
+
+- Given `GameToUIBusListener` wraps a widget for `gameId` G and `currentGameProvider` is G, When the bus emits `TurnResolutionCompleteEvent` for G with a newer turn saved in `GameService`, Then `currentGameProvider` updates to the loaded game from storage.
+- Given `GameToUIBusListener` for `gameId` G, When the bus emits `TurnResolutionCompleteEvent` for a different game id, Then `currentGameProvider` is unchanged.
+
+### GameService bridge
+
+- Given `GameService.eventBus` is non-null, When `runTurnResolution` completes with `TurnResolutionComplete`, Then the service emits `TurnResolutionCompleteEvent` with matching `gameId` and `turnNumber`.
+- Given `GameService.eventBus` is null, When `runTurnResolution` completes with `TurnResolutionComplete`, Then no `TurnResolutionCompleteEvent` is emitted.
+
+### Automated tests (must pass in CI)
+
+- `app/test/app_event_bus_test.dart` covers bus delivery, filtering, dispose, and equality for `UIActionEvent` / `UISystemEvent` / `GameToUIEvent` (including `OpenPauseMenuPanelEvent` where const).
+- `app/test/app_event_handler_test.dart` covers `OpenDialogEvent`, `NavigateToRouteEvent`, `ConfirmDialogEvent`, `OpenPanelEvent`, `OpenPauseMenuPanelEvent`, `PopNavigationEvent`, and snackbar/overlay callbacks.
+- `app/test/game_to_ui_bus_listener_test.dart` covers `TurnResolutionCompleteEvent` → provider reload.
+- Widget tests for `GameScreen`, `GameSideMenu`, and `TrainCiviliansDialog` / `CivilianUnitsPanel` cover pause menu, empire panels, and Train-via-bus behavior.
 
 ---
 
@@ -240,5 +229,5 @@ The raw `GameEvent` stream from `TurnResolver` is forwarded by passing `void Fun
 - `GameEvent` lives in `colonizethis_logic` (avoids circular dep with `colonizethis_models`); `DialogueEvent`/`PortraitMoodEvent` live in `colonizethis_models`.
 - No Flutter imports in `colonizethis_models` package — event bus and handlers live in `app/`.
 - Dialog builders are registered at shell init time; unknown IDs log a warning.
-- Event emission is fire-and-forget; `ConfirmDialogEvent` is the exception (returns `Future<bool>`).
+- Event emission is fire-and-forget; `ConfirmDialogEvent` carries `onResult` / `result()` for the bool outcome (user choice A: callback on the event).
 - Province ids in any game events are always **prefixed** (`regionId|localId`).

--- a/app/lib/config/routes.dart
+++ b/app/lib/config/routes.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../features/debug_log/debug_log_viewer_screen.dart';
 import '../features/game/flame/game_screen.dart';
@@ -7,7 +6,6 @@ import '../features/game/widgets/diplomacy_screen.dart';
 import '../features/game/widgets/production_screen.dart';
 import '../features/game/widgets/technology_screen.dart';
 import '../features/shell/shell_screen.dart';
-import '../providers/games_provider.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 
@@ -77,16 +75,11 @@ class Routes {
         );
       case technology:
         final player = game.players.firstWhere((p) => p.id == humanPlayerId);
-        final currentOrders =
-            args['currentOrders'] as Orders? ?? const Orders();
         return MaterialPageRoute<void>(
           settings: settings,
-          builder: (_) => Consumer(
-            builder: (_, ref, __) => TechnologyScreen(
-              game: game,
-              player: player,
-              currentOrders: ref.watch(currentOrdersProvider),
-            ),
+          builder: (_) => TechnologyScreen(
+            game: game,
+            player: player,
           ),
         );
       default:

--- a/app/lib/core/services/app_event_handler.dart
+++ b/app/lib/core/services/app_event_handler.dart
@@ -23,6 +23,15 @@ import 'dart:async';
 
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../features/game/flame/game_screen_shared.dart';
+import '../../features/game/widgets/civilian_units_panel.dart';
+import '../../features/game/widgets/military_units_panel.dart';
+import '../../features/game/widgets/naval_units_panel.dart';
+import '../../features/game/widgets/pause_menu_panel.dart';
+import '../../providers/app_event_bus_provider.dart';
+import '../../providers/games_provider.dart';
 
 typedef DialogBuilder =
     Widget Function(BuildContext context, Map<String, Object?>? params);
@@ -83,6 +92,14 @@ class AppEventHandler {
       nav?.pushNamed(event.route, arguments: event.arguments);
     } else if (event is PopNavigationEvent) {
       nav?.pop();
+    } else if (event is OpenPauseMenuPanelEvent) {
+      _openPauseMenuPanel(event, nav);
+    } else if (event is OpenCivilianUnitsPanelEvent) {
+      _openCivilianUnitsPanel(event, nav);
+    } else if (event is OpenMilitaryUnitsPanelEvent) {
+      _openMilitaryUnitsPanel(event, nav);
+    } else if (event is OpenNavalUnitsPanelEvent) {
+      _openNavalUnitsPanel(event, nav);
     } else if (event is OpenPanelEvent) {
       _openPanel(event, nav);
     } else if (event is ClosePanelEvent) {
@@ -153,5 +170,121 @@ class AppEventHandler {
       context: nav.context,
       builder: (ctx) => builder(ctx, event.params),
     );
+  }
+
+  Future<void> _openPauseMenuPanel(
+    OpenPauseMenuPanelEvent event,
+    NavigatorState? nav,
+  ) async {
+    if (nav == null) return;
+    await showModalBottomSheet<void>(
+      context: nav.context,
+      builder: (ctx) => PauseMenuPanel(
+        params: {
+          'onDebugLog': event.onDebugLog,
+          'onResume': event.onResume,
+        },
+      ),
+    );
+  }
+
+  Future<void> _openCivilianUnitsPanel(
+    OpenCivilianUnitsPanelEvent event,
+    NavigatorState? nav,
+  ) async {
+    if (nav == null) return;
+    await showModalBottomSheet<void>(
+      context: nav.context,
+      isScrollControlled: true,
+      builder: (ctx) => Consumer(
+        builder: (context, ref, _) {
+          final game = ref.watch(currentGameProvider);
+          if (game == null) {
+            return const SizedBox.shrink();
+          }
+          final humanPlayerId = _humanPlayerId(game);
+          final currentOrders = ref.watch(currentOrdersProvider);
+          final availableWorkTargets = ref.watch(availableWorkTargetsProvider);
+          final bus = ref.watch(appEventBusProvider);
+          final isNarrow =
+              MediaQuery.sizeOf(context).width < kInGameNarrowBreakpoint;
+          final maxHeight =
+              MediaQuery.sizeOf(context).height * (isNarrow ? 0.33 : 0.5);
+          return ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: maxHeight),
+            child: CivilianUnitsPanel(
+              game: game,
+              humanPlayerId: humanPlayerId,
+              bus: bus,
+              currentOrders: currentOrders,
+              availableWorkTargets: availableWorkTargets,
+              onLocateUnit: event.onLocateUnit,
+              onRemoveWorkOrder: event.onRemoveWorkOrder,
+              onCancelUnitWork: event.onCancelUnitWork,
+              onStartWorkTargetSelection: (unit, workTarget) {
+                Navigator.of(context).pop();
+                event.onStartWorkTargetSelection(unit, workTarget);
+              },
+            ),
+          );
+        },
+      ),
+    ).whenComplete(() => event.onPanelDismissed?.call());
+  }
+
+  Future<void> _openMilitaryUnitsPanel(
+    OpenMilitaryUnitsPanelEvent event,
+    NavigatorState? nav,
+  ) async {
+    if (nav == null) return;
+    await showModalBottomSheet<void>(
+      context: nav.context,
+      builder: (ctx) => Consumer(
+        builder: (context, ref, _) {
+          final game = ref.watch(currentGameProvider);
+          if (game == null) {
+            return const SizedBox.shrink();
+          }
+          final humanPlayerId = _humanPlayerId(game);
+          return MilitaryUnitsPanel(
+            game: game,
+            humanPlayerId: humanPlayerId,
+            onLocateTile: event.onLocateTile,
+          );
+        },
+      ),
+    ).whenComplete(() => event.onPanelDismissed?.call());
+  }
+
+  Future<void> _openNavalUnitsPanel(
+    OpenNavalUnitsPanelEvent event,
+    NavigatorState? nav,
+  ) async {
+    if (nav == null) return;
+    await showModalBottomSheet<void>(
+      context: nav.context,
+      builder: (ctx) => Consumer(
+        builder: (context, ref, _) {
+          final game = ref.watch(currentGameProvider);
+          if (game == null) {
+            return const SizedBox.shrink();
+          }
+          final humanPlayerId = _humanPlayerId(game);
+          return NavalUnitsPanel(
+            game: game,
+            humanPlayerId: humanPlayerId,
+            onLocateFleet: event.onLocateFleet,
+            onFleetsChanged: event.onFleetsChanged,
+          );
+        },
+      ),
+    ).whenComplete(() => event.onPanelDismissed?.call());
+  }
+
+  String _humanPlayerId(Game game) {
+    for (final p in game.players) {
+      if (p.isHuman) return p.id;
+    }
+    return game.players.first.id;
   }
 }

--- a/app/lib/core/services/app_event_handler_scope.dart
+++ b/app/lib/core/services/app_event_handler_scope.dart
@@ -1,0 +1,115 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logger/logger.dart';
+import 'package:colonizethis_app/app.dart';
+import 'package:colonizethis_app/features/game/widgets/train_civilians_dialog.dart';
+import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
+
+import 'app_event_handler.dart';
+
+/// [OpenDialogEvent] id for [TrainCiviliansDialog]. SPEC/program/app-event-bus.md.
+const String trainCiviliansDialogId = 'train_civilians';
+
+final _log = Logger();
+
+/// Binds [AppEventHandler] to [appNavigatorKey] for the app lifetime.
+/// SPEC/program/app-event-bus.md.
+class AppEventHandlerScope extends ConsumerStatefulWidget {
+  const AppEventHandlerScope({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  ConsumerState<AppEventHandlerScope> createState() =>
+      _AppEventHandlerScopeState();
+}
+
+class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
+  AppEventHandler? _handler;
+  bool _bound = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_bound) {
+      return;
+    }
+    _bound = true;
+    final bus = ref.read(appEventBusProvider);
+    _handler = AppEventHandler(
+      bus: bus,
+      navigatorKey: appNavigatorKey,
+      dialogBuilders: {
+        trainCiviliansDialogId: (ctx, _) {
+          final container = ProviderScope.containerOf(ctx);
+          final game = container.read(currentGameProvider);
+          if (game == null) {
+            return const SizedBox.shrink();
+          }
+          final humanPlayerId = _humanPlayerId(game);
+          final orders = container.read(currentOrdersProvider);
+          return TrainCiviliansDialog(
+            game: game,
+            humanPlayerId: humanPlayerId,
+            currentOrders: orders,
+            onOrdersChanged: (newOrders) {
+              final o = container.read(currentOrdersProvider);
+              final existing =
+                  o.buildUnitOrdersByPlayerId[humanPlayerId] ?? [];
+              container.read(currentOrdersProvider.notifier).state = o
+                  .copyWith(
+                    buildUnitOrdersByPlayerId: {
+                      ...o.buildUnitOrdersByPlayerId,
+                      humanPlayerId: [...existing, ...newOrders],
+                    },
+                  );
+            },
+          );
+        },
+      },
+      onShowSnackBar: _showSnackBar,
+    );
+    _handler!.bind();
+    _log.d('ui:app_event: AppEventHandler bound');
+  }
+
+  void _showSnackBar(ShowSnackBarEvent event) {
+    final ctx = appNavigatorKey.currentContext;
+    if (ctx == null) {
+      return;
+    }
+    final messenger = ScaffoldMessenger.maybeOf(ctx);
+    if (messenger == null) {
+      return;
+    }
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(event.message),
+        action: event.actionLabel != null && event.action != null
+            ? SnackBarAction(
+                label: event.actionLabel!,
+                onPressed: event.action!,
+              )
+            : null,
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _handler?.unbind();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+
+  static String _humanPlayerId(Game game) {
+    for (final p in game.players) {
+      if (p.isHuman) return p.id;
+    }
+    return game.players.first.id;
+  }
+}

--- a/app/lib/core/services/game_service.dart
+++ b/app/lib/core/services/game_service.dart
@@ -157,7 +157,14 @@ class GameService {
       onGameEvent: onGameEvent,
     );
     if (result is TurnResolutionComplete) {
-      saveGame(result.game);
+      final complete = result;
+      saveGame(complete.game);
+      eventBus?.emit(
+        TurnResolutionCompleteEvent(
+          gameId: complete.game.id,
+          turnNumber: complete.game.worldState.turnState.turnNumber,
+        ),
+      );
     }
     return result;
   }
@@ -262,6 +269,7 @@ class GameService {
       warpLinks: result.warpLinks,
     );
     saveGame(result.game);
+    eventBus?.emit(NewGameCreatedEvent(gameId: result.game.id));
     return result.game;
   }
 }

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -14,6 +14,7 @@ import '../../../../providers/games_provider.dart';
 import '../../../../providers/map_view_provider.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/ct_screen_shell.dart';
+import '../../../widgets/game_to_ui_bus_listener.dart';
 
 import '../dialogue/game_start_intro_overlay.dart';
 import '../dialogue/overture_dialogue_overlay.dart';
@@ -22,17 +23,16 @@ import 'game_map_area.dart';
 import 'victory_overlay.dart';
 
 /// Shows the in-game pause menu (Debug log, Resume). SPEC/program/debug-log-viewer.md.
-/// Emits `OpenPanelEvent('pause_menu')` via [bus] to let AppEventHandler open the bottom sheet.
-/// Menu item actions emit `ClosePanelEvent` and `NavigateToRouteEvent`.
+/// Emits [OpenPauseMenuPanelEvent]; shell event handler shows the bottom sheet.
 void _showPauseMenu(AppEventBus bus) {
   bus.emit(
-    OpenPanelEvent('pause_menu', {
-      'onDebugLog': () {
+    OpenPauseMenuPanelEvent(
+      onDebugLog: () {
         bus.emit(const ClosePanelEvent());
         bus.emit(NavigateToRouteEvent(Routes.debugLog));
       },
-      'onResume': () => bus.emit(const ClosePanelEvent()),
-    }),
+      onResume: () => bus.emit(const ClosePanelEvent()),
+    ),
   );
 }
 
@@ -100,6 +100,10 @@ class GameScreen extends ConsumerWidget {
           VictoryOverlay(game: game, victory: victory),
       ],
     );
+
+    if (game != null) {
+      content = GameToUIBusListener(gameId: game.id, child: content);
+    }
 
     if (showIntro) {
       content = GameStartIntroOverlay(

--- a/app/lib/features/game/flame/game_side_menu.dart
+++ b/app/lib/features/game/flame/game_side_menu.dart
@@ -10,15 +10,6 @@ import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
 
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/ct_panel.dart';
-import '../widgets/civilian_units_panel.dart';
-import '../widgets/diplomacy_screen.dart';
-import '../widgets/military_units_panel.dart';
-import '../widgets/naval_units_panel.dart';
-import '../widgets/production_screen.dart';
-import '../widgets/technology_screen.dart';
-import '../widgets/train_civilians_dialog.dart';
-
-import 'game_screen_shared.dart';
 
 /// Side menu ("Production", "Units", etc.) for the in-game shell.
 class GameSideMenu extends ConsumerWidget {
@@ -74,8 +65,6 @@ class GameSideMenu extends ConsumerWidget {
   }
 
   List<Widget> _buildEmpireMenuButtons(BuildContext context, WidgetRef ref) {
-    final player =
-        game.players.where((p) => p.isHuman).firstOrNull ?? game.players.first;
     final orders = ref.read(currentOrdersProvider);
     final mapData = ref.read(gameServiceProvider).getMapData(game.id);
     final topology = mapData?.combinedTopology ?? MapTopology();
@@ -101,77 +90,27 @@ class GameSideMenu extends ConsumerWidget {
         iconAsset: 'assets/images/ui_icon_civilian_units.png',
         label: 'Civilian Units',
         onPressed: () {
-          // Capture navigator before onClose(): GameSideMenu is removed from
-          // the tree when the sheet opens; Train's showDialog must not use this
-          // widget's BuildContext (it would be unmounted).
-          final navigator = Navigator.of(context);
           onClose();
-          // Capture values before showing bottom sheet to avoid using
-          // disposed ref when widget rebuilds during work target selection.
-          final currentGame = ref.read(currentGameProvider) ?? game;
-          final currentOrders = ref.read(currentOrdersProvider);
-          final availableWorkTargets = ref.read(availableWorkTargetsProvider);
-          showModalBottomSheet<void>(
-            context: navigator.context,
-            isScrollControlled: true,
-            builder: (ctx) {
-              final isNarrowCtx =
-                  MediaQuery.sizeOf(ctx).width < kInGameNarrowBreakpoint;
-              final maxHeight =
-                  MediaQuery.sizeOf(ctx).height * (isNarrowCtx ? 0.33 : 0.5);
-              return ConstrainedBox(
-                constraints: BoxConstraints(maxHeight: maxHeight),
-                child: CivilianUnitsPanel(
-                  game: currentGame,
-                  humanPlayerId: humanPlayerId,
-                  bus: bus,
-                  currentOrders: currentOrders,
-                  availableWorkTargets: availableWorkTargets,
-                  onLocateUnit: onLocateCivilianUnit,
-                  onRemoveWorkOrder: (playerId, index) {
-                    final o = currentOrders;
-                    final list = List<ct_models.WorkOrder>.from(
-                      o.workOrdersByPlayerId[playerId] ?? [],
-                    )..removeAt(index);
-                    ref.read(currentOrdersProvider.notifier).state = o.copyWith(
-                      workOrdersByPlayerId: {
-                        ...o.workOrdersByPlayerId,
-                        playerId: list,
-                      },
-                    );
+          bus.emit(
+            ct_models.OpenCivilianUnitsPanelEvent(
+              onLocateUnit: onLocateCivilianUnit,
+              onRemoveWorkOrder: (playerId, index) {
+                final o = ref.read(currentOrdersProvider);
+                final list = List<ct_models.WorkOrder>.from(
+                  o.workOrdersByPlayerId[playerId] ?? [],
+                )..removeAt(index);
+                ref.read(currentOrdersProvider.notifier).state = o.copyWith(
+                  workOrdersByPlayerId: {
+                    ...o.workOrdersByPlayerId,
+                    playerId: list,
                   },
-                  onCancelUnitWork: onCancelUnitWork,
-                  onStartWorkTargetSelection: (unit, workTarget) {
-                    Navigator.of(ctx).pop();
-                    onStartWorkTargetSelection(unit, workTarget);
-                  },
-                  onTrainPressed: () {
-                    Navigator.of(ctx).pop();
-                    showDialog<void>(
-                      context: navigator.context,
-                      builder: (dialogCtx) => TrainCiviliansDialog(
-                        game: currentGame,
-                        humanPlayerId: humanPlayerId,
-                        currentOrders: currentOrders,
-                        onOrdersChanged: (newOrders) {
-                          final o = currentOrders;
-                          final existing =
-                              o.buildUnitOrdersByPlayerId[humanPlayerId] ?? [];
-                          ref.read(currentOrdersProvider.notifier).state = o
-                              .copyWith(
-                                buildUnitOrdersByPlayerId: {
-                                  ...o.buildUnitOrdersByPlayerId,
-                                  humanPlayerId: [...existing, ...newOrders],
-                                },
-                              );
-                        },
-                      ),
-                    );
-                  },
-                ),
-              );
-            },
-          ).whenComplete(onPanelDismissed);
+                );
+              },
+              onCancelUnitWork: onCancelUnitWork,
+              onStartWorkTargetSelection: onStartWorkTargetSelection,
+              onPanelDismissed: onPanelDismissed,
+            ),
+          );
         },
       ),
       _empireButton(
@@ -180,14 +119,12 @@ class GameSideMenu extends ConsumerWidget {
         label: 'Military Units',
         onPressed: () {
           onClose();
-          showModalBottomSheet<void>(
-            context: context,
-            builder: (ctx) => MilitaryUnitsPanel(
-              game: game,
-              humanPlayerId: humanPlayerId,
+          bus.emit(
+            ct_models.OpenMilitaryUnitsPanelEvent(
               onLocateTile: onLocateMilitaryTile,
+              onPanelDismissed: onPanelDismissed,
             ),
-          ).whenComplete(onPanelDismissed);
+          );
         },
       ),
       _empireButton(
@@ -196,20 +133,15 @@ class GameSideMenu extends ConsumerWidget {
         label: 'Naval Units',
         onPressed: () {
           onClose();
-          showModalBottomSheet<void>(
-            context: context,
-            builder: (ctx) {
-              final currentGame = ref.read(currentGameProvider) ?? game;
-              return NavalUnitsPanel(
-                game: currentGame,
-                humanPlayerId: humanPlayerId,
-                onLocateFleet: onLocateNavalFleet,
-                onFleetsChanged: (newGame) {
-                  ref.read(currentGameProvider.notifier).state = newGame;
-                },
-              );
-            },
-          ).whenComplete(onPanelDismissed);
+          bus.emit(
+            ct_models.OpenNavalUnitsPanelEvent(
+              onLocateFleet: onLocateNavalFleet,
+              onFleetsChanged: (newGame) {
+                ref.read(currentGameProvider.notifier).state = newGame;
+              },
+              onPanelDismissed: onPanelDismissed,
+            ),
+          );
         },
       ),
       _empireButton(

--- a/app/lib/features/game/widgets/civilian_units_panel.dart
+++ b/app/lib/features/game/widgets/civilian_units_panel.dart
@@ -6,7 +6,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
-import '../../../widgets/ct_dialog_shell.dart';
+import '../../../core/services/app_event_handler_scope.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/ct_panel.dart';
 
@@ -102,7 +102,6 @@ class CivilianUnitsPanel extends StatelessWidget {
     this.onRemoveWorkOrder,
     this.onCancelUnitWork,
     this.onStartWorkTargetSelection,
-    this.onTrainPressed,
   });
 
   final Game game;
@@ -123,9 +122,6 @@ class CivilianUnitsPanel extends StatelessWidget {
 
   /// Called when user picked an order from the Assign menu; shell enters work-target selection mode.
   final void Function(Unit unit, String workTarget)? onStartWorkTargetSelection;
-
-  /// Called when the user taps the Train button.
-  final VoidCallback? onTrainPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -162,11 +158,13 @@ class CivilianUnitsPanel extends StatelessWidget {
                         style: Theme.of(context).textTheme.titleMedium,
                       ),
                     ),
-                    if (onTrainPressed != null)
-                      CtNinePatchButton(
-                        onPressed: onTrainPressed,
-                        child: const Text('Train'),
-                      ),
+                    CtNinePatchButton(
+                      onPressed: () {
+                        Navigator.of(context).maybePop();
+                        bus.emit(OpenDialogEvent(trainCiviliansDialogId));
+                      },
+                      child: const Text('Train'),
+                    ),
                   ],
                 ),
               ),

--- a/app/lib/features/game/widgets/diplomacy_screen.dart
+++ b/app/lib/features/game/widgets/diplomacy_screen.dart
@@ -6,7 +6,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../providers/app_event_bus_provider.dart';
+import '../../../providers/games_provider.dart';
 import '../../../widgets/ct_screen_shell.dart';
+import '../../../widgets/game_to_ui_bus_listener.dart';
 import 'diplomacy_panel.dart';
 
 class DiplomacyScreen extends ConsumerWidget {
@@ -28,16 +30,23 @@ class DiplomacyScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final bus = ref.watch(appEventBusProvider);
-    return CtScreenShell(
-      title: 'Diplomacy',
-      showBackButton: true,
-      child: DiplomacyPanel(
-        game: game,
-        humanPlayerId: humanPlayerId,
-        topology: topology,
-        currentOrders: currentOrders,
-        onOrdersChanged: onOrdersChanged,
-        bus: bus,
+    final live = ref.watch(currentGameProvider);
+    final displayGame =
+        live != null && live.id == game.id ? live : game;
+
+    return GameToUIBusListener(
+      gameId: game.id,
+      child: CtScreenShell(
+        title: 'Diplomacy',
+        showBackButton: true,
+        child: DiplomacyPanel(
+          game: displayGame,
+          humanPlayerId: humanPlayerId,
+          topology: topology,
+          currentOrders: currentOrders,
+          onOrdersChanged: onOrdersChanged,
+          bus: bus,
+        ),
       ),
     );
   }

--- a/app/lib/features/game/widgets/pause_menu_panel.dart
+++ b/app/lib/features/game/widgets/pause_menu_panel.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+/// Pause menu content for [OpenPanelEvent] id `pause_menu`.
+/// Params: `onDebugLog`, `onResume` as [VoidCallback] (typically emit bus events).
+class PauseMenuPanel extends StatelessWidget {
+  const PauseMenuPanel({super.key, required this.params});
+
+  final Map<String, Object?>? params;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ListTile(
+            leading: const Icon(Icons.list),
+            title: const Text('Debug log'),
+            onTap: () => (params?['onDebugLog'] as VoidCallback?)?.call(),
+          ),
+          ListTile(
+            leading: const Icon(Icons.play_arrow),
+            title: const Text('Resume'),
+            onTap: () => (params?['onResume'] as VoidCallback?)?.call(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/game/widgets/production_screen.dart
+++ b/app/lib/features/game/widgets/production_screen.dart
@@ -4,8 +4,10 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../providers/games_provider.dart';
 import '../../../providers/production_allocation_provider.dart';
 import '../../../widgets/ct_screen_shell.dart';
+import '../../../widgets/game_to_ui_bus_listener.dart';
 import 'production_panel.dart';
 
 class ProductionScreen extends ConsumerWidget {
@@ -13,26 +15,41 @@ class ProductionScreen extends ConsumerWidget {
     super.key,
     required this.game,
     required this.player,
+    this.attachGameToUiListener = true,
   });
 
   final Game game;
   final Player player;
 
+  /// When true (default), [GameToUIBusListener] subscribes to turn-complete events.
+  /// Set false in isolated widget tests where the listener tree affects layout.
+  final bool attachGameToUiListener;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final desiredOutputByRecipe = ref.watch(productionDesiredOutputProvider);
+    final live =
+        attachGameToUiListener ? ref.watch(currentGameProvider) : null;
+    final displayGame =
+        live != null && live.id == game.id ? live : game;
+    final displayPlayer =
+        displayGame.players.firstWhere((p) => p.id == player.id);
 
-    return CtScreenShell(
+    final shell = CtScreenShell(
       title: 'Production',
       showBackButton: true,
       child: ProductionPanel(
-        game: game,
-        player: player,
+        game: displayGame,
+        player: displayPlayer,
         desiredOutputByRecipe: desiredOutputByRecipe,
         onDesiredOutputChanged: (next) {
           ref.read(productionDesiredOutputProvider.notifier).state = next;
         },
       ),
     );
+    if (!attachGameToUiListener) {
+      return shell;
+    }
+    return GameToUIBusListener(gameId: game.id, child: shell);
   }
 }

--- a/app/lib/features/game/widgets/technology_screen.dart
+++ b/app/lib/features/game/widgets/technology_screen.dart
@@ -2,58 +2,69 @@
 
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../providers/games_provider.dart';
 import '../../../widgets/ct_screen_shell.dart';
+import '../../../widgets/game_to_ui_bus_listener.dart';
 import 'technology_panel.dart';
 import 'tech_tree_widget.dart';
 
 /// Full-screen Technology screen with two tabs: Research Slots and Tech Tree.
 /// SPEC/ui/tech-tree-widget.md.
-class TechnologyScreen extends StatelessWidget {
+class TechnologyScreen extends ConsumerWidget {
   const TechnologyScreen({
     super.key,
     required this.game,
     required this.player,
-    this.currentOrders = const Orders(),
-    this.onOrdersChanged,
   });
 
   final Game game;
   final Player player;
-  final Orders currentOrders;
-  final void Function(Orders orders)? onOrdersChanged;
 
   @override
-  Widget build(BuildContext context) {
-    return DefaultTabController(
-      length: 2,
-      child: CtScreenShell(
-        title: 'Technology',
-        showBackButton: true,
-        child: Column(
-          children: [
-            const TabBar(
-              tabs: [
-                Tab(text: 'Slots'),
-                Tab(text: 'Tree'),
-              ],
-            ),
-            const SizedBox(height: 8),
-            const Divider(height: 1),
-            Expanded(
-              child: TabBarView(
-                children: [
-                  _SlotsTab(
-                    game: game,
-                    player: player,
-                    currentOrders: currentOrders,
-                    onOrdersChanged: onOrdersChanged,
-                  ),
-                  _TreeTab(game: game, player: player),
+  Widget build(BuildContext context, WidgetRef ref) {
+    final live = ref.watch(currentGameProvider);
+    final displayGame =
+        live != null && live.id == game.id ? live : game;
+    final displayPlayer =
+        displayGame.players.firstWhere((p) => p.id == player.id);
+    final currentOrders = ref.watch(currentOrdersProvider);
+
+    return GameToUIBusListener(
+      gameId: game.id,
+      child: DefaultTabController(
+        length: 2,
+        child: CtScreenShell(
+          title: 'Technology',
+          showBackButton: true,
+          child: Column(
+            children: [
+              const TabBar(
+                tabs: [
+                  Tab(text: 'Slots'),
+                  Tab(text: 'Tree'),
                 ],
               ),
-            ),
-          ],
+              const SizedBox(height: 8),
+              const Divider(height: 1),
+              Expanded(
+                child: TabBarView(
+                  children: [
+                    _SlotsTab(
+                      game: displayGame,
+                      player: displayPlayer,
+                      currentOrders: currentOrders,
+                      onOrdersChanged: (next) {
+                        ref.read(currentOrdersProvider.notifier).state = next;
+                      },
+                    ),
+                    _TreeTab(game: displayGame, player: displayPlayer),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:session_log_buffer/session_log_buffer.dart';
 
 import 'app.dart';
 import 'config/constants.dart';
+import 'core/services/app_event_handler_scope.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -17,5 +18,5 @@ void main() async {
   } catch (_) {
     // Phase 0: stub wiring; boxes may be locked (e.g. another instance). App still runs.
   }
-  runApp(const ProviderScope(child: App()));
+  runApp(const ProviderScope(child: AppEventHandlerScope(child: App())));
 }

--- a/app/lib/providers/game_service_provider.dart
+++ b/app/lib/providers/game_service_provider.dart
@@ -2,12 +2,18 @@ import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../core/services/game_service.dart';
+import 'app_event_bus_provider.dart';
 import 'games_box_provider.dart';
 
-final gameSaveAdapterProvider = Provider<GameSaveAdapter>((ref) => GameSaveAdapter());
+final gameSaveAdapterProvider = Provider<GameSaveAdapter>(
+  (ref) => GameSaveAdapter(),
+);
 
 final gameServiceProvider = Provider<GameService>((ref) {
   final box = ref.watch(gamesBoxProvider);
   final adapter = ref.watch(gameSaveAdapterProvider);
-  return GameService(box, adapter);
+  final bus = ref.watch(appEventBusProvider);
+  final service = GameService(box, adapter);
+  service.eventBus = bus;
+  return service;
 });

--- a/app/lib/widgets/ct_slider.dart
+++ b/app/lib/widgets/ct_slider.dart
@@ -35,24 +35,40 @@ class _CtSliderState extends State<CtSlider> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final t = ((widget.value - widget.min) / (widget.max - widget.min)).clamp(
-      0,
-      1,
-    );
+    final range = widget.max - widget.min;
+    final t = (range > 0 && range.isFinite)
+        ? ((widget.value - widget.min) / range).clamp(0.0, 1.0)
+        : 0.0;
 
     return LayoutBuilder(
       builder: (context, constraints) {
         final width = constraints.maxWidth;
         final trackHeight = 6.0;
         final handleSize = 14.0;
-        final handleX = t * (width - handleSize);
+        final trackUsable = width.isFinite && width > handleSize
+            ? width - handleSize
+            : 0.0;
+        final handleX =
+            trackUsable > 0 && t.isFinite ? t * trackUsable : 0.0;
 
         void handleTapOrDrag(Offset localPos) {
-          final x = localPos.dx.clamp(0, width - handleSize);
-          final ratio = x / (width - handleSize);
-          final raw = widget.min + ratio * (widget.max - widget.min);
+          if (range <= 0 || !range.isFinite) {
+            widget.onChanged(widget.min);
+            return;
+          }
+          if (!width.isFinite || width <= handleSize) {
+            return;
+          }
+          final d = width - handleSize;
+          final x = localPos.dx.clamp(0.0, d);
+          final ratio = x / d;
+          final raw = widget.min + ratio * range;
           if (widget.divisions > 0) {
-            final step = (widget.max - widget.min) / widget.divisions;
+            final step = range / widget.divisions;
+            if (step <= 0 || !step.isFinite) {
+              widget.onChanged(widget.min);
+              return;
+            }
             final snapped = (raw / step).round() * step + widget.min;
             widget.onChanged(snapped.clamp(widget.min, widget.max));
           } else {

--- a/app/lib/widgets/game_to_ui_bus_listener.dart
+++ b/app/lib/widgets/game_to_ui_bus_listener.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../providers/app_event_bus_provider.dart';
+import '../providers/game_service_provider.dart';
+import '../providers/games_provider.dart';
+
+/// Subscribes to [TurnResolutionCompleteEvent] for [gameId] and reloads
+/// [currentGameProvider] from [GameService] when the active game matches.
+/// SPEC/program/app-event-bus.md — empire screens subscribe individually.
+class GameToUIBusListener extends ConsumerStatefulWidget {
+  const GameToUIBusListener({
+    super.key,
+    required this.gameId,
+    required this.child,
+  });
+
+  final String gameId;
+  final Widget child;
+
+  @override
+  ConsumerState<GameToUIBusListener> createState() =>
+      _GameToUIBusListenerState();
+}
+
+class _GameToUIBusListenerState extends ConsumerState<GameToUIBusListener> {
+  StreamSubscription<TurnResolutionCompleteEvent>? _turnSub;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _turnSub ??=
+        ref.read(appEventBusProvider).on<TurnResolutionCompleteEvent>().listen(
+              _onTurnResolutionComplete,
+            );
+  }
+
+  void _onTurnResolutionComplete(TurnResolutionCompleteEvent event) {
+    if (!mounted || event.gameId != widget.gameId) {
+      return;
+    }
+    final current = ref.read(currentGameProvider);
+    if (current?.id != event.gameId) {
+      return;
+    }
+    final reloaded = ref.read(gameServiceProvider).loadGame(event.gameId);
+    if (reloaded == null || !mounted) {
+      return;
+    }
+    ref.read(currentGameProvider.notifier).state = reloaded;
+  }
+
+  @override
+  void dispose() {
+    _turnSub?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/app/test/app_event_bus_test.dart
+++ b/app/test/app_event_bus_test.dart
@@ -152,6 +152,13 @@ void main() {
       );
     });
 
+    test('OpenPauseMenuPanelEvent equal when both use null callbacks', () {
+      expect(
+        const OpenPauseMenuPanelEvent(),
+        const OpenPauseMenuPanelEvent(),
+      );
+    });
+
     test('StartTargetSelectionEvent equal for same params', () {
       expect(
         const StartTargetSelectionEvent(unitId: 'u1', action: 'move'),

--- a/app/test/app_event_handler_test.dart
+++ b/app/test/app_event_handler_test.dart
@@ -157,6 +157,38 @@ void main() {
       expect(find.text('base_route'), findsOneWidget);
     });
 
+    testWidgets('OpenPauseMenuPanelEvent opens pause bottom sheet', (
+      tester,
+    ) async {
+      handler.bind();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navKey,
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => TextButton(
+                onPressed: () => bus.emit(
+                  const OpenPauseMenuPanelEvent(
+                    onDebugLog: null,
+                    onResume: null,
+                  ),
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Debug log'), findsOneWidget);
+      expect(find.text('Resume'), findsOneWidget);
+    });
+
     testWidgets('OpenPanelEvent opens registered bottom sheet panel', (
       tester,
     ) async {

--- a/app/test/app_shell_routes_test.dart
+++ b/app/test/app_shell_routes_test.dart
@@ -1,15 +1,21 @@
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/app.dart';
 import 'package:colonizethis_app/config/routes.dart';
+import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
 
 void main() {
   suppressLogsForTests();
 
   group('App shell and routes', () {
-    testWidgets('App uses Routes.shell as initial route', (WidgetTester tester) async {
-      await tester.pumpWidget(const App());
+    testWidgets('App uses Routes.shell as initial route', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const ProviderScope(child: AppEventHandlerScope(child: App())),
+      );
       await tester.pumpAndSettle();
 
       // Shell route should be active; CtMainMenu buttons should be visible.
@@ -17,8 +23,12 @@ void main() {
       expect(find.text('Load Game'), findsOneWidget);
     });
 
-    testWidgets('Debug log menu item pushes debug route', (WidgetTester tester) async {
-      await tester.pumpWidget(const App());
+    testWidgets('Debug log menu item pushes debug route', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const ProviderScope(child: AppEventHandlerScope(child: App())),
+      );
       await tester.pumpAndSettle();
 
       // Simulate menu selection using the exported navigator key.
@@ -29,4 +39,3 @@ void main() {
     });
   });
 }
-

--- a/app/test/game_screen_branches_test.dart
+++ b/app/test/game_screen_branches_test.dart
@@ -1,6 +1,8 @@
+import 'package:colonizethis_app/app.dart';
 import 'package:colonizethis_app/config/themes.dart';
-import 'package:colonizethis_app/features/game/flame/game_screen.dart';
+import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
 import 'package:colonizethis_app/features/game/dialogue/game_start_intro_overlay.dart';
+import 'package:colonizethis_app/features/game/flame/game_screen.dart';
 import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/providers/map_view_provider.dart';
@@ -12,91 +14,6 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'dart:async';
-
-class TestAppEventBus implements AppEventBus {
-  TestAppEventBus(this._inner);
-
-  final AppEventBus _inner;
-  NavigatorState? _navigator;
-  BuildContext? _context;
-  Map<String, Object?>? _lastOpenPanelParams;
-
-  void setNavigator(NavigatorState navigator) {
-    _navigator = navigator;
-  }
-
-  void setContext(BuildContext context) {
-    _context = context;
-  }
-
-  Map<String, Object?>? get lastOpenPanelParams => _lastOpenPanelParams;
-
-  @override
-  void emit(AppEvent event) {
-    if (event is NavigateToRouteEvent && _navigator != null) {
-      _navigator!.pushNamed(event.route, arguments: event.arguments);
-    } else if (event is OpenPanelEvent && event.panelId == 'pause_menu') {
-      _lastOpenPanelParams = event.params;
-      if (_context != null) {
-        _showPauseMenu(_context!, event.params);
-      }
-    }
-    _inner.emit(event);
-  }
-
-  void _showPauseMenu(BuildContext context, Map<String, Object?>? params) {
-    showModalBottomSheet<void>(
-      context: context,
-      builder: (ctx) => Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          ListTile(
-            leading: const Icon(Icons.list),
-            title: const Text('Debug log'),
-            onTap: () {
-              Navigator.of(ctx).pop();
-              (params?['onDebugLog'] as VoidCallback?)?.call();
-            },
-          ),
-          ListTile(
-            leading: const Icon(Icons.play_arrow),
-            title: const Text('Resume'),
-            onTap: () {
-              Navigator.of(ctx).pop();
-              (params?['onResume'] as VoidCallback?)?.call();
-            },
-          ),
-        ],
-      ),
-    );
-  }
-
-  @override
-  Stream<AppEvent> get stream => _inner.stream;
-
-  @override
-  Stream<T> on<T extends AppEvent>() => _inner.on<T>();
-
-  @override
-  Stream<UIActionEvent> get uiActionEvents => _inner.uiActionEvents;
-
-  @override
-  Stream<UISystemEvent> get uiSystemEvents => _inner.uiSystemEvents;
-
-  @override
-  Stream<GameToUIEvent> get gameToUIEvents => _inner.gameToUIEvents;
-
-  @override
-  Stream<DialogueEvent> get dialogueEvents => _inner.dialogueEvents;
-
-  @override
-  Stream<PortraitMoodEvent> get portraitMoodEvents => _inner.portraitMoodEvents;
-
-  @override
-  void dispose() => _inner.dispose();
-}
 
 void main() {
   suppressLogsForTests();
@@ -115,20 +32,26 @@ void main() {
     required Game game,
     required InitGameMapViewData? mapViewData,
     required Set<String> introShownIds,
-    TestAppEventBus? testBus,
   }) {
     return ProviderScope(
       overrides: [
         currentGameProvider.overrideWith((ref) => game),
         mapViewDataProvider.overrideWith((ref) => mapViewData),
         gameIdsWithIntroShownProvider.overrideWith((ref) => introShownIds),
-        if (testBus != null) appEventBusProvider.overrideWith((ref) => testBus),
+        appEventBusProvider.overrideWith((ref) {
+          final bus = AppEventBus.create();
+          ref.onDispose(bus.dispose);
+          return bus;
+        }),
       ],
-      child: MaterialApp(
-        theme: AppThemes.colonial,
-        home: MediaQuery(
-          data: MediaQueryData(size: Size(width, height)),
-          child: const GameScreen(),
+      child: AppEventHandlerScope(
+        child: MaterialApp(
+          navigatorKey: appNavigatorKey,
+          theme: AppThemes.colonial,
+          home: MediaQuery(
+            data: MediaQueryData(size: Size(width, height)),
+            child: const GameScreen(),
+          ),
         ),
       ),
     );
@@ -164,8 +87,6 @@ void main() {
   testWidgets('GameScreen shows pause menu and opens bottom sheet', (
     WidgetTester tester,
   ) async {
-    final testBus = TestAppEventBus(AppEventBus.create());
-
     await tester.pumpWidget(
       buildGameScreen(
         width: 800,
@@ -173,7 +94,6 @@ void main() {
         game: baseGame,
         mapViewData: null,
         introShownIds: {baseGame.id},
-        testBus: testBus,
       ),
     );
     await tester.pump(const Duration(milliseconds: 200));
@@ -181,9 +101,6 @@ void main() {
     expect(find.textContaining('Next turn'), findsOneWidget);
     expect(find.byIcon(Icons.menu), findsOneWidget);
 
-    final scaffoldFinder = find.byType(Scaffold);
-    expect(scaffoldFinder, findsOneWidget);
-    testBus.setContext(tester.element(scaffoldFinder));
     await tester.tap(find.byIcon(Icons.menu));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 200));
@@ -206,7 +123,6 @@ void main() {
       );
       await tester.pump(const Duration(milliseconds: 200));
 
-      // Just verifying presence is enough to cover the GameScreen branch.
       expect(find.byType(GameStartIntroOverlay), findsOneWidget);
     },
   );

--- a/app/test/game_screen_narrow_test.dart
+++ b/app/test/game_screen_narrow_test.dart
@@ -1,9 +1,11 @@
 // In-game shell side menu. SPEC/ui/in-game-shell-narrow.md, empire-buttons.md.
 
-import 'package:colonizethis_app/config/themes.dart';
+import 'package:colonizethis_app/app.dart';
 import 'package:colonizethis_app/config/routes.dart';
-import 'package:colonizethis_app/features/game/flame/game_screen.dart';
+import 'package:colonizethis_app/config/themes.dart';
+import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
 import 'package:colonizethis_app/features/game/dialogue/overture_dialogue_overlay.dart';
+import 'package:colonizethis_app/features/game/flame/game_screen.dart';
 import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/providers/map_view_provider.dart';
@@ -14,87 +16,6 @@ import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'dart:async';
-
-class TestAppEventBus implements AppEventBus {
-  TestAppEventBus(this._inner);
-
-  final AppEventBus _inner;
-  NavigatorState? _navigator;
-  BuildContext? _context;
-
-  void setNavigator(NavigatorState navigator) {
-    _navigator = navigator;
-  }
-
-  void setContext(BuildContext context) {
-    _context = context;
-  }
-
-  @override
-  void emit(AppEvent event) {
-    if (event is NavigateToRouteEvent && _navigator != null) {
-      _navigator!.pushNamed(event.route, arguments: event.arguments);
-    } else if (event is OpenPanelEvent && event.panelId == 'pause_menu') {
-      if (_context != null) {
-        _showPauseMenu(_context!, event.params);
-      }
-    }
-    _inner.emit(event);
-  }
-
-  void _showPauseMenu(BuildContext context, Map<String, Object?>? params) {
-    showModalBottomSheet<void>(
-      context: context,
-      builder: (ctx) => Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          ListTile(
-            leading: const Icon(Icons.list),
-            title: const Text('Debug log'),
-            onTap: () {
-              Navigator.of(ctx).pop();
-              (params?['onDebugLog'] as VoidCallback?)?.call();
-            },
-          ),
-          ListTile(
-            leading: const Icon(Icons.play_arrow),
-            title: const Text('Resume'),
-            onTap: () {
-              Navigator.of(ctx).pop();
-              (params?['onResume'] as VoidCallback?)?.call();
-            },
-          ),
-        ],
-      ),
-    );
-  }
-
-  @override
-  Stream<AppEvent> get stream => _inner.stream;
-
-  @override
-  Stream<T> on<T extends AppEvent>() => _inner.on<T>();
-
-  @override
-  Stream<UIActionEvent> get uiActionEvents => _inner.uiActionEvents;
-
-  @override
-  Stream<UISystemEvent> get uiSystemEvents => _inner.uiSystemEvents;
-
-  @override
-  Stream<GameToUIEvent> get gameToUIEvents => _inner.gameToUIEvents;
-
-  @override
-  Stream<DialogueEvent> get dialogueEvents => _inner.dialogueEvents;
-
-  @override
-  Stream<PortraitMoodEvent> get portraitMoodEvents => _inner.portraitMoodEvents;
-
-  @override
-  void dispose() => _inner.dispose();
-}
 
 void main() {
   suppressLogsForTests();
@@ -113,12 +34,20 @@ void main() {
         gameIdsWithIntroShownProvider.overrideWith(
           (ref) => {debugResult.game.id},
         ),
+        appEventBusProvider.overrideWith((ref) {
+          final bus = AppEventBus.create();
+          ref.onDispose(bus.dispose);
+          return bus;
+        }),
       ],
-      child: MaterialApp(
-        theme: AppThemes.colonial,
-        home: MediaQuery(
-          data: MediaQueryData(size: Size(width, height)),
-          child: const GameScreen(),
+      child: AppEventHandlerScope(
+        child: MaterialApp(
+          navigatorKey: appNavigatorKey,
+          theme: AppThemes.colonial,
+          home: MediaQuery(
+            data: MediaQueryData(size: Size(width, height)),
+            child: const GameScreen(),
+          ),
         ),
       ),
     );
@@ -347,26 +276,27 @@ void main() {
   });
 
   group('GameScreen — pause menu and victory overlay', () {
-    Widget _buildGameScreenWithPauseMenu({
-      required Game game,
-      TestAppEventBus? testBus,
-    }) {
+    Widget _buildGameScreenWithPauseMenu({required Game game}) {
       return ProviderScope(
         overrides: [
           currentGameProvider.overrideWith((ref) => game),
-          // No mapViewData override so that overlay buttons (pause menu, Next turn)
-          // are shown on top of the Flame canvas.
           mapViewDataProvider.overrideWith((ref) => null),
           gameIdsWithIntroShownProvider.overrideWith((ref) => {game.id}),
-          if (testBus != null)
-            appEventBusProvider.overrideWith((ref) => testBus),
+          appEventBusProvider.overrideWith((ref) {
+            final bus = AppEventBus.create();
+            ref.onDispose(bus.dispose);
+            return bus;
+          }),
         ],
-        child: MaterialApp(
-          routes: {
-            Routes.debugLog: (context) =>
-                const Scaffold(body: Center(child: Text('Debug log screen'))),
-          },
-          home: const GameScreen(),
+        child: AppEventHandlerScope(
+          child: MaterialApp(
+            navigatorKey: appNavigatorKey,
+            routes: {
+              Routes.debugLog: (context) =>
+                  const Scaffold(body: Center(child: Text('Debug log screen'))),
+            },
+            home: const GameScreen(),
+          ),
         ),
       );
     }
@@ -374,25 +304,15 @@ void main() {
     testWidgets(
       'pause menu opens bottom sheet and shows debug log entry',
       (WidgetTester tester) async {
-        final testBus = TestAppEventBus(AppEventBus.create());
-
         await tester.pumpWidget(
-          _buildGameScreenWithPauseMenu(
-            game: debugResult.game,
-            testBus: testBus,
-          ),
+          _buildGameScreenWithPauseMenu(game: debugResult.game),
         );
         await tester.pump();
 
-        final scaffoldFinder = find.byType(Scaffold);
-        testBus.setContext(tester.element(scaffoldFinder));
-
-        // Tap the pause menu icon in the overlay stack.
         await tester.tap(find.byIcon(Icons.menu).first);
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 200));
 
-        // Bottom sheet should show a Debug log entry.
         expect(find.text('Debug log'), findsOneWidget);
       },
       timeout: const Timeout(Duration(seconds: 20)),
@@ -419,10 +339,18 @@ void main() {
               gameIdsWithIntroShownProvider.overrideWith(
                 (ref) => {victoryGame.id},
               ),
+              appEventBusProvider.overrideWith((ref) {
+                final bus = AppEventBus.create();
+                ref.onDispose(bus.dispose);
+                return bus;
+              }),
             ],
-            child: MaterialApp(
-              theme: AppThemes.colonial,
-              home: const GameScreen(),
+            child: AppEventHandlerScope(
+              child: MaterialApp(
+                navigatorKey: appNavigatorKey,
+                theme: AppThemes.colonial,
+                home: const GameScreen(),
+              ),
             ),
           ),
         );

--- a/app/test/game_side_menu_test.dart
+++ b/app/test/game_side_menu_test.dart
@@ -474,11 +474,19 @@ void main() {
             availableWorkTargetsProvider.overrideWith(
               (ref) => <String, List<String>>{},
             ),
+            appEventBusProvider.overrideWith((ref) {
+              final bus = AppEventBus.create();
+              ref.onDispose(bus.dispose);
+              return bus;
+            }),
           ],
-          child: MaterialApp(
-            home: _SideMenuUnmountingHost(
-              game: game,
-              humanPlayerId: humanPlayerId,
+          child: AppEventHandlerScope(
+            child: MaterialApp(
+              navigatorKey: appNavigatorKey,
+              home: _SideMenuUnmountingHost(
+                game: game,
+                humanPlayerId: humanPlayerId,
+              ),
             ),
           ),
         ),
@@ -589,8 +597,8 @@ void main() {
             navigatorKey: appNavigatorKey,
             routes: {
               Routes.debugLog: (_) => const Scaffold(
-                    body: Center(child: Text('debug-route-marker')),
-                  ),
+                body: Center(child: Text('debug-route-marker')),
+              ),
             },
             home: Scaffold(
               body: Stack(

--- a/app/test/game_side_menu_test.dart
+++ b/app/test/game_side_menu_test.dart
@@ -1,5 +1,7 @@
+import 'package:colonizethis_app/app.dart';
 import 'package:colonizethis_app/config/constants.dart';
 import 'package:colonizethis_app/config/routes.dart';
+import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
 import 'package:colonizethis_app/core/services/game_service.dart';
 import 'package:colonizethis_app/features/game/flame/game_side_menu.dart';
 import 'package:colonizethis_app/features/game/widgets/diplomacy_screen.dart';
@@ -20,51 +22,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
-
-import 'dart:async';
-
-class TestAppEventBus implements AppEventBus {
-  TestAppEventBus(this._inner);
-
-  final AppEventBus _inner;
-  NavigatorState? _navigator;
-
-  void setNavigator(NavigatorState navigator) {
-    _navigator = navigator;
-  }
-
-  @override
-  void emit(AppEvent event) {
-    if (event is NavigateToRouteEvent && _navigator != null) {
-      _navigator!.pushNamed(event.route, arguments: event.arguments);
-    }
-    _inner.emit(event);
-  }
-
-  @override
-  Stream<AppEvent> get stream => _inner.stream;
-
-  @override
-  Stream<T> on<T extends AppEvent>() => _inner.on<T>();
-
-  @override
-  Stream<UIActionEvent> get uiActionEvents => _inner.uiActionEvents;
-
-  @override
-  Stream<UISystemEvent> get uiSystemEvents => _inner.uiSystemEvents;
-
-  @override
-  Stream<GameToUIEvent> get gameToUIEvents => _inner.gameToUIEvents;
-
-  @override
-  Stream<DialogueEvent> get dialogueEvents => _inner.dialogueEvents;
-
-  @override
-  Stream<PortraitMoodEvent> get portraitMoodEvents => _inner.portraitMoodEvents;
-
-  @override
-  void dispose() => _inner.dispose();
-}
 
 void main() {
   suppressLogsForTests();
@@ -102,24 +59,32 @@ void main() {
             availableWorkTargetsProvider.overrideWith(
               (ref) => <String, List<String>>{},
             ),
+            appEventBusProvider.overrideWith((ref) {
+              final bus = AppEventBus.create();
+              ref.onDispose(bus.dispose);
+              return bus;
+            }),
           ],
-          child: MaterialApp(
-            home: Scaffold(
-              body: Stack(
-                children: [
-                  GameSideMenu(
-                    game: game,
-                    humanPlayerId: humanPlayerId,
-                    sideMenuOpen: true,
-                    onClose: () => closed = true,
-                    onPanelDismissed: () {},
-                    onLocateCivilianUnit: (_) {},
-                    onLocateMilitaryTile: (_, __) {},
-                    onLocateNavalFleet: (_, __) {},
-                    onCancelUnitWork: (_) {},
-                    onStartWorkTargetSelection: (_, __) {},
-                  ),
-                ],
+          child: AppEventHandlerScope(
+            child: MaterialApp(
+              navigatorKey: appNavigatorKey,
+              home: Scaffold(
+                body: Stack(
+                  children: [
+                    GameSideMenu(
+                      game: game,
+                      humanPlayerId: humanPlayerId,
+                      sideMenuOpen: true,
+                      onClose: () => closed = true,
+                      onPanelDismissed: () {},
+                      onLocateCivilianUnit: (_) {},
+                      onLocateMilitaryTile: (_, __) {},
+                      onLocateNavalFleet: (_, __) {},
+                      onCancelUnitWork: (_) {},
+                      onStartWorkTargetSelection: (_, __) {},
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
@@ -146,9 +111,6 @@ void main() {
         ? game.players.where((p) => p.isHuman).first.id
         : game.players.first.id;
 
-    final testBus = TestAppEventBus(AppEventBus.create());
-    final navigatorKey = GlobalKey<NavigatorState>();
-
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
@@ -161,33 +123,38 @@ void main() {
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
           ),
-          appEventBusProvider.overrideWith((ref) => testBus),
+          appEventBusProvider.overrideWith((ref) {
+            final bus = AppEventBus.create();
+            ref.onDispose(bus.dispose);
+            return bus;
+          }),
         ],
-        child: MaterialApp(
-          navigatorKey: navigatorKey,
-          onGenerateRoute: Routes.generate,
-          home: Scaffold(
-            body: Stack(
-              children: [
-                GameSideMenu(
-                  game: game,
-                  humanPlayerId: humanPlayerId,
-                  sideMenuOpen: true,
-                  onClose: () {},
-                  onPanelDismissed: () {},
-                  onLocateCivilianUnit: (_) {},
-                  onLocateMilitaryTile: (_, __) {},
-                  onLocateNavalFleet: (_, __) {},
-                  onCancelUnitWork: (_) {},
-                  onStartWorkTargetSelection: (_, __) {},
-                ),
-              ],
+        child: AppEventHandlerScope(
+          child: MaterialApp(
+            navigatorKey: appNavigatorKey,
+            onGenerateRoute: Routes.generate,
+            home: Scaffold(
+              body: Stack(
+                children: [
+                  GameSideMenu(
+                    game: game,
+                    humanPlayerId: humanPlayerId,
+                    sideMenuOpen: true,
+                    onClose: () {},
+                    onPanelDismissed: () {},
+                    onLocateCivilianUnit: (_) {},
+                    onLocateMilitaryTile: (_, __) {},
+                    onLocateNavalFleet: (_, __) {},
+                    onCancelUnitWork: (_) {},
+                    onStartWorkTargetSelection: (_, __) {},
+                  ),
+                ],
+              ),
             ),
           ),
         ),
       ),
     );
-    testBus.setNavigator(navigatorKey.currentState!);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Production'));
@@ -204,9 +171,6 @@ void main() {
         ? game.players.where((p) => p.isHuman).first.id
         : game.players.first.id;
 
-    final testBus = TestAppEventBus(AppEventBus.create());
-    final navigatorKey = GlobalKey<NavigatorState>();
-
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
@@ -219,33 +183,38 @@ void main() {
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
           ),
-          appEventBusProvider.overrideWith((ref) => testBus),
+          appEventBusProvider.overrideWith((ref) {
+            final bus = AppEventBus.create();
+            ref.onDispose(bus.dispose);
+            return bus;
+          }),
         ],
-        child: MaterialApp(
-          navigatorKey: navigatorKey,
-          onGenerateRoute: Routes.generate,
-          home: Scaffold(
-            body: Stack(
-              children: [
-                GameSideMenu(
-                  game: game,
-                  humanPlayerId: humanPlayerId,
-                  sideMenuOpen: true,
-                  onClose: () {},
-                  onPanelDismissed: () {},
-                  onLocateCivilianUnit: (_) {},
-                  onLocateMilitaryTile: (_, __) {},
-                  onLocateNavalFleet: (_, __) {},
-                  onCancelUnitWork: (_) {},
-                  onStartWorkTargetSelection: (_, __) {},
-                ),
-              ],
+        child: AppEventHandlerScope(
+          child: MaterialApp(
+            navigatorKey: appNavigatorKey,
+            onGenerateRoute: Routes.generate,
+            home: Scaffold(
+              body: Stack(
+                children: [
+                  GameSideMenu(
+                    game: game,
+                    humanPlayerId: humanPlayerId,
+                    sideMenuOpen: true,
+                    onClose: () {},
+                    onPanelDismissed: () {},
+                    onLocateCivilianUnit: (_) {},
+                    onLocateMilitaryTile: (_, __) {},
+                    onLocateNavalFleet: (_, __) {},
+                    onCancelUnitWork: (_) {},
+                    onStartWorkTargetSelection: (_, __) {},
+                  ),
+                ],
+              ),
             ),
           ),
         ),
       ),
     );
-    testBus.setNavigator(navigatorKey.currentState!);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Technology'));
@@ -275,24 +244,32 @@ void main() {
             availableWorkTargetsProvider.overrideWith(
               (ref) => <String, List<String>>{},
             ),
+            appEventBusProvider.overrideWith((ref) {
+              final bus = AppEventBus.create();
+              ref.onDispose(bus.dispose);
+              return bus;
+            }),
           ],
-          child: MaterialApp(
-            home: Scaffold(
-              body: Stack(
-                children: [
-                  GameSideMenu(
-                    game: game,
-                    humanPlayerId: humanPlayerId,
-                    sideMenuOpen: true,
-                    onClose: () {},
-                    onPanelDismissed: () {},
-                    onLocateCivilianUnit: (_) {},
-                    onLocateMilitaryTile: (_, __) {},
-                    onLocateNavalFleet: (_, __) {},
-                    onCancelUnitWork: (_) {},
-                    onStartWorkTargetSelection: (_, __) {},
-                  ),
-                ],
+          child: AppEventHandlerScope(
+            child: MaterialApp(
+              navigatorKey: appNavigatorKey,
+              home: Scaffold(
+                body: Stack(
+                  children: [
+                    GameSideMenu(
+                      game: game,
+                      humanPlayerId: humanPlayerId,
+                      sideMenuOpen: true,
+                      onClose: () {},
+                      onPanelDismissed: () {},
+                      onLocateCivilianUnit: (_) {},
+                      onLocateMilitaryTile: (_, __) {},
+                      onLocateNavalFleet: (_, __) {},
+                      onCancelUnitWork: (_) {},
+                      onStartWorkTargetSelection: (_, __) {},
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
@@ -328,24 +305,32 @@ void main() {
             availableWorkTargetsProvider.overrideWith(
               (ref) => <String, List<String>>{},
             ),
+            appEventBusProvider.overrideWith((ref) {
+              final bus = AppEventBus.create();
+              ref.onDispose(bus.dispose);
+              return bus;
+            }),
           ],
-          child: MaterialApp(
-            home: Scaffold(
-              body: Stack(
-                children: [
-                  GameSideMenu(
-                    game: game,
-                    humanPlayerId: humanPlayerId,
-                    sideMenuOpen: true,
-                    onClose: () {},
-                    onPanelDismissed: () {},
-                    onLocateCivilianUnit: (_) {},
-                    onLocateMilitaryTile: (_, __) {},
-                    onLocateNavalFleet: (_, __) {},
-                    onCancelUnitWork: (_) {},
-                    onStartWorkTargetSelection: (_, __) {},
-                  ),
-                ],
+          child: AppEventHandlerScope(
+            child: MaterialApp(
+              navigatorKey: appNavigatorKey,
+              home: Scaffold(
+                body: Stack(
+                  children: [
+                    GameSideMenu(
+                      game: game,
+                      humanPlayerId: humanPlayerId,
+                      sideMenuOpen: true,
+                      onClose: () {},
+                      onPanelDismissed: () {},
+                      onLocateCivilianUnit: (_) {},
+                      onLocateMilitaryTile: (_, __) {},
+                      onLocateNavalFleet: (_, __) {},
+                      onCancelUnitWork: (_) {},
+                      onStartWorkTargetSelection: (_, __) {},
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
@@ -379,24 +364,32 @@ void main() {
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
           ),
+          appEventBusProvider.overrideWith((ref) {
+            final bus = AppEventBus.create();
+            ref.onDispose(bus.dispose);
+            return bus;
+          }),
         ],
-        child: MaterialApp(
-          home: Scaffold(
-            body: Stack(
-              children: [
-                GameSideMenu(
-                  game: game,
-                  humanPlayerId: humanPlayerId,
-                  sideMenuOpen: true,
-                  onClose: () {},
-                  onPanelDismissed: () {},
-                  onLocateCivilianUnit: (_) {},
-                  onLocateMilitaryTile: (_, __) {},
-                  onLocateNavalFleet: (_, __) {},
-                  onCancelUnitWork: (_) {},
-                  onStartWorkTargetSelection: (_, __) {},
-                ),
-              ],
+        child: AppEventHandlerScope(
+          child: MaterialApp(
+            navigatorKey: appNavigatorKey,
+            home: Scaffold(
+              body: Stack(
+                children: [
+                  GameSideMenu(
+                    game: game,
+                    humanPlayerId: humanPlayerId,
+                    sideMenuOpen: true,
+                    onClose: () {},
+                    onPanelDismissed: () {},
+                    onLocateCivilianUnit: (_) {},
+                    onLocateMilitaryTile: (_, __) {},
+                    onLocateNavalFleet: (_, __) {},
+                    onCancelUnitWork: (_) {},
+                    onStartWorkTargetSelection: (_, __) {},
+                  ),
+                ],
+              ),
             ),
           ),
         ),
@@ -429,11 +422,19 @@ void main() {
             availableWorkTargetsProvider.overrideWith(
               (ref) => <String, List<String>>{},
             ),
+            appEventBusProvider.overrideWith((ref) {
+              final bus = AppEventBus.create();
+              ref.onDispose(bus.dispose);
+              return bus;
+            }),
           ],
-          child: MaterialApp(
-            home: _SideMenuUnmountingHost(
-              game: game,
-              humanPlayerId: humanPlayerId,
+          child: AppEventHandlerScope(
+            child: MaterialApp(
+              navigatorKey: appNavigatorKey,
+              home: _SideMenuUnmountingHost(
+                game: game,
+                humanPlayerId: humanPlayerId,
+              ),
             ),
           ),
         ),
@@ -461,9 +462,6 @@ void main() {
         ? game.players.where((p) => p.isHuman).first.id
         : game.players.first.id;
 
-    final testBus = TestAppEventBus(AppEventBus.create());
-    final navigatorKey = GlobalKey<NavigatorState>();
-
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
@@ -476,33 +474,38 @@ void main() {
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
           ),
-          appEventBusProvider.overrideWith((ref) => testBus),
+          appEventBusProvider.overrideWith((ref) {
+            final bus = AppEventBus.create();
+            ref.onDispose(bus.dispose);
+            return bus;
+          }),
         ],
-        child: MaterialApp(
-          navigatorKey: navigatorKey,
-          onGenerateRoute: Routes.generate,
-          home: Scaffold(
-            body: Stack(
-              children: [
-                GameSideMenu(
-                  game: game,
-                  humanPlayerId: humanPlayerId,
-                  sideMenuOpen: true,
-                  onClose: () {},
-                  onPanelDismissed: () {},
-                  onLocateCivilianUnit: (_) {},
-                  onLocateMilitaryTile: (_, __) {},
-                  onLocateNavalFleet: (_, __) {},
-                  onCancelUnitWork: (_) {},
-                  onStartWorkTargetSelection: (_, __) {},
-                ),
-              ],
+        child: AppEventHandlerScope(
+          child: MaterialApp(
+            navigatorKey: appNavigatorKey,
+            onGenerateRoute: Routes.generate,
+            home: Scaffold(
+              body: Stack(
+                children: [
+                  GameSideMenu(
+                    game: game,
+                    humanPlayerId: humanPlayerId,
+                    sideMenuOpen: true,
+                    onClose: () {},
+                    onPanelDismissed: () {},
+                    onLocateCivilianUnit: (_) {},
+                    onLocateMilitaryTile: (_, __) {},
+                    onLocateNavalFleet: (_, __) {},
+                    onCancelUnitWork: (_) {},
+                    onStartWorkTargetSelection: (_, __) {},
+                  ),
+                ],
+              ),
             ),
           ),
         ),
       ),
     );
-    testBus.setNavigator(navigatorKey.currentState!);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Diplomacy'));
@@ -518,9 +521,6 @@ void main() {
         ? game.players.where((p) => p.isHuman).first.id
         : game.players.first.id;
 
-    final testBus = TestAppEventBus(AppEventBus.create());
-    final navigatorKey = GlobalKey<NavigatorState>();
-
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
@@ -533,36 +533,42 @@ void main() {
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
           ),
-          appEventBusProvider.overrideWith((ref) => testBus),
+          appEventBusProvider.overrideWith((ref) {
+            final bus = AppEventBus.create();
+            ref.onDispose(bus.dispose);
+            return bus;
+          }),
         ],
-        child: MaterialApp(
-          navigatorKey: navigatorKey,
-          routes: {
-            Routes.debugLog: (_) =>
-                const Scaffold(body: Center(child: Text('debug-route-marker'))),
-          },
-          home: Scaffold(
-            body: Stack(
-              children: [
-                GameSideMenu(
-                  game: game,
-                  humanPlayerId: humanPlayerId,
-                  sideMenuOpen: true,
-                  onClose: () {},
-                  onPanelDismissed: () {},
-                  onLocateCivilianUnit: (_) {},
-                  onLocateMilitaryTile: (_, __) {},
-                  onLocateNavalFleet: (_, __) {},
-                  onCancelUnitWork: (_) {},
-                  onStartWorkTargetSelection: (_, __) {},
-                ),
-              ],
+        child: AppEventHandlerScope(
+          child: MaterialApp(
+            navigatorKey: appNavigatorKey,
+            routes: {
+              Routes.debugLog: (_) => const Scaffold(
+                    body: Center(child: Text('debug-route-marker')),
+                  ),
+            },
+            home: Scaffold(
+              body: Stack(
+                children: [
+                  GameSideMenu(
+                    game: game,
+                    humanPlayerId: humanPlayerId,
+                    sideMenuOpen: true,
+                    onClose: () {},
+                    onPanelDismissed: () {},
+                    onLocateCivilianUnit: (_) {},
+                    onLocateMilitaryTile: (_, __) {},
+                    onLocateNavalFleet: (_, __) {},
+                    onCancelUnitWork: (_) {},
+                    onStartWorkTargetSelection: (_, __) {},
+                  ),
+                ],
+              ),
             ),
           ),
         ),
       ),
     );
-    testBus.setNavigator(navigatorKey.currentState!);
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Debug log'));
@@ -592,24 +598,32 @@ void main() {
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
           ),
+          appEventBusProvider.overrideWith((ref) {
+            final bus = AppEventBus.create();
+            ref.onDispose(bus.dispose);
+            return bus;
+          }),
         ],
-        child: MaterialApp(
-          home: Scaffold(
-            body: Stack(
-              children: [
-                GameSideMenu(
-                  game: game,
-                  humanPlayerId: humanPlayerId,
-                  sideMenuOpen: true,
-                  onClose: () => closed = true,
-                  onPanelDismissed: () {},
-                  onLocateCivilianUnit: (_) {},
-                  onLocateMilitaryTile: (_, __) {},
-                  onLocateNavalFleet: (_, __) {},
-                  onCancelUnitWork: (_) {},
-                  onStartWorkTargetSelection: (_, __) {},
-                ),
-              ],
+        child: AppEventHandlerScope(
+          child: MaterialApp(
+            navigatorKey: appNavigatorKey,
+            home: Scaffold(
+              body: Stack(
+                children: [
+                  GameSideMenu(
+                    game: game,
+                    humanPlayerId: humanPlayerId,
+                    sideMenuOpen: true,
+                    onClose: () => closed = true,
+                    onPanelDismissed: () {},
+                    onLocateCivilianUnit: (_) {},
+                    onLocateMilitaryTile: (_, __) {},
+                    onLocateNavalFleet: (_, __) {},
+                    onCancelUnitWork: (_) {},
+                    onStartWorkTargetSelection: (_, __) {},
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/app/test/game_to_ui_bus_listener_test.dart
+++ b/app/test/game_to_ui_bus_listener_test.dart
@@ -1,0 +1,103 @@
+// SPEC/program/app-event-bus.md — GameToUI per-screen subscription.
+
+import 'package:colonizethis_app/core/services/game_service.dart';
+import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
+import 'package:colonizethis_app/providers/game_service_provider.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_app/widgets/game_to_ui_bus_listener.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_save/colonizethis_save.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/providers/games_box_provider.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  late Box<dynamic> gamesBox;
+
+  setUpAll(() async {
+    Hive.init('./.dart_tool/test_hive_game_to_ui');
+    gamesBox = await Hive.openBox<dynamic>(HiveBoxNames.games);
+  });
+
+  testWidgets(
+    'Given GameToUIBusListener for current game When TurnResolutionCompleteEvent '
+    'Then currentGameProvider reloads from GameService',
+    (WidgetTester tester) async {
+      final game = Game(
+        id: 'g_bus_1',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [
+          Player(
+            id: 'p1',
+            displayName: 'Human',
+            isHuman: true,
+            treasury: 0,
+          ),
+        ],
+      );
+      final updated = game.copyWith(
+        worldState: game.worldState.copyWith(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+        ),
+      );
+
+      final adapter = GameSaveAdapter();
+      adapter.save(gamesBox, game);
+
+      final bus = AppEventBus.create();
+      addTearDown(bus.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gamesBoxProvider.overrideWith((ref) => gamesBox),
+            gameSaveAdapterProvider.overrideWith((ref) => adapter),
+            gameServiceProvider.overrideWith((ref) {
+              final svc = GameService(gamesBox, adapter);
+              svc.eventBus = bus;
+              return svc;
+            }),
+            appEventBusProvider.overrideWith((ref) => bus),
+            currentGameProvider.overrideWith((ref) => game),
+          ],
+          child: MaterialApp(
+            home: GameToUIBusListener(
+              gameId: game.id,
+              child: Consumer(
+                builder: (context, ref, _) {
+                  final g = ref.watch(currentGameProvider);
+                  return Scaffold(
+                    body: Text('turn:${g?.worldState.turnState.turnNumber ?? -1}'),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('turn:1'), findsOneWidget);
+
+      adapter.save(gamesBox, updated);
+      bus.emit(
+        const TurnResolutionCompleteEvent(gameId: 'g_bus_1', turnNumber: 2),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('turn:2'), findsOneWidget);
+    },
+  );
+}

--- a/app/test/production_screen_integration_test.dart
+++ b/app/test/production_screen_integration_test.dart
@@ -4,8 +4,10 @@
 import 'package:colonizethis_app/features/game/widgets/production_panel_demo_data.dart';
 import 'package:colonizethis_app/features/game/widgets/province_overlay_demo_data.dart';
 import 'package:colonizethis_app/features/game/widgets/production_screen.dart';
-import 'package:colonizethis_app/widgets/ct_slider.dart';
+import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/providers/production_allocation_provider.dart';
+import 'package:colonizethis_app/widgets/ct_slider.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -31,6 +33,12 @@ void main() {
   }) {
     return ProviderScope(
       overrides: [
+        currentGameProvider.overrideWith((ref) => demoGame),
+        appEventBusProvider.overrideWith((ref) {
+          final bus = AppEventBus.create();
+          ref.onDispose(bus.dispose);
+          return bus;
+        }),
         if (initialDesiredOutput != null)
           productionDesiredOutputProvider
               .overrideWith((ref) => initialDesiredOutput),
@@ -38,7 +46,11 @@ void main() {
       child: MaterialApp(
         home: MediaQuery(
           data: MediaQueryData(size: Size(width, height)),
-          child: ProductionScreen(game: demoGame, player: fullPlayer),
+          child: ProductionScreen(
+            game: demoGame,
+            player: fullPlayer,
+            attachGameToUiListener: false,
+          ),
         ),
       ),
     );

--- a/app/test/tech_tree_widget_test.dart
+++ b/app/test/tech_tree_widget_test.dart
@@ -4,12 +4,15 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/tech_tree_widget.dart';
 import 'package:colonizethis_app/features/game/widgets/technology_screen.dart';
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
 import 'package:colonizethis_app/widgets/ct_screen_shell.dart';
+import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
 
 void main() {
@@ -23,6 +26,21 @@ void main() {
     game = result.game;
     player = game.players.isNotEmpty ? game.players.first : _dummyPlayer();
   });
+
+  Widget _scopedTechnology(Game g, Widget child) {
+    return ProviderScope(
+      overrides: [
+        currentGameProvider.overrideWith((ref) => g),
+        currentOrdersProvider.overrideWith((ref) => const Orders()),
+        appEventBusProvider.overrideWith((ref) {
+          final bus = AppEventBus.create();
+          ref.onDispose(bus.dispose);
+          return bus;
+        }),
+      ],
+      child: child,
+    );
+  }
 
   testWidgets('TechTreeWidget builds and shows scrollable content', (
     WidgetTester tester,
@@ -67,9 +85,12 @@ void main() {
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: TechnologyScreen(game: game, player: player),
+      _scopedTechnology(
+        game,
+        MaterialApp(
+          home: Scaffold(
+            body: TechnologyScreen(game: game, player: player),
+          ),
         ),
       ),
     );
@@ -83,14 +104,17 @@ void main() {
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
-      MaterialApp(
-        home: Navigator(
-          pages: [
-            MaterialPage(
-              child: TechnologyScreen(game: game, player: player),
-            ),
-          ],
-          onDidRemovePage: (_) {},
+      _scopedTechnology(
+        game,
+        MaterialApp(
+          home: Navigator(
+            pages: [
+              MaterialPage(
+                child: TechnologyScreen(game: game, player: player),
+              ),
+            ],
+            onDidRemovePage: (_) {},
+          ),
         ),
       ),
     );
@@ -105,15 +129,18 @@ void main() {
   ) async {
     await tester.pumpWidget(MaterialApp(home: const Text('Home')));
     await tester.pumpWidget(
-      MaterialApp(
-        home: Navigator(
-          pages: [
-            const MaterialPage(child: Text('Home')),
-            MaterialPage(
-              child: TechnologyScreen(game: game, player: player),
-            ),
-          ],
-          onDidRemovePage: (_) {},
+      _scopedTechnology(
+        game,
+        MaterialApp(
+          home: Navigator(
+            pages: [
+              const MaterialPage(child: Text('Home')),
+              MaterialPage(
+                child: TechnologyScreen(game: game, player: player),
+              ),
+            ],
+            onDidRemovePage: (_) {},
+          ),
         ),
       ),
     );
@@ -132,9 +159,12 @@ void main() {
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: TechnologyScreen(game: game, player: player),
+      _scopedTechnology(
+        game,
+        MaterialApp(
+          home: Scaffold(
+            body: TechnologyScreen(game: game, player: player),
+          ),
         ),
       ),
     );

--- a/app/test/train_civilians_dialog_test.dart
+++ b/app/test/train_civilians_dialog_test.dart
@@ -1,14 +1,18 @@
 // Tests for TrainCiviliansDialog. SPEC/ui/train-civilians-dialog.md.
 
+import 'package:colonizethis_app/app.dart';
+import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
+import 'package:colonizethis_app/features/game/widgets/civilian_units_panel.dart';
+import 'package:colonizethis_app/features/game/widgets/train_civilians_dialog.dart';
+import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:colonizethis_app/features/game/widgets/train_civilians_dialog.dart';
-import 'package:colonizethis_app/features/game/widgets/civilian_units_panel.dart';
-import 'package:colonizethis_app/widgets/debug_init_game.dart';
 
 void main() {
   suppressLogsForTests();
@@ -380,13 +384,30 @@ void main() {
       WidgetTester tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: CivilianUnitsPanel(
-              game: game,
-              humanPlayerId: humanPlayerId,
-              bus: AppEventBus(),
-              onTrainPressed: () {},
+        ProviderScope(
+          overrides: [
+            currentGameProvider.overrideWith((ref) => game),
+            currentOrdersProvider.overrideWith((ref) => const Orders()),
+            appEventBusProvider.overrideWith((ref) {
+              final bus = AppEventBus.create();
+              ref.onDispose(bus.dispose);
+              return bus;
+            }),
+          ],
+          child: AppEventHandlerScope(
+            child: MaterialApp(
+              navigatorKey: appNavigatorKey,
+              home: Scaffold(
+                body: Consumer(
+                  builder: (context, ref, _) {
+                    return CivilianUnitsPanel(
+                      game: game,
+                      humanPlayerId: humanPlayerId,
+                      bus: ref.watch(appEventBusProvider),
+                    );
+                  },
+                ),
+              ),
             ),
           ),
         ),
@@ -396,21 +417,34 @@ void main() {
       expect(find.text('Train'), findsOneWidget);
     });
 
-    testWidgets('AC: Train button triggers onTrainPressed callback', (
+    testWidgets('AC: Train button opens TrainCiviliansDialog via app event bus', (
       WidgetTester tester,
     ) async {
-      bool trainPressed = false;
-
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: CivilianUnitsPanel(
-              game: game,
-              humanPlayerId: humanPlayerId,
-              bus: AppEventBus(),
-              onTrainPressed: () {
-                trainPressed = true;
-              },
+        ProviderScope(
+          overrides: [
+            currentGameProvider.overrideWith((ref) => game),
+            currentOrdersProvider.overrideWith((ref) => const Orders()),
+            appEventBusProvider.overrideWith((ref) {
+              final bus = AppEventBus.create();
+              ref.onDispose(bus.dispose);
+              return bus;
+            }),
+          ],
+          child: AppEventHandlerScope(
+            child: MaterialApp(
+              navigatorKey: appNavigatorKey,
+              home: Scaffold(
+                body: Consumer(
+                  builder: (context, ref, _) {
+                    return CivilianUnitsPanel(
+                      game: game,
+                      humanPlayerId: humanPlayerId,
+                      bus: ref.watch(appEventBusProvider),
+                    );
+                  },
+                ),
+              ),
             ),
           ),
         ),
@@ -420,7 +454,8 @@ void main() {
       await tester.tap(find.text('Train'));
       await tester.pumpAndSettle();
 
-      expect(trainPressed, isTrue);
+      expect(find.byType(TrainCiviliansDialog), findsOneWidget);
+      expect(find.text('Train Civilians'), findsOneWidget);
     });
   });
 }

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -5,13 +5,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:colonizethis_app/app.dart';
+import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
 
 void main() {
   // Suppress logs for test run.
   suppressLogsForTests();
 
   testWidgets('App shell smoke test', (WidgetTester tester) async {
-    await tester.pumpWidget(const ProviderScope(child: App()));
+    await tester.pumpWidget(
+      const ProviderScope(child: AppEventHandlerScope(child: App())),
+    );
     await tester.pumpAndSettle();
     expect(find.text('ColonizeThis V3'), findsOneWidget);
   });

--- a/packages/colonizethis_models/lib/src/app_events.dart
+++ b/packages/colonizethis_models/lib/src/app_events.dart
@@ -8,6 +8,12 @@
 //
 // Note: GameEvent lives in colonizethis_logic to avoid circular deps.
 // DialogueEvent and PortraitMoodEvent live here in colonizethis_models.
+//
+// Panel requests: prefer typed subclasses below (SPEC/program/app-event-bus.md).
+// [OpenPanelEvent] remains for legacy string-id panels until migrated.
+
+import 'game.dart';
+import 'unit.dart';
 
 export 'ai_events.dart' show DialogueEvent, PortraitMoodEvent;
 
@@ -70,6 +76,58 @@ class OpenPanelEvent extends UIActionEvent {
 /// Request to close the current panel or overlay.
 class ClosePanelEvent extends UIActionEvent {
   const ClosePanelEvent();
+}
+
+/// In-game pause menu bottom sheet. Handled by the shell-level event handler (app layer).
+class OpenPauseMenuPanelEvent extends UIActionEvent {
+  const OpenPauseMenuPanelEvent({this.onDebugLog, this.onResume});
+
+  final void Function()? onDebugLog;
+  final void Function()? onResume;
+}
+
+/// Civilian units bottom sheet. App handler supplies [Game] / orders from Riverpod;
+/// callbacks bridge map/shell behavior (locate, work orders, target pick).
+class OpenCivilianUnitsPanelEvent extends UIActionEvent {
+  OpenCivilianUnitsPanelEvent({
+    required this.onLocateUnit,
+    required this.onRemoveWorkOrder,
+    required this.onCancelUnitWork,
+    required this.onStartWorkTargetSelection,
+    this.onPanelDismissed,
+  });
+
+  final void Function(Unit unit) onLocateUnit;
+  final void Function(String playerId, int index) onRemoveWorkOrder;
+  final void Function(String unitId) onCancelUnitWork;
+  final void Function(Unit unit, String workTarget) onStartWorkTargetSelection;
+
+  /// Invoked when the bottom sheet route is popped (any reason).
+  final void Function()? onPanelDismissed;
+}
+
+/// Military units bottom sheet.
+class OpenMilitaryUnitsPanelEvent extends UIActionEvent {
+  OpenMilitaryUnitsPanelEvent({
+    required this.onLocateTile,
+    this.onPanelDismissed,
+  });
+
+  final void Function(String tileKey, String regionId) onLocateTile;
+  final void Function()? onPanelDismissed;
+}
+
+/// Naval units bottom sheet.
+class OpenNavalUnitsPanelEvent extends UIActionEvent {
+  OpenNavalUnitsPanelEvent({
+    required this.onLocateFleet,
+    required this.onFleetsChanged,
+    this.onPanelDismissed,
+  });
+
+  final void Function(String tileKey, String regionId) onLocateFleet;
+  final void Function(Game game) onFleetsChanged;
+  final void Function()? onPanelDismissed;
 }
 
 /// Request to start a unit target-selection mode (map enters target-pick state).


### PR DESCRIPTION
## Summary
Extends the app event bus pattern with **typed panel open events** (pause, civilian/military/naval units), **per-screen** subscriptions to **GameToUI** (`TurnResolutionCompleteEvent`) via `GameToUIBusListener`, and updated **SPEC/program/app-event-bus.md** acceptance criteria plus tests.

## Key changes
- **Models:** `OpenPauseMenuPanelEvent`, typed unit panel events (optional `onPanelDismissed`); legacy string `OpenPanelEvent` retained where needed.
- **Handler:** `AppEventHandler` + new `AppEventHandlerScope` for dialog registration; `PauseMenuPanel` extracted; game side menu emits events instead of opening sheets directly.
- **Game → UI:** `GameService` emits `TurnResolutionCompleteEvent` when appropriate; `game_service_provider` wires `AppEventBus`. Production, Diplomacy, Technology, and game screen wrap content with `GameToUIBusListener` when a game is active.
- **Robustness:** `CtSlider` handles `min == max` and invalid track width (avoids NaN/`Infinity` in `.round()` during drags).

## Testing
- `flutter test` under `app/` (full suite) passes.

Made with [Cursor](https://cursor.com)