### PR TITLE
chore(rules): consolidate AGENTS and Cursor rule guidance

### DIFF
--- a/.cursor/rules/colonizethis-code-review.mdc
+++ b/.cursor/rules/colonizethis-code-review.mdc
@@ -6,16 +6,16 @@ alwaysApply: false
 
 # ColonizeThis Code Review
 
-When reviewing or generating code, apply this checklist. Details in other rules.
+When reviewing or generating code, apply this checklist. Canonical policy lives in `spec-required`, `core-principles`, `testing`, and `ui-design`.
 
 - **Function:** > 20 lines → refactor (extract, move to service/component).
 - **Widget/screen:** > ~60 lines → split; move logic out of `build`.
 - **UI vs data:** Split if class does both; UI in widget/screen/component, logic in service/provider/Flame.
 - **Strings:** User-facing or repeated → constants (`app/lib/config/constants.dart`, `routes.dart`, or feature constants).
 - **Types:** Explicit; no `dynamic`.
-- **Spec:** New/changed behavior authorized by GDD/TDD/UI spec (spec-required).
-- **Logging:** Key flows, rejections, errors logged; appropriate levels; see core-principles and `SPEC/program/ctdev-logging.md`.
-- **Flame/Flutter:** No game logic in Flutter `build`; respect division (core-principles, ui-design).
+- **Spec:** New/changed behavior is authorized by SPEC (see `colonizethis-spec-required.mdc`).
+- **Logging:** Runtime logs use `logger`; no `print` (see `colonizethis-core-principles.mdc`).
+- **Flame/Flutter boundary:** No game logic in Flutter `build`.
 - **Reuse:** Check `app/lib/core/utils/`, `app/lib/widgets/`, `app/lib/config/`, `packages/*/lib/src/` before adding.
-- **New widgets:** Catalog + Widgetbook (component-structure, ui-design).
-- **Tests:** Critical paths covered; layout per testing rule.
+- **New widgets:** Catalog + Widgetbook registration (see `colonizethis-ui-design.mdc`).
+- **Tests:** Critical paths covered; thresholds and test layers follow `colonizethis-testing.mdc`.

--- a/.cursor/rules/colonizethis-component-structure.mdc
+++ b/.cursor/rules/colonizethis-component-structure.mdc
@@ -6,11 +6,13 @@ alwaysApply: false
 
 # Component Structure
 
+Scope: code organization and extraction rules (folders, reuse thresholds, naming).
+
 **Folder layout:**
 - `lib/game/` — Flame game, world, camera. `lib/game/components/` — Flame components (optional: `units/`, `map/`, `ui/`).
 - `lib/widgets/` or `lib/ui/` — Shared Flutter widgets. `lib/screens/` or `lib/pages/` — Full screens.
 - `lib/state/` or `lib/providers/` — State (e.g. Riverpod). `lib/services/` — Save/load, API, audio. `lib/models/` — Domain models, DTOs.
 
-**Reuse:** Extract at 2+ places or when testable in isolation. Flame: small components, mixins (e.g. `Tappable`); keep rendering in components. Flutter: reusable widgets for loading/error/empty/list; thin screens. New Flutter widgets: catalog + Widgetbook (see UI design rule).
+**Reuse:** Extract at 2+ places or when testable in isolation. Flame: keep components small and rendering-local. Flutter: keep screens thin and favor reusable widgets for loading/error/empty/list patterns.
 
-**Naming:** Flame: `*Component` when clarifying. Flutter: `*Widget`, `*Screen`, `*Page` when clarifying.
+**Naming:** Flame: `*Component` when useful for clarity. Flutter: `*Widget`, `*Screen`, `*Page` when useful for clarity.

--- a/.cursor/rules/colonizethis-testing.mdc
+++ b/.cursor/rules/colonizethis-testing.mdc
@@ -1,12 +1,13 @@
 ---
-description: Test layers and 90% per-package coverage requirement
+description: Test layers and package-specific coverage thresholds
 globs: "**/*_test.dart,**/test/**/*.dart"
 alwaysApply: false
 ---
 
 # Testing
 
