### PR TITLE
fix(app): handle CombatModeChosenEvent in AppEventHandlerScope

### DIFF
--- a/app/lib/core/services/app_event_handler_scope.dart
+++ b/app/lib/core/services/app_event_handler_scope.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:colonizethis_app/app.dart';
 import 'package:colonizethis_app/features/game/logic/naval_fleet_split_apply.dart';
@@ -41,6 +42,18 @@ const String quickBattleResultDialogId = 'quick_battle_result';
 
 final _logShell = appLogger('shell');
 final _logEvent = appLogger('event');
+
+/// Applies a chosen combat mode to the current game session state.
+@visibleForTesting
+Game? applyCombatModeChoiceToGame(Game? currentGame, CombatMode chosenMode) {
+  if (currentGame == null) {
+    return null;
+  }
+  if (currentGame.defaultCombatMode == chosenMode) {
+    return currentGame;
+  }
+  return currentGame.copyWith(defaultCombatMode: chosenMode);
+}
 
 /// Replaces pending train-at-capital civilian [BuildUnitOrder]s for [humanPlayerId];
 /// keeps military, naval, and other build orders. Matches [TrainCiviliansDialog] semantics.
@@ -314,8 +327,9 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
         if (g == null) return;
         final pid = _humanPlayerId(g);
         final o = ref.read(currentOrdersProvider);
-        ref.read(currentOrdersProvider.notifier).state =
-            _mergeTrainCivilianOrdersForPlayer(
+        ref
+            .read(currentOrdersProvider.notifier)
+            .state = _mergeTrainCivilianOrdersForPlayer(
           current: o,
           game: g,
           humanPlayerId: pid,
@@ -327,18 +341,33 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
         if (g == null) return;
         final pid = _humanPlayerId(g);
         final o = ref.read(currentOrdersProvider);
-        ref.read(currentOrdersProvider.notifier).state =
-            _mergeTrainMilitaryOrdersForPlayer(
+        ref
+            .read(currentOrdersProvider.notifier)
+            .state = _mergeTrainMilitaryOrdersForPlayer(
           current: o,
           game: g,
           humanPlayerId: pid,
           newFromDialog: e.orders,
         );
       }),
+      bus.on<CombatModeChosenEvent>().listen((e) {
+        final g = ref.read(currentGameProvider);
+        final updated = applyCombatModeChoiceToGame(g, e.mode);
+        if (updated == null) {
+          _logEvent.w(
+            'CombatModeChosenEvent received without an active game; ignoring',
+          );
+          return;
+        }
+        if (identical(updated, g)) {
+          return;
+        }
+        ref.read(currentGameProvider.notifier).setGame(updated);
+        ref.read(gameServiceProvider).saveGame(updated);
+        _logEvent.i('combat: set default combat mode to ${e.mode.name}');
+      }),
     ]);
-    _logEvent.d(
-      'AppEventHandler bound; session command listeners attached',
-    );
+    _logEvent.d('AppEventHandler bound; session command listeners attached');
   }
 
   void _showSnackBar(ShowSnackBarEvent event) {

--- a/app/test/app_event_handler_scope_test.dart
+++ b/app/test/app_event_handler_scope_test.dart
@@ -1,0 +1,42 @@
+import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Game gameWithMode(CombatMode mode) {
+    return Game(
+      id: 'g1',
+      worldState: const WorldState(
+        turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: RegionData(),
+        newWorld: RegionData(),
+      ),
+      players: const [
+        Player(id: 'p1', displayName: 'P1', isHuman: true),
+        Player(id: 'p2', displayName: 'P2', isHuman: false),
+      ],
+      defaultCombatMode: mode,
+    );
+  }
+
+  group('applyCombatModeChoiceToGame', () {
+    test('returns null when there is no active game', () {
+      final updated = applyCombatModeChoiceToGame(null, CombatMode.quickBattle);
+      expect(updated, isNull);
+    });
+
+    test('returns same instance when mode is unchanged', () {
+      final game = gameWithMode(CombatMode.quickBattle);
+      final updated = applyCombatModeChoiceToGame(game, CombatMode.quickBattle);
+      expect(identical(updated, game), isTrue);
+    });
+
+    test('updates default combat mode when player picks a new mode', () {
+      final game = gameWithMode(CombatMode.autoResolve);
+      final updated = applyCombatModeChoiceToGame(game, CombatMode.quickBattle);
+      expect(updated, isNotNull);
+      expect(updated!.defaultCombatMode, CombatMode.quickBattle);
+      expect(updated.id, game.id);
+    });
+  });
+}

--- a/app/test/app_event_handler_scope_test.dart
+++ b/app/test/app_event_handler_scope_test.dart
@@ -1,8 +1,11 @@
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  suppressLogsForTests();
+
   Game gameWithMode(CombatMode mode) {
     return Game(
       id: 'g1',


### PR DESCRIPTION
## Summary
- subscribe to `CombatModeChosenEvent` in `AppEventHandlerScope` so combat mode choices are not dropped
- apply chosen mode to `currentGameProvider` and persist via `GameService.saveGame`
- add `app_event_handler_scope_test.dart` coverage for null, unchanged, and changed combat mode paths

## Test plan
- [x] `dart format app/lib/core/services/app_event_handler_scope.dart app/test/app_event_handler_scope_test.dart`
- [ ] `flutter test app/test/app_event_handler_scope_test.dart` *(blocked by unrelated compile errors in `intervention_dialogue_overlay` missing `game_intervention_*` l10n members)*

Made with [Cursor](https://cursor.com)