### PR TITLE
feat(app): production panel affordance readout (max · bottleneck)

### DIFF
--- a/SPEC/ui/production-panel.md
+++ b/SPEC/ui/production-panel.md
@@ -8,59 +8,7 @@ The production panel lets the player allocate production by setting **desired ou
 
 ## Resource and Worker Icons
 
-Each commodity and worker tier has a unique pixel-art icon (32×32) following the style defined in [game-toolbar-icons.md](game-toolbar-icons.md).
-
-### Icon Asset Names
-
-| Icon ID | Filename | Description |
-|---------|----------|-------------|
-| **Food** |||
-| grain | `ui_icon_com_grain.png` | Wheat sheaf or grain bundle |
-| meat | `ui_icon_com_meat.png` | Meat cut or ham |
-| **Raw Materials** |||
-| timber | `ui_icon_com_timber.png` | Wooden log |
-| iron | `ui_icon_com_iron.png` | Iron ore chunk or ingot |
-| wool | `ui_icon_com_wool.png` | Wool bundle or fleece |
-| cotton | `ui_icon_com_cotton.png` | Cotton boll |
-| coal | `ui_icon_com_coal.png` | Coal lump |
-| sugar_cane | `ui_icon_com_sugar_cane.png` | Sugar cane stalk |
-| tobacco | `ui_icon_com_tobacco.png` | Tobacco leaf |
-| furs | `ui_icon_com_furs.png` | Fur pelt |
-| copper | `ui_icon_com_copper.png` | Copper ingot |
-| tin | `ui_icon_com_tin.png` | Tin ingot |
-| horses | `ui_icon_com_horses.png` | Horse head |
-| **Manufactured** |||
-| lumber | `ui_icon_com_lumber.png` | Stack of lumber planks |
-| cast_iron | `ui_icon_com_cast_iron.png` | Cast iron product |
-| fabric | `ui_icon_com_fabric.png` | Fabric bolt or cloth roll |
-| refined_sugar | `ui_icon_com_refined_sugar.png` | Sugar loaf |
-| cigars | `ui_icon_com_cigars.png` | Cigar bundle |
-| fur_hats | `ui_icon_com_fur_hats.png` | Fur hat |
-| steel | `ui_icon_com_steel.png` | Steel ingot |
-| paper | `ui_icon_com_paper.png` | Paper scroll or sheet |
-| bronze | `ui_icon_com_bronze.png` | Bronze ingot |
-| **Workers** |||
-| peasant | `ui_icon_worker_peasant.png` | Peasant worker |
-| apprentice | `ui_icon_worker_apprentice.png` | Apprentice worker |
-| journeyman | `ui_icon_worker_journeyman.png` | Journeyman worker |
-| master | `ui_icon_worker_master.png` | Master craftsman |
-
-### Icon Style
-
-Icons follow the style defined in [game-toolbar-icons.md](game-toolbar-icons.md):
-- Size: 32×32 pixels
-- Format: PNG with RGBA transparency
-- Outline: `single color outline`
-- Shading: `medium shading`
-- Detail: `medium detail`
-- View: `high top-down` (orthographic)
-- Style lock: Match color palette from `ui_main_menu_button.png`
-
-### Icon Usage
-
-Icons appear in two contexts:
-1. **Available subpanel:** Before each commodity and worker quantity line
-2. **Allocation subpanel:** Before each commodity name in recipe labels (output and inputs)
+Asset filenames and style for commodities and workers appear in [game-toolbar-icons.md](game-toolbar-icons.md) § Resource & Worker Icons (Production Panel). **Usage:** (1) **Available** — icon before each commodity/worker line; (2) **Allocation** — icon before the **output** commodity name on each recipe row (input materials are listed by name in parentheses).
 
 ## Layout
 
@@ -71,7 +19,7 @@ Icons appear in two contexts:
   - **Workers section:** Displayed in a **2-column grid**. Each cell shows: icon, worker type, and count.
   - **Effective labour:** Bold line at bottom of workers section.
   - Read-only display of stockpile quantities and net changes from current allocations.
