### PR TITLE
feat(ui): add cargo hold indicator to in-game shell

### DIFF
--- a/SPEC/ui/empire-overview.md
+++ b/SPEC/ui/empire-overview.md
@@ -17,6 +17,8 @@
 - **Tabs:** One tab per region (e.g. "Old World", "New World"). Selecting a tab shows that region's map in the map area.
 - **Desktop:** Tab bar visible; map widget fills the map area for the active region. Layout may include sidebar and HUD (separate spec).
 - **Mobile:** One region per map. Same tab system: user switches regions via tabs. Each tab shows the full map widget for that region; no side-by-side regions on small screens. See [mobile-adaptation.md](mobile-adaptation.md) for touch targets and layout.
+- **Cargo hold indicator:** In the same control row as the region tabs, the UI shows a non-interactive cargo hold indicator with a crate icon and a numeric value in the exact format `used/capacity` (no spaces). `capacity` is the total cargo holds from all ships in the human player's Home Fleet (`cargoHoldsForHomeFleet`), and `used` is the total overseas resources extracted for that player in the current world state (sum of `computeExtraction(...).overseas` values for the player). The indicator is global (single total, not per-region) and remains visible when switching region tabs.
+- **Update contract:** The cargo hold indicator updates only when cargo-relevant game state changes (for example, fleet composition changes or extraction-relevant state changes) through the app's event bus/provider wiring; no animation or interaction is applied.
 
 ---
 
@@ -77,6 +79,10 @@ On mobile: same tab row; map area fills available space; one region visible at a
 - **When** the user selects a different region tab, **then** the map area shows that region's map (one region per map; no side-by-side on mobile).
 - **Given** the map widget is visible, **then** the user can pan, zoom (fixed levels, smooth), and toggle the political overlay; tap/click on a province invokes the selection callback and the screen can show province details (details content TBD).
 - **Desktop and mobile:** Both use the same tab-based region switching; on mobile, one region per map and tab system only.
+- **Given** the in-game shell control row is visible, **when** the UI renders region tabs, **then** the UI layer also renders a non-interactive cargo hold indicator beside the tabs with a crate icon and text formatted exactly as `used/capacity` (no spaces).
+- **Given** the in-game shell control row is visible for a human player, **when** the cargo hold indicator is computed, **then** `used` equals the sum of that player's overseas extraction totals in the current world state and `capacity` equals the total home-fleet cargo holds for that player.
+- **Given** the player switches between Old World and New World tabs, **when** the region tab changes, **then** the cargo hold indicator value remains a single global total and does not switch to per-region values.
+- **Given** fleet composition or extraction-relevant state changes and the app event bus/provider flow publishes those changes into the in-game shell state, **when** the map controls rebuild, **then** the cargo hold indicator updates to the new `used/capacity` value without animation.
 - **Given** the player has just entered the in-game shell (after init or load), **when** the map area is first shown, **then** the base layer display mode is terrain + resources + improvements (full letters visible).
 - **Given** the Empire overview map is visible, **when** the user taps the base-layer cycle button at the top-left of the map area, **then** the map advances to the next mode in order: terrain only → terrain + resources → terrain + resources + improvements → terrain only (repeating).
 - **Given** the Empire overview map is visible, **then** the base-layer cycle button is visible at the top-left of the map area and displays the stacked layers icon (icon-only).

--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -18,6 +18,7 @@ import '../../../../providers/game_service_provider.dart';
 import '../../../../providers/games_provider.dart';
 import '../../../../providers/map_province_panel_provider.dart';
 import '../../../../providers/map_view_provider.dart';
+import '../../../../providers/home_fleet_cargo_provider.dart';
 
 import 'game_screen_shared.dart';
 import 'game_side_menu.dart';