-- **Coverage:** 90% per package (enforce in CI, e.g. `tool/test_coverage.py`). **App:** 80% line coverage for **widget-unit code only** (`lib/widgets/`); entry points, config, providers, and features are excluded. Enforced by `tool/run_quality_gate_tests.sh` and `tool/check_coverage_threshold.sh 80 app` (see SPEC/program/test-logging.md).
+- **Coverage policy:** `logic`, `ai`, and `map` packages require **90%** line coverage. All other packages require **80%** line coverage.
+- **App scope note:** In `app`, the 80% threshold is enforced on **widget-unit code only** (`lib/widgets/`); entry points, config, providers, and features are excluded. Enforcement uses `tool/run_quality_gate_tests.sh` and `tool/check_coverage_threshold.sh 80 app` (see `SPEC/program/test-logging.md`).
 - **How to run:** App and ctdev use Flutter widget tests. Run with **`flutter test`** from the package dir (e.g. `cd app && flutter test`) or `melos run test_app`. Do **not** use `dart test app/test/...` — that breaks (Flutter bindings missing).
 - **Layers:** **Unit** — pure logic, models, services (no Flutter/Flame); mock deps. **Widget** — Flutter; `flutter_test`, `pumpWidget`; mock state/providers. **Game/component** — Flame in isolation (minimal `FlameGame` + component); test `onLoad`, `update`, removal.
 - **Layout:** `test/` mirrors `lib/`; **`*_test.dart`**; group by feature or class.

--- a/.cursor/rules/colonizethis-tui.mdc
+++ b/.cursor/rules/colonizethis-tui.mdc
@@ -1,6 +1,6 @@
 ---
 description: TUI (ctterm) source of truth, Nocterm usage, and TUI-specific conventions.
-globs: "SPEC/tui/**", "ctterm/**"
+globs: "SPEC/tui/**,ctterm/**"
 alwaysApply: false
 ---
 

--- a/.cursor/rules/colonizethis-ui-design.mdc
+++ b/.cursor/rules/colonizethis-ui-design.mdc
@@ -6,12 +6,15 @@ alwaysApply: false
 
 # UI Design
 
+Scope: UI spec/process rules (wireframes, behavior contracts, component interaction boundaries).
+
 UI specs in `SPEC/ui/` derive from GDD/TDD (spec-required rule).
 
-- **Implementing UI:** Widgetbook story per new/changed component/screen; register in **widget catalog** (Ct-prefix, name, category, path/story). Keep catalog up to date for reuse.
-- **Mobile:** When designing screens, consider how layouts will appear on mobile from the start; see [SPEC/ui/mobile-adaptation.md](../SPEC/ui/mobile-adaptation.md). Provide at least one mobile viewport use case per screen; add a **mobile-only mockup** in Widgetbook when the mobile layout differs meaningfully (e.g. stacked vs row) so the mobile design can be reviewed in isolation.
+- **Implementing UI:** Add/update Widgetbook stories for new or changed components/screens and keep the widget catalog registration current.
+- **Mobile:** Design for mobile from the start (see `SPEC/ui/mobile-adaptation.md`). Include at least one mobile viewport use case per screen; add a mobile-only Widgetbook mockup when the mobile layout differs meaningfully.
 - **Wireframe:** Every UI spec has a wireframe; positions, layout, hierarchy visible to reviewers. Prefer UXD 07 schema (canvas, regions, positions, hierarchy).
-- **Components:** Define which components each screen uses (UXD 03, UXD 07). Use catalog; prefer reuse; new components: name, category, props, register. Reusable where pattern appears 2+ times.
+- **Components:** Specify which components each screen uses (UXD 03, UXD 07), including names and key props. Prefer existing components before adding new ones.
+- **Decoupling:** Keep UI components/panels decoupled. For cross-component or cross-screen coordination, use typed events via `SPEC/program/app-event-bus.md` or shared state via Riverpod; avoid direct panel-to-panel orchestration.
 - **Behavior:** Define inputs, outputs, callbacks, user-visible outcomes; document in spec or interaction manifest (UXD 07).
 - **Pixel art:** Spec must define required images and generation spec (e.g. PixelLab: subject, size, type). Record **exact prompts** and asset dimensions in spec. **Check assets first** — do not regenerate if suitable asset exists (UXD 04, 05, 07).
 - **Style:** Follow UXD 02 (pixel canon, 1x grid, no AA, 16th/17th c. aesthetic, palette, typography).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,45 +1,42 @@
 # Agent instructions (ColonizeThis)
 
