### PR TITLE
fix: new game async setup, map join hang, tests

### DIFF
--- a/SPEC/program/app-event-bus.md
+++ b/SPEC/program/app-event-bus.md
@@ -118,7 +118,7 @@ class AppEventHandler {
 **`GameService`** (`app/lib/core/services/game_service.dart`) holds optional **`AppEventBus? eventBus`** and optional **`GameEventBus? logicEventBus`**. When **`eventBus`** is set, it emits:
 
 - **`TurnResolutionCompleteEvent`** after `runTurnResolution` / `resumeOvertureDecisions` completes with **`TurnResolutionComplete`**
-- **`NewGameCreatedEvent`** after **`createNewGame()`** saves
+- **`NewGameCreatedEvent`** after a new game is created and saved (sync **`createNewGame()`** or async phased **`createNewGameAsync()`** used by the shell)
 - **`OvertureRequiredEvent`** when `runTurnResolution` or `resumeOvertureDecisions` returns **`TurnResolutionPendingOvertures`**
 
 When **`logicEventBus`** is set, turn resolution passes it into **`resolveTurnForGame`** / **`resumeTurnResolutionWithOvertureDecisions`** so **`GameEventBridge`** can subscribe and map logic **`GameEvent`** instances to **`GameToUIEvent`** on the app bus. **Full bridge:** **SPEC/program/game-event-bridge.md**.

--- a/SPEC/program/app-ui-wiring.md
+++ b/SPEC/program/app-ui-wiring.md
@@ -62,7 +62,7 @@ Register builders in **`app/lib/core/services/app_event_handler_scope.dart`**.
 | `quick_battle_result` | `QuickBattleResultDialog` | planned (or local if combat UI stays internal) |
 | `combat_mode_choice` | `CombatModeChoiceDialog` | same |
 
-**Local by design (no `OpenDialogEvent`):** map display options (`GameMapArea`), tech detail (`TechTreeWidget`), split fleet (`NavalUnitsPanel`), civilian work-target sheet (`CivilianUnitsPanel`), next-turn confirmation (`GameMapArea`), research tech picker (`TechnologyPanel`), **`CtDropdown`** internal picker.
+**Local by design (no `OpenDialogEvent`):** map display options (`GameMapArea`), tech detail (`TechTreeWidget`), split fleet (`NavalUnitsPanel`), civilian work-target sheet (`CivilianUnitsPanel`), next-turn confirmation (`GameMapArea`), research tech picker (`TechnologyPanel`), **`CtDropdown`** internal picker, **new-game setup progress and error dialogs** after leader confirmation (see **SPEC/ui/game-initializing.md**).
 
 ---
 

--- a/SPEC/program/game-setup-pipeline.md
+++ b/SPEC/program/game-setup-pipeline.md
@@ -48,7 +48,7 @@ Entry point: `runInitGame(config, options)` in colonizethis_logic. CLI tool: [in
 
 - **Phase:** Pre-game (before turn 0).
 - **Upstream:** colonizethis_data (config, ruleset merge), colonizethis_map (map generation).
-- **Downstream:** App (GameService.createNewGame), init_game CLI tool, ctdev debug views.
+- **Downstream:** App (`GameService.createNewGame`, `GameService.createNewGameAsync` with coarse progress per SPEC/ui/game-initializing.md), init_game CLI tool, ctdev debug views.
 
 ## Constraints
 

--- a/SPEC/ui/game-initializing.md
+++ b/SPEC/ui/game-initializing.md
@@ -1,57 +1,81 @@
-# Game Initializing Screen
+# Game initialization (new game)
 
-**SPEC/ui** — App screen shown after Game Setup when the user taps Start Game. Shows discrete generation progress; one-way until complete. Authority: app screen flow (post–Game Setup).
-
----
-
-## Purpose
-
-After the shell receives `onStartGame` from Game Setup, it runs the game setup pipeline (e.g. `runInitGame`). This screen is shown **during** that work. The user sees discrete steps and cannot cancel; on success the app navigates to Empire overview (in-game shell). On failure the app navigates to home (Main Menu).
+**SPEC/ui** — User-visible progress and errors while the app builds a new game (map generation, setup pipeline, persistence). Aligns with pipeline phases in [game-setup-pipeline.md](../program/game-setup-pipeline.md).
 
 ---
 
-## Flow
+## Scope
 
-- **From:** Game Setup (user tapped Start Game; shell builds config and starts initialization).
-- **To (success):** Empire overview (in-game shell).
-- **To (failure):** Main Menu (crash to home — clear in-progress state, show Main Menu).
-- **Cancel:** None. One-way until done.
-
----
-
-## Widget contract (presentational)
-
-The screen is presentational where possible. The shell owns: starting the pipeline, receiving progress/result, and navigation.
-
-| Aspect | Specification |
-|--------|---------------|
-| **Progress** | Discrete steps. Each step shows a short label. Steps align with [game-setup-pipeline.md](../program/game-setup-pipeline.md) phases (e.g. "Generating Old World…", "Generating New World…", "Linking regions…", "Assigning nations…", "Building world…", "Finalizing…"). Exact labels and count are implementation-defined from pipeline phases. |
-| **Display** | Current step label prominent; optional step index (e.g. "Step 2 of 6"). Optional progress indicator (e.g. bar or spinner). Title: e.g. "Generating World" or "Initializing Game". |
-| **Interaction** | No cancel or back. User waits. |
-| **On success** | Shell navigates to Empire overview. |
-| **On failure** | Shell navigates to Main Menu; no retry on this screen. |
+- **In scope:** Shell flow after the user confirms **Start** on the leader selection dialog (`new_game_leader_selection`): show progress, run setup on the **main isolate** with **async yields** between coarse steps (Option A — no background isolate).
+- **Also applies:** Any future full-screen Game Setup (`CtGameSetup`) path that uses the same app setup API should match the same progress and error behavior unless a separate spec says otherwise.
+- **Out of scope:** Cancel mid-setup; fine-grained per-tile progress.
 
 ---
 
-## Layout
+## Presentation
 
-- Centered content; title and current step visible.
-- Works on desktop and mobile (see [mobile-adaptation.md](mobile-adaptation.md): SafeArea, readable text, no overflow).
-- No pixel-art requirement for this screen unless UXD extends; standard Flutter/theme is fine.
+The shell may use a **modal progress dialog** (blocking the shell) or a dedicated full-screen initializing view. Both satisfy this spec if the ACs below hold.
+
+| Element | Requirement |
+|--------|-------------|
+| Title | Short label (e.g. “Creating game”). |
+| Step text | One **coarse** label visible at a time; updates when the pipeline advances. |
+| Indicator | Indeterminate progress (e.g. circular progress) is sufficient. |
+| Dismiss | None while work is in progress. |
+
+**Coarse steps (minimum set):** The UI layer must expose at least these phases in order (labels are implementation-defined; l10n keys in `app/lib/l10n/`). Program indices `0..4` match `GameService.newGameSetupProgressStepCount` (`app/lib/core/services/game_service.dart`):
+
+| Index | Phase |
+|-------|--------|
+| 0 | Generating Old World map |
+| 1 | Generating New World map |
+| 2 | Linking Old World and New World (warp zones) |
+| 3 | Building world (`createGameFromGeneratedMaps`: assignment, connectivity repair, capitals, naming, initial units) |
+| 4 | Saving game (cache, map persistence, save, `NewGameCreatedEvent` when configured) |
+
+The implementation may merge adjacent steps for fewer on-screen updates if every listed phase still runs in order before the next.
 
 ---
 
-## Acceptance criteria
+## Execution model
 
-- **Given** the user completed Game Setup and tapped Start Game, **when** the shell starts initialization, **then** the Game Initializing screen is shown with a title and the first discrete step label.
-- **When** the pipeline advances to a new phase, **then** the displayed step label updates to the corresponding step.
-- **When** initialization completes successfully, **then** the shell navigates to the Empire overview (in-game shell).
-- **When** initialization fails, **then** the shell navigates to the Main Menu (crash to home); the user is not left on the initializing screen.
-- **Given** the screen is visible, **then** there is no cancel or back control; the flow is one-way until done.
+- Work runs on the **Dart UI isolate**; between coarse steps the app **yields** (e.g. `await Future<void>.delayed(Duration.zero)`) so Flutter can **paint** updated step text and keep the UI responsive for that dialog.
+- **Success:** Close progress UI, set the current game in app state, navigate to **`Routes.game`**, emit **`NewGameCreatedEvent`** when the bus is configured (existing `GameService` contract).
+
+---
+
+## Failure and retry
+
+- On **any** thrown error during setup (map generation, `createGameFromGeneratedMaps`, save, etc.), the progress UI closes and the UI layer shows an **error dialog** with:
+  - A short title (e.g. “Could not create game”).
+  - The error **message** as returned by the exception’s `toString()` (or equivalent single string), suitable for debugging; not required to be end-user polished.
+- **Retry:** A **Retry** action dismisses the error dialog and **starts setup again** from step 1 with a **new RNG seed** derived from the **base** config seed: `effectiveSeed = baseSeed + attemptIndex`, where `baseSeed` is `GameSetupConfig.seed` from the user’s chosen leaders/config before the first attempt, and `attemptIndex` is `0` on the first try, `1` on the first retry, `2` on the second retry, etc. NW map generator continues to use a derived seed consistent with the existing app rule (e.g. `effectiveSeed + 1` for New World params when that is how the synchronous API behaves).
+- **Dismiss:** A **Close** (or **OK**) action dismisses the error dialog only; the shell does **not** navigate to the game; no new game is set as current.
+
+---
+
+## Acceptance criteria (Given–When–Then)
+
+- Given the user confirmed **Start** on the leader selection dialog, when the shell begins new-game setup, then the UI layer shows a progress UI with a title and the first coarse step label (Old World map generation) before that step’s heavy work completes.
+- Given the progress UI is visible, when the pipeline completes the Old World map phase and begins the New World map phase, then the displayed step label updates to reflect New World map generation (or a merged label that still includes that phase per the minimum set above).
+- Given the progress UI is visible, when the pipeline completes New World map generation and begins warp generation, then the displayed step label updates to reflect linking regions / warp zones.
+- Given the progress UI is visible, when the pipeline enters `createGameFromGeneratedMaps` (assignment, repair, capitals, naming, units), then the displayed step label updates to reflect building the world.
+- Given the progress UI is visible, when the pipeline begins persisting the game and map data, then the displayed step label updates to reflect saving.
+- Given new-game setup completes without error, when the pipeline finishes, then the progress UI is closed, the created `Game` is stored as the current game, the shell navigates to `Routes.game`, and the `GameService` emits `NewGameCreatedEvent` on the app event bus when configured.
+- Given new-game setup throws an error during any phase, when the error propagates to the shell handler, then the progress UI is closed and the UI layer shows an error dialog with a Retry control and a Close (or OK) control, and the error’s `toString()` text (or equivalent) is shown to the user.
+- Given the error dialog is shown after a failed attempt with `attemptIndex == N` (non-negative integer), when the user taps **Retry**, then the error dialog closes and setup runs again with `GameSetupConfig.seed` set to `baseSeed + (N + 1)` where `baseSeed` is the seed from the config used before the first attempt in this dialog session, and the progress UI appears again from the first step.
+- Given the error dialog is shown, when the user taps **Close** (or **OK**), then the dialog closes and the shell does not navigate to the game and does not set a new current game from that failed run.
 
 ---
 
 ## Integration
 
-- **Data:** Shell calls game setup pipeline (e.g. colonizethis_logic `runInitGame`). Pipeline may report progress via callback or stream; the screen consumes that to show the current step.
-- **Spec alignment:** Pipeline phases: [game-setup-pipeline.md](../program/game-setup-pipeline.md). App screen flow: [game-setup.md](game-setup.md) § App flow after Start Game.
+- **App:** `GameService` exposes an async phased API used by the shell; synchronous `createNewGame` may remain for tools/tests that do not need progress.
+- **Wiring:** Leader confirmation and progress/error dialogs are **local** to the shell flow (`showDialog` / `Navigator` from the handler context is allowed per [app-ui-wiring.md](../program/app-ui-wiring.md) § Local by design).
+
+---
+
+## Related
+
+- [game-setup.md](game-setup.md) — full Game Setup screen (six slots); § App flow references initializing behavior.
+- [SPEC/program/game-setup-pipeline.md](../program/game-setup-pipeline.md) — pipeline phases.

--- a/SPEC/ui/game-setup.md
+++ b/SPEC/ui/game-setup.md
@@ -38,7 +38,7 @@ The CtGameSetup widget is presentational and accepts the following parameters. T
 
 **Interaction.** The widget holds per-slot state (ordered list of six gpIds and leader variant per gpId) and exposes it via `onStartGame(orderedGpIdsForSlots, leaderVariantByGpId)`. No routing logic lives in the widget.
 
-**App flow after Start Game.** When the user taps Start Game, the shell builds GameSetupConfig and starts game initialization. The shell then shows the [Game Initializing](game-initializing.md) screen (discrete steps, one-way). On success the shell navigates to the [Empire overview](empire-overview.md) (in-game shell). On failure the shell navigates to the Main Menu (crash to home).
+**App flow after Start Game.** When the user taps Start Game, the shell builds GameSetupConfig and starts game initialization. The shell shows progress per [Game initialization (new game)](game-initializing.md) (coarse steps; modal or full screen). On success the shell navigates to the [Empire overview](empire-overview.md) (in-game shell). On failure the shell shows an error dialog with retry (new seed) per that spec, not silent navigation to Main Menu.
 
 **Automated tests.** Widget tests in `app/test/screen_spec_acceptance_test.dart` assert the acceptance criteria above (visibility, initial state, Start disabled until complete, no duplicate nations, leader follows nation, onStartGame/onBack payloads, loading state). Run: `flutter test test/screen_spec_acceptance_test.dart` from the app package.
 

--- a/app/lib/core/services/app_event_handler_scope.dart
+++ b/app/lib/core/services/app_event_handler_scope.dart
@@ -7,10 +7,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logger/logger.dart';
 import 'package:colonizethis_app/app.dart';
-import 'package:colonizethis_app/config/routes.dart';
 import 'package:colonizethis_app/features/game/widgets/diplomacy_dialogs.dart';
 import 'package:colonizethis_app/features/game/widgets/train_civilians_dialog.dart';
 import 'package:colonizethis_app/features/shell/new_game_leader_selection_dialog.dart';
+import 'package:colonizethis_app/features/shell/new_game_setup_flow.dart';
 import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
 import 'package:colonizethis_app/providers/game_service_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
@@ -97,7 +97,6 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
       navigatorKey: appNavigatorKey,
       dialogBuilders: {
         newGameLeaderSelectionDialogId: (ctx, _) {
-          final container = ProviderScope.containerOf(ctx);
           final baseConfig = GameSetupConfig.defaultConfig;
           final naming = defaultNamingConfig;
           final initialSelections = <String, String>{};
@@ -113,7 +112,15 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
             initialLeaderByGpId: initialSelections,
             onCancel: () => Navigator.of(ctx).pop(),
             onConfirmed: (leaderVariantByGpId) {
-              final config = GameSetupConfig(
+              final navCtx = appNavigatorKey.currentContext;
+              if (navCtx == null) {
+                _log.w(
+                  'shell: appNavigatorKey has no context; skipping new game setup',
+                );
+                return;
+              }
+              final rootContainer = ProviderScope.containerOf(navCtx);
+              final templateConfig = GameSetupConfig(
                 selectedGreatPowerIds: baseConfig.selectedGreatPowerIds,
                 leaderVariantByGpId: leaderVariantByGpId,
                 continentCount: baseConfig.continentCount,
@@ -125,12 +132,12 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
                 seed: baseConfig.seed,
                 startingResources: baseConfig.startingResources,
               );
-              final service = container.read(gameServiceProvider);
-              final game = service.createNewGame(config: config);
-              container.read(currentGameProvider.notifier).state = game;
-              container.read(appEventBusProvider).emit(
-                    const NavigateToRouteEvent(Routes.game),
-                  );
+              unawaited(
+                runNewGameSetupAfterLeaderPick(
+                  container: rootContainer,
+                  templateConfig: templateConfig,
+                ),
+              );
             },
           );
         },

--- a/app/lib/core/services/game_service.dart
+++ b/app/lib/core/services/game_service.dart
@@ -200,12 +200,86 @@ class GameService {
     return requireTurnResolutionComplete(result);
   }
 
+  /// Number of coarse progress steps reported by [createNewGameAsync]. SPEC/ui/game-initializing.md.
+  static const int newGameSetupProgressStepCount = 5;
+
   /// Creates a new game via the full game-setup pipeline (map gen, province assignment, capital auto-choice).
   /// Uses [config] (defaults to GameSetupConfig.defaultConfig) and saves the game; map data is cached for nextTurn.
   Game createNewGame({String? id, GameSetupConfig? config}) {
     final gameId = id ?? 'game_${DateTime.now().millisecondsSinceEpoch}';
     final cfg = config ?? GameSetupConfig.defaultConfig;
+    final (tileMapOW, topoOW) = _generateTileMapOldWorld(cfg);
+    final (tileMapNW, topoNW) = _generateTileMapNewWorld(cfg);
+    final warpLinks = _generateWarpLinks(
+      cfg: cfg,
+      tileMapOW: tileMapOW,
+      topoOW: topoOW,
+      tileMapNW: tileMapNW,
+      topoNW: topoNW,
+    );
+    final result = createGameFromGeneratedMaps(
+      config: cfg,
+      tileMapOldWorld: tileMapOW,
+      topologyOldWorld: topoOW,
+      tileMapNewWorld: tileMapNW,
+      topologyNewWorld: topoNW,
+      gameId: gameId,
+      warpLinks: warpLinks,
+    );
+    _persistNewGame(gameId: gameId, result: result);
+    return result.game;
+  }
 
+  /// Same pipeline as [createNewGame], but yields between coarse steps so the UI isolate can paint.
+  /// [onProgress] is invoked with `(stepIndex, newGameSetupProgressStepCount)` before each major phase
+  /// (0 = Old World map … 4 = saving). SPEC/ui/game-initializing.md.
+  Future<Game> createNewGameAsync({
+    String? id,
+    GameSetupConfig? config,
+    void Function(int stepIndex, int totalSteps)? onProgress,
+  }) async {
+    final gameId = id ?? 'game_${DateTime.now().millisecondsSinceEpoch}';
+    final cfg = config ?? GameSetupConfig.defaultConfig;
+    const total = newGameSetupProgressStepCount;
+    Future<void> yieldUi() => Future<void>.delayed(Duration.zero);
+
+    onProgress?.call(0, total);
+    await yieldUi();
+    final (tileMapOW, topoOW) = _generateTileMapOldWorld(cfg);
+
+    onProgress?.call(1, total);
+    await yieldUi();
+    final (tileMapNW, topoNW) = _generateTileMapNewWorld(cfg);
+
+    onProgress?.call(2, total);
+    await yieldUi();
+    final warpLinks = _generateWarpLinks(
+      cfg: cfg,
+      tileMapOW: tileMapOW,
+      topoOW: topoOW,
+      tileMapNW: tileMapNW,
+      topoNW: topoNW,
+    );
+
+    onProgress?.call(3, total);
+    await yieldUi();
+    final result = createGameFromGeneratedMaps(
+      config: cfg,
+      tileMapOldWorld: tileMapOW,
+      topologyOldWorld: topoOW,
+      tileMapNewWorld: tileMapNW,
+      topologyNewWorld: topoNW,
+      gameId: gameId,
+      warpLinks: warpLinks,
+    );
+
+    onProgress?.call(4, total);
+    await yieldUi();
+    _persistNewGame(gameId: gameId, result: result);
+    return result.game;
+  }
+
+  (TileMapResult, MapTopology) _generateTileMapOldWorld(GameSetupConfig cfg) {
     final mapGenParams = MapGenerationParams(
       numContinents: cfg.continentCount,
       seed: cfg.seed,
@@ -221,13 +295,20 @@ class GameService {
       seed: cfg.seed,
       seaFraction: 0.6,
     );
-    final (tileMapOW, topoOW) = TileMapGenerator(params: paramsOW).generate(
+    return TileMapGenerator(params: paramsOW).generate(
       numProvinces: cfg.numProvincesOldWorld,
       numContinents: cfg.continentCount,
       regionId: 'oldWorld',
       resourceRules: ResourceRules.defaultRules,
     );
+  }
 
+  (TileMapResult, MapTopology) _generateTileMapNewWorld(GameSetupConfig cfg) {
+    final mapGenParams = MapGenerationParams(
+      numContinents: cfg.continentCount,
+      seed: cfg.seed,
+      seaFraction: 0.6,
+    );
     final sizeNW = computeGridSizeFromParams(
       cfg.numProvincesNewWorld,
       mapGenParams,
@@ -238,15 +319,22 @@ class GameService {
       seed: cfg.seed + 1,
       seaFraction: 0.6,
     );
-    final (tileMapNW, topoNW) = TileMapGenerator(params: paramsNW).generate(
+    return TileMapGenerator(params: paramsNW).generate(
       numProvinces: cfg.numProvincesNewWorld,
       numContinents: cfg.continentCount.clamp(1, cfg.numProvincesNewWorld),
       regionId: 'newWorld',
       resourceRules: ResourceRules.defaultRules,
     );
+  }
 
-    // Generate warp zones between Old World and New World.
-    final warpLinks = generateWarpZones(
+  List<WarpLink> _generateWarpLinks({
+    required GameSetupConfig cfg,
+    required TileMapResult tileMapOW,
+    required MapTopology topoOW,
+    required TileMapResult tileMapNW,
+    required MapTopology topoNW,
+  }) {
+    return generateWarpZones(
       tileMapOldWorld: tileMapOW,
       topologyOldWorld: topoOW,
       tileMapNewWorld: tileMapNW,
@@ -255,17 +343,12 @@ class GameService {
       regionIdNew: 'newWorld',
       seed: cfg.seed,
     );
+  }
 
-    final result = createGameFromGeneratedMaps(
-      config: cfg,
-      tileMapOldWorld: tileMapOW,
-      topologyOldWorld: topoOW,
-      tileMapNewWorld: tileMapNW,
-      topologyNewWorld: topoNW,
-      gameId: gameId,
-      warpLinks: warpLinks,
-    );
-
+  void _persistNewGame({
+    required String gameId,
+    required GameSetupResult result,
+  }) {
     _mapCache[gameId] = _GameMapCache(
       combinedTopology: result.combinedTopology,
       tileMapByRegion: result.tileMapByRegion,
@@ -282,6 +365,5 @@ class GameService {
     );
     saveGame(result.game);
     eventBus?.emit(NewGameCreatedEvent(gameId: result.game.id));
-    return result.game;
   }
 }

--- a/app/lib/features/shell/new_game_setup_flow.dart
+++ b/app/lib/features/shell/new_game_setup_flow.dart
@@ -1,0 +1,217 @@
+// SPEC/ui/game-initializing.md — progress dialog, async setup, error + retry (new seed).
+
+import 'dart:async';
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:colonizethis_app/app.dart';
+import 'package:colonizethis_app/config/routes.dart';
+import 'package:colonizethis_app/core/services/game_service.dart';
+import 'package:colonizethis_app/l10n/l10n.dart';
+import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
+import 'package:colonizethis_app/providers/game_service_provider.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
+
+final _log = appLogger('shell');
+
+sealed class _NewGameOutcome {}
+
+class _NewGameOutcomeSuccess extends _NewGameOutcome {
+  _NewGameOutcomeSuccess(this.game);
+  final Game game;
+}
+
+class _NewGameOutcomeFailure extends _NewGameOutcome {
+  _NewGameOutcomeFailure(this.error);
+  final Object error;
+}
+
+/// Runs phased new-game creation after leader selection: progress dialog, navigate on success,
+/// error dialog with retry (`seed = baseSeed + attemptIndex`). SPEC/ui/game-initializing.md.
+Future<void> runNewGameSetupAfterLeaderPick({
+  required ProviderContainer container,
+  required GameSetupConfig templateConfig,
+}) async {
+  final baseSeed = templateConfig.seed;
+  var attemptIndex = 0;
+  final service = container.read(gameServiceProvider);
+  final bus = container.read(appEventBusProvider);
+
+  while (true) {
+    final config = GameSetupConfig(
+      selectedGreatPowerIds: templateConfig.selectedGreatPowerIds,
+      leaderVariantByGpId: templateConfig.leaderVariantByGpId,
+      continentCount: templateConfig.continentCount,
+      minorNationCount: templateConfig.minorNationCount,
+      tribeCount: templateConfig.tribeCount,
+      numProvincesOldWorld: templateConfig.numProvincesOldWorld,
+      numProvincesNewWorld: templateConfig.numProvincesNewWorld,
+      minProvincesPerMinor: templateConfig.minProvincesPerMinor,
+      seed: baseSeed + attemptIndex,
+      startingResources: templateConfig.startingResources,
+    );
+
+    final outcome = await _showNewGameProgressDialog(
+      config: config,
+      service: service,
+    );
+    if (outcome == null) {
+      _log.w('new game setup: could not show progress dialog');
+      return;
+    }
+
+    switch (outcome) {
+      case _NewGameOutcomeSuccess(:final game):
+        container.read(currentGameProvider.notifier).state = game;
+        bus.emit(const NavigateToRouteEvent(Routes.game));
+        return;
+      case _NewGameOutcomeFailure(:final error):
+        final retry = await _showNewGameErrorDialog(error);
+        if (retry) {
+          attemptIndex++;
+          continue;
+        }
+        return;
+    }
+  }
+}
+
+Future<_NewGameOutcome?> _showNewGameProgressDialog({
+  required GameSetupConfig config,
+  required GameService service,
+}) async {
+  final ctx = appNavigatorKey.currentContext;
+  if (ctx == null) {
+    return null;
+  }
+  return showDialog<_NewGameOutcome>(
+    context: ctx,
+    barrierDismissible: false,
+    useRootNavigator: true,
+    builder: (dialogCtx) => _NewGameSetupProgressDialog(
+      config: config,
+      service: service,
+    ),
+  );
+}
+
+Future<bool> _showNewGameErrorDialog(Object error) async {
+  final ctx = appNavigatorKey.currentContext;
+  if (ctx == null) {
+    return false;
+  }
+  final l10n = appL10n(ctx);
+  final retry = await showDialog<bool>(
+    context: ctx,
+    useRootNavigator: true,
+    builder: (ctx) => AlertDialog(
+      title: Text(l10n.shell_newGameError_title),
+      content: SingleChildScrollView(
+        child: SelectableText(error.toString()),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(false),
+          child: Text(l10n.common_close),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(true),
+          child: Text(l10n.shell_newGameError_retry),
+        ),
+      ],
+    ),
+  );
+  return retry ?? false;
+}
+
+String _stepLabel(BuildContext context, int stepIndex) {
+  final l10n = appL10n(context);
+  switch (stepIndex) {
+    case 0:
+      return l10n.shell_newGameProgress_stepOldWorld;
+    case 1:
+      return l10n.shell_newGameProgress_stepNewWorld;
+    case 2:
+      return l10n.shell_newGameProgress_stepWarp;
+    case 3:
+      return l10n.shell_newGameProgress_stepBuildWorld;
+    case 4:
+      return l10n.shell_newGameProgress_stepSave;
+    default:
+      return l10n.shell_newGameProgress_title;
+  }
+}
+
+class _NewGameSetupProgressDialog extends StatefulWidget {
+  const _NewGameSetupProgressDialog({
+    required this.config,
+    required this.service,
+  });
+
+  final GameSetupConfig config;
+  final GameService service;
+
+  @override
+  State<_NewGameSetupProgressDialog> createState() =>
+      _NewGameSetupProgressDialogState();
+}
+
+class _NewGameSetupProgressDialogState extends State<_NewGameSetupProgressDialog> {
+  var _stepIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => unawaited(_run()));
+  }
+
+  Future<void> _run() async {
+    try {
+      final game = await widget.service.createNewGameAsync(
+        config: widget.config,
+        onProgress: (stepIndex, _) {
+          if (mounted) {
+            setState(() => _stepIndex = stepIndex);
+          }
+        },
+      );
+      if (!mounted) {
+        return;
+      }
+      Navigator.of(context).pop(_NewGameOutcomeSuccess(game));
+    } catch (e, st) {
+      _log.e('new game setup failed', error: e, stackTrace: st);
+      if (!mounted) {
+        return;
+      }
+      Navigator.of(context).pop(_NewGameOutcomeFailure(e));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = appL10n(context);
+    return PopScope(
+      canPop: false,
+      child: AlertDialog(
+        title: Text(l10n.shell_newGameProgress_title),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(
+              height: 36,
+              width: 36,
+              child: CircularProgressIndicator(),
+            ),
+            const SizedBox(height: 16),
+            Text(_stepLabel(context, _stepIndex)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -185,6 +185,46 @@
   "shell_leaderDialog_title": "New game — Leaders",
   "@shell_leaderDialog_title": {
     "description": "Title of the leader selection dialog in the new-game flow."
+  },
+
+  "shell_newGameProgress_title": "Creating game",
+  "@shell_newGameProgress_title": {
+    "description": "Title of the modal shown while a new game is being generated."
+  },
+
+  "shell_newGameProgress_stepOldWorld": "Generating Old World map…",
+  "@shell_newGameProgress_stepOldWorld": {
+    "description": "Coarse progress step: Old World tile map."
+  },
+
+  "shell_newGameProgress_stepNewWorld": "Generating New World map…",
+  "@shell_newGameProgress_stepNewWorld": {
+    "description": "Coarse progress step: New World tile map."
+  },
+
+  "shell_newGameProgress_stepWarp": "Linking Old World and New World…",
+  "@shell_newGameProgress_stepWarp": {
+    "description": "Coarse progress step: warp zones between regions."
+  },
+
+  "shell_newGameProgress_stepBuildWorld": "Building world…",
+  "@shell_newGameProgress_stepBuildWorld": {
+    "description": "Coarse progress step: province assignment, capitals, units."
+  },
+
+  "shell_newGameProgress_stepSave": "Saving game…",
+  "@shell_newGameProgress_stepSave": {
+    "description": "Coarse progress step: persisting game and map data."
+  },
+
+  "shell_newGameError_title": "Could not create game",
+  "@shell_newGameError_title": {
+    "description": "Title of the error dialog when new-game setup fails."
+  },
+
+  "shell_newGameError_retry": "Retry",
+  "@shell_newGameError_retry": {
+    "description": "Button to retry new-game setup with a different random seed."
   }
 }
 

--- a/app/test/game_service_integration_test.dart
+++ b/app/test/game_service_integration_test.dart
@@ -79,6 +79,48 @@ void main() {
       expect(reloaded!.worldState.turnState.turnNumber, updated.worldState.turnState.turnNumber);
       expect(reloaded.players.length, updated.players.length);
     });
+
+    test('createNewGameAsync reports coarse progress indices 0..4', () async {
+      final steps = <int>[];
+      final totals = <int>[];
+      final config = GameSetupConfig(
+        selectedGreatPowerIds: const ['england'],
+        continentCount: 1,
+        minorNationCount: 0,
+        tribeCount: 1,
+        numProvincesOldWorld: 3,
+        numProvincesNewWorld: 2,
+      );
+      final game = await service.createNewGameAsync(
+        id: 'g_async_progress',
+        config: config,
+        onProgress: (i, t) {
+          steps.add(i);
+          totals.add(t);
+        },
+      );
+      expect(steps, [0, 1, 2, 3, 4]);
+      expect(totals, List.filled(5, GameService.newGameSetupProgressStepCount));
+      expect(game.players.length, 1);
+      expect(service.loadGame('g_async_progress'), isNotNull);
+    });
+
+    test('createNewGameAsync builds same worldState as createNewGame for same config', () async {
+      final config = GameSetupConfig(
+        seed: 9001,
+        selectedGreatPowerIds: const ['england'],
+        continentCount: 1,
+        minorNationCount: 0,
+        tribeCount: 1,
+        numProvincesOldWorld: 3,
+        numProvincesNewWorld: 2,
+      );
+      final syncGame = service.createNewGame(id: 'g_sync_world', config: config);
+      final asyncGame = await service.createNewGameAsync(id: 'g_async_world', config: config);
+      expect(asyncGame.worldState.oldWorld, syncGame.worldState.oldWorld);
+      expect(asyncGame.worldState.newWorld, syncGame.worldState.newWorld);
+      expect(asyncGame.players.length, syncGame.players.length);
+    });
   });
 }
 

--- a/app/test/shell_screen_test.dart
+++ b/app/test/shell_screen_test.dart
@@ -1,3 +1,4 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_test/flutter_test.dart';
 
@@ -27,6 +28,20 @@ class _DummyGameService extends GameService {
 
   @override
   Game? loadGame(String gameId) => _loadedGame;
+
+  @override
+  Future<Game> createNewGameAsync({
+    String? id,
+    GameSetupConfig? config,
+    void Function(int stepIndex, int totalSteps)? onProgress,
+  }) async {
+    const total = GameService.newGameSetupProgressStepCount;
+    for (var i = 0; i < total; i++) {
+      onProgress?.call(i, total);
+      await Future<void>.delayed(Duration.zero);
+    }
+    return createNewGame(id: id, config: config);
+  }
 
   @override
   Game createNewGame({String? id, config}) {

--- a/packages/colonizethis_map/lib/src/tile_map_generator.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator.dart
@@ -713,6 +713,8 @@ class TileMapGenerator {
         ? resourceGrid.map((row) => row.toList()).toList()
         : null;
     final ocean = _oceanCells(g, seaZoneId);
+    // Upper bound so we cannot spin forever if sea-fraction preservation undoes a bridge.
+    final maxJoinIterationsPerContinent = params.width * params.height;
 
     final capState =
         (tg != null &&
@@ -729,7 +731,9 @@ class TileMapGenerator {
         : null;
 
     for (var c = 0; c < numContinents; c++) {
-      while (true) {
+      var joinIterations = 0;
+      while (joinIterations < maxJoinIterationsPerContinent) {
+        joinIterations++;
         final landCells = _landCellsForContinent(
           g,
           provinceToContinent,
@@ -744,6 +748,7 @@ class TileMapGenerator {
         final path = _shortestSeaPath(g, seaZoneId, compA, compB);
         if (path.isEmpty) break;
         final provinceId = _provinceIdAdjacentToSeaPath(g, compA, path);
+        final bridgeCells = path.toSet();
         for (final (x, y) in path) {
           g[y][x] = provinceId;
           if (tg != null &&
@@ -762,7 +767,29 @@ class TileMapGenerator {
             );
           }
         }
-        _preserveSeaFraction(g, tg, rg, seaZoneId, ocean, path.length);
+        // Do not convert bridge tiles back to sea: _preserveSeaFraction picks the
+        // most "coastal" land first, which matches the new corridor and would undo
+        // the join, leaving >1 component and an infinite loop.
+        _preserveSeaFraction(
+          g,
+          tg,
+          rg,
+          seaZoneId,
+          ocean,
+          path.length,
+          landCellsExcludedFromSeaRestore: bridgeCells,
+        );
+      }
+      if (joinIterations >= maxJoinIterationsPerContinent) {
+        final stillSplit = _connectedComponentsOfLand(
+          _landCellsForContinent(g, provinceToContinent, c, seaZoneId),
+        );
+        if (stillSplit.length > 1) {
+          _log.w(
+            'map: join continents hit iteration cap with >1 land component for '
+            'continent index $c (width=${params.width} height=${params.height})',
+          );
+        }
       }
     }
     return (g, tg, rg, didJoin);
@@ -1074,12 +1101,16 @@ class TileMapGenerator {
     List<List<Resource?>>? resourceGrid,
     String seaZoneId,
     Set<(int x, int y)> ocean,
-    int count,
-  ) {
+    int count, {
+    Set<(int x, int y)>? landCellsExcludedFromSeaRestore,
+  }) {
     final coastal = <(int x, int y)>[];
     for (var y = 0; y < params.height; y++) {
       for (var x = 0; x < params.width; x++) {
         if (grid[y][x] == seaZoneId) continue;
+        if (landCellsExcludedFromSeaRestore?.contains((x, y)) ?? false) {
+          continue;
+        }
         final oceanNeighbours = [(x - 1, y), (x + 1, y), (x, y - 1), (x, y + 1)]
             .where(
               (p) =>

--- a/packages/colonizethis_map/test/tile_map_generator_test.dart
+++ b/packages/colonizethis_map/test/tile_map_generator_test.dart
@@ -853,6 +853,25 @@ void main() {
       });
       expect(hasBridge, isFalse);
     });
+
+    test(
+      'joinContinents completes for small multi-continent grids (regression: no hang)',
+      () {
+        for (final seed in [0, 7, 42, 99, 777]) {
+          final params = TileMapParams(
+            width: 20,
+            height: 18,
+            seed: seed,
+            seaFraction: 0.6,
+          );
+          TileMapGenerator(params: params).generate(
+            numProvinces: 6,
+            numContinents: 3,
+            regionId: 'oldWorld',
+          );
+        }
+      },
+    );
   });
 
   group('validateTileMapTopology', () {


### PR DESCRIPTION
## Summary

Addresses the shell freeze when starting a new game after leader selection by running setup in phased async steps with UI yields, and fixes a real infinite-loop case in map generation when joining continents interacted badly with sea-fraction preservation.

## Changes

- **Map:** `TileMapGenerator` — iteration cap on continent join; bridge tiles excluded from `_preserveSeaFraction` coastal conversion so bridges are not immediately undone.
- **App:** `GameService.createNewGameAsync` — same pipeline as `createNewGame` with `onProgress(0..4)` and `Future.delayed(Duration.zero)` between phases; `new_game_setup_flow.dart` shows modal progress, error dialog, retry with `baseSeed + attemptIndex`.
- **Specs:** `SPEC/ui/game-initializing.md` and cross-refs in program/ui specs.
- **L10n:** Progress and error strings in `app_en.arb`.
- **Tests:** Integration tests for async progress and world parity vs sync; map regression test over several seeds; `_DummyGameService.createNewGameAsync` for fast shell widget test.

## Verification

- `flutter test test/shell_screen_test.dart test/game_service_integration_test.dart`
- `dart test` (colonizethis_map tile_map_generator tests including new regression)


Made with [Cursor](https://cursor.com)