### PR TITLE
feat(app): resume game from auto-save slot

### DIFF
--- a/SPEC/program/save-load.md
+++ b/SPEC/program/save-load.md
@@ -7,7 +7,7 @@
 ## Responsibility
 
 - Define the save/load contract implemented by `colonizethis_save` (GameSaveAdapter): storage backend, key convention, schema, required map data, and behaviour on load for the current schema.
-- Cross-referenced by: [world-model.md](../game/world-model.md) (serialization), [ctdev-app.md](ctdev-app.md) (Load Savegame flow), [init-game-tool.md](init-game-tool.md) (save output), [turn-resolution.md](turn-resolution.md) (persist after resolve), [game-setup-pipeline.md](game-setup-pipeline.md) (persist or pass), [plan-update-gp-colours-save-load.md](../project/plan-update-gp-colours-save-load.md) (GP colour override persisted on Game).
+- Cross-referenced by: [world-model.md](../game/world-model.md) (serialization), [ctdev-app.md](ctdev-app.md) (Load Savegame flow), [init-game-tool.md](init-game-tool.md) (save output), [turn-resolution.md](turn-resolution.md) (persist after resolve; auto-save mirror on complete), [game-setup-pipeline.md](game-setup-pipeline.md) (persist or pass), [plan-update-gp-colours-save-load.md](../project/plan-update-gp-colours-save-load.md) (GP colour override persisted on Game), [main-menu.md](../ui/main-menu.md) (Resume game).
 
 ---
 
@@ -19,6 +19,14 @@
   - **gameId constraints:** The `gameId` must be a non-empty string. It may contain any characters except those that would create ambiguity with map-data keys (see below). For clarity, avoid gameIds that end with `_tileMapByRegion`, `_topologyByRegion`, or `_combinedTopology` unless you intentionally want the game to be treated as a potential map-data key (see listGameIds behavior).
   - **Required map data:** keys = `gameId + suffix`; suffixes: `_tileMapByRegion`, `_topologyByRegion`, `_combinedTopology`. Values = JSON produced by the respective model `toJson()` (e.g. `TileMapResult`, `MapTopology`).
 - **Province/region identity:** Province and region ids stored in the saved payload are whatever the model stores; for consistency with [world-model-identity.md](../game/world-model-identity.md), any province or region id in saved state follows the same prefixed form and lookup rules as at runtime (no separate serialization format).
+
+### Auto-save slot (Flutter app)
+
+- **Purpose:** One **crash-recovery** slot written in addition to the normal game entry. The in-memory `Game.id` inside the JSON is the real session id; Hive keys for the slot use a **fixed stem** only for storage.
+- **Stem:** Constant `kAutoSaveSlotId` = `__colonizethis_autosave` (implementation in `colonizethis_save`). Same layout as a normal game: one JSON key = stem, plus `stem +` map suffixes (`_tileMapByRegion`, `_topologyByRegion`, `_combinedTopology`, optional `_warpLinks`).
+- **Listing:** `listGameIds` **never** returns the auto-save stem. Orphan-detection for map suffixes **ignores** keys whose prefix equals `kAutoSaveSlotId` so map-data keys for the slot are never mistaken for user saves.
+- **When written:** After a **playable** state is persisted at **turn boundary**: immediately after new-game setup save, and after each **completed** turn resolution (`TurnResolutionComplete`). The app also saves the real `gameId` entry as today; auto-save **mirrors** that state into the slot.
+- **Validation / corruption:** If the slot is unreadable (bad JSON, missing map data, or invalid map JSON), the implementation **clears** the slot (all stem keys) and logs with prefix `save:` at warning (or error where appropriate). The main-menu **Resume game** control is hidden until a valid slot exists again.
 
 ---
 
@@ -61,3 +69,9 @@
 - **Delete.** Given a Hive box and a `gameId`, when the system deletes the game, then the system removes the key `gameId` and the three map-data keys (`gameId + _tileMapByRegion`, etc.); no-op if the game key is not present.
 - **Round-trip Game fields.** Given a Game with worldState, players, greatPowerColorOverride, turnTimeMapping, and other serialized fields, when the system saves and then loads by the same game id, then the loaded Game equals the original for all fields covered by `Game.toJson()`/`fromJson()` (as covered by existing game_save_adapter_test.dart).
 - **Logging.** Save/load operations use the `save:` prefix and log gameId and success or failure per [ctdev-logging.md](ctdev-logging.md).
