### PR TITLE
COL-143: Order-engine: explicit acceptance criteria for projected effects

### DIFF
--- a/SPEC/program/order-engine.md
+++ b/SPEC/program/order-engine.md
@@ -42,9 +42,20 @@ Validation is per-player only. No cross-player conflict resolution at this stage
 
 ## Projected Effects
 
-Supports a **dry-run**: apply orders via the resolver (which returns **new** state); return projected effects for UI (worker count, treasury delta, unit locations, stockpile deltas). The engine does **not** mutate the passed-in game; the caller may pass the live game. No mutation of real state.
+Supports a **dry-run**: apply orders via the resolver (which returns **new** state); return projected effects for UI. The engine does **not** mutate the passed-in game; the caller may pass the live game. No mutation of real state.
 
 `projectedEffects` accepts an optional `tileMapByRegion`. When omitted or empty, the dry-run uses no tile maps and **expected extraction is zero**; callers (e.g. SimGameController) may pass tile maps when available so projected extraction is non-zero. See [order-projections.md](order-projections.md).
+
+### ProjectedEffects fields
+
+| Field | Required for MVP | Implemented |
+|-------|------------------|-------------|
+| `workerCount` | Yes | Yes |
+| `treasuryDelta` | Yes | Yes |
+| `unitLocations` | Yes | Yes |
+| `stockpileDeltas` | Yes | Yes |
+| `productionByRecipe` | No (optional; when `defaultAssignments` provided) | Yes |
+| `extractionByCommodity` | No (optional; deferred) | No |
 
 ---
 
@@ -106,7 +117,7 @@ The OrderEngine validates and stores **move, build, work, diplomatic, naval move
 - **Research orders:** Research orders are **not** added to OrderEngine; they are supplied separately via `Orders.researchOrdersByPlayerId` and validated/applied in the Research phase (TurnResolver).
 - **Caller contract:** The caller (app or ctdev) supplies move/build/work/diplomatic/naval orders via OrderEngine methods; research orders are collected separately and passed to the resolver via `Orders.researchOrdersByPlayerId`.
 - **Merge:** Human + AI orders merged with human over AI for conflicts; ordering is stable for deterministic replay (player id, then conflict key / order type as specified).
-- **Projected effects:** Dry-run returns worker count, treasury delta, and when implemented unit locations and stockpile deltas for UI; no mutation of the passed-in game from the caller's perspective.
+- **Projected effects:** Dry-run returns `ProjectedEffects` with worker count, treasury delta, unit locations, and stockpile deltas (all required for MVP and implemented); no mutation of the passed-in game from the caller's perspective. See § ProjectedEffects fields for the full list and implementation status.
 - **No application:** Order engine does not apply orders to world state; TurnResolver applies after merge.
 - **Move validation (extracted):** Given a move order that violates civilian-into-GP or civilian-into-Minor/Tribe rules (per [orders.md](orders.md)), when validated with context, the result is rejected with reason "Civilian cannot enter other Great Power territory" or "Civilian cannot enter Minor/Tribe territory" as applicable. Military moves into GP or Minor/Tribe provinces without war (or same-turn declareWar) are rejected with the appropriate "Must declare war before attacking..." reason.
 - **Work order cost (single source):** Given work orders with material costs, when validated and when projecting effects in the same pass, the same cost calculation is used via WorkOrderCostCalculator (single source of truth).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves COL-143: replaces the vague "when implemented" phrasing in the order-engine projected-effects acceptance criterion with an explicit, testable list.

## Changes

- **Added § ProjectedEffects fields** table in `SPEC/program/order-engine.md`:
  - Lists all six fields of `ProjectedEffects`
  - Marks each as required for MVP or optional
  - Marks each as implemented or not

- **Updated acceptance criterion** bullet:
  - Explicitly names the four MVP fields (worker count, treasury delta, unit locations, stockpile deltas)
  - States they are required for MVP and implemented
  - References § ProjectedEffects fields for the full list and implementation status

- **Added implementation plan** `SPEC/project/impl-extraction-by-commodity.md`:
  - Follow-up plan for implementing `extractionByCommodity` (field exists but not populated)
  - Describes logic changes, tests, spec updates, app provider flow, and production panel UI (+x indicator)
  - For use when creating the follow-up Linear issue

## Implementation status (from codebase)

| Field | Required for MVP | Implemented |
|-------|------------------|-------------|
| workerCount | Yes | Yes |
| treasuryDelta | Yes | Yes |
| unitLocations | Yes | Yes |
| stockpileDeltas | Yes | Yes |
| productionByRecipe | No | Yes (when defaultAssignments provided) |
| extractionByCommodity | No | No (deferred) |

Supports testability and closure of #62/#66.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [COL-143](https://linear.app/colonizethisv3/issue/COL-143/order-engine-explicit-acceptance-criteria-for-projected-effects)

<div><a href="https://cursor.com/agents/bc-22f13da6-7c19-4a93-b52d-b6f8d7efe43d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22f13da6-7c19-4a93-b52d-b6f8d7efe43d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

