### PR TITLE
refactor(logic): complete #1616 playerById call sites

### DIFF
--- a/packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
+++ b/packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
@@ -154,9 +154,7 @@ List<DialogueEvent> dialogueEventsForReactiveFortsOnBorder(
   String provinceId,
   int seed,
 ) {
-  final builder = game.players
-      .where((p) => p.id == builderPlayerId)
-      .firstOrNull;
+  final builder = game.playerById(builderPlayerId);
   if (builder == null || builder.isHuman != true) return [];
   final regionId = ProvinceId.regionIdFrom(provinceId);
   final localId = ProvinceId.localIdFrom(provinceId);

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -507,9 +507,7 @@ Game applyBuildAndWorkOrders(
                 .toList();
             if (missing.isNotEmpty && rand.nextDouble() < spyTechStealChance) {
               final granted = missing[rand.nextInt(missing.length)];
-              final player = s.game.players
-                  .where((p) => p.id == u.ownerId)
-                  .firstOrNull;
+              final player = s.game.playerById(u.ownerId);
               if (player != null) {
                 final updated = Map<String, bool>.from(
                   player.techUnlocked ?? {},

--- a/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
@@ -95,10 +95,7 @@ Game applyNavalMissionOrders(
         final homeFleet = fleetById[homeFleetId];
         if (homeFleet == null) continue;
         // Only fleets in port at the player's capital province can join home fleet. SPEC/game/ships-and-naval.md.
-        final capitalProvinceId = game.players
-            .where((p) => p.id == playerId)
-            .map((p) => p.capitalProvinceId)
-            .firstOrNull;
+        final capitalProvinceId = game.playerById(playerId)?.capitalProvinceId;
         if (capitalProvinceId == null ||
             fleet.inPortAtProvinceId != capitalProvinceId) {
           continue;


### PR DESCRIPTION
## Summary
Completes the remaining manual `game.players.where((p) => p.id == …).firstOrNull` lookups after https://github.com/waigore/colonizethisv3/pull/1658.

## Changes
- `event_dialogue.dart`: reactive fort builder lookup
- `orders_application.dart`: spy tech steal owner lookup  
- `naval_resolution.dart`: capital province for join_home_fleet

## AC (issue #1616)
- All such patterns in `colonizethis_logic/lib` now use `playerById` (province `.where((p) => p.id == provinceId)` unchanged).

Refs #1616

Made with [Cursor](https://cursor.com)