### PR TITLE
feat(quality): enforce app asset path constants in CI

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -291,6 +291,9 @@ jobs:
       - name: Check logic/ai decoupling convention (SPEC/program/repo-and-packages.md)
         run: tool/check_logic_ai_decoupling.sh
 
+      - name: Check asset path constants convention (SPEC/program/repo-and-packages.md)
+        run: tool/check_asset_path_constants.sh
+
       - name: Wang incremental assets gate (Python)
         run: |
           set -euo pipefail

--- a/SPEC/program/repo-and-packages.md
+++ b/SPEC/program/repo-and-packages.md
@@ -63,13 +63,17 @@ colonizethis_data    (no package deps)
 
 - **Given** package metadata for `colonizethis_logic`, **when** dependency analysis reads `dependencies` and `dev_dependencies`, **then** no `colonizethis_ai` entry exists.
 - **Given** `colonizethis_ai` imports logic interfaces, **when** static analysis inspects imports under `packages/colonizethis_ai/lib`, **then** imports use narrow logic contract libraries (`order_suggestion_api.dart`, `ai_api.dart`) and do not import `package:colonizethis_logic/colonizethis_logic.dart`.
+- **Given** Dart source under `app/lib` except `app/lib/config/app_assets.dart`, **when** static analysis inspects string literals, **then** direct asset path literals matching `assets/...` or `packages/<pkg>/assets/...` are rejected and diagnostics include file, line, and reason.
+- **Given** an app runtime asset reference in `app/lib`, **when** the code compiles, **then** the reference uses constants or helper builders defined in `app/lib/config/app_assets.dart`.
 
 ### Automated guard gate (CI)
 
 The repository enforces this boundary in CI via:
 
 - `tool/check_logic_ai_decoupling.sh`
+- `tool/check_asset_path_constants.sh`
 - `.github/workflows/quality.yml` step: `Check logic/ai decoupling convention (SPEC/program/repo-and-packages.md)`
+- `.github/workflows/quality.yml` step: `Check asset path constants convention (SPEC/program/repo-and-packages.md)`
 
 Guard behavior:
 
@@ -77,6 +81,13 @@ Guard behavior:
 - Fails if `packages/colonizethis_ai/lib/**` imports `package:colonizethis_logic/colonizethis_logic.dart`.
 - Fails if `packages/colonizethis_ai/lib/**` imports logic from any path other than `ai_api.dart` or `order_suggestion_api.dart`.
 - Fails if `packages/colonizethis_logic/test/**` imports `package:colonizethis_ai/...`.
+- Fails if `app/lib/**` contains direct `assets/...` or `packages/<pkg>/assets/...` string literals outside `app/lib/config/app_assets.dart`.
+
+Asset-path guard remediation:
+
+- Add new runtime asset constants (or helper path builders) in `app/lib/config/app_assets.dart`.
+- Replace direct string literals in `app/lib/**` with those constants/helpers.
+- Keep exclusions explicit and minimal; current exclusion is only the constants source file itself.
 
 ---
 

--- a/app/lib/config/app_assets.dart
+++ b/app/lib/config/app_assets.dart
@@ -1,2 +1,21 @@
 /// Root-relative prefix for UI icon PNGs in the Flutter asset bundle (see pubspec `assets:`).
 const String kAppIconAssetPrefix = 'assets/icons/';
+
+/// Root-relative prefix for terrain tile PNGs.
+const String kTerrainTileAssetPrefix = 'assets/images/terrain/tile_';
+
+/// Main menu pixel-art assets.
+const String kMainMenuLogoAsset = 'assets/images/ui_main_menu_logo.png';
+const String kMainMenuBackgroundAsset =
+    'assets/images/ui_main_menu_background.png';
+
+/// Dialogue script assets.
+const String kDialogueGameIntroAsset = 'assets/dialogue/game_intro.yarn';
+const String kDialogueInterventionAsset = 'assets/dialogue/intervention.yarn';
+const String kDialogueOvertureAsset = 'assets/dialogue/overture.yarn';
+
+/// Map terrain config asset loaded at app startup.
+const String kMapTerrainTilesetsAsset = 'assets/data/map_terrain_tilesets.json';
+
+String terrainTileAssetPath(String assetStem) =>
+    '$kTerrainTileAssetPrefix$assetStem.png';

