### PR TITLE
feat(map): land province name labels + display toggle

### DIFF
--- a/SPEC/ui/empire-overview.md
+++ b/SPEC/ui/empire-overview.md
@@ -44,9 +44,9 @@
 
 - **Overlay:** A third button is overlaid at the **top-left** of the map area, directly **beneath** the home-to-capital button. Icon only: pixel-art gear icon (`ui_icon_map_options.png` from [game-toolbar-icons.md](game-toolbar-icons.md)). The button is shown only on the in-game Empire overview map, not in Widgetbook or debug map stories.
 - **Dialog type:** Tapping the button opens a modal **“Map display options”** dialog that blocks interaction with the underlying map and closes when the user taps the dialog’s **Close** button, taps outside the dialog, or presses the back key.
-- **Borders toggle:** The dialog contains a single toggle control labelled **“Show borders”** (switch or checkbox). The toggle controls the global **borders layer visibility** for all in-game Empire overview maps in the current app session (Old World and New World).
-- **Default behavior:** At the start of a game session (after init or load), the **Show borders** toggle is **ON** by default. When the user changes it, the new value is remembered for the remainder of the session and is reflected every time the dialog is reopened.
-- **Effect on rendering:** When **Show borders** is ON, the map widget draws province and sea-zone boundary strokes per [map-widget.md](map-widget.md) § Layer model. When OFF, province and sea-zone boundary strokes are not drawn; hover selectors, hover province glows, capitals, ports, and warp zone indicators remain visible.
+- **Toggles:** The dialog contains **two** independent toggles (switch or checkbox): **“Show borders”** and **“Show province names”**. Each controls its own global layer for all in-game Empire overview maps in the current session (Old World and New World). Neither toggle affects the other.
+- **Default behavior:** At the start of a game session (after init or load), **Show borders** and **Show province names** are both **ON** by default. When the user changes either toggle, the new values are remembered for the remainder of the session and are reflected every time the dialog is reopened.
+- **Effect on rendering:** When **Show borders** is ON, the map widget draws province and sea-zone boundary strokes per [map-widget.md](map-widget.md) § Layer model. When OFF, those strokes are not drawn; hover selectors, hover province glows, capitals, ports, warp zone indicators, and (per the province-names toggle) labels remain according to their own toggle. When **Show province names** is ON, land province labels are drawn per [map-widget.md](map-widget.md) § Layer model (province names row). When OFF, no province name labels are drawn.
 
 ---
 
@@ -86,9 +86,12 @@ On mobile: same tab row; map area fills available space; one region visible at a
 
 - **Given** the Empire overview map is visible, **then** a third icon-only button with the gear icon is visible directly beneath the home-to-capital button at the top-left of the map area.
 - **Given** the Empire overview map is visible, **when** the user taps the third map display options button, **then** the UI layer shows a modal dialog titled `Map display options` with a dismiss action and the underlying map is not interactive until the dialog is closed.
-- **Given** the Map display options dialog is visible for the first time in a game session, **then** the dialog shows a single toggle control labelled `Show borders` in the ON state.
+- **Given** the Map display options dialog is visible for the first time in a game session, **then** the dialog shows toggle controls labelled `Show borders` and `Show province names`, both in the ON state.
 - **Given** the Map display options dialog is visible, **when** the user toggles `Show borders` OFF, **then** the UI layer updates the global borders visibility state so that all in-game Empire overview maps stop drawing province and sea-zone boundary strokes until `Show borders` is toggled ON again.
 - **Given** the user has toggled `Show borders` OFF in the Map display options dialog and then closed the dialog, **when** the user reopens the Map display options dialog in the same app session, **then** the `Show borders` toggle appears in the OFF state and the in-game maps continue to omit province and sea-zone boundary strokes.
+- **Given** the Map display options dialog is visible, **when** the user toggles `Show province names` OFF, **then** the UI layer updates global state so all in-game Empire overview maps stop drawing land province name labels until the toggle is ON again.
+- **Given** the user has toggled `Show province names` OFF and closed the dialog, **when** they reopen the dialog in the same session, **then** the `Show province names` toggle appears OFF and maps continue to omit province name labels.
+- **Given** `Show borders` is OFF and `Show province names` is ON, **when** the map renders, **then** province name labels are still visible (no dependency on the borders toggle).
 
 ---
 

--- a/SPEC/ui/map-widget.md
+++ b/SPEC/ui/map-widget.md
@@ -22,6 +22,7 @@
 | **Base (tile)** | Terrain, resources, improvements, towns, capitals. | Optional per-sublayer if needed; at minimum base is always on. |
 | **Borders** | Province and sea-zone boundaries (topology edges P–P, P–S, S–S). | Yes. User can turn the borders layer on/off. |
 | **Political** | Political borders (ownership differences between adjacent land provinces). Drawn on top of base and borders. | Yes. User can turn political overlay on/off. |
