### PR TITLE
feat(quality): custom_lint for domain generic throws (Refs #1615)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -336,8 +336,11 @@ jobs:
       - name: Check custom exception enforcement (SPEC/program/exception-enforcement.md)
         run: dart run tool/check_custom_exceptions.dart
 
-      - name: Test custom exception checker (SPEC/program/exception-enforcement.md)
-        run: dart test test/check_custom_exceptions_test.dart --reporter=compact
+      - name: Run domain exception custom_lint (SPEC/program/exception-enforcement.md)
+        run: bash tool/run_custom_lint_domain_exceptions.sh
+
+      - name: Test colonizethis_exception_lint (SPEC/program/exception-enforcement.md)
+        run: dart test packages/colonizethis_exception_lint/test --reporter=compact
 
       - name: Check disallowed AST patterns (SPEC/program/disallowed-ast-patterns.md)
         run: dart run tool/check_disallowed_ast_patterns.dart

--- a/SPEC/program/exception-enforcement.md
+++ b/SPEC/program/exception-enforcement.md
@@ -36,9 +36,14 @@ Enforcement applies to runtime code across:
 
 Generated files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`) are excluded.
 
-## Implementation Contract (AST checker)
+## Implementation Contract (AST checker + custom_lint)
 
-The repository uses an AST-based checker that:
+The repository enforces the same policy in two places (shared implementation in `packages/colonizethis_exception_lint`):
+
+1. **CI / CLI:** `dart run tool/check_custom_exceptions.dart` from the repository root (also `melos run check_custom_exceptions`). Scans runtime domain files under the roots listed in that tool.
+2. **IDE / analyzer:** `custom_lint` with package `colonizethis_exception_lint`, wired in every workspace package that contains scoped runtime `lib/` code (see each package `pubspec.yaml` + `analysis_options.yaml`). Run locally per package via `dart run custom_lint`, or `bash tool/run_custom_lint_domain_exceptions.sh` for all wired packages. CI runs the same script after the root checker.
+
+The checker:
 
 1. Parses Dart files with analyzer.
 2. Visits `ThrowExpression` nodes.
@@ -51,6 +56,7 @@ The repository uses an AST-based checker that:
 ### Phase 1 (implemented)
 
 - Introduce checker and CI hook.
+- Add `colonizethis_exception_lint` (`custom_lint` plugin) for in-editor diagnostics aligned with the checker.
 - Migrate setup domain (`packages/colonizethis_logic/lib/src/setup/**`) to `SetupValidationException`.
 - Add package-local validation exception types in map/data/models/ui/ctterm/tool runtime code and migrate existing generic throws in those domains.
 
@@ -62,6 +68,7 @@ The repository uses an AST-based checker that:
 ## Acceptance Criteria
 
 - AST checker exists and runs from repository root.
+- The same rules are available as a `custom_lint` rule (`colonizethis_exception_lint`) in scoped packages so IDEs surface violations during normal analysis.
 - Checker scans all runtime domains listed above.
 - New generic exception throws fail checks unless explicitly allowlisted.
 - Setup domain migration uses `SetupValidationException` for validation failures.

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -36,6 +36,8 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  colonizethis_exception_lint:
+    path: ../packages/colonizethis_exception_lint
   custom_lint: ^0.8.1
   hardcoded_strings_lint: ^1.0.4
 

--- a/ctdev/analysis_options.yaml
+++ b/ctdev/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  plugins:
+    - custom_lint

--- a/ctdev/pubspec.yaml
+++ b/ctdev/pubspec.yaml
@@ -24,7 +24,10 @@ dependencies:
   colonizethis_save: any
 
 dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../packages/colonizethis_exception_lint
   colonizethis_test:
+  custom_lint: ^0.8.1
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0

--- a/ctterm/analysis_options.yaml
+++ b/ctterm/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/ctterm/pubspec.yaml
+++ b/ctterm/pubspec.yaml
@@ -25,7 +25,10 @@ dependencies:
   colonizethis_save: any
 
 dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../packages/colonizethis_exception_lint
   colonizethis_test:
+  custom_lint: ^0.8.1
   test: ^1.24.0
 
 executables:

--- a/packages/colonizethis_ai/analysis_options.yaml
+++ b/packages/colonizethis_ai/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/packages/colonizethis_ai/pubspec.yaml
+++ b/packages/colonizethis_ai/pubspec.yaml
@@ -17,5 +17,8 @@ dependencies:
   colonizethis_models:
 
 dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../colonizethis_exception_lint
   colonizethis_test:
+  custom_lint: ^0.8.1
   test: ^1.24.0

--- a/packages/colonizethis_data/analysis_options.yaml
+++ b/packages/colonizethis_data/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/packages/colonizethis_data/pubspec.yaml
+++ b/packages/colonizethis_data/pubspec.yaml
@@ -14,6 +14,9 @@ dependencies:
   colonizethis_models:
 
 dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../colonizethis_exception_lint
   colonizethis_test:
   coverage: ^1.15.0
+  custom_lint: ^0.8.1
   test: ^1.24.0

--- a/packages/colonizethis_exception_lint/analysis_options.yaml
+++ b/packages/colonizethis_exception_lint/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:lints/recommended.yaml
+
+analyzer:
+  plugins:
+    - custom_lint

--- a/packages/colonizethis_exception_lint/lib/colonizethis_exception_lint.dart
+++ b/packages/colonizethis_exception_lint/lib/colonizethis_exception_lint.dart
@@ -1,0 +1,12 @@
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+import 'src/no_generic_domain_throw_rule.dart';
+
+PluginBase createPlugin() => _ColonizeThisExceptionLint();
+
+class _ColonizeThisExceptionLint extends PluginBase {
+  @override
+  List<LintRule> getLintRules(CustomLintConfigs configs) => [
+    NoGenericDomainThrowRule(),
+  ];
+}

--- a/packages/colonizethis_exception_lint/lib/exception_enforcement.dart
+++ b/packages/colonizethis_exception_lint/lib/exception_enforcement.dart
@@ -1,0 +1,6 @@
+/// Shared AST scan used by CI `tool/check_custom_exceptions.dart` and the
+/// custom_lint rule in this package.
+library;
+
+export 'src/enforcement.dart';
+export 'src/no_generic_domain_throw_rule.dart' show NoGenericDomainThrowRule;

--- a/packages/colonizethis_exception_lint/lib/src/enforcement.dart
+++ b/packages/colonizethis_exception_lint/lib/src/enforcement.dart
@@ -1,0 +1,131 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/source/line_info.dart';
+
+/// Whether [filePath] is runtime domain code covered by exception enforcement.
+///
+/// [filePath] may be absolute or repo-relative; path separators are normalized.
+bool shouldEnforceDomainExceptions(String filePath) {
+  final p = filePath.replaceAll(r'\', '/');
+  if (!p.contains('/lib/')) {
+    return false;
+  }
+  if (p.contains('/test/') || p.endsWith('_test.dart')) {
+    return false;
+  }
+  if (p.endsWith('.g.dart') ||
+      p.endsWith('.freezed.dart') ||
+      p.endsWith('.mocks.dart')) {
+    return false;
+  }
+  if (RegExp(r'(^|/)packages/').hasMatch(p)) {
+    return true;
+  }
+  if (p.contains('/app/lib/') || p.startsWith('app/lib/')) {
+    return true;
+  }
+  if (p.contains('/ctdev/lib/') || p.startsWith('ctdev/lib/')) {
+    return true;
+  }
+  if (p.contains('/ctterm/lib/') || p.startsWith('ctterm/lib/')) {
+    return true;
+  }
+  if (RegExp(r'(^|/)tool/').hasMatch(p)) {
+    return true;
+  }
+  return false;
+}
+
+/// When non-null, [expression] is a forbidden generic throw operand.
+String? forbiddenGenericThrowLabel(Expression expression) {
+  if (expression is InstanceCreationExpression) {
+    final rawTypeName = expression.constructorName.type.toSource();
+    final typeName = rawTypeName.split('<').first;
+    if (_forbiddenExceptionTypes.contains(typeName)) {
+      return typeName;
+    }
+    return null;
+  }
+  if (expression is MethodInvocation) {
+    if (_isArgumentErrorValueInvocation(expression)) {
+      return 'ArgumentError.value';
+    }
+    if (expression.target == null &&
+        _forbiddenExceptionTypes.contains(expression.methodName.name)) {
+      return expression.methodName.name;
+    }
+  }
+  return null;
+}
+
+const _forbiddenExceptionTypes = {'ArgumentError', 'Exception'};
+
+/// `ArgumentError.value(...)` parses as a static method invocation, not a
+/// constructor [InstanceCreationExpression].
+bool _isArgumentErrorValueInvocation(MethodInvocation node) {
+  if (node.methodName.name != 'value') {
+    return false;
+  }
+  final target = node.target;
+  if (target is SimpleIdentifier && target.name == 'ArgumentError') {
+    return true;
+  }
+  return false;
+}
+
+/// One generic-throw violation in a scanned file.
+class CustomExceptionViolation {
+  const CustomExceptionViolation({
+    required this.path,
+    required this.line,
+    required this.exceptionType,
+  });
+
+  final String path;
+  final int line;
+  final String exceptionType;
+}
+
+/// Parses [content] and returns violations for [relativePath] when enforcement
+/// applies (same behavior as the repository CI script).
+List<CustomExceptionViolation> findCustomExceptionViolations(
+  String relativePath,
+  String content,
+) {
+  if (!relativePath.endsWith('.dart')) {
+    return const [];
+  }
+  if (!shouldEnforceDomainExceptions(relativePath)) {
+    return const [];
+  }
+
+  final parsed = parseString(
+    content: content,
+    path: relativePath,
+    throwIfDiagnostics: false,
+  );
+  final visitor = _ThrowVisitor(relativePath, parsed.lineInfo);
+  parsed.unit.accept(visitor);
+  return visitor.violations;
+}
+
+class _ThrowVisitor extends RecursiveAstVisitor<void> {
+  _ThrowVisitor(this.path, this.lineInfo);
+
+  final String path;
+  final LineInfo lineInfo;
+  final List<CustomExceptionViolation> violations = [];
+
+  @override
+  void visitThrowExpression(ThrowExpression node) {
+    final label = forbiddenGenericThrowLabel(node.expression);
+    if (label != null) {
+      final line = lineInfo.getLocation(node.offset).lineNumber;
+      violations.add(
+        CustomExceptionViolation(path: path, line: line, exceptionType: label),
+      );
+    }
+    super.visitThrowExpression(node);
+  }
+}

--- a/packages/colonizethis_exception_lint/lib/src/no_generic_domain_throw_rule.dart
+++ b/packages/colonizethis_exception_lint/lib/src/no_generic_domain_throw_rule.dart
@@ -1,0 +1,40 @@
+// custom_lint / analyzer still surface ErrorSeverity + ErrorReporter on these APIs.
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/error/error.dart' show ErrorSeverity;
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+import 'enforcement.dart';
+
+/// Forbids `throw ArgumentError`, `throw Exception`, and `throw ArgumentError.value`
+/// in domain runtime paths. SPEC/program/exception-enforcement.md
+class NoGenericDomainThrowRule extends DartLintRule {
+  NoGenericDomainThrowRule()
+    : super(
+        code: LintCode(
+          name: 'no_generic_domain_throw',
+          problemMessage:
+              'Generic throws (ArgumentError / Exception) are disallowed in '
+              'domain runtime code; use a domain-specific exception type. '
+              'See SPEC/program/exception-enforcement.md.',
+          errorSeverity: ErrorSeverity.ERROR,
+        ),
+      );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addThrowExpression((node) {
+      if (!shouldEnforceDomainExceptions(resolver.path)) {
+        return;
+      }
+      if (forbiddenGenericThrowLabel(node.expression) != null) {
+        reporter.atNode(node, code);
+      }
+    });
+  }
+}

--- a/packages/colonizethis_exception_lint/pubspec.yaml
+++ b/packages/colonizethis_exception_lint/pubspec.yaml
@@ -1,0 +1,21 @@
+name: colonizethis_exception_lint
+description: >
+  Custom lint + shared AST helpers forbidding generic throws in ColonizeThis
+  domain runtime code. SPEC/program/exception-enforcement.md
+version: 0.0.1
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: '>=3.11.0 <4.0.0'
+
+dependencies:
+  analyzer: ^8.4.0
+  analyzer_plugin: ^0.13.7
+  custom_lint_builder: ^0.8.1
+
+dev_dependencies:
+  custom_lint: ^0.8.1
+  lints: ^6.0.0
+  path: ^1.9.1
+  test: ^1.24.0

--- a/packages/colonizethis_exception_lint/pubspec.yaml
+++ b/packages/colonizethis_exception_lint/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   custom_lint_builder: ^0.8.1
 
 dev_dependencies:
+  colonizethis_test:
   custom_lint: ^0.8.1
   lints: ^6.0.0
   path: ^1.9.1

--- a/packages/colonizethis_exception_lint/test/enforcement_test.dart
+++ b/packages/colonizethis_exception_lint/test/enforcement_test.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_exception_lint/exception_enforcement.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 void main() {
   group('findCustomExceptionViolations', () {

--- a/packages/colonizethis_exception_lint/test/enforcement_test.dart
+++ b/packages/colonizethis_exception_lint/test/enforcement_test.dart
@@ -1,6 +1,5 @@
+import 'package:colonizethis_exception_lint/exception_enforcement.dart';
 import 'package:test/test.dart';
-
-import '../tool/check_custom_exceptions.dart';
 
 void main() {
   group('findCustomExceptionViolations', () {
@@ -83,6 +82,17 @@ void f() {
         findCustomExceptionViolations('packages/foo/lib/x.g.dart', src),
         isEmpty,
       );
+    });
+
+    test('shouldEnforceDomainExceptions skips widgetbook_host', () {
+      expect(
+        shouldEnforceDomainExceptions('/repo/widgetbook_host/lib/main.dart'),
+        isFalse,
+      );
+    });
+
+    test('shouldEnforceDomainExceptions accepts app/lib', () {
+      expect(shouldEnforceDomainExceptions('/repo/app/lib/main.dart'), isTrue);
     });
   });
 }

--- a/packages/colonizethis_exception_lint/test/no_generic_domain_throw_rule_test.dart
+++ b/packages/colonizethis_exception_lint/test/no_generic_domain_throw_rule_test.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
 import 'package:colonizethis_exception_lint/exception_enforcement.dart';
+import 'package:colonizethis_test/test.dart';
 import 'package:path/path.dart' as p;
-import 'package:test/test.dart';
 
 void main() {
   test('lint reports error when path matches domain packages/', () async {

--- a/packages/colonizethis_exception_lint/test/no_generic_domain_throw_rule_test.dart
+++ b/packages/colonizethis_exception_lint/test/no_generic_domain_throw_rule_test.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+
+import 'package:colonizethis_exception_lint/exception_enforcement.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  test('lint reports error when path matches domain packages/', () async {
+    final tmp = Directory.systemTemp.createTempSync('ct_exc_lint_pkg_');
+    addTearDown(() => tmp.deleteSync(recursive: true));
+    final libDir = Directory(p.join(tmp.path, 'packages', 'sample', 'lib'));
+    libDir.createSync(recursive: true);
+    final file = File(p.join(libDir.path, 'bad.dart'));
+    file.writeAsStringSync('void f() { throw ArgumentError("x"); }\n');
+
+    final rule = NoGenericDomainThrowRule();
+    final errors = await rule.testAnalyzeAndRun(file);
+    expect(errors, isNotEmpty);
+    expect(errors.first.diagnosticCode.name, 'no_generic_domain_throw');
+  });
+
+  test('lint skips widgetbook_host-shaped paths', () async {
+    final tmp = Directory.systemTemp.createTempSync('ct_exc_lint_wb_');
+    addTearDown(() => tmp.deleteSync(recursive: true));
+    final libDir = Directory(p.join(tmp.path, 'widgetbook_host', 'lib'));
+    libDir.createSync(recursive: true);
+    final file = File(p.join(libDir.path, 'bad.dart'));
+    file.writeAsStringSync('void f() { throw ArgumentError("x"); }\n');
+
+    final rule = NoGenericDomainThrowRule();
+    final errors = await rule.testAnalyzeAndRun(file);
+    expect(errors, isEmpty);
+  });
+}

--- a/packages/colonizethis_logger/analysis_options.yaml
+++ b/packages/colonizethis_logger/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/packages/colonizethis_logger/pubspec.yaml
+++ b/packages/colonizethis_logger/pubspec.yaml
@@ -12,6 +12,9 @@ dependencies:
   logger: ^2.0.2
 
 dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../colonizethis_exception_lint
   colonizethis_test:
   coverage: ^1.15.0
+  custom_lint: ^0.8.1
   test: ^1.24.0

--- a/packages/colonizethis_logic/analysis_options.yaml
+++ b/packages/colonizethis_logic/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/packages/colonizethis_logic/pubspec.yaml
+++ b/packages/colonizethis_logic/pubspec.yaml
@@ -17,6 +17,9 @@ dependencies:
   colonizethis_models:
 
 dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../colonizethis_exception_lint
   colonizethis_test:
   coverage: ^1.15.0
+  custom_lint: ^0.8.1
   test: ^1.24.0

--- a/packages/colonizethis_map/analysis_options.yaml
+++ b/packages/colonizethis_map/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/packages/colonizethis_map/pubspec.yaml
+++ b/packages/colonizethis_map/pubspec.yaml
@@ -17,7 +17,10 @@ dependencies:
   image: ^4.7.2
 
 dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../colonizethis_exception_lint
   colonizethis_test:
   coverage: ^1.15.0
+  custom_lint: ^0.8.1
   test: ^1.24.0
 

--- a/packages/colonizethis_models/analysis_options.yaml
+++ b/packages/colonizethis_models/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/packages/colonizethis_models/pubspec.yaml
+++ b/packages/colonizethis_models/pubspec.yaml
@@ -9,8 +9,11 @@ environment:
   sdk: '>=3.11.0 <4.0.0'
 
 dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../colonizethis_exception_lint
   colonizethis_test:
   coverage: ^1.15.0
+  custom_lint: ^0.8.1
   test: ^1.24.0
 
 dependencies:

--- a/packages/colonizethis_save/analysis_options.yaml
+++ b/packages/colonizethis_save/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/packages/colonizethis_save/pubspec.yaml
+++ b/packages/colonizethis_save/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
   hive: ^2.2.3
 
 dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../colonizethis_exception_lint
   colonizethis_test:
   coverage: ^1.15.0
+  custom_lint: ^0.8.1
   test: ^1.24.0

--- a/packages/colonizethis_test/analysis_options.yaml
+++ b/packages/colonizethis_test/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/packages/colonizethis_test/pubspec.yaml
+++ b/packages/colonizethis_test/pubspec.yaml
@@ -12,3 +12,8 @@ dependencies:
   colonizethis_logger: any
   logger: ^2.0.2
   test: ^1.24.0
+
+dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../colonizethis_exception_lint
+  custom_lint: ^0.8.1

--- a/packages/session_log_buffer/analysis_options.yaml
+++ b/packages/session_log_buffer/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/packages/session_log_buffer/pubspec.yaml
+++ b/packages/session_log_buffer/pubspec.yaml
@@ -12,5 +12,8 @@ dependencies:
   logger: ^2.0.2
 
 dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../colonizethis_exception_lint
   colonizethis_test:
+  custom_lint: ^0.8.1
   test: ^1.24.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ workspace:
   - widgetbook_host
   - ctdev
   - ctterm
+  - packages/colonizethis_exception_lint
   - packages/session_log_buffer
   - packages/colonizethis_logger
   - packages/colonizethis_models
@@ -29,6 +30,8 @@ workspace:
 
 dev_dependencies:
   analyzer: ^8.4.0
+  colonizethis_exception_lint:
+    path: packages/colonizethis_exception_lint
   image: ^4.5.4
   melos: ^7.0.0
   path: ^1.9.1
@@ -67,6 +70,9 @@ melos:
     check_custom_exceptions:
       description: AST check that forbids generic exceptions in runtime domain code. SPEC/program/exception-enforcement.md.
       run: dart run tool/check_custom_exceptions.dart
+    custom_lint_domain_exceptions:
+      description: Run custom_lint in packages wired for colonizethis_exception_lint. SPEC/program/exception-enforcement.md.
+      run: bash tool/run_custom_lint_domain_exceptions.sh
     check_app_hardcoded_ui_strings:
       description: AST check that forbids hardcoded user-visible UI strings in app/lib. SPEC/program/localization.md.
       run: dart run tool/check_app_hardcoded_ui_strings.dart

--- a/tool/check_custom_exceptions.dart
+++ b/tool/check_custom_exceptions.dart
@@ -1,9 +1,6 @@
 import 'dart:io';
 
-import 'package:analyzer/dart/analysis/utilities.dart';
-import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/source/line_info.dart';
+import 'package:colonizethis_exception_lint/exception_enforcement.dart';
 import 'package:path/path.dart' as p;
 
 final _domainRoots = <String>[
@@ -13,8 +10,6 @@ final _domainRoots = <String>[
   'ctterm/lib',
   'tool',
 ];
-
-final _forbiddenExceptionTypes = <String>{'ArgumentError', 'Exception'};
 
 /// PR-blocking check for generic exception throws in runtime domain code.
 ///
@@ -47,33 +42,6 @@ void main() {
   exitCode = 1;
 }
 
-/// Exposed for unit tests (same behavior as production scan for a single file).
-List<CustomExceptionViolation> findCustomExceptionViolations(
-  String relativePath,
-  String content,
-) {
-  if (!relativePath.endsWith('.dart')) {
-    return const [];
-  }
-  if (relativePath.contains('/test/') || relativePath.endsWith('_test.dart')) {
-    return const [];
-  }
-  if (relativePath.endsWith('.g.dart') ||
-      relativePath.endsWith('.freezed.dart') ||
-      relativePath.endsWith('.mocks.dart')) {
-    return const [];
-  }
-
-  final parsed = parseString(
-    content: content,
-    path: relativePath,
-    throwIfDiagnostics: false,
-  );
-  final visitor = _ThrowVisitor(relativePath, parsed.lineInfo);
-  parsed.unit.accept(visitor);
-  return visitor.violations;
-}
-
 List<File> _collectDomainDartFiles(String repoRoot) {
   final files = <File>[];
   for (final domainRoot in _domainRoots) {
@@ -104,68 +72,4 @@ List<File> _collectDomainDartFiles(String repoRoot) {
     }
   }
   return files;
-}
-
-class CustomExceptionViolation {
-  const CustomExceptionViolation({
-    required this.path,
-    required this.line,
-    required this.exceptionType,
-  });
-
-  final String path;
-  final int line;
-  final String exceptionType;
-}
-
-class _ThrowVisitor extends RecursiveAstVisitor<void> {
-  _ThrowVisitor(this.path, this.lineInfo);
-
-  final String path;
-  final LineInfo lineInfo;
-  final List<CustomExceptionViolation> violations = [];
-
-  @override
-  void visitThrowExpression(ThrowExpression node) {
-    final expression = node.expression;
-    if (expression is InstanceCreationExpression) {
-      final rawTypeName = expression.constructorName.type.toSource();
-      final typeName = rawTypeName.split('<').first;
-      if (_forbiddenExceptionTypes.contains(typeName)) {
-        _addViolation(node, typeName);
-      }
-    } else if (expression is MethodInvocation) {
-      if (_isArgumentErrorValueInvocation(expression)) {
-        _addViolation(node, 'ArgumentError.value');
-      } else if (expression.target == null &&
-          _forbiddenExceptionTypes.contains(expression.methodName.name)) {
-        _addViolation(node, expression.methodName.name);
-      }
-    }
-    super.visitThrowExpression(node);
-  }
-
-  void _addViolation(ThrowExpression node, String exceptionType) {
-    final line = lineInfo.getLocation(node.offset).lineNumber;
-    violations.add(
-      CustomExceptionViolation(
-        path: path,
-        line: line,
-        exceptionType: exceptionType,
-      ),
-    );
-  }
-}
-
-/// `ArgumentError.value(...)` parses as a static method invocation, not a
-/// constructor [InstanceCreationExpression].
-bool _isArgumentErrorValueInvocation(MethodInvocation node) {
-  if (node.methodName.name != 'value') {
-    return false;
-  }
-  final target = node.target;
-  if (target is SimpleIdentifier && target.name == 'ArgumentError') {
-    return true;
-  }
-  return false;
 }

--- a/tool/check_gdd_coverage/analysis_options.yaml
+++ b/tool/check_gdd_coverage/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/tool/check_gdd_coverage/pubspec.yaml
+++ b/tool/check_gdd_coverage/pubspec.yaml
@@ -11,5 +11,10 @@ dependencies:
   colonizethis_logger: any
   path: ^1.9.0
 
+dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../../packages/colonizethis_exception_lint
+  custom_lint: ^0.8.1
+
 executables:
   check_gdd_coverage: bin/check_gdd_coverage.dart

--- a/tool/generate_map/analysis_options.yaml
+++ b/tool/generate_map/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/tool/generate_map/pubspec.yaml
+++ b/tool/generate_map/pubspec.yaml
@@ -14,7 +14,10 @@ dependencies:
   colonizethis_models:
 
 dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../../packages/colonizethis_exception_lint
   colonizethis_test:
+  custom_lint: ^0.8.1
   path: ^1.9.0
   test: ^1.24.0
 

--- a/tool/init_game/analysis_options.yaml
+++ b/tool/init_game/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/tool/init_game/pubspec.yaml
+++ b/tool/init_game/pubspec.yaml
@@ -15,7 +15,10 @@ dependencies:
   colonizethis_save:
 
 dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../../packages/colonizethis_exception_lint
   colonizethis_test:
+  custom_lint: ^0.8.1
   path: ^1.9.0
   test: ^1.24.0
 

--- a/tool/run_custom_lint_domain_exceptions.sh
+++ b/tool/run_custom_lint_domain_exceptions.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Runs `dart run custom_lint` in every package wired for colonizethis_exception_lint.
+# SPEC/program/exception-enforcement.md
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+run_if_wired() {
+  local dir="$1"
+  local pubspec="$ROOT/$dir/pubspec.yaml"
+  if [[ -f "$pubspec" ]] && grep -q 'colonizethis_exception_lint' "$pubspec"; then
+    echo "custom_lint: $dir"
+    (cd "$ROOT/$dir" && dart run custom_lint)
+  fi
+}
+
+for dir in \
+  app \
+  ctdev \
+  ctterm \
+  packages/colonizethis_ai \
+  packages/colonizethis_data \
+  packages/colonizethis_exception_lint \
+  packages/colonizethis_logger \
+  packages/colonizethis_logic \
+  packages/colonizethis_map \
+  packages/colonizethis_models \
+  packages/colonizethis_save \
+  packages/colonizethis_test \
+  packages/session_log_buffer \
+  tool/check_gdd_coverage \
+  tool/generate_map \
+  tool/init_game \
+  tool/show_tech \
+  tool/sim_combat \
+  tool/sim_combat_montecarlo \
+  tool/sim_economy \
+  tool/sim_scenarios
+do
+  run_if_wired "$dir"
+done

--- a/tool/show_tech/analysis_options.yaml
+++ b/tool/show_tech/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/tool/show_tech/pubspec.yaml
+++ b/tool/show_tech/pubspec.yaml
@@ -12,5 +12,8 @@ dependencies:
   colonizethis_data:
 
 dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../../packages/colonizethis_exception_lint
   colonizethis_test:
+  custom_lint: ^0.8.1
   test: ^1.24.0

--- a/tool/sim_combat/analysis_options.yaml
+++ b/tool/sim_combat/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/tool/sim_combat/pubspec.yaml
+++ b/tool/sim_combat/pubspec.yaml
@@ -14,7 +14,10 @@ dependencies:
   colonizethis_models:
 
 dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../../packages/colonizethis_exception_lint
   colonizethis_test:
+  custom_lint: ^0.8.1
   test: ^1.24.0
 
 executables:

--- a/tool/sim_combat_montecarlo/analysis_options.yaml
+++ b/tool/sim_combat_montecarlo/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/tool/sim_combat_montecarlo/pubspec.yaml
+++ b/tool/sim_combat_montecarlo/pubspec.yaml
@@ -14,7 +14,10 @@ dependencies:
   colonizethis_models:
 
 dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../../packages/colonizethis_exception_lint
   colonizethis_test:
+  custom_lint: ^0.8.1
   path: ^1.9.0
   test: ^1.24.0
 

--- a/tool/sim_economy/analysis_options.yaml
+++ b/tool/sim_economy/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/tool/sim_economy/pubspec.yaml
+++ b/tool/sim_economy/pubspec.yaml
@@ -14,7 +14,10 @@ dependencies:
   colonizethis_logic:
 
 dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../../packages/colonizethis_exception_lint
   colonizethis_test:
+  custom_lint: ^0.8.1
   test: ^1.24.0
 
 executables:

--- a/tool/sim_scenarios/analysis_options.yaml
+++ b/tool/sim_scenarios/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/tool/sim_scenarios/pubspec.yaml
+++ b/tool/sim_scenarios/pubspec.yaml
@@ -19,7 +19,10 @@ dependencies:
   colonizethis_map:
 
 dev_dependencies:
+  colonizethis_exception_lint:
+    path: ../../packages/colonizethis_exception_lint
   colonizethis_test:
+  custom_lint: ^0.8.1
   test: ^1.24.0
 
 executables:


### PR DESCRIPTION
## Summary
Delivers the remaining #1615 slice: `custom_lint` + analyzer plugin aligned with the existing root AST checker, so IDE analysis surfaces the same `ArgumentError` / `Exception` throw policy as CI.

## SPEC
- `SPEC/program/exception-enforcement.md` — documents dual enforcement (root script + `colonizethis_exception_lint`), CI custom_lint step, and melos script.

## Implementation
- New workspace package `packages/colonizethis_exception_lint`: shared `findCustomExceptionViolations` / `shouldEnforceDomainExceptions`, `NoGenericDomainThrowRule`, `createPlugin` entrypoint.
- `tool/check_custom_exceptions.dart` now delegates scanning logic to the package (single source of truth).
- Wired `custom_lint` + path dependency into every scoped runtime package (app, ctdev, ctterm, `packages/*` with `lib/`, `tool/*` with `lib/`). `widgetbook_host` intentionally unchanged (outside enforcement roots).
- `tool/run_custom_lint_domain_exceptions.sh` + quality workflow step; `melos run custom_lint_domain_exceptions`.
- Tests live under `packages/colonizethis_exception_lint/test/` (moved from root); added rule tests using temp dirs for path-shaped fixtures.

## Deferred (issue Phase 2+)
- Per-path allowed-thrown-type map / explicit interop allowlist beyond generic `ArgumentError`/`Exception` (already tracked in SPEC Phase 2+).

## Tests
- `dart test packages/colonizethis_exception_lint/test`
- `dart run tool/check_custom_exceptions.dart`
- `bash tool/run_custom_lint_domain_exceptions.sh`

Refs #1615

Made with [Cursor](https://cursor.com)