### PR TITLE
fix(app): resolve startup zone mismatch and add bootstrap tests

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
@@ -17,21 +18,42 @@ Future<void> _openHiveBoxSafely(String name) async {
     await Hive.openBox<dynamic>(name);
   } catch (e, st) {
     // Boxes may be locked (e.g. another instance) or corrupt; app still runs where possible.
-    dataLogger('hive').w('failed to open box "$name"', error: e, stackTrace: st);
+    dataLogger(
+      'hive',
+    ).w('failed to open box "$name"', error: e, stackTrace: st);
   }
 }
 
-void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  SessionLogBuffer.init();
-  await MapTerrainConfig.ensureLoaded();
-  await Hive.initFlutter();
-  await _openHiveBoxSafely(HiveBoxNames.settings);
-  await _openHiveBoxSafely(HiveBoxNames.games);
-  await _openHiveBoxSafely(HiveBoxNames.offlineQueue);
+@visibleForTesting
+Future<void> bootstrapApp({
+  required void Function() ensureBindingInitialized,
+  required void Function() initSessionLogBuffer,
+  required Future<void> Function() ensureMapTerrainLoaded,
+  required Future<void> Function() initHive,
+  required Future<void> Function(String name) openHiveBoxSafely,
+  required void Function(Widget app) runAppFn,
+}) async {
+  ensureBindingInitialized();
+  initSessionLogBuffer();
+  await ensureMapTerrainLoaded();
+  await initHive();
+  await openHiveBoxSafely(HiveBoxNames.settings);
+  await openHiveBoxSafely(HiveBoxNames.games);
+  await openHiveBoxSafely(HiveBoxNames.offlineQueue);
+  runAppFn(const ProviderScope(child: AppEventHandlerScope(child: App())));
+}
+
+void main() {
   runZonedGuarded(
-    () {
-      runApp(const ProviderScope(child: AppEventHandlerScope(child: App())));
+    () async {
+      await bootstrapApp(
+        ensureBindingInitialized: WidgetsFlutterBinding.ensureInitialized,
+        initSessionLogBuffer: SessionLogBuffer.init,
+        ensureMapTerrainLoaded: MapTerrainConfig.ensureLoaded,
+        initHive: Hive.initFlutter,
+        openHiveBoxSafely: _openHiveBoxSafely,
+        runAppFn: runApp,
+      );
     },
     (Object error, StackTrace stackTrace) {
       appLogger().e(

--- a/app/test/main_bootstrap_test.dart
+++ b/app/test/main_bootstrap_test.dart
@@ -1,0 +1,88 @@
+import 'dart:async';
+
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/main.dart' as app_main;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('bootstrap initializes bindings and runApp in the same zone', () async {
+    Zone? bindingZone;
+    Zone? runAppZone;
+
+    final bootstrapFuture = runZonedGuarded<Future<void>>(
+      () async {
+        await app_main.bootstrapApp(
+          ensureBindingInitialized: () {
+            bindingZone = Zone.current;
+          },
+          initSessionLogBuffer: () {},
+          ensureMapTerrainLoaded: () async {},
+          initHive: () async {},
+          openHiveBoxSafely: (_) async {},
+          runAppFn: (_) {
+            runAppZone = Zone.current;
+          },
+        );
+      },
+      (Object error, StackTrace stackTrace) {
+        fail('unexpected zoned error: $error\n$stackTrace');
+      },
+    );
+
+    await bootstrapFuture;
+
+    expect(bindingZone, isNotNull);
+    expect(runAppZone, isNotNull);
+    expect(identical(bindingZone, runAppZone), isTrue);
+  });
+
+  test('bootstrap awaits startup initialization before runApp', () async {
+    final callOrder = <String>[];
+    final openedBoxes = <String>[];
+
+    await app_main.bootstrapApp(
+      ensureBindingInitialized: () {
+        callOrder.add('binding');
+      },
+      initSessionLogBuffer: () {
+        callOrder.add('session');
+      },
+      ensureMapTerrainLoaded: () async {
+        callOrder.add('terrain');
+      },
+      initHive: () async {
+        callOrder.add('hive');
+      },
+      openHiveBoxSafely: (name) async {
+        callOrder.add('box:$name');
+        openedBoxes.add(name);
+      },
+      runAppFn: (Widget app) {
+        callOrder.add('runApp');
+      },
+    );
+
+    expect(
+      callOrder,
+      equals([
+        'binding',
+        'session',
+        'terrain',
+        'hive',
+        'box:${HiveBoxNames.settings}',
+        'box:${HiveBoxNames.games}',
+        'box:${HiveBoxNames.offlineQueue}',
+        'runApp',
+      ]),
+    );
+    expect(
+      openedBoxes,
+      equals([
+        HiveBoxNames.settings,
+        HiveBoxNames.games,
+        HiveBoxNames.offlineQueue,
+      ]),
+    );
+  });
+}

--- a/app/test/main_bootstrap_test.dart
+++ b/app/test/main_bootstrap_test.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 
+import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_app/config/constants.dart';
 import 'package:colonizethis_app/main.dart' as app_main;
 import 'package:flutter/widgets.dart';
-import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('bootstrap initializes bindings and runApp in the same zone', () async {


### PR DESCRIPTION
## Summary
- move app bootstrap into the same `runZonedGuarded` zone as `runApp` to prevent Flutter startup zone mismatch assertions
- extract startup orchestration into testable `bootstrapApp(...)` while preserving existing init steps and error logging behavior
- add regression tests covering same-zone bootstrap and startup init ordering before `runApp`

## Test plan
- [x] `flutter test app/test/main_bootstrap_test.dart`

## Related
- Refs #1579

Made with [Cursor](https://cursor.com)