### PR TITLE
refactor(ui): train, split-fleet, diplomacy via AppEventBus

### DIFF
--- a/SPEC/program/app-event-bus.md
+++ b/SPEC/program/app-event-bus.md
@@ -52,7 +52,7 @@ A typed event bus lets emitters publish **`AppEvent`** subclasses without depend
 Defined in **`colonizethis_models`** (`app_events.dart`, exports).
 
 - **`UIActionEvent`** — dialogs, navigation, panels, map locate/selection intents, grants/subsidy submit; concrete types in source and **[app-ui-wiring.md](app-ui-wiring.md)**.
-- **`SessionCommandEvent`** — session mutations applied by long-lived shell listeners (e.g. **`AppEventHandlerScope`**), not by **`AppEventHandler`**. Includes **`RemovePendingWorkOrderRequestedEvent`**, **`CancelInProgressCivilianWorkRequestedEvent`**, **`NavalFleetsUpdatedEvent`**.
+- **`SessionCommandEvent`** — session mutations applied by long-lived shell listeners (e.g. **`AppEventHandlerScope`**), not by **`AppEventHandler`**. Includes **`RemovePendingWorkOrderRequestedEvent`**, **`CancelInProgressCivilianWorkRequestedEvent`**, **`NavalFleetsUpdatedEvent`**, **`NavalSplitFleetRequestedEvent`**, **`TrainCivilianBuildOrdersCommittedEvent`**, **`TrainMilitaryBuildOrdersCommittedEvent`**.
 - **`UISystemEvent`** — snackbar, overlay, notify.
 - **`GameToUIEvent`** — e.g. **`TurnResolutionCompleteEvent`**, **`OvertureRequiredEvent`**, **`InterventionRequiredEvent`**, **`CallToArmsRequiredEvent`**, **`NewGameCreatedEvent`**, **`SaveGameCompleteEvent`**, plus bridge types **`AppCombatResultEvent`**, **`AppProvinceCapturedEvent`**, **`AppDiplomacyChangeEvent`**, **`AppResearchCompleteEvent`**, **`AppVictorySetEvent`**, **`AppOrderRejectedEvent`** (**SPEC/program/game-event-bridge.md**).
 
