### PR TITLE
feat: turn-start news digest and dialog

### DIFF
--- a/SPEC/game/world-model.md
+++ b/SPEC/game/world-model.md
@@ -60,6 +60,8 @@ All entities support JSON (or equivalent) for persistence; save layer reads/writ
 - **Fleets:** Each ship hull in `WorldState.fleets` has a **unique instance id** within the save; fleet rows store instances with catalog `typeId`. Counts by type in UI or formulas are aggregations. See [ships-and-naval.md](ships-and-naval.md) § Ship instances.
 - **Armies:** Each land military regiment unit id appears in **exactly one** army’s member list in `WorldState.armies` (or equivalent per-region storage per TDD). Each army has a stable **army id** for the life of the save. See [military-armies.md](military-armies.md).
 
+- **Province capture / handover:** When the game records a **change of control** of a province from one faction to another (e.g. combat capture per [combat.md](combat.md)), the new `Province.ownerId` is always a **non-empty** faction id (another Great Power, Minor Nation, or Tribe). Handovers do not clear ownership to null/empty as the outcome of capture. A null/empty `ownerId` is reserved for **uncolonized** frontier provinces (e.g. New World before first colonization), not as the “new owner” after losing control. `province_captured` events and turn-news capture lines require both previous and new owners to be non-empty; see [game-events.md](../program/game-events.md) and [turn-news-digest.md](../program/turn-news-digest.md).
+
 ---
 
 ## Acceptance Criteria
@@ -75,6 +77,10 @@ All entities support JSON (or equivalent) for persistence; save layer reads/writ
 - Given a WorldState with a Tile map for a region and at least one Province that owns tiles in that region  
   When the System computes effective extraction for that Province  
   Then the System uses the tiles assigned to that Province in the per-region 2D grid, applies terrain, resource, and improvement data from those tiles, and caps extraction for each tile at the owning Player’s tech cap as defined in the active ruleset.
+
+- Given a supported resolution step that applies a **faction-to-faction** province ownership change (previous and new owner each a non-empty faction id)  
+  When the System commits that change to `WorldState`  
+  Then the province’s `ownerId` equals the new faction id and is non-empty, and the System does not represent a successful capture by setting `ownerId` to null or empty.
 
 - Given a Game entity that has Players, Minor Nations, Tribes, and a WorldState with provinces and units  
   When the System serializes the Game to JSON and later reloads it by game id  

--- a/SPEC/program/game-events.md
+++ b/SPEC/program/game-events.md
@@ -24,7 +24,7 @@ Events are a union or sealed type (e.g. `GameEvent`) with variants. Payloads use
 |----------------------|----------------------------------|-------------------|
 | `combat_result`      | After Combat phase              | provinceId (prefixed), attackerId, defenderId, winnerId, casualties (or summary). |
 | `naval_combat_result` | After each resolved sea battle in Naval interception phase | seaZoneId (local, e.g. s3), side1OwnerId, side2OwnerId, outcomeName (`NavalBattleOutcome.name`), turnNumber, optional winnerOwnerId, retreat flags. |
-| `province_captured`  | When province owner changes     | provinceId (prefixed), previousOwnerId, newOwnerId, turnNumber. |
+| `province_captured`  | When province ownership transfers **from one non-empty faction to another** (combat capture or other supported handover) | provinceId (prefixed), previousOwnerId, newOwnerId (both non-empty faction ids), turnNumber. Not emitted when the new `ownerId` would be null/empty—uncolonized frontier is not a capture outcome; see [world-model.md](../game/world-model.md) § Invariants. |
 | `diplomacy_change`   | After Diplomacy phase           | actorId, targetId, changeType (e.g. war, peace, alliance), turnNumber. |
 | `research_complete`   | When a tech is researched      | playerId, techId, turnNumber. |
 | `victory_set`        | End-of-turn when victory set    | winnerPlayerId, victoryType, turnNumber. See [victory.md](../game/victory.md). |
@@ -59,6 +59,8 @@ The **caller** that owns the order list or invokes TurnResolver is responsible f
 - **Emission — order_rejected.** Given the order engine validates a player’s order list and the first rejection occurs at order N with reason R, when validation returns, then the system has emitted an `order_rejected` event for that order with a reasonCode consistent with R (or the validation layer exposes the same so that a consumer can emit the event).
 - **Determinism.** Given the same Game (and WorldState), same per-player order lists, same ruleset, and same seeds, when the system runs turn resolution and order validation, then the sequence of GameEvents emitted for that run is identical to any other run with the same inputs.
 - **Province identity.** Given any GameEvent that carries a province id, when the event is emitted, then that id is in prefixed form (`regionId|localId`) per [world-model-identity.md](../game/world-model-identity.md).
+
+- **Emission — province_captured.** Given combat or another resolver step would change a province from owner **A** to owner **B**, when **A** and **B** are each a non-empty faction id and **A ≠ B**, then the system may emit a `province_captured` event with `previousOwnerId == A`, `newOwnerId == B`, and prefixed `provinceId`. Given the post-resolution `ownerId` for that province is null or empty while the previous snapshot had a non-empty owner, when the emitter runs, then the system does **not** emit `province_captured` for that province (invalid capture state; see [world-model.md](../game/world-model.md) § Invariants).
 
 ---
 

--- a/SPEC/program/turn-news-digest.md
+++ b/SPEC/program/turn-news-digest.md
@@ -21,7 +21,7 @@ Lists are kept sorted for deterministic JSON and equality.
 
 Categories and sort keys:
 
-1. **Province captured** — same predicate as `emitProvinceCapturedEvents`: `previousOwner != null` and `previousOwner != prov.ownerId` (new owner may be null/empty). Sort by `provinceId`.
+1. **Province captured** — same predicate as `emitProvinceCapturedEvents`: **both** `previousOwner` and `prov.ownerId` are non-empty faction ids and they differ (faction-to-faction handover). Null/empty `ownerId` is uncolonized frontier only, not a capture outcome. Sort by `provinceId`.
 2. **War / peace** — symmetric pair `RelationState` transitions only: to `atWar` or to `atPeace`. Neutral copy: faction ids sorted lexicographically (`A` and `B`). No aggressor/defender labels.
 3. **Overture advanced** — `OvertureState.stage` strictly increased vs start of turn for the same `(gpId, targetId)`; all faction pairs. Sort by `gpId`, `targetId`, then `stage.name`.
 4. **Province discovered** — any Great Power tile visibility in that province moves from all-`unknown` to any non-`unknown` (includes partial/coastal reveal). Emit only if province id ∉ `newsDigestProvinceRevealDoneIds` at start; then add id to tracking. Sort by `provinceId`.
@@ -32,3 +32,19 @@ Within the digest, emit lines in category order above; within a category, use th
 ## Determinism
 
 Same start/end games → same digest lines and order. Implementation uses sorted iteration over provinces, relations, overtures, and zones.
+
+## Acceptance criteria
+
+- Given a start/end pair where a province’s `ownerId` changes from a non-empty faction **A** to **null** or empty  
+  When the system builds the turn news digest for that resolution  
+  Then the digest contains **no** `TurnNewsProvinceCapturedLine` for that province.
+
+- Given a start/end pair where a province’s `ownerId` changes from non-empty faction **A** to non-empty faction **B** with **A ≠ B**  
+  When the system builds the turn news digest for that resolution  
+  Then the digest includes exactly one province-captured line for that province with `previousOwnerId == A` and `newOwnerId == B` (prefixed province id), consistent with `emitProvinceCapturedEvents` for the same transition.
+
+---
+
+## Integration
+
+Province ownership invariant for captures: [world-model.md](../game/world-model.md) § Invariants. Event contract: [game-events.md](game-events.md).

--- a/SPEC/program/turn-news-digest.md
+++ b/SPEC/program/turn-news-digest.md
@@ -1,0 +1,34 @@
+# Turn news digest (logic)
+
+**Source:** GitHub issue #1478 + product comment 2026-04-03. **Audience:** omniscient (world newspaper); province names may appear before the human map reveals them.
+
+## When it runs
+
+After a full `resolveTurnForGame` completes (no pending diplomacy), compare **game at start of resolution** (after `ensureMilitaryArmiesForGame`) to **final game** (after end-of-turn, including turn increment). If `final.victory != null`, **no** digest is produced (victory UX runs first; no news dialog).
+
+`resolvedTurnNumber` in the digest is `start.worldState.turnState.turnNumber` (the turn that was just resolved). The UI shows the dialog when `turnNumberAfter >= 1` (see `TurnResolutionCompleteEvent`).
+
+## Persistent tracking (`WorldState`)
+
+Stored on save so reload does not duplicate lines:
+
+- **`newsDigestProvinceRevealDoneIds`**: prefixed province ids for which a **province discovery** line has already been emitted (global; do not re-emit when another GP later gains first local visibility).
+- **`newsDigestSeaZoneFleetDoneIds`**: prefixed sea zone ids for which a **first fleet presence** line has already been emitted (global).
+
+Lists are kept sorted for deterministic JSON and equality.
+
+## Line taxonomy (deterministic order)
+
+Categories and sort keys:
+
+1. **Province captured** — same rule as `ProvinceCapturedEvent`: `previousOwner != null`, owner changed. Sort by `provinceId`.
+2. **War / peace** — symmetric pair `RelationState` transitions only: to `atWar` or to `atPeace`. Neutral copy: faction ids sorted lexicographically (`A` and `B`). No aggressor/defender labels.
+3. **Overture advanced** — `OvertureState.stage` strictly increased vs start of turn for the same `(gpId, targetId)`; all faction pairs. Sort by `gpId`, `targetId`, then `stage.name`.
+4. **Province discovered** — any Great Power tile visibility in that province moves from all-`unknown` to any non-`unknown` (includes partial/coastal reveal). Emit only if province id ∉ `newsDigestProvinceRevealDoneIds` at start; then add id to tracking. Sort by `provinceId`.
+5. **Sea zone — first fleet presence** — sea zone has at least one fleet at sea in final state, zone id ∉ `newsDigestSeaZoneFleetDoneIds` at start; then add zone id to tracking. Sort by sea zone id.
+
+Within the digest, emit lines in category order above; within a category, use the sort keys listed.
+
+## Determinism
+
+Same start/end games → same digest lines and order. Implementation uses sorted iteration over provinces, relations, overtures, and zones.

--- a/SPEC/program/turn-news-digest.md
+++ b/SPEC/program/turn-news-digest.md
@@ -21,7 +21,7 @@ Lists are kept sorted for deterministic JSON and equality.
 
 Categories and sort keys:
 
-1. **Province captured** — same rule as `ProvinceCapturedEvent`: `previousOwner != null`, owner changed. Sort by `provinceId`.
+1. **Province captured** — same predicate as `emitProvinceCapturedEvents`: `previousOwner != null` and `previousOwner != prov.ownerId` (new owner may be null/empty). Sort by `provinceId`.
 2. **War / peace** — symmetric pair `RelationState` transitions only: to `atWar` or to `atPeace`. Neutral copy: faction ids sorted lexicographically (`A` and `B`). No aggressor/defender labels.
 3. **Overture advanced** — `OvertureState.stage` strictly increased vs start of turn for the same `(gpId, targetId)`; all faction pairs. Sort by `gpId`, `targetId`, then `stage.name`.
 4. **Province discovered** — any Great Power tile visibility in that province moves from all-`unknown` to any non-`unknown` (includes partial/coastal reveal). Emit only if province id ∉ `newsDigestProvinceRevealDoneIds` at start; then add id to tracking. Sort by `provinceId`.

