### PR TITLE
docs(spec): align naval interception MVP constants and ACs

### DIFF
--- a/SPEC/game/ships-and-naval.md
+++ b/SPEC/game/ships-and-naval.md
@@ -214,6 +214,10 @@ missionFactor = 0.5 for Patrol, 0.9 for Blockade
 interceptChance = clamp(missionFactor × ratio, 0.05, 0.85)
 ```
 
+MVP contract: these interception factors are hardcoded in logic (`patrol=0.5`, `blockade=0.9`, clamp `0.05..0.85`) and are not loaded from ruleset configuration.
+
+Interception tech/composition bonus is not applied as a separate path in MVP; this is deferred.
+
 
 ---
 
@@ -248,6 +252,8 @@ civilianPenalty = 2.0 # Civilian ships twice as vulnerable
 raidEfficiency = 0.3 to 0.7 depending on relative strength
 ```
 
+MVP contract: trade/transport interception uses hardcoded constants in logic for these terms (including civilian penalty and raid-efficiency bounds), not ruleset-config values.
+
 ---
 
 ## Acceptance Criteria
@@ -279,6 +285,10 @@ raidEfficiency = 0.3 to 0.7 depending on relative strength
 - Given a Great Power’s home fleet (in port at the capital) carries overseas cargo during Extraction/Trade and hostile fleets **at sea** at war with that Great Power are patrolling or blockading relevant sea zones  
   When the System resolves overseas transport and trade for that turn  
   Then the System uses the interception probabilities and escort protection formulas in this document (including the definitions of `escortStrength` and `cargoStrength`) to determine whether cargo and civilian ships are lost, reduces delivered quantities and ship counts accordingly, and applies at most the documented maximum loss reduction from escorts.
+
+- Given naval interception probability is resolved in MVP for identical fleet stats and identical seed  
+  When the System evaluates mission-based interception and trade/transport interception  
+  Then the System uses the hardcoded constants documented in this specification, performs no ruleset lookup for those constants, applies no separate interception tech/composition bonus path, and returns deterministic outputs.
 
 - Given the global tech catalog’s `shipUnlockIds` lists and the ship build economy table in this document  
   When the System loads ship build data  

--- a/SPEC/program/naval-movement-resolution.md
+++ b/SPEC/program/naval-movement-resolution.md
@@ -40,7 +40,14 @@ Only fleets **at sea** on Patrol or Blockade mission participate. For each such 
 5. `P_intercept = clamp(missionFactor × ratio, 0.05, 0.85)`.
 6. On success, create a BattleContextSea and invoke [naval-combat-resolution.md](naval-combat-resolution.md).
 
-Exact numeric values in ruleset config; formula shape: mission factor × relative strength × tech/composition.
+For MVP, interception uses hardcoded constants in logic code (no ruleset lookup):
+
+- Patrol mission factor: `0.5` (`kNavalInterceptMissionFactorPatrol`).
+- Blockade mission factor: `0.9` (`kNavalInterceptMissionFactorBlockade`).
+- Clamp bounds: `[0.05, 0.85]`.
+- Formula: `P_intercept = clamp(missionFactor × ratio, 0.05, 0.85)`.
+
+No additional interception tech/composition bonus path is applied in MVP; any such bonus is deferred.
 
 **Trade/Transport Interception:**
 
@@ -52,6 +59,16 @@ During Extraction/Trade phase, overseas cargo on home-fleet ships may be raided.
 4. `P_cargo_intercept = clamp(1.2 × base × (1 - escortFactor), 0.1, 0.9)`.
 5. `P_ship_sunk = clamp(0.4 × base × (1 - escortFactor), 0.02, 0.5)`.
 6. Reduce delivered quantities; remove sunk merchant ships from home fleet.
+
+For MVP, trade/transport interception also uses hardcoded constants in logic code (no ruleset lookup), including:
+
+- `civilianTargetBonus = 1.25`
+- `actionFactorPatrol = 0.5`
+- `blockadeBonusFactor = 1.5`
+- `escortFactorMax = 0.5`
+- `escortStrengthWeight = 0.3`
+- `civilianShipLossPenalty = 2.0`
+- `raidEfficiencyMin = 0.3`, `raidEfficiencyMax = 0.7`
 
 **Join home fleet:**
 
@@ -75,3 +92,17 @@ BuildUnitOrder for naval type; spawns in home fleet (in port at capital). Costs 
 - Deterministic for a given seed.
 - S↔S topology edges required from map generation.
 - Owned by colonizethis_logic; numeric config from colonizethis_data.
+
+## Acceptance Criteria
+
+- Given naval interception probability is computed for a fleet on `patrol` or `blockade` with fixed intercept and flee scores  
+  When the System resolves interception in MVP  
+  Then the System uses hardcoded mission factors (`patrol=0.5`, `blockade=0.9`) and computes `P_intercept = clamp(missionFactor × ratio, 0.05, 0.85)` with no ruleset lookup.
+
+- Given interception modifiers are evaluated in MVP  
+  When the System computes interception probability for fleet movement resolution  
+  Then the System does not apply any separate interception tech/composition bonus path, and treats those bonuses as deferred behavior.
+
+- Given trade/transport interception runs during Extraction/Trade for fixed seed and identical game state  
+  When the System applies cargo and ship-loss reduction formulas  
+  Then the System uses documented named code constants (including `civilianTargetBonus`, mission factors, escort constants, and raid-efficiency bounds) and produces deterministic outputs.


### PR DESCRIPTION
## Summary
- Align `SPEC/program/naval-movement-resolution.md` with current MVP behavior: naval interception and trade/transport interception use hardcoded named constants (no ruleset lookup).
- Clarify that separate interception tech/composition bonus behavior is deferred for MVP.
- Add explicit Given–When–Then ACs for deterministic, constant-based interception behavior and keep `SPEC/game/ships-and-naval.md` wording consistent.

Closes #1285.

## Test plan
- [x] Manual SPEC review for consistency between `SPEC/program/naval-movement-resolution.md` and `SPEC/game/ships-and-naval.md`
- [x] Confirm only spec docs changed (`git diff`)

Made with [Cursor](https://cursor.com)