### PR TITLE
Fix town-rule-only extraction cap bug (issue #1400)

### DIFF
--- a/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
+++ b/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
@@ -43,9 +43,7 @@ Map<String, ExtractionTotals> computeExtraction({
       continue;
     }
     final pathTransportCap = cr!.pathTransportCap;
-    final roadRuleTiles = cr.connectedByRoadRule.isEmpty
-        ? cr.connected
-        : cr.connectedByRoadRule;
+    final roadRuleTiles = cr.connectedByRoadRule;
     final portTileKeys = game.worldState.portsByProvinceSeaboard.values.toSet();
     final cap = player.capitalTile;
     final capitalRegionId = cap?.regionId;
@@ -102,8 +100,7 @@ Map<String, ExtractionTotals> computeExtraction({
 
       final production =
           (improvementLevel < techCap ? improvementLevel : techCap).clamp(0, 4);
-      var effective =
-          (production < pathCap ? production : pathCap).clamp(0, 4);
+      var effective = (production < pathCap ? production : pathCap).clamp(0, 4);
 
       final isCapitalProvince = provinceId == player.capitalProvinceId;
       final usesRoadRule = roadRuleTiles.contains(tileKey);

--- a/packages/colonizethis_logic/test/resource_extractor_test.dart
+++ b/packages/colonizethis_logic/test/resource_extractor_test.dart
@@ -20,7 +20,12 @@ void main() {
         grid: grid,
         resourceGrid: resourceGrid,
       );
-      final cap = CapitalTile(regionId: 'oldWorld', provinceId: 'p1', x: 0, y: 0);
+      final cap = CapitalTile(
+        regionId: 'oldWorld',
+        provinceId: 'p1',
+        x: 0,
+        y: 0,
+      );
       final tileState = TileMapState()
           .setImprovement('oldWorld|p1|0|0', 3)
           .setImprovement('oldWorld|p1|1|0', 2)
@@ -39,9 +44,11 @@ void main() {
         id: 'g1',
         worldState: WorldState(
           turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
-          oldWorld: RegionData(provinces: [
-            Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
-          ]),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
+            ],
+          ),
           newWorld: const RegionData(),
           tileState: tileState,
         ),
@@ -49,11 +56,7 @@ void main() {
       );
       final connectivity = {
         'pl1': ConnectivityResult(
-          connected: {
-            'oldWorld|p1|0|0',
-            'oldWorld|p1|1|0',
-            'oldWorld|p1|0|1',
-          },
+          connected: {'oldWorld|p1|0|0', 'oldWorld|p1|1|0', 'oldWorld|p1|0|1'},
         ),
       };
       final result = computeExtraction(
@@ -71,12 +74,16 @@ void main() {
     });
 
     test('effective extraction capped by transport level', () {
-      final grid = [['p1']];
+      final grid = [
+        ['p1'],
+      ];
       final tileMap = TileMapResult(
         width: 1,
         height: 1,
         grid: grid,
-        resourceGrid: [[Resource.grain]],
+        resourceGrid: [
+          [Resource.grain],
+        ],
       );
       final tileState = TileMapState()
           .setImprovement('oldWorld|p1|0|0', 4)
@@ -86,15 +93,22 @@ void main() {
         displayName: 'Spain',
         isHuman: true,
         capitalProvinceId: 'p1',
-        capitalTile: CapitalTile(regionId: 'oldWorld', provinceId: 'p1', x: 0, y: 0),
+        capitalTile: CapitalTile(
+          regionId: 'oldWorld',
+          provinceId: 'p1',
+          x: 0,
+          y: 0,
+        ),
       );
       final game = Game(
         id: 'g1',
         worldState: WorldState(
           turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
-          oldWorld: RegionData(provinces: [
-            Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
-          ]),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
+            ],
+          ),
           newWorld: const RegionData(),
           tileState: tileState,
         ),
@@ -103,81 +117,90 @@ void main() {
       final result = computeExtraction(
         game: game,
         tileMapByRegion: {'oldWorld': tileMap},
-        connectivityResult: {'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'})},
+        connectivityResult: {
+          'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'}),
+        },
         techCapForPlayer: (_) => 4,
       );
       expect(result['pl1']!.land['grain'], 1);
     });
 