@@ -222,10 +223,10 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
         .read(currentOrdersProvider.notifier)
         .replaceAll(
           GameMapAreaStateLogic.addHumanWorkOrder(
-      orders: orders,
-      humanPlayerId: _humanPlayerId,
-      workOrder: workOrder,
-    ),
+            orders: orders,
+            humanPlayerId: _humanPlayerId,
+            workOrder: workOrder,
+          ),
         );
     setState(() {
       _workTargetSelection = null;
@@ -262,8 +263,9 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
   @override
   Widget build(BuildContext context) {
     final showProvinceOverlay = ref.watch(mapProvinceOverlayVisibleProvider);
-    final showProvinceOwnershipTint =
-        ref.watch(mapProvinceOwnershipTintVisibleProvider);
+    final showProvinceOwnershipTint = ref.watch(
+      mapProvinceOwnershipTintVisibleProvider,
+    );
     final showProvinceNames = ref.watch(mapProvinceNamesVisibleProvider);
     final isNarrow = MediaQuery.sizeOf(context).width < kInGameNarrowBreakpoint;
     final mapTopology = widget.mapViewData.combinedTopology;
@@ -280,6 +282,7 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
         widget.game.turnTimeMapping,
       ),
     );
+    final cargoSummary = ref.watch(homeFleetCargoSummaryProvider);
     return Column(
       children: [
         GameMapControls(
@@ -291,6 +294,8 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
           onRegionIndexChanged: (i) =>
               setState(() => _regionIndex = i == 0 ? 0 : 1),
           nextTurnText: nextTurnText,
+          cargoUsed: cargoSummary.used,
+          cargoCapacity: cargoSummary.capacity,
         ),
         Expanded(
           child: Focus(
@@ -362,11 +367,11 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
                                       value: provinceOverlayVisible,
                                       onChanged: (value) {
                                         ref
-                                                .read(
-                                                  mapProvinceOverlayVisibleProvider
-                                                      .notifier,
-                                                )
-                                                .set(value);
+                                            .read(
+                                              mapProvinceOverlayVisibleProvider
+                                                  .notifier,
+                                            )
+                                            .set(value);
                                       },
                                     ),
                                     SwitchListTile(
@@ -376,11 +381,11 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
                                       value: ownershipTintVisible,
                                       onChanged: (value) {
                                         ref
-                                                .read(
-                                                  mapProvinceOwnershipTintVisibleProvider
-                                                      .notifier,
-                                                )
-                                                .set(value);
+                                            .read(
+                                              mapProvinceOwnershipTintVisibleProvider
+                                                  .notifier,
+                                            )
+                                            .set(value);
                                       },
                                     ),
                                     SwitchListTile(
@@ -390,11 +395,11 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
                                       value: namesVisible,
                                       onChanged: (value) {
                                         ref
-                                                .read(
-                                                  mapProvinceNamesVisibleProvider
-                                                      .notifier,
-                                                )
-                                                .set(value);
+                                            .read(
+                                              mapProvinceNamesVisibleProvider
+                                                  .notifier,
+                                            )
+                                            .set(value);
                                       },
                                     ),
                                   ],

--- a/app/lib/features/game/flame/game_map_controls.dart
+++ b/app/lib/features/game/flame/game_map_controls.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import '../../../widgets/ct_choice_chip.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
+import 'game_screen_shared.dart';
 
 /// Top bar and region chips for the in-game map shell.
 class GameMapControls extends StatelessWidget {
@@ -12,6 +13,8 @@ class GameMapControls extends StatelessWidget {
     required this.regionIndex,
     required this.onRegionIndexChanged,
     required this.nextTurnText,
+    required this.cargoUsed,
+    required this.cargoCapacity,
     super.key,
   });
 
@@ -21,6 +24,8 @@ class GameMapControls extends StatelessWidget {
   final int regionIndex;
   final void Function(int index) onRegionIndexChanged;
   final String nextTurnText;
+  final int cargoUsed;
+  final int cargoCapacity;
 
   @override
   Widget build(BuildContext context) {
@@ -61,6 +66,21 @@ class GameMapControls extends StatelessWidget {
                 selected: regionIndex == 1,
                 onSelected: (_) => onRegionIndexChanged(1),
               ),
+              const SizedBox(width: 10),
+              Container(
+                key: kCargoHoldIndicatorKey,
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                color: Colors.black.withValues(alpha: 0.1),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    // Reserved crate-icon slot; issue #1328 tracks the asset.
+                    const SizedBox(width: 16, height: 16),
+                    const SizedBox(width: 4),
+                    Text('$cargoUsed/$cargoCapacity'),
+                  ],
+                ),
+              ),
             ],
           ),
         ),
@@ -68,4 +88,3 @@ class GameMapControls extends StatelessWidget {
     );
   }
 }
-

--- a/app/lib/features/game/flame/game_screen_shared.dart
+++ b/app/lib/features/game/flame/game_screen_shared.dart
@@ -12,3 +12,5 @@ const Key kHomeToCapitalButtonKey = Key('home_to_capital_button');
 /// Key for the map display options button (for tests). SPEC/ui/empire-overview.md § Map display options button and dialog.
 const Key kMapDisplayOptionsButtonKey = Key('map_display_options_button');
 
+/// Key for the cargo hold indicator row item. SPEC/ui/empire-overview.md.
+const Key kCargoHoldIndicatorKey = Key('cargo_hold_indicator');