+| **Province names** | Land province labels: `CellViewData.provinceDisplayName` (same string as the Political section in the province detail overlay), with fallback to local province id when missing. One label per land province per region. Position: centroid of that province’s **land** tiles in the region (tile centers averaged). **Not** drawn for sea zones. **Player-constrained visibility:** only tiles that are not `unrevealed` participate in the centroid and get a label; if no qualifying tiles, no label. **Screen space:** text and backing plate use roughly **constant logical pixel size** regardless of map zoom (inverse scale in world space). Style: short label on a semi-transparent rectangular plate; neighbor overlap is acceptable. Rendered after province/political border strokes and before capitals/ports. | Yes. Independent of borders and political overlay toggles. |
 
 Data source for tiles and ownership: shared view model (e.g. `RegionMapViewData` / game + tile maps per [map-visualization.md](../program/map-visualization.md)). Province and tile identity: [world-model-identity.md](../game/world-model-identity.md).
 
@@ -281,7 +282,10 @@ If a tileset fails to load, the widget falls back to solid color rendering using
 
 - **Given** a map widget with a region's data, **when** the widget is laid out, **then** the viewport matches the widget size and shows the base tile layer (terrain, resources, improvements, towns, capitals) at the current zoom level.
 - **Given** the borders layer is enabled, **when** the map renders province and sea-zone boundaries, **then** land↔sea-zone edges use a subtle/fainter stroke (instead of a solid black line) and other province/sea-zone borders are rendered subtly (not solid black).
-- **Given** the borders layer is disabled, **when** the map renders the region, **then** province and sea-zone boundary strokes are not drawn while hover selectors, hover glows, capitals, ports, and warp zone indicators remain visible.
+- **Given** the borders layer is disabled, **when** the map renders the region, **then** province and sea-zone boundary strokes are not drawn while hover selectors, hover glows, capitals, ports, warp zone indicators, and (if enabled) province name labels remain visible.
+- **Given** the province names layer is enabled, **when** the map renders land provinces, **then** each land province has at most one label at the centroid of its land tiles (subject to visibility rules above), using `provinceDisplayName` with local-id fallback, on a semi-transparent plate, with roughly constant on-screen size across zoom levels.
+- **Given** the province names layer is disabled, **when** the map renders, **then** no province name labels are drawn.
+- **Given** the province names layer is enabled and the borders layer is disabled, **when** the map renders, **then** province name labels are still drawn (no dependency on borders).
 - **Given** the political overlay is enabled while the borders layer is enabled, **when** two adjacent land tiles belong to different owning factions, **then** a thicker political border stroke is drawn between them on top of the province/sea-zone boundary stroke.
 - **Given** the political overlay is disabled, **when** the map renders adjacent land tiles with different owning factions, **then** no political border stroke is drawn between them regardless of the borders layer setting.
 - **When** the user pans, **then** the visible portion of the map updates; the full map remains pannable within the fixed scale.

--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -249,6 +249,7 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
   @override
   Widget build(BuildContext context) {
     final showBorders = ref.watch(mapBordersVisibleProvider);
+    final showProvinceNames = ref.watch(mapProvinceNamesVisibleProvider);
     final isNarrow = MediaQuery.sizeOf(context).width < kInGameNarrowBreakpoint;
     final l10n = appL10n(context);
     final nextTurnText = l10n.game_nextTurnButton(
@@ -290,6 +291,7 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
                   region: _currentRegion,
                   baseLayerDisplayMode: _baseLayerDisplayMode,
                   showBordersLayer: showBorders,
+                  showProvinceNamesLayer: showProvinceNames,
                   humanPlayerId: _humanPlayerId,
                   selectedDetailId: _selectedDetailId,
                   displayId: _displayId,
@@ -334,18 +336,43 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
                                 final bordersVisible = ref.watch(
                                   mapBordersVisibleProvider,
                                 );
-                                return SwitchListTile(
-                                  title: Text(l10n.map_displayOptions_showBorders),
-                                  value: bordersVisible,
-                                  onChanged: (value) {
-                                    ref
-                                            .read(
-                                              mapBordersVisibleProvider
-                                                  .notifier,
-                                            )
-                                            .state =
-                                        value;
-                                  },
+                                final namesVisible = ref.watch(
+                                  mapProvinceNamesVisibleProvider,
+                                );
+                                return Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    SwitchListTile(
+                                      title: Text(
+                                        l10n.map_displayOptions_showBorders,
+                                      ),
+                                      value: bordersVisible,
+                                      onChanged: (value) {
+                                        ref
+                                                .read(
+                                                  mapBordersVisibleProvider
+                                                      .notifier,
+                                                )
+                                                .state =
+                                            value;
+                                      },
+                                    ),
+                                    SwitchListTile(
+                                      title: Text(
+                                        l10n.map_displayOptions_showProvinceNames,
+                                      ),
+                                      value: namesVisible,
+                                      onChanged: (value) {
+                                        ref
+                                                .read(
+                                                  mapProvinceNamesVisibleProvider
+                                                      .notifier,
+                                                )
+                                                .state =
+                                            value;
+                                      },
+                                    ),
+                                  ],
                                 );
                               },
                             ),

