### PR TITLE
Naval Move fleet dialog and end-of-turn distant sea fog (#1437)

### DIFF
--- a/SPEC/game/fog-and-exploration.md
+++ b/SPEC/game/fog-and-exploration.md
@@ -29,6 +29,14 @@ For each **Great Power** (including the human player), all tiles in sea zones th
 - **Application:** Applied twice: (1) during Game Setup, immediately after initial visibility assignment, so players can see adjacent sea zones from turn 0; and (2) every turn at turn resolution, **after** all phases that affect visibility: Movement (ship reveal), Combat (ownership change), Build/work (exploration, prospecting), End-of-turn fog decay. The coastal sea zone visibility step runs inEnd-of-turn after fog decay so visibility is consistent for all players before the turn advances.
 - **Scope:** Full game rule: authoritative visibility state and PlayerView are updated; map widget, order suggestions, and AI use the same visibility.
 
+### Distant sea zone fog (End-of-turn)
+
+For each **Great Power**, after Explorer/Spy fog decay each turn and **before** the coastal sea zone pass:
+
+A **sea zone** S (per region) reverts to **fogged** for that player for all **water** tiles in S **only when** both hold: (1) no province **fully owned** by that player has a **P–S** edge to S; and (2) that player has **no** fleet **at sea** in S (fleets **in port** do not count). Tiles that are **unknown** stay **unknown**.
+
+While a fleet **enters** S during Movement, that player’s water tiles in S are set **fully visible** until this rule applies (see [ships-and-naval.md](ships-and-naval.md), [naval-movement-resolution.md](../program/naval-movement-resolution.md), [fog-and-exploration-resolution.md](../program/fog-and-exploration-resolution.md)).
+
 ### Initial Visibility
 
 - **Old World:** Starts fogged (own provinces fully visible); coastal sea zones adjacent to owned provinces are set to fully visible during Game Setup.

--- a/SPEC/game/ships-and-naval.md
+++ b/SPEC/game/ships-and-naval.md
@@ -107,7 +107,7 @@ Like military and civilian **units**, each ship **hull** in play has a **stable 
 
 ## Ship Reveal Mechanic
 
-When a fleet **enters** a sea zone (move order), all **coastal land tiles** of provinces adjacent to that sea zone are set to **revealed** for that player. This enables Explorer deployment to New World (at least one coastal tile must be revealed first). Reference: I2 03-units-civilian — "first terrain tile is uncovered when a ship enters a sea zone adjacent to the New World."
+When a fleet **enters** a sea zone (move order), all **coastal land tiles** of provinces adjacent to that sea zone are set to **revealed** for that player, and all **water** tiles in that sea zone are set **fully visible** for that player (see [fog-and-exploration.md](fog-and-exploration.md) § Distant sea zone fog for End-of-turn re-fog when no owned adjacent coast and no fleet at sea there). This enables Explorer deployment to New World (at least one coastal tile must be revealed first). Reference: I2 03-units-civilian — "first terrain tile is uncovered when a ship enters a sea zone adjacent to the New World."
 
 Province identity for visibility updates must use **full** province id (`regionId|localId`) and **region-scoped** lookup (only provinces in the destination sea zone's region); see [world-model-identity.md](world-model-identity.md).
 
@@ -123,10 +123,12 @@ The **home fleet** is a special fleet for each Great Power:
 
 ### Membership and state
 
-- A ship is either **part of the home fleet** (in port at capital) or **part of a sea‑going fleet** (at sea or in port at another owned province); membership is mutually exclusive.
+- **Only the Home Fleet** may be **in port at the capital province**. Sea‑going fleets **never** remain docked at the capital; any naval **move** that **docks at the capital** resolves by **merging** that fleet’s ships into the Home Fleet and **removing** the sea‑going fleet (same merge semantics as combine: instance ids preserved, no duplicates).
+- A ship is either **part of the home fleet** (in port at capital) or **part of a sea‑going fleet** (at sea or in port at **non‑capital** owned provinces); membership is mutually exclusive.
 - Ships **enter** the home fleet when:
   - They are built as naval units via `BuildUnitOrder` (default spawn into the home fleet in port at the capital), or
-  - A `join home fleet` order resolves successfully during turn resolution, moving ships from a sea‑going fleet that is **in port at the capital province** into the home fleet.
+  - A naval **move** order **docks** at the player’s **capital province** during turn resolution, or
+  - A `join home fleet` order resolves successfully when a sea‑going fleet is **in port at the capital** (legacy or transitional saves only; under normal rules no sea‑going fleet occupies the capital port).
 - Ships **leave** the home fleet when they receive a naval move or mission order that creates or updates a non‑home fleet (a fleet that can move and receive missions).
 
 ### Missions and movement

--- a/SPEC/program/app-event-bus.md
+++ b/SPEC/program/app-event-bus.md
@@ -63,7 +63,7 @@ A typed event bus lets emitters publish **`AppEvent`** subclasses without depend
 Defined in **`colonizethis_models`** (`app_events.dart`, exports).
 
 - **`UIActionEvent`** — dialogs, navigation, panels, map locate/selection intents, grants/subsidy submit; concrete types in source and **[app-ui-wiring.md](app-ui-wiring.md)**.
-- **`SessionCommandEvent`** — session mutations applied by long-lived shell listeners (e.g. **`AppEventHandlerScope`**), not by **`AppEventHandler`**. Includes **`RemovePendingWorkOrderRequestedEvent`**, **`CancelInProgressCivilianWorkRequestedEvent`**, **`NavalFleetsUpdatedEvent`**, **`NavalSplitFleetRequestedEvent`**, **`TrainCivilianBuildOrdersCommittedEvent`**, **`TrainMilitaryBuildOrdersCommittedEvent`**.
+- **`SessionCommandEvent`** — session mutations applied by long-lived shell listeners (e.g. **`AppEventHandlerScope`**), not by **`AppEventHandler`**. Includes **`RemovePendingWorkOrderRequestedEvent`**, **`CancelInProgressCivilianWorkRequestedEvent`**, **`NavalFleetsUpdatedEvent`**, **`NavalSplitFleetRequestedEvent`**, **`NavalMoveFleetRequestedEvent`** (naval panel → current‑turn orders draft), **`TrainCivilianBuildOrdersCommittedEvent`**, **`TrainMilitaryBuildOrdersCommittedEvent`**.
 - **`UISystemEvent`** — snackbar, overlay, notify.
 - **`GameToUIEvent`** — e.g. **`TurnResolutionCompleteEvent`**, **`OvertureRequiredEvent`**, **`InterventionRequiredEvent`**, **`CallToArmsRequiredEvent`**, **`NewGameCreatedEvent`**, **`SaveGameCompleteEvent`**, plus bridge types **`AppCombatResultEvent`**, **`AppProvinceCapturedEvent`**, **`AppDiplomacyChangeEvent`**, **`AppResearchCompleteEvent`**, **`AppVictorySetEvent`**, **`AppOrderRejectedEvent`** (**SPEC/program/game-event-bridge.md**).
 

--- a/SPEC/program/app-ui-wiring.md
+++ b/SPEC/program/app-ui-wiring.md
@@ -69,6 +69,8 @@ For `train_civilians` and `train_military`, shared order/count orchestration mus
 
 **Split fleet:** `NavalUnitsPanel` uses local `showDialog` for `SplitFleetDialog`, but the dialog commits via **`NavalSplitFleetRequestedEvent`** → `AppEventHandlerScope` (applies `applyNavalSplitFleet`, then emits **`NavalFleetsUpdatedEvent`**) so the dialog does not receive panel merge callbacks. Widgetbook / tests without the shell wire the same request event or listen for `NavalFleetsUpdatedEvent` only.
 
+**Move fleet:** `NavalUnitsPanel` uses local `showDialog` for `MoveFleetDialog`. On confirm, emit **`NavalMoveFleetRequestedEvent`** → `AppEventHandlerScope` updates **`currentOrdersProvider`** via **`applyNavalMoveOrderForPlayer`** (replaces any prior naval move for that fleet and removes naval mission orders for that fleet from the draft). No merge callback into the dialog.
+
 **Train at-capital dialogs:** `TrainCiviliansDialog` / `TrainMilitaryDialog` emit **`TrainCivilianBuildOrdersCommittedEvent`** / **`TrainMilitaryBuildOrdersCommittedEvent`** on close; `AppEventHandlerScope` merges into orders. No `onOrdersChanged` callback from the shell into the dialog.
 
 ---

--- a/SPEC/program/fog-and-exploration-resolution.md
+++ b/SPEC/program/fog-and-exploration-resolution.md
@@ -56,6 +56,14 @@ Maintains per-player visibility and prospected state on world state; resolves ex
 4. Set each of those tile keys to `fullyVisible` for that player in `WorldState.playerVisibilityByTile` (overrides unknown or fogged).
 5. **Runs twice:** (a) during Game Setup, immediately after initial visibility assignment, so players can see adjacent sea zones from turn 0; and (b) during End-of-turn after fog decay, so visibility remains consistent after ownership changes. Tribes and Minor Nations do not get this rule.
 
+**Distant sea zone fog** (End-of-turn phase, after Explorer/Spy fog decay, **before** coastal sea zone full visibility):
+
+1. For each Great Power player and each sea zone S in each region (from topology sea-zone nodes in that region):
+   - **Skip** S if there exists a province P with a **P–S** edge to S (same regional topology slice) such that `P` is **fully owned** by that player.
+   - **Skip** S if that player has **any fleet at sea** in S (`Fleet.seaZoneId == S`, `Fleet.regionId` matches S’s region, `fleet.ownerId == playerId`). Fleets **in port** do not count for this check.
+   - Otherwise, for each water tile key in S from `tileKeysByRegionAndProvince[regionId][seaZoneLocalId]`, set visibility to **fogged** unless the tile is **unknown** (leave unknown unchanged).
+2. **Ordering:** This step runs after `applyFogDecay` and **before** `applyCoastalSeaZoneFullVisibility` so coastal waters return to full visibility when the player owns adjacent land.
+
 **Ship reveal** (Naval Movement phase):
 
 1. When fleet enters sea zone S, set all coastal land tiles of adjacent provinces to revealed for that player.
@@ -76,7 +84,7 @@ Maintains per-player visibility and prospected state on world state; resolves ex
 | Game Setup | Initial visibility (OW: own fully visible, others fogged; NW: unknown); **coastal sea zone full visibility** (for each GP, set all tiles in sea zones adjacent to owned provinces to fullyVisible) |
 | Naval Movement | Ship reveal (coastal land tiles → revealed) |
 | Build/Work | Exploration progress; prospect resolution |
-| End-of-turn | Fog decay (Spy timer + Explorer/Spy); **coastal sea zone full visibility** (for each GP, set all tiles in sea zones adjacent to owned provinces to fullyVisible) |
+| End-of-turn | Fog decay (Spy timer + Explorer/Spy); **distant sea zone fog** (sea zones not adjacent to owned coast and with no player fleet at sea in that zone → water tiles fogged, unknown unchanged); **coastal sea zone full visibility** (for each GP, set all tiles in sea zones adjacent to owned provinces to fullyVisible) |
 
 **Upstream:** World state (provinces, tile map, units, owners).
 
@@ -99,8 +107,10 @@ Maintains per-player visibility and prospected state on world state; resolves ex
 - **Prospecting:** Prospect work orders validate that the target tile is mineral-eligible per game rules, is not already in that player's `playerProspectedTiles`, and meets visibility (province at least fogged); on application the tile is added to the player's prospected set in WorldState and does not change visibility by itself. Order validation uses the same mineral-eligibility helper as application (including optional per-region tile maps when provided at validation time).
 - **Spy reveal and decay:** While a Spy is present in a non-owner province, that province is fully visible to the Spy's owner via PlayerView; when the Spy leaves, a per-(player, province) timer (duration = Spy fog decay turns, **fixed at 5 for MVP**) is started **only if the province is owned by another faction** and, when it reaches 0, tiles in that province decay to fogged for that player. Spy timers MUST NOT be created for a player's own provinces and MUST NOT change visibility in own provinces.
 - **Explorer/Spy fog decay:** At end of turn, for each other-faction province where the player previously had Explorer/Spy presence, if no Explorer/Spy remains and no Spy timer is active, all tiles in that province decay to fogged while preserving last-known state.
-- **Ship reveal and integration:** When a fleet enters a sea zone, coastal tiles of adjacent provinces become revealed for that player, delegated to naval-movement-resolution; PlayerView construction (including Spy invisibility rules) is the single source for AI and order-suggestion visibility, never reading visibility directly from WorldState.
+- **Ship reveal and integration:** When a fleet enters a sea zone, coastal tiles of adjacent provinces become **revealed** and **water** tiles in that sea zone become **fully visible** for that player, delegated to naval-movement-resolution; PlayerView construction (including Spy invisibility rules) is the single source for AI and order-suggestion visibility, never reading visibility directly from WorldState.
 - **Coastal sea zone full visibility:** During Game Setup (after initial visibility) and every turn in End-of-turn (after fog decay), for each Great Power (including human): all tiles in sea zones that are adjacent (P–S in topology) to provinces that player fully owns are set to fullyVisible in WorldState; PlayerView reflects this; Tribes and Minor Nations do not receive this rule.
+
+- **Distant sea zone fog:** given a Great Power player, a sea zone S in region R, and water tile keys for S in `tileKeysByRegionAndProvince`, when End-of-turn runs after Movement and S is **not** P–S adjacent to any province owned by that player and that player has **no** fleet **at sea** in S, then every such water tile that is **not** `unknown` in that player’s visibility map is set to **fogged** before the coastal sea zone visibility pass; when that player **does** have a fleet **at sea** in S, water tiles in S are **not** forced to fogged by this rule solely due to lack of adjacent owned coast.
 
 ### Additional Given–When–Then acceptance criteria
 
@@ -115,6 +125,14 @@ Maintains per-player visibility and prospected state on world state; resolves ex
 - Given a Great Power owns a coastal province \(P\) and sea zone \(S\) is adjacent to \(P\) (P–S edge in topology) and the tile map has at least one tile in \(S\)  
   When game setup completes (before turn 0)  
   Then every tile key that belongs to sea zone \(S\) (second segment of tile key = \(S\)'s local id in that region) is set to `fullyVisible` for that player in `WorldState.playerVisibilityByTile`.
+
+- Given a Great Power \(G\) owns no province with a P–S edge to sea zone \(S\) in region \(R\), and \(G\) has no fleet at sea in \(S\), and a water tile \(T\) in \(S\) is listed in `tileKeysByRegionAndProvince` for \(R\) with key \(S\), and \(G\)’s visibility for \(T\) is `fullyVisible`  
+  When the system completes the End-of-turn **distant sea zone fog** step (before coastal sea zone full visibility)  
+  Then \(G\)’s visibility for \(T\) in `WorldState.playerVisibilityByTile` is `fogged`.
+
+- Given a Great Power \(G\) has a fleet at sea in sea zone \(S\) (same region as \(S\)) and \(G\) owns no coastal province adjacent to \(S\)  
+  When the system completes the End-of-turn **distant sea zone fog** step  
+  Then \(G\)’s visibility for water tiles in \(S\) is not set to `fogged` by that step solely because of missing adjacent owned coast (fleet presence preserves open-water visibility until the fleet leaves).
 
 - Given a Great Power owns a coastal province \(P\) and sea zone \(S\) is adjacent to \(P\) (P–S edge in topology) and the tile map has at least one tile in \(S\)  
   When the system runs the End-of-turn phase including the coastal sea zone full visibility step  

--- a/SPEC/program/naval-movement-resolution.md
+++ b/SPEC/program/naval-movement-resolution.md
@@ -15,14 +15,19 @@ Resolves fleet movement orders, triggers ship-reveal for coastal provinces, and 
 
 **Movement:**
 
-1. For a fleet **at sea:** validate destination is adjacent (S↔S or P↔S) via topology. If destination is a **port** (P↔S), the target province must be **owned by the fleet owner**; otherwise reject. On apply: if moving to a sea zone, set fleet to that sea zone (at sea); if moving to a port, set fleet to in port at that province.
+1. For a fleet **at sea:** validate destination is adjacent (S↔S or P↔S) via topology. If destination is a **port** (P↔S), the target province must be **owned by the fleet owner**; otherwise reject. On apply: if moving to a sea zone, set fleet to that sea zone (at sea); if moving to a **non‑capital** port, set fleet to in port at that province. If moving to the player’s **capital** province, **merge** ships into the **Home Fleet** and **remove** the sea‑going fleet (see [ships-and-naval.md](../game/ships-and-naval.md) § Home Fleet).
 2. For a fleet **in port:** destination must be an adjacent sea zone (undock). On apply: set fleet to at sea in that sea zone.
 3. Trigger **ship reveal** when a fleet **enters** a sea zone (move to sea zone or undock into one).
 4. Home fleet cannot move; orders targeting it are no-ops.
+5. Applying a **successful naval move** for a sea‑going fleet clears that fleet’s **mission** and mission targets for the resulting state (`none` / null targets), including after merge into Home Fleet (Home Fleet remains mission `none`).
 
 **Ship Reveal:**
 
 On fleet entering sea zone S: for each province P with a P↔S edge (within the **destination sea zone's region** only), set coastal tiles of P to `revealed` for fleet owner. Province identity for which tiles to reveal must use full province id (`regionId|localId`) and region-scoped lookup per [world-model-identity.md](../game/world-model-identity.md). Updates visibility state per [fog-and-exploration-resolution.md](fog-and-exploration-resolution.md).
+
+Also on entering S: set all **water** tile keys belonging to S in `tileKeysByRegionAndProvince[regionId][S]` to **fully visible** for the fleet owner so open-ocean hexes are visible while the fleet is present; **End-of-turn** [distant sea zone fog](fog-and-exploration-resolution.md) may fog them again when no owned coast is adjacent and no fleet of that player is at sea in S.
+
+On fleet **docking** at a port province (including merge into Home Fleet at capital): set **all** tiles of that province listed in `tileKeysByRegionAndProvince` to `revealed` for the fleet owner (same visibility field names as elsewhere), so unrevealed coastal hinterland from fog is uncovered when the player brings a fleet into port.
 
 **Interception Checks:**
 
@@ -55,6 +60,8 @@ A `join_home_fleet` order is valid only when the fleet is **in port at the playe
 **Build Ship:**
 
 BuildUnitOrder for naval type; spawns in home fleet (in port at capital). Costs from colonizethis_data ship economy catalog.
+
+**Orders draft (human):** Submitting a **naval move** for fleet **F** replaces any prior **naval move** for **F** and removes any **naval mission** order for **F** from the current-turn draft. During turn resolution, if fleet **F** has a **naval move** order, **naval mission** orders for **F** are not applied that turn (move takes precedence if both appear after merge).
 
 ## Integration
 

--- a/SPEC/ui/naval-units-panel.md
+++ b/SPEC/ui/naval-units-panel.md
@@ -12,7 +12,26 @@ The naval units panel gives the player a single place to see every **fleet** the
 - Always shows the **Home Fleet** as a special entry at the top for the player’s capital, even when it currently has zero ships.
 - Shows **key info first** (fleet name, current location, mission, and a short composition summary).
 - Lets the player expand a fleet to see **ship composition and capabilities** (including Home Fleet cargo capacity).
+- Lets the player issue a **Move** order for each **sea‑going** fleet (see [Move fleet](#move-fleet)).
 - Centers the map on the selected fleet’s location and switches the region tab if needed so the player immediately sees where that fleet operates.
+
+---
+
+## Move fleet
+
+For every **sea‑going** fleet (any fleet that is **not** the Home Fleet), the **expanded** row includes a **Move** button next to **Split**. The **Home Fleet** row does **not** show **Move** (cannot move).
+
+**Dialog (local `showDialog`, commit via bus):** Opening **Move** shows a modal where the player:
+
+1. Sees two sections (**Sea zones** first, then **Provinces**), each a **sorted** list of **legal** destinations from the fleet’s **current** location per [ships-and-naval.md](../game/ships-and-naval.md) and [naval-movement-resolution.md](../program/naval-movement-resolution.md):
+   - **At sea:** all **adjacent** sea zones (including **warp** / cross‑region links); then all **owned** provinces the fleet may **dock** at from its current sea zone (topology P↔S). Destinations in a **different** region than the fleet’s current sea zone must be labeled so the player sees **cross‑region** (e.g. include the destination region label in the row text).
+   - **In port:** only **adjacent** sea zones for **undock**; the **Provinces** section is **empty** (no port‑to‑port moves).
+2. **Selects** one row (radio or single selection), then taps **Confirm** to submit (or **Cancel** to close without changing orders).
+3. May tap a **locate** control beside each destination row to emit **`LocateMapTileEvent`** (same family as fleet locate): province → town/first tile; sea zone → port tile adjacent to that zone per [map-widget.md](map-widget.md) / [map_location_resolver](military/naval panel contract).
+
+**Orders:** On confirm, the panel emits **`NavalMoveFleetRequestedEvent`** (see [app-ui-wiring.md](../program/app-ui-wiring.md)). The shell applies **`applyNavalMoveOrderForPlayer`** (colonizethis_logic): the new **naval move** replaces any prior **naval move** for that fleet and **removes** any **naval mission** order for that fleet from the current‑turn draft.
+
+**Labels:** The capital province (dock), when listed, should indicate that the fleet **joins the Home Fleet** when the order resolves (per GDD).
 
 ---
 
@@ -162,4 +181,12 @@ The naval units panel participates in the Widgetbook catalog for review and test
 - **Given** the Widgetbook “Naval Units Panel” folder is open, **when** the user selects the “Standalone” use case, **then** the UI layer displays only the Naval Units panel with demo or debug game data so that region grouping, Home Fleet pinning, collapsed vs expanded fleet rows, and composition/capabilities content can be verified in isolation.
 
 - **Given** the Widgetbook “Naval Units Panel” folder is open, **when** the user selects the “With map” use case, **then** the UI layer displays the Naval Units panel alongside a map built from a real generated map and initialized game (`getDebugInitGameResult()`), and clicking a fleet row highlights and pans/centers the map on the appropriate tile (capital port for Home Fleet, port or adjacent port for other fleets) while switching the region tab when necessary.
+
+- **Given** the Naval Units panel is open and a **sea‑going** fleet row is expanded, **when** the user views the row actions, **then** the UI layer shows a **Move** button (in addition to **Split**) and does **not** omit it for that fleet.
+
+- **Given** the Naval Units panel is open and the **Home Fleet** row is expanded, **when** the user views the row actions, **then** the UI layer does **not** show a **Move** button for the Home Fleet.
+
+- **Given** the Move dialog is open with at least one destination, **when** the user selects a destination and taps **Confirm**, **then** the UI layer emits **`NavalMoveFleetRequestedEvent`** with a **naval move** order matching the selection (sea zone id or dock province id per `NavalMoveOrder`) and closes the dialog.
+
+- **Given** the Move dialog is open, **when** the user taps **Cancel**, **then** the UI layer closes the dialog without emitting **`NavalMoveFleetRequestedEvent`**.
 

--- a/app/lib/core/services/app_event_handler.dart
+++ b/app/lib/core/services/app_event_handler.dart
@@ -22,6 +22,7 @@
 
 import 'dart:async';
 
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
@@ -34,6 +35,7 @@ import '../../features/game/widgets/military_units_panel.dart';
 import '../../features/game/widgets/naval_units_panel.dart';
 import '../../features/game/widgets/pause_menu_panel.dart';
 import '../../providers/app_event_bus_provider.dart';
+import '../../providers/game_service_provider.dart';
 import '../../providers/games_provider.dart';
 
 typedef DialogBuilder =
@@ -292,10 +294,12 @@ class AppEventHandler {
           }
           final humanPlayerId = _humanPlayerId(game);
           final bus = ref.watch(appEventBusProvider);
+          final mapData = ref.watch(gameServiceProvider).getMapData(game.id);
           return NavalUnitsPanel(
             game: game,
             humanPlayerId: humanPlayerId,
             bus: bus,
+            topology: mapData?.combinedTopology ?? const MapTopology(),
           );
         },
       ),

--- a/app/lib/core/services/app_event_handler_scope.dart
+++ b/app/lib/core/services/app_event_handler_scope.dart
@@ -322,6 +322,14 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
         );
         bus.emit(NavalFleetsUpdatedEvent(game: newGame));
       }),
+      bus.on<NavalMoveFleetRequestedEvent>().listen((e) {
+        final o = ref.read(currentOrdersProvider);
+        ref.read(currentOrdersProvider.notifier).state = applyNavalMoveOrderForPlayer(
+          o,
+          e.humanPlayerId,
+          e.moveOrder,
+        );
+      }),
       bus.on<TrainCivilianBuildOrdersCommittedEvent>().listen((e) {
         final g = ref.read(currentGameProvider);
         if (g == null) return;

--- a/app/lib/features/game/widgets/move_fleet_dialog.dart
+++ b/app/lib/features/game/widgets/move_fleet_dialog.dart
@@ -1,0 +1,263 @@
+// Move fleet dialog. SPEC/ui/naval-units-panel.md, SPEC/program/app-ui-wiring.md.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+
+import '../../../widgets/ct_nine_patch_button.dart';
+import '../utils/map_location_resolver.dart';
+import 'units/shared/units_panel_region_label.dart';
+
+sealed class _MovePick {
+  const _MovePick();
+
+  NavalMoveOrder toOrder(String fleetId);
+  String get rowLabel;
+  void emitLocate(AppEventBus bus, Game game);
+}
+
+final class _PickSeaZone extends _MovePick {
+  const _PickSeaZone({
+    required this.seaZoneId,
+    required this.zoneRegionId,
+    required this.rowLabel,
+  });
+
+  final String seaZoneId;
+  final String zoneRegionId;
+  @override
+  final String rowLabel;
+
+  @override
+  NavalMoveOrder toOrder(String fleetId) =>
+      NavalMoveOrder(fleetId: fleetId, destinationSeaZoneId: seaZoneId);
+
+  @override
+  void emitLocate(AppEventBus bus, Game game) {
+    final key = tileKeyForSeaZoneLocation(game, zoneRegionId, seaZoneId);
+    if (key == null) return;
+    bus.emit(LocateMapTileEvent(tileKey: key, regionId: zoneRegionId));
+  }
+}
+
+final class _PickPort extends _MovePick {
+  const _PickPort({
+    required this.fullProvinceId,
+    required this.rowLabel,
+    required this.provinceRegionId,
+  });
+
+  final String fullProvinceId;
+  @override
+  final String rowLabel;
+  final String provinceRegionId;
+
+  @override
+  NavalMoveOrder toOrder(String fleetId) => NavalMoveOrder(
+        fleetId: fleetId,
+        destinationPortProvinceId: fullProvinceId,
+      );
+
+  @override
+  void emitLocate(AppEventBus bus, Game game) {
+    final province = tryGetProvince(game.worldState, fullProvinceId);
+    if (province == null) return;
+    final key = tileKeyForProvinceLocation(game, province);
+    if (key == null) return;
+    bus.emit(LocateMapTileEvent(tileKey: key, regionId: provinceRegionId));
+  }
+}
+
+List<_MovePick> _buildNavalMovePicks({
+  required Game game,
+  required MapTopology topology,
+  required String humanPlayerId,
+  required Fleet fleet,
+}) {
+  final outSea = <_PickSeaZone>[];
+  final outPort = <_PickPort>[];
+
+  final String? currentSeaZoneId;
+  if (fleet.isAtSea) {
+    currentSeaZoneId = fleet.seaZoneId;
+  } else {
+    final inPort = fleet.inPortAtProvinceId;
+    if (inPort == null) return const [];
+    final rl = regionAndLocalProvinceForFleetInPort(inPort, fleet.regionId);
+    currentSeaZoneId = seaZoneIdForProvince(
+      topology,
+      rl.localId,
+      regionId: rl.regionId,
+    );
+  }
+  if (currentSeaZoneId == null || currentSeaZoneId.isEmpty) return const [];
+
+  final fleetSeaRegion =
+      regionIdForSeaZone(topology, currentSeaZoneId) ?? fleet.regionId;
+
+  final adjZones = <String>{};
+  for (final e in topology.edges) {
+    if (e.id1 == currentSeaZoneId) {
+      adjZones.add(e.id2);
+    } else if (e.id2 == currentSeaZoneId) {
+      adjZones.add(e.id1);
+    }
+  }
+  final sortedZones = adjZones.toList()..sort();
+  for (final z in sortedZones) {
+    final zReg = regionIdForSeaZone(topology, z) ?? fleetSeaRegion;
+    final regLabel = unitsPanelRegionLabel(zReg);
+    final cross = zReg != fleetSeaRegion;
+    final label = cross ? '$z · $regLabel (cross-region)' : '$z · $regLabel';
+    outSea.add(_PickSeaZone(seaZoneId: z, zoneRegionId: zReg, rowLabel: label));
+  }
+  outSea.sort((a, b) => a.rowLabel.compareTo(b.rowLabel));
+
+  if (fleet.isAtSea && fleet.seaZoneId != null) {
+    final rz = regionIdForSeaZone(topology, fleet.seaZoneId!) ?? fleet.regionId;
+    final localProvinces = provinceIdsAdjacentToSeaZone(
+      topology,
+      fleet.seaZoneId!,
+      regionId: rz,
+    );
+    final portRows = <({String fullId, String label})>[];
+    for (final lp in localProvinces) {
+      final full = ProvinceId.full(rz, lp);
+      final province = tryGetProvince(game.worldState, full);
+      if (province == null || province.ownerId != humanPlayerId) continue;
+      final name = province.displayName ?? province.id;
+      final isCap = dockOrderTargetsPlayerCapital(game, humanPlayerId, full);
+      final label = isCap ? '$name (capital — joins Home Fleet)' : name;
+      portRows.add((fullId: full, label: label));
+    }
+    portRows.sort((a, b) => a.label.compareTo(b.label));
+    for (final r in portRows) {
+      outPort.add(
+        _PickPort(
+          fullProvinceId: r.fullId,
+          rowLabel: r.label,
+          provinceRegionId: rz,
+        ),
+      );
+    }
+  }
+
+  return [...outSea, ...outPort];
+}
+
+class MoveFleetDialog extends StatefulWidget {
+  const MoveFleetDialog({
+    super.key,
+    required this.game,
+    required this.topology,
+    required this.humanPlayerId,
+    required this.fleet,
+    required this.bus,
+  });
+
+  final Game game;
+  final MapTopology topology;
+  final String humanPlayerId;
+  final Fleet fleet;
+  final AppEventBus bus;
+
+  @override
+  State<MoveFleetDialog> createState() => _MoveFleetDialogState();
+}
+
+class _MoveFleetDialogState extends State<MoveFleetDialog> {
+  late final List<_MovePick> _picks;
+  _MovePick? _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _picks = _buildNavalMovePicks(
+      game: widget.game,
+      topology: widget.topology,
+      humanPlayerId: widget.humanPlayerId,
+      fleet: widget.fleet,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final picks = _picks;
+    final seaPicks = picks.whereType<_PickSeaZone>().toList();
+    final portPicks = picks.whereType<_PickPort>().toList();
+
+    return AlertDialog(
+      title: Text('Move fleet — ${widget.fleet.id}'),
+      content: SizedBox(
+        width: 420,
+        child: picks.isEmpty
+            ? const Text('No adjacent sea zones (check map topology).')
+            : SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (seaPicks.isNotEmpty) ...[
+                      const Text(
+                        'Sea zones',
+                        style: TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                      ...seaPicks.map(_row),
+                    ],
+                    if (portPicks.isNotEmpty) ...[
+                      if (seaPicks.isNotEmpty) const SizedBox(height: 12),
+                      const Text(
+                        'Provinces (dock)',
+                        style: TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                      ...portPicks.map(_row),
+                    ],
+                  ],
+                ),
+              ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        CtNinePatchButton(
+          onPressed: _selected == null
+              ? null
+              : () {
+                  widget.bus.emit(
+                    NavalMoveFleetRequestedEvent(
+                      humanPlayerId: widget.humanPlayerId,
+                      moveOrder: _selected!.toOrder(widget.fleet.id),
+                    ),
+                  );
+                  Navigator.pop(context);
+                },
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+          minHeight: 40,
+          child: const Text('Confirm'),
+        ),
+      ],
+    );
+  }
+
+  Widget _row(_MovePick pick) {
+    return RadioListTile<_MovePick>(
+      value: pick,
+      groupValue: _selected,
+      onChanged: (v) => setState(() => _selected = v),
+      title: Row(
+        children: [
+          Expanded(child: Text(pick.rowLabel)),
+          IconButton(
+            tooltip: 'Locate on map',
+            icon: const Icon(Icons.my_location, size: 18),
+            onPressed: () => pick.emitLocate(widget.bus, widget.game),
+            visualDensity: VisualDensity.compact,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../utils/map_location_resolver.dart';
+import 'move_fleet_dialog.dart';
 import 'split_fleet_dialog.dart';
 import 'units/shared/location_section_header.dart';
 import 'units/shared/region_section_header.dart';
@@ -388,11 +389,13 @@ class NavalUnitsPanel extends StatefulWidget {
     required this.game,
     required this.humanPlayerId,
     required this.bus,
+    required this.topology,
   });
 
   final Game game;
   final String humanPlayerId;
   final AppEventBus bus;
+  final MapTopology topology;
 
   @override
   State<NavalUnitsPanel> createState() => _NavalUnitsPanelState();
@@ -594,6 +597,29 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
     );
   }
 
+  void _openMoveFleetDialog(_FleetRow row) {
+    if (row.isHomeFleet) return;
+    Fleet? fleet;
+    for (final f in widget.game.worldState.fleets) {
+      if (f.id == row.fleetId) {
+        fleet = f;
+        break;
+      }
+    }
+    final nonNullFleet = fleet;
+    if (nonNullFleet == null) return;
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => MoveFleetDialog(
+        game: widget.game,
+        topology: widget.topology,
+        humanPlayerId: widget.humanPlayerId,
+        fleet: nonNullFleet,
+        bus: widget.bus,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final tree = _buildNavalTree(widget.game, widget.humanPlayerId);
@@ -651,6 +677,7 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
               onCombineSelectionToggle: () =>
                   _toggleFleetSelection(group.homeFleet!),
               onSplitFleet: () => _openSplitDialog(group.homeFleet!),
+              onMoveFleet: null,
               isSplitAllowed: true,
             ),
           for (final loc in group.locations) ...[
@@ -674,6 +701,7 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
                 ),
                 onCombineSelectionToggle: () => _toggleFleetSelection(row),
                 onSplitFleet: () => _openSplitDialog(row),
+                onMoveFleet: () => _openMoveFleetDialog(row),
                 isSplitAllowed: true,
               ),
           ],
@@ -691,6 +719,7 @@ class _FleetExpansionTile extends StatelessWidget {
     required this.isSelectedForCombine,
     required this.onCombineSelectionToggle,
     this.onSplitFleet,
+    this.onMoveFleet,
     this.isSplitAllowed = false,
   });
 
@@ -699,6 +728,7 @@ class _FleetExpansionTile extends StatelessWidget {
   final bool isSelectedForCombine;
   final VoidCallback onCombineSelectionToggle;
   final VoidCallback? onSplitFleet;
+  final VoidCallback? onMoveFleet;
   final bool isSplitAllowed;
 
   String _summary() {
@@ -773,6 +803,18 @@ class _FleetExpansionTile extends StatelessWidget {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
+                  if (onMoveFleet != null) ...[
+                    CtNinePatchButton(
+                      onPressed: onMoveFleet,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 8,
+                      ),
+                      minHeight: 36,
+                      child: const Text('Move'),
+                    ),
+                    const SizedBox(width: 8),
+                  ],
                   CtNinePatchButton(
                     onPressed: onSplitFleet,
                     padding: const EdgeInsets.symmetric(

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -601,6 +601,7 @@ List<WidgetbookNode> get navalUnitsPanelDirectories => [
               game: game,
               humanPlayerId: humanPlayerId,
               bus: AppEventBus.create(),
+              topology: result.combinedTopology,
             ),
           );
         },
@@ -1282,6 +1283,7 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
   String? _centerOnTileKey;
   bool _showProvinceNames = true;
   late Game _game;
+  late MapTopology _combinedTopology;
   late AppEventBus _navalBus;
   StreamSubscription<NavalFleetsUpdatedEvent>? _navalSub;
   StreamSubscription<NavalSplitFleetRequestedEvent>? _navalSplitSub;
@@ -1291,6 +1293,7 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
     super.initState();
     final result = getDebugInitGameResult();
     _game = result.game;
+    _combinedTopology = result.combinedTopology;
     _navalBus = AppEventBus.create();
     _navalSub = _navalBus.on<NavalFleetsUpdatedEvent>().listen((e) {
       if (!mounted) return;
@@ -1399,6 +1402,7 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
               game: _game,
               humanPlayerId: humanPlayerId,
               bus: _navalBus,
+              topology: _combinedTopology,
             ),
           ),
         ],

--- a/app/lib/widgetbook/catalog.dart
+++ b/app/lib/widgetbook/catalog.dart
@@ -709,6 +709,7 @@ List<WidgetbookNode> get navalUnitsPanelDirectories => [
               game: game,
               humanPlayerId: humanPlayerId,
               bus: AppEventBus.create(),
+              topology: result.combinedTopology,
             ),
           );
         },
@@ -1390,6 +1391,7 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
   String? _centerOnTileKey;
   bool _showProvinceNames = true;
   late Game _game;
+  late MapTopology _combinedTopology;
   late AppEventBus _navalBus;
   StreamSubscription<NavalFleetsUpdatedEvent>? _navalSub;
   StreamSubscription<NavalSplitFleetRequestedEvent>? _navalSplitSub;
@@ -1399,6 +1401,7 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
     super.initState();
     final result = getDebugInitGameResult();
     _game = result.game;
+    _combinedTopology = result.combinedTopology;
     _navalBus = AppEventBus.create();
     _navalSub = _navalBus.on<NavalFleetsUpdatedEvent>().listen((e) {
       if (!mounted) return;
@@ -1507,6 +1510,7 @@ class _NavalPanelWithMapStoryState extends State<_NavalPanelWithMapStory> {
               game: _game,
               humanPlayerId: humanPlayerId,
               bus: _navalBus,
+              topology: _combinedTopology,
             ),
           ),
         ],

--- a/app/test/naval_units_panel_test.dart
+++ b/app/test/naval_units_panel_test.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart' show homeFleetIdFor;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -103,6 +104,7 @@ void main() {
     required Game game,
     required String humanPlayerId,
     AppEventBus? bus,
+    MapTopology topology = const MapTopology(),
   }) {
     final resolvedBus = bus ?? AppEventBus.create();
     return MaterialApp(
@@ -111,6 +113,7 @@ void main() {
           game: game,
           humanPlayerId: humanPlayerId,
           bus: resolvedBus,
+          topology: topology,
         ),
       ),
     );
@@ -891,6 +894,7 @@ void main() {
                       game: game,
                       humanPlayerId: humanId,
                       bus: bus,
+                      topology: getDebugInitGameResult().combinedTopology,
                     ),
                   ),
                 ],