-This project uses **Cursor rules** as the source of truth for how to work in the codebase. Agents (including Cursor AI) should follow these rules when editing code, adding features, or reviewing.
+Cursor rules are the source of truth for implementation and review behavior.
 
-## Where the rules live
+## Rule location
 
-- **Path:** `.cursor/rules/`
-- **Format:** Markdown with optional front matter (`.mdc`). Each file describes one concern (SPEC, testing, UI, tools, etc.).
+- Path: `.cursor/rules/`
+- Format: Markdown `.mdc` with front matter (`description`, optional `globs`, `alwaysApply`)
 
 ## Always-applied rules
 
-These rules are applied in every context; follow them for all changes.
-
-| Rule file | Summary |
-|-----------|---------|
-| **colonizethis-spec-required.mdc** | SPEC-first: specify before implementing; no behavior that contradicts specs. GDD `SPEC/game/`, TDD `SPEC/program/`, AI `SPEC/ai/`, UI `SPEC/ui/` (sub-specs, max 1000 words). Source of truth: GDD for game/AI, TDD for architecture. Conflicts: resolve GDD/TDD first. Rulesets: configurable; specify where/how in GDD/TDD. New behavior: point to authorizing spec or add/extend spec first. |
-| **colonizethis-core-principles.mdc** | Stack: Flutter (UI), Flame (game/simulation), Dart. Strict typing, null safety, logger (no `print`). Thin screens; delegate to services/controllers/Flame. Province lookup: always use `(regionId, provinceId)` or prefixed id; never province id alone. **UI:** `SPEC/program/app-ui-wiring.md` (coupling, dialogs, routes); `SPEC/program/app-event-bus.md` (bus architecture). |
-| **colonizethis-logging-file.mdc** | Whenever file logging is needed, use **basic_logger_file** (BasicLogger + FileOutputLogger). Do not implement custom file logging (e.g. raw File/IOSink or manual log-to-file). |
+| Rule file | Focus |
+|-----------|-------|
+| `colonizethis-spec-required.mdc` | SPEC-first workflow and source-of-truth boundaries |
+| `colonizethis-core-principles.mdc` | Dart/Flutter/Flame coding principles and architecture boundaries |
+| `colonizethis-logging-file.mdc` | Required file logging approach (`basic_logger_file`) |
 
 ## Context-specific rules
 
-Apply these when working in the indicated areas (by path or topic).
+| Rule file | Applies to | Focus |
+|-----------|------------|-------|
+| `colonizethis-tools.mdc` | `tool/**` | Thin facades + Melos execution + docs |
+| `colonizethis-testing.mdc` | `**/*_test.dart`, `**/test/**/*.dart` | Test layers, critical paths, coverage policy |
+| `colonizethis-ui-design.mdc` | `SPEC/ui/**`, `**/lib/widgets/**`, `**/lib/ui/**` | UI specs, wireframes, Widgetbook/catalog, pixel-art process |
+| `colonizethis-component-structure.mdc` | `**/*.dart` | Folder conventions, extraction/reuse, naming |
+| `colonizethis-code-review.mdc` | `**/*.dart` | Review checklist and quality gates |
+| `colonizethis-lifecycle.mdc` | `**/*.dart` | Flame/Flutter lifecycle conventions |
+| `colonizethis-assets.mdc` | `**/*.dart`, `**/pubspec.yaml`, `**/assets/**` | Asset structure, naming, loading |
+| `colonizethis-tui.mdc` | `SPEC/tui/**`, `ctterm/**` | ctterm-specific behavior and constraints |
+| `colonizethis-acceptance-criteria.mdc` | `SPEC/ai/**`, `SPEC/game/**`, `SPEC/program/**`, `SPEC/ui/**` | Given–When–Then, testable AC quality |
 
