### PR TITLE
refactor(logging): enforce package-owned logger APIs and prefixes

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -291,6 +291,9 @@ jobs:
       - name: Check logic/ai decoupling convention (SPEC/program/repo-and-packages.md)
         run: tool/check_logic_ai_decoupling.sh
 
+      - name: Check package logger API convention (SPEC/program/logging/logging.md)
+        run: tool/check_naked_logger_usage.sh
+
       - name: Wang incremental assets gate (Python)
         run: |
           set -euo pipefail

--- a/SPEC/program/logging/logging.md
+++ b/SPEC/program/logging/logging.md
@@ -27,9 +27,18 @@
 
 ---
 
-## Prefixes
+## Prefixes and package ownership
 
-Use **`colonizethis_logger`** (`logicLogger`, `aiLogger`, `mapLogger`, etc.). Message text must **not** repeat the top-level prefix (avoid `logic: logic: …`).
+Each package is the owner of its own logging prefix and must define exactly one
+package-local constant file at `lib/package_log_prefix.dart` containing
+`kPackageLogPrefix`.
+
+Each package must expose exactly one package-local logging API at
+`lib/package_logger.dart` with signature `CtLogger packageLogger([String? subPrefix])`.
+Package code must use this API for all logger acquisition. Direct/naked
+`Logger(...)` construction in package code is forbidden.
+
+Message text must **not** repeat the top-level prefix (avoid `logic: logic: …`).
 
 | Prefix | Typical ownership |
 |--------|-------------------|
@@ -42,8 +51,12 @@ Use **`colonizethis_logger`** (`logicLogger`, `aiLogger`, `mapLogger`, etc.). Me
 | `game` | Flame / in-game components |
 | `ctdev` | Ctdev app lifecycle, sim controller |
 | `tui` | Ctterm (see [ctterm.md](../../tui/ctterm.md)) |
+| package-defined | Any other first-party package not listed above must define its own package prefix in `lib/package_log_prefix.dart` |
 
-Sub-areas may use **dot** sub-prefixes via factories (e.g. `logicLogger('combat')` → `logic.combat` in logger naming; message body still uses stable **tokens** such as `combat battle_start` for grep). Align **session log filter** lists with [session_log_buffer](../../../packages/session_log_buffer/lib/session_log_buffer.dart) `knownPrefixes`.
+Sub-areas may use dot sub-prefixes via package-local `packageLogger` factories
+(e.g. `packageLogger('combat')` -> `logic.combat` in logger naming; message body
+still uses stable tokens such as `combat battle_start` for grep). Align session
+log filter lists with [session_log_buffer](../../../packages/session_log_buffer/lib/session_log_buffer.dart) `knownPrefixes`.
 
 ---
 
