### PR TITLE
Naval panel: multi-select combine (locality rules, Home Fleet target)

### DIFF
--- a/SPEC/ui/naval-units-fleet-management.md
+++ b/SPEC/ui/naval-units-fleet-management.md
@@ -7,59 +7,60 @@
 ## Purpose
 
 Players need to reorganize their fleets:
+
 - **Split**: Divide a fleet into two fleets (e.g., send a detachment on a separate mission).
-- **Combine**: Merge multiple fleets at the same location into a single fleet.
+- **Combine**: Merge **two or more selected** fleets that share the **same naval locality** (see below) into one fleet.
 
 ---
 
 ## Combine Fleets
 
-### Trigger
+### Trigger and layout
 
-Each non-Home Fleet row in the expanded state shows a **"Combine"** button.
+- The panel **title row** includes:
+  - A **Select all / Deselect all** control implemented as a **tristate header checkbox** (unchecked = none selected; checked = all fleets selected; indeterminate = partial selection). Interacting with it **selects every fleet row** or **clears all selection** (same behavior as typical “select all” patterns: from none or partial → select all; from all → deselect all).
+  - A **Combine** button (same family as other panel actions, e.g. nine-patch), placed in the title row next to that checkbox.
+- **No separate Cancel** for combine; clearing selection uses the header control or per-row checkboxes.
 
-### Behavior
+### Per-fleet selection
 
-1. **First tap on a fleet's Combine button**:
-   - The button changes to indicate the fleet is the **combine target**.
-   - Other fleets at the **same location** (same port province OR same sea zone) that are also owned by the human player become visually selectable (e.g., highlighted with a checkbox).
+- Every fleet row (including **Home Fleet**) shows a **checkbox** in the row header **at all times** (collapsed or expanded). Checking does not require expanding the row.
+- **Combine** is **enabled** only when:
+  - **At least two** fleets are checked, and
+  - Every checked fleet shares the **same combine locality**: either the **same sea zone** (fleets at sea) or the **same port province** (fleets in port). Ports are **not** mixed with sea zones for this rule—a fleet in port and a fleet at sea in an adjacent zone cannot combine.
+- **Combine** is **disabled** when fewer than two fleets are checked, or when checked fleets span more than one locality.
 
-2. **Selecting another fleet at the same location** (e.g. checkbox on its title row):
-   - That fleet is added to the selection set.
-   - Visual feedback shows all selected fleets.
+### Merge target and ship data
 
-3. **Tapping Confirm on the target fleet** (after selecting sources):
-   - All selected fleets (non-target sources) are merged into the **target fleet**.
-   - **Ship instances** (`id` + `typeId`) from each source fleet are **appended** to the target fleet’s instance list (each hull keeps its unique id).
-   - Source fleets (non-target) are **removed** from `WorldState.fleets`.
-   - The Home Fleet is **excluded** from combine operations.
-
-4. **Cancel**: Tapping elsewhere dismisses the combine mode without changes.
+- **Survivor fleet** (merge target):
+  - If **Home Fleet** is among the checked fleets, the **Home Fleet** is always the target (all other checked fleets merge **into** it).
+  - Otherwise, the target is the checked fleet that appears **first in panel display order** (same ordering as [naval-units-panel.md](naval-units-panel.md): region groups, Home Fleet section when present, then location nodes and stable fleet order within each node).
+- **Sources:** every **other** checked fleet, in **panel display order** after the target.
+- **Ship instances:** Append each source’s `ships` list onto the target’s list in that order; each hull keeps its unique instance `id` (no duplicate ids across fleets).
+- **Remove** every **source** fleet from `WorldState.fleets` after the merge.
+- **Mission:** The **surviving** fleet’s mission is set to **`none`** (missions from merged fleets do not carry over). Clear any mission-specific targets on the merged fleet if the model supports them.
 
 ### Rules
 
 | Rule | Description |
 |------|-------------|
-| Same location | Only fleets at the same port province OR same sea zone can be combined. |
-| Same owner | Only fleets owned by the human player. |
-| Home Fleet excluded | Home Fleet cannot be combined into or used as source. |
-| Empty fleets auto-deleted | After combining, source fleets with no ships (edge case) are removed. Home Fleet is never deleted even if empty. |
-| Target selection | The fleet whose Combine button was tapped first becomes the target. |
+| Same locality | Only fleets in the **same port province** or the **same sea zone** may be combined together in one action. |
+| Same owner | Only fleets owned by the human player are listed; combine only affects the player’s selection. |
+| Home Fleet | **May** be selected and combined. When checked with other fleets, Home Fleet is **always** the merge target. |
+| Empty fleets | After combining, any non-Home fleet with no ships is removed. Home Fleet is **never** deleted when empty. |
 
 ### Data changes
 
 ```dart
-// Before: Fleet A (target) + Fleet B (source), each with List<ShipInstance> ships
-// After: Fleet A.ships = [...A.ships, ...B.ships]; Fleet B removed from WorldState.fleets
+// Checked fleets at same locality: target T (Home if selected, else first in panel order among checked),
+// sources S1, S2, … in display order after T.
+// After: T.ships = [...T.ships, ...S1.ships, ...]; S1, S2, … removed; T.mission = none.
 ```
 
-### UI
+### UI notes
 
-- **Combine button**: Nine-patch button in the **expanded** fleet tile (scroll if needed in short panels), labeled "Combine".
-- **Selection state**: Checkbox appears next to each eligible fleet title. Selected fleets show a checked checkbox.
-- **Target indicator**: Target fleet shows a **TARGET** badge on the title row; its action button is **Confirm**.
-- **Ineligible fleets**: Fleets at different locations are not selectable (no checkbox).
-- **Expansion vs locate:** Tapping the fleet **header** expands or collapses the tile. **Locate fleet** runs only from the **location icon** in the header (not a whole-row tap).
+- **Locate fleet** remains on the **location icon** in the header (not the whole row), per [naval-units-panel.md](naval-units-panel.md) interaction with fleet management.
+- **Expansion vs locate:** Tapping the fleet **title text** (or default expansion affordance) expands or collapses the tile; the checkbox only toggles selection.
 
 ---
 
@@ -80,6 +81,7 @@ dual-list quantity movement. The naval split dialog configures this component
 with fleet-specific labels and validation.
 
 `CtTransferList` API requirements:
+
 - Inputs: left/right titles, optional subtitles, initial counts for both sides
 - Transfer controls: per-row one/all moves in both directions (`<`, `>`, `<<`, `>>`) on each list row (no separate “selected type” step)
 - Validation hook: `canConfirm(leftCounts, rightCounts)`
@@ -88,6 +90,7 @@ with fleet-specific labels and validation.
 - Customizable item label and empty-state labels
 
 Naval-specific behavior remains outside the component:
+
 - Home-fleet split rule override
 - Fleet location labeling
 - Conversion from right-side counts to the set of **ship instance ids** transferred to the new fleet
@@ -159,6 +162,7 @@ Naval-specific behavior remains outside the component:
 ## Empty Fleet Cleanup
 
 After any fleet operation (split or combine):
+
 - Fleets with an **empty** `ships` list are removed from `WorldState.fleets`.
 - Exception: The Home Fleet is **never deleted**, even when empty.
 
@@ -176,13 +180,21 @@ After any fleet operation (split or combine):
 
 ### Combine
 
-- **Given** two fleets at the same port province owned by the human player, **when** the user expands Fleet A, taps Combine, selects Fleet B via its checkbox, and taps Confirm on the target, **then** Fleet A’s instance list contains every hull from both fleets (each **instance id** appears once), Fleet B is removed, and the panel reflects these changes immediately.
+- **Given** two fleets in the **same port province** owned by the human player, **when** the user checks both and taps **Combine**, **then** the first-checked fleet in **panel order** among the selection (or **Home Fleet** if it is checked) receives every ship instance from the other, the source fleet is removed, the survivor’s mission is **`none`**, and the panel updates immediately.
 
