### PR TITLE
feat(capital-choice): define class A/B/C tile classes (#1264)

### DIFF
--- a/packages/colonizethis_logic/lib/src/setup/capital_choice.dart
+++ b/packages/colonizethis_logic/lib/src/setup/capital_choice.dart
@@ -6,6 +6,12 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 /// setCapital validates province is sea-bound, sets player capital, and
 /// auto-builds port (on capital if coastal, else nearest coastal tile) and road.
 
+/// Capital tile class per SPEC/game/capital-choice-phase:
+/// - A: coastal and not adjacent to another province
+/// - B: interior and not adjacent to another province
+/// - C: all remaining tiles
+enum CapitalTileClass { a, b, c }
+
 /// Returns true if [provinceId] has at least one P–S edge in [topology].
 bool isProvinceSeaBound(MapTopology topology, String provinceId) {
   for (final edge in topology.edges) {
@@ -69,16 +75,21 @@ TopologyNode? _nodeById(MapTopology topology, String id) {
   for (var y = 0; y < tileMap.height; y++) {
     for (var x = 0; x < tileMap.width; x++) {
       if (tileMap.cell(x, y) != localProvinceId) continue;
-      final coastal = _isTileAdjacentToSea(x, y, tileMap, topology);
-      final adjacentOtherProvince =
-          _isTileAdjacentToOtherProvince(x, y, tileMap, provinceIds, localProvinceId);
+      final tileClass = classifyCapitalTile(
+        x: x,
+        y: y,
+        tileMap: tileMap,
+        topology: topology,
+        localProvinceId: localProvinceId,
+        provinceIds: provinceIds,
+      );
 
-      if (coastal && !adjacentOtherProvince) {
+      if (tileClass == CapitalTileClass.a) {
         if (classAx == null) {
           classAx = x;
           classAy = y;
         }
-      } else if (!coastal && !adjacentOtherProvince) {
+      } else if (tileClass == CapitalTileClass.b) {
         if (classBx == null) {
           classBx = x;
           classBy = y;
@@ -318,6 +329,34 @@ Game setCapitalForTribe({
     worldState: worldState,
     tribes: updatedTribes,
   );
+}
+
+/// Classifies a province tile according to capital-choice class A/B/C.
+CapitalTileClass classifyCapitalTile({
+  required int x,
+  required int y,
+  required TileMapResult tileMap,
+  required MapTopology topology,
+  required String localProvinceId,
+  Set<String>? provinceIds,
+}) {
+  final knownProvinceIds =
+      provinceIds ??
+      topology.nodes
+          .where((n) => n.type == TopologyNodeType.province)
+          .map((n) => n.id)
+          .toSet();
+  final coastal = _isTileAdjacentToSea(x, y, tileMap, topology);
+  final adjacentOtherProvince = _isTileAdjacentToOtherProvince(
+    x,
+    y,
+    tileMap,
+    knownProvinceIds,
+    localProvinceId,
+  );
+  if (coastal && !adjacentOtherProvince) return CapitalTileClass.a;
+  if (!coastal && !adjacentOtherProvince) return CapitalTileClass.b;
+  return CapitalTileClass.c;
 }
 
 Set<String> _seaZonesAdjacentToProvince(MapTopology topology, String provinceId) {

--- a/packages/colonizethis_logic/test/capital_choice_test.dart
+++ b/packages/colonizethis_logic/test/capital_choice_test.dart
@@ -357,5 +357,81 @@ void main() {
       expect(next.players.single.capitalProvinceId, 'oldWorld|p1');
       expect(next.worldState.tileState.roadLevel('oldWorld|p1|0|0'), 4);
     });
+
+    test('classifyCapitalTile returns class A for coastal non-border tile', () {
+      final grid = [
+        ['p1', 'sea1'],
+        ['p1', 'p1'],
+      ];
+      final topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+        ],
+        edges: [TopologyEdge(id1: 'p1', id2: 'sea1')],
+      );
+      final tileMap = TileMapResult(width: 2, height: 2, grid: grid);
+      final tileClass = classifyCapitalTile(
+        x: 0,
+        y: 0,
+        tileMap: tileMap,
+        topology: topology,
+        localProvinceId: 'p1',
+      );
+      expect(tileClass, CapitalTileClass.a);
+    });
+
+    test('classifyCapitalTile returns class B for interior non-border tile', () {
+      final grid = [
+        ['sea1', 'sea1', 'sea1', 'sea1', 'sea1'],
+        ['sea1', 'p1', 'p1', 'p1', 'sea1'],
+        ['sea1', 'p1', 'p1', 'p1', 'sea1'],
+        ['sea1', 'p1', 'p1', 'p1', 'sea1'],
+        ['sea1', 'sea1', 'sea1', 'sea1', 'sea1'],
+      ];
+      final topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+        ],
+        edges: [TopologyEdge(id1: 'p1', id2: 'sea1')],
+      );
+      final tileMap = TileMapResult(width: 5, height: 5, grid: grid);
+      final tileClass = classifyCapitalTile(
+        x: 2,
+        y: 2,
+        tileMap: tileMap,
+        topology: topology,
+        localProvinceId: 'p1',
+      );
+      expect(tileClass, CapitalTileClass.b);
+    });
+
+    test('classifyCapitalTile returns class C for tile bordering another province', () {
+      final grid = [
+        ['p1', 'p2'],
+        ['sea1', 'sea1'],
+      ];
+      final topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 'p2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+        ],
+        edges: [
+          TopologyEdge(id1: 'p1', id2: 'p2'),
+          TopologyEdge(id1: 'p1', id2: 'sea1'),
+        ],
+      );
+      final tileMap = TileMapResult(width: 2, height: 2, grid: grid);
+      final tileClass = classifyCapitalTile(
+        x: 0,
+        y: 0,
+        tileMap: tileMap,
+        topology: topology,
+        localProvinceId: 'p1',
+      );
+      expect(tileClass, CapitalTileClass.c);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Define explicit `CapitalTileClass` A/B/C semantics for capital tile selection in setup.
- Refactor `pickCapitalForFaction` to use shared `classifyCapitalTile(...)` logic instead of inline condition checks.
- Add tests covering each class outcome (A coastal non-border, B interior non-border, C remaining/bordering-other-province).

Closes #1264

## Test plan
- [x] `flutter test packages/colonizethis_logic/test/capital_choice_test.dart`
- [ ] Run full `colonizethis_logic` test suite in CI

Made with [Cursor](https://cursor.com)