### PR TITLE
fix(logging): map pass logs, ctterm zone guard, tool loggers (#1382)

### DIFF
--- a/app/lib/core/services/game_service.dart
+++ b/app/lib/core/services/game_service.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -18,6 +19,9 @@ class _GameMapCache {
   final Map<String, MapTopology> topologyByRegion;
   final List<WarpLink>? warpLinks;
 }
+
+/// Pass milestones for in-app tile map generation (SPEC/program/logging/map-generation.md).
+final _mapGenPassLog = mapLogger('tile_map');
 
 /// Loads/saves games and advances turn. SPEC/project/phase-1: app invokes TurnResolver and persists via colonizethis_save.
 /// Phase 2: createNewGame uses full game-setup pipeline; nextTurn uses cached map data when available.
@@ -404,6 +408,7 @@ class GameService {
       numContinents: cfg.continentCount,
       regionId: 'oldWorld',
       resourceRules: ResourceRules.defaultRules,
+      onLog: _mapGenPassLog.d,
     );
   }
 
@@ -428,6 +433,7 @@ class GameService {
       numContinents: cfg.continentCount.clamp(1, cfg.numProvincesNewWorld),
       regionId: 'newWorld',
       resourceRules: ResourceRules.defaultRules,
+      onLog: _mapGenPassLog.d,
     );
   }
 

--- a/ctterm/bin/ctterm.dart
+++ b/ctterm/bin/ctterm.dart
@@ -1,5 +1,7 @@
 // ctterm entrypoint. SPEC/tui/ctterm.md. Run with: dart run ctterm [--data-dir <path>]
 
+import 'dart:async';
+
 import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
@@ -38,8 +40,19 @@ void main(List<String> args) async {
     );
   }
 
-  runApp(CttermApp(
-    dataDirOverride: dataDirOverride,
-    initialLockDetected: initialLockDetected,
-  ));
+  runZonedGuarded(
+    () {
+      runApp(CttermApp(
+        dataDirOverride: dataDirOverride,
+        initialLockDetected: initialLockDetected,
+      ));
+    },
+    (Object error, StackTrace stackTrace) {
+      tuiLogger().e(
+        'uncaught async error',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    },
+  );
 }

--- a/packages/colonizethis_ai/lib/src/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/economy_planner.dart
@@ -8,9 +8,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'ai_config.dart';
 import 'seed_bundle.dart';
 
-final _log = aiLogger();
-
-const String _kEconomyLogPrefix = 'ai/economy_planner';
+final _log = aiLogger('economy_planner');
 
 /// Cargo preference for naval/build planners. SPEC/ai/economy-planner.md.
 enum CargoPreference { none, preferCargo, strongCargo }
