### PR TITLE
refactor(riverpod): migrate currentOrdersProvider to NotifierProvider

### DIFF
--- a/app/lib/core/services/app_event_handler_scope.dart
+++ b/app/lib/core/services/app_event_handler_scope.dart
@@ -157,13 +157,14 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
             currentOrders: orders,
             onOrdersChanged: (newOrders) {
               final o = container.read(currentOrdersProvider);
-              container.read(currentOrdersProvider.notifier).state =
-                  _mergeTrainCivilianOrdersForPlayer(
+              container.read(currentOrdersProvider.notifier).replaceAll(
+                    _mergeTrainCivilianOrdersForPlayer(
                 current: o,
                 game: game,
                 humanPlayerId: humanPlayerId,
                 newFromDialog: newOrders,
-              );
+              ),
+                  );
             },
           );
         },
@@ -198,7 +199,7 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
           e.playerId,
           e.index,
         );
-        ref.read(currentOrdersProvider.notifier).state = updated;
+        ref.read(currentOrdersProvider.notifier).replaceAll(updated);
       }),
       bus.on<CancelInProgressCivilianWorkRequestedEvent>().listen((e) {
         final game = ref.read(currentGameProvider);

--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -220,11 +220,13 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
     final orders = ref.read(currentOrdersProvider);
     ref
         .read(currentOrdersProvider.notifier)
-        .state = GameMapAreaStateLogic.addHumanWorkOrder(
+        .replaceAll(
+          GameMapAreaStateLogic.addHumanWorkOrder(
       orders: orders,
       humanPlayerId: _humanPlayerId,
       workOrder: workOrder,
-    );
+    ),
+        );
     setState(() {
       _workTargetSelection = null;
       _cachedValidTileKeys = null;
@@ -246,7 +248,7 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
     final orders = ref.read(currentOrdersProvider);
     final newGame = service.nextTurn(game, orders: orders);
     ref.read(currentGameProvider.notifier).state = newGame;
-    ref.read(currentOrdersProvider.notifier).state = const ct_models.Orders();
+    ref.read(currentOrdersProvider.notifier).clear();
   }
 
   @override

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -131,8 +131,7 @@ class GameScreen extends ConsumerWidget {
                 final result = service.runTurnResolution(game, orders: orders);
                 if (result is TurnResolutionComplete) {
                   ref.read(currentGameProvider.notifier).state = result.game;
-                  ref.read(currentOrdersProvider.notifier).state =
-                      const Orders();
+                  ref.read(currentOrdersProvider.notifier).clear();
                 } else if (result is TurnResolutionPendingOvertures) {
                   ref.read(currentGameProvider.notifier).state = result.game;
                   ref.read(pendingOverturesProvider.notifier).state =
@@ -189,7 +188,7 @@ class GameScreen extends ConsumerWidget {
           ref.read(pendingOverturesProvider.notifier).state = null;
           if (result is TurnResolutionComplete) {
             ref.read(currentGameProvider.notifier).state = result.game;
-            ref.read(currentOrdersProvider.notifier).state = const Orders();
+            ref.read(currentOrdersProvider.notifier).clear();
           } else if (result is TurnResolutionPendingOvertures) {
             ref.read(currentGameProvider.notifier).state = result.game;
             ref.read(pendingOverturesProvider.notifier).state =

--- a/app/lib/features/game/widgets/technology_screen.dart
+++ b/app/lib/features/game/widgets/technology_screen.dart
@@ -56,7 +56,7 @@ class TechnologyScreen extends ConsumerWidget {
                       player: displayPlayer,
                       currentOrders: currentOrders,
                       onOrdersChanged: (next) {
-                        ref.read(currentOrdersProvider.notifier).state = next;
+                        ref.read(currentOrdersProvider.notifier).replaceAll(next);
                       },
                     ),
                     _TreeTab(game: displayGame, player: displayPlayer),

--- a/app/lib/providers/games_provider.dart
+++ b/app/lib/providers/games_provider.dart
@@ -17,7 +17,26 @@ final currentGameProvider = StateProvider<Game?>((ref) => null);
 
 /// Current-turn orders for the human player (work orders, move orders, etc.).
 /// Updated when the player assigns/cancels work in the civilian panel; passed to nextTurn and reset after resolution.
-final currentOrdersProvider = StateProvider<Orders>((ref) => const Orders());
+class CurrentOrdersNotifier extends Notifier<Orders> {
+  CurrentOrdersNotifier([this._initial = const Orders()]);
+
+  final Orders _initial;
+
+  @override
+  Orders build() => _initial;
+
+  void replaceAll(Orders next) {
+    state = next;
+  }
+
+  void clear() {
+    state = const Orders();
+  }
+}
+
+final currentOrdersProvider = NotifierProvider<CurrentOrdersNotifier, Orders>(
+  CurrentOrdersNotifier.new,
+);
 
 /// Available work targets per civilian unit (unitId → allowed target ids).
 ///

--- a/app/test/game_side_menu_test.dart
+++ b/app/test/game_side_menu_test.dart
@@ -55,7 +55,9 @@ void main() {
               (ref) => GameService(gamesBox, GameSaveAdapter()),
             ),
             currentGameProvider.overrideWith((ref) => game),
-            currentOrdersProvider.overrideWith((ref) => const Orders()),
+            currentOrdersProvider.overrideWith(
+              () => CurrentOrdersNotifier(const Orders()),
+            ),
             availableWorkTargetsProvider.overrideWith(
               (ref) => <String, List<String>>{},
             ),
@@ -118,7 +120,9 @@ void main() {
             (ref) => GameService(gamesBox, GameSaveAdapter()),
           ),
           currentGameProvider.overrideWith((ref) => game),
-          currentOrdersProvider.overrideWith((ref) => const Orders()),
+          currentOrdersProvider.overrideWith(
+            () => CurrentOrdersNotifier(const Orders()),
+          ),
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
           ),
@@ -177,7 +181,9 @@ void main() {
             (ref) => GameService(gamesBox, GameSaveAdapter()),
           ),
           currentGameProvider.overrideWith((ref) => game),
-          currentOrdersProvider.overrideWith((ref) => const Orders()),
+          currentOrdersProvider.overrideWith(
+            () => CurrentOrdersNotifier(const Orders()),
+          ),
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
           ),
@@ -237,7 +243,9 @@ void main() {
               (ref) => GameService(gamesBox, GameSaveAdapter()),
             ),
             currentGameProvider.overrideWith((ref) => game),
-            currentOrdersProvider.overrideWith((ref) => const Orders()),
+            currentOrdersProvider.overrideWith(
+              () => CurrentOrdersNotifier(const Orders()),
+            ),
             availableWorkTargetsProvider.overrideWith(
               (ref) => <String, List<String>>{},
             ),
@@ -297,7 +305,9 @@ void main() {
               (ref) => GameService(gamesBox, GameSaveAdapter()),
             ),
             currentGameProvider.overrideWith((ref) => game),
-            currentOrdersProvider.overrideWith((ref) => const Orders()),
+            currentOrdersProvider.overrideWith(
+              () => CurrentOrdersNotifier(const Orders()),
+            ),
             availableWorkTargetsProvider.overrideWith(
               (ref) => <String, List<String>>{},
             ),
@@ -355,7 +365,9 @@ void main() {
             (ref) => GameService(gamesBox, GameSaveAdapter()),
           ),
           currentGameProvider.overrideWith((ref) => game),
-          currentOrdersProvider.overrideWith((ref) => const Orders()),
+          currentOrdersProvider.overrideWith(
+            () => CurrentOrdersNotifier(const Orders()),
+          ),
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
           ),
@@ -412,7 +424,9 @@ void main() {
               (ref) => GameService(gamesBox, GameSaveAdapter()),
             ),
             currentGameProvider.overrideWith((ref) => game),
-            currentOrdersProvider.overrideWith((ref) => const Orders()),
+            currentOrdersProvider.overrideWith(
+              () => CurrentOrdersNotifier(const Orders()),
+            ),
             availableWorkTargetsProvider.overrideWith(
               (ref) => <String, List<String>>{},
             ),
@@ -464,7 +478,9 @@ void main() {
               (ref) => GameService(gamesBox, GameSaveAdapter()),
             ),
             currentGameProvider.overrideWith((ref) => game),
-            currentOrdersProvider.overrideWith((ref) => const Orders()),
+            currentOrdersProvider.overrideWith(
+              () => CurrentOrdersNotifier(const Orders()),
+            ),
             availableWorkTargetsProvider.overrideWith(
               (ref) => <String, List<String>>{},
             ),
@@ -517,7 +533,9 @@ void main() {
             (ref) => GameService(gamesBox, GameSaveAdapter()),
           ),
           currentGameProvider.overrideWith((ref) => game),
-          currentOrdersProvider.overrideWith((ref) => const Orders()),
+          currentOrdersProvider.overrideWith(
+            () => CurrentOrdersNotifier(const Orders()),
+          ),
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
           ),
@@ -575,7 +593,9 @@ void main() {
             (ref) => GameService(gamesBox, GameSaveAdapter()),
           ),
           currentGameProvider.overrideWith((ref) => game),
-          currentOrdersProvider.overrideWith((ref) => const Orders()),
+          currentOrdersProvider.overrideWith(
+            () => CurrentOrdersNotifier(const Orders()),
+          ),
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
           ),
@@ -639,7 +659,9 @@ void main() {
             (ref) => GameService(gamesBox, GameSaveAdapter()),
           ),
           currentGameProvider.overrideWith((ref) => game),
-          currentOrdersProvider.overrideWith((ref) => const Orders()),
+          currentOrdersProvider.overrideWith(
+            () => CurrentOrdersNotifier(const Orders()),
+          ),
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
           ),

--- a/app/test/tech_tree_widget_test.dart
+++ b/app/test/tech_tree_widget_test.dart
@@ -31,7 +31,9 @@ void main() {
     return ProviderScope(
       overrides: [
         currentGameProvider.overrideWith((ref) => g),
-        currentOrdersProvider.overrideWith((ref) => const Orders()),
+        currentOrdersProvider.overrideWith(
+          () => CurrentOrdersNotifier(const Orders()),
+        ),
         appEventBusProvider.overrideWith((ref) {
           final bus = AppEventBus.create();
           ref.onDispose(bus.dispose);

--- a/app/test/train_civilians_dialog_test.dart
+++ b/app/test/train_civilians_dialog_test.dart
@@ -425,7 +425,9 @@ void main() {
         ProviderScope(
           overrides: [
             currentGameProvider.overrideWith((ref) => game),
-            currentOrdersProvider.overrideWith((ref) => const Orders()),
+            currentOrdersProvider.overrideWith(
+              () => CurrentOrdersNotifier(const Orders()),
+            ),
             appEventBusProvider.overrideWith((ref) {
               final bus = AppEventBus.create();
               ref.onDispose(bus.dispose);
@@ -462,7 +464,9 @@ void main() {
           ProviderScope(
             overrides: [
               currentGameProvider.overrideWith((ref) => game),
-              currentOrdersProvider.overrideWith((ref) => const Orders()),
+              currentOrdersProvider.overrideWith(
+                () => CurrentOrdersNotifier(const Orders()),
+              ),
               appEventBusProvider.overrideWith((ref) {
                 final bus = AppEventBus.create();
                 ref.onDispose(bus.dispose);

--- a/app/test/train_military_dialog_test.dart
+++ b/app/test/train_military_dialog_test.dart
@@ -173,7 +173,9 @@ void main() {
       ProviderScope(
         overrides: [
           currentGameProvider.overrideWith((ref) => richGame),
-          currentOrdersProvider.overrideWith((ref) => const Orders()),
+          currentOrdersProvider.overrideWith(
+            () => CurrentOrdersNotifier(const Orders()),
+          ),
           appEventBusProvider.overrideWith((ref) {
             final bus = AppEventBus.create();
             ref.onDispose(bus.dispose);


### PR DESCRIPTION
## Summary
- Migrates `currentOrdersProvider` from legacy `StateProvider<Orders>` to Riverpod v3 `NotifierProvider`.
- Replaces `.state = ...` writes with explicit notifier methods (`replaceAll` / `clear`) in app code.
- Updates test overrides to `NotifierProvider.overrideWith(() => CurrentOrdersNotifier(...))`.

## Test plan
- `melos run test_app`


Made with [Cursor](https://cursor.com)