### PR TITLE
feat(ui): resource icons beside names in province overlay

### DIFF
--- a/SPEC/ui/pixel-art-ui-catalog.md
+++ b/SPEC/ui/pixel-art-ui-catalog.md
@@ -37,6 +37,13 @@ Any new UI component must either:
 
 ---
 
+## Commodity / resource labels
+
+- Whenever the UI shows a **resource or commodity** by id or human-readable name (lists, province overlay, production, tooltips, etc.), show the **pixel commodity icon** (`ResourceIcon` / `ResourceLabelInline` in app widgets) **immediately to the left** of the text, with a small gap (e.g. 4 logical px). If no icon asset exists for that id, keep the reserved icon width (empty box) so layout stays aligned.
+- Do not show resource/commodity names as plain text-only rows in new shell UI unless the spec explicitly exempts that surface.
+
+---
+
 ## References
 
 - [buttons-nine-patch.md](buttons-nine-patch.md)

--- a/SPEC/ui/province-sea-zone-detail-overlay.md
+++ b/SPEC/ui/province-sea-zone-detail-overlay.md
@@ -65,13 +65,13 @@ Non-Material, pixel-art friendly: `CtPanel`, `CtTabStrip`, explicit text styles 
 
 ## Province overlay content
 
-**Tile:** From **`selectedTileKey`** only. Empty: “Click a tile to see details.” Else: coordinates, terrain, resource (— if none), **Prospected** (prospectable & not prospected → no; not prospectable → —), improvement, roads/rail, **civilian count** (fog-aware: same rules as Civilian — `foreignCivilianVisibleToPlayer`; enemy Spies never). `???` when `CellViewData.visibility` is unrevealed or province is fully unrevealed.
+**Tile:** From **`selectedTileKey`** only. Empty: “Click a tile to see details.” Else: coordinates, terrain, **resource** with **commodity icon beside the visible id/name** (— if none; same rule as [pixel-art-ui-catalog.md](pixel-art-ui-catalog.md) commodity labels), **Prospected** (prospectable & not prospected → no; not prospectable → —), improvement, roads/rail, **civilian count** (fog-aware: same rules as Civilian — `foreignCivilianVisibleToPlayer`; enemy Spies never). `???` when `CellViewData.visibility` is unrevealed or province is fully unrevealed.
 
 **Military:** In-province military units (`Unit.locationProvinceId`); group by **owner**, then **type counts** per owner.
 
 **Civilian:** Own units — full lines (type, id, status). Other players — only if `foreignCivilianVisibleToPlayer` allows (tile visibility ≠ unknown; not enemy Spy).
 
-**Political / Economic / Naval:** Owner, resources, prospects, improvements, fleets in port (see game specs). List hover → **`secondaryHighlightTileKey`** via callback (no overlay↔map import).
+**Political / Economic / Naval:** Owner, **province resources** listed with **icon + id** per commodity label rule (see [pixel-art-ui-catalog.md](pixel-art-ui-catalog.md)), prospects, improvements, fleets in port (see game specs). List hover → **`secondaryHighlightTileKey`** via callback (no overlay↔map import).
 
 **Sea zone:** Political + Naval (fleets in zone).
 

--- a/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
+++ b/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
@@ -13,6 +13,7 @@ import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_app/widgets/ct_panel.dart';
 import 'package:colonizethis_app/widgets/ct_tab_strip.dart';
+import 'package:colonizethis_app/widgets/resource_icon.dart';
 import 'package:flutter/material.dart';
 
 /// Overlay showing province or sea zone details. Toggleable; responsive; max 1/3 screen.
