### PR TITLE
Align region minimap cell size with main map

### DIFF
--- a/SPEC/ui/empire-overview.md
+++ b/SPEC/ui/empire-overview.md
@@ -61,6 +61,8 @@
 
 **Acceptance (minimap):** Given the in-game shell map is visible, when the minimap toggle is on, then the UI shows the active region grid with visibility rules above and a white viewport indicator when the main map has published a matching snapshot. When the user taps the toggle, then the minimap hides or shows for the session only (default on at shell entry). When the user drags on the minimap or the bus emits a pan event for that region, then the main map host remains without exceptions. When the side menu is open, then the minimap stack order keeps it interactive above the scrim.
 
+**Acceptance (minimap ↔ main map):** Given the active region’s `RegionMapViewData.cellSize` matches the main `CtRegionMap` cell size, when the minimap is visible and a viewport snapshot exists for that region, then the white viewport rectangle matches the main map’s visible world area (center and span within tolerance for rounding). When the user taps a point on the minimap, then the main map camera centers on the corresponding world position (clamped). When the user drags on the minimap, then the camera pans in the same direction with world delta consistent with the snapshot’s world scale (same `cellSizePx` / map extents as [map-widget.md](map-widget.md) § Region minimap camera sync).
+
 ---
 
 ## Wireframe (conceptual)

--- a/SPEC/ui/map-widget.md
+++ b/SPEC/ui/map-widget.md
@@ -16,6 +16,7 @@
 ### Region minimap camera sync
 
 - **`CtRegionMap`** may report viewport changes via **`onViewportSnapshotChanged`** (`RegionMapViewportSnapshot`: `regionId`, `cellSizePx`, map world size, camera center, `zoom`, logical viewport width/height). Emitted when the camera changes size, zoom, or center; math matches `_CtRegionMapGame._clampCameraToMap` (same viewport-in-world as hover/tap conversion).
+- **`GameRegionMinimap`** (in-game shell) must use the **same** logical cell size and world extent as **`CtRegionMap`** for that region: `mapWidthWorld` / `mapHeightWorld` = `region.width` × `cellSizePx` and `region.height` × `cellSizePx` with `cellSizePx == RegionMapViewData.cellSize`. If the minimap uses a different `cellSizePx` than the snapshot, the viewport indicator and tap/drag camera mapping will be wrong.
 - The in-game shell may request camera moves using **`RequestRegionMapCameraCenterWorldEvent`** and **`RequestRegionMapCameraPanWorldDeltaEvent`** on the shared **`AppEventBus`**; the map host applies them only when `event.regionId` matches the widget’s `RegionMapViewData.regionId`.
 
 ---

--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -483,7 +483,7 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
                     region: _currentRegion,
                     viewportSnapshot: _regionViewportSnapshot,
                     bus: ref.read(appEventBusProvider),
-                    cellSizePx: 24,
+                    cellSizePx: _currentRegion.cellSize.toDouble(),
                   ),
                 ),
               ],

--- a/app/lib/features/game/flame/game_region_minimap.dart
+++ b/app/lib/features/game/flame/game_region_minimap.dart
@@ -28,6 +28,9 @@ const Color kRegionMinimapSeaColor = Color(0xFF0D47A1);
 const double kRegionMinimapFoggedAlpha = 0.55;
 
 /// Dismissible region minimap (Empire overview). SPEC/ui/empire-overview.md § Region minimap.
+///
+/// [cellSizePx] must match [RegionMapViewData.cellSize] used by the Flame-backed region map for this
+/// region so world↔minimap math matches [RegionMapViewportSnapshot] (see SPEC/ui/map-widget.md).
 class GameRegionMinimap extends ConsumerWidget {
   const GameRegionMinimap({
     required this.region,

--- a/app/test/game_map_area_region_minimap_test.dart
+++ b/app/test/game_map_area_region_minimap_test.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_app/features/game/flame/game_map_area.dart';
+import 'package:colonizethis_app/features/game/flame/game_region_minimap.dart';
 import 'package:colonizethis_app/features/game/flame/game_screen_shared.dart';
 import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
@@ -35,6 +36,13 @@ void main() {
     await tester.pumpAndSettle(const Duration(seconds: 5));
 
     expect(find.byKey(kRegionMinimapCustomPaintKey), findsOneWidget);
+
+    final minimap = tester.widget<GameRegionMinimap>(find.byType(GameRegionMinimap));
+    expect(
+      minimap.cellSizePx,
+      init.mapViewData.oldWorld.cellSize.toDouble(),
+      reason: 'minimap world scale must match CtRegionMap / RegionMapViewportSnapshot',
+    );
 
     await tester.tap(find.byKey(kRegionMinimapToggleKey));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary

The in-game region minimap used a hardcoded `cellSizePx: 24` while `CtRegionMap` uses `region.cellSize` (e.g. 64 from terrain config). Viewport snapshots are emitted in the correct world space; minimap tap/drag and the white viewport rectangle scaled with the wrong map extents, so they did not match the main map.

## Changes

- `GameMapArea`: pass `_currentRegion.cellSize.toDouble()` into `GameRegionMinimap`.
- `GameRegionMinimap`: document that `cellSizePx` must match the Flame map for the region.
- `SPEC/ui/map-widget.md`: state the minimap/main-map `cellSizePx` parity requirement under Region minimap camera sync.
- `SPEC/ui/empire-overview.md`: add acceptance criteria for minimap ↔ main map alignment.
- `game_map_area_region_minimap_test.dart`: assert minimap `cellSizePx` matches debug init region `cellSize`.

## Issue

Refs #1510 (does not close — verification on device welcome).

Made with [Cursor](https://cursor.com)