### PR TITLE
feat(ui): confirm Android back exit to main menu

### DIFF
--- a/SPEC/program/app-ui-wiring.md
+++ b/SPEC/program/app-ui-wiring.md
@@ -62,7 +62,7 @@ Register builders in **`app/lib/core/services/app_event_handler_scope.dart`**.
 | `quick_battle_result` | `QuickBattleResultDialog` | planned (or local if combat UI stays internal) |
 | `combat_mode_choice` | `CombatModeChoiceDialog` | same |
 
-**Local by design (no `OpenDialogEvent`):** map display options (`GameMapArea`), tech detail (`TechTreeWidget`), split fleet (`NavalUnitsPanel`), civilian work-target sheet (`CivilianUnitsPanel`), next-turn confirmation (`GameMapArea`), research tech picker (`TechnologyPanel`), **`CtDropdown`** internal picker, **new-game setup progress and error dialogs** after leader confirmation (see **SPEC/ui/game-initializing.md**).
+**Local by design (no `OpenDialogEvent`):** map display options (`GameMapArea`), tech detail (`TechTreeWidget`), split fleet (`NavalUnitsPanel`), civilian work-target sheet (`CivilianUnitsPanel`), next-turn confirmation (`GameMapArea`), in-game Android back exit confirmation (`GameScreen`), research tech picker (`TechnologyPanel`), **`CtDropdown`** internal picker, **new-game setup progress and error dialogs** after leader confirmation (see **SPEC/ui/game-initializing.md**).
 
 ---
 

--- a/SPEC/ui/in-game-shell-narrow.md
+++ b/SPEC/ui/in-game-shell-narrow.md
@@ -42,6 +42,22 @@ The top bar shows:
 
 ---
 
+## Android back confirm (exit to main menu)
+
+- **Scope:** Applies in any state where pressing Android system back from the in-game shell would leave the current game screen.
+- **Interception:** The in-game shell traps Android back before route pop, then decides whether to present confirmation.
+- **Dialog:** The app shows a pixel-art confirmation dialog using **CtDialogShell** and **CtNinePatchButton** (no Material `AlertDialog` / Material action buttons).
+- **Text:**
+  - Title: `Exit game?`
+  - Body: `Your current progress will be lost if not saved.`
+  - Actions: `Cancel` and `Exit`
+- **Actions:**
+  - `Cancel` dismisses the dialog and keeps the player on the in-game shell.
+  - `Exit` navigates to the main menu (`Routes.shell`), ending the in-game shell route.
+- **Dismissal:** Tapping outside the dialog (barrier area) dismisses the dialog and keeps the player in-game.
+
+---
+
 ## Province/sea zone detail overlay
 
 - **Wide viewport (≥ 600 dp):** Province detail appears as a side panel (width 320 dp) to the right of the map.
@@ -92,6 +108,10 @@ Side menu (when open, overlaid from left):
 - **Given** the side menu is **open**, **when** the user performs a keyboard action that would normally affect the map (e.g. map hotkeys), **then** the map does not react while the menu is open.
 - **Given** the side menu is **open**, **when** the user taps or clicks outside the menu (on the dimmed background), **then** the side menu closes and that tap/click is **not** forwarded to the map (no province selection or camera movement is triggered).
 - **Given** the side menu is **open**, **when** the user presses **Escape** (or the platform back key where applicable), **then** the side menu closes and focus/input returns to the in-game shell.
+- **Given** the in-game shell is visible and Android back would leave the game screen, **when** the user presses Android back, **then** the UI layer shows a pixel-art confirmation dialog with title `Exit game?`, body `Your current progress will be lost if not saved.`, and actions `Cancel` and `Exit`.
+- **Given** the exit confirmation dialog is visible, **when** the user taps `Cancel`, **then** the UI layer dismisses the dialog and remains on the in-game shell.
+- **Given** the exit confirmation dialog is visible, **when** the user taps outside the dialog, **then** the UI layer dismisses the dialog and remains on the in-game shell.
+- **Given** the exit confirmation dialog is visible, **when** the user taps `Exit`, **then** the UI layer navigates to the main menu route (`Routes.shell`).
 
 ---
 

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -12,6 +12,7 @@ import '../../../../providers/app_event_bus_provider.dart';
 import '../../../../providers/game_service_provider.dart';
 import '../../../../providers/games_provider.dart';
 import '../../../../providers/map_view_provider.dart';
+import '../../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/ct_screen_shell.dart';
 import '../../../widgets/game_to_ui_bus_listener.dart';
