### PR TITLE
fix(logging): remove remaining generate_map double-prefix for #1382

### DIFF
--- a/tool/generate_map/bin/generate_map.dart
+++ b/tool/generate_map/bin/generate_map.dart
@@ -330,7 +330,7 @@ MapGenerationResult runMapGeneration(ParsedMapArgs args) {
     outFile.writeAsStringSync(
       const JsonEncoder.withIndent('  ').convert(tileMapResult.toJson()),
     );
-    _log.i('map: Tile map JSON: ${outFile.absolute.path}');
+    _log.i('Tile map JSON: ${outFile.absolute.path}');
     stdout.writeln('Tile map JSON: ${outFile.absolute.path}');
   }
 


### PR DESCRIPTION
## Summary
- Remove the manual `map:` token from the `Tile map JSON` info log in `tool/generate_map/bin/generate_map.dart`.
- Keep logger prefix ownership with `mapLogger()` so this line no longer double-prefixes.
- Completes the remaining runtime logging policy gap identified on issue #1382.

## Test plan
- [x] `cd tool/generate_map && dart test`


Made with [Cursor](https://cursor.com)