### PR TITLE
fix(app): open Hive boxes independently (games box not skipped)

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,22 +1,31 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:logger/logger.dart';
 import 'package:session_log_buffer/session_log_buffer.dart';
 
 import 'app.dart';
 import 'config/constants.dart';
 import 'core/services/app_event_handler_scope.dart';
 
+final _log = Logger();
+
+/// Opens one Hive box; failures are isolated so another box (e.g. games) still opens.
+Future<void> _openHiveBoxSafely(String name) async {
+  try {
+    await Hive.openBox<dynamic>(name);
+  } catch (e, st) {
+    // Boxes may be locked (e.g. another instance) or corrupt; app still runs where possible.
+    _log.w('data:hive: failed to open box "$name"', error: e, stackTrace: st);
+  }
+}
+
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   SessionLogBuffer.init();
   await Hive.initFlutter();
-  try {
-    await Hive.openBox(HiveBoxNames.settings);
-    await Hive.openBox(HiveBoxNames.games);
-    await Hive.openBox(HiveBoxNames.offlineQueue);
-  } catch (_) {
-    // Phase 0: stub wiring; boxes may be locked (e.g. another instance). App still runs.
-  }
+  await _openHiveBoxSafely(HiveBoxNames.settings);
+  await _openHiveBoxSafely(HiveBoxNames.games);
+  await _openHiveBoxSafely(HiveBoxNames.offlineQueue);
   runApp(const ProviderScope(child: AppEventHandlerScope(child: App())));
 }


### PR DESCRIPTION
## Summary

Fixes **HiveError: Box not found** when tapping **Start game** on the leader selection dialog.

## Root cause

`main()` wrapped all `Hive.openBox` calls in a single `try/catch`. If opening `settings` or `offline_queue` failed, `games` was never opened, but the app still ran. `gameServiceProvider` → `gamesBoxProvider` then called `Hive.box(games)` and threw.

## Change

- Open each Hive box in its own `_openHiveBoxSafely` helper so one failure does not skip the others.
- Log failures with prefix `data:hive:` and pass `error` / `stackTrace` (no silent swallow).

## Testing

- Manual: new game flow from leader selection after a clean launch.
- If `games` itself fails to open, the warning log will name the box; that case still needs user-visible handling separately.