### PR TITLE
docs(tech-tree): make tech description batches 6 and 7 concrete

### DIFF
--- a/SPEC/game/tech-tree-diplomacy-civilian.md
+++ b/SPEC/game/tech-tree-diplomacy-civilian.md
@@ -14,10 +14,10 @@ The **diplomacy and civilian tech table in this doc is the GDD source of truth**
 
 | id | name | era | prerequisites | effects |
 |----|------|-----|---------------|--------|
-| diplomatic_expertise | Diplomatic Expertise | 1 | — | Offer embassies to Minor Nations; Merchants, Engineers, Builders may work there |
-| merchant_companies | Merchant Companies | 1 | — | Construct Merchant units; buy land in Minor Nations |
-| national_bureaucracy | National Bureaucracy | 2 | printing_press, money_lending, diplomatic_expertise | Builders may upgrade provincial towns; contributes to raising general cap to at least 3 per [military-generals.md](military-generals.md) |
-| propaganda | Propaganda | 3 | national_bureaucracy, university | Decreases diplomatic penalties for declaring war |
+| diplomatic_expertise | Diplomatic Expertise | 1 | — | Enables: embassy overture to Minor Nations and civilian work access in embassy-linked Minor Nations (Merchants, Engineers, Builders). Unlocks: prerequisite for `national_bureaucracy`. |
+| merchant_companies | Merchant Companies | 1 | — | Enables: Merchant civilian unit construction and `purchase_land` work orders in Minor Nations/Tribes when an embassy exists and the parties are not at war. Unlocks: prerequisite for `trade_fairs`. |
+| national_bureaucracy | National Bureaucracy | 2 | printing_press, money_lending, diplomatic_expertise | Enables: Builder `upgrade_town` work order for provincial towns. Improves: general cap floor to at least **3** per [military-generals.md](military-generals.md). Unlocks: prerequisite for `propaganda`. |
+| propaganda | Propaganda | 3 | national_bureaucracy, university | Improves: third-party diplomatic protest penalty against a war aggressor from **-10** to **-5** relation score when the aggressor has `propaganda` (per diplomacy lookup constants). Unlocks: prerequisite for `nationalism`. |
 | nationalism | Nationalism | 3 | propaganda, master_artisans, modern_forts | Deployment limit 12 regiments (vs 10); general adds more; raises general cap to at least 4 per [military-generals.md](military-generals.md) |
 | empire_building | Empire Building | 4 | nationalism, banking | Ask Great Powers to join your empire peacefully |
 

--- a/SPEC/game/tech-tree-labour-economy.md
+++ b/SPEC/game/tech-tree-labour-economy.md
@@ -8,13 +8,13 @@
 
 | id | name | era | prerequisites | effects |
 |----|------|-----|---------------|--------|
-| printing_press | Printing Press | 1 | — | Leads to Journeymen, tactics, siege engineering |
-| apprentice_workers | Apprentice Workers | 2 | land_enclosure, sugar_refining | 4× labour; consume refined sugar |
-| trained_journeymen | Trained Journeymen | 2 | cigar_production, printing_press | 6× labour; consume cigars |
-| master_artisans | Master Artisans | 3 | apprentice_workers, university, hat_production | 8× labour; consume fur hats |
+| printing_press | Printing Press | 1 | — | Unlocks: prerequisite for `trained_journeymen`, `university`, `improved_infantry_tactics`, `siege_engineering`, and `national_bureaucracy`. Prerequisite-only: no direct production or treasury modifier in MVP. |
+| apprentice_workers | Apprentice Workers | 2 | land_enclosure, sugar_refining | Enables: Apprentice worker tier with **4x labour output** and refined sugar luxury consumption per [workers-and-population.md](workers-and-population.md). Unlocks: prerequisite for `master_artisans` and `university`. |
+| trained_journeymen | Trained Journeymen | 2 | cigar_production, printing_press | Enables: Journeyman worker tier with **6x labour output** and cigar luxury consumption per [workers-and-population.md](workers-and-population.md). Unlocks: prerequisite for `cotton_gin` and `steppe_horsemen` recruitment path. |
+| master_artisans | Master Artisans | 3 | apprentice_workers, university, hat_production | Enables: Master worker tier with **8x labour output** and fur hat luxury consumption per [workers-and-population.md](workers-and-population.md). Unlocks: prerequisite for `banking`, `nationalism`, and `scientific_cattle_breeding`. |
 | money_lending | Money Lending | 1 | land_enclosure | Research treasury floor −500 (see below); borrowing/interest deferred |
