### PR TITLE
feat(app): tile-scoped civilian panel interactions (Refs #1564)

### DIFF
--- a/SPEC/ui/civilian-units-panel.md
+++ b/SPEC/ui/civilian-units-panel.md
@@ -21,6 +21,7 @@ The civilian units panel gives the player a single place to see every civilian u
 ## Panel placement and opening
 
 - **Access:** The panel is opened from the in-game shell **toolbar**, in the same way as the Production panel (e.g. a toolbar button such as "Civilian Units" or "Units" that opens the panel).
+- **Map tile access (tile scope):** The panel may also be opened from a **civilian map marker tap** (see [map-widget.md](map-widget.md)). In this mode the panel is scoped to one tile key (`regionId|provinceId|x|y`) and shows only player-owned civilians whose **rendered tile** equals that tile key (assigned civilians use `assignedTileKey` when present; otherwise `tileKey`).
 - **Presentation:** The panel **appears from the bottom** as a **bottom sheet** that slides up from the bottom edge (same pattern as the province/sea zone detail overlay on narrow viewports; see [province-sea-zone-detail-overlay.md](province-sea-zone-detail-overlay.md)). This applies on both desktop and narrow viewports so behaviour is consistent and the map remains visible above.
 - **Max height:** Bottom sheet is constrained (e.g. up to one-third of screen height on narrow, or similar cap on wide) so the map stays visible; content scrolls inside the sheet.
 - **Mobile / narrow viewport:** Same bottom-sheet presentation; touch targets per [mobile-adaptation.md](mobile-adaptation.md).
@@ -56,6 +57,13 @@ For each civilian unit, the panel shows:
 - **When** the user clicks a unit row in the civilian units panel, **then** the UI layer: (1) sets the map's **highlighted tile** to that unit's `tileKey`; (2) **pans and centers** the map viewport so that the unit's tile is visible and centered; (3) **switches the active region tab** to the unit's region if it differs from the current tab.
 - **Contract:** The map widget supports `highlightedTileKey` per [province-sea-zone-detail-overlay.md](province-sea-zone-detail-overlay.md) and an optional "center on tile" (e.g. `centerOnTileKey` or callback) so the shell can request pan/center when a unit is selected from the panel.
 - **Clearing:** Highlight remains until the user selects another unit, selects a province/tile elsewhere, or closes the panel (implementation may keep or clear highlight on panel close).
+
+### Tile-scoped panel behavior
+
+- **Selection model:** In tile scope, the panel keeps one selected unit id. Initial selection is the unit id provided by the map marker tap; if missing, the first row in deterministic list order is selected.
+- **Selection swap:** In tile scope, tapping a different row changes selected unit id immediately.
+- **Action target:** In tile scope, row actions (Assign, Cancel, Tile) apply to the selected row only.
+- **Tile button:** In tile scope, the selected row includes a **Tile** button that opens province/tile detail for that selected row’s rendered tile (`assignedTileKey` when present, otherwise `tileKey`).
 
 ---
 
@@ -106,6 +114,12 @@ For each civilian unit, the panel shows:
 - **Given** the Civilian Units panel is open and a unit has a pending work order this turn or has `Unit.status == working` with `Unit.currentWork != null`, **when** the user views that unit's row, **then** the UI layer shows a **Cancel** control.
 
 - **Given** the user clicked **Cancel** for a unit with work (pending or in-progress), **when** the UI layer responds, **then** it first shows a confirm dialog (e.g. "Cancel this work order?"); on confirm, pending work is removed from orders and in-progress work is cleared (unit status idle, currentWork cleared; no refund); on dismiss, no change.
+
+- **Given** the user taps a civilian map marker for tile key `T`, **when** the civilian units panel opens in tile scope, **then** the UI layer lists only player-owned civilian units whose rendered tile equals `T`.
+
+- **Given** the civilian units panel is open in tile scope with selected unit `A`, **when** the user taps row `B`, **then** the UI layer updates selection to `B` and uses `B` as the target for panel actions.
+
+- **Given** the civilian units panel is open in tile scope and a unit row is selected, **when** the user presses **Tile**, **then** the UI layer opens province/tile detail for the selected row’s rendered tile key.
 
 ---
 

--- a/app/lib/core/services/app_event_handler.dart
+++ b/app/lib/core/services/app_event_handler.dart
@@ -261,6 +261,8 @@ class AppEventHandler {
               bus: bus,
               currentOrders: currentOrders,
               availableWorkTargets: availableWorkTargets,
+              tileScopeTileKey: event.tileScopeTileKey,
+              initialSelectedUnitId: event.initialSelectedUnitId,
             ),
           );
         },

