### PR TITLE
refactor: Replace magic numbers and hardcoded strings (issue #1531 item 3)

### DIFF
--- a/packages/colonizethis_logic/lib/src/constants.dart
+++ b/packages/colonizethis_logic/lib/src/constants.dart
@@ -6,6 +6,17 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 const String kRegionOldWorld = 'oldWorld';
 const String kRegionNewWorld = 'newWorld';
 
+/// Default sea fraction for map generation (0.6 = 60% sea, 40% land).
+const double kDefaultSeaFraction = 0.6;
+
+/// Work target string constants for work orders. Used across order suggestion,
+/// validation, and application to avoid hardcoded string literals.
+const String kWorkTargetStealTech = 'steal_tech';
+const String kWorkTargetCounterSpy = 'counter_spy';
+const String kWorkTargetPurchaseLand = 'purchase_land';
+const String kWorkTargetExplore = 'explore';
+const String kWorkTargetProspect = 'prospect';
+
 /// Resource ids that count as minerals for work/purchase rules.
 /// Shared across extraction, work orders, and order application helpers.
 const Set<String> kMineralResourceIds = {

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
@@ -103,6 +103,12 @@ const int callToArmsRefusalScorePenalty = 20;
 /// AI ally joins the war if B–A relation score is at least this (inclusive). SPEC/game/diplomacy.md.
 const int callToArmsAiAcceptMinRelationScore = 50;
 
+/// AI intervention probability by relation level (0–1). SPEC/game/diplomacy.md § Intervention.
+/// Relation score 0–25 (Hostile) → 0%, 26–50 (Neutral) → 25%, 51–75 (Friendly) → 50%, 76–100 (Allied) → 80%.
+const double kInterventionProbabilityNeutral = 0.25;
+const double kInterventionProbabilityFriendly = 0.5;
+const double kInterventionProbabilityAllied = 0.8;
+
 /// Default Grant Aid amount (UI + suggestions). Positive multiples of [grantAidAmountStep].
 const int grantAidDefaultAmount = 1000;
 
@@ -139,12 +145,14 @@ String relationScoreToDisplayLabel(int score) {
 }
 
 /// Normalizes faction pair for lookup (consistent ordering).
-String pairKey(String a, String b) =>
-    a.compareTo(b) <= 0 ? '$a|$b' : '$b|$a';
+String pairKey(String a, String b) => a.compareTo(b) <= 0 ? '$a|$b' : '$b|$a';
 
 /// Returns relation for faction pair, or null if not found.
 DiplomacyRelation? getRelation(
-    Game game, String factionId1, String factionId2) {
+  Game game,
+  String factionId1,
+  String factionId2,
+) {
   final key = pairKey(factionId1, factionId2);
   for (final r in game.diplomacyRelations) {
     if (pairKey(r.factionId1, r.factionId2) == key) return r;
@@ -160,8 +168,9 @@ List<DiplomacyRelation> upsertRelation(
   DiplomacyRelation Function(DiplomacyRelation?) updater,
 ) {
   final key = pairKey(factionId1, factionId2);
-  final idx =
-      relations.indexWhere((r) => pairKey(r.factionId1, r.factionId2) == key);
+  final idx = relations.indexWhere(
+    (r) => pairKey(r.factionId1, r.factionId2) == key,
+  );
   final existing = idx >= 0 ? relations[idx] : null;
   final updated = updater(existing);
   final result = List<DiplomacyRelation>.from(relations);
@@ -197,9 +206,11 @@ bool canAttackWithWarOrDeclaring(
 ) {
   final rel = getRelation(game, playerId, targetOwnerId);
   final atWar = rel?.atWar ?? false;
-  final declaringWarThisTurn = diplomaticOrders.any((o) =>
-      o.type == DiplomaticOrderType.declareWar &&
-      o.targetFactionId == targetOwnerId);
+  final declaringWarThisTurn = diplomaticOrders.any(
+    (o) =>
+        o.type == DiplomaticOrderType.declareWar &&
+        o.targetFactionId == targetOwnerId,
+  );
   return atWar || declaringWarThisTurn;
 }
 
@@ -211,8 +222,11 @@ List<DiplomaticEvent> diplomaticHistoryForPair(
   String factionB,
 ) {
   final list = game.diplomaticHistoryEvents
-      .where((e) =>
-          e.participants.contains(factionA) && e.participants.contains(factionB))
+      .where(
+        (e) =>
+            e.participants.contains(factionA) &&
+            e.participants.contains(factionB),
+      )
       .toList();
   list.sort((a, b) {
     final turnCmp = b.turn.compareTo(a.turn);

--- a/packages/colonizethis_logic/lib/src/diplomacy/intervention_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/intervention_resolver.dart
@@ -107,9 +107,11 @@ CallToArmsDecision? _findCallToArmsDecision(
 /// Relation score 0–25 → 0%, 26–50 → 25%, 51–75 → 50%, 76–100 → 80%.
 double _aiInterventionProbability(int relationScore) {
   if (relationScore <= relationScoreLevelHostileMax) return 0;
-  if (relationScore <= relationScoreLevelNeutralMax) return 0.25;
-  if (relationScore <= relationScoreLevelFriendlyMax) return 0.5;
-  return 0.8;
+  if (relationScore <= relationScoreLevelNeutralMax)
+    return kInterventionProbabilityNeutral;
+  if (relationScore <= relationScoreLevelFriendlyMax)
+    return kInterventionProbabilityFriendly;
+  return kInterventionProbabilityAllied;
 }
 
 InterventionChoice _chooseAiIntervention(

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../constants.dart';
 import '../diplomacy/diplomacy_relation_lookup.dart';
 import '../diplomacy/diplomacy_resolver.dart';
 import '../world/movement.dart';
@@ -205,13 +206,10 @@ bool _armyMoveNeedsDeclareWarTrial(
   String? destOwnerId,
   List<DiplomaticOrder> diplo,
 ) {
-  if (destOwnerId == null ||
-      destOwnerId.isEmpty ||
-      destOwnerId == playerId) {
+  if (destOwnerId == null || destOwnerId.isEmpty || destOwnerId == playerId) {
     return false;
   }
-  if (!isGreatPower(game, destOwnerId) &&
-      !isMinorOrTribe(game, destOwnerId)) {
+  if (!isGreatPower(game, destOwnerId) && !isMinorOrTribe(game, destOwnerId)) {
     return false;
   }
   return !canAttackWithWarOrDeclaring(game, playerId, destOwnerId, diplo);
@@ -228,7 +226,8 @@ List<ArmyMovePickerDestination> armyMovePickerDestinations({
   required Orders currentOrders,
 }) {
   final view = buildPlayerView(game, topology, playerId);
-  final diplo = currentOrders.diplomaticOrdersByPlayerId[playerId] ??
+  final diplo =
+      currentOrders.diplomaticOrdersByPlayerId[playerId] ??
       const <DiplomaticOrder>[];
   final raw = armyMoveCandidateDestinationProvinceIds(
     game: game,
@@ -240,10 +239,7 @@ List<ArmyMovePickerDestination> armyMovePickerDestinations({
   for (final fullId in raw) {
     final province = tryGetProvince(game.worldState, fullId);
     final ownerId = province?.ownerId ?? '';
-    final move = ArmyMoveOrder(
-      armyId: army.id,
-      destinationProvinceId: fullId,
-    );
+    final move = ArmyMoveOrder(armyId: army.id, destinationProvinceId: fullId);
     final acceptedBase = _isArmyMoveOrderAccepted(
       game,
       topology,
@@ -564,11 +560,12 @@ List<WorkOrder> suggestWorkOrders(
     if (isSpy && tilesInProvince.isNotEmpty) {
       final allowedTargets = workOrderTargetsByUnitType[type];
       if (allowedTargets != null) {
-        if (allowedTargets.contains('counter_spy') && ownerId == playerId) {
+        if (allowedTargets.contains(kWorkTargetCounterSpy) &&
+            ownerId == playerId) {
           final targetTileKey = tilesInProvince.first;
           final candidate = WorkOrder(
             unitId: unit.id,
-            target: 'counter_spy',
+            target: kWorkTargetCounterSpy,
             targetTileKey: targetTileKey,
           );
           if (_isWorkOrderAccepted(
@@ -582,7 +579,7 @@ List<WorkOrder> suggestWorkOrders(
             suggestions.add(candidate);
           }
         }
-        if (allowedTargets.contains('steal_tech')) {
+        if (allowedTargets.contains(kWorkTargetStealTech)) {
           for (final other in game.players) {
             if (other.id == playerId || other.capitalProvinceId == null)
               continue;
@@ -593,7 +590,7 @@ List<WorkOrder> suggestWorkOrders(
             if (capTiles.isEmpty) continue;
             final candidate = WorkOrder(
               unitId: unit.id,
-              target: 'steal_tech',
+              target: kWorkTargetStealTech,
               targetTileKey: capTiles.first,
             );
             if (_isWorkOrderAccepted(
@@ -614,7 +611,8 @@ List<WorkOrder> suggestWorkOrders(
 
     if (isMerchant) {
       final allowedTargets = workOrderTargetsByUnitType[type];
-      if (allowedTargets != null && allowedTargets.contains('purchase_land')) {
+      if (allowedTargets != null &&
+          allowedTargets.contains(kWorkTargetPurchaseLand)) {
         final resourceByTile = game.worldState.resourceByTileKey;
         final playerIds = game.players.map((p) => p.id).toSet();
         for (final p in allProvinces(game.worldState)) {
@@ -626,7 +624,7 @@ List<WorkOrder> suggestWorkOrders(
             if (devExclusiveReservedTiles.contains(tk)) continue;
             final candidate = WorkOrder(
               unitId: unit.id,
-              target: 'purchase_land',
+              target: kWorkTargetPurchaseLand,
               targetTileKey: tk,
             );
             if (_isWorkOrderAccepted(
@@ -1073,7 +1071,7 @@ Set<String> _preFilterWorkTargetTiles({
       );
       break;
 
-    case 'counter_spy':
+    case kWorkTargetCounterSpy:
       // Any tile in owned provinces
       _addCandidateTilesForCounterSpy(
         tileKeysByRegion: tileKeysByRegion,
@@ -1082,7 +1080,7 @@ Set<String> _preFilterWorkTargetTiles({
       );
       break;
 
-    case 'steal_tech':
+    case kWorkTargetStealTech:
       // Other GP capital provinces
       _addCandidateTilesForStealTech(
         game: game,
@@ -1091,7 +1089,7 @@ Set<String> _preFilterWorkTargetTiles({
       );
       break;
 
-    case 'purchase_land':
+    case kWorkTargetPurchaseLand:
       // Tiles in Minor/Tribe provinces with resource
       _addCandidateTilesForPurchaseLand(
         game: game,
@@ -1102,7 +1100,7 @@ Set<String> _preFilterWorkTargetTiles({
       );
       break;
 
-    case 'explore':
+    case kWorkTargetExplore:
       for (final regionEntry in tileKeysByRegion.entries) {
         for (final provinceEntry in regionEntry.value.entries) {
           result.addAll(provinceEntry.value);
@@ -1110,7 +1108,7 @@ Set<String> _preFilterWorkTargetTiles({
       }
       break;
 
-    case 'prospect':
+    case kWorkTargetProspect:
       _addCandidateTilesForProspect(
         game: game,
         playerId: playerId,

--- a/packages/colonizethis_logic/lib/src/orders/order_visibility.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_visibility.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../constants.dart';
 import '../world/player_view.dart';
 
 /// Order visibility rules. SPEC/program/fog-and-exploration-resolution.md.
@@ -46,7 +47,11 @@ bool moveSourceVisibilityOk(
   String provinceId,
 ) {
   return provinceHasAtLeastVisibility(
-      view, regionId, provinceId, VisibilityLevel.revealed);
+    view,
+    regionId,
+    provinceId,
+    VisibilityLevel.revealed,
+  );
 }
 
 /// Move order: destination province must be known (not unknown).
@@ -88,7 +93,12 @@ String regionIdForUnit(PlayerView view, Unit unit) {
 
 /// Work order: true iff the unit's province (and [targetTileKey] when applicable) meets
 /// the minimum visibility for [workTarget]. SPEC/program/fog-and-exploration-resolution.md.
-bool workOrderVisibilityOk(PlayerView view, Unit unit, String workTarget, [String? targetTileKey]) {
+bool workOrderVisibilityOk(
+  PlayerView view,
+  Unit unit,
+  String workTarget, [
+  String? targetTileKey,
+]) {
   final regionId = targetTileKey != null && targetTileKey.isNotEmpty
       ? Unit.requireRegionIdFromTileKey(targetTileKey)
       : regionIdForUnit(view, unit);
@@ -101,10 +111,18 @@ bool workOrderVisibilityOk(PlayerView view, Unit unit, String workTarget, [Strin
   switch (workTarget) {
     case 'explore':
       return provinceHasAtLeastVisibility(
-          view, regionId, provinceId, VisibilityLevel.revealed);
+        view,
+        regionId,
+        provinceId,
+        VisibilityLevel.revealed,
+      );
     case 'prospect':
       return provinceHasAtLeastVisibility(
-          view, regionId, provinceId, VisibilityLevel.fogged);
+        view,
+        regionId,
+        provinceId,
+        VisibilityLevel.fogged,
+      );
     case 'build_improvement':
     case 'upgrade_town':
     case 'build_road':
@@ -113,19 +131,35 @@ bool workOrderVisibilityOk(PlayerView view, Unit unit, String workTarget, [Strin
     case 'build_rail':
       return isOwned ||
           provinceHasAtLeastVisibility(
-              view, regionId, provinceId, VisibilityLevel.fogged);
-    case 'purchase_land':
+            view,
+            regionId,
+            provinceId,
+            VisibilityLevel.fogged,
+          );
+    case kWorkTargetPurchaseLand:
       // Minor/Tribe province; tile must be visible to place order. SPEC/civilian-units.md.
       return provinceHasAtLeastVisibility(
-          view, regionId, provinceId, VisibilityLevel.revealed);
-    case 'steal_tech':
+        view,
+        regionId,
+        provinceId,
+        VisibilityLevel.revealed,
+      );
+    case kWorkTargetStealTech:
       // Other GP capital province must be visible. SPEC/civilian-units.md.
       return provinceHasAtLeastVisibility(
-          view, regionId, provinceId, VisibilityLevel.revealed);
-    case 'counter_spy':
+        view,
+        regionId,
+        provinceId,
+        VisibilityLevel.revealed,
+      );
+    case kWorkTargetCounterSpy:
       return isOwned ||
           provinceHasAtLeastVisibility(
-              view, regionId, provinceId, VisibilityLevel.fogged);
+            view,
+            regionId,
+            provinceId,
+            VisibilityLevel.fogged,
+          );
     default:
       return false;
   }

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -39,8 +39,9 @@ void _appendMilitaryRegimentToArmy(
       : fieldArmyIdFor(player.id, spawnProvinceId);
   final ws = state.game.worldState;
   final regionId = ProvinceId.regionIdFrom(spawnProvinceId);
-  final idx =
-      ws.armies.indexWhere((a) => a.id == armyId && a.ownerId == player.id);
+  final idx = ws.armies.indexWhere(
+    (a) => a.id == armyId && a.ownerId == player.id,
+  );
   if (idx >= 0) {
     final a = ws.armies[idx];
     final updated = a.copyWith(
@@ -59,8 +60,7 @@ void _appendMilitaryRegimentToArmy(
     regimentUnitIds: [newUnitId],
     isHomeArmy: atHome,
   );
-  final next = [...ws.armies, newArmy]
-    ..sort((a, b) => a.id.compareTo(b.id));
+  final next = [...ws.armies, newArmy]..sort((a, b) => a.id.compareTo(b.id));
   state.game = state.game.copyWith(worldState: ws.copyWith(armies: next));
 }
 
@@ -253,7 +253,12 @@ void _runBuildPhase(_BuildWorkState state) {
       }
 
       if (category == BuildUnitCategory.military) {
-        _appendMilitaryRegimentToArmy(state, player, spawnProvinceId, newUnit.id);
+        _appendMilitaryRegimentToArmy(
+          state,
+          player,
+          spawnProvinceId,
+          newUnit.id,
+        );
       }
     }
 
@@ -489,8 +494,8 @@ Game applyBuildAndWorkOrders(
           }
         }
         break;
-      case 'steal_tech':
-      case 'counter_spy':
+      case kWorkTargetStealTech:
+      case kWorkTargetCounterSpy:
         break;
       default:
         break;
@@ -529,7 +534,8 @@ Game applyBuildAndWorkOrders(
       }
       // Cancel work if tile no longer under player control (conquest or purchase reverted). SPEC #376.
       // Use same rule as validation: owned province or purchased tile; skip for counter_spy/steal_tech.
-      if (cw.workTarget != 'counter_spy' && cw.workTarget != 'steal_tech') {
+      if (cw.workTarget != kWorkTargetCounterSpy &&
+          cw.workTarget != kWorkTargetStealTech) {
         if (!isTileControlledByPlayer(s.game, u.ownerId, cw.tileKey)) {
           unitsById[entry.key] = u.copyWith(
             status: UnitStatus.idle,
@@ -541,7 +547,7 @@ Game applyBuildAndWorkOrders(
           continue;
         }
       }
-      if (cw.workTarget == 'counter_spy') {
+      if (cw.workTarget == kWorkTargetCounterSpy) {
         // Per-turn: N% per friendly spy (cap M%) to kill one enemy spy in province
         final provinceId = u.locationProvinceId;
         final friendlySpies = unitsById.values
@@ -549,7 +555,7 @@ Game applyBuildAndWorkOrders(
               (x) =>
                   x.ownerId == u.ownerId &&
                   isSpyUnit(x.type) &&
-                  x.currentWork?.workTarget == 'counter_spy' &&
+                  x.currentWork?.workTarget == kWorkTargetCounterSpy &&
                   x.locationProvinceId == provinceId,
             )
             .length;
@@ -590,7 +596,7 @@ Game applyBuildAndWorkOrders(
       }
       final nextRemaining = cw.remainingTurns - 1;
       if (nextRemaining <= 0) {
-        if (cw.workTarget == 'steal_tech') {
+        if (cw.workTarget == kWorkTargetStealTech) {
           final targetProvinceId = Unit.provinceIdFromTileKey(cw.tileKey);
           final otherPlayer = s.game.players
               .where(
@@ -870,8 +876,11 @@ void _runWorkPhase(
         return true;
       }
 
-      if (order.target == 'purchase_land' &&
-          isWorkOrderTargetAllowedForUnitType(u.type, 'purchase_land') &&
+      if (order.target == kWorkTargetPurchaseLand &&
+          isWorkOrderTargetAllowedForUnitType(
+            u.type,
+            kWorkTargetPurchaseLand,
+          ) &&
           hasValidTarget) {
         // SPEC/game/diplomacy.md (GP–Minor/Tribe Rules): purchase_land requires an Embassy
         // with the Minor/Tribe and the buyer must not be at war with that faction.
@@ -915,11 +924,11 @@ void _runWorkPhase(
         continue;
       }
 
-      if (order.target == 'steal_tech' &&
-          isWorkOrderTargetAllowedForUnitType(u.type, 'steal_tech') &&
+      if (order.target == kWorkTargetStealTech &&
+          isWorkOrderTargetAllowedForUnitType(u.type, kWorkTargetStealTech) &&
           u.currentWork == null &&
           hasValidTarget) {
-        final totalTurns = totalTurnsForWork('steal_tech');
+        final totalTurns = totalTurnsForWork(kWorkTargetStealTech);
         _log.d(
           'work order accepted and assigned unit=${order.unitId} target=steal_tech targetTileKey=$targetTileKey totalTurns=$totalTurns',
         );
@@ -929,7 +938,7 @@ void _runWorkPhase(
             status: UnitStatus.working,
             tileKey: targetTileKey,
             currentWork: CurrentWork(
-              workTarget: 'steal_tech',
+              workTarget: kWorkTargetStealTech,
               tileKey: targetTileKey,
               totalTurns: totalTurns,
               remainingTurns: totalTurns,
@@ -939,11 +948,11 @@ void _runWorkPhase(
         continue;
       }
 
-      if (order.target == 'counter_spy' &&
-          isWorkOrderTargetAllowedForUnitType(u.type, 'counter_spy') &&
+      if (order.target == kWorkTargetCounterSpy &&
+          isWorkOrderTargetAllowedForUnitType(u.type, kWorkTargetCounterSpy) &&
           u.currentWork == null &&
           hasValidTarget) {
-        final totalTurns = totalTurnsForWork('counter_spy');
+        final totalTurns = totalTurnsForWork(kWorkTargetCounterSpy);
         _log.d(
           'work order accepted and assigned unit=${order.unitId} target=counter_spy targetTileKey=$targetTileKey totalTurns=$totalTurns',
         );
@@ -953,7 +962,7 @@ void _runWorkPhase(
             status: UnitStatus.working,
             tileKey: targetTileKey,
             currentWork: CurrentWork(
-              workTarget: 'counter_spy',
+              workTarget: kWorkTargetCounterSpy,
               tileKey: targetTileKey,
               totalTurns: totalTurns,
               remainingTurns: 1,
@@ -963,7 +972,7 @@ void _runWorkPhase(
         continue;
       }
 
-      if (order.target == 'prospect' &&
+      if (order.target == kWorkTargetProspect &&
           hasValidTarget &&
           isExplorerUnit(u.type) &&
           isMineralEligibleTile(
@@ -986,7 +995,7 @@ void _runWorkPhase(
       if (order.target == 'build_improvement') {
         if (applyStandardWorkOrder('build_improvement')) continue;
       }
-      if (order.target == 'explore' &&
+      if (order.target == kWorkTargetExplore &&
           isExplorerUnit(u.type) &&
           u.currentWork == null &&
           hasValidTarget) {
@@ -1012,7 +1021,7 @@ void _runWorkPhase(
               status: UnitStatus.working,
               tileKey: targetTileKey,
               currentWork: CurrentWork(
-                workTarget: 'explore',
+                workTarget: kWorkTargetExplore,
                 tileKey: targetTileKey,
                 totalTurns: totalTurns,
                 remainingTurns: totalTurns,

--- a/packages/colonizethis_logic/lib/src/orders/unit_type_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/orders/unit_type_helpers.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_models/colonizethis_models.dart'
     show Game, Orders, WorldState;
 
+import '../constants.dart';
 import '../world/unit_lookup.dart' show allUnitsFromWorld;
 
 /// Shared unit-type and work-target predicates for orders. SPEC/program/orders.md § Work orders.
@@ -18,7 +19,7 @@ bool isDevExclusiveWorkTarget(String target) =>
     target == 'build_road' ||
     target == 'build_port' ||
     target == 'build_fort' ||
-    target == 'purchase_land';
+    target == kWorkTargetPurchaseLand;
 
 /// Tile keys already reserved by [playerId]'s Builder/Engineer/Merchant currentWork.
 /// Used for per-player tile exclusivity (SPEC/game/civilian-units.md, SPEC/program/orders.md).

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_cost_calculator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_cost_calculator.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../../constants.dart';
 import '../../world/province_lookup.dart';
 
 /// Calculates work order material costs. Reduces duplication between validation and projection.
@@ -19,9 +20,9 @@ class WorkOrderCostCalculator {
     int? fortLevel,
     int? roadLevel,
   }) {
-    if (target == 'steal_tech' ||
-        target == 'counter_spy' ||
-        target == 'purchase_land') {
+    if (target == kWorkTargetStealTech ||
+        target == kWorkTargetCounterSpy ||
+        target == kWorkTargetPurchaseLand) {
       return null;
     }
 

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
@@ -96,7 +96,7 @@ class WorkOrderValidator {
           }
         }
 
-        if (o.target == 'steal_tech') {
+        if (o.target == kWorkTargetStealTech) {
           if (targetProvinceId == null) {
             return OrderValidationResult.rejected(
               'Invalid target for steal_tech',
@@ -124,13 +124,13 @@ class WorkOrderValidator {
               'Target has no technology you lack',
             );
           }
-        } else if (o.target == 'counter_spy') {
+        } else if (o.target == kWorkTargetCounterSpy) {
           if (ownerId != _playerId) {
             return OrderValidationResult.rejected(
               'counter_spy target must be your own province',
             );
           }
-        } else if (o.target == 'purchase_land') {
+        } else if (o.target == kWorkTargetPurchaseLand) {
           if (ownerId == null || ownerId == _playerId) {
             return OrderValidationResult.rejected(
               'purchase_land target must be a Minor or Tribe province',
@@ -244,9 +244,9 @@ class WorkOrderValidator {
           );
         }
 
-        if (o.target != 'steal_tech' &&
-            o.target != 'counter_spy' &&
-            o.target != 'purchase_land') {
+        if (o.target != kWorkTargetStealTech &&
+            o.target != kWorkTargetCounterSpy &&
+            o.target != kWorkTargetPurchaseLand) {
           final improvementLevel = o.target == 'build_improvement'
               ? _game.worldState.tileState.improvementLevel(o.targetTileKey)
               : 0;
@@ -315,7 +315,7 @@ class WorkOrderValidator {
           );
         }
 
-        if (o.target == 'prospect') {
+        if (o.target == kWorkTargetProspect) {
           if (!isMineralEligibleTile(
             _game,
             _tileMapByRegion,
@@ -339,14 +339,15 @@ class WorkOrderValidator {
         }
 
         // Apply projected cost so subsequent work orders see updated state.
-        if (o.target == 'purchase_land') {
+        if (o.target == kWorkTargetPurchaseLand) {
           final resourceId =
               _game.worldState.resourceByTileKey[o.targetTileKey];
           if (resourceId != null && resourceId.isNotEmpty) {
             final cost = purchaseLandCost(resourceId);
             _treasury -= cost;
           }
-        } else if (o.target != 'steal_tech' && o.target != 'counter_spy') {
+        } else if (o.target != kWorkTargetStealTech &&
+            o.target != kWorkTargetCounterSpy) {
           final improvementLevel = o.target == 'build_improvement'
               ? _game.worldState.tileState.improvementLevel(o.targetTileKey)
               : 0;

--- a/packages/colonizethis_logic/lib/src/setup/init_game_orchestrator.dart
+++ b/packages/colonizethis_logic/lib/src/setup/init_game_orchestrator.dart
@@ -101,7 +101,7 @@ InitGameResult runInitGame({
   final mapGenParams = MapGenerationParams(
     numContinents: config.continentCount,
     seed: effectiveSeed,
-    seaFraction: 0.6,
+    seaFraction: kDefaultSeaFraction,
   );
   final sizeOW = computeGridSizeFromParams(
     config.numProvincesOldWorld,
@@ -111,7 +111,7 @@ InitGameResult runInitGame({
     width: sizeOW.width,
     height: sizeOW.height,
     seed: effectiveSeed,
-    seaFraction: 0.6,
+    seaFraction: kDefaultSeaFraction,
     skipFillLakes: options.skipFillLakes,
   );
   final gen = generateRegion ?? defaultTileMapRegionGenerator;
@@ -133,7 +133,7 @@ InitGameResult runInitGame({
     width: sizeNW.width,
     height: sizeNW.height,
     seed: effectiveSeed + 1,
-    seaFraction: 0.6,
+    seaFraction: kDefaultSeaFraction,
     skipFillLakes: options.skipFillLakes,
   );
   final (tileMapNW, topoNW) = gen(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -497,10 +497,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

Addresses issue #1531 high priority item #3: Magic Numbers and Hardcoded Strings

### Changes Made

1. **Sea Fraction Constant** (`kDefaultSeaFraction = 0.6`)
   - Added to `packages/colonizethis_logic/lib/src/constants.dart`
   - Replaced 3 hardcoded `0.6` values in `init_game_orchestrator.dart`

2. **Intervention Probability Constants** (in `diplomacy_relation_lookup.dart`)
   - `kInterventionProbabilityNeutral = 0.25`
   - `kInterventionProbabilityFriendly = 0.5`
   - `kInterventionProbabilityAllied = 0.8`
   - Replaced hardcoded values in `intervention_resolver.dart`

3. **Work Target String Constants** (`constants.dart`)
   - `kWorkTargetStealTech = 'steal_tech'`
   - `kWorkTargetCounterSpy = 'counter_spy'`
   - `kWorkTargetPurchaseLand = 'purchase_land'`
   - `kWorkTargetExplore = 'explore'`
   - `kWorkTargetProspect = 'prospect'`
   - Replaced across multiple files in `colonizethis_logic`

### Files Modified

- `packages/colonizethis_logic/lib/src/constants.dart` - Added new constants
- `packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart` - Added intervention probability constants
- `packages/colonizethis_logic/lib/src/diplomacy/intervention_resolver.dart` - Use constants
- `packages/colonizethis_logic/lib/src/setup/init_game_orchestrator.dart` - Use `kDefaultSeaFraction`
- `packages/colonizethis_logic/lib/src/orders/orders_application.dart` - Use work target constants
- `packages/colonizethis_logic/lib/src/orders/order_suggestion.dart` - Use work target constants
- `packages/colonizethis_logic/lib/src/orders/order_visibility.dart` - Use work target constants
- `packages/colonizethis_logic/lib/src/orders/unit_type_helpers.dart` - Use work target constants
- `packages/colonizethis_logic/lib/src/orders/validators/work_order_cost_calculator.dart` - Use work target constants
- `packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart` - Use work target constants

### Verification

- All colonizethis_logic tests pass (1046 tests)
- All colonizethis_map tests pass (127 tests)

---

Refs #1531