### PR TITLE
feat(ui/tui): Handle TurnResolutionPendingIntervention (#1379)

### DIFF
--- a/SPEC/ai/dialogue-content-and-yarn.md
+++ b/SPEC/ai/dialogue-content-and-yarn.md
@@ -17,6 +17,8 @@ Dialogue **content** (lines and choices) is authored separately from logic. The 
   - **situation** or **subtype** (e.g. overture stage: `trade_consulate`, `embassy`, `nap`, `join_empire`; intervention: `minor_embassy`, `tribe_investment`);
   - Optional **era** and **variables** (e.g. offerer name, province) for localization or branching.
 
+- **intervention_choice (app):** Nodes in `assets/dialogue/intervention.yarn`: `DialoguePoint/intervention_intro`, `DialoguePoint/intervention_situation`, `DialoguePoint/intervention_reaction_intervene`, `DialoguePoint/intervention_reaction_do_nothing`, `DialoguePoint/intervention_reaction_protest`. Variables: `aggressorName`, `defenderName`, `interveningName` (strings). See [pending-intervention-overlay.md](../ui/screens/pending-intervention-overlay.md).
+
 - **App (Jenny):** The content key maps to a **Yarn node name**. Convention: `DialoguePoint/<kind>/<situation>` (e.g. `DialoguePoint/overture_target_response/embassy`). The node contains:
   - **Lines:** Speaker (leader/offerer), text (possibly with inline expressions for variables).
   - **Options:** Each option has a **destination** (next node or stop) and an **outcome tag** or **command** that the runner interprets as the game outcome (e.g. `<<Accept>>`, `<<Reject>>` for overture; `<<Intervene>>`, `<<DoNothing>>`, `<<Protest>>` for intervention).

--- a/SPEC/tui/screens/pending-intervention.md
+++ b/SPEC/tui/screens/pending-intervention.md
@@ -1,0 +1,40 @@
+# Pending intervention (ctterm)
+
+**SPEC/tui** — Dedicated screen when `resolveTurnForGame` returns `TurnResolutionPendingIntervention`. Mirrors [pending-overtures.md](pending-overtures.md) and [pending-call-to-arms.md](pending-call-to-arms.md). Program contract: [dialogue-system.md](../../program/dialogue-system.md).
+
+---
+
+## Responsibility
+
+Block the TUI until the human submits one choice per `InterventionPrompt`, then call **`resumeTurnResolutionWithInterventionDecisions`** with the same `Game`, `Orders`, topology, and tile maps as the pending call. **No Yarn runtime** in ctterm; copy is **static archaic English** aligned with [dialogue-content-and-yarn.md](../../ai/dialogue-content-and-yarn.md) (same meaning as app Yarn; TUI resolves from inline strings per TUI dialogue spec).
+
+---
+
+## Route
+
+- **Enum:** `CttermRoute.pendingIntervention`.
+- **Screen ID:** `100022` (see [ctterm.md](../ctterm.md)).
+
+---
+
+## Layout
+
+- Title: e.g. `War and intervention`.
+- Body: explain that a GP has attacked a Minor/Tribe where the player has interest; list each prompt with **aggressor / defender / your power** display names from `Game`.
+- Per row: current choice **Intervene / Do naught / Protest** (one active row).
+- Keys: **[I]** Intervene **[O]** Do naught **[P]** Protest **[Up/Down]** select row **[Enter]** submit all.
+
+---
+
+## Navigation
+
+- **Shell** does not map Escape on this route to in-game shell (blocking, same as pending overtures).
+- **App state:** `ctterm_app` holds `List<InterventionPrompt>?` and navigates here from `onEndTurn` or from resume chains when the next pending type is intervention.
+
+---
+
+## Acceptance criteria
+
+- Given `resolveTurnForGame` returns `TurnResolutionPendingIntervention` with N prompts, when the shell runs end-turn, then the app navigates to `pendingIntervention` and stores the updated `Game` plus the prompt list.
+- Given the user presses Enter with valid per-row choices, when `onInterventionDecisions` runs, then the app calls `resumeTurnResolutionWithInterventionDecisions` with N `InterventionDecision` rows matching the prompts.
+- Given resume returns `TurnResolutionPendingOvertures` or `TurnResolutionPendingCallToArms`, when the app handles the result, then the app navigates to the corresponding pending route and clears intervention state.

--- a/SPEC/ui/dialogue-presentation.md
+++ b/SPEC/ui/dialogue-presentation.md
@@ -47,6 +47,7 @@ The app presents **PendingDialoguePoint**s from the dialogue system. It uses **J
 
 - **Dialogue overlay / modal component:** Owns the DialogueRunner and a view that displays the current line and options. Receives PendingDialoguePoint(s); starts the appropriate node; on option selected, emits outcome to the game/orchestration layer which calls the resume API. Built from CtDialogShell and catalog components; no Material dialog widgets.
 - **Placement:** Managed by the game screen or a top-level orchestrator that decides modal vs overlay based on presentationMode and blocking. When turn resolution returns TurnResolutionPendingOvertures, the orchestrator converts to PendingDialoguePoint(s) and shows the dialogue (modal) until the user submits OvertureDecisions.
+- **Pending diplomacy state:** The app uses a **single** Riverpod notifier for at most one blocking gate (overtures, intervention, or call to arms); see [pending-diplomacy-state.md](pending-diplomacy-state.md). `GameScreen` shows one overlay according to that state.
 
 ---
 

--- a/SPEC/ui/pending-diplomacy-state.md
+++ b/SPEC/ui/pending-diplomacy-state.md
@@ -1,0 +1,35 @@
+# Pending diplomacy state (Flutter Riverpod)
+
+**SPEC/ui** — Single source of truth for **one** blocking diplomacy gate from turn resolution. Program dialogue contract: [dialogue-system.md](../program/dialogue-system.md).
+
+---
+
+## Responsibility
+
+Expose a **discriminated** pending state so `GameScreen` shows exactly one of: overture dialogue, intervention dialogue, or call-to-arms dialogue. Turn resolution may return only **one** pending kind at a time; resuming may chain to another kind — the provider is **replaced** wholesale on each result.
+
+---
+
+## Model
+
+Sealed variants (conceptual):
+
+- **Overtures** — `List<OvertureOffer>`.
+- **Intervention** — `List<InterventionPrompt>` (logic types).
+- **Call to arms** — `List<CallToArmsPending>`.
+
+`null` means no pending diplomacy gate.
+
+---
+
+## API
+
+Notifier methods: `setOvertures`, `setIntervention`, `setCallToArms`, `clear`. Setting any variant **clears** the others implicitly (single state field).
+
+---
+
+## Acceptance criteria
+
+- Given the notifier is cleared, when any consumer reads the provider, then the value is null.
+- Given the notifier holds an intervention state, when `setOvertures` is called, then the provider exposes only overture state (previous intervention is discarded).
+- Given `GameScreen` applies `TurnResolutionComplete`, when the notifier is cleared, then no diplomacy overlay is visible.

--- a/SPEC/ui/screens/pending-intervention-overlay.md
+++ b/SPEC/ui/screens/pending-intervention-overlay.md
@@ -1,0 +1,52 @@
+# Pending intervention overlay (Flutter)
+
+**SPEC/ui** — Blocking turn-resolution UI when `TurnResolutionPendingIntervention` is returned. Technical contract: [dialogue-system.md](../../program/dialogue-system.md). Yarn keys: [dialogue-content-and-yarn.md](../../ai/dialogue-content-and-yarn.md). Event bus: [app-event-bus.md](../../program/app-event-bus.md).
+
+---
+
+## Responsibility
+
+Present **all** `InterventionPrompt` rows for the current pending batch before the turn advances. Copy is **Jenny + Yarn** (archaic register, aligned with game-start intro). After each player choice, show a short **aggressor reaction** line (positive/neutral/negative tone per choice). On completion, the orchestration layer calls `GameService.resumeInterventionDecisions` with a matching `List<InterventionDecision>`.
+
+---
+
+## State ownership
+
+- **Riverpod:** A single `pendingDiplomacyProvider` holds **at most one** blocking diplomacy gate (`overtures` \| `intervention` \| `call_to_arms`). See [pending-diplomacy-state.md](../pending-diplomacy-state.md).
+- **GameScreen** watches that provider and stacks **one** blocking overlay. No cross-panel callbacks; optional `InterventionRequiredEvent` is informational only (tests / future listeners).
+
+---
+
+## Layout (modal)
+
+- **Frame:** `CtDialogShell` centered over the game; `Material` scrim `Colors.black54`.
+- **Phases:** (1) Yarn intro node — line(s) + Continue; (2) Per prompt: Yarn situation node (variables: aggressor, defender, intervening names) + Continue; (3) Three `CtNinePatchButton` actions: **Intervene**, **Do naught**, **Diplomatic protest** → map to `InterventionChoice`; (4) Yarn reaction node for that choice + Continue; repeat until all prompts decided; (5) implicit submit — parent receives full `InterventionDecision` list.
+
+---
+
+## Yarn nodes (app)
+
+| Node | Role |
+|------|------|
+| `DialoguePoint/intervention_intro` | Opening; archaic; sets tone. |
+| `DialoguePoint/intervention_situation` | Per-prompt context; uses `{$aggressorName}`, `{$defenderName}`, `{$interveningName}`. |
+| `DialoguePoint/intervention_reaction_intervene` | Hostile / negative aggressor tone. |
+| `DialoguePoint/intervention_reaction_do_nothing` | Dismissive / neutral tone. |
+| `DialoguePoint/intervention_reaction_protest` | Cold formal / restrained negative tone. |
+
+Variables are set on `YarnProject.variables` before `startDialogue`.
+
+---
+
+## Widgetbook
+
+- **Use case:** `InterventionDialogueOverlay` with `skipIntroForTest: true`, one synthetic prompt, placeholder `Game` with matching player/minor ids, dark colonial theme.
+
+---
+
+## Acceptance criteria
+
+- Given `pendingDiplomacyProvider` holds `PendingDiplomacyInterventionState` with N prompts, when the overlay mounts, then the UI layer runs the intro Yarn node before showing the first prompt’s situation and choices.
+- Given the player has selected a choice for prompt k, when the reaction Yarn node finishes, then the UI layer either advances to prompt k+1 or, if k+1 == N, invokes the callback with N `InterventionDecision` values whose triples match the prompts and whose `InterventionChoice` values match the selections.
+- Given Yarn fails to load, when the overlay is shown, then the UI layer shows an error affordance and still allows submitting decisions (degraded path) so the player is not soft-locked.
+- Given turn resolution returns a different pending type after intervention resume, when the parent applies the result, then `pendingDiplomacyProvider` reflects only the new pending type (never two kinds at once).

--- a/app/assets/dialogue/intervention.yarn
+++ b/app/assets/dialogue/intervention.yarn
@@ -1,0 +1,30 @@
+title: DialoguePoint/intervention_intro
+---
+Heavy tidings cross thy desk from distant shores. A fellow sovereign hath drawn sword against a lesser state wherein thy nation maintaineth commerce, embassy, or solemn bond. The Crown looketh to thee: thou must answer ere the courts of Christendom take the measure of thy honour.
+Each matter before thee shall be judged in turn.
+-> Continue
+===
+
+title: DialoguePoint/intervention_situation
+---
+Dispatch from thy minister: {$aggressorName} hath proclaimed open war against {$defenderName}. Thine own envoy standeth witness; the interest of {$interveningName} cannot feign ignorance.
+-> Continue
+===
+
+title: DialoguePoint/intervention_reaction_intervene
+---
+{$aggressorName} rendeth the air with oaths. "So!" he crieth. "Thou wouldst take arms against me? Know then that I account thee mine enemy from this hour, and thy protestations shall avail thee naught."
+-> Continue
+===
+
+title: DialoguePoint/intervention_reaction_do_nothing
+---
+{$aggressorName} smirketh as if at a court fool. "I thought thee a power of some account; thou art but parchment, wax, and delay." Thy ministers murmur at the slight, yet none may say thou didst overleap thy counsel unadvisedly.
+-> Continue
+===
+
+title: DialoguePoint/intervention_reaction_protest
+---
+{$aggressorName} returneth a chill and formal note. "Thy protest is entered in the record. Speak softly; the world hath long ears, and little mercy for scolds who lack the stomach for steel."
+-> Continue
+===

--- a/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
@@ -1,0 +1,383 @@
+import 'dart:async';
+
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:jenny/jenny.dart';
+import 'package:logger/logger.dart';
+
+import '../../../../widgets/ct_dialog_shell.dart';
+import '../../../../widgets/ct_nine_patch_button.dart';
+import 'ct_dialogue_view.dart';
+
+/// Blocking intervention dialogue: Yarn intro, per-prompt situation + reaction, three choices.
+/// SPEC/ui/screens/pending-intervention-overlay.md, SPEC/ai/dialogue-content-and-yarn.md.
+class InterventionDialogueOverlay extends StatefulWidget {
+  const InterventionDialogueOverlay({
+    super.key,
+    required this.game,
+    required this.prompts,
+    required this.onDecisions,
+    required this.child,
+    this.logger,
+    this.skipIntroForTest = false,
+    this.assetBundle,
+  });
+
+  final Game game;
+  final List<InterventionPrompt> prompts;
+  final void Function(List<InterventionDecision> decisions) onDecisions;
+  final Widget child;
+  final Logger? logger;
+  final bool skipIntroForTest;
+  final AssetBundle? assetBundle;
+
+  @override
+  State<InterventionDialogueOverlay> createState() =>
+      _InterventionDialogueOverlayState();
+}
+
+class _InterventionDialogueOverlayState extends State<InterventionDialogueOverlay> {
+  static const String _kAsset = 'assets/dialogue/intervention.yarn';
+  static const String _kIntro = 'DialoguePoint/intervention_intro';
+  static const String _kSituation = 'DialoguePoint/intervention_situation';
+  static const String _kReactIntervene =
+      'DialoguePoint/intervention_reaction_intervene';
+  static const String _kReactNothing =
+      'DialoguePoint/intervention_reaction_do_nothing';
+  static const String _kReactProtest =
+      'DialoguePoint/intervention_reaction_protest';
+
+  YarnProject? _project;
+  DialogueRunner? _runner;
+  CtDialogueView? _view;
+  Object? _loadError;
+  bool _yarnUiActive = false;
+  bool _awaitingChoice = false;
+  Completer<InterventionChoice>? _choiceCompleter;
+  final List<InterventionDecision> _decisions = [];
+  int _promptIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_runFlow());
+  }
+
+  Future<void> _runFlow() async {
+    final log = widget.logger ?? Logger();
+    try {
+      final bundle = widget.assetBundle ?? rootBundle;
+      final text = await bundle.loadString(_kAsset);
+      final project = YarnProject()..parse(text);
+      for (final node in [
+        _kIntro,
+        _kSituation,
+        _kReactIntervene,
+        _kReactNothing,
+        _kReactProtest,
+      ]) {
+        if (!project.nodes.containsKey(node)) {
+          throw StateError('Intervention node "$node" missing in $_kAsset');
+        }
+      }
+      final view = CtDialogueView(logger: log);
+      final runner = DialogueRunner(
+        yarnProject: project,
+        dialogueViews: [view],
+      );
+      if (!mounted) return;
+      setState(() {
+        _project = project;
+        _runner = runner;
+        _view = view;
+        view.onStateChanged = (line, choice) {
+          if (mounted) setState(() {});
+        };
+      });
+
+      if (widget.prompts.isEmpty) {
+        widget.onDecisions(const []);
+        return;
+      }
+
+      if (!widget.skipIntroForTest) {
+        setState(() => _yarnUiActive = true);
+        await runner.startDialogue(_kIntro);
+        if (!mounted) return;
+      }
+
+      for (var i = 0; i < widget.prompts.length; i++) {
+        if (!mounted) return;
+        _promptIndex = i;
+        final prompt = widget.prompts[i];
+        _setFactionVariables(project, prompt);
+        setState(() => _yarnUiActive = true);
+        await runner.startDialogue(_kSituation);
+        if (!mounted) return;
+
+        final completer = Completer<InterventionChoice>();
+        _choiceCompleter = completer;
+        setState(() {
+          _yarnUiActive = false;
+          _awaitingChoice = true;
+        });
+        final choice = await completer.future;
+        if (!mounted) return;
+        setState(() => _awaitingChoice = false);
+        _choiceCompleter = null;
+
+        _decisions.add(
+          InterventionDecision(
+            aggressorGpId: prompt.aggressorGpId,
+            defenderMinorOrTribeId: prompt.defenderMinorOrTribeId,
+            interveningGpId: prompt.interveningGpId,
+            choice: choice,
+          ),
+        );
+
+        project.variables.setVariable(
+          'aggressorName',
+          _factionDisplayName(widget.game, prompt.aggressorGpId),
+        );
+        setState(() => _yarnUiActive = true);
+        await runner.startDialogue(_reactionNodeFor(choice));
+        if (!mounted) return;
+        setState(() => _yarnUiActive = false);
+      }
+
+      if (!mounted) return;
+      widget.onDecisions(List<InterventionDecision>.from(_decisions));
+    } catch (e, st) {
+      log.e(
+        'ui:dialogue: intervention flow failed',
+        error: e,
+        stackTrace: st,
+      );
+      if (mounted) setState(() => _loadError = e);
+    }
+  }
+
+  void _setFactionVariables(YarnProject project, InterventionPrompt prompt) {
+    project.variables.setVariable(
+      'aggressorName',
+      _factionDisplayName(widget.game, prompt.aggressorGpId),
+    );
+    project.variables.setVariable(
+      'defenderName',
+      _factionDisplayName(widget.game, prompt.defenderMinorOrTribeId),
+    );
+    project.variables.setVariable(
+      'interveningName',
+      _factionDisplayName(widget.game, prompt.interveningGpId),
+    );
+  }
+
+  static String _reactionNodeFor(InterventionChoice choice) {
+    switch (choice) {
+      case InterventionChoice.intervene:
+        return _kReactIntervene;
+      case InterventionChoice.doNothing:
+        return _kReactNothing;
+      case InterventionChoice.protest:
+        return _kReactProtest;
+    }
+  }
+
+  static String _factionDisplayName(Game game, String factionId) {
+    for (final p in game.players) {
+      if (p.id == factionId) return p.displayName;
+    }
+    for (final m in game.minorNations) {
+      if (m.id == factionId) return m.displayName ?? m.id;
+    }
+    for (final t in game.tribes) {
+      if (t.id == factionId) return t.displayName ?? t.id;
+    }
+    return factionId;
+  }
+
+  void _pick(InterventionChoice choice) {
+    final c = _choiceCompleter;
+    if (c != null && !c.isCompleted) {
+      c.complete(choice);
+    }
+  }
+
+  void _degradedSubmitDoNothing() {
+    final out = <InterventionDecision>[];
+    for (final p in widget.prompts) {
+      out.add(
+        InterventionDecision(
+          aggressorGpId: p.aggressorGpId,
+          defenderMinorOrTribeId: p.defenderMinorOrTribeId,
+          interveningGpId: p.interveningGpId,
+          choice: InterventionChoice.doNothing,
+        ),
+      );
+    }
+    widget.onDecisions(out);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loadError != null) {
+      return Stack(
+        children: [
+          widget.child,
+          Material(
+            color: Colors.black54,
+            child: Center(
+              child: CtDialogShell(
+                maxWidth: 520,
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Text(
+                        'Could not load intervention dialogue: $_loadError',
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        'Submit all responses as “Do naught” to continue.',
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                      const SizedBox(height: 16),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: CtNinePatchButton(
+                          onPressed: _degradedSubmitDoNothing,
+                          child: const Text('Continue'),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    if (_project == null || _runner == null || _view == null) {
+      return Stack(
+        children: [
+          widget.child,
+          Material(
+            color: Colors.black54,
+            child: Center(
+              child: CtDialogShell(
+                child: const Padding(
+                  padding: EdgeInsets.all(24),
+                  child: CircularProgressIndicator(),
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    Widget? dialoguePanel;
+    if (_yarnUiActive) {
+      final line = _view!.currentLine;
+      final choice = _view!.currentChoice;
+      dialoguePanel = CtDialogShell(
+        maxWidth: 520,
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              if (line != null) ...[
+                Text(
+                  line.text,
+                  style: Theme.of(context).textTheme.bodyLarge,
+                ),
+                const SizedBox(height: 16),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: CtNinePatchButton(
+                    onPressed: () => _view!.advanceLine(),
+                    child: const Text('Continue'),
+                  ),
+                ),
+              ] else if (choice != null) ...[
+                ...choice.options.asMap().entries.map(
+                  (entry) => Padding(
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: CtNinePatchButton(
+                      onPressed: () => _view!.selectOption(entry.key),
+                      child: Text(entry.value.text),
+                    ),
+                  ),
+                ),
+              ] else
+                const Center(child: CircularProgressIndicator()),
+            ],
+          ),
+        ),
+      );
+    } else if (_awaitingChoice) {
+      final prompt = widget.prompts[_promptIndex];
+      dialoguePanel = CtDialogShell(
+        maxWidth: 520,
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Thy resolution (${_promptIndex + 1} of ${widget.prompts.length})',
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                '${_factionDisplayName(widget.game, prompt.aggressorGpId)} '
+                'against ${_factionDisplayName(widget.game, prompt.defenderMinorOrTribeId)}. '
+                'Thou speakest for ${_factionDisplayName(widget.game, prompt.interveningGpId)}.',
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 16),
+              CtNinePatchButton(
+                onPressed: () => _pick(InterventionChoice.intervene),
+                child: const Text('Intervene with force'),
+              ),
+              const SizedBox(height: 8),
+              CtNinePatchButton(
+                onPressed: () => _pick(InterventionChoice.doNothing),
+                child: const Text('Do naught'),
+              ),
+              const SizedBox(height: 8),
+              CtNinePatchButton(
+                onPressed: () => _pick(InterventionChoice.protest),
+                child: const Text('Diplomatic protest'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (dialoguePanel == null) {
+      return widget.child;
+    }
+
+    return Stack(
+      children: [
+        widget.child,
+        Material(
+          color: Colors.black54,
+          child: Center(child: dialoguePanel),
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -19,6 +19,7 @@ import '../../../widgets/game_to_ui_bus_listener.dart';
 
 import '../dialogue/call_to_arms_dialogue_overlay.dart';
 import '../dialogue/game_start_intro_overlay.dart';
+import '../dialogue/intervention_dialogue_overlay.dart';
 import '../dialogue/overture_dialogue_overlay.dart';
 import 'game_canvas.dart';
 import 'game_map_area.dart';
@@ -77,6 +78,27 @@ Future<bool> _showExitToMainMenuConfirmDialog(BuildContext context) async {
   return shouldExit ?? false;
 }
 
+void _applyTurnResolutionResult(WidgetRef ref, TurnResolutionResult result) {
+  final gameN = ref.read(currentGameProvider.notifier);
+  final ordersN = ref.read(currentOrdersProvider.notifier);
+  final dipN = ref.read(pendingDiplomacyProvider.notifier);
+  switch (result) {
+    case TurnResolutionComplete():
+      gameN.setGame(result.game);
+      ordersN.clear();
+      dipN.clear();
+    case TurnResolutionPendingOvertures():
+      gameN.setGame(result.game);
+      dipN.setOvertures(result.pendingOvertures);
+    case TurnResolutionPendingIntervention():
+      gameN.setGame(result.game);
+      dipN.setIntervention(result.pendingInterventions);
+    case TurnResolutionPendingCallToArms():
+      gameN.setGame(result.game);
+      dipN.setCallToArms(result.pendingCallToArms);
+  }
+}
+
 void _navigateToMainMenu(BuildContext context) {
   var foundShellRoute = false;
   final navigator = Navigator.of(context);
@@ -105,8 +127,7 @@ class GameScreen extends ConsumerWidget {
         game != null && victory == null && mapViewData == null;
     final introShownIds = ref.watch(gameIdsWithIntroShownProvider);
     final showIntro = game != null && !introShownIds.contains(game.id);
-    final pendingOvertures = ref.watch(pendingOverturesProvider);
-    final pendingCallToArms = ref.watch(pendingCallToArmsProvider);
+    final pendingDiplomacy = ref.watch(pendingDiplomacyProvider);
     Widget content = Stack(
       children: [
         if (mapViewData != null && game != null)
@@ -131,20 +152,7 @@ class GameScreen extends ConsumerWidget {
                 final service = ref.read(gameServiceProvider);
                 final orders = ref.read(currentOrdersProvider);
                 final result = service.runTurnResolution(game, orders: orders);
-                if (result is TurnResolutionComplete) {
-                  ref.read(currentGameProvider.notifier).setGame(result.game);
-                  ref.read(currentOrdersProvider.notifier).clear();
-                } else if (result is TurnResolutionPendingOvertures) {
-                  ref.read(currentGameProvider.notifier).setGame(result.game);
-                  ref
-                      .read(pendingOverturesProvider.notifier)
-                      .setPending(result.pendingOvertures);
-                } else if (result is TurnResolutionPendingCallToArms) {
-                  ref.read(currentGameProvider.notifier).setGame(result.game);
-                  ref
-                      .read(pendingCallToArmsProvider.notifier)
-                      .setPending(result.pendingCallToArms);
-                }
+                _applyTurnResolutionResult(ref, result);
               },
               child: Text(
                 appL10n(context).game_nextTurnButton(
@@ -176,73 +184,61 @@ class GameScreen extends ConsumerWidget {
       );
     }
 
-    if (game != null &&
-        pendingOvertures != null &&
-        pendingOvertures.isNotEmpty) {
-      content = OvertureDialogueOverlay(
-        game: game,
-        pendingOvertures: pendingOvertures,
-        onDecisions: (decisions) {
-          final service = ref.read(gameServiceProvider);
-          final orders = ref.read(currentOrdersProvider);
-          final result = service.resumeOvertureDecisions(
-            game,
-            pendingOvertures,
-            decisions,
-            orders,
+    if (game != null && pendingDiplomacy != null) {
+      switch (pendingDiplomacy) {
+        case PendingDiplomacyOvertures(:final offers) when offers.isNotEmpty:
+          content = OvertureDialogueOverlay(
+            game: game,
+            pendingOvertures: offers,
+            onDecisions: (decisions) {
+              final service = ref.read(gameServiceProvider);
+              final orders = ref.read(currentOrdersProvider);
+              final result = service.resumeOvertureDecisions(
+                game,
+                offers,
+                decisions,
+                orders,
+              );
+              _applyTurnResolutionResult(ref, result);
+            },
+            child: content,
           );
-          ref.read(pendingOverturesProvider.notifier).clear();
-          if (result is TurnResolutionComplete) {
-            ref.read(currentGameProvider.notifier).setGame(result.game);
-            ref.read(currentOrdersProvider.notifier).clear();
-          } else if (result is TurnResolutionPendingOvertures) {
-            ref.read(currentGameProvider.notifier).setGame(result.game);
-            ref
-                .read(pendingOverturesProvider.notifier)
-                .setPending(result.pendingOvertures);
-          } else if (result is TurnResolutionPendingCallToArms) {
-            ref.read(currentGameProvider.notifier).setGame(result.game);
-            ref
-                .read(pendingCallToArmsProvider.notifier)
-                .setPending(result.pendingCallToArms);
-          }
-        },
-        child: content,
-      );
-    }
-
-    if (game != null &&
-        pendingCallToArms != null &&
-        pendingCallToArms.isNotEmpty) {
-      content = CallToArmsDialogueOverlay(
-        game: game,
-        pending: pendingCallToArms,
-        onDecisions: (decisions) {
-          final service = ref.read(gameServiceProvider);
-          final orders = ref.read(currentOrdersProvider);
-          final result = service.resumeCallToArmsDecisions(
-            game,
-            decisions,
-            orders,
+        case PendingDiplomacyIntervention(:final prompts)
+            when prompts.isNotEmpty:
+          content = InterventionDialogueOverlay(
+            game: game,
+            prompts: prompts,
+            onDecisions: (decisions) {
+              final service = ref.read(gameServiceProvider);
+              final orders = ref.read(currentOrdersProvider);
+              final result = service.resumeInterventionDecisions(
+                game,
+                decisions,
+                orders,
+              );
+              _applyTurnResolutionResult(ref, result);
+            },
+            child: content,
           );
-          ref.read(pendingCallToArmsProvider.notifier).clear();
-          if (result is TurnResolutionComplete) {
-            ref.read(currentGameProvider.notifier).setGame(result.game);
-            ref.read(currentOrdersProvider.notifier).clear();
-          } else if (result is TurnResolutionPendingOvertures) {
-            ref.read(currentGameProvider.notifier).setGame(result.game);
-            ref
-                .read(pendingOverturesProvider.notifier)
-                .setPending(result.pendingOvertures);
-          } else if (result is TurnResolutionPendingCallToArms) {
-            ref.read(currentGameProvider.notifier).setGame(result.game);
-            ref
-                .read(pendingCallToArmsProvider.notifier)
-                .setPending(result.pendingCallToArms);
-          }
-        },
-        child: content,
-      );
+        case PendingDiplomacyCallToArms(:final pending) when pending.isNotEmpty:
+          content = CallToArmsDialogueOverlay(
+            game: game,
+            pending: pending,
+            onDecisions: (decisions) {
+              final service = ref.read(gameServiceProvider);
+              final orders = ref.read(currentOrdersProvider);
+              final result = service.resumeCallToArmsDecisions(
+                game,
+                decisions,
+                orders,
+              );
+              _applyTurnResolutionResult(ref, result);
+            },
+            child: content,
+          );
+        case _:
+          break;
+      }
     }
 
     return PopScope(

--- a/app/lib/providers/games_provider.dart
+++ b/app/lib/providers/games_provider.dart
@@ -125,18 +125,45 @@ final gameIdsWithIntroShownProvider =
       GameIdsWithIntroShownNotifier.new,
     );
 
-/// When non-null, turn resolution is suspended; user must accept/reject overtures.
-/// SPEC/program/dialogue-system.md, SPEC/ai/dialogue-management.md.
-class PendingOverturesNotifier extends Notifier<List<OvertureOffer>?> {
-  PendingOverturesNotifier([this._initial]);
+/// At most one blocking diplomacy gate from turn resolution (overture, intervention, CTA).
+/// SPEC/ui/pending-diplomacy-state.md, SPEC/program/dialogue-system.md.
+sealed class PendingDiplomacyState {
+  const PendingDiplomacyState();
+}
 
-  final List<OvertureOffer>? _initial;
+final class PendingDiplomacyOvertures extends PendingDiplomacyState {
+  const PendingDiplomacyOvertures(this.offers);
+  final List<OvertureOffer> offers;
+}
+
+final class PendingDiplomacyIntervention extends PendingDiplomacyState {
+  const PendingDiplomacyIntervention(this.prompts);
+  final List<InterventionPrompt> prompts;
+}
+
+final class PendingDiplomacyCallToArms extends PendingDiplomacyState {
+  const PendingDiplomacyCallToArms(this.pending);
+  final List<CallToArmsPending> pending;
+}
+
+class PendingDiplomacyNotifier extends Notifier<PendingDiplomacyState?> {
+  PendingDiplomacyNotifier([this._initial]);
+
+  final PendingDiplomacyState? _initial;
 
   @override
-  List<OvertureOffer>? build() => _initial;
+  PendingDiplomacyState? build() => _initial;
 
-  void setPending(List<OvertureOffer>? overtures) {
-    state = overtures;
+  void setOvertures(List<OvertureOffer> offers) {
+    state = PendingDiplomacyOvertures(offers);
+  }
+
+  void setIntervention(List<InterventionPrompt> prompts) {
+    state = PendingDiplomacyIntervention(prompts);
+  }
+
+  void setCallToArms(List<CallToArmsPending> pending) {
+    state = PendingDiplomacyCallToArms(pending);
   }
 
   void clear() {
@@ -144,30 +171,7 @@ class PendingOverturesNotifier extends Notifier<List<OvertureOffer>?> {
   }
 }
 
-final pendingOverturesProvider =
-    NotifierProvider<PendingOverturesNotifier, List<OvertureOffer>?>(
-      PendingOverturesNotifier.new,
-    );
-
-/// When non-null, turn resolution is suspended; user must join or refuse call to arms.
-class PendingCallToArmsNotifier extends Notifier<List<CallToArmsPending>?> {
-  PendingCallToArmsNotifier([this._initial]);
-
-  final List<CallToArmsPending>? _initial;
-
-  @override
-  List<CallToArmsPending>? build() => _initial;
-
-  void setPending(List<CallToArmsPending>? value) {
-    state = value;
-  }
-
-  void clear() {
-    state = null;
-  }
-}
-
-final pendingCallToArmsProvider =
-    NotifierProvider<PendingCallToArmsNotifier, List<CallToArmsPending>?>(
-      PendingCallToArmsNotifier.new,
+final pendingDiplomacyProvider =
+    NotifierProvider<PendingDiplomacyNotifier, PendingDiplomacyState?>(
+      PendingDiplomacyNotifier.new,
     );

--- a/app/lib/widgetbook/catalog.dart
+++ b/app/lib/widgetbook/catalog.dart
@@ -19,6 +19,7 @@ import '../features/game/widgets/province_sea_zone_detail_overlay.dart';
 import '../features/game/widgets/province_overlay_demo_data.dart';
 import '../features/game/widgets/tech_tree_widget.dart';
 import '../features/game/widgets/technology_screen.dart';
+import '../features/game/dialogue/intervention_dialogue_overlay.dart';
 import '../features/game/widgets/train_civilians_dialog.dart';
 import '../features/game/widgets/train_military_dialog.dart';
 import '../widgets/debug_init_game.dart';
@@ -67,6 +68,7 @@ class CtWidgetbookApp extends StatelessWidget {
         ...navalUnitsPanelDirectories,
         ...diplomacyPanelDirectories,
         ...techTreeDirectories,
+        ...interventionDialogueDirectories,
       ],
       lightTheme: AppThemes.colonial,
       darkTheme: AppThemes.colonial,
@@ -591,6 +593,63 @@ List<WidgetbookNode> get techTreeDirectories => [
             home: Scaffold(
               appBar: AppBar(title: const Text('Tech Tree')),
               body: TechTreeWidget(game: midGame, player: midGamePlayer),
+            ),
+          );
+        },
+      ),
+    ],
+  ),
+];
+
+/// Intervention blocking dialogue. SPEC/ui/screens/pending-intervention-overlay.md.
+List<WidgetbookNode> get interventionDialogueDirectories => [
+  WidgetbookFolder(
+    name: 'Dialogue',
+    children: [
+      WidgetbookUseCase(
+        name: 'InterventionDialogueOverlay',
+        builder: (context) {
+          final game = Game(
+            id: 'wb_iv',
+            worldState: const WorldState(
+              turnState: TurnState(phase: TurnPhase.orders, turnNumber: 3),
+              oldWorld: RegionData(),
+              newWorld: RegionData(),
+            ),
+            players: const [
+              Player(
+                id: 'spain',
+                displayName: 'Spain',
+                isHuman: false,
+                treasury: 0,
+              ),
+              Player(
+                id: 'portugal',
+                displayName: 'Portugal',
+                isHuman: true,
+                treasury: 0,
+              ),
+            ],
+            minorNations: const [
+              MinorNation(id: 'minorca', displayName: 'Minorca'),
+            ],
+          );
+          return MaterialApp(
+            theme: AppThemes.colonial,
+            home: Scaffold(
+              body: InterventionDialogueOverlay(
+                game: game,
+                prompts: const [
+                  InterventionPrompt(
+                    aggressorGpId: 'spain',
+                    defenderMinorOrTribeId: 'minorca',
+                    interveningGpId: 'portugal',
+                  ),
+                ],
+                skipIntroForTest: true,
+                onDecisions: (_) {},
+                child: const Center(child: Text('Game shell')),
+              ),
             ),
           );
         },

--- a/app/test/game_screen_overture_pending_test.dart
+++ b/app/test/game_screen_overture_pending_test.dart
@@ -35,8 +35,10 @@ void main() {
           gameIdsWithIntroShownProvider.overrideWith(
             () => GameIdsWithIntroShownNotifier({game.id}),
           ),
-          pendingOverturesProvider.overrideWith(
-            () => PendingOverturesNotifier(pending),
+          pendingDiplomacyProvider.overrideWith(
+            () => PendingDiplomacyNotifier(
+              PendingDiplomacyOvertures(pending),
+            ),
           ),
         ],
         child: MaterialApp(

--- a/app/test/game_screen_turn_resolution_branches_test.dart
+++ b/app/test/game_screen_turn_resolution_branches_test.dart
@@ -44,6 +44,32 @@ class _PendingTurnGameService extends GameService {
   }
 }
 
+class _PendingInterventionGameService extends GameService {
+  _PendingInterventionGameService(super.box, super.adapter);
+
+  @override
+  TurnResolutionResult runTurnResolution(
+    Game current, {
+    Orders? orders,
+    Orders? aiOrders,
+    MapTopology? topology,
+    Map<String, TileMapResult>? tileMapByRegion,
+    void Function(GameEvent)? onGameEvent,
+  }) {
+    final humanId = current.players.firstWhere((p) => p.isHuman).id;
+    return TurnResolutionPendingIntervention(
+      game: current,
+      pendingInterventions: [
+        InterventionPrompt(
+          aggressorGpId: 'aggressor_gp',
+          defenderMinorOrTribeId: 'minor_1',
+          interveningGpId: humanId,
+        ),
+      ],
+    );
+  }
+}
+
 void main() {
   suppressLogsForTests();
 
@@ -101,9 +127,70 @@ void main() {
 
       final container =
           ProviderScope.containerOf(tester.element(find.byType(GameScreen)));
-      final pending = container.read(pendingOverturesProvider);
-      expect(pending, isNotNull);
-      expect(pending, isNotEmpty);
+      final pending = container.read(pendingDiplomacyProvider);
+      expect(pending, isA<PendingDiplomacyOvertures>());
+      expect((pending! as PendingDiplomacyOvertures).offers, isNotEmpty);
+    },
+    timeout: const Timeout(Duration(seconds: 30)),
+  );
+
+  testWidgets(
+    'GameScreen Next turn sets pending intervention when resolution returns pending',
+    (WidgetTester tester) async {
+      final game = Game(
+        id: 'turn_pending_intervention_ui',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [
+          Player(
+            id: 'gp_human',
+            displayName: 'Human',
+            isHuman: true,
+            treasury: 0,
+          ),
+        ],
+        minorNations: const [
+          MinorNation(
+            id: 'minor_1',
+            displayName: 'Minorca',
+            capitalProvinceId: 'oldWorld|p1',
+          ),
+        ],
+      );
+
+      final service = _PendingInterventionGameService(box, GameSaveAdapter());
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gamesBoxProvider.overrideWith((ref) => box),
+            gameServiceProvider.overrideWith((ref) => service),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+            mapViewDataProvider.overrideWith((ref) => null),
+            gameIdsWithIntroShownProvider.overrideWith(
+              () => GameIdsWithIntroShownNotifier({game.id}),
+            ),
+          ],
+          child: MaterialApp(
+            theme: AppThemes.colonial,
+            home: const GameScreen(),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      await tester.tap(find.textContaining('Next turn').last);
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final container =
+          ProviderScope.containerOf(tester.element(find.byType(GameScreen)));
+      final pending = container.read(pendingDiplomacyProvider);
+      expect(pending, isA<PendingDiplomacyIntervention>());
+      expect((pending! as PendingDiplomacyIntervention).prompts, isNotEmpty);
     },
     timeout: const Timeout(Duration(seconds: 30)),
   );

--- a/app/test/game_service_test.dart
+++ b/app/test/game_service_test.dart
@@ -48,6 +48,40 @@ class _PendingOverturesGameService extends GameService {
   }
 }
 
+class _PendingInterventionGameService extends GameService {
+  _PendingInterventionGameService(super.box, super.adapter);
+
+  @override
+  TurnResolutionResult runTurnResolution(
+    Game current, {
+    Orders? orders,
+    Orders? aiOrders,
+    MapTopology? topology,
+    Map<String, TileMapResult>? tileMapByRegion,
+    void Function(GameEvent)? onGameEvent,
+  }) {
+    final humanId = current.players.firstWhere((p) => p.isHuman).id;
+    final prompts = <Object>[
+      InterventionPrompt(
+        aggressorGpId: 'gp2',
+        defenderMinorOrTribeId: 'minor_x',
+        interveningGpId: humanId,
+      ),
+    ];
+    eventBus?.emit(InterventionRequiredEvent(prompts: prompts));
+    return TurnResolutionPendingIntervention(
+      game: current,
+      pendingInterventions: [
+        InterventionPrompt(
+          aggressorGpId: 'gp2',
+          defenderMinorOrTribeId: 'minor_x',
+          interveningGpId: humanId,
+        ),
+      ],
+    );
+  }
+}
+
 void main() {
   suppressLogsForTests();
 
@@ -137,6 +171,43 @@ void main() {
         final offer = event.overtures.first as OvertureOffer;
         expect(offer.offererGpId, 'gp2');
         expect(offer.stage, OvertureStage.tradeConsulate);
+      },
+    );
+
+    test(
+      'runTurnResolution returns TurnResolutionPendingIntervention and emits InterventionRequiredEvent',
+      () async {
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+
+        final service = _PendingInterventionGameService(box, adapter);
+        service.eventBus = bus;
+
+        final game = Game(
+          id: 'g_intervention_test',
+          worldState: const WorldState(
+            turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(),
+            newWorld: RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'Human', isHuman: true, treasury: 0),
+          ],
+        );
+
+        final received = <AppEvent>[];
+        bus.on<InterventionRequiredEvent>().listen(received.add);
+
+        final result = service.runTurnResolution(game);
+
+        await pumpEventQueue();
+        expect(result, isA<TurnResolutionPendingIntervention>());
+        expect(received, hasLength(1));
+        final event = received.first as InterventionRequiredEvent;
+        expect(event.prompts, hasLength(1));
+        final prompt = event.prompts.first as InterventionPrompt;
+        expect(prompt.aggressorGpId, 'gp2');
+        expect(prompt.interveningGpId, 'gp1');
       },
     );
 

--- a/app/test/games_provider_test.dart
+++ b/app/test/games_provider_test.dart
@@ -10,6 +10,7 @@ import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/features/game/widgets/province_overlay_demo_data.dart'
     show demoGameForOverlay;
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -94,18 +95,17 @@ void main() {
     expect(updated, contains('game_1'));
   });
 
-  test('pendingOverturesProvider defaults null and can be updated', () {
+  test('pendingDiplomacyProvider defaults null and can set overtures', () {
     final container = ProviderContainer();
     addTearDown(container.dispose);
 
-    final initial = container.read(pendingOverturesProvider);
-    expect(initial, isNull);
+    expect(container.read(pendingDiplomacyProvider), isNull);
 
-    container.read(pendingOverturesProvider.notifier).setPending(const []);
+    container.read(pendingDiplomacyProvider.notifier).setOvertures(const []);
 
-    final updated = container.read(pendingOverturesProvider);
-    expect(updated, isNotNull);
-    expect(updated, isEmpty);
+    final updated = container.read(pendingDiplomacyProvider);
+    expect(updated, isA<PendingDiplomacyOvertures>());
+    expect((updated! as PendingDiplomacyOvertures).offers, isEmpty);
   });
 
   test('currentGameProvider setGame and clear update the state', () {
@@ -147,16 +147,33 @@ void main() {
     expect(container.read(currentOrdersProvider), const Orders());
   });
 
-  test('pendingOverturesProvider clear resets pending overtures to null', () {
+  test('pendingDiplomacyProvider clear resets to null', () {
     final container = ProviderContainer();
     addTearDown(container.dispose);
 
-    final notifier = container.read(pendingOverturesProvider.notifier);
-    notifier.setPending(const []);
-    expect(container.read(pendingOverturesProvider), isNotNull);
+    final notifier = container.read(pendingDiplomacyProvider.notifier);
+    notifier.setOvertures(const []);
+    expect(container.read(pendingDiplomacyProvider), isNotNull);
 
     notifier.clear();
-    expect(container.read(pendingOverturesProvider), isNull);
+    expect(container.read(pendingDiplomacyProvider), isNull);
+  });
+
+  test('setIntervention replaces overtures state', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    container.read(pendingDiplomacyProvider.notifier).setOvertures(const []);
+    container.read(pendingDiplomacyProvider.notifier).setIntervention(const [
+      InterventionPrompt(
+        aggressorGpId: 'a',
+        defenderMinorOrTribeId: 'm',
+        interveningGpId: 'b',
+      ),
+    ]);
+    final s = container.read(pendingDiplomacyProvider);
+    expect(s, isA<PendingDiplomacyIntervention>());
+    expect((s! as PendingDiplomacyIntervention).prompts, hasLength(1));
   });
 }
 

--- a/ctterm/lib/ctterm_app.dart
+++ b/ctterm/lib/ctterm_app.dart
@@ -65,6 +65,7 @@ class _CttermAppState extends State<CttermApp> {
   /// When non-null, turn resolution is suspended; user must accept/reject overtures. SPEC/program/turn-resolution-phases.md.
   List<OvertureOffer>? _pendingOvertures;
   List<CallToArmsPending>? _pendingCallToArms;
+  List<InterventionPrompt>? _pendingInterventions;
   /// Game events received during turn processing (displayed to user).
   final List<GameEvent> _gameEvents = [];
   /// Current terminal theme.
@@ -193,6 +194,7 @@ class _CttermAppState extends State<CttermApp> {
       _pendingNewGameConfig = null;
       _pendingOvertures = null;
       _pendingCallToArms = null;
+      _pendingInterventions = null;
       _gameEvents.clear();
     });
   }
@@ -204,7 +206,22 @@ class _CttermAppState extends State<CttermApp> {
       _currentGame = game;
       _pendingOvertures = pending;
       _pendingCallToArms = null;
+      _pendingInterventions = null;
       _route = CttermRoute.pendingOvertures;
+    });
+  }
+
+  void _onTurnResolutionPendingIntervention(
+    Game game,
+    List<InterventionPrompt> pending,
+  ) {
+    _log.d('tui:app: turn resolution pending ${pending.length} intervention(s)');
+    setState(() {
+      _currentGame = game;
+      _pendingInterventions = pending;
+      _pendingOvertures = null;
+      _pendingCallToArms = null;
+      _route = CttermRoute.pendingIntervention;
     });
   }
 
@@ -217,6 +234,7 @@ class _CttermAppState extends State<CttermApp> {
       _currentGame = game;
       _pendingCallToArms = pending;
       _pendingOvertures = null;
+      _pendingInterventions = null;
       _route = CttermRoute.pendingCallToArms;
     });
   }
@@ -245,6 +263,7 @@ class _CttermAppState extends State<CttermApp> {
         _currentGame = result.game;
         _pendingOvertures = null;
         _pendingCallToArms = null;
+        _pendingInterventions = null;
         _route = CttermRoute.inGameShell;
       });
       _onTurnProcessed(result.game);
@@ -254,6 +273,18 @@ class _CttermAppState extends State<CttermApp> {
         _currentGame = result.game;
         _pendingOvertures = result.pendingOvertures;
         _pendingCallToArms = null;
+        _pendingInterventions = null;
+      });
+    } else if (result is TurnResolutionPendingIntervention) {
+      _log.d(
+        'tui:app: after overtures, pending ${result.pendingInterventions.length} intervention(s)',
+      );
+      setState(() {
+        _currentGame = result.game;
+        _pendingOvertures = null;
+        _pendingCallToArms = null;
+        _pendingInterventions = result.pendingInterventions;
+        _route = CttermRoute.pendingIntervention;
       });
     } else if (result is TurnResolutionPendingCallToArms) {
       _log.d(
@@ -261,6 +292,58 @@ class _CttermAppState extends State<CttermApp> {
       );
       setState(() {
         _currentGame = result.game;
+        _pendingOvertures = null;
+        _pendingInterventions = null;
+        _pendingCallToArms = result.pendingCallToArms;
+        _route = CttermRoute.pendingCallToArms;
+      });
+    }
+  }
+
+  void _onInterventionDecisions(List<InterventionDecision> decisions) {
+    final game = _currentGame;
+    final mapCache = _mapCache;
+    if (game == null || mapCache == null) {
+      _log.w('tui:app: onInterventionDecisions with null game/mapCache');
+      return;
+    }
+    final result = resumeTurnResolutionWithInterventionDecisions(
+      game: game,
+      decisions: decisions,
+      topology: mapCache.combinedTopology,
+      orders: _currentOrders,
+      tileMapByRegion: mapCache.tileMapByRegion,
+      onGameEvent: _onGameEvent,
+    );
+    if (result is TurnResolutionComplete) {
+      _log.d('tui:app: turn resolution complete after intervention');
+      setState(() {
+        _currentGame = result.game;
+        _pendingInterventions = null;
+        _pendingOvertures = null;
+        _pendingCallToArms = null;
+        _route = CttermRoute.inGameShell;
+      });
+      _onTurnProcessed(result.game);
+    } else if (result is TurnResolutionPendingOvertures) {
+      setState(() {
+        _currentGame = result.game;
+        _pendingInterventions = null;
+        _pendingCallToArms = null;
+        _pendingOvertures = result.pendingOvertures;
+        _route = CttermRoute.pendingOvertures;
+      });
+    } else if (result is TurnResolutionPendingIntervention) {
+      setState(() {
+        _currentGame = result.game;
+        _pendingOvertures = null;
+        _pendingCallToArms = null;
+        _pendingInterventions = result.pendingInterventions;
+      });
+    } else if (result is TurnResolutionPendingCallToArms) {
+      setState(() {
+        _currentGame = result.game;
+        _pendingInterventions = null;
         _pendingOvertures = null;
         _pendingCallToArms = result.pendingCallToArms;
         _route = CttermRoute.pendingCallToArms;
@@ -289,6 +372,7 @@ class _CttermAppState extends State<CttermApp> {
         _currentGame = result.game;
         _pendingCallToArms = null;
         _pendingOvertures = null;
+        _pendingInterventions = null;
         _route = CttermRoute.inGameShell;
       });
       _onTurnProcessed(result.game);
@@ -296,12 +380,23 @@ class _CttermAppState extends State<CttermApp> {
       setState(() {
         _currentGame = result.game;
         _pendingCallToArms = null;
+        _pendingInterventions = null;
         _pendingOvertures = result.pendingOvertures;
         _route = CttermRoute.pendingOvertures;
+      });
+    } else if (result is TurnResolutionPendingIntervention) {
+      setState(() {
+        _currentGame = result.game;
+        _pendingCallToArms = null;
+        _pendingOvertures = null;
+        _pendingInterventions = result.pendingInterventions;
+        _route = CttermRoute.pendingIntervention;
       });
     } else if (result is TurnResolutionPendingCallToArms) {
       setState(() {
         _currentGame = result.game;
+        _pendingInterventions = null;
+        _pendingOvertures = null;
         _pendingCallToArms = result.pendingCallToArms;
       });
     }
@@ -423,10 +518,13 @@ class _CttermAppState extends State<CttermApp> {
         onLoadGame: _loadGame,
         pendingOvertures: _pendingOvertures,
         pendingCallToArms: _pendingCallToArms,
+        pendingInterventions: _pendingInterventions,
         onTurnResolutionPending: _onTurnResolutionPending,
         onTurnResolutionPendingCallToArms: _onTurnResolutionPendingCallToArms,
+        onTurnResolutionPendingIntervention: _onTurnResolutionPendingIntervention,
         onOvertureDecisions: _onOvertureDecisions,
         onCallToArmsDecisions: _onCallToArmsDecisions,
+        onInterventionDecisions: _onInterventionDecisions,
         initialTheme: _terminalTheme,
         onThemeChanged: _onThemeChanged,
         /// When in Settings, Back goes to Pause if we came from Pause. SPEC/tui/screens/pause-options.md §7.

--- a/ctterm/lib/ctterm_routes.dart
+++ b/ctterm/lib/ctterm_routes.dart
@@ -24,6 +24,8 @@ enum CttermRoute {
   pendingOvertures,
   /// Human ally must join or refuse call to arms. SPEC/game/diplomacy.md.
   pendingCallToArms,
+  /// Diplomacy-phase intervention choices (GP vs Minor/Tribe). SPEC/tui/screens/pending-intervention.md.
+  pendingIntervention,
   /// Debug log viewer. SPEC/program/debug-log-viewer.md.
   debugLogViewer,
 }
@@ -73,6 +75,8 @@ extension CttermRouteScreenId on CttermRoute {
         return '100019';
       case CttermRoute.pendingCallToArms:
         return '100021';
+      case CttermRoute.pendingIntervention:
+        return '100022';
       case CttermRoute.debugLogViewer:
         return '100020';
     }

--- a/ctterm/lib/screens/pending_intervention_screen.dart
+++ b/ctterm/lib/screens/pending_intervention_screen.dart
@@ -1,0 +1,169 @@
+// Pending intervention: Diplomacy-phase choices when a GP attacks Minor/Tribe.
+// SPEC/tui/screens/pending-intervention.md, SPEC/program/dialogue-system.md.
+
+import 'package:logger/logger.dart' as log_pkg;
+import 'package:nocterm/nocterm.dart' hide Logger;
+
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+final _log = log_pkg.Logger();
+
+/// Blocking screen: human chooses intervene / do naught / protest per prompt.
+class PendingInterventionScreen extends StatefulComponent {
+  const PendingInterventionScreen({
+    super.key,
+    required this.game,
+    required this.prompts,
+    required this.onDecisions,
+  });
+
+  final Game game;
+  final List<InterventionPrompt> prompts;
+  final void Function(List<InterventionDecision> decisions) onDecisions;
+
+  @override
+  State<PendingInterventionScreen> createState() =>
+      _PendingInterventionScreenState();
+}
+
+class _PendingInterventionScreenState extends State<PendingInterventionScreen> {
+  int _selectedIndex = 0;
+  late List<InterventionChoice> _choices;
+
+  @override
+  void initState() {
+    super.initState();
+    _choices = List<InterventionChoice>.filled(
+      component.prompts.length,
+      InterventionChoice.doNothing,
+    );
+  }
+
+  String _factionName(String id) {
+    final g = component.game;
+    for (final p in g.players) {
+      if (p.id == id) return p.displayName;
+    }
+    for (final m in g.minorNations) {
+      if (m.id == id) return m.displayName ?? m.id;
+    }
+    for (final t in g.tribes) {
+      if (t.id == id) return t.displayName ?? t.id;
+    }
+    return id;
+  }
+
+  static String _choiceLabel(InterventionChoice c) {
+    switch (c) {
+      case InterventionChoice.intervene:
+        return 'Intervene';
+      case InterventionChoice.doNothing:
+        return 'Do naught';
+      case InterventionChoice.protest:
+        return 'Protest';
+    }
+  }
+
+  @override
+  Component build(BuildContext context) {
+    final prompts = component.prompts;
+    if (prompts.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.all(1),
+        child: Text('No pending intervention.'),
+      );
+    }
+    return Focusable(
+      focused: true,
+      onKeyEvent: _handleKeyEvent,
+      child: Container(
+        padding: const EdgeInsets.all(2),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'War and intervention',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const Text(
+              'Grave news: a sovereign hath made war upon a lesser state wherein '
+              'thy nation hath embassy, commerce, or bond. The Crown awaiteth thy '
+              'answer ere the turn proceedeth.',
+            ),
+            const SizedBox(height: 1),
+            ...List.generate(prompts.length, (i) {
+              final p = prompts[i];
+              final sel = i == _selectedIndex;
+              final prefix = sel ? '> ' : '  ';
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 0),
+                child: Text(
+                  '$prefix${_factionName(p.aggressorGpId)} vs '
+                  '${_factionName(p.defenderMinorOrTribeId)} '
+                  '(thy voice: ${_factionName(p.interveningGpId)}): '
+                  '${_choiceLabel(_choices[i])}',
+                ),
+              );
+            }),
+            const SizedBox(height: 2),
+            const Text(
+              '[I] Intervene  [O] Do naught  [P] Protest  [Up/Down] Select  [Enter] Submit',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ignore: strict_top_level_inference
+  bool _handleKeyEvent(event) {
+    final key = event.logicalKey;
+    final c = event.character?.toLowerCase();
+    final n = component.prompts.length;
+    if (n == 0) return false;
+
+    if (c == 'i') {
+      setState(() => _choices[_selectedIndex] = InterventionChoice.intervene);
+      return true;
+    }
+    if (c == 'o') {
+      setState(() => _choices[_selectedIndex] = InterventionChoice.doNothing);
+      return true;
+    }
+    if (c == 'p') {
+      setState(() => _choices[_selectedIndex] = InterventionChoice.protest);
+      return true;
+    }
+    if (key == LogicalKey.arrowUp || c == 'w') {
+      setState(() {
+        if (_selectedIndex > 0) _selectedIndex--;
+      });
+      return true;
+    }
+    if (key == LogicalKey.arrowDown || c == 's') {
+      setState(() {
+        if (_selectedIndex < n - 1) _selectedIndex++;
+      });
+      return true;
+    }
+    if (key == LogicalKey.enter) {
+      final decisions = <InterventionDecision>[];
+      for (var i = 0; i < component.prompts.length; i++) {
+        final p = component.prompts[i];
+        decisions.add(
+          InterventionDecision(
+            aggressorGpId: p.aggressorGpId,
+            defenderMinorOrTribeId: p.defenderMinorOrTribeId,
+            interveningGpId: p.interveningGpId,
+            choice: _choices[i],
+          ),
+        );
+      }
+      _log.d('tui:intervention: submitting ${decisions.length} decision(s)');
+      component.onDecisions(decisions);
+      return true;
+    }
+    return false;
+  }
+}

--- a/ctterm/lib/screens/shell_screen.dart
+++ b/ctterm/lib/screens/shell_screen.dart
@@ -23,6 +23,7 @@ import 'package:ctterm/screens/diplomacy_screen.dart';
 import 'package:ctterm/screens/technology_screen.dart';
 import 'package:ctterm/screens/pause_options_screen.dart';
 import 'package:ctterm/screens/pending_call_to_arms_screen.dart';
+import 'package:ctterm/screens/pending_intervention_screen.dart';
 import 'package:ctterm/screens/pending_overtures_screen.dart';
 import 'package:ctterm/screens/debug_log_viewer_screen.dart';
 import 'package:ctterm/save_service.dart';
@@ -60,10 +61,13 @@ class ShellScreen extends StatefulComponent {
     this.debugLogViewerReturnRoute,
     this.pendingOvertures,
     this.pendingCallToArms,
+    this.pendingInterventions,
     this.onTurnResolutionPending,
     this.onTurnResolutionPendingCallToArms,
+    this.onTurnResolutionPendingIntervention,
     this.onOvertureDecisions,
     this.onCallToArmsDecisions,
+    this.onInterventionDecisions,
     this.showGameStartIntro = false,
     this.onIntroDismissed,
   });
@@ -136,6 +140,9 @@ class ShellScreen extends StatefulComponent {
   /// When non-null, human ally must respond to call to arms. SPEC/game/diplomacy.md.
   final List<CallToArmsPending>? pendingCallToArms;
 
+  /// When non-null, human must choose intervention per prompt. SPEC/tui/screens/pending-intervention.md.
+  final List<InterventionPrompt>? pendingInterventions;
+
   /// Called when resolve returns pending; app should navigate to pendingOvertures and show prompt.
   final void Function(Game game, List<OvertureOffer> pending)?
       onTurnResolutionPending;
@@ -144,11 +151,18 @@ class ShellScreen extends StatefulComponent {
   final void Function(Game game, List<CallToArmsPending> pending)?
       onTurnResolutionPendingCallToArms;
 
+  /// Called when resolve returns pending intervention.
+  final void Function(Game game, List<InterventionPrompt> pending)?
+      onTurnResolutionPendingIntervention;
+
   /// Called when user submits accept/reject decisions; app resumes resolution and updates game or re-shows pending.
   final void Function(List<OvertureDecision> decisions)? onOvertureDecisions;
 
   /// Called when user submits call to arms decisions.
   final void Function(List<CallToArmsDecision> decisions)? onCallToArmsDecisions;
+
+  /// Called when user submits intervention decisions.
+  final void Function(List<InterventionDecision> decisions)? onInterventionDecisions;
 
   /// When true, in-game shell shows game-start intro overlay until dismissed. SPEC/ai/dialogue-management.md.
   final bool showGameStartIntro;
@@ -340,6 +354,15 @@ class _ShellScreenState extends State<ShellScreen> {
                   ?.call(result.game, result.pendingOvertures);
               return;
             }
+            if (result is TurnResolutionPendingIntervention) {
+              _log.d(
+                  'tui:game: turn resolution pending ${result.pendingInterventions.length} intervention(s)');
+              component.onTurnResolutionPendingIntervention?.call(
+                result.game,
+                result.pendingInterventions,
+              );
+              return;
+            }
             if (result is TurnResolutionPendingCallToArms) {
               _log.d(
                   'tui:game: turn resolution pending ${result.pendingCallToArms.length} call(s) to arms');
@@ -516,6 +539,26 @@ class _ShellScreenState extends State<ShellScreen> {
           game: ctaGame,
           pending: ctaPending,
           onDecisions: onCta,
+        );
+      case CttermRoute.pendingIntervention:
+        final ivGame = component.game;
+        final ivPending = component.pendingInterventions;
+        final onIv = component.onInterventionDecisions;
+        if (ivGame == null ||
+            ivPending == null ||
+            ivPending.isEmpty ||
+            onIv == null) {
+          _log.w(
+              'tui:nav: pendingIntervention route with missing game/pending/onDecisions');
+          return const Padding(
+            padding: EdgeInsets.all(1),
+            child: Text('No pending intervention.'),
+          );
+        }
+        return PendingInterventionScreen(
+          game: ivGame,
+          prompts: ivPending,
+          onDecisions: onIv,
         );
     }
   }

--- a/ctterm/test/ctterm_app_test.dart
+++ b/ctterm/test/ctterm_app_test.dart
@@ -46,7 +46,7 @@ void main() {
     });
 
     test(' CttermRoute enum has all expected values', () {
-      expect(CttermRoute.values.length, equals(21));
+      expect(CttermRoute.values.length, equals(22));
       expect(CttermRoute.mainMenu.screenId, equals('100001'));
       expect(CttermRoute.gameSetup.screenId, equals('100002'));
       expect(CttermRoute.loadGame.screenId, equals('100003'));
@@ -68,6 +68,7 @@ void main() {
       expect(CttermRoute.pendingOvertures.screenId, equals('100019'));
       expect(CttermRoute.debugLogViewer.screenId, equals('100020'));
       expect(CttermRoute.pendingCallToArms.screenId, equals('100021'));
+      expect(CttermRoute.pendingIntervention.screenId, equals('100022'));
     });
   });
 }


### PR DESCRIPTION
## Summary

Implements **#1379**: when turn resolution returns `TurnResolutionPendingIntervention`, the Flutter app and ctterm collect all required `InterventionDecision` rows and call the appropriate resume API without dropping game state or orders.

## Flutter

- **Unified pending diplomacy:** `pendingDiplomacyProvider` + sealed `PendingDiplomacyState` (overtures | intervention | call to arms), replacing separate overture/CTA notifiers.
- **GameScreen:** `_applyTurnResolutionResult` centralizes handling of `TurnResolutionComplete`, `TurnResolutionPendingOvertures`, `TurnResolutionPendingIntervention`, and `TurnResolutionPendingCallToArms` on end-turn and on every resume path.
- **InterventionDialogueOverlay** + **`assets/dialogue/intervention.yarn`:** Jenny intro, per-prompt situation (faction variables), three actions, then Yarn “aggressor reaction” per choice (archaic register aligned with game intro).
- **Widgetbook:** `Dialogue` → `InterventionDialogueOverlay` (intro skipped for catalog).

## ctterm

- **`CttermRoute.pendingIntervention`** (screen ID `100022`), **`PendingInterventionScreen`**, shell end-turn branch, and full resume chains between overture / intervention / CTA and shell.

## Specs

- `SPEC/ui/pending-diplomacy-state.md`, `SPEC/ui/screens/pending-intervention-overlay.md`, `SPEC/tui/screens/pending-intervention.md`
- Updates to `SPEC/ai/dialogue-content-and-yarn.md`, `SPEC/ui/dialogue-presentation.md`

## Tests

- `game_service_test`: `InterventionRequiredEvent` when bus set + pending intervention return
- `games_provider_test`, `game_screen_*`, `ctterm_app_test` (route count / screen id)

## Note

Local unstaged changes remain in `naval_units_panel.dart` and `split_fleet_dialog.dart` (not part of this PR).