### PR TITLE
refactor(app): finish #1513 verification gaps

### DIFF
--- a/app/lib/core/services/game_service.dart
+++ b/app/lib/core/services/game_service.dart
@@ -151,7 +151,7 @@ class GameService {
       eventBus: logicEventBus,
       onGameEvent: onGameEvent,
     );
-    _emitTurnResolutionResultEvent(result);
+    _emitTurnResolutionEvents(result);
     return result;
   }
 
@@ -174,7 +174,7 @@ class GameService {
       eventBus: logicEventBus,
       onGameEvent: onGameEvent,
     );
-    _emitTurnResolutionResultEvent(result);
+    _emitTurnResolutionEvents(result);
     return result;
   }
 
@@ -201,7 +201,7 @@ class GameService {
       eventBus: logicEventBus,
       onGameEvent: onGameEvent,
     );
-    _emitTurnResolutionResultEvent(result);
+    _emitTurnResolutionEvents(result);
     return result;
   }
 
@@ -224,7 +224,7 @@ class GameService {
       eventBus: logicEventBus,
       onGameEvent: onGameEvent,
     );
-    _emitTurnResolutionResultEvent(result);
+    _emitTurnResolutionEvents(result);
     return result;
   }
 
@@ -419,7 +419,9 @@ class GameService {
     eventBus?.emit(NewGameCreatedEvent(gameId: result.game.id));
   }
 
-  void _emitTurnResolutionResultEvent(TurnResolutionResult result) {
+  /// Maps [TurnResolutionResult] to app-level bus events and persists when complete.
+  /// SPEC/program/app-event-bus.md.
+  void _emitTurnResolutionEvents(TurnResolutionResult result) {
     if (result is TurnResolutionComplete) {
       final complete = result;
       saveGame(complete.game);

--- a/app/lib/features/game/flame/region_map_component.dart
+++ b/app/lib/features/game/flame/region_map_component.dart
@@ -75,6 +75,15 @@ const Color _provinceBorderLandColor = Color.fromRGBO(0, 0, 0, 0.35);
 const Color _provinceBorderSeaLandColor = Color.fromRGBO(0, 0, 0, 0.25);
 const Color _provinceBorderSeaZoneColor = Color.fromRGBO(130, 200, 255, 0.55);
 
+/// Province name labels: text shadow (semi-transparent black, ARGB).
+const Color _kProvinceLabelShadowColor = Color(0x8A000000);
+
+/// Fogged land tiles: modulate alpha for resource icons (linear 0–1).
+const double _kFoggedResourceIconModulateAlpha = 0.6;
+
+/// Political (faction) border stroke — indigo, visible over terrain.
+const Color _kFactionPoliticalBorderColor = Color(0xFF1A237E);
+
 /// Land province labels: max text width and font size in **logical pixels** (screen space).
 const double _provinceLabelMaxWidthPx = 120;
 const double _provinceLabelFontSizePx = 11;
@@ -563,7 +572,7 @@ class CtRegionMapComponent extends PositionComponent {
       shadows: <Shadow>[
         Shadow(
           blurRadius: 2,
-          color: Color(0x8A000000),
+          color: _kProvinceLabelShadowColor,
           offset: Offset(0.5, 0.5),
         ),
       ],
@@ -1121,7 +1130,9 @@ class CtRegionMapComponent extends PositionComponent {
           if (visibilityMode == CtMapVisibilityMode.playerConstrained &&
               cell.visibility == TileVisibility.fogged) {
             paint.colorFilter = ColorFilter.mode(
-              const Color(0xFFFFFFFF).withValues(alpha: 0.6),
+              _kMapHoverSelectorIdle.withValues(
+                alpha: _kFoggedResourceIconModulateAlpha,
+              ),
               BlendMode.modulate,
             );
           }
@@ -1198,7 +1209,7 @@ class CtRegionMapComponent extends PositionComponent {
     final paint = Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = kProvinceOverlayHoverGlowStrokeWidth
-      ..color = const Color(0x88FFFFFF).withValues(alpha: opacity);
+      ..color = _kMapHoverSelectorIdle.withValues(alpha: opacity);
     final provinceId = _hoveredProvinceId!;
     for (var y = 0; y < region.height; y++) {
       for (var x = 0; x < region.width; x++) {
@@ -1368,7 +1379,7 @@ class CtRegionMapComponent extends PositionComponent {
     final paint = Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = kProvinceOverlayPoliticalStrokeWidth
-      ..color = const Color(0xFF1A237E);
+      ..color = _kFactionPoliticalBorderColor;
     for (var y = 0; y < region.height; y++) {
       for (var x = 0; x < region.width; x++) {
         final cell = region.cellAt(x, y);


### PR DESCRIPTION
## Summary

Closes remaining gaps from verification of [#1513](https://github.com/waigore/colonizethisv3/issues/1513) (naming and `region_map_component` literals).

## Changes

- **GameService:** Rename `_emitTurnResolutionResultEvent` → `_emitTurnResolutionEvents` to match the issue’s acceptance criteria (behavior unchanged).
- **RegionMapComponent:** Replace remaining inline `Color(0x…)` / raw alpha in map visual paths with named top-level constants (`_kProvinceLabelShadowColor`, `_kFoggedResourceIconModulateAlpha`, `_kFactionPoliticalBorderColor`) and reuse `_kMapHoverSelectorIdle` for hover-glow stroke (white + oscillating alpha; equivalent to prior `0x88FFFFFF` + `withValues(alpha: opacity)`).

## Tests

- `dart analyze` on touched files
- `flutter test app/test/game_service_test.dart app/test/ct_region_map_widget_test.dart`

## Target

`dev` per CONTRIBUTING.

Made with [Cursor](https://cursor.com)