### PR TITLE
refactor(topology): remove unused seaZoneId from topology inference

### DIFF
--- a/SPEC/program/tile-map-gen-resources.md
+++ b/SPEC/program/tile-map-gen-resources.md
@@ -28,7 +28,7 @@ Assign resources and provinces to land, subdivide sea zones, infer topology.
 
 ## Topology inference
 
-After all passes: `MapTopology inferTopologyFromTileMap(TileMapResult result, String regionId, String seaZoneId)`. Unique region ids from grid. **Node type:** s+digits → sea zone; p+digits → province. Edges from `TileMapResult.adjacentRegionPairs()`.
+After all passes: `MapTopology inferTopologyFromTileMap(TileMapResult result, String regionId)`. Unique region ids from grid. **Node type:** s+digits → sea zone; p+digits → province. Edges from `TileMapResult.adjacentRegionPairs()`.
 
 ---
 

--- a/packages/colonizethis_map/lib/src/tile_map_generator.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator.dart
@@ -543,7 +543,7 @@ class TileMapGenerator {
       terrainGrid: terrainGrid,
       resourceGrid: resourceGrid,
     );
-    final topology = inferTopologyFromTileMap(result, regionId, seaZoneId);
+    final topology = inferTopologyFromTileMap(result, regionId);
     _log.i(
       'TileMapGenerator.generate end regionId=$regionId provinces=${topology.nodes.where((n) => n.type == TopologyNodeType.province).length}',
     );

--- a/packages/colonizethis_map/lib/src/topology_inference.dart
+++ b/packages/colonizethis_map/lib/src/topology_inference.dart
@@ -7,7 +7,6 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 MapTopology inferTopologyFromTileMap(
   TileMapResult result,
   String regionId,
-  String seaZoneId,
 ) {
   final ids = <String>{};
   for (var y = 0; y < result.height; y++) {

--- a/packages/colonizethis_map/test/topology_inference_test.dart
+++ b/packages/colonizethis_map/test/topology_inference_test.dart
@@ -13,7 +13,7 @@ void main() {
           ['p2', 'p2', 's1'],
         ],
       );
-      final topology = inferTopologyFromTileMap(result, 'oldWorld', 's1');
+      final topology = inferTopologyFromTileMap(result, 'oldWorld');
       final provinceIds = topology.nodes
           .where((n) => n.type == TopologyNodeType.province)
           .map((n) => n.id)
@@ -36,7 +36,7 @@ void main() {
           ['p2', 'p2', 's1'],
         ],
       );
-      final topology = inferTopologyFromTileMap(result, 'oldWorld', 's1');
+      final topology = inferTopologyFromTileMap(result, 'oldWorld');
       final edgeSet = <String>{};
       for (final e in topology.edges) {
         final key = e.id1.compareTo(e.id2) < 0 ? '${e.id1}|${e.id2}' : '${e.id2}|${e.id1}';


### PR DESCRIPTION
## Summary
- remove the unused `seaZoneId` parameter from `inferTopologyFromTileMap`
- update the generator callsite and topology inference tests to match the new signature
- align `SPEC/program/tile-map-gen-resources.md` topology inference signature with implementation

## Test plan
- [x] `dart test packages/colonizethis_map/test/topology_inference_test.dart`
- [x] previous targeted run also included `packages/colonizethis_map/test/tile_map_generator_test.dart`
- [x] manual search confirms no remaining 3-arg `inferTopologyFromTileMap(...)` callsites

Closes #281

Made with [Cursor](https://cursor.com)