-    test(
-      'effective extraction capped by player tech cap when improvement and '
-      'transport are high',
-      () {
-        final grid = [['p1']];
-        final tileMap = TileMapResult(
-          width: 1,
-          height: 1,
-          grid: grid,
-          resourceGrid: [[Resource.grain]],
-        );
-        final tileState = TileMapState()
-            .setImprovement('oldWorld|p1|0|0', 4)
-            .setRoadLevel('oldWorld|p1|0|0', 4);
-        final player = Player(
-          id: 'pl1',
-          displayName: 'Spain',
-          isHuman: true,
-          capitalProvinceId: 'p1',
-          capitalTile: CapitalTile(
-            regionId: 'oldWorld',
-            provinceId: 'p1',
-            x: 0,
-            y: 0,
-          ),
-        );
-        final game = Game(
-          id: 'g1',
-          worldState: WorldState(
-            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
-            oldWorld: RegionData(provinces: [
+    test('effective extraction capped by player tech cap when improvement and '
+        'transport are high', () {
+      final grid = [
+        ['p1'],
+      ];
+      final tileMap = TileMapResult(
+        width: 1,
+        height: 1,
+        grid: grid,
+        resourceGrid: [
+          [Resource.grain],
+        ],
+      );
+      final tileState = TileMapState()
+          .setImprovement('oldWorld|p1|0|0', 4)
+          .setRoadLevel('oldWorld|p1|0|0', 4);
+      final player = Player(
+        id: 'pl1',
+        displayName: 'Spain',
+        isHuman: true,
+        capitalProvinceId: 'p1',
+        capitalTile: CapitalTile(
+          regionId: 'oldWorld',
+          provinceId: 'p1',
+          x: 0,
+          y: 0,
+        ),
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+          oldWorld: RegionData(
+            provinces: [
               Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
-            ]),
-            newWorld: const RegionData(),
-            tileState: tileState,
+            ],
           ),
-          players: [player],
-        );
-        final resultCap2 = computeExtraction(
-          game: game,
-          tileMapByRegion: {'oldWorld': tileMap},
-          connectivityResult: {
-            'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'}),
-          },
-          techCapForPlayer: (_) => 2,
-        );
-        expect(resultCap2['pl1']!.land['grain'], 2);
+          newWorld: const RegionData(),
+          tileState: tileState,
+        ),
+        players: [player],
+      );
+      final resultCap2 = computeExtraction(
+        game: game,
+        tileMapByRegion: {'oldWorld': tileMap},
+        connectivityResult: {
+          'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'}),
+        },
+        techCapForPlayer: (_) => 2,
+      );
+      expect(resultCap2['pl1']!.land['grain'], 2);
 
