### PR TITLE
fix(ui): move tile-scoped Tile action to header

### DIFF
--- a/SPEC/ui/civilian-units-panel.md
+++ b/SPEC/ui/civilian-units-panel.md
@@ -62,8 +62,8 @@ For each civilian unit, the panel shows:
 
 - **Selection model:** In tile scope, the panel keeps one selected unit id. Initial selection is the unit id provided by the map marker tap; if missing, the first row in deterministic list order is selected.
 - **Selection swap:** In tile scope, tapping a different row changes selected unit id immediately.
-- **Action target:** In tile scope, row actions (Assign, Cancel, Tile) apply to the selected row only.
-- **Tile button:** In tile scope, the selected row includes a **Tile** button that opens province/tile detail for that selected row’s rendered tile (`assignedTileKey` when present, otherwise `tileKey`).
+- **Action target:** In tile scope, row actions (**Assign**, **Cancel**) apply to the selected row only.
+- **Header actions (tile scope only):** The panel title row includes **Tile** then **Train** (left to right after the title). **Tile** opens province/tile detail for the **currently selected** unit’s **rendered tile** (`assignedTileKey` when present, otherwise `tileKey`). When there is no selected unit or no rendered tile key, **Tile** is disabled (or equivalent). **Full-list mode** (panel opened from the rail, no tile scope): the title row has **Train** only—no **Tile** in the header.
 
 ---
 
@@ -117,9 +117,13 @@ For each civilian unit, the panel shows:
 
 - **Given** the user taps a civilian map marker for tile key `T`, **when** the civilian units panel opens in tile scope, **then** the UI layer lists only player-owned civilian units whose rendered tile equals `T`.
 
-- **Given** the civilian units panel is open in tile scope with selected unit `A`, **when** the user taps row `B`, **then** the UI layer updates selection to `B` and uses `B` as the target for panel actions.
+- **Given** the civilian units panel is open in tile scope with selected unit `A`, **when** the user taps row `B`, **then** the UI layer updates selection to `B` and uses `B` as the target for row actions and for the header **Tile** action.
 
-- **Given** the civilian units panel is open in tile scope and a unit row is selected, **when** the user presses **Tile**, **then** the UI layer opens province/tile detail for the selected row’s rendered tile key.
+- **Given** the civilian units panel is open in tile scope and a unit row is selected, **when** the user presses **Tile** in the panel header, **then** the UI layer opens province/tile detail for the selected row’s rendered tile key.
+
+- **Given** the civilian units panel is open in **full-list** mode (no tile scope), **when** the panel is displayed, **then** the title row shows **Train** only and does not show a header **Tile** button.
+
+- **Given** the civilian units panel is open in tile scope with **no** listed units for that tile (empty scoped list), **when** the panel is displayed, **then** the header **Tile** control does not open detail incorrectly (disabled or non-actionable).
 
 ---
 

--- a/app/lib/features/game/widgets/civilian_units_panel.dart
+++ b/app/lib/features/game/widgets/civilian_units_panel.dart
@@ -151,10 +151,11 @@ class _CivilianUnitsPanelState extends State<CivilianUnitsPanel> {
     );
     List<Unit> scopedOw = ow;
     List<Unit> scopedNw = nw;
