### PR TITLE
Repo lint Phase 2: shared domain scan contract (Refs #1730)

### DIFF
--- a/SPEC/program/disallowed-ast-patterns.md
+++ b/SPEC/program/disallowed-ast-patterns.md
@@ -19,7 +19,7 @@ Rationale: `clear()` returns `void`; the cascade form suggests chaining a result
 
 ### Coverage
 
-Enforcement uses the same runtime roots as `SPEC/program/exception-enforcement.md`:
+Enforcement walks the same domain trees via `tool/ct_repo_lint_scan_contract.dart` (`collectRepoLintDomainDartFiles`), aligned with `SPEC/program/exception-enforcement.md` coverage:
 
 - `packages/**/lib/**`
 - `app/lib/**`

--- a/SPEC/program/exception-enforcement.md
+++ b/SPEC/program/exception-enforcement.md
@@ -40,7 +40,7 @@ Generated files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`) are excluded.
 
 The repository enforces the same policy in two places (shared implementation in `packages/colonizethis_exception_lint`):
 
-1. **CI / CLI:** Quality runs `dart run tool/ct_repo_lint.dart` (rule `repo.custom_exceptions`; see [repo-lint.md](repo-lint.md)), which invokes `tool/check_custom_exceptions.dart`. Direct run: `dart run tool/check_custom_exceptions.dart` (also `melos run check_custom_exceptions`). Scans runtime domain files under the roots listed in that tool.
+1. **CI / CLI:** Quality runs `dart run tool/ct_repo_lint.dart` (rule `repo.custom_exceptions`; see [repo-lint.md](repo-lint.md)), which invokes `tool/check_custom_exceptions.dart`. Direct run: `dart run tool/check_custom_exceptions.dart` (also `melos run check_custom_exceptions`). File discovery uses `tool/ct_repo_lint_scan_contract.dart` (`collectRepoLintDomainDartFiles`), same as the disallowed-AST checker.
 2. **IDE / analyzer:** `custom_lint` with package `colonizethis_exception_lint`, wired in every workspace package that contains scoped runtime `lib/` code (see each package `pubspec.yaml` + `analysis_options.yaml`). Run locally per package via `dart run custom_lint`, or `bash tool/run_custom_lint_domain_exceptions.sh` for all wired packages. CI runs the same script after the root checker.
 
 The checker:

--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -9,6 +9,7 @@
 | `tool/ct_repo_lint_manifest.yaml` | Lists **rules** with stable **`rule_id`**, **group**, human title, SPEC path, and how to invoke the checker |
 | `tool/ct_repo_lint.dart` | Orchestrator: loads manifest, runs rules in order, stops on first failure |
 | `tool/ct_repo_lint_lib.dart` | Parse/execute helpers (also covered by `test/ct_repo_lint_test.dart`) |
+| `tool/ct_repo_lint_scan_contract.dart` | **Shared domain scan contract:** roots, test/generated filters, and `collectRepoLintDomainDartFiles` for AST checkers that share the exception-enforcement coverage shape (`test/ct_repo_lint_scan_contract_test.dart`) |
 
 ## Rule IDs and groups
 
@@ -29,7 +30,8 @@ Do **not** add new top-level `tool/check_*.dart` **entrypoints** for CI without 
 
 1. Add a row under `rules:` in `tool/ct_repo_lint_manifest.yaml` with a new stable `rule_id`.
 2. Implement or extend logic in a **library** or existing checker module; keep a single `main()` wrapper only if required for `dart run`, and wire it from the manifest.
-3. Align wording with `colonizethis_exception_lint` (and similar) when the same policy exists in the analyzer.
+3. When a new checker scans the **same domain `lib/` tree** as exception / disallowed-AST enforcement, reuse **`tool/ct_repo_lint_scan_contract.dart`** instead of duplicating roots and exclude predicates.
+4. Align wording with `colonizethis_exception_lint` (and similar) when the same policy exists in the analyzer.
 
 ## CLI options
 
@@ -38,7 +40,7 @@ Do **not** add new top-level `tool/check_*.dart` **entrypoints** for CI without 
 ## Follow-ups (out of scope for initial landing)
 
 - SARIF output for GitHub annotations.
-- Optional shared exclude lists applied uniformly across rules (today each checker owns excludes).
+- Extend the shared scan contract to other checkers that still duplicate roots/excludes (identifier literal checkers, canonical tile keys, etc.), or lift shared pieces into the manifest once all consumers read it.
 
 ## Acceptance criteria
 

--- a/test/ct_repo_lint_scan_contract_test.dart
+++ b/test/ct_repo_lint_scan_contract_test.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../tool/ct_repo_lint_scan_contract.dart';
+
+void main() {
+  group('repoLintPathIsExcludedTestOrGeneratedDart', () {
+    test('excludes tests and generated suffixes', () {
+      expect(repoLintPathIsExcludedTestOrGeneratedDart('a.dart'), isFalse);
+      expect(repoLintPathIsExcludedTestOrGeneratedDart('x_test.dart'), isTrue);
+      expect(
+        repoLintPathIsExcludedTestOrGeneratedDart('lib/foo_test.dart'),
+        isTrue,
+      );
+      expect(
+        repoLintPathIsExcludedTestOrGeneratedDart('packages/p/test/a.dart'),
+        isTrue,
+      );
+      expect(repoLintPathIsExcludedTestOrGeneratedDart('lib/x.g.dart'), isTrue);
+      expect(
+        repoLintPathIsExcludedTestOrGeneratedDart('lib/x.freezed.dart'),
+        isTrue,
+      );
+      expect(
+        repoLintPathIsExcludedTestOrGeneratedDart('lib/x.mocks.dart'),
+        isTrue,
+      );
+      expect(repoLintPathIsExcludedTestOrGeneratedDart('lib/x.txt'), isTrue);
+    });
+  });
+
+  group('repoLintPathIsDomainLibSourceForScan', () {
+    test('requires lib segment and allows normal sources', () {
+      expect(
+        repoLintPathIsDomainLibSourceForScan('packages/foo/lib/a.dart'),
+        isTrue,
+      );
+      expect(
+        repoLintPathIsDomainLibSourceForScan('tool/x/bin/run.dart'),
+        isFalse,
+      );
+    });
+  });
+
+  group('collectRepoLintDomainDartFiles', () {
+    test('walks roots and applies filters', () {
+      final tmp = Directory.systemTemp.createTempSync('ct_repo_scan_');
+      addTearDown(() {
+        if (tmp.existsSync()) {
+          tmp.deleteSync(recursive: true);
+        }
+      });
+
+      final repo = tmp.path;
+      final keep = File(p.join(repo, 'packages', 'z', 'lib', 'keep.dart'));
+      keep.createSync(recursive: true);
+      File(p.join(repo, 'packages', 'z', 'lib', 'keep.g.dart')).createSync();
+      File(
+        p.join(repo, 'packages', 'z', 'test', 't.dart'),
+      ).createSync(recursive: true);
+      File(
+        p.join(repo, 'packages', 'z', 'lib', 'nested', 'x.dart'),
+      ).createSync(recursive: true);
+
+      final got = collectRepoLintDomainDartFiles(repo);
+      final rels = got.map((f) => p.relative(f.path, from: repo)).toSet();
+      expect(
+        rels,
+        containsAll(<String>[
+          p.join('packages', 'z', 'lib', 'keep.dart'),
+          p.join('packages', 'z', 'lib', 'nested', 'x.dart'),
+        ]),
+      );
+      expect(
+        rels,
+        isNot(contains(p.join('packages', 'z', 'lib', 'keep.g.dart'))),
+      );
+      expect(rels, isNot(contains(p.join('packages', 'z', 'test', 't.dart'))));
+    });
+  });
+}

--- a/tool/check_custom_exceptions.dart
+++ b/tool/check_custom_exceptions.dart
@@ -3,20 +3,14 @@ import 'dart:io';
 import 'package:colonizethis_exception_lint/exception_enforcement.dart';
 import 'package:path/path.dart' as p;
 
-final _domainRoots = <String>[
-  'packages',
-  'app/lib',
-  'ctdev/lib',
-  'ctterm/lib',
-  'tool',
-];
+import 'ct_repo_lint_scan_contract.dart';
 
 /// PR-blocking check for generic exception throws in runtime domain code.
 ///
 /// SPEC: SPEC/program/exception-enforcement.md
 void main() {
   final repoRoot = Directory.current.path;
-  final dartFiles = _collectDomainDartFiles(repoRoot);
+  final dartFiles = collectRepoLintDomainDartFiles(repoRoot);
   final violations = <CustomExceptionViolation>[];
 
   for (final file in dartFiles) {
@@ -40,36 +34,4 @@ void main() {
     );
   }
   exitCode = 1;
-}
-
-List<File> _collectDomainDartFiles(String repoRoot) {
-  final files = <File>[];
-  for (final domainRoot in _domainRoots) {
-    final base = Directory(p.join(repoRoot, domainRoot));
-    if (!base.existsSync()) {
-      continue;
-    }
-    for (final entity in base.listSync(recursive: true, followLinks: false)) {
-      if (entity is! File) {
-        continue;
-      }
-      if (!entity.path.endsWith('.dart')) {
-        continue;
-      }
-      final rel = p.relative(entity.path, from: repoRoot);
-      if (rel.contains('/test/') || rel.endsWith('_test.dart')) {
-        continue;
-      }
-      if (!rel.contains('/lib/')) {
-        continue;
-      }
-      if (rel.endsWith('.g.dart') ||
-          rel.endsWith('.freezed.dart') ||
-          rel.endsWith('.mocks.dart')) {
-        continue;
-      }
-      files.add(entity);
-    }
-  }
-  return files;
 }

--- a/tool/check_disallowed_ast_patterns.dart
+++ b/tool/check_disallowed_ast_patterns.dart
@@ -8,6 +8,8 @@ import 'package:analyzer/source/line_info.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
+import 'ct_repo_lint_scan_contract.dart';
+
 /// PR-blocking structural AST checks driven by [tool/disallowed_ast_patterns.yaml].
 ///
 /// SPEC: SPEC/program/disallowed-ast-patterns.md
@@ -31,7 +33,7 @@ void main() {
     return;
   }
 
-  final dartFiles = _collectDomainDartFiles(repoRoot);
+  final dartFiles = collectRepoLintDomainDartFiles(repoRoot);
   final violations = <DisallowedAstViolation>[];
 
   for (final file in dartFiles) {
@@ -65,15 +67,7 @@ List<DisallowedAstViolation> findDisallowedAstViolations(
   if (rules.isEmpty) {
     return const [];
   }
-  if (!relativePath.endsWith('.dart')) {
-    return const [];
-  }
-  if (relativePath.contains('/test/') || relativePath.endsWith('_test.dart')) {
-    return const [];
-  }
-  if (relativePath.endsWith('.g.dart') ||
-      relativePath.endsWith('.freezed.dart') ||
-      relativePath.endsWith('.mocks.dart')) {
+  if (repoLintPathIsExcludedTestOrGeneratedDart(relativePath)) {
     return const [];
   }
 
@@ -170,45 +164,6 @@ bool _isSuppressedAtLine(String source, int lineNumber1Based, String ruleId) {
     return true;
   }
   return false;
-}
-
-List<File> _collectDomainDartFiles(String repoRoot) {
-  final domainRoots = <String>[
-    'packages',
-    'app/lib',
-    'ctdev/lib',
-    'ctterm/lib',
-    'tool',
-  ];
-  final files = <File>[];
-  for (final domainRoot in domainRoots) {
-    final base = Directory(p.join(repoRoot, domainRoot));
-    if (!base.existsSync()) {
-      continue;
-    }
-    for (final entity in base.listSync(recursive: true, followLinks: false)) {
-      if (entity is! File) {
-        continue;
-      }
-      if (!entity.path.endsWith('.dart')) {
-        continue;
-      }
-      final rel = p.relative(entity.path, from: repoRoot);
-      if (rel.contains('/test/') || rel.endsWith('_test.dart')) {
-        continue;
-      }
-      if (!rel.contains('/lib/')) {
-        continue;
-      }
-      if (rel.endsWith('.g.dart') ||
-          rel.endsWith('.freezed.dart') ||
-          rel.endsWith('.mocks.dart')) {
-        continue;
-      }
-      files.add(entity);
-    }
-  }
-  return files;
 }
 
 class DisallowedPatternRule {

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -2,8 +2,10 @@
 # SPEC: SPEC/program/repo-lint.md
 version: 1
 
-# Shared defaults (documentation for Phase 2+; individual runners apply their own excludes today).
+# Domain lib scan roots / excludes for AST rules aligned with exception-enforcement:
+# see tool/ct_repo_lint_scan_contract.dart (single source of truth).
 shared_scan_notes:
+  dart_contract: tool/ct_repo_lint_scan_contract.dart
   exclude_path_globs:
     - "**/test/**"
     - "**/*.g.dart"

--- a/tool/ct_repo_lint_scan_contract.dart
+++ b/tool/ct_repo_lint_scan_contract.dart
@@ -1,0 +1,67 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// Shared “domain runtime Dart” scan roots for repo-wide AST checks.
+///
+/// SPEC: SPEC/program/repo-lint.md
+const List<String> repoLintDomainScanRoots = <String>[
+  'packages',
+  'app/lib',
+  'ctdev/lib',
+  'ctterm/lib',
+  'tool',
+];
+
+/// True when [relativePathFromRepo] should not be scanned (test/fixture context
+/// or generated Dart), matching the historical `check_*` predicates.
+bool repoLintPathIsExcludedTestOrGeneratedDart(String relativePathFromRepo) {
+  if (!relativePathFromRepo.endsWith('.dart')) {
+    return true;
+  }
+  if (relativePathFromRepo.contains('/test/') ||
+      relativePathFromRepo.endsWith('_test.dart')) {
+    return true;
+  }
+  if (relativePathFromRepo.endsWith('.g.dart') ||
+      relativePathFromRepo.endsWith('.freezed.dart') ||
+      relativePathFromRepo.endsWith('.mocks.dart')) {
+    return true;
+  }
+  return false;
+}
+
+/// True for `.dart` files under a `lib/` directory segment, excluding tests and
+/// generated files — the set walked by [collectRepoLintDomainDartFiles].
+bool repoLintPathIsDomainLibSourceForScan(String relativePathFromRepo) {
+  if (repoLintPathIsExcludedTestOrGeneratedDart(relativePathFromRepo)) {
+    return false;
+  }
+  if (!relativePathFromRepo.contains('/lib/')) {
+    return false;
+  }
+  return true;
+}
+
+/// All domain `lib/**/*.dart` files under [repoLintDomainScanRoots], excluding
+/// tests and generated files (same behavior as the pre–Phase 2 checkers).
+List<File> collectRepoLintDomainDartFiles(String repoRoot) {
+  final files = <File>[];
+  for (final domainRoot in repoLintDomainScanRoots) {
+    final base = Directory(p.join(repoRoot, domainRoot));
+    if (!base.existsSync()) {
+      continue;
+    }
+    for (final entity in base.listSync(recursive: true, followLinks: false)) {
+      if (entity is! File) {
+        continue;
+      }
+      final rel = p.relative(entity.path, from: repoRoot);
+      if (!repoLintPathIsDomainLibSourceForScan(rel)) {
+        continue;
+      }
+      files.add(entity);
+    }
+  }
+  return files;
+}


### PR DESCRIPTION
## Slice (Phase 2)

Centralizes the duplicated **domain `lib/` scan roots and test/generated excludes** used by `check_custom_exceptions.dart` and `check_disallowed_ast_patterns.dart` into `tool/ct_repo_lint_scan_contract.dart`, per #1730 migration plan.

## Deferred

- Porting identifier-literal / other checkers to the same contract (or manifest-driven shared config).
- SARIF / deleting redundant `main()` entrypoints beyond this shared library step.

## Tests

- `dart test test/ct_repo_lint_scan_contract_test.dart test/ct_repo_lint_test.dart test/check_disallowed_ast_patterns_test.dart`
- `dart analyze` on touched tool sources

Refs #1730

Made with [Cursor](https://cursor.com)