### PR TITLE
feat(ai): add full-AI war desire diplomacy scoring

### DIFF
--- a/SPEC/ai/ai-architecture.md
+++ b/SPEC/ai/ai-architecture.md
@@ -48,6 +48,13 @@ AI uses the order suggestion API and applies:
   - **Prefer enemy:** When choosing among valid move candidates, score moves into enemy (at-war) territory higher than moves into unowned or own territory; weighted selection then prefers enemy/contested. Default bonus +20 to score when destination owner is at war with the mover.
 - **Build/work:** Prefer cheaper orders improving owned, visible provinces.
 - **Research:** Prefer lower-era, cheaper techs unlocking core capabilities.
+- **Diplomacy (Full AI):**
+  - Compute a per-pair `warDesireScore` (0..100) for GP↔target where target can be GP, Minor, or Tribe.
+  - Use the same composite power basis as diplomacy power score (military + province + naval) for strength ratio.
+  - Compute improve-relations desire as `100 - warDesireScore`.
+  - Keep relation gate for war declarations.
+  - Apply per GP-target pair cooldowns for war-declare and improve-relations retries.
+  - While at war, recompute war desire each turn to decide continue-war vs offer-peace bias and adjust desired territory objective.
 - **Province identity:** Movement targets, build provinces, and visibility use the **prefixed** form `regionId|localId` per [world-model-identity.md](../game/world-model-identity.md).
 
 Seeded randomness selects among acceptable candidates; personality weights bias selection.

--- a/SPEC/ai/ai-personalities.md
+++ b/SPEC/ai/ai-personalities.md
@@ -55,6 +55,7 @@ Personality also adjusts **thresholds** used by planners:
 - **Peace tendency** — Willingness to accept peace offers (Victoria high, Napoleon lower).
 - **Alliance tendency** — Likelihood to accept/offer alliances and maintain them (Victoria high, Napoleon low).
 - **Research preference** — Weights per tech category (naval, military, economic, exploration) so that e.g. Isabella favors exploration techs.
+- **War desire shaping** — Personality war/peace tendencies bias how the diplomacy planner interprets computed war-desire and improve-relations desire, but must not bypass hard diplomacy constraints (relation gate, legal-order checks, cooldowns).
 
 These are applied when scoring actions (e.g. declare war, accept peace, choose research slot). Combined with hidden agenda modifiers (see [hidden-agendas.md](hidden-agendas.md)).
 

--- a/SPEC/game/diplomacy.md
+++ b/SPEC/game/diplomacy.md
@@ -68,6 +68,53 @@ When these conditions hold, other Great Powers that meet the tech and overture r
 - **Intervention:** Same **Intervention** rules as for Minors (Embassy or purchased land; Diplomacy phase when a GP declares war on the Tribe).
 - **War and overtures:** If relationState becomes `AT_WAR` between a GP and a Tribe, any existing overture state between that GP and that Tribe is **cleared to `none`** and cannot be re-established while they remain at war. After peace, the GP must rebuild the overture chain from `none` if it wants to regain consulate/embassy/colony-level relations.
 
+### GP AI policy for war vs. relations (Full AI only)
+
+This policy applies only to **Phase 6 Full AI**. It does not apply to Phase 4 simple AI.
+
+- For every candidate target faction (GP, Minor, or Tribe), Full AI computes a **war desire score** per `(gpId, targetFactionId)` each turn.
+- Full AI computes an **improve-relations desire score** as `100 - warDesireScore`.
+- The diplomacy planner uses these scores to prioritize `Declare War`, `Offer Peace`, and `Establish Overture`.
+- Full AI keeps the existing relation gate for war declarations (high positive relations can block war declarations even if war desire is high).
+
+#### War desire score (0..100)
+
+`warDesireScore` is clamped to integer range `0..100`, starts at base `50`, then applies factors:
+
+- **Relative power score (primary factor):** uses the same power formula as Great Power power score (military + province + naval):
+  - `relativePower = attackerPowerScore / max(1, targetPowerScore)`
+  - `relativePower >= 1.35` => `+30`
+  - `0.85 <= relativePower < 1.35` => `+5`
+  - `relativePower < 0.85` => `-25`
+- **Relation pressure factor:**
+  - relation score `>= 70` => `-40`
+  - relation score `50..69` => `-20`
+  - relation score `<= 25` => `+10`
+
+For **Minor/Tribe targets**, add:
+
+- **Resource need bonus:** for each distinct target-owned resource that the GP currently has zero stockpile of, `+5`, capped at `+15`.
+- **Intervention-risk penalty:** for each *other GP* with embassy on that Minor/Tribe, `-8`, capped at `-24`.
+- **Invasion capacity adjustment:**
+  - if GP regiment count is too low to stage invasion (`ownRegiments < max(2, targetRegiments/2 floored)`), `-20`
+  - else if `ownRegiments > targetRegiments`, `+10`
+  - if target requires overseas invasion (target has provinces in regions where attacker has none) and attacker has no ships, `-25`
+  - if attacker is already in 2+ active wars, `-15`
+
+#### Cooldowns (per GP-target pair)
+
+- **War declaration cooldown:** after AI initiates `Declare War` on target, AI must wait `4` turns before re-scoring that pair for a new war declaration.
+- **Improve-relations cooldown:** after AI overture accept/reject outcome for target, AI must wait `2` turns before attempting another overture-driven improve-relations action for that same pair.
+
+#### War goals and in-war reassessment
+
+- Before selecting `Declare War`, Full AI derives a **desired territory objective**:
+  - `desiredTerritory = clamp(round(warDesireScore / 25), 1, targetProvinceCount)`
+- While at war, each turn Full AI recomputes `warDesireScore` for that pair:
+  - high war desire lowers `Offer Peace` preference (continue war),
+  - low war desire raises `Offer Peace` preference (de-escalate / adjust down goals).
+- MVP stores war goals as planner output (deterministic logs and action scoring), not as a separate persistent war-goal state object.
+
 ### Diplomatic Order Types
 
 - **Declare War** — target faction; valid if AT_PEACE.
@@ -132,6 +179,30 @@ The following Given–When–Then criteria are testable conditions for diplomacy
   When the system evaluates whether that AI Great Power will intervene against the aggressor  
   Then the system computes a probability to intervene based solely on the current relation score between the AI Great Power and that Minor/Tribe, using the default mapping 0–25 → 0%, 26–50 → 25%, 51–75 → 50%, 76–100 → 80% unless overridden by a ruleset, and samples a single Bernoulli trial with that probability to decide whether to intervene (otherwise **Do Nothing**; AI does not choose **Protest** in MVP).
 
+- Given Full AI controls a Great Power and has legal diplomacy candidates against a target faction in turn `t`  
+  When the AI diplomacy planner scores candidates for that `(gpId, targetFactionId)` pair  
+  Then the system computes `warDesireScore` from the strength ratio and relation factors defined in `GP AI policy for war vs. relations` and computes improve-relations desire as `100 - warDesireScore`.
+
+- Given Full AI controls a Great Power and a Minor/Tribe target has at least one target-owned resource that the GP has zero stockpile of, while no additional constraints change  
+  When the AI computes `warDesireScore` for that target  
+  Then the system increases war desire by `+5` per missing distinct resource up to `+15`.
+
+- Given Full AI controls a Great Power and one or more other Great Powers have embassy overtures with a Minor/Tribe target  
+  When the AI computes `warDesireScore` for war against that target  
+  Then the system applies an intervention-risk penalty of `-8` per such GP up to `-24`.
+
+- Given Full AI controls a Great Power and a `(gpId, targetFactionId)` pair has a prior AI-initiated `Declare War` event at turn `t0`  
+  When the AI evaluates that same pair at turn `t` where `t - t0 < 4`  
+  Then the system treats war declaration for that pair as on cooldown and does not select `Declare War` for that pair in that evaluation.
+
+- Given Full AI controls a Great Power and a `(gpId, targetFactionId)` pair has an overture accept/reject event at turn `t0`  
+  When the AI evaluates improve-relations overture actions for that pair at turn `t` where `t - t0 < 2`  
+  Then the system treats overture-driven improve-relations for that pair as on cooldown and does not select those actions for that pair in that evaluation.
+
+- Given Full AI controls a Great Power and is evaluating a legal `Declare War` candidate against target faction `X` with `targetProvinceCount >= 1`  
+  When the AI computes `warDesireScore` for `X` in that turn  
+  Then the system computes `desiredTerritory = clamp(round(warDesireScore / 25), 1, targetProvinceCount)` and uses that objective to bias wartime continuation/de-escalation scoring in subsequent turns.
+
 - Given the same AI intervention context and the Bernoulli trial results in **intervene**  
   When the Diplomacy phase applies that outcome  
   Then the system changes the relation state between that AI Great Power and the declaring Great Power to `AT_WAR` with `sinceTurn = t`, updates `lastInteractionTurn = t`, and leaves Embassy and overture state between the AI Great Power and the Minor/Tribe unchanged.
