### PR TITLE
fix(app): paint L1 plains resource terrain variants (Refs #1584)

### DIFF
--- a/app/lib/features/game/flame/region_map_component_render_mixin.dart
+++ b/app/lib/features/game/flame/region_map_component_render_mixin.dart
@@ -596,6 +596,39 @@ extension _CtRegionMapRenderExtension on CtRegionMapComponent {
       return;
     }
 
+    if (terrain == TerrainType.plains) {
+      final plainsVariantKey = landInteriorPlainsVariantTileKey(cell);
+      if (plainsVariantKey != null) {
+        final standaloneTile =
+            terrainTilesetCache.getStandaloneTileByKey(plainsVariantKey);
+        if (standaloneTile == null) {
+          throw StateError(
+            'Missing required plains terrain variant tile: $plainsVariantKey',
+          );
+        }
+        final dstRect = Rect.fromLTWH(left, top, cellSize, cellSize);
+        final paint = Paint();
+        if (shouldApplyFogToLandBase(
+          visibilityMode: visibilityMode,
+          tileVisibility: cell.visibility,
+          terrain: terrain,
+        )) {
+          paint.colorFilter = ColorFilter.mode(
+            Color.fromRGBO(0, 0, 0, _fogOverlayOpacity),
+            BlendMode.darken,
+          );
+        }
+        final srcRect = Rect.fromLTWH(
+          0,
+          0,
+          standaloneTile.image.width.toDouble(),
+          standaloneTile.image.height.toDouble(),
+        );
+        canvas.drawImageRect(standaloneTile.image, srcRect, dstRect, paint);
+        return;
+      }
+    }
+
     final interiorTileset = terrain == TerrainType.desert
         ? terrainTilesetCache.getSeaDesertTileset()
         : terrainTilesetCache.getSeaPlainsTileset();

--- a/app/lib/features/game/flame/terrain_tileset.dart
+++ b/app/lib/features/game/flame/terrain_tileset.dart
@@ -5,6 +5,7 @@ import 'dart:ui' as ui;
 import 'package:colonizethis_app/config/map_terrain_config.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_map/colonizethis_map.dart' show CellViewData;
 import 'package:flutter/services.dart';
 
 final _log = gameLogger();
@@ -167,6 +168,18 @@ String? terrainVariantTileKey({
   }
 }
 
+/// L1 interior plains cells only: standalone tile key when a resource variant
+/// applies. Caller must not use this on plains↔desert transition cells (Wang).
+/// Returns null when the canonical plains Wang base should be drawn.
+String? landInteriorPlainsVariantTileKey(CellViewData cell) {
+  if (cell.terrainType != TerrainType.plains) return null;
+  return terrainVariantTileKey(
+    terrain: TerrainType.plains,
+    resourceId: cell.resourceId,
+    improvementLevel: cell.improvementLevel,
+  );
+}
+
 String featureOverlayTileKey({
   required TerrainType terrain,
   String? resourceId,
@@ -270,9 +283,18 @@ class TerrainTilesetCache {
       }
 
       _isLoaded = true;
-    } catch (e) {
-      _log.e('One or more terrain tilesets failed to load', error: e);
+    } catch (e, stackTrace) {
+      _log.e(
+        'One or more terrain tilesets failed to load',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      _seaPlainsTileset = null;
+      _seaDesertTileset = null;
+      _plainsDesertTileset = null;
+      _standaloneTiles.clear();
       _isLoaded = false;
+      rethrow;
     } finally {
       _isLoading = false;
     }

--- a/app/test/features/game/flame/terrain_tileset_test.dart
+++ b/app/test/features/game/flame/terrain_tileset_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/features/game/flame/terrain_tileset.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_map/colonizethis_map.dart' show CellViewData;
 
 void main() {
   suppressLogsForTests();
@@ -165,6 +166,65 @@ void main() {
         terrainVariantTileKey(
           terrain: TerrainType.desert,
           resourceId: 'diamonds',
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('landInteriorPlainsVariantTileKey', () {
+    CellViewData landPlains({
+      String? resourceId,
+      TerrainType? terrainType,
+    }) =>
+        CellViewData(
+          x: 0,
+          y: 0,
+          regionCellId: 'p0',
+          isSea: false,
+          terrainType: terrainType ?? TerrainType.plains,
+          resourceId: resourceId,
+        );
+
+    test('returns variant keys only for plains with grain, meat, horses', () {
+      expect(
+        landInteriorPlainsVariantTileKey(landPlains(resourceId: 'grain')),
+        'tile_plains_grain',
+      );
+      expect(
+        landInteriorPlainsVariantTileKey(landPlains(resourceId: 'meat')),
+        'tile_plains_meat',
+      );
+      expect(
+        landInteriorPlainsVariantTileKey(landPlains(resourceId: 'horses')),
+        'tile_plains_horses',
+      );
+    });
+
+    test('returns null for plains without mapped resource', () {
+      expect(
+        landInteriorPlainsVariantTileKey(landPlains(resourceId: 'sugarCane')),
+        isNull,
+      );
+      expect(landInteriorPlainsVariantTileKey(landPlains()), isNull);
+    });
+
+    test('returns null for desert even if resource would map on plains', () {
+      expect(
+        landInteriorPlainsVariantTileKey(
+          landPlains(
+            terrainType: TerrainType.desert,
+            resourceId: 'grain',
+          ),
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null for feature terrain with grain (not L1 plains)', () {
+      expect(
+        landInteriorPlainsVariantTileKey(
+          landPlains(terrainType: TerrainType.forest, resourceId: 'grain'),
         ),
         isNull,
       );
@@ -340,15 +400,14 @@ void main() {
     });
 
     test(
-      'load() sets isLoaded to false when standalone tile fails to load (no silent fallback)',
+      'fresh cache load() completes and exposes required plains standalone tiles',
       () async {
         final cache = TerrainTilesetCache();
         await cache.load();
-        // After load, isLoaded reflects whether all assets loaded successfully.
-        // If any standalone tile failed to load, isLoaded will be false.
-        // Note: The global terrainTilesetCache uses real asset paths, so this
-        // test verifies the behavior when loading fails - the cache does NOT
-        // silently swallow errors but propagates them, resulting in isLoaded=false.
+        expect(cache.isLoaded, isTrue);
+        expect(cache.getStandaloneTileByKey('tile_plains_grain'), isNotNull);
+        expect(cache.getStandaloneTileByKey('tile_plains_meat'), isNotNull);
+        expect(cache.getStandaloneTileByKey('tile_plains_horses'), isNotNull);
       },
     );
   });


### PR DESCRIPTION
## Summary
Completes the missing L1 render wiring for issue #1584: interior `TerrainType.plains` cells with `grain` / `meat` / `horses` now draw the corresponding standalone terrain art on the land-base pass (after plains↔desert Wang branches). Plains↔desert transition cells keep Wang-only rendering.

`TerrainTilesetCache.load()` now rethrows after logging and clears partial state so missing required terrain assets surface as load failures instead of leaving `isLoaded == false` with a completed Future.

## SPEC
No doc change: behavior already specified in `SPEC/ui/layered-terrain-rendering.md` and `SPEC/ui/map-widget.md`.

## Tests
- Extended `terrain_tileset_test.dart`: `landInteriorPlainsVariantTileKey` coverage; fresh-cache load asserts required plains standalones.
- Commands: `flutter test test/features/game/flame/terrain_tileset_test.dart test/ct_region_map_widget_test.dart test/region_map_zoom_fit_test.dart`

Refs #1584

Made with [Cursor](https://cursor.com)