### PR TITLE
COL-187: Naval ship construction consumes one peasant

### DIFF
--- a/packages/colonizethis_logic/lib/src/economy/build_cost.dart
+++ b/packages/colonizethis_logic/lib/src/economy/build_cost.dart
@@ -82,6 +82,9 @@ typedef _BuildDeductionPlan = ({
           (player.techUnlocked?[shipUnlockTech] != true)) {
         return (failReason: 'Insufficient tech', plan: null);
       }
+      if (workers.peasants <= 0) {
+        return (failReason: 'Insufficient resources', plan: null);
+      }
       if (treasury < shipEcon.buildTreasuryCost) {
         return (failReason: 'Insufficient treasury', plan: null);
       }
@@ -95,7 +98,7 @@ typedef _BuildDeductionPlan = ({
         plan: (
           treasuryCost: shipEcon.buildTreasuryCost,
           materialCosts: shipEcon.buildInputs,
-          subtractOnePeasant: false,
+          subtractOnePeasant: true,
         ),
       );
 

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -224,7 +224,7 @@ void _runBuildPhase(_BuildWorkState state) {
 /// BuildUnitOrder is applied by unit type category (civilian / military / naval) per buildUnitCategoryForUnitType.
 /// - Civilian: deduct treasury + paper, add unit with tileKey.
 /// - Military: deduct cost + worker, add unit.
-/// - Naval: deduct cost, add ship to home fleet at capital port.
+/// - Naval: deduct cost + one peasant, add ship to home fleet at capital port.
 /// - WorkOrder: sets the unit status to working; no terrain change yet.
 Game applyBuildAndWorkOrders(
   Game game,

--- a/packages/colonizethis_logic/test/build_cost_test.dart
+++ b/packages/colonizethis_logic/test/build_cost_test.dart
@@ -129,10 +129,34 @@ void main() {
         treasuryStart,
       );
       expect(after.treasury, treasuryStart - econ.buildTreasuryCost);
-      expect(after.workers.peasants, workers.peasants);
+      expect(after.workers.peasants, workers.peasants - 1);
       for (final e in econ.buildInputs.entries) {
         expect(after.stockpile.quantityOf(e.key), 0);
       }
+    });
+
+    test('naval carrack: canAfford false when peasants are zero', () {
+      const player = Player(id: 'p1', displayName: 'P', isHuman: true);
+      const workers = WorkerPool(peasants: 0);
+      final econ = ShipEconomyCatalog.byId['carrack']!;
+      var stockpile = const Stockpile();
+      for (final e in econ.buildInputs.entries) {
+        stockpile = stockpile.applyDelta(e.key, e.value);
+      }
+      const order = BuildUnitOrder(
+        unitType: 'carrack',
+        isMilitary: false,
+        spawnProvinceId: 'oldWorld|p1',
+      );
+      final result = canAffordBuild(
+        player,
+        order,
+        workers,
+        stockpile,
+        econ.buildTreasuryCost + 10,
+      );
+      expect(result.canAfford, isFalse);
+      expect(result.reason, 'Insufficient resources');
     });
   });
 }

--- a/packages/colonizethis_logic/test/order_engine_test.dart
+++ b/packages/colonizethis_logic/test/order_engine_test.dart
@@ -1579,6 +1579,60 @@ void main() {
       },
     );
 
