### PR TITLE
refactor: issue 1555 remaining refactor slice

### DIFF
--- a/app/lib/core/services/app_event_handler.dart
+++ b/app/lib/core/services/app_event_handler.dart
@@ -30,6 +30,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../config/routes.dart';
 import '../../config/constants.dart';
+import 'subscription_tracker.dart';
 import '../../features/game/widgets/civilian_units_panel.dart';
 import '../../features/game/widgets/military_units_panel.dart';
 import '../../features/game/widgets/naval_units_panel.dart';
@@ -73,20 +74,17 @@ class AppEventHandler {
   final void Function(DismissOverlayEvent)? _onDismissOverlay;
   final void Function(NotifyEvent)? _onNotify;
 
-  final List<StreamSubscription> _subscriptions = [];
+  final SubscriptionTracker _subscriptions = SubscriptionTracker();
 
   /// Start listening to the event bus. Call from StatefulWidget.initState or main.
   void bind() {
-    _subscriptions.add(_bus.on<UIActionEvent>().listen(_handleUIAction));
-    _subscriptions.add(_bus.on<UISystemEvent>().listen(_handleUISystem));
+    _subscriptions.track(_bus.on<UIActionEvent>().listen(_handleUIAction));
+    _subscriptions.track(_bus.on<UISystemEvent>().listen(_handleUISystem));
   }
 
   /// Stop listening. Call from StatefulWidget.dispose or when tearing down.
   void unbind() {
-    for (final s in _subscriptions) {
-      s.cancel();
-    }
-    _subscriptions.clear();
+    _subscriptions.cancelAll();
   }
 
   void _handleUIAction(UIActionEvent event) {
@@ -249,8 +247,7 @@ class AppEventHandler {
           final currentOrders = ref.watch(currentOrdersProvider);
           final availableWorkTargets = ref.watch(availableWorkTargetsProvider);
           final bus = ref.watch(appEventBusProvider);
-          final isNarrow =
-              MediaQuery.sizeOf(context).width < kNarrowBreakpoint;
+          final isNarrow = MediaQuery.sizeOf(context).width < kNarrowBreakpoint;
           final maxHeight =
               MediaQuery.sizeOf(context).height * (isNarrow ? 0.33 : 0.5);
           return ConstrainedBox(

--- a/app/lib/core/services/subscription_tracker.dart
+++ b/app/lib/core/services/subscription_tracker.dart
@@ -1,0 +1,19 @@
+import 'dart:async';
+
+/// Tracks stream subscriptions for predictable batch cleanup.
+class SubscriptionTracker {
+  final List<StreamSubscription<dynamic>> _subscriptions =
+      <StreamSubscription<dynamic>>[];
+
+  T track<T extends StreamSubscription<dynamic>>(T subscription) {
+    _subscriptions.add(subscription);
+    return subscription;
+  }
+
+  void cancelAll() {
+    for (final subscription in _subscriptions) {
+      subscription.cancel();
+    }
+    _subscriptions.clear();
+  }
+}

--- a/app/lib/widgets/ct_region_map.dart
+++ b/app/lib/widgets/ct_region_map.dart
@@ -10,6 +10,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../core/services/subscription_tracker.dart';
 import '../features/game/flame/region_map_component.dart';
 import '../features/game/flame/region_map_viewport_snapshot.dart'
     show
@@ -603,10 +604,7 @@ class CtRegionMap extends StatefulWidget {
 
 class _CtRegionMapState extends State<CtRegionMap> {
   late _CtRegionMapGame _game;
-  StreamSubscription<RequestRegionMapCameraCenterWorldEvent>? _cameraCenterSub;
-  StreamSubscription<RequestRegionMapCameraPanWorldDeltaEvent>? _cameraPanSub;
-  StreamSubscription<RequestRegionMapSetZoomMultiplierEvent>?
-  _zoomMultiplierSub;
+  final SubscriptionTracker _subscriptions = SubscriptionTracker();
   double _scaleGestureStartMultiplier = 1.0;
 
   @override
@@ -618,39 +616,32 @@ class _CtRegionMapState extends State<CtRegionMap> {
 
   @override
   void dispose() {
-    _cameraCenterSub?.cancel();
-    _cameraPanSub?.cancel();
-    _zoomMultiplierSub?.cancel();
+    _subscriptions.cancelAll();
     super.dispose();
   }
 
   void _attachMinimapCameraBusSubscriptions() {
-    _cameraCenterSub?.cancel();
-    _cameraPanSub?.cancel();
-    _zoomMultiplierSub?.cancel();
-    _cameraCenterSub = null;
-    _cameraPanSub = null;
-    _zoomMultiplierSub = null;
+    _subscriptions.cancelAll();
     final b = widget.bus;
     if (b == null) return;
-    _cameraCenterSub = b.on<RequestRegionMapCameraCenterWorldEvent>().listen((
-      e,
-    ) {
-      if (!mounted || e.regionId != widget.region.regionId) return;
-      _game.setCameraCenterWorld(e.worldCenterX, e.worldCenterY);
-    });
-    _cameraPanSub = b.on<RequestRegionMapCameraPanWorldDeltaEvent>().listen((
-      e,
-    ) {
-      if (!mounted || e.regionId != widget.region.regionId) return;
-      _game.panCameraWorld(e.worldDx, e.worldDy);
-    });
-    _zoomMultiplierSub = b.on<RequestRegionMapSetZoomMultiplierEvent>().listen((
-      e,
-    ) {
-      if (!mounted || e.regionId != widget.region.regionId) return;
-      _game.setZoomMultiplierAbsolute(e.zoomMultiplier);
-    });
+    _subscriptions.track(
+      b.on<RequestRegionMapCameraCenterWorldEvent>().listen((e) {
+        if (!mounted || e.regionId != widget.region.regionId) return;
+        _game.setCameraCenterWorld(e.worldCenterX, e.worldCenterY);
+      }),
+    );
+    _subscriptions.track(
+      b.on<RequestRegionMapCameraPanWorldDeltaEvent>().listen((e) {
+        if (!mounted || e.regionId != widget.region.regionId) return;
+        _game.panCameraWorld(e.worldDx, e.worldDy);
+      }),
+    );
+    _subscriptions.track(
+      b.on<RequestRegionMapSetZoomMultiplierEvent>().listen((e) {
+        if (!mounted || e.regionId != widget.region.regionId) return;
+        _game.setZoomMultiplierAbsolute(e.zoomMultiplier);
+      }),
+    );
   }
 
   @override

--- a/ctterm/lib/screens/production_screen.dart
+++ b/ctterm/lib/screens/production_screen.dart
@@ -47,72 +47,33 @@ class ExtractionTileInfo {
   });
 }
 
-/// MVP production recipes (program-level constants per spec).
-const _productionRecipes = [
-  ProductionRecipe(
-    id: 'timber_to_lumber',
-    name: 'Timber to Lumber',
-    inputs: {'timber': 2},
-    outputs: {'lumber': 1},
-    labourRequired: 2,
-  ),
-  ProductionRecipe(
-    id: 'timber_iron_to_cast_iron',
-    name: 'Timber + Iron to Cast Iron',
-    inputs: {'timber': 2, 'iron': 2},
-    outputs: {'castIron': 1},
-    labourRequired: 5,
-  ),
-  ProductionRecipe(
-    id: 'wool_to_fabric',
-    name: 'Wool to Fabric',
-    inputs: {'wool': 2},
-    outputs: {'fabric': 1},
-    labourRequired: 2,
-  ),
-  ProductionRecipe(
-    id: 'cotton_to_fabric',
-    name: 'Cotton to Fabric',
-    inputs: {'cotton': 2},
-    outputs: {'fabric': 1},
-    labourRequired: 2,
-  ),
-  ProductionRecipe(
-    id: 'sugar_cane_to_refined_sugar',
-    name: 'Sugar Cane to Refined Sugar',
-    inputs: {'sugarCane': 2},
-    outputs: {'refinedSugar': 1},
-    labourRequired: 2,
-  ),
-  ProductionRecipe(
-    id: 'tobacco_to_cigars',
-    name: 'Tobacco to Cigars',
-    inputs: {'tobacco': 2},
-    outputs: {'cigars': 1},
-    labourRequired: 3,
-  ),
-  ProductionRecipe(
-    id: 'furs_to_fur_hats',
-    name: 'Furs to Fur Hats',
-    inputs: {'furs': 2},
-    outputs: {'furHats': 1},
-    labourRequired: 3,
-  ),
-  ProductionRecipe(
-    id: 'iron_coal_to_steel',
-    name: 'Iron + Coal to Steel',
-    inputs: {'iron': 2, 'coal': 2},
-    outputs: {'steel': 1},
-    labourRequired: 4,
-  ),
-  ProductionRecipe(
-    id: 'copper_tin_to_bronze',
-    name: 'Copper + Tin to Bronze',
-    inputs: {'copper': 1, 'tin': 1},
-    outputs: {'bronze': 1},
-    labourRequired: 2,
-  ),
-];
+String _commodityName(String id) =>
+    data.CommodityCatalog.byId[id]?.displayName ?? id;
+
+String _recipeName(data.ProductionRecipe recipe) {
+  final inputNames = recipe.inputQuantities.keys
+      .map(_commodityName)
+      .toList(growable: false);
+  final outputName = _commodityName(recipe.outputCommodityId);
+  if (inputNames.isEmpty) {
+    return outputName;
+  }
+  return '${inputNames.join(' + ')} to $outputName';
+}
+
+final List<ProductionRecipe> _productionRecipes = data
+    .ProductionRecipesCatalog
+    .all
+    .map(
+      (recipe) => ProductionRecipe(
+        id: recipe.id,
+        name: _recipeName(recipe),
+        inputs: recipe.inputQuantities,
+        outputs: {recipe.outputCommodityId: recipe.outputQuantity},
+        labourRequired: recipe.labourPerOutput,
+      ),
+    )
+    .toList(growable: false);
 
 /// Commodity ids from the canonical catalog (SPEC/game/commodity-catalog.md).
 List<String> _allCommodityIds() {
@@ -140,16 +101,16 @@ class ProductionScreen extends StatefulComponent {
 class _ProductionScreenState extends State<ProductionScreen> {
   /// Currently selected panel: 'extraction', 'stockpile', 'production'.
   String _selectedPanel = 'stockpile';
-  
+
   /// Selected index within the current panel.
   int _selectedIndex = 0;
-  
+
   /// Currently active production recipes (by recipe id).
   final Set<String> _activeRecipes = {};
-  
+
   /// Feedback message to display.
   String _feedbackMessage = '';
-  
+
   /// Color for feedback message.
   Color _feedbackColor = const Color(0xFFFFFFFF);
 
@@ -159,7 +120,9 @@ class _ProductionScreenState extends State<ProductionScreen> {
       if (!entry.value) return entry.key;
     }
     // Fallback: first player
-    return component.game.players.isNotEmpty ? component.game.players.first.id : null;
+    return component.game.players.isNotEmpty
+        ? component.game.players.first.id
+        : null;
   }
 
   /// Get the human player's data.
@@ -203,30 +166,38 @@ class _ProductionScreenState extends State<ProductionScreen> {
         final tileKey = province.townTileKey!;
         final parts = tileKey.split('|');
         final regionId = parts.isNotEmpty ? parts[0] : null;
-        
+
         // Get tile improvement and road level from tile state
         final improvement = tileState.improvementLevel(tileKey);
         final roadLevel = tileState.roadLevel(tileKey);
-        
+
         // Calculate yield per turn (simplified: min of improvement, town dev, 1)
         // Per spec: min(improvement, tech cap, transport, town development)
         final townDev = province.townDevelopmentLevel;
         final transportCap = roadLevel > 0 ? roadLevel : 1;
-        final yieldAmount = [improvement, townDev, transportCap].reduce((a, b) => a < b ? a : b);
-        
+        final yieldAmount = [
+          improvement,
+          townDev,
+          transportCap,
+        ].reduce((a, b) => a < b ? a : b);
+
         // Determine resource type from tile key (simplified - would need ruleset)
         // For MVP, derive from tile position
-        final coords = parts.length >= 4 ? parts.sublist(1) : <String>['', '', ''];
-        
-        tiles.add(ExtractionTileInfo(
-          tileKey: tileKey,
-          provinceId: province.id,
-          regionId: regionId,
-          resource: _deriveResourceType(tileKey, coords),
-          improvementLevel: improvement,
-          roadLevel: roadLevel,
-          yieldPerTurn: yieldAmount > 0 ? yieldAmount : 1,
-        ));
+        final coords = parts.length >= 4
+            ? parts.sublist(1)
+            : <String>['', '', ''];
+
+        tiles.add(
+          ExtractionTileInfo(
+            tileKey: tileKey,
+            provinceId: province.id,
+            regionId: regionId,
+            resource: _deriveResourceType(tileKey, coords),
+            improvementLevel: improvement,
+            roadLevel: roadLevel,
+            yieldPerTurn: yieldAmount > 0 ? yieldAmount : 1,
+          ),
+        );
       }
     }
 
@@ -237,7 +208,16 @@ class _ProductionScreenState extends State<ProductionScreen> {
   String _deriveResourceType(String tileKey, List<String> coords) {
     // Simplified: use hash of tile key to pick a resource
     final hash = tileKey.hashCode.abs();
-    final resources = <String>['timber', 'iron', 'coal', 'wool', 'cotton', 'grain', 'furs', 'horses'];
+    final resources = <String>[
+      'timber',
+      'iron',
+      'coal',
+      'wool',
+      'cotton',
+      'grain',
+      'furs',
+      'horses',
+    ];
     return resources[hash % resources.length];
   }
 
@@ -252,7 +232,9 @@ class _ProductionScreenState extends State<ProductionScreen> {
   }
 
   /// Check if a recipe can be activated (has enough inputs and labour).
-  (bool canActivate, String reason) _canActivateRecipe(ProductionRecipe recipe) {
+  (bool canActivate, String reason) _canActivateRecipe(
+    ProductionRecipe recipe,
+  ) {
     final player = _getHumanPlayer();
     if (player == null) return (false, 'No player');
 
@@ -267,7 +249,10 @@ class _ProductionScreenState extends State<ProductionScreen> {
     // Check labour availability
     final availableLabour = player.workerPool.totalWorkers;
     if (availableLabour < recipe.labourRequired) {
-      return (false, 'Need ${recipe.labourRequired} labour, have $availableLabour');
+      return (
+        false,
+        'Need ${recipe.labourRequired} labour, have $availableLabour',
+      );
     }
 
     return (true, 'Ready to produce');
@@ -365,7 +350,7 @@ class _ProductionScreenState extends State<ProductionScreen> {
     }
 
     // Enter/Space: select recipe (in production panel)
-    if (_selectedPanel == 'production' && 
+    if (_selectedPanel == 'production' &&
         (key == LogicalKey.enter || key == LogicalKey.space)) {
       final recipes = _productionRecipes;
       if (_selectedIndex < recipes.length) {
@@ -402,7 +387,7 @@ class _ProductionScreenState extends State<ProductionScreen> {
       }
       return true;
     }
-    
+
     return false;
   }
 
@@ -445,8 +430,8 @@ class _ProductionScreenState extends State<ProductionScreen> {
             child: _selectedPanel == 'extraction'
                 ? _buildExtractionPanel(extractionTiles)
                 : _selectedPanel == 'stockpile'
-                    ? _buildStockpilePanel(player)
-                    : _buildProductionPanel(player),
+                ? _buildStockpilePanel(player)
+                : _buildProductionPanel(player),
           ),
           // Feedback message
           if (_feedbackMessage.isNotEmpty)
@@ -507,7 +492,10 @@ class _ProductionScreenState extends State<ProductionScreen> {
             color: const Color(0xFF1a1a2e),
             child: const Text(
               ' CONNECTED EXTRACTION TILES ',
-              style: TextStyle(color: Color(0xFFFFFFFF), fontWeight: FontWeight.bold),
+              style: TextStyle(
+                color: Color(0xFFFFFFFF),
+                fontWeight: FontWeight.bold,
+              ),
             ),
           ),
           Expanded(
@@ -515,13 +503,19 @@ class _ProductionScreenState extends State<ProductionScreen> {
               itemCount: tiles.length,
               itemBuilder: (context, index) {
                 final tile = tiles[index];
-                final isSelected = _selectedPanel == 'extraction' && _selectedIndex == index;
+                final isSelected =
+                    _selectedPanel == 'extraction' && _selectedIndex == index;
                 final bg = isSelected ? const Color(0xFF2a2a4e) : null;
-                final fg = isSelected ? const Color(0xFFFFFFFF) : const Color(0xFFAAAAAA);
-                
+                final fg = isSelected
+                    ? const Color(0xFFFFFFFF)
+                    : const Color(0xFFAAAAAA);
+
                 return Container(
                   color: bg,
-                  padding: const EdgeInsets.symmetric(horizontal: 1, vertical: 0),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 1,
+                    vertical: 0,
+                  ),
                   child: Text(
                     '  ${_provinceLabel(tile.provinceId)}: ${tile.resource} (imp:${tile.improvementLevel}, road:${tile.roadLevel}) -> +${tile.yieldPerTurn}/turn',
                     style: TextStyle(color: fg),
@@ -558,7 +552,10 @@ class _ProductionScreenState extends State<ProductionScreen> {
             color: const Color(0xFF1a1a2e),
             child: const Text(
               ' STOCKPILE ',
-              style: TextStyle(color: Color(0xFFFFFFFF), fontWeight: FontWeight.bold),
+              style: TextStyle(
+                color: Color(0xFFFFFFFF),
+                fontWeight: FontWeight.bold,
+              ),
             ),
           ),
           Expanded(
@@ -568,32 +565,35 @@ class _ProductionScreenState extends State<ProductionScreen> {
                 final leftIndex = rowIndex;
                 final rightIndex = rowIndex + half;
                 final leftId = commodities[leftIndex];
-                final rightId = rightIndex < commodities.length ? commodities[rightIndex] : null;
+                final rightId = rightIndex < commodities.length
+                    ? commodities[rightIndex]
+                    : null;
 
                 Component buildCell(String id, int globalIndex) {
                   final quantity = stockpile.quantityOf(id);
                   final isSelected =
-                      _selectedPanel == 'stockpile' && _selectedIndex == globalIndex;
+                      _selectedPanel == 'stockpile' &&
+                      _selectedIndex == globalIndex;
                   final isZero = quantity == 0;
                   final fg = isSelected
                       ? const Color(0xFFFFFFFF)
                       : (isZero
-                          ? const Color(0xFFFF6666)
-                          : const Color(0xFFAAAAAA));
+                            ? const Color(0xFFFF6666)
+                            : const Color(0xFFAAAAAA));
                   return Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 1, vertical: 0),
-                    child: Text(
-                      '$id: $quantity',
-                      style: TextStyle(color: fg),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 1,
+                      vertical: 0,
                     ),
+                    child: Text('$id: $quantity', style: TextStyle(color: fg)),
                   );
                 }
 
-                final rowIsSelected = _selectedPanel == 'stockpile' &&
+                final rowIsSelected =
+                    _selectedPanel == 'stockpile' &&
                     (_selectedIndex == leftIndex ||
                         (rightId != null && _selectedIndex == rightIndex));
-                final rowBg =
-                    rowIsSelected ? const Color(0xFF2a2a4e) : null;
+                final rowBg = rowIsSelected ? const Color(0xFF2a2a4e) : null;
 
                 return Container(
                   color: rowBg,
@@ -635,7 +635,10 @@ class _ProductionScreenState extends State<ProductionScreen> {
             color: const Color(0xFF1a1a2e),
             child: const Text(
               ' PRODUCTION RECIPES ',
-              style: TextStyle(color: Color(0xFFFFFFFF), fontWeight: FontWeight.bold),
+              style: TextStyle(
+                color: Color(0xFFFFFFFF),
+                fontWeight: FontWeight.bold,
+              ),
             ),
           ),
           Expanded(
@@ -644,9 +647,10 @@ class _ProductionScreenState extends State<ProductionScreen> {
               itemBuilder: (context, index) {
                 final recipe = _productionRecipes[index];
                 final isActive = _activeRecipes.contains(recipe.id);
-                final isSelected = _selectedPanel == 'production' && _selectedIndex == index;
+                final isSelected =
+                    _selectedPanel == 'production' && _selectedIndex == index;
                 final (canActivate, _) = _canActivateRecipe(recipe);
-                
+
                 final inputStr = recipe.inputs.entries
                     .map((e) => '${e.value} ${e.key}')
                     .join(', ');
@@ -655,15 +659,20 @@ class _ProductionScreenState extends State<ProductionScreen> {
                     .join(', ');
 
                 final bg = isSelected ? const Color(0xFF2a2a4e) : null;
-                final fg = isSelected 
-                    ? const Color(0xFFFFFFFF) 
-                    : (isActive 
-                        ? const Color(0xFF66FF66) 
-                        : (canActivate ? const Color(0xFFAAAAAA) : const Color(0xFFFF6666)));
-                
+                final fg = isSelected
+                    ? const Color(0xFFFFFFFF)
+                    : (isActive
+                          ? const Color(0xFF66FF66)
+                          : (canActivate
+                                ? const Color(0xFFAAAAAA)
+                                : const Color(0xFFFF6666)));
+
                 return Container(
                   color: bg,
-                  padding: const EdgeInsets.symmetric(horizontal: 1, vertical: 0),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 1,
+                    vertical: 0,
+                  ),
                   child: Text(
                     '  ${isActive ? "[*] " : "[ ] "}${recipe.name}: $inputStr -> $outputStr (labour: ${recipe.labourRequired})${!canActivate ? " (N/A)" : ""}',
                     style: TextStyle(color: fg),
@@ -699,7 +708,10 @@ class _ProductionScreenState extends State<ProductionScreen> {
     );
   }
 
-  Component _buildExtractionSummary(List<ExtractionTileInfo> tiles, Map<String, int> totals) {
+  Component _buildExtractionSummary(
+    List<ExtractionTileInfo> tiles,
+    Map<String, int> totals,
+  ) {
     final tileCount = tiles.length;
     final landTotal = totals.entries.fold(0, (sum, e) => sum + e.value);
     // Simplified: no overseas extraction in MVP

--- a/ctterm/lib/screens/shipyard_screen.dart
+++ b/ctterm/lib/screens/shipyard_screen.dart
@@ -97,33 +97,81 @@ class _ShipyardScreenState extends State<ShipyardScreen> {
     return component.game.players.firstWhereOrNull((p) => p.id == playerId);
   }
 
+  String _displayNameForShip(String shipTypeId) {
+    return shipTypeId
+        .split('_')
+        .map(
+          (part) => part.isEmpty
+              ? part
+              : '${part[0].toUpperCase()}${part.substring(1)}',
+        )
+        .join(' ');
+  }
+
   List<ShipDisplayInfo> _getShipList() {
-    return const [
-      ShipDisplayInfo(id: 'carrack', name: 'Carrack', category: 'Merchant', cost: 80, inputs: {'lumber': 2, 'fabric': 1}, firepower: 2, range: 1, armour: 1, hull: 2, movement: 2, cargoHold: 3, isAvailable: true),
-      ShipDisplayInfo(id: 'fluyte', name: 'Fluyte', category: 'Merchant', cost: 60, inputs: {'lumber': 1, 'fabric': 1}, firepower: 1, range: 1, armour: 1, hull: 1, movement: 2, cargoHold: 4, isAvailable: true),
-      ShipDisplayInfo(id: 'sloop', name: 'Sloop', category: 'Warship', cost: 50, inputs: {'lumber': 1}, firepower: 1, range: 1, armour: 1, hull: 1, movement: 2, cargoHold: 0, isAvailable: true),
-      ShipDisplayInfo(id: 'frigate', name: 'Frigate', category: 'Warship', cost: 100, inputs: {'lumber': 2, 'iron': 1}, firepower: 2, range: 2, armour: 1, hull: 2, movement: 3, cargoHold: 0, isAvailable: true),
-    ];
+    final player = _getHumanPlayer();
+    final techUnlocked = player?.techUnlocked;
+    final unlockMap = unlockingTechByShipId;
+    return ShipEconomyCatalog.all.map((entry) {
+      final stats = NavalStatsCatalog.get(entry.shipTypeId);
+      final requiredTech = unlockMap[entry.shipTypeId];
+      final isAvailable =
+          requiredTech == null || (techUnlocked?[requiredTech] ?? false);
+      final category = stats.cargoHold > 0 ? 'Merchant' : 'Warship';
+      return ShipDisplayInfo(
+        id: entry.shipTypeId,
+        name: _displayNameForShip(entry.shipTypeId),
+        category: category,
+        cost: entry.buildTreasuryCost ~/ 100,
+        inputs: entry.buildInputs.map((key, value) => MapEntry(key, value)),
+        firepower: stats.firepower,
+        range: stats.range,
+        armour: stats.armour,
+        hull: stats.hull,
+        movement: stats.movement,
+        cargoHold: stats.cargoHold,
+        isAvailable: isAvailable,
+      );
+    }).toList();
   }
 
   List<BuildOrderInfo> _getBuildOrders() {
     final playerId = _getHumanPlayerId();
     if (playerId == null) return [];
-    final buildOrders = component.orders.buildUnitOrdersByPlayerId[playerId] ?? [];
+    final buildOrders =
+        component.orders.buildUnitOrdersByPlayerId[playerId] ?? [];
     final shipNames = {for (final s in _getShipList()) s.id: s.name};
-    return buildOrders.where((o) => ShipEconomyCatalog.byId.containsKey(o.unitType)).map((o) => BuildOrderInfo(shipTypeId: o.unitType, shipName: shipNames[o.unitType] ?? o.unitType, provinceId: o.spawnProvinceId, turnsRemaining: 2)).toList();
+    return buildOrders
+        .where((o) => ShipEconomyCatalog.byId.containsKey(o.unitType))
+        .map(
+          (o) => BuildOrderInfo(
+            shipTypeId: o.unitType,
+            shipName: shipNames[o.unitType] ?? o.unitType,
+            provinceId: o.spawnProvinceId,
+            turnsRemaining: 2,
+          ),
+        )
+        .toList();
   }
 
   List<Unit> _getHomeFleet() {
     final playerId = _getHumanPlayerId();
     if (playerId == null) return [];
-    return component.game.worldState.oldWorld.units.where((u) => u.ownerId == playerId && ShipEconomyCatalog.byId.containsKey(u.type)).toList();
+    return component.game.worldState.oldWorld.units
+        .where(
+          (u) =>
+              u.ownerId == playerId &&
+              ShipEconomyCatalog.byId.containsKey(u.type),
+        )
+        .toList();
   }
 
   List<Province> _getPortProvinces() {
     final playerId = _getHumanPlayerId();
     if (playerId == null) return [];
-    return component.game.worldState.oldWorld.provinces.where((p) => p.ownerId == playerId && p.townDevelopmentLevel >= 1).toList();
+    return component.game.worldState.oldWorld.provinces
+        .where((p) => p.ownerId == playerId && p.townDevelopmentLevel >= 1)
+        .toList();
   }
 
   int _getPlayerGold() => _getHumanPlayer()?.treasury ?? 0;
@@ -145,69 +193,168 @@ class _ShipyardScreenState extends State<ShipyardScreen> {
 
   void _issueBuildOrder(String provinceId, ShipDisplayInfo ship) {
     final playerId = _getHumanPlayerId();
-    if (playerId == null) { setState(() { _feedbackMessage = 'Error: No human player'; _feedbackColor = Colors.red; }); return; }
-    if (!ship.isAvailable) { setState(() { _feedbackMessage = 'Ship not available'; _feedbackColor = Colors.red; }); return; }
+    if (playerId == null) {
+      setState(() {
+        _feedbackMessage = 'Error: No human player';
+        _feedbackColor = Colors.red;
+      });
+      return;
+    }
+    if (!ship.isAvailable) {
+      setState(() {
+        _feedbackMessage = 'Ship not available';
+        _feedbackColor = Colors.red;
+      });
+      return;
+    }
     final gold = _getPlayerGold();
-    if (gold < ship.cost) { setState(() { _feedbackMessage = 'Insufficient gold: need ${ship.cost}, have $gold'; _feedbackColor = Colors.red; }); return; }
+    if (gold < ship.cost) {
+      setState(() {
+        _feedbackMessage = 'Insufficient gold: need ${ship.cost}, have $gold';
+        _feedbackColor = Colors.red;
+      });
+      return;
+    }
     final hasPort = _getPortProvinces().any((p) => p.id == provinceId);
-    if (!hasPort) { setState(() { _feedbackMessage = 'Province has no port'; _feedbackColor = Colors.red; }); return; }
-    final newOrder = BuildUnitOrder(unitType: ship.id, isMilitary: false, spawnProvinceId: provinceId);
+    if (!hasPort) {
+      setState(() {
+        _feedbackMessage = 'Province has no port';
+        _feedbackColor = Colors.red;
+      });
+      return;
+    }
+    final newOrder = BuildUnitOrder(
+      unitType: ship.id,
+      isMilitary: false,
+      spawnProvinceId: provinceId,
+    );
     final existing = component.orders.buildUnitOrdersByPlayerId[playerId] ?? [];
     final newOrders = Orders(
       moveOrdersByPlayerId: component.orders.moveOrdersByPlayerId,
-      buildUnitOrdersByPlayerId: {...component.orders.buildUnitOrdersByPlayerId, playerId: [...existing, newOrder]},
+      buildUnitOrdersByPlayerId: {
+        ...component.orders.buildUnitOrdersByPlayerId,
+        playerId: [...existing, newOrder],
+      },
       workOrdersByPlayerId: component.orders.workOrdersByPlayerId,
       diplomaticOrdersByPlayerId: component.orders.diplomaticOrdersByPlayerId,
       researchOrdersByPlayerId: component.orders.researchOrdersByPlayerId,
       navalMoveOrdersByPlayerId: component.orders.navalMoveOrdersByPlayerId,
-      navalMissionOrdersByPlayerId: component.orders.navalMissionOrdersByPlayerId,
+      navalMissionOrdersByPlayerId:
+          component.orders.navalMissionOrdersByPlayerId,
     );
     component.onOrdersChanged(newOrders);
     _log.i('build order for ${ship.name} in $provinceId');
-    setState(() { _inputMode = InputMode.none; _provinceInput = ''; _feedbackMessage = 'Build order issued'; _feedbackColor = Colors.green; });
+    setState(() {
+      _inputMode = InputMode.none;
+      _provinceInput = '';
+      _feedbackMessage = 'Build order issued';
+      _feedbackColor = Colors.green;
+    });
   }
 
   void _cancelBuildOrder(int index) {
     final playerId = _getHumanPlayerId();
     if (playerId == null) return;
     final existing = component.orders.buildUnitOrdersByPlayerId[playerId] ?? [];
-    final shipOrders = existing.where((o) => ShipEconomyCatalog.byId.containsKey(o.unitType)).toList();
+    final shipOrders = existing
+        .where((o) => ShipEconomyCatalog.byId.containsKey(o.unitType))
+        .toList();
     if (index >= shipOrders.length) return;
     final toCancel = shipOrders[index];
     final updated = existing.where((o) => o != toCancel).toList();
     final newOrders = Orders(
       moveOrdersByPlayerId: component.orders.moveOrdersByPlayerId,
-      buildUnitOrdersByPlayerId: {...component.orders.buildUnitOrdersByPlayerId, playerId: updated},
+      buildUnitOrdersByPlayerId: {
+        ...component.orders.buildUnitOrdersByPlayerId,
+        playerId: updated,
+      },
       workOrdersByPlayerId: component.orders.workOrdersByPlayerId,
       diplomaticOrdersByPlayerId: component.orders.diplomaticOrdersByPlayerId,
       researchOrdersByPlayerId: component.orders.researchOrdersByPlayerId,
       navalMoveOrdersByPlayerId: component.orders.navalMoveOrdersByPlayerId,
-      navalMissionOrdersByPlayerId: component.orders.navalMissionOrdersByPlayerId,
+      navalMissionOrdersByPlayerId:
+          component.orders.navalMissionOrdersByPlayerId,
     );
     component.onOrdersChanged(newOrders);
-    setState(() { _inputMode = InputMode.none; _feedbackMessage = 'Order cancelled'; _feedbackColor = Colors.green; });
+    setState(() {
+      _inputMode = InputMode.none;
+      _feedbackMessage = 'Order cancelled';
+      _feedbackColor = Colors.green;
+    });
   }
 
   bool _handleKeyEvent(dynamic event) {
     final key = event.logicalKey;
     final c = event.character?.toLowerCase();
     if (key == LogicalKey.escape) {
-      if (_inputMode != InputMode.none) { setState(() { _inputMode = InputMode.none; _provinceInput = ''; _feedbackMessage = ''; }); return true; }
-      component.onNavigate(CttermRoute.inGameShell); return true;
+      if (_inputMode != InputMode.none) {
+        setState(() {
+          _inputMode = InputMode.none;
+          _provinceInput = '';
+          _feedbackMessage = '';
+        });
+        return true;
+      }
+      component.onNavigate(CttermRoute.inGameShell);
+      return true;
     }
     final ships = _getShipList();
     if (ships.isEmpty) return false;
     if (_inputMode == InputMode.province) {
-      if (key == LogicalKey.enter) { _issueBuildOrder(_provinceInput, ships[_selectedIndex]); return true; }
-      else if (key == LogicalKey.backspace) { setState(() { _provinceInput = _provinceInput.isNotEmpty ? _provinceInput.substring(0, _provinceInput.length - 1) : ''; }); return true; }
-      else if (c != null && (c == '|' || (c.codeUnitAt(0) >= 48 && c.codeUnitAt(0) <= 57))) { setState(() { _provinceInput += c; }); return true; }
+      if (key == LogicalKey.enter) {
+        _issueBuildOrder(_provinceInput, ships[_selectedIndex]);
+        return true;
+      } else if (key == LogicalKey.backspace) {
+        setState(() {
+          _provinceInput = _provinceInput.isNotEmpty
+              ? _provinceInput.substring(0, _provinceInput.length - 1)
+              : '';
+        });
+        return true;
+      } else if (c != null &&
+          (c == '|' || (c.codeUnitAt(0) >= 48 && c.codeUnitAt(0) <= 57))) {
+        setState(() {
+          _provinceInput += c;
+        });
+        return true;
+      }
       return false;
     }
-    if (key == LogicalKey.arrowUp || c == 'k') { setState(() { _selectedIndex = (_selectedIndex - 1).clamp(0, ships.length - 1); _feedbackMessage = ''; }); return true; }
-    if (key == LogicalKey.arrowDown || c == 'j') { setState(() { _selectedIndex = (_selectedIndex + 1).clamp(0, ships.length - 1); _feedbackMessage = ''; }); return true; }
-    if (c == 'b') { setState(() { _inputMode = InputMode.province; _provinceInput = ''; _feedbackMessage = 'Enter province ID:'; _feedbackColor = Colors.cyan; }); return true; }
-    if (c == 'c') { final orders = _getBuildOrders(); if (orders.isNotEmpty && _selectedIndex < orders.length) _cancelBuildOrder(_selectedIndex); return true; }
-    if (c == 'h') { setState(() { _showHomeFleet = !_showHomeFleet; }); return true; }
+    if (key == LogicalKey.arrowUp || c == 'k') {
+      setState(() {
+        _selectedIndex = (_selectedIndex - 1).clamp(0, ships.length - 1);
+        _feedbackMessage = '';
+      });
+      return true;
+    }
+    if (key == LogicalKey.arrowDown || c == 'j') {
+      setState(() {
+        _selectedIndex = (_selectedIndex + 1).clamp(0, ships.length - 1);
+        _feedbackMessage = '';
+      });
+      return true;
+    }
+    if (c == 'b') {
+      setState(() {
+        _inputMode = InputMode.province;
+        _provinceInput = '';
+        _feedbackMessage = 'Enter province ID:';
+        _feedbackColor = Colors.cyan;
+      });
+      return true;
+    }
+    if (c == 'c') {
+      final orders = _getBuildOrders();
+      if (orders.isNotEmpty && _selectedIndex < orders.length)
+        _cancelBuildOrder(_selectedIndex);
+      return true;
+    }
+    if (c == 'h') {
+      setState(() {
+        _showHomeFleet = !_showHomeFleet;
+      });
+      return true;
+    }
     return false;
   }
 
@@ -217,183 +364,236 @@ class _ShipyardScreenState extends State<ShipyardScreen> {
     final buildOrders = _getBuildOrders();
     final homeFleet = _getHomeFleet();
     final ports = _getPortProvinces();
-    final selected = ships.isNotEmpty && _selectedIndex < ships.length ? ships[_selectedIndex] : null;
+    final selected = ships.isNotEmpty && _selectedIndex < ships.length
+        ? ships[_selectedIndex]
+        : null;
     return Focusable(
       focused: true,
       onKeyEvent: _handleKeyEvent,
       child: Container(
         color: Colors.black,
-        child: Column(children: [
-          Container(padding: const EdgeInsets.all(1), color: Colors.blue, child: Row(children: [
-            const Text(' Shipyard ', style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
-            const Text('[b]uild [c]ancel [h]ome [Esc]back', style: TextStyle(color: Colors.grey)),
-          ])),
-          Expanded(
-            child: Row(
-              children: [
-                Expanded(
-                  flex: 3,
-                  child: Container(
-                    padding: const EdgeInsets.all(1),
-                    child: Column(
-                      children: [
-                        const Text(
-                          'Available Ships:',
-                          style: TextStyle(
-                            color: Colors.yellow,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                        const SizedBox(height: 1),
-                        Expanded(
-                          child: ListView(
-                            children: [
-                              for (var i = 0; i < ships.length; i++)
-                                _shipRow(ships[i], i == _selectedIndex),
-                            ],
-                          ),
-                        ),
-                      ],
+        child: Column(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(1),
+              color: Colors.blue,
+              child: Row(
+                children: [
+                  const Text(
+                    ' Shipyard ',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
                     ),
                   ),
-                ),
-                Expanded(
-                  flex: 2,
-                  child: Container(
-                    padding: const EdgeInsets.all(1),
-                    child: Column(
-                      children: [
-                        const Text(
-                          'Details:',
-                          style: TextStyle(
-                            color: Colors.yellow,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                        const SizedBox(height: 1),
-                        if (selected != null) ...[
-                          Text(
-                            selected.name,
-                            style: const TextStyle(
-                              color: Colors.white,
+                  const Text(
+                    '[b]uild [c]ancel [h]ome [Esc]back',
+                    style: TextStyle(color: Colors.grey),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: Row(
+                children: [
+                  Expanded(
+                    flex: 3,
+                    child: Container(
+                      padding: const EdgeInsets.all(1),
+                      child: Column(
+                        children: [
+                          const Text(
+                            'Available Ships:',
+                            style: TextStyle(
+                              color: Colors.yellow,
                               fontWeight: FontWeight.bold,
                             ),
                           ),
-                          Text(
-                            'Category: ${selected.category}',
-                            style: const TextStyle(color: Colors.grey),
-                          ),
-                          Text(
-                            'Cost: ${selected.cost}g',
-                            style: const TextStyle(color: Colors.white),
-                          ),
-                          const Text(
-                            'Stats:',
-                            style: TextStyle(color: Colors.cyan),
-                          ),
-                          Text(
-                            '  FRP:${selected.firepower} RNG:${selected.range}',
-                            style: const TextStyle(color: Colors.white),
-                          ),
-                          Text(
-                            '  ARM:${selected.armour} HULL:${selected.hull}',
-                            style: const TextStyle(color: Colors.white),
-                          ),
-                          Text(
-                            '  MV:${selected.movement}',
-                            style: const TextStyle(color: Colors.white),
-                          ),
-                          Text(
-                            selected.isAvailable ? '[b]uild' : 'Locked',
-                            style: TextStyle(
-                              color: selected.isAvailable
-                                  ? Colors.green
-                                  : Colors.red,
+                          const SizedBox(height: 1),
+                          Expanded(
+                            child: ListView(
+                              children: [
+                                for (var i = 0; i < ships.length; i++)
+                                  _shipRow(ships[i], i == _selectedIndex),
+                              ],
                             ),
                           ),
-                        ] else
-                          const Text(
-                            'No selection',
-                            style: TextStyle(color: Colors.grey),
-                          ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
-                ),
-                Expanded(
-                  flex: 2,
-                  child: Container(
-                    padding: const EdgeInsets.all(1),
-                    child: Column(
-                      children: [
-                        Text(
-                          _showHomeFleet ? 'Home Fleet:' : 'Build Queue:',
-                          style: const TextStyle(
-                            color: Colors.yellow,
-                            fontWeight: FontWeight.bold,
+                  Expanded(
+                    flex: 2,
+                    child: Container(
+                      padding: const EdgeInsets.all(1),
+                      child: Column(
+                        children: [
+                          const Text(
+                            'Details:',
+                            style: TextStyle(
+                              color: Colors.yellow,
+                              fontWeight: FontWeight.bold,
+                            ),
                           ),
-                        ),
-                        const SizedBox(height: 1),
-                        if (_showHomeFleet) ...[
-                          if (homeFleet.isEmpty)
-                            const Text(
-                              'No ships',
-                              style: TextStyle(color: Colors.grey),
-                            )
-                          else
-                            ...homeFleet.map(
-                              (u) => Text(
-                                _fmtShip(u.type),
-                                style: const TextStyle(color: Colors.white),
+                          const SizedBox(height: 1),
+                          if (selected != null) ...[
+                            Text(
+                              selected.name,
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold,
                               ),
                             ),
-                          Text(
-                            'Ports: ${ports.length}',
-                            style: const TextStyle(color: Colors.grey),
-                          ),
-                        ] else ...[
-                          if (buildOrders.isEmpty)
+                            Text(
+                              'Category: ${selected.category}',
+                              style: const TextStyle(color: Colors.grey),
+                            ),
+                            Text(
+                              'Cost: ${selected.cost}g',
+                              style: const TextStyle(color: Colors.white),
+                            ),
                             const Text(
-                              'No orders',
-                              style: TextStyle(color: Colors.grey),
-                            )
-                          else
-                            ...buildOrders.asMap().entries.map(
-                              (e) => Text(
-                                '${e.key + 1}.${e.value.shipName}>${_provinceLabel(e.value.provinceId)}',
-                                style: TextStyle(
-                                  color: e.key == _selectedIndex
-                                      ? Colors.green
-                                      : Colors.white,
-                                ),
+                              'Stats:',
+                              style: TextStyle(color: Colors.cyan),
+                            ),
+                            Text(
+                              '  FRP:${selected.firepower} RNG:${selected.range}',
+                              style: const TextStyle(color: Colors.white),
+                            ),
+                            Text(
+                              '  ARM:${selected.armour} HULL:${selected.hull}',
+                              style: const TextStyle(color: Colors.white),
+                            ),
+                            Text(
+                              '  MV:${selected.movement}',
+                              style: const TextStyle(color: Colors.white),
+                            ),
+                            Text(
+                              selected.isAvailable ? '[b]uild' : 'Locked',
+                              style: TextStyle(
+                                color: selected.isAvailable
+                                    ? Colors.green
+                                    : Colors.red,
                               ),
+                            ),
+                          ] else
+                            const Text(
+                              'No selection',
+                              style: TextStyle(color: Colors.grey),
                             ),
                         ],
-                      ],
+                      ),
                     ),
                   ),
-                ),
-              ],
+                  Expanded(
+                    flex: 2,
+                    child: Container(
+                      padding: const EdgeInsets.all(1),
+                      child: Column(
+                        children: [
+                          Text(
+                            _showHomeFleet ? 'Home Fleet:' : 'Build Queue:',
+                            style: const TextStyle(
+                              color: Colors.yellow,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: 1),
+                          if (_showHomeFleet) ...[
+                            if (homeFleet.isEmpty)
+                              const Text(
+                                'No ships',
+                                style: TextStyle(color: Colors.grey),
+                              )
+                            else
+                              ...homeFleet.map(
+                                (u) => Text(
+                                  _fmtShip(u.type),
+                                  style: const TextStyle(color: Colors.white),
+                                ),
+                              ),
+                            Text(
+                              'Ports: ${ports.length}',
+                              style: const TextStyle(color: Colors.grey),
+                            ),
+                          ] else ...[
+                            if (buildOrders.isEmpty)
+                              const Text(
+                                'No orders',
+                                style: TextStyle(color: Colors.grey),
+                              )
+                            else
+                              ...buildOrders.asMap().entries.map(
+                                (e) => Text(
+                                  '${e.key + 1}.${e.value.shipName}>${_provinceLabel(e.value.provinceId)}',
+                                  style: TextStyle(
+                                    color: e.key == _selectedIndex
+                                        ? Colors.green
+                                        : Colors.white,
+                                  ),
+                                ),
+                              ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ),
-          ),
-          Container(padding: const EdgeInsets.all(1), color: Colors.grey, child: Row(children: [
-            if (_inputMode == InputMode.province) ...[
-              Text(_provinceInput.isEmpty ? 'Province: ' : _provinceInput, style: TextStyle(color: _feedbackColor)),
-              const Text('_', style: TextStyle(color: Colors.cyan)),
-            ] else Text(_feedbackMessage.isEmpty ? 'arrows/jk b c h' : _feedbackMessage, style: TextStyle(color: _feedbackColor)),
-          ])),
-        ]),
+            Container(
+              padding: const EdgeInsets.all(1),
+              color: Colors.grey,
+              child: Row(
+                children: [
+                  if (_inputMode == InputMode.province) ...[
+                    Text(
+                      _provinceInput.isEmpty ? 'Province: ' : _provinceInput,
+                      style: TextStyle(color: _feedbackColor),
+                    ),
+                    const Text('_', style: TextStyle(color: Colors.cyan)),
+                  ] else
+                    Text(
+                      _feedbackMessage.isEmpty
+                          ? 'arrows/jk b c h'
+                          : _feedbackMessage,
+                      style: TextStyle(color: _feedbackColor),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
 
-  String _fmtShip(String id) => id.replaceAll('_', ' ').split(' ').map((w) => w.isEmpty ? w : w[0].toUpperCase() + w.substring(1)).join(' ');
+  String _fmtShip(String id) => id
+      .replaceAll('_', ' ')
+      .split(' ')
+      .map((w) => w.isEmpty ? w : w[0].toUpperCase() + w.substring(1))
+      .join(' ');
 
   Component _shipRow(ShipDisplayInfo ship, bool sel) {
-    return Container(color: sel ? Colors.blue : Colors.black, padding: const EdgeInsets.all(1), child: Row(children: [
-      Text(sel ? '> ' : '  ', style: const TextStyle(color: Colors.cyan)),
-      Expanded(child: Text('${ship.name.padRight(10)} ${ship.category.padRight(10)} ${ship.isAvailable?"Avail":"Lock"}', style: TextStyle(color: sel ? Colors.white : (ship.isAvailable ? Colors.green : Colors.red)))),
-      Text('${ship.cost}g', style: const TextStyle(color: Colors.yellow)),
-    ]));
+    return Container(
+      color: sel ? Colors.blue : Colors.black,
+      padding: const EdgeInsets.all(1),
+      child: Row(
+        children: [
+          Text(sel ? '> ' : '  ', style: const TextStyle(color: Colors.cyan)),
+          Expanded(
+            child: Text(
+              '${ship.name.padRight(10)} ${ship.category.padRight(10)} ${ship.isAvailable ? "Avail" : "Lock"}',
+              style: TextStyle(
+                color: sel
+                    ? Colors.white
+                    : (ship.isAvailable ? Colors.green : Colors.red),
+              ),
+            ),
+          ),
+          Text('${ship.cost}g', style: const TextStyle(color: Colors.yellow)),
+        ],
+      ),
+    );
   }
 }

--- a/packages/colonizethis_logic/lib/src/event_bus/game_event_bus.dart
+++ b/packages/colonizethis_logic/lib/src/event_bus/game_event_bus.dart
@@ -10,6 +10,12 @@ const int kGameEventLogSummaryMaxChars = 500;
 
 final _gameEventLog = logicLogger();
 
+extension _GameEventStreamWhereType on Stream<GameEvent> {
+  Stream<T> whereType<T extends GameEvent>() {
+    return where((event) => event is T).map((event) => event as T);
+  }
+}
+
 String _gameEventPayloadSummary(GameEvent event) {
   return switch (event) {
     CombatResultEvent e =>
@@ -82,10 +88,7 @@ class DefaultGameEventBus implements GameEventBus {
   @override
   void Function() subscribe<T extends GameEvent>(void Function(T) handler) {
     late final StreamSubscription<GameEvent> sub;
-    sub = _controller.stream
-        .where((e) => e is T)
-        .map((e) => e as T)
-        .listen(handler);
+    sub = _controller.stream.whereType<T>().listen(handler);
     return () => sub.cancel();
   }
 

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -112,8 +112,7 @@ class OrderEngine {
 
   Orders _copyOrders(Orders o) => Orders(
     moveOrdersByPlayerId: _copyMapOfOrderLists(o.moveOrdersByPlayerId),
-    armyMoveOrdersByPlayerId:
-        _copyMapOfOrderLists(o.armyMoveOrdersByPlayerId),
+    armyMoveOrdersByPlayerId: _copyMapOfOrderLists(o.armyMoveOrdersByPlayerId),
     buildUnitOrdersByPlayerId: _copyMapOfOrderLists(
       o.buildUnitOrdersByPlayerId,
     ),
@@ -168,9 +167,7 @@ class OrderEngine {
     }
     final r = results.last;
     if (!r.isAccepted)
-      _log.w(
-        '$orderLabel order rejected player=$playerId reason=${r.reason}',
-      );
+      _log.w('$orderLabel order rejected player=$playerId reason=${r.reason}');
     return r;
   }
 
@@ -199,8 +196,7 @@ class OrderEngine {
   static Orders _withArmyMoveOrders(
     Orders o,
     Map<String, List<ArmyMoveOrder>> m,
-  ) =>
-      o.copyWith(armyMoveOrdersByPlayerId: m);
+  ) => o.copyWith(armyMoveOrdersByPlayerId: m);
 
   static Map<String, List<BuildUnitOrder>> _buildOrders(Orders o) =>
       o.buildUnitOrdersByPlayerId;
@@ -245,10 +241,10 @@ class OrderEngine {
 
   static const _OrderSlot<ArmyMoveOrder> _armyMoveSlot =
       _OrderSlot<ArmyMoveOrder>(
-    getter: _armyMoveOrders,
-    updater: _withArmyMoveOrders,
-    label: 'army move',
-  );
+        getter: _armyMoveOrders,
+        updater: _withArmyMoveOrders,
+        label: 'army move',
+      );
 
   static const _OrderSlot<BuildUnitOrder> _buildSlot =
       _OrderSlot<BuildUnitOrder>(
@@ -320,8 +316,10 @@ class OrderEngine {
   OrderValidationResult addMoveOrder(String playerId, MoveOrder order) =>
       _addOrder(playerId, order, _moveSlot);
 
-  OrderValidationResult addArmyMoveOrder(String playerId, ArmyMoveOrder order) =>
-      _addOrder(playerId, order, _armyMoveSlot);
+  OrderValidationResult addArmyMoveOrder(
+    String playerId,
+    ArmyMoveOrder order,
+  ) => _addOrder(playerId, order, _armyMoveSlot);
 
   OrderValidationResult addMoveOrderWithContext(
     Game game,
@@ -329,15 +327,14 @@ class OrderEngine {
     String playerId,
     MoveOrder order, {
     Map<String, TileMapResult>? tileMapByRegion,
-  }) =>
-      _addOrderWithContextSlot(
-        game,
-        topology,
-        playerId,
-        order,
-        _moveSlot,
-        tileMapByRegion: tileMapByRegion,
-      );
+  }) => _addOrderWithContextSlot(
+    game,
+    topology,
+    playerId,
+    order,
+    _moveSlot,
+    tileMapByRegion: tileMapByRegion,
+  );
 
   OrderValidationResult addArmyMoveOrderWithContext(
     Game game,
@@ -345,15 +342,14 @@ class OrderEngine {
     String playerId,
     ArmyMoveOrder order, {
     Map<String, TileMapResult>? tileMapByRegion,
-  }) =>
-      _addOrderWithContextSlot(
-        game,
-        topology,
-        playerId,
-        order,
-        _armyMoveSlot,
-        tileMapByRegion: tileMapByRegion,
-      );
+  }) => _addOrderWithContextSlot(
+    game,
+    topology,
+    playerId,
+    order,
+    _armyMoveSlot,
+    tileMapByRegion: tileMapByRegion,
+  );
 
   OrderValidationResult addBuildOrder(String playerId, BuildUnitOrder order) =>
       _addOrder(playerId, order, _buildSlot);
@@ -364,15 +360,14 @@ class OrderEngine {
     String playerId,
     BuildUnitOrder order, {
     Map<String, TileMapResult>? tileMapByRegion,
-  }) =>
-      _addOrderWithContextSlot(
-        game,
-        topology,
-        playerId,
-        order,
-        _buildSlot,
-        tileMapByRegion: tileMapByRegion,
-      );
+  }) => _addOrderWithContextSlot(
+    game,
+    topology,
+    playerId,
+    order,
+    _buildSlot,
+    tileMapByRegion: tileMapByRegion,
+  );
 
   OrderValidationResult addWorkOrder(String playerId, WorkOrder order) =>
       _addOrder(playerId, order, _workSlot);
@@ -383,15 +378,14 @@ class OrderEngine {
     String playerId,
     WorkOrder order, {
     Map<String, TileMapResult>? tileMapByRegion,
-  }) =>
-      _addOrderWithContextSlot(
-        game,
-        topology,
-        playerId,
-        order,
-        _workSlot,
-        tileMapByRegion: tileMapByRegion,
-      );
+  }) => _addOrderWithContextSlot(
+    game,
+    topology,
+    playerId,
+    order,
+    _workSlot,
+    tileMapByRegion: tileMapByRegion,
+  );
 
   OrderValidationResult addDiplomaticOrder(
     String playerId,
@@ -404,15 +398,14 @@ class OrderEngine {
     String playerId,
     DiplomaticOrder order, {
     Map<String, TileMapResult>? tileMapByRegion,
-  }) =>
-      _addOrderWithContextSlot(
-        game,
-        topology,
-        playerId,
-        order,
-        _diplomaticSlot,
-        tileMapByRegion: tileMapByRegion,
-      );
+  }) => _addOrderWithContextSlot(
+    game,
+    topology,
+    playerId,
+    order,
+    _diplomaticSlot,
+    tileMapByRegion: tileMapByRegion,
+  );
 
   OrderValidationResult addNavalMoveOrder(
     String playerId,
@@ -425,15 +418,14 @@ class OrderEngine {
     String playerId,
     NavalMoveOrder order, {
     Map<String, TileMapResult>? tileMapByRegion,
-  }) =>
-      _addOrderWithContextSlot(
-        game,
-        topology,
-        playerId,
-        order,
-        _navalMoveSlot,
-        tileMapByRegion: tileMapByRegion,
-      );
+  }) => _addOrderWithContextSlot(
+    game,
+    topology,
+    playerId,
+    order,
+    _navalMoveSlot,
+    tileMapByRegion: tileMapByRegion,
+  );
 
   OrderValidationResult addNavalMissionOrder(
     String playerId,
@@ -446,15 +438,14 @@ class OrderEngine {
     String playerId,
     NavalMissionOrder order, {
     Map<String, TileMapResult>? tileMapByRegion,
-  }) =>
-      _addOrderWithContextSlot(
-        game,
-        topology,
-        playerId,
-        order,
-        _navalMissionSlot,
-        tileMapByRegion: tileMapByRegion,
-      );
+  }) => _addOrderWithContextSlot(
+    game,
+    topology,
+    playerId,
+    order,
+    _navalMissionSlot,
+    tileMapByRegion: tileMapByRegion,
+  );
 
   void removeMoveOrder(String playerId, int index) =>
       _removeOrderAtSlot(playerId, index, _moveSlot);
@@ -552,16 +543,19 @@ class OrderEngine {
     stockpile = buildValidator.stockpile;
     treasury = buildValidator.treasury;
 
-    final workValidator = WorkOrderValidator(
+    final workContext = WorkOrderValidationContext(
       game: game,
       player: player,
       playerId: playerId,
       view: view,
       unitsById: unitsById,
       devExclusiveTiles: devExclusiveTiles,
+      tileMapByRegion: tileMapByRegion,
+    );
+    final workValidator = WorkOrderValidator(
+      context: workContext,
       stockpile: stockpile,
       treasury: treasury,
-      tileMapByRegion: tileMapByRegion,
     );
     rejected = _appendValidationResults(
       results,

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
@@ -449,22 +449,19 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
   final otherGps = game.players
       .where((p) => p.id != playerId)
       .map((p) => p.id)
-      .toList();
-  final minorIds = game.minorNations.map((m) => m.id).toList();
-  final tribeIds = game.tribes.map((t) => t.id).toList();
-  final allTargets = <String>[...otherGps, ...minorIds, ...tribeIds];
-  final knownTargets = allTargets
-      .where((id) => knownFactionIds.contains(id))
-      .toList();
+      .toSet();
+  final minorIds = game.minorNations.map((m) => m.id).toSet();
+  final tribeIds = game.tribes.map((t) => t.id).toSet();
+  final knownTargets = <String>{
+    ...otherGps.where(knownFactionIds.contains),
+    ...minorIds.where(knownFactionIds.contains),
+    ...tribeIds.where(knownFactionIds.contains),
+  };
   final knownTargetIds = knownTargets.toSet();
 
   final unionTargets = <String>{
     ...knownTargets,
     ...otherGps,
-    for (final id in minorIds)
-      if (knownFactionIds.contains(id)) id,
-    for (final id in tribeIds)
-      if (knownFactionIds.contains(id)) id,
     for (final o in game.overtureStates)
       if (o.gpId == playerId) o.targetId,
   };

--- a/packages/colonizethis_logic/lib/src/orders/order_validation_result.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_validation_result.dart
@@ -5,10 +5,7 @@
 enum OrderValidationStatus { accepted, rejected }
 
 class OrderValidationResult {
-  const OrderValidationResult({
-    required this.status,
-    this.reason,
-  });
+  const OrderValidationResult({required this.status, this.reason});
 
   final OrderValidationStatus status;
   final String? reason;
@@ -17,13 +14,17 @@ class OrderValidationResult {
 
   /// Factory for rejected result with optional reason.
   factory OrderValidationResult.rejected(String reason) =>
-      OrderValidationResult(status: OrderValidationStatus.rejected, reason: reason);
+      OrderValidationResult(
+        status: OrderValidationStatus.rejected,
+        reason: reason,
+      );
 
   /// Factory for accepted result.
   factory OrderValidationResult.accepted() => _accepted;
 
-  static const _accepted =
-      OrderValidationResult(status: OrderValidationStatus.accepted);
+  static const _accepted = OrderValidationResult(
+    status: OrderValidationStatus.accepted,
+  );
 }
 
 /// Shared constant result used when a previous order in the sequence
@@ -32,6 +33,30 @@ const OrderValidationResult previousInvalidOrderResult = OrderValidationResult(
   status: OrderValidationStatus.rejected,
   reason: 'Previous invalid',
 );
+
+/// Base helper for validators that short-circuit after the first rejected order.
+abstract class OrderValidator {
+  const OrderValidator();
+
+  OrderValidationResult shortCircuitIfPreviousRejected({
+    required bool previousRejected,
+    required OrderValidationResult Function() body,
+  }) {
+    return previousRejected ? previousInvalidOrderResult : body();
+  }
+
+  ({OrderValidationResult result, int treasury})
+  shortCircuitIfPreviousRejectedWithTreasury({
+    required bool previousRejected,
+    required int currentTreasury,
+    required ({OrderValidationResult result, int treasury}) Function() body,
+  }) {
+    if (previousRejected) {
+      return (result: previousInvalidOrderResult, treasury: currentTreasury);
+    }
+    return body();
+  }
+}
 
 /// Helper for validators that use a [previousRejected] flag.
 /// If [previousRejected] is true, returns [previousInvalidOrderResult] and skips [body].
@@ -48,7 +73,8 @@ OrderValidationResult shortCircuitIfPreviousRejected({
 
 /// Like [shortCircuitIfPreviousRejected] for validators that also return updated treasury.
 /// When [previousRejected], returns (previousInvalidOrderResult, currentTreasury); else [body]().
-({OrderValidationResult result, int treasury}) shortCircuitIfPreviousRejectedWithTreasury({
+({OrderValidationResult result, int treasury})
+shortCircuitIfPreviousRejectedWithTreasury({
   required bool previousRejected,
   required int currentTreasury,
   required ({OrderValidationResult result, int treasury}) Function() body,

--- a/packages/colonizethis_logic/lib/src/orders/validators/build_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/build_order_validator.dart
@@ -7,7 +7,7 @@ import '../order_validation_result.dart';
 /// Validates build unit orders for a single player in submission order.
 /// Mutates internal economy state (workers, stockpile, treasury) when an order
 /// is accepted. SPEC/program/orders.md § Build orders.
-class BuildOrderValidator {
+class BuildOrderValidator extends OrderValidator {
   final Game _game;
   final Player _player;
 

--- a/packages/colonizethis_logic/lib/src/orders/validators/diplomatic_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/diplomatic_order_validator.dart
@@ -6,7 +6,7 @@ import '../order_validation_result.dart';
 
 /// Validates diplomatic orders for a single player in submission order.
 /// SPEC/program/orders.md § Diplomatic orders.
-class DiplomaticOrderValidator {
+class DiplomaticOrderValidator extends OrderValidator {
   final Game _game;
   final String _playerId;
 
@@ -20,27 +20,25 @@ class DiplomaticOrderValidator {
     required Game game,
     required String playerId,
     required int initialTreasury,
-  })  : _game = game,
-        _playerId = playerId,
-        _treasury = initialTreasury;
+  }) : _game = game,
+       _playerId = playerId,
+       _treasury = initialTreasury;
 
   int get treasury => _treasury;
 
-  ({OrderValidationResult result, int treasury}) _reject(String reason) => (
-        result: OrderValidationResult.rejected(reason),
-        treasury: _treasury,
-      );
+  ({OrderValidationResult result, int treasury}) _reject(String reason) =>
+      (result: OrderValidationResult.rejected(reason), treasury: _treasury);
 
-  ({OrderValidationResult result, int treasury}) _accept() => (
-        result: OrderValidationResult.accepted(),
-        treasury: _treasury,
-      );
+  ({OrderValidationResult result, int treasury}) _accept() =>
+      (result: OrderValidationResult.accepted(), treasury: _treasury);
 
   ({OrderValidationResult result, int treasury}) _acceptRecordingTarget(
     String targetId,
     DiplomaticOrderType type,
   ) {
-    _typesByTarget.putIfAbsent(targetId, () => <DiplomaticOrderType>{}).add(type);
+    _typesByTarget
+        .putIfAbsent(targetId, () => <DiplomaticOrderType>{})
+        .add(type);
     return _accept();
   }
 
@@ -62,10 +60,7 @@ class DiplomaticOrderValidator {
   /// for this player in this turn has already been rejected.
   ///
   /// Returns the [OrderValidationResult] and updated treasury.
-  ({
-    OrderValidationResult result,
-    int treasury,
-  }) validate(
+  ({OrderValidationResult result, int treasury}) validate(
     DiplomaticOrder order, {
     required bool previousRejected,
   }) {
@@ -121,18 +116,14 @@ class DiplomaticOrderValidator {
           return _reject('Alliance target must be a Great Power');
         }
         if (atWar) {
-          return _reject(
-            'Cannot form alliance while at war with that faction',
-          );
+          return _reject('Cannot form alliance while at war with that faction');
         }
         return _acceptRecordingTarget(targetId, order.type);
 
       case DiplomaticOrderType.establishOverture:
         final stage = order.overtureStage;
         if (stage == null || stage == OvertureStage.none) {
-          return _reject(
-            'Overture stage is required for establishOverture',
-          );
+          return _reject('Overture stage is required for establishOverture');
         }
         if (!isMinorOrTribe(_game, targetId) &&
             !isGreatPower(_game, targetId)) {
@@ -226,7 +217,9 @@ class DiplomaticOrderValidator {
               );
             }
           } else if (!isMinorOrTribe(_game, targetId)) {
-            return _reject('Join Empire target must be a Minor Nation, Tribe, or Great Power');
+            return _reject(
+              'Join Empire target must be a Minor Nation, Tribe, or Great Power',
+            );
           }
           final cost = joinEmpireCostForMinorOrTribe(_game, targetId);
           if (_treasury < cost) {
@@ -283,9 +276,7 @@ class DiplomaticOrderValidator {
           return _reject('Consulate or Embassy required for SetSubsidy');
         }
         if (_treasury < amount) {
-          return _reject(
-            'Insufficient treasury for SetSubsidy (need $amount)',
-          );
+          return _reject('Insufficient treasury for SetSubsidy (need $amount)');
         }
         _treasury -= amount;
         return _acceptRecordingTarget(targetId, order.type);
@@ -311,4 +302,3 @@ class DiplomaticOrderValidator {
     return false;
   }
 }
-

--- a/packages/colonizethis_logic/lib/src/orders/validators/naval_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/naval_order_validator.dart
@@ -9,7 +9,7 @@ import '../order_validation_result.dart';
 
 /// Validates naval move and naval mission orders for a single player.
 /// SPEC/program/orders.md § Naval orders; SPEC/game/capital-and-connectivity.md § Blockade.
-class NavalOrderValidator {
+class NavalOrderValidator extends OrderValidator {
   final Game _game;
   final MapTopology _topology;
   final String _playerId;

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
@@ -17,35 +17,37 @@ import 'work_order_target_prechecks.dart';
 /// Validates work orders for a single player in submission order.
 /// Mutates internal economy state (stockpile, treasury) and [devExclusiveTiles]
 /// when an order is accepted. SPEC/program/orders.md § Work orders.
-class WorkOrderValidator {
-  final Game _game;
-  final Player _player;
-  final String _playerId;
-  final PlayerView _view;
-  final Map<String, Unit> _unitsById;
-  final Set<String> _devExclusiveTiles;
-  final Map<String, TileMapResult>? _tileMapByRegion;
+class WorkOrderValidationContext {
+  const WorkOrderValidationContext({
+    required this.game,
+    required this.player,
+    required this.playerId,
+    required this.view,
+    required this.unitsById,
+    required this.devExclusiveTiles,
+    this.tileMapByRegion,
+  });
+
+  final Game game;
+  final Player player;
+  final String playerId;
+  final PlayerView view;
+  final Map<String, Unit> unitsById;
+  final Set<String> devExclusiveTiles;
+  final Map<String, TileMapResult>? tileMapByRegion;
+}
+
+class WorkOrderValidator extends OrderValidator {
+  final WorkOrderValidationContext _context;
 
   Stockpile _stockpile;
   int _treasury;
 
   WorkOrderValidator({
-    required Game game,
-    required Player player,
-    required String playerId,
-    required PlayerView view,
-    required Map<String, Unit> unitsById,
-    required Set<String> devExclusiveTiles,
+    required WorkOrderValidationContext context,
     required Stockpile stockpile,
     required int treasury,
-    Map<String, TileMapResult>? tileMapByRegion,
-  }) : _game = game,
-       _player = player,
-       _playerId = playerId,
-       _view = view,
-       _unitsById = unitsById,
-       _devExclusiveTiles = devExclusiveTiles,
-       _tileMapByRegion = tileMapByRegion,
+  }) : _context = context,
        _stockpile = stockpile,
        _treasury = treasury;
 
@@ -62,8 +64,8 @@ class WorkOrderValidator {
     return shortCircuitIfPreviousRejected(
       previousRejected: previousRejected,
       body: () {
-        final unit = _unitsById[o.unitId];
-        if (unit == null || unit.ownerId != _playerId) {
+        final unit = _context.unitsById[o.unitId];
+        if (unit == null || unit.ownerId != _context.playerId) {
           return OrderValidationResult.rejected('Unit not found');
         }
         if (unit.currentWork != null) {
@@ -85,14 +87,14 @@ class WorkOrderValidator {
 
         final targetProvinceId = Unit.provinceIdFromTileKey(o.targetTileKey);
         final province = targetProvinceId != null
-            ? tryGetProvince(_game.worldState, targetProvinceId)
+            ? tryGetProvince(_context.game.worldState, targetProvinceId)
             : null;
         final ownerId = province?.ownerId;
 
         final preCtx = WorkOrderTargetPrecheckContext(
-          game: _game,
-          player: _player,
-          playerId: _playerId,
+          game: _context.game,
+          player: _context.player,
+          playerId: _context.playerId,
           treasury: _treasury,
           civilianEmbassyWorkAllowed: _civilianWorkAllowedInMinorTribeProvince,
         );
@@ -112,8 +114,8 @@ class WorkOrderValidator {
               o.target,
             )) {
           final controlled = isTileControlledByPlayer(
-            _game,
-            _playerId,
+            _context.game,
+            _context.playerId,
             o.targetTileKey,
           );
           final embassyWork = _civilianWorkAllowedInMinorTribeProvince(
@@ -129,7 +131,7 @@ class WorkOrderValidator {
 
         if (isDevExclusiveUnitType(type) &&
             isDevExclusiveWorkTarget(o.target) &&
-            _devExclusiveTiles.contains(o.targetTileKey)) {
+            _context.devExclusiveTiles.contains(o.targetTileKey)) {
           return OrderValidationResult.rejected(
             'Tile already has development or purchase work for this player',
           );
@@ -139,15 +141,17 @@ class WorkOrderValidator {
             o.target != kWorkTargetCounterSpy &&
             o.target != kWorkTargetPurchaseLand) {
           final improvementLevel = o.target == kWorkTargetBuildImprovement
-              ? _game.worldState.tileState.improvementLevel(o.targetTileKey)
+              ? _context.game.worldState.tileState.improvementLevel(
+                  o.targetTileKey,
+                )
               : 0;
           final fortLevel = province?.fortLevel ?? 0;
-          final roadLevel = _game.worldState.tileState.roadLevel(
+          final roadLevel = _context.game.worldState.tileState.roadLevel(
             o.targetTileKey,
           );
           if (o.target == kWorkTargetBuildRoad && roadLevel >= 1) {
             final hasRoadConstruction =
-                _player.techUnlocked?['road_construction'] == true;
+                _context.player.techUnlocked?['road_construction'] == true;
             if (!hasRoadConstruction) {
               return OrderValidationResult.rejected(
                 'Road Construction tech required for transport level 2',
@@ -156,13 +160,13 @@ class WorkOrderValidator {
           }
           if (o.target == kWorkTargetBuildFort) {
             if (fortLevel == 1 &&
-                _player.techUnlocked?['mine_engineering'] != true) {
+                _context.player.techUnlocked?['mine_engineering'] != true) {
               return OrderValidationResult.rejected(
                 'Mine Engineering tech required for fort level 2',
               );
             }
             if (fortLevel == 2 &&
-                _player.techUnlocked?['modern_forts'] != true) {
+                _context.player.techUnlocked?['modern_forts'] != true) {
               return OrderValidationResult.rejected(
                 'Modern Forts tech required for fort level 3',
               );
@@ -170,11 +174,11 @@ class WorkOrderValidator {
           }
           if (o.target == 'build_rail') {
             final terrain = terrainTypeForTileKey(
-              _tileMapByRegion,
+              _context.tileMapByRegion,
               o.targetTileKey,
             );
             final reason = rejectionReasonForBuildRailOrder(
-              techUnlocked: _player.techUnlocked,
+              techUnlocked: _context.player.techUnlocked,
               roadLevel: roadLevel,
               terrain: terrain,
             );
@@ -182,7 +186,7 @@ class WorkOrderValidator {
               return OrderValidationResult.rejected(reason);
             }
           }
-          final costMap = WorkOrderCostCalculator(_game).calculateCost(
+          final costMap = WorkOrderCostCalculator(_context.game).calculateCost(
             o.target,
             o.targetTileKey,
             improvementLevel: improvementLevel,
@@ -200,7 +204,12 @@ class WorkOrderValidator {
           }
         }
 
-        if (!workOrderVisibilityOk(_view, unit, o.target, o.targetTileKey)) {
+        if (!workOrderVisibilityOk(
+          _context.view,
+          unit,
+          o.target,
+          o.targetTileKey,
+        )) {
           return OrderValidationResult.rejected(
             'Province or tile not visible for this work',
           );
@@ -208,8 +217,8 @@ class WorkOrderValidator {
 
         if (o.target == kWorkTargetProspect) {
           if (!isMineralEligibleTile(
-            _game,
-            _tileMapByRegion,
+            _context.game,
+            _context.tileMapByRegion,
             o.targetTileKey,
           )) {
             return OrderValidationResult.rejected(
@@ -217,7 +226,8 @@ class WorkOrderValidator {
             );
           }
           final prospected =
-              _game.worldState.playerProspectedTiles[_playerId] ??
+              _context.game.worldState.playerProspectedTiles[_context
+                  .playerId] ??
               const <String>{};
           if (prospected.contains(o.targetTileKey)) {
             return OrderValidationResult.rejected('Tile already prospected');
@@ -226,13 +236,13 @@ class WorkOrderValidator {
 
         if (isDevExclusiveUnitType(type) &&
             isDevExclusiveWorkTarget(o.target)) {
-          _devExclusiveTiles.add(o.targetTileKey);
+          _context.devExclusiveTiles.add(o.targetTileKey);
         }
 
         // Apply projected cost so subsequent work orders see updated state.
         if (o.target == kWorkTargetPurchaseLand) {
           final resourceId =
-              _game.worldState.resourceByTileKey[o.targetTileKey];
+              _context.game.worldState.resourceByTileKey[o.targetTileKey];
           if (resourceId != null && resourceId.isNotEmpty) {
             final cost = purchaseLandCost(resourceId);
             _treasury -= cost;
@@ -240,9 +250,11 @@ class WorkOrderValidator {
         } else if (o.target != kWorkTargetStealTech &&
             o.target != kWorkTargetCounterSpy) {
           final improvementLevel = o.target == kWorkTargetBuildImprovement
-              ? _game.worldState.tileState.improvementLevel(o.targetTileKey)
+              ? _context.game.worldState.tileState.improvementLevel(
+                  o.targetTileKey,
+                )
               : 0;
-          final costMap = WorkOrderCostCalculator(_game).calculateCost(
+          final costMap = WorkOrderCostCalculator(_context.game).calculateCost(
             o.target,
             o.targetTileKey,
             improvementLevel: improvementLevel,
@@ -266,7 +278,7 @@ class WorkOrderValidator {
     String unitType,
     String? provinceOwnerId,
   ) {
-    if (provinceOwnerId == null || provinceOwnerId == _playerId) {
+    if (provinceOwnerId == null || provinceOwnerId == _context.playerId) {
       return false;
     }
     if (unitType != 'Builder' &&
@@ -274,11 +286,15 @@ class WorkOrderValidator {
         unitType != 'Merchant') {
       return false;
     }
-    if (!isMinorOrTribe(_game, provinceOwnerId)) return false;
-    final rel = getRelation(_game, _playerId, provinceOwnerId);
+    if (!isMinorOrTribe(_context.game, provinceOwnerId)) return false;
+    final rel = getRelation(_context.game, _context.playerId, provinceOwnerId);
     if (rel?.atWar == true) return false;
-    final overture = getOverture(_game, _playerId, provinceOwnerId);
+    final overture = getOverture(
+      _context.game,
+      _context.playerId,
+      provinceOwnerId,
+    );
     if (overture == null || !overture.hasEmbassy) return false;
-    return _player.techUnlocked?[kTechIdDiplomaticExpertise] == true;
+    return _context.player.techUnlocked?[kTechIdDiplomaticExpertise] == true;
   }
 }

--- a/packages/colonizethis_logic/lib/src/world/province_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/world/province_lookup.dart
@@ -10,12 +10,17 @@ RegionData? _regionForId(WorldState world, String regionId) {
 }
 
 Province? _findProvinceInRegion(
-    RegionData region, String regionId, String localId) {
+  RegionData region,
+  String regionId,
+  String localId,
+) {
   final fullId = ProvinceId.full(regionId, localId);
-  final idx = region.provinces.indexWhere((p) =>
-      p.id == fullId ||
-      (p.regionId == regionId &&
-          (p.id == localId || ProvinceId.localIdFrom(p.id) == localId)));
+  final idx = region.provinces.indexWhere(
+    (p) =>
+        p.id == fullId ||
+        (p.regionId == regionId &&
+            (p.id == localId || ProvinceId.localIdFrom(p.id) == localId)),
+  );
   if (idx < 0) return null;
   return region.provinces[idx];
 }
@@ -45,31 +50,46 @@ Iterable<Province> allProvinces(WorldState world) sync* {
 String resolveToFullProvinceId(WorldState world, String provinceId) {
   if (ProvinceId.isPrefixed(provinceId)) return provinceId;
   throw StateError(
-      'Province id must be prefixed (regionId|localId); short id not allowed: $provinceId');
+    'Province id must be prefixed (regionId|localId); short id not allowed: $provinceId',
+  );
 }
 
 /// Returns [provinceId] if already prefixed, otherwise [ProvinceId.full](regionId, provinceId).
 /// Use when keying or looking up by an id that may be local or full (e.g. player view).
 String toFullProvinceId(String regionId, String provinceId) {
-  return ProvinceId.isPrefixed(provinceId) ? provinceId : ProvinceId.full(regionId, provinceId);
+  return ProvinceId.isPrefixed(provinceId)
+      ? provinceId
+      : ProvinceId.full(regionId, provinceId);
 }
 
 /// Region-scoped lookup: returns the province in [regionId] with local id [localId]. Looks only in that region.
 /// Throws [StateError] if the region is unknown or the province is not found.
-Province getProvinceByRegion(WorldState world, String regionId, String localId) {
+Province getProvinceByRegion(
+  WorldState world,
+  String regionId,
+  String localId,
+) {
   final region = _regionForId(world, regionId);
   if (region == null) {
-    throw StateError('Unknown region "$regionId" for province $regionId|$localId');
+    throw StateError(
+      'Unknown region "$regionId" for province $regionId|$localId',
+    );
   }
   final p = _findProvinceInRegion(region, regionId, localId);
   if (p == null) {
-    throw StateError('Province not found: $regionId|$localId in region "$regionId"');
+    throw StateError(
+      'Province not found: $regionId|$localId in region "$regionId"',
+    );
   }
   return p;
 }
 
 /// Optional region-scoped lookup: province in [regionId] with local id [localId], or null.
-Province? tryGetProvinceByRegion(WorldState world, String regionId, String localId) {
+Province? tryGetProvinceByRegion(
+  WorldState world,
+  String regionId,
+  String localId,
+) {
   final region = _regionForId(world, regionId);
   if (region == null) return null;
   return _findProvinceInRegion(region, regionId, localId);
@@ -79,12 +99,79 @@ Province? tryGetProvinceByRegion(WorldState world, String regionId, String local
 /// resolution is region-scoped. Throws [StateError] if id is not prefixed or province is not found.
 Province getProvince(WorldState world, String fullProvinceId) {
   final resolved = resolveToFullProvinceId(world, fullProvinceId);
-  return getProvinceByRegion(world, ProvinceId.regionIdFrom(resolved), ProvinceId.localIdFrom(resolved));
+  return getProvinceByRegion(
+    world,
+    ProvinceId.regionIdFrom(resolved),
+    ProvinceId.localIdFrom(resolved),
+  );
 }
 
 /// Optional lookup by full id. Requires prefixed id; non-prefixed returns null. Region-scoped.
 Province? tryGetProvince(WorldState world, String fullProvinceId) {
   if (!ProvinceId.isPrefixed(fullProvinceId)) return null;
   return tryGetProvinceByRegion(
-      world, ProvinceId.regionIdFrom(fullProvinceId), ProvinceId.localIdFrom(fullProvinceId));
+    world,
+    ProvinceId.regionIdFrom(fullProvinceId),
+    ProvinceId.localIdFrom(fullProvinceId),
+  );
+}
+
+/// Province lookup helpers on [WorldState] to avoid repeatedly passing the world state.
+extension WorldStateProvinceLookup on WorldState {
+  RegionData? regionDataForId(String regionId) => _regionForId(this, regionId);
+
+  Iterable<Province> allProvinces() sync* {
+    yield* oldWorld.provinces;
+    yield* newWorld.provinces;
+  }
+
+  String resolveToFullProvinceId(String provinceId) =>
+      ProvinceId.isPrefixed(provinceId)
+      ? provinceId
+      : (throw StateError(
+          'Province id must be prefixed (regionId|localId); short id not allowed: $provinceId',
+        ));
+
+  String toFullProvinceId(String regionId, String provinceId) =>
+      ProvinceId.isPrefixed(provinceId)
+      ? provinceId
+      : ProvinceId.full(regionId, provinceId);
+
+  Province getProvinceByRegion(String regionId, String localId) {
+    final region = _regionForId(this, regionId);
+    if (region == null) {
+      throw StateError(
+        'Unknown region "$regionId" for province $regionId|$localId',
+      );
+    }
+    final p = _findProvinceInRegion(region, regionId, localId);
+    if (p == null) {
+      throw StateError(
+        'Province not found: $regionId|$localId in region "$regionId"',
+      );
+    }
+    return p;
+  }
+
+  Province? tryGetProvinceByRegion(String regionId, String localId) {
+    final region = _regionForId(this, regionId);
+    if (region == null) return null;
+    return _findProvinceInRegion(region, regionId, localId);
+  }
+
+  Province getProvince(String fullProvinceId) {
+    final resolved = resolveToFullProvinceId(fullProvinceId);
+    return getProvinceByRegion(
+      ProvinceId.regionIdFrom(resolved),
+      ProvinceId.localIdFrom(resolved),
+    );
+  }
+
+  Province? tryGetProvince(String fullProvinceId) {
+    if (!ProvinceId.isPrefixed(fullProvinceId)) return null;
+    return tryGetProvinceByRegion(
+      ProvinceId.regionIdFrom(fullProvinceId),
+      ProvinceId.localIdFrom(fullProvinceId),
+    );
+  }
 }

--- a/packages/colonizethis_models/lib/src/events/dialogue_event_bus.dart
+++ b/packages/colonizethis_models/lib/src/events/dialogue_event_bus.dart
@@ -2,6 +2,12 @@ import 'dart:async';
 
 import '../ai_events.dart';
 
+extension _DialogueEventStreamWhereType on Stream<DialogueEvent> {
+  Stream<T> whereType<T extends DialogueEvent>() {
+    return where((event) => event is T).map((event) => event as T);
+  }
+}
+
 abstract class DialogueEventBus {
   void publish(DialogueEvent event);
 
@@ -24,10 +30,7 @@ class DefaultDialogueEventBus implements DialogueEventBus {
   @override
   void Function() subscribe<T extends DialogueEvent>(void Function(T) handler) {
     late final StreamSubscription<DialogueEvent> sub;
-    sub = _controller.stream
-        .where((e) => e is T)
-        .map((e) => e as T)
-        .listen(handler);
+    sub = _controller.stream.whereType<T>().listen(handler);
     return () => sub.cancel();
   }
 


### PR DESCRIPTION
## Summary
- derive ctterm shipyard and production display/recipe data from canonical catalogs instead of duplicated hardcoded tables
- add shared validator/subscription abstractions (`OrderValidator`, `WorkOrderValidationContext`, `SubscriptionTracker`) and adopt them in order validators and app event listeners
- remove redundant event-bus cast chains and reduce intermediate allocation patterns in diplomatic order suggestion flow; add `WorldStateProvinceLookup` extension methods

## Scope
- Implements a substantial remaining slice for #1555 across items 2, 7, 8, 9, 11, 12, 13, and 14.
- Deferred from umbrella issue #1555: additional magic-string migration and any remaining cross-package cleanup not touched in this slice.

## Test plan
- [x] `dart test test/orders/validators/naval_order_validator_test.dart test/orders/validators/work_order_target_prechecks_test.dart test/event_bus/game_event_bus_test.dart test/order_suggestion_core_part2_test.dart` (in `packages/colonizethis_logic`)
- [x] `flutter test test/panel_screens_test.dart` (in `ctterm`)
- [ ] `flutter test test/game_map_area_region_minimap_test.dart test/game_region_minimap_widget_test.dart` (in `app`) currently blocked by pre-existing localization compile errors in `province_*` l10n keys, unrelated to this branch

Refs #1555

Made with [Cursor](https://cursor.com)