### PR TITLE
Expand AI dialogue and mood coverage (issue #1411)

### DIFF
--- a/SPEC/ai/dialogue-and-mood.md
+++ b/SPEC/ai/dialogue-and-mood.md
@@ -13,7 +13,7 @@ AI emits **events** that describe what to say and which mood to show. The UI (or
 ## Dialogue categories
 
 - **diplomatic** — Declaration of war, peace offer, alliance proposal, trade agreement, warning, demand, insult, compliment.
-- **reactive** — Response to player action (forts on border, attack on ally, tech first, colony founded, threat ignored, gift, spies caught).
+- **reactive** — Response to player action (forts on border, attack on ally, attack on minor, attack on tribe, tech first, colony founded, threat ignored, gift, spies caught).
 - **event** — Commentary on game events (battle won/lost, colony founded, tech discovered, capital threatened, era transition).
 - **agenda** — Hint at hidden motivation (personality + hidden agenda flavour).
 - **negotiation** — Lines during active deal-making, keyed by mood and situation (opening, counter_offer, accepting, rejecting).
@@ -87,6 +87,29 @@ Agenda-flavoured dialogue (optional commentary on a leader's hidden agenda) is e
 - **PortraitMoodEvent:** When negotiation mood transitions; optionally when opening/closing diplomacy screen with a base mood.
 
 Emission is synchronous from AI turn or from resolution hooks; no async side effects. Order of events is deterministic for replay.
+
+---
+
+## Situation coverage matrix (implementation truth table)
+
+Canonical `situation` strings are stable for `dialogueKeyForEvent`.
+
+| Category | Situation | Status | Hook | Notes |
+|---|---|---|---|---|
+| reactive | forts_on_border | implemented | build/work fort completion | Human-built fort adjacent to AI-owned province. |
+| reactive | attack_on_ally | implemented | combat phase detection | Human attacks faction that is allied with an AI speaker. |
+| reactive | attack_on_minor | implemented | combat phase detection | Human attacks a Minor Nation province. |
+| reactive | attack_on_tribe | implemented | combat phase detection | Human attacks a Tribe province. |
+| reactive | tech_first | implemented | research-complete detection | Human is first faction in match to unlock a tech. |
+| reactive | spies_caught | implemented | counter-spy kill resolution | AI owner of target province speaks when human spy is removed by counter-spy. |
+| reactive | colony_founded | deferred | n/a | Not separately observable as a player-action hook in current turn pipeline. |
+| reactive | threat_ignored | deferred | n/a | No canonical "threat issued/ignored" state transition is currently recorded. |
+| reactive | gift | deferred | n/a | No distinct gift action hook currently exists in diplomacy resolution. |
+| event | battle_won / battle_lost | implemented | land/naval battle resolution | Existing deterministic event dialogue path. |
+| event | era_change | implemented | end-of-turn era transition | Existing deterministic event dialogue path. |
+| event | tech_discovered | implemented | research-complete detection | AI discoverer emits commentary. |
+| event | capital_threatened | implemented | combat conflict pre-resolution | AI capital is targeted by at least one human attacker this turn. |
+| event | colony_founded | implemented | province ownership transition | Province owner changes from null to AI in New World. |
 
 ---
 

--- a/SPEC/program/ai-events-and-dossier.md
+++ b/SPEC/program/ai-events-and-dossier.md
@@ -21,7 +21,7 @@ Internal record appended when an action matches an evidence rule. Fields: observ
 ### Dialogue and Mood
 1. AI calls `onDialogue(DialogueEvent)` and `onMood(PortraitMoodEvent)` callbacks during order generation.
 2. Caller guarantees deterministic invocation order.
-3. **Negotiation mood:** App updates offer state and stall count; mood state machine computes next mood and emits event on transition. Inputs deterministic for replay.
+3. **Negotiation mood:** App updates offer state and stall count; mood state machine computes next mood and emits event on transition. Inputs deterministic for replay. Canonical integration helper computes `toMood` with `computeNextNegotiationMood` and emits `PortraitMoodEvent` when `toMood != currentMood`.
 4. UI subscribes and resolves to text/portrait assets. No asset paths in events.
 
 ### Evidence and Dossier

--- a/packages/colonizethis_ai/lib/src/mood_state_machine.dart
+++ b/packages/colonizethis_ai/lib/src/mood_state_machine.dart
@@ -1,10 +1,15 @@
 // Negotiation mood state machine. SPEC/ai/dialogue-and-mood.md, SPEC/program/ai-events-and-dossier.md.
 // Given current mood, offerQualityDelta (-1..1), and stallCounter, compute next mood; deterministic given seed.
 
-import 'package:colonizethis_data/colonizethis_data.dart' show kPortraitMoodValues;
+import 'package:colonizethis_data/colonizethis_data.dart'
+    show kPortraitMoodValues;
+import 'package:colonizethis_models/colonizethis_models.dart';
 
 /// Default mood when no negotiation context (e.g. opening diplomacy).
 const String kDefaultMood = 'considering';
+
+/// Default portrait transition duration for negotiation mood changes.
+const int kNegotiationMoodTransitionDurationMs = 1200;
 
 /// Computes the next negotiation mood from current mood, offer quality delta, and stall count.
 /// Deterministic: same (currentMood, offerQualityDelta, stallCounter, seed) → same result.
@@ -52,4 +57,28 @@ String computeNextNegotiationMood(
     return 'calculating';
   }
   return 'considering';
+}
+
+/// Computes and emits a negotiation mood transition event when mood changes.
+PortraitMoodEvent? buildNegotiationMoodTransitionEvent({
+  required String leaderId,
+  required String currentMood,
+  required double offerQualityDelta,
+  required int stallCounter,
+  required int seed,
+  int durationMs = kNegotiationMoodTransitionDurationMs,
+}) {
+  final nextMood = computeNextNegotiationMood(
+    currentMood,
+    offerQualityDelta,
+    stallCounter,
+    seed,
+  );
+  if (nextMood == currentMood) return null;
+  return PortraitMoodEvent(
+    leaderId: leaderId,
+    fromMood: currentMood,
+    toMood: nextMood,
+    durationMs: durationMs,
+  );
 }

--- a/packages/colonizethis_ai/test/mood_state_machine_test.dart
+++ b/packages/colonizethis_ai/test/mood_state_machine_test.dart
@@ -7,7 +7,12 @@ void main() {
     test('returns only valid mood values', () {
       for (final current in kPortraitMoodValues) {
         for (final delta in [-1.0, 0.0, 1.0]) {
-          final next = computeNextNegotiationMood(current, delta.toDouble(), 0, 0);
+          final next = computeNextNegotiationMood(
+            current,
+            delta.toDouble(),
+            0,
+            0,
+          );
           expect(kPortraitMoodValues, contains(next));
         }
       }
@@ -49,6 +54,34 @@ void main() {
       expect(kPortraitMoodValues, contains('impatient'));
       expect(kPortraitMoodValues, contains('irritated'));
       expect(kPortraitMoodValues, contains('dismissive'));
+    });
+  });
+
+  group('buildNegotiationMoodTransitionEvent', () {
+    test('emits PortraitMoodEvent when mood changes', () {
+      final event = buildNegotiationMoodTransitionEvent(
+        leaderId: 'gp1',
+        currentMood: 'considering',
+        offerQualityDelta: -0.8,
+        stallCounter: 0,
+        seed: 0,
+      );
+      expect(event, isNotNull);
+      expect(event!.leaderId, 'gp1');
+      expect(event.fromMood, 'considering');
+      expect(event.toMood, anyOf('irritated', 'dismissive'));
+      expect(event.durationMs, kNegotiationMoodTransitionDurationMs);
+    });
+
+    test('returns null when mood does not change', () {
+      final event = buildNegotiationMoodTransitionEvent(
+        leaderId: 'gp1',
+        currentMood: 'calculating',
+        offerQualityDelta: 0.0,
+        stallCounter: 2,
+        seed: 42,
+      );
+      expect(event, isNull);
     });
   });
 }

--- a/packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
+++ b/packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
@@ -6,12 +6,18 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../constants.dart';
 import '../world/movement.dart';
 import '../world/province_lookup.dart';
 import 'evidence_rules.dart';
 
 /// Era names for dialogue (SPEC/ai/dialogue-and-mood.md: discovery | earlyModern | imperial | industrial).
-const List<String> kDialogueEras = ['discovery', 'earlyModern', 'imperial', 'industrial'];
+const List<String> kDialogueEras = [
+  'discovery',
+  'earlyModern',
+  'imperial',
+  'industrial',
+];
 
 /// Maps calendar year to dialogue era. SPEC/game/turn-time-mapping.md, SPEC/ai/dialogue-and-mood.md.
 /// Bands: discovery < 1600, earlyModern 1600–1699, imperial 1700–1799, industrial >= 1800.
@@ -33,13 +39,15 @@ List<DialogueEvent> dialogueEventsForEraChange(
   final events = <DialogueEvent>[];
   for (final p in game.players) {
     if (!isAiControlledForEvidence(game, p.id)) continue;
-    events.add(DialogueEvent(
-      leaderId: p.id,
-      category: 'event',
-      situation: 'era_change',
-      era: newEra,
-      variables: {'previousEra': previousEra},
-    ));
+    events.add(
+      DialogueEvent(
+        leaderId: p.id,
+        category: 'event',
+        situation: 'era_change',
+        era: newEra,
+        variables: {'previousEra': previousEra},
+      ),
+    );
   }
   return events;
 }
@@ -59,22 +67,26 @@ List<DialogueEvent> dialogueEventsForLandBattleResult(
   final year = mapping.yearAtTurn(turnNumber);
   final era = eraFromYear(year);
   if (isAiControlledForEvidence(game, victorId)) {
-    events.add(DialogueEvent(
-      leaderId: victorId,
-      category: 'event',
-      situation: 'battle_won',
-      era: era,
-      variables: {'otherNation': loserId, 'province': provinceId},
-    ));
+    events.add(
+      DialogueEvent(
+        leaderId: victorId,
+        category: 'event',
+        situation: 'battle_won',
+        era: era,
+        variables: {'otherNation': loserId, 'province': provinceId},
+      ),
+    );
   }
   if (isAiControlledForEvidence(game, loserId)) {
-    events.add(DialogueEvent(
-      leaderId: loserId,
-      category: 'event',
-      situation: 'battle_lost',
-      era: era,
-      variables: {'otherNation': victorId, 'province': provinceId},
-    ));
+    events.add(
+      DialogueEvent(
+        leaderId: loserId,
+        category: 'event',
+        situation: 'battle_lost',
+        era: era,
+        variables: {'otherNation': victorId, 'province': provinceId},
+      ),
+    );
   }
   return events;
 }
@@ -93,28 +105,36 @@ List<DialogueEvent> dialogueEventsForNavalBattleResult(
   final year = mapping.yearAtTurn(turnNumber);
   final era = eraFromYear(year);
   if (isAiControlledForEvidence(game, victorId)) {
-    events.add(DialogueEvent(
-      leaderId: victorId,
-      category: 'event',
-      situation: 'battle_won',
-      era: era,
-      variables: {'otherNation': loserId},
-    ));
+    events.add(
+      DialogueEvent(
+        leaderId: victorId,
+        category: 'event',
+        situation: 'battle_won',
+        era: era,
+        variables: {'otherNation': loserId},
+      ),
+    );
   }
   if (isAiControlledForEvidence(game, loserId)) {
-    events.add(DialogueEvent(
-      leaderId: loserId,
-      category: 'event',
-      situation: 'battle_lost',
-      era: era,
-      variables: {'otherNation': victorId},
-    ));
+    events.add(
+      DialogueEvent(
+        leaderId: loserId,
+        category: 'event',
+        situation: 'battle_lost',
+        era: era,
+        variables: {'otherNation': victorId},
+      ),
+    );
   }
   return events;
 }
 
 /// Neighbor province local ids in [regionId] that share an edge with [localId]. Province nodes only.
-List<String> neighborProvinceLocalIds(MapTopology topology, String regionId, String localId) {
+List<String> neighborProvinceLocalIds(
+  MapTopology topology,
+  String regionId,
+  String localId,
+) {
   return neighborProvinceIdsInRegion(topology, regionId, localId).toList();
 }
 
@@ -134,11 +154,17 @@ List<DialogueEvent> dialogueEventsForReactiveFortsOnBorder(
   String provinceId,
   int seed,
 ) {
-  final builder = game.players.where((p) => p.id == builderPlayerId).firstOrNull;
+  final builder = game.players
+      .where((p) => p.id == builderPlayerId)
+      .firstOrNull;
   if (builder == null || builder.isHuman != true) return [];
   final regionId = ProvinceId.regionIdFrom(provinceId);
   final localId = ProvinceId.localIdFrom(provinceId);
-  final neighborLocalIds = neighborProvinceLocalIds(topology, regionId, localId);
+  final neighborLocalIds = neighborProvinceLocalIds(
+    topology,
+    regionId,
+    localId,
+  );
   final mapping = game.turnTimeMapping ?? TurnTimeMapping.gdd01;
   final year = mapping.yearAtTurn(game.worldState.turnState.turnNumber);
   final era = eraFromYear(year);
@@ -147,16 +173,20 @@ List<DialogueEvent> dialogueEventsForReactiveFortsOnBorder(
   for (final neighborLocal in neighborLocalIds) {
     final fullId = ProvinceId.full(regionId, neighborLocal);
     final ownerId = _ownerOfProvince(game, fullId);
-    if (ownerId == null || !isAiControlledForEvidence(game, ownerId) || !seenAi.add(ownerId)) {
+    if (ownerId == null ||
+        !isAiControlledForEvidence(game, ownerId) ||
+        !seenAi.add(ownerId)) {
       continue;
     }
-    events.add(DialogueEvent(
-      leaderId: ownerId,
-      category: 'reactive',
-      situation: 'forts_on_border',
-      era: era,
-      variables: {'otherNation': builderPlayerId, 'province': provinceId},
-    ));
+    events.add(
+      DialogueEvent(
+        leaderId: ownerId,
+        category: 'reactive',
+        situation: 'forts_on_border',
+        era: era,
+        variables: {'otherNation': builderPlayerId, 'province': provinceId},
+      ),
+    );
   }
   return events;
 }
@@ -179,4 +209,221 @@ DialogueEvent dialogueEventForNegotiation({
     mood: mood,
     variables: variables,
   );
+}
+
+bool _isHumanGp(Game game, String factionId) {
+  final player = game.players.where((p) => p.id == factionId).firstOrNull;
+  return player?.isHuman == true;
+}
+
+bool _isAiGp(Game game, String factionId) {
+  return isAiControlledForEvidence(game, factionId);
+}
+
+bool _isMinorFaction(Game game, String factionId) {
+  return game.minorNations.any((m) => m.id == factionId);
+}
+
+bool _isTribeFaction(Game game, String factionId) {
+  return game.tribes.any((t) => t.id == factionId);
+}
+
+DiplomacyRelation? _relationBetween(Game game, String a, String b) {
+  for (final rel in game.diplomacyRelations) {
+    final direct = rel.factionId1 == a && rel.factionId2 == b;
+    final reverse = rel.factionId1 == b && rel.factionId2 == a;
+    if (direct || reverse) return rel;
+  }
+  return null;
+}
+
+bool _isAllied(Game game, String a, String b) {
+  final rel = _relationBetween(game, a, b);
+  if (rel == null) return false;
+  return rel.level == RelationLevel.allied &&
+      rel.state == RelationState.atPeace;
+}
+
+bool _hasEmbassyWithTarget(Game game, String gpId, String targetId) {
+  return game.overtureStates.any(
+    (o) => o.gpId == gpId && o.targetId == targetId && o.hasEmbassy,
+  );
+}
+
+String _eraForTurn(Game game, int turnNumber) {
+  final mapping = game.turnTimeMapping ?? TurnTimeMapping.gdd01;
+  final year = mapping.yearAtTurn(turnNumber);
+  return eraFromYear(year);
+}
+
+/// Reactive dialogue for human-initiated attacks.
+/// Emits attack_on_ally / attack_on_minor / attack_on_tribe for affected AI leaders.
+List<DialogueEvent> dialogueEventsForReactiveHumanAttack(
+  Game game, {
+  required String attackerFactionId,
+  required String defenderFactionId,
+  required String provinceId,
+  required int turnNumber,
+  required int seed,
+}) {
+  if (!_isHumanGp(game, attackerFactionId)) return const [];
+  final era = _eraForTurn(game, turnNumber);
+  final aiSpeakers =
+      game.players.where((p) => _isAiGp(game, p.id)).map((p) => p.id).toList()
+        ..sort();
+  final events = <DialogueEvent>[];
+  final seenKeys = <String>{};
+  final isMinor = _isMinorFaction(game, defenderFactionId);
+  final isTribe = _isTribeFaction(game, defenderFactionId);
+  for (final speakerId in aiSpeakers) {
+    if (speakerId == attackerFactionId) continue;
+    String? situation;
+    if (isMinor) {
+      final tiedToMinor =
+          _hasEmbassyWithTarget(game, speakerId, defenderFactionId) ||
+          _isAllied(game, speakerId, defenderFactionId);
+      if (tiedToMinor) situation = 'attack_on_minor';
+    } else if (isTribe) {
+      final tiedToTribe =
+          _hasEmbassyWithTarget(game, speakerId, defenderFactionId) ||
+          _isAllied(game, speakerId, defenderFactionId);
+      if (tiedToTribe) situation = 'attack_on_tribe';
+    } else {
+      if (_isAllied(game, speakerId, defenderFactionId)) {
+        situation = 'attack_on_ally';
+      }
+    }
+    if (situation == null) continue;
+    final dedupeKey = '$speakerId|$situation|$provinceId';
+    if (!seenKeys.add(dedupeKey)) continue;
+    events.add(
+      DialogueEvent(
+        leaderId: speakerId,
+        category: 'reactive',
+        situation: situation,
+        era: era,
+        variables: {
+          'otherNation': attackerFactionId,
+          'targetNation': defenderFactionId,
+          'province': provinceId,
+        },
+      ),
+    );
+  }
+  return events;
+}
+
+/// Event dialogue for AI tech discoveries.
+List<DialogueEvent> dialogueEventsForTechDiscovered(
+  Game game, {
+  required String discovererId,
+  required String techId,
+  required int turnNumber,
+  required int seed,
+}) {
+  if (!_isAiGp(game, discovererId)) return const [];
+  return [
+    DialogueEvent(
+      leaderId: discovererId,
+      category: 'event',
+      situation: 'tech_discovered',
+      era: _eraForTurn(game, turnNumber),
+      variables: {'techId': techId},
+    ),
+  ];
+}
+
+/// Reactive dialogue for human first-to-tech milestone.
+List<DialogueEvent> dialogueEventsForReactiveTechFirst(
+  Game game, {
+  required String discovererId,
+  required String techId,
+  required int turnNumber,
+  required int seed,
+}) {
+  if (!_isHumanGp(game, discovererId)) return const [];
+  final era = _eraForTurn(game, turnNumber);
+  final aiSpeakers =
+      game.players.where((p) => _isAiGp(game, p.id)).map((p) => p.id).toList()
+        ..sort();
+  return aiSpeakers
+      .map(
+        (speakerId) => DialogueEvent(
+          leaderId: speakerId,
+          category: 'reactive',
+          situation: 'tech_first',
+          era: era,
+          variables: {'otherNation': discovererId, 'techId': techId},
+        ),
+      )
+      .toList();
+}
+
+/// Event dialogue when an AI capital is targeted by human attackers.
+List<DialogueEvent> dialogueEventsForCapitalThreatened(
+  Game game, {
+  required String capitalOwnerId,
+  required String provinceId,
+  required List<String> attackerFactionIds,
+  required int turnNumber,
+  required int seed,
+}) {
+  if (!_isAiGp(game, capitalOwnerId)) return const [];
+  final humanAttackers = attackerFactionIds.where((id) => _isHumanGp(game, id));
+  final primaryAttacker = humanAttackers.toList()..sort();
+  if (primaryAttacker.isEmpty) return const [];
+  return [
+    DialogueEvent(
+      leaderId: capitalOwnerId,
+      category: 'event',
+      situation: 'capital_threatened',
+      era: _eraForTurn(game, turnNumber),
+      variables: {'otherNation': primaryAttacker.first, 'province': provinceId},
+    ),
+  ];
+}
+
+/// Event dialogue for New World colony foundation when owner changes null -> AI.
+List<DialogueEvent> dialogueEventsForColonyFounded(
+  Game game, {
+  required String provinceId,
+  required String? previousOwnerId,
+  required String newOwnerId,
+  required int turnNumber,
+  required int seed,
+}) {
+  if (previousOwnerId != null && previousOwnerId.isNotEmpty) return const [];
+  if (ProvinceId.regionIdFrom(provinceId) != kRegionNewWorld) return const [];
+  if (!_isAiGp(game, newOwnerId)) return const [];
+  return [
+    DialogueEvent(
+      leaderId: newOwnerId,
+      category: 'event',
+      situation: 'colony_founded',
+      era: _eraForTurn(game, turnNumber),
+      variables: {'province': provinceId},
+    ),
+  ];
+}
+
+/// Reactive dialogue for AI when human spy is caught by counter-spy.
+List<DialogueEvent> dialogueEventsForReactiveSpiesCaught(
+  Game game, {
+  required String speakerId,
+  required String caughtSpyOwnerId,
+  required String provinceId,
+  required int turnNumber,
+  required int seed,
+}) {
+  if (!_isAiGp(game, speakerId)) return const [];
+  if (!_isHumanGp(game, caughtSpyOwnerId)) return const [];
+  return [
+    DialogueEvent(
+      leaderId: speakerId,
+      category: 'reactive',
+      situation: 'spies_caught',
+      era: _eraForTurn(game, turnNumber),
+      variables: {'otherNation': caughtSpyOwnerId, 'province': provinceId},
+    ),
+  ];
 }

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -436,9 +436,7 @@ Game applyBuildAndWorkOrders(
           if (reason == null) {
             s.tileState = s.tileState.setRoadLevel(cw.tileKey, 4);
           } else {
-            _log.d(
-              'build_rail completion skipped unit=${u.id} reason=$reason',
-            );
+            _log.d('build_rail completion skipped unit=${u.id} reason=$reason');
           }
         }
         break;
@@ -521,6 +519,19 @@ Game applyBuildAndWorkOrders(
         if (enemySpies.isNotEmpty && rand.nextDouble() < killChance) {
           final toRemove = enemySpies.first.key;
           final removed = unitsById[toRemove];
+          if (s.onDialogue != null && removed != null) {
+            final events = dialogueEventsForReactiveSpiesCaught(
+              s.game,
+              speakerId: u.ownerId,
+              caughtSpyOwnerId: removed.ownerId,
+              provinceId: provinceId,
+              turnNumber: s.game.worldState.turnState.turnNumber,
+              seed: s.game.globalGameSeed ?? 0,
+            );
+            for (final e in events) {
+              s.onDialogue!(e);
+            }
+          }
           if (removed?.currentWork != null) {
             _log.d('work cancelled unit=$toRemove reason=unit dead');
           }
@@ -980,9 +991,7 @@ void _runWorkPhase(
           continue;
         }
         if (fortLevel == 2 && player.techUnlocked?['modern_forts'] != true) {
-          _log.d(
-            'build_fort skipped - Modern Forts required for fort level 3',
-          );
+          _log.d('build_fort skipped - Modern Forts required for fort level 3');
           continue;
         }
         if (applyStandardWorkOrder('build_fort')) continue;

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolution_events.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolution_events.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../dossier/event_dialogue.dart';
 import '../event_bus/game_event_bus.dart';
 import '../game_events.dart';
 
@@ -14,8 +15,19 @@ void emitResearchCompleteEvents(
   int turn,
   GameEventBus? eventBus,
   void Function(GameEvent)? onGameEvent,
+  void Function(DialogueEvent)? onDialogue,
 ) {
-  for (final player in stateAfter.players) {
+  final hadTechBefore = <String>{};
+  for (final p in stateBefore.players) {
+    final unlocked = p.techUnlocked ?? const <String, bool>{};
+    for (final e in unlocked.entries) {
+      if (e.value) hadTechBefore.add(e.key);
+    }
+  }
+  final firstDiscoveriesThisTurn = <String>{};
+  final sortedPlayers = List<Player>.from(stateAfter.players)
+    ..sort((a, b) => a.id.compareTo(b.id));
+  for (final player in sortedPlayers) {
     final unlocked = player.techUnlocked ?? {};
     final current = unlocked.entries
         .where((e) => e.value)
@@ -34,6 +46,29 @@ void emitResearchCompleteEvents(
           turnNumber: turn,
         );
         deliverGameEvent(event, eventBus: eventBus, onGameEvent: onGameEvent);
+        if (onDialogue != null) {
+          final eventDialogue = dialogueEventsForTechDiscovered(
+            stateAfter,
+            discovererId: player.id,
+            techId: tech,
+            turnNumber: turn,
+            seed: turn,
+          );
+          for (final e in eventDialogue) onDialogue(e);
+          final isFirst =
+              !hadTechBefore.contains(tech) &&
+              firstDiscoveriesThisTurn.add(tech);
+          if (isFirst) {
+            final reactive = dialogueEventsForReactiveTechFirst(
+              stateAfter,
+              discovererId: player.id,
+              techId: tech,
+              turnNumber: turn,
+              seed: turn,
+            );
+            for (final e in reactive) onDialogue(e);
+          }
+        }
       }
     }
   }
@@ -68,6 +103,7 @@ void emitProvinceCapturedEvents(
   int turn,
   GameEventBus? eventBus,
   void Function(GameEvent)? onGameEvent,
+  void Function(DialogueEvent)? onDialogue,
 ) {
   for (final region in [
     stateAfter.worldState.oldWorld,
@@ -83,6 +119,19 @@ void emitProvinceCapturedEvents(
           turnNumber: turn,
         );
         deliverGameEvent(event, eventBus: eventBus, onGameEvent: onGameEvent);
+      }
+      if (onDialogue != null &&
+          prov.ownerId != null &&
+          prov.ownerId!.isNotEmpty) {
+        final colonyDialogue = dialogueEventsForColonyFounded(
+          stateAfter,
+          provinceId: prov.id,
+          previousOwnerId: previousOwner,
+          newOwnerId: prov.ownerId!,
+          turnNumber: turn,
+          seed: turn,
+        );
+        for (final e in colonyDialogue) onDialogue(e);
       }
     }
   }

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -273,6 +273,7 @@ TurnResolutionResult resolveTurnForGame({
             turn,
             eventBus,
             onGameEvent,
+            onDialogue,
           );
           break;
         }
@@ -376,6 +377,7 @@ TurnResolutionResult resolveTurnForGame({
             turn,
             eventBus,
             onGameEvent,
+            onDialogue,
           );
           break;
         }
@@ -741,8 +743,7 @@ Game _runProductionPhase(
   for (final player in game.players) {
     final assignments =
         defaultAssignmentsByPlayerId?[player.id] ?? defaultAssignments;
-    final idleLabour =
-        idleLabourByPlayerId[player.id] ?? WorkerIdleCounts.zero;
+    final idleLabour = idleLabourByPlayerId[player.id] ?? WorkerIdleCounts.zero;
     final result = resolveProduction(
       stockpile: player.stockpile,
       workers: player.workerPool,
@@ -775,8 +776,10 @@ Game _runConsumptionPhase(
   final updatedPlayers = <Player>[];
 
   for (final player in game.players) {
-    final regimentCounts =
-        regimentTypeCountsForPlayer(game.worldState, player.id);
+    final regimentCounts = regimentTypeCountsForPlayer(
+      game.worldState,
+      player.id,
+    );
     final shipCounts = shipTypeCountsForPlayer(game.worldState, player.id);
 
     final result = resolveConsumption(
@@ -1050,8 +1053,40 @@ Game _runCombatPhase(
   };
   Game state = game;
   final turn = state.worldState.turnState.turnNumber;
+  final preBattleDialogueSeed =
+      (game.globalGameSeed ?? 0) ^ (turn * 0x9E3779B1);
   _log.i('combat conflict_detection start turn=$turn');
   final battles = detectConflicts(state, orders);
+  if (onDialogue != null && battles.isNotEmpty) {
+    for (final ctx in battles) {
+      final attackerIds = ctx.attackers.map((a) => a.factionId).toList()
+        ..sort();
+      final capitalThreatened = dialogueEventsForCapitalThreatened(
+        state,
+        capitalOwnerId: ctx.defenderFactionId,
+        provinceId: ctx.provinceId,
+        attackerFactionIds: attackerIds,
+        turnNumber: turn,
+        seed: preBattleDialogueSeed,
+      );
+      for (final e in capitalThreatened) {
+        onDialogue(e);
+      }
+      for (final attackerId in attackerIds) {
+        final reactive = dialogueEventsForReactiveHumanAttack(
+          state,
+          attackerFactionId: attackerId,
+          defenderFactionId: ctx.defenderFactionId,
+          provinceId: ctx.provinceId,
+          turnNumber: turn,
+          seed: preBattleDialogueSeed,
+        );
+        for (final e in reactive) {
+          onDialogue(e);
+        }
+      }
+    }
+  }
   _log.i(
     'combat conflict_detection end turn=$turn battleContexts=${battles.length}',
   );

--- a/packages/colonizethis_logic/test/event_dialogue_test.dart
+++ b/packages/colonizethis_logic/test/event_dialogue_test.dart
@@ -7,38 +7,46 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 void main() {
   group('dialogueEventsForLandBattleResult', () {
-    test('AI victor and AI loser both emit event with era from turn-time mapping', () {
-      const mapping = TurnTimeMapping.gdd01;
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'gp1', displayName: 'Human', isHuman: true),
-          Player(id: 'gp2', displayName: 'AI Victor', isHuman: false),
-          Player(id: 'gp3', displayName: 'AI Loser', isHuman: false),
-        ],
-      );
-      final expectedEra = eraFromYear(mapping.yearAtTurn(2));
-      final events = dialogueEventsForLandBattleResult(
-        game, 'gp2', 'gp3', 'ow|prov1', 2, 12345,
-      );
-      expect(events.length, 2);
-      final won = events.where((e) => e.situation == 'battle_won').toList();
-      final lost = events.where((e) => e.situation == 'battle_lost').toList();
-      expect(won.length, 1);
-      expect(lost.length, 1);
-      expect(won.first.leaderId, 'gp2');
-      expect(won.first.category, 'event');
-      expect(won.first.era, expectedEra);
-      expect(won.first.variables['otherNation'], 'gp3');
-      expect(won.first.variables['province'], 'ow|prov1');
-      expect(lost.first.leaderId, 'gp3');
-      expect(lost.first.variables['otherNation'], 'gp2');
-    });
+    test(
+      'AI victor and AI loser both emit event with era from turn-time mapping',
+      () {
+        const mapping = TurnTimeMapping.gdd01;
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'Human', isHuman: true),
+            Player(id: 'gp2', displayName: 'AI Victor', isHuman: false),
+            Player(id: 'gp3', displayName: 'AI Loser', isHuman: false),
+          ],
+        );
+        final expectedEra = eraFromYear(mapping.yearAtTurn(2));
+        final events = dialogueEventsForLandBattleResult(
+          game,
+          'gp2',
+          'gp3',
+          'ow|prov1',
+          2,
+          12345,
+        );
+        expect(events.length, 2);
+        final won = events.where((e) => e.situation == 'battle_won').toList();
+        final lost = events.where((e) => e.situation == 'battle_lost').toList();
+        expect(won.length, 1);
+        expect(lost.length, 1);
+        expect(won.first.leaderId, 'gp2');
+        expect(won.first.category, 'event');
+        expect(won.first.era, expectedEra);
+        expect(won.first.variables['otherNation'], 'gp3');
+        expect(won.first.variables['province'], 'ow|prov1');
+        expect(lost.first.leaderId, 'gp3');
+        expect(lost.first.variables['otherNation'], 'gp2');
+      },
+    );
 
     test('human victor returns no dialogue for victor', () {
       final game = Game(
@@ -54,7 +62,12 @@ void main() {
         ],
       );
       final events = dialogueEventsForLandBattleResult(
-        game, 'gp1', 'gp2', 'ow|p1', 2, 0,
+        game,
+        'gp1',
+        'gp2',
+        'ow|p1',
+        2,
+        0,
       );
       expect(events.length, 1);
       expect(events.first.situation, 'battle_lost');
@@ -75,7 +88,12 @@ void main() {
         ],
       );
       final events = dialogueEventsForLandBattleResult(
-        game, 'gp2', 'gp1', 'ow|p1', 2, 0,
+        game,
+        'gp2',
+        'gp1',
+        'ow|p1',
+        2,
+        0,
       );
       expect(events.length, 1);
       expect(events.first.situation, 'battle_won');
@@ -99,11 +117,21 @@ void main() {
         ],
       );
       final events = dialogueEventsForNavalBattleResult(
-        game, 'gp2', 'gp3', 3, 999,
+        game,
+        'gp2',
+        'gp3',
+        3,
+        999,
       );
       expect(events.length, 2);
-      expect(events.any((e) => e.situation == 'battle_won' && e.leaderId == 'gp2'), isTrue);
-      expect(events.any((e) => e.situation == 'battle_lost' && e.leaderId == 'gp3'), isTrue);
+      expect(
+        events.any((e) => e.situation == 'battle_won' && e.leaderId == 'gp2'),
+        isTrue,
+      );
+      expect(
+        events.any((e) => e.situation == 'battle_lost' && e.leaderId == 'gp3'),
+        isTrue,
+      );
       expect(events.first.variables['otherNation'], isNotNull);
     });
 
@@ -121,7 +149,11 @@ void main() {
         ],
       );
       final events = dialogueEventsForNavalBattleResult(
-        game, 'gp1', 'gp2', 1, 0,
+        game,
+        'gp1',
+        'gp2',
+        1,
+        0,
       );
       expect(events.length, 1);
       expect(events.first.situation, 'battle_lost');
@@ -156,7 +188,10 @@ void main() {
         ],
       );
       final events = dialogueEventsForEraChange(
-        game, 'earlyModern', 'imperial', 42,
+        game,
+        'earlyModern',
+        'imperial',
+        42,
       );
       expect(events.length, 2);
       for (final e in events) {
@@ -182,7 +217,10 @@ void main() {
         ],
       );
       final events = dialogueEventsForEraChange(
-        game, 'earlyModern', 'imperial', 0,
+        game,
+        'earlyModern',
+        'imperial',
+        0,
       );
       expect(events, isEmpty);
     });
@@ -192,8 +230,16 @@ void main() {
     test('returns empty when builder is AI', () {
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'P1', regionId: 'ow', type: TopologyNodeType.province),
-          TopologyNode(id: 'P2', regionId: 'ow', type: TopologyNodeType.province),
+          TopologyNode(
+            id: 'P1',
+            regionId: 'ow',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'P2',
+            regionId: 'ow',
+            type: TopologyNodeType.province,
+          ),
         ],
         edges: const [TopologyEdge(id1: 'P1', id2: 'P2')],
       );
@@ -201,10 +247,12 @@ void main() {
         id: 'g1',
         worldState: WorldState(
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(provinces: [
-            Province(id: 'ow|P1', regionId: 'ow', ownerId: 'gp2'),
-            Province(id: 'ow|P2', regionId: 'ow', ownerId: 'gp1'),
-          ]),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'ow|P1', regionId: 'ow', ownerId: 'gp2'),
+              Province(id: 'ow|P2', regionId: 'ow', ownerId: 'gp1'),
+            ],
+          ),
           newWorld: const RegionData(),
         ),
         players: const [
@@ -213,44 +261,65 @@ void main() {
         ],
       );
       final events = dialogueEventsForReactiveFortsOnBorder(
-        game, topology, 'gp2', 'ow|P2', 0,
+        game,
+        topology,
+        'gp2',
+        'ow|P2',
+        0,
       );
       expect(events, isEmpty);
     });
 
