### PR TITLE
fix(game-setup): add naming logs and MVP naming source note

### DIFF
--- a/SPEC/game/naming.md
+++ b/SPEC/game/naming.md
@@ -26,6 +26,8 @@ Per active ruleset, naming config defines:
 
 All names are **ruleset-driven**; game logic only consumes resolved naming data.
 
+**MVP source note:** Until ruleset JSON load/merge is implemented (tracked in #57), game setup resolves naming from the program-level `defaultNamingConfig` in `colonizethis_data`. This is the temporary MVP source of truth for runtime naming data; see [ruleset-config.md](../program/ruleset-config.md).
+
 The **default** minor nation and tribe identities and province name pools are defined in **GDD 09b (Minor Nations)** and **GDD 09c (New World Tribes)**. The default ruleset exposes 6 minors (ids `minor1`–`minor6`) and 10 tribes (ids `tribe1`–`tribe10`) in GDD order.
 
 ---

--- a/packages/colonizethis_logic/lib/src/setup/game_setup.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup.dart
@@ -661,9 +661,12 @@ Game _applyNaming({
   final owById = {for (final p in owProvinces) p.id: p};
   final nwById = {for (final p in nwProvinces) p.id: p};
   final usedProvinceNames = <String>{};
+  var proceduralFallbackCount = 0;
 
-  String generateFallback(int seedOffset) =>
-      generateUniqueProvinceName(namingSeed + seedOffset, usedProvinceNames);
+  String generateFallback(int seedOffset) {
+    proceduralFallbackCount++;
+    return generateUniqueProvinceName(namingSeed + seedOffset, usedProvinceNames);
+  }
 
   // Helper: assign names to provinces from pool (random order). Capital gets capitalName; others get shuffled pool, wrap if needed.
   void assignProvinceNames({
@@ -760,10 +763,7 @@ Game _applyNaming({
     if (owned.isEmpty) continue;
     final capitalProvId = minor.capitalProvinceId;
     final capitalName = namingMinor.id.isEmpty
-        ? generateUniqueProvinceName(
-            namingSeed + minor.id.hashCode,
-            usedProvinceNames,
-          )
+        ? generateFallback(namingSeed + minor.id.hashCode)
         : (namingMinor.provinceNamePool.isNotEmpty
               ? namingMinor.provinceNamePool.first
               : namingMinor.displayName);
@@ -794,10 +794,7 @@ Game _applyNaming({
     if (owned.isEmpty) continue;
     final capitalProvId = tribe.capitalProvinceId;
     final capitalName = namingTribe.id.isEmpty
-        ? generateUniqueProvinceName(
-            namingSeed + tribe.id.hashCode,
-            usedProvinceNames,
-          )
+        ? generateFallback(namingSeed + tribe.id.hashCode)
         : (namingTribe.provinceNamePool.isNotEmpty
               ? namingTribe.provinceNamePool.first
               : namingTribe.displayName);
@@ -870,6 +867,15 @@ Game _applyNaming({
       units: game.worldState.newWorld.units,
     ),
   );
+
+  _log.i(
+    'logic: naming applied ow=${updatedWorld.oldWorld.provinces.length} '
+    'nw=${updatedWorld.newWorld.provinces.length} players=${game.players.length} '
+    'minors=${game.minorNations.length} tribes=${game.tribes.length}',
+  );
+  if (proceduralFallbackCount > 0) {
+    _log.d('logic: naming procedural fallback used count=$proceduralFallbackCount');
+  }
 
   return game.copyWith(
     worldState: updatedWorld,


### PR DESCRIPTION
## Summary
- add `_applyNaming` logging in game setup: one `logic:` info line on naming completion and one debug line when procedural fallback names are generated
- route procedural name generation through a single helper so fallback usage is counted consistently
- update `SPEC/game/naming.md` to explicitly state MVP uses `defaultNamingConfig` from `colonizethis_data` until ruleset JSON loading/merge exists (#57)
- explicitly links this PR to issue #1265

Closes #1265.

## Test plan
- [x] `flutter test packages/colonizethis_logic/test/game_setup_test.dart`
- [x] `flutter test packages/colonizethis_logic/test/characterization/game_setup_snapshot_test.dart`

Made with [Cursor](https://cursor.com)