-- **Subpanel 2 — Allocation (right):** One row per production recipe: label showing output icon with commodity name and input icons with names (e.g. "🪵 Lumber (🪵 timber ×2)"), slider for desired output, and validation feedback when labour is insufficient.
+- **Subpanel 2 — Allocation (right):** One row per recipe: left, output icon + name and inputs in parentheses; **right-aligned** on that row, `max · bottleneck` (`max` = slider cap; `bottleneck` = limiting commodity **display name** or **Labour**). Next row: slider; **right-aligned** numeric desired output. Summary lines below retain total labour / insufficient-labour warning.
 - Subpanels are laid out in a **row** (Available | Allocation) to conserve horizontal space.
 
 ### Mobile / narrow viewport (e.g. width < 600 dp)
@@ -90,32 +38,18 @@ Icons appear in two contexts:
 
 - Sliders adjust desired output; recipe labels display **icon + output commodity name** followed by **icon + input commodities** in parentheses (e.g. "🪵 Lumber (🪵 timber ×2)").
 - **Reset:** A "Reset" button clears all slider allocations to zero.
-- **Validation:** Each recipe slider is capped at the **achievable runs** considering both current stockpile inputs AND labour already allocated to other recipes. The slider maximum is recalculated dynamically as other allocations change. The UI does not accept a desired output above that cap. When total required labour across all recipes exceeds effective labour, the UI shows **insufficient labour** and displays a warning that production will be capped next turn.
+- **Validation:** Slider max = same **max** as the affordance readout: min of labour headroom (excluding this recipe) and each input’s stock headroom (excluding this recipe), after subtracting **other** recipes’ committed inputs/labour; then clamp 0–`kProductionAllocationSliderCap` (50). Recalculates on **any** allocation change. No desired output above that max. If **total** required labour > effective labour, show error styling and “capped next turn” message.
+- **Affordance bottleneck:** Tightest of labour + **all** recipe inputs (catalog display names; labour label **Labour**). **Ties:** first tied **input** in `inputQuantities` iteration order; if no input ties, **Labour**.
 - **Net Changes:** The Available panel displays expected net change for each commodity based on current allocations, shown in parentheses (positive for production, negative for consumption).
 - When the player advances the turn, the app passes the current allocation as production assignments for the human player to the turn resolver (`defaultAssignmentsByPlayerId`). Assignment is not persisted in the save (app state only) unless extended later.
 - The turn resolver still runs as many complete recipe runs as inputs and labour allow (per production-recipes.md).
 
 ## Acceptance Criteria
 
-- **Given** the user opens the production panel, **when** viewing the Available subpanel, **then** the UI layer shows commodity groups (Food, Raw Materials, Manufactured) in a 3-column grid layout with stockpile quantities and icons for all commodities from the commodity catalog, and worker pool tiers (peasants, apprentices, journeymen, masters) in a 2-column grid layout plus effective labour.
-
-- **Given** the user opens the production panel, **when** viewing any commodity or worker entry, **then** the UI displays the corresponding 32×32 pixel-art icon before the name, matching the style from [game-toolbar-icons.md](game-toolbar-icons.md).
-
-- **Given** the user opens the production panel with active allocations, **when** viewing the Available subpanel, **then** each commodity displays its icon, name, current quantity, followed by the expected net change in parentheses (e.g. "🪵 Timber: 100 (-20)").
-
-- **Given** the user is on the Allocation subpanel, **when** viewing the recipe labels, **then** each label shows the output icon and commodity name followed by input icons and commodity names in parentheses (e.g. "🪵 Lumber (🪵 timber ×2)").
-
-- **Given** the user is on the Allocation subpanel, **when** the user moves a slider for a recipe, **then** the UI layer enforces the slider maximum at the achievable runs for that recipe, considering both current stockpile inputs and labour already allocated to other recipes.
-
-- **Given** the user taps the Reset button, **when** viewing the Allocation subpanel, **then** all sliders are set to zero and the allocation state is cleared.
-
-- **Given** the user has set desired outputs and closes the panel, **when** the user presses Next turn, **then** the system passes the corresponding production assignments for the human player to the turn resolver and production runs accordingly.
-
-- **Given** the total required labour across all recipes exceeds the player's effective labour, **when** the user views the Allocation subpanel, **then** the UI layer shows total required labour vs effective labour in error colour and a message that production will be capped next turn.
-
-- **Given** the viewport width is less than 600 dp (narrow/mobile), **when** the production panel is displayed, **then** the UI layer stacks the Available subpanel above the Allocation subpanel in a single column and makes the content scrollable so all content is reachable, while maintaining 3-column resource grids and 2-column worker grid.
-
-- **Given** the viewport width is at least 600 dp (wide), **when** the production panel is displayed, **then** the UI layer shows the Available subpanel and the Allocation subpanel side by side in a row.
+- **Available:** Food / Raw Materials / Manufactured in **3-column** grids (icon, name, qty, net change in parentheses); Workers **2-column** + effective labour; icons 32×32 per [game-toolbar-icons.md](game-toolbar-icons.md).
+- **Allocation:** Each recipe: output icon + name; inputs in parentheses; **right-aligned** `max · bottleneck`; slider row with **right-aligned** desired number. **max** equals slider cap (Behaviour). Changing **any** recipe’s allocation updates **every** row’s **max** / **bottleneck**.
+- **Reset** clears all sliders. **Next turn** passes human assignments to the turn resolver. **Labour line** uses error colour + cap message when total required labour > effective.
+- **Narrow (<600 dp):** stack subpanels, scroll, keep grid column counts. **Wide (≥600 dp):** Available | Allocation in a row.
 
 ## Integration
 