-    test('emits one event per AI neighbor when human builds fort on border', () {
-      final topology = MapTopology(
-        nodes: const [
-          TopologyNode(id: 'P1', regionId: 'ow', type: TopologyNodeType.province),
-          TopologyNode(id: 'P2', regionId: 'ow', type: TopologyNodeType.province),
-        ],
-        edges: const [TopologyEdge(id1: 'P1', id2: 'P2')],
-      );
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(provinces: [
-            Province(id: 'ow|P1', regionId: 'ow', ownerId: 'gp2'),
-            Province(id: 'ow|P2', regionId: 'ow', ownerId: 'gp1'),
-          ]),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'gp1', displayName: 'Human', isHuman: true),
-          Player(id: 'gp2', displayName: 'AI', isHuman: false),
-        ],
-      );
-      final events = dialogueEventsForReactiveFortsOnBorder(
-        game, topology, 'gp1', 'ow|P2', 0,
-      );
-      expect(events.length, 1);
-      expect(events.first.leaderId, 'gp2');
-      expect(events.first.category, 'reactive');
-      expect(events.first.situation, 'forts_on_border');
-      expect(events.first.variables['otherNation'], 'gp1');
-      expect(events.first.variables['province'], 'ow|P2');
-    });
+    test(
+      'emits one event per AI neighbor when human builds fort on border',
+      () {
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'P1',
+              regionId: 'ow',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'P2',
+              regionId: 'ow',
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: const [TopologyEdge(id1: 'P1', id2: 'P2')],
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: 'ow|P1', regionId: 'ow', ownerId: 'gp2'),
+                Province(id: 'ow|P2', regionId: 'ow', ownerId: 'gp1'),
+              ],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'Human', isHuman: true),
+            Player(id: 'gp2', displayName: 'AI', isHuman: false),
+          ],
+        );
+        final events = dialogueEventsForReactiveFortsOnBorder(
+          game,
+          topology,
+          'gp1',
+          'ow|P2',
+          0,
+        );
+        expect(events.length, 1);
+        expect(events.first.leaderId, 'gp2');
+        expect(events.first.category, 'reactive');
+        expect(events.first.situation, 'forts_on_border');
+        expect(events.first.variables['otherNation'], 'gp1');
+        expect(events.first.variables['province'], 'ow|P2');
+      },
+    );
 
     test('resolves owner from newWorld when fort built in newWorld', () {
       const nw = 'newWorld';
@@ -266,10 +335,12 @@ void main() {
         worldState: WorldState(
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
           oldWorld: const RegionData(),
-          newWorld: RegionData(provinces: [
-            Province(id: 'newWorld|N1', regionId: nw, ownerId: 'gp1'),
-            Province(id: 'newWorld|N2', regionId: nw, ownerId: 'gp2'),
-          ]),
+          newWorld: RegionData(
+            provinces: [
+              Province(id: 'newWorld|N1', regionId: nw, ownerId: 'gp1'),
+              Province(id: 'newWorld|N2', regionId: nw, ownerId: 'gp2'),
+            ],
+          ),
         ),
         players: const [
           Player(id: 'gp1', displayName: 'Human', isHuman: true),
@@ -277,7 +348,11 @@ void main() {
         ],
       );
       final events = dialogueEventsForReactiveFortsOnBorder(
-        game, topology, 'gp1', 'newWorld|N1', 0,
+        game,
+        topology,
+        'gp1',
+        'newWorld|N1',
+        0,
       );
       expect(events.length, 1);
       expect(events.first.leaderId, 'gp2');
@@ -311,6 +386,206 @@ void main() {
       expect(e.category, 'negotiation');
       expect(e.situation, 'opening');
       expect(e.mood, isNull);
+    });
+  });
+
+  group('dialogueEventsForReactiveHumanAttack', () {
+    test('emits attack_on_ally for AI allied with defender', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 5),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'human', displayName: 'Human', isHuman: true),
+          Player(id: 'ai1', displayName: 'AI', isHuman: false),
+          Player(id: 'ai2', displayName: 'AI Defender', isHuman: false),
+        ],
+        diplomacyRelations: const [
+          DiplomacyRelation(
+            factionId1: 'ai1',
+            factionId2: 'ai2',
+            level: RelationLevel.allied,
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      final events = dialogueEventsForReactiveHumanAttack(
+        game,
+        attackerFactionId: 'human',
+        defenderFactionId: 'ai2',
+        provinceId: 'oldWorld|P1',
+        turnNumber: 5,
+        seed: 1,
+      );
+      expect(events.length, 1);
+      expect(events.first.leaderId, 'ai1');
+      expect(events.first.situation, 'attack_on_ally');
+    });
+
+    test('emits attack_on_minor and attack_on_tribe for AI with embassy', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 5),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'human', displayName: 'Human', isHuman: true),
+          Player(id: 'ai1', displayName: 'AI', isHuman: false),
+        ],
+        minorNations: const [MinorNation(id: 'mn1')],
+        tribes: const [Tribe(id: 'tr1')],
+        overtureStates: const [
+          OvertureState(
+            gpId: 'ai1',
+            targetId: 'mn1',
+            stage: OvertureStage.embassy,
+          ),
+          OvertureState(
+            gpId: 'ai1',
+            targetId: 'tr1',
+            stage: OvertureStage.embassy,
+          ),
+        ],
+      );
+      final minorEvents = dialogueEventsForReactiveHumanAttack(
+        game,
+        attackerFactionId: 'human',
+        defenderFactionId: 'mn1',
+        provinceId: 'oldWorld|P9',
+        turnNumber: 5,
+        seed: 1,
+      );
+      final tribeEvents = dialogueEventsForReactiveHumanAttack(
+        game,
+        attackerFactionId: 'human',
+        defenderFactionId: 'tr1',
+        provinceId: 'newWorld|N2',
+        turnNumber: 5,
+        seed: 1,
+      );
+      expect(minorEvents.single.situation, 'attack_on_minor');
+      expect(tribeEvents.single.situation, 'attack_on_tribe');
+    });
+  });
+
+  group('additional event/reactive situations', () {
+    test('tech_discovered emits for AI discoverer only', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 8),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'h1', displayName: 'Human', isHuman: true),
+          Player(id: 'a1', displayName: 'AI', isHuman: false),
+        ],
+      );
+      final aiEvents = dialogueEventsForTechDiscovered(
+        game,
+        discovererId: 'a1',
+        techId: 'rifling',
+        turnNumber: 8,
+        seed: 0,
+      );
+      final humanEvents = dialogueEventsForTechDiscovered(
+        game,
+        discovererId: 'h1',
+        techId: 'rifling',
+        turnNumber: 8,
+        seed: 0,
+      );
+      expect(aiEvents.single.situation, 'tech_discovered');
+      expect(humanEvents, isEmpty);
+    });
+
+    test('capital_threatened emits when human attacker targets AI capital', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'h1', displayName: 'Human', isHuman: true),
+          Player(
+            id: 'a1',
+            displayName: 'AI',
+            isHuman: false,
+            capitalProvinceId: 'oldWorld|P2',
+          ),
+        ],
+      );
+      final events = dialogueEventsForCapitalThreatened(
+        game,
+        capitalOwnerId: 'a1',
+        provinceId: 'oldWorld|P2',
+        attackerFactionIds: const ['h1'],
+        turnNumber: 3,
+        seed: 0,
+      );
+      expect(events.single.situation, 'capital_threatened');
+    });
+
+    test('colony_founded emits only for null->AI owner in New World', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 10),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'a1', displayName: 'AI', isHuman: false)],
+      );
+      final yes = dialogueEventsForColonyFounded(
+        game,
+        provinceId: 'newWorld|N1',
+        previousOwnerId: null,
+        newOwnerId: 'a1',
+        turnNumber: 10,
+        seed: 0,
+      );
+      final no = dialogueEventsForColonyFounded(
+        game,
+        provinceId: 'oldWorld|P1',
+        previousOwnerId: null,
+        newOwnerId: 'a1',
+        turnNumber: 10,
+        seed: 0,
+      );
+      expect(yes.single.situation, 'colony_founded');
+      expect(no, isEmpty);
+    });
+
+    test('spies_caught emits only for AI speaker and human spy owner', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 7),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'h1', displayName: 'Human', isHuman: true),
+          Player(id: 'a1', displayName: 'AI', isHuman: false),
+        ],
+      );
+      final events = dialogueEventsForReactiveSpiesCaught(
+        game,
+        speakerId: 'a1',
+        caughtSpyOwnerId: 'h1',
+        provinceId: 'oldWorld|P4',
+        turnNumber: 7,
+        seed: 0,
+      );
+      expect(events.single.situation, 'spies_caught');
     });
   });
 }

