### PR TITLE
Refs #1685: spec contracts, envy evidence, tech UI copy

### DIFF
--- a/SPEC/ai/ai-personalities.md
+++ b/SPEC/ai/ai-personalities.md
@@ -43,7 +43,7 @@ Each personality defines **domain weights** (economy, military, diplomacy, resea
 
 Exact numbers live in config data; SPEC does not mandate values, only that each leader has a defined vector and that it biases goal selection and utility scores.
 
-**Config source:** Personality config (domain weights, goal weights, behavioral thresholds) lives in program-level config (`colonizethis_data/lib/src/ai_personality_config.dart`) per [ruleset-config.md](../program/ruleset-config.md). Ruleset-configurable personality bundles are deferred to a future phase when the ruleset loader supports JSON merge. The `personalityId` field in AIConfig is reserved for future ruleset-driven personality overrides.
+**Config source:** Personality config (domain weights, goal weights, behavioral thresholds) lives in program-level config (`colonizethis_data/lib/src/ai_personality_config.dart`). Lookup order for weights/thresholds: **`personalityId`** when it names a known archetype key in that config; otherwise **canonical `leaderId`** derived from `Player.leaderKey`; if still unknown, **neutral defaults** are used. Ruleset-driven JSON overlays for this table remain out of scope until specified in [ruleset-config.md](../program/ruleset-config.md).
 
 ---
 
@@ -73,8 +73,8 @@ Personality is loaded as config and supplied via **AIConfig** when the AI genera
 
 In current product, **AIConfig** fields related to personality have the following contract:
 
-- `leaderId` — canonical leader id (e.g. `victoria`, `napoleon`). This is the **only** id used by `colonizethis_ai` for personality lookups: domain weights, goal weights, and behavioral thresholds in `colonizethis_data/lib/src/ai_personality_config.dart` are all keyed by canonical leader id. Dossier/archetype display also derives from `leaderId` via that config.
-- `personalityId` — optional personality archetype id (e.g. an archetype handle in future rulesets). In current product, `colonizethis_ai` does **not** read this field; callers SHOULD pass the same canonical id as `leaderId`. Future ruleset-configurable personality bundles may use `personalityId` as an override handle; when that happens, this spec and [ruleset-config.md](../program/ruleset-config.md) must be updated first.
+- `leaderId` — canonical leader id (e.g. `victoria`, `napoleon`) from `Player.leaderKey` / scenario mapping. Used as **identity** and as the **fallback** personality key when `personalityId` is absent or unknown.
+- `personalityId` — **active** archetype key for domain/goal/threshold lookups when it matches a key in `ai_personality_config.dart`; otherwise resolution falls back to **`leaderId`**, then to neutral defaults. Implementation: `personalityLookupKeyForAi` + `getDomainWeightsForLeader` / `getGoalWeightsForLeader` / `getThresholdsForLeader` in `colonizethis_data`. `colonizethis_ai` reads **`personalityId`** from scenario/`Player` via `AIConfig.personalityId` (see `full_ai_planner.dart`).
 
 ### Leader identity and `Player.leaderKey` (current product)
 

--- a/SPEC/ai/hidden-agendas.md
+++ b/SPEC/ai/hidden-agendas.md
@@ -60,9 +60,15 @@ When the game or AI performs an action, **evidence rules** (defined per agenda) 
 - **Suspicion levels** map total evidence score to a band: Unknown (0–2), Possible (3–5), Likely (6–8), Almost certain (9–10), Confirmed (10+). Display labels in dossier use these bands; “Confirmed” is a threshold, not revelation of true agenda.
 - Evidence is deterministic (same actions → same evidence). Dossier projection is PlayerView-safe: only suspicion scores and capped evidence log exposed. See [ai-dossier.md](ai-dossier.md).
 
-**Evidence rule coverage (current product vs deferred)**  
-- **current product (in scope):** Evidence rules are implemented for: war declaration → warmonger/backstabber; peace offer → peacemaker; land battle victory → warmonger; naval battle victory → warmonger. Implementation: evidence rules evaluated during turn resolution (see [ai-events-and-dossier.md](../program/ai-events-and-dossier.md)).
-- **Deferred (not yet implemented):** Evidence rules for the following are not in current product scope: Tech Thief (spy usage); Isolationist (alliance decline); Backstabber (treaty-breaking events); Envy (mirror-build detection). Until implemented, suspicion for those agenda types is not incremented by evidence rules; they may be added in a later release.
+**Evidence rule coverage (current product)**  
+Evidence rules are evaluated during turn resolution (see [ai-events-and-dossier.md](../program/ai-events-and-dossier.md)) with deterministic, PlayerView-safe deltas:
+
+- **War declaration** — Warmonger when the target is a weaker Great Power (+2) or any GP target (+1 battle-oriented signal as implemented). **Backstabber** when the AI declared war on a prior ally (+3), or when the AI declared war on a Great Power toward whom it had **`callToArmsRefused`** in the same turn or within the prior **3** turns (+3; “broke obligation then struck”).
+- **Peace offer** — Peacemaker (+1).
+- **Land / naval battle victory (attacker)** — Warmonger per implemented rules.
+- **Isolationist** — AI refuses **call to arms** while still at peace with the defender (+2).
+- **Tech thief** — Resolved **`steal_tech`** spy work: **+1** per attempt, **+2** additional on success (**+3** total on success). Implementation: `evidenceForAiStealTechResolved`.
+- **Envy** — AI completes a tech in the **same catalog category** the human most recently completed via research, within **2** turns after that human completion (same turn counts): **+1** per qualifying completion, **max +3** total envy suspicion for that AI subject in that turn. Mirror tracking uses `Game.lastHumanCompletedResearchCategory` / `lastHumanResearchCategoryCompletionTurn`; build/improvement mirroring is out of scope until a single category model is defined for builds.
 
 ---
 
@@ -72,7 +78,7 @@ When the game or AI performs an action, **evidence rules** (defined per agenda) 
 - **Determinism:** Same global game seed and `aiSeed[P]` yield the same agenda. Same observable actions yield the same evidence points (replay- and save/load-consistent).
 - **Behavior modifiers:** Each agenda type has defined effects in the spec categories: war declaration, peace acceptance, alliance acceptance, build/order choice, treaty breaking. Expressed as weights or thresholds in config.
 - **War declaration (relation threshold and target scoring):** Declare-war candidates are scored only when relation score ≤ agenda’s `declareWarMaxRelationScore` (default 50; warmonger 70; peacemaker 30). When scoring declare-war, warmonger receives bonus for target in weakNeighbors; backstabber receives bonus for allied target. Implementation uses config for thresholds and bonuses; diplomacy planner filters or zero-scores out-of-threshold declare-war and applies target bonuses.
-- **Evidence and suspicion:** Evidence rules add points per (observer nation, subject AI, agenda type). Suspicion bands (Unknown, Possible, Likely, Almost certain, Confirmed) map total evidence score; display uses bands only. True agenda is never exposed to the player. Evidence rule coverage: current product (war declaration, peace offer, land/naval battle victory) is implemented; deferred (spy, alliance decline, treaty break, mirror-build) is documented and not in scope for current product.
+- **Evidence and suspicion:** Evidence rules add points per (observer nation, subject AI, agenda type). Suspicion bands (Unknown, Possible, Likely, Almost certain, Confirmed) map total evidence score; display uses bands only. True agenda is never exposed to the player. Evidence rule coverage matches **Evidence rule coverage (current product)** above (including spy, call-to-arms refuse, treaty-break attack window, and research-category envy).
 - **Dossier contract:** Only suspicion scores and capped evidence log are exposed (PlayerView-safe). See [ai-dossier.md](ai-dossier.md) and [ai-events-and-dossier.md](../program/ai-events-and-dossier.md).
 
 ## Implementation

--- a/SPEC/game/tech-tree-labour-economy.md
+++ b/SPEC/game/tech-tree-labour-economy.md
@@ -53,7 +53,7 @@ This section resolves ambiguity called out for **#145**: which table rows are **
 
 - Given the Labour and Economy tech table in this doc and the global tech catalog built from all tech-tree docs  
   When the System validates the catalog at startup  
-  Then the System ensures that each id in this table is unique, that its prerequisites refer to techs present in the global catalog, and that **implemented** effects (worker tiers, research slots, Money Lending research debt floor) match [economy-models.md](../program/economy-models.md) and [research-resolution.md](../program/research-resolution.md). **Deferred** rows (`banking` economy effects, `trade_fairs` commodity counts) must remain explicitly marked as deferred in this doc until wired.
+  Then the System ensures that each id in this table is unique, that its prerequisites refer to techs present in the global catalog, and that **implemented** effects (worker tiers, research slots, Money Lending research debt floor, **Banking** extended research debt floor with Money Lending, **Trade Fairs** commodity-slot capacity per [diplomacy-resolution.md](../program/diplomacy-resolution.md)) match [economy-models.md](../program/economy-models.md) and [research-resolution.md](../program/research-resolution.md). General borrowing / interest outside the research-phase floor remains explicitly out of scope in this doc.
 
 - Given a player does **not** have `money_lending` in `techUnlocked`  
   When the Research phase applies research funding that would spend treasury  
@@ -65,7 +65,7 @@ This section resolves ambiguity called out for **#145**: which table rows are **
 
 - Given a player has `banking` in `techUnlocked` but **not** `money_lending`  
   When the System computes the research treasury floor for the Research phase  
-  Then the System uses a floor of **0** (Banking does not extend research debt until specified in a future spec change).
+  Then the System uses a floor of **0** (Banking extends the floor only when `money_lending` is also unlocked).
 
 - Given the global tech catalog  
   When a designer reads a “Leads to …” cell in this doc’s table  

--- a/SPEC/program/ai-events-and-dossier.md
+++ b/SPEC/program/ai-events-and-dossier.md
@@ -25,7 +25,7 @@ Internal record appended when an action matches an evidence rule. Fields: observ
 4. UI subscribes and resolves to text/portrait assets. No asset paths in events.
 
 ### Evidence and Dossier
-1. Evidence rules evaluated when actions are applied (turn resolution or post-resolution hook). Rules per [hidden-agendas.md](../ai/hidden-agendas.md). Which triggers are in scope (current product) vs deferred is defined in that doc (§ Evidence rule coverage).
+1. Evidence rules evaluated when actions are applied (turn resolution or post-resolution hook). Rules per [hidden-agendas.md](../ai/hidden-agendas.md) § **Evidence rule coverage (current product)**.
 2. Storage: per (observer, subject, agenda type) counter + optional (turn, description) list. Deterministic: same actions → same evidence.
 3. Dossier projection: read API returning PlayerView-safe data (basic intel, suspicion levels, evidence list, behavioral notes). True hidden agenda never exposed.
 4. **Confidence % mapping:** Best-guess agenda confidence (display %) is derived from the highest suspicion score for that agenda. Mapping: score 0–2 → 0%; 3–5 → 25%; 6–8 → 60%; 9–10 → 85%; 11+ → 100%. Implementation must use this mapping for consistency with display bands (see [ai-dossier.md](../ai/ai-dossier.md) § PlayerView-safe rules).

--- a/app/lib/features/game/widgets/tech_tree_widget.dart
+++ b/app/lib/features/game/widgets/tech_tree_widget.dart
@@ -387,7 +387,9 @@ class TechTreeWidget extends StatelessWidget {
         list.add(
           'Unlocks: Trained Journeymen, University, and military doctrine paths',
         );
-        list.add('Prerequisite-only in MVP: no direct economy modifier');
+        list.add(
+          'Prerequisite-only: unlock paths only; no direct economy modifier',
+        );
         break;
       case 'money_lending':
         list.add('Enables: Research-phase treasury floor to -500');
@@ -410,13 +412,15 @@ class TechTreeWidget extends StatelessWidget {
         break;
       case 'trade_fairs':
         list.add(
-          'Enables: Planned increase to trade commodity slots (deferred in MVP)',
+          'Enables: 6 commodity slots per embassy trade agreement (3 baseline without this tech)',
         );
         list.add('Unlocks: Banking');
         break;
       case 'banking':
         list.add('Unlocks: Dynamite, Empire Building, Modern Military Funding');
-        list.add('Prerequisite-only in MVP: extended banking rules deferred');
+        list.add(
+          'With Money Lending: extends research-phase treasury floor to −£1000',
+        );
         break;
       case 'diplomatic_expertise':
         list.add('Enables: Embassy overtures with Minor Nations');
@@ -430,7 +434,9 @@ class TechTreeWidget extends StatelessWidget {
         list.add('Unlocks: Nationalism');
         break;
       case 'nationalism':
-        list.add('Improves: Battle deployment base limit to 12 regiments (vs 10)');
+        list.add(
+          'Improves: Battle deployment base limit to 12 regiments (vs 10)',
+        );
         list.add('Improves: General cap floor to at least 4');
         list.add('Unlocks: Empire Building (with Banking)');
         break;
@@ -446,7 +452,9 @@ class TechTreeWidget extends StatelessWidget {
         list.add('Unlocks: Improved Sail Design and Navigation hull paths');
         break;
       case 'improved_sail_design':
-        list.add('Unlocks: Advanced Hull Design path (University + Privateering)');
+        list.add(
+          'Unlocks: Advanced Hull Design path (University + Privateering)',
+        );
         break;
       case 'convoying':
         list.add('Unlocks: Large Hulls (with Wind Saw Mill + Navigation)');
@@ -484,7 +492,9 @@ class TechTreeWidget extends StatelessWidget {
         list.add(
           'Improves: Patrol/Blockade interception and trade-raid effectiveness',
         );
-        list.add('Unlocks: Advanced Hull Design (frigate doctrine prerequisite)');
+        list.add(
+          'Unlocks: Advanced Hull Design (frigate doctrine prerequisite)',
+        );
         break;
       case 'advanced_iron_working':
         list.add('Improves: Ironclad armored steam combat hull');
@@ -511,7 +521,9 @@ class TechTreeWidget extends StatelessWidget {
         list.add('Unlocks: No regiment from this tech alone');
         break;
       case 'bayonet':
-        list.add('Unlocks: Needle Guns (with Industrial Funding + Early Rifles)');
+        list.add(
+          'Unlocks: Needle Guns (with Industrial Funding + Early Rifles)',
+        );
         break;
       case 'weapon_craftsmanship':
         list.add(
@@ -591,19 +603,19 @@ class TechTreeWidget extends StatelessWidget {
         break;
       case 'scientific_sheep_breeding':
         list.add('Improves: Wool extraction cap to 3');
-        list.add('Terminal in MVP catalog: no other tech requires this');
+        list.add('Terminal tech: nothing else in the catalog requires this');
         break;
       case 'scientific_cattle_breeding':
         list.add('Improves: Meat extraction cap to 4');
-        list.add('Terminal in MVP catalog: no other tech requires this');
+        list.add('Terminal tech: nothing else in the catalog requires this');
         break;
       case 'moldboard_plow':
         list.add('Improves: Grain extraction cap to 4');
-        list.add('Terminal in MVP catalog: no other tech requires this');
+        list.add('Terminal tech: nothing else in the catalog requires this');
         break;
       case 'safety_lamp':
         list.add('Improves: Coal extraction cap to 4');
-        list.add('Terminal in MVP catalog: no other tech requires this');
+        list.add('Terminal tech: nothing else in the catalog requires this');
         break;
       case 'large_precious_stone_mines':
         list.add('Improves: Gems/diamonds extraction cap to 3');
@@ -618,25 +630,25 @@ class TechTreeWidget extends StatelessWidget {
       case 'geological_prospecting':
         list.add('Improves: Gems/diamonds extraction cap to 4');
         list.add(
-          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+          'Prerequisite-only: catalog leaf; extraction-cap increase is the active benefit',
         );
         break;
       case 'amalgamation_process':
         list.add('Improves: Gold/silver extraction cap to 4');
         list.add(
-          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+          'Prerequisite-only: catalog leaf; extraction-cap increase is the active benefit',
         );
         break;
       case 'industrial_iron_mining':
         list.add('Improves: Iron extraction cap to 4');
         list.add(
-          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+          'Prerequisite-only: catalog leaf; extraction-cap increase is the active benefit',
         );
         break;
       case 'efficient_extraction_of_copper_and_tin':
         list.add('Improves: Copper/Tin extraction cap to 4');
         list.add(
-          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+          'Prerequisite-only: catalog leaf; extraction-cap increase is the active benefit',
         );
         break;
       case 'discovery_of_sugar':
@@ -664,7 +676,7 @@ class TechTreeWidget extends StatelessWidget {
       case 'sugar_industry':
         list.add('Improves: Sugar cane extraction cap to 4');
         list.add(
-          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+          'Prerequisite-only: catalog leaf; extraction-cap increase is the active benefit',
         );
         break;
       case 'discovery_of_tobacco':
@@ -690,7 +702,7 @@ class TechTreeWidget extends StatelessWidget {
       case 'tobacco_industry':
         list.add('Improves: Tobacco extraction cap to 4');
         list.add(
-          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+          'Prerequisite-only: catalog leaf; extraction-cap increase is the active benefit',
         );
         break;
       case 'discovery_of_cotton':
@@ -706,7 +718,7 @@ class TechTreeWidget extends StatelessWidget {
       case 'cotton_weaving':
         list.add('Enables: Cloth production from cotton');
         list.add(
-          'Prerequisite-only in MVP catalog: no other tech requires this; recipe unlock is the active benefit',
+          'Prerequisite-only: catalog leaf; recipe unlock is the active benefit',
         );
         break;
       case 'large_cotton_plantations':
@@ -716,7 +728,7 @@ class TechTreeWidget extends StatelessWidget {
       case 'cotton_gin':
         list.add('Improves: Cotton extraction cap to 4');
         list.add(
-          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+          'Prerequisite-only: catalog leaf; extraction-cap increase is the active benefit',
         );
         break;
       case 'discovery_of_furs':
@@ -744,7 +756,7 @@ class TechTreeWidget extends StatelessWidget {
       case 'excessive_fur_harvesting':
         list.add('Improves: Furs extraction cap to 4');
         list.add(
-          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+          'Prerequisite-only: catalog leaf; extraction-cap increase is the active benefit',
         );
         break;
       case 'discovery_of_spices':
@@ -784,7 +796,7 @@ class TechTreeWidget extends StatelessWidget {
       case 'improved_food_preservation':
         list.add('Improves: Spices extraction cap to 4');
         list.add(
-          'Prerequisite-only in MVP catalog: no other tech requires this; cap increase is the active benefit',
+          'Prerequisite-only: catalog leaf; extraction-cap increase is the active benefit',
         );
         break;
       case 'industrial_machinery':
@@ -792,7 +804,7 @@ class TechTreeWidget extends StatelessWidget {
           'Unlocks: Explosives, Improved Cavalry Weapons, Industrial Funding of Research (as prerequisite)',
         );
         list.add(
-          'Improves (deferred in MVP): military attack treasury cost by 25% once application point is fixed per SPEC',
+          'Improves: ×0.75 multiplicative on per-land-battle attack treasury cost at combat resolution',
         );
         break;
       case 'explosives':
@@ -881,7 +893,7 @@ class TechTreeWidget extends StatelessWidget {
           'Unlocks: Field Artillery Tactics, High Grade Steel, Elite Military Training stack',
         );
         list.add(
-          'Improves (deferred in MVP): cheaper military attack once application point is fixed per SPEC',
+          'Improves: ×0.85 multiplicative on per-land-battle attack treasury cost (stacks with Industrial Machinery)',
         );
         break;
       case 'industrial_funding_of_research':
@@ -889,7 +901,7 @@ class TechTreeWidget extends StatelessWidget {
           'Unlocks: Needle Guns, Repeating Cavalry Carbine, High Grade Steel, Advanced Iron Working (as prerequisite)',
         );
         list.add(
-          'Improves (deferred in MVP): research efficiency for military/naval tech per SPEC',
+          'Improves: +20% effective RP (floor) for military and naval category research allocations',
         );
         break;
       default:

--- a/app/test/tech_tree_widget_test.dart
+++ b/app/test/tech_tree_widget_test.dart
@@ -827,7 +827,7 @@ void main() {
         'Banking':
             'Unlocks: Dynamite, Empire Building, Modern Military Funding',
         'Trade Fairs':
-            'Enables: Planned increase to trade commodity slots (deferred in MVP)',
+            'Enables: 6 commodity slots per embassy trade agreement (3 baseline without this tech)',
         'University': 'Enables: Fourth active research slot (3 -> 4)',
         'Diplomatic Expertise': 'Enables: Embassy overtures with Minor Nations',
         'Merchant Companies': 'Enables: Merchant civilian unit construction',
@@ -950,8 +950,7 @@ void main() {
             'Improves: Battle-line capital ship for decisive fleet engagements',
         'Privateering Companies':
             'Improves: Patrol/Blockade interception and trade-raid effectiveness',
-        'Advanced Iron Working':
-            'Improves: Ironclad armored steam combat hull',
+        'Advanced Iron Working': 'Improves: Ironclad armored steam combat hull',
         'Organised Regiments': 'Improves: General cap floor to at least 2',
         'Improved Iron Weapons': 'Unlocks: Bayonet (with Crucible Process)',
         'Improved Infantry Tactics':

--- a/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+++ b/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
@@ -24,6 +24,27 @@ bool isAiControlledForEvidence(Game game, String playerId) {
   return p != null && !p.isHuman;
 }
 
+/// True when [actorGpId] refused call-to-arms toward [targetGpId] in the same
+/// turn as [warTurn] or within the prior [window] turns (treaty strain then attack).
+/// SPEC/ai/hidden-agendas.md (Backstabber evidence).
+bool hadCallToArmsRefusedWithTargetInAttackWindow(
+  Game game,
+  String actorGpId,
+  String targetGpId,
+  int warTurn, {
+  int window = 3,
+}) {
+  for (final e in game.diplomaticHistoryEvents) {
+    if (e.type != DiplomaticEventType.callToArmsRefused) continue;
+    if (e.fromFactionId != actorGpId || e.toFactionId != targetGpId) continue;
+    final delta = warTurn - e.turn;
+    if (delta >= 0 && delta <= window) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /// Returns true if [targetId] is a weaker GP than [actorId] by military level (for warmonger evidence).
 bool _isWeakerGp(Game game, String actorId, String targetId) {
   final actor = game.playerById(actorId);
@@ -51,6 +72,14 @@ List<DossierEvidenceEntry> evidenceForDeclareWar(
   final weaker = targetIsGp && _isWeakerGp(game, actorGpId, targetFactionId);
 
   final entries = <DossierEvidenceEntry>[];
+  final treatyBreakAttack =
+      !wasAllied &&
+      hadCallToArmsRefusedWithTargetInAttackWindow(
+        game,
+        actorGpId,
+        targetFactionId,
+        turnNumber,
+      );
   for (final observerId in observers) {
     if (wasAllied) {
       entries.add(
@@ -60,6 +89,17 @@ List<DossierEvidenceEntry> evidenceForDeclareWar(
           agendaType: 'backstabber',
           turnNumber: turnNumber,
           description: 'declared war on ally',
+          scoreDelta: 3,
+        ),
+      );
+    } else if (treatyBreakAttack) {
+      entries.add(
+        DossierEvidenceEntry(
+          observerId: observerId,
+          subjectId: actorGpId,
+          agendaType: 'backstabber',
+          turnNumber: turnNumber,
+          description: 'declared war soon after breaking alliance obligation',
           scoreDelta: 3,
         ),
       );
@@ -222,7 +262,82 @@ List<DossierEvidenceEntry> evidenceForIsolationistCallToArmsRefuse(
   return entries;
 }
 
+int _envyScoreAccumulatedForSubjectAndTurn(
+  Game game,
+  String subjectId,
+  int turnNumber,
+  List<DossierEvidenceEntry> pendingSameTurn,
+) {
+  var sum = 0;
+  for (final e in game.dossierEvidenceEntries) {
+    if (e.subjectId == subjectId &&
+        e.agendaType == 'envy' &&
+        e.turnNumber == turnNumber) {
+      sum += e.scoreDelta;
+    }
+  }
+  for (final e in pendingSameTurn) {
+    if (e.subjectId == subjectId &&
+        e.agendaType == 'envy' &&
+        e.turnNumber == turnNumber) {
+      sum += e.scoreDelta;
+    }
+  }
+  return sum;
+}
+
+/// Envy agenda: AI completed research in the same category the human most recently
+/// completed, within **2 turns** after that human completion (same turn counts).
+/// **+1** per qualifying tech completion, **max +3** total envy suspicion for the
+/// subject AI in that turn. SPEC/ai/hidden-agendas.md.
+List<DossierEvidenceEntry> evidenceForEnvyResearchMirror(
+  Game game,
+  String aiGpId,
+  String completedCategory,
+  int turnNumber,
+  List<DossierEvidenceEntry> pendingSameTurn,
+) {
+  if (!isAiControlledForEvidence(game, aiGpId)) return [];
+  final observers = _humanObserverIds(game);
+  if (observers.isEmpty) return [];
+
+  final refCat = game.lastHumanCompletedResearchCategory;
+  final refTurn = game.lastHumanResearchCategoryCompletionTurn;
+  if (refCat == null || refTurn == null) return [];
+  if (completedCategory != refCat) return [];
+  if (turnNumber < refTurn || turnNumber > refTurn + 2) return [];
+
+  final already = _envyScoreAccumulatedForSubjectAndTurn(
+    game,
+    aiGpId,
+    turnNumber,
+    pendingSameTurn,
+  );
+  if (already >= 3) return [];
+
+  final entries = <DossierEvidenceEntry>[];
+  for (final observerId in observers) {
+    entries.add(
+      DossierEvidenceEntry(
+        observerId: observerId,
+        subjectId: aiGpId,
+        agendaType: 'envy',
+        turnNumber: turnNumber,
+        description: 'mirrored human research category shortly after human',
+        scoreDelta: 1,
+      ),
+    );
+  }
+  if (entries.isNotEmpty) {
+    _log.d(
+      'evidence envy mirror ai=$aiGpId category=$completedCategory turn=$turnNumber',
+    );
+  }
+  return entries;
+}
+
 /// Tech Thief agenda: resolved steal_tech spy work against another Great Power.
+/// **+1** per attempt, **+2** additional on success (**+3** total on success).
 /// SPEC/ai/hidden-agendas.md.
 List<DossierEvidenceEntry> evidenceForAiStealTechResolved(
   Game game,

--- a/packages/colonizethis_logic/lib/src/turn/research_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/research_resolver.dart
@@ -2,6 +2,8 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../constants.dart';
+import '../dossier/evidence_rules.dart';
 import '../world/player_view.dart';
 import 'economy_debt_rules.dart';
 import 'economy_tech_effects.dart';
@@ -23,10 +25,12 @@ Game resolveResearchPhase(Game game, Orders orders) {
   final playersWithOrders = researchByPlayer.values
       .where((o) => o.isNotEmpty)
       .length;
+  var state = game;
+  final extraEvidence = <DossierEvidenceEntry>[];
   final updatedPlayers = <Player>[];
 
   for (final p in game.players) {
-    final player = p;
+    final player = state.playerById(p.id)!;
     final playerOrders = researchByPlayer[player.id] ?? const <ResearchOrder>[];
     if (playerOrders.isEmpty) {
       updatedPlayers.add(player);
@@ -158,6 +162,35 @@ Game resolveResearchPhase(Game game, Orders orders) {
       progress.remove(techId);
     }
 
+    for (final techId in toUnlock) {
+      final techMeta = techById(techId);
+      final cat = techMeta?.category;
+      if (cat != null && cat.isNotEmpty && player.isHuman) {
+        state = state.copyWith(
+          lastHumanCompletedResearchCategory: cat,
+          lastHumanResearchCategoryCompletionTurn: turn,
+        );
+      }
+    }
+    for (final techId in toUnlock) {
+      final techMeta = techById(techId);
+      final cat = techMeta?.category;
+      if (cat != null &&
+          cat.isNotEmpty &&
+          !player.isHuman &&
+          isAiControlledForEvidence(state, player.id)) {
+        extraEvidence.addAll(
+          evidenceForEnvyResearchMirror(
+            state,
+            player.id,
+            cat,
+            turn,
+            extraEvidence,
+          ),
+        );
+      }
+    }
+
     Map<String, bool>? nextUnlocked;
     if (workingUnlocked.isNotEmpty) {
       nextUnlocked = workingUnlocked;
@@ -193,5 +226,8 @@ Game resolveResearchPhase(Game game, Orders orders) {
   }
 
   _log.i('research phase end turn=$turn playersWithOrders=$playersWithOrders');
-  return game.copyWith(players: updatedPlayers);
+  return state.copyWith(
+    players: updatedPlayers,
+    dossierEvidenceEntries: [...state.dossierEvidenceEntries, ...extraEvidence],
+  );
 }

--- a/packages/colonizethis_logic/test/evidence_rules_test.dart
+++ b/packages/colonizethis_logic/test/evidence_rules_test.dart
@@ -6,28 +6,41 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 void main() {
   group('evidenceForLandBattleVictory', () {
-    test('AI victor vs defender appends warmonger evidence for human observer', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'gp1', displayName: 'Human', isHuman: true),
-          Player(id: 'gp2', displayName: 'AI', isHuman: false, militaryLevel: 4),
-          Player(id: 'gp3', displayName: 'Other', isHuman: false, militaryLevel: 2),
-        ],
-      );
-      final entries = evidenceForLandBattleVictory(game, 'gp2', 'gp3', 2);
-      expect(entries.length, 1);
-      expect(entries.first.observerId, 'gp1');
-      expect(entries.first.subjectId, 'gp2');
-      expect(entries.first.agendaType, 'warmonger');
-      expect(entries.first.scoreDelta, 2);
-      expect(entries.first.description, contains('weaker'));
-    });
+    test(
+      'AI victor vs defender appends warmonger evidence for human observer',
+      () {
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'Human', isHuman: true),
+            Player(
+              id: 'gp2',
+              displayName: 'AI',
+              isHuman: false,
+              militaryLevel: 4,
+            ),
+            Player(
+              id: 'gp3',
+              displayName: 'Other',
+              isHuman: false,
+              militaryLevel: 2,
+            ),
+          ],
+        );
+        final entries = evidenceForLandBattleVictory(game, 'gp2', 'gp3', 2);
+        expect(entries.length, 1);
+        expect(entries.first.observerId, 'gp1');
+        expect(entries.first.subjectId, 'gp2');
+        expect(entries.first.agendaType, 'warmonger');
+        expect(entries.first.scoreDelta, 2);
+        expect(entries.first.description, contains('weaker'));
+      },
+    );
 
     test('AI victor vs non-weaker defender gives scoreDelta 1', () {
       final game = Game(
@@ -39,8 +52,18 @@ void main() {
         ),
         players: const [
           Player(id: 'gp1', displayName: 'Human', isHuman: true),
-          Player(id: 'gp2', displayName: 'AI', isHuman: false, militaryLevel: 2),
-          Player(id: 'gp3', displayName: 'Other', isHuman: false, militaryLevel: 4),
+          Player(
+            id: 'gp2',
+            displayName: 'AI',
+            isHuman: false,
+            militaryLevel: 2,
+          ),
+          Player(
+            id: 'gp3',
+            displayName: 'Other',
+            isHuman: false,
+            militaryLevel: 4,
+          ),
         ],
       );
       final entries = evidenceForLandBattleVictory(game, 'gp2', 'gp3', 2);
@@ -128,105 +151,161 @@ void main() {
   });
 
   group('evidenceForDeclareWar', () {
-    test('AI declaring war on weaker allied GP adds backstabber and warmonger evidence', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'human', displayName: 'Human', isHuman: true, militaryLevel: 3),
-          Player(id: 'ai', displayName: 'AI', isHuman: false, militaryLevel: 5),
-          Player(id: 'ally', displayName: 'Ally', isHuman: false, militaryLevel: 2),
-        ],
-        diplomacyRelations: const [
-          DiplomacyRelation(
-            factionId1: 'ai',
-            factionId2: 'ally',
-            level: RelationLevel.allied,
+    test(
+      'AI declaring war on weaker allied GP adds backstabber and warmonger evidence',
+      () {
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
           ),
-        ],
-      );
+          players: const [
+            Player(
+              id: 'human',
+              displayName: 'Human',
+              isHuman: true,
+              militaryLevel: 3,
+            ),
+            Player(
+              id: 'ai',
+              displayName: 'AI',
+              isHuman: false,
+              militaryLevel: 5,
+            ),
+            Player(
+              id: 'ally',
+              displayName: 'Ally',
+              isHuman: false,
+              militaryLevel: 2,
+            ),
+          ],
+          diplomacyRelations: const [
+            DiplomacyRelation(
+              factionId1: 'ai',
+              factionId2: 'ally',
+              level: RelationLevel.allied,
+            ),
+          ],
+        );
 
-      final entries = evidenceForDeclareWar(game, 'ai', 'ally', 2);
+        final entries = evidenceForDeclareWar(game, 'ai', 'ally', 2);
 
-      expect(entries.length, 2);
-      final backstabberEntries =
-          entries.where((e) => e.agendaType == 'backstabber').toList();
-      final warmongerEntries =
-          entries.where((e) => e.agendaType == 'warmonger').toList();
+        expect(entries.length, 2);
+        final backstabberEntries = entries
+            .where((e) => e.agendaType == 'backstabber')
+            .toList();
+        final warmongerEntries = entries
+            .where((e) => e.agendaType == 'warmonger')
+            .toList();
 
-      expect(backstabberEntries.length, 1);
-      expect(backstabberEntries.first.observerId, 'human');
-      expect(backstabberEntries.first.subjectId, 'ai');
-      expect(backstabberEntries.first.scoreDelta, 3);
-      expect(backstabberEntries.first.description, contains('ally'));
+        expect(backstabberEntries.length, 1);
+        expect(backstabberEntries.first.observerId, 'human');
+        expect(backstabberEntries.first.subjectId, 'ai');
+        expect(backstabberEntries.first.scoreDelta, 3);
+        expect(backstabberEntries.first.description, contains('ally'));
 
-      expect(warmongerEntries.length, 1);
-      expect(warmongerEntries.first.observerId, 'human');
-      expect(warmongerEntries.first.subjectId, 'ai');
-      expect(warmongerEntries.first.scoreDelta, 2);
-      expect(warmongerEntries.first.description, contains('weaker'));
-    });
+        expect(warmongerEntries.length, 1);
+        expect(warmongerEntries.first.observerId, 'human');
+        expect(warmongerEntries.first.subjectId, 'ai');
+        expect(warmongerEntries.first.scoreDelta, 2);
+        expect(warmongerEntries.first.description, contains('weaker'));
+      },
+    );
 
-    test('AI declaring war on weaker non-allied GP only adds warmonger evidence', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'human', displayName: 'Human', isHuman: true, militaryLevel: 3),
-          Player(id: 'ai', displayName: 'AI', isHuman: false, militaryLevel: 5),
-          Player(id: 'target', displayName: 'Target', isHuman: false, militaryLevel: 2),
-        ],
-      );
-
-      final entries = evidenceForDeclareWar(game, 'ai', 'target', 2);
-
-      expect(entries.length, 1);
-      expect(entries.first.agendaType, 'warmonger');
-      expect(entries.first.observerId, 'human');
-      expect(entries.first.subjectId, 'ai');
-      expect(entries.first.scoreDelta, 2);
-      expect(entries.first.description, contains('weaker'));
-    });
-
-    test('AI declaring war on allied non-weaker GP only adds backstabber evidence', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'human', displayName: 'Human', isHuman: true, militaryLevel: 3),
-          Player(id: 'ai', displayName: 'AI', isHuman: false, militaryLevel: 2),
-          Player(id: 'ally', displayName: 'Ally', isHuman: false, militaryLevel: 5),
-        ],
-        diplomacyRelations: const [
-          DiplomacyRelation(
-            factionId1: 'ai',
-            factionId2: 'ally',
-            level: RelationLevel.allied,
+    test(
+      'AI declaring war on weaker non-allied GP only adds warmonger evidence',
+      () {
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
           ),
-        ],
-      );
+          players: const [
+            Player(
+              id: 'human',
+              displayName: 'Human',
+              isHuman: true,
+              militaryLevel: 3,
+            ),
+            Player(
+              id: 'ai',
+              displayName: 'AI',
+              isHuman: false,
+              militaryLevel: 5,
+            ),
+            Player(
+              id: 'target',
+              displayName: 'Target',
+              isHuman: false,
+              militaryLevel: 2,
+            ),
+          ],
+        );
 
-      final entries = evidenceForDeclareWar(game, 'ai', 'ally', 2);
+        final entries = evidenceForDeclareWar(game, 'ai', 'target', 2);
 
-      expect(entries.length, 1);
-      expect(entries.first.agendaType, 'backstabber');
-      expect(entries.first.observerId, 'human');
-      expect(entries.first.subjectId, 'ai');
-      expect(entries.first.scoreDelta, 3);
-      expect(entries.first.description, contains('ally'));
-    });
+        expect(entries.length, 1);
+        expect(entries.first.agendaType, 'warmonger');
+        expect(entries.first.observerId, 'human');
+        expect(entries.first.subjectId, 'ai');
+        expect(entries.first.scoreDelta, 2);
+        expect(entries.first.description, contains('weaker'));
+      },
+    );
+
+    test(
+      'AI declaring war on allied non-weaker GP only adds backstabber evidence',
+      () {
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(
+              id: 'human',
+              displayName: 'Human',
+              isHuman: true,
+              militaryLevel: 3,
+            ),
+            Player(
+              id: 'ai',
+              displayName: 'AI',
+              isHuman: false,
+              militaryLevel: 2,
+            ),
+            Player(
+              id: 'ally',
+              displayName: 'Ally',
+              isHuman: false,
+              militaryLevel: 5,
+            ),
+          ],
+          diplomacyRelations: const [
+            DiplomacyRelation(
+              factionId1: 'ai',
+              factionId2: 'ally',
+              level: RelationLevel.allied,
+            ),
+          ],
+        );
+
+        final entries = evidenceForDeclareWar(game, 'ai', 'ally', 2);
+
+        expect(entries.length, 1);
+        expect(entries.first.agendaType, 'backstabber');
+        expect(entries.first.observerId, 'human');
+        expect(entries.first.subjectId, 'ai');
+        expect(entries.first.scoreDelta, 3);
+        expect(entries.first.description, contains('ally'));
+      },
+    );
 
     test('human actor returns no evidence', () {
       final game = Game(
@@ -328,6 +407,150 @@ void main() {
 
       final entries = evidenceForOfferPeace(game, 'ai', 'other', 2);
 
+      expect(entries, isEmpty);
+    });
+  });
+
+  group('evidenceForDeclareWar treaty-break window', () {
+    test(
+      'adds backstabber when war follows callToArmsRefused within 3 turns',
+      () {
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 6),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(
+              id: 'human',
+              displayName: 'Human',
+              isHuman: true,
+              militaryLevel: 5,
+            ),
+            Player(
+              id: 'ai',
+              displayName: 'AI',
+              isHuman: false,
+              militaryLevel: 5,
+            ),
+            Player(
+              id: 'target',
+              displayName: 'Target',
+              isHuman: false,
+              militaryLevel: 5,
+            ),
+          ],
+          diplomacyRelations: const [
+            DiplomacyRelation(
+              factionId1: 'ai',
+              factionId2: 'target',
+              level: RelationLevel.friendly,
+              state: RelationState.atPeace,
+            ),
+          ],
+          diplomaticHistoryEvents: [
+            DiplomaticEvent(
+              turn: 5,
+              intraTurnIndex: 0,
+              type: DiplomaticEventType.callToArmsRefused,
+              participants: {'ai', 'target'},
+              fromFactionId: 'ai',
+              toFactionId: 'target',
+            ),
+          ],
+        );
+
+        final entries = evidenceForDeclareWar(game, 'ai', 'target', 6);
+
+        expect(entries.length, 1);
+        expect(entries.single.agendaType, 'backstabber');
+        expect(entries.single.scoreDelta, 3);
+      },
+    );
+  });
+
+  group('evidenceForEnvyResearchMirror', () {
+    Game baseMirrorGame({required int refTurn, required int currentTurn}) {
+      return Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: TurnState(
+            phase: TurnPhase.orders,
+            turnNumber: currentTurn,
+          ),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'human', displayName: 'Human', isHuman: true),
+          Player(id: 'ai', displayName: 'AI', isHuman: false),
+        ],
+        aiControlByGpId: const {'ai': true},
+        lastHumanCompletedResearchCategory: 'gathering',
+        lastHumanResearchCategoryCompletionTurn: refTurn,
+      );
+    }
+
+    test('adds envy when category matches within window', () {
+      final game = baseMirrorGame(refTurn: 1, currentTurn: 2);
+      final entries = evidenceForEnvyResearchMirror(
+        game,
+        'ai',
+        'gathering',
+        2,
+        const [],
+      );
+      expect(entries.length, 1);
+      expect(entries.single.agendaType, 'envy');
+      expect(entries.single.scoreDelta, 1);
+    });
+
+    test('empty when category differs', () {
+      final game = baseMirrorGame(refTurn: 1, currentTurn: 2);
+      final entries = evidenceForEnvyResearchMirror(
+        game,
+        'ai',
+        'military',
+        2,
+        const [],
+      );
+      expect(entries, isEmpty);
+    });
+
+    test('empty when outside 2-turn window', () {
+      final game = baseMirrorGame(refTurn: 1, currentTurn: 4);
+      final entries = evidenceForEnvyResearchMirror(
+        game,
+        'ai',
+        'gathering',
+        4,
+        const [],
+      );
+      expect(entries, isEmpty);
+    });
+
+    test('respects per-turn cap of 3', () {
+      final game = baseMirrorGame(refTurn: 1, currentTurn: 1);
+      final pending = <DossierEvidenceEntry>[
+        for (var i = 0; i < 3; i++)
+          DossierEvidenceEntry(
+            observerId: 'human',
+            subjectId: 'ai',
+            agendaType: 'envy',
+            turnNumber: 1,
+            description: 'prior',
+            scoreDelta: 1,
+          ),
+      ];
+      final entries = evidenceForEnvyResearchMirror(
+        game,
+        'ai',
+        'gathering',
+        1,
+        pending,
+      );
       expect(entries, isEmpty);
     });
   });

--- a/packages/colonizethis_logic/test/research_phase_test.dart
+++ b/packages/colonizethis_logic/test/research_phase_test.dart
@@ -28,10 +28,70 @@ void main() {
       return Game(id: 'g', worldState: world, players: [player]);
     }
 
-    test('resolveResearchPhase returns game unchanged when no research orders', () {
-      final game = baseGame(treasury: 1000);
-      final result = resolveResearchPhase(game, const Orders());
-      expect(identical(result, game), isTrue);
+    test(
+      'resolveResearchPhase returns game unchanged when no research orders',
+      () {
+        final game = baseGame(treasury: 1000);
+        final result = resolveResearchPhase(game, const Orders());
+        expect(identical(result, game), isTrue);
+      },
+    );
+
+    test('resolveResearchPhase adds envy evidence when AI mirrors human '
+        'research category same turn', () {
+      final world = WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+        oldWorld: const RegionData(),
+        newWorld: const RegionData(),
+      );
+      final human = Player(
+        id: 'h1',
+        displayName: 'Human',
+        isHuman: true,
+        treasury: 10000,
+        researchSlots: 1,
+        techUnlocked: const {},
+      );
+      final ai = Player(
+        id: 'a1',
+        displayName: 'AI',
+        isHuman: false,
+        treasury: 10000,
+        researchSlots: 1,
+        techUnlocked: const {},
+      );
+      final game = Game(
+        id: 'g',
+        worldState: world,
+        players: [human, ai],
+        aiControlByGpId: const {'a1': true},
+      );
+      final orders = Orders(
+        researchOrdersByPlayerId: {
+          'h1': const [
+            ResearchOrder(
+              slotIndex: 0,
+              techId: 'crop_rotation',
+              funding: ResearchFundingLevel.maximum,
+            ),
+          ],
+          'a1': const [
+            ResearchOrder(
+              slotIndex: 0,
+              techId: 'crop_rotation',
+              funding: ResearchFundingLevel.maximum,
+            ),
+          ],
+        },
+      );
+      final next = resolveResearchPhase(game, orders);
+      final envy = next.dossierEvidenceEntries
+          .where((e) => e.agendaType == 'envy')
+          .toList();
+      expect(envy, isNotEmpty);
+      expect(envy.every((e) => e.subjectId == 'a1'), isTrue);
+      expect(next.lastHumanCompletedResearchCategory, 'gathering');
+      expect(next.lastHumanResearchCategoryCompletionTurn, 2);
     });
 
     test('resolveResearchPhase skips player when researchSlots is zero', () {
@@ -49,118 +109,122 @@ void main() {
       );
       final result = resolveResearchPhase(game, orders);
       expect(result.players.single.treasury, 2000);
-      expect(result.players.single.researchProgressByTechId ?? const {}, isEmpty);
+      expect(
+        result.players.single.researchProgressByTechId ?? const {},
+        isEmpty,
+      );
     });
 
     test(
-        'resolveResearchPhase clears progress when slot canceled (empty techId)',
-        () {
-      const initialTreasury = 500;
-      final game = baseGame(
-        treasury: initialTreasury,
-        techUnlocked: const {},
-        progress: const {'crop_rotation': 10},
-        researchSlots: 1,
-      );
-      final orders = Orders(
-        researchOrdersByPlayerId: {
-          'p1': const [
-            ResearchOrder(
-              slotIndex: 0,
-              techId: '',
-              funding: ResearchFundingLevel.none,
-            ),
-          ],
-        },
-      );
-      final result = resolveResearchPhase(game, orders);
-      final player = result.players.single;
-      expect(player.treasury, initialTreasury);
-      expect(player.researchProgressByTechId ?? const {}, isEmpty);
-    });
+      'resolveResearchPhase clears progress when slot canceled (empty techId)',
+      () {
+        const initialTreasury = 500;
+        final game = baseGame(
+          treasury: initialTreasury,
+          techUnlocked: const {},
+          progress: const {'crop_rotation': 10},
+          researchSlots: 1,
+        );
+        final orders = Orders(
+          researchOrdersByPlayerId: {
+            'p1': const [
+              ResearchOrder(
+                slotIndex: 0,
+                techId: '',
+                funding: ResearchFundingLevel.none,
+              ),
+            ],
+          },
+        );
+        final result = resolveResearchPhase(game, orders);
+        final player = result.players.single;
+        expect(player.treasury, initialTreasury);
+        expect(player.researchProgressByTechId ?? const {}, isEmpty);
+      },
+    );
 
     test(
-        'resolveResearchPhase keeps progress for tech still assigned in another slot',
-        () {
-      const initialTreasury = 500;
-      final game = baseGame(
-        treasury: initialTreasury,
-        techUnlocked: const {'saw_mill': true},
-        progress: const {'wind_saw_mill': 80},
-        researchSlots: 2,
-      );
-      final orders = Orders(
-        researchOrdersByPlayerId: {
-          'p1': const [
-            ResearchOrder(
-              slotIndex: 0,
-              techId: '',
-              funding: ResearchFundingLevel.none,
-            ),
-            ResearchOrder(
-              slotIndex: 1,
-              techId: 'wind_saw_mill',
-              funding: ResearchFundingLevel.none,
-            ),
-          ],
-        },
-      );
-      final result = resolveResearchPhase(game, orders);
-      final player = result.players.single;
-      expect(player.treasury, initialTreasury);
-      expect(player.researchProgressByTechId, {'wind_saw_mill': 80});
-    });
+      'resolveResearchPhase keeps progress for tech still assigned in another slot',
+      () {
+        const initialTreasury = 500;
+        final game = baseGame(
+          treasury: initialTreasury,
+          techUnlocked: const {'saw_mill': true},
+          progress: const {'wind_saw_mill': 80},
+          researchSlots: 2,
+        );
+        final orders = Orders(
+          researchOrdersByPlayerId: {
+            'p1': const [
+              ResearchOrder(
+                slotIndex: 0,
+                techId: '',
+                funding: ResearchFundingLevel.none,
+              ),
+              ResearchOrder(
+                slotIndex: 1,
+                techId: 'wind_saw_mill',
+                funding: ResearchFundingLevel.none,
+              ),
+            ],
+          },
+        );
+        final result = resolveResearchPhase(game, orders);
+        final player = result.players.single;
+        expect(player.treasury, initialTreasury);
+        expect(player.researchProgressByTechId, {'wind_saw_mill': 80});
+      },
+    );
 
-    test('resolveResearchPhase skips player when that player has no research orders', () {
-      final p1 = Player(
-        id: 'p1',
-        displayName: 'P1',
-        isHuman: true,
-        treasury: 2000,
-        researchSlots: 1,
-      );
-      final p2 = Player(
-        id: 'p2',
-        displayName: 'P2',
-        isHuman: true,
-        treasury: 500,
-        researchSlots: 1,
-      );
-      final game = Game(
-        id: 'g',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: [p1, p2],
-      );
-      final orders = Orders(
-        researchOrdersByPlayerId: {
-          'p1': const [
-            ResearchOrder(
-              slotIndex: 0,
-              techId: 'crop_rotation',
-              funding: ResearchFundingLevel.maximum,
-            ),
-          ],
-        },
-      );
-      final result = resolveResearchPhase(game, orders);
-      expect(result.players.length, 2);
-      final rp2 = result.players.where((p) => p.id == 'p2').single;
-      expect(rp2.treasury, 500);
-      expect(rp2.researchProgressByTechId ?? const {}, isEmpty);
-    });
+    test(
+      'resolveResearchPhase skips player when that player has no research orders',
+      () {
+        final p1 = Player(
+          id: 'p1',
+          displayName: 'P1',
+          isHuman: true,
+          treasury: 2000,
+          researchSlots: 1,
+        );
+        final p2 = Player(
+          id: 'p2',
+          displayName: 'P2',
+          isHuman: true,
+          treasury: 500,
+          researchSlots: 1,
+        );
+        final game = Game(
+          id: 'g',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: [p1, p2],
+        );
+        final orders = Orders(
+          researchOrdersByPlayerId: {
+            'p1': const [
+              ResearchOrder(
+                slotIndex: 0,
+                techId: 'crop_rotation',
+                funding: ResearchFundingLevel.maximum,
+              ),
+            ],
+          },
+        );
+        final result = resolveResearchPhase(game, orders);
+        expect(result.players.length, 2);
+        final rp2 = result.players.where((p) => p.id == 'p2').single;
+        expect(rp2.treasury, 500);
+        expect(rp2.researchProgressByTechId ?? const {}, isEmpty);
+      },
+    );
 
-    test('accumulates research progress and unlocks tech when cost reached',
-        () {
+    test('accumulates research progress and unlocks tech when cost reached', () {
       final tech = techById('crop_rotation')!;
       // Maximum funding costs 1000 gold/turn (per SPEC/game/tech-tree.md)
-      final game = baseGame(
-        treasury: 2000,
-        techUnlocked: const {},
-      );
+      final game = baseGame(treasury: 2000, techUnlocked: const {});
 
       final orders = Orders(
         researchOrdersByPlayerId: {
@@ -175,11 +239,9 @@ void main() {
       );
 
       final topology = const MapTopology();
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: topology,
-        orders: orders,
-      ));
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(game: game, topology: topology, orders: orders),
+      );
       final player = next.players.single;
 
       // One turn of maximum funding should make progress > 0 and reduce treasury.
@@ -217,11 +279,13 @@ void main() {
         },
       );
 
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: const MapTopology(),
-        orders: orders,
-      ));
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: const MapTopology(),
+          orders: orders,
+        ),
+      );
       final player = next.players.single;
 
       // Treasury unchanged and no progress recorded because prerequisite not met.
@@ -230,33 +294,42 @@ void main() {
       expect(player.techUnlocked?['wind_saw_mill'], isNot(true));
     });
 
-    test('research with funding none does not spend treasury or add progress',
-        () {
-      final game = baseGame(treasury: 100, techUnlocked: const {});
-      final orders = Orders(
-        researchOrdersByPlayerId: {
-          'p1': const [
-            ResearchOrder(
-              slotIndex: 0,
-              techId: 'crop_rotation',
-              funding: ResearchFundingLevel.none,
-            ),
-          ],
-        },
-      );
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: const MapTopology(),
-        orders: orders,
-      ));
-      expect(next.players.single.treasury, 100);
-      expect(next.players.single.researchProgressByTechId ?? const {}, isEmpty);
-    });
+    test(
+      'research with funding none does not spend treasury or add progress',
+      () {
+        final game = baseGame(treasury: 100, techUnlocked: const {});
+        final orders = Orders(
+          researchOrdersByPlayerId: {
+            'p1': const [
+              ResearchOrder(
+                slotIndex: 0,
+                techId: 'crop_rotation',
+                funding: ResearchFundingLevel.none,
+              ),
+            ],
+          },
+        );
+        final next = requireTurnResolutionComplete(
+          resolveTurnForGame(
+            game: game,
+            topology: const MapTopology(),
+            orders: orders,
+          ),
+        );
+        expect(next.players.single.treasury, 100);
+        expect(
+          next.players.single.researchProgressByTechId ?? const {},
+          isEmpty,
+        );
+      },
+    );
 
     test('research with low funding deducts treasury and adds progress', () {
       // Use wind_saw_mill (cost 160) with prereq so 100 RP does not complete in one turn.
-      final game =
-          baseGame(treasury: 100, techUnlocked: const {'saw_mill': true});
+      final game = baseGame(
+        treasury: 100,
+        techUnlocked: const {'saw_mill': true},
+      );
       final orders = Orders(
         researchOrdersByPlayerId: {
           'p1': const [
@@ -268,17 +341,20 @@ void main() {
           ],
         },
       );
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: const MapTopology(),
-        orders: orders,
-      ));
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: const MapTopology(),
+          orders: orders,
+        ),
+      );
       // Low funding: 50 gold cost, 100 RP per turn (per SPEC/game/tech-tree.md)
       expect(next.players.single.treasury, 50);
       expect(
-          (next.players.single.researchProgressByTechId ??
-              const {})['wind_saw_mill'],
-          100);
+        (next.players.single.researchProgressByTechId ??
+            const {})['wind_saw_mill'],
+        100,
+      );
     });
 
     test('research with maximum funding has efficiency bonus', () {
@@ -294,11 +370,13 @@ void main() {
           ],
         },
       );
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: const MapTopology(),
-        orders: orders,
-      ));
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: const MapTopology(),
+          orders: orders,
+        ),
+      );
       // Maximum funding: 1000 gold cost, 2500 RP per turn (2.5x efficiency).
       // crop_rotation cost is 120, so tech unlocks and progress is cleared.
       expect(next.players.single.treasury, 1000);
