### PR TITLE
refactor(ui): consolidate diplomacy order label and mutation helpers (#1351)

### DIFF
--- a/app/lib/features/game/widgets/diplomacy_order_helpers.dart
+++ b/app/lib/features/game/widgets/diplomacy_order_helpers.dart
@@ -1,0 +1,72 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Shared short label for diplomacy action buttons and confirmation prompts.
+String diplomacyActionLabel(DiplomaticOrder order) {
+  switch (order.type) {
+    case DiplomaticOrderType.declareWar:
+      return 'Declare War';
+    case DiplomaticOrderType.offerPeace:
+      return 'Offer Peace';
+    case DiplomaticOrderType.alliance:
+      return 'Alliance';
+    case DiplomaticOrderType.establishOverture:
+      return order.overtureStage != null
+          ? diplomacyOvertureStageShortLabel(order.overtureStage!)
+          : 'Overture';
+    case DiplomaticOrderType.grantAid:
+      return order.amount != null
+          ? 'Grant Aid (£${order.amount})'
+          : 'Grant Aid';
+    case DiplomaticOrderType.setSubsidy:
+      return order.amount != null
+          ? 'Subsidy (£${order.amount})'
+          : 'Set Subsidy';
+  }
+}
+
+/// Compact overture stage name used in diplomacy action labels.
+String diplomacyOvertureStageShortLabel(OvertureStage stage) {
+  return switch (stage) {
+    OvertureStage.none => 'Overture',
+    OvertureStage.tradeConsulate => 'Consulate',
+    OvertureStage.embassy => 'Embassy',
+    OvertureStage.nap => 'NAP',
+    OvertureStage.joinEmpire => 'Join Empire',
+  };
+}
+
+extension DiplomacyOrderMutations on Orders {
+  Orders appendDiplomaticOrderForPlayer(
+    String playerId,
+    DiplomaticOrder order,
+  ) {
+    final list = List<DiplomaticOrder>.from(
+      diplomaticOrdersByPlayerId[playerId] ?? const <DiplomaticOrder>[],
+    )..add(order);
+    return copyWith(
+      diplomaticOrdersByPlayerId: {
+        ...diplomaticOrdersByPlayerId,
+        playerId: list,
+      },
+    );
+  }
+
+  Orders removeDiplomaticOrderForPlayer(
+    String playerId, {
+    required DiplomaticOrderType type,
+    required String targetFactionId,
+  }) {
+    final list =
+        List<DiplomaticOrder>.from(
+          diplomaticOrdersByPlayerId[playerId] ?? const <DiplomaticOrder>[],
+        )..removeWhere(
+          (o) => o.type == type && o.targetFactionId == targetFactionId,
+        );
+    return copyWith(
+      diplomaticOrdersByPlayerId: {
+        ...diplomaticOrdersByPlayerId,
+        playerId: list,
+      },
+    );
+  }
+}

--- a/app/lib/features/game/widgets/diplomacy_panel.dart
+++ b/app/lib/features/game/widgets/diplomacy_panel.dart
@@ -9,6 +9,7 @@ import '../../../config/routes.dart';
 import '../../../core/services/app_event_handler_scope.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/ct_panel.dart';
+import 'diplomacy_order_helpers.dart';
 
 /// Faction type for display. SPEC/game/factions.md.
 enum FactionKind { greatPower, minor, tribe }
@@ -272,37 +273,8 @@ class DiplomacyPanel extends StatelessWidget {
     }
   }
 