-        final resultCap3 = computeExtraction(
-          game: game,
-          tileMapByRegion: {'oldWorld': tileMap},
-          connectivityResult: {
-            'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'}),
-          },
-          techCapForPlayer: (_) => 3,
-        );
-        expect(resultCap3['pl1']!.land['grain'], 3);
-      },
-    );
+      final resultCap3 = computeExtraction(
+        game: game,
+        tileMapByRegion: {'oldWorld': tileMap},
+        connectivityResult: {
+          'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'}),
+        },
+        techCapForPlayer: (_) => 3,
+      );
+      expect(resultCap3['pl1']!.land['grain'], 3);
+    });
 
     test(
       'tech cap from extractionCapForUnlocked matches turn_resolver wiring',
       () {
-        final grid = [['p1']];
+        final grid = [
+          ['p1'],
+        ];
         final tileMap = TileMapResult(
           width: 1,
           height: 1,
           grid: grid,
-          resourceGrid: [[Resource.grain]],
+          resourceGrid: [
+            [Resource.grain],
+          ],
         );
         final tileState = TileMapState()
             .setImprovement('oldWorld|p1|0|0', 4)
@@ -199,9 +222,11 @@ void main() {
           id: 'g1',
           worldState: WorldState(
             turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
-            oldWorld: RegionData(provinces: [
-              Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
-            ]),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
+              ],
+            ),
             newWorld: const RegionData(),
             tileState: tileState,
           ),
@@ -252,16 +277,28 @@ void main() {
         displayName: 'Spain',
         isHuman: true,
         capitalProvinceId: 'p1',
-        capitalTile: CapitalTile(regionId: 'oldWorld', provinceId: 'p1', x: 0, y: 0),
+        capitalTile: CapitalTile(
+          regionId: 'oldWorld',
+          provinceId: 'p1',
+          x: 0,
+          y: 0,
+        ),
       );
-      final connectedTiles = {'oldWorld|p1|0|0', 'oldWorld|p1|1|0', 'oldWorld|p1|0|1', 'oldWorld|p1|1|1'};
+      final connectedTiles = {
+        'oldWorld|p1|0|0',
+        'oldWorld|p1|1|0',
+        'oldWorld|p1|0|1',
+        'oldWorld|p1|1|1',
+      };
       final game = Game(
         id: 'g1',
         worldState: WorldState(
           turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
-          oldWorld: RegionData(provinces: [
-            Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
-          ]),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
+            ],
+          ),
           newWorld: const RegionData(),
           tileState: tileState,
           playerProspectedTiles: {'pl1': connectedTiles},
@@ -271,7 +308,9 @@ void main() {
       final result = computeExtraction(
         game: game,
         tileMapByRegion: {'oldWorld': tileMap},
-        connectivityResult: {'pl1': ConnectivityResult(connected: connectedTiles)},
+        connectivityResult: {
+          'pl1': ConnectivityResult(connected: connectedTiles),
+        },
         techCapForPlayer: (_) => 4,
       );
       expect(result['pl1']!.land['wool'], 1);
@@ -281,12 +320,16 @@ void main() {
     });
 
     test('mineral tiles without prospected are excluded from extraction', () {
-      final grid = [['p1']];
+      final grid = [
+        ['p1'],
+      ];
       final tileMap = TileMapResult(
         width: 1,
         height: 1,
         grid: grid,
-        resourceGrid: [[Resource.iron]],
+        resourceGrid: [
+          [Resource.iron],
+        ],
       );
       final tileState = TileMapState()
           .setImprovement('oldWorld|p1|0|0', 2)
@@ -296,15 +339,22 @@ void main() {
         displayName: 'Spain',
         isHuman: true,
         capitalProvinceId: 'p1',
-        capitalTile: CapitalTile(regionId: 'oldWorld', provinceId: 'p1', x: 0, y: 0),
+        capitalTile: CapitalTile(
+          regionId: 'oldWorld',
+          provinceId: 'p1',
+          x: 0,
+          y: 0,
+        ),
       );
       final game = Game(
         id: 'g1',
         worldState: WorldState(
           turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
-          oldWorld: RegionData(provinces: [
-            Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
-          ]),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
+            ],
+          ),
           newWorld: const RegionData(),
           tileState: tileState,
         ),
@@ -313,7 +363,9 @@ void main() {
       final result = computeExtraction(
         game: game,
         tileMapByRegion: {'oldWorld': tileMap},
-        connectivityResult: {'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'})},
+        connectivityResult: {
+          'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'}),
+        },
         techCapForPlayer: (_) => 4,
       );
       expect(result['pl1']!.land['iron'], isNull);
