### PR TITLE
fix(logging): session prefix bucketing, generate_map mapLogger, evidence bodies

### DIFF
--- a/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+++ b/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
@@ -79,7 +79,7 @@ List<DossierEvidenceEntry> evidenceForDeclareWar(
   }
   if (entries.isNotEmpty) {
     _log.d(
-      'data: evidence for declareWar actor=$actorGpId target=$targetFactionId entries=${entries.length}',
+      'evidence for declareWar actor=$actorGpId target=$targetFactionId entries=${entries.length}',
     );
   }
   return entries;
@@ -110,7 +110,7 @@ List<DossierEvidenceEntry> evidenceForOfferPeace(
     );
   }
   _log.d(
-    'data: evidence for offerPeace actor=$actorGpId target=$targetFactionId entries=${entries.length}',
+    'evidence for offerPeace actor=$actorGpId target=$targetFactionId entries=${entries.length}',
   );
   return entries;
 }
@@ -148,7 +148,7 @@ List<DossierEvidenceEntry> evidenceForLandBattleVictory(
   }
   if (entries.isNotEmpty) {
     _log.d(
-      'data: evidence for land battle victory victor=$victorGpId defender=$defenderFactionId entries=${entries.length}',
+      'evidence for land battle victory victor=$victorGpId defender=$defenderFactionId entries=${entries.length}',
     );
   }
   return entries;
@@ -180,7 +180,7 @@ List<DossierEvidenceEntry> evidenceForNavalBattleVictory(
   }
   if (entries.isNotEmpty) {
     _log.d(
-      'data: evidence for naval battle victory victor=$victorOwnerId loser=$loserOwnerId entries=${entries.length}',
+      'evidence for naval battle victory victor=$victorOwnerId loser=$loserOwnerId entries=${entries.length}',
     );
   }
   return entries;

--- a/packages/session_log_buffer/lib/session_log_buffer.dart
+++ b/packages/session_log_buffer/lib/session_log_buffer.dart
@@ -43,12 +43,24 @@ class SessionLogEntry {
   final Object? error;
   final StackTrace? stackTrace;
 
-  /// Prefix derived from message (e.g. "logic: foo" -> "logic"). Empty if no colon prefix.
+  /// Filter bucket for [getFiltered] and viewer presets ([knownPrefixes]).
+  ///
+  /// Plain tags: `"logic: foo"` → `logic`. Dotted factory tags such as
+  /// `"ctdev.running_game: foo"` map to the first segment when it is listed in
+  /// [knownPrefixes] (here `ctdev`); otherwise the full tag before `:` is used.
   String get prefix {
     final msg = message;
     final colon = msg.indexOf(':');
     if (colon <= 0) return '';
-    return msg.substring(0, colon).trim().toLowerCase();
+    final full = msg.substring(0, colon).trim().toLowerCase();
+    final dot = full.indexOf('.');
+    if (dot > 0) {
+      final head = full.substring(0, dot);
+      if (knownPrefixes.contains(head)) {
+        return head;
+      }
+    }
+    return full;
   }
 
   /// Formatted main line: timestamp level message.

--- a/packages/session_log_buffer/test/session_log_buffer_test.dart
+++ b/packages/session_log_buffer/test/session_log_buffer_test.dart
@@ -48,6 +48,17 @@ void main() {
       expect(filtered, isEmpty);
     });
 
