### PR TITLE
Combat: garrison recovery regiment type (most-advanced infantry)

### DIFF
--- a/SPEC/game/combat.md
+++ b/SPEC/game/combat.md
@@ -24,6 +24,8 @@ Auto-resolved combat triggers when **armies** move into enemy-controlled provinc
 
 **Outcomes:** Attacker victory (defender eliminated → province flips), defender victory (attacker eliminated, no change), stalemate (both survive, no flip), mutual annihilation (both wiped; defender recovers 20% rounded up of initial regiments if further attackers remain, otherwise ungarrisoned).
 
+**Garrison recovery type (mutual annihilation, chain continues):** Each recovered regiment uses the **same** regiment type: the defender faction’s **most advanced infantry** for its **effective military era** `E` (Great Power `E = 4`; Minor Nation / Tribe per [factions.md](factions.md)). **Infantry-eligible** catalog entries are those that are **not** cavalry and **not** artillery ([military-units.md](military-units.md) roster / `RegimentCategory`). **Advancement** is `FPN + FPM` on the catalog row for era `E` (matches auto-resolve strength basis). **Tie-break:** among types tied on `FPN + FPM`, choose the **lexicographically smallest** regiment `id` (ASCII). **Fallback:** if no infantry-eligible row exists for `E`, use `peasant_levies`. **Implementation:** `garrisonRecoveryRegimentTypeForEra` in `combat_config.dart`; applied in `resolveBattleContext` when spawning `recover_*` units.
+
 **Province Flip:** After **defender armies are eliminated** (no defending regiments remain in the province for the defender faction). Army casualties and army removal are applied **before** ownership flips; see [military-armies.md](military-armies.md). Flip is immediate when the defender has no regiments left, before later same-province battles in the chain. Connectivity/extraction recompute next turn.
 
 ## Acceptance Criteria
@@ -66,7 +68,15 @@ Auto-resolved combat triggers when **armies** move into enemy-controlled provinc
 
 - Given a combat where both the attacker side and the defender side lose all regiments in the final exchange, and there is at least one additional attacker faction remaining in the multi-attacker chain for that province  
   When the system completes the current attacker–defender exchange  
-  Then the system records a mutual annihilation outcome for that exchange, restores a new defending garrison equal to 20% of the defender’s initial regiment count in that battle rounded up, and continues the multi-attacker chain using this restored defending garrison against the next attacker faction.
+  Then the system records a mutual annihilation outcome for that exchange, restores a new defending garrison equal to 20% of the defender’s initial regiment count in that battle rounded up (minimum 1 regiment, at most that initial count), sets **every** recovered regiment’s type to the most advanced infantry type for the defending faction’s effective military era `E` per § Garrison recovery type, and continues the multi-attacker chain using this restored defending garrison against the next attacker faction.
+
+- Given mutual annihilation with remaining attackers and a defending faction whose effective military era is `E`, and the active ruleset’s regiment catalog contains at least one infantry-eligible row for era `E`  
+  When the system applies garrison recovery  
+  Then every recovered regiment’s type equals the catalog infantry-eligible row for era `E` with maximum `FPN + FPM`, using the lexicographically smallest `id` among rows tied on that sum.
+
+- Given mutual annihilation with remaining attackers and a defending faction whose effective military era is `E`, and the catalog has **no** infantry-eligible row for era `E`  
+  When the system applies garrison recovery  
+  Then every recovered regiment’s type is exactly `peasant_levies`.
 
 - Given a combat where both the attacker side and the defender side lose all regiments in the final exchange and there are no further attackers remaining in the multi-attacker chain  
   When the system completes combat resolution for that province  
@@ -78,7 +88,7 @@ Auto-resolved combat triggers when **armies** move into enemy-controlled provinc
 
 - Given two combat resolutions for the same province in the same game state with identical unit compositions, stats, modifiers, and move orders  
   When the system executes combat resolution for that province both times  
-  Then the system produces the same ordered sequence of battle pairings, the same winner for the overall province combat, the same casualty counts per faction and side, and the same province ownership outcome in both executions.
+  Then the system produces the same ordered sequence of battle pairings, the same winner for the overall province combat, the same casualty counts per faction and side, the same province ownership outcome in both executions, and the same regiment types for any mutual-annihilation recovered garrison regiments.
 
 ## Configurable Values
 
@@ -88,7 +98,8 @@ Auto-resolved combat triggers when **armies** move into enemy-controlled provinc
 | W_medal | 10.0 | Initiative medal weight; tuned so each general medal gives a noticeable but smaller boost than full cavalry share. Matches `initiativeGeneralMedalWeight` in `combat_config.dart`. |
 | Medal multipliers | 1.0 / 1.1 / 1.2 / 1.3 / 1.4 | Per medal level 0–4 |
 | DEF divisor | 9 | Durability scaling |
-| Recovery % | 20% (ceil) | Mutual-annihilation garrison |
+| Recovery % | 20% (ceil) | Mutual-annihilation garrison count (min 1, max initial defender count in that exchange) |
+| Garrison recovery type | Most-advanced infantry at era `E` | Per § Garrison recovery type; `garrisonRecoveryRegimentTypeForEra` in `combat_config.dart` |
 | Feeding modifiers | 1.0 / 0.75 / 0.5 | Coverage ≥ 1.0 / 0.5–1.0 / < 0.5; implemented via morale multiplier and **adopted as the intended rule** (no open question). |
 | Terrain modifiers | Per terrain type | In ruleset config |
 | Fort modifiers | Per fort level 0–3 | In ruleset config |

--- a/SPEC/program/combat-resolution.md
+++ b/SPEC/program/combat-resolution.md
@@ -81,7 +81,7 @@ Per BattleContext:
    - Run per-engagement resolver.
    - Apply casualties to local views.
    - Interpret outcome per game/combat.md § Rules (Outcomes).
-   - On mutual annihilation with remaining attackers: recover garrison per game/combat.md § Configurable Values (Recovery %).
+   - On mutual annihilation with remaining attackers: recover garrison per game/combat.md — regiment **count** from Recovery % (§ Configurable Values) and regiment **type** from § Garrison recovery type (most-advanced infantry at defender effective era `E`, deterministic tie-break, `peasant_levies` fallback). Logic: `garrisonRecoveryRegimentTypeForEra` in `packages/colonizethis_data/.../combat_config.dart`; applied when `resolveBattleContext` spawns `recover_*` units.
 3. After chain completes, apply to world state in a single pass:
    - Remove casualty units.
    - Flip province ownership if defender eliminated per game/combat.md § Rules (Province Flip).
