### PR TITLE
Scale military/naval treasury costs by 100x

### DIFF
--- a/SPEC/game/military-generals.md
+++ b/SPEC/game/military-generals.md
@@ -61,6 +61,42 @@ Each regiment type has **training cost** and **food upkeep** defined in **progra
 
 Per-regiment values follow the same era/category progression as the tactical stats table in [military-units.md](military-units.md).
 
+### Regiment treasury cost scale (canonical)
+
+`buildTreasuryCost` for every regiment is defined as the Phase 5 baseline value multiplied by **100**. This scale is the source of truth for military `BuildUnitOrder` treasury validation and deduction.
+
+| regiment_id | build_treasury_cost |
+| --- | ---: |
+| peasant_levies | 2000 |
+| pikemen | 4000 |
+| arquebusiers | 5000 |
+| bowmen | 3000 |
+| squires | 6000 |
+| knights | 8000 |
+| culverin | 8000 |
+| calivermen | 7000 |
+| halberdiers | 7000 |
+| musketeers | 8000 |
+| cossacks | 9000 |
+| lancers | 10000 |
+| harquebusiers | 11000 |
+| horse_artillery | 11000 |
+| royal_artillery | 12000 |
+| skirmishers | 9000 |
+| regulars | 11000 |
+| grenadiers | 13000 |
+| hussars | 13000 |
+| cuirassiers | 15000 |
+| light_artillery | 14000 |
+| heavy_artillery | 16000 |
+| sharpshooters | 12000 |
+| rifle_infantry | 14000 |
+| guards | 18000 |
+| scouts | 15000 |
+| carbine_cavalry | 18000 |
+| field_artillery | 18000 |
+| siege_guns | 22000 |
+
 **Config source:** Regiment economy values (training cost, food upkeep) live in program-level config (`colonizethis_data/lib/src/regiment_economy.dart`) per [ruleset-config.md](../program/ruleset-config.md). Ruleset-configurable regiment economy is deferred to a future phase when the ruleset loader supports JSON merge.
 
 **Implementation:** Training cost (cash, materials, worker) is applied at build time when BuildUnitOrder (military) is resolved per [orders.md](../program/orders.md). Food upkeep is consumed during the Consumption phase per [turn-resolution-phase-details.md](../program/turn-resolution-phase-details.md) § Consumption and [economy-models.md](../program/economy-models.md).

--- a/SPEC/game/ships-and-naval.md
+++ b/SPEC/game/ships-and-naval.md
@@ -45,22 +45,24 @@ Tech unlocks per [tech-tree-naval.md](tech-tree-naval.md). Cargo holds determine
 
 **Scaling:** Costs increase with the **unlocking tech era** (1–4) from [tech-tree-naval.md](tech-tree-naval.md). Merchants emphasize **treasury + cargo** progression; warships emphasize **hulls and combat materials**. Steam-era hulls add **cast iron** and/or **coal**.
 
+**Treasury scale:** `build_treasury_cost` values are the prior Phase 5 baseline multiplied by **100**.
+
 **Frozen baseline (do not change without explicit design pass):** `carrack` and `fluyte` treasury and material rows match the original Phase 5 catalog.
 
 | ship_type_id | role | unlock era | build_treasury_cost | build_inputs |
 | --- | --- | ---: | ---: | --- |
