### PR TITLE
feat(app): Map ↔ province panel via Riverpod; overlay layout; UI specs

### DIFF
--- a/SPEC/ui/map-widget.md
+++ b/SPEC/ui/map-widget.md
@@ -121,12 +121,23 @@ The map widget exposes callbacks so the parent (e.g. Empire overview) can react;
 | Callback | Purpose |
 |----------|---------|
 | **onProvinceSelected** | Invoked when the user taps/clicks a province (e.g. with prefixed province id). Province details (what to show, where) are defined by the parent/screen; the map widget only reports selection. |
+| **onMapTileTappedForDetail** | Optional. Invoked when the user **taps/clicks** a tile for the **province/sea zone detail** flow with full tile key `regionId|provinceId|x|y`. The **embedding shell** (not the reusable map) connects this to shared UI state (e.g. Riverpod `mapProvincePanelProvider`). The map widget does **not** import the detail overlay. See [province-sea-zone-detail-overlay.md](province-sea-zone-detail-overlay.md). |
 | **onRegionViewChanged** | Optional: viewport or zoom level changed (e.g. for syncing with sidebar or URL). |
 | **onProvinceHovered** | Optional: invoked when hover enters or leaves a province (prefixed province id, or null when leaving). Enables e.g. tooltips. |
 | **onTileSelected** | Optional. When the map is in **work target selection mode** (see below), invoked when the user taps/clicks a tile with the tile key `regionId|provinceId|x|y`. Used by the Civilian Units panel assign flow. |
 | **validTileKeys** | Optional. When non-null and non-empty, the map is in work target selection mode: tiles whose key is in this set are drawn with a **subtle glow** (e.g. soft overlay or outline) so the user sees which tiles are valid targets. Tap on a valid tile invokes **onTileSelected** with that tile key; tap on an invalid tile or empty area does not invoke onTileSelected (parent may treat as cancel/back-out). |
 
-Details of what “province details” shows are **not** defined in this spec; the screen that embeds the map defines that. The map widget only supports selection via these callbacks.
+**Constructor / props (driven by parent):** **`selectedTileKey`** — full tile key for the **orange** selection outline (detail panel’s selected tile). **`secondaryHighlightTileKey`** — optional second outline (e.g. cyan) for list/locate; distinct from selection. Parents set these from shared state (e.g. Riverpod); the map does not read panel widgets.
+
+Details of what “province details” shows are **not** defined in this spec; the screen that embeds the map defines that. The map widget reports taps via callbacks and paints outlines from passed-in keys.
+
+---
+
+## Province / sea zone detail panel (decoupling)
+
+- **No cross-imports:** The Flame map component tree and `CtRegionMap` MUST NOT import `ProvinceSeaZoneDetailOverlay` or any province-panel-only module. The detail overlay MUST NOT import the Flame map game class.
+- **Bridge:** In the app, **`mapProvincePanelProvider`** holds `overlayOpen`, `selectedTileKey`, `secondaryHighlightTileKey`. A **Consumer** host (e.g. game map canvas stack) wires `onMapTileTappedForDetail` → `reportMapTileTapped`, and passes `selectedTileKey` / `secondaryHighlightTileKey` from `ref.watch` into the map widget. Side and narrow panel slots are separate Consumers that read the same provider and build the overlay. This satisfies “Riverpod-only” wiring between map and panel; `AppEventBus` is optional for other concerns.
+- **Behavior:** **Tap** drives detail selection and panel content. **Hover** drives the animated hover selector and province/sea glow only — it does **not** update the detail panel’s selected tile. Full rules: [province-sea-zone-detail-overlay.md](province-sea-zone-detail-overlay.md).
 
 ---
 
@@ -150,9 +161,7 @@ Details of what “province details” shows are **not** defined in this spec; t
 - **Selector:** When the pointer hovers over a tile, the widget shows a selector on that tile (e.g. a simple square outline). The selector has a **subtle bouncing animation** (e.g. scale or position) so it is clearly visible and responsive.
 - **Province border highlight:** The province (or sea zone) that contains the hovered tile is highlighted: its borders **glow** and use a **subtle animation** (e.g. opacity or stroke pulse). This applies to both land provinces and sea zones.
 - **Optional callback:** The widget may expose **onProvinceHovered**(prefixed province id, or null when hover leaves) so the parent can show tooltips or other feedback.
-- **Tap-as-hover on touch:** On touch-only/mobile viewports where pointer hover is not available, **tapping a tile** must drive the same hover visuals and tile/province callbacks as pointer hover:
-  - The hover selector and province-border glow move to the tapped tile (subject to visibility rules below) and remain there until another tile is hovered/tapped or the map loses focus.
-  - The map widget invokes **onTileHovered** and **onProvinceHovered** for the tapped tile/province in the same way it would for a hover event, so overlays such as the Province/Sea Zone Detail overlay can treat the tapped tile as the “current hovered tile” on mobile.
+- **Tap-as-hover on touch (map visuals only):** On touch-only/mobile viewports where pointer hover is not available, **tapping a tile** drives the same **hover** visuals and **onTileHovered** / **onProvinceHovered** as pointer hover (selector + province glow). The **province/sea zone detail panel** does **not** use hover or tap-as-hover for its Tile section — only **onMapTileTappedForDetail** (and provider state) updates that panel.
 
 ---
 
@@ -186,7 +195,7 @@ Hover, selection, and overlay behavior:
 
 - Hover selector and province-border glow only apply to tiles that are not `unrevealed`.
 - Province selection callbacks (`onProvinceSelected`, `onProvinceHovered`) **are invoked** for taps/clicks on tiles whose visibility is `visible`, `fogged`, or `unrevealed`; it is the responsibility of the overlay (see `SPEC/ui/province-sea-zone-detail-overlay.md`) to obfuscate data for fully unrevealed provinces/tiles.
-- On touch devices, tapping a tile that is not `unrevealed` also updates the **hover selector** and hover callbacks as described in the Hover section so that the visual cursor and overlay stay in sync even without pointer hover.
+- On touch devices, tapping a tile that is not `unrevealed` also updates the **hover selector** and hover callbacks as in the Hover section. The **detail overlay** stays in sync only when the shell also handles **onMapTileTappedForDetail** / provider selection — not via hover callbacks alone.
 
 ---
 
@@ -289,7 +298,7 @@ If a tileset fails to load, the widget falls back to solid color rendering using
 - **When** the user taps/clicks a province, **then** the widget invokes the provided province-selection callback with an identifier (e.g. prefixed province id); the widget does not render province details itself.
 - **When** the user hovers over a tile, **then** a selector (e.g. simple square) is shown on that tile with a subtle bouncing animation.
 - **When** the user hovers over a tile, **then** the borders of that tile's province (or sea zone) glow and have a subtle animation; when hover leaves, the highlight is removed.
-- **Given** a touch/mobile viewport where pointer hover is not available, **when** the user taps a non-`unrevealed` tile, **then** the widget both invokes province/tile selection callbacks and updates the hover selector and province-border glow as if the tile were hovered.
+- **Given** a touch/mobile viewport where pointer hover is not available, **when** the user taps a non-`unrevealed` tile, **then** the widget updates the hover selector and province-border glow and invokes hover-related callbacks as if the tile were hovered; **when** the host wires **onMapTileTappedForDetail**, **then** that callback also runs for the detail panel flow (provider), independent of hover.
 - **Given** the component is implemented with Flame, **then** it is possible to drive per-tile or per-asset animations from external events or timers.
 - **Given** the Widgetbook map widget story is configured with an initialized game whose `Game.players` list is non-empty, **when** the user enables player-constrained visibility mode in the story controls, **then** the widget builds its map view using the first player's (`game.players.first`) player view and applies per-tile visibility from that view.
 - **Given** a map widget with `CellViewData.visibility` populated and the visibility mode set to **full**, **when** the widget renders tiles, **then** tiles whose visibility is `visible`, `fogged`, or `unrevealed` are all drawn as fully visible (no gray or black masking is applied based on visibility).
@@ -316,5 +325,5 @@ If a tileset fails to load, the widget falls back to solid color rendering using
 ## Integration
 
 - **Data:** Uses shared view models and game state (e.g. `RegionMapViewData`, Game, topology, tile maps). See [map-visualization.md](../program/map-visualization.md), [player-view.md](../program/player-view.md) for visibility when needed. `RegionMapViewData` / `CellViewData` are the source of truth for what is rendered; the map widget does not perform its own world simulation.
-- **Flame/Flutter:** Flame for the map canvas and animations; Flutter for shell and overlays. Per [repo-and-packages.md](../program/repo-and-packages.md): Flame owns game canvas and in-game pixel-art UI; communicate via state and callbacks. The reusable map widget is exposed to Flutter as a `CtRegionMap`-style wrapper that embeds a Flame `GameWidget` and internal Flame game/component tree.
+- **Flame/Flutter:** Flame for the map canvas and animations; Flutter for shell and overlays. Per [repo-and-packages.md](../program/repo-and-packages.md): Flame owns game canvas and in-game pixel-art UI; communicate via state and callbacks. The reusable map widget is exposed to Flutter as a `CtRegionMap`-style wrapper that embeds a Flame `GameWidget` and internal Flame game/component tree. Province detail UI is wired only through **Riverpod** (or bus) at the shell — see **Province / sea zone detail panel** above and [province-sea-zone-detail-overlay.md](province-sea-zone-detail-overlay.md).
 - **Catalog:** Once implemented, register in app widget catalog (e.g. CtRegionMap or similar; category: game/map, Flame component).

--- a/SPEC/ui/province-sea-zone-detail-overlay.md
+++ b/SPEC/ui/province-sea-zone-detail-overlay.md
@@ -1,146 +1,94 @@
 # Province and Sea Zone Detail Overlay
 
-**SPEC/ui** — Detail overlay shown when the user selects a province or sea zone on the map. Integrates with [map-widget.md](map-widget.md) and [empire-overview.md](empire-overview.md). Province/sea zone identity: [world-model-identity.md](../game/world-model-identity.md).
+**SPEC/ui** — Detail overlay when the user selects a tile on the map for province/sea-zone context. Integrates with [map-widget.md](map-widget.md). Province/sea zone identity: [world-model-identity.md](../game/world-model-identity.md).
+
+---
+
+## Architecture and wiring (Riverpod-only)
+
+- The **region map** (Flame stack / `CtRegionMap`) and the **province/sea zone detail UI** (side panel or narrow bottom slot) MUST **not** import or reference each other. No passing panel callbacks into the map widget for panel orchestration, and no map types inside the overlay widget file.
+- Shared UI state lives in **`mapProvincePanelProvider`** (Riverpod `StateNotifier`): `overlayOpen`, `selectedTileKey` (orange selection / panel content), `secondaryHighlightTileKey` (optional locate/list cursor on the map). The **map embedding layer** (e.g. `GameMapCanvasStack`) reads/writes this provider and passes **plain data + callbacks** into `CtRegionMap` (`selectedTileKey`, `secondaryHighlightTileKey`, `onMapTileTappedForDetail`). The **panel hosts** (`GameMapProvinceDetailSidePanel`, `GameMapNarrowDetailOverlaySlot`) are `ConsumerWidget`s that read the same provider and build `ProvinceSeaZoneDetailOverlay` with `displayId` derived from `selectedTileKey`.
+- Other features may use `AppEventBus`; this overlay’s map↔panel contract is the provider. No `Ref`/`BuildContext` chains across unrelated panels (TDD app UI wiring).
 
 ---
 
 ## Purpose
 
-When the user taps/clicks a tile on the map widget, the in-game shell displays a detail overlay for the province (land) or sea zone (water) containing that tile. The overlay shows essential information; it is toggleable (tap again or close button) and responsive (side panel on desktop, bottom sheet with tabs on mobile).
+When the user **taps/clicks a map tile** (not hover), the shell shows detail for the **province or sea zone** containing that tile. **Hover** may move the hover selector and province glow on the map but does **not** change panel content. The overlay is toggleable (close control; a further tile tap can reopen/update per shell rules).
 
 ---
 
 ## Interaction
 
-- **Open:** User taps/clicks a province or sea zone on the map. The overlay appears.
-- **Close (desktop and mobile):** User taps/clicks the close button (or an explicit dismiss control provided by the shell). **Tapping the same province/sea zone again does not close the overlay;** it remains visible until explicitly dismissed.
-- **Switch:** Tapping/clicking a different province/sea zone updates the overlay content to the new selection while keeping the overlay visible.
-- **Map highlight (orange cursor):** When the overlay is closed (via its close control or equivalent shell action), the in-game shell must also **clear any map `highlightedTileKey`** so that the secondary/orange cursor disappears from the map.
-- **Hover (pointer devices):** When the overlay is open, hovering over the map immediately updates the overlay to show the hovered province and, in the Tile section, the hovered tile’s details (coordinates, terrain, resources, prospected, improvements, roads/railroads, civilian units in province).
-- **Tap-as-hover (touch/mobile):** On touch-only/mobile viewports where pointer hover is not available, tapping a tile acts as “hover” for the purposes of the Tile section and province display:
-  - The map widget drives `onTileHovered` / `onProvinceHovered` for the tapped tile/province.
-  - The overlay treats the last tapped tile as the current “hovered” tile, so the Tile section and province header update accordingly while the overlay stays open.
-- **Data context:** All data is from the human player's view (visibility, prospecting, etc.).
+- **Open / update:** User taps/clicks a tile → provider records `selectedTileKey`, sets `overlayOpen` → panel shows that province/sea zone; **Tile** section uses the same tile key.
+- **Close:** User uses the overlay close control → `overlayOpen` false; `selectedTileKey` may remain for a later reopen. Map **orange selection** follows provider: implementation may clear or keep selection when closed; tile tap while closed should be able to **reopen** with that tile selected.
+- **Switch province/tile:** Tap another tile → new `selectedTileKey` → panel updates (including province-scoped sections for the new tile’s province).
+- **Hover:** Pointer hover updates **only** map hover visuals (and optional `onProvinceHovered` / tooltips). It does **not** update `selectedTileKey` or the Tile section.
+- **Touch / mobile:** There is **no** “tap-as-hover” for **panel** content. Only **tap** commits selection for the overlay.
+- **Data context:** Human player view (visibility, prospecting, etc.).
 
 ---
 
-## Layout and Responsiveness
+## Map cursors (with map widget)
 
