### PR TITLE
refactor(ui): share train dialog order/count orchestration

### DIFF
--- a/SPEC/program/app-ui-wiring.md
+++ b/SPEC/program/app-ui-wiring.md
@@ -58,6 +58,8 @@ Register builders in **`app/lib/core/services/app_event_handler_scope.dart`**.
 | `grant_or_subsidy` | `GrantOrSubsidyDialog` | `grantOrSubsidyDialogId` |
 | `new_game_leader_selection` | `NewGameLeaderSelectionDialog` (six slots: **nation** + **leader** per slot; nation picker shows default GP map colour swatch beside each nation name; fair GP Old World assignment checkbox; initial nations = `GameSetupConfig.defaultConfig.selectedGreatPowerIds`) | `newGameLeaderSelectionDialogId` |
 
+For `train_civilians` and `train_military`, shared order/count orchestration must be implemented in `app/lib/features/game/widgets/train_unit_dialog_helper.dart`; keep dialog-specific economics and lock rules inside each dialog widget.
+
 | ID | Widget | Status |
 |----|--------|--------|
 | `quick_battle_result` | `QuickBattleResultDialog` | planned (or local if combat UI stays internal) |
@@ -143,3 +145,4 @@ Feature-specific behavior (tabs, panel listeners, orders callbacks, local dialog
 ### Automated tests (widget / integration)
 
 - Widget tests for `GameScreen`, `GameSideMenu`, and `TrainCiviliansDialog` / `CivilianUnitsPanel` cover pause menu, empire panels, and Train-via-bus behavior.
+- Train dialog helper tests in `app/test/train_unit_dialog_helper_test.dart` cover shared count initialization, order materialization, and shared stepper count mutation helpers used by both train dialogs.

--- a/SPEC/ui/train-civilians-dialog.md
+++ b/SPEC/ui/train-civilians-dialog.md
@@ -122,6 +122,16 @@ On dialog `didPop` / `Navigator.of(context).pop()`:
 
 **Note:** The dialog does NOT validate that capital is set — this is enforced by the logic package at game setup and turn resolution.
 
+### Shared helper requirement
+
+To keep civilian and military train-dialog orchestration aligned, the UI layer must use the shared helper at `app/lib/features/game/widgets/train_unit_dialog_helper.dart` for:
+
+- initializing counts from current orders at capital (`initialTrainDialogCountsFromOrders`)
+- materializing `List<BuildUnitOrder>` from counts (`materializeTrainDialogOrdersFromCounts`)
+- count mutation patterns for stepper interactions (`incrementTrainDialogCount`, `decrementTrainDialogCount`, `resetTrainDialogCounts`)
+
+Dialog-specific affordability and tech-lock logic remains local to each dialog.
+
 ---
 
 ## Tech Unlock Display
@@ -195,6 +205,8 @@ pixellab_create_map_object(
 
 - **Given** the Train Civilians dialog is open, **when** the user has queued training orders and closes the dialog, **then** those orders are persisted in the current turn's orders.
 
+- **Given** both train dialogs use shared orchestration behavior, **when** developers update train order/count conversion rules, **then** the UI layer updates `train_unit_dialog_helper.dart` and validates behavior with helper tests in `app/test/train_unit_dialog_helper_test.dart`.
+
 - **Given** the Train Civilians dialog is open, **when** the user has no capital set, **then** the UI shows an error message "No capital set — cannot train units" and all steppers are disabled.
 
 - **Given** the Train Civilians dialog is open, **when** the player has insufficient resources for any unit, **then** the deficit hint shows "Treasury low", "Paper low", or both.
@@ -217,5 +229,6 @@ pixellab_create_map_object(
 - The dialog is a **StatefulWidget** to hold stepper counts locally during the session.
 - Stepper counts are NOT persisted until dialog close.
 - The dialog receives `Game`, `humanPlayerId`, `currentOrders`, and an `onOrdersChanged(BuildUnitOrder[])` callback.
+- Shared order/count orchestration is implemented in `train_unit_dialog_helper.dart`; dialog code keeps only civilian-specific affordability/lock behavior.
 - All resource calculations are derived client-side from `Player` data — no server validation needed in UI.
 - Capital tile spawn: `BuildUnitOrder.spawnProvinceId = Player.capitalProvinceId` — the logic package handles resolution.

--- a/SPEC/ui/train-military-dialog.md
+++ b/SPEC/ui/train-military-dialog.md
@@ -82,6 +82,16 @@ On dialog close (`didPop` / close button), create orders from current counts:
 
 If no capital exists, UI shows `No capital set — cannot train units`, steppers are disabled, and no orders are created.
 
+### Shared helper requirement
+
+To keep military and civilian train-dialog orchestration aligned, the UI layer must use the shared helper at `app/lib/features/game/widgets/train_unit_dialog_helper.dart` for:
+
+- initializing counts from current orders at capital (`initialTrainDialogCountsFromOrders`)
+- materializing `List<BuildUnitOrder>` from counts (`materializeTrainDialogOrdersFromCounts`)
+- count mutation patterns for stepper interactions (`incrementTrainDialogCount`, `decrementTrainDialogCount`, `resetTrainDialogCounts`)
+
+Dialog-specific affordability and tech-lock logic remains local to each dialog.
+
 ---
 
 ## Integration
@@ -106,3 +116,5 @@ If no capital exists, UI shows `No capital set — cannot train units`, steppers
 - **Given** the Train Military dialog opens with existing pending military train orders for the player's capital, **when** the dialog renders, **then** the steppers pre-populate with those existing counts.
 
 - **Given** the Train Military dialog is open and the user closes it, **when** there are non-zero selected counts, **then** the UI layer writes `BuildUnitOrder` entries with `isMilitary == true` and `spawnProvinceId == Player.capitalProvinceId`, replacing only dialog-managed military orders and leaving all other build orders unchanged.
+
+- **Given** both train dialogs use shared orchestration behavior, **when** developers update train order/count conversion rules, **then** the UI layer updates `train_unit_dialog_helper.dart` and validates behavior with helper tests in `app/test/train_unit_dialog_helper_test.dart`.

--- a/app/lib/features/game/widgets/train_civilians_dialog.dart
+++ b/app/lib/features/game/widgets/train_civilians_dialog.dart
@@ -8,6 +8,7 @@ import '../../../config/app_assets.dart';
 import '../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/strict_asset_icon.dart';
+import 'train_unit_dialog_helper.dart';
 
 class TrainCiviliansDialog extends StatefulWidget {
   const TrainCiviliansDialog({
@@ -38,20 +39,13 @@ class _TrainCiviliansDialogState extends State<TrainCiviliansDialog> {
 
   /// Counts pending train-at-capital civilian builds from [widget.currentOrders].
   Map<String, int> _initialCountsFromOrders() {
-    final next = {for (final e in CivilianEconomyCatalog.all) e.id: 0};
-    final capital = _player?.capitalProvinceId;
-    if (capital == null) return next;
-    final civilianIds = CivilianEconomyCatalog.byId.keys.toSet();
-    final list =
-        widget.currentOrders.buildUnitOrdersByPlayerId[widget.humanPlayerId] ??
-        const <BuildUnitOrder>[];
-    for (final o in list) {
-      if (o.isMilitary) continue;
-      if (!civilianIds.contains(o.unitType)) continue;
-      if (o.spawnProvinceId != capital) continue;
-      next[o.unitType] = (next[o.unitType] ?? 0) + 1;
-    }
-    return next;
+    return initialTrainDialogCountsFromOrders(
+      unitTypeIds: CivilianEconomyCatalog.byId.keys,
+      currentOrders: widget.currentOrders,
+      humanPlayerId: widget.humanPlayerId,
+      capitalProvinceId: _player?.capitalProvinceId,
+      isMilitary: false,
+    );
   }
 
   Player? get _player {
@@ -115,41 +109,32 @@ class _TrainCiviliansDialogState extends State<TrainCiviliansDialog> {
     if (_isLocked(unitType)) return;
     if (!_canAffordIncrement(unitType)) return;
     setState(() {
-      _counts[unitType] = (_counts[unitType] ?? 0) + 1;
+      _counts = incrementTrainDialogCount(_counts, unitType);
     });
   }
 
   void _decrement(String unitType) {
     if (_counts[unitType] == null || _counts[unitType]! <= 0) return;
     setState(() {
-      _counts[unitType] = _counts[unitType]! - 1;
+      _counts = decrementTrainDialogCount(_counts, unitType);
     });
   }
 
   void _reset() {
     setState(() {
-      for (final e in CivilianEconomyCatalog.all) {
-        _counts[e.id] = 0;
-      }
+      _counts = resetTrainDialogCounts(_counts);
     });
   }
 
   void _applyOrders() {
-    final orders = <BuildUnitOrder>[];
     final capital = _player?.capitalProvinceId;
     if (capital == null) return;
-    for (final e in CivilianEconomyCatalog.all) {
-      final count = _counts[e.id] ?? 0;
-      for (var i = 0; i < count; i++) {
-        orders.add(
-          BuildUnitOrder(
-            unitType: e.id,
-            isMilitary: false,
-            spawnProvinceId: capital,
-          ),
-        );
-      }
-    }
+    final orders = materializeTrainDialogOrdersFromCounts(
+      orderedUnitTypeIds: CivilianEconomyCatalog.byId.keys,
+      counts: _counts,
+      capitalProvinceId: capital,
+      isMilitary: false,
+    );
     widget.onOrdersChanged(orders);
   }
 

--- a/app/lib/features/game/widgets/train_military_dialog.dart
+++ b/app/lib/features/game/widgets/train_military_dialog.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import '../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/resource_icon.dart';
+import 'train_unit_dialog_helper.dart';
 
 class TrainMilitaryDialog extends StatefulWidget {
   const TrainMilitaryDialog({
@@ -34,20 +35,13 @@ class _TrainMilitaryDialogState extends State<TrainMilitaryDialog> {
   }
 
   Map<String, int> _initialCountsFromOrders() {
-    final next = {for (final e in RegimentEconomyCatalog.all) e.id: 0};
-    final capital = _player?.capitalProvinceId;
-    if (capital == null) return next;
-    final regimentIds = RegimentEconomyCatalog.byId.keys.toSet();
-    final list =
-        widget.currentOrders.buildUnitOrdersByPlayerId[widget.humanPlayerId] ??
-        const <BuildUnitOrder>[];
-    for (final o in list) {
-      if (!o.isMilitary) continue;
-      if (!regimentIds.contains(o.unitType)) continue;
-      if (o.spawnProvinceId != capital) continue;
-      next[o.unitType] = (next[o.unitType] ?? 0) + 1;
-    }
-    return next;
+    return initialTrainDialogCountsFromOrders(
+      unitTypeIds: RegimentEconomyCatalog.byId.keys,
+      currentOrders: widget.currentOrders,
+      humanPlayerId: widget.humanPlayerId,
+      capitalProvinceId: _player?.capitalProvinceId,
+      isMilitary: true,
+    );
   }
 
   Player? get _player {
@@ -144,41 +138,32 @@ class _TrainMilitaryDialogState extends State<TrainMilitaryDialog> {
   void _increment(String unitType) {
     if (!_canAffordIncrement(unitType)) return;
     setState(() {
-      _counts[unitType] = (_counts[unitType] ?? 0) + 1;
+      _counts = incrementTrainDialogCount(_counts, unitType);
     });
   }
 
   void _decrement(String unitType) {
     if ((_counts[unitType] ?? 0) <= 0) return;
     setState(() {
-      _counts[unitType] = (_counts[unitType] ?? 0) - 1;
+      _counts = decrementTrainDialogCount(_counts, unitType);
     });
   }
 
   void _reset() {
     setState(() {
-      for (final e in RegimentEconomyCatalog.all) {
-        _counts[e.id] = 0;
-      }
+      _counts = resetTrainDialogCounts(_counts);
     });
   }
 
   void _applyOrders() {
-    final orders = <BuildUnitOrder>[];
     final capital = _player?.capitalProvinceId;
     if (capital == null) return;
-    for (final e in RegimentEconomyCatalog.all) {
-      final count = _counts[e.id] ?? 0;
-      for (var i = 0; i < count; i++) {
-        orders.add(
-          BuildUnitOrder(
-            unitType: e.id,
-            isMilitary: true,
-            spawnProvinceId: capital,
-          ),
-        );
-      }
-    }
+    final orders = materializeTrainDialogOrdersFromCounts(
+      orderedUnitTypeIds: RegimentEconomyCatalog.byId.keys,
+      counts: _counts,
+      capitalProvinceId: capital,
+      isMilitary: true,
+    );
     widget.onOrdersChanged(orders);
   }
 

--- a/app/lib/features/game/widgets/train_unit_dialog_helper.dart
+++ b/app/lib/features/game/widgets/train_unit_dialog_helper.dart
@@ -1,0 +1,64 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Shared train-dialog helper for order/count orchestration.
+///
+/// Used by both `TrainCiviliansDialog` and `TrainMilitaryDialog` to keep
+/// count initialization and order materialization logic consistent.
+Map<String, int> initialTrainDialogCountsFromOrders({
+  required Iterable<String> unitTypeIds,
+  required Orders currentOrders,
+  required String humanPlayerId,
+  required String? capitalProvinceId,
+  required bool isMilitary,
+}) {
+  final next = {for (final id in unitTypeIds) id: 0};
+  if (capitalProvinceId == null) return next;
+  final allowedUnitTypes = unitTypeIds.toSet();
+  final list =
+      currentOrders.buildUnitOrdersByPlayerId[humanPlayerId] ??
+      const <BuildUnitOrder>[];
+  for (final order in list) {
+    if (order.isMilitary != isMilitary) continue;
+    if (!allowedUnitTypes.contains(order.unitType)) continue;
+    if (order.spawnProvinceId != capitalProvinceId) continue;
+    next[order.unitType] = (next[order.unitType] ?? 0) + 1;
+  }
+  return next;
+}
+
+List<BuildUnitOrder> materializeTrainDialogOrdersFromCounts({
+  required Iterable<String> orderedUnitTypeIds,
+  required Map<String, int> counts,
+  required String? capitalProvinceId,
+  required bool isMilitary,
+}) {
+  if (capitalProvinceId == null) return const <BuildUnitOrder>[];
+  final orders = <BuildUnitOrder>[];
+  for (final unitType in orderedUnitTypeIds) {
+    final count = counts[unitType] ?? 0;
+    for (var i = 0; i < count; i++) {
+      orders.add(
+        BuildUnitOrder(
+          unitType: unitType,
+          isMilitary: isMilitary,
+          spawnProvinceId: capitalProvinceId,
+        ),
+      );
+    }
+  }
+  return orders;
+}
+
+Map<String, int> incrementTrainDialogCount(Map<String, int> counts, String id) {
+  return {...counts, id: (counts[id] ?? 0) + 1};
+}
+
+Map<String, int> decrementTrainDialogCount(Map<String, int> counts, String id) {
+  final current = counts[id] ?? 0;
+  if (current <= 0) return counts;
+  return {...counts, id: current - 1};
+}
+
+Map<String, int> resetTrainDialogCounts(Map<String, int> counts) {
+  return {for (final id in counts.keys) id: 0};
+}

--- a/app/test/train_unit_dialog_helper_test.dart
+++ b/app/test/train_unit_dialog_helper_test.dart
@@ -1,8 +1,11 @@
 import 'package:colonizethis_app/features/game/widgets/train_unit_dialog_helper.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  suppressLogsForTests();
+
   group('initialTrainDialogCountsFromOrders', () {
     test('counts only managed train-at-capital military orders', () {
       const playerId = 'p1';

--- a/app/test/train_unit_dialog_helper_test.dart
+++ b/app/test/train_unit_dialog_helper_test.dart
@@ -1,0 +1,104 @@
+import 'package:colonizethis_app/features/game/widgets/train_unit_dialog_helper.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('initialTrainDialogCountsFromOrders', () {
+    test('counts only managed train-at-capital military orders', () {
+      const playerId = 'p1';
+      const capital = 'r1|cap';
+      final counts = initialTrainDialogCountsFromOrders(
+        unitTypeIds: const ['Infantry', 'Cavalry'],
+        currentOrders: const Orders(
+          buildUnitOrdersByPlayerId: {
+            playerId: [
+              BuildUnitOrder(
+                unitType: 'Infantry',
+                isMilitary: true,
+                spawnProvinceId: capital,
+              ),
+              BuildUnitOrder(
+                unitType: 'Infantry',
+                isMilitary: true,
+                spawnProvinceId: capital,
+              ),
+              BuildUnitOrder(
+                unitType: 'Infantry',
+                isMilitary: true,
+                spawnProvinceId: 'r2|elsewhere',
+              ),
+              BuildUnitOrder(
+                unitType: 'Builder',
+                isMilitary: false,
+                spawnProvinceId: capital,
+              ),
+            ],
+          },
+        ),
+        humanPlayerId: playerId,
+        capitalProvinceId: capital,
+        isMilitary: true,
+      );
+
+      expect(counts['Infantry'], 2);
+      expect(counts['Cavalry'], 0);
+      expect(counts.containsKey('Builder'), isFalse);
+    });
+
+    test('returns zeroed map when capital is missing', () {
+      final counts = initialTrainDialogCountsFromOrders(
+        unitTypeIds: const ['Builder', 'Explorer'],
+        currentOrders: const Orders(),
+        humanPlayerId: 'p1',
+        capitalProvinceId: null,
+        isMilitary: false,
+      );
+
+      expect(counts, equals(const {'Builder': 0, 'Explorer': 0}));
+    });
+  });
+
+  group('materializeTrainDialogOrdersFromCounts', () {
+    test('creates train orders with expected type, flag, and capital', () {
+      final orders = materializeTrainDialogOrdersFromCounts(
+        orderedUnitTypeIds: const ['Builder', 'Explorer'],
+        counts: const {'Builder': 2, 'Explorer': 1},
+        capitalProvinceId: 'r1|cap',
+        isMilitary: false,
+      );
+
+      expect(orders.length, 3);
+      expect(orders.where((o) => o.unitType == 'Builder').length, 2);
+      expect(orders.where((o) => o.unitType == 'Explorer').length, 1);
+      expect(orders.every((o) => o.isMilitary == false), isTrue);
+      expect(orders.every((o) => o.spawnProvinceId == 'r1|cap'), isTrue);
+    });
+
+    test('returns empty when capital is missing', () {
+      final orders = materializeTrainDialogOrdersFromCounts(
+        orderedUnitTypeIds: const ['Infantry'],
+        counts: const {'Infantry': 3},
+        capitalProvinceId: null,
+        isMilitary: true,
+      );
+
+      expect(orders, isEmpty);
+    });
+  });
+
+  group('count mutation helpers', () {
+    test('increment/decrement/reset helpers are consistent', () {
+      final initial = <String, int>{'Builder': 1, 'Explorer': 0};
+      final incremented = incrementTrainDialogCount(initial, 'Builder');
+      final decremented = decrementTrainDialogCount(incremented, 'Builder');
+      final unchanged = decrementTrainDialogCount(decremented, 'Explorer');
+      final reset = resetTrainDialogCounts(unchanged);
+
+      expect(initial['Builder'], 1, reason: 'helpers should be immutable');
+      expect(incremented['Builder'], 2);
+      expect(decremented['Builder'], 1);
+      expect(unchanged['Explorer'], 0);
+      expect(reset, equals(const {'Builder': 0, 'Explorer': 0}));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- extract a lightweight shared helper for train dialog count initialization, order materialization, and common stepper mutations
- refactor `TrainCiviliansDialog` and `TrainMilitaryDialog` to use the shared helper while keeping economics/lock logic local
- document the shared-helper requirement in SPEC and add dedicated helper tests

## Test plan
- [x] `flutter test app/test/train_unit_dialog_helper_test.dart`
- [ ] `flutter test app/test/train_civilians_dialog_test.dart` *(currently blocked by unrelated pre-existing localization compile errors in app shell/game files)*
- [ ] `flutter test app/test/train_military_dialog_test.dart` *(currently blocked by unrelated pre-existing localization compile errors in app shell/game files)*

Made with [Cursor](https://cursor.com)