--- a/app/lib/features/game/production_recipe_affordance.dart
+++ b/app/lib/features/game/production_recipe_affordance.dart
@@ -1,0 +1,141 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Maximum desired output the production panel slider allows per recipe.
+/// SPEC/ui/production-panel.md
+const int kProductionAllocationSliderCap = 50;
+
+/// Stock- and labour-based affordance for one recipe row (panel slider cap).
+/// SPEC/ui/production-panel.md
+final class RecipeAffordance {
+  const RecipeAffordance({
+    required this.maxDesiredOutput,
+    required this.limitingLabel,
+  });
+
+  /// Desired output units allowed for this recipe (same cap as the slider).
+  final int maxDesiredOutput;
+
+  /// Commodity display name or `Labour` for the tightest constraint before
+  /// [kProductionAllocationSliderCap] (ties: first recipe input in catalog
+  /// map order, then labour).
+  final String limitingLabel;
+}
+
+int _remainingLabourForRecipe({
+  required String recipeId,
+  required int effectiveLabour,
+  required Map<String, int> desiredOutputByRecipe,
+}) {
+  var used = 0;
+  for (final entry in desiredOutputByRecipe.entries) {
+    if (entry.key == recipeId) continue;
+    final recipe = ProductionRecipesCatalog.byId[entry.key];
+    if (recipe != null) {
+      used += entry.value * recipe.labourPerOutput;
+    }
+  }
+  return (effectiveLabour - used).clamp(0, effectiveLabour);
+}
+
+Map<String, int> _remainingStockByCommodity({
+  required String recipeId,
+  required Stockpile stockpile,
+  required Map<String, int> desiredOutputByRecipe,
+}) {
+  final remaining = <String, int>{};
+  for (final comm in CommodityCatalog.all) {
+    remaining[comm.id] = stockpile.quantityOf(comm.id);
+  }
+  for (final entry in desiredOutputByRecipe.entries) {
+    if (entry.key == recipeId) continue;
+    final recipe = ProductionRecipesCatalog.byId[entry.key];
+    if (recipe != null) {
+      for (final input in recipe.inputQuantities.entries) {
+        remaining[input.key] =
+            (remaining[input.key] ?? 0) - (input.value * entry.value);
+      }
+    }
+  }
+  for (final key in remaining.keys.toList()) {
+    if (remaining[key]! < 0) {
+      remaining[key] = 0;
+    }
+  }
+  return remaining;
+}
+
+String _commodityDisplayName(String commodityId) {
+  final c = CommodityCatalog.byId[commodityId];
+  return c?.displayName ?? commodityId;
+}
+
+/// Computes max desired output and bottleneck label for [recipe].
+///
+/// Uses current stockpile minus inputs committed by **other** recipes'
+/// desired outputs, and effective labour minus labour assigned to **other**
+/// recipes — matching the allocation slider rules.
+RecipeAffordance computeRecipeAffordance({
+  required ProductionRecipe recipe,
+  required Stockpile stockpile,
+  required Map<String, int> desiredOutputByRecipe,
+  required int effectiveLabour,
+  int sliderCap = kProductionAllocationSliderCap,
+}) {
+  final labourPerOutput = recipe.labourPerOutput;
+  final remainingLabour = _remainingLabourForRecipe(
+    recipeId: recipe.id,
+    effectiveLabour: effectiveLabour,
+    desiredOutputByRecipe: desiredOutputByRecipe,
+  );
+
+  if (labourPerOutput <= 0) {
+    return const RecipeAffordance(maxDesiredOutput: 0, limitingLabel: 'Labour');
+  }
+
+  var maxByLabour = remainingLabour ~/ labourPerOutput;
+  if (maxByLabour <= 0) {
+    return const RecipeAffordance(maxDesiredOutput: 0, limitingLabel: 'Labour');
+  }
+
+  final remainingStock = _remainingStockByCommodity(
+    recipeId: recipe.id,
+    stockpile: stockpile,
+    desiredOutputByRecipe: desiredOutputByRecipe,
+  );
+
+  var trueMax = maxByLabour;
+  final runsPerInput = <String, int>{};
+  for (final entry in recipe.inputQuantities.entries) {
+    final perUnit = entry.value;
+    if (perUnit <= 0) {
+      continue;
+    }
+    final have = remainingStock[entry.key] ?? 0;
+    final runs = have ~/ perUnit;
+    runsPerInput[entry.key] = runs;
+    if (runs < trueMax) {
+      trueMax = runs;
+    }
+  }
+
+  String? limitingLabel;
+  for (final entry in recipe.inputQuantities.entries) {
+    final perUnit = entry.value;
+    if (perUnit <= 0) {
+      continue;
+    }
+    final runs = runsPerInput[entry.key] ?? 0;
+    if (runs == trueMax) {
+      limitingLabel = _commodityDisplayName(entry.key);
+      break;
+    }
+  }
+  limitingLabel ??= 'Labour';
+
+  final capped = trueMax.clamp(0, sliderCap);
+  return RecipeAffordance(
+    maxDesiredOutput: capped,
+    limitingLabel: limitingLabel,
+  );
+}