--- a/app/lib/features/game/flame/game_map_canvas_stack.dart
+++ b/app/lib/features/game/flame/game_map_canvas_stack.dart
@@ -16,6 +16,7 @@ class GameMapCanvasStack extends StatelessWidget {
     required this.region,
     required this.baseLayerDisplayMode,
     required this.showBordersLayer,
+    required this.showProvinceNamesLayer,
     required this.humanPlayerId,
     required this.selectedDetailId,
     required this.displayId,
@@ -38,6 +39,7 @@ class GameMapCanvasStack extends StatelessWidget {
   final RegionMapViewData region;
   final BaseLayerDisplayMode baseLayerDisplayMode;
   final bool showBordersLayer;
+  final bool showProvinceNamesLayer;
   final String humanPlayerId;
   final String? selectedDetailId;
   final String displayId;
@@ -69,6 +71,7 @@ class GameMapCanvasStack extends StatelessWidget {
                   region: region,
                   cellSizePx: 24,
                   showBordersLayer: showBordersLayer,
+                  showProvinceNamesLayer: showProvinceNamesLayer,
                   visibilityMode: CtMapVisibilityMode.playerConstrained,
                   baseLayerDisplayMode: baseLayerDisplayMode,
                   onProvinceSelected: onProvinceSelected,

--- a/app/lib/features/game/flame/region_map_component.dart
+++ b/app/lib/features/game/flame/region_map_component.dart
@@ -20,6 +20,12 @@ const Color _provinceBorderLandColor = Color.fromRGBO(0, 0, 0, 0.35);
 const Color _provinceBorderSeaLandColor = Color.fromRGBO(0, 0, 0, 0.25);
 const Color _provinceBorderSeaZoneColor = Color.fromRGBO(130, 200, 255, 0.55);
 
+/// Land province labels: max text width and font size in **logical pixels** (screen space).
+const double _provinceLabelMaxWidthPx = 120;
+const double _provinceLabelFontSizePx = 11;
+const double _provinceLabelPlatePaddingPx = 4;
+const Color _provinceLabelPlateColor = Color.fromRGBO(0, 0, 0, 0.55);
+
 /// Check if a terrain type uses L2+ standalone tile rendering (features).
 /// L0: Sea (Wang). L1: Plains/Desert (Wang). L2+: Features (standalone).
 bool _isFeatureTerrain(TerrainType terrain) {
@@ -89,6 +95,7 @@ class CtRegionMapComponent extends PositionComponent {
     required this.cellSize,
     required this.showPoliticalOverlay,
     required this.showBordersLayer,
+    required this.showProvinceNamesLayer,
     required this.visibilityMode,
     this.baseLayerDisplayMode =
         BaseLayerDisplayMode.terrainResourcesImprovements,
@@ -104,7 +111,11 @@ class CtRegionMapComponent extends PositionComponent {
   double cellSize;
   bool showPoliticalOverlay;
   bool showBordersLayer;
+  bool showProvinceNamesLayer;
   CtMapVisibilityMode visibilityMode;
+
+  /// Camera zoom from Flame viewfinder; used to keep label size constant on screen.
+  double cameraZoom = 1.0;
   BaseLayerDisplayMode baseLayerDisplayMode;
   void Function(String provinceId)? onProvinceSelected;
   void Function(String? provinceId)? onProvinceHovered;
@@ -117,6 +128,11 @@ class CtRegionMapComponent extends PositionComponent {
   int? _hoveredTileY;
   String? _hoveredProvinceId;
   double _hoverAnimationT = 0.0;
+
+  RegionMapViewData? _provinceLabelsRegionRef;
+  double? _provinceLabelsCellSize;
+  CtMapVisibilityMode? _provinceLabelsVisibilityMode;
+  List<({double cx, double cy, String text})>? _provinceLabelsCached;
 
   @override
   Future<void> onLoad() async {
@@ -221,6 +237,9 @@ class CtRegionMapComponent extends PositionComponent {
     if (showPoliticalOverlay && showBordersLayer) {
       _paintFactionBorders(canvas);
     }
+    if (showProvinceNamesLayer) {
+      _paintProvinceNames(canvas);
+    }
     _paintCapitals(canvas);
     _paintPorts(canvas);
     _paintWarpZones(canvas);
@@ -274,6 +293,105 @@ class CtRegionMapComponent extends PositionComponent {
       ..strokeWidth = 2.5
       ..color = const Color(0xFFFFAA00);
     canvas.drawRect(rect, paint);
+  }
+
+  void _ensureProvinceLabelCache() {
+    if (identical(_provinceLabelsRegionRef, region) &&
+        _provinceLabelsCellSize == cellSize &&
+        _provinceLabelsVisibilityMode == visibilityMode &&
+        _provinceLabelsCached != null) {
+      return;
+    }
+    _provinceLabelsRegionRef = region;
+    _provinceLabelsCellSize = cellSize;
+    _provinceLabelsVisibilityMode = visibilityMode;
+    _provinceLabelsCached = _computeProvinceLabels();
+  }
+
+  List<({double cx, double cy, String text})> _computeProvinceLabels() {
+    final byLocalId = <String, List<CellViewData>>{};
+    for (final cell in region.cells) {
+      if (cell.isSea) continue;
+      if (visibilityMode == CtMapVisibilityMode.playerConstrained &&
+          cell.visibility == TileVisibility.unrevealed) {
+        continue;
+      }
+      byLocalId.putIfAbsent(cell.regionCellId, () => []).add(cell);
+    }
+    final out = <({double cx, double cy, String text})>[];
+    for (final e in byLocalId.entries) {
+      final cells = e.value;
+      if (cells.isEmpty) continue;
+      var sx = 0.0;
+      var sy = 0.0;
+      for (final c in cells) {
+        sx += (c.x + 0.5) * cellSize;
+        sy += (c.y + 0.5) * cellSize;
+      }
+      final n = cells.length;
+      final cx = sx / n;
+      final cy = sy / n;
+      String? name;
+      for (final c in cells) {
+        final dn = c.provinceDisplayName;
+        if (dn != null && dn.isNotEmpty) {
+          name = dn;
+          break;
+        }
+      }
+      final text = name ?? e.key;
+      out.add((cx: cx, cy: cy, text: text));
+    }
+    return out;
+  }
+
+  void _paintProvinceNames(Canvas canvas) {
+    _ensureProvinceLabelCache();
+    final labels = _provinceLabelsCached;
+    if (labels == null || labels.isEmpty) {
+      return;
+    }
+
+    final invZ = 1.0 / cameraZoom.clamp(0.25, 4.0);
+    const textStyle = TextStyle(
+      color: Colors.white,
+      fontSize: _provinceLabelFontSizePx,
+      fontWeight: FontWeight.w600,
+      shadows: <Shadow>[
+        Shadow(
+          blurRadius: 2,
+          color: Color(0x8A000000),
+          offset: Offset(0.5, 0.5),
+        ),
+      ],
+    );
+    final platePaint = Paint()..color = _provinceLabelPlateColor;
+
+    for (final item in labels) {
+      final tp = TextPainter(
+        text: TextSpan(text: item.text, style: textStyle),
+        textDirection: TextDirection.ltr,
+        maxLines: 3,
+        ellipsis: '…',
+      )..layout(maxWidth: _provinceLabelMaxWidthPx);
+
+      final tw = tp.width;
+      final th = tp.height;
+      const pad = _provinceLabelPlatePaddingPx;
+      final bw = tw + pad * 2;
+      final bh = th + pad * 2;
+
+      canvas.save();
+      canvas.translate(item.cx, item.cy);
+      canvas.scale(invZ);
+      final rect = RRect.fromRectAndRadius(
+        Rect.fromCenter(center: Offset.zero, width: bw, height: bh),
+        const Radius.circular(4),
+      );
+      canvas.drawRRect(rect, platePaint);
+      tp.paint(canvas, Offset(-tw / 2, -th / 2));
+      canvas.restore();
+    }
   }
 
   void _paintTiles(Canvas canvas) {

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -122,6 +122,11 @@
     "description": "Toggle label for showing map borders."
   },
 
+  "map_displayOptions_showProvinceNames": "Show province names",
+  "@map_displayOptions_showProvinceNames": {
+    "description": "Toggle label for showing land province names on the map."
+  },
+
   "common_close": "Close",
   "@common_close": {
     "description": "Generic Close button label or tooltip."

--- a/app/lib/providers/map_view_provider.dart
+++ b/app/lib/providers/map_view_provider.dart
@@ -10,6 +10,10 @@ import 'games_provider.dart';
 /// Defaults to true at app start; updated via the Map display options dialog.
 final mapBordersVisibleProvider = StateProvider<bool>((ref) => true);
 
+/// Global land province name labels on in-game Empire overview maps.
+/// Independent of [mapBordersVisibleProvider]. Defaults to true at app start.
+final mapProvinceNamesVisibleProvider = StateProvider<bool>((ref) => true);
+
 /// Map view data for the current game with player-constrained visibility.
 /// Null when no game, no map data (legacy save), or loading.
 final mapViewDataProvider = Provider<InitGameMapViewData?>((ref) {

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -788,6 +788,7 @@ class _CivilianPanelWithMapStoryState
   String? _centerOnTileKey;
   ({Unit unit, String workTarget})? _workTargetSelection;
   CtMapVisibilityMode _visibilityMode = CtMapVisibilityMode.full;
+  bool _showProvinceNames = true;
   Set<String>? _cachedValidTileKeys;
   String? _cachedWorkTargetSelection;
 
@@ -976,6 +977,16 @@ class _CivilianPanelWithMapStoryState
                         _visibilityMode = CtMapVisibilityMode.playerConstrained,
                   ),
                 ),
+                CtChoiceChip(
+                  label: const Text('Province names'),
+                  selected: _showProvinceNames,
+                  onSelected: (_) => setState(() => _showProvinceNames = true),
+                ),
+                CtChoiceChip(
+                  label: const Text('No province names'),
+                  selected: !_showProvinceNames,
+                  onSelected: (_) => setState(() => _showProvinceNames = false),
+                ),
               ],
             ),
           ),
@@ -984,6 +995,7 @@ class _CivilianPanelWithMapStoryState
               region: region,
               cellSizePx: 24,
               visibilityMode: _visibilityMode,
+              showProvinceNamesLayer: _showProvinceNames,
               onProvinceSelected: (_) {},
               highlightedTileKey: _highlightedTileKey,
               centerOnTileKey: _centerOnTileKey,
@@ -1100,6 +1112,7 @@ class _MilitaryPanelWithMapStoryState
   int _regionIndex = 0;
   String? _highlightedTileKey;
   String? _centerOnTileKey;
+  bool _showProvinceNames = true;
 
   void _onLocateTile(String tileKey, String regionId) {
     setState(() {
@@ -1152,6 +1165,19 @@ class _MilitaryPanelWithMapStoryState
                         selected: _regionIndex == 1,
                         onSelected: (_) => setState(() => _regionIndex = 1),
                       ),
+                      const SizedBox(width: 8),
+                      ChoiceChip(
+                        label: const Text('Province names'),
+                        selected: _showProvinceNames,
+                        onSelected: (_) =>
+                            setState(() => _showProvinceNames = true),
+                      ),
+                      ChoiceChip(
+                        label: const Text('No names'),
+                        selected: !_showProvinceNames,
+                        onSelected: (_) =>
+                            setState(() => _showProvinceNames = false),
+                      ),
                     ],
                   ),
                 ),
@@ -1159,6 +1185,7 @@ class _MilitaryPanelWithMapStoryState
                   child: CtRegionMap(
                     region: region,
                     cellSizePx: 24,
+                    showProvinceNamesLayer: _showProvinceNames,
                     onProvinceSelected: (_) {},
                     highlightedTileKey: _highlightedTileKey,
                     centerOnTileKey: _centerOnTileKey,
@@ -1194,6 +1221,7 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
   int _regionIndex = 0;
   String? _highlightedTileKey;
   String? _centerOnTileKey;
+  bool _showProvinceNames = true;
   late Game _game;
   late AppEventBus _navalBus;
   StreamSubscription<NavalFleetsUpdatedEvent>? _navalSub;
@@ -1266,6 +1294,19 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
                         selected: _regionIndex == 1,
                         onSelected: (_) => setState(() => _regionIndex = 1),
                       ),
+                      const SizedBox(width: 8),
+                      ChoiceChip(
+                        label: const Text('Province names'),
+                        selected: _showProvinceNames,
+                        onSelected: (_) =>
+                            setState(() => _showProvinceNames = true),
+                      ),
+                      ChoiceChip(
+                        label: const Text('No names'),
+                        selected: !_showProvinceNames,
+                        onSelected: (_) =>
+                            setState(() => _showProvinceNames = false),
+                      ),
                     ],
                   ),
                 ),
@@ -1273,6 +1314,7 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
                   child: CtRegionMap(
                     region: region,
                     cellSizePx: 24,
+                    showProvinceNamesLayer: _showProvinceNames,
                     onProvinceSelected: (_) {},
                     highlightedTileKey: _highlightedTileKey,
                     centerOnTileKey: _centerOnTileKey,
@@ -1312,6 +1354,7 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
   String? _hoveredTileKey;
   String? _highlightedTileKey;
   CtMapVisibilityMode _visibilityMode = CtMapVisibilityMode.full;
+  bool _showProvinceNames = true;
 
   String get _displayId {
     if (_hoveredTileKey != null) {
@@ -1382,6 +1425,19 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
                         });
                       },
                     ),
+                    const SizedBox(width: 8),
+                    ChoiceChip(
+                      label: const Text('Province names'),
+                      selected: _showProvinceNames,
+                      onSelected: (_) =>
+                          setState(() => _showProvinceNames = true),
+                    ),
+                    ChoiceChip(
+                      label: const Text('No names'),
+                      selected: !_showProvinceNames,
+                      onSelected: (_) =>
+                          setState(() => _showProvinceNames = false),
+                    ),
                   ],
                 ),
               ),
