### PR TITLE
refactor(riverpod): replace legacy map toggle providers

### DIFF
--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -364,8 +364,7 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
                                                   mapProvinceOverlayVisibleProvider
                                                       .notifier,
                                                 )
-                                                .state =
-                                            value;
+                                                .set(value);
                                       },
                                     ),
                                     SwitchListTile(
@@ -379,8 +378,7 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
                                                   mapProvinceOwnershipTintVisibleProvider
                                                       .notifier,
                                                 )
-                                                .state =
-                                            value;
+                                                .set(value);
                                       },
                                     ),
                                     SwitchListTile(
@@ -394,8 +392,7 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
                                                   mapProvinceNamesVisibleProvider
                                                       .notifier,
                                                 )
-                                                .state =
-                                            value;
+                                                .set(value);
                                       },
                                     ),
                                   ],

--- a/app/lib/providers/map_view_provider.dart
+++ b/app/lib/providers/map_view_provider.dart
@@ -1,7 +1,6 @@
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 
 import 'game_service_provider.dart';
 import 'games_provider.dart';
@@ -9,15 +8,45 @@ import 'games_provider.dart';
 /// Global province/sea boundary strokes on in-game Empire overview maps.
 /// Defaults to true at app start; updated via the Map display options dialog.
 /// SPEC/ui/map-widget.md, SPEC/ui/empire-overview.md.
-final mapProvinceOverlayVisibleProvider = StateProvider<bool>((ref) => true);
+class MapProvinceOverlayVisibleNotifier extends Notifier<bool> {
+  @override
+  bool build() => true;
+
+  void set(bool value) => state = value;
+}
+
+final mapProvinceOverlayVisibleProvider =
+    NotifierProvider<MapProvinceOverlayVisibleNotifier, bool>(
+      MapProvinceOverlayVisibleNotifier.new,
+    );
 
 /// Great Power land ownership tint on in-game Empire overview maps.
 /// Independent of [mapProvinceOverlayVisibleProvider]. Defaults to true at app start.
-final mapProvinceOwnershipTintVisibleProvider = StateProvider<bool>((ref) => true);
+class MapProvinceOwnershipTintVisibleNotifier extends Notifier<bool> {
+  @override
+  bool build() => true;
+
+  void set(bool value) => state = value;
+}
+
+final mapProvinceOwnershipTintVisibleProvider =
+    NotifierProvider<MapProvinceOwnershipTintVisibleNotifier, bool>(
+      MapProvinceOwnershipTintVisibleNotifier.new,
+    );
 
 /// Global land province name labels on in-game Empire overview maps.
 /// Independent of boundary and ownership-tint toggles. Defaults to true at app start.
-final mapProvinceNamesVisibleProvider = StateProvider<bool>((ref) => true);
+class MapProvinceNamesVisibleNotifier extends Notifier<bool> {
+  @override
+  bool build() => true;
+
+  void set(bool value) => state = value;
+}
+
+final mapProvinceNamesVisibleProvider =
+    NotifierProvider<MapProvinceNamesVisibleNotifier, bool>(
+      MapProvinceNamesVisibleNotifier.new,
+    );
 
 /// Map view data for the current game with player-constrained visibility.
 /// Null when no game, no map data (legacy save), or loading.


### PR DESCRIPTION
## Summary
- Migrates map display toggle providers from legacy `StateProvider<bool>` to Riverpod v3 `NotifierProvider`.
- Updates the Map display options dialog to write state via notifier methods.

## Test plan
- `melos run test_app`


Made with [Cursor](https://cursor.com)