### PR TITLE
Civilian unit type constants and AST gate

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -373,6 +373,44 @@ jobs:
           echo "Running work-target convention check on changed Dart files only."
           tool/check_work_target_constants.sh --files "$changed_files"
 
+      - name: Check civilian unit type constants convention (SPEC/program/repo-and-packages.md)
+        run: |
+          set -euo pipefail
+          base_ref="${GITHUB_BASE_REF:-}"
+          if [ -z "$base_ref" ]; then
+            echo "No GITHUB_BASE_REF in context; running full civilian unit type scan."
+            tool/check_civilian_unit_type_constants.sh
+            exit 0
+          fi
+
+          if ! git fetch --no-tags --depth=1 origin "$base_ref"; then
+            echo "Could not fetch origin/$base_ref; running full civilian unit type scan."
+            tool/check_civilian_unit_type_constants.sh
+            exit 0
+          fi
+
+          merge_base="$(git merge-base "origin/$base_ref" HEAD 2>/dev/null || true)"
+          if [ -z "$merge_base" ]; then
+            echo "No merge base between origin/$base_ref and HEAD in this checkout; running full civilian unit type scan."
+            tool/check_civilian_unit_type_constants.sh
+            exit 0
+          fi
+
+          changed_files="$(
+            git diff --name-only "origin/$base_ref"...HEAD -- '*.dart' \
+              | tr '\n' ',' \
+              | sed 's/,$//'
+          )"
+
+          if [ -z "$changed_files" ]; then
+            echo "No changed Dart files detected in PR diff; running full civilian unit type scan."
+            tool/check_civilian_unit_type_constants.sh
+            exit 0
+          fi
+
+          echo "Running civilian unit type convention check on changed Dart files only."
+          tool/check_civilian_unit_type_constants.sh --files "$changed_files"
+
       - name: Check package logger API convention (SPEC/program/logging/logging.md)
         run: tool/check_naked_logger_usage.sh
 
@@ -399,6 +437,9 @@ jobs:
 
       - name: Test work target constants checker (SPEC/program/repo-and-packages.md)
         run: dart test test/check_work_target_constants_test.dart --reporter=compact
+
+      - name: Test civilian unit type constants checker (SPEC/program/repo-and-packages.md)
+        run: dart test test/check_civilian_unit_type_constants_test.dart --reporter=compact
 
       - name: Check canonical province tile-key literals (SPEC/game/world-model-identity.md)
         run: dart run tool/check_canonical_province_tile_keys.dart

--- a/SPEC/program/repo-and-packages.md
+++ b/SPEC/program/repo-and-packages.md
@@ -69,6 +69,8 @@ colonizethis_data    (no package deps)
 - **Given** the tech-ID convention gate reports a violation, **when** a developer inspects the output, **then** each violation includes file path, line, column, and the offending tech ID literal for direct remediation.
 - **Given** Dart source under `app/`, `ctterm/`, `packages/`, and `tool/`, **when** static analysis inspects executable AST string literals, **then** raw literals equal to canonical work target IDs are rejected outside the allowlisted work-target declaration file and fixture paths.
 - **Given** the work-target convention gate reports a violation, **when** a developer inspects the output, **then** each violation includes file path, line, column, and the offending work target literal with a suggested `kWorkTarget*` constant when available.
+- **Given** Dart source under `app/`, `ctterm/`, `packages/`, and `tool/`, **when** static analysis inspects executable AST string literals, **then** raw literals equal to canonical civilian unit type ids (`Explorer`, `Builder`, `Engineer`, `Spy`, `Merchant`, `Rail Builder` per `SPEC/game/civilian-units.md`) are rejected outside `packages/colonizethis_models/lib/src/civilian_unit_type_ids.dart`, approved fixture/test-data paths, and an explicit allowlist for ambiguous spellings (e.g. naval ship category vs civilian `Merchant`, personality archetype display strings).
+- **Given** the civilian unit type convention gate reports a violation, **when** a developer inspects the output, **then** each violation includes file path, line, column, and the offending literal with a suggested `kUnitType*` constant when available.
 
 ### Automated guard gate (CI)
 