-- **Given** three fleets at the same sea zone owned by the human player, **when** the user combines them, **then** the target fleet receives all ships, the two source fleets are removed, and the panel updates immediately.
+- **Given** the **Home Fleet** and another fleet **in port at the capital** (same locality), **when** the user checks both and taps **Combine**, **then** all ship instances merge **into the Home Fleet** regardless of panel order relative to the other fleet, the non-home fleet is removed, and the Home Fleet’s mission is **`none`**.
 
-- **Given** a fleet at a port province and another fleet at a different port province, **when** the user attempts to combine them, **then** the combine operation is not available between these fleets.
+- **Given** a fleet at a port province and another fleet at a **different** port or at **sea**, **when** the user checks both, **then** **Combine** remains **disabled** and no merge occurs until the selection is valid.
 
-- **Given** the Home Fleet is present, **when** the user views fleet options, **then** the Home Fleet does not show a Combine button.
+- **Given** the Naval Units panel is open, **when** fewer than two fleets are checked, **then** **Combine** is **disabled**.
+
+- **Given** the panel title **select-all** checkbox, **when** the user uses it to select all fleets then uses it again, **then** selection clears (deselect all).
+
+- **Given** **three or more** fleets sharing the **same port** or the **same sea zone**, **when** the user checks them and taps **Combine**, **then** one survivor fleet (Home if selected, else first in panel order) contains every ship in panel order, the other checked fleets are removed, the survivor’s mission is **`none`**, and the panel updates immediately.
+
+- **Given** two fleets **at sea** in **different** sea zones, **when** both are checked, **then** **Combine** stays **disabled**.
+
+- **Given** one fleet **at sea** and one **in port**, **when** both are checked, **then** **Combine** stays **disabled** (mixed locality).
 
 ### Split
 
@@ -210,16 +222,14 @@ After any fleet operation (split or combine):
 
 ### Stories
 
-1. **Combine Mode Active**: Shows a fleet row with Combine button pressed, other fleets at same location highlighted with checkboxes.
+1. **Combine selection**: Title row with header checkbox and Combine; several fleets with per-row checkboxes; Combine disabled until two+ at same locality.
 2. **Split Dialog Open**: Shows the split fleet modal dialog with ship transfer controls.
 3. **Post-Operation State**: Shows the panel after a combine/split operation.
 
 ### Test Coverage
 
-- Unit tests for combine logic (same location validation, ship aggregation).
-- Unit tests for split logic (minimum ship validation, new fleet creation).
-- Widget tests for combine mode UI (selection, target, confirmation).
-- Widget tests for split dialog (ship movement, confirm/cancel).
+- Unit tests for combine logic (same locality validation, ship aggregation, Home Fleet target priority, mission reset).
+- Widget tests for combine UI (selection, header select-all, disabled Combine when invalid).
 
 ---
 
@@ -235,7 +245,7 @@ After any fleet operation (split or combine):
 
 ### Key Implementation Details
 
-1. **Combine Mode State**: Managed via `_NavalUnitsPanelState` with `_combineTargetFleetId` and `_selectedForCombine` fields.
+1. **Combine selection**: `Set<String>` of canonical fleet ids (`homeFleetIdFor(player)` for Home Fleet rows; otherwise row `fleetId`).
 
 2. **Split Dialog**: `SplitFleetDialog` uses `CtDialogShell` for pixel-art framing, `CtNinePatchButton` for actions, and `CtPanel` for fleet panels.
 
@@ -245,10 +255,9 @@ After any fleet operation (split or combine):
 
 5. **State Propagation**: Changes are propagated via `onFleetsChanged` callback which calls the Riverpod `currentGameProvider.notifier.state`.
 
-### UI Changes
+### UI labels
 
-- **Split Button**: Shortened from "Split Fleet" to "Split" to save space
-- **Combine Button**: Shows "Select"/"Remove" during selection, "Confirm" for target
-- **TARGET badge**: Theme-colored badge next to target fleet name
-- **Checkboxes**: Appear on eligible fleets during combine mode
+- **Split** button: shortened from "Split Fleet" in-row.
+- **Combine**: single action in the panel title row (not per-row).
 
