### PR TITLE
Wire AC3 negotiation mood transitions into diplomacy UI (refs #1411)

### DIFF
--- a/app/lib/features/game/widgets/diplomacy_panel.dart
+++ b/app/lib/features/game/widgets/diplomacy_panel.dart
@@ -1,9 +1,11 @@
 // Diplomacy panel. SPEC/ui/diplomacy-panel.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
+import 'dart:async';
 
 import '../../../config/routes.dart';
 import '../../../core/services/app_event_handler_scope.dart';
@@ -214,7 +216,7 @@ List<DiplomacyRowData> buildDiplomacyRows(
 }
 
 /// Full-page diplomacy panel. SPEC/ui/diplomacy-panel.md.
-class DiplomacyPanel extends StatelessWidget {
+class DiplomacyPanel extends StatefulWidget {
   const DiplomacyPanel({
     super.key,
     required this.game,
@@ -235,12 +237,34 @@ class DiplomacyPanel extends StatelessWidget {
   final VoidCallback? onClose;
 
   @override
+  State<DiplomacyPanel> createState() => _DiplomacyPanelState();
+}
+
+class _DiplomacyPanelState extends State<DiplomacyPanel> {
+  final Map<String, String> _moodByLeaderId = <String, String>{};
+  StreamSubscription<PortraitMoodEvent>? _moodSub;
+
+  @override
+  void initState() {
+    super.initState();
+    _moodSub = widget.bus.on<PortraitMoodEvent>().listen((event) {
+      _moodByLeaderId[event.leaderId] = event.toMood;
+    });
+  }
+
+  @override
+  void dispose() {
+    _moodSub?.cancel();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final rows = buildDiplomacyRows(
-      game,
-      topology,
-      humanPlayerId,
-      currentOrders,
+      widget.game,
+      widget.topology,
+      widget.humanPlayerId,
+      widget.currentOrders,
     );
     final gps = rows.where((r) => r.kind == FactionKind.greatPower).toList();
     final minors = rows.where((r) => r.kind == FactionKind.minor).toList();
@@ -305,12 +329,19 @@ class DiplomacyPanel extends StatelessWidget {
 
   void _submitOrDialog(DiplomaticOrder order) {
     final pending =
-        currentOrders.diplomaticOrdersByPlayerId[humanPlayerId] ?? [];
+        widget.currentOrders.diplomaticOrdersByPlayerId[widget.humanPlayerId] ??
+        [];
     final alreadyPending = pending.any(
       (o) => o.type == order.type && o.targetFactionId == order.targetFactionId,
     );
     if (alreadyPending) {
       _removeOrder(order.type, order.targetFactionId);
+      _emitNegotiationMood(
+        leaderId: order.targetFactionId,
+        offerQualityDelta: -0.25,
+        stallCounter: pending.length,
+        discriminator: '${order.type.name}:cancel',
+      );
       return;
     }
     final needsParams =
@@ -327,7 +358,7 @@ class DiplomacyPanel extends StatelessWidget {
 
   void _showConfirmDialog(DiplomaticOrder order) {
     final actionLabel = diplomacyActionLabel(order);
-    bus.emit(
+    widget.bus.emit(
       ConfirmDialogEvent(
         title: actionLabel,
         message:
@@ -335,6 +366,12 @@ class DiplomacyPanel extends StatelessWidget {
         onResult: (confirmed) {
           if (confirmed) {
             _appendOrder(order);
+            _emitNegotiationMood(
+              leaderId: order.targetFactionId,
+              offerQualityDelta: _offerQualityDeltaFor(order.type),
+              stallCounter: _pendingCountForTarget(order.targetFactionId),
+              discriminator: order.type.name,
+            );
           }
         },
       ),
@@ -342,12 +379,12 @@ class DiplomacyPanel extends StatelessWidget {
   }
 
   String _targetName(String factionId) {
-    final p = game.playerById(factionId);
+    final p = widget.game.playerById(factionId);
     if (p != null) return p.displayName;
-    for (final m in game.minorNations) {
+    for (final m in widget.game.minorNations) {
       if (m.id == factionId) return m.displayName ?? factionId;
     }
-    for (final t in game.tribes) {
+    for (final t in widget.game.tribes) {
       if (t.id == factionId) return t.displayName ?? factionId;
     }
     return factionId;
@@ -356,7 +393,7 @@ class DiplomacyPanel extends StatelessWidget {
   void _showDialogForOrder(DiplomaticOrder order) {
     if (order.type == DiplomaticOrderType.grantAid ||
         order.type == DiplomaticOrderType.setSubsidy) {
-      bus.emit(
+      widget.bus.emit(
         OpenDialogEvent(grantOrSubsidyDialogId, {
           'targetFactionId': order.targetFactionId,
           'isSubsidy': order.type == DiplomaticOrderType.setSubsidy,
@@ -369,9 +406,9 @@ class DiplomacyPanel extends StatelessWidget {
   }
 
   void _removeOrder(DiplomaticOrderType type, String targetFactionId) {
-    onOrdersChanged(
-      currentOrders.removeDiplomaticOrderForPlayer(
-        humanPlayerId,
+    widget.onOrdersChanged(
+      widget.currentOrders.removeDiplomaticOrderForPlayer(
+        widget.humanPlayerId,
         type: type,
         targetFactionId: targetFactionId,
       ),
@@ -379,10 +416,10 @@ class DiplomacyPanel extends StatelessWidget {
   }
 
   void _openDetail(DiplomacyRowData row) {
-    bus.emit(
+    widget.bus.emit(
       NavigateToRouteEvent(Routes.diplomacyDetail, {
-        'game': game,
-        'humanPlayerId': humanPlayerId,
+        'game': widget.game,
+        'humanPlayerId': widget.humanPlayerId,
         'factionId': row.factionId,
         'factionDisplayName': row.displayName,
         'kind': row.kind,
@@ -392,8 +429,73 @@ class DiplomacyPanel extends StatelessWidget {
   }
 
   void _appendOrder(DiplomaticOrder order) {
-    onOrdersChanged(
-      currentOrders.appendDiplomaticOrderForPlayer(humanPlayerId, order),
+    widget.onOrdersChanged(
+      widget.currentOrders.appendDiplomaticOrderForPlayer(
+        widget.humanPlayerId,
+        order,
+      ),
+    );
+  }
+
+  int _pendingCountForTarget(String targetFactionId) {
+    final list =
+        widget.currentOrders.diplomaticOrdersByPlayerId[widget.humanPlayerId] ??
+        const <DiplomaticOrder>[];
+    return list.where((o) => o.targetFactionId == targetFactionId).length;
+  }
+
+  double _offerQualityDeltaFor(DiplomaticOrderType type) {
+    switch (type) {
+      case DiplomaticOrderType.declareWar:
+        return -0.8;
+      case DiplomaticOrderType.offerPeace:
+        return 0.6;
+      case DiplomaticOrderType.alliance:
+        return 0.4;
+      case DiplomaticOrderType.establishOverture:
+        return 0.5;
+      case DiplomaticOrderType.grantAid:
+        return 0.7;
+      case DiplomaticOrderType.setSubsidy:
+        return 0.5;
+    }
+  }
+
+  int _stableSeed({
+    required String leaderId,
+    required String discriminator,
+    required int stallCounter,
+  }) {
+    final turn = widget.game.worldState.turnState.turnNumber;
+    final base = widget.game.globalGameSeed ?? 0;
+    final text = '$leaderId|$discriminator|$stallCounter|$turn';
+    var hash = 0x811C9DC5;
+    for (final code in text.codeUnits) {
+      hash ^= code;
+      hash = (hash * 0x01000193) & 0x7fffffff;
+    }
+    return base ^ hash;
+  }
+
+  void _emitNegotiationMood({
+    required String leaderId,
+    required double offerQualityDelta,
+    required int stallCounter,
+    required String discriminator,
+  }) {
+    final currentMood = _moodByLeaderId[leaderId] ?? kDefaultMood;
+    widget.bus.emit(
+      NegotiationMoodUpdateEvent(
+        leaderId: leaderId,
+        currentMood: currentMood,
+        offerQualityDelta: offerQualityDelta,
+        stallCounter: stallCounter,
+        seed: _stableSeed(
+          leaderId: leaderId,
+          discriminator: discriminator,
+          stallCounter: stallCounter,
+        ),
+      ),
     );
   }
 }

--- a/app/lib/features/game/widgets/grant_or_subsidy_listener.dart
+++ b/app/lib/features/game/widgets/grant_or_subsidy_listener.dart
@@ -2,6 +2,7 @@
 
 import 'dart:async';
 
+import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
@@ -26,6 +27,8 @@ class GrantOrSubsidyListener extends StatefulWidget {
 
 class _GrantOrSubsidyListenerState extends State<GrantOrSubsidyListener> {
   StreamSubscription? _sub;
+  StreamSubscription<PortraitMoodEvent>? _moodSub;
+  final Map<String, String> _moodByLeaderId = <String, String>{};
 
   String _targetName(String factionId) {
     final p = widget.game.playerById(factionId);
@@ -42,6 +45,9 @@ class _GrantOrSubsidyListenerState extends State<GrantOrSubsidyListener> {
   @override
   void initState() {
     super.initState();
+    _moodSub = widget.bus.on<PortraitMoodEvent>().listen((event) {
+      _moodByLeaderId[event.leaderId] = event.toMood;
+    });
     _sub = widget.bus.on<GrantOrSubsidySubmittedEvent>().listen((event) {
       final targetName = _targetName(event.targetFactionId);
       final actionName = event.isSubsidy ? 'Set subsidy' : 'Grant aid';
@@ -54,6 +60,19 @@ class _GrantOrSubsidyListenerState extends State<GrantOrSubsidyListener> {
               final orderType = event.isSubsidy
                   ? DiplomaticOrderType.setSubsidy
                   : DiplomaticOrderType.grantAid;
+              final turn = widget.game.worldState.turnState.turnNumber;
+              final base = widget.game.globalGameSeed ?? 0;
+              final currentMood =
+                  _moodByLeaderId[event.targetFactionId] ?? kDefaultMood;
+              widget.bus.emit(
+                NegotiationMoodUpdateEvent(
+                  leaderId: event.targetFactionId,
+                  currentMood: currentMood,
+                  offerQualityDelta: event.isSubsidy ? 0.5 : 0.7,
+                  stallCounter: 0,
+                  seed: base ^ (turn * 0x9E3779B1) ^ event.amount,
+                ),
+              );
               widget.onConfirmed(
                 DiplomaticOrder(
                   type: orderType,
@@ -71,6 +90,7 @@ class _GrantOrSubsidyListenerState extends State<GrantOrSubsidyListener> {
   @override
   void dispose() {
     _sub?.cancel();
+    _moodSub?.cancel();
     super.dispose();
   }
 

--- a/app/lib/widgets/game_to_ui_bus_listener.dart
+++ b/app/lib/widgets/game_to_ui_bus_listener.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -28,6 +29,7 @@ class GameToUIBusListener extends ConsumerStatefulWidget {
 
 class _GameToUIBusListenerState extends ConsumerState<GameToUIBusListener> {
   StreamSubscription<TurnResolutionCompleteEvent>? _turnSub;
+  StreamSubscription<NegotiationMoodUpdateEvent>? _negotiationMoodSub;
 
   @override
   void didChangeDependencies() {
@@ -36,6 +38,11 @@ class _GameToUIBusListenerState extends ConsumerState<GameToUIBusListener> {
         ref.read(appEventBusProvider).on<TurnResolutionCompleteEvent>().listen(
               _onTurnResolutionComplete,
             );
+    _negotiationMoodSub ??=
+        ref
+            .read(appEventBusProvider)
+            .on<NegotiationMoodUpdateEvent>()
+            .listen(_onNegotiationMoodUpdate);
   }
 
   void _onTurnResolutionComplete(TurnResolutionCompleteEvent event) {
@@ -53,9 +60,24 @@ class _GameToUIBusListenerState extends ConsumerState<GameToUIBusListener> {
     ref.read(currentGameProvider.notifier).setGame(reloaded);
   }
 
+  void _onNegotiationMoodUpdate(NegotiationMoodUpdateEvent event) {
+    if (!mounted) return;
+    final transition = buildNegotiationMoodTransitionEvent(
+      leaderId: event.leaderId,
+      currentMood: event.currentMood,
+      offerQualityDelta: event.offerQualityDelta,
+      stallCounter: event.stallCounter,
+      seed: event.seed,
+      durationMs: event.durationMs,
+    );
+    if (transition == null) return;
+    ref.read(appEventBusProvider).emit(transition);
+  }
+
   @override
   void dispose() {
     _turnSub?.cancel();
+    _negotiationMoodSub?.cancel();
     super.dispose();
   }
 

--- a/app/test/app_event_bus_test.dart
+++ b/app/test/app_event_bus_test.dart
@@ -208,6 +208,43 @@ void main() {
         ),
       );
     });
+
+    test('NegotiationMoodUpdateEvent equal for same params', () {
+      expect(
+        const NegotiationMoodUpdateEvent(
+          leaderId: 'ai1',
+          currentMood: 'considering',
+          offerQualityDelta: 0.4,
+          stallCounter: 1,
+          seed: 7,
+        ),
+        const NegotiationMoodUpdateEvent(
+          leaderId: 'ai1',
+          currentMood: 'considering',
+          offerQualityDelta: 0.4,
+          stallCounter: 1,
+          seed: 7,
+        ),
+      );
+      expect(
+        const NegotiationMoodUpdateEvent(
+          leaderId: 'ai1',
+          currentMood: 'considering',
+          offerQualityDelta: 0.4,
+          stallCounter: 1,
+          seed: 7,
+        ),
+        isNot(
+          const NegotiationMoodUpdateEvent(
+            leaderId: 'ai1',
+            currentMood: 'considering',
+            offerQualityDelta: -0.4,
+            stallCounter: 1,
+            seed: 7,
+          ),
+        ),
+      );
+    });
   });
 
   group('UISystemEvent equality', () {

--- a/app/test/diplomacy_panel_test.dart
+++ b/app/test/diplomacy_panel_test.dart
@@ -367,6 +367,40 @@ void main() {
     );
 
     testWidgets(
+      'AC3: Confirmed diplomacy action emits NegotiationMoodUpdateEvent',
+      (WidgetTester tester) async {
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+        final moodEvents = <NegotiationMoodUpdateEvent>[];
+        final sub = bus.on<NegotiationMoodUpdateEvent>().listen(moodEvents.add);
+        addTearDown(sub.cancel);
+
+        await tester.pumpWidget(
+          buildPanel(
+            game: gameWithFactions,
+            humanPlayerId: humanPlayerId,
+            topology: topology,
+            bus: bus,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final declareWar = find.text('Declare War');
+        if (declareWar.evaluate().isEmpty) return;
+        await tester.tap(declareWar.first);
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle();
+
+        expect(moodEvents, isNotEmpty);
+        final e = moodEvents.last;
+        expect(e.leaderId, isNotEmpty);
+        expect(e.currentMood, isNotEmpty);
+        expect(e.offerQualityDelta, isNot(0));
+      },
+    );
+
+    testWidgets(
       'AC: Param action opens grant/subsidy dialog via event handler wrapper',
       (WidgetTester tester) async {
         await tester.pumpWidget(

--- a/app/test/game_to_ui_bus_listener_test.dart
+++ b/app/test/game_to_ui_bus_listener_test.dart
@@ -100,4 +100,136 @@ void main() {
       expect(find.text('turn:2'), findsOneWidget);
     },
   );
+
+  testWidgets(
+    'Given negotiation mood input When mood changes Then emits PortraitMoodEvent',
+    (WidgetTester tester) async {
+      final game = Game(
+        id: 'g_bus_mood_1',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'Human', isHuman: true, treasury: 0),
+        ],
+      );
+
+      final adapter = GameSaveAdapter();
+      adapter.save(gamesBox, game);
+      final bus = AppEventBus.create();
+      addTearDown(bus.dispose);
+
+      final moodEvents = <PortraitMoodEvent>[];
+      final moodSub = bus.portraitMoodEvents.listen(moodEvents.add);
+      addTearDown(moodSub.cancel);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gamesBoxProvider.overrideWith((ref) => gamesBox),
+            gameSaveAdapterProvider.overrideWith((ref) => adapter),
+            gameServiceProvider.overrideWith((ref) {
+              final svc = GameService(gamesBox, adapter);
+              svc.eventBus = bus;
+              return svc;
+            }),
+            appEventBusProvider.overrideWith((ref) => bus),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+          ],
+          child: const MaterialApp(
+            home: GameToUIBusListener(
+              gameId: 'g_bus_mood_1',
+              child: SizedBox.shrink(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      bus.emit(
+        const NegotiationMoodUpdateEvent(
+          leaderId: 'ai1',
+          currentMood: 'considering',
+          offerQualityDelta: -0.8,
+          stallCounter: 0,
+          seed: 0,
+          durationMs: 900,
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(moodEvents, hasLength(1));
+      expect(moodEvents.single.leaderId, 'ai1');
+      expect(moodEvents.single.fromMood, 'considering');
+      expect(moodEvents.single.toMood, anyOf('irritated', 'dismissive'));
+      expect(moodEvents.single.durationMs, 900);
+    },
+  );
+
+  testWidgets(
+    'Given negotiation mood input When mood does not change Then emits no PortraitMoodEvent',
+    (WidgetTester tester) async {
+      final game = Game(
+        id: 'g_bus_mood_2',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'Human', isHuman: true, treasury: 0),
+        ],
+      );
+
+      final adapter = GameSaveAdapter();
+      adapter.save(gamesBox, game);
+      final bus = AppEventBus.create();
+      addTearDown(bus.dispose);
+
+      final moodEvents = <PortraitMoodEvent>[];
+      final moodSub = bus.portraitMoodEvents.listen(moodEvents.add);
+      addTearDown(moodSub.cancel);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gamesBoxProvider.overrideWith((ref) => gamesBox),
+            gameSaveAdapterProvider.overrideWith((ref) => adapter),
+            gameServiceProvider.overrideWith((ref) {
+              final svc = GameService(gamesBox, adapter);
+              svc.eventBus = bus;
+              return svc;
+            }),
+            appEventBusProvider.overrideWith((ref) => bus),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+          ],
+          child: const MaterialApp(
+            home: GameToUIBusListener(
+              gameId: 'g_bus_mood_2',
+              child: SizedBox.shrink(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      bus.emit(
+        const NegotiationMoodUpdateEvent(
+          leaderId: 'ai1',
+          currentMood: 'calculating',
+          offerQualityDelta: 0.0,
+          stallCounter: 2,
+          seed: 1,
+          durationMs: 900,
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(moodEvents, isEmpty);
+    },
+  );
 }

--- a/packages/colonizethis_models/lib/src/app_events.dart
+++ b/packages/colonizethis_models/lib/src/app_events.dart
@@ -252,6 +252,28 @@ class TrainMilitaryBuildOrdersCommittedEvent extends SessionCommandEvent {
   final List<BuildUnitOrder> orders;
 }
 
+/// Negotiation UI mood input for portrait transitions.
+///
+/// UI supplies deterministic negotiation inputs; session listeners compute the
+/// next mood and emit [PortraitMoodEvent] when the mood changes.
+class NegotiationMoodUpdateEvent extends SessionCommandEvent {
+  const NegotiationMoodUpdateEvent({
+    required this.leaderId,
+    required this.currentMood,
+    required this.offerQualityDelta,
+    required this.stallCounter,
+    required this.seed,
+    this.durationMs = 1200,
+  });
+
+  final String leaderId;
+  final String currentMood;
+  final double offerQualityDelta;
+  final int stallCounter;
+  final int seed;
+  final int durationMs;
+}
+
 // ---------------------------------------------------------------------------
 // UISystemEvent — emitted by any layer to request transient system feedback.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a typed `NegotiationMoodUpdateEvent` to carry deterministic negotiation mood inputs (`leaderId`, `currentMood`, `offerQualityDelta`, `stallCounter`, `seed`, `durationMs`)
- wire runtime bridge in `GameToUIBusListener` to compute and emit `PortraitMoodEvent` transitions via `buildNegotiationMoodTransitionEvent`
- emit negotiation mood updates from real diplomacy interactions (confirm/cancel actions in `DiplomacyPanel` and confirmed grant/subsidy in `GrantOrSubsidyListener`) and add focused tests

## Test plan
- [x] `flutter test app/test/game_to_ui_bus_listener_test.dart app/test/app_event_bus_test.dart`
- [x] `dart analyze app/lib/features/game/widgets/diplomacy_panel.dart app/lib/features/game/widgets/grant_or_subsidy_listener.dart packages/colonizethis_models/lib/src/app_events.dart`
- [ ] `flutter test app/test/diplomacy_panel_test.dart` *(currently blocked by unrelated existing localization compile errors in `intervention_dialogue_overlay.dart`)*

Refs #1411

Made with [Cursor](https://cursor.com)