### PR TITLE
feat(app): centralize map location resolver and region labels (#1347)

### DIFF
--- a/app/lib/features/game/utils/map_location_resolver.dart
+++ b/app/lib/features/game/utils/map_location_resolver.dart
@@ -1,0 +1,41 @@
+// Tile keys for centering the map on provinces and sea zones from game UI.
+// SPEC/ui/military-units-panel.md, SPEC/ui/naval-units-panel.md.
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Resolves the tile key to use when centering on [province] (town tile or first tile).
+/// Uses `(regionId, province.id)` via [Province.regionId] and prefixed map keys.
+/// Returns null if no tile can be resolved.
+String? tileKeyForProvinceLocation(Game game, Province province) {
+  final prefixedId = '${province.regionId}|${province.id}';
+  if (province.townTileKey != null && province.townTileKey!.isNotEmpty) {
+    return province.townTileKey;
+  }
+  final byProvince =
+      game.worldState.tileKeysByRegionAndProvince[province.regionId];
+  final tiles = byProvince?[prefixedId] ?? byProvince?[province.id];
+  if (tiles != null && tiles.isNotEmpty) return tiles.first;
+  return null;
+}
+
+/// Resolves a port tile key adjacent to the given sea zone in [regionId].
+/// [seaZoneId] may be prefixed (`regionId|localId`) or local. Returns null if none.
+String? tileKeyForSeaZoneLocation(
+  Game game,
+  String regionId,
+  String seaZoneId,
+) {
+  final localSeaZone = seaZoneId.contains('|')
+      ? seaZoneId.split('|').last
+      : seaZoneId;
+  for (final e in game.worldState.portsByProvinceSeaboard.entries) {
+    final parts = e.key.split('|');
+    if (parts.length < 2) continue;
+    final keyRegion = parts[0];
+    final keySeaZone = parts.last;
+    if (keyRegion == regionId && keySeaZone == localSeaZone) {
+      return e.value;
+    }
+  }
+  return null;
+}

--- a/app/lib/features/game/utils/region_labels.dart
+++ b/app/lib/features/game/utils/region_labels.dart
@@ -1,0 +1,14 @@
+// Region id → user-facing label for units panels and related UI.
+// SPEC/ui/military-units-panel.md, SPEC/ui/civilian-units-panel.md, SPEC/ui/naval-units-panel.md.
+
+/// Maps a world [regionId] (`oldWorld`, `newWorld`, …) to a short display label.
+String regionDisplayLabel(String regionId) {
+  switch (regionId) {
+    case 'oldWorld':
+      return 'Old World';
+    case 'newWorld':
+      return 'New World';
+    default:
+      return regionId;
+  }
+}

--- a/app/lib/features/game/widgets/military_units_panel.dart
+++ b/app/lib/features/game/widgets/military_units_panel.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 
 import '../../../core/services/app_event_handler_scope.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
+import '../utils/map_location_resolver.dart';
 import 'units/shared/location_section_header.dart';
 import 'units/shared/region_section_header.dart';
 import 'units/shared/units_panel_region_label.dart';
@@ -25,43 +26,6 @@ String _missionLabel(FleetMission m) {
     case FleetMission.defend:
       return 'Defend';
   }
-}
-
-/// Resolves the tile key to use when centering on [province] (town tile or first tile).
-/// Returns null if no tile can be resolved. SPEC/ui/military-units-panel.md.
-String? tileKeyForProvinceLocation(Game game, Province province) {
-  final prefixedId = '${province.regionId}|${province.id}';
-  if (province.townTileKey != null && province.townTileKey!.isNotEmpty) {
-    return province.townTileKey;
-  }
-  final byProvince =
-      game.worldState.tileKeysByRegionAndProvince[province.regionId];
-  final tiles = byProvince?[prefixedId] ?? byProvince?[province.id];
-  if (tiles != null && tiles.isNotEmpty) return tiles.first;
-  return null;
-}
-
-/// Resolves a port tile key adjacent to the given sea zone in [regionId].
-/// [seaZoneId] may be prefixed (regionId|localId) or local. Returns null if none.
-/// SPEC/ui/military-units-panel.md.
-String? tileKeyForSeaZoneLocation(
-  Game game,
-  String regionId,
-  String seaZoneId,
-) {
-  final localSeaZone = seaZoneId.contains('|')
-      ? seaZoneId.split('|').last
-      : seaZoneId;
-  for (final e in game.worldState.portsByProvinceSeaboard.entries) {
-    final parts = e.key.split('|');
-    if (parts.length < 2) continue;
-    final keyRegion = parts[0];
-    final keySeaZone = parts.last;
-    if (keyRegion == regionId && keySeaZone == localSeaZone) {
-      return e.value;
-    }
-  }
-  return null;
 }
 
 /// One regiment-type row under a province: type, count, medals, status.

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
 import '../../../widgets/ct_nine_patch_button.dart';
