### PR TITLE
fix(ui): player resource visibility on map and province panel

### DIFF
--- a/app/lib/features/game/flame/game_map_canvas_stack.dart
+++ b/app/lib/features/game/flame/game_map_canvas_stack.dart
@@ -62,6 +62,7 @@ class GameMapCanvasStack extends ConsumerWidget {
                   showBordersLayer: showBordersLayer,
                   showProvinceNamesLayer: showProvinceNamesLayer,
                   visibilityMode: CtMapVisibilityMode.playerConstrained,
+                  playerViewForResources: playerView,
                   baseLayerDisplayMode: baseLayerDisplayMode,
                   onProvinceSelected: null,
                   onMapTileTappedForDetail: inWorkTargetSelectionMode

--- a/app/lib/features/game/flame/region_map_component.dart
+++ b/app/lib/features/game/flame/region_map_component.dart
@@ -1,6 +1,8 @@
 import 'dart:math' as math;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show PlayerView, resourceIdVisibleInPlayerView;
 import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:flame/components.dart';
@@ -76,6 +78,21 @@ enum CtMapVisibilityMode {
   playerConstrained,
 }
 
+/// [CtMapVisibilityMode.playerConstrained] requires [playerViewForResources].
+void assertCtMapPlayerViewRequired({
+  required CtMapVisibilityMode visibilityMode,
+  required PlayerView? playerViewForResources,
+}) {
+  if (visibilityMode == CtMapVisibilityMode.playerConstrained &&
+      playerViewForResources == null) {
+    throw StateError(
+      'CtMapVisibilityMode.playerConstrained requires a non-null '
+      'PlayerView (pass playerViewForResources), e.g. '
+      'buildPlayerView(game, topology, humanPlayerId).',
+    );
+  }
+}
+
 /// Base layer display mode: which tile letters are drawn. SPEC/ui/map-widget.md § Base layer display mode.
 enum BaseLayerDisplayMode {
   /// Terrain only; no resource or improvement/road letters.
@@ -109,6 +126,7 @@ class CtRegionMapComponent extends PositionComponent {
     this.secondaryHighlightTileKey,
     this.validTileKeys,
     this.onTownIconTapped,
+    this.playerViewForResources,
   });
 
   RegionMapViewData region;
@@ -117,6 +135,11 @@ class CtRegionMapComponent extends PositionComponent {
   bool showBordersLayer;
   bool showProvinceNamesLayer;
   CtMapVisibilityMode visibilityMode;
+
+  /// When [visibilityMode] is [CtMapVisibilityMode.playerConstrained], gates
+  /// resource icons by fog + prospecting (SPEC/game/fog-and-exploration.md).
+  /// Must be non-null in that mode; see [assertCtMapPlayerViewRequired].
+  PlayerView? playerViewForResources;
 
   /// Camera zoom from Flame viewfinder; used to keep label size constant on screen.
   double cameraZoom = 1.0;
@@ -143,6 +166,10 @@ class CtRegionMapComponent extends PositionComponent {
 
   @override
   Future<void> onLoad() async {
+    assertCtMapPlayerViewRequired(
+      visibilityMode: visibilityMode,
+      playerViewForResources: playerViewForResources,
+    );
     await super.onLoad();
     await Future.wait([
       terrainTilesetCache.load(),
@@ -827,6 +854,23 @@ class CtRegionMapComponent extends PositionComponent {
     return region.cellAt(x, y);
   }
 
+  String? _resourceIdForMapIcon(CellViewData cell) {
+    final raw = cell.resourceId;
+    if (raw == null) return null;
+    if (visibilityMode != CtMapVisibilityMode.playerConstrained) {
+      return raw;
+    }
+    final view = playerViewForResources;
+    if (view == null) {
+      throw StateError(
+        'CtRegionMapComponent: playerConstrained requires playerViewForResources',
+      );
+    }
+    final tileKey =
+        '${region.regionId}|${cell.regionCellId}|${cell.x}|${cell.y}';
+    return resourceIdVisibleInPlayerView(view, tileKey, raw);
+  }
+
   void _paintOverlay(Canvas canvas) {
     final showResources =
         baseLayerDisplayMode == BaseLayerDisplayMode.terrainAndResources ||
@@ -847,8 +891,9 @@ class CtRegionMapComponent extends PositionComponent {
       final cy = cell.y * cellSize + cellSize / 2;
 
       // Draw resource icon if present and mode includes resources.
-      if (showResources && cell.resourceId != null) {
-        final icon = resourceIconCache.getIcon(cell.resourceId);
+      final resourceForIcon = _resourceIdForMapIcon(cell);
+      if (showResources && resourceForIcon != null) {
+        final icon = resourceIconCache.getIcon(resourceForIcon);
         if (icon != null) {
           final iconSize = ResourceIconCache.iconSize;
           final tileLeft = cell.x * cellSize;

--- a/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
+++ b/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
@@ -1,7 +1,14 @@
 // Province and sea zone detail overlay. SPEC/ui/province-sea-zone-detail-overlay.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show
+        fleetsInPortAtProvince,
+        foreignCivilianVisibleToPlayer,
+        kProspectRequiredResourceIds,
+        PlayerView,
+        resourceIdVisibleInPlayerView,
+        VisibilityLevel;
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_app/widgets/ct_panel.dart';
@@ -272,7 +279,6 @@ _OverlayContent _provinceContent({
   final resourceByTile = game.worldState.resourceByTileKey;
   final tileState = game.worldState.tileState;
   final prospected = game.worldState.playerProspectedTiles[humanPlayerId] ?? {};
-  const mineralResources = {'iron', 'copper', 'tin', 'coal', 'silver', 'gold', 'gems', 'diamonds'};
 
   final tilesToProspect = <String>[];
   final improvementsBuilt = <({String tileKey, int x, int y, String name, int level})>[];
@@ -281,12 +287,18 @@ _OverlayContent _provinceContent({
 
   for (final tk in tileKeys) {
     final res = resourceByTile[tk];
-    if (res != null) resources.add(res);
+    final visLevel = playerView.visibilityForTile(tk);
+    final visibleRes = resourceIdVisibleInPlayerView(playerView, tk, res);
+    if (visibleRes != null) {
+      resources.add(visibleRes);
+    }
     final parts = tk.split('|');
     if (parts.length < 4) continue;
     final x = int.tryParse(parts[2]) ?? 0;
     final y = int.tryParse(parts[3]) ?? 0;
-    if (mineralResources.contains(res) && !prospected.contains(tk)) {
+    if (res != null &&
+        kProspectRequiredResourceIds.contains(res) &&
+        !prospected.contains(tk)) {
       tilesToProspect.add(tk);
     }
     final imp = tileState.improvementLevel(tk);
@@ -295,7 +307,11 @@ _OverlayContent _provinceContent({
         tileKey: tk,
         x: x,
         y: y,
-        name: _improvementNameForResource(res),
+        name: _improvementBaseNameForPlayer(
+          visLevel: visLevel,
+          rawResourceId: res,
+          visibleResourceId: visibleRes,
+        ),
         level: imp,
       ));
     } else if (res != null && imp < 4) {
@@ -308,6 +324,7 @@ _OverlayContent _provinceContent({
     region: region,
     provinceId: provinceId,
     humanPlayerId: humanPlayerId,
+    playerView: playerView,
     civilianCount: visibleCivilianCount,
     selectedTileKey: selectedTileKey,
   );
@@ -360,11 +377,50 @@ _OverlayContent _provinceContent({
   return _OverlayContent(tabLabels: tabLabels, tabViews: tabViews, sections: sections);
 }
 
+String _improvementBaseNameForPlayer({
+  required VisibilityLevel visLevel,
+  required String? rawResourceId,
+  required String? visibleResourceId,
+}) {
+  if (visibleResourceId != null) {
+    return _improvementNameForResource(visibleResourceId);
+  }
+  if (visLevel == VisibilityLevel.revealed) {
+    return 'Improvement';
+  }
+  if (rawResourceId != null &&
+      kProspectRequiredResourceIds.contains(rawResourceId)) {
+    return 'Mine';
+  }
+  if (rawResourceId != null) {
+    return _improvementNameForResource(rawResourceId);
+  }
+  return 'Improvement';
+}
+
+String _improvementLabelForTileDetail({
+  required int impLevel,
+  required VisibilityLevel visLevel,
+  required String? rawResourceId,
+  required String? visibleResourceId,
+}) {
+  if (impLevel <= 0) {
+    return '—';
+  }
+  final base = _improvementBaseNameForPlayer(
+    visLevel: visLevel,
+    rawResourceId: rawResourceId,
+    visibleResourceId: visibleResourceId,
+  );
+  return '$base L$impLevel';
+}
+
 Widget _buildTileSection({
   required Game game,
   required RegionMapViewData region,
   required String provinceId,
   required String humanPlayerId,
+  required PlayerView playerView,
   required int civilianCount,
   String? selectedTileKey,
 }) {
@@ -405,21 +461,14 @@ Widget _buildTileSection({
   final tileState = game.worldState.tileState;
   final resourceByTile = game.worldState.resourceByTileKey;
   final prospected = game.worldState.playerProspectedTiles[humanPlayerId] ?? {};
-  const mineralResources = {
-    'iron',
-    'copper',
-    'tin',
-    'coal',
-    'silver',
-    'gold',
-    'gems',
-    'diamonds',
-  };
   final terrainStr = cell.terrainType?.name ?? cell.terrainTypeId ?? '—';
   final resourceRaw = resourceByTile[selectedTileKey] ?? cell.resourceId;
-  final resource = resourceRaw ?? '—';
-  final prospectable =
-      resourceRaw != null && mineralResources.contains(resourceRaw);
+  final visLevel = playerView.visibilityForTile(selectedTileKey);
+  final resourceVisible =
+      resourceIdVisibleInPlayerView(playerView, selectedTileKey, resourceRaw);
+  final resourceLabel = resourceVisible ?? '—';
+  final prospectable = resourceRaw != null &&
+      kProspectRequiredResourceIds.contains(resourceRaw);
   final prospectedLabel =
       !prospectable ? '—' : (prospected.contains(selectedTileKey) ? 'yes' : 'no');
   final impLevel = tileState.improvementLevel(selectedTileKey);
@@ -433,9 +482,12 @@ Widget _buildTileSection({
           4 => 'port or railroad',
           _ => 'level $roadLevel',
         };
-  final improvementName = impLevel > 0 && resource != '—'
-      ? _improvementNameForResource(resource)
-      : null;
+  final improvementLine = _improvementLabelForTileDetail(
+    impLevel: impLevel,
+    visLevel: visLevel,
+    rawResourceId: resourceRaw,
+    visibleResourceId: resourceVisible,
+  );
 
   return _buildSection('Tile', Column(
     crossAxisAlignment: CrossAxisAlignment.start,
@@ -443,9 +495,9 @@ Widget _buildTileSection({
     children: [
       Text('Coordinates: ($x, $y)'),
       Text('Terrain: $terrainStr'),
-      Text('Resource: $resource'),
+      Text('Resource: $resourceLabel'),
       Text('Prospected: $prospectedLabel'),
-      Text('Improvement: ${improvementName != null ? '$improvementName L$impLevel' : '—'}'),
+      Text('Improvement: $improvementLine'),
       Text('Road / railroad: $roadLabel'),
       Text('Civilian units (province): $civilianCount'),
     ],

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -998,6 +998,10 @@ class _CivilianPanelWithMapStoryState
               region: region,
               cellSizePx: 24,
               visibilityMode: _visibilityMode,
+              playerViewForResources: _visibilityMode ==
+                      CtMapVisibilityMode.playerConstrained
+                  ? debugPlayerViewForFirstPlayer()
+                  : null,
               showProvinceNamesLayer: _showProvinceNames,
               onProvinceSelected: (_) {},
               secondaryHighlightTileKey: _secondaryHighlightTileKey,
@@ -1478,6 +1482,10 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
                         region: region,
                         cellSizePx: 28,
                         visibilityMode: _visibilityMode,
+                        playerViewForResources: _visibilityMode ==
+                                CtMapVisibilityMode.playerConstrained
+                            ? playerView
+                            : null,
                         showProvinceNamesLayer: _showProvinceNames,
                         onProvinceSelected: null,
                         onMapTileTappedForDetail: (tk) => setState(() {

--- a/app/lib/widgetbook/catalog.dart
+++ b/app/lib/widgetbook/catalog.dart
@@ -1000,6 +1000,10 @@ class _CivilianPanelWithMapStoryState
               region: region,
               cellSizePx: 24,
               visibilityMode: _visibilityMode,
+              playerViewForResources: _visibilityMode ==
+                      CtMapVisibilityMode.playerConstrained
+                  ? debugPlayerViewForFirstPlayer()
+                  : null,
               showProvinceNamesLayer: _showProvinceNames,
               onProvinceSelected: (_) {},
               secondaryHighlightTileKey: _secondaryHighlightTileKey,
@@ -1480,6 +1484,10 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
                         region: region,
                         cellSizePx: 28,
                         visibilityMode: _visibilityMode,
+                        playerViewForResources: _visibilityMode ==
+                                CtMapVisibilityMode.playerConstrained
+                            ? playerView
+                            : null,
                         showProvinceNamesLayer: _showProvinceNames,
                         onProvinceSelected: null,
                         onMapTileTappedForDetail: (tk) => setState(() {

--- a/app/lib/widgets/ct_region_map.dart
+++ b/app/lib/widgets/ct_region_map.dart
@@ -1,3 +1,4 @@
+import 'package:colonizethis_logic/colonizethis_logic.dart' show PlayerView;
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flame/events.dart';
@@ -10,7 +11,10 @@ import 'package:flutter/services.dart';
 import '../features/game/flame/region_map_component.dart';
 
 export '../features/game/flame/region_map_component.dart'
-    show BaseLayerDisplayMode, CtMapVisibilityMode;
+    show
+        assertCtMapPlayerViewRequired,
+        BaseLayerDisplayMode,
+        CtMapVisibilityMode;
 
 /// FlameGame host for the region map, with basic tap/drag/pinch wiring.
 class _CtRegionMapGame extends FlameGame with TapDetector {
@@ -34,6 +38,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
     required void Function(String tileKey)? onTileSelected,
     required VoidCallback? onWorkTargetSelectionCancelled,
     required void Function(String provinceId)? onTownIconTapped,
+    this.playerViewForResources,
   }) : region = region,
        cellSizePx = cellSizePx,
        showPoliticalOverlay = showPoliticalOverlay,
@@ -71,6 +76,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
   void Function(String tileKey)? onTileSelected;
   VoidCallback? onWorkTargetSelectionCancelled;
   void Function(String provinceId)? onTownIconTapped;
+  PlayerView? playerViewForResources;
 
   late final CtRegionMapComponent _mapComponent;
 
@@ -109,6 +115,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
       },
       validTileKeys: validTileKeys,
       onTownIconTapped: onTownIconTapped,
+      playerViewForResources: playerViewForResources,
     )..position = Vector2.zero();
     await world.add(_mapComponent);
     _mapLoaded = true;
@@ -143,6 +150,7 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
     bool clearValidTileKeys = false,
     void Function(String tileKey)? onTileSelected,
     VoidCallback? onWorkTargetSelectionCancelled,
+    required PlayerView? playerViewForResources,
   }) {
     if (region != null) {
       this.region = region;
@@ -180,6 +188,12 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
     // Update callbacks (these may change when parent widget rebuilds).
     this.onTileSelected = onTileSelected;
     this.onWorkTargetSelectionCancelled = onWorkTargetSelectionCancelled;
+    this.playerViewForResources = playerViewForResources;
+
+    assertCtMapPlayerViewRequired(
+      visibilityMode: this.visibilityMode,
+      playerViewForResources: this.playerViewForResources,
+    );
 
     if (_mapLoaded) {
       _mapComponent
@@ -192,7 +206,8 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
         ..baseLayerDisplayMode = this.baseLayerDisplayMode
         ..selectedTileKey = this.selectedTileKey
         ..secondaryHighlightTileKey = this.secondaryHighlightTileKey
-        ..validTileKeys = this.validTileKeys;
+        ..validTileKeys = this.validTileKeys
+        ..playerViewForResources = this.playerViewForResources;
     }
   }
 
@@ -373,6 +388,7 @@ class CtRegionMap extends StatefulWidget {
     this.onTileSelected,
     this.onWorkTargetSelectionCancelled,
     this.bus,
+    this.playerViewForResources,
   });
 
   final RegionMapViewData region;
@@ -399,6 +415,9 @@ class CtRegionMap extends StatefulWidget {
   /// Optional event bus for emitting town icon tap events.
   /// When provided, tapping a town/port icon emits OpenProvinceDetailPanelEvent.
   final AppEventBus? bus;
+
+  /// Required when [visibilityMode] is [CtMapVisibilityMode.playerConstrained].
+  final PlayerView? playerViewForResources;
 
   @override
   State<CtRegionMap> createState() => _CtRegionMapState();
@@ -428,7 +447,8 @@ class _CtRegionMapState extends State<CtRegionMap> {
             oldWidget.secondaryHighlightTileKey ||
         widget.onTileSelected != oldWidget.onTileSelected ||
         widget.onWorkTargetSelectionCancelled !=
-            oldWidget.onWorkTargetSelectionCancelled) {
+            oldWidget.onWorkTargetSelectionCancelled ||
+        widget.playerViewForResources != oldWidget.playerViewForResources) {
       _game.updateProps(
         region: widget.region,
         showPoliticalOverlay: widget.showPoliticalOverlay,
@@ -448,6 +468,7 @@ class _CtRegionMapState extends State<CtRegionMap> {
             widget.validTileKeys == null && oldWidget.validTileKeys != null,
         onTileSelected: widget.onTileSelected,
         onWorkTargetSelectionCancelled: widget.onWorkTargetSelectionCancelled,
+        playerViewForResources: widget.playerViewForResources,
       );
     }
     if (widget.centerOnTileKey != null &&
@@ -484,11 +505,16 @@ class _CtRegionMapState extends State<CtRegionMap> {
               widget.bus!.emit(OpenProvinceDetailPanelEvent(provinceId));
             }
           : null,
+      playerViewForResources: widget.playerViewForResources,
     );
   }
 
   @override
   Widget build(BuildContext context) {
+    assertCtMapPlayerViewRequired(
+      visibilityMode: widget.visibilityMode,
+      playerViewForResources: widget.playerViewForResources,
+    );
     return Focus(
       autofocus: true,
       child: CallbackShortcuts(

--- a/app/lib/widgets/debug_map_visibility_story.dart
+++ b/app/lib/widgets/debug_map_visibility_story.dart
@@ -9,18 +9,25 @@ import 'debug_init_game.dart';
 /// Builds InitGameMapViewData for the debug init game result, enriching it with
 /// per-tile visibility derived from the first player's PlayerView. Used by map
 /// Widgetbook stories to support full vs player-constrained visibility modes.
-InitGameMapViewData debugMapViewDataWithVisibilityForFirstPlayer() {
+
+/// [PlayerView] for the first great power in the debug init game; null if none.
+PlayerView? debugPlayerViewForFirstPlayer() {
   final result = getDebugInitGameResult();
   final game = result.game;
   if (game.players.isEmpty) {
-    return result.mapViewData;
+    return null;
   }
   final playerId = game.players.first.id;
-  final view = buildPlayerView(
-    game,
-    result.combinedTopology,
-    playerId,
-  );
+  return buildPlayerView(game, result.combinedTopology, playerId);
+}
+
+InitGameMapViewData debugMapViewDataWithVisibilityForFirstPlayer() {
+  final result = getDebugInitGameResult();
+  final view = debugPlayerViewForFirstPlayer();
+  if (view == null) {
+    return result.mapViewData;
+  }
+  final game = result.game;
 
   final visibilityByTile = <String, TileVisibility>{};
   view.visibilityByTile.forEach((tileKey, level) {
@@ -129,6 +136,10 @@ class _DebugMapVisibilityStoryState extends State<DebugMapVisibilityStory> {
               showPoliticalOverlay: widget.showPoliticalOverlay,
               cellSizePx: 28,
               visibilityMode: _visibilityMode,
+              playerViewForResources: _visibilityMode ==
+                      CtMapVisibilityMode.playerConstrained
+                  ? debugPlayerViewForFirstPlayer()
+                  : null,
               showProvinceNamesLayer: _showProvinceNames,
               onProvinceSelected: (id) {},
             ),

--- a/app/test/ct_region_map_test.dart
+++ b/app/test/ct_region_map_test.dart
@@ -1,4 +1,6 @@
+import 'package:colonizethis_logic/colonizethis_logic.dart' show PlayerView;
 import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_models/colonizethis_models.dart' show Player;
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -14,6 +16,21 @@ import 'package:colonizethis_app/widgets/debug_init_game.dart';
 
 void main() {
   suppressLogsForTests();
+
+  /// Minimal view for map tests in [CtMapVisibilityMode.playerConstrained].
+  const ctRegionMapTestPlayerView = PlayerView(
+    playerId: 'ct_region_map_test',
+    player: Player(
+      id: 'ct_region_map_test',
+      displayName: 'Test',
+      isHuman: false,
+    ),
+    ownUnitsById: {},
+    provincesById: {},
+    visibilityByTile: {},
+    prospectedTiles: {},
+    diplomacyByOtherId: {},
+  );
 
   group('debug init Old World region', () {
     test('returns region with correct dimensions and cell count', () {
@@ -73,6 +90,7 @@ void main() {
     String? selectedTileKey,
     String? secondaryHighlightTileKey,
     VoidCallback? onRegionViewChanged,
+    PlayerView? playerViewForResources,
   }) {
     return MaterialApp(
       home: Scaffold(
@@ -86,6 +104,7 @@ void main() {
               showPoliticalOverlay: showPoliticalOverlay,
               showBordersLayer: showBordersLayer,
               visibilityMode: visibilityMode,
+              playerViewForResources: playerViewForResources,
               baseLayerDisplayMode: baseLayerDisplayMode,
               centerOnTileKey: centerOnTileKey,
               onProvinceSelected: onProvinceSelected,
@@ -103,6 +122,31 @@ void main() {
   }
 
   group('CtRegionMap (Flame map widget)', () {
+    testWidgets(
+      'throws StateError when playerConstrained without playerViewForResources',
+      (WidgetTester tester) async {
+        final region = _oldWorldRegion();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: SizedBox(
+                  width: 400,
+                  height: 320,
+                  child: CtRegionMap(
+                    region: region,
+                    visibilityMode: CtMapVisibilityMode.playerConstrained,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        expect(tester.takeException(), isA<StateError>());
+      },
+      timeout: const Timeout(Duration(seconds: 5)),
+    );
+
     testWidgets(
       'required Wang tileset asset files are present in test asset bundle',
       (WidgetTester tester) async {
@@ -177,6 +221,7 @@ void main() {
             showPoliticalOverlay: false,
             showBordersLayer: false,
             visibilityMode: CtMapVisibilityMode.playerConstrained,
+            playerViewForResources: ctRegionMapTestPlayerView,
           ),
         );
         await tester.pump();
@@ -349,6 +394,7 @@ void main() {
             region: region,
             showPoliticalOverlay: false,
             visibilityMode: CtMapVisibilityMode.playerConstrained,
+            playerViewForResources: ctRegionMapTestPlayerView,
             baseLayerDisplayMode: BaseLayerDisplayMode.terrainOnly,
           ),
         );
@@ -628,6 +674,7 @@ void main() {
           _buildCtRegionMap(
             region: region,
             visibilityMode: CtMapVisibilityMode.playerConstrained,
+            playerViewForResources: ctRegionMapTestPlayerView,
             onProvinceSelected: (id) => selectedId = id,
           ),
         );
@@ -836,6 +883,7 @@ void main() {
           _buildCtRegionMap(
             region: region,
             visibilityMode: CtMapVisibilityMode.playerConstrained,
+            playerViewForResources: ctRegionMapTestPlayerView,
             baseLayerDisplayMode: BaseLayerDisplayMode.terrainAndResources,
           ),
         );

--- a/ctdev/lib/player_view_map_painter.dart
+++ b/ctdev/lib/player_view_map_painter.dart
@@ -128,7 +128,12 @@ class PlayerViewMapPainter extends CustomPainter {
         if (vis != VisibilityLevel.fogged && vis != VisibilityLevel.fullyVisible) {
           continue;
         }
-        final letter = resourceIdToLegendLetter(cell.resourceId);
+        final visRes = resourceIdVisibleInPlayerView(
+          playerView,
+          tileKeyForCell(region, cell),
+          cell.resourceId,
+        );
+        final letter = resourceIdToLegendLetter(visRes);
         if (letter == null) continue;
         final cx = cell.x * cellSize + cellSize / 2;
         final cy = cell.y * cellSize + cellSize / 2;

--- a/packages/colonizethis_logic/lib/src/world/player_view.dart
+++ b/packages/colonizethis_logic/lib/src/world/player_view.dart
@@ -154,9 +154,53 @@ PlayerView buildPlayerView(
 
 /// Resources that require prospecting before the player "knows" them.
 /// SPEC/game/fog-and-exploration.md: iron, copper, tin, coal, silver, gold, gems, diamonds.
-const Set<String> _prospectRequiredResourceIds = {
+const Set<String> kProspectRequiredResourceIds = {
   'iron', 'copper', 'tin', 'coal', 'silver', 'gold', 'gems', 'diamonds',
 };
+
+/// Resource commodity id to show in UI for the given visibility and
+/// prospection state, or null to show no resource.
+///
+/// [authoritativeResourceId] is ground truth from the tile map /
+/// [WorldState.resourceByTileKey]. SPEC/game/fog-and-exploration.md.
+String? resourceIdVisibleToPlayer({
+  required String? authoritativeResourceId,
+  required VisibilityLevel visibility,
+  required bool tileProspectedByPlayer,
+}) {
+  final id = authoritativeResourceId;
+  if (id == null || id.isEmpty) return null;
+
+  switch (visibility) {
+    case VisibilityLevel.unknown:
+      return null;
+    case VisibilityLevel.revealed:
+      return null;
+    case VisibilityLevel.fogged:
+      if (kProspectRequiredResourceIds.contains(id)) {
+        return tileProspectedByPlayer ? id : null;
+      }
+      return id;
+    case VisibilityLevel.fullyVisible:
+      if (kProspectRequiredResourceIds.contains(id)) {
+        return tileProspectedByPlayer ? id : null;
+      }
+      return id;
+  }
+}
+
+/// Convenience wrapper using [PlayerView] visibility and prospected-tile set.
+String? resourceIdVisibleInPlayerView(
+  PlayerView view,
+  String tileKey,
+  String? authoritativeResourceId,
+) {
+  return resourceIdVisibleToPlayer(
+    authoritativeResourceId: authoritativeResourceId,
+    visibility: view.visibilityForTile(tileKey),
+    tileProspectedByPlayer: view.tileIsProspected(tileKey),
+  );
+}
 
 /// True if [playerId] has at least one revealed tile containing [resourceId].
 /// Revealed = visibility fully visible, fogged, or revealed. For prospect-required
@@ -166,7 +210,7 @@ bool hasRevealedResourceForPlayer(Game game, String playerId, String resourceId)
   final ws = game.worldState;
   final visibility = ws.playerVisibilityByTile[playerId] ?? const {};
   final prospected = ws.playerProspectedTiles[playerId] ?? const <String>{};
-  final needProspect = _prospectRequiredResourceIds.contains(resourceId);
+  final needProspect = kProspectRequiredResourceIds.contains(resourceId);
 
   for (final e in ws.resourceByTileKey.entries) {
     if (e.value != resourceId) continue;
@@ -176,8 +220,8 @@ bool hasRevealedResourceForPlayer(Game game, String playerId, String resourceId)
     if (needProspect && !prospected.contains(tileKey)) continue;
     return true;
   }
-    return false;
-  }
+  return false;
+}
 
 /// Whether [unit] should appear in another player's province UI for civilians.
 ///

--- a/packages/colonizethis_logic/test/player_view_test.dart
+++ b/packages/colonizethis_logic/test/player_view_test.dart
@@ -150,6 +150,63 @@ void main() {
       expect(view.visibilityByTile['tileB'], VisibilityLevel.unknown);
     });
 
+    test('resourceIdVisibleToPlayer hides prospect minerals until prospected', () {
+      expect(
+        resourceIdVisibleToPlayer(
+          authoritativeResourceId: 'gold',
+          visibility: VisibilityLevel.fullyVisible,
+          tileProspectedByPlayer: false,
+        ),
+        isNull,
+      );
+      expect(
+        resourceIdVisibleToPlayer(
+          authoritativeResourceId: 'gold',
+          visibility: VisibilityLevel.fullyVisible,
+          tileProspectedByPlayer: true,
+        ),
+        'gold',
+      );
+      expect(
+        resourceIdVisibleToPlayer(
+          authoritativeResourceId: 'grain',
+          visibility: VisibilityLevel.fullyVisible,
+          tileProspectedByPlayer: false,
+        ),
+        'grain',
+      );
+    });
+
+    test('resourceIdVisibleToPlayer hides all resources when revealed', () {
+      expect(
+        resourceIdVisibleToPlayer(
+          authoritativeResourceId: 'grain',
+          visibility: VisibilityLevel.revealed,
+          tileProspectedByPlayer: false,
+        ),
+        isNull,
+      );
+    });
+
+    test('resourceIdVisibleToPlayer hides prospect minerals when fogged and not prospected', () {
+      expect(
+        resourceIdVisibleToPlayer(
+          authoritativeResourceId: 'iron',
+          visibility: VisibilityLevel.fogged,
+          tileProspectedByPlayer: false,
+        ),
+        isNull,
+      );
+      expect(
+        resourceIdVisibleToPlayer(
+          authoritativeResourceId: 'timber',
+          visibility: VisibilityLevel.fogged,
+          tileProspectedByPlayer: false,
+        ),
+        'timber',
+      );
+    });
+
     test('buildPlayerView throws when playerId not in game', () {
       final game = Game(
         id: 'g1',


### PR DESCRIPTION
## Summary
Resource icons and province tile details now respect **player visibility** and **prospecting**: prospect-required minerals stay hidden until prospected, including on the player’s own land. `full` map mode remains ground truth for tooling.

## Implementation
- **Single source of truth:** `resourceIdVisibleToPlayer` / `resourceIdVisibleInPlayerView` in `colonizethis_logic` (`player_view.dart`).
- **Map:** `CtRegionMap` / `CtRegionMapComponent` take `playerViewForResources` when using `CtMapVisibilityMode.playerConstrained`; `GameMapCanvasStack` passes the built `PlayerView`.
- **Strict config:** `playerConstrained` without `playerViewForResources` throws `StateError` (no fallback to raw cell data).
- **Other UI:** Province sea zone detail overlay and `ctdev` `player_view_map_painter` use the same helpers.
- **Tests:** `player_view_test.dart`, `ct_region_map_test.dart` (including misconfiguration case). Widgetbook/debug stories updated.

## Review notes
- `pubspec.lock` was not changed (incidental `meta` bump reverted).

Made with [Cursor](https://cursor.com)