### PR TITLE
fix(spec): align connectivity with town-agnostic behavior (#1313)

### DIFF
--- a/SPEC/game/capital-and-connectivity.md
+++ b/SPEC/game/capital-and-connectivity.md
@@ -58,9 +58,16 @@ A **port** is connected to the player's capital iff: **(1)** the capital is on t
 
 ## Connectivity (Game Rule)
 
-A tile T is **connected** to the capital for a player iff there is a path of road/rail/port from T to the **province's town** and from that town to the capital (existing rules). So: **(a)** T is adjacent to the capital tile, or **(b)** T is on or adjacent to a road/railroad tile that has a path to the **province's town**, and that town has a path to the capital tile. The graph is: tiles connected by shared edge; edges are road/railroad tiles or adjacency to the capital tile or the province town.
+Connectivity is a **tile-level graph rule** and does **not** depend on `townTileKey` location.
 
-**Town development level** (from Builder `upgrade_town` work) and **transport level** along the path limit extraction: effective yield = min(production, tech cap, **town development level**, **min transport level along path to town**, then to capital). If multiple paths exist (e.g. tile connected to two towns), the **maximum** transport level path determines the cap.
+A tile `T` is **connected** to the capital for a player iff there is a valid road/rail/port path from `T` to the capital under ownership and sea rules in this document:
+
+- **Same region / land path:** `T` must be reachable to the capital tile through shared-edge tile adjacency where traversal expands along road/rail/port-capable paths and only through the player's owned provinces.
+- **Different region / overseas:** `T` must have a road/rail path to an owned port in that province, and that port must be connected to the capital by sea topology/warp rules and blockade constraints.
+
+Town remains an extraction anchor for **town development level** only; it is not a connectivity gate.
+
+**Town development level** (from Builder `upgrade_town` work) and **transport level** along the selected capital path limit extraction: effective yield = min(production, tech cap, **town development level**, **path transport cap to capital**). If multiple valid paths exist, the **maximum** path transport cap is used.
 
 **Road level** on a tile is the same as **transport level** used for extraction (effective yield = min(production, transport level)); railroads are a higher road/transport level gated by tech (see [extraction-and-improvements.md](extraction-and-improvements.md), [tech-tree-transport.md](tech-tree-transport.md)).
 
@@ -164,13 +171,17 @@ This Great Power fall check runs **after** combat and capital reassignment, and 
   When the system evaluates whether `portC` is connected to the capital  
   Then `portC` is considered connected if and only if its sea zone is reachable from `S_cap` by a path that may cross warp-zone edges between regions and sea–sea edges within each region.
 
-- Given a tile `T` in a land province owned by a Great Power player and that province has a `townTileKey` with a valid path to the capital according to the connectivity rules  
+- Given a tile `T` in a land province owned by a Great Power player and a current world state with owned-territory roads/rails  
   When the system evaluates whether `T` is connected to the capital for extraction  
-  Then `T` is considered connected if and only if either `T` is the capital tile or directly edge-adjacent to the capital tile, or `T` lies on or is edge-adjacent to a road or rail tile that has a road or rail path to the province’s town tile, and the town tile has a path to the capital tile.
+  Then `T` is considered connected if and only if either `T` is the capital tile or directly edge-adjacent to the capital tile, or `T` lies on or is edge-adjacent to a road or rail tile that has a valid owned-territory path to the capital tile.
 
 - Given a tile `T_overseas` in an overseas province owned by a Great Power player, and that province has a port `P_over` that is road or rail connected to `T_overseas` and is itself connected to the capital by sea and land per the port-connection and sea-path rules  
   When the system evaluates whether `T_overseas` is connected to the capital for extraction  
   Then `T_overseas` is considered connected if and only if there exists a road or rail path from `T_overseas` to `P_over` and `P_over` is marked as connected to the capital.
+
+- Given a fixed game state where ownership, roads/rails, ports, sea topology, and blockade status are unchanged and only a province `townTileKey` value changes
+  When the system recomputes connectivity
+  Then the set of connected tiles and per-tile path transport caps remain unchanged for that player.
 
 - Given a connected tile `T_conn` with base production `P`, technology cap `TechCap`, a town development level `TownLvl` for its province’s town tile, and a set of transport levels along the chosen connectivity path with minimum value `MinTransport`  
   When the system computes the effective extracted yield for `T_conn`  

--- a/SPEC/game/extraction-and-improvements.md
+++ b/SPEC/game/extraction-and-improvements.md
@@ -17,7 +17,7 @@ Extraction and connectivity use **tile keys** (format `regionId|localId|x|y`) an
 Each land tile in an owned province may have one extraction improvement (mine, farm, ranch, plantation, fur post, town, etc.) with an improvement level (0–4) and at most one resource (terrain-constrained per [resource-terrain-region-rules.md](resource-terrain-region-rules.md)).
 
 **Production** = min(improvement level, owner's tech-allowed max level).
-**Effective yield** = min(production, transport level, **town development level**, **transport level along path to town and to capital**). See [capital-and-connectivity.md](capital-and-connectivity.md) for town and connectivity.
+**Effective yield** = min(production, transport level, **town development level**, **transport level along path to capital**). See [capital-and-connectivity.md](capital-and-connectivity.md) for connectivity.
 
 Tech caps first, then transport caps. Example: level 4 farm, tech cap 3, transport 2 → 2 units/turn. The improvement stays at level 4; tech/transport upgrades or conquest can unlock more later.
 
@@ -57,7 +57,7 @@ Acceptance criteria (naming only):
 
 ### Town and extraction
 
-Each province has one **town** tile assigned at game init (see [capital-and-connectivity.md](capital-and-connectivity.md) § Town per province). A tile's resources are extractable only if the tile is **connected to the province's town** (path of road/rail/port to the town) and the town is connected to the capital. **Town development level** (raised by Builder `upgrade_town` work) and the **transport level** along the path limit extraction. If multiple paths exist from a tile to the capital, the **maximum** transport level path determines the cap.
+Each province has one **town** tile assigned at game init (see [capital-and-connectivity.md](capital-and-connectivity.md) § Town per province). A tile's resources are extractable only if the tile is **connected to the capital** per connectivity rules. `townTileKey` is not a connectivity predicate. **Town development level** (raised by Builder `upgrade_town` work) and the **transport level** along valid capital paths limit extraction. If multiple paths exist from a tile to the capital, the **maximum** transport level path determines the cap.
 
 ### Mineral Prospecting Gate
 
@@ -144,9 +144,9 @@ Extractable commodities are exactly the same as in Imp2. See [commodity-catalog.
   When the system computes extraction for that tile
   Then the production equals min(N, owner's tech-allowed max level for that terrain/resource)
 
-- Given a land tile with improvement level N and transport level T in an owned province that is connected to a town with development level D
+- Given a land tile with improvement level N and transport level T in an owned province that is connected to the capital and has town development level D
   When the system computes effective yield for that tile
-  Then the effective yield equals min(N, T, D, transport level along path to town and capital)
+  Then the effective yield equals min(N, T, D, transport level along path to capital)
 
 - Given a player attempts to build a level 2 road (transport level 2) on a tile
   When the system validates the build_road work order
@@ -154,7 +154,7 @@ Extractable commodities are exactly the same as in Imp2. See [commodity-catalog.
 
 - Given a tile with a resource that requires prospecting (iron, copper, tin, coal, silver, gold, gems, or diamonds)
   When the system evaluates whether that resource can be extracted
-  Then the system requires both (a) the tile is connected to a town and (b) the player has prospected that tile
+  Then the system requires both (a) the tile is connected to the capital and (b) the player has prospected that tile
 
 - Given a player submits a build_improvement work order for a tile that has no resource (resource id missing or empty)
   When the order engine validates the work order
@@ -188,9 +188,13 @@ Extractable commodities are exactly the same as in Imp2. See [commodity-catalog.
   When the system computes transport level cap for that tile's extraction
   Then the system uses the maximum transport level among all valid paths
 
-- Given a province has a town on a port tile adjacent to a sea zone
+- Given an overseas province has an owned port tile adjacent to a sea zone and that sea zone has a valid path to the capital sea (subject to blockade)
   When the system evaluates connectivity for overseas extraction
-  Then that province is considered connected via sea transport using that port
+  Then that province is considered connected via sea transport using that port regardless of the province `townTileKey` location
+
+- Given a fixed game state where ownership, roads/rails, ports, sea topology, and blockade status are unchanged and only a province `townTileKey` value changes
+  When the system recomputes extraction connectivity
+  Then tile connectivity outcomes remain unchanged, and only town development level can affect extraction amounts
 
 - Given a tile's improvement level, transport level, or town development level changes
   When the next production phase runs

--- a/packages/colonizethis_logic/test/connectivity_resolver_test.dart
+++ b/packages/colonizethis_logic/test/connectivity_resolver_test.dart
@@ -385,5 +385,108 @@ void main() {
       result = resolveConnectivity(game: gameP2Restored, tileMapByRegion: tileMapByRegion, topology: topology);
       expect(result['pl1']!.connected.contains('oldWorld|p3|2|0'), true);
     });
+
+    test('changing townTileKey alone does not change connectivity', () {
+      const ow = 'oldWorld';
+      final grid = [
+        ['p1', 'p2', 'p2'],
+        ['p1', 'p2', 'p2'],
+      ];
+      final tileMap = TileMapResult(width: 3, height: 2, grid: grid);
+      final topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'p1', regionId: ow, type: TopologyNodeType.province),
+          TopologyNode(id: 'p2', regionId: ow, type: TopologyNodeType.province),
+        ],
+        edges: [],
+      );
+      final cap = CapitalTile(regionId: ow, provinceId: '$ow|p1', x: 0, y: 0);
+      final tileState = TileMapState()
+          .setRoadLevel('oldWorld|p1|0|0', 1)
+          .setRoadLevel('oldWorld|p2|1|0', 1)
+          .setRoadLevel('oldWorld|p2|2|0', 1)
+          .setRoadLevel('oldWorld|p2|2|1', 1);
+
+      final gameTownA = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+          oldWorld: RegionData(provinces: [
+            Province(
+              id: '$ow|p1',
+              regionId: ow,
+              ownerId: 'pl1',
+              townTileKey: 'oldWorld|p1|0|0',
+            ),
+            Province(
+              id: '$ow|p2',
+              regionId: ow,
+              ownerId: 'pl1',
+              townTileKey: 'oldWorld|p2|1|0',
+            ),
+          ]),
+          newWorld: const RegionData(),
+          tileState: tileState,
+        ),
+        players: [
+          Player(
+            id: 'pl1',
+            displayName: 'Spain',
+            isHuman: true,
+            capitalProvinceId: '$ow|p1',
+            capitalTile: cap,
+          ),
+        ],
+      );
+
+      final gameTownB = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+          oldWorld: RegionData(provinces: [
+            Province(
+              id: '$ow|p1',
+              regionId: ow,
+              ownerId: 'pl1',
+              townTileKey: 'oldWorld|p1|1|1',
+            ),
+            Province(
+              id: '$ow|p2',
+              regionId: ow,
+              ownerId: 'pl1',
+              townTileKey: 'oldWorld|p2|2|1',
+            ),
+          ]),
+          newWorld: const RegionData(),
+          tileState: tileState,
+        ),
+        players: [
+          Player(
+            id: 'pl1',
+            displayName: 'Spain',
+            isHuman: true,
+            capitalProvinceId: '$ow|p1',
+            capitalTile: cap,
+          ),
+        ],
+      );
+
+      final resultA = resolveConnectivity(
+        game: gameTownA,
+        tileMapByRegion: {'oldWorld': tileMap},
+        topology: topology,
+      );
+      final resultB = resolveConnectivity(
+        game: gameTownB,
+        tileMapByRegion: {'oldWorld': tileMap},
+        topology: topology,
+      );
+
+      expect(resultA['pl1']!.connected, equals(resultB['pl1']!.connected));
+      expect(
+        resultA['pl1']!.pathTransportCap,
+        equals(resultB['pl1']!.pathTransportCap),
+      );
+    });
   });
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -497,10 +497,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- update connectivity and extraction specs to define connectivity independent of `townTileKey`
- add acceptance criteria that `townTileKey` changes alone do not change connectivity outcomes
- add resolver test coverage proving `connected` and `pathTransportCap` are unchanged when only `townTileKey` changes

## Test plan
- [x] `dart test packages/colonizethis_logic/test/connectivity_resolver_test.dart`
- [x] `dart test packages/colonizethis_logic/test/connectivity_resolver_blockade_test.dart`

Made with [Cursor](https://cursor.com)