### PR TITLE
Tech descriptions batch 2: gathering SPEC and tech tree dialog (Refs #1626)

### DIFF
--- a/SPEC/game/tech-tree-gathering.md
+++ b/SPEC/game/tech-tree-gathering.md
@@ -24,16 +24,16 @@ The **gathering table below is the GDD source of truth** for ids, effects, and p
 | wind_saw_mill | Wind Saw Mill | 2 | saw_mill | Improves: timber extraction cap to **3**. Unlocks: prerequisite for `circular_saw`. |
 | seed_drill | Seed Drill | 2 | land_enclosure | Improves: grain extraction cap to **3**. Unlocks: prerequisite for `moldboard_plow`. |
 | sheep_ranching | Sheep Ranching | 2 | crop_rotation | Improves: wool extraction cap to **2**. Unlocks: prerequisite for `scientific_sheep_breeding`. |
-| animal_husbandry | Animal Husbandry | 2 | crop_rotation | Meat 3 |
-| square_set_timbering | Square-set Timbering | 2 | coal_mining | Coal 2 |
-| steam_in_mining | Steam in Mining | 2 | iron_mining | Iron 3 |
-| large_coal_mines | Large Coal Mines | 2 | square_set_timbering, steam_in_mining | Coal 3 |
-| large_copper_and_tin_mines | Large Copper and Tin Mines | 2 | copper_and_tin_mining | Copper/tin 3 |
-| circular_saw | Circular Saw | 3 | wind_saw_mill, university | Timber 4 |
-| scientific_sheep_breeding | Scientific Sheep Breeding | 3 | sheep_ranching, university | Wool 3 |
-| scientific_cattle_breeding | Scientific Cattle Breeding | 3 | animal_husbandry, university | Meat 4 |
-| moldboard_plow | Moldboard Plow | 3 | seed_drill | Grain 4 |
-| safety_lamp | Safety Lamp | 4 | large_coal_mines, dynamite | Coal 4 |
+| animal_husbandry | Animal Husbandry | 2 | crop_rotation | Improves: meat extraction cap to **3**. Unlocks: prerequisite for `scientific_cattle_breeding` (with University). Enables: satisfies military prerequisites that reference this tech (for example Improved Cavalry Tactics and Horse Artillery). |
+| square_set_timbering | Square-set Timbering | 2 | coal_mining | Improves: coal extraction cap to **2**. Unlocks: prerequisite for `large_coal_mines` together with `steam_in_mining`. Enables: satisfies transport and military prerequisites (for example Early Steam Engine and Crucible Process). |
+| steam_in_mining | Steam in Mining | 2 | iron_mining | Improves: iron extraction cap to **3**. Unlocks: prerequisite for `large_coal_mines` together with `square_set_timbering`; prerequisite for `industrial_iron_mining`, `early_steam_engine`, `crucible_process`, and `industrial_machinery`. |
+| large_coal_mines | Large Coal Mines | 2 | square_set_timbering, steam_in_mining | Improves: coal extraction cap to **3**. Unlocks: prerequisite for `safety_lamp` (with Dynamite) and `efficient_extraction_of_copper_and_tin`. |
+| large_copper_and_tin_mines | Large Copper and Tin Mines | 2 | copper_and_tin_mining | Improves: copper/tin extraction cap to **3**. Unlocks: prerequisite for `efficient_extraction_of_copper_and_tin` (with Large Coal Mines) and `ship_of_the_line` (with Large Hulls). |
+| circular_saw | Circular Saw | 3 | wind_saw_mill, university | Improves: timber extraction cap to **4**. Unlocks: prerequisite for `clipper_ships` (with Advanced Hull Design). |
+| scientific_sheep_breeding | Scientific Sheep Breeding | 3 | sheep_ranching, university | Improves: wool extraction cap to **3** (raises cap from Sheep Ranching **2**). No other tech in the MVP catalog lists this id as a prerequisite. |
+| scientific_cattle_breeding | Scientific Cattle Breeding | 3 | animal_husbandry, university | Improves: meat extraction cap to **4** (raises cap from Animal Husbandry **3**). No other tech in the MVP catalog lists this id as a prerequisite. |
+| moldboard_plow | Moldboard Plow | 3 | seed_drill | Improves: grain extraction cap to **4** (raises cap from Seed Drill **3**). No other tech in the MVP catalog lists this id as a prerequisite. |
+| safety_lamp | Safety Lamp | 4 | large_coal_mines, dynamite | Improves: coal extraction cap to **4** (raises cap from Large Coal Mines **3**). No other tech in the MVP catalog lists this id as a prerequisite. |
 | large_precious_stone_mines | Large Precious Stone Mines | 3 | precious_stone_mining, university | Gems/diamonds 3 |
 | extraction_of_precious_metals | Extraction of Precious Metals | 3 | precious_metals_mining, university | Gold/silver 3 |
 | geological_prospecting | Geological Prospecting | 4 | large_precious_stone_mines, dynamite | Gems/diamonds 4 |
@@ -55,6 +55,10 @@ The **gathering table below is the GDD source of truth** for ids, effects, and p
 - Given the `crop_rotation`, `saw_mill`, `land_enclosure`, `mine_engineering`, `iron_mining`, `copper_and_tin_mining`, `coal_mining`, `wind_saw_mill`, `seed_drill`, and `sheep_ranching` rows in this tech table  
   When the System or UI layer renders their design descriptions from SPEC-authorized wording  
   Then each row includes at least one fixed-field phrase (`Unlocks:`, `Improves:`, `Enables:`, or `Prerequisite-only:`), names concrete mechanics or explicit unlock targets, and does not use generic fallback wording.
+
+- Given the `animal_husbandry`, `square_set_timbering`, `steam_in_mining`, `large_coal_mines`, `large_copper_and_tin_mines`, `circular_saw`, `scientific_sheep_breeding`, `scientific_cattle_breeding`, `moldboard_plow`, and `safety_lamp` rows in this tech table  
+  When the System or UI layer renders their design descriptions from SPEC-authorized wording  
+  Then each row includes at least one fixed-field phrase (`Unlocks:`, `Improves:`, `Enables:`, or `Prerequisite-only:`), states extraction caps with explicit numeric levels where applicable, names concrete unlock targets or explicitly states that the MVP catalog has no dependent techs, and does not use generic fallback wording.
 
 - **Table:** Each row has a unique id; prerequisite ids reference techs defined in this doc or other category docs.
 - **Extraction cap:** In the full model, per-resource cap is derived from unlocked gathering techs (max level per resource from the table). MVP uses a single scalar cap; see [tech-and-extraction-cap.md](tech-and-extraction-cap.md).

--- a/app/lib/features/game/widgets/tech_tree_widget.dart
+++ b/app/lib/features/game/widgets/tech_tree_widget.dart
@@ -443,6 +443,55 @@ class TechTreeWidget extends StatelessWidget {
         list.add('Improves: Wool extraction cap to 2');
         list.add('Unlocks: Scientific Sheep Breeding');
         break;
+      case 'animal_husbandry':
+        list.add('Improves: Meat extraction cap to 3');
+        list.add('Unlocks: Scientific Cattle Breeding (with University)');
+        list.add('Enables: Military branches that require this tech');
+        break;
+      case 'square_set_timbering':
+        list.add('Improves: Coal extraction cap to 2');
+        list.add('Unlocks: Large Coal Mines (requires Steam in Mining)');
+        list.add('Prerequisite for: Early Steam Engine and Crucible Process');
+        break;
+      case 'steam_in_mining':
+        list.add('Improves: Iron extraction cap to 3');
+        list.add('Unlocks: Large Coal Mines (with Square-set Timbering)');
+        list.add(
+          'Prerequisite for: Industrial Iron Mining, Early Steam Engine, Crucible Process, Industrial Machinery',
+        );
+        break;
+      case 'large_coal_mines':
+        list.add('Improves: Coal extraction cap to 3');
+        list.add('Unlocks: Safety Lamp (with Dynamite)');
+        list.add('Unlocks: Efficient Extraction of Copper & Tin');
+        break;
+      case 'large_copper_and_tin_mines':
+        list.add('Improves: Copper/Tin extraction cap to 3');
+        list.add(
+          'Unlocks: Efficient Extraction of Copper & Tin (with Large Coal Mines)',
+        );
+        list.add('Prerequisite for: Ship of the Line');
+        break;
+      case 'circular_saw':
+        list.add('Improves: Timber extraction cap to 4');
+        list.add('Unlocks: Clipper Ships (with Advanced Hull Design)');
+        break;
+      case 'scientific_sheep_breeding':
+        list.add('Improves: Wool extraction cap to 3');
+        list.add('Terminal in MVP catalog: no other tech requires this');
+        break;
+      case 'scientific_cattle_breeding':
+        list.add('Improves: Meat extraction cap to 4');
+        list.add('Terminal in MVP catalog: no other tech requires this');
+        break;
+      case 'moldboard_plow':
+        list.add('Improves: Grain extraction cap to 4');
+        list.add('Terminal in MVP catalog: no other tech requires this');
+        break;
+      case 'safety_lamp':
+        list.add('Improves: Coal extraction cap to 4');
+        list.add('Terminal in MVP catalog: no other tech requires this');
+        break;
       case 'hat_production':
         list.add('Improves: Enables fur hats luxury production');
         break;

--- a/app/test/tech_tree_widget_test.dart
+++ b/app/test/tech_tree_widget_test.dart
@@ -490,6 +490,62 @@ void main() {
     },
   );
 
+  testWidgets(
+    'Batch-2 tech descriptions are concrete and avoid generic fallback text (Refs #1626)',
+    (WidgetTester tester) async {
+      final emptyPlayer = player.copyWith(techUnlocked: <String, bool>{});
+      final gameWithEmptyPlayer = game.copyWith(
+        players: [emptyPlayer, ...game.players.skip(1)],
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TechTreeWidget(
+              game: gameWithEmptyPlayer,
+              player: emptyPlayer,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final expectedByTech = <String, String>{
+        'Animal Husbandry': 'Improves: Meat extraction cap to 3',
+        'Square-set Timbering': 'Improves: Coal extraction cap to 2',
+        'Steam in Mining': 'Improves: Iron extraction cap to 3',
+        'Large Coal Mines': 'Improves: Coal extraction cap to 3',
+        'Large Copper and Tin Mines':
+            'Improves: Copper/Tin extraction cap to 3',
+        'Circular Saw': 'Improves: Timber extraction cap to 4',
+        'Scientific Sheep Breeding': 'Improves: Wool extraction cap to 3',
+        'Scientific Cattle Breeding': 'Improves: Meat extraction cap to 4',
+        'Moldboard Plow': 'Improves: Grain extraction cap to 4',
+        'Safety Lamp': 'Improves: Coal extraction cap to 4',
+      };
+
+      for (final entry in expectedByTech.entries) {
+        final techNode = find.text(entry.key).first;
+        await tester.ensureVisible(techNode);
+        await tester.tap(techNode);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CtDialogShell), findsOneWidget);
+        expect(find.textContaining(entry.value), findsOneWidget);
+        expect(
+          find.textContaining('Improves gathering capabilities'),
+          findsNothing,
+        );
+        expect(
+          find.textContaining('Improves labour and economy output'),
+          findsNothing,
+        );
+
+        await tester.tap(find.text('Close'));
+        await tester.pumpAndSettle();
+      }
+    },
+  );
+
   test(
     'Column rule: A→B→C and A→C places B between A and C (gap between A and C)',
     () {


### PR DESCRIPTION
## Summary
Implements GitHub issue #1626 (batch 2 of the tech description epic): fixed-field, concrete wording for the ten gathering techs listed in the issue.

## SPEC
- Updated `SPEC/game/tech-tree-gathering.md` effects column and acceptance criteria for the batch-2 ids (extraction caps, unlock targets, terminal-tech note where the MVP catalog has no dependents).

## UI
- Extended `TechTreeWidget._effectSummary` in `app/lib/features/game/widgets/tech_tree_widget.dart` so each batch-2 tech shows concrete benefits in the description dialog.

## Tests
- Added `Batch-2 tech descriptions are concrete...` widget test in `app/test/tech_tree_widget_test.dart` (mirrors batch-1 pattern; fails on generic gathering fallback text).

## Commands run
- `flutter test test/tech_tree_widget_test.dart`
- `dart analyze lib/features/game/widgets/tech_tree_widget.dart`

Refs #1626

Made with [Cursor](https://cursor.com)