### PR TITLE
Land combat lifecycle logging (#1274)

### DIFF
--- a/SPEC/program/combat-resolution.md
+++ b/SPEC/program/combat-resolution.md
@@ -96,6 +96,10 @@ Separate resolver for simulation and Monte Carlo analysis; **not** used in the m
 - Casualty selection: strength-weighted (weight ∝ 1 / (strength + 0.1)).
 - Deterministic given same seed.
 
+## Observability
+
+Structured **land** combat logs (`logic: combat …`) are specified in [ctdev-logging.md](ctdev-logging.md) § Land combat: conflict detection, `battle_start`, per-engagement (debug, auto-resolve), and `battle_apply`. Global logger emission does not change resolver return values or determinism of game state.
+
 ## Integration
 
 - **Phase:** Combat phase, after Movement.
@@ -104,7 +108,7 @@ Separate resolver for simulation and Monte Carlo analysis; **not** used in the m
 
 ## Constraints
 
-- Resolver is a pure function: same inputs (including seed) → same output.
+- Resolver is a pure function: same inputs (including seed) → same **returned** `Game` / world state. Emitting logs via the global Dart `logger` is allowed for observability and is not part of the functional output.
 - No global RNG access; callers provide explicit seed when randomness is needed.
 - Province battles are independent; processing order is deterministic (prefixed province id `regionId|localId`).
 - Results applied in a single pass after full chain resolution per BattleContext.

--- a/SPEC/program/ctdev-logging.md
+++ b/SPEC/program/ctdev-logging.md
@@ -37,6 +37,17 @@
 
 - **ctdev:** App lifecycle, init game submit, start sim (session id), turn steps, exceptions in turn handlers.
 - **logic:** Turn resolution (phases), order engine (validation, rejections), order suggestion API (all suggestion functions and results), movement, combat, naval, extraction, production, consumption, research, diplomacy, init game orchestration, game setup.
+
+### Land combat (`logic:`)
+
+During the Combat phase, **land** resolution emits grep-oriented lines (token `logic: combat`). **Naval** combat logging is unchanged unless separately specified.
+
+- **Conflict detection** (info): start and end of detection for the phase, including `turn` and `battleContexts` count. Emitted from turn combat orchestration (`_runCombatPhase`), not from standalone `detectConflicts` unit tests in isolation.
+- **Per battle** (info): `battle_start` with `turn`, `battleIndex`, prefixed `regionId` and `provinceId`, `defenderFactionId`, `attackerSides`, `attackerUnitsTotal`, and `mode` (`autoResolve` or `quickBattle`).
+- **Per engagement** (debug, auto-resolve only): each executed engagement logs `attackerFactionId`, `result` (`EngagementResult` enum name), and `attCasualties` / `defCasualties` **counts** only (no per-unit id lists at info).
+- **World application** (info): `battle_apply` with `regionId`, `provinceId`, `mode`, `provinceFlipped`, casualty counts as applicable, `ownerAfter` for the province when resolved, and for Quick Battle `winner` (`QuickBattleWinner` enum name).
+
+Message bodies use `key=value` segments separated by spaces where practical so logs are easy to filter (e.g. `rg 'logic: combat battle_apply'`).
 - **ai:** Order generation, planner, goals/candidates. Info = major decisions; debug = full evals (goal weights, candidate scores, perception snapshot, dossier, economy recipe scores).
 - **data:** Catalog/config lookups; fallbacks and defaults.
 - **map:** Map generation (tile map, topology), init game map view build, load savegame view build.
@@ -55,3 +66,15 @@ See [ctdev-app.md](ctdev-app.md) for UI behaviour (session ID display, Sim Log p
 - **Levels:** File at debug and above; in-memory Sim Log at info and above, last 10 lines, cleared at start of every turn (resolve/step).
 - **Exceptions:** Log calls use `error` and `stackTrace` where applicable; uncaught errors in `runZonedGuarded` logged with stack.
 - **Scope:** ctdev, logic, ai, data, map, save each log key operations (start/end of flows, rejections, errors) with the specified prefixes; no `print` for operational/diagnostic output in ctdev and in-scope flows (or document exemptions).
+
+### Land combat — acceptance criteria
+
+- **Given** a game state after Movement where at least one land `BattleContext` exists for the turn, **when** the system runs the Combat phase (`_runCombatPhase`), **then** the logger emits at **info** a line containing `logic: combat conflict_detection start` with `turn=<integer>` and a line containing `logic: combat conflict_detection end` with the same `turn` and `battleContexts=<non-negative integer>`.
+
+- **Given** a land `BattleContext` processed in that phase, **when** the system begins resolving that battle, **then** the logger emits at **info** a line containing `logic: combat battle_start` with `regionId=`, `provinceId=`, `defenderFactionId=`, `attackerSides=<integer>`, `attackerUnitsTotal=<integer>`, and `mode=autoResolve` or `mode=quickBattle`.
+
+- **Given** auto-resolve for a `BattleContext` with at least one executed engagement, **when** each engagement completes, **then** the logger emits at **debug** a line containing `logic: combat engagement` with `attackerFactionId=<string>`, `result=<EngagementResult enum name>`, `attCasualties=<integer>`, and `defCasualties=<integer>`.
+
+- **Given** auto-resolve completes for a `BattleContext`, **when** the system applies the result to world state, **then** the logger emits at **info** a line containing `logic: combat battle_apply` with `mode=autoResolve`, `provinceFlipped=true` or `provinceFlipped=false`, `casualtiesApplied=<integer>`, and `ownerAfter=<faction id string or empty if unknown>`.
+
+- **Given** Quick Battle completes for a `BattleContext`, **when** the system applies the result to world state, **then** the logger emits at **info** a line containing `logic: combat battle_apply` with `mode=quickBattle`, `winner=<QuickBattleWinner enum name>`, `provinceFlipped=true` or `provinceFlipped=false`, and per-side casualty **counts** (`attCasualties`, `defCasualties`).

--- a/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
@@ -8,6 +9,8 @@ import '../world/unit_lookup.dart';
 import 'conflict_detection.dart';
 import 'leader_bonus_helpers.dart';
 import 'military_strength.dart';
+
+final _combatLog = logicLogger();
 
 /// Result of one engagement. SPEC/game/combat.md.
 enum EngagementResult {
@@ -151,6 +154,12 @@ Game resolveBattleContext(
       attackerLeaderMultiplier: attackerLeaderMult,
       defenderLeaderMultiplier: defenderLeaderMult,
     );
+    _combatLog.d(
+      'logic: combat engagement regionId=${ctx.regionId} provinceId=${ctx.provinceId} '
+      'attackerFactionId=${attacker.side.factionId} result=${outcome.result.name} '
+      'attCasualties=${outcome.attackerCasualties.length} '
+      'defCasualties=${outcome.defenderCasualties.length}',
+    );
 
     for (final id in outcome.attackerCasualties) {
       allCasualties.add(id);
@@ -232,6 +241,18 @@ Game resolveBattleContext(
     defenderFactionId: ctx.defenderFactionId,
     survivingAttackerFactionId: survivingAttackerFactionId,
     defenderUnitIds: defenderUnitIds,
+  );
+  var ownerAfter = '';
+  for (final p in post.region.provinces) {
+    if (p.id == ctx.provinceId) {
+      ownerAfter = p.ownerId ?? '';
+      break;
+    }
+  }
+  _combatLog.i(
+    'logic: combat battle_apply regionId=${ctx.regionId} provinceId=${ctx.provinceId} '
+    'mode=autoResolve provinceFlipped=${post.provinceChangedOwner} '
+    'casualtiesApplied=${allCasualties.length} ownerAfter=$ownerAfter',
   );
 
   var newWorldState = ctx.regionId == kRegionOldWorld

--- a/packages/colonizethis_logic/lib/src/turn/combat_phase_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/turn/combat_phase_helpers.dart
@@ -1,6 +1,7 @@
 // Helpers for the combat phase: apply one land battle (quick or auto-resolve), evidence, dialogue.
 // SPEC/program/turn-resolution-phase-details.md § Combat. Called from turn_resolver._runCombatPhase.
 
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../combat/combat_resolver.dart';
@@ -11,6 +12,8 @@ import '../constants.dart';
 import '../dossier/evidence_rules.dart';
 import '../dossier/event_dialogue.dart';
 import '../game_events.dart';
+
+final _combatPhaseLog = logicLogger();
 
 /// Runs one land battle: applies result (quick battle or auto-resolve), evidence, and dialogue.
 Game runOneLandBattle(
@@ -24,6 +27,15 @@ Game runOneLandBattle(
   void Function(DialogueEvent)? onDialogue,
   void Function(GameEvent)? onGameEvent,
 }) {
+  final attackerUnitsTotal =
+      ctx.attackers.fold<int>(0, (s, a) => s + a.unitIds.length);
+  _combatPhaseLog.i(
+    'logic: combat battle_start turn=$turn battleIndex=$battleIndex '
+    'regionId=${ctx.regionId} provinceId=${ctx.provinceId} '
+    'defenderFactionId=${ctx.defenderFactionId} attackerSides=${ctx.attackers.length} '
+    'attackerUnitsTotal=$attackerUnitsTotal mode=${mode.name}',
+  );
+
   String? winnerId;
   Map<String, int> casualties = {};
 
@@ -32,6 +44,15 @@ Game runOneLandBattle(
         seed: state.worldState.turnState.turnNumber);
     final qbResult = resolveQuickBattle(input);
     state = applyQuickBattleResultToGame(state, ctx, qbResult);
+    final qbFlipped = qbResult.provinceFlips &&
+        qbResult.winner == QuickBattleWinner.attacker &&
+        ctx.attackers.isNotEmpty;
+    _combatPhaseLog.i(
+      'logic: combat battle_apply regionId=${ctx.regionId} provinceId=${ctx.provinceId} '
+      'mode=quickBattle winner=${qbResult.winner.name} provinceFlipped=$qbFlipped '
+      'attCasualties=${qbResult.attackerCasualties.length} '
+      'defCasualties=${qbResult.defenderCasualties.length}',
+    );
 
     // Determine winner and casualties
     if (qbResult.winner == QuickBattleWinner.attacker) {

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -921,9 +921,13 @@ Game _runCombatPhase(
     for (final p in game.players) p.id: p.capitalProvinceId,
   };
   Game state = applyMinorMilitaryParity(game);
-  final battles = detectConflicts(state, orders);
-  final defaultMode = game.defaultCombatMode ?? CombatMode.autoResolve;
   final turn = state.worldState.turnState.turnNumber;
+  _log.i('logic: combat conflict_detection start turn=$turn');
+  final battles = detectConflicts(state, orders);
+  _log.i(
+    'logic: combat conflict_detection end turn=$turn battleContexts=${battles.length}',
+  );
+  final defaultMode = game.defaultCombatMode ?? CombatMode.autoResolve;
   var seed = (game.globalGameSeed ?? 0) ^ (turn * 0x9E3779B1);
   var battleIndex = 0;
   for (final ctx in battles) {

--- a/packages/colonizethis_logic/test/combat_logging_test.dart
+++ b/packages/colonizethis_logic/test/combat_logging_test.dart
@@ -1,0 +1,481 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
+
+List<String> _combatMessages(List<LogEvent> events) => [
+      for (final e in events)
+        if (e.message.contains('logic: combat')) e.message,
+    ];
+
+void main() {
+  group('land combat logging', () {
+    late List<LogEvent> capturedEvents;
+    late void Function(LogEvent) listener;
+
+    setUp(() {
+      capturedEvents = [];
+      listener = capturedEvents.add;
+      Logger.addLogListener(listener);
+      Logger.level = Level.debug;
+    });
+
+    tearDown(() {
+      Logger.removeLogListener(listener);
+      capturedEvents.clear();
+      Logger.level = Level.info;
+    });
+
+    test('resolveBattleContext emits engagement (debug) and battle_apply (info)', () {
+      final attackerUnits = [
+        Unit(
+          id: 'a1',
+          type: 'grenadiers',
+          ownerId: 'att',
+          locationProvinceId: 'p',
+          medals: 3,
+        ),
+        Unit(
+          id: 'a2',
+          type: 'grenadiers',
+          ownerId: 'att',
+          locationProvinceId: 'p',
+          medals: 2,
+        ),
+      ];
+      final defenderUnits = [
+        Unit(
+          id: 'd1',
+          type: 'peasant_levies',
+          ownerId: 'def',
+          locationProvinceId: 'p',
+          medals: 0,
+        ),
+      ];
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'p', regionId: 'oldWorld', ownerId: 'def'),
+            ],
+            units: [...attackerUnits, ...defenderUnits],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(
+            id: 'att',
+            displayName: 'France',
+            isHuman: true,
+            leaderKey: 'napoleon',
+          ),
+          Player(
+            id: 'def',
+            displayName: 'Prussia',
+            isHuman: false,
+            leaderKey: 'frederick',
+          ),
+        ],
+      );
+      const ctx = BattleContext(
+        provinceId: 'p',
+        regionId: 'oldWorld',
+        defenderFactionId: 'def',
+        defenderUnitIds: ['d1'],
+        attackers: [
+          AttackingSide(factionId: 'att', unitIds: ['a1', 'a2']),
+        ],
+        fortLevel: 0,
+        terrain: 'plains',
+      );
+
+      resolveBattleContext(game, ctx);
+
+      final combat = _combatMessages(capturedEvents);
+      expect(
+        combat.where((m) => m.contains('logic: combat engagement')).length,
+        1,
+      );
+      final engagement = combat.firstWhere(
+        (m) => m.contains('logic: combat engagement'),
+      );
+      expect(engagement, contains('result='));
+      expect(engagement, contains('attackerFactionId=att'));
+      expect(engagement, contains('attCasualties='));
+      expect(engagement, contains('defCasualties='));
+
+      final apply = combat.firstWhere(
+        (m) => m.contains('logic: combat battle_apply'),
+      );
+      expect(apply, contains('mode=autoResolve'));
+      expect(apply, contains('provinceFlipped='));
+      expect(apply, contains('casualtiesApplied='));
+      expect(apply, contains('ownerAfter='));
+
+      expect(
+        capturedEvents.any(
+          (e) =>
+              e.level == Level.debug &&
+              e.message.contains('logic: combat engagement'),
+        ),
+        isTrue,
+      );
+      expect(
+        capturedEvents.any(
+          (e) =>
+              e.level == Level.info &&
+              e.message.contains('logic: combat battle_apply'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('two attacker sides emit one debug line per executed engagement', () {
+      // First attacker must lose (defender still holds); otherwise a decisive
+      // first attacker victory skips remaining attackers (no second engagement).
+      final game = Game(
+        id: 'g1',
+        globalGameSeed: 1234,
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 8),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'p', regionId: 'oldWorld', ownerId: 'def'),
+            ],
+            units: [
+              Unit(
+                id: 'a1',
+                type: 'peasant_levies',
+                ownerId: 'attA',
+                locationProvinceId: 'p',
+              ),
+              Unit(
+                id: 'a2',
+                type: 'peasant_levies',
+                ownerId: 'attB',
+                locationProvinceId: 'p',
+              ),
+              Unit(
+                id: 'd1',
+                type: 'grenadiers',
+                ownerId: 'def',
+                locationProvinceId: 'p',
+                medals: 2,
+              ),
+              Unit(
+                id: 'd2',
+                type: 'grenadiers',
+                ownerId: 'def',
+                locationProvinceId: 'p',
+                medals: 2,
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'attA', displayName: 'A', isHuman: true),
+          Player(id: 'attB', displayName: 'B', isHuman: true),
+          Player(id: 'def', displayName: 'D', isHuman: true),
+        ],
+      );
+      const ctx = BattleContext(
+        provinceId: 'p',
+        regionId: 'oldWorld',
+        defenderFactionId: 'def',
+        defenderUnitIds: ['d1', 'd2'],
+        attackers: [
+          AttackingSide(factionId: 'attA', unitIds: ['a1']),
+          AttackingSide(factionId: 'attB', unitIds: ['a2']),
+        ],
+        fortLevel: 0,
+        terrain: 'plains',
+      );
+
+      resolveBattleContext(game, ctx);
+
+      final engagementLines = _combatMessages(capturedEvents)
+          .where((m) => m.contains('logic: combat engagement'))
+          .toList();
+      expect(engagementLines.length, 2);
+      expect(
+        engagementLines.where((m) => m.contains('attackerFactionId=attA')).length,
+        1,
+      );
+      expect(
+        engagementLines.where((m) => m.contains('attackerFactionId=attB')).length,
+        1,
+      );
+    });
+
+    test('Combat phase logs conflict_detection and battle_start for moved-in attack', () {
+      final topology = MapTopology(
+        nodes: [
+          const TopologyNode(
+            id: 'P1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          const TopologyNode(
+            id: 'P2',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+        ],
+        edges: [
+          const TopologyEdge(id1: 'P1', id2: 'P2'),
+        ],
+      );
+
+      const ow = 'oldWorld';
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+            ],
+            units: [
+              Unit(
+                id: 'u1',
+                type: 'grenadiers',
+                ownerId: 'p1',
+                locationProvinceId: '$ow|P1',
+                medals: 2,
+              ),
+              Unit(
+                id: 'u2',
+                type: 'peasant_levies',
+                ownerId: 'p2',
+                locationProvinceId: '$ow|P2',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: [
+          Player(id: 'p1', displayName: 'A', isHuman: true, militaryLevel: 3),
+          Player(id: 'p2', displayName: 'B', isHuman: true, militaryLevel: 1),
+        ],
+      );
+
+      final orders = Orders(
+        moveOrdersByPlayerId: {
+          'p1': [
+            MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P2'),
+          ],
+        },
+      );
+
+      requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: topology,
+          orders: orders,
+          extractedByPlayerId: const {},
+          defaultAssignments: const [],
+        ),
+      );
+
+      final combat = _combatMessages(capturedEvents);
+      expect(
+        combat.any((m) => m.contains('logic: combat conflict_detection start')),
+        isTrue,
+      );
+      expect(
+        combat.any(
+          (m) =>
+              m.contains('logic: combat conflict_detection end') &&
+              m.contains('battleContexts=1'),
+        ),
+        isTrue,
+      );
+      expect(
+        combat.any(
+          (m) =>
+              m.contains('logic: combat battle_start') &&
+              m.contains('attackerSides=1') &&
+              m.contains('attackerUnitsTotal=1') &&
+              m.contains('mode=autoResolve'),
+        ),
+        isTrue,
+      );
+      expect(
+        combat.any((m) => m.contains('logic: combat engagement')),
+        isTrue,
+      );
+      expect(
+        combat.any(
+          (m) =>
+              m.contains('logic: combat battle_apply') &&
+              m.contains('mode=autoResolve'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('Quick Battle path logs battle_apply quickBattle not auto engagement', () {
+      final topology = MapTopology(
+        nodes: [
+          const TopologyNode(
+            id: 'P1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          const TopologyNode(
+            id: 'P2',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+        ],
+        edges: [
+          const TopologyEdge(id1: 'P1', id2: 'P2'),
+        ],
+      );
+
+      const ow = 'oldWorld';
+      final game = Game(
+        id: 'g1',
+        defaultCombatMode: CombatMode.quickBattle,
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+            ],
+            units: [
+              Unit(
+                id: 'u1',
+                type: 'grenadiers',
+                ownerId: 'p1',
+                locationProvinceId: '$ow|P1',
+                medals: 2,
+              ),
+              Unit(
+                id: 'u2',
+                type: 'peasant_levies',
+                ownerId: 'p2',
+                locationProvinceId: '$ow|P2',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: [
+          Player(id: 'p1', displayName: 'A', isHuman: true, militaryLevel: 3),
+          Player(id: 'p2', displayName: 'B', isHuman: true, militaryLevel: 1),
+        ],
+      );
+
+      final orders = Orders(
+        moveOrdersByPlayerId: {
+          'p1': [
+            MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P2'),
+          ],
+        },
+      );
+
+      requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: topology,
+          orders: orders,
+          extractedByPlayerId: const {},
+          defaultAssignments: const [],
+        ),
+      );
+
+      final combat = _combatMessages(capturedEvents);
+      expect(
+        combat.any(
+          (m) =>
+              m.contains('logic: combat battle_start') &&
+              m.contains('mode=quickBattle'),
+        ),
+        isTrue,
+      );
+      expect(
+        combat.any(
+          (m) =>
+              m.contains('logic: combat battle_apply') &&
+              m.contains('mode=quickBattle') &&
+              m.contains('winner='),
+        ),
+        isTrue,
+      );
+      expect(
+        combat.any((m) => m.contains('logic: combat engagement')),
+        isFalse,
+      );
+    });
+
+    test('no land battles still logs conflict_detection end with battleContexts=0', () {
+      final topology = MapTopology(
+        nodes: [
+          const TopologyNode(
+            id: 'P1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+        ],
+        edges: const [],
+      );
+
+      const ow = 'oldWorld';
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+            ],
+            units: [
+              Unit(
+                id: 'u1',
+                type: 'grenadiers',
+                ownerId: 'p1',
+                locationProvinceId: '$ow|P1',
+                medals: 2,
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: [
+          Player(id: 'p1', displayName: 'A', isHuman: true, militaryLevel: 3),
+        ],
+      );
+
+      requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: topology,
+          orders: const Orders(),
+          extractedByPlayerId: const {},
+          defaultAssignments: const [],
+        ),
+      );
+
+      final combat = _combatMessages(capturedEvents);
+      expect(
+        combat.any(
+          (m) =>
+              m.contains('logic: combat conflict_detection end') &&
+              m.contains('battleContexts=0'),
+        ),
+        isTrue,
+      );
+      expect(
+        combat.any((m) => m.contains('logic: combat battle_start')),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Implements GitHub #1274 (parent #28): structured `logic:` land combat logs per `SPEC/program/ctdev-logging.md`.

## Changes
- **Conflict detection** (info): start/end + `battleContexts` count from `_runCombatPhase` only.
- **Per battle** (info): `battle_start` with region/province, defender, `attackerSides`, `attackerUnitsTotal`, `mode`.
- **Per engagement** (debug, auto-resolve): `engagement` with `attackerFactionId`, `result`, casualty counts.
- **World apply** (info): `battle_apply` for auto-resolve and Quick Battle (winner, flip, counts).
- **Specs:** `ctdev-logging.md` § Land combat + GWT ACs; `combat-resolution.md` observability + purity note.
- **Tests:** `combat_logging_test.dart` (listener-based).

Naval logging unchanged.

## How to verify
```bash
cd packages/colonizethis_logic && dart test test/combat_logging_test.dart
```

Made with [Cursor](https://cursor.com)