--- a/app/lib/config/map_terrain_config.dart
+++ b/app/lib/config/map_terrain_config.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'app_assets.dart';
 
 final _log = gameLogger();
 
@@ -42,13 +43,10 @@ class WangTilesetAssetConfig {
 ///
 /// Edit [kDefaultMapTerrainTilesetsAsset] only to switch tilesets or cell size.
 class MapTerrainConfig {
-  MapTerrainConfig._({
-    required this.mapCellSizePx,
-    required this.wangTilesets,
-  });
+  MapTerrainConfig._({required this.mapCellSizePx, required this.wangTilesets});
 
   static const String kDefaultMapTerrainTilesetsAsset =
-      'assets/data/map_terrain_tilesets.json';
+      kMapTerrainTilesetsAsset;
 
   static MapTerrainConfig? _instance;
 

--- a/app/lib/features/game/dialogue/game_start_intro_overlay.dart
+++ b/app/lib/features/game/dialogue/game_start_intro_overlay.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_logger/colonizethis_logger.dart';
+import 'package:colonizethis_app/config/app_assets.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 import 'package:jenny/jenny.dart';
@@ -15,6 +16,7 @@ class GameStartIntroOverlay extends StatefulWidget {
     required this.onDismissed,
     required this.child,
     this.logger,
+
     /// When set (e.g. in tests), used to load the Yarn asset instead of [rootBundle].
     this.assetBundle,
   });
@@ -29,7 +31,6 @@ class GameStartIntroOverlay extends StatefulWidget {
 }
 
 class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
-  static const String _kIntroAsset = 'assets/dialogue/game_intro.yarn';
   static const String _kIntroNode = 'game_start_intro';
 
   CtDialogueView? _view;
@@ -47,11 +48,13 @@ class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
     final log = widget.logger ?? appLogger('dialogue');
     try {
       final bundle = widget.assetBundle ?? rootBundle;
-      final text = await bundle.loadString(_kIntroAsset);
+      final text = await bundle.loadString(kDialogueGameIntroAsset);
       final project = YarnProject();
       project.parse(text);
       if (!project.nodes.containsKey(_kIntroNode)) {
-        throw StateError('Intro node "$_kIntroNode" not found in $_kIntroAsset');
+        throw StateError(
+          'Intro node "$_kIntroNode" not found in $kDialogueGameIntroAsset',
+        );
       }
       final view = CtDialogueView(logger: log);
       final runner = DialogueRunner(
@@ -71,7 +74,11 @@ class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
       setState(() => _dialogueFinished = true);
       widget.onDismissed();
     } catch (e, st) {
-      log.e('ui:dialogue: failed to load or run intro', error: e, stackTrace: st);
+      log.e(
+        'ui:dialogue: failed to load or run intro',
+        error: e,
+        stackTrace: st,
+      );
       if (mounted) {
         setState(() => _loadError = e);
       }

--- a/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_app/config/app_assets.dart';
 import 'package:flutter/material.dart';
 import 'package:colonizethis_logger/colonizethis_logger.dart';
 import 'package:flutter/services.dart';
@@ -39,8 +40,8 @@ class InterventionDialogueOverlay extends StatefulWidget {
       _InterventionDialogueOverlayState();
 }
 
-class _InterventionDialogueOverlayState extends State<InterventionDialogueOverlay> {
-  static const String _kAsset = 'assets/dialogue/intervention.yarn';
+class _InterventionDialogueOverlayState
+    extends State<InterventionDialogueOverlay> {
   static const String _kIntro = 'DialoguePoint/intervention_intro';
   static const String _kSituation = 'DialoguePoint/intervention_situation';
   static const String _kReactIntervene =
@@ -70,7 +71,7 @@ class _InterventionDialogueOverlayState extends State<InterventionDialogueOverla
     final log = widget.logger ?? appLogger('dialogue');
     try {
       final bundle = widget.assetBundle ?? rootBundle;
-      final text = await bundle.loadString(_kAsset);
+      final text = await bundle.loadString(kDialogueInterventionAsset);
       final project = YarnProject()..parse(text);
       for (final node in [
         _kIntro,
@@ -80,7 +81,9 @@ class _InterventionDialogueOverlayState extends State<InterventionDialogueOverla
         _kReactProtest,
       ]) {
         if (!project.nodes.containsKey(node)) {
-          throw StateError('Intervention node "$node" missing in $_kAsset');
+          throw StateError(
+            'Intervention node "$node" missing in $kDialogueInterventionAsset',
+          );
         }
       }
       final view = CtDialogueView(logger: log);
@@ -151,11 +154,7 @@ class _InterventionDialogueOverlayState extends State<InterventionDialogueOverla
       if (!mounted) return;
       widget.onDecisions(List<InterventionDecision>.from(_decisions));
     } catch (e, st) {
-      log.e(
-        'ui:dialogue: intervention flow failed',
-        error: e,
-        stackTrace: st,
-      );
+      log.e('ui:dialogue: intervention flow failed', error: e, stackTrace: st);
       if (mounted) setState(() => _loadError = e);
     }
   }
@@ -298,10 +297,7 @@ class _InterventionDialogueOverlayState extends State<InterventionDialogueOverla
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               if (line != null) ...[
-                Text(
-                  line.text,
-                  style: Theme.of(context).textTheme.bodyLarge,
-                ),
+                Text(line.text, style: Theme.of(context).textTheme.bodyLarge),
                 const SizedBox(height: 16),
                 Align(
                   alignment: Alignment.centerRight,

--- a/app/lib/features/game/dialogue/overture_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/overture_dialogue_overlay.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_app/config/app_assets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:colonizethis_logger/colonizethis_logger.dart';
@@ -19,6 +20,7 @@ class OvertureDialogueOverlay extends StatefulWidget {
     required this.onDecisions,
     required this.child,
     this.logger,
+
     /// When true, skip Jenny intro and show list immediately. For tests only.
     this.skipIntroForTest = false,
   });
@@ -36,7 +38,6 @@ class OvertureDialogueOverlay extends StatefulWidget {
 }
 
 class _OvertureDialogueOverlayState extends State<OvertureDialogueOverlay> {
-  static const String _kOvertureAsset = 'assets/dialogue/overture.yarn';
   static const String _kOvertureNode = 'DialoguePoint/overture_target_response';
 
   bool _introDone = false;
@@ -58,12 +59,13 @@ class _OvertureDialogueOverlayState extends State<OvertureDialogueOverlay> {
   Future<void> _loadAndRunIntro() async {
     final log = widget.logger ?? appLogger('dialogue');
     try {
-      final text = await rootBundle.loadString(_kOvertureAsset);
+      final text = await rootBundle.loadString(kDialogueOvertureAsset);
       final project = YarnProject();
       project.parse(text);
       if (!project.nodes.containsKey(_kOvertureNode)) {
         throw StateError(
-            'Overture node "$_kOvertureNode" not found in $_kOvertureAsset');
+          'Overture node "$_kOvertureNode" not found in $kDialogueOvertureAsset',
+        );
       }
       final view = CtDialogueView(logger: log);
       final runner = DialogueRunner(
@@ -81,7 +83,11 @@ class _OvertureDialogueOverlayState extends State<OvertureDialogueOverlay> {
       if (!mounted) return;
       setState(() => _introDone = true);
     } catch (e, st) {
-      log.e('ui:dialogue: failed to load overture intro', error: e, stackTrace: st);
+      log.e(
+        'ui:dialogue: failed to load overture intro',
+        error: e,
+        stackTrace: st,
+      );
       if (mounted) setState(() => _loadError = e);
     }
   }
@@ -112,12 +118,14 @@ class _OvertureDialogueOverlayState extends State<OvertureDialogueOverlay> {
     final decisions = <OvertureDecision>[];
     for (var i = 0; i < widget.pendingOvertures.length; i++) {
       final offer = widget.pendingOvertures[i];
-      decisions.add(OvertureDecision(
-        offererGpId: offer.offererGpId,
-        targetFactionId: offer.targetFactionId,
-        stage: offer.stage,
-        accepted: _accepted[i],
-      ));
+      decisions.add(
+        OvertureDecision(
+          offererGpId: offer.offererGpId,
+          targetFactionId: offer.targetFactionId,
+          stage: offer.stage,
+          accepted: _accepted[i],
+        ),
+      );
     }
     widget.onDecisions(decisions);
   }
@@ -188,8 +196,7 @@ class _OvertureDialogueOverlayState extends State<OvertureDialogueOverlay> {
                           (entry) => Padding(
                             padding: const EdgeInsets.only(bottom: 8),
                             child: CtNinePatchButton(
-                              onPressed: () =>
-                                  _view!.selectOption(entry.key),
+                              onPressed: () => _view!.selectOption(entry.key),
                               child: Text(entry.value.text),
                             ),
                           ),

--- a/app/lib/features/game/flame/terrain_tileset.dart
+++ b/app/lib/features/game/flame/terrain_tileset.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:ui' as ui;
 
+import 'package:colonizethis_app/config/app_assets.dart';
 import 'package:colonizethis_app/config/map_terrain_config.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logger/colonizethis_logger.dart';
@@ -402,7 +403,7 @@ class TerrainTilesetCache {
   }
 
   Future<void> _loadStandaloneTile(String tileId, String assetStem) async {
-    final pngPath = 'assets/images/terrain/tile_$assetStem.png';
+    final pngPath = terrainTileAssetPath(assetStem);
 
     try {
       final imageData = await rootBundle.load(pngPath);
@@ -427,7 +428,7 @@ class TerrainTilesetCache {
     String tileId,
     String assetStem,
   ) async {
-    final pngPath = 'assets/images/terrain/tile_$assetStem.png';
+    final pngPath = terrainTileAssetPath(assetStem);
     final imageData = await rootBundle.load(pngPath);
     final completer = Completer<ui.Image>();
     ui.decodeImageFromList(imageData.buffer.asUint8List(), completer.complete);

--- a/app/lib/widgets/main_menu.dart
+++ b/app/lib/widgets/main_menu.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
+import '../config/app_assets.dart';
 import '../config/themes.dart';
 import 'ct_nine_patch_button.dart';
 
@@ -11,10 +12,6 @@ enum MainMenuVariant {
   /// Same layout with pixel-art assets from SPEC/ui/main-menu.md.
   pixelArt,
 }
-
-/// Asset paths for pixel-art variant. SPEC/ui/main-menu.md.
-const String _kAssetLogo = 'assets/images/ui_main_menu_logo.png';
-const String _kAssetBackground = 'assets/images/ui_main_menu_background.png';
 
 /// Content state of the main menu. SPEC/ui/main-menu.md; UXD 03a.
 enum MainMenuState {
@@ -44,9 +41,9 @@ class CtMainMenu extends StatelessWidget {
     required this.onSettings,
     required this.onQuit,
   }) : assert(
-          !resumeGameVisible || onResumeGame != null,
-          'onResumeGame is required when resumeGameVisible is true',
-        );
+         !resumeGameVisible || onResumeGame != null,
+         'onResumeGame is required when resumeGameVisible is true',
+       );
 
   final MainMenuVariant variant;
   final MainMenuState state;
@@ -77,56 +74,53 @@ class CtMainMenu extends StatelessWidget {
                 children: [
                   const SizedBox(height: 48),
                   _buildLogo(context),
-                if (_showAfterVictorySubtitle) ...[
-                  const SizedBox(height: 12),
-                  Text(
-                    l10n.mainMenu_subtitleAfterVictory,
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          fontStyle: FontStyle.italic,
-                        ),
-                    textAlign: TextAlign.center,
+                  if (_showAfterVictorySubtitle) ...[
+                    const SizedBox(height: 12),
+                    Text(
+                      l10n.mainMenu_subtitleAfterVictory,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        fontStyle: FontStyle.italic,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                  const SizedBox(height: 32),
+                  _MenuButton(
+                    label: l10n.mainMenu_newGame,
+                    variant: variant,
+                    onPressed: onNewGame,
                   ),
-                ],
-                const SizedBox(height: 32),
-                _MenuButton(
-                  label: l10n.mainMenu_newGame,
-                  variant: variant,
-                  onPressed: onNewGame,
-                ),
-                if (resumeGameVisible) ...[
+                  if (resumeGameVisible) ...[
+                    const SizedBox(height: 12),
+                    _MenuButton(
+                      label: l10n.mainMenu_resumeGame,
+                      variant: variant,
+                      onPressed: onResumeGame!,
+                    ),
+                  ],
+                  const SizedBox(height: 12),
+                  _LoadGameButton(
+                    enabled: _loadGameEnabled,
+                    variant: variant,
+                    onPressed: onLoadGame,
+                  ),
                   const SizedBox(height: 12),
                   _MenuButton(
-                    label: l10n.mainMenu_resumeGame,
+                    label: l10n.mainMenu_settings,
                     variant: variant,
-                    onPressed: onResumeGame!,
+                    onPressed: onSettings,
                   ),
+                  const SizedBox(height: 32),
+                  Text(version, style: Theme.of(context).textTheme.bodySmall),
+                  const SizedBox(height: 8),
+                  _MenuButton(
+                    label: l10n.mainMenu_quit,
+                    variant: variant,
+                    onPressed: onQuit,
+                  ),
+                  const SizedBox(height: 24),
                 ],
-                const SizedBox(height: 12),
-                _LoadGameButton(
-                  enabled: _loadGameEnabled,
-                  variant: variant,
-                  onPressed: onLoadGame,
-                ),
-                const SizedBox(height: 12),
-                _MenuButton(
-                  label: l10n.mainMenu_settings,
-                  variant: variant,
-                  onPressed: onSettings,
-                ),
-                const SizedBox(height: 32),
-                Text(
-                  version,
-                  style: Theme.of(context).textTheme.bodySmall,
-                ),
-                const SizedBox(height: 8),
-                _MenuButton(
-                  label: l10n.mainMenu_quit,
-                  variant: variant,
-                  onPressed: onQuit,
-                ),
-                const SizedBox(height: 24),
-              ],
-            ),
+              ),
             ),
           ),
         ),
@@ -140,18 +134,14 @@ class CtMainMenu extends StatelessWidget {
           children: [
             Positioned.fill(
               child: Image.asset(
-                _kAssetBackground,
+                kMainMenuBackgroundAsset,
                 fit: BoxFit.cover,
                 filterQuality: FilterQuality.none,
-                errorBuilder: (_, _, _) => Container(
-                  color: const Color(0xFF5D3A1A),
-                ),
+                errorBuilder: (_, _, _) =>
+                    Container(color: const Color(0xFF5D3A1A)),
               ),
             ),
-            Theme(
-              data: AppThemes.colonialPixelArt,
-              child: content,
-            ),
+            Theme(data: AppThemes.colonialPixelArt, child: content),
           ],
         ),
       );
@@ -172,7 +162,7 @@ class CtMainMenu extends StatelessWidget {
     return SizedBox(
       height: 64,
       child: Image.asset(
-        _kAssetLogo,
+        kMainMenuLogoAsset,
         fit: BoxFit.contain,
         filterQuality: FilterQuality.none,
         errorBuilder: (_, _, _) {
@@ -201,10 +191,7 @@ class _MenuButton extends StatelessWidget {
     }
     return SizedBox(
       width: double.infinity,
-      child: CtNinePatchButton(
-        onPressed: onPressed,
-        child: Text(label),
-      ),
+      child: CtNinePatchButton(onPressed: onPressed, child: Text(label)),
     );
   }
 }
@@ -236,13 +223,11 @@ class _PixelArtButtonState extends State<_PixelArtButton>
   @override
   void initState() {
     super.initState();
-    _bobController = AnimationController(
-      vsync: this,
-      duration: _bobDuration,
-    );
-    _bobAnimation = Tween<double>(begin: 0, end: 1).animate(
-      CurvedAnimation(parent: _bobController, curve: Curves.easeInOut),
-    );
+    _bobController = AnimationController(vsync: this, duration: _bobDuration);
+    _bobAnimation = Tween<double>(
+      begin: 0,
+      end: 1,
+    ).animate(CurvedAnimation(parent: _bobController, curve: Curves.easeInOut));
   }
 
   @override
@@ -271,15 +256,16 @@ class _PixelArtButtonState extends State<_PixelArtButton>
       child: MouseRegion(
         onEnter: _onHoverEnter,
         onExit: _onHoverExit,
-        cursor: widget.enabled ? SystemMouseCursors.click : SystemMouseCursors.basic,
+        cursor: widget.enabled
+            ? SystemMouseCursors.click
+            : SystemMouseCursors.basic,
         child: AnimatedBuilder(
           animation: _bobAnimation,
           builder: (context, child) {
-            final double dy = _hovered ? (_bobAnimation.value * 2 * _bobAmount - _bobAmount) : 0;
-            return Transform.translate(
-              offset: Offset(0, dy),
-              child: child,
-            );
+            final double dy = _hovered
+                ? (_bobAnimation.value * 2 * _bobAmount - _bobAmount)
+                : 0;
+            return Transform.translate(offset: Offset(0, dy), child: child);
           },
           child: ColorFiltered(
             colorFilter: _hovered && widget.enabled

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
+      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
       url: "https://pub.dev"
     source: hosted
-    version: "93.0.0"
+    version: "91.0.0"
   accessibility_tools:
     dependency: transitive
     description:
@@ -18,13 +18,13 @@ packages:
     source: hosted
     version: "2.8.0"
   analyzer:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: analyzer
-      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
+      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.1"
+    version: "8.4.1"
   ansi_escape_codes:
     dependency: transitive
     description:
@@ -589,7 +589,7 @@ packages:
     source: hosted
     version: "2.2.0"
   path:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,9 @@ workspace:
   - tool/check_gdd_coverage
 
 dev_dependencies:
+  analyzer: ^8.4.0
   melos: ^7.0.0
+  path: ^1.9.1
 
 melos:
   scripts:

--- a/tool/check_asset_path_constants.dart
+++ b/tool/check_asset_path_constants.dart
@@ -1,0 +1,130 @@
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:path/path.dart' as p;
+
+const _scannedRoots = <String>['app/lib'];
+
+const _excludedPaths = <String>{'app/lib/config/app_assets.dart'};
+
+void main() {
+  final cwd = Directory.current.path;
+  final root = p.normalize(cwd);
+  final violations = <_Violation>[];
+
+  for (final relRoot in _scannedRoots) {
+    final absRoot = p.join(root, relRoot);
+    final dir = Directory(absRoot);
+    if (!dir.existsSync()) {
+      continue;
+    }
+    for (final entity in dir.listSync(recursive: true, followLinks: false)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) {
+        continue;
+      }
+      final relPath = p.normalize(p.relative(entity.path, from: root));
+      if (_excludedPaths.contains(relPath)) {
+        continue;
+      }
+      final src = entity.readAsStringSync();
+      final parsed = parseString(
+        content: src,
+        path: entity.path,
+        throwIfDiagnostics: false,
+      );
+      final visitor = _AssetLiteralVisitor(path: relPath, unit: parsed.unit);
+      parsed.unit.visitChildren(visitor);
+      violations.addAll(visitor.violations);
+    }
+  }
+
+  if (violations.isEmpty) {
+    stdout.writeln('Asset path constant check passed.');
+    exit(0);
+  }
+
+  stderr.writeln(
+    'ERROR: Found direct asset path literals. Use constants from '
+    'app/lib/config/app_assets.dart instead.',
+  );
+  for (final v in violations) {
+    stderr.writeln('${v.path}:${v.line}:${v.column} ${v.message}');
+  }
+  exit(1);
+}
+
+class _AssetLiteralVisitor extends RecursiveAstVisitor<void> {
+  _AssetLiteralVisitor({required this.path, required this.unit});
+
+  final String path;
+  final CompilationUnit unit;
+  final List<_Violation> violations = [];
+
+  @override
+  void visitSimpleStringLiteral(SimpleStringLiteral node) {
+    _checkLiteral(
+      node.value,
+      node,
+      isPackageAsset: _isPackageAsset(node.value),
+    );
+  }
+
+  @override
+  void visitStringInterpolation(StringInterpolation node) {
+    if (node.elements.isEmpty) {
+      return;
+    }
+    final firstElement = node.elements.first;
+    if (firstElement is! InterpolationString) {
+      return;
+    }
+    final first = firstElement;
+    final prefix = first.value;
+    _checkLiteral(prefix, first, isPackageAsset: _isPackageAsset(prefix));
+  }
+
+  bool _isPackageAsset(String value) {
+    if (!value.startsWith('packages/')) {
+      return false;
+    }
+    final parts = value.split('/');
+    return parts.length >= 3 && parts[2] == 'assets';
+  }
+
+  void _checkLiteral(
+    String value,
+    AstNode node, {
+    required bool isPackageAsset,
+  }) {
+    final isDirectAsset = value.startsWith('assets/');
+    final isCandidate = isDirectAsset || isPackageAsset;
+    if (!isCandidate) {
+      return;
+    }
+    final location = unit.lineInfo.getLocation(node.offset);
+    violations.add(
+      _Violation(
+        path: path,
+        line: location.lineNumber,
+        column: location.columnNumber,
+        message: 'direct asset path literal "$value"',
+      ),
+    );
+  }
+}
+
+class _Violation {
+  const _Violation({
+    required this.path,
+    required this.line,
+    required this.column,
+    required this.message,
+  });
+
+  final String path;
+  final int line;
+  final int column;
+  final String message;
+}

--- a/tool/check_asset_path_constants.sh
+++ b/tool/check_asset_path_constants.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Enforce asset path constants policy in app runtime code.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+dart run tool/check_asset_path_constants.dart


### PR DESCRIPTION
## Summary
- add an AST-based guard (`tool/check_asset_path_constants.dart`) that fails on direct `assets/...` and `packages/<pkg>/assets/...` literals in `app/lib/**`
- centralize touched runtime asset references in `app/lib/config/app_assets.dart` and update affected app files to consume those constants/helpers
- wire the check into `.github/workflows/quality.yml` and document policy, scope, exclusions, and remediation in `SPEC/program/repo-and-packages.md`

## Test plan
- [x] `tool/check_asset_path_constants.sh`
- [x] `cd app && flutter test test/overture_dialogue_overlay_test.dart test/intervention_dialogue_overlay_test.dart test/overture_dialogue_intro_test.dart test/screen_spec_acceptance_test.dart --reporter=compact`

Refs #1653

Made with [Cursor](https://cursor.com)