### PR TITLE
ci(quality): satisfy required checks when app test path filter is off

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -40,34 +40,45 @@ jobs:
               - 'tool/show_tech/**'
 
   # Resolved pub cache + .dart_tool + gen-l10n; flutter analyze gate; then pack for shards (--no-pub).
+  # Jobs always run after `changes` so required branch checks get success (not skip) when the path filter
+  # excludes app/packages (e.g. SPEC-only PRs); heavy steps are gated on outputs.tests.
   app_tests_cache:
     name: App test cache (deps + l10n + analyze)
     needs: changes
-    if: needs.changes.outputs.tests == 'true'
+    if: always() && needs.changes.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
       PUB_CACHE: ${{ github.workspace }}/.pub-cache
     steps:
+      - name: Skip when no test-relevant paths changed
+        if: needs.changes.outputs.tests != 'true'
+        run: echo "No test-relevant paths matched; skipping app test cache."
+
       - name: Checkout
+        if: needs.changes.outputs.tests == 'true'
         uses: actions/checkout@v4
 
       - name: Setup Flutter
+        if: needs.changes.outputs.tests == 'true'
         uses: subosito/flutter-action@v2
         with:
           channel: stable
           cache: true
 
       - name: Resolve dependencies (workspace)
+        if: needs.changes.outputs.tests == 'true'
         run: dart pub get
 
       - name: Generate app localizations
+        if: needs.changes.outputs.tests == 'true'
         run: |
           set -e
           cd app
           flutter gen-l10n
 
       - name: Compile app entrypoints (Flutter analyze)
+        if: needs.changes.outputs.tests == 'true'
         run: |
           set -e
           if [ -d app ]; then
@@ -82,6 +93,7 @@ jobs:
           fi
 
       - name: Pack cache for test shards
+        if: needs.changes.outputs.tests == 'true'
         run: |
           set -e
           parts=()
@@ -96,6 +108,7 @@ jobs:
           tar czf app-test-cache.tar.gz "${parts[@]}"
 
       - name: Upload app test cache
+        if: needs.changes.outputs.tests == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: app-test-cache
@@ -106,7 +119,13 @@ jobs:
     # job.name cannot use env.* (GitHub limitation); keep "2" in sync with APP_TEST_TOTAL_SHARDS and matrix.shard.
     name: App tests (shard ${{ matrix.shard }}/2)
     needs: [changes, app_tests_cache]
-    if: needs.changes.outputs.tests == 'true'
+    if: |
+      always() &&
+      needs.changes.result == 'success' &&
+      (
+        needs.changes.outputs.tests != 'true' ||
+        needs.app_tests_cache.result == 'success'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -117,25 +136,34 @@ jobs:
       PUB_CACHE: ${{ github.workspace }}/.pub-cache
       SUPPRESS_IMAGE_VIEWER: "1"
     steps:
+      - name: Skip when no test-relevant paths changed
+        if: needs.changes.outputs.tests != 'true'
+        run: echo "No test-relevant paths matched; skipping app tests."
+
       - name: Checkout
+        if: needs.changes.outputs.tests == 'true'
         uses: actions/checkout@v4
 
       - name: Setup Flutter
+        if: needs.changes.outputs.tests == 'true'
         uses: subosito/flutter-action@v2
         with:
           channel: stable
           cache: true
 
       - name: Download app test cache
+        if: needs.changes.outputs.tests == 'true'
         uses: actions/download-artifact@v4
         with:
           name: app-test-cache
           path: _app_test_cache
 
       - name: Restore pub + Dart tool cache
+        if: needs.changes.outputs.tests == 'true'
         run: tar xzf _app_test_cache/app-test-cache.tar.gz -C "$GITHUB_WORKSPACE"
 
       - name: Run Flutter tests (shard)
+        if: needs.changes.outputs.tests == 'true'
         run: |
           set -e
           mkdir -p app/coverage
@@ -147,6 +175,7 @@ jobs:
             --total-shards=${{ env.APP_TEST_TOTAL_SHARDS }} --shard-index=${{ matrix.shard }}
 
       - name: Upload shard coverage
+        if: needs.changes.outputs.tests == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: app-lcov-shard-${{ matrix.shard }}
@@ -304,16 +333,30 @@ jobs:
   quality_app_coverage:
     name: App coverage (merge shards)
     needs: [changes, quality, app_tests_shard]
-    if: needs.changes.outputs.tests == 'true'
+    if: |
+      always() &&
+      needs.changes.result == 'success' &&
+      needs.quality.result == 'success' &&
+      (
+        needs.changes.outputs.tests != 'true' ||
+        needs.app_tests_shard.result == 'success'
+      )
     runs-on: ubuntu-latest
     steps:
+      - name: Skip when no test-relevant paths changed
+        if: needs.changes.outputs.tests != 'true'
+        run: echo "No test-relevant paths matched; skipping app coverage merge."
+
       - name: Checkout
+        if: needs.changes.outputs.tests == 'true'
         uses: actions/checkout@v4
 
       - name: Install lcov
+        if: needs.changes.outputs.tests == 'true'
         run: sudo apt-get update && sudo apt-get install -y lcov
 
       - name: Download shard coverage
+        if: needs.changes.outputs.tests == 'true'
         uses: actions/download-artifact@v4
         with:
           pattern: app-lcov-shard-*
@@ -321,6 +364,7 @@ jobs:
           path: _lcov_shards
 
       - name: Merge shard lcov into app/coverage/lcov.info
+        if: needs.changes.outputs.tests == 'true'
         run: |
           set -euo pipefail
           mkdir -p app/coverage
@@ -333,4 +377,5 @@ jobs:
           tool/merge_app_lcov_shards.sh "${APP_TEST_TOTAL_SHARDS}"
 
       - name: App coverage gate (app/lib/ >= 80%)
+        if: needs.changes.outputs.tests == 'true'
         run: tool/check_coverage_threshold.sh 80 app


### PR DESCRIPTION
## Problem
PRs that only change paths outside the Quality workflow path filter (e.g. `SPEC/**`) leave `app_tests_cache`, `app_tests_shard`, and `quality_app_coverage` **skipped**. Required branch status checks that are skipped do not count as successful, so merges stay blocked (e.g. #1464).

## Change
- Always run those jobs after `changes` succeeds; early no-op when `outputs.tests != 'true'`.
- Gate heavy steps on `needs.changes.outputs.tests == 'true'`.
- Use `always()` + explicit `needs.*.result` so dependents run when upstream jobs are skipped in the no-match case.

## Follow-up
After this merges to `dev`, merge/rebase `dev` into affected PR branches (or re-run checks) so the updated workflow runs on the next push.

Made with [Cursor](https://cursor.com)