### PR TITLE
feat(quality): add work-target constants convention gate

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -330,6 +330,44 @@ jobs:
           echo "Running tech-id convention check on changed Dart files only."
           tool/check_tech_id_constants.sh --files "$changed_files"
 
+      - name: Check work target constants convention (SPEC/program/repo-and-packages.md)
+        run: |
+          set -euo pipefail
+          base_ref="${GITHUB_BASE_REF:-}"
+          if [ -z "$base_ref" ]; then
+            echo "No GITHUB_BASE_REF in context; running full work-target scan."
+            tool/check_work_target_constants.sh
+            exit 0
+          fi
+
+          if ! git fetch --no-tags --depth=1 origin "$base_ref"; then
+            echo "Could not fetch origin/$base_ref; running full work-target scan."
+            tool/check_work_target_constants.sh
+            exit 0
+          fi
+
+          merge_base="$(git merge-base "origin/$base_ref" HEAD 2>/dev/null || true)"
+          if [ -z "$merge_base" ]; then
+            echo "No merge base between origin/$base_ref and HEAD in this checkout; running full work-target scan."
+            tool/check_work_target_constants.sh
+            exit 0
+          fi
+
+          changed_files="$(
+            git diff --name-only "origin/$base_ref"...HEAD -- '*.dart' \
+              | tr '\n' ',' \
+              | sed 's/,$//'
+          )"
+
+          if [ -z "$changed_files" ]; then
+            echo "No changed Dart files detected in PR diff; running full work-target scan."
+            tool/check_work_target_constants.sh
+            exit 0
+          fi
+
+          echo "Running work-target convention check on changed Dart files only."
+          tool/check_work_target_constants.sh --files "$changed_files"
+
       - name: Check package logger API convention (SPEC/program/logging/logging.md)
         run: tool/check_naked_logger_usage.sh
 
@@ -350,6 +388,9 @@ jobs:
 
       - name: Test app hardcoded UI string checker (SPEC/program/localization.md)
         run: dart test test/check_app_hardcoded_ui_strings_test.dart --reporter=compact
+
+      - name: Test work target constants checker (SPEC/program/repo-and-packages.md)
+        run: dart test test/check_work_target_constants_test.dart --reporter=compact
 
       - name: Wang incremental assets gate (Python)
         run: |

--- a/SPEC/program/repo-and-packages.md
+++ b/SPEC/program/repo-and-packages.md
@@ -67,6 +67,8 @@ colonizethis_data    (no package deps)
 - **Given** an app runtime asset reference in `app/lib`, **when** the code compiles, **then** the reference uses constants or helper builders defined in `app/lib/config/app_assets.dart`.
 - **Given** Dart source under `app/`, `ctterm/`, `packages/`, and `tool/`, **when** static analysis inspects executable AST string literals, **then** raw literals equal to canonical tech IDs are rejected outside allowlisted declaration/config and fixture paths.
 - **Given** the tech-ID convention gate reports a violation, **when** a developer inspects the output, **then** each violation includes file path, line, column, and the offending tech ID literal for direct remediation.
+- **Given** Dart source under `app/`, `ctterm/`, `packages/`, and `tool/`, **when** static analysis inspects executable AST string literals, **then** raw literals equal to canonical work target IDs are rejected outside the allowlisted work-target declaration file and fixture paths.
+- **Given** the work-target convention gate reports a violation, **when** a developer inspects the output, **then** each violation includes file path, line, column, and the offending work target literal with a suggested `kWorkTarget*` constant when available.
 
 ### Automated guard gate (CI)
 
@@ -75,9 +77,11 @@ The repository enforces this boundary in CI via:
 - `tool/check_logic_ai_decoupling.sh`
 - `tool/check_asset_path_constants.sh`
 - `tool/check_tech_id_constants.sh`
+- `tool/check_work_target_constants.sh`
 - `.github/workflows/quality.yml` step: `Check logic/ai decoupling convention (SPEC/program/repo-and-packages.md)`
 - `.github/workflows/quality.yml` step: `Check asset path constants convention (SPEC/program/repo-and-packages.md)`
 - `.github/workflows/quality.yml` step: `Check tech ID constants convention (SPEC/program/repo-and-packages.md)`