@@ -68,6 +81,8 @@ All hosts consume the **same** `Logger` stream from packages; hosts only differ 
 
 - **Given** code in packages, app, ctdev, or ctterm that implements a feature described in an annex, **when** that feature runs in a dev configuration with file/debug logging enabled, **then** emitted lines follow the **info vs debug** split and **prefix** rules in this document and the relevant annex.
 - **Given** a new PR that touches logging behavior, **when** reviewers use [CONTRIBUTING.md](../../../CONTRIBUTING.md) checklist, **then** they confirm alignment with **SPEC/program/logging/** and linked sink specs.
+- **Given** any first-party package in this repository, **when** package logging setup is reviewed, **then** the package contains `lib/package_log_prefix.dart` defining `kPackageLogPrefix` and `lib/package_logger.dart` defining `packageLogger`.
+- **Given** CI quality checks run for a pull request, **when** any package code uses naked `Logger(...)` instead of the package API, **then** CI fails with a blocking convention error.
 
 ---
 

--- a/app/lib/config/map_terrain_config.dart
+++ b/app/lib/config/map_terrain_config.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
-final _log = gameLogger();
+final _log = packageLogger();
 
 /// Paths + expected tile pixel size for one Wang tileset (PixelLab JSON + PNG atlas).
 class WangTilesetAssetConfig {

--- a/app/lib/core/services/app_event_handler.dart
+++ b/app/lib/core/services/app_event_handler.dart
@@ -23,7 +23,7 @@
 import 'dart:async';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -42,7 +42,7 @@ import '../../providers/games_provider.dart';
 typedef DialogBuilder =
     Widget Function(BuildContext context, Map<String, Object?>? params);
 
-final _log = appLogger('event');
+final _log = packageLogger('event');
 
 class AppEventHandler {
   AppEventHandler({

--- a/app/lib/core/services/app_event_handler_scope.dart
+++ b/app/lib/core/services/app_event_handler_scope.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:colonizethis_app/app.dart';
@@ -41,8 +41,8 @@ const String combatModeChoiceDialogId = 'combat_mode_choice';
 /// [OpenDialogEvent] id for [QuickBattleResultDialog]. SPEC/program/app-ui-wiring.md.
 const String quickBattleResultDialogId = 'quick_battle_result';
 
-final _logShell = appLogger('shell');
-final _logEvent = appLogger('event');
+final _logShell = packageLogger('shell');
+final _logEvent = packageLogger('event');
 
 /// Applies a chosen combat mode to the current game session state.
 @visibleForTesting

--- a/app/lib/core/services/game_service.dart
+++ b/app/lib/core/services/game_service.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -21,7 +21,7 @@ class _GameMapCache {
 }
 
 /// Pass milestones for in-app tile map generation (SPEC/program/logging/map-generation.md).
-final _mapGenPassLog = mapLogger('tile_map');
+final _mapGenPassLog = packageLogger('tile_map');
 
 /// Loads/saves games and advances turn. SPEC/project/phase-1: app invokes TurnResolver and persists via colonizethis_save.
 /// Phase 2: createNewGame uses full game-setup pipeline; nextTurn requires cached/persisted map data.
@@ -68,7 +68,7 @@ class GameService {
       _requireMapData(gameId);
       return game;
     } catch (e, st) {
-      saveLogger().e(
+      packageLogger().e(
         'required map data missing/invalid for gameId=$gameId',
         error: e,
         stackTrace: st,
@@ -156,7 +156,7 @@ class GameService {
       );
       return game;
     } catch (e, st) {
-      saveLogger().e(
+      packageLogger().e(
         'save: loadAutoSaveGame failed',
         error: e,
         stackTrace: st,
@@ -178,7 +178,7 @@ class GameService {
         warpLinks: md.warpLinks,
       );
     } catch (e, st) {
-      saveLogger().e(
+      packageLogger().e(
         'save: auto-save mirror failed',
         error: e,
         stackTrace: st,

--- a/app/lib/features/game/dialogue/ct_dialogue_view.dart
+++ b/app/lib/features/game/dialogue/ct_dialogue_view.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:jenny/jenny.dart';
 
 /// Flutter/Jenny dialogue view that drives UI via callbacks and completers.
 /// SPEC/ui/dialogue-presentation.md, SPEC/ai/dialogue-content-and-yarn.md.
 class CtDialogueView extends DialogueView {
-  CtDialogueView({CtLogger? logger}) : _log = logger ?? appLogger('dialogue');
+  CtDialogueView({CtLogger? logger}) : _log = logger ?? packageLogger('dialogue');
 
   final CtLogger _log;
 

--- a/app/lib/features/game/dialogue/game_start_intro_overlay.dart
+++ b/app/lib/features/game/dialogue/game_start_intro_overlay.dart
@@ -1,4 +1,4 @@
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 import 'package:jenny/jenny.dart';
@@ -44,7 +44,7 @@ class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
   }
 
   Future<void> _loadAndRun() async {
-    final log = widget.logger ?? appLogger('dialogue');
+    final log = widget.logger ?? packageLogger('dialogue');
     try {
       final bundle = widget.assetBundle ?? rootBundle;
       final text = await bundle.loadString(_kIntroAsset);

--- a/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:flutter/services.dart';
 import 'package:jenny/jenny.dart';
 
@@ -67,7 +67,7 @@ class _InterventionDialogueOverlayState extends State<InterventionDialogueOverla
   }
 
   Future<void> _runFlow() async {
-    final log = widget.logger ?? appLogger('dialogue');
+    final log = widget.logger ?? packageLogger('dialogue');
     try {
       final bundle = widget.assetBundle ?? rootBundle;
       final text = await bundle.loadString(_kAsset);

--- a/app/lib/features/game/dialogue/overture_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/overture_dialogue_overlay.dart
@@ -2,7 +2,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:jenny/jenny.dart';
 
 import '../../../../widgets/ct_dialog_shell.dart';
@@ -56,7 +56,7 @@ class _OvertureDialogueOverlayState extends State<OvertureDialogueOverlay> {
   }
 
   Future<void> _loadAndRunIntro() async {
-    final log = widget.logger ?? appLogger('dialogue');
+    final log = widget.logger ?? packageLogger('dialogue');
     try {
       final text = await rootBundle.loadString(_kOvertureAsset);
       final project = YarnProject();

--- a/app/lib/features/game/flame/civilian_icon_cache.dart
+++ b/app/lib/features/game/flame/civilian_icon_cache.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 import 'dart:ui' as ui;
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:flutter/services.dart';
 
 import '../../../config/app_assets.dart';
 
-final _log = gameLogger();
+final _log = packageLogger();
 
 const Map<String, String> kCivilianTypeToIconSlug = {
   'builder': 'builder',

--- a/app/lib/features/game/flame/province_label_icon_cache.dart
+++ b/app/lib/features/game/flame/province_label_icon_cache.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 import 'dart:ui' as ui;
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:flutter/services.dart';
 
 import '../../../config/app_assets.dart';
 
-final _log = gameLogger();
+final _log = packageLogger();
 
 const Set<String> kProvinceLabelIconIds = {
   'map_capital_star',

--- a/app/lib/features/game/flame/region_map_component.dart
+++ b/app/lib/features/game/flame/region_map_component.dart
@@ -3,7 +3,7 @@ import 'dart:math' as math;
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart'
     show PlayerView, resourceIdVisibleInPlayerView;
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:flame/components.dart';
 import 'package:flutter/material.dart';
@@ -20,7 +20,7 @@ import 'town_icon_cache.dart';
 part 'region_map_component_shared.dart';
 part 'region_map_component_render_mixin.dart';
 
-final _log = gameLogger();
+final _log = packageLogger();
 
 /// Flame-based region map component. Renders one RegionMapViewData and exposes
 /// hover/selection state via callbacks. SPEC/ui/map-widget.md.

--- a/app/lib/features/game/flame/resource_icon_cache.dart
+++ b/app/lib/features/game/flame/resource_icon_cache.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 import 'dart:ui' as ui;
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:flutter/services.dart';
 
 import '../../../config/app_assets.dart';
 
-final _log = gameLogger();
+final _log = packageLogger();
 
 /// Resource IDs for which icons exist (excludes commodities without tile resources).
 const Set<String> kResourceIconIds = {

--- a/app/lib/features/game/flame/terrain_tileset.dart
+++ b/app/lib/features/game/flame/terrain_tileset.dart
@@ -4,11 +4,11 @@ import 'dart:ui' as ui;
 
 import 'package:colonizethis_app/config/map_terrain_config.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:colonizethis_map/colonizethis_map.dart' show CellViewData;
 import 'package:flutter/services.dart';
 
-final _log = gameLogger();
+final _log = packageLogger();
 
 /// Sea terrain identifier (not in TerrainType enum).
 const String seaTerrainId = 'sea';

--- a/app/lib/features/game/flame/town_icon_cache.dart
+++ b/app/lib/features/game/flame/town_icon_cache.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 import 'dart:ui' as ui;
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:flutter/services.dart';
 
 import '../../../config/app_assets.dart';
 
-final _log = gameLogger();
+final _log = packageLogger();
 
 const Set<String> kTownIconIds = {'port', 'town_inland_64'};
 

--- a/app/lib/features/shell/new_game_setup_flow.dart
+++ b/app/lib/features/shell/new_game_setup_flow.dart
@@ -3,7 +3,7 @@
 import 'dart:async';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -18,7 +18,7 @@ import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 
-final _log = appLogger('shell');
+final _log = packageLogger('shell');
 
 sealed class _NewGameOutcome {}
 

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:io' show Directory;
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
@@ -19,7 +19,7 @@ Future<void> _openHiveBoxSafely(String name) async {
     await Hive.openBox<dynamic>(name);
   } catch (e, st) {
     // Boxes may be locked (e.g. another instance) or corrupt; app still runs where possible.
-    dataLogger(
+    packageLogger(
       'hive',
     ).w('failed to open box "$name"', error: e, stackTrace: st);
   }
@@ -80,7 +80,7 @@ void main() {
       );
     },
     (Object error, StackTrace stackTrace) {
-      appLogger().e(
+      packageLogger().e(
         'uncaught async error',
         error: error,
         stackTrace: stackTrace,

--- a/app/lib/package_log_prefix.dart
+++ b/app/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'app';

--- a/app/lib/package_logger.dart
+++ b/app/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:colonizethis_app/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/app/lib/package_logger.dart
+++ b/app/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:colonizethis_app/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/app/lib/providers/home_fleet_cargo_provider.dart
+++ b/app/lib/providers/home_fleet_cargo_provider.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -7,7 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'game_service_provider.dart';
 import 'games_provider.dart';
 
-final _homeFleetCargoLog = appLogger('home_fleet_cargo');
+final _homeFleetCargoLog = packageLogger('home_fleet_cargo');
 
 class HomeFleetCargoSummary {
   const HomeFleetCargoSummary({

--- a/app/lib/widgets/ct_dialog_shell.dart
+++ b/app/lib/widgets/ct_dialog_shell.dart
@@ -1,4 +1,4 @@
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:flame/widgets.dart';
 import 'package:flutter/material.dart';
 
@@ -74,7 +74,7 @@ class CtDialogShell extends StatelessWidget {
                   child: child,
                 ),
                 errorBuilder: (_) {
-                  appLogger('ui').w(
+                  packageLogger('ui').w(
                     'dialog nine-patch asset not found, using fallback frame',
                   );
                   return _FallbackDialogFrame(

--- a/app/lib/widgets/ct_nine_patch_button.dart
+++ b/app/lib/widgets/ct_nine_patch_button.dart
@@ -1,4 +1,4 @@
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:flame/widgets.dart';
 import 'package:flutter/material.dart';
 
@@ -84,7 +84,7 @@ class CtNinePatchButton extends StatelessWidget {
               child: child,
             ),
             errorBuilder: (_) {
-              appLogger('ui').w(
+              packageLogger('ui').w(
                 'nine-patch button asset not found, using fallback',
               );
               return _FallbackButton(

--- a/app/lib/widgets/ct_panel.dart
+++ b/app/lib/widgets/ct_panel.dart
@@ -1,4 +1,4 @@
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:flame/widgets.dart';
 import 'package:flutter/material.dart';
 
@@ -47,7 +47,7 @@ class CtPanel extends StatelessWidget {
             child: child,
           ),
           errorBuilder: (_) {
-            appLogger('ui').w(
+            packageLogger('ui').w(
               'panel nine-patch asset not found, using fallback',
             );
             return _FallbackPanel(

--- a/app/test/ct_dialogue_view_test.dart
+++ b/app/test/ct_dialogue_view_test.dart
@@ -1,4 +1,4 @@
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/package_logger.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jenny/jenny.dart';
@@ -11,7 +11,7 @@ void main() {
 
   test('CtDialogueView advanceLine completes line future and clears state',
       () async {
-    final view = CtDialogueView(logger: appLogger('dialogue'));
+    final view = CtDialogueView(logger: packageLogger('dialogue'));
 
     var stateCalls = 0;
     view.onStateChanged = (_, _) => stateCalls++;
@@ -37,7 +37,7 @@ void main() {
 
   test('CtDialogueView selectOption completes choice future with index',
       () async {
-    final view = CtDialogueView(logger: appLogger('dialogue'));
+    final view = CtDialogueView(logger: packageLogger('dialogue'));
 
     final choice = DialogueChoice([
       DialogueOption(content: LineContent('Option A')),
@@ -58,7 +58,7 @@ void main() {
 
   test('CtDialogueView onDialogueFinish clears state and signals nulls',
       () async {
-    final view = CtDialogueView(logger: appLogger('dialogue'));
+    final view = CtDialogueView(logger: packageLogger('dialogue'));
 
     var nullCalls = 0;
     view.onStateChanged = (line, choice) {

--- a/ctdev/lib/main.dart
+++ b/ctdev/lib/main.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctdev/package_logger.dart';
 import 'package:flutter/material.dart';
 
 import 'ctdev_log.dart';
@@ -12,7 +12,7 @@ void main() {
   runZonedGuarded(
     () => runApp(const CtDevApp()),
     (Object error, StackTrace stackTrace) {
-      ctdevLogger().e('uncaught error', error: error, stackTrace: stackTrace);
+      packageLogger().e('uncaught error', error: error, stackTrace: stackTrace);
     },
   );
 }

--- a/ctdev/lib/package_log_prefix.dart
+++ b/ctdev/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'ctdev';

--- a/ctdev/lib/package_logger.dart
+++ b/ctdev/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:ctdev/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/ctdev/lib/package_logger.dart
+++ b/ctdev/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:ctdev/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/ctdev/lib/save_service.dart
+++ b/ctdev/lib/save_service.dart
@@ -4,11 +4,11 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctdev/package_logger.dart';
 import 'package:hive/hive.dart';
 import 'package:path_provider/path_provider.dart';
 
-final _log = ctdevLogger('save');
+final _log = packageLogger('save');
 
 Box<dynamic>? _box;
 

--- a/ctdev/lib/screens/running_game_screen.dart
+++ b/ctdev/lib/screens/running_game_screen.dart
@@ -2,7 +2,7 @@ import 'dart:math' as math;
 
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctdev/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
@@ -11,7 +11,7 @@ import '../debug_map_painter.dart';
 import '../player_view_map_painter.dart';
 import '../sim_game_controller.dart';
 
-final _runningGameLog = ctdevLogger('running_game');
+final _runningGameLog = packageLogger('running_game');
 
 /// Running Game Screen: sim game with control bar and tabs.
 class RunningGameScreen extends StatefulWidget {

--- a/ctdev/lib/sim_game_controller.dart
+++ b/ctdev/lib/sim_game_controller.dart
@@ -2,13 +2,13 @@ import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctdev/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:meta/meta.dart';
 
 import 'ctdev_log.dart';
 
-final _ctdevSimLog = ctdevLogger();
+final _ctdevSimLog = packageLogger();
 
 /// One order entry in the sim game order history (for UI display).
 class SimOrderHistoryEntry {

--- a/ctterm/bin/ctterm.dart
+++ b/ctterm/bin/ctterm.dart
@@ -2,7 +2,7 @@
 
 import 'dart:async';
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_app.dart';
@@ -10,7 +10,7 @@ import 'package:ctterm/ctterm_log.dart';
 import 'package:ctterm/save_service.dart';
 import 'package:session_log_buffer/session_log_buffer.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 void main(List<String> args) async {
   String? dataDirOverride;
@@ -48,7 +48,7 @@ void main(List<String> args) async {
       ));
     },
     (Object error, StackTrace stackTrace) {
-      tuiLogger().e(
+      packageLogger().e(
         'uncaught async error',
         error: error,
         stackTrace: stackTrace,

--- a/ctterm/lib/ctterm_app.dart
+++ b/ctterm/lib/ctterm_app.dart
@@ -1,6 +1,6 @@
 // Root ctterm app: navigation shell and main menu. SPEC/tui/ctterm.md. /// CTTerm application entry point
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart';
 
 import 'package:ctterm/ctterm_routes.dart';
@@ -12,7 +12,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Pending setup data when user has completed Game Setup and we are about to generate the world.
 class _PendingNewGameConfig {

--- a/ctterm/lib/package_log_prefix.dart
+++ b/ctterm/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'tui';

--- a/ctterm/lib/package_logger.dart
+++ b/ctterm/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:ctterm/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/ctterm/lib/package_logger.dart
+++ b/ctterm/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:ctterm/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/ctterm/lib/save_service.dart
+++ b/ctterm/lib/save_service.dart
@@ -7,10 +7,10 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:hive/hive.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:path/path.dart' as path;
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 String? _initDataDir;
 Box<dynamic>? _box;

--- a/ctterm/lib/screens/defeat_screen.dart
+++ b/ctterm/lib/screens/defeat_screen.dart
@@ -1,11 +1,11 @@
 // Defeat screen: shown when human player loses. SPEC/tui/ctterm.md, SPEC/game/victory.md.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Defeat screen: shown when another Great Power wins the game.
 /// 

--- a/ctterm/lib/screens/development_screen.dart
+++ b/ctterm/lib/screens/development_screen.dart
@@ -1,6 +1,6 @@
 // Development Screen: manage civilian unit work orders. SPEC/tui/screens/development.md.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
@@ -10,7 +10,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Valid work targets per spec: work target id -> display label.
 const _validWorkTargets = {

--- a/ctterm/lib/screens/diplomacy_screen.dart
+++ b/ctterm/lib/screens/diplomacy_screen.dart
@@ -1,13 +1,13 @@
 // Diplomacy Screen: manage relations with other powers. SPEC/tui/screens/diplomacy.md.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Faction type for display.
 enum FactionType { greatPower, minorNation, tribe }

--- a/ctterm/lib/screens/game_setup_screen.dart
+++ b/ctterm/lib/screens/game_setup_screen.dart
@@ -1,10 +1,10 @@
 // Game Setup screen. SPEC/tui/screens/game-setup.md, SPEC/tui/ctterm.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Number of player slots: 1 human + 5 AI.
 const int _kNumSlots = 6;

--- a/ctterm/lib/screens/generating_world_screen.dart
+++ b/ctterm/lib/screens/generating_world_screen.dart
@@ -2,10 +2,10 @@
 
 import 'dart:async';
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Screen shown while the game world is being generated.
 /// SPEC/tui/screens/generating-world.md.

--- a/ctterm/lib/screens/in_game_shell_screen.dart
+++ b/ctterm/lib/screens/in_game_shell_screen.dart
@@ -2,7 +2,7 @@
 // SPEC/tui/ctterm.md, SPEC/tui/screens/in-game-shell.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
@@ -11,7 +11,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:ctterm/map_tui_mapping.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// In-game shell: topology graph map, HUD, province info panel, navigation to panels.
 class InGameShellScreen extends StatefulComponent {

--- a/ctterm/lib/screens/load_game_screen.dart
+++ b/ctterm/lib/screens/load_game_screen.dart
@@ -1,11 +1,11 @@
 // Load Game screen. SPEC/tui/screens/load-game.md, SPEC/tui/ctterm.md.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/save_service.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Load Game: lists saved games, allows load or delete.
 class LoadGameScreen extends StatefulComponent {

--- a/ctterm/lib/screens/main_menu_screen.dart
+++ b/ctterm/lib/screens/main_menu_screen.dart
@@ -1,12 +1,12 @@
 // Main Menu. SPEC/ui/main-menu.md, SPEC/tui/ctterm.md.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/menu_logic.dart';
 import 'package:ctterm/save_service.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Main menu: New Game, Load Game (L always navigates; list empty when no saves), Settings, Debug log, Quit.
 class MainMenuScreen extends StatefulComponent {

--- a/ctterm/lib/screens/map_context_screen.dart
+++ b/ctterm/lib/screens/map_context_screen.dart
@@ -2,12 +2,12 @@
 // SPEC/tui/ctterm.md, SPEC/tui/screens/map-context.md
 
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Map context screen showing detailed province information, map layers, and region navigation.
 class MapContextScreen extends StatefulComponent {

--- a/ctterm/lib/screens/pause_options_screen.dart
+++ b/ctterm/lib/screens/pause_options_screen.dart
@@ -1,11 +1,11 @@
 // Pause/Options screen. SPEC/tui/screens/pause-options.md.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Pause menu with exit to main menu and settings options.
 class PauseOptionsScreen extends StatefulComponent {

--- a/ctterm/lib/screens/pending_call_to_arms_screen.dart
+++ b/ctterm/lib/screens/pending_call_to_arms_screen.dart
@@ -1,12 +1,12 @@
 // Pending call to arms: join or refuse when an ally is declared upon. SPEC/game/diplomacy.md.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Screen when turn resolution blocks on human ally call to arms.
 class PendingCallToArmsScreen extends StatefulComponent {

--- a/ctterm/lib/screens/pending_intervention_screen.dart
+++ b/ctterm/lib/screens/pending_intervention_screen.dart
@@ -1,13 +1,13 @@
 // Pending intervention: Diplomacy-phase choices when a GP attacks Minor/Tribe.
 // SPEC/tui/screens/pending-intervention.md, SPEC/program/dialogue-system.md.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Builds the rows submitted when the player confirms all prompts (Enter).
 /// SPEC/tui/screens/pending-intervention.md.

--- a/ctterm/lib/screens/pending_overtures_screen.dart
+++ b/ctterm/lib/screens/pending_overtures_screen.dart
@@ -1,13 +1,13 @@
 // Pending overtures: accept/reject diplomatic offers during turn resolution.
 // SPEC/program/turn-resolution-phases.md, SPEC/game/diplomacy.md.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Screen shown when turn resolution blocks on the human player accepting or
 /// rejecting diplomatic overtures from other players.

--- a/ctterm/lib/screens/production_screen.dart
+++ b/ctterm/lib/screens/production_screen.dart
@@ -1,13 +1,13 @@
 // Production Screen: manage resource extraction, stockpile, and production. SPEC/tui/screens/production.md.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_data/colonizethis_data.dart' as data;
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Production recipe definition for display.
 class ProductionRecipe {

--- a/ctterm/lib/screens/settings_screen.dart
+++ b/ctterm/lib/screens/settings_screen.dart
@@ -1,9 +1,9 @@
 // Settings screen. SPEC/tui/ctterm.md, SPEC/tui/screens/settings.md.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Available terminal themes.
 enum TerminalTheme {

--- a/ctterm/lib/screens/shell_screen.dart
+++ b/ctterm/lib/screens/shell_screen.dart
@@ -1,6 +1,6 @@
 // Navigation shell: switches on route and shows Main Menu or stub. SPEC/tui/ctterm.md.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
@@ -31,7 +31,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Displays the current route (Main Menu or a stub) and handles back/exit.
 class ShellScreen extends StatefulComponent {

--- a/ctterm/lib/screens/shipyard_screen.dart
+++ b/ctterm/lib/screens/shipyard_screen.dart
@@ -1,6 +1,6 @@
 // Shipyard Screen: construct naval units. SPEC/tui/screens/shipyard.md.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:collection/collection.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
@@ -9,7 +9,7 @@ import 'package:ctterm/screens/input_mode.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Display info for a ship type in the Shipyard.
 class ShipDisplayInfo {

--- a/ctterm/lib/screens/technology_screen.dart
+++ b/ctterm/lib/screens/technology_screen.dart
@@ -1,6 +1,6 @@
 // Technology screen — research panel. SPEC/tui/screens/technology.md.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
@@ -8,7 +8,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Technology research panel.
 /// Shows research slots, available techs, and allows assigning research.

--- a/ctterm/lib/screens/units_screen.dart
+++ b/ctterm/lib/screens/units_screen.dart
@@ -1,6 +1,6 @@
 // Units Screen: manage military and civilian unit orders. SPEC/tui/screens/units.md.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
@@ -10,7 +10,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart'
     show neighborProvinceIdsInRegion;
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Units screen for managing unit stacks and issuing orders.
 class UnitsScreen extends StatefulComponent {

--- a/ctterm/lib/screens/victory_progress_screen.dart
+++ b/ctterm/lib/screens/victory_progress_screen.dart
@@ -1,11 +1,11 @@
 // Victory/Progress screen: shows progress toward victory. SPEC/tui/ctterm.md, SPEC/tui/screens/victory-progress.md.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Victory/Progress screen: shows progress toward victory condition.
 /// 

--- a/ctterm/lib/screens/victory_screen.dart
+++ b/ctterm/lib/screens/victory_screen.dart
@@ -1,11 +1,11 @@
 // Victory screen: shown when human player wins. SPEC/tui/ctterm.md, SPEC/game/victory.md.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 import 'package:nocterm/nocterm.dart' hide Logger;
 
 import 'package:ctterm/ctterm_routes.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Victory screen: shown when human player wins the game.
 /// 

--- a/ctterm/lib/startup_check.dart
+++ b/ctterm/lib/startup_check.dart
@@ -1,9 +1,9 @@
 // Startup save check: testable logic for lock detection. SPEC/tui/ctterm.md §5.1.
 
 import 'package:ctterm/save_service.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:ctterm/package_logger.dart';
 
-final _log = tuiLogger();
+final _log = packageLogger();
 
 /// Runs the save-service readiness check. Returns true if a lock was detected
 /// ([StaleLockException]), so the app should show the lock-prompt screen.

--- a/packages/colonizethis_ai/lib/package_log_prefix.dart
+++ b/packages/colonizethis_ai/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'ai';

--- a/packages/colonizethis_ai/lib/package_logger.dart
+++ b/packages/colonizethis_ai/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:colonizethis_ai/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/packages/colonizethis_ai/lib/package_logger.dart
+++ b/packages/colonizethis_ai/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:colonizethis_ai/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/packages/colonizethis_ai/lib/src/domain_planners.dart
+++ b/packages/colonizethis_ai/lib/src/domain_planners.dart
@@ -1,7 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_ai/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_logic/order_suggestion_api.dart';
@@ -10,7 +10,7 @@ import 'goal_manager.dart';
 import 'hidden_agenda.dart';
 import 'perception.dart';
 
-final _log = aiLogger();
+final _log = packageLogger();
 
 // Domain planners (utility AI). SPEC/ai/ai-architecture.md, ai-systems-impl.md, economy-planner.md.
 

--- a/packages/colonizethis_ai/lib/src/dossier.dart
+++ b/packages/colonizethis_ai/lib/src/dossier.dart
@@ -1,11 +1,11 @@
 // Dossier projection: PlayerView-safe read API. SPEC/ai/ai-dossier.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_ai/package_logger.dart';
 import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = aiLogger();
+final _log = packageLogger();
 
 /// Suspicion band for display. Never exposes true agenda.
 /// Bands defined by [dossierScoreUnknownMax], [dossierScorePossibleMax], etc. SPEC/ai/ai-dossier.md.

--- a/packages/colonizethis_ai/lib/src/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/economy_planner.dart
@@ -1,11 +1,11 @@
 // Economy planner: worker allocation and cargo preference. SPEC/ai/economy-planner.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_ai/package_logger.dart';
 import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = aiLogger('economy_planner');
+final _log = packageLogger('economy_planner');
 
 /// Shortage target below which we consider a commodity "needed".
 const int _kShortageThreshold = 8;

--- a/packages/colonizethis_ai/lib/src/goal_manager.dart
+++ b/packages/colonizethis_ai/lib/src/goal_manager.dart
@@ -1,13 +1,13 @@
 import 'dart:math' as math;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_ai/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'hidden_agenda.dart';
 import 'perception.dart';
 
-final _log = aiLogger();
+final _log = packageLogger();
 
 // Goal selection (behavior tree). SPEC/ai/ai-architecture.md, ai-personalities.md.
 

--- a/packages/colonizethis_ai/lib/src/perception.dart
+++ b/packages/colonizethis_ai/lib/src/perception.dart
@@ -1,9 +1,9 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_ai/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_logic/ai_api.dart';
 
-final _log = aiLogger();
+final _log = packageLogger();
 
 // Perception: PlayerView → AIWorldSnapshot. SPEC/ai/ai-architecture.md.
 // All data derived from PlayerView only; no hidden state.

--- a/packages/colonizethis_ai/lib/src/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/strategic_ai.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_ai/package_logger.dart';
 import 'package:colonizethis_logic/ai_api.dart' show PlayerView;
 import 'package:colonizethis_logic/order_suggestion_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -10,7 +10,7 @@ import 'goal_manager.dart';
 import 'mood_state_machine.dart';
 import 'perception.dart';
 
-final _log = aiLogger();
+final _log = packageLogger();
 
 /// Strategic order generation for full AI. SPEC/program/ai-systems-impl.md.
 ///

--- a/packages/colonizethis_data/lib/package_log_prefix.dart
+++ b/packages/colonizethis_data/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'data';

--- a/packages/colonizethis_data/lib/package_logger.dart
+++ b/packages/colonizethis_data/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:colonizethis_data/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/packages/colonizethis_data/lib/package_logger.dart
+++ b/packages/colonizethis_data/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:colonizethis_data/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/packages/colonizethis_data/lib/src/game_setup_config.dart
+++ b/packages/colonizethis_data/lib/src/game_setup_config.dart
@@ -1,8 +1,8 @@
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_data/package_logger.dart';
 
 import 'starting_resources_config.dart';
 
-final _log = dataLogger();
+final _log = packageLogger();
 
 /// Game setup parameters. SPEC/game/game-setup.md, SPEC/game/ruleset-config.md,
 /// SPEC/program/game-setup-pipeline.md.

--- a/packages/colonizethis_logger/lib/package_log_prefix.dart
+++ b/packages/colonizethis_logger/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'logger';

--- a/packages/colonizethis_logger/lib/package_logger.dart
+++ b/packages/colonizethis_logger/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'src/ct_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/packages/colonizethis_logger/lib/package_logger.dart
+++ b/packages/colonizethis_logger/lib/package_logger.dart
@@ -1,4 +1,5 @@
 import 'package_log_prefix.dart';
+export 'src/ct_logger.dart' show CtLogger;
 import 'src/ct_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {

--- a/packages/colonizethis_logger/test/ct_logger_test.dart
+++ b/packages/colonizethis_logger/test/ct_logger_test.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logger/package_logger.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:logger/logger.dart';
 
@@ -81,26 +82,13 @@ void main() {
       expect(capturedEvents[0].stackTrace, stackTrace);
     });
 
-    test('factory functions create loggers with correct prefixes', () {
-      expect(ctdevLogger().prefix, 'ctdev');
-      expect(logicLogger().prefix, 'logic');
-      expect(aiLogger().prefix, 'ai');
-      expect(dataLogger().prefix, 'data');
-      expect(mapLogger().prefix, 'map');
-      expect(saveLogger().prefix, 'save');
-      expect(tuiLogger().prefix, 'tui');
-      expect(gameLogger().prefix, 'game');
-      expect(appLogger().prefix, 'app');
+    test('package logger creates logger with package prefix', () {
+      expect(packageLogger().prefix, 'logger');
     });
 
-    test(
-      'factory functions with subPrefix create loggers with compound prefixes',
-      () {
-        expect(logicLogger('turn').prefix, 'logic.turn');
-        expect(aiLogger('planner').prefix, 'ai.planner');
-        expect(mapLogger('tileset').prefix, 'map.tileset');
-      },
-    );
+    test('package logger subPrefix creates compound prefix', () {
+      expect(packageLogger('ct').prefix, 'logger.ct');
+    });
   });
 
   group('prefixes', () {

--- a/packages/colonizethis_logic/lib/package_log_prefix.dart
+++ b/packages/colonizethis_logic/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'logic';

--- a/packages/colonizethis_logic/lib/package_logger.dart
+++ b/packages/colonizethis_logic/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:colonizethis_logic/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/packages/colonizethis_logic/lib/package_logger.dart
+++ b/packages/colonizethis_logic/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
+++ b/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
@@ -5,7 +5,7 @@ library;
 import 'dart:math' as math;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
@@ -14,7 +14,7 @@ import '../orders/order_suggestion.dart';
 import '../world/army_migration.dart';
 import '../world/player_view.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Derives turn seed per ai-planner: turnSeed = hash(globalGameSeed, aiSeed[P], T).
 /// When [fallbackAiSeed] is provided and [game.aiSeedByGpId] has no entry for

--- a/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
@@ -13,7 +13,7 @@ import 'conflict_detection.dart';
 import 'leader_bonus_helpers.dart';
 import 'military_strength.dart';
 
-final _combatLog = logicLogger();
+final _combatLog = packageLogger();
 
 /// Result of one engagement. SPEC/game/combat.md.
 enum EngagementResult {

--- a/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
@@ -2,12 +2,12 @@
 // Interception and retreat: SPEC/game/ships-and-naval.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'military_strength.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Mission factor for Patrol interception probability.
 const double kNavalInterceptMissionFactorPatrol = 0.50;

--- a/packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
@@ -9,7 +9,7 @@ import '../world/army_migration.dart';
 import '../world/fog_resolution.dart';
 import 'conflict_detection.dart';
 
-final _qbLog = logicLogger();
+final _qbLog = packageLogger();
 
 /// Quick Battle resolution pipeline. SPEC/program/quick-battle-resolution.md.
 /// Deterministic for given seed; output feeds same casualty/flip pipeline as auto-resolve.

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -8,7 +8,7 @@ library;
 import 'dart:math' show Random;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../ai/ai_control.dart';
@@ -28,7 +28,7 @@ part 'intervention_resolver.dart';
 part 'overture_resolver.dart';
 part 'war_resolver.dart';
 
-final _diploLog = logicLogger();
+final _diploLog = packageLogger();
 
 bool isMinorOrTribe(Game game, String factionId) {
   return game.minorNations.any((m) => m.id == factionId) ||

--- a/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+++ b/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
@@ -2,13 +2,13 @@
 // When diplomatic (or other) actions are applied, evidence rules add suspicion points per agenda type.
 // Evidence is stored per (observer, subject, agenda type); only human observers receive entries.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
 import '../diplomacy/diplomacy_relation_lookup.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Human Great Power ids (observers for whom we store evidence).
 List<String> _humanObserverIds(Game game) {

--- a/packages/colonizethis_logic/lib/src/economy/economy_consumption.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_consumption.dart
@@ -1,8 +1,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Thrown when [resolveConsumption] sees a ship type id not in [ShipEconomyCatalog].
 /// SPEC/game/workers-and-population.md (invalid fleet data).

--- a/packages/colonizethis_logic/lib/src/economy/economy_extraction.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_extraction.dart
@@ -1,7 +1,7 @@
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Extraction and auto-transport helpers.
 /// SPEC/game/extraction-and-improvements.md

--- a/packages/colonizethis_logic/lib/src/economy/economy_production.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_production.dart
@@ -1,8 +1,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Production resolution helpers.
 /// SPEC/game/production-recipes.md

--- a/packages/colonizethis_logic/lib/src/economy/economy_riches_to_treasury.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_riches_to_treasury.dart
@@ -1,8 +1,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Riches-to-treasury phase: convert riches in stockpile to treasury at base price.
 /// SPEC/program/turn-resolution-phases.md (Riches to treasury).

--- a/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
+++ b/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
@@ -1,12 +1,12 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
 import '../world/connectivity_resolver.dart';
 import '../world/province_lookup.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Per-player extraction totals: land (same region as capital) vs overseas.
 class ExtractionTotals {

--- a/packages/colonizethis_logic/lib/src/economy/sea_transport.dart
+++ b/packages/colonizethis_logic/lib/src/economy/sea_transport.dart
@@ -1,10 +1,10 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../world/naval.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Sea transport: allocate overseas extraction to stockpile by priority. SPEC/program/auto-transport.
 /// Trade/transport interception: SPEC/program/naval-movement-resolution.md (P_cargo_intercept, P_ship_sunk).

--- a/packages/colonizethis_logic/lib/src/event_bus/game_event_bus.dart
+++ b/packages/colonizethis_logic/lib/src/event_bus/game_event_bus.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 
 import '../game_events.dart';
 
@@ -8,7 +8,7 @@ import '../game_events.dart';
 /// SPEC/program/logging/events.md — truncate with `…` and `truncated=true` when exceeded.
 const int kGameEventLogSummaryMaxChars = 500;
 
-final _gameEventLog = logicLogger();
+final _gameEventLog = packageLogger();
 
 extension _GameEventStreamWhereType on Stream<GameEvent> {
   Stream<T> whereType<T extends GameEvent>() {

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'order_projections.dart';
@@ -12,7 +12,7 @@ export 'order_validation_result.dart';
 import 'order_validators.dart';
 import 'unit_type_helpers.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Order engine: current-turn orders per player, validation, projected effects.
 /// SPEC/program/order-engine.md. Does not mutate world state.

--- a/packages/colonizethis_logic/lib/src/orders/order_projections.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_projections.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
@@ -7,7 +7,7 @@ import '../world/unit_lookup.dart';
 import 'projected_effects.dart';
 import '../turn/turn_resolver.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Projects effects of unresolved orders. SPEC/program/order-projections.md.
 /// Dry-run of resolveTurnForGame; no world state mutation.

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
@@ -25,4 +25,4 @@ part 'order_suggestion_work.dart';
 part 'order_suggestion_build_research.dart';
 part 'order_suggestion_naval_diplomatic.dart';
 
-final _log = logicLogger('order_suggestion');
+final _log = packageLogger('order_suggestion');

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_api_impl.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_api_impl.dart
@@ -1,12 +1,12 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'order_suggestion.dart' as suggestion;
 import 'order_suggestion_api.dart';
 import '../world/player_view.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Default implementation of [OrderSuggestionAPI] using the top-level suggest* functions.
 class DefaultOrderSuggestionAPI implements OrderSuggestionAPI {

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
@@ -22,7 +22,7 @@ part 'orders_application_work_phase.dart';
 part 'orders_application_completed_work.dart';
 part 'orders_application_build_phase.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 void _appendMilitaryRegimentToArmy(
   _BuildWorkState state,

--- a/packages/colonizethis_logic/lib/src/setup/game_setup.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup.dart
@@ -5,7 +5,7 @@
 import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'capital_choice.dart';
@@ -26,4 +26,4 @@ part 'game_setup_create.dart';
 part 'game_setup_helpers.dart';
 part 'game_setup_ownership.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();

--- a/packages/colonizethis_logic/lib/src/setup/gp_starting_grain.dart
+++ b/packages/colonizethis_logic/lib/src/setup/gp_starting_grain.dart
@@ -1,13 +1,13 @@
 // SPEC/game/tile-map-and-generation.md § Great Power starting grain (bootstrap).
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
 import 'town_capital_occupancy.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Thrown when the capital province cannot host four bootstrap grain farms on land tiles.
 class GreatPowerGrainBootstrapError implements Exception {

--- a/packages/colonizethis_logic/lib/src/setup/init_game_orchestrator.dart
+++ b/packages/colonizethis_logic/lib/src/setup/init_game_orchestrator.dart
@@ -4,7 +4,7 @@
 import 'dart:typed_data';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
@@ -14,7 +14,7 @@ import '../world/unit_lookup.dart';
 import 'game_setup.dart';
 import 'warp_zone_generator.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Result of running init game.
 class InitGameResult {

--- a/packages/colonizethis_logic/lib/src/setup/init_town_roads.dart
+++ b/packages/colonizethis_logic/lib/src/setup/init_town_roads.dart
@@ -3,12 +3,12 @@
 import 'dart:collection';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 const int _initTownRoadLevel = 1;
 

--- a/packages/colonizethis_logic/lib/src/setup/warp_zone_generator.dart
+++ b/packages/colonizethis_logic/lib/src/setup/warp_zone_generator.dart
@@ -4,9 +4,9 @@
 import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Picks one representative sea zone per map edge (top, bottom, left, right).
 /// Returns a map of edge name ('top', 'bottom', 'left', 'right') to sea zone id.

--- a/packages/colonizethis_logic/lib/src/turn/combat_phase_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/turn/combat_phase_helpers.dart
@@ -1,7 +1,7 @@
 // Helpers for the combat phase: apply one land battle (quick or auto-resolve), evidence, dialogue.
 // SPEC/program/turn-resolution-phase-details.md § Combat. Called from turn_resolver._runCombatPhase.
 
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../combat/battle_general_assignment.dart';
@@ -15,7 +15,7 @@ import '../dossier/event_dialogue.dart';
 import '../event_bus/game_event_bus.dart';
 import '../game_events.dart';
 
-final _combatPhaseLog = logicLogger();
+final _combatPhaseLog = packageLogger();
 
 /// Runs one land battle: applies result (quick battle or auto-resolve), evidence, and dialogue.
 Game runOneLandBattle(

--- a/packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
@@ -3,13 +3,13 @@
 // Called from turn_resolver.resolveTurnForGame.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../dossier/event_dialogue.dart';
 import '../world/fog_resolution.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Runs the end-of-turn phase: victory check, era-change dialogue, Spy timers, fog decay,
 /// coastal sea zone full visibility, advance turn.

--- a/packages/colonizethis_logic/lib/src/turn/phases/combat_phase.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases/combat_phase.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../combat/battle_general_assignment.dart';
@@ -11,7 +11,7 @@ import '../combat_phase_helpers.dart';
 import '../turn_seed_constants.dart';
 import '../../world/capital_and_gp_fall.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 Game runCombatPhase(
   Game game,

--- a/packages/colonizethis_logic/lib/src/turn/research_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/research_resolver.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../world/player_view.dart';
@@ -7,7 +7,7 @@ import 'economy_debt_rules.dart';
 import 'economy_tech_effects.dart';
 import 'research_rules.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Research phase resolution. SPEC/program/research-resolution.md.
 Game resolveResearchPhase(Game game, Orders orders) {

--- a/packages/colonizethis_logic/lib/src/turn/turn_phase_runner.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_phase_runner.dart
@@ -1,4 +1,4 @@
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../diplomacy/diplomacy_resolver.dart';
@@ -12,7 +12,7 @@ import 'turn_resolution_sequence.dart';
 import 'turn_resolver_config.dart';
 import 'phases.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Runs full turn phase sequence; may return early for pending diplomacy.
 TurnResolutionResult runTurnResolutionPipeline({

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../event_bus/game_event_bus.dart';
@@ -19,7 +19,7 @@ export 'turn_resolution_sequence.dart';
 import 'turn_resolver_config.dart';
 export 'turn_resolver_config.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Turn resolver stub (Phase 1 compatibility). Runs phase sequence; only
 /// endOfTurn advances turn number.

--- a/packages/colonizethis_logic/lib/src/world/army_movement.dart
+++ b/packages/colonizethis_logic/lib/src/world/army_movement.dart
@@ -1,12 +1,12 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'army_migration.dart';
 import 'movement.dart';
 import 'province_lookup.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Applies army moves in [regionId] (same-region leg). See [applyMoveOrdersToRegion].
 WorldState applyArmyMoveOrdersToRegion(

--- a/packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
+++ b/packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../setup/capital_choice.dart';
@@ -7,7 +7,7 @@ import '../setup/town_capital_occupancy.dart';
 import '../world/province_lookup.dart';
 import 'capital_reassignment_fatal.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 Game applyCapitalReassignmentAfterCombat(
   Game state,

--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'naval.dart';
@@ -7,7 +7,7 @@ import 'province_lookup.dart';
 import 'topology_helpers.dart';
 import '../diplomacy/diplomacy_relation_lookup.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Result of connectivity resolution: connected tile set and per-tile path transport cap.
 /// SPEC/game/capital-and-connectivity, extraction-and-improvements: effective yield is

--- a/packages/colonizethis_logic/lib/src/world/movement.dart
+++ b/packages/colonizethis_logic/lib/src/world/movement.dart
@@ -1,12 +1,12 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'province_lookup.dart';
 import 'topology_helpers.dart';
 import 'unit_lookup.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 /// Movement validation and application.
 /// SPEC/program/movement.md

--- a/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../combat/naval_combat_resolver.dart';
@@ -14,7 +14,7 @@ import 'player_view.dart';
 import 'province_lookup.dart';
 import 'topology_helpers.dart';
 
-final _log = logicLogger();
+final _log = packageLogger();
 
 Map<String, Map<String, String>> _revealProvinceTilesForPlayer(
   Game game,

--- a/packages/colonizethis_map/lib/package_log_prefix.dart
+++ b/packages/colonizethis_map/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'map';

--- a/packages/colonizethis_map/lib/package_logger.dart
+++ b/packages/colonizethis_map/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:colonizethis_map/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/packages/colonizethis_map/lib/package_logger.dart
+++ b/packages/colonizethis_map/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:colonizethis_map/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/packages/colonizethis_map/lib/src/init_game_map_view_builder.dart
+++ b/packages/colonizethis_map/lib/src/init_game_map_view_builder.dart
@@ -3,7 +3,7 @@
 library;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_map/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'combine_region_topologies.dart';
@@ -40,7 +40,7 @@ String? _capitalTileKeyForProvince({
   return null;
 }
 
-final _log = mapLogger();
+final _log = packageLogger();
 
 const String _regionOldWorld = 'oldWorld';
 const String _regionNewWorld = 'newWorld';

--- a/packages/colonizethis_map/lib/src/tile_map_generator.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator.dart
@@ -3,7 +3,7 @@
 import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_map/package_logger.dart';
 
 import 'grid_voronoi.dart';
 import 'topology_inference.dart';
@@ -20,7 +20,7 @@ abstract class _TileMapGeneratorShell {
   _TileMapGeneratorShell({this.params = const TileMapParams()});
 
   final TileMapParams params;
-  final _log = mapLogger();
+  final _log = packageLogger();
 }
 
 /// Generates a per-region tile map from province/continent params. SPEC/program/tile-map-gen-algorithm.md, tile-map-gen-resources.md, tile-map-gen-config.md.

--- a/packages/colonizethis_models/lib/package_log_prefix.dart
+++ b/packages/colonizethis_models/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'models';

--- a/packages/colonizethis_models/lib/package_logger.dart
+++ b/packages/colonizethis_models/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:colonizethis_models/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/packages/colonizethis_models/lib/package_logger.dart
+++ b/packages/colonizethis_models/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:colonizethis_models/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/packages/colonizethis_models/pubspec.yaml
+++ b/packages/colonizethis_models/pubspec.yaml
@@ -12,3 +12,6 @@ dev_dependencies:
   colonizethis_test:
   coverage: ^1.15.0
   test: ^1.24.0
+
+dependencies:
+  colonizethis_logger: any

--- a/packages/colonizethis_save/lib/package_log_prefix.dart
+++ b/packages/colonizethis_save/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'save';

--- a/packages/colonizethis_save/lib/package_logger.dart
+++ b/packages/colonizethis_save/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:colonizethis_save/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/packages/colonizethis_save/lib/package_logger.dart
+++ b/packages/colonizethis_save/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:colonizethis_save/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/packages/colonizethis_save/lib/src/game_save_adapter.dart
+++ b/packages/colonizethis_save/lib/src/game_save_adapter.dart
@@ -1,9 +1,9 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_save/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:hive/hive.dart';
 
-final _log = saveLogger();
+final _log = packageLogger();
 
 const String _suffixTileMapByRegion = '_tileMapByRegion';
 const String _suffixTopologyByRegion = '_topologyByRegion';

--- a/packages/colonizethis_test/lib/package_log_prefix.dart
+++ b/packages/colonizethis_test/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'test';

--- a/packages/colonizethis_test/lib/package_logger.dart
+++ b/packages/colonizethis_test/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:colonizethis_test/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/packages/colonizethis_test/lib/package_logger.dart
+++ b/packages/colonizethis_test/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:colonizethis_test/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/packages/colonizethis_test/pubspec.yaml
+++ b/packages/colonizethis_test/pubspec.yaml
@@ -9,5 +9,6 @@ environment:
   sdk: '>=3.11.0 <4.0.0'
 
 dependencies:
+  colonizethis_logger: any
   logger: ^2.0.2
   test: ^1.24.0

--- a/packages/session_log_buffer/lib/package_log_prefix.dart
+++ b/packages/session_log_buffer/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'session.log.buffer';

--- a/packages/session_log_buffer/lib/package_logger.dart
+++ b/packages/session_log_buffer/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:session_log_buffer/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/packages/session_log_buffer/lib/package_logger.dart
+++ b/packages/session_log_buffer/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:session_log_buffer/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/packages/session_log_buffer/pubspec.yaml
+++ b/packages/session_log_buffer/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: '>=3.11.0 <4.0.0'
 
 dependencies:
+  colonizethis_logger: any
   logger: ^2.0.2
 
 dev_dependencies:

--- a/tool/check_gdd_coverage/lib/package_log_prefix.dart
+++ b/tool/check_gdd_coverage/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'check.gdd.coverage';

--- a/tool/check_gdd_coverage/lib/package_logger.dart
+++ b/tool/check_gdd_coverage/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:check_gdd_coverage/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/tool/check_gdd_coverage/lib/package_logger.dart
+++ b/tool/check_gdd_coverage/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:check_gdd_coverage/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/tool/check_gdd_coverage/pubspec.yaml
+++ b/tool/check_gdd_coverage/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: '>=3.11.0 <4.0.0'
 
 dependencies:
+  colonizethis_logger: any
   path: ^1.9.0
 
 executables:

--- a/tool/check_naked_logger_usage.sh
+++ b/tool/check_naked_logger_usage.sh
@@ -4,43 +4,28 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-matches="$(
-  rg --line-number "\\bLogger\\(" \
-    --glob '*.dart' \
-    --glob '!**/.dart_tool/**' \
-    --glob '!**/build/**' \
-    --glob '!**/package_logger.dart' \
-    --glob '!**/test/**' \
-    . || true
-)"
-
-matches="$(printf '%s\n' "$matches" | rg -v 'packages/colonizethis_logger/lib/src/ct_logger.dart' || true)"
-
-if [[ -n "$matches" ]]; then
-  printf '%s\n' "$matches"
-  echo
-  echo "Naked Logger(...) usage detected. Use package-local packageLogger() API."
-  exit 1
+SEARCH_TOOL=rg
+if ! command -v rg >/dev/null 2>&1; then
+  SEARCH_TOOL=grep
 fi
 
-echo "No naked Logger(...) usage detected."
-#!/usr/bin/env bash
-set -euo pipefail
+if [ "$SEARCH_TOOL" = "rg" ]; then
+  matches="$(
+    rg --line-number '\bLogger\(' \
+      --glob '*.dart' \
+      --glob '!**/.dart_tool/**' \
+      --glob '!**/build/**' \
+      --glob '!**/package_logger.dart' \
+      --glob '!**/test/**' \
+      . || true
+  )"
+else
+  matches="$(
+    grep -RIn --include='*.dart' --exclude-dir='.dart_tool' --exclude-dir='build' --exclude='package_logger.dart' --exclude-dir='test' 'Logger(' . || true
+  )"
+fi
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT_DIR"
-
-matches="$(
-  rg --line-number "\\bLogger\\(" \
-    --glob '*.dart' \
-    --glob '!**/.dart_tool/**' \
-    --glob '!**/build/**' \
-    --glob '!**/package_logger.dart' \
-    --glob '!**/test/**' \
-    . || true
-)"
-
-matches="$(printf '%s\n' "$matches" | rg -v 'packages/colonizethis_logger/lib/src/ct_logger.dart' || true)"
+matches="$(printf '%s\n' "$matches" | grep -v 'packages/colonizethis_logger/lib/src/ct_logger.dart' || true)"
 
 if [[ -n "$matches" ]]; then
   printf '%s\n' "$matches"

--- a/tool/check_naked_logger_usage.sh
+++ b/tool/check_naked_logger_usage.sh
@@ -21,7 +21,7 @@ if [ "$SEARCH_TOOL" = "rg" ]; then
   )"
 else
   matches="$(
-    grep -RIn --include='*.dart' --exclude-dir='.dart_tool' --exclude-dir='build' --exclude='package_logger.dart' --exclude-dir='test' 'Logger(' . || true
+    grep -RInE --include='*.dart' --exclude-dir='.dart_tool' --exclude-dir='build' --exclude='package_logger.dart' --exclude-dir='test' '(^|[^[:alnum:]_])Logger\(' . || true
   )"
 fi
 

--- a/tool/check_naked_logger_usage.sh
+++ b/tool/check_naked_logger_usage.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+matches="$(
+  rg --line-number "\\bLogger\\(" \
+    --glob '*.dart' \
+    --glob '!**/.dart_tool/**' \
+    --glob '!**/build/**' \
+    --glob '!**/package_logger.dart' \
+    --glob '!**/test/**' \
+    . || true
+)"
+
+matches="$(printf '%s\n' "$matches" | rg -v 'packages/colonizethis_logger/lib/src/ct_logger.dart' || true)"
+
+if [[ -n "$matches" ]]; then
+  printf '%s\n' "$matches"
+  echo
+  echo "Naked Logger(...) usage detected. Use package-local packageLogger() API."
+  exit 1
+fi
+
+echo "No naked Logger(...) usage detected."
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+matches="$(
+  rg --line-number "\\bLogger\\(" \
+    --glob '*.dart' \
+    --glob '!**/.dart_tool/**' \
+    --glob '!**/build/**' \
+    --glob '!**/package_logger.dart' \
+    --glob '!**/test/**' \
+    . || true
+)"
+
+matches="$(printf '%s\n' "$matches" | rg -v 'packages/colonizethis_logger/lib/src/ct_logger.dart' || true)"
+
+if [[ -n "$matches" ]]; then
+  printf '%s\n' "$matches"
+  echo
+  echo "Naked Logger(...) usage detected. Use package-local packageLogger() API."
+  exit 1
+fi
+
+echo "No naked Logger(...) usage detected."

--- a/tool/generate_map/bin/generate_map.dart
+++ b/tool/generate_map/bin/generate_map.dart
@@ -6,11 +6,11 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:generate_map/package_logger.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = mapLogger();
+final _log = packageLogger();
 
 void _errExit(String message) {
   stderr.writeln(message);

--- a/tool/generate_map/lib/package_log_prefix.dart
+++ b/tool/generate_map/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'generate.map';

--- a/tool/generate_map/lib/package_logger.dart
+++ b/tool/generate_map/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:generate_map/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/tool/generate_map/lib/package_logger.dart
+++ b/tool/generate_map/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:generate_map/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/tool/init_game/bin/init_game.dart
+++ b/tool/init_game/bin/init_game.dart
@@ -8,11 +8,11 @@ import 'dart:io';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:init_game/package_logger.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:hive/hive.dart';
 
-final _log = logicLogger('init_game');
+final _log = packageLogger('init_game');
 
 Future<void> main(List<String> arguments) async {
   String? configPath;

--- a/tool/init_game/lib/package_log_prefix.dart
+++ b/tool/init_game/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'init.game';

--- a/tool/init_game/lib/package_logger.dart
+++ b/tool/init_game/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:init_game/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/tool/init_game/lib/package_logger.dart
+++ b/tool/init_game/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:init_game/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/tool/show_tech/lib/package_log_prefix.dart
+++ b/tool/show_tech/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'show.tech';

--- a/tool/show_tech/lib/package_logger.dart
+++ b/tool/show_tech/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:show_tech/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/tool/show_tech/lib/package_logger.dart
+++ b/tool/show_tech/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:show_tech/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/tool/show_tech/pubspec.yaml
+++ b/tool/show_tech/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: ">=3.11.0 <4.0.0"
 
 dependencies:
+  colonizethis_logger: any
   colonizethis_data:
 
 dev_dependencies:

--- a/tool/sim_combat/bin/sim_combat.dart
+++ b/tool/sim_combat/bin/sim_combat.dart
@@ -5,10 +5,10 @@ import 'dart:io';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:sim_combat/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = logicLogger('sim_combat');
+final _log = packageLogger('sim_combat');
 
 void main(List<String> arguments) {
   String? scriptPath;

--- a/tool/sim_combat/lib/package_log_prefix.dart
+++ b/tool/sim_combat/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'sim.combat';

--- a/tool/sim_combat/lib/package_logger.dart
+++ b/tool/sim_combat/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:sim_combat/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/tool/sim_combat/lib/package_logger.dart
+++ b/tool/sim_combat/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:sim_combat/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/tool/sim_combat_montecarlo/bin/sim_combat_montecarlo.dart
+++ b/tool/sim_combat_montecarlo/bin/sim_combat_montecarlo.dart
@@ -7,10 +7,10 @@ import 'dart:io';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:sim_combat_montecarlo/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = logicLogger('sim_combat_montecarlo');
+final _log = packageLogger('sim_combat_montecarlo');
 
 /// Fixed defender effective military level for sim (SPEC: same for all script types).
 const int _simDefenderEffectiveLevel = 4;

--- a/tool/sim_combat_montecarlo/lib/package_log_prefix.dart
+++ b/tool/sim_combat_montecarlo/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'sim.combat.montecarlo';

--- a/tool/sim_combat_montecarlo/lib/package_logger.dart
+++ b/tool/sim_combat_montecarlo/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:sim_combat_montecarlo/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/tool/sim_combat_montecarlo/lib/package_logger.dart
+++ b/tool/sim_combat_montecarlo/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:sim_combat_montecarlo/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/tool/sim_economy/bin/sim_economy.dart
+++ b/tool/sim_economy/bin/sim_economy.dart
@@ -6,10 +6,10 @@ import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:sim_economy/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-final _log = logicLogger('sim_economy');
+final _log = packageLogger('sim_economy');
 
 void main(List<String> arguments) {
   String? scriptPath;

--- a/tool/sim_economy/lib/package_log_prefix.dart
+++ b/tool/sim_economy/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'sim.economy';

--- a/tool/sim_economy/lib/package_logger.dart
+++ b/tool/sim_economy/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:sim_economy/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/tool/sim_economy/lib/package_logger.dart
+++ b/tool/sim_economy/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:sim_economy/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/tool/sim_scenarios/bin/sim_scenarios.dart
+++ b/tool/sim_scenarios/bin/sim_scenarios.dart
@@ -8,13 +8,13 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:sim_scenarios/package_logger.dart';
 import 'package:path/path.dart' as path;
 
 import 'package:sim_scenarios/scenario.dart';
 import 'package:sim_scenarios/scenario_runner.dart';
 
-final _log = logicLogger('sim_scenarios');
+final _log = packageLogger('sim_scenarios');
 
 void main(List<String> args) async {
   final parser = ArgParser();

--- a/tool/sim_scenarios/lib/package_log_prefix.dart
+++ b/tool/sim_scenarios/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'sim.scenarios';

--- a/tool/sim_scenarios/lib/package_logger.dart
+++ b/tool/sim_scenarios/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:sim_scenarios/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/tool/sim_scenarios/lib/package_logger.dart
+++ b/tool/sim_scenarios/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:sim_scenarios/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/widgetbook_host/lib/package_log_prefix.dart
+++ b/widgetbook_host/lib/package_log_prefix.dart
@@ -1,0 +1,1 @@
+const String kPackageLogPrefix = 'widgetbook.host';

--- a/widgetbook_host/lib/package_logger.dart
+++ b/widgetbook_host/lib/package_logger.dart
@@ -1,5 +1,6 @@
 import 'package_log_prefix.dart';
-import 'package:widgetbook_host/package_logger.dart';
+export 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
+import 'package:colonizethis_logger/colonizethis_logger.dart';
 
 CtLogger packageLogger([String? subPrefix]) {
   if (subPrefix == null || subPrefix.isEmpty) {

--- a/widgetbook_host/lib/package_logger.dart
+++ b/widgetbook_host/lib/package_logger.dart
@@ -1,0 +1,9 @@
+import 'package_log_prefix.dart';
+import 'package:widgetbook_host/package_logger.dart';
+
+CtLogger packageLogger([String? subPrefix]) {
+  if (subPrefix == null || subPrefix.isEmpty) {
+    return CtLogger(kPackageLogPrefix);
+  }
+  return CtLogger('$kPackageLogPrefix.$subPrefix');
+}

--- a/widgetbook_host/pubspec.yaml
+++ b/widgetbook_host/pubspec.yaml
@@ -30,6 +30,7 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
+  colonizethis_logger: any
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
## Summary
- Update SPEC logging policy to require package-owned log prefixes and a mandatory `packageLogger` API per package.
- Add package-local `lib/package_log_prefix.dart` and `lib/package_logger.dart` across all repository packages, then migrate existing logger callsites to package APIs.
- Add CI enforcement (`tool/check_naked_logger_usage.sh`) and wire it into quality workflow to fail on naked `Logger(...)` usage outside approved wrapper implementation.

## Test plan
- [x] Run `tool/check_naked_logger_usage.sh` locally.
- [ ] Let CI run full quality checks.

Refs #1651

Made with [Cursor](https://cursor.com)