@@ -315,19 +393,26 @@ void main() {
         researchOrdersByPlayerId: {
           'p1': const [
             ResearchOrder(
-                slotIndex: 0,
-                techId: 'wind_saw_mill',
-                funding: ResearchFundingLevel.low),
+              slotIndex: 0,
+              techId: 'wind_saw_mill',
+              funding: ResearchFundingLevel.low,
+            ),
           ],
         },
       );
-      var next = requireTurnResolutionComplete(resolveTurnForGame(
-          game: game, topology: const MapTopology(), orders: orders));
+      var next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: const MapTopology(),
+          orders: orders,
+        ),
+      );
       expect(next.players.single.treasury, 50);
       expect(
-          (next.players.single.researchProgressByTechId ??
-              const {})['wind_saw_mill'],
-          100);
+        (next.players.single.researchProgressByTechId ??
+            const {})['wind_saw_mill'],
+        100,
+      );
 
       // Medium: 150 gold, 300 RP (unlocks wind_saw_mill)
       game = baseGame(treasury: 200, techUnlocked: prereqMet);
@@ -335,14 +420,20 @@ void main() {
         researchOrdersByPlayerId: {
           'p1': const [
             ResearchOrder(
-                slotIndex: 0,
-                techId: 'wind_saw_mill',
-                funding: ResearchFundingLevel.medium),
+              slotIndex: 0,
+              techId: 'wind_saw_mill',
+              funding: ResearchFundingLevel.medium,
+            ),
           ],
         },
       );
