### PR TITLE
fix(logging): enforce logger-owned prefixes and phase info logs

### DIFF
--- a/packages/colonizethis_logic/lib/src/setup/gp_starting_grain.dart
+++ b/packages/colonizethis_logic/lib/src/setup/gp_starting_grain.dart
@@ -55,7 +55,11 @@ List<String> selectGreatPowerBootstrapGrainTileKeysLandOnly({
 ///
 /// When the OW map lacks [TileMapResult.terrainGrid] or [TileMapResult.resourceGrid],
 /// skips bootstrap (hand-made test maps). Generated maps include both.
-({Game game, TileMapResult tileMap, Map<String, List<String>> grainKeysByPlayerId})
+({
+  Game game,
+  TileMapResult tileMap,
+  Map<String, List<String>> grainKeysByPlayerId,
+})
 applyGreatPowerStartingGrainBootstrap({
   required Game game,
   required TileMapResult tileMapOldWorld,
@@ -63,9 +67,9 @@ applyGreatPowerStartingGrainBootstrap({
 }) {
   final terrain = tileMapOldWorld.terrainGrid;
   final resGrid = tileMapOldWorld.resourceGrid;
-    if (terrain == null || resGrid == null) {
+  if (terrain == null || resGrid == null) {
     _log.i(
-      'logic: skip Great Power grain bootstrap (missing terrain or resource grid)',
+      'skip Great Power grain bootstrap (missing terrain or resource grid)',
     );
     return (
       game: game,
@@ -107,7 +111,10 @@ applyGreatPowerStartingGrainBootstrap({
       final x = int.parse(parts[2]);
       final y = int.parse(parts[3]);
       final t = map.terrainAt(x, y);
-      final allowedRegion = resourceRules.isAllowedInRegion(Resource.grain, cap.regionId);
+      final allowedRegion = resourceRules.isAllowedInRegion(
+        Resource.grain,
+        cap.regionId,
+      );
       final allowedTerrain =
           t != null && resourceRules.isAllowedOnTerrain(Resource.grain, t);
       if (!allowedRegion || !allowedTerrain) {

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -230,7 +230,7 @@ TurnResolutionResult resolveTurnForGame({
   for (var i = 0; i < turnResolutionSequence.length; i++) {
     final phase = turnResolutionSequence[i];
     if (i < phaseIndex) continue;
-    _log.d('phase ${phase.name} start');
+    _log.i('phase ${phase.name} start');
     switch (phase) {
       case TurnPhase.orders:
         // Orders are assumed to already be attached to the Game or passed in.
@@ -402,7 +402,7 @@ TurnResolutionResult resolveTurnForGame({
           break;
         }
     }
-    _log.d('phase ${phase.name} end');
+    _log.i('phase ${phase.name} end');
   }
 
   _log.i('turn $turn resolve end');

--- a/packages/colonizethis_logic/test/combat_logging_test.dart
+++ b/packages/colonizethis_logic/test/combat_logging_test.dart
@@ -5,9 +5,9 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
 
 List<String> _combatMessages(List<LogEvent> events) => [
-      for (final e in events)
-        if (e.message.contains('logic: combat')) e.message,
-    ];
+  for (final e in events)
+    if (e.message.contains('logic: combat')) e.message,
+];
 
 void main() {
   group('land combat logging', () {
@@ -27,111 +27,114 @@ void main() {
       Logger.level = Level.info;
     });
 
-    test('resolveBattleContext emits engagement (debug) and battle_apply (info)', () {
-      final attackerUnits = [
-        Unit(
-          id: 'a1',
-          type: 'grenadiers',
-          ownerId: 'att',
-          locationProvinceId: 'p',
-          medals: 3,
-        ),
-        Unit(
-          id: 'a2',
-          type: 'grenadiers',
-          ownerId: 'att',
-          locationProvinceId: 'p',
-          medals: 2,
-        ),
-      ];
-      final defenderUnits = [
-        Unit(
-          id: 'd1',
-          type: 'peasant_levies',
-          ownerId: 'def',
-          locationProvinceId: 'p',
-          medals: 0,
-        ),
-      ];
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            provinces: const [
-              Province(id: 'p', regionId: 'oldWorld', ownerId: 'def'),
-            ],
-            units: [...attackerUnits, ...defenderUnits],
+    test(
+      'resolveBattleContext emits engagement (debug) and battle_apply (info)',
+      () {
+        final attackerUnits = [
+          Unit(
+            id: 'a1',
+            type: 'grenadiers',
+            ownerId: 'att',
+            locationProvinceId: 'p',
+            medals: 3,
           ),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(
-            id: 'att',
-            displayName: 'France',
-            isHuman: true,
-            leaderKey: 'napoleon',
+          Unit(
+            id: 'a2',
+            type: 'grenadiers',
+            ownerId: 'att',
+            locationProvinceId: 'p',
+            medals: 2,
           ),
-          Player(
-            id: 'def',
-            displayName: 'Prussia',
-            isHuman: false,
-            leaderKey: 'frederick',
+        ];
+        final defenderUnits = [
+          Unit(
+            id: 'd1',
+            type: 'peasant_levies',
+            ownerId: 'def',
+            locationProvinceId: 'p',
+            medals: 0,
           ),
-        ],
-      );
-      const ctx = BattleContext(
-        provinceId: 'p',
-        regionId: 'oldWorld',
-        defenderFactionId: 'def',
-        defenderUnitIds: ['d1'],
-        attackers: [
-          AttackingSide(factionId: 'att', unitIds: ['a1', 'a2']),
-        ],
-        fortLevel: 0,
-        terrain: 'plains',
-      );
+        ];
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(id: 'p', regionId: 'oldWorld', ownerId: 'def'),
+              ],
+              units: [...attackerUnits, ...defenderUnits],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(
+              id: 'att',
+              displayName: 'France',
+              isHuman: true,
+              leaderKey: 'napoleon',
+            ),
+            Player(
+              id: 'def',
+              displayName: 'Prussia',
+              isHuman: false,
+              leaderKey: 'frederick',
+            ),
+          ],
+        );
+        const ctx = BattleContext(
+          provinceId: 'p',
+          regionId: 'oldWorld',
+          defenderFactionId: 'def',
+          defenderUnitIds: ['d1'],
+          attackers: [
+            AttackingSide(factionId: 'att', unitIds: ['a1', 'a2']),
+          ],
+          fortLevel: 0,
+          terrain: 'plains',
+        );
 
-      resolveBattleContext(game, ctx);
+        resolveBattleContext(game, ctx);
 
-      final combat = _combatMessages(capturedEvents);
-      expect(
-        combat.where((m) => m.contains('logic: combat engagement')).length,
-        1,
-      );
-      final engagement = combat.firstWhere(
-        (m) => m.contains('logic: combat engagement'),
-      );
-      expect(engagement, contains('result='));
-      expect(engagement, contains('attackerFactionId=att'));
-      expect(engagement, contains('attCasualties='));
-      expect(engagement, contains('defCasualties='));
+        final combat = _combatMessages(capturedEvents);
+        expect(
+          combat.where((m) => m.contains('logic: combat engagement')).length,
+          1,
+        );
+        final engagement = combat.firstWhere(
+          (m) => m.contains('logic: combat engagement'),
+        );
+        expect(engagement, contains('result='));
+        expect(engagement, contains('attackerFactionId=att'));
+        expect(engagement, contains('attCasualties='));
+        expect(engagement, contains('defCasualties='));
 
-      final apply = combat.firstWhere(
-        (m) => m.contains('logic: combat battle_apply'),
-      );
-      expect(apply, contains('mode=autoResolve'));
-      expect(apply, contains('provinceFlipped='));
-      expect(apply, contains('casualtiesApplied='));
-      expect(apply, contains('ownerAfter='));
+        final apply = combat.firstWhere(
+          (m) => m.contains('logic: combat battle_apply'),
+        );
+        expect(apply, contains('mode=autoResolve'));
+        expect(apply, contains('provinceFlipped='));
+        expect(apply, contains('casualtiesApplied='));
+        expect(apply, contains('ownerAfter='));
 
-      expect(
-        capturedEvents.any(
-          (e) =>
-              e.level == Level.debug &&
-              e.message.contains('logic: combat engagement'),
-        ),
-        isTrue,
-      );
-      expect(
-        capturedEvents.any(
-          (e) =>
-              e.level == Level.info &&
-              e.message.contains('logic: combat battle_apply'),
-        ),
-        isTrue,
-      );
-    });
+        expect(
+          capturedEvents.any(
+            (e) =>
+                e.level == Level.debug &&
+                e.message.contains('logic: combat engagement'),
+          ),
+          isTrue,
+        );
+        expect(
+          capturedEvents.any(
+            (e) =>
+                e.level == Level.info &&
+                e.message.contains('logic: combat battle_apply'),
+          ),
+          isTrue,
+        );
+      },
+    );
 
     test('two attacker sides emit one debug line per executed engagement', () {
       // First attacker must lose (defender still holds); otherwise a decisive
@@ -197,285 +200,306 @@ void main() {
 
       resolveBattleContext(game, ctx);
 
-      final engagementLines = _combatMessages(capturedEvents)
-          .where((m) => m.contains('logic: combat engagement'))
-          .toList();
+      final engagementLines = _combatMessages(
+        capturedEvents,
+      ).where((m) => m.contains('logic: combat engagement')).toList();
       expect(engagementLines.length, 2);
       expect(
-        engagementLines.where((m) => m.contains('attackerFactionId=attA')).length,
+        engagementLines
+            .where((m) => m.contains('attackerFactionId=attA'))
+            .length,
         1,
       );
       expect(
-        engagementLines.where((m) => m.contains('attackerFactionId=attB')).length,
+        engagementLines
+            .where((m) => m.contains('attackerFactionId=attB'))
+            .length,
         1,
       );
     });
 
-    test('Combat phase logs conflict_detection and battle_start for moved-in attack', () {
-      final topology = MapTopology(
-        nodes: [
-          const TopologyNode(
-            id: 'P1',
-            regionId: 'oldWorld',
-            type: TopologyNodeType.province,
-          ),
-          const TopologyNode(
-            id: 'P2',
-            regionId: 'oldWorld',
-            type: TopologyNodeType.province,
-          ),
-        ],
-        edges: [
-          const TopologyEdge(id1: 'P1', id2: 'P2'),
-        ],
-      );
-
-      const ow = 'oldWorld';
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-          oldWorld: RegionData(
-            provinces: [
-              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
-              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
-            ],
-            units: [
-              Unit(
-                id: 'u1',
-                type: 'grenadiers',
-                ownerId: 'p1',
-                locationProvinceId: '$ow|P1',
-                medals: 2,
-              ),
-              Unit(
-                id: 'u2',
-                type: 'peasant_levies',
-                ownerId: 'p2',
-                locationProvinceId: '$ow|P2',
-              ),
-            ],
-          ),
-          newWorld: const RegionData(),
-        ),
-        players: [
-          Player(id: 'p1', displayName: 'A', isHuman: true, militaryLevel: 3),
-          Player(id: 'p2', displayName: 'B', isHuman: true, militaryLevel: 1),
-        ],
-      );
-
-      final orders = Orders(
-        moveOrdersByPlayerId: {
-          'p1': [
-            MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P2'),
+    test(
+      'Combat phase logs conflict_detection and battle_start for moved-in attack',
+      () {
+        final topology = MapTopology(
+          nodes: [
+            const TopologyNode(
+              id: 'P1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            const TopologyNode(
+              id: 'P2',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
           ],
-        },
-      );
+          edges: [const TopologyEdge(id1: 'P1', id2: 'P2')],
+        );
 
-      requireTurnResolutionComplete(
-        resolveTurnForGame(
-          game: game,
-          topology: topology,
-          orders: orders,
-          extractedByPlayerId: const {},
-          defaultAssignments: const [],
-        ),
-      );
-
-      final combat = _combatMessages(capturedEvents);
-      expect(
-        combat.any((m) => m.contains('logic: combat conflict_detection start')),
-        isTrue,
-      );
-      expect(
-        combat.any(
-          (m) =>
-              m.contains('logic: combat conflict_detection end') &&
-              m.contains('battleContexts=1'),
-        ),
-        isTrue,
-      );
-      expect(
-        combat.any(
-          (m) =>
-              m.contains('logic: combat battle_start') &&
-              m.contains('attackerSides=1') &&
-              m.contains('attackerUnitsTotal=1') &&
-              m.contains('mode=autoResolve'),
-        ),
-        isTrue,
-      );
-      expect(
-        combat.any((m) => m.contains('logic: combat engagement')),
-        isTrue,
-      );
-      expect(
-        combat.any(
-          (m) =>
-              m.contains('logic: combat battle_apply') &&
-              m.contains('mode=autoResolve'),
-        ),
-        isTrue,
-      );
-    });
-
-    test('Quick Battle path logs battle_apply quickBattle not auto engagement', () {
-      final topology = MapTopology(
-        nodes: [
-          const TopologyNode(
-            id: 'P1',
-            regionId: 'oldWorld',
-            type: TopologyNodeType.province,
+        const ow = 'oldWorld';
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+                Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+              ],
+              units: [
+                Unit(
+                  id: 'u1',
+                  type: 'grenadiers',
+                  ownerId: 'p1',
+                  locationProvinceId: '$ow|P1',
+                  medals: 2,
+                ),
+                Unit(
+                  id: 'u2',
+                  type: 'peasant_levies',
+                  ownerId: 'p2',
+                  locationProvinceId: '$ow|P2',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
           ),
-          const TopologyNode(
-            id: 'P2',
-            regionId: 'oldWorld',
-            type: TopologyNodeType.province,
-          ),
-        ],
-        edges: [
-          const TopologyEdge(id1: 'P1', id2: 'P2'),
-        ],
-      );
-
-      const ow = 'oldWorld';
-      final game = Game(
-        id: 'g1',
-        defaultCombatMode: CombatMode.quickBattle,
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-          oldWorld: RegionData(
-            provinces: [
-              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
-              Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
-            ],
-            units: [
-              Unit(
-                id: 'u1',
-                type: 'grenadiers',
-                ownerId: 'p1',
-                locationProvinceId: '$ow|P1',
-                medals: 2,
-              ),
-              Unit(
-                id: 'u2',
-                type: 'peasant_levies',
-                ownerId: 'p2',
-                locationProvinceId: '$ow|P2',
-              ),
-            ],
-          ),
-          newWorld: const RegionData(),
-        ),
-        players: [
-          Player(id: 'p1', displayName: 'A', isHuman: true, militaryLevel: 3),
-          Player(id: 'p2', displayName: 'B', isHuman: true, militaryLevel: 1),
-        ],
-      );
-
-      final orders = Orders(
-        moveOrdersByPlayerId: {
-          'p1': [
-            MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P2'),
+          players: [
+            Player(id: 'p1', displayName: 'A', isHuman: true, militaryLevel: 3),
+            Player(id: 'p2', displayName: 'B', isHuman: true, militaryLevel: 1),
           ],
-        },
-      );
+        );
 
-      requireTurnResolutionComplete(
-        resolveTurnForGame(
-          game: game,
-          topology: topology,
-          orders: orders,
-          extractedByPlayerId: const {},
-          defaultAssignments: const [],
-        ),
-      );
+        final orders = Orders(
+          moveOrdersByPlayerId: {
+            'p1': [MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P2')],
+          },
+        );
 
-      final combat = _combatMessages(capturedEvents);
-      expect(
-        combat.any(
-          (m) =>
-              m.contains('logic: combat battle_start') &&
-              m.contains('mode=quickBattle'),
-        ),
-        isTrue,
-      );
-      expect(
-        combat.any(
-          (m) =>
-              m.contains('logic: combat battle_apply') &&
-              m.contains('mode=quickBattle') &&
-              m.contains('winner='),
-        ),
-        isTrue,
-      );
-      expect(
-        combat.any((m) => m.contains('logic: combat engagement')),
-        isFalse,
-      );
-    });
-
-    test('no land battles still logs conflict_detection end with battleContexts=0', () {
-      final topology = MapTopology(
-        nodes: [
-          const TopologyNode(
-            id: 'P1',
-            regionId: 'oldWorld',
-            type: TopologyNodeType.province,
+        requireTurnResolutionComplete(
+          resolveTurnForGame(
+            game: game,
+            topology: topology,
+            orders: orders,
+            extractedByPlayerId: const {},
+            defaultAssignments: const [],
           ),
-        ],
-        edges: const [],
-      );
+        );
 
-      const ow = 'oldWorld';
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-          oldWorld: RegionData(
-            provinces: [
-              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
-            ],
-            units: [
-              Unit(
-                id: 'u1',
-                type: 'grenadiers',
-                ownerId: 'p1',
-                locationProvinceId: '$ow|P1',
-                medals: 2,
-              ),
-            ],
+        final combat = _combatMessages(capturedEvents);
+        expect(
+          combat.any(
+            (m) => m.contains('logic: combat conflict_detection start'),
           ),
-          newWorld: const RegionData(),
-        ),
-        players: [
-          Player(id: 'p1', displayName: 'A', isHuman: true, militaryLevel: 3),
-        ],
-      );
+          isTrue,
+        );
+        expect(
+          combat.any(
+            (m) =>
+                m.contains('logic: combat conflict_detection end') &&
+                m.contains('battleContexts=1'),
+          ),
+          isTrue,
+        );
+        expect(
+          combat.any(
+            (m) =>
+                m.contains('logic: combat battle_start') &&
+                m.contains('attackerSides=1') &&
+                m.contains('attackerUnitsTotal=1') &&
+                m.contains('mode=autoResolve'),
+          ),
+          isTrue,
+        );
+        expect(
+          combat.any((m) => m.contains('logic: combat engagement')),
+          isTrue,
+        );
+        expect(
+          combat.any(
+            (m) =>
+                m.contains('logic: combat battle_apply') &&
+                m.contains('mode=autoResolve'),
+          ),
+          isTrue,
+        );
+        expect(
+          capturedEvents.any(
+            (e) =>
+                e.level == Level.info &&
+                e.message.contains('logic: phase combat start'),
+          ),
+          isTrue,
+        );
+        expect(
+          capturedEvents.any(
+            (e) =>
+                e.level == Level.info &&
+                e.message.contains('logic: phase combat end'),
+          ),
+          isTrue,
+        );
+      },
+    );
 
-      requireTurnResolutionComplete(
-        resolveTurnForGame(
-          game: game,
-          topology: topology,
-          orders: const Orders(),
-          extractedByPlayerId: const {},
-          defaultAssignments: const [],
-        ),
-      );
+    test(
+      'Quick Battle path logs battle_apply quickBattle not auto engagement',
+      () {
+        final topology = MapTopology(
+          nodes: [
+            const TopologyNode(
+              id: 'P1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            const TopologyNode(
+              id: 'P2',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: [const TopologyEdge(id1: 'P1', id2: 'P2')],
+        );
 
-      final combat = _combatMessages(capturedEvents);
-      expect(
-        combat.any(
-          (m) =>
-              m.contains('logic: combat conflict_detection end') &&
-              m.contains('battleContexts=0'),
-        ),
-        isTrue,
-      );
-      expect(
-        combat.any((m) => m.contains('logic: combat battle_start')),
-        isFalse,
-      );
-    });
+        const ow = 'oldWorld';
+        final game = Game(
+          id: 'g1',
+          defaultCombatMode: CombatMode.quickBattle,
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+                Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
+              ],
+              units: [
+                Unit(
+                  id: 'u1',
+                  type: 'grenadiers',
+                  ownerId: 'p1',
+                  locationProvinceId: '$ow|P1',
+                  medals: 2,
+                ),
+                Unit(
+                  id: 'u2',
+                  type: 'peasant_levies',
+                  ownerId: 'p2',
+                  locationProvinceId: '$ow|P2',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: [
+            Player(id: 'p1', displayName: 'A', isHuman: true, militaryLevel: 3),
+            Player(id: 'p2', displayName: 'B', isHuman: true, militaryLevel: 1),
+          ],
+        );
+
+        final orders = Orders(
+          moveOrdersByPlayerId: {
+            'p1': [MoveOrder(unitId: 'u1', destinationProvinceId: '$ow|P2')],
+          },
+        );
+
+        requireTurnResolutionComplete(
+          resolveTurnForGame(
+            game: game,
+            topology: topology,
+            orders: orders,
+            extractedByPlayerId: const {},
+            defaultAssignments: const [],
+          ),
+        );
+
+        final combat = _combatMessages(capturedEvents);
+        expect(
+          combat.any(
+            (m) =>
+                m.contains('logic: combat battle_start') &&
+                m.contains('mode=quickBattle'),
+          ),
+          isTrue,
+        );
+        expect(
+          combat.any(
+            (m) =>
+                m.contains('logic: combat battle_apply') &&
+                m.contains('mode=quickBattle') &&
+                m.contains('winner='),
+          ),
+          isTrue,
+        );
+        expect(
+          combat.any((m) => m.contains('logic: combat engagement')),
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'no land battles still logs conflict_detection end with battleContexts=0',
+      () {
+        final topology = MapTopology(
+          nodes: [
+            const TopologyNode(
+              id: 'P1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: const [],
+        );
+
+        const ow = 'oldWorld';
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
+              units: [
+                Unit(
+                  id: 'u1',
+                  type: 'grenadiers',
+                  ownerId: 'p1',
+                  locationProvinceId: '$ow|P1',
+                  medals: 2,
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: [
+            Player(id: 'p1', displayName: 'A', isHuman: true, militaryLevel: 3),
+          ],
+        );
+
+        requireTurnResolutionComplete(
+          resolveTurnForGame(
+            game: game,
+            topology: topology,
+            orders: const Orders(),
+            extractedByPlayerId: const {},
+            defaultAssignments: const [],
+          ),
+        );
+
+        final combat = _combatMessages(capturedEvents);
+        expect(
+          combat.any(
+            (m) =>
+                m.contains('logic: combat conflict_detection end') &&
+                m.contains('battleContexts=0'),
+          ),
+          isTrue,
+        );
+        expect(
+          combat.any((m) => m.contains('logic: combat battle_start')),
+          isFalse,
+        );
+      },
+    );
   });
 }

--- a/packages/colonizethis_logic/test/event_bus/game_event_bus_test.dart
+++ b/packages/colonizethis_logic/test/event_bus/game_event_bus_test.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:logger/logger.dart';
 
 void main() {
   group('GameEventBus', () {
@@ -198,6 +199,55 @@ void main() {
           turnNumber: 1,
         ),
       );
+    });
+
+    test('publish logs event line with event type and summary', () async {
+      final capturedEvents = <LogEvent>[];
+      void listener(LogEvent event) => capturedEvents.add(event);
+      Logger.addLogListener(listener);
+      addTearDown(() => Logger.removeLogListener(listener));
+
+      bus.publish(
+        DiplomacyChangeEvent(
+          actorId: 'gp1',
+          targetId: 'gp2',
+          changeType: 'peace',
+          turnNumber: 2,
+        ),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      final line = capturedEvents
+          .where((e) => e.level == Level.info)
+          .map((e) => e.message.toString())
+          .firstWhere((m) => m.contains('logic: event=DiplomacyChangeEvent'));
+      expect(line, contains('turn=2'));
+      expect(line, contains('actorId=gp1'));
+      expect(line, contains('targetId=gp2'));
+      expect(line, contains('changeType=peace'));
+    });
+
+    test('publish truncates long event summaries with marker', () async {
+      final capturedEvents = <LogEvent>[];
+      void listener(LogEvent event) => capturedEvents.add(event);
+      Logger.addLogListener(listener);
+      addTearDown(() => Logger.removeLogListener(listener));
+
+      final longSummary = List.filled(600, 'x').join();
+      bus.publish(
+        OrderRejectedEvent(
+          playerId: 'gp1',
+          orderSummary: longSummary,
+          reasonCode: 'invalid_order',
+        ),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      final line = capturedEvents
+          .where((e) => e.level == Level.info)
+          .map((e) => e.message.toString())
+          .firstWhere((m) => m.contains('logic: event=OrderRejectedEvent'));
+      expect(line, contains('truncated=true'));
     });
   });
 }


### PR DESCRIPTION
## Summary
- align turn phase boundary logging with `SPEC/program/logging/turn-resolution.md` by logging `phase <name> start/end` at info level in `turn_resolver`
- remove remaining manual `logic:` text in `gp_starting_grain` so prefixes are applied only by `CtLogger` context
- add regression tests for combat phase info-level phase logs and event bus delivery logging (event summary fields + truncation marker)

## Test plan
- [x] `dart test packages/colonizethis_logic/test/event_bus/game_event_bus_test.dart`
- [x] `dart test packages/colonizethis_logic/test/combat_logging_test.dart`
- [x] `dart test packages/colonizethis_logic/test/research_logging_test.dart`


Made with [Cursor](https://cursor.com)