### PR TITLE
refactor(map): consolidate map visualization resource helpers

### DIFF
--- a/packages/colonizethis_map/lib/colonizethis_map.dart
+++ b/packages/colonizethis_map/lib/colonizethis_map.dart
@@ -10,7 +10,9 @@ export 'src/tile_map_generator.dart';
 export 'src/tile_map_generation_fn.dart';
 export 'src/tile_map_visualization.dart';
 export 'src/tile_map_visualization_shared.dart'
-    show landSeedMarkerRgb, continentSeedMarkerRgb, resourceIdToLegendLetter;
+    show continentSeedMarkerRgb, geographicGameWorldLegendResources,
+        geographicGameWorldResourceGlyphLetter, landSeedMarkerRgb,
+        resourceIdToLegendLetter;
 export 'src/init_game_map_view_data.dart';
 export 'src/port_icon_placement.dart';
 export 'src/gp_ownership_tint.dart';

--- a/packages/colonizethis_map/lib/src/game_world_state_map_visualizer.dart
+++ b/packages/colonizethis_map/lib/src/game_world_state_map_visualizer.dart
@@ -310,7 +310,11 @@ Uint8List renderInitGameMapToPngFromViewData({
 
     // Legend height: geographic = title + Sea + terrains + "Resources:" + g/t/i + ports; else title + factions + ports.
     final legendLines = geographicMode
-        ? (1 + 1 + region.terrainColors.length + 1 + 3 +
+        ? (1 +
+            1 +
+            region.terrainColors.length +
+            1 +
+            geographicGameWorldLegendResources.length +
             (region.portMarkers.isNotEmpty ? 1 : 0))
         : (2 + region.factionColors.length +
             (region.portMarkers.isNotEmpty ? 1 : 0));
@@ -361,21 +365,17 @@ Uint8List renderInitGameMapToPngFromViewData({
 
     // Resource glyphs (geographic mode): g/t/i only per SPEC/program/map-visualization.md § Geographic legend scope.
     if (geographicMode) {
-      const geographicLegendResources = {'grain': 'g', 'timber': 't', 'iron': 'i'};
       for (final cell in region.cells) {
-        final letter = cell.resourceId != null ? geographicLegendResources[cell.resourceId] : null;
+        final letter = geographicGameWorldResourceGlyphLetter(cell.resourceId);
         if (letter == null) continue;
-        final cx = cell.x * region.cellSize + region.cellSize ~/ 2;
-        final cy = cell.y * region.cellSize + region.cellSize ~/ 2;
-        const letterOffsetX = 4;
-        const letterOffsetY = 6;
-        img.drawString(
+        drawResourceLetterAtCellCenter(
           image,
-          letter,
-          font: img.arial14,
-          x: cx - letterOffsetX,
-          y: cy - letterOffsetY,
+          letter: letter,
+          cellX: cell.x,
+          cellY: cell.y,
+          cellSize: region.cellSize,
           color: black,
+          offsetY: 6,
         );
       }
     }
@@ -430,11 +430,9 @@ Uint8List renderInitGameMapToPngFromViewData({
         color: black,
       );
       legendY += legendLineHeight;
-      for (final (letter, label) in [
-        ('g', 'Grain'),
-        ('t', 'Timber'),
-        ('i', 'Iron'),
-      ]) {
+      for (final r in geographicGameWorldLegendResources) {
+        final letter = resourceToLegendLetter(r);
+        final label = resourceToLegendLabel(r);
         img.drawString(
           image,
           '$letter  $label',

--- a/packages/colonizethis_map/lib/src/tile_map_visualization.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_visualization.dart
@@ -9,9 +9,9 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'tile_map_visualization_shared.dart'
     show colorMapFromIds, continentSeedMarkerRgb, drawBorders,
         drawLegendContinentSeedMarker, drawLegendLandSeedMarker,
-        drawLegendSwatch, landSeedMarkerRgb, legendLineHeight, legendPadding,
-        regionPalette, resourceToLegendLabel, resourceToLegendLetter, swatchGap,
-        swatchSize, terrainColorRgb;
+        drawLegendSwatch, drawResourceLetterAtCellCenter, landSeedMarkerRgb,
+        legendLineHeight, legendPadding, regionPalette, resourceToLegendLabel,
+        resourceToLegendLetter, swatchGap, swatchSize, terrainColorRgb;
 
 /// Deep blue for sea zones. SPEC/program/map-visualization.md § Tile map PNG export.
 const (int, int, int) seaColorRgb = (20, 60, 140);
@@ -255,18 +255,19 @@ Uint8List renderTileMapToPng(
 
   // Resource letters (drawn last on map so visible).
   if (result.resourceGrid != null) {
-    const letterOffsetX = 4;
-    const letterOffsetY = 7;
     for (var y = 0; y < result.height; y++) {
       for (var x = 0; x < result.width; x++) {
         final r = result.resourceAt(x, y);
         if (r == null) continue;
         final letter = resourceToLegendLetter(r);
-        final cx = x * cellSize + cellSize ~/ 2;
-        final cy = y * cellSize + cellSize ~/ 2;
-        final px = cx - letterOffsetX;
-        final py = cy - letterOffsetY;
-        img.drawString(image, letter, font: img.arial14, x: px, y: py, color: black);
+        drawResourceLetterAtCellCenter(
+          image,
+          letter: letter,
+          cellX: x,
+          cellY: y,
+          cellSize: cellSize,
+          color: black,
+        );
       }
     }
   }

--- a/packages/colonizethis_map/lib/src/tile_map_visualization_shared.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_visualization_shared.dart
@@ -137,6 +137,55 @@ String? resourceIdToLegendLetter(String? resourceId) {
   }
 }
 
+/// Resources shown as glyphs and legend rows in game-world geographic PNG (view-data path only).
+/// SPEC/program/map-visualization.md § Geographic legend scope (subset g, t, i).
+const List<Resource> geographicGameWorldLegendResources = [
+  Resource.grain,
+  Resource.timber,
+  Resource.iron,
+];
+
+/// Single-letter glyph for [resourceId] in geographic game-world map mode, or null if not in the g/t/i subset or unknown id.
+String? geographicGameWorldResourceGlyphLetter(String? resourceId) {
+  if (resourceId == null || resourceId.isEmpty) return null;
+  try {
+    final r = Resource.values.byName(resourceId);
+    switch (r) {
+      case Resource.grain:
+      case Resource.timber:
+      case Resource.iron:
+        return resourceToLegendLetter(r);
+      default:
+        return null;
+    }
+  } on ArgumentError {
+    return null;
+  }
+}
+
+/// Draws a single-letter resource glyph at cell centre (PNG map export). Shared by tile map and game-world geographic renderers.
+void drawResourceLetterAtCellCenter(
+  img.Image image, {
+  required String letter,
+  required int cellX,
+  required int cellY,
+  required int cellSize,
+  required img.Color color,
+  int offsetX = 4,
+  int offsetY = 7,
+}) {
+  final cx = cellX * cellSize + cellSize ~/ 2;
+  final cy = cellY * cellSize + cellSize ~/ 2;
+  img.drawString(
+    image,
+    letter,
+    font: img.arial14,
+    x: cx - offsetX,
+    y: cy - offsetY,
+    color: color,
+  );
+}
+
 /// Grey shades for minor nations (distinct from vibrant GP colours). Deterministic order.
 const List<(int r, int g, int b)> minorNationPalette = [
   (70, 70, 70),

--- a/packages/colonizethis_map/test/tile_map_visualization_test.dart
+++ b/packages/colonizethis_map/test/tile_map_visualization_test.dart
@@ -353,6 +353,31 @@ void main() {
     });
   });
 
+  group('geographicGameWorldResourceGlyphLetter', () {
+    test('returns letters only for grain, timber, iron resource ids', () {
+      expect(geographicGameWorldResourceGlyphLetter('grain'), 'g');
+      expect(geographicGameWorldResourceGlyphLetter('timber'), 't');
+      expect(geographicGameWorldResourceGlyphLetter('iron'), 'i');
+    });
+
+    test('returns null for ids outside geographic subset, empty, or invalid', () {
+      expect(geographicGameWorldResourceGlyphLetter('gold'), isNull);
+      expect(geographicGameWorldResourceGlyphLetter('notAResource'), isNull);
+      expect(geographicGameWorldResourceGlyphLetter(null), isNull);
+      expect(geographicGameWorldResourceGlyphLetter(''), isNull);
+    });
+  });
+
+  group('geographicGameWorldLegendResources', () {
+    test('is grain, timber, iron per SPEC geographic legend scope', () {
+      expect(geographicGameWorldLegendResources, const [
+        Resource.grain,
+        Resource.timber,
+        Resource.iron,
+      ]);
+    });
+  });
+
   group('openInDefaultViewer', () {
     test('does not throw; returns bool', () {
       final path = writeTileMapImageToTempFile(smallResult, topology);


### PR DESCRIPTION
## Summary
Implements Refs #1652: consolidates duplicated geographic resource handling and map glyph drawing for PNG visualizers.

## Changes
- Add `geographicGameWorldLegendResources`, `geographicGameWorldResourceGlyphLetter`, and `drawResourceLetterAtCellCenter` in `tile_map_visualization_shared.dart` (SPEC-aligned g/t/i subset).
- `game_world_state_map_visualizer`: use shared helpers for glyphs, legend rows, and legend line count (no magic `3`).
- `tile_map_visualization`: use `drawResourceLetterAtCellCenter` for resource grid letters (default offsets unchanged).
- Export new geographic helpers from package barrel for tests/consumers.
- Tests: glyph letter positive/negative cases; legend resource list order.

## Tests
`cd packages/colonizethis_map && dart analyze lib test && dart test`

## Scope
Full slice for issue 1652; no SPEC edit (existing map-visualization.md already defines geographic legend scope).

Refs #1652

Made with [Cursor](https://cursor.com)