### PR TITLE
test: widget coverage for issue #1398 (app event bus / panel flows)

### DIFF
--- a/app/test/app_event_handler_test.dart
+++ b/app/test/app_event_handler_test.dart
@@ -465,6 +465,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(chosen?.mode, CombatMode.quickBattle);
+        expect(find.text('Combat at TestProv'), findsNothing);
       },
     );
 

--- a/app/test/civilian_units_panel_test.dart
+++ b/app/test/civilian_units_panel_test.dart
@@ -297,6 +297,95 @@ void main() {
     });
 
     testWidgets(
+      'AC: tapping civilian row emits ClosePanelEvent before LocateMapTileEvent',
+      (WidgetTester tester) async {
+        final bus = AppEventBus.create();
+        final sequence = <Type>[];
+        bus.stream.listen((e) => sequence.add(e.runtimeType));
+
+        await tester.pumpWidget(
+          buildPanel(game: game, humanPlayerId: humanPlayerIdWithUnits, bus: bus),
+        );
+        await tester.pumpAndSettle();
+
+        final listTiles = find.byType(ListTile);
+        if (listTiles.evaluate().isEmpty) return;
+        await tester.tap(listTiles.first);
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        expect(
+          sequence.indexOf(ClosePanelEvent),
+          lessThan(sequence.indexOf(LocateMapTileEvent)),
+        );
+      },
+    );
+
+    testWidgets(
+      'AC: assign target emits ClosePanelEvent before StartCivilianWorkTargetSelectionEvent',
+      (WidgetTester tester) async {
+        final bus = AppEventBus.create();
+        final sequence = <Type>[];
+        bus.stream.listen((e) => sequence.add(e.runtimeType));
+
+        final units = [
+          ...game.worldState.oldWorld.units,
+          ...game.worldState.newWorld.units,
+        ];
+        final idleCivilians = units.where(
+          (u) =>
+              u.ownerId == humanPlayerIdWithUnits &&
+              u.tileKey != null &&
+              _isCivilian(u) &&
+              u.currentWork == null,
+        );
+        if (idleCivilians.isEmpty) return;
+
+        final availableWorkTargets = <String, List<String>>{};
+        for (final u in idleCivilians) {
+          final allowed = workOrderTargetsByUnitType[u.type] ?? const <String>[];
+          if (allowed.isNotEmpty) {
+            availableWorkTargets[u.id] = [allowed.first];
+          }
+        }
+        if (availableWorkTargets.isEmpty) return;
+
+        await tester.pumpWidget(
+          buildPanel(
+            game: game,
+            humanPlayerId: humanPlayerIdWithUnits,
+            bus: bus,
+            availableWorkTargets: availableWorkTargets,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final assignButton = find.text('Assign');
+        if (assignButton.evaluate().isEmpty) return;
+        await tester.tap(assignButton.first);
+        await tester.pumpAndSettle();
+
+        final enabledTargetTile = find.descendant(
+          of: find.byType(BottomSheet),
+          matching: find.byWidgetPredicate(
+            (w) => w is ListTile && w.enabled == true,
+          ),
+        );
+        if (enabledTargetTile.evaluate().isEmpty) return;
+        final targetTile = tester.widget<ListTile>(enabledTargetTile.first);
+        expect(targetTile.onTap, isNotNull);
+        targetTile.onTap!();
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        expect(
+          sequence.indexOf(ClosePanelEvent),
+          lessThan(sequence.indexOf(StartCivilianWorkTargetSelectionEvent)),
+        );
+      },
+    );
+
+    testWidgets(
       'Cancel on pending row shows confirm dialog; Yes emits RemovePendingWorkOrderRequestedEvent',
       (WidgetTester tester) async {
         final units = [

--- a/app/test/game_map_area_test.dart
+++ b/app/test/game_map_area_test.dart
@@ -1,0 +1,97 @@
+import 'package:colonizethis_app/features/game/flame/game_map_area.dart';
+import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_app/widgets/debug_init_game.dart';
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _MapAreaHost extends StatefulWidget {
+  const _MapAreaHost({required this.game, required this.mapViewData});
+
+  final Game game;
+  final InitGameMapViewData mapViewData;
+
+  @override
+  State<_MapAreaHost> createState() => _MapAreaHostState();
+}
+
+class _MapAreaHostState extends State<_MapAreaHost> {
+  bool _showMapArea = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: [
+          TextButton(
+            onPressed: () => setState(() => _showMapArea = false),
+            child: const Text('dispose-map-area'),
+          ),
+          Expanded(
+            child: _showMapArea
+                ? GameMapArea(game: widget.game, mapViewData: widget.mapViewData)
+                : const SizedBox.shrink(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+void main() {
+  suppressLogsForTests();
+
+  testWidgets('GameMapArea dispose cancels AppEventBus subscriptions', (
+    WidgetTester tester,
+  ) async {
+    final init = getDebugInitGameResult();
+    final game = init.game;
+    final mapViewData = init.mapViewData;
+    final bus = AppEventBus.create();
+    final sampleUnitId = game.worldState.oldWorld.units.isNotEmpty
+        ? game.worldState.oldWorld.units.first.id
+        : game.worldState.newWorld.units.isNotEmpty
+        ? game.worldState.newWorld.units.first.id
+        : 'missing-unit-id';
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appEventBusProvider.overrideWith((ref) {
+            return bus;
+          }),
+          currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+        ],
+        child: MaterialApp(
+          home: _MapAreaHost(game: game, mapViewData: mapViewData),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('dispose-map-area'));
+    await tester.pumpAndSettle();
+
+    bus.emit(
+      const LocateMapTileEvent(
+        tileKey: 'oldWorld|dummy|0|0',
+        regionId: 'oldWorld',
+      ),
+    );
+    bus.emit(
+      StartCivilianWorkTargetSelectionEvent(
+        unitId: sampleUnitId,
+        workTarget: 'explore',
+      ),
+    );
+    bus.emit(const UnitsPanelClosedEvent('civilian'));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    bus.dispose();
+  });
+}

--- a/app/test/pause_menu_panel_test.dart
+++ b/app/test/pause_menu_panel_test.dart
@@ -1,0 +1,60 @@
+import 'package:colonizethis_app/config/routes.dart';
+import 'package:colonizethis_app/features/game/widgets/pause_menu_panel.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  testWidgets('Debug log emits ClosePanelEvent then NavigateToRouteEvent', (
+    WidgetTester tester,
+  ) async {
+    final bus = AppEventBus.create();
+    final events = <AppEvent>[];
+    bus.stream.listen(events.add);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PauseMenuPanel(bus: bus),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Debug log'));
+    await tester.pumpAndSettle();
+
+    expect(events.length, greaterThanOrEqualTo(2));
+    final closeIndex = events.indexWhere((e) => e is ClosePanelEvent);
+    final navIndex = events.indexWhere(
+      (e) => e is NavigateToRouteEvent && e.route == Routes.debugLog,
+    );
+    expect(closeIndex, isNonNegative);
+    expect(navIndex, isNonNegative);
+    expect(closeIndex, lessThan(navIndex));
+  });
+
+  testWidgets('Resume emits only ClosePanelEvent', (WidgetTester tester) async {
+    final bus = AppEventBus.create();
+    final events = <AppEvent>[];
+    bus.stream.listen(events.add);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PauseMenuPanel(bus: bus),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Resume'));
+    await tester.pumpAndSettle();
+
+    expect(events, hasLength(1));
+    expect(events.single, isA<ClosePanelEvent>());
+  });
+}


### PR DESCRIPTION
## Summary

Adds widget tests that map to the acceptance criteria in [#1398](https://github.com/waigore/colonizethisv3/issues/1398): event ordering for civilian units panel (locate + work target), `PauseMenuPanel` bus-only follow-ups, `GameMapArea` subscription teardown after dispose, and combat mode dialog dismissal after choice.

## Changes

- `app/test/civilian_units_panel_test.dart` — `ClosePanelEvent` before `LocateMapTileEvent` / `StartCivilianWorkTargetSelectionEvent`
- `app/test/pause_menu_panel_test.dart` — Debug log / Resume emission order and shape
- `app/test/game_map_area_test.dart` — no exceptions when bus events fire after map area is disposed
- `app/test/app_event_handler_test.dart` — assert combat choice dialog closes after tap

## How tested

```
cd app && flutter test test/civilian_units_panel_test.dart test/pause_menu_panel_test.dart test/game_map_area_test.dart test/app_event_handler_test.dart
```

Refs #1398

Made with [Cursor](https://cursor.com)