### PR TITLE
Tech descriptions batch 1: concrete fixed-field wording for techs 1-10

### DIFF
--- a/SPEC/game/tech-tree-gathering.md
+++ b/SPEC/game/tech-tree-gathering.md
@@ -14,16 +14,16 @@ The **gathering table below is the GDD source of truth** for ids, effects, and p
 
 | id | name | era | prerequisites | effects |
 |----|------|-----|---------------|--------|
-| crop_rotation | Crop Rotation | 1 | — | Cattle herds; leads to sheep, cattle, horse |
-| saw_mill | Saw Mill | 1 | — | Timber 2 (forested land) |
-| land_enclosure | Land Enclosure | 1 | — | Grain 2 |
-| mine_engineering | Mine Engineering | 1 | — | Fort level 2 (see [siege-mechanics.md](siege-mechanics.md)); leads to mining |
-| iron_mining | Iron Mining | 1 | mine_engineering | Iron 2 |
-| copper_and_tin_mining | Copper and Tin Mining | 1 | mine_engineering | Copper/tin 2; required for Horse Artillery, Weapon Craftsmanship |
-| coal_mining | Coal Mining | 1 | mine_engineering | Coal 1 (construct) |
-| wind_saw_mill | Wind Saw Mill | 2 | saw_mill | Timber 3 |
-| seed_drill | Seed Drill | 2 | land_enclosure | Grain 3 |
-| sheep_ranching | Sheep Ranching | 2 | crop_rotation | Wool 2 |
+| crop_rotation | Crop Rotation | 1 | — | Unlocks: `sheep_ranching`, `animal_husbandry`, and `recruit_steppe_horsemen` research paths. Improves: establishes the first agriculture baseline required before wool/meat specialization techs can grant higher extraction caps. |
+| saw_mill | Saw Mill | 1 | — | Improves: timber extraction cap to **2** on forested provinces (effective output still bounded by transport and improvement level). Unlocks: prerequisite for `wind_saw_mill`. |
+| land_enclosure | Land Enclosure | 1 | — | Improves: grain extraction cap to **2**. Unlocks: prerequisite for `seed_drill`, `money_lending`, and `organised_regiments`. |
+| mine_engineering | Mine Engineering | 1 | — | Enables: builder fort upgrades to **Fort Level 2** (see [siege-mechanics.md](siege-mechanics.md)). Unlocks: prerequisite for `iron_mining`, `copper_and_tin_mining`, and `coal_mining`. |
+| iron_mining | Iron Mining | 1 | mine_engineering | Improves: iron extraction cap to **2**. Unlocks: prerequisite for `steam_in_mining`. |
+| copper_and_tin_mining | Copper and Tin Mining | 1 | mine_engineering | Improves: copper/tin extraction cap to **2**. Unlocks: prerequisite for `large_copper_and_tin_mines`. Enables: satisfies part of military prerequisites that reference this tech (for example Horse Artillery and Weapon Craftsmanship branches). |
+| coal_mining | Coal Mining | 1 | mine_engineering | Enables: coal extraction at cap **1** (first coal production permission). Unlocks: prerequisite for `square_set_timbering`. |
+| wind_saw_mill | Wind Saw Mill | 2 | saw_mill | Improves: timber extraction cap to **3**. Unlocks: prerequisite for `circular_saw`. |
+| seed_drill | Seed Drill | 2 | land_enclosure | Improves: grain extraction cap to **3**. Unlocks: prerequisite for `moldboard_plow`. |
+| sheep_ranching | Sheep Ranching | 2 | crop_rotation | Improves: wool extraction cap to **2**. Unlocks: prerequisite for `scientific_sheep_breeding`. |
 | animal_husbandry | Animal Husbandry | 2 | crop_rotation | Meat 3 |
 | square_set_timbering | Square-set Timbering | 2 | coal_mining | Coal 2 |
 | steam_in_mining | Steam in Mining | 2 | iron_mining | Iron 3 |
@@ -51,6 +51,10 @@ The **gathering table below is the GDD source of truth** for ids, effects, and p
 ---
 
 ## Acceptance criteria
+
+- Given the `crop_rotation`, `saw_mill`, `land_enclosure`, `mine_engineering`, `iron_mining`, `copper_and_tin_mining`, `coal_mining`, `wind_saw_mill`, `seed_drill`, and `sheep_ranching` rows in this tech table  
+  When the System or UI layer renders their design descriptions from SPEC-authorized wording  
+  Then each row includes at least one fixed-field phrase (`Unlocks:`, `Improves:`, `Enables:`, or `Prerequisite-only:`), names concrete mechanics or explicit unlock targets, and does not use generic fallback wording.
 
 - **Table:** Each row has a unique id; prerequisite ids reference techs defined in this doc or other category docs.
 - **Extraction cap:** In the full model, per-resource cap is derived from unlocked gathering techs (max level per resource from the table). MVP uses a single scalar cap; see [tech-and-extraction-cap.md](tech-and-extraction-cap.md).