--- a/packages/colonizethis_logic/test/turn_resolution_events_dialogue_test.dart
+++ b/packages/colonizethis_logic/test/turn_resolution_events_dialogue_test.dart
@@ -1,0 +1,130 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_logic/src/turn/turn_resolution_events.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+void main() {
+  group('turn resolution dialogue emissions', () {
+    test('emitResearchCompleteEvents emits tech_discovered for AI', () {
+      final before = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 6),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(
+            id: 'ai1',
+            displayName: 'AI',
+            isHuman: false,
+            techUnlocked: {},
+          ),
+        ],
+      );
+      final after = before.copyWith(
+        players: const [
+          Player(
+            id: 'ai1',
+            displayName: 'AI',
+            isHuman: false,
+            techUnlocked: {'steam_power': true},
+          ),
+        ],
+      );
+      final dialogue = <DialogueEvent>[];
+      emitResearchCompleteEvents(before, after, 6, null, null, dialogue.add);
+      expect(
+        dialogue.any(
+          (e) =>
+              e.category == 'event' &&
+              e.situation == 'tech_discovered' &&
+              e.leaderId == 'ai1',
+        ),
+        isTrue,
+      );
+    });
+
+    test('emitResearchCompleteEvents emits tech_first when human is first', () {
+      final before = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 6),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(
+            id: 'h1',
+            displayName: 'Human',
+            isHuman: true,
+            techUnlocked: {},
+          ),
+          Player(id: 'a1', displayName: 'AI', isHuman: false, techUnlocked: {}),
+        ],
+      );
+      final after = before.copyWith(
+        players: const [
+          Player(
+            id: 'h1',
+            displayName: 'Human',
+            isHuman: true,
+            techUnlocked: {'banking': true},
+          ),
+          Player(id: 'a1', displayName: 'AI', isHuman: false, techUnlocked: {}),
+        ],
+      );
+      final dialogue = <DialogueEvent>[];
+      emitResearchCompleteEvents(before, after, 6, null, null, dialogue.add);
+      expect(
+        dialogue.any(
+          (e) =>
+              e.category == 'reactive' &&
+              e.situation == 'tech_first' &&
+              e.leaderId == 'a1',
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+      'emitProvinceCapturedEvents emits colony_founded for New World null->AI',
+      () {
+        final after = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+            oldWorld: const RegionData(),
+            newWorld: RegionData(
+              provinces: const [
+                Province(
+                  id: 'newWorld|N1',
+                  regionId: 'newWorld',
+                  ownerId: 'a1',
+                ),
+              ],
+            ),
+          ),
+          players: const [Player(id: 'a1', displayName: 'AI', isHuman: false)],
+        );
+        final dialogue = <DialogueEvent>[];
+        emitProvinceCapturedEvents(
+          const {'newWorld|N1': null},
+          after,
+          2,
+          null,
+          null,
+          dialogue.add,
+        );
+        expect(
+          dialogue.any(
+            (e) =>
+                e.category == 'event' &&
+                e.situation == 'colony_founded' &&
+                e.leaderId == 'a1',
+          ),
+          isTrue,
+        );
+      },
+    );
+  });
+}

