### PR TITLE
fix(map): interior plains base under transparent tile_plains_* variants

### DIFF
--- a/SPEC/ui/layered-terrain-rendering.md
+++ b/SPEC/ui/layered-terrain-rendering.md
@@ -35,11 +35,12 @@ The map renderer draws terrain in **three passes**:
 - **Tilesets**:
   - `plains_desert` — Wang tileset with plains (lower) and desert (upper)
 - **Mechanism**: When a cell is desert, it clips the plains layer, and desert is drawn instead. The plains↔desert transition is handled by the `plains_desert` Wang tileset.
-- **Plains resource variants (L1)**: For plains cells only, terrain variant keys may override the default plains base art:
+- **Plains resource variants (L1)**: For **interior** plains cells only, the renderer selects standalone overlay assets with **RGBA transparency** (transparent “background” around the resource-specific art):
   - `resourceId = grain` → `tile_plains_grain`
   - `resourceId = meat` → `tile_plains_meat`
   - `resourceId = horses` → `tile_plains_horses`
-  - Any other `resourceId` (or null) keeps the canonical plains base tile.
+  - **Draw order:** L1 **first** draws the **same canonical interior plains** Wang upper-base tile used for a non-resource interior plains cell (`sea_plains` atlas), **then** draws the selected `tile_plains_*` image with normal alpha blending (`srcOver`). Transparent pixels in the overlay must reveal that plains base—not the empty canvas (which would read as black).
+  - Any other `resourceId` (or null) keeps a single draw of the canonical plains base tile (no overlay variant).
   - Desert never uses these plains variant keys.
 
 ### Layer 2+: Terrain Features (Overlay)
@@ -210,6 +211,8 @@ The **logic** (which tileset applies per corner pattern) is fixed by terrain typ
 - Given a plains tile with `resourceId = grain`, when rendering L1, then the renderer selects `tile_plains_grain` for that tile.
 - Given a plains tile with `resourceId = meat`, when rendering L1, then the renderer selects `tile_plains_meat` for that tile.
 - Given a plains tile with `resourceId = horses`, when rendering L1, then the renderer selects `tile_plains_horses` for that tile.
+- Given an **interior** plains cell with `resourceId` in `{grain, meat, horses}`, when rendering L1, then the renderer draws the canonical interior plains base, then the corresponding `tile_plains_*` overlay so transparent overlay pixels show plains grass (not an empty/black canvas).
+- Given an **interior** plains cell with `resourceId` in `{grain, meat, horses}` and player-constrained **fogged** visibility, when rendering L1 completes, then fog attenuation for that cell matches other interior plains land-base tiles (no unintended double-darkening from separate base vs overlay passes).
 - Given a plains tile with `resourceId` not in `{grain, meat, horses}` (or null), when rendering L1, then the renderer keeps the canonical plains base tile.
 - Given a desert tile with any `resourceId`, when rendering L1, then the renderer does not select any plains resource variant tile key.
 - Given a forest tile with `resourceId = timber`, when rendering L2+, then the renderer selects `tile_forest_timber`; otherwise for forest it selects `tile_forest`.

--- a/SPEC/ui/map-widget.md
+++ b/SPEC/ui/map-widget.md
@@ -316,12 +316,14 @@ Hover, selection, and overlay behavior:
 
 The map widget renders terrain using **Wang tilesets** for seamless terrain transitions. Each tileset is a 4×4 grid (16 tiles) that covers all corner combinations for transitions between two terrain types.
 
-For L1 plains cells, the renderer may apply resource-specific plains terrain variants selected by terrain/resource id:
+For L1 **interior** plains cells, the renderer may apply resource-specific plains terrain variants selected by terrain/resource id. Assets `tile_plains_grain`, `tile_plains_meat`, and `tile_plains_horses` use **transparent regions** around the drawn resource detail; the renderer **must** draw the **canonical interior plains** base (same `sea_plains` upper-base tile as non-resource interior plains) **before** compositing the variant PNG so transparency shows grass, not the blank canvas.
+
+Variant keys:
 - `tile_plains_grain` for `resourceId = grain`
 - `tile_plains_meat` for `resourceId = meat`
 - `tile_plains_horses` for `resourceId = horses`
 