@@ -1393,6 +1449,7 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
                         region: region,
                         cellSizePx: 28,
                         visibilityMode: _visibilityMode,
+                        showProvinceNamesLayer: _showProvinceNames,
                         onProvinceSelected: (id) =>
                             setState(() => _selectedId = id),
                         onProvinceHovered: (id) =>

--- a/app/lib/widgetbook/catalog.dart
+++ b/app/lib/widgetbook/catalog.dart
@@ -790,6 +790,7 @@ class _CivilianPanelWithMapStoryState
   String? _centerOnTileKey;
   ({Unit unit, String workTarget})? _workTargetSelection;
   CtMapVisibilityMode _visibilityMode = CtMapVisibilityMode.full;
+  bool _showProvinceNames = true;
   Set<String>? _cachedValidTileKeys;
   String? _cachedWorkTargetSelection;
 
@@ -978,6 +979,16 @@ class _CivilianPanelWithMapStoryState
                         _visibilityMode = CtMapVisibilityMode.playerConstrained,
                   ),
                 ),
+                CtChoiceChip(
+                  label: const Text('Province names'),
+                  selected: _showProvinceNames,
+                  onSelected: (_) => setState(() => _showProvinceNames = true),
+                ),
+                CtChoiceChip(
+                  label: const Text('No province names'),
+                  selected: !_showProvinceNames,
+                  onSelected: (_) => setState(() => _showProvinceNames = false),
+                ),
               ],
             ),
           ),