@@ -321,12 +373,16 @@ void main() {
     });
 
     test('mineral from prospected tile counts in land', () {
-      final grid = [['p1']];
+      final grid = [
+        ['p1'],
+      ];
       final tileMap = TileMapResult(
         width: 1,
         height: 1,
         grid: grid,
-        resourceGrid: [[Resource.iron]],
+        resourceGrid: [
+          [Resource.iron],
+        ],
       );
       final tileState = TileMapState()
           .setImprovement('oldWorld|p1|0|0', 2)
@@ -336,37 +392,52 @@ void main() {
         displayName: 'Spain',
         isHuman: true,
         capitalProvinceId: 'p1',
-        capitalTile: CapitalTile(regionId: 'oldWorld', provinceId: 'p1', x: 0, y: 0),
+        capitalTile: CapitalTile(
+          regionId: 'oldWorld',
+          provinceId: 'p1',
+          x: 0,
+          y: 0,
+        ),
       );
       final game = Game(
         id: 'g1',
         worldState: WorldState(
           turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
-          oldWorld: RegionData(provinces: [
-            Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
-          ]),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
+            ],
+          ),
           newWorld: const RegionData(),
           tileState: tileState,
-          playerProspectedTiles: {'pl1': {'oldWorld|p1|0|0'}},
+          playerProspectedTiles: {
+            'pl1': {'oldWorld|p1|0|0'},
+          },
         ),
         players: [player],
       );
       final result = computeExtraction(
         game: game,
         tileMapByRegion: {'oldWorld': tileMap},
-        connectivityResult: {'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'})},
+        connectivityResult: {
+          'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'}),
+        },
         techCapForPlayer: (_) => 4,
       );
       expect(result['pl1']!.land['iron'], 2);
     });
 
     test('effective extraction capped by province townDevelopmentLevel', () {
-      final grid = [['p1']];
+      final grid = [
+        ['p1'],
+      ];
       final tileMap = TileMapResult(
         width: 1,
         height: 1,
         grid: grid,
-        resourceGrid: [[Resource.grain]],
+        resourceGrid: [
+          [Resource.grain],
+        ],
       );
       final tileState = TileMapState()
           .setImprovement('oldWorld|p1|0|0', 4)
@@ -376,15 +447,27 @@ void main() {
         displayName: 'Spain',
         isHuman: true,
         capitalProvinceId: 'oldWorld|p1',
-        capitalTile: CapitalTile(regionId: 'oldWorld', provinceId: 'p1', x: 0, y: 0),
+        capitalTile: CapitalTile(
+          regionId: 'oldWorld',
+          provinceId: 'p1',
+          x: 0,
+          y: 0,
+        ),
       );
       final game = Game(
         id: 'g1',
         worldState: WorldState(
           turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
-          oldWorld: RegionData(provinces: [
-            Province(id: 'oldWorld|p1', regionId: 'oldWorld', ownerId: 'pl1', townDevelopmentLevel: 1),
-          ]),
+          oldWorld: RegionData(
+            provinces: [
+              Province(
+                id: 'oldWorld|p1',
+                regionId: 'oldWorld',
+                ownerId: 'pl1',
+                townDevelopmentLevel: 1,
+              ),
+            ],
+          ),
           newWorld: const RegionData(),
           tileState: tileState,
         ),
@@ -393,19 +476,190 @@ void main() {
       final result = computeExtraction(
         game: game,
         tileMapByRegion: {'oldWorld': tileMap},
-        connectivityResult: {'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'})},
+        connectivityResult: {
+          'pl1': ConnectivityResult(connected: {'oldWorld|p1|0|0'}),
+        },
         techCapForPlayer: (_) => 4,
       );
       expect(result['pl1']!.land['grain'], 1);
     });
 
