### PR TITLE
Fix Linux e2e CI plugin generation (Refs #1592)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -235,6 +235,13 @@ jobs:
         if: needs.changes.outputs.tests == 'true'
         run: flutter config --enable-linux-desktop
 
+      - name: Resolve app dependencies for Linux plugin generation
+        if: needs.changes.outputs.tests == 'true'
+        run: |
+          set -euo pipefail
+          cd app
+          flutter pub get
+
       # Headless DISPLAY for integration_test (-d linux). Same idea as community xvfb wrapper actions
       # (e.g. GabrielBB/xvfb-action; pin here for a maintained installer + cleanup).
       - name: Run Linux integration tests (xvfb)


### PR DESCRIPTION
## Summary
- keep the Linux e2e direction for issue #1592 and harden `app_e2e_linux` CI setup
- run `flutter pub get` in `app/` before Linux desktop integration tests so Flutter generates Linux plugin build files (`flutter/generated_plugins.cmake`)
- preserve existing job topology (`app_tests_shard` -> `app_e2e_linux`) and keep app coverage merge parallel

## Test plan
- [x] Inspect failing `app_e2e_linux` logs from prior run and confirm root cause (`flutter/generated_plugins.cmake` missing during CMake configure)
- [ ] Let GitHub Actions run `app_e2e_linux` for this PR

Refs #1592

Made with [Cursor](https://cursor.com)