### PR TITLE
Add logic logging for land movement application (#1306)

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/movement.dart
+++ b/packages/colonizethis_logic/lib/src/world/movement.dart
@@ -1,9 +1,12 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'province_lookup.dart';
 import 'topology_helpers.dart';
 import 'unit_lookup.dart';
+
+final _log = logicLogger();
 
 /// Movement validation and application.
 /// SPEC/program/movement.md
@@ -96,16 +99,36 @@ RegionData applyMoveOrdersToRegion(
   }
 
   final unitsById = Map<String, Unit>.from(unitsByIdFromRegion(regionData));
+  var ordersForRegion = 0;
+  var applied = 0;
+  var ignored = 0;
 
   for (final entry in moveOrdersByPlayerId.entries) {
     final playerId = entry.key;
     for (final order in entry.value) {
       final unit = unitsById[order.unitId];
-      if (unit == null || unit.ownerId != playerId) continue;
+      if (unit == null) {
+        continue;
+      }
+      ordersForRegion++;
+      if (unit.ownerId != playerId) {
+        ignored++;
+        _log.d(
+          'logic: movement ignored reason=owner_mismatch '
+          'unitId=${order.unitId} orderPlayerId=$playerId unitOwnerId=${unit.ownerId}',
+        );
+        continue;
+      }
       final currentProvinceId = unit.locationProvinceId;
       final destProvinceId = order.destinationProvinceId;
       if (regionId != null && ProvinceId.isPrefixed(destProvinceId) &&
           ProvinceId.regionIdFrom(destProvinceId) != regionId) {
+        ignored++;
+        _log.d(
+          'logic: movement ignored reason=region_mismatch '
+          'unitId=${order.unitId} destRegion=${ProvinceId.regionIdFrom(destProvinceId)} '
+          'expectedRegion=$regionId',
+        );
         continue; // Land move cannot cross regions.
       }
       // Normalize to prefixed form when regionId known (SPEC/game/world-model-identity.md).
@@ -123,8 +146,14 @@ RegionData applyMoveOrdersToRegion(
               ? isValidLandMoveInRegion(topology, regionId, fromLocal, toLocal)
               : isValidLandMove(topology, fromLocal, toLocal));
       if (!valid) {
+        ignored++;
+        _log.d(
+          'logic: movement ignored reason=invalid_adjacency '
+          'unitId=${order.unitId} from=$fromLocal to=$toLocal',
+        );
         continue;
       }
+      applied++;
       final isCivilian = unit.tileKey != null && unit.tileKey!.isNotEmpty;
       final firstTileInDest = regionId != null &&
               tileKeysByRegionAndProvince != null &&
@@ -140,6 +169,14 @@ RegionData applyMoveOrdersToRegion(
         unitsById[unit.id] = unit.copyWith(locationProvinceId: destFullId);
       }
     }
+  }
+
+  if (ordersForRegion > 0) {
+    final regionLabel = regionId ?? 'unspecified';
+    _log.i(
+      'logic: movement apply regionId=$regionLabel '
+      'orders=$ordersForRegion applied=$applied ignored=$ignored',
+    );
   }
 
   return RegionData(

--- a/packages/colonizethis_logic/test/movement_logging_test.dart
+++ b/packages/colonizethis_logic/test/movement_logging_test.dart
@@ -1,0 +1,148 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
+
+List<String> _movementMessages(List<LogEvent> events) => [
+      for (final e in events)
+        if (e.message.contains('logic: movement')) e.message,
+    ];
+
+void main() {
+  group('movement logging', () {
+    late List<LogEvent> capturedEvents;
+    late void Function(LogEvent) listener;
+
+    setUp(() {
+      capturedEvents = [];
+      listener = capturedEvents.add;
+      Logger.addLogListener(listener);
+      Logger.level = Level.debug;
+    });
+
+    tearDown(() {
+      Logger.removeLogListener(listener);
+      capturedEvents.clear();
+      Logger.level = Level.info;
+    });
+
+    test('applyMoveOrdersToRegion emits movement apply summary (info)', () {
+      const regionId = 'oldWorld';
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(id: 'P1', regionId: regionId, type: TopologyNodeType.province),
+          TopologyNode(id: 'P2', regionId: regionId, type: TopologyNodeType.province),
+        ],
+        edges: const [
+          TopologyEdge(id1: 'P1', id2: 'P2'),
+        ],
+      );
+
+      final region = RegionData(
+        provinces: const [
+          Province(id: 'P1', regionId: regionId, ownerId: 'p1'),
+          Province(id: 'P2', regionId: regionId, ownerId: 'p2'),
+        ],
+        units: [
+          Unit(
+            id: 'u1',
+            type: 'Regiment',
+            ownerId: 'p1',
+            locationProvinceId: 'P1',
+          ),
+        ],
+      );
+
+      final orders = {
+        'p1': [
+          const MoveOrder(unitId: 'u1', destinationProvinceId: 'P2'),
+        ],
+      };
+
+      applyMoveOrdersToRegion(
+        region,
+        topology,
+        orders,
+        regionId: regionId,
+      );
+
+      final movement = _movementMessages(capturedEvents);
+      expect(
+        movement.any(
+          (m) =>
+              m.contains('logic: movement apply') &&
+              m.contains('regionId=$regionId') &&
+              m.contains('orders=1') &&
+              m.contains('applied=1') &&
+              m.contains('ignored=0'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('applyMoveOrdersToRegion emits invalid_adjacency at debug when move rejected',
+        () {
+      const regionId = 'oldWorld';
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(id: 'P1', regionId: regionId, type: TopologyNodeType.province),
+          TopologyNode(id: 'P2', regionId: regionId, type: TopologyNodeType.province),
+          TopologyNode(id: 'P3', regionId: regionId, type: TopologyNodeType.province),
+        ],
+        edges: const [
+          TopologyEdge(id1: 'P1', id2: 'P2'),
+        ],
+      );
+
+      final region = RegionData(
+        provinces: const [
+          Province(id: 'P1', regionId: regionId, ownerId: 'p1'),
+          Province(id: 'P2', regionId: regionId, ownerId: 'p2'),
+          Province(id: 'P3', regionId: regionId, ownerId: 'p2'),
+        ],
+        units: [
+          Unit(
+            id: 'u1',
+            type: 'Regiment',
+            ownerId: 'p1',
+            locationProvinceId: 'P1',
+          ),
+        ],
+      );
+
+      final orders = {
+        'p1': [
+          const MoveOrder(unitId: 'u1', destinationProvinceId: 'P3'),
+        ],
+      };
+
+      applyMoveOrdersToRegion(
+        region,
+        topology,
+        orders,
+        regionId: regionId,
+      );
+
+      final movement = _movementMessages(capturedEvents);
+      expect(
+        movement.any(
+          (m) =>
+              m.contains('logic: movement ignored') &&
+              m.contains('reason=invalid_adjacency'),
+        ),
+        isTrue,
+      );
+      expect(
+        movement.any(
+          (m) =>
+              m.contains('logic: movement apply') &&
+              m.contains('orders=1') &&
+              m.contains('applied=0') &&
+              m.contains('ignored=1'),
+        ),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements [issue #1306](https://github.com/waigore/colonizethisv3/issues/1306): `logic:` logging for `applyMoveOrdersToRegion` per `SPEC/program/ctdev-logging.md`.

## Changes

- **`movement.dart`**: `logicLogger()` with grep-friendly messages.
  - **Info**: `logic: movement apply regionId=… orders=… applied=… ignored=…` when at least one order targets a unit in that region slice.
  - **Debug**: `logic: movement ignored reason=owner_mismatch|region_mismatch|invalid_adjacency` with compact key=value fields (no per-cell dumps).

- **`movement_logging_test.dart`**: asserts summary (info) and `invalid_adjacency` (debug), matching the pattern used for combat logging tests.

## Note on `unit_not_found`

The issue lists `unit_not_found`; it is intentionally omitted here because move orders are applied per world slice and logging on `unit == null` would duplicate one debug line per order on the non-matching region. A follow-up could add a single pass in `_runMovementPhase` if that signal is still desired.

## Testing

`flutter test packages/colonizethis_logic/test/movement_logging_test.dart`

Closes #1306.