### PR TITLE
feat(ui): sea-zone display names in move/split fleet dialogs

### DIFF
--- a/app/lib/features/game/widgets/move_fleet_dialog.dart
+++ b/app/lib/features/game/widgets/move_fleet_dialog.dart
@@ -6,6 +6,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
 import '../utils/map_location_resolver.dart';
+import '../utils/sea_zone_name_resolver.dart';
 import 'units/shared/units_panel_region_label.dart';
 
 sealed class _MovePick {
@@ -108,7 +109,14 @@ List<_MovePick> _buildNavalMovePicks({
     final zReg = regionIdForSeaZone(topology, z) ?? fleetSeaRegion;
     final regLabel = unitsPanelRegionLabel(zReg);
     final cross = zReg != fleetSeaRegion;
-    final label = cross ? '$z · $regLabel (cross-region)' : '$z · $regLabel';
+    final zoneLabel = seaZoneDisplayName(
+      game: game,
+      regionId: zReg,
+      seaZoneId: z,
+    );
+    final label = cross
+        ? '$zoneLabel · $regLabel (cross-region)'
+        : '$zoneLabel · $regLabel';
     outSea.add(_PickSeaZone(seaZoneId: z, zoneRegionId: zReg, rowLabel: label));
   }
   outSea.sort((a, b) => a.rowLabel.compareTo(b.rowLabel));

--- a/app/lib/features/game/widgets/split_fleet_dialog.dart
+++ b/app/lib/features/game/widgets/split_fleet_dialog.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import '../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_transfer_list.dart';
 import '../utils/region_labels.dart';
+import '../utils/sea_zone_name_resolver.dart';
 
 class SplitFleetDialog extends StatelessWidget {
   const SplitFleetDialog({
@@ -36,7 +37,13 @@ class SplitFleetDialog extends StatelessWidget {
       final localId = seaZoneId.contains('|')
           ? seaZoneId.split('|').last
           : seaZoneId;
-      return 'Region — $localId';
+      final zoneName = seaZoneDisplayName(
+        game: game,
+        regionId: fleet.regionId,
+        seaZoneId: localId,
+      );
+      final regionLabel = regionDisplayLabel(fleet.regionId);
+      return '$zoneName — $regionLabel';
     } else if (fleet.isInPort) {
       final inPortId = fleet.inPortAtProvinceId!;
       final provinceMap = <String, Province>{};

--- a/app/test/military_units_panel_test.dart
+++ b/app/test/military_units_panel_test.dart
@@ -87,6 +87,57 @@ void main() {
       },
     );
 
+    testWidgets('naval location header uses sea-zone display name', (
+      WidgetTester tester,
+    ) async {
+      const humanId = 'gp_mil_sea_label';
+      const cap = 'oldWorld|c1';
+      final miniGame = Game(
+        id: 'g_mil_sea_label',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(
+                id: 'c1',
+                regionId: 'oldWorld',
+                ownerId: humanId,
+                displayName: 'Cap',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          fleets: [
+            Fleet(
+              id: 'f_at_sea',
+              ownerId: humanId,
+              regionId: 'oldWorld',
+              seaZoneId: 'zone_x',
+              ships: const [ShipInstance(id: 's1', typeId: 'carrack')],
+            ),
+          ],
+          seaZoneDisplayNameById: const {'oldWorld|zone_x': 'Mil Named Sea'},
+        ),
+        players: const [
+          Player(
+            id: humanId,
+            displayName: 'Mil Sea Tester',
+            isHuman: true,
+            capitalProvinceId: cap,
+            capitalTile: CapitalTile(
+              regionId: 'oldWorld',
+              provinceId: cap,
+              x: 0,
+              y: 0,
+            ),
+          ),
+        ],
+      );
+      await tester.pumpWidget(buildPanel(game: miniGame, humanPlayerId: humanId));
+      await tester.pump();
+      expect(find.textContaining('Mil Named Sea'), findsWidgets);
+    });
+
     testWidgets(
       'AC: When player has military units, tree shows regions and type rows',
       (WidgetTester tester) async {

--- a/app/test/move_fleet_dialog_test.dart
+++ b/app/test/move_fleet_dialog_test.dart
@@ -38,6 +38,11 @@ void main() {
           'oldWorld|port_home|sea_local': 'oldWorld|port_home|0|0',
           'newWorld|port_nw|sea_nw': 'newWorld|port_nw|0|0',
         },
+        seaZoneDisplayNameById: const {
+          'oldWorld|sea_ow': 'Origin Sea',
+          'oldWorld|sea_local': 'Adjacent OW Sea',
+          'newWorld|sea_nw': 'Cross NW Sea',
+        },
       ),
       players: const [
         Player(
@@ -131,9 +136,9 @@ void main() {
     await openDialog(tester, bus: AppEventBus.create());
 
     expect(find.text('Sea zones'), findsOneWidget);
-    expect(find.text('$sameRegionAdjacentSea · Old World'), findsOneWidget);
+    expect(find.text('Adjacent OW Sea · Old World'), findsOneWidget);
     expect(
-      find.text('$crossRegionAdjacentSea · New World (cross-region)'),
+      find.text('Cross NW Sea · New World (cross-region)'),
       findsOneWidget,
     );
   });
@@ -150,7 +155,7 @@ void main() {
 
     await openDialog(tester, bus: bus);
 
-    await tester.tap(find.text('$crossRegionAdjacentSea · New World (cross-region)'));
+    await tester.tap(find.text('Cross NW Sea · New World (cross-region)'));
     await tester.pump();
     await tester.tap(find.text('Confirm'));
     await tester.pump();
@@ -253,6 +258,10 @@ void main() {
           ),
           newWorld: const RegionData(),
           portsByProvinceSeaboard: const {},
+          seaZoneDisplayNameById: const {
+            'oldWorld|sea1': 'First Sea',
+            'oldWorld|sea2': 'Second Sea',
+          },
         ),
         players: [
           Player(
@@ -311,7 +320,7 @@ void main() {
         findsNothing,
       );
       expect(find.text('Sea zones'), findsOneWidget);
-      expect(find.text('$ow|sea2 · Old World'), findsOneWidget);
+      expect(find.text('Second Sea · Old World'), findsOneWidget);
     },
   );
 }

--- a/app/test/split_fleet_dialog_test.dart
+++ b/app/test/split_fleet_dialog_test.dart
@@ -14,13 +14,17 @@ Widget _openDialogButton(VoidCallback onOpen) {
 void main() {
   suppressLogsForTests();
 
-  Game _minimalGame({required List<Province> provinces}) {
+  Game _minimalGame({
+    required List<Province> provinces,
+    Map<String, String> seaZoneDisplayNameById = const {},
+  }) {
     return Game(
       id: 'g1',
       worldState: WorldState(
         turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
         oldWorld: RegionData(provinces: provinces),
         newWorld: const RegionData(),
+        seaZoneDisplayNameById: seaZoneDisplayNameById,
       ),
       players: const [
         Player(id: 'gp1', displayName: 'Human', isHuman: true, treasury: 0),
@@ -60,6 +64,31 @@ void main() {
     await tester.tap(find.text('open'));
     await tester.pumpAndSettle();
   }
+
+  testWidgets('at-sea location subtitle uses sea-zone display name', (
+    WidgetTester tester,
+  ) async {
+    final fleet = Fleet(
+      id: 'f_sea_label',
+      ownerId: 'gp1',
+      regionId: 'oldWorld',
+      seaZoneId: 's1',
+      shipTypeIds: const ['carrack'],
+    );
+
+    await openDialog(
+      tester,
+      fleet: fleet,
+      game: _minimalGame(
+        provinces: const [],
+        seaZoneDisplayNameById: const {'oldWorld|s1': 'Adriatic Display'},
+      ),
+      isHomeFleet: false,
+      bus: AppEventBus.create(),
+    );
+
+    expect(find.textContaining('Adriatic Display'), findsWidgets);
+  });
 
   bool buttonEnabled(WidgetTester tester, String label) {
     final button = tester.widget<CtNinePatchButton>(


### PR DESCRIPTION
## Summary
- **Move fleet dialog:** Row labels for adjacent sea zones use `seaZoneDisplayName` (world state) instead of raw topology ids; move orders and map locate behavior unchanged.
- **Split fleet dialog:** At-sea fleet location subtitle uses the resolved sea-zone display name and region label (parallel to in-port province wording).
- **Tests:** Updated move-fleet expectations with `seaZoneDisplayNameById`; added a small split-fleet subtitle test; added a minimal military panel test that uses a single `pump()` to stay fast.

## Issue
Refs #1452 (does not close; remaining scope may include other surfaces or SPEC follow-ups per that issue).

## Testing
`flutter test app/test/move_fleet_dialog_test.dart app/test/split_fleet_dialog_test.dart`
`flutter test app/test/military_units_panel_test.dart --name "naval location header"` (or full file as needed)

Made with [Cursor](https://cursor.com)