--- a/app/lib/providers/home_fleet_cargo_provider.dart
+++ b/app/lib/providers/home_fleet_cargo_provider.dart
@@ -22,39 +22,41 @@ final homeFleetCargoSummaryProvider = Provider<HomeFleetCargoSummary>((ref) {
   final humanPlayer =
       game.players.where((p) => p.isHuman).firstOrNull ?? game.players.first;
   final playerId = humanPlayer.id;
+  final capacity = _homeFleetCapacity(game, playerId);
 
-  final service = ref.watch(gameServiceProvider);
-  final mapData = service.getMapData(game.id);
-  final tileMaps = mapData?.tileMapByRegion;
-  if (tileMaps == null || tileMaps.isEmpty) {
-    return HomeFleetCargoSummary(
-      used: 0,
-      capacity: _homeFleetCapacity(game, playerId),
+  // Some widget tests mount game UI without initializing Hive-backed services.
+  // Keep the indicator stable by falling back to 0/known-capacity in that case.
+  try {
+    final service = ref.watch(gameServiceProvider);
+    final mapData = service.getMapData(game.id);
+    final tileMaps = mapData?.tileMapByRegion;
+    if (tileMaps == null || tileMaps.isEmpty) {
+      return HomeFleetCargoSummary(used: 0, capacity: capacity);
+    }
+
+    final topology = mapData?.combinedTopology ?? const MapTopology();
+    final connectivity = resolveConnectivity(
+      game: game,
+      tileMapByRegion: tileMaps,
+      topology: topology,
     );
+    final extraction = computeExtraction(
+      game: game,
+      tileMapByRegion: tileMaps,
+      connectivityResult: connectivity,
+      techCapForPlayer: (id) {
+        final player = game.playerById(id);
+        return extractionCapForUnlocked(player?.techUnlocked);
+      },
+    );
+    final overseas =
+        extraction[playerId]?.overseas ?? const <CommodityId, int>{};
+    final used = overseas.values.fold<int>(0, (sum, value) => sum + value);
+
+    return HomeFleetCargoSummary(used: used, capacity: capacity);
+  } catch (_) {
+    return HomeFleetCargoSummary(used: 0, capacity: capacity);
   }
-
-  final topology = mapData?.combinedTopology ?? const MapTopology();
-  final connectivity = resolveConnectivity(
-    game: game,
-    tileMapByRegion: tileMaps,
-    topology: topology,
-  );
-  final extraction = computeExtraction(
-    game: game,
-    tileMapByRegion: tileMaps,
-    connectivityResult: connectivity,
-    techCapForPlayer: (id) {
-      final player = game.playerById(id);
-      return extractionCapForUnlocked(player?.techUnlocked);
-    },
-  );
-  final overseas = extraction[playerId]?.overseas ?? const <CommodityId, int>{};
-  final used = overseas.values.fold<int>(0, (sum, value) => sum + value);
-
-  return HomeFleetCargoSummary(
-    used: used,
-    capacity: _homeFleetCapacity(game, playerId),
-  );
 });
 
 int _homeFleetCapacity(Game game, String playerId) {

--- a/app/lib/providers/home_fleet_cargo_provider.dart
+++ b/app/lib/providers/home_fleet_cargo_provider.dart
@@ -1,0 +1,73 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'game_service_provider.dart';
+import 'games_provider.dart';
+
+class HomeFleetCargoSummary {
+  const HomeFleetCargoSummary({required this.used, required this.capacity});
+
+  final int used;
+  final int capacity;
+}
+
+final homeFleetCargoSummaryProvider = Provider<HomeFleetCargoSummary>((ref) {
+  final game = ref.watch(currentGameProvider);
+  if (game == null) {
+    return const HomeFleetCargoSummary(used: 0, capacity: 0);
+  }
+
+  final humanPlayer =
+      game.players.where((p) => p.isHuman).firstOrNull ?? game.players.first;
+  final playerId = humanPlayer.id;
+
+  final service = ref.watch(gameServiceProvider);
+  final mapData = service.getMapData(game.id);
+  final tileMaps = mapData?.tileMapByRegion;
+  if (tileMaps == null || tileMaps.isEmpty) {
+    return HomeFleetCargoSummary(
+      used: 0,
+      capacity: _homeFleetCapacity(game, playerId),
+    );
+  }
+
+  final topology = mapData?.combinedTopology ?? const MapTopology();
+  final connectivity = resolveConnectivity(
+    game: game,
+    tileMapByRegion: tileMaps,
+    topology: topology,
+  );
+  final extraction = computeExtraction(
+    game: game,
+    tileMapByRegion: tileMaps,
+    connectivityResult: connectivity,
+    techCapForPlayer: (id) {
+      final player = game.playerById(id);
+      return extractionCapForUnlocked(player?.techUnlocked);
+    },
+  );
+  final overseas = extraction[playerId]?.overseas ?? const <CommodityId, int>{};
+  final used = overseas.values.fold<int>(0, (sum, value) => sum + value);
+
+  return HomeFleetCargoSummary(
+    used: used,
+    capacity: _homeFleetCapacity(game, playerId),
+  );
+});
+
+int _homeFleetCapacity(Game game, String playerId) {
+  final homeFleetId = homeFleetIdFor(playerId);
+  final homeFleet = game.worldState.fleets
+      .where((f) => f.id == homeFleetId && f.ownerId == playerId)
+      .firstOrNull;
+  if (homeFleet == null) {
+    return 0;
+  }
+  var capacity = 0;
+  for (final shipTypeId in homeFleet.shipTypeIds) {
+    capacity += NavalStatsCatalog.get(shipTypeId).cargoHold;
+  }
+  return capacity;
+}

--- a/app/test/game_screen_narrow_test.dart
+++ b/app/test/game_screen_narrow_test.dart
@@ -4,10 +4,10 @@ import 'package:colonizethis_app/app.dart';
 import 'package:colonizethis_app/config/routes.dart';
 import 'package:colonizethis_app/config/themes.dart';
 import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
-import 'package:colonizethis_app/features/game/dialogue/overture_dialogue_overlay.dart';
 import 'package:colonizethis_app/features/game/flame/game_screen.dart';
 import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_app/providers/home_fleet_cargo_provider.dart';
 import 'package:colonizethis_app/providers/map_view_provider.dart';
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
@@ -42,6 +42,9 @@ void main() {
           ref.onDispose(bus.dispose);
           return bus;
         }),
+        homeFleetCargoSummaryProvider.overrideWith(
+          (ref) => const HomeFleetCargoSummary(used: 0, capacity: 0),
+        ),
       ],
       child: AppEventHandlerScope(
         child: MaterialApp(
@@ -75,6 +78,9 @@ void main() {
           ref.onDispose(bus.dispose);
           return bus;
         }),
+        homeFleetCargoSummaryProvider.overrideWith(
+          (ref) => const HomeFleetCargoSummary(used: 0, capacity: 0),
+        ),
       ],
       child: AppEventHandlerScope(
         child: MaterialApp(
@@ -95,6 +101,27 @@ void main() {
   }
 
   group('GameScreen — SPEC/ui/in-game-shell-narrow.md', () {
+    testWidgets(
+      'AC: cargo hold indicator appears beside region tabs in used/capacity format (SPEC/ui/empire-overview.md)',
+      (WidgetTester tester) async {
+        final dpr = tester.view.devicePixelRatio;
+        tester.view.physicalSize = Size(1500 * dpr, 700 * dpr);
+        addTearDown(tester.view.reset);
+        await tester.pumpWidget(buildGameScreen(width: 1500, height: 700));
+        await tester.pump();
+
+        final indicator = find.byKey(kCargoHoldIndicatorKey);
+        expect(indicator, findsOneWidget);
+
+        final formattedValue = find.descendant(
+          of: indicator,
+          matching: find.textContaining(RegExp(r'^\d+/\d+$')),
+        );
+        expect(formattedValue, findsOneWidget);
+      },
+      timeout: const Timeout(Duration(seconds: 15)),
+    );
+
     testWidgets(
       'AC: top bar shows hamburger menu and turn counter; empire buttons NOT in top bar (wide viewport)',
       (WidgetTester tester) async {
@@ -411,6 +438,9 @@ void main() {
             ref.onDispose(bus.dispose);
             return bus;
           }),
+          homeFleetCargoSummaryProvider.overrideWith(
+            (ref) => const HomeFleetCargoSummary(used: 0, capacity: 0),
+          ),
         ],
         child: AppEventHandlerScope(
           child: MaterialApp(
@@ -470,6 +500,9 @@ void main() {
                 ref.onDispose(bus.dispose);
                 return bus;
               }),
+              homeFleetCargoSummaryProvider.overrideWith(
+                (ref) => const HomeFleetCargoSummary(used: 0, capacity: 0),
+              ),
             ],
             child: AppEventHandlerScope(
               child: MaterialApp(

--- a/app/test/home_fleet_cargo_provider_test.dart
+++ b/app/test/home_fleet_cargo_provider_test.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/providers/game_service_provider.dart';
+import 'package:colonizethis_app/providers/games_box_provider.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_app/providers/home_fleet_cargo_provider.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+GameSetupConfig _tinyConfig() => GameSetupConfig(
+  selectedGreatPowerIds: ['england', 'france'],
+  continentCount: 1,
+  minorNationCount: 0,
+  tribeCount: 1,
+  numProvincesOldWorld: 4,
+  numProvincesNewWorld: 2,
+);
+
+void main() {
+  suppressLogsForTests();
+
+  late Directory dir;
+  late Box<dynamic> box;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp('ct_home_fleet_cargo_');
+    Hive.init(dir.path);
+    box = await Hive.openBox<dynamic>(HiveBoxNames.games);
+  });
+
+  tearDown(() async {
+    await box.close();
+    await Hive.close();
+    await dir.delete(recursive: true);
+  });
+
+  test(
+    'homeFleetCargoSummaryProvider matches extraction overseas sum and home fleet capacity',
+    () {
+      final container = ProviderContainer(
+        overrides: [gamesBoxProvider.overrideWith((ref) => box)],
+      );
+      addTearDown(container.dispose);
+
+      final service = container.read(gameServiceProvider);
+      final game = service.createNewGame(
+        id: 'cargo_summary',
+        config: _tinyConfig(),
+      );
+      container.read(currentGameProvider.notifier).setGame(game);
+
+      final summary = container.read(homeFleetCargoSummaryProvider);
+      final humanPlayer =
+          game.players.where((p) => p.isHuman).firstOrNull ??
+          game.players.first;
+      final mapData = service.getMapData(game.id)!;
+      final connectivity = resolveConnectivity(
+        game: game,
+        tileMapByRegion: mapData.tileMapByRegion,
+        topology: mapData.combinedTopology,
+      );
+      final extraction = computeExtraction(
+        game: game,
+        tileMapByRegion: mapData.tileMapByRegion,
+        connectivityResult: connectivity,
+        techCapForPlayer: (playerId) {
+          final player = game.playerById(playerId);
+          return extractionCapForUnlocked(player?.techUnlocked);
+        },
+      );
+      final expectedUsed =
+          extraction[humanPlayer.id]?.overseas.values.fold<int>(
+            0,
+            (sum, value) => sum + value,
+          ) ??
+          0;
+      final expectedCapacity = _homeFleetCapacity(game, humanPlayer.id);
+
+      expect(summary.used, expectedUsed);
+      expect(summary.capacity, expectedCapacity);
+    },
+  );
+
+  test('provider uses 0 used when map data is unavailable', () {
+    final container = ProviderContainer(
+      overrides: [gamesBoxProvider.overrideWith((ref) => box)],
+    );
+    addTearDown(container.dispose);
+
+    final service = container.read(gameServiceProvider);
+    final game = service.createNewGame(
+      id: 'cargo_no_map',
+      config: _tinyConfig(),
+    );
+    final gameWithoutCachedMap = game.copyWith(id: '${game.id}_missing_map');
+    container.read(currentGameProvider.notifier).setGame(gameWithoutCachedMap);
+
+    final summary = container.read(homeFleetCargoSummaryProvider);
+    final humanPlayer =
+        gameWithoutCachedMap.players.where((p) => p.isHuman).firstOrNull ??
+        gameWithoutCachedMap.players.first;
+    expect(summary.used, 0);
+    expect(
+      summary.capacity,
+      _homeFleetCapacity(gameWithoutCachedMap, humanPlayer.id),
+    );
+  });
+}
+
+int _homeFleetCapacity(Game game, String playerId) {
+  final homeFleetId = homeFleetIdFor(playerId);
+  final homeFleet = game.worldState.fleets
+      .where((f) => f.id == homeFleetId && f.ownerId == playerId)
+      .firstOrNull;
+  if (homeFleet == null) return 0;
+  var capacity = 0;
+  for (final typeId in homeFleet.shipTypeIds) {
+    capacity += NavalStatsCatalog.get(typeId).cargoHold;
+  }
+  return capacity;
+}


### PR DESCRIPTION
## Summary
- Add a global cargo hold indicator beside the Old World/New World toggles in the in-game shell, formatted as `used/capacity` with no spaces.
- Compute values via a dedicated provider: `used` = human player's total overseas extraction for current state; `capacity` = total cargo holds of ships in the human player's home fleet.
- Update UI spec and app tests; leave the icon slot intentionally empty for now and track asset follow-up in #1328.

## Test plan
- [x] `cd app && flutter test test/home_fleet_cargo_provider_test.dart test/game_screen_narrow_test.dart`
- [x] Validate cargo indicator AC in widget tests (presence + `^\\d+/\\d+$` format)
- [x] Validate provider computes overseas-used and home-fleet-capacity totals, including no-map-data fallback


Made with [Cursor](https://cursor.com)