--- a/SPEC/ui/turn-news-dialog.md
+++ b/SPEC/ui/turn-news-dialog.md
@@ -15,4 +15,4 @@
 
 ## Copy
 
-Neutral diplomacy wording (no invented aggressor). Province ids in logic remain prefixed; UI may show `displayName` when present.
+Neutral diplomacy wording (no invented aggressor). Province ids in logic remain prefixed; UI may show `displayName` when present. **Province captured** bullets are only produced for **faction-to-faction** handovers (both previous and new owner non-empty); see [turn-news-digest.md](../program/turn-news-digest.md) and [world-model.md](../game/world-model.md) § Invariants.

--- a/SPEC/ui/turn-news-dialog.md
+++ b/SPEC/ui/turn-news-dialog.md
@@ -1,0 +1,18 @@
+# Turn-start news dialog
+
+**Source:** #1478 + product 2026-04-03. **Trigger:** `TurnResolutionCompleteEvent` with `turnNumber >= 1`, `turnNewsDigest != null`, and loaded game `victory == null`. **Not shown** on initial map entry at turn 0 with no completed resolution. **Victory:** if `victory != null`, omit news (victory flow first).
+
+## Behavior
+
+- Modal dialog listing one bullet per `TurnNewsLine` (formatted with faction/province/sea labels from current `Game`).
+- **Empty digest:** show dialog with “No major events last turn.” (or equivalent l10n).
+- **Wiring:** `GameToUIBusListener` emits `OpenDialogEvent` with dialog id `turn_news` and params after reload; no cross-panel callbacks. See `SPEC/program/app-ui-wiring.md`.
+
+## Components
+
+- **Dialog:** `TurnNewsDialog` — title references the resolved turn; scrollable list; primary **Close** / OK.
+- **Widgetbook:** at least one story with sample lines + empty state; mobile viewport if layout differs.
+
+## Copy
+
+Neutral diplomacy wording (no invented aggressor). Province ids in logic remain prefixed; UI may show `displayName` when present.

--- a/app/lib/core/services/app_event_handler_scope.dart
+++ b/app/lib/core/services/app_event_handler_scope.dart
@@ -15,6 +15,7 @@ import 'package:colonizethis_app/features/game/combat/combat_mode_choice_dialog.
 import 'package:colonizethis_app/features/game/combat/quick_battle_result_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/train_civilians_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/train_military_dialog.dart';
+import 'package:colonizethis_app/features/game/widgets/turn_news_dialog.dart';
 import 'package:colonizethis_app/features/shell/new_game_leader_selection_dialog.dart';
 import 'package:colonizethis_app/features/shell/new_game_setup_flow.dart';
 import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
@@ -289,6 +290,20 @@ class _AppEventHandlerScopeState extends ConsumerState<AppEventHandlerScope> {
             result: result,
             attackerName: attackerName,
             defenderName: defenderName,
+          );
+        },
+        turnNewsDialogId: (ctx, params) {
+          final container = ProviderScope.containerOf(ctx);
+          final game = container.read(currentGameProvider);
+          final digest = params?['digest'] as TurnNewsDigest?;
+          final newTurnNumber = params?['newTurnNumber'] as int?;
+          if (game == null || digest == null || newTurnNumber == null) {
+            return const SizedBox.shrink();
+          }
+          return TurnNewsDialog(
+            game: game,
+            digest: digest,
+            newTurnNumber: newTurnNumber,
           );
         },
       },

--- a/app/lib/core/services/game_service.dart
+++ b/app/lib/core/services/game_service.dart
@@ -140,6 +140,7 @@ class GameService {
         TurnResolutionCompleteEvent(
           gameId: complete.game.id,
           turnNumber: complete.game.worldState.turnState.turnNumber,
+          turnNewsDigest: complete.turnNewsDigest,
         ),
       );
     } else if (result is TurnResolutionPendingOvertures) {
@@ -182,6 +183,7 @@ class GameService {
         TurnResolutionCompleteEvent(
           gameId: complete.game.id,
           turnNumber: complete.game.worldState.turnState.turnNumber,
+          turnNewsDigest: complete.turnNewsDigest,
         ),
       );
     } else if (result is TurnResolutionPendingOvertures) {
@@ -228,6 +230,7 @@ class GameService {
         TurnResolutionCompleteEvent(
           gameId: complete.game.id,
           turnNumber: complete.game.worldState.turnState.turnNumber,
+          turnNewsDigest: complete.turnNewsDigest,
         ),
       );
     } else if (result is TurnResolutionPendingOvertures) {
@@ -270,6 +273,7 @@ class GameService {
         TurnResolutionCompleteEvent(
           gameId: complete.game.id,
           turnNumber: complete.game.worldState.turnState.turnNumber,
+          turnNewsDigest: complete.turnNewsDigest,
         ),
       );
     } else if (result is TurnResolutionPendingOvertures) {

--- a/app/lib/features/game/widgets/turn_news_dialog.dart
+++ b/app/lib/features/game/widgets/turn_news_dialog.dart
@@ -1,0 +1,133 @@
+// Turn-start news modal. SPEC/ui/turn-news-dialog.md.
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+
+import '../../../l10n/app_localizations.dart';
+
+/// [OpenDialogEvent] id. SPEC/program/app-ui-wiring.md.
+const String turnNewsDialogId = 'turn_news';
+
+/// Prior-turn summary dialog; [newTurnNumber] is current turn after resolution.
+class TurnNewsDialog extends StatelessWidget {
+  const TurnNewsDialog({
+    super.key,
+    required this.game,
+    required this.digest,
+    required this.newTurnNumber,
+  });
+
+  final Game game;
+  final TurnNewsDigest digest;
+  final int newTurnNumber;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final lines = digest.lines.isEmpty
+        ? <String>[l10n.turnNews_empty]
+        : digest.lines.map((e) => formatTurnNewsLine(l10n, game, e)).toList();
+
+    return AlertDialog(
+      title: Text(l10n.turnNews_title(newTurnNumber)),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            for (final t in lines)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Text(t),
+              ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l10n.turnNews_close),
+        ),
+      ],
+    );
+  }
+}
+
+String _factionLabel(Game g, String id) {
+  for (final p in g.players) {
+    if (p.id == id) return p.displayName;
+  }
+  for (final m in g.minorNations) {
+    if (m.id == id) return m.displayName ?? m.id;
+  }
+  for (final t in g.tribes) {
+    if (t.id == id) return t.displayName ?? t.id;
+  }
+  return id;
+}
+
+String _provinceLabel(Game g, String fullProvinceId) {
+  for (final r in [g.worldState.oldWorld, g.worldState.newWorld]) {
+    for (final p in r.provinces) {
+      final full = p.id.contains('|') ? p.id : ProvinceId.full(p.regionId, p.id);
+      if (full == fullProvinceId) {
+        return p.displayName ?? fullProvinceId;
+      }
+    }
+  }
+  return fullProvinceId;
+}
+
+String _seaZoneLabel(Game g, String seaZoneId) {
+  return g.worldState.seaZoneDisplayNameById[seaZoneId] ?? seaZoneId;
+}
+
+String _overtureStageLabel(AppLocalizations l10n, OvertureStage s) {
+  return switch (s) {
+    OvertureStage.tradeConsulate => l10n.turnNews_stage_tradeConsulate,
+    OvertureStage.embassy => l10n.turnNews_stage_embassy,
+    OvertureStage.nap => l10n.turnNews_stage_nap,
+    OvertureStage.joinEmpire => l10n.turnNews_stage_joinEmpire,
+    OvertureStage.none => s.name,
+  };
+}
+
+/// Formats one digest line using [game] for display names.
+String formatTurnNewsLine(AppLocalizations l10n, Game game, TurnNewsLine line) {
+  return switch (line) {
+    TurnNewsProvinceCapturedLine(
+      :final provinceId,
+      :final previousOwnerId,
+      :final newOwnerId,
+    ) =>
+      l10n.turnNews_capture(
+        _provinceLabel(game, provinceId),
+        _factionLabel(game, previousOwnerId),
+        _factionLabel(game, newOwnerId),
+      ),
+    TurnNewsDiplomacyLine(:final factionIdA, :final factionIdB, :final kind) =>
+      kind == TurnNewsDiplomacyKind.war
+          ? l10n.turnNews_war(
+              _factionLabel(game, factionIdA),
+              _factionLabel(game, factionIdB),
+            )
+          : l10n.turnNews_peace(
+              _factionLabel(game, factionIdA),
+              _factionLabel(game, factionIdB),
+            ),
+    TurnNewsOvertureAdvancedLine(
+      :final offererGpId,
+      :final targetFactionId,
+      :final newStage,
+    ) =>
+      l10n.turnNews_overture(
+        _factionLabel(game, offererGpId),
+        _factionLabel(game, targetFactionId),
+        _overtureStageLabel(l10n, newStage),
+      ),
+    TurnNewsProvinceDiscoveredLine(:final provinceId) =>
+      l10n.turnNews_provinceDiscovered(_provinceLabel(game, provinceId)),
+    TurnNewsSeaZoneFleetLine(:final seaZoneId) =>
+      l10n.turnNews_seaDiscovered(_seaZoneLabel(game, seaZoneId)),
+  };
+}

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -358,6 +358,71 @@
   "game_intervention_protest": "Diplomatic protest",
   "@game_intervention_protest": {
     "description": "Button: formal protest without military action."
-  }
+  },
+  "turnNews_title": "Turn {turn}",
+  "@turnNews_title": {
+    "description": "Turn-start news dialog title; turn is the current turn after resolution.",
+    "placeholders": {
+      "turn": {"type": "int"}
+    }
+  },
+  "turnNews_empty": "No major events last turn.",
+  "@turnNews_empty": {
+    "description": "Shown when the prior-turn digest has no lines."
+  },
+  "turnNews_close": "Close",
+  "@turnNews_close": {
+    "description": "Button to dismiss the turn news dialog."
+  },
+  "turnNews_capture": "{province}: ownership changed from {prevOwner} to {newOwner}.",
+  "@turnNews_capture": {
+    "placeholders": {
+      "province": {"type": "String"},
+      "prevOwner": {"type": "String"},
+      "newOwner": {"type": "String"}
+    }
+  },
+  "turnNews_war": "{a} and {b} are now at war.",
+  "@turnNews_war": {
+    "placeholders": {
+      "a": {"type": "String"},
+      "b": {"type": "String"}
+    }
+  },
+  "turnNews_peace": "{a} and {b} are now at peace.",
+  "@turnNews_peace": {
+    "placeholders": {
+      "a": {"type": "String"},
+      "b": {"type": "String"}
+    }
+  },
+  "turnNews_overture": "{offerer} advanced relations with {target} ({stage}).",
+  "@turnNews_overture": {
+    "placeholders": {
+      "offerer": {"type": "String"},
+      "target": {"type": "String"},
+      "stage": {"type": "String"}
+    }
+  },
+  "turnNews_provinceDiscovered": "New reports chart {province}.",
+  "@turnNews_provinceDiscovered": {
+    "placeholders": {
+      "province": {"type": "String"}
+    }
+  },
+  "turnNews_seaDiscovered": "A fleet has entered {zone}.",
+  "@turnNews_seaDiscovered": {
+    "placeholders": {
+      "zone": {"type": "String"}
+    }
+  },
+  "turnNews_stage_tradeConsulate": "trade consulate",
+  "@turnNews_stage_tradeConsulate": {"description": "Overture stage label."},
+  "turnNews_stage_embassy": "embassy",
+  "@turnNews_stage_embassy": {"description": "Overture stage label."},
+  "turnNews_stage_nap": "non-aggression pact",
+  "@turnNews_stage_nap": {"description": "Overture stage label."},
+  "turnNews_stage_joinEmpire": "join empire",
+  "@turnNews_stage_joinEmpire": {"description": "Overture stage label."}
 }
 