--- a/packages/colonizethis_logic/lib/src/orders/draft_orders_mutations.dart
+++ b/packages/colonizethis_logic/lib/src/orders/draft_orders_mutations.dart
@@ -1,5 +1,55 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+/// Applies a human naval move to the turn draft: replaces any prior naval move for
+/// the same [fleetId] and removes naval mission orders for that fleet.
+/// SPEC/program/naval-movement-resolution.md.
+Orders applyNavalMoveOrderForPlayer(
+  Orders orders,
+  String playerId,
+  NavalMoveOrder newOrder,
+) {
+  final nextMoves = List<NavalMoveOrder>.from(
+    orders.navalMoveOrdersByPlayerId[playerId] ?? const [],
+  )..removeWhere((o) => o.fleetId == newOrder.fleetId);
+  nextMoves.add(newOrder);
+
+  final nextMissions = List<NavalMissionOrder>.from(
+    orders.navalMissionOrdersByPlayerId[playerId] ?? const [],
+  )..removeWhere((o) => o.fleetId == newOrder.fleetId);
+
+  return orders.copyWith(
+    navalMoveOrdersByPlayerId: {
+      ...orders.navalMoveOrdersByPlayerId,
+      playerId: nextMoves,
+    },
+    navalMissionOrdersByPlayerId: {
+      ...orders.navalMissionOrdersByPlayerId,
+      playerId: nextMissions,
+    },
+  );
+}
+
+/// Drops naval mission orders for fleets that have a naval move order this turn.
+/// SPEC/program/naval-movement-resolution.md.
+Map<String, List<NavalMissionOrder>> navalMissionOrdersRespectingNavalMoves(
+  Map<String, List<NavalMissionOrder>> navalMissionOrdersByPlayerId,
+  Map<String, List<NavalMoveOrder>> navalMoveOrdersByPlayerId,
+) {
+  final out = <String, List<NavalMissionOrder>>{};
+  navalMissionOrdersByPlayerId.forEach((playerId, list) {
+    final movedFleetIds = {
+      for (final o in navalMoveOrdersByPlayerId[playerId] ?? const <NavalMoveOrder>[])
+        o.fleetId,
+    };
+    final filtered = [
+      for (final o in list)
+        if (!movedFleetIds.contains(o.fleetId)) o,
+    ];
+    if (filtered.isNotEmpty) out[playerId] = filtered;
+  });
+  return out;
+}
+
 /// Removes the pending civilian work order at [index] for [playerId] in this
 /// turn's draft [orders]. No-op if the list is missing or [index] is out of
 /// range. SPEC/program/orders.md.