-These variants apply only to plains cells and do not alter desert rendering rules.
+These variants apply only to plains cells (not desert) and do not alter desert rendering rules.
 
 ### Runtime configuration (Flutter app)
 
@@ -398,6 +400,7 @@ Required plains resource variant assets (`tile_plains_grain.png`, `tile_plains_m
 - **Given** a tile with `terrainType = plains` and `resourceId = grain`, **when** the map renders the terrain layer, **then** it selects plains terrain variant `tile_plains_grain` for that tile.
 - **Given** a tile with `terrainType = plains` and `resourceId = meat`, **when** the map renders the terrain layer, **then** it selects plains terrain variant `tile_plains_meat` for that tile.
 - **Given** a tile with `terrainType = plains` and `resourceId = horses`, **when** the map renders the terrain layer, **then** it selects plains terrain variant `tile_plains_horses` for that tile.
+- **Given** an **interior** plains tile with `resourceId` in `{grain, meat, horses}`, **when** the map renders the L1 terrain layer, **then** it draws the canonical interior plains base and composites the selected `tile_plains_*` on top so pixels transparent in the PNG show the same plains base as neighboring non-resource plains (no spurious solid black from an undrawn background).
 - **Given** a tile with `terrainType = desert` and any `resourceId`, **when** the map renders the terrain layer, **then** it does not select a plains terrain variant.
 - **Given** terrain asset initialization and one required plains variant PNG is missing or fails decode, **when** map terrain assets are loaded, **then** initialization fails with an error instead of silently skipping that asset.
 - **Given** only a change to `map_terrain_tilesets.json` (paths, `tile_px`, and/or `map_cell_size_px`) plus matching atlas/JSON assets declared in `pubspec.yaml`, **when** the app runs, **then** the map uses the new files and cell size without Dart code edits (same loader contract).

--- a/app/lib/features/game/flame/region_map_component_render_mixin.dart
+++ b/app/lib/features/game/flame/region_map_component_render_mixin.dart
@@ -528,10 +528,67 @@ extension _CtRegionMapRenderExtension on CtRegionMapComponent {
     _paintLandBaseTile(canvas, cell);
   }
 
+  /// Wang interior upper-base tile for land: `sea_plains` for plains (and
+  /// feature terrains on plains) or `sea_desert` for desert. Used for L1 cells
+  /// and for the opaque grass under transparent `tile_plains_*` overlays.
+  void _drawLandInteriorUpperBaseForTerrain(
+    Canvas canvas, {
+    required TerrainType landTerrain,
+    required Rect dstRect,
+    required Paint paint,
+  }) {
+    final interiorTileset = landTerrain == TerrainType.desert
+        ? terrainTilesetCache.getSeaDesertTileset()
+        : terrainTilesetCache.getSeaPlainsTileset();
+    if (interiorTileset == null) {
+      throw StateError(
+        'Interior tileset is null for terrain=$landTerrain - '
+        'terrain tileset failed to load',
+      );
+    }
+    final tile = interiorTileset.upperBaseTileId != null
+        ? interiorTileset.findTileById(interiorTileset.upperBaseTileId!)
+        : null;
+    if (tile == null) {
+      throw StateError(
+        'Base tile not found for terrain=$landTerrain - '
+        'upperBaseTileId=${interiorTileset.upperBaseTileId}',
+      );
+    }
+    canvas.drawImageRect(
+      interiorTileset.image,
+      tile.boundingBox,
+      dstRect,
+      paint,
+    );
+  }
+
+  Paint _landBaseImagePaint({
+    required TerrainType terrain,
+    required TileVisibility tileVisibility,
+  }) {
+    final paint = Paint();
+    if (shouldApplyFogToLandBase(
+      visibilityMode: visibilityMode,
+      tileVisibility: tileVisibility,
+      terrain: terrain,
+    )) {
+      paint.colorFilter = ColorFilter.mode(
+        Color.fromRGBO(0, 0, 0, _fogOverlayOpacity),
+        BlendMode.darken,
+      );
+    }
+    return paint;
+  }
+
   void _paintLandBaseTile(Canvas canvas, CellViewData cell) {
     final left = cell.x * cellSize;
     final top = cell.y * cellSize;
-    final terrain = cell.terrainType;
+    final terrainNullable = cell.terrainType;
+    if (terrainNullable == null) {
+      throw StateError('Cell has no terrain type: $cell');
+    }
+    final terrain = terrainNullable;
 
     final isPlains =
         terrain == TerrainType.plains ||
@@ -597,25 +654,25 @@ extension _CtRegionMapRenderExtension on CtRegionMapComponent {
     if (terrain == TerrainType.plains) {
       final plainsVariantKey = landInteriorPlainsVariantTileKey(cell);
       if (plainsVariantKey != null) {
-        final standaloneTile =
-            terrainTilesetCache.getStandaloneTileByKey(plainsVariantKey);
+        final standaloneTile = terrainTilesetCache.getStandaloneTileByKey(
+          plainsVariantKey,
+        );
         if (standaloneTile == null) {
           throw StateError(
             'Missing required plains terrain variant tile: $plainsVariantKey',
           );
         }
         final dstRect = Rect.fromLTWH(left, top, cellSize, cellSize);
-        final paint = Paint();
-        if (shouldApplyFogToLandBase(
-          visibilityMode: visibilityMode,
-          tileVisibility: cell.visibility,
+        final paint = _landBaseImagePaint(
           terrain: terrain,
-        )) {
-          paint.colorFilter = ColorFilter.mode(
-            Color.fromRGBO(0, 0, 0, _fogOverlayOpacity),
-            BlendMode.darken,
-          );
-        }
+          tileVisibility: cell.visibility,
+        );
+        _drawLandInteriorUpperBaseForTerrain(
+          canvas,
+          landTerrain: TerrainType.plains,
+          dstRect: dstRect,
+          paint: paint,
+        );
         final srcRect = Rect.fromLTWH(
           0,
           0,
@@ -627,38 +684,17 @@ extension _CtRegionMapRenderExtension on CtRegionMapComponent {
       }
     }
 
-    final interiorTileset = terrain == TerrainType.desert
-        ? terrainTilesetCache.getSeaDesertTileset()
-        : terrainTilesetCache.getSeaPlainsTileset();
-    if (interiorTileset == null) {
-      throw StateError(
-        'Interior tileset is null for terrain=$terrain - '
-        'terrain tileset failed to load',
-      );
-    }
-    final tile = interiorTileset.upperBaseTileId != null
-        ? interiorTileset.findTileById(interiorTileset.upperBaseTileId!)
-        : null;
-    if (tile == null) {
-      throw StateError(
-        'Base tile not found for terrain=$terrain - '
-        'upperBaseTileId=${interiorTileset.upperBaseTileId}',
-      );
-    }
-    final srcRect = tile.boundingBox;
     final dstRect = Rect.fromLTWH(left, top, cellSize, cellSize);
-    final paint = Paint();
-    if (shouldApplyFogToLandBase(
-      visibilityMode: visibilityMode,
-      tileVisibility: cell.visibility,
+    final paint = _landBaseImagePaint(
       terrain: terrain,
-    )) {
-      paint.colorFilter = ColorFilter.mode(
-        Color.fromRGBO(0, 0, 0, _fogOverlayOpacity),
-        BlendMode.darken,
-      );
-    }
-    canvas.drawImageRect(interiorTileset.image, srcRect, dstRect, paint);
+      tileVisibility: cell.visibility,
+    );
+    _drawLandInteriorUpperBaseForTerrain(
+      canvas,
+      landTerrain: terrain,
+      dstRect: dstRect,
+      paint: paint,
+    );
   }
 
   void _paintFeatureCell(Canvas canvas, CellViewData cell) {

--- a/app/test/plains_resource_variant_land_base_test.dart
+++ b/app/test/plains_resource_variant_land_base_test.dart
@@ -1,0 +1,114 @@
+import 'dart:ui' as ui;
+
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:colonizethis_app/features/game/flame/terrain_tileset.dart';
+
+Future<(int r, int g, int b, int a)> _pixelStraightRgba(
+  ui.Image image,
+  int x,
+  int y,
+) async {
+  final bd = await image.toByteData(format: ui.ImageByteFormat.rawStraightRgba);
+  expect(bd, isNotNull);
+  final i = (y * image.width + x) * 4;
+  return (
+    bd!.getUint8(i),
+    bd.getUint8(i + 1),
+    bd.getUint8(i + 2),
+    bd.getUint8(i + 3),
+  );
+}
+
+void main() {
+  suppressLogsForTests();
+
+  const variantKeys = [
+    'tile_plains_grain',
+    'tile_plains_meat',
+    'tile_plains_horses',
+  ];
+
+  group('L1 plains resource variants (Refs #1600)', () {
+    test(
+      'transparent overlay pixels show interior plains when base is drawn first',
+      () async {
+        final cache = TerrainTilesetCache();
+        await cache.load();
+        expect(cache.isLoaded, isTrue);
+
+        final interior = cache.getSeaPlainsTileset();
+        expect(interior, isNotNull);
+        expect(interior!.upperBaseTileId, isNotNull);
+        final baseTile = interior.findTileById(interior.upperBaseTileId!);
+        expect(baseTile, isNotNull);
+
+        for (final key in variantKeys) {
+          final overlay = cache.getStandaloneTileByKey(key);
+          expect(overlay, isNotNull, reason: 'missing $key');
+
+          Future<ui.Image> renderComposed({
+            required bool drawInteriorPlainsBase,
+          }) async {
+            const size = 64;
+            final recorder = ui.PictureRecorder();
+            final canvas = Canvas(recorder);
+            canvas.drawRect(
+              const Rect.fromLTWH(0, 0, 64, 64),
+              Paint()..color = const Color(0xFF000000),
+            );
+            if (drawInteriorPlainsBase) {
+              canvas.drawImageRect(
+                interior.image,
+                baseTile!.boundingBox,
+                const Rect.fromLTWH(0, 0, 64, 64),
+                Paint(),
+              );
+            }
+            canvas.drawImageRect(
+              overlay!.image,
+              Rect.fromLTWH(
+                0,
+                0,
+                overlay.image.width.toDouble(),
+                overlay.image.height.toDouble(),
+              ),
+              const Rect.fromLTWH(0, 0, 64, 64),
+              Paint(),
+            );
+
+            final picture = recorder.endRecording();
+            final image = await picture.toImage(size, size);
+            addTearDown(image.dispose);
+            return image;
+          }
+
+          final variantOnly = await renderComposed(
+            drawInteriorPlainsBase: false,
+          );
+          final withBase = await renderComposed(drawInteriorPlainsBase: true);
+
+          final blackCorner = await _pixelStraightRgba(variantOnly, 0, 0);
+          expect(
+            blackCorner.$1 + blackCorner.$2 + blackCorner.$3,
+            lessThan(12),
+            reason:
+                '$key: (0,0) should stay black when overlay is transparent '
+                'and no base is drawn',
+          );
+
+          final composed = await _pixelStraightRgba(withBase, 0, 0);
+          expect(
+            composed.$1 + composed.$2 + composed.$3,
+            greaterThan(40),
+            reason:
+                '$key: (0,0) should pick up interior plains when base is drawn '
+                'under transparent overlay pixels',
+          );
+        }
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Interior plains cells with `resourceId` grain, meat, or horses draw the same `sea_plains` upper-base Wang tile as other interior plains, then composite the `tile_plains_*` RGBA overlay so transparent pixels show grass instead of black canvas.

## SPEC
- `SPEC/ui/layered-terrain-rendering.md` — L1 plains resource variants: explicit **base → overlay** order and new AC (fog single-pass intent).
- `SPEC/ui/map-widget.md` — same contract + acceptance criterion.

## Tests
- `app/test/plains_resource_variant_land_base_test.dart` — pixel check at (0,0) for all three variants: variant-only on black stays dark; with interior base drawn first, composed pixel is non-black.

```
flutter test app/test/plains_resource_variant_land_base_test.dart \
  app/test/features/game/flame/terrain_tileset_test.dart
```

Refs #1600

Made with [Cursor](https://cursor.com)