@@ -34,6 +35,60 @@ void _showPauseMenu(AppEventBus bus) {
       onResume: () => bus.emit(const ClosePanelEvent()),
     ),
   );
+}
+
+Future<bool> _showExitToMainMenuConfirmDialog(BuildContext context) async {
+  final l10n = appL10n(context);
+  final shouldExit = await showDialog<bool>(
+    context: context,
+    barrierDismissible: true,
+    useRootNavigator: true,
+    builder: (ctx) => CtDialogShell(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            l10n.game_exitConfirm_title,
+            style: Theme.of(ctx).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          Text(l10n.game_exitConfirm_body),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              CtNinePatchButton(
+                onPressed: () => Navigator.of(ctx).pop(false),
+                child: Text(l10n.common_cancel),
+              ),
+              const SizedBox(width: 8),
+              CtNinePatchButton(
+                onPressed: () => Navigator.of(ctx).pop(true),
+                child: Text(l10n.game_exitConfirm_exit),
+              ),
+            ],
+          ),
+        ],
+      ),
+    ),
+  );
+  return shouldExit ?? false;
+}
+
+void _navigateToMainMenu(BuildContext context) {
+  var foundShellRoute = false;
+  final navigator = Navigator.of(context);
+  navigator.popUntil((route) {
+    final matches = route.settings.name == Routes.shell;
+    if (matches) {
+      foundShellRoute = true;
+    }
+    return matches;
+  });
+  if (!foundShellRoute) {
+    navigator.pushNamedAndRemoveUntil(Routes.shell, (route) => false);
+  }
 }
 
 /// Hosts the Flame game canvas or map. When map data exists, shows map + province/sea zone overlay.
@@ -145,9 +200,18 @@ class GameScreen extends ConsumerWidget {
       );
     }
 
-    return CtScreenShell(
-      title: appL10n(context).game_screenTitle,
-      child: content,
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (didPop || !context.mounted) return;
+        final shouldExit = await _showExitToMainMenuConfirmDialog(context);
+        if (!shouldExit || !context.mounted) return;
+        _navigateToMainMenu(context);
+      },
+      child: CtScreenShell(
+        title: appL10n(context).game_screenTitle,
+        child: content,
+      ),
     );
   }
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -71,6 +71,21 @@
     "description": "Title used for the main game screen shell."
   },
 
+  "game_exitConfirm_title": "Exit game?",
+  "@game_exitConfirm_title": {
+    "description": "Title of the dialog asking for confirmation before leaving the in-game shell."
+  },
+
+  "game_exitConfirm_body": "Your current progress will be lost if not saved.",
+  "@game_exitConfirm_body": {
+    "description": "Body text warning the player before exiting to main menu from in-game shell."
+  },
+
+  "game_exitConfirm_exit": "Exit",
+  "@game_exitConfirm_exit": {
+    "description": "Button label that confirms leaving the in-game shell and navigating to main menu."
+  },
+
   "game_nextTurnButton": "Next turn ({turn} / {year})",
   "@game_nextTurnButton": {
     "description": "Label for the Next Turn button showing current turn and year.",

--- a/app/test/game_screen_narrow_test.dart
+++ b/app/test/game_screen_narrow_test.dart
@@ -9,6 +9,7 @@ import 'package:colonizethis_app/features/game/flame/game_screen.dart';
 import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/providers/map_view_provider.dart';
+import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -48,6 +49,42 @@ void main() {
             data: MediaQueryData(size: Size(width, height)),
             child: const GameScreen(),
           ),
+        ),
+      ),
+    );
+  }
+
+  Widget buildShellToGameFlow({
+    required double width,
+    required double height,
+    TargetPlatform platform = TargetPlatform.android,
+  }) {
+    return ProviderScope(
+      overrides: [
+        currentGameProvider.overrideWith((ref) => debugResult.game),
+        mapViewDataProvider.overrideWith((ref) => debugResult.mapViewData),
+        gameIdsWithIntroShownProvider.overrideWith(
+          (ref) => {debugResult.game.id},
+        ),
+        appEventBusProvider.overrideWith((ref) {
+          final bus = AppEventBus.create();
+          ref.onDispose(bus.dispose);
+          return bus;
+        }),
+      ],
+      child: AppEventHandlerScope(
+        child: MaterialApp(
+          navigatorKey: appNavigatorKey,
+          theme: AppThemes.colonial.copyWith(platform: platform),
+          routes: {
+            Routes.shell: (_) =>
+                const Scaffold(body: Center(child: Text('Main Menu'))),
+            Routes.game: (_) => MediaQuery(
+              data: MediaQueryData(size: Size(width, height)),
+              child: const GameScreen(),
+            ),
+          },
+          initialRoute: Routes.game,
         ),
       ),
     );
@@ -195,8 +232,9 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 100));
 
