### PR TITLE
refactor(logic): use Game.playerById for player lookups

### DIFF
--- a/packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
+++ b/packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
@@ -212,7 +212,7 @@ DialogueEvent dialogueEventForNegotiation({
 }
 
 bool _isHumanGp(Game game, String factionId) {
-  final player = game.players.where((p) => p.id == factionId).firstOrNull;
+  final player = game.playerById(factionId);
   return player?.isHuman == true;
 }
 

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
@@ -604,7 +604,7 @@ void _prefilterWtBuildRoad(_WorkTilePrefilterCtx c) {
 }
 
 void _prefilterWtBuildRail(_WorkTilePrefilterCtx c) {
-  final player = c.game.players.where((p) => p.id == c.playerId).firstOrNull;
+  final player = c.game.playerById(c.playerId);
   if (player == null) return;
   final tech = player.techUnlocked;
   final tileState = c.game.worldState.tileState;

--- a/packages/colonizethis_logic/lib/src/orders/orders_application_completed_work.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_completed_work.dart
@@ -165,7 +165,7 @@ void _completedWorkBuildRoad(
   void Function(_BuildWorkState, Unit, String) applyExploreCompletion,
 ) {
   final roadLevel = s.tileState.roadLevel(cw.tileKey);
-  final player = s.game.players.where((p) => p.id == u.ownerId).firstOrNull;
+  final player = s.game.playerById(u.ownerId);
   final hasRoadConstruction =
       player?.techUnlocked?['road_construction'] == true;
   final nextLevel = (roadLevel + 1).clamp(0, hasRoadConstruction ? 2 : 1);
@@ -258,7 +258,7 @@ void _completedWorkBuildRail(
   void Function(List<Province>) setProvinces,
   void Function(_BuildWorkState, Unit, String) applyExploreCompletion,
 ) {
-  final player = s.game.players.where((p) => p.id == u.ownerId).firstOrNull;
+  final player = s.game.playerById(u.ownerId);
   final roadLevel = s.tileState.roadLevel(cw.tileKey);
   final terrain = terrainTypeForTileKey(s.tileMapByRegion, cw.tileKey);
   final reason = rejectionReasonForBuildRailOrder(


### PR DESCRIPTION
## Summary
- Replace manual `game.players.where((p) => p.id == ...).firstOrNull` lookups with `game.playerById(...)` in targeted logic files.
- Reuse the existing `GamePlayerLookup` extension to reduce duplicated lookup logic while preserving behavior.
- Keep scope limited to issue #1616 refactor only.

## SPEC
- No SPEC behavior changes required; this is a non-functional refactor aligned with existing logic contracts.
- Refs #1616

## Test plan
- [x] `cd packages/colonizethis_logic && dart test`

Made with [Cursor](https://cursor.com)