### PR TITLE
test: strengthen stockpile preview coverage (refs #1421)

### DIFF
--- a/app/test/production_screen_integration_test.dart
+++ b/app/test/production_screen_integration_test.dart
@@ -1,10 +1,21 @@
 // Integration tests for productionDesiredOutputProvider + mapping helpers.
 // SPEC/ui/production-panel.md.
 
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:colonizethis_app/core/services/game_service.dart';
+import 'package:colonizethis_app/providers/game_service_provider.dart';
 import 'package:colonizethis_app/providers/production_allocation_provider.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
 
 class _SeededProductionDesiredOutputNotifier
     extends ProductionDesiredOutputNotifier {
@@ -16,8 +27,43 @@ class _SeededProductionDesiredOutputNotifier
   Map<String, int> build() => _initial;
 }
 
+class _MapBackedGameService extends GameService {
+  _MapBackedGameService(
+    super.box,
+    super.adapter, {
+    required this.expectedGameId,
+    required this.mapData,
+  });
+
+  final String expectedGameId;
+  final ({
+    MapTopology combinedTopology,
+    Map<String, TileMapResult> tileMapByRegion,
+    Map<String, MapTopology> topologyByRegion,
+    List<WarpLink>? warpLinks,
+  })
+  mapData;
+  int getMapDataCallCount = 0;
+
+  @override
+  ({
+    MapTopology combinedTopology,
+    Map<String, TileMapResult> tileMapByRegion,
+    Map<String, MapTopology> topologyByRegion,
+    List<WarpLink>? warpLinks,
+  })?
+  getMapData(String gameId) {
+    getMapDataCallCount += 1;
+    if (gameId != expectedGameId) return null;
+    return mapData;
+  }
+}
+
 void main() {
   suppressLogsForTests();
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Box<dynamic> gamesBox;
 
   group('production desired output provider integration', () {
     test('preseeded provider state is reflected', () {
@@ -61,4 +107,84 @@ void main() {
       expect(assignments.first.assignedLabour, 4);
     });
   });
+
+  setUpAll(() async {
+    final onePxPng = base64Decode(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=',
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMessageHandler('flutter/assets', (message) async {
+          final key = const StringCodec().decodeMessage(message);
+          if (key != null && key.startsWith('assets/') && key.endsWith('.png')) {
+            return ByteData.view(Uint8List.fromList(onePxPng).buffer);
+          }
+          return null;
+        });
+
+    Hive.init('./.dart_tool/test_hive_production_screen_integration');
+    gamesBox = await Hive.openBox<dynamic>('games_production_screen_integration');
+  });
+
+  tearDownAll(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMessageHandler('flutter/assets', null);
+    await gamesBox.close();
+  });
+
+  test(
+    'map-backed preview parity through GameService provider wiring',
+    () {
+      final game = Game(
+        id: 'g-prod-screen',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 2),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [
+          Player(
+            id: 'p1',
+            displayName: 'Human',
+            isHuman: true,
+            stockpile: Stockpile(quantities: {'grain': 2, 'timber': 2}),
+            workerPool: WorkerPool(peasants: 2),
+          ),
+        ],
+      );
+      final player = game.players.first;
+      final mapData = (
+        combinedTopology: const MapTopology(),
+        tileMapByRegion: <String, TileMapResult>{},
+        topologyByRegion: <String, MapTopology>{},
+        warpLinks: null,
+      );
+      final service = _MapBackedGameService(
+        gamesBox,
+        GameSaveAdapter(),
+        expectedGameId: game.id,
+        mapData: mapData,
+      );
+      final expected = previewStockpileNetDeltaByCommodityForPlayer(
+        game: game,
+        playerId: player.id,
+        topology: mapData.combinedTopology,
+        tileMapByRegion: mapData.tileMapByRegion,
+      );
+      final container = ProviderContainer(
+        overrides: [gameServiceProvider.overrideWith((ref) => service)],
+      );
+      addTearDown(container.dispose);
+      final wiredService = container.read(gameServiceProvider);
+      final loaded = wiredService.getMapData(game.id);
+      final actual = previewStockpileNetDeltaByCommodityForPlayer(
+        game: game,
+        playerId: player.id,
+        topology: loaded?.combinedTopology ?? const MapTopology(),
+        tileMapByRegion: loaded?.tileMapByRegion ?? const {},
+      );
+
+      expect(actual, expected);
+      expect(service.getMapDataCallCount, greaterThan(0));
+    },
+  );
 }

--- a/packages/colonizethis_logic/test/economy_stockpile_preview_test.dart
+++ b/packages/colonizethis_logic/test/economy_stockpile_preview_test.dart
@@ -161,5 +161,142 @@ void main() {
         expect(deltas, expected);
       },
     );
