### PR TITLE
fix(naval): seaZoneIdForProvince for combined topology

### DIFF
--- a/SPEC/program/map-data.md
+++ b/SPEC/program/map-data.md
@@ -100,6 +100,7 @@ The loading API (file layout, error handling) will be defined in a future spec u
 ## Province identity and tile key format
 
 - **Province ids:** Topology and tile maps use **local** ids (e.g. `p1`, `p2`). Game state uses **prefixed** ids (`regionId|localId`). Local ids are **not** globally unique across regions (e.g. `p1` can exist in oldWorld and newWorld). Movement and other topology queries (e.g. adjacency, connectivity) must scope by **region** when duplicate local ids exist. Always resolve by regionId + provinceId; never by province id alone. See [world-model.md](../game/world-model.md), [world-model-identity.md](../game/world-model-identity.md).
+- **Combined world topology:** `buildCombinedTopology` in game setup merges per-region graphs into one `MapTopology` whose **node ids and edge endpoints are prefixed** (`regionId|localId`), plus warp edges. The running app and turn resolver use this graph. Logic helpers that take a **local** province id and **regionId** for region-scoped P↔S lookup (e.g. `seaZoneIdForProvince` in colonizethis_logic) must resolve provinces and edges correctly for **both** per-region (local ids in the graph) and combined (prefixed ids) representations.
 - **Tile key format:** `regionId|provinceId|x|y` for mutable game state (extraction, transport, ports). Map visualizers must convert local ids to full province ids before querying ownership.
 
 ---

--- a/SPEC/program/naval-movement-resolution.md
+++ b/SPEC/program/naval-movement-resolution.md
@@ -67,6 +67,7 @@ BuildUnitOrder for naval type; spawns in home fleet (in port at capital). Costs 
 
 - **Phase:** Movement phase (alongside land movement); interception in Naval Interception & Naval Combat step ([turn-resolution-phases.md](turn-resolution-phases.md)). Trade interception during Extraction/Trade.
 - **Upstream:** Fleet orders from [orders.md](orders.md); topology from map data.
+- **Combined topology:** Runtime graph is **combined** `MapTopology` (prefixed node/edge ids per [map-data.md](map-data.md)). For a fleet **in port**, resolving the adjacent sea zone (undock, validation, UI move picks) uses `seaZoneIdForProvince` and related helpers; those lookups must succeed for **local province id + regionId** against that graph, not only against per-region local-id graphs.
 - **Downstream:** Updated fleet locations and visibility in WorldState; BattleContextSea to [naval-combat-resolution.md](naval-combat-resolution.md); cargo reductions to [auto-transport.md](auto-transport.md).
 
 ## Constraints

--- a/SPEC/ui/naval-units-panel.md
+++ b/SPEC/ui/naval-units-panel.md
@@ -33,6 +33,8 @@ For every **sea‑going** fleet (any fleet that is **not** the Home Fleet), the 
 
 **Labels:** The capital province (dock), when listed, should indicate that the fleet **joins the Home Fleet** when the order resolves (per GDD).
 
+**Acceptance — Move fleet with combined topology (in port):** Given a sea-going fleet **in port** at a **coastal** province (prefixed `inPortAtProvinceId`, seabound per map topology) and the panel uses the same **combined** world topology as turn resolution (prefixed node/edge ids per [map-data.md](../program/map-data.md)), when the player opens **Move fleet**, then the dialog shows **at least one** row under **Sea zones** (legal adjacent sea zones for undock) and does **not** show the sole empty-state message *No adjacent sea zones (check map topology).* when adjacency exists.
+
 ---
 
 ## Scope: which fleets are shown

--- a/app/test/move_fleet_dialog_test.dart
+++ b/app/test/move_fleet_dialog_test.dart
@@ -207,4 +207,111 @@ void main() {
     expect(locate!.regionId, 'newWorld');
     expect(locate!.tileKey, 'newWorld|port_nw|0|0');
   });
