### PR TITLE
Align runtime logging with SPEC/program/logging (#1382)

### DIFF
--- a/app/lib/core/services/app_event_handler.dart
+++ b/app/lib/core/services/app_event_handler.dart
@@ -22,10 +22,10 @@
 
 import 'dart:async';
 
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:logger/logger.dart';
 
 import '../../features/game/flame/game_screen_shared.dart';
 import '../../features/game/widgets/civilian_units_panel.dart';
@@ -38,7 +38,7 @@ import '../../providers/games_provider.dart';
 typedef DialogBuilder =
     Widget Function(BuildContext context, Map<String, Object?>? params);
 
-final _log = Logger();
+final _log = appLogger('event');
 
 class AppEventHandler {
   AppEventHandler({
@@ -167,7 +167,7 @@ class AppEventHandler {
       event.result(confirmed);
       return confirmed;
     } catch (e, st) {
-      _log.e('ui:app_event: ConfirmDialog failed', error: e, stackTrace: st);
+      _log.e('ConfirmDialog failed', error: e, stackTrace: st);
       event.result(false);
       return false;
     }

--- a/app/lib/core/services/app_event_handler_scope.dart
+++ b/app/lib/core/services/app_event_handler_scope.dart
@@ -3,9 +3,9 @@ import 'dart:async';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:logger/logger.dart';
 import 'package:colonizethis_app/app.dart';
 import 'package:colonizethis_app/features/game/widgets/diplomacy_dialogs.dart';
 import 'package:colonizethis_app/features/game/widgets/train_civilians_dialog.dart';
@@ -30,7 +30,8 @@ const String grantOrSubsidyDialogId = 'grant_or_subsidy';
 /// [OpenDialogEvent] id for [NewGameLeaderSelectionDialog]. SPEC/program/app-ui-wiring.md.
 const String newGameLeaderSelectionDialogId = 'new_game_leader_selection';
 
-final _log = Logger();
+final _logShell = appLogger('shell');
+final _logEvent = appLogger('event');
 
 /// Replaces pending train-at-capital civilian [BuildUnitOrder]s for [humanPlayerId];
 /// keeps military, naval, and other build orders. Matches [TrainCiviliansDialog] semantics.
@@ -164,8 +165,8 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
                 ) {
                   final navCtx = appNavigatorKey.currentContext;
                   if (navCtx == null) {
-                    _log.w(
-                      'shell: appNavigatorKey has no context; skipping new game setup',
+                    _logShell.w(
+                      'appNavigatorKey has no context; skipping new game setup',
                     );
                     return;
                   }
@@ -285,8 +286,8 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
         ref.read(currentGameProvider.notifier).setGame(e.game);
       }),
     ]);
-    _log.d(
-      'ui:app_event: AppEventHandler bound; session command listeners attached',
+    _logEvent.d(
+      'AppEventHandler bound; session command listeners attached',
     );
   }
 

--- a/app/lib/features/game/dialogue/ct_dialogue_view.dart
+++ b/app/lib/features/game/dialogue/ct_dialogue_view.dart
@@ -1,14 +1,14 @@
 import 'dart:async';
 
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:jenny/jenny.dart';
-import 'package:logger/logger.dart';
 
 /// Flutter/Jenny dialogue view that drives UI via callbacks and completers.
 /// SPEC/ui/dialogue-presentation.md, SPEC/ai/dialogue-content-and-yarn.md.
 class CtDialogueView extends DialogueView {
-  CtDialogueView({Logger? logger}) : _log = logger ?? Logger();
+  CtDialogueView({CtLogger? logger}) : _log = logger ?? appLogger('dialogue');
 
-  final Logger _log;
+  final CtLogger _log;
 
   DialogueLine? _currentLine;
   DialogueChoice? _currentChoice;
@@ -40,7 +40,7 @@ class CtDialogueView extends DialogueView {
 
   @override
   FutureOr<bool> onLineStart(DialogueLine line) {
-    _log.d('ui:dialogue: line start "${line.text}"');
+    _log.d('line start "${line.text}"');
     _currentLine = line;
     _currentChoice = null;
     _lineCompleter = Completer<void>();
@@ -54,7 +54,7 @@ class CtDialogueView extends DialogueView {
 
   @override
   FutureOr<int?> onChoiceStart(DialogueChoice choice) {
-    _log.d('ui:dialogue: choice start ${choice.options.length} options');
+    _log.d('choice start ${choice.options.length} options');
     _currentLine = null;
     _currentChoice = choice;
     _choiceCompleter = Completer<int?>();
@@ -68,7 +68,7 @@ class CtDialogueView extends DialogueView {
 
   @override
   FutureOr<void> onDialogueFinish() {
-    _log.d('ui:dialogue: dialogue finish');
+    _log.d('dialogue finish');
     _currentLine = null;
     _currentChoice = null;
     _lineCompleter = null;
@@ -78,6 +78,6 @@ class CtDialogueView extends DialogueView {
 
   @override
   void onDialogueStart() {
-    _log.d('ui:dialogue: dialogue start');
+    _log.d('dialogue start');
   }
 }

--- a/app/lib/features/game/dialogue/game_start_intro_overlay.dart
+++ b/app/lib/features/game/dialogue/game_start_intro_overlay.dart
@@ -1,7 +1,7 @@
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 import 'package:jenny/jenny.dart';
-import 'package:logger/logger.dart';
 
 import '../../../../widgets/ct_dialog_shell.dart';
 import '../../../../widgets/ct_nine_patch_button.dart';
@@ -21,7 +21,7 @@ class GameStartIntroOverlay extends StatefulWidget {
 
   final VoidCallback onDismissed;
   final Widget child;
-  final Logger? logger;
+  final CtLogger? logger;
   final AssetBundle? assetBundle;
 
   @override
@@ -44,7 +44,7 @@ class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
   }
 
   Future<void> _loadAndRun() async {
-    final log = widget.logger ?? Logger();
+    final log = widget.logger ?? appLogger('dialogue');
     try {
       final bundle = widget.assetBundle ?? rootBundle;
       final text = await bundle.loadString(_kIntroAsset);

--- a/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
@@ -3,9 +3,9 @@ import 'dart:async';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:flutter/services.dart';
 import 'package:jenny/jenny.dart';
-import 'package:logger/logger.dart';
 
 import '../../../../l10n/l10n.dart';
 import '../../../../widgets/ct_dialog_shell.dart';
@@ -30,7 +30,7 @@ class InterventionDialogueOverlay extends StatefulWidget {
   final List<InterventionPrompt> prompts;
   final void Function(List<InterventionDecision> decisions) onDecisions;
   final Widget child;
-  final Logger? logger;
+  final CtLogger? logger;
   final bool skipIntroForTest;
   final AssetBundle? assetBundle;
 
@@ -67,7 +67,7 @@ class _InterventionDialogueOverlayState extends State<InterventionDialogueOverla
   }
 
   Future<void> _runFlow() async {
-    final log = widget.logger ?? Logger();
+    final log = widget.logger ?? appLogger('dialogue');
     try {
       final bundle = widget.assetBundle ?? rootBundle;
       final text = await bundle.loadString(_kAsset);

--- a/app/lib/features/game/dialogue/overture_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/overture_dialogue_overlay.dart
@@ -2,8 +2,8 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:jenny/jenny.dart';
-import 'package:logger/logger.dart';
 
 import '../../../../widgets/ct_dialog_shell.dart';
 import '../../../../widgets/ct_nine_patch_button.dart';
@@ -27,7 +27,7 @@ class OvertureDialogueOverlay extends StatefulWidget {
   final List<OvertureOffer> pendingOvertures;
   final void Function(List<OvertureDecision> decisions) onDecisions;
   final Widget child;
-  final Logger? logger;
+  final CtLogger? logger;
   final bool skipIntroForTest;
 
   @override
@@ -57,7 +57,7 @@ class _OvertureDialogueOverlayState extends State<OvertureDialogueOverlay> {
   }
 
   Future<void> _loadAndRunIntro() async {
-    final log = widget.logger ?? Logger();
+    final log = widget.logger ?? appLogger('dialogue');
     try {
       final text = await rootBundle.loadString(_kOvertureAsset);
       final project = YarnProject();

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,14 +1,14 @@
+import 'dart:async';
+
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
-import 'package:logger/logger.dart';
 import 'package:session_log_buffer/session_log_buffer.dart';
 
 import 'app.dart';
 import 'config/constants.dart';
 import 'core/services/app_event_handler_scope.dart';
-
-final _log = Logger();
 
 /// Opens one Hive box; failures are isolated so another box (e.g. games) still opens.
 Future<void> _openHiveBoxSafely(String name) async {
@@ -16,7 +16,7 @@ Future<void> _openHiveBoxSafely(String name) async {
     await Hive.openBox<dynamic>(name);
   } catch (e, st) {
     // Boxes may be locked (e.g. another instance) or corrupt; app still runs where possible.
-    _log.w('data:hive: failed to open box "$name"', error: e, stackTrace: st);
+    dataLogger('hive').w('failed to open box "$name"', error: e, stackTrace: st);
   }
 }
 
@@ -27,5 +27,16 @@ void main() async {
   await _openHiveBoxSafely(HiveBoxNames.settings);
   await _openHiveBoxSafely(HiveBoxNames.games);
   await _openHiveBoxSafely(HiveBoxNames.offlineQueue);
-  runApp(const ProviderScope(child: AppEventHandlerScope(child: App())));
+  runZonedGuarded(
+    () {
+      runApp(const ProviderScope(child: AppEventHandlerScope(child: App())));
+    },
+    (Object error, StackTrace stackTrace) {
+      appLogger().e(
+        'uncaught async error',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    },
+  );
 }

--- a/app/lib/widgets/ct_dialog_shell.dart
+++ b/app/lib/widgets/ct_dialog_shell.dart
@@ -1,6 +1,6 @@
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:flame/widgets.dart';
 import 'package:flutter/material.dart';
-import 'package:logger/logger.dart';
 
 /// Pixel-art dialog shell using a nine-patch frame. SPEC/ui/buttons-nine-patch.md (reuse canon).
 ///
@@ -74,8 +74,8 @@ class CtDialogShell extends StatelessWidget {
                   child: child,
                 ),
                 errorBuilder: (_) {
-                  Logger().w(
-                    'ui: dialog nine-patch asset not found, using fallback frame',
+                  appLogger('ui').w(
+                    'dialog nine-patch asset not found, using fallback frame',
                   );
                   return _FallbackDialogFrame(
                     color: fallbackColor,

--- a/app/lib/widgets/ct_nine_patch_button.dart
+++ b/app/lib/widgets/ct_nine_patch_button.dart
@@ -1,6 +1,6 @@
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:flame/widgets.dart';
 import 'package:flutter/material.dart';
-import 'package:logger/logger.dart';
 
 /// Nine-patch button using Flame's [NineTileBoxWidget]. SPEC/ui/buttons-nine-patch.md.
 ///
@@ -95,8 +95,8 @@ class CtNinePatchButton extends StatelessWidget {
                   child: child,
                 ),
                 errorBuilder: (_) {
-                  Logger().w(
-                    'logic: nine-patch button asset not found, using fallback',
+                  appLogger('ui').w(
+                    'nine-patch button asset not found, using fallback',
                   );
                   return _FallbackButton(
                     color: fallbackColor,

--- a/app/lib/widgets/ct_panel.dart
+++ b/app/lib/widgets/ct_panel.dart
@@ -1,6 +1,6 @@
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:flame/widgets.dart';
 import 'package:flutter/material.dart';
-import 'package:logger/logger.dart';
 
 /// Pixel-art panel using the same nine-patch as buttons/dialogs.
 /// Replace [Card] with this for framed content sections.
@@ -47,8 +47,8 @@ class CtPanel extends StatelessWidget {
             child: child,
           ),
           errorBuilder: (_) {
-            Logger().w(
-              'ui: panel nine-patch asset not found, using fallback',
+            appLogger('ui').w(
+              'panel nine-patch asset not found, using fallback',
             );
             return _FallbackPanel(
               color: fallbackColor,

--- a/app/test/ct_dialogue_view_test.dart
+++ b/app/test/ct_dialogue_view_test.dart
@@ -1,7 +1,7 @@
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jenny/jenny.dart';
-import 'package:logger/logger.dart';
 import 'package:jenny/src/structure/line_content.dart';
 
 import 'package:colonizethis_app/features/game/dialogue/ct_dialogue_view.dart';
@@ -11,7 +11,7 @@ void main() {
 
   test('CtDialogueView advanceLine completes line future and clears state',
       () async {
-    final view = CtDialogueView(logger: Logger());
+    final view = CtDialogueView(logger: appLogger('dialogue'));
 
     var stateCalls = 0;
     view.onStateChanged = (_, __) => stateCalls++;
@@ -37,7 +37,7 @@ void main() {
 
   test('CtDialogueView selectOption completes choice future with index',
       () async {
-    final view = CtDialogueView(logger: Logger());
+    final view = CtDialogueView(logger: appLogger('dialogue'));
 
     var lastIndex = -1;
     view.onStateChanged = (line, choice) {
@@ -65,7 +65,7 @@ void main() {
 
   test('CtDialogueView onDialogueFinish clears state and signals nulls',
       () async {
-    final view = CtDialogueView(logger: Logger());
+    final view = CtDialogueView(logger: appLogger('dialogue'));
 
     var nullCalls = 0;
     view.onStateChanged = (line, choice) {

--- a/ctdev/lib/main.dart
+++ b/ctdev/lib/main.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:flutter/material.dart';
-import 'package:logger/logger.dart';
 
 import 'ctdev_log.dart';
 import 'screens/init_game_screen.dart';
@@ -12,7 +12,7 @@ void main() {
   runZonedGuarded(
     () => runApp(const CtDevApp()),
     (Object error, StackTrace stackTrace) {
-      Logger().e('ctdev: uncaught error', error: error, stackTrace: stackTrace);
+      ctdevLogger().e('uncaught error', error: error, stackTrace: stackTrace);
     },
   );
 }

--- a/ctdev/lib/save_service.dart
+++ b/ctdev/lib/save_service.dart
@@ -4,11 +4,11 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:hive/hive.dart';
-import 'package:logger/logger.dart';
 import 'package:path_provider/path_provider.dart';
 
-final Logger _log = Logger();
+final _log = ctdevLogger('save');
 
 Box<dynamic>? _box;
 
@@ -18,7 +18,7 @@ Future<Box<dynamic>> _ensureBox() async {
   final dir = await getApplicationDocumentsDirectory();
   Hive.init(dir.path);
   _box = await Hive.openBox<dynamic>('games');
-  _log.d('save: Hive box opened at ${dir.path}');
+  _log.d('Hive box opened at ${dir.path}');
   return _box!;
 }
 
@@ -28,7 +28,7 @@ final _adapter = GameSaveAdapter();
 Future<List<String>> listGameIds() async {
   final box = await _ensureBox();
   final ids = _adapter.listGameIds(box);
-  _log.d('save: listGameIds count=${ids.length}');
+  _log.d('listGameIds count=${ids.length}');
   return ids;
 }
 
@@ -60,5 +60,5 @@ Future<void> saveGameAndMapData(Game game, InitGameResult result) async {
     topologyByRegion: result.topologyByRegion,
     combinedTopology: result.combinedTopology,
   );
-  _log.i('save: saved gameId=${game.id} with map data');
+  _log.i('saved gameId=${game.id} with map data');
 }

--- a/ctdev/lib/screens/running_game_screen.dart
+++ b/ctdev/lib/screens/running_game_screen.dart
@@ -2,14 +2,16 @@ import 'dart:math' as math;
 
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
-import 'package:logger/logger.dart';
 
 import '../ctdev_log.dart';
 import '../debug_map_painter.dart';
 import '../player_view_map_painter.dart';
 import '../sim_game_controller.dart';
+
+final _runningGameLog = ctdevLogger('running_game');
 
 /// Running Game Screen: sim game with control bar and tabs.
 class RunningGameScreen extends StatefulWidget {
@@ -109,7 +111,7 @@ class _RunningGameScreenState extends State<RunningGameScreen>
       _controller.resolveFromPendingOrders();
       _refresh();
     } catch (e, st) {
-      Logger().e('ctdev: resolve turn failed', error: e, stackTrace: st);
+      _runningGameLog.e('resolve turn failed', error: e, stackTrace: st);
       rethrow;
     } finally {
       if (mounted) setState(() => _isSimulatingBatch = false);
@@ -123,7 +125,7 @@ class _RunningGameScreenState extends State<RunningGameScreen>
       _controller.stepFullTurn();
       _refresh();
     } catch (e, st) {
-      Logger().e('ctdev: step full turn failed', error: e, stackTrace: st);
+      _runningGameLog.e('step full turn failed', error: e, stackTrace: st);
       rethrow;
     } finally {
       if (mounted) setState(() => _isSimulatingBatch = false);
@@ -137,7 +139,7 @@ class _RunningGameScreenState extends State<RunningGameScreen>
       _controller.fastForward(turns: 10);
       _refresh();
     } catch (e, st) {
-      Logger().e('ctdev: fast-forward failed', error: e, stackTrace: st);
+      _runningGameLog.e('fast-forward failed', error: e, stackTrace: st);
       rethrow;
     } finally {
       if (mounted) setState(() => _isSimulatingBatch = false);

--- a/ctdev/lib/sim_game_controller.dart
+++ b/ctdev/lib/sim_game_controller.dart
@@ -2,11 +2,13 @@ import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 import 'package:meta/meta.dart';
 
 import 'ctdev_log.dart';
+
+final _ctdevSimLog = ctdevLogger();
 
 /// One order entry in the sim game order history (for UI display).
 class SimOrderHistoryEntry {
@@ -166,8 +168,8 @@ class SimGameController {
         final orders = generateOrdersForPlayer(_game, _topology, player.id);
         _pendingOrdersByPlayerId[player.id] = orders;
       }
-      Logger().i(
-        'ctdev: Turn $currentTurn: generated orders for ${player.displayName} (${player.id})',
+      _ctdevSimLog.i(
+        'Turn $currentTurn: generated orders for ${player.displayName} (${player.id})',
       );
       break;
     }
@@ -306,7 +308,7 @@ class SimGameController {
     final line = _combatEventUiLine(event);
     if (line == null) return;
     _lastTurnCombatSummaries.add(line);
-    Logger().i('ctdev: $line');
+    _ctdevSimLog.i(line);
   }
 
   bool _isOrdersEffectivelyEmpty(Orders o) =>
@@ -583,10 +585,10 @@ class SimGameController {
     }
 
     if (flips.isEmpty) {
-      Logger().i('ctdev: Turn $turn ($year): no province ownership changes');
+      _ctdevSimLog.i('Turn $turn ($year): no province ownership changes');
     } else {
-      Logger().i(
-        'ctdev: Turn $turn ($year): province ownership changes: ${flips.join(', ')}',
+      _ctdevSimLog.i(
+        'Turn $turn ($year): province ownership changes: ${flips.join(', ')}',
       );
     }
   }

--- a/ctdev/pubspec.yaml
+++ b/ctdev/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   basic_logger_file: ^0.1.3
+  colonizethis_logger: any
   logger: ^2.0.2
   path: ^1.9.0
   path_provider: ^2.1.0

--- a/ctterm/bin/ctterm.dart
+++ b/ctterm/bin/ctterm.dart
@@ -1,6 +1,6 @@
 // ctterm entrypoint. SPEC/tui/ctterm.md. Run with: dart run ctterm [--data-dir <path>]
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_app.dart';
@@ -8,7 +8,7 @@ import 'package:ctterm/ctterm_log.dart';
 import 'package:ctterm/save_service.dart';
 import 'package:session_log_buffer/session_log_buffer.dart';
 
-final log_pkg.Logger _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 void main(List<String> args) async {
   String? dataDirOverride;
@@ -22,16 +22,20 @@ void main(List<String> args) async {
 
   initCttermLogging(dataDirOverride);
   SessionLogBuffer.init();
-  _log.i('tui: ctterm starting');
+  _log.i('ctterm starting');
 
   var initialLockDetected = false;
   try {
     await ensureSaveServiceReady(dataDirOverride);
   } on StaleLockException catch (e) {
-    _log.d('tui: lock detected at ${e.dataDir}, showing prompt');
+    _log.d('lock detected at ${e.dataDir}, showing prompt');
     initialLockDetected = true;
   } catch (e, st) {
-    _log.w('tui: save service pre-init failed (menu may show Loading then recover)', error: e, stackTrace: st);
+    _log.w(
+      'save service pre-init failed (menu may show Loading then recover)',
+      error: e,
+      stackTrace: st,
+    );
   }
 
   runApp(CttermApp(

--- a/ctterm/lib/ctterm_app.dart
+++ b/ctterm/lib/ctterm_app.dart
@@ -1,6 +1,6 @@
 // Root ctterm app: navigation shell and main menu. SPEC/tui/ctterm.md. /// CTTerm application entry point
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart';
 
 import 'package:ctterm/ctterm_routes.dart';
@@ -12,7 +12,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final log_pkg.Logger _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Pending setup data when user has completed Game Setup and we are about to generate the world.
 class _PendingNewGameConfig {
@@ -98,7 +98,7 @@ class _CttermAppState extends State<CttermApp> {
     Map<String, String> leaderVariantByGpId,
     bool enforceFairGpOldWorldAssignment,
   ) {
-    _log.d('tui:app: prepare new game with ${orderedGpIdsForSlots.length} players');
+    _log.d('prepare new game with ${orderedGpIdsForSlots.length} players');
     setState(() {
       _pendingNewGameConfig = _PendingNewGameConfig(
         orderedGpIdsForSlots: orderedGpIdsForSlots,
@@ -114,7 +114,7 @@ class _CttermAppState extends State<CttermApp> {
   void _runGeneration() {
     final pending = _pendingNewGameConfig;
     if (pending == null) {
-      _log.w('tui:app: runGeneration called with no pending config');
+      _log.w('runGeneration called with no pending config');
       return;
     }
     final config = GameSetupConfig(
@@ -130,12 +130,12 @@ class _CttermAppState extends State<CttermApp> {
       enforceFairGpOldWorldAssignment: pending.enforceFairGpOldWorldAssignment,
     );
     try {
-      _log.i('tui:app: running init game');
+      _log.i('running init game');
       final result = runInitGame(
         config: config,
         options: const InitGameOptions(renderPng: false),
       );
-      _log.i('tui:app: init game complete, turn ${result.game.worldState.turnState.turnNumber}');
+      _log.i('init game complete, turn ${result.game.worldState.turnState.turnNumber}');
       // Set game and route in one setState so no rebuild can see inGameShell with null game.
       setState(() {
         _currentGame = result.game;
@@ -147,7 +147,7 @@ class _CttermAppState extends State<CttermApp> {
         _route = CttermRoute.inGameShell;
       });
     } catch (e, st) {
-      _log.e('tui:app: init game failed', error: e, stackTrace: st);
+      _log.e('init game failed', error: e, stackTrace: st);
       setState(() => _pendingNewGameConfig = null);
       _navigateTo(CttermRoute.mainMenu);
     }
@@ -155,13 +155,13 @@ class _CttermAppState extends State<CttermApp> {
 
   /// Loads a game by ID and navigates to in-game shell.
   Future<void> _loadGame(String gameId) async {
-    _log.d('tui:app: loading game $gameId');
+    _log.d('loading game $gameId');
     final game = await loadGame(gameId, component.dataDirOverride);
     if (game == null) {
-      _log.e('tui:app: failed to load game $gameId');
+      _log.e('failed to load game $gameId');
       return;
     }
-    _log.i('tui:app: loaded game $gameId, turn ${game.worldState.turnState.turnNumber}');
+    _log.i('loaded game $gameId, turn ${game.worldState.turnState.turnNumber}');
     setState(() {
       _currentGame = game;
       _route = CttermRoute.inGameShell;
@@ -170,7 +170,7 @@ class _CttermAppState extends State<CttermApp> {
 
   /// Callback when turn is processed, updates game state and clears orders.
   void _onTurnProcessed(Game updatedGame) {
-    _log.d('tui:app: turn processed, now turn ${updatedGame.worldState.turnState.turnNumber}');
+    _log.d('turn processed, now turn ${updatedGame.worldState.turnState.turnNumber}');
     setState(() {
       _currentGame = updatedGame;
       _currentOrders = const Orders(); // Clear orders after turn is processed
@@ -180,13 +180,13 @@ class _CttermAppState extends State<CttermApp> {
 
   /// Callback to receive game events (combat, diplomacy, research, victory, etc.).
   void _onGameEvent(GameEvent event) {
-    _log.d('tui:event: received ${event.runtimeType}');
+    _log.d('received ${event.runtimeType}');
     setState(() => _gameEvents.add(event));
   }
 
   /// Clears game state (e.g., when returning to main menu).
   void _clearGame() {
-    _log.d('tui:app: clearing game state');
+    _log.d('clearing game state');
     setState(() {
       _currentGame = null;
       _currentOrders = const Orders();
@@ -201,7 +201,7 @@ class _CttermAppState extends State<CttermApp> {
 
   /// Called when turn resolution returns pending overtures; navigate to pending overtures screen.
   void _onTurnResolutionPending(Game game, List<OvertureOffer> pending) {
-    _log.d('tui:app: turn resolution pending ${pending.length} overture(s)');
+    _log.d('turn resolution pending ${pending.length} overture(s)');
     setState(() {
       _currentGame = game;
       _pendingOvertures = pending;
@@ -215,7 +215,7 @@ class _CttermAppState extends State<CttermApp> {
     Game game,
     List<InterventionPrompt> pending,
   ) {
-    _log.d('tui:app: turn resolution pending ${pending.length} intervention(s)');
+    _log.d('turn resolution pending ${pending.length} intervention(s)');
     setState(() {
       _currentGame = game;
       _pendingInterventions = pending;
@@ -229,7 +229,7 @@ class _CttermAppState extends State<CttermApp> {
     Game game,
     List<CallToArmsPending> pending,
   ) {
-    _log.d('tui:app: turn resolution pending ${pending.length} call(s) to arms');
+    _log.d('turn resolution pending ${pending.length} call(s) to arms');
     setState(() {
       _currentGame = game;
       _pendingCallToArms = pending;
@@ -245,7 +245,7 @@ class _CttermAppState extends State<CttermApp> {
     final pending = _pendingOvertures;
     final mapCache = _mapCache;
     if (game == null || pending == null || mapCache == null) {
-      _log.w('tui:app: onOvertureDecisions with null game/pending/mapCache');
+      _log.w('onOvertureDecisions with null game/pending/mapCache');
       return;
     }
     final result = resumeTurnResolutionWithOvertureDecisions(
@@ -258,7 +258,7 @@ class _CttermAppState extends State<CttermApp> {
       onGameEvent: _onGameEvent,
     );
     if (result is TurnResolutionComplete) {
-      _log.d('tui:app: turn resolution complete after overture decisions');
+      _log.d('turn resolution complete after overture decisions');
       setState(() {
         _currentGame = result.game;
         _pendingOvertures = null;
@@ -268,7 +268,7 @@ class _CttermAppState extends State<CttermApp> {
       });
       _onTurnProcessed(result.game);
     } else if (result is TurnResolutionPendingOvertures) {
-      _log.d('tui:app: turn resolution still pending ${result.pendingOvertures.length} overture(s)');
+      _log.d('turn resolution still pending ${result.pendingOvertures.length} overture(s)');
       setState(() {
         _currentGame = result.game;
         _pendingOvertures = result.pendingOvertures;
@@ -277,7 +277,7 @@ class _CttermAppState extends State<CttermApp> {
       });
     } else if (result is TurnResolutionPendingIntervention) {
       _log.d(
-        'tui:app: after overtures, pending ${result.pendingInterventions.length} intervention(s)',
+        'after overtures, pending ${result.pendingInterventions.length} intervention(s)',
       );
       setState(() {
         _currentGame = result.game;
@@ -288,7 +288,7 @@ class _CttermAppState extends State<CttermApp> {
       });
     } else if (result is TurnResolutionPendingCallToArms) {
       _log.d(
-        'tui:app: after overtures, pending ${result.pendingCallToArms.length} call(s) to arms',
+        'after overtures, pending ${result.pendingCallToArms.length} call(s) to arms',
       );
       setState(() {
         _currentGame = result.game;
@@ -304,7 +304,7 @@ class _CttermAppState extends State<CttermApp> {
     final game = _currentGame;
     final mapCache = _mapCache;
     if (game == null || mapCache == null) {
-      _log.w('tui:app: onInterventionDecisions with null game/mapCache');
+      _log.w('onInterventionDecisions with null game/mapCache');
       return;
     }
     final result = resumeTurnResolutionWithInterventionDecisions(
@@ -316,7 +316,7 @@ class _CttermAppState extends State<CttermApp> {
       onGameEvent: _onGameEvent,
     );
     if (result is TurnResolutionComplete) {
-      _log.d('tui:app: turn resolution complete after intervention');
+      _log.d('turn resolution complete after intervention');
       setState(() {
         _currentGame = result.game;
         _pendingInterventions = null;
@@ -355,7 +355,7 @@ class _CttermAppState extends State<CttermApp> {
     final game = _currentGame;
     final mapCache = _mapCache;
     if (game == null || mapCache == null) {
-      _log.w('tui:app: onCallToArmsDecisions with null game/mapCache');
+      _log.w('onCallToArmsDecisions with null game/mapCache');
       return;
     }
     final result = resumeTurnResolutionWithCallToArmsDecisions(
@@ -367,7 +367,7 @@ class _CttermAppState extends State<CttermApp> {
       onGameEvent: _onGameEvent,
     );
     if (result is TurnResolutionComplete) {
-      _log.d('tui:app: turn resolution complete after call to arms');
+      _log.d('turn resolution complete after call to arms');
       setState(() {
         _currentGame = result.game;
         _pendingCallToArms = null;
@@ -404,7 +404,7 @@ class _CttermAppState extends State<CttermApp> {
 
   /// Updates current orders (e.g., from Units panel).
   void _updateOrders(Orders orders) {
-    _log.d('tui:app: orders updated');
+    _log.d('orders updated');
     setState(() => _currentOrders = orders);
   }
 
@@ -455,7 +455,7 @@ class _CttermAppState extends State<CttermApp> {
     final newGame = game.copyWith(
       worldState: ws.copyWith(oldWorld: newRegion, newWorld: newNwRegion),
     );
-    _log.d('tui:app: cancelled in-progress work for unit $unitId');
+    _log.d('cancelled in-progress work for unit $unitId');
     setState(() => _currentGame = newGame);
   }
 
@@ -465,7 +465,7 @@ class _CttermAppState extends State<CttermApp> {
 
   /// Handles theme change from Settings screen.
   void _onThemeChanged(TerminalTheme theme) {
-    _log.d('tui:app: theme changed to ${theme.name}');
+    _log.d('theme changed to ${theme.name}');
     setState(() => _terminalTheme = theme);
   }
 
@@ -511,7 +511,7 @@ class _CttermAppState extends State<CttermApp> {
         onCancelUnitWork: _cancelUnitWork,
         onGameEvent: _onGameEvent,
         onGameUpdated: (game) {
-          _log.d('tui:app: game updated from panel');
+          _log.d('game updated from panel');
           setState(() => _currentGame = game);
         },
         onClearGame: _clearGame,

--- a/ctterm/lib/save_service.dart
+++ b/ctterm/lib/save_service.dart
@@ -7,10 +7,10 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:hive/hive.dart';
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:path/path.dart' as path;
 
-final log_pkg.Logger _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 String? _initDataDir;
 Box<dynamic>? _box;
@@ -63,7 +63,7 @@ Future<Box<dynamic>> _ensureBox([String? dataDirOverride]) async {
     throw StaleLockException(dir);
   }
 
-  _log.d('tui:save: Hive box opened at $dir');
+  _log.d('Hive box opened at $dir');
   return _box!;
 }
 
@@ -74,7 +74,7 @@ void removeStaleLock([String? dataDirOverride]) {
   final lockFile = File(path.join(dir, gamesLockFilename));
   if (lockFile.existsSync()) {
     lockFile.deleteSync();
-    _log.i('tui:save: removed lock file at ${lockFile.path}');
+    _log.i('removed lock file at ${lockFile.path}');
   }
 }
 
@@ -91,7 +91,7 @@ final _adapter = GameSaveAdapter();
 Future<List<String>> listGameIds([String? dataDirOverride]) async {
   final box = await _ensureBox(dataDirOverride);
   final ids = _adapter.listGameIds(box);
-  _log.d('tui:save: listGameIds count=${ids.length}');
+  _log.d('listGameIds count=${ids.length}');
   return ids;
 }
 
@@ -128,7 +128,7 @@ Future<void> saveGameAndMapData(
     combinedTopology: result.combinedTopology,
     warpLinks: result.warpLinks,
   );
-  _log.i('tui:save: saved gameId=${game.id} with map data');
+  _log.i('saved gameId=${game.id} with map data');
 }
 
 /// Summary of a saved game for display in Load Game list.
@@ -179,7 +179,7 @@ Future<List<SaveSummary>> listSaves([String? dataDirOverride]) async {
   // Sort by turn number descending (most recent first)
   summaries.sort((a, b) => b.turnNumber.compareTo(a.turnNumber));
 
-  _log.d('tui:save: listSaves count=${summaries.length}');
+  _log.d('listSaves count=${summaries.length}');
   return summaries;
 }
 
@@ -187,5 +187,5 @@ Future<List<SaveSummary>> listSaves([String? dataDirOverride]) async {
 Future<void> deleteSave(String gameId, [String? dataDirOverride]) async {
   final box = await _ensureBox(dataDirOverride);
   _adapter.delete(box, gameId);
-  _log.i('tui:save: deleted gameId=$gameId');
+  _log.i('deleted gameId=$gameId');
 }

--- a/ctterm/lib/screens/debug_log_viewer_screen.dart
+++ b/ctterm/lib/screens/debug_log_viewer_screen.dart
@@ -1,6 +1,6 @@
 // Debug log viewer. SPEC/program/debug-log-viewer.md. Screen ID 100020.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:logger/logger.dart' show Level;
 import 'package:nocterm/nocterm.dart' hide Logger;
 import 'package:session_log_buffer/session_log_buffer.dart';
 
@@ -19,7 +19,7 @@ class DebugLogViewerScreen extends StatefulComponent {
 
 class _DebugLogViewerScreenState extends State<DebugLogViewerScreen> {
   Set<String> _selectedPrefixes = Set<String>.from(knownPrefixes);
-  Set<log_pkg.Level> _selectedLevels = Set<log_pkg.Level>.from(knownLevels);
+  Set<Level> _selectedLevels = Set<Level>.from(knownLevels);
   int _scrollOffset = 0;
 
   List<SessionLogEntry> get _filtered =>
@@ -86,10 +86,10 @@ class _DebugLogViewerScreenState extends State<DebugLogViewerScreen> {
             final l = knownLevels[levelIdx];
             setState(() {
               if (_selectedLevels.contains(l)) {
-                _selectedLevels = Set<log_pkg.Level>.from(_selectedLevels)
+                _selectedLevels = Set<Level>.from(_selectedLevels)
                   ..remove(l);
               } else {
-                _selectedLevels = Set<log_pkg.Level>.from(_selectedLevels)
+                _selectedLevels = Set<Level>.from(_selectedLevels)
                   ..add(l);
               }
             });
@@ -111,7 +111,7 @@ class _DebugLogViewerScreenState extends State<DebugLogViewerScreen> {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 1),
             child: Text(
-              'Package: ${_selectedPrefixes.join(' ')}  Level: ${_selectedLevels.map((log_pkg.Level l) => l.name).join(' ')}',
+              'Package: ${_selectedPrefixes.join(' ')}  Level: ${_selectedLevels.map((Level l) => l.name).join(' ')}',
               style: TextStyle(color: Colors.gray),
             ),
           ),

--- a/ctterm/lib/screens/defeat_screen.dart
+++ b/ctterm/lib/screens/defeat_screen.dart
@@ -1,11 +1,11 @@
 // Defeat screen: shown when human player loses. SPEC/tui/ctterm.md, SPEC/game/victory.md.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
 
-final log_pkg.Logger _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Defeat screen: shown when another Great Power wins the game.
 /// 
@@ -60,10 +60,10 @@ class _DefeatScreenState extends State<DefeatScreen> {
         // Confirm selection
         if (event.logicalKey == LogicalKey.enter || c == 'e') {
           if (_selectedOption == 'menu') {
-            _log.d('tui:nav: Defeat -> main menu');
+            _log.d('Defeat -> main menu');
             component.onExitToMainMenu();
           } else {
-            _log.d('tui:nav: Defeat -> final map');
+            _log.d('Defeat -> final map');
             component.onNavigate(CttermRoute.inGameShell);
           }
           return true;

--- a/ctterm/lib/screens/development_screen.dart
+++ b/ctterm/lib/screens/development_screen.dart
@@ -1,6 +1,6 @@
 // Development Screen: manage civilian unit work orders. SPEC/tui/screens/development.md.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
@@ -10,7 +10,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final log_pkg.Logger _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Valid work targets per spec: work target id -> display label.
 const _validWorkTargets = {
@@ -245,7 +245,7 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
           _tileWindowStart = 0;
           _feedbackMessage = '';
         });
-        _log.d('tui:nav: cancelled development input mode');
+        _log.d('cancelled development input mode');
         return true;
       }
       // Idle: leave Development screen back to in-game shell.
@@ -309,7 +309,7 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
         _tileWindowStart = 0;
         _feedbackMessage = '';
       });
-      _log.d('tui:nav: cancelled development input mode');
+      _log.d('cancelled development input mode');
       return true;
     }
     // Idle: leave Development screen back to in-game shell.
@@ -398,7 +398,7 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
         _feedbackColor = Colors.yellow;
       });
       _log.d(
-          'tui:development: no eligible tiles for $target and unit ${unit.id}');
+          'no eligible tiles for $target and unit ${unit.id}');
       return;
     }
 
@@ -426,7 +426,7 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
       _feedbackColor = Colors.cyan;
     });
     _log.d(
-        'tui:development: selecting province/tile for $target and unit ${unit.id}');
+        'selecting province/tile for $target and unit ${unit.id}');
   }
 
   /// Ensure the province sliding window keeps the selected province visible.
@@ -653,7 +653,7 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
       _feedbackColor = Colors.green;
     });
 
-    _log.d('tui:development: assigned $target to unit ${unit.id}');
+    _log.d('assigned $target to unit ${unit.id}');
   }
 
   /// Cancel work for a unit: remove pending order and/or clear in-progress currentWork.
@@ -690,7 +690,7 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
       _feedbackColor = Colors.yellow;
     });
 
-    _log.d('tui:development: cancelled work order for unit $unitId');
+    _log.d('cancelled work order for unit $unitId');
   }
 
   /// Get display name for work target.

--- a/ctterm/lib/screens/diplomacy_screen.dart
+++ b/ctterm/lib/screens/diplomacy_screen.dart
@@ -1,13 +1,13 @@
 // Diplomacy Screen: manage relations with other powers. SPEC/tui/screens/diplomacy.md.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Faction type for display.
 enum FactionType { greatPower, minorNation, tribe }
@@ -197,7 +197,7 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
 
     // Escape to go back
     if (key == LogicalKey.escape || c == 'b') {
-      _log.d('tui:nav: diplomacy -> in-game shell');
+      _log.d('diplomacy -> in-game shell');
       component.onNavigate(CttermRoute.inGameShell);
       return true;
     }
@@ -454,7 +454,7 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
     ));
     _updateSelectedFactionRelationState(RelationState.atWar);
     _setStatus('Declared war on ${_selectedFaction!.name}');
-    _log.d('tui:diplomacy: declared war on $targetId');
+    _log.d('declared war on $targetId');
   }
 
   void _handleOfferPeace() {
@@ -492,7 +492,7 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
     // Do NOT update UI to AT_PEACE immediately - wait for turn resolution
     // For GP-GP, peace requires mutual agreement
     _setStatus('Peace offer sent to ${_selectedFaction!.name} (pending resolution)');
-    _log.d('tui:diplomacy: peace offer sent to $targetId');
+    _log.d('peace offer sent to $targetId');
   }
 
   void _handleAlliance() {
@@ -515,7 +515,7 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
       targetFactionId: targetId,
     ));
     _setStatus('Proposed alliance with ${_selectedFaction!.name}');
-    _log.d('tui:diplomacy: proposed alliance with $targetId');
+    _log.d('proposed alliance with $targetId');
   }
 
   void _handleEstablishOverture(OvertureStage stage) {
@@ -572,7 +572,7 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
     _updateSelectedFactionOvertureStage(stage);
     final stageName = _getOvertureStageDisplayName(stage);
     _setStatus('Established $stageName with $factionName');
-    _log.d('tui:diplomacy: established $stage with $targetId');
+    _log.d('established $stage with $targetId');
   }
 
   String _getOvertureStageDisplayName(OvertureStage stage) {
@@ -625,7 +625,7 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
       overtureStage: OvertureStage.joinEmpire,
     ));
     _setStatus('Joining empire: ${_selectedFaction!.name}');
-    _log.d('tui:diplomacy: joining empire with $targetId');
+    _log.d('joining empire with $targetId');
   }
 
   int _getProvinceCount(String factionId) {
@@ -671,7 +671,7 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
       amount: aidAmount,
     ));
     _setStatus('Granted £$aidAmount to ${_selectedFaction!.name}');
-    _log.d('tui:diplomacy: grant aid $aidAmount to $targetId');
+    _log.d('grant aid $aidAmount to $targetId');
   }
 
   void _handleSetSubsidy() {
@@ -698,11 +698,11 @@ class _DiplomacyScreenState extends State<DiplomacyScreen> {
       amount: subsidyAmount,
     ));
     _setStatus('Set subsidy: £$subsidyAmount to ${_selectedFaction!.name}');
-    _log.d('tui:diplomacy: set subsidy $subsidyAmount to $targetId');
+    _log.d('set subsidy $subsidyAmount to $targetId');
   }
 
   void _handleIntervention(InterventionChoice choice) {
-    _log.d('tui:diplomacy: intervention choice $choice for minor $_interventionMinorId');
+    _log.d('intervention choice $choice for minor $_interventionMinorId');
     setState(() {
       _showIntervention = false;
       _setStatus('Intervention: $choice');

--- a/ctterm/lib/screens/game_setup_screen.dart
+++ b/ctterm/lib/screens/game_setup_screen.dart
@@ -1,10 +1,10 @@
 // Game Setup screen. SPEC/tui/screens/game-setup.md, SPEC/tui/ctterm.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
-final log_pkg.Logger _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Number of player slots: 1 human + 5 AI.
 const int _kNumSlots = 6;
@@ -100,7 +100,7 @@ class _GameSetupScreenState extends State<GameSetupScreen> {
     }
 
     if (filledSlots.isEmpty) {
-      _log.i('tui:setup: auto-assign: no changes');
+      _log.i('auto-assign: no changes');
       return;
     }
 
@@ -108,7 +108,7 @@ class _GameSetupScreenState extends State<GameSetupScreen> {
       _orderedGpIdsBySlot = currentOrdered;
       _leaderVariantByGpId = currentLeaders;
     });
-    _log.i('tui:setup: auto-assign filled slots $filledSlots');
+    _log.i('auto-assign filled slots $filledSlots');
   }
 
   /// Check if all slots have nation and leader selected.
@@ -156,7 +156,7 @@ class _GameSetupScreenState extends State<GameSetupScreen> {
       case 'b':
       case 'B':
       case 'escape':
-        _log.d('tui:setup: back pressed');
+        _log.d('back pressed');
         component.onBack();
         break;
       case 'enter':
@@ -209,7 +209,7 @@ class _GameSetupScreenState extends State<GameSetupScreen> {
           }
         }
       });
-      _log.d('tui:setup: slot $slotIndex nation -> $newGpId');
+      _log.d('slot $slotIndex nation -> $newGpId');
     } else {
       // Cycle through leaders for selected nation
       if (gpId.isEmpty) return;
@@ -225,7 +225,7 @@ class _GameSetupScreenState extends State<GameSetupScreen> {
       setState(() {
         _leaderVariantByGpId[gpId] = newVariant;
       });
-      _log.d('tui:setup: slot $slotIndex leader -> $newVariant');
+      _log.d('slot $slotIndex leader -> $newVariant');
     }
   }
 
@@ -242,7 +242,7 @@ class _GameSetupScreenState extends State<GameSetupScreen> {
         }
       }
     }
-    _log.i('tui:setup: start game with ${_orderedGpIdsBySlot.length} players');
+    _log.i('start game with ${_orderedGpIdsBySlot.length} players');
     component.onStartGame(
       List<String>.from(_orderedGpIdsBySlot),
       leaderMap,

--- a/ctterm/lib/screens/generating_world_screen.dart
+++ b/ctterm/lib/screens/generating_world_screen.dart
@@ -2,10 +2,10 @@
 
 import 'dart:async';
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
-final log_pkg.Logger _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Screen shown while the game world is being generated.
 /// SPEC/tui/screens/generating-world.md.
@@ -102,20 +102,20 @@ class _GeneratingWorldScreenState extends State<GeneratingWorldScreen> {
 
   void _onGenerationComplete() {
     if (_cancelled) return;
-    _log.d('tui:nav: World generation complete -> in-game shell');
+    _log.d('World generation complete -> in-game shell');
     component.onComplete();
   }
 
   void _handleCancel() {
     if (_error != null) {
       // After error, any key returns to main menu
-      _log.d('tui:nav: Generation error acknowledged -> main menu');
+      _log.d('Generation error acknowledged -> main menu');
       component.onCancel();
       return;
     }
 
     _cancelled = true;
-    _log.d('tui:nav: Generation cancelled by user -> main menu');
+    _log.d('Generation cancelled by user -> main menu');
     component.onCancel();
   }
 

--- a/ctterm/lib/screens/in_game_shell_screen.dart
+++ b/ctterm/lib/screens/in_game_shell_screen.dart
@@ -2,7 +2,7 @@
 // SPEC/tui/ctterm.md, SPEC/tui/screens/in-game-shell.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
@@ -11,7 +11,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:ctterm/map_tui_mapping.dart';
 
-final log_pkg.Logger _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// In-game shell: topology graph map, HUD, province info panel, navigation to panels.
 class InGameShellScreen extends StatefulComponent {
@@ -309,7 +309,7 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
       _neighbourIndex = 0;
     });
     _ensureSelection();
-    _log.d('tui:map: region changed to $_selectedRegion');
+    _log.d('region changed to $_selectedRegion');
   }
 
   void _selectNextNeighbour() {
@@ -422,7 +422,7 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
   Future<void> _handleEndTurn() async {
     if (_isEndingTurn) return;
     setState(() => _isEndingTurn = true);
-    _log.d('tui:game: ending turn $_turn');
+    _log.d('ending turn $_turn');
     await component.onEndTurn();
     final game = component.game;
     if (game?.victory != null) {
@@ -450,7 +450,7 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
         if (_isConfirmingEndTurn) {
           if (key == LogicalKey.enter || c == 'y') {
             _log.d(
-                'tui:game: end turn confirmed with $_idleCivilianCountForPrompt idle civilian unit(s)');
+                'end turn confirmed with $_idleCivilianCountForPrompt idle civilian unit(s)');
             setState(() {
               _isConfirmingEndTurn = false;
               _idleCivilianCountForPrompt = 0;
@@ -460,7 +460,7 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
           }
           if (key == LogicalKey.escape || c == 'n') {
             _log.d(
-                'tui:game: end turn cancelled with $_idleCivilianCountForPrompt idle civilian unit(s)');
+                'end turn cancelled with $_idleCivilianCountForPrompt idle civilian unit(s)');
             setState(() {
               _isConfirmingEndTurn = false;
               _idleCivilianCountForPrompt = 0;
@@ -503,7 +503,7 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
           return true;
         }
         if (c == 'm') {
-          _log.d('tui:nav: in-game shell -> map context');
+          _log.d('in-game shell -> map context');
           component.onNavigate(CttermRoute.mapContext);
           return true;
         }
@@ -1009,7 +1009,7 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
               onKeyEvent: (event) {
                 if (event.logicalKey == LogicalKey.enter ||
                     event.character == '\r') {
-                  _log.d('tui:dialogue: game start intro dismissed');
+                  _log.d('game start intro dismissed');
                   component.onIntroDismissed?.call();
                   return true;
                 }

--- a/ctterm/lib/screens/load_game_screen.dart
+++ b/ctterm/lib/screens/load_game_screen.dart
@@ -1,11 +1,11 @@
 // Load Game screen. SPEC/tui/screens/load-game.md, SPEC/tui/ctterm.md.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/save_service.dart';
 
-final log_pkg.Logger _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Load Game: lists saved games, allows load or delete.
 class LoadGameScreen extends StatefulComponent {
@@ -96,14 +96,14 @@ class _LoadGameScreenState extends State<LoadGameScreen> {
   void _doLoad() {
     if (_saves.isEmpty || _selectedIndex >= _saves.length) return;
     final gameId = _saves[_selectedIndex].gameId;
-    _log.d('tui:save: load gameId=$gameId');
+    _log.d('load gameId=$gameId');
     component.onLoad(gameId);
   }
 
   void _doDelete() {
     if (_saves.isEmpty || _selectedIndex >= _saves.length) return;
     final gameId = _saves[_selectedIndex].gameId;
-    _log.i('tui:save: delete gameId=$gameId');
+    _log.i('delete gameId=$gameId');
     component.onDelete(gameId);
     setState(() {
       _saves.removeAt(_selectedIndex);

--- a/ctterm/lib/screens/main_menu_screen.dart
+++ b/ctterm/lib/screens/main_menu_screen.dart
@@ -1,12 +1,12 @@
 // Main Menu. SPEC/ui/main-menu.md, SPEC/tui/ctterm.md.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/menu_logic.dart';
 import 'package:ctterm/save_service.dart';
 
-final log_pkg.Logger _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Main menu: New Game, Load Game (L always navigates; list empty when no saves), Settings, Debug log, Quit.
 class MainMenuScreen extends StatefulComponent {
@@ -45,14 +45,14 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
     try {
       final ids = await listGameIds(component.dataDirOverride)
           .timeout(const Duration(seconds: 5), onTimeout: () => <String>[]);
-      _log.d('tui:menu: listGameIds count=${ids.length}');
+      _log.d('listGameIds count=${ids.length}');
       if (!mounted) return;
       setState(() {
         _loadGameEnabled = isLoadGameEnabled(ids);
         _savesChecked = true;
       });
     } catch (e, st) {
-      _log.w('tui:menu: checkSaves failed', error: e, stackTrace: st);
+      _log.w('checkSaves failed', error: e, stackTrace: st);
       if (!mounted) return;
       setState(() {
         _loadGameEnabled = false;

--- a/ctterm/lib/screens/map_context_screen.dart
+++ b/ctterm/lib/screens/map_context_screen.dart
@@ -2,12 +2,12 @@
 // SPEC/tui/ctterm.md, SPEC/tui/screens/map-context.md
 
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
 
-final log_pkg.Logger _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Map context screen showing detailed province information, map layers, and region navigation.
 class MapContextScreen extends StatefulComponent {
@@ -111,7 +111,7 @@ class _MapContextScreenState extends State<MapContextScreen> {
       final idx = _regions.indexOf(_currentRegion);
       _currentRegion = _regions[(idx + 1) % _regions.length];
     });
-    _log.d('tui:map: region changed to $_currentRegion');
+    _log.d('region changed to $_currentRegion');
   }
 
   void _toggleLayer(int layer) {
@@ -132,7 +132,7 @@ class _MapContextScreenState extends State<MapContextScreen> {
       }
     });
     _log.d(
-        'tui:map: layer toggled: terrain=$_showTerrain ownership=$_showOwnership towns=$_showTowns fog=$_showFog');
+        'layer toggled: terrain=$_showTerrain ownership=$_showOwnership towns=$_showTowns fog=$_showFog');
   }
 
   void _moveCursor(int dx, int dy) {
@@ -151,7 +151,7 @@ class _MapContextScreenState extends State<MapContextScreen> {
     setState(() {
       _tileMode = !_tileMode;
     });
-    _log.d('tui:map: selection mode: ${_tileMode ? "tile" : "province"}');
+    _log.d('selection mode: ${_tileMode ? "tile" : "province"}');
   }
 
   /// Gets the currently selected province data.
@@ -276,7 +276,7 @@ class _MapContextScreenState extends State<MapContextScreen> {
 
         // Escape - go back
         if (key == LogicalKey.escape) {
-          _log.d('tui:nav: map context -> in-game shell');
+          _log.d('map context -> in-game shell');
           component.onNavigate(CttermRoute.inGameShell);
           return true;
         }

--- a/ctterm/lib/screens/pause_options_screen.dart
+++ b/ctterm/lib/screens/pause_options_screen.dart
@@ -1,11 +1,11 @@
 // Pause/Options screen. SPEC/tui/screens/pause-options.md.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
 
-final _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Pause menu with exit to main menu and settings options.
 class PauseOptionsScreen extends StatefulComponent {
@@ -95,7 +95,7 @@ class _PauseOptionsScreenState extends State<PauseOptionsScreen> {
     // Handle exit confirmation
     if (_showExitConfirm) {
       if (c == 'y' || key == LogicalKey.enter) {
-        _log.d('tui:nav: exiting to main menu from pause');
+        _log.d('exiting to main menu from pause');
         component.onExitToMainMenu();
         return true;
       } else if (c == 'n' || key == LogicalKey.escape) {

--- a/ctterm/lib/screens/pending_call_to_arms_screen.dart
+++ b/ctterm/lib/screens/pending_call_to_arms_screen.dart
@@ -1,12 +1,12 @@
 // Pending call to arms: join or refuse when an ally is declared upon. SPEC/game/diplomacy.md.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Screen when turn resolution blocks on human ally call to arms.
 class PendingCallToArmsScreen extends StatefulComponent {
@@ -121,7 +121,7 @@ class _PendingCallToArmsScreenState extends State<PendingCallToArmsScreen> {
           ),
         );
       }
-      _log.d('tui:call_to_arms: submitting ${decisions.length} decision(s)');
+      _log.d('submitting ${decisions.length} decision(s)');
       component.onDecisions(decisions);
       return true;
     }

--- a/ctterm/lib/screens/pending_intervention_screen.dart
+++ b/ctterm/lib/screens/pending_intervention_screen.dart
@@ -1,13 +1,13 @@
 // Pending intervention: Diplomacy-phase choices when a GP attacks Minor/Tribe.
 // SPEC/tui/screens/pending-intervention.md, SPEC/program/dialogue-system.md.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Blocking screen: human chooses intervene / do naught / protest per prompt.
 class PendingInterventionScreen extends StatefulComponent {
@@ -160,7 +160,7 @@ class _PendingInterventionScreenState extends State<PendingInterventionScreen> {
           ),
         );
       }
-      _log.d('tui:intervention: submitting ${decisions.length} decision(s)');
+      _log.d('submitting ${decisions.length} decision(s)');
       component.onDecisions(decisions);
       return true;
     }

--- a/ctterm/lib/screens/pending_overtures_screen.dart
+++ b/ctterm/lib/screens/pending_overtures_screen.dart
@@ -1,13 +1,13 @@
 // Pending overtures: accept/reject diplomatic offers during turn resolution.
 // SPEC/program/turn-resolution-phases.md, SPEC/game/diplomacy.md.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Screen shown when turn resolution blocks on the human player accepting or
 /// rejecting diplomatic overtures from other players.
@@ -138,7 +138,7 @@ class _PendingOverturesScreenState extends State<PendingOverturesScreen> {
           accepted: _accepted[i],
         ));
       }
-      _log.d('tui:overtures: submitting ${decisions.length} decision(s)');
+      _log.d('submitting ${decisions.length} decision(s)');
       component.onDecisions(decisions);
       return true;
     }

--- a/ctterm/lib/screens/production_screen.dart
+++ b/ctterm/lib/screens/production_screen.dart
@@ -1,13 +1,13 @@
 // Production Screen: manage resource extraction, stockpile, and production. SPEC/tui/screens/production.md.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_data/colonizethis_data.dart' as data;
 
-final log_pkg.Logger _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Production recipe definition for display.
 class ProductionRecipe {
@@ -309,7 +309,7 @@ class _ProductionScreenState extends State<ProductionScreen> {
 
     // Escape: back to shell
     if (key == LogicalKey.escape) {
-      _log.d('tui:nav: Production -> shell');
+      _log.d('Production -> shell');
       component.onNavigate(CttermRoute.inGameShell);
       return true;
     }

--- a/ctterm/lib/screens/settings_screen.dart
+++ b/ctterm/lib/screens/settings_screen.dart
@@ -1,9 +1,9 @@
 // Settings screen. SPEC/tui/ctterm.md, SPEC/tui/screens/settings.md.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
-final log_pkg.Logger _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Available terminal themes.
 enum TerminalTheme {
@@ -40,12 +40,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
   void initState() {
     super.initState();
     _selectedTheme = component.initialTheme ?? TerminalTheme.dark;
-    _log.d('tui:settings: init, theme=${_selectedTheme.name}');
+    _log.d('init, theme=${_selectedTheme.name}');
   }
 
   void _selectTheme(TerminalTheme theme) {
     setState(() => _selectedTheme = theme);
-    _log.d('tui:settings: theme selected=${theme.name}');
+    _log.d('theme selected=${theme.name}');
     // Notify parent to apply theme
     component.onThemeChanged?.call(theme);
   }

--- a/ctterm/lib/screens/shell_screen.dart
+++ b/ctterm/lib/screens/shell_screen.dart
@@ -1,6 +1,6 @@
 // Navigation shell: switches on route and shows Main Menu or stub. SPEC/tui/ctterm.md.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
@@ -31,7 +31,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final log_pkg.Logger _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Displays the current route (Main Menu or a stub) and handles back/exit.
 class ShellScreen extends StatefulComponent {
@@ -180,7 +180,7 @@ class _ShellScreenState extends State<ShellScreen> {
   void _triggerVictory() {
     final game = component.game;
     final turn = game?.victory?.turnNumber ?? 1;
-    _log.d('tui:game: victory triggered, turn $turn');
+    _log.d('victory triggered, turn $turn');
     component.onNavigate(CttermRoute.victory);
   }
 
@@ -190,7 +190,7 @@ class _ShellScreenState extends State<ShellScreen> {
     final game = component.game;
     final turn = game?.victory?.turnNumber ?? 1;
     final winnerId = game?.victory?.winnerPlayerId;
-    _log.d('tui:game: defeat triggered, turn $turn, winner=$winnerId');
+    _log.d('defeat triggered, turn $turn, winner=$winnerId');
     component.onNavigate(CttermRoute.defeat);
   }
 
@@ -205,13 +205,13 @@ class _ShellScreenState extends State<ShellScreen> {
               component.route == CttermRoute.loadGame ||
               component.route == CttermRoute.settings ||
               component.route == CttermRoute.generatingWorld) {
-            _log.d('tui:nav: Esc -> main menu');
+            _log.d('Esc -> main menu');
             component.onNavigate(CttermRoute.mainMenu);
             return true;
           }
           // In-game panels: Esc -> back to in-game shell (so Escape works even if panel does not receive key)
           if (component.route == CttermRoute.debugLogViewer) {
-            _log.d('tui:nav: Esc -> from debug log viewer');
+            _log.d('Esc -> from debug log viewer');
             component.onNavigate(
                 component.debugLogViewerReturnRoute ?? CttermRoute.mainMenu);
             return true;
@@ -226,7 +226,7 @@ class _ShellScreenState extends State<ShellScreen> {
               component.route == CttermRoute.technology ||
               component.route == CttermRoute.victoryProgress ||
               component.route == CttermRoute.pauseOptions) {
-            _log.d('tui:nav: Esc -> in-game shell');
+            _log.d('Esc -> in-game shell');
             component.onNavigate(CttermRoute.inGameShell);
             return true;
           }
@@ -280,7 +280,7 @@ class _ShellScreenState extends State<ShellScreen> {
         return GameSetupScreen(
           onStartGame:
               (orderedGpIdsForSlots, leaderVariantByGpId, enforceFairGp) {
-            _log.d('tui:nav: Game Setup complete -> generating world');
+            _log.d('Game Setup complete -> generating world');
             component.onPrepareNewGame?.call(
               orderedGpIdsForSlots,
               leaderVariantByGpId,
@@ -294,12 +294,12 @@ class _ShellScreenState extends State<ShellScreen> {
         return LoadGameScreen(
           dataDirOverride: component.dataDirOverride,
           onLoad: (gameId) async {
-            _log.d('tui:nav: Load gameId=$gameId');
+            _log.d('Load gameId=$gameId');
             // Use the app's loadGame callback to load and navigate
             await component.onLoadGame?.call(gameId);
           },
           onDelete: (gameId) async {
-            _log.i('tui:save: deleting gameId=$gameId');
+            _log.i('deleting gameId=$gameId');
             // Import is already at top, just use deleteSave
             await deleteSave(gameId, component.dataDirOverride);
           },
@@ -331,11 +331,11 @@ class _ShellScreenState extends State<ShellScreen> {
           onEndTurn: () async {
             final game = component.game;
             if (game == null) {
-              _log.w('tui:game: no game to process turn');
+              _log.w('no game to process turn');
               return;
             }
             _log.d(
-                'tui:game: processing turn ${game.worldState.turnState.turnNumber}');
+                'processing turn ${game.worldState.turnState.turnNumber}');
 
             final currentOrders = component.orders ?? const Orders();
             final topology = component.combinedTopology ?? const MapTopology();
@@ -349,14 +349,14 @@ class _ShellScreenState extends State<ShellScreen> {
             );
             if (result is TurnResolutionPendingOvertures) {
               _log.d(
-                  'tui:game: turn resolution pending ${result.pendingOvertures.length} overture(s)');
+                  'turn resolution pending ${result.pendingOvertures.length} overture(s)');
               component.onTurnResolutionPending
                   ?.call(result.game, result.pendingOvertures);
               return;
             }
             if (result is TurnResolutionPendingIntervention) {
               _log.d(
-                  'tui:game: turn resolution pending ${result.pendingInterventions.length} intervention(s)');
+                  'turn resolution pending ${result.pendingInterventions.length} intervention(s)');
               component.onTurnResolutionPendingIntervention?.call(
                 result.game,
                 result.pendingInterventions,
@@ -365,7 +365,7 @@ class _ShellScreenState extends State<ShellScreen> {
             }
             if (result is TurnResolutionPendingCallToArms) {
               _log.d(
-                  'tui:game: turn resolution pending ${result.pendingCallToArms.length} call(s) to arms');
+                  'turn resolution pending ${result.pendingCallToArms.length} call(s) to arms');
               component.onTurnResolutionPendingCallToArms
                   ?.call(result.game, result.pendingCallToArms);
               return;
@@ -373,12 +373,12 @@ class _ShellScreenState extends State<ShellScreen> {
             final nextGame = requireTurnResolutionComplete(result);
             component.onTurnProcessed?.call(nextGame);
             _log.i(
-                'tui:game: turn processed, now turn ${nextGame.worldState.turnState.turnNumber}');
+                'turn processed, now turn ${nextGame.worldState.turnState.turnNumber}');
           },
           onVictory: _triggerVictory,
           onDefeat: _triggerDefeat,
           onExitToMainMenu: () {
-            _log.d('tui:nav: exit to main menu');
+            _log.d('exit to main menu');
             component.onClearGame?.call();
             component.onNavigate(CttermRoute.mainMenu);
           },
@@ -463,7 +463,7 @@ class _ShellScreenState extends State<ShellScreen> {
         return VictoryScreen(
           onNavigate: component.onNavigate,
           onExitToMainMenu: () {
-            _log.d('tui:nav: Victory -> main menu');
+            _log.d('Victory -> main menu');
             component.onNavigate(CttermRoute.mainMenu);
           },
           victoryType: victory?.type.name ?? 'Military',
@@ -480,7 +480,7 @@ class _ShellScreenState extends State<ShellScreen> {
         return DefeatScreen(
           onNavigate: component.onNavigate,
           onExitToMainMenu: () {
-            _log.d('tui:nav: Defeat -> main menu');
+            _log.d('Defeat -> main menu');
             component.onNavigate(CttermRoute.mainMenu);
           },
           winnerName: victory?.winnerPlayerId ?? 'AI Player',
@@ -492,7 +492,7 @@ class _ShellScreenState extends State<ShellScreen> {
         return PauseOptionsScreen(
           onNavigate: component.onNavigate,
           onExitToMainMenu: () {
-            _log.d('tui:nav: exit to main menu from pause');
+            _log.d('exit to main menu from pause');
             component.onClearGame?.call();
             component.onNavigate(CttermRoute.mainMenu);
           },
@@ -511,7 +511,7 @@ class _ShellScreenState extends State<ShellScreen> {
             pending.isEmpty ||
             onDecisions == null) {
           _log.w(
-              'tui:nav: pendingOvertures route with missing game/pending/onDecisions');
+              'pendingOvertures route with missing game/pending/onDecisions');
           return const Padding(
               padding: EdgeInsets.all(1), child: Text('No pending overtures.'));
         }
@@ -529,7 +529,7 @@ class _ShellScreenState extends State<ShellScreen> {
             ctaPending.isEmpty ||
             onCta == null) {
           _log.w(
-              'tui:nav: pendingCallToArms route with missing game/pending/onDecisions');
+              'pendingCallToArms route with missing game/pending/onDecisions');
           return const Padding(
             padding: EdgeInsets.all(1),
             child: Text('No pending call to arms.'),
@@ -549,7 +549,7 @@ class _ShellScreenState extends State<ShellScreen> {
             ivPending.isEmpty ||
             onIv == null) {
           _log.w(
-              'tui:nav: pendingIntervention route with missing game/pending/onDecisions');
+              'pendingIntervention route with missing game/pending/onDecisions');
           return const Padding(
             padding: EdgeInsets.all(1),
             child: Text('No pending intervention.'),

--- a/ctterm/lib/screens/shipyard_screen.dart
+++ b/ctterm/lib/screens/shipyard_screen.dart
@@ -1,13 +1,13 @@
 // Shipyard Screen: construct naval units. SPEC/tui/screens/shipyard.md.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Display info for a ship type in the Shipyard.
 class ShipDisplayInfo {
@@ -165,7 +165,7 @@ class _ShipyardScreenState extends State<ShipyardScreen> {
       navalMissionOrdersByPlayerId: component.orders.navalMissionOrdersByPlayerId,
     );
     component.onOrdersChanged(newOrders);
-    _log.i('tui:shipyard: build order for ${ship.name} in $provinceId');
+    _log.i('build order for ${ship.name} in $provinceId');
     setState(() { _inputMode = 'none'; _provinceInput = ''; _feedbackMessage = 'Build order issued'; _feedbackColor = Colors.green; });
   }
 

--- a/ctterm/lib/screens/technology_screen.dart
+++ b/ctterm/lib/screens/technology_screen.dart
@@ -1,6 +1,6 @@
 // Technology screen — research panel. SPEC/tui/screens/technology.md.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
@@ -8,7 +8,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Technology research panel.
 /// Shows research slots, available techs, and allows assigning research.
@@ -173,7 +173,7 @@ class _TechnologyScreenState extends State<TechnologyScreen> {
         setState(() {
           _feedbackMessage = 'Prerequisites not met: ${missing.join(', ')}';
         });
-        _log.d('tui:tech: failed to assign $techId - missing prerequisites: $missing');
+        _log.d('failed to assign $techId - missing prerequisites: $missing');
         return;
       }
     }
@@ -217,7 +217,7 @@ class _TechnologyScreenState extends State<TechnologyScreen> {
     );
 
     component.onOrdersChanged(newOrders);
-    _log.d('tui:tech: assigned $techId to slot ${_selectedSlot + 1}');
+    _log.d('assigned $techId to slot ${_selectedSlot + 1}');
   }
 
   // Set funding level for slot
@@ -252,7 +252,7 @@ class _TechnologyScreenState extends State<TechnologyScreen> {
     );
 
     component.onOrdersChanged(newOrders);
-    _log.d('tui:tech: set funding ${level.name} for slot ${_selectedSlot + 1}');
+    _log.d('set funding ${level.name} for slot ${_selectedSlot + 1}');
   }
 
   // Cancel research in slot
@@ -279,7 +279,7 @@ class _TechnologyScreenState extends State<TechnologyScreen> {
 
     component.onOrdersChanged(newOrders);
     setState(() => _showCancelConfirm = false);
-    _log.d('tui:tech: cancelled slot ${_selectedSlot + 1}');
+    _log.d('cancelled slot ${_selectedSlot + 1}');
   }
 
   @override

--- a/ctterm/lib/screens/units_screen.dart
+++ b/ctterm/lib/screens/units_screen.dart
@@ -1,6 +1,6 @@
 // Units Screen: manage military and civilian unit orders. SPEC/tui/screens/units.md.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
@@ -9,7 +9,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart'
     show neighborProvinceIdsInRegion;
 
-final log_pkg.Logger _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Units screen for managing unit stacks and issuing orders.
 class UnitsScreen extends StatefulComponent {
@@ -145,7 +145,7 @@ class _UnitsScreenState extends State<UnitsScreen> {
           _inputMode = 'none';
           _feedbackMessage = '';
         });
-        _log.d('tui:nav: cancelled input mode');
+        _log.d('cancelled input mode');
         return true;
       }
       component.onNavigate(CttermRoute.inGameShell);
@@ -195,7 +195,7 @@ class _UnitsScreenState extends State<UnitsScreen> {
     // Enter/Space: select unit (show detail)
     if (key == LogicalKey.enter || key == LogicalKey.space) {
       // For now, just show the unit detail
-      _log.d('tui:units: selected unit ${units[_selectedIndex].id}');
+      _log.d('selected unit ${units[_selectedIndex].id}');
       return true;
     }
 
@@ -213,7 +213,7 @@ class _UnitsScreenState extends State<UnitsScreen> {
           _feedbackMessage = 'ERROR: Selected unit cannot attack';
           _feedbackColor = Colors.red;
         });
-        _log.w('tui:units: attack rejected - ${unit.type} cannot initiate combat');
+        _log.w('attack rejected - ${unit.type} cannot initiate combat');
         return true;
       }
       _startAttackOrder(unit);
@@ -344,7 +344,7 @@ class _UnitsScreenState extends State<UnitsScreen> {
       _feedbackMessage = 'Move to province:';
       _feedbackColor = Colors.yellow;
     });
-    _log.d('tui:units: start move order for ${unit.id}');
+    _log.d('start move order for ${unit.id}');
   }
 
   void _startAttackOrder(Unit unit) {
@@ -353,7 +353,7 @@ class _UnitsScreenState extends State<UnitsScreen> {
         _feedbackMessage = 'ERROR: Selected unit cannot attack';
         _feedbackColor = Colors.red;
       });
-      _log.w('tui:units: startAttackOrder called for non-combat unit ${unit.id} (${unit.type})');
+      _log.w('startAttackOrder called for non-combat unit ${unit.id} (${unit.type})');
       return;
     }
     // Use only enemy-controlled adjacent provinces for attack targeting
@@ -371,7 +371,7 @@ class _UnitsScreenState extends State<UnitsScreen> {
       _feedbackMessage = 'Select enemy province to attack:';
       _feedbackColor = Colors.yellow;
     });
-    _log.d('tui:units: start attack order for ${unit.id}');
+    _log.d('start attack order for ${unit.id}');
   }
 
   void _issueMoveOrder(Unit unit, String targetProvince) {
@@ -413,7 +413,7 @@ class _UnitsScreenState extends State<UnitsScreen> {
       _feedbackMessage = 'Move order accepted';
       _feedbackColor = Colors.green;
     });
-    _log.i('tui:units: move order accepted for ${unit.id} -> $targetProvince');
+    _log.i('move order accepted for ${unit.id} -> $targetProvince');
   }
 
   void _issueAttackOrder(Unit unit, String targetProvince) {
@@ -451,7 +451,7 @@ class _UnitsScreenState extends State<UnitsScreen> {
         _feedbackMessage = 'Invalid: cannot attack your own province';
         _feedbackColor = Colors.red;
       });
-      _log.w('tui:units: attack rejected - target ${targetProvince} owned by player ${playerId}');
+      _log.w('attack rejected - target ${targetProvince} owned by player ${playerId}');
       return;
     }
 
@@ -483,7 +483,7 @@ class _UnitsScreenState extends State<UnitsScreen> {
       _feedbackMessage = 'Attack order accepted';
       _feedbackColor = Colors.green;
     });
-    _log.i('tui:units: attack order accepted for ${unit.id} -> $targetProvince');
+    _log.i('attack order accepted for ${unit.id} -> $targetProvince');
   }
 
   void _clearOrders(Unit unit) {
@@ -509,7 +509,7 @@ class _UnitsScreenState extends State<UnitsScreen> {
         _feedbackMessage = 'Orders cleared';
         _feedbackColor = Colors.cyan;
       });
-      _log.i('tui:units: cleared orders for ${unit.id}');
+      _log.i('cleared orders for ${unit.id}');
     } else {
       setState(() {
         _feedbackMessage = 'No pending orders to clear';

--- a/ctterm/lib/screens/victory_progress_screen.dart
+++ b/ctterm/lib/screens/victory_progress_screen.dart
@@ -1,11 +1,11 @@
 // Victory/Progress screen: shows progress toward victory. SPEC/tui/ctterm.md, SPEC/tui/screens/victory-progress.md.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
 
-final log_pkg.Logger _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Victory/Progress screen: shows progress toward victory condition.
 /// 
@@ -56,18 +56,18 @@ class _VictoryProgressScreenState extends State<VictoryProgressScreen> {
       onKeyEvent: (event) {
         if (event.logicalKey == LogicalKey.escape || 
             event.character?.toLowerCase() == 'b') {
-          _log.d('tui:nav: Victory/Progress -> shell');
+          _log.d('Victory/Progress -> shell');
           component.onNavigate(CttermRoute.inGameShell);
           return true;
         }
         // For testing: V = victory, D = defeat
         if (event.character?.toLowerCase() == 'v') {
-          _log.d('tui:game: test victory triggered');
+          _log.d('test victory triggered');
           component.onVictory();
           return true;
         }
         if (event.character?.toLowerCase() == 'd') {
-          _log.d('tui:game: test defeat triggered');
+          _log.d('test defeat triggered');
           component.onDefeat();
           return true;
         }

--- a/ctterm/lib/screens/victory_screen.dart
+++ b/ctterm/lib/screens/victory_screen.dart
@@ -1,11 +1,11 @@
 // Victory screen: shown when human player wins. SPEC/tui/ctterm.md, SPEC/game/victory.md.
 
-import 'package:logger/logger.dart' as log_pkg;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
 
-final log_pkg.Logger _log = log_pkg.Logger();
+final _log = tuiLogger();
 
 /// Victory screen: shown when human player wins the game.
 /// 
@@ -57,10 +57,10 @@ class _VictoryScreenState extends State<VictoryScreen> {
         // Confirm selection
         if (event.logicalKey == LogicalKey.enter || c == 'e') {
           if (_selectedOption == 'menu') {
-            _log.d('tui:nav: Victory -> main menu');
+            _log.d('Victory -> main menu');
             component.onExitToMainMenu();
           } else {
-            _log.d('tui:nav: Victory -> final map');
+            _log.d('Victory -> final map');
             component.onNavigate(CttermRoute.inGameShell);
           }
           return true;

--- a/ctterm/pubspec.yaml
+++ b/ctterm/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   nocterm: ^0.4.4
+  colonizethis_logger: any
   logger: ^2.0.2
   basic_logger: ^0.2.2
   basic_logger_file: ^0.1.3

--- a/packages/colonizethis_data/lib/src/game_setup_config.dart
+++ b/packages/colonizethis_data/lib/src/game_setup_config.dart
@@ -35,7 +35,7 @@ class GameSetupConfig {
        assert(minProvincesPerMinor >= 0),
        assert(numProvincesNewWorld >= 1) {
     _log.d(
-      'data: GameSetupConfig created OW=$numProvincesOldWorld NW=$numProvincesNewWorld',
+      'GameSetupConfig created OW=$numProvincesOldWorld NW=$numProvincesNewWorld',
     );
   }
 

--- a/packages/colonizethis_logger/lib/src/ct_logger.dart
+++ b/packages/colonizethis_logger/lib/src/ct_logger.dart
@@ -60,3 +60,6 @@ CtLogger gameLogger([String? subPrefix]) =>
 
 CtLogger appLogger([String? subPrefix]) =>
     subPrefix != null ? CtLogger('app.$subPrefix') : CtLogger('app');
+
+CtLogger ctdevLogger([String? subPrefix]) =>
+    subPrefix != null ? CtLogger('ctdev.$subPrefix') : CtLogger('ctdev');

--- a/packages/colonizethis_logger/lib/src/prefixes.dart
+++ b/packages/colonizethis_logger/lib/src/prefixes.dart
@@ -6,8 +6,10 @@ const String kLogPrefixSave = 'save';
 const String kLogPrefixTui = 'tui';
 const String kLogPrefixGame = 'game';
 const String kLogPrefixApp = 'app';
+const String kLogPrefixCtdev = 'ctdev';
 
 const List<String> allLogPrefixes = [
+  kLogPrefixCtdev,
   kLogPrefixLogic,
   kLogPrefixAi,
   kLogPrefixData,

--- a/packages/colonizethis_logger/test/ct_logger_test.dart
+++ b/packages/colonizethis_logger/test/ct_logger_test.dart
@@ -82,6 +82,7 @@ void main() {
     });
 
     test('factory functions create loggers with correct prefixes', () {
+      expect(ctdevLogger().prefix, 'ctdev');
       expect(logicLogger().prefix, 'logic');
       expect(aiLogger().prefix, 'ai');
       expect(dataLogger().prefix, 'data');
@@ -104,6 +105,7 @@ void main() {
 
   group('prefixes', () {
     test('allLogPrefixes contains expected prefixes', () {
+      expect(allLogPrefixes, contains('ctdev'));
       expect(allLogPrefixes, contains('logic'));
       expect(allLogPrefixes, contains('ai'));
       expect(allLogPrefixes, contains('data'));
@@ -123,6 +125,7 @@ void main() {
       expect(kLogPrefixTui, 'tui');
       expect(kLogPrefixGame, 'game');
       expect(kLogPrefixApp, 'app');
+      expect(kLogPrefixCtdev, 'ctdev');
     });
   });
 }

--- a/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
@@ -153,7 +153,7 @@ Game resolveBattleContext(
       defenderLeaderMultiplier: defenderLeaderMult,
     );
     _combatLog.d(
-      'logic: combat engagement regionId=${ctx.regionId} provinceId=${ctx.provinceId} '
+      'combat engagement regionId=${ctx.regionId} provinceId=${ctx.provinceId} '
       'attackerFactionId=${attacker.side.factionId} result=${outcome.result.name} '
       'attCasualties=${outcome.attackerCasualties.length} '
       'defCasualties=${outcome.defenderCasualties.length}',
@@ -248,7 +248,7 @@ Game resolveBattleContext(
     }
   }
   _combatLog.i(
-    'logic: combat battle_apply regionId=${ctx.regionId} provinceId=${ctx.provinceId} '
+    'combat battle_apply regionId=${ctx.regionId} provinceId=${ctx.provinceId} '
     'mode=autoResolve provinceFlipped=${post.provinceChangedOwner} '
     'casualtiesApplied=${allCasualties.length} ownerAfter=$ownerAfter',
   );

--- a/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
@@ -290,7 +290,7 @@ NavalBattleResult resolveSeaBattle(
   }
 
   _log.d(
-    'logic: naval battle zone=${battle.seaZoneId} side1=${battle.side1.ownerId} side2=${battle.side2.ownerId} '
+    'naval battle zone=${battle.seaZoneId} side1=${battle.side1.ownerId} side2=${battle.side2.ownerId} '
     'outcome=${outcome.name} retreat1=$side1Retreated retreat2=$side2Retreated',
   );
 

--- a/packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
@@ -35,7 +35,7 @@ QuickBattleResult resolveQuickBattle(
   List<QuickBattleRoundActions>? roundActions,
 }) {
   _qbLog.d(
-    'logic: quick_battle start province=${input.provinceId} '
+    'quick_battle start province=${input.provinceId} '
     'seed=${input.seed} rounds=${input.maxRounds}',
   );
   final rng = Random(input.seed);
@@ -114,7 +114,7 @@ QuickBattleResult resolveQuickBattle(
           useVirtualEmplaced: useVirtualEmplaced,
         );
         _qbLog.d(
-          'logic: quick_battle end winner=${result.winner.name} '
+          'quick_battle end winner=${result.winner.name} '
           'flip=${result.provinceFlips} fortDowngrade=${result.fortDowngradeFromDestroyedEmplaced}',
         );
         return result;
@@ -157,7 +157,7 @@ QuickBattleResult resolveQuickBattle(
           useVirtualEmplaced: useVirtualEmplaced,
         );
         _qbLog.d(
-          'logic: quick_battle end winner=${result.winner.name} '
+          'quick_battle end winner=${result.winner.name} '
           'flip=${result.provinceFlips} fortDowngrade=${result.fortDowngradeFromDestroyedEmplaced}',
         );
         return result;
@@ -200,7 +200,7 @@ QuickBattleResult resolveQuickBattle(
         useVirtualEmplaced: useVirtualEmplaced,
       );
       _qbLog.d(
-        'logic: quick_battle end winner=${result.winner.name} '
+        'quick_battle end winner=${result.winner.name} '
         'flip=${result.provinceFlips} fortDowngrade=${result.fortDowngradeFromDestroyedEmplaced}',
       );
       return result;
@@ -216,7 +216,7 @@ QuickBattleResult resolveQuickBattle(
         useVirtualEmplaced: useVirtualEmplaced,
       );
       _qbLog.d(
-        'logic: quick_battle end winner=${result.winner.name} '
+        'quick_battle end winner=${result.winner.name} '
         'flip=${result.provinceFlips} fortDowngrade=${result.fortDowngradeFromDestroyedEmplaced}',
       );
       return result;
@@ -244,7 +244,7 @@ QuickBattleResult resolveQuickBattle(
       useVirtualEmplaced: useVirtualEmplaced,
     );
     _qbLog.d(
-      'logic: quick_battle end winner=${result.winner.name} '
+      'quick_battle end winner=${result.winner.name} '
       'flip=${result.provinceFlips} fortDowngrade=${result.fortDowngradeFromDestroyedEmplaced}',
     );
     return result;
@@ -260,7 +260,7 @@ QuickBattleResult resolveQuickBattle(
       useVirtualEmplaced: useVirtualEmplaced,
     );
     _qbLog.d(
-      'logic: quick_battle end winner=${result.winner.name} '
+      'quick_battle end winner=${result.winner.name} '
       'flip=${result.provinceFlips} fortDowngrade=${result.fortDowngradeFromDestroyedEmplaced}',
     );
     return result;
@@ -275,7 +275,7 @@ QuickBattleResult resolveQuickBattle(
     useVirtualEmplaced: useVirtualEmplaced,
   );
   _qbLog.d(
-    'logic: quick_battle end winner=${result.winner.name} '
+    'quick_battle end winner=${result.winner.name} '
     'flip=${result.provinceFlips} fortDowngrade=${result.fortDowngradeFromDestroyedEmplaced}',
   );
   return result;

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -101,7 +101,7 @@ DiplomacyPhaseResult resolveDiplomacyPhase(
   List<InterventionDecision>? interventionDecisions,
   List<CallToArmsDecision>? callToArmsDecisions,
 }) {
-  _diploLog.d('logic: diplomacy phase start');
+  _diploLog.d('diplomacy phase start');
   final turn = game.worldState.turnState.turnNumber;
   var state = game;
 
@@ -118,7 +118,7 @@ DiplomacyPhaseResult resolveDiplomacyPhase(
   if (overtureResult.pendingOvertures != null &&
       overtureResult.pendingOvertures!.isNotEmpty) {
     _diploLog.d(
-      'logic: diplomacy phase suspended (pending overture decisions)',
+      'diplomacy phase suspended (pending overture decisions)',
     );
     return DiplomacyPhaseResult(
       state,
@@ -170,7 +170,7 @@ DiplomacyPhaseResult resolveDiplomacyPhase(
   if (ctaResult.pendingCallToArms != null &&
       ctaResult.pendingCallToArms!.isNotEmpty) {
     _diploLog.d(
-      'logic: diplomacy phase suspended (pending call to arms)',
+      'diplomacy phase suspended (pending call to arms)',
     );
     return DiplomacyPhaseResult(
       state,
@@ -191,7 +191,7 @@ DiplomacyPhaseResult resolveDiplomacyPhase(
   // 9. Apply relation modifiers (grants, etc.)
   state = _applyRelationModifiersAndUpdateScores(state, diploByPlayer, turn);
 
-  _diploLog.d('logic: diplomacy phase end');
+  _diploLog.d('diplomacy phase end');
   return DiplomacyPhaseResult(state);
 }
 
@@ -355,7 +355,7 @@ _OverturePaymentsResult _processOverturePayments(
         wasAiInitiator: isAiControlledForEvidence(state, gpId),
       );
       _diploLog.i(
-        'logic: diplomacy overture $gpId -> $targetId $stage (accepted)',
+        'diplomacy overture $gpId -> $targetId $stage (accepted)',
       );
     }
   }
@@ -428,7 +428,7 @@ Game _resolveJoinEmpireColony(
         amount: cost,
         wasAiInitiator: isAiControlledForEvidence(game, gpId),
       );
-      _diploLog.i('logic: diplomacy join empire $gpId $targetId cost=$cost');
+      _diploLog.i('diplomacy join empire $gpId $targetId cost=$cost');
     }
   }
   return game;
@@ -607,7 +607,7 @@ Game _processAlliances(
         toFactionId: targetId,
         wasAiInitiator: isAiControlledForEvidence(game, gpId),
       );
-      _diploLog.i('logic: diplomacy alliance $gpId-$targetId');
+      _diploLog.i('diplomacy alliance $gpId-$targetId');
     }
   }
   return game;
@@ -682,7 +682,7 @@ Game _processWarAndPeace(
             wasAiInitiator: isAiControlledForEvidence(game, gpId),
           );
           _diploLog.i(
-            'logic: diplomacy war declared $gpId vs $targetId (scores reset to 20)',
+            'diplomacy war declared $gpId vs $targetId (scores reset to 20)',
           );
         }
       } else if (order.type == DiplomaticOrderType.offerPeace) {
@@ -745,7 +745,7 @@ Game _processWarAndPeace(
               toFactionId: targetId,
               wasAiInitiator: isAiControlledForEvidence(game, gpId),
             );
-            _diploLog.i('logic: diplomacy peace $gpId-$targetId');
+            _diploLog.i('diplomacy peace $gpId-$targetId');
           } else {
             game = game.copyWith(
               dossierEvidenceEntries: [
@@ -1061,7 +1061,7 @@ Game _cancelSubsidiesBetweenGps(
   var g = game.copyWith(subsidyStates: subsidyStates);
   for (final s in cancelled) {
     _diploLog.i(
-      'logic: diplomacy subsidies cancelled due to war ${s.payerId} vs ${s.targetId}',
+      'diplomacy subsidies cancelled due to war ${s.payerId} vs ${s.targetId}',
     );
     g = _appendDiplomaticEvent(
       g,
@@ -1102,7 +1102,7 @@ Game _applyCallToArmsAccept(
     wasAiInitiator: isAiControlledForEvidence(g, allyGpId),
   );
   _diploLog.i(
-    'logic: diplomacy call to arms accept $allyGpId joins war vs $aggressorGpId',
+    'diplomacy call to arms accept $allyGpId joins war vs $aggressorGpId',
   );
   return g;
 }
@@ -1150,7 +1150,7 @@ Game _applyCallToArmsRefuse(
     wasAiInitiator: isAiControlledForEvidence(g, allyGpId),
   );
   _diploLog.i(
-    'logic: diplomacy call to arms refuse $allyGpId breaks alliance with $defenderGpId',
+    'diplomacy call to arms refuse $allyGpId breaks alliance with $defenderGpId',
   );
   return g;
 }
@@ -1265,7 +1265,7 @@ Game _terminateAgreementsOnWar(Game game) {
         reason: 'war',
       );
     }
-    _diploLog.i('logic: diplomacy agreements terminated (war)');
+    _diploLog.i('diplomacy agreements terminated (war)');
   }
   return game;
 }
@@ -1328,7 +1328,7 @@ Game _applyRelationModifiersAndUpdateScores(
         wasAiInitiator: isAiControlledForEvidence(game, gpId),
       );
       _diploLog.i(
-        'logic: diplomacy GrantAid $gpId -> $targetId amount $amount',
+        'diplomacy GrantAid $gpId -> $targetId amount $amount',
       );
     }
   }
@@ -1401,11 +1401,11 @@ Game _applyRelationModifiersAndUpdateScores(
       final targetPlayer = game.playerById(targetId);
       if (targetPlayer != null) {
         _diploLog.i(
-          'logic: diplomacy SetSubsidy $gpId -> $targetId amount $amount/turn (ongoing)',
+          'diplomacy SetSubsidy $gpId -> $targetId amount $amount/turn (ongoing)',
         );
       } else {
         _diploLog.i(
-          'logic: diplomacy SetSubsidy $gpId -> $targetId amount $amount/turn (ongoing relation boost)',
+          'diplomacy SetSubsidy $gpId -> $targetId amount $amount/turn (ongoing relation boost)',
         );
       }
     }
@@ -1444,7 +1444,7 @@ Game _processOngoingSubsidies(Game game, int turn) {
           .where((s) => s.payerId != payerId || s.targetId != targetId)
           .toList();
       _diploLog.i(
-        'logic: diplomacy subsidy cancelled $payerId -> $targetId (insufficient funds)',
+        'diplomacy subsidy cancelled $payerId -> $targetId (insufficient funds)',
       );
       continue;
     }
@@ -1466,7 +1466,7 @@ Game _processOngoingSubsidies(Game game, int turn) {
           .where((s) => s.payerId != payerId || s.targetId != targetId)
           .toList();
       _diploLog.i(
-        'logic: diplomacy subsidy cancelled $payerId -> $targetId (war declared)',
+        'diplomacy subsidy cancelled $payerId -> $targetId (war declared)',
       );
       continue;
     }
@@ -1495,7 +1495,7 @@ Game _processOngoingSubsidies(Game game, int turn) {
         turn: turn,
       );
       _diploLog.i(
-        'logic: diplomacy subsidy processed $payerId -> $targetId amount=$amount boost=+$boost',
+        'diplomacy subsidy processed $payerId -> $targetId amount=$amount boost=+$boost',
       );
     } else {
       // GP target: transfer treasury
@@ -1506,7 +1506,7 @@ Game _processOngoingSubsidies(Game game, int turn) {
         );
       }
       _diploLog.i(
-        'logic: diplomacy subsidy processed $payerId -> $targetId amount=$amount (treasury transfer)',
+        'diplomacy subsidy processed $payerId -> $targetId amount=$amount (treasury transfer)',
       );
     }
   }

--- a/packages/colonizethis_logic/lib/src/economy/economy_consumption.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_consumption.dart
@@ -131,7 +131,7 @@ ConsumptionResult resolveConsumption({
     shipCountsById: shipCountsById,
   );
   _log.d(
-    'logic: consumption totalRegiments=${alloc.totalRegiments} '
+    'consumption totalRegiments=${alloc.totalRegiments} '
     'fullyFedRegiments=${alloc.fullyFedRegiments} '
     'totalShips=${alloc.totalShips} fullyFedShips=${alloc.fullyFedShips} '
     'idlePeasants=${alloc.idleLabour.peasants}',

--- a/packages/colonizethis_logic/lib/src/economy/economy_production.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_production.dart
@@ -55,7 +55,7 @@ ProductionResult resolveProduction({
   for (final assignment in assignments) {
     final recipe = ProductionRecipesCatalog.byId[assignment.recipeId];
     if (recipe == null) {
-      _log.w('logic: production skip unknown recipe id ${assignment.recipeId}');
+      _log.w('production skip unknown recipe id ${assignment.recipeId}');
       continue;
     }
     if (assignment.assignedLabour <= 0) continue;
@@ -64,7 +64,7 @@ ProductionResult resolveProduction({
     final labourPerOutput = recipe.labourPerOutput;
     if (labourPerOutput <= 0) {
       _log.w(
-        'logic: production recipe ${recipe.id} has non-positive labourPerOutput; skipping',
+        'production recipe ${recipe.id} has non-positive labourPerOutput; skipping',
       );
       continue;
     }
@@ -114,7 +114,7 @@ ProductionResult resolveProduction({
   }
 
   _log.d(
-    'logic: production assignments=${assignments.length} effectiveLabour=$effectiveLabour',
+    'production assignments=${assignments.length} effectiveLabour=$effectiveLabour',
   );
   return ProductionResult(
     stockpile: current,

--- a/packages/colonizethis_logic/lib/src/economy/economy_riches_to_treasury.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_riches_to_treasury.dart
@@ -44,7 +44,7 @@ RichesToTreasuryResult resolveRichesToTreasury({
   }
 
   _log.d(
-    'logic: riches-to-treasury treasuryDelta=$totalCash multiplier=$richesCashMultiplier',
+    'riches-to-treasury treasuryDelta=$totalCash multiplier=$richesCashMultiplier',
   );
   return RichesToTreasuryResult(
     stockpile: updatedStockpile,

--- a/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
+++ b/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
@@ -29,7 +29,7 @@ Map<String, ExtractionTotals> computeExtraction({
   required Map<String, ConnectivityResult> connectivityResult,
   int Function(String playerId) techCapForPlayer = _defaultTechCap,
 }) {
-  _log.d('logic: extraction compute start players=${game.players.length}');
+  _log.d('extraction compute start players=${game.players.length}');
   final out = <String, ExtractionTotals>{};
   for (final player in game.players) {
     final cr = connectivityResult[player.id];
@@ -122,7 +122,7 @@ Map<String, ExtractionTotals> computeExtraction({
     (s, t) => s + t.overseas.values.fold(0, (a, b) => a + b),
   );
   _log.d(
-    'logic: extraction compute end players=${out.length} landTotal=$landSum overseasTotal=$overseasSum',
+    'extraction compute end players=${out.length} landTotal=$landSum overseasTotal=$overseasSum',
   );
   return out;
 }

--- a/packages/colonizethis_logic/lib/src/event_bus/game_event_bus.dart
+++ b/packages/colonizethis_logic/lib/src/event_bus/game_event_bus.dart
@@ -1,6 +1,63 @@
 import 'dart:async';
 
+import 'package:colonizethis_logger/colonizethis_logger.dart';
+
 import '../game_events.dart';
+
+/// Max length for the payload summary segment in [deliverGameEvent] log lines.
+/// SPEC/program/logging/events.md — truncate with `…` and `truncated=true` when exceeded.
+const int kGameEventLogSummaryMaxChars = 500;
+
+final _gameEventLog = logicLogger();
+
+String _gameEventPayloadSummary(GameEvent event) {
+  return switch (event) {
+    CombatResultEvent e =>
+      'turn=${e.turnNumber} provinceId=${e.provinceId} attackerId=${e.attackerId} '
+          'defenderId=${e.defenderId} winnerId=${e.winnerId} '
+          'casualtyEntries=${e.casualties.length}',
+    NavalCombatResultEvent e =>
+      'turn=${e.turnNumber} seaZoneId=${e.seaZoneId} outcome=${e.outcomeName} '
+          'winnerOwnerId=${e.winnerOwnerId} side1=${e.side1OwnerId} side2=${e.side2OwnerId}',
+    ProvinceCapturedEvent e =>
+      'turn=${e.turnNumber} provinceId=${e.provinceId} previousOwnerId=${e.previousOwnerId} '
+          'newOwnerId=${e.newOwnerId}',
+    DiplomacyChangeEvent e =>
+      'turn=${e.turnNumber} actorId=${e.actorId} targetId=${e.targetId} changeType=${e.changeType}',
+    ResearchCompleteEvent e =>
+      'turn=${e.turnNumber} playerId=${e.playerId} techId=${e.techId}',
+    VictorySetEvent e =>
+      'turn=${e.turnNumber} winnerPlayerId=${e.winnerPlayerId} victoryType=${e.victoryType}',
+    OrderRejectedEvent e =>
+      'playerId=${e.playerId} reasonCode=${e.reasonCode} orderSummary=${e.orderSummary}',
+  };
+}
+
+void _logGameEventDelivery(GameEvent event) {
+  final typeName = event.runtimeType.toString();
+  var summary = _gameEventPayloadSummary(event);
+  var truncated = false;
+  if (summary.length > kGameEventLogSummaryMaxChars) {
+    summary = '${summary.substring(0, kGameEventLogSummaryMaxChars)}…';
+    truncated = true;
+  }
+  final suffix = truncated ? ' truncated=true' : '';
+  _gameEventLog.i('event=$typeName $summary$suffix');
+}
+
+/// Delivers [event] to [eventBus] and/or [onGameEvent], logging once per SPEC/program/logging/events.md.
+void deliverGameEvent(
+  GameEvent event, {
+  GameEventBus? eventBus,
+  void Function(GameEvent)? onGameEvent,
+}) {
+  if (eventBus != null) {
+    eventBus.publish(event);
+  } else {
+    _logGameEventDelivery(event);
+  }
+  onGameEvent?.call(event);
+}
 
 abstract class GameEventBus {
   void publish(GameEvent event);
@@ -15,6 +72,7 @@ class DefaultGameEventBus implements GameEventBus {
 
   @override
   void publish(GameEvent event) {
+    _logGameEventDelivery(event);
     _controller.add(event);
   }
 

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -156,7 +156,7 @@ class OrderEngine {
     Map<String, TileMapResult>? tileMapByRegion,
   }) {
     _appendOrder(playerId, order, getter, updater);
-    _log.d('logic: validating orders with context player=$playerId');
+    _log.d('validating orders with context player=$playerId');
     final results = validatePlayerOrdersWithContext(
       game,
       topology,
@@ -169,7 +169,7 @@ class OrderEngine {
     final r = results.last;
     if (!r.isAccepted)
       _log.w(
-        'logic: $orderLabel order rejected player=$playerId reason=${r.reason}',
+        '$orderLabel order rejected player=$playerId reason=${r.reason}',
       );
     return r;
   }
@@ -570,7 +570,7 @@ class OrderEngine {
     final tileMaps = tileMapByRegion ?? <String, TileMapResult>{};
     if (tileMaps.isEmpty) {
       _log.d(
-        'logic: projectedEffects called with no tileMapByRegion; expected extraction will be zero',
+        'projectedEffects called with no tileMapByRegion; expected extraction will be zero',
       );
     }
     return projectOrderEffects(

--- a/packages/colonizethis_logic/lib/src/orders/order_projections.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_projections.dart
@@ -23,10 +23,10 @@ ProjectedEffects projectOrderEffects({
   required String playerId,
   List<AssignedRecipe> defaultAssignments = const [],
 }) {
-  _log.d('logic: projectOrderEffects run for player $playerId');
+  _log.d('projectOrderEffects run for player $playerId');
   if (tileMapByRegion.isEmpty) {
     _log.d(
-      'logic: projectOrderEffects with empty tileMapByRegion; extraction will be zero',
+      'projectOrderEffects with empty tileMapByRegion; extraction will be zero',
     );
   }
   Map<String, Map<String, int>>? productionByRecipeByPlayerId;

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_api_impl.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_api_impl.dart
@@ -19,7 +19,7 @@ class DefaultOrderSuggestionAPI implements suggestion.OrderSuggestionAPI {
     Orders currentOrders,
   ) {
     _log.i(
-      'logic: order suggestion API suggestMoveOrders player=${view.playerId} turn=${game.worldState.turnState.turnNumber}',
+      'order suggestion API suggestMoveOrders player=${view.playerId} turn=${game.worldState.turnState.turnNumber}',
     );
     return suggestion.suggestMoveOrders(view, game, topology, currentOrders);
   }
@@ -33,7 +33,7 @@ class DefaultOrderSuggestionAPI implements suggestion.OrderSuggestionAPI {
     Map<String, TileMapResult>? tileMapByRegion,
   }) {
     _log.i(
-      'logic: order suggestion API suggestWorkOrders player=${view.playerId}',
+      'order suggestion API suggestWorkOrders player=${view.playerId}',
     );
     return suggestion.suggestWorkOrders(
       view,
@@ -52,7 +52,7 @@ class DefaultOrderSuggestionAPI implements suggestion.OrderSuggestionAPI {
     Orders currentOrders,
   ) {
     _log.i(
-      'logic: order suggestion API suggestBuildOrders player=${view.playerId}',
+      'order suggestion API suggestBuildOrders player=${view.playerId}',
     );
     return suggestion.suggestBuildOrders(view, game, topology, currentOrders);
   }
@@ -65,7 +65,7 @@ class DefaultOrderSuggestionAPI implements suggestion.OrderSuggestionAPI {
     Orders currentOrders,
   ) {
     _log.i(
-      'logic: order suggestion API suggestResearchOrders player=${view.playerId}',
+      'order suggestion API suggestResearchOrders player=${view.playerId}',
     );
     return suggestion.suggestResearchOrders(
       view,
@@ -83,7 +83,7 @@ class DefaultOrderSuggestionAPI implements suggestion.OrderSuggestionAPI {
     Orders currentOrders,
   ) {
     _log.i(
-      'logic: order suggestion API suggestNavalMoveOrders player=${view.playerId}',
+      'order suggestion API suggestNavalMoveOrders player=${view.playerId}',
     );
     return suggestion.suggestNavalMoveOrders(
       view,
@@ -101,7 +101,7 @@ class DefaultOrderSuggestionAPI implements suggestion.OrderSuggestionAPI {
     Orders currentOrders,
   ) {
     _log.i(
-      'logic: order suggestion API suggestNavalMissionOrders player=${view.playerId}',
+      'order suggestion API suggestNavalMissionOrders player=${view.playerId}',
     );
     return suggestion.suggestNavalMissionOrders(
       view,
@@ -120,7 +120,7 @@ class DefaultOrderSuggestionAPI implements suggestion.OrderSuggestionAPI {
     Map<String, TileMapResult>? tileMapByRegion,
   }) {
     _log.i(
-      'logic: order suggestion API suggestDiplomaticOrders player=${view.playerId}',
+      'order suggestion API suggestDiplomaticOrders player=${view.playerId}',
     );
     return suggestion.suggestDiplomaticOrders(
       view,

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -312,7 +312,7 @@ Game applyBuildAndWorkOrders(
     void Function(List<Province>) setProvinces,
   ) {
     _log.d(
-      'logic: work completed unit=${u.id} workTarget=${cw.workTarget} tileKey=${cw.tileKey}',
+      'work completed unit=${u.id} workTarget=${cw.workTarget} tileKey=${cw.tileKey}',
     );
     switch (cw.workTarget) {
       case 'build_improvement':
@@ -435,7 +435,7 @@ Game applyBuildAndWorkOrders(
             s.tileState = s.tileState.setRoadLevel(cw.tileKey, 4);
           } else {
             _log.d(
-              'logic: build_rail completion skipped unit=${u.id} reason=$reason',
+              'build_rail completion skipped unit=${u.id} reason=$reason',
             );
           }
         }
@@ -474,7 +474,7 @@ Game applyBuildAndWorkOrders(
           clearCurrentWork: true,
         );
         _log.d(
-          'logic: work cancelled unit=${u.id} reason=tile no longer owned tileKey=${cw.tileKey}',
+          'work cancelled unit=${u.id} reason=tile no longer owned tileKey=${cw.tileKey}',
         );
         continue;
       }
@@ -487,7 +487,7 @@ Game applyBuildAndWorkOrders(
             clearCurrentWork: true,
           );
           _log.d(
-            'logic: work cancelled unit=${u.id} reason=tile no longer under control tileKey=${cw.tileKey}',
+            'work cancelled unit=${u.id} reason=tile no longer under control tileKey=${cw.tileKey}',
           );
           continue;
         }
@@ -520,7 +520,7 @@ Game applyBuildAndWorkOrders(
           final toRemove = enemySpies.first.key;
           final removed = unitsById[toRemove];
           if (removed?.currentWork != null) {
-            _log.d('logic: work cancelled unit=$toRemove reason=unit dead');
+            _log.d('work cancelled unit=$toRemove reason=unit dead');
           }
           unitsById.remove(toRemove);
         }
@@ -790,7 +790,7 @@ void _runWorkPhase(
         final totalTurns = config.totalTurnsFn();
 
         _log.d(
-          'logic: work order accepted and assigned unit=${order.unitId} target=$orderTarget targetTileKey=$targetTileKey totalTurns=$totalTurns',
+          'work order accepted and assigned unit=${order.unitId} target=$orderTarget targetTileKey=$targetTileKey totalTurns=$totalTurns',
         );
         updateUnit(
           order.unitId,
@@ -859,7 +859,7 @@ void _runWorkPhase(
           hasValidTarget) {
         const totalTurns = 5;
         _log.d(
-          'logic: work order accepted and assigned unit=${order.unitId} target=steal_tech targetTileKey=$targetTileKey totalTurns=$totalTurns',
+          'work order accepted and assigned unit=${order.unitId} target=steal_tech targetTileKey=$targetTileKey totalTurns=$totalTurns',
         );
         updateUnit(
           order.unitId,
@@ -883,7 +883,7 @@ void _runWorkPhase(
           hasValidTarget) {
         const totalTurns = 0;
         _log.d(
-          'logic: work order accepted and assigned unit=${order.unitId} target=counter_spy targetTileKey=$targetTileKey totalTurns=$totalTurns',
+          'work order accepted and assigned unit=${order.unitId} target=counter_spy targetTileKey=$targetTileKey totalTurns=$totalTurns',
         );
         updateUnit(
           order.unitId,
@@ -942,7 +942,7 @@ void _runWorkPhase(
           if (maxTiles < 1) maxTiles = 1;
           final totalTurns = (3 * tilesInP / maxTiles).ceil().clamp(1, 999);
           _log.d(
-            'logic: work order accepted and assigned unit=${order.unitId} target=explore targetTileKey=$targetTileKey totalTurns=$totalTurns',
+            'work order accepted and assigned unit=${order.unitId} target=explore targetTileKey=$targetTileKey totalTurns=$totalTurns',
           );
           updateUnit(
             order.unitId,
@@ -973,13 +973,13 @@ void _runWorkPhase(
         if (fortLevel == 1 &&
             player.techUnlocked?['mine_engineering'] != true) {
           _log.d(
-            'logic: build_fort skipped - Mine Engineering required for fort level 2',
+            'build_fort skipped - Mine Engineering required for fort level 2',
           );
           continue;
         }
         if (fortLevel == 2 && player.techUnlocked?['modern_forts'] != true) {
           _log.d(
-            'logic: build_fort skipped - Modern Forts required for fort level 3',
+            'build_fort skipped - Modern Forts required for fort level 3',
           );
           continue;
         }
@@ -996,7 +996,7 @@ void _runWorkPhase(
           terrain: terrain,
         );
         if (railReason != null) {
-          _log.d('logic: build_rail skipped - $railReason');
+          _log.d('build_rail skipped - $railReason');
           continue;
         }
         if (applyStandardWorkOrder('build_rail')) continue;
@@ -1092,7 +1092,7 @@ void _propagateRoadToAdjacentCapitalOrPort({
 
     if (isCapital || isPort) {
       _log.d(
-        'logic: build_road propagating level $nextLevel to adjacent ${isCapital ? "capital" : "port"} tile $adjacentTileKey',
+        'build_road propagating level $nextLevel to adjacent ${isCapital ? "capital" : "port"} tile $adjacentTileKey',
       );
       final currentLevel = tileState.roadLevel(adjacentTileKey);
       // Only upgrade, never downgrade.

--- a/packages/colonizethis_logic/lib/src/setup/game_setup.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup.dart
@@ -59,7 +59,7 @@ GameSetupResult createGameFromGeneratedMaps({
   int? assignmentPerturbationBase,
   List<WarpLink>? warpLinks,
 }) {
-  _log.i('logic: game setup start gameId=$gameId');
+  _log.i('game setup start gameId=$gameId');
   final tileMapByRegion = {
     kRegionOldWorld: tileMapOldWorld,
     kRegionNewWorld: tileMapNewWorld,
@@ -129,8 +129,8 @@ GameSetupResult createGameFromGeneratedMaps({
           assignmentRandom: assignmentRandom,
         );
       } on StateError catch (e, st) {
-        _log.w('logic: OW assignment attempt $attempt failed: $e');
-        _log.d('logic: stack $st');
+        _log.w('OW assignment attempt $attempt failed: $e');
+        _log.d('stack $st');
         continue;
       }
       final ownersRepair = Map<String, String>.from(owOwner);
@@ -156,7 +156,7 @@ GameSetupResult createGameFromGeneratedMaps({
       );
     }
   } else {
-    _log.i('logic: OW assignment fast path (no GP land connectivity repair)');
+    _log.i('OW assignment fast path (no GP land connectivity repair)');
     owOwner = _assignOldWorldOwnershipContiguous(
       neighbours: owNeighbours,
       provinceIds: owProvinceIds,
@@ -434,7 +434,7 @@ GameSetupResult createGameFromGeneratedMaps({
     warpLinks: links,
   );
 
-  _log.i('logic: game setup end gameId=${game.id}');
+  _log.i('game setup end gameId=${game.id}');
   return GameSetupResult(
     game: game,
     tileMapByRegion: tileMapByRegion,
@@ -732,7 +732,7 @@ Game _assignProvinceTowns({
         return coastalCandidates.first;
       }
       _log.w(
-        'logic: seaboard town fallback for province=${p.id}: '
+        'seaboard town fallback for province=${p.id}: '
         'topology is sea-bound but no sea-zone-adjacent tile candidate found',
       );
     }
@@ -999,13 +999,13 @@ Game _applyNaming({
   );
 
   _log.i(
-    'logic: naming applied ow=${updatedWorld.oldWorld.provinces.length} '
+    'naming applied ow=${updatedWorld.oldWorld.provinces.length} '
     'nw=${updatedWorld.newWorld.provinces.length} players=${game.players.length} '
     'minors=${game.minorNations.length} tribes=${game.tribes.length}',
   );
   if (proceduralFallbackCount > 0) {
     _log.d(
-      'logic: naming procedural fallback used count=$proceduralFallbackCount',
+      'naming procedural fallback used count=$proceduralFallbackCount',
     );
   }
 
@@ -1499,7 +1499,7 @@ Map<String, String> _assignOldWorldOwnershipContiguous({
   );
   if (pack == null) {
     throw StateError(
-      'logic: GP landmass pack unexpectedly null at budget $gpProvinceBudget',
+      'GP landmass pack unexpectedly null at budget $gpProvinceBudget',
     );
   }
   final gpLandmassAssignments = pack.gpLandmassAssignments;

--- a/packages/colonizethis_logic/lib/src/setup/init_game_orchestrator.dart
+++ b/packages/colonizethis_logic/lib/src/setup/init_game_orchestrator.dart
@@ -90,7 +90,7 @@ InitGameResult runInitGame({
   }
 
   _log.i(
-    'logic: init game start OW:${config.numProvincesOldWorld} NW:${config.numProvincesNewWorld}',
+    'init game start OW:${config.numProvincesOldWorld} NW:${config.numProvincesNewWorld}',
   );
   // Derive an effective seed: non-zero config seeds are used as-is for
   // reproducible runs; a zero seed means "choose a time-based seed".
@@ -115,7 +115,7 @@ InitGameResult runInitGame({
     skipFillLakes: options.skipFillLakes,
   );
   final gen = generateRegion ?? defaultTileMapRegionGenerator;
-  _log.d('logic: init game generating OW map');
+  _log.d('init game generating OW map');
   final (tileMapOW, topoOW) = gen(
     params: paramsOW,
     numProvinces: config.numProvincesOldWorld,
@@ -124,7 +124,7 @@ InitGameResult runInitGame({
     resourceRules: ResourceRules.defaultRules,
   );
 
-  _log.d('logic: init game generating NW map');
+  _log.d('init game generating NW map');
   final sizeNW = computeGridSizeFromParams(
     config.numProvincesNewWorld,
     mapGenParams,
@@ -240,7 +240,7 @@ InitGameResult runInitGame({
   // Phase 6 full AI: populate hidden agendas before first AI order generation. SPEC: game-setup-pipeline.md step 9, ai-planner.md § Phase 6.
   game = assignHiddenAgendasForGame(game);
 
-  _log.i('logic: init game end seed=$effectiveSeed gameId=${game.id}');
+  _log.i('init game end seed=$effectiveSeed gameId=${game.id}');
   return InitGameResult(
     game: game,
     mapPngBytes: mapPngBytes,

--- a/packages/colonizethis_logic/lib/src/setup/init_town_roads.dart
+++ b/packages/colonizethis_logic/lib/src/setup/init_town_roads.dart
@@ -43,7 +43,7 @@ Game applyInitTownRoadsToCapitals({
     }
     final map = tileMapByRegion[regionId];
     if (map == null) {
-      _log.w('logic: init town roads skip regionId=$regionId (no tile map)');
+      _log.w('init town roads skip regionId=$regionId (no tile map)');
       return;
     }
 
@@ -98,7 +98,7 @@ Game applyInitTownRoadsToCapitals({
   }
 
   _log.i(
-    'logic: init town roads raised ${_initTownRoadLevel} on ${toRaise.length} tile(s)',
+    'init town roads raised ${_initTownRoadLevel} on ${toRaise.length} tile(s)',
   );
   return game.copyWith(worldState: ws.copyWith(tileState: tileState));
 }

--- a/packages/colonizethis_logic/lib/src/setup/warp_zone_generator.dart
+++ b/packages/colonizethis_logic/lib/src/setup/warp_zone_generator.dart
@@ -89,7 +89,7 @@ List<WarpLink> generateWarpZones({
     ..sort();
 
   if (commonEdges.isEmpty) {
-    _log.d('logic: warp zones: no common edges with sea zones, skipping');
+    _log.d('warp zones: no common edges with sea zones, skipping');
     return [];
   }
 
@@ -106,7 +106,7 @@ List<WarpLink> generateWarpZones({
   }
 
   _log.d(
-    'logic: warp zones: ${links.length} links on edges ${commonEdges.join(", ")}',
+    'warp zones: ${links.length} links on edges ${commonEdges.join(", ")}',
   );
   return links;
 }

--- a/packages/colonizethis_logic/lib/src/turn/combat_phase_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/turn/combat_phase_helpers.dart
@@ -12,6 +12,7 @@ import '../combat/quick_battle_resolver.dart';
 import '../constants.dart';
 import '../dossier/evidence_rules.dart';
 import '../dossier/event_dialogue.dart';
+import '../event_bus/game_event_bus.dart';
 import '../game_events.dart';
 
 final _combatPhaseLog = logicLogger();
@@ -32,7 +33,7 @@ Game runOneLandBattle(
   final attackerUnitsTotal =
       ctx.attackers.fold<int>(0, (s, a) => s + a.unitIds.length);
   _combatPhaseLog.i(
-    'logic: combat battle_start turn=$turn battleIndex=$battleIndex '
+    'combat battle_start turn=$turn battleIndex=$battleIndex '
     'regionId=${ctx.regionId} provinceId=${ctx.provinceId} '
     'defenderFactionId=${ctx.defenderFactionId} attackerSides=${ctx.attackers.length} '
     'attackerUnitsTotal=$attackerUnitsTotal mode=${mode.name}',
@@ -61,7 +62,7 @@ Game runOneLandBattle(
         qbResult.winner == QuickBattleWinner.attacker &&
         ctx.attackers.isNotEmpty;
     _combatPhaseLog.i(
-      'logic: combat battle_apply regionId=${ctx.regionId} provinceId=${ctx.provinceId} '
+      'combat battle_apply regionId=${ctx.regionId} provinceId=${ctx.provinceId} '
       'mode=quickBattle winner=${qbResult.winner.name} provinceFlipped=$qbFlipped '
       'attCasualties=${qbResult.attackerCasualties.length} '
       'defCasualties=${qbResult.defenderCasualties.length}',
@@ -151,14 +152,17 @@ Game runOneLandBattle(
   }
   // Emit combat_result event for this battle
   if (onGameEvent != null && winnerId != null && ctx.attackers.isNotEmpty) {
-    onGameEvent(CombatResultEvent(
-      provinceId: ctx.provinceId,
-      attackerId: ctx.attackers.first.factionId,
-      defenderId: ctx.defenderFactionId,
-      winnerId: winnerId,
-      turnNumber: turn,
-      casualties: casualties,
-    ));
+    deliverGameEvent(
+      CombatResultEvent(
+        provinceId: ctx.provinceId,
+        attackerId: ctx.attackers.first.factionId,
+        defenderId: ctx.defenderFactionId,
+        winnerId: winnerId,
+        turnNumber: turn,
+        casualties: casualties,
+      ),
+      onGameEvent: onGameEvent,
+    );
   }
 
   return state;

--- a/packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
@@ -24,7 +24,7 @@ Game runEndOfTurnPhase(
   final winnerId = findMilitaryVictoryWinner(game);
   if (winnerId != null) {
     final turnNumber = game.worldState.turnState.turnNumber;
-    _log.i('logic: military victory set winner=$winnerId turn=$turnNumber');
+    _log.i('military victory set winner=$winnerId turn=$turnNumber');
     return game.copyWith(
       victory: VictoryState(
         winnerPlayerId: winnerId,

--- a/packages/colonizethis_logic/lib/src/turn/research_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/research_resolver.dart
@@ -13,10 +13,10 @@ final _log = logicLogger();
 Game resolveResearchPhase(Game game, Orders orders) {
   final turn = game.worldState.turnState.turnNumber;
   final researchByPlayer = orders.researchOrdersByPlayerId;
-  _log.i('logic: research phase start turn=$turn');
+  _log.i('research phase start turn=$turn');
 
   if (researchByPlayer.isEmpty) {
-    _log.i('logic: research phase end turn=$turn playersWithOrders=0');
+    _log.i('research phase end turn=$turn playersWithOrders=0');
     return game;
   }
 
@@ -35,7 +35,7 @@ Game resolveResearchPhase(Game game, Orders orders) {
     final slots = player.researchSlots ?? defaultResearchSlots;
     if (slots <= 0) {
       _log.i(
-        'logic: research apply turn=$turn playerId=${player.id} '
+        'research apply turn=$turn playerId=${player.id} '
         'orders=${playerOrders.length} skipped=true reason=no_research_slots',
       );
       updatedPlayers.add(player);
@@ -169,7 +169,7 @@ Game resolveResearchPhase(Game game, Orders orders) {
 
     final treasuryDelta = treasury - player.treasury;
     _log.i(
-      'logic: research apply turn=$turn playerId=${player.id} '
+      'research apply turn=$turn playerId=${player.id} '
       'orders=${playerOrders.length} treasuryDelta=$treasuryDelta '
       'completedTechs=${toUnlock.length} inProgressTechs=${nextProgress.length}',
     );
@@ -186,7 +186,7 @@ Game resolveResearchPhase(Game game, Orders orders) {
   }
 
   _log.i(
-    'logic: research phase end turn=$turn playersWithOrders=$playersWithOrders',
+    'research phase end turn=$turn playersWithOrders=$playersWithOrders',
   );
   return game.copyWith(players: updatedPlayers);
 }

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolution_events.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolution_events.dart
@@ -33,8 +33,7 @@ void emitResearchCompleteEvents(
           techId: tech,
           turnNumber: turn,
         );
-        eventBus?.publish(event);
-        onGameEvent?.call(event);
+        deliverGameEvent(event, eventBus: eventBus, onGameEvent: onGameEvent);
       }
     }
   }
@@ -57,8 +56,7 @@ void emitDiplomacyChangeEvents(
         changeType: rel.state.name,
         turnNumber: turn,
       );
-      eventBus?.publish(event);
-      onGameEvent?.call(event);
+      deliverGameEvent(event, eventBus: eventBus, onGameEvent: onGameEvent);
     }
   }
 }
@@ -84,8 +82,7 @@ void emitProvinceCapturedEvents(
           newOwnerId: prov.ownerId ?? '',
           turnNumber: turn,
         );
-        eventBus?.publish(event);
-        onGameEvent?.call(event);
+        deliverGameEvent(event, eventBus: eventBus, onGameEvent: onGameEvent);
       }
     }
   }
@@ -104,7 +101,6 @@ void emitVictorySetEvent(
       victoryType: state.victory!.type.name,
       turnNumber: turn,
     );
-    eventBus?.publish(event);
-    onGameEvent?.call(event);
+    deliverGameEvent(event, eventBus: eventBus, onGameEvent: onGameEvent);
   }
 }

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -218,7 +218,7 @@ TurnResolutionResult resolveTurnForGame({
   List<CallToArmsDecision>? callToArmsDecisions,
 }) {
   final turn = game.worldState.turnState.turnNumber;
-  _log.i('logic: turn $turn resolve start');
+  _log.i('turn $turn resolve start');
   Game state = game;
   final landFeedingCoverageByPlayerId = <String, double>{};
   final navalFeedingCoverageByPlayerId = <String, double>{};
@@ -230,7 +230,7 @@ TurnResolutionResult resolveTurnForGame({
   for (var i = 0; i < turnResolutionSequence.length; i++) {
     final phase = turnResolutionSequence[i];
     if (i < phaseIndex) continue;
-    _log.d('logic: phase ${phase.name} start');
+    _log.d('phase ${phase.name} start');
     switch (phase) {
       case TurnPhase.orders:
         // Orders are assumed to already be attached to the Game or passed in.
@@ -318,7 +318,7 @@ TurnResolutionResult resolveTurnForGame({
               );
             }
             throw StateError(
-              'logic: diplomacy pending but no pending lists populated',
+              'diplomacy pending but no pending lists populated',
             );
           }
           state = diploResult.game;
@@ -400,10 +400,10 @@ TurnResolutionResult resolveTurnForGame({
           break;
         }
     }
-    _log.d('logic: phase ${phase.name} end');
+    _log.d('phase ${phase.name} end');
   }
 
-  _log.i('logic: turn $turn resolve end');
+  _log.i('turn $turn resolve end');
   return TurnResolutionComplete(state);
 }
 
@@ -557,8 +557,7 @@ void _filterOrderList<T>(
         orderSummary: orderSummary(order),
         reasonCode: r.reason!,
       );
-      eventBus?.publish(event);
-      onGameEvent?.call(event);
+      deliverGameEvent(event, eventBus: eventBus, onGameEvent: onGameEvent);
     }
   }
 }
@@ -1051,10 +1050,10 @@ Game _runCombatPhase(
   };
   Game state = game;
   final turn = state.worldState.turnState.turnNumber;
-  _log.i('logic: combat conflict_detection start turn=$turn');
+  _log.i('combat conflict_detection start turn=$turn');
   final battles = detectConflicts(state, orders);
   _log.i(
-    'logic: combat conflict_detection end turn=$turn battleContexts=${battles.length}',
+    'combat conflict_detection end turn=$turn battleContexts=${battles.length}',
   );
   final combatGeneralLedger = CombatPhaseGeneralLedger();
   final defaultMode = game.defaultCombatMode ?? CombatMode.autoResolve;

--- a/packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
+++ b/packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
@@ -38,7 +38,7 @@ Game applyCapitalReassignmentAfterCombat(
       }).toList();
       game = game.copyWith(players: updatedPlayers);
       _log.i(
-        'logic: player ${player.id} lost capital and has no provinces in $regionId; capital cleared',
+        'player ${player.id} lost capital and has no provinces in $regionId; capital cleared',
       );
       continue;
     }
@@ -54,7 +54,7 @@ Game applyCapitalReassignmentAfterCombat(
       final msg =
           'capital reassignment: province $newProvinceId not found in region $regionId for player ${player.id}';
       _log.e(
-        'logic: $msg',
+        '$msg',
         error: StateError(msg),
         stackTrace: StackTrace.current,
       );
@@ -67,7 +67,7 @@ Game applyCapitalReassignmentAfterCombat(
           'capital reassignment: missing townTileKey for province $newProvinceId player ${player.id}';
       final err = StateError(msg);
       _log.e(
-        'logic: $msg',
+        '$msg',
         error: err,
         stackTrace: StackTrace.current,
       );
@@ -81,7 +81,7 @@ Game applyCapitalReassignmentAfterCombat(
       final msg =
           'capital reassignment: invalid townTileKey for province $newProvinceId player ${player.id} raw="$rawTown"';
       _log.e(
-        'logic: $msg',
+        '$msg',
         error: e,
         stackTrace: st,
       );
@@ -99,13 +99,13 @@ Game applyCapitalReassignmentAfterCombat(
         tile: tile,
       );
       _log.i(
-        'logic: player ${player.id} capital reassigned to $newProvinceId (${tile.toTileKey()}) after loss',
+        'player ${player.id} capital reassigned to $newProvinceId (${tile.toTileKey()}) after loss',
       );
     } catch (e, st) {
       final msg =
           'capital reassignment: failed to apply new capital for ${player.id}';
       _log.e(
-        'logic: $msg',
+        '$msg',
         error: e,
         stackTrace: st,
       );

--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -77,7 +77,7 @@ Map<String, ConnectivityResult> resolveConnectivity({
   Map<String, Set<String>>? blockadedPortProvincesByPlayerId,
 }) {
   _log.d(
-    'logic: connectivity resolve start players=${game.players.length} regions=${tileMapByRegion.keys.join(",")}',
+    'connectivity resolve start players=${game.players.length} regions=${tileMapByRegion.keys.join(",")}',
   );
   final provinceIdsByType = provinceNodeIds(topology);
   final blockadedByPlayer =
@@ -89,7 +89,7 @@ Map<String, ConnectivityResult> resolveConnectivity({
     final capital = player.capitalTile;
     if (capital == null || player.capitalProvinceId == null) {
       _log.d(
-        'logic: connectivity resolve player=${player.id} skipped (no capital)',
+        'connectivity resolve player=${player.id} skipped (no capital)',
       );
       result[player.id] = ConnectivityResult(connected: {});
       continue;
@@ -110,7 +110,7 @@ Map<String, ConnectivityResult> resolveConnectivity({
   final summary = result.entries
       .map((e) => '${e.key}:${e.value.connected.length}')
       .join(' ');
-  _log.d('logic: connectivity resolve end $summary');
+  _log.d('connectivity resolve end $summary');
   return result;
 }
 

--- a/packages/colonizethis_logic/lib/src/world/movement.dart
+++ b/packages/colonizethis_logic/lib/src/world/movement.dart
@@ -111,7 +111,7 @@ RegionData applyMoveOrdersToRegion(
         ordersForRegion++;
         ignored++;
         _log.d(
-          'logic: movement ignored reason=unit_not_found '
+          'movement ignored reason=unit_not_found '
           'unitId=${order.unitId} orderPlayerId=$playerId',
         );
         continue;
@@ -120,7 +120,7 @@ RegionData applyMoveOrdersToRegion(
       if (unit.ownerId != playerId) {
         ignored++;
         _log.d(
-          'logic: movement ignored reason=owner_mismatch '
+          'movement ignored reason=owner_mismatch '
           'unitId=${order.unitId} orderPlayerId=$playerId unitOwnerId=${unit.ownerId}',
         );
         continue;
@@ -131,7 +131,7 @@ RegionData applyMoveOrdersToRegion(
           ProvinceId.regionIdFrom(destProvinceId) != regionId) {
         ignored++;
         _log.d(
-          'logic: movement ignored reason=region_mismatch '
+          'movement ignored reason=region_mismatch '
           'unitId=${order.unitId} destRegion=${ProvinceId.regionIdFrom(destProvinceId)} '
           'expectedRegion=$regionId',
         );
@@ -154,7 +154,7 @@ RegionData applyMoveOrdersToRegion(
       if (!valid) {
         ignored++;
         _log.d(
-          'logic: movement ignored reason=invalid_adjacency '
+          'movement ignored reason=invalid_adjacency '
           'unitId=${order.unitId} from=$fromLocal to=$toLocal',
         );
         continue;
@@ -180,7 +180,7 @@ RegionData applyMoveOrdersToRegion(
   if (ordersForRegion > 0) {
     final regionLabel = regionId ?? 'unspecified';
     _log.i(
-      'logic: movement apply regionId=$regionLabel '
+      'movement apply regionId=$regionLabel '
       'orders=$ordersForRegion applied=$applied ignored=$ignored',
     );
   }

--- a/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
@@ -300,7 +300,7 @@ Game runNavalInterceptionCombatPhase(
   GameEventBus? eventBus,
 }) {
   var battles = detectNavalConflicts(game);
-  _log.d('logic: naval phase detected battles=${battles.length}');
+  _log.d('naval phase detected battles=${battles.length}');
   final movedFleetIds = <String>{
     for (final list in navalMoveOrdersByPlayerId.values)
       for (final order in list) order.fleetId,
@@ -308,7 +308,7 @@ Game runNavalInterceptionCombatPhase(
   var seed = (game.globalGameSeed ?? 0) ^
       (game.worldState.turnState.turnNumber * 0x9E3779B1);
   battles = filterBattlesByInterception(game, battles, movedFleetIds, seed);
-  _log.d('logic: naval phase after interception battles=${battles.length}');
+  _log.d('naval phase after interception battles=${battles.length}');
   seed = (seed * 1103515245 + 12345) & 0x7fffffff;
   var state = game;
   final turn = game.worldState.turnState.turnNumber;
@@ -349,7 +349,7 @@ Game runNavalInterceptionCombatPhase(
       retreatDestinationSide2: retreatZoneSide2,
     );
     _log.d(
-      'logic: naval phase battle zone=${battle.seaZoneId} outcome=${result.outcome.name} '
+      'naval phase battle zone=${battle.seaZoneId} outcome=${result.outcome.name} '
       'side1Retreated=${result.side1Retreated} side2Retreated=${result.side2Retreated}',
     );
 
@@ -408,8 +408,7 @@ Game runNavalInterceptionCombatPhase(
       side1Retreated: result.side1Retreated,
       side2Retreated: result.side2Retreated,
     );
-    eventBus?.publish(navalEv);
-    onGameEvent?.call(navalEv);
+    deliverGameEvent(navalEv, eventBus: eventBus, onGameEvent: onGameEvent);
 
     battleIndex++;
   }

--- a/packages/colonizethis_map/lib/src/tile_map_generator.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator.dart
@@ -799,7 +799,7 @@ class TileMapGenerator {
         );
         if (stillSplit.length > 1) {
           _log.w(
-            'map: join continents hit iteration cap with >1 land component for '
+            'join continents hit iteration cap with >1 land component for '
             'continent index $c (width=${params.width} height=${params.height})',
           );
         }

--- a/packages/colonizethis_save/lib/src/game_save_adapter.dart
+++ b/packages/colonizethis_save/lib/src/game_save_adapter.dart
@@ -15,26 +15,26 @@ const String _suffixWarpLinks = '_warpLinks';
 class GameSaveAdapter {
   /// Saves [game] to [box]. Key = game.id, value = game.toJson().
   void save(Box<dynamic> box, Game game) {
-    _log.i('save: saving gameId=${game.id}');
+    _log.i('saving gameId=${game.id}');
     box.put(game.id, game.toJson());
-    _log.i('save: saved gameId=${game.id}');
+    _log.i('saved gameId=${game.id}');
   }
 
   /// Loads game by [gameId]. Returns null if not found or invalid.
   Game? load(Box<dynamic> box, String gameId) {
-    _log.i('save: loading gameId=$gameId');
+    _log.i('loading gameId=$gameId');
     final raw = box.get(gameId);
     if (raw == null) {
-      _log.w('save: gameId=$gameId not found');
+      _log.w('gameId=$gameId not found');
       return null;
     }
     try {
       final map = Map<String, dynamic>.from(raw as Map);
       final game = Game.fromJson(map);
-      _log.i('save: loaded gameId=$gameId');
+      _log.i('loaded gameId=$gameId');
       return game;
     } catch (e, st) {
-      _log.e('save: load failed gameId=$gameId', error: e, stackTrace: st);
+      _log.e('load failed gameId=$gameId', error: e, stackTrace: st);
       return null;
     }
   }
@@ -97,7 +97,7 @@ class GameSaveAdapter {
     required MapTopology combinedTopology,
     List<WarpLink>? warpLinks,
   }) {
-    _log.d('save: saving map data gameId=$gameId');
+    _log.d('saving map data gameId=$gameId');
     box.put(
       gameId + _suffixTileMapByRegion,
       tileMapByRegion.map((k, v) => MapEntry(k, v.toJson())),
@@ -113,7 +113,7 @@ class GameSaveAdapter {
         warpLinks.map((l) => l.toJson()).toList(),
       );
     }
-    _log.d('save: saved map data gameId=$gameId');
+    _log.d('saved map data gameId=$gameId');
   }
 
   /// Loads map data for [gameId]. Returns null if any key is missing (legacy save).
@@ -155,7 +155,7 @@ class GameSaveAdapter {
             .map((l) => WarpLink.fromJson(Map<String, dynamic>.from(l as Map)))
             .toList();
       }
-      _log.d('save: loaded map data gameId=$gameId');
+      _log.d('loaded map data gameId=$gameId');
       return (
         tileMapByRegion: tileMapByRegion,
         topologyByRegion: topologyByRegion,
@@ -164,7 +164,7 @@ class GameSaveAdapter {
       );
     } catch (e, st) {
       _log.e(
-        'save: load map data failed gameId=$gameId',
+        'load map data failed gameId=$gameId',
         error: e,
         stackTrace: st,
       );

--- a/packages/session_log_buffer/lib/session_log_buffer.dart
+++ b/packages/session_log_buffer/lib/session_log_buffer.dart
@@ -5,7 +5,7 @@ import 'package:logger/logger.dart';
 /// Default maximum number of log entries to retain (oldest dropped when exceeded).
 const int defaultMaxEntries = 5000;
 
-/// Known log prefixes used in the project (ctdev, logic, ai, data, map, save, tui, game).
+/// Known log prefixes used in the project (ctdev, logic, ai, data, map, save, tui, game, app).
 /// Used for filter options in the viewer.
 const List<String> knownPrefixes = [
   'ctdev',
@@ -16,6 +16,7 @@ const List<String> knownPrefixes = [
   'save',
   'game',
   'tui',
+  'app',
 ];
 
 /// Standard log levels for filter options.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -497,10 +497,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

Implements the work outlined in #1382: align operational logging with `SPEC/program/logging/` (policy + events annex) across packages, app, ctdev, and ctterm.

## Changes

- **No double-prefixing:** Remove redundant `logic:`, `save:`, `data:`, etc. from message bodies when using `CtLogger` factories (`colonizethis_logic`, `colonizethis_save`, `colonizethis_data`, `colonizethis_map`).
- **`ctdevLogger`:** New factory in `colonizethis_logger`; ctdev uses it for main, save service, sim controller, and running game screen errors.
- **Session buffer:** `knownPrefixes` includes `app` for the debug log viewer.
- **Game events:** `deliverGameEvent` + logging inside `DefaultGameEventBus.publish` — one info line per delivery with `event=`, ids, compact payload summary, and length cap (`events.md`).
- **App:** `appLogger` / `dataLogger('hive')`, `runZonedGuarded` for uncaught async errors; dialogue stack uses `CtLogger`.
- **Ctterm:** `tuiLogger()` everywhere; stripped manual `tui:area:` prefixes from messages; debug log viewer keeps `package:logger` only for `Level`.

## Testing

- `dart test` in `packages/colonizethis_logger`
- Focused `dart test` in `packages/colonizethis_logic` (event bus, combat/research/movement logging tests)
- `flutter test app/test/ct_dialogue_view_test.dart`
- `dart analyze` on ctdev lib, ctterm lib+bin

Closes #1382

Made with [Cursor](https://cursor.com)