### PR TITLE
refactor(ui): extract reusable transfer list for naval split flow

### DIFF
--- a/SPEC/ui/naval-units-fleet-management.md
+++ b/SPEC/ui/naval-units-fleet-management.md
@@ -72,6 +72,26 @@ Each fleet row in the expanded state shows a **"Split Fleet"** button, including
 
 Clicking "Split Fleet" opens a modal dialog: **Split Fleet Dialog**.
 
+### Reusable Transfer Component
+
+Split Fleet uses a reusable app-level transfer component (`CtTransferList`) for
+dual-list quantity movement. The naval split dialog configures this component
+with fleet-specific labels and validation.
+
+`CtTransferList` API requirements:
+- Inputs: left/right titles, optional subtitles, initial counts for both sides
+- Transfer controls: one/all moves in both directions (`<`, `>`, `<<`, `>>`)
+- Selection model: one selected row key at a time
+- Validation hook: `canConfirm(leftCounts, rightCounts)`
+- Confirm callback: `onConfirm(leftCounts, rightCounts)`
+- Optional cancel callback and customizable action labels
+- Customizable item label and empty-state labels
+
+Naval-specific behavior remains outside the component:
+- Home-fleet split rule override
+- Fleet location labeling
+- Conversion from right-side counts to resulting `shipTypeIds`
+
 ### Layout
 
 ```

--- a/app/lib/features/game/widgets/split_fleet_dialog.dart
+++ b/app/lib/features/game/widgets/split_fleet_dialog.dart
@@ -2,16 +2,9 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
 import '../../../widgets/ct_dialog_shell.dart';
-import '../../../widgets/ct_nine_patch_button.dart';
-import '../../../widgets/ct_panel.dart';
+import '../../../widgets/ct_transfer_list.dart';
 
-class ShipTransfer {
-  ShipTransfer({required this.typeId, required this.count});
-  final String typeId;
-  final int count;
-}
-
-class SplitFleetDialog extends StatefulWidget {
+class SplitFleetDialog extends StatelessWidget {
   const SplitFleetDialog({
     super.key,
     required this.originalFleet,
@@ -27,48 +20,16 @@ class SplitFleetDialog extends StatefulWidget {
   final void Function(List<String> shipsToNewFleet) onConfirm;
   final bool isHomeFleet;
 
-  @override
-  State<SplitFleetDialog> createState() => _SplitFleetDialogState();
-}
-
-class _SplitFleetDialogState extends State<SplitFleetDialog> {
-  static const double _panelListHeight = 150;
-  late Map<String, int> _originalCounts;
-  late Map<String, int> _newCounts;
-  String? _selectedTypeId;
-
-  @override
-  void initState() {
-    super.initState();
-    _initializeCounts();
-  }
-
-  void _initializeCounts() {
-    _originalCounts = {};
-    _newCounts = {};
-    _selectedTypeId = null;
-    for (final typeId in widget.originalFleet.shipTypeIds) {
-      _originalCounts[typeId] = (_originalCounts[typeId] ?? 0) + 1;
+  Map<String, int> _initialOriginalCounts() {
+    final counts = <String, int>{};
+    for (final typeId in originalFleet.shipTypeIds) {
+      counts[typeId] = (counts[typeId] ?? 0) + 1;
     }
-  }
-
-  int get _totalOriginal {
-    return _originalCounts.values.fold(0, (sum, count) => sum + count);
-  }
-
-  int get _totalNew {
-    return _newCounts.values.fold(0, (sum, count) => sum + count);
-  }
-
-  bool get _canConfirm {
-    if (widget.isHomeFleet) {
-      return _totalNew > 0;
-    }
-    return _totalOriginal >= 1 && _totalNew > 0;
+    return counts;
   }
 
   String _fleetLocationLabel() {
-    final fleet = widget.originalFleet;
+    final fleet = originalFleet;
     if (fleet.isAtSea) {
       final seaZoneId = fleet.seaZoneId!;
       final localId = seaZoneId.contains('|')
@@ -78,11 +39,11 @@ class _SplitFleetDialogState extends State<SplitFleetDialog> {
     } else if (fleet.isInPort) {
       final inPortId = fleet.inPortAtProvinceId!;
       final provinceMap = <String, Province>{};
-      for (final p in widget.game.worldState.oldWorld.provinces) {
+      for (final p in game.worldState.oldWorld.provinces) {
         provinceMap[p.id] = p;
         provinceMap['${p.regionId}|${p.id}'] = p;
       }
-      for (final p in widget.game.worldState.newWorld.provinces) {
+      for (final p in game.worldState.newWorld.provinces) {
         provinceMap[p.id] = p;
         provinceMap['${p.regionId}|${p.id}'] = p;
       }
@@ -95,279 +56,66 @@ class _SplitFleetDialogState extends State<SplitFleetDialog> {
     return 'Unknown';
   }
 
-  void _moveToNew(String typeId) {
-    setState(() {
-      final count = _originalCounts[typeId] ?? 0;
-      if (count > 0) {
-        _originalCounts[typeId] = count - 1;
-        _newCounts[typeId] = (_newCounts[typeId] ?? 0) + 1;
-        _cleanupZeros();
-      }
-    });
-  }
-
-  void _moveToOriginal(String typeId) {
-    setState(() {
-      final count = _newCounts[typeId] ?? 0;
-      if (count > 0) {
-        _newCounts[typeId] = count - 1;
-        _originalCounts[typeId] = (_originalCounts[typeId] ?? 0) + 1;
-        _cleanupZeros();
-      }
-    });
-  }
-
-  void _moveAllToNew(String typeId) {
-    setState(() {
-      final count = _originalCounts[typeId] ?? 0;
-      if (count > 0) {
-        _newCounts[typeId] = (_newCounts[typeId] ?? 0) + count;
-        _originalCounts.remove(typeId);
-      }
-    });
-  }
-
-  void _moveAllToOriginal(String typeId) {
-    setState(() {
-      final count = _newCounts[typeId] ?? 0;
-      if (count > 0) {
-        _originalCounts[typeId] = (_originalCounts[typeId] ?? 0) + count;
-        _newCounts.remove(typeId);
-      }
-    });
-  }
-
-  void _cleanupZeros() {
-    _originalCounts.removeWhere((_, v) => v == 0);
-    _newCounts.removeWhere((_, v) => v == 0);
-    final selected = _selectedTypeId;
-    if (selected != null &&
-        !_originalCounts.containsKey(selected) &&
-        !_newCounts.containsKey(selected)) {
-      _selectedTypeId = null;
-    }
-  }
-
-  void _toggleSelection(String typeId) {
-    setState(() {
-      _selectedTypeId = _selectedTypeId == typeId ? null : typeId;
-    });
-  }
-
-  void _moveSelectedToOriginal() {
-    final selected = _selectedTypeId;
-    if (selected == null) return;
-    _moveToOriginal(selected);
-  }
-
-  void _moveSelectedToNew() {
-    final selected = _selectedTypeId;
-    if (selected == null) return;
-    _moveToNew(selected);
-  }
-
-  void _moveAllSelectedToOriginal() {
-    final selected = _selectedTypeId;
-    if (selected == null) return;
-    _moveAllToOriginal(selected);
-  }
-
-  void _moveAllSelectedToNew() {
-    final selected = _selectedTypeId;
-    if (selected == null) return;
-    _moveAllToNew(selected);
-  }
-
-  void _handleConfirm() {
-    if (!_canConfirm) return;
+  void _handleConfirm(Map<String, int> newCounts, BuildContext context) {
     final shipsToNewFleet = <String>[];
-    for (final entry in _newCounts.entries) {
+    for (final entry in newCounts.entries) {
       for (var i = 0; i < entry.value; i++) {
         shipsToNewFleet.add(entry.key);
       }
     }
-    widget.onConfirm(shipsToNewFleet);
+    onConfirm(shipsToNewFleet);
     Navigator.of(context).pop();
   }
 
   @override
   Widget build(BuildContext context) {
-    final selected = _selectedTypeId;
-    final selectedInOriginal = selected == null ? 0 : (_originalCounts[selected] ?? 0);
-    final selectedInNew = selected == null ? 0 : (_newCounts[selected] ?? 0);
-
     return CtDialogShell(
       maxWidth: 520,
       maxHeight: 500,
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Text('Split Fleet', style: Theme.of(context).textTheme.titleLarge),
-            const SizedBox(height: 16),
-            Row(
-              children: [
-                Expanded(
-                  child: _FleetPanel(
-                    title: widget.originalFleet.id == 'home_fleet'
-                        ? 'Home Fleet'
-                        : 'Fleet ${widget.originalFleet.id}',
-                    location: _fleetLocationLabel(),
-                    counts: _originalCounts,
-                    total: _totalOriginal,
-                    listHeight: _panelListHeight,
-                    selectedTypeId: _selectedTypeId,
-                    onSelectType: _toggleSelection,
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: _FleetPanel(
-                    title: 'New Fleet',
-                    location: _fleetLocationLabel(),
-                    counts: _newCounts,
-                    total: _totalNew,
-                    listHeight: _panelListHeight,
-                    selectedTypeId: _selectedTypeId,
-                    onSelectType: _toggleSelection,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 16),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                CtNinePatchButton(
-                  onPressed: _moveAllSelectedToOriginal,
-                  enabled: selected != null && selectedInNew > 0,
-                  child: const Text('<<'),
-                ),
-                const SizedBox(width: 8),
-                CtNinePatchButton(
-                  onPressed: _moveSelectedToOriginal,
-                  enabled: selected != null && selectedInNew > 0,
-                  child: const Text('<'),
-                ),
-                const SizedBox(width: 16),
-                CtNinePatchButton(
-                  onPressed: _moveSelectedToNew,
-                  enabled: selected != null && selectedInOriginal > 0,
-                  child: const Text('>'),
-                ),
-                const SizedBox(width: 8),
-                CtNinePatchButton(
-                  onPressed: _moveAllSelectedToNew,
-                  enabled: selected != null && selectedInOriginal > 0,
-                  child: const Text('>>'),
-                ),
-              ],
-            ),
-            const SizedBox(height: 16),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                CtNinePatchButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: const Text('Cancel'),
-                ),
-                const SizedBox(width: 8),
-                CtNinePatchButton(
-                  onPressed: _handleConfirm,
-                  enabled: _canConfirm,
-                  child: const Text('Confirm Split'),
-                ),
-              ],
-            ),
-          ],
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Split Fleet',
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              const SizedBox(height: 16),
+              CtTransferList(
+                leftTitle: originalFleet.id == 'home_fleet'
+                    ? 'Home Fleet'
+                    : 'Fleet ${originalFleet.id}',
+                rightTitle: 'New Fleet',
+                leftSubtitle: _fleetLocationLabel(),
+                rightSubtitle: _fleetLocationLabel(),
+                initialLeftCounts: _initialOriginalCounts(),
+                leftEmptyLabel: 'No ships',
+                rightEmptyLabel: 'No ships',
+                confirmLabel: 'Confirm Split',
+                totalLabelBuilder: (total) => 'Total: $total ships',
+                canConfirm: (left, right) {
+                  final leftTotal = left.values.fold(
+                    0,
+                    (sum, count) => sum + count,
+                  );
+                  final rightTotal = right.values.fold(
+                    0,
+                    (sum, count) => sum + count,
+                  );
+                  if (isHomeFleet) {
+                    return rightTotal > 0;
+                  }
+                  return leftTotal >= 1 && rightTotal > 0;
+                },
+                onCancel: () => Navigator.of(context).pop(),
+                onConfirm: (_, right) => _handleConfirm(right, context),
+              ),
+            ],
+          ),
         ),
-      ),
-    );
-  }
-}
-
-class _FleetPanel extends StatelessWidget {
-  const _FleetPanel({
-    required this.title,
-    required this.location,
-    required this.counts,
-    required this.total,
-    required this.listHeight,
-    required this.selectedTypeId,
-    required this.onSelectType,
-  });
-
-  final String title;
-  final String location;
-  final Map<String, int> counts;
-  final int total;
-  final double listHeight;
-  final String? selectedTypeId;
-  final void Function(String typeId) onSelectType;
-
-  @override
-  Widget build(BuildContext context) {
-    final sortedTypes = counts.keys.toList()..sort();
-
-    return CtPanel(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(title, style: Theme.of(context).textTheme.titleSmall),
-          Text(location, style: Theme.of(context).textTheme.bodySmall),
-          const SizedBox(height: 8),
-          const Divider(height: 1),
-          const SizedBox(height: 8),
-          SizedBox(
-            height: listHeight,
-            child: sortedTypes.isEmpty
-                ? Center(
-                    child: Text(
-                      'No ships',
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                  )
-                : ListView.builder(
-                    itemCount: sortedTypes.length,
-                    itemBuilder: (context, index) {
-                      final typeId = sortedTypes[index];
-                      final count = counts[typeId] ?? 0;
-                      final isSelected = selectedTypeId == typeId;
-                      return Padding(
-                        padding: const EdgeInsets.symmetric(vertical: 2),
-                        child: Material(
-                          color: isSelected
-                              ? Theme.of(context).colorScheme.primaryContainer
-                              : Colors.transparent,
-                          child: InkWell(
-                            onTap: () => onSelectType(typeId),
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 8,
-                                vertical: 6,
-                              ),
-                              child: Text('$typeId ($count)'),
-                            ),
-                          ),
-                        ),
-                      );
-                    },
-                  ),
-          ),
-          const SizedBox(height: 8),
-          const Divider(height: 1),
-          const SizedBox(height: 4),
-          Text(
-            'Total: $total ships',
-            style: Theme.of(context).textTheme.bodySmall,
-          ),
-        ],
       ),
     );
   }

--- a/app/lib/widgetbook/catalog.dart
+++ b/app/lib/widgetbook/catalog.dart
@@ -28,6 +28,7 @@ import '../widgets/game_setup.dart';
 import '../widgets/main_menu.dart';
 import '../widgets/ct_nine_patch_button.dart';
 import '../widgets/ct_region_map.dart';
+import '../widgets/ct_transfer_list.dart';
 
 /// Invoked from `lib/widgetbook.dart` [main]; safe to call from tests after binding init.
 void bootstrapWidgetbook() {
@@ -53,6 +54,7 @@ class CtWidgetbookApp extends StatelessWidget {
     return Widgetbook.material(
       directories: [
         ...buttonDirectories,
+        ...transferListDirectories,
         ...mainMenuDirectories,
         ...gameSetupDirectories,
         ...mapWidgetDirectories,
@@ -106,6 +108,51 @@ List<WidgetbookNode> get buttonDirectories => [
                   ),
                 ),
               ],
+            ),
+          ),
+        ),
+      ),
+    ],
+  ),
+];
+
+/// Transfer list stories for reusable quantity transfer behavior.
+List<WidgetbookNode> get transferListDirectories => [
+  WidgetbookFolder(
+    name: 'Transfer List',
+    children: [
+      WidgetbookUseCase(
+        name: 'Default',
+        builder: (context) => Theme(
+          data: AppThemes.colonial,
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: SizedBox(
+              width: 560,
+              child: CtTransferList(
+                leftTitle: 'Original Fleet',
+                rightTitle: 'New Fleet',
+                leftSubtitle: 'Old World - Lisbon',
+                rightSubtitle: 'Old World - Lisbon',
+                initialLeftCounts: const {'carrack': 2, 'fluyte': 1},
+                leftEmptyLabel: 'No ships',
+                rightEmptyLabel: 'No ships',
+                totalLabelBuilder: (total) => 'Total: $total ships',
+                confirmLabel: 'Confirm Split',
+                canConfirm: (left, right) {
+                  final leftTotal = left.values.fold(
+                    0,
+                    (sum, count) => sum + count,
+                  );
+                  final rightTotal = right.values.fold(
+                    0,
+                    (sum, count) => sum + count,
+                  );
+                  return leftTotal >= 1 && rightTotal > 0;
+                },
+                onCancel: () {},
+                onConfirm: (_, __) {},
+              ),
             ),
           ),
         ),

--- a/app/lib/widgets/ct_transfer_list.dart
+++ b/app/lib/widgets/ct_transfer_list.dart
@@ -1,0 +1,362 @@
+import 'package:flutter/material.dart';
+
+import 'ct_nine_patch_button.dart';
+import 'ct_panel.dart';
+
+/// Generic dual-list transfer widget for moving counted items between two sides.
+///
+/// Use this component when a feature needs transferable quantities with:
+/// - one selected item at a time
+/// - single-item and move-all controls
+/// - configurable validation before confirm
+/// - customizable labels and item rendering
+class CtTransferList extends StatefulWidget {
+  const CtTransferList({
+    super.key,
+    required this.leftTitle,
+    required this.rightTitle,
+    required this.initialLeftCounts,
+    required this.onConfirm,
+    this.leftSubtitle,
+    this.rightSubtitle,
+    this.initialRightCounts = const {},
+    this.itemLabelBuilder,
+    this.canConfirm,
+    this.onChanged,
+    this.onCancel,
+    this.leftEmptyLabel = 'No items',
+    this.rightEmptyLabel = 'No items',
+    this.moveAllToLeftLabel = '<<',
+    this.moveOneToLeftLabel = '<',
+    this.moveOneToRightLabel = '>',
+    this.moveAllToRightLabel = '>>',
+    this.cancelLabel = 'Cancel',
+    this.confirmLabel = 'Confirm',
+    this.listHeight = 150,
+    this.totalLabelBuilder,
+  });
+
+  final String leftTitle;
+  final String rightTitle;
+  final String? leftSubtitle;
+  final String? rightSubtitle;
+  final Map<String, int> initialLeftCounts;
+  final Map<String, int> initialRightCounts;
+  final String Function(String itemId)? itemLabelBuilder;
+  final bool Function(Map<String, int> left, Map<String, int> right)?
+  canConfirm;
+  final void Function(Map<String, int> left, Map<String, int> right)? onChanged;
+  final void Function(Map<String, int> left, Map<String, int> right) onConfirm;
+  final VoidCallback? onCancel;
+  final String leftEmptyLabel;
+  final String rightEmptyLabel;
+  final String moveAllToLeftLabel;
+  final String moveOneToLeftLabel;
+  final String moveOneToRightLabel;
+  final String moveAllToRightLabel;
+  final String cancelLabel;
+  final String confirmLabel;
+  final double listHeight;
+  final String Function(int total)? totalLabelBuilder;
+
+  @override
+  State<CtTransferList> createState() => _CtTransferListState();
+}
+
+class _CtTransferListState extends State<CtTransferList> {
+  late Map<String, int> _leftCounts;
+  late Map<String, int> _rightCounts;
+  String? _selectedItemId;
+
+  int get _leftTotal => _leftCounts.values.fold(0, (sum, count) => sum + count);
+  int get _rightTotal =>
+      _rightCounts.values.fold(0, (sum, count) => sum + count);
+
+  bool get _canConfirm {
+    final validate = widget.canConfirm;
+    if (validate == null) {
+      return _rightTotal > 0;
+    }
+    return validate(_leftCounts, _rightCounts);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _leftCounts = Map<String, int>.from(widget.initialLeftCounts);
+    _rightCounts = Map<String, int>.from(widget.initialRightCounts);
+  }
+
+  String _itemLabel(String itemId) {
+    final builder = widget.itemLabelBuilder;
+    if (builder == null) return itemId;
+    return builder(itemId);
+  }
+
+  void _notifyChanged() {
+    widget.onChanged?.call(_leftCounts, _rightCounts);
+  }
+
+  void _cleanupZerosAndSelection() {
+    _leftCounts.removeWhere((_, v) => v <= 0);
+    _rightCounts.removeWhere((_, v) => v <= 0);
+    final selected = _selectedItemId;
+    if (selected == null) return;
+    if (!_leftCounts.containsKey(selected) &&
+        !_rightCounts.containsKey(selected)) {
+      _selectedItemId = null;
+    }
+  }
+
+  void _moveOneToRight(String itemId) {
+    final from = _leftCounts[itemId] ?? 0;
+    if (from <= 0) return;
+    setState(() {
+      _leftCounts[itemId] = from - 1;
+      _rightCounts[itemId] = (_rightCounts[itemId] ?? 0) + 1;
+      _cleanupZerosAndSelection();
+    });
+    _notifyChanged();
+  }
+
+  void _moveOneToLeft(String itemId) {
+    final from = _rightCounts[itemId] ?? 0;
+    if (from <= 0) return;
+    setState(() {
+      _rightCounts[itemId] = from - 1;
+      _leftCounts[itemId] = (_leftCounts[itemId] ?? 0) + 1;
+      _cleanupZerosAndSelection();
+    });
+    _notifyChanged();
+  }
+
+  void _moveAllToRight(String itemId) {
+    final from = _leftCounts[itemId] ?? 0;
+    if (from <= 0) return;
+    setState(() {
+      _rightCounts[itemId] = (_rightCounts[itemId] ?? 0) + from;
+      _leftCounts.remove(itemId);
+      _cleanupZerosAndSelection();
+    });
+    _notifyChanged();
+  }
+
+  void _moveAllToLeft(String itemId) {
+    final from = _rightCounts[itemId] ?? 0;
+    if (from <= 0) return;
+    setState(() {
+      _leftCounts[itemId] = (_leftCounts[itemId] ?? 0) + from;
+      _rightCounts.remove(itemId);
+      _cleanupZerosAndSelection();
+    });
+    _notifyChanged();
+  }
+
+  void _toggleSelection(String itemId) {
+    setState(() {
+      _selectedItemId = _selectedItemId == itemId ? null : itemId;
+    });
+  }
+
+  void _handleConfirm() {
+    if (!_canConfirm) return;
+    widget.onConfirm(
+      Map<String, int>.from(_leftCounts),
+      Map<String, int>.from(_rightCounts),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = _selectedItemId;
+    final selectedLeft = selected == null ? 0 : (_leftCounts[selected] ?? 0);
+    final selectedRight = selected == null ? 0 : (_rightCounts[selected] ?? 0);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: _TransferSidePanel(
+                title: widget.leftTitle,
+                subtitle: widget.leftSubtitle,
+                counts: _leftCounts,
+                total: _leftTotal,
+                listHeight: widget.listHeight,
+                selectedItemId: _selectedItemId,
+                emptyLabel: widget.leftEmptyLabel,
+                itemLabelBuilder: _itemLabel,
+                onSelectItem: _toggleSelection,
+                totalLabelBuilder: widget.totalLabelBuilder,
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: _TransferSidePanel(
+                title: widget.rightTitle,
+                subtitle: widget.rightSubtitle,
+                counts: _rightCounts,
+                total: _rightTotal,
+                listHeight: widget.listHeight,
+                selectedItemId: _selectedItemId,
+                emptyLabel: widget.rightEmptyLabel,
+                itemLabelBuilder: _itemLabel,
+                onSelectItem: _toggleSelection,
+                totalLabelBuilder: widget.totalLabelBuilder,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            CtNinePatchButton(
+              onPressed: selected == null
+                  ? null
+                  : () => _moveAllToLeft(selected),
+              enabled: selected != null && selectedRight > 0,
+              child: Text(widget.moveAllToLeftLabel),
+            ),
+            const SizedBox(width: 8),
+            CtNinePatchButton(
+              onPressed: selected == null
+                  ? null
+                  : () => _moveOneToLeft(selected),
+              enabled: selected != null && selectedRight > 0,
+              child: Text(widget.moveOneToLeftLabel),
+            ),
+            const SizedBox(width: 16),
+            CtNinePatchButton(
+              onPressed: selected == null
+                  ? null
+                  : () => _moveOneToRight(selected),
+              enabled: selected != null && selectedLeft > 0,
+              child: Text(widget.moveOneToRightLabel),
+            ),
+            const SizedBox(width: 8),
+            CtNinePatchButton(
+              onPressed: selected == null
+                  ? null
+                  : () => _moveAllToRight(selected),
+              enabled: selected != null && selectedLeft > 0,
+              child: Text(widget.moveAllToRightLabel),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            if (widget.onCancel != null) ...[
+              CtNinePatchButton(
+                onPressed: widget.onCancel,
+                child: Text(widget.cancelLabel),
+              ),
+              const SizedBox(width: 8),
+            ],
+            CtNinePatchButton(
+              onPressed: _handleConfirm,
+              enabled: _canConfirm,
+              child: Text(widget.confirmLabel),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _TransferSidePanel extends StatelessWidget {
+  const _TransferSidePanel({
+    required this.title,
+    required this.counts,
+    required this.total,
+    required this.listHeight,
+    required this.selectedItemId,
+    required this.emptyLabel,
+    required this.itemLabelBuilder,
+    required this.onSelectItem,
+    required this.totalLabelBuilder,
+    this.subtitle,
+  });
+
+  final String title;
+  final String? subtitle;
+  final Map<String, int> counts;
+  final int total;
+  final double listHeight;
+  final String? selectedItemId;
+  final String emptyLabel;
+  final String Function(String itemId) itemLabelBuilder;
+  final void Function(String itemId) onSelectItem;
+  final String Function(int total)? totalLabelBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    final sortedTypes = counts.keys.toList()..sort();
+    return CtPanel(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(title, style: Theme.of(context).textTheme.titleSmall),
+          if (subtitle != null)
+            Text(subtitle!, style: Theme.of(context).textTheme.bodySmall),
+          const SizedBox(height: 8),
+          const Divider(height: 1),
+          const SizedBox(height: 8),
+          SizedBox(
+            height: listHeight,
+            child: sortedTypes.isEmpty
+                ? Center(
+                    child: Text(
+                      emptyLabel,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  )
+                : ListView.builder(
+                    itemCount: sortedTypes.length,
+                    itemBuilder: (context, index) {
+                      final typeId = sortedTypes[index];
+                      final count = counts[typeId] ?? 0;
+                      final isSelected = selectedItemId == typeId;
+                      return Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 2),
+                        child: Material(
+                          color: isSelected
+                              ? Theme.of(context).colorScheme.primaryContainer
+                              : Colors.transparent,
+                          child: InkWell(
+                            onTap: () => onSelectItem(typeId),
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 6,
+                              ),
+                              child: Text(
+                                '${itemLabelBuilder(typeId)} ($count)',
+                              ),
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+          ),
+          const SizedBox(height: 8),
+          const Divider(height: 1),
+          const SizedBox(height: 4),
+          Text(
+            totalLabelBuilder?.call(total) ?? 'Total: $total items',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/test/widgets/ct_transfer_list_test.dart
+++ b/app/test/widgets/ct_transfer_list_test.dart
@@ -1,0 +1,127 @@
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  Future<void> pumpTransferList(
+    WidgetTester tester, {
+    required void Function(Map<String, int> left, Map<String, int> right)
+    onConfirm,
+    bool Function(Map<String, int> left, Map<String, int> right)? canConfirm,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CtTransferList(
+            leftTitle: 'Original',
+            rightTitle: 'New',
+            initialLeftCounts: const {'carrack': 2, 'fluyte': 1},
+            onConfirm: onConfirm,
+            canConfirm: canConfirm,
+            confirmLabel: 'Confirm Split',
+            leftEmptyLabel: 'No ships',
+            rightEmptyLabel: 'No ships',
+            totalLabelBuilder: (total) => 'Total: $total ships',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  bool buttonEnabled(WidgetTester tester, String label) {
+    final button = tester.widget<CtNinePatchButton>(
+      find.widgetWithText(CtNinePatchButton, label),
+    );
+    return button.enabled;
+  }
+
+  testWidgets('transfer controls disabled until an item is selected', (
+    WidgetTester tester,
+  ) async {
+    await pumpTransferList(tester, onConfirm: (_, __) {});
+
+    expect(buttonEnabled(tester, '<'), isFalse);
+    expect(buttonEnabled(tester, '>'), isFalse);
+    expect(buttonEnabled(tester, '<<'), isFalse);
+    expect(buttonEnabled(tester, '>>'), isFalse);
+  });
+
+  testWidgets('selected item supports one and all transfers', (
+    WidgetTester tester,
+  ) async {
+    await pumpTransferList(tester, onConfirm: (_, __) {});
+
+    await tester.tap(find.text('carrack (2)').first);
+    await tester.pump();
+
+    await tester.tap(find.widgetWithText(CtNinePatchButton, '>'));
+    await tester.pump();
+    expect(find.text('carrack (1)'), findsNWidgets(2));
+
+    await tester.tap(find.widgetWithText(CtNinePatchButton, '>>'));
+    await tester.pump();
+    expect(find.text('carrack (2)'), findsOneWidget);
+    expect(find.text('carrack (1)'), findsNothing);
+
+    await tester.tap(find.widgetWithText(CtNinePatchButton, '<'));
+    await tester.pump();
+    expect(find.text('carrack (1)'), findsNWidgets(2));
+  });
+
+  testWidgets('confirm enablement follows validation callback', (
+    WidgetTester tester,
+  ) async {
+    await pumpTransferList(
+      tester,
+      onConfirm: (_, __) {},
+      canConfirm: (left, right) {
+        final leftTotal = left.values.fold(0, (sum, value) => sum + value);
+        final rightTotal = right.values.fold(0, (sum, value) => sum + value);
+        return leftTotal >= 1 && rightTotal > 0;
+      },
+    );
+
+    expect(buttonEnabled(tester, 'Confirm Split'), isFalse);
+
+    await tester.tap(find.text('fluyte (1)'));
+    await tester.pump();
+    await tester.tap(find.widgetWithText(CtNinePatchButton, '>>'));
+    await tester.pump();
+
+    expect(buttonEnabled(tester, 'Confirm Split'), isTrue);
+  });
+
+  testWidgets('confirm returns current left and right counts', (
+    WidgetTester tester,
+  ) async {
+    Map<String, int>? confirmedLeft;
+    Map<String, int>? confirmedRight;
+
+    await pumpTransferList(
+      tester,
+      onConfirm: (left, right) {
+        confirmedLeft = left;
+        confirmedRight = right;
+      },
+    );
+
+    await tester.tap(find.text('carrack (2)').first);
+    await tester.pump();
+    await tester.tap(find.widgetWithText(CtNinePatchButton, '>'));
+    await tester.pump();
+
+    await tester.tap(find.text('Confirm Split'));
+    await tester.pumpAndSettle();
+
+    expect(confirmedLeft, isNotNull);
+    expect(confirmedRight, isNotNull);
+    expect(confirmedLeft!['carrack'], 1);
+    expect(confirmedRight!['carrack'], 1);
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -497,10 +497,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- add a reusable `CtTransferList` dual-list quantity transfer widget in the app UI layer with extension points for labels, validation, and confirm behavior
- migrate `SplitFleetDialog` to use `CtTransferList` while preserving naval split constraints and output semantics (home-fleet rule, ship movement, resulting payload)
- add widget coverage for the generic transfer widget and update spec/widgetbook references to document and showcase the reusable component

## Test plan
- [x] `cd app && flutter test test/naval_units_panel_test.dart test/split_fleet_dialog_test.dart test/widgets/ct_transfer_list_test.dart`
- [x] verify split dialog supports `<`, `>`, `<<`, `>>` transfer semantics and preserves home/non-home confirm rules
- [x] verify naval panel split flow still emits `NavalFleetsUpdatedEvent`


Made with [Cursor](https://cursor.com)