-| carrack | merchant | (none — always buildable) | 80 | `lumber`×2, `fabric`×1 |
-| fluyte | merchant | 1 | 60 | `lumber`×1, `fabric`×1 |
-| sloop | warship | 1 | 55 | `lumber`×1, `fabric`×1 |
-| trader | merchant | 2 | 75 | `lumber`×2, `fabric`×2 |
-| galleon | merchant | 2 | 95 | `lumber`×3, `fabric`×2 |
-| indiaman | merchant | 2 | 110 | `lumber`×3, `fabric`×3 |
-| frigate | warship | 3 | 105 | `lumber`×2, `fabric`×2 |
-| raider | warship | 3 | 115 | `lumber`×2, `fabric`×1, `castIron`×2 |
-| ship_of_the_line | warship | 3 | 165 | `lumber`×5, `fabric`×3 |
-| clipper | merchant | 4 | 135 | `lumber`×3, `fabric`×3 |
-| merchant_steamship | merchant | 4 | 155 | `lumber`×2, `fabric`×2, `coal`×3 |
-| ironclad | warship | 4 | 210 | `lumber`×2, `fabric`×2, `castIron`×5 |
+| carrack | merchant | (none — always buildable) | 8000 | `lumber`×2, `fabric`×1 |
+| fluyte | merchant | 1 | 6000 | `lumber`×1, `fabric`×1 |
+| sloop | warship | 1 | 5500 | `lumber`×1, `fabric`×1 |
+| trader | merchant | 2 | 7500 | `lumber`×2, `fabric`×2 |
+| galleon | merchant | 2 | 9500 | `lumber`×3, `fabric`×2 |
+| indiaman | merchant | 2 | 11000 | `lumber`×3, `fabric`×3 |
+| frigate | warship | 3 | 10500 | `lumber`×2, `fabric`×2 |
+| raider | warship | 3 | 11500 | `lumber`×2, `fabric`×1, `castIron`×2 |
+| ship_of_the_line | warship | 3 | 16500 | `lumber`×5, `fabric`×3 |
+| clipper | merchant | 4 | 13500 | `lumber`×3, `fabric`×3 |
+| merchant_steamship | merchant | 4 | 15500 | `lumber`×2, `fabric`×2, `coal`×3 |
+| ironclad | warship | 4 | 21000 | `lumber`×2, `fabric`×2, `castIron`×5 |
 
 Every `ship_type_id` that appears in any `shipUnlockIds` entry in the global tech catalog MUST have exactly one row in this table. `carrack` MUST NOT appear in `shipUnlockIds` (no unlocking tech).
 

