### PR TITLE
Sea zone detail overlay: fog parity for display names

### DIFF
--- a/SPEC/ui/province-sea-zone-detail-overlay.md
+++ b/SPEC/ui/province-sea-zone-detail-overlay.md
@@ -73,7 +73,7 @@ Non-Material, pixel-art friendly: `CtPanel`, `CtTabStrip`, explicit text styles 
 
 **Political / Economic / Naval:** Owner, **province resources** listed with **icon + id** per commodity label rule (see [pixel-art-ui-catalog.md](pixel-art-ui-catalog.md)), prospects, improvements, fleets in port (see game specs). List hover → **`secondaryHighlightTileKey`** via callback (no overlay↔map import).
 
-**Sea zone:** Political + Naval (fleets in zone). Political name must use sea-zone display name from world state (keyed by prefixed sea-zone id), not raw ids; if missing, fallback to id is allowed only as a defensive legacy path.
+**Sea zone:** Political + Naval (fleets in zone). **Player-view / fog parity:** if **every** sea tile in that zone in `RegionMapViewData` is `TileVisibility.unrevealed` for the human player, Political and Naval mirror fully unrevealed provinces (`???`); **do not** show canonical `seaZoneDisplayNameById` text until at least one water tile in the zone is not unrevealed (see [fog-and-exploration.md](../game/fog-and-exploration.md)). Otherwise, Political uses the sea-zone display name from world state (keyed by prefixed sea-zone id), not raw ids; if missing, fallback to id is allowed only as a defensive legacy path.
 
 ---
 
@@ -84,7 +84,8 @@ Non-Material, pixel-art friendly: `CtPanel`, `CtTabStrip`, explicit text styles 
 - Narrow full-width: max height ≤ `third` when parent does not already cap. Bottom slot height `third`: no overflow; tabs scroll. Narrow side rail: full rail height allowed. Desktop: side panel, scrollable.
 - Economic row hover updates `secondaryHighlightTileKey` and a non-orange map outline. Close sets `overlayOpen` false; tile tap may reopen.
 - Unrevealed / fully unrevealed province: `???` obfuscation per player view (unchanged).
-- Sea-zone political header text uses sea-zone display name from world-state sea-zone naming data for the selected prefixed sea-zone id (with raw id only as defensive fallback for legacy/missing data).
+- Fully unrevealed sea zone (all sea tiles in zone unrevealed in map view data): Political and Naval `???`; no preset sea-zone display name until partial reveal.
+- When at least one sea tile in the zone is not unrevealed: sea-zone political header uses world-state display name for the selected prefixed sea-zone id (raw id only as defensive fallback for legacy/missing data).
 
 ### Widgetbook
 
@@ -98,3 +99,4 @@ Map stories use `onMapTileTappedForDetail` and passed-in keys from demo/override
 - **Provider:** `mapProvincePanelProvider` in app; see TDD for app state if split.
 - **PlayerView:** `GameMapArea` builds with `buildPlayerView` + combined topology and passes through `GameMapCanvasStack` → `GameMapProvinceDetailSidePanel` / `GameMapNarrowDetailOverlaySlot` into `ProvinceSeaZoneDetailOverlay`.
 - **Ships in port:** colonizethis_logic helpers as before.
+- **Other `seaZoneDisplayName` call sites (audit):** Naval/military panels and fleet dialogs label zones for **own-fleet / own-port** flows and topology-adjacent move targets; they do not receive `RegionMapViewData` today. Map **detail overlay** was the surface leaking preset names without any revealed water in the zone. If [fog-and-exploration.md](../game/fog-and-exploration.md) later requires name obfuscation for adjacent-move or unit-panel labels, extend those widgets with the same visibility predicate and SPEC updates.

