### PR TITLE
Home Army: allow split when all regiments move; tests

### DIFF
--- a/app/test/military_units_panel_test.dart
+++ b/app/test/military_units_panel_test.dart
@@ -1379,12 +1379,12 @@ void main() {
         await tester.pump(const Duration(milliseconds: 100));
         await tester.pumpAndSettle();
 
-        expect(find.text('0 regiments · oldWorld|cap'), findsOneWidget);
-        expect(find.text('2 regiments · oldWorld|cap'), findsOneWidget);
+        expect(find.text('0 regiments · Capital'), findsOneWidget);
+        expect(find.text('2 regiments · Capital'), findsOneWidget);
 
         await tester.tap(find.text('Army army_1'));
         await tester.pumpAndSettle();
-        expect(find.text('musketeers: 2'), findsOneWidget);
+        expect(find.text('Musketeers: 2'), findsOneWidget);
       },
     );
 
@@ -1489,13 +1489,13 @@ void main() {
         await tester.pump(const Duration(milliseconds: 100));
         await tester.pumpAndSettle();
 
-        expect(find.text('1 regiments · oldWorld|cap'), findsNWidgets(2));
+        expect(find.text('1 regiments · Capital'), findsNWidgets(2));
 
-        expect(find.text('musketeers: 1'), findsOneWidget);
+        expect(find.text('Musketeers: 1'), findsOneWidget);
 
         await tester.tap(find.text('Army army_7'));
         await tester.pumpAndSettle();
-        expect(find.text('musketeers: 1'), findsNWidgets(2));
+        expect(find.text('Musketeers: 1'), findsNWidgets(2));
       },
     );
   });

--- a/app/test/military_units_panel_test.dart
+++ b/app/test/military_units_panel_test.dart
@@ -1303,6 +1303,9 @@ void main() {
         );
         await tester.pumpAndSettle();
         await tester.tap(find.text('Confirm Split'));
+        // Broadcast bus delivers listeners asynchronously; flush like split_army_dialog_test.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
         await tester.pumpAndSettle();
 
         expect(find.text('0 regiments · oldWorld|cap'), findsOneWidget);