@@ -192,6 +263,8 @@ The following Given–When–Then criteria are testable conditions for diplomacy
 | Join Empire per-province cost | £2000 | Added for each province owned by the target Minor/Tribe. Total cost = base + (province count × per-province). |
 | Call to arms refusal score penalty | 20 | Subtracted from ally–defender relation score; alliance ends (no longer Allied). |
 | Call to arms AI join threshold | 50 | AI ally joins the war if relation score with the defended ally is ≥ this value. |
+| Full AI war declaration cooldown (per GP-target pair) | 4 turns | Applies to AI-initiated `Declare War` re-attempts. |
+| Full AI improve-relations cooldown (per GP-target pair) | 2 turns | Applies to AI overture-driven relation improvement retries. |
 
 ### Player-facing relation display
 

--- a/SPEC/program/ai-planner.md
+++ b/SPEC/program/ai-planner.md
@@ -20,9 +20,10 @@ All AI randomness flows from these seeds. Same save + seeds → same orders and 
 
 ### When to Use Each Phase
 
-- **Phase 4 (Minimal / Simple Heuristics):** Default for the main game. Use for all AI-controlled Great Powers in standard gameplay. Suitable for production and casual play.
+- **Phase 4 (Minimal / Simple Heuristics):** Legacy/default heuristics path retained for compatibility and diagnostics.
 
 - **Phase 6 (Full AI):** Advanced AI for simulation, testing, or optional hard mode. Used by ctdev Sim Game when "Use Full AI" is enabled. May be offered as an optional setting in the main game (e.g., "Advanced AI" difficulty toggle). Note: Full AI requires hidden agenda assignment at game setup (see below).
+- **Main app turn flow:** Main app turn advancement uses Phase 6 Full AI order generation for AI-controlled Great Powers (human orders merged with full-AI orders before turn resolution).
 
 ### Phase 4 (Minimal)
 1. Build PlayerView for each AI GP.
@@ -59,6 +60,7 @@ When full AI (Phase 6) runs, the economy planner produces **production assignmen
 - **Seeding and determinism:** Per-AI seeds and per-turn `turnSeed` (with documented sub-seeds) are the only randomness inputs; given the same game state and seeds, AIPlanner produces the same strategic and tactical decisions.
 - **Phase 4 behaviour:** Minimal AI uses PlayerView and the order suggestion API with the documented category order and caps; it does not construct raw orders, and Quick Battle actions depend only on `tacticalSeed` and battle state.
 - **Phase 6 delegation:** Full Phase 6 AI delegates order generation to `colonizethis_ai` per [ai-architecture.md](../ai/ai-architecture.md) and [ai-systems-impl.md](ai-systems-impl.md); control rules, seeding, and order merge remain consistent with this spec. Games using full AI have hidden agendas assigned at setup/init; the caller (game setup or sim controller) invokes `assignHiddenAgendasForGame` before the first `generateOrdersForPlayerFullAI` call.
+- **Full AI diplomacy scoring:** For GP↔GP and GP↔Minor/Tribe pairs, full AI computes per-pair war desire and inverse improve-relations desire using composite power ratio (military + province + naval), relation factors, legal relation gate, and per GP-target cooldowns; wartime re-evaluation influences continue-war vs offer-peace output.
 - **Order merge:** Merged order list preserves stable ordering (player → unit → type), respects human precedence, emits at most one AI order per unit, and is fully validated and deterministic.
 
 ## Constraints

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -1,8 +1,9 @@
 export 'game_screen_shared.dart';
 
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:flame/game.dart';
+import 'package:flame/game.dart' hide Game;
 import 'package:flutter/material.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -90,6 +91,23 @@ void _applyTurnResolutionResult(WidgetRef ref, TurnResolutionResult result) {
   }
 }
 
+TurnResolutionResult resolveNextTurnForGameScreen({
+  required Game game,
+  required Orders orders,
+  required MapTopology? topologyForAi,
+  required TurnResolutionResult Function({
+    required Orders orders,
+    Orders? aiOrders,
+  })
+  runTurnResolution,
+}) {
+  final aiOrders = switch (topologyForAi) {
+    null => null,
+    _ => generateOrdersForGameFullAI(game, topologyForAi).orders,
+  };
+  return runTurnResolution(orders: orders, aiOrders: aiOrders);
+}
+
 /// Hosts the Flame game canvas or map. When map data exists, shows map + province/sea zone overlay.
 class GameScreen extends ConsumerWidget {
   const GameScreen({super.key});
@@ -127,7 +145,19 @@ class GameScreen extends ConsumerWidget {
               onPressed: () {
                 final service = ref.read(gameServiceProvider);
                 final orders = ref.read(currentOrdersProvider);
-                final result = service.runTurnResolution(game, orders: orders);
+                final mapData = service.getMapData(game.id);
+                final result = resolveNextTurnForGameScreen(
+                  game: game,
+                  orders: orders,
+                  topologyForAi: mapData?.combinedTopology,
+                  runTurnResolution:
+                      ({required Orders orders, Orders? aiOrders}) =>
+                          service.runTurnResolution(
+                            game,
+                            orders: orders,
+                            aiOrders: aiOrders,
+                          ),
+                );
                 _applyTurnResolutionResult(ref, result);
               },
               child: Text(

--- a/app/test/diplomacy_screen_test.dart
+++ b/app/test/diplomacy_screen_test.dart
@@ -2,6 +2,7 @@
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/app/test/game_screen_next_turn_ai_test.dart
+++ b/app/test/game_screen_next_turn_ai_test.dart
@@ -1,0 +1,85 @@
+import 'package:colonizethis_app/features/game/flame/game_screen.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('resolveNextTurnForGameScreen', () {
+    test('passes Full AI orders when map data is available', () {
+      final game = Game(
+        id: 'g-next-turn-ai',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'oldWorld|p1', regionId: 'oldWorld', ownerId: 'gp1'),
+            ],
+            units: [
+              Unit(
+                id: 'u1',
+                type: 'grenadiers',
+                ownerId: 'gp1',
+                locationProvinceId: 'oldWorld|p1',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            'gp1': {'oldWorld|p1|0|0': 'fullyVisible'},
+          },
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'AI GP', isHuman: false),
+        ],
+        globalGameSeed: 1,
+        aiSeedByGpId: const {'gp1': 1},
+      );
+      final expectedAiOrders = generateOrdersForGameFullAI(
+        game,
+        const MapTopology(nodes: [], edges: []),
+      ).orders;
+
+      Orders? capturedAiOrders;
+      final result = resolveNextTurnForGameScreen(
+        game: game,
+        orders: const Orders(),
+        topologyForAi: const MapTopology(nodes: [], edges: []),
+        runTurnResolution: ({required Orders orders, Orders? aiOrders}) {
+          capturedAiOrders = aiOrders;
+          return TurnResolutionComplete(game);
+        },
+      );
+
+      expect(result, isA<TurnResolutionComplete>());
+      expect(capturedAiOrders, isNotNull);
+      expect(capturedAiOrders, equals(expectedAiOrders));
+    });
+
+    test('passes null aiOrders when map data is unavailable', () {
+      final game = Game(
+        id: 'g-next-turn-no-map',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [Player(id: 'gp1', displayName: 'Human', isHuman: true)],
+      );
+
+      Orders? capturedAiOrders;
+      final result = resolveNextTurnForGameScreen(
+        game: game,
+        orders: const Orders(),
+        topologyForAi: null,
+        runTurnResolution: ({required Orders orders, Orders? aiOrders}) {
+          capturedAiOrders = aiOrders;
+          return TurnResolutionComplete(game);
+        },
+      );
+
+      expect(result, isA<TurnResolutionComplete>());
+      expect(capturedAiOrders, isNull);
+    });
+  });
+}