-  String _actionLabel(DiplomaticOrder o) {
-    switch (o.type) {
-      case DiplomaticOrderType.declareWar:
-        return 'Declare War';
-      case DiplomaticOrderType.offerPeace:
-        return 'Offer Peace';
-      case DiplomaticOrderType.alliance:
-        return 'Alliance';
-      case DiplomaticOrderType.establishOverture:
-        return o.overtureStage != null
-            ? _overtureStageShort(o.overtureStage!)
-            : 'Overture';
-      case DiplomaticOrderType.grantAid:
-        return o.amount != null ? 'Grant Aid (£${o.amount})' : 'Grant Aid';
-      case DiplomaticOrderType.setSubsidy:
-        return o.amount != null ? 'Subsidy (£${o.amount})' : 'Set Subsidy';
-    }
-  }
-
-  String _overtureStageShort(OvertureStage s) {
-    return switch (s) {
-      OvertureStage.none => 'Overture',
-      OvertureStage.tradeConsulate => 'Consulate',
-      OvertureStage.embassy => 'Embassy',
-      OvertureStage.nap => 'NAP',
-      OvertureStage.joinEmpire => 'Join Empire',
-    };
-  }
-
   void _showConfirmDialog(BuildContext context, DiplomaticOrder order) {
-    final actionLabel = _actionLabel(order);
+    final actionLabel = diplomacyActionLabel(order);
     bus.emit(
       ConfirmDialogEvent(
         title: actionLabel,
@@ -345,18 +317,11 @@ class DiplomacyPanel extends StatelessWidget {
   }
 
   void _removeOrder(DiplomaticOrderType type, String targetFactionId) {
-    final list =
-        List<DiplomaticOrder>.from(
-          currentOrders.diplomaticOrdersByPlayerId[humanPlayerId] ?? [],
-        )..removeWhere(
-          (o) => o.type == type && o.targetFactionId == targetFactionId,
-        );
     onOrdersChanged(
-      currentOrders.copyWith(
-        diplomaticOrdersByPlayerId: {
-          ...currentOrders.diplomaticOrdersByPlayerId,
-          humanPlayerId: list,
-        },
+      currentOrders.removeDiplomaticOrderForPlayer(
+        humanPlayerId,
+        type: type,
+        targetFactionId: targetFactionId,
       ),
     );
   }
@@ -375,16 +340,8 @@ class DiplomacyPanel extends StatelessWidget {
   }
 
   void _appendOrder(DiplomaticOrder order) {
-    final list = List<DiplomaticOrder>.from(
-      currentOrders.diplomaticOrdersByPlayerId[humanPlayerId] ?? [],
-    )..add(order);
     onOrdersChanged(
-      currentOrders.copyWith(
-        diplomaticOrdersByPlayerId: {
-          ...currentOrders.diplomaticOrdersByPlayerId,
-          humanPlayerId: list,
-        },
-      ),
+      currentOrders.appendDiplomaticOrderForPlayer(humanPlayerId, order),
     );
   }
 }
@@ -540,7 +497,7 @@ class _ActionButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final label = isPending ? 'Cancel' : _actionLabel(order);
+    final label = isPending ? 'Cancel' : diplomacyActionLabel(order);
     return SizedBox(
       height: 32,
       child: CtNinePatchButton(
@@ -549,34 +506,5 @@ class _ActionButton extends StatelessWidget {
         child: Text(label, style: const TextStyle(fontSize: 12)),
       ),
     );
-  }
-
-  String _actionLabel(DiplomaticOrder o) {
-    switch (o.type) {
-      case DiplomaticOrderType.declareWar:
-        return 'Declare War';
-      case DiplomaticOrderType.offerPeace:
-        return 'Offer Peace';
-      case DiplomaticOrderType.alliance:
-        return 'Alliance';
-      case DiplomaticOrderType.establishOverture:
-        return o.overtureStage != null
-            ? _overtureStageShort(o.overtureStage!)
-            : 'Overture';
-      case DiplomaticOrderType.grantAid:
-        return o.amount != null ? 'Grant Aid (£${o.amount})' : 'Grant Aid';
-      case DiplomaticOrderType.setSubsidy:
-        return o.amount != null ? 'Subsidy (£${o.amount})' : 'Set Subsidy';
-    }
-  }
-
-  String _overtureStageShort(OvertureStage s) {
-    return switch (s) {
-      OvertureStage.none => 'Overture',
-      OvertureStage.tradeConsulate => 'Consulate',
-      OvertureStage.embassy => 'Embassy',
-      OvertureStage.nap => 'NAP',
-      OvertureStage.joinEmpire => 'Join Empire',
-    };
   }
 }

--- a/app/lib/features/game/widgets/diplomacy_screen.dart
+++ b/app/lib/features/game/widgets/diplomacy_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../providers/app_event_bus_provider.dart';
 import '../../../widgets/ct_game_feature_screen_shell.dart';
+import 'diplomacy_order_helpers.dart';
 import 'diplomacy_panel.dart';
 import 'grant_or_subsidy_listener.dart';
 
@@ -37,15 +38,10 @@ class DiplomacyScreen extends ConsumerWidget {
           bus: bus,
           game: displayGame,
           onConfirmed: (order) {
-            final list = List<DiplomaticOrder>.from(
-              currentOrders.diplomaticOrdersByPlayerId[humanPlayerId] ?? [],
-            )..add(order);
             onOrdersChanged(
-              currentOrders.copyWith(
-                diplomaticOrdersByPlayerId: {
-                  ...currentOrders.diplomaticOrdersByPlayerId,
-                  humanPlayerId: list,
-                },
+              currentOrders.appendDiplomaticOrderForPlayer(
+                humanPlayerId,
+                order,
               ),
             );
           },

--- a/app/test/diplomacy_order_helpers_test.dart
+++ b/app/test/diplomacy_order_helpers_test.dart
@@ -1,0 +1,149 @@
+import 'package:colonizethis_app/features/game/widgets/diplomacy_order_helpers.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  group('diplomacyActionLabel', () {
+    test('formats non-parameter actions', () {
+      expect(
+        diplomacyActionLabel(
+          const DiplomaticOrder(
+            type: DiplomaticOrderType.declareWar,
+            targetFactionId: 'gp2',
+          ),
+        ),
+        'Declare War',
+      );
+      expect(
+        diplomacyActionLabel(
+          const DiplomaticOrder(
+            type: DiplomaticOrderType.offerPeace,
+            targetFactionId: 'gp2',
+          ),
+        ),
+        'Offer Peace',
+      );
+      expect(
+        diplomacyActionLabel(
+          const DiplomaticOrder(
+            type: DiplomaticOrderType.alliance,
+            targetFactionId: 'gp2',
+          ),
+        ),
+        'Alliance',
+      );
+    });
+
+    test('formats overture and amount actions', () {
+      expect(
+        diplomacyActionLabel(
+          const DiplomaticOrder(
+            type: DiplomaticOrderType.establishOverture,
+            targetFactionId: 'mn1',
+            overtureStage: OvertureStage.embassy,
+          ),
+        ),
+        'Embassy',
+      );
+      expect(
+        diplomacyActionLabel(
+          const DiplomaticOrder(
+            type: DiplomaticOrderType.grantAid,
+            targetFactionId: 'mn1',
+            amount: 1000,
+          ),
+        ),
+        'Grant Aid (£1000)',
+      );
+      expect(
+        diplomacyActionLabel(
+          const DiplomaticOrder(
+            type: DiplomaticOrderType.setSubsidy,
+            targetFactionId: 'mn1',
+            amount: 500,
+          ),
+        ),
+        'Subsidy (£500)',
+      );
+    });
+  });
+
+  group('DiplomacyOrderMutations', () {
+    test(
+      'appendDiplomaticOrderForPlayer appends and preserves other players',
+      () {
+        const existing = DiplomaticOrder(
+          type: DiplomaticOrderType.offerPeace,
+          targetFactionId: 'gp2',
+        );
+        const appended = DiplomaticOrder(
+          type: DiplomaticOrderType.declareWar,
+          targetFactionId: 'gp3',
+        );
+        const otherPlayerOrder = DiplomaticOrder(
+          type: DiplomaticOrderType.alliance,
+          targetFactionId: 'gp1',
+        );
+        final start = Orders(
+          diplomaticOrdersByPlayerId: {
+            'gp1': const [existing],
+            'gp2': const [otherPlayerOrder],
+          },
+        );
+
+        final updated = start.appendDiplomaticOrderForPlayer('gp1', appended);
+
+        expect(updated.diplomaticOrdersByPlayerId['gp1'], const [
+          existing,
+          appended,
+        ]);
+        expect(updated.diplomaticOrdersByPlayerId['gp2'], const [
+          otherPlayerOrder,
+        ]);
+        expect(start.diplomaticOrdersByPlayerId['gp1'], const [existing]);
+      },
+    );
+
+    test(
+      'removeDiplomaticOrderForPlayer removes only matching type and target',
+      () {
+        const keep = DiplomaticOrder(
+          type: DiplomaticOrderType.declareWar,
+          targetFactionId: 'gp2',
+        );
+        const remove = DiplomaticOrder(
+          type: DiplomaticOrderType.offerPeace,
+          targetFactionId: 'gp3',
+        );
+        const otherTarget = DiplomaticOrder(
+          type: DiplomaticOrderType.offerPeace,
+          targetFactionId: 'gp4',
+        );
+        final start = Orders(
+          diplomaticOrdersByPlayerId: {
+            'gp1': const [keep, remove, otherTarget],
+          },
+        );
+
+        final updated = start.removeDiplomaticOrderForPlayer(
+          'gp1',
+          type: DiplomaticOrderType.offerPeace,
+          targetFactionId: 'gp3',
+        );
+
+        expect(updated.diplomaticOrdersByPlayerId['gp1'], const [
+          keep,
+          otherTarget,
+        ]);
+        expect(start.diplomaticOrdersByPlayerId['gp1'], const [
+          keep,
+          remove,
+          otherTarget,
+        ]);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- extract shared diplomacy action label helpers into `diplomacy_order_helpers.dart` and use them from panel action buttons and confirm dialogs
- extract shared per-player diplomatic order mutation helpers (`append`/`remove`) on `Orders` and replace duplicated map-copy logic in `diplomacy_panel.dart` and `diplomacy_screen.dart`
- add focused tests in `diplomacy_order_helpers_test.dart` covering label formatting and order mutation behavior

## Test plan
- [x] `flutter test app/test/diplomacy_order_helpers_test.dart`
- [ ] `flutter test app/test/diplomacy_panel_test.dart` *(currently blocked by unrelated existing l10n compile errors in `new_game_leader_selection_dialog.dart` and `game_map_area.dart`)*
- [ ] `flutter test app/test/diplomacy_panel_orders_test.dart` *(currently blocked by the same unrelated l10n compile errors)*

Made with [Cursor](https://cursor.com)