+
+- **Auto-save round-trip.** Given a Hive box, when the system writes `saveAutoSave` with a valid `Game` and map data for stem `kAutoSaveSlotId`, then `load` with that stem returns an equal `Game` and `loadMapData` returns the same map bundle (as exercised in `game_save_adapter_test.dart`).
+
+- **Auto-save excluded from list.** Given a Hive box that contains only the auto-save stem and its map keys, when the system lists game ids, then the returned list is empty.
+
+- **Auto-save corrupt cleared.** Given a Hive box where the auto-save stem key holds invalid JSON or map data is missing/invalid, when the system validates the slot (e.g. `hasValidAutoSave`), then the system removes all keys for that stem and logs with prefix `save:`; subsequent listing still excludes the stem.

--- a/SPEC/program/turn-resolution.md
+++ b/SPEC/program/turn-resolution.md
@@ -35,7 +35,7 @@ Signature (conceptual): `WorldState resolve(WorldState current)` or `Game resolv
 ## Responsibilities
 
 - **colonizethis_logic** owns TurnResolver and phase sequence. Stub: no game rules beyond turn advance until full phases are implemented.
-- **App** (or a service) calls TurnResolver when user (or AI) commits “next turn”; then persists the returned state via colonizethis_save.
+- **App** (or a service) calls TurnResolver when user (or AI) commits “next turn”; then persists the returned state via colonizethis_save. After each **completed** resolution, the Flutter app also mirrors the same playable state into the **auto-save** slot ([save-load.md](save-load.md) § Auto-save slot).
 - **Load game** restores Game/WorldState from storage; “next turn” runs on that state and overwrites or replaces the saved state after resolve.
 
 ---

--- a/SPEC/ui/main-menu.md
+++ b/SPEC/ui/main-menu.md
@@ -14,6 +14,8 @@ The CtMainMenu widget is presentational and accepts the following parameters. Th
 | `state` | `default` \| `afterVictory` \| `noSaves` | **default:** no subtitle; Load Game enabled when saves exist. **afterVictory:** show subtitle "Congratulations, you won your last game." **noSaves:** Load Game disabled with explanatory tooltip/helper text. |
 | `version` | string | Version text shown in footer (e.g. `v1.0.0`). |
 | `onNewGame` | callback | Invoked when user taps New Game. |
+| `resumeGameVisible` | bool | When true, show **Resume game** between New Game and Load Game. When false, omit the control entirely (not disabled). |
+| `onResumeGame` | callback | Invoked when user taps **Resume game** (only when `resumeGameVisible` is true). |
 | `onLoadGame` | callback | Invoked when user taps Load Game (when enabled). |
 | `onSettings` | callback | Invoked when user taps Settings. |
 | `onQuit` | callback | Invoked when user taps Quit. |
@@ -24,13 +26,13 @@ The CtMainMenu widget is presentational and accepts the following parameters. Th
 
 **User stories.** The main menu supports: single tap **New Game** (one action to start fresh); **Load Game** (continue or pick a save); **Settings** (open from menu); **Quit** (exit app). Return-from-in-game is satisfied by the shell/navigation: pause and Victory Screen (03l) navigate back to this screen, which is the destination.
 
-**Acceptance criteria.** (1) **Visibility:** The app shell shows the Main Menu as the first screen after any splash; the widget displays New Game, Load Game, Settings, and Quit. (2) **Load Game:** When no saves exist, Load Game is disabled and shows explanatory tooltip or helper text; when saves exist, it is enabled. (3) **Navigation:** The widget does not perform routing; it exposes callbacks (`onNewGame`, `onLoadGame`, `onSettings`, `onQuit`). The shell wires: New Game → **combined nation & leader dialog** (`OpenDialogEvent` id `new_game_leader_selection`, `NewGameLeaderSelectionDialog`; same six-slot rules as [Game Setup](game-setup.md) § Shell new game dialog) → [Game Initializing](game-initializing.md) → [Empire overview](empire-overview.md); Load Game → Load list (03b) → Empire overview on load; Settings → Settings (03c); Quit → app exit. (4) **Return from game:** Pause "Exit to Main Menu" and Victory "Return to Main Menu" both navigate to this screen; the shell clears in-memory game state as needed.
+**Acceptance criteria.** (1) **Visibility:** The app shell shows the Main Menu as the first screen after any splash; the widget displays New Game, Load Game, Settings, and Quit, and optionally **Resume game** (see below). (2) **Resume game:** When a valid auto-save exists (`SPEC/program/save-load.md` § Auto-save slot), the shell sets `resumeGameVisible` to true; the widget shows **Resume game** **below New Game** and above Load Game. When no valid auto-save exists, `resumeGameVisible` is false and the widget does not show **Resume game**. (3) **Load Game:** When no manual saves exist, Load Game is disabled and shows explanatory tooltip or helper text; when saves exist, it is enabled. **Resume game** visibility is independent of manual saves. (4) **Navigation:** The widget does not perform routing; it exposes callbacks (`onNewGame`, `onResumeGame`, `onLoadGame`, `onSettings`, `onQuit`). The shell wires: New Game → **combined nation & leader dialog** (`OpenDialogEvent` id `new_game_leader_selection`, `NewGameLeaderSelectionDialog`; same six-slot rules as [Game Setup](game-setup.md) § Shell new game dialog) → [Game Initializing](game-initializing.md) → [Empire overview](empire-overview.md); **Resume game** → load auto-save slot → Empire overview (same entry conditions as a normal load); Load Game → Load list (03b) → Empire overview on load; Settings → Settings (03c); Quit → app exit. (5) **Return from game:** Pause "Exit to Main Menu" and Victory "Return to Main Menu" both navigate to this screen; the shell clears in-memory game state as needed. The shell re-evaluates `resumeGameVisible` when the menu is shown so **Resume game** appears immediately if an auto-save was written during play (no app restart).
 
 **Shell behaviour.** Shell responsibility (first screen after splash, callback wiring, clear in-memory game state on return from game) is defined in the app TDD: [ctdev-app.md](../program/ctdev-app.md) (app screens and navigation). For Flutter shell and route ownership see [repo-and-packages.md](../program/repo-and-packages.md).
 
-**Interaction.** The main menu widget is presentational: it receives callbacks for each action. The shell (or parent) supplies `onNewGame`, `onLoadGame`, `onSettings`, `onQuit` and handles navigation and app exit. No routing logic lives in the widget.
+**Interaction.** The main menu widget is presentational: it receives callbacks for each action. The shell (or parent) supplies `onNewGame`, `onResumeGame` (when resume is shown), `onLoadGame`, `onSettings`, `onQuit` and handles navigation and app exit. No routing logic lives in the widget.
 
-**Automated tests.** Widget tests in `app/test/screen_spec_acceptance_test.dart` assert the acceptance criteria above (visibility, Load Game state/tooltip, callbacks). Run: `flutter test test/screen_spec_acceptance_test.dart` from the app package.
+**Automated tests.** Widget tests in `app/test/screen_spec_acceptance_test.dart` assert the acceptance criteria above (visibility, Load Game state/tooltip, Resume visibility, callbacks). Run: `flutter test test/screen_spec_acceptance_test.dart` from the app package.
 
 ---
 
@@ -46,6 +48,7 @@ Positions, layout, and hierarchy (per UXD 03a; 44dp min touch targets).
 |                "ColonizeThis V3"                     |
 |                                                      |
 |  [ New Game ]                                        |
+|  [ Resume game ]  (only if auto-save exists)         |
 |  [ Load Game ]    (disabled if no saves)             |
 |  [ Settings ]                                        |
 |                                                      |

--- a/app/lib/core/services/app_event_handler.dart
+++ b/app/lib/core/services/app_event_handler.dart
@@ -204,6 +204,20 @@ class AppEventHandler {
 
   void _navigateToShell(NavigatorState? nav) {
     if (nav == null) return;
+    final ctx = nav.context;
+    if (ctx.mounted) {
+      try {
+        final container = ProviderScope.containerOf(ctx, listen: false);
+        container.read(currentGameProvider.notifier).clear();
+        container.read(currentOrdersProvider.notifier).clear();
+      } catch (e, st) {
+        _log.d(
+          'navigateToShell: skipped in-memory game clear (no ProviderScope)',
+          error: e,
+          stackTrace: st,
+        );
+      }
+    }
     var foundShellRoute = false;
     nav.popUntil((route) {
       final matches = route.settings.name == Routes.shell;

--- a/app/lib/core/services/game_service.dart
+++ b/app/lib/core/services/game_service.dart
@@ -121,6 +121,58 @@ class GameService {
   /// Lists all saved game ids.
   List<String> listGameIds() => _adapter.listGameIds(_box);
 
+  /// Whether the Hive auto-save slot is playable. Clears invalid slots. SPEC/program/save-load.md.
+  bool hasValidAutoSave() => _adapter.hasValidAutoSave(_box);
+
+  /// Loads the auto-save slot into memory cache under [Game.id]. Returns null if missing/invalid.
+  Game? loadAutoSaveGame() {
+    if (!_adapter.hasValidAutoSave(_box)) {
+      return null;
+    }
+    final game = _adapter.load(_box, kAutoSaveSlotId);
+    if (game == null) {
+      return null;
+    }
+    try {
+      final mapData = _adapter.loadMapData(_box, kAutoSaveSlotId);
+      _mapCache[game.id] = _GameMapCache(
+        combinedTopology: mapData.combinedTopology,
+        tileMapByRegion: mapData.tileMapByRegion,
+        topologyByRegion: mapData.topologyByRegion,
+        warpLinks: mapData.warpLinks,
+      );
+      return game;
+    } catch (e, st) {
+      saveLogger().e(
+        'save: loadAutoSaveGame failed',
+        error: e,
+        stackTrace: st,
+      );
+      _adapter.delete(_box, kAutoSaveSlotId);
+      return null;
+    }
+  }
+
+  void _mirrorAutoSave(Game game) {
+    try {
+      final md = _requiredMapDataView(game.id);
+      _adapter.saveAutoSave(
+        _box,
+        game,
+        tileMapByRegion: md.tileMapByRegion,
+        topologyByRegion: md.topologyByRegion,
+        combinedTopology: md.combinedTopology,
+        warpLinks: md.warpLinks,
+      );
+    } catch (e, st) {
+      saveLogger().e(
+        'save: auto-save mirror failed',
+        error: e,
+        stackTrace: st,
+      );
+    }
+  }
+
   /// Resolves one turn. Returns [TurnResolutionComplete] with new game (and persists),
   /// or a pending result: [TurnResolutionPendingOvertures], [TurnResolutionPendingIntervention],
   /// or [TurnResolutionPendingCallToArms].
@@ -416,6 +468,7 @@ class GameService {
       warpLinks: result.warpLinks,
     );
     saveGame(result.game);
+    _mirrorAutoSave(result.game);
     eventBus?.emit(NewGameCreatedEvent(gameId: result.game.id));
   }
 
@@ -425,6 +478,7 @@ class GameService {
     if (result is TurnResolutionComplete) {
       final complete = result;
       saveGame(complete.game);
+      _mirrorAutoSave(complete.game);
       eventBus?.emit(
         TurnResolutionCompleteEvent(
           gameId: complete.game.id,

--- a/app/lib/features/shell/shell_screen.dart
+++ b/app/lib/features/shell/shell_screen.dart
@@ -17,6 +17,7 @@ class ShellScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final bus = ref.watch(appEventBusProvider);
+    final resumeAvailable = ref.watch(mainMenuAutoSaveAvailableProvider);
     return CtMainMenu(
       variant: MainMenuVariant.plain,
       state: MainMenuState.default_,
@@ -24,6 +25,15 @@ class ShellScreen extends ConsumerWidget {
       onNewGame: () => bus.emit(
             const OpenDialogEvent(newGameLeaderSelectionDialogId),
           ),
+      resumeGameVisible: resumeAvailable,
+      onResumeGame: () {
+        final service = ref.read(gameServiceProvider);
+        final game = service.loadAutoSaveGame();
+        if (game != null && context.mounted) {
+          ref.read(currentGameProvider.notifier).setGame(game);
+          bus.emit(const NavigateToRouteEvent(Routes.game));
+        }
+      },
       onLoadGame: () async {
         final service = ref.read(gameServiceProvider);
         final ids = service.listGameIds();

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -31,6 +31,11 @@
     "description": "Main menu button label to start a new game."
   },
 
+  "mainMenu_resumeGame": "Resume game",
+  "@mainMenu_resumeGame": {
+    "description": "Main menu button label to continue from the auto-save slot."
+  },
+
   "mainMenu_loadGame": "Load Game",
   "@mainMenu_loadGame": {
     "description": "Main menu button label to load an existing game."

--- a/app/lib/providers/games_provider.dart
+++ b/app/lib/providers/games_provider.dart
@@ -2,7 +2,9 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 
+import '../config/constants.dart';
 import 'game_service_provider.dart';
 
 /// List of saved game ids. Refreshed by reading from GameService.
@@ -32,6 +34,17 @@ class CurrentGameNotifier extends Notifier<Game?> {
 final currentGameProvider = NotifierProvider<CurrentGameNotifier, Game?>(
   CurrentGameNotifier.new,
 );
+
+/// True when the auto-save slot is valid. Rebuilds when [currentGameProvider] changes
+/// so the main menu updates immediately after exiting to menu. SPEC/ui/main-menu.md.
+final mainMenuAutoSaveAvailableProvider = Provider<bool>((ref) {
+  ref.watch(currentGameProvider);
+  if (!Hive.isBoxOpen(HiveBoxNames.games)) {
+    return false;
+  }
+  final service = ref.watch(gameServiceProvider);
+  return service.hasValidAutoSave();
+});
 
 /// Current-turn orders for the human player (work orders, move orders, etc.).
 /// Updated when the player assigns/cancels work in the civilian panel; passed to nextTurn and reset after resolution.

--- a/app/lib/widgetbook.dart
+++ b/app/lib/widgetbook.dart
@@ -136,6 +136,20 @@ List<WidgetbookNode> get mainMenuDirectories => [
         ),
       ),
       WidgetbookUseCase(
+        name: 'With resume game',
+        builder: (context) => CtMainMenu(
+          variant: MainMenuVariant.plain,
+          state: MainMenuState.default_,
+          version: 'v1.0.0',
+          onNewGame: () {},
+          resumeGameVisible: true,
+          onResumeGame: () {},
+          onLoadGame: () {},
+          onSettings: () {},
+          onQuit: () {},
+        ),
+      ),
+      WidgetbookUseCase(
         name: 'After victory',
         builder: (context) => CtMainMenu(
           variant: MainMenuVariant.plain,

--- a/app/lib/widgetbook/catalog.dart
+++ b/app/lib/widgetbook/catalog.dart
@@ -185,6 +185,20 @@ List<WidgetbookNode> get mainMenuDirectories => [
         ),
       ),
       WidgetbookUseCase(
+        name: 'With resume game',
+        builder: (context) => CtMainMenu(
+          variant: MainMenuVariant.plain,
+          state: MainMenuState.default_,
+          version: 'v1.0.0',
+          onNewGame: () {},
+          resumeGameVisible: true,
+          onResumeGame: () {},
+          onLoadGame: () {},
+          onSettings: () {},
+          onQuit: () {},
+        ),
+      ),
+      WidgetbookUseCase(
         name: 'After victory',
         builder: (context) => CtMainMenu(
           variant: MainMenuVariant.plain,

--- a/app/lib/widgets/main_menu.dart
+++ b/app/lib/widgets/main_menu.dart
@@ -38,15 +38,22 @@ class CtMainMenu extends StatelessWidget {
     required this.state,
     required this.version,
     required this.onNewGame,
+    this.resumeGameVisible = false,
+    this.onResumeGame,
     required this.onLoadGame,
     required this.onSettings,
     required this.onQuit,
-  });
+  }) : assert(
+          !resumeGameVisible || onResumeGame != null,
+          'onResumeGame is required when resumeGameVisible is true',
+        );
 
   final MainMenuVariant variant;
   final MainMenuState state;
   final String version;
   final VoidCallback onNewGame;
+  final bool resumeGameVisible;
+  final VoidCallback? onResumeGame;
   final VoidCallback onLoadGame;
   final VoidCallback onSettings;
   final VoidCallback onQuit;
@@ -86,6 +93,14 @@ class CtMainMenu extends StatelessWidget {
                   variant: variant,
                   onPressed: onNewGame,
                 ),
+                if (resumeGameVisible) ...[
+                  const SizedBox(height: 12),
+                  _MenuButton(
+                    label: l10n.mainMenu_resumeGame,
+                    variant: variant,
+                    onPressed: onResumeGame!,
+                  ),
+                ],
                 const SizedBox(height: 12),
                 _LoadGameButton(
                   enabled: _loadGameEnabled,

--- a/app/test/game_service_integration_test.dart
+++ b/app/test/game_service_integration_test.dart
@@ -4,7 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:colonizethis_save/colonizethis_save.dart';
+import 'package:colonizethis_save/colonizethis_save.dart'
+    show GameSaveAdapter, kAutoSaveSlotId;
 import 'package:hive/hive.dart';
 
 import 'package:colonizethis_app/core/services/game_service.dart';
@@ -120,6 +121,49 @@ void main() {
       expect(asyncGame.worldState.oldWorld, syncGame.worldState.oldWorld);
       expect(asyncGame.worldState.newWorld, syncGame.worldState.newWorld);
       expect(asyncGame.players.length, syncGame.players.length);
+    });
+
+    test('createNewGame mirrors auto-save; loadAutoSaveGame round-trip', () {
+      final config = GameSetupConfig(
+        selectedGreatPowerIds: ['england'],
+        continentCount: 1,
+        minorNationCount: 0,
+        tribeCount: 1,
+        numProvincesOldWorld: 3,
+        numProvincesNewWorld: 2,
+      );
+      final game = service.createNewGame(id: 'g_autosave', config: config);
+      expect(service.hasValidAutoSave(), isTrue);
+      expect(service.listGameIds(), contains('g_autosave'));
+      expect(service.listGameIds(), isNot(contains(kAutoSaveSlotId)));
+
+      final fromSlot = service.loadAutoSaveGame();
+      expect(fromSlot, isNotNull);
+      expect(fromSlot!.id, game.id);
+      expect(
+        fromSlot.worldState.turnState.turnNumber,
+        game.worldState.turnState.turnNumber,
+      );
+    });
+
+    test('nextTurn updates mirrored auto-save', () {
+      final config = GameSetupConfig(
+        selectedGreatPowerIds: ['england'],
+        continentCount: 1,
+        minorNationCount: 0,
+        tribeCount: 1,
+        numProvincesOldWorld: 3,
+        numProvincesNewWorld: 2,
+      );
+      final game = service.createNewGame(id: 'g_autosave_turn', config: config);
+      final updated = service.nextTurn(game, orders: const Orders());
+      expect(service.hasValidAutoSave(), isTrue);
+      final fromSlot = service.loadAutoSaveGame();
+      expect(fromSlot, isNotNull);
+      expect(
+        fromSlot!.worldState.turnState.turnNumber,
+        updated.worldState.turnState.turnNumber,
+      );
     });
   });
 }

--- a/app/test/screen_spec_acceptance_test.dart
+++ b/app/test/screen_spec_acceptance_test.dart
@@ -18,6 +18,8 @@ void main() {
     Widget buildMainMenu({
       MainMenuState state = MainMenuState.default_,
       MainMenuVariant variant = MainMenuVariant.plain,
+      bool resumeGameVisible = false,
+      VoidCallback? onResumeGame,
       required VoidCallback onNewGame,
       required VoidCallback onLoadGame,
       required VoidCallback onSettings,
@@ -30,6 +32,8 @@ void main() {
           state: state,
           version: 'v1.0.0',
           onNewGame: onNewGame,
+          resumeGameVisible: resumeGameVisible,
+          onResumeGame: onResumeGame,
           onLoadGame: onLoadGame,
           onSettings: onSettings,
           onQuit: onQuit,
@@ -51,6 +55,52 @@ void main() {
       expect(find.text('Load Game'), findsOneWidget);
       expect(find.text('Settings'), findsOneWidget);
       expect(find.text('Quit'), findsOneWidget);
+    });
+
+    testWidgets('AC Resume game: hidden when resumeGameVisible is false',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildMainMenu(
+        onNewGame: () {},
+        onLoadGame: () {},
+        onSettings: () {},
+        onQuit: () {},
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Resume game'), findsNothing);
+    });
+
+    testWidgets('AC Resume game: shown below New Game when resumeGameVisible',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildMainMenu(
+        resumeGameVisible: true,
+        onResumeGame: () {},
+        onNewGame: () {},
+        onLoadGame: () {},
+        onSettings: () {},
+        onQuit: () {},
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Resume game'), findsOneWidget);
+    });
+
+    testWidgets('AC Resume game: tap invokes onResumeGame',
+        (WidgetTester tester) async {
+      var called = false;
+      await tester.pumpWidget(buildMainMenu(
+        resumeGameVisible: true,
+        onResumeGame: () => called = true,
+        onNewGame: () {},
+        onLoadGame: () {},
+        onSettings: () {},
+        onQuit: () {},
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Resume game'));
+      await tester.pumpAndSettle();
+      expect(called, isTrue);
     });
 
     testWidgets('AC Visibility: displays version in footer',

--- a/packages/colonizethis_save/lib/src/game_save_adapter.dart
+++ b/packages/colonizethis_save/lib/src/game_save_adapter.dart
@@ -10,6 +10,10 @@ const String _suffixTopologyByRegion = '_topologyByRegion';
 const String _suffixCombinedTopology = '_combinedTopology';
 const String _suffixWarpLinks = '_warpLinks';
 
+/// Fixed Hive key stem for the single auto-save slot. Not listed in [listGameIds].
+/// See SPEC/program/save-load.md § Auto-save slot.
+const String kAutoSaveSlotId = '__colonizethis_autosave';
+
 /// Saves and loads [Game] state to/from a Hive box. One entry per game, keyed by [Game.id].
 /// Map data (tile maps, topology) is required for playable saves. See SPEC/program/save-load.md.
 class GameSaveAdapter {
@@ -18,6 +22,70 @@ class GameSaveAdapter {
     _log.i('saving gameId=${game.id}');
     box.put(game.id, game.toJson());
     _log.i('saved gameId=${game.id}');
+  }
+
+  /// Writes [game] and map data under [kAutoSaveSlotId] (mirrors a playable session).
+  /// [Game.id] inside JSON remains the real session id. SPEC/program/save-load.md.
+  void saveAutoSave(
+    Box<dynamic> box,
+    Game game, {
+    required Map<String, TileMapResult> tileMapByRegion,
+    required Map<String, MapTopology> topologyByRegion,
+    required MapTopology combinedTopology,
+    List<WarpLink>? warpLinks,
+  }) {
+    _log.i('saving auto-save slot logicalGameId=${game.id}');
+    box.put(kAutoSaveSlotId, game.toJson());
+    saveMapData(
+      box,
+      kAutoSaveSlotId,
+      tileMapByRegion: tileMapByRegion,
+      topologyByRegion: topologyByRegion,
+      combinedTopology: combinedTopology,
+      warpLinks: warpLinks,
+    );
+    _log.i('saved auto-save slot logicalGameId=${game.id}');
+  }
+
+  /// Returns true when the auto-save slot holds a playable game + map data.
+  /// On invalid or partial data, clears the slot and logs with prefix `save:`.
+  bool hasValidAutoSave(Box<dynamic> box) {
+    if (!box.containsKey(kAutoSaveSlotId)) {
+      _removeOrphanAutosaveMapKeys(box);
+      return false;
+    }
+    final game = load(box, kAutoSaveSlotId);
+    if (game == null) {
+      _log.w('save: auto-save game JSON invalid; clearing slot');
+      delete(box, kAutoSaveSlotId);
+      return false;
+    }
+    try {
+      loadMapData(box, kAutoSaveSlotId);
+      return true;
+    } catch (e, st) {
+      _log.w(
+        'save: auto-save map data invalid; clearing slot',
+        error: e,
+        stackTrace: st,
+      );
+      delete(box, kAutoSaveSlotId);
+      return false;
+    }
+  }
+
+  void _removeOrphanAutosaveMapKeys(Box<dynamic> box) {
+    if (box.containsKey(kAutoSaveSlotId)) {
+      return;
+    }
+    final hasOrphan = box.containsKey(kAutoSaveSlotId + _suffixTileMapByRegion) ||
+        box.containsKey(kAutoSaveSlotId + _suffixTopologyByRegion) ||
+        box.containsKey(kAutoSaveSlotId + _suffixCombinedTopology) ||
+        box.containsKey(kAutoSaveSlotId + _suffixWarpLinks);
+    if (hasOrphan) {
+      _log.w('save: clearing orphan auto-save map keys');
+      delete(box, kAutoSaveSlotId);
+    }
   }
 
   /// Loads game by [gameId]. Returns null if not found or invalid.
@@ -51,6 +119,7 @@ class GameSaveAdapter {
     final definiteGameIds = allKeys
         .where(
           (k) =>
+              k != kAutoSaveSlotId &&
               !k.endsWith(_suffixTileMapByRegion) &&
               !k.endsWith(_suffixTopologyByRegion) &&
               !k.endsWith(_suffixCombinedTopology) &&
@@ -66,22 +135,30 @@ class GameSaveAdapter {
           0,
           key.length - _suffixTileMapByRegion.length,
         );
-        if (!definiteGameIds.contains(prefix)) result.add(key);
+        if (prefix != kAutoSaveSlotId && !definiteGameIds.contains(prefix)) {
+          result.add(key);
+        }
       } else if (key.endsWith(_suffixTopologyByRegion)) {
         final prefix = key.substring(
           0,
           key.length - _suffixTopologyByRegion.length,
         );
-        if (!definiteGameIds.contains(prefix)) result.add(key);
+        if (prefix != kAutoSaveSlotId && !definiteGameIds.contains(prefix)) {
+          result.add(key);
+        }
       } else if (key.endsWith(_suffixCombinedTopology)) {
         final prefix = key.substring(
           0,
           key.length - _suffixCombinedTopology.length,
         );
-        if (!definiteGameIds.contains(prefix)) result.add(key);
+        if (prefix != kAutoSaveSlotId && !definiteGameIds.contains(prefix)) {
+          result.add(key);
+        }
       } else if (key.endsWith(_suffixWarpLinks)) {
         final prefix = key.substring(0, key.length - _suffixWarpLinks.length);
-        if (!definiteGameIds.contains(prefix)) result.add(key);
+        if (prefix != kAutoSaveSlotId && !definiteGameIds.contains(prefix)) {
+          result.add(key);
+        }
       }
     }
 

--- a/packages/colonizethis_save/test/game_save_adapter_test.dart
+++ b/packages/colonizethis_save/test/game_save_adapter_test.dart
@@ -440,6 +440,154 @@ void main() {
       },
     );
 
+    group('Auto-save slot (kAutoSaveSlotId)', () {
+      Game minimalGame(String logicalId) {
+        return Game(
+          id: logicalId,
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'player1', displayName: 'Spain', isHuman: true),
+          ],
+        );
+      }
+
+      (TileMapResult, MapTopology) minimalMap() {
+        final tileMap = TileMapResult(
+          width: 2,
+          height: 2,
+          grid: [
+            ['p1', 'p1'],
+            ['p2', 's1'],
+          ],
+        );
+        final topo = MapTopology(
+          nodes: [
+            TopologyNode(
+              id: 'p1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'p2',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 's1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+          ],
+          edges: [],
+        );
+        return (tileMap, topo);
+      }
+
+      test('saveAutoSave then load round-trip preserves logical game id', () {
+        final game = minimalGame('session_abc');
+        final (tileMap, topo) = minimalMap();
+        adapter.saveAutoSave(
+          box,
+          game,
+          tileMapByRegion: {'oldWorld': tileMap, 'newWorld': tileMap},
+          topologyByRegion: {'oldWorld': topo, 'newWorld': topo},
+          combinedTopology: topo,
+        );
+        expect(adapter.hasValidAutoSave(box), isTrue);
+        final loaded = adapter.load(box, kAutoSaveSlotId);
+        expect(loaded, isNotNull);
+        expect(loaded!.id, 'session_abc');
+        expect(loaded.worldState.turnState.turnNumber, 3);
+        final md = adapter.loadMapData(box, kAutoSaveSlotId);
+        expect(md.tileMapByRegion['oldWorld']!.width, 2);
+      });
+
+      test('listGameIds excludes auto-save stem even when slot is populated', () {
+        final game = minimalGame('only_logical');
+        final (tileMap, topo) = minimalMap();
+        adapter.saveAutoSave(
+          box,
+          game,
+          tileMapByRegion: {'oldWorld': tileMap, 'newWorld': tileMap},
+          topologyByRegion: {'oldWorld': topo, 'newWorld': topo},
+          combinedTopology: topo,
+        );
+        expect(adapter.listGameIds(box), isEmpty);
+      });
+
+      test('listGameIds excludes stem when user game also exists', () {
+        final userGame = minimalGame('user_slot');
+        adapter.save(box, userGame);
+        final (tileMap, topo) = minimalMap();
+        adapter.saveMapData(
+          box,
+          'user_slot',
+          tileMapByRegion: {'oldWorld': tileMap, 'newWorld': tileMap},
+          topologyByRegion: {'oldWorld': topo, 'newWorld': topo},
+          combinedTopology: topo,
+        );
+        adapter.saveAutoSave(
+          box,
+          userGame,
+          tileMapByRegion: {'oldWorld': tileMap, 'newWorld': tileMap},
+          topologyByRegion: {'oldWorld': topo, 'newWorld': topo},
+          combinedTopology: topo,
+        );
+        expect(adapter.listGameIds(box), ['user_slot']);
+      });
+
+      test('hasValidAutoSave is false when slot empty', () {
+        expect(adapter.hasValidAutoSave(box), isFalse);
+      });
+
+      test('hasValidAutoSave clears slot when game JSON is corrupt', () {
+        box.put(kAutoSaveSlotId, 'not-json');
+        expect(adapter.hasValidAutoSave(box), isFalse);
+        expect(box.containsKey(kAutoSaveSlotId), isFalse);
+      });
+
+      test('hasValidAutoSave clears slot when map data missing', () {
+        final game = minimalGame('g');
+        box.put(kAutoSaveSlotId, game.toJson());
+        expect(adapter.hasValidAutoSave(box), isFalse);
+        expect(box.containsKey(kAutoSaveSlotId), isFalse);
+      });
+
+      test('hasValidAutoSave clears slot when map data invalid', () {
+        final game = minimalGame('g');
+        box.put(kAutoSaveSlotId, game.toJson());
+        box.put(
+          '${kAutoSaveSlotId}_tileMapByRegion',
+          {'bad': 'data'},
+        );
+        box.put(
+          '${kAutoSaveSlotId}_topologyByRegion',
+          {'bad': 'data'},
+        );
+        box.put('${kAutoSaveSlotId}_combinedTopology', 'x');
+        expect(adapter.hasValidAutoSave(box), isFalse);
+        expect(box.containsKey(kAutoSaveSlotId), isFalse);
+      });
+
+      test('clears orphan auto-save map keys when game key missing', () {
+        final (tileMap, topo) = minimalMap();
+        adapter.saveMapData(
+          box,
+          kAutoSaveSlotId,
+          tileMapByRegion: {'oldWorld': tileMap, 'newWorld': tileMap},
+          topologyByRegion: {'oldWorld': topo, 'newWorld': topo},
+          combinedTopology: topo,
+        );
+        expect(box.containsKey('${kAutoSaveSlotId}_tileMapByRegion'), isTrue);
+        expect(adapter.hasValidAutoSave(box), isFalse);
+        expect(box.containsKey('${kAutoSaveSlotId}_tileMapByRegion'), isFalse);
+      });
+    });
+
     test('backward compatibility - turnTimeMapping missing yields null', () {
       // Simulate legacy save where turnTimeMapping field is missing
       final gameJson = {


### PR DESCRIPTION
## Summary

Implements the Flutter main-menu **Resume game** flow and a mirrored **auto-save** Hive slot (`__colonizethis_autosave`), aligned with updated `SPEC/program/save-load.md` and `SPEC/ui/main-menu.md`. Auto-save is written after new-game persistence and after each completed turn resolution; invalid slots are cleared and logged. `NavigateToShellEvent` clears the in-memory game and orders so the menu (including Resume visibility) updates immediately when returning from play.

## Refs

Refs #1529 — this PR implements the planned work; it does **not** close the issue (follow-up tracking or closure can happen separately).

## Notes

- Generated l10n Dart files under `app/lib/l10n/app_localizations*.dart` are gitignored; run `flutter gen-l10n` in `app/` after pulling if the IDE reports a missing `mainMenu_resumeGame` getter.