@@ -134,7 +134,7 @@ When **`logicEventBus`** is set, turn resolution passes it into **`resolveTurnFo
 | `OpenMilitaryUnitsPanelEvent` | `GameSideMenu` | `MilitaryUnitsPanel` |
 | `OpenNavalUnitsPanelEvent` | `GameSideMenu` | `NavalUnitsPanel` (+ `AppEventBus`) |
 
-**Civilian / naval work and fleets:** `CivilianUnitsPanel` emits `StartCivilianWorkTargetSelectionEvent`, `LocateMapTileEvent`, `RemovePendingWorkOrderRequestedEvent`, and `CancelInProgressCivilianWorkRequestedEvent`; `MilitaryUnitsPanel` / `NavalUnitsPanel` emit `LocateMapTileEvent`; `NavalUnitsPanel` emits `NavalFleetsUpdatedEvent` after split/combine. `AppEventHandlerScope` subscribes and updates `currentOrdersProvider` / `currentGameProvider` using `colonizethis_logic` (`removePendingWorkOrderAt`, `clearUnitCurrentWork`). Panels do not receive Riverpod `ref` for those mutations.
+**Civilian / naval work and fleets:** `CivilianUnitsPanel` emits `StartCivilianWorkTargetSelectionEvent`, `LocateMapTileEvent`, `RemovePendingWorkOrderRequestedEvent`, and `CancelInProgressCivilianWorkRequestedEvent`; `MilitaryUnitsPanel` / `NavalUnitsPanel` emit `LocateMapTileEvent`; `NavalUnitsPanel` emits `NavalFleetsUpdatedEvent` after combine; split uses `SplitFleetDialog` → **`NavalSplitFleetRequestedEvent`** → scope applies and emits **`NavalFleetsUpdatedEvent`**. Train dialogs emit **`TrainCivilianBuildOrdersCommittedEvent`** / **`TrainMilitaryBuildOrdersCommittedEvent`** on close; scope merges orders. `AppEventHandlerScope` subscribes and updates `currentOrdersProvider` / `currentGameProvider` using `colonizethis_logic` where applicable (`removePendingWorkOrderAt`, `clearUnitCurrentWork`). Panels do not receive Riverpod `ref` for those mutations.
 
 **Consumption:** No single shell subscriber. Each screen that must react listens (e.g. **`GameToUIBusListener`**) and reloads **`currentGameProvider`** when **`gameId`** matches.
 

--- a/SPEC/program/app-ui-wiring.md
+++ b/SPEC/program/app-ui-wiring.md
@@ -65,7 +65,11 @@ For `train_civilians` and `train_military`, shared order/count orchestration mus
 | `quick_battle_result` | `QuickBattleResultDialog` | planned (or local if combat UI stays internal) |
 | `combat_mode_choice` | `CombatModeChoiceDialog` | same |
 
-**Local by design (no `OpenDialogEvent`):** map display options (`GameMapArea`), tech detail (`TechTreeWidget`), split fleet (`NavalUnitsPanel`), civilian work-target sheet (`CivilianUnitsPanel`), next-turn confirmation (`GameMapArea`), in-game Android back exit confirmation (`GameScreen`), research tech picker (`TechnologyPanel`), **`CtDropdown`** internal picker, **new-game setup progress and error dialogs** after leader confirmation (see **SPEC/ui/game-initializing.md**).
+**Local by design (no `OpenDialogEvent`):** map display options (`GameMapArea`), tech detail (`TechTreeWidget`), civilian work-target sheet (`CivilianUnitsPanel`), next-turn confirmation (`GameMapArea`), in-game Android back exit confirmation (`GameScreen`), research tech picker (`TechnologyPanel`), **`CtDropdown`** internal picker, **new-game setup progress and error dialogs** after leader confirmation (see **SPEC/ui/game-initializing.md**).
+
+**Split fleet:** `NavalUnitsPanel` uses local `showDialog` for `SplitFleetDialog`, but the dialog commits via **`NavalSplitFleetRequestedEvent`** → `AppEventHandlerScope` (applies `applyNavalSplitFleet`, then emits **`NavalFleetsUpdatedEvent`**) so the dialog does not receive panel merge callbacks. Widgetbook / tests without the shell wire the same request event or listen for `NavalFleetsUpdatedEvent` only.
+
+**Train at-capital dialogs:** `TrainCiviliansDialog` / `TrainMilitaryDialog` emit **`TrainCivilianBuildOrdersCommittedEvent`** / **`TrainMilitaryBuildOrdersCommittedEvent`** on close; `AppEventHandlerScope` merges into orders. No `onOrdersChanged` callback from the shell into the dialog.
 
 ---
 

--- a/app/lib/core/services/app_event_handler_scope.dart
+++ b/app/lib/core/services/app_event_handler_scope.dart
@@ -7,6 +7,7 @@ import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:colonizethis_app/app.dart';
+import 'package:colonizethis_app/features/game/logic/naval_fleet_split_apply.dart';
 import 'package:colonizethis_app/features/game/widgets/diplomacy_dialogs.dart';
 import 'package:colonizethis_app/features/game/widgets/train_civilians_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/train_military_dialog.dart';
@@ -208,17 +209,7 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
             game: game,
             humanPlayerId: humanPlayerId,
             currentOrders: orders,
-            onOrdersChanged: (newOrders) {
-              final o = container.read(currentOrdersProvider);
-              container
-                  .read(currentOrdersProvider.notifier)
-                  .state = _mergeTrainCivilianOrdersForPlayer(
-                current: o,
-                game: game,
-                humanPlayerId: humanPlayerId,
-                newFromDialog: newOrders,
-              );
-            },
+            bus: container.read(appEventBusProvider),
           );
         },
         trainMilitaryDialogId: (ctx, _) {
@@ -233,17 +224,7 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
             game: game,
             humanPlayerId: humanPlayerId,
             currentOrders: orders,
-            onOrdersChanged: (newOrders) {
-              final o = container.read(currentOrdersProvider);
-              container
-                  .read(currentOrdersProvider.notifier)
-                  .state = _mergeTrainMilitaryOrdersForPlayer(
-                current: o,
-                game: game,
-                humanPlayerId: humanPlayerId,
-                newFromDialog: newOrders,
-              );
-            },
+            bus: container.read(appEventBusProvider),
           );
         },
         grantOrSubsidyDialogId: (ctx, params) {
@@ -284,6 +265,43 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
       }),
       bus.on<NavalFleetsUpdatedEvent>().listen((e) {
         ref.read(currentGameProvider.notifier).setGame(e.game);
+      }),
+      bus.on<NavalSplitFleetRequestedEvent>().listen((e) {
+        final g = ref.read(currentGameProvider);
+        if (g == null) return;
+        final newGame = applyNavalSplitFleet(
+          game: g,
+          humanPlayerId: e.humanPlayerId,
+          originalFleetId: e.originalFleetId,
+          shipInstanceIdsToNewFleet: e.shipInstanceIdsToNewFleet,
+        );
+        bus.emit(NavalFleetsUpdatedEvent(game: newGame));
+      }),
+      bus.on<TrainCivilianBuildOrdersCommittedEvent>().listen((e) {
+        final g = ref.read(currentGameProvider);
+        if (g == null) return;
+        final pid = _humanPlayerId(g);
+        final o = ref.read(currentOrdersProvider);
+        ref.read(currentOrdersProvider.notifier).state =
+            _mergeTrainCivilianOrdersForPlayer(
+          current: o,
+          game: g,
+          humanPlayerId: pid,
+          newFromDialog: e.orders,
+        );
+      }),
+      bus.on<TrainMilitaryBuildOrdersCommittedEvent>().listen((e) {
+        final g = ref.read(currentGameProvider);
+        if (g == null) return;
+        final pid = _humanPlayerId(g);
+        final o = ref.read(currentOrdersProvider);
+        ref.read(currentOrdersProvider.notifier).state =
+            _mergeTrainMilitaryOrdersForPlayer(
+          current: o,
+          game: g,
+          humanPlayerId: pid,
+          newFromDialog: e.orders,
+        );
       }),
     ]);
     _logEvent.d(

--- a/app/lib/features/game/logic/naval_fleet_split_apply.dart
+++ b/app/lib/features/game/logic/naval_fleet_split_apply.dart
@@ -1,0 +1,60 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Returns [game] unchanged if the fleet is missing or [shipInstanceIdsToNewFleet] is empty.
+/// SPEC/ui/naval-units-fleet-management.md.
+Game applyNavalSplitFleet({
+  required Game game,
+  required String humanPlayerId,
+  required String originalFleetId,
+  required List<String> shipInstanceIdsToNewFleet,
+}) {
+  if (shipInstanceIdsToNewFleet.isEmpty) return game;
+
+  Fleet? originalFleet;
+  for (final f in game.worldState.fleets) {
+    if (f.id == originalFleetId) {
+      originalFleet = f;
+      break;
+    }
+  }
+  if (originalFleet == null) return game;
+  final orig = originalFleet;
+
+  final idSet = shipInstanceIdsToNewFleet.toSet();
+  final shipsToNewFleet = orig.ships
+      .where((s) => idSet.contains(s.id))
+      .toList();
+  final remainingShips = orig.ships
+      .where((s) => !idSet.contains(s.id))
+      .toList();
+
+  final allFleetIds = game.worldState.fleets
+      .map((f) => int.tryParse(f.id.replaceAll(RegExp(r'[^0-9]'), '')) ?? 0)
+      .toList();
+  final maxId = allFleetIds.isEmpty
+      ? 0
+      : allFleetIds.reduce((a, b) => a > b ? a : b);
+  final newFleetId = '${maxId + 1}';
+
+  final newFleet = Fleet(
+    id: newFleetId,
+    ownerId: humanPlayerId,
+    seaZoneId: orig.seaZoneId,
+    inPortAtProvinceId: orig.inPortAtProvinceId,
+    regionId: orig.regionId,
+    ships: shipsToNewFleet,
+    mission: FleetMission.none,
+  );
+
+  final updatedOriginal = orig.copyWith(ships: remainingShips);
+
+  final updatedFleets = <Fleet>[
+    ...game.worldState.fleets.where((f) => f.id != orig.id),
+    if (remainingShips.isNotEmpty) updatedOriginal,
+    newFleet,
+  ];
+
+  return game.copyWith(
+    worldState: game.worldState.copyWith(fleets: updatedFleets),
+  );
+}

--- a/app/lib/features/game/widgets/diplomacy_dialogs.dart
+++ b/app/lib/features/game/widgets/diplomacy_dialogs.dart
@@ -197,37 +197,3 @@ class _GrantSubsidyAmountBodyState extends State<_GrantSubsidyAmountBody> {
   }
 }
 
-/// Shows a dialog to enter amount for Grant Aid or Set Subsidy, then calls [onSubmitted].
-void showGrantOrSubsidyDialog({
-  required BuildContext context,
-  required Game game,
-  required String humanPlayerId,
-  required String targetFactionId,
-  required bool isSubsidy,
-  required void Function(int amount) onSubmitted,
-}) {
-  final treasury = _treasuryFor(game, humanPlayerId);
-
-  showDialog<void>(
-    context: context,
-    builder: (ctx) => CtDialogShell(
-      child: _GrantSubsidyAmountBody(
-        title: isSubsidy ? 'Set subsidy' : 'Grant aid',
-        treasury: treasury,
-        isSubsidy: isSubsidy,
-        onCancel: () => Navigator.of(ctx).pop(),
-        onSubmit: (amount) {
-          Navigator.of(ctx).pop();
-          onSubmitted(amount);
-        },
-      ),
-    ),
-  );
-}
-
-int _treasuryFor(Game game, String playerId) {
-  for (final p in game.players) {
-    if (p.id == playerId) return p.treasury;
-  }
-  return 0;
-}

--- a/app/lib/features/game/widgets/diplomacy_panel.dart
+++ b/app/lib/features/game/widgets/diplomacy_panel.dart
@@ -254,8 +254,8 @@ class DiplomacyPanel extends StatelessWidget {
           ...gps.map(
             (r) => _DiplomacyRow(
               data: r,
-              onAction: (order) => _submitOrDialog(context, order),
-              onTap: () => _openDetail(context, r),
+              onAction: _submitOrDialog,
+              onTap: () => _openDetail(r),
             ),
           ),
         ],
@@ -264,8 +264,8 @@ class DiplomacyPanel extends StatelessWidget {
           ...minors.map(
             (r) => _DiplomacyRow(
               data: r,
-              onAction: (order) => _submitOrDialog(context, order),
-              onTap: () => _openDetail(context, r),
+              onAction: _submitOrDialog,
+              onTap: () => _openDetail(r),
             ),
           ),
         ],
@@ -274,8 +274,8 @@ class DiplomacyPanel extends StatelessWidget {
           ...tribes.map(
             (r) => _DiplomacyRow(
               data: r,
-              onAction: (order) => _submitOrDialog(context, order),
-              onTap: () => _openDetail(context, r),
+              onAction: _submitOrDialog,
+              onTap: () => _openDetail(r),
             ),
           ),
         ],
@@ -303,7 +303,7 @@ class DiplomacyPanel extends StatelessWidget {
     );
   }
 
-  void _submitOrDialog(BuildContext context, DiplomaticOrder order) {
+  void _submitOrDialog(DiplomaticOrder order) {
     final pending =
         currentOrders.diplomaticOrdersByPlayerId[humanPlayerId] ?? [];
     final alreadyPending = pending.any(
@@ -319,13 +319,13 @@ class DiplomacyPanel extends StatelessWidget {
         (order.type == DiplomaticOrderType.establishOverture &&
             order.overtureStage != null);
     if (needsParams) {
-      _showDialogForOrder(context, order);
+      _showDialogForOrder(order);
     } else {
-      _showConfirmDialog(context, order);
+      _showConfirmDialog(order);
     }
   }
 
-  void _showConfirmDialog(BuildContext context, DiplomaticOrder order) {
+  void _showConfirmDialog(DiplomaticOrder order) {
     final actionLabel = diplomacyActionLabel(order);
     bus.emit(
       ConfirmDialogEvent(
@@ -353,7 +353,7 @@ class DiplomacyPanel extends StatelessWidget {
     return factionId;
   }
 
-  void _showDialogForOrder(BuildContext context, DiplomaticOrder order) {
+  void _showDialogForOrder(DiplomaticOrder order) {
     if (order.type == DiplomaticOrderType.grantAid ||
         order.type == DiplomaticOrderType.setSubsidy) {
       bus.emit(
@@ -364,7 +364,7 @@ class DiplomacyPanel extends StatelessWidget {
       );
     } else if (order.type == DiplomaticOrderType.establishOverture &&
         order.overtureStage != null) {
-      _showConfirmDialog(context, order);
+      _showConfirmDialog(order);
     }
   }
 
@@ -378,7 +378,7 @@ class DiplomacyPanel extends StatelessWidget {
     );
   }
 
-  void _openDetail(BuildContext context, DiplomacyRowData row) {
+  void _openDetail(DiplomacyRowData row) {
     bus.emit(
       NavigateToRouteEvent(Routes.diplomacyDetail, {
         'game': game,

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -589,55 +589,9 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
         game: widget.game,
         humanPlayerId: widget.humanPlayerId,
         isHomeFleet: row.isHomeFleet,
-        onConfirm: (shipInstanceIds) {
-          _performSplit(original, shipInstanceIds);
-        },
+        bus: widget.bus,
       ),
     );
-  }
-
-  void _performSplit(Fleet originalFleet, List<String> shipInstanceIdsToNew) {
-    if (shipInstanceIdsToNew.isEmpty) return;
-
-    final idSet = shipInstanceIdsToNew.toSet();
-    final shipsToNewFleet = originalFleet.ships
-        .where((s) => idSet.contains(s.id))
-        .toList();
-    final remainingShips = originalFleet.ships
-        .where((s) => !idSet.contains(s.id))
-        .toList();
-
-    final allFleetIds = widget.game.worldState.fleets
-        .map((f) => int.tryParse(f.id.replaceAll(RegExp(r'[^0-9]'), '')) ?? 0)
-        .toList();
-    final maxId = allFleetIds.isEmpty
-        ? 0
-        : allFleetIds.reduce((a, b) => a > b ? a : b);
-    final newFleetId = '${maxId + 1}';
-
-    final newFleet = Fleet(
-      id: newFleetId,
-      ownerId: widget.humanPlayerId,
-      seaZoneId: originalFleet.seaZoneId,
-      inPortAtProvinceId: originalFleet.inPortAtProvinceId,
-      regionId: originalFleet.regionId,
-      ships: shipsToNewFleet,
-      mission: FleetMission.none,
-    );
-
-    final updatedOriginal = originalFleet.copyWith(ships: remainingShips);
-
-    final List<Fleet> updatedFleets = [
-      ...widget.game.worldState.fleets.where((f) => f.id != originalFleet.id),
-      if (remainingShips.isNotEmpty) updatedOriginal,
-      newFleet,
-    ];
-
-    final newGame = widget.game.copyWith(
-      worldState: widget.game.worldState.copyWith(fleets: updatedFleets),
-    );
-
-    widget.bus.emit(NavalFleetsUpdatedEvent(game: newGame));
   }
 
   @override

--- a/app/lib/features/game/widgets/split_fleet_dialog.dart
+++ b/app/lib/features/game/widgets/split_fleet_dialog.dart
@@ -11,15 +11,14 @@ class SplitFleetDialog extends StatelessWidget {
     required this.originalFleet,
     required this.game,
     required this.humanPlayerId,
-    required this.onConfirm,
+    required this.bus,
     required this.isHomeFleet,
   });
 
   final Fleet originalFleet;
   final Game game;
   final String humanPlayerId;
-  /// Instance ids to place on the new fleet (see [ShipInstance.id]).
-  final void Function(List<String> shipInstanceIdsToNewFleet) onConfirm;
+  final AppEventBus bus;
   final bool isHomeFleet;
 
   Map<String, int> _initialOriginalCounts() {
@@ -61,7 +60,13 @@ class SplitFleetDialog extends StatelessWidget {
   void _handleConfirm(Map<String, int> newCounts, BuildContext context) {
     final toMove =
         shipInstancesForTransferCounts(originalFleet.ships, newCounts);
-    onConfirm(toMove.map((s) => s.id).toList());
+    bus.emit(
+      NavalSplitFleetRequestedEvent(
+        humanPlayerId: humanPlayerId,
+        originalFleetId: originalFleet.id,
+        shipInstanceIdsToNewFleet: toMove.map((s) => s.id).toList(),
+      ),
+    );
     Navigator.of(context).pop();
   }
 

--- a/app/lib/features/game/widgets/train_civilians_dialog.dart
+++ b/app/lib/features/game/widgets/train_civilians_dialog.dart
@@ -16,13 +16,13 @@ class TrainCiviliansDialog extends StatefulWidget {
     required this.game,
     required this.humanPlayerId,
     required this.currentOrders,
-    required this.onOrdersChanged,
+    required this.bus,
   });
 
   final Game game;
   final String humanPlayerId;
   final Orders currentOrders;
-  final void Function(List<BuildUnitOrder> orders) onOrdersChanged;
+  final AppEventBus bus;
 
   @override
   State<TrainCiviliansDialog> createState() => _TrainCiviliansDialogState();
@@ -135,7 +135,7 @@ class _TrainCiviliansDialogState extends State<TrainCiviliansDialog> {
       capitalProvinceId: capital,
       isMilitary: false,
     );
-    widget.onOrdersChanged(orders);
+    widget.bus.emit(TrainCivilianBuildOrdersCommittedEvent(orders: orders));
   }
 
   String _techRequiredLabel(String unitType) {

--- a/app/lib/features/game/widgets/train_military_dialog.dart
+++ b/app/lib/features/game/widgets/train_military_dialog.dart
@@ -13,13 +13,13 @@ class TrainMilitaryDialog extends StatefulWidget {
     required this.game,
     required this.humanPlayerId,
     required this.currentOrders,
-    required this.onOrdersChanged,
+    required this.bus,
   });
 
   final Game game;
   final String humanPlayerId;
   final Orders currentOrders;
-  final void Function(List<BuildUnitOrder> orders) onOrdersChanged;
+  final AppEventBus bus;
 
   @override
   State<TrainMilitaryDialog> createState() => _TrainMilitaryDialogState();
@@ -164,7 +164,7 @@ class _TrainMilitaryDialogState extends State<TrainMilitaryDialog> {
       capitalProvinceId: capital,
       isMilitary: true,
     );
-    widget.onOrdersChanged(orders);
+    widget.bus.emit(TrainMilitaryBuildOrdersCommittedEvent(orders: orders));
   }
 
   String _techRequiredLabel(String unitType) {

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -10,6 +10,7 @@ import 'config/themes.dart';
 import 'features/game/widgets/civilian_units_panel.dart';
 import 'features/game/widgets/diplomacy_panel.dart';
 import 'features/game/widgets/military_units_panel.dart';
+import 'features/game/logic/naval_fleet_split_apply.dart';
 import 'features/game/widgets/naval_units_panel.dart';
 import 'features/game/widgets/production_panel.dart';
 import 'features/game/widgets/production_panel_demo_data.dart';
@@ -368,7 +369,7 @@ List<WidgetbookNode> get trainCiviliansDialogDirectories => [
                   game: richGame,
                   humanPlayerId: humanPlayerId,
                   currentOrders: const Orders(),
-                  onOrdersChanged: (_) {},
+                  bus: AppEventBus.create(),
                 ),
               ),
             ),
@@ -403,7 +404,7 @@ List<WidgetbookNode> get trainCiviliansDialogDirectories => [
                   game: noTechGame,
                   humanPlayerId: humanPlayerId,
                   currentOrders: const Orders(),
-                  onOrdersChanged: (_) {},
+                  bus: AppEventBus.create(),
                 ),
               ),
             ),
@@ -437,7 +438,7 @@ List<WidgetbookNode> get trainCiviliansDialogDirectories => [
                   game: poorGame,
                   humanPlayerId: humanPlayerId,
                   currentOrders: const Orders(),
-                  onOrdersChanged: (_) {},
+                  bus: AppEventBus.create(),
                 ),
               ),
             ),
@@ -1254,7 +1255,7 @@ List<WidgetbookNode> get trainMilitaryDialogDirectories => [
                   game: richGame,
                   humanPlayerId: humanPlayerId,
                   currentOrders: const Orders(),
-                  onOrdersChanged: (_) {},
+                  bus: AppEventBus.create(),
                 ),
               ),
             ),
@@ -1282,6 +1283,7 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
   late Game _game;
   late AppEventBus _navalBus;
   StreamSubscription<NavalFleetsUpdatedEvent>? _navalSub;
+  StreamSubscription<NavalSplitFleetRequestedEvent>? _navalSplitSub;
 
   @override
   void initState() {
@@ -1293,11 +1295,21 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
       if (!mounted) return;
       setState(() => _game = e.game);
     });
+    _navalSplitSub = _navalBus.on<NavalSplitFleetRequestedEvent>().listen((e) {
+      final next = applyNavalSplitFleet(
+        game: _game,
+        humanPlayerId: e.humanPlayerId,
+        originalFleetId: e.originalFleetId,
+        shipInstanceIdsToNewFleet: e.shipInstanceIdsToNewFleet,
+      );
+      _navalBus.emit(NavalFleetsUpdatedEvent(game: next));
+    });
   }
 
   @override
   void dispose() {
     _navalSub?.cancel();
+    _navalSplitSub?.cancel();
     super.dispose();
   }
 

--- a/app/lib/widgetbook/catalog.dart
+++ b/app/lib/widgetbook/catalog.dart
@@ -12,6 +12,7 @@ import '../config/themes.dart';
 import '../features/game/widgets/civilian_units_panel.dart';
 import '../features/game/widgets/diplomacy_panel.dart';
 import '../features/game/widgets/military_units_panel.dart';
+import '../features/game/logic/naval_fleet_split_apply.dart';
 import '../features/game/widgets/naval_units_panel.dart';
 import '../features/game/widgets/production_panel.dart';
 import '../features/game/widgets/production_panel_demo_data.dart';
@@ -419,7 +420,7 @@ List<WidgetbookNode> get trainCiviliansDialogDirectories => [
                   game: richGame,
                   humanPlayerId: humanPlayerId,
                   currentOrders: const Orders(),
-                  onOrdersChanged: (_) {},
+                  bus: AppEventBus.create(),
                 ),
               ),
             ),
@@ -454,7 +455,7 @@ List<WidgetbookNode> get trainCiviliansDialogDirectories => [
                   game: noTechGame,
                   humanPlayerId: humanPlayerId,
                   currentOrders: const Orders(),
-                  onOrdersChanged: (_) {},
+                  bus: AppEventBus.create(),
                 ),
               ),
             ),
@@ -488,7 +489,7 @@ List<WidgetbookNode> get trainCiviliansDialogDirectories => [
                   game: poorGame,
                   humanPlayerId: humanPlayerId,
                   currentOrders: const Orders(),
-                  onOrdersChanged: (_) {},
+                  bus: AppEventBus.create(),
                 ),
               ),
             ),
@@ -1362,7 +1363,7 @@ List<WidgetbookNode> get trainMilitaryDialogDirectories => [
                   game: richGame,
                   humanPlayerId: humanPlayerId,
                   currentOrders: const Orders(),
-                  onOrdersChanged: (_) {},
+                  bus: AppEventBus.create(),
                 ),
               ),
             ),
@@ -1390,6 +1391,7 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
   late Game _game;
   late AppEventBus _navalBus;
   StreamSubscription<NavalFleetsUpdatedEvent>? _navalSub;
+  StreamSubscription<NavalSplitFleetRequestedEvent>? _navalSplitSub;
 
   @override
   void initState() {
@@ -1401,11 +1403,21 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
       if (!mounted) return;
       setState(() => _game = e.game);
     });
+    _navalSplitSub = _navalBus.on<NavalSplitFleetRequestedEvent>().listen((e) {
+      final next = applyNavalSplitFleet(
+        game: _game,
+        humanPlayerId: e.humanPlayerId,
+        originalFleetId: e.originalFleetId,
+        shipInstanceIdsToNewFleet: e.shipInstanceIdsToNewFleet,
+      );
+      _navalBus.emit(NavalFleetsUpdatedEvent(game: next));
+    });
   }
 
   @override
   void dispose() {
     _navalSub?.cancel();
+    _navalSplitSub?.cancel();
     super.dispose();
   }
 

--- a/app/test/diplomacy_dialogs_test.dart
+++ b/app/test/diplomacy_dialogs_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   suppressLogsForTests();
 
-  testWidgets('showGrantOrSubsidyDialog submits default valid grant amount',
+  testWidgets('GrantOrSubsidyDialog submits default valid grant amount',
       (WidgetTester tester) async {
     final game = getDebugInitGameResult().game;
     final humanPlayerId = game.players.first.id;
@@ -21,8 +21,12 @@ void main() {
         ? game.players[1].id
         : (game.minorNations.isNotEmpty ? game.minorNations.first.id : 'm1');
 
-    var submittedAmount = 0;
-    var submittedCalled = false;
+    final bus = AppEventBus.create();
+    GrantOrSubsidySubmittedEvent? submitted;
+    final sub = bus.on<GrantOrSubsidySubmittedEvent>().listen((e) {
+      submitted = e;
+    });
+    addTearDown(sub.cancel);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -31,16 +35,15 @@ void main() {
             builder: (context) => ElevatedButton(
               child: const Text('Open'),
               onPressed: () {
-                showGrantOrSubsidyDialog(
+                showDialog<void>(
                   context: context,
-                  game: game,
-                  humanPlayerId: humanPlayerId,
-                  targetFactionId: targetFactionId,
-                  isSubsidy: false,
-                  onSubmitted: (amount) {
-                    submittedAmount = amount;
-                    submittedCalled = true;
-                  },
+                  builder: (ctx) => GrantOrSubsidyDialog(
+                    game: game,
+                    humanPlayerId: humanPlayerId,
+                    targetFactionId: targetFactionId,
+                    isSubsidy: false,
+                    bus: bus,
+                  ),
                 );
               },
             ),
@@ -57,13 +60,14 @@ void main() {
     await tester.tap(find.widgetWithText(CtNinePatchButton, 'Submit'));
     await tester.pumpAndSettle();
 
-    expect(submittedCalled, isTrue);
-    expect(submittedAmount, 1000);
+    expect(submitted, isNotNull);
+    expect(submitted!.amount, 1000);
+    expect(submitted!.isSubsidy, isFalse);
     expect(find.text('Grant aid'), findsNothing);
   });
 
   testWidgets(
-      'showGrantOrSubsidyDialog submit disabled when treasury below minimum',
+      'GrantOrSubsidyDialog submit disabled when treasury below minimum',
       (WidgetTester tester) async {
     final base = getDebugInitGameResult().game;
     final humanPlayerId = base.players.first.id;
@@ -78,7 +82,12 @@ void main() {
       ],
     );
 
+    final bus = AppEventBus.create();
     var submittedCalled = false;
+    final sub = bus.on<GrantOrSubsidySubmittedEvent>().listen((_) {
+      submittedCalled = true;
+    });
+    addTearDown(sub.cancel);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -87,15 +96,15 @@ void main() {
             builder: (context) => ElevatedButton(
               child: const Text('Open'),
               onPressed: () {
-                showGrantOrSubsidyDialog(
+                showDialog<void>(
                   context: context,
-                  game: game,
-                  humanPlayerId: humanPlayerId,
-                  targetFactionId: targetFactionId,
-                  isSubsidy: false,
-                  onSubmitted: (_) {
-                    submittedCalled = true;
-                  },
+                  builder: (ctx) => GrantOrSubsidyDialog(
+                    game: game,
+                    humanPlayerId: humanPlayerId,
+                    targetFactionId: targetFactionId,
+                    isSubsidy: false,
+                    bus: bus,
+                  ),
                 );
               },
             ),
@@ -119,7 +128,7 @@ void main() {
     expect(find.text('Grant aid'), findsOneWidget);
   });
 
-  testWidgets('showGrantOrSubsidyDialog Cancel closes dialog',
+  testWidgets('GrantOrSubsidyDialog Cancel closes dialog',
       (WidgetTester tester) async {
     final game = getDebugInitGameResult().game;
     final humanPlayerId = game.players.first.id;
@@ -127,7 +136,12 @@ void main() {
         ? game.players[1].id
         : (game.minorNations.isNotEmpty ? game.minorNations.first.id : 'm1');
 
+    final bus = AppEventBus.create();
     var submittedCalled = false;
+    final sub = bus.on<GrantOrSubsidySubmittedEvent>().listen((_) {
+      submittedCalled = true;
+    });
+    addTearDown(sub.cancel);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -136,15 +150,15 @@ void main() {
             builder: (context) => ElevatedButton(
               child: const Text('Open'),
               onPressed: () {
-                showGrantOrSubsidyDialog(
+                showDialog<void>(
                   context: context,
-                  game: game,
-                  humanPlayerId: humanPlayerId,
-                  targetFactionId: targetFactionId,
-                  isSubsidy: false,
-                  onSubmitted: (_) {
-                    submittedCalled = true;
-                  },
+                  builder: (ctx) => GrantOrSubsidyDialog(
+                    game: game,
+                    humanPlayerId: humanPlayerId,
+                    targetFactionId: targetFactionId,
+                    isSubsidy: false,
+                    bus: bus,
+                  ),
                 );
               },
             ),

--- a/app/test/naval_units_panel_test.dart
+++ b/app/test/naval_units_panel_test.dart
@@ -14,10 +14,27 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:colonizethis_app/features/game/logic/naval_fleet_split_apply.dart';
 import 'package:colonizethis_app/features/game/widgets/naval_units_panel.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_panel.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
+
+/// Mirrors shell handling of [NavalSplitFleetRequestedEvent] for widget tests.
+StreamSubscription<NavalSplitFleetRequestedEvent> wireNavalSplitForWidgetTest({
+  required AppEventBus bus,
+  required Game Function() gameSnapshot,
+}) {
+  return bus.on<NavalSplitFleetRequestedEvent>().listen((e) {
+    final next = applyNavalSplitFleet(
+      game: gameSnapshot(),
+      humanPlayerId: e.humanPlayerId,
+      originalFleetId: e.originalFleetId,
+      shipInstanceIdsToNewFleet: e.shipInstanceIdsToNewFleet,
+    );
+    bus.emit(NavalFleetsUpdatedEvent(game: next));
+  });
+}
 
 void main() {
   suppressLogsForTests();
@@ -776,6 +793,11 @@ void main() {
           fleetEvent = e;
         });
         addTearDown(sub.cancel);
+        final subSplit = wireNavalSplitForWidgetTest(
+          bus: bus,
+          gameSnapshot: () => game,
+        );
+        addTearDown(subSplit.cancel);
 
         final splittable = game.worldState.fleets
             .where((f) => f.ownerId == humanId && f.shipTypeIds.length >= 2)
@@ -833,8 +855,13 @@ void main() {
         final sub = bus.on<NavalFleetsUpdatedEvent>().listen((e) {
           observedFleetCount.value = e.game.worldState.fleets.length;
         });
+        final subSplit = wireNavalSplitForWidgetTest(
+          bus: bus,
+          gameSnapshot: () => game,
+        );
         addTearDown(() async {
           await sub.cancel();
+          await subSplit.cancel();
           observedFleetCount.dispose();
         });
 

--- a/app/test/split_fleet_dialog_test.dart
+++ b/app/test/split_fleet_dialog_test.dart
@@ -33,7 +33,7 @@ void main() {
     required Fleet fleet,
     required Game game,
     required bool isHomeFleet,
-    required void Function(List<String> ships) onConfirm,
+    required AppEventBus bus,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -48,7 +48,7 @@ void main() {
                     game: game,
                     humanPlayerId: 'gp1',
                     isHomeFleet: isHomeFleet,
-                    onConfirm: onConfirm,
+                    bus: bus,
                   ),
                 );
               });
@@ -84,7 +84,7 @@ void main() {
       fleet: fleet,
       game: _minimalGame(provinces: const []),
       isHomeFleet: false,
-      onConfirm: (_) {},
+      bus: AppEventBus.create(),
     );
 
     expect(find.text('carrack (3)'), findsOneWidget);
@@ -112,7 +112,7 @@ void main() {
         fleet: fleet,
         game: _minimalGame(provinces: const []),
         isHomeFleet: false,
-        onConfirm: (_) {},
+        bus: AppEventBus.create(),
       );
 
       await tester.tap(find.byKey(CtTransferListKeys.leftMoveOne('carrack')));
@@ -143,7 +143,7 @@ void main() {
         fleet: fleet,
         game: _minimalGame(provinces: const []),
         isHomeFleet: false,
-        onConfirm: (_) {},
+        bus: AppEventBus.create(),
       );
 
       await tester.tap(find.byKey(CtTransferListKeys.leftMoveAll('carrack')));
@@ -160,10 +160,16 @@ void main() {
     },
   );
 
-  testWidgets('confirm sends only ships shown on new fleet side', (
+  testWidgets('confirm emits split request with only ships on new fleet side', (
     WidgetTester tester,
   ) async {
-    List<String>? captured;
+    NavalSplitFleetRequestedEvent? captured;
+    final bus = AppEventBus.create();
+    final sub = bus.on<NavalSplitFleetRequestedEvent>().listen((e) {
+      captured = e;
+    });
+    addTearDown(sub.cancel);
+
     final fleet = Fleet(
       id: 'f1d',
       ownerId: 'gp1',
@@ -177,7 +183,7 @@ void main() {
       fleet: fleet,
       game: _minimalGame(provinces: const []),
       isHomeFleet: false,
-      onConfirm: (ships) => captured = ships,
+      bus: bus,
     );
 
     await tester.tap(find.byKey(CtTransferListKeys.leftMoveOne('carrack')));
@@ -185,7 +191,10 @@ void main() {
     await tester.tap(find.text('Confirm Split'));
     await tester.pumpAndSettle();
 
-    expect(captured, [fleet.ships.first.id]);
+    expect(captured, isNotNull);
+    expect(captured!.shipInstanceIdsToNewFleet, [fleet.ships.first.id]);
+    expect(captured!.originalFleetId, fleet.id);
+    expect(captured!.humanPlayerId, 'gp1');
   });
 
   testWidgets('per-row controls: one and all transfers with exact counts', (
@@ -204,7 +213,7 @@ void main() {
       fleet: fleet,
       game: _minimalGame(provinces: const []),
       isHomeFleet: false,
-      onConfirm: (_) {},
+      bus: AppEventBus.create(),
     );
 
     expect(find.text('carrack (2)'), findsOneWidget);
@@ -238,7 +247,7 @@ void main() {
       fleet: fleet,
       game: _minimalGame(provinces: const []),
       isHomeFleet: false,
-      onConfirm: (_) {},
+      bus: AppEventBus.create(),
     );
 
     await tester.tap(find.byKey(CtTransferListKeys.leftMoveOne('fluyte')));
@@ -254,7 +263,13 @@ void main() {
   testWidgets('home fleet can split to zero original ships', (
     WidgetTester tester,
   ) async {
-    List<String>? captured;
+    NavalSplitFleetRequestedEvent? captured;
+    final bus = AppEventBus.create();
+    final sub = bus.on<NavalSplitFleetRequestedEvent>().listen((e) {
+      captured = e;
+    });
+    addTearDown(sub.cancel);
+
     final fleet = Fleet(
       id: 'home_fleet',
       ownerId: 'gp1',
@@ -268,7 +283,7 @@ void main() {
       fleet: fleet,
       game: _minimalGame(provinces: const []),
       isHomeFleet: true,
-      onConfirm: (ships) => captured = ships,
+      bus: bus,
     );
 
     await tester.tap(find.byKey(CtTransferListKeys.leftMoveAll('carrack')));
@@ -280,7 +295,7 @@ void main() {
     await tester.tap(find.text('Confirm Split'));
     await tester.pumpAndSettle();
     expect(captured, isNotNull);
-    expect(captured, hasLength(1));
-    expect(captured!.first, fleet.ships.single.id);
+    expect(captured!.shipInstanceIdsToNewFleet, hasLength(1));
+    expect(captured!.shipInstanceIdsToNewFleet.first, fleet.ships.single.id);
   });
 }

--- a/app/test/train_civilians_dialog_test.dart
+++ b/app/test/train_civilians_dialog_test.dart
@@ -58,7 +58,7 @@ void main() {
     required Game game,
     required String humanPlayerId,
     Orders currentOrders = const Orders(),
-    void Function(List<BuildUnitOrder>)? onOrdersChanged,
+    AppEventBus? bus,
   }) {
     return MaterialApp(
       home: Scaffold(
@@ -66,7 +66,7 @@ void main() {
           game: game,
           humanPlayerId: humanPlayerId,
           currentOrders: currentOrders,
-          onOrdersChanged: onOrdersChanged ?? (_) {},
+          bus: bus ?? AppEventBus.create(),
         ),
       ),
     );
@@ -355,9 +355,14 @@ void main() {
     });
 
     testWidgets(
-      'AC: Closing dialog calls onOrdersChanged with correct orders',
+      'AC: Closing dialog emits TrainCivilianBuildOrdersCommittedEvent with correct orders',
       (WidgetTester tester) async {
         List<BuildUnitOrder>? capturedOrders;
+        final bus = AppEventBus.create();
+        final sub = bus.on<TrainCivilianBuildOrdersCommittedEvent>().listen((e) {
+          capturedOrders = e.orders;
+        });
+        addTearDown(sub.cancel);
 
         final richGame = gameWithResources(treasury: 10000, paper: 100);
 
@@ -373,9 +378,7 @@ void main() {
                         game: richGame,
                         humanPlayerId: humanPlayerId,
                         currentOrders: const Orders(),
-                        onOrdersChanged: (orders) {
-                          capturedOrders = orders;
-                        },
+                        bus: bus,
                       ),
                     );
                   },

--- a/app/test/train_military_dialog_test.dart
+++ b/app/test/train_military_dialog_test.dart
@@ -63,7 +63,7 @@ void main() {
     required Game game,
     required String humanPlayerId,
     Orders currentOrders = const Orders(),
-    void Function(List<BuildUnitOrder>)? onOrdersChanged,
+    AppEventBus? bus,
   }) {
     return MaterialApp(
       home: Scaffold(
@@ -71,7 +71,7 @@ void main() {
           game: game,
           humanPlayerId: humanPlayerId,
           currentOrders: currentOrders,
-          onOrdersChanged: onOrdersChanged ?? (_) {},
+          bus: bus ?? AppEventBus.create(),
         ),
       ),
     );
@@ -120,6 +120,11 @@ void main() {
   ) async {
     List<BuildUnitOrder>? capturedOrders;
     final richGame = gameWithMilitaryResources();
+    final bus = AppEventBus.create();
+    final sub = bus.on<TrainMilitaryBuildOrdersCommittedEvent>().listen((e) {
+      capturedOrders = e.orders;
+    });
+    addTearDown(sub.cancel);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -133,9 +138,7 @@ void main() {
                     game: richGame,
                     humanPlayerId: humanPlayerId,
                     currentOrders: const Orders(),
-                    onOrdersChanged: (orders) {
-                      capturedOrders = orders;
-                    },
+                    bus: bus,
                   ),
                 );
               },

--- a/packages/colonizethis_models/lib/src/app_events.dart
+++ b/packages/colonizethis_models/lib/src/app_events.dart
@@ -13,6 +13,7 @@
 // [OpenPanelEvent] remains for legacy string-id panels until migrated.
 
 import 'game.dart';
+import 'orders.dart';
 
 export 'ai_events.dart' show DialogueEvent, PortraitMoodEvent;
 
@@ -211,6 +212,34 @@ class NavalFleetsUpdatedEvent extends SessionCommandEvent {
   NavalFleetsUpdatedEvent({required this.game});
 
   final Game game;
+}
+
+/// Split fleet dialog confirm: shell applies split and emits [NavalFleetsUpdatedEvent]
+/// (same pipeline as combine). SPEC/program/app-ui-wiring.md.
+class NavalSplitFleetRequestedEvent extends SessionCommandEvent {
+  NavalSplitFleetRequestedEvent({
+    required this.humanPlayerId,
+    required this.originalFleetId,
+    required this.shipInstanceIdsToNewFleet,
+  });
+
+  final String humanPlayerId;
+  final String originalFleetId;
+  final List<String> shipInstanceIdsToNewFleet;
+}
+
+/// Train civilians dialog close: shell merges into current-turn orders draft.
+class TrainCivilianBuildOrdersCommittedEvent extends SessionCommandEvent {
+  TrainCivilianBuildOrdersCommittedEvent({required this.orders});
+
+  final List<BuildUnitOrder> orders;
+}
+
+/// Train military dialog close: shell merges into current-turn orders draft.
+class TrainMilitaryBuildOrdersCommittedEvent extends SessionCommandEvent {
+  TrainMilitaryBuildOrdersCommittedEvent({required this.orders});
+
+  final List<BuildUnitOrder> orders;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Decouples game panels and dialogs from cross-panel callbacks by routing **train civilians/military**, **naval split fleet**, and **diplomacy grant/subsidy** through `AppEventBus` and `AppEventHandlerScope`, per `SPEC/program/app-ui-wiring.md` / `app-event-bus.md`.

## Changes

- **Models:** `NavalSplitFleetRequestedEvent`, `TrainCivilianBuildOrdersCommittedEvent`, `TrainMilitaryBuildOrdersCommittedEvent` in `packages/colonizethis_models`.
- **Logic:** `applyNavalSplitFleet` in `app/lib/features/game/logic/naval_fleet_split_apply.dart` for shell, Widgetbook, and tests without duplicating merge rules.
- **Shell:** `AppEventHandlerScope` listens for the new events and applies game updates; train dialogs receive `bus` instead of `onOrdersChanged`; `SplitFleetDialog` emits split requests; diplomacy drops `showGrantOrSubsidyDialog` in favor of `GrantOrSubsidySubmittedEvent` + `showDialog`.
- **Docs:** SPEC updates for the new event types and wiring.
- **Tests / catalog:** Assertions and harnesses updated; naval panel tests wire split via `applyNavalSplitFleet`.

## Note

`pubspec.lock` was not included (local `meta` resolution differed); no dependency changes were intended.