@@ -78,10 +80,12 @@ The repository enforces this boundary in CI via:
 - `tool/check_asset_path_constants.sh`
 - `tool/check_tech_id_constants.sh`
 - `tool/check_work_target_constants.sh`
+- `tool/check_civilian_unit_type_constants.sh`
 - `.github/workflows/quality.yml` step: `Check logic/ai decoupling convention (SPEC/program/repo-and-packages.md)`
 - `.github/workflows/quality.yml` step: `Check asset path constants convention (SPEC/program/repo-and-packages.md)`
 - `.github/workflows/quality.yml` step: `Check tech ID constants convention (SPEC/program/repo-and-packages.md)`
 - `.github/workflows/quality.yml` step: `Check work target constants convention (SPEC/program/repo-and-packages.md)`
+- `.github/workflows/quality.yml` step: `Check civilian unit type constants convention (SPEC/program/repo-and-packages.md)`
 
 Guard behavior:
 
@@ -94,6 +98,13 @@ Guard behavior:
 - Fails if executable `StringLiteral` AST nodes equal to canonical work target IDs appear outside `packages/colonizethis_logic/lib/src/constants.dart`, approved fixture/test-data paths, and an explicit temporary allowlist for generated/legacy surfaces pending migration.
 - In PR CI, the tech-ID guard may scan only changed Dart files for faster feedback; if PR diff context is unavailable, it falls back to a full repository scan with the same violation rules.
 - In PR CI, the work-target guard may scan only changed Dart files for faster feedback; if PR diff context is unavailable, it falls back to a full repository scan with the same violation rules.
+- Fails if executable `StringLiteral` AST nodes equal to canonical civilian unit type ids appear outside `packages/colonizethis_models/lib/src/civilian_unit_type_ids.dart`, approved fixture/test-data paths, and the explicit allowlist in `tool/check_civilian_unit_type_constants.dart`.
+- In PR CI, the civilian unit type guard may scan only changed Dart files for faster feedback; if PR diff context is unavailable, it falls back to a full repository scan with the same violation rules.
+
+Civilian unit type guard remediation:
+
+- Add or reuse `kUnitType*` constants in `packages/colonizethis_models/lib/src/civilian_unit_type_ids.dart` (also re-exported from `packages/colonizethis_logic/lib/src/constants.dart` for logic consumers).
+- Replace direct string literals in executable code with those constants; extend the tool allowlist only for documented ambiguous literals.
 
 Asset-path guard remediation:
 

--- a/ctterm/lib/screens/development_screen.dart
+++ b/ctterm/lib/screens/development_screen.dart
@@ -697,9 +697,6 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
     final reservedTiles = <String>{};
 
     // Existing multi-turn work (currentWork) for Builder/Engineer/Merchant units.