--- a/packages/colonizethis_ai/lib/src/domain_planners.dart
+++ b/packages/colonizethis_ai/lib/src/domain_planners.dart
@@ -509,10 +509,24 @@ Orders _runDiplomacyPlanner({
   final agendaId = config.hiddenAgendaId;
   final thresholds = getThresholdsForLeader(config.leaderId);
   final maxRelationForDeclareWar = getDeclareWarMaxRelationScore(agendaId);
+  final warCooldownTurns = 4;
+  final improveRelationsCooldownTurns = 2;
+  final currentTurn = game.worldState.turnState.turnNumber;
   final scores = diploCandidates.map((o) {
     var s = 50;
     switch (o.type) {
       case DiplomaticOrderType.offerPeace:
+        {
+          final rel = snapshot.relations[o.targetFactionId];
+          final warDesire = computeWarDesireScore(
+            game: game,
+            nationId: nationId,
+            targetFactionId: o.targetFactionId,
+            relationScore: rel?.score ?? 50,
+          );
+          // Lower peace desire when current war desire remains high.
+          s -= (warDesire - 50);
+        }
         s += agendaPeaceAcceptanceModifier(agendaId);
         s += (thresholds.peaceTendency - 50);
         break;
@@ -527,9 +541,34 @@ Orders _runDiplomacyPlanner({
           if (relationScore > maxRelationForDeclareWar) {
             s = 0;
           } else {
+            if (_isDecisionOnCooldown(
+              game: game,
+              actorFactionId: nationId,
+              targetFactionId: o.targetFactionId,
+              eventTypes: const [DiplomaticEventType.declareWar],
+              cooldownTurns: warCooldownTurns,
+              currentTurn: currentTurn,
+            )) {
+              s = 0;
+              break;
+            }
+            final warDesire = computeWarDesireScore(
+              game: game,
+              nationId: nationId,
+              targetFactionId: o.targetFactionId,
+              relationScore: relationScore,
+            );
+            final targetProvinceCount = provinceCountOwnedBy(
+              game,
+              o.targetFactionId,
+            );
+            final desiredTerritory = targetProvinceCount <= 0
+                ? 1
+                : ((warDesire / 25).round()).clamp(1, targetProvinceCount);
             s += agendaConquerModifier(agendaId);
             s += agendaTreatyBreakingModifier(agendaId);
             s += (thresholds.warLikelihood - 50);
+            s += (warDesire - 50);
             if (snapshot.opportunities.weakNeighbors.contains(
               o.targetFactionId,
             )) {
@@ -538,7 +577,38 @@ Orders _runDiplomacyPlanner({
             if (rel?.level == RelationLevel.allied) {
               s += getDeclareWarTargetBonusAlly(agendaId);
             }
+            _log.d(
+              'diplomacy warDesire nationId=$nationId targetFactionId=${o.targetFactionId} '
+              'warDesire=$warDesire desiredTerritory=$desiredTerritory',
+            );
           }
+          break;
+        }
+      case DiplomaticOrderType.establishOverture:
+        {
+          if (_isDecisionOnCooldown(
+            game: game,
+            actorFactionId: nationId,
+            targetFactionId: o.targetFactionId,
+            eventTypes: const [
+              DiplomaticEventType.overtureAccepted,
+              DiplomaticEventType.overtureRejected,
+            ],
+            cooldownTurns: improveRelationsCooldownTurns,
+            currentTurn: currentTurn,
+          )) {
+            s = 0;
+            break;
+          }
+          final rel = snapshot.relations[o.targetFactionId];
+          final warDesire = computeWarDesireScore(
+            game: game,
+            nationId: nationId,
+            targetFactionId: o.targetFactionId,
+            relationScore: rel?.score ?? 50,
+          );
+          final improveRelationsDesire = 100 - warDesire;
+          s += (improveRelationsDesire - 50);
           break;
         }
       default:
@@ -573,6 +643,144 @@ Orders _runDiplomacyPlanner({
     'type=${chosen.type}${chosen.type == DiplomaticOrderType.declareWar ? " targetFactionId=${chosen.targetFactionId}" : ""} score=${scores[idx]}',
   );
   return _appendDiplomaticOrders(orders, nationId, [chosen]);
+}
+
+int computeWarDesireScore({
+  required Game game,
+  required String nationId,
+  required String targetFactionId,
+  required int relationScore,
+}) {
+  final attackerPower = greatPowerPowerScore(game, nationId);
+  final targetPower = greatPowerPowerScore(game, targetFactionId);
+  final targetPowerSafe = targetPower <= 0 ? 1 : targetPower;
+  final strengthRatio = attackerPower / targetPowerSafe;
+  var score = 50;
+
+  // Power score already combines military + provinces + naval.
+  if (strengthRatio >= 1.35) {
+    score += 30;
+  } else if (strengthRatio >= 0.85) {
+    score += 5;
+  } else {
+    score -= 25;
+  }
+
+  // Keep relation as a hard strategic drag even before final relation gate.
+  if (relationScore >= 70) {
+    score -= 40;
+  } else if (relationScore >= 50) {
+    score -= 20;
+  } else if (relationScore <= 25) {
+    score += 10;
+  }
+
+  final targetIsMinorOrTribe =
+      game.minorNations.any((m) => m.id == targetFactionId) ||
+      game.tribes.any((t) => t.id == targetFactionId);
+  if (targetIsMinorOrTribe) {
+    score += _resourceNeedBonus(game, nationId, targetFactionId);
+    score += _interventionRiskPenalty(game, nationId, targetFactionId);
+    score += _invasionCapacityAdjustment(game, nationId, targetFactionId);
+  }
+
+  return score.clamp(0, 100);
+}
+
+bool _isDecisionOnCooldown({
+  required Game game,
+  required String actorFactionId,
+  required String targetFactionId,
+  required List<DiplomaticEventType> eventTypes,
+  required int cooldownTurns,
+  required int currentTurn,
+}) {
+  for (final event in game.diplomaticHistoryEvents.reversed) {
+    if (!eventTypes.contains(event.type)) continue;
+    if (event.fromFactionId != actorFactionId) continue;
+    if (event.toFactionId != targetFactionId) continue;
+    return (currentTurn - event.turn) < cooldownTurns;
+  }
+  return false;
+}
+
+int _resourceNeedBonus(Game game, String nationId, String targetFactionId) {
+  final ownedResourceIds = <String>{};
+  final player = game.playerById(nationId);
+  if (player != null) {
+    for (final entry in player.stockpile.quantities.entries) {
+      if (entry.value > 0) ownedResourceIds.add(entry.key);
+    }
+  }
+  final targetResourceIds = <String>{};
+  final byRegion = game.worldState.tileKeysByRegionAndProvince;
+  for (final p in allProvinces(game.worldState)) {
+    if (p.ownerId != targetFactionId) continue;
+    final tiles = byRegion[p.regionId]?[p.id] ?? const <String>[];
+    for (final tileKey in tiles) {
+      final resource = game.worldState.resourceByTileKey[tileKey];
+      if (resource != null && resource.isNotEmpty)
+        targetResourceIds.add(resource);
+    }
+  }
+  final missing = targetResourceIds
+      .where((id) => !ownedResourceIds.contains(id))
+      .length;
+  return (missing * 5).clamp(0, 15);
+}
+
+int _interventionRiskPenalty(
+  Game game,
+  String nationId,
+  String targetFactionId,
+) {
+  var count = 0;
+  for (final overture in game.overtureStates) {
+    if (overture.targetId != targetFactionId) continue;
+    if (overture.gpId == nationId) continue;
+    if (!overture.hasEmbassy) continue;
+    if (game.players.any((p) => p.id == overture.gpId)) count++;
+  }
+  return -(count * 8).clamp(0, 24);
+}
+
+int _invasionCapacityAdjustment(
+  Game game,
+  String nationId,
+  String targetFactionId,
+) {
+  final ownRegiments = allUnitsFromWorld(
+    game.worldState,
+  ).where((u) => u.ownerId == nationId).length;
+  final targetRegiments = allUnitsFromWorld(
+    game.worldState,
+  ).where((u) => u.ownerId == targetFactionId).length;
+  var score = 0;
+  if (ownRegiments < math.max(2, targetRegiments ~/ 2)) {
+    score -= 20;
+  } else if (ownRegiments > targetRegiments) {
+    score += 10;
+  }
+
+  final ownRegionIds = allProvinces(
+    game.worldState,
+  ).where((p) => p.ownerId == nationId).map((p) => p.regionId).toSet();
+  final targetRegionIds = allProvinces(
+    game.worldState,
+  ).where((p) => p.ownerId == targetFactionId).map((p) => p.regionId).toSet();
+  final requiresOverseas = targetRegionIds.any(
+    (id) => !ownRegionIds.contains(id),
+  );
+  if (requiresOverseas && shipCountForFaction(game, nationId) <= 0) {
+    score -= 25;
+  }
+
+  final activeWars = game.diplomacyRelations.where((r) {
+    final involvesNation = r.factionId1 == nationId || r.factionId2 == nationId;
+    return involvesNation && r.state == RelationState.atWar;
+  }).length;
+  if (activeWars >= 2) score -= 15;
+  return score;
 }
 
 Orders _appendDiplomaticOrders(

--- a/packages/colonizethis_ai/test/domain_planners_test.dart
+++ b/packages/colonizethis_ai/test/domain_planners_test.dart
@@ -30,8 +30,7 @@ class _FakeOrderSuggestionAPI implements OrderSuggestionAPI {
     Game game,
     MapTopology topology,
     Orders currentOrders,
-  ) =>
-      move;
+  ) => move;
 
   @override
   List<WorkOrder> suggestWorkOrders(
@@ -40,8 +39,7 @@ class _FakeOrderSuggestionAPI implements OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders, {
     Map<String, TileMapResult>? tileMapByRegion,
-  }) =>
-      work;
+  }) => work;
 
   @override
   List<BuildUnitOrder> suggestBuildOrders(
@@ -49,8 +47,7 @@ class _FakeOrderSuggestionAPI implements OrderSuggestionAPI {
     Game game,
     MapTopology topology,
     Orders currentOrders,
-  ) =>
-      build;
+  ) => build;
 
   @override
   List<ResearchOrder> suggestResearchOrders(
@@ -58,8 +55,7 @@ class _FakeOrderSuggestionAPI implements OrderSuggestionAPI {
     Game game,
     MapTopology topology,
     Orders currentOrders,
-  ) =>
-      research;
+  ) => research;
 
   @override
   List<NavalMoveOrder> suggestNavalMoveOrders(
@@ -67,8 +63,7 @@ class _FakeOrderSuggestionAPI implements OrderSuggestionAPI {
     Game game,
     MapTopology topology,
     Orders currentOrders,
-  ) =>
-      navalMove;
+  ) => navalMove;
 
   @override
   List<NavalMissionOrder> suggestNavalMissionOrders(
@@ -76,8 +71,7 @@ class _FakeOrderSuggestionAPI implements OrderSuggestionAPI {
     Game game,
     MapTopology topology,
     Orders currentOrders,
-  ) =>
-      navalMission;
+  ) => navalMission;
 
   @override
   List<DiplomaticOrder> suggestDiplomaticOrders(
@@ -86,8 +80,7 @@ class _FakeOrderSuggestionAPI implements OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders, {
     Map<String, TileMapResult>? tileMapByRegion,
-  }) =>
-      diplomatic;
+  }) => diplomatic;
 }
 
 void main() {
@@ -101,7 +94,12 @@ void main() {
           newWorld: RegionData(provinces: [], units: []),
         ),
         players: const [
-          Player(id: 'gp1', displayName: 'England', isHuman: false, leaderKey: 'victoria'),
+          Player(
+            id: 'gp1',
+            displayName: 'England',
+            isHuman: false,
+            leaderKey: 'victoria',
+          ),
         ],
       );
       const topology = MapTopology(nodes: [], edges: []);
@@ -168,13 +166,26 @@ void main() {
           },
         ),
         players: const [
-          Player(id: 'gp1', displayName: 'GP', isHuman: false, leaderKey: 'victoria'),
+          Player(
+            id: 'gp1',
+            displayName: 'GP',
+            isHuman: false,
+            leaderKey: 'victoria',
+          ),
         ],
       );
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          TopologyNode(id: 'p2', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(
+            id: 'p1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'p2',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
         ],
         edges: const [TopologyEdge(id1: 'p1', id2: 'p2')],
       );
@@ -214,18 +225,36 @@ void main() {
       // Fake suggestion API to hit economy (work/build), naval move/mission, and research
       // branches without depending on full game logic.
       final fakeApi = _FakeOrderSuggestionAPI(
-        work: const [WorkOrder(unitId: 'u1', target: 'explore', targetTileKey: 'oldWorld|p1|0|0')],
-        build: const [BuildUnitOrder(unitType: 'inf', isMilitary: false, spawnProvinceId: 'oldWorld|p1')],
-        move: const [MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|p2')],
+        work: const [
+          WorkOrder(
+            unitId: 'u1',
+            target: 'explore',
+            targetTileKey: 'oldWorld|p1|0|0',
+          ),
+        ],
+        build: const [
+          BuildUnitOrder(
+            unitType: 'inf',
+            isMilitary: false,
+            spawnProvinceId: 'oldWorld|p1',
+          ),
+        ],
+        move: const [
+          MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|p2'),
+        ],
         research: const [
           ResearchOrder(
             slotIndex: 0,
             techId: 'road_construction',
             funding: ResearchFundingLevel.low,
-          )
+          ),
         ],
-        navalMove: const [NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 's2')],
-        navalMission: const [NavalMissionOrder(fleetId: 'f1', mission: 'patrol')],
+        navalMove: const [
+          NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 's2'),
+        ],
+        navalMission: const [
+          NavalMissionOrder(fleetId: 'f1', mission: 'patrol'),
+        ],
       );
 
       final game = Game(
@@ -240,7 +269,8 @@ void main() {
             id: 'gp1',
             displayName: 'Leader',
             isHuman: false,
-            leaderKey: 'victoria', // economy and military weights both high enough
+            leaderKey:
+                'victoria', // economy and military weights both high enough
           ),
         ],
       );
