### PR TITLE
Tech descriptions batches 8–9: naval, diplomacy, infantry (Refs #1632, #1633)

### DIFF
--- a/SPEC/game/tech-tree-diplomacy-civilian.md
+++ b/SPEC/game/tech-tree-diplomacy-civilian.md
@@ -18,8 +18,8 @@ The **diplomacy and civilian tech table in this doc is the GDD source of truth**
 | merchant_companies | Merchant Companies | 1 | — | Enables: Merchant civilian unit construction and `purchase_land` work orders in Minor Nations/Tribes when an embassy exists and the parties are not at war. Unlocks: prerequisite for `trade_fairs`. |
 | national_bureaucracy | National Bureaucracy | 2 | printing_press, money_lending, diplomatic_expertise | Enables: Builder `upgrade_town` work order for provincial towns. Improves: general cap floor to at least **3** per [military-generals.md](military-generals.md). Unlocks: prerequisite for `propaganda`. |
 | propaganda | Propaganda | 3 | national_bureaucracy, university | Improves: third-party diplomatic protest penalty against a war aggressor from **-10** to **-5** relation score when the aggressor has `propaganda` (per diplomacy lookup constants). Unlocks: prerequisite for `nationalism`. |
-| nationalism | Nationalism | 3 | propaganda, master_artisans, modern_forts | Deployment limit 12 regiments (vs 10); general adds more; raises general cap to at least 4 per [military-generals.md](military-generals.md) |
-| empire_building | Empire Building | 4 | nationalism, banking | Ask Great Powers to join your empire peacefully |
+| nationalism | Nationalism | 3 | propaganda, master_artisans, modern_forts | **Improves:** battle **deployment base limit** to **12** regiments (vs **10**; general medals still **+1** regiment each per [military-generals.md](military-generals.md)). **Improves:** **general cap** floor to at least **4**. **Unlocks:** prerequisite for `empire_building`. |
+| empire_building | Empire Building | 4 | nationalism, banking | **Enables:** **Join Empire** diplomatic overture toward a **nearly defeated** Great Power (≤**3** provinces owned, **original capital not owned by target**) per [diplomacy.md](diplomacy.md). |
 
 ---
 
@@ -37,7 +37,8 @@ When a Great Power that **declared war** (the aggressor in an intervention conte
 
 - **Diplomatic Expertise:** Unlocks embassy overture and allows civilian units to work in Minor Nations with embassy.
 - **Merchant Companies:** Unlocks building Merchant civilian unit. **Purchasing land** (Merchant `purchase_land` work order) in a Minor Nation or Tribe requires Merchant Companies **and** an **embassy** with that Minor/Tribe (see [diplomacy.md](diplomacy.md), [civilian-units.md](civilian-units.md)).
-- **Empire Building:** Unlocks Join Empire (GP can ask another GP to join when that target is **nearly defeated** as defined in [diplomacy.md](diplomacy.md) — three or fewer provinces remaining and original capital lost). See [diplomacy.md](diplomacy.md).
+- **Nationalism:** Raises battle **deployment base limit** to **12** regiments (vs **10**) and **general cap** floor to at least **4** per [military-generals.md](military-generals.md); prerequisite for `empire_building`.
+- **Empire Building:** Enables **Join Empire** overture (GP can ask another GP to join when that target is **nearly defeated** as defined in [diplomacy.md](diplomacy.md) — three or fewer provinces remaining and original capital lost). See [diplomacy.md](diplomacy.md).
 
 ---
 

--- a/SPEC/game/tech-tree-military.md
+++ b/SPEC/game/tech-tree-military.md
@@ -14,12 +14,12 @@ The **military tech table in this doc is the GDD source of truth** for tech id, 
 
 | id | name | era | prerequisites | regiment / effect |
 |----|------|-----|---------------|-------------------|
-| organised_regiments | Organised Regiments | 1 | land_enclosure | Lancers; Knights upgrade path; raises general cap to at least 2 per [military-generals.md](military-generals.md) |
-| improved_iron_weapons | Improved Iron Weapons | 1 | organised_regiments, iron_mining | Halberdiers; Pikemen upgrade |
-| improved_infantry_tactics | Improved Infantry Tactics | 2 | organised_regiments, printing_press | Calivermen; Peasant Levies upgrade; contributes to raising general cap to at least 3 per [military-generals.md](military-generals.md) |
-| crucible_process | Crucible Process | 2 | square_set_timbering, steam_in_mining | Steel; leads to Bayonet and more |
-| bayonet | Bayonet | 2 | improved_iron_weapons, crucible_process | Regulars; Halberdiers upgrade |
-| weapon_craftsmanship | Weapon Craftsmanship | 2 | organised_regiments, copper_and_tin_mining | Musketeers; Arquebusiers upgrade |
+| organised_regiments | Organised Regiments | 1 | land_enclosure | **Unlocks:** **Lancers** regiment; **Knights** upgrade path. **Improves:** general cap floor to at least **2** per [military-generals.md](military-generals.md). **Unlocks:** prerequisite paths for `improved_iron_weapons`, `improved_infantry_tactics`, and `weapon_craftsmanship`. |
+| improved_iron_weapons | Improved Iron Weapons | 1 | organised_regiments, iron_mining | **Unlocks:** **Halberdiers** regiment; **Pikemen** upgrade path. **Unlocks:** prerequisite for `bayonet` (with `crucible_process`). |
+| improved_infantry_tactics | Improved Infantry Tactics | 2 | organised_regiments, printing_press | **Unlocks:** **Calivermen** regiment; **Peasant Levies** upgrade path. **Improves:** general cap floor to at least **3** (same slot as `national_bureaucracy`; see [military-generals.md](military-generals.md)). **Unlocks:** prerequisite for `early_rifles` (with `crucible_process`). |
+| crucible_process | Crucible Process | 2 | square_set_timbering, steam_in_mining | **Prerequisite-only:** gates **steel** chain for `bayonet`, `early_rifles`, `long_range_rifles`, `improved_cavalry_weapons`, `heavy_artillery`, `later_steam_engine`, `industrial_machinery`, and `industrial_funding_of_research`; **no regiment** unlocked by this tech alone. |
+| bayonet | Bayonet | 2 | improved_iron_weapons, crucible_process | **Unlocks:** **Regulars** regiment; **Halberdiers** upgrade path. **Unlocks:** prerequisite for `needle_guns` (with `industrial_funding_of_research` and `early_rifles`). |
+| weapon_craftsmanship | Weapon Craftsmanship | 2 | organised_regiments, copper_and_tin_mining | **Unlocks:** **Musketeers** regiment; **Arquebusiers** upgrade path. **Unlocks:** prerequisite for `explosives` (with `industrial_machinery`). |
 | industrial_machinery | Industrial Machinery | 3 | trained_journeymen, steam_in_mining, university | 25% cheaper military attack; leads to Explosives |
 | explosives | Explosives | 3 | weapon_craftsmanship, industrial_machinery | Grenadiers; Musketeers upgrade |
 | early_rifles | Early Rifles | 3 | improved_infantry_tactics, crucible_process | Skirmishers; Calivermen upgrade |

--- a/SPEC/game/tech-tree-naval.md
+++ b/SPEC/game/tech-tree-naval.md
@@ -8,14 +8,14 @@
 
 | id | name | era | prerequisites | effects |
 |----|------|-----|---------------|--------|
-| superior_hull_design | Superior Hull Design | 1 | — | Construct Fluytes |
-| improved_sail_design | Improved Sail Design | 2 | wind_saw_mill, superior_hull_design | Construct Trader |
-| convoying | Convoying | 2 | merchant_companies | Construct Galleons |
-| navigation | Navigation | 1 | superior_hull_design | Construct Sloops |
-| large_hulls | Large Hulls | 2 | wind_saw_mill, navigation, convoying | Construct Indiaman |
-| clipper_ships | Clipper Ships | 4 | circular_saw, advanced_hull_design | Construct Clipper |
-| paddlewheels | Paddlewheels | 3 | advanced_hull_design, early_steam_engine | Construct Raider |
-| merchant_steamships | Merchant Steamships | 4 | paddlewheels, riverboats | Construct Merchant Steamship |
+| superior_hull_design | Superior Hull Design | 1 | — | **Unlocks:** construct **Fluyte** merchant hull. **Unlocks:** prerequisite for `improved_sail_design` and `navigation`. |
+| improved_sail_design | Improved Sail Design | 2 | wind_saw_mill, superior_hull_design | **Unlocks:** construct **Trader**. **Unlocks:** prerequisite for `advanced_hull_design` (with `university` and `privateering_companies`). |
+| convoying | Convoying | 2 | merchant_companies | **Unlocks:** construct **Galleon**. **Unlocks:** prerequisite for `large_hulls` (with `wind_saw_mill` and `navigation`). |
+| navigation | Navigation | 1 | superior_hull_design | **Unlocks:** construct **Sloop**. **Unlocks:** prerequisite for `large_hulls` and `privateering_companies`. |
+| large_hulls | Large Hulls | 2 | wind_saw_mill, navigation, convoying | **Unlocks:** construct **Indiaman**. **Unlocks:** prerequisite for `ship_of_the_line` (with `large_copper_and_tin_mines`). |
+| clipper_ships | Clipper Ships | 4 | circular_saw, advanced_hull_design | **Unlocks:** construct **Clipper** fast merchant hull. |
+| paddlewheels | Paddlewheels | 3 | advanced_hull_design, early_steam_engine | **Unlocks:** construct **Raider**. **Unlocks:** prerequisite for `merchant_steamships` (with `riverboats`). |
+| merchant_steamships | Merchant Steamships | 4 | paddlewheels, riverboats | **Unlocks:** construct **Merchant Steamship** steam cargo hull. |
 
 ---
 
@@ -23,10 +23,10 @@
 
 | id | name | era | prerequisites | effects |
 |----|------|-----|---------------|--------|
-| advanced_hull_design | Advanced Hull Design | 3 | university, improved_sail_design, privateering_companies | Construct Frigates (high intercept rating, moderate flee rating) |
-| ship_of_the_line | Ship of the Line | 3 | large_hulls, large_copper_and_tin_mines | Construct Ships-of-the-Line |
-| privateering_companies | Privateering Companies | 2 | navigation, diplomatic_expertise | Improves naval interception (Patrol/Blockade) and trade-raid chance; unlocks privateering doctrines required for advanced warships |
-| advanced_iron_working | Advanced Iron Working | 4 | ship_of_the_line, industrial_funding_of_research, paddlewheels | Construct Ironclads |
+| advanced_hull_design | Advanced Hull Design | 3 | university, improved_sail_design, privateering_companies | **Unlocks:** construct **Frigate** (high **intercept**, moderate **flee** — fast interceptor role per Notes below). **Unlocks:** prerequisite for `clipper_ships` and `paddlewheels`. |
+| ship_of_the_line | Ship of the Line | 3 | large_hulls, large_copper_and_tin_mines | **Unlocks:** construct **Ship of the Line** battle-line capital hull. **Unlocks:** prerequisite for `advanced_iron_working` (with `industrial_funding_of_research` and `paddlewheels`). |
+| privateering_companies | Privateering Companies | 2 | navigation, diplomatic_expertise | **Improves:** naval **interception** and **trade-raid** effectiveness on **Patrol** / **Blockade** when those rules apply. **Unlocks:** prerequisite for `advanced_hull_design` (privateering-doctrine path to frigates and later hulls). |
+| advanced_iron_working | Advanced Iron Working | 4 | ship_of_the_line, industrial_funding_of_research, paddlewheels | **Unlocks:** construct **Ironclad** armored steam warship. |
 
 ---
 

--- a/app/lib/features/game/widgets/tech_tree_widget.dart
+++ b/app/lib/features/game/widgets/tech_tree_widget.dart
@@ -430,11 +430,93 @@ class TechTreeWidget extends StatelessWidget {
         list.add('Unlocks: Nationalism');
         break;
       case 'nationalism':
-        list.add('Increases battle deployment limit to 12 regiments');
-        list.add('Helps raise general cap');
+        list.add('Improves: Battle deployment base limit to 12 regiments (vs 10)');
+        list.add('Improves: General cap floor to at least 4');
+        list.add('Unlocks: Empire Building (with Banking)');
         break;
       case 'empire_building':
-        list.add('Allows asking Great Powers to join your empire peacefully');
+        list.add(
+          'Enables: Join Empire overture toward nearly-defeated Great Powers',
+        );
+        list.add(
+          'Requires: Target owns ≤3 provinces and lost original capital',
+        );
+        break;
+      case 'superior_hull_design':
+        list.add('Unlocks: Improved Sail Design and Navigation hull paths');
+        break;
+      case 'improved_sail_design':
+        list.add('Unlocks: Advanced Hull Design path (University + Privateering)');
+        break;
+      case 'convoying':
+        list.add('Unlocks: Large Hulls (with Wind Saw Mill + Navigation)');
+        break;
+      case 'navigation':
+        list.add('Unlocks: Large Hulls and Privateering Companies');
+        break;
+      case 'large_hulls':
+        list.add('Unlocks: Ship of the Line (with Large Copper and Tin Mines)');
+        break;
+      case 'clipper_ships':
+        list.add('Improves: Late-era fast merchant Clipper cargo line');
+        break;
+      case 'paddlewheels':
+        list.add('Unlocks: Merchant Steamships (with Riverboats)');
+        break;
+      case 'merchant_steamships':
+        list.add('Enables: Steam-powered merchant hull for seagoing trade');
+        break;
+      case 'advanced_hull_design':
+        list.add(
+          'Improves: Frigate — high intercept, moderate flee (patrol/blockade)',
+        );
+        list.add('Unlocks: Clipper Ships and Paddlewheels hull paths');
+        break;
+      case 'ship_of_the_line':
+        list.add(
+          'Improves: Battle-line capital ship for decisive fleet engagements',
+        );
+        list.add(
+          'Unlocks: Advanced Iron Working (with Industrial Funding + Paddlewheels)',
+        );
+        break;
+      case 'privateering_companies':
+        list.add(
+          'Improves: Patrol/Blockade interception and trade-raid effectiveness',
+        );
+        list.add('Unlocks: Advanced Hull Design (frigate doctrine prerequisite)');
+        break;
+      case 'advanced_iron_working':
+        list.add('Improves: Ironclad armored steam combat hull');
+        break;
+      case 'organised_regiments':
+        list.add('Improves: General cap floor to at least 2');
+        list.add(
+          'Unlocks: Improved Iron/Infantry/Weapon Craftsmanship doctrine paths',
+        );
+        break;
+      case 'improved_iron_weapons':
+        list.add('Unlocks: Bayonet (with Crucible Process)');
+        break;
+      case 'improved_infantry_tactics':
+        list.add(
+          'Improves: General cap floor to at least 3 (or National Bureaucracy)',
+        );
+        list.add('Unlocks: Early Rifles (with Crucible Process)');
+        break;
+      case 'crucible_process':
+        list.add(
+          'Prerequisite-only: Steel chain for Bayonet, rifles, steam, and cannons',
+        );
+        list.add('Unlocks: No regiment from this tech alone');
+        break;
+      case 'bayonet':
+        list.add('Unlocks: Needle Guns (with Industrial Funding + Early Rifles)');
+        break;
+      case 'weapon_craftsmanship':
+        list.add(
+          'Unlocks: Explosives and Grenadiers (with Industrial Machinery)',
+        );
         break;
       case 'land_enclosure':
         list.add('Improves: Grain extraction cap to 2');

--- a/app/test/tech_tree_widget_test.dart
+++ b/app/test/tech_tree_widget_test.dart
@@ -863,6 +863,130 @@ void main() {
     },
   );
 
+  testWidgets(
+    'Batch-8 tech descriptions are concrete and avoid generic fallback text (Refs #1632)',
+    (WidgetTester tester) async {
+      final emptyPlayer = player.copyWith(techUnlocked: <String, bool>{});
+      final gameWithEmptyPlayer = game.copyWith(
+        players: [emptyPlayer, ...game.players.skip(1)],
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TechTreeWidget(
+              game: gameWithEmptyPlayer,
+              player: emptyPlayer,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final expectedByTech = <String, String>{
+        'Nationalism':
+            'Improves: Battle deployment base limit to 12 regiments (vs 10)',
+        'Empire Building':
+            'Enables: Join Empire overture toward nearly-defeated Great Powers',
+        'Superior Hull Design':
+            'Unlocks: Improved Sail Design and Navigation hull paths',
+        'Improved Sail Design':
+            'Unlocks: Advanced Hull Design path (University + Privateering)',
+        'Convoying': 'Unlocks: Large Hulls (with Wind Saw Mill + Navigation)',
+        'Navigation': 'Unlocks: Large Hulls and Privateering Companies',
+        'Large Hulls':
+            'Unlocks: Ship of the Line (with Large Copper and Tin Mines)',
+        'Clipper Ships': 'Improves: Late-era fast merchant Clipper cargo line',
+        'Paddlewheels': 'Unlocks: Merchant Steamships (with Riverboats)',
+        'Merchant Steamships':
+            'Enables: Steam-powered merchant hull for seagoing trade',
+      };
+
+      for (final entry in expectedByTech.entries) {
+        final techNode = find.text(entry.key).first;
+        await tester.ensureVisible(techNode);
+        await tester.tap(techNode);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CtDialogShell), findsOneWidget);
+        expect(find.textContaining(entry.value), findsOneWidget);
+        expect(
+          find.textContaining('Improves naval capabilities'),
+          findsNothing,
+        );
+        expect(
+          find.textContaining('Improves diplomacy capabilities'),
+          findsNothing,
+        );
+
+        await tester.tap(find.text('Close'));
+        await tester.pumpAndSettle();
+      }
+    },
+  );
+
+  testWidgets(
+    'Batch-9 tech descriptions are concrete and avoid generic fallback text (Refs #1633)',
+    (WidgetTester tester) async {
+      final emptyPlayer = player.copyWith(techUnlocked: <String, bool>{});
+      final gameWithEmptyPlayer = game.copyWith(
+        players: [emptyPlayer, ...game.players.skip(1)],
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TechTreeWidget(
+              game: gameWithEmptyPlayer,
+              player: emptyPlayer,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final expectedByTech = <String, String>{
+        'Advanced Hull Design':
+            'Improves: Frigate — high intercept, moderate flee (patrol/blockade)',
+        'Ship of the Line':
+            'Improves: Battle-line capital ship for decisive fleet engagements',
+        'Privateering Companies':
+            'Improves: Patrol/Blockade interception and trade-raid effectiveness',
+        'Advanced Iron Working':
+            'Improves: Ironclad armored steam combat hull',
+        'Organised Regiments': 'Improves: General cap floor to at least 2',
+        'Improved Iron Weapons': 'Unlocks: Bayonet (with Crucible Process)',
+        'Improved Infantry Tactics':
+            'Improves: General cap floor to at least 3 (or National Bureaucracy)',
+        'Crucible Process':
+            'Prerequisite-only: Steel chain for Bayonet, rifles, steam, and cannons',
+        'Bayonet':
+            'Unlocks: Needle Guns (with Industrial Funding + Early Rifles)',
+        'Weapon Craftsmanship':
+            'Unlocks: Explosives and Grenadiers (with Industrial Machinery)',
+      };
+
+      for (final entry in expectedByTech.entries) {
+        final techNode = find.text(entry.key).first;
+        await tester.ensureVisible(techNode);
+        await tester.tap(techNode);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CtDialogShell), findsOneWidget);
+        expect(find.textContaining(entry.value), findsOneWidget);
+        expect(
+          find.textContaining('Improves naval capabilities'),
+          findsNothing,
+        );
+        expect(
+          find.textContaining('Improves military capabilities'),
+          findsNothing,
+        );
+
+        await tester.tap(find.text('Close'));
+        await tester.pumpAndSettle();
+      }
+    },
+  );
+
   test(
     'Column rule: A→B→C and A→C places B between A and C (gap between A and C)',
     () {


### PR DESCRIPTION
## Summary
Implements GitHub issues **#1632** (tech ids 71–80) and **#1633** (81–90): fixed-field, concrete tech descriptions in SPEC and Technology Tree dialog effect summaries, plus regression tests.

## SPEC
- `SPEC/game/tech-tree-diplomacy-civilian.md` — `nationalism`, `empire_building` table rows and Effect Semantics (`nationalism` bullet).
- `SPEC/game/tech-tree-naval.md` — merchant and warship rows for all batch ids.
- `SPEC/game/tech-tree-military.md` — `organised_regiments` through `weapon_craftsmanship`, explicit **Prerequisite-only** for `crucible_process`.

## Implementation
- `app/lib/features/game/widgets/tech_tree_widget.dart` — `_effectSummary` switch entries so these techs no longer fall through to generic category fallback text.

## Tests
- `app/test/tech_tree_widget_test.dart` — Batch-8 and Batch-9 widget tests (concrete substrings; no generic naval/diplomacy/military fallback).
- Command: `cd app && flutter test test/tech_tree_widget_test.dart`

## Scope
Full vertical slice for both issues (SPEC + UI summaries + tests). Parent epic: #1624.

Refs #1632
Refs #1633

Made with [Cursor](https://cursor.com)