--- a/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
+++ b/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
@@ -550,6 +550,38 @@ _OverlayContent _seaZoneContent({
       .where((f) => f.regionId == regionId && f.seaZoneId == localSeaZoneId)
       .toList();
 
+  final isSeaZoneFullyUnrevealed =
+      region.regionId == regionId &&
+      !region.cells.any(
+        (c) =>
+            c.isSea &&
+            c.regionCellId == localSeaZoneId &&
+            c.visibility != TileVisibility.unrevealed,
+      );
+  if (isSeaZoneFullyUnrevealed) {
+    const tabLabels = ['Political', 'Naval'];
+    final politicalObs = _buildSection('Political', const Text('???'));
+    final navalObs = _buildSection('Naval', const Text('???'));
+    const sections = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text('Political', style: TextStyle(fontWeight: FontWeight.bold)),
+        SizedBox(height: 4),
+        Text('???'),
+        SizedBox(height: 12),
+        Text('Naval', style: TextStyle(fontWeight: FontWeight.bold)),
+        SizedBox(height: 4),
+        Text('???'),
+      ],
+    );
+    return _OverlayContent(
+      tabLabels: tabLabels,
+      tabViews: [politicalObs, navalObs],
+      sections: sections,
+    );
+  }
+
   final seaName = seaZoneDisplayName(
     game: game,
     regionId: regionId,

--- a/app/test/province_overlay_test.dart
+++ b/app/test/province_overlay_test.dart
@@ -180,6 +180,178 @@ void main() {
       expect(find.text('Sea zone: Named Test Sea'), findsOneWidget);
     });
 
