### PR TITLE
fix(prospecting): make tile prospectability terrain-defined and shared

### DIFF
--- a/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
+++ b/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
@@ -5,6 +5,8 @@ import 'package:colonizethis_logic/colonizethis_logic.dart'
     show
         fleetsInPortAtProvince,
         foreignCivilianVisibleToPlayer,
+        isProspectableTerrain,
+        isProspectableTerrainId,
         kProspectRequiredResourceIds,
         PlayerView,
         resourceIdVisibleInPlayerView,
@@ -468,8 +470,9 @@ Widget _buildTileSection({
   final resourceVisible =
       resourceIdVisibleInPlayerView(playerView, selectedTileKey, resourceRaw);
   final resourceLabel = resourceVisible ?? '—';
-  final prospectable = resourceRaw != null &&
-      kProspectRequiredResourceIds.contains(resourceRaw);
+  final prospectable = cell.terrainType != null
+      ? isProspectableTerrain(cell.terrainType!)
+      : isProspectableTerrainId(cell.terrainTypeId);
   final prospectedLabel =
       !prospectable ? '—' : (prospected.contains(selectedTileKey) ? 'yes' : 'no');
   final impLevel = tileState.improvementLevel(selectedTileKey);

--- a/packages/colonizethis_logic/lib/src/constants.dart
+++ b/packages/colonizethis_logic/lib/src/constants.dart
@@ -1,5 +1,6 @@
 /// Shared constants and helpers for the colonizethis_logic package.
 
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 const String kRegionOldWorld = 'oldWorld';
@@ -17,6 +18,40 @@ const Set<String> kMineralResourceIds = {
   'gems',
   'diamonds',
 };
+
+/// Per-terrain prospectability, derived from resource terrain rules:
+/// any terrain that can host at least one mineral resource is prospectable.
+final Map<TerrainType, bool> kProspectableByTerrainType = {
+  for (final terrain in TerrainType.values)
+    terrain: _buildProspectableTerrainsFromRules().contains(terrain),
+};
+
+Set<TerrainType> _buildProspectableTerrainsFromRules() {
+  final rules = ResourceRules.defaultRules;
+  final terrains = <TerrainType>{};
+  for (final resource in Resource.values) {
+    if (!kMineralResourceIds.contains(resource.name)) {
+      continue;
+    }
+    terrains.addAll(rules.allowedTerrains[resource] ?? const <TerrainType>[]);
+  }
+  return terrains;
+}
+
+bool isProspectableTerrain(TerrainType terrain) =>
+    kProspectableByTerrainType[terrain] ?? false;
+
+bool isProspectableTerrainId(String? terrainTypeId) {
+  if (terrainTypeId == null || terrainTypeId.isEmpty) {
+    return false;
+  }
+  for (final terrain in TerrainType.values) {
+    if (terrain.name == terrainTypeId) {
+      return isProspectableTerrain(terrain);
+    }
+  }
+  return false;
+}
 
 /// Safe player lookup by id. Returns null if not found.
 extension GamePlayerLookup on Game {

--- a/packages/colonizethis_logic/lib/src/orders/orders_application_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_helpers.dart
@@ -13,13 +13,6 @@ bool isMineralEligibleTile(
   Map<String, TileMapResult>? tileMapByRegion,
   String tileKey,
 ) {
-  const mineralTerrains = {
-    TerrainType.swamp,
-    TerrainType.hills,
-    TerrainType.mountain,
-    TerrainType.desert,
-  };
-
   if (tileMapByRegion != null && tileMapByRegion.isNotEmpty) {
     final parts = tileKey.split('|');
     if (parts.length == 4) {
@@ -30,7 +23,7 @@ bool isMineralEligibleTile(
       if (tileMap != null && x != null && y != null) {
         final terrain = tileMap.terrainAt(x, y);
         if (terrain != null) {
-          return mineralTerrains.contains(terrain);
+          return isProspectableTerrain(terrain);
         }
       }
     }

--- a/packages/colonizethis_logic/test/orders_application_helpers_test.dart
+++ b/packages/colonizethis_logic/test/orders_application_helpers_test.dart
@@ -1,7 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/src/orders/orders_application_helpers.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 Game _gameWithResourceByTile(Map<String, String> resourceByTileKey) {
   return Game(

--- a/packages/colonizethis_logic/test/orders_application_helpers_test.dart
+++ b/packages/colonizethis_logic/test/orders_application_helpers_test.dart
@@ -1,0 +1,97 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/src/orders/orders_application_helpers.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:test/test.dart';
+
+Game _gameWithResourceByTile(Map<String, String> resourceByTileKey) {
+  return Game(
+    id: 'g-test',
+    players: const [
+      Player(id: 'p1', displayName: 'P1', isHuman: true),
+    ],
+    minorNations: const [],
+    tribes: const [],
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: const RegionData(),
+      newWorld: const RegionData(),
+      resourceByTileKey: resourceByTileKey,
+    ),
+  );
+}
+
+void main() {
+  group('isMineralEligibleTile with tile map terrain data', () {
+    test('returns true for prospectable terrain even when no resource is present', () {
+      final game = _gameWithResourceByTile(const {});
+      const tileKey = 'oldWorld|p1|0|0';
+      final tileMapByRegion = <String, TileMapResult>{
+        'oldWorld': TileMapResult(
+          width: 1,
+          height: 1,
+          grid: const [
+            ['p1'],
+          ],
+          terrainGrid: const [
+            [TerrainType.mountain],
+          ],
+          resourceGrid: const [
+            [null],
+          ],
+        ),
+      };
+
+      final result = isMineralEligibleTile(game, tileMapByRegion, tileKey);
+      expect(result, isTrue);
+    });
+
+    test('returns false for non-prospectable terrain even when mineral resource exists', () {
+      final game = _gameWithResourceByTile(const {'oldWorld|p1|0|0': 'gold'});
+      const tileKey = 'oldWorld|p1|0|0';
+      final tileMapByRegion = <String, TileMapResult>{
+        'oldWorld': TileMapResult(
+          width: 1,
+          height: 1,
+          grid: const [
+            ['p1'],
+          ],
+          terrainGrid: const [
+            [TerrainType.plains],
+          ],
+          resourceGrid: const [
+            [Resource.gold],
+          ],
+        ),
+      };
+
+      final result = isMineralEligibleTile(game, tileMapByRegion, tileKey);
+      expect(result, isFalse);
+    });
+  });
+
+  group('isMineralEligibleTile fallback with resource presence/absence', () {
+    test('returns false when resource is absent', () {
+      final game = _gameWithResourceByTile(const {});
+      const tileKey = 'oldWorld|p1|0|0';
+
+      final result = isMineralEligibleTile(game, null, tileKey);
+      expect(result, isFalse);
+    });
+
+    test('returns false for non-mineral resource', () {
+      final game = _gameWithResourceByTile(const {'oldWorld|p1|0|0': 'grain'});
+      const tileKey = 'oldWorld|p1|0|0';
+
+      final result = isMineralEligibleTile(game, null, tileKey);
+      expect(result, isFalse);
+    });
+
+    test('returns true for mineral resource', () {
+      final game = _gameWithResourceByTile(const {'oldWorld|p1|0|0': 'coal'});
+      const tileKey = 'oldWorld|p1|0|0';
+
+      final result = isMineralEligibleTile(game, null, tileKey);
+      expect(result, isTrue);
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/prospectable_terrain_test.dart
+++ b/packages/colonizethis_logic/test/prospectable_terrain_test.dart
@@ -1,0 +1,20 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('terrain prospectability classification', () {
+    test('defines prospectability for every terrain type', () {
+      expect(kProspectableByTerrainType.keys.toSet(), TerrainType.values.toSet());
+    });
+
+    test('matches canonical mineral prospecting terrain rules', () {
+      expect(kProspectableByTerrainType[TerrainType.plains], isFalse);
+      expect(kProspectableByTerrainType[TerrainType.forest], isFalse);
+      expect(kProspectableByTerrainType[TerrainType.hills], isTrue);
+      expect(kProspectableByTerrainType[TerrainType.mountain], isTrue);
+      expect(kProspectableByTerrainType[TerrainType.swamp], isTrue);
+      expect(kProspectableByTerrainType[TerrainType.desert], isTrue);
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/prospectable_terrain_test.dart
+++ b/packages/colonizethis_logic/test/prospectable_terrain_test.dart
@@ -1,6 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 void main() {
   group('terrain prospectability classification', () {


### PR DESCRIPTION
## Summary
- Replace ad-hoc prospectable terrain checks with shared helpers derived from canonical resource rules (`ResourceRules.defaultRules`) and mineral resource ids.
- Update tile detail overlay and order application helper to use the same terrain prospectability logic, so `Prospected` behavior is consistent.
- Add focused tests for (1) full terrain classification and (2) terrain/resource presence-absence behavior in mineral eligibility.

## Test plan
- [x] `dart test test/prospectable_terrain_test.dart` (from `packages/colonizethis_logic`)
- [x] `dart test test/orders_application_helpers_test.dart` (from `packages/colonizethis_logic`)

Made with [Cursor](https://cursor.com)