+
+  testWidgets(
+    'in-port fleet with combined topology shows Sea zones (issue #1446)',
+    (WidgetTester tester) async {
+      const ow = 'oldWorld';
+      const localCap = 'port_cap';
+      final fullCap = '$ow|$localCap';
+      final combinedTopology = MapTopology(
+        nodes: [
+          TopologyNode(
+            id: fullCap,
+            regionId: ow,
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: '$ow|sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
+          TopologyNode(
+            id: '$ow|sea2',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
+        ],
+        edges: [
+          TopologyEdge(id1: fullCap, id2: '$ow|sea1'),
+          TopologyEdge(id1: '$ow|sea1', id2: '$ow|sea2'),
+        ],
+      );
+      final gameInPort = Game(
+        id: 'g_move_dialog_in_port',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(
+                id: fullCap,
+                regionId: ow,
+                ownerId: humanId,
+                displayName: 'Seabound Capital',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          portsByProvinceSeaboard: const {},
+        ),
+        players: [
+          Player(
+            id: humanId,
+            displayName: 'Move Dialog Tester',
+            isHuman: true,
+            capitalProvinceId: fullCap,
+            capitalTile: CapitalTile(
+              regionId: ow,
+              provinceId: fullCap,
+              x: 0,
+              y: 0,
+            ),
+          ),
+        ],
+      );
+      final fleetInPort = Fleet(
+        id: 'f_in_port',
+        ownerId: humanId,
+        regionId: ow,
+        seaZoneId: null,
+        inPortAtProvinceId: fullCap,
+        ships: const [ShipInstance(id: 'ship_1', typeId: 'carrack')],
+      );
+      final bus = AppEventBus.create();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                return TextButton(
+                  onPressed: () {
+                    showDialog<void>(
+                      context: context,
+                      builder: (_) => MoveFleetDialog(
+                        game: gameInPort,
+                        topology: combinedTopology,
+                        humanPlayerId: humanId,
+                        fleet: fleetInPort,
+                        bus: bus,
+                      ),
+                    );
+                  },
+                  child: const Text('open'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pump();
+
+      expect(
+        find.text('No adjacent sea zones (check map topology).'),
+        findsNothing,
+      );
+      expect(find.text('Sea zones'), findsOneWidget);
+      expect(find.text('$ow|sea2 · Old World'), findsOneWidget);
+    },
+  );
 }

--- a/packages/colonizethis_logic/lib/src/world/naval.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval.dart
@@ -69,8 +69,12 @@ String? firstAdjacentSeaZone(MapTopology topology, String seaZoneId) {
 
 /// First sea zone id adjacent to [provinceId], or null if none. Used for home fleet and build_port.
 ///
-/// [provinceId] is the local province id (e.g. p1). When [regionId] is provided, lookup is
-/// region-scoped per SPEC/game/world-model-identity.md (required for multi-region world).
+/// [provinceId] is usually the **local** province id (e.g. `p1`). When [provinceId] is already
+/// prefixed (`regionId|localId`), it is used as-is for lookup. When [regionId] is provided,
+/// lookup is region-scoped per SPEC/game/world-model-identity.md.
+///
+/// Supports both **per-region** topology (node/edge ids are local) and **combined** topology
+/// from [buildCombinedTopology] (prefixed node/edge ids). SPEC/program/map-data.md.
 /// When [regionId] is null, uses first matching node (single-region or legacy).
 String? seaZoneIdForProvince(MapTopology topology, String provinceId, {String? regionId}) {
   if (regionId != null) {
@@ -80,11 +84,26 @@ String? seaZoneIdForProvince(MapTopology topology, String provinceId, {String? r
     }
     final regionNodes = nodesByRegionAndId[regionId];
     if (regionNodes == null) return null;
-    final provinceNode = regionNodes[provinceId];
-    if (provinceNode == null || provinceNode.type != TopologyNodeType.province) return null;
+    final primaryProvinceKey = ProvinceId.isPrefixed(provinceId)
+        ? provinceId
+        : ProvinceId.full(regionId, provinceId);
+    var provinceNode = regionNodes[primaryProvinceKey];
+    if (provinceNode == null && !ProvinceId.isPrefixed(provinceId)) {
+      provinceNode = regionNodes[provinceId];
+    }
+    if (provinceNode == null || provinceNode.type != TopologyNodeType.province) {
+      return null;
+    }
     for (final e in topology.edges) {
-      if (e.id1 != provinceId && e.id2 != provinceId) continue;
-      final other = e.id1 == provinceId ? e.id2 : e.id1;
+      String? other;
+      if (e.id1 == primaryProvinceKey || e.id2 == primaryProvinceKey) {
+        other = e.id1 == primaryProvinceKey ? e.id2 : e.id1;
+      } else if (!ProvinceId.isPrefixed(provinceId) &&
+          (e.id1 == provinceId || e.id2 == provinceId)) {
+        other = e.id1 == provinceId ? e.id2 : e.id1;
+      } else {
+        continue;
+      }
       final otherNode = regionNodes[other];
       if (otherNode?.type == TopologyNodeType.seaZone) return other;
     }

--- a/packages/colonizethis_logic/test/naval_test.dart
+++ b/packages/colonizethis_logic/test/naval_test.dart
@@ -194,6 +194,38 @@ void main() {
         );
         expect(seaZoneIdForProvince(inland, 'p1'), isNull);
       });
+
+      test(
+        'supports combined topology: prefixed node ids and edges (app/turn resolver graph)',
+        () {
+          const ow = 'oldWorld';
+          final combined = MapTopology(
+            nodes: [
+              TopologyNode(
+                id: '$ow|cap',
+                regionId: ow,
+                type: TopologyNodeType.province,
+              ),
+              TopologyNode(
+                id: '$ow|sea1',
+                regionId: ow,
+                type: TopologyNodeType.seaZone,
+              ),
+            ],
+            edges: [
+              TopologyEdge(id1: '$ow|cap', id2: '$ow|sea1'),
+            ],
+          );
+          expect(
+            seaZoneIdForProvince(combined, 'cap', regionId: ow),
+            '$ow|sea1',
+          );
+          expect(
+            seaZoneIdForProvince(combined, '$ow|cap', regionId: ow),
+            '$ow|sea1',
+          );
+        },
+      );
     });
 
     group('provinceIdsAdjacentToSeaZone', () {


### PR DESCRIPTION
## Summary

`seaZoneIdForProvince` failed when the graph was **combined** `MapTopology` (prefixed node/edge ids from `buildCombinedTopology`), because the region-scoped path only looked up local ids. That left **Move fleet** empty for fleets **in port** at coastal provinces even though the map was correct.

The helper now resolves `ProvinceId.full(regionId, localId)` first, with fallback to legacy local-only nodes/edges.

## Spec / tests

- AC on `SPEC/ui/naval-units-panel.md`; notes in `SPEC/program/map-data.md` and `SPEC/program/naval-movement-resolution.md`.
- `packages/colonizethis_logic/test/naval_test.dart`: combined topology case.
- `app/test/move_fleet_dialog_test.dart`: in-port fleet + combined topology widget test.

Refs #1446

Made with [Cursor](https://cursor.com)