### PR TITLE
refactor(map): extract tile map pass-family services

### DIFF
--- a/SPEC/program/tile-map-gen-algorithm.md
+++ b/SPEC/program/tile-map-gen-algorithm.md
@@ -53,6 +53,20 @@ Used for land (Pass 3), province (Pass 9), and sea zone (Pass 11):
 
 ---
 
+## Implementation Structure (Orchestrator + Services)
+
+The implementation SHOULD keep `TileMapGenerator` as an orchestration layer and extract pass-family logic into focused services with explicit inputs/outputs rather than hidden inheritance state. A compliant moderate extraction groups responsibilities as:
+
+- `LandSeedService`: Pass 2-3 seed placement and land-shape assignment.
+- `LakeAndProvinceService`: Pass 4, Pass 5, and Pass 8-9 lake/moat, border noise, and province assignment.
+- `TerrainResourceService`: Pass 6-7 terrain and resource assignment helpers.
+- `JoinAndSeaService`: Pass 10-11 join, terrain jitter, sea-zone subdivision.
+- Shared graph/connectivity helpers used by services.
+
+The orchestration contract remains unchanged: pass ordering, pass semantics, and observable outputs must match this spec and [tile-map-gen-resources.md](tile-map-gen-resources.md).
+
+---
+
 ## Constraints
 
 - Grid dimensions derived; no topology input. Province identity assigned in later passes.

--- a/packages/colonizethis_map/lib/src/tile_map_generator.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator.dart
@@ -23,16 +23,198 @@ abstract class _TileMapGeneratorShell {
   final _log = packageLogger();
 }
 
