### PR TITLE
fix(app): prevent zero-size nine-patch button hit testing

### DIFF
--- a/app/lib/widgets/ct_nine_patch_button.dart
+++ b/app/lib/widgets/ct_nine_patch_button.dart
@@ -53,52 +53,48 @@ class CtNinePatchButton extends StatelessWidget {
         color: Colors.transparent,
         child: InkWell(
           onTap: enabled ? onPressed : null,
-          child: LayoutBuilder(
-            builder: (context, _) {
-              return NineTileBoxWidget.asset(
-                path: _kAssetPath,
-                tileSize: _tileSize,
-                destTileSize: destTileSize,
-                padding: padding ??
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                child: Center(
-                  child: DefaultTextStyle(
-                    style: (theme.textTheme.titleSmall ??
-                            theme.textTheme.bodyLarge ??
-                            const TextStyle())
-                        .copyWith(color: foregroundColor),
-                    child: IconTheme(
-                      data: IconThemeData(
-                        color: foregroundColor,
-                        size: 20,
-                      ),
-                      child: child,
-                    ),
+          child: NineTileBoxWidget.asset(
+            path: _kAssetPath,
+            tileSize: _tileSize,
+            destTileSize: destTileSize,
+            padding: padding ??
+                const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Center(
+              child: DefaultTextStyle(
+                style: (theme.textTheme.titleSmall ??
+                        theme.textTheme.bodyLarge ??
+                        const TextStyle())
+                    .copyWith(color: foregroundColor),
+                child: IconTheme(
+                  data: IconThemeData(
+                    color: foregroundColor,
+                    size: 20,
                   ),
-                ),
-                loadingBuilder: (_) => _FallbackButton(
-                  color: fallbackColor,
-                  padding: padding ??
-                      const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 12,
-                      ),
                   child: child,
                 ),
-                errorBuilder: (_) {
-                  appLogger('ui').w(
-                    'nine-patch button asset not found, using fallback',
-                  );
-                  return _FallbackButton(
-                    color: fallbackColor,
-                    padding: padding ??
-                        const EdgeInsets.symmetric(
-                          horizontal: 16,
-                          vertical: 12,
-                        ),
-                    child: child,
-                  );
-                },
+              ),
+            ),
+            loadingBuilder: (_) => _FallbackButton(
+              color: fallbackColor,
+              padding: padding ??
+                  const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 12,
+                  ),
+              child: child,
+            ),
+            errorBuilder: (_) {
+              appLogger('ui').w(
+                'nine-patch button asset not found, using fallback',
+              );
+              return _FallbackButton(
+                color: fallbackColor,
+                padding: padding ??
+                    const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 12,
+                    ),
+                child: child,
               );
             },
           ),

--- a/app/lib/widgets/ct_nine_patch_button.dart
+++ b/app/lib/widgets/ct_nine_patch_button.dart
@@ -54,20 +54,11 @@ class CtNinePatchButton extends StatelessWidget {
         child: InkWell(
           onTap: enabled ? onPressed : null,
           child: LayoutBuilder(
-            builder: (context, constraints) {
-              final double? width = constraints.maxWidth.isFinite
-                  ? constraints.maxWidth
-                  : null;
-              final double? height = constraints.maxHeight.isFinite &&
-                      constraints.maxHeight >= minHeight
-                  ? constraints.maxHeight
-                  : null;
+            builder: (context, _) {
               return NineTileBoxWidget.asset(
                 path: _kAssetPath,
                 tileSize: _tileSize,
                 destTileSize: destTileSize,
-                width: width,
-                height: height,
                 padding: padding ??
                     const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
                 child: Center(

--- a/app/test/ct_nine_patch_button_test.dart
+++ b/app/test/ct_nine_patch_button_test.dart
@@ -1,0 +1,75 @@
+import 'dart:convert';
+
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final ninePatchFallbackPng = base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=',
+  );
+
+  setUpAll(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMessageHandler('flutter/assets', (message) async {
+          final key = const StringCodec().decodeMessage(message);
+          if (key == 'assets/images/ui_button_nine_patch.png') {
+            return ByteData.view(ninePatchFallbackPng.buffer);
+          }
+          return null;
+        });
+  });
+
+  tearDownAll(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMessageHandler('flutter/assets', null);
+  });
+
+  testWidgets(
+    'CtNinePatchButton works in AlertDialog action layout',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: Center(
+                child: TextButton(
+                  onPressed: () {
+                    showDialog<void>(
+                      context: context,
+                      builder: (_) => AlertDialog(
+                        title: const Text('Move fleet'),
+                        content: const Text('Pick a destination'),
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.pop(context),
+                            child: const Text('Cancel'),
+                          ),
+                          CtNinePatchButton(
+                            onPressed: () => Navigator.pop(context),
+                            minHeight: 40,
+                            child: const Text('Confirm'),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                  child: const Text('Open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Move fleet'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
+}

--- a/app/test/ct_nine_patch_button_test.dart
+++ b/app/test/ct_nine_patch_button_test.dart
@@ -1,11 +1,13 @@
 import 'dart:convert';
 
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  suppressLogsForTests();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   final ninePatchFallbackPng = base64Decode(


### PR DESCRIPTION
## Summary
- remove nullable width/height forwarding from `CtNinePatchButton` to `NineTileBoxWidget.asset`
- avoid constructing a nine-patch button render path with no concrete size in unbounded layouts
- keep existing button visuals/behavior while eliminating the move-button assertion cascade

Fixes #1441

## Test plan
- [x] `flutter test app/test/naval_units_panel_test.dart`
- [ ] In app, open Naval Units, expand a fleet, click `Move`, verify no `mouse_tracker.dart` assertions

Made with [Cursor](https://cursor.com)