-        final switchTile =
-            tester.widget<SwitchListTile>(showProvinceOverlayFinder);
+        final switchTile = tester.widget<SwitchListTile>(
+          showProvinceOverlayFinder,
+        );
         expect(switchTile.value, isFalse);
       },
       timeout: const Timeout(Duration(seconds: 20)),
@@ -405,6 +443,111 @@ void main() {
         // Overlay should be gone but we should still be on the Game screen shell.
         expect(find.textContaining('victory'), findsNothing);
         expect(find.byType(GameScreen), findsOneWidget);
+      },
+      timeout: const Timeout(Duration(seconds: 20)),
+    );
+  });
+
+  group('GameScreen — Android back exit confirmation', () {
+    testWidgets(
+      'AC: pressing back shows pixel-style confirm dialog',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildShellToGameFlow(width: 800, height: 600));
+        await tester.pump();
+
+        await tester.binding.handlePopRoute();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+
+        expect(find.byType(CtDialogShell), findsOneWidget);
+        expect(find.text('Exit game?'), findsOneWidget);
+        expect(
+          find.text('Your current progress will be lost if not saved.'),
+          findsOneWidget,
+        );
+        expect(find.text('Cancel'), findsOneWidget);
+        expect(find.text('Exit'), findsOneWidget);
+      },
+      timeout: const Timeout(Duration(seconds: 20)),
+    );
+
+    testWidgets(
+      'AC: tapping Cancel dismisses dialog and stays on game',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildShellToGameFlow(width: 800, height: 600));
+        await tester.pump();
+
+        await tester.binding.handlePopRoute();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+        await tester.tap(find.text('Cancel'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+
+        expect(find.byType(CtDialogShell), findsNothing);
+        expect(find.byType(GameScreen), findsOneWidget);
+        expect(find.text('Main Menu'), findsNothing);
+      },
+      timeout: const Timeout(Duration(seconds: 20)),
+    );
+
+    testWidgets(
+      'AC: tapping outside dialog dismisses and stays on game',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildShellToGameFlow(width: 800, height: 600));
+        await tester.pump();
+
+        await tester.binding.handlePopRoute();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+        await tester.tapAt(const Offset(4, 4));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+
+        expect(find.byType(CtDialogShell), findsNothing);
+        expect(find.byType(GameScreen), findsOneWidget);
+      },
+      timeout: const Timeout(Duration(seconds: 20)),
+    );
+
+    testWidgets(
+      'AC: tapping Exit navigates to main menu route',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildShellToGameFlow(width: 800, height: 600));
+        await tester.pump();
+
+        await tester.binding.handlePopRoute();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+        await tester.tap(find.text('Exit'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+
+        expect(find.text('Main Menu'), findsOneWidget);
+      },
+      timeout: const Timeout(Duration(seconds: 20)),
+    );
+
+    testWidgets(
+      'AC: Android back (platform-configured) shows exit confirm before leaving game',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          buildShellToGameFlow(
+            width: 800,
+            height: 600,
+            platform: TargetPlatform.android,
+          ),
+        );
+        await tester.pump();
+
+        await tester.binding.handlePopRoute();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+
+        expect(find.byType(CtDialogShell), findsOneWidget);
+        expect(find.text('Exit game?'), findsOneWidget);
+        expect(find.text('Cancel'), findsOneWidget);
+        expect(find.text('Exit'), findsOneWidget);
       },
       timeout: const Timeout(Duration(seconds: 20)),
     );


### PR DESCRIPTION
## Summary
- add SPEC coverage for Android back interception in the in-game shell, including pixel-art dialog requirements and Given-When-Then acceptance criteria
- intercept in-game back with `PopScope` and show a `CtDialogShell` + `CtNinePatchButton` confirm dialog (`Cancel`/`Exit`) before leaving
- route confirmed exit to `Routes.shell` and add widget tests for back-confirm behavior (cancel, outside-tap dismiss, exit, and Android-configured back)

## Test plan
- [x] `flutter test test/game_screen_narrow_test.dart` (from `app/`)

Made with [Cursor](https://cursor.com)