### PR TITLE
refactor(logic): map dispatch for spy/merchant work target validation

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_special_target_validation.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_special_target_validation.dart
@@ -1,0 +1,145 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../../constants.dart';
+import '../../diplomacy/diplomacy_resolver.dart';
+import '../order_validation_result.dart';
+
+/// Shared inputs for [workOrderSpecialTargetChecks] (spy/merchant targets).
+class WorkOrderSpecialTargetContext {
+  const WorkOrderSpecialTargetContext({
+    required this.game,
+    required this.player,
+    required this.playerId,
+    required this.treasury,
+  });
+
+  final Game game;
+  final Player player;
+  final String playerId;
+  final int treasury;
+}
+
+/// Returns a rejection, or `null` when this target-specific rule passes.
+typedef SpecialTargetWorkCheck =
+    OrderValidationResult? Function(
+      WorkOrderSpecialTargetContext ctx,
+      WorkOrder o,
+      String? targetProvinceId,
+      String? ownerId,
+    );
+
+/// Map dispatch for work targets that previously used a long if–else chain.
+/// Unknown targets are not present; caller continues with generic rules.
+final Map<String, SpecialTargetWorkCheck> workOrderSpecialTargetChecks = {
+  kWorkTargetStealTech: validateStealTechWorkTarget,
+  kWorkTargetCounterSpy: validateCounterSpyWorkTarget,
+  kWorkTargetPurchaseLand: validatePurchaseLandWorkTarget,
+};
+
+OrderValidationResult? validateStealTechWorkTarget(
+  WorkOrderSpecialTargetContext ctx,
+  WorkOrder _o,
+  String? targetProvinceId,
+  String? _ownerId,
+) {
+  if (targetProvinceId == null) {
+    return OrderValidationResult.rejected('Invalid target for steal_tech');
+  }
+  final otherPlayer = ctx.game.players
+      .where(
+        (p) =>
+            p.id != ctx.playerId && p.capitalProvinceId == targetProvinceId,
+      )
+      .firstOrNull;
+  if (otherPlayer == null) {
+    return OrderValidationResult.rejected(
+      'steal_tech target must be another Great Power capital province',
+    );
+  }
+  final ourTech = ctx.player.techUnlocked ?? {};
+  final theirTech = otherPlayer.techUnlocked ?? {};
+  final hasTechWeLack = theirTech.entries.any(
+    (e) => e.value == true && ourTech[e.key] != true,
+  );
+  if (!hasTechWeLack) {
+    return OrderValidationResult.rejected(
+      'Target has no technology you lack',
+    );
+  }
+  return null;
+}
+
+OrderValidationResult? validateCounterSpyWorkTarget(
+  WorkOrderSpecialTargetContext ctx,
+  WorkOrder _o,
+  String? _targetProvinceId,
+  String? ownerId,
+) {
+  if (ownerId != ctx.playerId) {
+    return OrderValidationResult.rejected(
+      'counter_spy target must be your own province',
+    );
+  }
+  return null;
+}
+
+OrderValidationResult? validatePurchaseLandWorkTarget(
+  WorkOrderSpecialTargetContext ctx,
+  WorkOrder o,
+  String? _targetProvinceId,
+  String? ownerId,
+) {
+  if (ownerId == null || ownerId == ctx.playerId) {
+    return OrderValidationResult.rejected(
+      'purchase_land target must be a Minor or Tribe province',
+    );
+  }
+  if (!isMinorOrTribe(ctx.game, ownerId)) {
+    return OrderValidationResult.rejected(
+      'purchase_land target must be a Minor or Tribe province',
+    );
+  }
+  final rel = getRelation(ctx.game, ctx.playerId, ownerId);
+  if (rel?.atWar == true) {
+    return OrderValidationResult.rejected(
+      'Cannot purchase land: at war with that faction',
+    );
+  }
+  final overture = getOverture(ctx.game, ctx.playerId, ownerId);
+  if (overture == null || !overture.hasEmbassy) {
+    return OrderValidationResult.rejected(
+      'Cannot purchase land: embassy required with that Minor/Tribe',
+    );
+  }
+  final resourceId = ctx.game.worldState.resourceByTileKey[o.targetTileKey];
+  if (resourceId == null || resourceId.isEmpty) {
+    return OrderValidationResult.rejected('Tile has no resource');
+  }
+  if (kMineralResourceIds.contains(resourceId)) {
+    final prospected =
+        ctx.game.worldState.playerProspectedTiles[ctx.playerId] ??
+        const <String>{};
+    if (!prospected.contains(o.targetTileKey)) {
+      return OrderValidationResult.rejected(
+        'Mineral tile must be prospected first',
+      );
+    }
+  }
+  final cost = purchaseLandCost(resourceId);
+  if (ctx.treasury < cost) {
+    return OrderValidationResult.rejected(
+      'Insufficient treasury for purchase_land (need $cost)',
+    );
+  }
+  final existingBuyer =
+      ctx.game.worldState.purchasedTilesByTileKey[o.targetTileKey];
+  if (existingBuyer != null) {
+    return OrderValidationResult.rejected(
+      existingBuyer == ctx.playerId
+          ? 'You already own this tile'
+          : 'Tile already purchased by another power',
+    );
+  }
+  return null;
+}

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
@@ -12,6 +12,7 @@ import '../order_visibility.dart';
 import '../order_validation_result.dart';
 import '../unit_type_helpers.dart';
 import 'work_order_cost_calculator.dart';