--- a/packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
@@ -44,8 +44,14 @@ Game runEndOfTurnPhase(
     ),
   );
   var nextVisibility = applyFogDecay(stateForFog);
+  nextVisibility = applyDistantSeaZoneFogRevert(
+    stateForFog,
+    nextVisibility,
+    topology,
+    topologyByRegion: topologyByRegion,
+  );
   nextVisibility = applyCoastalSeaZoneFullVisibility(
-    game,
+    stateForFog,
     nextVisibility,
     topology,
     topologyByRegion: topologyByRegion,

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -19,6 +19,7 @@ import '../economy/economy_riches_to_treasury.dart';
 import '../diplomacy/diplomacy_resolver.dart';
 import '../world/minor_military_parity.dart';
 import '../world/movement.dart';
+import '../orders/draft_orders_mutations.dart';
 import '../orders/orders_application.dart';
 import '../economy/resource_extractor.dart';
 import '../economy/sea_transport.dart';
@@ -975,7 +976,11 @@ Game _runMovementPhase(Game game, MapTopology topology, Orders orders) {
   }
 
   // Naval mission assignment. Phase 6. Apply after moves so fleet position is final.
-  final missionOrders = orders.navalMissionOrdersByPlayerId;
+  // Fleets with a naval move this turn do not apply a naval mission order.
+  final missionOrders = navalMissionOrdersRespectingNavalMoves(
+    orders.navalMissionOrdersByPlayerId,
+    orders.navalMoveOrdersByPlayerId,
+  );
   // Always apply so we run the clearing pass for blockades when not at war.
   state = applyNavalMissionOrders(state, missionOrders);
 

--- a/packages/colonizethis_logic/lib/src/world/fog_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/fog_resolution.dart
@@ -207,3 +207,99 @@ Map<String, Map<String, String>> applyCoastalSeaZoneFullVisibility(
   return result;
 }
 
+bool _seaZoneHasOwnedCoastalProvinceForPlayer(
+  Game game,
+  String playerId,
+  String regionId,
+  String seaZoneLocalId,
+  MapTopology regionTopology,
+) {
+  final adjacentLocal = provinceIdsAdjacentToSeaZone(
+    regionTopology,
+    seaZoneLocalId,
+    regionId: regionId,
+  );
+  for (final localPid in adjacentLocal) {
+    final full = ProvinceId.full(regionId, localPid);
+    final p = tryGetProvince(game.worldState, full);
+    if (p != null && p.ownerId == playerId) return true;
+  }
+  return false;
+}
+
+bool _playerHasFleetAtSeaInZone(
+  Game game,
+  String playerId,
+  String regionId,
+  String seaZoneLocalId,
+) {
+  for (final f in game.worldState.fleets) {
+    if (f.ownerId != playerId) continue;
+    if (!f.isAtSea || f.seaZoneId != seaZoneLocalId) continue;
+    if (f.regionId != regionId) continue;
+    return true;
+  }
+  return false;
+}
+
+/// For each Great Power, every sea zone that is **not** adjacent (P–S) to a
+/// province that player **fully owns**, and where that player has **no** fleet
+/// **at sea** in that zone: set all **water** tiles in that zone to **fogged**
+/// (tiles currently **unknown** are unchanged).
+///
+/// Runs after Explorer/Spy fog decay and **before** coastal sea zone full
+/// visibility. SPEC/program/fog-and-exploration-resolution.md § Distant sea zone fog.
+Map<String, Map<String, String>> applyDistantSeaZoneFogRevert(
+  Game game,
+  Map<String, Map<String, String>> visibility,
+  MapTopology topology, {
+  Map<String, MapTopology>? topologyByRegion,
+}) {
+  final gpIds = game.players.map((p) => p.id).toSet();
+  final tileKeysByRegion = game.worldState.tileKeysByRegionAndProvince;
+  final result = <String, Map<String, String>>{};
+  for (final entry in visibility.entries) {
+    result[entry.key] = Map<String, String>.from(entry.value);
+  }
+
+  for (final regionId in [kRegionOldWorld, kRegionNewWorld]) {
+    final regionTopology = _topologyForRegion(topology, topologyByRegion, regionId);
+    final seaZoneIds = regionTopology.nodes
+        .where((n) => n.type == TopologyNodeType.seaZone)
+        .map((n) => n.id);
+    final regionTileKeys = tileKeysByRegion[regionId];
+    if (regionTileKeys == null) continue;
+
+    for (final player in game.players) {
+      if (!gpIds.contains(player.id)) continue;
+      final playerId = player.id;
+      final vis = result[playerId];
+      if (vis == null) continue;
+
+      for (final seaZoneId in seaZoneIds) {
+        if (_seaZoneHasOwnedCoastalProvinceForPlayer(
+          game,
+          playerId,
+          regionId,
+          seaZoneId,
+          regionTopology,
+        )) {
+          continue;
+        }
+        if (_playerHasFleetAtSeaInZone(game, playerId, regionId, seaZoneId)) {
+          continue;
+        }
+        final keys = regionTileKeys[seaZoneId];
+        if (keys == null) continue;
+        for (final tk in keys) {
+          final cur = vis[tk];
+          if (cur == null || cur == VisibilityLevel.unknown.name) continue;
+          vis[tk] = VisibilityLevel.fogged.name;
+        }
+      }
+    }
+  }
+
+  return result;
+}
+

--- a/packages/colonizethis_logic/lib/src/world/naval.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval.dart
@@ -3,6 +3,26 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 /// Naval movement helpers. SPEC/program/naval-movement-resolution.md.
 
+/// True when a dock order targeting [dockFullProvinceId] is the player's capital;
+/// such a move merges into the Home Fleet. SPEC/game/ships-and-naval.md § Home Fleet.
+bool dockOrderTargetsPlayerCapital(
+  Game game,
+  String playerId,
+  String dockFullProvinceId,
+) {
+  String? cap;
+  for (final p in game.players) {
+    if (p.id == playerId) {
+      cap = p.capitalProvinceId;
+      break;
+    }
+  }
+  if (cap == null || cap.isEmpty) return false;
+  if (ProvinceId.isPrefixed(cap)) return cap == dockFullProvinceId;
+  return ProvinceId.full(ProvinceId.regionIdFrom(dockFullProvinceId), cap) ==
+      dockFullProvinceId;
+}
+
 /// Home fleet id convention for a Great Power. SPEC/game/ships-and-naval.md.
 String homeFleetIdFor(String playerId) => 'fleet_$playerId';
 

--- a/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
@@ -15,6 +15,23 @@ import 'province_lookup.dart';
 
 final _log = logicLogger();
 
+Map<String, Map<String, String>> _revealProvinceTilesForPlayer(
+  Game game,
+  Map<String, Map<String, String>> visibilityByTile,
+  String playerId,
+  String fullProvinceId,
+) {
+  final regionId = ProvinceId.regionIdFrom(fullProvinceId);
+  final tileKeys = game.worldState.tileKeysByRegionAndProvince[regionId]?[fullProvinceId] ??
+      const [];
+  if (tileKeys.isEmpty) return visibilityByTile;
+  final vis = Map<String, String>.from(visibilityByTile[playerId] ?? {});
+  for (final tk in tileKeys) {
+    vis[tk] = VisibilityLevel.revealed.name;
+  }
+  return Map<String, Map<String, String>>.from(visibilityByTile)..[playerId] = vis;
+}
+
 Map<String, Set<String>> _atWarByFaction(Game game) {
   final out = <String, Set<String>>{};
   for (final rel in game.diplomacyRelations) {
@@ -189,7 +206,8 @@ Game applyNavalMovesAndShipReveal(
       if (fleet.id == homeFleetId) continue;
 
       if (order.isDock) {
-        // Dock: fleet at sea moves to in port at owned province. SPEC/game/ships-and-naval.md.
+        // Dock: fleet at sea moves to in port at owned province, or merges into Home Fleet
+        // at capital. SPEC/game/ships-and-naval.md, SPEC/program/naval-movement-resolution.md.
         final portProvinceId = order.destinationPortProvinceId!;
         if (!fleet.isAtSea || fleet.seaZoneId == null) continue;
         final fullProvinceId = toFullProvinceId(fleet.regionId, portProvinceId);
@@ -197,6 +215,37 @@ Game applyNavalMovesAndShipReveal(
         if (province == null || province.ownerId != playerId) continue;
         final adjacentSeaZones = seaZoneIdsAdjacentToProvince(topology, fullProvinceId);
         if (!adjacentSeaZones.contains(fleet.seaZoneId)) continue;
+
+        visibilityByTile = _revealProvinceTilesForPlayer(
+          game,
+          visibilityByTile,
+          playerId,
+          fullProvinceId,
+        );
+
+        if (dockOrderTargetsPlayerCapital(game, playerId, fullProvinceId)) {
+          final homeFleet = fleetById[homeFleetId];
+          if (homeFleet == null) continue;
+          final updatedHome = Fleet(
+            id: homeFleet.id,
+            ownerId: homeFleet.ownerId,
+            seaZoneId: null,
+            inPortAtProvinceId: homeFleet.inPortAtProvinceId,
+            regionId: homeFleet.regionId,
+            ships: [...homeFleet.ships, ...fleet.ships],
+            mission: FleetMission.none,
+            targetPortId: null,
+            targetProvinceId: null,
+          );
+          fleets = fleets
+              .where((f) => f.id != fleet.id)
+              .map((f) => f.id == homeFleetId ? updatedHome : f)
+              .toList();
+          fleetById[homeFleetId] = updatedHome;
+          fleetById.remove(fleet.id);
+          continue;
+        }
+
         final portRegionId = ProvinceId.regionIdFrom(fullProvinceId);
         final newFleet = Fleet(
           id: fleet.id,
@@ -205,9 +254,9 @@ Game applyNavalMovesAndShipReveal(
           inPortAtProvinceId: fullProvinceId,
           regionId: portRegionId,
           ships: fleet.ships,
-          mission: fleet.mission,
-          targetPortId: fleet.targetPortId,
-          targetProvinceId: fleet.targetProvinceId,
+          mission: FleetMission.none,
+          targetPortId: null,
+          targetProvinceId: null,
         );
         final idx = fleets.indexWhere((f) => f.id == fleet.id);
         if (idx >= 0) {
@@ -241,7 +290,7 @@ Game applyNavalMovesAndShipReveal(
           !isAdjacentSeaZone(topology, currentSeaZoneId, destZoneId)) continue;
 
       final destRegionId = regionIdForSeaZone(topology, destZoneId);
-      // Moving to sea zone: fleet ends at sea (undock if was in port).
+      // Moving to sea zone: fleet ends at sea (undock if was in port); move clears mission.
       final newFleet = Fleet(
         id: fleet.id,
         ownerId: fleet.ownerId,
@@ -249,9 +298,9 @@ Game applyNavalMovesAndShipReveal(
         inPortAtProvinceId: null,
         regionId: destRegionId ?? fleet.regionId,
         ships: fleet.ships,
-        mission: fleet.mission,
-        targetPortId: fleet.targetPortId,
-        targetProvinceId: fleet.targetProvinceId,
+        mission: FleetMission.none,
+        targetPortId: null,
+        targetProvinceId: null,
       );
       final idx = fleets.indexWhere((f) => f.id == fleet.id);
       if (idx >= 0) {
@@ -273,6 +322,12 @@ Game applyNavalMovesAndShipReveal(
               [];
           for (final tk in tileKeys) {
             vis[tk] = VisibilityLevel.revealed.name;
+          }
+        }
+        final seaWaterKeys = game.worldState.tileKeysByRegionAndProvince[destRegionId]?[destZoneId];
+        if (seaWaterKeys != null) {
+          for (final tk in seaWaterKeys) {
+            vis[tk] = VisibilityLevel.fullyVisible.name;
           }
         }
         visibilityByTile =

--- a/packages/colonizethis_logic/test/draft_orders_naval_test.dart
+++ b/packages/colonizethis_logic/test/draft_orders_naval_test.dart
@@ -1,0 +1,80 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:test/test.dart';
+
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+
+void main() {
+  group('applyNavalMoveOrderForPlayer', () {
+    test('replaces prior naval move for same fleet', () {
+      const p1 = 'p1';
+      final before = Orders(
+        navalMoveOrdersByPlayerId: {
+          p1: [
+            const NavalMoveOrder(
+              fleetId: 'f1',
+              destinationSeaZoneId: 'sea1',
+            ),
+          ],
+        },
+      );
+      final after = applyNavalMoveOrderForPlayer(
+        before,
+        p1,
+        const NavalMoveOrder(
+          fleetId: 'f1',
+          destinationSeaZoneId: 'sea2',
+        ),
+      );
+      expect(
+        after.navalMoveOrdersByPlayerId[p1],
+        equals([
+          const NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 'sea2'),
+        ]),
+      );
+    });
+
+    test('removes naval mission orders for same fleet', () {
+      const p1 = 'p1';
+      final before = Orders(
+        navalMoveOrdersByPlayerId: {
+          p1: [
+            const NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 'sea2'),
+          ],
+        },
+        navalMissionOrdersByPlayerId: {
+          p1: [
+            NavalMissionOrder(fleetId: 'f1', mission: 'patrol'),
+            NavalMissionOrder(fleetId: 'f2', mission: 'patrol'),
+          ],
+        },
+      );
+      final after = applyNavalMoveOrderForPlayer(
+        before,
+        p1,
+        const NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 'sea3'),
+      );
+      expect(
+        after.navalMissionOrdersByPlayerId[p1]?.map((e) => e.fleetId).toList(),
+        equals(['f2']),
+      );
+    });
+  });
+
+  group('navalMissionOrdersRespectingNavalMoves', () {
+    test('drops mission for fleet that has a move order', () {
+      const p1 = 'p1';
+      final missions = {
+        p1: [
+          NavalMissionOrder(fleetId: 'f1', mission: 'patrol'),
+        ],
+      };
+      final moves = {
+        p1: [
+          const NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 'z'),
+        ],
+      };
+      final out = navalMissionOrdersRespectingNavalMoves(missions, moves);
+      expect(out.isEmpty, isTrue);
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/draft_orders_naval_test.dart
+++ b/packages/colonizethis_logic/test/draft_orders_naval_test.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 

--- a/packages/colonizethis_logic/test/fog_resolution_test.dart
+++ b/packages/colonizethis_logic/test/fog_resolution_test.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/src/turn/end_of_turn_resolver.dart';
 import 'package:colonizethis_logic/src/world/fog_resolution.dart';
 import 'package:colonizethis_logic/src/world/player_view.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -236,6 +237,280 @@ void main() {
 
       expect(next.containsKey('p1'), isFalse);
       expect(next['p2']!.containsKey('$ow|P2'), isTrue);
+    });
+  });
+
+  group('applyDistantSeaZoneFogRevert', () {
+    test('fogs open-ocean sea tiles when no owned coast and no fleet at sea', () {
+      const ow = 'oldWorld';
+      const tileSea2 = 'oldWorld|s2|0|0';
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(id: 'p1', regionId: ow, type: TopologyNodeType.province),
+          TopologyNode(id: 's1', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(id: 's2', regionId: ow, type: TopologyNodeType.seaZone),
+        ],
+        edges: const [
+          TopologyEdge(id1: 'p1', id2: 's1'),
+          TopologyEdge(id1: 's1', id2: 's2'),
+        ],
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: '$ow|p1', regionId: ow, ownerId: 'gp1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: const {
+            ow: {
+              's1': ['oldWorld|s1|0|0'],
+              's2': [tileSea2],
+            },
+          },
+          fleets: const [],
+        ),
+        players: const [Player(id: 'gp1', displayName: 'GP1', isHuman: true)],
+      );
+      final inputVis = <String, Map<String, String>>{
+        'gp1': {tileSea2: VisibilityLevel.fullyVisible.name},
+      };
+
+      final out = applyDistantSeaZoneFogRevert(game, inputVis, topology);
+
+      expect(out['gp1']![tileSea2], VisibilityLevel.fogged.name);
+    });
+
+    test('does not fog sea zone while player fleet is at sea there', () {
+      const ow = 'oldWorld';
+      const tileSea2 = 'oldWorld|s2|0|0';
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(id: 'p1', regionId: ow, type: TopologyNodeType.province),
+          TopologyNode(id: 's1', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(id: 's2', regionId: ow, type: TopologyNodeType.seaZone),
+        ],
+        edges: const [
+          TopologyEdge(id1: 'p1', id2: 's1'),
+          TopologyEdge(id1: 's1', id2: 's2'),
+        ],
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: '$ow|p1', regionId: ow, ownerId: 'gp1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: const {
+            ow: {
+              's2': [tileSea2],
+            },
+          },
+          fleets: [
+            Fleet(
+              id: 'f1',
+              ownerId: 'gp1',
+              seaZoneId: 's2',
+              regionId: ow,
+              shipTypeIds: const ['carrack'],
+            ),
+          ],
+        ),
+        players: const [Player(id: 'gp1', displayName: 'GP1', isHuman: true)],
+      );
+      final inputVis = <String, Map<String, String>>{
+        'gp1': {tileSea2: VisibilityLevel.fullyVisible.name},
+      };
+
+      final out = applyDistantSeaZoneFogRevert(game, inputVis, topology);
+
+      expect(out['gp1']![tileSea2], VisibilityLevel.fullyVisible.name);
+    });
+
+    test('fogs distant sea when player fleet is in port only (not at sea)', () {
+      const ow = 'oldWorld';
+      const tileSea2 = 'oldWorld|s2|0|0';
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(id: 'p1', regionId: ow, type: TopologyNodeType.province),
+          TopologyNode(id: 's1', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(id: 's2', regionId: ow, type: TopologyNodeType.seaZone),
+        ],
+        edges: const [
+          TopologyEdge(id1: 'p1', id2: 's1'),
+          TopologyEdge(id1: 's1', id2: 's2'),
+        ],
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: '$ow|p1', regionId: ow, ownerId: 'gp1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: const {
+            ow: {
+              's2': [tileSea2],
+            },
+          },
+          fleets: [
+            Fleet(
+              id: 'f1',
+              ownerId: 'gp1',
+              regionId: ow,
+              inPortAtProvinceId: '$ow|p1',
+              shipTypeIds: const ['carrack'],
+            ),
+          ],
+        ),
+        players: const [Player(id: 'gp1', displayName: 'GP1', isHuman: true)],
+      );
+      final inputVis = <String, Map<String, String>>{
+        'gp1': {tileSea2: VisibilityLevel.fullyVisible.name},
+      };
+
+      final out = applyDistantSeaZoneFogRevert(game, inputVis, topology);
+
+      expect(out['gp1']![tileSea2], VisibilityLevel.fogged.name);
+    });
+
+    test('does not change unknown water tiles', () {
+      const ow = 'oldWorld';
+      const tileSea2 = 'oldWorld|s2|0|0';
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(id: 's2', regionId: ow, type: TopologyNodeType.seaZone),
+        ],
+        edges: const [],
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 0),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: const {
+            ow: {
+              's2': [tileSea2],
+            },
+          },
+        ),
+        players: const [Player(id: 'gp1', displayName: 'GP1', isHuman: true)],
+      );
+      final inputVis = <String, Map<String, String>>{
+        'gp1': {tileSea2: VisibilityLevel.unknown.name},
+      };
+
+      final out = applyDistantSeaZoneFogRevert(game, inputVis, topology);
+
+      expect(out['gp1']![tileSea2], VisibilityLevel.unknown.name);
+    });
+
+    test('coastal pass after distant restores shore-adjacent sea from fogged', () {
+      const ow = 'oldWorld';
+      const tileS1 = 'oldWorld|s1|0|0';
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(id: 'p1', regionId: ow, type: TopologyNodeType.province),
+          TopologyNode(id: 's1', regionId: ow, type: TopologyNodeType.seaZone),
+        ],
+        edges: const [TopologyEdge(id1: 'p1', id2: 's1')],
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: '$ow|p1', regionId: ow, ownerId: 'gp1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: const {
+            ow: {'s1': [tileS1]},
+          },
+        ),
+        players: const [Player(id: 'gp1', displayName: 'GP1', isHuman: true)],
+      );
+      final afterDistant = applyDistantSeaZoneFogRevert(
+        game,
+        {'gp1': {tileS1: VisibilityLevel.fogged.name}},
+        topology,
+      );
+      expect(afterDistant['gp1']![tileS1], VisibilityLevel.fogged.name);
+      final afterCoastal = applyCoastalSeaZoneFullVisibility(
+        game,
+        afterDistant,
+        topology,
+      );
+      expect(afterCoastal['gp1']![tileS1], VisibilityLevel.fullyVisible.name);
+    });
+
+    test('runEndOfTurnPhase fogs distant sea then coastal restores owned shore',
+        () {
+      const ow = 'oldWorld';
+      const tileS1 = 'oldWorld|s1|0|0';
+      const tileS2 = 'oldWorld|s2|0|0';
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(id: 'p1', regionId: ow, type: TopologyNodeType.province),
+          TopologyNode(id: 's1', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(id: 's2', regionId: ow, type: TopologyNodeType.seaZone),
+        ],
+        edges: const [
+          TopologyEdge(id1: 'p1', id2: 's1'),
+          TopologyEdge(id1: 's1', id2: 's2'),
+        ],
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 5),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: '$ow|p1', regionId: ow, ownerId: 'gp1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: {
+            'gp1': {
+              tileS1: VisibilityLevel.fullyVisible.name,
+              tileS2: VisibilityLevel.fullyVisible.name,
+            },
+          },
+          tileKeysByRegionAndProvince: const {
+            ow: {
+              's1': [tileS1],
+              's2': [tileS2],
+            },
+          },
+          fleets: const [],
+        ),
+        players: const [Player(id: 'gp1', displayName: 'GP1', isHuman: true)],
+      );
+
+      final next = runEndOfTurnPhase(game, topology: topology);
+
+      expect(next.worldState.turnState.turnNumber, 6);
+      expect(next.worldState.turnState.phase, TurnPhase.orders);
+      expect(
+        next.worldState.playerVisibilityByTile['gp1']![tileS2],
+        VisibilityLevel.fogged.name,
+      );
+      expect(
+        next.worldState.playerVisibilityByTile['gp1']![tileS1],
+        VisibilityLevel.fullyVisible.name,
+      );
     });
   });
 

