### PR TITLE
Split Army: group regiments by type (like Split Fleet)

### DIFF
--- a/SPEC/ui/military-units-army-management.md
+++ b/SPEC/ui/military-units-army-management.md
@@ -23,7 +23,7 @@ Players reorganize **regiments** between **armies** in the same province, analog
 ## Split army
 
 - **Trigger:** Expanded army row shows **Split Army** (including Home Army).
-- **UX:** Reuse the same **transfer-list** pattern as naval split ([naval-units-fleet-management.md](naval-units-fleet-management.md) § Reusable Transfer Component): per-type or per-regiment counts as specified in TDD; confirm creates a **new** army in the **same** province with the chosen regiments.
+- **UX:** Reuse the same **transfer-list** pattern as naval split ([naval-units-fleet-management.md](naval-units-fleet-management.md) § Reusable Transfer Component): **one row per regiment type** with counts (like ship types in Split Fleet); confirm resolves types to concrete regiment unit ids in army list order and creates a **new** army in the **same** province with the chosen regiments.
 
 ---
 
@@ -34,6 +34,8 @@ Players reorganize **regiments** between **armies** in the same province, analog
 - Given **Home Army** and another army in the **same** province are both checked, when the user taps **Combine**, then the merge target is **Home Army** and the other army is removed after its regiments are appended.
 
 - Given one army in province `P` with at least two regiments, when the user completes **Split Army** with a non-empty subset, then the UI layer shows two armies in `P` reflecting the split without requiring a manual refresh.
+
+- Given an army with multiple regiments of the **same** type, when the user opens **Split Army**, then the transfer dialog shows **one row per type** with an aggregate count (not one row per regiment id), consistent with Split Fleet.
 
 - Given the user checks armies in **different** provinces, when the user views **Combine**, then **Combine** is disabled.
 

