### PR TITLE
feat(app): centralize panel/nav/dialog UI via AppEventHandler

### DIFF
--- a/SPEC/program/app-event-bus.md
+++ b/SPEC/program/app-event-bus.md
@@ -15,6 +15,17 @@ A typed event bus lets emitters publish **`AppEvent`** subclasses without depend
 - **Stable handlers, not ephemeral refs:** Panels, side menus, and routes that close before an async action completes must not capture `WidgetRef` or other context that becomes invalid on dispose. Emit a typed **command event** (e.g. `SessionCommandEvent`); a **long-lived** shell listener (e.g. `AppEventHandlerScope`) applies mutations using a stable ref.
 - **No coupling on sibling mount state:** Do not assume another widget is still mounted when handling user actions. The emitter publishes intent; the subscriber owns session state and may outlive any single panel.
 
+### Navigator, `maybePop`, and dialog/panel presentation
+
+**Heavily discouraged** outside **`AppEventHandler`** (and the small set of flows explicitly marked **local by design** in **[app-ui-wiring.md](app-ui-wiring.md)**):
+
+- Calling **`Navigator.of(context).push` / `pushNamed` / `popUntil` / `maybePop`** or **`showDialog` / `showModalBottomSheet`** from empire panels, the map, side menus, or shell to drive **cross-panel, cross-screen, or shell-level** behavior.
+- Using **`maybePop`** to dismiss bottom sheets or routes that **`AppEventHandler`** opened with **`navigatorKey`**, except from **`AppEventHandler`** itself (e.g. handling **`ClosePanelEvent`**) or from documented local-only flows.
+
+**Preferred:** Emit **`UIActionEvent`** subclasses (`NavigateToRouteEvent`, `NavigateToShellEvent`, `ClosePanelEvent`, `OpenDialogEvent`, typed panel opens, `LocateMapTileEvent`, etc.). **`AppEventHandler`** is the choke point that turns those into **`Navigator`** / **`showDialog`** using **`GlobalKey<NavigatorState>`**.
+
+**Local-by-design exception:** **`Navigator.pop`** / **`showDialog`** entirely **inside one widget’s local UX** (same panel subtree, confirm steps, internal pickers; see **Local by design** in app-ui-wiring) remain allowed; they must not replace the bus for cross-cutting actions.
+
 ---
 
 ## Architecture
@@ -154,6 +165,7 @@ When **`logicEventBus`** is set, turn resolution passes it into **`resolveTurnFo
 
 - Given **`AppEventHandler`** is bound with a registered **`train_civilians`** dialog builder, When the system emits **`OpenDialogEvent('train_civilians')`**, Then **`showDialog`** runs and the dialog widget tree is present.
 - Given **`AppEventHandler`** is bound, When the system emits **`OpenPauseMenuPanelEvent`**, Then a modal bottom sheet appears listing Debug log and Resume.
+- Given **`AppEventHandler`** is bound with routes **`shell`** and **`game`** on the stack, When the system emits **`NavigateToShellEvent`**, Then the navigator returns to the **`shell`** route.
 - Given **`AppEventHandler`** is bound, When the system emits **`OpenDialogEvent`** with an unknown **`dialogId`**, Then the handler logs a debug warning and does not throw.
 - Given **`ConfirmDialogEvent`** with **`onResult`**, When the user taps confirm, Then **`onResult(true)`** runs; When the user taps cancel, Then **`onResult(false)`** runs.
 
@@ -179,7 +191,7 @@ When **`logicEventBus`** is set, turn resolution passes it into **`resolveTurnFo
 ### Automated tests (must pass in CI)
 
 - **`app/test/app_event_bus_test.dart`** — delivery, filtering, **`dispose`**, equality for **`UIActionEvent`** / **`UISystemEvent`** / **`GameToUIEvent`** (including new **`GameToUIEvent`** subtypes where applicable).
-- **`app/test/app_event_handler_test.dart`** — **`OpenDialogEvent`**, **`NavigateToRouteEvent`**, **`ConfirmDialogEvent`**, **`OpenPanelEvent`**, **`OpenPauseMenuPanelEvent`**, **`PopNavigationEvent`**, snackbar/overlay callbacks.
+- **`app/test/app_event_handler_test.dart`** — **`OpenDialogEvent`**, **`NavigateToRouteEvent`**, **`NavigateToShellEvent`**, **`ClosePanelEvent`** sequencing, **`ConfirmDialogEvent`**, **`OpenPanelEvent`**, **`OpenPauseMenuPanelEvent`**, **`PopNavigationEvent`**, combat choice (**`CombatModeChosenEvent`**), snackbar/overlay callbacks.
 - **`app/test/game_to_ui_bus_listener_test.dart`** — **`TurnResolutionCompleteEvent`** → provider reload.
 - **`app/test/game_event_bridge_test.dart`** — bridge forwarding of **`GameEvent`** → **`GameToUIEvent`** mappings.
 

--- a/SPEC/program/app-ui-wiring.md
+++ b/SPEC/program/app-ui-wiring.md
@@ -62,8 +62,8 @@ For `train_civilians` and `train_military`, shared order/count orchestration mus
 
 | ID | Widget | Status |
 |----|--------|--------|
-| `quick_battle_result` | `QuickBattleResultDialog` | planned (or local if combat UI stays internal) |
-| `combat_mode_choice` | `CombatModeChoiceDialog` | same |
+| `quick_battle_result` | `QuickBattleResultDialog` | `quickBattleResultDialogId` |
+| `combat_mode_choice` | `CombatModeChoiceDialog` (`CombatModeChosenEvent` on choice) | `combatModeChoiceDialogId` |
 
 **Local by design (no `OpenDialogEvent`):** map display options (`GameMapArea`), tech detail (`TechTreeWidget`), split fleet (`NavalUnitsPanel`), civilian work-target sheet (`CivilianUnitsPanel`), next-turn confirmation (`GameMapArea`), in-game Android back exit confirmation (`GameScreen`), research tech picker (`TechnologyPanel`), **`CtDropdown`** internal picker, **new-game setup progress and error dialogs** after leader confirmation (see **SPEC/ui/game-initializing.md**).
 
@@ -82,6 +82,8 @@ Handled by **`AppEventHandler`** via **`pushNamed`**. Common names:
 | `Routes.technology` | `TechnologyScreen` |
 
 Shell/game entry: **`Routes.shell`**, **`Routes.game`** (see `config/routes.dart`).
