### PR TITLE
refactor(logic): split _BuildWorkState for orders application

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -20,6 +20,7 @@ import '../world/unit_lookup.dart';
 
 part 'orders_application_work_phase.dart';
 part 'orders_application_completed_work.dart';
+part 'orders_application_build_phase.dart';
 
 final _log = logicLogger();
 
@@ -118,15 +119,9 @@ Game clearUnitCurrentWork(Game game, String unitId) {
   }
 }
 
-/// Mutable state shared by build phase, work phase, and processWorkUnits.
-class _BuildWorkState {
-  _BuildWorkState({
-    required this.game,
-    required this.buildOrders,
-    required this.workOrders,
-    this.topology,
-    this.tileMapByRegion,
-    this.onDialogue,
+/// Mutable work-phase and per-turn scratch maps/lists (WorkState per #1618).
+class _WorkOrderState {
+  _WorkOrderState({
     required this.oldUnitsById,
     required this.newUnitsById,
     required this.tileState,
@@ -137,12 +132,6 @@ class _BuildWorkState {
     required this.newProvinces,
   });
 
-  Game game;
-  final Map<String, List<BuildUnitOrder>> buildOrders;
-  final Map<String, List<WorkOrder>> workOrders;
-  final MapTopology? topology;
-  final Map<String, TileMapResult>? tileMapByRegion;
-  final void Function(DialogueEvent)? onDialogue;
   final Map<String, Unit> oldUnitsById;
   final Map<String, Unit> newUnitsById;
   TileMapState tileState;
@@ -154,141 +143,25 @@ class _BuildWorkState {
   final List<Player> updatedPlayers = [];
 }
 
-/// Applies build orders for all players. Mutates [state.game], [state.oldUnitsById], [state.newUnitsById].
-void _runBuildPhase(_BuildWorkState state) {
-  for (final player in state.game.players) {
-    var workers = player.workerPool;
-    var stockpile = player.stockpile;
-    var treasury = player.treasury;
+/// Session context for applyBuildAndWorkOrders: game mutation, order maps, map topology.
+class _BuildWorkState {
+  _BuildWorkState({
+    required this.game,
+    required this.buildOrders,
+    required this.workOrders,
+    this.topology,
+    this.tileMapByRegion,
+    this.onDialogue,
+    required this.work,
+  });
 
-    for (final order in state.buildOrders[player.id] ?? const []) {
-      final category = buildUnitCategoryForUnitType(order.unitType);
-      if (category == BuildUnitCategory.unknown) continue;
-
-      final check = canAffordBuild(player, order, workers, stockpile, treasury);
-      if (!check.canAfford) continue;
-
-      final after = applyBuildCostDeduction(
-        player,
-        order,
-        workers,
-        stockpile,
-        treasury,
-      );
-      workers = after.workers;
-      stockpile = after.stockpile;
-      treasury = after.treasury;
-
-      if (category == BuildUnitCategory.naval) {
-        final capProvinceId = player.capitalProvinceId;
-        if (capProvinceId == null) continue;
-        final regionId = ProvinceId.regionIdFrom(capProvinceId);
-        // Only add ship when capital is sea-bound (has a port). SPEC/game/ships-and-naval.md.
-        if (state.topology == null) continue;
-        final seaZoneAtCap = seaZoneIdForProvince(
-          state.topology!,
-          ProvinceId.localIdFrom(capProvinceId),
-          regionId: regionId,
-        );
-        if (seaZoneAtCap == null) continue;
-
-        var ws = state.game.worldState;
-        var fleets = List<Fleet>.from(ws.fleets);
-        final homeFleetId = homeFleetIdFor(player.id);
-        final existing = fleets.indexWhere(
-          (f) => f.id == homeFleetId && f.ownerId == player.id,
-        );
-        var nextSeq = ws.nextShipInstanceSeq;
-        final inferred = inferNextShipInstanceSeqFromFleets(fleets);
-        if (nextSeq < inferred) nextSeq = inferred;
-        final (seqAfter, minted) = mintShipInstances(
-          nextShipInstanceSeq: nextSeq,
-          typeIds: [order.unitType],
-        );
-        nextSeq = seqAfter;
-        if (existing >= 0) {
-          final f = fleets[existing];
-          fleets = List<Fleet>.from(fleets)
-            ..[existing] = f.copyWith(ships: [...f.ships, ...minted]);
-        } else {
-          fleets = [
-            ...fleets,
-            Fleet(
-              id: homeFleetId,
-              ownerId: player.id,
-              seaZoneId: null,
-              inPortAtProvinceId: capProvinceId,
-              regionId: regionId,
-              ships: minted,
-            ),
-          ];
-        }
-        state.game = state.game.copyWith(
-          worldState: ws.copyWith(fleets: fleets, nextShipInstanceSeq: nextSeq),
-        );
-        continue;
-      }
-
-      final spawnProvinceId = resolveBuildSpawnProvinceId(
-        player: player,
-        worldState: state.game.worldState,
-        order: order,
-      );
-      if (spawnProvinceId == null) continue;
-      final regionId = ProvinceId.regionIdFrom(spawnProvinceId);
-      final civilianTileKey = category == BuildUnitCategory.civilian
-          ? resolveCivilianSpawnTileKey(
-              player: player,
-              worldState: state.game.worldState,
-            )
-          : null;
-      if (category == BuildUnitCategory.civilian && civilianTileKey == null) {
-        throw StateError(
-          '$kCivilianCapitalTileMissingReason: player=${player.id}',
-        );
-      }
-
-      final newUnit = Unit(
-        id: _buildUnitId(player.id, order, spawnProvinceId),
-        type: order.unitType,
-        ownerId: player.id,
-        locationProvinceId: spawnProvinceId,
-        tileKey: category == BuildUnitCategory.civilian
-            ? civilianTileKey
-            : null,
-      );
-
-      if (regionId == kRegionNewWorld) {
-        state.newUnitsById[newUnit.id] = newUnit;
-      } else {
-        state.oldUnitsById[newUnit.id] = newUnit;
-      }
-
-      if (category == BuildUnitCategory.military) {
-        _appendMilitaryRegimentToArmy(
-          state,
-          player,
-          spawnProvinceId,
-          newUnit.id,
-        );
-      }
-    }
-
-    // Apply build-phase deductions to this player so _runWorkPhase sees updated state.
-    state.game = state.game.copyWith(
-      players: state.game.players
-          .map(
-            (p) => p.id == player.id
-                ? p.copyWith(
-                    stockpile: stockpile,
-                    workerPool: workers,
-                    treasury: treasury,
-                  )
-                : p,
-          )
-          .toList(),
-    );
-  }
+  Game game;
+  final Map<String, List<BuildUnitOrder>> buildOrders;
+  final Map<String, List<WorkOrder>> workOrders;
+  final MapTopology? topology;
+  final Map<String, TileMapResult>? tileMapByRegion;
+  final void Function(DialogueEvent)? onDialogue;
+  final _WorkOrderState work;
 }
 
 /// Applies BuildUnitOrder and WorkOrder for all players in [game].
@@ -313,13 +186,7 @@ Game applyBuildAndWorkOrders(
     return game;
   }
 
-  final state = _BuildWorkState(
-    game: game,
-    buildOrders: buildOrders,
-    workOrders: workOrders,
-    topology: topology,
-    tileMapByRegion: tileMapByRegion,
-    onDialogue: onDialogue,
+  final work = _WorkOrderState(
     oldUnitsById: Map<String, Unit>.from(
       unitsByIdFromRegion(game.worldState.oldWorld),
     ),
@@ -341,6 +208,15 @@ Game applyBuildAndWorkOrders(
     oldProvinces: List<Province>.from(game.worldState.oldWorld.provinces),
     newProvinces: List<Province>.from(game.worldState.newWorld.provinces),
   );
+  final state = _BuildWorkState(
+    game: game,
+    buildOrders: buildOrders,
+    workOrders: workOrders,
+    topology: topology,
+    tileMapByRegion: tileMapByRegion,
+    onDialogue: onDialogue,
+    work: work,
+  );
 
   _runBuildPhase(state);
 
@@ -361,12 +237,14 @@ Game applyBuildAndWorkOrders(
             .tileKeysByRegionAndProvince[regionIdFromWork]?[fullProvinceId] ??
         [];
     final playerId = u.ownerId;
-    final vis = Map<String, String>.from(s.visibilityByTile[playerId] ?? {});
+    final vis = Map<String, String>.from(
+      s.work.visibilityByTile[playerId] ?? {},
+    );
     for (final tk in tileKeys) {
       vis[tk] = VisibilityLevel.fullyVisible.name;
     }
-    s.visibilityByTile = Map<String, Map<String, String>>.from(
-      s.visibilityByTile,
+    s.work.visibilityByTile = Map<String, Map<String, String>>.from(
+      s.work.visibilityByTile,
     )..[playerId] = vis;
   }
 
@@ -547,45 +425,45 @@ Game applyBuildAndWorkOrders(
 
   processWorkUnits(
     state,
-    state.oldUnitsById,
-    () => state.oldProvinces,
-    (p) => state.oldProvinces = p,
+    state.work.oldUnitsById,
+    () => state.work.oldProvinces,
+    (p) => state.work.oldProvinces = p,
   );
   processWorkUnits(
     state,
-    state.newUnitsById,
-    () => state.newProvinces,
-    (p) => state.newProvinces = p,
+    state.work.newUnitsById,
+    () => state.work.newProvinces,
+    (p) => state.work.newProvinces = p,
   );
 
   state.game = state.game.copyWith(
     worldState: state.game.worldState.copyWith(
-      tileState: state.tileState,
-      playerVisibilityByTile: state.visibilityByTile,
-      portsByProvinceSeaboard: state.portsByProvinceSeaboard,
-      purchasedTilesByTileKey: state.purchasedTilesByTileKey,
+      tileState: state.work.tileState,
+      playerVisibilityByTile: state.work.visibilityByTile,
+      portsByProvinceSeaboard: state.work.portsByProvinceSeaboard,
+      purchasedTilesByTileKey: state.work.purchasedTilesByTileKey,
       oldWorld: RegionData(
-        provinces: state.oldProvinces,
-        units: state.oldUnitsById.values.toList(),
+        provinces: state.work.oldProvinces,
+        units: state.work.oldUnitsById.values.toList(),
       ),
       newWorld: RegionData(
-        provinces: state.newProvinces,
-        units: state.newUnitsById.values.toList(),
+        provinces: state.work.newProvinces,
+        units: state.work.newUnitsById.values.toList(),
       ),
     ),
   );
 
   return state.game.copyWith(
-    players: state.updatedPlayers,
+    players: state.work.updatedPlayers,
     worldState: state.game.worldState.copyWith(
-      purchasedTilesByTileKey: state.purchasedTilesByTileKey,
+      purchasedTilesByTileKey: state.work.purchasedTilesByTileKey,
       oldWorld: RegionData(
         provinces: state.game.worldState.oldWorld.provinces,
-        units: state.oldUnitsById.values.toList(),
+        units: state.work.oldUnitsById.values.toList(),
       ),
       newWorld: RegionData(
         provinces: state.game.worldState.newWorld.provinces,
-        units: state.newUnitsById.values.toList(),
+        units: state.work.newUnitsById.values.toList(),
       ),
     ),
   );

--- a/packages/colonizethis_logic/lib/src/orders/orders_application_build_phase.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_build_phase.dart
@@ -1,0 +1,181 @@
+part of 'orders_application.dart';
+
+/// Home-fleet ship spawn when capital has a seaboard port (naval build slice, #1618).
+class _NavalBuildState {
+  _NavalBuildState(this._session);
+
+  final _BuildWorkState _session;
+
+  /// Spawns into home fleet when affordable build was already deducted; no-op if blocked.
+  void spawnHomeFleetShipIfEligible(Player player, BuildUnitOrder order) {
+    final capProvinceId = player.capitalProvinceId;
+    if (capProvinceId == null) return;
+    final regionId = ProvinceId.regionIdFrom(capProvinceId);
+    // Only add ship when capital is sea-bound (has a port). SPEC/game/ships-and-naval.md.
+    if (_session.topology == null) return;
+    final seaZoneAtCap = seaZoneIdForProvince(
+      _session.topology!,
+      ProvinceId.localIdFrom(capProvinceId),
+      regionId: regionId,
+    );
+    if (seaZoneAtCap == null) return;
+
+    var ws = _session.game.worldState;
+    var fleets = List<Fleet>.from(ws.fleets);
+    final homeFleetId = homeFleetIdFor(player.id);
+    final existing = fleets.indexWhere(
+      (f) => f.id == homeFleetId && f.ownerId == player.id,
+    );
+    var nextSeq = ws.nextShipInstanceSeq;
+    final inferred = inferNextShipInstanceSeqFromFleets(fleets);
+    if (nextSeq < inferred) nextSeq = inferred;
+    final (seqAfter, minted) = mintShipInstances(
+      nextShipInstanceSeq: nextSeq,
+      typeIds: [order.unitType],
+    );
+    nextSeq = seqAfter;
+    if (existing >= 0) {
+      final f = fleets[existing];
+      fleets = List<Fleet>.from(fleets)
+        ..[existing] = f.copyWith(ships: [...f.ships, ...minted]);
+    } else {
+      fleets = [
+        ...fleets,
+        Fleet(
+          id: homeFleetId,
+          ownerId: player.id,
+          seaZoneId: null,
+          inPortAtProvinceId: capProvinceId,
+          regionId: regionId,
+          ships: minted,
+        ),
+      ];
+    }
+    _session.game = _session.game.copyWith(
+      worldState: ws.copyWith(fleets: fleets, nextShipInstanceSeq: nextSeq),
+    );
+  }
+}
+
+/// Civilian unit spawn tile resolution (civilian build slice, #1618).
+class _CivilianBuildState {
+  _CivilianBuildState._();
+
+  static String? spawnTileKeyForCategory({
+    required BuildUnitCategory category,
+    required Player player,
+    required Game game,
+  }) {
+    if (category != BuildUnitCategory.civilian) return null;
+    return resolveCivilianSpawnTileKey(
+      player: player,
+      worldState: game.worldState,
+    );
+  }
+}
+
+/// Military regiment placement after land unit creation (military build slice, #1618).
+class _MilitaryBuildState {
+  _MilitaryBuildState._();
+
+  static void appendRegimentToArmy(
+    _BuildWorkState state,
+    Player player,
+    String spawnProvinceId,
+    String newUnitId,
+  ) {
+    _appendMilitaryRegimentToArmy(state, player, spawnProvinceId, newUnitId);
+  }
+}
+
+/// Applies build orders for all players. Mutates [state.game] and [state.work] unit maps.
+void _runBuildPhase(_BuildWorkState state) {
+  final naval = _NavalBuildState(state);
+  for (final player in state.game.players) {
+    var workers = player.workerPool;
+    var stockpile = player.stockpile;
+    var treasury = player.treasury;
+
+    for (final order in state.buildOrders[player.id] ?? const []) {
+      final category = buildUnitCategoryForUnitType(order.unitType);
+      if (category == BuildUnitCategory.unknown) continue;
+
+      final check = canAffordBuild(player, order, workers, stockpile, treasury);
+      if (!check.canAfford) continue;
+
+      final after = applyBuildCostDeduction(
+        player,
+        order,
+        workers,
+        stockpile,
+        treasury,
+      );
+      workers = after.workers;
+      stockpile = after.stockpile;
+      treasury = after.treasury;
+
+      if (category == BuildUnitCategory.naval) {
+        naval.spawnHomeFleetShipIfEligible(player, order);
+        continue;
+      }
+
+      final spawnProvinceId = resolveBuildSpawnProvinceId(
+        player: player,
+        worldState: state.game.worldState,
+        order: order,
+      );
+      if (spawnProvinceId == null) continue;
+      final regionId = ProvinceId.regionIdFrom(spawnProvinceId);
+      final civilianTileKey = _CivilianBuildState.spawnTileKeyForCategory(
+        category: category,
+        player: player,
+        game: state.game,
+      );
+      if (category == BuildUnitCategory.civilian && civilianTileKey == null) {
+        throw StateError(
+          '$kCivilianCapitalTileMissingReason: player=${player.id}',
+        );
+      }
+
+      final newUnit = Unit(
+        id: _buildUnitId(player.id, order, spawnProvinceId),
+        type: order.unitType,
+        ownerId: player.id,
+        locationProvinceId: spawnProvinceId,
+        tileKey: category == BuildUnitCategory.civilian
+            ? civilianTileKey
+            : null,
+      );
+
+      if (regionId == kRegionNewWorld) {
+        state.work.newUnitsById[newUnit.id] = newUnit;
+      } else {
+        state.work.oldUnitsById[newUnit.id] = newUnit;
+      }
+
+      if (category == BuildUnitCategory.military) {
+        _MilitaryBuildState.appendRegimentToArmy(
+          state,
+          player,
+          spawnProvinceId,
+          newUnit.id,
+        );
+      }
+    }
+
+    // Apply build-phase deductions to this player so _runWorkPhase sees updated state.
+    state.game = state.game.copyWith(
+      players: state.game.players
+          .map(
+            (p) => p.id == player.id
+                ? p.copyWith(
+                    stockpile: stockpile,
+                    workerPool: workers,
+                    treasury: treasury,
+                  )
+                : p,
+          )
+          .toList(),
+    );
+  }
+}

--- a/packages/colonizethis_logic/lib/src/orders/orders_application_completed_work.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_completed_work.dart
@@ -120,8 +120,11 @@ void _completedWorkBuildImprovement(
   void Function(List<Province>) setProvinces,
   void Function(_BuildWorkState, Unit, String) applyExploreCompletion,
 ) {
-  final level = s.tileState.improvementLevel(cw.tileKey);
-  s.tileState = s.tileState.setImprovement(cw.tileKey, (level + 1).clamp(0, 4));
+  final level = s.work.tileState.improvementLevel(cw.tileKey);
+  s.work.tileState = s.work.tileState.setImprovement(
+    cw.tileKey,
+    (level + 1).clamp(0, 4),
+  );
 }
 
 void _completedWorkUpgradeTown(
@@ -164,12 +167,12 @@ void _completedWorkBuildRoad(
   void Function(List<Province>) setProvinces,
   void Function(_BuildWorkState, Unit, String) applyExploreCompletion,
 ) {
-  final roadLevel = s.tileState.roadLevel(cw.tileKey);
+  final roadLevel = s.work.tileState.roadLevel(cw.tileKey);
   final player = s.game.playerById(u.ownerId);
   final hasRoadConstruction =
       player?.techUnlocked?['road_construction'] == true;
   final nextLevel = (roadLevel + 1).clamp(0, hasRoadConstruction ? 2 : 1);
-  s.tileState = s.tileState.setRoadLevel(cw.tileKey, nextLevel);
+  s.work.tileState = s.work.tileState.setRoadLevel(cw.tileKey, nextLevel);
 
   final tileMap = s.tileMapByRegion;
   if (tileMap != null) {
@@ -179,8 +182,8 @@ void _completedWorkBuildRoad(
       player: player,
       worldState: s.game.worldState,
       tileMapByRegion: tileMap,
-      tileState: s.tileState,
-      setTileState: (newTileState) => s.tileState = newTileState,
+      tileState: s.work.tileState,
+      setTileState: (newTileState) => s.work.tileState = newTileState,
     );
   }
 }
@@ -210,8 +213,8 @@ void _completedWorkBuildPort(
     regionId: regionIdFromTile,
   );
   if (seaZoneId != null) {
-    s.portsByProvinceSeaboard['$fullProvinceId|$seaZoneId'] = cw.tileKey;
-    s.tileState = s.tileState.setRoadLevel(cw.tileKey, 4);
+    s.work.portsByProvinceSeaboard['$fullProvinceId|$seaZoneId'] = cw.tileKey;
+    s.work.tileState = s.work.tileState.setRoadLevel(cw.tileKey, 4);
   }
 }
 
@@ -259,7 +262,7 @@ void _completedWorkBuildRail(
   void Function(_BuildWorkState, Unit, String) applyExploreCompletion,
 ) {
   final player = s.game.playerById(u.ownerId);
-  final roadLevel = s.tileState.roadLevel(cw.tileKey);
+  final roadLevel = s.work.tileState.roadLevel(cw.tileKey);
   final terrain = terrainTypeForTileKey(s.tileMapByRegion, cw.tileKey);
   final reason = rejectionReasonForBuildRailOrder(
     techUnlocked: player?.techUnlocked,
@@ -267,7 +270,7 @@ void _completedWorkBuildRail(
     terrain: terrain,
   );
   if (reason == null) {
-    s.tileState = s.tileState.setRoadLevel(cw.tileKey, 4);
+    s.work.tileState = s.work.tileState.setRoadLevel(cw.tileKey, 4);
   } else {
     _log.d('build_rail completion skipped unit=${u.id} reason=$reason');
   }

--- a/packages/colonizethis_logic/lib/src/orders/orders_application_work_phase.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_work_phase.dart
@@ -13,10 +13,10 @@ void _runWorkPhase(
   applyCompletedWorkTarget,
 ) {
   final workOrders = state.workOrders;
-  final tileState = state.tileState;
-  final oldUnitsById = state.oldUnitsById;
-  final newUnitsById = state.newUnitsById;
-  final purchasedTilesByTileKey = state.purchasedTilesByTileKey;
+  final tileState = state.work.tileState;
+  final oldUnitsById = state.work.oldUnitsById;
+  final newUnitsById = state.work.newUnitsById;
+  final purchasedTilesByTileKey = state.work.purchasedTilesByTileKey;
 
   for (final player in state.game.players) {
     var stockpile = player.stockpile;
@@ -387,7 +387,7 @@ void _runWorkPhase(
       }
     }
 
-    state.updatedPlayers.add(
+    state.work.updatedPlayers.add(
       player.copyWith(
         stockpile: stockpile,
         workerPool: workers,


### PR DESCRIPTION
## Summary

Implements the refactor described in the issue: separate work-phase mutable state from session context, and isolate naval / civilian / military build responsibilities.

## Changes

- **`_WorkOrderState`** (WorkState): holds unit maps, `tileState`, visibility, ports, purchased tiles, province lists, and `updatedPlayers` — everything mutated during work processing and completion.
- **`_BuildWorkState`**: game, build/work order maps, topology, tile maps, dialogue callback, and a single `work` reference.
- **`orders_application_build_phase.dart`**: `_runBuildPhase` plus `_NavalBuildState`, `_CivilianBuildState`, `_MilitaryBuildState` for category-specific build logic.

Behavior is unchanged; existing tests exercise the same paths.

## Tests

`cd packages/colonizethis_logic && dart test` (pass).

Refs #1618

Made with [Cursor](https://cursor.com)