@@ -281,76 +311,104 @@ void main() {
       );
 
       // Economy: at least one work and build order should be appended.
-      expect(orders.workOrdersByPlayerId['gp1']?.length ?? 0, greaterThanOrEqualTo(1));
-      expect(orders.buildUnitOrdersByPlayerId['gp1']?.length ?? 0, greaterThanOrEqualTo(1));
-      // Research: one research order.
-      expect(orders.researchOrdersByPlayerId['gp1']?.length ?? 0, greaterThanOrEqualTo(1));
-      // Naval: move + mission orders appended.
-      expect(orders.navalMoveOrdersByPlayerId['gp1']?.length ?? 0, greaterThanOrEqualTo(1));
-      expect(orders.navalMissionOrdersByPlayerId['gp1']?.length ?? 0, greaterThanOrEqualTo(1));
-    });
-
-    test('appends diplomatic order when goal is diplomacy and API returns candidates', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-          oldWorld: RegionData(provinces: [], units: []),
-          newWorld: RegionData(provinces: [], units: []),
-        ),
-        players: const [
-          Player(id: 'gp1', displayName: 'England', isHuman: false, leaderKey: 'victoria'),
-        ],
-      );
-      const topology = MapTopology(nodes: [], edges: []);
-      final view = buildPlayerView(game, topology, 'gp1');
-      final snapshot = AIWorldSnapshot.fromPlayerView(view);
-      const config = AIConfig(
-        leaderId: 'victoria',
-        personalityId: 'victoria',
-        hiddenAgendaId: 'peacemaker',
-      );
-      final seeds = AISeedBundle.fromTurnSeed(456);
-      const diploOrder = DiplomaticOrder(
-        type: DiplomaticOrderType.offerPeace,
-        targetFactionId: 'gp2',
-      );
-      const fakeApi = _FakeOrderSuggestionAPI(
-        work: [],
-        build: [],
-        move: [],
-        research: [],
-        navalMove: [],
-        navalMission: [],
-        diplomatic: [diploOrder],
-      );
-      const economyPlan = EconomyPlan(
-        productionAssignments: [],
-        cargoPreference: CargoPreference.none,
-      );
-
-      final orders = runDomainPlanners(
-        game: game,
-        topology: topology,
-        nationId: 'gp1',
-        view: view,
-        snapshot: snapshot,
-        config: config,
-        primaryGoal: StrategicGoal.diplomacy,
-        seeds: seeds,
-        suggestionAPI: fakeApi,
-        economyPlan: economyPlan,
-      );
-
-      expect(orders.diplomaticOrdersByPlayerId['gp1'], isNotNull);
-      expect(orders.diplomaticOrdersByPlayerId['gp1']!.length, greaterThanOrEqualTo(1));
       expect(
-        orders.diplomaticOrdersByPlayerId['gp1']!.any(
-          (o) => o.type == DiplomaticOrderType.offerPeace && o.targetFactionId == 'gp2',
-        ),
-        isTrue,
+        orders.workOrdersByPlayerId['gp1']?.length ?? 0,
+        greaterThanOrEqualTo(1),
+      );
+      expect(
+        orders.buildUnitOrdersByPlayerId['gp1']?.length ?? 0,
+        greaterThanOrEqualTo(1),
+      );
+      // Research: one research order.
+      expect(
+        orders.researchOrdersByPlayerId['gp1']?.length ?? 0,
+        greaterThanOrEqualTo(1),
+      );
+      // Naval: move + mission orders appended.
+      expect(
+        orders.navalMoveOrdersByPlayerId['gp1']?.length ?? 0,
+        greaterThanOrEqualTo(1),
+      );
+      expect(
+        orders.navalMissionOrdersByPlayerId['gp1']?.length ?? 0,
+        greaterThanOrEqualTo(1),
       );
     });
