### PR TITLE
feat(ctdev): Running Game diplomacy, combat log, projections, fleet map (#127)

### DIFF
--- a/SPEC/program/ctdev-app-running-game.md
+++ b/SPEC/program/ctdev-app-running-game.md
@@ -16,10 +16,10 @@ Reached via Start Game (Sim) from Init Game Map Debug. User may navigate back to
 
 | Tab | Content |
 |-----|---------|
-| **Map** | OW + NW. Sub-views: **Default** (ownership/geographic, capitals, ports); **Improvements** (per-tile improvement and transport level); **Units** (army markers per province per player). Fleet/navy state (locations, mission icons). |
-| **Game Overview** | Turn, year; owned province list per GP; military strength ([military-strength.md](military-strength.md)); diplomatic states. **Turn seed** `turnSeed[P, T]` per GP for reproducibility. |
-| **Orders (AI history)** | Per-turn, per-GP scrollable view: movement, build, work, diplomatic, naval orders; validation status (accepted/rejected + reason) per [order-engine.md](order-engine.md). Naval combat outcomes when applicable. |
-| **Player (GP) tabs** | One tab per GP. Per-player map via [player-view.md](player-view.md): Unknown (black), Revealed (grey), Fogged (ownership + grey stripes), Fully visible. Only viewing player's units. Below map: stockpiles, `techUnlocked` (stubs: `currentResearchTechId`, `researchableTechIds`); expected extraction/production ([order-projections.md](order-projections.md)); pending orders; available orders ([order-engine.md](order-engine.md)). |
+| **Map** | OW + NW. Sub-views: **Default** (ownership/geographic, capitals, ports); **Improvements** (per-tile improvement and transport level); **Units** (army markers per province per player **and** fleet markers: triangle + mission letter per [ships-and-naval.md](../game/ships-and-naval.md), same toggle as armies). |
+| **Game Overview** | Turn, year; owned province list per GP; military strength ([military-strength.md](military-strength.md)); **Diplomacy:** every row in `Game.diplomacyRelations` (faction display names, `RelationState`, `RelationLevel`, score). Undiscovered cross-region pairs are not stored as relations and do not appear. **Last turn combat:** land + naval summary lines from the most recent resolve (see Display and Logging). **Turn seed** `turnSeed[P, T]` per GP for reproducibility. |
+| **Orders (AI history)** | Per-turn, per-GP scrollable view: movement, build, work, diplomatic, research, naval move/mission orders; validation status (accepted/rejected + reason) per [order-engine.md](order-engine.md). Combat narratives: **Overview** and **Sim Log**, not this tab. |
+| **Player (GP) tabs** | One tab per GP. Per-player map via [player-view.md](player-view.md): Unknown (black), Revealed (grey), Fogged (ownership + grey stripes), Fully visible. Only viewing player's units **and** that player's fleets when **Units** is on. Below map: **Projected end of turn** via [order-projections.md](order-projections.md) (`projectOrderEffects`) when any GP has pending orders (empty `Orders` for GPs not yet filled this turn); stockpiles; `techUnlocked`; pending orders; available orders ([order-engine.md](order-engine.md)). |
 
 All tabs read from `SimGameController.game` and `pendingOrdersByPlayerId`; refresh on Next Player / Next Turn.
 
@@ -33,7 +33,7 @@ AI choice made on Init Map Debug before Start Game. **Player-by-player:** Next P
 
 ## Display and Logging
 
-After each resolved turn: map updates from `Game.worldState`; panel shows turn/year, land combat events (province, sides, winner, casualties, flips), naval combat events. Fast-forward 10 may compress to summary.
+After each resolved turn: map updates from `Game.worldState`. **Land combat:** `CombatResultEvent` from the Combat phase → one human-readable line per battle (province, attacker, defender, winner, optional casualties). **Naval combat:** `NavalCombatResultEvent` from the naval interception phase → one line per battle (sea zone, sides, outcome, optional winner, retreats). **Game Overview** repeats the same lines under **Last turn combat** for the turn just resolved. **In-memory Sim Log** receives these lines via `Logger().i('ctdev: …')` (info+), so they appear in the rolling UI log alongside other ctdev messages. Province ownership flips continue to be logged as today. Fast-forward 10 does not change event shape (one line per battle per turn).
 
 **In-memory Sim Log:** Last 10 lines at info+; cleared at start of each turn. Full detail in session log file ([ctdev-logging.md](ctdev-logging.md)).
 

--- a/SPEC/program/game-events.md
+++ b/SPEC/program/game-events.md
@@ -23,13 +23,14 @@ Events are a union or sealed type (e.g. `GameEvent`) with variants. Payloads use
 | Event type           | When emitted                    | Payload (minimal) |
 |----------------------|----------------------------------|-------------------|
 | `combat_result`      | After Combat phase              | provinceId (prefixed), attackerId, defenderId, winnerId, casualties (or summary). |
+| `naval_combat_result` | After each resolved sea battle in Naval interception phase | seaZoneId (local, e.g. s3), side1OwnerId, side2OwnerId, outcomeName (`NavalBattleOutcome.name`), turnNumber, optional winnerOwnerId, retreat flags. |
 | `province_captured`  | When province owner changes     | provinceId (prefixed), previousOwnerId, newOwnerId, turnNumber. |
 | `diplomacy_change`   | After Diplomacy phase           | actorId, targetId, changeType (e.g. war, peace, alliance), turnNumber. |
 | `research_complete`   | When a tech is researched      | playerId, techId, turnNumber. |
 | `victory_set`        | End-of-turn when victory set    | winnerPlayerId, victoryType, turnNumber. See [victory.md](../game/victory.md). |
 | `order_rejected`     | On validation failure          | playerId, orderSummaryOrId, reasonCode (e.g. insufficient_treasury, invalid_destination). |
 
-Additional event types (e.g. naval_combat_result, extraction_summary) may be added in the same format. Dialogue and mood ([ai-events-and-dossier.md](ai-events-and-dossier.md)) may be a separate channel or folded into this stream; the emitter guarantees a single, ordered stream per game/turn so consumers can present a chronological feed.
+Additional event types (e.g. extraction_summary) may be added in the same format. Dialogue and mood ([ai-events-and-dossier.md](ai-events-and-dossier.md)) may be a separate channel or folded into this stream; the emitter guarantees a single, ordered stream per game/turn so consumers can present a chronological feed.
 
 ---
 
@@ -53,6 +54,7 @@ The **caller** that owns the order list or invokes TurnResolver is responsible f
 ## Acceptance criteria (Given–When–Then)
 
 - **Emission — combat_result.** Given a turn resolution run in which the Combat phase resolves a battle in province P with a winner, when the Combat phase completes, then the system emits exactly one `combat_result` event with provinceId in prefixed form, and the payload includes winnerId and at least one of attackerId or defenderId consistent with the resolved battle.
+- **Emission — naval_combat_result.** Given the Naval interception phase resolves a sea battle in zone Z, when that battle’s resolution completes, then the system emits exactly one `naval_combat_result` event with seaZoneId, both side owner ids, outcomeName, turnNumber, and winnerOwnerId when the outcome is a decisive victory for one side.
 - **Emission — victory_set.** Given a turn resolution run in which the End-of-turn phase sets `Game.victory` (winner, type military, turn number), when the End-of-turn phase completes, then the system emits exactly one `victory_set` event with winnerPlayerId, victoryType, and turnNumber equal to the game’s victory state.
 - **Emission — order_rejected.** Given the order engine validates a player’s order list and the first rejection occurs at order N with reason R, when validation returns, then the system has emitted an `order_rejected` event for that order with a reasonCode consistent with R (or the validation layer exposes the same so that a consumer can emit the event).
 - **Determinism.** Given the same Game (and WorldState), same per-player order lists, same ruleset, and same seeds, when the system runs turn resolution and order validation, then the sequence of GameEvents emitted for that run is identical to any other run with the same inputs.

--- a/SPEC/program/order-projections.md
+++ b/SPEC/program/order-projections.md
@@ -49,6 +49,8 @@ Optionally, when feasible (currently deferred; fields exist on `ProjectedEffects
 
 When projecting for a single player: merge that player's orders with empty or placeholder orders for other players so the dry-run can complete. Cross-player effects (combat, diplomacy) require merged orders from all players. For build/work-only feedback, per-player projection in isolation may suffice if the API supports it.
 
+**ctdev Running Game:** For each GP tab, `SimGameController` builds one merged `Orders` value: for every Great Power, use that GP’s entry in `pendingOrdersByPlayerId` if present, otherwise `Orders()` (all maps empty). Then call `projectOrderEffects(..., playerId: <viewed GP>)`. If no GP has any pending orders yet for the turn, the UI shows no projection (em dash).
+
 ---
 
 ## Determinism

--- a/ctdev/lib/debug_map_painter.dart
+++ b/ctdev/lib/debug_map_painter.dart
@@ -2,7 +2,10 @@ import 'dart:math' as math;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
+
+import 'fleet_map_overlay.dart';
 
 /// Visual scale factor applied to logical cellSize from RegionMapViewData.
 /// Default 0.25 so both regions fit side-by-side in a typical viewport; zoom min 0.25.
@@ -19,6 +22,7 @@ class RegionMapPainter extends CustomPainter {
     this.geographicMode = false,
     this.showImprovements = false,
     this.showUnits = false,
+    this.fleets = const [],
     this.selectedX,
     this.selectedY,
   });
@@ -31,6 +35,8 @@ class RegionMapPainter extends CustomPainter {
   final bool geographicMode;
   final bool showImprovements;
   final bool showUnits;
+  /// When [showUnits] is true, drawn as triangles (same toggle as armies).
+  final List<Fleet> fleets;
   final int? selectedX;
   final int? selectedY;
 
@@ -132,6 +138,10 @@ class RegionMapPainter extends CustomPainter {
         canvas.drawCircle(Offset(cx, cy), radius, fillPaint);
         canvas.drawCircle(Offset(cx, cy), radius, strokePaint);
       }
+    }
+
+    if (showUnits && fleets.isNotEmpty) {
+      paintFleetsForRegion(canvas, region, fleets, cellSize);
     }
 
     // Improvements overlay: improvement level (0-4) and road level on land tiles.
@@ -276,6 +286,7 @@ class RegionMapPainter extends CustomPainter {
         oldDelegate.geographicMode != geographicMode ||
         oldDelegate.showImprovements != showImprovements ||
         oldDelegate.showUnits != showUnits ||
+        oldDelegate.fleets != fleets ||
         oldDelegate.selectedX != selectedX ||
         oldDelegate.selectedY != selectedY;
   }
@@ -290,6 +301,7 @@ class CombinedMapPainter extends CustomPainter {
     this.geographicMode = false,
     this.showImprovements = false,
     this.showUnits = false,
+    this.fleets = const [],
     this.selectedRegionId,
     this.selectedX,
     this.selectedY,
@@ -302,6 +314,7 @@ class CombinedMapPainter extends CustomPainter {
   final bool geographicMode;
   final bool showImprovements;
   final bool showUnits;
+  final List<Fleet> fleets;
   final String? selectedRegionId;
   final int? selectedX;
   final int? selectedY;
@@ -324,6 +337,7 @@ class CombinedMapPainter extends CustomPainter {
       geographicMode: geographicMode,
       showImprovements: showImprovements,
       showUnits: showUnits,
+      fleets: fleets,
       selectedX:
           selectedRegionId == ow.regionId ? selectedX : null,
       selectedY:
@@ -345,6 +359,7 @@ class CombinedMapPainter extends CustomPainter {
       geographicMode: geographicMode,
       showImprovements: showImprovements,
       showUnits: showUnits,
+      fleets: fleets,
       selectedX:
           selectedRegionId == nw.regionId ? selectedX : null,
       selectedY:
@@ -366,6 +381,7 @@ class CombinedMapPainter extends CustomPainter {
         oldDelegate.geographicMode != geographicMode ||
         oldDelegate.showImprovements != showImprovements ||
         oldDelegate.showUnits != showUnits ||
+        oldDelegate.fleets != fleets ||
         oldDelegate.selectedRegionId != selectedRegionId ||
         oldDelegate.selectedX != selectedX ||
         oldDelegate.selectedY != selectedY;

--- a/ctdev/lib/fleet_map_overlay.dart
+++ b/ctdev/lib/fleet_map_overlay.dart
@@ -1,0 +1,128 @@
+// Fleet markers on debug / player-view maps when Units overlay is on.
+// SPEC/program/ctdev-app-running-game.md.
+
+import 'dart:math' as math;
+
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+
+/// Paints triangles for [fleets] in [region] (same toggle as army unit dots).
+void paintFleetsForRegion(
+  Canvas canvas,
+  RegionMapViewData region,
+  List<Fleet> fleets,
+  double cellSize,
+) {
+  for (final f in fleets) {
+    if (f.regionId != region.regionId) continue;
+    final centroid = fleetCentroidCell(region, f);
+    if (centroid == null) continue;
+    final cx = centroid.$1 * cellSize + cellSize / 2;
+    final cy = centroid.$2 * cellSize + cellSize / 2;
+    final colorTuple =
+        region.factionColors[f.ownerId] ?? (128, 128, 128);
+    final fillPaint = Paint()
+      ..style = PaintingStyle.fill
+      ..color = Color.fromARGB(
+        255,
+        colorTuple.$1,
+        colorTuple.$2,
+        colorTuple.$3,
+      );
+    final strokePaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1
+      ..color = Colors.black;
+    const r = 6.0;
+    final path = Path()
+      ..moveTo(cx, cy - r)
+      ..lineTo(cx - r * 0.9, cy + r * 0.75)
+      ..lineTo(cx + r * 0.9, cy + r * 0.75)
+      ..close();
+    canvas.drawPath(path, fillPaint);
+    canvas.drawPath(path, strokePaint);
+
+    final letter = _missionLetter(f.mission);
+    final textPainter = TextPainter(
+      text: TextSpan(
+        text: letter,
+        style: TextStyle(
+          color: Colors.white,
+          fontSize: math.max(6, cellSize * 0.35),
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    textPainter.paint(
+      canvas,
+      Offset(
+        cx - textPainter.width / 2,
+        cy - textPainter.height / 2 - 1,
+      ),
+    );
+  }
+}
+
+String _missionLetter(FleetMission m) => switch (m) {
+      FleetMission.none => '·',
+      FleetMission.patrol => 'P',
+      FleetMission.blockade => 'B',
+      FleetMission.beachhead => 'H',
+      FleetMission.defend => 'D',
+    };
+
+/// Cell coordinates (x, y) for fleet marker, or null if not placed.
+(int, int)? fleetCentroidCell(RegionMapViewData region, Fleet fleet) {
+  final sea = fleet.seaZoneId;
+  if (sea != null) {
+    var sx = 0;
+    var sy = 0;
+    var n = 0;
+    for (final c in region.cells) {
+      if (c.isSea && c.regionCellId == sea) {
+        sx += c.x;
+        sy += c.y;
+        n++;
+      }
+    }
+    if (n == 0) return null;
+    return (sx ~/ n, sy ~/ n);
+  }
+  final port = fleet.inPortAtProvinceId;
+  if (port == null) return null;
+  final local = _localProvinceIdForRegion(port, fleet.regionId);
+  if (local == null) return null;
+
+  for (final pm in region.portMarkers) {
+    if (_provinceIdsEqual(pm.provinceId, local)) {
+      return (pm.x, pm.y);
+    }
+  }
+
+  var sx = 0;
+  var sy = 0;
+  var n = 0;
+  for (final c in region.cells) {
+    if (c.isSea) continue;
+    if (_provinceIdsEqual(c.regionCellId, local)) {
+      sx += c.x;
+      sy += c.y;
+      n++;
+    }
+  }
+  if (n == 0) return null;
+  return (sx ~/ n, sy ~/ n);
+}
+
+String? _localProvinceIdForRegion(String prefixedOrLocal, String regionId) {
+  final idx = prefixedOrLocal.indexOf('|');
+  if (idx < 0) return prefixedOrLocal;
+  final reg = prefixedOrLocal.substring(0, idx);
+  if (reg != regionId) return null;
+  return prefixedOrLocal.substring(idx + 1);
+}
+
+bool _provinceIdsEqual(String a, String b) =>
+    a.toLowerCase() == b.toLowerCase();

--- a/ctdev/lib/player_view_map_painter.dart
+++ b/ctdev/lib/player_view_map_painter.dart
@@ -3,9 +3,11 @@ import 'dart:math' as math;
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
 import 'debug_map_painter.dart';
+import 'fleet_map_overlay.dart';
 
 /// Builds the tile key for a cell in a region. Format: regionId|provinceId|x|y.
 String tileKeyForCell(RegionMapViewData region, CellViewData cell) {
@@ -25,6 +27,7 @@ class PlayerViewMapPainter extends CustomPainter {
     this.geographicMode = false,
     this.showImprovements = false,
     this.showUnits = true,
+    this.fleets = const [],
   });
 
   final InitGameMapViewData viewData;
@@ -35,6 +38,7 @@ class PlayerViewMapPainter extends CustomPainter {
   final bool geographicMode;
   final bool showImprovements;
   final bool showUnits;
+  final List<Fleet> fleets;
 
   static const Color _unknownColor = Colors.black;
   static const Color _revealedColor = Color(0xFF606060);
@@ -52,7 +56,12 @@ class PlayerViewMapPainter extends CustomPainter {
     final gap = cellSize * 2;
     final owWidthPx = ow.width * cellSize;
 
-    _paintRegion(canvas, ow, cellSize, Size(owWidthPx, ow.height * cellSize));
+    _paintRegion(
+      canvas,
+      ow,
+      cellSize,
+      Size(owWidthPx, ow.height * cellSize),
+    );
     canvas.save();
     canvas.translate(owWidthPx + gap, 0);
     _paintRegion(
@@ -64,7 +73,12 @@ class PlayerViewMapPainter extends CustomPainter {
     canvas.restore();
   }
 
-  void _paintRegion(Canvas canvas, RegionMapViewData region, double cellSize, Size size) {
+  void _paintRegion(
+    Canvas canvas,
+    RegionMapViewData region,
+    double cellSize,
+    Size size,
+  ) {
     final fillPaint = Paint()..style = PaintingStyle.fill;
 
     for (final cell in region.cells) {
@@ -178,6 +192,18 @@ class PlayerViewMapPainter extends CustomPainter {
         const radius = 5.0;
         canvas.drawCircle(Offset(cx, cy), radius, fillPaint);
         canvas.drawCircle(Offset(cx, cy), radius, strokePaint);
+      }
+    }
+
+    if (showUnits && fleets.isNotEmpty) {
+      final mine = fleets
+          .where(
+            (f) =>
+                f.regionId == region.regionId && f.ownerId == playerView.playerId,
+          )
+          .toList();
+      if (mine.isNotEmpty) {
+        paintFleetsForRegion(canvas, region, mine, cellSize);
       }
     }
 
@@ -344,6 +370,7 @@ class PlayerViewMapPainter extends CustomPainter {
         oldDelegate.showPorts != showPorts ||
         oldDelegate.geographicMode != geographicMode ||
         oldDelegate.showImprovements != showImprovements ||
-        oldDelegate.showUnits != showUnits;
+        oldDelegate.showUnits != showUnits ||
+        oldDelegate.fleets != fleets;
   }
 }

--- a/ctdev/lib/screens/running_game_screen.dart
+++ b/ctdev/lib/screens/running_game_screen.dart
@@ -316,6 +316,7 @@ class _RunningGameScreenState extends State<RunningGameScreen>
                   geographicMode: _geographicMode,
                   showImprovements: _showImprovements,
                   showUnits: _showUnits,
+                  fleets: _controller.game.worldState.fleets,
                 ),
               ),
             ),
@@ -364,6 +365,43 @@ class _RunningGameScreenState extends State<RunningGameScreen>
             final str = aggregateMilitaryStrengthForPlayer(game, p.id);
             return Text('${p.displayName}: ${str.toStringAsFixed(1)}');
           }),
+          const SizedBox(height: 16),
+          const Text('Diplomacy', style: TextStyle(fontWeight: FontWeight.bold)),
+          const SizedBox(height: 4),
+          if (game.diplomacyRelations.isEmpty)
+            const Text('—')
+          else
+            ...() {
+              final rels = List<DiplomacyRelation>.from(game.diplomacyRelations)
+                ..sort((a, b) {
+                  final c = a.factionId1.compareTo(b.factionId1);
+                  return c != 0 ? c : a.factionId2.compareTo(b.factionId2);
+                });
+              return rels
+                  .map(
+                    (rel) => Padding(
+                      padding: const EdgeInsets.only(bottom: 4),
+                      child: Text(
+                        '${_ctdevFactionLabel(game, rel.factionId1)} ↔ '
+                        '${_ctdevFactionLabel(game, rel.factionId2)}: '
+                        '${rel.state.name}, ${rel.level.name}, score=${rel.score}',
+                      ),
+                    ),
+                  )
+                  .toList();
+            }(),
+          const SizedBox(height: 16),
+          const Text('Last turn combat', style: TextStyle(fontWeight: FontWeight.bold)),
+          const SizedBox(height: 4),
+          if (_controller.lastTurnCombatSummaries.isEmpty)
+            const Text('—')
+          else
+            ..._controller.lastTurnCombatSummaries.map(
+              (s) => Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Text(s),
+              ),
+            ),
           const SizedBox(height: 16),
           const Text('Sim Log', style: TextStyle(fontWeight: FontWeight.bold)),
           const SizedBox(height: 4),
@@ -548,9 +586,20 @@ class _RunningGameScreenState extends State<RunningGameScreen>
                 geographicMode: _geographicMode,
                 showImprovements: _showImprovements,
                 showUnits: _showUnits,
+                fleets: game.worldState.fleets,
               ),
             ),
           ),
+          const SizedBox(height: 16),
+          const Text(
+            'Projected end of turn (pending orders)',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 4),
+          if (!_controller.hasPendingOrdersForProjection)
+            const Text('— (no pending orders for this turn)')
+          else
+            _buildProjectedEffectsForPlayer(player),
           const SizedBox(height: 16),
           const Text('Stockpile', style: TextStyle(fontWeight: FontWeight.bold)),
           Text(player.stockpile.quantities.isEmpty
@@ -702,6 +751,49 @@ class _RunningGameScreenState extends State<RunningGameScreen>
     );
   }
 
+  Widget _buildProjectedEffectsForPlayer(Player player) {
+    final fx = _controller.projectedEffectsForPlayer(player.id);
+    if (fx == null) {
+      return const Text('—');
+    }
+    final lines = <String>[];
+    if (fx.workerCount != null) {
+      lines.add('Workers after resolve: ${fx.workerCount}');
+    }
+    if (fx.treasuryDelta != null && fx.treasuryDelta != 0) {
+      lines.add('Treasury Δ: ${fx.treasuryDelta}');
+    }
+    if (fx.stockpileDeltas != null && fx.stockpileDeltas!.isNotEmpty) {
+      lines.add(
+        'Stockpile Δ: '
+        '${fx.stockpileDeltas!.entries.map((e) => '${e.key}:${e.value}').join(', ')}',
+      );
+    }
+    if (fx.unitLocations != null && fx.unitLocations!.isNotEmpty) {
+      final entries = fx.unitLocations!.entries.toList();
+      const maxU = 12;
+      final shown = entries.take(maxU).map((e) => '${e.key}→${e.value}').join('; ');
+      final more = entries.length > maxU ? ' …' : '';
+      lines.add('Unit provinces: $shown$more');
+    }
+    if (fx.productionByRecipe != null && fx.productionByRecipe!.isNotEmpty) {
+      lines.add(
+        'Production: '
+        '${fx.productionByRecipe!.entries.map((e) => '${e.key}×${e.value}').join(', ')}',
+      );
+    }
+    if (lines.isEmpty) {
+      return Text(
+        '(projection run; no worker/treasury/stockpile/unit/production deltas)',
+        style: Theme.of(context).textTheme.bodySmall,
+      );
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [for (final line in lines) Text(line)],
+    );
+  }
+
   static const _civilianUnitCapabilities = {
     'Explorer': 'Prospect, explore',
     'Builder': 'Develop tile',
@@ -739,4 +831,17 @@ class _CheckRow extends StatelessWidget {
           Text(label),
         ],
       );
+}
+
+String _ctdevFactionLabel(Game game, String factionId) {
+  for (final p in game.players) {
+    if (p.id == factionId) return '${p.displayName} ($factionId)';
+  }
+  for (final m in game.minorNations) {
+    if (m.id == factionId) return '${m.displayName} ($factionId)';
+  }
+  for (final t in game.tribes) {
+    if (t.id == factionId) return '${t.displayName} ($factionId)';
+  }
+  return factionId;
 }

--- a/ctdev/lib/sim_game_controller.dart
+++ b/ctdev/lib/sim_game_controller.dart
@@ -82,6 +82,7 @@ class SimGameController {
   /// When using full AI, economy plans per player for production phase. Cleared on resolve.
   final Map<String, EconomyPlan> _pendingEconomyPlansByPlayerId = {};
   final List<SimOrderHistoryEntry> _orderHistory = [];
+  final List<String> _lastTurnCombatSummaries = [];
 
   Game get game => _game;
   Map<String, Orders> get pendingOrdersByPlayerId =>
@@ -103,6 +104,40 @@ class SimGameController {
 
   List<SimOrderHistoryEntry> get orderHistory =>
       List.unmodifiable(_orderHistory);
+
+  /// Land + naval combat lines from the last resolved turn (Overview tab).
+  List<String> get lastTurnCombatSummaries =>
+      List.unmodifiable(_lastTurnCombatSummaries);
+
+  /// True when at least one GP has non-empty pending orders (for projections).
+  bool get hasPendingOrdersForProjection {
+    for (final p in _game.players) {
+      final o = _pendingOrdersByPlayerId[p.id];
+      if (o != null && !_isOrdersEffectivelyEmpty(o)) return true;
+    }
+    return false;
+  }
+
+  /// Dry-run effects for [playerId] from merged pending orders; null if no pending.
+  ProjectedEffects? projectedEffectsForPlayer(String playerId) {
+    if (!hasPendingOrdersForProjection) return null;
+    return projectOrderEffects(
+      game: _game,
+      orders: mergePendingOrdersForProjection(),
+      topology: _topology,
+      tileMapByRegion: _tileMapByRegion,
+      playerId: playerId,
+    );
+  }
+
+  /// Merges per-GP pending orders with empty [Orders] for GPs not yet filled.
+  Orders mergePendingOrdersForProjection() {
+    final list = <Orders>[
+      for (final p in _game.players)
+        _pendingOrdersByPlayerId[p.id] ?? const Orders(),
+    ];
+    return _combineOrders(list);
+  }
 
   bool get allPlayersHaveOrders {
     final ids = _game.players.map((p) => p.id).toList();
@@ -252,6 +287,7 @@ class SimGameController {
     Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
   }) {
     _recordOrderHistory(orders);
+    _lastTurnCombatSummaries.clear();
     final before = _game;
     final next = requireTurnResolutionComplete(validateOrdersAndResolveTurn(
       game: _game,
@@ -260,10 +296,27 @@ class SimGameController {
       tileMapByRegion: _tileMapByRegion,
       defaultAssignments: const [],
       defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+      onGameEvent: _recordCombatGameEvent,
     ));
     _game = next;
     _recordTurnLog(before: before, after: next);
   }
+
+  void _recordCombatGameEvent(GameEvent event) {
+    final line = _combatEventUiLine(event);
+    if (line == null) return;
+    _lastTurnCombatSummaries.add(line);
+    Logger().i('ctdev: $line');
+  }
+
+  bool _isOrdersEffectivelyEmpty(Orders o) =>
+      o.moveOrdersByPlayerId.isEmpty &&
+      o.buildUnitOrdersByPlayerId.isEmpty &&
+      o.workOrdersByPlayerId.isEmpty &&
+      o.diplomaticOrdersByPlayerId.isEmpty &&
+      o.researchOrdersByPlayerId.isEmpty &&
+      o.navalMoveOrdersByPlayerId.isEmpty &&
+      o.navalMissionOrdersByPlayerId.isEmpty;
 
   void _recordOrderHistory(Orders orders) {
     if (orders.moveOrdersByPlayerId.isEmpty &&
@@ -536,5 +589,40 @@ class SimGameController {
         'ctdev: Turn $turn ($year): province ownership changes: ${flips.join(', ')}',
       );
     }
+  }
+}
+
+String? _combatEventUiLine(GameEvent event) {
+  switch (event) {
+    case CombatResultEvent(
+        :final provinceId,
+        :final attackerId,
+        :final defenderId,
+        :final winnerId,
+        :final casualties,
+      ):
+      final cas = casualties.isEmpty ? '' : ' casualties=$casualties';
+      return 'Land combat $provinceId: $attackerId vs $defenderId → '
+          '$winnerId$cas';
+    case NavalCombatResultEvent(
+        :final seaZoneId,
+        :final side1OwnerId,
+        :final side2OwnerId,
+        :final outcomeName,
+        :final winnerOwnerId,
+        :final side1Retreated,
+        :final side2Retreated,
+      ):
+      final w = winnerOwnerId != null ? ' winner=$winnerOwnerId' : '';
+      final r = (side1Retreated || side2Retreated)
+          ? ' retreat=${[
+              if (side1Retreated) 'side1',
+              if (side2Retreated) 'side2',
+            ].join(',')}'
+          : '';
+      return 'Naval combat sea $seaZoneId: $side1OwnerId vs '
+          '$side2OwnerId → $outcomeName$w$r';
+    default:
+      return null;
   }
 }

--- a/packages/colonizethis_logic/lib/src/game_events.dart
+++ b/packages/colonizethis_logic/lib/src/game_events.dart
@@ -27,6 +27,32 @@ class CombatResultEvent extends GameEvent {
   final Map<String, int> casualties;
 }
 
+/// Naval battle resolved in a sea zone. SPEC/program/game-events.md.
+class NavalCombatResultEvent extends GameEvent {
+  const NavalCombatResultEvent({
+    required this.seaZoneId,
+    required this.side1OwnerId,
+    required this.side2OwnerId,
+    required this.outcomeName,
+    required this.turnNumber,
+    this.winnerOwnerId,
+    this.side1Retreated = false,
+    this.side2Retreated = false,
+  });
+
+  /// Sea zone local id (e.g. s3).
+  final String seaZoneId;
+  final String side1OwnerId;
+  final String side2OwnerId;
+  /// [NavalBattleOutcome] `.name` from resolver.
+  final String outcomeName;
+  final int turnNumber;
+  /// Set when [outcomeName] is a decisive victory for one side.
+  final String? winnerOwnerId;
+  final bool side1Retreated;
+  final bool side2Retreated;
+}
+
 /// Province ownership changed.
 class ProvinceCapturedEvent extends GameEvent {
   const ProvinceCapturedEvent({

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -301,6 +301,8 @@ TurnResolutionResult resolveTurnForGame({
           topology,
           orders.navalMoveOrdersByPlayerId,
           onDialogue: onDialogue,
+          onGameEvent: onGameEvent,
+          eventBus: eventBus,
         );
         break;
       case TurnPhase.combat:

--- a/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
@@ -7,6 +7,8 @@ import '../constants.dart';
 import '../diplomacy/diplomacy_relation_lookup.dart';
 import '../dossier/evidence_rules.dart';
 import '../dossier/event_dialogue.dart';
+import '../event_bus/game_event_bus.dart';
+import '../game_events.dart';
 import 'naval.dart';
 import 'player_view.dart';
 import 'province_lookup.dart';
@@ -293,6 +295,8 @@ Game runNavalInterceptionCombatPhase(
   MapTopology topology,
   Map<String, List<NavalMoveOrder>> navalMoveOrdersByPlayerId, {
   void Function(DialogueEvent)? onDialogue,
+  void Function(GameEvent)? onGameEvent,
+  GameEventBus? eventBus,
 }) {
   var battles = detectNavalConflicts(game);
   _log.d('logic: naval phase detected battles=${battles.length}');
@@ -381,6 +385,30 @@ Game runNavalInterceptionCombatPhase(
         }
       }
     }
+
+    String? winnerOwnerId;
+    switch (result.outcome) {
+      case NavalBattleOutcome.side1Victory:
+        winnerOwnerId = battle.side1.ownerId;
+      case NavalBattleOutcome.side2Victory:
+        winnerOwnerId = battle.side2.ownerId;
+      case NavalBattleOutcome.stalemate:
+      case NavalBattleOutcome.mutualDestruction:
+        winnerOwnerId = null;
+    }
+    final navalEv = NavalCombatResultEvent(
+      seaZoneId: battle.seaZoneId,
+      side1OwnerId: battle.side1.ownerId,
+      side2OwnerId: battle.side2.ownerId,
+      outcomeName: result.outcome.name,
+      turnNumber: turn,
+      winnerOwnerId: winnerOwnerId,
+      side1Retreated: result.side1Retreated,
+      side2Retreated: result.side2Retreated,
+    );
+    eventBus?.publish(navalEv);
+    onGameEvent?.call(navalEv);
+
     battleIndex++;
   }
   return state;

--- a/packages/colonizethis_logic/test/game_events_test.dart
+++ b/packages/colonizethis_logic/test/game_events_test.dart
@@ -78,5 +78,21 @@ void main() {
       expect(e.orderSummary, 'Build road');
       expect(e.reasonCode, 'insufficient_treasury');
     });
+
+    test('NavalCombatResultEvent has required fields', () {
+      const e = NavalCombatResultEvent(
+        seaZoneId: 's2',
+        side1OwnerId: 'gp1',
+        side2OwnerId: 'gp2',
+        outcomeName: 'side1Victory',
+        turnNumber: 4,
+        winnerOwnerId: 'gp1',
+        side1Retreated: false,
+        side2Retreated: true,
+      );
+      expect(e.seaZoneId, 's2');
+      expect(e.winnerOwnerId, 'gp1');
+      expect(e.side2Retreated, isTrue);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Implements the remaining ctdev Running Game gaps tracked under #127 (sub-issues #1248–#1251).

- **Overview — Diplomacy:** Lists every `Game.diplomacyRelations` row with faction labels (GP / minor / tribe), state, level, and score. Undiscovered cross-region pairs remain absent from the model and do not appear.
- **Combat — Overview + Sim Log:** `NavalCombatResultEvent` emitted from the naval interception phase; `SimGameController` wires `onGameEvent` to collect lines and log with `Logger().i('ctdev: …')` so the in-memory Sim Log and the **Last turn combat** section stay in sync. Land combat continues to use `CombatResultEvent`.
- **Player tab — Projections:** `projectOrderEffects` with merged pending orders (empty `Orders` for GPs not yet filled this turn). Shown only when at least one GP has pending orders.
- **Map — Fleets:** Triangle markers with mission letter on the combined map and per-player map when **Units** is enabled (`fleet_map_overlay.dart`).

## SPEC

- `SPEC/program/ctdev-app-running-game.md`
- `SPEC/program/game-events.md` (`naval_combat_result`)
- `SPEC/program/order-projections.md` (ctdev merge rule)

## Testing

- `cd ctdev && flutter test test/sim_game_controller_test.dart`
- `cd packages/colonizethis_logic && dart test test/game_events_test.dart test/naval_behavior_scenarios_test.dart`

Closes #1248. Closes #1249. Closes #1250. Closes #1251.

Made with [Cursor](https://cursor.com)