### PR TITLE
test: intervention coverage depth (#1379)

### DIFF
--- a/app/test/game_screen_intervention_flow_test.dart
+++ b/app/test/game_screen_intervention_flow_test.dart
@@ -1,0 +1,148 @@
+// Mirrors GameScreen onDecisions wiring: resumeInterventionDecisions(game, decisions, orders).
+// Full InterventionDialogueOverlay + Yarn is covered by intervention_dialogue_overlay_test.dart
+// and is brittle under widget tests (Jenny steps + Flame nine-patch hit targets).
+
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/config/themes.dart';
+import 'package:colonizethis_app/core/services/game_service.dart';
+import 'package:colonizethis_app/providers/game_service_provider.dart';
+import 'package:colonizethis_app/providers/games_box_provider.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_save/colonizethis_save.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+class _CaptureInterventionResumeGameService extends GameService {
+  _CaptureInterventionResumeGameService(super.box, super.adapter);
+
+  List<InterventionDecision>? capturedInterventionDecisions;
+  Orders? capturedResumeOrders;
+
+  @override
+  TurnResolutionResult resumeInterventionDecisions(
+    Game game,
+    List<InterventionDecision> decisions,
+    Orders orders, {
+    void Function(GameEvent)? onGameEvent,
+  }) {
+    capturedInterventionDecisions = decisions;
+    capturedResumeOrders = orders;
+    return TurnResolutionComplete(game);
+  }
+}
+
+/// Same callback shape as [GameScreen] intervention [onDecisions] (lines 211–218).
+class _ResumeHarness extends ConsumerWidget {
+  const _ResumeHarness();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Center(
+      child: TextButton(
+        onPressed: () {
+          final game = ref.read(currentGameProvider);
+          if (game == null) return;
+          final orders = ref.read(currentOrdersProvider);
+          final service = ref.read(gameServiceProvider);
+          final result = service.resumeInterventionDecisions(
+            game,
+            [
+              InterventionDecision(
+                aggressorGpId: 'gp2',
+                defenderMinorOrTribeId: 'minor1',
+                interveningGpId: 'gp1',
+                choice: InterventionChoice.protest,
+              ),
+            ],
+            orders,
+          );
+          if (result is TurnResolutionComplete) {
+            ref.read(currentGameProvider.notifier).setGame(result.game);
+            ref.read(currentOrdersProvider.notifier).clear();
+            ref.read(pendingDiplomacyProvider.notifier).clear();
+          }
+        },
+        child: const Text('Submit intervention'),
+      ),
+    );
+  }
+}
+
+void main() {
+  suppressLogsForTests();
+
+  late Box<dynamic> box;
+
+  setUpAll(() async {
+    Hive.init('./.dart_tool/test_hive_intervention_resume_flow');
+    box = await Hive.openBox<dynamic>(HiveBoxNames.games);
+  });
+
+  testWidgets(
+    'Intervention resume passes currentOrders into GameService.resumeInterventionDecisions',
+    (WidgetTester tester) async {
+      const seedOrders = Orders(
+        buildUnitOrdersByPlayerId: {
+          'gp1': [
+            BuildUnitOrder(
+              unitType: 'builder',
+              isMilitary: false,
+              spawnProvinceId: 'oldWorld|M1',
+            ),
+          ],
+        },
+      );
+
+      final game = Game(
+        id: 'intervention_resume_harness',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true, treasury: 0),
+          Player(id: 'gp2', displayName: 'Aggressor', isHuman: false, treasury: 0),
+        ],
+        minorNations: const [
+          MinorNation(id: 'minor1', displayName: 'Minorca', capitalProvinceId: 'oldWorld|p1'),
+        ],
+      );
+
+      final service = _CaptureInterventionResumeGameService(box, GameSaveAdapter());
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gamesBoxProvider.overrideWith((ref) => box),
+            gameServiceProvider.overrideWith((ref) => service),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+            currentOrdersProvider.overrideWith(() => CurrentOrdersNotifier(seedOrders)),
+          ],
+          child: MaterialApp(
+            theme: AppThemes.colonial,
+            home: const _ResumeHarness(),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Submit intervention'));
+      await tester.pump();
+
+      expect(service.capturedResumeOrders, seedOrders);
+      expect(service.capturedInterventionDecisions, isNotNull);
+      expect(service.capturedInterventionDecisions!.single.choice, InterventionChoice.protest);
+
+      final container =
+          ProviderScope.containerOf(tester.element(find.byType(_ResumeHarness)));
+      expect(container.read(currentOrdersProvider), const Orders());
+      expect(container.read(pendingDiplomacyProvider), isNull);
+    },
+  );
+}

