### PR TITLE
test(ai): full-AI diplomacy war desire and cooldown tests

### DIFF
--- a/packages/colonizethis_ai/lib/src/domain_planners.dart
+++ b/packages/colonizethis_ai/lib/src/domain_planners.dart
@@ -506,13 +506,58 @@ Orders _runDiplomacyPlanner({
   );
   if (diploCandidates.isEmpty) return orders;
 
+  final scores = computeDiplomaticCandidateScores(
+    candidates: diploCandidates,
+    nationId: nationId,
+    game: game,
+    snapshot: snapshot,
+    config: config,
+  );
+
+  final candidateDesc = diploCandidates
+      .map(
+        (o) =>
+            '${o.type.name}${o.type == DiplomaticOrderType.declareWar ? ":${o.targetFactionId}" : ""}',
+      )
+      .toList();
+  _log.d(
+    'diplomacy eval nationId=$nationId hiddenAgendaId=${config.hiddenAgendaId} '
+    'candidates=$candidateDesc scores=$scores',
+  );
+
+  final total = scores.reduce((a, b) => a + b);
+  if (total <= 0) return orders;
+  final rng = math.Random(seeds.diplomacySeed);
+  var r = rng.nextDouble() * total;
+  var idx = 0;
+  for (; idx < scores.length && r > scores[idx]; idx++) {
+    r -= scores[idx];
+  }
+  if (idx >= diploCandidates.length) idx = diploCandidates.length - 1;
+  final chosen = diploCandidates[idx];
+  _log.i(
+    'diplomacy chosen nationId=$nationId '
+    'type=${chosen.type}${chosen.type == DiplomaticOrderType.declareWar ? " targetFactionId=${chosen.targetFactionId}" : ""} score=${scores[idx]}',
+  );
+  return _appendDiplomaticOrders(orders, nationId, [chosen]);
+}
+
+/// Pre–weighted-random scores for diplomatic order candidates (0 = suppressed).
+/// Exposed for deterministic tests; [runDomainPlanners] uses the same values.
+List<int> computeDiplomaticCandidateScores({
+  required List<DiplomaticOrder> candidates,
+  required String nationId,
+  required Game game,
+  required AIWorldSnapshot snapshot,
+  required AIConfig config,
+}) {
   final agendaId = config.hiddenAgendaId;
   final thresholds = getThresholdsForLeader(config.leaderId);
   final maxRelationForDeclareWar = getDeclareWarMaxRelationScore(agendaId);
-  final warCooldownTurns = 4;
-  final improveRelationsCooldownTurns = 2;
+  const warCooldownTurns = 4;
+  const improveRelationsCooldownTurns = 2;
   final currentTurn = game.worldState.turnState.turnNumber;
-  final scores = diploCandidates.map((o) {
+  return candidates.map((o) {
     var s = 50;
     switch (o.type) {
       case DiplomaticOrderType.offerPeace:
@@ -616,33 +661,6 @@ Orders _runDiplomacyPlanner({
     }
     return s == 0 ? 0 : math.max(1, s);
   }).toList();
-
-  final candidateDesc = diploCandidates
-      .map(
-        (o) =>
-            '${o.type.name}${o.type == DiplomaticOrderType.declareWar ? ":${o.targetFactionId}" : ""}',
-      )
-      .toList();
-  _log.d(
-    'diplomacy eval nationId=$nationId hiddenAgendaId=$agendaId '
-    'candidates=$candidateDesc scores=$scores',
-  );
-
-  final total = scores.reduce((a, b) => a + b);
-  if (total <= 0) return orders;
-  final rng = math.Random(seeds.diplomacySeed);
-  var r = rng.nextDouble() * total;
-  var idx = 0;
-  for (; idx < scores.length && r > scores[idx]; idx++) {
-    r -= scores[idx];
-  }
-  if (idx >= diploCandidates.length) idx = diploCandidates.length - 1;
-  final chosen = diploCandidates[idx];
-  _log.i(
-    'diplomacy chosen nationId=$nationId '
-    'type=${chosen.type}${chosen.type == DiplomaticOrderType.declareWar ? " targetFactionId=${chosen.targetFactionId}" : ""} score=${scores[idx]}',
-  );
-  return _appendDiplomaticOrders(orders, nationId, [chosen]);
 }
 
 int computeWarDesireScore({

--- a/packages/colonizethis_ai/test/domain_planners_test.dart
+++ b/packages/colonizethis_ai/test/domain_planners_test.dart
@@ -1105,6 +1105,604 @@ void main() {
         expect(score, lessThan(50));
       },
     );
+
+    test('minor target resources increase war desire when GP stockpile lacks them', () {
+      const tileKey = 'oldWorld|p2|0|0';
+      WorldState state({required Map<String, String> resources}) => WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: RegionData(
+          provinces: const [
+            Province(
+              id: 'oldWorld|p1',
+              regionId: 'oldWorld',
+              ownerId: 'gp1',
+            ),
+            Province(
+              id: 'oldWorld|p2',
+              regionId: 'oldWorld',
+              ownerId: 'minor1',
+            ),
+          ],
+          units: [
+            Unit(
+              id: 'u1',
+              type: 'grenadiers',
+              ownerId: 'gp1',
+              locationProvinceId: 'oldWorld|p1',
+            ),
+            Unit(
+              id: 'u2',
+              type: 'grenadiers',
+              ownerId: 'gp1',
+              locationProvinceId: 'oldWorld|p1',
+            ),
+            Unit(
+              id: 'u3',
+              type: 'grenadiers',
+              ownerId: 'minor1',
+              locationProvinceId: 'oldWorld|p2',
+            ),
+          ],
+        ),
+        newWorld: const RegionData(),
+        tileKeysByRegionAndProvince: {
+          'oldWorld': {
+            'oldWorld|p2': [tileKey],
+          },
+        },
+        resourceByTileKey: resources,
+      );
+      final withoutRes = Game(
+        id: 'g-res-0',
+        worldState: state(resources: const {}),
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'A',
+            isHuman: false,
+            stockpile: Stockpile(quantities: {'grain': 10}),
+          ),
+        ],
+        minorNations: const [MinorNation(id: 'minor1', displayName: 'M')],
+      );
+      final withRes = withoutRes.copyWith(
+        id: 'g-res-1',
+        worldState: state(resources: {tileKey: 'tobacco'}),
+      );
+      const relation = 40;
+      final a = computeWarDesireScore(
+        game: withoutRes,
+        nationId: 'gp1',
+        targetFactionId: 'minor1',
+        relationScore: relation,
+      );
+      final b = computeWarDesireScore(
+        game: withRes,
+        nationId: 'gp1',
+        targetFactionId: 'minor1',
+        relationScore: relation,
+      );
+      expect(b - a, 5);
+    });
+  });
+
+  group('computeDiplomaticCandidateScores', () {
+    test('declareWar score exceeds establishOverture for same hostile target', () {
+      final game = Game(
+        id: 'g-diplo-score-1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(
+                id: 'oldWorld|p1',
+                regionId: 'oldWorld',
+                ownerId: 'gp1',
+              ),
+              Province(
+                id: 'oldWorld|p2',
+                regionId: 'oldWorld',
+                ownerId: 'gp1',
+              ),
+              Province(
+                id: 'oldWorld|p3',
+                regionId: 'oldWorld',
+                ownerId: 'gp1',
+              ),
+              Province(
+                id: 'oldWorld|p4',
+                regionId: 'oldWorld',
+                ownerId: 'gp2',
+              ),
+            ],
+            units: [
+              Unit(
+                id: 'u1',
+                type: 'grenadiers',
+                ownerId: 'gp1',
+                locationProvinceId: 'oldWorld|p1',
+              ),
+              Unit(
+                id: 'u2',
+                type: 'grenadiers',
+                ownerId: 'gp1',
+                locationProvinceId: 'oldWorld|p2',
+              ),
+              Unit(
+                id: 'u3',
+                type: 'grenadiers',
+                ownerId: 'gp1',
+                locationProvinceId: 'oldWorld|p3',
+              ),
+              Unit(
+                id: 'u4',
+                type: 'grenadiers',
+                ownerId: 'gp2',
+                locationProvinceId: 'oldWorld|p4',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'A', isHuman: false),
+          Player(id: 'gp2', displayName: 'B', isHuman: false),
+        ],
+        diplomacyRelations: [
+          const DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'gp2',
+            score: 20,
+            level: RelationLevel.hostile,
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      const topology = MapTopology(nodes: [], edges: []);
+      final view = buildPlayerView(game, topology, 'gp1');
+      final snapshot = AIWorldSnapshot.fromPlayerView(view);
+      const config = AIConfig(
+        leaderId: 'napoleon',
+        personalityId: 'napoleon',
+        hiddenAgendaId: 'warmonger',
+      );
+      final scores = computeDiplomaticCandidateScores(
+        candidates: const [
+          DiplomaticOrder(
+            type: DiplomaticOrderType.declareWar,
+            targetFactionId: 'gp2',
+          ),
+          DiplomaticOrder(
+            type: DiplomaticOrderType.establishOverture,
+            targetFactionId: 'gp2',
+          ),
+        ],
+        nationId: 'gp1',
+        game: game,
+        snapshot: snapshot,
+        config: config,
+      );
+      expect(scores.length, 2);
+      expect(scores[0], greaterThan(scores[1]));
+    });
+
+    test('offer peace candidate scores lower when war desire is higher', () {
+      Game gameForWarDesire({
+        required int gp2ProvinceCount,
+        required int gp2Regiments,
+      }) {
+        final provinces = <Province>[
+          const Province(
+            id: 'oldWorld|p1',
+            regionId: 'oldWorld',
+            ownerId: 'gp1',
+          ),
+        ];
+        var i = 0;
+        for (; i < gp2ProvinceCount; i++) {
+          provinces.add(
+            Province(
+              id: 'oldWorld|g2_$i',
+              regionId: 'oldWorld',
+              ownerId: 'gp2',
+            ),
+          );
+        }
+        final units = <Unit>[
+          Unit(
+            id: 'a1',
+            type: 'grenadiers',
+            ownerId: 'gp1',
+            locationProvinceId: 'oldWorld|p1',
+          ),
+          Unit(
+            id: 'a2',
+            type: 'grenadiers',
+            ownerId: 'gp1',
+            locationProvinceId: 'oldWorld|p1',
+          ),
+        ];
+        for (var r = 0; r < gp2Regiments; r++) {
+          units.add(
+            Unit(
+              id: 'b$r',
+              type: 'grenadiers',
+              ownerId: 'gp2',
+              locationProvinceId: 'oldWorld|g2_0',
+            ),
+          );
+        }
+        return Game(
+          id: 'g-peace-$gp2ProvinceCount-$gp2Regiments',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+            oldWorld: RegionData(provinces: provinces, units: units),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'A', isHuman: false),
+            Player(id: 'gp2', displayName: 'B', isHuman: false),
+          ],
+          diplomacyRelations: const [
+            DiplomacyRelation(
+              factionId1: 'gp1',
+              factionId2: 'gp2',
+              score: 25,
+              level: RelationLevel.hostile,
+              state: RelationState.atWar,
+            ),
+          ],
+        );
+      }
+
+      final highDesireGame = gameForWarDesire(gp2ProvinceCount: 1, gp2Regiments: 1);
+      final lowDesireGame =
+          gameForWarDesire(gp2ProvinceCount: 3, gp2Regiments: 4);
+      expect(
+        computeWarDesireScore(
+          game: highDesireGame,
+          nationId: 'gp1',
+          targetFactionId: 'gp2',
+          relationScore: 25,
+        ),
+        greaterThan(
+          computeWarDesireScore(
+            game: lowDesireGame,
+            nationId: 'gp1',
+            targetFactionId: 'gp2',
+            relationScore: 25,
+          ),
+        ),
+      );
+      const topology = MapTopology(nodes: [], edges: []);
+      final viewHi = buildPlayerView(highDesireGame, topology, 'gp1');
+      final viewLo = buildPlayerView(lowDesireGame, topology, 'gp1');
+      final snapHi = AIWorldSnapshot.fromPlayerView(viewHi);
+      final snapLo = AIWorldSnapshot.fromPlayerView(viewLo);
+      const config = AIConfig(
+        leaderId: 'victoria',
+        personalityId: 'victoria',
+        hiddenAgendaId: 'peacemaker',
+      );
+      final peaceHi = computeDiplomaticCandidateScores(
+        candidates: const [
+          DiplomaticOrder(
+            type: DiplomaticOrderType.offerPeace,
+            targetFactionId: 'gp2',
+          ),
+        ],
+        nationId: 'gp1',
+        game: highDesireGame,
+        snapshot: snapHi,
+        config: config,
+      ).single;
+      final peaceLo = computeDiplomaticCandidateScores(
+        candidates: const [
+          DiplomaticOrder(
+            type: DiplomaticOrderType.offerPeace,
+            targetFactionId: 'gp2',
+          ),
+        ],
+        nationId: 'gp1',
+        game: lowDesireGame,
+        snapshot: snapLo,
+        config: config,
+      ).single;
+      expect(peaceLo, greaterThan(peaceHi));
+    });
+  });
+
+  group('diplomacy planner cooldowns', () {
+    test('declareWar candidate score zero while wardec retry cooldown active', () {
+      final game = Game(
+        id: 'g-cool-war',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 5),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'A',
+            isHuman: false,
+            leaderKey: 'napoleon',
+          ),
+          Player(id: 'gp2', displayName: 'B', isHuman: false),
+        ],
+        diplomacyRelations: [
+          const DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'gp2',
+            score: 10,
+            level: RelationLevel.hostile,
+            state: RelationState.atPeace,
+          ),
+        ],
+        diplomaticHistoryEvents: [
+          DiplomaticEvent(
+            turn: 2,
+            intraTurnIndex: 0,
+            type: DiplomaticEventType.declareWar,
+            participants: {'gp1', 'gp2'},
+            fromFactionId: 'gp1',
+            toFactionId: 'gp2',
+          ),
+        ],
+      );
+      const topology = MapTopology(nodes: [], edges: []);
+      final view = buildPlayerView(game, topology, 'gp1');
+      final snapshot = AIWorldSnapshot.fromPlayerView(view);
+      const config = AIConfig(
+        leaderId: 'napoleon',
+        personalityId: 'napoleon',
+        hiddenAgendaId: 'warmonger',
+      );
+      final scores = computeDiplomaticCandidateScores(
+        candidates: const [
+          DiplomaticOrder(
+            type: DiplomaticOrderType.declareWar,
+            targetFactionId: 'gp2',
+          ),
+        ],
+        nationId: 'gp1',
+        game: game,
+        snapshot: snapshot,
+        config: config,
+      );
+      expect(scores.single, 0);
+    });
+
+    test('establishOverture score zero while improve-relations cooldown active', () {
+      final game = Game(
+        id: 'g-cool-overture',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 8),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'A',
+            isHuman: false,
+            leaderKey: 'victoria',
+          ),
+          Player(id: 'gp2', displayName: 'B', isHuman: false),
+        ],
+        diplomacyRelations: [
+          const DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'gp2',
+            score: 40,
+            state: RelationState.atPeace,
+          ),
+        ],
+        diplomaticHistoryEvents: [
+          DiplomaticEvent(
+            turn: 7,
+            intraTurnIndex: 0,
+            type: DiplomaticEventType.overtureAccepted,
+            participants: {'gp1', 'gp2'},
+            fromFactionId: 'gp1',
+            toFactionId: 'gp2',
+          ),
+        ],
+      );
+      const topology = MapTopology(nodes: [], edges: []);
+      final view = buildPlayerView(game, topology, 'gp1');
+      final snapshot = AIWorldSnapshot.fromPlayerView(view);
+      const config = AIConfig(
+        leaderId: 'victoria',
+        personalityId: 'victoria',
+        hiddenAgendaId: 'peacemaker',
+      );
+      final scores = computeDiplomaticCandidateScores(
+        candidates: const [
+          DiplomaticOrder(
+            type: DiplomaticOrderType.establishOverture,
+            targetFactionId: 'gp2',
+          ),
+        ],
+        nationId: 'gp1',
+        game: game,
+        snapshot: snapshot,
+        config: config,
+      );
+      expect(scores.single, 0);
+    });
+
+    test('runDomainPlanners emits no diplomatic order when all candidates on cooldown',
+        () {
+      final game = Game(
+        id: 'g-cool-all',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 4),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'A',
+            isHuman: false,
+            leaderKey: 'napoleon',
+          ),
+          Player(id: 'gp2', displayName: 'B', isHuman: false),
+        ],
+        diplomacyRelations: [
+          const DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'gp2',
+            score: 10,
+            level: RelationLevel.hostile,
+            state: RelationState.atPeace,
+          ),
+        ],
+        diplomaticHistoryEvents: [
+          DiplomaticEvent(
+            turn: 1,
+            intraTurnIndex: 0,
+            type: DiplomaticEventType.declareWar,
+            participants: {'gp1', 'gp2'},
+            fromFactionId: 'gp1',
+            toFactionId: 'gp2',
+          ),
+        ],
+      );
+      const topology = MapTopology(nodes: [], edges: []);
+      final view = buildPlayerView(game, topology, 'gp1');
+      final snapshot = AIWorldSnapshot.fromPlayerView(view);
+      const config = AIConfig(
+        leaderId: 'napoleon',
+        personalityId: 'napoleon',
+        hiddenAgendaId: 'warmonger',
+      );
+      final seeds = AISeedBundle.fromTurnSeed(202);
+      const fakeApi = _FakeOrderSuggestionAPI(
+        work: [],
+        build: [],
+        move: [],
+        research: [],
+        navalMove: [],
+        navalMission: [],
+        diplomatic: [
+          DiplomaticOrder(
+            type: DiplomaticOrderType.declareWar,
+            targetFactionId: 'gp2',
+          ),
+        ],
+      );
+      const economyPlan = EconomyPlan(
+        productionAssignments: [],
+        cargoPreference: CargoPreference.none,
+      );
+      final orders = runDomainPlanners(
+        game: game,
+        topology: topology,
+        nationId: 'gp1',
+        view: view,
+        snapshot: snapshot,
+        config: config,
+        primaryGoal: StrategicGoal.conquer,
+        seeds: seeds,
+        suggestionAPI: fakeApi,
+        economyPlan: economyPlan,
+      );
+      expect(orders.diplomaticOrdersByPlayerId['gp1'], isNull);
+    });
+
+    test('improve-relations cooldown expired allows overture selection deterministically',
+        () {
+      final game = Game(
+        id: 'g-cool-overture-ok',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 10),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'A',
+            isHuman: false,
+            leaderKey: 'victoria',
+          ),
+          Player(id: 'gp2', displayName: 'B', isHuman: false),
+        ],
+        diplomacyRelations: [
+          const DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'gp2',
+            score: 40,
+            state: RelationState.atPeace,
+          ),
+        ],
+        diplomaticHistoryEvents: [
+          DiplomaticEvent(
+            turn: 7,
+            intraTurnIndex: 0,
+            type: DiplomaticEventType.overtureAccepted,
+            participants: {'gp1', 'gp2'},
+            fromFactionId: 'gp1',
+            toFactionId: 'gp2',
+          ),
+        ],
+      );
+      const topology = MapTopology(nodes: [], edges: []);
+      final view = buildPlayerView(game, topology, 'gp1');
+      final snapshot = AIWorldSnapshot.fromPlayerView(view);
+      const config = AIConfig(
+        leaderId: 'victoria',
+        personalityId: 'victoria',
+        hiddenAgendaId: 'peacemaker',
+      );
+      final seeds = AISeedBundle.fromTurnSeed(77);
+      const diplo = DiplomaticOrder(
+        type: DiplomaticOrderType.establishOverture,
+        targetFactionId: 'gp2',
+      );
+      const fakeApi = _FakeOrderSuggestionAPI(
+        work: [],
+        build: [],
+        move: [],
+        research: [],
+        navalMove: [],
+        navalMission: [],
+        diplomatic: [diplo],
+      );
+      const economyPlan = EconomyPlan(
+        productionAssignments: [],
+        cargoPreference: CargoPreference.none,
+      );
+      final orders1 = runDomainPlanners(
+        game: game,
+        topology: topology,
+        nationId: 'gp1',
+        view: view,
+        snapshot: snapshot,
+        config: config,
+        primaryGoal: StrategicGoal.diplomacy,
+        seeds: seeds,
+        suggestionAPI: fakeApi,
+        economyPlan: economyPlan,
+      );
+      final orders2 = runDomainPlanners(
+        game: game,
+        topology: topology,
+        nationId: 'gp1',
+        view: view,
+        snapshot: snapshot,
+        config: config,
+        primaryGoal: StrategicGoal.diplomacy,
+        seeds: seeds,
+        suggestionAPI: fakeApi,
+        economyPlan: economyPlan,
+      );
+      expect(orders1.diplomaticOrdersByPlayerId['gp1'], isNotNull);
+      expect(orders1.diplomaticOrdersByPlayerId['gp1']!.single, diplo);
+      expect(orders2.diplomaticOrdersByPlayerId['gp1'], orders1.diplomaticOrdersByPlayerId['gp1']);
+    });
   });
 
   group('move planner diplomacy filter', () {


### PR DESCRIPTION
## Summary
Adds deterministic coverage for Full AI diplomacy scoring from #1456: minor resource bonus, declareWar vs establishOverture ordering, offer-peace weight vs war desire, wardec/improve-relations cooldown suppression, and planner cases that avoid weighted RNG flakiness.

## Implementation notes
- Extracted `computeDiplomaticCandidateScores` from `_runDiplomacyPlanner` so tests assert pre-RNG scores; planner behavior is unchanged aside from the shared helper.

## Verification
- `flutter test` in `packages/colonizethis_ai`

Refs #1456

Made with [Cursor](https://cursor.com)