### PR TITLE
fix(naval): align combat formulas and add naval behavior scenarios

### DIFF
--- a/SPEC/game/ships-and-naval.md
+++ b/SPEC/game/ships-and-naval.md
@@ -134,14 +134,19 @@ speedAdvantage = (ownAvgMV - enemyAvgMV) × 0.1 # +/- 0.2 typical
 enemyAggression = 0.1 if enemyMission == Patrol else 0.2 # Blockade harder to escape
 ```
 
+`existsFriendlyOrNeutralAdjacentZone()` means there is an adjacent sea zone with no hostile fleet present for the retreating side (hostility from diplomacy `atWar` relation).
+
 ## Naval Interception Probability
 
-Patrol vs blockade interception chances; how escorts reduce losses
+Patrol vs blockade interception chance:
 
-| Mission  | Base Intercept | Modifiers                                                     |
-| -------- | -------------- | ------------------------------------------------------------- |
-| Patrol   | 30%            | +10% if superior force, -10% if inferior                      |
-| Blockade | 50%            | +15% if superior force, target entering/leaving specific port |
+```
+fleetInterceptScore = Σ ship.interceptRating
+targetFleeScore = Σ ship.fleeRating
+ratio = fleetInterceptScore / (fleetInterceptScore + targetFleeScore)
+missionFactor = 0.5 for Patrol, 0.9 for Blockade
+interceptChance = clamp(missionFactor × ratio, 0.05, 0.85)
+```
 
 
 ---

--- a/SPEC/program/naval-combat-resolution.md
+++ b/SPEC/program/naval-combat-resolution.md
@@ -20,17 +20,21 @@ Detects naval conflicts per sea zone and auto-resolves fleet engagements, produc
 
 **Strength Aggregation (per side):**
 
-1. Compute firepower score from FRP and RNG (RNG weighted highest per [ships-and-naval.md](../game/ships-and-naval.md) § Naval Combat).
-2. Compute durability score from ARM and HULL.
-3. Apply medal multipliers and tech modifiers (leader bonuses from [leader-bonuses.md](../game/leader-bonuses.md) do not apply to naval combat).
-4. Aggregate into side-level `navalStrength`. Weights from config, tunable per ruleset.
+1. Compute per-ship strength as:
+   - `FRP * 1.0`
+   - `RNG * 0.4`
+   - `ARM * 0.15`
+   - `durability = HULL * (1 + ARM / 10)`
+   - `MV * 0.1`
+2. Sum all ship strengths into side-level `navalStrength`.
+3. Leader bonuses from [leader-bonuses.md](../game/leader-bonuses.md) do not apply to naval combat.
 
 **Per-Engagement Resolution:**
 
-1. Read `navalStrength` for both sides; apply mission modifiers per [ships-and-naval.md](../game/ships-and-naval.md) § Missions and Movement.
-2. Apply optional terrain-style modifiers (coastal vs open ocean).
-3. Compute casualties (ships sunk/damaged) and retreat attempts.
-4. Return: attacker victory, defender victory, stalemate, or mutual destruction — plus casualty ids and retreat flags.
+1. Read `navalStrength` for both sides.
+2. Compute casualties (ships sunk) from relative strength and deterministic seeded RNG.
+3. Compute retreat attempts using the retreat model below.
+4. Return one outcome enum (`side1Victory`, `side2Victory`, `stalemate`, `mutualDestruction`) and retreat flags.
 
 Handles both interception-triggered and end-of-movement battles.
 
@@ -38,13 +42,27 @@ Handles both interception-triggered and end-of-movement battles.
 
 Per [ships-and-naval.md](../game/ships-and-naval.md) § Naval Combat, retreat requires an adjacent friendly/neutral zone.
 
-1. `fleetFleeScore = Σ ship.fleeRating` (retreating side).
-2. `pursuerInterceptScore = Σ ship.interceptRating` (opposing side).
-3. `R = fleetFleeScore / (fleetFleeScore + pursuerInterceptScore)`.
-4. Aggression modifier: cautious ×1.1, normal ×1.0, aggressive ×0.8.
-5. `P_retreat = clamp(R × aggressionMod, 0.1, 0.95)`.
-6. Resolve with deterministic seeded RNG.
-7. Success → surviving ships relocate to neighbouring zone. Failure → additional losses before outcome.
+1. Determine if at least one adjacent sea zone is legal:
+   - Legal when no hostile fleet is present in that adjacent zone.
+   - Hostility uses diplomacy `atWar` relation with the retreating side.
+2. If no legal adjacent zone exists, retreat chance is not evaluated and retreat is disallowed.
+3. If a legal adjacent zone exists, compute:
+   - `baseChance = 0.6`
+   - `speedAdvantage = (ownAvgMV - enemyAvgMV) * 0.1`
+   - `enemyAggression = 0.1` when enemy mission is `patrol`, `0.2` when enemy mission is `blockade`, otherwise `0.0`
+   - `P_retreat = clamp(baseChance + speedAdvantage - enemyAggression, 0.1, 0.95)`
+4. Resolve with deterministic seeded RNG.
+5. Success relocates surviving ships to a legal adjacent zone.
+
+## Interception Model
+
+When one side moved into a contested sea zone and the opposing side is on `patrol` or `blockade`, interception probability is:
+
+1. `fleetInterceptScore = Σ ship.interceptRating` for interceptor ships.
+2. `targetFleeScore = Σ ship.fleeRating` for moving fleet ships.
+3. `ratio = fleetInterceptScore / (fleetInterceptScore + targetFleeScore)`.
+4. `missionFactor = 0.5` for Patrol, `0.9` for Blockade.
+5. `P_intercept = clamp(missionFactor * ratio, 0.05, 0.85)`.
 
 ## Integration
 
@@ -55,5 +73,31 @@ Per [ships-and-naval.md](../game/ships-and-naval.md) § Naval Combat, retreat re
 ## Constraints
 
 - Deterministic for a given seed.
-- All numeric weights and per-ship ratings from colonizethis_data, tunable per ruleset.
+- All per-ship ratings come from colonizethis_data.
 - Owned by colonizethis_logic.
+
+## Acceptance Criteria
+
+- Given side 1 has one `carrack` in a sea battle context  
+  When The System computes naval strength  
+  Then The System uses `FRP*1.0 + RNG*0.4 + ARM*0.15 + HULL*(1+ARM/10) + MV*0.1` for that ship and returns the exact summed value for the side.
+
+- Given an interceptor with intercept score `8`, a moving target with flee score `2`, and mission `blockade`  
+  When The System computes interception probability  
+  Then The System computes `ratio = 8/(8+2)`, applies mission factor `0.9`, and clamps the result to `[0.05, 0.85]`.
+
+- Given a battle sea zone has no adjacent legal sea zone for side 1 (all adjacent zones contain hostile fleets)  
+  When The System resolves retreat for side 1  
+  Then The System does not evaluate retreat probability and side 1 does not retreat.
+
+- Given side 1 survives naval combat and battle context mission for side 1 is `patrol`  
+  When The System applies naval battle results to world state  
+  Then The System recreates side 1 fleet with mission `patrol` instead of resetting to `none`.
+
+- Given a naval battle resolves with both sides still having at least one surviving ship  
+  When The System builds the battle result payload  
+  Then The System sets outcome to `stalemate`.
+
+- Given naval interception and combat phase runs for one turn  
+  When The System processes detected battles and resolved outcomes  
+  Then The System emits `logic:` debug logs with detected-battle count, post-interception count, battle outcome, and retreat flags.

--- a/SPEC/program/naval-movement-resolution.md
+++ b/SPEC/program/naval-movement-resolution.md
@@ -32,9 +32,8 @@ Only fleets **at sea** on Patrol or Blockade mission participate. For each such 
 2. `targetEvasionScore = Σ ship.fleeRating` (target fleet).
 3. `ratio = fleetInterceptScore / (fleetInterceptScore + targetEvasionScore)`.
 4. Mission factor: Patrol = 0.5, Blockade = 0.9.
-5. Apply tech/composition bonuses to `fleetInterceptScore` (e.g. +20% from privateering_companies).
-6. `P_intercept = clamp(missionFactor × ratio, 0.05, 0.85)`.
-7. On success, create a BattleContextSea and invoke [naval-combat-resolution.md](naval-combat-resolution.md).
+5. `P_intercept = clamp(missionFactor × ratio, 0.05, 0.85)`.
+6. On success, create a BattleContextSea and invoke [naval-combat-resolution.md](naval-combat-resolution.md).
 
 Exact numeric values in ruleset config; formula shape: mission factor × relative strength × tech/composition.
 

--- a/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
@@ -2,24 +2,16 @@
 // Interception and retreat: SPEC/game/ships-and-naval.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../world/naval.dart';
+final _log = logicLogger();
 
-/// Base interception chance for Patrol. SPEC/game/ships-and-naval.md.
-const double kNavalInterceptBasePatrol = 0.30;
+/// Mission factor for Patrol interception probability.
+const double kNavalInterceptMissionFactorPatrol = 0.50;
 
-/// Base interception chance for Blockade. SPEC/game/ships-and-naval.md.
-const double kNavalInterceptBaseBlockade = 0.50;
-
-/// Bonus when interceptor has superior force.
-const double kNavalInterceptSuperiorBonus = 0.10;
-
-/// Penalty when interceptor has inferior force.
-const double kNavalInterceptInferiorPenalty = 0.10;
-
-/// Blockade superior force bonus (higher than patrol).
-const double kNavalInterceptBlockadeSuperiorBonus = 0.15;
+/// Mission factor for Blockade interception probability.
+const double kNavalInterceptMissionFactorBlockade = 0.90;
 
 /// Retreat base chance. SPEC/game/ships-and-naval.md.
 const double kNavalRetreatBaseChance = 0.6;
@@ -104,20 +96,34 @@ List<BattleContextSea> detectNavalConflicts(Game game) {
   return result;
 }
 
-/// Interception probability: base (Patrol 30%, Blockade 50%) + superior/inferior modifiers.
-/// SPEC/game/ships-and-naval.md. Clamped to [0.05, 0.85].
+double _fleetInterceptScore(List<String> shipTypeIds) {
+  var total = 0.0;
+  for (final id in shipTypeIds) {
+    total += NavalStatsCatalog.get(id).interceptRating;
+  }
+  return total;
+}
+
+double _fleetFleeScore(List<String> shipTypeIds) {
+  var total = 0.0;
+  for (final id in shipTypeIds) {
+    total += NavalStatsCatalog.get(id).fleeRating;
+  }
+  return total;
+}
+
+/// Interception probability from mission factor × (intercept / (intercept + flee)).
+/// Clamped to [0.05, 0.85].
 double navalInterceptProbability({
-  required double interceptorStrength,
-  required double targetStrength,
+  required double interceptorScore,
+  required double targetFleeScore,
   required bool isBlockade,
 }) {
-  double base = isBlockade ? kNavalInterceptBaseBlockade : kNavalInterceptBasePatrol;
-  if (interceptorStrength > targetStrength) {
-    base += isBlockade ? kNavalInterceptBlockadeSuperiorBonus : kNavalInterceptSuperiorBonus;
-  } else if (interceptorStrength < targetStrength) {
-    base -= kNavalInterceptInferiorPenalty;
-  }
-  return base.clamp(0.05, 0.85);
+  final denom = interceptorScore + targetFleeScore;
+  final ratio = denom <= 0 ? 0.0 : interceptorScore / denom;
+  final missionFactor =
+      isBlockade ? kNavalInterceptMissionFactorBlockade : kNavalInterceptMissionFactorPatrol;
+  return (missionFactor * ratio).clamp(0.05, 0.85);
 }
 
 /// Average movement (MV) for a list of ship types. Used for retreat speed advantage.
@@ -148,8 +154,10 @@ List<BattleContextSea> filterBattlesByInterception(
         f.isAtSea && f.seaZoneId == zone && f.ownerId == battle.side1.ownerId && movedFleetIds.contains(f.id));
     final owner2Moved = game.worldState.fleets.any((f) =>
         f.isAtSea && f.seaZoneId == zone && f.ownerId == battle.side2.ownerId && movedFleetIds.contains(f.id));
-    final str1 = navalStrength(battle.side1.shipTypeIds);
-    final str2 = navalStrength(battle.side2.shipTypeIds);
+    final side1InterceptScore = _fleetInterceptScore(battle.side1.shipTypeIds);
+    final side2InterceptScore = _fleetInterceptScore(battle.side2.shipTypeIds);
+    final side1FleeScore = _fleetFleeScore(battle.side1.shipTypeIds);
+    final side2FleeScore = _fleetFleeScore(battle.side2.shipTypeIds);
     final side2IsInterceptor = battle.side2.mission == FleetMission.patrol || battle.side2.mission == FleetMission.blockade;
     final side1IsInterceptor = battle.side1.mission == FleetMission.patrol || battle.side1.mission == FleetMission.blockade;
     bool rollIntercept = false;
@@ -157,15 +165,15 @@ List<BattleContextSea> filterBattlesByInterception(
     if (owner1Moved && side2IsInterceptor) {
       rollIntercept = true;
       pIntercept = navalInterceptProbability(
-        interceptorStrength: str2,
-        targetStrength: str1,
+        interceptorScore: side2InterceptScore,
+        targetFleeScore: side1FleeScore,
         isBlockade: battle.side2.mission == FleetMission.blockade,
       );
     } else if (owner2Moved && side1IsInterceptor) {
       rollIntercept = true;
       pIntercept = navalInterceptProbability(
-        interceptorStrength: str1,
-        targetStrength: str2,
+        interceptorScore: side1InterceptScore,
+        targetFleeScore: side2FleeScore,
         isBlockade: battle.side1.mission == FleetMission.blockade,
       );
     }
@@ -184,9 +192,22 @@ double navalStrength(List<String> shipTypeIds) {
   var total = 0.0;
   for (final typeId in shipTypeIds) {
     final s = NavalStatsCatalog.get(typeId);
-    total += s.firepower * (1 + s.range * 0.2) + (s.armour + s.hull) * 0.5;
+    final durability = s.hull * (1 + (s.armour / 10.0));
+    final shipStrength = s.firepower +
+        (s.range * 0.4) +
+        (s.armour * 0.15) +
+        durability +
+        (s.movement * 0.1);
+    total += shipStrength;
   }
   return total;
+}
+
+enum NavalBattleOutcome {
+  side1Victory,
+  side2Victory,
+  stalemate,
+  mutualDestruction,
 }
 
 /// Result of resolving one sea battle: updated fleet lists (sunk ships removed).
@@ -196,17 +217,24 @@ class NavalBattleResult {
     required this.survivingShipTypeIdsSide2,
     this.side1Retreated = false,
     this.side2Retreated = false,
+    this.outcome = NavalBattleOutcome.stalemate,
   });
 
   final List<String> survivingShipTypeIdsSide1;
   final List<String> survivingShipTypeIdsSide2;
   final bool side1Retreated;
   final bool side2Retreated;
+  final NavalBattleOutcome outcome;
 }
 
 /// Resolve one sea battle deterministically. Seed from game + zone for RNG.
 /// Applies retreat roll per SPEC/game/ships-and-naval.md (base 0.6 + speed advantage - enemy aggression).
-NavalBattleResult resolveSeaBattle(BattleContextSea battle, int seed) {
+NavalBattleResult resolveSeaBattle(
+  BattleContextSea battle,
+  int seed, {
+  bool side1CanRetreat = true,
+  bool side2CanRetreat = true,
+}) {
   final rng = _SeededRng(seed);
   final str1 = navalStrength(battle.side1.shipTypeIds);
   final str2 = navalStrength(battle.side2.shipTypeIds);
@@ -239,14 +267,29 @@ NavalBattleResult resolveSeaBattle(BattleContextSea battle, int seed) {
   final enemyAggression2 = battle.side1.mission == FleetMission.blockade ? kNavalRetreatEnemyBlockade : (battle.side1.mission == FleetMission.patrol ? kNavalRetreatEnemyPatrol : 0.0);
   final pRetreat1 = (kNavalRetreatBaseChance + speedAdvantage1 - enemyAggression1).clamp(0.1, 0.95);
   final pRetreat2 = (kNavalRetreatBaseChance + speedAdvantage2 - enemyAggression2).clamp(0.1, 0.95);
-  if (list1.isNotEmpty && rng.nextInt(100) < (pRetreat1 * 100).round()) side1Retreated = true;
-  if (list2.isNotEmpty && rng.nextInt(100) < (pRetreat2 * 100).round()) side2Retreated = true;
+  if (side1CanRetreat && list1.isNotEmpty && rng.nextInt(100) < (pRetreat1 * 100).round()) side1Retreated = true;
+  if (side2CanRetreat && list2.isNotEmpty && rng.nextInt(100) < (pRetreat2 * 100).round()) side2Retreated = true;
+
+  NavalBattleOutcome outcome = NavalBattleOutcome.stalemate;
+  if (list1.isEmpty && list2.isEmpty) {
+    outcome = NavalBattleOutcome.mutualDestruction;
+  } else if (list1.isEmpty && list2.isNotEmpty) {
+    outcome = NavalBattleOutcome.side2Victory;
+  } else if (list2.isEmpty && list1.isNotEmpty) {
+    outcome = NavalBattleOutcome.side1Victory;
+  }
+
+  _log.d(
+    'logic: naval battle zone=${battle.seaZoneId} side1=${battle.side1.ownerId} side2=${battle.side2.ownerId} '
+    'outcome=${outcome.name} retreat1=$side1Retreated retreat2=$side2Retreated',
+  );
 
   return NavalBattleResult(
     survivingShipTypeIdsSide1: list1,
     survivingShipTypeIdsSide2: list2,
     side1Retreated: side1Retreated,
     side2Retreated: side2Retreated,
+    outcome: outcome,
   );
 }
 
@@ -261,13 +304,14 @@ class _SeededRng {
 }
 
 /// Apply naval battle results to game: replace all fleets of both sides in zone with surviving fleets.
-/// If [topology] is provided and a side retreated, that side's fleet is placed in an adjacent zone.
+/// If retreat destination is provided and side retreated, that side's fleet is placed in that zone.
 Game applyNavalBattleResults(
   Game game,
   BattleContextSea battle,
   NavalBattleResult result,
   String regionIdForZone, {
-  MapTopology? topology,
+  String? retreatDestinationSide1,
+  String? retreatDestinationSide2,
 }) {
   var fleets = List<Fleet>.from(game.worldState.fleets);
   final zone = battle.seaZoneId;
@@ -278,16 +322,8 @@ Game applyNavalBattleResults(
 
   var zone1 = zone;
   var zone2 = zone;
-  if (topology != null) {
-    if (result.side1Retreated) {
-      final adj = firstAdjacentSeaZone(topology, zone);
-      if (adj != null) zone1 = adj;
-    }
-    if (result.side2Retreated) {
-      final adj = firstAdjacentSeaZone(topology, zone);
-      if (adj != null) zone2 = adj;
-    }
-  }
+  if (result.side1Retreated && retreatDestinationSide1 != null) zone1 = retreatDestinationSide1;
+  if (result.side2Retreated && retreatDestinationSide2 != null) zone2 = retreatDestinationSide2;
 
   if (result.survivingShipTypeIdsSide1.isNotEmpty) {
     fleets.add(Fleet(
@@ -297,6 +333,7 @@ Game applyNavalBattleResults(
       inPortAtProvinceId: null,
       regionId: regionIdForZone,
       shipTypeIds: result.survivingShipTypeIdsSide1,
+      mission: battle.side1.mission,
     ));
   }
   if (result.survivingShipTypeIdsSide2.isNotEmpty) {
@@ -307,6 +344,7 @@ Game applyNavalBattleResults(
       inPortAtProvinceId: null,
       regionId: regionIdForZone,
       shipTypeIds: result.survivingShipTypeIdsSide2,
+      mission: battle.side2.mission,
     ));
   }
   return game.copyWith(

--- a/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
@@ -1,7 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../combat/conflict_detection.dart';
 import '../combat/naval_combat_resolver.dart';
 import '../constants.dart';
 import '../diplomacy/diplomacy_relation_lookup.dart';
@@ -10,6 +10,50 @@ import '../dossier/event_dialogue.dart';
 import 'naval.dart';
 import 'player_view.dart';
 import 'province_lookup.dart';
+
+final _log = logicLogger();
+
+Map<String, Set<String>> _atWarByFaction(Game game) {
+  final out = <String, Set<String>>{};
+  for (final rel in game.diplomacyRelations) {
+    if (rel.state != RelationState.atWar) continue;
+    out.putIfAbsent(rel.factionId1, () => <String>{}).add(rel.factionId2);
+    out.putIfAbsent(rel.factionId2, () => <String>{}).add(rel.factionId1);
+  }
+  return out;
+}
+
+List<String> _adjacentSeaZones(MapTopology topology, String seaZoneId) {
+  final out = <String>[];
+  for (final e in topology.edges) {
+    if (e.id1 == seaZoneId) {
+      out.add(e.id2);
+    } else if (e.id2 == seaZoneId) {
+      out.add(e.id1);
+    }
+  }
+  return out;
+}
+
+String? _firstFriendlyOrNeutralRetreatZone(
+  Game game,
+  MapTopology topology,
+  String fromSeaZoneId,
+  String ownerId,
+) {
+  final hostileByOwner = _atWarByFaction(game);
+  for (final adj in _adjacentSeaZones(topology, fromSeaZoneId)) {
+    final hostileOwnersPresent = game.worldState.fleets.any(
+      (fleet) =>
+          fleet.isAtSea &&
+          fleet.seaZoneId == adj &&
+          fleet.ownerId != ownerId &&
+          (hostileByOwner[ownerId]?.contains(fleet.ownerId) ?? false),
+    );
+    if (!hostileOwnersPresent) return adj;
+  }
+  return null;
+}
 
 Game applyNavalMissionOrders(
   Game game,
@@ -251,6 +295,7 @@ Game runNavalInterceptionCombatPhase(
   void Function(DialogueEvent)? onDialogue,
 }) {
   var battles = detectNavalConflicts(game);
+  _log.d('logic: naval phase detected battles=${battles.length}');
   final movedFleetIds = <String>{
     for (final list in navalMoveOrdersByPlayerId.values)
       for (final order in list) order.fleetId,
@@ -258,12 +303,30 @@ Game runNavalInterceptionCombatPhase(
   var seed = (game.globalGameSeed ?? 0) ^
       (game.worldState.turnState.turnNumber * 0x9E3779B1);
   battles = filterBattlesByInterception(game, battles, movedFleetIds, seed);
+  _log.d('logic: naval phase after interception battles=${battles.length}');
   seed = (seed * 1103515245 + 12345) & 0x7fffffff;
   var state = game;
   final turn = game.worldState.turnState.turnNumber;
   var battleIndex = 0;
   for (final battle in battles) {
-    final result = resolveSeaBattle(battle, seed);
+    final retreatZoneSide1 = _firstFriendlyOrNeutralRetreatZone(
+      state,
+      topology,
+      battle.seaZoneId,
+      battle.side1.ownerId,
+    );
+    final retreatZoneSide2 = _firstFriendlyOrNeutralRetreatZone(
+      state,
+      topology,
+      battle.seaZoneId,
+      battle.side2.ownerId,
+    );
+    final result = resolveSeaBattle(
+      battle,
+      seed,
+      side1CanRetreat: retreatZoneSide1 != null,
+      side2CanRetreat: retreatZoneSide2 != null,
+    );
     seed = (seed * 1103515245 + 12345) & 0x7fffffff;
     final zoneRegionId = regionIdForSeaZone(topology, battle.seaZoneId);
     final fleetsInZone =
@@ -276,7 +339,12 @@ Game runNavalInterceptionCombatPhase(
       battle,
       result,
       regionId,
-      topology: topology,
+      retreatDestinationSide1: retreatZoneSide1,
+      retreatDestinationSide2: retreatZoneSide2,
+    );
+    _log.d(
+      'logic: naval phase battle zone=${battle.seaZoneId} outcome=${result.outcome.name} '
+      'side1Retreated=${result.side1Retreated} side2Retreated=${result.side2Retreated}',
     );
 
     String? victorId;

--- a/packages/colonizethis_logic/test/naval_behavior_scenarios_test.dart
+++ b/packages/colonizethis_logic/test/naval_behavior_scenarios_test.dart
@@ -1,0 +1,224 @@
+import 'package:colonizethis_logic/src/world/naval_resolution.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+Game _baseGame({
+  required List<Fleet> fleets,
+  required List<DiplomacyRelation> relations,
+}) {
+  return Game(
+    id: 'g_naval',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: const RegionData(),
+      newWorld: const RegionData(),
+      fleets: fleets,
+    ),
+    players: const [
+      Player(id: 'p1', displayName: 'A', isHuman: true),
+      Player(id: 'p2', displayName: 'B', isHuman: true),
+      Player(id: 'p3', displayName: 'C', isHuman: true),
+    ],
+    diplomacyRelations: relations,
+    globalGameSeed: 42,
+  );
+}
+
+void main() {
+  group('naval behavior scenarios', () {
+    test('scenario: post-battle fleets preserve mission', () {
+      final game = _baseGame(
+        fleets: [
+          Fleet(
+            id: 'f1',
+            ownerId: 'p1',
+            seaZoneId: 'sea1',
+            regionId: 'oldWorld',
+            shipTypeIds: const ['carrack', 'carrack'],
+            mission: FleetMission.patrol,
+          ),
+          Fleet(
+            id: 'f2',
+            ownerId: 'p2',
+            seaZoneId: 'sea1',
+            regionId: 'oldWorld',
+            shipTypeIds: const ['fluyte', 'fluyte'],
+            mission: FleetMission.blockade,
+          ),
+        ],
+        relations: [
+          DiplomacyRelation(
+            factionId1: 'p1',
+            factionId2: 'p2',
+            state: RelationState.atWar,
+          ),
+        ],
+      );
+
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+        ],
+        edges: [],
+      );
+
+      final resolved = runNavalInterceptionCombatPhase(
+        game,
+        topology,
+        const {},
+      );
+
+      final p1Fleets = resolved.worldState.fleets.where((f) => f.ownerId == 'p1').toList();
+      final p2Fleets = resolved.worldState.fleets.where((f) => f.ownerId == 'p2').toList();
+      if (p1Fleets.isNotEmpty) {
+        expect(p1Fleets.first.mission, FleetMission.patrol);
+      }
+      if (p2Fleets.isNotEmpty) {
+        expect(p2Fleets.first.mission, FleetMission.blockade);
+      }
+    });
+
+    test('scenario: hostile adjacent sea zone is not used for retreat', () {
+      final game = _baseGame(
+        fleets: [
+          Fleet(
+            id: 'f1',
+            ownerId: 'p1',
+            seaZoneId: 'sea1',
+            regionId: 'oldWorld',
+            shipTypeIds: const ['carrack', 'carrack'],
+            mission: FleetMission.patrol,
+          ),
+          Fleet(
+            id: 'f2',
+            ownerId: 'p2',
+            seaZoneId: 'sea1',
+            regionId: 'oldWorld',
+            shipTypeIds: const ['fluyte', 'fluyte'],
+            mission: FleetMission.blockade,
+          ),
+          Fleet(
+            id: 'f3',
+            ownerId: 'p3',
+            seaZoneId: 'sea2',
+            regionId: 'oldWorld',
+            shipTypeIds: const ['carrack'],
+            mission: FleetMission.patrol,
+          ),
+        ],
+        relations: [
+          DiplomacyRelation(
+            factionId1: 'p1',
+            factionId2: 'p2',
+            state: RelationState.atWar,
+          ),
+          DiplomacyRelation(
+            factionId1: 'p1',
+            factionId2: 'p3',
+            state: RelationState.atWar,
+          ),
+          DiplomacyRelation(
+            factionId1: 'p2',
+            factionId2: 'p3',
+            state: RelationState.atWar,
+          ),
+        ],
+      );
+
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(id: 'sea2', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(id: 'sea3', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+        ],
+        edges: [
+          TopologyEdge(id1: 'sea1', id2: 'sea2'),
+          TopologyEdge(id1: 'sea1', id2: 'sea3'),
+        ],
+      );
+
+      final resolved = runNavalInterceptionCombatPhase(
+        game,
+        topology,
+        const {},
+      );
+
+      final retreatingOwnersInSea2 = resolved.worldState.fleets.where(
+        (f) => (f.ownerId == 'p1' || f.ownerId == 'p2') && f.seaZoneId == 'sea2',
+      );
+      expect(retreatingOwnersInSea2, isEmpty);
+    });
+
+    test('scenario: no legal retreat destination keeps survivors in battle zone', () {
+      final game = _baseGame(
+        fleets: [
+          Fleet(
+            id: 'f1',
+            ownerId: 'p1',
+            seaZoneId: 'sea1',
+            regionId: 'oldWorld',
+            shipTypeIds: const ['carrack', 'carrack'],
+            mission: FleetMission.patrol,
+          ),
+          Fleet(
+            id: 'f2',
+            ownerId: 'p2',
+            seaZoneId: 'sea1',
+            regionId: 'oldWorld',
+            shipTypeIds: const ['fluyte', 'fluyte'],
+            mission: FleetMission.blockade,
+          ),
+          Fleet(
+            id: 'f3',
+            ownerId: 'p3',
+            seaZoneId: 'sea2',
+            regionId: 'oldWorld',
+            shipTypeIds: const ['carrack'],
+            mission: FleetMission.patrol,
+          ),
+        ],
+        relations: [
+          DiplomacyRelation(
+            factionId1: 'p1',
+            factionId2: 'p2',
+            state: RelationState.atWar,
+          ),
+          DiplomacyRelation(
+            factionId1: 'p1',
+            factionId2: 'p3',
+            state: RelationState.atWar,
+          ),
+          DiplomacyRelation(
+            factionId1: 'p2',
+            factionId2: 'p3',
+            state: RelationState.atWar,
+          ),
+        ],
+      );
+
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(id: 'sea2', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+        ],
+        edges: [
+          TopologyEdge(id1: 'sea1', id2: 'sea2'),
+        ],
+      );
+
+      final resolved = runNavalInterceptionCombatPhase(
+        game,
+        topology,
+        const {},
+      );
+
+      final sideFleets = resolved.worldState.fleets.where(
+        (f) => f.ownerId == 'p1' || f.ownerId == 'p2',
+      );
+      for (final fleet in sideFleets) {
+        expect(fleet.seaZoneId, 'sea1');
+      }
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/naval_combat_resolver_test.dart
+++ b/packages/colonizethis_logic/test/naval_combat_resolver_test.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
@@ -118,9 +119,14 @@ void main() {
       expect(navalStrength([]), 0.0);
     });
 
-    test('returns positive value for known ship types', () {
-      final s = navalStrength(['carrack', 'fluyte']);
-      expect(s, greaterThan(0));
+    test('uses configured weighted formula including durability', () {
+      final carrack = NavalStatsCatalog.get('carrack');
+      final expected = carrack.firepower +
+          (carrack.range * 0.4) +
+          (carrack.armour * 0.15) +
+          (carrack.hull * (1 + carrack.armour / 10.0)) +
+          (carrack.movement * 0.1);
+      expect(navalStrength(['carrack']), closeTo(expected, 1e-9));
     });
   });
 
@@ -149,6 +155,30 @@ void main() {
       final result = resolveSeaBattle(battle, 0);
       expect(result.survivingShipTypeIdsSide1, isEmpty);
       expect(result.survivingShipTypeIdsSide2, isEmpty);
+    });
+
+    test('does not retreat when retreat is disallowed by topology/relation gate', () {
+      const battle = BattleContextSea(
+        seaZoneId: 'sea1',
+        side1: NavalBattleSide(
+          ownerId: 'p1',
+          shipTypeIds: ['carrack', 'carrack'],
+          mission: FleetMission.patrol,
+        ),
+        side2: NavalBattleSide(
+          ownerId: 'p2',
+          shipTypeIds: ['fluyte', 'fluyte'],
+          mission: FleetMission.blockade,
+        ),
+      );
+      final result = resolveSeaBattle(
+        battle,
+        42,
+        side1CanRetreat: false,
+        side2CanRetreat: false,
+      );
+      expect(result.side1Retreated, isFalse);
+      expect(result.side2Retreated, isFalse);
     });
   });
 
@@ -195,37 +225,81 @@ void main() {
       expect(updated.worldState.fleets.length, 1);
       expect(updated.worldState.fleets.single.ownerId, 'p1');
       expect(updated.worldState.fleets.single.shipTypeIds, ['carrack']);
+      expect(updated.worldState.fleets.single.mission, FleetMission.none);
+    });
+
+    test('preserves mission on recreated surviving fleets', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+          fleets: [
+            Fleet(
+              id: 'f1',
+              ownerId: 'p1',
+              seaZoneId: 'sea1',
+              regionId: 'oldWorld',
+              shipTypeIds: ['carrack'],
+              mission: FleetMission.patrol,
+            ),
+            Fleet(
+              id: 'f2',
+              ownerId: 'p2',
+              seaZoneId: 'sea1',
+              regionId: 'oldWorld',
+              shipTypeIds: ['fluyte'],
+              mission: FleetMission.blockade,
+            ),
+          ],
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'A', isHuman: true),
+          Player(id: 'p2', displayName: 'B', isHuman: true),
+        ],
+      );
+      const battle = BattleContextSea(
+        seaZoneId: 'sea1',
+        side1: NavalBattleSide(ownerId: 'p1', shipTypeIds: ['carrack'], mission: FleetMission.patrol),
+        side2: NavalBattleSide(ownerId: 'p2', shipTypeIds: ['fluyte'], mission: FleetMission.blockade),
+      );
+      const result = NavalBattleResult(
+        survivingShipTypeIdsSide1: ['carrack'],
+        survivingShipTypeIdsSide2: ['fluyte'],
+      );
+      final updated = applyNavalBattleResults(game, battle, result, 'oldWorld');
+      final p1 = updated.worldState.fleets.firstWhere((f) => f.ownerId == 'p1');
+      final p2 = updated.worldState.fleets.firstWhere((f) => f.ownerId == 'p2');
+      expect(p1.mission, FleetMission.patrol);
+      expect(p2.mission, FleetMission.blockade);
     });
   });
 
   group('navalInterceptProbability', () {
-    test('Patrol base is 0.3', () {
+    test('Patrol uses mission-factor * ratio', () {
+      // Ratio = 5/(5+5) = 0.5, patrol factor = 0.5 => 0.25
       expect(
-        navalInterceptProbability(interceptorStrength: 10, targetStrength: 10, isBlockade: false),
-        0.3,
+        navalInterceptProbability(interceptorScore: 5, targetFleeScore: 5, isBlockade: false),
+        0.25,
       );
     });
-    test('Blockade base is 0.5', () {
+
+    test('Blockade uses mission-factor * ratio', () {
+      // Ratio = 8/(8+2) = 0.8, blockade factor = 0.9 => 0.72
       expect(
-        navalInterceptProbability(interceptorStrength: 10, targetStrength: 10, isBlockade: true),
-        0.5,
+        navalInterceptProbability(interceptorScore: 8, targetFleeScore: 2, isBlockade: true),
+        closeTo(0.72, 1e-9),
       );
     });
-    test('superior force adds bonus', () {
-      final p = navalInterceptProbability(interceptorStrength: 20, targetStrength: 5, isBlockade: false);
-      expect(p, 0.3 + 0.1);
-    });
-    test('inferior force subtracts penalty', () {
-      final p = navalInterceptProbability(interceptorStrength: 5, targetStrength: 20, isBlockade: false);
-      expect(p, 0.3 - 0.1);
-    });
+
     test('result is clamped 0.05-0.85', () {
       expect(
-        navalInterceptProbability(interceptorStrength: 1, targetStrength: 100, isBlockade: false),
+        navalInterceptProbability(interceptorScore: 0, targetFleeScore: 100, isBlockade: false),
         greaterThanOrEqualTo(0.05),
       );
       expect(
-        navalInterceptProbability(interceptorStrength: 100, targetStrength: 1, isBlockade: true),
+        navalInterceptProbability(interceptorScore: 100, targetFleeScore: 0, isBlockade: true),
         lessThanOrEqualTo(0.85),
       );
     });

--- a/tool/sim_scenarios/lib/scenario.dart
+++ b/tool/sim_scenarios/lib/scenario.dart
@@ -54,6 +54,7 @@ class ScenarioInit {
 class ScenarioSetup {
   const ScenarioSetup({
     this.units,
+    this.initialFleets,
     this.stockpileOverrides,
     this.initialWorkers,
     this.initialStockpile,
@@ -67,6 +68,7 @@ class ScenarioSetup {
   });
 
   final List<UnitPlacement>? units;
+  final List<FleetPlacement>? initialFleets;
   final Map<String, int>? stockpileOverrides;
 
   /// Player id → { peasants, apprentices, journeymen, masters }. SPEC/game/workers-and-population.md.
@@ -95,6 +97,26 @@ class ScenarioSetup {
 
   /// Tile key → player id. Overrides WorldState.purchasedTilesByTileKey for build_improvement on purchased foreign tiles. SPEC/game/civilian-units.md, SPEC/program/orders.md.
   final Map<String, String>? purchasedTilesByTileKey;
+}
+
+class FleetPlacement {
+  const FleetPlacement({
+    required this.id,
+    required this.ownerId,
+    required this.regionId,
+    required this.shipTypeIds,
+    this.seaZoneId,
+    this.inPortAtProvinceId,
+    this.mission = 'none',
+  });
+
+  final String id;
+  final String ownerId;
+  final String regionId;
+  final List<String> shipTypeIds;
+  final String? seaZoneId;
+  final String? inPortAtProvinceId;
+  final String mission;
 }
 
 /// One production assignment: recipe id and labour to assign. Converted to AssignedRecipe in runner.
@@ -504,6 +526,9 @@ ScenarioSetup _parseScenarioSetup(Map<String, dynamic> json) {
     units: (json['units'] as List<dynamic>?)
         ?.map((u) => _parseUnitPlacement(u as Map<String, dynamic>))
         .toList(),
+    initialFleets: (json['initialFleets'] as List<dynamic>?)
+        ?.map((f) => _parseFleetPlacement(f as Map<String, dynamic>))
+        .toList(),
     stockpileOverrides: (json['stockpileOverrides'] as Map<String, dynamic>?)
         ?.map((k, v) => MapEntry(k, v.toInt())),
     initialWorkers: _parseInitialWorkers(json['initialWorkers']),
@@ -516,6 +541,20 @@ ScenarioSetup _parseScenarioSetup(Map<String, dynamic> json) {
     initialTreasury: _parseInitialTreasury(json['initialTreasury']),
     defaultCombatMode: json['defaultCombatMode'] as String?,
     purchasedTilesByTileKey: _parsePurchasedTilesByTileKey(json['purchasedTilesByTileKey']),
+  );
+}
+
+FleetPlacement _parseFleetPlacement(Map<String, dynamic> json) {
+  return FleetPlacement(
+    id: json['id'] as String,
+    ownerId: json['ownerId'] as String,
+    regionId: json['regionId'] as String,
+    shipTypeIds: (json['shipTypeIds'] as List<dynamic>? ?? const [])
+        .map((e) => e.toString())
+        .toList(),
+    seaZoneId: json['seaZoneId'] as String?,
+    inPortAtProvinceId: json['inPortAtProvinceId'] as String?,
+    mission: json['mission'] as String? ?? 'none',
   );
 }
 

--- a/tool/sim_scenarios/lib/scenario_runner.dart
+++ b/tool/sim_scenarios/lib/scenario_runner.dart
@@ -282,6 +282,25 @@ class ScenarioRunner {
         ),
       );
     }
+    if (setup.initialFleets != null && setup.initialFleets!.isNotEmpty) {
+      final fleets = setup.initialFleets!
+          .map((f) => Fleet(
+                id: f.id,
+                ownerId: f.ownerId,
+                seaZoneId: f.seaZoneId,
+                inPortAtProvinceId: f.inPortAtProvinceId,
+                regionId: f.regionId,
+                shipTypeIds: f.shipTypeIds,
+                mission: FleetMission.values.firstWhere(
+                  (m) => m.name == f.mission,
+                  orElse: () => FleetMission.none,
+                ),
+              ))
+          .toList();
+      game = game.copyWith(
+        worldState: game.worldState.copyWith(fleets: fleets),
+      );
+    }
     // Apply initialWorkers and initialStockpile (SPEC/game/workers-and-population.md).
     var players = game.players;
     if (setup.initialWorkers != null || setup.initialStockpile != null) {

--- a/tool/sim_scenarios/scenarios/naval_behavior_hostile_adjacent_not_retreat.json
+++ b/tool/sim_scenarios/scenarios/naval_behavior_hostile_adjacent_not_retreat.json
@@ -1,0 +1,75 @@
+{
+  "name": "naval_behavior_hostile_adjacent_not_retreat",
+  "description": "Retreat destination excludes adjacent sea zones containing hostile fleets.",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "seed": 4243,
+      "greatPowers": ["england", "france", "spain"],
+      "minorNationCount": 0
+    },
+    "oldWorld": {
+      "grid": [
+        ["p1", "p2", "p3"],
+        ["sea1", "sea1", "sea1"],
+        ["sea2", "sea2", "sea3"]
+      ],
+      "nodes": [
+        { "id": "p1", "regionId": "oldWorld", "type": "province" },
+        { "id": "p2", "regionId": "oldWorld", "type": "province" },
+        { "id": "p3", "regionId": "oldWorld", "type": "province" },
+        { "id": "sea1", "regionId": "oldWorld", "type": "seaZone" },
+        { "id": "sea2", "regionId": "oldWorld", "type": "seaZone" },
+        { "id": "sea3", "regionId": "oldWorld", "type": "seaZone" }
+      ],
+      "edges": [
+        { "id1": "p1", "id2": "sea1" },
+        { "id1": "p2", "id2": "sea1" },
+        { "id1": "p3", "id2": "sea1" },
+        { "id1": "sea1", "id2": "sea2" },
+        { "id1": "sea1", "id2": "sea3" }
+      ]
+    }
+  },
+  "setup": {
+    "initialFleets": [
+      {
+        "id": "f1",
+        "ownerId": "gp1",
+        "regionId": "oldWorld",
+        "seaZoneId": "sea1",
+        "shipTypeIds": ["carrack", "carrack"],
+        "mission": "patrol"
+      },
+      {
+        "id": "f2",
+        "ownerId": "gp2",
+        "regionId": "oldWorld",
+        "seaZoneId": "sea1",
+        "shipTypeIds": ["fluyte", "fluyte"],
+        "mission": "blockade"
+      },
+      {
+        "id": "f3",
+        "ownerId": "gp3",
+        "regionId": "oldWorld",
+        "seaZoneId": "sea2",
+        "shipTypeIds": ["carrack"],
+        "mission": "patrol"
+      }
+    ]
+  },
+  "turns": [
+    {
+      "turn": 1,
+      "orders": [
+        { "player": "gp1", "type": "diplomatic", "diplomaticType": "declareWar", "targetFactionId": "gp2" },
+        { "player": "gp1", "type": "diplomatic", "diplomaticType": "declareWar", "targetFactionId": "gp3" },
+        { "player": "gp2", "type": "diplomatic", "diplomaticType": "declareWar", "targetFactionId": "gp3" }
+      ]
+    }
+  ],
+  "assertions": [
+    { "turn": 1, "province": "oldWorld|p1", "owner": "gp1" }
+  ]
+}

--- a/tool/sim_scenarios/scenarios/naval_behavior_no_legal_retreat_stays.json
+++ b/tool/sim_scenarios/scenarios/naval_behavior_no_legal_retreat_stays.json
@@ -1,0 +1,73 @@
+{
+  "name": "naval_behavior_no_legal_retreat_stays",
+  "description": "When every adjacent sea zone is hostile, surviving fleets remain in the battle sea zone.",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "seed": 4244,
+      "greatPowers": ["england", "france", "spain"],
+      "minorNationCount": 0
+    },
+    "oldWorld": {
+      "grid": [
+        ["p1", "p2", "p3"],
+        ["sea1", "sea1", "sea1"],
+        ["sea2", "sea2", "sea2"]
+      ],
+      "nodes": [
+        { "id": "p1", "regionId": "oldWorld", "type": "province" },
+        { "id": "p2", "regionId": "oldWorld", "type": "province" },
+        { "id": "p3", "regionId": "oldWorld", "type": "province" },
+        { "id": "sea1", "regionId": "oldWorld", "type": "seaZone" },
+        { "id": "sea2", "regionId": "oldWorld", "type": "seaZone" }
+      ],
+      "edges": [
+        { "id1": "p1", "id2": "sea1" },
+        { "id1": "p2", "id2": "sea1" },
+        { "id1": "p3", "id2": "sea1" },
+        { "id1": "sea1", "id2": "sea2" }
+      ]
+    }
+  },
+  "setup": {
+    "initialFleets": [
+      {
+        "id": "f1",
+        "ownerId": "gp1",
+        "regionId": "oldWorld",
+        "seaZoneId": "sea1",
+        "shipTypeIds": ["carrack", "carrack"],
+        "mission": "patrol"
+      },
+      {
+        "id": "f2",
+        "ownerId": "gp2",
+        "regionId": "oldWorld",
+        "seaZoneId": "sea1",
+        "shipTypeIds": ["fluyte", "fluyte"],
+        "mission": "blockade"
+      },
+      {
+        "id": "f3",
+        "ownerId": "gp3",
+        "regionId": "oldWorld",
+        "seaZoneId": "sea2",
+        "shipTypeIds": ["carrack"],
+        "mission": "patrol"
+      }
+    ]
+  },
+  "turns": [
+    {
+      "turn": 1,
+      "orders": [
+        { "player": "gp1", "type": "diplomatic", "diplomaticType": "declareWar", "targetFactionId": "gp2" },
+        { "player": "gp1", "type": "diplomatic", "diplomaticType": "declareWar", "targetFactionId": "gp3" },
+        { "player": "gp2", "type": "diplomatic", "diplomaticType": "declareWar", "targetFactionId": "gp3" }
+      ]
+    }
+  ],
+  "assertions": [
+    { "turn": 1, "province": "oldWorld|p1", "owner": "gp1" }
+  ]
+}

--- a/tool/sim_scenarios/scenarios/naval_behavior_preserve_mission.json
+++ b/tool/sim_scenarios/scenarios/naval_behavior_preserve_mission.json
@@ -1,0 +1,60 @@
+{
+  "name": "naval_behavior_preserve_mission",
+  "description": "Naval battle survivors keep their assigned mission after combat resolution.",
+  "init": {
+    "type": "fromTopology",
+    "config": {
+      "seed": 4242,
+      "greatPowers": ["england", "france", "spain"],
+      "minorNationCount": 0
+    },
+    "oldWorld": {
+      "grid": [
+        ["p1", "p2", "p3"],
+        ["sea1", "sea1", "sea1"]
+      ],
+      "nodes": [
+        { "id": "p1", "regionId": "oldWorld", "type": "province" },
+        { "id": "p2", "regionId": "oldWorld", "type": "province" },
+        { "id": "p3", "regionId": "oldWorld", "type": "province" },
+        { "id": "sea1", "regionId": "oldWorld", "type": "seaZone" }
+      ],
+      "edges": [
+        { "id1": "p1", "id2": "sea1" },
+        { "id1": "p2", "id2": "sea1" },
+        { "id1": "p3", "id2": "sea1" }
+      ]
+    }
+  },
+  "setup": {
+    "initialFleets": [
+      {
+        "id": "f1",
+        "ownerId": "gp1",
+        "regionId": "oldWorld",
+        "seaZoneId": "sea1",
+        "shipTypeIds": ["carrack", "carrack"],
+        "mission": "patrol"
+      },
+      {
+        "id": "f2",
+        "ownerId": "gp2",
+        "regionId": "oldWorld",
+        "seaZoneId": "sea1",
+        "shipTypeIds": ["fluyte", "fluyte"],
+        "mission": "blockade"
+      }
+    ]
+  },
+  "turns": [
+    {
+      "turn": 1,
+      "orders": [
+        { "player": "gp1", "type": "diplomatic", "diplomaticType": "declareWar", "targetFactionId": "gp2" }
+      ]
+    }
+  ],
+  "assertions": [
+    { "turn": 1, "province": "oldWorld|p1", "owner": "gp1" }
+  ]
+}

--- a/tool/sim_scenarios/test/naval_behavior_scenarios_test.dart
+++ b/tool/sim_scenarios/test/naval_behavior_scenarios_test.dart
@@ -3,7 +3,11 @@ import 'dart:io';
 import 'package:colonizethis_test/test.dart';
 import 'package:sim_scenarios/scenario_runner.dart';
 
-File _scenarioFile(String name) => File('tool/sim_scenarios/scenarios/$name');
+File _scenarioFile(String name) {
+  final fromToolDir = File('scenarios/$name');
+  if (fromToolDir.existsSync()) return fromToolDir;
+  return File('tool/sim_scenarios/scenarios/$name');
+}
 
 void main() {
   group('naval behavior scenarios (json)', () {

--- a/tool/sim_scenarios/test/naval_behavior_scenarios_test.dart
+++ b/tool/sim_scenarios/test/naval_behavior_scenarios_test.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:colonizethis_test/test.dart';
+import 'package:sim_scenarios/scenario_runner.dart';
+
+File _scenarioFile(String name) => File('tool/sim_scenarios/scenarios/$name');
+
+void main() {
+  group('naval behavior scenarios (json)', () {
+    test('surviving fleets preserve mission after combat', () async {
+      final runner = ScenarioRunner();
+      final result = await runner.runFile(
+        _scenarioFile('naval_behavior_preserve_mission.json'),
+      );
+
+      expect(
+        result.passed,
+        isTrue,
+        reason: result.failures.join('\n'),
+      );
+      final game = result.finalState;
+      expect(game, isNotNull);
+
+      final p1Fleets =
+          game!.worldState.fleets.where((f) => f.ownerId == 'gp1').toList();
+      final p2Fleets =
+          game.worldState.fleets.where((f) => f.ownerId == 'gp2').toList();
+
+      if (p1Fleets.isNotEmpty) {
+        expect(p1Fleets.first.mission.name, 'patrol');
+      }
+      if (p2Fleets.isNotEmpty) {
+        expect(p2Fleets.first.mission.name, 'blockade');
+      }
+    });
+
+    test('hostile adjacent zone is never selected as retreat destination', () async {
+      final runner = ScenarioRunner();
+      final result = await runner.runFile(
+        _scenarioFile('naval_behavior_hostile_adjacent_not_retreat.json'),
+      );
+
+      expect(
+        result.passed,
+        isTrue,
+        reason: result.failures.join('\n'),
+      );
+      final game = result.finalState;
+      expect(game, isNotNull);
+
+      final sideFleetsInSea2 = game!.worldState.fleets.where(
+        (f) =>
+            (f.ownerId == 'gp1' || f.ownerId == 'gp2') && f.seaZoneId == 'sea2',
+      );
+      expect(sideFleetsInSea2, isEmpty);
+    });
+
+    test('no legal retreat keeps survivors in battle sea zone', () async {
+      final runner = ScenarioRunner();
+      final result = await runner.runFile(
+        _scenarioFile('naval_behavior_no_legal_retreat_stays.json'),
+      );
+
+      expect(
+        result.passed,
+        isTrue,
+        reason: result.failures.join('\n'),
+      );
+      final game = result.finalState;
+      expect(game, isNotNull);
+
+      final sideFleets = game!.worldState.fleets.where(
+        (f) => f.ownerId == 'gp1' || f.ownerId == 'gp2',
+      );
+      for (final fleet in sideFleets) {
+        expect(fleet.seaZoneId, 'sea1');
+      }
+    });
+  });
+}

--- a/tool/sim_scenarios/test/sim_scenarios_test.dart
+++ b/tool/sim_scenarios/test/sim_scenarios_test.dart
@@ -210,6 +210,36 @@ void main() {
         expect(scenario.assertions[1].stockpileCommodity, 0);
       });
 
+      test('parses setup initialFleets', () {
+        final json = {
+          'name': 'fleet_setup',
+          'init': {'type': 'fromTopology', 'config': {'greatPowers': ['england']}},
+          'setup': {
+            'initialFleets': [
+              {
+                'id': 'f1',
+                'ownerId': 'gp1',
+                'regionId': 'oldWorld',
+                'seaZoneId': 'sea1',
+                'shipTypeIds': ['carrack', 'fluyte'],
+                'mission': 'patrol',
+              },
+            ],
+          },
+          'turns': [],
+          'assertions': [],
+        };
+
+        final scenario = parseScenarioFromJson(json);
+        expect(scenario.setup, isNotNull);
+        expect(scenario.setup!.initialFleets, isNotNull);
+        expect(scenario.setup!.initialFleets!.length, 1);
+        expect(scenario.setup!.initialFleets!.first.id, 'f1');
+        expect(scenario.setup!.initialFleets!.first.ownerId, 'gp1');
+        expect(scenario.setup!.initialFleets!.first.shipTypeIds, ['carrack', 'fluyte']);
+        expect(scenario.setup!.initialFleets!.first.mission, 'patrol');
+      });
+
       test('parses setup productionAssignments', () {
         final json = {
           'name': 'production_setup',


### PR DESCRIPTION
## Summary
- align naval combat implementation and specs: strength aggregation, interception probability, retreat legality gating, explicit battle outcomes, and mission preservation after battle
- add `logic:` naval-phase logging plus updated acceptance criteria in naval SPEC docs to make behavior explicit and testable
- extend coverage with naval unit tests and add sim_scenarios JSON fixtures + tests for mission preservation and retreat destination behavior

## Test plan
- [x] `dart test packages/colonizethis_logic/test/naval_combat_resolver_test.dart`
- [x] `dart test packages/colonizethis_logic/test/naval_behavior_scenarios_test.dart`
- [x] `dart test tool/sim_scenarios/test/naval_behavior_scenarios_test.dart`
- [x] `dart test tool/sim_scenarios/test/sim_scenarios_test.dart tool/sim_scenarios/test/naval_behavior_scenarios_test.dart`

Made with [Cursor](https://cursor.com)