--- a/packages/colonizethis_logic/test/naval_test.dart
+++ b/packages/colonizethis_logic/test/naval_test.dart
@@ -53,6 +53,7 @@ void main() {
       const provinceLocalId = 'p1';
       const fullProvinceId = '$ow|$provinceLocalId';
       const tileKey = '$fullProvinceId|0|0';
+      const tileSea2 = '$ow|sea2|0|0';
 
       final revealTopology = MapTopology(
         nodes: const [
@@ -91,6 +92,7 @@ void main() {
           tileKeysByRegionAndProvince: const {
             ow: {
               fullProvinceId: [tileKey],
+              'sea2': [tileSea2],
             },
           },
           playerVisibilityByTile: const {
@@ -117,6 +119,10 @@ void main() {
       expect(
         next.worldState.playerVisibilityByTile['gp1']?[tileKey],
         VisibilityLevel.revealed.name,
+      );
+      expect(
+        next.worldState.playerVisibilityByTile['gp1']?[tileSea2],
+        VisibilityLevel.fullyVisible.name,
       );
     });
 

--- a/packages/colonizethis_logic/test/turn_resolver_resolve_turn_for_game_part2_test.dart
+++ b/packages/colonizethis_logic/test/turn_resolver_resolve_turn_for_game_part2_test.dart
@@ -995,5 +995,204 @@ void main() {
       expect(next.worldState.fleets.single.seaZoneId, 'sea1');
       expect(next.worldState.turnState.turnNumber, 1);
     });
+
+    test('dock at capital merges sea-going fleet into home fleet and reveals port tiles',
+        () {
+      const ow = 'oldWorld';
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(
+            id: 'sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
+          TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
+        ],
+        edges: const [TopologyEdge(id1: 'sea1', id2: 'P1')],
+      );
+      const tileKey = '$ow|P1|0|0';
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: {
+            ow: {'$ow|P1': [tileKey]},
+          },
+          playerVisibilityByTile: {
+            'p1': {tileKey: 'fogged'},
+          },
+          fleets: [
+            Fleet(
+              id: 'fleet_p1',
+              ownerId: 'p1',
+              seaZoneId: null,
+              inPortAtProvinceId: '$ow|P1',
+              regionId: ow,
+              shipTypeIds: const ['carrack'],
+            ),
+            Fleet(
+              id: 'f2',
+              ownerId: 'p1',
+              seaZoneId: 'sea1',
+              regionId: ow,
+              shipTypeIds: const ['frigate'],
+            ),
+          ],
+        ),
+        players: const [
+          Player(
+            id: 'p1',
+            displayName: 'A',
+            isHuman: true,
+            capitalProvinceId: '$ow|P1',
+          ),
+        ],
+      );
+      final orders = Orders(
+        navalMoveOrdersByPlayerId: {
+          'p1': [
+            NavalMoveOrder(fleetId: 'f2', destinationPortProvinceId: '$ow|P1'),
+          ],
+        },
+      );
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: topology,
+          orders: orders,
+          extractedByPlayerId: const {},
+          defaultAssignments: const [],
+        ),
+      );
+      expect(next.worldState.fleets.length, 1);
+      final home = next.worldState.fleets.single;
+      expect(home.id, 'fleet_p1');
+      expect(home.shipTypeIds.length, 2);
+      expect(home.isInPort, isTrue);
+      expect(
+        next.worldState.playerVisibilityByTile['p1']?[tileKey],
+        'revealed',
+      );
+    });
+
+    test('naval move clears mission on fleet', () {
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(
+            id: 'sea1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.seaZone,
+          ),
+          TopologyNode(
+            id: 'sea2',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.seaZone,
+          ),
+        ],
+        edges: const [TopologyEdge(id1: 'sea1', id2: 'sea2')],
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+          fleets: [
+            Fleet(
+              id: 'f1',
+              ownerId: 'p1',
+              seaZoneId: 'sea1',
+              regionId: 'oldWorld',
+              shipTypeIds: const ['carrack'],
+              mission: FleetMission.patrol,
+            ),
+          ],
+        ),
+        players: const [Player(id: 'p1', displayName: 'A', isHuman: true)],
+      );
+      final orders = Orders(
+        navalMoveOrdersByPlayerId: {
+          'p1': [
+            const NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 'sea2'),
+          ],
+        },
+      );
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: topology,
+          orders: orders,
+          extractedByPlayerId: const {},
+          defaultAssignments: const [],
+        ),
+      );
+      expect(next.worldState.fleets.single.mission, FleetMission.none);
+    });
+
+    test('naval mission order skipped when naval move targets same fleet', () {
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(
+            id: 'sea1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.seaZone,
+          ),
+          TopologyNode(
+            id: 'sea2',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.seaZone,
+          ),
+        ],
+        edges: const [TopologyEdge(id1: 'sea1', id2: 'sea2')],
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+          fleets: [
+            Fleet(
+              id: 'f1',
+              ownerId: 'p1',
+              seaZoneId: 'sea1',
+              regionId: 'oldWorld',
+              shipTypeIds: const ['carrack'],
+              mission: FleetMission.none,
+            ),
+          ],
+        ),
+        players: const [Player(id: 'p1', displayName: 'A', isHuman: true)],
+      );
+      final orders = Orders(
+        navalMoveOrdersByPlayerId: {
+          'p1': [
+            const NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 'sea2'),
+          ],
+        },
+        navalMissionOrdersByPlayerId: {
+          'p1': [
+            NavalMissionOrder(fleetId: 'f1', mission: 'patrol'),
+          ],
+        },
+      );
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: topology,
+          orders: orders,
+          extractedByPlayerId: const {},
+          defaultAssignments: const [],
+        ),
+      );
+      expect(next.worldState.fleets.single.seaZoneId, 'sea2');
+      expect(next.worldState.fleets.single.mission, FleetMission.none);
+    });
   });
 }