--- a/app/lib/features/game/widgets/tech_tree_widget.dart
+++ b/app/lib/features/game/widgets/tech_tree_widget.dart
@@ -351,7 +351,10 @@ class TechTreeWidget extends StatelessWidget {
         list.add('Railroads');
         break;
       case 'mine_engineering':
-        list.add('Fort level 2');
+        list.add('Enables: Builder upgrades to Fort Level 2');
+        list.add(
+          'Unlocks: Iron Mining, Copper and Tin Mining, and Coal Mining',
+        );
         break;
       case 'national_bureaucracy':
         list.add('Builders can upgrade provincial towns');
@@ -380,7 +383,9 @@ class TechTreeWidget extends StatelessWidget {
         list.add('Unlocks Master Artisans (8× labour; consume fur hats)');
         break;
       case 'trade_fairs':
-        list.add('Planned: more trade commodity slots vs baseline (not active yet)');
+        list.add(
+          'Planned: more trade commodity slots vs baseline (not active yet)',
+        );
         break;
       case 'banking':
         list.add('Unlocks later military, diplomacy, and transport techs');
@@ -401,8 +406,45 @@ class TechTreeWidget extends StatelessWidget {
         list.add('Allows asking Great Powers to join your empire peacefully');
         break;
       case 'land_enclosure':
+        list.add('Improves: Grain extraction cap to 2');
+        list.add('Unlocks: Seed Drill, Money Lending, and Organised Regiments');
+        break;
+      case 'crop_rotation':
+        list.add(
+          'Unlocks: Sheep Ranching, Animal Husbandry, and Steppe Horsemen research paths',
+        );
+        break;
+      case 'saw_mill':
+        list.add('Improves: Timber extraction cap to 2 (forested provinces)');
+        list.add('Unlocks: Wind Saw Mill');
+        break;
+      case 'iron_mining':
+        list.add('Improves: Iron extraction cap to 2');
+        list.add('Unlocks: Steam in Mining');
+        break;
+      case 'copper_and_tin_mining':
+        list.add('Improves: Copper/Tin extraction cap to 2');
+        list.add('Unlocks: Large Copper and Tin Mines');
+        list.add('Enables: Military branches that require this tech');
+        break;
+      case 'coal_mining':
+        list.add('Enables: Coal extraction (cap 1)');
+        list.add('Unlocks: Square-set Timbering');
+        break;
+      case 'wind_saw_mill':
+        list.add('Improves: Timber extraction cap to 3');
+        list.add('Unlocks: Circular Saw');
+        break;
+      case 'seed_drill':
+        list.add('Improves: Grain extraction cap to 3');
+        list.add('Unlocks: Moldboard Plow');
+        break;
+      case 'sheep_ranching':
+        list.add('Improves: Wool extraction cap to 2');
+        list.add('Unlocks: Scientific Sheep Breeding');
+        break;
       case 'hat_production':
-        list.add('Improves labour and economy output');
+        list.add('Improves: Enables fur hats luxury production');
         break;
       default:
         if (list.isEmpty) {

--- a/app/test/tech_tree_widget_test.dart
+++ b/app/test/tech_tree_widget_test.dart
@@ -434,6 +434,62 @@ void main() {
     expect(find.text('Effects'), findsOneWidget);
   });
 
+  testWidgets(
+    'Batch-1 tech descriptions are concrete and avoid generic fallback text',
+    (WidgetTester tester) async {
+      final emptyPlayer = player.copyWith(techUnlocked: <String, bool>{});
+      final gameWithEmptyPlayer = game.copyWith(
+        players: [emptyPlayer, ...game.players.skip(1)],
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TechTreeWidget(
+              game: gameWithEmptyPlayer,
+              player: emptyPlayer,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final expectedByTech = <String, String>{
+        'Crop Rotation':
+            'Unlocks: Sheep Ranching, Animal Husbandry, and Steppe Horsemen research paths',
+        'Saw Mill': 'Improves: Timber extraction cap to 2 (forested provinces)',
+        'Land Enclosure': 'Improves: Grain extraction cap to 2',
+        'Mine Engineering': 'Enables: Builder upgrades to Fort Level 2',
+        'Iron Mining': 'Improves: Iron extraction cap to 2',
+        'Copper and Tin Mining': 'Improves: Copper/Tin extraction cap to 2',
+        'Coal Mining': 'Enables: Coal extraction (cap 1)',
+        'Wind Saw Mill': 'Improves: Timber extraction cap to 3',
+        'Seed Drill': 'Improves: Grain extraction cap to 3',
+        'Sheep Ranching': 'Improves: Wool extraction cap to 2',
+      };
+
+      for (final entry in expectedByTech.entries) {
+        final techNode = find.text(entry.key).first;
+        await tester.ensureVisible(techNode);
+        await tester.tap(techNode);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CtDialogShell), findsOneWidget);
+        expect(find.textContaining(entry.value), findsOneWidget);
+        expect(
+          find.textContaining('Improves gathering capabilities'),
+          findsNothing,
+        );
+        expect(
+          find.textContaining('Improves labour and economy output'),
+          findsNothing,
+        );
+
+        await tester.tap(find.text('Close'));
+        await tester.pumpAndSettle();
+      }
+    },
+  );
+
   test(
     'Column rule: A→B→C and A→C places B between A and C (gap between A and C)',
     () {


### PR DESCRIPTION
## Summary
- Updates `SPEC/game/tech-tree-gathering.md` for batch-1 tech ids with fixed-field wording (`Unlocks:`, `Improves:`, `Enables:`) and concrete mechanics.
- Updates `app/lib/features/game/widgets/tech_tree_widget.dart` summaries for the same batch to remove generic messaging and align with the SPEC wording.
- Adds a widget test that iterates the batch and fails if generic fallback text appears.

## Scope
- In scope: issue #1625 batch of 10 tech ids (`crop_rotation`, `saw_mill`, `land_enclosure`, `mine_engineering`, `iron_mining`, `copper_and_tin_mining`, `coal_mining`, `wind_saw_mill`, `seed_drill`, `sheep_ranching`).
- Out of scope: remaining epic batches under #1624.

## Testing
- `flutter test test/tech_tree_widget_test.dart`

Refs #1625

Made with [Cursor](https://cursor.com)