### PR TITLE
refactor(riverpod): migrate productionDesiredOutputProvider

### DIFF
--- a/app/lib/features/game/widgets/production_screen.dart
+++ b/app/lib/features/game/widgets/production_screen.dart
@@ -43,7 +43,7 @@ class ProductionScreen extends ConsumerWidget {
         player: displayPlayer,
         desiredOutputByRecipe: desiredOutputByRecipe,
         onDesiredOutputChanged: (next) {
-          ref.read(productionDesiredOutputProvider.notifier).state = next;
+          ref.read(productionDesiredOutputProvider.notifier).replaceAll(next);
         },
       ),
     );

--- a/app/lib/providers/production_allocation_provider.dart
+++ b/app/lib/providers/production_allocation_provider.dart
@@ -1,12 +1,22 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 
 /// Desired output units per recipe (recipe id → units). Used by Production panel
 /// and passed to nextTurn as production assignments. SPEC/ui/production-panel.md.
+class ProductionDesiredOutputNotifier extends Notifier<Map<String, int>> {
+  @override
+  Map<String, int> build() => const {};
+
+  void replaceAll(Map<String, int> next) {
+    state = next;
+  }
+}
+
 final productionDesiredOutputProvider =
-    StateProvider<Map<String, int>>((ref) => const {});
+    NotifierProvider<ProductionDesiredOutputNotifier, Map<String, int>>(
+      ProductionDesiredOutputNotifier.new,
+    );
 
 /// Builds [AssignedRecipe] list from desired output map for the turn resolver.
 List<AssignedRecipe> desiredOutputToAssignments(Map<String, int> desiredByRecipe) {

--- a/app/test/production_screen_integration_test.dart
+++ b/app/test/production_screen_integration_test.dart
@@ -15,6 +15,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+class _SeededProductionDesiredOutputNotifier
+    extends ProductionDesiredOutputNotifier {
+  _SeededProductionDesiredOutputNotifier(this._initial);
+
+  final Map<String, int> _initial;
+
+  @override
+  Map<String, int> build() => _initial;
+}
+
 void main() {
   suppressLogsForTests();
 
@@ -41,7 +51,11 @@ void main() {
         }),
         if (initialDesiredOutput != null)
           productionDesiredOutputProvider
-              .overrideWith((ref) => initialDesiredOutput),
+              .overrideWith(() {
+                return _SeededProductionDesiredOutputNotifier(
+                  initialDesiredOutput,
+                );
+              }),
       ],
       child: MaterialApp(
         home: MediaQuery(


### PR DESCRIPTION
## Summary
- Migrates `productionDesiredOutputProvider` from legacy `StateProvider<Map<String,int>>` to Riverpod v3 `NotifierProvider`.
- Updates `ProductionScreen` to write state via notifier method.
- Updates the ProductionScreen integration test override to seed notifier state.

## Test plan
- `melos run test_app`


Made with [Cursor](https://cursor.com)