### PR TITLE
refactor(riverpod): migrate intro/overture state providers

### DIFF
--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -135,8 +135,9 @@ class GameScreen extends ConsumerWidget {
                       const Orders();
                 } else if (result is TurnResolutionPendingOvertures) {
                   ref.read(currentGameProvider.notifier).state = result.game;
-                  ref.read(pendingOverturesProvider.notifier).state =
-                      result.pendingOvertures;
+                  ref
+                      .read(pendingOverturesProvider.notifier)
+                      .setPending(result.pendingOvertures);
                 }
               },
               child: Text(
@@ -163,9 +164,7 @@ class GameScreen extends ConsumerWidget {
     if (showIntro) {
       content = GameStartIntroOverlay(
         onDismissed: () {
-          ref
-              .read(gameIdsWithIntroShownProvider.notifier)
-              .update((set) => {...set, game.id});
+          ref.read(gameIdsWithIntroShownProvider.notifier).markShown(game.id);
         },
         child: content,
       );
@@ -186,14 +185,15 @@ class GameScreen extends ConsumerWidget {
             decisions,
             orders,
           );
-          ref.read(pendingOverturesProvider.notifier).state = null;
+          ref.read(pendingOverturesProvider.notifier).clear();
           if (result is TurnResolutionComplete) {
             ref.read(currentGameProvider.notifier).state = result.game;
             ref.read(currentOrdersProvider.notifier).state = const Orders();
           } else if (result is TurnResolutionPendingOvertures) {
             ref.read(currentGameProvider.notifier).state = result.game;
-            ref.read(pendingOverturesProvider.notifier).state =
-                result.pendingOvertures;
+            ref
+                .read(pendingOverturesProvider.notifier)
+                .setPending(result.pendingOvertures);
           }
         },
         child: content,

--- a/app/lib/providers/games_provider.dart
+++ b/app/lib/providers/games_provider.dart
@@ -70,10 +70,44 @@ final devExclusiveReservedWorkTileKeysProvider = Provider<Set<String>>((ref) {
 
 /// Set of game ids for which the game-start intro dialogue has been shown.
 /// SPEC/ai/dialogue-management.md § First dialogue emission point.
+class GameIdsWithIntroShownNotifier extends Notifier<Set<String>> {
+  GameIdsWithIntroShownNotifier([this._initial = const <String>{}]);
+
+  final Set<String> _initial;
+
+  @override
+  Set<String> build() => _initial;
+
+  void markShown(String gameId) {
+    state = {...state, gameId};
+  }
+}
+
 final gameIdsWithIntroShownProvider =
-    StateProvider<Set<String>>((ref) => {});
+    NotifierProvider<GameIdsWithIntroShownNotifier, Set<String>>(
+      GameIdsWithIntroShownNotifier.new,
+    );
 
 /// When non-null, turn resolution is suspended; user must accept/reject overtures.
 /// SPEC/program/dialogue-system.md, SPEC/ai/dialogue-management.md.
+class PendingOverturesNotifier extends Notifier<List<OvertureOffer>?> {
+  PendingOverturesNotifier([this._initial]);
+
+  final List<OvertureOffer>? _initial;
+
+  @override
+  List<OvertureOffer>? build() => _initial;
+
+  void setPending(List<OvertureOffer>? overtures) {
+    state = overtures;
+  }
+
+  void clear() {
+    state = null;
+  }
+}
+
 final pendingOverturesProvider =
-    StateProvider<List<OvertureOffer>?>((ref) => null);
+    NotifierProvider<PendingOverturesNotifier, List<OvertureOffer>?>(
+      PendingOverturesNotifier.new,
+    );

--- a/app/test/game_screen_branches_test.dart
+++ b/app/test/game_screen_branches_test.dart
@@ -37,7 +37,9 @@ void main() {
       overrides: [
         currentGameProvider.overrideWith((ref) => game),
         mapViewDataProvider.overrideWith((ref) => mapViewData),
-        gameIdsWithIntroShownProvider.overrideWith((ref) => introShownIds),
+        gameIdsWithIntroShownProvider.overrideWith(
+          () => GameIdsWithIntroShownNotifier(introShownIds),
+        ),
         appEventBusProvider.overrideWith((ref) {
           final bus = AppEventBus.create();
           ref.onDispose(bus.dispose);

--- a/app/test/game_screen_narrow_test.dart
+++ b/app/test/game_screen_narrow_test.dart
@@ -33,7 +33,7 @@ void main() {
         currentGameProvider.overrideWith((ref) => debugResult.game),
         mapViewDataProvider.overrideWith((ref) => debugResult.mapViewData),
         gameIdsWithIntroShownProvider.overrideWith(
-          (ref) => {debugResult.game.id},
+          () => GameIdsWithIntroShownNotifier({debugResult.game.id}),
         ),
         appEventBusProvider.overrideWith((ref) {
           final bus = AppEventBus.create();
@@ -64,7 +64,7 @@ void main() {
         currentGameProvider.overrideWith((ref) => debugResult.game),
         mapViewDataProvider.overrideWith((ref) => debugResult.mapViewData),
         gameIdsWithIntroShownProvider.overrideWith(
-          (ref) => {debugResult.game.id},
+          () => GameIdsWithIntroShownNotifier({debugResult.game.id}),
         ),
         appEventBusProvider.overrideWith((ref) {
           final bus = AppEventBus.create();
@@ -399,7 +399,9 @@ void main() {
         overrides: [
           currentGameProvider.overrideWith((ref) => game),
           mapViewDataProvider.overrideWith((ref) => null),
-          gameIdsWithIntroShownProvider.overrideWith((ref) => {game.id}),
+          gameIdsWithIntroShownProvider.overrideWith(
+            () => GameIdsWithIntroShownNotifier({game.id}),
+          ),
           appEventBusProvider.overrideWith((ref) {
             final bus = AppEventBus.create();
             ref.onDispose(bus.dispose);
@@ -455,7 +457,7 @@ void main() {
                 (ref) => debugResult.mapViewData,
               ),
               gameIdsWithIntroShownProvider.overrideWith(
-                (ref) => {victoryGame.id},
+                () => GameIdsWithIntroShownNotifier({victoryGame.id}),
               ),
               appEventBusProvider.overrideWith((ref) {
                 final bus = AppEventBus.create();

--- a/app/test/game_screen_overture_pending_test.dart
+++ b/app/test/game_screen_overture_pending_test.dart
@@ -33,9 +33,11 @@ void main() {
           currentGameProvider.overrideWith((ref) => game),
           mapViewDataProvider.overrideWith((ref) => debugResult.mapViewData),
           gameIdsWithIntroShownProvider.overrideWith(
-            (ref) => {game.id},
+            () => GameIdsWithIntroShownNotifier({game.id}),
           ),
-          pendingOverturesProvider.overrideWith((ref) => pending),
+          pendingOverturesProvider.overrideWith(
+            () => PendingOverturesNotifier(pending),
+          ),
         ],
         child: MaterialApp(
           theme: AppThemes.colonial,

--- a/app/test/game_screen_side_menu_toggle_test.dart
+++ b/app/test/game_screen_side_menu_toggle_test.dart
@@ -30,7 +30,7 @@ void main() {
         currentGameProvider.overrideWith((ref) => debugResult.game),
         mapViewDataProvider.overrideWith((ref) => debugResult.mapViewData),
         gameIdsWithIntroShownProvider.overrideWith(
-          (ref) => {debugResult.game.id},
+          () => GameIdsWithIntroShownNotifier({debugResult.game.id}),
         ),
       ],
       child: MaterialApp(

--- a/app/test/game_screen_turn_resolution_branches_test.dart
+++ b/app/test/game_screen_turn_resolution_branches_test.dart
@@ -83,7 +83,9 @@ void main() {
             gameServiceProvider.overrideWith((ref) => service),
             currentGameProvider.overrideWith((ref) => game),
             mapViewDataProvider.overrideWith((ref) => null),
-            gameIdsWithIntroShownProvider.overrideWith((ref) => {game.id}),
+            gameIdsWithIntroShownProvider.overrideWith(
+              () => GameIdsWithIntroShownNotifier({game.id}),
+            ),
           ],
           child: MaterialApp(
             theme: AppThemes.colonial,

--- a/app/test/games_provider_test.dart
+++ b/app/test/games_provider_test.dart
@@ -47,7 +47,7 @@ void main() {
     final initial = container.read(gameIdsWithIntroShownProvider);
     expect(initial, isEmpty);
 
-    container.read(gameIdsWithIntroShownProvider.notifier).state = {'game_1'};
+    container.read(gameIdsWithIntroShownProvider.notifier).markShown('game_1');
 
     final updated = container.read(gameIdsWithIntroShownProvider);
     expect(updated, contains('game_1'));
@@ -60,7 +60,7 @@ void main() {
     final initial = container.read(pendingOverturesProvider);
     expect(initial, isNull);
 
-    container.read(pendingOverturesProvider.notifier).state = const [];
+    container.read(pendingOverturesProvider.notifier).setPending(const []);
 
     final updated = container.read(pendingOverturesProvider);
     expect(updated, isNotNull);


### PR DESCRIPTION
## Summary
- Migrates `gameIdsWithIntroShownProvider` and `pendingOverturesProvider` from legacy `StateProvider` to Riverpod v3 `NotifierProvider`.
- Updates `GameScreen` to use explicit notifier methods (`markShown`, `setPending`, `clear`).
- Updates widget/provider tests to use notifier overrides for the migrated providers.

## Test plan
- `melos run test_app`


Made with [Cursor](https://cursor.com)