### PR TITLE
fix(map): align resource icons for 32×32 tiles

### DIFF
--- a/SPEC/ui/map-widget.md
+++ b/SPEC/ui/map-widget.md
@@ -73,7 +73,8 @@ All icons are 32×32 PNG with RGBA transparency, colonial-era pixel art style ma
 
 - **Icon size:** Resource icons are always 32×32 pixels, regardless of the tile cell size. Icons are never scaled up; they render at native 32×32 resolution.
 - **Position:** Position depends on the tile cell size:
-  - **For tiles ≤32px:** Icon is centered horizontally within the tile cell; vertically positioned in the lower half of the cell to avoid overlapping terrain features.
+  - **For tiles &lt;32px:** Icon is centered horizontally; vertically **bottom-aligned** to the tile (top may extend above the cell) so the visible footprint sits toward the lower part of the cell.
+  - **For tiles exactly 32px:** Icon is **centered** in the cell (same width and height as the icon).
   - **For tiles >32px:** Icon is placed in the **bottom-left corner** of the tile cell (at x=0, y=tileSize-32). This ensures the icon remains visible and readable at native resolution without being obscured or requiring upscaling.
 - **Visibility:** Icons are subject to the same visibility rules as terrain (visible/fogged/unrevealed). Fogged tiles render icons with reduced opacity; unrevealed tiles show nothing.
 

--- a/app/lib/features/game/flame/region_map_component.dart
+++ b/app/lib/features/game/flame/region_map_component.dart
@@ -900,16 +900,20 @@ class CtRegionMapComponent extends PositionComponent {
           final tileTop = cell.y * cellSize;
 
           // Resource icons are always 32x32, never upscaled.
-          // For tiles <= 32px: center horizontally, position in lower half.
-          // For tiles > 32px: position in bottom-left corner.
+          // For tiles > 32px: bottom-left corner (SPEC/ui/map-widget.md).
+          // For tiles == 32px: centered in the cell (icon fills the tile).
+          // For tiles < 32px: center horizontally; bottom-align so the icon
+          // sits in the lower part of the cell (extends upward if needed).
           final double iconX;
           final double iconY;
-          if (cellSize <= iconSize) {
-            iconX = tileLeft + (cellSize - iconSize) / 2;
-            iconY = tileTop + cellSize / 2;
-          } else {
+          if (cellSize > iconSize) {
             iconX = tileLeft;
             iconY = tileTop + cellSize - iconSize;
+          } else {
+            iconX = tileLeft + (cellSize - iconSize) / 2;
+            iconY = cellSize < iconSize
+                ? tileTop + cellSize - iconSize
+                : tileTop + (cellSize - iconSize) / 2;
           }
 
           final dstRect = Rect.fromLTWH(iconX, iconY, iconSize, iconSize);


### PR DESCRIPTION
## Summary
Resource icons on the region map were drawn with `iconY = tileTop + cellSize / 2` whenever `cellSize <= 32`. That value is the **top** of the sprite, so for 32×32 tiles and 32×32 icons the art started at the vertical center of the cell and extended about half a tile below the tile bounds.

## Changes
- **`region_map_component.dart`:** For `cellSize == iconSize`, center the icon vertically (`tileTop + (cellSize - iconSize) / 2`). For `cellSize < iconSize`, keep horizontal centering and bottom-align vertically so the footprint sits toward the lower part of the cell. Unchanged behavior for `cellSize > 32` (bottom-left).
- **`SPEC/ui/map-widget.md`:** Clarify positioning for exactly 32px vs smaller tiles to match implementation.

## Testing
- `flutter test app/test/ct_region_map_test.dart`

Made with [Cursor](https://cursor.com)