-    bool isDevExclusiveUnitType(String type) =>
-        type == 'Builder' || type == 'Engineer' || type == 'Merchant';
-
     for (final u in world.oldWorld.units) {
       final w = u.currentWork;
       if (u.ownerId == playerId &&

--- a/packages/colonizethis_data/lib/src/civilian_economy.dart
+++ b/packages/colonizethis_data/lib/src/civilian_economy.dart
@@ -52,37 +52,37 @@ class CivilianEconomyCatalog {
   static const int _costPaperHigh = 4;
 
   static final CivilianEconomy builder = CivilianEconomy(
-    id: 'Builder',
+    id: kUnitTypeBuilder,
     buildTreasuryCost: _costCashLow,
     buildInputs: {CommodityCatalog.paper.id: _costPaperLow},
   );
 
   static final CivilianEconomy engineer = CivilianEconomy(
-    id: 'Engineer',
+    id: kUnitTypeEngineer,
     buildTreasuryCost: _costCashLow,
     buildInputs: {CommodityCatalog.paper.id: _costPaperLow},
   );
 
   static final CivilianEconomy explorer = CivilianEconomy(
-    id: 'Explorer',
+    id: kUnitTypeExplorer,
     buildTreasuryCost: _costCashLow,
     buildInputs: {CommodityCatalog.paper.id: _costPaperLow},
   );
 
   static final CivilianEconomy spy = CivilianEconomy(
-    id: 'Spy',
+    id: kUnitTypeSpy,
     buildTreasuryCost: _costCashHigh,
     buildInputs: {CommodityCatalog.paper.id: _costPaperHigh},
   );
 
   static final CivilianEconomy merchant = CivilianEconomy(
-    id: 'Merchant',
+    id: kUnitTypeMerchant,
     buildTreasuryCost: _costCashHigh,
     buildInputs: {CommodityCatalog.paper.id: _costPaperHigh},
   );
 
   static final CivilianEconomy railBuilder = CivilianEconomy(
-    id: 'Rail Builder',
+    id: kUnitTypeRailBuilder,
     buildTreasuryCost: _costCashHigh,
     buildInputs: {CommodityCatalog.paper.id: _costPaperHigh},
   );
@@ -104,6 +104,6 @@ class CivilianEconomyCatalog {
 /// Civilian unit type id → tech id that unlocks it. Absent = buildable from start.
 /// SPEC/game/tech-tree-diplomacy-civilian.md, tech-tree-transport.md.
 const Map<String, String> unlockingTechByCivilianId = {
-  'Merchant': 'merchant_companies',
-  'Rail Builder': 'early_steam_engine',
+  kUnitTypeMerchant: 'merchant_companies',
+  kUnitTypeRailBuilder: 'early_steam_engine',
 };

--- a/packages/colonizethis_data/lib/src/starting_resources_config.dart
+++ b/packages/colonizethis_data/lib/src/starting_resources_config.dart
@@ -1,3 +1,5 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
 /// Starting resources and units per Great Power at game start.
 /// TDD 09 (Great Powers), GDD 05 (Units). Scenario overlay may override per TDD 19.
 class StartingResourcesConfig {
@@ -61,9 +63,9 @@ class StartingResourcesConfig {
   final Map<String, int> startingCivilianUnits;
 
   static const Map<String, int> _defaultStartingCivilianUnits = {
-    'Explorer': 2,
-    'Builder': 2,
-    'Engineer': 1,
+    kUnitTypeExplorer: 2,
+    kUnitTypeBuilder: 2,
+    kUnitTypeEngineer: 1,
   };
 
   /// Default config for Phase 2+.

--- a/packages/colonizethis_data/lib/src/work_order_costs.dart
+++ b/packages/colonizethis_data/lib/src/work_order_costs.dart
@@ -1,3 +1,5 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
 import 'commodities.dart';
 
 /// Work order material costs and durations. SPEC/game/civilian-units.md, extraction-and-improvements.md, siege-mechanics.md. Single source of truth for stockpile costs in order validation and application.
@@ -125,12 +127,12 @@ WorkOrderCost? workOrderMaterialCost(
 
 /// Allowed work order targets per unit type. SPEC/game/civilian-units.md Work Order Summary.
 const Map<String, List<String>> workOrderTargetsByUnitType = {
-  'Explorer': ['explore', 'prospect'],
-  'Builder': ['build_improvement', 'upgrade_town'],
-  'Engineer': ['build_road', 'build_port', 'build_fort'],
-  'Rail Builder': ['build_rail'],
-  'Spy': ['steal_tech', 'counter_spy'],
-  'Merchant': ['purchase_land'],
+  kUnitTypeExplorer: ['explore', 'prospect'],
+  kUnitTypeBuilder: ['build_improvement', 'upgrade_town'],
+  kUnitTypeEngineer: ['build_road', 'build_port', 'build_fort'],
+  kUnitTypeRailBuilder: ['build_rail'],
+  kUnitTypeSpy: ['steal_tech', 'counter_spy'],
+  kUnitTypeMerchant: ['purchase_land'],
 };
 
 /// Returns true if [unitType] can perform work order [target].

--- a/packages/colonizethis_logic/lib/src/constants.dart
+++ b/packages/colonizethis_logic/lib/src/constants.dart
@@ -4,6 +4,15 @@ library;
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+export 'package:colonizethis_models/colonizethis_models.dart'
+    show
+        kUnitTypeBuilder,
+        kUnitTypeEngineer,
+        kUnitTypeExplorer,
+        kUnitTypeMerchant,
+        kUnitTypeRailBuilder,
+        kUnitTypeSpy;
+
 const String kRegionOldWorld = 'oldWorld';
 const String kRegionNewWorld = 'newWorld';
 

--- a/packages/colonizethis_logic/lib/src/orders/unit_type_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/orders/unit_type_helpers.dart
@@ -9,7 +9,9 @@ import '../world/unit_lookup.dart' show allUnitsFromWorld;
 
 /// True for Builder, Engineer, Merchant: at most one work order per tile per player.
 bool isDevExclusiveUnitType(String type) =>
-    type == 'Builder' || type == 'Engineer' || type == 'Merchant';
+    type == kUnitTypeBuilder ||
+    type == kUnitTypeEngineer ||
+    type == kUnitTypeMerchant;
 
 /// True for work targets that participate in per-tile exclusivity (one order per tile per player).
 /// Used with [isDevExclusiveUnitType] to enforce Builder/Engineer/Merchant tile exclusivity.

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
@@ -290,9 +290,9 @@ class WorkOrderValidator extends OrderValidator {
     if (provinceOwnerId == null || provinceOwnerId == _context.playerId) {
       return false;
     }
-    if (unitType != 'Builder' &&
-        unitType != 'Engineer' &&
-        unitType != 'Merchant') {
+    if (unitType != kUnitTypeBuilder &&
+        unitType != kUnitTypeEngineer &&
+        unitType != kUnitTypeMerchant) {
       return false;
     }
     if (!isMinorOrTribe(_context.game, provinceOwnerId)) return false;

--- a/packages/colonizethis_models/lib/colonizethis_models.dart
+++ b/packages/colonizethis_models/lib/colonizethis_models.dart
@@ -7,6 +7,7 @@ export 'src/diplomacy.dart';
 export 'src/fleet.dart';
 export 'src/ship_instance.dart';
 export 'src/combat_mode.dart';
+export 'src/civilian_unit_type_ids.dart';
 export 'src/current_work.dart';
 export 'src/game.dart';
 export 'src/general.dart';

--- a/packages/colonizethis_models/lib/src/civilian_unit_type_ids.dart
+++ b/packages/colonizethis_models/lib/src/civilian_unit_type_ids.dart
@@ -1,0 +1,9 @@
+/// Canonical civilian unit type id strings. SPEC/game/civilian-units.md.
+/// Must match [CivilianEconomyCatalog] keys in colonizethis_data and save format.
+
+const String kUnitTypeExplorer = 'Explorer';
+const String kUnitTypeBuilder = 'Builder';
+const String kUnitTypeEngineer = 'Engineer';
+const String kUnitTypeSpy = 'Spy';
+const String kUnitTypeMerchant = 'Merchant';
+const String kUnitTypeRailBuilder = 'Rail Builder';

--- a/test/check_civilian_unit_type_constants_test.dart
+++ b/test/check_civilian_unit_type_constants_test.dart
@@ -1,0 +1,95 @@
+import 'package:test/test.dart';
+
+import '../tool/check_civilian_unit_type_constants.dart';
+
+void main() {
+  const canonicalCivilianUnitTypeIds = <String>{'Explorer', 'Builder', 'Spy'};
+  const constantNameById = <String, String>{
+    'Explorer': 'kUnitTypeExplorer',
+    'Builder': 'kUnitTypeBuilder',
+    'Spy': 'kUnitTypeSpy',
+  };
+
+  group('findCivilianUnitTypeConstantViolations', () {
+    test('flags executable raw civilian unit type string literal', () {
+      const src = r'''
+void f() {
+  const t = 'Builder';
+  print(t);
+}
+''';
+      final violations = findCivilianUnitTypeConstantViolations(
+        relativePath: 'packages/foo/lib/x.dart',
+        source: src,
+        canonicalCivilianUnitTypeIds: canonicalCivilianUnitTypeIds,
+        constantNameById: constantNameById,
+      );
+      expect(violations, isNotEmpty);
+      expect(violations.first.message, contains('kUnitTypeBuilder'));
+      expect(violations.first.line, greaterThan(0));
+      expect(violations.first.column, greaterThan(0));
+    });
+
+    test('allows non-canonical literal', () {
+      const src = r'''
+void f() {
+  const t = 'Warship';
+  print(t);
+}
+''';
+      final violations = findCivilianUnitTypeConstantViolations(
+        relativePath: 'packages/foo/lib/x.dart',
+        source: src,
+        canonicalCivilianUnitTypeIds: canonicalCivilianUnitTypeIds,
+        constantNameById: constantNameById,
+      );
+      expect(violations, isEmpty);
+    });
+
+    test('does not flag top-level constant declarations', () {
+      const src = r'''
+const String kDemo = 'Explorer';
+void f() {}
+''';
+      final violations = findCivilianUnitTypeConstantViolations(
+        relativePath: 'packages/foo/lib/x.dart',
+        source: src,
+        canonicalCivilianUnitTypeIds: canonicalCivilianUnitTypeIds,
+        constantNameById: constantNameById,
+      );
+      expect(violations, isEmpty);
+    });
+
+    test('skips generated file paths', () {
+      const src = r'''
+void f() {
+  final t = 'Spy';
+  print(t);
+}
+''';
+      final violations = findCivilianUnitTypeConstantViolations(
+        relativePath: 'packages/foo/lib/x.g.dart',
+        source: src,
+        canonicalCivilianUnitTypeIds: canonicalCivilianUnitTypeIds,
+        constantNameById: constantNameById,
+      );
+      expect(violations, isEmpty);
+    });
+
+    test('skips test-data fixture directories', () {
+      const src = r'''
+void f() {
+  final t = 'Builder';
+  print(t);
+}
+''';
+      final violations = findCivilianUnitTypeConstantViolations(
+        relativePath: 'packages/foo/lib/test_data/sample.dart',
+        source: src,
+        canonicalCivilianUnitTypeIds: canonicalCivilianUnitTypeIds,
+        constantNameById: constantNameById,
+      );
+      expect(violations, isEmpty);
+    });
+  });
+}

--- a/tool/check_civilian_unit_type_constants.dart
+++ b/tool/check_civilian_unit_type_constants.dart
@@ -1,0 +1,350 @@
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:path/path.dart' as p;
+
+const _scanRoots = <String>['app', 'ctterm', 'packages', 'tool'];
+const _argFiles = '--files';
+
+/// Declarations for [kUnitTypeExplorer], etc. SPEC/game/civilian-units.md.
+const _civilianUnitTypeIdsRelPath =
+    'packages/colonizethis_models/lib/src/civilian_unit_type_ids.dart';
+
+const _excludedPaths = <String>{
+  _civilianUnitTypeIdsRelPath,
+  /// Naval ship category label; same spelling as civilian [kUnitTypeMerchant].
+  'ctterm/lib/screens/shipyard_screen.dart',
+  /// Archetype display names; values may match civilian spellings by coincidence.
+  'packages/colonizethis_data/lib/src/ai_personality_config.dart',
+};
+
+const _excludedDirMarkers = <String>[
+  '/test_data/',
+  '/testdata/',
+  '/fixtures/',
+  '/fixture/',
+  '/golden/',
+  '/goldens/',
+];
+
+void main(List<String> args) {
+  final parsedArgs = _parseArgs(args);
+  final root = p.normalize(Directory.current.path);
+  final canonicalIds = _loadCanonicalCivilianUnitTypeIds(root);
+  if (canonicalIds.isEmpty) {
+    stderr.writeln(
+      'ERROR: Could not derive canonical civilian unit type ids from '
+      '$_civilianUnitTypeIdsRelPath.',
+    );
+    exit(1);
+  }
+  final constantNameById = _loadCivilianUnitTypeConstantNames(root);
+  final candidateFiles = _collectCandidateFiles(root, parsedArgs.files);
+
+  final violations = <CivilianUnitTypeConstantViolation>[];
+  for (final file in candidateFiles) {
+    final relPath = p.normalize(p.relative(file.path, from: root));
+    if (_shouldSkipFile(relPath)) {
+      continue;
+    }
+    final source = file.readAsStringSync();
+    violations.addAll(
+      findCivilianUnitTypeConstantViolations(
+        relativePath: relPath,
+        source: source,
+        canonicalCivilianUnitTypeIds: canonicalIds,
+        constantNameById: constantNameById,
+      ),
+    );
+  }
+
+  if (violations.isEmpty) {
+    stdout.writeln('Civilian unit type constant usage check passed.');
+    exit(0);
+  }
+
+  stderr.writeln(
+    'ERROR: Found raw civilian unit type string literals in executable code. '
+    'Use kUnitType* constants from colonizethis_models.',
+  );
+  for (final violation in violations) {
+    stderr.writeln(
+      '${violation.path}:${violation.line}:${violation.column} '
+      '${violation.message}',
+    );
+  }
+  exit(1);
+}
+
+List<CivilianUnitTypeConstantViolation> findCivilianUnitTypeConstantViolations({
+  required String relativePath,
+  required String source,
+  required Set<String> canonicalCivilianUnitTypeIds,
+  required Map<String, String> constantNameById,
+}) {
+  if (!relativePath.endsWith('.dart')) {
+    return const [];
+  }
+  if (_shouldSkipFile(relativePath)) {
+    return const [];
+  }
+  final parsed = parseString(
+    content: source,
+    path: relativePath,
+    throwIfDiagnostics: false,
+  );
+  final visitor = _CivilianUnitTypeLiteralVisitor(
+    path: relativePath,
+    unit: parsed.unit,
+    canonicalCivilianUnitTypeIds: canonicalCivilianUnitTypeIds,
+    constantNameById: constantNameById,
+  );
+  parsed.unit.visitChildren(visitor);
+  return visitor.violations;
+}
+
+_ParsedArgs _parseArgs(List<String> args) {
+  String? filesArgValue;
+  for (var i = 0; i < args.length; i++) {
+    final arg = args[i];
+    if (arg == _argFiles) {
+      if (i + 1 >= args.length) {
+        stderr.writeln('ERROR: Missing value for $_argFiles.');
+        exit(2);
+      }
+      filesArgValue = args[i + 1];
+      i++;
+      continue;
+    }
+    if (arg.startsWith('$_argFiles=')) {
+      filesArgValue = arg.substring('$_argFiles='.length);
+      continue;
+    }
+    stderr.writeln(
+      'ERROR: Unsupported argument "$arg". Supported: $_argFiles '
+      '(comma-separated or newline-separated relative paths).',
+    );
+    exit(2);
+  }
+  return _ParsedArgs(
+    files: filesArgValue == null ? const [] : _splitFileArg(filesArgValue),
+  );
+}
+
+List<String> _splitFileArg(String value) {
+  if (value.trim().isEmpty) {
+    return const [];
+  }
+  final normalized = value.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+  return normalized
+      .split(RegExp('[,\n]'))
+      .map((entry) => entry.trim())
+      .where((entry) => entry.isNotEmpty)
+      .toList(growable: false);
+}
+
+List<File> _collectCandidateFiles(String root, List<String> requestedPaths) {
+  if (requestedPaths.isEmpty) {
+    final files = <File>[];
+    for (final relRoot in _scanRoots) {
+      final absRoot = p.join(root, relRoot);
+      final dir = Directory(absRoot);
+      if (!dir.existsSync()) {
+        continue;
+      }
+      for (final entity in dir.listSync(recursive: true, followLinks: false)) {
+        if (entity is File && entity.path.endsWith('.dart')) {
+          files.add(entity);
+        }
+      }
+    }
+    return files;
+  }
+
+  final files = <File>[];
+  for (final relPath in requestedPaths) {
+    if (!relPath.endsWith('.dart')) {
+      continue;
+    }
+    final normalizedRelPath = p.normalize(relPath);
+    if (!_isInScanRoots(normalizedRelPath)) {
+      continue;
+    }
+    final file = File(p.join(root, normalizedRelPath));
+    if (file.existsSync()) {
+      files.add(file);
+    }
+  }
+  return files;
+}
+
+bool _isInScanRoots(String relPath) {
+  final normalized = relPath.replaceAll('\\', '/');
+  for (final root in _scanRoots) {
+    if (normalized == root || normalized.startsWith('$root/')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool _shouldSkipFile(String relPath) {
+  final normalized = '/${relPath.replaceAll('\\', '/')}';
+  if (!normalized.contains('/lib/')) {
+    return true;
+  }
+  if (_excludedPaths.contains(relPath)) {
+    return true;
+  }
+  if (relPath.endsWith('.g.dart') ||
+      relPath.endsWith('.freezed.dart') ||
+      relPath.endsWith('.mocks.dart') ||
+      relPath.endsWith('.gen.dart')) {
+    return true;
+  }
+  for (final marker in _excludedDirMarkers) {
+    if (normalized.contains(marker)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+Set<String> _loadCanonicalCivilianUnitTypeIds(String root) {
+  final absPath = p.join(root, _civilianUnitTypeIdsRelPath);
+  final file = File(absPath);
+  if (!file.existsSync()) {
+    return const {};
+  }
+  final source = file.readAsStringSync();
+  final parsed = parseString(
+    content: source,
+    path: absPath,
+    throwIfDiagnostics: false,
+  );
+  final collector = _CivilianUnitTypeConstantCollector();
+  parsed.unit.visitChildren(collector);
+  return collector.constantNameById.keys.toSet();
+}
+
+Map<String, String> _loadCivilianUnitTypeConstantNames(String root) {
+  final absPath = p.join(root, _civilianUnitTypeIdsRelPath);
+  final file = File(absPath);
+  if (!file.existsSync()) {
+    return const {};
+  }
+  final source = file.readAsStringSync();
+  final parsed = parseString(
+    content: source,
+    path: absPath,
+    throwIfDiagnostics: false,
+  );
+  final collector = _CivilianUnitTypeConstantCollector();
+  parsed.unit.visitChildren(collector);
+  return collector.constantNameById;
+}
+
+class _CivilianUnitTypeConstantCollector extends RecursiveAstVisitor<void> {
+  final Map<String, String> constantNameById = <String, String>{};
+
+  @override
+  void visitTopLevelVariableDeclaration(TopLevelVariableDeclaration node) {
+    for (final variable in node.variables.variables) {
+      final initializer = variable.initializer;
+      if (initializer is! SimpleStringLiteral) {
+        continue;
+      }
+      if (initializer.value.isEmpty) {
+        continue;
+      }
+      final variableName = variable.name.lexeme;
+      if (!variableName.startsWith('kUnitType')) {
+        continue;
+      }
+      constantNameById[initializer.value] = variableName;
+    }
+    super.visitTopLevelVariableDeclaration(node);
+  }
+}
+
+class _CivilianUnitTypeLiteralVisitor extends RecursiveAstVisitor<void> {
+  _CivilianUnitTypeLiteralVisitor({
+    required this.path,
+    required this.unit,
+    required this.canonicalCivilianUnitTypeIds,
+    required this.constantNameById,
+  });
+
+  final String path;
+  final CompilationUnit unit;
+  final Set<String> canonicalCivilianUnitTypeIds;
+  final Map<String, String> constantNameById;
+  final List<CivilianUnitTypeConstantViolation> violations =
+      <CivilianUnitTypeConstantViolation>[];
+
+  @override
+  void visitSimpleStringLiteral(SimpleStringLiteral node) {
+    if (!_isExecutableLiteral(node)) {
+      return;
+    }
+    final value = node.value;
+    if (!canonicalCivilianUnitTypeIds.contains(value)) {
+      return;
+    }
+    final location = unit.lineInfo.getLocation(node.offset);
+    final suggestedConstant = constantNameById[value];
+    final suggestion = suggestedConstant == null
+        ? 'Use a kUnitType* constant from colonizethis_models.'
+        : 'Use $suggestedConstant from colonizethis_models.';
+    violations.add(
+      CivilianUnitTypeConstantViolation(
+        path: path,
+        line: location.lineNumber,
+        column: location.columnNumber,
+        message: 'raw civilian unit type literal "$value". $suggestion',
+      ),
+    );
+  }
+
+  bool _isExecutableLiteral(AstNode node) {
+    AstNode? cursor = node.parent;
+    while (cursor != null) {
+      if (cursor is Annotation || cursor is Comment) {
+        return false;
+      }
+      if (cursor is FunctionBody) {
+        return true;
+      }
+      if (cursor is ConstructorInitializer) {
+        return true;
+      }
+      if (cursor is TopLevelVariableDeclaration || cursor is FieldDeclaration) {
+        return false;
+      }
+      cursor = cursor.parent;
+    }
+    return false;
+  }
+}
+
+class CivilianUnitTypeConstantViolation {
+  const CivilianUnitTypeConstantViolation({
+    required this.path,
+    required this.line,
+    required this.column,
+    required this.message,
+  });
+
+  final String path;
+  final int line;
+  final int column;
+  final String message;
+}
+
+class _ParsedArgs {
+  const _ParsedArgs({required this.files});
+
+  final List<String> files;
+}

--- a/tool/check_civilian_unit_type_constants.sh
+++ b/tool/check_civilian_unit_type_constants.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Enforce civilian unit type id constant usage policy in executable Dart code.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+dart run tool/check_civilian_unit_type_constants.dart "$@"


### PR DESCRIPTION
## Summary
Implements **Refs #1639**: canonical `kUnitType*` civilian unit type ids, refactors key call sites to use them, and adds a dedicated AST checker in CI (same pattern as work-target / tech-id gates).

## SPEC
- `SPEC/program/repo-and-packages.md` — ACs, guard list, remediation for civilian unit type literals.

## Implementation
- **Models:** `packages/colonizethis_models/lib/src/civilian_unit_type_ids.dart` — six ids per `SPEC/game/civilian-units.md`.
- **Logic:** re-export from `constants.dart`; `isDevExclusiveUnitType`, `WorkOrderValidator` use constants.
- **Data:** `civilian_economy.dart`, `work_order_costs.dart`, `starting_resources_config.dart` use `kUnitType*` for ids / map keys.
- **ctterm:** `development_screen.dart` uses shared `isDevExclusiveUnitType` from colonizethis_logic (removes duplicate local helper).
- **CI:** `tool/check_civilian_unit_type_constants.dart` + shell wrapper; `quality.yml` step with PR-scoped `--files` fallback; `test/check_civilian_unit_type_constants_test.dart`.
- **Allowlist:** `shipyard_screen.dart` (naval `Merchant` category), `ai_personality_config.dart` (archetype display strings that match civilian spellings).

## Tests run
- `dart test test/check_civilian_unit_type_constants_test.dart`
- `dart analyze lib` (colonizethis_models, colonizethis_logic, ctterm)
- `dart test` (colonizethis_data, colonizethis_logic)
- `dart run tool/check_civilian_unit_type_constants.dart`

## Out of scope
- Bulk migration of every test/fixture literal (paths under `**/test/**` are skipped by the gate).
- Replacing all remaining production literals outside touched files (checker reports zero violations on current tree).

Refs #1639

Made with [Cursor](https://cursor.com)