### PR TITLE
feat(skills): add workflow-driven PR check unblocking skill

### DIFF
--- a/.cursor/skills/fix-pr-checks/SKILL.md
+++ b/.cursor/skills/fix-pr-checks/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: fix-pr-checks
+description: Diagnoses and unblocks a pull request by checking PR status, failing checks, and quality gates, then applying the minimal compliant fix and verifying results. Use when the user provides a PR URL or PR number and asks to fix or unblock the PR.
+---
+
+# Fix PR checks (ColonizeThis)
+
+## When this applies
+
+Apply this skill when the user gives a GitHub pull request reference:
+
+- PR number (for example `123`)
+- Full PR URL
+
+If repo/owner are ambiguous, ask once for clarification before making changes.
+
+## Non-negotiables (repo policy)
+
+Follow project rules in `AGENTS.md`, `.cursor/rules/`, and `CONTRIBUTING.md`.
+
+Hard constraints:
+
+- Keep fixes minimal and scoped to failures that block checks.
+- Do not introduce behavior outside SPEC authorization. If needed behavior is not specified, update specs first.
+- Preserve architecture boundaries (Flutter UI vs Flame simulation, event bus usage, strict typing, logging policy).
+- Do not bypass quality gates or test expectations to force green checks.
+
+## Workflow
+
+1. **Resolve PR context**
+   - Read PR metadata, status, changed files, comments, and check runs.
+   - Treat `.github/workflows/` as the source of truth for required checks and job names.
+   - Prioritize failures in the quality workflows, especially `quality` and `quality_app_coverage` (`App coverage (merge shards)`), and identify exact failure reasons (lint, test, type, build, policy, merge-base drift).
+
+2. **Reproduce locally (targeted)**
+   - Run only the failing or closest equivalent local commands first.
+   - Confirm root cause before editing.
+
+3. **Apply minimal fix**
+   - Prefer reusing existing patterns/utilities over adding new abstractions.
+   - Touch the smallest set of files required to unblock failures.
+   - Keep unrelated refactors out of scope.
+
+4. **Verify fix addresses the PR issue**
+   - Re-run the failing checks (or local equivalents derived from workflow steps) and confirm pass.
+   - Run any directly impacted tests and static analysis.
+   - Confirm no new failures were introduced.
+
+5. **Report result clearly**
+   - State what failed, root cause, and what changed.
+   - Provide verification evidence (commands/tests/checks).
+   - Call out any residual risk or checks that still need remote CI confirmation.
+
+## Output format
+
+Use this concise structure:
+
+```markdown
+PR: <number/url>
+
+Failures found:
+- <check>: <failure reason>
+
+Fix applied:
+- <minimal change summary>
+
+Verification:
+- <command/check> -> <result>
+- <command/check> -> <result>
+
+Status:
+- <unblocked / partially unblocked>
+- <remaining blockers, if any>
+```
+
+## Additional resources
+
+- [reference.md](reference.md) for command patterns and a minimal-fix checklist

--- a/.cursor/skills/fix-pr-checks/reference.md
+++ b/.cursor/skills/fix-pr-checks/reference.md
@@ -1,0 +1,72 @@
+# PR fix reference
+
+Use these as defaults; adapt to the repository state and failing check names.
+
+## PR inspection commands
+
+```bash
+gh pr view <number> --json number,title,url,state,baseRefName,headRefName,isDraft,mergeStateStatus
+gh pr checks <number>
+gh pr view <number> --json files,commits,statusCheckRollup
+```
+
+If the user provided a URL, extract the PR number first.
+
+## Workflow-first gate resolution
+
+Do not hardcode check names from memory. Read `.github/workflows/` and map failing PR checks to workflow jobs.
+
+For this repository, pay special attention to:
+
+- `quality.yml` -> `quality` job
+- `quality.yml` -> `quality_app_coverage` job (`App coverage (merge shards)`)
+
+Use workflow steps to derive the closest local verification commands.
+
+## Fast path: copy/paste checks
+
+Use this sequence first for quick PR triage:
+
+```bash
+# 1) Inspect failing checks on the PR
+gh pr checks <number>
+
+# 2) If quality failed, run the main local quality gate
+melos run quality
+
+# 3) If app coverage failed, run app tests with coverage and threshold gate
+(cd app && flutter test --coverage --reporter=compact -j 1 --no-track-widget-creation)
+tool/check_coverage_threshold.sh 80 app
+```
+
+If step 2 is unavailable in local scripts, derive equivalent commands from `.github/workflows/quality.yml` job steps.
+
+## Decision tree (quality vs app coverage)
+
+1. `gh pr checks <number>`  
+2. If failing check maps to `quality`:
+   - Run local quality gate (`melos run quality` or workflow-equivalent commands).
+   - Fix only the failing gate root cause.
+   - Re-run the same gate.
+3. If failing check maps to `quality_app_coverage` (`App coverage (merge shards)`):
+   - Regenerate app coverage locally.
+   - Run `tool/check_coverage_threshold.sh 80 app`.
+   - If below threshold, add/adjust the minimal tests needed to lift covered lines.
+4. If both fail:
+   - Fix `quality` first, then app coverage, then re-run both.
+
+## Local triage order
+
+1. Reproduce the failing check locally (preferred).
+2. If check command is unknown, inspect `.github/workflows/` and infer the closest local command from the failing job steps.
+3. Fix only what is required for the failing gate.
+4. Re-run the failing check and impacted tests.
+
+## Minimal-fix checklist
+
+- Root cause is identified and confirmed.
+- Only necessary files changed.
+- No speculative refactor.
+- Spec alignment preserved.
+- Tests/analysis relevant to the failing gate are green locally.
+- Final summary explicitly states whether PR is fully unblocked.


### PR DESCRIPTION
## Summary
- Add a new project skill at `.cursor/skills/fix-pr-checks/` for fixing PR failures using workflow-defined quality gates.
- Make the workflow reference-driven (from `.github/workflows/`) with explicit focus on `quality` and `quality_app_coverage` (`App coverage (merge shards)`).
- Add a fast-path decision flow and copy/paste triage commands to keep fixes minimal and quickly verifiable.

## Test plan
- [x] Verify skill files are created under `.cursor/skills/fix-pr-checks/`.
- [x] Verify SKILL metadata (`name`, `description`) and trigger language cover PR number/URL.
- [x] Verify instructions prioritize workflow-derived checks and app coverage gate handling.

Made with [Cursor](https://cursor.com)