### PR TITLE
refactor(setup): typed validation exceptions for init/capital setup

### DIFF
--- a/SPEC/game/capital-choice-phase.md
+++ b/SPEC/game/capital-choice-phase.md
@@ -48,7 +48,7 @@ The border-avoidance heuristic is purely aesthetic; it does not affect connectiv
 
 - Given a Great Power owns no provinces marked as sea-bound in the map topology (no P–S edges on any owned province)  
   When the system runs the capital auto-choice phase for that Great Power during game setup  
-  Then the system marks game setup as invalid for that game configuration and surfaces an error reason `no_sea_bound_capital_province` for that Great Power
+  Then the system marks game setup as invalid for that game configuration and surfaces an error reason `no_sea_bound_capital_province` for that Great Power via a setup validation exception code
 
 - Given a Minor Nation or Tribe owns at least one sea-bound province and at least one inland province  
   When the system runs the capital auto-choice phase for that faction during game setup  
@@ -68,7 +68,7 @@ The border-avoidance heuristic is purely aesthetic; it does not affect connectiv
 
 - Given the system has selected a capital province for a Great Power that is sea-bound and the province contains no coastal tiles in Class A or Class C  
   When the system selects the capital tile for that Great Power during game setup  
-  Then the system marks game setup as invalid for that game configuration and surfaces an error reason `no_coastal_capital_tile_for_gp` for that Great Power
+  Then the system marks game setup as invalid for that game configuration and surfaces an error reason `no_coastal_capital_tile_for_gp` for that Great Power via a setup validation exception code
 
 - Given the system has selected a capital province for a Minor Nation or Tribe and classified its tiles into Class A (coastal, no foreign border), Class B (interior, no foreign border), and Class C (remaining)  
   When the system selects the capital tile for that faction during game setup  

--- a/SPEC/program/game-setup-pipeline.md
+++ b/SPEC/program/game-setup-pipeline.md
@@ -70,6 +70,10 @@ These criteria are implemented and covered by automated tests where noted.
   When initialization completes  
   Then `result.game.globalGameSeed` equals `K` (colonizethis_logic `init_game_orchestrator_test.dart`).
 
+- Given setup validation fails while `runInitGame` or `createGameFromGeneratedMaps` checks Great Power province requirements or capital sea-bound requirements  
+  When the setup code throws the validation error  
+  Then The System throws a `SetupValidationException` subtype with a stable `code` string (for example `insufficient_old_world_provinces_for_great_powers` or `no_sea_bound_capital_province`) instead of a generic `ArgumentError`.
+
 - Given `runInitGame` uses the default tile-map generator and `GameSetupConfig.seed` equals non-zero `K`  
   When Old World and New World maps are generated  
   Then Old World `TileMapParams.seed` equals `K` and New World `TileMapParams.seed` equals `K + 1` (same test file, injected generator).

--- a/packages/colonizethis_logic/lib/colonizethis_logic.dart
+++ b/packages/colonizethis_logic/lib/colonizethis_logic.dart
@@ -20,6 +20,7 @@ export 'src/setup/warp_zone_generator.dart';
 export 'src/setup/province_assignment.dart';
 export 'src/setup/gp_land_connectivity_repair.dart';
 export 'src/setup/province_name_fallback.dart';
+export 'src/setup/setup_exceptions.dart';
 
 // Turn
 export 'src/turn/economy_debt_rules.dart';

--- a/packages/colonizethis_logic/lib/src/setup/capital_choice.dart
+++ b/packages/colonizethis_logic/lib/src/setup/capital_choice.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import 'setup_exceptions.dart';
 
 /// Capital-choice phase stub. SPEC/game/capital-choice-phase.
 ///