-      next = requireTurnResolutionComplete(resolveTurnForGame(
-          game: game, topology: const MapTopology(), orders: orders));
+      next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: const MapTopology(),
+          orders: orders,
+        ),
+      );
       expect(next.players.single.treasury, 50);
       expect(next.players.single.techUnlocked!['wind_saw_mill'], isTrue);
 
@@ -352,14 +443,20 @@ void main() {
         researchOrdersByPlayerId: {
           'p1': const [
             ResearchOrder(
-                slotIndex: 0,
-                techId: 'wind_saw_mill',
-                funding: ResearchFundingLevel.high),
+              slotIndex: 0,
+              techId: 'wind_saw_mill',
+              funding: ResearchFundingLevel.high,
+            ),
           ],
         },
       );
-      next = requireTurnResolutionComplete(resolveTurnForGame(
-          game: game, topology: const MapTopology(), orders: orders));
+      next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: const MapTopology(),
+          orders: orders,
+        ),
+      );
       expect(next.players.single.treasury, 100);
       expect(next.players.single.techUnlocked!['wind_saw_mill'], isTrue);
 
@@ -369,14 +466,20 @@ void main() {
         researchOrdersByPlayerId: {
           'p1': const [
             ResearchOrder(
-                slotIndex: 0,
-                techId: 'wind_saw_mill',
-                funding: ResearchFundingLevel.maximum),
+              slotIndex: 0,
+              techId: 'wind_saw_mill',
+              funding: ResearchFundingLevel.maximum,
+            ),
           ],
         },
       );
