### PR TITLE
test(app): reduce flakiness in diplomacy panel test subset

### DIFF
--- a/app/test/diplomacy_panel_orders_test.dart
+++ b/app/test/diplomacy_panel_orders_test.dart
@@ -71,11 +71,13 @@ class _PendingOrderShell extends StatefulWidget {
     required this.game,
     required this.humanPlayerId,
     required this.topology,
+    required this.bus,
   });
 
   final Game game;
   final String humanPlayerId;
   final MapTopology topology;
+  final AppEventBus bus;
 
   @override
   State<_PendingOrderShell> createState() => _PendingOrderShellState();
@@ -114,7 +116,7 @@ class _PendingOrderShellState extends State<_PendingOrderShell> {
           topology: widget.topology,
           currentOrders: _orders,
           onOrdersChanged: (o) => setState(() => _orders = o),
-          bus: AppEventBus(),
+          bus: widget.bus,
         ),
       ),
     );
@@ -123,6 +125,10 @@ class _PendingOrderShellState extends State<_PendingOrderShell> {
 
 void main() {
   suppressLogsForTests();
+
+  setUp(() {
+    AppEventBus.reset();
+  });
 
   testWidgets('DiplomacyPanel shows empty state when no factions discovered', (
     WidgetTester tester,
@@ -149,7 +155,7 @@ void main() {
             topology: MapTopology(),
             currentOrders: const Orders(),
             onOrdersChanged: (_) {},
-            bus: AppEventBus(),
+            bus: AppEventBus.create(),
           ),
         ),
       ),
@@ -165,7 +171,7 @@ void main() {
       final r = getDebugInitGameResult();
       final game = r.game;
       final humanId = game.players.firstWhere((p) => p.isHuman).id;
-      final bus = AppEventBus();
+      final bus = AppEventBus.create();
       final navigatorKey = GlobalKey<NavigatorState>();
 
       await tester.pumpWidget(
@@ -210,12 +216,14 @@ void main() {
       final r = getDebugInitGameResult();
       final game = r.game;
       final humanId = game.players.firstWhere((p) => p.isHuman).id;
+      final bus = AppEventBus.create();
 
       await tester.pumpWidget(
         _PendingOrderShell(
           game: game,
           humanPlayerId: humanId,
           topology: r.combinedTopology,
+          bus: bus,
         ),
       );
       await tester.pumpAndSettle();

--- a/app/test/diplomacy_panel_test.dart
+++ b/app/test/diplomacy_panel_test.dart
@@ -160,7 +160,7 @@ Widget buildPanel({
   void Function(Orders)? onOrdersChanged,
   AppEventBus? bus,
 }) {
-  final panelBus = bus ?? AppEventBus();
+  final panelBus = bus ?? AppEventBus.create();
   final navigatorKey = GlobalKey<NavigatorState>();
   return MaterialApp(
     navigatorKey: navigatorKey,
@@ -212,6 +212,10 @@ void main() {
   late Game gameWithNoDiscovered;
   late String humanPlayerId;
   late MapTopology topology;
+
+  setUp(() {
+    AppEventBus.reset();
+  });
 
   setUpAll(() async {
     await _preWarmFlameImageCache();
@@ -345,6 +349,7 @@ void main() {
 
         final declareWar = find.text('Declare War');
         if (declareWar.evaluate().isNotEmpty) {
+          await tester.ensureVisible(declareWar.first);
           await tester.tap(declareWar.first);
           await tester.pumpAndSettle();
           expect(find.text('OK'), findsOneWidget);
@@ -441,6 +446,7 @@ void main() {
 
         final declareWar = find.text('Declare War');
         if (declareWar.evaluate().isNotEmpty) {
+          await tester.ensureVisible(declareWar.first);
           await tester.tap(declareWar.first);
           await tester.pumpAndSettle();
           expect(find.text('OK'), findsOneWidget);


### PR DESCRIPTION
## Summary
- carve out a reduced-scope follow-up to #1436 focused only on diplomacy panel/widget test stability
- isolate these tests from `AppEventBus` singleton bleed-through by using `AppEventBus.create()` and resetting singleton state per test
- make declare-war button interactions deterministic by ensuring visibility before taps

## Test plan
- [x] `flutter test test/diplomacy_panel_test.dart test/diplomacy_panel_orders_test.dart`


Made with [Cursor](https://cursor.com)