@@ -986,6 +997,7 @@ class _CivilianPanelWithMapStoryState
               region: region,
               cellSizePx: 24,
               visibilityMode: _visibilityMode,
+              showProvinceNamesLayer: _showProvinceNames,
               onProvinceSelected: (_) {},
               highlightedTileKey: _highlightedTileKey,
               centerOnTileKey: _centerOnTileKey,
@@ -1102,6 +1114,7 @@ class _MilitaryPanelWithMapStoryState
   int _regionIndex = 0;
   String? _highlightedTileKey;
   String? _centerOnTileKey;
+  bool _showProvinceNames = true;
 
   void _onLocateTile(String tileKey, String regionId) {
     setState(() {
@@ -1154,6 +1167,19 @@ class _MilitaryPanelWithMapStoryState
                         selected: _regionIndex == 1,
                         onSelected: (_) => setState(() => _regionIndex = 1),
                       ),
+                      const SizedBox(width: 8),
+                      ChoiceChip(
+                        label: const Text('Province names'),
+                        selected: _showProvinceNames,
+                        onSelected: (_) =>
+                            setState(() => _showProvinceNames = true),
+                      ),
+                      ChoiceChip(
+                        label: const Text('No names'),
+                        selected: !_showProvinceNames,
+                        onSelected: (_) =>
+                            setState(() => _showProvinceNames = false),
+                      ),
                     ],
                   ),
                 ),
