### PR TITLE
fix: Flutter analyze — GameEvent bridge + ctdev loadMapData

### DIFF
--- a/SPEC/program/game-event-bridge.md
+++ b/SPEC/program/game-event-bridge.md
@@ -25,6 +25,7 @@ Forward by copying fields; no payload transforms. Province ids remain **prefixed
 | Logic `GameEvent` | App `GameToUIEvent` | Typical UI |
 |-------------------|---------------------|------------|
 | `CombatResultEvent` | `AppCombatResultEvent` | `NotifyEvent` |
+| `NavalCombatResultEvent` | `AppNavalCombatResultEvent` | `NotifyEvent` |
 | `ProvinceCapturedEvent` | `AppProvinceCapturedEvent` | `NotifyEvent` |
 | `DiplomacyChangeEvent` | `AppDiplomacyChangeEvent` | `NotifyEvent` |
 | `ResearchCompleteEvent` | `AppResearchCompleteEvent` | `NotifyEvent` |

--- a/app/lib/core/services/game_event_bridge.dart
+++ b/app/lib/core/services/game_event_bridge.dart
@@ -39,6 +39,19 @@ class GameEventBridge {
             casualties: event.casualties,
           ),
         );
+      case NavalCombatResultEvent():
+        _appBus.emit(
+          AppNavalCombatResultEvent(
+            seaZoneId: event.seaZoneId,
+            side1OwnerId: event.side1OwnerId,
+            side2OwnerId: event.side2OwnerId,
+            outcomeName: event.outcomeName,
+            turnNumber: event.turnNumber,
+            winnerOwnerId: event.winnerOwnerId,
+            side1Retreated: event.side1Retreated,
+            side2Retreated: event.side2Retreated,
+          ),
+        );
       case ProvinceCapturedEvent():
         _appBus.emit(
           AppProvinceCapturedEvent(

--- a/app/test/app_event_bus_test.dart
+++ b/app/test/app_event_bus_test.dart
@@ -287,6 +287,45 @@ void main() {
       );
     });
 