+
+    test(
+      'appends diplomatic order when goal is diplomacy and API returns candidates',
+      () {
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(provinces: [], units: []),
+            newWorld: RegionData(provinces: [], units: []),
+          ),
+          players: const [
+            Player(
+              id: 'gp1',
+              displayName: 'England',
+              isHuman: false,
+              leaderKey: 'victoria',
+            ),
+          ],
+        );
+        const topology = MapTopology(nodes: [], edges: []);
+        final view = buildPlayerView(game, topology, 'gp1');
+        final snapshot = AIWorldSnapshot.fromPlayerView(view);
+        const config = AIConfig(
+          leaderId: 'victoria',
+          personalityId: 'victoria',
+          hiddenAgendaId: 'peacemaker',
+        );
+        final seeds = AISeedBundle.fromTurnSeed(456);
+        const diploOrder = DiplomaticOrder(
+          type: DiplomaticOrderType.offerPeace,
+          targetFactionId: 'gp2',
+        );
+        const fakeApi = _FakeOrderSuggestionAPI(
+          work: [],
+          build: [],
+          move: [],
+          research: [],
+          navalMove: [],
+          navalMission: [],
+          diplomatic: [diploOrder],
+        );
+        const economyPlan = EconomyPlan(
+          productionAssignments: [],
+          cargoPreference: CargoPreference.none,
+        );
+
+        final orders = runDomainPlanners(
+          game: game,
+          topology: topology,
+          nationId: 'gp1',
+          view: view,
+          snapshot: snapshot,
+          config: config,
+          primaryGoal: StrategicGoal.diplomacy,
+          seeds: seeds,
+          suggestionAPI: fakeApi,
+          economyPlan: economyPlan,
+        );
+
+        expect(orders.diplomaticOrdersByPlayerId['gp1'], isNotNull);
+        expect(
+          orders.diplomaticOrdersByPlayerId['gp1']!.length,
+          greaterThanOrEqualTo(1),
+        );
+        expect(
+          orders.diplomaticOrdersByPlayerId['gp1']!.any(
+            (o) =>
+                o.type == DiplomaticOrderType.offerPeace &&
+                o.targetFactionId == 'gp2',
+          ),
+          isTrue,
+        );
+      },
+    );
 
     test('appends no diplomatic order when API returns empty candidates', () {
       final game = Game(
@@ -361,7 +419,12 @@ void main() {
           newWorld: RegionData(provinces: [], units: []),
         ),
         players: const [
-          Player(id: 'gp1', displayName: 'France', isHuman: false, leaderKey: 'napoleon'),
+          Player(
+            id: 'gp1',
+            displayName: 'France',
+            isHuman: false,
+            leaderKey: 'napoleon',
+          ),
         ],
       );
       const topology = MapTopology(nodes: [], edges: []);
@@ -403,209 +466,264 @@ void main() {
       expect(orders.diplomaticOrdersByPlayerId['gp1'], isNull);
     });
 
-    test('with strongCargo and ship candidate picks ship deterministically', () {
-      const regimentBuild = BuildUnitOrder(
-        unitType: 'peasant_levies',
-        isMilitary: true,
-        spawnProvinceId: 'oldWorld|p1',
-      );
-      const shipBuild = BuildUnitOrder(
-        unitType: 'fluyte',
-        isMilitary: false,
-        spawnProvinceId: 'oldWorld|p1',
-      );
-      const fakeApi = _FakeOrderSuggestionAPI(
-        work: [],
-        build: [regimentBuild, shipBuild],
-        move: [],
-        research: [],
-        navalMove: [],
-        navalMission: [],
-        diplomatic: [],
-      );
-      const economyPlanStrongCargo = EconomyPlan(
-        productionAssignments: [],
-        cargoPreference: CargoPreference.strongCargo,
-      );
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(
-            id: 'gp1',
-            displayName: 'A',
-            isHuman: false,
-            leaderKey: 'henry',
+    test(
+      'with strongCargo and ship candidate picks ship deterministically',
+      () {
+        const regimentBuild = BuildUnitOrder(
+          unitType: 'peasant_levies',
+          isMilitary: true,
+          spawnProvinceId: 'oldWorld|p1',
+        );
+        const shipBuild = BuildUnitOrder(
+          unitType: 'fluyte',
+          isMilitary: false,
+          spawnProvinceId: 'oldWorld|p1',
+        );
+        const fakeApi = _FakeOrderSuggestionAPI(
+          work: [],
+          build: [regimentBuild, shipBuild],
+          move: [],
+          research: [],
+          navalMove: [],
+          navalMission: [],
+          diplomatic: [],
+        );
+        const economyPlanStrongCargo = EconomyPlan(
+          productionAssignments: [],
+          cargoPreference: CargoPreference.strongCargo,
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
           ),
-        ],
-      );
-      const topology = MapTopology(nodes: [], edges: []);
-      final view = buildPlayerView(game, topology, 'gp1');
-      final snapshot = AIWorldSnapshot.fromPlayerView(view);
-      const config = AIConfig(
-        leaderId: 'henry',
-        personalityId: 'henry',
-        hiddenAgendaId: 'peacemaker',
-      );
-      final seeds = AISeedBundle.fromTurnSeed(42);
+          players: const [
+            Player(
+              id: 'gp1',
+              displayName: 'A',
+              isHuman: false,
+              leaderKey: 'henry',
+            ),
+          ],
+        );
+        const topology = MapTopology(nodes: [], edges: []);
+        final view = buildPlayerView(game, topology, 'gp1');
+        final snapshot = AIWorldSnapshot.fromPlayerView(view);
+        const config = AIConfig(
+          leaderId: 'henry',
+          personalityId: 'henry',
+          hiddenAgendaId: 'peacemaker',
+        );
+        final seeds = AISeedBundle.fromTurnSeed(42);
 
-      final orders = runDomainPlanners(
-        game: game,
-        topology: topology,
-        nationId: 'gp1',
-        view: view,
-        snapshot: snapshot,
-        config: config,
-        primaryGoal: StrategicGoal.expand,
-        seeds: seeds,
-        suggestionAPI: fakeApi,
-        economyPlan: economyPlanStrongCargo,
-      );
+        final orders = runDomainPlanners(
+          game: game,
+          topology: topology,
+          nationId: 'gp1',
+          view: view,
+          snapshot: snapshot,
+          config: config,
+          primaryGoal: StrategicGoal.expand,
+          seeds: seeds,
+          suggestionAPI: fakeApi,
+          economyPlan: economyPlanStrongCargo,
+        );
 
-      final builds = orders.buildUnitOrdersByPlayerId['gp1'] ?? [];
-      expect(builds.length, 1);
-      expect(builds.single.unitType, 'fluyte', reason: 'strongCargo should favour cargo ship over regiment');
-    });
+        final builds = orders.buildUnitOrdersByPlayerId['gp1'] ?? [];
+        expect(builds.length, 1);
+        expect(
+          builds.single.unitType,
+          'fluyte',
+          reason: 'strongCargo should favour cargo ship over regiment',
+        );
+      },
+    );
 
