### PR TITLE
feat(naval): canonical ship economy and stats for all tech-unlocked ships

### DIFF
--- a/SPEC/game/ships-and-naval.md
+++ b/SPEC/game/ships-and-naval.md
@@ -39,6 +39,54 @@ Mission choice is per fleet and stored with the fleet state. **Naval combat occu
 
 Tech unlocks per [tech-tree-naval.md](tech-tree-naval.md). Cargo holds determine transport/trade capacity (home fleet); firepower (FRP), range (RNG), armour (ARM), hull (HULL), and movement (MV) determine naval combat and interception effectiveness.
 
+### Ship build economy (canonical)
+
+**Source of truth:** The tables below are the authoritative build costs for naval `BuildUnitOrder` validation and deduction. Implementation (`ShipEconomyCatalog` and related code) MUST match these values. Commodity ids use the [commodity-catalog.md](commodity-catalog.md) canonical strings (`lumber`, `fabric`, `castIron`, `coal`).
+
+**Scaling:** Costs increase with the **unlocking tech era** (1–4) from [tech-tree-naval.md](tech-tree-naval.md). Merchants emphasize **treasury + cargo** progression; warships emphasize **hulls and combat materials**. Steam-era hulls add **cast iron** and/or **coal**.
+
+**Frozen baseline (do not change without explicit design pass):** `carrack` and `fluyte` treasury and material rows match the original Phase 5 catalog.
+
+| ship_type_id | role | unlock era | build_treasury_cost | build_inputs |
+| --- | --- | ---: | ---: | --- |
+| carrack | merchant | (none — always buildable) | 80 | `lumber`×2, `fabric`×1 |
+| fluyte | merchant | 1 | 60 | `lumber`×1, `fabric`×1 |
+| sloop | warship | 1 | 55 | `lumber`×1, `fabric`×1 |
+| trader | merchant | 2 | 75 | `lumber`×2, `fabric`×2 |
+| galleon | merchant | 2 | 95 | `lumber`×3, `fabric`×2 |
+| indiaman | merchant | 2 | 110 | `lumber`×3, `fabric`×3 |
+| frigate | warship | 3 | 105 | `lumber`×2, `fabric`×2 |
+| raider | warship | 3 | 115 | `lumber`×2, `fabric`×1, `castIron`×2 |
+| ship_of_the_line | warship | 3 | 165 | `lumber`×5, `fabric`×3 |
+| clipper | merchant | 4 | 135 | `lumber`×3, `fabric`×3 |
+| merchant_steamship | merchant | 4 | 155 | `lumber`×2, `fabric`×2, `coal`×3 |
+| ironclad | warship | 4 | 210 | `lumber`×2, `fabric`×2, `castIron`×5 |
+
+Every `ship_type_id` that appears in any `shipUnlockIds` entry in the global tech catalog MUST have exactly one row in this table. `carrack` MUST NOT appear in `shipUnlockIds` (no unlocking tech).
+
+### Ship combat and cargo stats (canonical)
+
+**Source of truth:** The table below defines per-ship **FRP**, **RNG**, **ARM**, **HULL**, **MV**, **interceptRating**, **fleeRating**, and **cargoHold** for naval combat, interception, and home-fleet cargo (`NavalStatsCatalog` and related code MUST match). **Warships** use `cargoHold = 0` (they do not contribute merchant cargo capacity). **Merchants** use `cargoHold ≥ 1`.
+
+**Scaling:** Stats generally increase with unlock era; fast interceptors (sloop, frigate, raider) emphasize **interceptRating**, **fleeRating**, and **MV**; line ships emphasize **FRP**, **ARM**, and **HULL**.
+
+**Frozen baseline:** `carrack` and `fluyte` rows match the original Phase 5 catalog.
+
+| ship_type_id | role | FRP | RNG | ARM | HULL | MV | intercept_rating | flee_rating | cargo_hold |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| carrack | merchant | 2 | 1 | 1 | 2 | 2 | 1 | 2 | 3 |
+| fluyte | merchant | 1 | 1 | 1 | 1 | 2 | 1 | 3 | 4 |
+| sloop | warship | 2 | 2 | 1 | 2 | 3 | 4 | 4 | 0 |
+| trader | merchant | 1 | 1 | 1 | 2 | 2 | 1 | 3 | 5 |
+| galleon | merchant | 2 | 1 | 2 | 4 | 2 | 1 | 2 | 6 |
+| indiaman | merchant | 2 | 2 | 2 | 5 | 2 | 1 | 2 | 8 |
+| frigate | warship | 4 | 3 | 2 | 4 | 3 | 5 | 4 | 0 |
+| raider | warship | 3 | 2 | 2 | 3 | 4 | 6 | 5 | 0 |
+| ship_of_the_line | warship | 6 | 4 | 4 | 8 | 2 | 2 | 1 | 0 |
+| clipper | merchant | 1 | 2 | 1 | 3 | 4 | 2 | 4 | 7 |
+| merchant_steamship | merchant | 2 | 2 | 3 | 5 | 3 | 1 | 3 | 9 |
+| ironclad | warship | 5 | 3 | 8 | 6 | 3 | 2 | 2 | 0 |
+
 ---
 
 ## Ship Reveal Mechanic