+    test('AppNavalCombatResultEvent equal for same fields', () {
+      expect(
+        const AppNavalCombatResultEvent(
+          seaZoneId: 's1',
+          side1OwnerId: 'gp1',
+          side2OwnerId: 'gp2',
+          outcomeName: 'draw',
+          turnNumber: 2,
+          winnerOwnerId: null,
+        ),
+        const AppNavalCombatResultEvent(
+          seaZoneId: 's1',
+          side1OwnerId: 'gp1',
+          side2OwnerId: 'gp2',
+          outcomeName: 'draw',
+          turnNumber: 2,
+          winnerOwnerId: null,
+        ),
+      );
+      expect(
+        const AppNavalCombatResultEvent(
+          seaZoneId: 's1',
+          side1OwnerId: 'gp1',
+          side2OwnerId: 'gp2',
+          outcomeName: 'draw',
+          turnNumber: 2,
+        ),
+        isNot(
+          const AppNavalCombatResultEvent(
+            seaZoneId: 's2',
+            side1OwnerId: 'gp1',
+            side2OwnerId: 'gp2',
+            outcomeName: 'draw',
+            turnNumber: 2,
+          ),
+        ),
+      );
+    });
+
     test('AppProvinceCapturedEvent equal for same fields', () {
       expect(
         const AppProvinceCapturedEvent(

--- a/app/test/game_event_bridge_test.dart
+++ b/app/test/game_event_bridge_test.dart
@@ -3,7 +3,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_test/flutter_test.dart';
 
-import '../lib/core/services/game_event_bridge.dart';
+import 'package:colonizethis_app/core/services/game_event_bridge.dart';
 
 void main() {
   suppressLogsForTests();
@@ -69,6 +69,37 @@ void main() {
       await pumpEventQueue();
 
       expect(received, isEmpty);
+    });
+
+    test('forwards NavalCombatResultEvent', () async {
+      final received = <AppNavalCombatResultEvent>[];
+      appBus.on<AppNavalCombatResultEvent>().listen(received.add);
+      bridge.start();
+
+      logicBus.publish(
+        NavalCombatResultEvent(
+          seaZoneId: 's3',
+          side1OwnerId: 'gp1',
+          side2OwnerId: 'gp2',
+          outcomeName: 'side1Victory',
+          turnNumber: 4,
+          winnerOwnerId: 'gp1',
+          side1Retreated: false,
+          side2Retreated: true,
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(received, hasLength(1));
+      final evt = received.first;
+      expect(evt.seaZoneId, 's3');
+      expect(evt.side1OwnerId, 'gp1');
+      expect(evt.side2OwnerId, 'gp2');
+      expect(evt.outcomeName, 'side1Victory');
+      expect(evt.turnNumber, 4);
+      expect(evt.winnerOwnerId, 'gp1');
+      expect(evt.side1Retreated, isFalse);
+      expect(evt.side2Retreated, isTrue);
     });
 
     test('forwards ProvinceCapturedEvent', () async {

--- a/ctdev/lib/save_service.dart
+++ b/ctdev/lib/save_service.dart
@@ -43,6 +43,7 @@ Future<({
   Map<String, TileMapResult> tileMapByRegion,
   Map<String, MapTopology> topologyByRegion,
   MapTopology combinedTopology,
+  List<WarpLink>? warpLinks,
 })?> loadMapData(String gameId) async {
   final box = await _ensureBox();
   return _adapter.loadMapData(box, gameId);

--- a/packages/colonizethis_models/lib/src/app_events.dart
+++ b/packages/colonizethis_models/lib/src/app_events.dart
@@ -307,6 +307,28 @@ class AppCombatResultEvent extends GameToUIEvent {
   final Map<String, int> casualties;
 }
 
+/// Naval battle resolved in a sea zone. Mirrors colonizethis_logic NavalCombatResultEvent.
+class AppNavalCombatResultEvent extends GameToUIEvent {
+  const AppNavalCombatResultEvent({
+    required this.seaZoneId,
+    required this.side1OwnerId,
+    required this.side2OwnerId,
+    required this.outcomeName,
+    required this.turnNumber,
+    this.winnerOwnerId,
+    this.side1Retreated = false,
+    this.side2Retreated = false,
+  });
+  final String seaZoneId;
+  final String side1OwnerId;
+  final String side2OwnerId;
+  final String outcomeName;
+  final int turnNumber;
+  final String? winnerOwnerId;
+  final bool side1Retreated;
+  final bool side2Retreated;
+}
+
 /// Province ownership changed. Mirrors colonizethis_logic ProvinceCapturedEvent.
 class AppProvinceCapturedEvent extends GameToUIEvent {
   const AppProvinceCapturedEvent({


### PR DESCRIPTION
Fixes analyzer **errors** that broke the `Compile app entrypoints (Flutter analyze)` quality job (same class of failure as PR #1253).

### Changes
- **GameEventBridge:** Handle `NavalCombatResultEvent` by emitting `AppNavalCombatResultEvent` (exhaustive switch on sealed `GameEvent`).
- **colonizethis_models:** Add `AppNavalCombatResultEvent` mirroring logic fields.
- **ctdev `save_service.loadMapData`:** Return type now includes optional `warpLinks` to match `GameSaveAdapter.loadMapData`.
- **SPEC:** `SPEC/program/game-event-bridge.md` mapping table updated.
- **Tests:** Bridge forwarding + `AppEventBus` equality; `game_event_bridge_test` uses `package:colonizethis_app/...` import.

### Verification
- `cd app && flutter analyze` — no `error` lines
- `flutter analyze` (repo root) — no `error` lines
- `flutter test test/game_event_bridge_test.dart test/app_event_bus_test.dart`

Made with [Cursor](https://cursor.com)