-    test('build selection is deterministic for same seed and cargoPreference none', () {
-      const regimentBuild = BuildUnitOrder(
-        unitType: 'peasant_levies',
-        isMilitary: true,
-        spawnProvinceId: 'oldWorld|p1',
-      );
-      const shipBuild = BuildUnitOrder(
-        unitType: 'fluyte',
-        isMilitary: false,
-        spawnProvinceId: 'oldWorld|p1',
-      );
-      const fakeApi = _FakeOrderSuggestionAPI(
-        work: [],
-        build: [regimentBuild, shipBuild],
-        move: [],
-        research: [],
-        navalMove: [],
-        navalMission: [],
-        diplomatic: [],
-      );
-      const economyPlan = EconomyPlan(
-        productionAssignments: [],
-        cargoPreference: CargoPreference.none,
-      );
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'gp1', displayName: 'A', isHuman: false, leaderKey: 'victoria'),
-        ],
-      );
-      const topology = MapTopology(nodes: [], edges: []);
-      final view = buildPlayerView(game, topology, 'gp1');
-      final snapshot = AIWorldSnapshot.fromPlayerView(view);
-      const config = AIConfig(
-        leaderId: 'victoria',
-        personalityId: 'victoria',
-        hiddenAgendaId: 'peacemaker',
-      );
-      final seeds = AISeedBundle.fromTurnSeed(999);
+    test(
+      'build selection is deterministic for same seed and cargoPreference none',
+      () {
+        const regimentBuild = BuildUnitOrder(
+          unitType: 'peasant_levies',
+          isMilitary: true,
+          spawnProvinceId: 'oldWorld|p1',
+        );
+        const shipBuild = BuildUnitOrder(
+          unitType: 'fluyte',
+          isMilitary: false,
+          spawnProvinceId: 'oldWorld|p1',
+        );
+        const fakeApi = _FakeOrderSuggestionAPI(
+          work: [],
+          build: [regimentBuild, shipBuild],
+          move: [],
+          research: [],
+          navalMove: [],
+          navalMission: [],
+          diplomatic: [],
+        );
+        const economyPlan = EconomyPlan(
+          productionAssignments: [],
+          cargoPreference: CargoPreference.none,
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(
+              id: 'gp1',
+              displayName: 'A',
+              isHuman: false,
+              leaderKey: 'victoria',
+            ),
+          ],
+        );
+        const topology = MapTopology(nodes: [], edges: []);
+        final view = buildPlayerView(game, topology, 'gp1');
+        final snapshot = AIWorldSnapshot.fromPlayerView(view);
+        const config = AIConfig(
+          leaderId: 'victoria',
+          personalityId: 'victoria',
+          hiddenAgendaId: 'peacemaker',
+        );
+        final seeds = AISeedBundle.fromTurnSeed(999);
 
-      final orders1 = runDomainPlanners(
-        game: game,
-        topology: topology,
-        nationId: 'gp1',
-        view: view,
-        snapshot: snapshot,
-        config: config,
-        primaryGoal: StrategicGoal.expand,
-        seeds: seeds,
-        suggestionAPI: fakeApi,
-        economyPlan: economyPlan,
-      );
-      final orders2 = runDomainPlanners(
-        game: game,
-        topology: topology,
-        nationId: 'gp1',
-        view: view,
-        snapshot: snapshot,
-        config: config,
-        primaryGoal: StrategicGoal.expand,
-        seeds: seeds,
-        suggestionAPI: fakeApi,
-        economyPlan: economyPlan,
-      );
+        final orders1 = runDomainPlanners(
+          game: game,
+          topology: topology,
+          nationId: 'gp1',
+          view: view,
+          snapshot: snapshot,
+          config: config,
+          primaryGoal: StrategicGoal.expand,
+          seeds: seeds,
+          suggestionAPI: fakeApi,
+          economyPlan: economyPlan,
+        );
+        final orders2 = runDomainPlanners(
+          game: game,
+          topology: topology,
+          nationId: 'gp1',
+          view: view,
+          snapshot: snapshot,
+          config: config,
+          primaryGoal: StrategicGoal.expand,
+          seeds: seeds,
+          suggestionAPI: fakeApi,
+          economyPlan: economyPlan,
+        );
 
-      final build1 = orders1.buildUnitOrdersByPlayerId['gp1']?.single.unitType;
-      final build2 = orders2.buildUnitOrdersByPlayerId['gp1']?.single.unitType;
-      expect(build1, build2, reason: 'same seed and economyPlan should yield same build choice');
-    });
+        final build1 =
+            orders1.buildUnitOrdersByPlayerId['gp1']?.single.unitType;
+        final build2 =
+            orders2.buildUnitOrdersByPlayerId['gp1']?.single.unitType;
+        expect(
+          build1,
+          build2,
+          reason: 'same seed and economyPlan should yield same build choice',
+        );
+      },
+    );
   });
 
   group('war declaration relation threshold and target scoring', () {
-    test('peacemaker scores declareWar 0 when relation above threshold so does not pick it when another candidate exists', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'gp1', displayName: 'A', isHuman: false, leaderKey: 'victoria'),
-          Player(id: 'gp2', displayName: 'B', isHuman: false),
-          Player(id: 'gp3', displayName: 'C', isHuman: false),
-        ],
-        diplomacyRelations: [
-          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp2', score: 60, level: RelationLevel.neutral, state: RelationState.atPeace),
-          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp3', score: 20, level: RelationLevel.hostile, state: RelationState.atPeace),
-        ],
-      );
-      const topology = MapTopology(nodes: [], edges: []);
-      final view = buildPlayerView(game, topology, 'gp1');
-      final snapshot = AIWorldSnapshot.fromPlayerView(view);
-      const config = AIConfig(
-        leaderId: 'victoria',
-        personalityId: 'victoria',
-        hiddenAgendaId: 'peacemaker',
-      );
-      final seeds = AISeedBundle.fromTurnSeed(111);
-      const fakeApi = _FakeOrderSuggestionAPI(
-        work: [],
-        build: [],
-        move: [],
-        research: [],
-        navalMove: [],
-        navalMission: [],
-        diplomatic: [
-          DiplomaticOrder(type: DiplomaticOrderType.declareWar, targetFactionId: 'gp2'),
-          DiplomaticOrder(type: DiplomaticOrderType.declareWar, targetFactionId: 'gp3'),
-        ],
-      );
-      const economyPlan = EconomyPlan(productionAssignments: [], cargoPreference: CargoPreference.none);
+    test(
+      'peacemaker scores declareWar 0 when relation above threshold so does not pick it when another candidate exists',
+      () {
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(
+              id: 'gp1',
+              displayName: 'A',
+              isHuman: false,
+              leaderKey: 'victoria',
+            ),
+            Player(id: 'gp2', displayName: 'B', isHuman: false),
+            Player(id: 'gp3', displayName: 'C', isHuman: false),
+          ],
+          diplomacyRelations: [
+            DiplomacyRelation(
+              factionId1: 'gp1',
+              factionId2: 'gp2',
+              score: 60,
+              level: RelationLevel.neutral,
+              state: RelationState.atPeace,
+            ),
+            DiplomacyRelation(
+              factionId1: 'gp1',
+              factionId2: 'gp3',
+              score: 20,
+              level: RelationLevel.hostile,
+              state: RelationState.atPeace,
+            ),
+          ],
+        );
+        const topology = MapTopology(nodes: [], edges: []);
+        final view = buildPlayerView(game, topology, 'gp1');
+        final snapshot = AIWorldSnapshot.fromPlayerView(view);
+        const config = AIConfig(
+          leaderId: 'victoria',
+          personalityId: 'victoria',
+          hiddenAgendaId: 'peacemaker',
+        );
+        final seeds = AISeedBundle.fromTurnSeed(111);
+        const fakeApi = _FakeOrderSuggestionAPI(
+          work: [],
+          build: [],
+          move: [],
+          research: [],
+          navalMove: [],
+          navalMission: [],
+          diplomatic: [
+            DiplomaticOrder(
+              type: DiplomaticOrderType.declareWar,
+              targetFactionId: 'gp2',
+            ),
+            DiplomaticOrder(
+              type: DiplomaticOrderType.declareWar,
+              targetFactionId: 'gp3',
+            ),
+          ],
+        );
+        const economyPlan = EconomyPlan(
+          productionAssignments: [],
+          cargoPreference: CargoPreference.none,
+        );
 