+    test('rejects naval build when peasants are zero', () {
+      const ow = 'oldWorld';
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(
+            id: 'P1',
+            regionId: ow,
+            type: TopologyNodeType.province,
+          ),
+        ],
+        edges: const [],
+      );
+      final shipEcon = ShipEconomyCatalog.byId['carrack']!;
+      var stockpile = const Stockpile();
+      for (final e in shipEcon.buildInputs.entries) {
+        stockpile = stockpile.applyDelta(e.key, e.value + 1);
+      }
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
+            units: [],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: [
+          Player(
+            id: 'p1',
+            displayName: 'P1',
+            isHuman: true,
+            capitalProvinceId: '$ow|P1',
+            stockpile: stockpile,
+            workerPool: const WorkerPool(peasants: 0),
+            treasury: shipEcon.buildTreasuryCost + 10,
+          ),
+        ],
+      );
+      final engine = OrderEngine();
+      final result = engine.addBuildOrderWithContext(
+        game,
+        topology,
+        'p1',
+        BuildUnitOrder(
+          unitType: 'carrack',
+          isMilitary: false,
+          spawnProvinceId: '$ow|P1',
+        ),
+      );
+      expect(result.status, OrderValidationStatus.rejected);
+      expect(result.reason, 'Insufficient resources');
+    });
+
     group('validateBuild (civilian)', () {
       const ow = 'oldWorld';
       final topology = MapTopology(

--- a/packages/colonizethis_logic/test/order_suggestion_api_impl_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_api_impl_test.dart
@@ -98,6 +98,7 @@ void main() {
             displayName: 'A',
             isHuman: false,
             capitalProvinceId: '$ow|p1',
+            workerPool: const WorkerPool(peasants: 1),
             treasury: 100,
             stockpile: stockpile,
           ),

--- a/packages/colonizethis_logic/test/order_suggestion_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_test.dart
@@ -731,6 +731,7 @@ void main() {
         displayName: 'GP',
         isHuman: false,
         capitalProvinceId: '$ow|p1',
+        workerPool: const WorkerPool(peasants: 1),
         treasury: 100,
         stockpile: stockpile,
       );

--- a/packages/colonizethis_logic/test/orders_application_test.dart
+++ b/packages/colonizethis_logic/test/orders_application_test.dart
@@ -166,7 +166,7 @@ void main() {
           isHuman: true,
           capitalProvinceId: 'oldWorld|P1',
           stockpile: const Stockpile(),
-          workerPool: const WorkerPool(peasants: 0),
+          workerPool: const WorkerPool(peasants: 2),
           treasury: 100,
           techUnlocked: {'superior_hull_design': true},
         );
@@ -219,8 +219,70 @@ void main() {
           ),
           isTrue,
         );
+        expect(next.players.single.workerPool.peasants, 1);
       },
     );
+
+    test('rejects naval build when peasants are zero', () {
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(
+            id: 'P1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'sea1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.seaZone,
+          ),
+        ],
+        edges: const [TopologyEdge(id1: 'P1', id2: 'sea1')],
+      );
+      final shipEcon = ShipEconomyCatalog.byId['fluyte']!;
+      var stockpile = const Stockpile();
+      for (final e in shipEcon.buildInputs.entries) {
+        stockpile = stockpile.applyDelta(e.key, e.value + 1);
+      }
+      final player = Player(
+        id: 'p1',
+        displayName: 'Spain',
+        isHuman: true,
+        capitalProvinceId: 'oldWorld|P1',
+        stockpile: stockpile,
+        workerPool: const WorkerPool(peasants: 0),
+        treasury: shipEcon.buildTreasuryCost + 10,
+        techUnlocked: {'superior_hull_design': true},
+      );
+      final world = WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+        oldWorld: const RegionData(
+          provinces: [
+            Province(id: 'P1', regionId: 'oldWorld', ownerId: 'p1'),
+          ],
+          units: [],
+        ),
+        newWorld: const RegionData(),
+      );
+      final game = Game(id: 'g', worldState: world, players: [player]);
+      final orders = Orders(
+        buildUnitOrdersByPlayerId: {
+          'p1': [
+            BuildUnitOrder(
+              unitType: 'fluyte',
+              isMilitary:
+                  buildUnitCategoryForUnitType('fluyte') ==
+                  BuildUnitCategory.military,
+              spawnProvinceId: 'oldWorld|P1',
+            ),
+          ],
+        },
+      );
+      final next = applyBuildAndWorkOrders(game, orders, topology: topology);
+      expect(next.worldState.fleets, isEmpty);
+      expect(next.players.single.workerPool.peasants, 0);
+      expect(next.players.single.treasury, player.treasury);
+    });
 
     test('second naval build adds ship to existing home fleet', () {
       const ow = 'oldWorld';
@@ -246,6 +308,7 @@ void main() {
         isHuman: true,
         capitalProvinceId: '$ow|P1',
         stockpile: stockpile,
+        workerPool: const WorkerPool(peasants: 2),
         treasury: shipEcon.buildTreasuryCost * 2 + 10,
         techUnlocked: {'superior_hull_design': true},
       );
@@ -286,6 +349,7 @@ void main() {
           .single;
       expect(p1Fleet.shipTypeIds.length, 2);
       expect(p1Fleet.shipTypeIds, contains('fluyte'));
+      expect(next.players.single.workerPool.peasants, 1);
     });
   });
 