--- a/packages/colonizethis_models/lib/src/app_events.dart
+++ b/packages/colonizethis_models/lib/src/app_events.dart
@@ -238,6 +238,18 @@ class NavalSplitFleetRequestedEvent extends SessionCommandEvent {
   final List<String> shipInstanceIdsToNewFleet;
 }
 
+/// Move fleet dialog confirm: shell merges [moveOrder] into current-turn draft orders.
+/// SPEC/program/app-ui-wiring.md.
+class NavalMoveFleetRequestedEvent extends SessionCommandEvent {
+  NavalMoveFleetRequestedEvent({
+    required this.humanPlayerId,
+    required this.moveOrder,
+  });
+
+  final String humanPlayerId;
+  final NavalMoveOrder moveOrder;
+}
+
 /// Train civilians dialog close: shell merges into current-turn orders draft.
 class TrainCivilianBuildOrdersCommittedEvent extends SessionCommandEvent {
   TrainCivilianBuildOrdersCommittedEvent({required this.orders});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -497,10 +497,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

Implements **Move fleet** from the naval units panel (dialog, app event bus, draft orders / turn resolution) and **end-of-turn distant sea zone fog** (refog open-ocean water when no owned adjacent coast and no fleet **at sea** in that zone), with specs and tests.

## Related issue

**Related to #1437** — this PR advances the issue but is **not** intended to close it (further verification or follow-ups may remain).

## Changes

- **UI**: `MoveFleetDialog`, naval panel **Move** integration; `NavalMoveFleetRequestedEvent` / result handling per `SPEC/program/app-ui-wiring.md`.
- **Logic**: `applyDistantSeaZoneFogRevert` in end-of-turn order (after fog decay, before coastal full visibility); naval move reveals **water** in destination sea zone; draft mutations for naval move vs mission.
- **Specs**: `SPEC/game/fog-and-exploration.md`, `SPEC/program/fog-and-exploration-resolution.md`, `SPEC/program/naval-movement-resolution.md`, `SPEC/game/ships-and-naval.md`, `SPEC/ui/naval-units-panel.md`, bus/wiring.
- **Tests**: `fog_resolution_test.dart`, `naval_test.dart`, `draft_orders_naval_test.dart`, `turn_resolver_resolve_turn_for_game_part2_test.dart`, `naval_units_panel_test.dart`.

## Verification

- `dart test` (package `colonizethis_logic`)
- `flutter test test/naval_units_panel_test.dart` (app)