+import 'work_order_special_target_validation.dart';
 
 /// Validates work orders for a single player in submission order.
 /// Mutates internal economy state (stockpile, treasury) and [devExclusiveTiles]
@@ -96,92 +97,22 @@ class WorkOrderValidator {
           }
         }
 
-        if (o.target == kWorkTargetStealTech) {
-          if (targetProvinceId == null) {
-            return OrderValidationResult.rejected(
-              'Invalid target for steal_tech',
-            );
-          }
-          final otherPlayer = _game.players
-              .where(
-                (p) =>
-                    p.id != _playerId &&
-                    p.capitalProvinceId == targetProvinceId,
-              )
-              .firstOrNull;
-          if (otherPlayer == null) {
-            return OrderValidationResult.rejected(
-              'steal_tech target must be another Great Power capital province',
-            );
-          }
-          final ourTech = _player.techUnlocked ?? {};
-          final theirTech = otherPlayer.techUnlocked ?? {};
-          final hasTechWeLack = theirTech.entries.any(
-            (e) => e.value == true && ourTech[e.key] != true,
+        final specialCheck = workOrderSpecialTargetChecks[o.target];
+        if (specialCheck != null) {
+          final specialCtx = WorkOrderSpecialTargetContext(
+            game: _game,
+            player: _player,
+            playerId: _playerId,
+            treasury: _treasury,
           );
-          if (!hasTechWeLack) {
-            return OrderValidationResult.rejected(
-              'Target has no technology you lack',
-            );
-          }
-        } else if (o.target == kWorkTargetCounterSpy) {
-          if (ownerId != _playerId) {
-            return OrderValidationResult.rejected(
-              'counter_spy target must be your own province',
-            );
-          }
-        } else if (o.target == kWorkTargetPurchaseLand) {
-          if (ownerId == null || ownerId == _playerId) {
-            return OrderValidationResult.rejected(
-              'purchase_land target must be a Minor or Tribe province',
-            );
-          }
-          if (!isMinorOrTribe(_game, ownerId)) {
-            return OrderValidationResult.rejected(
-              'purchase_land target must be a Minor or Tribe province',
-            );
-          }
-          final rel = getRelation(_game, _playerId, ownerId);
-          if (rel?.atWar == true) {
-            return OrderValidationResult.rejected(
-              'Cannot purchase land: at war with that faction',
-            );
-          }
-          final overture = getOverture(_game, _playerId, ownerId);
-          if (overture == null || !overture.hasEmbassy) {
-            return OrderValidationResult.rejected(
-              'Cannot purchase land: embassy required with that Minor/Tribe',
-            );
-          }
-          final resourceId =
-              _game.worldState.resourceByTileKey[o.targetTileKey];
-          if (resourceId == null || resourceId.isEmpty) {
-            return OrderValidationResult.rejected('Tile has no resource');
-          }
-          if (kMineralResourceIds.contains(resourceId)) {
-            final prospected =
-                _game.worldState.playerProspectedTiles[_playerId] ??
-                const <String>{};
-            if (!prospected.contains(o.targetTileKey)) {
-              return OrderValidationResult.rejected(
-                'Mineral tile must be prospected first',
-              );
-            }
-          }
-          final cost = purchaseLandCost(resourceId);
-          if (_treasury < cost) {
-            return OrderValidationResult.rejected(
-              'Insufficient treasury for purchase_land (need $cost)',
-            );
-          }
-          final existingBuyer =
-              _game.worldState.purchasedTilesByTileKey[o.targetTileKey];
-          if (existingBuyer != null) {
-            return OrderValidationResult.rejected(
-              existingBuyer == _playerId
-                  ? 'You already own this tile'
-                  : 'Tile already purchased by another power',
-            );
+          final specialResult = specialCheck(
+            specialCtx,
+            o,
+            targetProvinceId,
+            ownerId,
+          );
+          if (specialResult != null) {
+            return specialResult;
           }
         } else if (o.target == 'build_improvement') {
           final controlled = isTileControlledByPlayer(

--- a/packages/colonizethis_logic/test/orders/validators/work_order_special_target_validation_test.dart
+++ b/packages/colonizethis_logic/test/orders/validators/work_order_special_target_validation_test.dart
@@ -1,0 +1,189 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/src/constants.dart';
+import 'package:colonizethis_logic/src/orders/order_validation_result.dart';
+import 'package:colonizethis_logic/src/orders/validators/work_order_special_target_validation.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('workOrderSpecialTargetChecks', () {
+    test('registers steal_tech, counter_spy, and purchase_land only', () {
+      expect(
+        workOrderSpecialTargetChecks.keys.toSet(),
+        {
+          kWorkTargetStealTech,
+          kWorkTargetCounterSpy,
+          kWorkTargetPurchaseLand,
+        },
+      );
+    });
+
+    test('unknown work target is not in the map (falls through to generic rules)', () {
+      expect(workOrderSpecialTargetChecks['build_road'], isNull);
+      expect(workOrderSpecialTargetChecks['unknown_target'], isNull);
+    });
+  });
+
+  group('validateStealTechWorkTarget', () {
+    const ow = 'oldWorld';
+    final p1 = Player(
+      id: 'p1',
+      displayName: 'P1',
+      isHuman: true,
+      capitalProvinceId: '$ow|P1',
+      stockpile: const Stockpile(),
+      treasury: 0,
+    );
+    final emptyGame = Game(
+      id: 'g1',
+      worldState: WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+        oldWorld: const RegionData(),
+        newWorld: const RegionData(),
+      ),
+      players: [p1],
+    );
+
+    test('rejects when targetProvinceId is null', () {
+      const o = WorkOrder(
+        unitId: 'u1',
+        target: kWorkTargetStealTech,
+        targetTileKey: '$ow|P2|0|0',
+      );
+      final ctx = WorkOrderSpecialTargetContext(
+        game: emptyGame,
+        player: p1,
+        playerId: 'p1',
+        treasury: 0,
+      );
+      final r = validateStealTechWorkTarget(ctx, o, null, null);
+      expect(r?.status, OrderValidationStatus.rejected);
+      expect(r?.reason, contains('Invalid target'));
+    });
+
+    test('rejects when no other GP holds that capital province', () {
+      const o = WorkOrder(
+        unitId: 'u1',
+        target: kWorkTargetStealTech,
+        targetTileKey: '$ow|M1|0|0',
+      );
+      final ctx = WorkOrderSpecialTargetContext(
+        game: emptyGame,
+        player: p1,
+        playerId: 'p1',
+        treasury: 0,
+      );
+      final r = validateStealTechWorkTarget(ctx, o, '$ow|M1', null);
+      expect(r?.status, OrderValidationStatus.rejected);
+      expect(r?.reason, contains('Great Power capital'));
+    });
+  });
+
+  group('validateCounterSpyWorkTarget', () {
+    const ow = 'oldWorld';
+    final p1 = Player(
+      id: 'p1',
+      displayName: 'P1',
+      isHuman: true,
+      capitalProvinceId: '$ow|P1',
+      stockpile: const Stockpile(),
+      treasury: 0,
+    );
+    final game = Game(
+      id: 'g1',
+      worldState: WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+        oldWorld: const RegionData(),
+        newWorld: const RegionData(),
+      ),
+      players: [p1],
+    );
+
+    test('rejects when province is not owned by submitting player', () {
+      const o = WorkOrder(
+        unitId: 'u1',
+        target: kWorkTargetCounterSpy,
+        targetTileKey: '$ow|P2|0|0',
+      );
+      final ctx = WorkOrderSpecialTargetContext(
+        game: game,
+        player: p1,
+        playerId: 'p1',
+        treasury: 0,
+      );
+      final r = validateCounterSpyWorkTarget(ctx, o, null, 'p2');
+      expect(r?.status, OrderValidationStatus.rejected);
+      expect(r?.reason, contains('your own province'));
+    });
+
+    test('returns null when province owner matches player', () {
+      const o = WorkOrder(
+        unitId: 'u1',
+        target: kWorkTargetCounterSpy,
+        targetTileKey: '$ow|P1|0|0',
+      );
+      final ctx = WorkOrderSpecialTargetContext(
+        game: game,
+        player: p1,
+        playerId: 'p1',
+        treasury: 0,
+      );
+      expect(validateCounterSpyWorkTarget(ctx, o, null, 'p1'), isNull);
+    });
+  });
+
+  group('validatePurchaseLandWorkTarget', () {
+    const ow = 'oldWorld';
+    const minorProvinceId = '$ow|M1';
+    const tileKey = '$ow|M1|0|0';
+    final p1 = Player(
+      id: 'p1',
+      displayName: 'P1',
+      isHuman: true,
+      capitalProvinceId: '$ow|P1',
+      stockpile: const Stockpile(),
+      treasury: 500,
+      techUnlocked: {'merchant_companies': true},
+    );
+    final game = Game(
+      id: 'g1',
+      worldState: WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+        oldWorld: RegionData(
+          provinces: [
+            Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+            Province(id: minorProvinceId, regionId: ow, ownerId: 'minor1'),
+          ],
+          units: const [],
+        ),
+        newWorld: const RegionData(),
+        resourceByTileKey: const {tileKey: 'grain'},
+        playerProspectedTiles: const {},
+        purchasedTilesByTileKey: const {},
+      ),
+      players: [p1],
+      minorNations: const [
+        MinorNation(id: 'minor1', displayName: 'Minor 1'),
+      ],
+      overtureStates: const [],
+      diplomacyRelations: const [],
+    );
+
+    test('rejects when there is no embassy with Minor/Tribe owner', () {
+      const o = WorkOrder(
+        unitId: 'm1',
+        target: kWorkTargetPurchaseLand,
+        targetTileKey: tileKey,
+      );
+      final ctx = WorkOrderSpecialTargetContext(
+        game: game,
+        player: p1,
+        playerId: 'p1',
+        treasury: 500,
+      );
+      final r = validatePurchaseLandWorkTarget(ctx, o, null, 'minor1');
+      expect(r?.status, OrderValidationStatus.rejected);
+      expect(r?.reason, contains('embassy'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Implements a slice of GitHub #1531 (item 9): replace the if–else chain for `steal_tech`, `counter_spy`, and `purchase_land` in `WorkOrderValidator` with map-based dispatch and dedicated top-level validators in `work_order_special_target_validation.dart`.

## Tests
- New: `work_order_special_target_validation_test.dart` (registry keys, unknown targets, steal_tech/counter_spy/purchase_land cases).
- Full package: `melos exec --scope=colonizethis_logic -- dart test`

## Out of scope (parent issue)
#1531 remains open: long-file splits, full strategy pattern for every work target, barrels, circular-dependency audit, etc.

Refs #1531

Made with [Cursor](https://cursor.com)