--- a/app/lib/widgetbook/catalog.dart
+++ b/app/lib/widgetbook/catalog.dart
@@ -23,6 +23,8 @@ import '../features/game/widgets/technology_screen.dart';
 import '../features/game/dialogue/intervention_dialogue_overlay.dart';
 import '../features/game/widgets/train_civilians_dialog.dart';
 import '../features/game/widgets/train_military_dialog.dart';
+import '../features/game/widgets/turn_news_dialog.dart';
+import '../l10n/app_localizations.dart';
 import '../widgets/debug_init_game.dart';
 import '../widgets/ct_choice_chip.dart';
 import '../widgets/debug_map_visibility_story.dart';
@@ -70,6 +72,7 @@ class CtWidgetbookApp extends StatelessWidget {
         ...diplomacyPanelDirectories,
         ...techTreeDirectories,
         ...interventionDialogueDirectories,
+        ...turnNewsDialogDirectories,
       ],
       lightTheme: AppThemes.colonial,
       darkTheme: AppThemes.colonial,
@@ -649,6 +652,155 @@ List<WidgetbookNode> get interventionDialogueDirectories => [
                 skipIntroForTest: true,
                 onDecisions: (_) {},
                 child: const Center(child: Text('Game shell')),
+              ),
+            ),
+          );
+        },
+      ),
+    ],
+  ),
+];
+
+/// Turn news dialog. SPEC/ui/turn-news-dialog.md.
+List<WidgetbookNode> get turnNewsDialogDirectories => [
+  WidgetbookFolder(
+    name: 'Turn news',
+    children: [
+      WidgetbookUseCase(
+        name: 'Sample lines',
+        builder: (context) {
+          final game = Game(
+            id: 'wb_news',
+            worldState: const WorldState(
+              turnState: TurnState(phase: TurnPhase.orders, turnNumber: 3),
+              oldWorld: RegionData(
+                provinces: [
+                  Province(
+                    id: 'oldWorld|P1',
+                    regionId: 'oldWorld',
+                    ownerId: 'gp1',
+                    displayName: 'Sample Province',
+                  ),
+                ],
+              ),
+              newWorld: RegionData(),
+            ),
+            players: const [
+              Player(
+                id: 'gp1',
+                displayName: 'Spain',
+                isHuman: true,
+                treasury: 0,
+              ),
+              Player(
+                id: 'gp2',
+                displayName: 'Portugal',
+                isHuman: false,
+                treasury: 0,
+              ),
+            ],
+          );
+          final digest = TurnNewsDigest(
+            resolvedTurnNumber: 2,
+            lines: [
+              const TurnNewsDiplomacyLine(
+                factionIdA: 'gp1',
+                factionIdB: 'gp2',
+                kind: TurnNewsDiplomacyKind.war,
+              ),
+              const TurnNewsProvinceDiscoveredLine(provinceId: 'oldWorld|P1'),
+            ],
+          );
+          return MaterialApp(
+            theme: AppThemes.colonial,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Center(
+                child: TurnNewsDialog(
+                  game: game,
+                  digest: digest,
+                  newTurnNumber: 3,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'Empty digest',
+        builder: (context) {
+          final game = Game(
+            id: 'wb_news_e',
+            worldState: const WorldState(
+              turnState: TurnState(phase: TurnPhase.orders, turnNumber: 2),
+              oldWorld: RegionData(),
+              newWorld: RegionData(),
+            ),
+            players: const [
+              Player(
+                id: 'gp1',
+                displayName: 'Spain',
+                isHuman: true,
+                treasury: 0,
+              ),
+            ],
+          );
+          return MaterialApp(
+            theme: AppThemes.colonial,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Center(
+                child: TurnNewsDialog(
+                  game: game,
+                  digest: const TurnNewsDigest(
+                    resolvedTurnNumber: 1,
+                    lines: [],
+                  ),
+                  newTurnNumber: 2,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'Mobile viewport',
+        builder: (context) {
+          final game = Game(
+            id: 'wb_news_m',
+            worldState: const WorldState(
+              turnState: TurnState(phase: TurnPhase.orders, turnNumber: 2),
+              oldWorld: RegionData(),
+              newWorld: RegionData(),
+            ),
+            players: const [
+              Player(
+                id: 'gp1',
+                displayName: 'Spain',
+                isHuman: true,
+                treasury: 0,
+              ),
+            ],
+          );
+          return mobileViewport(
+            context,
+            MaterialApp(
+              theme: AppThemes.colonial,
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: Center(
+                  child: TurnNewsDialog(
+                    game: game,
+                    digest: const TurnNewsDigest(
+                      resolvedTurnNumber: 1,
+                      lines: [],
+                    ),
+                    newTurnNumber: 2,
+                  ),
+                ),
               ),
             ),
           );

--- a/app/lib/widgets/game_to_ui_bus_listener.dart
+++ b/app/lib/widgets/game_to_ui_bus_listener.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../features/game/widgets/turn_news_dialog.dart';
 import '../providers/app_event_bus_provider.dart';
 import '../providers/game_service_provider.dart';
 import '../providers/games_provider.dart';
@@ -58,6 +59,21 @@ class _GameToUIBusListenerState extends ConsumerState<GameToUIBusListener> {
       return;
     }
     ref.read(currentGameProvider.notifier).setGame(reloaded);
+    if (event.turnNumber >= 1 &&
+        event.turnNewsDigest != null &&
+        reloaded.victory == null) {
+      final digest = event.turnNewsDigest!;
+      final newTurn = event.turnNumber;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        ref.read(appEventBusProvider).emit(
+              OpenDialogEvent(turnNewsDialogId, {
+                'digest': digest,
+                'newTurnNumber': newTurn,
+              }),
+            );
+      });
+    }
   }
 
   void _onNegotiationMoodUpdate(NegotiationMoodUpdateEvent event) {

--- a/app/test/game_to_ui_bus_listener_test.dart
+++ b/app/test/game_to_ui_bus_listener_test.dart
@@ -41,12 +41,7 @@ void main() {
           newWorld: RegionData(),
         ),
         players: const [
-          Player(
-            id: 'p1',
-            displayName: 'Human',
-            isHuman: true,
-            treasury: 0,
-          ),
+          Player(id: 'p1', displayName: 'Human', isHuman: true, treasury: 0),
         ],
       );
       final updated = game.copyWith(
@@ -81,7 +76,9 @@ void main() {
                 builder: (context, ref, _) {
                   final g = ref.watch(currentGameProvider);
                   return Scaffold(
-                    body: Text('turn:${g?.worldState.turnState.turnNumber ?? -1}'),
+                    body: Text(
+                      'turn:${g?.worldState.turnState.turnNumber ?? -1}',
+                    ),
                   );
                 },
               ),
@@ -115,12 +112,7 @@ void main() {
           newWorld: RegionData(),
         ),
         players: const [
-          Player(
-            id: 'p1',
-            displayName: 'Human',
-            isHuman: true,
-            treasury: 0,
-          ),
+          Player(id: 'p1', displayName: 'Human', isHuman: true, treasury: 0),
         ],
       );
       final updated = game.copyWith(
@@ -175,6 +167,214 @@ void main() {
 
       expect(opens, hasLength(1));
       expect(opens.single.dialogId, 'turn_news');
+    },
+  );
+
+  testWidgets(
+    'Given turn complete at turn 0 with digest When processed Then does not emit OpenDialogEvent',
+    (WidgetTester tester) async {
+      final game = Game(
+        id: 'g_news_turn0',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'Human', isHuman: true, treasury: 0),
+        ],
+      );
+      final updated = game.copyWith(
+        worldState: game.worldState.copyWith(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        ),
+      );
+
+      final adapter = GameSaveAdapter();
+      adapter.save(gamesBox, game);
+
+      final bus = AppEventBus.create();
+      addTearDown(bus.dispose);
+
+      final opens = <OpenDialogEvent>[];
+      final openSub = bus.on<OpenDialogEvent>().listen(opens.add);
+      addTearDown(openSub.cancel);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gamesBoxProvider.overrideWith((ref) => gamesBox),
+            gameSaveAdapterProvider.overrideWith((ref) => adapter),
+            gameServiceProvider.overrideWith((ref) {
+              final svc = GameService(gamesBox, adapter);
+              svc.eventBus = bus;
+              return svc;
+            }),
+            appEventBusProvider.overrideWith((ref) => bus),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+          ],
+          child: MaterialApp(
+            home: GameToUIBusListener(
+              gameId: game.id,
+              child: const SizedBox.shrink(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      adapter.save(gamesBox, updated);
+      bus.emit(
+        TurnResolutionCompleteEvent(
+          gameId: game.id,
+          turnNumber: 0,
+          turnNewsDigest: _emptyDigestForTurn(0),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(opens, isEmpty);
+    },
+  );
+
+  testWidgets(
+    'Given reloaded game has victory When turn complete with digest Then does not emit OpenDialogEvent',
+    (WidgetTester tester) async {
+      final game = Game(
+        id: 'g_news_victory',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'Human', isHuman: true, treasury: 0),
+        ],
+      );
+      final updated = game.copyWith(
+        worldState: game.worldState.copyWith(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+        ),
+        victory: const VictoryState(
+          winnerPlayerId: 'p1',
+          type: VictoryType.military,
+          turnNumber: 2,
+        ),
+      );
+
+      final adapter = GameSaveAdapter();
+      adapter.save(gamesBox, game);
+
+      final bus = AppEventBus.create();
+      addTearDown(bus.dispose);
+
+      final opens = <OpenDialogEvent>[];
+      final openSub = bus.on<OpenDialogEvent>().listen(opens.add);
+      addTearDown(openSub.cancel);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gamesBoxProvider.overrideWith((ref) => gamesBox),
+            gameSaveAdapterProvider.overrideWith((ref) => adapter),
+            gameServiceProvider.overrideWith((ref) {
+              final svc = GameService(gamesBox, adapter);
+              svc.eventBus = bus;
+              return svc;
+            }),
+            appEventBusProvider.overrideWith((ref) => bus),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+          ],
+          child: MaterialApp(
+            home: GameToUIBusListener(
+              gameId: game.id,
+              child: const SizedBox.shrink(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      adapter.save(gamesBox, updated);
+      bus.emit(
+        TurnResolutionCompleteEvent(
+          gameId: game.id,
+          turnNumber: 2,
+          turnNewsDigest: _emptyDigestForTurn(1),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(opens, isEmpty);
+    },
+  );
+
+  testWidgets(
+    'Given turn complete without digest When victory null Then does not emit OpenDialogEvent',
+    (WidgetTester tester) async {
+      final game = Game(
+        id: 'g_news_no_digest',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'Human', isHuman: true, treasury: 0),
+        ],
+      );
+      final updated = game.copyWith(
+        worldState: game.worldState.copyWith(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+        ),
+      );
+
+      final adapter = GameSaveAdapter();
+      adapter.save(gamesBox, game);
+
+      final bus = AppEventBus.create();
+      addTearDown(bus.dispose);
+
+      final opens = <OpenDialogEvent>[];
+      final openSub = bus.on<OpenDialogEvent>().listen(opens.add);
+      addTearDown(openSub.cancel);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gamesBoxProvider.overrideWith((ref) => gamesBox),
+            gameSaveAdapterProvider.overrideWith((ref) => adapter),
+            gameServiceProvider.overrideWith((ref) {
+              final svc = GameService(gamesBox, adapter);
+              svc.eventBus = bus;
+              return svc;
+            }),
+            appEventBusProvider.overrideWith((ref) => bus),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+          ],
+          child: MaterialApp(
+            home: GameToUIBusListener(
+              gameId: game.id,
+              child: const SizedBox.shrink(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      adapter.save(gamesBox, updated);
+      bus.emit(
+        const TurnResolutionCompleteEvent(
+          gameId: 'g_news_no_digest',
+          turnNumber: 2,
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(opens, isEmpty);
     },
   );
 

--- a/app/test/game_to_ui_bus_listener_test.dart
+++ b/app/test/game_to_ui_bus_listener_test.dart
@@ -16,6 +16,9 @@ import 'package:hive/hive.dart';
 import 'package:colonizethis_app/config/constants.dart';
 import 'package:colonizethis_app/providers/games_box_provider.dart';
 
+TurnNewsDigest _emptyDigestForTurn(int resolvedTurn) =>
+    TurnNewsDigest(resolvedTurnNumber: resolvedTurn, lines: const []);
+
 void main() {
   suppressLogsForTests();
 
@@ -98,6 +101,80 @@ void main() {
       await tester.pump();
 
       expect(find.text('turn:2'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'Given turn complete with digest When victory null Then emits OpenDialogEvent',
+    (WidgetTester tester) async {
+      final game = Game(
+        id: 'g_news_1',
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [
+          Player(
+            id: 'p1',
+            displayName: 'Human',
+            isHuman: true,
+            treasury: 0,
+          ),
+        ],
+      );
+      final updated = game.copyWith(
+        worldState: game.worldState.copyWith(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+        ),
+      );
+
+      final adapter = GameSaveAdapter();
+      adapter.save(gamesBox, game);
+
+      final bus = AppEventBus.create();
+      addTearDown(bus.dispose);
+
+      final opens = <OpenDialogEvent>[];
+      final openSub = bus.on<OpenDialogEvent>().listen(opens.add);
+      addTearDown(openSub.cancel);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            gamesBoxProvider.overrideWith((ref) => gamesBox),
+            gameSaveAdapterProvider.overrideWith((ref) => adapter),
+            gameServiceProvider.overrideWith((ref) {
+              final svc = GameService(gamesBox, adapter);
+              svc.eventBus = bus;
+              return svc;
+            }),
+            appEventBusProvider.overrideWith((ref) => bus),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+          ],
+          child: MaterialApp(
+            home: GameToUIBusListener(
+              gameId: game.id,
+              child: const SizedBox.shrink(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      adapter.save(gamesBox, updated);
+      bus.emit(
+        TurnResolutionCompleteEvent(
+          gameId: game.id,
+          turnNumber: 2,
+          turnNewsDigest: _emptyDigestForTurn(1),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(opens, hasLength(1));
+      expect(opens.single.dialogId, 'turn_news');
     },
   );
 

--- a/app/test/turn_news_dialog_test.dart
+++ b/app/test/turn_news_dialog_test.dart
@@ -1,0 +1,84 @@
+// SPEC/ui/turn-news-dialog.md — empty state and formatted lines.
+
+import 'package:colonizethis_app/features/game/widgets/turn_news_dialog.dart';
+import 'package:colonizethis_app/l10n/app_localizations.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  Widget wrapWithL10n(Widget child) {
+    return MaterialApp(
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: child,
+    );
+  }
+
+  final baseGame = Game(
+    id: 'g',
+    worldState: const WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 2),
+      oldWorld: RegionData(),
+      newWorld: RegionData(),
+    ),
+    players: const [
+      Player(id: 'gp1', displayName: 'England', isHuman: true, treasury: 0),
+      Player(id: 'gp2', displayName: 'France', isHuman: false, treasury: 0),
+    ],
+  );
+
+  testWidgets(
+    'Given empty digest When dialog built Then shows empty-state copy',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        wrapWithL10n(
+          TurnNewsDialog(
+            game: baseGame,
+            digest: const TurnNewsDigest(resolvedTurnNumber: 1, lines: []),
+            newTurnNumber: 2,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('No major events last turn.'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'Given war digest line When dialog built Then shows localized war text',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        wrapWithL10n(
+          TurnNewsDialog(
+            game: baseGame,
+            digest: const TurnNewsDigest(
+              resolvedTurnNumber: 1,
+              lines: [
+                TurnNewsDiplomacyLine(
+                  factionIdA: 'gp1',
+                  factionIdB: 'gp2',
+                  kind: TurnNewsDiplomacyKind.war,
+                ),
+              ],
+            ),
+            newTurnNumber: 2,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('England and France are now at war.'), findsOneWidget);
+    },
+  );
+}

--- a/packages/colonizethis_logic/lib/colonizethis_logic.dart
+++ b/packages/colonizethis_logic/lib/colonizethis_logic.dart
@@ -22,6 +22,7 @@ export 'src/setup/province_name_fallback.dart';
 export 'src/turn/research_resolver.dart';
 export 'src/turn/turn_resolution_result.dart';
 export 'src/turn/turn_resolver.dart';
+export 'src/turn/turn_news_digest.dart';
 
 // Combat
 export 'src/combat/battle_general_assignment.dart';

--- a/packages/colonizethis_logic/lib/src/game_events.dart
+++ b/packages/colonizethis_logic/lib/src/game_events.dart
@@ -53,7 +53,11 @@ class NavalCombatResultEvent extends GameEvent {
   final bool side2Retreated;
 }
 
-/// Province ownership changed.
+/// Province ownership changed (faction-to-faction handover).
+///
+/// When emitted from turn resolution (`emitProvinceCapturedEvents`),
+/// [previousOwnerId] and [newOwnerId] are both non-empty faction ids.
+/// See SPEC/game/world-model.md.
 class ProvinceCapturedEvent extends GameEvent {
   const ProvinceCapturedEvent({
     required this.provinceId,
@@ -64,7 +68,9 @@ class ProvinceCapturedEvent extends GameEvent {
 
   /// Province id in prefixed form (regionId|localId).
   final String provinceId;
+  /// Non-empty prior owner when emitted from turn resolution.
   final String? previousOwnerId;
+  /// Non-empty new owner when emitted from turn resolution.
   final String newOwnerId;
   final int turnNumber;
 }

--- a/packages/colonizethis_logic/lib/src/turn/turn_news_digest.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_news_digest.dart
@@ -20,14 +20,18 @@ import '../world/player_view.dart';
   final diplomacy = _diplomacyLines(start, end);
   final overtures = _overtureLines(start, end);
 
-  final provReadDone =
-      Set<String>.from(start.worldState.newsDigestProvinceRevealDoneIds);
-  final provWriteDone =
-      Set<String>.from(start.worldState.newsDigestProvinceRevealDoneIds);
-  final seaReadDone =
-      Set<String>.from(start.worldState.newsDigestSeaZoneFleetDoneIds);
-  final seaWriteDone =
-      Set<String>.from(start.worldState.newsDigestSeaZoneFleetDoneIds);
+  final provReadDone = Set<String>.from(
+    start.worldState.newsDigestProvinceRevealDoneIds,
+  );
+  final provWriteDone = Set<String>.from(
+    start.worldState.newsDigestProvinceRevealDoneIds,
+  );
+  final seaReadDone = Set<String>.from(
+    start.worldState.newsDigestSeaZoneFleetDoneIds,
+  );
+  final seaWriteDone = Set<String>.from(
+    start.worldState.newsDigestSeaZoneFleetDoneIds,
+  );
 
   final discoveries = _provinceDiscoveryLines(
     start: start,
@@ -72,10 +76,9 @@ List<TurnNewsProvinceCapturedLine> _provinceCaptureLines(Game start, Game end) {
       final pid = _fullProvinceId(prov);
       final before = _ownerForProvince(start, pid);
       final after = _ownerForProvince(end, pid);
-      if (before != null &&
-          before.isNotEmpty &&
-          after != before &&
-          (after ?? '').isNotEmpty) {
+      // Same predicate as emitProvinceCapturedEvents (previousOwner != null &&
+      // previousOwner != prov.ownerId).
+      if (before != null && before != after) {
         out.add(
           TurnNewsProvinceCapturedLine(
             provinceId: pid,
@@ -112,8 +115,7 @@ Map<String, RelationState> _pairToState(Game g) {
   return m;
 }
 
-String _pairKey(String a, String b) =>
-    a.compareTo(b) <= 0 ? '$a|$b' : '$b|$a';
+String _pairKey(String a, String b) => a.compareTo(b) <= 0 ? '$a|$b' : '$b|$a';
 
 List<TurnNewsDiplomacyLine> _diplomacyLines(Game start, Game end) {
   final startMap = _pairToState(start);

--- a/packages/colonizethis_logic/lib/src/turn/turn_news_digest.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_news_digest.dart
@@ -1,0 +1,268 @@
+// Deterministic prior-turn news digest. SPEC/program/turn-news-digest.md.
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../world/player_view.dart';
+
+/// Builds digest lines and world-state tracking updates for the completed turn.
+/// [start] is game at resolution entry (after military ensure); [end] is final
+/// state including turn increment. Returns null digest when [end.victory] is set.
+({TurnNewsDigest? digest, Game game}) buildTurnNewsDigestForComplete({
+  required Game start,
+  required Game end,
+}) {
+  if (end.victory != null) {
+    return (digest: null, game: end);
+  }
+
+  final resolvedTurn = start.worldState.turnState.turnNumber;
+  final captures = _provinceCaptureLines(start, end);
+  final diplomacy = _diplomacyLines(start, end);
+  final overtures = _overtureLines(start, end);
+
+  final provReadDone =
+      Set<String>.from(start.worldState.newsDigestProvinceRevealDoneIds);
+  final provWriteDone =
+      Set<String>.from(start.worldState.newsDigestProvinceRevealDoneIds);
+  final seaReadDone =
+      Set<String>.from(start.worldState.newsDigestSeaZoneFleetDoneIds);
+  final seaWriteDone =
+      Set<String>.from(start.worldState.newsDigestSeaZoneFleetDoneIds);
+
+  final discoveries = _provinceDiscoveryLines(
+    start: start,
+    end: end,
+    readDone: provReadDone,
+    writeDone: provWriteDone,
+  );
+  final seaLines = _seaZoneFleetLines(
+    end: end,
+    readDone: seaReadDone,
+    writeDone: seaWriteDone,
+  );
+
+  final lines = <TurnNewsLine>[
+    ...captures,
+    ...diplomacy,
+    ...overtures,
+    ...discoveries,
+    ...seaLines,
+  ];
+
+  final sortedProv = provWriteDone.toList()..sort();
+  final sortedSea = seaWriteDone.toList()..sort();
+
+  final patched = end.copyWith(
+    worldState: end.worldState.copyWith(
+      newsDigestProvinceRevealDoneIds: sortedProv,
+      newsDigestSeaZoneFleetDoneIds: sortedSea,
+    ),
+  );
+
+  return (
+    digest: TurnNewsDigest(resolvedTurnNumber: resolvedTurn, lines: lines),
+    game: patched,
+  );
+}
+
+List<TurnNewsProvinceCapturedLine> _provinceCaptureLines(Game start, Game end) {
+  final out = <TurnNewsProvinceCapturedLine>[];
+  for (final region in [end.worldState.oldWorld, end.worldState.newWorld]) {
+    for (final prov in region.provinces) {
+      final pid = _fullProvinceId(prov);
+      final before = _ownerForProvince(start, pid);
+      final after = _ownerForProvince(end, pid);
+      if (before != null &&
+          before.isNotEmpty &&
+          after != before &&
+          (after ?? '').isNotEmpty) {
+        out.add(
+          TurnNewsProvinceCapturedLine(
+            provinceId: pid,
+            previousOwnerId: before,
+            newOwnerId: after ?? '',
+          ),
+        );
+      }
+    }
+  }
+  out.sort((a, b) => a.provinceId.compareTo(b.provinceId));
+  return out;
+}
+
+String? _ownerForProvince(Game g, String fullProvinceId) {
+  for (final region in [g.worldState.oldWorld, g.worldState.newWorld]) {
+    for (final p in region.provinces) {
+      if (_fullProvinceId(p) == fullProvinceId) {
+        return p.ownerId;
+      }
+    }
+  }
+  return null;
+}
+
+String _fullProvinceId(Province p) =>
+    p.id.contains('|') ? p.id : ProvinceId.full(p.regionId, p.id);
+
+Map<String, RelationState> _pairToState(Game g) {
+  final m = <String, RelationState>{};
+  for (final r in g.diplomacyRelations) {
+    m[_pairKey(r.factionId1, r.factionId2)] = r.state;
+  }
+  return m;
+}
+
+String _pairKey(String a, String b) =>
+    a.compareTo(b) <= 0 ? '$a|$b' : '$b|$a';
+
+List<TurnNewsDiplomacyLine> _diplomacyLines(Game start, Game end) {
+  final startMap = _pairToState(start);
+  final endMap = _pairToState(end);
+  final keys = {...startMap.keys, ...endMap.keys}.toList()..sort();
+  final out = <TurnNewsDiplomacyLine>[];
+  for (final k in keys) {
+    final before = startMap[k];
+    final after = endMap[k];
+    if (before == after) continue;
+    final parts = k.split('|');
+    if (parts.length != 2) continue;
+    final fa = parts[0];
+    final fb = parts[1];
+    if (after == RelationState.atWar && before != RelationState.atWar) {
+      out.add(
+        TurnNewsDiplomacyLine(
+          factionIdA: fa,
+          factionIdB: fb,
+          kind: TurnNewsDiplomacyKind.war,
+        ),
+      );
+    }
+    if (after == RelationState.atPeace && before == RelationState.atWar) {
+      out.add(
+        TurnNewsDiplomacyLine(
+          factionIdA: fa,
+          factionIdB: fb,
+          kind: TurnNewsDiplomacyKind.peace,
+        ),
+      );
+    }
+  }
+  return out;
+}
+
+List<TurnNewsOvertureAdvancedLine> _overtureLines(Game start, Game end) {
+  OvertureStage stageFor(String gp, String target, Game g) {
+    for (final o in g.overtureStates) {
+      if (o.gpId == gp && o.targetId == target) {
+        return o.stage;
+      }
+    }
+    return OvertureStage.none;
+  }
+
+  final out = <TurnNewsOvertureAdvancedLine>[];
+  for (final o in end.overtureStates) {
+    final prev = stageFor(o.gpId, o.targetId, start);
+    if (o.stage.index > prev.index) {
+      out.add(
+        TurnNewsOvertureAdvancedLine(
+          offererGpId: o.gpId,
+          targetFactionId: o.targetId,
+          newStage: o.stage,
+        ),
+      );
+    }
+  }
+  out.sort((a, b) {
+    final c = a.offererGpId.compareTo(b.offererGpId);
+    if (c != 0) return c;
+    final d = a.targetFactionId.compareTo(b.targetFactionId);
+    if (d != 0) return d;
+    return a.newStage.name.compareTo(b.newStage.name);
+  });
+  return out;
+}
+
+bool _provinceKnownToAnyGp(Game g, Province p) {
+  final regionId = p.regionId;
+  final local = ProvinceId.localIdFrom(_fullProvinceId(p));
+  final keys =
+      g.worldState.tileKeysByRegionAndProvince[regionId]?[local] ??
+      const <String>[];
+  if (keys.isEmpty) {
+    return false;
+  }
+  for (final player in g.players) {
+    final vis = g.worldState.playerVisibilityByTile[player.id] ?? {};
+    for (final tk in keys) {
+      if (_parseVis(vis[tk]) != VisibilityLevel.unknown) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+VisibilityLevel _parseVis(String? raw) {
+  if (raw == null) return VisibilityLevel.unknown;
+  for (final v in VisibilityLevel.values) {
+    if (v.name == raw) return v;
+  }
+  return VisibilityLevel.unknown;
+}
+
+List<TurnNewsProvinceDiscoveredLine> _provinceDiscoveryLines({
+  required Game start,
+  required Game end,
+  required Set<String> readDone,
+  required Set<String> writeDone,
+}) {
+  final out = <TurnNewsProvinceDiscoveredLine>[];
+  final seen = <String>{};
+  for (final region in [end.worldState.oldWorld, end.worldState.newWorld]) {
+    for (final p in region.provinces) {
+      final pid = _fullProvinceId(p);
+      if (seen.contains(pid)) continue;
+      seen.add(pid);
+      if (readDone.contains(pid)) continue;
+      final was = _provinceKnownToAnyGp(start, p);
+      final now = _provinceKnownToAnyGp(end, p);
+      if (!was && now) {
+        out.add(TurnNewsProvinceDiscoveredLine(provinceId: pid));
+        writeDone.add(pid);
+      }
+    }
+  }
+  out.sort((a, b) => a.provinceId.compareTo(b.provinceId));
+  return out;
+}
+
+String _fullSeaZoneId(Fleet f) {
+  final z = f.seaZoneId!;
+  return z.contains('|') ? z : ProvinceId.full(f.regionId, z);
+}
+
+Set<String> _seaZonesWithFleets(Game g) {
+  final s = <String>{};
+  for (final f in g.worldState.fleets) {
+    if (f.isAtSea) {
+      s.add(_fullSeaZoneId(f));
+    }
+  }
+  return s;
+}
+
+List<TurnNewsSeaZoneFleetLine> _seaZoneFleetLines({
+  required Game end,
+  required Set<String> readDone,
+  required Set<String> writeDone,
+}) {
+  final zones = _seaZonesWithFleets(end).toList()..sort();
+  final out = <TurnNewsSeaZoneFleetLine>[];
+  for (final z in zones) {
+    if (readDone.contains(z)) continue;
+    out.add(TurnNewsSeaZoneFleetLine(seaZoneId: z));
+    writeDone.add(z);
+  }
+  return out;
+}

--- a/packages/colonizethis_logic/lib/src/turn/turn_news_digest.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_news_digest.dart
@@ -76,14 +76,18 @@ List<TurnNewsProvinceCapturedLine> _provinceCaptureLines(Game start, Game end) {
       final pid = _fullProvinceId(prov);
       final before = _ownerForProvince(start, pid);
       final after = _ownerForProvince(end, pid);
-      // Same predicate as emitProvinceCapturedEvents (previousOwner != null &&
-      // previousOwner != prov.ownerId).
-      if (before != null && before != after) {
+      // Same predicate as emitProvinceCapturedEvents: both owners non-empty faction
+      // ids and owner changed (no null/empty "new owner" capture). See SPEC/game/world-model.md.
+      if (before != null &&
+          before.isNotEmpty &&
+          after != null &&
+          after.isNotEmpty &&
+          before != after) {
         out.add(
           TurnNewsProvinceCapturedLine(
             provinceId: pid,
             previousOwnerId: before,
-            newOwnerId: after ?? '',
+            newOwnerId: after,
           ),
         );
       }

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolution_events.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolution_events.dart
@@ -97,6 +97,10 @@ void emitDiplomacyChangeEvents(
 }
 
 /// Emit province_captured for each province whose owner changed vs [previousOwnership].
+///
+/// Only when **both** previous and new owners are non-empty faction ids (handover to
+/// another faction). Null/empty `ownerId` is uncolonized frontier only, not a capture
+/// outcome. SPEC/game/world-model.md § Invariants.
 void emitProvinceCapturedEvents(
   Map<String, String?> previousOwnership,
   Game stateAfter,
@@ -111,11 +115,16 @@ void emitProvinceCapturedEvents(
   ]) {
     for (final prov in region.provinces) {
       final previousOwner = previousOwnership[prov.id];
-      if (previousOwner != null && previousOwner != prov.ownerId) {
+      final newOwner = prov.ownerId;
+      if (previousOwner != null &&
+          previousOwner.isNotEmpty &&
+          newOwner != null &&
+          newOwner.isNotEmpty &&
+          previousOwner != newOwner) {
         final event = ProvinceCapturedEvent(
           provinceId: prov.id,
           previousOwnerId: previousOwner,
-          newOwnerId: prov.ownerId ?? '',
+          newOwnerId: newOwner,
           turnNumber: turn,
         );
         deliverGameEvent(event, eventBus: eventBus, onGameEvent: onGameEvent);

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolution_result.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolution_result.dart
@@ -202,8 +202,10 @@ sealed class TurnResolutionResult {
 
 /// Turn resolution completed; [game] is the final state.
 class TurnResolutionComplete extends TurnResolutionResult {
-  const TurnResolutionComplete(this.game);
+  const TurnResolutionComplete(this.game, {this.turnNewsDigest});
   final Game game;
+  /// Null when [game.victory] was set this resolution (news dialog suppressed).
+  final TurnNewsDigest? turnNewsDigest;
 }
 
 /// Turn resolution suspended: [game] is state at suspension; [pendingOvertures]

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -27,6 +27,7 @@ import '../orders/orders_application.dart';
 import '../economy/resource_extractor.dart';
 import '../economy/sea_transport.dart';
 import 'research_resolver.dart';
+import 'turn_news_digest.dart';
 import '../world/naval.dart';
 import '../world/naval_resolution.dart';
 import '../dossier/evidence_rules.dart';
@@ -224,6 +225,7 @@ TurnResolutionResult resolveTurnForGame({
   final turn = game.worldState.turnState.turnNumber;
   _log.i('turn $turn resolve start');
   Game state = ensureMilitaryArmiesForGame(game);
+  final gameAtResolutionStart = state;
   final landFeedingCoverageByPlayerId = <String, double>{};
   final navalFeedingCoverageByPlayerId = <String, double>{};
   final idleLabourByPlayerId = <String, WorkerIdleCounts>{};
@@ -410,7 +412,14 @@ TurnResolutionResult resolveTurnForGame({
   }
 
   _log.i('turn $turn resolve end');
-  return TurnResolutionComplete(state);
+  final news = buildTurnNewsDigestForComplete(
+    start: gameAtResolutionStart,
+    end: state,
+  );
+  return TurnResolutionComplete(
+    news.game,
+    turnNewsDigest: news.digest,
+  );
 }
 
 /// Returns the game when [result] is [TurnResolutionComplete]; throws when pending.

--- a/packages/colonizethis_logic/test/turn_news_digest_test.dart
+++ b/packages/colonizethis_logic/test/turn_news_digest_test.dart
@@ -2,6 +2,77 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:test/test.dart';
 
+void _expectDigestLinesEqual(TurnNewsDigest a, TurnNewsDigest b) {
+  expect(a.resolvedTurnNumber, b.resolvedTurnNumber);
+  expect(a.lines.length, b.lines.length);
+  for (var i = 0; i < a.lines.length; i++) {
+    _expectLineEqual(a.lines[i], b.lines[i]);
+  }
+}
+
+void _expectLineEqual(TurnNewsLine x, TurnNewsLine y) {
+  expect(x.runtimeType, y.runtimeType);
+  switch ((x, y)) {
+    case (
+      TurnNewsProvinceCapturedLine(
+        provinceId: final ap,
+        previousOwnerId: final a1,
+        newOwnerId: final a2,
+      ),
+      TurnNewsProvinceCapturedLine(
+        provinceId: final bp,
+        previousOwnerId: final b1,
+        newOwnerId: final b2,
+      ),
+    ):
+      expect(ap, bp);
+      expect(a1, b1);
+      expect(a2, b2);
+    case (
+      TurnNewsDiplomacyLine(
+        factionIdA: final aa,
+        factionIdB: final ab,
+        kind: final ak,
+      ),
+      TurnNewsDiplomacyLine(
+        factionIdA: final ba,
+        factionIdB: final bb,
+        kind: final bk,
+      ),
+    ):
+      expect(aa, ba);
+      expect(ab, bb);
+      expect(ak, bk);
+    case (
+      TurnNewsOvertureAdvancedLine(
+        offererGpId: final ao,
+        targetFactionId: final at,
+        newStage: final as_,
+      ),
+      TurnNewsOvertureAdvancedLine(
+        offererGpId: final bo,
+        targetFactionId: final bt,
+        newStage: final bs,
+      ),
+    ):
+      expect(ao, bo);
+      expect(at, bt);
+      expect(as_, bs);
+    case (
+      TurnNewsProvinceDiscoveredLine(provinceId: final ap),
+      TurnNewsProvinceDiscoveredLine(provinceId: final bp),
+    ):
+      expect(ap, bp);
+    case (
+      TurnNewsSeaZoneFleetLine(seaZoneId: final az),
+      TurnNewsSeaZoneFleetLine(seaZoneId: final bz),
+    ):
+      expect(az, bz);
+    default:
+      fail('Unexpected line pair: $x vs $y');
+  }
+}
+
 void main() {
   group('buildTurnNewsDigestForComplete', () {
     test('Given victory on end state When build Then digest is null', () {
@@ -19,79 +90,245 @@ void main() {
     });
 
     test('Given relation atPeace to atWar When build Then war line', () {
-      final start = _twoGpGame(
-        turn: 0,
-        relState: RelationState.atPeace,
-      );
-      final end = _twoGpGame(
-        turn: 1,
-        relState: RelationState.atWar,
-      );
+      final start = _twoGpGame(turn: 0, relState: RelationState.atPeace);
+      final end = _twoGpGame(turn: 1, relState: RelationState.atWar);
       final r = buildTurnNewsDigestForComplete(start: start, end: end);
       expect(r.digest, isNotNull);
       final warLines = r.digest!.lines.whereType<TurnNewsDiplomacyLine>();
       expect(warLines, hasLength(1));
       expect(warLines.single.kind, TurnNewsDiplomacyKind.war);
-      expect(
-        {warLines.single.factionIdA, warLines.single.factionIdB},
-        equals({'gp1', 'gp2'}),
-      );
+      expect({
+        warLines.single.factionIdA,
+        warLines.single.factionIdB,
+      }, equals({'gp1', 'gp2'}));
     });
 
-    test('Given first province reveal When build Then discovery line and id tracked',
-        () {
-      const regionId = 'oldWorld';
-      const localPid = 'P1';
-      final fullPid = ProvinceId.full(regionId, localPid);
-      final start = _gameWithProvinceVis(
-        turn: 0,
-        fullProvinceId: fullPid,
-        regionId: regionId,
-        localProvinceId: localPid,
-        visibility: 'unknown',
-      );
-      final end = _gameWithProvinceVis(
-        turn: 1,
-        fullProvinceId: fullPid,
-        regionId: regionId,
-        localProvinceId: localPid,
-        visibility: 'revealed',
-      );
+    test(
+      'Given first province reveal When build Then discovery line and id tracked',
+      () {
+        const regionId = 'oldWorld';
+        const localPid = 'P1';
+        final fullPid = ProvinceId.full(regionId, localPid);
+        final start = _gameWithProvinceVis(
+          turn: 0,
+          fullProvinceId: fullPid,
+          regionId: regionId,
+          localProvinceId: localPid,
+          visibility: 'unknown',
+        );
+        final end = _gameWithProvinceVis(
+          turn: 1,
+          fullProvinceId: fullPid,
+          regionId: regionId,
+          localProvinceId: localPid,
+          visibility: 'revealed',
+        );
+        final r = buildTurnNewsDigestForComplete(start: start, end: end);
+        expect(
+          r.game.worldState.newsDigestProvinceRevealDoneIds,
+          contains(fullPid),
+        );
+        final disc = r.digest!.lines
+            .whereType<TurnNewsProvinceDiscoveredLine>();
+        expect(disc, hasLength(1));
+        expect(disc.single.provinceId, fullPid);
+      },
+    );
+
+    test(
+      'Given province ownership gp1 to null When build Then capture line matches ProvinceCapturedEvent rule',
+      () {
+        const regionId = 'oldWorld';
+        const localPid = 'P1';
+        final fullPid = ProvinceId.full(regionId, localPid);
+        final start = Game(
+          id: 'g',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: fullPid, regionId: regionId, ownerId: 'gp1'),
+              ],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'A', isHuman: true, treasury: 0),
+          ],
+        );
+        final end = Game(
+          id: 'g',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: fullPid, regionId: regionId, ownerId: null),
+              ],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'A', isHuman: true, treasury: 0),
+          ],
+        );
+        final r = buildTurnNewsDigestForComplete(start: start, end: end);
+        final caps = r.digest!.lines.whereType<TurnNewsProvinceCapturedLine>();
+        expect(caps, hasLength(1));
+        expect(caps.single.provinceId, fullPid);
+        expect(caps.single.previousOwnerId, 'gp1');
+        expect(caps.single.newOwnerId, '');
+      },
+    );
+
+    test('Given relation atWar to atPeace When build Then peace line', () {
+      final start = _twoGpGame(turn: 0, relState: RelationState.atWar);
+      final end = _twoGpGame(turn: 1, relState: RelationState.atPeace);
       final r = buildTurnNewsDigestForComplete(start: start, end: end);
-      expect(
-        r.game.worldState.newsDigestProvinceRevealDoneIds,
-        contains(fullPid),
-      );
-      final disc = r.digest!.lines.whereType<TurnNewsProvinceDiscoveredLine>();
-      expect(disc, hasLength(1));
-      expect(disc.single.provinceId, fullPid);
+      final dip = r.digest!.lines.whereType<TurnNewsDiplomacyLine>();
+      expect(dip, hasLength(1));
+      expect(dip.single.kind, TurnNewsDiplomacyKind.peace);
+      expect({
+        dip.single.factionIdA,
+        dip.single.factionIdB,
+      }, equals({'gp1', 'gp2'}));
     });
 
-    test('Given province already in reveal done When reveal again Then no second discovery',
-        () {
-      const regionId = 'oldWorld';
-      const localPid = 'P1';
-      final fullPid = ProvinceId.full(regionId, localPid);
-      final start = _gameWithProvinceVis(
-        turn: 1,
-        fullProvinceId: fullPid,
-        regionId: regionId,
-        localProvinceId: localPid,
-        visibility: 'unknown',
-        revealDone: [fullPid],
-      );
-      final end = _gameWithProvinceVis(
-        turn: 2,
-        fullProvinceId: fullPid,
-        regionId: regionId,
-        localProvinceId: localPid,
-        visibility: 'revealed',
-        revealDone: [fullPid],
-      );
-      final r = buildTurnNewsDigestForComplete(start: start, end: end);
-      final disc = r.digest!.lines.whereType<TurnNewsProvinceDiscoveredLine>();
-      expect(disc, isEmpty);
-    });
+    test(
+      'Given overture stage advances When build Then overture line sorted',
+      () {
+        final start = Game(
+          id: 'g',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'A', isHuman: true, treasury: 0),
+          ],
+          overtureStates: const [
+            OvertureState(
+              gpId: 'gp1',
+              targetId: 'm1',
+              stage: OvertureStage.none,
+            ),
+          ],
+        );
+        final end = Game(
+          id: 'g',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'A', isHuman: true, treasury: 0),
+          ],
+          overtureStates: const [
+            OvertureState(
+              gpId: 'gp1',
+              targetId: 'm1',
+              stage: OvertureStage.tradeConsulate,
+            ),
+          ],
+        );
+        final r = buildTurnNewsDigestForComplete(start: start, end: end);
+        final ov = r.digest!.lines.whereType<TurnNewsOvertureAdvancedLine>();
+        expect(ov, hasLength(1));
+        expect(ov.single.offererGpId, 'gp1');
+        expect(ov.single.targetFactionId, 'm1');
+        expect(ov.single.newStage, OvertureStage.tradeConsulate);
+      },
+    );
+
+    test(
+      'Given first fleet at sea in zone When build Then sea line and id tracked',
+      () {
+        const regionId = 'oldWorld';
+        const localSea = 'seaA';
+        final fullSea = ProvinceId.full(regionId, localSea);
+        final fleet = Fleet(
+          id: 'fl1',
+          ownerId: 'gp1',
+          regionId: regionId,
+          seaZoneId: localSea,
+          ships: const [ShipInstance(id: 'ship_1', typeId: 'carrack')],
+        );
+        final start = Game(
+          id: 'g',
+          worldState: const WorldState(
+            turnState: TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(),
+            newWorld: RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'A', isHuman: true, treasury: 0),
+          ],
+        );
+        final end = Game(
+          id: 'g',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+            fleets: [fleet],
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'A', isHuman: true, treasury: 0),
+          ],
+        );
+        final r = buildTurnNewsDigestForComplete(start: start, end: end);
+        expect(
+          r.game.worldState.newsDigestSeaZoneFleetDoneIds,
+          contains(fullSea),
+        );
+        final sea = r.digest!.lines.whereType<TurnNewsSeaZoneFleetLine>();
+        expect(sea, hasLength(1));
+        expect(sea.single.seaZoneId, fullSea);
+      },
+    );
+
+    test(
+      'Given same start and end When build twice Then identical digest lines',
+      () {
+        final start = _twoGpGame(turn: 0, relState: RelationState.atPeace);
+        final end = _twoGpGame(turn: 1, relState: RelationState.atWar);
+        final r1 = buildTurnNewsDigestForComplete(start: start, end: end);
+        final r2 = buildTurnNewsDigestForComplete(start: start, end: end);
+        expect(r1.digest, isNotNull);
+        expect(r2.digest, isNotNull);
+        _expectDigestLinesEqual(r1.digest!, r2.digest!);
+      },
+    );
+
+    test(
+      'Given province already in reveal done When reveal again Then no second discovery',
+      () {
+        const regionId = 'oldWorld';
+        const localPid = 'P1';
+        final fullPid = ProvinceId.full(regionId, localPid);
+        final start = _gameWithProvinceVis(
+          turn: 1,
+          fullProvinceId: fullPid,
+          regionId: regionId,
+          localProvinceId: localPid,
+          visibility: 'unknown',
+          revealDone: [fullPid],
+        );
+        final end = _gameWithProvinceVis(
+          turn: 2,
+          fullProvinceId: fullPid,
+          regionId: regionId,
+          localProvinceId: localPid,
+          visibility: 'revealed',
+          revealDone: [fullPid],
+        );
+        final r = buildTurnNewsDigestForComplete(start: start, end: end);
+        final disc = r.digest!.lines
+            .whereType<TurnNewsProvinceDiscoveredLine>();
+        expect(disc, isEmpty);
+      },
+    );
   });
 }
 
@@ -104,12 +341,7 @@ Game _minimalGame({required int turn}) {
       newWorld: const RegionData(),
     ),
     players: const [
-      Player(
-        id: 'gp1',
-        displayName: 'A',
-        isHuman: true,
-        treasury: 0,
-      ),
+      Player(id: 'gp1', displayName: 'A', isHuman: true, treasury: 0),
     ],
   );
 }
@@ -127,11 +359,7 @@ Game _twoGpGame({required int turn, required RelationState relState}) {
       Player(id: 'gp2', displayName: 'B', isHuman: false, treasury: 0),
     ],
     diplomacyRelations: [
-      DiplomacyRelation(
-        factionId1: 'gp1',
-        factionId2: 'gp2',
-        state: relState,
-      ),
+      DiplomacyRelation(factionId1: 'gp1', factionId2: 'gp2', state: relState),
     ],
   );
 }
@@ -156,7 +384,9 @@ Game _gameWithProvinceVis({
       ),
       newWorld: const RegionData(),
       tileKeysByRegionAndProvince: {
-        regionId: {localProvinceId: [tileKey]},
+        regionId: {
+          localProvinceId: [tileKey],
+        },
       },
       playerVisibilityByTile: {
         'gp1': {tileKey: visibility},

--- a/packages/colonizethis_logic/test/turn_news_digest_test.dart
+++ b/packages/colonizethis_logic/test/turn_news_digest_test.dart
@@ -1,0 +1,170 @@
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('buildTurnNewsDigestForComplete', () {
+    test('Given victory on end state When build Then digest is null', () {
+      final start = _minimalGame(turn: 5);
+      final end = start.copyWith(
+        victory: const VictoryState(
+          winnerPlayerId: 'gp1',
+          type: VictoryType.military,
+          turnNumber: 5,
+        ),
+      );
+      final r = buildTurnNewsDigestForComplete(start: start, end: end);
+      expect(r.digest, isNull);
+      expect(r.game, same(end));
+    });
+
+    test('Given relation atPeace to atWar When build Then war line', () {
+      final start = _twoGpGame(
+        turn: 0,
+        relState: RelationState.atPeace,
+      );
+      final end = _twoGpGame(
+        turn: 1,
+        relState: RelationState.atWar,
+      );
+      final r = buildTurnNewsDigestForComplete(start: start, end: end);
+      expect(r.digest, isNotNull);
+      final warLines = r.digest!.lines.whereType<TurnNewsDiplomacyLine>();
+      expect(warLines, hasLength(1));
+      expect(warLines.single.kind, TurnNewsDiplomacyKind.war);
+      expect(
+        {warLines.single.factionIdA, warLines.single.factionIdB},
+        equals({'gp1', 'gp2'}),
+      );
+    });
+
+    test('Given first province reveal When build Then discovery line and id tracked',
+        () {
+      const regionId = 'oldWorld';
+      const localPid = 'P1';
+      final fullPid = ProvinceId.full(regionId, localPid);
+      final start = _gameWithProvinceVis(
+        turn: 0,
+        fullProvinceId: fullPid,
+        regionId: regionId,
+        localProvinceId: localPid,
+        visibility: 'unknown',
+      );
+      final end = _gameWithProvinceVis(
+        turn: 1,
+        fullProvinceId: fullPid,
+        regionId: regionId,
+        localProvinceId: localPid,
+        visibility: 'revealed',
+      );
+      final r = buildTurnNewsDigestForComplete(start: start, end: end);
+      expect(
+        r.game.worldState.newsDigestProvinceRevealDoneIds,
+        contains(fullPid),
+      );
+      final disc = r.digest!.lines.whereType<TurnNewsProvinceDiscoveredLine>();
+      expect(disc, hasLength(1));
+      expect(disc.single.provinceId, fullPid);
+    });
+
+    test('Given province already in reveal done When reveal again Then no second discovery',
+        () {
+      const regionId = 'oldWorld';
+      const localPid = 'P1';
+      final fullPid = ProvinceId.full(regionId, localPid);
+      final start = _gameWithProvinceVis(
+        turn: 1,
+        fullProvinceId: fullPid,
+        regionId: regionId,
+        localProvinceId: localPid,
+        visibility: 'unknown',
+        revealDone: [fullPid],
+      );
+      final end = _gameWithProvinceVis(
+        turn: 2,
+        fullProvinceId: fullPid,
+        regionId: regionId,
+        localProvinceId: localPid,
+        visibility: 'revealed',
+        revealDone: [fullPid],
+      );
+      final r = buildTurnNewsDigestForComplete(start: start, end: end);
+      final disc = r.digest!.lines.whereType<TurnNewsProvinceDiscoveredLine>();
+      expect(disc, isEmpty);
+    });
+  });
+}
+
+Game _minimalGame({required int turn}) {
+  return Game(
+    id: 'g',
+    worldState: WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: turn),
+      oldWorld: const RegionData(),
+      newWorld: const RegionData(),
+    ),
+    players: const [
+      Player(
+        id: 'gp1',
+        displayName: 'A',
+        isHuman: true,
+        treasury: 0,
+      ),
+    ],
+  );
+}
+
+Game _twoGpGame({required int turn, required RelationState relState}) {
+  return Game(
+    id: 'g',
+    worldState: WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: turn),
+      oldWorld: const RegionData(),
+      newWorld: const RegionData(),
+    ),
+    players: const [
+      Player(id: 'gp1', displayName: 'A', isHuman: true, treasury: 0),
+      Player(id: 'gp2', displayName: 'B', isHuman: false, treasury: 0),
+    ],
+    diplomacyRelations: [
+      DiplomacyRelation(
+        factionId1: 'gp1',
+        factionId2: 'gp2',
+        state: relState,
+      ),
+    ],
+  );
+}
+
+Game _gameWithProvinceVis({
+  required int turn,
+  required String fullProvinceId,
+  required String regionId,
+  required String localProvinceId,
+  required String visibility,
+  List<String> revealDone = const [],
+}) {
+  final tileKey = '$regionId|$localProvinceId|0|0';
+  return Game(
+    id: 'g',
+    worldState: WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: turn),
+      oldWorld: RegionData(
+        provinces: [
+          Province(id: fullProvinceId, regionId: regionId, ownerId: 'gp1'),
+        ],
+      ),
+      newWorld: const RegionData(),
+      tileKeysByRegionAndProvince: {
+        regionId: {localProvinceId: [tileKey]},
+      },
+      playerVisibilityByTile: {
+        'gp1': {tileKey: visibility},
+      },
+      newsDigestProvinceRevealDoneIds: revealDone,
+    ),
+    players: const [
+      Player(id: 'gp1', displayName: 'A', isHuman: true, treasury: 0),
+    ],
+  );
+}

--- a/packages/colonizethis_logic/test/turn_news_digest_test.dart
+++ b/packages/colonizethis_logic/test/turn_news_digest_test.dart
@@ -136,7 +136,7 @@ void main() {
     );
 
     test(
-      'Given province ownership gp1 to null When build Then capture line matches ProvinceCapturedEvent rule',
+      'Given province ownership gp1 to null When build Then no province captured line',
       () {
         const regionId = 'oldWorld';
         const localPid = 'P1';
@@ -154,6 +154,7 @@ void main() {
           ),
           players: const [
             Player(id: 'gp1', displayName: 'A', isHuman: true, treasury: 0),
+            Player(id: 'gp2', displayName: 'B', isHuman: false, treasury: 0),
           ],
         );
         final end = Game(
@@ -169,6 +170,51 @@ void main() {
           ),
           players: const [
             Player(id: 'gp1', displayName: 'A', isHuman: true, treasury: 0),
+            Player(id: 'gp2', displayName: 'B', isHuman: false, treasury: 0),
+          ],
+        );
+        final r = buildTurnNewsDigestForComplete(start: start, end: end);
+        final caps = r.digest!.lines.whereType<TurnNewsProvinceCapturedLine>();
+        expect(caps, isEmpty);
+      },
+    );
+
+    test(
+      'Given province ownership gp1 to gp2 When build Then capture line',
+      () {
+        const regionId = 'oldWorld';
+        const localPid = 'P1';
+        final fullPid = ProvinceId.full(regionId, localPid);
+        final start = Game(
+          id: 'g',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: fullPid, regionId: regionId, ownerId: 'gp1'),
+              ],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'A', isHuman: true, treasury: 0),
+            Player(id: 'gp2', displayName: 'B', isHuman: false, treasury: 0),
+          ],
+        );
+        final end = Game(
+          id: 'g',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: fullPid, regionId: regionId, ownerId: 'gp2'),
+              ],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'A', isHuman: true, treasury: 0),
+            Player(id: 'gp2', displayName: 'B', isHuman: false, treasury: 0),
           ],
         );
         final r = buildTurnNewsDigestForComplete(start: start, end: end);
@@ -176,7 +222,7 @@ void main() {
         expect(caps, hasLength(1));
         expect(caps.single.provinceId, fullPid);
         expect(caps.single.previousOwnerId, 'gp1');
-        expect(caps.single.newOwnerId, '');
+        expect(caps.single.newOwnerId, 'gp2');
       },
     );
 

--- a/packages/colonizethis_logic/test/turn_news_digest_test.dart
+++ b/packages/colonizethis_logic/test/turn_news_digest_test.dart
@@ -1,6 +1,6 @@
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 void _expectDigestLinesEqual(TurnNewsDigest a, TurnNewsDigest b) {
   expect(a.resolvedTurnNumber, b.resolvedTurnNumber);

--- a/packages/colonizethis_logic/test/turn_resolution_events_dialogue_test.dart
+++ b/packages/colonizethis_logic/test/turn_resolution_events_dialogue_test.dart
@@ -1,6 +1,7 @@
-import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_logic/src/turn/turn_resolution_events.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
 
 void main() {
   group('turn resolution dialogue emissions', () {
@@ -126,5 +127,76 @@ void main() {
         );
       },
     );
+
+    group('emitProvinceCapturedEvents', () {
+      test(
+        'Given previous owner set and new owner null When emit Then no province_captured',
+        () {
+          const fullPid = 'oldWorld|P1';
+          final after = Game(
+            id: 'g',
+            worldState: WorldState(
+              turnState: const TurnState(
+                phase: TurnPhase.orders,
+                turnNumber: 1,
+              ),
+              oldWorld: RegionData(
+                provinces: [
+                  Province(id: fullPid, regionId: 'oldWorld', ownerId: null),
+                ],
+              ),
+              newWorld: const RegionData(),
+            ),
+            players: const [
+              Player(id: 'gp1', displayName: 'A', isHuman: true, treasury: 0),
+            ],
+          );
+          final captured = <GameEvent>[];
+          emitProvinceCapturedEvents(
+            {fullPid: 'gp1'},
+            after,
+            1,
+            null,
+            captured.add,
+            null,
+          );
+          expect(captured, isEmpty);
+        },
+      );
+
+      test('Given gp1 to gp2 When emit Then one ProvinceCapturedEvent', () {
+        const fullPid = 'oldWorld|P1';
+        final after = Game(
+          id: 'g',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: [
+                Province(id: fullPid, regionId: 'oldWorld', ownerId: 'gp2'),
+              ],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'A', isHuman: true, treasury: 0),
+            Player(id: 'gp2', displayName: 'B', isHuman: false, treasury: 0),
+          ],
+        );
+        final captured = <GameEvent>[];
+        emitProvinceCapturedEvents(
+          {fullPid: 'gp1'},
+          after,
+          1,
+          null,
+          captured.add,
+          null,
+        );
+        expect(captured, hasLength(1));
+        final e = captured.single as ProvinceCapturedEvent;
+        expect(e.provinceId, fullPid);
+        expect(e.previousOwnerId, 'gp1');
+        expect(e.newOwnerId, 'gp2');
+      });
+    });
   });
 }

--- a/packages/colonizethis_models/lib/colonizethis_models.dart
+++ b/packages/colonizethis_models/lib/colonizethis_models.dart
@@ -24,6 +24,7 @@ export 'src/region_data.dart';
 export 'src/worker_pool.dart';
 export 'src/worker_idle_counts.dart';
 export 'src/turn_state.dart';
+export 'src/turn_news_digest.dart';
 export 'src/turn_time_mapping.dart';
 export 'src/unit.dart';
 export 'src/world_state.dart';

--- a/packages/colonizethis_models/lib/src/app_events.dart
+++ b/packages/colonizethis_models/lib/src/app_events.dart
@@ -15,6 +15,7 @@
 import 'combat_mode.dart';
 import 'diplomacy.dart';
 import 'game.dart';
+import 'turn_news_digest.dart';
 import 'orders.dart';
 
 export 'ai_events.dart' show DialogueEvent, PortraitMoodEvent;
@@ -413,9 +414,12 @@ class TurnResolutionCompleteEvent extends GameToUIEvent {
   const TurnResolutionCompleteEvent({
     required this.gameId,
     required this.turnNumber,
+    this.turnNewsDigest,
   });
   final String gameId;
   final int turnNumber;
+  /// Prior-turn digest for the news dialog; null when victory was set this resolution.
+  final TurnNewsDigest? turnNewsDigest;
 }
 
 /// Emitted when overture decisions are required; UI should show overture dialog.

--- a/packages/colonizethis_models/lib/src/turn_news_digest.dart
+++ b/packages/colonizethis_models/lib/src/turn_news_digest.dart
@@ -1,0 +1,73 @@
+// Turn-start news digest lines. SPEC/program/turn-news-digest.md; UI: SPEC/ui/turn-news-dialog.md.
+
+import 'diplomacy.dart';
+
+/// Digest for the turn that just finished (resolved turn number).
+class TurnNewsDigest {
+  const TurnNewsDigest({
+    required this.resolvedTurnNumber,
+    required this.lines,
+  });
+
+  final int resolvedTurnNumber;
+  final List<TurnNewsLine> lines;
+}
+
+/// One display line in the news digest.
+sealed class TurnNewsLine {
+  const TurnNewsLine();
+}
+
+class TurnNewsProvinceCapturedLine extends TurnNewsLine {
+  const TurnNewsProvinceCapturedLine({
+    required this.provinceId,
+    required this.previousOwnerId,
+    required this.newOwnerId,
+  });
+
+  final String provinceId;
+  final String previousOwnerId;
+  final String newOwnerId;
+}
+
+enum TurnNewsDiplomacyKind { war, peace }
+
+/// [factionIdA] and [factionIdB] are sorted lexicographically (stable neutral pair).
+class TurnNewsDiplomacyLine extends TurnNewsLine {
+  const TurnNewsDiplomacyLine({
+    required this.factionIdA,
+    required this.factionIdB,
+    required this.kind,
+  });
+
+  final String factionIdA;
+  final String factionIdB;
+  final TurnNewsDiplomacyKind kind;
+}
+
+/// Overture stage advanced vs start of turn (acceptance path).
+class TurnNewsOvertureAdvancedLine extends TurnNewsLine {
+  const TurnNewsOvertureAdvancedLine({
+    required this.offererGpId,
+    required this.targetFactionId,
+    required this.newStage,
+  });
+
+  final String offererGpId;
+  final String targetFactionId;
+  final OvertureStage newStage;
+}
+
+/// First global charting of a province (any GP gained non-unknown visibility).
+class TurnNewsProvinceDiscoveredLine extends TurnNewsLine {
+  const TurnNewsProvinceDiscoveredLine({required this.provinceId});
+
+  final String provinceId;
+}
+
+/// First recorded fleet presence in this sea zone (global).
+class TurnNewsSeaZoneFleetLine extends TurnNewsLine {
+  const TurnNewsSeaZoneFleetLine({required this.seaZoneId});
+
+  final String seaZoneId;
+}

--- a/packages/colonizethis_models/lib/src/world_state.dart
+++ b/packages/colonizethis_models/lib/src/world_state.dart
@@ -23,6 +23,8 @@ class WorldState {
     this.nextShipInstanceSeq = 1,
     this.armies = const [],
     this.nextArmySeq = 1,
+    this.newsDigestProvinceRevealDoneIds = const [],
+    this.newsDigestSeaZoneFleetDoneIds = const [],
   });
 
   final TurnState turnState;
@@ -73,6 +75,13 @@ class WorldState {
   /// Monotonic counter for minting non-home army ids (e.g. split armies).
   final int nextArmySeq;
 
+  /// Prefixed province ids that already generated a news "province discovered" line.
+  /// SPEC/program/turn-news-digest.md.
+  final List<String> newsDigestProvinceRevealDoneIds;
+
+  /// Prefixed sea zone ids that already generated a news "first fleet" line.
+  final List<String> newsDigestSeaZoneFleetDoneIds;
+
   Map<String, dynamic> toJson() => {
     'turnState': turnState.toJson(),
     'oldWorld': oldWorld.toJson(),
@@ -103,6 +112,10 @@ class WorldState {
     'nextShipInstanceSeq': nextShipInstanceSeq,
     if (armies.isNotEmpty) 'armies': armies.map((e) => e.toJson()).toList(),
     if (nextArmySeq != 1) 'nextArmySeq': nextArmySeq,
+    if (newsDigestProvinceRevealDoneIds.isNotEmpty)
+      'newsDigestProvinceRevealDoneIds': newsDigestProvinceRevealDoneIds,
+    if (newsDigestSeaZoneFleetDoneIds.isNotEmpty)
+      'newsDigestSeaZoneFleetDoneIds': newsDigestSeaZoneFleetDoneIds,
   };
 
   static WorldState fromJson(Map<String, dynamic> json) {
@@ -164,6 +177,16 @@ class WorldState {
 
     final storedArmySeq = json['nextArmySeq'];
     final nextArmySeq = storedArmySeq is int ? storedArmySeq : 1;
+
+    final newsProvRaw = json['newsDigestProvinceRevealDoneIds'] as List<dynamic>?;
+    final newsDigestProvinceRevealDoneIds = newsProvRaw == null
+        ? const <String>[]
+        : newsProvRaw.map((e) => e.toString()).toList();
+
+    final newsSeaRaw = json['newsDigestSeaZoneFleetDoneIds'] as List<dynamic>?;
+    final newsDigestSeaZoneFleetDoneIds = newsSeaRaw == null
+        ? const <String>[]
+        : newsSeaRaw.map((e) => e.toString()).toList();
 
     final tileKeysRaw = json['tileKeysByRegionAndProvince'];
     final tileKeysByRegionAndProvince = <String, Map<String, List<String>>>{};
@@ -240,6 +263,8 @@ class WorldState {
       seaZoneDisplayNameById: seaZoneDisplayNameById,
       armies: armies,
       nextArmySeq: nextArmySeq,
+      newsDigestProvinceRevealDoneIds: newsDigestProvinceRevealDoneIds,
+      newsDigestSeaZoneFleetDoneIds: newsDigestSeaZoneFleetDoneIds,
     );
   }
 
@@ -260,6 +285,8 @@ class WorldState {
     int? nextShipInstanceSeq,
     List<Army>? armies,
     int? nextArmySeq,
+    List<String>? newsDigestProvinceRevealDoneIds,
+    List<String>? newsDigestSeaZoneFleetDoneIds,
   }) {
     return WorldState(
       turnState: turnState ?? this.turnState,
@@ -285,6 +312,11 @@ class WorldState {
       nextShipInstanceSeq: nextShipInstanceSeq ?? this.nextShipInstanceSeq,
       armies: armies ?? this.armies,
       nextArmySeq: nextArmySeq ?? this.nextArmySeq,
+      newsDigestProvinceRevealDoneIds:
+          newsDigestProvinceRevealDoneIds ??
+          this.newsDigestProvinceRevealDoneIds,
+      newsDigestSeaZoneFleetDoneIds:
+          newsDigestSeaZoneFleetDoneIds ?? this.newsDigestSeaZoneFleetDoneIds,
     );
   }
 
@@ -317,7 +349,15 @@ class WorldState {
           _mapEquals(seaZoneDisplayNameById, other.seaZoneDisplayNameById) &&
           nextShipInstanceSeq == other.nextShipInstanceSeq &&
           _listEqualsArmy(armies, other.armies) &&
-          nextArmySeq == other.nextArmySeq;
+          nextArmySeq == other.nextArmySeq &&
+          _listEqualsString(
+            _sortedCopy(newsDigestProvinceRevealDoneIds),
+            _sortedCopy(other.newsDigestProvinceRevealDoneIds),
+          ) &&
+          _listEqualsString(
+            _sortedCopy(newsDigestSeaZoneFleetDoneIds),
+            _sortedCopy(other.newsDigestSeaZoneFleetDoneIds),
+          );
 
   @override
   int get hashCode => Object.hash(
@@ -360,7 +400,12 @@ class WorldState {
     nextShipInstanceSeq,
     Object.hashAll(armies),
     nextArmySeq,
+    Object.hashAll(_sortedCopy(newsDigestProvinceRevealDoneIds)),
+    Object.hashAll(_sortedCopy(newsDigestSeaZoneFleetDoneIds)),
   );
+
+  static List<String> _sortedCopy(List<String> xs) =>
+      List<String>.from(xs)..sort();
 
   static bool _tileKeysByRegionEquals(
     Map<String, Map<String, List<String>>> a,


### PR DESCRIPTION
## Summary

Implements the turn-start news flow from **Refs #1478** (does not close the issue).

- **Logic:** `buildTurnNewsDigestForComplete` builds a deterministic digest at end of `resolveTurnForGame`; patches `WorldState` with `newsDigestProvinceRevealDoneIds` / `newsDigestSeaZoneFleetDoneIds`. Province capture lines use the same predicate as `emitProvinceCapturedEvents` (including null/empty new owner).
- **Models:** `TurnNewsDigest` + line types; `TurnResolutionComplete` carries optional digest; `TurnResolutionCompleteEvent.turnNewsDigest`.
- **App:** After `TurnResolutionCompleteEvent`, `GameToUIBusListener` reloads the game and emits `OpenDialogEvent('turn_news')` when `turnNumber >= 1`, digest is non-null, and `victory == null`. `TurnNewsDialog` + l10n + Widgetbook stories.
- **SPEC:** `SPEC/program/turn-news-digest.md`, `SPEC/ui/turn-news-dialog.md`.

## Tests

- `dart test packages/colonizethis_logic/test/turn_news_digest_test.dart` (victory, war/peace, capture parity, overture, sea zone, discovery tracking, determinism)
- `flutter test app/test/game_to_ui_bus_listener_test.dart` (reload, news dialog open, turn 0 / victory / null-digest gates)
- `flutter test app/test/turn_news_dialog_test.dart` (empty state + war line l10n)

## Note

Generated `app/lib/l10n/app_localizations*.dart` are gitignored; run `flutter gen-l10n` in `app/` after checkout if needed.

Made with [Cursor](https://cursor.com)