-/// Generates a per-region tile map from province/continent params. SPEC/program/tile-map-gen-algorithm.md, tile-map-gen-resources.md, tile-map-gen-config.md.
-/// Map-first: topology is inferred from the grid after generation.
-class TileMapGenerator extends _TileMapGeneratorShell
+class _TileMapGeneratorKernel extends _TileMapGeneratorShell
     with
         _TileMapGeneratorGraph,
         _TileMapGeneratorJoinSeaAndJitter,
         _TileMapGeneratorTerrainAssign,
         _TileMapGeneratorLandSeeds,
         _TileMapGeneratorLakesProvinces {
-  TileMapGenerator({super.params});
+  _TileMapGeneratorKernel({required super.params});
+}
+
+class _LandSeedService {
+  _LandSeedService(this._kernel);
+  final _TileMapGeneratorKernel _kernel;
+
+  (List<(int x, int y)>, List<(int x, int y)>, List<int>) placeLandSeeds(
+    Map<String, int> provinceToContinent,
+    Random rnd,
+  ) => _kernel._placeLandSeeds(provinceToContinent, rnd);
+
+  (List<(int x, int y)>, List<(int x, int y)>, List<int>, List<List<String>>)
+  placeLandSeedsOrganic(
+    List<List<String>> grid,
+    Map<String, int> provinceToContinent,
+    String seaZoneId,
+    Random rnd,
+  ) =>
+      _kernel._placeLandSeedsOrganic(
+        grid,
+        provinceToContinent,
+        seaZoneId,
+        rnd,
+      );
+
+  List<List<String>> assignLandByLandSeeds(
+    List<List<String>> grid,
+    List<(int x, int y)> landSeeds,
+    List<int> continentBySeedIndex,
+    Map<String, int> provinceToContinent,
+    String seaZoneId,
+  ) => _kernel._assignLandByLandSeeds(
+    grid,
+    landSeeds,
+    continentBySeedIndex,
+    provinceToContinent,
+    seaZoneId,
+  );
+}
+
+class _LakeAndProvinceService {
+  _LakeAndProvinceService(this._kernel);
+  final _TileMapGeneratorKernel _kernel;
+
+  List<List<String>> fillLakes(
+    List<List<String>> grid,
+    String seaZoneId,
+    List<(int x, int y)> landSeeds,
+    List<int> continentBySeedIndex,
+  ) => _kernel._fillLakes(grid, seaZoneId, landSeeds, continentBySeedIndex);
+
+  List<List<String>> fillMoats(
+    List<List<String>> grid,
+    String seaZoneId,
+    List<(int x, int y)> landSeeds,
+    List<int> continentBySeedIndex,
+    Random rnd,
+  ) => _kernel._fillMoats(
+    grid,
+    seaZoneId,
+    landSeeds,
+    continentBySeedIndex,
+    rnd,
+  );
+
+  List<List<String>> borderNoise(
+    List<List<String>> grid,
+    String seaZoneId,
+    Random rnd,
+  ) => _kernel._borderNoise(grid, seaZoneId, rnd);
+
+  Map<String, (int x, int y)> placeProvinceSeedsOnLand(
+    List<List<String>> grid,
+    Map<String, int> provinceToContinent,
+    List<(int x, int y)> landSeeds,
+    List<int> continentBySeedIndex,
+    String seaZoneId,
+    Random rnd,
+  ) => _kernel._placeProvinceSeedsOnLand(
+    grid,
+    provinceToContinent,
+    landSeeds,
+    continentBySeedIndex,
+    seaZoneId,
+    rnd,
+  );
+
+  List<List<String>> assignProvincesFromSeeds(
+    List<List<String>> grid,
+    Map<String, (int x, int y)> provinceSeeds,
+    String seaZoneId,
+  ) => _kernel._assignProvincesFromSeeds(grid, provinceSeeds, seaZoneId);
+}
+
+class _TerrainResourceService {
+  _TerrainResourceService(this._kernel);
+  final _TileMapGeneratorKernel _kernel;
+
+  (List<List<TerrainType?>>, List<List<Resource?>>) assignTerrainAndResources(
+    List<List<String>> grid,
+    String regionId,
+    ResourceRules rules,
+    Random rnd,
+  ) => _kernel._assignTerrainAndResources(grid, regionId, rules, rnd);
+}
+
+class _JoinAndSeaService {
+  _JoinAndSeaService(this._kernel);
+  final _TileMapGeneratorKernel _kernel;
+
+  (List<List<String>>, List<List<TerrainType?>>?, List<List<Resource?>>?, bool)
+  joinContinents(
+    List<List<String>> grid,
+    List<List<TerrainType?>>? terrainGrid,
+    List<List<Resource?>>? resourceGrid,
+    Map<String, int> provinceToContinent,
+    String seaZoneId,
+    String regionId,
+    ResourceRules? resourceRules,
+    Random rnd,
+  ) => _kernel._joinContinents(
+    grid,
+    terrainGrid,
+    resourceGrid,
+    provinceToContinent,
+    seaZoneId,
+    regionId,
+    resourceRules,
+    rnd,
+  );
+
+  void jitterTerrainByProvince(
+    List<List<String>> grid,
+    List<List<TerrainType?>> terrainGrid,
+    List<List<Resource?>> resourceGrid,
+    String regionId,
+    Random rnd,
+  ) => _kernel._jitterTerrainByProvince(
+    grid,
+    terrainGrid,
+    resourceGrid,
+    regionId,
+    rnd,
+  );
+
+  int countSeaCells(List<List<String>> grid, String seaZoneId) =>
+      _kernel._countSeaCells(grid, seaZoneId);
+
+  (List<List<String>>, int) subdivideSeaZonesWithCap(
+    List<List<String>> grid,
+    String seaZoneId,
+    int totalSea,
+  ) => _kernel._subdivideSeaZonesWithCap(grid, seaZoneId, totalSea);
+}
+
+/// Generates a per-region tile map from province/continent params. SPEC/program/tile-map-gen-algorithm.md, tile-map-gen-resources.md, tile-map-gen-config.md.
+/// Map-first: topology is inferred from the grid after generation.
+class TileMapGenerator extends _TileMapGeneratorShell {
+  factory TileMapGenerator({TileMapParams params = const TileMapParams()}) {
+    final kernel = _TileMapGeneratorKernel(params: params);
+    return TileMapGenerator._(
+      params: params,
+      landSeedService: _LandSeedService(kernel),
+      lakeAndProvinceService: _LakeAndProvinceService(kernel),
+      terrainResourceService: _TerrainResourceService(kernel),
+      joinAndSeaService: _JoinAndSeaService(kernel),
+    );
+  }
+
+  TileMapGenerator._({
+    required super.params,
+    required _LandSeedService landSeedService,
+    required _LakeAndProvinceService lakeAndProvinceService,
+    required _TerrainResourceService terrainResourceService,
+    required _JoinAndSeaService joinAndSeaService,
+  }) : _landSeedService = landSeedService,
+       _lakeAndProvinceService = lakeAndProvinceService,
+       _terrainResourceService = terrainResourceService,
+       _joinAndSeaService = joinAndSeaService;
+
+  final _LandSeedService _landSeedService;
+  final _LakeAndProvinceService _lakeAndProvinceService;
+  final _TerrainResourceService _terrainResourceService;
+  final _JoinAndSeaService _joinAndSeaService;
 
   /// Generate a tile map from province/continent count. Returns (TileMapResult, inferred MapTopology).
   /// Optional [onLog] receives one line per pass.
@@ -94,14 +276,14 @@ class TileMapGenerator extends _TileMapGeneratorShell
 
     if (params.seedBeforeAssignment) {
       // Pass 2–3 (fallback): Place all seeds, then one global Voronoi
-      final placed = _placeLandSeeds(provinceToContinent, rnd);
+      final placed = _landSeedService.placeLandSeeds(provinceToContinent, rnd);
       continentSeeds = placed.$1;
       landSeeds = placed.$2;
       continentBySeedIndex = placed.$3;
       onLog?.call(
         'Pass 2: Continent seeds ${continentSeeds.length}, land seeds ${landSeeds.length}',
       );
-      grid = _assignLandByLandSeeds(
+      grid = _landSeedService.assignLandByLandSeeds(
         grid,
         landSeeds,
         continentBySeedIndex,
@@ -110,7 +292,7 @@ class TileMapGenerator extends _TileMapGeneratorShell
       );
     } else {
       // Organic: interleaved seed placement + small Voronoi + coastline growth
-      final organic = _placeLandSeedsOrganic(
+      final organic = _landSeedService.placeLandSeedsOrganic(
         grid,
         provinceToContinent,
         seaZoneId,
@@ -149,14 +331,25 @@ class TileMapGenerator extends _TileMapGeneratorShell
     if (params.skipFillLakes) {
       onLog?.call('Pass 4: Fill lakes and moats skipped');
     } else {
-      grid = _fillLakes(grid, seaZoneId, landSeeds, continentBySeedIndex);
-      grid = _fillMoats(grid, seaZoneId, landSeeds, continentBySeedIndex, rnd);
+      grid = _lakeAndProvinceService.fillLakes(
+        grid,
+        seaZoneId,
+        landSeeds,
+        continentBySeedIndex,
+      );
+      grid = _lakeAndProvinceService.fillMoats(
+        grid,
+        seaZoneId,
+        landSeeds,
+        continentBySeedIndex,
+        rnd,
+      );
       onLog?.call('Pass 4: Fill lakes and moats done');
     }
 
     // Pass 5: Border randomization (optional; sentinel = land)
     if (params.borderNoise > 0) {
-      grid = _borderNoise(grid, seaZoneId, rnd);
+      grid = _lakeAndProvinceService.borderNoise(grid, seaZoneId, rnd);
       onLog?.call('Pass 5: Border noise applied');
     } else {
       onLog?.call('Pass 5: Border noise skipped (0)');
@@ -166,7 +359,12 @@ class TileMapGenerator extends _TileMapGeneratorShell
     List<List<TerrainType?>>? terrainGrid;
     List<List<Resource?>>? resourceGrid;
     if (resourceRules != null) {
-      final t = _assignTerrainAndResources(grid, regionId, resourceRules, rnd);
+      final t = _terrainResourceService.assignTerrainAndResources(
+        grid,
+        regionId,
+        resourceRules,
+        rnd,
+      );
       terrainGrid = t.$1;
       resourceGrid = t.$2;
       var terrainCount = 0;
@@ -186,7 +384,7 @@ class TileMapGenerator extends _TileMapGeneratorShell
     }
 
     // Pass 8: Province seeds on land (one per province, per continent)
-    final provinceSeeds = _placeProvinceSeedsOnLand(
+    final provinceSeeds = _lakeAndProvinceService.placeProvinceSeedsOnLand(
       grid,
       provinceToContinent,
       landSeeds,
@@ -199,12 +397,16 @@ class TileMapGenerator extends _TileMapGeneratorShell
     );
 
     // Pass 9: Province assignment (Voronoi on land; replace sentinel with province id)
-    grid = _assignProvincesFromSeeds(grid, provinceSeeds, seaZoneId);
+    grid = _lakeAndProvinceService.assignProvincesFromSeeds(
+      grid,
+      provinceSeeds,
+      seaZoneId,
+    );
     onLog?.call('Pass 9: Province assignment complete');
 
     // Join step (optional): connect split land components per continent
     if (params.joinContinents) {
-      final joinResult = _joinContinents(
+      final joinResult = _joinAndSeaService.joinContinents(
         grid,
         terrainGrid,
         resourceGrid,
@@ -224,13 +426,19 @@ class TileMapGenerator extends _TileMapGeneratorShell
 
     // Optional Pass 10b: province-aware terrain jitter (tiles without resources only).
     if (terrainGrid != null && resourceGrid != null) {
-      _jitterTerrainByProvince(grid, terrainGrid, resourceGrid, regionId, rnd);
+      _joinAndSeaService.jitterTerrainByProvince(
+        grid,
+        terrainGrid,
+        resourceGrid,
+        regionId,
+        rnd,
+      );
     }
 
     // Pass 11: Sea zone subdivision with size cap (max fraction of total sea per zone).
-    final totalSea = _countSeaCells(grid, seaZoneId);
+    final totalSea = _joinAndSeaService.countSeaCells(grid, seaZoneId);
     if (totalSea > 0) {
-      final (newGrid, numSeaZones) = _subdivideSeaZonesWithCap(
+      final (newGrid, numSeaZones) = _joinAndSeaService.subdivideSeaZonesWithCap(
         grid,
         seaZoneId,
         totalSea,


### PR DESCRIPTION
## Summary
- Refactors `TileMapGenerator` into an explicit orchestrator with pass-family service facades (`LandSeedService`, `LakeAndProvinceService`, `TerrainResourceService`, `JoinAndSeaService`) so pass ownership is clearer and call flow is easier to navigate.
- Preserves existing generation behavior by delegating each pass to the same underlying pass implementations; this is a structural change, not a rules or algorithm change.
- Updates `SPEC/program/tile-map-gen-algorithm.md` with an implementation-structure section authorizing orchestrator + service extraction while keeping pass semantics unchanged.

## Current-state complexity assessment (from issue)
- Deep private mixin chain hid pass ownership behind inheritance order.
- Cross-pass helper dependencies were implicit, making extension/refactor riskier.
- Test seams were coupled to a single large generator type rather than pass families.

## Dependency/state model
- `TileMapGenerator` now owns explicit service collaborators.
- Shared generation state remains explicit in method parameters (grid, seeds, rules, region id, RNG), preserving deterministic behavior.
- Hidden runtime mutation remains avoided; pass data still flows via return values and local variables in orchestrator order.

## Risk register and mitigations
- **Risk: pass ordering regression** -> Mitigated by retaining original pass order and pass log emissions in orchestrator.
- **Risk: land/sea balance drift** -> Mitigated by reusing existing pass methods unchanged and validating with existing land/sea and sea-zone tests.
- **Risk: resource/terrain cap drift** -> Mitigated by keeping Pass 6-7 logic untouched and running resource-cap/regional rule tests.
- **Risk: topology/join behavior regressions** -> Mitigated by existing topology and join regression tests run in full tile-map generator suite.

## Test plan
- [x] `flutter test packages/colonizethis_map/test/tile_map_generator_test.dart`

Refs #1650

Made with [Cursor](https://cursor.com)