@@ -495,7 +496,16 @@ Widget _buildTileSection({
     children: [
       Text('Coordinates: ($x, $y)'),
       Text('Terrain: $terrainStr'),
-      Text('Resource: $resourceLabel'),
+      Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          const Text('Resource: '),
+          if (resourceVisible != null)
+            ResourceLabelInline(commodityId: resourceVisible)
+          else
+            Text(resourceLabel),
+        ],
+      ),
       Text('Prospected: $prospectedLabel'),
       Text('Improvement: $improvementLine'),
       Text('Road / railroad: $roadLabel'),
@@ -608,11 +618,30 @@ Widget _buildEconomicSection({
   required RegionMapViewData region,
   void Function(String?)? onHighlightTile,
 }) {
+  final sortedResourceIds = [...resources]..sort();
   return _buildSection('Economic', Column(
     crossAxisAlignment: CrossAxisAlignment.start,
     mainAxisSize: MainAxisSize.min,
     children: [
-      Text('Resources: ${resources.isEmpty ? "—" : resources.join(", ")}'),
+      Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('Resources: '),
+          Expanded(
+            child: sortedResourceIds.isEmpty
+                ? const Text('—')
+                : Wrap(
+                    spacing: 8,
+                    runSpacing: 4,
+                    children: sortedResourceIds
+                        .map(
+                          (id) => ResourceLabelInline(commodityId: id),
+                        )
+                        .toList(),
+                  ),
+          ),
+        ],
+      ),
       Text('Tiles to prospect: ${tilesToProspect.length}'),
       if (tilesToProspect.isNotEmpty)
         Wrap(

--- a/app/lib/widgets/resource_icon.dart
+++ b/app/lib/widgets/resource_icon.dart
@@ -61,6 +61,34 @@ class ResourceIcon extends StatelessWidget {
   }
 }
 
+/// Pixel [ResourceIcon] immediately before the visible resource/commodity label.
+/// Use for any UI line or chip that names a resource id (see SPEC/ui/pixel-art-ui-catalog.md).
+class ResourceLabelInline extends StatelessWidget {
+  const ResourceLabelInline({
+    super.key,
+    required this.commodityId,
+    this.label,
+    this.iconSize = 16,
+  });
+
+  final String commodityId;
+  final String? label;
+  final double iconSize;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        ResourceIcon(commodityId: commodityId, size: iconSize),
+        const SizedBox(width: 4),
+        Text(label ?? commodityId),
+      ],
+    );
+  }
+}
+
 class WorkerIcon extends StatelessWidget {
   const WorkerIcon({super.key, required this.workerType, this.size = 16});
 

--- a/app/test/production_panel_test.dart
+++ b/app/test/production_panel_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:colonizethis_app/features/game/widgets/production_panel.dart';
 import 'package:colonizethis_app/widgets/ct_slider.dart';
 import 'package:colonizethis_app/widgets/resource_icon.dart';
+import 'package:colonizethis_app/widgets/strict_asset_icon.dart';
 import 'package:colonizethis_app/features/game/widgets/production_panel_demo_data.dart';
 import 'package:colonizethis_app/features/game/widgets/province_overlay_demo_data.dart';
 
@@ -320,6 +321,39 @@ void main() {
       );
       await tester.pumpAndSettle();
 
+      expect(find.byType(ResourceIcon), findsOneWidget);
+    });
+
+    testWidgets('ResourceLabelInline shows icon and label text', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ResourceLabelInline(commodityId: 'grain', label: 'grain'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(StrictAssetIcon), findsOneWidget);
+      expect(find.text('grain'), findsOneWidget);
+    });
+
+    testWidgets('ResourceLabelInline reserves space when commodity has no icon asset', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ResourceLabelInline(commodityId: 'no_ui_icon_commodity'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(StrictAssetIcon), findsNothing);
+      expect(find.text('no_ui_icon_commodity'), findsOneWidget);
       expect(find.byType(ResourceIcon), findsOneWidget);
     });
   });