@@ -52,7 +50,7 @@ EconomyPlan runEconomyPlanner({
 }) {
   final player = game.playerById(view.playerId);
   if (player == null) {
-    _log.w('$_kEconomyLogPrefix: no player for ${view.playerId}');
+    _log.w('no player for ${view.playerId}');
     return const EconomyPlan(
       productionAssignments: [],
       cargoPreference: CargoPreference.none,
@@ -88,7 +86,7 @@ EconomyPlan runEconomyPlanner({
 
   final cargoPref = _cargoPreference(game, view.playerId, config);
   _log.i(
-    '$_kEconomyLogPrefix: economy plan playerId=${view.playerId} '
+    'economy plan playerId=${view.playerId} '
     'cargoPreference=$cargoPref productionAssignmentsCount=${assignments.length}',
   );
   return EconomyPlan(
@@ -104,7 +102,7 @@ CargoPreference _cargoPreference(Game game, String playerId, AIConfig config) {
   final economyWeight = domainWeights.economy;
   if (economyWeight < 30) {
     _log.d(
-      '$_kEconomyLogPrefix: cargoPreference none economyWeight=$economyWeight',
+      'cargoPreference none economyWeight=$economyWeight',
     );
     return CargoPreference.none;
   }
@@ -120,7 +118,7 @@ CargoPreference _cargoPreference(Game game, String playerId, AIConfig config) {
       ? CargoPreference.preferCargo
       : CargoPreference.none;
   _log.d(
-    '$_kEconomyLogPrefix: cargoPreference eval playerId=$playerId '
+    'cargoPreference eval playerId=$playerId '
     'economyWeight=$economyWeight agendaId=$agendaId tradeBias=$tradeBias result=$pref',
   );
   return pref;
@@ -170,7 +168,7 @@ List<AssignedRecipe> _allocateLabour({
   if (candidates.isEmpty) return result;
 
   _log.d(
-    '$_kEconomyLogPrefix: recipe eval playerId=${config.leaderId} effectiveLabour=$effectiveLabour '
+    'recipe eval playerId=${config.leaderId} effectiveLabour=$effectiveLabour '
     'candidates=${candidates.map((c) => "${c.recipe.id}:${c.score.toStringAsFixed(2)}").toList()}',
   );
 
@@ -221,7 +219,7 @@ List<AssignedRecipe> _allocateLabour({
   }
 
   _log.d(
-    '$_kEconomyLogPrefix: allocation effectiveLabour=$effectiveLabour '
+    'allocation effectiveLabour=$effectiveLabour '
     'labourByRecipe=$labourByRecipe assignmentsCount=${result.length}',
   );
   return result;

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -17,9 +17,7 @@ import '../world/unit_lookup.dart';
 
 export 'order_suggestion_helpers.dart';
 
-final _log = logicLogger();
-
-const String _kOrderSuggestionLogPrefix = 'logic/order_suggestion';
+final _log = logicLogger('order_suggestion');
 
 /// Suggests candidate move orders that are information-legal (per [PlayerView])
 /// and rules-legal (per [OrderEngine]) for [view.playerId].
@@ -30,7 +28,7 @@ List<MoveOrder> suggestMoveOrders(
   Orders currentOrders,
 ) {
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestMoveOrders player=${view.playerId}',
+    'suggestMoveOrders player=${view.playerId}',
   );
   final playerId = view.playerId;
   final suggestions = <MoveOrder>[];
@@ -138,14 +136,14 @@ List<MoveOrder> suggestMoveOrders(
   });
 
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestMoveOrders player=$playerId candidates=${suggestions.length}',
+    'suggestMoveOrders player=$playerId candidates=${suggestions.length}',
   );
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestMoveOrders full list ${suggestions.map((m) => "${m.unitId}->${m.destinationProvinceId}").toList()}',
+    'suggestMoveOrders full list ${suggestions.map((m) => "${m.unitId}->${m.destinationProvinceId}").toList()}',
   );
   if (suggestions.isEmpty)
     _log.w(
-      '$_kOrderSuggestionLogPrefix: suggestMoveOrders no candidates player=$playerId',
+      'suggestMoveOrders no candidates player=$playerId',
     );
   return suggestions;
 }
@@ -165,7 +163,7 @@ List<WorkOrder> suggestWorkOrders(
   Map<String, TileMapResult>? tileMapByRegion,
 }) {
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestWorkOrders player=${view.playerId}',
+    'suggestWorkOrders player=${view.playerId}',
   );
   final playerId = view.playerId;
   final suggestions = <WorkOrder>[];
@@ -208,7 +206,7 @@ List<WorkOrder> suggestWorkOrders(
         tileKeysByRegion[regionId]?[provinceId] ?? const <String>[];
 
     _log.d(
-      '$_kOrderSuggestionLogPrefix: suggestWorkOrders unit=${unit.id} provinceId=$provinceId provinceName=${province?.displayName} ownerId=$ownerId regionId=$regionId tilesInProvince=${tilesInProvince.length}',
+      'suggestWorkOrders unit=${unit.id} provinceId=$provinceId provinceName=${province?.displayName} ownerId=$ownerId regionId=$regionId tilesInProvince=${tilesInProvince.length}',
     );
 
     // Explorers: explore/prospect in their current province only; visibility rules apply.
@@ -340,12 +338,12 @@ List<WorkOrder> suggestWorkOrders(
           }
           if (accepted != null) {
             _log.d(
-              '$_kOrderSuggestionLogPrefix: suggestWorkOrders candidate=$accepted',
+              'suggestWorkOrders candidate=$accepted',
             );
             suggestions.add(accepted);
           } else {
             _log.d(
-              '$_kOrderSuggestionLogPrefix: suggestWorkOrders rejected target=$target unit=${unit.id} (no valid tile)',
+              'suggestWorkOrders rejected target=$target unit=${unit.id} (no valid tile)',
             );
           }
         }
@@ -446,14 +444,14 @@ List<WorkOrder> suggestWorkOrders(
   });
 
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestWorkOrders player=$playerId candidates=${suggestions.length}',
+    'suggestWorkOrders player=$playerId candidates=${suggestions.length}',
   );
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestWorkOrders full list ${suggestions.map((o) => "${o.unitId}:${o.target}").toList()}',
+    'suggestWorkOrders full list ${suggestions.map((o) => "${o.unitId}:${o.target}").toList()}',
   );
   if (suggestions.isEmpty)
     _log.w(
-      '$_kOrderSuggestionLogPrefix: suggestWorkOrders no candidates player=$playerId',
+      'suggestWorkOrders no candidates player=$playerId',
     );
   return suggestions;
 }
@@ -466,7 +464,7 @@ List<BuildUnitOrder> suggestBuildOrders(
   Orders currentOrders,
 ) {
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestBuildOrders player=${view.playerId}',
+    'suggestBuildOrders player=${view.playerId}',
   );
   final playerId = view.playerId;
   final player = view.player;
@@ -475,7 +473,7 @@ List<BuildUnitOrder> suggestBuildOrders(
   final capitalId = player.capitalProvinceId;
   if (capitalId == null) {
     _log.w(
-      '$_kOrderSuggestionLogPrefix: suggestBuildOrders no capital player=$playerId',
+      'suggestBuildOrders no capital player=$playerId',
     );
     return suggestions;
   }
@@ -524,14 +522,14 @@ List<BuildUnitOrder> suggestBuildOrders(
   suggestions.sort((a, b) => a.unitType.compareTo(b.unitType));
 
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestBuildOrders player=$playerId candidates=${suggestions.length}',
+    'suggestBuildOrders player=$playerId candidates=${suggestions.length}',
   );
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestBuildOrders full list ${suggestions.map((o) => o.unitType).toList()}',
+    'suggestBuildOrders full list ${suggestions.map((o) => o.unitType).toList()}',
   );
   if (suggestions.isEmpty)
     _log.w(
-      '$_kOrderSuggestionLogPrefix: suggestBuildOrders no candidates player=$playerId',
+      'suggestBuildOrders no candidates player=$playerId',
     );
   return suggestions;
 }
@@ -546,7 +544,7 @@ List<ResearchOrder> suggestResearchOrders(
   Orders currentOrders,
 ) {
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestResearchOrders player=${view.playerId}',
+    'suggestResearchOrders player=${view.playerId}',
   );
   final playerId = view.playerId;
   final player = view.player;
@@ -597,10 +595,10 @@ List<ResearchOrder> suggestResearchOrders(
   }
 
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestResearchOrders player=$playerId candidates=${suggestions.length}',
+    'suggestResearchOrders player=$playerId candidates=${suggestions.length}',
   );
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestResearchOrders full list ${suggestions.map((o) => "slot${o.slotIndex}:${o.techId}").toList()}',
+    'suggestResearchOrders full list ${suggestions.map((o) => "slot${o.slotIndex}:${o.techId}").toList()}',
   );
   return suggestions;
 }
