### PR TITLE
docs(spec): research-resolution + extraction-cap vs New World (refs #1260)

### DIFF
--- a/SPEC/game/tech-and-extraction-cap.md
+++ b/SPEC/game/tech-and-extraction-cap.md
@@ -1,6 +1,6 @@
 # Tech and Extraction Cap
 
-**SPEC/game** — Per-player tech and its effect on extraction. Derived from GDD 04b. Reference: Imperialism II 02-economy (production level 0–4; technology caps). Tech tree: [tech-tree.md](tech-tree.md). Extraction: [extraction-and-improvements.md](extraction-and-improvements.md).
+**SPEC/game** — Per-player tech and its effect on extraction. Derived from GDD 04b. Reference: Imperialism II 02-economy (production level 0–4; technology caps). Tech tree: [tech-tree.md](tech-tree.md). Gathering and related caps (GDD): [tech-tree-gathering.md](tech-tree-gathering.md). New World resource chains: [tech-tree-new-world.md](tech-tree-new-world.md). Extraction: [extraction-and-improvements.md](extraction-and-improvements.md).
 
 ---
 
@@ -14,25 +14,19 @@ Each player has a **tech table**: a map from tech id to unlocked (e.g. `Map<Stri
 
 The **max effective extraction level** (1–4) per resource or improvement type is **derived from the tech tree catalog**: which techs grant which max improvement level for each resource (grain, timber, iron, coal, etc.). Effective extraction per tile = min(improvement level, **owner’s tech cap** for that resource). The improvement level on the tile is unchanged; only the amount that counts for extraction is capped.
 
-**MVP:** The implementation uses a **single scalar** cap per player (one value for all resources) as a temporary simplification; the catalog is program-level (e.g. gathering_1/2/3). The full model will use **per-resource** caps from the category sub-docs (e.g. [tech-tree-gathering.md](tech-tree-gathering.md)).
+**MVP:** The implementation uses a **single scalar** cap per player (one integer 1–4 applied to every resource on every owned tile) as a temporary simplification. The full model will use **per-resource** caps from the category sub-docs (e.g. [tech-tree-gathering.md](tech-tree-gathering.md)).
 
-**MVP scalar mapping:** For the MVP scalar cap, the **gathering** techs map to max effective extraction levels as follows (highest unlocked applies):
+**MVP scalar mapping (program):** The System maintains a **program-level map** from tech id → max effective extraction level (1–4) for techs that raise the cap. That map includes techs aligned with the **gathering / industry** tree and with **New World** plantation, fur, spice, and precious-metal/stone chains (see [tech-tree-gathering.md](tech-tree-gathering.md), [tech-tree-new-world.md](tech-tree-new-world.md)). For a player, the scalar cap is the **maximum** level among all map entries whose tech id is unlocked; if none apply, the System uses the fallback below. **Authoritative list:** `packages/colonizethis_data/lib/src/tech_extraction.dart` (`_extractionCapByTechId`, consumed by `extractionCapForUnlocked`). Do not duplicate the full id list in this doc; update the Dart map when adding or changing cap-granting techs.
 
-- `gathering_1` → max effective extraction level **2**
-- `gathering_2` → max effective extraction level **3**
-- `gathering_3` → max effective extraction level **4**
-
-If a player has multiple gathering techs unlocked, the System uses the maximum cap implied by any unlocked gathering tech for that player.
-
-**Fallback:** When the full tech model is not yet loaded, when the tech table is missing or empty, or when a player has no gathering tech unlocked (null or all false), the System uses a **constant fallback cap of 4** per player so extraction resolution can run. The full model derives caps from [tech-tree.md](tech-tree.md) and category sub-docs. Ruleset: MVP program-level constants (including the fallback cap); future ruleset per [ruleset-config.md](../program/ruleset-config.md).
+**Fallback:** When the tech table is missing or empty, or when no tech in the program map is unlocked for that player, the System uses a **constant fallback cap of 4** per player so extraction resolution can run. The full per-resource model derives caps from [tech-tree.md](tech-tree.md) and category sub-docs. Ruleset: MVP program-level constants (including the fallback cap); future ruleset per [ruleset-config.md](../program/ruleset-config.md).
 
 ---
 
 ## Acceptance Criteria
 
-- Given a player has a tech table where each tech id is either unlocked or locked and a program-level catalog that maps tech ids to extraction caps per resource  
-  When the System computes the player’s current extraction caps from the tech table  
-  Then the System derives, for each relevant resource, a non-negative integer cap between 1 and 4 inclusive based only on the unlocked techs and the catalog, and does not assign any cap that contradicts the catalog.
+- Given a player has a tech table where each tech id is either unlocked or locked and a program-level map from tech id to extraction cap level (1–4) as defined in `tech_extraction.dart`  
+  When the System computes the player’s MVP scalar extraction cap from the tech table  
+  Then the System sets that scalar to the maximum cap level among unlocked techs present in that map, or to the configured fallback (4) when no mapped tech is unlocked, and does not use a level that contradicts the map.
 
 - Given the implementation is running in the MVP mode where a single scalar extraction cap is used per player for all resources  
   When the System evaluates extraction for any tile owned by that player as described in [extraction-and-improvements.md](extraction-and-improvements.md)  

--- a/SPEC/program/research-resolution.md
+++ b/SPEC/program/research-resolution.md
@@ -1,7 +1,7 @@
 # Research Resolution
 
 ## Responsibility
-Execute the research phase of turn resolution: validate orders, deduct spending, accumulate progress, complete techs. Game rules: [tech-tree.md](../game/tech-tree.md).
+Execute the research phase of turn resolution: validate orders, deduct spending, accumulate progress, complete techs. Game rules: [tech-tree.md](../game/tech-tree.md). **Discovery (New World) techs** — ids, resources, and “Explorer finds X” semantics: [tech-tree-new-world.md](../game/tech-tree-new-world.md); revealed vs prospected tiles: [tech-tree.md](../game/tech-tree.md), [fog-and-exploration.md](../game/fog-and-exploration.md).
 
 ## Data Model
 
@@ -13,10 +13,13 @@ Execute the research phase of turn resolution: validate orders, deduct spending,
 ### Research Orders Structure
 Per player, per turn: slot assignments (slot index → tech id) and funding level per slot (per [tech-tree.md](../game/tech-tree.md) presets). Merged with other order types per [order-engine.md](order-engine.md). **One order per slot:** if the merged list contains more than one order for the same slot index, the resolver applies exactly one per slot (last in list wins); no double spend or dual progress for that slot.
 
+### Discovery techs
+Techs that require the player to have found a resource on the map carry **discovery resource ids** in the program catalog (`discoveryResourceIds` on the tech definition; see [tech-tree-new-world.md](../game/tech-tree-new-world.md)). For those techs, research is allowed only when the player has **revealed** at least one tile containing the required resource, and for **prospect-required** resources (per [tech-tree.md](../game/tech-tree.md)) when that tile has also been **prospected** by the player.
+
 ## Algorithm / Flow
 
 1. **For each GP:** Read research orders (slot assignments, funding per slot).
-2. **Validate:** Check prerequisites, slot limits, treasury, and catalog membership per game rules. Reject or reduce invalid slots.
+2. **Validate:** Check prerequisites, slot limits, treasury, and catalog membership per game rules; for techs with non-empty `discoveryResourceIds`, check the discovery gate (revealed / prospected per GDD). Reject or reduce invalid slots.
 3. **Deduct** research spending from treasury.
 4. **Add progress:** Map funding level to research points (per GDD presets); add to slot's tech progress.
 5. **Complete:** Where progress ≥ tech cost: mark tech as unlocked, clear slot progress, update derived state (extraction cap, military level).
@@ -28,6 +31,7 @@ Per player, per turn: slot assignments (slot index → tech id) and funding leve
 - **Upstream:** Research orders from human UI or AI backend; treasury from economy phases.
 - **Downstream:** Updated `techUnlocked` drives extraction caps, unit availability, diplomatic options.
 - **Order merge:** Human and AI research orders merged per [order-engine.md](order-engine.md) precedence.
+- **Discovery enforcement:** The Research phase resolver (`packages/colonizethis_logic`, e.g. `research_resolver.dart`) applies the discovery gate when validating slot assignments. **Research eligibility** for UI, AI order suggestions, and similar callers uses `researchableTechIds` in `packages/colonizethis_data` with a `hasDiscoveredResource` callback backed by game visibility/prospection (e.g. `hasRevealedResourceForPlayer` in `packages/colonizethis_logic`).
 
 ## Constraints
 - Clearing a slot loses all progress for that tech (no partial save).
@@ -39,6 +43,7 @@ Per player, per turn: slot assignments (slot index → tech id) and funding leve
 - **Phase order:** Research phase runs after Production and Consumption per [turn-resolution-phases.md](turn-resolution-phases.md); resolver reads merged orders from [order-engine.md](order-engine.md).
 - **One order per slot:** At most one research order per slot index per player; if multiple exist, last in merged list wins; no double spend or dual progress for that slot.
 - **Validation:** Prerequisites, slot limits, treasury, and catalog membership are checked; invalid slots are rejected or reduced before spending.
+- **Discovery techs:** Given a tech has non-empty `discoveryResourceIds` per [tech-tree-new-world.md](../game/tech-tree-new-world.md), when the System validates research for that tech in the Research phase, then the System applies progress only if the player meets the revealed (and if required, prospected) tile rules per [tech-tree.md](../game/tech-tree.md). Given such a tech, when the UI or suggestion layer lists researchable techs for a player, then the System includes that tech only under the same discovery conditions (via `researchableTechIds` and player visibility/prospection state).
 - **Spend and progress:** Research spending is deducted from treasury; funding level maps to research points per GDD presets; progress is added to the slot's tech.
 - **Completion:** When progress ≥ tech cost, tech is marked unlocked, slot progress cleared, and derived state (extraction cap, military level) updated.
 - **Persistence:** Updated `techUnlocked`, research progress, and treasury are persisted; clearing a slot loses all progress for that tech (no partial save).


### PR DESCRIPTION
## Summary
Closes the SPEC gaps described in #1260 (documentation only).

### `SPEC/program/research-resolution.md`
- Links [tech-tree-new-world.md](../blob/dev/SPEC/game/tech-tree-new-world.md) and ties discovery rules to [tech-tree.md](...) / [fog-and-exploration.md](...).
- Documents `discoveryResourceIds`, validation during Research phase, and parallel enforcement via `researchableTechIds` + visibility/prospection for UI/suggestions.
- Extends acceptance criteria for discovery gating.

### `SPEC/game/tech-and-extraction-cap.md`
- Describes MVP scalar cap as the max over the program map in `packages/colonizethis_data/lib/src/tech_extraction.dart` (`_extractionCapByTechId`), including New World chains—not only legacy `gathering_*` examples.
- Refreshes the first AC to match MVP scalar behavior.

## Notes
- **Refs #1260** — does not close the issue; verify after merge if you want to close manually.

## Testing
SPEC-only change; no code or test updates.

Made with [Cursor](https://cursor.com)