+    test('town-rule-only + non-port: townDevelopmentLevel does NOT cap yield', () {
+      final grid = [
+        ['p1', 'p1', 'p1'],
+        ['p1', 'p2', 'p2'],
+        ['p1', 'p2', 'p2'],
+      ];
+      final resourceGrid = [
+        [null, null, null],
+        [null, Resource.grain, null],
+        [null, null, null],
+      ];
+      final tileMap = TileMapResult(
+        width: 3,
+        height: 3,
+        grid: grid,
+        resourceGrid: resourceGrid,
+      );
+      final cap = CapitalTile(
+        regionId: 'oldWorld',
+        provinceId: 'p1',
+        x: 0,
+        y: 0,
+      );
+      final tileState = TileMapState()
+          .setRoadLevel('oldWorld|p1|0|0', 1)
+          .setImprovement('oldWorld|p2|1|1', 4)
+          .setRoadLevel('oldWorld|p2|1|1', 0);
+      final player = Player(
+        id: 'pl1',
+        displayName: 'Spain',
+        isHuman: true,
+        capitalProvinceId: 'oldWorld|p1',
+        capitalTile: cap,
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+          oldWorld: RegionData(
+            provinces: [
+              Province(
+                id: 'oldWorld|p1',
+                regionId: 'oldWorld',
+                ownerId: 'pl1',
+                townTileKey: 'oldWorld|p1|0|0',
+                townDevelopmentLevel: 4,
+              ),
+              Province(
+                id: 'oldWorld|p2',
+                regionId: 'oldWorld',
+                ownerId: 'pl1',
+                townTileKey: 'oldWorld|p2|1|0',
+                townDevelopmentLevel: 2,
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          tileState: tileState,
+        ),
+        players: [player],
+      );
+      final tileKey = 'oldWorld|p2|1|1';
+      final result = computeExtraction(
+        game: game,
+        tileMapByRegion: {'oldWorld': tileMap},
+        connectivityResult: {
+          'pl1': ConnectivityResult(
+            connected: {tileKey},
+            pathTransportCap: {tileKey: 4},
+            connectedByRoadRule: const {},
+          ),
+        },
+        techCapForPlayer: (_) => 4,
+      );
+      expect(
+        result['pl1']!.land['grain'],
+        4,
+        reason:
+            'town-rule-only tile with non-port town; townDevelopmentLevel=2 must NOT cap '
+            'yield of 4 (SPEC/game/extraction-and-improvements.md § Extraction formula)',
+      );
+    });
+
+    test('town-rule-only + port: townDevelopmentLevel DOES cap yield', () {
+      final grid = [
+        ['p1', 'p1'],
+        ['p1', 'p2'],
+      ];
+      final resourceGrid = [
+        [null, null],
+        [null, Resource.grain],
+      ];
+      final tileMap = TileMapResult(
+        width: 2,
+        height: 2,
+        grid: grid,
+        resourceGrid: resourceGrid,
+      );
+      final cap = CapitalTile(
+        regionId: 'oldWorld',
+        provinceId: 'p1',
+        x: 0,
+        y: 0,
+      );
+      final tileState = TileMapState()
+          .setRoadLevel('oldWorld|p1|0|0', 1)
+          .setImprovement('oldWorld|p2|1|1', 4)
+          .setRoadLevel('oldWorld|p2|1|1', 0);
+      final player = Player(
+        id: 'pl1',
+        displayName: 'Spain',
+        isHuman: true,
+        capitalProvinceId: 'oldWorld|p1',
+        capitalTile: cap,
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+          oldWorld: RegionData(
+            provinces: [
+              Province(
+                id: 'oldWorld|p1',
+                regionId: 'oldWorld',
+                ownerId: 'pl1',
+                townTileKey: 'oldWorld|p1|0|0',
+                townDevelopmentLevel: 4,
+              ),
+              Province(
+                id: 'oldWorld|p2',
+                regionId: 'oldWorld',
+                ownerId: 'pl1',
+                townTileKey: 'oldWorld|p2|0|1',
+                townDevelopmentLevel: 2,
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          tileState: tileState,
+          portsByProvinceSeaboard: {'oldWorld|p2|sea1': 'oldWorld|p2|0|1'},
+        ),
+        players: [player],
+      );
+      final tileKey = 'oldWorld|p2|1|1';
+      final result = computeExtraction(
+        game: game,
+        tileMapByRegion: {'oldWorld': tileMap},
+        connectivityResult: {
+          'pl1': ConnectivityResult(
+            connected: {tileKey},
+            pathTransportCap: {tileKey: 4},
+            connectedByRoadRule: const {},
+          ),
+        },
+        techCapForPlayer: (_) => 4,
+      );
+      expect(
+        result['pl1']!.land['grain'],
+        2,
+        reason:
+            'town-rule-only tile with port town; townDevelopmentLevel=2 caps yield to 2 '
+            '(SPEC/game/extraction-and-improvements.md § Extraction formula)',
+      );
+    });
+
     test('overseas totals when connected tile in different region', () {
-      final gridNw = [['n1']];
+      final gridNw = [
+        ['n1'],
+      ];
       final tileMapNw = TileMapResult(
         width: 1,
         height: 1,
         grid: gridNw,
-        resourceGrid: [[Resource.sugarCane]],
+        resourceGrid: [
+          [Resource.sugarCane],
+        ],
       );
       final tileState = TileMapState()
           .setImprovement('newWorld|n1|0|0', 1)
@@ -415,123 +669,200 @@ void main() {
         displayName: 'Spain',
         isHuman: true,
         capitalProvinceId: 'p1',
-        capitalTile: CapitalTile(regionId: 'oldWorld', provinceId: 'p1', x: 0, y: 0),
+        capitalTile: CapitalTile(
+          regionId: 'oldWorld',
+          provinceId: 'p1',
+          x: 0,
+          y: 0,
+        ),
       );
       final game = Game(
         id: 'g1',
         worldState: WorldState(
           turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
-          oldWorld: RegionData(provinces: [
-            Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
-          ]),
-          newWorld: RegionData(provinces: [
-            Province(id: 'n1', regionId: 'newWorld', ownerId: 'pl1'),
-          ]),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
+            ],
+          ),
+          newWorld: RegionData(
+            provinces: [
+              Province(id: 'n1', regionId: 'newWorld', ownerId: 'pl1'),
+            ],
+          ),
           tileState: tileState,
         ),
         players: [player],
       );
       final result = computeExtraction(
         game: game,
-        tileMapByRegion: {'oldWorld': TileMapResult(width: 1, height: 1, grid: [['p1']], resourceGrid: [[null]]), 'newWorld': tileMapNw},
-        connectivityResult: {'pl1': ConnectivityResult(connected: {'newWorld|n1|0|0'})},
+        tileMapByRegion: {
+          'oldWorld': TileMapResult(
+            width: 1,
+            height: 1,
+            grid: [
+              ['p1'],
+            ],
+            resourceGrid: [
+              [null],
+            ],
+          ),
+          'newWorld': tileMapNw,
+        },
+        connectivityResult: {
+          'pl1': ConnectivityResult(connected: {'newWorld|n1|0|0'}),
+        },
         techCapForPlayer: (_) => 4,
       );
       expect(result['pl1']!.overseas['sugarCane'], 1);
       expect(result['pl1']!.land, isEmpty);
     });
 
-    test('blockaded overseas port: connectivity excludes tile so overseas extraction zero', () {
-      final oldGrid = [['p1', 'p1'], ['p1', 'p1']];
-      final newGrid = [['n1', 'n1'], ['n1', 'n1']];
-      final tileMapOw = TileMapResult(
-        width: 2,
-        height: 2,
-        grid: oldGrid,
-        resourceGrid: [[null, null], [null, null]],
-      );
-      final tileMapNw = TileMapResult(
-        width: 2,
-        height: 2,
-        grid: newGrid,
-        resourceGrid: [[Resource.sugarCane, Resource.sugarCane], [null, null]],
-      );
-      final topology = MapTopology(
-        nodes: [
-          TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          TopologyNode(id: 'n1', regionId: 'newWorld', type: TopologyNodeType.province),
-          TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
-          TopologyNode(id: 'sea2', regionId: 'newWorld', type: TopologyNodeType.seaZone),
-        ],
-        edges: [
-          TopologyEdge(id1: 'p1', id2: 'sea1'),
-          TopologyEdge(id1: 'n1', id2: 'sea2'),
-          TopologyEdge(id1: 'sea1', id2: 'sea2'),
-        ],
-      );
-      const ow = 'oldWorld', nw = 'newWorld';
-      final cap = CapitalTile(regionId: ow, provinceId: '$ow|p1', x: 0, y: 0);
-      final tileState = TileMapState()
-          .setImprovement('newWorld|n1|0|0', 1)
-          .setImprovement('newWorld|n1|1|0', 1)
-          .setRoadLevel('oldWorld|p1|0|0', 4)
-          .setRoadLevel('newWorld|n1|0|0', 4)
-          .setRoadLevel('newWorld|n1|1|0', 4);
-      final ports = {
-        '$ow|p1|sea1': 'oldWorld|p1|0|0',
-        '$nw|n1|sea2': 'newWorld|n1|0|0',
-      };
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
-          oldWorld: RegionData(provinces: [Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1')]),
-          newWorld: RegionData(provinces: [
-            Province(id: '$nw|n1', regionId: nw, ownerId: 'pl1', townDevelopmentLevel: 4),
-          ]),
-          tileState: tileState,
-          portsByProvinceSeaboard: ports,
-        ),
-        players: [Player(id: 'pl1', displayName: 'Spain', isHuman: true, capitalProvinceId: '$ow|p1', capitalTile: cap)],
-      );
-      final connectivityBlockaded = resolveConnectivity(
-        game: game,
-        tileMapByRegion: {'oldWorld': tileMapOw, 'newWorld': tileMapNw},
-        topology: topology,
-        blockadedPortProvincesByPlayerId: {'pl1': {'newWorld|n1'}},
-      );
-      final resultBlockaded = computeExtraction(
-        game: game,
-        tileMapByRegion: {'oldWorld': tileMapOw, 'newWorld': tileMapNw},
-        connectivityResult: connectivityBlockaded,
-        techCapForPlayer: (_) => 4,
-      );
-      expect(resultBlockaded['pl1']!.overseas, isEmpty);
-      expect(resultBlockaded['pl1']!.land, isEmpty);
+    test(
+      'blockaded overseas port: connectivity excludes tile so overseas extraction zero',
+      () {
+        final oldGrid = [
+          ['p1', 'p1'],
+          ['p1', 'p1'],
+        ];
+        final newGrid = [
+          ['n1', 'n1'],
+          ['n1', 'n1'],
+        ];
+        final tileMapOw = TileMapResult(
+          width: 2,
+          height: 2,
+          grid: oldGrid,
+          resourceGrid: [
+            [null, null],
+            [null, null],
+          ],
+        );
+        final tileMapNw = TileMapResult(
+          width: 2,
+          height: 2,
+          grid: newGrid,
+          resourceGrid: [
+            [Resource.sugarCane, Resource.sugarCane],
+            [null, null],
+          ],
+        );
+        final topology = MapTopology(
+          nodes: [
+            TopologyNode(
+              id: 'p1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'n1',
+              regionId: 'newWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'sea1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+            TopologyNode(
+              id: 'sea2',
+              regionId: 'newWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+          ],
+          edges: [
+            TopologyEdge(id1: 'p1', id2: 'sea1'),
+            TopologyEdge(id1: 'n1', id2: 'sea2'),
+            TopologyEdge(id1: 'sea1', id2: 'sea2'),
+          ],
+        );
+        const ow = 'oldWorld', nw = 'newWorld';
+        final cap = CapitalTile(regionId: ow, provinceId: '$ow|p1', x: 0, y: 0);
+        final tileState = TileMapState()
+            .setImprovement('newWorld|n1|0|0', 1)
+            .setImprovement('newWorld|n1|1|0', 1)
+            .setRoadLevel('oldWorld|p1|0|0', 4)
+            .setRoadLevel('newWorld|n1|0|0', 4)
+            .setRoadLevel('newWorld|n1|1|0', 4);
+        final ports = {
+          '$ow|p1|sea1': 'oldWorld|p1|0|0',
+          '$nw|n1|sea2': 'newWorld|n1|0|0',
+        };
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(
+              provinces: [Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1')],
+            ),
+            newWorld: RegionData(
+              provinces: [
+                Province(
+                  id: '$nw|n1',
+                  regionId: nw,
+                  ownerId: 'pl1',
+                  townDevelopmentLevel: 4,
+                ),
+              ],
+            ),
+            tileState: tileState,
+            portsByProvinceSeaboard: ports,
+          ),
+          players: [
+            Player(
+              id: 'pl1',
+              displayName: 'Spain',
+              isHuman: true,
+              capitalProvinceId: '$ow|p1',
+              capitalTile: cap,
+            ),
+          ],
+        );
+        final connectivityBlockaded = resolveConnectivity(
+          game: game,
+          tileMapByRegion: {'oldWorld': tileMapOw, 'newWorld': tileMapNw},
+          topology: topology,
+          blockadedPortProvincesByPlayerId: {
+            'pl1': {'newWorld|n1'},
+          },
+        );
+        final resultBlockaded = computeExtraction(
+          game: game,
+          tileMapByRegion: {'oldWorld': tileMapOw, 'newWorld': tileMapNw},
+          connectivityResult: connectivityBlockaded,
+          techCapForPlayer: (_) => 4,
+        );
+        expect(resultBlockaded['pl1']!.overseas, isEmpty);
+        expect(resultBlockaded['pl1']!.land, isEmpty);
 
-      final connectivityOpen = resolveConnectivity(
-        game: game,
-        tileMapByRegion: {'oldWorld': tileMapOw, 'newWorld': tileMapNw},
-        topology: topology,
-      );
-      final resultOpen = computeExtraction(
-        game: game,
-        tileMapByRegion: {'oldWorld': tileMapOw, 'newWorld': tileMapNw},
-        connectivityResult: connectivityOpen,
-        techCapForPlayer: (_) => 4,
-      );
-      expect(resultOpen['pl1']!.overseas['sugarCane'] ?? 0, greaterThan(0));
-    });
+        final connectivityOpen = resolveConnectivity(
+          game: game,
+          tileMapByRegion: {'oldWorld': tileMapOw, 'newWorld': tileMapNw},
+          topology: topology,
+        );
+        final resultOpen = computeExtraction(
+          game: game,
+          tileMapByRegion: {'oldWorld': tileMapOw, 'newWorld': tileMapNw},
+          connectivityResult: connectivityOpen,
+          techCapForPlayer: (_) => 4,
+        );
+        expect(resultOpen['pl1']!.overseas['sugarCane'] ?? 0, greaterThan(0));
+      },
+    );
 
     test('effective yield capped by min transport level along path to capital', () {
       // SPEC: effective yield = min(production, tech cap, town dev, min transport along path).
       // When pathTransportCap is provided, it caps yield (e.g. path with road-1 segment → cap 1).
-      final grid = [['p1']];
+      final grid = [
+        ['p1'],
+      ];
       final tileMap = TileMapResult(
         width: 1,
         height: 1,
         grid: grid,
-        resourceGrid: [[Resource.grain]],
+        resourceGrid: [
+          [Resource.grain],
+        ],
       );
       final tileState = TileMapState()
           .setImprovement('oldWorld|p1|0|0', 3)
@@ -540,9 +871,11 @@ void main() {
         id: 'g1',
         worldState: WorldState(
           turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
-          oldWorld: RegionData(provinces: [
-            Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
-          ]),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
+            ],
+          ),
           newWorld: const RegionData(),
           tileState: tileState,
         ),
@@ -552,7 +885,12 @@ void main() {
             displayName: 'Spain',
             isHuman: true,
             capitalProvinceId: 'p1',
-            capitalTile: CapitalTile(regionId: 'oldWorld', provinceId: 'p1', x: 0, y: 0),
+            capitalTile: CapitalTile(
+              regionId: 'oldWorld',
+              provinceId: 'p1',
+              x: 0,
+              y: 0,
+            ),
           ),
         ],
       );
@@ -560,7 +898,13 @@ void main() {
         game: game,
         tileMapByRegion: {'oldWorld': tileMap},
         topology: MapTopology(
-          nodes: [TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province)],
+          nodes: [
+            TopologyNode(
+              id: 'p1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+          ],
           edges: [],
         ),
       );
@@ -579,33 +923,43 @@ void main() {
       expect(resultWithPathCap['pl1']!.land['grain'], 1);
     });
 
-    test('returns empty ExtractionTotals when player has no connected tiles', () {
-      final player = Player(
-        id: 'pl1',
-        displayName: 'Spain',
-        isHuman: true,
-        capitalProvinceId: 'p1',
-        capitalTile: CapitalTile(regionId: 'oldWorld', provinceId: 'p1', x: 0, y: 0),
-      );
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
-          oldWorld: RegionData(provinces: [
-            Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
-          ]),
-          newWorld: const RegionData(),
-        ),
-        players: [player],
-      );
-      final result = computeExtraction(
-        game: game,
-        tileMapByRegion: const {},
-        connectivityResult: {'pl1': ConnectivityResult(connected: {})},
-        techCapForPlayer: (_) => 4,
-      );
-      expect(result['pl1']!.land, isEmpty);
-      expect(result['pl1']!.overseas, isEmpty);
-    });
+    test(
+      'returns empty ExtractionTotals when player has no connected tiles',
+      () {
+        final player = Player(
+          id: 'pl1',
+          displayName: 'Spain',
+          isHuman: true,
+          capitalProvinceId: 'p1',
+          capitalTile: CapitalTile(
+            regionId: 'oldWorld',
+            provinceId: 'p1',
+            x: 0,
+            y: 0,
+          ),
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
+              ],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: [player],
+        );
+        final result = computeExtraction(
+          game: game,
+          tileMapByRegion: const {},
+          connectivityResult: {'pl1': ConnectivityResult(connected: {})},
+          techCapForPlayer: (_) => 4,
+        );
+        expect(result['pl1']!.land, isEmpty);
+        expect(result['pl1']!.overseas, isEmpty);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Fixes a bug in `resource_extractor.dart` where the town-rule-only extraction branch was unreachable due to a faulty fallback in `roadRuleTiles` computation.

## Bug

When `connectedByRoadRule` was empty, the code fell back to using `cr.connected` for `roadRuleTiles`, causing `usesRoadRule = true` for ALL connected tiles and bypassing the town-development cap check for town-rule-only tiles.

```dart
// Before (buggy):
final roadRuleTiles = cr.connectedByRoadRule.isEmpty
    ? cr.connected   // ← BUG: treats ALL tiles as road-rule tiles
    : cr.connectedByRoadRule;

// After (fixed):
final roadRuleTiles = cr.connectedByRoadRule;
```

## Changes

- **resource_extractor.dart**: Fixed `roadRuleTiles` to use `connectedByRoadRule` directly
- **resource_extractor_test.dart**: Added two targeted tests covering the town-rule-only extraction branches:
  - `town-rule-only + non-port`: townDevelopmentLevel does NOT cap yield (yield = 4)
  - `town-rule-only + port`: townDevelopmentLevel DOES cap yield (yield = 2, capped by townDev=2)

## Testing

All 19 tests pass (14 resource_extractor + 5 gp_starting_grain_integration).

Closes #1400