### PR TITLE
ci: run flutter analyze in app_tests_cache before shard tests

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -39,9 +39,9 @@ jobs:
               - 'tool/sim_economy/**'
               - 'tool/show_tech/**'
 
-  # One resolved pub cache + workspace .dart_tool + gen-l10n output; shards reuse via --no-pub.
+  # Resolved pub cache + .dart_tool + gen-l10n; flutter analyze gate; then pack for shards (--no-pub).
   app_tests_cache:
-    name: App test cache (deps + l10n)
+    name: App test cache (deps + l10n + analyze)
     needs: changes
     if: needs.changes.outputs.tests == 'true'
     runs-on: ubuntu-latest
@@ -66,6 +66,20 @@ jobs:
           set -e
           cd app
           flutter gen-l10n
+
+      - name: Compile app entrypoints (Flutter analyze)
+        run: |
+          set -e
+          if [ -d app ]; then
+            cd app
+            output=$(flutter analyze 2>&1 || true)
+            echo "$output"
+            error_count=$(echo "$output" | grep -c "^[[:space:]]*error" || true)
+            if [ "$error_count" -gt 0 ]; then
+              echo "Errors found: $error_count"
+              exit 1
+            fi
+          fi
 
       - name: Pack cache for test shards
         run: |
@@ -269,20 +283,6 @@ jobs:
                 cat lib/l10n/untranslated.json
                 exit 1
               fi
-            fi
-          fi
-
-      - name: Compile app entrypoints (Flutter analyze)
-        if: needs.changes.outputs.tests == 'true'
-        run: |
-          if [ -d app ]; then
-            cd app
-            output=$(flutter analyze 2>&1 || true)
-            echo "$output"
-            error_count=$(echo "$output" | grep -c "^[[:space:]]*error" || true)
-            if [ "$error_count" -gt 0 ]; then
-              echo "Errors found: $error_count"
-              exit 1
             fi
           fi
 

--- a/tool/run_quality_gate_tests.sh
+++ b/tool/run_quality_gate_tests.sh
@@ -23,6 +23,21 @@ for dir in packages/colonizethis_models packages/colonizethis_data packages/colo
 done
 
 echo ""
+echo "=== App localizations + analyze (before app tests; CI: app_tests_cache job) ==="
+if [ -d app ]; then
+  (cd app && flutter gen-l10n)
+  cd app
+  output=$(flutter analyze 2>&1 || true)
+  echo "$output"
+  error_count=$(echo "$output" | grep -c "^[[:space:]]*error" || true)
+  cd "$ROOT"
+  if [ "${error_count:-0}" -gt 0 ]; then
+    echo "Errors found: $error_count"
+    exit 1
+  fi
+fi
+
+echo ""
 echo "=== Test app (Flutter) ==="
 # CI runs sharded app tests with a shared deps artifact (.github/workflows/quality.yml).
 # Locally: single process is enough; use the same flags as shards for parity.
@@ -53,20 +68,6 @@ for dir in tool/sim_scenarios tool/sim_combat_montecarlo tool/sim_combat tool/ge
   (cd "$dir" && dart test --coverage=coverage -j 4 --reporter=compact)
   (cd "$dir" && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
 done
-
-echo ""
-echo "=== Compile app entrypoints (Flutter analyze) ==="
-if [ -d app ]; then
-  cd app
-  output=$(flutter analyze 2>&1 || true)
-  echo "$output"
-  error_count=$(echo "$output" | grep -c "^[[:space:]]*error" || true)
-  cd "$ROOT"
-  if [ "${error_count:-0}" -gt 0 ]; then
-    echo "Errors found: $error_count"
-    exit 1
-  fi
-fi
 
 echo ""
 echo "=== Coverage gate (logic/map/ai >= 90%) ==="


### PR DESCRIPTION
## Summary

Moves **`flutter analyze`** from the **`quality`** job into **`app_tests_cache`**, immediately after **`flutter gen-l10n`** and **before** packing the cache artifact. App test shards only start if analyze passes, which avoids spending shard time when the app has analyzer errors.

Removes the duplicate analyze step from **`quality`**.

Updates **`tool/run_quality_gate_tests.sh`** so local runs use **`gen-l10n` + `analyze`** right before **`flutter test`**, matching the cache job ordering.

## Notes

- Analyze still runs only when the `tests` path filter is true (unchanged scope).
- The **`quality`** job continues to run the **App localization gate** (untranslated check) after package/tool tests.