### PR TITLE
feat(ai): army move parity for strategic AI and suggestions

### DIFF
--- a/app/lib/features/game/widgets/move_army_dialog.dart
+++ b/app/lib/features/game/widgets/move_army_dialog.dart
@@ -1,36 +1,11 @@
 // Move army dialog. SPEC/ui/military-units-panel.md, SPEC/program/app-ui-wiring.md.
 
-import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_data/colonizethis_data.dart' show MapTopology;
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
 import 'units/shared/units_panel_region_label.dart';
-
-/// Destination picks for one army move order.
-List<String> armyMoveDestinationFullProvinceIds({
-  required Game game,
-  required MapTopology topology,
-  required String humanPlayerId,
-  required Army army,
-}) {
-  final fromFull = army.stationedProvinceId;
-  final regionId = ProvinceId.regionIdFrom(fromFull);
-  final fromLocal = ProvinceId.localIdFrom(fromFull);
-  final out = <String>{};
-
-  for (final n in neighborProvinceIdsInRegion(topology, regionId, fromLocal)) {
-    out.add(ProvinceId.full(regionId, n));
-  }
-  for (final p in allProvinces(game.worldState)) {
-    if (p.ownerId == humanPlayerId) {
-      out.add(p.id);
-    }
-  }
-  out.remove(fromFull);
-  final sorted = out.toList()..sort();
-  return sorted;
-}
 
 class MoveArmyDialog extends StatefulWidget {
   const MoveArmyDialog({
@@ -57,10 +32,10 @@ class _MoveArmyDialogState extends State<MoveArmyDialog> {
 
   List<({String regionId, String fullProvinceId, String label})>
   _destinationEntries() {
-    final destIds = armyMoveDestinationFullProvinceIds(
+    final destIds = armyMoveCandidateDestinationProvinceIds(
       game: widget.game,
       topology: widget.topology,
-      humanPlayerId: widget.humanPlayerId,
+      playerId: widget.humanPlayerId,
       army: widget.army,
     );
     final out = <({String regionId, String fullProvinceId, String label})>[];

--- a/packages/colonizethis_ai/lib/src/domain_planners.dart
+++ b/packages/colonizethis_ai/lib/src/domain_planners.dart
@@ -115,6 +115,18 @@ Orders runDomainPlanners({
     suggestionAPI: suggestionAPI,
   );
 
+  orders = _runArmyMovePlanner(
+    nationId: nationId,
+    view: view,
+    game: game,
+    topology: topology,
+    orders: orders,
+    config: config,
+    primaryGoal: primaryGoal,
+    seeds: seeds,
+    suggestionAPI: suggestionAPI,
+  );
+
   // Naval: suggest naval moves and missions; weight by military/expand.
   orders = _runNavalPlanner(
     nationId: nationId,
@@ -254,6 +266,78 @@ Orders _runMovePlanner({
     'unitId=${selected.first.unitId} destinationProvinceId=${selected.first.destinationProvinceId}',
   );
   return _appendMoveOrders(orders, nationId, selected);
+}
+
+Orders _runArmyMovePlanner({
+  required String nationId,
+  required PlayerView view,
+  required Game game,
+  required MapTopology topology,
+  required Orders orders,
+  required AIConfig config,
+  required StrategicGoal primaryGoal,
+  required AISeedBundle seeds,
+  required OrderSuggestionAPI suggestionAPI,
+}) {
+  final armyMoveCandidates = suggestionAPI.suggestArmyMoveOrders(
+    view,
+    game,
+    topology,
+    orders,
+  );
+  if (armyMoveCandidates.isEmpty) {
+    _log.d('army move eval nationId=$nationId candidatesCount=0');
+    return orders;
+  }
+  final filtered = filterArmyMoveOrdersByDiplomacy(
+    game,
+    nationId,
+    armyMoveCandidates,
+  );
+  if (filtered.isEmpty) {
+    _log.d('army move filtered empty nationId=$nationId');
+    return orders;
+  }
+  final domainWeights = getDomainWeightsForLeader(config.leaderId);
+  final weight =
+      primaryGoal == StrategicGoal.conquer ||
+          primaryGoal == StrategicGoal.defend
+      ? domainWeights.military
+      : primaryGoal == StrategicGoal.expand
+      ? domainWeights.economy
+      : 50;
+  if (weight < 20) {
+    _log.d('army move skipped nationId=$nationId weight=$weight < 20');
+    return orders;
+  }
+  _log.d(
+    'army move eval nationId=$nationId weight=$weight '
+    'filteredCount=${filtered.length} '
+    'candidates=${filtered.map((m) => "${m.armyId}->${m.destinationProvinceId}").toList()}',
+  );
+  final provinceOwner = getProvinceOwnerMap(game);
+  final scores = filtered.map((m) {
+    final destOwner = provinceOwner[m.destinationProvinceId];
+    if (destOwner == null || destOwner == nationId) return 1.0;
+    final rel = getRelation(game, nationId, destOwner);
+    final atWar = rel != null && rel.atWar;
+    return 1.0 + (atWar ? kMovePreferEnemyTerritoryBonus.toDouble() : 0);
+  }).toList();
+  final total = scores.reduce((a, b) => a + b);
+  if (total <= 0) return orders;
+  final rng = math.Random(seeds.militarySeed + 2000);
+  var r = rng.nextDouble() * total;
+  var idx = 0;
+  for (; idx < filtered.length && r > scores[idx]; idx++) {
+    r -= scores[idx];
+  }
+  if (idx >= filtered.length) idx = filtered.length - 1;
+  final selected = filtered[idx];
+  _log.i(
+    'army move chosen nationId=$nationId '
+    'armyId=${selected.armyId} destinationProvinceId=${selected.destinationProvinceId}',
+  );
+  return applyArmyMoveOrderForPlayer(orders, nationId, selected);
 }
 
 Orders _appendMoveOrders(Orders o, String playerId, List<MoveOrder> list) {

--- a/packages/colonizethis_ai/lib/src/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/strategic_ai.dart
@@ -65,11 +65,13 @@ StrategicOrderResult generateStrategicOrders({
     economyPlan: economyPlan,
   );
   final moveCount = orders.moveOrdersByPlayerId[nationId]?.length ?? 0;
+  final armyMoveCount =
+      orders.armyMoveOrdersByPlayerId[nationId]?.length ?? 0;
   final buildCount = orders.buildUnitOrdersByPlayerId[nationId]?.length ?? 0;
   final workCount = orders.workOrdersByPlayerId[nationId]?.length ?? 0;
   final researchCount = orders.researchOrdersByPlayerId[nationId]?.length ?? 0;
   _log.i(
-    'generated orders nationId=$nationId move=$moveCount build=$buildCount work=$workCount research=$researchCount',
+    'generated orders nationId=$nationId move=$moveCount armyMove=$armyMoveCount build=$buildCount work=$workCount research=$researchCount',
   );
   _emitDialogueAndMood(
     config: config,

--- a/packages/colonizethis_ai/test/domain_planners_test.dart
+++ b/packages/colonizethis_ai/test/domain_planners_test.dart
@@ -14,6 +14,7 @@ class _FakeOrderSuggestionAPI implements OrderSuggestionAPI {
     required this.navalMove,
     required this.navalMission,
     this.diplomatic = const [],
+    this.armyMove = const [],
   });
 
   final List<WorkOrder> work;
@@ -23,6 +24,7 @@ class _FakeOrderSuggestionAPI implements OrderSuggestionAPI {
   final List<NavalMoveOrder> navalMove;
   final List<NavalMissionOrder> navalMission;
   final List<DiplomaticOrder> diplomatic;
+  final List<ArmyMoveOrder> armyMove;
 
   @override
   List<MoveOrder> suggestMoveOrders(
@@ -31,6 +33,14 @@ class _FakeOrderSuggestionAPI implements OrderSuggestionAPI {
     MapTopology topology,
     Orders currentOrders,
   ) => move;
+
+  @override
+  List<ArmyMoveOrder> suggestArmyMoveOrders(
+    PlayerView view,
+    Game game,
+    MapTopology topology,
+    Orders currentOrders,
+  ) => armyMove;
 
   @override
   List<WorkOrder> suggestWorkOrders(
@@ -219,6 +229,205 @@ void main() {
       expect(orders, isNotNull);
       // Move planner may add moves when weight >= 20 and candidates exist.
       expect(orders.moveOrdersByPlayerId['gp1'] != null, isTrue);
+    });
+
+    test('DefaultOrderSuggestionAPI can add army move for non-home army', () {
+      const cap = 'oldWorld|cap';
+      const p1 = 'oldWorld|p1';
+      const nw = 'newWorld|col';
+      final game = Game(
+        id: 'g_army_dom',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(
+                id: cap,
+                regionId: 'oldWorld',
+                ownerId: 'gp1',
+                townTileKey: 'oldWorld|cap|0|0',
+              ),
+              Province(id: p1, regionId: 'oldWorld', ownerId: 'gp1'),
+            ],
+            units: [
+              Unit(
+                id: 'u1',
+                type: 'musketeers',
+                ownerId: 'gp1',
+                locationProvinceId: p1,
+                tileKey: 'oldWorld|p1|0|0',
+              ),
+            ],
+          ),
+          newWorld: RegionData(
+            provinces: [
+              Province(id: nw, regionId: 'newWorld', ownerId: 'gp1'),
+            ],
+          ),
+          armies: [
+            Army(
+              id: homeArmyIdFor('gp1'),
+              ownerId: 'gp1',
+              regionId: 'oldWorld',
+              stationedProvinceId: cap,
+              regimentUnitIds: const [],
+              isHomeArmy: true,
+            ),
+            Army(
+              id: 'field_a',
+              ownerId: 'gp1',
+              regionId: 'oldWorld',
+              stationedProvinceId: p1,
+              regimentUnitIds: const ['u1'],
+              isHomeArmy: false,
+            ),
+          ],
+          playerVisibilityByTile: const {
+            'gp1': {
+              'oldWorld|cap|0|0': 'fullyVisible',
+              'oldWorld|p1|0|0': 'fullyVisible',
+              'newWorld|col|0|0': 'fullyVisible',
+            },
+          },
+          tileKeysByRegionAndProvince: {
+            'oldWorld': {
+              cap: [cap],
+              p1: ['oldWorld|p1|0|0'],
+            },
+            'newWorld': {
+              nw: ['newWorld|col|0|0'],
+            },
+          },
+        ),
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'GP',
+            isHuman: false,
+            leaderKey: 'victoria',
+            capitalProvinceId: cap,
+          ),
+        ],
+      );
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(
+            id: cap,
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: p1,
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: nw,
+            regionId: 'newWorld',
+            type: TopologyNodeType.province,
+          ),
+        ],
+        edges: const [],
+      );
+      final view = buildPlayerView(game, topology, 'gp1');
+      final snapshot = AIWorldSnapshot.fromPlayerView(view);
+      const config = AIConfig(
+        leaderId: 'victoria',
+        personalityId: 'victoria',
+        hiddenAgendaId: 'peacemaker',
+      );
+      final seeds = AISeedBundle.fromTurnSeed(77);
+      const api = DefaultOrderSuggestionAPI();
+      const economyPlan = EconomyPlan(
+        productionAssignments: [],
+        cargoPreference: CargoPreference.none,
+      );
+      final orders = runDomainPlanners(
+        game: game,
+        topology: topology,
+        nationId: 'gp1',
+        view: view,
+        snapshot: snapshot,
+        config: config,
+        primaryGoal: StrategicGoal.conquer,
+        seeds: seeds,
+        suggestionAPI: api,
+        economyPlan: economyPlan,
+      );
+
+      expect(orders.armyMoveOrdersByPlayerId['gp1'], isNotNull);
+      expect(orders.armyMoveOrdersByPlayerId['gp1']!, isNotEmpty);
+    });
+
+    test('_runArmyMovePlanner applies fake suggestion army move', () {
+      final fakeApi = _FakeOrderSuggestionAPI(
+        work: const [],
+        build: const [],
+        move: const [],
+        research: const [],
+        navalMove: const [],
+        navalMission: const [],
+        diplomatic: const [],
+        armyMove: const [
+          ArmyMoveOrder(
+            armyId: 'field_a',
+            destinationProvinceId: 'oldWorld|p2',
+          ),
+        ],
+      );
+      final game = Game(
+        id: 'g_army_fake',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(provinces: [], units: []),
+          newWorld: RegionData(provinces: [], units: []),
+        ),
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'Leader',
+            isHuman: false,
+            leaderKey: 'victoria',
+          ),
+        ],
+      );
+      const topology = MapTopology(nodes: [], edges: []);
+      final view = PlayerView(
+        playerId: 'gp1',
+        player: game.players.single,
+        ownUnitsById: const {},
+        provincesById: const {},
+        visibilityByTile: const {},
+        prospectedTiles: const {},
+        diplomacyByOtherId: const {},
+      );
+      final snapshot = AIWorldSnapshot.fromPlayerView(view);
+      const config = AIConfig(
+        leaderId: 'victoria',
+        personalityId: 'victoria',
+        hiddenAgendaId: 'peacemaker',
+      );
+      final seeds = AISeedBundle.fromTurnSeed(1);
+      const economyPlan = EconomyPlan(
+        productionAssignments: [],
+        cargoPreference: CargoPreference.none,
+      );
+
+      final orders = runDomainPlanners(
+        game: game,
+        topology: topology,
+        nationId: 'gp1',
+        view: view,
+        snapshot: snapshot,
+        config: config,
+        primaryGoal: StrategicGoal.conquer,
+        seeds: seeds,
+        suggestionAPI: fakeApi,
+        economyPlan: economyPlan,
+      );
+
+      expect(orders.armyMoveOrdersByPlayerId['gp1']?.single.destinationProvinceId,
+          'oldWorld|p2');
     });
 
     test('uses economy and naval planners when candidates exist', () {

--- a/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
+++ b/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
@@ -8,6 +8,7 @@ import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../orders/draft_orders_mutations.dart';
 import '../orders/order_suggestion.dart';
 import '../world/army_migration.dart';
 import '../world/player_view.dart';
@@ -101,15 +102,7 @@ Orders generateOrdersWithSimpleHeuristics(
         if (moveSuggestions.isEmpty) {
           final idx = rng.nextInt(armyMoveSuggestions.length);
           final chosen = armyMoveSuggestions[idx];
-          final list = List<ArmyMoveOrder>.from(
-            current.armyMoveOrdersByPlayerId[player.id] ?? const [],
-          )..add(chosen);
-          current = current.copyWith(
-            armyMoveOrdersByPlayerId: {
-              ...current.armyMoveOrdersByPlayerId,
-              player.id: list,
-            },
-          );
+          current = applyArmyMoveOrderForPlayer(current, player.id, chosen);
         } else if (armyMoveSuggestions.isEmpty) {
           final idx = rng.nextInt(moveSuggestions.length);
           final chosen = moveSuggestions[idx];
@@ -138,15 +131,7 @@ Orders generateOrdersWithSimpleHeuristics(
           } else {
             final idx = rng.nextInt(armyMoveSuggestions.length);
             final chosen = armyMoveSuggestions[idx];
-            final list = List<ArmyMoveOrder>.from(
-              current.armyMoveOrdersByPlayerId[player.id] ?? const [],
-            )..add(chosen);
-            current = current.copyWith(
-              armyMoveOrdersByPlayerId: {
-                ...current.armyMoveOrdersByPlayerId,
-                player.id: list,
-              },
-            );
+            current = applyArmyMoveOrderForPlayer(current, player.id, chosen);
           }
         }
         break;

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -8,6 +8,7 @@ import '../world/movement.dart';
 import '../world/naval.dart';
 import '../world/province_lookup.dart';
 import 'build_rail_work_rules.dart';
+import 'draft_orders_mutations.dart';
 import 'order_engine.dart';
 import 'order_visibility.dart';
 import 'orders_application_helpers.dart';
@@ -150,6 +151,33 @@ List<MoveOrder> suggestMoveOrders(
   return suggestions;
 }
 
+/// Destination province ids for army moves (Military Units picker parity): adjacent
+/// land provinces in the army's region plus every province owned by [playerId]
+/// in any region; excludes the army's current province.
+List<String> armyMoveCandidateDestinationProvinceIds({
+  required Game game,
+  required MapTopology topology,
+  required String playerId,
+  required Army army,
+}) {
+  final fromFull = army.stationedProvinceId;
+  final regionId = ProvinceId.regionIdFrom(fromFull);
+  final fromLocal = ProvinceId.localIdFrom(fromFull);
+  final out = <String>{};
+
+  for (final n in neighborProvinceIdsInRegion(topology, regionId, fromLocal)) {
+    out.add(ProvinceId.full(regionId, n));
+  }
+  for (final p in allProvinces(game.worldState)) {
+    if (p.ownerId == playerId) {
+      out.add(p.id);
+    }
+  }
+  out.remove(fromFull);
+  final sorted = out.toList()..sort();
+  return sorted;
+}
+
 /// Suggests candidate [ArmyMoveOrder]s for non-home armies owned by [view.playerId].
 List<ArmyMoveOrder> suggestArmyMoveOrders(
   PlayerView view,
@@ -174,28 +202,19 @@ List<ArmyMoveOrder> suggestArmyMoveOrders(
 
     final fromProvinceId = army.stationedProvinceId;
     final unitRegion = ProvinceId.regionIdFrom(fromProvinceId);
-    final fromLocalId = ProvinceId.localIdFrom(fromProvinceId);
 
     if (!moveSourceVisibilityOk(view, unitRegion, fromProvinceId)) continue;
 
-    for (final neighborLocalId in neighborProvinceIdsInRegion(
-      topology,
-      unitRegion,
-      fromLocalId,
-    )) {
-      final destinationProvinceId =
-          ProvinceId.full(unitRegion, neighborLocalId);
+    final destIds = armyMoveCandidateDestinationProvinceIds(
+      game: game,
+      topology: topology,
+      playerId: playerId,
+      army: army,
+    );
+
+    for (final destinationProvinceId in destIds) {
       final already = existingArmyMoves[army.id];
       if (already != null && already.contains(destinationProvinceId)) continue;
-
-      final hasVisibleTileInDest = view.visibilityByTile.entries.any((e) {
-        final parts = e.key.split('|');
-        if (parts.length != 4) return false;
-        return parts[0] == unitRegion &&
-            parts[1] == neighborLocalId &&
-            e.value != VisibilityLevel.unknown;
-      });
-      if (!hasVisibleTileInDest) continue;
 
       final candidate = ArmyMoveOrder(
         armyId: army.id,
@@ -701,14 +720,15 @@ bool _isArmyMoveOrderAccepted(
   Orders baseOrders,
   ArmyMoveOrder candidate,
 ) {
-  final engine = OrderEngine(initialOrders: baseOrders);
-  final result = engine.addArmyMoveOrderWithContext(
+  final merged = applyArmyMoveOrderForPlayer(baseOrders, playerId, candidate);
+  final engine = OrderEngine(initialOrders: merged);
+  final results = engine.validatePlayerOrdersWithContext(
     game,
     topology,
     playerId,
-    candidate,
   );
-  return result.isAccepted;
+  if (results.isEmpty) return false;
+  return results.every((r) => r.isAccepted);
 }
 
 bool _isWorkOrderAccepted(
@@ -1835,6 +1855,12 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
 /// colonizethis_ai calls this to get candidate orders; logic provides the implementation.
 abstract class OrderSuggestionAPI {
   List<MoveOrder> suggestMoveOrders(
+    PlayerView view,
+    Game game,
+    MapTopology topology,
+    Orders currentOrders,
+  );
+  List<ArmyMoveOrder> suggestArmyMoveOrders(
     PlayerView view,
     Game game,
     MapTopology topology,

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -170,7 +170,7 @@ List<String> armyMoveCandidateDestinationProvinceIds({
   }
   for (final p in allProvinces(game.worldState)) {
     if (p.ownerId == playerId) {
-      out.add(p.id);
+      out.add(toFullProvinceId(p.regionId, p.id));
     }
   }
   out.remove(fromFull);

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_api_impl.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_api_impl.dart
@@ -25,6 +25,24 @@ class DefaultOrderSuggestionAPI implements suggestion.OrderSuggestionAPI {
   }
 
   @override
+  List<ArmyMoveOrder> suggestArmyMoveOrders(
+    PlayerView view,
+    Game game,
+    MapTopology topology,
+    Orders currentOrders,
+  ) {
+    _log.i(
+      'order suggestion API suggestArmyMoveOrders player=${view.playerId}',
+    );
+    return suggestion.suggestArmyMoveOrders(
+      view,
+      game,
+      topology,
+      currentOrders,
+    );
+  }
+
+  @override
   List<WorkOrder> suggestWorkOrders(
     PlayerView view,
     Game game,

--- a/packages/colonizethis_logic/test/ai_planner_test.dart
+++ b/packages/colonizethis_logic/test/ai_planner_test.dart
@@ -328,6 +328,117 @@ void main() {
         reason: 'full-AI aggregation must include naval move orders',
       );
     });
+
+    test('generateOrdersForPlayerFullAI can emit cross-region army move', () {
+      const cap = 'oldWorld|cap';
+      const p1 = 'oldWorld|p1';
+      const nw = 'newWorld|col';
+      final game = Game(
+        id: 'g_full_ai_army',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(
+                id: cap,
+                regionId: 'oldWorld',
+                ownerId: 'gp1',
+                townTileKey: 'oldWorld|cap|0|0',
+              ),
+              Province(id: p1, regionId: 'oldWorld', ownerId: 'gp1'),
+            ],
+            units: [
+              Unit(
+                id: 'u1',
+                type: 'musketeers',
+                ownerId: 'gp1',
+                locationProvinceId: p1,
+                tileKey: 'oldWorld|p1|0|0',
+              ),
+            ],
+          ),
+          newWorld: RegionData(
+            provinces: [
+              Province(id: nw, regionId: 'newWorld', ownerId: 'gp1'),
+            ],
+          ),
+          armies: [
+            Army(
+              id: homeArmyIdFor('gp1'),
+              ownerId: 'gp1',
+              regionId: 'oldWorld',
+              stationedProvinceId: cap,
+              regimentUnitIds: const [],
+              isHomeArmy: true,
+            ),
+            Army(
+              id: 'field_a',
+              ownerId: 'gp1',
+              regionId: 'oldWorld',
+              stationedProvinceId: p1,
+              regimentUnitIds: const ['u1'],
+              isHomeArmy: false,
+            ),
+          ],
+          playerVisibilityByTile: const {
+            'gp1': {
+              'oldWorld|cap|0|0': 'fullyVisible',
+              'oldWorld|p1|0|0': 'fullyVisible',
+              'newWorld|col|0|0': 'fullyVisible',
+            },
+          },
+          tileKeysByRegionAndProvince: {
+            'oldWorld': {
+              cap: ['oldWorld|cap|0|0'],
+              p1: ['oldWorld|p1|0|0'],
+            },
+            'newWorld': {
+              nw: ['newWorld|col|0|0'],
+            },
+          },
+        ),
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'AI',
+            isHuman: false,
+            leaderKey: 'victoria',
+            capitalProvinceId: cap,
+          ),
+        ],
+        globalGameSeed: 3,
+        aiSeedByGpId: const {'gp1': 77},
+        hiddenAgendaByGpId: const {'gp1': 'warmonger'},
+      );
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(
+            id: 'oldWorld|cap',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'oldWorld|p1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'newWorld|col',
+            regionId: 'newWorld',
+            type: TopologyNodeType.province,
+          ),
+        ],
+        edges: [],
+      );
+      final result = generateOrdersForPlayerFullAI(game, topology, 'gp1');
+      final armyMoves =
+          result.orders.armyMoveOrdersByPlayerId['gp1'] ?? const [];
+      expect(
+        armyMoves.any((m) => m.destinationProvinceId == nw),
+        isTrue,
+        reason: 'full AI should issue army move onto owned province in other region',
+      );
+    });
   });
 }
 

--- a/packages/colonizethis_logic/test/logic_providers_test.dart
+++ b/packages/colonizethis_logic/test/logic_providers_test.dart
@@ -65,6 +65,7 @@ void main() {
       );
 
       expect(fake.suggestMoveCalls, greaterThan(0));
+      expect(fake.suggestArmyMoveCalls, greaterThan(0));
     });
 
     test('gameEventBusProvider returns GameEventBus instance', () {
@@ -77,6 +78,7 @@ void main() {
 
 final class _SpyOrderSuggestionAPI implements OrderSuggestionAPI {
   int suggestMoveCalls = 0;
+  int suggestArmyMoveCalls = 0;
 
   @override
   List<BuildUnitOrder> suggestBuildOrders(
@@ -105,6 +107,17 @@ final class _SpyOrderSuggestionAPI implements OrderSuggestionAPI {
     Orders currentOrders,
   ) {
     suggestMoveCalls++;
+    return const [];
+  }
+
+  @override
+  List<ArmyMoveOrder> suggestArmyMoveOrders(
+    PlayerView view,
+    Game game,
+    MapTopology topology,
+    Orders currentOrders,
+  ) {
+    suggestArmyMoveCalls++;
     return const [];
   }
 

--- a/packages/colonizethis_logic/test/order_suggestion_army_move_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_army_move_test.dart
@@ -1,0 +1,313 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  group('suggestArmyMoveOrders', () {
+    const gp = 'gp1';
+    const cap = 'oldWorld|cap';
+    const p1 = 'oldWorld|p1';
+    const nw = 'newWorld|col';
+
+    Game _game({String? extraNeighborProvinceId}) {
+      final provinces = <Province>[
+        Province(
+          id: cap,
+          regionId: 'oldWorld',
+          ownerId: gp,
+          townTileKey: 'oldWorld|cap|0|0',
+        ),
+        Province(id: p1, regionId: 'oldWorld', ownerId: gp),
+      ];
+      if (extraNeighborProvinceId != null) {
+        provinces.add(
+          Province(
+            id: extraNeighborProvinceId,
+            regionId: 'oldWorld',
+            ownerId: gp,
+          ),
+        );
+      }
+      return Game(
+        id: 'g_army_sug',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: provinces,
+            units: [
+              Unit(
+                id: 'u1',
+                type: 'musketeers',
+                ownerId: gp,
+                locationProvinceId: p1,
+                tileKey: 'oldWorld|p1|0|0',
+              ),
+            ],
+          ),
+          newWorld: RegionData(
+            provinces: [
+              Province(id: nw, regionId: 'newWorld', ownerId: gp),
+            ],
+          ),
+          armies: [
+            Army(
+              id: homeArmyIdFor(gp),
+              ownerId: gp,
+              regionId: 'oldWorld',
+              stationedProvinceId: cap,
+              regimentUnitIds: const [],
+              isHomeArmy: true,
+            ),
+            Army(
+              id: 'field_a',
+              ownerId: gp,
+              regionId: 'oldWorld',
+              stationedProvinceId: p1,
+              regimentUnitIds: const ['u1'],
+              isHomeArmy: false,
+            ),
+          ],
+          playerVisibilityByTile: {
+            gp: {
+              'oldWorld|cap|0|0': 'fullyVisible',
+              'oldWorld|p1|0|0': 'fullyVisible',
+              'newWorld|col|0|0': 'fullyVisible',
+            },
+          },
+          tileKeysByRegionAndProvince: {
+            'oldWorld': {
+              cap: ['oldWorld|cap|0|0'],
+              p1: ['oldWorld|p1|0|0'],
+            },
+            'newWorld': {
+              nw: ['newWorld|col|0|0'],
+            },
+          },
+        ),
+        players: [
+          Player(
+            id: gp,
+            displayName: 'T',
+            isHuman: true,
+            capitalProvinceId: cap,
+          ),
+        ],
+      );
+    }
+
+    MapTopology _topology({bool includeP2 = false}) {
+      final nodes = <TopologyNode>[
+        const TopologyNode(
+          id: 'oldWorld|cap',
+          regionId: 'oldWorld',
+          type: TopologyNodeType.province,
+        ),
+        const TopologyNode(
+          id: 'oldWorld|p1',
+          regionId: 'oldWorld',
+          type: TopologyNodeType.province,
+        ),
+        const TopologyNode(
+          id: 'newWorld|col',
+          regionId: 'newWorld',
+          type: TopologyNodeType.province,
+        ),
+      ];
+      final edges = <TopologyEdge>[];
+      if (includeP2) {
+        nodes.add(
+          const TopologyNode(
+            id: 'oldWorld|p2',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+        );
+        edges.add(
+          const TopologyEdge(id1: 'oldWorld|p1', id2: 'oldWorld|p2'),
+        );
+      }
+      return MapTopology(nodes: nodes, edges: edges);
+    }
+
+    test('includes cross-region player-owned province as destination', () {
+      final game = _game();
+      final topology = _topology();
+      final view = buildPlayerView(game, topology, gp);
+      final suggestions = suggestArmyMoveOrders(
+        view,
+        game,
+        topology,
+        const Orders(),
+      );
+      expect(
+        suggestions.any(
+          (s) => s.armyId == 'field_a' && s.destinationProvinceId == nw,
+        ),
+        isTrue,
+      );
+    });
+
+    test('still proposes alternate destination when draft has prior army move', () {
+      const p2 = 'oldWorld|p2';
+      final game = _game(extraNeighborProvinceId: p2);
+      final topology = _topology(includeP2: true);
+      final tileKeys = Map<String, List<String>>.from(
+        game.worldState.tileKeysByRegionAndProvince['oldWorld']!,
+      );
+      tileKeys[p2] = ['oldWorld|p2|0|0'];
+      final ws = game.worldState.copyWith(
+        tileKeysByRegionAndProvince: {
+          ...game.worldState.tileKeysByRegionAndProvince,
+          'oldWorld': tileKeys,
+        },
+        playerVisibilityByTile: {
+          gp: {
+            ...game.worldState.playerVisibilityByTile[gp]!,
+            'oldWorld|p2|0|0': 'fullyVisible',
+          },
+        },
+      );
+      final game2 = game.copyWith(worldState: ws);
+
+      final view2 = buildPlayerView(game2, topology, gp);
+      final current = Orders(
+        armyMoveOrdersByPlayerId: {
+          gp: [
+            ArmyMoveOrder(armyId: 'field_a', destinationProvinceId: p2),
+          ],
+        },
+      );
+      final suggestions = suggestArmyMoveOrders(
+        view2,
+        game2,
+        topology,
+        current,
+      );
+      expect(
+        suggestions.any((s) => s.destinationProvinceId == nw),
+        isTrue,
+        reason: 'replacement-aware validation should allow other owned destinations',
+      );
+    });
+  });
+
+  group('generateOrdersWithSimpleHeuristics army moves', () {
+    test('keeps at most one army move per army id', () {
+      const gp = 'gp_ai';
+      const cap = 'oldWorld|cap';
+      const p1 = 'oldWorld|p1';
+      const nw = 'newWorld|col';
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(
+            id: 'oldWorld|cap',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'oldWorld|p1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'newWorld|col',
+            regionId: 'newWorld',
+            type: TopologyNodeType.province,
+          ),
+        ],
+        edges: const [],
+      );
+      final game = Game(
+        id: 'g_heur',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(
+                id: cap,
+                regionId: 'oldWorld',
+                ownerId: gp,
+                townTileKey: 'oldWorld|cap|0|0',
+              ),
+              Province(id: p1, regionId: 'oldWorld', ownerId: gp),
+            ],
+            units: [
+              Unit(
+                id: 'u1',
+                type: 'musketeers',
+                ownerId: gp,
+                locationProvinceId: p1,
+                tileKey: 'oldWorld|p1|0|0',
+              ),
+            ],
+          ),
+          newWorld: RegionData(
+            provinces: [
+              Province(id: nw, regionId: 'newWorld', ownerId: gp),
+            ],
+          ),
+          armies: [
+            Army(
+              id: homeArmyIdFor(gp),
+              ownerId: gp,
+              regionId: 'oldWorld',
+              stationedProvinceId: cap,
+              regimentUnitIds: const [],
+              isHomeArmy: true,
+            ),
+            Army(
+              id: 'field_a',
+              ownerId: gp,
+              regionId: 'oldWorld',
+              stationedProvinceId: p1,
+              regimentUnitIds: const ['u1'],
+              isHomeArmy: false,
+            ),
+          ],
+          playerVisibilityByTile: {
+            gp: {
+              'oldWorld|cap|0|0': 'fullyVisible',
+              'oldWorld|p1|0|0': 'fullyVisible',
+              'newWorld|col|0|0': 'fullyVisible',
+            },
+          },
+          tileKeysByRegionAndProvince: {
+            'oldWorld': {
+              cap: ['oldWorld|cap|0|0'],
+              p1: ['oldWorld|p1|0|0'],
+            },
+            'newWorld': {
+              nw: ['newWorld|col|0|0'],
+            },
+          },
+        ),
+        players: [
+          Player(
+            id: gp,
+            displayName: 'AI',
+            isHuman: false,
+            capitalProvinceId: cap,
+          ),
+        ],
+        globalGameSeed: 1,
+        aiSeedByGpId: const {gp: 42},
+      );
+
+      final orders = generateOrdersWithSimpleHeuristics(
+        game,
+        topology,
+        gp,
+        turnSeedForPlayer(game, gp, 1),
+      );
+      final list = orders.armyMoveOrdersByPlayerId[gp] ?? [];
+      final perArmy = <String, int>{};
+      for (final o in list) {
+        perArmy[o.armyId] = (perArmy[o.armyId] ?? 0) + 1;
+      }
+      expect(perArmy.values.every((c) => c <= 1), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Completes the **AI / suggestion** gaps for army move orders relative to human Military Units behavior (issue #1470): shared destination enumeration (neighbors plus all player-owned provinces, any region), replacement semantics when validating and when the simple heuristic AI commits moves, `OrderSuggestionAPI.suggestArmyMoveOrders`, and a new **army move** step in domain planners (full strategic AI) with diplomacy filtering and scoring aligned with civilian move planning.

The app move dialog now calls `armyMoveCandidateDestinationProvinceIds` from `colonizethis_logic` so picker and AI stay in sync.

## Tests

- `packages/colonizethis_logic/test/order_suggestion_army_move_test.dart` (new)
- Updates to `domain_planners_test`, `ai_planner_test`, `logic_providers_test`
- Existing Military Units widget tests still pass

## Reference

Refs #1470 (does **not** close; tracks remaining / verification scope on the issue).

Made with [Cursor](https://cursor.com)