--- a/packages/colonizethis_logic/test/turn_resolver_resolve_turn_for_game_part2_test.dart
+++ b/packages/colonizethis_logic/test/turn_resolver_resolve_turn_for_game_part2_test.dart
@@ -9,13 +9,17 @@ void main() {
       final topology = MapTopology(
         nodes: [
           const TopologyNode(
-              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+            id: 'P1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
           const TopologyNode(
-              id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
+            id: 'P2',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
         ],
-        edges: [
-          const TopologyEdge(id1: 'P1', id2: 'P2'),
-        ],
+        edges: [const TopologyEdge(id1: 'P1', id2: 'P2')],
       );
 
       const ow = 'oldWorld';
@@ -54,17 +58,13 @@ void main() {
 
       final orders = Orders(
         moveOrdersByPlayerId: {
-          'p1': [
-            MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P2'),
-          ],
+          'p1': [MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P2')],
         },
       );
 
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: topology,
-        orders: orders,
-      ));
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(game: game, topology: topology, orders: orders),
+      );
 
       expect(next.worldState.turnState.turnNumber, 1);
       final p2 = next.worldState.oldWorld.provinces
@@ -77,239 +77,271 @@ void main() {
     });
 
     test(
-        'combat phase with AI players invokes onDialogue with event battle_won/battle_lost',
-        () {
-      final topology = MapTopology(
-        nodes: [
-          const TopologyNode(
-              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          const TopologyNode(
-              id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
-        ],
-        edges: [
-          const TopologyEdge(id1: 'P1', id2: 'P2'),
-        ],
-      );
+      'combat phase with AI players invokes onDialogue with event battle_won/battle_lost',
+      () {
+        final topology = MapTopology(
+          nodes: [
+            const TopologyNode(
+              id: 'P1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            const TopologyNode(
+              id: 'P2',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: [const TopologyEdge(id1: 'P1', id2: 'P2')],
+        );
 
-      const ow = 'oldWorld';
-      final game = Game(
-        id: 'g1',
-        globalGameSeed: 12345,
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-          oldWorld: RegionData(
-            provinces: [
-              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
-              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
-            ],
-            units: [
-              Unit(
-                id: 'u1',
-                type: 'grenadiers',
-                ownerId: 'p1',
-                locationProvinceId: '$ow|P1',
-              ),
-              Unit(
-                id: 'u2',
-                type: 'peasant_levies',
-                ownerId: 'p2',
-                locationProvinceId: '$ow|P2',
-              ),
-            ],
+        const ow = 'oldWorld';
+        final game = Game(
+          id: 'g1',
+          globalGameSeed: 12345,
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+                Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+              ],
+              units: [
+                Unit(
+                  id: 'u1',
+                  type: 'grenadiers',
+                  ownerId: 'p1',
+                  locationProvinceId: '$ow|P1',
+                ),
+                Unit(
+                  id: 'u2',
+                  type: 'peasant_levies',
+                  ownerId: 'p2',
+                  locationProvinceId: '$ow|P2',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
           ),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(
+          players: const [
+            Player(
               id: 'p1',
               displayName: 'AI Attacker',
               isHuman: false,
-              militaryLevel: 3),
-          Player(
+              militaryLevel: 3,
+            ),
+            Player(
               id: 'p2',
               displayName: 'AI Defender',
               isHuman: false,
-              militaryLevel: 1),
-        ],
-        defaultCombatMode: CombatMode.quickBattle,
-      );
-
-      final orders = Orders(
-        moveOrdersByPlayerId: {
-          'p1': [
-            MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P2'),
+              militaryLevel: 1,
+            ),
           ],
-        },
-      );
+          defaultCombatMode: CombatMode.quickBattle,
+        );
 
-      final dialogueEvents = <DialogueEvent>[];
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: topology,
-        orders: orders,
-        onDialogue: dialogueEvents.add,
-      ));
+        final orders = Orders(
+          moveOrdersByPlayerId: {
+            'p1': [MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P2')],
+          },
+        );
 
-      expect(next.worldState.turnState.turnNumber, 1);
-      final eventDialogue = dialogueEvents
-          .where((e) =>
-              e.category == 'event' &&
-              (e.situation == 'battle_won' || e.situation == 'battle_lost'))
-          .toList();
-      expect(eventDialogue, isNotEmpty);
-      expect(eventDialogue.any((e) => e.situation == 'battle_won'), isTrue);
-      expect(eventDialogue.any((e) => e.situation == 'battle_lost'), isTrue);
-    });
+        final dialogueEvents = <DialogueEvent>[];
+        final next = requireTurnResolutionComplete(
+          resolveTurnForGame(
+            game: game,
+            topology: topology,
+            orders: orders,
+            onDialogue: dialogueEvents.add,
+          ),
+        );
+
+        expect(next.worldState.turnState.turnNumber, 1);
+        final eventDialogue = dialogueEvents
+            .where(
+              (e) =>
+                  e.category == 'event' &&
+                  (e.situation == 'battle_won' || e.situation == 'battle_lost'),
+            )
+            .toList();
+        expect(eventDialogue, isNotEmpty);
+        expect(eventDialogue.any((e) => e.situation == 'battle_won'), isTrue);
+        expect(eventDialogue.any((e) => e.situation == 'battle_lost'), isTrue);
+      },
+    );
 
     test(
-        'quick battle defender holds: onDialogue receives battle_won for defender and battle_lost for attacker',
-        () {
-      final topology = MapTopology(
-        nodes: [
-          const TopologyNode(
-              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          const TopologyNode(
-              id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
-        ],
-        edges: [
-          const TopologyEdge(id1: 'P1', id2: 'P2'),
-        ],
-      );
+      'quick battle defender holds: onDialogue receives battle_won for defender and battle_lost for attacker',
+      () {
+        final topology = MapTopology(
+          nodes: [
+            const TopologyNode(
+              id: 'P1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            const TopologyNode(
+              id: 'P2',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: [const TopologyEdge(id1: 'P1', id2: 'P2')],
+        );
 
-      const ow = 'oldWorld';
-      final game = Game(
-        id: 'g1',
-        globalGameSeed: 7777,
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-          oldWorld: RegionData(
-            provinces: [
-              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
-              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
-            ],
-            units: [
-              Unit(
+        const ow = 'oldWorld';
+        final game = Game(
+          id: 'g1',
+          globalGameSeed: 7777,
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+                Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+              ],
+              units: [
+                Unit(
                   id: 'u1',
                   type: 'peasant_levies',
                   ownerId: 'p1',
-                  locationProvinceId: '$ow|P1'),
-              Unit(
+                  locationProvinceId: '$ow|P1',
+                ),
+                Unit(
                   id: 'u2',
                   type: 'grenadiers',
                   ownerId: 'p2',
                   locationProvinceId: '$ow|P2',
-                  medals: 2),
-            ],
+                  medals: 2,
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
           ),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(
+          players: const [
+            Player(
               id: 'p1',
               displayName: 'AI Attacker',
               isHuman: false,
-              militaryLevel: 1),
-          Player(
+              militaryLevel: 1,
+            ),
+            Player(
               id: 'p2',
               displayName: 'AI Defender',
               isHuman: false,
-              militaryLevel: 3),
-        ],
-        defaultCombatMode: CombatMode.quickBattle,
-      );
-
-      final orders = Orders(
-        moveOrdersByPlayerId: {
-          'p1': [MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P2')],
-        },
-      );
-
-      final dialogueEvents = <DialogueEvent>[];
-      requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: topology,
-        orders: orders,
-        onDialogue: dialogueEvents.add,
-      ));
-
-      final eventDialogue = dialogueEvents
-          .where((e) =>
-              e.category == 'event' &&
-              (e.situation == 'battle_won' || e.situation == 'battle_lost'))
-          .toList();
-      expect(eventDialogue, isNotEmpty);
-    });
-
-    test(
-        'naval interception combat with AI players invokes onDialogue with event battle_won/battle_lost',
-        () {
-      final topology = MapTopology(
-        nodes: const [
-          TopologyNode(
-              id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
-        ],
-        edges: const [],
-      );
-      final game = Game(
-        id: 'g1',
-        globalGameSeed: 42,
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-          fleets: [
-            Fleet(
-              id: 'f1',
-              ownerId: 'p1',
-              seaZoneId: 'sea1',
-              regionId: 'oldWorld',
-              shipTypeIds: ['carrack', 'carrack'],
-            ),
-            Fleet(
-              id: 'f2',
-              ownerId: 'p2',
-              seaZoneId: 'sea1',
-              regionId: 'oldWorld',
-              shipTypeIds: ['fluyte'],
+              militaryLevel: 3,
             ),
           ],
-        ),
-        players: const [
-          Player(id: 'p1', displayName: 'AI Fleet A', isHuman: false),
-          Player(id: 'p2', displayName: 'AI Fleet B', isHuman: false),
-        ],
-        diplomacyRelations: [
-          DiplomacyRelation(
-            factionId1: 'p1',
-            factionId2: 'p2',
-            state: RelationState.atWar,
-          ),
-        ],
-      );
-      final dialogueEvents = <DialogueEvent>[];
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: topology,
-        orders: const Orders(),
-        onDialogue: dialogueEvents.add,
-      ));
-      expect(next.worldState.turnState.turnNumber, 1);
-      // Naval battle may or may not eliminate one side; when it does, event dialogue is emitted.
-      final eventDialogue = dialogueEvents
-          .where((e) =>
-              e.category == 'event' &&
-              (e.situation == 'battle_won' || e.situation == 'battle_lost'))
-          .toList();
-      expect(eventDialogue.length, lessThanOrEqualTo(2));
-    });
+          defaultCombatMode: CombatMode.quickBattle,
+        );
 
-    test('endOfTurn era transition invokes onDialogue with event era_change',
-        () {
+        final orders = Orders(
+          moveOrdersByPlayerId: {
+            'p1': [MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P2')],
+          },
+        );
+
+        final dialogueEvents = <DialogueEvent>[];
+        requireTurnResolutionComplete(
+          resolveTurnForGame(
+            game: game,
+            topology: topology,
+            orders: orders,
+            onDialogue: dialogueEvents.add,
+          ),
+        );
+
+        final eventDialogue = dialogueEvents
+            .where(
+              (e) =>
+                  e.category == 'event' &&
+                  (e.situation == 'battle_won' || e.situation == 'battle_lost'),
+            )
+            .toList();
+        expect(eventDialogue, isNotEmpty);
+      },
+    );
+
+    test(
+      'naval interception combat with AI players invokes onDialogue with event battle_won/battle_lost',
+      () {
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'sea1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+          ],
+          edges: const [],
+        );
+        final game = Game(
+          id: 'g1',
+          globalGameSeed: 42,
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'f1',
+                ownerId: 'p1',
+                seaZoneId: 'sea1',
+                regionId: 'oldWorld',
+                shipTypeIds: ['carrack', 'carrack'],
+              ),
+              Fleet(
+                id: 'f2',
+                ownerId: 'p2',
+                seaZoneId: 'sea1',
+                regionId: 'oldWorld',
+                shipTypeIds: ['fluyte'],
+              ),
+            ],
+          ),
+          players: const [
+            Player(id: 'p1', displayName: 'AI Fleet A', isHuman: false),
+            Player(id: 'p2', displayName: 'AI Fleet B', isHuman: false),
+          ],
+          diplomacyRelations: [
+            DiplomacyRelation(
+              factionId1: 'p1',
+              factionId2: 'p2',
+              state: RelationState.atWar,
+            ),
+          ],
+        );
+        final dialogueEvents = <DialogueEvent>[];
+        final next = requireTurnResolutionComplete(
+          resolveTurnForGame(
+            game: game,
+            topology: topology,
+            orders: const Orders(),
+            onDialogue: dialogueEvents.add,
+          ),
+        );
+        expect(next.worldState.turnState.turnNumber, 1);
+        // Naval battle may or may not eliminate one side; when it does, event dialogue is emitted.
+        final eventDialogue = dialogueEvents
+            .where(
+              (e) =>
+                  e.category == 'event' &&
+                  (e.situation == 'battle_won' || e.situation == 'battle_lost'),
+            )
+            .toList();
+        expect(eventDialogue.length, lessThanOrEqualTo(2));
+      },
+    );
+
+    test('endOfTurn era transition invokes onDialogue with event era_change', () {
       // Turn 100 → year 1698 (earlyModern); turn 101 → 1700 (imperial). SPEC/ai/dialogue-and-mood.md.
       final topology = MapTopology(
         nodes: const [
           TopologyNode(
-              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
+            id: 'P1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
         ],
         edges: const [],
       );
@@ -327,12 +359,14 @@ void main() {
         turnTimeMapping: TurnTimeMapping.gdd01,
       );
       final dialogueEvents = <DialogueEvent>[];
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: topology,
-        orders: const Orders(),
-        onDialogue: dialogueEvents.add,
-      ));
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: topology,
+          orders: const Orders(),
+          onDialogue: dialogueEvents.add,
+        ),
+      );
       expect(next.worldState.turnState.turnNumber, 101);
       final eraChange = dialogueEvents
           .where((e) => e.category == 'event' && e.situation == 'era_change')
@@ -344,131 +378,360 @@ void main() {
       }
     });
 
-    test('resolveTurnForGameFromOrderEngine integrates order engine output',
-        () {
+    test('combat emits capital_threatened when human attacks AI capital', () {
       final topology = MapTopology(
-        nodes: [
-          const TopologyNode(
-              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          const TopologyNode(
-              id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
+        nodes: const [
+          TopologyNode(
+            id: 'P1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'P2',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
         ],
-        edges: [
-          const TopologyEdge(id1: 'P1', id2: 'P2'),
-        ],
+        edges: const [TopologyEdge(id1: 'P1', id2: 'P2')],
       );
-
       const ow = 'oldWorld';
       final game = Game(
         id: 'g1',
+        globalGameSeed: 42,
         worldState: WorldState(
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
           oldWorld: RegionData(
-            provinces: [
-              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
-              Province(id: '$ow|P2', regionId: ow, ownerId: 'p1'),
+            provinces: const [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'human'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'ai1'),
             ],
             units: [
               Unit(
                 id: 'u1',
                 type: 'grenadiers',
-                ownerId: 'p1',
+                ownerId: 'human',
                 locationProvinceId: '$ow|P1',
+              ),
+              Unit(
+                id: 'u2',
+                type: 'peasant_levies',
+                ownerId: 'ai1',
+                locationProvinceId: '$ow|P2',
               ),
             ],
           ),
           newWorld: const RegionData(),
-          playerVisibilityByTile: const {
-            'p1': {
-              'oldWorld|P1|0|0': 'fullyVisible',
-              'oldWorld|P2|0|0': 'fullyVisible',
-            },
-          },
         ),
         players: const [
-          Player(id: 'p1', displayName: 'A', isHuman: true),
+          Player(id: 'human', displayName: 'Human', isHuman: true),
+          Player(
+            id: 'ai1',
+            displayName: 'AI',
+            isHuman: false,
+            capitalProvinceId: '$ow|P2',
+          ),
         ],
       );
-
-      final engine = OrderEngine();
-      engine.addMoveOrder('p1',
-          const MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|P2'));
-
-      final next = requireTurnResolutionComplete(resolveTurnForGameFromOrderEngine(
-        game: game,
-        topology: topology,
-        orderEngine: engine,
-      ));
-
-      expect(next.worldState.turnState.turnNumber, 1);
-      expect(next.worldState.oldWorld.units.single.locationProvinceId, 'oldWorld|P2');
+      final dialogueEvents = <DialogueEvent>[];
+      requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: topology,
+          orders: const Orders(
+            moveOrdersByPlayerId: {
+              'human': [
+                MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P2'),
+              ],
+            },
+          ),
+          onDialogue: dialogueEvents.add,
+        ),
+      );
+      expect(
+        dialogueEvents.any(
+          (e) => e.category == 'event' && e.situation == 'capital_threatened',
+        ),
+        isTrue,
+      );
     });
 
     test(
-        'validateOrdersAndResolveTurn filters invalid order and applies only valid move',
-        () {
-      final topology = MapTopology(
-        nodes: [
-          const TopologyNode(
-              id: 'P1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          const TopologyNode(
-              id: 'P2', regionId: 'oldWorld', type: TopologyNodeType.province),
-        ],
-        edges: [const TopologyEdge(id1: 'P1', id2: 'P2')],
-      );
-      const ow = 'oldWorld';
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-          oldWorld: RegionData(
-            provinces: [
-              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
-              Province(id: '$ow|P2', regionId: ow, ownerId: 'p1'),
-            ],
-            units: [
-              Unit(
+      'combat emits attack_on_minor and attack_on_tribe reactive dialogue',
+      () {
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'P1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'P2',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'N1',
+              regionId: 'newWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'N2',
+              regionId: 'newWorld',
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: const [
+            TopologyEdge(id1: 'P1', id2: 'P2'),
+            TopologyEdge(id1: 'N1', id2: 'N2'),
+          ],
+        );
+        const ow = 'oldWorld';
+        const nw = 'newWorld';
+        final game = Game(
+          id: 'g1',
+          globalGameSeed: 99,
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(id: '$ow|P1', regionId: ow, ownerId: 'human'),
+                Province(id: '$ow|P2', regionId: ow, ownerId: 'mn1'),
+              ],
+              units: [
+                Unit(
+                  id: 'u1',
+                  type: 'grenadiers',
+                  ownerId: 'human',
+                  locationProvinceId: '$ow|P1',
+                ),
+                Unit(
+                  id: 'm1',
+                  type: 'peasant_levies',
+                  ownerId: 'mn1',
+                  locationProvinceId: '$ow|P2',
+                ),
+              ],
+            ),
+            newWorld: RegionData(
+              provinces: const [
+                Province(id: '$nw|N1', regionId: nw, ownerId: 'human'),
+                Province(id: '$nw|N2', regionId: nw, ownerId: 'tr1'),
+              ],
+              units: [
+                Unit(
+                  id: 'u2',
+                  type: 'grenadiers',
+                  ownerId: 'human',
+                  locationProvinceId: '$nw|N1',
+                ),
+                Unit(
+                  id: 't1',
+                  type: 'peasant_levies',
+                  ownerId: 'tr1',
+                  locationProvinceId: '$nw|N2',
+                ),
+              ],
+            ),
+          ),
+          players: const [
+            Player(id: 'human', displayName: 'Human', isHuman: true),
+            Player(id: 'ai1', displayName: 'AI', isHuman: false),
+          ],
+          minorNations: const [MinorNation(id: 'mn1')],
+          tribes: const [Tribe(id: 'tr1')],
+          overtureStates: const [
+            OvertureState(
+              gpId: 'ai1',
+              targetId: 'mn1',
+              stage: OvertureStage.embassy,
+            ),
+            OvertureState(
+              gpId: 'ai1',
+              targetId: 'tr1',
+              stage: OvertureStage.embassy,
+            ),
+          ],
+        );
+        final dialogueEvents = <DialogueEvent>[];
+        requireTurnResolutionComplete(
+          resolveTurnForGame(
+            game: game,
+            topology: topology,
+            orders: const Orders(
+              moveOrdersByPlayerId: {
+                'human': [
+                  MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P2'),
+                  MoveOrder(unitId: 'u2', destinationProvinceId: '$nw|N2'),
+                ],
+              },
+            ),
+            onDialogue: dialogueEvents.add,
+          ),
+        );
+        expect(
+          dialogueEvents.any((e) => e.situation == 'attack_on_minor'),
+          isTrue,
+        );
+        expect(
+          dialogueEvents.any((e) => e.situation == 'attack_on_tribe'),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'resolveTurnForGameFromOrderEngine integrates order engine output',
+      () {
+        final topology = MapTopology(
+          nodes: [
+            const TopologyNode(
+              id: 'P1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            const TopologyNode(
+              id: 'P2',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: [const TopologyEdge(id1: 'P1', id2: 'P2')],
+        );
+
+        const ow = 'oldWorld';
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+                Province(id: '$ow|P2', regionId: ow, ownerId: 'p1'),
+              ],
+              units: [
+                Unit(
+                  id: 'u1',
+                  type: 'grenadiers',
+                  ownerId: 'p1',
+                  locationProvinceId: '$ow|P1',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            playerVisibilityByTile: const {
+              'p1': {
+                'oldWorld|P1|0|0': 'fullyVisible',
+                'oldWorld|P2|0|0': 'fullyVisible',
+              },
+            },
+          ),
+          players: const [Player(id: 'p1', displayName: 'A', isHuman: true)],
+        );
+
+        final engine = OrderEngine();
+        engine.addMoveOrder(
+          'p1',
+          const MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|P2'),
+        );
+
+        final next = requireTurnResolutionComplete(
+          resolveTurnForGameFromOrderEngine(
+            game: game,
+            topology: topology,
+            orderEngine: engine,
+          ),
+        );
+
+        expect(next.worldState.turnState.turnNumber, 1);
+        expect(
+          next.worldState.oldWorld.units.single.locationProvinceId,
+          'oldWorld|P2',
+        );
+      },
+    );
+
+    test(
+      'validateOrdersAndResolveTurn filters invalid order and applies only valid move',
+      () {
+        final topology = MapTopology(
+          nodes: [
+            const TopologyNode(
+              id: 'P1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            const TopologyNode(
+              id: 'P2',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: [const TopologyEdge(id1: 'P1', id2: 'P2')],
+        );
+        const ow = 'oldWorld';
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+                Province(id: '$ow|P2', regionId: ow, ownerId: 'p1'),
+              ],
+              units: [
+                Unit(
                   id: 'u1',
                   type: 'musketeers',
                   ownerId: 'p1',
-                  locationProvinceId: '$ow|P1'),
-            ],
-          ),
-          newWorld: const RegionData(),
-          playerVisibilityByTile: const {
-            'p1': {
-              'oldWorld|P1|0|0': 'fullyVisible',
-              'oldWorld|P2|0|0': 'fullyVisible',
+                  locationProvinceId: '$ow|P1',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            playerVisibilityByTile: const {
+              'p1': {
+                'oldWorld|P1|0|0': 'fullyVisible',
+                'oldWorld|P2|0|0': 'fullyVisible',
+              },
             },
+          ),
+          players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+        );
+        final orders = Orders(
+          moveOrdersByPlayerId: {
+            'p1': [
+              MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P2'),
+              MoveOrder(unitId: 'u999', destinationProvinceId: '$ow|P2'),
+            ],
           },
-        ),
-        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
-      );
-      final orders = Orders(
-        moveOrdersByPlayerId: {
-          'p1': [
-            MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P2'),
-            MoveOrder(unitId: 'u999', destinationProvinceId: '$ow|P2'),
-          ],
-        },
-      );
-      final next = requireTurnResolutionComplete(validateOrdersAndResolveTurn(
-        game: game,
-        topology: topology,
-        orders: orders,
-        extractedByPlayerId: const {},
-        defaultAssignments: const [],
-      ));
-      expect(next.worldState.turnState.turnNumber, 1);
-      expect(next.worldState.oldWorld.units.length, 1);
-      expect(next.worldState.oldWorld.units.single.locationProvinceId, '$ow|P2');
-    });
+        );
+        final next = requireTurnResolutionComplete(
+          validateOrdersAndResolveTurn(
+            game: game,
+            topology: topology,
+            orders: orders,
+            extractedByPlayerId: const {},
+            defaultAssignments: const [],
+          ),
+        );
+        expect(next.worldState.turnState.turnNumber, 1);
+        expect(next.worldState.oldWorld.units.length, 1);
+        expect(
+          next.worldState.oldWorld.units.single.locationProvinceId,
+          '$ow|P2',
+        );
+      },
+    );
 
     test('movement phase applies naval mission order', () {
       final topology = MapTopology(
         nodes: const [
           TopologyNode(
-              id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+            id: 'sea1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.seaZone,
+          ),
         ],
         edges: const [],
       );
@@ -489,9 +752,7 @@ void main() {
             ),
           ],
         ),
-        players: const [
-          Player(id: 'p1', displayName: 'A', isHuman: true),
-        ],
+        players: const [Player(id: 'p1', displayName: 'A', isHuman: true)],
       );
       final orders = Orders(
         navalMissionOrdersByPlayerId: {
@@ -500,13 +761,15 @@ void main() {
           ],
         },
       );
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: topology,
-        orders: orders,
-        extractedByPlayerId: const {},
-        defaultAssignments: const [],
-      ));
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: topology,
+          orders: orders,
+          extractedByPlayerId: const {},
+          defaultAssignments: const [],
+        ),
+      );
       expect(next.worldState.fleets.single.mission, FleetMission.patrol);
       expect(next.worldState.turnState.turnNumber, 1);
     });