+- `.github/workflows/quality.yml` step: `Check work target constants convention (SPEC/program/repo-and-packages.md)`
 
 Guard behavior:
 
@@ -87,7 +91,9 @@ Guard behavior:
 - Fails if `packages/colonizethis_logic/test/**` imports `package:colonizethis_ai/...`.
 - Fails if `app/lib/**` contains direct `assets/...` or `packages/<pkg>/assets/...` string literals outside `app/lib/config/app_assets.dart`.
 - Fails if executable `StringLiteral` AST nodes equal to canonical tech IDs appear outside allowlisted tech declaration/config files and approved fixture/test-data paths.
+- Fails if executable `StringLiteral` AST nodes equal to canonical work target IDs appear outside `packages/colonizethis_logic/lib/src/constants.dart`, approved fixture/test-data paths, and an explicit temporary allowlist for generated/legacy surfaces pending migration.
 - In PR CI, the tech-ID guard may scan only changed Dart files for faster feedback; if PR diff context is unavailable, it falls back to a full repository scan with the same violation rules.
+- In PR CI, the work-target guard may scan only changed Dart files for faster feedback; if PR diff context is unavailable, it falls back to a full repository scan with the same violation rules.
 
 Asset-path guard remediation:
 

--- a/app/lib/features/game/flame/game_map_area_state_logic.dart
+++ b/app/lib/features/game/flame/game_map_area_state_logic.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
 import 'package:colonizethis_map/colonizethis_map.dart';
 
@@ -12,9 +13,9 @@ class GameMapAreaStateLogic {
   }
 
   static bool isWorkTargetTileProvinceBased(String workTarget) {
-    return workTarget == 'explore' ||
-        workTarget == 'steal_tech' ||
-        workTarget == 'counter_spy';
+    return workTarget == kWorkTargetExplore ||
+        workTarget == kWorkTargetStealTech ||
+        workTarget == kWorkTargetCounterSpy;
   }
 
   /// For province-based work targets, translate the tile key to a canonical tile

--- a/app/lib/features/game/widgets/province_panel_labels.dart
+++ b/app/lib/features/game/widgets/province_panel_labels.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_models/colonizethis_models.dart' show UnitStatus;
+import 'package:colonizethis_logic/colonizethis_logic.dart';
 
 import '../../../l10n/app_localizations.dart';
 
