### PR TITLE
chore(ci): enforce logic-ai decoupling boundary

### DIFF
--- a/.cursor/rules/colonizethis-logic-ai-decoupling.mdc
+++ b/.cursor/rules/colonizethis-logic-ai-decoupling.mdc
@@ -1,0 +1,36 @@
+---
+description: Enforce one-way logic/ai package decoupling
+alwaysApply: true
+---
+
+# Logic/AI Package Decoupling
+
+Enforce a strict one-way architecture boundary between `colonizethis_logic` and `colonizethis_ai`.
+
+## Dependency Direction (authoritative)
+
+- Allowed: `colonizethis_ai` -> `colonizethis_logic` (narrow contracts only).
+- Forbidden: any `colonizethis_logic` -> `colonizethis_ai` dependency (including `dev_dependencies`).
+- `colonizethis_logic/pubspec.yaml` must never contain `colonizethis_ai` in `dependencies` or `dev_dependencies`.
+
+## Import Surface Rules
+
+- In `packages/colonizethis_ai/lib/**`, import logic through explicit contract entrypoints only:
+  - `package:colonizethis_logic/ai_api.dart`
+  - `package:colonizethis_logic/order_suggestion_api.dart`
+- Do not import broad logic barrels for AI integration:
+  - Forbidden: `package:colonizethis_logic/colonizethis_logic.dart` (or equivalent broad exports).
+- If AI needs new capabilities from logic, add/extend a narrow contract in logic first, then consume that contract from AI.
+
+## Test Boundary Rules
+
+- Tests that exercise AI behavior/planning belong in `packages/colonizethis_ai/test/**`.
+- `packages/colonizethis_logic/test/**` must not require `colonizethis_ai` as a test-time dependency.
+
+## Change Review Checklist
+
+- Before finalizing changes touching AI/logic boundaries, verify:
+  - `colonizethis_logic/pubspec.yaml` has no `colonizethis_ai` dependency.
+  - AI imports use only allowed contract files.
+  - Static analysis remains clean for touched packages.
+  - Dependency direction remains consistent with `SPEC/program/repo-and-packages.md`.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -288,6 +288,9 @@ jobs:
       - name: Check test import convention (SPEC/program/test-logging.md)
         run: tool/check_test_imports.sh
 
+      - name: Check logic/ai decoupling convention (SPEC/program/repo-and-packages.md)
+        run: tool/check_logic_ai_decoupling.sh
+
       - name: Wang incremental assets gate (Python)
         run: |
           set -euo pipefail

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Cursor rules are the source of truth for implementation and review behavior.
 | `colonizethis-spec-required.mdc` | SPEC-first workflow and source-of-truth boundaries |
 | `colonizethis-core-principles.mdc` | Dart/Flutter/Flame coding principles and architecture boundaries |
 | `colonizethis-logging-file.mdc` | Required file logging approach (`basic_logger_file`) |
+| `colonizethis-logic-ai-decoupling.mdc` | Enforces one-way architecture boundary between `colonizethis_logic` and `colonizethis_ai` |
 
 ## Context-specific rules
 

--- a/SPEC/program/repo-and-packages.md
+++ b/SPEC/program/repo-and-packages.md
@@ -64,6 +64,20 @@ colonizethis_data    (no package deps)
 - **Given** package metadata for `colonizethis_logic`, **when** dependency analysis reads `dependencies` and `dev_dependencies`, **then** no `colonizethis_ai` entry exists.
 - **Given** `colonizethis_ai` imports logic interfaces, **when** static analysis inspects imports under `packages/colonizethis_ai/lib`, **then** imports use narrow logic contract libraries (`order_suggestion_api.dart`, `ai_api.dart`) and do not import `package:colonizethis_logic/colonizethis_logic.dart`.
 