@@ -137,3 +137,7 @@ Structured **land** combat logs (`combat …` tokens after the `logic` prefix) a
 - Given `BattleContext.attackers` has a first entry for faction **A** with **M** attacker medals under §3 for that battle  
   When `buildQuickBattleInput` runs for that context  
   Then `attackerGeneralMedals` equals **M** for that primary attacker (first list entry), not a sum of `AttackingSide.generalMedals` from conflict detection alone.
+
+- Given an engagement ends in mutual annihilation, at least one attacker remains later in the multi-attacker chain, and the defending faction’s effective military era is **E** (per game/factions.md and resolver inputs)  
+  When `resolveBattleContext` applies garrison recovery  
+  Then every spawned recovered regiment’s `type` equals `garrisonRecoveryRegimentTypeForEra(E)` from `combat_config.dart` (same value as game/combat.md § Garrison recovery type).

--- a/packages/colonizethis_data/lib/src/combat_config.dart
+++ b/packages/colonizethis_data/lib/src/combat_config.dart
@@ -28,6 +28,14 @@ class RegimentStats {
       category == RegimentCategory.lightCavalry ||
       category == RegimentCategory.spearCavalry ||
       category == RegimentCategory.heavyCavalry;
+
+  bool get isArtillery =>
+      category == RegimentCategory.lightArtillery ||
+      category == RegimentCategory.heavyArtillery;
+
+  /// Eligible for mutual-annihilation garrison recovery type: not cavalry, not artillery.
+  /// SPEC/game/combat.md (bowmen and other non-cav / non-arty roster types count).
+  bool get isEligibleGarrisonRecoveryInfantry => !isCavalry && !isArtillery;
 }
 
 /// Regiment category per Imperialism II military roster.
@@ -337,6 +345,40 @@ const List<RegimentStats> regimentCatalog = [
     era: 4,
   ),
 ];
+
+/// Deterministic pick for mutual-annihilation garrison recovery regiment type.
+/// Chooses maximum `(FPN + FPM)` among [eligible]; tie-break: lexicographically
+/// smallest `id`. Empty [eligible] is allowed (caller passes filtered catalog).
+/// SPEC/game/combat.md § Garrison recovery type.
+String selectGarrisonRecoveryRegimentType(Iterable<RegimentStats> eligible) {
+  RegimentStats? best;
+  for (final r in eligible) {
+    if (best == null) {
+      best = r;
+      continue;
+    }
+    final bestSum = best.fpn + best.fpm;
+    final sum = r.fpn + r.fpm;
+    if (sum > bestSum) {
+      best = r;
+    } else if (sum == bestSum && r.id.compareTo(best.id) < 0) {
+      best = r;
+    }
+  }
+  if (best == null) return 'peasant_levies';
+  return best.id;
+}
+
+/// Regiment id for recovered garrison units after mutual annihilation when the chain continues.
+/// Uses [regimentCatalog] entries for `era` in 1..4: eligible types are [RegimentStats.isEligibleGarrisonRecoveryInfantry].
+/// SPEC/game/combat.md § Garrison recovery type; implemented in `combat_resolver.dart`.
+String garrisonRecoveryRegimentTypeForEra(int era) {
+  final e = era.clamp(1, 4);
+  final eligible = regimentCatalog.where(
+    (r) => r.era == e && r.isEligibleGarrisonRecoveryInfantry,
+  );
+  return selectGarrisonRecoveryRegimentType(eligible);
+}
 
 /// Registry of regiment stats by id.
 RegimentStats? regimentStatsById(String id) {

--- a/packages/colonizethis_data/test/combat_config_test.dart
+++ b/packages/colonizethis_data/test/combat_config_test.dart
@@ -81,5 +81,63 @@ void main() {
       expect(fortDamageReduction[2], 0.45); // Stone
       expect(fortDamageReduction[3], 0.60); // Modern
     });
+
+    group('garrisonRecoveryRegimentTypeForEra', () {
+      test('era 4 picks guards (max FPN+FPM among infantry-eligible)', () {
+        expect(garrisonRecoveryRegimentTypeForEra(4), 'guards');
+      });
+
+      test('era 3 picks grenadiers', () {
+        expect(garrisonRecoveryRegimentTypeForEra(3), 'grenadiers');
+      });
+
+      test('era 2 picks musketeers', () {
+        expect(garrisonRecoveryRegimentTypeForEra(2), 'musketeers');
+      });
+
+      test('era 1 picks arquebusiers', () {
+        expect(garrisonRecoveryRegimentTypeForEra(1), 'arquebusiers');
+      });
+
+      test('clamps era into 1..4', () {
+        expect(garrisonRecoveryRegimentTypeForEra(0), 'arquebusiers');
+        expect(garrisonRecoveryRegimentTypeForEra(99), 'guards');
+      });
+
+      test(
+        'selectGarrisonRecoveryRegimentType tie-break uses lexicographic id',
+        () {
+          const a = RegimentStats(
+            id: 'zebra_inf',
+            fpn: 5,
+            fpm: 5,
+            rng: 1,
+            def: 3,
+            mvr: 3,
+            category: RegimentCategory.lightInfantry,
+            era: 1,
+          );
+          const b = RegimentStats(
+            id: 'alpha_inf',
+            fpn: 5,
+            fpm: 5,
+            rng: 1,
+            def: 3,
+            mvr: 3,
+            category: RegimentCategory.regularInfantry,
+            era: 1,
+          );
+          expect(selectGarrisonRecoveryRegimentType([a, b]), 'alpha_inf');
+          expect(selectGarrisonRecoveryRegimentType([b, a]), 'alpha_inf');
+        },
+      );
+
+      test(
+        'selectGarrisonRecoveryRegimentType empty yields peasant_levies',
+        () {
+          expect(selectGarrisonRecoveryRegimentType([]), 'peasant_levies');
+        },
+      );
+    });
   });
 }

--- a/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
@@ -211,9 +211,7 @@ Game resolveBattleContext(
             1,
             initialDefenderCount,
           );