@@ -696,7 +694,7 @@ Set<String> getValidWorkOrderTileKeys(
     }
   }
   _log.d(
-    '$_kOrderSuggestionLogPrefix: getValidWorkOrderTileKeys unit=$unitId target=$workTarget count=${valid.length}',
+    'getValidWorkOrderTileKeys unit=$unitId target=$workTarget count=${valid.length}',
   );
   return valid;
 }
@@ -720,25 +718,25 @@ Set<String> getValidWorkOrderTileKeysWithVisibility({
   ).where((u) => u.id == unitId).firstOrNull;
   if (unit == null || unit.ownerId != view.playerId) {
     _log.d(
-      '$_kOrderSuggestionLogPrefix: getValidWorkOrderTileKeysWithVisibility unit not found or not owned by player',
+      'getValidWorkOrderTileKeysWithVisibility unit not found or not owned by player',
     );
     return {};
   }
   if (unit.currentWork != null) {
     _log.d(
-      '$_kOrderSuggestionLogPrefix: getValidWorkOrderTileKeysWithVisibility unit has current work',
+      'getValidWorkOrderTileKeysWithVisibility unit has current work',
     );
     return {};
   }
   if (!isWorkOrderTargetAllowedForUnitType(unit.type, workTarget)) {
     _log.d(
-      '$_kOrderSuggestionLogPrefix: getValidWorkOrderTileKeysWithVisibility target $workTarget not allowed for unit type ${unit.type}',
+      'getValidWorkOrderTileKeysWithVisibility target $workTarget not allowed for unit type ${unit.type}',
     );
     return {};
   }
 
   _log.d(
-    '$_kOrderSuggestionLogPrefix: getValidWorkOrderTileKeysWithVisibility unit=${unit.id} type=${unit.type} workTarget=$workTarget',
+    'getValidWorkOrderTileKeysWithVisibility unit=${unit.id} type=${unit.type} workTarget=$workTarget',
   );
 
   final playerId = view.playerId;
@@ -759,7 +757,7 @@ Set<String> getValidWorkOrderTileKeysWithVisibility({
   final sortedVisible = _sortedVisibleWorkTargetCandidates(view, raw);
 
   _log.d(
-    '$_kOrderSuggestionLogPrefix: getValidWorkOrderTileKeysWithVisibility visible sorted count=${sortedVisible.length}',
+    'getValidWorkOrderTileKeysWithVisibility visible sorted count=${sortedVisible.length}',
   );
 
   final valid = <String>{};
@@ -786,7 +784,7 @@ Set<String> getValidWorkOrderTileKeysWithVisibility({
   }
 
   _log.d(
-    '$_kOrderSuggestionLogPrefix: getValidWorkOrderTileKeysWithVisibility unit=$unitId target=$workTarget count=${valid.length} (filtered from ${sortedVisible.length} visible candidates)',
+    'getValidWorkOrderTileKeysWithVisibility unit=$unitId target=$workTarget count=${valid.length} (filtered from ${sortedVisible.length} visible candidates)',
   );
   return valid;
 }
@@ -1220,7 +1218,7 @@ List<NavalMoveOrder> suggestNavalMoveOrders(
   Orders currentOrders,
 ) {
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestNavalMoveOrders player=${view.playerId}',
+    'suggestNavalMoveOrders player=${view.playerId}',
   );
   final playerId = view.playerId;
   final suggestions = <NavalMoveOrder>[];
@@ -1323,10 +1321,10 @@ List<NavalMoveOrder> suggestNavalMoveOrders(
     return keyA.compareTo(keyB);
   });
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestNavalMoveOrders player=$playerId candidates=${suggestions.length}',
+    'suggestNavalMoveOrders player=$playerId candidates=${suggestions.length}',
   );
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestNavalMoveOrders full list ${suggestions.map((o) => "fleetId=${o.fleetId} destSea=${o.destinationSeaZoneId} destPort=${o.destinationPortProvinceId}").toList()}',
+    'suggestNavalMoveOrders full list ${suggestions.map((o) => "fleetId=${o.fleetId} destSea=${o.destinationSeaZoneId} destPort=${o.destinationPortProvinceId}").toList()}',
   );
   return suggestions;
 }
