### PR TITLE
fix: sim_economy counts master labour; single-source tier rates (#239)

### DIFF
--- a/packages/colonizethis_logic/lib/src/economy/worker_economy.dart
+++ b/packages/colonizethis_logic/lib/src/economy/worker_economy.dart
@@ -10,7 +10,8 @@ int effectiveLabourForWorkers({
   required WorkerPool workers,
   required Stockpile stockpile,
 }) {
-  final peasantsLabour = workers.peasants * 1;
+  final peasantsLabour =
+      workers.peasants * WorkerPool.labourPerPeasantTurn;
 
   final refinedSugar = stockpile.quantityOf(CommodityCatalog.refinedSugar.id);
   final cigars = stockpile.quantityOf(CommodityCatalog.cigars.id);
@@ -29,9 +30,9 @@ int effectiveLabourForWorkers({
       : (furHats < workers.masters ? furHats : workers.masters);
 
   return peasantsLabour +
-      apprenticesWithLuxury * 4 +
-      journeymenWithLuxury * 6 +
-      mastersWithLuxury * 8;
+      apprenticesWithLuxury * WorkerPool.labourPerApprenticeTurn +
+      journeymenWithLuxury * WorkerPool.labourPerJourneymanTurn +
+      mastersWithLuxury * WorkerPool.labourPerMasterTurn;
 }
 
 /// Consumes up to [required] food units (grain/meat) from [stockpile].

--- a/packages/colonizethis_models/lib/src/worker_pool.dart
+++ b/packages/colonizethis_models/lib/src/worker_pool.dart
@@ -22,6 +22,22 @@ class WorkerPool {
 
   static const empty = WorkerPool();
 
+  /// Labour per trained worker per turn (GDD Worker Tiers table).
+  static const int labourPerPeasantTurn = 1;
+  static const int labourPerApprenticeTurn = 4;
+  static const int labourPerJourneymanTurn = 6;
+  static const int labourPerMasterTurn = 8;
+
+  /// Raw labour supply per turn from all tiers (sum of tier × count).
+  ///
+  /// Does not apply luxury gating; see `effectiveLabourForWorkers` in
+  /// `colonizethis_logic` for production-time effective labour.
+  int get labourSupplyPerTurn =>
+      peasants * labourPerPeasantTurn +
+      apprentices * labourPerApprenticeTurn +
+      journeymen * labourPerJourneymanTurn +
+      masters * labourPerMasterTurn;
+
   WorkerPool copyWith({
     int? peasants,
     int? apprentices,

--- a/packages/colonizethis_models/test/worker_pool_test.dart
+++ b/packages/colonizethis_models/test/worker_pool_test.dart
@@ -41,6 +41,27 @@ void main() {
       expect(pool.journeymen, 0);
       expect(pool.masters, 0);
     });
+
+    test('labourSupplyPerTurn sums GDD tier labour (incl. masters)', () {
+      const pool = WorkerPool(
+        peasants: 1,
+        apprentices: 1,
+        journeymen: 1,
+        masters: 1,
+      );
+      expect(
+        pool.labourSupplyPerTurn,
+        WorkerPool.labourPerPeasantTurn +
+            WorkerPool.labourPerApprenticeTurn +
+            WorkerPool.labourPerJourneymanTurn +
+            WorkerPool.labourPerMasterTurn,
+      );
+      const mastersOnly = WorkerPool(masters: 2);
+      expect(
+        mastersOnly.labourSupplyPerTurn,
+        2 * WorkerPool.labourPerMasterTurn,
+      );
+    });
   });
 }
 

--- a/tool/sim_economy/bin/sim_economy.dart
+++ b/tool/sim_economy/bin/sim_economy.dart
@@ -664,8 +664,7 @@ List<AssignedRecipe> _defaultAssignments(
   Random rng,
 ) {
   // Simple baseline: distribute a fixed amount of labour to core recipes.
-  final totalLabour =
-      workers.peasants * 1 + workers.apprentices * 4 + workers.journeymen * 6;
+  final totalLabour = workers.labourSupplyPerTurn;
   if (totalLabour <= 0) return const [];
 
   final toFabric = (totalLabour * 0.4).round();


### PR DESCRIPTION
## Summary
Closes the concrete bug in [#239](https://github.com/waigore/colonizethisv3/issues/239): `sim_economy` `_defaultAssignments` ignored master-tier labour (8/turn per GDD).

## Changes
- **WorkerPool** (`colonizethis_models`): static tier labour constants (1/4/6/8) and `labourSupplyPerTurn` getter (raw sum; luxury gating remains in logic).
- **sim_economy**: default assignment labour budget uses `workers.labourSupplyPerTurn`.
- **effectiveLabourForWorkers**: uses the same constants so multipliers stay in one place.

## Tests
- `dart test` in `packages/colonizethis_models` (new `labourSupplyPerTurn` test).
- `dart test` in `tool/sim_economy`.
- `dart test test/economy_logic_test.dart test/economy_production_test.dart` in `packages/colonizethis_logic`.

Fixes #239.

Made with [Cursor](https://cursor.com)