### PR TITLE
refactor(ui): shared units panel shell and section headers (#1346)

### DIFF
--- a/app/lib/features/game/widgets/civilian_units_panel.dart
+++ b/app/lib/features/game/widgets/civilian_units_panel.dart
@@ -8,7 +8,9 @@ import 'package:flutter/material.dart';
 
 import '../../../core/services/app_event_handler_scope.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
-import '../../../widgets/ct_panel.dart';
+import 'units/shared/region_section_header.dart';
+import 'units/shared/units_panel_region_label.dart';
+import 'units/shared/units_panel_shell.dart';
 
 /// Human-readable label for work target ids. SPEC/ui/civilian-units-panel.md.
 const Map<String, String> _workTargetLabels = {
@@ -24,18 +26,6 @@ const Map<String, String> _workTargetLabels = {
   'counter_spy': 'Counter spy',
   'purchase_land': 'Purchase land',
 };
-
-/// Region id to display label. SPEC/ui/civilian-units-panel.md.
-String _regionLabel(String regionId) {
-  switch (regionId) {
-    case 'oldWorld':
-      return 'Old World';
-    case 'newWorld':
-      return 'New World';
-    default:
-      return regionId;
-  }
-}
 
 /// Builds prefixed province id -> province display name from [game].
 Map<String, String> _provinceNamesByPrefixedId(Game game) {
@@ -127,111 +117,49 @@ class CivilianUnitsPanel extends StatelessWidget {
     );
     final hasAny = ow.isNotEmpty || nw.isNotEmpty;
 
-    return ConstrainedBox(
-      constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
-      child: Padding(
-        padding: const EdgeInsets.all(8),
-        child: CtPanel(
-          padding: EdgeInsets.zero,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Padding(
-                padding: const EdgeInsets.fromLTRB(12, 8, 8, 4),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        'Civilian Units',
-                        style: Theme.of(context).textTheme.titleMedium,
-                      ),
-                    ),
-                    CtNinePatchButton(
-                      onPressed: () {
-                        Navigator.of(context).maybePop();
-                        bus.emit(OpenDialogEvent(trainCiviliansDialogId));
-                      },
-                      child: const Text('Train'),
-                    ),
-                  ],
-                ),
-              ),
-              Flexible(
-                child: hasAny
-                    ? ListView(
-                        shrinkWrap: true,
-                        padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
-                        children: [
-                          if (ow.isNotEmpty) ...[
-                            _RegionHeader(label: _regionLabel('oldWorld')),
-                            ...ow.map(
-                              (u) => _UnitRow(
-                                unit: u,
-                                provinceNames: provinceNames,
-                                currentOrders: currentOrders,
-                                availableWorkTargets: availableWorkTargets,
-                                humanPlayerId: humanPlayerId,
-                                bus: bus,
-                                onAddWorkOrder: onAddWorkOrder,
-                              ),
-                            ),
-                          ],
-                          if (nw.isNotEmpty) ...[
-                            _RegionHeader(label: _regionLabel('newWorld')),
-                            ...nw.map(
-                              (u) => _UnitRow(
-                                unit: u,
-                                provinceNames: provinceNames,
-                                currentOrders: currentOrders,
-                                availableWorkTargets: availableWorkTargets,
-                                humanPlayerId: humanPlayerId,
-                                bus: bus,
-                                onAddWorkOrder: onAddWorkOrder,
-                              ),
-                            ),
-                          ],
-                        ],
-                      )
-                    : Padding(
-                        padding: const EdgeInsets.all(24),
-                        child: Center(
-                          child: Text(
-                            'No civilian units',
-                            style: Theme.of(context).textTheme.bodyMedium
-                                ?.copyWith(
-                                  color: Theme.of(
-                                    context,
-                                  ).colorScheme.onSurfaceVariant,
-                                ),
-                          ),
-                        ),
-                      ),
-              ),
-            ],
+    return UnitsPanelShell(
+      title: 'Civilian Units',
+      actions: [
+        CtNinePatchButton(
+          onPressed: () {
+            Navigator.of(context).maybePop();
+            bus.emit(OpenDialogEvent(trainCiviliansDialogId));
+          },
+          child: const Text('Train'),
+        ),
+      ],
+      hasContent: hasAny,
+      listChildren: [
+        if (ow.isNotEmpty) ...[
+          RegionSectionHeader(label: unitsPanelRegionLabel('oldWorld')),
+          ...ow.map(
+            (u) => _UnitRow(
+              unit: u,
+              provinceNames: provinceNames,
+              currentOrders: currentOrders,
+              availableWorkTargets: availableWorkTargets,
+              humanPlayerId: humanPlayerId,
+              bus: bus,
+              onAddWorkOrder: onAddWorkOrder,
+            ),
           ),
-        ),
-      ),
-    );
-  }
-}
-
-class _RegionHeader extends StatelessWidget {
-  const _RegionHeader({required this.label});
-
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(top: 8, bottom: 4),
-      child: Text(
-        label,
-        style: Theme.of(context).textTheme.titleSmall?.copyWith(
-          color: Theme.of(context).colorScheme.primary,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
+        ],
+        if (nw.isNotEmpty) ...[
+          RegionSectionHeader(label: unitsPanelRegionLabel('newWorld')),
+          ...nw.map(
+            (u) => _UnitRow(
+              unit: u,
+              provinceNames: provinceNames,
+              currentOrders: currentOrders,
+              availableWorkTargets: availableWorkTargets,
+              humanPlayerId: humanPlayerId,
+              bus: bus,
+              onAddWorkOrder: onAddWorkOrder,
+            ),
+          ),
+        ],
+      ],
+      emptyMessage: 'No civilian units',
     );
   }
 }
