### PR TITLE
refactor(riverpod): migrate currentGameProvider to NotifierProvider

### DIFF
--- a/app/lib/core/services/app_event_handler_scope.dart
+++ b/app/lib/core/services/app_event_handler_scope.dart
@@ -204,11 +204,11 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
         final game = ref.read(currentGameProvider);
         if (game == null) return;
         final newGame = clearUnitCurrentWork(game, e.unitId);
-        ref.read(currentGameProvider.notifier).state = newGame;
+        ref.read(currentGameProvider.notifier).setGame(newGame);
         ref.read(gameServiceProvider).saveGame(newGame);
       }),
       bus.on<NavalFleetsUpdatedEvent>().listen((e) {
-        ref.read(currentGameProvider.notifier).state = e.game;
+        ref.read(currentGameProvider.notifier).setGame(e.game);
       }),
     ]);
     _log.d(

--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -245,7 +245,7 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
     final service = ref.read(gameServiceProvider);
     final orders = ref.read(currentOrdersProvider);
     final newGame = service.nextTurn(game, orders: orders);
-    ref.read(currentGameProvider.notifier).state = newGame;
+    ref.read(currentGameProvider.notifier).setGame(newGame);
     ref.read(currentOrdersProvider.notifier).state = const ct_models.Orders();
   }
 

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -130,11 +130,11 @@ class GameScreen extends ConsumerWidget {
                 final orders = ref.read(currentOrdersProvider);
                 final result = service.runTurnResolution(game, orders: orders);
                 if (result is TurnResolutionComplete) {
-                  ref.read(currentGameProvider.notifier).state = result.game;
+                  ref.read(currentGameProvider.notifier).setGame(result.game);
                   ref.read(currentOrdersProvider.notifier).state =
                       const Orders();
                 } else if (result is TurnResolutionPendingOvertures) {
-                  ref.read(currentGameProvider.notifier).state = result.game;
+                  ref.read(currentGameProvider.notifier).setGame(result.game);
                   ref.read(pendingOverturesProvider.notifier).state =
                       result.pendingOvertures;
                 }
@@ -188,10 +188,10 @@ class GameScreen extends ConsumerWidget {
           );
           ref.read(pendingOverturesProvider.notifier).state = null;
           if (result is TurnResolutionComplete) {
-            ref.read(currentGameProvider.notifier).state = result.game;
+            ref.read(currentGameProvider.notifier).setGame(result.game);
             ref.read(currentOrdersProvider.notifier).state = const Orders();
           } else if (result is TurnResolutionPendingOvertures) {
-            ref.read(currentGameProvider.notifier).state = result.game;
+            ref.read(currentGameProvider.notifier).setGame(result.game);
             ref.read(pendingOverturesProvider.notifier).state =
                 result.pendingOvertures;
           }

--- a/app/lib/features/shell/new_game_setup_flow.dart
+++ b/app/lib/features/shell/new_game_setup_flow.dart
@@ -74,7 +74,7 @@ Future<void> runNewGameSetupAfterLeaderPick({
 
     switch (outcome) {
       case _NewGameOutcomeSuccess(:final game):
-        container.read(currentGameProvider.notifier).state = game;
+        container.read(currentGameProvider.notifier).setGame(game);
         bus.emit(const NavigateToRouteEvent(Routes.game));
         return;
       case _NewGameOutcomeFailure(:final error):

--- a/app/lib/features/shell/shell_screen.dart
+++ b/app/lib/features/shell/shell_screen.dart
@@ -30,7 +30,7 @@ class ShellScreen extends ConsumerWidget {
         if (ids.isEmpty || !context.mounted) return;
         final game = service.loadGame(ids.first);
         if (game != null && context.mounted) {
-          ref.read(currentGameProvider.notifier).state = game;
+          ref.read(currentGameProvider.notifier).setGame(game);
           if (context.mounted) {
             bus.emit(const NavigateToRouteEvent(Routes.game));
           }

--- a/app/lib/providers/games_provider.dart
+++ b/app/lib/providers/games_provider.dart
@@ -13,7 +13,26 @@ final gameListIdsProvider = FutureProvider<List<String>>((ref) async {
 });
 
 /// Currently loaded game, if any. Updated on load and after next turn.
-final currentGameProvider = StateProvider<Game?>((ref) => null);
+class CurrentGameNotifier extends Notifier<Game?> {
+  CurrentGameNotifier([this._initial]);
+
+  final Game? _initial;
+
+  @override
+  Game? build() => _initial;
+
+  void setGame(Game? game) {
+    state = game;
+  }
+
+  void clear() {
+    state = null;
+  }
+}
+
+final currentGameProvider = NotifierProvider<CurrentGameNotifier, Game?>(
+  CurrentGameNotifier.new,
+);
 
 /// Current-turn orders for the human player (work orders, move orders, etc.).
 /// Updated when the player assigns/cancels work in the civilian panel; passed to nextTurn and reset after resolution.

--- a/app/lib/widgets/game_to_ui_bus_listener.dart
+++ b/app/lib/widgets/game_to_ui_bus_listener.dart
@@ -50,7 +50,7 @@ class _GameToUIBusListenerState extends ConsumerState<GameToUIBusListener> {
     if (reloaded == null || !mounted) {
       return;
     }
-    ref.read(currentGameProvider.notifier).state = reloaded;
+    ref.read(currentGameProvider.notifier).setGame(reloaded);
   }
 
   @override

--- a/app/test/game_screen_branches_test.dart
+++ b/app/test/game_screen_branches_test.dart
@@ -35,7 +35,7 @@ void main() {
   }) {
     return ProviderScope(
       overrides: [
-        currentGameProvider.overrideWith((ref) => game),
+        currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
         mapViewDataProvider.overrideWith((ref) => mapViewData),
         gameIdsWithIntroShownProvider.overrideWith((ref) => introShownIds),
         appEventBusProvider.overrideWith((ref) {

--- a/app/test/game_screen_narrow_test.dart
+++ b/app/test/game_screen_narrow_test.dart
@@ -30,7 +30,9 @@ void main() {
   Widget buildGameScreen({required double width, required double height}) {
     return ProviderScope(
       overrides: [
-        currentGameProvider.overrideWith((ref) => debugResult.game),
+        currentGameProvider.overrideWith(
+          () => CurrentGameNotifier(debugResult.game),
+        ),
         mapViewDataProvider.overrideWith((ref) => debugResult.mapViewData),
         gameIdsWithIntroShownProvider.overrideWith(
           (ref) => {debugResult.game.id},
@@ -61,7 +63,9 @@ void main() {
   }) {
     return ProviderScope(
       overrides: [
-        currentGameProvider.overrideWith((ref) => debugResult.game),
+        currentGameProvider.overrideWith(
+          () => CurrentGameNotifier(debugResult.game),
+        ),
         mapViewDataProvider.overrideWith((ref) => debugResult.mapViewData),
         gameIdsWithIntroShownProvider.overrideWith(
           (ref) => {debugResult.game.id},
@@ -397,7 +401,7 @@ void main() {
     Widget _buildGameScreenWithPauseMenu({required Game game}) {
       return ProviderScope(
         overrides: [
-          currentGameProvider.overrideWith((ref) => game),
+          currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
           mapViewDataProvider.overrideWith((ref) => null),
           gameIdsWithIntroShownProvider.overrideWith((ref) => {game.id}),
           appEventBusProvider.overrideWith((ref) {
@@ -450,7 +454,9 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
-              currentGameProvider.overrideWith((ref) => victoryGame),
+              currentGameProvider.overrideWith(
+                () => CurrentGameNotifier(victoryGame),
+              ),
               mapViewDataProvider.overrideWith(
                 (ref) => debugResult.mapViewData,
               ),

--- a/app/test/game_screen_overture_pending_test.dart
+++ b/app/test/game_screen_overture_pending_test.dart
@@ -30,7 +30,7 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
-          currentGameProvider.overrideWith((ref) => game),
+          currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
           mapViewDataProvider.overrideWith((ref) => debugResult.mapViewData),
           gameIdsWithIntroShownProvider.overrideWith(
             (ref) => {game.id},

--- a/app/test/game_screen_side_menu_toggle_test.dart
+++ b/app/test/game_screen_side_menu_toggle_test.dart
@@ -27,7 +27,9 @@ void main() {
   Widget buildGameScreen({required double width, required double height}) {
     return ProviderScope(
       overrides: [
-        currentGameProvider.overrideWith((ref) => debugResult.game),
+        currentGameProvider.overrideWith(
+          () => CurrentGameNotifier(debugResult.game),
+        ),
         mapViewDataProvider.overrideWith((ref) => debugResult.mapViewData),
         gameIdsWithIntroShownProvider.overrideWith(
           (ref) => {debugResult.game.id},

--- a/app/test/game_screen_turn_resolution_branches_test.dart
+++ b/app/test/game_screen_turn_resolution_branches_test.dart
@@ -81,7 +81,7 @@ void main() {
           overrides: [
             gamesBoxProvider.overrideWith((ref) => box),
             gameServiceProvider.overrideWith((ref) => service),
-            currentGameProvider.overrideWith((ref) => game),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
             mapViewDataProvider.overrideWith((ref) => null),
             gameIdsWithIntroShownProvider.overrideWith((ref) => {game.id}),
           ],

--- a/app/test/game_side_menu_test.dart
+++ b/app/test/game_side_menu_test.dart
@@ -54,7 +54,7 @@ void main() {
             gameServiceProvider.overrideWith(
               (ref) => GameService(gamesBox, GameSaveAdapter()),
             ),
-            currentGameProvider.overrideWith((ref) => game),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
             currentOrdersProvider.overrideWith((ref) => const Orders()),
             availableWorkTargetsProvider.overrideWith(
               (ref) => <String, List<String>>{},
@@ -117,7 +117,7 @@ void main() {
           gameServiceProvider.overrideWith(
             (ref) => GameService(gamesBox, GameSaveAdapter()),
           ),
-          currentGameProvider.overrideWith((ref) => game),
+          currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
           currentOrdersProvider.overrideWith((ref) => const Orders()),
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
@@ -176,7 +176,7 @@ void main() {
           gameServiceProvider.overrideWith(
             (ref) => GameService(gamesBox, GameSaveAdapter()),
           ),
-          currentGameProvider.overrideWith((ref) => game),
+          currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
           currentOrdersProvider.overrideWith((ref) => const Orders()),
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
@@ -236,7 +236,7 @@ void main() {
             gameServiceProvider.overrideWith(
               (ref) => GameService(gamesBox, GameSaveAdapter()),
             ),
-            currentGameProvider.overrideWith((ref) => game),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
             currentOrdersProvider.overrideWith((ref) => const Orders()),
             availableWorkTargetsProvider.overrideWith(
               (ref) => <String, List<String>>{},
@@ -296,7 +296,7 @@ void main() {
             gameServiceProvider.overrideWith(
               (ref) => GameService(gamesBox, GameSaveAdapter()),
             ),
-            currentGameProvider.overrideWith((ref) => game),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
             currentOrdersProvider.overrideWith((ref) => const Orders()),
             availableWorkTargetsProvider.overrideWith(
               (ref) => <String, List<String>>{},
@@ -354,7 +354,7 @@ void main() {
           gameServiceProvider.overrideWith(
             (ref) => GameService(gamesBox, GameSaveAdapter()),
           ),
-          currentGameProvider.overrideWith((ref) => game),
+          currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
           currentOrdersProvider.overrideWith((ref) => const Orders()),
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
@@ -411,7 +411,7 @@ void main() {
             gameServiceProvider.overrideWith(
               (ref) => GameService(gamesBox, GameSaveAdapter()),
             ),
-            currentGameProvider.overrideWith((ref) => game),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
             currentOrdersProvider.overrideWith((ref) => const Orders()),
             availableWorkTargetsProvider.overrideWith(
               (ref) => <String, List<String>>{},
@@ -463,7 +463,7 @@ void main() {
             gameServiceProvider.overrideWith(
               (ref) => GameService(gamesBox, GameSaveAdapter()),
             ),
-            currentGameProvider.overrideWith((ref) => game),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
             currentOrdersProvider.overrideWith((ref) => const Orders()),
             availableWorkTargetsProvider.overrideWith(
               (ref) => <String, List<String>>{},
@@ -516,7 +516,7 @@ void main() {
           gameServiceProvider.overrideWith(
             (ref) => GameService(gamesBox, GameSaveAdapter()),
           ),
-          currentGameProvider.overrideWith((ref) => game),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
           currentOrdersProvider.overrideWith((ref) => const Orders()),
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
@@ -574,7 +574,7 @@ void main() {
           gameServiceProvider.overrideWith(
             (ref) => GameService(gamesBox, GameSaveAdapter()),
           ),
-          currentGameProvider.overrideWith((ref) => game),
+          currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
           currentOrdersProvider.overrideWith((ref) => const Orders()),
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},
@@ -638,7 +638,7 @@ void main() {
           gameServiceProvider.overrideWith(
             (ref) => GameService(gamesBox, GameSaveAdapter()),
           ),
-          currentGameProvider.overrideWith((ref) => game),
+          currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
           currentOrdersProvider.overrideWith((ref) => const Orders()),
           availableWorkTargetsProvider.overrideWith(
             (ref) => <String, List<String>>{},

--- a/app/test/game_to_ui_bus_listener_test.dart
+++ b/app/test/game_to_ui_bus_listener_test.dart
@@ -69,7 +69,7 @@ void main() {
               return svc;
             }),
             appEventBusProvider.overrideWith((ref) => bus),
-            currentGameProvider.overrideWith((ref) => game),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
           ],
           child: MaterialApp(
             home: GameToUIBusListener(

--- a/app/test/map_view_provider_test.dart
+++ b/app/test/map_view_provider_test.dart
@@ -167,7 +167,7 @@ void main() {
 
     final container = ProviderContainer(
       overrides: [
-        currentGameProvider.overrideWith((ref) => game),
+        currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
         gamesBoxProvider.overrideWith((ref) => gamesBox),
         gameServiceProvider.overrideWith(
           (ref) => _FakeGameService(gamesBox, GameSaveAdapter()),
@@ -227,7 +227,7 @@ void main() {
 
       final container = ProviderContainer(
         overrides: [
-          currentGameProvider.overrideWith((ref) => game),
+          currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
           gamesBoxProvider.overrideWith((ref) => gamesBox),
           gameServiceProvider.overrideWith(
             (ref) => _GameServiceWithMinimalMap(gamesBox, GameSaveAdapter()),

--- a/app/test/production_screen_integration_test.dart
+++ b/app/test/production_screen_integration_test.dart
@@ -43,7 +43,7 @@ void main() {
   }) {
     return ProviderScope(
       overrides: [
-        currentGameProvider.overrideWith((ref) => demoGame),
+        currentGameProvider.overrideWith(() => CurrentGameNotifier(demoGame)),
         appEventBusProvider.overrideWith((ref) {
           final bus = AppEventBus.create();
           ref.onDispose(bus.dispose);

--- a/app/test/providers_game_map_workflow_test.dart
+++ b/app/test/providers_game_map_workflow_test.dart
@@ -51,7 +51,7 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    container.read(currentGameProvider.notifier).state = game;
+    container.read(currentGameProvider.notifier).setGame(game);
 
     expect(container.read(mapViewDataProvider), isNotNull);
     expect(container.read(availableWorkTargetsProvider), isA<Map<String, List<String>>>());
@@ -73,7 +73,7 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    container.read(currentGameProvider.notifier).state = allAi;
+    container.read(currentGameProvider.notifier).setGame(allAi);
 
     expect(container.read(mapViewDataProvider), isNotNull);
   });

--- a/app/test/tech_tree_widget_test.dart
+++ b/app/test/tech_tree_widget_test.dart
@@ -30,7 +30,7 @@ void main() {
   Widget _scopedTechnology(Game g, Widget child) {
     return ProviderScope(
       overrides: [
-        currentGameProvider.overrideWith((ref) => g),
+        currentGameProvider.overrideWith(() => CurrentGameNotifier(g)),
         currentOrdersProvider.overrideWith((ref) => const Orders()),
         appEventBusProvider.overrideWith((ref) {
           final bus = AppEventBus.create();

--- a/app/test/train_civilians_dialog_test.dart
+++ b/app/test/train_civilians_dialog_test.dart
@@ -424,7 +424,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            currentGameProvider.overrideWith((ref) => game),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
             currentOrdersProvider.overrideWith((ref) => const Orders()),
             appEventBusProvider.overrideWith((ref) {
               final bus = AppEventBus.create();
@@ -461,7 +461,9 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
-              currentGameProvider.overrideWith((ref) => game),
+              currentGameProvider.overrideWith(
+                () => CurrentGameNotifier(game),
+              ),
               currentOrdersProvider.overrideWith((ref) => const Orders()),
               appEventBusProvider.overrideWith((ref) {
                 final bus = AppEventBus.create();

--- a/app/test/train_military_dialog_test.dart
+++ b/app/test/train_military_dialog_test.dart
@@ -172,7 +172,9 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
-          currentGameProvider.overrideWith((ref) => richGame),
+          currentGameProvider.overrideWith(
+            () => CurrentGameNotifier(richGame),
+          ),
           currentOrdersProvider.overrideWith((ref) => const Orders()),
           appEventBusProvider.overrideWith((ref) {
             final bus = AppEventBus.create();


### PR DESCRIPTION
## Summary
- Migrates `currentGameProvider` from legacy `StateProvider<Game?>` to Riverpod v3 `NotifierProvider`.
- Replaces direct `.state = ...` assignments with `setGame(...)` in app code.
- Updates widget/provider test overrides to `NotifierProvider.overrideWith(() => CurrentGameNotifier(...))`.

## Test plan
- `melos run test_app`


Made with [Cursor](https://cursor.com)