### PR TITLE
fix tech descriptions for New World batches 4 and 5

### DIFF
--- a/SPEC/game/tech-tree-new-world.md
+++ b/SPEC/game/tech-tree-new-world.md
@@ -12,26 +12,26 @@
 | sugar_planting | Sugar Planting | 1 | discovery_of_sugar | Improves: sugar cane extraction cap to **2**. Unlocks: prerequisite for `large_sugar_plantations`. |
 | sugar_refining | Sugar Refining | 1 | discovery_of_sugar | Enables: refined sugar luxury production consumed by Apprentice-tier workers per [workers-and-population.md](workers-and-population.md). Unlocks: prerequisite for `apprentice_workers` (with Land Enclosure) and `trade_fairs` (with Merchant Companies). |
 | large_sugar_plantations | Large Sugar Plantations | 2 | sugar_planting | Improves: sugar cane extraction cap to **3**. Unlocks: prerequisite for `sugar_industry`. |
-| sugar_industry | Sugar Industry | 3 | large_sugar_plantations | Sugar 4 |
-| discovery_of_tobacco | Discovery of Tobacco | 1 | (Explorer finds tobacco) | Tobacco plantations |
-| tobacco_planting | Tobacco Planting | 1 | discovery_of_tobacco | Tobacco 2 |
-| cigar_production | Cigar Production | 1 | discovery_of_tobacco | Cigars (journeyman luxury) |
-| large_tobacco_plantations | Large Tobacco Plantations | 2 | tobacco_planting, seed_drill | Tobacco 3 |
-| tobacco_industry | Tobacco Industry | 3 | early_steam_engine, large_tobacco_plantations | Tobacco 4 |
-| discovery_of_cotton | Discovery of Cotton | 1 | (Explorer finds cotton) | Cotton plantations |
-| cotton_planting | Cotton Planting | 1 | discovery_of_cotton | Cotton 2 |
-| cotton_weaving | Cotton Weaving | 1 | discovery_of_cotton | Fabric from cotton |
-| large_cotton_plantations | Large Cotton Plantations | 2 | cotton_planting | Cotton 3 |
-| cotton_gin | Cotton Gin | 3 | large_cotton_plantations, trained_journeymen | Cotton 4 |
-| discovery_of_furs | Discovery of Furs | 1 | (Explorer finds furs) | Fur trapping |
-| improved_trapping_techniques | Improved Trapping Techniques | 1 | discovery_of_furs | Furs 2 |
-| hat_production | Hat Production | 1 | discovery_of_furs | Fur hats (master artisan luxury) |
-| riverboats | Riverboats | 3 | improved_trapping_techniques, early_steam_engine | Furs 3 (trapper camps) |
-| excessive_fur_harvesting | Excessive Fur Harvesting | 4 | later_steam_engine, riverboats | Furs 4 |
-| discovery_of_spices | Discovery of Spices | 1 | (Explorer finds spices) | Spice orchards |
-| improved_sea_routes | Improved Sea Routes | 1 | discovery_of_spices | Spices from upgraded farms |
-| large_spice_plantations | Large Spice Plantations | 2 | seed_drill, improved_sea_routes | Spices 3 |
-| improved_food_preservation | Improved Food Preservation | 3 | large_spice_plantations | Spices 4 |
+| sugar_industry | Sugar Industry | 3 | large_sugar_plantations | Improves: sugar cane extraction cap to **4**. Prerequisite-only: no additional techs currently depend on this in the MVP catalog. |
+| discovery_of_tobacco | Discovery of Tobacco | 1 | (Explorer finds tobacco) | Enables: researchable only when the player has revealed tobacco per the discovery rule in this doc. Unlocks: `tobacco_planting` and `cigar_production`. |
+| tobacco_planting | Tobacco Planting | 1 | discovery_of_tobacco | Improves: tobacco extraction cap to **2**. Unlocks: prerequisite for `large_tobacco_plantations`. |
+| cigar_production | Cigar Production | 1 | discovery_of_tobacco | Enables: cigar luxury production consumed by Journeyman-tier workers per [workers-and-population.md](workers-and-population.md). Unlocks: prerequisite for `trained_journeymen`. |
+| large_tobacco_plantations | Large Tobacco Plantations | 2 | tobacco_planting, seed_drill | Improves: tobacco extraction cap to **3**. Unlocks: prerequisite for `tobacco_industry`. |
+| tobacco_industry | Tobacco Industry | 3 | early_steam_engine, large_tobacco_plantations | Improves: tobacco extraction cap to **4**. Prerequisite-only: no additional techs currently depend on this in the MVP catalog. |
+| discovery_of_cotton | Discovery of Cotton | 1 | (Explorer finds cotton) | Enables: researchable only when the player has revealed cotton per the discovery rule in this doc. Unlocks: `cotton_planting` and `cotton_weaving`. |
+| cotton_planting | Cotton Planting | 1 | discovery_of_cotton | Improves: cotton extraction cap to **2**. Unlocks: prerequisite for `large_cotton_plantations`. |
+| cotton_weaving | Cotton Weaving | 1 | discovery_of_cotton | Enables: cloth production from cotton via labour/industry recipes. Unlocks: prerequisite-only in MVP catalog (no direct downstream tech dependency yet). |
+| large_cotton_plantations | Large Cotton Plantations | 2 | cotton_planting | Improves: cotton extraction cap to **3**. Unlocks: prerequisite for `cotton_gin`. |
+| cotton_gin | Cotton Gin | 3 | large_cotton_plantations, trained_journeymen | Improves: cotton extraction cap to **4**. Prerequisite-only: no additional techs currently depend on this in the MVP catalog. |
+| discovery_of_furs | Discovery of Furs | 1 | (Explorer finds furs) | Enables: researchable only when the player has revealed furs per the discovery rule in this doc. Unlocks: `improved_trapping_techniques` and `hat_production`. |
+| improved_trapping_techniques | Improved Trapping Techniques | 1 | discovery_of_furs | Improves: furs extraction cap to **2**. Unlocks: prerequisite for `riverboats`. |
+| hat_production | Hat Production | 1 | discovery_of_furs | Enables: fur hats luxury production consumed by Master-tier workers per [workers-and-population.md](workers-and-population.md). Unlocks: prerequisite for `master_artisans`. |
+| riverboats | Riverboats | 3 | improved_trapping_techniques, early_steam_engine | Improves: furs extraction cap to **3**. Unlocks: prerequisite for `excessive_fur_harvesting` and `merchant_steamships`. |
+| excessive_fur_harvesting | Excessive Fur Harvesting | 4 | later_steam_engine, riverboats | Improves: furs extraction cap to **4**. Prerequisite-only: no additional techs currently depend on this in the MVP catalog. |
+| discovery_of_spices | Discovery of Spices | 1 | (Explorer finds spices) | Enables: researchable only when the player has revealed spices per the discovery rule in this doc. Unlocks: `improved_sea_routes`. |
+| improved_sea_routes | Improved Sea Routes | 1 | discovery_of_spices | Improves: spices extraction cap to **2**. Unlocks: prerequisite for `large_spice_plantations`. |
+| large_spice_plantations | Large Spice Plantations | 2 | seed_drill, improved_sea_routes | Improves: spices extraction cap to **3**. Unlocks: prerequisite for `improved_food_preservation`. |
+| improved_food_preservation | Improved Food Preservation | 3 | large_spice_plantations | Improves: spices extraction cap to **4**. Prerequisite-only: no additional techs currently depend on this in the MVP catalog. |
 | discovery_of_gold_or_silver | Discovery of Gold or Silver | 1 | (Explorer finds gold/silver) | Precious metal mines |
 | precious_metals_mining | Precious Metals Mining | 1 | discovery_of_gold_or_silver, mine_engineering | Gold/silver 2 |
 | discovery_of_gems_or_diamonds | Discovery of Gems or Diamonds | 1 | (Explorer finds gems/diamonds) | Precious stone mines |

