### PR TITLE
test(map): cover province presence icon behavior and relax semantics AC (#1427)

### DIFF
--- a/SPEC/ui/map-widget.md
+++ b/SPEC/ui/map-widget.md
@@ -56,7 +56,7 @@ Render and data rules:
 - **Fog/intel gate:** if current player intel does not permit knowledge of class presence in that province, render no class icons for that province (even if hidden world state has units there).
 - **Layout:** default is inline with the province name; when horizontal space is insufficient, wrap the icons to a second line below the province name while keeping class order.
 - **Interaction:** icons are decorative only (no counts, no direct command actions).
-- **Semantics:** map widget may expose semantic labels/tooltips describing class presence for accessibility.
+- **Semantics:** map widget may expose semantic labels/tooltips describing class presence for accessibility, but icon-level semantics are optional because these indicators are decorative and non-interactive.
 - **Refresh cadence:** label icon data is recomputed at turn start after turn resolution.
 
 ### Base overlay paint order (Z-order, bottom → top)

--- a/app/lib/features/game/flame/region_map_component.dart
+++ b/app/lib/features/game/flame/region_map_component.dart
@@ -35,6 +35,42 @@ const double _provinceLabelIconRenderedPx = 12;
 const double _provinceLabelIconGapPx = 3;
 const double _provinceLabelTextIconGapPx = 4;
 
+/// Resolves map province-label presence icon ids from province presence data.
+///
+/// Order is always civilian, regiment, ship. Icons are suppressed when intel is
+/// not visible or count is zero.
+List<String> resolveProvinceLabelPresenceIconIds(
+  ProvinceUnitPresenceView? presence,
+) {
+  final showPresenceIcons = presence != null && presence.intelVisible;
+  if (!showPresenceIcons) {
+    return const <String>[];
+  }
+  return <String>[
+    if (presence.civilianCount > 0) 'map_presence_civilian',
+    if (presence.regimentCount > 0) 'map_presence_regiment',
+    if (presence.shipCount > 0) 'map_presence_ship',
+  ];
+}
+
+/// Returns true when province-name text + icons should wrap icons to line 2.
+bool shouldWrapProvinceLabelPresenceIcons({
+  required double textWidthPx,
+  required int iconCount,
+  double maxWidthPx = _provinceLabelMaxWidthPx,
+  double iconRenderedPx = _provinceLabelIconRenderedPx,
+  double iconGapPx = _provinceLabelIconGapPx,
+  double textIconGapPx = _provinceLabelTextIconGapPx,
+}) {
+  if (iconCount <= 0) {
+    return false;
+  }
+  final iconsWidth =
+      (iconCount * iconRenderedPx) + ((iconCount - 1) * iconGapPx);
+  final singleLineContentWidth = textWidthPx + textIconGapPx + iconsWidth;
+  return singleLineContentWidth > maxWidthPx;
+}
+
 /// Check if a terrain type uses L2+ standalone tile rendering (features).
 /// L0: Sea (Wang). L1: Plains/Desert (Wang). L2+: Features (standalone).
 bool _isFeatureTerrain(TerrainType terrain) {
@@ -482,15 +518,7 @@ class CtRegionMapComponent extends PositionComponent {
 
     for (final item in labels) {
       final presence = region.provinceUnitPresenceByProvinceId[item.provinceId];
-      final showPresenceIcons =
-          presence != null && presence.intelVisible == true;
-      final iconIds = <String>[
-        if (showPresenceIcons && presence.civilianCount > 0)
-          'map_presence_civilian',
-        if (showPresenceIcons && presence.regimentCount > 0)
-          'map_presence_regiment',
-        if (showPresenceIcons && presence.shipCount > 0) 'map_presence_ship',
-      ];
+      final iconIds = resolveProvinceLabelPresenceIconIds(presence);
       final iconCount = iconIds.length;
       final iconsWidth = iconCount > 0
           ? (iconCount * _provinceLabelIconRenderedPx) +
@@ -507,8 +535,10 @@ class CtRegionMapComponent extends PositionComponent {
       final th = tp.height;
       final singleLineContentWidth =
           tw + (iconCount > 0 ? _provinceLabelTextIconGapPx + iconsWidth : 0);
-      final wrapIconsToSecondLine =
-          iconCount > 0 && singleLineContentWidth > _provinceLabelMaxWidthPx;
+      final wrapIconsToSecondLine = shouldWrapProvinceLabelPresenceIcons(
+        textWidthPx: tw,
+        iconCount: iconCount,
+      );
       final contentWidth = wrapIconsToSecondLine
           ? math.max(tw, iconsWidth)
           : singleLineContentWidth;

--- a/app/test/ct_region_map_widget_test.dart
+++ b/app/test/ct_region_map_widget_test.dart
@@ -8,6 +8,10 @@ import 'package:colonizethis_models/colonizethis_models.dart'
     show AppEventBus, OpenProvinceDetailPanelEvent;
 
 import 'package:colonizethis_app/features/game/flame/resource_icon_cache.dart';
+import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
+    show
+        resolveProvinceLabelPresenceIconIds,
+        shouldWrapProvinceLabelPresenceIcons;
 import 'package:colonizethis_app/features/game/flame/province_label_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/terrain_tileset.dart';
 import 'package:colonizethis_app/features/game/flame/town_icon_cache.dart';
@@ -67,6 +71,163 @@ void main() {
             reason: 'Province label icon $path is empty',
           );
         }
+      },
+      timeout: const Timeout(Duration(seconds: 10)),
+    );
+
+    testWidgets(
+      'province presence icon resolver enforces intel gate, zero suppression, and class order',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(const SizedBox.shrink());
+
+        expect(
+          resolveProvinceLabelPresenceIconIds(null),
+          isEmpty,
+          reason: 'Null presence should suppress all icons',
+        );
+        expect(
+          resolveProvinceLabelPresenceIconIds(
+            const ProvinceUnitPresenceView(
+              civilianCount: 1,
+              regimentCount: 1,
+              shipCount: 1,
+              intelVisible: false,
+            ),
+          ),
+          isEmpty,
+          reason: 'Hidden intel should suppress all icons',
+        );
+        expect(
+          resolveProvinceLabelPresenceIconIds(
+            const ProvinceUnitPresenceView(
+              civilianCount: 1,
+              regimentCount: 2,
+              shipCount: 3,
+              intelVisible: true,
+            ),
+          ),
+          const [
+            'map_presence_civilian',
+            'map_presence_regiment',
+            'map_presence_ship',
+          ],
+        );
+        expect(
+          resolveProvinceLabelPresenceIconIds(
+            const ProvinceUnitPresenceView(
+              civilianCount: 0,
+              regimentCount: 4,
+              shipCount: 0,
+              intelVisible: true,
+            ),
+          ),
+          const ['map_presence_regiment'],
+          reason: 'Only >0 classes should render',
+        );
+      },
+      timeout: const Timeout(Duration(seconds: 5)),
+    );
+
+    testWidgets(
+      'presence icon wrap helper moves icons to second line only when width is insufficient',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(const SizedBox.shrink());
+
+        expect(
+          shouldWrapProvinceLabelPresenceIcons(textWidthPx: 20, iconCount: 0),
+          isFalse,
+        );
+        expect(
+          shouldWrapProvinceLabelPresenceIcons(textWidthPx: 60, iconCount: 2),
+          isFalse,
+          reason: 'Content fits one line',
+        );
+        expect(
+          shouldWrapProvinceLabelPresenceIcons(textWidthPx: 110, iconCount: 3),
+          isTrue,
+          reason: 'Content should wrap to second line when too wide',
+        );
+      },
+      timeout: const Timeout(Duration(seconds: 5)),
+    );
+
+    testWidgets(
+      'didUpdateWidget refreshes map region presence data after rebuild',
+      (WidgetTester tester) async {
+        final base = ctRegionMapTestOldWorldRegion();
+        final localProvinceId = base.cells.firstWhere((c) => !c.isSea).regionCellId;
+        final fullProvinceId = '${base.regionId}|$localProvinceId';
+
+        RegionMapViewData withPresence({
+          required int civilianCount,
+          required int regimentCount,
+          required int shipCount,
+          required bool intelVisible,
+        }) {
+          return RegionMapViewData(
+            regionId: base.regionId,
+            width: base.width,
+            height: base.height,
+            cellSize: base.cellSize,
+            cells: base.cells,
+            capitalMarkers: base.capitalMarkers,
+            portMarkers: base.portMarkers,
+            factionColors: base.factionColors,
+            greatPowerFactionIds: base.greatPowerFactionIds,
+            terrainColors: base.terrainColors,
+            unitMarkers: base.unitMarkers,
+            warpMarkers: base.warpMarkers,
+            townMarkers: base.townMarkers,
+            provinceUnitPresenceByProvinceId: {
+              ...base.provinceUnitPresenceByProvinceId,
+              fullProvinceId: ProvinceUnitPresenceView(
+                civilianCount: civilianCount,
+                regimentCount: regimentCount,
+                shipCount: shipCount,
+                intelVisible: intelVisible,
+              ),
+            },
+          );
+        }
+
+        final initial = withPresence(
+          civilianCount: 0,
+          regimentCount: 0,
+          shipCount: 0,
+          intelVisible: true,
+        );
+        final refreshed = withPresence(
+          civilianCount: 1,
+          regimentCount: 1,
+          shipCount: 1,
+          intelVisible: true,
+        );
+
+        await tester.pumpWidget(ctRegionMapTestHarness(region: initial));
+        await tester.pump();
+
+        final gameWidgetFinder = find.byWidgetPredicate(
+          (w) => w.runtimeType.toString().startsWith('GameWidget<'),
+        );
+        expect(gameWidgetFinder, findsOneWidget);
+        final beforeWidget = tester.widget(gameWidgetFinder);
+        final beforeRegion = (beforeWidget as dynamic).game.region as RegionMapViewData;
+        final beforePresence = beforeRegion.provinceUnitPresenceByProvinceId[fullProvinceId];
+        expect(beforePresence, isNotNull);
+        expect(beforePresence!.civilianCount, 0);
+        expect(beforePresence.regimentCount, 0);
+        expect(beforePresence.shipCount, 0);
+
+        await tester.pumpWidget(ctRegionMapTestHarness(region: refreshed));
+        await tester.pump();
+
+        final afterWidget = tester.widget(gameWidgetFinder);
+        final afterRegion = (afterWidget as dynamic).game.region as RegionMapViewData;
+        final afterPresence = afterRegion.provinceUnitPresenceByProvinceId[fullProvinceId];
+        expect(afterPresence, isNotNull);
+        expect(afterPresence!.civilianCount, 1);
+        expect(afterPresence.regimentCount, 1);
+        expect(afterPresence.shipCount, 1);
       },
       timeout: const Timeout(Duration(seconds: 10)),
     );


### PR DESCRIPTION
## Summary
- add province-label presence icon behavior tests for intel gating, zero-count suppression, class order, wrap decision, and post-rebuild refresh propagation
- extract and reuse explicit helpers in the map component for icon id resolution and wrap threshold logic to make behavior directly testable
- relax `SPEC/ui/map-widget.md` semantics wording so icon-level accessibility semantics are optional for decorative/non-interactive presence indicators

Closes #1427.

## Test plan
- [x] `cd app && flutter test test/ct_region_map_widget_test.dart`

Made with [Cursor](https://cursor.com)