### PR TITLE
test(app): province panel pending orders and minimap inset (Refs #1550)

### DIFF
--- a/app/test/game_map_area_region_minimap_test.dart
+++ b/app/test/game_map_area_region_minimap_test.dart
@@ -14,10 +14,12 @@ import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
 import 'package:colonizethis_app/providers/game_service_provider.dart';
 import 'package:colonizethis_app/providers/games_box_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_app/providers/map_province_panel_provider.dart';
 import 'package:colonizethis_app/providers/map_view_provider.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
-import 'package:colonizethis_map/colonizethis_map.dart' show InitGameMapViewData;
+import 'package:colonizethis_map/colonizethis_map.dart'
+    show InitGameMapViewData;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
@@ -42,6 +44,23 @@ Future<void> _pumpUntilMinimapPaintVisible(WidgetTester tester) async {
   );
 }
 
+String _firstOldWorldTileKey(Game game) {
+  final m = game.worldState.tileKeysByRegionAndProvince['oldWorld'];
+  if (m == null) {
+    throw StateError('missing tileKeysByRegionAndProvince.oldWorld');
+  }
+  for (final keys in m.values) {
+    if (keys.isNotEmpty) return keys.first;
+  }
+  throw StateError('no tile keys under oldWorld');
+}
+
+/// [Positioned] wrapping [GameRegionMinimap] in [GameMapArea] (see `game_map_area.dart`).
+double? _minimapPositionedRight(WidgetTester tester) {
+  final ctx = tester.element(find.byType(GameRegionMinimap));
+  return ctx.findAncestorWidgetOfExactType<Positioned>()?.right;
+}
+
 void main() {
   suppressLogsForTests();
 
@@ -56,19 +75,18 @@ void main() {
     required AppEventBus bus,
     required Game game,
     required InitGameMapViewData mapViewData,
-  }) =>
-      [
-        appEventBusProvider.overrideWith((ref) => bus),
-        currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-        gamesBoxProvider.overrideWith((ref) => gamesBox),
-        gameServiceProvider.overrideWith(
-          (ref) => GameService(gamesBox, GameSaveAdapter()),
-        ),
-        currentOrdersProvider.overrideWith(
-          () => CurrentOrdersNotifier(const Orders()),
-        ),
-        mapViewDataProvider.overrideWith((ref) => mapViewData),
-      ];
+  }) => [
+    appEventBusProvider.overrideWith((ref) => bus),
+    currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+    gamesBoxProvider.overrideWith((ref) => gamesBox),
+    gameServiceProvider.overrideWith(
+      (ref) => GameService(gamesBox, GameSaveAdapter()),
+    ),
+    currentOrdersProvider.overrideWith(
+      () => CurrentOrdersNotifier(const Orders()),
+    ),
+    mapViewDataProvider.overrideWith((ref) => mapViewData),
+  ];
 
   testWidgets('region minimap: toggle visibility and minimap bus pan', (
     WidgetTester tester,
@@ -312,4 +330,49 @@ void main() {
       'oldWorld',
     );
   });
+
+  testWidgets(
+    'wide layout: minimap Positioned right inset clears province panel width when panel open',
+    (WidgetTester tester) async {
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.binding.setSurfaceSize(const Size(900, 800));
+
+      final init = getDebugInitGameResult();
+      final game = init.game;
+      final bus = AppEventBus.create();
+      addTearDown(bus.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: _mapAreaProviderOverrides(
+            bus: bus,
+            game: game,
+            mapViewData: init.mapViewData,
+          ),
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('en'),
+            home: Scaffold(
+              body: GameMapArea(game: game, mapViewData: init.mapViewData),
+            ),
+          ),
+        ),
+      );
+      await _pumpUntilMinimapPaintVisible(tester);
+
+      expect(_minimapPositionedRight(tester), 8.0);
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(GameMapArea)),
+      );
+      container
+          .read(mapProvincePanelProvider.notifier)
+          .reportMapTileTapped(_firstOldWorldTileKey(game));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+
+      expect(_minimapPositionedRight(tester), 8.0 + 320.0);
+    },
+  );
 }

--- a/app/test/province_panel_draft_orders_test.dart
+++ b/app/test/province_panel_draft_orders_test.dart
@@ -8,11 +8,20 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/widgets/province_sea_zone_detail_overlay.dart';
+import 'package:colonizethis_app/l10n/app_localizations.dart';
 
 const _regionId = 'oldWorld';
 const _localProvinceId = 'pDraft';
