### PR TITLE
fix(app): prevent production panel overflow in narrow layouts

### DIFF
--- a/app/lib/features/game/widgets/production_panel.dart
+++ b/app/lib/features/game/widgets/production_panel.dart
@@ -148,20 +148,25 @@ class _AvailableSubpanel extends StatelessWidget {
     Map<String, int> netChanges,
     ThemeData theme,
   ) {
-    return Wrap(
-      spacing: 8,
-      runSpacing: 4,
-      children: commodities.map((c) {
-        final qty = player.stockpile.quantityOf(c.id);
-        final change = netChanges[c.id] ?? 0;
-        return _buildCommodityRow(c, qty, change, theme);
-      }).toList(),
+    return LayoutBuilder(
+      builder: (context, constraints) => Wrap(
+        spacing: 8,
+        runSpacing: 4,
+        children: commodities.map((c) {
+          final qty = player.stockpile.quantityOf(c.id);
+          final change = netChanges[c.id] ?? 0;
+          return SizedBox(
+            width: constraints.maxWidth,
+            child: _buildCommodityRow(c, qty, change, theme),
+          );
+        }).toList(),
+      ),
     );
   }
 
   Widget _buildWorkerRow(String workerType, int count, ThemeData theme) {
     return Row(
-      mainAxisSize: MainAxisSize.min,
+      mainAxisSize: MainAxisSize.max,
       children: [
         WorkerIcon(workerType: workerType, size: 16),
         const SizedBox(width: 4),
@@ -237,21 +242,23 @@ class _AvailableSubpanel extends StatelessWidget {
             const SizedBox(height: 12),
             Text('Workers', style: theme.textTheme.labelMedium),
             const SizedBox(height: 4),
-            Wrap(
-              spacing: 16,
-              runSpacing: 4,
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 _buildWorkerRow('peasant', player.workerPool.peasants, theme),
+                const SizedBox(height: 4),
                 _buildWorkerRow(
                   'apprentice',
                   player.workerPool.apprentices,
                   theme,
                 ),
+                const SizedBox(height: 4),
                 _buildWorkerRow(
                   'journeyman',
                   player.workerPool.journeymen,
                   theme,
                 ),
+                const SizedBox(height: 4),
                 _buildWorkerRow('master', player.workerPool.masters, theme),
               ],
             ),


### PR DESCRIPTION
## Summary
- constrain production commodity rows in `ProductionPanel` so icon+label rows stay within available width in narrow layouts
- switch workers section to a vertical constrained layout so worker rows can ellipsize instead of overflowing
- resolves widget test failures caused by `RenderFlex overflow` in `app/test/production_panel_test.dart`

## Test plan
- [x] `cd app && flutter test test/production_panel_test.dart --reporter compact`

Made with [Cursor](https://cursor.com)