### PR TITLE
Military tech dialog summaries for batches 10–12 (Refs #1634, #1635, #1636)

### DIFF
--- a/SPEC/game/tech-tree-military.md
+++ b/SPEC/game/tech-tree-military.md
@@ -20,12 +20,12 @@ The **military tech table in this doc is the GDD source of truth** for tech id, 
 | crucible_process | Crucible Process | 2 | square_set_timbering, steam_in_mining | Steel; leads to Bayonet and more |
 | bayonet | Bayonet | 2 | improved_iron_weapons, crucible_process | Regulars; Halberdiers upgrade |
 | weapon_craftsmanship | Weapon Craftsmanship | 2 | organised_regiments, copper_and_tin_mining | Musketeers; Arquebusiers upgrade |
-| industrial_machinery | Industrial Machinery | 3 | trained_journeymen, steam_in_mining, university | 25% cheaper military attack; leads to Explosives |
-| explosives | Explosives | 3 | weapon_craftsmanship, industrial_machinery | Grenadiers; Musketeers upgrade |
-| early_rifles | Early Rifles | 3 | improved_infantry_tactics, crucible_process | Skirmishers; Calivermen upgrade |
-| long_range_rifles | Long Range Rifles | 3 | early_rifles, crucible_process | Sharpshooters; Skirmishers upgrade |
-| needle_guns | Needle Guns | 4 | industrial_funding_of_research, bayonet, early_rifles | Rifle Infantry; Regulars upgrade |
-| elite_military_training | Elite Military Training | 4 | modern_military_funding, needle_guns, explosives | Guards; Grenadiers upgrade |
+| industrial_machinery | Industrial Machinery | 3 | trained_journeymen, steam_in_mining, university | Improves (deferred in MVP): military attack treasury cost by **25%** once the application point is chosen per **Deferred effect types** below. Unlocks: prerequisite for `explosives`, `improved_cavalry_weapons`, and `industrial_funding_of_research`. |
+| explosives | Explosives | 3 | weapon_craftsmanship, industrial_machinery | Unlocks: **Grenadiers** regiment. Improves: **Musketeers** upgrade path. Prerequisite for: `elite_military_training`. |
+| early_rifles | Early Rifles | 3 | improved_infantry_tactics, crucible_process | Unlocks: **Skirmishers** regiment. Improves: **Calivermen** upgrade path. Prerequisite for: `long_range_rifles`, `scouting`, `needle_guns`. |
+| long_range_rifles | Long Range Rifles | 3 | early_rifles, crucible_process | Unlocks: **Sharpshooters** regiment. Improves: **Skirmishers** upgrade path. |
+| needle_guns | Needle Guns | 4 | industrial_funding_of_research, bayonet, early_rifles | Unlocks: **Rifle Infantry** regiment. Improves: **Regulars** upgrade path. Prerequisite for: `elite_military_training`. |
+| elite_military_training | Elite Military Training | 4 | modern_military_funding, needle_guns, explosives | Unlocks: **Guards** regiment. Improves: **Grenadiers** upgrade path. |
 
 ---
 
@@ -33,12 +33,12 @@ The **military tech table in this doc is the GDD source of truth** for tech id, 
 
 | id | name | era | prerequisites | regiment / effect |
 |----|------|-----|---------------|-------------------|
-| recruit_steppe_horsemen | Recruit Steppe Horsemen | 1 | crop_rotation | Cossacks; Squires upgrade |
-| improved_cavalry_tactics | Improved Cavalry Tactics | 2 | printing_press, animal_husbandry | Harquebusiers |
-| hussars | Hussars | 2 | improved_cavalry_tactics, recruit_steppe_horsemen | Hussars; Cossacks upgrade |
-| improved_cavalry_weapons | Improved Cavalry Weapons | 3 | industrial_machinery, crucible_process, improved_cavalry_tactics | Cuirassiers; Harquebusiers upgrade |
-| scouting | Scouting | 3 | hussars, early_rifles | Scouts; Hussars upgrade |
-| repeating_cavalry_carbine | Repeating Cavalry Carbine | 4 | industrial_funding_of_research, improved_cavalry_weapons | Carbine Cavalry; Cuirassiers upgrade |
+| recruit_steppe_horsemen | Recruit Steppe Horsemen | 1 | crop_rotation | Unlocks: **Cossacks** regiment. Improves: **Squires** upgrade path. Prerequisite for: `hussars`. |
+| improved_cavalry_tactics | Improved Cavalry Tactics | 2 | printing_press, animal_husbandry | Unlocks: **Harquebusiers** regiment. Prerequisite for: `hussars` and `improved_cavalry_weapons`. |
+| hussars | Hussars | 2 | improved_cavalry_tactics, recruit_steppe_horsemen | Unlocks: **Hussars** regiment. Improves: **Cossacks** upgrade path. Prerequisite for: `scouting`. |
+| improved_cavalry_weapons | Improved Cavalry Weapons | 3 | industrial_machinery, crucible_process, improved_cavalry_tactics | Unlocks: **Cuirassiers** regiment. Improves: **Harquebusiers** upgrade path. Prerequisite for: `repeating_cavalry_carbine`. |
+| scouting | Scouting | 3 | hussars, early_rifles | Unlocks: **Scouts** regiment. Improves: **Hussars** upgrade path. |
+| repeating_cavalry_carbine | Repeating Cavalry Carbine | 4 | industrial_funding_of_research, improved_cavalry_weapons | Unlocks: **Carbine Cavalry** regiment. Improves: **Cuirassiers** upgrade path. |
 
 ---
 
@@ -46,17 +46,17 @@ The **military tech table in this doc is the GDD source of truth** for tech id, 
 
 | id | name | era | prerequisites | regiment / effect |
 |----|------|-----|---------------|-------------------|
-| horse_artillery | Horse Artillery | 1 | animal_husbandry, copper_and_tin_mining | Horse Artillery |
-| siege_engineering | Siege Engineering | 2 | printing_press, copper_and_tin_mining | Royal Artillery; Culverin upgrade |
-| light_artillery_tactics | Light Artillery Tactics | 3 | crucible_process, university | Light Artillery; Horse Artillery upgrade |
-| modern_forts | Modern Forts | 3 | siege_engineering, university | Fort level 3; leads to Modern Military Funding |
-| heavy_artillery | Heavy Artillery | 3 | modern_forts, crucible_process | Heavy Artillery; Royal Artillery upgrade |
-| heavy_emplaced_artillery | Heavy Emplaced Artillery | 3 | road_construction, national_bureaucracy, siege_engineering | All emplaced artillery → Heavy |
-| field_artillery_tactics | Field Artillery Tactics | 4 | light_artillery_tactics, modern_military_funding | Field Artillery; Light Artillery upgrade |
-| high_grade_steel | High Grade Steel | 4 | heavy_artillery, industrial_funding_of_research, modern_military_funding | Siege Guns; Heavy Artillery upgrade |
-| emplaced_siege_guns | Emplaced Siege Guns | 4 | heavy_artillery, heavy_emplaced_artillery | All emplaced → Siege Guns |
-| modern_military_funding | Modern Military Funding | 3 | banking, large_precious_stone_mines, modern_forts | Cheaper attack; leads to elite units |
-| industrial_funding_of_research | Industrial Funding of Research | 3 | industrial_machinery, crucible_process | Research efficiency; military/naval tech |
+| horse_artillery | Horse Artillery | 1 | animal_husbandry, copper_and_tin_mining | Unlocks: **Horse Artillery** regiment (field artillery). Prerequisite for: `light_artillery_tactics`. |
+| siege_engineering | Siege Engineering | 2 | printing_press, copper_and_tin_mining | Unlocks: **Royal Artillery** regiment. Improves: **Culverin** upgrade path. Prerequisite for: `modern_forts`, `heavy_emplaced_artillery`. |
+| light_artillery_tactics | Light Artillery Tactics | 3 | crucible_process, university | Unlocks: **Light Artillery** regiment. Improves: **Horse Artillery** upgrade path. Prerequisite for: `field_artillery_tactics`. |
+| modern_forts | Modern Forts | 3 | siege_engineering, university | Enables: Builder **fort level 3** (Modern fort: 3 emplaced guns and strongest wall profile per [siege-mechanics.md](siege-mechanics.md)). Unlocks: prerequisite for `heavy_artillery` and `modern_military_funding`. |
+| heavy_artillery | Heavy Artillery | 3 | modern_forts, crucible_process | Unlocks: **Heavy Artillery** regiment. Improves: **Royal Artillery** upgrade path. Prerequisite for: `high_grade_steel`, `emplaced_siege_guns`. |
+| heavy_emplaced_artillery | Heavy Emplaced Artillery | 3 | road_construction, national_bureaucracy, siege_engineering | Improves: defender **emplaced fort batteries** to **Heavy** quality (Royal → Heavy → Siege line per [siege-mechanics.md](siege-mechanics.md)). Prerequisite for: `emplaced_siege_guns`. |
+| field_artillery_tactics | Field Artillery Tactics | 4 | light_artillery_tactics, modern_military_funding | Unlocks: **Field Artillery** regiment. Improves: **Light Artillery** upgrade path. |
+| high_grade_steel | High Grade Steel | 4 | heavy_artillery, industrial_funding_of_research, modern_military_funding | Unlocks: **Siege Guns** regiment (field). Improves: **Heavy Artillery** upgrade path. |
+| emplaced_siege_guns | Emplaced Siege Guns | 4 | heavy_artillery, heavy_emplaced_artillery | Improves: defender **emplaced fort batteries** to **Siege Gun** quality (final emplaced tier per [siege-mechanics.md](siege-mechanics.md)). |
+| modern_military_funding | Modern Military Funding | 3 | banking, large_precious_stone_mines, modern_forts | Improves (deferred in MVP): cheaper military attack once the application point is fixed per **Deferred effect types** below. Unlocks: prerequisite for `field_artillery_tactics`, `high_grade_steel`, and `elite_military_training`. |
+| industrial_funding_of_research | Industrial Funding of Research | 3 | industrial_machinery, crucible_process | Improves (deferred in MVP): research efficiency for military/naval tech per [research-resolution.md](../program/research-resolution.md) and **Deferred effect types** below. Unlocks: prerequisite for `needle_guns`, `repeating_cavalry_carbine`, `high_grade_steel`, and `advanced_iron_working`. |
 
 ---
 

--- a/app/lib/features/game/widgets/tech_tree_widget.dart
+++ b/app/lib/features/game/widgets/tech_tree_widget.dart
@@ -705,6 +705,111 @@ class TechTreeWidget extends StatelessWidget {
           'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
         );
         break;
+      case 'industrial_machinery':
+        list.add(
+          'Unlocks: Explosives, Improved Cavalry Weapons, Industrial Funding of Research (as prerequisite)',
+        );
+        list.add(
+          'Improves (deferred in MVP): military attack treasury cost by 25% once application point is fixed per SPEC',
+        );
+        break;
+      case 'explosives':
+        list.add('Improves: Musketeers regiment upgrade path');
+        list.add('Prerequisite for: Elite Military Training');
+        break;
+      case 'early_rifles':
+        list.add('Improves: Calivermen regiment upgrade path');
+        list.add(
+          'Prerequisite for: Long Range Rifles, Scouting, and Needle Guns',
+        );
+        break;
+      case 'long_range_rifles':
+        list.add('Improves: Skirmishers regiment upgrade path');
+        break;
+      case 'needle_guns':
+        list.add('Improves: Regulars regiment upgrade path');
+        list.add('Prerequisite for: Elite Military Training');
+        break;
+      case 'elite_military_training':
+        list.add('Improves: Grenadiers regiment upgrade path');
+        break;
+      case 'recruit_steppe_horsemen':
+        list.add('Improves: Squires regiment upgrade path');
+        list.add('Prerequisite for: Hussars');
+        break;
+      case 'improved_cavalry_tactics':
+        list.add('Prerequisite for: Hussars and Improved Cavalry Weapons');
+        break;
+      case 'hussars':
+        list.add('Improves: Cossacks regiment upgrade path');
+        list.add('Prerequisite for: Scouting');
+        break;
+      case 'improved_cavalry_weapons':
+        list.add('Improves: Harquebusiers regiment upgrade path');
+        list.add('Prerequisite for: Repeating Cavalry Carbine');
+        break;
+      case 'scouting':
+        list.add('Improves: Hussars regiment upgrade path');
+        break;
+      case 'repeating_cavalry_carbine':
+        list.add('Improves: Cuirassiers regiment upgrade path');
+        break;
+      case 'horse_artillery':
+        list.add('Prerequisite for: Light Artillery Tactics');
+        break;
+      case 'siege_engineering':
+        list.add('Improves: Culverin regiment upgrade path');
+        list.add('Prerequisite for: Modern Forts and Heavy Emplaced Artillery');
+        break;
+      case 'light_artillery_tactics':
+        list.add('Improves: Horse Artillery regiment upgrade path');
+        list.add('Prerequisite for: Field Artillery Tactics');
+        break;
+      case 'modern_forts':
+        list.add(
+          'Enables: Builder fort upgrades to level 3 (Modern: 3 emplaced guns, strongest walls)',
+        );
+        list.add(
+          'Unlocks: Heavy Artillery and Modern Military Funding (as prerequisite)',
+        );
+        break;
+      case 'heavy_artillery':
+        list.add('Improves: Royal Artillery regiment upgrade path');
+        list.add('Prerequisite for: High Grade Steel and Emplaced Siege Guns');
+        break;
+      case 'heavy_emplaced_artillery':
+        list.add(
+          'Improves: defender emplaced fort batteries to Heavy quality (Royal → Heavy line)',
+        );
+        list.add('Prerequisite for: Emplaced Siege Guns');
+        break;
+      case 'field_artillery_tactics':
+        list.add('Improves: Light Artillery regiment upgrade path');
+        break;
+      case 'high_grade_steel':
+        list.add('Improves: Heavy Artillery regiment upgrade path');
+        break;
+      case 'emplaced_siege_guns':
+        list.add(
+          'Improves: defender emplaced fort batteries to Siege Gun quality (final emplaced tier)',
+        );
+        break;
+      case 'modern_military_funding':
+        list.add(
+          'Unlocks: Field Artillery Tactics, High Grade Steel, Elite Military Training stack',
+        );
+        list.add(
+          'Improves (deferred in MVP): cheaper military attack once application point is fixed per SPEC',
+        );
+        break;
+      case 'industrial_funding_of_research':
+        list.add(
+          'Unlocks: Needle Guns, Repeating Cavalry Carbine, High Grade Steel, Advanced Iron Working (as prerequisite)',
+        );
+        list.add(
+          'Improves (deferred in MVP): research efficiency for military/naval tech per SPEC',
+        );
+        break;
       default:
         if (list.isEmpty) {
           list.add('Improves ${_categoryLabel(tech.category)} capabilities');

--- a/app/test/tech_tree_widget_test.dart
+++ b/app/test/tech_tree_widget_test.dart
@@ -863,6 +863,163 @@ void main() {
     },
   );
 
+  testWidgets(
+    'Batch-10 tech descriptions are concrete and avoid generic fallback text (Refs #1634)',
+    (WidgetTester tester) async {
+      final emptyPlayer = player.copyWith(techUnlocked: <String, bool>{});
+      final gameWithEmptyPlayer = game.copyWith(
+        players: [emptyPlayer, ...game.players.skip(1)],
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TechTreeWidget(
+              game: gameWithEmptyPlayer,
+              player: emptyPlayer,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final expectedByTech = <String, String>{
+        'Industrial Machinery':
+            'Unlocks: Explosives, Improved Cavalry Weapons, Industrial Funding of Research (as prerequisite)',
+        'Explosives': 'Improves: Musketeers regiment upgrade path',
+        'Early Rifles': 'Improves: Calivermen regiment upgrade path',
+        'Long Range Rifles': 'Improves: Skirmishers regiment upgrade path',
+        'Needle Guns': 'Improves: Regulars regiment upgrade path',
+        'Elite Military Training': 'Improves: Grenadiers regiment upgrade path',
+        'Recruit Steppe Horsemen': 'Improves: Squires regiment upgrade path',
+        'Improved Cavalry Tactics':
+            'Prerequisite for: Hussars and Improved Cavalry Weapons',
+        'Hussars': 'Improves: Cossacks regiment upgrade path',
+        'Improved Cavalry Weapons':
+            'Improves: Harquebusiers regiment upgrade path',
+      };
+
+      for (final entry in expectedByTech.entries) {
+        final techNode = find.text(entry.key).first;
+        await tester.ensureVisible(techNode);
+        await tester.tap(techNode);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CtDialogShell), findsOneWidget);
+        expect(find.textContaining(entry.value), findsOneWidget);
+        expect(
+          find.textContaining('Improves Military capabilities'),
+          findsNothing,
+        );
+
+        await tester.tap(find.text('Close'));
+        await tester.pumpAndSettle();
+      }
+    },
+  );
+
+  testWidgets(
+    'Batch-11 tech descriptions are concrete and avoid generic fallback text (Refs #1635)',
+    (WidgetTester tester) async {
+      final emptyPlayer = player.copyWith(techUnlocked: <String, bool>{});
+      final gameWithEmptyPlayer = game.copyWith(
+        players: [emptyPlayer, ...game.players.skip(1)],
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TechTreeWidget(
+              game: gameWithEmptyPlayer,
+              player: emptyPlayer,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final expectedByTech = <String, String>{
+        'Scouting': 'Improves: Hussars regiment upgrade path',
+        'Repeating Cavalry Carbine':
+            'Improves: Cuirassiers regiment upgrade path',
+        'Horse Artillery': 'Prerequisite for: Light Artillery Tactics',
+        'Siege Engineering': 'Improves: Culverin regiment upgrade path',
+        'Light Artillery Tactics':
+            'Improves: Horse Artillery regiment upgrade path',
+        'Modern Forts':
+            'Enables: Builder fort upgrades to level 3 (Modern: 3 emplaced guns, strongest walls)',
+        'Heavy Artillery': 'Improves: Royal Artillery regiment upgrade path',
+        'Heavy Emplaced Artillery':
+            'Improves: defender emplaced fort batteries to Heavy quality (Royal → Heavy line)',
+        'Field Artillery Tactics':
+            'Improves: Light Artillery regiment upgrade path',
+        'High Grade Steel': 'Improves: Heavy Artillery regiment upgrade path',
+      };
+
+      for (final entry in expectedByTech.entries) {
+        final techNode = find.text(entry.key).first;
+        await tester.ensureVisible(techNode);
+        await tester.tap(techNode);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CtDialogShell), findsOneWidget);
+        expect(find.textContaining(entry.value), findsOneWidget);
+        expect(
+          find.textContaining('Improves Military capabilities'),
+          findsNothing,
+        );
+
+        await tester.tap(find.text('Close'));
+        await tester.pumpAndSettle();
+      }
+    },
+  );
+
+  testWidgets(
+    'Batch-12 tech descriptions are concrete and avoid generic fallback text (Refs #1636)',
+    (WidgetTester tester) async {
+      final emptyPlayer = player.copyWith(techUnlocked: <String, bool>{});
+      final gameWithEmptyPlayer = game.copyWith(
+        players: [emptyPlayer, ...game.players.skip(1)],
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TechTreeWidget(
+              game: gameWithEmptyPlayer,
+              player: emptyPlayer,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final expectedByTech = <String, String>{
+        'Emplaced Siege Guns':
+            'Improves: defender emplaced fort batteries to Siege Gun quality (final emplaced tier)',
+        'Modern Military Funding':
+            'Unlocks: Field Artillery Tactics, High Grade Steel, Elite Military Training stack',
+        'Industrial Funding of Research':
+            'Unlocks: Needle Guns, Repeating Cavalry Carbine, High Grade Steel, Advanced Iron Working (as prerequisite)',
+      };
+
+      for (final entry in expectedByTech.entries) {
+        final techNode = find.text(entry.key).first;
+        await tester.ensureVisible(techNode);
+        await tester.tap(techNode);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CtDialogShell), findsOneWidget);
+        expect(find.textContaining(entry.value), findsOneWidget);
+        expect(
+          find.textContaining('Improves Military capabilities'),
+          findsNothing,
+        );
+
+        await tester.tap(find.text('Close'));
+        await tester.pumpAndSettle();
+      }
+    },
+  );
+
   test(
     'Column rule: A→B→C and A→C places B between A and C (gap between A and C)',
     () {


### PR DESCRIPTION
## Summary

Implements the tech-description epic slices for issues #1634, #1635, and #1636: fixed-field SPEC wording for the listed military tech ids, matching Technology Tree dialog summaries, plus regression tests that reject the generic military fallback line.

## Scope (this PR)

- **Batch 10 (#1634):** `industrial_machinery` through `improved_cavalry_weapons` (10 techs)
- **Batch 11 (#1635):** `scouting` through `high_grade_steel` (10 techs)
- **Batch 12 (#1636):** `emplaced_siege_guns`, `modern_military_funding`, `industrial_funding_of_research`

Deferred combat/funding effects remain explicitly labeled **deferred in MVP** per existing SPEC notes.

## SPEC

- `SPEC/game/tech-tree-military.md` — expanded regiment / effect column with Unlocks · Improves · Enables · Prerequisite-for wording

## Implementation

- `app/lib/features/game/widgets/tech_tree_widget.dart` — `_effectSummary` cases for the batch tech ids (catalog still adds regiment/ship unlock bullets)

## Tests

- `app/test/tech_tree_widget_test.dart` — Batch-10, Batch-11, Batch-12 widget tests; assert concrete substrings and absence of `Improves Military capabilities`
- Command: `flutter test app/test/tech_tree_widget_test.dart`

Refs #1634
Refs #1635
Refs #1636

Made with [Cursor](https://cursor.com)