+
+**Return to main menu from in-game / victory:** emit **`NavigateToShellEvent`**; **`AppEventHandler`** pops until **`Routes.shell`** or **`pushNamedAndRemoveUntil`** as needed. Do not call **`Navigator.popUntil`** from **`GameScreen`** / victory UI for that flow.
 
 ---
 
@@ -106,7 +108,6 @@ Feature-specific behavior (tabs, panel listeners, orders callbacks, local dialog
 - `grant_or_subsidy`, diplomacy detail nav/back, shell new-game leader + load-game nav, macOS debug log via bus (see [app-event-bus.md](app-event-bus.md) for service emissions).
 
 ### Optional
-- Combat dialogs: bus vs local per **When to use the bus vs local**.
 - New shared panels: prefer **typed** `UIActionEvent` subclasses over **`OpenPanelEvent(panelId)`**.
 
 ---
@@ -123,8 +124,9 @@ Feature-specific behavior (tabs, panel listeners, orders callbacks, local dialog
 ### Typed panels and decoupling
 
 - Given `GameSideMenu` is mounted with a valid `currentGameProvider`, When the user chooses Civilian Units, Then the system emits `OpenCivilianUnitsPanelEvent` (not `showModalBottomSheet` from `GameSideMenu`).
-- Given `CivilianUnitsPanel` is mounted with a bus, When the user taps Train, Then the system emits `OpenDialogEvent(trainCiviliansDialogId)` (panel does not call `showDialog` directly for that action).
-- Given `MilitaryUnitsPanel` is mounted with a bus, When the user taps Train, Then the system emits `OpenDialogEvent(trainMilitaryDialogId)` (panel does not call `showDialog` directly for that action).
+- Given `CivilianUnitsPanel` is mounted with a bus, When the user taps Train, Then the system emits `ClosePanelEvent` and then `OpenDialogEvent(trainCiviliansDialogId)` (panel does not call `showDialog` or `Navigator.maybePop` on the handler-owned sheet for that action).
+- Given `MilitaryUnitsPanel` is mounted with a bus, When the user taps Train, Then the system emits `ClosePanelEvent` and then `OpenDialogEvent(trainMilitaryDialogId)` under the same rules.
+- Given a units sheet should close before the map reacts, When the player triggers locate or work-target selection from that sheet, Then the system emits `ClosePanelEvent` before `LocateMapTileEvent` or `StartCivilianWorkTargetSelectionEvent`; the map widget does not call `Navigator.maybePop` for that teardown.
 - Given `DiplomacyPanel` is mounted with a bus, When the user taps Grant Aid or Set Subsidy, Then the system emits `OpenDialogEvent('grant_or_subsidy')` (panel does not call `showDialog` directly).
 - Given `DiplomacyPanel` is mounted with a bus, When the user taps a faction row, Then the system emits `NavigateToRouteEvent(Routes.diplomacyDetail)` (panel does not call `Navigator.push` directly).
 

--- a/app/lib/core/services/app_event_handler.dart
+++ b/app/lib/core/services/app_event_handler.dart
@@ -27,6 +27,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../config/routes.dart';
 import '../../features/game/flame/game_screen_shared.dart';
 import '../../features/game/widgets/civilian_units_panel.dart';
 import '../../features/game/widgets/military_units_panel.dart';
@@ -94,6 +95,8 @@ class AppEventHandler {
       _showConfirmDialog(event, nav);
     } else if (event is NavigateToRouteEvent) {
       nav?.pushNamed(event.route, arguments: event.arguments);
+    } else if (event is NavigateToShellEvent) {
+      _navigateToShell(nav);
     } else if (event is PopNavigationEvent) {
       nav?.pop();
     } else if (event is OpenPauseMenuPanelEvent) {
@@ -193,10 +196,23 @@ class AppEventHandler {
     if (nav == null) return;
     await showModalBottomSheet<void>(
       context: nav.context,
-      builder: (ctx) => PauseMenuPanel(
-        params: {'onDebugLog': event.onDebugLog, 'onResume': event.onResume},
-      ),
+      builder: (ctx) => PauseMenuPanel(bus: _bus),
     );
+  }
+
+  void _navigateToShell(NavigatorState? nav) {
+    if (nav == null) return;
+    var foundShellRoute = false;
+    nav.popUntil((route) {
+      final matches = route.settings.name == Routes.shell;
+      if (matches) {
+        foundShellRoute = true;
+      }
+      return matches;
+    });
+    if (!foundShellRoute) {
+      nav.pushNamedAndRemoveUntil(Routes.shell, (route) => false);
+    }
   }
 
   Future<void> _openCivilianUnitsPanel(

--- a/app/lib/core/services/app_event_handler_scope.dart
+++ b/app/lib/core/services/app_event_handler_scope.dart
@@ -8,6 +8,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:colonizethis_app/app.dart';
 import 'package:colonizethis_app/features/game/widgets/diplomacy_dialogs.dart';
+import 'package:colonizethis_app/features/game/combat/combat_mode_choice_dialog.dart';
+import 'package:colonizethis_app/features/game/combat/quick_battle_result_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/train_civilians_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/train_military_dialog.dart';
 import 'package:colonizethis_app/features/shell/new_game_leader_selection_dialog.dart';
@@ -29,6 +31,12 @@ const String grantOrSubsidyDialogId = 'grant_or_subsidy';
 
 /// [OpenDialogEvent] id for [NewGameLeaderSelectionDialog]. SPEC/program/app-ui-wiring.md.
 const String newGameLeaderSelectionDialogId = 'new_game_leader_selection';
+
+/// [OpenDialogEvent] id for [CombatModeChoiceDialog]. SPEC/program/app-ui-wiring.md.
+const String combatModeChoiceDialogId = 'combat_mode_choice';
+
+/// [OpenDialogEvent] id for [QuickBattleResultDialog]. SPEC/program/app-ui-wiring.md.
+const String quickBattleResultDialogId = 'quick_battle_result';
 
 final _logShell = appLogger('shell');
 final _logEvent = appLogger('event');
@@ -262,6 +270,30 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
             targetFactionId: targetFactionId,
             isSubsidy: isSubsidy,
             bus: bus,
+          );
+        },
+        combatModeChoiceDialogId: (ctx, params) {
+          final container = ProviderScope.containerOf(ctx);
+          final bus = container.read(appEventBusProvider);
+          final provinceName = params?['provinceName'] as String? ?? '';
+          final isCapitalSiege = params?['isCapitalSiege'] as bool? ?? false;
+          return CombatModeChoiceDialog(
+            bus: bus,
+            provinceName: provinceName,
+            isCapitalSiege: isCapitalSiege,
+          );
+        },
+        quickBattleResultDialogId: (ctx, params) {
+          final result = params?['result'] as QuickBattleResult?;
+          if (result == null) {
+            return const SizedBox.shrink();
+          }
+          final attackerName = params?['attackerName'] as String? ?? 'Attacker';
+          final defenderName = params?['defenderName'] as String? ?? 'Defender';
+          return QuickBattleResultDialog(
+            result: result,
+            attackerName: attackerName,
+            defenderName: defenderName,
           );
         },
       },

--- a/app/lib/features/game/combat/combat_mode_choice_dialog.dart
+++ b/app/lib/features/game/combat/combat_mode_choice_dialog.dart
@@ -5,34 +5,19 @@ import '../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 
 /// Dialog for choosing combat mode (Auto-Resolve vs Quick Battle).
+/// Open via `OpenDialogEvent('combat_mode_choice', params)` registered in `app_event_handler_scope.dart`.
 /// SPEC/program/quick-battle-resolution. Capital sieges force Quick Battle.
 class CombatModeChoiceDialog extends StatelessWidget {
   const CombatModeChoiceDialog({
     super.key,
+    required this.bus,
     required this.provinceName,
     required this.isCapitalSiege,
-    this.defaultMode = CombatMode.autoResolve,
   });
 
+  final AppEventBus bus;
   final String provinceName;
   final bool isCapitalSiege;
-  final CombatMode defaultMode;
-
-  static Future<CombatMode?> show(
-    BuildContext context, {
-    required String provinceName,
-    required bool isCapitalSiege,
-    CombatMode defaultMode = CombatMode.autoResolve,
-  }) {
-    return showDialog<CombatMode>(
-      context: context,
-      builder: (context) => CombatModeChoiceDialog(
-        provinceName: provinceName,
-        isCapitalSiege: isCapitalSiege,
-        defaultMode: defaultMode,
-      ),
-    );
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -58,14 +43,18 @@ class CombatModeChoiceDialog extends StatelessWidget {
             children: [
               if (!isCapitalSiege)
                 CtNinePatchButton(
-                  onPressed: () =>
-                      Navigator.pop(context, CombatMode.autoResolve),
+                  onPressed: () {
+                    bus.emit(const CombatModeChosenEvent(CombatMode.autoResolve));
+                    Navigator.of(context).pop();
+                  },
                   child: const Text('Auto-Resolve'),
                 ),
               if (!isCapitalSiege) const SizedBox(width: 8),
               CtNinePatchButton(
-                onPressed: () =>
-                    Navigator.pop(context, CombatMode.quickBattle),
+                onPressed: () {
+                  bus.emit(const CombatModeChosenEvent(CombatMode.quickBattle));
+                  Navigator.of(context).pop();
+                },
                 child: const Text('Quick Battle'),
               ),
             ],

--- a/app/lib/features/game/combat/quick_battle_result_dialog.dart
+++ b/app/lib/features/game/combat/quick_battle_result_dialog.dart
@@ -4,7 +4,8 @@ import 'package:flutter/material.dart';
 import '../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 
-/// Displays Quick Battle result. SPEC/program/quick-battle-resolution.
+/// Displays Quick Battle result. Open via `OpenDialogEvent('quick_battle_result', params)`.
+/// SPEC/program/quick-battle-resolution.
 class QuickBattleResultDialog extends StatelessWidget {
   const QuickBattleResultDialog({
     super.key,
@@ -16,22 +17,6 @@ class QuickBattleResultDialog extends StatelessWidget {
   final QuickBattleResult result;
   final String attackerName;
   final String defenderName;
-
-  static Future<void> show(
-    BuildContext context, {
-    required QuickBattleResult result,
-    String attackerName = 'Attacker',
-    String defenderName = 'Defender',
-  }) {
-    return showDialog(
-      context: context,
-      builder: (context) => QuickBattleResultDialog(
-        result: result,
-        attackerName: attackerName,
-        defenderName: defenderName,
-      ),
-    );
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -66,7 +51,7 @@ class QuickBattleResultDialog extends StatelessWidget {
           Align(
             alignment: Alignment.centerRight,
             child: CtNinePatchButton(
-              onPressed: () => Navigator.pop(context),
+              onPressed: () => Navigator.of(context).pop(),
               child: const Text('OK'),
             ),
           ),

--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -46,7 +46,7 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
   ({ct_models.Unit unit, String workTarget})? _workTargetSelection;
   Set<String>? _cachedValidTileKeys;
   bool _sideMenuOpen = false;
-  StreamSubscription<ct_models.AppEvent>? _busSubscription;
+  final List<StreamSubscription<dynamic>> _busSubscriptions = [];
 
   /// Base layer display mode for map letters. SPEC/ui/empire-overview.md § Base layer display cycle.
   BaseLayerDisplayMode _baseLayerDisplayMode =
@@ -56,28 +56,31 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
   void initState() {
     super.initState();
     final bus = ref.read(appEventBusProvider);
-    _busSubscription = bus.stream.listen((event) {
-      if (event is ct_models.OpenProvinceDetailPanelEvent) {
+    _busSubscriptions.addAll([
+      bus.on<ct_models.OpenProvinceDetailPanelEvent>().listen((_) {
+        if (!mounted) return;
         setState(() {
           // Town icon tap will be handled by the province panel provider
         });
-      } else if (event is ct_models.LocateMapTileEvent) {
-        _locateTile(event.tileKey, event.regionId, closePanel: event.closeCurrentPanel);
-      } else if (event is ct_models.StartCivilianWorkTargetSelectionEvent) {
-        _startWorkTargetSelection(
-          event.unitId,
-          event.workTarget,
-          closePanel: event.closeCurrentPanel,
-        );
-      } else if (event is ct_models.UnitsPanelClosedEvent) {
+      }),
+      bus.on<ct_models.LocateMapTileEvent>().listen(
+        (e) => _locateTile(e.tileKey, e.regionId),
+      ),
+      bus.on<ct_models.StartCivilianWorkTargetSelectionEvent>().listen(
+        (e) => _startWorkTargetSelection(e.unitId, e.workTarget),
+      ),
+      bus.on<ct_models.UnitsPanelClosedEvent>().listen((_) {
         ref.read(mapProvincePanelProvider.notifier).setSecondaryHighlight(null);
-      }
-    });
+      }),
+    ]);
   }
 
   @override
   void dispose() {
-    _busSubscription?.cancel();
+    for (final s in _busSubscriptions) {
+      s.cancel();
+    }
+    _busSubscriptions.clear();
     super.dispose();
   }
 
@@ -166,7 +169,7 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
     });
   }
 
-  void _locateTile(String tileKey, String regionId, {required bool closePanel}) {
+  void _locateTile(String tileKey, String regionId) {
     ref.read(mapProvincePanelProvider.notifier).setSecondaryHighlight(tileKey);
     setState(() {
       _centerOnTileKey = tileKey;
@@ -176,9 +179,6 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
         _regionIndex = 0;
       }
     });
-    if (closePanel) {
-      Navigator.of(context).maybePop();
-    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) setState(() => _centerOnTileKey = null);
     });
@@ -194,20 +194,13 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
     return null;
   }
 
-  void _startWorkTargetSelection(
-    String unitId,
-    String workTarget, {
-    required bool closePanel,
-  }) {
+  void _startWorkTargetSelection(String unitId, String workTarget) {
     final unit = _findUnitById(unitId);
     if (unit == null) return;
     setState(() {
       _workTargetSelection = (unit: unit, workTarget: workTarget);
       _computeValidTileKeysForSelection();
     });
-    if (closePanel) {
-      Navigator.of(context).maybePop();
-    }
   }
 
   void _onTileSelectedForWork(String tileKey) {

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -7,7 +7,6 @@ import 'package:flutter/material.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../../config/routes.dart';
 import '../../../../providers/app_event_bus_provider.dart';
 import '../../../../providers/game_service_provider.dart';
 import '../../../../providers/games_provider.dart';
@@ -28,15 +27,7 @@ import 'victory_overlay.dart';
 /// Shows the in-game pause menu (Debug log, Resume). SPEC/program/debug-log-viewer.md.
 /// Emits [OpenPauseMenuPanelEvent]; shell event handler shows the bottom sheet.
 void _showPauseMenu(AppEventBus bus) {
-  bus.emit(
-    OpenPauseMenuPanelEvent(
-      onDebugLog: () {
-        bus.emit(const ClosePanelEvent());
-        bus.emit(NavigateToRouteEvent(Routes.debugLog));
-      },
-      onResume: () => bus.emit(const ClosePanelEvent()),
-    ),
-  );
+  bus.emit(const OpenPauseMenuPanelEvent());
 }
 
 Future<bool> _showExitToMainMenuConfirmDialog(BuildContext context) async {
@@ -99,21 +90,6 @@ void _applyTurnResolutionResult(WidgetRef ref, TurnResolutionResult result) {
   }
 }
 
-void _navigateToMainMenu(BuildContext context) {
-  var foundShellRoute = false;
-  final navigator = Navigator.of(context);
-  navigator.popUntil((route) {
-    final matches = route.settings.name == Routes.shell;
-    if (matches) {
-      foundShellRoute = true;
-    }
-    return matches;
-  });
-  if (!foundShellRoute) {
-    navigator.pushNamedAndRemoveUntil(Routes.shell, (route) => false);
-  }
-}
-
 /// Hosts the Flame game canvas or map. When map data exists, shows map + province/sea zone overlay.
 class GameScreen extends ConsumerWidget {
   const GameScreen({super.key});
@@ -167,7 +143,11 @@ class GameScreen extends ConsumerWidget {
           ),
         ],
         if (game != null && victory != null)
-          VictoryOverlay(game: game, victory: victory),
+          VictoryOverlay(
+            game: game,
+            victory: victory,
+            bus: ref.read(appEventBusProvider),
+          ),
       ],
     );
 
@@ -247,7 +227,7 @@ class GameScreen extends ConsumerWidget {
         if (didPop || !context.mounted) return;
         final shouldExit = await _showExitToMainMenuConfirmDialog(context);
         if (!shouldExit || !context.mounted) return;
-        _navigateToMainMenu(context);
+        ref.read(appEventBusProvider).emit(const NavigateToShellEvent());
       },
       child: CtScreenShell(
         title: appL10n(context).game_screenTitle,

--- a/app/lib/features/game/flame/victory_overlay.dart
+++ b/app/lib/features/game/flame/victory_overlay.dart
@@ -10,11 +10,13 @@ class VictoryOverlay extends StatefulWidget {
   const VictoryOverlay({
     required this.game,
     required this.victory,
+    required this.bus,
     super.key,
   });
 
   final ct_models.Game game;
   final ct_models.VictoryState victory;
+  final ct_models.AppEventBus bus;
 
   @override
   State<VictoryOverlay> createState() => _VictoryOverlayState();
@@ -33,6 +35,7 @@ class _VictoryOverlayState extends State<VictoryOverlay> {
           child: VictoryPanel(
             game: widget.game,
             victory: widget.victory,
+            bus: widget.bus,
             onViewFinalState: () => setState(() => _dismissed = true),
           ),
         ),
@@ -45,12 +48,14 @@ class VictoryPanel extends StatelessWidget {
   const VictoryPanel({
     required this.game,
     required this.victory,
+    required this.bus,
     this.onViewFinalState,
     super.key,
   });
 
   final ct_models.Game game;
   final ct_models.VictoryState victory;
+  final ct_models.AppEventBus bus;
   final VoidCallback? onViewFinalState;
 
   @override
@@ -85,9 +90,7 @@ class VictoryPanel extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               children: [
                 CtNinePatchButton(
-                  onPressed: () {
-                    Navigator.of(context).popUntil((route) => route.isFirst);
-                  },
+                  onPressed: () => bus.emit(const ct_models.NavigateToShellEvent()),
                   child: const Text('Return to main menu'),
                 ),
                 const SizedBox(width: 12),

--- a/app/lib/features/game/widgets/civilian_units_panel.dart
+++ b/app/lib/features/game/widgets/civilian_units_panel.dart
@@ -87,7 +87,6 @@ class CivilianUnitsPanel extends StatelessWidget {
     required this.bus,
     this.currentOrders = const Orders(),
     this.availableWorkTargets = const {},
-    this.onAddWorkOrder,
   });
 
   final Game game;
@@ -99,8 +98,6 @@ class CivilianUnitsPanel extends StatelessWidget {
 
   /// Available work targets per unit (computed at turn start). Work targets not in this list are grayed out.
   final Map<String, List<String>> availableWorkTargets;
-
-  final void Function(WorkOrder order)? onAddWorkOrder;
 
   @override
   Widget build(BuildContext context) {
@@ -122,8 +119,10 @@ class CivilianUnitsPanel extends StatelessWidget {
       actions: [
         CtNinePatchButton(
           onPressed: () {
-            Navigator.of(context).maybePop();
-            bus.emit(OpenDialogEvent(trainCiviliansDialogId));
+            bus.emit(const ClosePanelEvent());
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              bus.emit(OpenDialogEvent(trainCiviliansDialogId));
+            });
           },
           child: const Text('Train'),
         ),
@@ -140,7 +139,6 @@ class CivilianUnitsPanel extends StatelessWidget {
               availableWorkTargets: availableWorkTargets,
               humanPlayerId: humanPlayerId,
               bus: bus,
-              onAddWorkOrder: onAddWorkOrder,
             ),
           ),
         ],
@@ -154,7 +152,6 @@ class CivilianUnitsPanel extends StatelessWidget {
               availableWorkTargets: availableWorkTargets,
               humanPlayerId: humanPlayerId,
               bus: bus,
-              onAddWorkOrder: onAddWorkOrder,
             ),
           ),
         ],
@@ -172,7 +169,6 @@ class _UnitRow extends StatelessWidget {
     required this.availableWorkTargets,
     required this.humanPlayerId,
     required this.bus,
-    this.onAddWorkOrder,
   });
 
   final Unit unit;
@@ -181,7 +177,6 @@ class _UnitRow extends StatelessWidget {
   final Map<String, List<String>> availableWorkTargets;
   final String humanPlayerId;
   final AppEventBus bus;
-  final void Function(WorkOrder order)? onAddWorkOrder;
 
   List<WorkOrder> get _pendingForPlayer =>
       currentOrders.workOrdersByPlayerId[humanPlayerId] ?? const [];
@@ -283,12 +278,15 @@ class _UnitRow extends StatelessWidget {
                 onTap: available.contains(target)
                     ? () {
                         Navigator.of(ctx).pop();
-                        bus.emit(
-                          StartCivilianWorkTargetSelectionEvent(
-                            unitId: unit.id,
-                            workTarget: target,
-                          ),
-                        );
+                        bus.emit(const ClosePanelEvent());
+                        WidgetsBinding.instance.addPostFrameCallback((_) {
+                          bus.emit(
+                            StartCivilianWorkTargetSelectionEvent(
+                              unitId: unit.id,
+                              workTarget: target,
+                            ),
+                          );
+                        });
                       }
                     : null,
               ),
@@ -351,13 +349,15 @@ class _UnitRow extends StatelessWidget {
               final tileKey = unit.tileKey!;
               final regionId = Unit.regionIdFromTileKey(tileKey);
               if (regionId == null) return;
-              bus.emit(
-                LocateMapTileEvent(
-                  tileKey: tileKey,
-                  regionId: regionId,
-                  closeCurrentPanel: true,
-                ),
-              );
+              bus.emit(const ClosePanelEvent());
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                bus.emit(
+                  LocateMapTileEvent(
+                    tileKey: tileKey,
+                    regionId: regionId,
+                  ),
+                );
+              });
             },
       trailing: Row(
         mainAxisSize: MainAxisSize.min,

--- a/app/lib/features/game/widgets/military_units_panel.dart
+++ b/app/lib/features/game/widgets/military_units_panel.dart
@@ -271,8 +271,10 @@ class MilitaryUnitsPanel extends StatelessWidget {
       actions: [
         CtNinePatchButton(
           onPressed: () {
-            Navigator.of(context).maybePop();
-            bus.emit(OpenDialogEvent(trainMilitaryDialogId));
+            bus.emit(const ClosePanelEvent());
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              bus.emit(OpenDialogEvent(trainMilitaryDialogId));
+            });
           },
           child: const Text('Train'),
         ),
@@ -292,13 +294,17 @@ class MilitaryUnitsPanel extends StatelessWidget {
                   row: row,
                   onTap: row.tileKey == null
                       ? null
-                      : () => bus.emit(
-                          LocateMapTileEvent(
-                            tileKey: row.tileKey!,
-                            regionId: row.regionId,
-                            closeCurrentPanel: true,
-                          ),
-                        ),
+                      : () {
+                          bus.emit(const ClosePanelEvent());
+                          WidgetsBinding.instance.addPostFrameCallback((_) {
+                            bus.emit(
+                              LocateMapTileEvent(
+                                tileKey: row.tileKey!,
+                                regionId: row.regionId,
+                              ),
+                            );
+                          });
+                        },
                 ),
             if (loc is _SeaZoneLocationNode)
               for (final row in loc.rows)
@@ -306,13 +312,17 @@ class MilitaryUnitsPanel extends StatelessWidget {
                   row: row,
                   onTap: row.tileKey == null
                       ? null
-                      : () => bus.emit(
-                          LocateMapTileEvent(
-                            tileKey: row.tileKey!,
-                            regionId: row.regionId,
-                            closeCurrentPanel: true,
-                          ),
-                        ),
+                      : () {
+                          bus.emit(const ClosePanelEvent());
+                          WidgetsBinding.instance.addPostFrameCallback((_) {
+                            bus.emit(
+                              LocateMapTileEvent(
+                                tileKey: row.tileKey!,
+                                regionId: row.regionId,
+                              ),
+                            );
+                          });
+                        },
                 ),
           ],
         ],

--- a/app/lib/features/game/widgets/pause_menu_panel.dart
+++ b/app/lib/features/game/widgets/pause_menu_panel.dart
@@ -1,11 +1,13 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
-/// Pause menu content for [OpenPanelEvent] id `pause_menu`.
-/// Params: `onDebugLog`, `onResume` as [VoidCallback] (typically emit bus events).
-class PauseMenuPanel extends StatelessWidget {
-  const PauseMenuPanel({super.key, required this.params});
+import '../../../config/routes.dart';
 
-  final Map<String, Object?>? params;
+/// Pause menu content for [OpenPauseMenuPanelEvent]. Emits bus follow-up events only.
+class PauseMenuPanel extends StatelessWidget {
+  const PauseMenuPanel({super.key, required this.bus});
+
+  final AppEventBus bus;
 
   @override
   Widget build(BuildContext context) {
@@ -16,12 +18,15 @@ class PauseMenuPanel extends StatelessWidget {
           ListTile(
             leading: const Icon(Icons.list),
             title: const Text('Debug log'),
-            onTap: () => (params?['onDebugLog'] as VoidCallback?)?.call(),
+            onTap: () {
+              bus.emit(const ClosePanelEvent());
+              bus.emit(const NavigateToRouteEvent(Routes.debugLog));
+            },
           ),
           ListTile(
             leading: const Icon(Icons.play_arrow),
             title: const Text('Resume'),
-            onTap: () => (params?['onResume'] as VoidCallback?)?.call(),
+            onTap: () => bus.emit(const ClosePanelEvent()),
           ),
         ],
       ),

--- a/app/test/app_event_bus_test.dart
+++ b/app/test/app_event_bus_test.dart
@@ -152,8 +152,25 @@ void main() {
       );
     });
 
-    test('OpenPauseMenuPanelEvent equal when both use null callbacks', () {
+    test('OpenPauseMenuPanelEvent equality', () {
       expect(const OpenPauseMenuPanelEvent(), const OpenPauseMenuPanelEvent());
+    });
+
+    test('NavigateToShellEvent equality', () {
+      expect(const NavigateToShellEvent(), const NavigateToShellEvent());
+    });
+
+    test('CombatModeChosenEvent equality', () {
+      expect(
+        const CombatModeChosenEvent(CombatMode.quickBattle),
+        const CombatModeChosenEvent(CombatMode.quickBattle),
+      );
+    });
+
+    test('LocateMapTileEvent locates tile only (no panel close on event)', () {
+      const e = LocateMapTileEvent(tileKey: 'oldWorld|1,1', regionId: 'oldWorld');
+      expect(e.tileKey, 'oldWorld|1,1');
+      expect(e.regionId, 'oldWorld');
     });
 
     test('StartTargetSelectionEvent equal for same params', () {

--- a/app/test/app_event_handler_test.dart
+++ b/app/test/app_event_handler_test.dart
@@ -5,7 +5,10 @@ import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:colonizethis_app/config/route_paths.dart';
 import 'package:colonizethis_app/core/services/app_event_handler.dart';
+import 'package:colonizethis_app/features/game/combat/combat_mode_choice_dialog.dart';
+import 'package:colonizethis_app/features/game/combat/quick_battle_result_dialog.dart';
 
 void main() {
   suppressLogsForTests();
@@ -168,12 +171,7 @@ void main() {
           home: Scaffold(
             body: Builder(
               builder: (context) => TextButton(
-                onPressed: () => bus.emit(
-                  const OpenPauseMenuPanelEvent(
-                    onDebugLog: null,
-                    onResume: null,
-                  ),
-                ),
+                onPressed: () => bus.emit(const OpenPauseMenuPanelEvent()),
                 child: const Text('open'),
               ),
             ),
@@ -362,6 +360,157 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(received?.overlayId, 'loading_spinner');
+    });
+
+    testWidgets('NavigateToShellEvent pops until shell route', (tester) async {
+      handler.bind();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navKey,
+          initialRoute: RoutePaths.shell,
+          onGenerateRoute: (settings) {
+            if (settings.name == RoutePaths.game) {
+              return MaterialPageRoute<void>(
+                settings: settings,
+                builder: (_) => const Text('game_layer'),
+              );
+            }
+            if (settings.name == RoutePaths.shell) {
+              return MaterialPageRoute<void>(
+                settings: settings,
+                builder: (_) => const Text('shell_layer'),
+              );
+            }
+            return null;
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('shell_layer'), findsOneWidget);
+
+      navKey.currentState!.pushNamed(RoutePaths.game);
+      await tester.pumpAndSettle();
+      expect(find.text('game_layer'), findsOneWidget);
+
+      bus.emit(const NavigateToShellEvent());
+      await tester.pumpAndSettle();
+
+      expect(find.text('game_layer'), findsNothing);
+      expect(find.text('shell_layer'), findsOneWidget);
+    });
+
+    testWidgets(
+      'ClosePanelEvent then OpenDialogEvent opens dialog (handler ordering)',
+      (tester) async {
+        handler.bind();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            navigatorKey: navKey,
+            home: const Scaffold(body: Text('home')),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        bus.emit(const ClosePanelEvent());
+        bus.emit(const OpenDialogEvent('test_dialog', {'id': 'after_close'}));
+        await tester.pumpAndSettle();
+
+        expect(find.text('dialog:after_close'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'CombatModeChoiceDialog opened via OpenDialog emits CombatModeChosenEvent',
+      (tester) async {
+        handler = AppEventHandler(
+          bus: bus,
+          navigatorKey: navKey,
+          dialogBuilders: {
+            'combat_mode_choice': (ctx, params) => CombatModeChoiceDialog(
+              bus: bus,
+              provinceName: params?['provinceName'] as String? ?? '',
+              isCapitalSiege: params?['isCapitalSiege'] as bool? ?? false,
+            ),
+          },
+        );
+        handler.bind();
+
+        CombatModeChosenEvent? chosen;
+        bus.on<CombatModeChosenEvent>().listen((e) => chosen = e);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            navigatorKey: navKey,
+            home: Builder(
+              builder: (ctx) => TextButton(
+                onPressed: () => bus.emit(
+                  const OpenDialogEvent('combat_mode_choice', {
+                    'provinceName': 'TestProv',
+                    'isCapitalSiege': false,
+                  }),
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('open'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Quick Battle'));
+        await tester.pumpAndSettle();
+
+        expect(chosen?.mode, CombatMode.quickBattle);
+      },
+    );
+
+    testWidgets('OpenDialogEvent quick_battle_result shows dialog', (
+      tester,
+    ) async {
+      handler = AppEventHandler(
+        bus: bus,
+        navigatorKey: navKey,
+        dialogBuilders: {
+          'quick_battle_result': (ctx, params) => QuickBattleResultDialog(
+            result: params!['result'] as QuickBattleResult,
+            attackerName: 'A',
+            defenderName: 'D',
+          ),
+        },
+      );
+      handler.bind();
+
+      final qb = QuickBattleResult(
+        winner: QuickBattleWinner.attacker,
+        attackerCasualties: const [],
+        defenderCasualties: const [],
+        provinceFlips: false,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navKey,
+          home: Builder(
+            builder: (ctx) => TextButton(
+              onPressed: () => bus.emit(
+                OpenDialogEvent('quick_battle_result', {'result': qb}),
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Battle Result'), findsOneWidget);
+      expect(find.textContaining('A wins'), findsOneWidget);
     });
   });
 }

--- a/app/test/civilian_units_panel_test.dart
+++ b/app/test/civilian_units_panel_test.dart
@@ -29,12 +29,16 @@ class _EventHandlingWrapper extends StatefulWidget {
 }
 
 class _EventHandlingWrapperState extends State<_EventHandlingWrapper> {
-  StreamSubscription? _sub;
+  StreamSubscription? _confirmSub;
+  StreamSubscription? _closeSub;
 
   @override
   void initState() {
     super.initState();
-    _sub = widget.bus.on<ConfirmDialogEvent>().listen((event) async {
+    _closeSub = widget.bus.on<ClosePanelEvent>().listen((_) {
+      widget.navigatorKey.currentState?.maybePop();
+    });
+    _confirmSub = widget.bus.on<ConfirmDialogEvent>().listen((event) async {
       final nav = widget.navigatorKey.currentState;
       if (nav == null) return;
       final result = await showDialog<bool>(
@@ -60,7 +64,8 @@ class _EventHandlingWrapperState extends State<_EventHandlingWrapper> {
 
   @override
   void dispose() {
-    _sub?.cancel();
+    _confirmSub?.cancel();
+    _closeSub?.cancel();
     super.dispose();
   }
 
@@ -88,7 +93,6 @@ void main() {
     Orders currentOrders = const Orders(),
     Map<String, List<String>> availableWorkTargets = const {},
     AppEventBus? bus,
-    void Function(WorkOrder order)? onAddWorkOrder,
   }) {
     final resolvedBus = bus ?? AppEventBus.create();
     final navigatorKey = GlobalKey<NavigatorState>();
@@ -104,7 +108,6 @@ void main() {
             currentOrders: currentOrders,
             availableWorkTargets: availableWorkTargets,
             bus: resolvedBus,
-            onAddWorkOrder: onAddWorkOrder,
           ),
         ),
       ),
@@ -286,6 +289,7 @@ void main() {
       final trainButton = find.text('Train');
       expect(trainButton, findsOneWidget);
       await tester.tap(trainButton);
+      await tester.pump();
       await tester.pumpAndSettle();
 
       expect(openDialogEvent, isNotNull);

--- a/app/test/military_units_panel_test.dart
+++ b/app/test/military_units_panel_test.dart
@@ -158,6 +158,7 @@ void main() {
       final listTiles = find.byType(ListTile);
       if (listTiles.evaluate().isEmpty) return;
       await tester.tap(listTiles.first);
+      await tester.pump();
       await tester.pumpAndSettle();
 
       expect(locateEvent, isNotNull);
@@ -197,10 +198,32 @@ void main() {
       final trainButton = find.text('Train');
       expect(trainButton, findsOneWidget);
       await tester.tap(trainButton);
+      await tester.pump();
       await tester.pumpAndSettle();
 
       expect(openDialogEvent, isNotNull);
       expect(openDialogEvent!.dialogId, trainMilitaryDialogId);
+    });
+
+    testWidgets(
+      'AC: Tapping locate emits ClosePanelEvent before LocateMapTileEvent',
+      (WidgetTester tester) async {
+      final bus = AppEventBus.create();
+      final sequence = <Type>[];
+      bus.stream.listen((e) => sequence.add(e.runtimeType));
+
+      await tester.pumpWidget(
+        buildPanel(game: game, humanPlayerId: humanPlayerIdWithUnits, bus: bus),
+      );
+      await tester.pumpAndSettle();
+
+      final listTiles = find.byType(ListTile);
+      if (listTiles.evaluate().isEmpty) return;
+      await tester.tap(listTiles.first);
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(sequence.indexOf(ClosePanelEvent), lessThan(sequence.indexOf(LocateMapTileEvent)));
     });
 
     testWidgets('panel is scrollable', (WidgetTester tester) async {

--- a/app/test/train_civilians_dialog_test.dart
+++ b/app/test/train_civilians_dialog_test.dart
@@ -496,6 +496,7 @@ void main() {
         await tester.pumpAndSettle();
 
         await tester.tap(find.text('Train'));
+        await tester.pump();
         await tester.pumpAndSettle();
 
         expect(find.byType(TrainCiviliansDialog), findsOneWidget);

--- a/app/test/victory_overlay_test.dart
+++ b/app/test/victory_overlay_test.dart
@@ -10,14 +10,22 @@ void main() {
 
   late ct_models.Game game;
   late String winnerPlayerId;
+  late ct_models.AppEventBus victoryTestBus;
 
   setUp(() {
+    ct_models.AppEventBus.reset();
+    victoryTestBus = ct_models.AppEventBus.create();
     game = getDebugInitGameResult().game;
     winnerPlayerId = game.players.first.id;
   });
 
+  tearDown(() {
+    ct_models.AppEventBus.reset();
+  });
+
   Widget buildVictoryRoute({
     required ct_models.VictoryState victory,
+    ct_models.AppEventBus? bus,
   }) {
     return Scaffold(
       body: Stack(
@@ -25,6 +33,7 @@ void main() {
           VictoryOverlay(
             game: game,
             victory: victory,
+            bus: bus ?? victoryTestBus,
           ),
         ],
       ),
@@ -71,7 +80,8 @@ void main() {
     expect(find.text('Military victory'), findsNothing);
   });
 
-  testWidgets('VictoryOverlay "Return to main menu" pops to first route',
+  testWidgets(
+      'VictoryOverlay "Return to main menu" emits NavigateToShellEvent',
       (WidgetTester tester) async {
     final victory = ct_models.VictoryState(
       winnerPlayerId: winnerPlayerId,
@@ -79,29 +89,23 @@ void main() {
       turnNumber: 3,
     );
 
-    final navigatorKey = GlobalKey<NavigatorState>();
+    ct_models.NavigateToShellEvent? emitted;
+    final sub = victoryTestBus.on<ct_models.NavigateToShellEvent>().listen(
+      (e) => emitted = e,
+    );
+    addTearDown(sub.cancel);
+
     await tester.pumpWidget(
       MaterialApp(
-        navigatorKey: navigatorKey,
-        initialRoute: '/',
-        routes: {
-          '/': (_) => const Scaffold(body: Text('Home')),
-          '/victory': (_) => buildVictoryRoute(victory: victory),
-        },
+        home: buildVictoryRoute(victory: victory, bus: victoryTestBus),
       ),
     );
     await tester.pumpAndSettle();
 
-    navigatorKey.currentState!.pushNamed('/victory');
-    await tester.pumpAndSettle();
-    expect(find.text('Home'), findsNothing);
-    expect(find.text('Military victory'), findsOneWidget);
-
     await tester.tap(find.text('Return to main menu'));
-    await tester.pumpAndSettle();
+    await tester.pump();
 
-    expect(find.text('Home'), findsOneWidget);
-    expect(find.text('Military victory'), findsNothing);
+    expect(emitted, isA<ct_models.NavigateToShellEvent>());
   });
 }
 

--- a/packages/colonizethis_models/lib/src/app_events.dart
+++ b/packages/colonizethis_models/lib/src/app_events.dart
@@ -12,6 +12,7 @@
 // Panel requests: prefer typed subclasses below (SPEC/program/app-ui-wiring.md).
 // [OpenPanelEvent] remains for legacy string-id panels until migrated.
 
+import 'combat_mode.dart';
 import 'game.dart';
 
 export 'ai_events.dart' show DialogueEvent, PortraitMoodEvent;
@@ -65,6 +66,12 @@ class PopNavigationEvent extends UIActionEvent {
   const PopNavigationEvent();
 }
 
+/// Return to the main menu shell, clearing the game route stack.
+/// Handled only by the app-layer event handler (`AppEventHandler`). SPEC/program/app-ui-wiring.md.
+class NavigateToShellEvent extends UIActionEvent {
+  const NavigateToShellEvent();
+}
+
 /// Request to open a side panel or overlay.
 class OpenPanelEvent extends UIActionEvent {
   const OpenPanelEvent(this.panelId, [this.params]);
@@ -78,11 +85,9 @@ class ClosePanelEvent extends UIActionEvent {
 }
 
 /// In-game pause menu bottom sheet. Handled by the shell-level event handler (app layer).
+/// Menu actions emit [ClosePanelEvent] / [NavigateToRouteEvent]; no callbacks on this event.
 class OpenPauseMenuPanelEvent extends UIActionEvent {
-  const OpenPauseMenuPanelEvent({this.onDebugLog, this.onResume});
-
-  final void Function()? onDebugLog;
-  final void Function()? onResume;
+  const OpenPauseMenuPanelEvent();
 }
 
 /// Civilian units bottom sheet. App handler supplies [Game] / orders from Riverpod.
@@ -102,30 +107,28 @@ class OpenNavalUnitsPanelEvent extends UIActionEvent {
   const OpenNavalUnitsPanelEvent();
 }
 
-/// Request to center/highlight a map tile, optionally dismissing the active panel.
+/// Request to center/highlight a map tile. To close a units sheet first, emit [ClosePanelEvent]
+/// before this event (same synchronous turn or after [SchedulerBinding] frame); do not dismiss sheets from the map widget.
 class LocateMapTileEvent extends UIActionEvent {
   const LocateMapTileEvent({
     required this.tileKey,
     required this.regionId,
-    this.closeCurrentPanel = false,
   });
 
   final String tileKey;
   final String regionId;
-  final bool closeCurrentPanel;
 }
 
 /// Request to start civilian target-selection mode from the units panel.
+/// Emit [ClosePanelEvent] first when the civilian units sheet should close.
 class StartCivilianWorkTargetSelectionEvent extends UIActionEvent {
   const StartCivilianWorkTargetSelectionEvent({
     required this.unitId,
     required this.workTarget,
-    this.closeCurrentPanel = true,
   });
 
   final String unitId;
   final String workTarget;
-  final bool closeCurrentPanel;
 }
 
 /// Emitted when a typed units panel route is dismissed.
@@ -152,6 +155,13 @@ class StartTargetSelectionEvent extends UIActionEvent {
 /// Cancel any active target-selection mode.
 class CancelTargetSelectionEvent extends UIActionEvent {
   const CancelTargetSelectionEvent();
+}
+
+/// Emitted when the user chooses auto-resolve or quick battle in [CombatModeChoiceDialog].
+class CombatModeChosenEvent extends UIActionEvent {
+  const CombatModeChosenEvent(this.mode);
+
+  final CombatMode mode;
 }
 
 /// Request to open the province/sea zone detail overlay for [provinceId].

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -497,10 +497,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
Implements the app-layer decoupling described in #1398.

## Summary

- Cross-cutting navigation and sheet/dialog presentation go through `AppEventBus` → `AppEventHandler` (only the handler uses `Navigator` / `maybePop` for those flows).
- New events: `NavigateToShellEvent`, `CombatModeChosenEvent`; `OpenPauseMenuPanelEvent` is parameterless; `LocateMapTileEvent` / `StartCivilianWorkTargetSelectionEvent` no longer carry “close panel” — emitters send `ClosePanelEvent` first (with post-frame follow-ups where needed).
- `GameMapArea` uses typed `bus.on<T>().listen()` subscriptions and no longer pops panels.
- `PauseMenuPanel` and victory “main menu” emit typed events instead of closures or inline `Navigator` chains.
- Combat choice / quick-battle result dialogs are opened via the handler registry; mode choice emits `CombatModeChosenEvent` then pops locally.
- SPEC updates in `app-event-bus.md` and `app-ui-wiring.md` discourage direct `Navigator` / `maybePop` / ad-hoc dialog/sheet open-close outside the handler.
- Tests extended for handler sequencing, shell navigation, combat dialogs, and panel locate/train event ordering.

Closes #1398.