-      final orders = runDomainPlanners(
-        game: game,
-        topology: topology,
-        nationId: 'gp1',
-        view: view,
-        snapshot: snapshot,
-        config: config,
-        primaryGoal: StrategicGoal.conquer,
-        seeds: seeds,
-        suggestionAPI: fakeApi,
-        economyPlan: economyPlan,
-      );
+        final orders = runDomainPlanners(
+          game: game,
+          topology: topology,
+          nationId: 'gp1',
+          view: view,
+          snapshot: snapshot,
+          config: config,
+          primaryGoal: StrategicGoal.conquer,
+          seeds: seeds,
+          suggestionAPI: fakeApi,
+          economyPlan: economyPlan,
+        );
 
-      final diplo = orders.diplomaticOrdersByPlayerId['gp1'];
-      expect(diplo, isNotNull);
-      expect(diplo!.single.targetFactionId, 'gp3', reason: 'peacemaker max relation 30; gp2 has 60 so score 0; only gp3 has positive score');
-    });
+        final diplo = orders.diplomaticOrdersByPlayerId['gp1'];
+        expect(diplo, isNotNull);
+        expect(
+          diplo!.single.targetFactionId,
+          'gp3',
+          reason:
+              'peacemaker max relation 30; gp2 has 60 so score 0; only gp3 has positive score',
+        );
+      },
+    );
 
     test('warmonger gets bonus for weakNeighbors target', () {
       final game = Game(
@@ -623,20 +741,48 @@ void main() {
           newWorld: const RegionData(),
         ),
         players: const [
-          Player(id: 'gp1', displayName: 'A', isHuman: false, leaderKey: 'napoleon', militaryLevel: 3),
+          Player(
+            id: 'gp1',
+            displayName: 'A',
+            isHuman: false,
+            leaderKey: 'napoleon',
+            militaryLevel: 3,
+          ),
           Player(id: 'gp2', displayName: 'B', isHuman: false, militaryLevel: 1),
           Player(id: 'gp3', displayName: 'C', isHuman: false, militaryLevel: 5),
         ],
         diplomacyRelations: [
-          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp2', score: 50, state: RelationState.atPeace),
-          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp3', score: 50, state: RelationState.atPeace),
+          DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'gp2',
+            score: 50,
+            state: RelationState.atPeace,
+          ),
+          DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'gp3',
+            score: 50,
+            state: RelationState.atPeace,
+          ),
         ],
       );
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          TopologyNode(id: 'p2', regionId: 'oldWorld', type: TopologyNodeType.province),
-          TopologyNode(id: 'p3', regionId: 'oldWorld', type: TopologyNodeType.province),
+          TopologyNode(
+            id: 'p1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'p2',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'p3',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
         ],
         edges: const [
           TopologyEdge(id1: 'p1', id2: 'p2'),
@@ -645,7 +791,11 @@ void main() {
       );
       final view = buildPlayerView(game, topology, 'gp1');
       final snapshot = AIWorldSnapshot.fromPlayerView(view, topology: topology);
-      expect(snapshot.opportunities.weakNeighbors, contains('gp2'), reason: 'gp2 owns p2 adjacent to gp1 p1');
+      expect(
+        snapshot.opportunities.weakNeighbors,
+        contains('gp2'),
+        reason: 'gp2 owns p2 adjacent to gp1 p1',
+      );
       expect(snapshot.opportunities.weakNeighbors, contains('gp3'));
       const config = AIConfig(
         leaderId: 'napoleon',
@@ -661,10 +811,16 @@ void main() {
         navalMove: [],
         navalMission: [],
         diplomatic: [
-          DiplomaticOrder(type: DiplomaticOrderType.declareWar, targetFactionId: 'gp2'),
+          DiplomaticOrder(
+            type: DiplomaticOrderType.declareWar,
+            targetFactionId: 'gp2',
+          ),
         ],
       );
-      const economyPlan = EconomyPlan(productionAssignments: [], cargoPreference: CargoPreference.none);
+      const economyPlan = EconomyPlan(
+        productionAssignments: [],
+        cargoPreference: CargoPreference.none,
+      );
 
       final orders = runDomainPlanners(
         game: game,
@@ -682,67 +838,273 @@ void main() {
       final diplo = orders.diplomaticOrdersByPlayerId['gp1'];
       expect(diplo, isNotNull);
       expect(diplo!.single.type, DiplomaticOrderType.declareWar);
-      expect(diplo.single.targetFactionId, 'gp2', reason: 'only candidate is gp2 (weak neighbor); warmonger applies +30 bonus');
+      expect(
+        diplo.single.targetFactionId,
+        'gp2',
+        reason:
+            'only candidate is gp2 (weak neighbor); warmonger applies +30 bonus',
+      );
     });
 
-    test('backstabber prefers allied target when it is the only declare-war candidate', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'gp1', displayName: 'A', isHuman: false, leaderKey: 'napoleon'),
-          Player(id: 'gp2', displayName: 'B', isHuman: false),
-          Player(id: 'gp3', displayName: 'C', isHuman: false),
-        ],
-        diplomacyRelations: [
-          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp2', score: 80, level: RelationLevel.allied, state: RelationState.atPeace),
-          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp3', score: 50, level: RelationLevel.neutral, state: RelationState.atPeace),
-        ],
-      );
-      const topology = MapTopology(nodes: [], edges: []);
-      final view = buildPlayerView(game, topology, 'gp1');
-      final snapshot = AIWorldSnapshot.fromPlayerView(view);
-      const config = AIConfig(
-        leaderId: 'napoleon',
-        personalityId: 'napoleon',
-        hiddenAgendaId: 'backstabber',
-      );
-      final seeds = AISeedBundle.fromTurnSeed(333);
-      const fakeApi = _FakeOrderSuggestionAPI(
-        work: [],
-        build: [],
-        move: [],
-        research: [],
-        navalMove: [],
-        navalMission: [],
-        diplomatic: [
-          DiplomaticOrder(type: DiplomaticOrderType.declareWar, targetFactionId: 'gp2'),
-        ],
-      );
-      const economyPlan = EconomyPlan(productionAssignments: [], cargoPreference: CargoPreference.none);
+    test(
+      'backstabber prefers allied target when it is the only declare-war candidate',
+      () {
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(
+              id: 'gp1',
+              displayName: 'A',
+              isHuman: false,
+              leaderKey: 'napoleon',
+            ),
+            Player(id: 'gp2', displayName: 'B', isHuman: false),
+            Player(id: 'gp3', displayName: 'C', isHuman: false),
+          ],
+          diplomacyRelations: [
+            DiplomacyRelation(
+              factionId1: 'gp1',
+              factionId2: 'gp2',
+              score: 80,
+              level: RelationLevel.allied,
+              state: RelationState.atPeace,
+            ),
+            DiplomacyRelation(
+              factionId1: 'gp1',
+              factionId2: 'gp3',
+              score: 50,
+              level: RelationLevel.neutral,
+              state: RelationState.atPeace,
+            ),
+          ],
+        );
+        const topology = MapTopology(nodes: [], edges: []);
+        final view = buildPlayerView(game, topology, 'gp1');
+        final snapshot = AIWorldSnapshot.fromPlayerView(view);
+        const config = AIConfig(
+          leaderId: 'napoleon',
+          personalityId: 'napoleon',
+          hiddenAgendaId: 'backstabber',
+        );
+        final seeds = AISeedBundle.fromTurnSeed(333);
+        const fakeApi = _FakeOrderSuggestionAPI(
+          work: [],
+          build: [],
+          move: [],
+          research: [],
+          navalMove: [],
+          navalMission: [],
+          diplomatic: [
+            DiplomaticOrder(
+              type: DiplomaticOrderType.declareWar,
+              targetFactionId: 'gp2',
+            ),
+          ],
+        );
+        const economyPlan = EconomyPlan(
+          productionAssignments: [],
+          cargoPreference: CargoPreference.none,
+        );
 