+### Automated guard gate (CI)
+
+The repository enforces this boundary in CI via:
+
+- `tool/check_logic_ai_decoupling.sh`
+- `.github/workflows/quality.yml` step: `Check logic/ai decoupling convention (SPEC/program/repo-and-packages.md)`
+
+Guard behavior:
+
+- Fails if `packages/colonizethis_logic/pubspec.yaml` declares `colonizethis_ai` under `dependencies` or `dev_dependencies`.
+- Fails if `packages/colonizethis_ai/lib/**` imports `package:colonizethis_logic/colonizethis_logic.dart`.
+- Fails if `packages/colonizethis_ai/lib/**` imports logic from any path other than `ai_api.dart` or `order_suggestion_api.dart`.
+- Fails if `packages/colonizethis_logic/test/**` imports `package:colonizethis_ai/...`.
+
 ---
 
 ## Flutter app `lib/` structure (TDD 15)

--- a/tool/check_logic_ai_decoupling.sh
+++ b/tool/check_logic_ai_decoupling.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Enforce architecture boundary between colonizethis_logic and colonizethis_ai.
+# Exit 0 when all checks pass, 1 otherwise.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+FAIL=0
+LOGIC_PUBSPEC="packages/colonizethis_logic/pubspec.yaml"
+AI_LIB_DIR="packages/colonizethis_ai/lib"
+LOGIC_TEST_DIR="packages/colonizethis_logic/test"
+
+echo "Checking logic/ai decoupling policy..."
+
+# 1) logic package must not depend on ai package (including dev_dependencies).
+if rg -n "^[[:space:]]*colonizethis_ai[[:space:]]*:" "$LOGIC_PUBSPEC" >/dev/null; then
+  echo "ERROR: $LOGIC_PUBSPEC must not contain colonizethis_ai in dependencies/dev_dependencies."
+  FAIL=1
+fi
+
+# 2) AI must not import broad logic barrel.
+if rg -n "package:colonizethis_logic/colonizethis_logic\\.dart" "$AI_LIB_DIR" >/dev/null; then
+  echo "ERROR: Forbidden import found in $AI_LIB_DIR: package:colonizethis_logic/colonizethis_logic.dart"
+  FAIL=1
+fi
+
+# 3) AI may import only narrow logic contracts.
+ALLOWED_IMPORT_A="package:colonizethis_logic/ai_api.dart"
+ALLOWED_IMPORT_B="package:colonizethis_logic/order_suggestion_api.dart"
+IMPORTS="$(rg -n "package:colonizethis_logic/[^']+" "$AI_LIB_DIR" || true)"
+if [[ -n "$IMPORTS" ]]; then
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    import_path="$(echo "$line" | sed -E "s/.*(package:colonizethis_logic\/[^']+).*/\1/")"
+    if [[ "$import_path" != "$ALLOWED_IMPORT_A" && "$import_path" != "$ALLOWED_IMPORT_B" ]]; then
+      echo "ERROR: Non-contract logic import in AI: $line"
+      echo "       Allowed: $ALLOWED_IMPORT_A or $ALLOWED_IMPORT_B"
+      FAIL=1
+    fi
+  done <<< "$IMPORTS"
+fi
+
+# 4) logic tests should not import ai package.
+if [[ -d "$LOGIC_TEST_DIR" ]]; then
+  if rg -n "package:colonizethis_ai/" "$LOGIC_TEST_DIR" >/dev/null; then
+    echo "ERROR: $LOGIC_TEST_DIR must not import package:colonizethis_ai/..."
+    FAIL=1
+  fi
+fi
+
+if [[ $FAIL -eq 1 ]]; then
+  exit 1
+fi
+
+echo "Logic/AI decoupling check passed."
+exit 0


### PR DESCRIPTION
## Summary
- add a dedicated decoupling guard script at `tool/check_logic_ai_decoupling.sh`
- wire the guard into `.github/workflows/quality.yml` so PRs fail on logic/ai boundary violations
- document the enforced boundary in `SPEC/program/repo-and-packages.md` and register the always-applied Cursor rule in `AGENTS.md`

Refs #1571

## Test plan
- [x] run `tool/check_logic_ai_decoupling.sh` locally
- [x] verify CI workflow includes `Check logic/ai decoupling convention` step
- [ ] let GitHub Actions `Quality` workflow run on this PR

Made with [Cursor](https://cursor.com)