-          final garrisonTypes = _garrisonTypesForFaction(
-            game,
-            provinceOwnerId,
+          final recoveryType = garrisonRecoveryRegimentTypeForEra(
             defenderEffectiveLevel,
           );
           for (
@@ -221,7 +219,7 @@ Game resolveBattleContext(
             i < recoverCount && defenderUnitIds.length < recoverCount;
             i++
           ) {
-            final type = garrisonTypes[i % garrisonTypes.length];
+            final type = recoveryType;
             final id = 'recover_${ctx.provinceId}_$i';
             defenderUnitIds.add(id);
             final stubUnit = Unit(
@@ -449,19 +447,6 @@ int _deploymentLimitForFaction(Game game, String factionId, int generalMedals) {
       ? deploymentLimitWithNationalism
       : deploymentLimitBase;
   return baseLimit + generalMedals;
-}
-
-List<String> _garrisonTypesForFaction(
-  Game game,
-  String factionId,
-  int effectiveLevel,
-) {
-  final eraTypes = regimentCatalog
-      .where((r) => r.era == effectiveLevel)
-      .map((r) => r.id)
-      .toList();
-  if (eraTypes.isEmpty) return ['peasant_levies'];
-  return eraTypes;
 }
 
 /// Resolves one engagement: attacker vs defender.

--- a/packages/colonizethis_logic/test/combat_resolver_test.dart
+++ b/packages/colonizethis_logic/test/combat_resolver_test.dart
@@ -1,3 +1,4 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -113,128 +114,141 @@ void main() {
         terrain: 'plains',
       );
 
-      expect(siege.result, isNot(equals(field.result)),
-          reason: 'Fort should affect outcome when strengths are close');
-    });
-
-    test(
-        'low attacker feeding coverage penalises strength via morale multiplier',
-        () {
-      final attackerUnits = [
-        Unit(
-          id: 'a1',
-          type: 'grenadiers',
-          ownerId: 'att',
-          locationProvinceId: 'p',
-          medals: 2,
-        ),
-      ];
-      final defenderUnits = [
-        Unit(
-          id: 'd1',
-          type: 'peasant_levies',
-          ownerId: 'def',
-          locationProvinceId: 'p',
-          medals: 0,
-        ),
-      ];
-
-      final wellFed = resolveEngagement(
-        attackerUnits: attackerUnits,
-        defenderUnits: defenderUnits,
-        fortLevel: 0,
-        terrain: 'plains',
-        attackerMoraleMultiplier: 1.0,
-        defenderMoraleMultiplier: 1.0,
-      );
-
-      final underfed = resolveEngagement(
-        attackerUnits: attackerUnits,
-        defenderUnits: defenderUnits,
-        fortLevel: 0,
-        terrain: 'plains',
-        attackerMoraleMultiplier: 0.5,
-        defenderMoraleMultiplier: 1.0,
-      );
-
-      // Attacker should be strictly weaker when underfed.
-      expect(underfed.attackerStrength, wellFed.attackerStrength);
-      // Effective strength ratio should be worse for the underfed attacker,
-      // leading to outcomes that are no better than the well-fed case.
       expect(
-        underfed.result == EngagementResult.attackerVictory,
-        isFalse,
-        reason:
-            'Underfed attacker should not perform better than well-fed attacker',
+        siege.result,
+        isNot(equals(field.result)),
+        reason: 'Fort should affect outcome when strengths are close',
       );
     });
 
     test(
-        'leader keys from Game produce correct multipliers in resolveEngagement path',
-        () {
-      final attackerUnits = [
-        Unit(
+      'low attacker feeding coverage penalises strength via morale multiplier',
+      () {
+        final attackerUnits = [
+          Unit(
             id: 'a1',
             type: 'grenadiers',
             ownerId: 'att',
             locationProvinceId: 'p',
-            medals: 2),
-        Unit(
-            id: 'a2',
-            type: 'grenadiers',
-            ownerId: 'att',
-            locationProvinceId: 'p',
-            medals: 1),
-      ];
-      final defenderUnits = [
-        Unit(
+            medals: 2,
+          ),
+        ];
+        final defenderUnits = [
+          Unit(
             id: 'd1',
             type: 'peasant_levies',
             ownerId: 'def',
             locationProvinceId: 'p',
-            medals: 0),
-      ];
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            provinces: const [
-              Province(id: 'p', regionId: 'oldWorld', ownerId: 'def')
-            ],
-            units: [...attackerUnits, ...defenderUnits],
+            medals: 0,
           ),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(
+        ];
+
+        final wellFed = resolveEngagement(
+          attackerUnits: attackerUnits,
+          defenderUnits: defenderUnits,
+          fortLevel: 0,
+          terrain: 'plains',
+          attackerMoraleMultiplier: 1.0,
+          defenderMoraleMultiplier: 1.0,
+        );
+
+        final underfed = resolveEngagement(
+          attackerUnits: attackerUnits,
+          defenderUnits: defenderUnits,
+          fortLevel: 0,
+          terrain: 'plains',
+          attackerMoraleMultiplier: 0.5,
+          defenderMoraleMultiplier: 1.0,
+        );
+
+        // Attacker should be strictly weaker when underfed.
+        expect(underfed.attackerStrength, wellFed.attackerStrength);
+        // Effective strength ratio should be worse for the underfed attacker,
+        // leading to outcomes that are no better than the well-fed case.
+        expect(
+          underfed.result == EngagementResult.attackerVictory,
+          isFalse,
+          reason:
+              'Underfed attacker should not perform better than well-fed attacker',
+        );
+      },
+    );
+
+    test(
+      'leader keys from Game produce correct multipliers in resolveEngagement path',
+      () {
+        final attackerUnits = [
+          Unit(
+            id: 'a1',
+            type: 'grenadiers',
+            ownerId: 'att',
+            locationProvinceId: 'p',
+            medals: 2,
+          ),
+          Unit(
+            id: 'a2',
+            type: 'grenadiers',
+            ownerId: 'att',
+            locationProvinceId: 'p',
+            medals: 1,
+          ),
+        ];
+        final defenderUnits = [
+          Unit(
+            id: 'd1',
+            type: 'peasant_levies',
+            ownerId: 'def',
+            locationProvinceId: 'p',
+            medals: 0,
+          ),
+        ];
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(id: 'p', regionId: 'oldWorld', ownerId: 'def'),
+              ],
+              units: [...attackerUnits, ...defenderUnits],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(
               id: 'att',
               displayName: 'France',
               isHuman: true,
-              leaderKey: 'napoleon'),
-          Player(
+              leaderKey: 'napoleon',
+            ),
+            Player(
               id: 'def',
               displayName: 'Prussia',
               isHuman: false,
-              leaderKey: 'frederick'),
-        ],
-      );
-      const ctx = BattleContext(
-        provinceId: 'p',
-        regionId: 'oldWorld',
-        defenderFactionId: 'def',
-        defenderUnitIds: ['d1'],
-        attackers: [
-          AttackingSide(factionId: 'att', unitIds: ['a1', 'a2'])
-        ],
-        fortLevel: 0,
-        terrain: 'plains',
-      );
-      final result = resolveBattleContext(game, ctx);
-      expect(result.worldState.oldWorld.units.length, lessThanOrEqualTo(3),
-          reason: 'some units may be casualties');
-      expect(result.worldState.oldWorld.provinces.single.id, 'p');
-    });
+              leaderKey: 'frederick',
+            ),
+          ],
+        );
+        const ctx = BattleContext(
+          provinceId: 'p',
+          regionId: 'oldWorld',
+          defenderFactionId: 'def',
+          defenderUnitIds: ['d1'],
+          attackers: [
+            AttackingSide(factionId: 'att', unitIds: ['a1', 'a2']),
+          ],
+          fortLevel: 0,
+          terrain: 'plains',
+        );
+        final result = resolveBattleContext(game, ctx);
+        expect(
+          result.worldState.oldWorld.units.length,
+          lessThanOrEqualTo(3),
+          reason: 'some units may be casualties',
+        );
+        expect(result.worldState.oldWorld.provinces.single.id, 'p');
+      },
+    );
 
     test('resolveBattleContext updates newWorld when regionId is newWorld', () {
       final game = Game(
@@ -248,23 +262,26 @@ void main() {
             ],
             units: [
               Unit(
-                  id: 'd1',
-                  type: 'peasant_levies',
-                  ownerId: 'def',
-                  locationProvinceId: 'N1',
-                  medals: 0),
+                id: 'd1',
+                type: 'peasant_levies',
+                ownerId: 'def',
+                locationProvinceId: 'N1',
+                medals: 0,
+              ),
               Unit(
-                  id: 'a1',
-                  type: 'grenadiers',
-                  ownerId: 'att',
-                  locationProvinceId: 'N1',
-                  medals: 3),
+                id: 'a1',
+                type: 'grenadiers',
+                ownerId: 'att',
+                locationProvinceId: 'N1',
+                medals: 3,
+              ),
               Unit(
-                  id: 'a2',
-                  type: 'grenadiers',
-                  ownerId: 'att',
-                  locationProvinceId: 'N1',
-                  medals: 2),
+                id: 'a2',
+                type: 'grenadiers',
+                ownerId: 'att',
+                locationProvinceId: 'N1',
+                medals: 2,
+              ),
             ],
           ),
         ),
