### PR TITLE
fix(ui): persist train civilians queue across dialog reopen

### DIFF
--- a/app/lib/core/services/app_event_handler_scope.dart
+++ b/app/lib/core/services/app_event_handler_scope.dart
@@ -28,6 +28,45 @@ const String newGameLeaderSelectionDialogId = 'new_game_leader_selection';
 
 final _log = Logger();
 
+/// Replaces pending train-at-capital civilian [BuildUnitOrder]s for [humanPlayerId];
+/// keeps military, naval, and other build orders. Matches [TrainCiviliansDialog] semantics.
+Orders _mergeTrainCivilianOrdersForPlayer({
+  required Orders current,
+  required Game game,
+  required String humanPlayerId,
+  required List<BuildUnitOrder> newFromDialog,
+}) {
+  Player? player;
+  for (final p in game.players) {
+    if (p.id == humanPlayerId) {
+      player = p;
+      break;
+    }
+  }
+  final capital = player?.capitalProvinceId;
+  final civilianUnitIds = CivilianEconomyCatalog.byId.keys.toSet();
+  final existingList =
+      current.buildUnitOrdersByPlayerId[humanPlayerId] ?? const <BuildUnitOrder>[];
+  final kept = <BuildUnitOrder>[];
+  for (final order in existingList) {
+    final isDialogManaged =
+        !order.isMilitary &&
+        civilianUnitIds.contains(order.unitType) &&
+        capital != null &&
+        order.spawnProvinceId == capital;
+    if (isDialogManaged) {
+      continue;
+    }
+    kept.add(order);
+  }
+  return current.copyWith(
+    buildUnitOrdersByPlayerId: {
+      ...current.buildUnitOrdersByPlayerId,
+      humanPlayerId: [...kept, ...newFromDialog],
+    },
+  );
+}
+
 /// Binds [AppEventHandler] to [appNavigatorKey] for the app lifetime.
 /// SPEC/program/app-event-bus.md (handler); SPEC/program/app-ui-wiring.md (dialog registration).
 class AppEventHandlerScope extends ConsumerStatefulWidget {
@@ -109,12 +148,12 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
             currentOrders: orders,
             onOrdersChanged: (newOrders) {
               final o = container.read(currentOrdersProvider);
-              final existing = o.buildUnitOrdersByPlayerId[humanPlayerId] ?? [];
-              container.read(currentOrdersProvider.notifier).state = o.copyWith(
-                buildUnitOrdersByPlayerId: {
-                  ...o.buildUnitOrdersByPlayerId,
-                  humanPlayerId: [...existing, ...newOrders],
-                },
+              container.read(currentOrdersProvider.notifier).state =
+                  _mergeTrainCivilianOrdersForPlayer(
+                current: o,
+                game: game,
+                humanPlayerId: humanPlayerId,
+                newFromDialog: newOrders,
               );
             },
           );

--- a/app/lib/features/game/widgets/train_civilians_dialog.dart
+++ b/app/lib/features/game/widgets/train_civilians_dialog.dart
@@ -31,7 +31,25 @@ class _TrainCiviliansDialogState extends State<TrainCiviliansDialog> {
   @override
   void initState() {
     super.initState();
-    _counts = {for (final e in CivilianEconomyCatalog.all) e.id: 0};
+    _counts = _initialCountsFromOrders();
+  }
+
+  /// Counts pending train-at-capital civilian builds from [widget.currentOrders].
+  Map<String, int> _initialCountsFromOrders() {
+    final next = {for (final e in CivilianEconomyCatalog.all) e.id: 0};
+    final capital = _player?.capitalProvinceId;
+    if (capital == null) return next;
+    final civilianIds = CivilianEconomyCatalog.byId.keys.toSet();
+    final list =
+        widget.currentOrders.buildUnitOrdersByPlayerId[widget.humanPlayerId] ??
+        const <BuildUnitOrder>[];
+    for (final o in list) {
+      if (o.isMilitary) continue;
+      if (!civilianIds.contains(o.unitType)) continue;
+      if (o.spawnProvinceId != capital) continue;
+      next[o.unitType] = (next[o.unitType] ?? 0) + 1;
+    }
+    return next;
   }
 
   Player? get _player {
@@ -141,84 +159,89 @@ class _TrainCiviliansDialogState extends State<TrainCiviliansDialog> {
 
   @override
   Widget build(BuildContext context) {
-    return CtDialogShell(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 16, 8, 8),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    'Train Civilians',
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                ),
-                IconButton(
-                  icon: const Icon(Icons.close),
-                  onPressed: () {
-                    _applyOrders();
-                    Navigator.of(context).pop();
-                  },
-                ),
-              ],
-            ),
-          ),
-          const Divider(height: 1),
-          if (!_hasCapital)
+    return PopScope(
+      canPop: true,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) {
+          _applyOrders();
+        }
+      },
+      child: CtDialogShell(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
             Padding(
-              padding: const EdgeInsets.all(16),
-              child: Text(
-                'No capital set — cannot train units',
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: Theme.of(context).colorScheme.error,
-                ),
-              ),
-            )
-          else ...[
-            _ResourceBar(
-              treasury: _treasury,
-              paperStockpile: _paperStockpile,
-              deficitHint: _deficitHint,
-            ),
-            const Divider(height: 1),
-            Flexible(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.symmetric(vertical: 8),
-                child: Column(
-                  children: [
-                    for (final econ in CivilianEconomyCatalog.all)
-                      _UnitTypeRow(
-                        econ: econ,
-                        count: _counts[econ.id] ?? 0,
-                        isLocked: _isLocked(econ.id),
-                        techRequiredLabel: _techRequiredLabel(econ.id),
-                        canIncrement: _canAffordIncrement(econ.id),
-                        canDecrement: (_counts[econ.id] ?? 0) > 0,
-                        onIncrement: () => _increment(econ.id),
-                        onDecrement: () => _decrement(econ.id),
-                      ),
-                  ],
-                ),
-              ),
-            ),
-            const Divider(height: 1),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+              padding: const EdgeInsets.fromLTRB(16, 16, 8, 8),
               child: Row(
-                mainAxisAlignment: MainAxisAlignment.end,
                 children: [
-                  CtNinePatchButton(
-                    onPressed: _reset,
-                    child: const Text('Reset'),
+                  Expanded(
+                    child: Text(
+                      'Train Civilians',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    onPressed: () => Navigator.of(context).pop(),
                   ),
                 ],
               ),
             ),
+            const Divider(height: 1),
+            if (!_hasCapital)
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  'No capital set — cannot train units',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.error,
+                  ),
+                ),
+              )
+            else ...[
+              _ResourceBar(
+                treasury: _treasury,
+                paperStockpile: _paperStockpile,
+                deficitHint: _deficitHint,
+              ),
+              const Divider(height: 1),
+              Flexible(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  child: Column(
+                    children: [
+                      for (final econ in CivilianEconomyCatalog.all)
+                        _UnitTypeRow(
+                          econ: econ,
+                          count: _counts[econ.id] ?? 0,
+                          isLocked: _isLocked(econ.id),
+                          techRequiredLabel: _techRequiredLabel(econ.id),
+                          canIncrement: _canAffordIncrement(econ.id),
+                          canDecrement: (_counts[econ.id] ?? 0) > 0,
+                          onIncrement: () => _increment(econ.id),
+                          onDecrement: () => _decrement(econ.id),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+              const Divider(height: 1),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    CtNinePatchButton(
+                      onPressed: _reset,
+                      child: const Text('Reset'),
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ],
-        ],
+        ),
       ),
     );
   }