@@ -515,13 +778,17 @@ void main() {
       final topology = MapTopology(
         nodes: const [
           TopologyNode(
-              id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+            id: 'sea1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.seaZone,
+          ),
           TopologyNode(
-              id: 'sea2', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+            id: 'sea2',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.seaZone,
+          ),
         ],
-        edges: const [
-          TopologyEdge(id1: 'sea1', id2: 'sea2'),
-        ],
+        edges: const [TopologyEdge(id1: 'sea1', id2: 'sea2')],
       );
       final game = Game(
         id: 'g1',
@@ -539,24 +806,22 @@ void main() {
             ),
           ],
         ),
-        players: const [
-          Player(id: 'p1', displayName: 'A', isHuman: true),
-        ],
+        players: const [Player(id: 'p1', displayName: 'A', isHuman: true)],
       );
       final orders = Orders(
         navalMoveOrdersByPlayerId: {
-          'p1': [
-            NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 'sea2'),
-          ],
+          'p1': [NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 'sea2')],
         },
       );
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: topology,
-        orders: orders,
-        extractedByPlayerId: const {},
-        defaultAssignments: const [],
-      ));
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: topology,
+          orders: orders,
+          extractedByPlayerId: const {},
+          defaultAssignments: const [],
+        ),
+      );
       expect(next.worldState.fleets.single.seaZoneId, 'sea2');
       expect(next.worldState.turnState.turnNumber, 1);
     });