@@ -280,7 +297,10 @@ void main() {
         defenderUnitIds: ['d1'],
         attackers: [
           AttackingSide(
-              factionId: 'att', unitIds: ['a1', 'a2'], generalMedals: 0),
+            factionId: 'att',
+            unitIds: ['a1', 'a2'],
+            generalMedals: 0,
+          ),
         ],
         fortLevel: 0,
         terrain: 'plains',
@@ -295,206 +315,221 @@ void main() {
     });
 
     test(
-        'deployment limit caps participating regiments per side (base 10, no Nationalism)',
-        () {
-      // 15 attackers, 15 defenders; deployment limit 10 per side without Nationalism.
-      final attackerUnits = List.generate(
-        15,
-        (i) => Unit(
-          id: 'a$i',
-          type: 'grenadiers',
-          ownerId: 'att',
-          locationProvinceId: 'p',
-          medals: 1,
-        ),
-      );
-      final defenderUnits = List.generate(
-        15,
-        (i) => Unit(
-          id: 'd$i',
-          type: 'peasant_levies',
-          ownerId: 'def',
-          locationProvinceId: 'p',
-          medals: 0,
-        ),
-      );
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            provinces: const [
-              Province(id: 'p', regionId: 'oldWorld', ownerId: 'def')
-            ],
-            units: [...attackerUnits, ...defenderUnits],
+      'deployment limit caps participating regiments per side (base 10, no Nationalism)',
+      () {
+        // 15 attackers, 15 defenders; deployment limit 10 per side without Nationalism.
+        final attackerUnits = List.generate(
+          15,
+          (i) => Unit(
+            id: 'a$i',
+            type: 'grenadiers',
+            ownerId: 'att',
+            locationProvinceId: 'p',
+            medals: 1,
           ),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'att', displayName: 'Att', isHuman: true),
-          Player(id: 'def', displayName: 'Def', isHuman: false),
-        ],
-      );
-      final ctx = BattleContext(
-        provinceId: 'p',
-        regionId: 'oldWorld',
-        defenderFactionId: 'def',
-        defenderUnitIds: defenderUnits.map((u) => u.id).toList(),
-        attackers: [
-          AttackingSide(
-            factionId: 'att',
-            unitIds: attackerUnits.map((u) => u.id).toList(),
-            generalMedals: 0,
+        );
+        final defenderUnits = List.generate(
+          15,
+          (i) => Unit(
+            id: 'd$i',
+            type: 'peasant_levies',
+            ownerId: 'def',
+            locationProvinceId: 'p',
+            medals: 0,
           ),
-        ],
-        fortLevel: 0,
-        terrain: 'plains',
-      );
-      final result = resolveBattleContext(game, ctx);
-      final survivingAtt = result.worldState.oldWorld.units
-          .where((u) => u.ownerId == 'att')
-          .length;
-      final survivingDef = result.worldState.oldWorld.units
-          .where((u) => u.ownerId == 'def')
-          .length;
-      // Only 10 per side participate; so at least 5 attackers never participated and must survive.
-      expect(survivingAtt, greaterThanOrEqualTo(5),
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(id: 'p', regionId: 'oldWorld', ownerId: 'def'),
+              ],
+              units: [...attackerUnits, ...defenderUnits],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'att', displayName: 'Att', isHuman: true),
+            Player(id: 'def', displayName: 'Def', isHuman: false),
+          ],
+        );
+        final ctx = BattleContext(
+          provinceId: 'p',
+          regionId: 'oldWorld',
+          defenderFactionId: 'def',
+          defenderUnitIds: defenderUnits.map((u) => u.id).toList(),
+          attackers: [
+            AttackingSide(
+              factionId: 'att',
+              unitIds: attackerUnits.map((u) => u.id).toList(),
+              generalMedals: 0,
+            ),
+          ],
+          fortLevel: 0,
+          terrain: 'plains',
+        );
+        final result = resolveBattleContext(game, ctx);
+        final survivingAtt = result.worldState.oldWorld.units
+            .where((u) => u.ownerId == 'att')
+            .length;
+        final survivingDef = result.worldState.oldWorld.units
+            .where((u) => u.ownerId == 'def')
+            .length;
+        // Only 10 per side participate; so at least 5 attackers never participated and must survive.
+        expect(
+          survivingAtt,
+          greaterThanOrEqualTo(5),
           reason:
-              'deployment limit 10: at most 10 attackers participate, so ≥5 must remain');
-      // Defender had 15; at most 10 in engagement; so ≥5 defenders could survive if they win or stalemate.
-      expect(survivingAtt + survivingDef, greaterThanOrEqualTo(5),
-          reason: 'at least one side has non-participants');
-    });
+              'deployment limit 10: at most 10 attackers participate, so ≥5 must remain',
+        );
+        // Defender had 15; at most 10 in engagement; so ≥5 defenders could survive if they win or stalemate.
+        expect(
+          survivingAtt + survivingDef,
+          greaterThanOrEqualTo(5),
+          reason: 'at least one side has non-participants',
+        );
+      },
+    );
 
     test(
-        'deployment limit with Nationalism tech is 12 (attacker has 13 units, ≥1 does not participate)',
-        () {
-      final attackerUnits = List.generate(
-        13,
-        (i) => Unit(
-          id: 'a$i',
-          type: 'grenadiers',
-          ownerId: 'att',
-          locationProvinceId: 'p',
-          medals: 0,
-        ),
-      );
-      final defenderUnits = [
-        Unit(
+      'deployment limit with Nationalism tech is 12 (attacker has 13 units, ≥1 does not participate)',
+      () {
+        final attackerUnits = List.generate(
+          13,
+          (i) => Unit(
+            id: 'a$i',
+            type: 'grenadiers',
+            ownerId: 'att',
+            locationProvinceId: 'p',
+            medals: 0,
+          ),
+        );
+        final defenderUnits = [
+          Unit(
             id: 'd1',
             type: 'peasant_levies',
             ownerId: 'def',
             locationProvinceId: 'p',
-            medals: 0),
-      ];
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            provinces: const [
-              Province(id: 'p', regionId: 'oldWorld', ownerId: 'def')
-            ],
-            units: [...attackerUnits, ...defenderUnits],
+            medals: 0,
           ),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(
+        ];
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(id: 'p', regionId: 'oldWorld', ownerId: 'def'),
+              ],
+              units: [...attackerUnits, ...defenderUnits],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(
               id: 'att',
               displayName: 'Att',
               isHuman: true,
-              techUnlocked: {'nationalism': true}),
-          Player(id: 'def', displayName: 'Def', isHuman: false),
-        ],
-      );
-      final ctx = BattleContext(
-        provinceId: 'p',
-        regionId: 'oldWorld',
-        defenderFactionId: 'def',
-        defenderUnitIds: ['d1'],
-        attackers: [
-          AttackingSide(
-            factionId: 'att',
-            unitIds: attackerUnits.map((u) => u.id).toList(),
-            generalMedals: 0,
-          ),
-        ],
-        fortLevel: 0,
-        terrain: 'plains',
-      );
-      final result = resolveBattleContext(game, ctx);
-      final survivingAtt = result.worldState.oldWorld.units
-          .where((u) => u.ownerId == 'att')
-          .length;
-      // With Nationalism, limit 12; 13 attackers so ≥1 does not participate and must survive.
-      expect(survivingAtt, greaterThanOrEqualTo(1),
+              techUnlocked: {'nationalism': true},
+            ),
+            Player(id: 'def', displayName: 'Def', isHuman: false),
+          ],
+        );
+        final ctx = BattleContext(
+          provinceId: 'p',
+          regionId: 'oldWorld',
+          defenderFactionId: 'def',
+          defenderUnitIds: ['d1'],
+          attackers: [
+            AttackingSide(
+              factionId: 'att',
+              unitIds: attackerUnits.map((u) => u.id).toList(),
+              generalMedals: 0,
+            ),
+          ],
+          fortLevel: 0,
+          terrain: 'plains',
+        );
+        final result = resolveBattleContext(game, ctx);
+        final survivingAtt = result.worldState.oldWorld.units
+            .where((u) => u.ownerId == 'att')
+            .length;
+        // With Nationalism, limit 12; 13 attackers so ≥1 does not participate and must survive.
+        expect(
+          survivingAtt,
+          greaterThanOrEqualTo(1),
           reason:
-              'deployment limit 12 with Nationalism: at most 12 participate');
-    });
+              'deployment limit 12 with Nationalism: at most 12 participate',
+        );
+      },
+    );
 
