### PR TITLE
Disallowed AST patterns CI + fix cascade ..clear() (Refs #1646)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -336,6 +336,12 @@ jobs:
       - name: Check custom exception enforcement (SPEC/program/exception-enforcement.md)
         run: dart run tool/check_custom_exceptions.dart
 
+      - name: Check disallowed AST patterns (SPEC/program/disallowed-ast-patterns.md)
+        run: dart run tool/check_disallowed_ast_patterns.dart
+
+      - name: Test disallowed AST patterns checker (SPEC/program/disallowed-ast-patterns.md)
+        run: dart test test/check_disallowed_ast_patterns_test.dart --reporter=compact
+
       - name: Test app hardcoded UI string checker (SPEC/program/localization.md)
         run: dart test test/check_app_hardcoded_ui_strings_test.dart --reporter=compact
 

--- a/SPEC/program/disallowed-ast-patterns.md
+++ b/SPEC/program/disallowed-ast-patterns.md
@@ -1,0 +1,42 @@
+# Disallowed AST patterns (CI)
+
+## Purpose
+
+Block a small, explicit set of Dart **structural** patterns that harm readability or mislead readers (for example pointless cascade segments on `void`-returning methods). Rules are config-driven so new patterns can be added without new executables.
+
+## Source of truth
+
+- Policy and rule kinds: this document.
+- Concrete rules (IDs, messages, matchers): `tool/disallowed_ast_patterns.yaml`.
+
+## Policy
+
+### Cascaded `clear()` calls
+
+In runtime domain code, a **cascade section** that invokes `.clear()` (`..clear()`) is disallowed. Prefer a standalone `.clear()` statement or replacing the collection with a new instance.
+
+Rationale: `clear()` returns `void`; the cascade form suggests chaining a result and is easy to misread.
+
+### Coverage
+
+Enforcement uses the same runtime roots as `SPEC/program/exception-enforcement.md`:
+
+- `packages/**/lib/**`
+- `app/lib/**`
+- `ctdev/lib/**`
+- `ctterm/lib/**`
+- `tool/**/lib/**`
+
+Generated files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`) and tests (`**/test/**`, `*_test.dart`) are excluded.
+
+## Implementation contract
+
+- **Given** the repository root as the working directory, **when** CI runs `dart run tool/check_disallowed_ast_patterns.dart`, **then** the tool loads `tool/disallowed_ast_patterns.yaml`, parses each listed Dart file, and reports violations with file path and line number.
+- **Given** a violation and an in-file suppression, **when** the offending line or the line above contains `ignore: disallowed_ast_<rule_id>`, or the file begins with `ignore_for_file: disallowed_ast_<rule_id>` for that rule, **then** the tool does not fail for that occurrence (`<rule_id>` matches the `id` field in YAML, e.g. `cascade_void_clear` → `disallowed_ast_cascade_void_clear`).
+- **Given** a new disallowed pattern, **when** maintainers extend `tool/disallowed_ast_patterns.yaml` with a documented `match.kind`, **then** the checker implementation supports that kind or the change includes the corresponding visitor logic and SPEC update.
+
+## Acceptance criteria
+
+- **Given** runtime Dart source containing a cascaded method invocation `..clear()`, **when** the disallowed AST checker runs, **then** it reports at least one violation with the correct file and line.
+- **Given** runtime Dart source that calls `.clear()` without a cascade, **when** the checker runs, **then** it does not report a violation for that call.
+- **Given** runtime Dart source with `// ignore: disallowed_ast_cascade_void_clear` on the violating line or the line above, **when** the checker runs, **then** it does not report that violation.

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -126,9 +126,8 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
       if (allSelected) {
         _selectedFleetIds.clear();
       } else {
-        _selectedFleetIds
-          ..clear()
-          ..addAll(ids);
+        _selectedFleetIds.clear();
+        _selectedFleetIds.addAll(ids);
       }
     });
   }
@@ -206,9 +205,8 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (!mounted) return;
           setState(() {
-            _selectedFleetIds
-              ..clear()
-              ..addAll(pruned);
+            _selectedFleetIds.clear();
+            _selectedFleetIds.addAll(pruned);
           });
         });
       }

--- a/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds.dart
@@ -553,9 +553,8 @@ class _TileMapGenLandSeeds {
           final score = scoreCoastalCell(sx, sy, c);
           if (score > bestScore) {
             bestScore = score;
-            bestCandidates
-              ..clear()
-              ..add((sx, sy));
+            bestCandidates.clear();
+            bestCandidates.add((sx, sy));
           } else if (score == bestScore) {
             bestCandidates.add((sx, sy));
           }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1154,7 +1154,7 @@ packages:
     source: hosted
     version: "6.6.1"
   yaml:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: yaml
       sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dev_dependencies:
   melos: ^7.0.0
   path: ^1.9.1
   test: ^1.24.0
+  yaml: ^3.1.3
 
 melos:
   scripts:
@@ -69,6 +70,9 @@ melos:
     check_app_hardcoded_ui_strings:
       description: AST check that forbids hardcoded user-visible UI strings in app/lib. SPEC/program/localization.md.
       run: dart run tool/check_app_hardcoded_ui_strings.dart
+    check_disallowed_ast_patterns:
+      description: Config-driven AST check for disallowed structural patterns. SPEC/program/disallowed-ast-patterns.md.
+      run: dart run tool/check_disallowed_ast_patterns.dart
     ctterm:
       description: Terminal UI for full single-player ColonizeThis. SPEC/tui/ctterm.md.
       run: dart run ctterm

--- a/test/check_disallowed_ast_patterns_test.dart
+++ b/test/check_disallowed_ast_patterns_test.dart
@@ -1,0 +1,107 @@
+import 'package:test/test.dart';
+
+import '../tool/check_disallowed_ast_patterns.dart';
+
+const _testYaml = r'''
+rules:
+  - id: cascade_void_clear
+    message: 'no cascade clear'
+    match:
+      kind: cascaded_method_invocation
+      method_names:
+        - clear
+''';
+
+void main() {
+  late List<DisallowedPatternRule> rules;
+
+  setUp(() {
+    rules = loadDisallowedAstRulesForTest(_testYaml);
+  });
+
+  group('findDisallowedAstViolations', () {
+    test('flags cascaded clear()', () {
+      const src = r'''
+void f(List<int> a) {
+  a..clear()..add(1);
+}
+''';
+      final v = findDisallowedAstViolations(
+        'packages/foo/lib/x.dart',
+        src,
+        rules,
+      );
+      expect(v, isNotEmpty);
+      expect(v.first.ruleId, 'cascade_void_clear');
+      expect(v.first.line, greaterThan(0));
+    });
+
+    test('allows non-cascaded clear()', () {
+      const src = r'''
+void f(List<int> a) {
+  a.clear();
+  a.add(1);
+}
+''';
+      expect(
+        findDisallowedAstViolations('packages/foo/lib/x.dart', src, rules),
+        isEmpty,
+      );
+    });
+
+    test('respects same-line ignore', () {
+      const src = r'''
+void f(List<int> a) {
+  a..clear()..add(1); // ignore: disallowed_ast_cascade_void_clear
+}
+''';
+      expect(
+        findDisallowedAstViolations('packages/foo/lib/x.dart', src, rules),
+        isEmpty,
+      );
+    });
+
+    test('respects ignore on previous line', () {
+      const src = r'''
+void f(List<int> a) {
+  // ignore: disallowed_ast_cascade_void_clear
+  a..clear()..add(1);
+}
+''';
+      expect(
+        findDisallowedAstViolations('packages/foo/lib/x.dart', src, rules),
+        isEmpty,
+      );
+    });
+
+    test('respects ignore_for_file', () {
+      const src = r'''
+// ignore_for_file: disallowed_ast_cascade_void_clear
+
+void f(List<int> a) {
+  a..clear()..add(1);
+}
+''';
+      expect(
+        findDisallowedAstViolations('packages/foo/lib/x.dart', src, rules),
+        isEmpty,
+      );
+    });
+
+    test('skips test paths', () {
+      const src = r'''
+void f(List<int> a) {
+  a..clear();
+}
+''';
+      expect(
+        findDisallowedAstViolations(
+          'packages/foo/test/x_test.dart',
+          src,
+          rules,
+        ),
+        isEmpty,
+      );
+    });
+  });
+}

--- a/tool/check_disallowed_ast_patterns.dart
+++ b/tool/check_disallowed_ast_patterns.dart
@@ -1,0 +1,278 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/source/line_info.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+/// PR-blocking structural AST checks driven by [tool/disallowed_ast_patterns.yaml].
+///
+/// SPEC: SPEC/program/disallowed-ast-patterns.md
+void main() {
+  final repoRoot = Directory.current.path;
+  final configFile = File(
+    p.join(repoRoot, 'tool', 'disallowed_ast_patterns.yaml'),
+  );
+  if (!configFile.existsSync()) {
+    stderr.writeln('check_disallowed_ast_patterns: missing ${configFile.path}');
+    exitCode = 1;
+    return;
+  }
+
+  final rules = _loadRules(configFile.readAsStringSync());
+  if (rules.isEmpty) {
+    stderr.writeln(
+      'check_disallowed_ast_patterns: no rules in disallowed_ast_patterns.yaml',
+    );
+    exitCode = 1;
+    return;
+  }
+
+  final dartFiles = _collectDomainDartFiles(repoRoot);
+  final violations = <DisallowedAstViolation>[];
+
+  for (final file in dartFiles) {
+    final relativePath = p.relative(file.path, from: repoRoot);
+    final content = file.readAsStringSync();
+    violations.addAll(
+      findDisallowedAstViolations(relativePath, content, rules),
+    );
+  }
+
+  if (violations.isEmpty) {
+    stdout.writeln('check_disallowed_ast_patterns: no violations found.');
+    return;
+  }
+
+  stderr.writeln(
+    'check_disallowed_ast_patterns: found ${violations.length} violation(s):',
+  );
+  for (final v in violations) {
+    stderr.writeln(' - ${v.path}:${v.line}: [${v.ruleId}] ${v.message}');
+  }
+  exitCode = 1;
+}
+
+/// Exposed for unit tests (same behavior as production scan).
+List<DisallowedAstViolation> findDisallowedAstViolations(
+  String relativePath,
+  String content,
+  List<DisallowedPatternRule> rules,
+) {
+  if (rules.isEmpty) {
+    return const [];
+  }
+  if (!relativePath.endsWith('.dart')) {
+    return const [];
+  }
+  if (relativePath.contains('/test/') || relativePath.endsWith('_test.dart')) {
+    return const [];
+  }
+  if (relativePath.endsWith('.g.dart') ||
+      relativePath.endsWith('.freezed.dart') ||
+      relativePath.endsWith('.mocks.dart')) {
+    return const [];
+  }
+
+  final parsed = parseString(
+    content: content,
+    path: relativePath,
+    throwIfDiagnostics: false,
+  );
+  final visitor = _DisallowedAstVisitor(
+    relativePath,
+    content,
+    parsed.lineInfo,
+    rules,
+  );
+  parsed.unit.accept(visitor);
+  return visitor.violations;
+}
+
+List<DisallowedPatternRule> loadDisallowedAstRulesForTest(String yamlText) =>
+    _parseRulesYaml(loadYaml(yamlText));
+
+List<DisallowedPatternRule> _loadRules(String yamlText) =>
+    _parseRulesYaml(loadYaml(yamlText));
+
+List<DisallowedPatternRule> _parseRulesYaml(Object? yamlRoot) {
+  if (yamlRoot is! YamlMap) {
+    return const [];
+  }
+  final rulesNode = yamlRoot['rules'];
+  if (rulesNode is! YamlList) {
+    return const [];
+  }
+  final out = <DisallowedPatternRule>[];
+  for (final entry in rulesNode.nodes) {
+    final value = entry.value;
+    if (value is! YamlMap) {
+      continue;
+    }
+    final id = value['id']?.toString();
+    final message = value['message']?.toString().trim();
+    final match = value['match'];
+    if (id == null || id.isEmpty || message == null || message.isEmpty) {
+      continue;
+    }
+    if (match is! YamlMap) {
+      continue;
+    }
+    final kind = match['kind']?.toString();
+    if (kind == 'cascaded_method_invocation') {
+      final namesNode = match['method_names'];
+      if (namesNode is! YamlList) {
+        continue;
+      }
+      final names = <String>{};
+      for (final n in namesNode.nodes) {
+        final s = n.value?.toString();
+        if (s != null && s.isNotEmpty) {
+          names.add(s);
+        }
+      }
+      if (names.isEmpty) {
+        continue;
+      }
+      out.add(
+        DisallowedPatternRule(
+          id: id,
+          message: message,
+          cascadedMethodNames: names,
+        ),
+      );
+    }
+  }
+  return out;
+}
+
+bool _fileIgnoresRule(String source, String ruleId) {
+  return source.contains('ignore_for_file: disallowed_ast_$ruleId');
+}
+
+bool _lineSuppressesRule(String line, String ruleId) {
+  return line.contains('ignore: disallowed_ast_$ruleId');
+}
+
+bool _isSuppressedAtLine(String source, int lineNumber1Based, String ruleId) {
+  final lines = const LineSplitter().convert(source);
+  final idx = lineNumber1Based - 1;
+  if (idx < 0 || idx >= lines.length) {
+    return false;
+  }
+  if (_lineSuppressesRule(lines[idx], ruleId)) {
+    return true;
+  }
+  if (idx > 0 && _lineSuppressesRule(lines[idx - 1], ruleId)) {
+    return true;
+  }
+  return false;
+}
+
+List<File> _collectDomainDartFiles(String repoRoot) {
+  final domainRoots = <String>[
+    'packages',
+    'app/lib',
+    'ctdev/lib',
+    'ctterm/lib',
+    'tool',
+  ];
+  final files = <File>[];
+  for (final domainRoot in domainRoots) {
+    final base = Directory(p.join(repoRoot, domainRoot));
+    if (!base.existsSync()) {
+      continue;
+    }
+    for (final entity in base.listSync(recursive: true, followLinks: false)) {
+      if (entity is! File) {
+        continue;
+      }
+      if (!entity.path.endsWith('.dart')) {
+        continue;
+      }
+      final rel = p.relative(entity.path, from: repoRoot);
+      if (rel.contains('/test/') || rel.endsWith('_test.dart')) {
+        continue;
+      }
+      if (!rel.contains('/lib/')) {
+        continue;
+      }
+      if (rel.endsWith('.g.dart') ||
+          rel.endsWith('.freezed.dart') ||
+          rel.endsWith('.mocks.dart')) {
+        continue;
+      }
+      files.add(entity);
+    }
+  }
+  return files;
+}
+
+class DisallowedPatternRule {
+  const DisallowedPatternRule({
+    required this.id,
+    required this.message,
+    required this.cascadedMethodNames,
+  });
+
+  final String id;
+  final String message;
+  final Set<String> cascadedMethodNames;
+}
+
+class DisallowedAstViolation {
+  const DisallowedAstViolation({
+    required this.path,
+    required this.line,
+    required this.ruleId,
+    required this.message,
+  });
+
+  final String path;
+  final int line;
+  final String ruleId;
+  final String message;
+}
+
+class _DisallowedAstVisitor extends RecursiveAstVisitor<void> {
+  _DisallowedAstVisitor(this.path, this.source, this.lineInfo, this.rules);
+
+  final String path;
+  final String source;
+  final LineInfo lineInfo;
+  final List<DisallowedPatternRule> rules;
+  final List<DisallowedAstViolation> violations = [];
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (!node.isCascaded) {
+      super.visitMethodInvocation(node);
+      return;
+    }
+    final name = node.methodName.name;
+    for (final rule in rules) {
+      if (!rule.cascadedMethodNames.contains(name)) {
+        continue;
+      }
+      final line = lineInfo.getLocation(node.offset).lineNumber;
+      if (_fileIgnoresRule(source, rule.id)) {
+        continue;
+      }
+      if (_isSuppressedAtLine(source, line, rule.id)) {
+        continue;
+      }
+      violations.add(
+        DisallowedAstViolation(
+          path: path,
+          line: line,
+          ruleId: rule.id,
+          message: rule.message,
+        ),
+      );
+    }
+    super.visitMethodInvocation(node);
+  }
+}

--- a/tool/disallowed_ast_patterns.yaml
+++ b/tool/disallowed_ast_patterns.yaml
@@ -1,0 +1,14 @@
+# Disallowed AST patterns — rules for tool/check_disallowed_ast_patterns.dart
+# SPEC: SPEC/program/disallowed-ast-patterns.md
+#
+# Suppress: // ignore: disallowed_ast_<id>  or  // ignore_for_file: disallowed_ast_<id>
+
+rules:
+  - id: cascade_void_clear
+    message: >-
+      Do not use cascade ..clear(); use a separate .clear() statement or a new
+      collection instance. Cascading void methods is misleading.
+    match:
+      kind: cascaded_method_invocation
+      method_names:
+        - clear


### PR DESCRIPTION
## Summary

Introduces a standalone, YAML-driven AST checker for structural bans (starting with cascaded `..clear()`), refactors the known call sites, and wires the tool into CI and Melos.

## Acceptance criteria (this PR)

- Confusing `..clear()` cascade segments removed in `naval_units_panel` and `tile_map_generator_land_seeds`.
- SPEC documents policy, roots, suppressions, and ACs.
- Checker runs in Quality workflow; unit tests exercise flag/allow/ignore paths.
- `melos run check_disallowed_ast_patterns` runs from repo root.

## SPEC

- `SPEC/program/disallowed-ast-patterns.md` (new)
- `tool/disallowed_ast_patterns.yaml` (rule config)

## Tests

- `dart test test/check_disallowed_ast_patterns_test.dart --reporter=compact`
- `dart run tool/check_disallowed_ast_patterns.dart` (full repo scan)
- `packages/colonizethis_map` test suite

Refs #1646

Made with [Cursor](https://cursor.com)