### PR TITLE
fix(ctdev): sim order history for research and naval orders

### DIFF
--- a/ctdev/lib/sim_game_controller.dart
+++ b/ctdev/lib/sim_game_controller.dart
@@ -4,6 +4,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
+import 'package:meta/meta.dart';
 
 import 'ctdev_log.dart';
 
@@ -194,6 +195,12 @@ class SimGameController {
     for (var i = 0; i < turns; i++) {
       stepFullTurn();
     }
+  }
+
+  /// Resolves one turn from explicit [orders] (tests and scripted runs).
+  @visibleForTesting
+  void advanceTurnForTesting(Orders orders) {
+    _advanceOneTurnFromOrders(orders);
   }
 
   Orders _combineOrders(List<Orders> all) {
@@ -434,6 +441,60 @@ class SimGameController {
             playerName: player.displayName,
             orderType: 'diplomatic',
             summary: 'Diplomacy $typeLabel → $target$extra',
+            status: validation.status,
+            reason: validation.reason,
+          ),
+        );
+      }
+
+      // Research is not part of [OrderEngine.validatePlayerOrdersWithContext] results;
+      // resolution applies rules in the research phase. Log submissions for the Orders tab.
+      for (final o in research) {
+        final techLabel = o.techId.isEmpty
+            ? 'cancel slot'
+            : techDisplayName(o.techId);
+        _orderHistory.add(
+          SimOrderHistoryEntry(
+            turnNumber: currentTurn,
+            playerId: playerId,
+            playerName: player.displayName,
+            orderType: 'research',
+            summary:
+                'Research slot ${o.slotIndex}: $techLabel (${o.funding.name})',
+            status: OrderValidationStatus.accepted,
+            reason: null,
+          ),
+        );
+      }
+
+      for (final o in naval) {
+        final dest = o.isDock
+            ? 'dock ${o.destinationPortProvinceId}'
+            : 'sea ${o.destinationSeaZoneId}';
+        final validation = nextResult();
+        _orderHistory.add(
+          SimOrderHistoryEntry(
+            turnNumber: currentTurn,
+            playerId: playerId,
+            playerName: player.displayName,
+            orderType: 'naval_move',
+            summary: 'Naval move fleet ${o.fleetId} → $dest',
+            status: validation.status,
+            reason: validation.reason,
+          ),
+        );
+      }
+
+      for (final o in mission) {
+        final target = o.targetProvinceId ?? o.targetPortId ?? '—';
+        final validation = nextResult();
+        _orderHistory.add(
+          SimOrderHistoryEntry(
+            turnNumber: currentTurn,
+            playerId: playerId,
+            playerName: player.displayName,
+            orderType: 'naval_mission',
+            summary: 'Naval mission fleet ${o.fleetId}: ${o.mission} ($target)',
             status: validation.status,
             reason: validation.reason,
           ),

--- a/ctdev/test/sim_game_controller_test.dart
+++ b/ctdev/test/sim_game_controller_test.dart
@@ -1,3 +1,4 @@
+import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -178,6 +179,133 @@ void main() {
         expect(entry.turnNumber, 0);
         expect(entry.playerId, 'p1');
       }
+    });
+
+    test('order history records research and naval validation results', () {
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(
+            id: 'P1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'P2',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+        ],
+        edges: const [
+          TopologyEdge(id1: 'P1', id2: 'P2'),
+        ],
+      );
+
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'oldWorld|P1', regionId: 'oldWorld', ownerId: 'p1'),
+              Province(id: 'oldWorld|P2', regionId: 'oldWorld', ownerId: 'p1'),
+            ],
+            units: [
+              Unit(
+                id: 'u1',
+                type: 'grenadiers',
+                ownerId: 'p1',
+                locationProvinceId: 'oldWorld|P1',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            'p1': {
+              'oldWorld|P1|0|0': 'fullyVisible',
+              'oldWorld|P2|0|0': 'fullyVisible',
+            },
+          },
+        ),
+        players: const [
+          Player(
+            id: 'p1',
+            displayName: 'Power 1',
+            isHuman: true,
+            researchSlots: 2,
+          ),
+        ],
+      );
+
+      final tileMapByRegion = <String, TileMapResult>{
+        'oldWorld': TileMapResult(
+          width: 1,
+          height: 2,
+          grid: const [
+            ['P1'],
+            ['P2'],
+          ],
+          resourceGrid: const [
+            [Resource.grain],
+            [Resource.grain],
+          ],
+        ),
+        'newWorld': TileMapResult(
+          width: 0,
+          height: 0,
+          grid: const [],
+          resourceGrid: const [],
+        ),
+      };
+
+      final controller = SimGameController(
+        initialGame: game,
+        topology: topology,
+        tileMapByRegion: tileMapByRegion,
+        baseSeed: 123,
+      );
+
+      final orders = Orders(
+        moveOrdersByPlayerId: {
+          'p1': [
+            MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|P2'),
+          ],
+        },
+        researchOrdersByPlayerId: {
+          'p1': [
+            ResearchOrder(
+              slotIndex: 0,
+              techId: 'printing_press',
+              funding: ResearchFundingLevel.low,
+            ),
+          ],
+        },
+        navalMoveOrdersByPlayerId: {
+          'p1': [
+            NavalMoveOrder(
+              fleetId: 'no_such_fleet',
+              destinationSeaZoneId: 'sz1',
+            ),
+          ],
+        },
+      );
+
+      controller.advanceTurnForTesting(orders);
+
+      final researchEntries =
+          controller.orderHistory.where((e) => e.orderType == 'research').toList();
+      expect(researchEntries, hasLength(1));
+      expect(researchEntries.single.summary, contains('Printing Press'));
+      expect(researchEntries.single.status, OrderValidationStatus.accepted);
+
+      final navalEntries =
+          controller.orderHistory.where((e) => e.orderType == 'naval_move').toList();
+      expect(navalEntries, hasLength(1));
+      expect(navalEntries.single.status, OrderValidationStatus.rejected);
+
+      final moveEntries =
+          controller.orderHistory.where((e) => e.orderType == 'move').toList();
+      expect(moveEntries, hasLength(1));
+      expect(moveEntries.single.status, OrderValidationStatus.accepted);
     });
   });
 }


### PR DESCRIPTION
## Summary

Extends `SimGameController._recordOrderHistory` so the Running Game **Orders** tab matches what the order engine validates:

- **Naval move** and **naval mission** rows are appended with `nextResult()`, so status and reason come from `NavalOrderValidator` (same order as `validatePlayerOrdersWithContext`).
- **Research** rows are appended after diplomatic orders for visibility. Research is not part of engine validation (the research phase applies rules), so rows use `accepted` as a submission log.

Adds `@visibleForTesting void advanceTurnForTesting(Orders)` and a unit test that exercises move + research + a rejected naval move.

## Testing

`cd ctdev && flutter test test/sim_game_controller_test.dart`

## Refs

- Closes the **order history** portion of #127 (comment already posted on that issue).

Made with [Cursor](https://cursor.com)