--- a/app/test/game_service_test.dart
+++ b/app/test/game_service_test.dart
@@ -48,40 +48,6 @@ class _PendingOverturesGameService extends GameService {
   }
 }
 
-class _PendingInterventionGameService extends GameService {
-  _PendingInterventionGameService(super.box, super.adapter);
-
-  @override
-  TurnResolutionResult runTurnResolution(
-    Game current, {
-    Orders? orders,
-    Orders? aiOrders,
-    MapTopology? topology,
-    Map<String, TileMapResult>? tileMapByRegion,
-    void Function(GameEvent)? onGameEvent,
-  }) {
-    final humanId = current.players.firstWhere((p) => p.isHuman).id;
-    final prompts = <Object>[
-      InterventionPrompt(
-        aggressorGpId: 'gp2',
-        defenderMinorOrTribeId: 'minor_x',
-        interveningGpId: humanId,
-      ),
-    ];
-    eventBus?.emit(InterventionRequiredEvent(prompts: prompts));
-    return TurnResolutionPendingIntervention(
-      game: current,
-      pendingInterventions: [
-        InterventionPrompt(
-          aggressorGpId: 'gp2',
-          defenderMinorOrTribeId: 'minor_x',
-          interveningGpId: humanId,
-        ),
-      ],
-    );
-  }
-}
-
 void main() {
   suppressLogsForTests();
 
@@ -175,30 +141,72 @@ void main() {
     );
 
     test(
-      'runTurnResolution returns TurnResolutionPendingIntervention and emits InterventionRequiredEvent',
+      'runTurnResolution emits InterventionRequiredEvent from GameService when resolver returns pending intervention',
       () async {
         final bus = AppEventBus.create();
         addTearDown(bus.dispose);
 
-        final service = _PendingInterventionGameService(box, adapter);
+        final service = GameService(box, adapter);
         service.eventBus = bus;
 
+        const ow = 'oldWorld';
+        const minorProvId = '$ow|M1';
         final game = Game(
-          id: 'g_intervention_test',
-          worldState: const WorldState(
-            turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-            oldWorld: RegionData(),
-            newWorld: RegionData(),
+          id: 'g_intervention_bus_integration',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(id: minorProvId, regionId: ow, ownerId: 'minor1'),
+              ],
+              units: const [],
+            ),
+            newWorld: const RegionData(),
           ),
           players: const [
             Player(id: 'gp1', displayName: 'Human', isHuman: true, treasury: 0),
+            Player(id: 'gp2', displayName: 'Aggressor', isHuman: false, treasury: 0),
           ],
+          minorNations: const [
+            MinorNation(id: 'minor1', displayName: 'Minor 1'),
+          ],
+          diplomacyRelations: const [
+            DiplomacyRelation(
+              factionId1: 'gp1',
+              factionId2: 'minor1',
+              state: RelationState.atPeace,
+            ),
+            DiplomacyRelation(
+              factionId1: 'gp2',
+              factionId2: 'minor1',
+              state: RelationState.atPeace,
+            ),
+          ],
+          overtureStates: const [
+            OvertureState(
+              gpId: 'gp1',
+              targetId: 'minor1',
+              stage: OvertureStage.embassy,
+              sinceTurn: 0,
+            ),
+          ],
+        );
+
+        final orders = Orders(
+          diplomaticOrdersByPlayerId: const {
+            'gp2': [
+              DiplomaticOrder(
+                type: DiplomaticOrderType.declareWar,
+                targetFactionId: 'minor1',
+              ),
+            ],
+          },
         );
 
         final received = <AppEvent>[];
         bus.on<InterventionRequiredEvent>().listen(received.add);
 
-        final result = service.runTurnResolution(game);
+        final result = service.runTurnResolution(game, orders: orders);
 
         await pumpEventQueue();
         expect(result, isA<TurnResolutionPendingIntervention>());
@@ -207,6 +215,7 @@ void main() {
         expect(event.prompts, hasLength(1));
         final prompt = event.prompts.first as InterventionPrompt;
         expect(prompt.aggressorGpId, 'gp2');
+        expect(prompt.defenderMinorOrTribeId, 'minor1');
         expect(prompt.interveningGpId, 'gp1');
       },
     );