--- a/app/test/train_civilians_dialog_test.dart
+++ b/app/test/train_civilians_dialog_test.dart
@@ -125,6 +125,44 @@ void main() {
       expect(minusButtons, findsNWidgets(CivilianEconomyCatalog.all.length));
     });
 
+    testWidgets(
+      'AC: Steppers reflect existing train-at-capital civilian build orders',
+      (WidgetTester tester) async {
+        final richGame = gameWithResources(treasury: 10000, paper: 100);
+        final player = getPlayer(humanPlayerId);
+        final capital =
+            player.capitalProvinceId ?? player.capitalTile?.provinceId;
+        expect(capital, isNotNull, reason: 'debug game needs capital');
+        final cap = capital!;
+        final orders = Orders(
+          buildUnitOrdersByPlayerId: {
+            humanPlayerId: [
+              BuildUnitOrder(
+                unitType: 'Builder',
+                isMilitary: false,
+                spawnProvinceId: cap,
+              ),
+              BuildUnitOrder(
+                unitType: 'Builder',
+                isMilitary: false,
+                spawnProvinceId: cap,
+              ),
+            ],
+          },
+        );
+        await tester.pumpWidget(
+          buildDialog(
+            game: richGame,
+            humanPlayerId: humanPlayerId,
+            currentOrders: orders,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('2'), findsWidgets);
+      },
+    );
+
     testWidgets('AC: Tapping + increments the count', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
## Summary

Train Civilians dialog steppers always reset to zero on reopen even when `currentOrdersProvider` still held pending civilian build orders. Closing via the modal barrier also skipped committing orders.

## Changes

- **Hydrate** stepper counts from existing civilian `BuildUnitOrder`s at the player capital when the dialog opens.
- **PopScope**: run `_applyOrders` on any successful pop (close button, back, barrier tap); close button only pops.
- **Merge**: replace train-at-capital civilian build orders for the human player instead of appending duplicates each close (`_mergeTrainCivilianOrdersForPlayer` in `app_event_handler_scope.dart`).

## Tests

- Widget test: existing train-at-capital Builder orders show correct stepper count on open.

## Spec

Aligns with SPEC/ui/train-civilians-dialog.md (orders in `buildUnitOrdersByPlayerId`; apply on close).

Made with [Cursor](https://cursor.com)