### PR TITLE
Sync dev into build/app/android (#1483 + compile fixes)

### DIFF
--- a/SPEC/program/map-data.md
+++ b/SPEC/program/map-data.md
@@ -107,9 +107,9 @@ The loading API (file layout, error handling) will be defined in a future spec u
 
 ## Tile map format
 
-**Per-region 2D grid (static per scenario).** Each cell: region id (province or sea zone), type (land/water), **terrain type** (land), **resource** (optional; at most one). Resource must be allowed for region and terrain; rules in colonizethis_data. Extraction level and road are **mutable** game state (keyed by tile), not part of static tile map. For MVP, produced by [tile-map-gen-*](tile-map-gen-algorithm.md) or supplied from init_game; optional map data in saves is per [save-load.md](save-load.md). Loading from static tile-map files is deferred.
+**Per-region 2D grid (static per scenario).** Each cell: region id (province or sea zone), type (land/water), **terrain type** (land), **resource** (optional; at most one). Resource must be allowed for region and terrain; rules in colonizethis_data. Extraction level and road are **mutable** game state (keyed by tile), not part of static tile map. For MVP, produced by [tile-map-gen-*](tile-map-gen-algorithm.md) or supplied from init_game; required save payload map data is specified in [save-load.md](save-load.md). Loading from static tile-map files is deferred.
 
-**Persistence (MVP):** The tile map is **not** part of the mandatory game save payload; only world state (e.g. province ownership) is required to load a game. When a save is created by **ctdev** or **init_game** with map output, tile maps may be stored as **optional map data** per [save-load.md](save-load.md) (keys `_tileMapByRegion`, etc.). That serialization uses the same TileMapResult JSON format and is for **ctdev/init tooling** (e.g. Load Savegame map view); the main game does not require map data to load. Format and semantics of the tile map are defined in this spec; the save/load contract for optional map data is in save-load.md.
+**Persistence (MVP):** The tile map is part of the required playable save payload together with topology and combined topology per [save-load.md](save-load.md) (keys `_tileMapByRegion`, `_topologyByRegion`, `_combinedTopology`). Saves missing required map data are invalid for gameplay load. Format and semantics of the tile map are defined in this spec; the save/load contract is in save-load.md.
 
 ---
 

--- a/SPEC/program/save-load.md
+++ b/SPEC/program/save-load.md
@@ -1,12 +1,12 @@
 # Save/Load — Technical Design
 
-**SPEC/program** — Contract, storage backend, optional map data, and acceptance criteria for game save/load. Province and region identity in saved state follows [world-model-identity.md](../game/world-model-identity.md) (prefixed ids, region-scoped lookup).
+**SPEC/program** — Contract, storage backend, required map data, and acceptance criteria for game save/load. Province and region identity in saved state follows [world-model-identity.md](../game/world-model-identity.md) (prefixed ids, region-scoped lookup).
 
 ---
 
 ## Responsibility
 
-- Define the save/load contract implemented by `colonizethis_save` (GameSaveAdapter): storage backend, key convention, schema, optional map data, and behaviour on load for the current schema.
+- Define the save/load contract implemented by `colonizethis_save` (GameSaveAdapter): storage backend, key convention, schema, required map data, and behaviour on load for the current schema.
 - Cross-referenced by: [world-model.md](../game/world-model.md) (serialization), [ctdev-app.md](ctdev-app.md) (Load Savegame flow), [init-game-tool.md](init-game-tool.md) (save output), [turn-resolution.md](turn-resolution.md) (persist after resolve), [game-setup-pipeline.md](game-setup-pipeline.md) (persist or pass), [plan-update-gp-colours-save-load.md](../project/plan-update-gp-colours-save-load.md) (GP colour override persisted on Game).
 
 ---
@@ -17,7 +17,7 @@
 - **Key convention:**
   - **Game:** key = `gameId`; value = `Game.toJson()`. Schema is the Game model (no separate version field in MVP). `Game.toJson()` includes all core fields, including `politicalGlyphByPlayerId` (1-character political owner glyphs) so that ownership glyphs on political maps are stable across loads.
   - **gameId constraints:** The `gameId` must be a non-empty string. It may contain any characters except those that would create ambiguity with map-data keys (see below). For clarity, avoid gameIds that end with `_tileMapByRegion`, `_topologyByRegion`, or `_combinedTopology` unless you intentionally want the game to be treated as a potential map-data key (see listGameIds behavior).
-  - **Optional map data:** keys = `gameId + suffix`; suffixes: `_tileMapByRegion`, `_topologyByRegion`, `_combinedTopology`. Values = JSON produced by the respective model `toJson()` (e.g. `TileMapResult`, `MapTopology`).
+  - **Required map data:** keys = `gameId + suffix`; suffixes: `_tileMapByRegion`, `_topologyByRegion`, `_combinedTopology`. Values = JSON produced by the respective model `toJson()` (e.g. `TileMapResult`, `MapTopology`).
 - **Province/region identity:** Province and region ids stored in the saved payload are whatever the model stores; for consistency with [world-model-identity.md](../game/world-model-identity.md), any province or region id in saved state follows the same prefixed form and lookup rules as at runtime (no separate serialization format).
 
 ---
@@ -30,11 +30,11 @@
 
 ---
 
-## Optional map data
+## Required map data
 
-- Map data (tile maps per region, topology per region, combined topology) is optional. Saves created by ctdev Init Game or init_game with map output include it; legacy saves may have none. Tile map structure and semantics are defined in [map-data.md](map-data.md) § Tile map format; this serialization is for **ctdev/init tooling** (e.g. Load Savegame map view). The main game does not require map data to load.
+- Map data (tile maps per region, topology per region, combined topology) is required for playable saves. Tile map structure and semantics are defined in [map-data.md](map-data.md) § Tile map format.
 - **saveMapData:** Writes the three map-data keys for the given `gameId`. Caller supplies `tileMapByRegion`, `topologyByRegion`, `combinedTopology`.
-- **loadMapData:** Returns the three maps for `gameId`, or **null** if any of the three keys is missing (legacy save). Ctdev Load Savegame shows a message when map data is absent and cannot open the map view; see [ctdev-app.md](ctdev-app.md) § Load Savegame.
+- **loadMapData:** Returns the three maps for `gameId` when all required map-data keys are present and valid. If any required key is missing or invalid, load fails with an explicit error; gameplay entry points must reject the save.
 
 ---
 
@@ -43,7 +43,7 @@
 | Concern | Spec |
 |--------|------|
 | Game/WorldState serialization | [world-model.md](../game/world-model.md) |
-| Load Savegame flow, map data absent | [ctdev-app.md](ctdev-app.md) |
+| Load Savegame flow | [ctdev-app.md](ctdev-app.md) |
 | init_game save output (`--output-game`) | [init-game-tool.md](init-game-tool.md) |
 | Persist after turn resolve | [turn-resolution.md](turn-resolution.md) |
 | Persist or pass after game setup | [game-setup-pipeline.md](game-setup-pipeline.md) |
@@ -56,8 +56,8 @@
 - **Save Game.** Given a Hive box and a Game with id `gameId`, when the system saves the game, then the system writes one entry with key `gameId` and value `Game.toJson()`, and the system logs with prefix `save:` including `gameId` and success (per [ctdev-logging.md](ctdev-logging.md)).
 - **Load Game.** Given a Hive box and a `gameId`, when the system loads the game, then the system returns a Game instance from the stored JSON, or null if the key is not found or deserialization fails; on failure the system logs with prefix `save:` including `gameId` and error (per [ctdev-logging.md](ctdev-logging.md)).
 - **List game ids.** Given a Hive box, when the system lists game ids, then the system returns only keys that are game ids. Keys ending with `_tileMapByRegion`, `_topologyByRegion`, or `_combinedTopology` are excluded ONLY if their prefix (gameId) exists as a separate key in the box (proving they are map data). This ensures game IDs that happen to end with these suffixes are not incorrectly excluded.
-- **Optional map data — save/load round-trip.** Given a Hive box, a `gameId`, and valid `tileMapByRegion`, `topologyByRegion`, and `combinedTopology`, when the system calls saveMapData and then loadMapData for that `gameId`, then loadMapData returns the same three maps (round-trip preserves data).
-- **Optional map data missing.** Given a Hive box and a `gameId` for which no map-data key exists (or any one of the three keys is missing), when the system calls `loadMapData` for that `gameId`, then `loadMapData` returns null.
+- **Required map data — save/load round-trip.** Given a Hive box, a `gameId`, and valid `tileMapByRegion`, `topologyByRegion`, and `combinedTopology`, when the system calls saveMapData and then loadMapData for that `gameId`, then loadMapData returns the same three maps (round-trip preserves data).
+- **Required map data missing.** Given a Hive box and a `gameId` for which any required map-data key is missing, when the system calls `loadMapData` for that `gameId`, then `loadMapData` fails with an explicit error that identifies missing required map data.
 - **Delete.** Given a Hive box and a `gameId`, when the system deletes the game, then the system removes the key `gameId` and the three map-data keys (`gameId + _tileMapByRegion`, etc.); no-op if the game key is not present.
 - **Round-trip Game fields.** Given a Game with worldState, players, greatPowerColorOverride, turnTimeMapping, and other serialized fields, when the system saves and then loads by the same game id, then the loaded Game equals the original for all fields covered by `Game.toJson()`/`fromJson()` (as covered by existing game_save_adapter_test.dart).
 - **Logging.** Save/load operations use the `save:` prefix and log gameId and success or failure per [ctdev-logging.md](ctdev-logging.md).

--- a/SPEC/program/turn-resolution.md
+++ b/SPEC/program/turn-resolution.md
@@ -48,20 +48,14 @@ Signature (conceptual): `WorldState resolve(WorldState current)` or `Game resolv
 
 ## Loaded Game Behavior
 
-When a game is **loaded from save**, the map data (`tileMapByRegion`, `topologyByRegion`) may be absent (not serialized with the game). In this case, the resolver operates with empty or null map topology:
-
-- **Extraction Phase:** When `tileMapByRegion` is empty or null, extraction leaves stockpiles unchanged. No resources are extracted because the tile map data required to calculate yields is unavailable. This is a graceful degradation: the turn advances without crashing, but no economic progress occurs until the map is restored.
-
-- **Movement Phase:** When `topologyByRegion` is empty or null, land movement applies no adjacency validation. Units may not be able to move to adjacent provinces because the topology data defining adjacency is missing. Sea movement similarly lacks topology for sea zone adjacency.
-
-- **Combat Phase:** Combat resolution proceeds with available world state data. Unit strengths and casualties are calculated normally, but terrain modifiers may be unavailable without tile map data.
+Map data required for resolution (`tileMapByRegion`, `topologyByRegion`, and combined topology used for AI) is mandatory for playable saves. Turn resolution call sites must not execute with missing topology data.
 
 **Acceptance Criteria:**
 
-- Given a game is loaded from save without serialized tileMapByRegion or topologyByRegion
-- When TurnResolver runs the next turn
-- Then the turn advances successfully (turn number increments, no crash)
-- And extraction leaves stockpiles unchanged (graceful degradation)
-- And movement is limited or blocked by missing topology
+- Given a game load attempt where required map data is missing or invalid
+- When the app/service prepares turn resolution or AI order generation
+- Then the app/service rejects the save with an explicit error and does not run turn resolution
 
-**App-Level Note:** The app may cache map data separately and re-provide it on load. If the app provides cached map data to the resolver, full extraction and movement are restored. This behavior is app-level (GameService) and not part of the core resolver contract.
+- Given a playable loaded game with required map data present
+- When TurnResolver runs the next turn
+- Then extraction, movement, combat, and AI order generation execute with map topology provided by the loaded map data

--- a/app/lib/core/services/game_service.dart
+++ b/app/lib/core/services/game_service.dart
@@ -24,7 +24,7 @@ class _GameMapCache {
 final _mapGenPassLog = mapLogger('tile_map');
 
 /// Loads/saves games and advances turn. SPEC/project/phase-1: app invokes TurnResolver and persists via colonizethis_save.
-/// Phase 2: createNewGame uses full game-setup pipeline; nextTurn uses cached map data when available.
+/// Phase 2: createNewGame uses full game-setup pipeline; nextTurn requires cached/persisted map data.
 class GameService {
   GameService(this._box, this._adapter);
 
@@ -45,26 +45,42 @@ class GameService {
   /// Populated when creating a new game or when loading a game with persisted map data.
   final Map<String, _GameMapCache> _mapCache = {};
 
-  /// Loads game by id. Returns null if not found.
-  /// When map data exists in storage, populates _mapCache so map rendering works.
+  _GameMapCache _requireMapData(String gameId) {
+    final cached = _mapCache[gameId];
+    if (cached != null) return cached;
+    final mapData = _adapter.loadMapData(_box, gameId);
+    final loaded = _GameMapCache(
+      combinedTopology: mapData.combinedTopology,
+      tileMapByRegion: mapData.tileMapByRegion,
+      topologyByRegion: mapData.topologyByRegion,
+      warpLinks: mapData.warpLinks,
+    );
+    _mapCache[gameId] = loaded;
+    return loaded;
+  }
+
+  /// Loads game by id. Returns null if not found or required map data is missing/invalid.
+  /// Populates _mapCache on successful load so map rendering and turn resolution work.
   Game? loadGame(String gameId) {
     final game = _adapter.load(_box, gameId);
     if (game == null) return null;
-    final cached = _mapCache[gameId];
-    if (cached != null) return game;
-    final mapData = _adapter.loadMapData(_box, gameId);
-    if (mapData != null) {
-      _mapCache[gameId] = _GameMapCache(
-        combinedTopology: mapData.combinedTopology,
-        tileMapByRegion: mapData.tileMapByRegion,
-        topologyByRegion: mapData.topologyByRegion,
-        warpLinks: mapData.warpLinks,
+    try {
+      _requireMapData(gameId);
+      return game;
+    } catch (e, st) {
+      saveLogger().e(
+        'required map data missing/invalid for gameId=$gameId',
+        error: e,
+        stackTrace: st,
       );
+      return null;
     }
-    return game;
   }
 
-  /// Returns map data for [gameId] from cache or storage. Null if not available (legacy save).
+  /// Returns map data for [gameId] from cache or storage.
+  ///
+  /// Returns null only when no game exists for [gameId]. For existing games, map data
+  /// is required and missing/invalid map data raises [StateError].
   ({
     MapTopology combinedTopology,
     Map<String, TileMapResult> tileMapByRegion,
@@ -72,28 +88,30 @@ class GameService {
     List<WarpLink>? warpLinks,
   })?
   getMapData(String gameId) {
-    final cached = _mapCache[gameId];
-    if (cached != null) {
-      return (
-        combinedTopology: cached.combinedTopology,
-        tileMapByRegion: cached.tileMapByRegion,
-        topologyByRegion: cached.topologyByRegion,
-        warpLinks: cached.warpLinks,
-      );
-    }
-    final mapData = _adapter.loadMapData(_box, gameId);
-    if (mapData == null) return null;
-    _mapCache[gameId] = _GameMapCache(
-      combinedTopology: mapData.combinedTopology,
-      tileMapByRegion: mapData.tileMapByRegion,
-      topologyByRegion: mapData.topologyByRegion,
-      warpLinks: mapData.warpLinks,
-    );
+    final gameExists = _adapter.load(_box, gameId) != null;
+    if (!gameExists) return null;
+    final cache = _requireMapData(gameId);
     return (
-      combinedTopology: mapData.combinedTopology,
-      tileMapByRegion: mapData.tileMapByRegion,
-      topologyByRegion: mapData.topologyByRegion,
-      warpLinks: mapData.warpLinks,
+      combinedTopology: cache.combinedTopology,
+      tileMapByRegion: cache.tileMapByRegion,
+      topologyByRegion: cache.topologyByRegion,
+      warpLinks: cache.warpLinks,
+    );
+  }
+
+  ({
+    MapTopology combinedTopology,
+    Map<String, TileMapResult> tileMapByRegion,
+    Map<String, MapTopology> topologyByRegion,
+    List<WarpLink>? warpLinks,
+  })
+  _requiredMapDataView(String gameId) {
+    final cache = _requireMapData(gameId);
+    return (
+      combinedTopology: cache.combinedTopology,
+      tileMapByRegion: cache.tileMapByRegion,
+      topologyByRegion: cache.topologyByRegion,
+      warpLinks: cache.warpLinks,
     );
   }
 
@@ -118,9 +136,9 @@ class GameService {
     Map<String, TileMapResult>? tileMapByRegion,
     void Function(GameEvent)? onGameEvent,
   }) {
-    final cache = _mapCache[current.id];
-    final topo = topology ?? cache?.combinedTopology ?? const MapTopology();
-    final tileMaps = tileMapByRegion ?? cache?.tileMapByRegion;
+    final mapData = _requiredMapDataView(current.id);
+    final topo = topology ?? mapData.combinedTopology;
+    final tileMaps = tileMapByRegion ?? mapData.tileMapByRegion;
     final humanOrders = orders ?? const Orders();
     final resolvedOrders = aiOrders != null
         ? mergeOrderLists(humanOrders: humanOrders, aiOrders: aiOrders)
@@ -164,9 +182,9 @@ class GameService {
     Orders orders, {
     void Function(GameEvent)? onGameEvent,
   }) {
-    final cache = _mapCache[game.id];
-    final topo = cache?.combinedTopology ?? const MapTopology();
-    final tileMaps = cache?.tileMapByRegion;
+    final mapData = _requiredMapDataView(game.id);
+    final topo = mapData.combinedTopology;
+    final tileMaps = mapData.tileMapByRegion;
     final result = resumeTurnResolutionWithCallToArmsDecisions(
       game: game,
       decisions: decisions,
@@ -210,9 +228,9 @@ class GameService {
     Orders orders, {
     void Function(GameEvent)? onGameEvent,
   }) {
-    final cache = _mapCache[game.id];
-    final topo = cache?.combinedTopology ?? const MapTopology();
-    final tileMaps = cache?.tileMapByRegion;
+    final mapData = _requiredMapDataView(game.id);
+    final topo = mapData.combinedTopology;
+    final tileMaps = mapData.tileMapByRegion;
     final result = resumeTurnResolutionWithOvertureDecisions(
       game: game,
       pendingOvertures: pendingOvertures,
@@ -254,9 +272,9 @@ class GameService {
     Orders orders, {
     void Function(GameEvent)? onGameEvent,
   }) {
-    final cache = _mapCache[game.id];
-    final topo = cache?.combinedTopology ?? const MapTopology();
-    final tileMaps = cache?.tileMapByRegion;
+    final mapData = _requiredMapDataView(game.id);
+    final topo = mapData.combinedTopology;
+    final tileMaps = mapData.tileMapByRegion;
     final result = resumeTurnResolutionWithInterventionDecisions(
       game: game,
       decisions: decisions,

--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -201,9 +201,6 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
       _workTargetSelection = (unit: unit, workTarget: workTarget);
       _computeValidTileKeysForSelection();
     });
-    if (closePanel) {
-      Navigator.of(context).maybePop();
-    }
   }
 
   void _onTileSelectedForWork(String tileKey) {

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -94,17 +94,14 @@ void _applyTurnResolutionResult(WidgetRef ref, TurnResolutionResult result) {
 TurnResolutionResult resolveNextTurnForGameScreen({
   required Game game,
   required Orders orders,
-  required MapTopology? topologyForAi,
+  required MapTopology topologyForAi,
   required TurnResolutionResult Function({
     required Orders orders,
     Orders? aiOrders,
   })
   runTurnResolution,
 }) {
-  final aiOrders = switch (topologyForAi) {
-    null => null,
-    _ => generateOrdersForGameFullAI(game, topologyForAi).orders,
-  };
+  final aiOrders = generateOrdersForGameFullAI(game, topologyForAi).orders;
   return runTurnResolution(orders: orders, aiOrders: aiOrders);
 }
 
@@ -146,10 +143,15 @@ class GameScreen extends ConsumerWidget {
                 final service = ref.read(gameServiceProvider);
                 final orders = ref.read(currentOrdersProvider);
                 final mapData = service.getMapData(game.id);
+                if (mapData == null) {
+                  throw StateError(
+                    'Missing required map data for gameId=${game.id}',
+                  );
+                }
                 final result = resolveNextTurnForGameScreen(
                   game: game,
                   orders: orders,
-                  topologyForAi: mapData?.combinedTopology,
+                  topologyForAi: mapData.combinedTopology,
                   runTurnResolution:
                       ({required Orders orders, Orders? aiOrders}) =>
                           service.runTurnResolution(

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -626,52 +626,6 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
   }
 
   @override
-  void didUpdateWidget(covariant NavalUnitsPanel oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.game != widget.game) {
-      final flat = _flattenTree(
-        _buildNavalTree(widget.game, widget.humanPlayerId),
-      );
-      final valid = flat.map(_selectionFleetId).toSet();
-      final pruned = _selectedFleetIds.intersection(valid);
-      if (pruned.length != _selectedFleetIds.length) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (!mounted) return;
-          setState(() {
-            _selectedFleetIds
-              ..clear()
-              ..addAll(pruned);
-          });
-        });
-      }
-    }
-  }
-
-  void _openSplitDialog(_FleetRow row) {
-    final id = _selectionFleetId(row);
-    Fleet? fleet;
-    for (final f in widget.game.worldState.fleets) {
-      if (f.id == id) {
-        fleet = f;
-        break;
-      }
-    }
-    if (fleet == null) return;
-
-    final original = fleet;
-    showDialog<void>(
-      context: context,
-      builder: (ctx) => SplitFleetDialog(
-        originalFleet: original,
-        game: widget.game,
-        humanPlayerId: widget.humanPlayerId,
-        isHomeFleet: row.isHomeFleet,
-        bus: widget.bus,
-      ),
-    );
-  }
-
-  @override
   Widget build(BuildContext context) {
     final tree = _buildNavalTree(widget.game, widget.humanPlayerId);
     final flat = _flattenTree(tree);

--- a/app/lib/providers/map_view_provider.dart
+++ b/app/lib/providers/map_view_provider.dart
@@ -49,13 +49,15 @@ final mapProvinceNamesVisibleProvider =
     );
 
 /// Map view data for the current game with player-constrained visibility.
-/// Null when no game, no map data (legacy save), or loading.
+/// Null when no game or loading.
 final mapViewDataProvider = Provider<InitGameMapViewData?>((ref) {
   final game = ref.watch(currentGameProvider);
   if (game == null) return null;
   final service = ref.watch(gameServiceProvider);
   final mapData = service.getMapData(game.id);
-  if (mapData == null) return null;
+  if (mapData == null) {
+    throw StateError('Missing required map data for gameId=${game.id}');
+  }
   final colorOverride = greatPowerColorOverrideFromGame(game);
 
   final humanPlayerId =

--- a/app/test/game_screen_next_turn_ai_test.dart
+++ b/app/test/game_screen_next_turn_ai_test.dart
@@ -55,31 +55,5 @@ void main() {
       expect(capturedAiOrders, isNotNull);
       expect(capturedAiOrders, equals(expectedAiOrders));
     });
-
-    test('passes null aiOrders when map data is unavailable', () {
-      final game = Game(
-        id: 'g-next-turn-no-map',
-        worldState: const WorldState(
-          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(),
-          newWorld: RegionData(),
-        ),
-        players: const [Player(id: 'gp1', displayName: 'Human', isHuman: true)],
-      );
-
-      Orders? capturedAiOrders;
-      final result = resolveNextTurnForGameScreen(
-        game: game,
-        orders: const Orders(),
-        topologyForAi: null,
-        runTurnResolution: ({required Orders orders, Orders? aiOrders}) {
-          capturedAiOrders = aiOrders;
-          return TurnResolutionComplete(game);
-        },
-      );
-
-      expect(result, isA<TurnResolutionComplete>());
-      expect(capturedAiOrders, isNull);
-    });
   });
 }

--- a/app/test/game_screen_turn_resolution_branches_test.dart
+++ b/app/test/game_screen_turn_resolution_branches_test.dart
@@ -74,10 +74,30 @@ void main() {
   suppressLogsForTests();
 
   late Box<dynamic> box;
+  late GameSaveAdapter adapter;
+
+  void saveRequiredMapDataForGame(String gameId) {
+    final tileMap = TileMapResult(
+      width: 1,
+      height: 1,
+      grid: [
+        ['oldWorld|M1'],
+      ],
+    );
+    const topo = MapTopology(nodes: [], edges: []);
+    adapter.saveMapData(
+      box,
+      gameId,
+      tileMapByRegion: {'oldWorld': tileMap, 'newWorld': tileMap},
+      topologyByRegion: {'oldWorld': topo, 'newWorld': topo},
+      combinedTopology: topo,
+    );
+  }
 
   setUpAll(() async {
     Hive.init('./.dart_tool/test_hive_game_screen_turn_branches');
     box = await Hive.openBox<dynamic>(HiveBoxNames.games);
+    adapter = GameSaveAdapter();
   });
 
   testWidgets(
@@ -100,7 +120,9 @@ void main() {
         ],
       );
 
-      final service = _PendingTurnGameService(box, GameSaveAdapter());
+      adapter.save(box, game);
+      saveRequiredMapDataForGame(game.id);
+      final service = _PendingTurnGameService(box, adapter);
 
       await tester.pumpWidget(
         ProviderScope(
@@ -161,7 +183,9 @@ void main() {
         ],
       );
 
-      final service = _PendingInterventionGameService(box, GameSaveAdapter());
+      adapter.save(box, game);
+      saveRequiredMapDataForGame(game.id);
+      final service = _PendingInterventionGameService(box, adapter);
 
       await tester.pumpWidget(
         ProviderScope(

--- a/app/test/game_service_cache_test.dart
+++ b/app/test/game_service_cache_test.dart
@@ -37,31 +37,51 @@ void main() {
       expect(result, isNull);
     });
 
-    test('fresh GameService loads map from storage on getMapData and loadGame', () {
-      const gameId = 'persist_map';
-      final config = GameSetupConfig(
-        selectedGreatPowerIds: ['england'],
-        continentCount: 1,
-        minorNationCount: 0,
-        tribeCount: 1,
-        numProvincesOldWorld: 3,
-        numProvincesNewWorld: 2,
+    test('loadGame returns null when required map data is missing', () {
+      const gameId = 'missing_map_data';
+      final game = Game(
+        id: gameId,
+        worldState: const WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(),
+          newWorld: RegionData(),
+        ),
+        players: const [Player(id: 'gp1', displayName: 'Human', isHuman: true)],
       );
-      final writer = GameService(box, GameSaveAdapter());
-      writer.createNewGame(id: gameId, config: config);
+      service.saveGame(game);
 
-      final reader = GameService(box, GameSaveAdapter());
-      final first = reader.getMapData(gameId);
-      expect(first, isNotNull);
-      expect(first!.combinedTopology, isNotNull);
-
-      final second = reader.getMapData(gameId);
-      expect(second, isNotNull);
-
-      final freshForLoad = GameService(box, GameSaveAdapter());
-      final loaded = freshForLoad.loadGame(gameId);
-      expect(loaded, isNotNull);
+      final loaded = service.loadGame(gameId);
+      expect(loaded, isNull);
     });
+
+    test(
+      'fresh GameService loads map from storage on getMapData and loadGame',
+      () {
+        const gameId = 'persist_map';
+        final config = GameSetupConfig(
+          selectedGreatPowerIds: ['england'],
+          continentCount: 1,
+          minorNationCount: 0,
+          tribeCount: 1,
+          numProvincesOldWorld: 3,
+          numProvincesNewWorld: 2,
+        );
+        final writer = GameService(box, GameSaveAdapter());
+        writer.createNewGame(id: gameId, config: config);
+
+        final reader = GameService(box, GameSaveAdapter());
+        final first = reader.getMapData(gameId);
+        expect(first, isNotNull);
+        expect(first!.combinedTopology, isNotNull);
+
+        final second = reader.getMapData(gameId);
+        expect(second, isNotNull);
+
+        final freshForLoad = GameService(box, GameSaveAdapter());
+        final loaded = freshForLoad.loadGame(gameId);
+        expect(loaded, isNotNull);
+      },
+    );
 
     test('runTurnResolution uses merge when aiOrders is non-null', () {
       const gameId = 'merge_ai';
@@ -96,4 +116,3 @@ void main() {
     });
   });
 }
-

--- a/app/test/game_service_test.dart
+++ b/app/test/game_service_test.dart
@@ -77,6 +77,24 @@ void main() {
   });
 
   group('GameService event emission', () {
+    void saveRequiredMapDataForGame(String gameId) {
+      final tileMap = TileMapResult(
+        width: 1,
+        height: 1,
+        grid: [
+          ['oldWorld|M1'],
+        ],
+      );
+      final topo = const MapTopology(nodes: [], edges: []);
+      adapter.saveMapData(
+        box,
+        gameId,
+        tileMapByRegion: {'oldWorld': tileMap, 'newWorld': tileMap},
+        topologyByRegion: {'oldWorld': topo, 'newWorld': topo},
+        combinedTopology: topo,
+      );
+    }
+
     test(
       'AppEventBus emits OvertureRequiredEvent synchronously and listener receives it',
       () async {
@@ -165,7 +183,12 @@ void main() {
           ),
           players: const [
             Player(id: 'gp1', displayName: 'Human', isHuman: true, treasury: 0),
-            Player(id: 'gp2', displayName: 'Aggressor', isHuman: false, treasury: 0),
+            Player(
+              id: 'gp2',
+              displayName: 'Aggressor',
+              isHuman: false,
+              treasury: 0,
+            ),
           ],
           minorNations: const [
             MinorNation(id: 'minor1', displayName: 'Minor 1'),
@@ -205,6 +228,7 @@ void main() {
 
         final received = <AppEvent>[];
         bus.on<InterventionRequiredEvent>().listen(received.add);
+        saveRequiredMapDataForGame(game.id);
 
         final result = service.runTurnResolution(game, orders: orders);
 

--- a/app/test/game_to_ui_bus_listener_test.dart
+++ b/app/test/game_to_ui_bus_listener_test.dart
@@ -5,6 +5,9 @@ import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
 import 'package:colonizethis_app/providers/game_service_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/widgets/game_to_ui_bus_listener.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -23,10 +26,30 @@ void main() {
   suppressLogsForTests();
 
   late Box<dynamic> gamesBox;
+  late GameSaveAdapter adapter;
+
+  void saveRequiredMapDataForGame(String gameId) {
+    final tileMap = TileMapResult(
+      width: 1,
+      height: 1,
+      grid: [
+        ['oldWorld|M1'],
+      ],
+    );
+    const topo = MapTopology(nodes: [], edges: []);
+    adapter.saveMapData(
+      gamesBox,
+      gameId,
+      tileMapByRegion: {'oldWorld': tileMap, 'newWorld': tileMap},
+      topologyByRegion: {'oldWorld': topo, 'newWorld': topo},
+      combinedTopology: topo,
+    );
+  }
 
   setUpAll(() async {
     Hive.init('./.dart_tool/test_hive_game_to_ui');
     gamesBox = await Hive.openBox<dynamic>(HiveBoxNames.games);
+    adapter = GameSaveAdapter();
   });
 
   testWidgets(
@@ -50,8 +73,8 @@ void main() {
         ),
       );
 
-      final adapter = GameSaveAdapter();
       adapter.save(gamesBox, game);
+      saveRequiredMapDataForGame(game.id);
 
       final bus = AppEventBus.create();
       addTearDown(bus.dispose);
@@ -121,8 +144,8 @@ void main() {
         ),
       );
 
-      final adapter = GameSaveAdapter();
       adapter.save(gamesBox, game);
+      saveRequiredMapDataForGame(game.id);
 
       final bus = AppEventBus.create();
       addTearDown(bus.dispose);
@@ -190,8 +213,8 @@ void main() {
         ),
       );
 
-      final adapter = GameSaveAdapter();
       adapter.save(gamesBox, game);
+      saveRequiredMapDataForGame(game.id);
 
       final bus = AppEventBus.create();
       addTearDown(bus.dispose);
@@ -263,8 +286,8 @@ void main() {
         ),
       );
 
-      final adapter = GameSaveAdapter();
       adapter.save(gamesBox, game);
+      saveRequiredMapDataForGame(game.id);
 
       final bus = AppEventBus.create();
       addTearDown(bus.dispose);
@@ -331,8 +354,8 @@ void main() {
         ),
       );
 
-      final adapter = GameSaveAdapter();
       adapter.save(gamesBox, game);
+      saveRequiredMapDataForGame(game.id);
 
       final bus = AppEventBus.create();
       addTearDown(bus.dispose);
@@ -393,8 +416,8 @@ void main() {
         ],
       );
 
-      final adapter = GameSaveAdapter();
       adapter.save(gamesBox, game);
+      saveRequiredMapDataForGame(game.id);
       final bus = AppEventBus.create();
       addTearDown(bus.dispose);
 
@@ -461,8 +484,8 @@ void main() {
         ],
       );
 
-      final adapter = GameSaveAdapter();
       adapter.save(gamesBox, game);
+      saveRequiredMapDataForGame(game.id);
       final bus = AppEventBus.create();
       addTearDown(bus.dispose);
 

--- a/app/test/map_view_provider_test.dart
+++ b/app/test/map_view_provider_test.dart
@@ -15,7 +15,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive/hive.dart';
 
 class _FakeGameService extends GameService {
-  _FakeGameService(Box<dynamic> box, GameSaveAdapter adapter) : super(box, adapter);
+  _FakeGameService(Box<dynamic> box, GameSaveAdapter adapter)
+    : super(box, adapter);
 
   @override
   getMapData(String gameId) {
@@ -26,7 +27,7 @@ class _FakeGameService extends GameService {
 /// Minimal OW/NW tile maps + topology for [mapViewDataProvider] integration tests.
 class _GameServiceWithMinimalMap extends GameService {
   _GameServiceWithMinimalMap(Box<dynamic> box, GameSaveAdapter adapter)
-      : super(box, adapter);
+    : super(box, adapter);
 
   static final Map<String, MapTopology> _topologyByRegion = {
     'oldWorld': MapTopology(
@@ -147,7 +148,7 @@ void main() {
     expect(mapView, isNull);
   });
 
-  test('mapViewDataProvider returns null when GameService has no map data', () {
+  test('mapViewDataProvider throws when GameService has no map data', () {
     final game = Game(
       id: 'g1',
       worldState: const WorldState(
@@ -156,12 +157,7 @@ void main() {
         newWorld: RegionData(),
       ),
       players: const [
-        Player(
-          id: 'gp1',
-          displayName: 'Human',
-          isHuman: true,
-          treasury: 0,
-        ),
+        Player(id: 'gp1', displayName: 'Human', isHuman: true, treasury: 0),
       ],
     );
 
@@ -176,8 +172,15 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    final mapView = container.read(mapViewDataProvider);
-    expect(mapView, isNull);
+    expect(
+      () => container.read(mapViewDataProvider),
+      throwsA(
+        predicate(
+          (e) =>
+              e.toString().contains('Missing required map data for gameId=g1'),
+        ),
+      ),
+    );
   });
 
   test(
@@ -211,12 +214,7 @@ void main() {
           ),
         ),
         players: const [
-          Player(
-            id: 'gp1',
-            displayName: 'Human',
-            isHuman: true,
-            treasury: 0,
-          ),
+          Player(id: 'gp1', displayName: 'Human', isHuman: true, treasury: 0),
         ],
         minorNations: const [],
         tribes: const [],
@@ -243,4 +241,3 @@ void main() {
     },
   );
 }
-

--- a/packages/colonizethis_save/lib/src/game_save_adapter.dart
+++ b/packages/colonizethis_save/lib/src/game_save_adapter.dart
@@ -11,7 +11,7 @@ const String _suffixCombinedTopology = '_combinedTopology';
 const String _suffixWarpLinks = '_warpLinks';
 
 /// Saves and loads [Game] state to/from a Hive box. One entry per game, keyed by [Game.id].
-/// Optional map data (tile maps, topology) can be stored per game for Load Savegame view. See SPEC/program/save-load.md.
+/// Map data (tile maps, topology) is required for playable saves. See SPEC/program/save-load.md.
 class GameSaveAdapter {
   /// Saves [game] to [box]. Key = game.id, value = game.toJson().
   void save(Box<dynamic> box, Game game) {
@@ -88,7 +88,7 @@ class GameSaveAdapter {
     return result;
   }
 
-  /// Saves map data for [gameId] so Load Savegame can build InitGameMapViewData. Optional; legacy saves have none.
+  /// Saves required map data for [gameId].
   void saveMapData(
     Box<dynamic> box,
     String gameId, {
@@ -116,20 +116,22 @@ class GameSaveAdapter {
     _log.d('saved map data gameId=$gameId');
   }
 
-  /// Loads map data for [gameId]. Returns null if any key is missing (legacy save).
-  /// Warp links are optional for backward compatibility with legacy saves.
+  /// Loads required map data for [gameId].
+  ///
+  /// Throws [StateError] when any required key is missing.
+  /// Throws [FormatException] when map data exists but is invalid.
   ({
     Map<String, TileMapResult> tileMapByRegion,
     Map<String, MapTopology> topologyByRegion,
     MapTopology combinedTopology,
     List<WarpLink>? warpLinks,
-  })?
+  })
   loadMapData(Box<dynamic> box, String gameId) {
     final tileRaw = box.get(gameId + _suffixTileMapByRegion);
     final topoRaw = box.get(gameId + _suffixTopologyByRegion);
     final combinedRaw = box.get(gameId + _suffixCombinedTopology);
     if (tileRaw == null || topoRaw == null || combinedRaw == null) {
-      return null;
+      throw StateError('Required map data missing for gameId=$gameId');
     }
     try {
       final tileMapByRegion = (tileRaw as Map).map<String, TileMapResult>(
@@ -163,12 +165,8 @@ class GameSaveAdapter {
         warpLinks: warpLinks,
       );
     } catch (e, st) {
-      _log.e(
-        'load map data failed gameId=$gameId',
-        error: e,
-        stackTrace: st,
-      );
-      return null;
+      _log.e('load map data failed gameId=$gameId', error: e, stackTrace: st);
+      throw FormatException('Invalid map data for gameId=$gameId');
     }
   }
 

--- a/packages/colonizethis_save/test/game_save_adapter_test.dart
+++ b/packages/colonizethis_save/test/game_save_adapter_test.dart
@@ -29,7 +29,9 @@ void main() {
         worldState: WorldState(
           turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 5),
           oldWorld: const RegionData(
-            provinces: [Province(id: 'p1', regionId: 'oldWorld', ownerId: 'player1')],
+            provinces: [
+              Province(id: 'p1', regionId: 'oldWorld', ownerId: 'player1'),
+            ],
             units: [],
           ),
           newWorld: const RegionData(),
@@ -64,15 +66,31 @@ void main() {
       );
       adapter.save(box, game);
       adapter.save(box, game.copyWith(id: 'g2'));
-      final tileMap = TileMapResult(width: 2, height: 2, grid: [
-        ['p1', 'p1'],
-        ['p2', 's1'],
-      ]);
+      final tileMap = TileMapResult(
+        width: 2,
+        height: 2,
+        grid: [
+          ['p1', 'p1'],
+          ['p2', 's1'],
+        ],
+      );
       final topo = MapTopology(
         nodes: [
-          TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          TopologyNode(id: 'p2', regionId: 'oldWorld', type: TopologyNodeType.province),
-          TopologyNode(id: 's1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(
+            id: 'p1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'p2',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 's1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.seaZone,
+          ),
         ],
         edges: [],
       );
@@ -87,62 +105,75 @@ void main() {
       expect(adapter.listGameIds(box).length, 2);
     });
 
-    test('listGameIds returns game id that ends with suffix when no matching map-data exists', () {
-      final game = Game(
-        id: 'mygame_tileMapByRegion',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [],
-      );
-      adapter.save(box, game);
-      adapter.save(box, game.copyWith(id: 'normalGame'));
+    test(
+      'listGameIds returns game id that ends with suffix when no matching map-data exists',
+      () {
+        final game = Game(
+          id: 'mygame_tileMapByRegion',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: const [],
+        );
+        adapter.save(box, game);
+        adapter.save(box, game.copyWith(id: 'normalGame'));
 
-      final ids = adapter.listGameIds(box);
-      expect(ids, containsAll(['mygame_tileMapByRegion', 'normalGame']));
-      expect(ids.length, 2);
-    });
+        final ids = adapter.listGameIds(box);
+        expect(ids, containsAll(['mygame_tileMapByRegion', 'normalGame']));
+        expect(ids.length, 2);
+      },
+    );
 
-    test('listGameIds excludes map-data keys when corresponding game exists', () {
-      final game = Game(
-        id: 'gameWithMapData',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [],
-      );
-      adapter.save(box, game);
+    test(
+      'listGameIds excludes map-data keys when corresponding game exists',
+      () {
+        final game = Game(
+          id: 'gameWithMapData',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: const [],
+        );
+        adapter.save(box, game);
 
-      final tileMap = TileMapResult(width: 2, height: 2, grid: [
-        ['p1', 'p1'],
-        ['p2', 's1'],
-      ]);
-      final topo = MapTopology(
-        nodes: [
-          TopologyNode(
-              id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
-        ],
-        edges: [],
-      );
-      adapter.saveMapData(
-        box,
-        'gameWithMapData',
-        tileMapByRegion: {'oldWorld': tileMap},
-        topologyByRegion: {'oldWorld': topo},
-        combinedTopology: topo,
-      );
+        final tileMap = TileMapResult(
+          width: 2,
+          height: 2,
+          grid: [
+            ['p1', 'p1'],
+            ['p2', 's1'],
+          ],
+        );
+        final topo = MapTopology(
+          nodes: [
+            TopologyNode(
+              id: 'p1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: [],
+        );
+        adapter.saveMapData(
+          box,
+          'gameWithMapData',
+          tileMapByRegion: {'oldWorld': tileMap},
+          topologyByRegion: {'oldWorld': topo},
+          combinedTopology: topo,
+        );
 
-      final ids = adapter.listGameIds(box);
-      expect(ids, contains('gameWithMapData'));
-      expect(ids.length, 1);
-      expect(ids, isNot(contains('gameWithMapData_tileMapByRegion')));
-      expect(ids, isNot(contains('gameWithMapData_topologyByRegion')));
-      expect(ids, isNot(contains('gameWithMapData_combinedTopology')));
-    });
+        final ids = adapter.listGameIds(box);
+        expect(ids, contains('gameWithMapData'));
+        expect(ids.length, 1);
+        expect(ids, isNot(contains('gameWithMapData_tileMapByRegion')));
+        expect(ids, isNot(contains('gameWithMapData_topologyByRegion')));
+        expect(ids, isNot(contains('gameWithMapData_combinedTopology')));
+      },
+    );
 
     test('saveMapData then loadMapData returns same data', () {
       final tileMap = TileMapResult(
@@ -163,9 +194,21 @@ void main() {
       );
       final topo = MapTopology(
         nodes: [
-          TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          TopologyNode(id: 'p2', regionId: 'oldWorld', type: TopologyNodeType.province),
-          TopologyNode(id: 's1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(
+            id: 'p1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'p2',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 's1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.seaZone,
+          ),
         ],
         edges: [TopologyEdge(id1: 'p1', id2: 'p2')],
       );
@@ -181,14 +224,23 @@ void main() {
       expect(loaded!.tileMapByRegion['oldWorld']!.width, 2);
       expect(loaded.tileMapByRegion['oldWorld']!.height, 2);
       expect(loaded.tileMapByRegion['oldWorld']!.cell(0, 0), 'p1');
-      expect(loaded.tileMapByRegion['oldWorld']!.terrainAt(0, 0), TerrainType.plains);
-      expect(loaded.tileMapByRegion['oldWorld']!.resourceAt(0, 0), Resource.grain);
+      expect(
+        loaded.tileMapByRegion['oldWorld']!.terrainAt(0, 0),
+        TerrainType.plains,
+      );
+      expect(
+        loaded.tileMapByRegion['oldWorld']!.resourceAt(0, 0),
+        Resource.grain,
+      );
       expect(loaded.combinedTopology.nodes.length, 3);
       expect(loaded.combinedTopology.edges.length, 1);
     });
 
-    test('loadMapData returns null for legacy save without map data', () {
-      expect(adapter.loadMapData(box, 'noMapData'), isNull);
+    test('loadMapData throws when required map data is missing', () {
+      expect(
+        () => adapter.loadMapData(box, 'noMapData'),
+        throwsA(isA<StateError>()),
+      );
     });
 
     test('delete removes game', () {
@@ -215,9 +267,11 @@ void main() {
         id: 'withCapital',
         worldState: WorldState(
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(provinces: [
-            Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
-          ]),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
+            ],
+          ),
           newWorld: const RegionData(),
           tileState: tileState,
           portsByProvinceSeaboard: {'p1|sea1': 'oldWorld|p1|0|0'},
@@ -240,9 +294,15 @@ void main() {
       adapter.save(box, game);
       final loaded = adapter.load(box, 'withCapital');
       expect(loaded, isNotNull);
-      expect(loaded!.worldState.tileState.improvementLevel('oldWorld|p1|0|0'), 2);
+      expect(
+        loaded!.worldState.tileState.improvementLevel('oldWorld|p1|0|0'),
+        2,
+      );
       expect(loaded.worldState.tileState.roadLevel('oldWorld|p1|0|0'), 1);
-      expect(loaded.worldState.portsByProvinceSeaboard['p1|sea1'], 'oldWorld|p1|0|0');
+      expect(
+        loaded.worldState.portsByProvinceSeaboard['p1|sea1'],
+        'oldWorld|p1|0|0',
+      );
       expect(loaded.players.single.capitalProvinceId, 'p1');
       expect(loaded.players.single.capitalTile?.regionId, 'oldWorld');
       expect(loaded.players.single.capitalTile?.x, 0);
@@ -284,12 +344,8 @@ void main() {
             militaryLevel: 4,
           ),
         ],
-        minorNations: [
-          MinorNation(id: 'min1', effectiveMilitaryLevel: 4),
-        ],
-        tribes: [
-          Tribe(id: 'tribe1', effectiveMilitaryLevel: 1),
-        ],
+        minorNations: [MinorNation(id: 'min1', effectiveMilitaryLevel: 4)],
+        tribes: [Tribe(id: 'tribe1', effectiveMilitaryLevel: 1)],
       );
       adapter.save(box, game);
       final loaded = adapter.load(box, 'phase3');
@@ -310,9 +366,7 @@ void main() {
           oldWorld: const RegionData(),
           newWorld: const RegionData(),
         ),
-        players: const [
-          Player(id: 'pl1', displayName: 'Spain', isHuman: true),
-        ],
+        players: const [Player(id: 'pl1', displayName: 'Spain', isHuman: true)],
         greatPowerColorOverride: {
           'gp1': [255, 0, 0],
           'gp2': [0, 255, 0],
@@ -334,9 +388,7 @@ void main() {
           oldWorld: const RegionData(),
           newWorld: const RegionData(),
         ),
-        players: const [
-          Player(id: 'pl1', displayName: 'Spain', isHuman: true),
-        ],
+        players: const [Player(id: 'pl1', displayName: 'Spain', isHuman: true)],
         turnTimeMapping: const TurnTimeMapping(
           startYear: 1600,
           cutoffYear: 1750,
@@ -354,34 +406,39 @@ void main() {
       expect(loaded.turnTimeMapping!.yearsPerTurnAfterCutoff, 2);
     });
 
-    test('loadMapData returns null and logs for invalid map data JSON', () {
+    test('loadMapData throws for invalid map data JSON', () {
       // Manually insert invalid map data to simulate corrupted save
       box.put('invalidMap_tileMapByRegion', {'invalid': 'data'});
       box.put('invalidMap_topologyByRegion', {'nodes': 'not-a-list'});
       box.put('invalidMap_combinedTopology', 'also invalid');
-      final loaded = adapter.loadMapData(box, 'invalidMap');
-      expect(loaded, isNull);
+      expect(
+        () => adapter.loadMapData(box, 'invalidMap'),
+        throwsA(isA<FormatException>()),
+      );
     });
 
-    test('backward compatibility - greatPowerColorOverride missing yields null', () {
-      // Simulate legacy save where greatPowerColorOverride field is missing
-      final gameJson = {
-        'id': 'legacyGame',
-        'worldState': {
-          'turnState': {'phase': 'orders', 'turnNumber': 1},
-          'oldWorld': {'provinces': []},
-          'newWorld': {'provinces': []},
-        },
-        'players': [
-          {'id': 'pl1', 'displayName': 'Spain', 'isHuman': true},
-        ],
-        // Note: greatPowerColorOverride is intentionally missing
-      };
-      box.put('legacyGame', gameJson);
-      final loaded = adapter.load(box, 'legacyGame');
-      expect(loaded, isNotNull);
-      expect(loaded!.greatPowerColorOverride, isNull);
-    });
+    test(
+      'backward compatibility - greatPowerColorOverride missing yields null',
+      () {
+        // Simulate legacy save where greatPowerColorOverride field is missing
+        final gameJson = {
+          'id': 'legacyGame',
+          'worldState': {
+            'turnState': {'phase': 'orders', 'turnNumber': 1},
+            'oldWorld': {'provinces': []},
+            'newWorld': {'provinces': []},
+          },
+          'players': [
+            {'id': 'pl1', 'displayName': 'Spain', 'isHuman': true},
+          ],
+          // Note: greatPowerColorOverride is intentionally missing
+        };
+        box.put('legacyGame', gameJson);
+        final loaded = adapter.load(box, 'legacyGame');
+        expect(loaded, isNotNull);
+        expect(loaded!.greatPowerColorOverride, isNull);
+      },
+    );
 
     test('backward compatibility - turnTimeMapping missing yields null', () {
       // Simulate legacy save where turnTimeMapping field is missing


### PR DESCRIPTION
## Summary
Merges latest `origin/dev` into `build/app/android` so the Android release workflow includes **#1483** (*Require map topology for playable saves*) and stays aligned with dev.

## Why the extra commit
A plain merge did **not** remove bad Dart on the Android branch: `naval_units_panel.dart` had **duplicate** `didUpdateWidget` / `_openSplitDialog`, and `game_map_area.dart` referenced an undefined `closePanel` (current CI failure on `assembleRelease`). Those files are restored to match `dev` in commit `fix(android-sync): align naval_units_panel and game_map_area with dev`.

## Conflict strategy
Merge used `-X theirs` (`dev` wins on conflicts); the follow-up commit pins the two UI files to `dev` where auto-merge reintroduced broken code.

## Validation
`flutter analyze` on the two touched files reports no errors (only existing info-level lints).

Made with [Cursor](https://cursor.com)