@@ -214,10 +262,22 @@ raidEfficiency = 0.3 to 0.7 depending on relative strength
   When the System resolves overseas transport and trade for that turn  
   Then the System uses the interception probabilities and escort protection formulas in this document (including the definitions of `escortStrength` and `cargoStrength`) to determine whether cargo and civilian ships are lost, reduces delivered quantities and ship counts accordingly, and applies at most the documented maximum loss reduction from escorts.
 
+- Given the global tech catalog’s `shipUnlockIds` lists and the ship build economy table in this document  
+  When the System loads ship build data  
+  Then the System defines a build economy entry for every `ship_type_id` in that table, `carrack` has no unlocking tech (absent from `unlockingTechByShipId`), every id referenced in any `shipUnlockIds` array appears in the table with costs exactly as listed, and implementation values match the table.
+
+- Given the ship combat and cargo stats table in this document  
+  When the System resolves naval combat, interception scoring, or home-fleet cargo capacity  
+  Then the System uses the listed FRP, RNG, ARM, HULL, MV, intercept_rating, flee_rating, and cargo_hold for each `ship_type_id`, with warship `cargo_hold` equal to 0 for transport capacity sums.
+
+- Given a player owns a capital province adjacent to a sea zone, has treasury and stockpile sufficient for a non-`carrack` ship per the build economy table, and has the unlocking tech for that ship in `techUnlocked`  
+  When the player issues a valid naval `BuildUnitOrder` for that ship type during the build phase  
+  Then the System accepts the order, deducts treasury and commodities per the table, and adds the ship to the home fleet (subject to topology and capital rules elsewhere in this document).
+
 ---
 
 ## Testing Approach
 
-- **Unit tests:** Cover naval strength aggregation, retreat probability, interception probability, and the trade/transport interception formulas (including use of `escortStrength` and `cargoStrength`) with deterministic inputs and expected outputs.
+- **Unit tests:** Cover naval strength aggregation, retreat probability, interception probability, and the trade/transport interception formulas (including use of `escortStrength` and `cargoStrength`) with deterministic inputs and expected outputs. Cover alignment of `ShipEconomyCatalog` / `NavalStatsCatalog` with the canonical tables in this document (every tech-unlocked ship type plus `carrack`) and at least one sim scenario that builds a non-`carrack` ship when tech and resources are satisfied.
 - **Integration tests:** Use sim_game or focused scenarios to verify ship reveal on movement into a sea zone, mission handling (Move/Patrol/Blockade/Beachhead/Defend), one-turn beachhead lifecycle and its interaction with land invasions, and trade/transport raids during Extraction/Trade.
 - **Scenario tests:** Construct scenario data for edge cases (e.g. minimal escorts, overwhelming escorts, symmetric and asymmetric naval strength) to validate that interception and raid outcomes remain within documented clamps and respect war/peace conditions.