@@ -565,21 +830,21 @@ void main() {
       const ow = 'oldWorld';
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(
+            id: 'sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
           TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
         ],
-        edges: const [
-          TopologyEdge(id1: 'sea1', id2: 'P1'),
-        ],
+        edges: const [TopologyEdge(id1: 'sea1', id2: 'P1')],
       );
       final game = Game(
         id: 'g1',
         worldState: WorldState(
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
           oldWorld: RegionData(
-            provinces: [
-              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
-            ],
+            provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
           ),
           newWorld: const RegionData(),
           fleets: [
@@ -593,27 +858,24 @@ void main() {
             ),
           ],
         ),
-        players: const [
-          Player(id: 'p1', displayName: 'A', isHuman: true),
-        ],
+        players: const [Player(id: 'p1', displayName: 'A', isHuman: true)],
       );
       final orders = Orders(
         navalMoveOrdersByPlayerId: {
           'p1': [
-            NavalMoveOrder(
-              fleetId: 'f1',
-              destinationPortProvinceId: '$ow|P1',
-            ),
+            NavalMoveOrder(fleetId: 'f1', destinationPortProvinceId: '$ow|P1'),
           ],
         },
       );
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: topology,
-        orders: orders,
-        extractedByPlayerId: const {},
-        defaultAssignments: const [],
-      ));
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: topology,
+          orders: orders,
+          extractedByPlayerId: const {},
+          defaultAssignments: const [],
+        ),
+      );
       final fleet = next.worldState.fleets.single;
       expect(fleet.isInPort, isTrue);
       expect(fleet.inPortAtProvinceId, '$ow|P1');