+    testWidgets(
+      'AC: sea zone hides canonical name when all sea tiles in zone are unrevealed',
+      (WidgetTester tester) async {
+        const tinyPngBase64 =
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=';
+        final tinyPng = Uint8List.fromList(base64Decode(tinyPngBase64));
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMessageHandler('flutter/assets', (message) async {
+              final key = const StringCodec().decodeMessage(message);
+              if (key == 'assets/images/ui_button_nine_patch.png') {
+                return ByteData.view(tinyPng.buffer);
+              }
+              return null;
+            });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMessageHandler('flutter/assets', null);
+        });
+
+        final baseRegion = demoRegionForOverlay;
+        final cells = baseRegion.cells
+            .map(
+              (c) => CellViewData(
+                x: c.x,
+                y: c.y,
+                regionCellId: c.regionCellId,
+                isSea: c.isSea,
+                terrainTypeId: c.terrainTypeId,
+                terrainType: c.terrainType,
+                resourceId: c.resourceId,
+                ownerFactionId: c.ownerFactionId,
+                provinceDisplayName: c.provinceDisplayName,
+                improvementLevel: c.improvementLevel,
+                roadLevel: c.roadLevel,
+                visibility: TileVisibility.unrevealed,
+              ),
+            )
+            .toList();
+        final region = RegionMapViewData(
+          regionId: baseRegion.regionId,
+          width: baseRegion.width,
+          height: baseRegion.height,
+          cellSize: baseRegion.cellSize,
+          cells: cells,
+          capitalMarkers: baseRegion.capitalMarkers,
+          portMarkers: baseRegion.portMarkers,
+          factionColors: baseRegion.factionColors,
+          greatPowerFactionIds: baseRegion.greatPowerFactionIds,
+          terrainColors: baseRegion.terrainColors,
+          unitMarkers: baseRegion.unitMarkers,
+        );
+
+        final game = demoGameForOverlay;
+        final named = game.copyWith(
+          worldState: game.worldState.copyWith(
+            seaZoneDisplayNameById: {
+              sampleSeaZoneIdForOverlay: 'Named Test Sea',
+            },
+          ),
+        );
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: ProvinceSeaZoneDetailOverlay(
+                game: named,
+                region: region,
+                displayId: sampleSeaZoneIdForOverlay,
+                selectedTileKey: null,
+                humanPlayerId: named.players.first.id,
+                playerView: demoHumanPlayerViewForOverlay,
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('Named Test Sea'), findsNothing);
+        expect(find.textContaining('Sea zone:'), findsNothing);
+        expect(find.text('???'), findsWidgets);
+      },
+    );
+
+    testWidgets(
+      'AC: sea zone shows display name when at least one sea tile in zone is fogged',
+      (WidgetTester tester) async {
+        const tinyPngBase64 =
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=';
+        final tinyPng = Uint8List.fromList(base64Decode(tinyPngBase64));
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMessageHandler('flutter/assets', (message) async {
+              final key = const StringCodec().decodeMessage(message);
+              if (key == 'assets/images/ui_button_nine_patch.png') {
+                return ByteData.view(tinyPng.buffer);
+              }
+              return null;
+            });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMessageHandler('flutter/assets', null);
+        });
+
+        final baseRegion = demoRegionForOverlay;
+        final seaPrefixed = sampleSeaZoneIdForOverlay;
+        final seaParts = seaPrefixed.split('|');
+        final localSea = seaParts.length >= 2
+            ? seaParts.sublist(1).join('|')
+            : seaPrefixed;
+        var revealOneSeaInZone = true;
+        final cells = baseRegion.cells.map((c) {
+          final inZone = c.isSea && c.regionCellId == localSea;
+          var visibility = TileVisibility.unrevealed;
+          if (inZone && revealOneSeaInZone) {
+            revealOneSeaInZone = false;
+            visibility = TileVisibility.fogged;
+          }
+          return CellViewData(
+            x: c.x,
+            y: c.y,
+            regionCellId: c.regionCellId,
+            isSea: c.isSea,
+            terrainTypeId: c.terrainTypeId,
+            terrainType: c.terrainType,
+            resourceId: c.resourceId,
+            ownerFactionId: c.ownerFactionId,
+            provinceDisplayName: c.provinceDisplayName,
+            improvementLevel: c.improvementLevel,
+            roadLevel: c.roadLevel,
+            visibility: visibility,
+          );
+        }).toList();
+        final region = RegionMapViewData(
+          regionId: baseRegion.regionId,
+          width: baseRegion.width,
+          height: baseRegion.height,
+          cellSize: baseRegion.cellSize,
+          cells: cells,
+          capitalMarkers: baseRegion.capitalMarkers,
+          portMarkers: baseRegion.portMarkers,
+          factionColors: baseRegion.factionColors,
+          greatPowerFactionIds: baseRegion.greatPowerFactionIds,
+          terrainColors: baseRegion.terrainColors,
+          unitMarkers: baseRegion.unitMarkers,
+        );
+
+        final game = demoGameForOverlay;
+        final named = game.copyWith(
+          worldState: game.worldState.copyWith(
+            seaZoneDisplayNameById: {
+              sampleSeaZoneIdForOverlay: 'Named Test Sea',
+            },
+          ),
+        );
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: ProvinceSeaZoneDetailOverlay(
+                game: named,
+                region: region,
+                displayId: sampleSeaZoneIdForOverlay,
+                selectedTileKey: null,
+                humanPlayerId: named.players.first.id,
+                playerView: demoHumanPlayerViewForOverlay,
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Sea zone: Named Test Sea'), findsOneWidget);
+      },
+    );
+
     testWidgets('AC: Close button invokes onClose', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
## Summary

The province/sea zone detail overlay now hides preset sea-zone display names until the human player has at least one **non–unrevealed** water tile in that zone (per `RegionMapViewData`), matching fully unrevealed province behavior (`???` for Political and Naval).

## Spec / tests

- Updated `SPEC/ui/province-sea-zone-detail-overlay.md` (fog parity, acceptance criteria, audit note for other `seaZoneDisplayName` call sites).
- Extended `app/test/province_overlay_test.dart` with widget tests for fully unrevealed vs partially revealed (fogged) sea zones.

## Issue

Refs #1473 — this PR implements the overlay slice; it **does not** use closing keywords so the issue stays open for any follow-up (e.g. panel/dialog parity if required).

Tests: `flutter test test/province_overlay_test.dart`.

Made with [Cursor](https://cursor.com)