-- **Max height:** Overlay never occupies more than one-third of the screen height in the main game shell; Widgetbook map+overlay mock may use a fixed fraction (e.g. bottom half of the story area) to clearly demonstrate the interaction.
-- **Desktop / larger screens:** In the main game shell, overlay appears as a side panel (e.g. right side). Content scrolls if needed.
-- **Mobile / narrow viewports:** Overlay appears as a bottom sheet on top of the map. Content is organized in **tabs** (Political, Economic, Military, Civilian, Naval) so each tab fits within the one-third height constraint.
-- **Tabs:** Political | Economic | Military | Civilian | Naval. On desktop, tabs may be shown as sections in a single scrollable panel if space allows; in Widgetbook, the "With map" story uses a simple bottom overlay to showcase interaction rather than full tab chrome.
+- **Selection (orange outline):** The tile in `selectedTileKey` (when set). Must match the Tile section and political `displayId` (`regionId|provinceId` from tile key).
+- **Secondary highlight:** Optional outline for list/locate (`secondaryHighlightTileKey`); distinct from orange selection.
 
 ---
 
-## Style / Implementation
+## Layout, responsiveness, and height rules
 
-- Overlay uses **non-Material, pixel-art friendly** components: CtPanel, custom tab strip (CtTabStrip), explicit text styles. No Material Card, TabBar, or IconButton (UXD 02).
+**Narrow** means viewport width &lt; shell breakpoint (e.g. 600 logical px). Let `H` = `MediaQuery` screen height, `third = 0.33 * H`. Let layout max height from parent be `parentMax` (from `LayoutBuilder` / parent constraints).
 
----
+| Case | Effective max content height |
+|------|-------------------------------|
+| Not narrow (wide shell) | Use parent’s bounded height (full side column). |
+| Narrow, **full-width** map (max width ≈ screen width) | `min(parentMax, third)` so the overlay never exceeds one-third of screen height. |
+| Narrow, **side rail** (panel width clearly less than screen width, e.g. fixed 320px) | `parentMax` (full height of the rail), **not** capped to `third`. |
+| Narrow, parent **already** constrains height to ≤ `third` (e.g. bottom slot `SizedBox(height: third)`) | Use that height exactly (do not shrink further). |
+| Narrow, **unbounded** vertical constraint | `third`. |
 
-## Province Overlay Content
+**Scrolling:** On narrow layouts with tabs, each tab’s body must be **scrollable** so content never overflows a short panel (e.g. `SingleChildScrollView` around tab page content).
 
-### Tile (hovered tile details)
+- **Desktop / larger shell:** Overlay in a **side panel** (e.g. right); single **scrollable** column of sections when not using tabs.
+- **Mobile / narrow full-width:** **Bottom** area with **tabs**; tab strip + scrollable pages; obey height table above.
 
-When the user hovers a tile on the map (with overlay open), this section shows that tile’s information. When no tile is hovered, it shows “Hover a tile to see details.”
-
-- **Tile coordinates:** (x, y) in the region grid.
-- **Terrain type:** From the tile map (e.g. plains, forest, hills).
-- **Resource:** Resource id on that tile (or —).
-- **Prospected:** Yes/no for the human player.
-- **Improvement:** Improvement name and level (e.g. Farm L2) or —.
-- **Road / railroad:** Road level (none, primitive, improved, port or railroad).
-- **Civilian units (province):** Count of civilian units in the tile’s province.
-
-#### Visibility and obfuscation (player-constrained views)
-
-When the map widget is in **player-constrained visibility mode** and the overlay is driven by a tile or province that the human player has never seen, the overlay must obfuscate details rather than leaking information:
-
-- **Per-tile (Tile section):**
-  - For tiles whose `CellViewData.visibility` is `visible` or `fogged`, the Tile section shows full details as listed above.
-  - For tiles whose `CellViewData.visibility` is `unrevealed`, the Tile section still shows the heading "Tile" but replaces all data fields (coordinates, terrain, resource, prospected, improvement, road/railroad, civilian units in province) with the literal placeholder text `???`.
-- **Per-province (all sections):**
-  - A province is treated as **fully unrevealed** when every tile in that province (all cells where `regionCellId` equals the province’s local id) has `visibility == TileVisibility.unrevealed` in the current `RegionMapViewData`.
-  - When a fully unrevealed province is selected, the overlay may still open (taps are allowed), but all content sections (Tile, Political, Economic, Military, Civilian, Naval) must replace data values with the literal placeholder text `???` while still indicating that a province is selected.
-  - Provinces that contain at least one tile with visibility `visible` or `fogged` are treated as **known**; the overlay shows full data for those provinces.
-
-### Political
-
-- Province name (or prefixed id fallback)
-- Owner (Great Power, Minor Nation, Tribe, or "Unclaimed")
-
-### Economic
-
-- **Resources available:** List of resource ids present on tiles in the province (from `WorldState.resourceByTileKey` and `tileKeysByRegionAndProvince`).
-- **Tiles yet to be prospected:** Count and list of tile coordinates `(x, y)` for mineral tiles (iron, copper, tin, coal, silver, gold, gems, diamonds) that are not in `playerProspectedTiles[humanPlayerId]`.
-- **Improvements built:** List of tile coordinates `(x, y)` with improvement level > 0; show improvement type (Farm, Mine, etc.) and level per [extraction-and-improvements.md](../game/extraction-and-improvements.md) naming.
-- **Improvements available:** List of tile coordinates `(x, y)` where the human player can build (tile has resource, improvement level < 4, tech allows, connectivity). Hover over a coordinate shows a secondary cursor/highlight on the map over that tile.
-
-### Military
-
-- **Regiments present:** Units in the province where `unitRoleForType(u.type) == UnitRole.military`. Show type and count (or list).
-
-### Civilian
-
-- **Civilian units present:** Units in the province that are not military (Explorer, Builder, Engineer, etc.). Show unit type, id, and **status** (idle, working, done; from `Unit.status` and `currentWork` if present).
-
-### Naval
-
-- **Ships in port:** Fleets that are **in port at this province** (attached to the province per [ships-and-naval.md](../game/ships-and-naval.md)). Implementation uses `Fleet.inPortAtProvinceId` (or equivalent); see ships-in-port helper in colonizethis_logic that returns fleets whose in-port province matches the selected province.
+**Tab order (labels):** Political, Tile, Economic, Military, Civilian, Naval (Political before Tile). Sea zones: Political, Naval only where applicable.
 
 ---
 
-## Sea Zone Overlay Content
+## Style / implementation
 
-Similar structure where applicable:
-
-- **Political:** Sea zone id/name (or prefixed id).
-- **Economic:** N/A for sea zones.
-- **Military:** N/A (land units only).
-- **Civilian:** N/A.
-- **Naval:** Fleets in this sea zone (owner, ship types, mission).
+Non-Material, pixel-art friendly: `CtPanel`, `CtTabStrip`, explicit text styles (UXD 02). Overlay widget receives **`displayId`** and **`selectedTileKey`** from parents; it does **not** import `mapProvincePanelProvider`.
 
 ---
 
-## Tile Coordinate Hover
+## Province overlay content
 
-When the overlay lists tile coordinates (e.g. improvements built/available), hovering over a coordinate entry causes a **secondary highlight** on the map: a cursor or outline appears over the corresponding tile. The map widget must support an optional `highlightedTileKey` (or `highlightedTileX`, `highlightedTileY`) prop and render the highlight. The overlay passes the hovered coordinate to the parent, which updates the map's highlight.
+**Tile:** From **`selectedTileKey`** only. Empty: “Click a tile to see details.” Else: coordinates, terrain, resource (— if none), **Prospected** (prospectable & not prospected → no; not prospectable → —), improvement, roads/rail, civilian count. `???` when unrevealed per player view.
+
+**Political / Economic / Military / Civilian / Naval:** Owner, resources, prospects, improvements, units, fleets in port (see game specs). List hover → **`secondaryHighlightTileKey`** via callback (no overlay↔map import).
+
+**Sea zone:** Political + Naval (fleets in zone).
 
 ---
 
-## Acceptance Criteria
+## Acceptance criteria
 
-- **Given** the user taps a province on the map, **when** the overlay is not shown, **then** the overlay appears with province content (Political, Economic, Military, Civilian, Naval).
-- **Given** the overlay is shown for a province, **when** the user taps the same province again, **then** the overlay **remains visible** and continues to show that province until the user explicitly dismisses it (e.g. via the close button).
-- **Given** the overlay is shown for a province, **when** the user taps the close button, **then** the overlay closes.
-- **Given** the overlay is shown, **when** the user taps a different province, **then** the overlay content updates to the new province and remains visible.
-- **Given** the user taps a sea zone, **when** the overlay is not shown, **then** the overlay appears with sea zone content (Political, Naval).
-- **Given** the overlay lists tile coordinates, **when** the user hovers over a coordinate, **then** a secondary highlight appears on the map over that tile.
-- **Given** a mobile viewport, **when** the overlay is shown, **then** it appears as a bottom sheet with tabs and does not exceed one-third of screen height.
-- **Given** a desktop viewport, **when** the overlay is shown, **then** it appears as a side panel.
-- **Given** a touch/mobile viewport where pointer hover is not available and the overlay is open, **when** the user taps a non-`unrevealed` tile on the map, **then** the overlay’s Tile section and province header update to show that tile’s province and tile information while the overlay remains visible.
-
-- **Given** the overlay is shown and a tile coordinate hover or other UI has caused the map to display a secondary/orange cursor via `highlightedTileKey`, **when** the user closes the overlay, **then** the in-game shell clears the map’s `highlightedTileKey` so that the secondary/orange cursor is no longer shown on the map.
-
-- **Given** the map widget is in player-constrained visibility mode and the user hovers a tile whose `CellViewData.visibility` is `unrevealed`, **when** the overlay’s Tile section is rendered, **then** the UI layer shows the heading "Tile" and replaces all Tile data fields (coordinates, terrain, resource, prospected, improvement, road/railroad, civilian units in province) with the literal text `???`.
-
-- **Given** the map widget is in player-constrained visibility mode and the user taps a province where every tile in that province has `CellViewData.visibility == TileVisibility.unrevealed`, **when** the overlay is shown for that province, **then** the UI layer displays all content sections (Tile, Political, Economic, Military, Civilian, Naval) with data values obfuscated as `???` while still indicating that a province is selected.
-
-- **Given** the map widget is in player-constrained visibility mode and the user taps a province that contains at least one tile with `CellViewData.visibility` equal to `visible` or `fogged`, **when** the overlay is shown for that province, **then** the UI layer displays full province content (Political, Economic, Military, Civilian, Naval) without replacing values with `???`.
+- Map and panel do not cross-import; bridge is `mapProvincePanelProvider` (and map ctor params fed by that layer).
+- Tile **tap** opens/updates overlay and `selectedTileKey`; Tile section matches. **Hover** does not change `selectedTileKey` or Tile section.
+- Narrow full-width: max height ≤ `third` when parent does not already cap. Bottom slot height `third`: no overflow; tabs scroll. Narrow side rail: full rail height allowed. Desktop: side panel, scrollable.
+- Economic row hover updates `secondaryHighlightTileKey` and a non-orange map outline. Close sets `overlayOpen` false; tile tap may reopen.
+- Unrevealed / fully unrevealed province: `???` obfuscation per player view (unchanged).
 
 ### Widgetbook
 
-- **Given** the Province Overlay Widgetbook story "Standalone — province", **when** the story renders, **then** the overlay displays province content (Political, Economic, Military, Civilian, Naval) with demo data.
-- **Given** the Province Overlay Widgetbook story "Standalone — sea zone", **when** the story renders, **then** the overlay displays sea zone content (Political, Naval).
-- **Given** the Province Overlay Widgetbook story "With map — province selected", **when** the story renders, **then** the map fills the story area and, when a province is selected, a province detail overlay appears as a bottom sheet covering roughly the lower half of the map; tapping the same province again or the close button hides the overlay; tapping a different province updates the overlay content.
-- **Given** the Province Overlay Widgetbook story "With map — province selected", **when** a province is selected, **then** the overlay remains visible until the story’s close control is used; subsequent taps on the same province do not close the overlay, and taps on other provinces switch the overlay content to the new selection.
-- **Given** the Province Overlay Widgetbook story "Standalone (mobile)", **when** the story renders, **then** the overlay uses tabs and does not exceed one-third of viewport height.
+Map stories use `onMapTileTappedForDetail` and passed-in keys from demo/overrides; Flame map does not import the overlay.
 
 ---
 
 ## Integration
 
-- **Map widget:** [map-widget.md](map-widget.md). Uses `onProvinceSelected`; selection may be province or sea zone (regionCellId). Map widget supports `highlightedTileKey` for coordinate hover.
-- **Ships in port:** Helper in colonizethis_logic returns fleets that are in port at a province (attachment: `inPortAtProvinceId` equals that province).
-- **Catalog:** Register overlay component in app widget catalog when implemented.
+- **Map widget:** [map-widget.md](map-widget.md) — `onMapTileTappedForDetail`, `selectedTileKey`, `secondaryHighlightTileKey`.
+- **Provider:** `mapProvincePanelProvider` in app; see TDD for app state if split.
+- **Ships in port:** colonizethis_logic helpers as before.

--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -13,6 +13,7 @@ import '../../../../widgets/ct_region_map.dart' show BaseLayerDisplayMode;
 
 import '../../../../providers/game_service_provider.dart';
 import '../../../../providers/games_provider.dart';
+import '../../../../providers/map_province_panel_provider.dart';
 import '../../../../providers/map_view_provider.dart';
 
 import 'game_screen_shared.dart';
