### PR TITLE
feat(combat): wire general assignment and medal progression

### DIFF
--- a/SPEC/game/combat.md
+++ b/SPEC/game/combat.md
@@ -12,13 +12,13 @@ Auto-resolved combat triggers when units move into enemy-controlled provinces. B
 
 **Battle Mode:** Field (fort level 0, terrain modifiers) or Siege (fort level ≥ 1; walls, emplaced artillery per [siege-mechanics.md](siege-mechanics.md)).
 
-**Initiative:** `initiative = cavalryShare × W_cav + generalMedals × W_medal`, where `cavalryShare = cavalry regiments / total regiments`.
+**Initiative:** `initiative = cavalryShare × W_cav + generalMedals × W_medal`, where `cavalryShare = cavalry regiments / total regiments`. If two attackers have equal initiative, tie-break with one deterministic RNG roll for the battle context (seeded by combat seed and battle context identity), not lexical faction id.
 
-**Multi-Attacker Chain:** Sort attackers by initiative descending (tie-break: faction id). Resolve sequentially: defender vs highest-initiative attacker; winner (no heal) vs next attacker; repeat until no attackers remain or defender eliminated.
+**Multi-Attacker Chain:** Sort attackers by initiative descending, using the deterministic battle-context RNG tie-break for exact initiative ties. Resolve sequentially: defender vs highest-initiative attacker; winner (no heal) vs next attacker; repeat until no attackers remain or defender eliminated.
 
 **Strength:** Per-regiment FPN + FPM (from [military-units.md](military-units.md)). Medals (0–4) multiply by 1.0–1.4. DEF durability = DEF / 9. Damaged units: firepower ∝ remaining / starting health. Side strength = `Σ (FPN_eff + FPM_eff) × medalMult`, adjusted by modifiers. **Current auto-resolve:** Strength aggregation uses (FPN + FPM) × medalMult only; DEF/9 and damaged-unit health scaling are deferred (no unit health field; casualty selection uses strength-weighted choice).
 
-**Modifiers:** Terrain (province type), fort (level 0–3; damage reduction + emplaced guns per [siege-mechanics.md](siege-mechanics.md)), difficulty (scales attacker/defender; deferred in auto-resolve until difficulty is wired from game config), general (+1 deployment per medal + initiative contribution), leader (per [leader-bonuses.md](leader-bonuses.md)), feeding coverage (see table below).
+**Modifiers:** Terrain (province type), fort (level 0–3; damage reduction + emplaced guns per [siege-mechanics.md](siege-mechanics.md)), difficulty (scales attacker/defender; deferred in auto-resolve until difficulty is wired from game config), general (+1 deployment per medal + initiative contribution), leader (per [leader-bonuses.md](leader-bonuses.md), including fallback medal derivation when no uncommitted general is available), feeding coverage (see table below).
 
 **Resolution:** Compare total attacker vs defender strength after modifiers. Deterministic output: winner + casualties per side.
 
@@ -34,11 +34,23 @@ Auto-resolved combat triggers when units move into enemy-controlled provinces. B
 
 - Given one defender and two or more attacking factions each with at least one regiment in the same province  
   When the system resolves combat for that province  
-  Then the system computes initiative for each attacker as `initiative = cavalryShare × W_cav + generalMedals × W_medal`, breaks ties by ascending faction id, and orders the attackers from highest to lowest initiative for the multi-attacker chain.
+  Then the system computes initiative for each attacker as `initiative = cavalryShare × W_cav + generalMedals × W_medal`, and for exact initiative ties it uses one deterministic RNG tie-break for that battle context to order tied attackers for the multi-attacker chain.
 
 - Given a defender and an ordered list of attackers as defined above, each with at least one regiment remaining  
   When the system executes the multi-attacker chain for that province  
   Then the system first resolves a battle between the defender and the highest-initiative attacker, and for each subsequent attacker it resolves a new battle between the previous battle’s winner (without healing or regenerating regiments) and the next attacker in the ordered list until either all attackers are eliminated or the defender side is eliminated.
