### PR TITLE
Extraction auto-transport: logging, SPEC override docs, integration tests (refs #1289)

### DIFF
--- a/SPEC/program/auto-transport.md
+++ b/SPEC/program/auto-transport.md
@@ -14,6 +14,22 @@
 
 **Per-player extracted quantities by commodity** — produced by the resource extractor (land = same-region totals, overseas = different-region totals). Player's current stockpile. No raw tile iteration inside transport.
 
+---
+
+## Caller-supplied extraction override (`extractedByPlayerId`)
+
+When turn resolution (or economy preview) is invoked with a **non-empty** `Map<String, Map<CommodityId, int>> extractedByPlayerId`, the implementation applies those per-player commodity totals **directly** to each player’s central stockpile via `applyExtractionForPlayers` and **does not** run the normal extraction auto-transport pipeline for that turn. In particular, this path **intentionally bypasses**:
+
+- Connectivity resolution  
+- Per-tile resource extraction (`computeExtraction`)  
+- Land vs overseas split  
+- Cargo-hold allocation (`allocateOverseasToStockpile`)  
+- Trade/transport interception (`applyTradeInterception`)
+
+Callers using this override must therefore supply **already-final** delivered amounts (as if land and overseas processing were already complete). It is intended for tests, sim_economy, and similar controlled inputs—not for normal play when tile maps drive extraction.
+
+---
+
 **Sea cargo priority is not configurable:** Overseas allocation under cargo-hold limits uses a **single fixed** category order (see table below). The system does **not** read transport-priority preferences from player orders, AI, or rulesets, and implementations must **not** expose a per-player, per-faction, or per-ruleset override for this ordering. (GitHub #1290 — design decision: no order-driven priority.)
 
 ---

--- a/SPEC/program/turn-resolution-phase-details.md
+++ b/SPEC/program/turn-resolution-phase-details.md
@@ -20,6 +20,8 @@ Full resolution per [diplomacy-resolution.md](diplomacy-resolution.md): overture
 
 (1) **Connectivity:** Recompute per-player connectivity (see [extraction-pipeline.md](extraction-pipeline.md)). (2) **Extract:** Per-tile effective extraction: min(improvement, tech cap), then min(..., transport level); minerals only from prospected tiles per [fog-and-exploration-resolution.md](fog-and-exploration-resolution.md); sum by commodity; separate same-region vs overseas. (3) **Land:** Add same-region totals to stockpile. (4) **Sea:** Allocate overseas totals by priority, capped by cargo holds derived from the player's home fleet (in port at capital; see [auto-transport.md](auto-transport.md)); add only the transported portion to stockpile. Reference: [capital-and-connectivity.md](../game/capital-and-connectivity.md), [extraction-pipeline.md](extraction-pipeline.md).
 
+**Override:** When `extractedByPlayerId` is **non-empty**, the phase applies `applyExtractionForPlayers` only: per-player maps are merged into central stockpiles with **no** connectivity, tile extraction, land/overseas split, cargo-hold cap, or interception. See [auto-transport.md](auto-transport.md) § Caller-supplied extraction override.
+
 ---
 
 ## Riches to treasury

--- a/packages/colonizethis_logic/lib/src/economy/economy_extraction.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_extraction.dart
@@ -1,4 +1,7 @@
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+
+final _log = logicLogger();
 
 /// Extraction and auto-transport helpers.
 /// SPEC/game/extraction-and-improvements.md
@@ -14,6 +17,21 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 /// Applies [extracted] commodity quantities to [stockpile], returning the
 /// updated stockpile. Negative values in [extracted] are treated as zero.
 /// There is no maximum stockpile size; deltas add without storage caps.
+///
+/// Debug logging for land totals applied during extraction auto-transport.
+/// SPEC/program/auto-transport.md; grep token `extraction auto_transport land`.
+void logExtractionAutoTransportLand(
+  String playerId,
+  Map<CommodityId, int> land,
+) {
+  if (land.isEmpty) return;
+  final totalUnits = land.values.fold<int>(0, (a, b) => a + b);
+  final detail = land.entries.map((e) => '${e.key}=${e.value}').join(',');
+  _log.d(
+    'extraction auto_transport land playerId=$playerId totalUnits=$totalUnits detail=$detail',
+  );
+}
+
 Stockpile applyExtractionToStockpile(
   Stockpile stockpile,
   Map<CommodityId, int> extracted,
@@ -54,4 +72,3 @@ Game applyExtractionForPlayers(
 
   return game.copyWith(players: updatedPlayers);
 }
-

--- a/packages/colonizethis_logic/lib/src/economy/sea_transport.dart
+++ b/packages/colonizethis_logic/lib/src/economy/sea_transport.dart
@@ -1,7 +1,10 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../world/naval.dart';
+
+final _log = logicLogger();
 
 /// Sea transport: allocate overseas extraction to stockpile by priority. SPEC/program/auto-transport.
 /// Trade/transport interception: SPEC/program/naval-movement-resolution.md (P_cargo_intercept, P_ship_sunk).
@@ -52,6 +55,55 @@ Map<CommodityId, int> allocateOverseasToStockpile(
   }
 
   return delivered;
+}
+
+/// Debug logging for overseas cargo-cap allocation during extraction auto-transport.
+/// SPEC/program/auto-transport.md; grep token `extraction auto_transport overseas`.
+void logExtractionAutoTransportOverseasAllocation({
+  required String playerId,
+  required int cargoHolds,
+  required Map<CommodityId, int> overseasTotals,
+  required Map<CommodityId, int> allocatedToStockpile,
+}) {
+  if (overseasTotals.isEmpty) return;
+  final overseasTotalUnits = overseasTotals.values.fold<int>(
+    0,
+    (a, b) => a + b,
+  );
+  final allocatedUnits = allocatedToStockpile.values.fold<int>(
+    0,
+    (a, b) => a + b,
+  );
+  final detail = allocatedToStockpile.entries
+      .map((e) => '${e.key}=${e.value}')
+      .join(',');
+  _log.d(
+    'extraction auto_transport overseas cargo_cap playerId=$playerId '
+    'cargoHolds=$cargoHolds overseasTotalUnits=$overseasTotalUnits '
+    'allocatedUnits=$allocatedUnits allocatedDetail=$detail',
+  );
+}
+
+void _logExtractionAutoTransportInterception(
+  String playerId,
+  Map<CommodityId, int> before,
+  Map<CommodityId, int> after,
+) {
+  final beforeUnits = before.values.fold<int>(0, (s, v) => s + v);
+  final afterUnits = after.values.fold<int>(0, (s, v) => s + v);
+  final ids = {...before.keys, ...after.keys};
+  final deltas = <String>[];
+  for (final id in ids) {
+    final bv = before[id] ?? 0;
+    final av = after[id] ?? 0;
+    if (bv != av) deltas.add('$id $bv->$av');
+  }
+  final deltaStr = deltas.isEmpty ? 'none' : deltas.join(';');
+  _log.d(
+    'extraction auto_transport interception playerId=$playerId '
+    'deliveredBeforeUnits=$beforeUnits deliveredAfterUnits=$afterUnits '
+    'perCommodityDelta=$deltaStr',
+  );
 }
 
 /// Total cargo holds for [playerId] based on ships in the home fleet at the capital port.
@@ -124,13 +176,18 @@ Set<String> _enemiesAtWar(Game game, String playerId) {
 }
 
 /// Intercept score and whether any enemy has Blockade mission.
-(int interceptScore, bool hasBlockade) _interceptScoreAndBlockade(List<Fleet> fleets, Set<String> enemyIds) {
+(int interceptScore, bool hasBlockade) _interceptScoreAndBlockade(
+  List<Fleet> fleets,
+  Set<String> enemyIds,
+) {
   var sum = 0;
   var hasBlockade = false;
   for (final f in fleets) {
-    if (!f.isAtSea) continue; // Only fleets at sea can intercept. SPEC/game/ships-and-naval.md.
+    if (!f.isAtSea)
+      continue; // Only fleets at sea can intercept. SPEC/game/ships-and-naval.md.
     if (!enemyIds.contains(f.ownerId)) continue;
-    if (f.mission != FleetMission.patrol && f.mission != FleetMission.blockade) continue;
+    if (f.mission != FleetMission.patrol && f.mission != FleetMission.blockade)
+      continue;
     if (f.mission == FleetMission.blockade) hasBlockade = true;
     for (final typeId in f.shipTypeIds) {
       sum += NavalStatsCatalog.get(typeId).interceptRating;
@@ -194,19 +251,34 @@ TradeInterceptionResult applyTradeInterception(
 
   final enemies = _enemiesAtWar(game, playerId);
   if (enemies.isEmpty) {
+    final unchanged = Map<CommodityId, int>.from(overseasDelivered);
+    _logExtractionAutoTransportInterception(
+      playerId,
+      overseasDelivered,
+      unchanged,
+    );
     return TradeInterceptionResult(
-      reducedDelivered: Map<CommodityId, int>.from(overseasDelivered),
+      reducedDelivered: unchanged,
       updatedFleets: game.worldState.fleets,
     );
   }
 
   final fleets = game.worldState.fleets;
-  final (interceptScore, hasBlockade) = _interceptScoreAndBlockade(fleets, enemies);
+  final (interceptScore, hasBlockade) = _interceptScoreAndBlockade(
+    fleets,
+    enemies,
+  );
   final evasionScore = _evasionScoreForPlayer(fleets, playerId);
 
   if (interceptScore <= 0) {
+    final unchanged = Map<CommodityId, int>.from(overseasDelivered);
+    _logExtractionAutoTransportInterception(
+      playerId,
+      overseasDelivered,
+      unchanged,
+    );
     return TradeInterceptionResult(
-      reducedDelivered: Map<CommodityId, int>.from(overseasDelivered),
+      reducedDelivered: unchanged,
       updatedFleets: game.worldState.fleets,
     );
   }
@@ -215,8 +287,13 @@ TradeInterceptionResult applyTradeInterception(
   final ratio = total > 0 ? interceptScore / total : 1.0;
 
   // Escort protection: lossReduction = min(0.5, escortStrength/cargoStrength × 0.3). SPEC.
-  final (escortStrength, cargoStrength) = _escortAndCargoStrength(fleets, playerId, overseasDelivered);
-  final escortFactor = (escortStrength / cargoStrength * escortStrengthWeight).clamp(0.0, escortFactorMax);
+  final (escortStrength, cargoStrength) = _escortAndCargoStrength(
+    fleets,
+    playerId,
+    overseasDelivered,
+  );
+  final escortFactor = (escortStrength / cargoStrength * escortStrengthWeight)
+      .clamp(0.0, escortFactorMax);
 
   // Base before escort: used for cargo (with escort) and for ship loss (escort applied once per GDD).
   double baseBeforeEscort = actionFactorPatrol * ratio * civilianTargetBonus;
@@ -226,12 +303,14 @@ TradeInterceptionResult applyTradeInterception(
   double base = baseBeforeEscort * (1.0 - escortFactor);
 
   final pIntercept = (1.2 * base).clamp(0.1, 0.9);
-  final raidEfficiency = raidEfficiencyMin + ratio * (raidEfficiencyMax - raidEfficiencyMin);
+  final raidEfficiency =
+      raidEfficiencyMin + ratio * (raidEfficiencyMax - raidEfficiencyMin);
   final pCargoEffective = (pIntercept * raidEfficiency).clamp(0.0, 1.0);
 
   // GDD: shipLossChance = baseShipLoss × (1 - escortFactor) × civilianPenalty — escort applied once.
   final baseShipLoss = (0.4 * baseBeforeEscort).clamp(0.0, 1.0);
-  final pShip = (baseShipLoss * (1.0 - escortFactor) * civilianShipLossPenalty).clamp(0.02, 0.5);
+  final pShip = (baseShipLoss * (1.0 - escortFactor) * civilianShipLossPenalty)
+      .clamp(0.02, 0.5);
 
   final reducedDelivered = <CommodityId, int>{};
   for (final entry in overseasDelivered.entries) {
@@ -250,12 +329,19 @@ TradeInterceptionResult applyTradeInterception(
   final playerFleets = fleets.where((f) => f.ownerId == playerId).toList();
   var shipsToRemove = 0;
   for (final f in playerFleets) {
-    final merchantCount = f.shipTypeIds.where((id) => _merchantShipTypes.contains(id)).length;
+    final merchantCount = f.shipTypeIds
+        .where((id) => _merchantShipTypes.contains(id))
+        .length;
     for (var i = 0; i < merchantCount; i++) {
       if (nextInt(100) < (pShip * 100)) shipsToRemove++;
     }
   }
   if (shipsToRemove <= 0) {
+    _logExtractionAutoTransportInterception(
+      playerId,
+      overseasDelivered,
+      reducedDelivered,
+    );
     return TradeInterceptionResult(
       reducedDelivered: reducedDelivered,
       updatedFleets: game.worldState.fleets,
@@ -281,6 +367,11 @@ TradeInterceptionResult applyTradeInterception(
     }
   }
 
+  _logExtractionAutoTransportInterception(
+    playerId,
+    overseasDelivered,
+    reducedDelivered,
+  );
   return TradeInterceptionResult(
     reducedDelivered: reducedDelivered,
     updatedFleets: updatedFleets,

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -725,9 +725,17 @@ Game _runExtractionPhase(
     final tot = extraction[player.id];
     if (tot != null) {
       stockpile = applyExtractionToStockpile(stockpile, tot.land);
+      logExtractionAutoTransportLand(player.id, tot.land);
+      final cargoHolds = cargoHoldsForHomeFleet(state, player.id);
       var overseasDelivered = allocateOverseasToStockpile(
         tot.overseas,
-        cargoHolds: cargoHoldsForHomeFleet(state, player.id),
+        cargoHolds: cargoHolds,
+      );
+      logExtractionAutoTransportOverseasAllocation(
+        playerId: player.id,
+        cargoHolds: cargoHolds,
+        overseasTotals: tot.overseas,
+        allocatedToStockpile: overseasDelivered,
       );
       if (overseasDelivered.isNotEmpty) {
         extractionSeed = (extractionSeed * 1103515245 + 12345) & 0x7fffffff;

--- a/packages/colonizethis_logic/test/extraction_auto_transport_logging_test.dart
+++ b/packages/colonizethis_logic/test/extraction_auto_transport_logging_test.dart
@@ -1,0 +1,85 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:logger/logger.dart';
+
+import 'extraction_auto_transport_test_fixtures.dart';
+
+List<String> _autoTransportMessages(List<LogEvent> events) => [
+  for (final e in events)
+    if (e.message.contains('logic: extraction auto_transport')) e.message,
+];
+
+void main() {
+  group('extraction auto-transport logging', () {
+    late List<LogEvent> capturedEvents;
+    late void Function(LogEvent) listener;
+
+    setUp(() {
+      capturedEvents = [];
+      listener = capturedEvents.add;
+      Logger.addLogListener(listener);
+      Logger.level = Level.debug;
+    });
+
+    tearDown(() {
+      Logger.removeLogListener(listener);
+      capturedEvents.clear();
+      Logger.level = Level.off;
+    });
+
+    test(
+      'resolveTurnForGame emits land, overseas cargo_cap, and interception lines',
+      () {
+        const globalSeed = 42;
+        final enemyPatrol = Fleet(
+          id: 'f_p2_patrol',
+          ownerId: 'p2',
+          seaZoneId: 'sea1',
+          regionId: 'oldWorld',
+          shipTypeIds: const ['sloop'],
+          mission: FleetMission.patrol,
+        );
+        final nwGrid = [
+          [Resource.sugarCane, Resource.sugarCane],
+          [Resource.sugarCane, Resource.sugarCane],
+        ];
+        final (:game, :tileMapByRegion) = extractionAutoTransportFixture(
+          nwResourceGrid: nwGrid,
+          nwImprovementLevel: 1,
+          extraFleets: [enemyPatrol],
+          globalGameSeed: globalSeed,
+          relationWithP2: RelationState.atWar,
+        );
+        final topology = crossRegionSeaTopologyForExtractionTests();
+
+        requireTurnResolutionComplete(
+          resolveTurnForGame(
+            game: game,
+            topology: topology,
+            orders: const Orders(),
+            tileMapByRegion: tileMapByRegion,
+            defaultAssignments: const [],
+          ),
+        );
+
+        final lines = _autoTransportMessages(capturedEvents);
+        expect(
+          lines.any((m) => m.contains('extraction auto_transport land')),
+          isTrue,
+        );
+        expect(
+          lines.any((m) => m.contains('extraction auto_transport overseas')),
+          isTrue,
+        );
+        expect(
+          lines.any(
+            (m) => m.contains('extraction auto_transport interception'),
+          ),
+          isTrue,
+        );
+      },
+    );
+  });
+}

--- a/packages/colonizethis_logic/test/extraction_auto_transport_test_fixtures.dart
+++ b/packages/colonizethis_logic/test/extraction_auto_transport_test_fixtures.dart
@@ -1,0 +1,166 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Matches [_runExtractionPhase] interception seed for the first player with
+/// non-empty overseas allocation on turn [turnNumber].
+int extractionAutoTransportInterceptionSeed({
+  required int globalGameSeed,
+  required int turnNumber,
+  required String playerId,
+}) {
+  var extractionSeed = globalGameSeed ^ (turnNumber * 0x9E3779B1);
+  extractionSeed = (extractionSeed * 1103515245 + 12345) & 0x7fffffff;
+  return extractionSeed ^ playerId.hashCode;
+}
+
+MapTopology crossRegionSeaTopologyForExtractionTests() {
+  return MapTopology(
+    nodes: const [
+      TopologyNode(
+        id: 'p1',
+        regionId: 'oldWorld',
+        type: TopologyNodeType.province,
+      ),
+      TopologyNode(
+        id: 'n1',
+        regionId: 'newWorld',
+        type: TopologyNodeType.province,
+      ),
+      TopologyNode(
+        id: 'sea1',
+        regionId: 'oldWorld',
+        type: TopologyNodeType.seaZone,
+      ),
+      TopologyNode(
+        id: 'sea2',
+        regionId: 'newWorld',
+        type: TopologyNodeType.seaZone,
+      ),
+    ],
+    edges: const [
+      TopologyEdge(id1: 'p1', id2: 'sea1'),
+      TopologyEdge(id1: 'n1', id2: 'sea2'),
+      TopologyEdge(id1: 'sea1', id2: 'sea2'),
+    ],
+  );
+}
+
+final tileMapOldWorldGrain = TileMapResult(
+  width: 1,
+  height: 1,
+  grid: [
+    ['p1'],
+  ],
+  resourceGrid: [
+    [Resource.grain],
+  ],
+);
+
+TileMapState _tileStateForExtractionFixture(int nwImprovementLevel) {
+  return TileMapState()
+      .setImprovement('oldWorld|p1|0|0', 1)
+      .setRoadLevel('oldWorld|p1|0|0', 4)
+      .setImprovement('newWorld|n1|0|0', nwImprovementLevel)
+      .setRoadLevel('newWorld|n1|0|0', 4)
+      .setImprovement('newWorld|n1|1|0', nwImprovementLevel)
+      .setRoadLevel('newWorld|n1|1|0', 4)
+      .setImprovement('newWorld|n1|0|1', nwImprovementLevel)
+      .setRoadLevel('newWorld|n1|0|1', 4)
+      .setImprovement('newWorld|n1|1|1', nwImprovementLevel)
+      .setRoadLevel('newWorld|n1|1|1', 4);
+}
+
+/// Cross-region extraction setup: OW capital grain tile + 2×2 NW grid.
+({Game game, Map<String, TileMapResult> tileMapByRegion})
+extractionAutoTransportFixture({
+  required List<List<Resource?>> nwResourceGrid,
+  required int nwImprovementLevel,
+  List<Fleet> extraFleets = const [],
+  int globalGameSeed = 0,
+  RelationState relationWithP2 = RelationState.atPeace,
+}) {
+  const ow = 'oldWorld', nw = 'newWorld';
+  final tileMapNw = TileMapResult(
+    width: 2,
+    height: 2,
+    grid: const [
+      ['n1', 'n1'],
+      ['n1', 'n1'],
+    ],
+    resourceGrid: nwResourceGrid,
+  );
+
+  final tileState = _tileStateForExtractionFixture(nwImprovementLevel);
+
+  final ports = {
+    '$ow|p1|sea1': 'oldWorld|p1|0|0',
+    '$nw|n1|sea2': 'newWorld|n1|0|0',
+  };
+
+  final cap = CapitalTile(regionId: ow, provinceId: '$ow|p1', x: 0, y: 0);
+  final homeFleet = Fleet(
+    id: 'fleet_pl1',
+    ownerId: 'pl1',
+    inPortAtProvinceId: '$ow|p1',
+    regionId: ow,
+    shipTypeIds: const ['carrack'],
+    mission: FleetMission.none,
+  );
+
+  final game = Game(
+    id: 'g1',
+    globalGameSeed: globalGameSeed,
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+      oldWorld: RegionData(
+        provinces: [
+          Province(
+            id: '$ow|p1',
+            regionId: ow,
+            ownerId: 'pl1',
+            townDevelopmentLevel: 4,
+          ),
+        ],
+      ),
+      newWorld: RegionData(
+        provinces: [
+          Province(
+            id: '$nw|n1',
+            regionId: nw,
+            ownerId: 'pl1',
+            townDevelopmentLevel: 4,
+          ),
+        ],
+      ),
+      tileState: tileState,
+      portsByProvinceSeaboard: ports,
+      fleets: [homeFleet, ...extraFleets],
+    ),
+    players: [
+      Player(
+        id: 'pl1',
+        displayName: 'Spain',
+        isHuman: true,
+        capitalProvinceId: '$ow|p1',
+        capitalTile: cap,
+        stockpile: const Stockpile().applyDelta(
+          CommodityCatalog.grain.id,
+          1000,
+        ),
+      ),
+      const Player(id: 'p2', displayName: 'Rival', isHuman: false),
+    ],
+    diplomacyRelations: [
+      DiplomacyRelation(
+        factionId1: 'pl1',
+        factionId2: 'p2',
+        state: relationWithP2,
+      ),
+    ],
+  );
+
+  return (
+    game: game,
+    tileMapByRegion: {'oldWorld': tileMapOldWorldGrain, 'newWorld': tileMapNw},
+  );
+}

--- a/packages/colonizethis_logic/test/turn_resolver_extraction_auto_transport_integration_test.dart
+++ b/packages/colonizethis_logic/test/turn_resolver_extraction_auto_transport_integration_test.dart
@@ -1,0 +1,195 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+import 'extraction_auto_transport_test_fixtures.dart';
+
+void main() {
+  group('Extraction auto-transport (TurnResolver integration)', () {
+    test(
+      'overseas cargo cap: land grain fully added; overseas sugar capped by home fleet holds',
+      () {
+        const globalSeed = 7;
+        final nwGrid = [
+          [Resource.sugarCane, Resource.sugarCane],
+          [Resource.sugarCane, Resource.sugarCane],
+        ];
+        final (:game, :tileMapByRegion) = extractionAutoTransportFixture(
+          nwResourceGrid: nwGrid,
+          nwImprovementLevel: 1,
+          globalGameSeed: globalSeed,
+        );
+        final topology = crossRegionSeaTopologyForExtractionTests();
+
+        final connectivity = resolveConnectivity(
+          game: game,
+          tileMapByRegion: tileMapByRegion,
+          topology: topology,
+        );
+        final extraction = computeExtraction(
+          game: game,
+          tileMapByRegion: tileMapByRegion,
+          connectivityResult: connectivity,
+        );
+        final overseas = extraction['pl1']!.overseas;
+        expect(overseas['sugarCane'], 4);
+
+        final holds = cargoHoldsForHomeFleet(game, 'pl1');
+        expect(holds, NavalStatsCatalog.carrack.cargoHold);
+        final allocated = allocateOverseasToStockpile(
+          overseas,
+          cargoHolds: holds,
+        );
+        expect(allocated['sugarCane'], 3);
+
+        final next = requireTurnResolutionComplete(
+          resolveTurnForGame(
+            game: game,
+            topology: topology,
+            orders: const Orders(),
+            tileMapByRegion: tileMapByRegion,
+            defaultAssignments: const [],
+          ),
+        );
+
+        expect(next.players.first.stockpile.quantityOf('sugarCane'), 3);
+        const shipFood = 2;
+        expect(
+          next.players.first.stockpile.quantityOf('grain'),
+          1000 - shipFood + 1,
+        );
+      },
+    );
+
+    test(
+      'overseas priority: cargo cap fills earlier catalog raw materials before later ones',
+      () {
+        // Two New World raw materials; cotton appears before sugarCane in
+        // [CommodityCatalog.all], so cargo fill prefers cotton first.
+        const globalSeed = 11;
+        final nwGrid = [
+          [Resource.cotton, Resource.sugarCane],
+          [null, null],
+        ];
+        final (:game, :tileMapByRegion) = extractionAutoTransportFixture(
+          nwResourceGrid: nwGrid,
+          nwImprovementLevel: 2,
+          globalGameSeed: globalSeed,
+        );
+        final topology = crossRegionSeaTopologyForExtractionTests();
+
+        final connectivity = resolveConnectivity(
+          game: game,
+          tileMapByRegion: tileMapByRegion,
+          topology: topology,
+        );
+        final extraction = computeExtraction(
+          game: game,
+          tileMapByRegion: tileMapByRegion,
+          connectivityResult: connectivity,
+        );
+        final overseas = extraction['pl1']!.overseas;
+        expect(overseas['cotton'], 2);
+        expect(overseas['sugarCane'], 2);
+        final holds = cargoHoldsForHomeFleet(game, 'pl1');
+        final allocated = allocateOverseasToStockpile(
+          overseas,
+          cargoHolds: holds,
+        );
+        expect(allocated['cotton'], 2);
+        expect(allocated['sugarCane'], 1);
+
+        final next = requireTurnResolutionComplete(
+          resolveTurnForGame(
+            game: game,
+            topology: topology,
+            orders: const Orders(),
+            tileMapByRegion: tileMapByRegion,
+            defaultAssignments: const [],
+          ),
+        );
+
+        expect(next.players.first.stockpile.quantityOf('grain'), 1000 - 2 + 1);
+        expect(next.players.first.stockpile.quantityOf('cotton'), 2);
+        expect(next.players.first.stockpile.quantityOf('sugarCane'), 1);
+      },
+    );
+
+    test(
+      'naval trade interception reduces overseas additions after cargo cap',
+      () {
+        const globalSeed = 42;
+        final enemyPatrol = Fleet(
+          id: 'f_p2_patrol',
+          ownerId: 'p2',
+          seaZoneId: 'sea1',
+          regionId: 'oldWorld',
+          shipTypeIds: const ['sloop'],
+          mission: FleetMission.patrol,
+        );
+        final nwGrid = [
+          [Resource.sugarCane, Resource.sugarCane],
+          [Resource.sugarCane, Resource.sugarCane],
+        ];
+        final (:game, :tileMapByRegion) = extractionAutoTransportFixture(
+          nwResourceGrid: nwGrid,
+          nwImprovementLevel: 1,
+          extraFleets: [enemyPatrol],
+          globalGameSeed: globalSeed,
+          relationWithP2: RelationState.atWar,
+        );
+        final topology = crossRegionSeaTopologyForExtractionTests();
+
+        final connectivity = resolveConnectivity(
+          game: game,
+          tileMapByRegion: tileMapByRegion,
+          topology: topology,
+        );
+        final extraction = computeExtraction(
+          game: game,
+          tileMapByRegion: tileMapByRegion,
+          connectivityResult: connectivity,
+        );
+        final overseas = extraction['pl1']!.overseas;
+        final holds = cargoHoldsForHomeFleet(game, 'pl1');
+        final allocated = allocateOverseasToStockpile(
+          overseas,
+          cargoHolds: holds,
+        );
+        final seed = extractionAutoTransportInterceptionSeed(
+          globalGameSeed: globalSeed,
+          turnNumber: 0,
+          playerId: 'pl1',
+        );
+        final intercepted = applyTradeInterception(
+          game,
+          'pl1',
+          allocated,
+          seed: seed,
+        );
+        expect(
+          intercepted.reducedDelivered.values.fold<int>(0, (a, b) => a + b),
+          lessThan(allocated.values.fold<int>(0, (a, b) => a + b)),
+        );
+
+        final next = requireTurnResolutionComplete(
+          resolveTurnForGame(
+            game: game,
+            topology: topology,
+            orders: const Orders(),
+            tileMapByRegion: tileMapByRegion,
+            defaultAssignments: const [],
+          ),
+        );
+
+        final expectedSugar =
+            intercepted.reducedDelivered[CommodityCatalog.sugarCane.id] ?? 0;
+        expect(
+          next.players.first.stockpile.quantityOf('sugarCane'),
+          expectedSugar,
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Implements [issue #1289](https://github.com/waigore/colonizethisv3/issues/1289): debug logging for extraction phase auto-transport steps, SPEC documentation for the `extractedByPlayerId` shortcut, and TurnResolver integration coverage.

## Changes
- **Logging:** `logExtractionAutoTransportLand` in `economy_extraction.dart`; `logExtractionAutoTransportOverseasAllocation` plus interception summaries in `applyTradeInterception` (`sea_transport.dart`). Messages use grep-friendly tokens `extraction auto_transport land`, `... overseas cargo_cap`, `... interception` (emitted as `logic: …` via `logicLogger`).
- **SPEC:** `SPEC/program/auto-transport.md` (caller override section); `SPEC/program/turn-resolution-phase-details.md` (Extraction override bullet).
- **Tests:** Shared fixtures `extraction_auto_transport_test_fixtures.dart`; integration tests for cargo cap (carrack holds vs four NW sugar tiles), overseas fill priority (cotton vs sugarCane under cap), and interception vs peace; `extraction_auto_transport_logging_test.dart` asserts log lines with a listener.

## Verification
- `dart test test/turn_resolver_extraction_auto_transport_integration_test.dart test/extraction_auto_transport_logging_test.dart` (passes locally).

Refs #1289 (does not close).

Made with [Cursor](https://cursor.com)