-| Rule file | When to apply | Summary |
-|-----------|----------------|---------|
-| **colonizethis-tools.mdc** | `tool/**` | Tools are thin facades; logic lives in packages. Run from root via Melos: `melos run <tool_name> -- [args]`. Document in `docs/project-tools.md`. |
-| **colonizethis-testing.mdc** | `**/*_test.dart`, `**/test/**/*.dart` | 90% per-package coverage. Unit / widget / game-component layers. Mocks (mockito/mocktail). Critical paths: combat, economy, save/load, ruleset loading. |
-| **colonizethis-ui-design.mdc** | `SPEC/ui/**`, `**/lib/widgets/**`, `**/lib/ui/**` | Wireframes in UI spec; Widgetbook + widget catalog for components; pixel art via spec and PixelLab; UXD 02/03/04/05/07. Flame vs Flutter division. |
-| **colonizethis-component-structure.mdc** | `**/*.dart` | Folder layout: `lib/game/`, `lib/widgets/`, `lib/screens/`, etc. Reuse at 2+ places; Flame `*Component`, Flutter catalog + Widgetbook. |
-| **colonizethis-code-review.mdc** | `**/*.dart` | Checklist: function &lt; 20 lines, widget &lt; ~60 lines, no UI+logic mix, constants for strings, explicit types, spec alignment, logging, reuse, tests. |
-| **colonizethis-lifecycle.mdc** | `**/*.dart` | Flame: `onLoad` (init), `onMount`/`onRemove` (subscribe/cleanup), `update`/`render` (tick/paint). Flutter: `initState`/`dispose`. |
-| **colonizethis-assets.mdc** | `**/*.dart`, `**/pubspec.yaml`, `**/assets/**` | Asset dirs: `assets/images/`, `assets/audio/`, `assets/data/`. Snake_case naming. Load in Flame `onLoad()`; use caches. |
-| **colonizethis-tui.mdc** | `SPEC/tui/**`, `ctterm/**` | TUI (ctterm): SPEC/tui and ctterm.md source of truth; Given–When–Then for TUI AC; keyboard-first; Nocterm; log prefixes `tui:*`; province identity (prefixed id); no Flutter in ctterm. |
+## Quick reference
 
-## Quick reference for agents
+1. Check/extend SPEC first; implement only spec-authorized behavior.
+2. Keep Flutter UI and Flame simulation concerns separated.
+3. Prefer reuse; keep screens thin and delegate logic to services/controllers/components.
+4. Coverage policy: **90% for logic/ai/map packages; 80% everywhere else**.
+5. Run app/ctdev widget tests with `flutter test` (or `melos run test_app`), not `dart test app/...`.
+6. Use `logger` for runtime logs; use `basic_logger_file` for file logging.
+7. For cross-panel UI orchestration, use `AppEventBus` (`SPEC/program/app-ui-wiring.md`, `SPEC/program/app-event-bus.md`).
 
-1. **Before implementing:** Check GDD/TDD/UI spec; implement only what is specified; if missing, add or extend the spec first.
-2. **Code style:** Strict Dart, logger (no `print`), thin screens, single responsibility. Province lookup: always `(regionId, provinceId)` or prefixed id. Cross-panel UI: `SPEC/program/app-ui-wiring.md` + `SPEC/program/app-event-bus.md`.
-3. **When touching UI:** Wireframes in spec; Widgetbook + catalog; pixel art per UXD (exact prompts in spec; check assets first, don’t regenerate if suitable asset exists); Flame for canvas, Flutter for shell/overlays/menus.
-4. **When adding a tool:** Thin facade in `tool/<name>`; logic in packages; Melos script and `docs/project-tools.md` updated.
-5. **When writing tests:** 90% per package; unit/widget/game-component layers; cover combat, economy, save/load, ruleset loading. **App/ctdev widget tests:** run with `flutter test` from app/ (or `melos run test_app`); do not use `dart test app/...`.
-6. **When file logging:** Use **basic_logger_file** (BasicLogger + FileOutputLogger); do not implement custom file logging.
-7. **When reviewing/generating code:** Use the code-review checklist (lengths, types, spec, logging, reuse, tests).
-
-For full text of each rule, read the files in `.cursor/rules/`.
+For complete details, read the relevant rule file(s) in `.cursor/rules/`.


### PR DESCRIPTION
## Summary
- trim AGENTS.md into a concise index of rule ownership and include the missing acceptance-criteria rule
- reduce duplicated policy wording across rule files while keeping canonical guidance in spec/core/testing/ui rules
- clarify coverage policy to 90% for logic/ai/map packages and 80% elsewhere, fix TUI front-matter globs, and add explicit UI decoupling guidance (AppEventBus or Riverpod)

## Test plan
- [x] Review rendered diffs for AGENTS and all touched `.cursor/rules/*.mdc` files
- [x] Verify no behavioral/runtime code changes were introduced (docs/rules only)
- [ ] Optional: validate Cursor rule loading behavior in editor against updated front matter

Made with [Cursor](https://cursor.com)