--- a/packages/colonizethis_data/lib/src/regiment_economy.dart
+++ b/packages/colonizethis_data/lib/src/regiment_economy.dart
@@ -34,7 +34,7 @@ class RegimentEconomyCatalog {
   // Era 1
   static final RegimentEconomy peasantLevies = RegimentEconomy(
     id: 'peasant_levies',
-    buildTreasuryCost: 20,
+    buildTreasuryCost: 2000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
     },
@@ -43,7 +43,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy pikemen = RegimentEconomy(
     id: 'pikemen',
-    buildTreasuryCost: 40,
+    buildTreasuryCost: 4000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 1,
@@ -53,7 +53,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy arquebusiers = RegimentEconomy(
     id: 'arquebusiers',
-    buildTreasuryCost: 50,
+    buildTreasuryCost: 5000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 1,
@@ -63,7 +63,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy bowmen = RegimentEconomy(
     id: 'bowmen',
-    buildTreasuryCost: 30,
+    buildTreasuryCost: 3000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
     },
@@ -72,7 +72,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy squires = RegimentEconomy(
     id: 'squires',
-    buildTreasuryCost: 60,
+    buildTreasuryCost: 6000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 1,
@@ -83,7 +83,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy knights = RegimentEconomy(
     id: 'knights',
-    buildTreasuryCost: 80,
+    buildTreasuryCost: 8000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 2,
@@ -94,7 +94,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy culverin = RegimentEconomy(
     id: 'culverin',
-    buildTreasuryCost: 80,
+    buildTreasuryCost: 8000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 2,
@@ -106,7 +106,7 @@ class RegimentEconomyCatalog {
   // Era 2
   static final RegimentEconomy calivermen = RegimentEconomy(
     id: 'calivermen',
-    buildTreasuryCost: 70,
+    buildTreasuryCost: 7000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 1,
@@ -116,7 +116,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy halberdiers = RegimentEconomy(
     id: 'halberdiers',
-    buildTreasuryCost: 70,
+    buildTreasuryCost: 7000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 2,
@@ -126,7 +126,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy musketeers = RegimentEconomy(
     id: 'musketeers',
-    buildTreasuryCost: 80,
+    buildTreasuryCost: 8000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 2,
@@ -136,7 +136,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy cossacks = RegimentEconomy(
     id: 'cossacks',
-    buildTreasuryCost: 90,
+    buildTreasuryCost: 9000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 2,
@@ -147,7 +147,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy lancers = RegimentEconomy(
     id: 'lancers',
-    buildTreasuryCost: 100,
+    buildTreasuryCost: 10000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 2,
@@ -158,7 +158,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy harquebusiers = RegimentEconomy(
     id: 'harquebusiers',
-    buildTreasuryCost: 110,
+    buildTreasuryCost: 11000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 2,
@@ -169,7 +169,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy horseArtillery = RegimentEconomy(
     id: 'horse_artillery',
-    buildTreasuryCost: 110,
+    buildTreasuryCost: 11000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 2,
@@ -181,7 +181,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy royalArtillery = RegimentEconomy(
     id: 'royal_artillery',
-    buildTreasuryCost: 120,
+    buildTreasuryCost: 12000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 3,
@@ -193,7 +193,7 @@ class RegimentEconomyCatalog {
   // Era 3
   static final RegimentEconomy skirmishers = RegimentEconomy(
     id: 'skirmishers',
-    buildTreasuryCost: 90,
+    buildTreasuryCost: 9000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 2,
@@ -203,7 +203,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy regulars = RegimentEconomy(
     id: 'regulars',
-    buildTreasuryCost: 110,
+    buildTreasuryCost: 11000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 2,
@@ -213,7 +213,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy grenadiers = RegimentEconomy(
     id: 'grenadiers',
-    buildTreasuryCost: 130,
+    buildTreasuryCost: 13000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 3,
@@ -223,7 +223,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy hussars = RegimentEconomy(
     id: 'hussars',
-    buildTreasuryCost: 130,
+    buildTreasuryCost: 13000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 2,
@@ -234,7 +234,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy cuirassiers = RegimentEconomy(
     id: 'cuirassiers',
-    buildTreasuryCost: 150,
+    buildTreasuryCost: 15000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 3,
@@ -245,7 +245,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy lightArtillery = RegimentEconomy(
     id: 'light_artillery',
-    buildTreasuryCost: 140,
+    buildTreasuryCost: 14000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 2,
@@ -256,7 +256,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy heavyArtillery = RegimentEconomy(
     id: 'heavy_artillery',
-    buildTreasuryCost: 160,
+    buildTreasuryCost: 16000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 3,
@@ -268,7 +268,7 @@ class RegimentEconomyCatalog {
   // Era 4
   static final RegimentEconomy sharpshooters = RegimentEconomy(
     id: 'sharpshooters',
-    buildTreasuryCost: 120,
+    buildTreasuryCost: 12000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 2,
@@ -278,7 +278,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy rifleInfantry = RegimentEconomy(
     id: 'rifle_infantry',
-    buildTreasuryCost: 140,
+    buildTreasuryCost: 14000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 3,
@@ -288,7 +288,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy guards = RegimentEconomy(
     id: 'guards',
-    buildTreasuryCost: 180,
+    buildTreasuryCost: 18000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 3,
@@ -299,7 +299,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy scouts = RegimentEconomy(
     id: 'scouts',
-    buildTreasuryCost: 150,
+    buildTreasuryCost: 15000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 2,
@@ -310,7 +310,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy carbineCavalry = RegimentEconomy(
     id: 'carbine_cavalry',
-    buildTreasuryCost: 180,
+    buildTreasuryCost: 18000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 3,
@@ -321,7 +321,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy fieldArtillery = RegimentEconomy(
     id: 'field_artillery',
-    buildTreasuryCost: 180,
+    buildTreasuryCost: 18000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 3,
@@ -333,7 +333,7 @@ class RegimentEconomyCatalog {
 
   static final RegimentEconomy siegeGuns = RegimentEconomy(
     id: 'siege_guns',
-    buildTreasuryCost: 220,
+    buildTreasuryCost: 22000,
     buildInputs: {
       CommodityCatalog.fabric.id: 1,
       CommodityCatalog.castIron.id: 3,

--- a/packages/colonizethis_data/lib/src/ship_economy.dart
+++ b/packages/colonizethis_data/lib/src/ship_economy.dart
@@ -21,49 +21,49 @@ class ShipEconomyCatalog {
 
   static final ShipEconomyEntry carrack = ShipEconomyEntry(
     shipTypeId: 'carrack',
-    buildTreasuryCost: 80,
+    buildTreasuryCost: 8000,
     buildInputs: {CommodityCatalog.lumber.id: 2, CommodityCatalog.fabric.id: 1},
   );
 
   static final ShipEconomyEntry fluyte = ShipEconomyEntry(
     shipTypeId: 'fluyte',
-    buildTreasuryCost: 60,
+    buildTreasuryCost: 6000,
     buildInputs: {CommodityCatalog.lumber.id: 1, CommodityCatalog.fabric.id: 1},
   );
 
   static final ShipEconomyEntry sloop = ShipEconomyEntry(
     shipTypeId: 'sloop',
-    buildTreasuryCost: 55,
+    buildTreasuryCost: 5500,
     buildInputs: {CommodityCatalog.lumber.id: 1, CommodityCatalog.fabric.id: 1},
   );
 
   static final ShipEconomyEntry trader = ShipEconomyEntry(
     shipTypeId: 'trader',
-    buildTreasuryCost: 75,
+    buildTreasuryCost: 7500,
     buildInputs: {CommodityCatalog.lumber.id: 2, CommodityCatalog.fabric.id: 2},
   );
 
   static final ShipEconomyEntry galleon = ShipEconomyEntry(
     shipTypeId: 'galleon',
-    buildTreasuryCost: 95,
+    buildTreasuryCost: 9500,
     buildInputs: {CommodityCatalog.lumber.id: 3, CommodityCatalog.fabric.id: 2},
   );
 
   static final ShipEconomyEntry indiaman = ShipEconomyEntry(
     shipTypeId: 'indiaman',
-    buildTreasuryCost: 110,
+    buildTreasuryCost: 11000,
     buildInputs: {CommodityCatalog.lumber.id: 3, CommodityCatalog.fabric.id: 3},
   );
 
   static final ShipEconomyEntry frigate = ShipEconomyEntry(
     shipTypeId: 'frigate',
-    buildTreasuryCost: 105,
+    buildTreasuryCost: 10500,
     buildInputs: {CommodityCatalog.lumber.id: 2, CommodityCatalog.fabric.id: 2},
   );
 
   static final ShipEconomyEntry raider = ShipEconomyEntry(
     shipTypeId: 'raider',
-    buildTreasuryCost: 115,
+    buildTreasuryCost: 11500,
     buildInputs: {
       CommodityCatalog.lumber.id: 2,
       CommodityCatalog.fabric.id: 1,
@@ -73,19 +73,19 @@ class ShipEconomyCatalog {
 
   static final ShipEconomyEntry shipOfTheLine = ShipEconomyEntry(
     shipTypeId: 'ship_of_the_line',
-    buildTreasuryCost: 165,
+    buildTreasuryCost: 16500,
     buildInputs: {CommodityCatalog.lumber.id: 5, CommodityCatalog.fabric.id: 3},
   );
 
   static final ShipEconomyEntry clipper = ShipEconomyEntry(
     shipTypeId: 'clipper',
-    buildTreasuryCost: 135,
+    buildTreasuryCost: 13500,
     buildInputs: {CommodityCatalog.lumber.id: 3, CommodityCatalog.fabric.id: 3},
   );
 
   static final ShipEconomyEntry merchantSteamship = ShipEconomyEntry(
     shipTypeId: 'merchant_steamship',
-    buildTreasuryCost: 155,
+    buildTreasuryCost: 15500,
     buildInputs: {
       CommodityCatalog.lumber.id: 2,
       CommodityCatalog.fabric.id: 2,
@@ -95,7 +95,7 @@ class ShipEconomyCatalog {
 
   static final ShipEconomyEntry ironclad = ShipEconomyEntry(
     shipTypeId: 'ironclad',
-    buildTreasuryCost: 210,
+    buildTreasuryCost: 21000,
     buildInputs: {
       CommodityCatalog.lumber.id: 2,
       CommodityCatalog.fabric.id: 2,

--- a/packages/colonizethis_logic/test/build_cost_test.dart
+++ b/packages/colonizethis_logic/test/build_cost_test.dart
@@ -83,7 +83,7 @@ void main() {
       for (final e in econ.buildInputs.entries) {
         stockpile = stockpile.applyDelta(e.key, e.value);
       }
-      const treasuryStart = 500;
+      final treasuryStart = econ.buildTreasuryCost + 500;
       const order = BuildUnitOrder(
         unitType: 'peasant_levies',
         isMilitary: true,
@@ -113,7 +113,7 @@ void main() {
       for (final e in econ.buildInputs.entries) {
         stockpile = stockpile.applyDelta(e.key, e.value);
       }
-      const treasuryStart = 500;
+      final treasuryStart = econ.buildTreasuryCost + 500;
       const order = BuildUnitOrder(
         unitType: 'carrack',
         isMilitary: false,

--- a/packages/colonizethis_logic/test/order_suggestion_api_impl_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_api_impl_test.dart
@@ -79,6 +79,8 @@ void main() {
     test('suggestBuildOrders includes ship types when player can afford a ship', () {
       const api = DefaultOrderSuggestionAPI();
       const ow = 'oldWorld';
+      final affordableShipTreasury =
+          ShipEconomyCatalog.byId['carrack']!.buildTreasuryCost;
       final stockpile = const Stockpile()
           .applyDelta(CommodityCatalog.lumber.id, 2)
           .applyDelta(CommodityCatalog.fabric.id, 2);
@@ -98,7 +100,7 @@ void main() {
             displayName: 'A',
             isHuman: false,
             capitalProvinceId: '$ow|p1',
-            treasury: 100,
+            treasury: affordableShipTreasury,
             stockpile: stockpile,
           ),
         ],

--- a/packages/colonizethis_logic/test/order_suggestion_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_test.dart
@@ -723,6 +723,8 @@ void main() {
     test('suggestBuildOrders returns ship when affordable', () {
       const playerId = 'gp1';
       const ow = 'oldWorld';
+      final affordableShipTreasury =
+          ShipEconomyCatalog.byId['carrack']!.buildTreasuryCost;
       final stockpile = const Stockpile()
           .applyDelta(CommodityCatalog.lumber.id, 2)
           .applyDelta(CommodityCatalog.fabric.id, 2);
@@ -731,7 +733,7 @@ void main() {
         displayName: 'GP',
         isHuman: false,
         capitalProvinceId: '$ow|p1',
-        treasury: 100,
+        treasury: affordableShipTreasury,
         stockpile: stockpile,
       );
       final world = WorldState(
@@ -776,6 +778,8 @@ void main() {
       () {
         const playerId = 'gp1';
         const ow = 'oldWorld';
+        final affordableBothTreasury =
+            ShipEconomyCatalog.byId['carrack']!.buildTreasuryCost + 1000;
         final stockpile = const Stockpile()
             .applyDelta(CommodityCatalog.lumber.id, 5)
             .applyDelta(CommodityCatalog.fabric.id, 5)
@@ -786,7 +790,7 @@ void main() {
           isHuman: false,
           capitalProvinceId: '$ow|p1',
           workerPool: const WorkerPool(peasants: 2, apprentices: 1),
-          treasury: 500,
+          treasury: affordableBothTreasury,
           stockpile: stockpile,
         );
         final world = WorldState(


### PR DESCRIPTION
## Summary
- Update SPEC canonical economy definitions so military regiment and naval ship treasury costs are explicitly scaled 100x from prior baselines.
- Apply the same 100x treasury cost scale in `RegimentEconomyCatalog` and `ShipEconomyCatalog`.
- Update affordability-focused tests to use catalog-derived treasury values instead of hardcoded low constants.

## Test plan
- [x] `cd packages/colonizethis_data && dart test test/regiment_economy_test.dart test/ship_catalog_alignment_test.dart`
- [x] `cd packages/colonizethis_logic && dart test test/build_cost_test.dart test/orders/validators/work_order_cost_calculator_test.dart`
- [x] `cd packages/colonizethis_logic && dart test test/order_suggestion_api_impl_test.dart`
- [x] `cd packages/colonizethis_logic && dart test test/order_suggestion_test.dart`
- [x] `cd packages/colonizethis_logic && dart test`


Made with [Cursor](https://cursor.com)