@@ -1339,7 +1337,7 @@ List<NavalMissionOrder> suggestNavalMissionOrders(
   Orders currentOrders,
 ) {
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestNavalMissionOrders player=${view.playerId}',
+    'suggestNavalMissionOrders player=${view.playerId}',
   );
   final playerId = view.playerId;
   final suggestions = <NavalMissionOrder>[];
@@ -1373,10 +1371,10 @@ List<NavalMissionOrder> suggestNavalMissionOrders(
     return a.mission.compareTo(b.mission);
   });
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestNavalMissionOrders player=$playerId candidates=${suggestions.length}',
+    'suggestNavalMissionOrders player=$playerId candidates=${suggestions.length}',
   );
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestNavalMissionOrders full list ${suggestions.map((o) => "fleetId=${o.fleetId} mission=${o.mission}").toList()}',
+    'suggestNavalMissionOrders full list ${suggestions.map((o) => "fleetId=${o.fleetId} mission=${o.mission}").toList()}',
   );
   return suggestions;
 }
@@ -1600,7 +1598,7 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
   Map<String, TileMapResult>? tileMapByRegion,
 }) {
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestDiplomaticOrders player=${view.playerId}',
+    'suggestDiplomaticOrders player=${view.playerId}',
   );
   final playerId = view.playerId;
   final suggestions = <DiplomaticOrder>[];
@@ -1734,10 +1732,10 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
     return (a.amount ?? 0).compareTo(b.amount ?? 0);
   });
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestDiplomaticOrders player=$playerId candidates=${suggestions.length}',
+    'suggestDiplomaticOrders player=$playerId candidates=${suggestions.length}',
   );
   _log.d(
-    '$_kOrderSuggestionLogPrefix: suggestDiplomaticOrders full list ${suggestions.map((o) => "${o.type.name}:${o.targetFactionId}").toList()}',
+    'suggestDiplomaticOrders full list ${suggestions.map((o) => "${o.type.name}:${o.targetFactionId}").toList()}',
   );
   return suggestions;
 }

--- a/tool/init_game/bin/init_game.dart
+++ b/tool/init_game/bin/init_game.dart
@@ -8,11 +8,11 @@ import 'dart:io';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:hive/hive.dart';
-import 'package:logger/logger.dart';
 