-    final tileScopeTileKey = widget.tileScopeTileKey;
-    if (tileScopeTileKey != null && tileScopeTileKey.isNotEmpty) {
-      scopedOw = ow.where((u) => _renderedTileKey(u) == tileScopeTileKey).toList();
-      scopedNw = nw.where((u) => _renderedTileKey(u) == tileScopeTileKey).toList();
+    final scopeTileKey = widget.tileScopeTileKey;
+    final tileScopeActive = scopeTileKey != null && scopeTileKey.isNotEmpty;
+    if (tileScopeActive) {
+      scopedOw = ow.where((u) => _renderedTileKey(u) == scopeTileKey).toList();
+      scopedNw = nw.where((u) => _renderedTileKey(u) == scopeTileKey).toList();
     }
     final hasAny = scopedOw.isNotEmpty || scopedNw.isNotEmpty;
     final allScopedUnits = <Unit>[...scopedOw, ...scopedNw];
@@ -164,10 +165,37 @@ class _CivilianUnitsPanelState extends State<CivilianUnitsPanel> {
             allScopedUnits.any((u) => u.id == selectedUnitId)
         ? selectedUnitId
         : (allScopedUnits.isNotEmpty ? allScopedUnits.first.id : null);
+    Unit? resolvedSelectedUnit;
+    if (resolvedSelectedUnitId != null) {
+      for (final u in allScopedUnits) {
+        if (u.id == resolvedSelectedUnitId) {
+          resolvedSelectedUnit = u;
+          break;
+        }
+      }
+    }
+    final headerTileKey = resolvedSelectedUnit == null
+        ? null
+        : _renderedTileKey(resolvedSelectedUnit);
 
     return UnitsPanelShell(
-      title: tileScopeTileKey != null ? 'Civilian Units (Tile)' : 'Civilian Units',
+      title: tileScopeActive ? 'Civilian Units (Tile)' : 'Civilian Units',
       actions: [
+        if (tileScopeActive)
+          CtNinePatchButton(
+            enabled: headerTileKey != null && headerTileKey.isNotEmpty,
+            onPressed: () {
+              final key = headerTileKey;
+              if (key == null || key.isEmpty) {
+                return;
+              }
+              widget.bus.emit(const ClosePanelEvent());
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                widget.bus.emit(OpenMapTileDetailEvent(tileKey: key));
+              });
+            },
+            child: const Text('Tile'),
+          ),
         CtNinePatchButton(
           onPressed: () {
             widget.bus.emit(const ClosePanelEvent());
@@ -190,7 +218,7 @@ class _CivilianUnitsPanelState extends State<CivilianUnitsPanel> {
               availableWorkTargets: widget.availableWorkTargets,
               humanPlayerId: widget.humanPlayerId,
               bus: widget.bus,
-              isTileScope: tileScopeTileKey != null,
+              isTileScope: tileScopeActive,
               isSelectedInTileScope: resolvedSelectedUnitId == u.id,
               onSelectInTileScope: () => setState(() => _selectedUnitId = u.id),
             ),
@@ -206,7 +234,7 @@ class _CivilianUnitsPanelState extends State<CivilianUnitsPanel> {
               availableWorkTargets: widget.availableWorkTargets,
               humanPlayerId: widget.humanPlayerId,
               bus: widget.bus,
-              isTileScope: tileScopeTileKey != null,
+              isTileScope: tileScopeActive,
               isSelectedInTileScope: resolvedSelectedUnitId == u.id,
               onSelectInTileScope: () => setState(() => _selectedUnitId = u.id),
             ),
@@ -419,32 +447,13 @@ class _UnitRow extends StatelessWidget {
         if (regionId == null) return;
         bus.emit(const ClosePanelEvent());
         WidgetsBinding.instance.addPostFrameCallback((_) {
-          bus.emit(
-            LocateMapTileEvent(
-              tileKey: tileKey,
-              regionId: regionId,
-            ),
-          );
+          bus.emit(LocateMapTileEvent(tileKey: tileKey, regionId: regionId));
         });
       },
       trailing: showActions
           ? Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                if (isTileScope)
-                  CtNinePatchButton(
-                    onPressed: () {
-                      final renderedTileKey = _renderedTileKey(unit);
-                      if (renderedTileKey == null) return;
-                      bus.emit(const ClosePanelEvent());
-                      WidgetsBinding.instance.addPostFrameCallback((_) {
-                        bus.emit(
-                          OpenMapTileDetailEvent(tileKey: renderedTileKey),
-                        );
-                      });
-                    },
-                    child: const Text('Tile'),
-                  ),
                 if (_isIdleNoPending)
                   CtNinePatchButton(
                     onPressed: () => _showOrderMenu(context),

--- a/app/test/civilian_units_panel_test.dart
+++ b/app/test/civilian_units_panel_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
 import 'package:colonizethis_app/features/game/widgets/civilian_units_panel.dart';
+import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_shell.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
 
@@ -124,6 +125,18 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Civilian Units'), findsOneWidget);
+    });
+
+    testWidgets('AC: full-list mode has Train only in header (no Tile)', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildPanel(game: game, humanPlayerId: humanPlayerIdWithUnits),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Train'), findsOneWidget);
+      expect(find.text('Tile'), findsNothing);
     });
 
     testWidgets('AC: Empty state when human player has zero civilian units', (
@@ -304,7 +317,11 @@ void main() {
         bus.stream.listen((e) => sequence.add(e.runtimeType));
 
         await tester.pumpWidget(
-          buildPanel(game: game, humanPlayerId: humanPlayerIdWithUnits, bus: bus),
+          buildPanel(
+            game: game,
+            humanPlayerId: humanPlayerIdWithUnits,
+            bus: bus,
+          ),
         );
         await tester.pumpAndSettle();
 
@@ -343,7 +360,8 @@ void main() {
 
         final availableWorkTargets = <String, List<String>>{};
         for (final u in idleCivilians) {
-          final allowed = workOrderTargetsByUnitType[u.type] ?? const <String>[];
+          final allowed =
+              workOrderTargetsByUnitType[u.type] ?? const <String>[];
           if (allowed.isNotEmpty) {
             availableWorkTargets[u.id] = [allowed.first];
           }
@@ -728,7 +746,7 @@ void main() {
     );
 
     testWidgets(
-      'tile-scoped mode shows Tile action for selected civilian',
+      'tile-scoped mode: Tile then Train in header; no Tile on ListTiles',
       (WidgetTester tester) async {
         final units = [
           ...game.worldState.oldWorld.units,
@@ -744,17 +762,6 @@ void main() {
         final scopedTileKey = civilianWithTile.first.tileKey!;
         final scopedUnitId = civilianWithTile.first.id;
         final bus = AppEventBus.create();
-
-        await tester.pumpWidget(
-          buildPanel(
-            game: game,
-            humanPlayerId: humanPlayerIdWithUnits,
-            bus: bus,
-            currentOrders: const Orders(),
-            availableWorkTargets: const {},
-          ),
-        );
-        await tester.pumpAndSettle();
 
         await tester.pumpWidget(
           MaterialApp(
@@ -774,7 +781,108 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('Civilian Units (Tile)'), findsOneWidget);
-        expect(find.text('Tile'), findsAtLeastNWidgets(1));
+        expect(find.text('Tile'), findsOneWidget);
+
+        final shellButtons = find.descendant(
+          of: find.byType(UnitsPanelShell),
+          matching: find.byType(CtNinePatchButton),
+        );
+        expect(
+          find.descendant(of: shellButtons.at(0), matching: find.text('Tile')),
+          findsOneWidget,
+        );
+        expect(
+          find.descendant(of: shellButtons.at(1), matching: find.text('Train')),
+          findsOneWidget,
+        );
+
+        expect(
+          find.descendant(
+            of: find.byType(ListTile),
+            matching: find.text('Tile'),
+          ),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets('tile-scoped empty list: header Tile is disabled', (
+      WidgetTester tester,
+    ) async {
+      final bus = AppEventBus.create();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CivilianUnitsPanel(
+              game: game,
+              humanPlayerId: humanPlayerIdWithUnits,
+              bus: bus,
+              tileScopeTileKey:
+                  'oldWorld|no_civilian_units_on_this_province|0|0',
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Civilian Units (Tile)'), findsOneWidget);
+      expect(find.text('No civilian units'), findsOneWidget);
+      final tileButton = find.ancestor(
+        of: find.text('Tile'),
+        matching: find.byType(CtNinePatchButton),
+      );
+      expect(tester.widget<CtNinePatchButton>(tileButton).enabled, isFalse);
+    });
+
+    testWidgets(
+      'tile-scoped header Tile emits OpenMapTileDetailEvent for rendered tile',
+      (WidgetTester tester) async {
+        final units = [
+          ...game.worldState.oldWorld.units,
+          ...game.worldState.newWorld.units,
+        ];
+        final civilian = units.where(
+          (u) =>
+              u.ownerId == humanPlayerIdWithUnits &&
+              u.tileKey != null &&
+              _isCivilian(u),
+        );
+        if (civilian.isEmpty) return;
+        final u = civilian.first;
+        final rendered = u.assignedTileKey?.isNotEmpty == true
+            ? u.assignedTileKey!
+            : u.tileKey!;
+
+        final bus = AppEventBus.create();
+        OpenMapTileDetailEvent? captured;
+        final sub = bus.on<OpenMapTileDetailEvent>().listen((e) {
+          captured = e;
+        });
+        addTearDown(sub.cancel);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: CivilianUnitsPanel(
+                game: game,
+                humanPlayerId: humanPlayerIdWithUnits,
+                bus: bus,
+                tileScopeTileKey: rendered,
+                initialSelectedUnitId: u.id,
+              ),
+            ),
+          ),
+        );
+        // Avoid pumpAndSettle: nine-patch buttons may not settle in widget tests.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        captured = null;
+        await tester.tap(find.text('Tile'));
+        await tester.pump();
+        await tester.pump();
+        expect(captured, isNotNull);
+        expect(captured?.tileKey, rendered);
       },
     );
   });


### PR DESCRIPTION
## Summary
- Move the tile-scoped **Tile** action from selected rows to the Civilian Units panel header, ordered **Tile -> Train**.
- Keep full-list mode unchanged with **Train** only in the header (no Tile button when not tile-scoped).
- Update `SPEC/ui/civilian-units-panel.md` and widget tests for header behavior, edge cases, and event wiring.

## Test plan
- [x] `flutter test test/civilian_units_panel_test.dart`

Refs #1668

Made with [Cursor](https://cursor.com)