-      final orders = runDomainPlanners(
-        game: game,
-        topology: topology,
-        nationId: 'gp1',
-        view: view,
-        snapshot: snapshot,
-        config: config,
-        primaryGoal: StrategicGoal.conquer,
-        seeds: seeds,
-        suggestionAPI: fakeApi,
-        economyPlan: economyPlan,
-      );
+        final orders = runDomainPlanners(
+          game: game,
+          topology: topology,
+          nationId: 'gp1',
+          view: view,
+          snapshot: snapshot,
+          config: config,
+          primaryGoal: StrategicGoal.conquer,
+          seeds: seeds,
+          suggestionAPI: fakeApi,
+          economyPlan: economyPlan,
+        );
 
-      final diplo = orders.diplomaticOrdersByPlayerId['gp1'];
-      expect(diplo, isNotNull);
-      expect(diplo!.single.type, DiplomaticOrderType.declareWar);
-      expect(diplo.single.targetFactionId, 'gp2', reason: 'only candidate is gp2 (allied); backstabber applies +25 bonus');
-    });
+        final diplo = orders.diplomaticOrdersByPlayerId['gp1'];
+        expect(diplo, isNotNull);
+        expect(diplo!.single.type, DiplomaticOrderType.declareWar);
+        expect(
+          diplo.single.targetFactionId,
+          'gp2',
+          reason:
+              'only candidate is gp2 (allied); backstabber applies +25 bonus',
+        );
+      },
+    );
+  });
+
+  group('computeWarDesireScore', () {
+    test(
+      'higher relative power and hostile relation yields higher war desire',
+      () {
+        final strongVsWeak = Game(
+          id: 'g-desire-1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(
+                  id: 'oldWorld|p1',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp1',
+                ),
+                Province(
+                  id: 'oldWorld|p2',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp1',
+                ),
+                Province(
+                  id: 'oldWorld|p3',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp2',
+                ),
+              ],
+              units: [
+                Unit(
+                  id: 'u1',
+                  type: 'grenadiers',
+                  ownerId: 'gp1',
+                  locationProvinceId: 'oldWorld|p1',
+                ),
+                Unit(
+                  id: 'u2',
+                  type: 'grenadiers',
+                  ownerId: 'gp1',
+                  locationProvinceId: 'oldWorld|p2',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'A', isHuman: false),
+            Player(id: 'gp2', displayName: 'B', isHuman: false),
+          ],
+        );
+        final weakVsStrong = strongVsWeak.copyWith(
+          worldState: strongVsWeak.worldState.copyWith(
+            oldWorld: RegionData(
+              provinces: strongVsWeak.worldState.oldWorld.provinces,
+              units: [
+                Unit(
+                  id: 'u3',
+                  type: 'grenadiers',
+                  ownerId: 'gp2',
+                  locationProvinceId: 'oldWorld|p3',
+                ),
+                Unit(
+                  id: 'u4',
+                  type: 'grenadiers',
+                  ownerId: 'gp2',
+                  locationProvinceId: 'oldWorld|p3',
+                ),
+              ],
+            ),
+          ),
+        );
+
+        final high = computeWarDesireScore(
+          game: strongVsWeak,
+          nationId: 'gp1',
+          targetFactionId: 'gp2',
+          relationScore: 20,
+        );
+        final low = computeWarDesireScore(
+          game: weakVsStrong,
+          nationId: 'gp1',
+          targetFactionId: 'gp2',
+          relationScore: 80,
+        );
+
+        expect(high, greaterThan(low));
+      },
+    );
+
+    test(
+      'minor target with intervention risk and no navy reduces war desire',
+      () {
+        final game = Game(
+          id: 'g-desire-2',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(
+                  id: 'oldWorld|p1',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp1',
+                ),
+                Province(
+                  id: 'oldWorld|p2',
+                  regionId: 'oldWorld',
+                  ownerId: 'minor1',
+                ),
+              ],
+              units: [
+                Unit(
+                  id: 'u1',
+                  type: 'grenadiers',
+                  ownerId: 'gp1',
+                  locationProvinceId: 'oldWorld|p1',
+                ),
+              ],
+            ),
+            newWorld: RegionData(
+              provinces: const [
+                Province(
+                  id: 'newWorld|n1',
+                  regionId: 'newWorld',
+                  ownerId: 'minor1',
+                ),
+              ],
+              units: [
+                Unit(
+                  id: 'u2',
+                  type: 'grenadiers',
+                  ownerId: 'minor1',
+                  locationProvinceId: 'newWorld|n1',
+                ),
+                Unit(
+                  id: 'u3',
+                  type: 'grenadiers',
+                  ownerId: 'minor1',
+                  locationProvinceId: 'newWorld|n1',
+                ),
+              ],
+            ),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'A', isHuman: false),
+            Player(id: 'gp2', displayName: 'B', isHuman: false),
+            Player(id: 'gp3', displayName: 'C', isHuman: false),
+          ],
+          minorNations: const [MinorNation(id: 'minor1', displayName: 'Minor')],
+          overtureStates: const [
+            OvertureState(
+              gpId: 'gp2',
+              targetId: 'minor1',
+              stage: OvertureStage.embassy,
+            ),
+            OvertureState(
+              gpId: 'gp3',
+              targetId: 'minor1',
+              stage: OvertureStage.embassy,
+            ),
+          ],
+        );
+        final score = computeWarDesireScore(
+          game: game,
+          nationId: 'gp1',
+          targetFactionId: 'minor1',
+          relationScore: 40,
+        );
+        expect(score, lessThan(50));
+      },
+    );
   });
 
   group('move planner diplomacy filter', () {
@@ -763,13 +1125,28 @@ void main() {
           newWorld: const RegionData(),
         ),
         players: const [
-          Player(id: 'gp1', displayName: 'A', isHuman: false, leaderKey: 'napoleon'),
+          Player(
+            id: 'gp1',
+            displayName: 'A',
+            isHuman: false,
+            leaderKey: 'napoleon',
+          ),
           Player(id: 'gp2', displayName: 'B', isHuman: false),
           Player(id: 'gp3', displayName: 'C', isHuman: false),
         ],
         diplomacyRelations: [
-          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp2', score: 0, state: RelationState.atWar),
-          DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp3', score: 50, state: RelationState.atPeace),
+          DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'gp2',
+            score: 0,
+            state: RelationState.atWar,
+          ),
+          DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'gp3',
+            score: 50,
+            state: RelationState.atPeace,
+          ),
         ],
       );
       const topology = MapTopology(nodes: [], edges: []);
@@ -793,7 +1170,10 @@ void main() {
         navalMission: [],
         diplomatic: [],
       );
-      const economyPlan = EconomyPlan(productionAssignments: [], cargoPreference: CargoPreference.none);
+      const economyPlan = EconomyPlan(
+        productionAssignments: [],
+        cargoPreference: CargoPreference.none,
+      );
 
       final orders = runDomainPlanners(
         game: game,
@@ -809,7 +1189,11 @@ void main() {
       );
 
       final moves = orders.moveOrdersByPlayerId['gp1'] ?? [];
-      expect(moves.length, 1, reason: 'move to gp3 at peace should be filtered out');
+      expect(
+        moves.length,
+        1,
+        reason: 'move to gp3 at peace should be filtered out',
+      );
       expect(moves.single.destinationProvinceId, 'oldWorld|p2');
     });
   });


### PR DESCRIPTION
## Summary
- add Full AI diplomacy war desire scoring for GP-target pairs using composite power (military + province + naval) with relation gating and per-target cooldowns
- add Minor/Tribe-specific war factors (resource need, intervention risk, invasion capacity) plus wartime reassessment bias for continue-war vs offer-peace
- route app `Next turn` through Full AI order generation when topology is available, and add an app-level test covering AI-order injection path
- update SPEC docs (`SPEC/game/diplomacy.md`, `SPEC/ai/ai-architecture.md`, `SPEC/ai/ai-personalities.md`, `SPEC/program/ai-planner.md`) with requirements and ACs

## Test plan
- [x] `dart test packages/colonizethis_ai/test/domain_planners_test.dart`
- [x] `flutter test app/test/game_screen_next_turn_ai_test.dart`
- [ ] run broader app/widget/regression suite as needed

Closes #1456

Made with [Cursor](https://cursor.com)