+
+- Given a side in combat has no uncommitted assignable general for a BattleContext  
+  When the system derives `generalMedals` for initiative and combat modifiers  
+  Then the system derives fallback medals from that side’s leader combat multiplier using this mapping: multiplier `>= 1.25` => 4 medals, `>= 1.20` => 3 medals, `>= 1.15` => 2 medals, `>= 1.10` => 1 medal, else 0 medals.
+
+- Given an engagement winner is carried forward as the defender in the next step of a multi-attacker chain  
+  When the system initializes the next engagement in that same BattleContext  
+  Then the system reuses the carried winner’s assigned or fallback `generalMedals` as the defender medals for that next engagement.
+
+- Given an engagement has a winning side with an assigned general record and current medals in range 0..4  
+  When the system finalizes that engagement result  
+  Then the system increments that winning general’s medals by exactly 1 and caps the stored value at 4, and persists the updated medals into game state for subsequent engagements and turns.
 
 - Given a defender and one or more attackers with regiment-level stats (FPN, FPM, medals, DEF) and combat modifiers (terrain, fort, difficulty, leaders, feeding coverage) defined in the active ruleset  
   When the system computes side strength for auto-resolve combat in that province  

--- a/SPEC/game/military-generals.md
+++ b/SPEC/game/military-generals.md
@@ -25,9 +25,9 @@ Each Great Power has a **general cap**: the maximum (and minimum) number of gene
 Generals are **not** assigned to provinces or stacks by default. Assignment is **required and automated at combat time**:
 
 - **When attacking:** A faction that orders an attack (move into an enemy province) must commit one general to that attack. The system chooses **one general at random** from that faction’s generals who are not already committed to another battle this turn. That general is “assigned” to that attacking force for the **duration of that battle only**. This **caps the number of attacks** a faction can make in one turn: at most one attack per general (so at most general cap attacks per turn).
-- **When defending:** When a province owned by the faction is attacked, the system automatically assigns **one general at random** from that faction’s generals who are not already committed to another battle this turn. If the faction has **no uncommitted general**, the province **may still be defended**, but **without a general** (defender general medals = 0 for that battle).
+- **When defending:** When a province owned by the faction is attacked, the system automatically assigns **one general at random** from that faction’s generals who are not already committed to another battle this turn. If the faction has **no uncommitted general**, the province **may still be defended** and uses fallback `generalMedals` derived from leader combat multiplier: `>=1.25 => 4`, `>=1.20 => 3`, `>=1.15 => 2`, `>=1.10 => 1`, else `0`.
 
-**Defender general modeling:** Currently, defender generals are **not modeled** in combat resolution—defender general medals are treated as 0. This means the defender side does not receive +1 per defender general medal to the deployment limit, and no defender morale aura or initiative bonus is applied. When defender general state is added in a future phase, the defender side should symmetrically receive +1 per defender general medal to the deployment limit (matching attacker behavior).
+**Defender general modeling:** Defender generals are modeled in combat resolution symmetrically with attackers. Defender assigned medals (or fallback medals when no uncommitted general exists) apply to deployment limit, morale aura, and initiative effects.
 
 **Commitment lifetime:** A general is committed only for the duration of one battle. When that battle’s resolution completes, the generals assigned to that battle (attacker and defender) are **freed**. If there is a subsequent battle in the same turn (e.g. another province), the assignment process runs again and any general may be assigned, including one who was just in a previous battle.
 