-| banking | Banking | 3 | master_artisans, trade_fairs | Prereq for other techs; extended debt/interest/military-treasury links deferred |
-| trade_fairs | Trade Fairs | 2 | merchant_companies, sugar_refining | Forward-looking: more trade commodity slots vs baseline (not wired in MVP; see below) |
+| banking | Banking | 3 | master_artisans, trade_fairs | Unlocks: prerequisite for `dynamite`, `empire_building`, and `modern_military_funding`. Prerequisite-only in MVP for economy mechanics: extended debt/interest and military-treasury links remain deferred (see status below). |
+| trade_fairs | Trade Fairs | 2 | merchant_companies, sugar_refining | Enables: planned increase in trade commodity slots versus baseline (**deferred in MVP**; see status below). Unlocks: prerequisite for `banking`. |
 | university | University | 3 | money_lending, apprentice_workers, printing_press | Increases research slots from 3 to 4 (permanent per player); leads to many advances |
 
 ---

--- a/SPEC/game/tech-tree-new-world.md
+++ b/SPEC/game/tech-tree-new-world.md
@@ -32,10 +32,10 @@
 | improved_sea_routes | Improved Sea Routes | 1 | discovery_of_spices | Improves: spices extraction cap to **2**. Unlocks: prerequisite for `large_spice_plantations`. |
 | large_spice_plantations | Large Spice Plantations | 2 | seed_drill, improved_sea_routes | Improves: spices extraction cap to **3**. Unlocks: prerequisite for `improved_food_preservation`. |
 | improved_food_preservation | Improved Food Preservation | 3 | large_spice_plantations | Improves: spices extraction cap to **4**. Prerequisite-only: no additional techs currently depend on this in the MVP catalog. |
-| discovery_of_gold_or_silver | Discovery of Gold or Silver | 1 | (Explorer finds gold/silver) | Precious metal mines |
-| precious_metals_mining | Precious Metals Mining | 1 | discovery_of_gold_or_silver, mine_engineering | Gold/silver 2 |
-| discovery_of_gems_or_diamonds | Discovery of Gems or Diamonds | 1 | (Explorer finds gems/diamonds) | Precious stone mines |
-| precious_stone_mining | Precious Stone Mining | 1 | discovery_of_gems_or_diamonds | Gems/diamonds 2 |
+| discovery_of_gold_or_silver | Discovery of Gold or Silver | 1 | (Explorer finds gold/silver) | Enables: researchable only when the player has revealed and prospected a tile with gold or silver per the discovery rule in this doc. Unlocks: `precious_metals_mining` and `extraction_of_precious_metals` (with `university`). |
+| precious_metals_mining | Precious Metals Mining | 1 | discovery_of_gold_or_silver, mine_engineering | Improves: gold/silver extraction cap to **2**. Unlocks: prerequisite for `extraction_of_precious_metals`. |
+| discovery_of_gems_or_diamonds | Discovery of Gems or Diamonds | 1 | (Explorer finds gems/diamonds) | Enables: researchable only when the player has revealed and prospected a tile with gems or diamonds per the discovery rule in this doc. Unlocks: `precious_stone_mining` and `large_precious_stone_mines` (with `modern_forts`). |
+| precious_stone_mining | Precious Stone Mining | 1 | discovery_of_gems_or_diamonds | Improves: gems/diamonds extraction cap to **2**. Unlocks: prerequisite for `large_precious_stone_mines`. |
 
 ---
 

--- a/SPEC/game/tech-tree-transport.md
+++ b/SPEC/game/tech-tree-transport.md
@@ -8,10 +8,10 @@
 
 | id | name | era | prerequisites | effects |
 |----|------|-----|---------------|--------|
