### PR TITLE
refactor(orders): align MoveValidator short-circuit handling

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -493,18 +493,6 @@ class OrderEngine {
     const _moveValidator = MoveValidator();
     const _armyMoveValidator = ArmyMoveValidator();
 
-    OrderValidationResult validateMove(MoveOrder o) {
-      return _moveValidator.validate(
-        o,
-        game,
-        playerId,
-        unitsById,
-        diplomatic,
-        view,
-        topology,
-      );
-    }
-
     OrderValidationResult validateArmyMove(ArmyMoveOrder o) {
       return _armyMoveValidator.validate(
         o,
@@ -520,7 +508,16 @@ class OrderEngine {
       results,
       moves,
       rejected,
-      (o, prev) => prev ? previousInvalidOrderResult : validateMove(o),
+      (o, prev) => _moveValidator.validate(
+        o,
+        game,
+        playerId,
+        unitsById,
+        diplomatic,
+        view,
+        topology,
+        previousRejected: prev,
+      ),
     );
 
     rejected = _appendValidationResults(

--- a/packages/colonizethis_logic/lib/src/orders/validators/move_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/move_validator.dart
@@ -11,7 +11,7 @@ import '../order_visibility.dart';
 
 /// Validates move orders. SPEC/program/orders.md § Move orders.
 /// Used by OrderEngine in validatePlayerOrdersWithContext.
-class MoveValidator {
+class MoveValidator extends OrderValidator {
   const MoveValidator();
 
   OrderValidationResult validate(
@@ -22,107 +22,113 @@ class MoveValidator {
     List<DiplomaticOrder> diplomaticOrders,
     PlayerView view,
     MapTopology topology,
+    {required bool previousRejected}
   ) {
-    final unit = unitsById[order.unitId];
-    if (unit == null || unit.ownerId != playerId) {
-      return OrderValidationResult.rejected('Invalid move');
-    }
-    if (isMilitaryUnit(unit.type)) {
-      return OrderValidationResult.rejected(
-        'Military units move with armies; use army move',
-      );
-    }
-    final unitRegion = unit.tileKey != null && unit.tileKey!.isNotEmpty
-        ? Unit.requireRegionIdFromTileKey(unit.tileKey)
-        : ProvinceId.regionIdFrom(
-            resolveToFullProvinceId(game.worldState, unit.locationProvinceId),
+    return shortCircuitIfPreviousRejected(
+      previousRejected: previousRejected,
+      body: () {
+        final unit = unitsById[order.unitId];
+        if (unit == null || unit.ownerId != playerId) {
+          return OrderValidationResult.rejected('Invalid move');
+        }
+        if (isMilitaryUnit(unit.type)) {
+          return OrderValidationResult.rejected(
+            'Military units move with armies; use army move',
           );
-    final destFullId = resolveToFullProvinceId(
-      game.worldState,
-      order.destinationProvinceId,
-    );
-    final destRegion = ProvinceId.regionIdFrom(destFullId);
-    final destProvince = game.worldState.tryGetProvince(destFullId);
-    final destOwnerId = destProvince?.ownerId;
-    // Movement within own provinces: always allowed. SPEC/program/movement.md.
-    final moveToOwnProvince = destOwnerId == playerId;
-    if (!moveToOwnProvince && destRegion != unitRegion) {
-      return OrderValidationResult.rejected('Invalid move');
-    }
-    if (!moveToOwnProvince) {
-      final unitLocalId = ProvinceId.localIdFrom(unit.locationProvinceId);
-      final destLocalId = ProvinceId.localIdFrom(destFullId);
-      if (!isValidLandMoveInRegion(
-        topology,
-        unitRegion,
-        unitLocalId,
-        destLocalId,
-      )) {
-        return OrderValidationResult.rejected('Invalid move');
-      }
-    }
-
-    // Civilian vs foreign territory
-    if (!isMilitaryUnit(unit.type) &&
-        destOwnerId != null &&
-        destOwnerId != playerId) {
-      if (isGreatPower(game, destOwnerId) && !isSpyUnit(unit.type)) {
-        return OrderValidationResult.rejected(
-          'Civilian cannot enter other Great Power territory',
-        );
-      }
-      if (isMinorOrTribe(game, destOwnerId) &&
-          !isExplorerUnit(unit.type) &&
-          !isMerchantUnit(unit.type) &&
-          !isSpyUnit(unit.type)) {
-        return OrderValidationResult.rejected(
-          'Civilian cannot enter Minor/Tribe territory',
-        );
-      }
-    }
-
-    // Attack validation: GP province requires war or same-turn declareWar.
-    if (destOwnerId != null &&
-        destOwnerId != playerId &&
-        isGreatPower(game, destOwnerId) &&
-        !canAttackWithWarOrDeclaring(
-          game,
-          playerId,
-          destOwnerId,
-          diplomaticOrders,
-        )) {
-      return OrderValidationResult.rejected(
-        'Must declare war before attacking Great Power province',
-      );
-    }
-
-    // Attack validation: Minor/Tribe province requires war for military units.
-    if (destOwnerId != null &&
-        destOwnerId != playerId &&
-        isMinorOrTribe(game, destOwnerId) &&
-        isMilitaryUnit(unit.type) &&
-        !canAttackWithWarOrDeclaring(
-          game,
-          playerId,
-          destOwnerId,
-          diplomaticOrders,
-        )) {
-      return OrderValidationResult.rejected(
-        'Must declare war before attacking Minor Nation or Tribe province',
-      );
-    }
-
-    if (!moveSourceVisibilityOk(view, unitRegion, unit.locationProvinceId) ||
-        !moveDestVisibilityOk(
-          view,
-          destRegion,
+        }
+        final unitRegion = unit.tileKey != null && unit.tileKey!.isNotEmpty
+            ? Unit.requireRegionIdFromTileKey(unit.tileKey)
+            : ProvinceId.regionIdFrom(
+                resolveToFullProvinceId(game.worldState, unit.locationProvinceId),
+              );
+        final destFullId = resolveToFullProvinceId(
+          game.worldState,
           order.destinationProvinceId,
-          unit.type,
-        )) {
-      return OrderValidationResult.rejected(
-        'Source or destination not visible',
-      );
-    }
-    return OrderValidationResult.accepted();
+        );
+        final destRegion = ProvinceId.regionIdFrom(destFullId);
+        final destProvince = game.worldState.tryGetProvince(destFullId);
+        final destOwnerId = destProvince?.ownerId;
+        // Movement within own provinces: always allowed. SPEC/program/movement.md.
+        final moveToOwnProvince = destOwnerId == playerId;
+        if (!moveToOwnProvince && destRegion != unitRegion) {
+          return OrderValidationResult.rejected('Invalid move');
+        }
+        if (!moveToOwnProvince) {
+          final unitLocalId = ProvinceId.localIdFrom(unit.locationProvinceId);
+          final destLocalId = ProvinceId.localIdFrom(destFullId);
+          if (!isValidLandMoveInRegion(
+            topology,
+            unitRegion,
+            unitLocalId,
+            destLocalId,
+          )) {
+            return OrderValidationResult.rejected('Invalid move');
+          }
+        }
+
+        // Civilian vs foreign territory
+        if (!isMilitaryUnit(unit.type) &&
+            destOwnerId != null &&
+            destOwnerId != playerId) {
+          if (isGreatPower(game, destOwnerId) && !isSpyUnit(unit.type)) {
+            return OrderValidationResult.rejected(
+              'Civilian cannot enter other Great Power territory',
+            );
+          }
+          if (isMinorOrTribe(game, destOwnerId) &&
+              !isExplorerUnit(unit.type) &&
+              !isMerchantUnit(unit.type) &&
+              !isSpyUnit(unit.type)) {
+            return OrderValidationResult.rejected(
+              'Civilian cannot enter Minor/Tribe territory',
+            );
+          }
+        }
+
+        // Attack validation: GP province requires war or same-turn declareWar.
+        if (destOwnerId != null &&
+            destOwnerId != playerId &&
+            isGreatPower(game, destOwnerId) &&
+            !canAttackWithWarOrDeclaring(
+              game,
+              playerId,
+              destOwnerId,
+              diplomaticOrders,
+            )) {
+          return OrderValidationResult.rejected(
+            'Must declare war before attacking Great Power province',
+          );
+        }
+
+        // Attack validation: Minor/Tribe province requires war for military units.
+        if (destOwnerId != null &&
+            destOwnerId != playerId &&
+            isMinorOrTribe(game, destOwnerId) &&
+            isMilitaryUnit(unit.type) &&
+            !canAttackWithWarOrDeclaring(
+              game,
+              playerId,
+              destOwnerId,
+              diplomaticOrders,
+            )) {
+          return OrderValidationResult.rejected(
+            'Must declare war before attacking Minor Nation or Tribe province',
+          );
+        }
+
+        if (!moveSourceVisibilityOk(view, unitRegion, unit.locationProvinceId) ||
+            !moveDestVisibilityOk(
+              view,
+              destRegion,
+              order.destinationProvinceId,
+              unit.type,
+            )) {
+          return OrderValidationResult.rejected(
+            'Source or destination not visible',
+          );
+        }
+        return OrderValidationResult.accepted();
+      },
+    );
   }
 }

--- a/packages/colonizethis_logic/test/orders/validators/move_validator_test.dart
+++ b/packages/colonizethis_logic/test/orders/validators/move_validator_test.dart
@@ -70,6 +70,7 @@ void main() {
         [],
         view,
         topology,
+        previousRejected: false,
       );
       expect(result.status, OrderValidationStatus.rejected);
       expect(result.reason, contains('Civilian cannot enter other Great Power'));
@@ -118,6 +119,7 @@ void main() {
         [],
         view,
         topology,
+        previousRejected: false,
       );
       expect(result.status, OrderValidationStatus.rejected);
       expect(result.reason, contains('army move'));
@@ -209,9 +211,51 @@ void main() {
         [],
         view,
         topology,
+        previousRejected: false,
       );
       expect(result.status, OrderValidationStatus.rejected);
       expect(result.reason, contains('Civilian cannot enter Minor'));
+    });
+
+    test('short-circuits when previous order rejected', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
+              Province(id: '$ow|P2', regionId: ow, ownerId: 'p1'),
+            ],
+            units: [
+              Unit(id: 'u1', type: 'Builder', ownerId: 'p1', locationProvinceId: '$ow|P1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            'p1': {
+              'oldWorld|P1|0|0': 'fullyVisible',
+              'oldWorld|P2|0|0': 'revealed',
+            },
+          },
+        ),
+        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+      );
+      final unitsById = {for (final u in game.worldState.oldWorld.units) u.id: u};
+      final view = buildPlayerView(game, topology, 'p1');
+      const validator = MoveValidator();
+      final result = validator.validate(
+        const MoveOrder(unitId: 'u1', destinationProvinceId: 'oldWorld|P2'),
+        game,
+        'p1',
+        unitsById,
+        [],
+        view,
+        topology,
+        previousRejected: true,
+      );
+      expect(result.status, OrderValidationStatus.rejected);
+      expect(result.reason, 'Previous invalid');
     });
 
     test('ArmyMoveValidator military cannot move into Minor province without war', () {


### PR DESCRIPTION
## Summary
- Refactors `MoveValidator` to extend `OrderValidator` and use `shortCircuitIfPreviousRejected` for consistent order-validation sequencing.
- Updates `OrderEngine` move-order validation wiring to pass `previousRejected` directly into `MoveValidator`.
- Expands `move_validator_test.dart` with a regression test that asserts prior invalid orders short-circuit with `Previous invalid`.

## Test plan
- [x] `cd packages/colonizethis_logic && dart test test/orders/validators/move_validator_test.dart`

Refs #1555

Made with [Cursor](https://cursor.com)