@@ -281,7 +209,7 @@ class _UnitRow extends StatelessWidget {
     if (regionId == null || provinceId == null) return '—';
     final prefixed = '$regionId|$provinceId';
     final name = provinceNames[prefixed] ?? prefixed;
-    final regionLabel = _regionLabel(regionId);
+    final regionLabel = unitsPanelRegionLabel(regionId);
     return '$regionLabel — $name';
   }
 
@@ -297,7 +225,7 @@ class _UnitRow extends StatelessWidget {
         if (regionId != null && provinceId != null) {
           final name =
               provinceNames['$regionId|$provinceId'] ?? '$regionId|$provinceId';
-          location = ' (${_regionLabel(regionId)} — $name)';
+          location = ' (${unitsPanelRegionLabel(regionId)} — $name)';
         }
         return '$workLabel$location (pending)';
       }
@@ -314,7 +242,7 @@ class _UnitRow extends StatelessWidget {
     if (regionId != null && provinceId != null) {
       final name =
           provinceNames['$regionId|$provinceId'] ?? '$regionId|$provinceId';
-      location = ' (${_regionLabel(regionId)} — $name)';
+      location = ' (${unitsPanelRegionLabel(regionId)} — $name)';
     }
     final progress = cw.totalTurns > 0
         ? ' ${cw.remainingTurns}/${cw.totalTurns} turns'

--- a/app/lib/features/game/widgets/military_units_panel.dart
+++ b/app/lib/features/game/widgets/military_units_panel.dart
@@ -6,19 +6,10 @@ import 'package:flutter/material.dart';
 
 import '../../../core/services/app_event_handler_scope.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
-import '../../../widgets/ct_panel.dart';
-
-/// Region id to display label. SPEC/ui/military-units-panel.md.
-String _regionLabel(String regionId) {
-  switch (regionId) {
-    case 'oldWorld':
-      return 'Old World';
-    case 'newWorld':
-      return 'New World';
-    default:
-      return regionId;
-  }
-}
+import 'units/shared/location_section_header.dart';
+import 'units/shared/region_section_header.dart';
+import 'units/shared/units_panel_region_label.dart';
+import 'units/shared/units_panel_shell.dart';
 
 /// Fleet mission to display label.
 String _missionLabel(FleetMission m) {
@@ -311,140 +302,58 @@ class MilitaryUnitsPanel extends StatelessWidget {
     final tree = _buildMilitaryTree(game, humanPlayerId);
     final hasAny = tree.isNotEmpty;
 
-    return ConstrainedBox(
-      constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
-      child: Padding(
-        padding: const EdgeInsets.all(8),
-        child: CtPanel(
-          padding: EdgeInsets.zero,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Padding(
-                padding: const EdgeInsets.fromLTRB(12, 8, 8, 4),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        'Military Units',
-                        style: Theme.of(context).textTheme.titleMedium,
-                      ),
-                    ),
-                    CtNinePatchButton(
-                      onPressed: () {
-                        Navigator.of(context).maybePop();
-                        bus.emit(OpenDialogEvent(trainMilitaryDialogId));
-                      },
-                      child: const Text('Train'),
-                    ),
-                  ],
-                ),
-              ),
-              Flexible(
-                child: hasAny
-                    ? ListView(
-                        shrinkWrap: true,
-                        padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
-                        children: [
-                          for (final group in tree) ...[
-                            _RegionHeader(label: _regionLabel(group.regionId)),
-                            for (final loc in group.locations) ...[
-                              _LocationHeader(
-                                label: loc.displayLabel,
-                                regionLabel: _regionLabel(loc.regionId),
-                              ),
-                              if (loc is _ProvinceLocationNode)
-                                for (final row in loc.rows)
-                                  _RegimentRow(
-                                    row: row,
-                                    onTap: row.tileKey == null
-                                        ? null
-                                        : () => bus.emit(
-                                            LocateMapTileEvent(
-                                              tileKey: row.tileKey!,
-                                              regionId: row.regionId,
-                                              closeCurrentPanel: true,
-                                            ),
-                                          ),
-                                  ),
-                              if (loc is _SeaZoneLocationNode)
-                                for (final row in loc.rows)
-                                  _ShipRow(
-                                    row: row,
-                                    onTap: row.tileKey == null
-                                        ? null
-                                        : () => bus.emit(
-                                            LocateMapTileEvent(
-                                              tileKey: row.tileKey!,
-                                              regionId: row.regionId,
-                                              closeCurrentPanel: true,
-                                            ),
-                                          ),
-                                  ),
-                            ],
-                          ],
-                        ],
-                      )
-                    : Padding(
-                        padding: const EdgeInsets.all(24),
-                        child: Center(
-                          child: Text(
-                            'No military units',
-                            style: Theme.of(context).textTheme.bodyMedium
-                                ?.copyWith(
-                                  color: Theme.of(
-                                    context,
-                                  ).colorScheme.onSurfaceVariant,
-                                ),
+    return UnitsPanelShell(
+      title: 'Military Units',
+      actions: [
+        CtNinePatchButton(
+          onPressed: () {
+            Navigator.of(context).maybePop();
+            bus.emit(OpenDialogEvent(trainMilitaryDialogId));
+          },
+          child: const Text('Train'),
+        ),
+      ],
+      hasContent: hasAny,
+      listChildren: [
+        for (final group in tree) ...[
+          RegionSectionHeader(label: unitsPanelRegionLabel(group.regionId)),
+          for (final loc in group.locations) ...[
+            LocationSectionHeader(
+              label: loc.displayLabel,
+              regionLabel: unitsPanelRegionLabel(loc.regionId),
+            ),
+            if (loc is _ProvinceLocationNode)
+              for (final row in loc.rows)
+                _RegimentRow(
+                  row: row,
+                  onTap: row.tileKey == null
+                      ? null
+                      : () => bus.emit(
+                          LocateMapTileEvent(
+                            tileKey: row.tileKey!,
+                            regionId: row.regionId,
+                            closeCurrentPanel: true,
                           ),
                         ),
-                      ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _RegionHeader extends StatelessWidget {
-  const _RegionHeader({required this.label});
-
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(top: 8, bottom: 4),
-      child: Text(
-        label,
-        style: Theme.of(context).textTheme.titleSmall?.copyWith(
-          color: Theme.of(context).colorScheme.primary,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
-  }
-}
-
-class _LocationHeader extends StatelessWidget {
-  const _LocationHeader({required this.label, required this.regionLabel});
-
-  final String label;
-  final String regionLabel;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 12, top: 6, bottom: 2),
-      child: Text(
-        '$label — $regionLabel',
-        style: Theme.of(context).textTheme.titleSmall?.copyWith(
-          color: Theme.of(context).colorScheme.onSurface,
-        ),
-      ),
+                ),
+            if (loc is _SeaZoneLocationNode)
+              for (final row in loc.rows)
+                _ShipRow(
+                  row: row,
+                  onTap: row.tileKey == null
+                      ? null
+                      : () => bus.emit(
+                          LocateMapTileEvent(
+                            tileKey: row.tileKey!,
+                            regionId: row.regionId,
+                            closeCurrentPanel: true,
+                          ),
+                        ),
+                ),
+          ],
+        ],
+      ],
+      emptyMessage: 'No military units',
     );
   }
 }

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -5,19 +5,11 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
 import '../../../widgets/ct_nine_patch_button.dart';
-import '../../../widgets/ct_panel.dart';
 import 'split_fleet_dialog.dart';
-
-String _regionLabel(String regionId) {
-  switch (regionId) {
-    case 'oldWorld':
-      return 'Old World';
-    case 'newWorld':
-      return 'New World';
-    default:
-      return regionId;
-  }
-}
+import 'units/shared/location_section_header.dart';
+import 'units/shared/region_section_header.dart';
+import 'units/shared/units_panel_region_label.dart';
+import 'units/shared/units_panel_shell.dart';
 
 String _missionLabel(FleetMission m) {
   switch (m) {
@@ -289,7 +281,7 @@ _buildNavalTree(Game game, String humanPlayerId) {
         final zoneLabel = zoneKey.contains('|')
             ? zoneKey.split('|').last
             : zoneKey;
-        locationLabel = '${_regionLabel(regionId)} — $zoneLabel';
+        locationLabel = '${unitsPanelRegionLabel(regionId)} — $zoneLabel';
         tileKey = tileKeyForSeaZoneLocation(game, regionId, zoneKey);
         locationKey = 'sea:$zoneKey';
         final row = _FleetRow(
@@ -318,7 +310,7 @@ _buildNavalTree(Game game, String humanPlayerId) {
         if (province == null) continue;
         tileKey = tileKeyForProvinceLocation(game, province);
         locationLabel =
-            '${_regionLabel(regionId)} — ${province.displayName ?? province.id}';
+            '${unitsPanelRegionLabel(regionId)} — ${province.displayName ?? province.id}';
         locationKey = 'port:${province.regionId}|${province.id}';
         final row = _FleetRow(
           fleetId: fleet.id,
@@ -357,7 +349,7 @@ _buildNavalTree(Game game, String humanPlayerId) {
       if (province != null) {
         final tileKey = tileKeyForProvinceLocation(game, province);
         final locationLabel =
-            '${_regionLabel(regionId)} — ${province.displayName ?? province.id}';
+            '${unitsPanelRegionLabel(regionId)} — ${province.displayName ?? province.id}';
         homeFleetRow = _FleetRow(
           fleetId: 'home_fleet',
           label: 'Home Fleet',
@@ -593,169 +585,75 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
     return GestureDetector(
       onTap: _isCombineModeActive() ? _cancelCombine : null,
       behavior: HitTestBehavior.translucent,
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
-        child: Padding(
-          padding: const EdgeInsets.all(8),
-          child: CtPanel(
-            padding: EdgeInsets.zero,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(12, 8, 8, 4),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: Text(
-                          'Naval Units',
-                          style: Theme.of(context).textTheme.titleMedium,
+      child: UnitsPanelShell(
+        title: 'Naval Units',
+        actions: [
+          if (_isCombineModeActive())
+            TextButton(onPressed: _cancelCombine, child: const Text('Cancel')),
+        ],
+        hasContent: hasAny,
+        listChildren: [
+          for (final group in tree) ...[
+            RegionSectionHeader(label: unitsPanelRegionLabel(group.regionId)),
+            if (group.homeFleet != null)
+              _FleetExpansionTile(
+                row: group.homeFleet!,
+                onTap: group.homeFleet!.tileKey != null
+                    ? () => widget.bus.emit(
+                        LocateMapTileEvent(
+                          tileKey: group.homeFleet!.tileKey!,
+                          regionId: group.homeFleet!.regionId,
                         ),
-                      ),
-                      if (_isCombineModeActive())
-                        TextButton(
-                          onPressed: _cancelCombine,
-                          child: const Text('Cancel'),
-                        ),
-                    ],
-                  ),
+                      )
+                    : null,
+                isCombineMode: _isCombineModeActive(),
+                isCombineTarget:
+                    _combineTargetFleetId == group.homeFleet!.fleetId,
+                isSelectedForCombine: _selectedForCombine.contains(
+                  group.homeFleet!.fleetId,
                 ),
-                Flexible(
-                  child: hasAny
-                      ? ListView(
-                          shrinkWrap: true,
-                          padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
-                          children: [
-                            for (final group in tree) ...[
-                              _RegionHeader(
-                                label: _regionLabel(group.regionId),
-                              ),
-                              if (group.homeFleet != null)
-                                _FleetExpansionTile(
-                                  row: group.homeFleet!,
-                                  onTap:
-                                      group.homeFleet!.tileKey != null
-                                      ? () => widget.bus.emit(
-                                          LocateMapTileEvent(
-                                            tileKey: group.homeFleet!.tileKey!,
-                                            regionId: group.homeFleet!.regionId,
-                                          ),
-                                        )
-                                      : null,
-                                  isCombineMode: _isCombineModeActive(),
-                                  isCombineTarget:
-                                      _combineTargetFleetId ==
-                                      group.homeFleet!.fleetId,
-                                  isSelectedForCombine: _selectedForCombine
-                                      .contains(group.homeFleet!.fleetId),
-                                  isEligibleForCombine:
-                                      _isCombineModeActive() &&
-                                      _isEligibleForCombine(group.homeFleet!),
-                                  onCombineStart: () =>
-                                      _startCombine(group.homeFleet!),
-                                  onCombineToggle: () =>
-                                      _toggleFleetForCombine(group.homeFleet!),
-                                  onCombineConfirm: () => _confirmCombine(),
-                                  onSplitFleet: () =>
-                                      _openSplitDialog(group.homeFleet!),
-                                  isSplitAllowed: true,
-                                ),
-                              for (final loc in group.locations) ...[
-                                _LocationHeader(
-                                  label: loc.displayLabel,
-                                  regionLabel: _regionLabel(loc.regionId),
-                                ),
-                                for (final row in loc.fleets)
-                                  _FleetExpansionTile(
-                                    row: row,
-                                    onTap:
-                                        row.tileKey != null
-                                        ? () => widget.bus.emit(
-                                            LocateMapTileEvent(
-                                              tileKey: row.tileKey!,
-                                              regionId: row.regionId,
-                                            ),
-                                          )
-                                        : null,
-                                    isCombineMode: _isCombineModeActive(),
-                                    isCombineTarget:
-                                        _combineTargetFleetId == row.fleetId,
-                                    isSelectedForCombine: _selectedForCombine
-                                        .contains(row.fleetId),
-                                    isEligibleForCombine:
-                                        _isCombineModeActive() &&
-                                        _isEligibleForCombine(row),
-                                    onCombineStart: () => _startCombine(row),
-                                    onCombineToggle: () =>
-                                        _toggleFleetForCombine(row),
-                                    onCombineConfirm: () => _confirmCombine(),
-                                    onSplitFleet: () => _openSplitDialog(row),
-                                    isSplitAllowed: true,
-                                  ),
-                              ],
-                            ],
-                          ],
-                        )
-                      : Padding(
-                          padding: const EdgeInsets.all(24),
-                          child: Center(
-                            child: Text(
-                              'No naval units',
-                              style: Theme.of(context).textTheme.bodyMedium
-                                  ?.copyWith(
-                                    color: Theme.of(
-                                      context,
-                                    ).colorScheme.onSurfaceVariant,
-                                  ),
-                            ),
+                isEligibleForCombine:
+                    _isCombineModeActive() &&
+                    _isEligibleForCombine(group.homeFleet!),
+                onCombineStart: () => _startCombine(group.homeFleet!),
+                onCombineToggle: () => _toggleFleetForCombine(group.homeFleet!),
+                onCombineConfirm: () => _confirmCombine(),
+                onSplitFleet: () => _openSplitDialog(group.homeFleet!),
+                isSplitAllowed: true,
+              ),
+            for (final loc in group.locations) ...[
+              LocationSectionHeader(
+                label: loc.displayLabel,
+                regionLabel: unitsPanelRegionLabel(loc.regionId),
+              ),
+              for (final row in loc.fleets)
+                _FleetExpansionTile(
+                  row: row,
+                  onTap: row.tileKey != null
+                      ? () => widget.bus.emit(
+                          LocateMapTileEvent(
+                            tileKey: row.tileKey!,
+                            regionId: row.regionId,
                           ),
-                        ),
+                        )
+                      : null,
+                  isCombineMode: _isCombineModeActive(),
+                  isCombineTarget: _combineTargetFleetId == row.fleetId,
+                  isSelectedForCombine: _selectedForCombine.contains(
+                    row.fleetId,
+                  ),
+                  isEligibleForCombine:
+                      _isCombineModeActive() && _isEligibleForCombine(row),
+                  onCombineStart: () => _startCombine(row),
+                  onCombineToggle: () => _toggleFleetForCombine(row),
+                  onCombineConfirm: () => _confirmCombine(),
+                  onSplitFleet: () => _openSplitDialog(row),
+                  isSplitAllowed: true,
                 ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _RegionHeader extends StatelessWidget {
-  const _RegionHeader({required this.label});
-
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(top: 8, bottom: 4),
-      child: Text(
-        label,
-        style: Theme.of(context).textTheme.titleSmall?.copyWith(
-          color: Theme.of(context).colorScheme.primary,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
-  }
-}
-
-class _LocationHeader extends StatelessWidget {
-  const _LocationHeader({required this.label, required this.regionLabel});
-
-  final String label;
-  final String regionLabel;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 12, top: 6, bottom: 2),
-      child: Text(
-        '$label — $regionLabel',
-        style: Theme.of(context).textTheme.titleSmall?.copyWith(
-          color: Theme.of(context).colorScheme.onSurface,
-        ),
+            ],
+          ],
+        ],
+        emptyMessage: 'No naval units',
       ),
     );
   }

--- a/app/lib/features/game/widgets/units/shared/location_section_header.dart
+++ b/app/lib/features/game/widgets/units/shared/location_section_header.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+/// Sub-header for a province or sea zone within a region in military/naval panels.
+class LocationSectionHeader extends StatelessWidget {
+  const LocationSectionHeader({
+    super.key,
+    required this.label,
+    required this.regionLabel,
+  });
+
+  final String label;
+  final String regionLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 12, top: 6, bottom: 2),
+      child: Text(
+        '$label — $regionLabel',
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+          color: Theme.of(context).colorScheme.onSurface,
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/game/widgets/units/shared/region_section_header.dart
+++ b/app/lib/features/game/widgets/units/shared/region_section_header.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+/// Section title for a world region (Old World / New World) in units panels.
+class RegionSectionHeader extends StatelessWidget {
+  const RegionSectionHeader({super.key, required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 8, bottom: 4),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+          color: Theme.of(context).colorScheme.primary,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/game/widgets/units/shared/units_panel_region_label.dart
+++ b/app/lib/features/game/widgets/units/shared/units_panel_region_label.dart
@@ -1,0 +1,13 @@
+// Shared region labels for units panels. SPEC/ui/civilian-units-panel.md et al.
+
+/// Region id to display label for Old/New World sections in units panels.
+String unitsPanelRegionLabel(String regionId) {
+  switch (regionId) {
+    case 'oldWorld':
+      return 'Old World';
+    case 'newWorld':
+      return 'New World';
+    default:
+      return regionId;
+  }
+}

--- a/app/lib/features/game/widgets/units/shared/units_panel_shell.dart
+++ b/app/lib/features/game/widgets/units/shared/units_panel_shell.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../widgets/ct_panel.dart';
+
+/// Shared layout: constrained panel, [CtPanel], title row, and list or empty state.
+class UnitsPanelShell extends StatelessWidget {
+  const UnitsPanelShell({
+    super.key,
+    required this.title,
+    this.actions = const [],
+    required this.hasContent,
+    required this.listChildren,
+    required this.emptyMessage,
+    this.listPadding = const EdgeInsets.fromLTRB(8, 0, 8, 8),
+  });
+
+  final String title;
+  final List<Widget> actions;
+  final bool hasContent;
+  final List<Widget> listChildren;
+  final String emptyMessage;
+  final EdgeInsets listPadding;
+
+  static const BoxConstraints panelConstraints = BoxConstraints(
+    maxWidth: 400,
+    maxHeight: 500,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: panelConstraints,
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: CtPanel(
+          padding: EdgeInsets.zero,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(12, 8, 8, 4),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        title,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                    ),
+                    ...actions,
+                  ],
+                ),
+              ),
+              Flexible(
+                child: hasContent
+                    ? ListView(
+                        shrinkWrap: true,
+                        padding: listPadding,
+                        children: listChildren,
+                      )
+                    : Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: Center(
+                          child: Text(
+                            emptyMessage,
+                            style: Theme.of(context).textTheme.bodyMedium
+                                ?.copyWith(
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.onSurfaceVariant,
+                                ),
+                          ),
+                        ),
+                      ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/test/units_panel_shared_widgets_test.dart
+++ b/app/test/units_panel_shared_widgets_test.dart
@@ -1,0 +1,113 @@
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/features/game/widgets/units/shared/location_section_header.dart';
+import 'package:colonizethis_app/features/game/widgets/units/shared/region_section_header.dart';
+import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_region_label.dart';
+import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_shell.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  group('unitsPanelRegionLabel', () {
+    test('maps known region ids', () {
+      expect(unitsPanelRegionLabel('oldWorld'), 'Old World');
+      expect(unitsPanelRegionLabel('newWorld'), 'New World');
+    });
+
+    test('passes through unknown ids', () {
+      expect(unitsPanelRegionLabel('custom'), 'custom');
+    });
+  });
+
+  group('RegionSectionHeader', () {
+    testWidgets('shows label text', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: RegionSectionHeader(label: 'Old World')),
+        ),
+      );
+      expect(find.text('Old World'), findsOneWidget);
+    });
+  });
+
+  group('LocationSectionHeader', () {
+    testWidgets('shows label and region', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: LocationSectionHeader(
+              label: 'Province A',
+              regionLabel: 'New World',
+            ),
+          ),
+        ),
+      );
+      expect(find.text('Province A — New World'), findsOneWidget);
+    });
+  });
+
+  group('UnitsPanelShell', () {
+    testWidgets('shows title and empty message when no content', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: UnitsPanelShell(
+              title: 'Test Panel',
+              hasContent: false,
+              listChildren: [],
+              emptyMessage: 'Nothing here',
+            ),
+          ),
+        ),
+      );
+      expect(find.text('Test Panel'), findsOneWidget);
+      expect(find.text('Nothing here'), findsOneWidget);
+    });
+
+    testWidgets('shows list children when hasContent', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: UnitsPanelShell(
+              title: 'With rows',
+              hasContent: true,
+              listChildren: [
+                const ListTile(title: Text('Row one')),
+                const ListTile(title: Text('Row two')),
+              ],
+              emptyMessage: 'ignored',
+            ),
+          ),
+        ),
+      );
+      expect(find.text('Row one'), findsOneWidget);
+      expect(find.text('Row two'), findsOneWidget);
+      expect(find.text('ignored'), findsNothing);
+    });
+
+    testWidgets('forwards trailing actions', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: UnitsPanelShell(
+              title: 'T',
+              actions: [
+                TextButton(onPressed: () {}, child: const Text('Action')),
+              ],
+              hasContent: false,
+              listChildren: const [],
+              emptyMessage: 'E',
+            ),
+          ),
+        ),
+      );
+      expect(find.text('Action'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements [issue #1346](https://github.com/waigore/colonizethisv3/issues/1346): deduplicate `CivilianUnitsPanel`, `MilitaryUnitsPanel`, and `NavalUnitsPanel` scaffolding into shared app UI helpers under `app/lib/features/game/widgets/units/shared/`.

## Scope verification (issue AC)

| Criterion | Status |
|-----------|--------|
| All three panels use shared shell/header widgets | `UnitsPanelShell` + `RegionSectionHeader` in all three; `LocationSectionHeader` in military & naval (civilian has no province/sea sub-sections in the list, matching prior UI). |
| Shared helpers live in app, not logic packages | New code is under `app/lib/features/game/widgets/units/shared/`. |
| No behavior change to actions or bus events | Train / Cancel combine / `Navigator.maybePop`, `OpenDialogEvent`, `LocateMapTileEvent`, combine/split flows unchanged; only layout composition moved. |
| Tests | `civilian_units_panel_test`, `military_units_panel_test`, `naval_units_panel_test` pass; added `units_panel_shared_widgets_test.dart` for shell, headers, and `unitsPanelRegionLabel`. |

## Files

- **New:** `units_panel_shell.dart`, `region_section_header.dart`, `location_section_header.dart`, `units_panel_region_label.dart`
- **Updated:** three panel widgets; naval still wraps the shell in `GestureDetector` for combine-mode tap-outside cancel.

Closes #1346.