### PR TITLE
fix(quality): exception checker gaps + migrate remaining throws (Refs #1615)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -336,6 +336,9 @@ jobs:
       - name: Check custom exception enforcement (SPEC/program/exception-enforcement.md)
         run: dart run tool/check_custom_exceptions.dart
 
+      - name: Test custom exception checker (SPEC/program/exception-enforcement.md)
+        run: dart test test/check_custom_exceptions_test.dart --reporter=compact
+
       - name: Check disallowed AST patterns (SPEC/program/disallowed-ast-patterns.md)
         run: dart run tool/check_disallowed_ast_patterns.dart
 

--- a/SPEC/program/exception-enforcement.md
+++ b/SPEC/program/exception-enforcement.md
@@ -42,9 +42,9 @@ The repository uses an AST-based checker that:
 
 1. Parses Dart files with analyzer.
 2. Visits `ThrowExpression` nodes.
-3. Detects `InstanceCreationExpression` for disallowed generic exception constructors.
-4. Reports file + line + constructor name for each violation.
-5. Fails CI when a violation is outside the migration allowlist.
+3. Detects disallowed generic throws: `ArgumentError` / `Exception` as `InstanceCreationExpression` (e.g. `throw const ArgumentError(...)`) or as implicit-constructor `MethodInvocation` with a null target (e.g. `throw ArgumentError(...)` / `throw Exception(...)`), and `ArgumentError.value(...)` (static `MethodInvocation` on `ArgumentError`).
+4. Reports file + line + disallowed form for each violation.
+5. Fails CI on violations (Phase 2+ may introduce an explicit path allowlist for documented interop boundaries).
 
 ## Rollout Model
 
@@ -56,7 +56,7 @@ The repository uses an AST-based checker that:
 
 ### Phase 2+
 
-- Expand from constructor-only detection to broader thrown-type validation policy per domain.
+- Expand to broader thrown-type validation policy per domain (e.g. path glob → allowed base types).
 - Keep checker mandatory in CI and apply the same migration pattern to any newly introduced runtime packages.
 
 ## Acceptance Criteria

--- a/packages/colonizethis_logic/lib/colonizethis_logic.dart
+++ b/packages/colonizethis_logic/lib/colonizethis_logic.dart
@@ -6,6 +6,7 @@ export 'package:colonizethis_models/colonizethis_models.dart'
     show AssignedRecipe;
 export 'order_suggestion_api.dart';
 export 'src/constants.dart';
+export 'src/logic_validation_exception.dart';
 export 'src/event_bus/game_event_bus.dart';
 export 'src/game_events.dart';
 export 'src/turn_to_year.dart';

--- a/packages/colonizethis_logic/lib/src/logic_validation_exception.dart
+++ b/packages/colonizethis_logic/lib/src/logic_validation_exception.dart
@@ -1,0 +1,9 @@
+/// Domain-specific validation exception for non-setup logic invariants.
+///
+/// Extends [ArgumentError] so callers that catch [ArgumentError] keep working.
+class LogicValidationException extends ArgumentError {
+  LogicValidationException([super.message]);
+
+  LogicValidationException.value(Object? value, [String? name, Object? message])
+    : super.value(value, name, message);
+}

--- a/packages/colonizethis_logic/lib/src/world/player_view.dart
+++ b/packages/colonizethis_logic/lib/src/world/player_view.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../logic_validation_exception.dart';
 import 'province_lookup.dart';
 import 'unit_lookup.dart';
 
@@ -70,7 +71,11 @@ class PlayerView {
 PlayerView buildPlayerView(Game game, MapTopology _, String playerId) {
   final player = game.playerById(playerId);
   if (player == null) {
-    throw ArgumentError.value(playerId, 'playerId', 'Player not found in game');
+    throw LogicValidationException.value(
+      playerId,
+      'playerId',
+      'Player not found in game',
+    );
   }
 
   // Provinces: key by full id (p.id is regionId|localId).

--- a/packages/colonizethis_logic/test/player_view_test.dart
+++ b/packages/colonizethis_logic/test/player_view_test.dart
@@ -209,7 +209,7 @@ void main() {
       const topology = MapTopology(nodes: [], edges: []);
       expect(
         () => buildPlayerView(game, topology, 'nonexistent'),
-        throwsA(isA<ArgumentError>()),
+        throwsA(isA<LogicValidationException>()),
       );
     });
 

--- a/packages/colonizethis_models/lib/src/model_validation_exception.dart
+++ b/packages/colonizethis_models/lib/src/model_validation_exception.dart
@@ -1,4 +1,7 @@
 /// Domain-specific validation exception for model deserialization invariants.
 class ModelValidationException extends ArgumentError {
   ModelValidationException([super.message]);
+
+  ModelValidationException.value(Object? value, [String? name, Object? message])
+    : super.value(value, name, message);
 }

--- a/packages/colonizethis_models/lib/src/region.dart
+++ b/packages/colonizethis_models/lib/src/region.dart
@@ -1,8 +1,7 @@
+import 'model_validation_exception.dart';
+
 /// Region identifier. SPEC/game/world-model: Old World + New World.
-enum Region {
-  oldWorld,
-  newWorld,
-}
+enum Region { oldWorld, newWorld }
 
 extension RegionJson on Region {
   static Region fromJson(String value) {
@@ -12,7 +11,7 @@ extension RegionJson on Region {
       case 'newWorld':
         return Region.newWorld;
       default:
-        throw ArgumentError.value(value, 'value', 'Unknown Region');
+        throw ModelValidationException.value(value, 'value', 'Unknown Region');
     }
   }
 

--- a/packages/colonizethis_models/lib/src/turn_state.dart
+++ b/packages/colonizethis_models/lib/src/turn_state.dart
@@ -1,3 +1,5 @@
+import 'model_validation_exception.dart';
+
 /// Turn phase in resolution sequence. SPEC/program/turn-resolution.
 /// SPEC/program/turn-resolution-phases.md
 enum TurnPhase {
@@ -20,7 +22,11 @@ extension TurnPhaseJson on TurnPhase {
   static TurnPhase fromJson(String value) {
     return TurnPhase.values.firstWhere(
       (e) => e.name == value,
-      orElse: () => throw ArgumentError.value(value, 'value', 'Unknown TurnPhase'),
+      orElse: () => throw ModelValidationException.value(
+        value,
+        'value',
+        'Unknown TurnPhase',
+      ),
     );
   }
 
@@ -29,18 +35,15 @@ extension TurnPhaseJson on TurnPhase {
 
 /// Turn state: phase and turn number. Part of WorldState.
 class TurnState {
-  const TurnState({
-    required this.phase,
-    required this.turnNumber,
-  });
+  const TurnState({required this.phase, required this.turnNumber});
 
   final TurnPhase phase;
   final int turnNumber;
 
   Map<String, dynamic> toJson() => {
-        'phase': phase.toJson(),
-        'turnNumber': turnNumber,
-      };
+    'phase': phase.toJson(),
+    'turnNumber': turnNumber,
+  };
 
   static TurnState fromJson(Map<String, dynamic> json) {
     return TurnState(

--- a/packages/colonizethis_models/test/turn_state_test.dart
+++ b/packages/colonizethis_models/test/turn_state_test.dart
@@ -27,5 +27,11 @@ void main() {
         expect(TurnState.fromJson(s.toJson()).phase, phase);
       }
     });
+    test('fromJson rejects unknown phase string', () {
+      expect(
+        () => TurnState.fromJson({'phase': 'notARealPhase', 'turnNumber': 0}),
+        throwsArgumentError,
+      );
+    });
   });
 }

--- a/test/check_custom_exceptions_test.dart
+++ b/test/check_custom_exceptions_test.dart
@@ -1,0 +1,88 @@
+import 'package:test/test.dart';
+
+import '../tool/check_custom_exceptions.dart';
+
+void main() {
+  group('findCustomExceptionViolations', () {
+    test('flags throw ArgumentError()', () {
+      const src = r'''
+void f() {
+  throw ArgumentError('x');
+}
+''';
+      final v = findCustomExceptionViolations('packages/foo/lib/x.dart', src);
+      expect(v, isNotEmpty);
+      expect(v.first.exceptionType, 'ArgumentError');
+      expect(v.first.line, greaterThan(0));
+    });
+
+    test('flags throw const ArgumentError()', () {
+      const src = r'''
+void f() {
+  throw const ArgumentError('x');
+}
+''';
+      final v = findCustomExceptionViolations('packages/foo/lib/x.dart', src);
+      expect(v, isNotEmpty);
+      expect(v.first.exceptionType, 'ArgumentError');
+    });
+
+    test('flags throw Exception()', () {
+      const src = r'''
+void f() {
+  throw Exception('x');
+}
+''';
+      final v = findCustomExceptionViolations('packages/foo/lib/x.dart', src);
+      expect(v, isNotEmpty);
+      expect(v.first.exceptionType, 'Exception');
+    });
+
+    test('flags throw ArgumentError.value(...)', () {
+      const src = r'''
+void f() {
+  throw ArgumentError.value(1, 'a', 'b');
+}
+''';
+      final v = findCustomExceptionViolations('packages/foo/lib/x.dart', src);
+      expect(v, isNotEmpty);
+      expect(v.first.exceptionType, 'ArgumentError.value');
+    });
+
+    test('allows domain validation throw', () {
+      const src = r'''
+void f() {
+  throw ModelValidationException.value(1, 'a', 'b');
+}
+''';
+      expect(
+        findCustomExceptionViolations('packages/foo/lib/x.dart', src),
+        isEmpty,
+      );
+    });
+
+    test('skips test paths', () {
+      const src = r'''
+void f() {
+  throw ArgumentError('x');
+}
+''';
+      expect(
+        findCustomExceptionViolations('packages/foo/test/x_test.dart', src),
+        isEmpty,
+      );
+    });
+
+    test('skips generated files', () {
+      const src = r'''
+void f() {
+  throw ArgumentError('x');
+}
+''';
+      expect(
+        findCustomExceptionViolations('packages/foo/lib/x.g.dart', src),
+        isEmpty,
+      );
+    });
+  });
+}

--- a/tool/check_custom_exceptions.dart
+++ b/tool/check_custom_exceptions.dart
@@ -16,22 +16,18 @@ final _domainRoots = <String>[
 
 final _forbiddenExceptionTypes = <String>{'ArgumentError', 'Exception'};
 
+/// PR-blocking check for generic exception throws in runtime domain code.
+///
+/// SPEC: SPEC/program/exception-enforcement.md
 void main() {
   final repoRoot = Directory.current.path;
   final dartFiles = _collectDomainDartFiles(repoRoot);
-  final violations = <_Violation>[];
+  final violations = <CustomExceptionViolation>[];
 
   for (final file in dartFiles) {
     final relativePath = p.relative(file.path, from: repoRoot);
     final content = file.readAsStringSync();
-    final parsed = parseString(
-      content: content,
-      path: file.path,
-      throwIfDiagnostics: false,
-    );
-    final visitor = _ThrowVisitor(relativePath, parsed.lineInfo);
-    parsed.unit.accept(visitor);
-    violations.addAll(visitor.violations);
+    violations.addAll(findCustomExceptionViolations(relativePath, content));
   }
 
   if (violations.isEmpty) {
@@ -49,6 +45,33 @@ void main() {
     );
   }
   exitCode = 1;
+}
+
+/// Exposed for unit tests (same behavior as production scan for a single file).
+List<CustomExceptionViolation> findCustomExceptionViolations(
+  String relativePath,
+  String content,
+) {
+  if (!relativePath.endsWith('.dart')) {
+    return const [];
+  }
+  if (relativePath.contains('/test/') || relativePath.endsWith('_test.dart')) {
+    return const [];
+  }
+  if (relativePath.endsWith('.g.dart') ||
+      relativePath.endsWith('.freezed.dart') ||
+      relativePath.endsWith('.mocks.dart')) {
+    return const [];
+  }
+
+  final parsed = parseString(
+    content: content,
+    path: relativePath,
+    throwIfDiagnostics: false,
+  );
+  final visitor = _ThrowVisitor(relativePath, parsed.lineInfo);
+  parsed.unit.accept(visitor);
+  return visitor.violations;
 }
 
 List<File> _collectDomainDartFiles(String repoRoot) {
@@ -83,32 +106,8 @@ List<File> _collectDomainDartFiles(String repoRoot) {
   return files;
 }
 
-class _ThrowVisitor extends RecursiveAstVisitor<void> {
-  _ThrowVisitor(this.path, this.lineInfo);
-
-  final String path;
-  final LineInfo lineInfo;
-  final List<_Violation> violations = [];
-
-  @override
-  void visitThrowExpression(ThrowExpression node) {
-    final expression = node.expression;
-    if (expression is! InstanceCreationExpression) {
-      return;
-    }
-    final rawTypeName = expression.constructorName.type.toSource();
-    final typeName = rawTypeName.split('<').first;
-    if (_forbiddenExceptionTypes.contains(typeName)) {
-      final line = lineInfo.getLocation(node.offset).lineNumber;
-      violations.add(
-        _Violation(path: path, line: line, exceptionType: typeName),
-      );
-    }
-  }
-}
-
-class _Violation {
-  const _Violation({
+class CustomExceptionViolation {
+  const CustomExceptionViolation({
     required this.path,
     required this.line,
     required this.exceptionType,
@@ -117,4 +116,56 @@ class _Violation {
   final String path;
   final int line;
   final String exceptionType;
+}
+
+class _ThrowVisitor extends RecursiveAstVisitor<void> {
+  _ThrowVisitor(this.path, this.lineInfo);
+
+  final String path;
+  final LineInfo lineInfo;
+  final List<CustomExceptionViolation> violations = [];
+
+  @override
+  void visitThrowExpression(ThrowExpression node) {
+    final expression = node.expression;
+    if (expression is InstanceCreationExpression) {
+      final rawTypeName = expression.constructorName.type.toSource();
+      final typeName = rawTypeName.split('<').first;
+      if (_forbiddenExceptionTypes.contains(typeName)) {
+        _addViolation(node, typeName);
+      }
+    } else if (expression is MethodInvocation) {
+      if (_isArgumentErrorValueInvocation(expression)) {
+        _addViolation(node, 'ArgumentError.value');
+      } else if (expression.target == null &&
+          _forbiddenExceptionTypes.contains(expression.methodName.name)) {
+        _addViolation(node, expression.methodName.name);
+      }
+    }
+    super.visitThrowExpression(node);
+  }
+
+  void _addViolation(ThrowExpression node, String exceptionType) {
+    final line = lineInfo.getLocation(node.offset).lineNumber;
+    violations.add(
+      CustomExceptionViolation(
+        path: path,
+        line: line,
+        exceptionType: exceptionType,
+      ),
+    );
+  }
+}
+
+/// `ArgumentError.value(...)` parses as a static method invocation, not a
+/// constructor [InstanceCreationExpression].
+bool _isArgumentErrorValueInvocation(MethodInvocation node) {
+  if (node.methodName.name != 'value') {
+    return false;
+  }
+  final target = node.target;
+  if (target is SimpleIdentifier && target.name == 'ArgumentError') {
+    return true;
+  }
+  return false;
 }


### PR DESCRIPTION
## Summary

Completes the remaining **Phase 1** work for exception-type enforcement (`SPEC/program/exception-enforcement.md`): the AST checker now catches forms the analyzer represents as `MethodInvocation` (implicit `throw ArgumentError(...)` / `throw Exception(...)` and `throw ArgumentError.value(...)`), migrates the last generic throws in logic/models runtime code, and adds regression tests plus a CI step.

## Acceptance criteria (this PR)

- Remaining `ArgumentError.value` throws in scoped `lib` code replaced with domain types (`LogicValidationException`, `ModelValidationException`).
- Checker reports violations for constructor and implicit-constructor / `.value` forms; repo scan is clean.
- Unit tests cover the checker; workflow runs them after `dart run tool/check_custom_exceptions.dart`.

## Out of scope (issue #1615 remainder)

- Dedicated `custom_lint` plugin (repo uses root AST checker + CI per SPEC Phase 1).
- Domain-root taxonomies (`GameDomainException`, etc.) and per-path allowlist policy (SPEC Phase 2+).

## SPEC

- `SPEC/program/exception-enforcement.md` — implementation contract updated for current analyzer AST shapes.

## Tests

- `dart test test/check_custom_exceptions_test.dart`
- `dart run tool/check_custom_exceptions.dart`
- `dart test packages/colonizethis_logic/test/player_view_test.dart`
- `dart test packages/colonizethis_models/test/turn_state_test.dart packages/colonizethis_models/test/region_test.dart`

Refs #1615

Made with [Cursor](https://cursor.com)