--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -81,6 +81,9 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
       bus.on<ct_models.UnitsPanelClosedEvent>().listen((_) {
         ref.read(mapProvincePanelProvider.notifier).setSecondaryHighlight(null);
       }),
+      bus.on<ct_models.OpenMapTileDetailEvent>().listen(
+        (e) => _openMapTileDetail(e.tileKey),
+      ),
     ]);
   }
 
@@ -190,6 +193,19 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
     });
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) setState(() => _centerOnTileKey = null);
+    });
+  }
+
+  void _openMapTileDetail(String tileKey) {
+    final regionId = ct_models.Unit.regionIdFromTileKey(tileKey);
+    if (regionId == null) return;
+    ref.read(mapProvincePanelProvider.notifier).reportMapTileTapped(tileKey);
+    setState(() {
+      if (regionId == 'newWorld') {
+        _regionIndex = 1;
+      } else if (regionId == 'oldWorld') {
+        _regionIndex = 0;
+      }
     });
   }
 
@@ -369,9 +385,24 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
                               })
                             : null,
                         onCivilianTileTapped: (tileKey) {
+                          String? initialSelectedUnitId;
+                          for (final marker in _currentRegion
+                              .civilianTileMarkers) {
+                            if (marker.tileKey == tileKey &&
+                                marker.unitIds.isNotEmpty) {
+                              initialSelectedUnitId = marker.unitIds.first;
+                              break;
+                            }
+                          }
                           setState(() {
                             _selectedCivilianTileKey = tileKey;
                           });
+                          ref.read(appEventBusProvider).emit(
+                            ct_models.OpenCivilianUnitsPanelEvent(
+                              tileScopeTileKey: tileKey,
+                              initialSelectedUnitId: initialSelectedUnitId,
+                            ),
+                          );
                         },
                         onCivilianTileSelectionCleared: () {
                           if (_selectedCivilianTileKey == null) return;

--- a/app/lib/features/game/widgets/civilian_units_panel.dart
+++ b/app/lib/features/game/widgets/civilian_units_panel.dart
@@ -78,8 +78,16 @@ List<Unit> _civilianUnitsInRegion(
   return list;
 }
 
+String? _renderedTileKey(Unit unit) {
+  final assigned = unit.assignedTileKey;
+  if (assigned != null && assigned.isNotEmpty) {
+    return assigned;
+  }
+  return unit.tileKey;
+}
+
 /// Panel that lists all civilian units for the human player. SPEC/ui/civilian-units-panel.md.
-class CivilianUnitsPanel extends StatelessWidget {
+class CivilianUnitsPanel extends StatefulWidget {
   const CivilianUnitsPanel({
     super.key,
     required this.game,
@@ -87,6 +95,8 @@ class CivilianUnitsPanel extends StatelessWidget {
     required this.bus,
     this.currentOrders = const Orders(),
     this.availableWorkTargets = const {},
+    this.tileScopeTileKey,
+    this.initialSelectedUnitId,
   });
 
   final Game game;
@@ -99,29 +109,70 @@ class CivilianUnitsPanel extends StatelessWidget {
   /// Available work targets per unit (computed at turn start). Work targets not in this list are grayed out.
   final Map<String, List<String>> availableWorkTargets;
 
+  /// Optional tile key (`regionId|provinceId|x|y`) for tile-scoped mode.
+  final String? tileScopeTileKey;
+
+  /// Optional initial selected unit in tile-scoped mode.
+  final String? initialSelectedUnitId;
+
+  @override
+  State<CivilianUnitsPanel> createState() => _CivilianUnitsPanelState();
+}
+
+class _CivilianUnitsPanelState extends State<CivilianUnitsPanel> {
+  String? _selectedUnitId;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedUnitId = widget.initialSelectedUnitId;
+  }
+
+  @override
+  void didUpdateWidget(covariant CivilianUnitsPanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.initialSelectedUnitId != widget.initialSelectedUnitId) {
+      _selectedUnitId = widget.initialSelectedUnitId;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    final provinceNames = _provinceNamesByPrefixedId(game);
+    final provinceNames = _provinceNamesByPrefixedId(widget.game);
     final ow = _civilianUnitsInRegion(
-      game.worldState.oldWorld.units,
-      humanPlayerId,
+      widget.game.worldState.oldWorld.units,
+      widget.humanPlayerId,
       provinceNames,
     );
     final nw = _civilianUnitsInRegion(
-      game.worldState.newWorld.units,
-      humanPlayerId,
+      widget.game.worldState.newWorld.units,
+      widget.humanPlayerId,
       provinceNames,
     );
-    final hasAny = ow.isNotEmpty || nw.isNotEmpty;
+    List<Unit> scopedOw = ow;
+    List<Unit> scopedNw = nw;
+    final tileScopeTileKey = widget.tileScopeTileKey;
+    if (tileScopeTileKey != null && tileScopeTileKey.isNotEmpty) {
+      scopedOw = ow.where((u) => _renderedTileKey(u) == tileScopeTileKey).toList();
+      scopedNw = nw.where((u) => _renderedTileKey(u) == tileScopeTileKey).toList();
+    }
+    final hasAny = scopedOw.isNotEmpty || scopedNw.isNotEmpty;
+    final allScopedUnits = <Unit>[...scopedOw, ...scopedNw];
+    final selectedUnitId = _selectedUnitId;
+    final resolvedSelectedUnitId =
+        selectedUnitId != null &&
+            allScopedUnits.any((u) => u.id == selectedUnitId)
+        ? selectedUnitId
+        : (allScopedUnits.isNotEmpty ? allScopedUnits.first.id : null);
 
     return UnitsPanelShell(
-      title: 'Civilian Units',
+      title: tileScopeTileKey != null ? 'Civilian Units (Tile)' : 'Civilian Units',
       actions: [
         CtNinePatchButton(
           onPressed: () {
-            bus.emit(const ClosePanelEvent());
+            widget.bus.emit(const ClosePanelEvent());
             WidgetsBinding.instance.addPostFrameCallback((_) {
-              bus.emit(OpenDialogEvent(trainCiviliansDialogId));
+              widget.bus.emit(OpenDialogEvent(trainCiviliansDialogId));
             });
           },
           child: const Text('Train'),
@@ -129,29 +180,35 @@ class CivilianUnitsPanel extends StatelessWidget {
       ],
       hasContent: hasAny,
       listChildren: [
-        if (ow.isNotEmpty) ...[
+        if (scopedOw.isNotEmpty) ...[
           RegionSectionHeader(label: unitsPanelRegionLabel('oldWorld')),
-          ...ow.map(
+          ...scopedOw.map(
             (u) => _UnitRow(
               unit: u,
               provinceNames: provinceNames,
-              currentOrders: currentOrders,
-              availableWorkTargets: availableWorkTargets,
-              humanPlayerId: humanPlayerId,
-              bus: bus,
+              currentOrders: widget.currentOrders,
+              availableWorkTargets: widget.availableWorkTargets,
+              humanPlayerId: widget.humanPlayerId,
+              bus: widget.bus,
+              isTileScope: tileScopeTileKey != null,
+              isSelectedInTileScope: resolvedSelectedUnitId == u.id,
+              onSelectInTileScope: () => setState(() => _selectedUnitId = u.id),
             ),
           ),
         ],
-        if (nw.isNotEmpty) ...[
+        if (scopedNw.isNotEmpty) ...[
           RegionSectionHeader(label: unitsPanelRegionLabel('newWorld')),
-          ...nw.map(
+          ...scopedNw.map(
             (u) => _UnitRow(
               unit: u,
               provinceNames: provinceNames,
-              currentOrders: currentOrders,
-              availableWorkTargets: availableWorkTargets,
-              humanPlayerId: humanPlayerId,
-              bus: bus,
+              currentOrders: widget.currentOrders,
+              availableWorkTargets: widget.availableWorkTargets,
+              humanPlayerId: widget.humanPlayerId,
+              bus: widget.bus,
+              isTileScope: tileScopeTileKey != null,
+              isSelectedInTileScope: resolvedSelectedUnitId == u.id,
+              onSelectInTileScope: () => setState(() => _selectedUnitId = u.id),
             ),
           ),
         ],
@@ -169,6 +226,9 @@ class _UnitRow extends StatelessWidget {
     required this.availableWorkTargets,
     required this.humanPlayerId,
     required this.bus,
+    required this.isTileScope,
+    required this.isSelectedInTileScope,
+    required this.onSelectInTileScope,
   });
 
   final Unit unit;
@@ -177,6 +237,9 @@ class _UnitRow extends StatelessWidget {
   final Map<String, List<String>> availableWorkTargets;
   final String humanPlayerId;
   final AppEventBus bus;
+  final bool isTileScope;
+  final bool isSelectedInTileScope;
+  final VoidCallback onSelectInTileScope;
 
   List<WorkOrder> get _pendingForPlayer =>
       currentOrders.workOrdersByPlayerId[humanPlayerId] ?? const [];
@@ -331,7 +394,9 @@ class _UnitRow extends StatelessWidget {
       UnitStatus.working => 'Working',
       UnitStatus.done => 'Done',
     };
+    final showActions = !isTileScope || isSelectedInTileScope;
     return ListTile(
+      selected: isTileScope && isSelectedInTileScope,
       title: Text(unit.type),
       subtitle: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -343,37 +408,56 @@ class _UnitRow extends StatelessWidget {
         ],
       ),
       dense: true,
-      onTap: unit.tileKey == null
-          ? null
-          : () {
-              final tileKey = unit.tileKey!;
-              final regionId = Unit.regionIdFromTileKey(tileKey);
-              if (regionId == null) return;
-              bus.emit(const ClosePanelEvent());
-              WidgetsBinding.instance.addPostFrameCallback((_) {
-                bus.emit(
-                  LocateMapTileEvent(
-                    tileKey: tileKey,
-                    regionId: regionId,
+      onTap: () {
+        if (isTileScope) {
+          onSelectInTileScope();
+          return;
+        }
+        final tileKey = unit.tileKey;
+        if (tileKey == null) return;
+        final regionId = Unit.regionIdFromTileKey(tileKey);
+        if (regionId == null) return;
+        bus.emit(const ClosePanelEvent());
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          bus.emit(
+            LocateMapTileEvent(
+              tileKey: tileKey,
+              regionId: regionId,
+            ),
+          );
+        });
+      },
+      trailing: showActions
+          ? Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (isTileScope)
+                  CtNinePatchButton(
+                    onPressed: () {
+                      final renderedTileKey = _renderedTileKey(unit);
+                      if (renderedTileKey == null) return;
+                      bus.emit(const ClosePanelEvent());
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        bus.emit(
+                          OpenMapTileDetailEvent(tileKey: renderedTileKey),
+                        );
+                      });
+                    },
+                    child: const Text('Tile'),
                   ),
-                );
-              });
-            },
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (_isIdleNoPending)
-            CtNinePatchButton(
-              onPressed: () => _showOrderMenu(context),
-              child: const Text('Assign'),
-            ),
-          if (_hasWork)
-            CtNinePatchButton(
-              onPressed: () => _confirmCancel(context),
-              child: const Text('Cancel'),
-            ),
-        ],
-      ),
+                if (_isIdleNoPending)
+                  CtNinePatchButton(
+                    onPressed: () => _showOrderMenu(context),
+                    child: const Text('Assign'),
+                  ),
+                if (_hasWork)
+                  CtNinePatchButton(
+                    onPressed: () => _confirmCancel(context),
+                    child: const Text('Cancel'),
+                  ),
+              ],
+            )
+          : null,
     );
   }
 }

--- a/app/test/civilian_units_panel_test.dart
+++ b/app/test/civilian_units_panel_test.dart
@@ -726,6 +726,57 @@ void main() {
         expect(find.textContaining('(pending)'), findsAtLeastNWidgets(1));
       },
     );
+
+    testWidgets(
+      'tile-scoped mode shows Tile action for selected civilian',
+      (WidgetTester tester) async {
+        final units = [
+          ...game.worldState.oldWorld.units,
+          ...game.worldState.newWorld.units,
+        ];
+        final civilianWithTile = units.where(
+          (u) =>
+              u.ownerId == humanPlayerIdWithUnits &&
+              u.tileKey != null &&
+              _isCivilian(u),
+        );
+        if (civilianWithTile.isEmpty) return;
+        final scopedTileKey = civilianWithTile.first.tileKey!;
+        final scopedUnitId = civilianWithTile.first.id;
+        final bus = AppEventBus.create();
+
+        await tester.pumpWidget(
+          buildPanel(
+            game: game,
+            humanPlayerId: humanPlayerIdWithUnits,
+            bus: bus,
+            currentOrders: const Orders(),
+            availableWorkTargets: const {},
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: CivilianUnitsPanel(
+                game: game,
+                humanPlayerId: humanPlayerIdWithUnits,
+                currentOrders: const Orders(),
+                availableWorkTargets: const {},
+                bus: bus,
+                tileScopeTileKey: scopedTileKey,
+                initialSelectedUnitId: scopedUnitId,
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Civilian Units (Tile)'), findsOneWidget);
+        expect(find.text('Tile'), findsAtLeastNWidgets(1));
+      },
+    );
   });
 }
 

--- a/packages/colonizethis_models/lib/src/app_events.dart
+++ b/packages/colonizethis_models/lib/src/app_events.dart
@@ -97,7 +97,17 @@ class OpenPauseMenuPanelEvent extends UIActionEvent {
 /// Pending work removal and in-progress cancel use [SessionCommandEvent]s (bus), not
 /// closures on this event — see SPEC/program/app-event-bus.md.
 class OpenCivilianUnitsPanelEvent extends UIActionEvent {
-  const OpenCivilianUnitsPanelEvent();
+  const OpenCivilianUnitsPanelEvent({
+    this.tileScopeTileKey,
+    this.initialSelectedUnitId,
+  });
+
+  /// Optional tile-scope key (`regionId|provinceId|x|y`) used to show only
+  /// civilians currently rendered on that tile.
+  final String? tileScopeTileKey;
+
+  /// Optional initial selected unit id when opening in tile scope.
+  final String? initialSelectedUnitId;
 }
 
 /// Military units bottom sheet.
@@ -120,6 +130,13 @@ class LocateMapTileEvent extends UIActionEvent {
 
   final String tileKey;
   final String regionId;
+}
+
+/// Request to open the province/tile detail panel for a concrete map tile key.
+class OpenMapTileDetailEvent extends UIActionEvent {
+  const OpenMapTileDetailEvent({required this.tileKey});
+
+  final String tileKey;
 }
 
 /// In-game region minimap requests the Flame map camera center at world coordinates (after clamp).


### PR DESCRIPTION
## Summary
- Implements the next non-overlapping #1564 slice after merged S4/S7 work and the in-flight grayscale marker PR (`#1575`): tile-scoped civilian panel opening from map marker taps.
- Extends `OpenCivilianUnitsPanelEvent` with optional tile-scope and initial-selection fields; map tap wiring in `GameMapArea` now opens the civilian panel scoped to the tapped civilian tile.
- Adds tile-scoped panel behavior in `CivilianUnitsPanel`: rendered-tile filtering (`assignedTileKey` preferred), selected row highlight/swap, and a `Tile` action to request tile-detail opening via typed bus event (`OpenMapTileDetailEvent`).
- Updates `SPEC/ui/civilian-units-panel.md` with tile-scope contract and testable ACs for scope filtering, selection swap, and Tile action behavior.

## Scope
In scope for this slice:
- Tile-scoped civilian panel orchestration and interactions.
- Typed event wiring to open tile detail from the panel in a decoupled way.

Deferred (already covered or still pending in #1564 pipeline):
- PixelLab per-type icon assets and final icon rendering pass.
- Grayscale marker rendering path (already in open PR #1575).
- Remaining map-side interaction polish beyond this panel-focused slice.

## Tests
- `flutter test test/civilian_units_panel_test.dart` (run from `app/`)
- `flutter test test/app_event_handler_test.dart` (run from `app/`)
- `flutter test test/ct_region_map_widget_test.dart --plain-name "tap on civilian marker tile invokes civilian callback and suppresses detail tap callback"` (run from `app/`)

Refs #1564

Made with [Cursor](https://cursor.com)