### PR TITLE
chore(riverpod): upgrade to v3 (legacy providers)

### DIFF
--- a/app/lib/providers/games_provider.dart
+++ b/app/lib/providers/games_provider.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 
 import 'game_service_provider.dart';
 

--- a/app/lib/providers/map_province_panel_provider.dart
+++ b/app/lib/providers/map_province_panel_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 
 /// Shared UI state between the region map and the province/sea detail panel.
 /// Map and panel stay decoupled: both read/write this provider only.

--- a/app/lib/providers/map_view_provider.dart
+++ b/app/lib/providers/map_view_provider.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 
 import 'game_service_provider.dart';
 import 'games_provider.dart';

--- a/app/lib/providers/offline_queue_provider.dart
+++ b/app/lib/providers/offline_queue_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 
 /// Stub provider for offline action queue (multiplayer). Phase 0: MVP has no backend.
 final offlineQueueProvider = StateProvider<List<dynamic>>((ref) => []);

--- a/app/lib/providers/production_allocation_provider.dart
+++ b/app/lib/providers/production_allocation_provider.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 
 /// Desired output units per recipe (recipe id → units). Used by Production panel
 /// and passed to nextTurn as production assignments. SPEC/ui/production-panel.md.

--- a/app/lib/providers/settings_provider.dart
+++ b/app/lib/providers/settings_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 
 /// Stub provider for user settings. Phase 0: no real state; Phase 1+ wires to Hive.
 final settingsProvider = StateProvider<Map<String, dynamic>>((ref) => {});

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flame: ^1.36.0
   jenny: ^1.5.1
   logger: ^2.0.2
-  flutter_riverpod: ^2.6.1
+  flutter_riverpod: ^3.3.1
   hive: ^2.2.3
   hive_flutter: ^1.1.0
   session_log_buffer:

--- a/packages/colonizethis_ai/pubspec.yaml
+++ b/packages/colonizethis_ai/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   logger: ^2.0.2
-  riverpod: ^2.6.1
+  riverpod: ^3.2.1
   colonizethis_logger:
   colonizethis_data:
   colonizethis_logic:

--- a/packages/colonizethis_logic/pubspec.yaml
+++ b/packages/colonizethis_logic/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   logger: ^2.0.2
-  riverpod: ^2.6.1
+  riverpod: ^3.2.1
   colonizethis_logger:
   colonizethis_ai:
   colonizethis_data:

--- a/packages/colonizethis_map/pubspec.yaml
+++ b/packages/colonizethis_map/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   logger: ^2.0.2
-  riverpod: ^2.6.1
+  riverpod: ^3.2.1
   colonizethis_logger:
   colonizethis_data:
   colonizethis_models:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -263,10 +263,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_riverpod
-      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      sha256: "4e166be88e1dbbaa34a280bdb744aeae73b7ef25fdf8db7a3bb776760a3648e2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "3.3.1"
   flutter_test:
     dependency: transitive
     description: flutter
@@ -729,10 +729,10 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      sha256: "8c22216be8ad3ef2b44af3a329693558c98eca7b8bd4ef495c92db0bba279f83"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "3.2.1"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: cli_launcher
-      sha256: "17d2744fb9a254c49ec8eda582536abe714ea0131533e24389843a4256f82eac"
+      sha256: "35cf15a3ffaeb9c11849eaa0afba761bb76dceb42d050532bfd3e1299c9748cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.2+1"
+    version: "0.3.3+1"
   cli_util:
     dependency: transitive
     description:
@@ -449,10 +449,10 @@ packages:
     dependency: transitive
     description:
       name: logger
-      sha256: a7967e31b703831a893bbc3c3dd11db08126fe5f369b5c648a36f821979f5be3
+      sha256: "25aee487596a6257655a1e091ec2ae66bc30e7af663592cc3a27e6591e05035c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.2"
+    version: "2.7.0"
   logging:
     dependency: transitive
     description:
@@ -465,10 +465,10 @@ packages:
     dependency: transitive
     description:
       name: markdown
-      sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"
+      sha256: ee85086ad7698b42522c6ad42fe195f1b9898e4d974a1af4576c1a3a176cada9
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.0"
+    version: "7.3.1"
   matcher:
     dependency: transitive
     description:
@@ -489,18 +489,18 @@ packages:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: "7dcc4444d79b538ab8353bb38308f97e90b032984f75e8fd516fedfe8160b35e"
+      sha256: "72942b70e2fad1f01b2d66b42696546f9f48f57c342bee61726c540e8bfdcb02"
       url: "https://pub.dev"
     source: hosted
-    version: "7.4.0"
+    version: "7.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -513,18 +513,18 @@ packages:
     dependency: transitive
     description:
       name: mustache_template
-      sha256: "4326d0002ff58c74b9486990ccbdab08157fca3c996fe9e197aff9d61badf307"
+      sha256: "544ff0b837836f5ad6b351e7a676ff7c2cad4fa412c465908aeb9358caddb6fc"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   native_toolchain_c:
     dependency: transitive
     description:
       name: native_toolchain_c
-      sha256: "92b2ca62c8bd2b8d2f267cdfccf9bfbdb7322f778f8f91b3ce5b5cda23a3899f"
+      sha256: "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572"
       url: "https://pub.dev"
     source: hosted
-    version: "0.17.5"
+    version: "0.17.6"
   nested:
     dependency: transitive
     description:
@@ -593,10 +593,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: f2c65e21139ce2c3dad46922be8272bb5963516045659e71bb16e151c93b580e
+      sha256: "149441ca6e4f38193b2e004c0ca6376a3d11f51fa5a77552d8bd4d2b0c0912ba"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.22"
+    version: "2.2.23"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -886,10 +886,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611"
+      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.28"
+    version: "6.3.29"
   url_launcher_ios:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- Upgrades `flutter_riverpod`/`riverpod` constraints to Riverpod v3.
- Updates providers that used `StateProvider`/`StateNotifier*` to import from `flutter_riverpod/legacy.dart` (Riverpod v3 legacy API entrypoint).

## Test plan
- `melos run test_app`


Made with [Cursor](https://cursor.com)