### PR TITLE
Tech descriptions batch 3 (gathering + New World sugar)

### DIFF
--- a/SPEC/game/tech-tree-gathering.md
+++ b/SPEC/game/tech-tree-gathering.md
@@ -34,12 +34,12 @@ The **gathering table below is the GDD source of truth** for ids, effects, and p
 | scientific_cattle_breeding | Scientific Cattle Breeding | 3 | animal_husbandry, university | Meat 4 |
 | moldboard_plow | Moldboard Plow | 3 | seed_drill | Grain 4 |
 | safety_lamp | Safety Lamp | 4 | large_coal_mines, dynamite | Coal 4 |
-| large_precious_stone_mines | Large Precious Stone Mines | 3 | precious_stone_mining, university | Gems/diamonds 3 |
-| extraction_of_precious_metals | Extraction of Precious Metals | 3 | precious_metals_mining, university | Gold/silver 3 |
-| geological_prospecting | Geological Prospecting | 4 | large_precious_stone_mines, dynamite | Gems/diamonds 4 |
-| amalgamation_process | Amalgamation Process | 4 | dynamite, extraction_of_precious_metals | Gold/silver 4 |
-| industrial_iron_mining | Industrial Iron Mining | 4 | industrial_funding_of_research, steam_in_mining | Iron 4 |
-| efficient_extraction_of_copper_and_tin | Efficient Extraction of Copper & Tin | 4 | large_coal_mines, large_copper_and_tin_mines | Copper/tin 4 |
+| large_precious_stone_mines | Large Precious Stone Mines | 3 | precious_stone_mining, university | Improves: gems/diamonds extraction cap to **3**. Unlocks: prerequisite for `geological_prospecting` (with Dynamite) and `modern_military_funding` (with Banking and Modern Forts). |
+| extraction_of_precious_metals | Extraction of Precious Metals | 3 | precious_metals_mining, university | Improves: gold/silver extraction cap to **3**. Unlocks: prerequisite for `amalgamation_process` (with Dynamite). |
+| geological_prospecting | Geological Prospecting | 4 | large_precious_stone_mines, dynamite | Improves: gems/diamonds extraction cap to **4**. Prerequisite-only in MVP catalog: no other tech lists this id as a prerequisite; cap increase is the active benefit. |
+| amalgamation_process | Amalgamation Process | 4 | dynamite, extraction_of_precious_metals | Improves: gold/silver extraction cap to **4**. Prerequisite-only in MVP catalog: no other tech lists this id as a prerequisite; cap increase is the active benefit. |
+| industrial_iron_mining | Industrial Iron Mining | 4 | industrial_funding_of_research, steam_in_mining | Improves: iron extraction cap to **4**. Prerequisite-only in MVP catalog: no other tech lists this id as a prerequisite; cap increase is the active benefit. |
+| efficient_extraction_of_copper_and_tin | Efficient Extraction of Copper & Tin | 4 | large_coal_mines, large_copper_and_tin_mines | Improves: copper/tin extraction cap to **4**. Prerequisite-only in MVP catalog: no other tech lists this id as a prerequisite; cap increase is the active benefit. |
 
 ---
 
@@ -55,6 +55,10 @@ The **gathering table below is the GDD source of truth** for ids, effects, and p
 - Given the `crop_rotation`, `saw_mill`, `land_enclosure`, `mine_engineering`, `iron_mining`, `copper_and_tin_mining`, `coal_mining`, `wind_saw_mill`, `seed_drill`, and `sheep_ranching` rows in this tech table  
   When the System or UI layer renders their design descriptions from SPEC-authorized wording  
   Then each row includes at least one fixed-field phrase (`Unlocks:`, `Improves:`, `Enables:`, or `Prerequisite-only:`), names concrete mechanics or explicit unlock targets, and does not use generic fallback wording.
+
+- Given the `large_precious_stone_mines`, `extraction_of_precious_metals`, `geological_prospecting`, `amalgamation_process`, `industrial_iron_mining`, and `efficient_extraction_of_copper_and_tin` rows in this tech table  
+  When the System or UI layer renders their design descriptions from SPEC-authorized wording  
+  Then each row includes at least one fixed-field phrase (`Unlocks:`, `Improves:`, `Enables:`, or `Prerequisite-only:`), states extraction caps with explicit numeric levels where applicable, names concrete unlock targets or explicitly states that the MVP catalog has no dependent techs, and does not use generic fallback wording.
 
 - **Table:** Each row has a unique id; prerequisite ids reference techs defined in this doc or other category docs.
 - **Extraction cap:** In the full model, per-resource cap is derived from unlocked gathering techs (max level per resource from the table). MVP uses a single scalar cap; see [tech-and-extraction-cap.md](tech-and-extraction-cap.md).