-    test('assigned winning general gains +1 medal immediately and persists', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 5),
-          oldWorld: RegionData(
-            provinces: const [
-              Province(id: 'p', regionId: 'oldWorld', ownerId: 'def')
-            ],
-            units: [
-              Unit(
-                id: 'a1',
-                type: 'grenadiers',
-                ownerId: 'att',
-                locationProvinceId: 'p',
-              ),
-              Unit(
-                id: 'a2',
-                type: 'grenadiers',
-                ownerId: 'att',
-                locationProvinceId: 'p',
-              ),
-              Unit(
-                id: 'd1',
-                type: 'peasant_levies',
-                ownerId: 'def',
-                locationProvinceId: 'p',
-              ),
-            ],
+    test(
+      'assigned winning general gains +1 medal immediately and persists',
+      () {
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 5),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(id: 'p', regionId: 'oldWorld', ownerId: 'def'),
+              ],
+              units: [
+                Unit(
+                  id: 'a1',
+                  type: 'grenadiers',
+                  ownerId: 'att',
+                  locationProvinceId: 'p',
+                ),
+                Unit(
+                  id: 'a2',
+                  type: 'grenadiers',
+                  ownerId: 'att',
+                  locationProvinceId: 'p',
+                ),
+                Unit(
+                  id: 'd1',
+                  type: 'peasant_levies',
+                  ownerId: 'def',
+                  locationProvinceId: 'p',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
           ),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'att', displayName: 'Att', isHuman: true),
-          Player(id: 'def', displayName: 'Def', isHuman: true),
-        ],
-        generals: const [
-          General(id: 'g-att', ownerId: 'att', medals: 1),
-        ],
-      );
-      const ctx = BattleContext(
-        provinceId: 'p',
-        regionId: 'oldWorld',
-        defenderFactionId: 'def',
-        defenderUnitIds: ['d1'],
-        attackers: [
-          AttackingSide(
-            factionId: 'att',
-            unitIds: ['a1', 'a2'],
-            generalId: 'g-att',
-            generalMedals: 1,
-          ),
-        ],
-        fortLevel: 0,
-        terrain: 'plains',
-      );
+          players: const [
+            Player(id: 'att', displayName: 'Att', isHuman: true),
+            Player(id: 'def', displayName: 'Def', isHuman: true),
+          ],
+          generals: const [General(id: 'g-att', ownerId: 'att', medals: 1)],
+        );
+        const ctx = BattleContext(
+          provinceId: 'p',
+          regionId: 'oldWorld',
+          defenderFactionId: 'def',
+          defenderUnitIds: ['d1'],
+          attackers: [
+            AttackingSide(
+              factionId: 'att',
+              unitIds: ['a1', 'a2'],
+              generalId: 'g-att',
+              generalMedals: 1,
+            ),
+          ],
+          fortLevel: 0,
+          terrain: 'plains',
+        );
 
