### PR TITLE
refactor: complete app package cleanups (fixes #1513)

### DIFF
--- a/app/lib/config/constants.dart
+++ b/app/lib/config/constants.dart
@@ -1,3 +1,13 @@
+/// Viewport width threshold in **logical pixels** below which the in-game shell uses
+/// narrow layout (side menu, reduced top bar). SPEC/ui/in-game-shell-narrow.md.
+const double kNarrowBreakpoint = 600;
+
+/// Viewport width threshold in **logical pixels** below which Game Setup uses stacked
+/// slot rows. Intentionally lower than [kNarrowBreakpoint] so setup can stay multi-column
+/// on widths where the in-game shell is already narrow. SPEC/ui/mobile-adaptation.md;
+/// SPEC/ui/game-setup.md.
+const double kGameSetupNarrowBreakpoint = 500;
+
 /// App and Hive constants. TDD 15 Local Storage box names.
 abstract final class HiveBoxNames {
   static const String settings = 'settings';

--- a/app/lib/core/services/app_event_handler.dart
+++ b/app/lib/core/services/app_event_handler.dart
@@ -29,7 +29,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../config/routes.dart';
-import '../../features/game/flame/game_screen_shared.dart';
+import '../../config/constants.dart';
 import '../../features/game/widgets/civilian_units_panel.dart';
 import '../../features/game/widgets/military_units_panel.dart';
 import '../../features/game/widgets/naval_units_panel.dart';
@@ -236,7 +236,7 @@ class AppEventHandler {
           final availableWorkTargets = ref.watch(availableWorkTargetsProvider);
           final bus = ref.watch(appEventBusProvider);
           final isNarrow =
-              MediaQuery.sizeOf(context).width < kInGameNarrowBreakpoint;
+              MediaQuery.sizeOf(context).width < kNarrowBreakpoint;
           final maxHeight =
               MediaQuery.sizeOf(context).height * (isNarrow ? 0.33 : 0.5);
           return ConstrainedBox(

--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -22,6 +22,7 @@ import '../../../../providers/region_minimap_provider.dart';
 import 'region_map_viewport_snapshot.dart';
 import '../../../../providers/home_fleet_cargo_provider.dart';
 
+import '../../../config/constants.dart';
 import 'game_screen_shared.dart';
 import 'game_side_menu.dart';
 import 'game_map_controls.dart';
@@ -293,7 +294,7 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
       mapProvinceOwnershipTintVisibleProvider,
     );
     final showProvinceNames = ref.watch(mapProvinceNamesVisibleProvider);
-    final isNarrow = MediaQuery.sizeOf(context).width < kInGameNarrowBreakpoint;
+    final isNarrow = MediaQuery.sizeOf(context).width < kNarrowBreakpoint;
     final mapTopology = widget.mapViewData.combinedTopology;
     final humanPlayerView = buildPlayerView(
       widget.game,

--- a/app/lib/features/game/flame/game_screen_shared.dart
+++ b/app/lib/features/game/flame/game_screen_shared.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
 
-/// Breakpoint for in-game narrow layout (side menu, reduced top bar). SPEC/ui/in-game-shell-narrow.md.
-const double kInGameNarrowBreakpoint = 600;
-
 /// Key for the base layer cycle button (for tests). SPEC/ui/empire-overview.md § Base layer display cycle.
 const Key kBaseLayerCycleButtonKey = Key('base_layer_cycle_button');
 

--- a/app/lib/features/game/flame/region_map_component.dart
+++ b/app/lib/features/game/flame/region_map_component.dart
@@ -21,6 +21,54 @@ final _log = gameLogger();
 /// Fog overlay opacity when drawing a dark rect over tiles (0 = no overlay, 1 = full black).
 const double _fogOverlayOpacity = 0.4;
 
+/// Work-target valid tiles: opacity baseline in **linear 0–1** before sin pulse.
+const double _kValidWorkTargetGlowOpacityBase = 0.4;
+
+/// Work-target valid tiles: extra opacity added by sin pulse (peak = base + amplitude).
+const double _kValidWorkTargetGlowOpacityAmplitude = 0.4;
+
+/// Work-target pulse speed: sin argument is `t *` this factor ([_hoverAnimationT] domain).
+const double _kValidWorkTargetGlowTimeScale = 3;
+
+/// Hovered-province glow: midpoint opacity for stroke (linear 0–1).
+const double _kHoveredProvinceGlowOpacityMid = 0.5;
+
+/// Hovered-province glow: half-amplitude of sin oscillation (linear 0–1).
+const double _kHoveredProvinceGlowOpacityAmplitude = 0.25;
+
+/// Hovered-province glow: angular frequency (radians per unit [_hoverAnimationT]); one full cycle per t=1.
+const double _kHoveredProvinceGlowAngularFrequency = 6.283185307179586;
+
+/// Capital marker fill and warp-zone accent (gold).
+const Color _kMapSelectionGold = Color(0xFFFFD700);
+
+/// Outer warp-zone glow alpha (linear 0–1) over [_kMapSelectionGold].
+const double _kWarpZoneOuterGlowAlpha = 0.3;
+
+/// Inner warp-zone stroke (bright yellow).
+const Color _kWarpZoneInnerHighlight = Color(0xFFFFEA00);
+
+/// Valid work-target tile stroke (pure yellow channel; alpha applied per frame).
+const Color _kValidWorkTargetStrokeYellow = Color(0xFFFFFF00);
+
+/// Selected tile outline (orange).
+const Color _kMapSelectedHighlightOrange = Color(0xFFFFAA00);
+
+/// Secondary tile highlight outline (cyan).
+const Color _kMapSecondarySelectionCyan = Color(0xFF66D9FF);
+
+/// Hover selector rect: scale baseline (1 = cell fit).
+const double _kHoverSelectorBounceBaseline = 1.0;
+
+/// Hover selector rect: sin amplitude for subtle pulse (visual feedback).
+const double _kHoverSelectorBounceAmplitude = 0.04;
+
+/// Hover selector stroke when not in work-target mode (white).
+const Color _kMapHoverSelectorIdle = Color(0xFFFFFFFF);
+
+/// Normalized midpoint for mapping sin from [-1,1] to [0,1] before scaling opacity.
+const double _kSinNormalizedMid = 0.5;
+
 /// Political border stroke colors.
 /// These are intentionally subtle so they don't overpower the terrain art.
 const Color _provinceBorderLandColor = Color.fromRGBO(0, 0, 0, 0.35);
@@ -381,11 +429,16 @@ class CtRegionMapComponent extends PositionComponent {
     // Flashing yellow border for valid tiles (opacity oscillates 0.4-0.8).
     // SPEC/ui/map-widget.md § Work target selection mode.
     final t = _hoverAnimationT;
-    final opacity = 0.4 + 0.4 * (0.5 + 0.5 * math.sin(t * 3));
+    final opacity =
+        _kValidWorkTargetGlowOpacityBase +
+        _kValidWorkTargetGlowOpacityAmplitude *
+            (_kSinNormalizedMid +
+                _kSinNormalizedMid *
+                    math.sin(t * _kValidWorkTargetGlowTimeScale));
     final paint = Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = kMapValidTileTargetStrokeWidth
-      ..color = Color(0xFFFFFF00).withValues(alpha: opacity);
+      ..color = _kValidWorkTargetStrokeYellow.withValues(alpha: opacity);
     for (var y = 0; y < region.height; y++) {
       for (var x = 0; x < region.width; x++) {
         final cell = region.cellAt(x, y);
@@ -402,7 +455,7 @@ class CtRegionMapComponent extends PositionComponent {
     _paintTileOutlineRing(
       canvas,
       tileKey: selectedTileKey!,
-      color: const Color(0xFFFFAA00),
+      color: _kMapSelectedHighlightOrange,
       strokeWidth: kMapSelectedTileStrokeWidth,
     );
   }
@@ -411,7 +464,7 @@ class CtRegionMapComponent extends PositionComponent {
     _paintTileOutlineRing(
       canvas,
       tileKey: secondaryHighlightTileKey!,
-      color: const Color(0xFF66D9FF),
+      color: _kMapSecondarySelectionCyan,
       strokeWidth: kMapSecondaryHighlightStrokeWidth,
     );
   }
@@ -1134,7 +1187,10 @@ class CtRegionMapComponent extends PositionComponent {
 
   void _paintHoveredProvinceGlow(Canvas canvas) {
     final t = _hoverAnimationT;
-    final opacity = 0.5 + 0.25 * math.sin(t * 2 * math.pi);
+    final opacity =
+        _kHoveredProvinceGlowOpacityMid +
+        _kHoveredProvinceGlowOpacityAmplitude *
+            math.sin(t * _kHoveredProvinceGlowAngularFrequency);
     final coastInset = provinceOverlayLandSeaInsetPx(
       cellSizePx: cellSize,
       topologyStrokeWidth: kProvinceOverlayTopologyStrokeWidth,
@@ -1201,7 +1257,10 @@ class CtRegionMapComponent extends PositionComponent {
   void _paintSelector(Canvas canvas) {
     final x = _hoveredTileX!;
     final y = _hoveredTileY!;
-    final bounce = 1.0 + 0.04 * math.sin(_hoverAnimationT * 2 * math.pi);
+    final bounce =
+        _kHoverSelectorBounceBaseline +
+        _kHoverSelectorBounceAmplitude *
+            math.sin(_hoverAnimationT * _kHoveredProvinceGlowAngularFrequency);
     final cx = x * cellSize + cellSize / 2;
     final cy = y * cellSize + cellSize / 2;
     final half = (cellSize / 2 - 2.0) * bounce;
@@ -1212,8 +1271,8 @@ class CtRegionMapComponent extends PositionComponent {
     // Orange cursor when in work target selection mode; white otherwise.
     // SPEC/ui/map-widget.md § Work target selection mode.
     final color = (validTileKeys != null && validTileKeys!.isNotEmpty)
-        ? const Color(0xFFFFAA00)
-        : const Color(0xFFFFFFFF);
+        ? _kMapSelectedHighlightOrange
+        : _kMapHoverSelectorIdle;
     final paint = Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = kMapHoverSelectorStrokeWidth
@@ -1370,7 +1429,7 @@ class CtRegionMapComponent extends PositionComponent {
       }
       final cx = cap.x * cellSize + cellSize / 2;
       final cy = cap.y * cellSize + cellSize / 2;
-      fill.color = const Color(0xFFFFD700);
+      fill.color = _kMapSelectionGold;
       canvas.drawCircle(Offset(cx, cy), 6, fill);
       canvas.drawCircle(Offset(cx, cy), 6, stroke);
     }
@@ -1475,12 +1534,12 @@ class CtRegionMapComponent extends PositionComponent {
     final glowOuter = Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = kWarpZoneGlowOuterStrokeWidth
-      ..color = const Color(0xFFFFD700).withValues(alpha: 0.3); // gold glow
+      ..color = _kMapSelectionGold.withValues(alpha: _kWarpZoneOuterGlowAlpha);
     // Inner bright border.
     final glowInner = Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = kWarpZoneGlowInnerStrokeWidth
-      ..color = const Color(0xFFFFEA00); // bright yellow
+      ..color = _kWarpZoneInnerHighlight;
 
     for (final (x, y) in warpTiles) {
       final cell = region.cellAt(x, y);

--- a/app/lib/features/game/widgets/military_units_panel.dart
+++ b/app/lib/features/game/widgets/military_units_panel.dart
@@ -1,15 +1,13 @@
 // Military units panel. SPEC/ui/military-units-panel.md, SPEC/ui/military-units-army-management.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
 import '../../../core/services/app_event_handler_scope.dart'
     show trainMilitaryDialogId;
 import '../../../widgets/ct_nine_patch_button.dart';
-import '../utils/map_location_resolver.dart';
-import '../utils/sea_zone_name_resolver.dart';
+import 'utils/military_tree_builder.dart';
 import 'move_army_dialog.dart';
 import 'split_army_dialog.dart';
 import 'units/shared/location_section_header.dart';
@@ -17,361 +15,6 @@ import 'units/shared/region_section_header.dart';
 import 'units/shared/units_panel_region_label.dart';
 import 'units/shared/units_panel_shell.dart';
 
-String _armyStationedProvinceDisplayLabel(Game game, Army army) {
-  final pid = army.stationedProvinceId;
-  final full = ProvinceId.isPrefixed(pid)
-      ? pid
-      : ProvinceId.full(army.regionId, pid);
-  final p = tryGetProvince(game.worldState, full);
-  if (p != null) {
-    return p.displayName ?? p.id;
-  }
-  return full;
-}
-
-/// Pending army move line for Military Units (naval draft move parity).
-String? armyDraftMoveLineForArmy({
-  required Game game,
-  required String humanPlayerId,
-  required String armyId,
-  required Orders draftOrders,
-}) {
-  final moves =
-      draftOrders.armyMoveOrdersByPlayerId[humanPlayerId] ?? const [];
-  for (final o in moves) {
-    if (o.armyId != armyId) continue;
-    final full = resolveToFullProvinceId(game.worldState, o.destinationProvinceId);
-    final p = tryGetProvince(game.worldState, full);
-    final name = p?.displayName ?? p?.id ?? ProvinceId.localIdFrom(full);
-    return 'Moving to: $name';
-  }
-  return null;
-}
-
-/// Fleet mission to display label.
-String _missionLabel(FleetMission m) {
-  switch (m) {
-    case FleetMission.none:
-      return 'None';
-    case FleetMission.patrol:
-      return 'Patrol';
-    case FleetMission.blockade:
-      return 'Blockade';
-    case FleetMission.beachhead:
-      return 'Beachhead';
-    case FleetMission.defend:
-      return 'Defend';
-  }
-}
-
-/// One regiment-type row under an army: type, count, medals, status.
-class _RegimentTypeRow {
-  _RegimentTypeRow({
-    required this.typeId,
-    required this.count,
-    required this.medalsSummary,
-    required this.statusLabel,
-    required this.tileKey,
-    required this.regionId,
-  });
-
-  final String typeId;
-  final int count;
-  final String medalsSummary;
-  final String statusLabel;
-  final String? tileKey;
-  final String regionId;
-}
-
-class _ShipTypeRow {
-  _ShipTypeRow({
-    required this.typeId,
-    required this.count,
-    required this.statusLabel,
-    required this.tileKey,
-    required this.regionId,
-  });
-
-  final String typeId;
-  final int count;
-  final String statusLabel;
-  final String? tileKey;
-  final String regionId;
-}
-
-abstract class _LocationNode {
-  String get displayLabel;
-  String get regionId;
-}
-
-/// Province with one or more armies (land).
-class _ProvinceArmiesNode extends _LocationNode {
-  _ProvinceArmiesNode({required this.province, required this.armies});
-
-  final Province province;
-  final List<_ArmyBlock> armies;
-
-  @override
-  String get displayLabel => province.displayName ?? province.id;
-
-  @override
-  String get regionId => province.regionId;
-}
-
-class _ArmyBlock {
-  _ArmyBlock({required this.army, required this.rows, required this.regionKey});
-
-  final Army army;
-  final List<_RegimentTypeRow> rows;
-
-  /// Panel region key: `oldWorld` / `newWorld` (matches [TileMapResult] regions).
-  final String regionKey;
-}
-
-class _SeaZoneLocationNode extends _LocationNode {
-  _SeaZoneLocationNode({
-    required this.seaZoneLabel,
-    required this.regionId,
-    required this.rows,
-  });
-
-  final String seaZoneLabel;
-  @override
-  final String regionId;
-  final List<_ShipTypeRow> rows;
-
-  @override
-  String get displayLabel => seaZoneLabel;
-}
-
-class _RegionMilitaryGroup {
-  _RegionMilitaryGroup({
-    required this.regionKey,
-    required this.provinces,
-    required this.seaLocations,
-  });
-
-  final String regionKey;
-  final List<_ProvinceArmiesNode> provinces;
-  final List<_SeaZoneLocationNode> seaLocations;
-}
-
-List<_RegimentTypeRow> _rowsForArmyUnits(
-  Game game,
-  Province province,
-  List<Unit> units,
-  String regionKey,
-) {
-  final tileKey = tileKeyForProvinceLocation(game, province);
-  final byType = <String, List<Unit>>{};
-  for (final u in units) {
-    byType.putIfAbsent(u.type, () => []).add(u);
-  }
-  final typeIds = byType.keys.toList()..sort();
-  final rows = <_RegimentTypeRow>[];
-  for (final typeId in typeIds) {
-    final list = byType[typeId]!;
-    final medals = list.map((u) => u.medals).toSet();
-    final medalsSummary = medals.length == 1
-        ? '${medals.single}'
-        : '${medals.reduce((a, b) => a < b ? a : b)}–${medals.reduce((a, b) => a > b ? a : b)}';
-    final status = list.any((u) => u.status == UnitStatus.working)
-        ? UnitStatus.working
-        : list.any((u) => u.status == UnitStatus.done)
-        ? UnitStatus.done
-        : UnitStatus.idle;
-    final statusLabel = switch (status) {
-      UnitStatus.idle => 'Idle',
-      UnitStatus.working => 'Working',
-      UnitStatus.done => 'Done',
-    };
-    rows.add(
-      _RegimentTypeRow(
-        typeId: typeId,
-        count: list.length,
-        medalsSummary: medalsSummary,
-        statusLabel: statusLabel,
-        tileKey: tileKey,
-        regionId: regionKey,
-      ),
-    );
-  }
-  return rows;
-}
-
-List<_RegionMilitaryGroup> _buildMilitaryGroups(
-  Game game,
-  String humanPlayerId,
-) {
-  final unitsById = <String, Unit>{
-    for (final u in game.worldState.oldWorld.units) u.id: u,
-    for (final u in game.worldState.newWorld.units) u.id: u,
-  };
-
-  final armies =
-      game.worldState.armies
-          .where((a) => a.ownerId == humanPlayerId)
-          .where((a) => a.isHomeArmy || a.regimentUnitIds.isNotEmpty)
-          .toList()
-        ..sort((a, b) {
-          if (a.isHomeArmy != b.isHomeArmy) {
-            return a.isHomeArmy ? -1 : 1;
-          }
-          return a.id.compareTo(b.id);
-        });
-
-  final result = <_RegionMilitaryGroup>[];
-
-  for (final regionEntry in {
-    'oldWorld': game.worldState.oldWorld,
-    'newWorld': game.worldState.newWorld,
-  }.entries) {
-    final regionKey = regionEntry.key;
-    final regionData = regionEntry.value;
-
-    final provinceById = {
-      for (final p in regionData.provinces) '${p.regionId}|${p.id}': p,
-      for (final p in regionData.provinces) p.id: p,
-    };
-
-    final armiesHere = armies.where((a) {
-      final full = ProvinceId.isPrefixed(a.stationedProvinceId)
-          ? a.stationedProvinceId
-          : ProvinceId.full(regionKey, a.stationedProvinceId);
-      final p = tryGetProvince(game.worldState, full);
-      return p != null && p.regionId == regionKey;
-    }).toList();
-
-    final byProvince = <String, List<Army>>{};
-    for (final a in armiesHere) {
-      final pid = a.stationedProvinceId;
-      final full = ProvinceId.isPrefixed(pid)
-          ? pid
-          : ProvinceId.full(regionKey, pid);
-      byProvince.putIfAbsent(full, () => []).add(a);
-    }
-
-    final provinceNodes = <_ProvinceArmiesNode>[];
-    final provinceIds = byProvince.keys.toList()..sort();
-    for (final fullProvinceId in provinceIds) {
-      final province = provinceById[fullProvinceId];
-      if (province == null) continue;
-      final list = byProvince[fullProvinceId]!;
-      final blocks = <_ArmyBlock>[];
-      for (final army in list) {
-        final regUnits = <Unit>[
-          for (final id in army.regimentUnitIds)
-            if (unitsById[id] != null) unitsById[id]!,
-        ];
-        blocks.add(
-          _ArmyBlock(
-            army: army,
-            rows: _rowsForArmyUnits(game, province, regUnits, regionKey),
-            regionKey: regionKey,
-          ),
-        );
-      }
-      provinceNodes.add(
-        _ProvinceArmiesNode(province: province, armies: blocks),
-      );
-    }
-
-    final fleetsInRegion = game.worldState.fleets
-        .where(
-          (f) =>
-              f.ownerId == humanPlayerId &&
-              f.regionId == regionKey &&
-              f.shipTypeIds.isNotEmpty &&
-              f.isAtSea &&
-              f.seaZoneId != null,
-        )
-        .toList();
-    final bySeaZone = <String, List<Fleet>>{};
-    for (final f in fleetsInRegion) {
-      final seaZoneId = f.seaZoneId!;
-      final zoneKey = seaZoneId.contains('|')
-          ? seaZoneId
-          : '$regionKey|$seaZoneId';
-      bySeaZone.putIfAbsent(zoneKey, () => []).add(f);
-    }
-
-    final seaLocations = <_SeaZoneLocationNode>[];
-    final seaZoneKeys = bySeaZone.keys.toList()..sort();
-    for (final zoneKey in seaZoneKeys) {
-      final fleets = bySeaZone[zoneKey]!;
-      final shipTypeIds = <String, int>{};
-      FleetMission? mission;
-      for (final f in fleets) {
-        for (final typeId in f.shipTypeIds) {
-          shipTypeIds[typeId] = (shipTypeIds[typeId] ?? 0) + 1;
-        }
-        mission ??= f.mission;
-      }
-      final zoneLabel = seaZoneDisplayName(
-        game: game,
-        regionId: regionKey,
-        seaZoneId: zoneKey,
-      );
-      final tileKey = tileKeyForSeaZoneLocation(game, regionKey, zoneKey);
-      final rows = <_ShipTypeRow>[];
-      for (final typeId in shipTypeIds.keys.toList()..sort()) {
-        rows.add(
-          _ShipTypeRow(
-            typeId: typeId,
-            count: shipTypeIds[typeId]!,
-            statusLabel: _missionLabel(mission ?? FleetMission.none),
-            tileKey: tileKey,
-            regionId: regionKey,
-          ),
-        );
-      }
-      seaLocations.add(
-        _SeaZoneLocationNode(
-          seaZoneLabel: zoneLabel,
-          regionId: regionKey,
-          rows: rows,
-        ),
-      );
-    }
-
-    if (provinceNodes.isNotEmpty || seaLocations.isNotEmpty) {
-      result.add(
-        _RegionMilitaryGroup(
-          regionKey: regionKey,
-          provinces: provinceNodes,
-          seaLocations: seaLocations,
-        ),
-      );
-    }
-  }
-
-  return result;
-}
-
-List<_ArmyBlock> _flattenArmies(List<_RegionMilitaryGroup> groups) {
-  final out = <_ArmyBlock>[];
-  for (final g in groups) {
-    for (final p in g.provinces) {
-      out.addAll(p.armies);
-    }
-  }
-  return out;
-}
-
-bool _canCombineArmySelection(
-  List<_ArmyBlock> flat,
-  Set<String> selectedArmyIds,
-) {
-  if (selectedArmyIds.length < 2) return false;
-  final selected = flat
-      .where((b) => selectedArmyIds.contains(b.army.id))
-      .toList();
-  if (selected.length < 2) return false;
-  final province = selected.first.army.stationedProvinceId;
-  return selected.every((b) => b.army.stationedProvinceId == province);
-}
-
-/// Panel that lists armies (land) and ships (sea) for the human player.
 class MilitaryUnitsPanel extends StatefulWidget {
   const MilitaryUnitsPanel({
     super.key,
@@ -405,7 +48,7 @@ class _MilitaryUnitsPanelState extends State<MilitaryUnitsPanel> {
     });
   }
 
-  bool? _headerSelectAllValue(List<_ArmyBlock> flat) {
+  bool? _headerSelectAllValue(List<ArmyBlock> flat) {
     if (flat.isEmpty) return false;
     final n = flat.length;
     final sel = _selectedArmyIds.length;
@@ -414,7 +57,7 @@ class _MilitaryUnitsPanelState extends State<MilitaryUnitsPanel> {
     return null;
   }
 
-  void _onHeaderSelectAllTapped(List<_ArmyBlock> flat) {
+  void _onHeaderSelectAllTapped(List<ArmyBlock> flat) {
     setState(() {
       final allSelected =
           flat.isNotEmpty &&
@@ -429,8 +72,8 @@ class _MilitaryUnitsPanelState extends State<MilitaryUnitsPanel> {
     });
   }
 
-  void _performCombine(List<_ArmyBlock> flat) {
-    if (!_canCombineArmySelection(flat, _selectedArmyIds)) return;
+  void _performCombine(List<ArmyBlock> flat) {
+    if (!canCombineArmySelection(flat, _selectedArmyIds)) return;
     final ids = _selectedArmyIds.toList()..sort();
     widget.bus.emit(
       ArmyCombineRequestedEvent(
@@ -441,7 +84,7 @@ class _MilitaryUnitsPanelState extends State<MilitaryUnitsPanel> {
     setState(() => _selectedArmyIds.clear());
   }
 
-  void _openSplitDialog(_ArmyBlock block) {
+  void _openSplitDialog(ArmyBlock block) {
     showDialog<void>(
       context: context,
       builder: (ctx) => SplitArmyDialog(
@@ -454,7 +97,7 @@ class _MilitaryUnitsPanelState extends State<MilitaryUnitsPanel> {
     );
   }
 
-  void _openMoveDialog(_ArmyBlock block) {
+  void _openMoveDialog(ArmyBlock block) {
     showDialog<void>(
       context: context,
       builder: (ctx) => MoveArmyDialog(
@@ -470,10 +113,10 @@ class _MilitaryUnitsPanelState extends State<MilitaryUnitsPanel> {
 
   @override
   Widget build(BuildContext context) {
-    final groups = _buildMilitaryGroups(widget.game, widget.humanPlayerId);
-    final flat = _flattenArmies(groups);
+    final groups = buildMilitaryGroups(widget.game, widget.humanPlayerId);
+    final flat = flattenMilitaryArmyBlocks(groups);
     final hasAny = groups.isNotEmpty;
-    final canCombine = _canCombineArmySelection(flat, _selectedArmyIds);
+    final canCombine = canCombineArmySelection(flat, _selectedArmyIds);
     final headerCheckbox = _headerSelectAllValue(flat);
 
     return UnitsPanelShell(
@@ -524,7 +167,7 @@ class _MilitaryUnitsPanelState extends State<MilitaryUnitsPanel> {
               _ArmyExpansionTile(
                 block: block,
                 stationedProvinceDisplayLabel:
-                    _armyStationedProvinceDisplayLabel(widget.game, block.army),
+                    armyStationedProvinceDisplayLabel(widget.game, block.army),
                 draftArmyMoveLine: armyDraftMoveLineForArmy(
                   game: widget.game,
                   humanPlayerId: widget.humanPlayerId,
@@ -600,7 +243,7 @@ class _ArmyExpansionTile extends StatelessWidget {
     this.onMove,
   });
 
-  final _ArmyBlock block;
+  final ArmyBlock block;
   final String stationedProvinceDisplayLabel;
   final String? draftArmyMoveLine;
   final bool isSelectedForCombine;
@@ -694,7 +337,7 @@ class _ArmyExpansionTile extends StatelessWidget {
 class _RegimentRow extends StatelessWidget {
   const _RegimentRow({required this.row, this.onTap});
 
-  final _RegimentTypeRow row;
+  final RegimentTypeRow row;
   final VoidCallback? onTap;
 
   @override
@@ -716,7 +359,7 @@ class _RegimentRow extends StatelessWidget {
 class _ShipRow extends StatelessWidget {
   const _ShipRow({required this.row, this.onTap});
 
-  final _ShipTypeRow row;
+  final MilitarySeaShipRow row;
   final VoidCallback? onTap;
 
   @override

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -1,450 +1,18 @@
 // Naval units panel. SPEC/ui/naval-units-panel.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show homeFleetIdFor, regionIdForSeaZone, tryGetProvince;
+import 'package:colonizethis_logic/colonizethis_logic.dart' show homeFleetIdFor;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
 import '../../../widgets/ct_nine_patch_button.dart';
-import '../utils/map_location_resolver.dart';
-import '../utils/sea_zone_name_resolver.dart';
+import 'utils/naval_tree_builder.dart';
 import 'move_fleet_dialog.dart';
 import 'split_fleet_dialog.dart';
 import 'units/shared/location_section_header.dart';
 import 'units/shared/region_section_header.dart';
 import 'units/shared/units_panel_region_label.dart';
 import 'units/shared/units_panel_shell.dart';
-
-String? navalDraftMoveLineForFleet({
-  required Game game,
-  required MapTopology topology,
-  required String humanPlayerId,
-  required String fleetRegionId,
-  required String fleetId,
-  required Orders draftOrders,
-}) {
-  final moves =
-      draftOrders.navalMoveOrdersByPlayerId[humanPlayerId] ?? const [];
-  for (final o in moves) {
-    if (o.fleetId != fleetId) continue;
-    if (o.isDock) {
-      final pid = o.destinationPortProvinceId!;
-      final p = tryGetProvince(game.worldState, pid);
-      final name = p?.displayName ?? p?.id ?? pid;
-      return 'Moving to: $name (dock)';
-    }
-    final z = o.destinationSeaZoneId!;
-    final zReg = regionIdForSeaZone(topology, z) ?? fleetRegionId;
-    final zoneKey = z.contains('|') ? z : '$zReg|$z';
-    final label = seaZoneDisplayName(
-      game: game,
-      regionId: zReg,
-      seaZoneId: zoneKey,
-    );
-    return 'Moving to: $label';
-  }
-  return null;
-}
-
-String _missionLabel(FleetMission m) {
-  switch (m) {
-    case FleetMission.none:
-      return 'None';
-    case FleetMission.patrol:
-      return 'Patrol';
-    case FleetMission.blockade:
-      return 'Blockade';
-    case FleetMission.beachhead:
-      return 'Beachhead';
-    case FleetMission.defend:
-      return 'Defend';
-  }
-}
-
-class _FleetRow {
-  _FleetRow({
-    required this.fleetId,
-    required this.label,
-    required this.locationLabel,
-    required this.regionId,
-    required this.missionLabel,
-    required this.totalShips,
-    required this.warshipCount,
-    required this.merchantCount,
-    required this.strength,
-    required this.tileKey,
-    required this.isHomeFleet,
-    required this.shipCountsByType,
-    required this.cargoCapacity,
-    required this.isAtSea,
-    required this.locationKey,
-    this.inPortAtProvinceId,
-    this.seaZoneId,
-    this.draftNavalMoveLine,
-  });
-
-  final String fleetId;
-  final String label;
-  final String locationLabel;
-  final String regionId;
-  final String missionLabel;
-  final int totalShips;
-  final int warshipCount;
-  final int merchantCount;
-  final double strength;
-  final String? tileKey;
-  final bool isHomeFleet;
-  final Map<String, int> shipCountsByType;
-  final int cargoCapacity;
-  final bool isAtSea;
-  final String locationKey;
-  final String? inPortAtProvinceId;
-  final String? seaZoneId;
-  final String? draftNavalMoveLine;
-}
-
-abstract class _FleetLocationNode {
-  String get displayLabel;
-  String get regionId;
-  List<_FleetRow> get fleets;
-}
-
-class _PortLocationNode extends _FleetLocationNode {
-  _PortLocationNode({required this.province, required this.fleets});
-
-  final Province province;
-
-  @override
-  final List<_FleetRow> fleets;
-
-  @override
-  String get displayLabel => province.displayName ?? province.id;
-
-  @override
-  String get regionId => province.regionId;
-}
-
-class _SeaZoneLocationNode extends _FleetLocationNode {
-  _SeaZoneLocationNode({
-    required this.seaZoneLabel,
-    required this.regionId,
-    required this.fleets,
-  });
-
-  final String seaZoneLabel;
-
-  @override
-  final String regionId;
-
-  @override
-  final List<_FleetRow> fleets;
-
-  @override
-  String get displayLabel => seaZoneLabel;
-}
-
-List<_FleetRow> _flattenTree(
-  List<
-    ({
-      String regionId,
-      _FleetRow? homeFleet,
-      List<_FleetLocationNode> locations,
-    })
-  >
-  tree,
-) {
-  final rows = <_FleetRow>[];
-  for (final group in tree) {
-    if (group.homeFleet != null) {
-      rows.add(group.homeFleet!);
-    }
-    for (final loc in group.locations) {
-      rows.addAll(loc.fleets);
-    }
-  }
-  return rows;
-}
-
-List<
-  ({String regionId, _FleetRow? homeFleet, List<_FleetLocationNode> locations})
->
-_buildNavalTree(
-  Game game,
-  String humanPlayerId,
-  MapTopology topology,
-  Orders draftOrders,
-) {
-  final player = game.players.firstWhere(
-    (p) => p.id == humanPlayerId,
-    orElse: () => game.players.first,
-  );
-  final capitalTile = player.capitalTile;
-  String? capitalRegionId;
-  String? capitalProvinceLocalId;
-  if (capitalTile != null) {
-    final tileKey = capitalTile.toTileKey();
-    final parts = tileKey.split('|');
-    if (parts.length >= 2) {
-      capitalRegionId = parts[0];
-      capitalProvinceLocalId = parts[1];
-    }
-  }
-
-  final result =
-      <
-        ({
-          String regionId,
-          _FleetRow? homeFleet,
-          List<_FleetLocationNode> locations,
-        })
-      >[];
-
-  final provinceByRegionAndId = <String, Map<String, Province>>{
-    'oldWorld': {
-      for (final p in game.worldState.oldWorld.provinces)
-        '${p.regionId}|${p.id}': p,
-      for (final p in game.worldState.oldWorld.provinces) p.id: p,
-    },
-    'newWorld': {
-      for (final p in game.worldState.newWorld.provinces)
-        '${p.regionId}|${p.id}': p,
-      for (final p in game.worldState.newWorld.provinces) p.id: p,
-    },
-  };
-
-  bool _isMerchant(String typeId) {
-    final stats = NavalStatsCatalog.get(typeId);
-    return stats.cargoHold > 0;
-  }
-
-  double _shipStrength(String typeId) {
-    final stats = NavalStatsCatalog.get(typeId);
-    final durability = stats.hull * (1 + stats.armour / 10.0);
-    return stats.firepower * 1.0 +
-        stats.range * 0.4 +
-        stats.movement * 0.1 +
-        durability;
-  }
-
-  for (final regionEntry in {
-    'oldWorld': game.worldState.oldWorld,
-    'newWorld': game.worldState.newWorld,
-  }.entries) {
-    final regionId = regionEntry.key;
-
-    final fleetsInRegion = game.worldState.fleets
-        .where(
-          (f) =>
-              f.ownerId == humanPlayerId &&
-              f.regionId == regionId &&
-              f.shipTypeIds.isNotEmpty,
-        )
-        .toList();
-    if (fleetsInRegion.isEmpty && capitalRegionId != regionId) {
-      continue;
-    }
-
-    _FleetRow? homeFleetRow;
-    final ports = <String, List<_FleetRow>>{};
-    final seas = <String, List<_FleetRow>>{};
-
-    for (final fleet in fleetsInRegion) {
-      final isAtSea = fleet.isAtSea && fleet.seaZoneId != null;
-      final inPortId = fleet.inPortAtProvinceId;
-
-      final shipCounts = <String, int>{};
-      int totalShips = 0;
-      int warships = 0;
-      int merchants = 0;
-      int cargoCapacity = 0;
-      double strength = 0;
-      for (final typeId in fleet.shipTypeIds) {
-        shipCounts[typeId] = (shipCounts[typeId] ?? 0) + 1;
-        totalShips += 1;
-        final stats = NavalStatsCatalog.get(typeId);
-        cargoCapacity += stats.cargoHold;
-        strength += _shipStrength(typeId);
-        if (_isMerchant(typeId)) {
-          merchants += 1;
-        } else {
-          warships += 1;
-        }
-      }
-
-      final atPlayerCapitalPort =
-          capitalRegionId != null &&
-          capitalProvinceLocalId != null &&
-          !isAtSea &&
-          regionId == capitalRegionId &&
-          inPortId != null &&
-          (inPortId == capitalProvinceLocalId ||
-              inPortId == '$capitalRegionId|$capitalProvinceLocalId');
-      final isHomeFleet =
-          fleet.id == homeFleetIdFor(humanPlayerId) && atPlayerCapitalPort;
-
-      String locationLabel;
-      String? tileKey;
-      String locationKey;
-      if (isAtSea) {
-        final seaZoneId = fleet.seaZoneId!;
-        final zoneKey = seaZoneId.contains('|')
-            ? seaZoneId
-            : '$regionId|$seaZoneId';
-        final zoneLabel = seaZoneDisplayName(
-          game: game,
-          regionId: regionId,
-          seaZoneId: zoneKey,
-        );
-        locationLabel = '${unitsPanelRegionLabel(regionId)} — $zoneLabel';
-        tileKey = tileKeyForSeaZoneLocation(game, regionId, zoneKey);
-        locationKey = 'sea:$zoneKey';
-        final row = _FleetRow(
-          fleetId: fleet.id,
-          label: 'Fleet ${fleet.id}',
-          locationLabel: locationLabel,
-          regionId: regionId,
-          missionLabel: _missionLabel(fleet.mission),
-          totalShips: totalShips,
-          warshipCount: warships,
-          merchantCount: merchants,
-          strength: strength,
-          tileKey: tileKey,
-          isHomeFleet: isHomeFleet,
-          shipCountsByType: shipCounts,
-          cargoCapacity: cargoCapacity,
-          isAtSea: true,
-          locationKey: locationKey,
-          seaZoneId: zoneKey,
-          draftNavalMoveLine: navalDraftMoveLineForFleet(
-            game: game,
-            topology: topology,
-            humanPlayerId: humanPlayerId,
-            fleetRegionId: regionId,
-            fleetId: fleet.id,
-            draftOrders: draftOrders,
-          ),
-        );
-        seas.putIfAbsent(zoneKey, () => []).add(row);
-      } else if (inPortId != null) {
-        final provinceMap = provinceByRegionAndId[regionId] ?? const {};
-        final province =
-            provinceMap['$regionId|$inPortId'] ?? provinceMap[inPortId];
-        if (province == null) continue;
-        tileKey = tileKeyForProvinceLocation(game, province);
-        locationLabel =
-            '${unitsPanelRegionLabel(regionId)} — ${province.displayName ?? province.id}';
-        locationKey = 'port:${province.regionId}|${province.id}';
-        final row = _FleetRow(
-          fleetId: fleet.id,
-          label: isHomeFleet ? 'Home Fleet' : 'Fleet ${fleet.id}',
-          locationLabel: locationLabel,
-          regionId: regionId,
-          missionLabel: _missionLabel(fleet.mission),
-          totalShips: totalShips,
-          warshipCount: warships,
-          merchantCount: merchants,
-          strength: strength,
-          tileKey: tileKey,
-          isHomeFleet: isHomeFleet,
-          shipCountsByType: shipCounts,
-          cargoCapacity: cargoCapacity,
-          isAtSea: false,
-          locationKey: locationKey,
-          inPortAtProvinceId: inPortId,
-          draftNavalMoveLine: isHomeFleet
-              ? null
-              : navalDraftMoveLineForFleet(
-                  game: game,
-                  topology: topology,
-                  humanPlayerId: humanPlayerId,
-                  fleetRegionId: regionId,
-                  fleetId: fleet.id,
-                  draftOrders: draftOrders,
-                ),
-        );
-        if (isHomeFleet) {
-          homeFleetRow = row;
-        } else {
-          final fullProvinceId = '${province.regionId}|${province.id}';
-          ports.putIfAbsent(fullProvinceId, () => []).add(row);
-        }
-      }
-    }
-
-    if (capitalRegionId == regionId &&
-        capitalProvinceLocalId != null &&
-        homeFleetRow == null) {
-      final provinceMap = provinceByRegionAndId[regionId] ?? const {};
-      final province =
-          provinceMap['$capitalRegionId|$capitalProvinceLocalId'] ??
-          provinceMap[capitalProvinceLocalId];
-      if (province != null) {
-        final tileKey = tileKeyForProvinceLocation(game, province);
-        final locationLabel =
-            '${unitsPanelRegionLabel(regionId)} — ${province.displayName ?? province.id}';
-        homeFleetRow = _FleetRow(
-          fleetId: homeFleetIdFor(humanPlayerId),
-          label: 'Home Fleet',
-          locationLabel: locationLabel,
-          regionId: regionId,
-          missionLabel: _missionLabel(FleetMission.none),
-          totalShips: 0,
-          warshipCount: 0,
-          merchantCount: 0,
-          strength: 0,
-          tileKey: tileKey,
-          isHomeFleet: true,
-          shipCountsByType: const {},
-          cargoCapacity: 0,
-          isAtSea: false,
-          locationKey: 'port:${province.regionId}|${province.id}',
-          inPortAtProvinceId: '$capitalRegionId|$capitalProvinceLocalId',
-          draftNavalMoveLine: null,
-        );
-      }
-    }
-
-    final locations = <_FleetLocationNode>[];
-
-    final provinceIds = ports.keys.toList()..sort();
-    for (final fullProvinceId in provinceIds) {
-      final provinceMap = provinceByRegionAndId[regionId] ?? const {};
-      final province = provinceMap[fullProvinceId];
-      if (province == null) continue;
-      final fleets = ports[fullProvinceId]!
-        ..sort((a, b) => a.label.compareTo(b.label));
-      locations.add(_PortLocationNode(province: province, fleets: fleets));
-    }
-
-    final seaZoneKeys = seas.keys.toList()..sort();
-    for (final zoneKey in seaZoneKeys) {
-      final zoneLabel = seaZoneDisplayName(
-        game: game,
-        regionId: regionId,
-        seaZoneId: zoneKey,
-      );
-      final fleets = seas[zoneKey]!..sort((a, b) => a.label.compareTo(b.label));
-      locations.add(
-        _SeaZoneLocationNode(
-          seaZoneLabel: zoneLabel,
-          regionId: regionId,
-          fleets: fleets,
-        ),
-      );
-    }
-
-    if (homeFleetRow != null || locations.isNotEmpty) {
-      result.add((
-        regionId: regionId,
-        homeFleet: homeFleetRow,
-        locations: locations,
-      ));
-    }
-  }
-
-  return result;
-}
 
 class NavalUnitsPanel extends StatefulWidget {
   const NavalUnitsPanel({
@@ -470,13 +38,13 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
   final Set<String> _selectedFleetIds = {};
 
   /// Canonical fleet id for combine/split selection (Home Fleet uses [homeFleetIdFor]).
-  String _selectionFleetId(_FleetRow row) {
+  String _selectionFleetId(FleetRow row) {
     if (row.isHomeFleet) return homeFleetIdFor(widget.humanPlayerId);
     return row.fleetId;
   }
 
-  bool _canCombineSelection(List<_FleetRow> flat) {
-    final rowsById = <String, _FleetRow>{
+  bool _canCombineSelection(List<FleetRow> flat) {
+    final rowsById = <String, FleetRow>{
       for (final r in flat) _selectionFleetId(r): r,
     };
     final activeIds = _selectedFleetIds.where(rowsById.containsKey).toList();
@@ -490,7 +58,7 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
     return true;
   }
 
-  String _combineTargetFleetId(List<_FleetRow> flat, Set<String> selected) {
+  String _combineTargetFleetId(List<FleetRow> flat, Set<String> selected) {
     for (final row in flat) {
       final id = _selectionFleetId(row);
       if (!selected.contains(id)) continue;
@@ -503,7 +71,7 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
     throw StateError('combine target: empty selection');
   }
 
-  Fleet? _fleetForRow(_FleetRow row) {
+  Fleet? _fleetForRow(FleetRow row) {
     final id = _selectionFleetId(row);
     for (final f in widget.game.worldState.fleets) {
       if (f.id == id) return f;
@@ -523,7 +91,7 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
     return null;
   }
 
-  void _toggleFleetSelection(_FleetRow row) {
+  void _toggleFleetSelection(FleetRow row) {
     setState(() {
       final id = _selectionFleetId(row);
       if (_selectedFleetIds.contains(id)) {
@@ -534,7 +102,7 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
     });
   }
 
-  bool? _headerSelectAllValue(List<_FleetRow> flat) {
+  bool? _headerSelectAllValue(List<FleetRow> flat) {
     if (flat.isEmpty) return false;
     final ids = flat.map(_selectionFleetId).toSet();
     var n = 0;
@@ -548,7 +116,7 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
 
   /// Select-all header: from none or partial → select every row; from all → clear.
   /// Does not rely on [Checkbox] tristate `next` (indeterminate taps may pass false).
-  void _onHeaderSelectAllTapped(List<_FleetRow> flat) {
+  void _onHeaderSelectAllTapped(List<FleetRow> flat) {
     setState(() {
       final ids = flat.map(_selectionFleetId).toSet();
       final allSelected =
@@ -563,13 +131,13 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
     });
   }
 
-  void _performCombine(List<_FleetRow> flat) {
+  void _performCombine(List<FleetRow> flat) {
     if (!_canCombineSelection(flat)) return;
 
     final selected = Set<String>.from(_selectedFleetIds);
     final targetId = _combineTargetFleetId(flat, selected);
 
-    _FleetRow? targetRow;
+    FleetRow? targetRow;
     for (final row in flat) {
       if (_selectionFleetId(row) == targetId) {
         targetRow = row;
@@ -621,8 +189,8 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.game != widget.game ||
         oldWidget.draftOrders != widget.draftOrders) {
-      final flat = _flattenTree(
-        _buildNavalTree(
+      final flat = flattenNavalTree(
+        buildNavalTree(
           widget.game,
           widget.humanPlayerId,
           widget.topology,
@@ -644,7 +212,7 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
     }
   }
 
-  void _openSplitDialog(_FleetRow row) {
+  void _openSplitDialog(FleetRow row) {
     final id = _selectionFleetId(row);
     Fleet? fleet;
     for (final f in widget.game.worldState.fleets) {
@@ -668,7 +236,7 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
     );
   }
 
-  void _openMoveFleetDialog(_FleetRow row) {
+  void _openMoveFleetDialog(FleetRow row) {
     if (row.isHomeFleet) return;
     Fleet? fleet;
     for (final f in widget.game.worldState.fleets) {
@@ -693,13 +261,13 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
 
   @override
   Widget build(BuildContext context) {
-    final tree = _buildNavalTree(
+    final tree = buildNavalTree(
       widget.game,
       widget.humanPlayerId,
       widget.topology,
       widget.draftOrders,
     );
-    final flat = _flattenTree(tree);
+    final flat = flattenNavalTree(tree);
     final hasAny = tree.any(
       (group) => group.homeFleet != null || group.locations.isNotEmpty,
     );
@@ -799,7 +367,7 @@ class _FleetExpansionTile extends StatelessWidget {
     this.isSplitAllowed = false,
   });
 
-  final _FleetRow row;
+  final FleetRow row;
   final VoidCallback? onTap;
   final bool isSelectedForCombine;
   final VoidCallback onCombineSelectionToggle;

--- a/app/lib/features/game/widgets/production_panel.dart
+++ b/app/lib/features/game/widgets/production_panel.dart
@@ -3,7 +3,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
-import '../flame/game_screen_shared.dart';
+import '../../../config/constants.dart';
 import '../production_recipe_affordance.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/ct_panel.dart';
@@ -57,7 +57,7 @@ class ProductionPanel extends StatelessWidget {
     );
     final inputCommodityIds = _inputCommodityIds;
     final outputCommodityIds = _outputCommodityIds;
-    final isNarrow = MediaQuery.sizeOf(context).width < kInGameNarrowBreakpoint;
+    final isNarrow = MediaQuery.sizeOf(context).width < kNarrowBreakpoint;
 
     if (isNarrow) {
       return SingleChildScrollView(

--- a/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
+++ b/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
@@ -19,7 +19,7 @@ import 'package:colonizethis_app/widgets/ct_tab_strip.dart';
 import 'package:colonizethis_app/widgets/resource_icon.dart';
 import 'package:flutter/material.dart';
 
-import '../flame/game_screen_shared.dart';
+import '../../../config/constants.dart';
 import '../utils/sea_zone_name_resolver.dart';
 
 /// Overlay showing province or sea zone details. Toggleable; responsive; max 1/3 screen.
@@ -62,7 +62,7 @@ class ProvinceSeaZoneDetailOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isNarrow = MediaQuery.sizeOf(context).width < kInGameNarrowBreakpoint;
+    final isNarrow = MediaQuery.sizeOf(context).width < kNarrowBreakpoint;
     final content = _isSeaZone(displayId)
         ? _seaZoneContent(game: game, region: region, seaZoneId: displayId)
         : _provinceContent(

--- a/app/lib/features/game/widgets/utils/fleet_mission_label.dart
+++ b/app/lib/features/game/widgets/utils/fleet_mission_label.dart
@@ -1,0 +1,17 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// User-visible label for [FleetMission] in units panels.
+String fleetMissionDisplayLabel(FleetMission m) {
+  switch (m) {
+    case FleetMission.none:
+      return 'None';
+    case FleetMission.patrol:
+      return 'Patrol';
+    case FleetMission.blockade:
+      return 'Blockade';
+    case FleetMission.beachhead:
+      return 'Beachhead';
+    case FleetMission.defend:
+      return 'Defend';
+  }
+}

--- a/app/lib/features/game/widgets/utils/military_tree_builder.dart
+++ b/app/lib/features/game/widgets/utils/military_tree_builder.dart
@@ -1,0 +1,336 @@
+// Pure data for Military Units panel tree. SPEC/ui/military-units-panel.md.
+
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show resolveToFullProvinceId, tryGetProvince;
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../../utils/map_location_resolver.dart';
+import '../../utils/sea_zone_name_resolver.dart';
+import 'fleet_mission_label.dart';
+
+String armyStationedProvinceDisplayLabel(Game game, Army army) {
+  final pid = army.stationedProvinceId;
+  final full = ProvinceId.isPrefixed(pid)
+      ? pid
+      : ProvinceId.full(army.regionId, pid);
+  final p = tryGetProvince(game.worldState, full);
+  if (p != null) {
+    return p.displayName ?? p.id;
+  }
+  return full;
+}
+
+/// Pending army move line for Military Units (naval draft move parity).
+String? armyDraftMoveLineForArmy({
+  required Game game,
+  required String humanPlayerId,
+  required String armyId,
+  required Orders draftOrders,
+}) {
+  final moves = draftOrders.armyMoveOrdersByPlayerId[humanPlayerId] ?? const [];
+  for (final o in moves) {
+    if (o.armyId != armyId) continue;
+    final full = resolveToFullProvinceId(
+      game.worldState,
+      o.destinationProvinceId,
+    );
+    final p = tryGetProvince(game.worldState, full);
+    final name = p?.displayName ?? p?.id ?? ProvinceId.localIdFrom(full);
+    return 'Moving to: $name';
+  }
+  return null;
+}
+
+/// One regiment-type row under an army: type, count, medals, status.
+class RegimentTypeRow {
+  RegimentTypeRow({
+    required this.typeId,
+    required this.count,
+    required this.medalsSummary,
+    required this.statusLabel,
+    required this.tileKey,
+    required this.regionId,
+  });
+
+  final String typeId;
+  final int count;
+  final String medalsSummary;
+  final String statusLabel;
+  final String? tileKey;
+  final String regionId;
+}
+
+/// Ship-type counts at sea within the military panel (aggregated by sea zone).
+class MilitarySeaShipRow {
+  MilitarySeaShipRow({
+    required this.typeId,
+    required this.count,
+    required this.statusLabel,
+    required this.tileKey,
+    required this.regionId,
+  });
+
+  final String typeId;
+  final int count;
+  final String statusLabel;
+  final String? tileKey;
+  final String regionId;
+}
+
+/// Province with one or more armies (land).
+class ProvinceArmiesNode {
+  ProvinceArmiesNode({required this.province, required this.armies});
+
+  final Province province;
+  final List<ArmyBlock> armies;
+
+  String get displayLabel => province.displayName ?? province.id;
+
+  String get regionId => province.regionId;
+}
+
+class ArmyBlock {
+  ArmyBlock({required this.army, required this.rows, required this.regionKey});
+
+  final Army army;
+  final List<RegimentTypeRow> rows;
+
+  /// Panel region key: `oldWorld` / `newWorld` (matches [TileMapResult] regions).
+  final String regionKey;
+}
+
+class MilitarySeaZoneNode {
+  MilitarySeaZoneNode({
+    required this.seaZoneLabel,
+    required this.regionId,
+    required this.rows,
+  });
+
+  final String seaZoneLabel;
+  final String regionId;
+  final List<MilitarySeaShipRow> rows;
+
+  String get displayLabel => seaZoneLabel;
+}
+
+class RegionMilitaryGroup {
+  RegionMilitaryGroup({
+    required this.regionKey,
+    required this.provinces,
+    required this.seaLocations,
+  });
+
+  final String regionKey;
+  final List<ProvinceArmiesNode> provinces;
+  final List<MilitarySeaZoneNode> seaLocations;
+}
+
+List<RegimentTypeRow> rowsForArmyUnits(
+  Game game,
+  Province province,
+  List<Unit> units,
+  String regionKey,
+) {
+  final tileKey = tileKeyForProvinceLocation(game, province);
+  final byType = <String, List<Unit>>{};
+  for (final u in units) {
+    byType.putIfAbsent(u.type, () => []).add(u);
+  }
+  final typeIds = byType.keys.toList()..sort();
+  final rows = <RegimentTypeRow>[];
+  for (final typeId in typeIds) {
+    final list = byType[typeId]!;
+    final medals = list.map((u) => u.medals).toSet();
+    final medalsSummary = medals.length == 1
+        ? '${medals.single}'
+        : '${medals.reduce((a, b) => a < b ? a : b)}–${medals.reduce((a, b) => a > b ? a : b)}';
+    final status = list.any((u) => u.status == UnitStatus.working)
+        ? UnitStatus.working
+        : list.any((u) => u.status == UnitStatus.done)
+        ? UnitStatus.done
+        : UnitStatus.idle;
+    final statusLabel = switch (status) {
+      UnitStatus.idle => 'Idle',
+      UnitStatus.working => 'Working',
+      UnitStatus.done => 'Done',
+    };
+    rows.add(
+      RegimentTypeRow(
+        typeId: typeId,
+        count: list.length,
+        medalsSummary: medalsSummary,
+        statusLabel: statusLabel,
+        tileKey: tileKey,
+        regionId: regionKey,
+      ),
+    );
+  }
+  return rows;
+}
+
+List<RegionMilitaryGroup> buildMilitaryGroups(Game game, String humanPlayerId) {
+  final unitsById = <String, Unit>{
+    for (final u in game.worldState.oldWorld.units) u.id: u,
+    for (final u in game.worldState.newWorld.units) u.id: u,
+  };
+
+  final armies =
+      game.worldState.armies
+          .where((a) => a.ownerId == humanPlayerId)
+          .where((a) => a.isHomeArmy || a.regimentUnitIds.isNotEmpty)
+          .toList()
+        ..sort((a, b) {
+          if (a.isHomeArmy != b.isHomeArmy) {
+            return a.isHomeArmy ? -1 : 1;
+          }
+          return a.id.compareTo(b.id);
+        });
+
+  final result = <RegionMilitaryGroup>[];
+
+  for (final regionEntry in {
+    'oldWorld': game.worldState.oldWorld,
+    'newWorld': game.worldState.newWorld,
+  }.entries) {
+    final regionKey = regionEntry.key;
+    final regionData = regionEntry.value;
+
+    final provinceById = {
+      for (final p in regionData.provinces) '${p.regionId}|${p.id}': p,
+      for (final p in regionData.provinces) p.id: p,
+    };
+
+    final armiesHere = armies.where((a) {
+      final full = ProvinceId.isPrefixed(a.stationedProvinceId)
+          ? a.stationedProvinceId
+          : ProvinceId.full(regionKey, a.stationedProvinceId);
+      final p = tryGetProvince(game.worldState, full);
+      return p != null && p.regionId == regionKey;
+    }).toList();
+
+    final byProvince = <String, List<Army>>{};
+    for (final a in armiesHere) {
+      final pid = a.stationedProvinceId;
+      final full = ProvinceId.isPrefixed(pid)
+          ? pid
+          : ProvinceId.full(regionKey, pid);
+      byProvince.putIfAbsent(full, () => []).add(a);
+    }
+
+    final provinceNodes = <ProvinceArmiesNode>[];
+    final provinceIds = byProvince.keys.toList()..sort();
+    for (final fullProvinceId in provinceIds) {
+      final province = provinceById[fullProvinceId];
+      if (province == null) continue;
+      final list = byProvince[fullProvinceId]!;
+      final blocks = <ArmyBlock>[];
+      for (final army in list) {
+        final regUnits = <Unit>[
+          for (final id in army.regimentUnitIds)
+            if (unitsById[id] != null) unitsById[id]!,
+        ];
+        blocks.add(
+          ArmyBlock(
+            army: army,
+            rows: rowsForArmyUnits(game, province, regUnits, regionKey),
+            regionKey: regionKey,
+          ),
+        );
+      }
+      provinceNodes.add(ProvinceArmiesNode(province: province, armies: blocks));
+    }
+
+    final fleetsInRegion = game.worldState.fleets
+        .where(
+          (f) =>
+              f.ownerId == humanPlayerId &&
+              f.regionId == regionKey &&
+              f.shipTypeIds.isNotEmpty &&
+              f.isAtSea &&
+              f.seaZoneId != null,
+        )
+        .toList();
+    final bySeaZone = <String, List<Fleet>>{};
+    for (final f in fleetsInRegion) {
+      final seaZoneId = f.seaZoneId!;
+      final zoneKey = seaZoneId.contains('|')
+          ? seaZoneId
+          : '$regionKey|$seaZoneId';
+      bySeaZone.putIfAbsent(zoneKey, () => []).add(f);
+    }
+
+    final seaLocations = <MilitarySeaZoneNode>[];
+    final seaZoneKeys = bySeaZone.keys.toList()..sort();
+    for (final zoneKey in seaZoneKeys) {
+      final fleets = bySeaZone[zoneKey]!;
+      final shipTypeIds = <String, int>{};
+      FleetMission? mission;
+      for (final f in fleets) {
+        for (final typeId in f.shipTypeIds) {
+          shipTypeIds[typeId] = (shipTypeIds[typeId] ?? 0) + 1;
+        }
+        mission ??= f.mission;
+      }
+      final zoneLabel = seaZoneDisplayName(
+        game: game,
+        regionId: regionKey,
+        seaZoneId: zoneKey,
+      );
+      final tileKey = tileKeyForSeaZoneLocation(game, regionKey, zoneKey);
+      final rows = <MilitarySeaShipRow>[];
+      for (final typeId in shipTypeIds.keys.toList()..sort()) {
+        rows.add(
+          MilitarySeaShipRow(
+            typeId: typeId,
+            count: shipTypeIds[typeId]!,
+            statusLabel: fleetMissionDisplayLabel(mission ?? FleetMission.none),
+            tileKey: tileKey,
+            regionId: regionKey,
+          ),
+        );
+      }
+      seaLocations.add(
+        MilitarySeaZoneNode(
+          seaZoneLabel: zoneLabel,
+          regionId: regionKey,
+          rows: rows,
+        ),
+      );
+    }
+
+    if (provinceNodes.isNotEmpty || seaLocations.isNotEmpty) {
+      result.add(
+        RegionMilitaryGroup(
+          regionKey: regionKey,
+          provinces: provinceNodes,
+          seaLocations: seaLocations,
+        ),
+      );
+    }
+  }
+
+  return result;
+}
+
+List<ArmyBlock> flattenMilitaryArmyBlocks(List<RegionMilitaryGroup> groups) {
+  final out = <ArmyBlock>[];
+  for (final g in groups) {
+    for (final p in g.provinces) {
+      out.addAll(p.armies);
+    }
+  }
+  return out;
+}
+
+bool canCombineArmySelection(
+  List<ArmyBlock> flat,
+  Set<String> selectedArmyIds,
+) {
+  if (selectedArmyIds.length < 2) return false;
+  final selected = flat
+      .where((b) => selectedArmyIds.contains(b.army.id))
+      .toList();
+  if (selected.length < 2) return false;
+  final province = selected.first.army.stationedProvinceId;
+  return selected.every((b) => b.army.stationedProvinceId == province);
+}

--- a/app/lib/features/game/widgets/utils/naval_tree_builder.dart
+++ b/app/lib/features/game/widgets/utils/naval_tree_builder.dart
@@ -1,0 +1,421 @@
+// Pure data for Naval Units panel tree. SPEC/ui/naval-units-panel.md.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show homeFleetIdFor, regionIdForSeaZone, tryGetProvince;
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../units/shared/units_panel_region_label.dart';
+import '../../utils/map_location_resolver.dart';
+import '../../utils/sea_zone_name_resolver.dart';
+import 'fleet_mission_label.dart';
+
+String? navalDraftMoveLineForFleet({
+  required Game game,
+  required MapTopology topology,
+  required String humanPlayerId,
+  required String fleetRegionId,
+  required String fleetId,
+  required Orders draftOrders,
+}) {
+  final moves =
+      draftOrders.navalMoveOrdersByPlayerId[humanPlayerId] ?? const [];
+  for (final o in moves) {
+    if (o.fleetId != fleetId) continue;
+    if (o.isDock) {
+      final pid = o.destinationPortProvinceId!;
+      final p = tryGetProvince(game.worldState, pid);
+      final name = p?.displayName ?? p?.id ?? pid;
+      return 'Moving to: $name (dock)';
+    }
+    final z = o.destinationSeaZoneId!;
+    final zReg = regionIdForSeaZone(topology, z) ?? fleetRegionId;
+    final zoneKey = z.contains('|') ? z : '$zReg|$z';
+    final label = seaZoneDisplayName(
+      game: game,
+      regionId: zReg,
+      seaZoneId: zoneKey,
+    );
+    return 'Moving to: $label';
+  }
+  return null;
+}
+
+class FleetRow {
+  FleetRow({
+    required this.fleetId,
+    required this.label,
+    required this.locationLabel,
+    required this.regionId,
+    required this.missionLabel,
+    required this.totalShips,
+    required this.warshipCount,
+    required this.merchantCount,
+    required this.strength,
+    required this.tileKey,
+    required this.isHomeFleet,
+    required this.shipCountsByType,
+    required this.cargoCapacity,
+    required this.isAtSea,
+    required this.locationKey,
+    this.inPortAtProvinceId,
+    this.seaZoneId,
+    this.draftNavalMoveLine,
+  });
+
+  final String fleetId;
+  final String label;
+  final String locationLabel;
+  final String regionId;
+  final String missionLabel;
+  final int totalShips;
+  final int warshipCount;
+  final int merchantCount;
+  final double strength;
+  final String? tileKey;
+  final bool isHomeFleet;
+  final Map<String, int> shipCountsByType;
+  final int cargoCapacity;
+  final bool isAtSea;
+  final String locationKey;
+  final String? inPortAtProvinceId;
+  final String? seaZoneId;
+  final String? draftNavalMoveLine;
+}
+
+abstract class NavalTreeLocationNode {
+  String get displayLabel;
+  String get regionId;
+  List<FleetRow> get fleets;
+}
+
+class NavalTreePortNode extends NavalTreeLocationNode {
+  NavalTreePortNode({required this.province, required this.fleets});
+
+  final Province province;
+
+  @override
+  final List<FleetRow> fleets;
+
+  @override
+  String get displayLabel => province.displayName ?? province.id;
+
+  @override
+  String get regionId => province.regionId;
+}
+
+class NavalTreeSeaZoneNode extends NavalTreeLocationNode {
+  NavalTreeSeaZoneNode({
+    required this.seaZoneLabel,
+    required this.regionId,
+    required this.fleets,
+  });
+
+  final String seaZoneLabel;
+
+  @override
+  final String regionId;
+
+  @override
+  final List<FleetRow> fleets;
+
+  @override
+  String get displayLabel => seaZoneLabel;
+}
+
+List<FleetRow> flattenNavalTree(
+  List<
+    ({
+      String regionId,
+      FleetRow? homeFleet,
+      List<NavalTreeLocationNode> locations,
+    })
+  >
+  tree,
+) {
+  final rows = <FleetRow>[];
+  for (final group in tree) {
+    if (group.homeFleet != null) {
+      rows.add(group.homeFleet!);
+    }
+    for (final loc in group.locations) {
+      rows.addAll(loc.fleets);
+    }
+  }
+  return rows;
+}
+
+List<
+  ({
+    String regionId,
+    FleetRow? homeFleet,
+    List<NavalTreeLocationNode> locations,
+  })
+>
+buildNavalTree(
+  Game game,
+  String humanPlayerId,
+  MapTopology topology,
+  Orders draftOrders,
+) {
+  final player = game.players.firstWhere(
+    (p) => p.id == humanPlayerId,
+    orElse: () => game.players.first,
+  );
+  final capitalTile = player.capitalTile;
+  String? capitalRegionId;
+  String? capitalProvinceLocalId;
+  if (capitalTile != null) {
+    final tileKey = capitalTile.toTileKey();
+    final parts = tileKey.split('|');
+    if (parts.length >= 2) {
+      capitalRegionId = parts[0];
+      capitalProvinceLocalId = parts[1];
+    }
+  }
+
+  final result =
+      <
+        ({
+          String regionId,
+          FleetRow? homeFleet,
+          List<NavalTreeLocationNode> locations,
+        })
+      >[];
+
+  final provinceByRegionAndId = <String, Map<String, Province>>{
+    'oldWorld': {
+      for (final p in game.worldState.oldWorld.provinces)
+        '${p.regionId}|${p.id}': p,
+      for (final p in game.worldState.oldWorld.provinces) p.id: p,
+    },
+    'newWorld': {
+      for (final p in game.worldState.newWorld.provinces)
+        '${p.regionId}|${p.id}': p,
+      for (final p in game.worldState.newWorld.provinces) p.id: p,
+    },
+  };
+
+  bool isMerchantShip(String typeId) {
+    final stats = NavalStatsCatalog.get(typeId);
+    return stats.cargoHold > 0;
+  }
+
+  for (final regionEntry in {
+    'oldWorld': game.worldState.oldWorld,
+    'newWorld': game.worldState.newWorld,
+  }.entries) {
+    final regionId = regionEntry.key;
+
+    final fleetsInRegion = game.worldState.fleets
+        .where(
+          (f) =>
+              f.ownerId == humanPlayerId &&
+              f.regionId == regionId &&
+              f.shipTypeIds.isNotEmpty,
+        )
+        .toList();
+    if (fleetsInRegion.isEmpty && capitalRegionId != regionId) {
+      continue;
+    }
+
+    FleetRow? homeFleetRow;
+    final ports = <String, List<FleetRow>>{};
+    final seas = <String, List<FleetRow>>{};
+
+    for (final fleet in fleetsInRegion) {
+      final isAtSea = fleet.isAtSea && fleet.seaZoneId != null;
+      final inPortId = fleet.inPortAtProvinceId;
+
+      final shipCounts = <String, int>{};
+      int totalShips = 0;
+      int warships = 0;
+      int merchants = 0;
+      int cargoCapacity = 0;
+      double strength = 0;
+      for (final typeId in fleet.shipTypeIds) {
+        shipCounts[typeId] = (shipCounts[typeId] ?? 0) + 1;
+        totalShips += 1;
+        final stats = NavalStatsCatalog.get(typeId);
+        cargoCapacity += stats.cargoHold;
+        strength += NavalStatsCatalog.shipStrength(typeId);
+        if (isMerchantShip(typeId)) {
+          merchants += 1;
+        } else {
+          warships += 1;
+        }
+      }
+
+      final atPlayerCapitalPort =
+          capitalRegionId != null &&
+          capitalProvinceLocalId != null &&
+          !isAtSea &&
+          regionId == capitalRegionId &&
+          inPortId != null &&
+          (inPortId == capitalProvinceLocalId ||
+              inPortId == '$capitalRegionId|$capitalProvinceLocalId');
+      final isHomeFleet =
+          fleet.id == homeFleetIdFor(humanPlayerId) && atPlayerCapitalPort;
+
+      String locationLabel;
+      String? tileKey;
+      String locationKey;
+      if (isAtSea) {
+        final seaZoneId = fleet.seaZoneId!;
+        final zoneKey = seaZoneId.contains('|')
+            ? seaZoneId
+            : '$regionId|$seaZoneId';
+        final zoneLabel = seaZoneDisplayName(
+          game: game,
+          regionId: regionId,
+          seaZoneId: zoneKey,
+        );
+        locationLabel = '${unitsPanelRegionLabel(regionId)} — $zoneLabel';
+        tileKey = tileKeyForSeaZoneLocation(game, regionId, zoneKey);
+        locationKey = 'sea:$zoneKey';
+        final row = FleetRow(
+          fleetId: fleet.id,
+          label: 'Fleet ${fleet.id}',
+          locationLabel: locationLabel,
+          regionId: regionId,
+          missionLabel: fleetMissionDisplayLabel(fleet.mission),
+          totalShips: totalShips,
+          warshipCount: warships,
+          merchantCount: merchants,
+          strength: strength,
+          tileKey: tileKey,
+          isHomeFleet: isHomeFleet,
+          shipCountsByType: shipCounts,
+          cargoCapacity: cargoCapacity,
+          isAtSea: true,
+          locationKey: locationKey,
+          seaZoneId: zoneKey,
+          draftNavalMoveLine: navalDraftMoveLineForFleet(
+            game: game,
+            topology: topology,
+            humanPlayerId: humanPlayerId,
+            fleetRegionId: regionId,
+            fleetId: fleet.id,
+            draftOrders: draftOrders,
+          ),
+        );
+        seas.putIfAbsent(zoneKey, () => []).add(row);
+      } else if (inPortId != null) {
+        final provinceMap = provinceByRegionAndId[regionId] ?? const {};
+        final province =
+            provinceMap['$regionId|$inPortId'] ?? provinceMap[inPortId];
+        if (province == null) continue;
+        tileKey = tileKeyForProvinceLocation(game, province);
+        locationLabel =
+            '${unitsPanelRegionLabel(regionId)} — ${province.displayName ?? province.id}';
+        locationKey = 'port:${province.regionId}|${province.id}';
+        final row = FleetRow(
+          fleetId: fleet.id,
+          label: isHomeFleet ? 'Home Fleet' : 'Fleet ${fleet.id}',
+          locationLabel: locationLabel,
+          regionId: regionId,
+          missionLabel: fleetMissionDisplayLabel(fleet.mission),
+          totalShips: totalShips,
+          warshipCount: warships,
+          merchantCount: merchants,
+          strength: strength,
+          tileKey: tileKey,
+          isHomeFleet: isHomeFleet,
+          shipCountsByType: shipCounts,
+          cargoCapacity: cargoCapacity,
+          isAtSea: false,
+          locationKey: locationKey,
+          inPortAtProvinceId: inPortId,
+          draftNavalMoveLine: isHomeFleet
+              ? null
+              : navalDraftMoveLineForFleet(
+                  game: game,
+                  topology: topology,
+                  humanPlayerId: humanPlayerId,
+                  fleetRegionId: regionId,
+                  fleetId: fleet.id,
+                  draftOrders: draftOrders,
+                ),
+        );
+        if (isHomeFleet) {
+          homeFleetRow = row;
+        } else {
+          final fullProvinceId = '${province.regionId}|${province.id}';
+          ports.putIfAbsent(fullProvinceId, () => []).add(row);
+        }
+      }
+    }
+
+    if (capitalRegionId == regionId &&
+        capitalProvinceLocalId != null &&
+        homeFleetRow == null) {
+      final provinceMap = provinceByRegionAndId[regionId] ?? const {};
+      final province =
+          provinceMap['$capitalRegionId|$capitalProvinceLocalId'] ??
+          provinceMap[capitalProvinceLocalId];
+      if (province != null) {
+        final tileKey = tileKeyForProvinceLocation(game, province);
+        final locationLabel =
+            '${unitsPanelRegionLabel(regionId)} — ${province.displayName ?? province.id}';
+        homeFleetRow = FleetRow(
+          fleetId: homeFleetIdFor(humanPlayerId),
+          label: 'Home Fleet',
+          locationLabel: locationLabel,
+          regionId: regionId,
+          missionLabel: fleetMissionDisplayLabel(FleetMission.none),
+          totalShips: 0,
+          warshipCount: 0,
+          merchantCount: 0,
+          strength: 0,
+          tileKey: tileKey,
+          isHomeFleet: true,
+          shipCountsByType: const {},
+          cargoCapacity: 0,
+          isAtSea: false,
+          locationKey: 'port:${province.regionId}|${province.id}',
+          inPortAtProvinceId: '$capitalRegionId|$capitalProvinceLocalId',
+          draftNavalMoveLine: null,
+        );
+      }
+    }
+
+    final locations = <NavalTreeLocationNode>[];
+
+    final provinceIds = ports.keys.toList()..sort();
+    for (final fullProvinceId in provinceIds) {
+      final provinceMap = provinceByRegionAndId[regionId] ?? const {};
+      final province = provinceMap[fullProvinceId];
+      if (province == null) continue;
+      final fleets = ports[fullProvinceId]!
+        ..sort((a, b) => a.label.compareTo(b.label));
+      locations.add(NavalTreePortNode(province: province, fleets: fleets));
+    }
+
+    final seaZoneKeys = seas.keys.toList()..sort();
+    for (final zoneKey in seaZoneKeys) {
+      final zoneLabel = seaZoneDisplayName(
+        game: game,
+        regionId: regionId,
+        seaZoneId: zoneKey,
+      );
+      final fleets = seas[zoneKey]!..sort((a, b) => a.label.compareTo(b.label));
+      locations.add(
+        NavalTreeSeaZoneNode(
+          seaZoneLabel: zoneLabel,
+          regionId: regionId,
+          fleets: fleets,
+        ),
+      );
+    }
+
+    if (homeFleetRow != null || locations.isNotEmpty) {
+      result.add((
+        regionId: regionId,
+        homeFleet: homeFleetRow,
+        locations: locations,
+      ));
+    }
+  }
+
+  return result;
+}

--- a/app/lib/widgets/game_setup.dart
+++ b/app/lib/widgets/game_setup.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:flutter/material.dart';
 
+import '../config/constants.dart';
 import 'ct_dropdown.dart';
 import 'ct_nine_patch_button.dart';
 
@@ -24,10 +25,6 @@ enum GameSetupState {
 
 /// Number of player slots. Slot 0 = human, 1..5 = AI. SPEC/ui/game-setup.md.
 const int _kNumSlots = 6;
-
-/// Viewport width below which slot rows use stacked layout. SPEC/ui/mobile-adaptation.md.
-const double _kNarrowBreakpoint = 500;
-
 
 /// Game Setup screen. Six player slots; slot 0 = human, 1–5 = AI.
 /// Per slot: nation (GP) dropdown, then leader dropdown for that nation.
@@ -107,7 +104,7 @@ class _CtGameSetupState extends State<CtGameSetup> {
   @override
   Widget build(BuildContext context) {
     final bool narrow =
-        MediaQuery.sizeOf(context).width < _kNarrowBreakpoint;
+        MediaQuery.sizeOf(context).width < kGameSetupNarrowBreakpoint;
     return Scaffold(
       body: SafeArea(
         child: Padding(

--- a/packages/colonizethis_data/lib/src/naval_stats.dart
+++ b/packages/colonizethis_data/lib/src/naval_stats.dart
@@ -179,4 +179,16 @@ class NavalStatsCatalog {
 
   static NavalStatsEntry get(String shipTypeId) =>
       byId[shipTypeId] ?? const NavalStatsEntry();
+
+  /// Per-ship strength score (firepower, range, armour, hull durability, movement).
+  /// Used by naval combat aggregation and fleet strength in the naval units panel.
+  static double shipStrength(String shipTypeId) {
+    final s = get(shipTypeId);
+    final durability = s.hull * (1 + (s.armour / 10.0));
+    return s.firepower +
+        (s.range * 0.4) +
+        (s.armour * 0.15) +
+        durability +
+        (s.movement * 0.1);
+  }
 }

--- a/packages/colonizethis_data/test/naval_stats_test.dart
+++ b/packages/colonizethis_data/test/naval_stats_test.dart
@@ -1,0 +1,24 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('NavalStatsCatalog.shipStrength', () {
+    test('matches explicit weighting for carrack', () {
+      const s = NavalStatsCatalog.carrack;
+      final durability = s.hull * (1 + (s.armour / 10.0));
+      final expected = s.firepower +
+          (s.range * 0.4) +
+          (s.armour * 0.15) +
+          durability +
+          (s.movement * 0.1);
+      expect(NavalStatsCatalog.shipStrength('carrack'), expected);
+    });
+
+    test('unknown type uses default entry stats', () {
+      expect(
+        NavalStatsCatalog.shipStrength('no_such_ship'),
+        NavalStatsCatalog.shipStrength('___unknown___'),
+      );
+    });
+  });
+}

--- a/packages/colonizethis_data/test/naval_stats_test.dart
+++ b/packages/colonizethis_data/test/naval_stats_test.dart
@@ -1,5 +1,6 @@
+import 'package:colonizethis_test/test.dart';
+
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:test/test.dart';
 
 void main() {
   group('NavalStatsCatalog.shipStrength', () {

--- a/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
@@ -255,14 +255,7 @@ List<BattleContextSea> filterBattlesByInterception(
 double navalStrength(List<String> shipTypeIds) {
   var total = 0.0;
   for (final typeId in shipTypeIds) {
-    final s = NavalStatsCatalog.get(typeId);
-    final durability = s.hull * (1 + (s.armour / 10.0));
-    final shipStrength = s.firepower +
-        (s.range * 0.4) +
-        (s.armour * 0.15) +
-        durability +
-        (s.movement * 0.1);
-    total += shipStrength;
+    total += NavalStatsCatalog.shipStrength(typeId);
   }
   return total;
 }


### PR DESCRIPTION
## Summary

Completes the remaining items from #1513 (alongside the earlier `GameService` emission helper in #1518).

### Breakpoints
- `kNarrowBreakpoint` (600 logical px) and `kGameSetupNarrowBreakpoint` (500 logical px) live in `app/lib/config/constants.dart` with SPEC pointers.
- In-game callers use `kNarrowBreakpoint`; Game Setup uses `kGameSetupNarrowBreakpoint` (intentionally lower than in-game).
- Removed duplicate `kInGameNarrowBreakpoint` from `game_screen_shared.dart`.

### Panel tree builders
- `app/lib/features/game/widgets/utils/naval_tree_builder.dart` — fleet tree data, `FleetRow`, location nodes, `buildNavalTree` / `flattenNavalTree`, draft move line helper.
- `app/lib/features/game/widgets/utils/military_tree_builder.dart` — army/sea aggregation, `RegimentTypeRow`, `ArmyBlock`, `buildMilitaryGroups`, etc.
- `fleet_mission_label.dart` — shared mission display strings.

### Ship strength
- `NavalStatsCatalog.shipStrength` in `colonizethis_data`; `navalStrength` in logic delegates to it. Naval panel uses the same formula (UI totals now match combat weighting including `armour * 0.15`).

### Region map
- Named constants for valid-tile pulse, province hover glow, selector bounce, gold selection/warp colors (values unchanged).

### Tests
- `packages/colonizethis_data/test/naval_stats_test.dart`
- `flutter test` — `test/naval_units_panel_test.dart`, `test/military_units_panel_test.dart`
- `dart test` — `packages/colonizethis_logic/test/naval_combat_resolver_test.dart`

Fixes #1513

Made with [Cursor](https://cursor.com)