--- a/app/lib/features/game/widgets/tech_tree_widget.dart
+++ b/app/lib/features/game/widgets/tech_tree_widget.dart
@@ -548,8 +548,111 @@ class TechTreeWidget extends StatelessWidget {
         list.add('Improves: Sugar cane extraction cap to 3');
         list.add('Unlocks: Sugar Industry');
         break;
+      case 'sugar_industry':
+        list.add('Improves: Sugar cane extraction cap to 4');
+        list.add(
+          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+        );
+        break;
+      case 'discovery_of_tobacco':
+        list.add(
+          'Enables: Research when player has revealed tobacco (discovery rule)',
+        );
+        list.add('Unlocks: Tobacco Planting and Cigar Production');
+        break;
+      case 'tobacco_planting':
+        list.add('Improves: Tobacco extraction cap to 2');
+        list.add('Unlocks: Large Tobacco Plantations');
+        break;
+      case 'cigar_production':
+        list.add(
+          'Enables: Cigar luxury production for Journeyman-tier worker consumption',
+        );
+        list.add('Unlocks: Trained Journeymen');
+        break;
+      case 'large_tobacco_plantations':
+        list.add('Improves: Tobacco extraction cap to 3');
+        list.add('Unlocks: Tobacco Industry');
+        break;
+      case 'tobacco_industry':
+        list.add('Improves: Tobacco extraction cap to 4');
+        list.add(
+          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+        );
+        break;
+      case 'discovery_of_cotton':
+        list.add(
+          'Enables: Research when player has revealed cotton (discovery rule)',
+        );
+        list.add('Unlocks: Cotton Planting and Cotton Weaving');
+        break;
+      case 'cotton_planting':
+        list.add('Improves: Cotton extraction cap to 2');
+        list.add('Unlocks: Large Cotton Plantations');
+        break;
+      case 'cotton_weaving':
+        list.add('Enables: Cloth production from cotton');
+        list.add(
+          'Prerequisite-only in MVP catalog: no other tech requires this; recipe unlock is the active benefit',
+        );
+        break;
+      case 'large_cotton_plantations':
+        list.add('Improves: Cotton extraction cap to 3');
+        list.add('Unlocks: Cotton Gin');
+        break;
+      case 'cotton_gin':
+        list.add('Improves: Cotton extraction cap to 4');
+        list.add(
+          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+        );
+        break;
+      case 'discovery_of_furs':
+        list.add(
+          'Enables: Research when player has revealed furs (discovery rule)',
+        );
+        list.add('Unlocks: Improved Trapping Techniques and Hat Production');
+        break;
+      case 'improved_trapping_techniques':
+        list.add('Improves: Furs extraction cap to 2');
+        list.add('Unlocks: Riverboats');
+        break;
       case 'hat_production':
-        list.add('Improves: Enables fur hats luxury production');
+        list.add(
+          'Enables: Fur hats luxury production for Master-tier worker consumption',
+        );
+        list.add('Unlocks: Master Artisans');
+        break;
+      case 'riverboats':
+        list.add('Improves: Furs extraction cap to 3');
+        list.add(
+          'Unlocks: Excessive Fur Harvesting and Merchant Steamships research paths',
+        );
+        break;
+      case 'excessive_fur_harvesting':
+        list.add('Improves: Furs extraction cap to 4');
+        list.add(
+          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+        );
+        break;
+      case 'discovery_of_spices':
+        list.add(
+          'Enables: Research when player has revealed spices (discovery rule)',
+        );
+        list.add('Unlocks: Improved Sea Routes');
+        break;
+      case 'improved_sea_routes':
+        list.add('Improves: Spices extraction cap to 2');
+        list.add('Unlocks: Large Spice Plantations');
+        break;
+      case 'large_spice_plantations':
+        list.add('Improves: Spices extraction cap to 3');
+        list.add('Unlocks: Improved Food Preservation');
+        break;
+      case 'improved_food_preservation':
+        list.add('Improves: Spices extraction cap to 4');
+        list.add(
+          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+        );
         break;
       default:
         if (list.isEmpty) {

--- a/app/test/tech_tree_widget_test.dart
+++ b/app/test/tech_tree_widget_test.dart
@@ -610,6 +610,130 @@ void main() {
     },
   );
 
+  testWidgets(
+    'Batch-4 tech descriptions are concrete and avoid generic fallback text (Refs #1628)',
+    (WidgetTester tester) async {
+      final emptyPlayer = player.copyWith(techUnlocked: <String, bool>{});
+      final gameWithEmptyPlayer = game.copyWith(
+        players: [emptyPlayer, ...game.players.skip(1)],
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TechTreeWidget(
+              game: gameWithEmptyPlayer,
+              player: emptyPlayer,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final expectedByTech = <String, String>{
+        'Sugar Industry': 'Improves: Sugar cane extraction cap to 4',
+        'Discovery of Tobacco':
+            'Enables: Research when player has revealed tobacco (discovery rule)',
+        'Tobacco Planting': 'Improves: Tobacco extraction cap to 2',
+        'Cigar Production':
+            'Enables: Cigar luxury production for Journeyman-tier worker consumption',
+        'Large Tobacco Plantations': 'Improves: Tobacco extraction cap to 3',
+        'Tobacco Industry': 'Improves: Tobacco extraction cap to 4',
+        'Discovery of Cotton':
+            'Enables: Research when player has revealed cotton (discovery rule)',
+        'Cotton Planting': 'Improves: Cotton extraction cap to 2',
+        'Cotton Weaving': 'Enables: Cloth production from cotton',
+        'Large Cotton Plantations': 'Improves: Cotton extraction cap to 3',
+      };
+
+      for (final entry in expectedByTech.entries) {
+        final techNode = find.text(entry.key).first;
+        await tester.ensureVisible(techNode);
+        await tester.tap(techNode);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CtDialogShell), findsOneWidget);
+        expect(find.textContaining(entry.value), findsOneWidget);
+        expect(
+          find.textContaining('Improves gathering capabilities'),
+          findsNothing,
+        );
+        expect(
+          find.textContaining('Improves labour and economy output'),
+          findsNothing,
+        );
+        expect(
+          find.textContaining('Improves new-world capabilities'),
+          findsNothing,
+        );
+
+        await tester.tap(find.text('Close'));
+        await tester.pumpAndSettle();
+      }
+    },
+  );
+
+  testWidgets(
+    'Batch-5 tech descriptions are concrete and avoid generic fallback text (Refs #1629)',
+    (WidgetTester tester) async {
+      final emptyPlayer = player.copyWith(techUnlocked: <String, bool>{});
+      final gameWithEmptyPlayer = game.copyWith(
+        players: [emptyPlayer, ...game.players.skip(1)],
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TechTreeWidget(
+              game: gameWithEmptyPlayer,
+              player: emptyPlayer,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final expectedByTech = <String, String>{
+        'Cotton Gin': 'Improves: Cotton extraction cap to 4',
+        'Discovery of Furs':
+            'Enables: Research when player has revealed furs (discovery rule)',
+        'Improved Trapping Techniques': 'Improves: Furs extraction cap to 2',
+        'Hat Production':
+            'Enables: Fur hats luxury production for Master-tier worker consumption',
+        'Riverboats': 'Improves: Furs extraction cap to 3',
+        'Excessive Fur Harvesting': 'Improves: Furs extraction cap to 4',
+        'Discovery of Spices':
+            'Enables: Research when player has revealed spices (discovery rule)',
+        'Improved Sea Routes': 'Improves: Spices extraction cap to 2',
+        'Large Spice Plantations': 'Improves: Spices extraction cap to 3',
+        'Improved Food Preservation': 'Improves: Spices extraction cap to 4',
+      };
+
+      for (final entry in expectedByTech.entries) {
+        final techNode = find.text(entry.key).first;
+        await tester.ensureVisible(techNode);
+        await tester.tap(techNode);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CtDialogShell), findsOneWidget);
+        expect(find.textContaining(entry.value), findsOneWidget);
+        expect(
+          find.textContaining('Improves gathering capabilities'),
+          findsNothing,
+        );
+        expect(
+          find.textContaining('Improves labour and economy output'),
+          findsNothing,
+        );
+        expect(
+          find.textContaining('Improves new-world capabilities'),
+          findsNothing,
+        );
+
+        await tester.tap(find.text('Close'));
+        await tester.pumpAndSettle();
+      }
+    },
+  );
+
   test(
     'Column rule: A→B→C and A→C places B between A and C (gap between A and C)',
     () {


### PR DESCRIPTION
## Summary
- Rewrite SPEC New World tech descriptions for issue batches #1628 and #1629 using fixed-field, concrete wording.
- Add explicit Tech Tree dialog effect summaries for all 20 batch techs to remove generic fallback text.
- Add widget regression tests for batch-4 and batch-5 tech descriptions.

## Scope
- In scope: tech ids from issue #1628 and #1629 only.
- Deferred: remaining epic #1624 batches.

## SPEC
- Updated `SPEC/game/tech-tree-new-world.md` table entries for the targeted tech ids.

## Test plan
- [x] `flutter test test/tech_tree_widget_test.dart`

Refs #1628
Refs #1629
Part of #1624

Made with [Cursor](https://cursor.com)