--- a/app/test/intervention_dialogue_overlay_test.dart
+++ b/app/test/intervention_dialogue_overlay_test.dart
@@ -1,0 +1,77 @@
+import 'package:colonizethis_app/config/themes.dart';
+import 'package:colonizethis_app/features/game/dialogue/intervention_dialogue_overlay.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FailingAssetBundle extends Fake implements AssetBundle {
+  @override
+  Future<String> loadString(String key, {bool cache = true}) {
+    return Future.error(StateError('missing intervention yarn'));
+  }
+}
+
+void main() {
+  suppressLogsForTests();
+
+  testWidgets(
+    'InterventionDialogueOverlay degraded path submits do-nothing decisions when Yarn fails',
+    (WidgetTester tester) async {
+      final game = Game(
+        id: 'iv_degraded',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true, treasury: 0),
+          Player(id: 'gp2', displayName: 'Aggressor', isHuman: false, treasury: 0),
+        ],
+        minorNations: const [
+          MinorNation(id: 'minor1', displayName: 'Minor 1'),
+        ],
+      );
+
+      const prompts = [
+        InterventionPrompt(
+          aggressorGpId: 'gp2',
+          defenderMinorOrTribeId: 'minor1',
+          interveningGpId: 'gp1',
+        ),
+      ];
+
+      List<InterventionDecision>? captured;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppThemes.colonial,
+          home: InterventionDialogueOverlay(
+            game: game,
+            prompts: prompts,
+            skipIntroForTest: true,
+            assetBundle: _FailingAssetBundle(),
+            onDecisions: (d) => captured = d,
+            child: const SizedBox.expand(),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.textContaining('Could not load intervention dialogue'), findsOneWidget);
+      await tester.tap(find.text('Continue'));
+      await tester.pump();
+
+      expect(captured, isNotNull);
+      expect(captured!, hasLength(1));
+      expect(captured!.single.choice, InterventionChoice.doNothing);
+      expect(captured!.single.aggressorGpId, 'gp2');
+      expect(captured!.single.defenderMinorOrTribeId, 'minor1');
+      expect(captured!.single.interveningGpId, 'gp1');
+    },
+  );
+}

--- a/ctterm/lib/screens/pending_intervention_screen.dart
+++ b/ctterm/lib/screens/pending_intervention_screen.dart
@@ -9,6 +9,28 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 final _log = tuiLogger();
 