--- a/SPEC/game/tech-tree-new-world.md
+++ b/SPEC/game/tech-tree-new-world.md
@@ -8,10 +8,10 @@
 
 | id | name | era | prerequisites | effects |
 |----|------|-----|---------------|--------|
-| discovery_of_sugar | Discovery of Sugar | 1 | (Explorer finds sugar) | Sugar plantations; sugar refining |
-| sugar_planting | Sugar Planting | 1 | discovery_of_sugar | Sugar 2 |
-| sugar_refining | Sugar Refining | 1 | discovery_of_sugar | Refined sugar (apprentice luxury) |
-| large_sugar_plantations | Large Sugar Plantations | 2 | sugar_planting | Sugar 3 |
+| discovery_of_sugar | Discovery of Sugar | 1 | (Explorer finds sugar) | Enables: researchable only when the player has revealed sugar cane per the discovery rule in this doc. Unlocks: `sugar_planting` and `sugar_refining`. |
+| sugar_planting | Sugar Planting | 1 | discovery_of_sugar | Improves: sugar cane extraction cap to **2**. Unlocks: prerequisite for `large_sugar_plantations`. |
+| sugar_refining | Sugar Refining | 1 | discovery_of_sugar | Enables: refined sugar luxury production consumed by Apprentice-tier workers per [workers-and-population.md](workers-and-population.md). Unlocks: prerequisite for `apprentice_workers` (with Land Enclosure) and `trade_fairs` (with Merchant Companies). |
+| large_sugar_plantations | Large Sugar Plantations | 2 | sugar_planting | Improves: sugar cane extraction cap to **3**. Unlocks: prerequisite for `sugar_industry`. |
 | sugar_industry | Sugar Industry | 3 | large_sugar_plantations | Sugar 4 |
 | discovery_of_tobacco | Discovery of Tobacco | 1 | (Explorer finds tobacco) | Tobacco plantations |
 | tobacco_planting | Tobacco Planting | 1 | discovery_of_tobacco | Tobacco 2 |
@@ -66,3 +66,7 @@ A tech whose prerequisite is "(Explorer finds X)" is researchable **only if** th
 - Given a player has unlocked `sugar_refining`, `cigar_production`, or `hat_production` as listed in this table  
   When the System computes which luxuries can be consumed by Apprentices, Journeymen, and Masters during the Consumption phase per [workers-and-population.md](workers-and-population.md)  
   Then the System allows the corresponding luxury commodities (refined sugar, cigars, fur hats) to be produced via recipes and consumed by the appropriate worker tiers, and does not allow those luxuries to be consumed before the relevant tech has been unlocked.
+
+- Given the `discovery_of_sugar`, `sugar_planting`, `sugar_refining`, and `large_sugar_plantations` rows in this tech table  
+  When the System or UI layer renders their design descriptions from SPEC-authorized wording  
+  Then each row includes at least one fixed-field phrase (`Unlocks:`, `Improves:`, `Enables:`, or `Prerequisite-only:`), names concrete mechanics (extraction caps, discovery gating, luxury consumption, or explicit unlock targets), and does not use generic fallback wording.

--- a/app/lib/features/game/widgets/tech_tree_widget.dart
+++ b/app/lib/features/game/widgets/tech_tree_widget.dart
@@ -443,6 +443,62 @@ class TechTreeWidget extends StatelessWidget {
         list.add('Improves: Wool extraction cap to 2');
         list.add('Unlocks: Scientific Sheep Breeding');
         break;
+      case 'large_precious_stone_mines':
+        list.add('Improves: Gems/diamonds extraction cap to 3');
+        list.add(
+          'Unlocks: Geological Prospecting (with Dynamite); Modern Military Funding (with Banking and Modern Forts)',
+        );
+        break;
+      case 'extraction_of_precious_metals':
+        list.add('Improves: Gold/silver extraction cap to 3');
+        list.add('Unlocks: Amalgamation Process (with Dynamite)');
+        break;
+      case 'geological_prospecting':
+        list.add('Improves: Gems/diamonds extraction cap to 4');
+        list.add(
+          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+        );
+        break;
+      case 'amalgamation_process':
+        list.add('Improves: Gold/silver extraction cap to 4');
+        list.add(
+          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+        );
+        break;
+      case 'industrial_iron_mining':
+        list.add('Improves: Iron extraction cap to 4');
+        list.add(
+          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+        );
+        break;
+      case 'efficient_extraction_of_copper_and_tin':
+        list.add('Improves: Copper/Tin extraction cap to 4');
+        list.add(
+          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+        );
+        break;
+      case 'discovery_of_sugar':
+        list.add(
+          'Enables: Research when player has revealed sugar cane (discovery rule)',
+        );
+        list.add('Unlocks: Sugar Planting and Sugar Refining');
+        break;
+      case 'sugar_planting':
+        list.add('Improves: Sugar cane extraction cap to 2');
+        list.add('Unlocks: Large Sugar Plantations');
+        break;
+      case 'sugar_refining':
+        list.add(
+          'Enables: Refined sugar luxury for Apprentice-tier worker consumption',
+        );
+        list.add(
+          'Unlocks: Apprentice Workers (with Land Enclosure); Trade Fairs (with Merchant Companies)',
+        );
+        break;
+      case 'large_sugar_plantations':
+        list.add('Improves: Sugar cane extraction cap to 3');
+        list.add('Unlocks: Sugar Industry');
+        break;
       case 'hat_production':
         list.add('Improves: Enables fur hats luxury production');
         break;

--- a/app/test/tech_tree_widget_test.dart
+++ b/app/test/tech_tree_widget_test.dart
@@ -490,6 +490,70 @@ void main() {
     },
   );
 
