### PR TITLE
test(logic): extraction respects player tech cap (#272)

### DIFF
--- a/packages/colonizethis_logic/test/resource_extractor_test.dart
+++ b/packages/colonizethis_logic/test/resource_extractor_test.dart
@@ -109,6 +109,120 @@ void main() {
       expect(result['pl1']!.land['grain'], 1);
     });
 
+    test(
+      'effective extraction capped by player tech cap when improvement and '
+      'transport are high',
+      () {
+        final grid = [['p1']];
+        final tileMap = TileMapResult(
+          width: 1,
+          height: 1,
+          grid: grid,
+          resourceGrid: [[Resource.grain]],
+        );
+        final tileState = TileMapState()
+            .setImprovement('oldWorld|p1|0|0', 4)
+            .setRoadLevel('oldWorld|p1|0|0', 4);
+        final player = Player(
+          id: 'pl1',
+          displayName: 'Spain',
+          isHuman: true,
+          capitalProvinceId: 'p1',
+          capitalTile: CapitalTile(
+            regionId: 'oldWorld',
+            provinceId: 'p1',
+            x: 0,
+            y: 0,
+          ),
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(provinces: [
+              Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
+            ]),
+            newWorld: const RegionData(),
+            tileState: tileState,
+          ),
+          players: [player],
+        );
+        final resultCap2 = computeExtraction(
+          game: game,
+          tileMapByRegion: {'oldWorld': tileMap},
+          connectivityResult: {
+            'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'}),
+          },
+          techCapForPlayer: (_) => 2,
+        );
+        expect(resultCap2['pl1']!.land['grain'], 2);
+
+        final resultCap3 = computeExtraction(
+          game: game,
+          tileMapByRegion: {'oldWorld': tileMap},
+          connectivityResult: {
+            'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'}),
+          },
+          techCapForPlayer: (_) => 3,
+        );
+        expect(resultCap3['pl1']!.land['grain'], 3);
+      },
+    );
+
+    test(
+      'tech cap from extractionCapForUnlocked matches turn_resolver wiring',
+      () {
+        final grid = [['p1']];
+        final tileMap = TileMapResult(
+          width: 1,
+          height: 1,
+          grid: grid,
+          resourceGrid: [[Resource.grain]],
+        );
+        final tileState = TileMapState()
+            .setImprovement('oldWorld|p1|0|0', 4)
+            .setRoadLevel('oldWorld|p1|0|0', 4);
+        final player = Player(
+          id: 'pl1',
+          displayName: 'Spain',
+          isHuman: true,
+          capitalProvinceId: 'p1',
+          capitalTile: CapitalTile(
+            regionId: 'oldWorld',
+            provinceId: 'p1',
+            x: 0,
+            y: 0,
+          ),
+          techUnlocked: {'saw_mill': true, 'seed_drill': true},
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(provinces: [
+              Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
+            ]),
+            newWorld: const RegionData(),
+            tileState: tileState,
+          ),
+          players: [player],
+        );
+        final result = computeExtraction(
+          game: game,
+          tileMapByRegion: {'oldWorld': tileMap},
+          connectivityResult: {
+            'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'}),
+          },
+          techCapForPlayer: (playerId) {
+            final p = game.playerById(playerId);
+            return extractionCapForUnlocked(p?.techUnlocked);
+          },
+        );
+        expect(extractionCapForUnlocked(player.techUnlocked), 3);
+        expect(result['pl1']!.land['grain'], 3);
+      },
+    );
+
     test('extracts wool and copper when present on tile map', () {
       final grid = [
         ['p1', 'p1'],


### PR DESCRIPTION
## Summary
Addresses [#272](https://github.com/waigore/colonizethisv3/issues/272): `computeExtraction` always used `techCapForPlayer: (_) => 4` in tests, so nothing asserted that a lower cap limits yield.

## What was added
- **Cap 2 vs 3:** Single connected grain tile with improvement 4 and road 4; `techCapForPlayer` returns 2 then 3 → land grain totals 2 and 3 respectively (production bound by tech, not transport).
- **Real cap wiring:** Player with `techUnlocked: saw_mill + seed_drill` (cap 3 per `extractionCapForUnlocked`), same tile setup, and `techCapForPlayer` matching `turn_resolver` (`extractionCapForUnlocked(player?.techUnlocked)`).

## Tests
`dart test packages/colonizethis_logic/test/resource_extractor_test.dart`

Fixes #272.

Made with [Cursor](https://cursor.com)