### PR TITLE
Naval move fleet: topology picks (S/S/P), dialog title, draft destination in panel

### DIFF
--- a/SPEC/ui/naval-units-panel.md
+++ b/SPEC/ui/naval-units-panel.md
@@ -23,9 +23,11 @@ For every **sea‑going** fleet (any fleet that is **not** the Home Fleet), the 
 
 **Dialog (local `showDialog`, commit via bus):** Opening **Move** shows a modal where the player:
 
-1. Sees two sections (**Sea zones** first, then **Provinces**), each a **sorted** list of **legal** destinations from the fleet’s **current** location per [ships-and-naval.md](../game/ships-and-naval.md) and [naval-movement-resolution.md](../program/naval-movement-resolution.md):
-   - **At sea:** all **adjacent** sea zones (including **warp** / cross‑region links); then all **owned** provinces the fleet may **dock** at from its current sea zone (topology P↔S). Destinations in a **different** region than the fleet’s current sea zone must be labeled so the player sees **cross‑region** (e.g. include the destination region label in the row text).
-   - **In port:** only **adjacent** sea zones for **undock**; the **Provinces** section is **empty** (no port‑to‑port moves).
+**Title:** **Fleet \<id\>** (or equivalent) and, when there is at least one destination, **(N destinations)** so numeric ids are not mistaken for option counts.
+
+1. Sees two sections (**Sea zones** first, then **Provinces**), each a **sorted** list of **legal** destinations from the fleet’s **current** location per [ships-and-naval.md](../game/ships-and-naval.md) and [naval-movement-resolution.md](../program/naval-movement-resolution.md). One-hop naval moves use topology only: **S→S** (sea to adjacent sea), **S→P** (dock at adjacent owned port), **P→S** (undock to adjacent sea). **No P→P** and no multi-hop in a single order; every offered destination shares an edge with the fleet’s current sea node or port node.
+   - **At sea:** **Sea zones** lists only **S–S** neighbors of the fleet’s current sea zone (including **warp** / cross‑region links where the graph has an S–S edge). **Provinces (dock)** lists only **owned** provinces with a direct **S–P** edge from that sea zone. Destinations in a **different** region than the fleet’s current sea zone must be labeled so the player sees **cross‑region** (e.g. include the destination region label in the row text).
+   - **In port:** **Sea zones** lists only seas with a direct **P–S** edge from the fleet’s port; the **Provinces** section is **empty** (no port‑to‑port moves).
 2. **Selects** one row (radio or single selection), then taps **Confirm** to submit (or **Cancel** to close without changing orders).
 3. May tap a **locate** control beside each destination row to emit **`LocateMapTileEvent`** (same family as fleet locate): province → town/first tile; sea zone → port tile adjacent to that zone per [map-widget.md](map-widget.md) / [map_location_resolver](military/naval panel contract).
 
@@ -88,7 +90,7 @@ For every fleet (including the Home Fleet), the collapsed row shows:
 |-------------------|------------------------------------------|-------|
 | **Fleet name**    | Fleet id or display name                | For Home Fleet, label is “Home Fleet”. For other fleets, use a human-readable label (e.g. “Fleet #3”, “Atlantic Squadron” if available; otherwise a stable fallback). |
 | **Location**      | `inPortAtProvinceId` or `seaZoneId`     | Display as `Region — Province` for in-port fleets (province display name) or `Region — Sea zone` for at-sea fleets. Region label uses same mapping as Military Units panel. |
-| **Mission**       | `Fleet.mission`                         | Enum mapped to user labels: None, Patrol, Blockade, Beachhead, Defend. For Home Fleet, always shown as “None”. |
+| **Mission**       | `Fleet.mission`                         | Enum mapped to user labels: None, Patrol, Blockade, Beachhead, Defend. For Home Fleet, always shown as “None”. When the shell’s draft **`Orders`** contains a **naval move** for this fleet, show **Moving to:** \<display name of destination sea zone or dock province\> (dock targets may suffix **(dock)** in UI copy). |
 | **Ships summary** | Fleet ship list and naval catalog       | Summary text such as `Total ships: N` and a short breakdown, e.g. `2 warships · 3 merchants` based on ship types' merchant/warship role per [ships-and-naval.md](../game/ships-and-naval.md) (§ Ship Types). |
 
 The entire collapsed row is clickable to select/locate the fleet and to toggle expansion.

--- a/app/lib/core/services/app_event_handler.dart
+++ b/app/lib/core/services/app_event_handler.dart
@@ -297,11 +297,13 @@ class AppEventHandler {
           final humanPlayerId = _humanPlayerId(game);
           final bus = ref.watch(appEventBusProvider);
           final mapData = ref.watch(gameServiceProvider).getMapData(game.id);
+          final draftOrders = ref.watch(currentOrdersProvider);
           return NavalUnitsPanel(
             game: game,
             humanPlayerId: humanPlayerId,
             bus: bus,
             topology: mapData?.combinedTopology ?? const MapTopology(),
+            draftOrders: draftOrders,
           );
         },
       ),

--- a/app/lib/features/game/widgets/move_fleet_dialog.dart
+++ b/app/lib/features/game/widgets/move_fleet_dialog.dart
@@ -55,9 +55,9 @@ final class _PickPort extends _MovePick {
 
   @override
   NavalMoveOrder toOrder(String fleetId) => NavalMoveOrder(
-        fleetId: fleetId,
-        destinationPortProvinceId: fullProvinceId,
-      );
+    fleetId: fleetId,
+    destinationPortProvinceId: fullProvinceId,
+  );
 
   @override
   void emitLocate(AppEventBus bus, Game game) {
@@ -69,6 +69,16 @@ final class _PickPort extends _MovePick {
   }
 }
 
