### PR TITLE
fix(quality): add AI domain exception taxonomy (Refs #1615)

### DIFF
--- a/SPEC/program/exception-enforcement.md
+++ b/SPEC/program/exception-enforcement.md
@@ -58,7 +58,7 @@ The checker:
 - Introduce checker and CI hook.
 - Add `colonizethis_exception_lint` (`custom_lint` plugin) for in-editor diagnostics aligned with the checker.
 - Migrate setup domain (`packages/colonizethis_logic/lib/src/setup/**`) to `SetupValidationException`.
-- Add package-local validation exception types in map/data/models/ui/ctterm/tool runtime code and migrate existing generic throws in those domains.
+- Add package-local validation exception types in ai/map/data/models/ui/ctterm/tool runtime code and migrate existing generic throws in those domains.
 
 ### Phase 2+
 

--- a/packages/colonizethis_ai/lib/colonizethis_ai.dart
+++ b/packages/colonizethis_ai/lib/colonizethis_ai.dart
@@ -15,6 +15,7 @@ export 'src/economy_planner.dart';
 export 'src/full_ai_planner.dart';
 export 'src/goal_manager.dart';
 export 'src/hidden_agenda.dart';
+export 'src/ai_validation_exception.dart';
 export 'src/mood_state_machine.dart';
 export 'src/perception.dart';
 export 'src/strategic_ai.dart';

--- a/packages/colonizethis_ai/lib/src/ai_validation_exception.dart
+++ b/packages/colonizethis_ai/lib/src/ai_validation_exception.dart
@@ -1,0 +1,18 @@
+/// Base exception for AI domain runtime errors.
+///
+/// Extends [ArgumentError] for compatibility with existing generic catch
+/// blocks while allowing AI-specific exception typing.
+class AiDomainException extends ArgumentError {
+  AiDomainException([super.message]);
+
+  AiDomainException.value(Object? value, [String? name, Object? message])
+    : super.value(value, name, message);
+}
+
+/// Domain-specific validation exception for AI planning invariants.
+class AiValidationException extends AiDomainException {
+  AiValidationException([super.message]);
+
+  AiValidationException.value(Object? value, [String? name, Object? message])
+    : super.value(value, name, message);
+}

--- a/packages/colonizethis_ai/test/ai_validation_exception_test.dart
+++ b/packages/colonizethis_ai/test/ai_validation_exception_test.dart
@@ -1,0 +1,21 @@
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('AiValidationException', () {
+    test('is typed as AI domain exception', () {
+      final ex = AiValidationException('ai invariant failed');
+      expect(ex, isA<AiDomainException>());
+      expect(ex, isA<ArgumentError>());
+      expect(ex.message, 'ai invariant failed');
+    });
+
+    test('value constructor preserves value and field name', () {
+      final ex = AiValidationException.value(-1, 'threatScore', 'out of range');
+      expect(ex, isA<AiDomainException>());
+      expect(ex.invalidValue, -1);
+      expect(ex.name, 'threatScore');
+      expect(ex.message, 'out of range');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `AiDomainException` and `AiValidationException` in `packages/colonizethis_ai/lib/src/ai_validation_exception.dart` to complete domain exception taxonomy coverage
- export AI exception types from `packages/colonizethis_ai/lib/colonizethis_ai.dart` for package consumers
- update `SPEC/program/exception-enforcement.md` phase-1 migration note to include AI domain taxonomy

## Tests
- `dart test packages/colonizethis_ai/test --reporter=compact`
- `dart run custom_lint` (in `packages/colonizethis_ai`)
- `dart run tool/check_custom_exceptions.dart`

## Scope
- This PR implements the remaining slice of #1615 identified during verification (AI taxonomy parity).
- Existing lint/CI enforcement and non-AI domain migrations were completed in #1709 and #1712.

Refs #1615

Made with [Cursor](https://cursor.com)