-final _log = Logger();
+final _log = logicLogger('init_game');
 
 Future<void> main(List<String> arguments) async {
   String? configPath;
@@ -245,31 +245,31 @@ Future<void> main(List<String> arguments) async {
   }
 
   try {
-    _log.i('logic: init_game start');
-    _log.i('logic: Running game setup...');
+    _log.i('start');
+    _log.i('Running game setup...');
     final shouldRenderPng = outputMapPath != null && outputMapPath.isNotEmpty;
     final result = runInitGame(
       config: config,
       options: InitGameOptions(cellSize: 24, renderPng: shouldRenderPng),
     );
-    _log.i('logic: Game created: ${result.game.id}');
+    _log.i('Game created: ${result.game.id}');
 
     if (outputMapPath != null && outputMapPath.isNotEmpty) {
       File(outputMapPath).writeAsBytesSync(result.mapPngBytes);
-      _log.d('logic: Map PNG: $outputMapPath');
+      _log.d('Map PNG: $outputMapPath');
     }
 
     if (outputMarkdownPath != null && outputMarkdownPath.isNotEmpty) {
       File(outputMarkdownPath).writeAsStringSync(result.markdown);
-      _log.d('logic: Markdown: $outputMarkdownPath');
+      _log.d('Markdown: $outputMarkdownPath');
     }
 
     if (!noSave && outputGamePath != null && outputGamePath.isNotEmpty) {
       await _saveGame(result.game, outputGamePath);
-      _log.d('logic: Game saved: $outputGamePath');
+      _log.d('Game saved: $outputGamePath');
     }
 
-    _log.i('logic: Faction setup:\n${result.markdown}');
+    _log.i('Faction setup:\n${result.markdown}');
   } catch (e) {
     final message = e is ArgumentError
         ? (e.message ?? e.toString())

--- a/tool/init_game/pubspec.yaml
+++ b/tool/init_game/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=3.11.0 <4.0.0'
 
 dependencies:
-  logger: ^2.0.2
+  colonizethis_logger:
   colonizethis_data:
   colonizethis_logic:
   colonizethis_models:

--- a/tool/sim_combat/bin/sim_combat.dart
+++ b/tool/sim_combat/bin/sim_combat.dart
@@ -5,10 +5,10 @@ import 'dart:io';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
-final _log = Logger();
+final _log = logicLogger('sim_combat');
 
 void main(List<String> arguments) {
   String? scriptPath;
@@ -36,14 +36,14 @@ void main(List<String> arguments) {
     } else if (arg == '--seed' && i + 1 < arguments.length) {
       final v = int.tryParse(arguments[++i]);
       if (v == null) {
-        _log.e('logic: sim_combat: Error: --seed requires an integer');
+        _log.e('Error: --seed requires an integer');
         exit(1);
       }
       seed = v;
     } else if (arg.startsWith('--seed=')) {
       final v = int.tryParse(arg.substring('--seed='.length).trim());
       if (v == null) {
-        _log.e('logic: sim_combat: Error: --seed requires an integer');
+        _log.e('Error: --seed requires an integer');
         exit(1);
       }
       seed = v;
@@ -51,14 +51,14 @@ void main(List<String> arguments) {
   }
 
   if (scriptPath == null || scriptPath.isEmpty) {
-    _log.e('logic: sim_combat: Error: --script <path> is required');
+    _log.e('Error: --script <path> is required');
     _printUsage();
     exit(1);
   }
 
   final file = File(scriptPath);
   if (!file.existsSync()) {
-    _log.e('logic: sim_combat: Error: script file not found: $scriptPath');
+    _log.e('Error: script file not found: $scriptPath');
     exit(1);
   }
 
@@ -84,7 +84,7 @@ void main(List<String> arguments) {
     final terrain = provinceRaw['terrain'] as String? ?? 'plains';
 
     if (fortLevel < 0 || fortLevel > 3) {
-      _log.e('logic: sim_combat: Error: battle $id: fortLevel must be 0-3, got $fortLevel');
+      _log.e('Error: battle $id: fortLevel must be 0-3, got $fortLevel');
       exit(1);
     }
 
@@ -154,7 +154,7 @@ void main(List<String> arguments) {
 
   final outPath = outputPath ?? 'sim_combat.md';
   File(outPath).writeAsStringSync(markdown);
-  _log.i('logic: sim_combat: Wrote Markdown report to ${File(outPath).absolute.path}');
+  _log.i('Wrote Markdown report to ${File(outPath).absolute.path}');
 
   if (jsonOutputPath != null && jsonOutputPath.isNotEmpty) {
     final jsonResults = results.map((r) {
@@ -169,7 +169,7 @@ void main(List<String> arguments) {
       return m;
     }).toList();
     File(jsonOutputPath).writeAsStringSync(jsonEncode(jsonResults));
-    _log.i('logic: sim_combat: Wrote JSON log to ${File(jsonOutputPath).absolute.path}');
+    _log.i('Wrote JSON log to ${File(jsonOutputPath).absolute.path}');
   }
 }
 
@@ -184,7 +184,7 @@ List<Unit> _parseUnits(
     final u = Map<String, dynamic>.from(unitsRaw[i] as Map);
     final type = u['type'] as String? ?? 'peasant_levies';
     if (regimentStatsById(type) == null) {
-      _log.e('logic: sim_combat: Error: battle $battleId: unknown unit type "$type"');
+      _log.e('Error: battle $battleId: unknown unit type "$type"');
       exit(1);
     }
     final medals = (u['medals'] as int?) ?? 0;
@@ -277,8 +277,8 @@ String _buildMarkdownReport({
 }
 
 void _printUsage() {
-  _log.i('logic: sim_combat: Usage:');
-  _log.i('logic: sim_combat:   melos run sim_combat -- --script <path> [--output <path>] [--json-output <path>] [--seed <int>]');
-  _log.i('logic: sim_combat: ');
-  _log.i('logic: sim_combat: Simulates probabilistic combat resolution on scripted scenarios. SPEC/program/sim-combat.md.');
+  _log.i('Usage:');
+  _log.i('  melos run sim_combat -- --script <path> [--output <path>] [--json-output <path>] [--seed <int>]');
+  _log.i('');
+  _log.i('Simulates probabilistic combat resolution on scripted scenarios. SPEC/program/sim-combat.md.');
 }

--- a/tool/sim_combat/pubspec.yaml
+++ b/tool/sim_combat/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=3.11.0 <4.0.0'
 
 dependencies:
-  logger: ^2.0.2
+  colonizethis_logger:
   colonizethis_data:
   colonizethis_logic:
   colonizethis_models:

--- a/tool/sim_combat_montecarlo/bin/sim_combat_montecarlo.dart
+++ b/tool/sim_combat_montecarlo/bin/sim_combat_montecarlo.dart
@@ -7,10 +7,10 @@ import 'dart:io';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
-final _log = Logger();
+final _log = logicLogger('sim_combat_montecarlo');
 
 /// Fixed defender effective military level for sim (SPEC: same for all script types).
 const int _simDefenderEffectiveLevel = 4;
@@ -40,25 +40,25 @@ void main(List<String> arguments) {
     } else if (arg == '--trials' && i + 1 < arguments.length) {
       final v = int.tryParse(arguments[++i]);
       if (v == null || v < 1) {
-        _errExit('logic: sim_combat_montecarlo: --trials must be a positive integer');
+        _errExit('--trials must be a positive integer');
       }
       trials = v!;
     } else if (arg.startsWith('--trials=')) {
       final v = int.tryParse(arg.substring('--trials='.length).trim());
       if (v == null || v < 1) {
-        _errExit('logic: sim_combat_montecarlo: --trials must be a positive integer');
+        _errExit('--trials must be a positive integer');
       }
       trials = v!;
     } else if (arg == '--seed' && i + 1 < arguments.length) {
       final v = int.tryParse(arguments[++i]);
       if (v == null) {
-        _errExit('logic: sim_combat_montecarlo: --seed requires an integer');
+        _errExit('--seed requires an integer');
       }
       seed = v;
     } else if (arg.startsWith('--seed=')) {
       final v = int.tryParse(arg.substring('--seed='.length).trim());
       if (v == null) {
-        _errExit('logic: sim_combat_montecarlo: --seed requires an integer');
+        _errExit('--seed requires an integer');
       }
       seed = v;
     } else if (arg == '--output' && i + 1 < arguments.length) {
@@ -73,30 +73,30 @@ void main(List<String> arguments) {
   }
 
   if (scriptPath == null || scriptPath.isEmpty) {
-    _log.e('logic: sim_combat_montecarlo: --script <path> is required');
+    _log.e('--script <path> is required');
     _log.i(_usage);
-    stderr.writeln('logic: sim_combat_montecarlo: --script <path> is required');
+    stderr.writeln('--script <path> is required');
     stderr.writeln(_usage);
     exit(1);
   }
 
   final file = File(scriptPath);
   if (!file.existsSync()) {
-    _errExit('logic: sim_combat_montecarlo: script file not found: $scriptPath');
+    _errExit('script file not found: $scriptPath');
   }
 
   Map<String, dynamic> decoded;
   try {
     decoded = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
   } catch (e, st) {
-    _log.e('logic: sim_combat_montecarlo: malformed script JSON', error: e, stackTrace: st);
-    stderr.writeln('logic: sim_combat_montecarlo: malformed script JSON: $e');
+    _log.e('malformed script JSON', error: e, stackTrace: st);
+    stderr.writeln('malformed script JSON: $e');
     exit(1);
   }
   final metadata = decoded['metadata'] as String? ?? 'sim_combat_montecarlo';
   final battlesRaw = decoded['battles'];
   if (battlesRaw is! List<dynamic>) {
-    _errExit('logic: sim_combat_montecarlo: script must have "battles" array');
+    _errExit('script must have "battles" array');
   }
   final baseSeed = seed ?? DateTime.now().millisecondsSinceEpoch;
 
@@ -105,7 +105,7 @@ void main(List<String> arguments) {
   for (var idx = 0; idx < battlesRaw.length; idx++) {
     final entry = battlesRaw[idx];
     if (entry is! Map) {
-      _errExit('logic: sim_combat_montecarlo: battle $idx must be an object');
+      _errExit('battle $idx must be an object');
     }
     final b = Map<String, dynamic>.from(entry as Map);
     _validateBattleKeys(b, idx);
@@ -122,7 +122,7 @@ void main(List<String> arguments) {
     final terrain = provinceRaw['terrain'] as String? ?? 'plains';
 
     if (fortLevel < 0 || fortLevel > 3) {
-      _errExit('logic: sim_combat_montecarlo: battle $id: fortLevel must be 0-3, got $fortLevel');
+      _errExit('battle $id: fortLevel must be 0-3, got $fortLevel');
     }
 
     var attWins = 0;
@@ -195,11 +195,11 @@ void main(List<String> arguments) {
 
   final outPath = outputPath ?? 'sim_combat_montecarlo.md';
   File(outPath).writeAsStringSync(markdown);
-  _log.i('logic: sim_combat_montecarlo: wrote Markdown report to ${File(outPath).absolute.path}');
+  _log.i('wrote Markdown report to ${File(outPath).absolute.path}');
 
   if (jsonOutputPath != null && jsonOutputPath.isNotEmpty) {
     File(jsonOutputPath).writeAsStringSync(jsonEncode(aggregatedResults));
-    _log.i('logic: sim_combat_montecarlo: wrote JSON log to ${File(jsonOutputPath).absolute.path}');
+    _log.i('wrote JSON log to ${File(jsonOutputPath).absolute.path}');
   }
 }
 
@@ -208,25 +208,25 @@ void _validateBattleKeys(Map<String, dynamic> b, int idx) {
   final idVal = b['id'];
   if (idVal == null || idVal is! String) {
     _errExit(
-      'logic: sim_combat_montecarlo: battle $idx: required key "id" missing or not a string',
+      'battle $idx: required key "id" missing or not a string',
     );
   }
   final att = b['attacker'];
   if (att == null || att is! Map) {
     _errExit(
-      'logic: sim_combat_montecarlo: battle $idx: required key "attacker" missing or not an object',
+      'battle $idx: required key "attacker" missing or not an object',
     );
   }
   final def = b['defender'];
   if (def == null || def is! Map) {
     _errExit(
-      'logic: sim_combat_montecarlo: battle $idx: required key "defender" missing or not an object',
+      'battle $idx: required key "defender" missing or not an object',
     );
   }
   final prov = b['province'];
   if (prov == null || prov is! Map) {
     _errExit(
-      'logic: sim_combat_montecarlo: battle $idx: required key "province" missing or not an object',
+      'battle $idx: required key "province" missing or not an object',
     );
   }
 }
@@ -242,7 +242,7 @@ List<Unit> _parseUnits(
     final u = Map<String, dynamic>.from(unitsRaw[i] as Map);
     final type = u['type'] as String? ?? 'peasant_levies';
     if (regimentStatsById(type) == null) {
-      _errExit('logic: sim_combat_montecarlo: battle $battleId: unknown unit type "$type"');
+      _errExit('battle $battleId: unknown unit type "$type"');
     }
     final medals = (u['medals'] as int?) ?? 0;
     units.add(Unit(

--- a/tool/sim_combat_montecarlo/pubspec.yaml
+++ b/tool/sim_combat_montecarlo/pubspec.yaml
@@ -8,10 +8,10 @@ environment:
   sdk: '>=3.11.0 <4.0.0'
 
 dependencies:
+  colonizethis_logger:
   colonizethis_data:
   colonizethis_logic:
   colonizethis_models:
-  logger: ^2.0.2
 
 dev_dependencies:
   colonizethis_test:

--- a/tool/sim_economy/bin/sim_economy.dart
+++ b/tool/sim_economy/bin/sim_economy.dart
@@ -6,10 +6,10 @@ import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:logger/logger.dart';
 
-final _log = Logger();
+final _log = logicLogger('sim_economy');
 
 void main(List<String> arguments) {
   String? scriptPath;
@@ -31,28 +31,28 @@ void main(List<String> arguments) {
       final value = arguments[++i];
       turns = int.tryParse(value);
       if (turns == null || turns < 1) {
-        _log.e('logic: sim_economy: Error: --turns must be a positive integer, got: $value');
+        _log.e('Error: --turns must be a positive integer, got: $value');
         exit(1);
       }
     } else if (arg.startsWith('--turns=')) {
       final value = arg.substring('--turns='.length).trim();
       turns = int.tryParse(value);
       if (turns == null || turns < 1) {
-        _log.e('logic: sim_economy: Error: --turns must be a positive integer, got: $value');
+        _log.e('Error: --turns must be a positive integer, got: $value');
         exit(1);
       }
     } else if (arg == '--seed' && i + 1 < arguments.length) {
       final value = arguments[++i];
       seed = int.tryParse(value);
       if (seed == null) {
-        _log.e('logic: sim_economy: Error: --seed requires an integer, got: $value');
+        _log.e('Error: --seed requires an integer, got: $value');
         exit(1);
       }
     } else if (arg.startsWith('--seed=')) {
       final value = arg.substring('--seed='.length).trim();
       seed = int.tryParse(value);
       if (seed == null) {
-        _log.e('logic: sim_economy: Error: --seed requires an integer, got: $value');
+        _log.e('Error: --seed requires an integer, got: $value');
         exit(1);
       }
     } else if (arg == '--output' && i + 1 < arguments.length) {
@@ -68,7 +68,7 @@ void main(List<String> arguments) {
 
   final useScript = scriptPath != null && scriptPath.isNotEmpty;
   if (!useScript && turns == null) {
-    _log.e('logic: sim_economy: Error: --turns is required when no --script is provided.');
+    _log.e('Error: --turns is required when no --script is provided.');
     _printUsage();
     exit(1);
   }
@@ -86,7 +86,7 @@ void main(List<String> arguments) {
   if (useScript) {
     final file = File(scriptPath);
     if (!file.existsSync()) {
-      _log.e('logic: sim_economy: Error: script file not found: $scriptPath');
+      _log.e('Error: script file not found: $scriptPath');
       exit(1);
     }
     final decoded = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
@@ -191,21 +191,21 @@ void main(List<String> arguments) {
 
   final markdownFile = File(outputConfig.markdownPath);
   markdownFile.writeAsStringSync(markdown);
-  _log.i('logic: sim_economy: Wrote Markdown report to ${markdownFile.absolute.path}');
+  _log.i('Wrote Markdown report to ${markdownFile.absolute.path}');
 
   if (outputConfig.jsonPath != null) {
     final jsonFile = File(outputConfig.jsonPath!);
     jsonFile.writeAsStringSync(jsonEncode(turnsLog));
-    _log.i('logic: sim_economy: Wrote JSON log to ${jsonFile.absolute.path}');
+    _log.i('Wrote JSON log to ${jsonFile.absolute.path}');
   }
 }
 
 void _printUsage() {
-  _log.i('logic: sim_economy: Usage:');
+  _log.i('Usage:');
   _log.i(
-      'logic: sim_economy:   melos run sim_economy -- [--script path] [--turns N] [--seed S] [--output path] [--json-output path]');
-  _log.i('logic: sim_economy: ');
-  _log.i('logic: sim_economy: Simulates a single player economy using Phase 2 rules.');
+      '  melos run sim_economy -- [--script path] [--turns N] [--seed S] [--output path] [--json-output path]');
+  _log.i('');
+  _log.i('Simulates a single player economy using Phase 2 rules.');
 }
 
 Map<String, int> _quantitiesFromStockpile(Stockpile stockpile) {

--- a/tool/sim_economy/pubspec.yaml
+++ b/tool/sim_economy/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=3.11.0 <4.0.0'
 
 dependencies:
-  logger: ^2.0.2
+  colonizethis_logger:
   colonizethis_models:
   colonizethis_data:
   colonizethis_logic:

--- a/tool/sim_scenarios/bin/sim_scenarios.dart
+++ b/tool/sim_scenarios/bin/sim_scenarios.dart
@@ -8,13 +8,13 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:logger/logger.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:path/path.dart' as path;
 
 import 'package:sim_scenarios/scenario.dart';
 import 'package:sim_scenarios/scenario_runner.dart';
 
-final _log = Logger();
+final _log = logicLogger('sim_scenarios');
 
 void main(List<String> args) async {
   final parser = ArgParser();
@@ -47,15 +47,15 @@ void main(List<String> args) async {
   final results = parser.parse(args);
 
   if (results['help'] == true) {
-    _log.i('logic: sim_scenarios: sim_scenarios - Batch scenario test driver');
-    _log.i('logic: sim_scenarios: ');
-    _log.i('logic: sim_scenarios: Usage:');
-    _log.i('logic: sim_scenarios:   dart run sim_scenarios                          # Run all scenarios');
-    _log.i('logic: sim_scenarios:   dart run sim_scenarios --scenario=path.json     # Run specific scenario');
-    _log.i('logic: sim_scenarios:   dart run sim_scenarios --directory=path         # Run from directory');
-    _log.i('logic: sim_scenarios:   dart run sim_scenarios --verbose                # Verbose output');
-    _log.i('logic: sim_scenarios: ');
-    _log.i('logic: sim_scenarios: ${parser.usage}');
+    _log.i('sim_scenarios - Batch scenario test driver');
+    _log.i('');
+    _log.i('Usage:');
+    _log.i('  dart run sim_scenarios                          # Run all scenarios');
+    _log.i('  dart run sim_scenarios --scenario=path.json     # Run specific scenario');
+    _log.i('  dart run sim_scenarios --directory=path         # Run from directory');
+    _log.i('  dart run sim_scenarios --verbose                # Verbose output');
+    _log.i('');
+    _log.i(parser.usage);
     return;
   }
 
@@ -88,30 +88,30 @@ void main(List<String> args) async {
     // Run single scenario
     final file = File(scenarioPath);
     if (!file.existsSync()) {
-      _log.e('logic: sim_scenarios: Error: Scenario file not found: $scenarioPath');
+      _log.e('Error: Scenario file not found: $scenarioPath');
       exit(1);
     }
     if (verbose) {
-      _log.i('logic: sim_scenarios: Running scenario: $scenarioPath');
+      _log.i('Running scenario: $scenarioPath');
     }
     final result = await runner.runFile(file);
     final report = formatScenarioReport(result);
-    _log.i('logic: sim_scenarios:\n$report');
+    _log.i('run report\n$report');
     print(report);
     exit(result.passed ? 0 : 1);
   } else {
     // Run all scenarios in directory
     final dir = Directory(directory);
     if (!dir.existsSync()) {
-      _log.e('logic: sim_scenarios: Error: Directory not found: $directory');
+      _log.e('Error: Directory not found: $directory');
       exit(1);
     }
     if (verbose) {
-      _log.i('logic: sim_scenarios: Running all scenarios in: $directory');
+      _log.i('Running all scenarios in: $directory');
     }
     final batchResult = await runner.runAll(dir);
     final report = formatBatchReport(batchResult);
-    _log.i('logic: sim_scenarios:\n$report');
+    _log.i('run report\n$report');
     print(report);
     exit(batchResult.failed > 0 ? 1 : 0);
   }

--- a/tool/sim_scenarios/pubspec.yaml
+++ b/tool/sim_scenarios/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=3.11.0 <4.0.0'
 
 dependencies:
-  logger: ^2.0.2
+  colonizethis_logger:
   args:
   path:
   hive:


### PR DESCRIPTION
## Summary
Completes remaining items for aligning runtime logging with `SPEC/program/logging` (issue #1382).

## Changes
- **App:** `GameService` passes `onLog: mapLogger('tile_map').d` into `TileMapGenerator.generate` for Old/New World so pass milestones appear in the shared logger (map-generation annex).
- **ctterm:** Wrap `runApp` in `runZonedGuarded` and log uncaught async errors with `tuiLogger()`, matching app/ctdev.
- **Packages:** `order_suggestion` uses `logicLogger('order_suggestion')`; `economy_planner` uses `aiLogger('economy_planner')` — message bodies no longer duplicate domain path prefixes.
- **Tools:** `sim_combat`, `sim_economy`, `sim_scenarios`, `sim_combat_montecarlo`, `init_game` use `colonizethis_logger` factories instead of raw `Logger()` and stripped manual `logic:` prefixes from messages.

## Testing
- `dart analyze` on touched entrypoints
- `dart test packages/colonizethis_ai/test/economy_planner_test.dart`

Closes #1382

Made with [Cursor](https://cursor.com)