--- a/app/lib/features/game/widgets/production_panel.dart
+++ b/app/lib/features/game/widgets/production_panel.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../production_recipe_affordance.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/ct_panel.dart';
 import '../../../widgets/ct_slider.dart';
@@ -288,58 +289,6 @@ class _AllocationSubpanel extends StatelessWidget {
   final Map<String, int> desiredOutputByRecipe;
   final ValueChanged<Map<String, int>> onDesiredOutputChanged;
 
-  static const int _absoluteMaxSliderOutput = 50;
-
-  int _remainingLabour(String excludeRecipeId) {
-    int used = 0;
-    for (final entry in desiredOutputByRecipe.entries) {
-      if (entry.key == excludeRecipeId) continue;
-      final recipe = ProductionRecipesCatalog.byId[entry.key];
-      if (recipe != null) {
-        used += entry.value * recipe.labourPerOutput;
-      }
-    }
-    return (effectiveLabour - used).clamp(0, effectiveLabour);
-  }
-
-  Map<String, int> _remainingInputs(String excludeRecipeId) {
-    final remaining = <String, int>{};
-    for (final comm in CommodityCatalog.all) {
-      remaining[comm.id] = player.stockpile.quantityOf(comm.id);
-    }
-    for (final entry in desiredOutputByRecipe.entries) {
-      if (entry.key == excludeRecipeId) continue;
-      final recipe = ProductionRecipesCatalog.byId[entry.key];
-      if (recipe != null) {
-        for (final input in recipe.inputQuantities.entries) {
-          remaining[input.key] =
-              (remaining[input.key] ?? 0) - (input.value * entry.value);
-        }
-      }
-    }
-    for (final key in remaining.keys.toList()) {
-      if (remaining[key]! < 0) remaining[key] = 0;
-    }
-    return remaining;
-  }
-
-  int _achievableRunsForRecipe(ProductionRecipe recipe) {
-    final remainingLabour = _remainingLabour(recipe.id);
-    var maxByLabour = remainingLabour ~/ recipe.labourPerOutput;
-    if (maxByLabour <= 0) return 0;
-    final remainingInputs = _remainingInputs(recipe.id);
-    var maxByInputs = maxByLabour;
-    for (final entry in recipe.inputQuantities.entries) {
-      final remaining = remainingInputs[entry.key] ?? 0;
-      final perRun = entry.value;
-      if (perRun <= 0) continue;
-      final runs = remaining ~/ perRun;
-      if (runs < maxByInputs) maxByInputs = runs;
-    }
-    final cap = maxByInputs < maxByLabour ? maxByInputs : maxByLabour;
-    return cap.clamp(0, _absoluteMaxSliderOutput);
-  }
-
   Widget _buildRecipeLabel(ProductionRecipe recipe, ThemeData theme) {
     final outputCommodity = CommodityCatalog.byId[recipe.outputCommodityId];
     final outputName = outputCommodity?.displayName ?? recipe.outputCommodityId;
@@ -354,10 +303,6 @@ class _AllocationSubpanel extends StatelessWidget {
 
     final hasOutputIcon =
         outputCommodity != null && ResourceIcon.hasIcon(outputCommodity.id);
-    final inputCommodities = recipe.inputQuantities.entries
-        .map((e) => CommodityCatalog.byId[e.key])
-        .whereType<Commodity>()
-        .toList();
 
     return Row(
       mainAxisSize: MainAxisSize.min,
@@ -412,10 +357,18 @@ class _AllocationSubpanel extends StatelessWidget {
             const SizedBox(height: 8),
             ...ProductionRecipesCatalog.all.map((recipe) {
               final desired = desiredOutputByRecipe[recipe.id] ?? 0;
-              final maxAchievable = _achievableRunsForRecipe(recipe);
+              final affordance = computeRecipeAffordance(
+                recipe: recipe,
+                stockpile: player.stockpile,
+                desiredOutputByRecipe: desiredOutputByRecipe,
+                effectiveLabour: effectiveLabour,
+              );
+              final maxAchievable = affordance.maxDesiredOutput;
               final sliderMax = maxAchievable == 0
                   ? 0.0
-                  : maxAchievable.clamp(1, _absoluteMaxSliderOutput).toDouble();
+                  : maxAchievable
+                        .clamp(1, kProductionAllocationSliderCap)
+                        .toDouble();
 
               return Padding(
                 padding: const EdgeInsets.only(bottom: 12),
@@ -423,7 +376,24 @@ class _AllocationSubpanel extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    _buildRecipeLabel(recipe, theme),
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Expanded(
+                          flex: 2,
+                          child: _buildRecipeLabel(recipe, theme),
+                        ),
+                        Expanded(
+                          flex: 1,
+                          child: Text(
+                            '${affordance.maxDesiredOutput} · ${affordance.limitingLabel}',
+                            textAlign: TextAlign.right,
+                            style: theme.textTheme.labelSmall,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ),
                     Row(
                       children: [
                         Expanded(
@@ -435,7 +405,7 @@ class _AllocationSubpanel extends StatelessWidget {
                                 ? 1
                                 : maxAchievable.clamp(
                                     1,
-                                    _absoluteMaxSliderOutput,
+                                    kProductionAllocationSliderCap,
                                   ),
                             onChanged: (v) {
                               final next = Map<String, int>.from(
@@ -455,6 +425,7 @@ class _AllocationSubpanel extends StatelessWidget {
                           width: 36,
                           child: Text(
                             '$desired',
+                            textAlign: TextAlign.right,
                             style: theme.textTheme.bodySmall,
                           ),
                         ),

--- a/app/test/production_panel_test.dart
+++ b/app/test/production_panel_test.dart
@@ -89,6 +89,19 @@ void main() {
       expect(find.textContaining('Fabric'), findsWidgets);
     });
 
+    testWidgets(
+      'Allocation rows show right-aligned affordance max · bottleneck',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildPanel(player: fullPlayer));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.textContaining('·'),
+          findsAtLeastNWidgets(ProductionRecipesCatalog.all.length),
+        );
+      },
+    );
+
     testWidgets('Reset button clears all allocations', (
       WidgetTester tester,
     ) async {
@@ -196,46 +209,53 @@ void main() {
     });
 
     testWidgets(
-        'Over-allocating labour shows insufficient labour warning in summary',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(buildPanel(
-        player: fullPlayer,
-        desiredOutputByRecipe: {
-          // Choose a recipe and deliberately over-allocate beyond what labour allows.
-          'lumber_from_timber': 999,
-        },
-      ));
-      await tester.pumpAndSettle();
+      'Over-allocating labour shows insufficient labour warning in summary',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          buildPanel(
+            player: fullPlayer,
+            desiredOutputByRecipe: {
+              // Choose a recipe and deliberately over-allocate beyond what labour allows.
+              'lumber_from_timber': 999,
+            },
+          ),
+        );
+        await tester.pumpAndSettle();
 
-      // Summary line should turn into an error-coloured warning with explanatory text.
-      expect(
-        find.textContaining('Total labour:'),
-        findsOneWidget,
-      );
-      expect(
-        find.text('Insufficient labour — production will be capped next turn'),
-        findsOneWidget,
-      );
-    });
+        // Summary line should turn into an error-coloured warning with explanatory text.
+        expect(find.textContaining('Total labour:'), findsOneWidget);
+        expect(
+          find.text(
+            'Insufficient labour — production will be capped next turn',
+          ),
+          findsOneWidget,
+        );
+      },
+    );
 
     testWidgets(
-        'Unknown recipe ids are ignored when computing total labour (no warning)',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(buildPanel(
-        player: fullPlayer,
-        desiredOutputByRecipe: {
-          // Not a real production recipe id; should be ignored by the panel.
-          'definitely_not_a_recipe_id': 5,
-        },
-      ));
-      await tester.pumpAndSettle();
+      'Unknown recipe ids are ignored when computing total labour (no warning)',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          buildPanel(
+            player: fullPlayer,
+            desiredOutputByRecipe: {
+              // Not a real production recipe id; should be ignored by the panel.
+              'definitely_not_a_recipe_id': 5,
+            },
+          ),
+        );
+        await tester.pumpAndSettle();
 
-      expect(find.textContaining('Total labour:'), findsOneWidget);
-      expect(
-        find.text('Insufficient labour — production will be capped next turn'),
-        findsNothing,
-      );
-    });
+        expect(find.textContaining('Total labour:'), findsOneWidget);
+        expect(
+          find.text(
+            'Insufficient labour — production will be capped next turn',
+          ),
+          findsNothing,
+        );
+      },
+    );
 
     testWidgets('Recipe labels show output with inputs in parentheses', (
       WidgetTester tester,

--- a/app/test/production_recipe_affordance_test.dart
+++ b/app/test/production_recipe_affordance_test.dart
@@ -1,0 +1,126 @@
+// Unit tests for production recipe affordance. SPEC/ui/production-panel.md.
+
+import 'package:colonizethis_app/features/game/production_recipe_affordance.dart';
+import 'package:colonizethis_app/features/game/widgets/production_panel_demo_data.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  group('computeRecipeAffordance', () {
+    test('partial player: lumber capped by labour', () {
+      final player = partialAvailabilityProductionPlayer();
+      final effectiveLabour = effectiveLabourForWorkers(
+        workers: player.workerPool,
+        stockpile: player.stockpile,
+      );
+      final affordance = computeRecipeAffordance(
+        recipe: ProductionRecipesCatalog.lumberFromTimber,
+        stockpile: player.stockpile,
+        desiredOutputByRecipe: const {},
+        effectiveLabour: effectiveLabour,
+      );
+      expect(affordance.maxDesiredOutput, 1);
+      expect(affordance.limitingLabel, 'Labour');
+    });
+
+    test('other recipes committed inputs reduce lumber max', () {
+      final stockpile = Stockpile(
+        quantities: {
+          CommodityCatalog.grain.id: 20,
+          CommodityCatalog.timber.id: 100,
+        },
+      );
+      const workers = WorkerPool(
+        peasants: 100,
+        apprentices: 0,
+        journeymen: 0,
+        masters: 0,
+      );
+      final effectiveLabour = effectiveLabourForWorkers(
+        workers: workers,
+        stockpile: stockpile,
+      );
+      final baseline = computeRecipeAffordance(
+        recipe: ProductionRecipesCatalog.lumberFromTimber,
+        stockpile: stockpile,
+        desiredOutputByRecipe: const {},
+        effectiveLabour: effectiveLabour,
+      );
+      expect(baseline.maxDesiredOutput, kProductionAllocationSliderCap);
+
+      final affordance = computeRecipeAffordance(
+        recipe: ProductionRecipesCatalog.lumberFromTimber,
+        stockpile: stockpile,
+        desiredOutputByRecipe: const {'paper_from_timber': 10},
+        effectiveLabour: effectiveLabour,
+      );
+      expect(affordance.maxDesiredOutput, 35);
+      expect(affordance.limitingLabel, 'Timber');
+    });
+
+    test('tie on inputs uses first input in recipe map order', () {
+      final stockpile = Stockpile(
+        quantities: {
+          CommodityCatalog.timber.id: 10,
+          CommodityCatalog.iron.id: 10,
+        },
+      );
+      final affordance = computeRecipeAffordance(
+        recipe: ProductionRecipesCatalog.castIronFromTimberIronCoal,
+        stockpile: stockpile,
+        desiredOutputByRecipe: const {},
+        effectiveLabour: 500,
+      );
+      expect(affordance.maxDesiredOutput, 5);
+      expect(affordance.limitingLabel, 'Timber');
+    });
+
+    test('applies slider cap when stock and labour are abundant', () {
+      final stockpile = Stockpile(
+        quantities: {
+          CommodityCatalog.grain.id: 20,
+          CommodityCatalog.timber.id: 500,
+        },
+      );
+      const workers = WorkerPool(
+        peasants: 150,
+        apprentices: 0,
+        journeymen: 0,
+        masters: 0,
+      );
+      final effectiveLabour = effectiveLabourForWorkers(
+        workers: workers,
+        stockpile: stockpile,
+      );
+      final affordance = computeRecipeAffordance(
+        recipe: ProductionRecipesCatalog.lumberFromTimber,
+        stockpile: stockpile,
+        desiredOutputByRecipe: const {},
+        effectiveLabour: effectiveLabour,
+      );
+      expect(affordance.maxDesiredOutput, kProductionAllocationSliderCap);
+      expect(affordance.limitingLabel, 'Labour');
+    });
+
+    test('zero remaining labour for recipe yields 0 and Labour', () {
+      final player = fullAvailabilityProductionPlayer();
+      final effectiveLabour = effectiveLabourForWorkers(
+        workers: player.workerPool,
+        stockpile: player.stockpile,
+      );
+      final affordance = computeRecipeAffordance(
+        recipe: ProductionRecipesCatalog.lumberFromTimber,
+        stockpile: player.stockpile,
+        desiredOutputByRecipe: const {'fabric_from_wool': 25},
+        effectiveLabour: effectiveLabour,
+      );
+      expect(affordance.maxDesiredOutput, 0);
+      expect(affordance.limitingLabel, 'Labour');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Adds per-recipe affordance feedback on the Flutter production allocation panel: **right-aligned** `max · bottleneck` on the label row (same **max** as the slider), plus **right-aligned** desired output beside the slider. **max** uses current stockpile minus inputs committed by **other** recipes and effective labour minus labour for **other** recipes, then clamps to `kProductionAllocationSliderCap` (50). **bottleneck** is the limiting commodity display name or **Labour**, with deterministic tie-break (first tied recipe input in map order, else Labour).

## Spec
- `SPEC/ui/production-panel.md`: layout, behaviour, acceptance criteria; icon table deduped (pointer to `game-toolbar-icons.md`) to stay within sub-spec word limit.

## Implementation
- `app/lib/features/game/production_recipe_affordance.dart`: `computeRecipeAffordance`, shared with slider max logic.
- `production_panel.dart`: wired to helper; removed dead local variable.

## Tests
- `app/test/production_recipe_affordance_test.dart`: labour cap, cross-recipe consumption, input tie-break, slider cap, zero headroom.
- `app/test/production_panel_test.dart`: affordance `·` present per recipe.

## Verification
`flutter test` on production affordance, production panel, and production screen integration tests.

Made with [Cursor](https://cursor.com)