+
+    test('explicit extracted override takes precedence over tile-map extraction', () {
+      final game = _singlePlayerGame(
+        stockpile: const Stockpile(quantities: {'timber': 2}),
+        workerPool: WorkerPool.empty,
+      );
+
+      final projected = previewStockpileNetDeltaByCommodityForPlayer(
+        game: game,
+        playerId: 'p1',
+        topology: const MapTopology(
+          nodes: [
+            TopologyNode(
+              id: 'oldWorld|p1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: [],
+        ),
+        tileMapByRegion: {
+          'oldWorld': TileMapResult(
+            width: 1,
+            height: 1,
+            grid: [
+              ['p1'],
+            ],
+          ),
+        },
+        extractedByPlayerId: const {
+          'p1': {'timber': 5},
+        },
+      );
+
+      expect(projected['timber'], 5);
+    });
+
+    test(
+      'multi-player preview leaves non-viewed players with empty production assignments',
+      () {
+        final game = Game(
+          id: 'g-multi',
+          worldState: const WorldState(
+            turnState: TurnState(phase: TurnPhase.orders, turnNumber: 3),
+            oldWorld: RegionData(),
+            newWorld: RegionData(),
+          ),
+          players: const [
+            Player(
+              id: 'p1',
+              displayName: 'Human',
+              isHuman: true,
+              stockpile: Stockpile(quantities: {'timber': 2}),
+              workerPool: WorkerPool(apprentices: 1),
+            ),
+            Player(
+              id: 'p2',
+              displayName: 'AI',
+              isHuman: false,
+              stockpile: Stockpile(quantities: {'timber': 2}),
+              workerPool: WorkerPool(apprentices: 1),
+            ),
+          ],
+        );
+
+        final assignmentsByPlayerId = <String, List<AssignedRecipe>>{
+          for (final p in game.players) p.id: const <AssignedRecipe>[],
+        };
+        assignmentsByPlayerId['p1'] = assignedRecipesFromDesiredOutput(const {
+          'lumber_from_timber': 1,
+        });
+
+        final after = applyEconomyPhasesForPreview(
+          game: game,
+          topology: const MapTopology(),
+          tileMapByRegion: const {},
+          assignmentsByPlayerId: assignmentsByPlayerId,
+          extractedByPlayerId: const {
+            'p1': {'grain': 1, 'refinedSugar': 1},
+            'p2': {'grain': 1, 'refinedSugar': 1},
+          },
+        );
+
+        final p2Before = game.playerById('p2')!;
+        final p2After = after.playerById('p2')!;
+        expect(p2After.stockpile.quantityOf('lumber'), 0);
+        expect(
+          p2After.stockpile.quantityOf('timber'),
+          p2Before.stockpile.quantityOf('timber'),
+        );
+      },
+    );
+
+    test('assigned recipes ignores invalid and non-positive desired output', () {
+      final assignments = assignedRecipesFromDesiredOutput(const {
+        'lumber_from_timber': 2,
+        'not_a_recipe': 4,
+        'fabric_from_wool': 0,
+        'furniture_from_lumber': -3,
+      });
+
+      expect(assignments, hasLength(1));
+      expect(assignments.first.recipeId, 'lumber_from_timber');
+      expect(assignments.first.assignedLabour, 4);
+    });
+
+    test('preview returns empty map for unknown player id', () {
+      final game = _singlePlayerGame(
+        stockpile: const Stockpile(quantities: {'timber': 2}),
+        workerPool: WorkerPool.empty,
+      );
+
+      final deltas = previewStockpileNetDeltaByCommodityForPlayer(
+        game: game,
+        playerId: 'missing-player',
+        topology: const MapTopology(),
+        tileMapByRegion: const {},
+      );
+
+      expect(deltas, isEmpty);
+    });
+
+    test('consumption can remove commodity entirely and emits negative delta', () {
+      final game = _singlePlayerGame(
+        stockpile: const Stockpile(quantities: {'grain': 1}),
+        workerPool: const WorkerPool(peasants: 2),
+      );
+
+      final deltas = previewStockpileNetDeltaByCommodityForPlayer(
+        game: game,
+        playerId: 'p1',
+        topology: const MapTopology(),
+        tileMapByRegion: const {},
+      );
+
+      expect(deltas['grain'], -1);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- add five new logic tests for stockpile preview edge cases (override precedence, non-viewed assignment isolation, invalid desired-output filtering, unknown player handling, and full-consumption negative deltas)
- add provider integration coverage to validate map-backed preview parity through `gameServiceProvider` wiring
- keep changes scoped to tests for issue #1421 reliability hardening

## Test plan
- [x] `dart test packages/colonizethis_logic/test/economy_stockpile_preview_test.dart`
- [x] `flutter test app/test/production_screen_integration_test.dart`


Made with [Cursor](https://cursor.com)