### PR TITLE
fix(app): reliable single-ship and bulk split-fleet transfers (#1341)

### DIFF
--- a/SPEC/ui/naval-units-fleet-management.md
+++ b/SPEC/ui/naval-units-fleet-management.md
@@ -80,8 +80,7 @@ with fleet-specific labels and validation.
 
 `CtTransferList` API requirements:
 - Inputs: left/right titles, optional subtitles, initial counts for both sides
-- Transfer controls: one/all moves in both directions (`<`, `>`, `<<`, `>>`)
-- Selection model: one selected row key at a time
+- Transfer controls: per-row one/all moves in both directions (`<`, `>`, `<<`, `>>`) on each list row (no separate “selected type” step)
 - Validation hook: `canConfirm(leftCounts, rightCounts)`
 - Confirm callback: `onConfirm(leftCounts, rightCounts)`
 - Optional cancel callback and customizable action labels
@@ -104,16 +103,14 @@ Naval-specific behavior remains outside the component:
 │  │ Fleet 5             │    │ Fleet 6             ││
 │  │ Location: OW-Lisbon │    │ Location: OW-Lisbon ││
 │  │                     │    │                     ││
-│  │ Ships:              │    │ Ships:              ││
-│  │ □ Carrack (2)       │    │ □ Carrack (0)       ││
-│  │ □ Fluyte (1)        │    │ □ Fluyte (0)        ││
-│  │ □ Galleon (1)       │    │ □ Galleon (0)       ││
-│  │                     │    │                     ││
+│  │ Ships:                │    │ Ships:                ││
+│  │ Carrack (2)  [>][>>]  │    │ [<<][<] Carrack (0)  ││
+│  │ Fluyte (1)   [>][>>]  │    │ [<<][<] Fluyte (0)   ││
+│  │ Galleon (1)  [>][>>]  │    │ [<<][<] Galleon (0)  ││
+│  │                       │    │                       ││
 │  └─────────────────────┘    └─────────────────────┘│
 │                                                     │
 │  Total: 4 ships             Total: 0 ships          │
-│                                                     │
-│              [ < ]       [ > ]                      │
 │                                                     │
 ├─────────────────────────────────────────────────────┤
 │              [Cancel]  [Confirm Split]              │
@@ -122,10 +119,9 @@ Naval-specific behavior remains outside the component:
 
 ### Ship Movement
 
-- **Selection**: Clicking a ship row selects/deselects one ship type for transfer.
-- **Individual move**: Click `>` to move one ship of the selected type from Original to New. Click `<` to move one ship back.
-- **Move all**: Click `>>` to move all ships of the selected type from Original to New. Click `<<` to move all selected ships back.
-- **Disabled transfer controls**: `<`, `>`, `<<`, and `>>` are disabled when no ship type is selected.
+- **Individual move**: On each Original row, use `>` to move one ship of that type to New; on each New row, use `<` to move one back.
+- **Move all**: On each Original row, use `>>` to move all ships of that type to New; on each New row, use `<<` to move all of that type back to Original.
+- **Disabled transfer controls**: Row buttons for a type are absent when that side has zero of that type; otherwise controls respect minimum-ship rules via Confirm validation.
 
 ### Rules
 

--- a/app/lib/features/game/widgets/split_fleet_dialog.dart
+++ b/app/lib/features/game/widgets/split_fleet_dialog.dart
@@ -86,6 +86,7 @@ class SplitFleetDialog extends StatelessWidget {
               ),
               const SizedBox(height: 16),
               CtTransferList(
+                listHeight: 220,
                 leftTitle: originalFleet.id == 'home_fleet'
                     ? 'Home Fleet'
                     : 'Fleet ${originalFleet.id}',

--- a/app/lib/widgets/ct_transfer_list.dart
+++ b/app/lib/widgets/ct_transfer_list.dart
@@ -6,8 +6,7 @@ import 'ct_panel.dart';
 /// Generic dual-list transfer widget for moving counted items between two sides.
 ///
 /// Use this component when a feature needs transferable quantities with:
-/// - one selected item at a time
-/// - single-item and move-all controls
+/// - per-row single-item and move-all controls (no selection step)
 /// - configurable validation before confirm
 /// - customizable labels and item rendering
 class CtTransferList extends StatefulWidget {
@@ -63,10 +62,24 @@ class CtTransferList extends StatefulWidget {
   State<CtTransferList> createState() => _CtTransferListState();
 }
 
+/// Keys for widget tests: one control per ship type and side/direction.
+abstract final class CtTransferListKeys {
+  static Key leftMoveOne(String itemId) =>
+      ValueKey<String>('ctTransfer.left.>$itemId');
+
+  static Key leftMoveAll(String itemId) =>
+      ValueKey<String>('ctTransfer.left.>>$itemId');
+
+  static Key rightMoveOne(String itemId) =>
+      ValueKey<String>('ctTransfer.right.<$itemId');
+
+  static Key rightMoveAll(String itemId) =>
+      ValueKey<String>('ctTransfer.right.<<$itemId');
+}
+
 class _CtTransferListState extends State<CtTransferList> {
   late Map<String, int> _leftCounts;
   late Map<String, int> _rightCounts;
-  String? _selectedItemId;
 
   int get _leftTotal => _leftCounts.values.fold(0, (sum, count) => sum + count);
   int get _rightTotal =>
@@ -97,15 +110,9 @@ class _CtTransferListState extends State<CtTransferList> {
     widget.onChanged?.call(_leftCounts, _rightCounts);
   }
 
-  void _cleanupZerosAndSelection() {
+  void _cleanupZeros() {
     _leftCounts.removeWhere((_, v) => v <= 0);
     _rightCounts.removeWhere((_, v) => v <= 0);
-    final selected = _selectedItemId;
-    if (selected == null) return;
-    if (!_leftCounts.containsKey(selected) &&
-        !_rightCounts.containsKey(selected)) {
-      _selectedItemId = null;
-    }
   }
 
   void _moveOneToRight(String itemId) {
@@ -114,7 +121,7 @@ class _CtTransferListState extends State<CtTransferList> {
     setState(() {
       _leftCounts[itemId] = from - 1;
       _rightCounts[itemId] = (_rightCounts[itemId] ?? 0) + 1;
-      _cleanupZerosAndSelection();
+      _cleanupZeros();
     });
     _notifyChanged();
   }
@@ -125,7 +132,7 @@ class _CtTransferListState extends State<CtTransferList> {
     setState(() {
       _rightCounts[itemId] = from - 1;
       _leftCounts[itemId] = (_leftCounts[itemId] ?? 0) + 1;
-      _cleanupZerosAndSelection();
+      _cleanupZeros();
     });
     _notifyChanged();
   }
@@ -136,7 +143,7 @@ class _CtTransferListState extends State<CtTransferList> {
     setState(() {
       _rightCounts[itemId] = (_rightCounts[itemId] ?? 0) + from;
       _leftCounts.remove(itemId);
-      _cleanupZerosAndSelection();
+      _cleanupZeros();
     });
     _notifyChanged();
   }
@@ -147,15 +154,9 @@ class _CtTransferListState extends State<CtTransferList> {
     setState(() {
       _leftCounts[itemId] = (_leftCounts[itemId] ?? 0) + from;
       _rightCounts.remove(itemId);
-      _cleanupZerosAndSelection();
+      _cleanupZeros();
     });
     _notifyChanged();
-  }
-
-  void _toggleSelection(String itemId) {
-    setState(() {
-      _selectedItemId = _selectedItemId == itemId ? null : itemId;
-    });
   }
 
   void _handleConfirm() {
@@ -168,9 +169,6 @@ class _CtTransferListState extends State<CtTransferList> {
 
   @override
   Widget build(BuildContext context) {
-    final selected = _selectedItemId;
-    final selectedLeft = selected == null ? 0 : (_leftCounts[selected] ?? 0);
-    final selectedRight = selected == null ? 0 : (_rightCounts[selected] ?? 0);
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -184,11 +182,18 @@ class _CtTransferListState extends State<CtTransferList> {
                 counts: _leftCounts,
                 total: _leftTotal,
                 listHeight: widget.listHeight,
-                selectedItemId: _selectedItemId,
                 emptyLabel: widget.leftEmptyLabel,
                 itemLabelBuilder: _itemLabel,
-                onSelectItem: _toggleSelection,
                 totalLabelBuilder: widget.totalLabelBuilder,
+                placeActionsAfterLabel: true,
+                moveAllToLeftLabel: widget.moveAllToLeftLabel,
+                moveOneToLeftLabel: widget.moveOneToLeftLabel,
+                moveOneToRightLabel: widget.moveOneToRightLabel,
+                moveAllToRightLabel: widget.moveAllToRightLabel,
+                onMoveOneToRight: _moveOneToRight,
+                onMoveAllToRight: _moveAllToRight,
+                onMoveOneToLeft: _moveOneToLeft,
+                onMoveAllToLeft: _moveAllToLeft,
               ),
             ),
             const SizedBox(width: 16),
@@ -199,49 +204,19 @@ class _CtTransferListState extends State<CtTransferList> {
                 counts: _rightCounts,
                 total: _rightTotal,
                 listHeight: widget.listHeight,
-                selectedItemId: _selectedItemId,
                 emptyLabel: widget.rightEmptyLabel,
                 itemLabelBuilder: _itemLabel,
-                onSelectItem: _toggleSelection,
                 totalLabelBuilder: widget.totalLabelBuilder,
+                placeActionsAfterLabel: false,
+                moveAllToLeftLabel: widget.moveAllToLeftLabel,
+                moveOneToLeftLabel: widget.moveOneToLeftLabel,
+                moveOneToRightLabel: widget.moveOneToRightLabel,
+                moveAllToRightLabel: widget.moveAllToRightLabel,
+                onMoveOneToRight: _moveOneToRight,
+                onMoveAllToRight: _moveAllToRight,
+                onMoveOneToLeft: _moveOneToLeft,
+                onMoveAllToLeft: _moveAllToLeft,
               ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 16),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            CtNinePatchButton(
-              onPressed: selected == null
-                  ? null
-                  : () => _moveAllToLeft(selected),
-              enabled: selected != null && selectedRight > 0,
-              child: Text(widget.moveAllToLeftLabel),
-            ),
-            const SizedBox(width: 8),
-            CtNinePatchButton(
-              onPressed: selected == null
-                  ? null
-                  : () => _moveOneToLeft(selected),
-              enabled: selected != null && selectedRight > 0,
-              child: Text(widget.moveOneToLeftLabel),
-            ),
-            const SizedBox(width: 16),
-            CtNinePatchButton(
-              onPressed: selected == null
-                  ? null
-                  : () => _moveOneToRight(selected),
-              enabled: selected != null && selectedLeft > 0,
-              child: Text(widget.moveOneToRightLabel),
-            ),
-            const SizedBox(width: 8),
-            CtNinePatchButton(
-              onPressed: selected == null
-                  ? null
-                  : () => _moveAllToRight(selected),
-              enabled: selected != null && selectedLeft > 0,
-              child: Text(widget.moveAllToRightLabel),
             ),
           ],
         ),
@@ -274,11 +249,18 @@ class _TransferSidePanel extends StatelessWidget {
     required this.counts,
     required this.total,
     required this.listHeight,
-    required this.selectedItemId,
     required this.emptyLabel,
     required this.itemLabelBuilder,
-    required this.onSelectItem,
     required this.totalLabelBuilder,
+    required this.placeActionsAfterLabel,
+    required this.moveAllToLeftLabel,
+    required this.moveOneToLeftLabel,
+    required this.moveOneToRightLabel,
+    required this.moveAllToRightLabel,
+    required this.onMoveOneToRight,
+    required this.onMoveAllToRight,
+    required this.onMoveOneToLeft,
+    required this.onMoveAllToLeft,
     this.subtitle,
   });
 
@@ -287,11 +269,26 @@ class _TransferSidePanel extends StatelessWidget {
   final Map<String, int> counts;
   final int total;
   final double listHeight;
-  final String? selectedItemId;
   final String emptyLabel;
   final String Function(String itemId) itemLabelBuilder;
-  final void Function(String itemId) onSelectItem;
   final String Function(int total)? totalLabelBuilder;
+
+  /// True: original-fleet panel — label then [>] [>>]. False: new-fleet panel — [<<] [<] then label.
+  final bool placeActionsAfterLabel;
+  final String moveAllToLeftLabel;
+  final String moveOneToLeftLabel;
+  final String moveOneToRightLabel;
+  final String moveAllToRightLabel;
+  final void Function(String itemId) onMoveOneToRight;
+  final void Function(String itemId) onMoveAllToRight;
+  final void Function(String itemId) onMoveOneToLeft;
+  final void Function(String itemId) onMoveAllToLeft;
+
+  static const double _rowButtonMinHeight = 40;
+  static const EdgeInsets _rowButtonPadding = EdgeInsets.symmetric(
+    horizontal: 8,
+    vertical: 6,
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -324,24 +321,76 @@ class _TransferSidePanel extends StatelessWidget {
                     itemBuilder: (context, index) {
                       final typeId = sortedTypes[index];
                       final count = counts[typeId] ?? 0;
-                      final isSelected = selectedItemId == typeId;
+                      final label = Text(
+                        '${itemLabelBuilder(typeId)} ($count)',
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      );
+                      final List<Widget> rowChildren;
+                      if (placeActionsAfterLabel) {
+                        final canMove = count > 0;
+                        rowChildren = [
+                          Expanded(child: label),
+                          const SizedBox(width: 6),
+                          CtNinePatchButton(
+                            key: CtTransferListKeys.leftMoveOne(typeId),
+                            minHeight: _rowButtonMinHeight,
+                            padding: _rowButtonPadding,
+                            enabled: canMove,
+                            onPressed: canMove
+                                ? () => onMoveOneToRight(typeId)
+                                : null,
+                            child: Text(moveOneToRightLabel),
+                          ),
+                          const SizedBox(width: 4),
+                          CtNinePatchButton(
+                            key: CtTransferListKeys.leftMoveAll(typeId),
+                            minHeight: _rowButtonMinHeight,
+                            padding: _rowButtonPadding,
+                            enabled: canMove,
+                            onPressed: canMove
+                                ? () => onMoveAllToRight(typeId)
+                                : null,
+                            child: Text(moveAllToRightLabel),
+                          ),
+                        ];
+                      } else {
+                        final canMove = count > 0;
+                        rowChildren = [
+                          CtNinePatchButton(
+                            key: CtTransferListKeys.rightMoveAll(typeId),
+                            minHeight: _rowButtonMinHeight,
+                            padding: _rowButtonPadding,
+                            enabled: canMove,
+                            onPressed: canMove
+                                ? () => onMoveAllToLeft(typeId)
+                                : null,
+                            child: Text(moveAllToLeftLabel),
+                          ),
+                          const SizedBox(width: 4),
+                          CtNinePatchButton(
+                            key: CtTransferListKeys.rightMoveOne(typeId),
+                            minHeight: _rowButtonMinHeight,
+                            padding: _rowButtonPadding,
+                            enabled: canMove,
+                            onPressed: canMove
+                                ? () => onMoveOneToLeft(typeId)
+                                : null,
+                            child: Text(moveOneToLeftLabel),
+                          ),
+                          const SizedBox(width: 6),
+                          Expanded(child: label),
+                        ];
+                      }
                       return Padding(
                         padding: const EdgeInsets.symmetric(vertical: 2),
                         child: Material(
-                          color: isSelected
-                              ? Theme.of(context).colorScheme.primaryContainer
-                              : Colors.transparent,
-                          child: InkWell(
-                            onTap: () => onSelectItem(typeId),
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 8,
-                                vertical: 6,
-                              ),
-                              child: Text(
-                                '${itemLabelBuilder(typeId)} ($count)',
-                              ),
+                          color: Colors.transparent,
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 4,
+                              vertical: 4,
                             ),
+                            child: Row(children: rowChildren),
                           ),
                         ),
                       );

--- a/app/test/split_fleet_dialog_test.dart
+++ b/app/test/split_fleet_dialog_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/split_fleet_dialog.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
 
 Widget _openDialogButton(VoidCallback onOpen) {
   return TextButton(onPressed: onOpen, child: const Text('open'));
@@ -67,7 +68,7 @@ void main() {
     return button.enabled;
   }
 
-  testWidgets('transfer buttons disabled until a type is selected', (
+  testWidgets('moving exactly one from three of a type leaves 2 and 1', (
     WidgetTester tester,
   ) async {
     final fleet = Fleet(
@@ -75,7 +76,7 @@ void main() {
       ownerId: 'gp1',
       regionId: 'oldWorld',
       seaZoneId: 'oldWorld|s1',
-      shipTypeIds: const ['carrack', 'fluyte'],
+      shipTypeIds: const ['carrack', 'carrack', 'carrack', 'fluyte'],
     );
 
     await openDialog(
@@ -86,13 +87,108 @@ void main() {
       onConfirm: (_) {},
     );
 
-    expect(buttonEnabled(tester, '<'), isFalse);
-    expect(buttonEnabled(tester, '>'), isFalse);
-    expect(buttonEnabled(tester, '<<'), isFalse);
-    expect(buttonEnabled(tester, '>>'), isFalse);
+    expect(find.text('carrack (3)'), findsOneWidget);
+    await tester.tap(find.byKey(CtTransferListKeys.leftMoveOne('carrack')));
+    await tester.pump();
+
+    expect(find.text('carrack (2)'), findsOneWidget);
+    expect(find.text('carrack (1)'), findsOneWidget);
+    expect(find.text('fluyte (1)'), findsOneWidget);
   });
 
-  testWidgets('selected type supports one and all transfers with exact counts', (
+  testWidgets(
+    'bulk >> moves all remaining of a type after a single-carrier move (non-Home)',
+    (WidgetTester tester) async {
+      final fleet = Fleet(
+        id: 'f1b',
+        ownerId: 'gp1',
+        regionId: 'oldWorld',
+        seaZoneId: 'oldWorld|s1',
+        shipTypeIds: const ['carrack', 'carrack', 'carrack', 'fluyte'],
+      );
+
+      await openDialog(
+        tester,
+        fleet: fleet,
+        game: _minimalGame(provinces: const []),
+        isHomeFleet: false,
+        onConfirm: (_) {},
+      );
+
+      await tester.tap(find.byKey(CtTransferListKeys.leftMoveOne('carrack')));
+      await tester.pump();
+      expect(find.text('carrack (2)'), findsOneWidget);
+      expect(find.text('carrack (1)'), findsOneWidget);
+
+      await tester.tap(find.byKey(CtTransferListKeys.leftMoveAll('carrack')));
+      await tester.pump();
+      expect(find.text('carrack (3)'), findsOneWidget);
+      expect(find.text('fluyte (1)'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    '<< moves all of a type from new back to original in one action',
+    (WidgetTester tester) async {
+      final fleet = Fleet(
+        id: 'f1c',
+        ownerId: 'gp1',
+        regionId: 'oldWorld',
+        seaZoneId: 'oldWorld|s1',
+        shipTypeIds: const ['carrack', 'carrack', 'carrack', 'fluyte'],
+      );
+
+      await openDialog(
+        tester,
+        fleet: fleet,
+        game: _minimalGame(provinces: const []),
+        isHomeFleet: false,
+        onConfirm: (_) {},
+      );
+
+      await tester.tap(find.byKey(CtTransferListKeys.leftMoveAll('carrack')));
+      await tester.pump();
+      expect(find.text('carrack (3)'), findsOneWidget);
+      expect(find.text('fluyte (1)'), findsOneWidget);
+
+      await tester.tap(find.byKey(CtTransferListKeys.rightMoveAll('carrack')));
+      await tester.pump();
+      expect(find.text('carrack (3)'), findsOneWidget);
+      expect(find.text('fluyte (1)'), findsOneWidget);
+      expect(find.text('carrack (2)'), findsNothing);
+      expect(find.text('carrack (1)'), findsNothing);
+    },
+  );
+
+  testWidgets('confirm sends only ships shown on new fleet side', (
+    WidgetTester tester,
+  ) async {
+    List<String>? captured;
+    final fleet = Fleet(
+      id: 'f1d',
+      ownerId: 'gp1',
+      regionId: 'oldWorld',
+      seaZoneId: 'oldWorld|s1',
+      shipTypeIds: const ['carrack', 'carrack', 'fluyte'],
+    );
+
+    await openDialog(
+      tester,
+      fleet: fleet,
+      game: _minimalGame(provinces: const []),
+      isHomeFleet: false,
+      onConfirm: (ships) => captured = ships,
+    );
+
+    await tester.tap(find.byKey(CtTransferListKeys.leftMoveOne('carrack')));
+    await tester.pump();
+    await tester.tap(find.text('Confirm Split'));
+    await tester.pumpAndSettle();
+
+    expect(captured, ['carrack']);
+  });
+
+  testWidgets('per-row controls: one and all transfers with exact counts', (
     WidgetTester tester,
   ) async {
     final fleet = Fleet(
@@ -112,19 +208,16 @@ void main() {
     );
 
     expect(find.text('carrack (2)'), findsOneWidget);
-    await tester.tap(find.text('carrack (2)'));
-    await tester.pump();
-
-    await tester.tap(find.widgetWithText(CtNinePatchButton, '>'));
+    await tester.tap(find.byKey(CtTransferListKeys.leftMoveOne('carrack')));
     await tester.pump();
     expect(find.text('carrack (1)'), findsNWidgets(2));
 
-    await tester.tap(find.widgetWithText(CtNinePatchButton, '>>'));
+    await tester.tap(find.byKey(CtTransferListKeys.leftMoveAll('carrack')));
     await tester.pump();
     expect(find.text('carrack (2)'), findsOneWidget);
     expect(find.text('carrack (1)'), findsNothing);
 
-    await tester.tap(find.widgetWithText(CtNinePatchButton, '<'));
+    await tester.tap(find.byKey(CtTransferListKeys.rightMoveOne('carrack')));
     await tester.pump();
     expect(find.text('carrack (1)'), findsNWidgets(2));
   });
@@ -148,13 +241,11 @@ void main() {
       onConfirm: (_) {},
     );
 
-    await tester.tap(find.text('fluyte (2)'));
-    await tester.pump();
-    await tester.tap(find.widgetWithText(CtNinePatchButton, '>'));
+    await tester.tap(find.byKey(CtTransferListKeys.leftMoveOne('fluyte')));
     await tester.pump();
     expect(find.text('fluyte (1)'), findsNWidgets(2));
 
-    await tester.tap(find.widgetWithText(CtNinePatchButton, '<'));
+    await tester.tap(find.byKey(CtTransferListKeys.rightMoveOne('fluyte')));
     await tester.pump();
     expect(find.text('fluyte (2)'), findsOneWidget);
     expect(find.text('fluyte (1)'), findsNothing);
@@ -180,9 +271,7 @@ void main() {
       onConfirm: (ships) => captured = ships,
     );
 
-    await tester.tap(find.text('carrack (1)'));
-    await tester.pump();
-    await tester.tap(find.widgetWithText(CtNinePatchButton, '>>'));
+    await tester.tap(find.byKey(CtTransferListKeys.leftMoveAll('carrack')));
     await tester.pump();
 
     expect(find.text('No ships'), findsOneWidget);

--- a/app/test/widgets/ct_transfer_list_test.dart
+++ b/app/test/widgets/ct_transfer_list_test.dart
@@ -13,6 +13,7 @@ void main() {
     required void Function(Map<String, int> left, Map<String, int> right)
     onConfirm,
     bool Function(Map<String, int> left, Map<String, int> right)? canConfirm,
+    Map<String, int> initialLeftCounts = const {'carrack': 2, 'fluyte': 1},
   }) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -20,7 +21,7 @@ void main() {
           body: CtTransferList(
             leftTitle: 'Original',
             rightTitle: 'New',
-            initialLeftCounts: const {'carrack': 2, 'fluyte': 1},
+            initialLeftCounts: initialLeftCounts,
             onConfirm: onConfirm,
             canConfirm: canConfirm,
             confirmLabel: 'Confirm Split',
@@ -34,44 +35,78 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  bool buttonEnabled(WidgetTester tester, String label) {
-    final button = tester.widget<CtNinePatchButton>(
-      find.widgetWithText(CtNinePatchButton, label),
-    );
+  bool buttonEnabled(WidgetTester tester, Finder finder) {
+    final button = tester.widget<CtNinePatchButton>(finder);
     return button.enabled;
   }
 
-  testWidgets('transfer controls disabled until an item is selected', (
+  testWidgets(
+    'repeated single moves transfer exactly one per tap (3 identical items)',
+    (WidgetTester tester) async {
+      await pumpTransferList(
+        tester,
+        onConfirm: (_, __) {},
+        initialLeftCounts: const {'carrack': 3},
+      );
+
+      await tester.tap(find.byKey(CtTransferListKeys.leftMoveOne('carrack')));
+      await tester.pump();
+      expect(find.text('carrack (2)'), findsOneWidget);
+      expect(find.text('carrack (1)'), findsOneWidget);
+
+      await tester.tap(find.byKey(CtTransferListKeys.leftMoveOne('carrack')));
+      await tester.pump();
+      expect(find.text('carrack (1)'), findsOneWidget);
+      expect(find.text('carrack (2)'), findsOneWidget);
+
+      await tester.tap(find.byKey(CtTransferListKeys.leftMoveAll('carrack')));
+      await tester.pump();
+      expect(find.text('carrack (3)'), findsOneWidget);
+      expect(find.text('carrack (2)'), findsNothing);
+      expect(find.text('carrack (1)'), findsNothing);
+    },
+  );
+
+  testWidgets('per-row controls move one and all without selection', (
     WidgetTester tester,
   ) async {
     await pumpTransferList(tester, onConfirm: (_, __) {});
 
-    expect(buttonEnabled(tester, '<'), isFalse);
-    expect(buttonEnabled(tester, '>'), isFalse);
-    expect(buttonEnabled(tester, '<<'), isFalse);
-    expect(buttonEnabled(tester, '>>'), isFalse);
-  });
-
-  testWidgets('selected item supports one and all transfers', (
-    WidgetTester tester,
-  ) async {
-    await pumpTransferList(tester, onConfirm: (_, __) {});
-
-    await tester.tap(find.text('carrack (2)').first);
-    await tester.pump();
-
-    await tester.tap(find.widgetWithText(CtNinePatchButton, '>'));
+    await tester.tap(find.byKey(CtTransferListKeys.leftMoveOne('carrack')));
     await tester.pump();
     expect(find.text('carrack (1)'), findsNWidgets(2));
 
-    await tester.tap(find.widgetWithText(CtNinePatchButton, '>>'));
+    await tester.tap(find.byKey(CtTransferListKeys.leftMoveAll('carrack')));
     await tester.pump();
     expect(find.text('carrack (2)'), findsOneWidget);
     expect(find.text('carrack (1)'), findsNothing);
 
-    await tester.tap(find.widgetWithText(CtNinePatchButton, '<'));
+    await tester.tap(find.byKey(CtTransferListKeys.rightMoveOne('carrack')));
     await tester.pump();
     expect(find.text('carrack (1)'), findsNWidgets(2));
+  });
+
+  testWidgets('<< on new side moves entire type back in one action', (
+    WidgetTester tester,
+  ) async {
+    await pumpTransferList(
+      tester,
+      onConfirm: (_, __) {},
+      initialLeftCounts: const {'carrack': 2, 'galleon': 1},
+    );
+
+    await tester.tap(find.byKey(CtTransferListKeys.leftMoveOne('carrack')));
+    await tester.pump();
+    await tester.tap(find.byKey(CtTransferListKeys.leftMoveAll('carrack')));
+    await tester.pump();
+    expect(find.text('carrack (2)'), findsOneWidget);
+    expect(find.text('galleon (1)'), findsOneWidget);
+
+    await tester.tap(find.byKey(CtTransferListKeys.rightMoveAll('carrack')));
+    await tester.pump();
+    expect(find.text('carrack (2)'), findsOneWidget);
+    expect(find.text('galleon (1)'), findsOneWidget);
+    expect(find.text('carrack (1)'), findsNothing);
   });
 
   testWidgets('confirm enablement follows validation callback', (
@@ -87,14 +122,24 @@ void main() {
       },
     );
 
-    expect(buttonEnabled(tester, 'Confirm Split'), isFalse);
+    expect(
+      buttonEnabled(
+        tester,
+        find.widgetWithText(CtNinePatchButton, 'Confirm Split'),
+      ),
+      isFalse,
+    );
 
-    await tester.tap(find.text('fluyte (1)'));
-    await tester.pump();
-    await tester.tap(find.widgetWithText(CtNinePatchButton, '>>'));
+    await tester.tap(find.byKey(CtTransferListKeys.leftMoveAll('fluyte')));
     await tester.pump();
 
-    expect(buttonEnabled(tester, 'Confirm Split'), isTrue);
+    expect(
+      buttonEnabled(
+        tester,
+        find.widgetWithText(CtNinePatchButton, 'Confirm Split'),
+      ),
+      isTrue,
+    );
   });
 
   testWidgets('confirm returns current left and right counts', (
@@ -111,9 +156,7 @@ void main() {
       },
     );
 
-    await tester.tap(find.text('carrack (2)').first);
-    await tester.pump();
-    await tester.tap(find.widgetWithText(CtNinePatchButton, '>'));
+    await tester.tap(find.byKey(CtTransferListKeys.leftMoveOne('carrack')));
     await tester.pump();
 
     await tester.tap(find.text('Confirm Split'));


### PR DESCRIPTION
## Summary

Addresses [#1341](https://github.com/waigore/colonizethisv3/issues/1341): split fleet could not reliably move **one** ship of a type per action because selection was a **shared toggle** on the type id (a second tap on the same type cleared selection, and duplicate labels on both columns made this easy to hit).

## Changes

- **`CtTransferList`**: Per-row `>`, `>>` on the original column and `<<`, `<` on the new column; removed the center control row and selection state. Added `CtTransferListKeys` for tests.
- **`SplitFleetDialog`**: Slightly taller list (`listHeight: 220`) for the bulkier rows.
- **`SPEC/ui/naval-units-fleet-management.md`**: Documents per-row controls (repo spec uses explicit `>>` / `<<` buttons; issue text mentioning long-press is outdated vs this spec).

## Tests

Widget coverage for acceptance criteria and proposed scenarios:

| Criterion | Test |
|-----------|------|
| One of three identical → 2 left, 1 right | `moving exactly one from three...`; `repeated single moves...` (component) |
| Other types unchanged when moving one | `fluyte (1)` assertion in first dialog test |
| Bulk moves **all remaining** of that type (non-Home anchor ship) | `bulk >> moves all remaining...` |
| `<<` moves all back in one action | `<< moves all of a type from new back...`; `<< on new side...` (component) |
| One-at-a-time and single-step back | existing `per-row controls` / `arrow semantics` |
| Home fleet move-all | unchanged |
| Confirm payload | `confirm sends only ships shown on new fleet side` |

## Closes

Fixes #1341.