+const _localDestProvinceId = 'pDest';
 String get _fullProvinceId => '$_regionId|$_localProvinceId';
+String get _fullDestProvinceId => '$_regionId|$_localDestProvinceId';
 String _tileKey(int x, int y) => '$_fullProvinceId|$x|$y';
+
+/// Bounded pumps only — avoid [pumpAndSettle] (animations / unbounded work).
+Future<void> _pumpOverlayLayout(WidgetTester tester) async {
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 16));
+}
 
 void main() {
   suppressLogsForTests();
@@ -47,7 +56,9 @@ void main() {
           ),
           newWorld: const RegionData(),
           tileKeysByRegionAndProvince: {
-            _regionId: {_fullProvinceId: [tk]},
+            _regionId: {
+              _fullProvinceId: [tk],
+            },
           },
         ),
         players: const [
@@ -103,6 +114,9 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
           home: Scaffold(
             body: ProvinceSeaZoneDetailOverlay(
               game: game,
@@ -116,7 +130,7 @@ void main() {
           ),
         ),
       );
-      await tester.pumpAndSettle();
+      await _pumpOverlayLayout(tester);
 
       expect(find.textContaining('build improvement'), findsOneWidget);
       expect(find.textContaining(': idle'), findsNothing);
@@ -150,7 +164,9 @@ void main() {
           ),
           newWorld: const RegionData(),
           tileKeysByRegionAndProvince: {
-            _regionId: {_fullProvinceId: [tk]},
+            _regionId: {
+              _fullProvinceId: [tk],
+            },
           },
         ),
         players: const [
@@ -195,6 +211,9 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
           home: Scaffold(
             body: ProvinceSeaZoneDetailOverlay(
               game: game,
@@ -207,10 +226,252 @@ void main() {
           ),
         ),
       );
-      await tester.pumpAndSettle();
+      await _pumpOverlayLayout(tester);
 
       expect(find.textContaining('Peasant levies'), findsOneWidget);
       expect(find.textContaining('peasant_levies:'), findsNothing);
     });