@@ -46,7 +46,7 @@ Medal effects in combat (see [combat.md](combat.md) and [combat-resolution.md](.
 - **Morale aura:** Regiments on that side receive a strength bonus of **5% per general medal**, up to a maximum of **20%** (at 4 medals). These values are program-level constants; ruleset-configurable morale aura is deferred to a future phase.
 - **Initiative:** Army initiative uses `cavalryShare × W_cav + generalMedals × W_medal` for ordering multi-attacker chains.
 
-Defender without a general uses 0 general medals for deployment, morale, and initiative.
+Defender without an uncommitted general uses fallback medals derived from leader combat multiplier for deployment, morale, and initiative.
 
 **Quick Battle:** General medals (deployment limit, initiative, morale aura) apply the same way in Quick Battle as in auto-resolve; see [quick-battle.md](quick-battle.md).
 
@@ -111,9 +111,9 @@ Province ids use the prefixed form and lookup rules in [world-model-identity.md]
   When the player orders an attack (move into an enemy province)  
   Then the system selects one general at random from that faction’s G generals, commits that general to that attack for this turn, and allows the attack to proceed; the number of attacks that faction may order this turn is at most G.
 
-- Given a Great Power that has already committed all G of its generals to attacks or defenses this turn  
+- Given a Great Power that has already committed all G of its generals to attacks or defenses this turn and leader combat multiplier `L`  
   When an enemy attack targets another province owned by that faction  
-  Then the system allows the province to be defended with defender general medals equal to 0 (no general assigned to that defense).
+  Then the system allows the province to be defended with fallback defender general medals derived from `L` using this mapping: `>=1.25 => 4`, `>=1.20 => 3`, `>=1.15 => 2`, `>=1.10 => 1`, else `0`.
 
 - Given a province owned by a faction with at least one uncommitted general and under attack  
   When the system resolves the defender side for that battle  

--- a/SPEC/program/combat-resolution.md
+++ b/SPEC/program/combat-resolution.md
@@ -26,11 +26,25 @@ For each province with units from multiple factions:
 
 ### 2. Initiative Ordering
 
-Per BattleContext, compute initiative per attacking side per game/combat.md § Rules (Initiative). Sort descending; tie-break by faction id.
+Per BattleContext, compute initiative per attacking side per game/combat.md § Rules (Initiative). Sort descending. For exact ties, use one deterministic RNG tie-break for the whole BattleContext (seeded from combat seed + context identity), not lexical faction id.
 
 ### 3. General assignment (per BattleContext)
 
-Before resolving a BattleContext, assign generals per [military-generals.md](../game/military-generals.md): for each attacking side, assign one uncommitted general at random (or none if the faction has no uncommitted general); for the defender, assign one uncommitted general at random (or none, in which case defender general medals = 0). Populate each side’s `generalMedals` from the assigned general’s medals. When the **entire** BattleContext resolution (full multi-attacker chain) completes, **free** all generals assigned to that battle so they may be assigned again in a subsequent BattleContext the same turn.
+Before resolving a BattleContext, assign generals per [military-generals.md](../game/military-generals.md): for each attacking side, assign one uncommitted general at random (or none if the faction has no uncommitted general); for the defender, assign one uncommitted general at random (or none if unavailable). Populate each side’s `generalMedals` from the assigned general’s medals.
+
+If a side has no uncommitted general, derive fallback `generalMedals` from leader combat multiplier (`leader-bonuses.md`) using this mapping:
+
+- multiplier `>= 1.25` => 4 medals
+- multiplier `>= 1.20` => 3 medals
+- multiplier `>= 1.15` => 2 medals
+- multiplier `>= 1.10` => 1 medal
+- else => 0 medals
+
+In multi-attacker chains, when the winner of engagement _n_ becomes defender in engagement _n+1_, reuse that winner side's assigned/fallback `generalMedals` for the carried defender role.
+
+When an engagement is won by a side with an assigned general record, increment that general's medals by exactly `+1` (cap at 4) and persist to game state immediately so later engagements in the same BattleContext observe updated medals. Medal gain is per engagement win, not per BattleContext aggregate.
+
+When the **entire** BattleContext resolution (full multi-attacker chain) completes, **free** all generals assigned to that battle so they may be assigned again in a subsequent BattleContext the same turn.
 
 ### 4. Deployment Limit (per side)
 
@@ -50,7 +64,7 @@ Steps:
 
 **Output:** EngagementResult.
 
-**Implementation note:** Conflict detection currently does not perform general assignment; when implemented, run the assignment step (§3) before resolution and pass resulting generalMedals into the resolver. Record which general commanded each side so medal gain can be applied to the winning general per military-generals.md. DEF/9 in strength/casualties and unit health scaling are deferred. Difficulty is not wired from game config into the resolver.
+**Implementation note:** Conflict detection currently does not perform general assignment; when implemented, run the assignment step (§3) before resolution and pass resulting generalMedals into the resolver. Record which general commanded each side so medal gain can be applied to the winning general per military-generals.md and this spec's per-engagement medal progression rule. DEF/9 in strength/casualties and unit health scaling are deferred. Difficulty is not wired from game config into the resolver.
 
 ### 6. Resolution Chain
 

--- a/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
@@ -51,21 +52,52 @@ Game resolveBattleContext(
   var defenderUnitIds = ctx.defenderUnitIds.toList();
   var defenderFactionId = ctx.defenderFactionId;
   var provinceOwnerId = ctx.defenderFactionId;
+  var generalsById = {for (final g in game.generals) g.id: g};
+  final battleRng = Random(
+    Object.hash(
+      game.globalGameSeed ?? 0,
+      game.worldState.turnState.turnNumber,
+      ctx.regionId,
+      ctx.provinceId,
+      ctx.defenderFactionId,
+      ctx.attackers.length,
+    ),
+  );
+  final generalAssignment = _assignGeneralsForBattleContext(
+    game: game,
+    ctx: ctx,
+    rng: battleRng,
+  );
 
-  var sortedAttackers = ctx.attackers.toList();
-  _sortAttackersByInitiative(sortedAttackers, region.units, unitsById);
+  final attackerSidesWithMedals = ctx.attackers.map((att) {
+    final assigned = generalAssignment.attackerByFactionId[att.factionId];
+    return _AttackingSideInBattle(
+      side: att.copyWith(generalMedals: assigned?.medals ?? 0),
+      assignedGeneralId: assigned?.generalId,
+    );
+  }).toList();
+  _sortAttackersByInitiative(
+    attackerSidesWithMedals,
+    unitsById,
+    battleRng,
+  );
+  var currentDefenderGeneralId = generalAssignment.defenderGeneralId;
+  var currentDefenderMedals = generalAssignment.defenderMedals;
 
   final allCasualties = <String>[];
   String? survivingAttackerFactionId;
 
   final initialDefenderCount = ctx.defenderUnitIds.length;
 
-  for (final attacker in sortedAttackers) {
+  for (var attackerIndex = 0;
+      attackerIndex < attackerSidesWithMedals.length;
+      attackerIndex++) {
+    final attacker = attackerSidesWithMedals[attackerIndex];
     if (defenderUnitIds.isEmpty && survivingAttackerFactionId != null) {
       break;
     }
 
-    final attackerUnits = attacker.unitIds
+    final attackerUnits = attacker.side.unitIds
         .map((id) => unitsById[id])
         .whereType<Unit>()
         .where((u) => !allCasualties.contains(u.id))
@@ -80,33 +112,35 @@ Game resolveBattleContext(
         .toList();
 
     if (defenderUnits.isEmpty) {
-      survivingAttackerFactionId = attacker.factionId;
+      survivingAttackerFactionId = attacker.side.factionId;
       break;
     }
 
     // Deployment limit per side. SPEC/game/military-generals.md.
     final attackerLimit = _deploymentLimitForFaction(
-        game, attacker.factionId, attacker.generalMedals);
+        game, attacker.side.factionId, attacker.side.generalMedals);
     final defenderLimit =
-        _deploymentLimitForFaction(game, defenderFactionId, 0);
+        _deploymentLimitForFaction(game, defenderFactionId, currentDefenderMedals);
     final cappedAttackerUnits = attackerUnits.take(attackerLimit).toList();
     final cappedDefenderUnits = defenderUnits.take(defenderLimit).toList();
 
     final defenderEffectiveLevel =
         _defenderEffectiveLevel(game, defenderFactionId);
     final attackerCoverage =
-        feedingCoverageByPlayerId[attacker.factionId] ?? 1.0;
+        feedingCoverageByPlayerId[attacker.side.factionId] ?? 1.0;
     final defenderCoverage =
         feedingCoverageByPlayerId[defenderFactionId] ?? 1.0;
-    final attackerLeaderMult = leaderBonusForFaction(game, attacker.factionId);
+    final attackerLeaderMult =
+        leaderBonusForFaction(game, attacker.side.factionId);
     final defenderLeaderMult = leaderBonusForFaction(game, defenderFactionId);
     final attackerGeneralMorale =
-        moraleMultiplierForGeneralMedals(attacker.generalMedals);
-    final defenderGeneralMorale = moraleMultiplierForGeneralMedals(0);
+        moraleMultiplierForGeneralMedals(attacker.side.generalMedals);
+    final defenderGeneralMorale =
+        moraleMultiplierForGeneralMedals(currentDefenderMedals);
     final outcome = resolveEngagement(
       attackerUnits: cappedAttackerUnits,
       defenderUnits: cappedDefenderUnits,
-      generalMedals: attacker.generalMedals,
+      generalMedals: attacker.side.generalMedals,
       fortLevel: ctx.fortLevel,
       terrain: ctx.terrain,
       defenderEffectiveMilitaryLevel: defenderEffectiveLevel,
@@ -133,11 +167,27 @@ Game resolveBattleContext(
 
     switch (outcome.result) {
       case EngagementResult.attackerVictory:
-        survivingAttackerFactionId = attacker.factionId;
-        defenderFactionId = attacker.factionId;
-        provinceOwnerId = attacker.factionId;
+        _incrementGeneralMedals(
+          generalsById: generalsById,
+          generalId: attacker.assignedGeneralId,
+        );
+        survivingAttackerFactionId = attacker.side.factionId;
+        defenderFactionId = attacker.side.factionId;
+        provinceOwnerId = attacker.side.factionId;
+        currentDefenderGeneralId = attacker.assignedGeneralId;
+        currentDefenderMedals = attacker.side.generalMedals +
+            (attacker.assignedGeneralId != null ? 1 : 0);
+        if (currentDefenderMedals > 4) currentDefenderMedals = 4;
         break;
       case EngagementResult.defenderVictory:
+        _incrementGeneralMedals(
+          generalsById: generalsById,
+          generalId: currentDefenderGeneralId,
+        );
+        if (currentDefenderGeneralId != null) {
+          final updated = generalsById[currentDefenderGeneralId!];
+          if (updated != null) currentDefenderMedals = updated.medals;
+        }
         survivingAttackerFactionId = null;
         break;
       case EngagementResult.stalemate:
@@ -145,9 +195,8 @@ Game resolveBattleContext(
       case EngagementResult.mutualAnnihilation:
         defenderFactionId = provinceOwnerId;
         survivingAttackerFactionId = null;
-        final remainingAttackers = sortedAttackers
-            .skip(sortedAttackers.indexOf(attacker) + 1)
-            .toList();
+        final remainingAttackers =
+            attackerSidesWithMedals.skip(attackerIndex + 1).toList();
         if (remainingAttackers.isNotEmpty) {
           final recoverCount = (initialDefenderCount * 0.2)
               .ceil()
@@ -203,7 +252,12 @@ Game resolveBattleContext(
     );
   }
 
-  return game.copyWith(worldState: newWorldState);
+  return game.copyWith(
+    worldState: newWorldState,
+    generals: game.generals
+        .map((g) => generalsById[g.id] ?? g)
+        .toList(growable: false),
+  );
 }
 
 /// Builds post-battle region state: applies casualties, garrison recovery,
@@ -288,9 +342,9 @@ Map<String, String> _clearPurchasedTilesForProvince(
 }
 
 void _sortAttackersByInitiative(
-  List<AttackingSide> attackers,
-  List<Unit> allUnits,
+  List<_AttackingSideInBattle> attackers,
   Map<String, Unit> unitsById,
+  Random rng,
 ) {
   int cavalryCount(AttackingSide side) {
     var count = 0;
@@ -303,21 +357,116 @@ void _sortAttackersByInitiative(
     return count;
   }
 
+  final tieBreakRoll = rng.nextInt(1 << 31);
+  int tieRank(String factionId) => Object.hash(factionId, tieBreakRoll);
+
   attackers.sort((a, b) {
-    final cavA = cavalryCount(a);
-    final cavB = cavalryCount(b);
-    final totalA = a.unitIds.length;
-    final totalB = b.unitIds.length;
+    final cavA = cavalryCount(a.side);
+    final cavB = cavalryCount(b.side);
+    final totalA = a.side.unitIds.length;
+    final totalB = b.side.unitIds.length;
     final shareA = totalA > 0 ? cavA / totalA : 0.0;
     final shareB = totalB > 0 ? cavB / totalB : 0.0;
     final initA = shareA * initiativeCavalryShareWeight +
-        a.generalMedals * initiativeGeneralMedalWeight;
+        a.side.generalMedals * initiativeGeneralMedalWeight;
     final initB = shareB * initiativeCavalryShareWeight +
-        b.generalMedals * initiativeGeneralMedalWeight;
+        b.side.generalMedals * initiativeGeneralMedalWeight;
     final cmp = initB.compareTo(initA);
     if (cmp != 0) return cmp;
-    return a.factionId.compareTo(b.factionId);
+    return tieRank(a.side.factionId).compareTo(tieRank(b.side.factionId));
   });
+}
+
+class _AssignedGeneral {
+  const _AssignedGeneral({
+    required this.generalId,
+    required this.medals,
+  });
+
+  final String? generalId;
+  final int medals;
+}
+
+class _GeneralAssignment {
+  const _GeneralAssignment({
+    required this.attackerByFactionId,
+    required this.defenderGeneralId,
+    required this.defenderMedals,
+  });
+
+  final Map<String, _AssignedGeneral> attackerByFactionId;
+  final String? defenderGeneralId;
+  final int defenderMedals;
+}
+
+class _AttackingSideInBattle {
+  const _AttackingSideInBattle({
+    required this.side,
+    required this.assignedGeneralId,
+  });
+
+  final AttackingSide side;
+  final String? assignedGeneralId;
+}
+
+_GeneralAssignment _assignGeneralsForBattleContext({
+  required Game game,
+  required BattleContext ctx,
+  required Random rng,
+}) {
+  final assignedGeneralIds = <String>{};
+
+  _AssignedGeneral assignForFaction(String factionId) {
+    final available = game.generals
+        .where(
+          (g) => g.ownerId == factionId && !assignedGeneralIds.contains(g.id),
+        )
+        .toList();
+    if (available.isEmpty) {
+      return _AssignedGeneral(
+        generalId: null,
+        medals: _fallbackGeneralMedalsFromLeader(game, factionId),
+      );
+    }
+    final selected = available[rng.nextInt(available.length)];
+    assignedGeneralIds.add(selected.id);
+    return _AssignedGeneral(
+      generalId: selected.id,
+      medals: selected.medals.clamp(0, 4),
+    );
+  }
+
+  final attackerByFactionId = <String, _AssignedGeneral>{};
+  for (final attacker in ctx.attackers) {
+    attackerByFactionId[attacker.factionId] = assignForFaction(attacker.factionId);
+  }
+  final defender = assignForFaction(ctx.defenderFactionId);
+  return _GeneralAssignment(
+    attackerByFactionId: attackerByFactionId,
+    defenderGeneralId: defender.generalId,
+    defenderMedals: defender.medals,
+  );
+}
+
+int _fallbackGeneralMedalsFromLeader(Game game, String factionId) {
+  final leaderMult = leaderBonusForFaction(game, factionId);
+  if (leaderMult >= 1.25) return 4;
+  if (leaderMult >= 1.20) return 3;
+  if (leaderMult >= 1.15) return 2;
+  if (leaderMult >= 1.10) return 1;
+  return 0;
+}
+
+void _incrementGeneralMedals({
+  required Map<String, General> generalsById,
+  required String? generalId,
+}) {
+  if (generalId == null) return;
+  final current = generalsById[generalId];
+  if (current == null) return;
+  generalsById[generalId] = current.copyWith(
+    medals: (current.medals + 1).clamp(0, 4),
+  );
 }
 
 int _defenderEffectiveLevel(Game game, String defenderFactionId) {

--- a/packages/colonizethis_logic/lib/src/combat/conflict_detection.dart
+++ b/packages/colonizethis_logic/lib/src/combat/conflict_detection.dart
@@ -35,6 +35,18 @@ class AttackingSide {
   final String factionId;
   final List<String> unitIds;
   final int generalMedals;
+
+  AttackingSide copyWith({
+    String? factionId,
+    List<String>? unitIds,
+    int? generalMedals,
+  }) {
+    return AttackingSide(
+      factionId: factionId ?? this.factionId,
+      unitIds: unitIds ?? this.unitIds,
+      generalMedals: generalMedals ?? this.generalMedals,
+    );
+  }
 }
 
 /// Conflict detection after movement. SPEC/program/combat-resolution.md.

--- a/packages/colonizethis_logic/test/combat_resolver_test.dart
+++ b/packages/colonizethis_logic/test/combat_resolver_test.dart
@@ -432,6 +432,234 @@ void main() {
           reason:
               'deployment limit 12 with Nationalism: at most 12 participate');
     });
+
+    test('assigned winning general gains +1 medal immediately and persists', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 5),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'p', regionId: 'oldWorld', ownerId: 'def')
+            ],
+            units: [
+              Unit(
+                id: 'a1',
+                type: 'grenadiers',
+                ownerId: 'att',
+                locationProvinceId: 'p',
+              ),
+              Unit(
+                id: 'a2',
+                type: 'grenadiers',
+                ownerId: 'att',
+                locationProvinceId: 'p',
+              ),
+              Unit(
+                id: 'd1',
+                type: 'peasant_levies',
+                ownerId: 'def',
+                locationProvinceId: 'p',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'att', displayName: 'Att', isHuman: true),
+          Player(id: 'def', displayName: 'Def', isHuman: true),
+        ],
+        generals: const [
+          General(id: 'g-att', ownerId: 'att', medals: 1),
+        ],
+      );
+      const ctx = BattleContext(
+        provinceId: 'p',
+        regionId: 'oldWorld',
+        defenderFactionId: 'def',
+        defenderUnitIds: ['d1'],
+        attackers: [
+          AttackingSide(factionId: 'att', unitIds: ['a1', 'a2']),
+        ],
+        fortLevel: 0,
+        terrain: 'plains',
+      );
+
+      final after = resolveBattleContext(game, ctx);
+      final updatedGeneral =
+          after.generals.firstWhere((g) => g.id == 'g-att');
+      expect(updatedGeneral.medals, 2);
+    });
+
+    test('leader fallback medals apply when no uncommitted general exists', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'p', regionId: 'oldWorld', ownerId: 'def')
+            ],
+            units: [
+              Unit(
+                id: 'a1',
+                type: 'grenadiers',
+                ownerId: 'att',
+                locationProvinceId: 'p',
+              ),
+              Unit(
+                id: 'd1',
+                type: 'grenadiers',
+                ownerId: 'def',
+                locationProvinceId: 'p',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(
+            id: 'att',
+            displayName: 'Att',
+            isHuman: true,
+            leaderKey: 'napoleon',
+          ),
+          Player(id: 'def', displayName: 'Def', isHuman: true),
+        ],
+      );
+      const ctx = BattleContext(
+        provinceId: 'p',
+        regionId: 'oldWorld',
+        defenderFactionId: 'def',
+        defenderUnitIds: ['d1'],
+        attackers: [
+          AttackingSide(factionId: 'att', unitIds: ['a1']),
+        ],
+        fortLevel: 0,
+        terrain: 'plains',
+      );
+
+      final after = resolveBattleContext(game, ctx);
+      // No assigned generals exist; fallback medals should not create new general records.
+      expect(after.generals, isEmpty);
+    });
+
+    test('general medals are capped at 4 on immediate engagement win', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 6),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'p', regionId: 'oldWorld', ownerId: 'def')
+            ],
+            units: [
+              Unit(
+                id: 'a1',
+                type: 'grenadiers',
+                ownerId: 'att',
+                locationProvinceId: 'p',
+              ),
+              Unit(
+                id: 'a2',
+                type: 'grenadiers',
+                ownerId: 'att',
+                locationProvinceId: 'p',
+              ),
+              Unit(
+                id: 'd1',
+                type: 'peasant_levies',
+                ownerId: 'def',
+                locationProvinceId: 'p',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'att', displayName: 'Att', isHuman: true),
+          Player(id: 'def', displayName: 'Def', isHuman: true),
+        ],
+        generals: const [
+          General(id: 'g-att', ownerId: 'att', medals: 4),
+        ],
+      );
+      const ctx = BattleContext(
+        provinceId: 'p',
+        regionId: 'oldWorld',
+        defenderFactionId: 'def',
+        defenderUnitIds: ['d1'],
+        attackers: [
+          AttackingSide(factionId: 'att', unitIds: ['a1', 'a2']),
+        ],
+        fortLevel: 0,
+        terrain: 'plains',
+      );
+      final after = resolveBattleContext(game, ctx);
+      final updatedGeneral =
+          after.generals.firstWhere((g) => g.id == 'g-att');
+      expect(updatedGeneral.medals, 4);
+    });
+
+    test('battle tie-break is deterministic for same seed and context', () {
+      final makeGame = () => Game(
+            id: 'g1',
+            globalGameSeed: 1234,
+            worldState: WorldState(
+              turnState:
+                  const TurnState(phase: TurnPhase.orders, turnNumber: 8),
+              oldWorld: RegionData(
+                provinces: const [
+                  Province(id: 'p', regionId: 'oldWorld', ownerId: 'def'),
+                ],
+                units: [
+                  Unit(
+                    id: 'a1',
+                    type: 'pikemen',
+                    ownerId: 'attA',
+                    locationProvinceId: 'p',
+                  ),
+                  Unit(
+                    id: 'a2',
+                    type: 'pikemen',
+                    ownerId: 'attB',
+                    locationProvinceId: 'p',
+                  ),
+                  Unit(
+                    id: 'd1',
+                    type: 'pikemen',
+                    ownerId: 'def',
+                    locationProvinceId: 'p',
+                  ),
+                ],
+              ),
+              newWorld: const RegionData(),
+            ),
+            players: const [
+              Player(id: 'attA', displayName: 'A', isHuman: true),
+              Player(id: 'attB', displayName: 'B', isHuman: true),
+              Player(id: 'def', displayName: 'D', isHuman: true),
+            ],
+          );
+      const ctx = BattleContext(
+        provinceId: 'p',
+        regionId: 'oldWorld',
+        defenderFactionId: 'def',
+        defenderUnitIds: ['d1'],
+        attackers: [
+          AttackingSide(factionId: 'attA', unitIds: ['a1']),
+          AttackingSide(factionId: 'attB', unitIds: ['a2']),
+        ],
+        fortLevel: 0,
+        terrain: 'plains',
+      );
+
+      final r1 = resolveBattleContext(makeGame(), ctx);
+      final r2 = resolveBattleContext(makeGame(), ctx);
+      expect(r1.worldState.oldWorld.provinces, r2.worldState.oldWorld.provinces);
+      expect(r1.worldState.oldWorld.units, r2.worldState.oldWorld.units);
+      expect(r1.generals, r2.generals);
+    });
   });
 
   group('resolveBattleContext Spy timer interaction', () {


### PR DESCRIPTION
## Summary
- align combat specs for deterministic RNG initiative tie-breaks, leader-based fallback general medals, carried-winner defender medals, and immediate per-engagement medal progression
- implement battle-context general assignment in combat resolver with seeded RNG and persistent general medal updates (`+1` per engagement win, capped at `4`)
- add combat tests covering immediate medal gain persistence, medal cap behavior, and deterministic tie-break outcomes

## Test plan
- [x] `dart test packages/colonizethis_logic/test/combat_resolver_test.dart`
- [x] `dart test packages/colonizethis_logic/test/combat_resolver_probabilistic_test.dart`
- [ ] `dart test packages/colonizethis_logic/test/turn_resolver_test.dart` (currently has an unrelated existing failure: `resolveTurnForGameFromOrderEngine preserves diplomatic orders through merge`)

## Linked issues
- parent tracking issue: #28
- implementation sub-issue: #1273
- logging sub-issue (separate): #1274

Made with [Cursor](https://cursor.com)