### PR TITLE
feat(app): add military training dialog + panel entrypoint

### DIFF
--- a/SPEC/program/app-ui-wiring.md
+++ b/SPEC/program/app-ui-wiring.md
@@ -54,6 +54,7 @@ Register builders in **`app/lib/core/services/app_event_handler_scope.dart`**.
 | ID | Widget | Constant |
 |----|--------|----------|
 | `train_civilians` | `TrainCiviliansDialog` | `trainCiviliansDialogId` |
+| `train_military` | `TrainMilitaryDialog` | `trainMilitaryDialogId` |
 | `grant_or_subsidy` | `GrantOrSubsidyDialog` | `grantOrSubsidyDialogId` |
 | `new_game_leader_selection` | `NewGameLeaderSelectionDialog` (six slots: **nation** + **leader** per slot; nation picker shows default GP map colour swatch beside each nation name; fair GP Old World assignment checkbox; initial nations = `GameSetupConfig.defaultConfig.selectedGreatPowerIds`) | `newGameLeaderSelectionDialogId` |
 
@@ -106,6 +107,7 @@ Shell/game entry: **`Routes.shell`**, **`Routes.game`** (see `config/routes.dart
 
 - Given `GameSideMenu` is mounted with a valid `currentGameProvider`, When the user chooses Civilian Units, Then the system emits `OpenCivilianUnitsPanelEvent` (not `showModalBottomSheet` from `GameSideMenu`).
 - Given `CivilianUnitsPanel` is mounted with a bus, When the user taps Train, Then the system emits `OpenDialogEvent(trainCiviliansDialogId)` (panel does not call `showDialog` directly for that action).
+- Given `MilitaryUnitsPanel` is mounted with a bus, When the user taps Train, Then the system emits `OpenDialogEvent(trainMilitaryDialogId)` (panel does not call `showDialog` directly for that action).
 - Given `DiplomacyPanel` is mounted with a bus, When the user taps Grant Aid or Set Subsidy, Then the system emits `OpenDialogEvent('grant_or_subsidy')` (panel does not call `showDialog` directly).
 - Given `DiplomacyPanel` is mounted with a bus, When the user taps a faction row, Then the system emits `NavigateToRouteEvent(Routes.diplomacyDetail)` (panel does not call `Navigator.push` directly).
 

--- a/SPEC/ui/military-units-panel.md
+++ b/SPEC/ui/military-units-panel.md
@@ -23,6 +23,7 @@ The military units panel gives the player a single place to see every regiment a
 - **Access:** The panel is opened from the in-game shell **toolbar** via a dedicated button (e.g. "Military Units"), in the same way as the Civilian Units panel.
 - **Desktop / wide viewport:** Panel appears as a side panel or bottom sheet so the map remains visible. Max height or scroll so content fits.
 - **Mobile / narrow viewport:** Panel appears as a bottom sheet or full-width overlay per [mobile-adaptation.md](mobile-adaptation.md).
+- **Train button:** Header includes a **Train** button in the same position/pattern as [civilian-units-panel.md](civilian-units-panel.md). On tap, the panel route is popped and the UI layer emits `OpenDialogEvent(trainMilitaryDialogId)` to open [train-military-dialog.md](train-military-dialog.md).
 
 ---
 
@@ -92,6 +93,8 @@ The military units panel gives the player a single place to see every regiment a
 - **Given** the panel is displayed with at least one region containing provinces with regiments or sea zones with ships, **when** the user views the tree, **then** the UI layer shows region headings, under each region location nodes (province name + region, or sea zone + region), and under each location type rows with type name, count, and status (and medals for regiments).
 
 - **Given** the user opens the Military Units panel on a narrow viewport (e.g. width < 600 dp), **when** the panel is displayed, **then** the UI layer presents the panel in a layout appropriate for mobile per [mobile-adaptation.md](mobile-adaptation.md).
+
+- **Given** the Military Units panel is open, **when** the user taps the Train button, **then** the UI layer closes the panel and emits `OpenDialogEvent(trainMilitaryDialogId)` so the Train Military dialog opens via `AppEventBus` wiring (the panel does not call `showDialog` directly).
 
 ---
 

--- a/SPEC/ui/train-military-dialog.md
+++ b/SPEC/ui/train-military-dialog.md
@@ -1,0 +1,108 @@
+# Train Military Dialog
+
+**SPEC/ui** — Modal dialog for queuing military regiment training orders. Integrates with [military-units-panel.md](military-units-panel.md), [empire-overview.md](empire-overview.md), and [buttons-nine-patch.md](buttons-nine-patch.md). Game model: [military-units.md](../game/military-units.md), [tech-tree-military.md](../game/tech-tree-military.md), [world-model.md](../game/world-model.md). Order model: [orders.md](../program/orders.md). Province identity: [world-model-identity.md](../game/world-model-identity.md).
+
+---
+
+## Purpose
+
+The Train Military dialog lets the player queue military regiment build orders in a single modal flow. It mirrors the civilian training UX pattern: one row per trainable type, +/- steppers, optional reset, and order creation on dialog close. Trained regiments spawn at the player's capital province and appear after turn resolution (next turn from the player's perspective).
+
+---
+
+## Opening the dialog
+
+- **Trigger:** `Train` button in [military-units-panel.md](military-units-panel.md).
+- **Flow parity with civilian:** On tap, the military panel closes, then `OpenDialogEvent(trainMilitaryDialogId)` opens this modal.
+- **Presentation:** `CtDialogShell` modal with transparent backdrop.
+
+---
+
+## Layout
+
+- **Header:** `Train Military` title + close (`X`) button.
+- **Resource bar:** Shows available `Treasury`, `Peasants`, and regiment-input commodities (as applicable): `fabric`, `castIron`, `lumber`, `horses`, `steel`, `bronze`. Use existing resource/worker icons.
+- **Deficit hint:** Same wording style as civilian (`{Resource} low`, `{A} and {B} low`, etc.) using military resource names.
+- **Rows:** One row per `RegimentEconomyCatalog.all` entry.
+  - regiment id label (text-only; no regiment icon requirement)
+  - cost summary: treasury + commodity requirements with icons
+  - locked state + `Requires: {tech}` when regiment unlocking tech is missing
+  - `[-] count [+]` stepper
+- **Footer:** `Reset` button that clears all row counts to `0`.
+
+---
+
+## Stepper and availability behavior
+
+- Count initializes from existing pending military build orders (dialog-managed set; see Order submission).
+- `+` increments by 1 only when adding one more unit remains affordable.
+- `-` decrements by 1, minimum 0.
+- Locked regiments: row subdued and steppers disabled.
+- `+` uses aggregate affordability across all currently selected regiment rows:
+  - treasury
+  - peasants (`workerPool.peasants`, 1 consumed per military regiment)
+  - commodity stockpile requirements for all selected rows
+
+---
+
+## Dynamic cost calculation
+
+On every stepper change:
+
+- `totalTreasuryCost = sum(count[regiment] * RegimentEconomy.buildTreasuryCost)`
+- `totalPeasantCost = sum(count[regiment])`
+- `totalCommodityCost[commodityId] = sum(count[regiment] * RegimentEconomy.buildInputs[commodityId])`
+
+Affordability requires all constraints:
+
+- `totalTreasuryCost <= Player.treasury`
+- `totalPeasantCost <= Player.workerPool.peasants`
+- `totalCommodityCost[c] <= Player.stockpile.quantityOf(c)` for each required commodity
+
+---
+
+## Tech lock display
+
+- Lock mapping source: `unlockingTechByRegimentId`.
+- Locked when unlocking tech exists and `Player.techUnlocked?[techId] != true`.
+- Lock label: `Requires: {techDisplayName(techId)}`.
+
+---
+
+## Order submission
+
+On dialog close (`didPop` / close button), create orders from current counts:
+
+1. Resolve `capitalProvinceId = Player.capitalProvinceId`.
+2. For each regiment type where `count > 0`, add `count` entries of:
+   - `BuildUnitOrder(unitType: regimentId, isMilitary: true, spawnProvinceId: capitalProvinceId)`
+3. Replace only the dialog-managed military orders in `currentOrders.buildUnitOrdersByPlayerId[humanPlayerId]`:
+   - replace set: orders with `isMilitary == true`, regiment `unitType` in `RegimentEconomyCatalog.byId`, and `spawnProvinceId == capitalProvinceId`
+   - keep all other build orders unchanged (civilian, naval, other military outside this managed set)
+
+If no capital exists, UI shows `No capital set — cannot train units`, steppers are disabled, and no orders are created.
+
+---
+
+## Integration
+
+- **Parent:** [military-units-panel.md](military-units-panel.md)
+- **Wiring:** Dialog opens via `AppEventBus` and is registered in app handler scope with id `train_military`.
+- **Model:** Uses `BuildUnitOrder` (`isMilitary: true`) and existing order merge semantics in app shell state.
+- **Timing:** Unit appears after turn resolution (next turn from the player view).
+
+---
+
+## Acceptance criteria
+
+- **Given** the Military Units panel is open, **when** the user taps `Train`, **then** the UI layer closes the panel and opens Train Military as a modal dialog via `OpenDialogEvent(trainMilitaryDialogId)`.
+
+- **Given** the Train Military dialog is open, **when** the user views the resource bar, **then** the UI layer shows treasury, peasants, and relevant military-input resources using existing resource/worker icon components.
+
+- **Given** the Train Military dialog is open, **when** the player increments regiment steppers, **then** the UI layer enables/disables each row's `+` based on aggregate affordability across treasury, peasants, and all required commodities.
+
+- **Given** the Train Military dialog is open, **when** the player lacks the unlocking tech for a regiment, **then** the row shows locked state with `Requires: {tech}` and disabled steppers.
+
+- **Given** the Train Military dialog opens with existing pending military train orders for the player's capital, **when** the dialog renders, **then** the steppers pre-populate with those existing counts.
+
+- **Given** the Train Military dialog is open and the user closes it, **when** there are non-zero selected counts, **then** the UI layer writes `BuildUnitOrder` entries with `isMilitary == true` and `spawnProvinceId == Player.capitalProvinceId`, replacing only dialog-managed military orders and leaving all other build orders unchanged.

--- a/app/lib/core/services/app_event_handler.dart
+++ b/app/lib/core/services/app_event_handler.dart
@@ -167,11 +167,7 @@ class AppEventHandler {
       event.result(confirmed);
       return confirmed;
     } catch (e, st) {
-      _log.e(
-        'ui:app_event: ConfirmDialog failed',
-        error: e,
-        stackTrace: st,
-      );
+      _log.e('ui:app_event: ConfirmDialog failed', error: e, stackTrace: st);
       event.result(false);
       return false;
     }
@@ -198,10 +194,7 @@ class AppEventHandler {
     await showModalBottomSheet<void>(
       context: nav.context,
       builder: (ctx) => PauseMenuPanel(
-        params: {
-          'onDebugLog': event.onDebugLog,
-          'onResume': event.onResume,
-        },
+        params: {'onDebugLog': event.onDebugLog, 'onResume': event.onResume},
       ),
     );
   }
@@ -262,9 +255,11 @@ class AppEventHandler {
             return const SizedBox.shrink();
           }
           final humanPlayerId = _humanPlayerId(game);
+          final bus = ref.watch(appEventBusProvider);
           return MilitaryUnitsPanel(
             game: game,
             humanPlayerId: humanPlayerId,
+            bus: bus,
             onLocateTile: event.onLocateTile,
           );
         },

--- a/app/lib/core/services/app_event_handler_scope.dart
+++ b/app/lib/core/services/app_event_handler_scope.dart
@@ -9,6 +9,7 @@ import 'package:logger/logger.dart';
 import 'package:colonizethis_app/app.dart';
 import 'package:colonizethis_app/features/game/widgets/diplomacy_dialogs.dart';
 import 'package:colonizethis_app/features/game/widgets/train_civilians_dialog.dart';
+import 'package:colonizethis_app/features/game/widgets/train_military_dialog.dart';
 import 'package:colonizethis_app/features/shell/new_game_leader_selection_dialog.dart';
 import 'package:colonizethis_app/features/shell/new_game_setup_flow.dart';
 import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
@@ -19,6 +20,9 @@ import 'app_event_handler.dart';
 
 /// [OpenDialogEvent] id for [TrainCiviliansDialog]. SPEC/program/app-ui-wiring.md.
 const String trainCiviliansDialogId = 'train_civilians';
+
+/// [OpenDialogEvent] id for [TrainMilitaryDialog]. SPEC/program/app-ui-wiring.md.
+const String trainMilitaryDialogId = 'train_military';
 
 /// [OpenDialogEvent] id for [GrantOrSubsidyDialog]. SPEC/program/app-ui-wiring.md.
 const String grantOrSubsidyDialogId = 'grant_or_subsidy';
@@ -46,12 +50,53 @@ Orders _mergeTrainCivilianOrdersForPlayer({
   final capital = player?.capitalProvinceId;
   final civilianUnitIds = CivilianEconomyCatalog.byId.keys.toSet();
   final existingList =
-      current.buildUnitOrdersByPlayerId[humanPlayerId] ?? const <BuildUnitOrder>[];
+      current.buildUnitOrdersByPlayerId[humanPlayerId] ??
+      const <BuildUnitOrder>[];
   final kept = <BuildUnitOrder>[];
   for (final order in existingList) {
     final isDialogManaged =
         !order.isMilitary &&
         civilianUnitIds.contains(order.unitType) &&
+        capital != null &&
+        order.spawnProvinceId == capital;
+    if (isDialogManaged) {
+      continue;
+    }
+    kept.add(order);
+  }
+  return current.copyWith(
+    buildUnitOrdersByPlayerId: {
+      ...current.buildUnitOrdersByPlayerId,
+      humanPlayerId: [...kept, ...newFromDialog],
+    },
+  );
+}
+
+/// Replaces pending train-at-capital military [BuildUnitOrder]s for [humanPlayerId];
+/// keeps civilian, naval, and other build orders. Matches [TrainMilitaryDialog] semantics.
+Orders _mergeTrainMilitaryOrdersForPlayer({
+  required Orders current,
+  required Game game,
+  required String humanPlayerId,
+  required List<BuildUnitOrder> newFromDialog,
+}) {
+  Player? player;
+  for (final p in game.players) {
+    if (p.id == humanPlayerId) {
+      player = p;
+      break;
+    }
+  }
+  final capital = player?.capitalProvinceId;
+  final regimentIds = RegimentEconomyCatalog.byId.keys.toSet();
+  final existingList =
+      current.buildUnitOrdersByPlayerId[humanPlayerId] ??
+      const <BuildUnitOrder>[];
+  final kept = <BuildUnitOrder>[];
+  for (final order in existingList) {
+    final isDialogManaged =
+        order.isMilitary &&
+        regimentIds.contains(order.unitType) &&
         capital != null &&
         order.spawnProvinceId == capital;
     if (isDialogManaged) {
@@ -112,35 +157,40 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
             initialLeaderByGpId: initialSelections,
             onCancel: () => Navigator.of(ctx).pop(),
             onConfirmed:
-                (orderedGreatPowerIds, leaderVariantByGpId, enforceFairGpOldWorldAssignment) {
-              final navCtx = appNavigatorKey.currentContext;
-              if (navCtx == null) {
-                _log.w(
-                  'shell: appNavigatorKey has no context; skipping new game setup',
-                );
-                return;
-              }
-              final rootContainer = ProviderScope.containerOf(navCtx);
-              final templateConfig = GameSetupConfig(
-                selectedGreatPowerIds: orderedGreatPowerIds,
-                leaderVariantByGpId: leaderVariantByGpId,
-                continentCount: baseConfig.continentCount,
-                minorNationCount: baseConfig.minorNationCount,
-                tribeCount: baseConfig.tribeCount,
-                numProvincesOldWorld: baseConfig.numProvincesOldWorld,
-                numProvincesNewWorld: baseConfig.numProvincesNewWorld,
-                minProvincesPerMinor: baseConfig.minProvincesPerMinor,
-                seed: baseConfig.seed,
-                startingResources: baseConfig.startingResources,
-                enforceFairGpOldWorldAssignment: enforceFairGpOldWorldAssignment,
-              );
-              unawaited(
-                runNewGameSetupAfterLeaderPick(
-                  container: rootContainer,
-                  templateConfig: templateConfig,
-                ),
-              );
-            },
+                (
+                  orderedGreatPowerIds,
+                  leaderVariantByGpId,
+                  enforceFairGpOldWorldAssignment,
+                ) {
+                  final navCtx = appNavigatorKey.currentContext;
+                  if (navCtx == null) {
+                    _log.w(
+                      'shell: appNavigatorKey has no context; skipping new game setup',
+                    );
+                    return;
+                  }
+                  final rootContainer = ProviderScope.containerOf(navCtx);
+                  final templateConfig = GameSetupConfig(
+                    selectedGreatPowerIds: orderedGreatPowerIds,
+                    leaderVariantByGpId: leaderVariantByGpId,
+                    continentCount: baseConfig.continentCount,
+                    minorNationCount: baseConfig.minorNationCount,
+                    tribeCount: baseConfig.tribeCount,
+                    numProvincesOldWorld: baseConfig.numProvincesOldWorld,
+                    numProvincesNewWorld: baseConfig.numProvincesNewWorld,
+                    minProvincesPerMinor: baseConfig.minProvincesPerMinor,
+                    seed: baseConfig.seed,
+                    startingResources: baseConfig.startingResources,
+                    enforceFairGpOldWorldAssignment:
+                        enforceFairGpOldWorldAssignment,
+                  );
+                  unawaited(
+                    runNewGameSetupAfterLeaderPick(
+                      container: rootContainer,
+                      templateConfig: templateConfig,
+                    ),
+                  );
+                },
           );
         },
         trainCiviliansDialogId: (ctx, _) {
@@ -157,8 +207,34 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
             currentOrders: orders,
             onOrdersChanged: (newOrders) {
               final o = container.read(currentOrdersProvider);
-              container.read(currentOrdersProvider.notifier).state =
-                  _mergeTrainCivilianOrdersForPlayer(
+              container
+                  .read(currentOrdersProvider.notifier)
+                  .state = _mergeTrainCivilianOrdersForPlayer(
+                current: o,
+                game: game,
+                humanPlayerId: humanPlayerId,
+                newFromDialog: newOrders,
+              );
+            },
+          );
+        },
+        trainMilitaryDialogId: (ctx, _) {
+          final container = ProviderScope.containerOf(ctx);
+          final game = container.read(currentGameProvider);
+          if (game == null) {
+            return const SizedBox.shrink();
+          }
+          final humanPlayerId = _humanPlayerId(game);
+          final orders = container.read(currentOrdersProvider);
+          return TrainMilitaryDialog(
+            game: game,
+            humanPlayerId: humanPlayerId,
+            currentOrders: orders,
+            onOrdersChanged: (newOrders) {
+              final o = container.read(currentOrdersProvider);
+              container
+                  .read(currentOrdersProvider.notifier)
+                  .state = _mergeTrainMilitaryOrdersForPlayer(
                 current: o,
                 game: game,
                 humanPlayerId: humanPlayerId,
@@ -193,11 +269,7 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
     _sessionCommandSubs.addAll([
       bus.on<RemovePendingWorkOrderRequestedEvent>().listen((e) {
         final current = ref.read(currentOrdersProvider);
-        final updated = removePendingWorkOrderAt(
-          current,
-          e.playerId,
-          e.index,
-        );
+        final updated = removePendingWorkOrderAt(current, e.playerId, e.index);
         ref.read(currentOrdersProvider.notifier).state = updated;
       }),
       bus.on<CancelInProgressCivilianWorkRequestedEvent>().listen((e) {

--- a/app/lib/features/game/widgets/military_units_panel.dart
+++ b/app/lib/features/game/widgets/military_units_panel.dart
@@ -4,6 +4,8 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../../../core/services/app_event_handler_scope.dart';
+import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/ct_panel.dart';
 
 /// Region id to display label. SPEC/ui/military-units-panel.md.
@@ -114,10 +116,7 @@ abstract class _LocationNode {
 }
 
 class _ProvinceLocationNode extends _LocationNode {
-  _ProvinceLocationNode({
-    required this.province,
-    required this.rows,
-  });
+  _ProvinceLocationNode({required this.province, required this.rows});
 
   final Province province;
   final List<_RegimentTypeRow> rows;
@@ -169,31 +168,32 @@ List<({String regionId, List<_LocationNode> locations})> _buildMilitaryTree(
 
     // Regiments in this region: group by full province id, then by type.
     final militaryUnits = regionData.units
-        .where((u) =>
-            u.ownerId == humanPlayerId && isMilitaryUnit(u.type))
+        .where((u) => u.ownerId == humanPlayerId && isMilitaryUnit(u.type))
         .toList();
     final byProvince = <String, List<Unit>>{};
     for (final u in militaryUnits) {
       final loc = u.locationProvinceId;
-      final fullProvinceId =
-          loc.contains('|') ? loc : '$regionId|$loc';
+      final fullProvinceId = loc.contains('|') ? loc : '$regionId|$loc';
       byProvince.putIfAbsent(fullProvinceId, () => []).add(u);
     }
 
     // Fleets in this region owned by player that are at sea (have seaZoneId).
     final fleetsInRegion = game.worldState.fleets
-        .where((f) =>
-            f.ownerId == humanPlayerId &&
-            f.regionId == regionId &&
-            f.shipTypeIds.isNotEmpty &&
-            f.isAtSea &&
-            f.seaZoneId != null)
+        .where(
+          (f) =>
+              f.ownerId == humanPlayerId &&
+              f.regionId == regionId &&
+              f.shipTypeIds.isNotEmpty &&
+              f.isAtSea &&
+              f.seaZoneId != null,
+        )
         .toList();
     final bySeaZone = <String, List<Fleet>>{};
     for (final f in fleetsInRegion) {
       final seaZoneId = f.seaZoneId!;
-      final zoneKey =
-          seaZoneId.contains('|') ? seaZoneId : '$regionId|$seaZoneId';
+      final zoneKey = seaZoneId.contains('|')
+          ? seaZoneId
+          : '$regionId|$seaZoneId';
       bySeaZone.putIfAbsent(zoneKey, () => []).add(f);
     }
 
@@ -227,21 +227,23 @@ List<({String regionId, List<_LocationNode> locations})> _buildMilitaryTree(
         final status = list.any((u) => u.status == UnitStatus.working)
             ? UnitStatus.working
             : list.any((u) => u.status == UnitStatus.done)
-                ? UnitStatus.done
-                : UnitStatus.idle;
+            ? UnitStatus.done
+            : UnitStatus.idle;
         final statusLabel = switch (status) {
           UnitStatus.idle => 'Idle',
           UnitStatus.working => 'Working',
           UnitStatus.done => 'Done',
         };
-        rows.add(_RegimentTypeRow(
-          typeId: typeId,
-          count: list.length,
-          medalsSummary: medalsSummary,
-          statusLabel: statusLabel,
-          tileKey: tileKey,
-          regionId: regionId,
-        ));
+        rows.add(
+          _RegimentTypeRow(
+            typeId: typeId,
+            count: list.length,
+            medalsSummary: medalsSummary,
+            statusLabel: statusLabel,
+            tileKey: tileKey,
+            regionId: regionId,
+          ),
+        );
       }
       locations.add(_ProvinceLocationNode(province: province, rows: rows));
     }
@@ -264,19 +266,23 @@ List<({String regionId, List<_LocationNode> locations})> _buildMilitaryTree(
       final tileKey = tileKeyForSeaZoneLocation(game, regionId, zoneKey);
       final rows = <_ShipTypeRow>[];
       for (final typeId in shipTypeIds.keys.toList()..sort()) {
-        rows.add(_ShipTypeRow(
-          typeId: typeId,
-          count: shipTypeIds[typeId]!,
-          statusLabel: _missionLabel(mission ?? FleetMission.none),
-          tileKey: tileKey,
-          regionId: regionId,
-        ));
+        rows.add(
+          _ShipTypeRow(
+            typeId: typeId,
+            count: shipTypeIds[typeId]!,
+            statusLabel: _missionLabel(mission ?? FleetMission.none),
+            tileKey: tileKey,
+            regionId: regionId,
+          ),
+        );
       }
-      locations.add(_SeaZoneLocationNode(
-        seaZoneLabel: zoneLabel,
-        regionId: regionId,
-        rows: rows,
-      ));
+      locations.add(
+        _SeaZoneLocationNode(
+          seaZoneLabel: zoneLabel,
+          regionId: regionId,
+          rows: rows,
+        ),
+      );
     }
 
     if (locations.isNotEmpty) {
@@ -293,11 +299,13 @@ class MilitaryUnitsPanel extends StatelessWidget {
     super.key,
     required this.game,
     required this.humanPlayerId,
+    required this.bus,
     this.onLocateTile,
   });
 
   final Game game;
   final String humanPlayerId;
+  final AppEventBus bus;
 
   /// Called when the user taps a row. [tileKey] and [regionId] for highlight/center and tab switch.
   final void Function(String tileKey, String regionId)? onLocateTile;
@@ -327,6 +335,13 @@ class MilitaryUnitsPanel extends StatelessWidget {
                         style: Theme.of(context).textTheme.titleMedium,
                       ),
                     ),
+                    CtNinePatchButton(
+                      onPressed: () {
+                        Navigator.of(context).maybePop();
+                        bus.emit(OpenDialogEvent(trainMilitaryDialogId));
+                      },
+                      child: const Text('Train'),
+                    ),
                   ],
                 ),
               ),
@@ -337,9 +352,7 @@ class MilitaryUnitsPanel extends StatelessWidget {
                         padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
                         children: [
                           for (final group in tree) ...[
-                            _RegionHeader(
-                              label: _regionLabel(group.regionId),
-                            ),
+                            _RegionHeader(label: _regionLabel(group.regionId)),
                             for (final loc in group.locations) ...[
                               _LocationHeader(
                                 label: loc.displayLabel,
@@ -349,24 +362,26 @@ class MilitaryUnitsPanel extends StatelessWidget {
                                 for (final row in loc.rows)
                                   _RegimentRow(
                                     row: row,
-                                    onTap: row.tileKey != null &&
+                                    onTap:
+                                        row.tileKey != null &&
                                             onLocateTile != null
                                         ? () => onLocateTile!(
-                                              row.tileKey!,
-                                              row.regionId,
-                                            )
+                                            row.tileKey!,
+                                            row.regionId,
+                                          )
                                         : null,
                                   ),
                               if (loc is _SeaZoneLocationNode)
                                 for (final row in loc.rows)
                                   _ShipRow(
                                     row: row,
-                                    onTap: row.tileKey != null &&
+                                    onTap:
+                                        row.tileKey != null &&
                                             onLocateTile != null
                                         ? () => onLocateTile!(
-                                              row.tileKey!,
-                                              row.regionId,
-                                            )
+                                            row.tileKey!,
+                                            row.regionId,
+                                          )
                                         : null,
                                   ),
                             ],
@@ -378,13 +393,11 @@ class MilitaryUnitsPanel extends StatelessWidget {
                         child: Center(
                           child: Text(
                             'No military units',
-                            style: Theme.of(context)
-                                .textTheme
-                                .bodyMedium
+                            style: Theme.of(context).textTheme.bodyMedium
                                 ?.copyWith(
-                                  color: Theme.of(context)
-                                      .colorScheme
-                                      .onSurfaceVariant,
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.onSurfaceVariant,
                                 ),
                           ),
                         ),
@@ -410,18 +423,16 @@ class _RegionHeader extends StatelessWidget {
       child: Text(
         label,
         style: Theme.of(context).textTheme.titleSmall?.copyWith(
-            color: Theme.of(context).colorScheme.primary,
-            fontWeight: FontWeight.w600),
+          color: Theme.of(context).colorScheme.primary,
+          fontWeight: FontWeight.w600,
+        ),
       ),
     );
   }
 }
 
 class _LocationHeader extends StatelessWidget {
-  const _LocationHeader({
-    required this.label,
-    required this.regionLabel,
-  });
+  const _LocationHeader({required this.label, required this.regionLabel});
 
   final String label;
   final String regionLabel;
@@ -433,7 +444,8 @@ class _LocationHeader extends StatelessWidget {
       child: Text(
         '$label — $regionLabel',
         style: Theme.of(context).textTheme.titleSmall?.copyWith(
-            color: Theme.of(context).colorScheme.onSurface),
+          color: Theme.of(context).colorScheme.onSurface,
+        ),
       ),
     );
   }
@@ -452,7 +464,8 @@ class _RegimentRow extends StatelessWidget {
       child: ListTile(
         title: Text('${row.typeId}: ${row.count}'),
         subtitle: Text(
-            'Medals: ${row.medalsSummary} · Status: ${row.statusLabel}'),
+          'Medals: ${row.medalsSummary} · Status: ${row.statusLabel}',
+        ),
         dense: true,
         onTap: onTap,
       ),

--- a/app/lib/features/game/widgets/train_military_dialog.dart
+++ b/app/lib/features/game/widgets/train_military_dialog.dart
@@ -1,0 +1,506 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+
+import '../../../widgets/ct_dialog_shell.dart';
+import '../../../widgets/ct_nine_patch_button.dart';
+import '../../../widgets/resource_icon.dart';
+
+class TrainMilitaryDialog extends StatefulWidget {
+  const TrainMilitaryDialog({
+    super.key,
+    required this.game,
+    required this.humanPlayerId,
+    required this.currentOrders,
+    required this.onOrdersChanged,
+  });
+
+  final Game game;
+  final String humanPlayerId;
+  final Orders currentOrders;
+  final void Function(List<BuildUnitOrder> orders) onOrdersChanged;
+
+  @override
+  State<TrainMilitaryDialog> createState() => _TrainMilitaryDialogState();
+}
+
+class _TrainMilitaryDialogState extends State<TrainMilitaryDialog> {
+  late Map<String, int> _counts;
+
+  @override
+  void initState() {
+    super.initState();
+    _counts = _initialCountsFromOrders();
+  }
+
+  Map<String, int> _initialCountsFromOrders() {
+    final next = {for (final e in RegimentEconomyCatalog.all) e.id: 0};
+    final capital = _player?.capitalProvinceId;
+    if (capital == null) return next;
+    final regimentIds = RegimentEconomyCatalog.byId.keys.toSet();
+    final list =
+        widget.currentOrders.buildUnitOrdersByPlayerId[widget.humanPlayerId] ??
+        const <BuildUnitOrder>[];
+    for (final o in list) {
+      if (!o.isMilitary) continue;
+      if (!regimentIds.contains(o.unitType)) continue;
+      if (o.spawnProvinceId != capital) continue;
+      next[o.unitType] = (next[o.unitType] ?? 0) + 1;
+    }
+    return next;
+  }
+
+  Player? get _player {
+    for (final p in widget.game.players) {
+      if (p.id == widget.humanPlayerId) return p;
+    }
+    return null;
+  }
+
+  bool get _hasCapital => _player?.capitalProvinceId != null;
+
+  int get _treasury => _player?.treasury ?? 0;
+  int get _peasants => _player?.workerPool.peasants ?? 0;
+  Map<String, bool> get _techUnlocked => _player?.techUnlocked ?? const {};
+
+  int _stockpileQty(String commodityId) =>
+      _player?.stockpile.quantityOf(commodityId) ?? 0;
+
+  bool _isLocked(String unitType) {
+    final techId = unlockingTechByRegimentId[unitType];
+    if (techId == null) return false;
+    return _techUnlocked[techId] != true;
+  }
+
+  int _totalTreasuryCost() {
+    var total = 0;
+    for (final e in RegimentEconomyCatalog.all) {
+      total += (_counts[e.id] ?? 0) * e.buildTreasuryCost;
+    }
+    return total;
+  }
+
+  int _totalPeasantCost() {
+    var total = 0;
+    for (final e in RegimentEconomyCatalog.all) {
+      total += (_counts[e.id] ?? 0);
+    }
+    return total;
+  }
+
+  Map<String, int> _totalCommodityCosts() {
+    final totals = <String, int>{};
+    for (final e in RegimentEconomyCatalog.all) {
+      final count = _counts[e.id] ?? 0;
+      if (count <= 0) continue;
+      for (final input in e.buildInputs.entries) {
+        totals[input.key] = (totals[input.key] ?? 0) + (input.value * count);
+      }
+    }
+    return totals;
+  }
+
+  bool _canAffordIncrement(String unitType) {
+    final econ = RegimentEconomyCatalog.byId[unitType];
+    if (econ == null) return false;
+    if (_isLocked(unitType)) return false;
+
+    final newTreasury = _totalTreasuryCost() + econ.buildTreasuryCost;
+    final newPeasants = _totalPeasantCost() + 1;
+    if (newTreasury > _treasury) return false;
+    if (newPeasants > _peasants) return false;
+
+    final totals = _totalCommodityCosts();
+    for (final input in econ.buildInputs.entries) {
+      totals[input.key] = (totals[input.key] ?? 0) + input.value;
+    }
+    for (final e in totals.entries) {
+      if (e.value > _stockpileQty(e.key)) return false;
+    }
+    return true;
+  }
+
+  String? get _deficitHint {
+    final deficits = <String>[];
+    if (_totalTreasuryCost() > _treasury) deficits.add('Treasury');
+    if (_totalPeasantCost() > _peasants) deficits.add('Peasants');
+    final totalComms = _totalCommodityCosts();
+    for (final e in totalComms.entries) {
+      if (e.value > _stockpileQty(e.key)) {
+        deficits.add(_commodityDisplayName(e.key));
+      }
+    }
+    if (deficits.isEmpty) return null;
+    if (deficits.length == 1) return '${deficits.first} low';
+    if (deficits.length == 2) return '${deficits[0]} and ${deficits[1]} low';
+    final head = deficits.sublist(0, deficits.length - 1).join(', ');
+    return '$head and ${deficits.last} low';
+  }
+
+  String _commodityDisplayName(String commodityId) {
+    return CommodityCatalog.byId[commodityId]?.displayName ?? commodityId;
+  }
+
+  void _increment(String unitType) {
+    if (!_canAffordIncrement(unitType)) return;
+    setState(() {
+      _counts[unitType] = (_counts[unitType] ?? 0) + 1;
+    });
+  }
+
+  void _decrement(String unitType) {
+    if ((_counts[unitType] ?? 0) <= 0) return;
+    setState(() {
+      _counts[unitType] = (_counts[unitType] ?? 0) - 1;
+    });
+  }
+
+  void _reset() {
+    setState(() {
+      for (final e in RegimentEconomyCatalog.all) {
+        _counts[e.id] = 0;
+      }
+    });
+  }
+
+  void _applyOrders() {
+    final orders = <BuildUnitOrder>[];
+    final capital = _player?.capitalProvinceId;
+    if (capital == null) return;
+    for (final e in RegimentEconomyCatalog.all) {
+      final count = _counts[e.id] ?? 0;
+      for (var i = 0; i < count; i++) {
+        orders.add(
+          BuildUnitOrder(
+            unitType: e.id,
+            isMilitary: true,
+            spawnProvinceId: capital,
+          ),
+        );
+      }
+    }
+    widget.onOrdersChanged(orders);
+  }
+
+  String _techRequiredLabel(String unitType) {
+    final techId = unlockingTechByRegimentId[unitType];
+    if (techId == null) return '';
+    return 'Requires: ${techDisplayName(techId)}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: true,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) {
+          _applyOrders();
+        }
+      },
+      child: CtDialogShell(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 8, 8),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Train Military',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+            if (!_hasCapital)
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  'No capital set — cannot train units',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.error,
+                  ),
+                ),
+              )
+            else ...[
+              _MilitaryResourceBar(
+                treasury: _treasury,
+                peasants: _peasants,
+                stockpile: _player?.stockpile ?? const Stockpile(),
+                deficitHint: _deficitHint,
+              ),
+              const Divider(height: 1),
+              Flexible(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  child: Column(
+                    children: [
+                      for (final econ in RegimentEconomyCatalog.all)
+                        _RegimentRow(
+                          econ: econ,
+                          count: _counts[econ.id] ?? 0,
+                          isLocked: _isLocked(econ.id),
+                          techRequiredLabel: _techRequiredLabel(econ.id),
+                          canIncrement: _canAffordIncrement(econ.id),
+                          canDecrement: (_counts[econ.id] ?? 0) > 0,
+                          onIncrement: () => _increment(econ.id),
+                          onDecrement: () => _decrement(econ.id),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+              const Divider(height: 1),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    CtNinePatchButton(
+                      onPressed: _reset,
+                      child: const Text('Reset'),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MilitaryResourceBar extends StatelessWidget {
+  const _MilitaryResourceBar({
+    required this.treasury,
+    required this.peasants,
+    required this.stockpile,
+    required this.deficitHint,
+  });
+
+  final int treasury;
+  final int peasants;
+  final Stockpile stockpile;
+  final String? deficitHint;
+
+  static const _militaryCommodityIds = <String>[
+    'fabric',
+    'castIron',
+    'lumber',
+    'horses',
+    'steel',
+    'bronze',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: 10,
+            runSpacing: 6,
+            children: [
+              _ResourceChip(child: Text('Treasury: $treasury')),
+              _ResourceChip(
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const WorkerIcon(workerType: 'peasant', size: 14),
+                    const SizedBox(width: 4),
+                    Text('Peasants: $peasants'),
+                  ],
+                ),
+              ),
+              for (final commodityId in _militaryCommodityIds)
+                _ResourceChip(
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      ResourceIcon(commodityId: commodityId, size: 14),
+                      const SizedBox(width: 4),
+                      Text(
+                        '${_label(commodityId)}: ${stockpile.quantityOf(commodityId)}',
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+          if (deficitHint != null) ...[
+            const SizedBox(height: 4),
+            Text(
+              deficitHint!,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.error,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _label(String commodityId) {
+    return CommodityCatalog.byId[commodityId]?.displayName ?? commodityId;
+  }
+}
+
+class _ResourceChip extends StatelessWidget {
+  const _ResourceChip({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Theme.of(
+          context,
+        ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+        child: child,
+      ),
+    );
+  }
+}
+
+class _RegimentRow extends StatelessWidget {
+  const _RegimentRow({
+    required this.econ,
+    required this.count,
+    required this.isLocked,
+    required this.techRequiredLabel,
+    required this.canIncrement,
+    required this.canDecrement,
+    required this.onIncrement,
+    required this.onDecrement,
+  });
+
+  final RegimentEconomy econ;
+  final int count;
+  final bool isLocked;
+  final String techRequiredLabel;
+  final bool canIncrement;
+  final bool canDecrement;
+  final VoidCallback onIncrement;
+  final VoidCallback onDecrement;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Opacity(
+      opacity: isLocked ? 0.5 : 1.0,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    econ.id,
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                Text(
+                  '${econ.buildTreasuryCost}',
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ],
+            ),
+            const SizedBox(height: 2),
+            Wrap(
+              spacing: 8,
+              runSpacing: 4,
+              children: [
+                _InlineCost(
+                  icon: const Icon(Icons.payments_outlined, size: 14),
+                  label: '${econ.buildTreasuryCost}',
+                ),
+                _InlineCost(
+                  icon: const WorkerIcon(workerType: 'peasant', size: 14),
+                  label: '1',
+                ),
+                for (final input in econ.buildInputs.entries)
+                  _InlineCost(
+                    icon: ResourceIcon(commodityId: input.key, size: 14),
+                    label: '${input.value}',
+                  ),
+              ],
+            ),
+            if (isLocked) ...[
+              const SizedBox(height: 2),
+              Text(
+                techRequiredLabel,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.error,
+                ),
+              ),
+            ],
+            const SizedBox(height: 4),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                CtNinePatchButton(
+                  onPressed: isLocked || !canDecrement ? null : onDecrement,
+                  child: const Text('−'),
+                ),
+                const SizedBox(width: 8),
+                SizedBox(
+                  width: 32,
+                  child: Text(
+                    '$count',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.bodyLarge,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                CtNinePatchButton(
+                  onPressed: isLocked || !canIncrement ? null : onIncrement,
+                  child: const Text('+'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InlineCost extends StatelessWidget {
+  const _InlineCost({required this.icon, required this.label});
+
+  final Widget icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        icon,
+        const SizedBox(width: 3),
+        Text(label, style: Theme.of(context).textTheme.bodySmall),
+      ],
+    );
+  }
+}

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -18,6 +18,7 @@ import 'features/game/widgets/province_overlay_demo_data.dart';
 import 'features/game/widgets/tech_tree_widget.dart';
 import 'features/game/widgets/technology_screen.dart';
 import 'features/game/widgets/train_civilians_dialog.dart';
+import 'features/game/widgets/train_military_dialog.dart';
 import 'widgets/debug_init_game.dart';
 import 'widgets/ct_choice_chip.dart';
 import 'widgets/debug_map_visibility_story.dart';
@@ -57,6 +58,7 @@ class CtWidgetbookApp extends StatelessWidget {
         ...productionPanelDirectories,
         ...civilianUnitsPanelDirectories,
         ...trainCiviliansDialogDirectories,
+        ...trainMilitaryDialogDirectories,
         ...militaryUnitsPanelDirectories,
         ...navalUnitsPanelDirectories,
         ...diplomacyPanelDirectories,
@@ -563,7 +565,11 @@ List<WidgetbookNode> get militaryUnitsPanelDirectories => [
               : 'gp1';
           return ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
-            child: MilitaryUnitsPanel(game: game, humanPlayerId: humanPlayerId),
+            child: MilitaryUnitsPanel(
+              game: game,
+              humanPlayerId: humanPlayerId,
+              bus: AppEventBus.create(),
+            ),
           );
         },
       ),
@@ -998,8 +1004,8 @@ class _CivilianPanelWithMapStoryState
               region: region,
               cellSizePx: 24,
               visibilityMode: _visibilityMode,
-              playerViewForResources: _visibilityMode ==
-                      CtMapVisibilityMode.playerConstrained
+              playerViewForResources:
+                  _visibilityMode == CtMapVisibilityMode.playerConstrained
                   ? debugPlayerViewForFirstPlayer()
                   : null,
               showProvinceNamesLayer: _showProvinceNames,
@@ -1206,6 +1212,7 @@ class _MilitaryPanelWithMapStoryState
             child: MilitaryUnitsPanel(
               game: game,
               humanPlayerId: humanPlayerId,
+              bus: AppEventBus.create(),
               onLocateTile: _onLocateTile,
             ),
           ),
@@ -1214,6 +1221,59 @@ class _MilitaryPanelWithMapStoryState
     );
   }
 }
+
+/// Train Military Dialog stories. SPEC/ui/train-military-dialog.md.
+List<WidgetbookNode> get trainMilitaryDialogDirectories => [
+  WidgetbookFolder(
+    name: 'Train Military Dialog',
+    children: [
+      WidgetbookUseCase(
+        name: 'Standalone',
+        builder: (context) {
+          final result = getDebugInitGameResult();
+          final game = result.game;
+          final humanPlayerId = game.players.isNotEmpty
+              ? game.players.firstWhere((p) => p.isHuman).id
+              : game.players.first.id;
+          final player = game.players.firstWhere((p) => p.id == humanPlayerId);
+          final richGame = game.copyWith(
+            players: [
+              player.copyWith(
+                treasury: 10000,
+                workerPool: player.workerPool.copyWith(peasants: 20),
+                stockpile: player.stockpile.merge(
+                  const Stockpile(
+                    quantities: {
+                      'fabric': 50,
+                      'castIron': 50,
+                      'lumber': 50,
+                      'horses': 50,
+                      'steel': 50,
+                      'bronze': 50,
+                    },
+                  ),
+                ),
+              ),
+              ...game.players.where((p) => p.id != humanPlayerId),
+            ],
+          );
+          return MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: TrainMilitaryDialog(
+                  game: richGame,
+                  humanPlayerId: humanPlayerId,
+                  currentOrders: const Orders(),
+                  onOrdersChanged: (_) {},
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    ],
+  ),
+];
 
 /// Naval Units Panel + map in tandem. SPEC/ui/naval-units-panel.md.
 class _NavalPanelWithMapStory extends StatefulWidget {
@@ -1375,8 +1435,9 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
     final mapViewData = debugMapViewDataWithVisibilityForFirstPlayer();
     final region = mapViewData.oldWorld;
     final game = getDebugInitGameResult().game;
-    final tiles =
-        game.worldState.tileKeysByRegionAndProvince[region.regionId]?[widget.selectedId];
+    final tiles = game
+        .worldState
+        .tileKeysByRegionAndProvince[region.regionId]?[widget.selectedId];
     if (tiles != null && tiles.isNotEmpty) {
       _selectedTileKey = tiles.first;
     } else {
@@ -1395,8 +1456,9 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
       final mapViewData = debugMapViewDataWithVisibilityForFirstPlayer();
       final region = mapViewData.oldWorld;
       final game = getDebugInitGameResult().game;
-      final tiles =
-          game.worldState.tileKeysByRegionAndProvince[region.regionId]?[widget.selectedId];
+      final tiles = game
+          .worldState
+          .tileKeysByRegionAndProvince[region.regionId]?[widget.selectedId];
       if (tiles != null && tiles.isNotEmpty) {
         _selectedTileKey = tiles.first;
       } else {
@@ -1414,8 +1476,11 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
   Widget build(BuildContext context) {
     final initResult = getDebugInitGameResult();
     final game = initResult.game;
-    final playerView =
-        buildPlayerView(game, initResult.combinedTopology, 'gp1');
+    final playerView = buildPlayerView(
+      game,
+      initResult.combinedTopology,
+      'gp1',
+    );
     final mapViewData = debugMapViewDataWithVisibilityForFirstPlayer();
     final region = mapViewData.oldWorld;
     final displayId = _displayIdFromTile(_selectedTileKey) ?? widget.selectedId;
@@ -1482,7 +1547,8 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
                         region: region,
                         cellSizePx: 28,
                         visibilityMode: _visibilityMode,
-                        playerViewForResources: _visibilityMode ==
+                        playerViewForResources:
+                            _visibilityMode ==
                                 CtMapVisibilityMode.playerConstrained
                             ? playerView
                             : null,

--- a/app/lib/widgetbook/catalog.dart
+++ b/app/lib/widgetbook/catalog.dart
@@ -20,6 +20,7 @@ import '../features/game/widgets/province_overlay_demo_data.dart';
 import '../features/game/widgets/tech_tree_widget.dart';
 import '../features/game/widgets/technology_screen.dart';
 import '../features/game/widgets/train_civilians_dialog.dart';
+import '../features/game/widgets/train_military_dialog.dart';
 import '../widgets/debug_init_game.dart';
 import '../widgets/ct_choice_chip.dart';
 import '../widgets/debug_map_visibility_story.dart';
@@ -59,6 +60,7 @@ class CtWidgetbookApp extends StatelessWidget {
         ...productionPanelDirectories,
         ...civilianUnitsPanelDirectories,
         ...trainCiviliansDialogDirectories,
+        ...trainMilitaryDialogDirectories,
         ...militaryUnitsPanelDirectories,
         ...navalUnitsPanelDirectories,
         ...diplomacyPanelDirectories,
@@ -565,7 +567,11 @@ List<WidgetbookNode> get militaryUnitsPanelDirectories => [
               : 'gp1';
           return ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
-            child: MilitaryUnitsPanel(game: game, humanPlayerId: humanPlayerId),
+            child: MilitaryUnitsPanel(
+              game: game,
+              humanPlayerId: humanPlayerId,
+              bus: AppEventBus.create(),
+            ),
           );
         },
       ),
@@ -1000,8 +1006,8 @@ class _CivilianPanelWithMapStoryState
               region: region,
               cellSizePx: 24,
               visibilityMode: _visibilityMode,
-              playerViewForResources: _visibilityMode ==
-                      CtMapVisibilityMode.playerConstrained
+              playerViewForResources:
+                  _visibilityMode == CtMapVisibilityMode.playerConstrained
                   ? debugPlayerViewForFirstPlayer()
                   : null,
               showProvinceNamesLayer: _showProvinceNames,
@@ -1208,6 +1214,7 @@ class _MilitaryPanelWithMapStoryState
             child: MilitaryUnitsPanel(
               game: game,
               humanPlayerId: humanPlayerId,
+              bus: AppEventBus.create(),
               onLocateTile: _onLocateTile,
             ),
           ),
@@ -1216,6 +1223,59 @@ class _MilitaryPanelWithMapStoryState
     );
   }
 }
+
+/// Train Military Dialog stories. SPEC/ui/train-military-dialog.md.
+List<WidgetbookNode> get trainMilitaryDialogDirectories => [
+  WidgetbookFolder(
+    name: 'Train Military Dialog',
+    children: [
+      WidgetbookUseCase(
+        name: 'Standalone',
+        builder: (context) {
+          final result = getDebugInitGameResult();
+          final game = result.game;
+          final humanPlayerId = game.players.isNotEmpty
+              ? game.players.firstWhere((p) => p.isHuman).id
+              : game.players.first.id;
+          final player = game.players.firstWhere((p) => p.id == humanPlayerId);
+          final richGame = game.copyWith(
+            players: [
+              player.copyWith(
+                treasury: 10000,
+                workerPool: player.workerPool.copyWith(peasants: 20),
+                stockpile: player.stockpile.merge(
+                  const Stockpile(
+                    quantities: {
+                      'fabric': 50,
+                      'castIron': 50,
+                      'lumber': 50,
+                      'horses': 50,
+                      'steel': 50,
+                      'bronze': 50,
+                    },
+                  ),
+                ),
+              ),
+              ...game.players.where((p) => p.id != humanPlayerId),
+            ],
+          );
+          return MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: TrainMilitaryDialog(
+                  game: richGame,
+                  humanPlayerId: humanPlayerId,
+                  currentOrders: const Orders(),
+                  onOrdersChanged: (_) {},
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    ],
+  ),
+];
 
 /// Naval Units Panel + map in tandem. SPEC/ui/naval-units-panel.md.
 class _NavalPanelWithMapStory extends StatefulWidget {
@@ -1377,8 +1437,9 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
     final mapViewData = debugMapViewDataWithVisibilityForFirstPlayer();
     final region = mapViewData.oldWorld;
     final game = getDebugInitGameResult().game;
-    final tiles =
-        game.worldState.tileKeysByRegionAndProvince[region.regionId]?[widget.selectedId];
+    final tiles = game
+        .worldState
+        .tileKeysByRegionAndProvince[region.regionId]?[widget.selectedId];
     if (tiles != null && tiles.isNotEmpty) {
       _selectedTileKey = tiles.first;
     } else {
@@ -1397,8 +1458,9 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
       final mapViewData = debugMapViewDataWithVisibilityForFirstPlayer();
       final region = mapViewData.oldWorld;
       final game = getDebugInitGameResult().game;
-      final tiles =
-          game.worldState.tileKeysByRegionAndProvince[region.regionId]?[widget.selectedId];
+      final tiles = game
+          .worldState
+          .tileKeysByRegionAndProvince[region.regionId]?[widget.selectedId];
       if (tiles != null && tiles.isNotEmpty) {
         _selectedTileKey = tiles.first;
       } else {
@@ -1416,8 +1478,11 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
   Widget build(BuildContext context) {
     final initResult = getDebugInitGameResult();
     final game = initResult.game;
-    final playerView =
-        buildPlayerView(game, initResult.combinedTopology, 'gp1');
+    final playerView = buildPlayerView(
+      game,
+      initResult.combinedTopology,
+      'gp1',
+    );
     final mapViewData = debugMapViewDataWithVisibilityForFirstPlayer();
     final region = mapViewData.oldWorld;
     final displayId = _displayIdFromTile(_selectedTileKey) ?? widget.selectedId;
@@ -1484,7 +1549,8 @@ class _MapWithOverlayStoryState extends State<_MapWithOverlayStory> {
                         region: region,
                         cellSizePx: 28,
                         visibilityMode: _visibilityMode,
-                        playerViewForResources: _visibilityMode ==
+                        playerViewForResources:
+                            _visibilityMode ==
                                 CtMapVisibilityMode.playerConstrained
                             ? playerView
                             : null,

--- a/app/test/military_units_panel_test.dart
+++ b/app/test/military_units_panel_test.dart
@@ -27,6 +27,7 @@ void main() {
   Widget buildPanel({
     required Game game,
     required String humanPlayerId,
+    AppEventBus? bus,
     void Function(String tileKey, String regionId)? onLocateTile,
   }) {
     return MaterialApp(
@@ -34,6 +35,7 @@ void main() {
         body: MilitaryUnitsPanel(
           game: game,
           humanPlayerId: humanPlayerId,
+          bus: bus ?? AppEventBus.create(),
           onLocateTile: onLocateTile,
         ),
       ),

--- a/app/test/train_military_dialog_test.dart
+++ b/app/test/train_military_dialog_test.dart
@@ -1,0 +1,209 @@
+import 'package:colonizethis_app/app.dart';
+import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
+import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart';
+import 'package:colonizethis_app/features/game/widgets/train_military_dialog.dart';
+import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_app/widgets/debug_init_game.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  late Game game;
+  late String humanPlayerId;
+
+  setUpAll(() {
+    game = getDebugInitGameResult().game;
+    humanPlayerId = game.players.isNotEmpty
+        ? game.players.firstWhere((p) => p.isHuman).id
+        : game.players.first.id;
+  });
+
+  Player getPlayer(String pid) {
+    return game.players.firstWhere((p) => p.id == pid);
+  }
+
+  Game gameWithMilitaryResources() {
+    final player = getPlayer(humanPlayerId);
+    final techUnlocked = Map<String, bool>.from(player.techUnlocked ?? {});
+    for (final techId in unlockingTechByRegimentId.values) {
+      techUnlocked[techId] = true;
+    }
+    return game.copyWith(
+      players: [
+        player.copyWith(
+          treasury: 10000,
+          workerPool: player.workerPool.copyWith(peasants: 20),
+          techUnlocked: techUnlocked,
+          stockpile: player.stockpile.merge(
+            const Stockpile(
+              quantities: {
+                'fabric': 100,
+                'castIron': 100,
+                'lumber': 100,
+                'horses': 100,
+                'steel': 100,
+                'bronze': 100,
+              },
+            ),
+          ),
+        ),
+        ...game.players.where((p) => p.id != humanPlayerId),
+      ],
+    );
+  }
+
+  Widget buildDialog({
+    required Game game,
+    required String humanPlayerId,
+    Orders currentOrders = const Orders(),
+    void Function(List<BuildUnitOrder>)? onOrdersChanged,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: TrainMilitaryDialog(
+          game: game,
+          humanPlayerId: humanPlayerId,
+          currentOrders: currentOrders,
+          onOrdersChanged: onOrdersChanged ?? (_) {},
+        ),
+      ),
+    );
+  }
+
+  testWidgets('dialog shows existing military orders in steppers on open', (
+    WidgetTester tester,
+  ) async {
+    final richGame = gameWithMilitaryResources();
+    final player = richGame.players.firstWhere((p) => p.id == humanPlayerId);
+    final capital = player.capitalProvinceId ?? player.capitalTile?.provinceId;
+    expect(capital, isNotNull, reason: 'debug game requires capital');
+
+    final firstRegiment = RegimentEconomyCatalog.all.first.id;
+    final orders = Orders(
+      buildUnitOrdersByPlayerId: {
+        humanPlayerId: [
+          BuildUnitOrder(
+            unitType: firstRegiment,
+            isMilitary: true,
+            spawnProvinceId: capital!,
+          ),
+          BuildUnitOrder(
+            unitType: firstRegiment,
+            isMilitary: true,
+            spawnProvinceId: capital,
+          ),
+        ],
+      },
+    );
+
+    await tester.pumpWidget(
+      buildDialog(
+        game: richGame,
+        humanPlayerId: humanPlayerId,
+        currentOrders: orders,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('2'), findsWidgets);
+  });
+
+  testWidgets('dialog submits military orders when closed', (
+    WidgetTester tester,
+  ) async {
+    List<BuildUnitOrder>? capturedOrders;
+    final richGame = gameWithMilitaryResources();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (ctx) => ElevatedButton(
+              onPressed: () {
+                showDialog<void>(
+                  context: ctx,
+                  builder: (_) => TrainMilitaryDialog(
+                    game: richGame,
+                    humanPlayerId: humanPlayerId,
+                    currentOrders: const Orders(),
+                    onOrdersChanged: (orders) {
+                      capturedOrders = orders;
+                    },
+                  ),
+                );
+              },
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    final firstPlus = find.text('+').first;
+    await tester.ensureVisible(firstPlus);
+    await tester.tap(firstPlus);
+    await tester.pumpAndSettle();
+    await tester.tap(firstPlus);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pumpAndSettle();
+
+    expect(capturedOrders, isNotNull);
+    expect(capturedOrders!.length, 2);
+    expect(capturedOrders!.every((o) => o.isMilitary), isTrue);
+  });
+
+  testWidgets('military panel train opens train military dialog via bus', (
+    WidgetTester tester,
+  ) async {
+    final richGame = gameWithMilitaryResources();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          currentGameProvider.overrideWith((ref) => richGame),
+          currentOrdersProvider.overrideWith((ref) => const Orders()),
+          appEventBusProvider.overrideWith((ref) {
+            final bus = AppEventBus.create();
+            ref.onDispose(bus.dispose);
+            return bus;
+          }),
+        ],
+        child: AppEventHandlerScope(
+          child: MaterialApp(
+            navigatorKey: appNavigatorKey,
+            home: Scaffold(
+              body: Consumer(
+                builder: (context, ref, _) {
+                  return MilitaryUnitsPanel(
+                    game: richGame,
+                    humanPlayerId: humanPlayerId,
+                    bus: ref.watch(appEventBusProvider),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Train'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TrainMilitaryDialog), findsOneWidget);
+    expect(find.text('Train Military'), findsOneWidget);
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -497,10 +497,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- Add a Train button to `MilitaryUnitsPanel` that emits `OpenDialogEvent(trainMilitaryDialogId)` via `AppEventBus`.
- Implement `TrainMilitaryDialog` mirroring the civilian training flow (steppers, resource bar, tech locks) and create `BuildUnitOrder`s with `isMilitary: true` spawning at capital next turn.
- Wire dialog registration + order merge semantics in `AppEventHandlerScope` and add Widgetbook stories + widget tests.

## Test plan
- [x] `dart analyze` (repo currently has pre-existing warnings)
- [x] `flutter test --coverage` (from `app/`)
- [x] Coverage summary (app): 82.6% lines (5620/6801); `TrainMilitaryDialog` 163/173 lines hit


Made with [Cursor](https://cursor.com)