+
+    testWidgets(
+      'Military section shows pending regiment move line from draftOrders',
+      (WidgetTester tester) async {
+        final tk = _tileKey(0, 0);
+        final game = Game(
+          id: 'mil_pending_test',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: [
+                Province(
+                  id: _fullProvinceId,
+                  regionId: _regionId,
+                  displayName: 'FromProv',
+                ),
+                Province(
+                  id: _fullDestProvinceId,
+                  regionId: _regionId,
+                  displayName: 'DestProv',
+                ),
+              ],
+              units: [
+                Unit(
+                  id: 'r_move',
+                  type: 'peasant_levies',
+                  ownerId: 'gp1',
+                  locationProvinceId: _fullProvinceId,
+                  tileKey: tk,
+                  status: UnitStatus.idle,
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            tileKeysByRegionAndProvince: {
+              _regionId: {
+                _fullProvinceId: [tk],
+              },
+            },
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'Human', isHuman: true, treasury: 0),
+          ],
+        );
+        final region = RegionMapViewData(
+          regionId: _regionId,
+          width: 1,
+          height: 1,
+          cellSize: 32,
+          cells: const [
+            CellViewData(
+              x: 0,
+              y: 0,
+              regionCellId: _localProvinceId,
+              isSea: false,
+              terrainTypeId: 'plains',
+              visibility: TileVisibility.visible,
+            ),
+          ],
+          capitalMarkers: const [],
+          portMarkers: const [],
+          factionColors: const {},
+          greatPowerFactionIds: const {'gp1'},
+          terrainColors: const {},
+        );
+        final view = PlayerView(
+          playerId: 'gp1',
+          player: const Player(
+            id: 'gp1',
+            displayName: 'Human',
+            isHuman: true,
+            treasury: 0,
+          ),
+          ownUnitsById: const {},
+          provincesById: const {},
+          visibilityByTile: {tk: VisibilityLevel.fullyVisible},
+          prospectedTiles: const {},
+          diplomacyByOtherId: const {},
+        );
+        final orders = Orders(
+          moveOrdersByPlayerId: {
+            'gp1': [
+              MoveOrder(
+                unitId: 'r_move',
+                destinationProvinceId: _fullDestProvinceId,
+              ),
+            ],
+          },
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('en'),
+            home: Scaffold(
+              body: ProvinceSeaZoneDetailOverlay(
+                game: game,
+                region: region,
+                displayId: _fullProvinceId,
+                selectedTileKey: tk,
+                humanPlayerId: 'gp1',
+                playerView: view,
+                draftOrders: orders,
+              ),
+            ),
+          ),
+        );
+        await _pumpOverlayLayout(tester);
+
+        expect(
+          find.textContaining('Ordered: move regiment to'),
+          findsOneWidget,
+        );
+        expect(find.textContaining('DestProv'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Naval section shows pending dock move and mission from draftOrders',
+      (WidgetTester tester) async {
+        final tk = _tileKey(0, 0);
+        final game = Game(
+          id: 'naval_pending_test',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: [
+                Province(
+                  id: _fullProvinceId,
+                  regionId: _regionId,
+                  displayName: 'PortProv',
+                ),
+                Province(
+                  id: _fullDestProvinceId,
+                  regionId: _regionId,
+                  displayName: 'OtherPort',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'fleet_in_port',
+                ownerId: 'gp1',
+                regionId: _regionId,
+                inPortAtProvinceId: _fullProvinceId,
+                shipTypeIds: const ['sloop'],
+              ),
+            ],
+            tileKeysByRegionAndProvince: {
+              _regionId: {
+                _fullProvinceId: [tk],
+              },
+            },
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'Human', isHuman: true, treasury: 0),
+          ],
+        );
+        final region = RegionMapViewData(
+          regionId: _regionId,
+          width: 1,
+          height: 1,
+          cellSize: 32,
+          cells: const [
+            CellViewData(
+              x: 0,
+              y: 0,
+              regionCellId: _localProvinceId,
+              isSea: false,
+              terrainTypeId: 'plains',
+              visibility: TileVisibility.visible,
+            ),
+          ],
+          capitalMarkers: const [],
+          portMarkers: const [],
+          factionColors: const {},
+          greatPowerFactionIds: const {'gp1'},
+          terrainColors: const {},
+        );
+        final view = PlayerView(
+          playerId: 'gp1',
+          player: const Player(
+            id: 'gp1',
+            displayName: 'Human',
+            isHuman: true,
+            treasury: 0,
+          ),
+          ownUnitsById: const {},
+          provincesById: const {},
+          visibilityByTile: {tk: VisibilityLevel.fullyVisible},
+          prospectedTiles: const {},
+          diplomacyByOtherId: const {},
+        );
+        final orders = Orders(
+          navalMoveOrdersByPlayerId: {
+            'gp1': [
+              NavalMoveOrder(
+                fleetId: 'fleet_in_port',
+                destinationPortProvinceId: _fullDestProvinceId,
+              ),
+            ],
+          },
+          navalMissionOrdersByPlayerId: {
+            'gp1': [
+              const NavalMissionOrder(
+                fleetId: 'fleet_in_port',
+                mission: 'patrol',
+              ),
+            ],
+          },
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('en'),
+            home: Scaffold(
+              body: ProvinceSeaZoneDetailOverlay(
+                game: game,
+                region: region,
+                displayId: _fullProvinceId,
+                selectedTileKey: tk,
+                humanPlayerId: 'gp1',
+                playerView: view,
+                draftOrders: orders,
+              ),
+            ),
+          ),
+        );
+        await _pumpOverlayLayout(tester);
+
+        expect(find.textContaining('Ordered: dock fleet at'), findsOneWidget);
+        expect(find.textContaining('OtherPort'), findsOneWidget);
+        expect(
+          find.textContaining('Ordered: fleet mission — patrol'),
+          findsOneWidget,
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Adds the follow-up widget tests called out after #1550 / #1552: pending land and naval order preview lines in the province overlay, and wide-layout minimap horizontal inset when the province side panel is open.

## Changes

- `province_panel_draft_orders_test.dart`: regiment `MoveOrder` preview line; naval dock `NavalMoveOrder` + `NavalMissionOrder` preview lines; English `MaterialApp` localizations; replace `pumpAndSettle` with two bounded pumps for the overlay tests.
- `game_map_area_region_minimap_test.dart`: assert `Positioned.right` is `8` with panel closed and `8 + 320` after `reportMapTileTapped` on a wide (900×800) surface.

## Tests

```
cd app && flutter test test/province_panel_draft_orders_test.dart test/game_map_area_region_minimap_test.dart
```

Refs #1550

Made with [Cursor](https://cursor.com)