@@ -1411,6 +1414,8 @@ void main() {
         );
         await tester.pumpAndSettle();
         await tester.tap(find.text('Confirm Split'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
         await tester.pumpAndSettle();
 
         expect(find.text('1 regiments · oldWorld|cap'), findsNWidgets(2));

--- a/app/test/military_units_panel_test.dart
+++ b/app/test/military_units_panel_test.dart
@@ -1,6 +1,9 @@
 // Tests for MilitaryUnitsPanel. SPEC/ui/military-units-panel.md.
 
+import 'dart:async';
+
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
@@ -10,8 +13,63 @@ import 'package:colonizethis_app/features/game/utils/map_location_resolver.dart'
 import 'package:colonizethis_app/features/game/widgets/move_army_dialog.dart';
 import 'package:colonizethis_app/features/game/widgets/military_units_panel.dart';
 import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/ct_panel.dart';
+import 'package:colonizethis_app/widgets/ct_transfer_list.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
+
+/// Applies [ArmySplitRequestedEvent] like [AppEventHandlerScope] and rebuilds
+/// the panel with updated [Game] (widget tests do not mount full shell).
+class _ArmySplitTestHarness extends StatefulWidget {
+  const _ArmySplitTestHarness({
+    required this.initialGame,
+    required this.humanPlayerId,
+    required this.bus,
+  });
+
+  final Game initialGame;
+  final String humanPlayerId;
+  final AppEventBus bus;
+
+  @override
+  State<_ArmySplitTestHarness> createState() => _ArmySplitTestHarnessState();
+}
+
+class _ArmySplitTestHarnessState extends State<_ArmySplitTestHarness> {
+  late Game _game;
+  StreamSubscription<ArmySplitRequestedEvent>? _sub;
+
+  @override
+  void initState() {
+    super.initState();
+    _game = widget.initialGame;
+    _sub = widget.bus.on<ArmySplitRequestedEvent>().listen((e) {
+      final next = applyArmySplit(
+        game: _game,
+        playerId: e.humanPlayerId,
+        sourceArmyId: e.sourceArmyId,
+        unitIdsToMove: e.unitIdsToMove,
+      );
+      setState(() => _game = next);
+    });
+  }
+
+  @override
+  void dispose() {
+    unawaited(_sub?.cancel());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MilitaryUnitsPanel(
+      game: _game,
+      humanPlayerId: widget.humanPlayerId,
+      bus: widget.bus,
+      topology: const MapTopology(),
+    );
+  }
+}
 
 Future<void> expandFirstArmyExpansion(WidgetTester tester) async {
   final tiles = find.byType(ExpansionTile);
@@ -1147,5 +1205,222 @@ void main() {
       expect(captured!.moveOrder.armyId, 'amove');
       expect(captured!.moveOrder.destinationProvinceId, newDest);
     });
+
+    testWidgets(
+      'split home army (all regiments): panel shows new army with regiment rows',
+      (WidgetTester tester) async {
+        const playerId = 'gp_split_ui_full';
+        const cap = 'oldWorld|cap';
+        final initial = Game(
+          id: 'g_split_full',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: [
+                Province(
+                  id: cap,
+                  regionId: 'oldWorld',
+                  ownerId: playerId,
+                  displayName: 'Capital',
+                  townTileKey: 'tk_cap',
+                ),
+              ],
+              units: [
+                Unit(
+                  id: 'r1',
+                  type: 'musketeers',
+                  ownerId: playerId,
+                  locationProvinceId: cap,
+                ),
+                Unit(
+                  id: 'r2',
+                  type: 'musketeers',
+                  ownerId: playerId,
+                  locationProvinceId: cap,
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            armies: [
+              Army(
+                id: 'home_army',
+                ownerId: playerId,
+                regionId: 'oldWorld',
+                stationedProvinceId: cap,
+                regimentUnitIds: const ['r1', 'r2'],
+                isHomeArmy: true,
+              ),
+            ],
+            nextArmySeq: 1,
+            tileKeysByRegionAndProvince: {
+              'oldWorld': {cap: ['tk_cap']},
+            },
+          ),
+          players: [
+            Player(
+              id: playerId,
+              displayName: 'Splitter',
+              isHuman: true,
+              capitalProvinceId: cap,
+            ),
+          ],
+        );
+
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                height: 900,
+                width: 480,
+                child: _ArmySplitTestHarness(
+                  initialGame: initial,
+                  humanPlayerId: playerId,
+                  bus: bus,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final homeTile = find.widgetWithText(ExpansionTile, 'Home Army');
+        await tester.tap(homeTile);
+        await tester.pumpAndSettle();
+
+        final splitBtn = find.descendant(
+          of: homeTile,
+          matching: find.widgetWithText(CtNinePatchButton, 'Split'),
+        );
+        await tester.ensureVisible(splitBtn);
+        await tester.tap(splitBtn);
+        await tester.pumpAndSettle();
+
+        await tester.tap(
+          find.byKey(CtTransferListKeys.leftMoveAll('musketeers')),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Confirm Split'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('0 regiments · oldWorld|cap'), findsOneWidget);
+        expect(find.text('2 regiments · oldWorld|cap'), findsOneWidget);
+
+        await tester.tap(find.text('Army army_1'));
+        await tester.pumpAndSettle();
+        expect(find.text('musketeers: 2'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'split home army (partial): panel shows correct counts on both armies',
+      (WidgetTester tester) async {
+        const playerId = 'gp_split_ui_partial';
+        const cap = 'oldWorld|cap';
+        final initial = Game(
+          id: 'g_split_partial',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: [
+                Province(
+                  id: cap,
+                  regionId: 'oldWorld',
+                  ownerId: playerId,
+                  displayName: 'Capital',
+                  townTileKey: 'tk_cap',
+                ),
+              ],
+              units: [
+                Unit(
+                  id: 'r1',
+                  type: 'musketeers',
+                  ownerId: playerId,
+                  locationProvinceId: cap,
+                ),
+                Unit(
+                  id: 'r2',
+                  type: 'musketeers',
+                  ownerId: playerId,
+                  locationProvinceId: cap,
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            armies: [
+              Army(
+                id: 'home_army',
+                ownerId: playerId,
+                regionId: 'oldWorld',
+                stationedProvinceId: cap,
+                regimentUnitIds: const ['r1', 'r2'],
+                isHomeArmy: true,
+              ),
+            ],
+            nextArmySeq: 7,
+            tileKeysByRegionAndProvince: {
+              'oldWorld': {cap: ['tk_cap']},
+            },
+          ),
+          players: [
+            Player(
+              id: playerId,
+              displayName: 'Splitter',
+              isHuman: true,
+              capitalProvinceId: cap,
+            ),
+          ],
+        );
+
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                height: 900,
+                width: 480,
+                child: _ArmySplitTestHarness(
+                  initialGame: initial,
+                  humanPlayerId: playerId,
+                  bus: bus,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final homeTile = find.widgetWithText(ExpansionTile, 'Home Army');
+        await tester.tap(homeTile);
+        await tester.pumpAndSettle();
+
+        final splitBtn = find.descendant(
+          of: homeTile,
+          matching: find.widgetWithText(CtNinePatchButton, 'Split'),
+        );
+        await tester.ensureVisible(splitBtn);
+        await tester.tap(splitBtn);
+        await tester.pumpAndSettle();
+
+        await tester.tap(
+          find.byKey(CtTransferListKeys.leftMoveOne('musketeers')),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Confirm Split'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('1 regiments · oldWorld|cap'), findsNWidgets(2));
+
+        expect(find.text('musketeers: 1'), findsOneWidget);
+
+        await tester.tap(find.text('Army army_7'));
+        await tester.pumpAndSettle();
+        expect(find.text('musketeers: 1'), findsNWidgets(2));
+      },
+    );
   });
 }

--- a/packages/colonizethis_logic/lib/src/world/army_commands.dart
+++ b/packages/colonizethis_logic/lib/src/world/army_commands.dart
@@ -66,7 +66,11 @@ Game applyArmySplit({
   }
   final moveSet = unitIdsToMove.toSet();
   if (!moveSet.every(source.regimentUnitIds.contains)) return game;
-  if (moveSet.length >= source.regimentUnitIds.length) return game;
+  // Empty non-Home source armies are not created: reject moving every regiment.
+  // Home Army may be left with zero regiments per SPEC/game/military-armies.md.
+  if (moveSet.length >= source.regimentUnitIds.length && !source.isHomeArmy) {
+    return game;
+  }
 
   final remaining =
       source.regimentUnitIds.where((id) => !moveSet.contains(id)).toList();

--- a/packages/colonizethis_logic/test/army_integration_test.dart
+++ b/packages/colonizethis_logic/test/army_integration_test.dart
@@ -276,6 +276,97 @@ void main() {
       expect(spun.regimentUnitIds, ['u2']);
       expect(spun.stationedProvinceId, p);
     });
+
+    test('split from home army moves all regiments to new army', () {
+      const p = 'oldWorld|p1';
+      const playerId = 'gp1';
+      var game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+          armies: [
+            Army(
+              id: 'home_army',
+              ownerId: playerId,
+              regionId: 'oldWorld',
+              stationedProvinceId: p,
+              regimentUnitIds: const ['u1', 'u2'],
+              isHomeArmy: true,
+            ),
+          ],
+          nextArmySeq: 5,
+        ),
+        players: [
+          Player(
+            id: playerId,
+            displayName: 'P',
+            capitalProvinceId: p,
+            isHuman: true,
+          ),
+        ],
+      );
+
+      game = applyArmySplit(
+        game: game,
+        playerId: playerId,
+        sourceArmyId: 'home_army',
+        unitIdsToMove: const ['u1', 'u2'],
+      );
+
+      expect(game.worldState.armies.length, 2);
+      final home =
+          game.worldState.armies.where((a) => a.isHomeArmy).single;
+      final spun =
+          game.worldState.armies.where((a) => !a.isHomeArmy).single;
+      expect(home.regimentUnitIds, isEmpty);
+      expect(spun.regimentUnitIds, ['u1', 'u2']);
+      expect(spun.id, 'army_5');
+      expect(spun.stationedProvinceId, p);
+    });
+
+    test('split non-home with all regiments leaves state unchanged', () {
+      const p = 'oldWorld|p1';
+      const playerId = 'gp1';
+      var game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+          armies: [
+            Army(
+              id: 'src',
+              ownerId: playerId,
+              regionId: 'oldWorld',
+              stationedProvinceId: p,
+              regimentUnitIds: const ['u1', 'u2'],
+              isHomeArmy: false,
+            ),
+          ],
+          nextArmySeq: 5,
+        ),
+        players: [
+          Player(
+            id: playerId,
+            displayName: 'P',
+            capitalProvinceId: p,
+            isHuman: true,
+          ),
+        ],
+      );
+
+      game = applyArmySplit(
+        game: game,
+        playerId: playerId,
+        sourceArmyId: 'src',
+        unitIdsToMove: const ['u1', 'u2'],
+      );
+
+      expect(game.worldState.armies.length, 1);
+      expect(game.worldState.armies.single.regimentUnitIds, ['u1', 'u2']);
+    });
   });
 
   group('ensureMilitaryArmiesForGame', () {


### PR DESCRIPTION
## Summary

- **`applyArmySplit`:** When the source is the **Home Army**, moving **all** regiments to a new army is now allowed. The Home Army may end with zero regiments, consistent with `SPEC/game/military-armies.md`. **Non-Home** armies still reject a split that would move every regiment (avoids an empty non-Home army without a separate product rule).
- **Tests:** Integration tests in `colonizethis_logic` for home vs non-home “move all” behavior. **Military Units** widget tests use `_ArmySplitTestHarness` to apply `ArmySplitRequestedEvent` like the shell and assert subtitles plus expanded **regiment type rows** (`musketeers: N`) after split.

## Verification

- `cd app && flutter test test/military_units_panel_test.dart`
- `cd packages/colonizethis_logic && dart test test/army_integration_test.dart` (or run the `applyArmyCombine and applyArmySplit` group)

Ref #1499
