### PR TITLE
fix(map): enforce single-pass fog in render passes

### DIFF
--- a/app/lib/features/game/flame/region_map_component_render_mixin.dart
+++ b/app/lib/features/game/flame/region_map_component_render_mixin.dart
@@ -617,8 +617,11 @@ extension _CtRegionMapRenderExtension on CtRegionMapComponent {
     final srcRect = tile.boundingBox;
     final dstRect = Rect.fromLTWH(left, top, cellSize, cellSize);
     final paint = Paint();
-    if (visibilityMode == CtMapVisibilityMode.playerConstrained &&
-        cell.visibility == TileVisibility.fogged) {
+    if (shouldApplyFogToLandBase(
+      visibilityMode: visibilityMode,
+      tileVisibility: cell.visibility,
+      terrain: terrain,
+    )) {
       paint.colorFilter = ColorFilter.mode(
         Color.fromRGBO(0, 0, 0, _fogOverlayOpacity),
         BlendMode.darken,
@@ -656,8 +659,11 @@ extension _CtRegionMapRenderExtension on CtRegionMapComponent {
     }
 
     final paint = Paint();
-    if (visibilityMode == CtMapVisibilityMode.playerConstrained &&
-        cell.visibility == TileVisibility.fogged) {
+    if (shouldApplyFogToFeatureOverlay(
+      visibilityMode: visibilityMode,
+      tileVisibility: cell.visibility,
+      terrain: terrain,
+    )) {
       paint.colorFilter = ColorFilter.mode(
         Color.fromRGBO(0, 0, 0, _fogOverlayOpacity),
         BlendMode.darken,

--- a/app/lib/features/game/flame/region_map_component_shared.dart
+++ b/app/lib/features/game/flame/region_map_component_shared.dart
@@ -133,6 +133,27 @@ bool shouldApplyFogToLandBase({
   return !_isFeatureTerrain(terrain);
 }
 
+/// Returns true when the feature-overlay pass should apply fog darkening.
+///
+/// Feature terrain should receive fog attenuation in the overlay pass only, so
+/// fogged feature cells do not get darkened twice across base + overlay.
+bool shouldApplyFogToFeatureOverlay({
+  required CtMapVisibilityMode visibilityMode,
+  required TileVisibility tileVisibility,
+  required TerrainType? terrain,
+}) {
+  if (visibilityMode != CtMapVisibilityMode.playerConstrained) {
+    return false;
+  }
+  if (tileVisibility != TileVisibility.fogged) {
+    return false;
+  }
+  if (terrain == null) {
+    return false;
+  }
+  return _isFeatureTerrain(terrain);
+}
+
 /// Check if a terrain type uses L2+ standalone tile rendering (features).
 /// L0: Sea (Wang). L1: Plains/Desert (Wang). L2+: Features (standalone).
 bool _isFeatureTerrain(TerrainType terrain) {

--- a/app/test/ct_region_map_widget_test.dart
+++ b/app/test/ct_region_map_widget_test.dart
@@ -12,6 +12,7 @@ import 'package:colonizethis_app/features/game/flame/resource_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
     show
         resolveProvinceLabelPresenceIconIds,
+        shouldApplyFogToFeatureOverlay,
         shouldApplyFogToLandBase,
         shouldWrapProvinceLabelPresenceIcons;
 import 'package:colonizethis_app/features/game/flame/civilian_icon_cache.dart';
@@ -70,6 +71,15 @@ void main() {
           reason: 'Fogged feature tiles darken in overlay pass only',
         );
         expect(
+          shouldApplyFogToFeatureOverlay(
+            visibilityMode: CtMapVisibilityMode.playerConstrained,
+            tileVisibility: TileVisibility.fogged,
+            terrain: TerrainType.swamp,
+          ),
+          isTrue,
+          reason: 'Fogged feature tiles should darken in overlay pass',
+        );
+        expect(
           shouldApplyFogToLandBase(
             visibilityMode: CtMapVisibilityMode.playerConstrained,
             tileVisibility: TileVisibility.fogged,
@@ -78,10 +88,36 @@ void main() {
           isFalse,
         );
         expect(
+          shouldApplyFogToFeatureOverlay(
+            visibilityMode: CtMapVisibilityMode.playerConstrained,
+            tileVisibility: TileVisibility.fogged,
+            terrain: TerrainType.forest,
+          ),
+          isTrue,
+        );
+        expect(
+          shouldApplyFogToFeatureOverlay(
+            visibilityMode: CtMapVisibilityMode.playerConstrained,
+            tileVisibility: TileVisibility.fogged,
+            terrain: TerrainType.plains,
+          ),
+          isFalse,
+          reason: 'Fogged non-feature tiles darken in land-base pass only',
+        );
+        expect(
           shouldApplyFogToLandBase(
             visibilityMode: CtMapVisibilityMode.full,
             tileVisibility: TileVisibility.fogged,
             terrain: TerrainType.plains,
+          ),
+          isFalse,
+          reason: 'Full visibility mode must not apply fog',
+        );
+        expect(
+          shouldApplyFogToFeatureOverlay(
+            visibilityMode: CtMapVisibilityMode.full,
+            tileVisibility: TileVisibility.fogged,
+            terrain: TerrainType.swamp,
           ),
           isFalse,
           reason: 'Full visibility mode must not apply fog',


### PR DESCRIPTION
## Summary
- wire fog darkening in `CtRegionMapComponent` through explicit pass guards so fogged feature terrain is darkened in exactly one pass
- add a feature-overlay fog helper and keep terrain-class fog routing centralized in shared map logic
- extend map widget fog regression assertions to verify complementary base-vs-feature fog behavior in player-constrained mode

## Spec alignment
- aligns with `SPEC/ui/layered-terrain-rendering.md` acceptance criterion requiring single-pass fog attenuation for fogged feature cells

## Test plan
- [x] `flutter test test/ct_region_map_widget_test.dart --plain-name "land-base fog application skips feature terrains to prevent double darkening"` (run from `app/`)
- [x] `flutter test test/ct_region_map_widget_test.dart --plain-name "resource icons are fogged in player-constrained visibility mode for fogged tiles"` (run from `app/`)

Refs #1586

Made with [Cursor](https://cursor.com)