### PR TITLE
feat(logic): normalize naval attacker side mapping

### DIFF
--- a/SPEC/game/ships-and-naval.md
+++ b/SPEC/game/ships-and-naval.md
@@ -162,11 +162,12 @@ Transport and trade use this capacity in priority order (cross‑region extracti
 
 Naval battles are **strategic resolutions** between opposing fleets **in the same sea zone**. **Naval combat can only take place in sea zones**; fleets in port do not fight until they leave port.
 
-- Inputs: fleets **at sea** (owner, ships with stats and medals, mission, aggression), sea zone id, tech state.
-- Outcomes per engagement: attacker victory, defender victory, stalemate (both retain ships), or mutual destruction.
+- Inputs: fleets **at sea** (owner, ships with stats and medals, **mission**), sea zone id; aggregated per faction in the zone. There is **no** separate per-side “aggression level” input for combat or retreat.
+- **Attacker and defender:** Before resolution, the engine assigns **side1 = attacker** and **side2 = defender** per [naval-combat-resolution.md](../program/naval-combat-resolution.md) (mover vs interceptor rules, then lexicographic tie-break).
+- Outcomes per engagement (technical enum): **`side1Victory`** (attacker wins), **`side2Victory`** (defender wins), **stalemate** (both retain ships), **mutual destruction**.
 - Per Imp2: "superior range is usually the most important statistic" — RNG should be weighted highest in strength aggregation.
 
-Retreat is allowed only if there is at least one **adjacent friendly or neutral sea zone**. Success depends on relative fleet speed/composition and aggression level. Failed retreat causes additional losses.
+Retreat is allowed only if there is at least one **adjacent friendly or neutral sea zone**. Success uses base chance, speed advantage, and a mission-based **enemyAggression** term from the **opponent’s** mission (`patrol` / `blockade` / neither), not a faction aggression setting. Failed retreat causes additional losses.
 
 Interception and battle contexts are created when:
 
@@ -197,7 +198,7 @@ if canRetreat:
 retreatSuccess = baseChance + speedAdvantage - enemyAggression
 baseChance = 0.6
 speedAdvantage = (ownAvgMV - enemyAvgMV) × 0.1 # +/- 0.2 typical
-enemyAggression = 0.1 if enemyMission == Patrol else 0.2 # Blockade harder to escape
+enemyAggression = 0.1 if enemyMission == Patrol else (0.2 if enemyMission == Blockade else 0.0)
 ```
 
 `existsFriendlyOrNeutralAdjacentZone()` means there is an adjacent sea zone with no hostile fleet present for the retreating side (hostility from diplomacy `atWar` relation).
@@ -277,6 +278,18 @@ MVP contract: trade/transport interception uses hardcoded constants in logic for
 - Given two opposing fleets **at sea** with known ship stats (FRP, RNG, ARM, HULL, MV) and medals occupy the same sea zone and a naval battle is triggered  
   When the System computes naval combat strength and resolves the battle  
   Then the System uses the aggregation and durability formulas in this document (including RNG weighting and HULL × (1 + ARM/10)), applies tech modifiers as specified in related specs (leader bonuses do not apply to naval combat; see [leader-bonuses.md](leader-bonuses.md) § When Bonuses Apply), and produces deterministic outcomes (winner, casualties, and possible retreats) for identical inputs across multiple runs. Fleets in port do not participate in naval combat.
+
+- Given a naval engagement after movement where only faction **A** moved a fleet into the contested sea zone and faction **B** is not on Patrol or Blockade there  
+  When the System builds the battle context for resolution per [naval-combat-resolution.md](../program/naval-combat-resolution.md)  
+  Then the System labels faction **A** as the **attacker** (technical **side1**) and faction **B** as the **defender** (technical **side2**).
+
+- Given a naval engagement after movement where faction **A** moved into the zone and faction **B** is on **Patrol** or **Blockade** in that zone  
+  When the System builds the battle context for resolution per [naval-combat-resolution.md](../program/naval-combat-resolution.md)  
+  Then the System labels faction **B** as the **attacker** (technical **side1**) and faction **A** as the **defender** (technical **side2**).
+
+- Given the documented naval retreat formula in this document  
+  When an implementer checks required per-faction inputs  
+  Then the System does not require any **cautious / normal / aggressive** side attribute; retreat’s `enemyAggression` term is derived only from the **opponent’s** mission (`patrol`, `blockade`, or neither) as specified above.
 
 - Given a fleet is **in port at the player's capital province** (and is not the home fleet) and the player issues a `join_home_fleet` order for that fleet  
   When the System resolves the order during the Movement phase  

--- a/SPEC/program/naval-combat-resolution.md
+++ b/SPEC/program/naval-combat-resolution.md
@@ -6,17 +6,28 @@ Detects naval conflicts per sea zone and auto-resolves fleet engagements, produc
 
 ## Data Model
 
-- **BattleContextSea:** `seaZoneId`, list of sides.
-  - **Side:** fleet owner id, ship ids, mission type, aggression level, tech snapshot.
+- **BattleContextSea:** `seaZoneId`, **side1** (attacker), **side2** (defender).
+  - **Side:** fleet owner id, ship instance ids/types, **mission** (`FleetMission` — used for interception eligibility and for the opponent’s retreat formula term derived from mission, not a player “aggression level”).
   - Combines multiple same-faction fleets present in one zone.
+
+## Attacker / side1 mapping
+
+Before interception rolls and combat resolution, each `BattleContextSea` is **normalized** so **side1 = attacker** and **side2 = defender**:
+
+1. **Interception posture:** If exactly one faction had a moving fleet in the sea zone this turn and the other faction’s mission is **Patrol** or **Blockade**, the **interceptor** (Patrol/Blockade side) is the attacker (**side1**), and the **mover** is the defender (**side2**).
+2. **Move into contested zone (no interceptor asymmetry):** Else if exactly one faction had a moving fleet in the zone, that **mover** is the attacker (**side1**).
+3. **Symmetric case:** Else (both factions moved, or neither did), **side1** is the faction with the **lexicographically smaller** `ownerId`, and **side2** the other (deterministic ordering only).
+
+Combat outcomes use the technical enum: **`side1Victory`** means the **attacker** (side1) wins; **`side2Victory`** means the **defender** (side2) wins.
 
 ## Algorithm / Flow
 
 **Conflict Detection:**
 
-1. After movement and interception, scan each sea zone with fleets from 2+ factions.
-2. Group by owner; for each hostile pair (war state), create/update a BattleContextSea.
-3. Beachhead and port fleets participate if opponents occupy the same zone.
+1. After movement, scan each sea zone with fleets from 2+ factions.
+2. Group by owner; for each hostile pair (war state), create a provisional `BattleContextSea` (side order from detection is arbitrary until normalized).
+3. Apply **Attacker / side1 mapping** using this turn’s naval move orders (which fleet ids moved).
+4. Beachhead and port fleets participate if opponents occupy the same zone.
 
 **Strength Aggregation (per side):**
 
@@ -35,7 +46,7 @@ Detects naval conflicts per sea zone and auto-resolves fleet engagements, produc
 1. Read morale-adjusted `navalStrength` for both sides.
 2. Compute casualties (ships sunk) from relative strength and deterministic seeded RNG.
 3. Compute retreat attempts using the retreat model below.
-4. Return one outcome enum (`side1Victory`, `side2Victory`, `stalemate`, `mutualDestruction`) and retreat flags.
+4. Return one outcome enum (`side1Victory` = attacker wins, `side2Victory` = defender wins, `stalemate`, `mutualDestruction`) and retreat flags.
 
 Handles both interception-triggered and end-of-movement battles.
 
@@ -50,7 +61,7 @@ Per [ships-and-naval.md](../game/ships-and-naval.md) § Naval Combat, retreat re
 3. If a legal adjacent zone exists, compute:
    - `baseChance = 0.6`
    - `speedAdvantage = (ownAvgMV - enemyAvgMV) * 0.1`
-   - `enemyAggression = 0.1` when enemy mission is `patrol`, `0.2` when enemy mission is `blockade`, otherwise `0.0`
+   - `enemyAggression` (**mission-based**, not a faction “aggression level” setting): `0.1` when the **opposing** side’s mission is `patrol`, `0.2` when it is `blockade`, otherwise `0.0`
    - `P_retreat = clamp(baseChance + speedAdvantage - enemyAggression, 0.1, 0.95)`
 4. Resolve with deterministic seeded RNG.
 5. Success relocates surviving ships to a legal adjacent zone.
@@ -87,13 +98,13 @@ When one side moved into a contested sea zone and the opposing side is on `patro
   When The System computes interception probability  
   Then The System computes `ratio = 8/(8+2)`, applies mission factor `0.9`, and clamps the result to `[0.05, 0.85]`.
 
-- Given a battle sea zone has no adjacent legal sea zone for side 1 (all adjacent zones contain hostile fleets)  
-  When The System resolves retreat for side 1  
-  Then The System does not evaluate retreat probability and side 1 does not retreat.
+- Given a battle sea zone has no adjacent legal sea zone for the **attacker (side1)** (all adjacent zones contain hostile fleets)  
+  When The System resolves retreat for side1  
+  Then The System does not evaluate retreat probability and side1 does not retreat.
 
-- Given side 1 survives naval combat and battle context mission for side 1 is `patrol`  
+- Given the **attacker (side1)** survives naval combat and battle context mission for side1 is `patrol`  
   When The System applies naval battle results to world state  
-  Then The System recreates side 1 fleet with mission `patrol` instead of resetting to `none`.
+  Then The System recreates side1 fleet with mission `patrol` instead of resetting to `none`.
 
 - Given a naval battle resolves with both sides still having at least one surviving ship  
   When The System builds the battle result payload  
@@ -102,3 +113,19 @@ When one side moved into a contested sea zone and the opposing side is on `patro
 - Given naval interception and combat phase runs for one turn  
   When The System processes detected battles and resolved outcomes  
   Then The System emits `logic:` debug logs with detected-battle count, post-interception count, battle outcome, and retreat flags.
+
+- Given two at-war fleets in the same sea zone after movement, faction **A** is the only faction that had a naval move order applied this turn for a fleet in that zone, and faction **B** is not on Patrol or Blockade  
+  When The System builds the normalized `BattleContextSea` for resolution  
+  Then The System sets **side1** (attacker) to faction **A** and **side2** (defender) to faction **B**.
+
+- Given two at-war fleets in the same sea zone after movement, faction **A** had a moving fleet in that zone and faction **B**’s mission in that zone is **Patrol** or **Blockade**  
+  When The System builds the normalized `BattleContextSea` for resolution  
+  Then The System sets **side1** (attacker) to faction **B** (interceptor) and **side2** (defender) to faction **A** (mover).
+
+- Given two at-war fleets in the same sea zone after movement, neither faction had a moving fleet in that zone this turn, `ownerId` of one side is `gp_alpha` and of the other is `gp_beta`  
+  When The System builds the normalized `BattleContextSea` for resolution  
+  Then The System sets **side1** to the faction with id `gp_alpha` and **side2** to `gp_beta` (lexicographic order of `ownerId`).
+
+- Given retreat probability is documented for naval combat  
+  When a reader checks required inputs for the retreat formula  
+  Then The specification does not require any per-side **cautious / normal / aggressive** attribute; only the **opponent’s mission** (`patrol` / `blockade` / other) sets the `enemyAggression` term as defined in § Retreat Resolution.

--- a/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
@@ -27,7 +27,7 @@ const double kNavalRetreatEnemyPatrol = 0.1;
 /// Enemy aggression when enemy is on Blockade.
 const double kNavalRetreatEnemyBlockade = 0.2;
 
-/// One side in a sea battle: owner, ship instances, optional mission for retreat aggression.
+/// One side in a sea battle: owner, ship instances, mission (used for retreat `enemyAggression` from opponent mission).
 class NavalBattleSide {
   const NavalBattleSide({
     required this.ownerId,
@@ -44,6 +44,8 @@ class NavalBattleSide {
 }
 
 /// Sea battle context for one zone. SPEC/program/naval-combat-resolution.md.
+///
+/// After [normalizeNavalBattleSidesForAttacker], [side1] is the **attacker** and [side2] is the **defender**.
 class BattleContextSea {
   const BattleContextSea({
     required this.seaZoneId,
@@ -54,6 +56,63 @@ class BattleContextSea {
   final String seaZoneId;
   final NavalBattleSide side1;
   final NavalBattleSide side2;
+}
+
+bool _ownerHadMovingFleetInZone(
+  Game game,
+  String seaZoneId,
+  String ownerId,
+  Set<String> movedFleetIds,
+) {
+  if (movedFleetIds.isEmpty) return false;
+  return game.worldState.fleets.any(
+    (f) =>
+        f.isAtSea &&
+        f.seaZoneId == seaZoneId &&
+        f.ownerId == ownerId &&
+        movedFleetIds.contains(f.id),
+  );
+}
+
+bool _isInterceptorMission(FleetMission m) =>
+    m == FleetMission.patrol || m == FleetMission.blockade;
+
+/// Orders [battle] so [side1] is the attacker and [side2] is the defender per SPEC/program/naval-combat-resolution.md.
+///
+/// Precedence: (1) If exactly one faction moved into the zone and the other is on Patrol or Blockade, the interceptor is the attacker. (2) Else if exactly one faction moved, the mover is the attacker. (3) Else (both moved, or neither) use lexicographically smaller `ownerId` as attacker for deterministic ordering.
+BattleContextSea normalizeNavalBattleSidesForAttacker(
+  BattleContextSea battle,
+  Game game,
+  Set<String> movedFleetIds,
+) {
+  final s1 = battle.side1;
+  final s2 = battle.side2;
+  final m1 = _ownerHadMovingFleetInZone(game, battle.seaZoneId, s1.ownerId, movedFleetIds);
+  final m2 = _ownerHadMovingFleetInZone(game, battle.seaZoneId, s2.ownerId, movedFleetIds);
+  final int1 = _isInterceptorMission(s1.mission);
+  final int2 = _isInterceptorMission(s2.mission);
+
+  final bool swap;
+  if (m1 && !m2 && int2) {
+    swap = true;
+  } else if (m2 && !m1 && int1) {
+    swap = false;
+  } else if (m1 && !m2) {
+    swap = false;
+  } else if (m2 && !m1) {
+    swap = true;
+  } else {
+    swap = s1.ownerId.compareTo(s2.ownerId) > 0;
+  }
+
+  if (!swap) {
+    return battle;
+  }
+  return BattleContextSea(
+    seaZoneId: battle.seaZoneId,
+    side1: s2,
+    side2: s1,
+  );
 }
 
 /// Conflict detection: returns contested sea zones with two hostile sides.
@@ -233,7 +292,7 @@ class NavalBattleResult {
 }
 
 /// Resolve one sea battle deterministically. Seed from game + zone for RNG.
-/// Applies retreat roll per SPEC/game/ships-and-naval.md (base 0.6 + speed advantage - enemy aggression).
+/// Applies retreat roll per SPEC/game/ships-and-naval.md (base 0.6 + speed advantage - enemy mission aggression term).
 NavalBattleResult resolveSeaBattle(
   BattleContextSea battle,
   int seed, {

--- a/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
@@ -360,6 +360,9 @@ Game runNavalInterceptionCombatPhase(
     for (final list in navalMoveOrdersByPlayerId.values)
       for (final order in list) order.fleetId,
   };
+  battles = [
+    for (final b in battles) normalizeNavalBattleSidesForAttacker(b, game, movedFleetIds),
+  ];
   var seed = (game.globalGameSeed ?? 0) ^
       (game.worldState.turnState.turnNumber * 0x9E3779B1);
   battles = filterBattlesByInterception(game, battles, movedFleetIds, seed);

--- a/packages/colonizethis_logic/test/naval_behavior_scenarios_test.dart
+++ b/packages/colonizethis_logic/test/naval_behavior_scenarios_test.dart
@@ -1,3 +1,4 @@
+import 'package:colonizethis_logic/colonizethis_logic.dart' show NavalCombatResultEvent;
 import 'package:colonizethis_logic/src/world/naval_resolution.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -6,6 +7,7 @@ import 'package:colonizethis_test/test.dart';
 Game _baseGame({
   required List<Fleet> fleets,
   required List<DiplomacyRelation> relations,
+  int globalGameSeed = 42,
 }) {
   return Game(
     id: 'g_naval',
@@ -21,12 +23,70 @@ Game _baseGame({
       Player(id: 'p3', displayName: 'C', isHuman: true),
     ],
     diplomacyRelations: relations,
-    globalGameSeed: 42,
+    globalGameSeed: globalGameSeed,
   );
 }
 
 void main() {
   group('naval behavior scenarios', () {
+    test(
+        'scenario: sole mover is side1 (attacker) in naval event when opponent is not Patrol/Blockade '
+        '(no interception roll; battle always proceeds)', () {
+      NavalCombatResultEvent? navalEvent;
+      final game = _baseGame(
+        fleets: [
+          Fleet(
+            id: 'f_mover',
+            ownerId: 'p1',
+            seaZoneId: 'sea1',
+            regionId: 'oldWorld',
+            shipTypeIds: const ['carrack', 'carrack'],
+            mission: FleetMission.none,
+          ),
+          Fleet(
+            id: 'f_other',
+            ownerId: 'p2',
+            seaZoneId: 'sea1',
+            regionId: 'oldWorld',
+            shipTypeIds: const ['fluyte', 'fluyte'],
+            mission: FleetMission.defend,
+          ),
+        ],
+        relations: [
+          DiplomacyRelation(
+            factionId1: 'p1',
+            factionId2: 'p2',
+            state: RelationState.atWar,
+          ),
+        ],
+      );
+
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+        ],
+        edges: [],
+      );
+
+      runNavalInterceptionCombatPhase(
+        game,
+        topology,
+        {
+          'p1': [
+            NavalMoveOrder(fleetId: 'f_mover', destinationSeaZoneId: 'sea1'),
+          ],
+        },
+        onGameEvent: (e) {
+          if (e is NavalCombatResultEvent) navalEvent = e;
+        },
+      );
+
+      expect(navalEvent, isNotNull);
+      final ev = navalEvent!;
+      expect(ev.side1OwnerId, 'p1');
+      expect(ev.side2OwnerId, 'p2');
+    });
+
     test('scenario: post-battle fleets preserve mission', () {
       final game = _baseGame(
         fleets: [

--- a/packages/colonizethis_logic/test/naval_combat_resolver_test.dart
+++ b/packages/colonizethis_logic/test/naval_combat_resolver_test.dart
@@ -116,6 +116,174 @@ void main() {
     });
   });
 
+  group('normalizeNavalBattleSidesForAttacker', () {
+    Game gameTwoFleets({
+      required Fleet fleet1,
+      required Fleet fleet2,
+    }) {
+      return Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+          fleets: [fleet1, fleet2],
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'A', isHuman: true),
+          Player(id: 'p2', displayName: 'B', isHuman: true),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'p1',
+            factionId2: 'p2',
+            state: RelationState.atWar,
+          ),
+        ],
+      );
+    }
+
+    test('only mover is attacker when the other is not Patrol or Blockade', () {
+      final game = gameTwoFleets(
+        fleet1: Fleet(
+          id: 'mv',
+          ownerId: 'p1',
+          seaZoneId: 'sea1',
+          regionId: 'oldWorld',
+          shipTypeIds: ['carrack'],
+          mission: FleetMission.none,
+        ),
+        fleet2: Fleet(
+          id: 'st',
+          ownerId: 'p2',
+          seaZoneId: 'sea1',
+          regionId: 'oldWorld',
+          shipTypeIds: ['fluyte'],
+          mission: FleetMission.defend,
+        ),
+      );
+      final battle = BattleContextSea(
+        seaZoneId: 'sea1',
+        side1: NavalBattleSide(
+          ownerId: 'p2',
+          ships: legacyShipInstancesForFleet('x', ['fluyte']),
+          mission: FleetMission.defend,
+        ),
+        side2: NavalBattleSide(
+          ownerId: 'p1',
+          ships: legacyShipInstancesForFleet('y', ['carrack']),
+          mission: FleetMission.none,
+        ),
+      );
+      final n = normalizeNavalBattleSidesForAttacker(battle, game, {'mv'});
+      expect(n.side1.ownerId, 'p1');
+      expect(n.side2.ownerId, 'p2');
+    });
+
+    test('interceptor is attacker when the other faction moved', () {
+      final game = gameTwoFleets(
+        fleet1: Fleet(
+          id: 'mv',
+          ownerId: 'p1',
+          seaZoneId: 'sea1',
+          regionId: 'oldWorld',
+          shipTypeIds: ['carrack'],
+          mission: FleetMission.none,
+        ),
+        fleet2: Fleet(
+          id: 'ic',
+          ownerId: 'p2',
+          seaZoneId: 'sea1',
+          regionId: 'oldWorld',
+          shipTypeIds: ['fluyte'],
+          mission: FleetMission.blockade,
+        ),
+      );
+      final battle = BattleContextSea(
+        seaZoneId: 'sea1',
+        side1: NavalBattleSide(
+          ownerId: 'p1',
+          ships: legacyShipInstancesForFleet('a', ['carrack']),
+          mission: FleetMission.none,
+        ),
+        side2: NavalBattleSide(
+          ownerId: 'p2',
+          ships: legacyShipInstancesForFleet('b', ['fluyte']),
+          mission: FleetMission.blockade,
+        ),
+      );
+      final n = normalizeNavalBattleSidesForAttacker(battle, game, {'mv'});
+      expect(n.side1.ownerId, 'p2');
+      expect(n.side2.ownerId, 'p1');
+    });
+
+    test('neither moved: lexicographically smaller ownerId is attacker', () {
+      final game = gameTwoFleets(
+        fleet1: Fleet(
+          id: 'fa',
+          ownerId: 'p1',
+          seaZoneId: 'sea1',
+          regionId: 'oldWorld',
+          shipTypeIds: ['carrack'],
+        ),
+        fleet2: Fleet(
+          id: 'fb',
+          ownerId: 'p2',
+          seaZoneId: 'sea1',
+          regionId: 'oldWorld',
+          shipTypeIds: ['fluyte'],
+        ),
+      );
+      final battle = BattleContextSea(
+        seaZoneId: 'sea1',
+        side1: NavalBattleSide(
+          ownerId: 'p2',
+          ships: legacyShipInstancesForFleet('u2', ['fluyte']),
+        ),
+        side2: NavalBattleSide(
+          ownerId: 'p1',
+          ships: legacyShipInstancesForFleet('u1', ['carrack']),
+        ),
+      );
+      final n = normalizeNavalBattleSidesForAttacker(battle, game, {});
+      expect(n.side1.ownerId, 'p1');
+      expect(n.side2.ownerId, 'p2');
+    });
+
+    test('both moved: lexicographically smaller ownerId is attacker', () {
+      final game = gameTwoFleets(
+        fleet1: Fleet(
+          id: 'fa',
+          ownerId: 'p1',
+          seaZoneId: 'sea1',
+          regionId: 'oldWorld',
+          shipTypeIds: ['carrack'],
+        ),
+        fleet2: Fleet(
+          id: 'fb',
+          ownerId: 'p2',
+          seaZoneId: 'sea1',
+          regionId: 'oldWorld',
+          shipTypeIds: ['fluyte'],
+        ),
+      );
+      final battle = BattleContextSea(
+        seaZoneId: 'sea1',
+        side1: NavalBattleSide(
+          ownerId: 'p2',
+          ships: legacyShipInstancesForFleet('u2', ['fluyte']),
+        ),
+        side2: NavalBattleSide(
+          ownerId: 'p1',
+          ships: legacyShipInstancesForFleet('u1', ['carrack']),
+        ),
+      );
+      final n = normalizeNavalBattleSidesForAttacker(battle, game, {'fa', 'fb'});
+      expect(n.side1.ownerId, 'p1');
+      expect(n.side2.ownerId, 'p2');
+    });
+  });
+
   group('navalStrength', () {
     test('returns 0 for empty list', () {
       expect(navalStrength([]), 0.0);


### PR DESCRIPTION
## Summary
- Align naval SPEC language to remove side-level aggression attribute text and document mission-based retreat input.
- Define and implement deterministic attacker mapping so `side1` is attacker and `side2` is defender (mover/interceptor rules, lexicographic tie-break fallback).
- Add unit/scenario tests to lock side ordering behavior and event payload expectations.

References #1284

## Test plan
- [x] `cd packages/colonizethis_logic && dart test test/naval_combat_resolver_test.dart test/naval_behavior_scenarios_test.dart`
- [x] `cd packages/colonizethis_logic && dart analyze lib test` (existing repo warnings present; no new linter errors in touched files)

Made with [Cursor](https://cursor.com)