--- a/app/test/province_sea_zone_resource_labels_test.dart
+++ b/app/test/province_sea_zone_resource_labels_test.dart
@@ -1,0 +1,308 @@
+// Widget tests for resource icon + label in province overlay (Tile + Economic).
+// SPEC/ui/province-sea-zone-detail-overlay.md, SPEC/ui/pixel-art-ui-catalog.md.
+
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show PlayerView, VisibilityLevel;
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/features/game/widgets/province_sea_zone_detail_overlay.dart';
+import 'package:colonizethis_app/widgets/resource_icon.dart';
+import 'package:colonizethis_app/widgets/strict_asset_icon.dart';
+
+const _regionId = 'oldWorld';
+const _localProvinceId = 'pResTest';
+String get _fullProvinceId => '$_regionId|$_localProvinceId';
+
+String _tileKey(int x, int y) => '$_fullProvinceId|$x|$y';
+
+RegionMapViewData _regionWithCells(List<CellViewData> cells, int w, int h) {
+  return RegionMapViewData(
+    regionId: _regionId,
+    width: w,
+    height: h,
+    cellSize: 32,
+    cells: cells,
+    capitalMarkers: const [],
+    portMarkers: const [],
+    factionColors: const {},
+    terrainColors: const {},
+  );
+}
+
+Game _minimalGame({
+  required Map<String, List<String>> tileKeysByProvince,
+  Map<String, String> resourceByTileKey = const {},
+  Map<String, Map<String, String>> playerVisibilityByTile = const {},
+}) {
+  return Game(
+    id: 'res_label_test',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+      oldWorld: RegionData(
+        provinces: [
+          Province(
+            id: _fullProvinceId,
+            regionId: _regionId,
+            displayName: 'ResTest',
+          ),
+        ],
+      ),
+      newWorld: const RegionData(),
+      tileKeysByRegionAndProvince: {_regionId: tileKeysByProvince},
+      resourceByTileKey: resourceByTileKey,
+      playerVisibilityByTile: playerVisibilityByTile,
+    ),
+    players: const [
+      Player(id: 'gp1', displayName: 'Human', isHuman: true, treasury: 0),
+    ],
+  );
+}
+
+PlayerView _omniscientViewForTiles(Iterable<String> keys) {
+  return PlayerView(
+    playerId: 'gp1',
+    player: const Player(
+      id: 'gp1',
+      displayName: 'Human',
+      isHuman: true,
+      treasury: 0,
+    ),
+    ownUnitsById: const {},
+    provincesById: const {},
+    visibilityByTile: {for (final k in keys) k: VisibilityLevel.fullyVisible},
+    prospectedTiles: const {},
+    diplomacyByOtherId: const {},
+  );
+}
+
+void main() {
+  suppressLogsForTests();
+
+  group('ProvinceSeaZoneDetailOverlay resource labels', () {
+    testWidgets(
+      'Tile and Economic show ResourceLabelInline when grain is visible',
+      (WidgetTester tester) async {
+        final tk = _tileKey(0, 0);
+        final game = _minimalGame(
+          tileKeysByProvince: {
+            _fullProvinceId: [tk],
+          },
+          resourceByTileKey: {tk: 'grain'},
+          playerVisibilityByTile: {
+            'gp1': {tk: 'fullyVisible'},
+          },
+        );
+        final region = _regionWithCells(
+          [
+            const CellViewData(
+              x: 0,
+              y: 0,
+              regionCellId: _localProvinceId,
+              isSea: false,
+              terrainTypeId: 'plains',
+              resourceId: 'grain',
+              visibility: TileVisibility.visible,
+            ),
+          ],
+          1,
+          1,
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 800,
+                child: ProvinceSeaZoneDetailOverlay(
+                  game: game,
+                  region: region,
+                  displayId: _fullProvinceId,
+                  selectedTileKey: tk,
+                  humanPlayerId: 'gp1',
+                  playerView: _omniscientViewForTiles([tk]),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('grain'), findsNWidgets(2));
+        expect(find.byType(ResourceLabelInline), findsNWidgets(2));
+        expect(find.byType(StrictAssetIcon), findsNWidgets(2));
+      },
+    );
+
+    testWidgets('Tile shows plain em dash when tile has no visible resource', (
+      WidgetTester tester,
+    ) async {
+      final tk = _tileKey(0, 0);
+      final game = _minimalGame(
+        tileKeysByProvince: {
+          _fullProvinceId: [tk],
+        },
+        resourceByTileKey: const {},
+        playerVisibilityByTile: {
+          'gp1': {tk: 'fullyVisible'},
+        },
+      );
+      final region = _regionWithCells(
+        [
+          const CellViewData(
+            x: 0,
+            y: 0,
+            regionCellId: _localProvinceId,
+            isSea: false,
+            terrainTypeId: 'plains',
+            visibility: TileVisibility.visible,
+          ),
+        ],
+        1,
+        1,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              child: ProvinceSeaZoneDetailOverlay(
+                game: game,
+                region: region,
+                displayId: _fullProvinceId,
+                selectedTileKey: tk,
+                humanPlayerId: 'gp1',
+                playerView: _omniscientViewForTiles([tk]),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ResourceLabelInline), findsNothing);
+      expect(find.textContaining('Resource:'), findsWidgets);
+    });
+
+    testWidgets(
+      'Prospect-required resource hidden until prospected (no ResourceLabelInline)',
+      (WidgetTester tester) async {
+        final tk = _tileKey(0, 0);
+        final game = _minimalGame(
+          tileKeysByProvince: {
+            _fullProvinceId: [tk],
+          },
+          resourceByTileKey: {tk: 'iron'},
+          playerVisibilityByTile: {
+            'gp1': {tk: 'fullyVisible'},
+          },
+        );
+        final region = _regionWithCells(
+          [
+            const CellViewData(
+              x: 0,
+              y: 0,
+              regionCellId: _localProvinceId,
+              isSea: false,
+              terrainTypeId: 'hills',
+              resourceId: 'iron',
+              visibility: TileVisibility.visible,
+            ),
+          ],
+          1,
+          1,
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 800,
+                child: ProvinceSeaZoneDetailOverlay(
+                  game: game,
+                  region: region,
+                  displayId: _fullProvinceId,
+                  selectedTileKey: tk,
+                  humanPlayerId: 'gp1',
+                  playerView: _omniscientViewForTiles([tk]),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(ResourceLabelInline), findsNothing);
+        expect(find.text('iron'), findsNothing);
+      },
+    );
+
+    testWidgets('Economic lists two province resources with icons (sorted)', (
+      WidgetTester tester,
+    ) async {
+      final tk0 = _tileKey(0, 0);
+      final tk1 = _tileKey(1, 0);
+      final game = _minimalGame(
+        tileKeysByProvince: {
+          _fullProvinceId: [tk0, tk1],
+        },
+        resourceByTileKey: {tk0: 'timber', tk1: 'grain'},
+        playerVisibilityByTile: {
+          'gp1': {tk0: 'fullyVisible', tk1: 'fullyVisible'},
+        },
+      );
+      final region = _regionWithCells(
+        [
+          const CellViewData(
+            x: 0,
+            y: 0,
+            regionCellId: _localProvinceId,
+            isSea: false,
+            terrainTypeId: 'forest',
+            resourceId: 'timber',
+            visibility: TileVisibility.visible,
+          ),
+          const CellViewData(
+            x: 1,
+            y: 0,
+            regionCellId: _localProvinceId,
+            isSea: false,
+            terrainTypeId: 'plains',
+            resourceId: 'grain',
+            visibility: TileVisibility.visible,
+          ),
+        ],
+        2,
+        1,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              child: ProvinceSeaZoneDetailOverlay(
+                game: game,
+                region: region,
+                displayId: _fullProvinceId,
+                selectedTileKey: tk0,
+                humanPlayerId: 'gp1',
+                playerView: _omniscientViewForTiles([tk0, tk1]),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('grain'), findsOneWidget);
+      expect(find.text('timber'), findsNWidgets(2));
+      expect(find.byType(ResourceLabelInline), findsNWidgets(3));
+      expect(find.byType(StrictAssetIcon), findsNWidgets(3));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Show `ResourceLabelInline` (pixel icon + id) in the province panel **Tile** row when a resource is visible, and in **Economic** as a sorted wrap of labeled chips.
- Add reusable `ResourceLabelInline` next to `ResourceIcon` in `app/lib/widgets/resource_icon.dart`.
- SPEC: commodity/resource label rule in `SPEC/ui/pixel-art-ui-catalog.md`; overlay details in `SPEC/ui/province-sea-zone-detail-overlay.md`.

## Tests
- `app/test/province_sea_zone_resource_labels_test.dart`: minimal `Game` + `RegionMapViewData` fixtures for visible grain, no resource, hidden prospect ore, and two-tile province.
- `app/test/production_panel_test.dart`: `ResourceLabelInline` with unknown commodity id (reserved space, no `StrictAssetIcon`).

## How to verify
```bash
cd app && flutter test test/province_sea_zone_resource_labels_test.dart test/production_panel_test.dart --name ResourceLabelInline
```

Made with [Cursor](https://cursor.com)