-      next = requireTurnResolutionComplete(resolveTurnForGame(
-          game: game, topology: const MapTopology(), orders: orders));
+      next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: const MapTopology(),
+          orders: orders,
+        ),
+      );
       expect(next.players.single.treasury, 500);
       expect(next.players.single.techUnlocked!['wind_saw_mill'], isTrue);
     });
@@ -403,11 +506,13 @@ void main() {
           ],
         },
       );
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: const MapTopology(),
-        orders: orders,
-      ));
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: const MapTopology(),
+          orders: orders,
+        ),
+      );
       final player = next.players.single;
       expect(player.techUnlocked!['university'], isTrue);
       expect(player.researchSlots, 4);
@@ -416,14 +521,14 @@ void main() {
     test('Money Lending allows limited negative treasury for research', () {
       // Money Lending: allow research spending to drive treasury down to -500.
       final tech = techById('crop_rotation')!;
-      expect(tech.cost, lessThan(2500)); // sanity: one turn of max funding can complete
+      expect(
+        tech.cost,
+        lessThan(2500),
+      ); // sanity: one turn of max funding can complete
 
       final game = baseGame(
         treasury: 500,
-        techUnlocked: const {
-          'land_enclosure': true,
-          'money_lending': true,
-        },
+        techUnlocked: const {'land_enclosure': true, 'money_lending': true},
       );
       final orders = Orders(
         researchOrdersByPlayerId: {
@@ -437,11 +542,13 @@ void main() {
         },
       );
 
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: const MapTopology(),
-        orders: orders,
-      ));
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: const MapTopology(),
+          orders: orders,
+        ),
+      );
       final player = next.players.single;
 
       // With Money Lending, treasury may go as low as -500; maximum funding
