### PR TITLE
feat(ui): localize intervention overlay (#1379 follow-up)

### DIFF
--- a/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:jenny/jenny.dart';
 import 'package:logger/logger.dart';
 
+import '../../../../l10n/l10n.dart';
 import '../../../../widgets/ct_dialog_shell.dart';
 import '../../../../widgets/ct_nine_patch_button.dart';
 import 'ct_dialogue_view.dart';
@@ -222,6 +223,7 @@ class _InterventionDialogueOverlayState extends State<InterventionDialogueOverla
 
   @override
   Widget build(BuildContext context) {
+    final l10n = appL10n(context);
     if (_loadError != null) {
       return Stack(
         children: [
@@ -238,12 +240,12 @@ class _InterventionDialogueOverlayState extends State<InterventionDialogueOverla
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
                       Text(
-                        'Could not load intervention dialogue: $_loadError',
+                        l10n.game_intervention_loadError(_loadError.toString()),
                         style: Theme.of(context).textTheme.bodyMedium,
                       ),
                       const SizedBox(height: 16),
                       Text(
-                        'Submit all responses as “Do naught” to continue.',
+                        l10n.game_intervention_degradedHint,
                         style: Theme.of(context).textTheme.bodySmall,
                       ),
                       const SizedBox(height: 16),
@@ -251,7 +253,7 @@ class _InterventionDialogueOverlayState extends State<InterventionDialogueOverla
                         alignment: Alignment.centerRight,
                         child: CtNinePatchButton(
                           onPressed: _degradedSubmitDoNothing,
-                          child: const Text('Continue'),
+                          child: Text(l10n.game_intervention_continue),
                         ),
                       ),
                     ],
@@ -305,7 +307,7 @@ class _InterventionDialogueOverlayState extends State<InterventionDialogueOverla
                   alignment: Alignment.centerRight,
                   child: CtNinePatchButton(
                     onPressed: () => _view!.advanceLine(),
-                    child: const Text('Continue'),
+                    child: Text(l10n.game_intervention_continue),
                   ),
                 ),
               ] else if (choice != null) ...[
@@ -335,30 +337,38 @@ class _InterventionDialogueOverlayState extends State<InterventionDialogueOverla
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               Text(
-                'Thy resolution (${_promptIndex + 1} of ${widget.prompts.length})',
+                l10n.game_intervention_resolutionProgress(
+                  _promptIndex + 1,
+                  widget.prompts.length,
+                ),
                 style: Theme.of(context).textTheme.titleSmall,
               ),
               const SizedBox(height: 12),
               Text(
-                '${_factionDisplayName(widget.game, prompt.aggressorGpId)} '
-                'against ${_factionDisplayName(widget.game, prompt.defenderMinorOrTribeId)}. '
-                'Thou speakest for ${_factionDisplayName(widget.game, prompt.interveningGpId)}.',
+                l10n.game_intervention_situation(
+                  _factionDisplayName(widget.game, prompt.aggressorGpId),
+                  _factionDisplayName(
+                    widget.game,
+                    prompt.defenderMinorOrTribeId,
+                  ),
+                  _factionDisplayName(widget.game, prompt.interveningGpId),
+                ),
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
               const SizedBox(height: 16),
               CtNinePatchButton(
                 onPressed: () => _pick(InterventionChoice.intervene),
-                child: const Text('Intervene with force'),
+                child: Text(l10n.game_intervention_intervene),
               ),
               const SizedBox(height: 8),
               CtNinePatchButton(
                 onPressed: () => _pick(InterventionChoice.doNothing),
-                child: const Text('Do naught'),
+                child: Text(l10n.game_intervention_doNothing),
               ),
               const SizedBox(height: 8),
               CtNinePatchButton(
                 onPressed: () => _pick(InterventionChoice.protest),
-                child: const Text('Diplomatic protest'),
+                child: Text(l10n.game_intervention_protest),
               ),
             ],
           ),

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -304,6 +304,60 @@
   "game_callToArms_submit": "Submit",
   "@game_callToArms_submit": {
     "description": "Submit all call-to-arms choices."
+  },
+
+  "game_intervention_loadError": "Could not load intervention dialogue: {error}",
+  "@game_intervention_loadError": {
+    "description": "Error banner when intervention Yarn fails to load.",
+    "placeholders": {
+      "error": {
+        "type": "String",
+        "description": "Exception or error object string."
+      }
+    }
+  },
+  "game_intervention_degradedHint": "Submit all responses as \"Do naught\" to continue.",
+  "@game_intervention_degradedHint": {
+    "description": "Explains degraded intervention flow when dialogue asset is missing."
+  },
+  "game_intervention_continue": "Continue",
+  "@game_intervention_continue": {
+    "description": "Advance intervention Yarn line or exit degraded error dialog."
+  },
+  "game_intervention_resolutionProgress": "Thy resolution ({current} of {total})",
+  "@game_intervention_resolutionProgress": {
+    "description": "Header showing which intervention prompt is active.",
+    "placeholders": {
+      "current": {
+        "type": "int",
+        "description": "1-based index of the current prompt."
+      },
+      "total": {
+        "type": "int",
+        "description": "Total number of intervention prompts."
+      }
+    }
+  },
+  "game_intervention_situation": "{aggressor} against {defender}. Thou speakest for {intervening}.",
+  "@game_intervention_situation": {
+    "description": "One-line summary of the war and which GP the player decides for.",
+    "placeholders": {
+      "aggressor": {"type": "String"},
+      "defender": {"type": "String"},
+      "intervening": {"type": "String"}
+    }
+  },
+  "game_intervention_intervene": "Intervene with force",
+  "@game_intervention_intervene": {
+    "description": "Button: military intervention on behalf of the defender."
+  },
+  "game_intervention_doNothing": "Do naught",
+  "@game_intervention_doNothing": {
+    "description": "Button: decline to intervene."
+  },
+  "game_intervention_protest": "Diplomatic protest",
+  "@game_intervention_protest": {
+    "description": "Button: formal protest without military action."
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1386 for **#1379**: moves all **Flutter** user-visible strings in `InterventionDialogueOverlay` into `app_en.arb`, consistent with `CallToArmsDialogueOverlay`. **Yarn** copy in `intervention.yarn` is unchanged.

## Changes

- New `game_intervention_*` l10n keys (error/degraded path, Continue, progress header, situation line, three choice buttons).
- Overlay uses `appL10n(context)` (same pattern as call-to-arms).

## Testing

- `flutter gen-l10n` (generated `app_localizations*.dart` remain gitignored per repo policy).
- `flutter test` on `games_provider_test`, `game_screen_turn_resolution_branches_test`, `game_service_test`.

Fixes #1379