@@ -624,21 +886,21 @@ void main() {
       const ow = 'oldWorld';
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(
+            id: 'sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
           TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
         ],
-        edges: const [
-          TopologyEdge(id1: 'sea1', id2: 'P1'),
-        ],
+        edges: const [TopologyEdge(id1: 'sea1', id2: 'P1')],
       );
       final game = Game(
         id: 'g1',
         worldState: WorldState(
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
           oldWorld: RegionData(
-            provinces: [
-              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
-            ],
+            provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
           ),
           newWorld: const RegionData(),
           fleets: [
@@ -652,9 +914,7 @@ void main() {
             ),
           ],
         ),
-        players: const [
-          Player(id: 'p1', displayName: 'A', isHuman: true),
-        ],
+        players: const [Player(id: 'p1', displayName: 'A', isHuman: true)],
       );
       final orders = Orders(
         navalMoveOrdersByPlayerId: {
@@ -663,13 +923,15 @@ void main() {
           ],
         },
       );
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: topology,
-        orders: orders,
-        extractedByPlayerId: const {},
-        defaultAssignments: const [],
-      ));
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: topology,
+          orders: orders,
+          extractedByPlayerId: const {},
+          defaultAssignments: const [],
+        ),
+      );
       final fleet = next.worldState.fleets.single;
       expect(fleet.isAtSea, isTrue);
       expect(fleet.seaZoneId, 'sea1');
