### PR TITLE
fix(combat): use set-backed casualty lookups in battle resolution

### DIFF
--- a/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
@@ -69,7 +69,7 @@ Game resolveBattleContext(
   var currentDefenderGeneralId = ctx.defenderGeneralId;
   var currentDefenderMedals = ctx.defenderGeneralMedals;
 
-  final allCasualties = <String>[];
+  final allCasualties = <String>{};
   String? survivingAttackerFactionId;
 
   final initialDefenderCount = ctx.defenderUnitIds.length;
@@ -298,7 +298,7 @@ Game resolveBattleContext(
 ({RegionData region, bool provinceChangedOwner}) _buildPostBattleRegion({
   required RegionData region,
   required BattleContext ctx,
-  required List<String> allCasualties,
+  required Set<String> allCasualties,
   required Map<String, Unit> unitsById,
   required String provinceOwnerId,
   required String defenderFactionId,


### PR DESCRIPTION
## Summary
- Switch `allCasualties` in `CombatResolver` from `List<String>` to `Set<String>` to make repeated `.contains()` checks O(1) during engagement loops.
- Update `_buildPostBattleRegion` to accept `Set<String>` for casualty filtering, preserving existing behavior.
- Keep scope intentionally minimal for issue #1620 (no gameplay behavior changes).

## Spec
- No SPEC changes required; this is a performance-only internal data structure refactor aligned with existing behavior and ACs.

## Test plan
- [x] `flutter test packages/colonizethis_logic/test/combat_resolver_test.dart`

Refs #1620

Made with [Cursor](https://cursor.com)