--- a/app/lib/features/game/widgets/split_army_dialog.dart
+++ b/app/lib/features/game/widgets/split_army_dialog.dart
@@ -35,9 +35,13 @@ class SplitArmyDialog extends StatelessWidget {
   }
 
   Map<String, int> _initialLeftCounts() {
-    return {
-      for (final id in army.regimentUnitIds) id: 1,
-    };
+    final counts = <String, int>{};
+    for (final id in army.regimentUnitIds) {
+      final u = _unit(id);
+      final bucket = regimentTransferBucketKey(u, id);
+      counts[bucket] = (counts[bucket] ?? 0) + 1;
+    }
+    return counts;
   }
 
   String _locationLabel() {
@@ -50,10 +54,11 @@ class SplitArmyDialog extends StatelessWidget {
   }
 
   void _handleConfirm(Map<String, int> right, BuildContext context) {
-    final toMove = <String>[
-      for (final e in right.entries)
-        if (e.value > 0) e.key,
-    ];
+    final toMove = regimentUnitIdsForTransferCounts(
+      army.regimentUnitIds,
+      _unit,
+      right,
+    );
     bus.emit(
       ArmySplitRequestedEvent(
         humanPlayerId: humanPlayerId,
@@ -76,10 +81,7 @@ class SplitArmyDialog extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Text(
-                'Split Army',
-                style: Theme.of(context).textTheme.titleLarge,
-              ),
+              Text('Split Army', style: Theme.of(context).textTheme.titleLarge),
               const SizedBox(height: 16),
               CtTransferList(
                 listHeight: 220,
@@ -88,19 +90,14 @@ class SplitArmyDialog extends StatelessWidget {
                 leftSubtitle: _locationLabel(),
                 rightSubtitle: _locationLabel(),
                 initialLeftCounts: _initialLeftCounts(),
-                itemLabelBuilder: (unitId) {
-                  final u = _unit(unitId);
-                  return u != null ? '${u.type} ($unitId)' : unitId;
-                },
+                itemLabelBuilder: (bucketKey) => bucketKey,
                 leftEmptyLabel: 'No regiments',
                 rightEmptyLabel: 'No regiments',
                 confirmLabel: 'Confirm Split',
                 totalLabelBuilder: (total) => 'Total: $total regiments',
                 canConfirm: (left, right) {
-                  final leftTotal =
-                      left.values.fold(0, (sum, c) => sum + c);
-                  final rightTotal =
-                      right.values.fold(0, (sum, c) => sum + c);
+                  final leftTotal = left.values.fold(0, (sum, c) => sum + c);
+                  final rightTotal = right.values.fold(0, (sum, c) => sum + c);
                   if (isHomeArmy) {
                     return rightTotal > 0;
                   }

--- a/app/test/split_army_dialog_test.dart
+++ b/app/test/split_army_dialog_test.dart
@@ -1,0 +1,245 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/features/game/widgets/split_army_dialog.dart';
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
+
+Widget _openDialogButton(VoidCallback onOpen) {
+  return TextButton(onPressed: onOpen, child: const Text('open'));
+}
+
+void main() {
+  suppressLogsForTests();
+
+  Game _gameWithArmy({required Army army, required List<Unit> units}) {
+    const province = Province(
+      id: 'cap',
+      regionId: 'oldWorld',
+      displayName: 'Lisbon',
+    );
+    return Game(
+      id: 'g1',
+      worldState: WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+        oldWorld: RegionData(provinces: const [province], units: units),
+        newWorld: const RegionData(),
+      ),
+      players: const [
+        Player(id: 'gp1', displayName: 'Human', isHuman: true, treasury: 0),
+      ],
+    );
+  }
+
+  Future<void> openDialog(
+    WidgetTester tester, {
+    required Army army,
+    required Game game,
+    required bool isHomeArmy,
+    required AppEventBus bus,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              return _openDialogButton(() {
+                showDialog<void>(
+                  context: context,
+                  builder: (ctx) => SplitArmyDialog(
+                    army: army,
+                    game: game,
+                    humanPlayerId: 'gp1',
+                    isHomeArmy: isHomeArmy,
+                    bus: bus,
+                  ),
+                );
+              });
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  List<Unit> _threeLevyOneMusk() => [
+    Unit(
+      id: 'levy_1',
+      type: 'peasant_levy',
+      ownerId: 'gp1',
+      locationProvinceId: 'oldWorld|cap',
+    ),
+    Unit(
+      id: 'levy_2',
+      type: 'peasant_levy',
+      ownerId: 'gp1',
+      locationProvinceId: 'oldWorld|cap',
+    ),
+    Unit(
+      id: 'levy_3',
+      type: 'peasant_levy',
+      ownerId: 'gp1',
+      locationProvinceId: 'oldWorld|cap',
+    ),
+    Unit(
+      id: 'mus_1',
+      type: 'musketeer',
+      ownerId: 'gp1',
+      locationProvinceId: 'oldWorld|cap',
+    ),
+  ];
+
+  testWidgets('same-type regiments show single row with aggregate count', (
+    WidgetTester tester,
+  ) async {
+    final army = Army(
+      id: 'army_1',
+      ownerId: 'gp1',
+      regionId: 'oldWorld',
+      stationedProvinceId: 'oldWorld|cap',
+      regimentUnitIds: const ['levy_1', 'levy_2', 'levy_3', 'mus_1'],
+    );
+    final game = _gameWithArmy(army: army, units: _threeLevyOneMusk());
+
+    await openDialog(
+      tester,
+      army: army,
+      game: game,
+      isHomeArmy: false,
+      bus: AppEventBus.create(),
+    );
+
+    expect(find.text('peasant_levy (3)'), findsOneWidget);
+    expect(find.text('musketeer (1)'), findsOneWidget);
+  });
+
+  testWidgets('moving one levy updates both columns', (
+    WidgetTester tester,
+  ) async {
+    final army = Army(
+      id: 'army_1',
+      ownerId: 'gp1',
+      regionId: 'oldWorld',
+      stationedProvinceId: 'oldWorld|cap',
+      regimentUnitIds: const ['levy_1', 'levy_2', 'levy_3', 'mus_1'],
+    );
+    final game = _gameWithArmy(army: army, units: _threeLevyOneMusk());
+
+    await openDialog(
+      tester,
+      army: army,
+      game: game,
+      isHomeArmy: false,
+      bus: AppEventBus.create(),
+    );
+
+    await tester.tap(
+      find.byKey(CtTransferListKeys.leftMoveOne('peasant_levy')),
+    );
+    await tester.pump();
+
+    expect(find.text('peasant_levy (2)'), findsOneWidget);
+    expect(find.text('peasant_levy (1)'), findsOneWidget);
+    expect(find.text('musketeer (1)'), findsOneWidget);
+  });
+
+  testWidgets('confirm emits first regiments in army order for moved counts', (
+    WidgetTester tester,
+  ) async {
+    ArmySplitRequestedEvent? captured;
+    final bus = AppEventBus.create();
+    final sub = bus.on<ArmySplitRequestedEvent>().listen((e) {
+      captured = e;
+    });
+    addTearDown(sub.cancel);
+
+    final army = Army(
+      id: 'army_1',
+      ownerId: 'gp1',
+      regionId: 'oldWorld',
+      stationedProvinceId: 'oldWorld|cap',
+      regimentUnitIds: const ['levy_1', 'levy_2', 'levy_3', 'mus_1'],
+    );
+    final game = _gameWithArmy(army: army, units: _threeLevyOneMusk());
+
+    await openDialog(
+      tester,
+      army: army,
+      game: game,
+      isHomeArmy: false,
+      bus: bus,
+    );
+
+    await tester.tap(
+      find.byKey(CtTransferListKeys.leftMoveOne('peasant_levy')),
+    );
+    await tester.pump();
+    await tester.tap(find.text('Confirm Split'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(captured, isNotNull);
+    expect(captured!.sourceArmyId, army.id);
+    expect(captured!.humanPlayerId, 'gp1');
+    expect(captured!.unitIdsToMove, ['levy_1']);
+  });
+
+  testWidgets('home army can confirm when original side is empty', (
+    WidgetTester tester,
+  ) async {
+    ArmySplitRequestedEvent? captured;
+    final bus = AppEventBus.create();
+    final sub = bus.on<ArmySplitRequestedEvent>().listen((e) {
+      captured = e;
+    });
+    addTearDown(sub.cancel);
+
+    final units = [
+      Unit(
+        id: 'only',
+        type: 'peasant_levy',
+        ownerId: 'gp1',
+        locationProvinceId: 'oldWorld|cap',
+      ),
+    ];
+    final army = Army(
+      id: 'home_army',
+      ownerId: 'gp1',
+      regionId: 'oldWorld',
+      stationedProvinceId: 'oldWorld|cap',
+      regimentUnitIds: const ['only'],
+      isHomeArmy: true,
+    );
+    final game = _gameWithArmy(army: army, units: units);
+
+    await openDialog(
+      tester,
+      army: army,
+      game: game,
+      isHomeArmy: true,
+      bus: bus,
+    );
+
+    await tester.tap(
+      find.byKey(CtTransferListKeys.leftMoveAll('peasant_levy')),
+    );
+    await tester.pump();
+
+    expect(find.text('No regiments'), findsOneWidget);
+    final button = tester.widget<CtNinePatchButton>(
+      find.widgetWithText(CtNinePatchButton, 'Confirm Split'),
+    );
+    expect(button.enabled, isTrue);
+
+    await tester.tap(find.text('Confirm Split'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(captured?.unitIdsToMove, ['only']);
+  });
+}

--- a/packages/colonizethis_models/lib/colonizethis_models.dart
+++ b/packages/colonizethis_models/lib/colonizethis_models.dart
@@ -19,6 +19,7 @@ export 'src/tile_map_state.dart';
 export 'src/province.dart';
 export 'src/province_id.dart';
 export 'src/quick_battle.dart';
+export 'src/regiment_transfer.dart';
 export 'src/region.dart';
 export 'src/region_data.dart';
 export 'src/worker_pool.dart';

--- a/packages/colonizethis_models/lib/src/regiment_transfer.dart
+++ b/packages/colonizethis_models/lib/src/regiment_transfer.dart
@@ -1,0 +1,34 @@
+import 'unit.dart';
+
+/// Bucket key for split-army transfer rows: [Unit.type] when known and non-empty,
+/// otherwise the unit id (missing unit data).
+String regimentTransferBucketKey(Unit? unit, String unitId) {
+  if (unit != null && unit.type.isNotEmpty) return unit.type;
+  return unitId;
+}
+
+/// Picks regiment unit ids in [regimentUnitIdsInOrder] for [countsByBucketToMove],
+/// taking the first matches per bucket (same order semantics as [shipInstancesForTransferCounts]).
+List<String> regimentUnitIdsForTransferCounts(
+  List<String> regimentUnitIdsInOrder,
+  Unit? Function(String unitId) tryUnit,
+  Map<String, int> countsByBucketToMove,
+) {
+  final need = <String, int>{
+    for (final e in countsByBucketToMove.entries)
+      if (e.value > 0) e.key: e.value,
+  };
+  if (need.isEmpty) return const [];
+
+  final out = <String>[];
+  for (final unitId in regimentUnitIdsInOrder) {
+    final u = tryUnit(unitId);
+    final bucket = regimentTransferBucketKey(u, unitId);
+    final left = need[bucket] ?? 0;
+    if (left > 0) {
+      out.add(unitId);
+      need[bucket] = left - 1;
+    }
+  }
+  return out;
+}

--- a/packages/colonizethis_models/test/regiment_transfer_test.dart
+++ b/packages/colonizethis_models/test/regiment_transfer_test.dart
@@ -1,0 +1,81 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+void main() {
+  group('regimentTransferBucketKey', () {
+    test('uses unit type when present', () {
+      final u = Unit(
+        id: 'r1',
+        type: 'peasant_levy',
+        ownerId: 'p1',
+        locationProvinceId: 'oldWorld|x',
+      );
+      expect(regimentTransferBucketKey(u, 'r1'), 'peasant_levy');
+    });
+
+    test('falls back to unit id when unit is null', () {
+      expect(regimentTransferBucketKey(null, 'ghost'), 'ghost');
+    });
+  });
+
+  group('regimentUnitIdsForTransferCounts', () {
+    final units = <Unit>[
+      Unit(
+        id: 'a',
+        type: 'peasant_levy',
+        ownerId: 'p1',
+        locationProvinceId: 'oldWorld|x',
+      ),
+      Unit(
+        id: 'b',
+        type: 'peasant_levy',
+        ownerId: 'p1',
+        locationProvinceId: 'oldWorld|x',
+      ),
+      Unit(
+        id: 'c',
+        type: 'peasant_levy',
+        ownerId: 'p1',
+        locationProvinceId: 'oldWorld|x',
+      ),
+      Unit(
+        id: 'd',
+        type: 'musketeer',
+        ownerId: 'p1',
+        locationProvinceId: 'oldWorld|x',
+      ),
+    ];
+    Unit? tryUnit(String id) {
+      for (final u in units) {
+        if (u.id == id) return u;
+      }
+      return null;
+    }
+
+    test('takes first N per type in regiment order', () {
+      const order = ['a', 'b', 'c', 'd'];
+      final moved = regimentUnitIdsForTransferCounts(order, tryUnit, {
+        'peasant_levy': 2,
+        'musketeer': 1,
+      });
+      expect(moved, ['a', 'b', 'd']);
+    });
+
+    test('returns empty when need map is empty or all zero', () {
+      expect(regimentUnitIdsForTransferCounts(['a'], tryUnit, {}), isEmpty);
+      expect(
+        regimentUnitIdsForTransferCounts(['a'], tryUnit, {'peasant_levy': 0}),
+        isEmpty,
+      );
+    });
+
+    test('unknown regiment id uses id as bucket', () {
+      final moved = regimentUnitIdsForTransferCounts(
+        ['a', 'missing', 'b'],
+        tryUnit,
+        {'peasant_levy': 1, 'missing': 1},
+      );
+      expect(moved, ['a', 'missing']);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements **Split Army** transfer grouping **by regiment type** (aggregate counts per row), matching **Split Fleet** behavior. Confirm resolves type counts to concrete regiment unit ids in **army list order** (same semantics as `shipInstancesForTransferCounts`).

## Related

Related to [#1496](https://github.com/waigore/colonizethisv3/issues/1496) (does not close).

## Changes

- **`colonizethis_models`:** `regimentTransferBucketKey`, `regimentUnitIdsForTransferCounts` in `lib/src/regiment_transfer.dart`; unit tests in `test/regiment_transfer_test.dart`.
- **App:** `SplitArmyDialog` builds `initialLeftCounts` by `Unit.type`; confirm uses the new helper.
- **SPEC:** `SPEC/ui/military-units-army-management.md` — split dialog one row per regiment type + AC bullet.
- **Tests:** `app/test/split_army_dialog_test.dart` — grouping, move-one, confirm payload, home army empty-left confirm. Uses bounded `pump` / short delays instead of `pumpAndSettle` after dialog open to avoid animation/timer flakes.

## How to verify

```bash
dart test packages/colonizethis_models/test/regiment_transfer_test.dart
flutter test app/test/split_army_dialog_test.dart
```