--- a/SPEC/game/tech-tree-naval.md
+++ b/SPEC/game/tech-tree-naval.md
@@ -44,7 +44,7 @@
 
 - Given the naval tech table in this doc and the global tech catalog  
   When the System validates the catalog at startup  
-  Then the System ensures that each naval tech id is unique, that its prerequisites refer to techs present in the catalog, and that each ship type unlocked by these techs has a corresponding ship definition in the naval unit specs referenced by [ships-and-naval.md](ships-and-naval.md).
+  Then the System ensures that each naval tech id is unique, that its prerequisites refer to techs present in the catalog, and that each ship type unlocked by these techs has corresponding **build economy** and **naval stats** rows in the canonical tables under [ships-and-naval.md](ships-and-naval.md) (ship build economy and ship combat/cargo stats), with implementation catalogs matching those tables.
 
 - Given a player has unlocked a naval tech such as `superior_hull_design`, `improved_sail_design`, `convoying`, `large_hulls`, `clipper_ships`, `paddlewheels`, `merchant_steamships`, `advanced_hull_design`, `ship_of_the_line`, `privateering_companies`, or `advanced_iron_working`  
   When the System evaluates which ship types are buildable for that player during a build phase per [ships-and-naval.md](ships-and-naval.md)  

--- a/packages/colonizethis_data/lib/src/naval_stats.dart
+++ b/packages/colonizethis_data/lib/src/naval_stats.dart
@@ -1,4 +1,5 @@
-// Per-ship naval combat and interception stats. SPEC/program/naval-combat-resolution.md, naval-movement-resolution.md.
+// Per-ship naval combat and interception stats. SPEC/game/ships-and-naval.md § Ship combat and cargo stats;
+// resolution: SPEC/program/naval-combat-resolution.md, naval-movement-resolution.md.
 
 /// Naval stats for one ship type (FRP, RNG, ARM, HULL, MV, interceptRating, fleeRating, cargoHold).
 class NavalStatsEntry {
@@ -20,6 +21,7 @@ class NavalStatsEntry {
   final int movement;
   final int interceptRating;
   final int fleeRating;
+
   /// Cargo capacity in holds for this ship type. Each hold = 1 unit per turn.
   final int cargoHold;
 }
@@ -50,9 +52,129 @@ class NavalStatsCatalog {
     cargoHold: 4,
   );
 
+  static const NavalStatsEntry sloop = NavalStatsEntry(
+    firepower: 2,
+    range: 2,
+    armour: 1,
+    hull: 2,
+    movement: 3,
+    interceptRating: 4,
+    fleeRating: 4,
+    cargoHold: 0,
+  );
+
+  static const NavalStatsEntry trader = NavalStatsEntry(
+    firepower: 1,
+    range: 1,
+    armour: 1,
+    hull: 2,
+    movement: 2,
+    interceptRating: 1,
+    fleeRating: 3,
+    cargoHold: 5,
+  );
+
+  static const NavalStatsEntry galleon = NavalStatsEntry(
+    firepower: 2,
+    range: 1,
+    armour: 2,
+    hull: 4,
+    movement: 2,
+    interceptRating: 1,
+    fleeRating: 2,
+    cargoHold: 6,
+  );
+
+  static const NavalStatsEntry indiaman = NavalStatsEntry(
+    firepower: 2,
+    range: 2,
+    armour: 2,
+    hull: 5,
+    movement: 2,
+    interceptRating: 1,
+    fleeRating: 2,
+    cargoHold: 8,
+  );
+
+  static const NavalStatsEntry frigate = NavalStatsEntry(
+    firepower: 4,
+    range: 3,
+    armour: 2,
+    hull: 4,
+    movement: 3,
+    interceptRating: 5,
+    fleeRating: 4,
+    cargoHold: 0,
+  );
+
+  static const NavalStatsEntry raider = NavalStatsEntry(
+    firepower: 3,
+    range: 2,
+    armour: 2,
+    hull: 3,
+    movement: 4,
+    interceptRating: 6,
+    fleeRating: 5,
+    cargoHold: 0,
+  );
+
+  static const NavalStatsEntry shipOfTheLine = NavalStatsEntry(
+    firepower: 6,
+    range: 4,
+    armour: 4,
+    hull: 8,
+    movement: 2,
+    interceptRating: 2,
+    fleeRating: 1,
+    cargoHold: 0,
+  );
+
+  static const NavalStatsEntry clipper = NavalStatsEntry(
+    firepower: 1,
+    range: 2,
+    armour: 1,
+    hull: 3,
+    movement: 4,
+    interceptRating: 2,
+    fleeRating: 4,
+    cargoHold: 7,
+  );
+
+  static const NavalStatsEntry merchantSteamship = NavalStatsEntry(
+    firepower: 2,
+    range: 2,
+    armour: 3,
+    hull: 5,
+    movement: 3,
+    interceptRating: 1,
+    fleeRating: 3,
+    cargoHold: 9,
+  );
+
+  static const NavalStatsEntry ironclad = NavalStatsEntry(
+    firepower: 5,
+    range: 3,
+    armour: 8,
+    hull: 6,
+    movement: 3,
+    interceptRating: 2,
+    fleeRating: 2,
+    cargoHold: 0,
+  );
+
   static const Map<String, NavalStatsEntry> byId = {
     'carrack': carrack,
     'fluyte': fluyte,
+    'sloop': sloop,
+    'trader': trader,
+    'galleon': galleon,
+    'indiaman': indiaman,
+    'frigate': frigate,
+    'raider': raider,
+    'ship_of_the_line': shipOfTheLine,
+    'clipper': clipper,
+    'merchant_steamship': merchantSteamship,
+    'ironclad': ironclad,
   };
 
   static NavalStatsEntry get(String shipTypeId) =>

--- a/packages/colonizethis_data/lib/src/ship_economy.dart
+++ b/packages/colonizethis_data/lib/src/ship_economy.dart
@@ -2,7 +2,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'commodities.dart';
 
-/// Ship build cost configuration. SPEC/game/ships-and-naval.md.
+/// Ship build cost configuration. SPEC/game/ships-and-naval.md § Ship build economy.
 class ShipEconomyEntry {
   const ShipEconomyEntry({
     required this.shipTypeId,
@@ -15,29 +15,108 @@ class ShipEconomyEntry {
   final Map<CommodityId, int> buildInputs;
 }
 
-/// Ship economy catalog for Phase 5. SPEC/program/naval-movement-resolution.md.
+/// Ship economy catalog. SPEC/game/ships-and-naval.md (canonical table).
 class ShipEconomyCatalog {
   ShipEconomyCatalog._();
 
   static final ShipEconomyEntry carrack = ShipEconomyEntry(
     shipTypeId: 'carrack',
     buildTreasuryCost: 80,
-    buildInputs: {
-      CommodityCatalog.lumber.id: 2,
-      CommodityCatalog.fabric.id: 1,
-    },
+    buildInputs: {CommodityCatalog.lumber.id: 2, CommodityCatalog.fabric.id: 1},
   );
 
   static final ShipEconomyEntry fluyte = ShipEconomyEntry(
     shipTypeId: 'fluyte',
     buildTreasuryCost: 60,
+    buildInputs: {CommodityCatalog.lumber.id: 1, CommodityCatalog.fabric.id: 1},
+  );
+
+  static final ShipEconomyEntry sloop = ShipEconomyEntry(
+    shipTypeId: 'sloop',
+    buildTreasuryCost: 55,
+    buildInputs: {CommodityCatalog.lumber.id: 1, CommodityCatalog.fabric.id: 1},
+  );
+
+  static final ShipEconomyEntry trader = ShipEconomyEntry(
+    shipTypeId: 'trader',
+    buildTreasuryCost: 75,
+    buildInputs: {CommodityCatalog.lumber.id: 2, CommodityCatalog.fabric.id: 2},
+  );
+
+  static final ShipEconomyEntry galleon = ShipEconomyEntry(
+    shipTypeId: 'galleon',
+    buildTreasuryCost: 95,
+    buildInputs: {CommodityCatalog.lumber.id: 3, CommodityCatalog.fabric.id: 2},
+  );
+
+  static final ShipEconomyEntry indiaman = ShipEconomyEntry(
+    shipTypeId: 'indiaman',
+    buildTreasuryCost: 110,
+    buildInputs: {CommodityCatalog.lumber.id: 3, CommodityCatalog.fabric.id: 3},
+  );
+
+  static final ShipEconomyEntry frigate = ShipEconomyEntry(
+    shipTypeId: 'frigate',
+    buildTreasuryCost: 105,
+    buildInputs: {CommodityCatalog.lumber.id: 2, CommodityCatalog.fabric.id: 2},
+  );
+
+  static final ShipEconomyEntry raider = ShipEconomyEntry(
+    shipTypeId: 'raider',
+    buildTreasuryCost: 115,
     buildInputs: {
-      CommodityCatalog.lumber.id: 1,
+      CommodityCatalog.lumber.id: 2,
       CommodityCatalog.fabric.id: 1,
+      CommodityCatalog.castIron.id: 2,
     },
   );
 
-  static final List<ShipEconomyEntry> all = [carrack, fluyte];
+  static final ShipEconomyEntry shipOfTheLine = ShipEconomyEntry(
+    shipTypeId: 'ship_of_the_line',
+    buildTreasuryCost: 165,
+    buildInputs: {CommodityCatalog.lumber.id: 5, CommodityCatalog.fabric.id: 3},
+  );
+
+  static final ShipEconomyEntry clipper = ShipEconomyEntry(
+    shipTypeId: 'clipper',
+    buildTreasuryCost: 135,
+    buildInputs: {CommodityCatalog.lumber.id: 3, CommodityCatalog.fabric.id: 3},
+  );
+
+  static final ShipEconomyEntry merchantSteamship = ShipEconomyEntry(
+    shipTypeId: 'merchant_steamship',
+    buildTreasuryCost: 155,
+    buildInputs: {
+      CommodityCatalog.lumber.id: 2,
+      CommodityCatalog.fabric.id: 2,
+      CommodityCatalog.coal.id: 3,
+    },
+  );
+
+  static final ShipEconomyEntry ironclad = ShipEconomyEntry(
+    shipTypeId: 'ironclad',
+    buildTreasuryCost: 210,
+    buildInputs: {
+      CommodityCatalog.lumber.id: 2,
+      CommodityCatalog.fabric.id: 2,
+      CommodityCatalog.castIron.id: 5,
+    },
+  );
+
+  static final List<ShipEconomyEntry> all = [
+    carrack,
+    fluyte,
+    sloop,
+    trader,
+    galleon,
+    indiaman,
+    frigate,
+    raider,
+    shipOfTheLine,
+    clipper,
+    merchantSteamship,
+    ironclad,
+  ];
 
   static final Map<String, ShipEconomyEntry> byId = {
     for (final e in all) e.shipTypeId: e,
@@ -45,4 +124,5 @@ class ShipEconomyCatalog {
 }
 
 /// True if [unitType] is a ship type (buildable as naval unit, spawns in home fleet).
-bool isShipUnitType(String unitType) => ShipEconomyCatalog.byId.containsKey(unitType);
+bool isShipUnitType(String unitType) =>
+    ShipEconomyCatalog.byId.containsKey(unitType);

--- a/packages/colonizethis_data/test/ship_catalog_alignment_test.dart
+++ b/packages/colonizethis_data/test/ship_catalog_alignment_test.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 /// SPEC/game/ships-and-naval.md: every tech-unlocked ship + baseline carrack has
 /// economy and naval stats entries.

--- a/packages/colonizethis_data/test/ship_catalog_alignment_test.dart
+++ b/packages/colonizethis_data/test/ship_catalog_alignment_test.dart
@@ -1,0 +1,73 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:test/test.dart';
+
+/// SPEC/game/ships-and-naval.md: every tech-unlocked ship + baseline carrack has
+/// economy and naval stats entries.
+void main() {
+  group('ship catalog alignment', () {
+    test('carrack has no unlocking tech and full catalog entries', () {
+      expect(unlockingTechByShipId['carrack'], isNull);
+      expect(ShipEconomyCatalog.byId['carrack'], isNotNull);
+      expect(NavalStatsCatalog.byId['carrack'], isNotNull);
+    });
+
+    test(
+      'every shipUnlockIds target has ShipEconomyCatalog and NavalStatsCatalog',
+      () {
+        final shipIds = unlockingTechByShipId.keys.toList()..sort();
+        expect(shipIds, isNotEmpty);
+        for (final id in shipIds) {
+          expect(
+            ShipEconomyCatalog.byId[id],
+            isNotNull,
+            reason: 'missing ShipEconomyEntry for $id',
+          );
+          expect(
+            NavalStatsCatalog.byId[id],
+            isNotNull,
+            reason: 'missing NavalStatsEntry for $id',
+          );
+        }
+      },
+    );
+
+    test('ShipEconomyCatalog.all matches byId keys exactly', () {
+      final fromList = {for (final e in ShipEconomyCatalog.all) e.shipTypeId};
+      expect(fromList, NavalStatsCatalog.byId.keys.toSet());
+      expect(fromList, ShipEconomyCatalog.byId.keys.toSet());
+    });
+
+    test('warships have zero cargoHold, merchants positive', () {
+      const warships = {
+        'sloop',
+        'frigate',
+        'raider',
+        'ship_of_the_line',
+        'ironclad',
+      };
+      const merchants = {
+        'carrack',
+        'fluyte',
+        'trader',
+        'galleon',
+        'indiaman',
+        'clipper',
+        'merchant_steamship',
+      };
+      for (final id in warships) {
+        expect(
+          NavalStatsCatalog.byId[id]!.cargoHold,
+          0,
+          reason: '$id should be warship (cargo 0)',
+        );
+      }
+      for (final id in merchants) {
+        expect(
+          NavalStatsCatalog.byId[id]!.cargoHold,
+          greaterThan(0),
+          reason: '$id should be merchant',
+        );
+      }
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/sea_transport_test.dart
+++ b/packages/colonizethis_logic/test/sea_transport_test.dart
@@ -51,13 +51,13 @@ void main() {
       );
     });
 
-    test('returns 0 when home fleet has only non-cargo ship types', () {
+    test('returns 0 when home fleet has only warship types (cargoHold 0)', () {
       final fleet = Fleet(
         id: 'fleet_p1',
         ownerId: 'p1',
         seaZoneId: 'sea1',
         regionId: 'oldWorld',
-        shipTypeIds: const ['galleon'],
+        shipTypeIds: const ['sloop'],
       );
       final game = Game(
         id: 'g1',


### PR DESCRIPTION
## Summary

Closes #1261.

- **SPEC:** Canonical **ship build economy** and **combat/cargo stats** tables in `SPEC/game/ships-and-naval.md`, with new acceptance criteria and testing notes. `SPEC/game/tech-tree-naval.md` AC updated to require those tables.
- **Data:** `ShipEconomyCatalog` and `NavalStatsCatalog` extended for every `shipUnlockIds` target; `carrack` / `fluyte` costs and stats unchanged.
- **Tests:** `packages/colonizethis_data/test/ship_catalog_alignment_test.dart` (catalog vs `unlockingTechByShipId`, warship vs merchant cargo). `sea_transport_test` now uses `sloop` for the zero-cargo home-fleet case (since `galleon` is a merchant with holds).

## Testing

- `dart test packages/colonizethis_data/test/` (195 tests)
- `dart test` in `packages/colonizethis_logic` (848 tests)
- `dart test` in `tool/sim_scenarios` (24 tests)
- `flutter test test/naval_units_panel_test.dart` in `app` (20 tests)

## Follow-up

Balance and design review of default numbers: #1281.

Made with [Cursor](https://cursor.com)