+    test('dotted logger tag buckets under known top-level prefix for filters', () {
+      final buffer = SessionLogBuffer.instance;
+      buffer.add(LogEvent(Level.info, 'ctdev.running_game: started'));
+      expect(buffer.entries.first.prefix, 'ctdev');
+      final filtered = buffer.getFiltered(
+        selectedPrefixes: {'ctdev'},
+        selectedLevels: {Level.info},
+      );
+      expect(filtered.length, 1);
+    });
+
     test('getFiltered with non-matching level returns empty', () {
       final buffer = SessionLogBuffer.instance;
       buffer.add(LogEvent(Level.debug, 'logic: test'));

--- a/tool/generate_map/bin/generate_map.dart
+++ b/tool/generate_map/bin/generate_map.dart
@@ -6,15 +6,15 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
-final _log = Logger();
+final _log = mapLogger();
 
 void _errExit(String message) {
   stderr.writeln(message);
-  _log.w('map: $message');
+  _log.w(message);
   exit(1);
 }
 
@@ -286,8 +286,10 @@ MapGenerationResult runMapGeneration(ParsedMapArgs args) {
     continentBufferTiles: mapGenParams.continentBufferTiles,
   );
 
-  _log.i('map: === Map generation ===');
-  _log.i('map: Generating map: ${args.numProvinces} provinces, ${args.numContinents} continents, region ${args.regionId} (seed: ${args.seedUsed})');
+  _log.i('=== Map generation ===');
+  _log.i(
+    'Generating map: ${args.numProvinces} provinces, ${args.numContinents} continents, region ${args.regionId} (seed: ${args.seedUsed})',
+  );
   stdout.writeln('Generating map: ${args.numProvinces} provinces, ${args.numContinents} continents, region ${args.regionId} (seed: ${args.seedUsed})');
   List<(int x, int y)>? landSeeds;
   List<int>? landSeedContinentIndices;
@@ -297,7 +299,7 @@ MapGenerationResult runMapGeneration(ParsedMapArgs args) {
     numContinents: args.numContinents,
     regionId: args.regionId,
     resourceRules: ResourceRules.defaultRules,
-    onLog: (msg) => _log.i('map: $msg'),
+    onLog: _log.i,
     onLandSeedsPlaced: (s, indices) {
       landSeeds = List.from(s);
       landSeedContinentIndices = List.from(indices);
@@ -307,7 +309,7 @@ MapGenerationResult runMapGeneration(ParsedMapArgs args) {
 
   final tileCounts = computeTileCountsPerRegion(tileMapResult);
   final centroids = computeCentroidsPerRegion(tileMapResult);
-  _log.i('map: Tile map seed: ${args.seedUsed}');
+  _log.i('Tile map seed: ${args.seedUsed}');
 
   if (args.withTileMapImage) {
     final cellSize = args.tileSize;
@@ -335,10 +337,10 @@ MapGenerationResult runMapGeneration(ParsedMapArgs args) {
       );
     }
     final opened = openInDefaultViewer(imagePath);
-    _log.i('map: Tile map image: $imagePath');
+    _log.i('Tile map image: $imagePath');
     stdout.writeln('Tile map image: $imagePath');
     if (!opened) {
-      _log.w('map: Could not open in viewer. Saved to: $imagePath');
+      _log.w('Could not open in viewer. Saved to: $imagePath');
     }
   }
 
@@ -361,7 +363,7 @@ MapGenerationResult runMapGeneration(ParsedMapArgs args) {
     );
     final dotFile = dotPath ?? _tempDotPath();
     File(dotFile).writeAsStringSync(dotContent);
-    _log.i('map: Topology graph (DOT): $dotFile');
+    _log.i('Topology graph (DOT): $dotFile');
     stdout.writeln('Topology graph (DOT): $dotFile');
 
     try {
@@ -369,9 +371,9 @@ MapGenerationResult runMapGeneration(ParsedMapArgs args) {
       final proc = Process.runSync('neato', ['-n', '-Tpng', '-o', pngPath, dotFile]);
       if (proc.exitCode == 0) {
         final opened = openInDefaultViewer(pngPath);
-        _log.i('map: Topology graph (PNG): $pngPath');
+        _log.i('Topology graph (PNG): $pngPath');
         if (!opened) {
-          _log.w('map: Could not open topology graph in viewer. Saved to: $pngPath');
+          _log.w('Could not open topology graph in viewer. Saved to: $pngPath');
         }
       } else {
         _warnGraphviz();
@@ -428,7 +430,7 @@ String _tempDotPath() {
 void _warnGraphviz() {
   const msg = 'Warning: Graphviz not installed; run `brew install graphviz` to render topology graph to PNG.';
   stderr.writeln(msg);
-  _log.w('map: $msg');
+  _log.w(msg);
 }
 
 void _printUsage() {

--- a/tool/generate_map/pubspec.yaml
+++ b/tool/generate_map/pubspec.yaml
@@ -9,9 +9,9 @@ environment:
 
 dependencies:
   colonizethis_data:
+  colonizethis_logger:
   colonizethis_map:
   colonizethis_models:
-  logger: ^2.0.2
 
 dev_dependencies:
   colonizethis_test:


### PR DESCRIPTION
## Summary
High-impact follow-ups for [#1382](https://github.com/waigore/colonizethisv3/issues/1382) (logging alignment).

### Session log / debug viewer
- `SessionLogEntry.prefix` now buckets dotted factory tags (e.g. `ctdev.running_game:`) under the first segment when it appears in `knownPrefixes`, so package filters in the app/ctterm viewers match real `CtLogger` output.

### Evidence rules
- Removed the redundant `data:` prefix from debug message bodies; `logicLogger()` already supplies the domain prefix.

### generate_map CLI
- Switched from raw `Logger()` + manual `map:` strings to `mapLogger()` per `SPEC/program/logging/map-generation.md`.
- `onLog` forwards directly to `_log.i` (generator lines are plain text; `map:` is added once by the factory).

## Tests
- `dart test` in `packages/session_log_buffer`
- `dart test` in `packages/colonizethis_logic` (full suite)
- `dart test` in `tool/generate_map`
- `flutter test test/debug_log_viewer_test.dart` in `app`


Made with [Cursor](https://cursor.com)