### PR TITLE
refactor(riverpod): remove legacy API usage and modernize provider tests

### DIFF
--- a/app/lib/providers/games_provider.dart
+++ b/app/lib/providers/games_provider.dart
@@ -2,7 +2,6 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 
 import 'game_service_provider.dart';
 

--- a/app/lib/providers/map_province_panel_provider.dart
+++ b/app/lib/providers/map_province_panel_provider.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 
 /// Shared UI state between the region map and the province/sea detail panel.
 /// Map and panel stay decoupled: both read/write this provider only.
@@ -27,8 +26,9 @@ String? displayProvinceOrSeaIdFromTileKey(String? tileKey) {
   return '${parts[0]}|${parts[1]}';
 }
 
-class MapProvincePanelNotifier extends StateNotifier<MapProvincePanelUiState> {
-  MapProvincePanelNotifier() : super(const MapProvincePanelUiState());
+class MapProvincePanelNotifier extends Notifier<MapProvincePanelUiState> {
+  @override
+  MapProvincePanelUiState build() => const MapProvincePanelUiState();
 
   /// User tapped a map cell: select tile, open panel, keep secondary highlight as-is.
   void reportMapTileTapped(String tileKey) {
@@ -61,6 +61,6 @@ class MapProvincePanelNotifier extends StateNotifier<MapProvincePanelUiState> {
 }
 
 final mapProvincePanelProvider =
-    StateNotifierProvider<MapProvincePanelNotifier, MapProvincePanelUiState>(
-      (ref) => MapProvincePanelNotifier(),
+    NotifierProvider<MapProvincePanelNotifier, MapProvincePanelUiState>(
+      MapProvincePanelNotifier.new,
     );

--- a/app/lib/providers/offline_queue_provider.dart
+++ b/app/lib/providers/offline_queue_provider.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 
 /// Stub provider for offline action queue (multiplayer). Phase 0: MVP has no backend.
 class OfflineQueueNotifier extends Notifier<List<Object?>> {

--- a/app/lib/providers/settings_provider.dart
+++ b/app/lib/providers/settings_provider.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 
 /// Stub provider for user settings. Phase 0: no real state; Phase 1+ wires to Hive.
 class SettingsNotifier extends Notifier<Map<String, Object?>> {

--- a/app/test/game_map_narrow_detail_overlay_test.dart
+++ b/app/test/game_map_narrow_detail_overlay_test.dart
@@ -25,13 +25,6 @@ void main() {
 
     await tester.pumpWidget(
       ProviderScope(
-        overrides: [
-          mapProvincePanelProvider.overrideWith((ref) {
-            final n = MapProvincePanelNotifier();
-            n.reportMapTileTapped(sampleTileKeyForProvinceOverlay);
-            return n;
-          }),
-        ],
         child: MediaQuery(
           data: const MediaQueryData(size: Size(400, 600)),
           child: MaterialApp(
@@ -47,6 +40,11 @@ void main() {
         ),
       ),
     );
+    final ctx = tester.element(find.byType(GameMapNarrowDetailOverlaySlot));
+    final container = ProviderScope.containerOf(ctx);
+    container
+        .read(mapProvincePanelProvider.notifier)
+        .reportMapTileTapped(sampleTileKeyForProvinceOverlay);
     await tester.pumpAndSettle();
 
     expect(find.byType(GameMapNarrowDetailOverlaySlot), findsOneWidget);
@@ -56,8 +54,6 @@ void main() {
     await tester.tap(find.byKey(const Key('overlay_close')));
     await tester.pumpAndSettle();
 
-    final ctx = tester.element(find.byType(GameMapNarrowDetailOverlaySlot));
-    final container = ProviderScope.containerOf(ctx);
     expect(
       container.read(mapProvincePanelProvider).overlayOpen,
       isFalse,
@@ -77,13 +73,6 @@ void main() {
 
     await tester.pumpWidget(
       ProviderScope(
-        overrides: [
-          mapProvincePanelProvider.overrideWith((ref) {
-            final n = MapProvincePanelNotifier();
-            n.reportMapTileTapped(sampleTileKeyForProvinceOverlay);
-            return n;
-          }),
-        ],
         child: MediaQuery(
           data: const MediaQueryData(size: Size(400, viewportHeight)),
           child: MaterialApp(
@@ -99,7 +88,11 @@ void main() {
         ),
       ),
     );
-
+    final ctx = tester.element(find.byType(GameMapNarrowDetailOverlaySlot));
+    final container = ProviderScope.containerOf(ctx);
+    container
+        .read(mapProvincePanelProvider.notifier)
+        .reportMapTileTapped(sampleTileKeyForProvinceOverlay);
     await tester.pumpAndSettle();
 
     final constrained = find.byWidgetPredicate(

--- a/app/test/games_provider_test.dart
+++ b/app/test/games_provider_test.dart
@@ -1,10 +1,16 @@
+import 'dart:io';
+
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/core/services/game_service.dart';
 import 'package:colonizethis_app/providers/game_service_provider.dart';
-import 'package:colonizethis_app/providers/games_box_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_app/features/game/widgets/province_overlay_demo_data.dart'
+    show demoGameForOverlay;
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive/hive.dart';
@@ -15,6 +21,15 @@ void main() {
   setUpAll(() async {
     Hive.init('./.dart_tool/test_hive_games_provider');
     await Hive.openBox<dynamic>(HiveBoxNames.games);
+  });
+
+  tearDownAll(() async {
+    await Hive.box<dynamic>(HiveBoxNames.games).clear();
+    await Hive.close();
+    final dir = Directory('./.dart_tool/test_hive_games_provider');
+    if (dir.existsSync()) {
+      await dir.delete(recursive: true);
+    }
   });
 
   test('gameListIdsProvider returns empty list when no games saved', () async {
@@ -38,6 +53,32 @@ void main() {
     addTearDown(container.dispose);
 
     expect(container.read(devExclusiveReservedWorkTileKeysProvider), isEmpty);
+  });
+
+  test('derived providers compute with a real current game', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final gameService = container.read(gameServiceProvider);
+    expect(gameService, isA<GameService>());
+
+    final game = gameService.createNewGame(
+      id: 'games_provider_derived',
+      config: GameSetupConfig(
+        selectedGreatPowerIds: const ['england', 'france'],
+        continentCount: 1,
+        minorNationCount: 0,
+        tribeCount: 1,
+        numProvincesOldWorld: 4,
+        numProvincesNewWorld: 2,
+      ),
+    );
+    container.read(currentGameProvider.notifier).setGame(game);
+
+    final targets = container.read(availableWorkTargetsProvider);
+    final reserved = container.read(devExclusiveReservedWorkTileKeysProvider);
+    expect(targets, isA<Map<String, List<String>>>());
+    expect(reserved, isA<Set<String>>());
   });
 
   test('gameIdsWithIntroShownProvider defaults empty and can be updated', () {
@@ -65,6 +106,57 @@ void main() {
     final updated = container.read(pendingOverturesProvider);
     expect(updated, isNotNull);
     expect(updated, isEmpty);
+  });
+
+  test('currentGameProvider setGame and clear update the state', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final notifier = container.read(currentGameProvider.notifier);
+    expect(container.read(currentGameProvider), isNull);
+
+    notifier.setGame(demoGameForOverlay);
+    expect(container.read(currentGameProvider)?.id, demoGameForOverlay.id);
+
+    notifier.clear();
+    expect(container.read(currentGameProvider), isNull);
+  });
+
+  test('currentOrdersProvider replaceAll and clear update the state', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final notifier = container.read(currentOrdersProvider.notifier);
+    expect(container.read(currentOrdersProvider), const Orders());
+
+    const next = Orders(
+      buildUnitOrdersByPlayerId: {
+        'p1': [
+          BuildUnitOrder(
+            unitType: 'builder',
+            isMilitary: false,
+            spawnProvinceId: 'oldWorld|p1',
+          ),
+        ],
+      },
+    );
+    notifier.replaceAll(next);
+    expect(container.read(currentOrdersProvider), next);
+
+    notifier.clear();
+    expect(container.read(currentOrdersProvider), const Orders());
+  });
+
+  test('pendingOverturesProvider clear resets pending overtures to null', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final notifier = container.read(pendingOverturesProvider.notifier);
+    notifier.setPending(const []);
+    expect(container.read(pendingOverturesProvider), isNotNull);
+
+    notifier.clear();
+    expect(container.read(pendingOverturesProvider), isNull);
   });
 }
 

--- a/app/test/map_province_panel_provider_test.dart
+++ b/app/test/map_province_panel_provider_test.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_app/providers/map_province_panel_provider.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -7,30 +8,39 @@ void main() {
 
   group('MapProvincePanelNotifier', () {
     test('reportMapTileTapped opens overlay and sets selection', () {
-      final n = MapProvincePanelNotifier();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final n = container.read(mapProvincePanelProvider.notifier);
       const key = 'r1|p1|2|3';
       n.reportMapTileTapped(key);
-      expect(n.state.overlayOpen, isTrue);
-      expect(n.state.selectedTileKey, key);
+      final state = container.read(mapProvincePanelProvider);
+      expect(state.overlayOpen, isTrue);
+      expect(state.selectedTileKey, key);
     });
 
     test('closeOverlay keeps selectedTileKey', () {
-      final n = MapProvincePanelNotifier();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final n = container.read(mapProvincePanelProvider.notifier);
       const key = 'r1|p1|2|3';
       n.reportMapTileTapped(key);
       n.closeOverlay();
-      expect(n.state.overlayOpen, isFalse);
-      expect(n.state.selectedTileKey, key);
+      final state = container.read(mapProvincePanelProvider);
+      expect(state.overlayOpen, isFalse);
+      expect(state.selectedTileKey, key);
     });
 
     test('setSecondaryHighlight does not clear selection', () {
-      final n = MapProvincePanelNotifier();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final n = container.read(mapProvincePanelProvider.notifier);
       const key = 'r1|p1|2|3';
       const secondary = 'r1|p1|4|5';
       n.reportMapTileTapped(key);
       n.setSecondaryHighlight(secondary);
-      expect(n.state.selectedTileKey, key);
-      expect(n.state.secondaryHighlightTileKey, secondary);
+      final state = container.read(mapProvincePanelProvider);
+      expect(state.selectedTileKey, key);
+      expect(state.secondaryHighlightTileKey, secondary);
     });
 
     test('displayProvinceOrSeaIdFromTileKey strips to region|province', () {

--- a/app/test/settings_provider_test.dart
+++ b/app/test/settings_provider_test.dart
@@ -1,0 +1,26 @@
+import 'package:colonizethis_app/providers/settings_provider.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  test('settingsProvider replaceAll and setValue update settings map', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final notifier = container.read(settingsProvider.notifier);
+    expect(container.read(settingsProvider), isEmpty);
+
+    notifier.replaceAll(const {'musicVolume': 8});
+    expect(container.read(settingsProvider), const {'musicVolume': 8});
+
+    notifier.setValue('musicVolume', 10);
+    notifier.setValue('language', 'en');
+    expect(
+      container.read(settingsProvider),
+      const {'musicVolume': 10, 'language': 'en'},
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- remove remaining app-level legacy Riverpod usage by migrating `mapProvincePanelProvider` to `NotifierProvider` and deleting `legacy.dart` imports
- update provider/widget tests to follow Notifier initialization semantics and avoid invalid legacy override patterns
- add targeted provider tests to raise coverage and verify notifier behaviors/derived provider paths

## Test plan
- [x] `flutter test app/test/games_provider_test.dart app/test/settings_provider_test.dart app/test/map_province_panel_provider_test.dart app/test/offline_queue_provider_test.dart app/test/providers_smoke_test.dart --coverage`
- [x] `flutter analyze app/test/games_provider_test.dart app/test/settings_provider_test.dart`
- [x] confirm no matches for `flutter_riverpod/legacy.dart`, `riverpod/legacy.dart`, `StateNotifierProvider`, `extends StateNotifier`


Made with [Cursor](https://cursor.com)