@@ -451,7 +558,10 @@ void main() {
       expect(player.treasury, greaterThanOrEqualTo(-500));
       final unlocked = player.techUnlocked ?? const {};
       final progress = player.researchProgressByTechId ?? const {};
-      expect(unlocked['crop_rotation'] == true || progress['crop_rotation'] != null, isTrue);
+      expect(
+        unlocked['crop_rotation'] == true || progress['crop_rotation'] != null,
+        isTrue,
+      );
     });
 
     test('Banking extends research debt floor to -1000 with Money Lending', () {
@@ -476,45 +586,52 @@ void main() {
         },
       );
 
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: const MapTopology(),
-        orders: orders,
-      ));
+      final next = requireTurnResolutionComplete(
+        resolveTurnForGame(
+          game: game,
+          topology: const MapTopology(),
+          orders: orders,
+        ),
+      );
       final player = next.players.single;
       expect(player.treasury, greaterThanOrEqualTo(-1000));
       expect(player.treasury, -1000);
     });
 
     test(
-        'duplicate slotIndex: only one order per slot applied (last wins), no double spend',
-        () {
-      // SPEC: one assignment per slot. If list has two orders for same slot, resolver uses one (last wins).
-      final game = baseGame(treasury: 2000, techUnlocked: const {});
-      final orders = Orders(
-        researchOrdersByPlayerId: {
-          'p1': const [
-            ResearchOrder(
+      'duplicate slotIndex: only one order per slot applied (last wins), no double spend',
+      () {
+        // SPEC: one assignment per slot. If list has two orders for same slot, resolver uses one (last wins).
+        final game = baseGame(treasury: 2000, techUnlocked: const {});
+        final orders = Orders(
+          researchOrdersByPlayerId: {
+            'p1': const [
+              ResearchOrder(
                 slotIndex: 0,
                 techId: 'crop_rotation',
-                funding: ResearchFundingLevel.low),
-            ResearchOrder(
+                funding: ResearchFundingLevel.low,
+              ),
+              ResearchOrder(
                 slotIndex: 0,
                 techId: 'crop_rotation',
-                funding: ResearchFundingLevel.maximum),
-          ],
-        },
-      );
-      final next = requireTurnResolutionComplete(resolveTurnForGame(
-        game: game,
-        topology: const MapTopology(),
-        orders: orders,
-      ));
-      final player = next.players.single;
-      // Last wins => maximum only: 1000 spent, 2500 RP => crop_rotation (cost 120) unlocks.
-      expect(player.treasury, 1000);
-      expect(player.techUnlocked!['crop_rotation'], isTrue);
-      // If both were applied we would have 1050 spent and dual progress; so no double spend.
-    });
+                funding: ResearchFundingLevel.maximum,
+              ),
+            ],
+          },
+        );
+        final next = requireTurnResolutionComplete(
+          resolveTurnForGame(
+            game: game,
+            topology: const MapTopology(),
+            orders: orders,
+          ),
+        );
+        final player = next.players.single;
+        // Last wins => maximum only: 1000 spent, 2500 RP => crop_rotation (cost 120) unlocks.
+        expect(player.treasury, 1000);
+        expect(player.techUnlocked!['crop_rotation'], isTrue);
+        // If both were applied we would have 1050 spent and dual progress; so no double spend.
+      },
+    );
   });
 }