+/// Builds the rows submitted when the player confirms all prompts (Enter).
+/// SPEC/tui/screens/pending-intervention.md.
+List<InterventionDecision> buildInterventionDecisionsForSubmit({
+  required List<InterventionPrompt> prompts,
+  required List<InterventionChoice> choices,
+}) {
+  if (prompts.length != choices.length) {
+    throw ArgumentError(
+      'prompts (${prompts.length}) and choices (${choices.length}) length mismatch',
+    );
+  }
+  return List<InterventionDecision>.generate(prompts.length, (i) {
+    final p = prompts[i];
+    return InterventionDecision(
+      aggressorGpId: p.aggressorGpId,
+      defenderMinorOrTribeId: p.defenderMinorOrTribeId,
+      interveningGpId: p.interveningGpId,
+      choice: choices[i],
+    );
+  });
+}
+
 /// Blocking screen: human chooses intervene / do naught / protest per prompt.
 class PendingInterventionScreen extends StatefulComponent {
   const PendingInterventionScreen({
@@ -148,18 +170,10 @@ class _PendingInterventionScreenState extends State<PendingInterventionScreen> {
       return true;
     }
     if (key == LogicalKey.enter) {
-      final decisions = <InterventionDecision>[];
-      for (var i = 0; i < component.prompts.length; i++) {
-        final p = component.prompts[i];
-        decisions.add(
-          InterventionDecision(
-            aggressorGpId: p.aggressorGpId,
-            defenderMinorOrTribeId: p.defenderMinorOrTribeId,
-            interveningGpId: p.interveningGpId,
-            choice: _choices[i],
-          ),
-        );
-      }
+      final decisions = buildInterventionDecisionsForSubmit(
+        prompts: component.prompts,
+        choices: _choices,
+      );
       _log.d('submitting ${decisions.length} decision(s)');
       component.onDecisions(decisions);
       return true;

--- a/ctterm/test/pending_intervention_screen_test.dart
+++ b/ctterm/test/pending_intervention_screen_test.dart
@@ -1,0 +1,99 @@
+// Pending intervention submit mapping. SPEC/tui/screens/pending-intervention.md.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:ctterm/screens/pending_intervention_screen.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('buildInterventionDecisionsForSubmit', () {
+    test('maps each prompt to a decision with the matching choice', () {
+      const prompts = [
+        InterventionPrompt(
+          aggressorGpId: 'a1',
+          defenderMinorOrTribeId: 'm1',
+          interveningGpId: 'h1',
+        ),
+        InterventionPrompt(
+          aggressorGpId: 'a2',
+          defenderMinorOrTribeId: 't1',
+          interveningGpId: 'h2',
+        ),
+      ];
+      const choices = [
+        InterventionChoice.intervene,
+        InterventionChoice.protest,
+      ];
+
+      final out = buildInterventionDecisionsForSubmit(
+        prompts: prompts,
+        choices: choices,
+      );
+
+      expect(out, hasLength(2));
+      expect(out[0].aggressorGpId, 'a1');
+      expect(out[0].defenderMinorOrTribeId, 'm1');
+      expect(out[0].interveningGpId, 'h1');
+      expect(out[0].choice, InterventionChoice.intervene);
+      expect(out[1].aggressorGpId, 'a2');
+      expect(out[1].choice, InterventionChoice.protest);
+    });
+
+    test('throws when prompts and choices lengths differ', () {
+      const prompts = [
+        InterventionPrompt(
+          aggressorGpId: 'a',
+          defenderMinorOrTribeId: 'm',
+          interveningGpId: 'h',
+        ),
+      ];
+      expect(
+        () => buildInterventionDecisionsForSubmit(
+          prompts: prompts,
+          choices: const [
+            InterventionChoice.doNothing,
+            InterventionChoice.protest,
+          ],
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('PendingInterventionScreen', () {
+    test('constructs with required parameters', () {
+      final game = Game(
+        id: 't1',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true, treasury: 0),
+        ],
+        minorNations: const [
+          MinorNation(id: 'minor1', displayName: 'Minor 1'),
+        ],
+      );
+      var invoked = false;
+      final screen = PendingInterventionScreen(
+        game: game,
+        prompts: const [
+          InterventionPrompt(
+            aggressorGpId: 'gp2',
+            defenderMinorOrTribeId: 'minor1',
+            interveningGpId: 'gp1',
+          ),
+        ],
+        onDecisions: (_) => invoked = true,
+      );
+
+      expect(screen.game, game);
+      expect(screen.prompts, hasLength(1));
+      screen.onDecisions(const []);
+      expect(invoked, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds automated coverage aligned with the gaps called out for **#1379** (pending intervention / `InterventionRequiredEvent` / resume wiring).

## Changes

- **App `GameService`:** Integration-style test that drives **real** `runTurnResolution` with a resolver-built `TurnResolutionPendingIntervention` game + orders, and asserts **`InterventionRequiredEvent`** is emitted from production `GameService` (replaces the mock that duplicated the emit).
- **App resume path:** New harness test that mirrors **`GameScreen`’s** `onDecisions` body (`currentOrders` → `resumeInterventionDecisions` → clear orders / pending on complete). Full `GameScreen` + Yarn + Flame is intentionally avoided here (brittle in widget tests); degraded overlay is covered separately.
- **`InterventionDialogueOverlay`:** Widget test for **Yarn load failure** → error UI → degraded submit (all **do-nothing** decisions).
- **ctterm:** `buildInterventionDecisionsForSubmit` used on Enter, with unit tests for row mapping and validation; light construction test for `PendingInterventionScreen`.

## Issue

Refs #1379