+import '../utils/map_location_resolver.dart';
 import 'split_fleet_dialog.dart';
 import 'units/shared/location_section_header.dart';
 import 'units/shared/region_section_header.dart';
@@ -24,38 +25,6 @@ String _missionLabel(FleetMission m) {
     case FleetMission.defend:
       return 'Defend';
   }
-}
-
-String? tileKeyForProvinceLocation(Game game, Province province) {
-  final prefixedId = '${province.regionId}|${province.id}';
-  if (province.townTileKey != null && province.townTileKey!.isNotEmpty) {
-    return province.townTileKey;
-  }
-  final byProvince =
-      game.worldState.tileKeysByRegionAndProvince[province.regionId];
-  final tiles = byProvince?[prefixedId] ?? byProvince?[province.id];
-  if (tiles != null && tiles.isNotEmpty) return tiles.first;
-  return null;
-}
-
-String? tileKeyForSeaZoneLocation(
-  Game game,
-  String regionId,
-  String seaZoneId,
-) {
-  final localSeaZone = seaZoneId.contains('|')
-      ? seaZoneId.split('|').last
-      : seaZoneId;
-  for (final e in game.worldState.portsByProvinceSeaboard.entries) {
-    final parts = e.key.split('|');
-    if (parts.length < 2) continue;
-    final keyRegion = parts[0];
-    final keySeaZone = parts.last;
-    if (keyRegion == regionId && keySeaZone == localSeaZone) {
-      return e.value;
-    }
-  }
-  return null;
 }
 
 class _FleetRow {

--- a/app/lib/features/game/widgets/split_fleet_dialog.dart
+++ b/app/lib/features/game/widgets/split_fleet_dialog.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import '../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_transfer_list.dart';
+import '../utils/region_labels.dart';
 
 class SplitFleetDialog extends StatelessWidget {
   const SplitFleetDialog({
@@ -49,7 +50,7 @@ class SplitFleetDialog extends StatelessWidget {
       }
       final province = provinceMap[inPortId];
       final regionId = fleet.regionId;
-      final regionLabel = regionId == 'oldWorld' ? 'Old World' : 'New World';
+      final regionLabel = regionDisplayLabel(regionId);
       final provinceName = province?.displayName ?? inPortId;
       return '$provinceName — $regionLabel';
     }

--- a/app/lib/features/game/widgets/units/shared/units_panel_region_label.dart
+++ b/app/lib/features/game/widgets/units/shared/units_panel_region_label.dart
@@ -1,13 +1,6 @@
 // Shared region labels for units panels. SPEC/ui/civilian-units-panel.md et al.
 
+import '../../../utils/region_labels.dart';
+
 /// Region id to display label for Old/New World sections in units panels.
-String unitsPanelRegionLabel(String regionId) {
-  switch (regionId) {
-    case 'oldWorld':
-      return 'Old World';
-    case 'newWorld':
-      return 'New World';
-    default:
-      return regionId;
-  }
-}
+String unitsPanelRegionLabel(String regionId) => regionDisplayLabel(regionId);

--- a/app/test/military_units_panel_test.dart
+++ b/app/test/military_units_panel_test.dart
@@ -6,6 +6,7 @@ import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:colonizethis_app/features/game/utils/map_location_resolver.dart';
 import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart';
 import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
 import 'package:colonizethis_app/widgets/ct_panel.dart';


### PR DESCRIPTION
## Summary
Implements [#1347](https://github.com/waigore/colonizethisv3/issues/1347): single place for province/sea **tile key** resolution and **region display** strings used by units UI.

## Changes
- **`app/lib/features/game/utils/map_location_resolver.dart`** — `tileKeyForProvinceLocation`, `tileKeyForSeaZoneLocation` (explicit `(regionId, province)` / prefixed sea-zone ids).
- **`app/lib/features/game/utils/region_labels.dart`** — `regionDisplayLabel`.
- **`units_panel_region_label.dart`** — `unitsPanelRegionLabel` now delegates to `regionDisplayLabel` so existing panel imports stay stable.
- **Naval / military** panels import the resolver and drop duplicated implementations.
- **`split_fleet_dialog.dart`** uses `regionDisplayLabel` (fixes unknown `regionId` defaulting to “New World”).
- **Tests** — `military_units_panel_test` imports the shared resolver for tile-key groups.

## Verification
- `flutter test` on military, naval, civilian panel tests and `units_panel_shared_widgets_test` (run locally with `flutter gen-l10n` as needed).

Closes #1347.