-| road_construction | Road Construction | 1 | saw_mill, land_enclosure, iron_mining | Allows building transport level 2 (2 units/tile); leads to railroads |
-| early_steam_engine | Early Steam Engine | 2 | road_construction, square_set_timbering, steam_in_mining | Railroads in flat terrain; 4 units/tile; unlocks Rail Builder |
-| later_steam_engine | Later Steam Engine | 3 | early_steam_engine, crucible_process | Rail through hills and swamps |
-| dynamite | Dynamite | 4 | later_steam_engine, banking, explosives | Railroads through mountains |
+| road_construction | Road Construction | 1 | saw_mill, land_enclosure, iron_mining | Enables: Engineer build orders that set transport level **2** roads (capacity **2 units/tile**). Unlocks: prerequisite for `early_steam_engine`. |
+| early_steam_engine | Early Steam Engine | 2 | road_construction, square_set_timbering, steam_in_mining | Enables: Rail Builder unit and railroad build orders on flat terrain only (transport level **4**, capacity **4 units/tile**). Unlocks: prerequisite for `later_steam_engine`, `tobacco_industry`, and `riverboats`. |
+| later_steam_engine | Later Steam Engine | 3 | early_steam_engine, crucible_process | Enables: railroad build orders on hills and swamps in addition to flat terrain (transport level **4**). Unlocks: prerequisite for `dynamite` and `excessive_fur_harvesting`. |
+| dynamite | Dynamite | 4 | later_steam_engine, banking, explosives | Enables: railroad build orders on mountains (completes flat/hill/swamp/mountain rail coverage at transport level **4**). Unlocks: prerequisite for `safety_lamp`, `geological_prospecting`, and `amalgamation_process`. |
 
 ---
 