@@ -1161,6 +1187,7 @@ class _MilitaryPanelWithMapStoryState
                   child: CtRegionMap(
                     region: region,
                     cellSizePx: 24,
+                    showProvinceNamesLayer: _showProvinceNames,
                     onProvinceSelected: (_) {},
                     highlightedTileKey: _highlightedTileKey,
                     centerOnTileKey: _centerOnTileKey,
@@ -1196,6 +1223,7 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
   int _regionIndex = 0;
   String? _highlightedTileKey;
   String? _centerOnTileKey;
+  bool _showProvinceNames = true;
   late Game _game;
   late AppEventBus _navalBus;
   StreamSubscription<NavalFleetsUpdatedEvent>? _navalSub;
@@ -1268,6 +1296,19 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
                         selected: _regionIndex == 1,
                         onSelected: (_) => setState(() => _regionIndex = 1),
                       ),
+                      const SizedBox(width: 8),
+                      ChoiceChip(
+                        label: const Text('Province names'),
+                        selected: _showProvinceNames,
+                        onSelected: (_) =>
+                            setState(() => _showProvinceNames = true),
+                      ),
+                      ChoiceChip(
+                        label: const Text('No names'),
+                        selected: !_showProvinceNames,
+                        onSelected: (_) =>
+                            setState(() => _showProvinceNames = false),
+                      ),
                     ],
                   ),
                 ),
@@ -1275,6 +1316,7 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
                   child: CtRegionMap(
                     region: region,
                     cellSizePx: 24,
+                    showProvinceNamesLayer: _showProvinceNames,
                     onProvinceSelected: (_) {},
                     highlightedTileKey: _highlightedTileKey,
                     centerOnTileKey: _centerOnTileKey,
@@ -1314,6 +1356,7 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
   String? _hoveredTileKey;
   String? _highlightedTileKey;
   CtMapVisibilityMode _visibilityMode = CtMapVisibilityMode.full;
+  bool _showProvinceNames = true;
 
   String get _displayId {
     if (_hoveredTileKey != null) {
@@ -1384,6 +1427,19 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
                         });
                       },
                     ),
+                    const SizedBox(width: 8),
+                    ChoiceChip(
+                      label: const Text('Province names'),
+                      selected: _showProvinceNames,
+                      onSelected: (_) =>
+                          setState(() => _showProvinceNames = true),
+                    ),
+                    ChoiceChip(
+                      label: const Text('No names'),
+                      selected: !_showProvinceNames,
+                      onSelected: (_) =>
+                          setState(() => _showProvinceNames = false),
+                    ),
                   ],
                 ),
               ),
@@ -1395,6 +1451,7 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
                         region: region,
                         cellSizePx: 28,
                         visibilityMode: _visibilityMode,
+                        showProvinceNamesLayer: _showProvinceNames,
                         onProvinceSelected: (id) =>
                             setState(() => _selectedId = id),
                         onProvinceHovered: (id) =>