@@ -54,8 +55,9 @@ TopologyNode? _nodeById(MapTopology topology, String id) {
   final provinceId = seaBound.isNotEmpty
       ? seaBound.first
       : (requireSeaBound
-            ? (throw ArgumentError(
-                'No sea-bound province among $ownedProvinceIds; setup must assign at least one sea-bound per faction',
+            ? (throw NoSeaBoundCapitalProvinceException(
+                details:
+                    'No sea-bound province among $ownedProvinceIds; setup must assign at least one sea-bound per faction',
               ))
             : (List<String>.from(ownedProvinceIds)..sort()).first);
 
@@ -126,8 +128,9 @@ TopologyNode? _nodeById(MapTopology topology, String id) {
       x = classCCoastalX;
       y = classCCoastalY;
     } else {
-      throw ArgumentError(
-        'no_coastal_capital_tile_for_gp: No coastal tile found in sea-bound province $provinceId in region $regionId',
+      throw NoCoastalCapitalTileForGpException(
+        details:
+            'No coastal tile found in sea-bound province $provinceId in region $regionId',
       );
     }
   } else if (classBx != null) {
@@ -139,8 +142,9 @@ TopologyNode? _nodeById(MapTopology topology, String id) {
   }
 
   if (x == null || y == null) {
-    throw ArgumentError(
-      'No tile found in province $provinceId in region $regionId',
+    throw SetupTopologyDataException(
+      code: 'capital_tile_not_found',
+      details: 'No tile found in province $provinceId in region $regionId',
     );
   }
   final tile = CapitalTile(
@@ -161,17 +165,14 @@ String pickCapitalProvinceIdForReassignment(
   MapTopology topology,
 ) {
   if (ownedProvinceIds.isEmpty) {
-    throw ArgumentError.value(
-      ownedProvinceIds,
-      'ownedProvinceIds',
-      'must be non-empty',
+    throw SetupConfigConstraintException(
+      code: 'capital_reassignment_requires_owned_provinces',
+      details: 'ownedProvinceIds must be non-empty',
     );
   }
   final sorted = List<String>.from(ownedProvinceIds)..sort();
   final seaBound = sorted
-      .where(
-        (id) => isProvinceSeaBound(topology, ProvinceId.localIdFrom(id)),
-      )
+      .where((id) => isProvinceSeaBound(topology, ProvinceId.localIdFrom(id)))
       .toList();
   if (seaBound.isNotEmpty) return seaBound.first;
   return sorted.first;
@@ -187,7 +188,12 @@ WorldState applyCapitalPortAndRoad(
 ) {
   final regionId = tile.regionId;
   final map = tileMapByRegion[regionId];
-  if (map == null) throw ArgumentError('No tile map for region $regionId');
+  if (map == null) {
+    throw SetupTopologyDataException(
+      code: 'missing_region_tile_map',
+      details: 'No tile map for region $regionId',
+    );
+  }
   final localProvinceId = ProvinceId.localIdFrom(provinceId);
 
   var tileState = worldState.tileState;
@@ -199,7 +205,10 @@ WorldState applyCapitalPortAndRoad(
     localProvinceId,
   ).toList()..sort();
   if (seaZoneIds.isEmpty) {
-    throw ArgumentError('Province $provinceId has no sea zone in topology');
+    throw SetupTopologyDataException(
+      code: 'province_has_no_sea_zone',
+      details: 'Province $provinceId has no sea zone in topology',
+    );
   }
 
   for (final seaZoneId in seaZoneIds) {
@@ -226,8 +235,10 @@ WorldState applyCapitalPortAndRoad(
       seaZoneId,
     );
     if (coastal == null) {
-      throw ArgumentError(
-        'No coastal tile in province $provinceId for sea zone $seaZoneId',
+      throw SetupTopologyDataException(
+        code: 'seaboard_port_tile_not_found',
+        details:
+            'No coastal tile in province $provinceId for sea zone $seaZoneId',
       );
     }
     final portKey = CapitalTile.tileKey(
@@ -277,8 +288,7 @@ WorldState applyGreatPowerCapitalProvinceTownDevelopment(
     final region = worldState.oldWorld;
     final provinces = region.provinces
         .map(
-          (p) =>
-              ProvinceId.localIdFrom(p.id) == localTarget
+          (p) => ProvinceId.localIdFrom(p.id) == localTarget
               ? p.copyWith(townDevelopmentLevel: 4)
               : p,
         )
@@ -291,8 +301,7 @@ WorldState applyGreatPowerCapitalProvinceTownDevelopment(
     final region = worldState.newWorld;
     final provinces = region.provinces
         .map(
-          (p) =>
-              ProvinceId.localIdFrom(p.id) == localTarget
+          (p) => ProvinceId.localIdFrom(p.id) == localTarget
               ? p.copyWith(townDevelopmentLevel: 4)
               : p,
         )
@@ -326,11 +335,14 @@ Game setCapital({
   required Map<String, TileMapResult> tileMapByRegion,
 }) {
   if (!isProvinceSeaBound(topology, ProvinceId.localIdFrom(provinceId))) {
-    throw ArgumentError('Province $provinceId is not sea-bound');
+    throw NoSeaBoundCapitalProvinceException(
+      details: 'Province $provinceId is not sea-bound',
+    );
   }
   if (tile.provinceId != provinceId) {
-    throw ArgumentError(
-      'Capital tile province ${tile.provinceId} does not match $provinceId',
+    throw CapitalTileMismatchException(
+      details:
+          'Capital tile province ${tile.provinceId} does not match $provinceId',
     );
   }
 
@@ -365,8 +377,9 @@ Game setCapitalForReassignment({
   required CapitalTile tile,
 }) {
   if (tile.provinceId != provinceId) {
-    throw ArgumentError(
-      'Capital tile province ${tile.provinceId} does not match $provinceId',
+    throw CapitalTileMismatchException(
+      details:
+          'Capital tile province ${tile.provinceId} does not match $provinceId',
     );
   }
   final updatedPlayers = game.players.map((p) {
@@ -387,8 +400,9 @@ Game setCapitalForMinorNation({
   required Map<String, TileMapResult> tileMapByRegion,
 }) {
   if (tile.provinceId != provinceId) {
-    throw ArgumentError(
-      'Capital tile province ${tile.provinceId} does not match $provinceId',
+    throw CapitalTileMismatchException(
+      details:
+          'Capital tile province ${tile.provinceId} does not match $provinceId',
     );
   }
 
@@ -422,8 +436,9 @@ Game setCapitalForTribe({
   required Map<String, TileMapResult> tileMapByRegion,
 }) {
   if (tile.provinceId != provinceId) {
-    throw ArgumentError(
-      'Capital tile province ${tile.provinceId} does not match $provinceId',
+    throw CapitalTileMismatchException(
+      details:
+          'Capital tile province ${tile.provinceId} does not match $provinceId',
     );
   }
 

--- a/packages/colonizethis_logic/lib/src/setup/game_setup.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup.dart
@@ -13,6 +13,7 @@ import 'gp_land_connectivity_repair.dart';
 import 'gp_starting_grain.dart';
 import 'town_capital_occupancy.dart';
 import 'init_town_roads.dart';
+import 'setup_exceptions.dart';
 import '../constants.dart';
 import '../diplomacy/diplomacy_relation_lookup.dart';
 import 'initial_visibility.dart';

--- a/packages/colonizethis_logic/lib/src/setup/game_setup_create.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup_create.dart
@@ -53,8 +53,10 @@ GameSetupResult createGameFromGeneratedMaps({
   final nwProvinceIds = _provinceIdsFromTopology(topologyNewWorld);
 
   if (owProvinceIds.length < config.greatPowerCount) {
-    throw ArgumentError(
-      'Old World has ${owProvinceIds.length} provinces but ${config.greatPowerCount} Great Powers need at least one each',
+    throw SetupConfigConstraintException(
+      code: 'insufficient_old_world_provinces_for_great_powers',
+      details:
+          'Old World has ${owProvinceIds.length} provinces but ${config.greatPowerCount} Great Powers need at least one each',
     );
   }
 
@@ -64,8 +66,9 @@ GameSetupResult createGameFromGeneratedMaps({
           .toList()
         ..sort();
   if (seaBoundOW.length < config.greatPowerCount) {
-    throw ArgumentError(
-      'Old World has ${seaBoundOW.length} sea-bound provinces but ${config.greatPowerCount} Great Powers need one each',
+    throw NoSeaBoundCapitalProvinceException(
+      details:
+          'Old World has ${seaBoundOW.length} sea-bound provinces but ${config.greatPowerCount} Great Powers need one each',
     );
   }
 

--- a/packages/colonizethis_logic/lib/src/setup/game_setup_ownership.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup_ownership.dart
@@ -226,9 +226,11 @@ Map<String, String> _assignOldWorldOwnershipContiguous({
   final reservedForMinors = minorCount * minProvincesPerMinor;
   final availableForGps = totalOw - reservedForMinors;
   if (availableForGps < gpCount) {
-    throw ArgumentError(
-      'Old World has $totalOw provinces but after reserving $reservedForMinors '
-      'for $minorCount minors only $availableForGps remain for $gpCount Great Powers',
+    throw SetupConfigConstraintException(
+      code: 'insufficient_old_world_budget_for_great_powers',
+      details:
+          'Old World has $totalOw provinces but after reserving $reservedForMinors '
+          'for $minorCount minors only $availableForGps remain for $gpCount Great Powers',
     );
   }
 
@@ -257,10 +259,12 @@ Map<String, String> _assignOldWorldOwnershipContiguous({
     gpCount: gpCount,
   );
   if (maxGpProvincesByTopology < gpCount) {
-    throw ArgumentError(
-      'Old World GP assignment infeasible: topology allows at most '
-      '$maxGpProvincesByTopology province(s) for $gpCount Great Power(s) under the '
-      'one-landmass-per-GP rule (sea-bound slots per landmass: $seaBoundCountByLandmass)',
+    throw SetupTopologyDataException(
+      code: 'old_world_gp_assignment_infeasible',
+      details:
+          'Old World GP assignment infeasible: topology allows at most '
+          '$maxGpProvincesByTopology province(s) for $gpCount Great Power(s) under the '
+          'one-landmass-per-GP rule (sea-bound slots per landmass: $seaBoundCountByLandmass)',
     );
   }
 
@@ -277,10 +281,12 @@ Map<String, String> _assignOldWorldOwnershipContiguous({
     seaBoundCountByLandmass: seaBoundCountByLandmass,
   );
   if (gpProvinceBudget < gpCount) {
-    throw ArgumentError(
-      'Old World GP landmass packing failed: no feasible fair target budget for '
-      '$gpCount Great Power(s) within cap $cap. Landmass sizes: $landmassSizes, '
-      'sea-bound per landmass: $seaBoundCountByLandmass',
+    throw SetupTopologyDataException(
+      code: 'old_world_gp_landmass_packing_failed',
+      details:
+          'Old World GP landmass packing failed: no feasible fair target budget for '
+          '$gpCount Great Power(s) within cap $cap. Landmass sizes: $landmassSizes, '
+          'sea-bound per landmass: $seaBoundCountByLandmass',
     );
   }
 
@@ -396,14 +402,17 @@ Map<String, String> _selectGpSeedsForLandmass({
   for (final gpId in gpIdsInAssignmentOrder) {
     final assignedLandmass = gpLandmassAssignments[gpId];
     if (assignedLandmass == null) {
-      throw ArgumentError(
-        'Great Power $gpId has no landmass assignment; cannot pick sea-bound seed',
+      throw SetupTopologyDataException(
+        code: 'missing_gp_landmass_assignment',
+        details:
+            'Great Power $gpId has no landmass assignment; cannot pick sea-bound seed',
       );
     }
     final seaBoundOnLandmass = seaBoundByLandmass[assignedLandmass];
     if (seaBoundOnLandmass == null || seaBoundOnLandmass.isEmpty) {
-      throw ArgumentError(
-        'No sea-bound province left on landmass $assignedLandmass for Great Power $gpId',
+      throw NoSeaBoundCapitalProvinceException(
+        details:
+            'No sea-bound province left on landmass $assignedLandmass for Great Power $gpId',
       );
     }
     final seedProv = seaBoundOnLandmass.removeAt(0);
@@ -411,9 +420,10 @@ Map<String, String> _selectGpSeedsForLandmass({
   }
 
   if (gpSeeds.length != gpCount) {
-    throw ArgumentError(
-      'Not enough sea-bound provinces to seed all Great Powers on their landmasses: '
-      'have ${gpSeeds.length}, need $gpCount',
+    throw NoSeaBoundCapitalProvinceException(
+      details:
+          'Not enough sea-bound provinces to seed all Great Powers on their landmasses: '
+          'have ${gpSeeds.length}, need $gpCount',
     );
   }
 

--- a/packages/colonizethis_logic/lib/src/setup/init_game_orchestrator.dart
+++ b/packages/colonizethis_logic/lib/src/setup/init_game_orchestrator.dart
@@ -12,6 +12,7 @@ import '../ai/hidden_agenda_assignment.dart';
 import '../constants.dart';
 import '../world/unit_lookup.dart';
 import 'game_setup.dart';
+import 'setup_exceptions.dart';
 import 'warp_zone_generator.dart';
 
 final _log = packageLogger();
@@ -83,9 +84,11 @@ InitGameResult runInitGame({
   TileMapRegionGenerator? generateRegion,
 }) {
   if (config.numProvincesOldWorld < config.greatPowerCount) {
-    throw ArgumentError(
-      'Config requests ${config.numProvincesOldWorld} Old World provinces but '
-      '${config.greatPowerCount} Great Powers need at least one each',
+    throw SetupConfigConstraintException(
+      code: 'insufficient_old_world_provinces_for_great_powers',
+      details:
+          'Config requests ${config.numProvincesOldWorld} Old World provinces but '
+          '${config.greatPowerCount} Great Powers need at least one each',
     );
   }
 
@@ -227,7 +230,9 @@ InitGameResult runInitGame({
 
   // Phase 4: set AI seeds and GP colour override for determinism / display
   var game = setupResult.game;
-  final gpColorOverrideList = mapColorTuples?.map((k, v) => MapEntry(k, [v.$1, v.$2, v.$3]));
+  final gpColorOverrideList = mapColorTuples?.map(
+    (k, v) => MapEntry(k, [v.$1, v.$2, v.$3]),
+  );
   game = game.copyWith(
     globalGameSeed: effectiveSeed,
     aiSeedByGpId: {

--- a/packages/colonizethis_logic/lib/src/setup/setup_exceptions.dart
+++ b/packages/colonizethis_logic/lib/src/setup/setup_exceptions.dart
@@ -1,0 +1,42 @@
+/// Base type for setup-time validation failures in colonizethis_logic.
+class SetupValidationException implements Exception {
+  const SetupValidationException(this.code, this.message);
+
+  final String code;
+  final String message;
+
+  @override
+  String toString() => 'SetupValidationException($code): $message';
+}
+
+/// Thrown when a Great Power cannot be assigned a valid sea-bound capital province.
+class NoSeaBoundCapitalProvinceException extends SetupValidationException {
+  NoSeaBoundCapitalProvinceException({required String details})
+    : super('no_sea_bound_capital_province', details);
+}
+
+/// Thrown when a sea-bound GP capital province has no coastal tile candidate.
+class NoCoastalCapitalTileForGpException extends SetupValidationException {
+  NoCoastalCapitalTileForGpException({required String details})
+    : super('no_coastal_capital_tile_for_gp', details);
+}
+
+/// Thrown when setup receives an invalid capital tile/province combination.
+class CapitalTileMismatchException extends SetupValidationException {
+  CapitalTileMismatchException({required String details})
+    : super('capital_tile_province_mismatch', details);
+}
+
+/// Thrown when setup cannot resolve required map/topology data for a region/province.
+class SetupTopologyDataException extends SetupValidationException {
+  SetupTopologyDataException({required String code, required String details})
+    : super(code, details);
+}
+
+/// Thrown when setup config values are inconsistent with required faction counts.
+class SetupConfigConstraintException extends SetupValidationException {
+  SetupConfigConstraintException({
+    required String code,
+    required String details,
+  }) : super(code, details);
+}

--- a/packages/colonizethis_logic/test/capital_choice_test.dart
+++ b/packages/colonizethis_logic/test/capital_choice_test.dart
@@ -154,7 +154,13 @@ void main() {
             topology,
             tileMap,
           ),
-          throwsArgumentError,
+          throwsA(
+            isA<NoSeaBoundCapitalProvinceException>().having(
+              (e) => e.code,
+              'code',
+              'no_sea_bound_capital_province',
+            ),
+          ),
         );
       },
     );
@@ -273,11 +279,13 @@ void main() {
       expect(
         () => pickCapitalForFaction(['p1'], 'oldWorld', topology, tileMap),
         throwsA(
-          isA<ArgumentError>().having(
-            (e) => e.message.toString(),
-            'message',
-            contains('no_coastal_capital_tile_for_gp'),
-          ),
+          isA<NoCoastalCapitalTileForGpException>()
+              .having((e) => e.code, 'code', 'no_coastal_capital_tile_for_gp')
+              .having(
+                (e) => e.message,
+                'message',
+                contains('No coastal tile found'),
+              ),
         ),
       );
     });
@@ -592,7 +600,9 @@ void main() {
               ],
             ),
             newWorld: const RegionData(),
-            portsByProvinceSeaboard: const {'oldWorld|p1|sea1': 'oldWorld|p1|0|0'},
+            portsByProvinceSeaboard: const {
+              'oldWorld|p1|sea1': 'oldWorld|p1|0|0',
+            },
           ),
           players: [Player(id: 'pl1', displayName: 'Spain', isHuman: true)],
         );
@@ -618,35 +628,36 @@ void main() {
       },
     );
 
-    test('pickCapitalProvinceIdForReassignment prefers seaboard by sorted id', () {
-      final topology = MapTopology(
-        nodes: const [
-          TopologyNode(
-            id: 'pA',
-            regionId: 'oldWorld',
-            type: TopologyNodeType.province,
-          ),
-          TopologyNode(
-            id: 'pB',
-            regionId: 'oldWorld',
-            type: TopologyNodeType.province,
-          ),
-          TopologyNode(
-            id: 'sea1',
-            regionId: 'oldWorld',
-            type: TopologyNodeType.seaZone,
-          ),
-        ],
-        edges: const [
-          TopologyEdge(id1: 'pA', id2: 'sea1'),
-        ],
-      );
-      final id = pickCapitalProvinceIdForReassignment(
-        ['oldWorld|pB', 'oldWorld|pA'],
-        topology,
-      );
-      expect(id, 'oldWorld|pA');
-    });
+    test(
+      'pickCapitalProvinceIdForReassignment prefers seaboard by sorted id',
+      () {
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'pA',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'pB',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'sea1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+          ],
+          edges: const [TopologyEdge(id1: 'pA', id2: 'sea1')],
+        );
+        final id = pickCapitalProvinceIdForReassignment([
+          'oldWorld|pB',
+          'oldWorld|pA',
+        ], topology);
+        expect(id, 'oldWorld|pA');
+      },
+    );
 
     test('pickCapitalProvinceIdForReassignment inland when no seaboard', () {
       final topology = MapTopology(
@@ -664,10 +675,10 @@ void main() {
         ],
         edges: const [],
       );
-      final id = pickCapitalProvinceIdForReassignment(
-        ['oldWorld|pB', 'oldWorld|pA'],
-        topology,
-      );
+      final id = pickCapitalProvinceIdForReassignment([
+        'oldWorld|pB',
+        'oldWorld|pA',
+      ], topology);
       expect(id, 'oldWorld|pA');
     });
 

--- a/packages/colonizethis_logic/test/init_game_orchestrator_test.dart
+++ b/packages/colonizethis_logic/test/init_game_orchestrator_test.dart
@@ -9,61 +9,66 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 void main() {
   group('runInitGame', () {
     test(
-        'renderPng=false skips PNG bytes but still returns game and view data',
-        () {
-      final config = GameSetupConfig.defaultConfig;
+      'renderPng=false skips PNG bytes but still returns game and view data',
+      () {
+        final config = GameSetupConfig.defaultConfig;
 
-      final result = runInitGame(
-        config: config,
-        options: const InitGameOptions(
-          cellSize: 8,
-          renderPng: false,
-        ),
-      );
+        final result = runInitGame(
+          config: config,
+          options: const InitGameOptions(cellSize: 8, renderPng: false),
+        );
 
-      expect(result.game, isNotNull);
-      expect(result.mapViewData, isNotNull);
-      expect(result.markdown, isNotEmpty);
-      expect(result.mapPngBytes, isA<Uint8List>());
-      expect(result.mapPngBytes, isEmpty);
-    });
+        expect(result.game, isNotNull);
+        expect(result.mapViewData, isNotNull);
+        expect(result.markdown, isNotEmpty);
+        expect(result.mapPngBytes, isA<Uint8List>());
+        expect(result.mapPngBytes, isEmpty);
+      },
+    );
 
     test(
-        'greatPowerColorOverride from semantic ids is applied to runtime player ids',
-        () {
-      // Use default config so selectedGreatPowerIds and players are created
-      // in a consistent order; the first selected GP becomes the first Player.
-      final config = GameSetupConfig.defaultConfig;
+      'greatPowerColorOverride from semantic ids is applied to runtime player ids',
+      () {
+        // Use default config so selectedGreatPowerIds and players are created
+        // in a consistent order; the first selected GP becomes the first Player.
+        final config = GameSetupConfig.defaultConfig;
 
-      const overrideSemanticId = 'england';
-      const overrideColor = (200, 10, 150);
+        const overrideSemanticId = 'england';
+        const overrideColor = (200, 10, 150);
 
-      final result = runInitGame(
-        config: config,
-        options: const InitGameOptions(
-          cellSize: 8,
-          renderPng: false,
-          greatPowerColorOverride: {overrideSemanticId: overrideColor},
-        ),
-      );
+        final result = runInitGame(
+          config: config,
+          options: const InitGameOptions(
+            cellSize: 8,
+            renderPng: false,
+            greatPowerColorOverride: {overrideSemanticId: overrideColor},
+          ),
+        );
 
-      final game = result.game;
+        final game = result.game;
 
-      // Find the player that corresponds to the overridden semantic id by
-      // using the resolved display name from naming (e.g. "England").
-      final overriddenPlayer = game.players.firstWhere(
-        (p) => p.displayName == defaultNamingConfig.gpById(overrideSemanticId)!.countryName,
-        orElse: () => game.players.first,
-      );
+        // Find the player that corresponds to the overridden semantic id by
+        // using the resolved display name from naming (e.g. "England").
+        final overriddenPlayer = game.players.firstWhere(
+          (p) =>
+              p.displayName ==
+              defaultNamingConfig.gpById(overrideSemanticId)!.countryName,
+          orElse: () => game.players.first,
+        );
 
-      final gpOverride = game.greatPowerColorOverride;
-      expect(gpOverride, isNotNull);
-      expect(gpOverride![overriddenPlayer.id], [overrideColor.$1, overrideColor.$2, overrideColor.$3]);
+        final gpOverride = game.greatPowerColorOverride;
+        expect(gpOverride, isNotNull);
+        expect(gpOverride![overriddenPlayer.id], [
+          overrideColor.$1,
+          overrideColor.$2,
+          overrideColor.$3,
+        ]);
 
-      final viewOverride = result.greatPowerColorOverride;
-      expect(viewOverride, isNotNull);
-      expect(viewOverride![overriddenPlayer.id], overrideColor);
-    });
+        final viewOverride = result.greatPowerColorOverride;
+        expect(viewOverride, isNotNull);
+        expect(viewOverride![overriddenPlayer.id], overrideColor);
+      },
+    );
 
     test('markdown contains Faction Setup and Starting State tables', () {
       final config = GameSetupConfig.defaultConfig;
@@ -73,8 +78,14 @@ void main() {
       );
       expect(result.markdown, contains('## Faction Setup'));
       expect(result.markdown, contains('## Faction Starting State'));
-      expect(result.markdown, contains('| Faction | Type | Capital Province | Provinces Owned |'));
-      expect(result.markdown, contains('| Faction | Stockpile | Workers | Treasury | Units |'));
+      expect(
+        result.markdown,
+        contains('| Faction | Type | Capital Province | Provinces Owned |'),
+      );
+      expect(
+        result.markdown,
+        contains('| Faction | Stockpile | Workers | Treasury | Units |'),
+      );
     });
 
     test('skipFillLakes=true runs without throwing', () {
@@ -91,29 +102,46 @@ void main() {
       expect(result.markdown, isNotEmpty);
     });
 
-    test('result includes warpLinks and combinedTopology has prefixed node ids', () {
-      final config = GameSetupConfig.defaultConfig;
-      final result = runInitGame(
-        config: config,
-        options: const InitGameOptions(cellSize: 8, renderPng: false),
-      );
-      expect(result.warpLinks, isA<List<WarpLink>>());
-      final combined = result.combinedTopology;
-      expect(combined.nodes, isNotEmpty);
-      for (final n in combined.nodes) {
-        expect(n.id.contains('|'), isTrue, reason: 'combined topology node id must be prefixed (regionId|localId)');
-      }
-      if (result.warpLinks.isNotEmpty) {
-        expect(result.warpLinks.first.regionId, anyOf('oldWorld', 'newWorld'));
-        expect(result.warpLinks.first.otherRegionId, anyOf('oldWorld', 'newWorld'));
-      }
-    });
+    test(
+      'result includes warpLinks and combinedTopology has prefixed node ids',
+      () {
+        final config = GameSetupConfig.defaultConfig;
+        final result = runInitGame(
+          config: config,
+          options: const InitGameOptions(cellSize: 8, renderPng: false),
+        );
+        expect(result.warpLinks, isA<List<WarpLink>>());
+        final combined = result.combinedTopology;
+        expect(combined.nodes, isNotEmpty);
+        for (final n in combined.nodes) {
+          expect(
+            n.id.contains('|'),
+            isTrue,
+            reason:
+                'combined topology node id must be prefixed (regionId|localId)',
+          );
+        }
+        if (result.warpLinks.isNotEmpty) {
+          expect(
+            result.warpLinks.first.regionId,
+            anyOf('oldWorld', 'newWorld'),
+          );
+          expect(
+            result.warpLinks.first.otherRegionId,
+            anyOf('oldWorld', 'newWorld'),
+          );
+        }
+      },
+    );
 
     test('seed=0 uses time-based effective seed', () {
       final config = GameSetupConfig(
-        selectedGreatPowerIds: GameSetupConfig.defaultConfig.selectedGreatPowerIds,
-        numProvincesOldWorld: GameSetupConfig.defaultConfig.numProvincesOldWorld,
-        numProvincesNewWorld: GameSetupConfig.defaultConfig.numProvincesNewWorld,
+        selectedGreatPowerIds:
+            GameSetupConfig.defaultConfig.selectedGreatPowerIds,
+        numProvincesOldWorld:
+            GameSetupConfig.defaultConfig.numProvincesOldWorld,
+        numProvincesNewWorld:
+            GameSetupConfig.defaultConfig.numProvincesNewWorld,
         seed: 0,
       );
       final result = runInitGame(
@@ -157,9 +185,13 @@ void main() {
         String seaZoneId = 's1',
         ResourceRules? resourceRules,
         void Function(String)? onLog,
-        void Function(List<(int x, int y)> landSeeds, List<int> continentIndices)?
-            onLandSeedsPlaced,
-        void Function(List<(int x, int y)> continentSeeds)? onContinentSeedsPlaced,
+        void Function(
+          List<(int x, int y)> landSeeds,
+          List<int> continentIndices,
+        )?
+        onLandSeedsPlaced,
+        void Function(List<(int x, int y)> continentSeeds)?
+        onContinentSeedsPlaced,
       }) {
         seedsByRegion[regionId] = params.seed;
         return defaultTileMapRegionGenerator(
@@ -230,9 +262,13 @@ void main() {
         String seaZoneId = 's1',
         ResourceRules? resourceRules,
         void Function(String)? onLog,
-        void Function(List<(int x, int y)> landSeeds, List<int> continentIndices)?
-            onLandSeedsPlaced,
-        void Function(List<(int x, int y)> continentSeeds)? onContinentSeedsPlaced,
+        void Function(
+          List<(int x, int y)> landSeeds,
+          List<int> continentIndices,
+        )?
+        onLandSeedsPlaced,
+        void Function(List<(int x, int y)> continentSeeds)?
+        onContinentSeedsPlaced,
       }) {
         callCount++;
         return defaultTileMapRegionGenerator(
@@ -295,8 +331,7 @@ void main() {
         final nbr = _provincePpNeighboursForInitGameTest(topo);
         final owners = <String, String>{
           for (final p in game.worldState.oldWorld.provinces)
-            if (p.ownerId != null)
-              ProvinceId.localIdFrom(p.id): p.ownerId!,
+            if (p.ownerId != null) ProvinceId.localIdFrom(p.id): p.ownerId!,
         };
         for (final gpId in ['gp1', 'gp2', 'gp3', 'gp4', 'gp5', 'gp6']) {
           expect(
@@ -308,27 +343,34 @@ void main() {
       },
     );
 
-    test('throws ArgumentError when OW provinces fewer than Great Powers', () {
-      // Config with 6 GPs but only 2 OW provinces: createGameFromGeneratedMaps throws
-      // (either "provinces" or "sea-bound provinces" check). Accept either message.
-      final config = GameSetupConfig(
-        selectedGreatPowerIds: GameSetupConfig.defaultConfig.selectedGreatPowerIds,
-        numProvincesOldWorld: 2,
-        numProvincesNewWorld: 5,
-      );
-      expect(
-        () => runInitGame(
-          config: config,
-          options: const InitGameOptions(cellSize: 8, renderPng: false),
-        ),
-        throwsA(predicate<ArgumentError>((e) {
-          final msg = e.message ?? '';
-          return msg.contains('Great Powers') &&
-              (msg.contains('need at least one each') ||
-                  msg.contains('need one each'));
-        })),
-      );
-    });
+    test(
+      'throws setup config exception when OW provinces fewer than Great Powers',
+      () {
+        // Config with 6 GPs but only 2 OW provinces: createGameFromGeneratedMaps throws
+        // (either "provinces" or "sea-bound provinces" check). Accept either message.
+        final config = GameSetupConfig(
+          selectedGreatPowerIds:
+              GameSetupConfig.defaultConfig.selectedGreatPowerIds,
+          numProvincesOldWorld: 2,
+          numProvincesNewWorld: 5,
+        );
+        expect(
+          () => runInitGame(
+            config: config,
+            options: const InitGameOptions(cellSize: 8, renderPng: false),
+          ),
+          throwsA(
+            isA<SetupConfigConstraintException>()
+                .having(
+                  (e) => e.code,
+                  'code',
+                  'insufficient_old_world_provinces_for_great_powers',
+                )
+                .having((e) => e.message, 'message', contains('Great Powers')),
+          ),
+        );
+      },
+    );
   });
 }
 
@@ -351,4 +393,3 @@ Map<String, Set<String>> _provincePpNeighboursForInitGameTest(
   }
   return neighbours;
 }
-


### PR DESCRIPTION
## Summary
- Introduce `SetupValidationException` + setup-specific subtypes in `colonizethis_logic` and export them publicly.
- Migrate setup validation throw sites (capital selection/application and init setup constraints) away from generic `ArgumentError` to typed exceptions with stable `code` values.
- Update SPEC acceptance text and setup tests to assert the typed exception contract.

## Scope
- This PR implements a setup-validation slice of #1615.
- Out of scope in this PR: cross-domain exception migration and AST custom lint enforcement across all packages.

## Test plan
- [x] `dart analyze` on touched setup and test files via MCP analyze
- [x] `dart test` for:
  - `packages/colonizethis_logic/test/capital_choice_test.dart`
  - `packages/colonizethis_logic/test/init_game_orchestrator_test.dart`

Refs #1615

Made with [Cursor](https://cursor.com)