@@ -2581,7 +2645,7 @@ void main() {
         isHuman: true,
         capitalProvinceId: 'oldWorld|P1',
         stockpile: stockpile,
-        workerPool: const WorkerPool(peasants: 0),
+        workerPool: const WorkerPool(peasants: 1),
         treasury: shipEcon.buildTreasuryCost + 10,
         techUnlocked: {'superior_hull_design': true},
       );
@@ -2614,6 +2678,15 @@ void main() {
       );
       final next = applyBuildAndWorkOrders(game, orders); // no topology
       expect(next.worldState.fleets, isEmpty);
+      final nextPlayer = next.players.single;
+      expect(nextPlayer.treasury, player.treasury - shipEcon.buildTreasuryCost);
+      expect(nextPlayer.workerPool.peasants, 0);
+      for (final e in shipEcon.buildInputs.entries) {
+        expect(
+          nextPlayer.stockpile.quantityOf(e.key),
+          stockpile.quantityOf(e.key) - e.value,
+        );
+      }
     });
 
     test('ship build with capitalProvinceId null does not add fleet', () {
@@ -2643,7 +2716,7 @@ void main() {
         isHuman: true,
         capitalProvinceId: null, // no capital
         stockpile: stockpile,
-        workerPool: const WorkerPool(peasants: 0),
+        workerPool: const WorkerPool(peasants: 1),
         treasury: shipEcon.buildTreasuryCost + 10,
         techUnlocked: {'superior_hull_design': true},
       );
@@ -2676,6 +2749,15 @@ void main() {
       );
       final next = applyBuildAndWorkOrders(game, orders, topology: topology);
       expect(next.worldState.fleets, isEmpty);
+      final nextPlayer = next.players.single;
+      expect(nextPlayer.treasury, player.treasury - shipEcon.buildTreasuryCost);
+      expect(nextPlayer.workerPool.peasants, 0);
+      for (final e in shipEcon.buildInputs.entries) {
+        expect(
+          nextPlayer.stockpile.quantityOf(e.key),
+          stockpile.quantityOf(e.key) - e.value,
+        );
+      }
     });
 
     test('ship build with capital not adjacent to sea does not add ship', () {
@@ -2705,7 +2787,7 @@ void main() {
         isHuman: true,
         capitalProvinceId: 'oldWorld|P1',
         stockpile: stockpile,
-        workerPool: const WorkerPool(peasants: 0),
+        workerPool: const WorkerPool(peasants: 1),
         treasury: shipEcon.buildTreasuryCost + 10,
         techUnlocked: {'superior_hull_design': true},
       );
@@ -2738,6 +2820,15 @@ void main() {
       );
       final next = applyBuildAndWorkOrders(game, orders, topology: topology);
       expect(next.worldState.fleets, isEmpty);
+      final nextPlayer = next.players.single;
+      expect(nextPlayer.treasury, player.treasury - shipEcon.buildTreasuryCost);
+      expect(nextPlayer.workerPool.peasants, 0);
+      for (final e in shipEcon.buildInputs.entries) {
+        expect(
+          nextPlayer.stockpile.quantityOf(e.key),
+          stockpile.quantityOf(e.key) - e.value,
+        );
+      }
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [COL-187](https://linear.app): naval unit builds now require at least one peasant in the worker pool and subtract one peasant on successful cost application, matching `SPEC/game/workers-and-population.md` (military/naval construction consumes a worker).

## Changes

- `build_cost.dart`: naval branch checks `workers.peasants > 0` and sets `subtractOnePeasant: true`.
- `orders_application.dart`: doc comment updated to mention peasant deduction for naval builds.
- Tests: `build_cost_test`, `orders_application_test` (success + zero-peasant rejection + placement-failure still deducts when affordable), `order_engine_test` (validation rejects zero peasants), ship suggestion tests give the player at least one peasant so `carrack` suggestions still pass the order engine.

## Testing

Dart/Flutter was not available in this agent environment (`dart: command not found`). Please run locally, for example:

`dart test packages/colonizethis_logic/test/build_cost_test.dart packages/colonizethis_logic/test/orders_application_test.dart packages/colonizethis_logic/test/order_engine_test.dart packages/colonizethis_logic/test/order_suggestion_test.dart packages/colonizethis_logic/test/order_suggestion_api_impl_test.dart`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [COL-187](https://linear.app/colonizethisv3/issue/COL-187/build-naval-ship-construction-should-consume-one-worker)

<div><a href="https://cursor.com/agents/bc-c8a4af38-5a67-4299-9c49-8135d23a6e7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8a4af38-5a67-4299-9c49-8135d23a6e7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