+  testWidgets(
+    'Batch-3 tech descriptions are concrete and avoid generic fallback text (Refs #1627)',
+    (WidgetTester tester) async {
+      final emptyPlayer = player.copyWith(techUnlocked: <String, bool>{});
+      final gameWithEmptyPlayer = game.copyWith(
+        players: [emptyPlayer, ...game.players.skip(1)],
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TechTreeWidget(
+              game: gameWithEmptyPlayer,
+              player: emptyPlayer,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final expectedByTech = <String, String>{
+        'Large Precious Stone Mines':
+            'Improves: Gems/diamonds extraction cap to 3',
+        'Extraction of Precious Metals':
+            'Improves: Gold/silver extraction cap to 3',
+        'Geological Prospecting': 'Improves: Gems/diamonds extraction cap to 4',
+        'Amalgamation Process': 'Improves: Gold/silver extraction cap to 4',
+        'Industrial Iron Mining': 'Improves: Iron extraction cap to 4',
+        'Efficient Extraction of Copper & Tin':
+            'Improves: Copper/Tin extraction cap to 4',
+        'Discovery of Sugar':
+            'Enables: Research when player has revealed sugar cane (discovery rule)',
+        'Sugar Planting': 'Improves: Sugar cane extraction cap to 2',
+        'Sugar Refining':
+            'Enables: Refined sugar luxury for Apprentice-tier worker consumption',
+        'Large Sugar Plantations': 'Improves: Sugar cane extraction cap to 3',
+      };
+
+      for (final entry in expectedByTech.entries) {
+        final techNode = find.text(entry.key).first;
+        await tester.ensureVisible(techNode);
+        await tester.tap(techNode);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CtDialogShell), findsOneWidget);
+        expect(find.textContaining(entry.value), findsOneWidget);
+        expect(
+          find.textContaining('Improves gathering capabilities'),
+          findsNothing,
+        );
+        expect(
+          find.textContaining('Improves labour and economy output'),
+          findsNothing,
+        );
+        expect(
+          find.textContaining('Improves new-world capabilities'),
+          findsNothing,
+        );
+
+        await tester.tap(find.text('Close'));
+        await tester.pumpAndSettle();
+      }
+    },
+  );
+
   test(
     'Column rule: A→B→C and A→C places B between A and C (gap between A and C)',
     () {


### PR DESCRIPTION
## Summary
Implements [issue #1627](https://github.com/waigore/colonizethisv3/issues/1627): fixed-field, concrete tech descriptions for the listed batch (precious stones/metals chain, industrial iron, efficient copper/tin, and the sugar chain).

## SPEC
- `SPEC/game/tech-tree-gathering.md`: rows for `large_precious_stone_mines`, `extraction_of_precious_metals`, `geological_prospecting`, `amalgamation_process`, `industrial_iron_mining`, `efficient_extraction_of_copper_and_tin`; added acceptance criterion for this subset.
- `SPEC/game/tech-tree-new-world.md`: rows for `discovery_of_sugar`, `sugar_planting`, `sugar_refining`, `large_sugar_plantations`; added acceptance criterion for this subset.

## Implementation
- `app/lib/features/game/widgets/tech_tree_widget.dart`: `_effectSummary` entries for all ten tech ids (aligned with SPEC).

## Tests
- `app/test/tech_tree_widget_test.dart`: batch-3 widget test; asserts expected effect lines and rejects generic category fallbacks (including New World).

**Commands run:** `dart format` on touched Dart files; `flutter test test/tech_tree_widget_test.dart` (all passed).

Refs #1627

Made with [Cursor](https://cursor.com)