+GitHub tracking: [issue #1390](https://github.com/waigore/colonizethisv3/issues/1390) (naval combine UX: checkbox multi-select, locality rule, Home Fleet target).

--- a/SPEC/ui/naval-units-panel.md
+++ b/SPEC/ui/naval-units-panel.md
@@ -6,7 +6,7 @@
 
 ## Purpose
 
-The naval units panel gives the player a single place to see every **fleet** they control, including the **Home Fleet**. The panel:
+The naval units panel gives the player a single place to see every **fleet** they control, including the **Home Fleet**. **Split** and **combine** fleet actions (checkbox multi-select, locality rules, Home Fleet merge target) are specified in [naval-units-fleet-management.md](naval-units-fleet-management.md). The panel:
 
 - Lists fleets grouped by **region** and by **location** (in port at a province vs at sea in a sea zone).
 - Always shows the **Home Fleet** as a special entry at the top for the player’s capital, even when it currently has zero ships.

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -399,108 +399,193 @@ class NavalUnitsPanel extends StatefulWidget {
 }
 
 class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
-  String? _combineTargetFleetId;
-  final Set<String> _selectedForCombine = {};
+  final Set<String> _selectedFleetIds = {};
 
-  bool _isCombineModeActive() => _combineTargetFleetId != null;
+  /// Canonical fleet id for combine/split selection (Home Fleet uses [homeFleetIdFor]).
+  String _selectionFleetId(_FleetRow row) {
+    if (row.isHomeFleet) return homeFleetIdFor(widget.humanPlayerId);
+    return row.fleetId;
+  }
 
-  _FleetRow? _getTargetRow() {
-    if (_combineTargetFleetId == null) return null;
-    final tree = _buildNavalTree(widget.game, widget.humanPlayerId);
-    final allRows = _flattenTree(tree);
-    for (final row in allRows) {
-      if (row.fleetId == _combineTargetFleetId) {
-        return row;
-      }
+  bool _canCombineSelection(List<_FleetRow> flat) {
+    final rowsById = <String, _FleetRow>{
+      for (final r in flat) _selectionFleetId(r): r,
+    };
+    final activeIds = _selectedFleetIds.where(rowsById.containsKey).toList();
+    if (activeIds.length < 2) return false;
+    String? locationKey;
+    for (final id in activeIds) {
+      final row = rowsById[id]!;
+      locationKey ??= row.locationKey;
+      if (row.locationKey != locationKey) return false;
+    }
+    return true;
+  }
+
+  String _combineTargetFleetId(List<_FleetRow> flat, Set<String> selected) {
+    for (final row in flat) {
+      final id = _selectionFleetId(row);
+      if (!selected.contains(id)) continue;
+      if (row.isHomeFleet) return id;
+    }
+    for (final row in flat) {
+      final id = _selectionFleetId(row);
+      if (selected.contains(id)) return id;
+    }
+    throw StateError('combine target: empty selection');
+  }
+
+  Fleet? _fleetForRow(_FleetRow row) {
+    final id = _selectionFleetId(row);
+    for (final f in widget.game.worldState.fleets) {
+      if (f.id == id) return f;
+    }
+    if (row.isHomeFleet) {
+      final portId = row.inPortAtProvinceId;
+      if (portId == null) return null;
+      return Fleet(
+        id: id,
+        ownerId: widget.humanPlayerId,
+        regionId: row.regionId,
+        inPortAtProvinceId: portId,
+        ships: const [],
+        mission: FleetMission.none,
+      );
     }
     return null;
   }
 
-  bool _isEligibleForCombine(_FleetRow row) {
-    final targetRow = _getTargetRow();
-    if (targetRow == null) return false;
-    if (row.isHomeFleet) return false;
-    if (row.fleetId == targetRow.fleetId) return false;
-    return row.locationKey == targetRow.locationKey;
-  }
-
-  void _startCombine(_FleetRow row) {
+  void _toggleFleetSelection(_FleetRow row) {
     setState(() {
-      _combineTargetFleetId = row.fleetId;
-      _selectedForCombine.clear();
-    });
-  }
-
-  void _toggleFleetForCombine(_FleetRow row) {
-    setState(() {
-      if (_selectedForCombine.contains(row.fleetId)) {
-        _selectedForCombine.remove(row.fleetId);
+      final id = _selectionFleetId(row);
+      if (_selectedFleetIds.contains(id)) {
+        _selectedFleetIds.remove(id);
       } else {
-        _selectedForCombine.add(row.fleetId);
+        _selectedFleetIds.add(id);
       }
     });
   }
 
-  void _confirmCombine() {
-    if (_combineTargetFleetId == null) return;
-
-    final targetFleet = widget.game.worldState.fleets.firstWhere(
-      (f) => f.id == _combineTargetFleetId,
-      orElse: () => widget.game.worldState.fleets.first,
-    );
-
-    final fleetsToCombine = <Fleet>[targetFleet];
-    for (final fleetId in _selectedForCombine) {
-      final fleet = widget.game.worldState.fleets.firstWhere(
-        (f) => f.id == fleetId,
-        orElse: () => widget.game.worldState.fleets.first,
-      );
-      fleetsToCombine.add(fleet);
+  bool? _headerSelectAllValue(List<_FleetRow> flat) {
+    if (flat.isEmpty) return false;
+    final ids = flat.map(_selectionFleetId).toSet();
+    var n = 0;
+    for (final id in ids) {
+      if (_selectedFleetIds.contains(id)) n++;
     }
-
-    final allShips = <ShipInstance>[];
-    for (final fleet in fleetsToCombine) {
-      allShips.addAll(fleet.ships);
-    }
-
-    final updatedTarget = targetFleet.copyWith(ships: allShips);
-    final sourceFleetIds = _selectedForCombine.toSet();
-
-    final updatedFleets = widget.game.worldState.fleets
-        .where((f) => !sourceFleetIds.contains(f.id))
-        .map((f) => f.id == _combineTargetFleetId ? updatedTarget : f)
-        .toList();
-
-    final newGame = widget.game.copyWith(
-      worldState: widget.game.worldState.copyWith(fleets: updatedFleets),
-    );
-
-    _cancelCombine();
-    widget.bus.emit(NavalFleetsUpdatedEvent(game: newGame));
+    if (n == 0) return false;
+    if (n == ids.length) return true;
+    return null;
   }
 
-  void _cancelCombine() {
+  void _onHeaderSelectAllChanged(bool? next, List<_FleetRow> flat) {
     setState(() {
-      _combineTargetFleetId = null;
-      _selectedForCombine.clear();
+      if (next == true) {
+        _selectedFleetIds
+          ..clear()
+          ..addAll(flat.map(_selectionFleetId));
+      } else {
+        _selectedFleetIds.clear();
+      }
     });
   }
 
-  void _openSplitDialog(_FleetRow row) {
-    final fleet = widget.game.worldState.fleets.firstWhere(
-      (f) => f.id == row.fleetId,
-      orElse: () => widget.game.worldState.fleets.first,
+  void _performCombine(List<_FleetRow> flat) {
+    if (!_canCombineSelection(flat)) return;
+
+    final selected = Set<String>.from(_selectedFleetIds);
+    final targetId = _combineTargetFleetId(flat, selected);
+
+    _FleetRow? targetRow;
+    for (final row in flat) {
+      if (_selectionFleetId(row) == targetId) {
+        targetRow = row;
+        break;
+      }
+    }
+    if (targetRow == null) return;
+
+    final targetFleet = _fleetForRow(targetRow);
+    if (targetFleet == null) return;
+
+    final mergedShips = <ShipInstance>[...targetFleet.ships];
+    for (final row in flat) {
+      final id = _selectionFleetId(row);
+      if (!selected.contains(id) || id == targetId) continue;
+      final f = _fleetForRow(row);
+      if (f != null) mergedShips.addAll(f.ships);
+    }
+
+    final merged = Fleet(
+      id: targetId,
+      ownerId: widget.humanPlayerId,
+      seaZoneId: targetFleet.seaZoneId,
+      inPortAtProvinceId: targetFleet.inPortAtProvinceId,
+      regionId: targetFleet.regionId,
+      ships: mergedShips,
+      mission: FleetMission.none,
     );
 
+    final homeId = homeFleetIdFor(widget.humanPlayerId);
+    var updated = widget.game.worldState.fleets
+        .where((f) => !selected.contains(f.id))
+        .toList();
+    updated = [...updated, merged];
+    updated = updated
+        .where((f) => f.ships.isNotEmpty || f.id == homeId)
+        .toList();
+
+    final newGame = widget.game.copyWith(
+      worldState: widget.game.worldState.copyWith(fleets: updated),
+    );
+
+    setState(_selectedFleetIds.clear);
+    widget.bus.emit(NavalFleetsUpdatedEvent(game: newGame));
+  }
+
+  @override
+  void didUpdateWidget(covariant NavalUnitsPanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.game != widget.game) {
+      final flat = _flattenTree(
+        _buildNavalTree(widget.game, widget.humanPlayerId),
+      );
+      final valid = flat.map(_selectionFleetId).toSet();
+      final pruned = _selectedFleetIds.intersection(valid);
+      if (pruned.length != _selectedFleetIds.length) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          setState(() {
+            _selectedFleetIds
+              ..clear()
+              ..addAll(pruned);
+          });
+        });
+      }
+    }
+  }
+
+  void _openSplitDialog(_FleetRow row) {
+    final id = _selectionFleetId(row);
+    Fleet? fleet;
+    for (final f in widget.game.worldState.fleets) {
+      if (f.id == id) {
+        fleet = f;
+        break;
+      }
+    }
+    if (fleet == null) return;
+
+    final original = fleet;
     showDialog<void>(
       context: context,
       builder: (ctx) => SplitFleetDialog(
-        originalFleet: fleet,
+        originalFleet: original,
         game: widget.game,
         humanPlayerId: widget.humanPlayerId,
         isHomeFleet: row.isHomeFleet,
         onConfirm: (shipInstanceIds) {
-          _performSplit(fleet, shipInstanceIds);
+          _performSplit(original, shipInstanceIds);
         },
       ),
     );
@@ -510,10 +595,12 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
     if (shipInstanceIdsToNew.isEmpty) return;
 
     final idSet = shipInstanceIdsToNew.toSet();
-    final shipsToNewFleet =
-        originalFleet.ships.where((s) => idSet.contains(s.id)).toList();
-    final remainingShips =
-        originalFleet.ships.where((s) => !idSet.contains(s.id)).toList();
+    final shipsToNewFleet = originalFleet.ships
+        .where((s) => idSet.contains(s.id))
+        .toList();
+    final remainingShips = originalFleet.ships
+        .where((s) => !idSet.contains(s.id))
+        .toList();
 
     final allFleetIds = widget.game.worldState.fleets
         .map((f) => int.tryParse(f.id.replaceAll(RegExp(r'[^0-9]'), '')) ?? 0)
@@ -551,83 +638,89 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
   @override
   Widget build(BuildContext context) {
     final tree = _buildNavalTree(widget.game, widget.humanPlayerId);
+    final flat = _flattenTree(tree);
     final hasAny = tree.any(
       (group) => group.homeFleet != null || group.locations.isNotEmpty,
     );
+    final canCombine = _canCombineSelection(flat);
+    final headerCheckbox = _headerSelectAllValue(flat);
 
-    return GestureDetector(
-      onTap: _isCombineModeActive() ? _cancelCombine : null,
-      behavior: HitTestBehavior.translucent,
-      child: UnitsPanelShell(
-        title: 'Naval Units',
-        actions: [
-          if (_isCombineModeActive())
-            TextButton(onPressed: _cancelCombine, child: const Text('Cancel')),
+    return UnitsPanelShell(
+      title: 'Naval Units',
+      actions: [
+        if (hasAny && flat.isNotEmpty) ...[
+          Tooltip(
+            message: headerCheckbox == true
+                ? 'Deselect all fleets'
+                : 'Select all fleets',
+            child: Checkbox(
+              tristate: true,
+              value: headerCheckbox,
+              onChanged: (v) => _onHeaderSelectAllChanged(v, flat),
+              visualDensity: VisualDensity.compact,
+              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+          ),
+          const SizedBox(width: 4),
+          CtNinePatchButton(
+            onPressed: canCombine ? () => _performCombine(flat) : null,
+            enabled: canCombine,
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            minHeight: 32,
+            child: const Text('Combine'),
+          ),
         ],
-        hasContent: hasAny,
-        listChildren: [
-          for (final group in tree) ...[
-            RegionSectionHeader(label: unitsPanelRegionLabel(group.regionId)),
-            if (group.homeFleet != null)
+      ],
+      hasContent: hasAny,
+      listChildren: [
+        for (final group in tree) ...[
+          RegionSectionHeader(label: unitsPanelRegionLabel(group.regionId)),
+          if (group.homeFleet != null)
+            _FleetExpansionTile(
+              row: group.homeFleet!,
+              onTap: group.homeFleet!.tileKey != null
+                  ? () => widget.bus.emit(
+                      LocateMapTileEvent(
+                        tileKey: group.homeFleet!.tileKey!,
+                        regionId: group.homeFleet!.regionId,
+                      ),
+                    )
+                  : null,
+              isSelectedForCombine: _selectedFleetIds.contains(
+                _selectionFleetId(group.homeFleet!),
+              ),
+              onCombineSelectionToggle: () =>
+                  _toggleFleetSelection(group.homeFleet!),
+              onSplitFleet: () => _openSplitDialog(group.homeFleet!),
+              isSplitAllowed: true,
+            ),
+          for (final loc in group.locations) ...[
+            LocationSectionHeader(
+              label: loc.displayLabel,
+              regionLabel: unitsPanelRegionLabel(loc.regionId),
+            ),
+            for (final row in loc.fleets)
               _FleetExpansionTile(
-                row: group.homeFleet!,
-                onTap: group.homeFleet!.tileKey != null
+                row: row,
+                onTap: row.tileKey != null
                     ? () => widget.bus.emit(
                         LocateMapTileEvent(
-                          tileKey: group.homeFleet!.tileKey!,
-                          regionId: group.homeFleet!.regionId,
+                          tileKey: row.tileKey!,
+                          regionId: row.regionId,
                         ),
                       )
                     : null,
-                isCombineMode: _isCombineModeActive(),
-                isCombineTarget:
-                    _combineTargetFleetId == group.homeFleet!.fleetId,
-                isSelectedForCombine: _selectedForCombine.contains(
-                  group.homeFleet!.fleetId,
+                isSelectedForCombine: _selectedFleetIds.contains(
+                  _selectionFleetId(row),
                 ),
-                isEligibleForCombine:
-                    _isCombineModeActive() &&
-                    _isEligibleForCombine(group.homeFleet!),
-                onCombineStart: () => _startCombine(group.homeFleet!),
-                onCombineToggle: () => _toggleFleetForCombine(group.homeFleet!),
-                onCombineConfirm: () => _confirmCombine(),
-                onSplitFleet: () => _openSplitDialog(group.homeFleet!),
+                onCombineSelectionToggle: () => _toggleFleetSelection(row),
+                onSplitFleet: () => _openSplitDialog(row),
                 isSplitAllowed: true,
               ),
-            for (final loc in group.locations) ...[
-              LocationSectionHeader(
-                label: loc.displayLabel,
-                regionLabel: unitsPanelRegionLabel(loc.regionId),
-              ),
-              for (final row in loc.fleets)
-                _FleetExpansionTile(
-                  row: row,
-                  onTap: row.tileKey != null
-                      ? () => widget.bus.emit(
-                          LocateMapTileEvent(
-                            tileKey: row.tileKey!,
-                            regionId: row.regionId,
-                          ),
-                        )
-                      : null,
-                  isCombineMode: _isCombineModeActive(),
-                  isCombineTarget: _combineTargetFleetId == row.fleetId,
-                  isSelectedForCombine: _selectedForCombine.contains(
-                    row.fleetId,
-                  ),
-                  isEligibleForCombine:
-                      _isCombineModeActive() && _isEligibleForCombine(row),
-                  onCombineStart: () => _startCombine(row),
-                  onCombineToggle: () => _toggleFleetForCombine(row),
-                  onCombineConfirm: () => _confirmCombine(),
-                  onSplitFleet: () => _openSplitDialog(row),
-                  isSplitAllowed: true,
-                ),
-            ],
           ],
         ],
-        emptyMessage: 'No naval units',
-      ),
+      ],
+      emptyMessage: 'No naval units',
     );
   }
 }
@@ -636,26 +729,16 @@ class _FleetExpansionTile extends StatelessWidget {
   const _FleetExpansionTile({
     required this.row,
     this.onTap,
-    this.isCombineMode = false,
-    this.isCombineTarget = false,
-    this.isSelectedForCombine = false,
-    this.isEligibleForCombine = false,
-    this.onCombineStart,
-    this.onCombineToggle,
-    this.onCombineConfirm,
+    required this.isSelectedForCombine,
+    required this.onCombineSelectionToggle,
     this.onSplitFleet,
     this.isSplitAllowed = false,
   });
 
   final _FleetRow row;
   final VoidCallback? onTap;
-  final bool isCombineMode;
-  final bool isCombineTarget;
   final bool isSelectedForCombine;
-  final bool isEligibleForCombine;
-  final VoidCallback? onCombineStart;
-  final VoidCallback? onCombineToggle;
-  final VoidCallback? onCombineConfirm;
+  final VoidCallback onCombineSelectionToggle;
   final VoidCallback? onSplitFleet;
   final bool isSplitAllowed;
 
@@ -674,43 +757,19 @@ class _FleetExpansionTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bool showCheckbox =
-        isCombineMode && !isCombineTarget && isEligibleForCombine;
-
     return Padding(
       padding: const EdgeInsets.only(left: 8),
       child: ExpansionTile(
         title: Row(
           children: [
-            if (showCheckbox) ...[
-              Checkbox(
-                value: isSelectedForCombine,
-                onChanged: (_) => onCombineToggle?.call(),
-              ),
-              const SizedBox(width: 8),
-            ],
+            Checkbox(
+              value: isSelectedForCombine,
+              onChanged: (_) => onCombineSelectionToggle(),
+              visualDensity: VisualDensity.compact,
+              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            const SizedBox(width: 4),
             Flexible(child: Text(row.label, overflow: TextOverflow.ellipsis)),
-            if (isCombineTarget) ...[
-              const SizedBox(width: 8),
-              Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 6,
-                  vertical: 2,
-                ),
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.primary,
-                  borderRadius: BorderRadius.circular(4),
-                ),
-                child: Text(
-                  'TARGET',
-                  style: TextStyle(
-                    color: Theme.of(context).colorScheme.onPrimary,
-                    fontSize: 10,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ),
-            ],
             if (onTap != null) ...[
               const SizedBox(width: 4),
               IconButton(
@@ -727,7 +786,6 @@ class _FleetExpansionTile extends StatelessWidget {
           '${row.locationLabel}\nMission: ${row.missionLabel} · ${_summary()}',
         ),
         dense: true,
-        initiallyExpanded: isCombineMode,
         children: [
           if (row.shipCountsByType.isEmpty)
             const ListTile(title: Text('No ships in this fleet'), dense: true)
@@ -750,12 +808,12 @@ class _FleetExpansionTile extends StatelessWidget {
             ),
             dense: true,
           ),
-          Padding(
-            padding: const EdgeInsets.all(8),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                if (isSplitAllowed) ...[
+          if (isSplitAllowed)
+            Padding(
+              padding: const EdgeInsets.all(8),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
                   CtNinePatchButton(
                     onPressed: onSplitFleet,
                     padding: const EdgeInsets.symmetric(
@@ -765,31 +823,9 @@ class _FleetExpansionTile extends StatelessWidget {
                     minHeight: 36,
                     child: const Text('Split'),
                   ),
-                  const SizedBox(width: 8),
                 ],
-                if (!row.isHomeFleet)
-                  CtNinePatchButton(
-                    onPressed: isCombineTarget
-                        ? onCombineConfirm
-                        : isCombineMode
-                        ? onCombineToggle
-                        : onCombineStart,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 8,
-                    ),
-                    minHeight: 36,
-                    child: Text(
-                      isCombineTarget
-                          ? 'Confirm'
-                          : isCombineMode
-                          ? (isSelectedForCombine ? 'Remove' : 'Select')
-                          : 'Combine',
-                    ),
-                  ),
-              ],
+              ),
             ),
-          ),
         ],
       ),
     );

--- a/app/test/naval_units_panel_test.dart
+++ b/app/test/naval_units_panel_test.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:colonizethis_logic/colonizethis_logic.dart' show homeFleetIdFor;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flame/flame.dart';
@@ -14,6 +15,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_panel.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
 
@@ -614,25 +616,46 @@ void main() {
       expect(find.text('Split'), findsOneWidget);
     });
 
-    testWidgets('AC: Combine button is not shown for Home Fleet', (
-      WidgetTester tester,
-    ) async {
-      final humanId = humanPlayerIdWithFleets;
+    testWidgets(
+      'AC: Home Fleet row has a checkbox; Combine is only in the panel header',
+      (WidgetTester tester) async {
+        final humanId = humanPlayerIdWithFleets;
 
-      await tester.pumpWidget(buildPanel(game: game, humanPlayerId: humanId));
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(buildPanel(game: game, humanPlayerId: humanId));
+        await tester.pumpAndSettle();
 
-      final homeFleetFinder = find.widgetWithText(ExpansionTile, 'Home Fleet');
-      if (homeFleetFinder.evaluate().isEmpty) {
-        return;
-      }
+        final homeFleetFinder = find.widgetWithText(
+          ExpansionTile,
+          'Home Fleet',
+        );
+        if (homeFleetFinder.evaluate().isEmpty) {
+          return;
+        }
 
-      await tester.ensureVisible(homeFleetFinder);
-      await tester.tap(homeFleetFinder);
-      await tester.pumpAndSettle();
+        expect(
+          find.descendant(of: homeFleetFinder, matching: find.byType(Checkbox)),
+          findsOneWidget,
+        );
 
-      expect(find.text('Combine'), findsNothing);
-    });
+        final combineButtons = find.widgetWithText(
+          CtNinePatchButton,
+          'Combine',
+        );
+        expect(combineButtons, findsOneWidget);
+
+        await tester.ensureVisible(homeFleetFinder);
+        await tester.tap(homeFleetFinder);
+        await tester.pumpAndSettle();
+
+        expect(
+          find.descendant(
+            of: homeFleetFinder,
+            matching: find.widgetWithText(CtNinePatchButton, 'Combine'),
+          ),
+          findsNothing,
+        );
+      },
+    );
 
     testWidgets('AC: Split button is shown for non-Home Fleet', (
       WidgetTester tester,
@@ -717,38 +740,30 @@ void main() {
       },
     );
 
-    testWidgets('AC: Combine button is shown for non-Home Fleet', (
-      WidgetTester tester,
-    ) async {
-      final humanId = humanPlayerIdWithFleets;
+    testWidgets(
+      'AC: Combine control is in the panel header when fleets exist',
+      (WidgetTester tester) async {
+        final humanId = humanPlayerIdWithFleets;
 
-      final playerFleets = game.worldState.fleets
-          .where(
-            (f) =>
-                f.ownerId == humanId &&
-                f.shipTypeIds.isNotEmpty &&
-                f.id != 'home_fleet',
-          )
-          .toList();
-      if (playerFleets.isEmpty) return;
+        final playerFleets = game.worldState.fleets
+            .where(
+              (f) =>
+                  f.ownerId == humanId &&
+                  f.shipTypeIds.isNotEmpty &&
+                  f.id != 'home_fleet',
+            )
+            .toList();
+        if (playerFleets.isEmpty) return;
 
-      final baseFleet = playerFleets.first;
+        await tester.pumpWidget(buildPanel(game: game, humanPlayerId: humanId));
+        await tester.pumpAndSettle();
 
-      await tester.pumpWidget(buildPanel(game: game, humanPlayerId: humanId));
-      await tester.pumpAndSettle();
-
-      final fleetFinder = find.widgetWithText(
-        ExpansionTile,
-        'Fleet ${baseFleet.id}',
-      );
-      if (fleetFinder.evaluate().isEmpty) return;
-
-      await tester.ensureVisible(fleetFinder);
-      await tester.tap(fleetFinder);
-      await tester.pumpAndSettle();
-
-      expect(find.text('Combine'), findsOneWidget);
-    });
+        expect(
+          find.widgetWithText(CtNinePatchButton, 'Combine'),
+          findsOneWidget,
+        );
+      },
+    );
 
     testWidgets(
       'AC: NavalFleetsUpdatedEvent is emitted when fleet split completes',
@@ -892,44 +907,104 @@ void main() {
       },
     );
 
-    testWidgets('AC: Combine mode shows Cancel button', (
-      WidgetTester tester,
-    ) async {
-      final humanId = humanPlayerIdWithFleets;
+    testWidgets(
+      'AC: Header checkbox selects all fleets then second interaction clears',
+      (WidgetTester tester) async {
+        const humanId = 'gp_select_all';
+        const capProvince = 'oldWorld|cap1';
+        const mergePort = 'oldWorld|mergeport';
 
-      final playerFleets = game.worldState.fleets
-          .where(
-            (f) =>
-                f.ownerId == humanId &&
-                f.shipTypeIds.isNotEmpty &&
-                f.id != 'home_fleet',
-          )
-          .toList();
-      if (playerFleets.isEmpty) return;
+        final selectAllGame = Game(
+          id: 'g_select_all',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: [
+                Province(
+                  id: 'cap1',
+                  regionId: 'oldWorld',
+                  ownerId: humanId,
+                  displayName: 'Capital',
+                ),
+                Province(
+                  id: 'mergeport',
+                  regionId: 'oldWorld',
+                  ownerId: humanId,
+                  displayName: 'Merge Port',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'a',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                inPortAtProvinceId: mergePort,
+                ships: const [ShipInstance(id: 'ship_1', typeId: 'carrack')],
+              ),
+              Fleet(
+                id: 'b',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                inPortAtProvinceId: mergePort,
+                ships: const [ShipInstance(id: 'ship_2', typeId: 'fluyte')],
+              ),
+            ],
+            tileKeysByRegionAndProvince: {
+              'oldWorld': {
+                capProvince: ['oldWorld|cap1|0|0'],
+              },
+            },
+            nextShipInstanceSeq: 3,
+          ),
+          players: [
+            Player(
+              id: humanId,
+              displayName: 'Select-all tester',
+              isHuman: true,
+              capitalProvinceId: capProvince,
+              capitalTile: const CapitalTile(
+                regionId: 'oldWorld',
+                provinceId: capProvince,
+                x: 0,
+                y: 0,
+              ),
+            ),
+          ],
+        );
 
-      final baseFleet = playerFleets.first;
+        await tester.pumpWidget(
+          buildPanel(game: selectAllGame, humanPlayerId: humanId),
+        );
+        await tester.pumpAndSettle();
 
-      await tester.pumpWidget(buildPanel(game: game, humanPlayerId: humanId));
-      await tester.pumpAndSettle();
+        final headerCheckboxFinder = find.descendant(
+          of: find.byType(NavalUnitsPanel),
+          matching: find.byWidgetPredicate(
+            (w) => w is Checkbox && w.tristate == true,
+          ),
+        );
+        expect(headerCheckboxFinder, findsOneWidget);
 
-      final fleetFinder = find.widgetWithText(
-        ExpansionTile,
-        'Fleet ${baseFleet.id}',
-      );
-      if (fleetFinder.evaluate().isEmpty) return;
+        await tester.tap(headerCheckboxFinder);
+        await tester.pumpAndSettle();
 
-      await tester.ensureVisible(fleetFinder);
-      await tester.tap(fleetFinder);
-      await tester.pumpAndSettle();
+        final checkboxes = find.byType(Checkbox);
+        final cbCount = checkboxes.evaluate().length;
+        expect(cbCount, greaterThanOrEqualTo(2));
+        for (var i = 0; i < cbCount; i++) {
+          expect(tester.widget<Checkbox>(checkboxes.at(i)).value, isTrue);
+        }
 
-      final combineButton = find.text('Combine');
-      if (combineButton.evaluate().isEmpty) return;
+        await tester.tap(headerCheckboxFinder);
+        await tester.pumpAndSettle();
 
-      await tester.tap(combineButton);
-      await tester.pumpAndSettle();
-
-      expect(find.text('Cancel'), findsOneWidget);
-    });
+        for (var i = 0; i < cbCount; i++) {
+          expect(tester.widget<Checkbox>(checkboxes.at(i)).value, isFalse);
+        }
+      },
+    );
 
     testWidgets('AC: Combining fleets creates correct ship counts', (
       WidgetTester tester,
@@ -965,18 +1040,14 @@ void main() {
               ownerId: humanId,
               regionId: 'oldWorld',
               inPortAtProvinceId: mergePort,
-              ships: const [
-                ShipInstance(id: 'ship_1', typeId: 'carrack'),
-              ],
+              ships: const [ShipInstance(id: 'ship_1', typeId: 'carrack')],
             ),
             Fleet(
               id: 'test_fleet_2',
               ownerId: humanId,
               regionId: 'oldWorld',
               inPortAtProvinceId: mergePort,
-              ships: const [
-                ShipInstance(id: 'ship_2', typeId: 'fluyte'),
-              ],
+              ships: const [ShipInstance(id: 'ship_2', typeId: 'fluyte')],
             ),
           ],
           // Capital only: merge-port fleets intentionally have no tile key so the
@@ -1023,60 +1094,30 @@ void main() {
       );
       expect(fleet1Finder, findsOneWidget);
 
-      await tester.ensureVisible(fleet1Finder);
-      final fleet1Title = find.descendant(
-        of: fleet1Finder,
-        matching: find.text('Fleet test_fleet_1'),
-      );
-      expect(fleet1Title, findsOneWidget);
-      final fleet1HeaderListTile = find.ancestor(
-        of: fleet1Title,
-        matching: find.byType(ListTile),
-      );
-      await tester.ensureVisible(fleet1HeaderListTile);
-      await tester.tap(fleet1HeaderListTile);
-      await tester.pumpAndSettle();
-
-      final splitInFleet1 = find.descendant(
-        of: fleet1Finder,
-        matching: find.text('Split'),
-      );
-      expect(splitInFleet1, findsOneWidget);
-
-      final combineInFleet1 = find.descendant(
-        of: fleet1Finder,
-        matching: find.text('Combine'),
-      );
-      await tester.scrollUntilVisible(combineInFleet1, 80);
-      await tester.pumpAndSettle();
-      await tester.ensureVisible(combineInFleet1);
-      await tester.tap(combineInFleet1);
-      await tester.pumpAndSettle();
-
-      expect(find.text('TARGET'), findsOneWidget);
-
       final fleet2Finder = find.widgetWithText(
         ExpansionTile,
         'Fleet test_fleet_2',
       );
       expect(fleet2Finder, findsOneWidget);
-      await tester.ensureVisible(fleet2Finder);
 
-      final checkboxInFleet2 = find.descendant(
+      final cb1 = find.descendant(
+        of: fleet1Finder,
+        matching: find.byType(Checkbox),
+      );
+      final cb2 = find.descendant(
         of: fleet2Finder,
         matching: find.byType(Checkbox),
       );
-      expect(checkboxInFleet2, findsOneWidget);
-      await tester.ensureVisible(checkboxInFleet2);
-      await tester.tap(checkboxInFleet2);
+      await tester.ensureVisible(cb1);
+      await tester.tap(cb1);
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(cb2);
+      await tester.tap(cb2);
       await tester.pumpAndSettle();
 
-      final confirmInFleet1 = find.descendant(
-        of: fleet1Finder,
-        matching: find.text('Confirm'),
-      );
-      await tester.ensureVisible(confirmInFleet1);
-      await tester.tap(confirmInFleet1);
+      final combineFinder = find.widgetWithText(CtNinePatchButton, 'Combine');
+      await tester.ensureVisible(combineFinder);
+      await tester.tap(combineFinder);
       await tester.pumpAndSettle();
 
       expect(updated, isNotNull);
@@ -1087,55 +1128,533 @@ void main() {
       expect(fleetsAfter.any((f) => f.id == 'test_fleet_2'), isFalse);
     });
 
-    testWidgets('AC: Fleets at different locations cannot be combined', (
-      WidgetTester tester,
-    ) async {
-      final humanId = humanPlayerIdWithFleets;
+    testWidgets(
+      'AC: Fleets at different locations keep Combine disabled when both checked',
+      (WidgetTester tester) async {
+        const humanId = 'gp_diff_loc';
+        const capProvince = 'oldWorld|cap1';
+        const portA = 'oldWorld|port_a';
+        const portB = 'oldWorld|port_b';
 
-      final playerFleets = game.worldState.fleets
-          .where(
-            (f) =>
-                f.ownerId == humanId &&
-                f.shipTypeIds.isNotEmpty &&
-                f.id != 'home_fleet',
-          )
-          .toList();
-      if (playerFleets.length < 2) return;
+        final diffLocGame = Game(
+          id: 'g_diff_loc',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: [
+                Province(
+                  id: 'cap1',
+                  regionId: 'oldWorld',
+                  ownerId: humanId,
+                  displayName: 'Capital',
+                ),
+                Province(
+                  id: 'port_a',
+                  regionId: 'oldWorld',
+                  ownerId: humanId,
+                  displayName: 'Port A',
+                ),
+                Province(
+                  id: 'port_b',
+                  regionId: 'oldWorld',
+                  ownerId: humanId,
+                  displayName: 'Port B',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'fa',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                inPortAtProvinceId: portA,
+                ships: const [ShipInstance(id: 'ship_1', typeId: 'carrack')],
+              ),
+              Fleet(
+                id: 'fb',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                inPortAtProvinceId: portB,
+                ships: const [ShipInstance(id: 'ship_2', typeId: 'fluyte')],
+              ),
+            ],
+            tileKeysByRegionAndProvince: {
+              'oldWorld': {
+                capProvince: ['oldWorld|cap1|0|0'],
+              },
+            },
+            nextShipInstanceSeq: 3,
+          ),
+          players: [
+            Player(
+              id: humanId,
+              displayName: 'Diff-loc tester',
+              isHuman: true,
+              capitalProvinceId: capProvince,
+              capitalTile: const CapitalTile(
+                regionId: 'oldWorld',
+                provinceId: capProvince,
+                x: 0,
+                y: 0,
+              ),
+            ),
+          ],
+        );
 
-      final fleet1 = playerFleets.first;
-      final fleet2 = playerFleets[1];
+        await tester.pumpWidget(
+          buildPanel(game: diffLocGame, humanPlayerId: humanId),
+        );
+        await tester.pumpAndSettle();
 
-      if (fleet1.inPortAtProvinceId == null ||
-          fleet2.inPortAtProvinceId == null)
-        return;
-      if (fleet1.inPortAtProvinceId == fleet2.inPortAtProvinceId) return;
+        final fleetAFinder = find.widgetWithText(ExpansionTile, 'Fleet fa');
+        final fleetBFinder = find.widgetWithText(ExpansionTile, 'Fleet fb');
+        expect(fleetAFinder, findsOneWidget);
+        expect(fleetBFinder, findsOneWidget);
 
-      await tester.pumpWidget(buildPanel(game: game, humanPlayerId: humanId));
-      await tester.pumpAndSettle();
+        await tester.tap(
+          find.descendant(of: fleetAFinder, matching: find.byType(Checkbox)),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.descendant(of: fleetBFinder, matching: find.byType(Checkbox)),
+        );
+        await tester.pumpAndSettle();
 
-      final fleet1Finder = find.widgetWithText(
-        ExpansionTile,
-        'Fleet ${fleet1.id}',
-      );
-      if (fleet1Finder.evaluate().isEmpty) return;
+        final combineBtn = tester.widget<CtNinePatchButton>(
+          find.widgetWithText(CtNinePatchButton, 'Combine'),
+        );
+        expect(combineBtn.enabled, isFalse);
+      },
+    );
 
-      await tester.ensureVisible(fleet1Finder);
-      await tester.tap(fleet1Finder);
-      await tester.pumpAndSettle();
+    testWidgets(
+      'AC: Combining into Home Fleet merges ships into home id when Home is selected',
+      (WidgetTester tester) async {
+        const humanId = 'gp_home_combine';
+        const capProvince = 'oldWorld|cap1';
+        final homeId = homeFleetIdFor(humanId);
 
-      final combineButton = find.text('Combine');
-      if (combineButton.evaluate().isEmpty) return;
+        final homeCombineGame = Game(
+          id: 'g_home_combine',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: [
+                Province(
+                  id: 'cap1',
+                  regionId: 'oldWorld',
+                  ownerId: humanId,
+                  displayName: 'Capital',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: homeId,
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                inPortAtProvinceId: capProvince,
+                ships: const [ShipInstance(id: 'ship_h', typeId: 'carrack')],
+                mission: FleetMission.patrol,
+              ),
+              Fleet(
+                id: 'at_capital',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                inPortAtProvinceId: capProvince,
+                ships: const [ShipInstance(id: 'ship_v', typeId: 'fluyte')],
+              ),
+            ],
+            tileKeysByRegionAndProvince: {
+              'oldWorld': {
+                capProvince: ['oldWorld|cap1|0|0'],
+              },
+            },
+            nextShipInstanceSeq: 3,
+          ),
+          players: [
+            Player(
+              id: humanId,
+              displayName: 'Home combine tester',
+              isHuman: true,
+              capitalProvinceId: capProvince,
+              capitalTile: const CapitalTile(
+                regionId: 'oldWorld',
+                provinceId: capProvince,
+                x: 0,
+                y: 0,
+              ),
+            ),
+          ],
+        );
 
-      await tester.tap(combineButton);
-      await tester.pumpAndSettle();
+        final bus = AppEventBus.create();
+        NavalFleetsUpdatedEvent? updated;
+        final sub = bus.on<NavalFleetsUpdatedEvent>().listen((e) {
+          updated = e;
+        });
+        addTearDown(sub.cancel);
 
-      final fleet2Finder = find.widgetWithText(
-        ExpansionTile,
-        'Fleet ${fleet2.id}',
-      );
+        await tester.pumpWidget(
+          buildPanel(game: homeCombineGame, humanPlayerId: humanId, bus: bus),
+        );
+        await tester.pumpAndSettle();
 
-      expect(find.byType(Checkbox), findsNothing);
-    });
+        final homeFinder = find.widgetWithText(ExpansionTile, 'Home Fleet');
+        final otherFinder = find.widgetWithText(
+          ExpansionTile,
+          'Fleet at_capital',
+        );
+        expect(homeFinder, findsOneWidget);
+        expect(otherFinder, findsOneWidget);
+
+        await tester.tap(
+          find.descendant(of: homeFinder, matching: find.byType(Checkbox)),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.descendant(of: otherFinder, matching: find.byType(Checkbox)),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.widgetWithText(CtNinePatchButton, 'Combine'));
+        await tester.pumpAndSettle();
+
+        expect(updated, isNotNull);
+        final fleetsAfter = updated!.game.worldState.fleets;
+        expect(fleetsAfter.where((f) => f.id == 'at_capital'), isEmpty);
+
+        final home = fleetsAfter.firstWhere((f) => f.id == homeId);
+        final shipIds = home.ships.map((s) => s.id).toList()..sort();
+        expect(shipIds, ['ship_h', 'ship_v']);
+        expect(home.mission, FleetMission.none);
+      },
+    );
+
+    testWidgets(
+      'AC: Combining three fleets at same port merges all ships into first in panel order',
+      (WidgetTester tester) async {
+        const humanId = 'gp_three_combine';
+        const capProvince = 'oldWorld|cap1';
+        const mergePort = 'oldWorld|mergeport';
+
+        final threeGame = Game(
+          id: 'g_three_combine',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: [
+                Province(
+                  id: 'cap1',
+                  regionId: 'oldWorld',
+                  ownerId: humanId,
+                  displayName: 'Capital',
+                ),
+                Province(
+                  id: 'mergeport',
+                  regionId: 'oldWorld',
+                  ownerId: humanId,
+                  displayName: 'Merge Port',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'c1',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                inPortAtProvinceId: mergePort,
+                ships: const [ShipInstance(id: 's1', typeId: 'carrack')],
+              ),
+              Fleet(
+                id: 'c2',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                inPortAtProvinceId: mergePort,
+                ships: const [ShipInstance(id: 's2', typeId: 'fluyte')],
+              ),
+              Fleet(
+                id: 'c3',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                inPortAtProvinceId: mergePort,
+                ships: const [ShipInstance(id: 's3', typeId: 'carrack')],
+              ),
+            ],
+            tileKeysByRegionAndProvince: {
+              'oldWorld': {
+                capProvince: ['oldWorld|cap1|0|0'],
+              },
+            },
+            nextShipInstanceSeq: 4,
+          ),
+          players: [
+            Player(
+              id: humanId,
+              displayName: 'Three combine tester',
+              isHuman: true,
+              capitalProvinceId: capProvince,
+              capitalTile: const CapitalTile(
+                regionId: 'oldWorld',
+                provinceId: capProvince,
+                x: 0,
+                y: 0,
+              ),
+            ),
+          ],
+        );
+
+        final bus = AppEventBus.create();
+        NavalFleetsUpdatedEvent? updated;
+        final sub = bus.on<NavalFleetsUpdatedEvent>().listen((e) {
+          updated = e;
+        });
+        addTearDown(sub.cancel);
+
+        await tester.pumpWidget(
+          buildPanel(game: threeGame, humanPlayerId: humanId, bus: bus),
+        );
+        await tester.pumpAndSettle();
+
+        for (final label in ['Fleet c1', 'Fleet c2', 'Fleet c3']) {
+          final tile = find.widgetWithText(ExpansionTile, label);
+          expect(tile, findsOneWidget);
+          final cb = find.descendant(
+            of: tile,
+            matching: find.byType(Checkbox),
+          );
+          await tester.scrollUntilVisible(cb, 120);
+          await tester.pumpAndSettle();
+          await tester.ensureVisible(cb);
+          await tester.tap(cb);
+          await tester.pumpAndSettle();
+        }
+
+        final combineBtnFinder = find.widgetWithText(
+          CtNinePatchButton,
+          'Combine',
+        );
+        await tester.scrollUntilVisible(combineBtnFinder, 120);
+        await tester.pumpAndSettle();
+        await tester.tap(combineBtnFinder);
+        await tester.pumpAndSettle();
+
+        expect(updated, isNotNull);
+        final fleetsAfter = updated!.game.worldState.fleets;
+        expect(fleetsAfter.length, 1);
+        final survivor = fleetsAfter.single;
+        expect(survivor.id, 'c1');
+        final ids = survivor.ships.map((s) => s.id).toList();
+        expect(ids, ['s1', 's2', 's3']);
+        expect(survivor.mission, FleetMission.none);
+      },
+    );
+
+    testWidgets(
+      'AC: Fleets in different sea zones keep Combine disabled when both checked',
+      (WidgetTester tester) async {
+        const humanId = 'gp_two_seas';
+        const capProvince = 'oldWorld|cap1';
+
+        final twoSeaGame = Game(
+          id: 'g_two_seas',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: [
+                Province(
+                  id: 'coast',
+                  regionId: 'oldWorld',
+                  ownerId: humanId,
+                  displayName: 'Coast',
+                ),
+                Province(
+                  id: 'cap1',
+                  regionId: 'oldWorld',
+                  ownerId: humanId,
+                  displayName: 'Capital',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'sea_a',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                seaZoneId: 'zone_alpha',
+                inPortAtProvinceId: null,
+                ships: const [ShipInstance(id: 'a1', typeId: 'carrack')],
+              ),
+              Fleet(
+                id: 'sea_b',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                seaZoneId: 'zone_beta',
+                inPortAtProvinceId: null,
+                ships: const [ShipInstance(id: 'b1', typeId: 'fluyte')],
+              ),
+            ],
+            portsByProvinceSeaboard: {
+              'oldWorld|coast|zone_alpha': 'oldWorld|coast|0|0',
+              'oldWorld|coast|zone_beta': 'oldWorld|coast|1|0',
+            },
+            tileKeysByRegionAndProvince: {
+              'oldWorld': {
+                capProvince: ['oldWorld|cap1|0|0'],
+                'oldWorld|coast': ['oldWorld|coast|0|0'],
+              },
+            },
+            nextShipInstanceSeq: 2,
+          ),
+          players: [
+            Player(
+              id: humanId,
+              displayName: 'Two seas tester',
+              isHuman: true,
+              capitalProvinceId: capProvince,
+              capitalTile: const CapitalTile(
+                regionId: 'oldWorld',
+                provinceId: capProvince,
+                x: 0,
+                y: 0,
+              ),
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(
+          buildPanel(game: twoSeaGame, humanPlayerId: humanId),
+        );
+        await tester.pumpAndSettle();
+
+        final finderA = find.widgetWithText(ExpansionTile, 'Fleet sea_a');
+        final finderB = find.widgetWithText(ExpansionTile, 'Fleet sea_b');
+        expect(finderA, findsOneWidget);
+        expect(finderB, findsOneWidget);
+
+        await tester.tap(
+          find.descendant(of: finderA, matching: find.byType(Checkbox)),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.descendant(of: finderB, matching: find.byType(Checkbox)),
+        );
+        await tester.pumpAndSettle();
+
+        final combineBtn = tester.widget<CtNinePatchButton>(
+          find.widgetWithText(CtNinePatchButton, 'Combine'),
+        );
+        expect(combineBtn.enabled, isFalse);
+      },
+    );
+
+    testWidgets(
+      'AC: Fleet at sea and fleet in port keep Combine disabled when both checked',
+      (WidgetTester tester) async {
+        const humanId = 'gp_sea_port';
+        const capProvince = 'oldWorld|cap1';
+        const mergePort = 'oldWorld|mergeport';
+
+        final seaPortGame = Game(
+          id: 'g_sea_port',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: [
+                Province(
+                  id: 'cap1',
+                  regionId: 'oldWorld',
+                  ownerId: humanId,
+                  displayName: 'Capital',
+                ),
+                Province(
+                  id: 'mergeport',
+                  regionId: 'oldWorld',
+                  ownerId: humanId,
+                  displayName: 'Merge Port',
+                ),
+                Province(
+                  id: 'coast',
+                  regionId: 'oldWorld',
+                  ownerId: humanId,
+                  displayName: 'Coast',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'at_sea',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                seaZoneId: 'zone_alpha',
+                inPortAtProvinceId: null,
+                ships: const [ShipInstance(id: 's_sea', typeId: 'carrack')],
+              ),
+              Fleet(
+                id: 'in_port',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                inPortAtProvinceId: mergePort,
+                ships: const [ShipInstance(id: 's_port', typeId: 'fluyte')],
+              ),
+            ],
+            portsByProvinceSeaboard: {
+              'oldWorld|coast|zone_alpha': 'oldWorld|coast|0|0',
+            },
+            tileKeysByRegionAndProvince: {
+              'oldWorld': {
+                capProvince: ['oldWorld|cap1|0|0'],
+                'oldWorld|coast': ['oldWorld|coast|0|0'],
+              },
+            },
+            nextShipInstanceSeq: 3,
+          ),
+          players: [
+            Player(
+              id: humanId,
+              displayName: 'Sea-port tester',
+              isHuman: true,
+              capitalProvinceId: capProvince,
+              capitalTile: const CapitalTile(
+                regionId: 'oldWorld',
+                provinceId: capProvince,
+                x: 0,
+                y: 0,
+              ),
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(
+          buildPanel(game: seaPortGame, humanPlayerId: humanId),
+        );
+        await tester.pumpAndSettle();
+
+        final seaFinder = find.widgetWithText(ExpansionTile, 'Fleet at_sea');
+        final portFinder = find.widgetWithText(ExpansionTile, 'Fleet in_port');
+        expect(seaFinder, findsOneWidget);
+        expect(portFinder, findsOneWidget);
+
+        await tester.tap(
+          find.descendant(of: seaFinder, matching: find.byType(Checkbox)),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.descendant(of: portFinder, matching: find.byType(Checkbox)),
+        );
+        await tester.pumpAndSettle();
+
+        final combineBtn = tester.widget<CtNinePatchButton>(
+          find.widgetWithText(CtNinePatchButton, 'Combine'),
+        );
+        expect(combineBtn.enabled, isFalse);
+      },
+    );
 
     testWidgets('AC: Beachhead mission appears in status line', (
       WidgetTester tester,


### PR DESCRIPTION
## Summary
Implements the combine UX from [#1390](https://github.com/waigore/colonizethisv3/issues/1390): header **Combine** and tristate **select/deselect all**, always-visible per-fleet checkboxes, and merge rules (same port or same sea zone only; Home Fleet as target when selected; first in panel order otherwise; survivor mission `none`).

## Changes
- `app/lib/features/game/widgets/naval_units_panel.dart` — new selection and combine flow; split dialog resolves home fleet id via `homeFleetIdFor`.
- `SPEC/ui/naval-units-fleet-management.md`, `SPEC/ui/naval-units-panel.md` — spec and AC updates.
- `app/test/naval_units_panel_test.dart` — coverage for home merge, three fleets, different sea zones, sea vs port, select-all, and prior cases.

## Testing
`flutter test app/test/naval_units_panel_test.dart`

Closes #1390

Made with [Cursor](https://cursor.com)