@@ -37,10 +38,6 @@ class GameMapArea extends ConsumerStatefulWidget {
 
 class _GameMapAreaState extends ConsumerState<GameMapArea> {
   int _regionIndex = 0;
-  String? _selectedDetailId;
-  String? _hoveredDetailId;
-  String? _hoveredTileKey;
-  String? _highlightedTileKey;
   String? _centerOnTileKey;
   ({ct_models.Unit unit, String workTarget})? _workTargetSelection;
   Set<String>? _cachedValidTileKeys;
@@ -116,8 +113,8 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
     }
     final tileKey = capital.toTileKey();
     final regionId = capital.regionId;
+    ref.read(mapProvincePanelProvider.notifier).setSecondaryHighlight(tileKey);
     setState(() {
-      _highlightedTileKey = tileKey;
       _centerOnTileKey = tileKey;
       if (regionId == 'newWorld') {
         _regionIndex = 1;
@@ -133,29 +130,12 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
     });
   }
 
-  /// Province/sea zone to show in overlay (hover when overlay open, else selection). Prefixed id.
-  String get _displayId {
-    return GameMapAreaStateLogic.displayIdFromHover(
-      hoveredTileKey: _hoveredTileKey,
-      hoveredDetailId: _hoveredDetailId,
-      selectedDetailId: _selectedDetailId,
-    );
-  }
-
-  void _onProvinceSelected(String provinceId) {
-    // Province tap always selects/shows the overlay; it stays visible until
-    // explicitly dismissed via the overlay close button. SPEC/ui/province-sea-zone-detail-overlay.md.
-    setState(() {
-      _selectedDetailId = provinceId;
-    });
-  }
-
   void _onLocateCivilianUnit(ct_models.Unit unit) {
     final tileKey = unit.tileKey;
     if (tileKey == null) return;
     final regionId = ct_models.Unit.regionIdFromTileKey(tileKey);
+    ref.read(mapProvincePanelProvider.notifier).setSecondaryHighlight(tileKey);
     setState(() {
-      _highlightedTileKey = tileKey;
       _centerOnTileKey = tileKey;
       if (regionId == 'newWorld') {
         _regionIndex = 1;
@@ -170,8 +150,8 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
   }
 
   void _onLocateMilitaryTile(String tileKey, String regionId) {
+    ref.read(mapProvincePanelProvider.notifier).setSecondaryHighlight(tileKey);
     setState(() {
-      _highlightedTileKey = tileKey;
       _centerOnTileKey = tileKey;
       if (regionId == 'newWorld') {
         _regionIndex = 1;
@@ -186,8 +166,8 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
   }
 
   void _onLocateNavalFleet(String tileKey, String regionId) {
+    ref.read(mapProvincePanelProvider.notifier).setSecondaryHighlight(tileKey);
     setState(() {
-      _highlightedTileKey = tileKey;
       _centerOnTileKey = tileKey;
       if (regionId == 'newWorld') {
         _regionIndex = 1;
@@ -247,6 +227,14 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
   }
 
   @override
+  void didUpdateWidget(covariant GameMapArea oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.game.id != widget.game.id) {
+      ref.read(mapProvincePanelProvider.notifier).reset();
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final showBorders = ref.watch(mapBordersVisibleProvider);
     final isNarrow = MediaQuery.sizeOf(context).width < kInGameNarrowBreakpoint;
@@ -291,16 +279,8 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
                   baseLayerDisplayMode: _baseLayerDisplayMode,
                   showBordersLayer: showBorders,
                   humanPlayerId: _humanPlayerId,
-                  selectedDetailId: _selectedDetailId,
-                  displayId: _displayId,
-                  hoveredTileKey: _hoveredTileKey,
-                  highlightedTileKey: _highlightedTileKey,
                   centerOnTileKey: _centerOnTileKey,
                   validTileKeysForSelection: _validTileKeysForSelection,
-                  onProvinceSelected: _onProvinceSelected,
-                  onProvinceHovered: (id) =>
-                      setState(() => _hoveredDetailId = id),
-                  onTileHovered: (key) => setState(() => _hoveredTileKey = key),
                   onTileSelectedForWork: _workTargetSelection != null
                       ? _onTileSelectedForWork
                       : null,
@@ -310,12 +290,6 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
                           _cachedValidTileKeys = null;
                         })
                       : null,
-                  onHighlightTile: (k) =>
-                      setState(() => _highlightedTileKey = k),
-                  onCloseDetailOverlay: () => setState(() {
-                    _selectedDetailId = null;
-                    _highlightedTileKey = null;
-                  }),
                 ),
                 Positioned(
                   left: 0,
@@ -390,8 +364,9 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
                     humanPlayerId: _humanPlayerId,
                     sideMenuOpen: _sideMenuOpen,
                     onClose: () => setState(() => _sideMenuOpen = false),
-                    onPanelDismissed: () =>
-                        setState(() => _highlightedTileKey = null),
+                    onPanelDismissed: () => ref
+                        .read(mapProvincePanelProvider.notifier)
+                        .setSecondaryHighlight(null),
                     onLocateCivilianUnit: _onLocateCivilianUnit,
                     onLocateMilitaryTile: _onLocateMilitaryTile,
                     onLocateNavalFleet: _onLocateNavalFleet,
@@ -410,19 +385,11 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
             ),
           ),
         ),
-        if (isNarrow && _selectedDetailId != null)
-          GameMapNarrowDetailOverlay(
+        if (isNarrow)
+          GameMapNarrowDetailOverlaySlot(
             game: widget.game,
             region: _currentRegion,
-            selectedId: _selectedDetailId!,
-            displayId: _displayId,
             humanPlayerId: _humanPlayerId,
-            hoveredTileKey: _hoveredTileKey,
-            onHighlightTile: (k) => setState(() => _highlightedTileKey = k),
-            onClose: () => setState(() {
-              _selectedDetailId = null;
-              _highlightedTileKey = null;
-            }),
           ),
       ],
     );

--- a/app/lib/features/game/flame/game_map_area_state_logic.dart
+++ b/app/lib/features/game/flame/game_map_area_state_logic.dart
@@ -2,20 +2,6 @@ import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
 
 /// Pure-ish helpers for `GameMapArea` state translation.
 class GameMapAreaStateLogic {
-  static String displayIdFromHover({
-    required String? hoveredTileKey,
-    required String? hoveredDetailId,
-    required String? selectedDetailId,
-  }) {
-    if (hoveredTileKey != null) {
-      final parts = hoveredTileKey.split('|');
-      if (parts.length >= 2) {
-        return '${parts[0]}|${parts[1]}';
-      }
-    }
-    return hoveredDetailId ?? selectedDetailId ?? '';
-  }
-
   static int regionIndexFromWorldRegionId(String regionId) {
     if (regionId == 'newWorld') return 1;
     return 0; // oldWorld (default)

--- a/app/lib/features/game/flame/game_map_canvas_stack.dart
+++ b/app/lib/features/game/flame/game_map_canvas_stack.dart
@@ -1,15 +1,18 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
 import 'package:colonizethis_map/colonizethis_map.dart' show RegionMapViewData;
 
+import '../../../../providers/map_province_panel_provider.dart';
 import '../../../../widgets/ct_region_map.dart'
     show BaseLayerDisplayMode, CtMapVisibilityMode, CtRegionMap;
 
-import '../widgets/province_sea_zone_detail_overlay.dart';
+import 'game_map_province_detail_side_panel.dart';
 
-/// Renders the Flame-backed map and the wide right-side detail overlay.
-class GameMapCanvasStack extends StatelessWidget {
+/// Renders the Flame-backed map and the wide right-side detail panel.
+/// Map and panel communicate only via [mapProvincePanelProvider].
+class GameMapCanvasStack extends ConsumerWidget {
   const GameMapCanvasStack({
     required this.isNarrow,
     required this.game,
@@ -17,19 +20,10 @@ class GameMapCanvasStack extends StatelessWidget {
     required this.baseLayerDisplayMode,
     required this.showBordersLayer,
     required this.humanPlayerId,
-    required this.selectedDetailId,
-    required this.displayId,
-    required this.hoveredTileKey,
-    required this.highlightedTileKey,
     required this.centerOnTileKey,
     required this.validTileKeysForSelection,
-    required this.onProvinceSelected,
-    required this.onProvinceHovered,
-    required this.onTileHovered,
     required this.onTileSelectedForWork,
     required this.onWorkTargetSelectionCancelled,
-    required this.onHighlightTile,
-    required this.onCloseDetailOverlay,
     super.key,
   });
 
@@ -39,25 +33,15 @@ class GameMapCanvasStack extends StatelessWidget {
   final BaseLayerDisplayMode baseLayerDisplayMode;
   final bool showBordersLayer;
   final String humanPlayerId;
-  final String? selectedDetailId;
-  final String displayId;
-  final String? hoveredTileKey;
-  final String? highlightedTileKey;
   final String? centerOnTileKey;
   final Set<String>? validTileKeysForSelection;
-
-  final void Function(String provinceId) onProvinceSelected;
-  final void Function(String? provinceId) onProvinceHovered;
-  final void Function(String? tileKey) onTileHovered;
 
   final void Function(String tileKey)? onTileSelectedForWork;
   final VoidCallback? onWorkTargetSelectionCancelled;
 
-  final void Function(String?) onHighlightTile;
-  final VoidCallback onCloseDetailOverlay;
-
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final panel = ref.watch(mapProvincePanelProvider);
     final inWorkTargetSelectionMode = validTileKeysForSelection != null;
     return Positioned.fill(
       child: Stack(
@@ -71,10 +55,16 @@ class GameMapCanvasStack extends StatelessWidget {
                   showBordersLayer: showBordersLayer,
                   visibilityMode: CtMapVisibilityMode.playerConstrained,
                   baseLayerDisplayMode: baseLayerDisplayMode,
-                  onProvinceSelected: onProvinceSelected,
-                  onProvinceHovered: onProvinceHovered,
-                  onTileHovered: onTileHovered,
-                  highlightedTileKey: highlightedTileKey,
+                  onProvinceSelected: null,
+                  onMapTileTappedForDetail: inWorkTargetSelectionMode
+                      ? null
+                      : (tk) => ref
+                            .read(mapProvincePanelProvider.notifier)
+                            .reportMapTileTapped(tk),
+                  onProvinceHovered: (_) {},
+                  onTileHovered: (_) {},
+                  selectedTileKey: panel.selectedTileKey,
+                  secondaryHighlightTileKey: panel.secondaryHighlightTileKey,
                   centerOnTileKey: centerOnTileKey,
                   validTileKeys: validTileKeysForSelection,
                   onTileSelected: onTileSelectedForWork,
@@ -82,24 +72,14 @@ class GameMapCanvasStack extends StatelessWidget {
                       onWorkTargetSelectionCancelled,
                 ),
               ),
-              if (!isNarrow && selectedDetailId != null)
-                SizedBox(
-                  width: 320,
-                  child: ProvinceSeaZoneDetailOverlay(
-                    game: game,
-                    region: region,
-                    selectedId: selectedDetailId!,
-                    displayId: displayId,
-                    humanPlayerId: humanPlayerId,
-                    hoveredTileKey: hoveredTileKey,
-                    onHighlightTile: (k) => onHighlightTile(k),
-                    onClose: onCloseDetailOverlay,
-                  ),
+              if (!isNarrow)
+                GameMapProvinceDetailSidePanel(
+                  game: game,
+                  region: region,
+                  humanPlayerId: humanPlayerId,
                 ),
             ],
           ),
-          // Cancel button overlay for work target selection mode.
-          // SPEC/ui/map-widget.md § Work target selection mode.
           if (inWorkTargetSelectionMode)
             Positioned(
               top: 8,

--- a/app/lib/features/game/flame/game_map_province_detail_side_panel.dart
+++ b/app/lib/features/game/flame/game_map_province_detail_side_panel.dart
@@ -1,15 +1,14 @@
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-
-import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
-import 'package:colonizethis_map/colonizethis_map.dart' show RegionMapViewData;
 
 import '../../../../providers/map_province_panel_provider.dart';
 import '../widgets/province_sea_zone_detail_overlay.dart';
 
-/// Narrow-layout bottom sheet host; reads [mapProvincePanelProvider] only.
-class GameMapNarrowDetailOverlaySlot extends ConsumerWidget {
-  const GameMapNarrowDetailOverlaySlot({
+/// Wide-layout province / sea zone panel; reads [mapProvincePanelProvider] only.
+class GameMapProvinceDetailSidePanel extends ConsumerWidget {
+  const GameMapProvinceDetailSidePanel({
     required this.game,
     required this.region,
     required this.humanPlayerId,
@@ -32,7 +31,7 @@ class GameMapNarrowDetailOverlaySlot extends ConsumerWidget {
       return const SizedBox.shrink();
     }
     return SizedBox(
-      height: MediaQuery.sizeOf(context).height * 0.33,
+      width: 320,
       child: ProvinceSeaZoneDetailOverlay(
         game: game,
         region: region,

--- a/app/lib/features/game/flame/region_map_component.dart
+++ b/app/lib/features/game/flame/region_map_component.dart
@@ -93,10 +93,12 @@ class CtRegionMapComponent extends PositionComponent {
     this.baseLayerDisplayMode =
         BaseLayerDisplayMode.terrainResourcesImprovements,
     this.onProvinceSelected,
+    this.onMapTileTappedForDetail,
     this.onProvinceHovered,
     this.onTileHovered,
     this.onTileTapped,
-    this.highlightedTileKey,
+    this.selectedTileKey,
+    this.secondaryHighlightTileKey,
     this.validTileKeys,
   });
 
@@ -107,10 +109,12 @@ class CtRegionMapComponent extends PositionComponent {
   CtMapVisibilityMode visibilityMode;
   BaseLayerDisplayMode baseLayerDisplayMode;
   void Function(String provinceId)? onProvinceSelected;
+  void Function(String tileKey)? onMapTileTappedForDetail;
   void Function(String? provinceId)? onProvinceHovered;
   void Function(String? tileKey)? onTileHovered;
   void Function(String? tileKey)? onTileTapped;
-  String? highlightedTileKey;
+  String? selectedTileKey;
+  String? secondaryHighlightTileKey;
   Set<String>? validTileKeys;
 
   int? _hoveredTileX;
@@ -200,11 +204,8 @@ class CtRegionMapComponent extends PositionComponent {
     }
     // Not in work target mode: allow province selection.
     final provinceId = '${region.regionId}|${cell.regionCellId}';
+    onMapTileTappedForDetail?.call(tileKey);
     onProvinceSelected?.call(provinceId);
-
-    // On touch/mobile, treat tap as hover so the selector and province glow
-    // move to the tapped tile (for non-unrevealed tiles). SPEC/ui/map-widget.md.
-    _setHoverFromCell(x, y);
   }
 
   @override
@@ -227,8 +228,11 @@ class CtRegionMapComponent extends PositionComponent {
     if (_hoveredTileX != null && _hoveredTileY != null) {
       _paintSelector(canvas);
     }
-    if (highlightedTileKey != null) {
-      _paintHighlightedTile(canvas);
+    if (selectedTileKey != null) {
+      _paintSelectedTile(canvas);
+    }
+    if (secondaryHighlightTileKey != null) {
+      _paintSecondaryHighlightTile(canvas);
     }
     if (validTileKeys != null && validTileKeys!.isNotEmpty) {
       _paintValidTilesGlow(canvas);
@@ -257,9 +261,31 @@ class CtRegionMapComponent extends PositionComponent {
     }
   }
 
-  void _paintHighlightedTile(Canvas canvas) {
-    final key = highlightedTileKey!;
-    final parts = key.split('|');
+  void _paintSelectedTile(Canvas canvas) {
+    _paintTileOutlineRing(
+      canvas,
+      tileKey: selectedTileKey!,
+      color: const Color(0xFFFFAA00),
+      strokeWidth: 3,
+    );
+  }
+
+  void _paintSecondaryHighlightTile(Canvas canvas) {
+    _paintTileOutlineRing(
+      canvas,
+      tileKey: secondaryHighlightTileKey!,
+      color: const Color(0xFF66D9FF),
+      strokeWidth: 2.5,
+    );
+  }
+
+  void _paintTileOutlineRing(
+    Canvas canvas, {
+    required String tileKey,
+    required Color color,
+    required double strokeWidth,
+  }) {
+    final parts = tileKey.split('|');
     if (parts.length < 4) return;
     if (parts[0] != region.regionId) return;
     final x = int.tryParse(parts[2]);
@@ -271,8 +297,8 @@ class CtRegionMapComponent extends PositionComponent {
     final rect = Rect.fromLTWH(left, top, cellSize, cellSize);
     final paint = Paint()
       ..style = PaintingStyle.stroke
-      ..strokeWidth = 2.5
-      ..color = const Color(0xFFFFAA00);
+      ..strokeWidth = strokeWidth
+      ..color = color;
     canvas.drawRect(rect, paint);
   }
 

--- a/app/lib/features/game/widgets/province_overlay_demo_data.dart
+++ b/app/lib/features/game/widgets/province_overlay_demo_data.dart
@@ -24,6 +24,20 @@ String get sampleProvinceIdForOverlay {
   return '${region.regionId}|p1';
 }
 
+/// A full tile key in [sampleProvinceIdForOverlay] for Tile section demos/tests.
+String get sampleTileKeyForProvinceOverlay {
+  final game = getDebugInitGameResult().game;
+  final region = getDebugInitGameResult().mapViewData.oldWorld;
+  final provinceId = sampleProvinceIdForOverlay;
+  final tiles =
+      game.worldState.tileKeysByRegionAndProvince[region.regionId]?[provinceId];
+  if (tiles != null && tiles.isNotEmpty) {
+    return tiles.first;
+  }
+  final cell = region.cells.firstWhere((c) => !c.isSea);
+  return '${region.regionId}|${cell.regionCellId}|${cell.x}|${cell.y}';
+}
+
 /// First sea zone prefixed id in Old World (for overlay story selectedId).
 String get sampleSeaZoneIdForOverlay {
   final region = getDebugInitGameResult().mapViewData.oldWorld;

--- a/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
+++ b/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
@@ -9,30 +9,25 @@ import 'package:colonizethis_app/widgets/ct_tab_strip.dart';
 import 'package:flutter/material.dart';
 
 /// Overlay showing province or sea zone details. Toggleable; responsive; max 1/3 screen.
-/// When [hoveredTileKey] is set, overlay shows that tile's info and uses its province for content;
-/// otherwise shows [displayId]. Hover updates content immediately when overlay is open.
+/// [displayId] is the province or sea-zone id (`regionId|localId`) for tab content;
+/// [selectedTileKey] drives the Tile section and must stay in sync with the map selection.
 class ProvinceSeaZoneDetailOverlay extends StatelessWidget {
   const ProvinceSeaZoneDetailOverlay({
     super.key,
     required this.game,
     required this.region,
-    required this.selectedId,
     required this.displayId,
+    required this.selectedTileKey,
     required this.humanPlayerId,
-    this.hoveredTileKey,
     this.onHighlightTile,
     this.onClose,
   });
 
   final Game game;
   final RegionMapViewData region;
-  /// Pinned selection (click-to-toggle close).
-  final String selectedId;
-  /// Province or sea zone id to display (hovered when overlay open, else selected).
   final String displayId;
+  final String? selectedTileKey;
   final String humanPlayerId;
-  /// When set, tile section shows this tile's coords, terrain, resources, prospected, improvements, roads, civilian units.
-  final String? hoveredTileKey;
   final void Function(String? tileKey)? onHighlightTile;
   final VoidCallback? onClose;
 
@@ -55,22 +50,36 @@ class ProvinceSeaZoneDetailOverlay extends StatelessWidget {
             game: game,
             region: region,
             seaZoneId: displayId,
-            hoveredTileKey: hoveredTileKey,
           )
         : _provinceContent(
             game: game,
             region: region,
             provinceId: displayId,
             humanPlayerId: humanPlayerId,
-            hoveredTileKey: hoveredTileKey,
+            selectedTileKey: selectedTileKey,
             onHighlightTile: onHighlightTile,
           );
     return LayoutBuilder(
       builder: (context, constraints) {
-        // Desktop: full height of side panel; mobile: max one-third screen (SPEC).
-        final maxHeight = isNarrow
-            ? MediaQuery.sizeOf(context).height * 0.33
-            : constraints.maxHeight;
+        // Narrow full-width (mobile): cap at one-third screen (SPEC). Narrow
+        // side rail (width < screen): use parent height. Parent already capped
+        // to ≤ one-third (bottom slot): honor that height.
+        final mqSize = MediaQuery.sizeOf(context);
+        final thirdScreen = mqSize.height * 0.33;
+        final isFullWidthNarrow =
+            isNarrow && (constraints.maxWidth >= mqSize.width - 8);
+        final double maxHeight;
+        if (!isNarrow) {
+          maxHeight = constraints.maxHeight;
+        } else if (!constraints.maxHeight.isFinite) {
+          maxHeight = thirdScreen;
+        } else if (constraints.maxHeight <= thirdScreen + 1) {
+          maxHeight = constraints.maxHeight;
+        } else if (isFullWidthNarrow) {
+          maxHeight = thirdScreen;
+        } else {
+          maxHeight = constraints.maxHeight;
+        }
         return Padding(
           padding: const EdgeInsets.all(8),
           child: ConstrainedBox(
@@ -99,7 +108,14 @@ class ProvinceSeaZoneDetailOverlay extends StatelessWidget {
                     child: isNarrow
                         ? CtTabStrip(
                             tabLabels: content.tabLabels,
-                            tabViews: content.tabViews,
+                            tabViews: content.tabViews
+                                .map(
+                                  (w) => SingleChildScrollView(
+                                    physics: const ClampingScrollPhysics(),
+                                    child: w,
+                                  ),
+                                )
+                                .toList(),
                             contentPadding: const EdgeInsets.all(12),
                           )
                         : SingleChildScrollView(
@@ -163,7 +179,7 @@ _OverlayContent _provinceContent({
   required RegionMapViewData region,
   required String provinceId,
   required String humanPlayerId,
-  String? hoveredTileKey,
+  String? selectedTileKey,
   void Function(String?)? onHighlightTile,
 }) {
   final parts = provinceId.split('|');
@@ -176,15 +192,17 @@ _OverlayContent _provinceContent({
             c.visibility != TileVisibility.unrevealed,
       );
   if (isFullyUnrevealed) {
-    final placeholder = _buildSection(
-      'Tile',
-      const Text('???'),
-    );
+    final politicalObs = _buildSection('Political', const Text('???'));
+    final tileObs = _buildSection('Tile', const Text('???'));
     final sections = Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: const [
         Text('Political', style: TextStyle(fontWeight: FontWeight.bold)),
+        SizedBox(height: 4),
+        Text('???'),
+        SizedBox(height: 12),
+        Text('Tile', style: TextStyle(fontWeight: FontWeight.bold)),
         SizedBox(height: 4),
         Text('???'),
         SizedBox(height: 12),
@@ -206,16 +224,16 @@ _OverlayContent _provinceContent({
       ],
     );
     const tabLabels = [
-      'Tile',
       'Political',
+      'Tile',
       'Economic',
       'Military',
       'Civilian',
       'Naval',
     ];
     final tabViews = [
-      placeholder,
-      const _ObfuscatedSection(),
+      politicalObs,
+      tileObs,
       const _ObfuscatedSection(),
       const _ObfuscatedSection(),
       const _ObfuscatedSection(),
@@ -276,7 +294,7 @@ _OverlayContent _provinceContent({
     provinceId: provinceId,
     humanPlayerId: humanPlayerId,
     civilianCount: civilian.length,
-    hoveredTileKey: hoveredTileKey,
+    selectedTileKey: selectedTileKey,
   );
   final political = _buildPoliticalSection(
     name: province?.displayName ?? provinceId,
@@ -295,16 +313,16 @@ _OverlayContent _provinceContent({
   final naval = _buildNavalSection(game, fleetsInPort);
 
   const tabLabels = [
-    'Tile',
     'Political',
+    'Tile',
     'Economic',
     'Military',
     'Civilian',
     'Naval',
   ];
   final tabViews = [
-    tileSection,
     political,
+    tileSection,
     economic,
     militarySection,
     civilianSection,
@@ -314,8 +332,8 @@ _OverlayContent _provinceContent({
     crossAxisAlignment: CrossAxisAlignment.start,
     mainAxisSize: MainAxisSize.min,
     children: [
-      tileSection,
       political,
+      tileSection,
       economic,
       militarySection,
       civilianSection,
@@ -331,12 +349,15 @@ Widget _buildTileSection({
   required String provinceId,
   required String humanPlayerId,
   required int civilianCount,
-  String? hoveredTileKey,
+  String? selectedTileKey,
 }) {
-  if (hoveredTileKey == null) {
-    return _buildSection('Tile', const Text('Hover a tile to see details.'));
+  if (selectedTileKey == null) {
+    return _buildSection(
+      'Tile',
+      const Text('Click a tile to see details.'),
+    );
   }
-  final parts = hoveredTileKey.split('|');
+  final parts = selectedTileKey.split('|');
   if (parts.length < 4 || parts[0] != region.regionId) {
     return _buildSection('Tile', const Text('—'));
   }
@@ -367,11 +388,25 @@ Widget _buildTileSection({
   final tileState = game.worldState.tileState;
   final resourceByTile = game.worldState.resourceByTileKey;
   final prospected = game.worldState.playerProspectedTiles[humanPlayerId] ?? {};
+  const mineralResources = {
+    'iron',
+    'copper',
+    'tin',
+    'coal',
+    'silver',
+    'gold',
+    'gems',
+    'diamonds',
+  };
   final terrainStr = cell.terrainType?.name ?? cell.terrainTypeId ?? '—';
-  final resource = resourceByTile[hoveredTileKey] ?? cell.resourceId ?? '—';
-  final isProspected = prospected.contains(hoveredTileKey);
-  final impLevel = tileState.improvementLevel(hoveredTileKey);
-  final roadLevel = cell.isSea ? null : tileState.roadLevel(hoveredTileKey);
+  final resourceRaw = resourceByTile[selectedTileKey] ?? cell.resourceId;
+  final resource = resourceRaw ?? '—';
+  final prospectable =
+      resourceRaw != null && mineralResources.contains(resourceRaw);
+  final prospectedLabel =
+      !prospectable ? '—' : (prospected.contains(selectedTileKey) ? 'yes' : 'no');
+  final impLevel = tileState.improvementLevel(selectedTileKey);
+  final roadLevel = cell.isSea ? null : tileState.roadLevel(selectedTileKey);
   final roadLabel = roadLevel == null
       ? '—'
       : switch (roadLevel) {
@@ -392,7 +427,7 @@ Widget _buildTileSection({
       Text('Coordinates: ($x, $y)'),
       Text('Terrain: $terrainStr'),
       Text('Resource: $resource'),
-      Text('Prospected: ${isProspected ? 'yes' : 'no'}'),
+      Text('Prospected: $prospectedLabel'),
       Text('Improvement: ${improvementName != null ? '$improvementName L$impLevel' : '—'}'),
       Text('Road / railroad: $roadLabel'),
       Text('Civilian units (province): $civilianCount'),
@@ -404,7 +439,6 @@ _OverlayContent _seaZoneContent({
   required Game game,
   required RegionMapViewData region,
   required String seaZoneId,
-  String? hoveredTileKey,
 }) {
   final parts = seaZoneId.split('|');
   final regionId = parts.isNotEmpty ? parts[0] : 'oldWorld';

--- a/app/lib/providers/map_province_panel_provider.dart
+++ b/app/lib/providers/map_province_panel_provider.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Shared UI state between the region map and the province/sea detail panel.
+/// Map and panel stay decoupled: both read/write this provider only.
+@immutable
+class MapProvincePanelUiState {
+  const MapProvincePanelUiState({
+    this.overlayOpen = false,
+    this.selectedTileKey,
+    this.secondaryHighlightTileKey,
+  });
+
+  final bool overlayOpen;
+  final String? selectedTileKey;
+
+  /// List-hover / locate secondary cursor on the map (not the orange selection).
+  final String? secondaryHighlightTileKey;
+}
+
+/// Province / sea-zone id (`regionId|localId`) derived from a full tile key.
+String? displayProvinceOrSeaIdFromTileKey(String? tileKey) {
+  if (tileKey == null) return null;
+  final parts = tileKey.split('|');
+  if (parts.length < 4) return null;
+  return '${parts[0]}|${parts[1]}';
+}
+
+class MapProvincePanelNotifier extends StateNotifier<MapProvincePanelUiState> {
+  MapProvincePanelNotifier() : super(const MapProvincePanelUiState());
+
+  /// User tapped a map cell: select tile, open panel, keep secondary highlight as-is.
+  void reportMapTileTapped(String tileKey) {
+    state = MapProvincePanelUiState(
+      overlayOpen: true,
+      selectedTileKey: tileKey,
+      secondaryHighlightTileKey: state.secondaryHighlightTileKey,
+    );
+  }
+
+  void closeOverlay() {
+    state = MapProvincePanelUiState(
+      overlayOpen: false,
+      selectedTileKey: state.selectedTileKey,
+      secondaryHighlightTileKey: state.secondaryHighlightTileKey,
+    );
+  }
+
+  void setSecondaryHighlight(String? tileKey) {
+    state = MapProvincePanelUiState(
+      overlayOpen: state.overlayOpen,
+      selectedTileKey: state.selectedTileKey,
+      secondaryHighlightTileKey: tileKey,
+    );
+  }
+
+  void reset() {
+    state = const MapProvincePanelUiState();
+  }
+}
+
+final mapProvincePanelProvider =
+    StateNotifierProvider<MapProvincePanelNotifier, MapProvincePanelUiState>(
+      (ref) => MapProvincePanelNotifier(),
+    );

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -665,8 +665,8 @@ List<WidgetbookNode> get provinceOverlayDirectories => [
             child: ProvinceSeaZoneDetailOverlay(
               game: game,
               region: region,
-              selectedId: sampleProvinceIdForOverlay,
               displayId: sampleProvinceIdForOverlay,
+              selectedTileKey: sampleTileKeyForProvinceOverlay,
               humanPlayerId: game.players.first.id,
               onClose: () {},
             ),
@@ -684,8 +684,8 @@ List<WidgetbookNode> get provinceOverlayDirectories => [
             child: ProvinceSeaZoneDetailOverlay(
               game: game,
               region: region,
-              selectedId: sampleSeaZoneIdForOverlay,
               displayId: sampleSeaZoneIdForOverlay,
+              selectedTileKey: null,
               humanPlayerId: game.players.first.id,
               onClose: () {},
             ),
@@ -703,8 +703,8 @@ List<WidgetbookNode> get provinceOverlayDirectories => [
               return ProvinceSeaZoneDetailOverlay(
                 game: game,
                 region: region,
-                selectedId: sampleProvinceIdForOverlay,
                 displayId: sampleProvinceIdForOverlay,
+                selectedTileKey: sampleTileKeyForProvinceOverlay,
                 humanPlayerId: game.players.first.id,
                 onClose: () {},
               );
@@ -784,7 +784,7 @@ class _CivilianPanelWithMapStoryState
   final List<StreamSubscription<dynamic>> _sessionCommandSubs = [];
   Orders _orders = const Orders();
   int _regionIndex = 0;
-  String? _highlightedTileKey;
+  String? _secondaryHighlightTileKey;
   String? _centerOnTileKey;
   ({Unit unit, String workTarget})? _workTargetSelection;
   CtMapVisibilityMode _visibilityMode = CtMapVisibilityMode.full;
@@ -880,7 +880,7 @@ class _CivilianPanelWithMapStoryState
     if (tileKey == null) return;
     final regionId = Unit.regionIdFromTileKey(tileKey);
     setState(() {
-      _highlightedTileKey = tileKey;
+      _secondaryHighlightTileKey = tileKey;
       _centerOnTileKey = tileKey;
       if (regionId == 'newWorld') {
         _regionIndex = 1;
@@ -985,7 +985,7 @@ class _CivilianPanelWithMapStoryState
               cellSizePx: 24,
               visibilityMode: _visibilityMode,
               onProvinceSelected: (_) {},
-              highlightedTileKey: _highlightedTileKey,
+              secondaryHighlightTileKey: _secondaryHighlightTileKey,
               centerOnTileKey: _centerOnTileKey,
               validTileKeys: _validTileKeys,
               onTileSelected: _workTargetSelection != null
@@ -1098,12 +1098,12 @@ class _MilitaryPanelWithMapStory extends StatefulWidget {
 class _MilitaryPanelWithMapStoryState
     extends State<_MilitaryPanelWithMapStory> {
   int _regionIndex = 0;
-  String? _highlightedTileKey;
+  String? _secondaryHighlightTileKey;
   String? _centerOnTileKey;
 
   void _onLocateTile(String tileKey, String regionId) {
     setState(() {
-      _highlightedTileKey = tileKey;
+      _secondaryHighlightTileKey = tileKey;
       _centerOnTileKey = tileKey;
       if (regionId == 'newWorld') {
         _regionIndex = 1;
@@ -1160,7 +1160,7 @@ class _MilitaryPanelWithMapStoryState
                     region: region,
                     cellSizePx: 24,
                     onProvinceSelected: (_) {},
-                    highlightedTileKey: _highlightedTileKey,
+                    secondaryHighlightTileKey: _secondaryHighlightTileKey,
                     centerOnTileKey: _centerOnTileKey,
                   ),
                 ),
@@ -1192,7 +1192,7 @@ class _NavalPanelWithMapStory extends StatefulWidget {
 
 class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
   int _regionIndex = 0;
-  String? _highlightedTileKey;
+  String? _secondaryHighlightTileKey;
   String? _centerOnTileKey;
   late Game _game;
   late AppEventBus _navalBus;
@@ -1218,7 +1218,7 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
 
   void _onLocateFleet(String tileKey, String regionId) {
     setState(() {
-      _highlightedTileKey = tileKey;
+      _secondaryHighlightTileKey = tileKey;
       _centerOnTileKey = tileKey;
       if (regionId == 'newWorld') {
         _regionIndex = 1;
@@ -1274,7 +1274,7 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
                     region: region,
                     cellSizePx: 24,
                     onProvinceSelected: (_) {},
-                    highlightedTileKey: _highlightedTileKey,
+                    secondaryHighlightTileKey: _secondaryHighlightTileKey,
                     centerOnTileKey: _centerOnTileKey,
                   ),
                 ),
@@ -1307,33 +1307,56 @@ class _MapWithOverlayStory extends StatefulWidget {
 }
 
 class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
-  late String _selectedId;
-  String? _hoveredDetailId;
-  String? _hoveredTileKey;
-  String? _highlightedTileKey;
+  late String? _selectedTileKey;
+  String? _secondaryHighlightTileKey;
+  var _overlayOpen = true;
   CtMapVisibilityMode _visibilityMode = CtMapVisibilityMode.full;
 
-  String get _displayId {
-    if (_hoveredTileKey != null) {
-      final parts = _hoveredTileKey!.split('|');
-      if (parts.length >= 2) {
-        return '${parts[0]}|${parts[1]}';
-      }
-    }
-    return _hoveredDetailId ?? _selectedId;
+  String? _displayIdFromTile(String? tileKey) {
+    if (tileKey == null) return null;
+    final parts = tileKey.split('|');
+    if (parts.length < 4) return null;
+    return '${parts[0]}|${parts[1]}';
   }
 
   @override
   void initState() {
     super.initState();
-    _selectedId = widget.selectedId;
+    final mapViewData = debugMapViewDataWithVisibilityForFirstPlayer();
+    final region = mapViewData.oldWorld;
+    final game = getDebugInitGameResult().game;
+    final tiles =
+        game.worldState.tileKeysByRegionAndProvince[region.regionId]?[widget.selectedId];
+    if (tiles != null && tiles.isNotEmpty) {
+      _selectedTileKey = tiles.first;
+    } else {
+      final cell = region.cells.firstWhere(
+        (c) => '${region.regionId}|${c.regionCellId}' == widget.selectedId,
+      );
+      _selectedTileKey =
+          '${region.regionId}|${cell.regionCellId}|${cell.x}|${cell.y}';
+    }
   }
 
   @override
   void didUpdateWidget(covariant _MapWithOverlayStory oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.selectedId != widget.selectedId) {
-      _selectedId = widget.selectedId;
+      final mapViewData = debugMapViewDataWithVisibilityForFirstPlayer();
+      final region = mapViewData.oldWorld;
+      final game = getDebugInitGameResult().game;
+      final tiles =
+          game.worldState.tileKeysByRegionAndProvince[region.regionId]?[widget.selectedId];
+      if (tiles != null && tiles.isNotEmpty) {
+        _selectedTileKey = tiles.first;
+      } else {
+        final cell = region.cells.firstWhere(
+          (c) => '${region.regionId}|${c.regionCellId}' == widget.selectedId,
+        );
+        _selectedTileKey =
+            '${region.regionId}|${cell.regionCellId}|${cell.x}|${cell.y}';
+      }
+      _overlayOpen = true;
     }
   }
 
@@ -1343,6 +1366,7 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
     final game = initResult.game;
     final mapViewData = debugMapViewDataWithVisibilityForFirstPlayer();
     final region = mapViewData.oldWorld;
+    final displayId = _displayIdFromTile(_selectedTileKey) ?? widget.selectedId;
     return LayoutBuilder(
       builder: (context, constraints) {
         final totalHeight = constraints.maxHeight > 0
@@ -1393,16 +1417,16 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
                         region: region,
                         cellSizePx: 28,
                         visibilityMode: _visibilityMode,
-                        onProvinceSelected: (id) =>
-                            setState(() => _selectedId = id),
-                        onProvinceHovered: (id) =>
-                            setState(() => _hoveredDetailId = id),
-                        onTileHovered: (key) =>
-                            setState(() => _hoveredTileKey = key),
-                        highlightedTileKey: _highlightedTileKey,
+                        onProvinceSelected: null,
+                        onMapTileTappedForDetail: (tk) => setState(() {
+                          _selectedTileKey = tk;
+                          _overlayOpen = true;
+                        }),
+                        selectedTileKey: _selectedTileKey,
+                        secondaryHighlightTileKey: _secondaryHighlightTileKey,
                       ),
                     ),
-                    if (_selectedId.isNotEmpty)
+                    if (_overlayOpen && _selectedTileKey != null)
                       Align(
                         alignment: Alignment.bottomCenter,
                         child: SizedBox(
@@ -1411,13 +1435,14 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
                           child: ProvinceSeaZoneDetailOverlay(
                             game: game,
                             region: region,
-                            selectedId: _selectedId,
-                            displayId: _displayId,
+                            displayId: displayId,
+                            selectedTileKey: _selectedTileKey,
                             humanPlayerId: 'gp1',
-                            hoveredTileKey: _hoveredTileKey,
                             onHighlightTile: (k) =>
-                                setState(() => _highlightedTileKey = k),
-                            onClose: () => setState(() => _selectedId = ''),
+                                setState(() => _secondaryHighlightTileKey = k),
+                            onClose: () => setState(() {
+                              _overlayOpen = false;
+                            }),
                           ),
                         ),
                       ),

--- a/app/lib/widgetbook/catalog.dart
+++ b/app/lib/widgetbook/catalog.dart
@@ -667,8 +667,8 @@ List<WidgetbookNode> get provinceOverlayDirectories => [
             child: ProvinceSeaZoneDetailOverlay(
               game: game,
               region: region,
-              selectedId: sampleProvinceIdForOverlay,
               displayId: sampleProvinceIdForOverlay,
+              selectedTileKey: sampleTileKeyForProvinceOverlay,
               humanPlayerId: game.players.first.id,
               onClose: () {},
             ),
@@ -686,8 +686,8 @@ List<WidgetbookNode> get provinceOverlayDirectories => [
             child: ProvinceSeaZoneDetailOverlay(
               game: game,
               region: region,
-              selectedId: sampleSeaZoneIdForOverlay,
               displayId: sampleSeaZoneIdForOverlay,
+              selectedTileKey: null,
               humanPlayerId: game.players.first.id,
               onClose: () {},
             ),
@@ -705,8 +705,8 @@ List<WidgetbookNode> get provinceOverlayDirectories => [
               return ProvinceSeaZoneDetailOverlay(
                 game: game,
                 region: region,
-                selectedId: sampleProvinceIdForOverlay,
                 displayId: sampleProvinceIdForOverlay,
+                selectedTileKey: sampleTileKeyForProvinceOverlay,
                 humanPlayerId: game.players.first.id,
                 onClose: () {},
               );
@@ -786,7 +786,7 @@ class _CivilianPanelWithMapStoryState
   final List<StreamSubscription<dynamic>> _sessionCommandSubs = [];
   Orders _orders = const Orders();
   int _regionIndex = 0;
-  String? _highlightedTileKey;
+  String? _secondaryHighlightTileKey;
   String? _centerOnTileKey;
   ({Unit unit, String workTarget})? _workTargetSelection;
   CtMapVisibilityMode _visibilityMode = CtMapVisibilityMode.full;
@@ -882,7 +882,7 @@ class _CivilianPanelWithMapStoryState
     if (tileKey == null) return;
     final regionId = Unit.regionIdFromTileKey(tileKey);
     setState(() {
-      _highlightedTileKey = tileKey;
+      _secondaryHighlightTileKey = tileKey;
       _centerOnTileKey = tileKey;
       if (regionId == 'newWorld') {
         _regionIndex = 1;
@@ -987,7 +987,7 @@ class _CivilianPanelWithMapStoryState
               cellSizePx: 24,
               visibilityMode: _visibilityMode,
               onProvinceSelected: (_) {},
-              highlightedTileKey: _highlightedTileKey,
+              secondaryHighlightTileKey: _secondaryHighlightTileKey,
               centerOnTileKey: _centerOnTileKey,
               validTileKeys: _validTileKeys,
               onTileSelected: _workTargetSelection != null
@@ -1100,12 +1100,12 @@ class _MilitaryPanelWithMapStory extends StatefulWidget {
 class _MilitaryPanelWithMapStoryState
     extends State<_MilitaryPanelWithMapStory> {
   int _regionIndex = 0;
-  String? _highlightedTileKey;
+  String? _secondaryHighlightTileKey;
   String? _centerOnTileKey;
 
   void _onLocateTile(String tileKey, String regionId) {
     setState(() {
-      _highlightedTileKey = tileKey;
+      _secondaryHighlightTileKey = tileKey;
       _centerOnTileKey = tileKey;
       if (regionId == 'newWorld') {
         _regionIndex = 1;
@@ -1162,7 +1162,7 @@ class _MilitaryPanelWithMapStoryState
                     region: region,
                     cellSizePx: 24,
                     onProvinceSelected: (_) {},
-                    highlightedTileKey: _highlightedTileKey,
+                    secondaryHighlightTileKey: _secondaryHighlightTileKey,
                     centerOnTileKey: _centerOnTileKey,
                   ),
                 ),
@@ -1194,7 +1194,7 @@ class _NavalPanelWithMapStory extends StatefulWidget {
 
 class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
   int _regionIndex = 0;
-  String? _highlightedTileKey;
+  String? _secondaryHighlightTileKey;
   String? _centerOnTileKey;
   late Game _game;
   late AppEventBus _navalBus;
@@ -1220,7 +1220,7 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
 
   void _onLocateFleet(String tileKey, String regionId) {
     setState(() {
-      _highlightedTileKey = tileKey;
+      _secondaryHighlightTileKey = tileKey;
       _centerOnTileKey = tileKey;
       if (regionId == 'newWorld') {
         _regionIndex = 1;
@@ -1276,7 +1276,7 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
                     region: region,
                     cellSizePx: 24,
                     onProvinceSelected: (_) {},
-                    highlightedTileKey: _highlightedTileKey,
+                    secondaryHighlightTileKey: _secondaryHighlightTileKey,
                     centerOnTileKey: _centerOnTileKey,
                   ),
                 ),
@@ -1309,33 +1309,56 @@ class _MapWithOverlayStory extends StatefulWidget {
 }
 
 class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
-  late String _selectedId;
-  String? _hoveredDetailId;
-  String? _hoveredTileKey;
-  String? _highlightedTileKey;
+  late String? _selectedTileKey;
+  String? _secondaryHighlightTileKey;
+  var _overlayOpen = true;
   CtMapVisibilityMode _visibilityMode = CtMapVisibilityMode.full;
 
-  String get _displayId {
-    if (_hoveredTileKey != null) {
-      final parts = _hoveredTileKey!.split('|');
-      if (parts.length >= 2) {
-        return '${parts[0]}|${parts[1]}';
-      }
-    }
-    return _hoveredDetailId ?? _selectedId;
+  String? _displayIdFromTile(String? tileKey) {
+    if (tileKey == null) return null;
+    final parts = tileKey.split('|');
+    if (parts.length < 4) return null;
+    return '${parts[0]}|${parts[1]}';
   }
 
   @override
   void initState() {
     super.initState();
-    _selectedId = widget.selectedId;
+    final mapViewData = debugMapViewDataWithVisibilityForFirstPlayer();
+    final region = mapViewData.oldWorld;
+    final game = getDebugInitGameResult().game;
+    final tiles =
+        game.worldState.tileKeysByRegionAndProvince[region.regionId]?[widget.selectedId];
+    if (tiles != null && tiles.isNotEmpty) {
+      _selectedTileKey = tiles.first;
+    } else {
+      final cell = region.cells.firstWhere(
+        (c) => '${region.regionId}|${c.regionCellId}' == widget.selectedId,
+      );
+      _selectedTileKey =
+          '${region.regionId}|${cell.regionCellId}|${cell.x}|${cell.y}';
+    }
   }
 
   @override
   void didUpdateWidget(covariant _MapWithOverlayStory oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.selectedId != widget.selectedId) {
-      _selectedId = widget.selectedId;
+      final mapViewData = debugMapViewDataWithVisibilityForFirstPlayer();
+      final region = mapViewData.oldWorld;
+      final game = getDebugInitGameResult().game;
+      final tiles =
+          game.worldState.tileKeysByRegionAndProvince[region.regionId]?[widget.selectedId];
+      if (tiles != null && tiles.isNotEmpty) {
+        _selectedTileKey = tiles.first;
+      } else {
+        final cell = region.cells.firstWhere(
+          (c) => '${region.regionId}|${c.regionCellId}' == widget.selectedId,
+        );
+        _selectedTileKey =
+            '${region.regionId}|${cell.regionCellId}|${cell.x}|${cell.y}';
+      }
+      _overlayOpen = true;
     }
   }
 
@@ -1345,6 +1368,7 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
     final game = initResult.game;
     final mapViewData = debugMapViewDataWithVisibilityForFirstPlayer();
     final region = mapViewData.oldWorld;
+    final displayId = _displayIdFromTile(_selectedTileKey) ?? widget.selectedId;
     return LayoutBuilder(
       builder: (context, constraints) {
         final totalHeight = constraints.maxHeight > 0
@@ -1395,16 +1419,16 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
                         region: region,
                         cellSizePx: 28,
                         visibilityMode: _visibilityMode,
-                        onProvinceSelected: (id) =>
-                            setState(() => _selectedId = id),
-                        onProvinceHovered: (id) =>
-                            setState(() => _hoveredDetailId = id),
-                        onTileHovered: (key) =>
-                            setState(() => _hoveredTileKey = key),
-                        highlightedTileKey: _highlightedTileKey,
+                        onProvinceSelected: null,
+                        onMapTileTappedForDetail: (tk) => setState(() {
+                          _selectedTileKey = tk;
+                          _overlayOpen = true;
+                        }),
+                        selectedTileKey: _selectedTileKey,
+                        secondaryHighlightTileKey: _secondaryHighlightTileKey,
                       ),
                     ),
-                    if (_selectedId.isNotEmpty)
+                    if (_overlayOpen && _selectedTileKey != null)
                       Align(
                         alignment: Alignment.bottomCenter,
                         child: SizedBox(
@@ -1413,13 +1437,14 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
                           child: ProvinceSeaZoneDetailOverlay(
                             game: game,
                             region: region,
-                            selectedId: _selectedId,
-                            displayId: _displayId,
+                            displayId: displayId,
+                            selectedTileKey: _selectedTileKey,
                             humanPlayerId: 'gp1',
-                            hoveredTileKey: _hoveredTileKey,
                             onHighlightTile: (k) =>
-                                setState(() => _highlightedTileKey = k),
-                            onClose: () => setState(() => _selectedId = ''),
+                                setState(() => _secondaryHighlightTileKey = k),
+                            onClose: () => setState(() {
+                              _overlayOpen = false;
+                            }),
                           ),
                         ),
                       ),

--- a/app/lib/widgets/ct_region_map.dart
+++ b/app/lib/widgets/ct_region_map.dart
@@ -22,10 +22,12 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
     BaseLayerDisplayMode baseLayerDisplayMode =
         BaseLayerDisplayMode.terrainResourcesImprovements,
     required void Function(String provinceId)? onProvinceSelected,
+    void Function(String tileKey)? onMapTileTappedForDetail,
     required VoidCallback? onRegionViewChanged,
     required void Function(String? provinceId)? onProvinceHovered,
     required void Function(String? tileKey)? onTileHovered,
-    required String? highlightedTileKey,
+    required String? selectedTileKey,
+    required String? secondaryHighlightTileKey,
     required Set<String>? validTileKeys,
     required void Function(String tileKey)? onTileSelected,
     required VoidCallback? onWorkTargetSelectionCancelled,
@@ -36,10 +38,12 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
        visibilityMode = visibilityMode,
        baseLayerDisplayMode = baseLayerDisplayMode,
        onProvinceSelected = onProvinceSelected,
+       onMapTileTappedForDetail = onMapTileTappedForDetail,
        onRegionViewChanged = onRegionViewChanged,
        onProvinceHovered = onProvinceHovered,
        onTileHovered = onTileHovered,
-       highlightedTileKey = highlightedTileKey,
+       selectedTileKey = selectedTileKey,
+       secondaryHighlightTileKey = secondaryHighlightTileKey,
        validTileKeys = validTileKeys,
        onTileSelected = onTileSelected,
        onWorkTargetSelectionCancelled = onWorkTargetSelectionCancelled;
@@ -51,10 +55,12 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
   CtMapVisibilityMode visibilityMode;
   BaseLayerDisplayMode baseLayerDisplayMode;
   void Function(String provinceId)? onProvinceSelected;
+  void Function(String tileKey)? onMapTileTappedForDetail;
   VoidCallback? onRegionViewChanged;
   void Function(String? provinceId)? onProvinceHovered;
   void Function(String? tileKey)? onTileHovered;
-  String? highlightedTileKey;
+  String? selectedTileKey;
+  String? secondaryHighlightTileKey;
   Set<String>? validTileKeys;
   void Function(String tileKey)? onTileSelected;
   VoidCallback? onWorkTargetSelectionCancelled;
@@ -76,8 +82,11 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
       visibilityMode: visibilityMode,
       baseLayerDisplayMode: baseLayerDisplayMode,
       onProvinceSelected: onProvinceSelected,
+      onMapTileTappedForDetail: onMapTileTappedForDetail,
       onProvinceHovered: onProvinceHovered,
       onTileHovered: onTileHovered,
+      selectedTileKey: selectedTileKey,
+      secondaryHighlightTileKey: secondaryHighlightTileKey,
       onTileTapped: (tileKey) {
         // Tap handler for work target selection mode.
         if (onTileSelected != null && validTileKeys != null) {
@@ -90,7 +99,6 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
           }
         }
       },
-      highlightedTileKey: highlightedTileKey,
       validTileKeys: validTileKeys,
     )..position = Vector2.zero();
     await world.add(_mapComponent);
@@ -109,8 +117,10 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
     bool? showBordersLayer,
     CtMapVisibilityMode? visibilityMode,
     BaseLayerDisplayMode? baseLayerDisplayMode,
-    String? highlightedTileKey,
-    bool clearHighlightedTileKey = false,
+    String? selectedTileKey,
+    String? secondaryHighlightTileKey,
+    bool clearSelectedTileKey = false,
+    bool clearSecondaryHighlightTileKey = false,
     Set<String>? validTileKeys,
     bool clearValidTileKeys = false,
     void Function(String tileKey)? onTileSelected,
@@ -131,11 +141,15 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
     if (baseLayerDisplayMode != null) {
       this.baseLayerDisplayMode = baseLayerDisplayMode;
     }
-    if (clearHighlightedTileKey) {
-      this.highlightedTileKey = null;
+    if (clearSelectedTileKey) {
+      this.selectedTileKey = null;
+    } else if (selectedTileKey != null) {
+      this.selectedTileKey = selectedTileKey;
     }
-    if (highlightedTileKey != null) {
-      this.highlightedTileKey = highlightedTileKey;
+    if (clearSecondaryHighlightTileKey) {
+      this.secondaryHighlightTileKey = null;
+    } else if (secondaryHighlightTileKey != null) {
+      this.secondaryHighlightTileKey = secondaryHighlightTileKey;
     }
     if (clearValidTileKeys) {
       this.validTileKeys = null;
@@ -154,7 +168,8 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
         ..showBordersLayer = this.showBordersLayer
         ..visibilityMode = this.visibilityMode
         ..baseLayerDisplayMode = this.baseLayerDisplayMode
-        ..highlightedTileKey = this.highlightedTileKey
+        ..selectedTileKey = this.selectedTileKey
+        ..secondaryHighlightTileKey = this.secondaryHighlightTileKey
         ..validTileKeys = this.validTileKeys;
     }
   }
@@ -324,10 +339,12 @@ class CtRegionMap extends StatefulWidget {
     this.visibilityMode = CtMapVisibilityMode.full,
     this.baseLayerDisplayMode,
     this.onProvinceSelected,
+    this.onMapTileTappedForDetail,
     this.onRegionViewChanged,
     this.onProvinceHovered,
     this.onTileHovered,
-    this.highlightedTileKey,
+    this.selectedTileKey,
+    this.secondaryHighlightTileKey,
     this.centerOnTileKey,
     this.validTileKeys,
     this.onTileSelected,
@@ -343,10 +360,12 @@ class CtRegionMap extends StatefulWidget {
   /// When null, full letters (terrain + resources + improvements) for backward compatibility.
   final BaseLayerDisplayMode? baseLayerDisplayMode;
   final void Function(String provinceId)? onProvinceSelected;
+  final void Function(String tileKey)? onMapTileTappedForDetail;
   final VoidCallback? onRegionViewChanged;
   final void Function(String? provinceId)? onProvinceHovered;
   final void Function(String? tileKey)? onTileHovered;
-  final String? highlightedTileKey;
+  final String? selectedTileKey;
+  final String? secondaryHighlightTileKey;
   final String? centerOnTileKey;
   final Set<String>? validTileKeys;
   final void Function(String tileKey)? onTileSelected;
@@ -374,7 +393,9 @@ class _CtRegionMapState extends State<CtRegionMap> {
         widget.visibilityMode != oldWidget.visibilityMode ||
         widget.baseLayerDisplayMode != oldWidget.baseLayerDisplayMode ||
         widget.validTileKeys != oldWidget.validTileKeys ||
-        widget.highlightedTileKey != oldWidget.highlightedTileKey ||
+        widget.selectedTileKey != oldWidget.selectedTileKey ||
+        widget.secondaryHighlightTileKey !=
+            oldWidget.secondaryHighlightTileKey ||
         widget.onTileSelected != oldWidget.onTileSelected ||
         widget.onWorkTargetSelectionCancelled !=
             oldWidget.onWorkTargetSelectionCancelled) {
@@ -386,8 +407,11 @@ class _CtRegionMapState extends State<CtRegionMap> {
         baseLayerDisplayMode:
             widget.baseLayerDisplayMode ??
             BaseLayerDisplayMode.terrainResourcesImprovements,
-        highlightedTileKey: widget.highlightedTileKey,
-        clearHighlightedTileKey: widget.highlightedTileKey == null,
+        selectedTileKey: widget.selectedTileKey,
+        clearSelectedTileKey: widget.selectedTileKey == null,
+        secondaryHighlightTileKey: widget.secondaryHighlightTileKey,
+        clearSecondaryHighlightTileKey:
+            widget.secondaryHighlightTileKey == null,
         validTileKeys: widget.validTileKeys,
         clearValidTileKeys:
             widget.validTileKeys == null && oldWidget.validTileKeys != null,
@@ -414,10 +438,12 @@ class _CtRegionMapState extends State<CtRegionMap> {
           widget.baseLayerDisplayMode ??
           BaseLayerDisplayMode.terrainResourcesImprovements,
       onProvinceSelected: widget.onProvinceSelected,
+      onMapTileTappedForDetail: widget.onMapTileTappedForDetail,
       onRegionViewChanged: widget.onRegionViewChanged,
       onProvinceHovered: widget.onProvinceHovered,
       onTileHovered: widget.onTileHovered,
-      highlightedTileKey: widget.highlightedTileKey,
+      selectedTileKey: widget.selectedTileKey,
+      secondaryHighlightTileKey: widget.secondaryHighlightTileKey,
       validTileKeys: widget.validTileKeys,
       onTileSelected: widget.onTileSelected,
       onWorkTargetSelectionCancelled: widget.onWorkTargetSelectionCancelled,

--- a/app/test/ct_region_map_test.dart
+++ b/app/test/ct_region_map_test.dart
@@ -68,6 +68,9 @@ void main() {
     void Function(String)? onProvinceSelected,
     void Function(String?)? onProvinceHovered,
     void Function(String?)? onTileHovered,
+    void Function(String)? onMapTileTappedForDetail,
+    String? selectedTileKey,
+    String? secondaryHighlightTileKey,
     VoidCallback? onRegionViewChanged,
   }) {
     return MaterialApp(
@@ -87,6 +90,9 @@ void main() {
               onProvinceSelected: onProvinceSelected,
               onProvinceHovered: onProvinceHovered,
               onTileHovered: onTileHovered,
+              onMapTileTappedForDetail: onMapTileTappedForDetail,
+              selectedTileKey: selectedTileKey,
+              secondaryHighlightTileKey: secondaryHighlightTileKey,
               onRegionViewChanged: onRegionViewChanged,
             ),
           ),
@@ -532,16 +538,16 @@ void main() {
     );
 
     testWidgets(
-      'tap invokes onTileHovered with tapped tile key so overlay shows tile on mobile',
+      'tap invokes onMapTileTappedForDetail with full tile key',
       (WidgetTester tester) async {
         final region = _oldWorldRegion();
         String? selectedId;
-        String? hoveredTileKey;
+        String? detailTileKey;
         await tester.pumpWidget(
           _buildCtRegionMap(
             region: region,
             onProvinceSelected: (id) => selectedId = id,
-            onTileHovered: (key) => hoveredTileKey = key,
+            onMapTileTappedForDetail: (tk) => detailTileKey = tk,
           ),
         );
         await tester.pump();
@@ -552,8 +558,8 @@ void main() {
         await tester.pump();
 
         expect(selectedId, isNotNull);
-        expect(hoveredTileKey, isNotNull);
-        final parts = hoveredTileKey!.split('|');
+        expect(detailTileKey, isNotNull);
+        final parts = detailTileKey!.split('|');
         expect(parts.length, 4);
         expect(parts[0], region.regionId);
         expect(parts[1], selectedId!.split('|').last);
@@ -564,7 +570,7 @@ void main() {
     );
 
     testWidgets(
-      'tap also drives hover selector on mobile (no crash path)',
+      'tap does not invoke onTileHovered without pointer hover',
       (WidgetTester tester) async {
         final region = _oldWorldRegion();
         String? hoveredTileKey;
@@ -581,10 +587,7 @@ void main() {
         await tester.tap(mapFinder);
         await tester.pump();
 
-        // The game wrapper translates tap into a world-position tap; as long as
-        // we get a hovered tile key back, the Flame component has updated its
-        // internal hover state for the tapped tile (selector + glow).
-        expect(hoveredTileKey, isNotNull);
+        expect(hoveredTileKey, isNull);
       },
       timeout: const Timeout(Duration(seconds: 5)),
     );

--- a/app/test/game_map_area_state_logic_test.dart
+++ b/app/test/game_map_area_state_logic_test.dart
@@ -3,45 +3,22 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_app/features/game/flame/game_map_area_state_logic.dart';
+import 'package:colonizethis_app/providers/map_province_panel_provider.dart';
 
 void main() {
   suppressLogsForTests();
   group('GameMapAreaStateLogic', () {
-    group('displayIdFromHover', () {
-      test('uses hoveredTileKey province when provided', () {
-        final displayId = GameMapAreaStateLogic.displayIdFromHover(
-          hoveredTileKey: 'oldWorld|p1|10|20',
-          hoveredDetailId: 'ignored',
-          selectedDetailId: 'oldWorld|p1',
+    group('displayProvinceOrSeaIdFromTileKey', () {
+      test('extracts region and province from full tile key', () {
+        expect(
+          displayProvinceOrSeaIdFromTileKey('oldWorld|p1|10|20'),
+          'oldWorld|p1',
         );
-        expect(displayId, 'oldWorld|p1');
       });
 
-      test('falls back to hoveredDetailId when hoveredTileKey parts < 2', () {
-        final displayId = GameMapAreaStateLogic.displayIdFromHover(
-          hoveredTileKey: 'badKey',
-          hoveredDetailId: 'oldWorld|p1',
-          selectedDetailId: 'newWorld|p2',
-        );
-        expect(displayId, 'oldWorld|p1');
-      });
-
-      test('falls back to selectedDetailId when hover detail is null', () {
-        final displayId = GameMapAreaStateLogic.displayIdFromHover(
-          hoveredTileKey: null,
-          hoveredDetailId: null,
-          selectedDetailId: 'newWorld|p2',
-        );
-        expect(displayId, 'newWorld|p2');
-      });
-
-      test('returns empty string when all inputs are null', () {
-        final displayId = GameMapAreaStateLogic.displayIdFromHover(
-          hoveredTileKey: null,
-          hoveredDetailId: null,
-          selectedDetailId: null,
-        );
-        expect(displayId, '');
+      test('returns null for short keys', () {
+        expect(displayProvinceOrSeaIdFromTileKey('badKey'), isNull);
+        expect(displayProvinceOrSeaIdFromTileKey(null), isNull);
       });
     });
 

--- a/app/test/game_map_narrow_detail_overlay_test.dart
+++ b/app/test/game_map_narrow_detail_overlay_test.dart
@@ -1,35 +1,41 @@
 import 'package:colonizethis_app/features/game/flame/game_map_narrow_detail_overlay.dart';
 import 'package:colonizethis_app/features/game/widgets/province_overlay_demo_data.dart';
+import 'package:colonizethis_app/providers/map_province_panel_provider.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   suppressLogsForTests();
 
-  testWidgets('GameMapNarrowDetailOverlay builds and close button calls onClose',
+  testWidgets(
+      'GameMapNarrowDetailOverlaySlot builds and close button closes via provider',
       (WidgetTester tester) async {
     final game = demoGameForOverlay;
     final region = demoRegionForOverlay;
-    final selectedId = sampleProvinceIdForOverlay;
 
-    var closed = false;
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.binding.setSurfaceSize(const Size(400, 600));
 
-    const viewportHeight = 600.0;
     await tester.pumpWidget(
-      MediaQuery(
-        data: const MediaQueryData(size: Size(400, viewportHeight)),
-        child: MaterialApp(
-          home: Scaffold(
-            body: GameMapNarrowDetailOverlay(
-              game: game,
-              region: region,
-              selectedId: selectedId,
-              displayId: selectedId,
-              humanPlayerId: game.players.first.id,
-              hoveredTileKey: null,
-              onHighlightTile: (_) {},
-              onClose: () => closed = true,
+      ProviderScope(
+        overrides: [
+          mapProvincePanelProvider.overrideWith((ref) {
+            final n = MapProvincePanelNotifier();
+            n.reportMapTileTapped(sampleTileKeyForProvinceOverlay);
+            return n;
+          }),
+        ],
+        child: MediaQuery(
+          data: const MediaQueryData(size: Size(400, 600)),
+          child: MaterialApp(
+            home: Scaffold(
+              body: GameMapNarrowDetailOverlaySlot(
+                game: game,
+                region: region,
+                humanPlayerId: game.players.first.id,
+              ),
             ),
           ),
         ),
@@ -37,39 +43,50 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.byType(GameMapNarrowDetailOverlay), findsOneWidget);
+    expect(find.byType(GameMapNarrowDetailOverlaySlot), findsOneWidget);
     expect(find.text('Province'), findsOneWidget);
     expect(find.byKey(const Key('overlay_close')), findsOneWidget);
 
     await tester.tap(find.byKey(const Key('overlay_close')));
     await tester.pumpAndSettle();
 
-    expect(closed, isTrue);
+    final ctx = tester.element(find.byType(GameMapNarrowDetailOverlaySlot));
+    final container = ProviderScope.containerOf(ctx);
+    expect(
+      container.read(mapProvincePanelProvider).overlayOpen,
+      isFalse,
+    );
   });
 
-  testWidgets('GameMapNarrowDetailOverlay is height constrained (narrow)',
+  testWidgets('GameMapNarrowDetailOverlaySlot is height constrained (narrow)',
       (WidgetTester tester) async {
     final game = demoGameForOverlay;
     final region = demoRegionForOverlay;
-    final selectedId = sampleProvinceIdForOverlay;
 
     const viewportHeight = 600.0;
     final expectedMaxHeight = viewportHeight * 0.33;
 
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.binding.setSurfaceSize(const Size(400, viewportHeight));
+
     await tester.pumpWidget(
-      MediaQuery(
-        data: const MediaQueryData(size: Size(400, viewportHeight)),
-        child: MaterialApp(
-          home: Scaffold(
-            body: GameMapNarrowDetailOverlay(
-              game: game,
-              region: region,
-              selectedId: selectedId,
-              displayId: selectedId,
-              humanPlayerId: game.players.first.id,
-              hoveredTileKey: null,
-              onHighlightTile: (_) {},
-              onClose: () {},
+      ProviderScope(
+        overrides: [
+          mapProvincePanelProvider.overrideWith((ref) {
+            final n = MapProvincePanelNotifier();
+            n.reportMapTileTapped(sampleTileKeyForProvinceOverlay);
+            return n;
+          }),
+        ],
+        child: MediaQuery(
+          data: const MediaQueryData(size: Size(400, viewportHeight)),
+          child: MaterialApp(
+            home: Scaffold(
+              body: GameMapNarrowDetailOverlaySlot(
+                game: game,
+                region: region,
+                humanPlayerId: game.players.first.id,
+              ),
             ),
           ),
         ),
@@ -78,14 +95,11 @@ void main() {
 
     await tester.pumpAndSettle();
 
-    // The inner ProvinceSeaZoneDetailOverlay sets maxHeight based on MediaQuery width,
-    // and GameMapNarrowDetailOverlay wraps it in a SizedBox at the same 0.33 factor.
     final constrained = find.byWidgetPredicate(
       (w) =>
-          w is ConstrainedBox &&
-          (w.constraints.maxHeight - expectedMaxHeight).abs() < 0.01,
+          w is SizedBox &&
+          (w.height! - expectedMaxHeight).abs() < 0.01,
     );
-    expect(constrained, findsAtLeastNWidgets(1));
+    expect(constrained, findsOneWidget);
   });
 }
-

--- a/app/test/map_province_panel_provider_test.dart
+++ b/app/test/map_province_panel_provider_test.dart
@@ -1,0 +1,42 @@
+import 'package:colonizethis_app/providers/map_province_panel_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('MapProvincePanelNotifier', () {
+    test('reportMapTileTapped opens overlay and sets selection', () {
+      final n = MapProvincePanelNotifier();
+      const key = 'r1|p1|2|3';
+      n.reportMapTileTapped(key);
+      expect(n.state.overlayOpen, isTrue);
+      expect(n.state.selectedTileKey, key);
+    });
+
+    test('closeOverlay keeps selectedTileKey', () {
+      final n = MapProvincePanelNotifier();
+      const key = 'r1|p1|2|3';
+      n.reportMapTileTapped(key);
+      n.closeOverlay();
+      expect(n.state.overlayOpen, isFalse);
+      expect(n.state.selectedTileKey, key);
+    });
+
+    test('setSecondaryHighlight does not clear selection', () {
+      final n = MapProvincePanelNotifier();
+      const key = 'r1|p1|2|3';
+      const secondary = 'r1|p1|4|5';
+      n.reportMapTileTapped(key);
+      n.setSecondaryHighlight(secondary);
+      expect(n.state.selectedTileKey, key);
+      expect(n.state.secondaryHighlightTileKey, secondary);
+    });
+
+    test('displayProvinceOrSeaIdFromTileKey strips to region|province', () {
+      expect(
+        displayProvinceOrSeaIdFromTileKey('oldWorld|provA|10|20'),
+        'oldWorld|provA',
+      );
+      expect(displayProvinceOrSeaIdFromTileKey(null), isNull);
+      expect(displayProvinceOrSeaIdFromTileKey('short'), isNull);
+    });
+  });
+}

--- a/app/test/map_province_panel_provider_test.dart
+++ b/app/test/map_province_panel_provider_test.dart
@@ -1,7 +1,10 @@
 import 'package:colonizethis_app/providers/map_province_panel_provider.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  suppressLogsForTests();
+
   group('MapProvincePanelNotifier', () {
     test('reportMapTileTapped opens overlay and sets selection', () {
       final n = MapProvincePanelNotifier();

--- a/app/test/province_overlay_test.dart
+++ b/app/test/province_overlay_test.dart
@@ -26,7 +26,8 @@ void main() {
 
   group('ProvinceSeaZoneDetailOverlay', () {
     Widget buildOverlay({
-      required String selectedId,
+      required String displayId,
+      String? selectedTileKey,
       void Function(String?)? onHighlightTile,
       VoidCallback? onClose,
     }) {
@@ -37,8 +38,8 @@ void main() {
           body: ProvinceSeaZoneDetailOverlay(
             game: game,
             region: region,
-            selectedId: selectedId,
-            displayId: selectedId,
+            displayId: displayId,
+            selectedTileKey: selectedTileKey,
             humanPlayerId: game.players.first.id,
             onHighlightTile: onHighlightTile,
             onClose: onClose,
@@ -49,7 +50,10 @@ void main() {
 
     testWidgets('AC: Standalone province overlay displays Political, Economic, Military, Civilian, Naval',
         (WidgetTester tester) async {
-      await tester.pumpWidget(buildOverlay(selectedId: sampleProvinceIdForOverlay));
+      await tester.pumpWidget(buildOverlay(
+        displayId: sampleProvinceIdForOverlay,
+        selectedTileKey: sampleTileKeyForProvinceOverlay,
+      ));
       await tester.pumpAndSettle();
 
       expect(find.byType(ProvinceSeaZoneDetailOverlay), findsOneWidget);
@@ -71,7 +75,10 @@ void main() {
         (c) => !c.isSea && '${region.regionId}|${c.regionCellId}' == selectedId,
       );
       final game = demoGameForOverlay;
-      await tester.pumpWidget(buildOverlay(selectedId: selectedId));
+      await tester.pumpWidget(buildOverlay(
+        displayId: selectedId,
+        selectedTileKey: sampleTileKeyForProvinceOverlay,
+      ));
       await tester.pumpAndSettle();
 
       final provinceName = cell.provinceDisplayName ?? cell.regionCellId;
@@ -94,7 +101,7 @@ void main() {
 
     testWidgets('AC: Sea zone overlay displays Political and Naval',
         (WidgetTester tester) async {
-      await tester.pumpWidget(buildOverlay(selectedId: sampleSeaZoneIdForOverlay));
+      await tester.pumpWidget(buildOverlay(displayId: sampleSeaZoneIdForOverlay));
       await tester.pumpAndSettle();
 
       expect(find.byType(ProvinceSeaZoneDetailOverlay), findsOneWidget);
@@ -106,7 +113,8 @@ void main() {
     testWidgets('AC: Close button invokes onClose', (WidgetTester tester) async {
       var closed = false;
       await tester.pumpWidget(buildOverlay(
-        selectedId: sampleProvinceIdForOverlay,
+        displayId: sampleProvinceIdForOverlay,
+        selectedTileKey: sampleTileKeyForProvinceOverlay,
         onClose: () => closed = true,
       ));
       await tester.pumpAndSettle();
@@ -129,8 +137,8 @@ void main() {
               body: ProvinceSeaZoneDetailOverlay(
                 game: demoGameForOverlay,
                 region: demoRegionForOverlay,
-                selectedId: sampleProvinceIdForOverlay,
                 displayId: sampleProvinceIdForOverlay,
+                selectedTileKey: sampleTileKeyForProvinceOverlay,
                 humanPlayerId: demoGameForOverlay.players.first.id,
                 onClose: () {},
               ),
@@ -158,8 +166,8 @@ void main() {
               body: ProvinceSeaZoneDetailOverlay(
                 game: demoGameForOverlay,
                 region: demoRegionForOverlay,
-                selectedId: sampleProvinceIdForOverlay,
                 displayId: sampleProvinceIdForOverlay,
+                selectedTileKey: sampleTileKeyForProvinceOverlay,
                 humanPlayerId: demoGameForOverlay.players.first.id,
                 onClose: () {},
               ),
@@ -216,8 +224,10 @@ void main() {
         );
 
         final hoveredCell = region.cells.first;
-        final hoveredTileKey =
+        final selectedTileKey =
             '${region.regionId}|${hoveredCell.regionCellId}|${hoveredCell.x}|${hoveredCell.y}';
+        final provinceId =
+            '${region.regionId}|${hoveredCell.regionCellId}';
 
         await tester.pumpWidget(
           MaterialApp(
@@ -225,12 +235,9 @@ void main() {
               body: ProvinceSeaZoneDetailOverlay(
                 game: demoGameForOverlay,
                 region: region,
-                selectedId:
-                    '${region.regionId}|${hoveredCell.regionCellId}',
-                displayId:
-                    '${region.regionId}|${hoveredCell.regionCellId}',
+                displayId: provinceId,
+                selectedTileKey: selectedTileKey,
                 humanPlayerId: demoGameForOverlay.players.first.id,
-                hoveredTileKey: hoveredTileKey,
                 onClose: () {},
               ),
             ),
@@ -288,8 +295,8 @@ void main() {
               body: ProvinceSeaZoneDetailOverlay(
                 game: demoGameForOverlay,
                 region: region,
-                selectedId: provinceId,
                 displayId: provinceId,
+                selectedTileKey: null,
                 humanPlayerId: demoGameForOverlay.players.first.id,
                 onClose: () {},
               ),
@@ -305,10 +312,11 @@ void main() {
 
   group('ProvinceSeaZoneDetailOverlay with map', () {
     testWidgets(
-      'AC: Map and overlay appear side by side when province selected; closing overlay clears map highlight (orange cursor)',
+      'AC: Map orange selection may persist after overlay closes',
       (WidgetTester tester) async {
         final game = demoGameForOverlay;
-        String? highlightedTileKey = 'oldWorld|p0|0|0';
+        final selectedTk = sampleTileKeyForProvinceOverlay;
+        var overlayOpen = true;
 
         await tester.pumpWidget(
           MaterialApp(
@@ -321,23 +329,23 @@ void main() {
                         child: CtRegionMap(
                           region: demoRegionForOverlay,
                           cellSizePx: 28,
-                          onProvinceSelected: (_) {},
-                          highlightedTileKey: highlightedTileKey,
+                          selectedTileKey: selectedTk,
                         ),
                       ),
-                      SizedBox(
-                        width: 320,
-                        child: ProvinceSeaZoneDetailOverlay(
-                          game: game,
-                          region: demoRegionForOverlay,
-                          selectedId: sampleProvinceIdForOverlay,
-                          displayId: sampleProvinceIdForOverlay,
-                          humanPlayerId: game.players.first.id,
-                          onClose: () => setState(() {
-                            highlightedTileKey = null;
-                          }),
+                      if (overlayOpen)
+                        SizedBox(
+                          width: 320,
+                          child: ProvinceSeaZoneDetailOverlay(
+                            game: game,
+                            region: demoRegionForOverlay,
+                            displayId: sampleProvinceIdForOverlay,
+                            selectedTileKey: selectedTk,
+                            humanPlayerId: game.players.first.id,
+                            onClose: () => setState(() {
+                              overlayOpen = false;
+                            }),
+                          ),
                         ),
-                      ),
                     ],
                   ),
                 );
@@ -349,19 +357,21 @@ void main() {
 
         expect(find.byType(CtRegionMap), findsOneWidget);
         expect(find.byType(ProvinceSeaZoneDetailOverlay), findsOneWidget);
-        expect(highlightedTileKey, isNotNull);
 
         await tester.tap(find.byKey(const Key('overlay_close')));
         await tester.pumpAndSettle();
 
-        expect(highlightedTileKey, isNull);
+        expect(overlayOpen, isFalse);
+        expect(selectedTk, isNotEmpty);
       },
     );
 
-    testWidgets('AC: Map tap invokes onProvinceSelected; overlay can show selection and stays open until closed',
+    testWidgets(
+        'AC: Map tap sets tile key and opens overlay; stays open until closed',
         (WidgetTester tester) async {
       final region = demoRegionForOverlay;
-      String? selectedId;
+      String? selectedTileKey;
+      var overlayOpen = false;
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -375,21 +385,27 @@ void main() {
                       child: CtRegionMap(
                         region: region,
                         cellSizePx: 28,
-                        onProvinceSelected: (id) =>
-                            setState(() => selectedId = id),
-                        highlightedTileKey: null,
+                        selectedTileKey: selectedTileKey,
+                        onMapTileTappedForDetail: (tk) => setState(() {
+                          selectedTileKey = tk;
+                          overlayOpen = true;
+                        }),
                       ),
                     ),
-                    if (selectedId != null && selectedId!.isNotEmpty)
+                    if (overlayOpen && selectedTileKey != null)
                       SizedBox(
                         width: 320,
                         child: ProvinceSeaZoneDetailOverlay(
                           game: demoGameForOverlay,
                           region: demoRegionForOverlay,
-                          selectedId: selectedId!,
-                          displayId: selectedId!,
+                          displayId: selectedTileKey!.split('|').length >= 2
+                              ? '${selectedTileKey!.split('|')[0]}|${selectedTileKey!.split('|')[1]}'
+                              : '',
+                          selectedTileKey: selectedTileKey,
                           humanPlayerId: demoGameForOverlay.players.first.id,
-                          onClose: () => setState(() => selectedId = null),
+                          onClose: () => setState(() {
+                            overlayOpen = false;
+                          }),
                         ),
                       ),
                   ],
@@ -401,24 +417,22 @@ void main() {
       );
       await tester.pump();
 
-      expect(selectedId, isNull);
+      expect(overlayOpen, isFalse);
       final mapFinder = find.byType(CtRegionMap);
       await tester.tap(mapFinder);
       await tester.pump();
 
-      expect(selectedId, isNotNull);
-      expect(selectedId!, startsWith('${region.regionId}|'));
+      expect(selectedTileKey, isNotNull);
+      expect(overlayOpen, isTrue);
+      expect(selectedTileKey!, startsWith('${region.regionId}|'));
 
-      // Tapping the same province again should not hide the overlay; it remains
-      // visible until the close handler clears the selection. SPEC/ui/province-sea-zone-detail-overlay.md.
       await tester.tap(mapFinder);
       await tester.pump();
-      expect(selectedId, isNotNull);
+      expect(overlayOpen, isTrue);
 
-      // Close via the overlay and verify it clears selection.
       await tester.tap(find.byKey(const Key('overlay_close')));
       await tester.pump();
-      expect(selectedId, isNull);
+      expect(overlayOpen, isFalse);
     });
   });
 }

--- a/app/test/province_sea_zone_overlay_detail_paths_test.dart
+++ b/app/test/province_sea_zone_overlay_detail_paths_test.dart
@@ -1,4 +1,4 @@
-// Tests for ProvinceSeaZoneDetailOverlay hover and branching paths.
+// Tests for ProvinceSeaZoneDetailOverlay tile selection and branching paths.
 // Covers SPEC/ui/province-sea-zone-detail-overlay.md conditional content.
 
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -18,10 +18,9 @@ void main() {
   Widget buildOverlay({
     required Game game,
     required RegionMapViewData region,
-    required String selectedId,
     required String displayId,
     required String humanPlayerId,
-    String? hoveredTileKey,
+    String? selectedTileKey,
     VoidCallback? onClose,
   }) {
     return MaterialApp(
@@ -29,10 +28,9 @@ void main() {
         body: ProvinceSeaZoneDetailOverlay(
           game: game,
           region: region,
-          selectedId: selectedId,
           displayId: displayId,
+          selectedTileKey: selectedTileKey,
           humanPlayerId: humanPlayerId,
-          hoveredTileKey: hoveredTileKey,
           onClose: onClose,
         ),
       ),
@@ -49,9 +47,9 @@ void main() {
     return (x: x, y: y);
   }
 
-  group('ProvinceSeaZoneDetailOverlay - hover + branching paths', () {
+  group('ProvinceSeaZoneDetailOverlay - selected tile + branching paths', () {
     testWidgets(
-        'AC: Revealed hovered tile renders coordinates + terrain + prospected fields',
+        'AC: Revealed selected tile renders coordinates + terrain + prospected fields',
         (WidgetTester tester) async {
       final game = demoGameForOverlay;
       final region = demoRegionForOverlay;
@@ -66,7 +64,7 @@ void main() {
           game.worldState.tileKeysByRegionAndProvince[region.regionId]?[provinceId] ??
               const <String>[];
 
-      String? hoveredTileKey;
+      String? selectedTileKey;
       ({int x, int y}) coords = (x: -1, y: -1);
       for (final tk in possibleTiles) {
         final c = coordsFromTileKey(tk);
@@ -76,23 +74,22 @@ void main() {
         }
         final cell = region.cellAt(c.x, c.y);
         if (cell.visibility != TileVisibility.unrevealed) {
-          hoveredTileKey = tk;
+          selectedTileKey = tk;
           coords = c;
           break;
         }
       }
 
       // If demo data is unexpectedly unrevealed, fail with a clear message.
-      expect(hoveredTileKey, isNotNull, reason: 'No revealed tile found in demo overlay data');
+      expect(selectedTileKey, isNotNull, reason: 'No revealed tile found in demo overlay data');
 
       await tester.pumpWidget(
         buildOverlay(
           game: game,
           region: region,
-          selectedId: provinceId,
           displayId: provinceId,
           humanPlayerId: humanPlayerId,
-          hoveredTileKey: hoveredTileKey,
+          selectedTileKey: selectedTileKey,
         ),
       );
       await tester.pumpAndSettle();
@@ -103,7 +100,7 @@ void main() {
       expect(find.textContaining('Prospected:'), findsOneWidget);
     });
 
-    testWidgets('AC: Out-of-bounds hovered tile shows placeholder "—"', (
+    testWidgets('AC: Out-of-bounds selected tile shows placeholder "—"', (
       WidgetTester tester,
     ) async {
       final game = demoGameForOverlay;
@@ -113,16 +110,15 @@ void main() {
       // Use the overlay's expected tile-key format but push x outside bounds.
       final firstLandCell = region.cells.firstWhere((c) => !c.isSea);
       final provinceId = '${region.regionId}|${firstLandCell.regionCellId}';
-      final hoveredTileKey = '${region.regionId}|${firstLandCell.regionCellId}|${region.width + 5}|0';
+      final badTileKey = '${region.regionId}|${firstLandCell.regionCellId}|${region.width + 5}|0';
 
       await tester.pumpWidget(
         buildOverlay(
           game: game,
           region: region,
-          selectedId: provinceId,
           displayId: provinceId,
           humanPlayerId: humanPlayerId,
-          hoveredTileKey: hoveredTileKey,
+          selectedTileKey: badTileKey,
         ),
       );
       await tester.pumpAndSettle();
@@ -133,7 +129,7 @@ void main() {
     });
 
     testWidgets(
-        'AC: Sea zone display never renders Tile section even when hoveredTileKey is provided',
+        'AC: Sea zone display never renders Tile section even when selectedTileKey is provided',
         (WidgetTester tester) async {
       final game = demoGameForOverlay;
       final region = demoRegionForOverlay;
@@ -159,10 +155,9 @@ void main() {
         buildOverlay(
           game: game,
           region: region,
-          selectedId: seaZoneId,
           displayId: seaZoneId,
           humanPlayerId: humanPlayerId,
-          hoveredTileKey: anyTileKey,
+          selectedTileKey: anyTileKey,
         ),
       );
       await tester.pumpAndSettle();
@@ -186,26 +181,25 @@ void main() {
       final possibleTiles =
           game.worldState.tileKeysByRegionAndProvince[region.regionId]?[provinceId] ??
               const <String>[];
-      String? hoveredTileKey;
+      String? selectedTileKey;
       for (final tk in possibleTiles) {
         final c = coordsFromTileKey(tk);
         if (c.x < 0 || c.x >= region.width || c.y < 0 || c.y >= region.height) continue;
         final cell = region.cellAt(c.x, c.y);
         if (cell.visibility != TileVisibility.unrevealed) {
-          hoveredTileKey = tk;
+          selectedTileKey = tk;
           break;
         }
       }
-      expect(hoveredTileKey, isNotNull, reason: 'No revealed tile in New World demo province');
+      expect(selectedTileKey, isNotNull, reason: 'No revealed tile in New World demo province');
 
       await tester.pumpWidget(
         buildOverlay(
           game: game,
           region: region,
-          selectedId: provinceId,
           displayId: provinceId,
           humanPlayerId: humanPlayerId,
-          hoveredTileKey: hoveredTileKey,
+          selectedTileKey: selectedTileKey,
         ),
       );
       await tester.pumpAndSettle();
@@ -238,26 +232,25 @@ void main() {
       final possibleTiles =
           game.worldState.tileKeysByRegionAndProvince[region.regionId]?[provinceId] ??
               const <String>[];
-      String? hoveredTileKey;
+      String? selectedTileKey;
       for (final tk in possibleTiles) {
         final c = coordsFromTileKey(tk);
         if (c.x < 0 || c.x >= region.width || c.y < 0 || c.y >= region.height) continue;
         final cell = region.cellAt(c.x, c.y);
         if (cell.visibility != TileVisibility.unrevealed) {
-          hoveredTileKey = tk;
+          selectedTileKey = tk;
           break;
         }
       }
-      expect(hoveredTileKey, isNotNull);
+      expect(selectedTileKey, isNotNull);
 
       await tester.pumpWidget(
         buildOverlay(
           game: game,
           region: region,
-          selectedId: provinceId,
           displayId: provinceId,
           humanPlayerId: humanPlayerId,
-          hoveredTileKey: hoveredTileKey,
+          selectedTileKey: selectedTileKey,
         ),
       );
       await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary

This change decouples the region map from the province/sea zone detail UI: both sides use **`mapProvincePanelProvider`** (Riverpod) only—no cross-imports between the Flame map stack and the overlay widget.

## Behavior

- **Tap** on a map tile opens/updates the panel and sets **`selectedTileKey`** (orange outline). **Hover** keeps separate map visuals and does not drive panel content.
- **`secondaryHighlightTileKey`** is used for Economic list / locate highlighting (distinct from selection).
- **`GameMapProvinceDetailSidePanel`** and **`GameMapNarrowDetailOverlaySlot`** are `ConsumerWidget`s; **`GameMapCanvasStack`** reads/writes the same provider and passes plain props into **`CtRegionMap`**.
- **`ProvinceSeaZoneDetailOverlay`**: narrow height rules (full-width vs side rail vs pre-capped bottom slot), scrollable tab pages, Political-before-Tile order, copy/prospected rules aligned with prior product decisions.

## Tests

- `map_province_panel_provider_test.dart` for notifier + `displayProvinceOrSeaIdFromTileKey`.
- Narrow overlay tests use **`setSurfaceSize`** so `MediaQuery` matches the intended viewport.
- Updated map/overlay/widgetbook-related tests.

## Specs

- **`SPEC/ui/province-sea-zone-detail-overlay.md`**: Riverpod-only wiring, height table, tap vs hover ACs.
- **`SPEC/ui/map-widget.md`**: `onMapTileTappedForDetail`, selection keys, decoupling section.

## How to verify

From `app/`: `dart analyze` and `flutter test` on touched test paths (or full suite).