--- a/app/lib/widgets/ct_region_map.dart
+++ b/app/lib/widgets/ct_region_map.dart
@@ -18,6 +18,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
     required double cellSizePx,
     required bool showPoliticalOverlay,
     required bool showBordersLayer,
+    required bool showProvinceNamesLayer,
     required CtMapVisibilityMode visibilityMode,
     BaseLayerDisplayMode baseLayerDisplayMode =
         BaseLayerDisplayMode.terrainResourcesImprovements,
@@ -33,6 +34,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
        cellSizePx = cellSizePx,
        showPoliticalOverlay = showPoliticalOverlay,
        showBordersLayer = showBordersLayer,
+       showProvinceNamesLayer = showProvinceNamesLayer,
        visibilityMode = visibilityMode,
        baseLayerDisplayMode = baseLayerDisplayMode,
        onProvinceSelected = onProvinceSelected,
@@ -48,6 +50,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
   final double cellSizePx;
   bool showPoliticalOverlay;
   bool showBordersLayer;
+  bool showProvinceNamesLayer;
   CtMapVisibilityMode visibilityMode;
   BaseLayerDisplayMode baseLayerDisplayMode;
   void Function(String provinceId)? onProvinceSelected;
@@ -73,6 +76,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
       cellSize: cellSizePx,
       showPoliticalOverlay: showPoliticalOverlay,
       showBordersLayer: showBordersLayer,
+      showProvinceNamesLayer: showProvinceNamesLayer,
       visibilityMode: visibilityMode,
       baseLayerDisplayMode: baseLayerDisplayMode,
       onProvinceSelected: onProvinceSelected,
@@ -102,11 +106,20 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
     }
   }
 
+  @override
+  void update(double dt) {
+    super.update(dt);
+    if (_mapLoaded) {
+      _mapComponent.cameraZoom = camera.viewfinder.zoom;
+    }
+  }
+
   /// Update map configuration without recreating the game.
   void updateProps({
     RegionMapViewData? region,
     bool? showPoliticalOverlay,
     bool? showBordersLayer,
+    bool? showProvinceNamesLayer,
     CtMapVisibilityMode? visibilityMode,
     BaseLayerDisplayMode? baseLayerDisplayMode,
     String? highlightedTileKey,
@@ -124,6 +137,9 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
     }
     if (showBordersLayer != null) {
       this.showBordersLayer = showBordersLayer;
+    }
+    if (showProvinceNamesLayer != null) {
+      this.showProvinceNamesLayer = showProvinceNamesLayer;
     }
     if (visibilityMode != null) {
       this.visibilityMode = visibilityMode;
@@ -152,6 +168,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
         ..cellSize = cellSizePx
         ..showPoliticalOverlay = this.showPoliticalOverlay
         ..showBordersLayer = this.showBordersLayer
+        ..showProvinceNamesLayer = this.showProvinceNamesLayer
         ..visibilityMode = this.visibilityMode
         ..baseLayerDisplayMode = this.baseLayerDisplayMode
         ..highlightedTileKey = this.highlightedTileKey
@@ -320,6 +337,7 @@ class CtRegionMap extends StatefulWidget {
     required this.region,
     this.showPoliticalOverlay = true,
     this.showBordersLayer = true,
+    this.showProvinceNamesLayer = true,
     this.cellSizePx = 32,
     this.visibilityMode = CtMapVisibilityMode.full,
     this.baseLayerDisplayMode,
@@ -337,6 +355,7 @@ class CtRegionMap extends StatefulWidget {
   final RegionMapViewData region;
   final bool showPoliticalOverlay;
   final bool showBordersLayer;
+  final bool showProvinceNamesLayer;
   final double cellSizePx;
   final CtMapVisibilityMode visibilityMode;
 
@@ -371,6 +390,7 @@ class _CtRegionMapState extends State<CtRegionMap> {
     if (widget.region != oldWidget.region ||
         widget.showPoliticalOverlay != oldWidget.showPoliticalOverlay ||
         widget.showBordersLayer != oldWidget.showBordersLayer ||
+        widget.showProvinceNamesLayer != oldWidget.showProvinceNamesLayer ||
         widget.visibilityMode != oldWidget.visibilityMode ||
         widget.baseLayerDisplayMode != oldWidget.baseLayerDisplayMode ||
         widget.validTileKeys != oldWidget.validTileKeys ||
@@ -382,6 +402,7 @@ class _CtRegionMapState extends State<CtRegionMap> {
         region: widget.region,
         showPoliticalOverlay: widget.showPoliticalOverlay,
         showBordersLayer: widget.showBordersLayer,
+        showProvinceNamesLayer: widget.showProvinceNamesLayer,
         visibilityMode: widget.visibilityMode,
         baseLayerDisplayMode:
             widget.baseLayerDisplayMode ??
@@ -409,6 +430,7 @@ class _CtRegionMapState extends State<CtRegionMap> {
       cellSizePx: widget.cellSizePx,
       showPoliticalOverlay: widget.showPoliticalOverlay,
       showBordersLayer: widget.showBordersLayer,
+      showProvinceNamesLayer: widget.showProvinceNamesLayer,
       visibilityMode: widget.visibilityMode,
       baseLayerDisplayMode:
           widget.baseLayerDisplayMode ??

--- a/app/lib/widgets/debug_map_visibility_story.dart
+++ b/app/lib/widgets/debug_map_visibility_story.dart
@@ -68,6 +68,7 @@ class DebugMapVisibilityStory extends StatefulWidget {
 
 class _DebugMapVisibilityStoryState extends State<DebugMapVisibilityStory> {
   CtMapVisibilityMode _visibilityMode = CtMapVisibilityMode.full;
+  bool _showProvinceNames = true;
 
   @override
   Widget build(BuildContext context) {
@@ -105,6 +106,20 @@ class _DebugMapVisibilityStoryState extends State<DebugMapVisibilityStory> {
                     });
                   },
                 ),
+                CtChoiceChip(
+                  label: const Text('Province names'),
+                  selected: _showProvinceNames,
+                  onSelected: (_) {
+                    setState(() => _showProvinceNames = true);
+                  },
+                ),
+                CtChoiceChip(
+                  label: const Text('No province names'),
+                  selected: !_showProvinceNames,
+                  onSelected: (_) {
+                    setState(() => _showProvinceNames = false);
+                  },
+                ),
               ],
             ),
           ),
@@ -114,6 +129,7 @@ class _DebugMapVisibilityStoryState extends State<DebugMapVisibilityStory> {
               showPoliticalOverlay: widget.showPoliticalOverlay,
               cellSizePx: 28,
               visibilityMode: _visibilityMode,
+              showProvinceNamesLayer: _showProvinceNames,
               onProvinceSelected: (id) {},
             ),
           ),

--- a/app/test/game_screen_narrow_test.dart
+++ b/app/test/game_screen_narrow_test.dart
@@ -152,6 +152,7 @@ void main() {
 
         expect(find.text('Map display options'), findsOneWidget);
         expect(find.text('Show borders'), findsOneWidget);
+        expect(find.text('Show province names'), findsOneWidget);
       },
       timeout: const Timeout(Duration(seconds: 20)),
     );
@@ -173,7 +174,10 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 100));
 
-        final showBordersFinder = find.byType(SwitchListTile);
+        final showBordersFinder = find.widgetWithText(
+          SwitchListTile,
+          'Show borders',
+        );
         expect(showBordersFinder, findsOneWidget);
 
         // Toggle off.
@@ -191,10 +195,46 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 100));
 