@@ -680,13 +942,17 @@ void main() {
       final topology = MapTopology(
         nodes: const [
           TopologyNode(
-              id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+            id: 'sea1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.seaZone,
+          ),
           TopologyNode(
-              id: 'sea2', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+            id: 'sea2',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.seaZone,
+          ),
         ],
-        edges: const [
-          TopologyEdge(id1: 'sea1', id2: 'sea2'),
-        ],
+        edges: const [TopologyEdge(id1: 'sea1', id2: 'sea2')],
       );
       final game = Game(
         id: 'g1',
@@ -704,26 +970,28 @@ void main() {
             ),
           ],
         ),
-        players: const [
-          Player(id: 'p1', displayName: 'A', isHuman: true),
-        ],
+        players: const [Player(id: 'p1', displayName: 'A', isHuman: true)],
       );
       final orders = Orders(
         navalMoveOrdersByPlayerId: {
           'p1': [
             const NavalMoveOrder(
-                fleetId: 'fleet_p1', destinationSeaZoneId: 'sea2'),
+              fleetId: 'fleet_p1',
+              destinationSeaZoneId: 'sea2',
+            ),
           ],
         },
       );
 
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: topology,
-        orders: orders,
-        extractedByPlayerId: const {},
-        defaultAssignments: const [],
-      ));
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: topology,
+          orders: orders,
+          extractedByPlayerId: const {},
+          defaultAssignments: const [],
+        ),
+      );
       expect(next.worldState.fleets.single.seaZoneId, 'sea1');
       expect(next.worldState.turnState.turnNumber, 1);
     });


### PR DESCRIPTION
## Summary
- Align SPEC and implementation for remaining dialogue/mood ACs in #1411, including an explicit implemented-vs-deferred situation truth table and canonical situation tokens.
- Add deterministic event/reactive dialogue emission hooks for `attack_on_ally`, `attack_on_minor`, `attack_on_tribe`, `tech_first`, `spies_caught`, `tech_discovered`, `capital_threatened`, and `colony_founded`.
- Add negotiation mood transition helper/event path and extend logic/AI tests to cover each implemented path and deterministic behavior.

Re #1411.

## Test plan
- [x] `dart test packages/colonizethis_ai/test/mood_state_machine_test.dart`
- [x] `dart test packages/colonizethis_logic/test/event_dialogue_test.dart`
- [x] `dart test packages/colonizethis_logic/test/turn_resolution_events_dialogue_test.dart`
- [x] `dart test packages/colonizethis_logic/test/turn_resolver_resolve_turn_for_game_part2_test.dart`

Made with [Cursor](https://cursor.com)