+String _fleetMoveDialogTitleLabel(Fleet fleet) => 'Fleet ${fleet.id}';
+
+String _fullProvinceIdForTopologyProvince(
+  String topologyProvinceId,
+  String regionId,
+) {
+  if (ProvinceId.isPrefixed(topologyProvinceId)) return topologyProvinceId;
+  return ProvinceId.full(regionId, topologyProvinceId);
+}
+
 List<_MovePick> _buildNavalMovePicks({
   required Game game,
   required MapTopology topology,
@@ -78,34 +88,14 @@ List<_MovePick> _buildNavalMovePicks({
   final outSea = <_PickSeaZone>[];
   final outPort = <_PickPort>[];
 
-  final String? currentSeaZoneId;
-  if (fleet.isAtSea) {
-    currentSeaZoneId = fleet.seaZoneId;
-  } else {
-    final inPort = fleet.inPortAtProvinceId;
-    if (inPort == null) return const [];
-    final rl = regionAndLocalProvinceForFleetInPort(inPort, fleet.regionId);
-    currentSeaZoneId = seaZoneIdForProvince(
-      topology,
-      rl.localId,
-      regionId: rl.regionId,
-    );
-  }
-  if (currentSeaZoneId == null || currentSeaZoneId.isEmpty) return const [];
+  final topo = navalMoveTopologyPicksForFleet(topology: topology, fleet: fleet);
+  if (topo.totalCount == 0) return const [];
 
-  final fleetSeaRegion =
-      regionIdForSeaZone(topology, currentSeaZoneId) ?? fleet.regionId;
+  final fleetSeaRegion = fleet.isAtSea && fleet.seaZoneId != null
+      ? regionIdForSeaZone(topology, fleet.seaZoneId!) ?? fleet.regionId
+      : fleet.regionId;
 
-  final adjZones = <String>{};
-  for (final e in topology.edges) {
-    if (e.id1 == currentSeaZoneId) {
-      adjZones.add(e.id2);
-    } else if (e.id2 == currentSeaZoneId) {
-      adjZones.add(e.id1);
-    }
-  }
-  final sortedZones = adjZones.toList()..sort();
-  for (final z in sortedZones) {
+  for (final z in topo.adjacentSeaZoneIds) {
     final zReg = regionIdForSeaZone(topology, z) ?? fleetSeaRegion;
     final regLabel = unitsPanelRegionLabel(zReg);
     final cross = zReg != fleetSeaRegion;
@@ -123,14 +113,9 @@ List<_MovePick> _buildNavalMovePicks({
 
   if (fleet.isAtSea && fleet.seaZoneId != null) {
     final rz = regionIdForSeaZone(topology, fleet.seaZoneId!) ?? fleet.regionId;
-    final localProvinces = provinceIdsAdjacentToSeaZone(
-      topology,
-      fleet.seaZoneId!,
-      regionId: rz,
-    );
     final portRows = <({String fullId, String label})>[];
-    for (final lp in localProvinces) {
-      final full = ProvinceId.full(rz, lp);
+    for (final lp in topo.adjacentProvinceIdsForDock) {
+      final full = _fullProvinceIdForTopologyProvince(lp, rz);
       final province = tryGetProvince(game.worldState, full);
       if (province == null || province.ownerId != humanPlayerId) continue;
       final name = province.displayName ?? province.id;
@@ -193,9 +178,13 @@ class _MoveFleetDialogState extends State<MoveFleetDialog> {
     final picks = _picks;
     final seaPicks = picks.whereType<_PickSeaZone>().toList();
     final portPicks = picks.whereType<_PickPort>().toList();
+    final fleetLabel = _fleetMoveDialogTitleLabel(widget.fleet);
+    final titleText = picks.isEmpty
+        ? 'Move fleet — $fleetLabel'
+        : 'Move fleet — $fleetLabel (${picks.length} destinations)';
 
     return AlertDialog(
-      title: Text('Move fleet — ${widget.fleet.id}'),
+      title: Text(titleText),
       content: SizedBox(
         width: 420,
         child: picks.isEmpty

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -1,7 +1,8 @@
 // Naval units panel. SPEC/ui/naval-units-panel.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart' show homeFleetIdFor;
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show homeFleetIdFor, regionIdForSeaZone, tryGetProvince;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
@@ -14,6 +15,37 @@ import 'units/shared/location_section_header.dart';
 import 'units/shared/region_section_header.dart';
 import 'units/shared/units_panel_region_label.dart';
 import 'units/shared/units_panel_shell.dart';
+
+String? navalDraftMoveLineForFleet({
+  required Game game,
+  required MapTopology topology,
+  required String humanPlayerId,
+  required String fleetRegionId,
+  required String fleetId,
+  required Orders draftOrders,
+}) {
+  final moves =
+      draftOrders.navalMoveOrdersByPlayerId[humanPlayerId] ?? const [];
+  for (final o in moves) {
+    if (o.fleetId != fleetId) continue;
+    if (o.isDock) {
+      final pid = o.destinationPortProvinceId!;
+      final p = tryGetProvince(game.worldState, pid);
+      final name = p?.displayName ?? p?.id ?? pid;
+      return 'Moving to: $name (dock)';
+    }
+    final z = o.destinationSeaZoneId!;
+    final zReg = regionIdForSeaZone(topology, z) ?? fleetRegionId;
+    final zoneKey = z.contains('|') ? z : '$zReg|$z';
+    final label = seaZoneDisplayName(
+      game: game,
+      regionId: zReg,
+      seaZoneId: zoneKey,
+    );
+    return 'Moving to: $label';
+  }
+  return null;
+}
 
 String _missionLabel(FleetMission m) {
   switch (m) {
@@ -49,6 +81,7 @@ class _FleetRow {
     required this.locationKey,
     this.inPortAtProvinceId,
     this.seaZoneId,
+    this.draftNavalMoveLine,
   });
 
   final String fleetId;
@@ -68,6 +101,7 @@ class _FleetRow {
   final String locationKey;
   final String? inPortAtProvinceId;
   final String? seaZoneId;
+  final String? draftNavalMoveLine;
 }
 
 abstract class _FleetLocationNode {
@@ -135,7 +169,12 @@ List<_FleetRow> _flattenTree(
 List<
   ({String regionId, _FleetRow? homeFleet, List<_FleetLocationNode> locations})
 >
-_buildNavalTree(Game game, String humanPlayerId) {
+_buildNavalTree(
+  Game game,
+  String humanPlayerId,
+  MapTopology topology,
+  Orders draftOrders,
+) {
   final player = game.players.firstWhere(
     (p) => p.id == humanPlayerId,
     orElse: () => game.players.first,
@@ -277,6 +316,14 @@ _buildNavalTree(Game game, String humanPlayerId) {
           isAtSea: true,
           locationKey: locationKey,
           seaZoneId: zoneKey,
+          draftNavalMoveLine: navalDraftMoveLineForFleet(
+            game: game,
+            topology: topology,
+            humanPlayerId: humanPlayerId,
+            fleetRegionId: regionId,
+            fleetId: fleet.id,
+            draftOrders: draftOrders,
+          ),
         );
         seas.putIfAbsent(zoneKey, () => []).add(row);
       } else if (inPortId != null) {
@@ -305,6 +352,16 @@ _buildNavalTree(Game game, String humanPlayerId) {
           isAtSea: false,
           locationKey: locationKey,
           inPortAtProvinceId: inPortId,
+          draftNavalMoveLine: isHomeFleet
+              ? null
+              : navalDraftMoveLineForFleet(
+                  game: game,
+                  topology: topology,
+                  humanPlayerId: humanPlayerId,
+                  fleetRegionId: regionId,
+                  fleetId: fleet.id,
+                  draftOrders: draftOrders,
+                ),
         );
         if (isHomeFleet) {
           homeFleetRow = row;
@@ -343,6 +400,7 @@ _buildNavalTree(Game game, String humanPlayerId) {
           isAtSea: false,
           locationKey: 'port:${province.regionId}|${province.id}',
           inPortAtProvinceId: '$capitalRegionId|$capitalProvinceLocalId',
+          draftNavalMoveLine: null,
         );
       }
     }
@@ -395,12 +453,14 @@ class NavalUnitsPanel extends StatefulWidget {
     required this.humanPlayerId,
     required this.bus,
     required this.topology,
+    this.draftOrders = const Orders(),
   });
 
   final Game game;
   final String humanPlayerId;
   final AppEventBus bus;
   final MapTopology topology;
+  final Orders draftOrders;
 
   @override
   State<NavalUnitsPanel> createState() => _NavalUnitsPanelState();
@@ -559,9 +619,15 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
   @override
   void didUpdateWidget(covariant NavalUnitsPanel oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.game != widget.game) {
+    if (oldWidget.game != widget.game ||
+        oldWidget.draftOrders != widget.draftOrders) {
       final flat = _flattenTree(
-        _buildNavalTree(widget.game, widget.humanPlayerId),
+        _buildNavalTree(
+          widget.game,
+          widget.humanPlayerId,
+          widget.topology,
+          widget.draftOrders,
+        ),
       );
       final valid = flat.map(_selectionFleetId).toSet();
       final pruned = _selectedFleetIds.intersection(valid);
@@ -627,7 +693,12 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
 
   @override
   Widget build(BuildContext context) {
-    final tree = _buildNavalTree(widget.game, widget.humanPlayerId);
+    final tree = _buildNavalTree(
+      widget.game,
+      widget.humanPlayerId,
+      widget.topology,
+      widget.draftOrders,
+    );
     final flat = _flattenTree(tree);
     final hasAny = tree.any(
       (group) => group.homeFleet != null || group.locations.isNotEmpty,
@@ -777,7 +848,8 @@ class _FleetExpansionTile extends StatelessWidget {
           ],
         ),
         subtitle: Text(
-          '${row.locationLabel}\nMission: ${row.missionLabel} · ${_summary()}',
+          '${row.locationLabel}\nMission: ${row.missionLabel} · ${_summary()}'
+          '${row.draftNavalMoveLine != null ? '\n${row.draftNavalMoveLine}' : ''}',
         ),
         dense: true,
         children: [

--- a/app/test/move_fleet_dialog_test.dart
+++ b/app/test/move_fleet_dialog_test.dart
@@ -135,6 +135,10 @@ void main() {
   ) async {
     await openDialog(tester, bus: AppEventBus.create());
 
+    expect(
+      find.textContaining('Move fleet — Fleet f_move (2 destinations)'),
+      findsOneWidget,
+    );
     expect(find.text('Sea zones'), findsOneWidget);
     expect(find.text('Adjacent OW Sea · Old World'), findsOneWidget);
     expect(
@@ -239,6 +243,7 @@ void main() {
         ],
         edges: [
           TopologyEdge(id1: fullCap, id2: '$ow|sea1'),
+          TopologyEdge(id1: fullCap, id2: '$ow|sea2'),
           TopologyEdge(id1: '$ow|sea1', id2: '$ow|sea2'),
         ],
       );
@@ -323,4 +328,119 @@ void main() {
       expect(find.text('Second Sea · Old World'), findsOneWidget);
     },
   );
+
+  testWidgets('sea zone section lists S–S neighbors only, not provinces', (
+    WidgetTester tester,
+  ) async {
+    const humanId = 'gp_mix';
+    const seaA = 'sea_a';
+    const seaB = 'sea_b';
+    const coastProv = 'coast_p';
+    final game = Game(
+      id: 'g_mix',
+      worldState: WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: RegionData(
+          provinces: [
+            Province(
+              id: 'oldWorld|inland_cap',
+              regionId: 'oldWorld',
+              ownerId: humanId,
+              displayName: 'Inland Capital',
+            ),
+            Province(
+              id: 'oldWorld|$coastProv',
+              regionId: 'oldWorld',
+              ownerId: humanId,
+              displayName: 'Coastal Province',
+            ),
+          ],
+        ),
+        newWorld: const RegionData(),
+        portsByProvinceSeaboard: const {},
+        seaZoneDisplayNameById: const {
+          'oldWorld|$seaA': 'Alpha Sea',
+          'oldWorld|$seaB': 'Beta Sea',
+        },
+      ),
+      players: const [
+        Player(
+          id: humanId,
+          displayName: 'T',
+          isHuman: true,
+          capitalProvinceId: 'oldWorld|inland_cap',
+          capitalTile: CapitalTile(
+            regionId: 'oldWorld',
+            provinceId: 'oldWorld|inland_cap',
+            x: 0,
+            y: 0,
+          ),
+        ),
+      ],
+    );
+    const topology = MapTopology(
+      nodes: [
+        TopologyNode(
+          id: seaA,
+          regionId: 'oldWorld',
+          type: TopologyNodeType.seaZone,
+        ),
+        TopologyNode(
+          id: seaB,
+          regionId: 'oldWorld',
+          type: TopologyNodeType.seaZone,
+        ),
+        TopologyNode(
+          id: coastProv,
+          regionId: 'oldWorld',
+          type: TopologyNodeType.province,
+        ),
+      ],
+      edges: [
+        TopologyEdge(id1: seaA, id2: coastProv),
+        TopologyEdge(id1: seaA, id2: seaB),
+      ],
+    );
+    final fleet = Fleet(
+      id: 'f_mix',
+      ownerId: humanId,
+      regionId: 'oldWorld',
+      seaZoneId: seaA,
+      ships: const [ShipInstance(id: 's1', typeId: 'carrack')],
+    );
+    final bus = AppEventBus.create();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              return TextButton(
+                onPressed: () {
+                  showDialog<void>(
+                    context: context,
+                    builder: (_) => MoveFleetDialog(
+                      game: game,
+                      topology: topology,
+                      humanPlayerId: humanId,
+                      fleet: fleet,
+                      bus: bus,
+                    ),
+                  );
+                },
+                child: const Text('open'),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Sea zones'), findsOneWidget);
+    expect(find.text('Provinces (dock)'), findsOneWidget);
+    expect(find.text('Coastal Province'), findsOneWidget);
+    expect(find.textContaining('Beta Sea'), findsOneWidget);
+    expect(find.textContaining('Alpha Sea'), findsNothing);
+  });
 }

--- a/app/test/naval_units_panel_test.dart
+++ b/app/test/naval_units_panel_test.dart
@@ -106,6 +106,7 @@ void main() {
     required String humanPlayerId,
     AppEventBus? bus,
     MapTopology topology = const MapTopology(),
+    Orders draftOrders = const Orders(),
   }) {
     final resolvedBus = bus ?? AppEventBus.create();
     return MaterialApp(
@@ -115,6 +116,7 @@ void main() {
           humanPlayerId: humanPlayerId,
           bus: resolvedBus,
           topology: topology,
+          draftOrders: draftOrders,
         ),
       ),
     );
@@ -2885,5 +2887,84 @@ void main() {
         expect(updated, isNull);
       },
     );
+  });
+
+  group('Draft naval move subtitle', () {
+    testWidgets('shows Moving to line when draft order present', (
+      WidgetTester tester,
+    ) async {
+      const ow = 'oldWorld';
+      const humanId = 'gp_draft_line';
+      const capProvince = '$ow|capital';
+      final draftGame = Game(
+        id: 'g_draft_line',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(
+                id: capProvince,
+                regionId: ow,
+                ownerId: humanId,
+                displayName: 'Capital',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          fleets: [
+            Fleet(
+              id: homeFleetIdFor(humanId),
+              ownerId: humanId,
+              regionId: ow,
+              inPortAtProvinceId: capProvince,
+              ships: const [],
+            ),
+            Fleet(
+              id: 'f_at_sea',
+              ownerId: humanId,
+              regionId: ow,
+              seaZoneId: 'sz0',
+              ships: const [ShipInstance(id: 's1', typeId: 'carrack')],
+            ),
+          ],
+          seaZoneDisplayNameById: const {'oldWorld|sz1': 'Target Sea'},
+        ),
+        players: [
+          Player(
+            id: humanId,
+            displayName: 'P',
+            isHuman: true,
+            capitalProvinceId: capProvince,
+            capitalTile: CapitalTile(
+              regionId: ow,
+              provinceId: capProvince,
+              x: 0,
+              y: 0,
+            ),
+          ),
+        ],
+      );
+      final orders = Orders(
+        navalMoveOrdersByPlayerId: {
+          humanId: [
+            const NavalMoveOrder(
+              fleetId: 'f_at_sea',
+              destinationSeaZoneId: 'sz1',
+            ),
+          ],
+        },
+      );
+
+      await tester.pumpWidget(
+        buildPanel(
+          game: draftGame,
+          humanPlayerId: humanId,
+          draftOrders: orders,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.textContaining('Moving to: Target Sea'), findsOneWidget);
+    });
   });
 }

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -7,6 +7,7 @@ import '../diplomacy/diplomacy_resolver.dart';
 import '../world/movement.dart';
 import '../world/naval.dart';
 import '../world/province_lookup.dart';
+import '../world/topology_helpers.dart';
 import 'build_rail_work_rules.dart';
 import 'draft_orders_mutations.dart';
 import 'order_engine.dart';
@@ -28,9 +29,7 @@ List<MoveOrder> suggestMoveOrders(
   MapTopology topology,
   Orders currentOrders,
 ) {
-  _log.d(
-    'suggestMoveOrders player=${view.playerId}',
-  );
+  _log.d('suggestMoveOrders player=${view.playerId}');
   final playerId = view.playerId;
   final suggestions = <MoveOrder>[];
 
@@ -138,16 +137,12 @@ List<MoveOrder> suggestMoveOrders(
     return a.destinationProvinceId.compareTo(b.destinationProvinceId);
   });
 
-  _log.d(
-    'suggestMoveOrders player=$playerId candidates=${suggestions.length}',
-  );
+  _log.d('suggestMoveOrders player=$playerId candidates=${suggestions.length}');
   _log.d(
     'suggestMoveOrders full list ${suggestions.map((m) => "${m.unitId}->${m.destinationProvinceId}").toList()}',
   );
   if (suggestions.isEmpty)
-    _log.w(
-      'suggestMoveOrders no candidates player=$playerId',
-    );
+    _log.w('suggestMoveOrders no candidates player=$playerId');
   return suggestions;
 }
 
@@ -255,9 +250,7 @@ List<WorkOrder> suggestWorkOrders(
   Orders currentOrders, {
   Map<String, TileMapResult>? tileMapByRegion,
 }) {
-  _log.d(
-    'suggestWorkOrders player=${view.playerId}',
-  );
+  _log.d('suggestWorkOrders player=${view.playerId}');
   final playerId = view.playerId;
   final suggestions = <WorkOrder>[];
 
@@ -430,9 +423,7 @@ List<WorkOrder> suggestWorkOrders(
             }
           }
           if (accepted != null) {
-            _log.d(
-              'suggestWorkOrders candidate=$accepted',
-            );
+            _log.d('suggestWorkOrders candidate=$accepted');
             suggestions.add(accepted);
           } else {
             _log.d(
@@ -536,16 +527,12 @@ List<WorkOrder> suggestWorkOrders(
     return a.targetTileKey.compareTo(b.targetTileKey);
   });
 
-  _log.d(
-    'suggestWorkOrders player=$playerId candidates=${suggestions.length}',
-  );
+  _log.d('suggestWorkOrders player=$playerId candidates=${suggestions.length}');
   _log.d(
     'suggestWorkOrders full list ${suggestions.map((o) => "${o.unitId}:${o.target}").toList()}',
   );
   if (suggestions.isEmpty)
-    _log.w(
-      'suggestWorkOrders no candidates player=$playerId',
-    );
+    _log.w('suggestWorkOrders no candidates player=$playerId');
   return suggestions;
 }
 
@@ -556,18 +543,14 @@ List<BuildUnitOrder> suggestBuildOrders(
   MapTopology topology,
   Orders currentOrders,
 ) {
-  _log.d(
-    'suggestBuildOrders player=${view.playerId}',
-  );
+  _log.d('suggestBuildOrders player=${view.playerId}');
   final playerId = view.playerId;
   final player = view.player;
   final suggestions = <BuildUnitOrder>[];
 
   final capitalId = player.capitalProvinceId;
   if (capitalId == null) {
-    _log.w(
-      'suggestBuildOrders no capital player=$playerId',
-    );
+    _log.w('suggestBuildOrders no capital player=$playerId');
     return suggestions;
   }
 
@@ -621,9 +604,7 @@ List<BuildUnitOrder> suggestBuildOrders(
     'suggestBuildOrders full list ${suggestions.map((o) => o.unitType).toList()}',
   );
   if (suggestions.isEmpty)
-    _log.w(
-      'suggestBuildOrders no candidates player=$playerId',
-    );
+    _log.w('suggestBuildOrders no candidates player=$playerId');
   return suggestions;
 }
 
@@ -636,9 +617,7 @@ List<ResearchOrder> suggestResearchOrders(
   MapTopology topology,
   Orders currentOrders,
 ) {
-  _log.d(
-    'suggestResearchOrders player=${view.playerId}',
-  );
+  _log.d('suggestResearchOrders player=${view.playerId}');
   final playerId = view.playerId;
   final player = view.player;
   final suggestions = <ResearchOrder>[];
@@ -834,9 +813,7 @@ Set<String> getValidWorkOrderTileKeysWithVisibility({
     return {};
   }
   if (unit.currentWork != null) {
-    _log.d(
-      'getValidWorkOrderTileKeysWithVisibility unit has current work',
-    );
+    _log.d('getValidWorkOrderTileKeysWithVisibility unit has current work');
     return {};
   }
   if (!isWorkOrderTargetAllowedForUnitType(unit.type, workTarget)) {
@@ -1328,9 +1305,7 @@ List<NavalMoveOrder> suggestNavalMoveOrders(
   MapTopology topology,
   Orders currentOrders,
 ) {
-  _log.d(
-    'suggestNavalMoveOrders player=${view.playerId}',
-  );
+  _log.d('suggestNavalMoveOrders player=${view.playerId}');
   final playerId = view.playerId;
   final suggestions = <NavalMoveOrder>[];
   final existingByFleet = <String, Set<String>>{};
@@ -1347,56 +1322,45 @@ List<NavalMoveOrder> suggestNavalMoveOrders(
   final homeFleetId = homeFleetIdFor(playerId);
   for (final fleet in game.worldState.fleets) {
     if (fleet.ownerId != playerId || fleet.id == homeFleetId) continue;
-    final String? currentZone;
     if (fleet.isAtSea) {
-      currentZone = fleet.seaZoneId;
-    } else {
-      final inPortProvinceId = fleet.inPortAtProvinceId;
-      if (inPortProvinceId == null) continue;
-      final rl = regionAndLocalProvinceForFleetInPort(
-        inPortProvinceId,
-        fleet.regionId,
-      );
-      currentZone = seaZoneIdForProvince(
-        topology,
-        rl.localId,
-        regionId: rl.regionId,
-      );
-    }
-    if (currentZone == null) continue;
+      final cur = fleet.seaZoneId;
+      if (cur == null) continue;
 
-    // Suggest move to adjacent sea zones.
-    for (final node in topology.nodes) {
-      if (node.type != TopologyNodeType.seaZone) continue;
-      final destId = node.id;
-      if (!isAdjacentSeaZone(topology, currentZone, destId)) continue;
-      if (existingByFleet[fleet.id]?.contains(destId) ?? false) continue;
-      final candidate = NavalMoveOrder(
-        fleetId: fleet.id,
-        destinationSeaZoneId: destId,
-      );
-      if (_isNavalMoveOrderAccepted(
-        game,
-        topology,
-        playerId,
-        currentOrders,
-        candidate,
-      )) {
-        suggestions.add(candidate);
+      // Suggest S–S moves only (direct sea-zone edges).
+      for (final node in topology.nodes) {
+        if (node.type != TopologyNodeType.seaZone) continue;
+        final destId = node.id;
+        if (cur != destId && !isAdjacentSeaSeaZone(topology, cur, destId)) {
+          continue;
+        }
+        if (existingByFleet[fleet.id]?.contains(destId) ?? false) continue;
+        final candidate = NavalMoveOrder(
+          fleetId: fleet.id,
+          destinationSeaZoneId: destId,
+        );
+        if (_isNavalMoveOrderAccepted(
+          game,
+          topology,
+          playerId,
+          currentOrders,
+          candidate,
+        )) {
+          suggestions.add(candidate);
+        }
       }
-    }
 
-    // Suggest dock at adjacent owned provinces (fleets at sea only). SPEC/game/ships-and-naval.md.
-    if (fleet.isAtSea) {
-      final zoneRegionId = regionIdForSeaZone(topology, currentZone);
+      // Suggest dock at adjacent owned provinces (S–P). SPEC/game/ships-and-naval.md.
+      final zoneRegionId = regionIdForSeaZone(topology, cur);
       if (zoneRegionId != null) {
         final adjacentLocalIds = provinceIdsAdjacentToSeaZone(
           topology,
-          currentZone,
+          cur,
           regionId: zoneRegionId,
         );
         for (final localId in adjacentLocalIds) {
-          final fullProvinceId = ProvinceId.full(zoneRegionId, localId);
+          final fullProvinceId = ProvinceId.isPrefixed(localId)
+              ? localId
+              : ProvinceId.full(zoneRegionId, localId);
           if (existingByFleet[fleet.id]?.contains('port:$fullProvinceId') ??
               false)
             continue;
@@ -1415,6 +1379,31 @@ List<NavalMoveOrder> suggestNavalMoveOrders(
           )) {
             suggestions.add(candidate);
           }
+        }
+      }
+    } else {
+      final inPortProvinceId = fleet.inPortAtProvinceId;
+      if (inPortProvinceId == null) continue;
+      final rl = regionAndLocalProvinceForFleetInPort(
+        inPortProvinceId,
+        fleet.regionId,
+      );
+      final pNode = provinceTopologyNodeId(topology, rl.localId, rl.regionId);
+      if (pNode == null) continue;
+      for (final destId in seaZonesAdjacentToProvince(topology, pNode)) {
+        if (existingByFleet[fleet.id]?.contains(destId) ?? false) continue;
+        final candidate = NavalMoveOrder(
+          fleetId: fleet.id,
+          destinationSeaZoneId: destId,
+        );
+        if (_isNavalMoveOrderAccepted(
+          game,
+          topology,
+          playerId,
+          currentOrders,
+          candidate,
+        )) {
+          suggestions.add(candidate);
         }
       }
     }
@@ -1447,9 +1436,7 @@ List<NavalMissionOrder> suggestNavalMissionOrders(
   MapTopology topology,
   Orders currentOrders,
 ) {
-  _log.d(
-    'suggestNavalMissionOrders player=${view.playerId}',
-  );
+  _log.d('suggestNavalMissionOrders player=${view.playerId}');
   final playerId = view.playerId;
   final suggestions = <NavalMissionOrder>[];
   final existingByFleet = <String>{};
@@ -1595,7 +1582,7 @@ List<DiplomaticOrder> _diplomaticCandidatesForTargetOrdered({
   final isGpTarget = game.players.any((p) => p.id == targetId);
   final isMinorOrTribe =
       game.minorNations.any((m) => m.id == targetId) ||
-          game.tribes.any((t) => t.id == targetId);
+      game.tribes.any((t) => t.id == targetId);
 
   if (knownTargetIds.contains(targetId) && atWar) {
     out.add(
@@ -1722,9 +1709,7 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
   Orders currentOrders, {
   Map<String, TileMapResult>? tileMapByRegion,
 }) {
-  _log.d(
-    'suggestDiplomaticOrders player=${view.playerId}',
-  );
+  _log.d('suggestDiplomaticOrders player=${view.playerId}');
   final playerId = view.playerId;
   final suggestions = <DiplomaticOrder>[];
   final player = view.player;

--- a/packages/colonizethis_logic/lib/src/orders/validators/naval_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/naval_order_validator.dart
@@ -4,6 +4,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import '../../diplomacy/diplomacy_resolver.dart';
 import '../../world/naval.dart';
 import '../../world/province_lookup.dart';
+import '../../world/topology_helpers.dart';
 import '../order_validation_result.dart';
 
 /// Validates naval move and naval mission orders for a single player.
@@ -18,10 +19,10 @@ class NavalOrderValidator {
     required Game game,
     required MapTopology topology,
     required String playerId,
-  })  : _game = game,
-        _topology = topology,
-        _playerId = playerId,
-        _fleetById = {for (final f in game.worldState.fleets) f.id: f};
+  }) : _game = game,
+       _topology = topology,
+       _playerId = playerId,
+       _fleetById = {for (final f in game.worldState.fleets) f.id: f};
 
   /// Validates one [NavalMoveOrder]. Home fleet cannot move; move must be to adjacent sea zone (or undock from port).
   OrderValidationResult validateNavalMove(
@@ -33,7 +34,9 @@ class NavalOrderValidator {
       body: () {
         final fleet = _fleetById[o.fleetId];
         final homeFleetId = homeFleetIdFor(_playerId);
-        if (fleet == null || fleet.ownerId != _playerId || fleet.id == homeFleetId) {
+        if (fleet == null ||
+            fleet.ownerId != _playerId ||
+            fleet.id == homeFleetId) {
           return OrderValidationResult.rejected(
             fleet == null ? 'Fleet not found' : 'Invalid naval move',
           );
@@ -47,8 +50,10 @@ class NavalOrderValidator {
               'Dock only allowed when fleet is at sea',
             );
           }
-          final fullProvinceId =
-              toFullProvinceId(fleet.regionId, portProvinceId);
+          final fullProvinceId = toFullProvinceId(
+            fleet.regionId,
+            portProvinceId,
+          );
           final province = tryGetProvince(_game.worldState, fullProvinceId);
           if (province == null) {
             return OrderValidationResult.rejected('Port province not found');
@@ -58,37 +63,55 @@ class NavalOrderValidator {
               'Can only dock at own province',
             );
           }
-          final adjacentSeaZones = seaZoneIdsAdjacentToProvince(_topology, fullProvinceId);
+          final adjacentSeaZones = seaZoneIdsAdjacentToProvince(
+            _topology,
+            fullProvinceId,
+          );
           final valid = adjacentSeaZones.contains(fleet.seaZoneId);
           return valid
               ? OrderValidationResult.accepted()
               : OrderValidationResult.rejected('Invalid naval move');
         }
 
-        // Move to sea zone: destination must be adjacent.
-        final String? currentZone;
+        // Move to sea zone: S–S when at sea; P–S undock when in port; [destZone] must be a sea node.
+        final destZone = o.destinationSeaZoneId;
+        if (destZone == null || destZone.isEmpty) {
+          return OrderValidationResult.rejected('Invalid naval move');
+        }
+        if (!seaZoneNodeIds(_topology).contains(destZone)) {
+          return OrderValidationResult.rejected('Invalid naval move');
+        }
         if (fleet.isAtSea) {
-          currentZone = fleet.seaZoneId;
-        } else {
-          final inPortProvinceId = fleet.inPortAtProvinceId;
-          if (inPortProvinceId == null) {
+          final cur = fleet.seaZoneId;
+          if (cur == null) {
             return OrderValidationResult.rejected('Invalid naval move');
           }
-          final rl = regionAndLocalProvinceForFleetInPort(
-            inPortProvinceId,
-            fleet.regionId,
-          );
-          currentZone = seaZoneIdForProvince(
-            _topology,
-            rl.localId,
-            regionId: rl.regionId,
-          );
+          final valid =
+              cur == destZone || isAdjacentSeaSeaZone(_topology, cur, destZone);
+          return valid
+              ? OrderValidationResult.accepted()
+              : OrderValidationResult.rejected('Invalid naval move');
         }
-        final destZone = o.destinationSeaZoneId;
-        final valid = currentZone != null &&
-            destZone != null &&
-            destZone.isNotEmpty &&
-            (currentZone == destZone || isAdjacentSeaZone(_topology, currentZone, destZone));
+        final inPortProvinceId = fleet.inPortAtProvinceId;
+        if (inPortProvinceId == null) {
+          return OrderValidationResult.rejected('Invalid naval move');
+        }
+        final rl = regionAndLocalProvinceForFleetInPort(
+          inPortProvinceId,
+          fleet.regionId,
+        );
+        final provinceNodeId = provinceTopologyNodeId(
+          _topology,
+          rl.localId,
+          rl.regionId,
+        );
+        if (provinceNodeId == null) {
+          return OrderValidationResult.rejected('Invalid naval move');
+        }
+        final valid = seaZonesAdjacentToProvince(
+          _topology,
+          provinceNodeId,
+        ).contains(destZone);
         return valid
             ? OrderValidationResult.accepted()
             : OrderValidationResult.rejected('Invalid naval move');
@@ -106,7 +129,8 @@ class NavalOrderValidator {
       body: () {
         final fleet = _fleetById[o.fleetId];
         final homeFleetId = homeFleetIdFor(_playerId);
-        var valid = fleet != null &&
+        var valid =
+            fleet != null &&
             fleet.ownerId == _playerId &&
             (o.mission == 'join_home_fleet' || fleet.id != homeFleetId);
         String? rejectReason = valid
@@ -141,7 +165,9 @@ class NavalOrderValidator {
 
         return valid
             ? OrderValidationResult.accepted()
-            : OrderValidationResult.rejected(rejectReason ?? 'Invalid naval mission');
+            : OrderValidationResult.rejected(
+                rejectReason ?? 'Invalid naval mission',
+              );
       },
     );
   }

--- a/packages/colonizethis_logic/lib/src/world/naval.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval.dart
@@ -1,6 +1,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'topology_helpers.dart';
+
 /// Naval movement helpers. SPEC/program/naval-movement-resolution.md.
 
 /// True when a dock order targeting [dockFullProvinceId] is the player's capital;
@@ -58,6 +60,126 @@ bool isAdjacentSeaZone(
   return false;
 }
 
+/// True when both ids are **sea-zone** topology nodes sharing an undirected edge (S–S only).
+/// At-sea fleet moves use this; undock uses [seaZonesAdjacentToProvince].
+bool isAdjacentSeaSeaZone(
+  MapTopology topology,
+  String seaZoneIdA,
+  String seaZoneIdB,
+) {
+  final seas = seaZoneNodeIds(topology);
+  if (!seas.contains(seaZoneIdA) || !seas.contains(seaZoneIdB)) return false;
+  if (seaZoneIdA == seaZoneIdB) return false;
+  for (final e in topology.edges) {
+    if ((e.id1 == seaZoneIdA && e.id2 == seaZoneIdB) ||
+        (e.id1 == seaZoneIdB && e.id2 == seaZoneIdA)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Topology node id for [provinceId] in [regionId] (matches [MapTopology] edge endpoints).
+/// [provinceId] is the same form as for [seaZoneIdForProvince] (local or prefixed).
+String? provinceTopologyNodeId(
+  MapTopology topology,
+  String provinceId,
+  String regionId,
+) {
+  final nodesByRegionAndId = <String, Map<String, TopologyNode>>{};
+  for (final n in topology.nodes) {
+    nodesByRegionAndId.putIfAbsent(n.regionId, () => {})[n.id] = n;
+  }
+  final regionNodes = nodesByRegionAndId[regionId];
+  if (regionNodes == null) return null;
+  final primaryProvinceKey = ProvinceId.isPrefixed(provinceId)
+      ? provinceId
+      : ProvinceId.full(regionId, provinceId);
+  var provinceNode = regionNodes[primaryProvinceKey];
+  if (provinceNode == null && !ProvinceId.isPrefixed(provinceId)) {
+    provinceNode = regionNodes[provinceId];
+  }
+  if (provinceNode == null || provinceNode.type != TopologyNodeType.province) {
+    return null;
+  }
+  return provinceNode.id;
+}
+
+/// Neighbors of [currentSeaZoneId] along **S–S** edges only, sorted.
+List<String> adjacentSeaZoneIdsSeaOnly(
+  MapTopology topology,
+  String currentSeaZoneId,
+) {
+  final seas = seaZoneNodeIds(topology);
+  if (!seas.contains(currentSeaZoneId)) return const [];
+  final out = <String>{};
+  for (final e in topology.edges) {
+    final a = e.id1;
+    final b = e.id2;
+    if (a == currentSeaZoneId && seas.contains(b)) out.add(b);
+    if (b == currentSeaZoneId && seas.contains(a)) out.add(a);
+  }
+  return out.toList()..sort();
+}
+
+/// One-hop naval **topology** destinations: S–S and S–P when at sea; P–S undock when in port.
+/// Province ids match topology endpoints (local or prefixed); resolve world [Province] in the UI.
+class NavalMoveTopologyPicks {
+  const NavalMoveTopologyPicks({
+    required this.adjacentSeaZoneIds,
+    required this.adjacentProvinceIdsForDock,
+  });
+
+  final List<String> adjacentSeaZoneIds;
+  final List<String> adjacentProvinceIdsForDock;
+
+  int get totalCount =>
+      adjacentSeaZoneIds.length + adjacentProvinceIdsForDock.length;
+}
+
+/// Legal adjacent nodes for the Move fleet dialog and validation (same graph rules).
+NavalMoveTopologyPicks navalMoveTopologyPicksForFleet({
+  required MapTopology topology,
+  required Fleet fleet,
+}) {
+  if (fleet.isAtSea && fleet.seaZoneId != null) {
+    final z = fleet.seaZoneId!;
+    final seaList = adjacentSeaZoneIdsSeaOnly(topology, z);
+    final rz = regionIdForSeaZone(topology, z) ?? fleet.regionId;
+    final dockSet = provinceIdsAdjacentToSeaZone(topology, z, regionId: rz);
+    final dockList = dockSet.toList()..sort();
+    return NavalMoveTopologyPicks(
+      adjacentSeaZoneIds: seaList,
+      adjacentProvinceIdsForDock: dockList,
+    );
+  }
+  final inPort = fleet.inPortAtProvinceId;
+  if (inPort != null) {
+    final rl = regionAndLocalProvinceForFleetInPort(inPort, fleet.regionId);
+    final provinceNodeId = provinceTopologyNodeId(
+      topology,
+      rl.localId,
+      rl.regionId,
+    );
+    if (provinceNodeId == null) {
+      return const NavalMoveTopologyPicks(
+        adjacentSeaZoneIds: [],
+        adjacentProvinceIdsForDock: [],
+      );
+    }
+    final undock = seaZonesAdjacentToProvince(topology, provinceNodeId).toList()
+      ..sort();
+    return NavalMoveTopologyPicks(
+      adjacentSeaZoneIds: undock,
+      adjacentProvinceIdsForDock: [],
+    );
+  }
+  return const NavalMoveTopologyPicks(
+    adjacentSeaZoneIds: [],
+    adjacentProvinceIdsForDock: [],
+  );
+}
+
 /// First sea zone id adjacent to [seaZoneId], or null if none. Used for naval retreat.
 String? firstAdjacentSeaZone(MapTopology topology, String seaZoneId) {
   for (final e in topology.edges) {
@@ -76,7 +198,11 @@ String? firstAdjacentSeaZone(MapTopology topology, String seaZoneId) {
 /// Supports both **per-region** topology (node/edge ids are local) and **combined** topology
 /// from [buildCombinedTopology] (prefixed node/edge ids). SPEC/program/map-data.md.
 /// When [regionId] is null, uses first matching node (single-region or legacy).
-String? seaZoneIdForProvince(MapTopology topology, String provinceId, {String? regionId}) {
+String? seaZoneIdForProvince(
+  MapTopology topology,
+  String provinceId, {
+  String? regionId,
+}) {
   if (regionId != null) {
     final nodesByRegionAndId = <String, Map<String, TopologyNode>>{};
     for (final n in topology.nodes) {
@@ -91,7 +217,8 @@ String? seaZoneIdForProvince(MapTopology topology, String provinceId, {String? r
     if (provinceNode == null && !ProvinceId.isPrefixed(provinceId)) {
       provinceNode = regionNodes[provinceId];
     }
-    if (provinceNode == null || provinceNode.type != TopologyNodeType.province) {
+    if (provinceNode == null ||
+        provinceNode.type != TopologyNodeType.province) {
       return null;
     }
     for (final e in topology.edges) {
@@ -141,10 +268,13 @@ Set<String> provinceIdsAdjacentToSeaZone(
   if (regionNodes == null) return {};
   final out = <String>{};
   for (final e in topology.edges) {
-    final otherId = e.id1 == seaZoneId ? e.id2 : (e.id2 == seaZoneId ? e.id1 : null);
+    final otherId = e.id1 == seaZoneId
+        ? e.id2
+        : (e.id2 == seaZoneId ? e.id1 : null);
     if (otherId != null) {
       final node = regionNodes[otherId];
-      if (node != null && node.type == TopologyNodeType.province) out.add(otherId);
+      if (node != null && node.type == TopologyNodeType.province)
+        out.add(otherId);
     }
   }
   return out;
@@ -168,13 +298,17 @@ Set<String> seaZoneIdsAdjacentToProvince(
   String localProvinceId = provinceId;
   if (provinceId.contains('|')) {
     final parts = provinceId.split('|');
-    localProvinceId = parts.length > 1 ? parts.sublist(1).join('|') : provinceId;
+    localProvinceId = parts.length > 1
+        ? parts.sublist(1).join('|')
+        : provinceId;
   }
   final nodeById = {for (final n in topology.nodes) n.id: n};
   final out = <String>{};
   for (final e in topology.edges) {
     final id1 = e.id1, id2 = e.id2;
-    final prov = (id1 == localProvinceId || id1 == provinceId) ? id1 : ((id2 == localProvinceId || id2 == provinceId) ? id2 : null);
+    final prov = (id1 == localProvinceId || id1 == provinceId)
+        ? id1
+        : ((id2 == localProvinceId || id2 == provinceId) ? id2 : null);
     if (prov == null) continue;
     final other = id1 == prov ? id2 : id1;
     final node = nodeById[other];
@@ -187,7 +321,9 @@ Set<String> seaZoneIdsAdjacentToProvince(
 /// fleet attached to that province ([inPortAtProvinceId] equals province id).
 /// [provinceId] must be prefixed (regionId|localId) when world is multi-region.
 List<Fleet> fleetsInPortAtProvince(WorldState worldState, String provinceId) {
-  final normalized = provinceId.contains('|') ? provinceId : 'oldWorld|$provinceId';
+  final normalized = provinceId.contains('|')
+      ? provinceId
+      : 'oldWorld|$provinceId';
   return worldState.fleets
       .where((f) => f.inPortAtProvinceId == normalized)
       .toList();

--- a/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
@@ -12,6 +12,7 @@ import '../game_events.dart';
 import 'naval.dart';
 import 'player_view.dart';
 import 'province_lookup.dart';
+import 'topology_helpers.dart';
 
 final _log = logicLogger();
 
@@ -22,14 +23,16 @@ Map<String, Map<String, String>> _revealProvinceTilesForPlayer(
   String fullProvinceId,
 ) {
   final regionId = ProvinceId.regionIdFrom(fullProvinceId);
-  final tileKeys = game.worldState.tileKeysByRegionAndProvince[regionId]?[fullProvinceId] ??
+  final tileKeys =
+      game.worldState.tileKeysByRegionAndProvince[regionId]?[fullProvinceId] ??
       const [];
   if (tileKeys.isEmpty) return visibilityByTile;
   final vis = Map<String, String>.from(visibilityByTile[playerId] ?? {});
   for (final tk in tileKeys) {
     vis[tk] = VisibilityLevel.revealed.name;
   }
-  return Map<String, Map<String, String>>.from(visibilityByTile)..[playerId] = vis;
+  return Map<String, Map<String, String>>.from(visibilityByTile)
+    ..[playerId] = vis;
 }
 
 Map<String, Set<String>> _atWarByFaction(Game game) {
@@ -97,7 +100,8 @@ Game applyNavalMissionOrders(
             .map((p) => p.capitalProvinceId)
             .firstOrNull;
         if (capitalProvinceId == null ||
-            fleet.inPortAtProvinceId != capitalProvinceId) continue;
+            fleet.inPortAtProvinceId != capitalProvinceId)
+          continue;
         if (fleet.shipTypeIds.isEmpty) continue;
         final updatedHome = homeFleet.copyWith(
           ships: [...homeFleet.ships, ...fleet.ships],
@@ -123,14 +127,17 @@ Game applyNavalMissionOrders(
 
       if (mission == FleetMission.blockade) {
         final targetProvinceId = order.targetProvinceId;
-        final province = targetProvinceId != null &&
+        final province =
+            targetProvinceId != null &&
                 targetProvinceId.isNotEmpty &&
                 ProvinceId.isPrefixed(targetProvinceId)
             ? tryGetProvince(game.worldState, targetProvinceId)
             : null;
         final ownerId = province?.ownerId;
         final atWar =
-            ownerId != null && ownerId != playerId && factionsAtWar(game, playerId, ownerId);
+            ownerId != null &&
+            ownerId != playerId &&
+            factionsAtWar(game, playerId, ownerId);
         if (!atWar) {
           final cleared = fleet.copyWith(
             mission: FleetMission.none,
@@ -169,7 +176,9 @@ Game applyNavalMissionOrders(
         : null;
     final ownerId = province?.ownerId;
     final atWar =
-        ownerId != null && ownerId != f.ownerId && factionsAtWar(game, f.ownerId, ownerId);
+        ownerId != null &&
+        ownerId != f.ownerId &&
+        factionsAtWar(game, f.ownerId, ownerId);
     if (!atWar) {
       fleets = List<Fleet>.from(fleets)
         ..[i] = f.copyWith(
@@ -180,9 +189,7 @@ Game applyNavalMissionOrders(
     }
   }
 
-  return game.copyWith(
-    worldState: game.worldState.copyWith(fleets: fleets),
-  );
+  return game.copyWith(worldState: game.worldState.copyWith(fleets: fleets));
 }
 
 Game applyNavalMovesAndShipReveal(
@@ -213,7 +220,10 @@ Game applyNavalMovesAndShipReveal(
         final fullProvinceId = toFullProvinceId(fleet.regionId, portProvinceId);
         final province = tryGetProvince(game.worldState, fullProvinceId);
         if (province == null || province.ownerId != playerId) continue;
-        final adjacentSeaZones = seaZoneIdsAdjacentToProvince(topology, fullProvinceId);
+        final adjacentSeaZones = seaZoneIdsAdjacentToProvince(
+          topology,
+          fullProvinceId,
+        );
         if (!adjacentSeaZones.contains(fleet.seaZoneId)) continue;
 
         visibilityByTile = _revealProvinceTilesForPlayer(
@@ -266,28 +276,38 @@ Game applyNavalMovesAndShipReveal(
         continue;
       }
 
-      // Move to sea zone (or undock from port).
-      final String? currentSeaZoneId;
+      // Move to sea zone (S–S) or undock (P–S): destination must be a sea-zone node.
+      final destZoneId = order.destinationSeaZoneId;
+      if (destZoneId == null || destZoneId.isEmpty) continue;
+      if (!seaZoneNodeIds(topology).contains(destZoneId)) continue;
+
       if (fleet.isAtSea) {
-        currentSeaZoneId = fleet.seaZoneId;
+        final cur = fleet.seaZoneId;
+        if (cur == null) continue;
+        if (cur != destZoneId &&
+            !isAdjacentSeaSeaZone(topology, cur, destZoneId)) {
+          continue;
+        }
       } else {
-        // Fleet in port: adjacency is from the port's sea zone.
         final inPortProvinceId = fleet.inPortAtProvinceId;
         if (inPortProvinceId == null) continue;
         final rl = regionAndLocalProvinceForFleetInPort(
           inPortProvinceId,
           fleet.regionId,
         );
-        currentSeaZoneId = seaZoneIdForProvince(
+        final provinceNodeId = provinceTopologyNodeId(
           topology,
           rl.localId,
-          regionId: rl.regionId,
+          rl.regionId,
         );
+        if (provinceNodeId == null) continue;
+        if (!seaZonesAdjacentToProvince(
+          topology,
+          provinceNodeId,
+        ).contains(destZoneId)) {
+          continue;
+        }
       }
-      final destZoneId = order.destinationSeaZoneId;
-      if (currentSeaZoneId == null || destZoneId == null || destZoneId.isEmpty) continue;
-      if (currentSeaZoneId != destZoneId &&
-          !isAdjacentSeaZone(topology, currentSeaZoneId, destZoneId)) continue;
 
       final destRegionId = regionIdForSeaZone(topology, destZoneId);
       // Moving to sea zone: fleet ends at sea (undock if was in port); move clears mission.
@@ -317,22 +337,26 @@ Game applyNavalMovesAndShipReveal(
         final vis = Map<String, String>.from(visibilityByTile[playerId] ?? {});
         for (final localProvinceId in provinceIds) {
           final fullProvinceId = ProvinceId.full(destRegionId, localProvinceId);
-          final tileKeys = game.worldState
+          final tileKeys =
+              game
+                  .worldState
                   .tileKeysByRegionAndProvince[destRegionId]?[fullProvinceId] ??
               [];
           for (final tk in tileKeys) {
             vis[tk] = VisibilityLevel.revealed.name;
           }
         }
-        final seaWaterKeys = game.worldState.tileKeysByRegionAndProvince[destRegionId]?[destZoneId];
+        final seaWaterKeys = game
+            .worldState
+            .tileKeysByRegionAndProvince[destRegionId]?[destZoneId];
         if (seaWaterKeys != null) {
           for (final tk in seaWaterKeys) {
             vis[tk] = VisibilityLevel.fullyVisible.name;
           }
         }
-        visibilityByTile =
-            Map<String, Map<String, String>>.from(visibilityByTile)
-              ..[playerId] = vis;
+        visibilityByTile = Map<String, Map<String, String>>.from(
+          visibilityByTile,
+        )..[playerId] = vis;
       }
     }
   }
@@ -361,9 +385,11 @@ Game runNavalInterceptionCombatPhase(
       for (final order in list) order.fleetId,
   };
   battles = [
-    for (final b in battles) normalizeNavalBattleSidesForAttacker(b, game, movedFleetIds),
+    for (final b in battles)
+      normalizeNavalBattleSidesForAttacker(b, game, movedFleetIds),
   ];
-  var seed = (game.globalGameSeed ?? 0) ^
+  var seed =
+      (game.globalGameSeed ?? 0) ^
       (game.worldState.turnState.turnNumber * 0x9E3779B1);
   battles = filterBattlesByInterception(game, battles, movedFleetIds, seed);
   _log.d('naval phase after interception battles=${battles.length}');
@@ -393,9 +419,11 @@ Game runNavalInterceptionCombatPhase(
     );
     seed = (seed * 1103515245 + 12345) & 0x7fffffff;
     final zoneRegionId = regionIdForSeaZone(topology, battle.seaZoneId);
-    final fleetsInZone =
-        state.worldState.fleets.where((f) => f.seaZoneId == battle.seaZoneId);
-    final regionId = zoneRegionId ??
+    final fleetsInZone = state.worldState.fleets.where(
+      (f) => f.seaZoneId == battle.seaZoneId,
+    );
+    final regionId =
+        zoneRegionId ??
         (fleetsInZone.isEmpty ? null : fleetsInZone.first.regionId) ??
         kRegionOldWorld;
     state = applyNavalBattleResults(
@@ -423,13 +451,19 @@ Game runNavalInterceptionCombatPhase(
       loserId = battle.side2.ownerId;
     }
     if (victorId != null && loserId != null) {
-      final evidence =
-          evidenceForNavalBattleVictory(state, victorId, loserId, turn);
+      final evidence = evidenceForNavalBattleVictory(
+        state,
+        victorId,
+        loserId,
+        turn,
+      );
       if (evidence.isNotEmpty) {
-        state = state.copyWith(dossierEvidenceEntries: [
-          ...state.dossierEvidenceEntries,
-          ...evidence
-        ]);
+        state = state.copyWith(
+          dossierEvidenceEntries: [
+            ...state.dossierEvidenceEntries,
+            ...evidence,
+          ],
+        );
       }
       final dialogueSeed = (seed ^ (battleIndex * 0x9E3779B1)) & 0x7fffffff;
       final events = dialogueEventsForNavalBattleResult(

--- a/packages/colonizethis_logic/test/naval_test.dart
+++ b/packages/colonizethis_logic/test/naval_test.dart
@@ -11,10 +11,26 @@ void main() {
     setUp(() {
       topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
-          TopologyNode(id: 'p2', regionId: 'oldWorld', type: TopologyNodeType.province),
-          TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
-          TopologyNode(id: 'sea2', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+          TopologyNode(
+            id: 'p1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'p2',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'sea1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.seaZone,
+          ),
+          TopologyNode(
+            id: 'sea2',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.seaZone,
+          ),
         ],
         edges: const [
           TopologyEdge(id1: 'p1', id2: 'sea1'),
@@ -45,8 +61,72 @@ void main() {
       });
     });
 
-    test('ship reveal sets coastal tiles to revealed when fleet enters sea zone',
-        () {
+    group('isAdjacentSeaSeaZone', () {
+      test('true only for S–S edges between sea-zone nodes', () {
+        expect(isAdjacentSeaSeaZone(topology, 'sea1', 'sea2'), isTrue);
+        expect(isAdjacentSeaSeaZone(topology, 'sea1', 'p1'), isFalse);
+        expect(isAdjacentSeaSeaZone(topology, 'p1', 'sea1'), isFalse);
+      });
+    });
+
+    group('navalMoveTopologyPicksForFleet', () {
+      test('at sea: sea list is S–S only; dock list from S–P', () {
+        final fleet = Fleet(
+          id: 'f1',
+          ownerId: 'p1',
+          regionId: 'oldWorld',
+          seaZoneId: 'sea1',
+          shipTypeIds: const ['carrack'],
+        );
+        final picks = navalMoveTopologyPicksForFleet(
+          topology: topology,
+          fleet: fleet,
+        );
+        expect(picks.adjacentSeaZoneIds, ['sea2']);
+        expect(picks.adjacentProvinceIdsForDock.toSet(), {'p1', 'p2'});
+      });
+
+      test('in port: undock list is P–S only (all seas touching port)', () {
+        final top = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'p1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'sea1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+            TopologyNode(
+              id: 'sea2',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+          ],
+          edges: const [
+            TopologyEdge(id1: 'p1', id2: 'sea1'),
+            TopologyEdge(id1: 'p1', id2: 'sea2'),
+          ],
+        );
+        final fleet = Fleet(
+          id: 'f1',
+          ownerId: 'p1',
+          regionId: 'oldWorld',
+          inPortAtProvinceId: 'p1',
+          shipTypeIds: const ['carrack'],
+        );
+        final picks = navalMoveTopologyPicksForFleet(
+          topology: top,
+          fleet: fleet,
+        );
+        expect(picks.adjacentSeaZoneIds.toSet(), {'sea1', 'sea2'});
+        expect(picks.adjacentProvinceIdsForDock, isEmpty);
+      });
+    });
+
+    test('ship reveal sets coastal tiles to revealed when fleet enters sea zone', () {
       // Single coastal province adjacent to a sea zone; moving fleet into that
       // sea zone should reveal the province's coastal tiles for the fleet owner.
       const ow = 'oldWorld';
@@ -58,13 +138,20 @@ void main() {
       final revealTopology = MapTopology(
         nodes: const [
           TopologyNode(
-              id: provinceLocalId,
-              regionId: ow,
-              type: TopologyNodeType.province),
+            id: provinceLocalId,
+            regionId: ow,
+            type: TopologyNodeType.province,
+          ),
           TopologyNode(
-              id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
+            id: 'sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
           TopologyNode(
-              id: 'sea2', regionId: ow, type: TopologyNodeType.seaZone),
+            id: 'sea2',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
         ],
         edges: const [
           // Province is coastal to the destination sea zone (sea2); sea1 adjacent
@@ -95,26 +182,18 @@ void main() {
               'sea2': [tileSea2],
             },
           },
-          playerVisibilityByTile: const {
-            'gp1': {},
-          },
+          playerVisibilityByTile: const {'gp1': {}},
         ),
-        players: const [
-          Player(id: 'gp1', displayName: 'GP1', isHuman: true),
-        ],
+        players: const [Player(id: 'gp1', displayName: 'GP1', isHuman: true)],
       );
 
       final orders = {
         'gp1': [
-          const NavalMoveOrder(
-            fleetId: 'f1',
-            destinationSeaZoneId: 'sea2',
-          ),
+          const NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 'sea2'),
         ],
       };
 
-      final next =
-          applyNavalMovesAndShipReveal(game, revealTopology, orders);
+      final next = applyNavalMovesAndShipReveal(game, revealTopology, orders);
 
       expect(
         next.worldState.playerVisibilityByTile['gp1']?[tileKey],
@@ -130,8 +209,16 @@ void main() {
       test('returns id2 when id1 matches seaZoneId', () {
         final seaOnly = MapTopology(
           nodes: const [
-            TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
-            TopologyNode(id: 'sea2', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+            TopologyNode(
+              id: 'sea1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+            TopologyNode(
+              id: 'sea2',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
           ],
           edges: const [TopologyEdge(id1: 'sea1', id2: 'sea2')],
         );
@@ -141,8 +228,16 @@ void main() {
       test('returns id1 when id2 matches seaZoneId', () {
         final seaOnly = MapTopology(
           nodes: const [
-            TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
-            TopologyNode(id: 'sea2', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+            TopologyNode(
+              id: 'sea1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+            TopologyNode(
+              id: 'sea2',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
           ],
           edges: const [TopologyEdge(id1: 'sea1', id2: 'sea2')],
         );
@@ -152,7 +247,11 @@ void main() {
       test('returns null when sea zone has no edges', () {
         final noEdgeTopology = MapTopology(
           nodes: const [
-            TopologyNode(id: 'sea0', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+            TopologyNode(
+              id: 'sea0',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
           ],
           edges: const [],
         );
@@ -166,29 +265,62 @@ void main() {
         expect(seaZoneIdForProvince(topology, 'p2'), 'sea1');
       });
 
-      test('when regionId is provided, lookup is region-scoped (world-model-identity)', () {
-        final multiRegion = MapTopology(
-          nodes: const [
-            TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
-            TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
-            TopologyNode(id: 'p1', regionId: 'newWorld', type: TopologyNodeType.province),
-            TopologyNode(id: 'sea2', regionId: 'newWorld', type: TopologyNodeType.seaZone),
-          ],
-          edges: const [
-            TopologyEdge(id1: 'p1', id2: 'sea1'),
-            TopologyEdge(id1: 'p1', id2: 'sea2'),
-          ],
-        );
-        expect(seaZoneIdForProvince(multiRegion, 'p1', regionId: 'oldWorld'), 'sea1');
-        expect(seaZoneIdForProvince(multiRegion, 'p1', regionId: 'newWorld'), 'sea2');
-        expect(seaZoneIdForProvince(multiRegion, 'p1'), isNotNull);
-      });
+      test(
+        'when regionId is provided, lookup is region-scoped (world-model-identity)',
+        () {
+          final multiRegion = MapTopology(
+            nodes: const [
+              TopologyNode(
+                id: 'p1',
+                regionId: 'oldWorld',
+                type: TopologyNodeType.province,
+              ),
+              TopologyNode(
+                id: 'sea1',
+                regionId: 'oldWorld',
+                type: TopologyNodeType.seaZone,
+              ),
+              TopologyNode(
+                id: 'p1',
+                regionId: 'newWorld',
+                type: TopologyNodeType.province,
+              ),
+              TopologyNode(
+                id: 'sea2',
+                regionId: 'newWorld',
+                type: TopologyNodeType.seaZone,
+              ),
+            ],
+            edges: const [
+              TopologyEdge(id1: 'p1', id2: 'sea1'),
+              TopologyEdge(id1: 'p1', id2: 'sea2'),
+            ],
+          );
+          expect(
+            seaZoneIdForProvince(multiRegion, 'p1', regionId: 'oldWorld'),
+            'sea1',
+          );
+          expect(
+            seaZoneIdForProvince(multiRegion, 'p1', regionId: 'newWorld'),
+            'sea2',
+          );
+          expect(seaZoneIdForProvince(multiRegion, 'p1'), isNotNull);
+        },
+      );
 
       test('returns null for province with no sea edge', () {
         final inland = MapTopology(
           nodes: const [
-            TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
-            TopologyNode(id: 'p2', regionId: 'oldWorld', type: TopologyNodeType.province),
+            TopologyNode(
+              id: 'p1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'p2',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
           ],
           edges: const [TopologyEdge(id1: 'p1', id2: 'p2')],
         );
@@ -212,9 +344,7 @@ void main() {
                 type: TopologyNodeType.seaZone,
               ),
             ],
-            edges: [
-              TopologyEdge(id1: '$ow|cap', id2: '$ow|sea1'),
-            ],
+            edges: [TopologyEdge(id1: '$ow|cap', id2: '$ow|sea1')],
           );
           expect(
             seaZoneIdForProvince(combined, 'cap', regionId: ow),
@@ -256,34 +386,57 @@ void main() {
       test('when regionId passed, returns only provinces in that region', () {
         final multiRegion = MapTopology(
           nodes: const [
-            TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
-            TopologyNode(id: 'sea1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
-            TopologyNode(id: 'p1', regionId: 'newWorld', type: TopologyNodeType.province),
-            TopologyNode(id: 'sea1', regionId: 'newWorld', type: TopologyNodeType.seaZone),
+            TopologyNode(
+              id: 'p1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'sea1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+            TopologyNode(
+              id: 'p1',
+              regionId: 'newWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'sea1',
+              regionId: 'newWorld',
+              type: TopologyNodeType.seaZone,
+            ),
           ],
-          edges: const [
-            TopologyEdge(id1: 'p1', id2: 'sea1'),
-          ],
+          edges: const [TopologyEdge(id1: 'p1', id2: 'sea1')],
         );
         expect(
-          provinceIdsAdjacentToSeaZone(multiRegion, 'sea1', regionId: 'oldWorld'),
+          provinceIdsAdjacentToSeaZone(
+            multiRegion,
+            'sea1',
+            regionId: 'oldWorld',
+          ),
           equals({'p1'}),
         );
         expect(
-          provinceIdsAdjacentToSeaZone(multiRegion, 'sea1', regionId: 'newWorld'),
+          provinceIdsAdjacentToSeaZone(
+            multiRegion,
+            'sea1',
+            regionId: 'newWorld',
+          ),
           equals({'p1'}),
         );
         expect(
-          provinceIdsAdjacentToSeaZone(multiRegion, 'sea1', regionId: 'otherRegion'),
+          provinceIdsAdjacentToSeaZone(
+            multiRegion,
+            'sea1',
+            regionId: 'otherRegion',
+          ),
           isEmpty,
         );
       });
 
       test('when sea zone not in topology, returns empty', () {
-        expect(
-          provinceIdsAdjacentToSeaZone(topology, 'nonexistent'),
-          isEmpty,
-        );
+        expect(provinceIdsAdjacentToSeaZone(topology, 'nonexistent'), isEmpty);
       });
     });
 

--- a/packages/colonizethis_logic/test/orders/validators/naval_order_validator_test.dart
+++ b/packages/colonizethis_logic/test/orders/validators/naval_order_validator_test.dart
@@ -11,8 +11,16 @@ void main() {
     test('validateNavalMove rejects when previousRejected', () {
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
-          TopologyNode(id: 'sea2', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(
+            id: 'sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
+          TopologyNode(
+            id: 'sea2',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
         ],
         edges: const [TopologyEdge(id1: 'sea1', id2: 'sea2')],
       );
@@ -50,7 +58,11 @@ void main() {
     test('validateNavalMove rejects when fleet not found', () {
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(
+            id: 'sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
         ],
         edges: const [],
       );
@@ -80,7 +92,11 @@ void main() {
     test('validateNavalMove rejects when fleet not owned by player', () {
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(
+            id: 'sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
         ],
         edges: const [],
       );
@@ -121,8 +137,16 @@ void main() {
     test('validateNavalMove rejects when home fleet', () {
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
-          TopologyNode(id: 'sea2', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(
+            id: 'sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
+          TopologyNode(
+            id: 'sea2',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
         ],
         edges: const [TopologyEdge(id1: 'sea1', id2: 'sea2')],
       );
@@ -150,8 +174,7 @@ void main() {
         playerId: 'p1',
       );
       final result = validator.validateNavalMove(
-        const NavalMoveOrder(
-            fleetId: 'fleet_p1', destinationSeaZoneId: 'sea2'),
+        const NavalMoveOrder(fleetId: 'fleet_p1', destinationSeaZoneId: 'sea2'),
         previousRejected: false,
       );
       expect(result.status, OrderValidationStatus.rejected);
@@ -161,8 +184,16 @@ void main() {
     test('validateNavalMove accept move to adjacent sea zone when at sea', () {
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
-          TopologyNode(id: 'sea2', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(
+            id: 'sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
+          TopologyNode(
+            id: 'sea2',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
         ],
         edges: const [TopologyEdge(id1: 'sea1', id2: 'sea2')],
       );
@@ -200,13 +231,23 @@ void main() {
     test('validateNavalMove reject move to non-adjacent sea zone', () {
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
-          TopologyNode(id: 'sea2', regionId: ow, type: TopologyNodeType.seaZone),
-          TopologyNode(id: 'sea3', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(
+            id: 'sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
+          TopologyNode(
+            id: 'sea2',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
+          TopologyNode(
+            id: 'sea3',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
         ],
-        edges: const [
-          TopologyEdge(id1: 'sea1', id2: 'sea2'),
-        ],
+        edges: const [TopologyEdge(id1: 'sea1', id2: 'sea2')],
       );
       final game = Game(
         id: 'g1',
@@ -240,102 +281,117 @@ void main() {
     });
 
     test(
-        'validateNavalMove dock accept when at sea adjacent owned province', () {
-      final topology = MapTopology(
-        nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
-          TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
-        ],
-        edges: const [TopologyEdge(id1: 'sea1', id2: 'P1')],
-      );
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-          oldWorld: RegionData(
-            provinces: [
-              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
-            ],
-          ),
-          newWorld: const RegionData(),
-          fleets: [
-            Fleet(
-              id: 'f1',
-              ownerId: 'p1',
-              seaZoneId: 'sea1',
+      'validateNavalMove dock accept when at sea adjacent owned province',
+      () {
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'sea1',
               regionId: ow,
-              shipTypeIds: const ['carrack'],
+              type: TopologyNodeType.seaZone,
+            ),
+            TopologyNode(
+              id: 'P1',
+              regionId: ow,
+              type: TopologyNodeType.province,
             ),
           ],
-        ),
-        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
-      );
-      final validator = NavalOrderValidator(
-        game: game,
-        topology: topology,
-        playerId: 'p1',
-      );
-      final result = validator.validateNavalMove(
-        NavalMoveOrder(
-          fleetId: 'f1',
-          destinationPortProvinceId: '$ow|P1',
-        ),
-        previousRejected: false,
-      );
-      expect(result.status, OrderValidationStatus.accepted);
-      expect(result.reason, isNull);
-    });
+          edges: const [TopologyEdge(id1: 'sea1', id2: 'P1')],
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
+            ),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'f1',
+                ownerId: 'p1',
+                seaZoneId: 'sea1',
+                regionId: ow,
+                shipTypeIds: const ['carrack'],
+              ),
+            ],
+          ),
+          players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+        );
+        final validator = NavalOrderValidator(
+          game: game,
+          topology: topology,
+          playerId: 'p1',
+        );
+        final result = validator.validateNavalMove(
+          NavalMoveOrder(fleetId: 'f1', destinationPortProvinceId: '$ow|P1'),
+          previousRejected: false,
+        );
+        expect(result.status, OrderValidationStatus.accepted);
+        expect(result.reason, isNull);
+      },
+    );
 
-    test('validateNavalMove dock accept when port province id is local (unprefixed)', () {
-      final topology = MapTopology(
-        nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
-          TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
-        ],
-        edges: const [TopologyEdge(id1: 'sea1', id2: 'P1')],
-      );
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-          oldWorld: RegionData(
-            provinces: [
-              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
-            ],
-          ),
-          newWorld: const RegionData(),
-          fleets: [
-            Fleet(
-              id: 'f1',
-              ownerId: 'p1',
-              seaZoneId: 'sea1',
+    test(
+      'validateNavalMove dock accept when port province id is local (unprefixed)',
+      () {
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'sea1',
               regionId: ow,
-              shipTypeIds: const ['carrack'],
+              type: TopologyNodeType.seaZone,
+            ),
+            TopologyNode(
+              id: 'P1',
+              regionId: ow,
+              type: TopologyNodeType.province,
             ),
           ],
-        ),
-        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
-      );
-      final validator = NavalOrderValidator(
-        game: game,
-        topology: topology,
-        playerId: 'p1',
-      );
-      final result = validator.validateNavalMove(
-        NavalMoveOrder(
-          fleetId: 'f1',
-          destinationPortProvinceId: 'P1',
-        ),
-        previousRejected: false,
-      );
-      expect(result.status, OrderValidationStatus.accepted);
-      expect(result.reason, isNull);
-    });
+          edges: const [TopologyEdge(id1: 'sea1', id2: 'P1')],
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
+            ),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'f1',
+                ownerId: 'p1',
+                seaZoneId: 'sea1',
+                regionId: ow,
+                shipTypeIds: const ['carrack'],
+              ),
+            ],
+          ),
+          players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+        );
+        final validator = NavalOrderValidator(
+          game: game,
+          topology: topology,
+          playerId: 'p1',
+        );
+        final result = validator.validateNavalMove(
+          NavalMoveOrder(fleetId: 'f1', destinationPortProvinceId: 'P1'),
+          previousRejected: false,
+        );
+        expect(result.status, OrderValidationStatus.accepted);
+        expect(result.reason, isNull);
+      },
+    );
 
     test('validateNavalMove dock reject when fleet in port', () {
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(
+            id: 'sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
           TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
         ],
         edges: const [TopologyEdge(id1: 'sea1', id2: 'P1')],
@@ -345,9 +401,7 @@ void main() {
         worldState: WorldState(
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
           oldWorld: RegionData(
-            provinces: [
-              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
-            ],
+            provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
           ),
           newWorld: const RegionData(),
           fleets: [
@@ -369,10 +423,7 @@ void main() {
         playerId: 'p1',
       );
       final result = validator.validateNavalMove(
-        NavalMoveOrder(
-          fleetId: 'f1',
-          destinationPortProvinceId: '$ow|P1',
-        ),
+        NavalMoveOrder(fleetId: 'f1', destinationPortProvinceId: '$ow|P1'),
         previousRejected: false,
       );
       expect(result.status, OrderValidationStatus.rejected);
@@ -382,7 +433,11 @@ void main() {
     test('validateNavalMove dock reject when port province not owned', () {
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(
+            id: 'sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
           TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
         ],
         edges: const [TopologyEdge(id1: 'sea1', id2: 'P1')],
@@ -392,9 +447,7 @@ void main() {
         worldState: WorldState(
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
           oldWorld: RegionData(
-            provinces: [
-              Province(id: '$ow|P1', regionId: ow, ownerId: 'p2'),
-            ],
+            provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p2')],
           ),
           newWorld: const RegionData(),
           fleets: [
@@ -418,10 +471,7 @@ void main() {
         playerId: 'p1',
       );
       final result = validator.validateNavalMove(
-        NavalMoveOrder(
-          fleetId: 'f1',
-          destinationPortProvinceId: '$ow|P1',
-        ),
+        NavalMoveOrder(fleetId: 'f1', destinationPortProvinceId: '$ow|P1'),
         previousRejected: false,
       );
       expect(result.status, OrderValidationStatus.rejected);
@@ -431,7 +481,11 @@ void main() {
     test('validateNavalMove dock reject when port province not found', () {
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(
+            id: 'sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
         ],
         edges: const [],
       );
@@ -469,60 +523,74 @@ void main() {
       expect(result.reason, 'Port province not found');
     });
 
-    test('validateNavalMove dock reject when sea zone not adjacent to province', () {
-      final topology = MapTopology(
-        nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
-          TopologyNode(id: 'sea2', regionId: ow, type: TopologyNodeType.seaZone),
-          TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
-        ],
-        edges: const [
-          TopologyEdge(id1: 'sea1', id2: 'sea2'),
-          TopologyEdge(id1: 'sea2', id2: 'P1'),
-        ],
-      );
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-          oldWorld: RegionData(
-            provinces: [
-              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
-            ],
-          ),
-          newWorld: const RegionData(),
-          fleets: [
-            Fleet(
-              id: 'f1',
-              ownerId: 'p1',
-              seaZoneId: 'sea1',
+    test(
+      'validateNavalMove dock reject when sea zone not adjacent to province',
+      () {
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'sea1',
               regionId: ow,
-              shipTypeIds: const ['carrack'],
+              type: TopologyNodeType.seaZone,
+            ),
+            TopologyNode(
+              id: 'sea2',
+              regionId: ow,
+              type: TopologyNodeType.seaZone,
+            ),
+            TopologyNode(
+              id: 'P1',
+              regionId: ow,
+              type: TopologyNodeType.province,
             ),
           ],
-        ),
-        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
-      );
-      final validator = NavalOrderValidator(
-        game: game,
-        topology: topology,
-        playerId: 'p1',
-      );
-      final result = validator.validateNavalMove(
-        NavalMoveOrder(
-          fleetId: 'f1',
-          destinationPortProvinceId: '$ow|P1',
-        ),
-        previousRejected: false,
-      );
-      expect(result.status, OrderValidationStatus.rejected);
-      expect(result.reason, 'Invalid naval move');
-    });
+          edges: const [
+            TopologyEdge(id1: 'sea1', id2: 'sea2'),
+            TopologyEdge(id1: 'sea2', id2: 'P1'),
+          ],
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
+            ),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'f1',
+                ownerId: 'p1',
+                seaZoneId: 'sea1',
+                regionId: ow,
+                shipTypeIds: const ['carrack'],
+              ),
+            ],
+          ),
+          players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+        );
+        final validator = NavalOrderValidator(
+          game: game,
+          topology: topology,
+          playerId: 'p1',
+        );
+        final result = validator.validateNavalMove(
+          NavalMoveOrder(fleetId: 'f1', destinationPortProvinceId: '$ow|P1'),
+          previousRejected: false,
+        );
+        expect(result.status, OrderValidationStatus.rejected);
+        expect(result.reason, 'Invalid naval move');
+      },
+    );
 
     test('validateNavalMove accept undock from port to adjacent sea zone', () {
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(
+            id: 'sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
           TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
         ],
         edges: const [TopologyEdge(id1: 'sea1', id2: 'P1')],
@@ -532,9 +600,7 @@ void main() {
         worldState: WorldState(
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
           oldWorld: RegionData(
-            provinces: [
-              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
-            ],
+            provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
           ),
           newWorld: const RegionData(),
           fleets: [
@@ -563,44 +629,226 @@ void main() {
       expect(result.reason, isNull);
     });
 
-    test('validateNavalMove reject when in port but inPortAtProvinceId null', () {
-      final topology = MapTopology(
-        nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
-        ],
-        edges: const [],
-      );
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-          fleets: [
-            Fleet(
-              id: 'f1',
-              ownerId: 'p1',
-              seaZoneId: null,
-              inPortAtProvinceId: null,
+    test(
+      'validateNavalMove at sea rejects province id as destinationSeaZoneId',
+      () {
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'sea1',
               regionId: ow,
-              shipTypeIds: const ['carrack'],
+              type: TopologyNodeType.seaZone,
+            ),
+            TopologyNode(
+              id: 'P1',
+              regionId: ow,
+              type: TopologyNodeType.province,
             ),
           ],
-        ),
-        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
-      );
-      final validator = NavalOrderValidator(
-        game: game,
-        topology: topology,
-        playerId: 'p1',
-      );
-      final result = validator.validateNavalMove(
-        const NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 'sea1'),
-        previousRejected: false,
-      );
-      expect(result.status, OrderValidationStatus.rejected);
-      expect(result.reason, 'Invalid naval move');
-    });
+          edges: const [TopologyEdge(id1: 'sea1', id2: 'P1')],
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'f1',
+                ownerId: 'p1',
+                seaZoneId: 'sea1',
+                regionId: ow,
+                shipTypeIds: const ['carrack'],
+              ),
+            ],
+          ),
+          players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+        );
+        final validator = NavalOrderValidator(
+          game: game,
+          topology: topology,
+          playerId: 'p1',
+        );
+        final result = validator.validateNavalMove(
+          const NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 'P1'),
+          previousRejected: false,
+        );
+        expect(result.status, OrderValidationStatus.rejected);
+        expect(result.reason, 'Invalid naval move');
+      },
+    );
+
+    test(
+      'validateNavalMove in-port accepts any sea with direct P–S edge to port',
+      () {
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'sea1',
+              regionId: ow,
+              type: TopologyNodeType.seaZone,
+            ),
+            TopologyNode(
+              id: 'sea2',
+              regionId: ow,
+              type: TopologyNodeType.seaZone,
+            ),
+            TopologyNode(
+              id: 'P1',
+              regionId: ow,
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: const [
+            TopologyEdge(id1: 'P1', id2: 'sea1'),
+            TopologyEdge(id1: 'P1', id2: 'sea2'),
+          ],
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
+            ),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'f1',
+                ownerId: 'p1',
+                seaZoneId: null,
+                inPortAtProvinceId: '$ow|P1',
+                regionId: ow,
+                shipTypeIds: const ['carrack'],
+              ),
+            ],
+          ),
+          players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+        );
+        final validator = NavalOrderValidator(
+          game: game,
+          topology: topology,
+          playerId: 'p1',
+        );
+        final toSea2 = validator.validateNavalMove(
+          const NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 'sea2'),
+          previousRejected: false,
+        );
+        expect(toSea2.status, OrderValidationStatus.accepted);
+      },
+    );
+
+    test(
+      'validateNavalMove in-port rejects sea only reachable via S–S from port sea',
+      () {
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'sea1',
+              regionId: ow,
+              type: TopologyNodeType.seaZone,
+            ),
+            TopologyNode(
+              id: 'sea2',
+              regionId: ow,
+              type: TopologyNodeType.seaZone,
+            ),
+            TopologyNode(
+              id: 'P1',
+              regionId: ow,
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: const [
+            TopologyEdge(id1: 'P1', id2: 'sea1'),
+            TopologyEdge(id1: 'sea1', id2: 'sea2'),
+          ],
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
+            ),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'f1',
+                ownerId: 'p1',
+                seaZoneId: null,
+                inPortAtProvinceId: '$ow|P1',
+                regionId: ow,
+                shipTypeIds: const ['carrack'],
+              ),
+            ],
+          ),
+          players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+        );
+        final validator = NavalOrderValidator(
+          game: game,
+          topology: topology,
+          playerId: 'p1',
+        );
+        final toSea2 = validator.validateNavalMove(
+          const NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 'sea2'),
+          previousRejected: false,
+        );
+        expect(toSea2.status, OrderValidationStatus.rejected);
+        final toSea1 = validator.validateNavalMove(
+          const NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 'sea1'),
+          previousRejected: false,
+        );
+        expect(toSea1.status, OrderValidationStatus.accepted);
+      },
+    );
+
+    test(
+      'validateNavalMove reject when in port but inPortAtProvinceId null',
+      () {
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'sea1',
+              regionId: ow,
+              type: TopologyNodeType.seaZone,
+            ),
+          ],
+          edges: const [],
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'f1',
+                ownerId: 'p1',
+                seaZoneId: null,
+                inPortAtProvinceId: null,
+                regionId: ow,
+                shipTypeIds: const ['carrack'],
+              ),
+            ],
+          ),
+          players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+        );
+        final validator = NavalOrderValidator(
+          game: game,
+          topology: topology,
+          playerId: 'p1',
+        );
+        final result = validator.validateNavalMove(
+          const NavalMoveOrder(fleetId: 'f1', destinationSeaZoneId: 'sea1'),
+          previousRejected: false,
+        );
+        expect(result.status, OrderValidationStatus.rejected);
+        expect(result.reason, 'Invalid naval move');
+      },
+    );
 
     test('validateNavalMission rejects when previousRejected', () {
       final game = Game(
@@ -638,7 +886,11 @@ void main() {
     test('validateNavalMission blockade requires target province', () {
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(
+            id: 'sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
         ],
         edges: const [],
       );
@@ -680,7 +932,11 @@ void main() {
     test('validateNavalMission blockade reject when target not prefixed', () {
       final topology = MapTopology(
         nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
+          TopologyNode(
+            id: 'sea1',
+            regionId: ow,
+            type: TopologyNodeType.seaZone,
+          ),
         ],
         edges: const [],
       );
@@ -719,88 +975,100 @@ void main() {
       expect(result.reason, 'Blockade requires a target province');
     });
 
-    test('validateNavalMission blockade reject when blockading own province', () {
-      final topology = MapTopology(
-        nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
-        ],
-        edges: const [],
-      );
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-          oldWorld: RegionData(
-            provinces: [
-              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+    test(
+      'validateNavalMission blockade reject when blockading own province',
+      () {
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'sea1',
+              regionId: ow,
+              type: TopologyNodeType.seaZone,
+            ),
+          ],
+          edges: const [],
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: RegionData(
+              provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
+            ),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'f1',
+                ownerId: 'p1',
+                seaZoneId: 'sea1',
+                regionId: ow,
+                shipTypeIds: const ['carrack'],
+              ),
             ],
           ),
-          newWorld: const RegionData(),
-          fleets: [
-            Fleet(
-              id: 'f1',
-              ownerId: 'p1',
-              seaZoneId: 'sea1',
-              regionId: ow,
-              shipTypeIds: const ['carrack'],
-            ),
-          ],
-        ),
-        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
-      );
-      final validator = NavalOrderValidator(
-        game: game,
-        topology: topology,
-        playerId: 'p1',
-      );
-      final result = validator.validateNavalMission(
-        NavalMissionOrder(
-          fleetId: 'f1',
-          mission: FleetMission.blockade.name,
-          targetProvinceId: '$ow|P1',
-        ),
-        previousRejected: false,
-      );
-      expect(result.status, OrderValidationStatus.rejected);
-      expect(result.reason, 'Cannot blockade own province');
-    });
+          players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+        );
+        final validator = NavalOrderValidator(
+          game: game,
+          topology: topology,
+          playerId: 'p1',
+        );
+        final result = validator.validateNavalMission(
+          NavalMissionOrder(
+            fleetId: 'f1',
+            mission: FleetMission.blockade.name,
+            targetProvinceId: '$ow|P1',
+          ),
+          previousRejected: false,
+        );
+        expect(result.status, OrderValidationStatus.rejected);
+        expect(result.reason, 'Cannot blockade own province');
+      },
+    );
 
-    test('validateNavalMission accept non-blockade mission when fleet at sea', () {
-      final topology = MapTopology(
-        nodes: const [
-          TopologyNode(id: 'sea1', regionId: ow, type: TopologyNodeType.seaZone),
-        ],
-        edges: const [],
-      );
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-          fleets: [
-            Fleet(
-              id: 'f1',
-              ownerId: 'p1',
-              seaZoneId: 'sea1',
+    test(
+      'validateNavalMission accept non-blockade mission when fleet at sea',
+      () {
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'sea1',
               regionId: ow,
-              shipTypeIds: const ['carrack'],
+              type: TopologyNodeType.seaZone,
             ),
           ],
-        ),
-        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
-      );
-      final validator = NavalOrderValidator(
-        game: game,
-        topology: topology,
-        playerId: 'p1',
-      );
-      final result = validator.validateNavalMission(
-        const NavalMissionOrder(fleetId: 'f1', mission: 'patrol'),
-        previousRejected: false,
-      );
-      expect(result.status, OrderValidationStatus.accepted);
-      expect(result.reason, isNull);
-    });
+          edges: const [],
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'f1',
+                ownerId: 'p1',
+                seaZoneId: 'sea1',
+                regionId: ow,
+                shipTypeIds: const ['carrack'],
+              ),
+            ],
+          ),
+          players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+        );
+        final validator = NavalOrderValidator(
+          game: game,
+          topology: topology,
+          playerId: 'p1',
+        );
+        final result = validator.validateNavalMission(
+          const NavalMissionOrder(fleetId: 'f1', mission: 'patrol'),
+          previousRejected: false,
+        );
+        expect(result.status, OrderValidationStatus.accepted);
+        expect(result.reason, isNull);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Implements the naval move improvements tracked in #1501:

- **Logic:** Shared `navalMoveTopologyPicksForFleet` with strict **S–S** (at sea), **P–S** (undock), **S–P** (dock). `NavalOrderValidator`, `naval_resolution`, and `suggestNavalMoveOrders` aligned so move-to-sea targets must be sea-zone nodes; in-port undock uses direct port–sea edges only.
- **UI:** Move fleet dialog title uses **Fleet \<id\>** plus **(N destinations)**; sea-zone section lists S–S neighbors only. Naval Units panel shows **Moving to:** from draft `Orders` (wired from `currentOrdersProvider`).
- **SPEC:** `SPEC/ui/naval-units-panel.md` updated for rules, title, and draft line.
- **Tests:** Logic (`naval_test`, `naval_order_validator_test`) and app (`move_fleet_dialog_test`, `naval_units_panel_test` draft subtitle).

## Issue

Refs #1501 (does **not** close the issue; verification can continue there after merge).

## Checklist

- [x] Targets `dev`
- [x] SPEC updated for UI behavior
- [x] Tests added/updated

Made with [Cursor](https://cursor.com)