-      final after = resolveBattleContext(game, ctx);
-      final updatedGeneral =
-          after.generals.firstWhere((g) => g.id == 'g-att');
-      expect(updatedGeneral.medals, 2);
-    });
+        final after = resolveBattleContext(game, ctx);
+        final updatedGeneral = after.generals.firstWhere(
+          (g) => g.id == 'g-att',
+        );
+        expect(updatedGeneral.medals, 2);
+      },
+    );
 
     test('leader fallback medals apply when no uncommitted general exists', () {
       final game = Game(
@@ -503,7 +538,7 @@ void main() {
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
           oldWorld: RegionData(
             provinces: const [
-              Province(id: 'p', regionId: 'oldWorld', ownerId: 'def')
+              Province(id: 'p', regionId: 'oldWorld', ownerId: 'def'),
             ],
             units: [
               Unit(
@@ -556,7 +591,7 @@ void main() {
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 6),
           oldWorld: RegionData(
             provinces: const [
-              Province(id: 'p', regionId: 'oldWorld', ownerId: 'def')
+              Province(id: 'p', regionId: 'oldWorld', ownerId: 'def'),
             ],
             units: [
               Unit(
@@ -585,9 +620,7 @@ void main() {
           Player(id: 'att', displayName: 'Att', isHuman: true),
           Player(id: 'def', displayName: 'Def', isHuman: true),
         ],
-        generals: const [
-          General(id: 'g-att', ownerId: 'att', medals: 4),
-        ],
+        generals: const [General(id: 'g-att', ownerId: 'att', medals: 4)],
       );
       const ctx = BattleContext(
         provinceId: 'p',
@@ -601,51 +634,49 @@ void main() {
         terrain: 'plains',
       );
       final after = resolveBattleContext(game, ctx);
-      final updatedGeneral =
-          after.generals.firstWhere((g) => g.id == 'g-att');
+      final updatedGeneral = after.generals.firstWhere((g) => g.id == 'g-att');
       expect(updatedGeneral.medals, 4);
     });
 
     test('battle tie-break is deterministic for same seed and context', () {
       final makeGame = () => Game(
-            id: 'g1',
-            globalGameSeed: 1234,
-            worldState: WorldState(
-              turnState:
-                  const TurnState(phase: TurnPhase.orders, turnNumber: 8),
-              oldWorld: RegionData(
-                provinces: const [
-                  Province(id: 'p', regionId: 'oldWorld', ownerId: 'def'),
-                ],
-                units: [
-                  Unit(
-                    id: 'a1',
-                    type: 'pikemen',
-                    ownerId: 'attA',
-                    locationProvinceId: 'p',
-                  ),
-                  Unit(
-                    id: 'a2',
-                    type: 'pikemen',
-                    ownerId: 'attB',
-                    locationProvinceId: 'p',
-                  ),
-                  Unit(
-                    id: 'd1',
-                    type: 'pikemen',
-                    ownerId: 'def',
-                    locationProvinceId: 'p',
-                  ),
-                ],
-              ),
-              newWorld: const RegionData(),
-            ),
-            players: const [
-              Player(id: 'attA', displayName: 'A', isHuman: true),
-              Player(id: 'attB', displayName: 'B', isHuman: true),
-              Player(id: 'def', displayName: 'D', isHuman: true),
+        id: 'g1',
+        globalGameSeed: 1234,
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 8),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'p', regionId: 'oldWorld', ownerId: 'def'),
             ],
-          );
+            units: [
+              Unit(
+                id: 'a1',
+                type: 'pikemen',
+                ownerId: 'attA',
+                locationProvinceId: 'p',
+              ),
+              Unit(
+                id: 'a2',
+                type: 'pikemen',
+                ownerId: 'attB',
+                locationProvinceId: 'p',
+              ),
+              Unit(
+                id: 'd1',
+                type: 'pikemen',
+                ownerId: 'def',
+                locationProvinceId: 'p',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'attA', displayName: 'A', isHuman: true),
+          Player(id: 'attB', displayName: 'B', isHuman: true),
+          Player(id: 'def', displayName: 'D', isHuman: true),
+        ],
+      );
       const ctx = BattleContext(
         provinceId: 'p',
         regionId: 'oldWorld',
@@ -661,9 +692,233 @@ void main() {
 
       final r1 = resolveBattleContext(makeGame(), ctx);
       final r2 = resolveBattleContext(makeGame(), ctx);
-      expect(r1.worldState.oldWorld.provinces, r2.worldState.oldWorld.provinces);
+      expect(
+        r1.worldState.oldWorld.provinces,
+        r2.worldState.oldWorld.provinces,
+      );
       expect(r1.worldState.oldWorld.units, r2.worldState.oldWorld.units);
       expect(r1.generals, r2.generals);
+    });
+
+    group('mutual annihilation garrison recovery type', () {
+      test(
+        'great power defender: recovered regiments match most-advanced infantry era 4',
+        () {
+          const provinceId = 'ma_gp';
+          final game = Game(
+            id: 'g1',
+            worldState: WorldState(
+              turnState: const TurnState(
+                phase: TurnPhase.orders,
+                turnNumber: 1,
+              ),
+              oldWorld: RegionData(
+                provinces: const [
+                  Province(
+                    id: provinceId,
+                    regionId: 'oldWorld',
+                    ownerId: 'def',
+                  ),
+                ],
+                units: [
+                  Unit(
+                    id: 'aStrong',
+                    type: 'rifle_infantry',
+                    ownerId: 'att1',
+                    locationProvinceId: provinceId,
+                  ),
+                  Unit(
+                    id: 'aWeak',
+                    type: 'peasant_levies',
+                    ownerId: 'att2',
+                    locationProvinceId: provinceId,
+                  ),
+                  Unit(
+                    id: 'd1',
+                    type: 'guards',
+                    ownerId: 'def',
+                    locationProvinceId: provinceId,
+                  ),
+                ],
+              ),
+              newWorld: const RegionData(),
+            ),
+            players: const [
+              Player(id: 'att1', displayName: 'A1', isHuman: true),
+              Player(id: 'att2', displayName: 'A2', isHuman: true),
+              Player(id: 'def', displayName: 'Def', isHuman: true),
+            ],
+          );
+          final ctx = BattleContext(
+            provinceId: provinceId,
+            regionId: 'oldWorld',
+            defenderFactionId: 'def',
+            defenderUnitIds: const ['d1'],
+            attackers: const [
+              AttackingSide(
+                factionId: 'att1',
+                unitIds: ['aStrong'],
+                generalMedals: 1,
+              ),
+              AttackingSide(factionId: 'att2', unitIds: ['aWeak']),
+            ],
+            fortLevel: 0,
+            terrain: 'plains',
+          );
+          final after = resolveBattleContext(game, ctx);
+          final expected = garrisonRecoveryRegimentTypeForEra(4);
+          final recovered = after.worldState.oldWorld.units
+              .where((u) => u.id.startsWith('recover_'))
+              .toList();
+          expect(recovered, isNotEmpty);
+          for (final u in recovered) {
+            expect(u.type, expected);
+          }
+        },
+      );
+
+      test(
+        'minor nation effective era 3: recovered regiments are grenadiers',
+        () {
+          const provinceId = 'ma_minor';
+          final game = Game(
+            id: 'g1',
+            minorNations: const [
+              MinorNation(id: 'minor1', effectiveMilitaryLevel: 3),
+            ],
+            worldState: WorldState(
+              turnState: const TurnState(
+                phase: TurnPhase.orders,
+                turnNumber: 2,
+              ),
+              oldWorld: RegionData(
+                provinces: const [
+                  Province(
+                    id: provinceId,
+                    regionId: 'oldWorld',
+                    ownerId: 'minor1',
+                  ),
+                ],
+                units: [
+                  Unit(
+                    id: 'aStrong',
+                    type: 'regulars',
+                    ownerId: 'att1',
+                    locationProvinceId: provinceId,
+                  ),
+                  Unit(
+                    id: 'aWeak',
+                    type: 'peasant_levies',
+                    ownerId: 'att2',
+                    locationProvinceId: provinceId,
+                  ),
+                  Unit(
+                    id: 'd1',
+                    type: 'grenadiers',
+                    ownerId: 'minor1',
+                    locationProvinceId: provinceId,
+                  ),
+                ],
+              ),
+              newWorld: const RegionData(),
+            ),
+            players: const [
+              Player(id: 'att1', displayName: 'A1', isHuman: true),
+              Player(id: 'att2', displayName: 'A2', isHuman: true),
+            ],
+          );
+          final ctx = BattleContext(
+            provinceId: provinceId,
+            regionId: 'oldWorld',
+            defenderFactionId: 'minor1',
+            defenderUnitIds: const ['d1'],
+            attackers: const [
+              AttackingSide(
+                factionId: 'att1',
+                unitIds: ['aStrong'],
+                generalMedals: 1,
+              ),
+              AttackingSide(factionId: 'att2', unitIds: ['aWeak']),
+            ],
+            fortLevel: 0,
+            terrain: 'plains',
+          );
+          final after = resolveBattleContext(game, ctx);
+          expect(garrisonRecoveryRegimentTypeForEra(3), 'grenadiers');
+          final recovered = after.worldState.oldWorld.units
+              .where((u) => u.id.startsWith('recover_'))
+              .toList();
+          expect(recovered, isNotEmpty);
+          for (final u in recovered) {
+            expect(u.type, 'grenadiers');
+          }
+        },
+      );
+
+      test('tribe effective era 1: recovered regiments are arquebusiers', () {
+        const provinceId = 'ma_tribe';
+        final game = Game(
+          id: 'g1',
+          tribes: const [Tribe(id: 'tr1')],
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(id: provinceId, regionId: 'oldWorld', ownerId: 'tr1'),
+              ],
+              units: [
+                Unit(
+                  id: 'aStrong',
+                  type: 'bowmen',
+                  ownerId: 'att1',
+                  locationProvinceId: provinceId,
+                ),
+                Unit(
+                  id: 'aWeak',
+                  type: 'peasant_levies',
+                  ownerId: 'att2',
+                  locationProvinceId: provinceId,
+                ),
+                Unit(
+                  id: 'd1',
+                  type: 'pikemen',
+                  ownerId: 'tr1',
+                  locationProvinceId: provinceId,
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'att1', displayName: 'A1', isHuman: true),
+            Player(id: 'att2', displayName: 'A2', isHuman: true),
+          ],
+        );
+        final ctx = BattleContext(
+          provinceId: provinceId,
+          regionId: 'oldWorld',
+          defenderFactionId: 'tr1',
+          defenderUnitIds: const ['d1'],
+          attackers: const [
+            AttackingSide(
+              factionId: 'att1',
+              unitIds: ['aStrong'],
+              generalMedals: 1,
+            ),
+            AttackingSide(factionId: 'att2', unitIds: ['aWeak']),
+          ],
+          fortLevel: 0,
+          terrain: 'plains',
+        );
+        final after = resolveBattleContext(game, ctx);
+        final recovered = after.worldState.oldWorld.units
+            .where((u) => u.id.startsWith('recover_'))
+            .toList();
+        expect(recovered, isNotEmpty);
+        for (final u in recovered) {
+          expect(u.type, 'arquebusiers');
+        }
+      });
     });
   });
 
@@ -701,9 +956,7 @@ void main() {
             'att': {tileKey: 'fullyVisible'},
           },
           spyRevealTurnsByPlayer: const {
-            'att': {
-              provinceId: 3,
-            },
+            'att': {provinceId: 3},
           },
           tileKeysByRegionAndProvince: const {
             ow: {
@@ -723,11 +976,7 @@ void main() {
         defenderFactionId: 'def',
         defenderUnitIds: ['def1'],
         attackers: [
-          AttackingSide(
-            factionId: 'att',
-            unitIds: ['att1'],
-            generalMedals: 0,
-          ),
+          AttackingSide(factionId: 'att', unitIds: ['att1'], generalMedals: 0),
         ],
         fortLevel: 0,
         terrain: 'plains',
@@ -755,10 +1004,7 @@ void main() {
       final game = Game(
         id: 'g1',
         worldState: WorldState(
-          turnState: const TurnState(
-            phase: TurnPhase.orders,
-            turnNumber: 1,
-          ),
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
           oldWorld: RegionData(
             provinces: const [
               Province(id: provinceId, regionId: ow, ownerId: 'minor1'),
@@ -779,17 +1025,13 @@ void main() {
             ],
           ),
           newWorld: const RegionData(),
-          purchasedTilesByTileKey: const {
-            tileKey: 'gp1',
-          },
+          purchasedTilesByTileKey: const {tileKey: 'gp1'},
         ),
         players: const [
           Player(id: 'gp1', displayName: 'Investor', isHuman: true),
           Player(id: 'gp2', displayName: 'Aggressor', isHuman: false),
         ],
-        minorNations: const [
-          MinorNation(id: 'minor1', displayName: 'Minor 1'),
-        ],
+        minorNations: const [MinorNation(id: 'minor1', displayName: 'Minor 1')],
       );
 
       const ctx = BattleContext(
@@ -798,11 +1040,7 @@ void main() {
         defenderFactionId: 'minor1',
         defenderUnitIds: ['def1'],
         attackers: [
-          AttackingSide(
-            factionId: 'gp2',
-            unitIds: ['att1'],
-            generalMedals: 0,
-          ),
+          AttackingSide(factionId: 'gp2', unitIds: ['att1'], generalMedals: 0),
         ],
         fortLevel: 0,
         terrain: 'plains',
@@ -819,17 +1057,25 @@ void main() {
       );
     });
 
-    test('general medals provide morale aura bonus (5% per medal, max 20%)',
-        () {
-      expect(moraleMultiplierForGeneralMedals(0), 1.0);
-      expect(moraleMultiplierForGeneralMedals(1), 1.05);
-      expect(moraleMultiplierForGeneralMedals(2), 1.10);
-      expect(moraleMultiplierForGeneralMedals(3), 1.15);
-      expect(moraleMultiplierForGeneralMedals(4), 1.20);
-      expect(moraleMultiplierForGeneralMedals(5), 1.20,
-          reason: 'capped at 4 medals');
-      expect(moraleMultiplierForGeneralMedals(-1), 1.0,
-          reason: 'negative clamped to 0');
-    });
+    test(
+      'general medals provide morale aura bonus (5% per medal, max 20%)',
+      () {
+        expect(moraleMultiplierForGeneralMedals(0), 1.0);
+        expect(moraleMultiplierForGeneralMedals(1), 1.05);
+        expect(moraleMultiplierForGeneralMedals(2), 1.10);
+        expect(moraleMultiplierForGeneralMedals(3), 1.15);
+        expect(moraleMultiplierForGeneralMedals(4), 1.20);
+        expect(
+          moraleMultiplierForGeneralMedals(5),
+          1.20,
+          reason: 'capped at 4 medals',
+        );
+        expect(
+          moraleMultiplierForGeneralMedals(-1),
+          1.0,
+          reason: 'negative clamped to 0',
+        );
+      },
+    );
   });
 }

--- a/packages/colonizethis_logic/test/combat_resolver_test.dart
+++ b/packages/colonizethis_logic/test/combat_resolver_test.dart
@@ -701,6 +701,9 @@ void main() {
     });
 
     group('mutual annihilation garrison recovery type', () {
+      // A second attacker with no unitIds keeps remainingAttackers non-empty
+      // (recovery triggers) while the resolver skips a follow-up engagement so
+      // recover_* units are not fought again in the same context.
       test(
         'great power defender: recovered regiments match most-advanced infantry era 4',
         () {
@@ -725,12 +728,6 @@ void main() {
                     id: 'aStrong',
                     type: 'rifle_infantry',
                     ownerId: 'att1',
-                    locationProvinceId: provinceId,
-                  ),
-                  Unit(
-                    id: 'aWeak',
-                    type: 'peasant_levies',
-                    ownerId: 'att2',
                     locationProvinceId: provinceId,
                   ),
                   Unit(
@@ -760,7 +757,7 @@ void main() {
                 unitIds: ['aStrong'],
                 generalMedals: 1,
               ),
-              AttackingSide(factionId: 'att2', unitIds: ['aWeak']),
+              AttackingSide(factionId: 'att2', unitIds: []),
             ],
             fortLevel: 0,
             terrain: 'plains',
@@ -807,12 +804,6 @@ void main() {
                     locationProvinceId: provinceId,
                   ),
                   Unit(
-                    id: 'aWeak',
-                    type: 'peasant_levies',
-                    ownerId: 'att2',
-                    locationProvinceId: provinceId,
-                  ),
-                  Unit(
                     id: 'd1',
                     type: 'grenadiers',
                     ownerId: 'minor1',
@@ -838,7 +829,7 @@ void main() {
                 unitIds: ['aStrong'],
                 generalMedals: 1,
               ),
-              AttackingSide(factionId: 'att2', unitIds: ['aWeak']),
+              AttackingSide(factionId: 'att2', unitIds: []),
             ],
             fortLevel: 0,
             terrain: 'plains',
@@ -874,12 +865,6 @@ void main() {
                   locationProvinceId: provinceId,
                 ),
                 Unit(
-                  id: 'aWeak',
-                  type: 'peasant_levies',
-                  ownerId: 'att2',
-                  locationProvinceId: provinceId,
-                ),
-                Unit(
                   id: 'd1',
                   type: 'pikemen',
                   ownerId: 'tr1',
@@ -905,7 +890,7 @@ void main() {
               unitIds: ['aStrong'],
               generalMedals: 1,
             ),
-            AttackingSide(factionId: 'att2', unitIds: ['aWeak']),
+            AttackingSide(factionId: 'att2', unitIds: []),
           ],
           fortLevel: 0,
           terrain: 'plains',


### PR DESCRIPTION
## Summary

Implements mutual-annihilation garrison **regiment type** selection: defender effective-era infantry with maximum `FPN + FPM`, lexicographic `id` tie-break, `peasant_levies` fallback. Updates GDD/TDD specs and ACs; adds `garrisonRecoveryRegimentTypeForEra` in `combat_config.dart`; `resolveBattleContext` spawns uniform `recover_*` units.

## Testing

- `dart test packages/colonizethis_data/test/combat_config_test.dart`
- `dart test packages/colonizethis_logic/test/combat_resolver_test.dart` (includes new mutual-annihilation recovery group)

## Issue

Refs #1283 (does **not** close).

Made with [Cursor](https://cursor.com)