--- a/packages/colonizethis_models/lib/src/game.dart
+++ b/packages/colonizethis_models/lib/src/game.dart
@@ -87,6 +87,8 @@ class Game {
     this.richesCashMultiplier = 1.0,
     this.capitalTileGrainBonusPerTurn = 5,
     this.politicalGlyphByPlayerId = const {},
+    this.lastHumanCompletedResearchCategory,
+    this.lastHumanResearchCategoryCompletionTurn,
   });
 
   final String id;
@@ -152,6 +154,13 @@ class Game {
   /// UIs for the political ownership layer. SPEC/tui/map-tui-mapping.md.
   final Map<String, String> politicalGlyphByPlayerId;
 
+  /// Last tech **category** a human Great Power completed via research (most recent).
+  /// Used for Envy hidden-agenda evidence. SPEC/ai/hidden-agendas.md.
+  final String? lastHumanCompletedResearchCategory;
+
+  /// Turn number when [lastHumanCompletedResearchCategory] was set.
+  final int? lastHumanResearchCategoryCompletionTurn;
+
   Map<String, dynamic> toJson() => {
     'id': id,
     'worldState': worldState.toJson(),
@@ -195,6 +204,11 @@ class Game {
       'generals': generals.map((e) => e.toJson()).toList(),
     if (politicalGlyphByPlayerId.isNotEmpty)
       'politicalGlyphByPlayerId': politicalGlyphByPlayerId,
+    if (lastHumanCompletedResearchCategory != null)
+      'lastHumanCompletedResearchCategory': lastHumanCompletedResearchCategory,
+    if (lastHumanResearchCategoryCompletionTurn != null)
+      'lastHumanResearchCategoryCompletionTurn':
+          lastHumanResearchCategoryCompletionTurn,
   };
 
   static Game fromJson(Map<String, dynamic> json) {
@@ -202,10 +216,9 @@ class Game {
     final minorNationsList = json['minorNations'] as List<dynamic>? ?? [];
     final tribesList = json['tribes'] as List<dynamic>? ?? [];
     final turnTimeMappingRaw = json['turnTimeMapping'];
-    final Map<String, dynamic>? turnTimeMappingJson =
-        turnTimeMappingRaw is Map
-            ? Map<String, dynamic>.from(turnTimeMappingRaw)
-            : null;
+    final Map<String, dynamic>? turnTimeMappingJson = turnTimeMappingRaw is Map
+        ? Map<String, dynamic>.from(turnTimeMappingRaw)
+        : null;
     final defaultCombatModeRaw = json['defaultCombatMode'] as String?;
     final defaultCombatMode = defaultCombatModeRaw != null
         ? CombatMode.values.firstWhere(
@@ -332,6 +345,10 @@ class Game {
       richesCashMultiplier: richesCashMultiplier,
       capitalTileGrainBonusPerTurn: capitalTileGrainBonusPerTurn,
       politicalGlyphByPlayerId: politicalGlyphByPlayerId,
+      lastHumanCompletedResearchCategory:
+          json['lastHumanCompletedResearchCategory'] as String?,
+      lastHumanResearchCategoryCompletionTurn:
+          (json['lastHumanResearchCategoryCompletionTurn'] as num?)?.toInt(),
     );
   }
 
@@ -359,6 +376,8 @@ class Game {
     double? richesCashMultiplier,
     int? capitalTileGrainBonusPerTurn,
     Map<String, String>? politicalGlyphByPlayerId,
+    String? lastHumanCompletedResearchCategory,
+    int? lastHumanResearchCategoryCompletionTurn,
   }) {
     return Game(
       id: id ?? this.id,
@@ -390,6 +409,12 @@ class Game {
           capitalTileGrainBonusPerTurn ?? this.capitalTileGrainBonusPerTurn,
       politicalGlyphByPlayerId:
           politicalGlyphByPlayerId ?? this.politicalGlyphByPlayerId,
+      lastHumanCompletedResearchCategory:
+          lastHumanCompletedResearchCategory ??
+          this.lastHumanCompletedResearchCategory,
+      lastHumanResearchCategoryCompletionTurn:
+          lastHumanResearchCategoryCompletionTurn ??
+          this.lastHumanResearchCategoryCompletionTurn,
     );
   }
 
@@ -423,7 +448,14 @@ class Game {
           victory == other.victory &&
           richesCashMultiplier == other.richesCashMultiplier &&
           capitalTileGrainBonusPerTurn == other.capitalTileGrainBonusPerTurn &&
-          _mapEquals(politicalGlyphByPlayerId, other.politicalGlyphByPlayerId);
+          _mapEquals(
+            politicalGlyphByPlayerId,
+            other.politicalGlyphByPlayerId,
+          ) &&
+          lastHumanCompletedResearchCategory ==
+              other.lastHumanCompletedResearchCategory &&
+          lastHumanResearchCategoryCompletionTurn ==
+              other.lastHumanResearchCategoryCompletionTurn;
 
   @override
   int get hashCode => Object.hash(
@@ -455,6 +487,8 @@ class Game {
       richesCashMultiplier,
       capitalTileGrainBonusPerTurn,
       Object.hashAll(politicalGlyphByPlayerId.entries),
+      lastHumanCompletedResearchCategory,
+      lastHumanResearchCategoryCompletionTurn,
     ),
   );
 

--- a/packages/colonizethis_models/test/game_test.dart
+++ b/packages/colonizethis_models/test/game_test.dart
@@ -30,7 +30,9 @@ void main() {
             oldWorld: const RegionData(),
             newWorld: const RegionData(),
           ),
-          players: const [Player(id: 'p1', displayName: 'Spain', isHuman: true)],
+          players: const [
+            Player(id: 'p1', displayName: 'Spain', isHuman: true),
+          ],
           turnTimeMapping: const TurnTimeMapping(
             startYear: 1600,
             cutoffYear: 1750,
@@ -84,6 +86,23 @@ void main() {
       expect(game, game2);
       expect(game.hashCode, game2.hashCode);
     });
+
+    test('human research mirror hint fields round-trip JSON', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'p1', displayName: 'Spain', isHuman: true)],
+        lastHumanCompletedResearchCategory: 'gathering',
+        lastHumanResearchCategoryCompletionTurn: 2,
+      );
+      final restored = Game.fromJson(game.toJson());
+      expect(restored.lastHumanCompletedResearchCategory, 'gathering');
+      expect(restored.lastHumanResearchCategoryCompletionTurn, 2);
+    });
     test('copyWith id and players', () {
       final game = Game(
         id: 'g1',
@@ -98,7 +117,9 @@ void main() {
       expect(game2.id, 'g2');
       expect(game2.players, game.players);
       final game3 = game.copyWith(
-        players: [const Player(id: 'p2', displayName: 'France', isHuman: false)],
+        players: [
+          const Player(id: 'p2', displayName: 'France', isHuman: false),
+        ],
       );
       expect(game3.players.length, 1);
       expect(game3.players.first.id, 'p2');
@@ -173,7 +194,9 @@ void main() {
       expect(round.tribes.first.id, 'tribe1');
       expect(round.tribes.first.capitalTile?.x, 1);
       // Backward compat: missing minorNations/tribes => empty lists
-      final legacy = Map<String, dynamic>.from(json)..remove('minorNations')..remove('tribes');
+      final legacy = Map<String, dynamic>.from(json)
+        ..remove('minorNations')
+        ..remove('tribes');
       final fromLegacy = Game.fromJson(legacy);
       expect(fromLegacy.minorNations, isEmpty);
       expect(fromLegacy.tribes, isEmpty);
@@ -208,7 +231,8 @@ void main() {
       final defaultJson = defaultGame.toJson();
       expect(defaultJson.containsKey('richesCashMultiplier'), false);
       // Backward compat: missing richesCashMultiplier => default 1.0
-      final legacy = Map<String, dynamic>.from(json)..remove('richesCashMultiplier');
+      final legacy = Map<String, dynamic>.from(json)
+        ..remove('richesCashMultiplier');
       final fromLegacy = Game.fromJson(legacy);
       expect(fromLegacy.richesCashMultiplier, 1.0);
     });
@@ -234,12 +258,16 @@ void main() {
       );
       final round = Game.fromJson(game.toJson());
       expect(round.diplomaticHistoryEvents.length, 1);
-      expect(round.diplomaticHistoryEvents.first.type, DiplomaticEventType.declareWar);
+      expect(
+        round.diplomaticHistoryEvents.first.type,
+        DiplomaticEventType.declareWar,
+      );
       expect(round.diplomaticHistoryEvents.first.participants, contains('gp1'));
       expect(round.diplomaticHistoryEvents.first.turn, 1);
       // Backward compat: missing key => empty list
       final json = game.toJson();
-      final legacy = Map<String, dynamic>.from(json)..remove('diplomaticHistoryEvents');
+      final legacy = Map<String, dynamic>.from(json)
+        ..remove('diplomaticHistoryEvents');
       final fromLegacy = Game.fromJson(legacy);
       expect(fromLegacy.diplomaticHistoryEvents, isEmpty);
     });


### PR DESCRIPTION
## Summary
Implements a slice of **#1685**: strict product contracts for hidden-agenda evidence, human-research mirroring (Envy), diplomacy backstabber treaty-break window, AI personality `personalityId` wording, labour tech AC cleanup, and removal of MVP/deferred placeholder strings from the tech tree widget.

## Out of scope (per #1685 / #1682)
- Extraction-cap, `build_improvement` tech gating, `tech_extraction` (#1682).
- Static map file loading (map-data spec already states generation + save round-trip).
- Save versioning was already present in `GameSaveAdapter`; not changed here.

## SPEC
- `SPEC/ai/hidden-agendas.md` — full current-product evidence list (spy, CTA refuse, treaty-break war, research-category envy).
- `SPEC/ai/ai-personalities.md` — `personalityId` as primary lookup with leader/neutral fallback.
- `SPEC/game/tech-tree-labour-economy.md` — AC aligns with implemented banking / trade_fairs.
- `SPEC/program/ai-events-and-dossier.md` — pointer to hidden-agendas coverage.

## Implementation
- `Game`: optional `lastHumanCompletedResearchCategory` + turn (save JSON).
- `resolveResearchPhase`: updates mirror hints; appends envy evidence for AI completions (+1, cap +3/turn/subject).
- `evidenceForDeclareWar`: backstabber +3 when war follows `callToArmsRefused` with same actor/target within 3 turns and not already allied-war path.
- `tech_tree_widget` / test: product-accurate effect blurbs (trade slots, banking floor, military modifiers).

## Tests
- `dart test` `packages/colonizethis_logic/test/evidence_rules_test.dart` `test/research_phase_test.dart`
- `dart test` `packages/colonizethis_models/test/game_test.dart`
- `flutter test` `app/test/tech_tree_widget_test.dart`

Refs #1685

Made with [Cursor](https://cursor.com)