### PR TITLE
Align development resolution spec with work durations and build_improvement completion (#1291)

### DIFF
--- a/SPEC/game/extraction-and-improvements.md
+++ b/SPEC/game/extraction-and-improvements.md
@@ -97,7 +97,7 @@ A Builder may build an improvement on a tile only if: (a) the tile has a **resou
 
 ### Railroad Costs (Rail Builder)
 
-2 lumber + 2 steel per tile (authoritative values in `work_order_costs.dart` / ruleset config).
+2 lumber + 2 steel per tile (authoritative values in `work_order_costs.dart`).
 
 ### Port Placement
 

--- a/SPEC/program/development-resolution.md
+++ b/SPEC/program/development-resolution.md
@@ -24,13 +24,13 @@
   - Validate **unit type**, **target tile** (targetTileKey: exists, tile ownership, terrain eligibility), and **tech prerequisites** (e.g. Road Construction for transport level 2, Early Steam Engine for rail, Mine Engineering / Modern Forts for higher forts, gathering techs for higher improvements).
   - For **build_improvement** specifically: reject if the tile has no resource (per [extraction-and-improvements.md](../game/extraction-and-improvements.md)); reject if the tile's improvement level is already at max (4) or if the next level would exceed the player's tech-allowed extraction cap (see [tech-and-extraction-cap.md](../game/tech-and-extraction-cap.md)).
   - Look up:
-    - `totalTurns` for this action from ruleset config (higher levels → more turns; fort and rail slower than level-1 road/improvement).
-    - Material **costs** per action.
+    - `totalTurns` for this action using `totalTurnsForWork` in `packages/colonizethis_data` `work_order_costs.dart`, applied from `applyBuildAndWorkOrders` for standard material-backed targets (`build_improvement`, `build_road`, `build_port`, `build_fort`, `build_rail`, `upgrade_town`). **`explore`** uses the province-scaled turn count computed in that application path (see [fog-and-exploration-resolution.md](fog-and-exploration-resolution.md)). **`steal_tech`** uses 5 turns. **`counter_spy`** is ongoing (see loop below). **`purchase_land`** and **`prospect`** do not use this `currentWork` duration path in the build-phase application (see application code and fog spec).
+    - Material **costs** per action from `work_order_materialCost` / related helpers in the same module (and treasury rules for `purchase_land`).
   - If validation passes and the player has sufficient materials (or no material cost for that target):
-    - **Deduct materials when work is assigned** (during Build/Work phase application of WorkOrder; atomic per action; no refund if later cancelled). Look up costs from ruleset/config.
+    - **Deduct materials when work is assigned** (during Build/Work phase application of WorkOrder; atomic per action; no refund if later cancelled).
     - Enforce **per-player tile exclusivity** for development and purchase work: if another Builder, Engineer, or Merchant unit owned by the same player already has `currentWork` targeting that `targetTileKey`, the new work order must have been rejected earlier and is not applied here.
     - Set unit `status = working`, `currentWork = (target, targetTileKey, totalTurns, remainingTurns = totalTurns)`, and **unit.tileKey = targetTileKey** (civilian unit is considered on the target tile for the turn).
-  - `totalTurns` comes from ruleset config (default 1); config can vary by action and level (e.g. higher improvement/fort levels take more turns).
+  - Durations are code-defined in `totalTurnsForWork` (and the `explore` formula where applicable); `build_fort` scales with current fort level (e.g. longer builds for higher fort levels).
 
 ---
 
@@ -42,7 +42,7 @@ During the **Build / Work** phase (see [turn-resolution-phases.md](turn-resoluti
    - If unit is dead or tile is no longer owned by the player, **cancel** work: clear `currentWork`, set `status = idle`; costs are not refunded.
    - Otherwise, decrement `remainingTurns` by 1.
 2. When `remainingTurns` reaches 0, apply the action's effect:
-   - `build_improvement`: increase improvement level for `tileKey` by 1, clamped by terrain and tech caps.
+   - `build_improvement`: set stored improvement level to `min(currentLevel + 1, 4)` (global max improvement level per [extraction-and-improvements.md](../game/extraction-and-improvements.md)). Tech-allowed extraction cap and tile eligibility are enforced **only when the work order is accepted**; completion does **not** recompute those caps. Effective extraction still uses `min(improvement level, tech cap, …)` each turn per that GDD.
    - `upgrade_town`: increase the province's **town development level** by 1 (not generic improvement level on the tile); used in extraction formula per [capital-and-connectivity.md](../game/capital-and-connectivity.md).
    - `build_road`: set or upgrade transport level for `tileKey` (0→1→2; level 2 requires Road Construction tech) and, if applicable, adjacent capital/port tiles per [capital-and-connectivity.md](../game/capital-and-connectivity.md). "If applicable" means: when the target tile is adjacent (4-neighbour) to a tile that is either the player's capital or a port, the transport level is also applied to that adjacent tile (upgrade only, never downgrade).
    - `build_port`: create/update a `(provinceId, seaZoneId) → tileKey` mapping in `portsByProvinceSeaboard` and ensure the port tile has transport level 4.
@@ -78,10 +78,39 @@ Exploration and prospecting (`explore`, `prospect`) follow [fog-and-exploration-
 
 ### Acceptance criteria
 
-- **Work assign:** Validation covers unit type, target tile (exists, ownership, terrain eligibility), tech prerequisites, and material availability; on accept, materials are deducted at assign (no refund if work is later cancelled); unit gets `currentWork` set and `status = working`.
-- **build_improvement validation:** The order engine rejects build_improvement when the target tile has no resource, when the tile's improvement level is already 4, or when the player's tech-allowed extraction cap is less than (current improvement level + 1).
-- **Build/Work phase loop:** Each turn, for each working civilian: if unit is dead or the tile is no longer owned by the player (e.g. conquest; see #376), cancel work (clear `currentWork`, set `status = idle`); otherwise decrement `remainingTurns`; when it reaches 0, apply the action effect then set `status = idle` and clear `currentWork`.
-- **Player-initiated cancel:** When the player confirms cancel for a unit with in-progress work, the system clears that unit's `currentWork` and sets `status = idle`; materials are not refunded. Pending work orders for that unit are removed from the current turn's orders. Implementation may use a cancel-work order applied at the start of Build/Work phase or a direct game-state update per TDD.
-- **build_port:** Completion requires topology to be defined. If topology is `null`, the build_port completion has no effect—no port is registered in `portsByProvinceSeaboard` and the transport level is not set on the tile. Therefore, build_port must only be offered/completed when topology is available. Port key uses full province id per [world-model-identity.md](../game/world-model-identity.md).
-- **Shared use:** The same TurnResolver and development resolution logic are used in the main game and in sim_game.
+- **Work assign (validation and materials):** Given a civilian `WorkOrder` that passes order-engine validation for unit type, target tile (exists, ownership, terrain eligibility), tech prerequisites, and material availability  
+  When the system applies that order in the Build/Work application path  
+  Then the system deducts materials at assign time (no refund if work is later cancelled), sets the unit `status` to `working`, and sets `currentWork` with `remainingTurns == totalTurns`.
+
+- **Work assign (`totalTurns` source):** Given a standard material-backed work target handled by `applyStandardWorkOrder` (e.g. `build_improvement`, `build_road`, `build_fort`)  
+  When the system assigns that work  
+  Then `currentWork.totalTurns` equals `totalTurnsForWork` from `colonizethis_data` `work_order_costs.dart` for that target and its level arguments (e.g. fort level for `build_fort`).
+
+- **build_improvement validation:** Given a `build_improvement` work order  
+  When the order engine validates it  
+  Then the engine rejects the order if the target tile has no resource, if the tile's improvement level is already 4, or if the player's tech-allowed extraction cap is strictly less than (current improvement level + 1).
+
+- **build_improvement completion (stored level):** Given a unit completes `build_improvement` on a tile whose stored improvement level is `N` with `0 <= N <= 3`  
+  When `remainingTurns` reaches 0 and the effect is applied  
+  Then the stored improvement level becomes `N + 1` (and never exceeds 4).
+
+- **build_improvement completion (no assign-time re-check):** Given a unit has in-progress `build_improvement` on a tile at stored level 3  
+  When `remainingTurns` reaches 0 and the effect is applied  
+  Then the system sets stored improvement level to 4 without re-evaluating the player's tech-allowed extraction cap at completion (cap was enforced when the order was accepted; extraction yield still follows `min(level, tech cap, …)` per GDD).
+
+- **Build/Work phase loop:** Given a civilian with `status = working` and `currentWork != null`  
+  When the Build/Work phase runs  
+  Then if the unit is dead or the tile is no longer owned by the player, the system clears `currentWork` and sets `status = idle` with no material refund; otherwise it decrements `remainingTurns` by 1, and when `remainingTurns` reaches 0 it applies the action effect, then sets `status = idle` and clears `currentWork`.
+
+- **Player-initiated cancel:** Given a unit with in-progress work  
+  When the player confirms cancel  
+  Then the system clears that unit's `currentWork`, sets `status = idle`, and does not refund materials; pending work orders for that unit are removed from the current turn's orders. Implementation may use a cancel-work order at the start of Build/Work phase or a direct game-state update per TDD.
+
+- **build_port:** Given `build_port` work completes  
+  When topology is `null`  
+  Then the system does not register a port in `portsByProvinceSeaboard` and does not set transport level on the tile from that completion. Port keys use full province id per [world-model-identity.md](../game/world-model-identity.md).
+
+- **Shared use:** Given the same `WorkOrder` inputs  
+  When the main game or `sim_game` resolves the Build/Work phase  
+  Then both use the same turn resolution / development application logic for durations, costs, and completion effects.
 

--- a/packages/colonizethis_data/lib/src/work_order_costs.dart
+++ b/packages/colonizethis_data/lib/src/work_order_costs.dart
@@ -1,12 +1,12 @@
 import 'commodities.dart';
 
 /// Work order material costs and durations. SPEC/game/civilian-units.md, extraction-and-improvements.md, siege-mechanics.md. Single source of truth for stockpile costs in order validation and application.
-/// Single source of truth for order engine validation and orders_application deduction.
+/// Durations: SPEC/program/development-resolution.md — `totalTurnsForWork` is authoritative for assign-time `currentWork.totalTurns` for standard material-backed targets (see `applyBuildAndWorkOrders`).
 
 /// Material cost for a work order: commodity id -> quantity.
 typedef WorkOrderCost = Map<String, int>;
 
-/// Default duration in turns when not specified by level. Config can override later.
+/// Duration in turns for a work target. Used when assigning `currentWork` for standard development orders.
 int totalTurnsForWork(String workTarget, {int? improvementLevel, int? fortLevel}) {
   switch (workTarget) {
     case 'explore':

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -316,6 +316,8 @@ Game applyBuildAndWorkOrders(
     );
     switch (cw.workTarget) {
       case 'build_improvement':
+        // Stored level: min(level+1, 4). Tech/resource gating at assign only;
+        // SPEC/program/development-resolution.md (build_improvement completion).
         final level = s.tileState.improvementLevel(cw.tileKey);
         s.tileState = s.tileState.setImprovement(
           cw.tileKey,
@@ -857,7 +859,7 @@ void _runWorkPhase(
           isWorkOrderTargetAllowedForUnitType(u.type, 'steal_tech') &&
           u.currentWork == null &&
           hasValidTarget) {
-        const totalTurns = 5;
+        final totalTurns = totalTurnsForWork('steal_tech');
         _log.d(
           'work order accepted and assigned unit=${order.unitId} target=steal_tech targetTileKey=$targetTileKey totalTurns=$totalTurns',
         );
@@ -881,7 +883,7 @@ void _runWorkPhase(
           isWorkOrderTargetAllowedForUnitType(u.type, 'counter_spy') &&
           u.currentWork == null &&
           hasValidTarget) {
-        const totalTurns = 0;
+        final totalTurns = totalTurnsForWork('counter_spy');
         _log.d(
           'work order accepted and assigned unit=${order.unitId} target=counter_spy targetTileKey=$targetTileKey totalTurns=$totalTurns',
         );

--- a/packages/colonizethis_logic/test/orders_application_work_completion_test.dart
+++ b/packages/colonizethis_logic/test/orders_application_work_completion_test.dart
@@ -67,6 +67,99 @@ void main() {
     );
 
     test(
+      'build_improvement completion raises stored level from 3 to 4 (global max)',
+      () {
+        final tileState = TileMapState().setImprovement(tileKey, 3);
+        final unit = Unit(
+          id: 'u1',
+          type: 'Builder',
+          ownerId: 'p1',
+          locationProvinceId: provinceId,
+          tileKey: tileKey,
+          status: UnitStatus.working,
+          currentWork: const CurrentWork(
+            workTarget: 'build_improvement',
+            tileKey: tileKey,
+            totalTurns: 1,
+            remainingTurns: 1,
+          ),
+        );
+        final game = Game(
+          id: 'g',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: provinceId, regionId: ow, ownerId: 'p1'),
+              ],
+              units: [unit],
+            ),
+            newWorld: const RegionData(),
+            resourceByTileKey: const {tileKey: 'grain'},
+            tileState: tileState,
+          ),
+          players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+        );
+        final next = applyBuildAndWorkOrders(
+          game,
+          _ordersToTriggerProcessWork(),
+        );
+        expect(next.worldState.tileState.improvementLevel(tileKey), 4);
+      },
+    );
+
+    test(
+      'build_improvement completion does not re-apply extraction tech cap (#1291)',
+      () {
+        // Assign-time would reject 3→4 with extraction cap 2; completion still applies +1 to stored level.
+        expect(extractionCapForUnlocked(const {'saw_mill': true}), 2);
+        final tileState = TileMapState().setImprovement(tileKey, 3);
+        final unit = Unit(
+          id: 'u1',
+          type: 'Builder',
+          ownerId: 'p1',
+          locationProvinceId: provinceId,
+          tileKey: tileKey,
+          status: UnitStatus.working,
+          currentWork: const CurrentWork(
+            workTarget: 'build_improvement',
+            tileKey: tileKey,
+            totalTurns: 1,
+            remainingTurns: 1,
+          ),
+        );
+        final game = Game(
+          id: 'g',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: provinceId, regionId: ow, ownerId: 'p1'),
+              ],
+              units: [unit],
+            ),
+            newWorld: const RegionData(),
+            resourceByTileKey: const {tileKey: 'grain'},
+            tileState: tileState,
+          ),
+          players: const [
+            Player(
+              id: 'p1',
+              displayName: 'P1',
+              isHuman: true,
+              techUnlocked: {'saw_mill': true},
+            ),
+          ],
+        );
+        final next = applyBuildAndWorkOrders(
+          game,
+          _ordersToTriggerProcessWork(),
+        );
+        expect(next.worldState.tileState.improvementLevel(tileKey), 4);
+      },
+    );
+
+    test(
       'work cancelled when province containing target tile is conquered (#376)',
       () {
         // Unit p1 is working on a tile in P1; province P1 is conquered by p2.

--- a/packages/colonizethis_logic/test/orders_application_work_order_application_part1_test.dart
+++ b/packages/colonizethis_logic/test/orders_application_work_order_application_part1_test.dart
@@ -245,6 +245,70 @@ void main() {
       },
     );
 
+    test(
+      'build_fort assigns currentWork.totalTurns from totalTurnsForWork (fort level)',
+      () {
+        final unit = Unit(
+          id: 'u1',
+          type: 'Engineer',
+          ownerId: 'p1',
+          locationProvinceId: provinceId,
+          tileKey: tileKey,
+        );
+        final cost = workOrderCostBuildFort(1);
+        var stockpile = const Stockpile();
+        for (final e in cost.entries) {
+          stockpile = stockpile.applyDelta(e.key, e.value);
+        }
+        final game = Game(
+          id: 'g',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [
+                Province(
+                  id: provinceId,
+                  regionId: ow,
+                  ownerId: 'p1',
+                  fortLevel: 1,
+                ),
+              ],
+              units: [unit],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: [
+            Player(
+              id: 'p1',
+              displayName: 'P1',
+              isHuman: true,
+              stockpile: stockpile,
+              techUnlocked: const {'mine_engineering': true},
+            ),
+          ],
+        );
+        final orders = Orders(
+          workOrdersByPlayerId: {
+            'p1': [
+              WorkOrder(
+                unitId: 'u1',
+                target: 'build_fort',
+                targetTileKey: tileKey,
+              ),
+            ],
+          },
+        );
+        final next = applyBuildAndWorkOrders(game, orders);
+        final u = next.worldState.oldWorld.units.single;
+        expect(
+          u.currentWork!.totalTurns,
+          totalTurnsForWork('build_fort', fortLevel: 1),
+        );
+        expect(u.currentWork!.remainingTurns, 1);
+        expect(next.worldState.oldWorld.provinces.single.fortLevel, 1);
+      },
+    );
+
     test('steal_tech work order sets currentWork for Spy unit', () {
       const targetProvinceId = 'oldWorld|P2';
       const targetTileKey = 'oldWorld|P2|0|0';


### PR DESCRIPTION
## Summary

Closes #1291.

Implements **Option A** from the issue: the program spec and game copy now match the implemented behavior—work `totalTurns` come from `colonizethis_data` `work_order_costs.dart` (`totalTurnsForWork`) with documented exceptions (`explore`, `steal_tech`, `counter_spy`, `purchase_land`, `prospect`), and `build_improvement` completion only bumps stored level by 1 clamped to 4 with **no** extraction tech re-check at completion (gating remains at assign time).

## Changes

- **`SPEC/program/development-resolution.md`:** Assigning-work and completion narrative; Given–When–Then acceptance criteria.
- **`SPEC/game/extraction-and-improvements.md`:** Drop stale “ruleset config” on rail cost (authoritative `work_order_costs.dart` only).
- **`work_order_costs.dart`:** Doc comment ties durations to the program spec.
- **`orders_application.dart`:** `steal_tech` / `counter_spy` use `totalTurnsForWork`; comment on `build_improvement` completion.
- **Tests:** Fort `totalTurns` wiring; `build_improvement` 3→4 and no tech cap at completion (#1291).

## Testing

- `flutter test` on `orders_application_work_completion_test.dart`, `orders_application_work_order_application_part1_test.dart`, and `orders_application_work_order_application_part2_test.dart`.