--- a/app/lib/features/game/widgets/tech_tree_widget.dart
+++ b/app/lib/features/game/widgets/tech_tree_widget.dart
@@ -342,13 +342,28 @@ class TechTreeWidget extends StatelessWidget {
     }
     switch (tech.id) {
       case 'university':
-        list.add('Fourth research slot');
+        list.add('Enables: Fourth active research slot (3 -> 4)');
+        list.add(
+          'Unlocks: Master Artisans, Propaganda, Scientific Cattle Breeding',
+        );
         break;
       case 'road_construction':
-        list.add('Road level 2');
+        list.add('Enables: Engineer road upgrades to transport level 2');
+        list.add('Unlocks: Early Steam Engine');
         break;
       case 'early_steam_engine':
-        list.add('Railroads');
+        list.add('Enables: Rail Builder and railroads on flat terrain');
+        list.add('Unlocks: Later Steam Engine, Riverboats, Tobacco Industry');
+        break;
+      case 'later_steam_engine':
+        list.add('Enables: Railroads on hills and swamps');
+        list.add('Unlocks: Dynamite and Excessive Fur Harvesting');
+        break;
+      case 'dynamite':
+        list.add('Enables: Railroads on mountains');
+        list.add(
+          'Unlocks: Safety Lamp, Geological Prospecting, Amalgamation Process',
+        );
         break;
       case 'mine_engineering':
         list.add('Enables: Builder upgrades to Fort Level 2');
@@ -357,46 +372,62 @@ class TechTreeWidget extends StatelessWidget {
         );
         break;
       case 'national_bureaucracy':
-        list.add('Builders can upgrade provincial towns');
-        list.add('Helps increase general cap');
+        list.add('Enables: Builder upgrade_town work order');
+        list.add('Improves: General cap floor to at least 3');
+        list.add('Unlocks: Propaganda');
         break;
       case 'merchant_companies':
-        list.add('Unlocks Merchant civilian unit');
-        list.add('Allows purchasing land in Minor Nations (with embassy)');
+        list.add('Enables: Merchant civilian unit construction');
+        list.add(
+          'Enables: purchase_land in Minor Nations/Tribes (requires embassy, not at war)',
+        );
+        list.add('Unlocks: Trade Fairs');
         break;
       case 'printing_press':
-        list.add('Enables Trained Journeymen and advanced tactics');
+        list.add(
+          'Unlocks: Trained Journeymen, University, and military doctrine paths',
+        );
+        list.add('Prerequisite-only in MVP: no direct economy modifier');
         break;
       case 'money_lending':
-        list.add('Research funding may reduce treasury to −500');
-        list.add('General borrowing/interest not simulated yet');
+        list.add('Enables: Research-phase treasury floor to -500');
+        list.add('Prerequisite for: University, National Bureaucracy');
+        list.add('Deferred: General borrowing/interest not simulated yet');
         break;
       case 'apprentice_workers':
         list.add(
-          'Unlocks Apprentice Workers (4× labour; consume refined sugar)',
+          'Enables: Apprentice tier (4x labour; consumes refined sugar)',
         );
+        list.add('Unlocks: University and Master Artisans');
         break;
       case 'trained_journeymen':
-        list.add('Unlocks Trained Journeymen (6× labour; consume cigars)');
+        list.add('Enables: Journeyman tier (6x labour; consumes cigars)');
+        list.add('Unlocks: Cotton Gin and Recruit Steppe Horsemen');
         break;
       case 'master_artisans':
-        list.add('Unlocks Master Artisans (8× labour; consume fur hats)');
+        list.add('Enables: Master tier (8x labour; consumes fur hats)');
+        list.add('Unlocks: Banking, Nationalism, Scientific Cattle Breeding');
         break;
       case 'trade_fairs':
         list.add(
-          'Planned: more trade commodity slots vs baseline (not active yet)',
+          'Enables: Planned increase to trade commodity slots (deferred in MVP)',
         );
+        list.add('Unlocks: Banking');
         break;
       case 'banking':
-        list.add('Unlocks later military, diplomacy, and transport techs');
-        list.add('Extended banking rules not active yet');
+        list.add('Unlocks: Dynamite, Empire Building, Modern Military Funding');
+        list.add('Prerequisite-only in MVP: extended banking rules deferred');
         break;
       case 'diplomatic_expertise':
-        list.add('Unlocks embassies with Minor Nations');
-        list.add('Civilian units may work in Minors with an embassy');
+        list.add('Enables: Embassy overtures with Minor Nations');
+        list.add('Enables: civilian work in embassy-linked Minor Nations');
+        list.add('Unlocks: National Bureaucracy');
         break;
       case 'propaganda':
-        list.add('Decreases diplomatic penalties for declaring war');
+        list.add(
+          'Improves: Diplomatic protest war penalty against aggressor (-10 -> -5)',
+        );
+        list.add('Unlocks: Nationalism');
         break;
       case 'nationalism':
         list.add('Increases battle deployment limit to 12 regiments');
@@ -639,6 +670,26 @@ class TechTreeWidget extends StatelessWidget {
           'Enables: Research when player has revealed spices (discovery rule)',
         );
         list.add('Unlocks: Improved Sea Routes');
+        break;
+      case 'discovery_of_gold_or_silver':
+        list.add(
+          'Enables: Research when player has revealed and prospected gold/silver',
+        );
+        list.add('Unlocks: Precious Metals Mining');
+        break;
+      case 'precious_metals_mining':
+        list.add('Improves: Gold/silver extraction cap to 2');
+        list.add('Unlocks: Extraction of Precious Metals');
+        break;
+      case 'discovery_of_gems_or_diamonds':
+        list.add(
+          'Enables: Research when player has revealed and prospected gems/diamonds',
+        );
+        list.add('Unlocks: Precious Stone Mining');
+        break;
+      case 'precious_stone_mining':
+        list.add('Improves: Gems/diamonds extraction cap to 2');
+        list.add('Unlocks: Large Precious Stone Mines (with Modern Forts)');
         break;
       case 'improved_sea_routes':
         list.add('Improves: Spices extraction cap to 2');

--- a/app/test/tech_tree_widget_test.dart
+++ b/app/test/tech_tree_widget_test.dart
@@ -734,6 +734,135 @@ void main() {
     },
   );
 