-        final switchTile = tester.widget<SwitchListTile>(
-          showBordersFinder.first,
-        );
+        final switchTile = tester.widget<SwitchListTile>(showBordersFinder);
         expect(switchTile.value, isFalse);
+      },
+      timeout: const Timeout(Duration(seconds: 20)),
+    );
+
+    testWidgets(
+      'AC: toggling Show province names in dialog updates state and persists within session (SPEC/ui/empire-overview.md)',
+      (WidgetTester tester) async {
+        final dpr = tester.view.devicePixelRatio;
+        tester.view.physicalSize = Size(1500 * dpr, 700 * dpr);
+        addTearDown(tester.view.reset);
+        await tester.pumpWidget(buildGameScreen(width: 1500, height: 700));
+        await tester.pump();
+
+        final optionsButtonFinder = find.byKey(kMapDisplayOptionsButtonKey);
+        await tester.tap(optionsButtonFinder);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        final showNamesFinder = find.widgetWithText(
+          SwitchListTile,
+          'Show province names',
+        );
+        expect(showNamesFinder, findsOneWidget);
+
+        await tester.tap(showNamesFinder);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        await tester.tap(find.text('Close'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        await tester.tap(optionsButtonFinder);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        final namesTile = tester.widget<SwitchListTile>(showNamesFinder);
+        expect(namesTile.value, isFalse);
       },
       timeout: const Timeout(Duration(seconds: 20)),
     );


### PR DESCRIPTION
## Summary
Implements optional **land province name** labels on the in-game region map, aligned with `SPEC/ui/map-widget.md` and `SPEC/ui/empire-overview.md`.

## Behavior
- Labels use `CellViewData.provinceDisplayName` (local id fallback), centroid of qualifying land tiles; **sea zones** omitted.
- **Player-constrained** visibility: only non-`unrevealed` tiles count; no label if none qualify.
- Text + semi-transparent plate use **roughly constant logical pixel size** (inverse scale vs camera zoom).
- **Map display options** adds **Show province names** (session `StateProvider`), independent of **Show borders** (default ON for both).
- Widgetbook / debug map stories include chips to toggle labels.

## Tests
- `game_screen_narrow_test`: dialog shows both toggles; province names toggle persists within session.
- `ct_region_map_test` (existing suite) still passes with defaults.

## Notes
- Regenerate l10n locally after pull (`flutter gen-l10n`) if your workflow expects fresh `app_localizations*.dart`; tracked source is `app_en.arb`.