@@ -60,17 +61,17 @@ String shipTypeDisplayLabel(AppLocalizations l10n, String shipTypeId) {
 /// Localized work-order target string for province Civilian lines.
 String workOrderTargetDisplayLabel(AppLocalizations l10n, String target) {
   return switch (target) {
-    'explore' => l10n.province_workOrder_explore,
-    'prospect' => l10n.province_workOrder_prospect,
-    'build_improvement' => l10n.province_workOrder_build_improvement,
-    'upgrade_town' => l10n.province_workOrder_upgrade_town,
-    'build_road' => l10n.province_workOrder_build_road,
-    'build_port' => l10n.province_workOrder_build_port,
-    'build_fort' => l10n.province_workOrder_build_fort,
-    'build_rail' => l10n.province_workOrder_build_rail,
-    'steal_tech' => l10n.province_workOrder_steal_tech,
-    'counter_spy' => l10n.province_workOrder_counter_spy,
-    'purchase_land' => l10n.province_workOrder_purchase_land,
+    kWorkTargetExplore => l10n.province_workOrder_explore,
+    kWorkTargetProspect => l10n.province_workOrder_prospect,
+    kWorkTargetBuildImprovement => l10n.province_workOrder_build_improvement,
+    kWorkTargetUpgradeTown => l10n.province_workOrder_upgrade_town,
+    kWorkTargetBuildRoad => l10n.province_workOrder_build_road,
+    kWorkTargetBuildPort => l10n.province_workOrder_build_port,
+    kWorkTargetBuildFort => l10n.province_workOrder_build_fort,
+    kWorkTargetBuildRail => l10n.province_workOrder_build_rail,
+    kWorkTargetStealTech => l10n.province_workOrder_steal_tech,
+    kWorkTargetCounterSpy => l10n.province_workOrder_counter_spy,
+    kWorkTargetPurchaseLand => l10n.province_workOrder_purchase_land,
     _ => target,
   };
 }

--- a/packages/colonizethis_ai/lib/src/domain_planners.dart
+++ b/packages/colonizethis_ai/lib/src/domain_planners.dart
@@ -48,7 +48,8 @@ Orders runDomainPlanners({
     orders,
   );
   final hasSpyWork = workCandidates.any(
-    (o) => o.target == 'steal_tech' || o.target == 'counter_spy',
+    (o) =>
+        o.target == kWorkTargetStealTech || o.target == kWorkTargetCounterSpy,
   );
   final workThreshold =
       40 - (hasSpyWork ? agendaSpyOrderModifier(config.hiddenAgendaId) : 0);
@@ -64,7 +65,9 @@ Orders runDomainPlanners({
     final pickFrom = (agendaId == 'tech_thief' && hasSpyWork)
         ? workCandidates
               .where(
-                (o) => o.target == 'steal_tech' || o.target == 'counter_spy',
+                (o) =>
+                    o.target == kWorkTargetStealTech ||
+                    o.target == kWorkTargetCounterSpy,
               )
               .toList()
         : workCandidates;

--- a/packages/colonizethis_logic/lib/ai_api.dart
+++ b/packages/colonizethis_logic/lib/ai_api.dart
@@ -6,7 +6,8 @@ library;
 
 export 'src/ai/ai_control.dart' show isAiControlled;
 export 'src/ai/simple_ai_heuristics.dart' show turnSeedForPlayer;
-export 'src/constants.dart' show GamePlayerLookup;
+export 'src/constants.dart'
+    show GamePlayerLookup, kWorkTargetCounterSpy, kWorkTargetStealTech;
 export 'src/diplomacy/diplomacy_relation_lookup.dart'
     show
         getRelation,

--- a/packages/colonizethis_logic/lib/src/orders/orders_application_work_phase.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_work_phase.dart
@@ -118,7 +118,7 @@ void _runWorkPhase(
                 return totalTurnsForWork(target, fortLevel: fortLevel);
               },
             );
-          case 'build_rail':
+          case kWorkTargetBuildRail:
             return (
               target: target,
               allowedForUnitType: (t) =>
@@ -367,7 +367,7 @@ void _runWorkPhase(
         }
         if (applyStandardWorkOrder(kWorkTargetBuildFort)) continue;
       }
-      if (workTarget == 'build_rail') {
+      if (workTarget == kWorkTargetBuildRail) {
         final terrain = terrainTypeForTileKey(
           state.tileMapByRegion,
           targetTileKey,
@@ -381,7 +381,7 @@ void _runWorkPhase(
           _log.d('build_rail skipped - $railReason');
           continue;
         }
-        if (applyStandardWorkOrder('build_rail')) continue;
+        if (applyStandardWorkOrder(kWorkTargetBuildRail)) continue;
       }
       if (workTarget == kWorkTargetUpgradeTown) {
         if (applyStandardWorkOrder(kWorkTargetUpgradeTown)) continue;

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
@@ -172,7 +172,7 @@ class WorkOrderValidator extends OrderValidator {
               );
             }
           }
-          if (o.target == 'build_rail') {
+          if (o.target == kWorkTargetBuildRail) {
             final terrain = terrainTypeForTileKey(
               _context.tileMapByRegion,
               o.targetTileKey,

--- a/test/check_work_target_constants_test.dart
+++ b/test/check_work_target_constants_test.dart
@@ -1,0 +1,95 @@
+import 'package:test/test.dart';
+
+import '../tool/check_work_target_constants.dart';
+
+void main() {
+  const canonicalWorkTargets = <String>{'explore', 'prospect', 'steal_tech'};
+  const constantNameByWorkTarget = <String, String>{
+    'explore': 'kWorkTargetExplore',
+    'prospect': 'kWorkTargetProspect',
+    'steal_tech': 'kWorkTargetStealTech',
+  };
+
+  group('findWorkTargetConstantViolations', () {
+    test('flags executable raw work target string literal', () {
+      const src = r'''
+void f() {
+  const target = 'explore';
+  print(target);
+}
+''';
+      final violations = findWorkTargetConstantViolations(
+        relativePath: 'packages/foo/lib/x.dart',
+        source: src,
+        canonicalWorkTargets: canonicalWorkTargets,
+        constantNameByWorkTarget: constantNameByWorkTarget,
+      );
+      expect(violations, isNotEmpty);
+      expect(violations.first.message, contains('kWorkTargetExplore'));
+      expect(violations.first.line, greaterThan(0));
+      expect(violations.first.column, greaterThan(0));
+    });
+
+    test('allows non-canonical literal', () {
+      const src = r'''
+void f() {
+  const target = 'not_a_work_target';
+  print(target);
+}
+''';
+      final violations = findWorkTargetConstantViolations(
+        relativePath: 'packages/foo/lib/x.dart',
+        source: src,
+        canonicalWorkTargets: canonicalWorkTargets,
+        constantNameByWorkTarget: constantNameByWorkTarget,
+      );
+      expect(violations, isEmpty);
+    });
+
+    test('does not flag top-level constant declarations', () {
+      const src = r'''
+const String kDemo = 'explore';
+void f() {}
+''';
+      final violations = findWorkTargetConstantViolations(
+        relativePath: 'packages/foo/lib/x.dart',
+        source: src,
+        canonicalWorkTargets: canonicalWorkTargets,
+        constantNameByWorkTarget: constantNameByWorkTarget,
+      );
+      expect(violations, isEmpty);
+    });
+
+    test('skips generated file paths', () {
+      const src = r'''
+void f() {
+  final target = 'prospect';
+  print(target);
+}
+''';
+      final violations = findWorkTargetConstantViolations(
+        relativePath: 'packages/foo/lib/x.g.dart',
+        source: src,
+        canonicalWorkTargets: canonicalWorkTargets,
+        constantNameByWorkTarget: constantNameByWorkTarget,
+      );
+      expect(violations, isEmpty);
+    });
+
+    test('skips test-data fixture directories', () {
+      const src = r'''
+void f() {
+  final target = 'steal_tech';
+  print(target);
+}
+''';
+      final violations = findWorkTargetConstantViolations(
+        relativePath: 'packages/foo/lib/test_data/sample.dart',
+        source: src,
+        canonicalWorkTargets: canonicalWorkTargets,
+        constantNameByWorkTarget: constantNameByWorkTarget,
+      );
+      expect(violations, isEmpty);
+    });
+  });
+}

--- a/tool/check_work_target_constants.dart
+++ b/tool/check_work_target_constants.dart
@@ -1,0 +1,350 @@
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:path/path.dart' as p;
+
+const _scanRoots = <String>['app', 'ctterm', 'packages', 'tool'];
+const _argFiles = '--files';
+
+const _workTargetConstantsRelPath =
+    'packages/colonizethis_logic/lib/src/constants.dart';
+
+const _excludedPaths = <String>{
+  _workTargetConstantsRelPath,
+  'app/lib/l10n/app_localizations_en.dart',
+  'app/lib/widgetbook.dart',
+  'app/lib/widgetbook/catalog.dart',
+  'ctterm/lib/screens/development_screen.dart',
+  'packages/colonizethis_data/lib/src/work_order_costs.dart',
+};
+
+const _excludedDirMarkers = <String>[
+  '/test_data/',
+  '/testdata/',
+  '/fixtures/',
+  '/fixture/',
+  '/golden/',
+  '/goldens/',
+];
+
+void main(List<String> args) {
+  final parsedArgs = _parseArgs(args);
+  final root = p.normalize(Directory.current.path);
+  final canonicalWorkTargets = _loadCanonicalWorkTargets(root);
+  if (canonicalWorkTargets.isEmpty) {
+    stderr.writeln(
+      'ERROR: Could not derive canonical work target IDs from '
+      '$_workTargetConstantsRelPath.',
+    );
+    exit(1);
+  }
+  final constantNameByWorkTarget = _loadWorkTargetConstantNames(root);
+  final candidateFiles = _collectCandidateFiles(root, parsedArgs.files);
+
+  final violations = <WorkTargetConstantViolation>[];
+  for (final file in candidateFiles) {
+    final relPath = p.normalize(p.relative(file.path, from: root));
+    if (_shouldSkipFile(relPath)) {
+      continue;
+    }
+    final source = file.readAsStringSync();
+    violations.addAll(
+      findWorkTargetConstantViolations(
+        relativePath: relPath,
+        source: source,
+        canonicalWorkTargets: canonicalWorkTargets,
+        constantNameByWorkTarget: constantNameByWorkTarget,
+      ),
+    );
+  }
+
+  if (violations.isEmpty) {
+    stdout.writeln('Work target constant usage check passed.');
+    exit(0);
+  }
+
+  stderr.writeln(
+    'ERROR: Found raw work target string literals in executable code. '
+    'Use constants from colonizethis_logic.',
+  );
+  for (final violation in violations) {
+    stderr.writeln(
+      '${violation.path}:${violation.line}:${violation.column} '
+      '${violation.message}',
+    );
+  }
+  exit(1);
+}
+
+List<WorkTargetConstantViolation> findWorkTargetConstantViolations({
+  required String relativePath,
+  required String source,
+  required Set<String> canonicalWorkTargets,
+  required Map<String, String> constantNameByWorkTarget,
+}) {
+  if (!relativePath.endsWith('.dart')) {
+    return const [];
+  }
+  if (_shouldSkipFile(relativePath)) {
+    return const [];
+  }
+  final parsed = parseString(
+    content: source,
+    path: relativePath,
+    throwIfDiagnostics: false,
+  );
+  final visitor = _WorkTargetLiteralVisitor(
+    path: relativePath,
+    unit: parsed.unit,
+    canonicalWorkTargets: canonicalWorkTargets,
+    constantNameByWorkTarget: constantNameByWorkTarget,
+  );
+  parsed.unit.visitChildren(visitor);
+  return visitor.violations;
+}
+
+_ParsedArgs _parseArgs(List<String> args) {
+  String? filesArgValue;
+  for (var i = 0; i < args.length; i++) {
+    final arg = args[i];
+    if (arg == _argFiles) {
+      if (i + 1 >= args.length) {
+        stderr.writeln('ERROR: Missing value for $_argFiles.');
+        exit(2);
+      }
+      filesArgValue = args[i + 1];
+      i++;
+      continue;
+    }
+    if (arg.startsWith('$_argFiles=')) {
+      filesArgValue = arg.substring('$_argFiles='.length);
+      continue;
+    }
+    stderr.writeln(
+      'ERROR: Unsupported argument "$arg". Supported: $_argFiles '
+      '(comma-separated or newline-separated relative paths).',
+    );
+    exit(2);
+  }
+  return _ParsedArgs(
+    files: filesArgValue == null ? const [] : _splitFileArg(filesArgValue),
+  );
+}
+
+List<String> _splitFileArg(String value) {
+  if (value.trim().isEmpty) {
+    return const [];
+  }
+  final normalized = value.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+  return normalized
+      .split(RegExp('[,\n]'))
+      .map((entry) => entry.trim())
+      .where((entry) => entry.isNotEmpty)
+      .toList(growable: false);
+}
+
+List<File> _collectCandidateFiles(String root, List<String> requestedPaths) {
+  if (requestedPaths.isEmpty) {
+    final files = <File>[];
+    for (final relRoot in _scanRoots) {
+      final absRoot = p.join(root, relRoot);
+      final dir = Directory(absRoot);
+      if (!dir.existsSync()) {
+        continue;
+      }
+      for (final entity in dir.listSync(recursive: true, followLinks: false)) {
+        if (entity is File && entity.path.endsWith('.dart')) {
+          files.add(entity);
+        }
+      }
+    }
+    return files;
+  }
+
+  final files = <File>[];
+  for (final relPath in requestedPaths) {
+    if (!relPath.endsWith('.dart')) {
+      continue;
+    }
+    final normalizedRelPath = p.normalize(relPath);
+    if (!_isInScanRoots(normalizedRelPath)) {
+      continue;
+    }
+    final file = File(p.join(root, normalizedRelPath));
+    if (file.existsSync()) {
+      files.add(file);
+    }
+  }
+  return files;
+}
+
+bool _isInScanRoots(String relPath) {
+  final normalized = relPath.replaceAll('\\', '/');
+  for (final root in _scanRoots) {
+    if (normalized == root || normalized.startsWith('$root/')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool _shouldSkipFile(String relPath) {
+  final normalized = '/${relPath.replaceAll('\\', '/')}';
+  if (!normalized.contains('/lib/')) {
+    return true;
+  }
+  if (_excludedPaths.contains(relPath)) {
+    return true;
+  }
+  if (relPath.endsWith('.g.dart') ||
+      relPath.endsWith('.freezed.dart') ||
+      relPath.endsWith('.mocks.dart') ||
+      relPath.endsWith('.gen.dart')) {
+    return true;
+  }
+  for (final marker in _excludedDirMarkers) {
+    if (normalized.contains(marker)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+Set<String> _loadCanonicalWorkTargets(String root) {
+  final constantsAbsPath = p.join(root, _workTargetConstantsRelPath);
+  final file = File(constantsAbsPath);
+  if (!file.existsSync()) {
+    return const {};
+  }
+  final source = file.readAsStringSync();
+  final parsed = parseString(
+    content: source,
+    path: constantsAbsPath,
+    throwIfDiagnostics: false,
+  );
+  final collector = _WorkTargetConstantCollector();
+  parsed.unit.visitChildren(collector);
+  return collector.constantNameByWorkTarget.keys.toSet();
+}
+
+Map<String, String> _loadWorkTargetConstantNames(String root) {
+  final constantsAbsPath = p.join(root, _workTargetConstantsRelPath);
+  final file = File(constantsAbsPath);
+  if (!file.existsSync()) {
+    return const {};
+  }
+  final source = file.readAsStringSync();
+  final parsed = parseString(
+    content: source,
+    path: constantsAbsPath,
+    throwIfDiagnostics: false,
+  );
+  final collector = _WorkTargetConstantCollector();
+  parsed.unit.visitChildren(collector);
+  return collector.constantNameByWorkTarget;
+}
+
+class _WorkTargetConstantCollector extends RecursiveAstVisitor<void> {
+  final Map<String, String> constantNameByWorkTarget = <String, String>{};
+
+  @override
+  void visitTopLevelVariableDeclaration(TopLevelVariableDeclaration node) {
+    for (final variable in node.variables.variables) {
+      final initializer = variable.initializer;
+      if (initializer is! SimpleStringLiteral) {
+        continue;
+      }
+      if (initializer.value.isEmpty) {
+        continue;
+      }
+      final variableName = variable.name.lexeme;
+      if (!variableName.startsWith('kWorkTarget')) {
+        continue;
+      }
+      constantNameByWorkTarget[initializer.value] = variableName;
+    }
+    super.visitTopLevelVariableDeclaration(node);
+  }
+}
+
+class _WorkTargetLiteralVisitor extends RecursiveAstVisitor<void> {
+  _WorkTargetLiteralVisitor({
+    required this.path,
+    required this.unit,
+    required this.canonicalWorkTargets,
+    required this.constantNameByWorkTarget,
+  });
+
+  final String path;
+  final CompilationUnit unit;
+  final Set<String> canonicalWorkTargets;
+  final Map<String, String> constantNameByWorkTarget;
+  final List<WorkTargetConstantViolation> violations =
+      <WorkTargetConstantViolation>[];
+
+  @override
+  void visitSimpleStringLiteral(SimpleStringLiteral node) {
+    if (!_isExecutableLiteral(node)) {
+      return;
+    }
+    final value = node.value;
+    if (!canonicalWorkTargets.contains(value)) {
+      return;
+    }
+    final location = unit.lineInfo.getLocation(node.offset);
+    final suggestedConstant = constantNameByWorkTarget[value];
+    final suggestion = suggestedConstant == null
+        ? 'Use a kWorkTarget* constant from colonizethis_logic.'
+        : 'Use $suggestedConstant from colonizethis_logic.';
+    violations.add(
+      WorkTargetConstantViolation(
+        path: path,
+        line: location.lineNumber,
+        column: location.columnNumber,
+        message: 'raw work target literal "$value". $suggestion',
+      ),
+    );
+  }
+
+  bool _isExecutableLiteral(AstNode node) {
+    AstNode? cursor = node.parent;
+    while (cursor != null) {
+      if (cursor is Annotation || cursor is Comment) {
+        return false;
+      }
+      if (cursor is FunctionBody) {
+        return true;
+      }
+      if (cursor is ConstructorInitializer) {
+        return true;
+      }
+      if (cursor is TopLevelVariableDeclaration || cursor is FieldDeclaration) {
+        return false;
+      }
+      cursor = cursor.parent;
+    }
+    return false;
+  }
+}
+
+class WorkTargetConstantViolation {
+  const WorkTargetConstantViolation({
+    required this.path,
+    required this.line,
+    required this.column,
+    required this.message,
+  });
+
+  final String path;
+  final int line;
+  final int column;
+  final String message;
+}
+
+class _ParsedArgs {
+  const _ParsedArgs({required this.files});
+
+  final List<String> files;
+}

--- a/tool/check_work_target_constants.sh
+++ b/tool/check_work_target_constants.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Enforce work target constant usage policy in executable Dart code.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+dart run tool/check_work_target_constants.dart "$@"

--- a/tool/run_quality_gate_tests.sh
+++ b/tool/run_quality_gate_tests.sh
@@ -49,6 +49,10 @@ echo "=== App hardcoded UI string gate (AST, app/lib/** -> l10n) ==="
 dart run "$ROOT/tool/check_app_hardcoded_ui_strings.dart"
 
 echo ""
+echo "=== Work target constants convention gate ==="
+bash "$ROOT/tool/check_work_target_constants.sh"
+
+echo ""
 echo "=== Test app (Flutter) ==="
 # CI runs sharded app tests with a shared deps artifact (.github/workflows/quality.yml).
 # Locally: single process is enough; use the same flags as shards for parity.

--- a/tool/sim_scenarios/lib/order_script.dart
+++ b/tool/sim_scenarios/lib/order_script.dart
@@ -86,7 +86,7 @@ Orders parseOrderCommands(List<OrderCommand> commands, Game game) {
         // should provide targetTileKey; otherwise empty string is used.
         final workOrder = WorkOrder(
           unitId: cmd.unit ?? '',
-          target: cmd.workType ?? 'explore',
+          target: cmd.workType ?? kWorkTargetExplore,
           targetTileKey: cmd.targetTileKey ?? '',
         );
         workOrdersByPlayerId.putIfAbsent(cmd.player, () => []).add(workOrder);


### PR DESCRIPTION
## Summary
- add `tool/check_work_target_constants.dart` + `tool/check_work_target_constants.sh` to block raw executable work-target string literals and suggest `kWorkTarget*` constants
- wire a new quality workflow step with PR incremental `--files` scan and full-scan fallback, and add checker tests in `test/check_work_target_constants_test.dart`
- update `SPEC/program/repo-and-packages.md` AC/guard documentation, and migrate touched runtime callers to canonical constants where straightforward

## Scope notes
- keeps an explicit temporary allowlist for existing generated/legacy surfaces (`app` l10n/widgetbook, `ctterm` development screen, `colonizethis_data` work-order cost table) so the guard is actionable immediately while preserving current behavior

## Test plan
- [x] `dart test test/check_work_target_constants_test.dart --reporter=compact`
- [x] `bash tool/check_work_target_constants.sh`
- [x] `dart test packages/colonizethis_logic/test/order_engine_validate_work_build_rail_test.dart --reporter=compact`
- [x] `dart test packages/colonizethis_ai/test/domain_planners_test.dart --reporter=compact`

Refs #1644

Made with [Cursor](https://cursor.com)