+  testWidgets(
+    'Batch-6 tech descriptions are concrete and avoid generic fallback text (Refs #1630)',
+    (WidgetTester tester) async {
+      final emptyPlayer = player.copyWith(techUnlocked: <String, bool>{});
+      final gameWithEmptyPlayer = game.copyWith(
+        players: [emptyPlayer, ...game.players.skip(1)],
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TechTreeWidget(
+              game: gameWithEmptyPlayer,
+              player: emptyPlayer,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final expectedByTech = <String, String>{
+        'Discovery of Gold or Silver':
+            'Enables: Research when player has revealed and prospected gold/silver',
+        'Precious Metals Mining': 'Improves: Gold/silver extraction cap to 2',
+        'Discovery of Gems or Diamonds':
+            'Enables: Research when player has revealed and prospected gems/diamonds',
+        'Precious Stone Mining': 'Improves: Gems/diamonds extraction cap to 2',
+        'Road Construction':
+            'Enables: Engineer road upgrades to transport level 2',
+        'Early Steam Engine':
+            'Enables: Rail Builder and railroads on flat terrain',
+        'Later Steam Engine': 'Enables: Railroads on hills and swamps',
+        'Dynamite': 'Enables: Railroads on mountains',
+        'Printing Press':
+            'Unlocks: Trained Journeymen, University, and military doctrine paths',
+        'Apprentice Workers':
+            'Enables: Apprentice tier (4x labour; consumes refined sugar)',
+      };
+
+      for (final entry in expectedByTech.entries) {
+        final techNode = find.text(entry.key).first;
+        await tester.ensureVisible(techNode);
+        await tester.tap(techNode);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CtDialogShell), findsOneWidget);
+        expect(find.textContaining(entry.value), findsOneWidget);
+        expect(
+          find.textContaining('Improves new-world capabilities'),
+          findsNothing,
+        );
+        expect(
+          find.textContaining('Improves transport capabilities'),
+          findsNothing,
+        );
+        expect(
+          find.textContaining('Improves labour capabilities'),
+          findsNothing,
+        );
+
+        await tester.tap(find.text('Close'));
+        await tester.pumpAndSettle();
+      }
+    },
+  );
+
+  testWidgets(
+    'Batch-7 tech descriptions are concrete and avoid generic fallback text (Refs #1631)',
+    (WidgetTester tester) async {
+      final emptyPlayer = player.copyWith(techUnlocked: <String, bool>{});
+      final gameWithEmptyPlayer = game.copyWith(
+        players: [emptyPlayer, ...game.players.skip(1)],
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TechTreeWidget(
+              game: gameWithEmptyPlayer,
+              player: emptyPlayer,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final expectedByTech = <String, String>{
+        'Trained Journeymen':
+            'Enables: Journeyman tier (6x labour; consumes cigars)',
+        'Master Artisans':
+            'Enables: Master tier (8x labour; consumes fur hats)',
+        'Money Lending': 'Enables: Research-phase treasury floor to -500',
+        'Banking':
+            'Unlocks: Dynamite, Empire Building, Modern Military Funding',
+        'Trade Fairs':
+            'Enables: Planned increase to trade commodity slots (deferred in MVP)',
+        'University': 'Enables: Fourth active research slot (3 -> 4)',
+        'Diplomatic Expertise': 'Enables: Embassy overtures with Minor Nations',
+        'Merchant Companies': 'Enables: Merchant civilian unit construction',
+        'National Bureaucracy': 'Enables: Builder upgrade_town work order',
+        'Propaganda':
+            'Improves: Diplomatic protest war penalty against aggressor (-10 -> -5)',
+      };
+
+      for (final entry in expectedByTech.entries) {
+        final techNode = find.text(entry.key).first;
+        await tester.ensureVisible(techNode);
+        await tester.tap(techNode);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CtDialogShell), findsOneWidget);
+        expect(find.textContaining(entry.value), findsOneWidget);
+        expect(
+          find.textContaining('Improves labour capabilities'),
+          findsNothing,
+        );
+        expect(
+          find.textContaining('Improves diplomacy capabilities'),
+          findsNothing,
+        );
+        expect(
+          find.textContaining('Improves civilian capabilities'),
+          findsNothing,
+        );
+
+        await tester.tap(find.text('Close'));
+        await tester.pumpAndSettle();
+      }
+    },
+  );
+
   test(
     'Column rule: A→B→C and A→C places B between A and C (gap between A and C)',
     () {


### PR DESCRIPTION
## Summary
- Rewrite SPEC wording for issues #1630 and #1631 tech ids using fixed fields (`Enables`, `Improves`, `Unlocks`, `Prerequisite-only`) with concrete mechanics and explicit unlock targets.
- Update `TechTreeWidget` dialog effect summaries for all 20 techs in batches 6 and 7, including previously generic/fallback-sensitive entries.
- Add Batch-6 and Batch-7 widget tests to enforce concrete descriptions and block generic fallback text regressions.

## Scope
- In scope: issue batches #1630 and #1631 only.
- Deferred: later batch issues under epic #1624.

## SPEC updates
- `SPEC/game/tech-tree-new-world.md`
- `SPEC/game/tech-tree-transport.md`
- `SPEC/game/tech-tree-labour-economy.md`
- `SPEC/game/tech-tree-diplomacy-civilian.md`

## Test plan
- [x] `flutter test test/tech_tree_widget_test.dart` (run from `app/`)

Refs #1630
Refs #1631

Made with [Cursor](https://cursor.com)