### PR TITLE
Repo lint: shared identifier-literal scan contract (Refs #1730)

### DIFF
--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -9,7 +9,7 @@
 | `tool/ct_repo_lint_manifest.yaml` | Lists **rules** with stable **`rule_id`**, **group**, human title, SPEC path, and how to invoke the checker |
 | `tool/ct_repo_lint.dart` | Orchestrator: loads manifest, runs rules in order, stops on first failure |
 | `tool/ct_repo_lint_lib.dart` | Parse/execute helpers (also covered by `test/ct_repo_lint_test.dart`) |
-| `tool/ct_repo_lint_scan_contract.dart` | **Shared domain scan contract:** roots, test/generated filters, and `collectRepoLintDomainDartFiles` for AST checkers that share the exception-enforcement coverage shape (`test/ct_repo_lint_scan_contract_test.dart`) |
+| `tool/ct_repo_lint_scan_contract.dart` | **Shared scan contract:** (1) `collectRepoLintDomainDartFiles` + predicates for exception / disallowed-AST-style **`lib/`** trees; (2) `repoLintIdentifierLiteralScanRoots`, `collectRepoLintDartFilesUnderRelativeRoots`, and `repoLintIdentifierLiteralShouldSkipFile` for tech / work-target / civilian literal checkers (`test/ct_repo_lint_scan_contract_test.dart`) |
 
 ## Rule IDs and groups
 
@@ -30,7 +30,7 @@ Do **not** add new top-level `tool/check_*.dart` **entrypoints** for CI without 
 
 1. Add a row under `rules:` in `tool/ct_repo_lint_manifest.yaml` with a new stable `rule_id`.
 2. Implement or extend logic in a **library** or existing checker module; keep a single `main()` wrapper only if required for `dart run`, and wire it from the manifest.
-3. When a new checker scans the **same domain `lib/` tree** as exception / disallowed-AST enforcement, reuse **`tool/ct_repo_lint_scan_contract.dart`** instead of duplicating roots and exclude predicates.
+3. When a new checker scans the **same domain `lib/` tree** as exception / disallowed-AST enforcement, reuse **`collectRepoLintDomainDartFiles`** (and related predicates) from **`tool/ct_repo_lint_scan_contract.dart`**. When it matches **tech / work-target / civilian** literal scans (`app`, `ctterm`, `packages`, `tool` trees, `lib/`-gated, fixture-dir markers), reuse **`repoLintIdentifierLiteralScanRoots`** and **`repoLintIdentifierLiteralShouldSkipFile`** with a checker-local `excludedPaths` set.
 4. Align wording with `colonizethis_exception_lint` (and similar) when the same policy exists in the analyzer.
 
 ## CLI options
@@ -40,7 +40,8 @@ Do **not** add new top-level `tool/check_*.dart` **entrypoints** for CI without 
 ## Follow-ups (out of scope for initial landing)
 
 - SARIF output for GitHub annotations.
-- Extend the shared scan contract to other checkers that still duplicate roots/excludes (identifier literal checkers, canonical tile keys, etc.), or lift shared pieces into the manifest once all consumers read it.
+- Align **canonical province tile-key** and **app hardcoded UI string** checkers with the same contract patterns where it reduces duplication without changing coverage.
+- Optionally lift shared roots into the manifest once all consumers read it.
 
 ## Acceptance criteria
 

--- a/test/ct_repo_lint_scan_contract_test.dart
+++ b/test/ct_repo_lint_scan_contract_test.dart
@@ -80,4 +80,89 @@ void main() {
       expect(rels, isNot(contains(p.join('packages', 'z', 'test', 't.dart'))));
     });
   });
+
+  group('repoLintPathIsUnderLiteralScanRoots', () {
+    test('matches top-level scan roots only', () {
+      expect(
+        repoLintPathIsUnderLiteralScanRoots(
+          'packages/foo/lib/a.dart',
+          repoLintIdentifierLiteralScanRoots,
+        ),
+        isTrue,
+      );
+      expect(
+        repoLintPathIsUnderLiteralScanRoots(
+          'ctdev/lib/x.dart',
+          repoLintIdentifierLiteralScanRoots,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('repoLintIdentifierLiteralShouldSkipFile', () {
+    test('requires lib, honors excludes and fixture dirs', () {
+      const excluded = <String>{'packages/x/lib/skip.dart'};
+      expect(
+        repoLintIdentifierLiteralShouldSkipFile('app/lib/a.dart', excluded),
+        isFalse,
+      );
+      expect(
+        repoLintIdentifierLiteralShouldSkipFile('app/bin/a.dart', excluded),
+        isTrue,
+      );
+      expect(
+        repoLintIdentifierLiteralShouldSkipFile(
+          'packages/x/lib/skip.dart',
+          excluded,
+        ),
+        isTrue,
+      );
+      expect(
+        repoLintIdentifierLiteralShouldSkipFile(
+          'packages/p/lib/goldens/foo.dart',
+          excluded,
+        ),
+        isTrue,
+      );
+      expect(
+        repoLintIdentifierLiteralShouldSkipFile(
+          'packages/p/lib/x.gen.dart',
+          excluded,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('collectRepoLintDartFilesUnderRelativeRoots', () {
+    test('collects dart files under given roots', () {
+      final tmp = Directory.systemTemp.createTempSync('ct_repo_lit_roots_');
+      addTearDown(() {
+        if (tmp.existsSync()) {
+          tmp.deleteSync(recursive: true);
+        }
+      });
+      final repo = tmp.path;
+      File(
+        p.join(repo, 'packages', 'q', 'lib', 'a.dart'),
+      ).createSync(recursive: true);
+      File(
+        p.join(repo, 'tool', 't', 'lib', 'b.dart'),
+      ).createSync(recursive: true);
+
+      final got = collectRepoLintDartFilesUnderRelativeRoots(repo, const [
+        'packages',
+        'tool',
+      ]);
+      final rels = got.map((f) => p.relative(f.path, from: repo)).toSet();
+      expect(
+        rels,
+        containsAll(<String>[
+          p.join('packages', 'q', 'lib', 'a.dart'),
+          p.join('tool', 't', 'lib', 'b.dart'),
+        ]),
+      );
+    });
+  });
 }

--- a/tool/check_civilian_unit_type_constants.dart
+++ b/tool/check_civilian_unit_type_constants.dart
@@ -5,7 +5,8 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:path/path.dart' as p;
 
-const _scanRoots = <String>['app', 'ctterm', 'packages', 'tool'];
+import 'ct_repo_lint_scan_contract.dart';
+
 const _argFiles = '--files';
 
 /// Declarations for [kUnitTypeExplorer], etc. SPEC/game/civilian-units.md.
@@ -14,20 +15,13 @@ const _civilianUnitTypeIdsRelPath =
 
 const _excludedPaths = <String>{
   _civilianUnitTypeIdsRelPath,
+
   /// Naval ship category label; same spelling as civilian [kUnitTypeMerchant].
   'ctterm/lib/screens/shipyard_screen.dart',
+
   /// Archetype display names; values may match civilian spellings by coincidence.
   'packages/colonizethis_data/lib/src/ai_personality_config.dart',
 };
-
-const _excludedDirMarkers = <String>[
-  '/test_data/',
-  '/testdata/',
-  '/fixtures/',
-  '/fixture/',
-  '/golden/',
-  '/goldens/',
-];
 
 void main(List<String> args) {
   final parsedArgs = _parseArgs(args);
@@ -46,7 +40,7 @@ void main(List<String> args) {
   final violations = <CivilianUnitTypeConstantViolation>[];
   for (final file in candidateFiles) {
     final relPath = p.normalize(p.relative(file.path, from: root));
-    if (_shouldSkipFile(relPath)) {
+    if (repoLintIdentifierLiteralShouldSkipFile(relPath, _excludedPaths)) {
       continue;
     }
     final source = file.readAsStringSync();
@@ -87,7 +81,7 @@ List<CivilianUnitTypeConstantViolation> findCivilianUnitTypeConstantViolations({
   if (!relativePath.endsWith('.dart')) {
     return const [];
   }
-  if (_shouldSkipFile(relativePath)) {
+  if (repoLintIdentifierLiteralShouldSkipFile(relativePath, _excludedPaths)) {
     return const [];
   }
   final parsed = parseString(
@@ -147,20 +141,10 @@ List<String> _splitFileArg(String value) {
 
 List<File> _collectCandidateFiles(String root, List<String> requestedPaths) {
   if (requestedPaths.isEmpty) {
-    final files = <File>[];
-    for (final relRoot in _scanRoots) {
-      final absRoot = p.join(root, relRoot);
-      final dir = Directory(absRoot);
-      if (!dir.existsSync()) {
-        continue;
-      }
-      for (final entity in dir.listSync(recursive: true, followLinks: false)) {
-        if (entity is File && entity.path.endsWith('.dart')) {
-          files.add(entity);
-        }
-      }
-    }
-    return files;
+    return collectRepoLintDartFilesUnderRelativeRoots(
+      root,
+      repoLintIdentifierLiteralScanRoots,
+    );
   }
 
   final files = <File>[];
@@ -169,7 +153,10 @@ List<File> _collectCandidateFiles(String root, List<String> requestedPaths) {
       continue;
     }
     final normalizedRelPath = p.normalize(relPath);
-    if (!_isInScanRoots(normalizedRelPath)) {
+    if (!repoLintPathIsUnderLiteralScanRoots(
+      normalizedRelPath,
+      repoLintIdentifierLiteralScanRoots,
+    )) {
       continue;
     }
     final file = File(p.join(root, normalizedRelPath));
@@ -178,38 +165,6 @@ List<File> _collectCandidateFiles(String root, List<String> requestedPaths) {
     }
   }
   return files;
-}
-
-bool _isInScanRoots(String relPath) {
-  final normalized = relPath.replaceAll('\\', '/');
-  for (final root in _scanRoots) {
-    if (normalized == root || normalized.startsWith('$root/')) {
-      return true;
-    }
-  }
-  return false;
-}
-
-bool _shouldSkipFile(String relPath) {
-  final normalized = '/${relPath.replaceAll('\\', '/')}';
-  if (!normalized.contains('/lib/')) {
-    return true;
-  }
-  if (_excludedPaths.contains(relPath)) {
-    return true;
-  }
-  if (relPath.endsWith('.g.dart') ||
-      relPath.endsWith('.freezed.dart') ||
-      relPath.endsWith('.mocks.dart') ||
-      relPath.endsWith('.gen.dart')) {
-    return true;
-  }
-  for (final marker in _excludedDirMarkers) {
-    if (normalized.contains(marker)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 Set<String> _loadCanonicalCivilianUnitTypeIds(String root) {

--- a/tool/check_tech_id_constants.dart
+++ b/tool/check_tech_id_constants.dart
@@ -5,7 +5,8 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:path/path.dart' as p;
 
-const _scanRoots = <String>['app', 'ctterm', 'packages', 'tool'];
+import 'ct_repo_lint_scan_contract.dart';
+
 const _argFiles = '--files';
 
 const _excludedPaths = <String>{
@@ -16,15 +17,6 @@ const _excludedPaths = <String>{
   'app/lib/features/game/widgets/province_panel_labels.dart',
   'tool/sim_scenarios/lib/scenario_runner.dart',
 };
-
-const _excludedDirMarkers = <String>[
-  '/test_data/',
-  '/testdata/',
-  '/fixtures/',
-  '/fixture/',
-  '/golden/',
-  '/goldens/',
-];
 
 void main(List<String> args) {
   final parsedArgs = _parseArgs(args);
@@ -43,7 +35,7 @@ void main(List<String> args) {
   final violations = <_Violation>[];
   for (final file in candidateFiles) {
     final relPath = p.normalize(p.relative(file.path, from: root));
-    if (_shouldSkipFile(relPath)) {
+    if (repoLintIdentifierLiteralShouldSkipFile(relPath, _excludedPaths)) {
       continue;
     }
     final source = file.readAsStringSync();
@@ -122,20 +114,10 @@ List<String> _splitFileArg(String value) {
 
 List<File> _collectCandidateFiles(String root, List<String> requestedPaths) {
   if (requestedPaths.isEmpty) {
-    final files = <File>[];
-    for (final relRoot in _scanRoots) {
-      final absRoot = p.join(root, relRoot);
-      final dir = Directory(absRoot);
-      if (!dir.existsSync()) {
-        continue;
-      }
-      for (final entity in dir.listSync(recursive: true, followLinks: false)) {
-        if (entity is File && entity.path.endsWith('.dart')) {
-          files.add(entity);
-        }
-      }
-    }
-    return files;
+    return collectRepoLintDartFilesUnderRelativeRoots(
+      root,
+      repoLintIdentifierLiteralScanRoots,
+    );
   }
 
   final files = <File>[];
@@ -144,7 +126,10 @@ List<File> _collectCandidateFiles(String root, List<String> requestedPaths) {
       continue;
     }
     final normalizedRelPath = p.normalize(relPath);
-    if (!_isInScanRoots(normalizedRelPath)) {
+    if (!repoLintPathIsUnderLiteralScanRoots(
+      normalizedRelPath,
+      repoLintIdentifierLiteralScanRoots,
+    )) {
       continue;
     }
     final file = File(p.join(root, normalizedRelPath));
@@ -153,38 +138,6 @@ List<File> _collectCandidateFiles(String root, List<String> requestedPaths) {
     }
   }
   return files;
-}
-
-bool _isInScanRoots(String relPath) {
-  final normalized = relPath.replaceAll('\\', '/');
-  for (final root in _scanRoots) {
-    if (normalized == root || normalized.startsWith('$root/')) {
-      return true;
-    }
-  }
-  return false;
-}
-
-bool _shouldSkipFile(String relPath) {
-  final normalized = '/${relPath.replaceAll('\\', '/')}';
-  if (!normalized.contains('/lib/')) {
-    return true;
-  }
-  if (_excludedPaths.contains(relPath)) {
-    return true;
-  }
-  if (relPath.endsWith('.g.dart') ||
-      relPath.endsWith('.freezed.dart') ||
-      relPath.endsWith('.mocks.dart') ||
-      relPath.endsWith('.gen.dart')) {
-    return true;
-  }
-  for (final marker in _excludedDirMarkers) {
-    if (normalized.contains(marker)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 Set<String> _loadCanonicalTechIds(String root) {

--- a/tool/check_work_target_constants.dart
+++ b/tool/check_work_target_constants.dart
@@ -5,7 +5,8 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:path/path.dart' as p;
 
-const _scanRoots = <String>['app', 'ctterm', 'packages', 'tool'];
+import 'ct_repo_lint_scan_contract.dart';
+
 const _argFiles = '--files';
 
 const _workTargetConstantsRelPath =
@@ -19,15 +20,6 @@ const _excludedPaths = <String>{
   'ctterm/lib/screens/development_screen.dart',
   'packages/colonizethis_data/lib/src/work_order_costs.dart',
 };
-
-const _excludedDirMarkers = <String>[
-  '/test_data/',
-  '/testdata/',
-  '/fixtures/',
-  '/fixture/',
-  '/golden/',
-  '/goldens/',
-];
 
 void main(List<String> args) {
   final parsedArgs = _parseArgs(args);
@@ -46,7 +38,7 @@ void main(List<String> args) {
   final violations = <WorkTargetConstantViolation>[];
   for (final file in candidateFiles) {
     final relPath = p.normalize(p.relative(file.path, from: root));
-    if (_shouldSkipFile(relPath)) {
+    if (repoLintIdentifierLiteralShouldSkipFile(relPath, _excludedPaths)) {
       continue;
     }
     final source = file.readAsStringSync();
@@ -87,7 +79,7 @@ List<WorkTargetConstantViolation> findWorkTargetConstantViolations({
   if (!relativePath.endsWith('.dart')) {
     return const [];
   }
-  if (_shouldSkipFile(relativePath)) {
+  if (repoLintIdentifierLiteralShouldSkipFile(relativePath, _excludedPaths)) {
     return const [];
   }
   final parsed = parseString(
@@ -147,20 +139,10 @@ List<String> _splitFileArg(String value) {
 
 List<File> _collectCandidateFiles(String root, List<String> requestedPaths) {
   if (requestedPaths.isEmpty) {
-    final files = <File>[];
-    for (final relRoot in _scanRoots) {
-      final absRoot = p.join(root, relRoot);
-      final dir = Directory(absRoot);
-      if (!dir.existsSync()) {
-        continue;
-      }
-      for (final entity in dir.listSync(recursive: true, followLinks: false)) {
-        if (entity is File && entity.path.endsWith('.dart')) {
-          files.add(entity);
-        }
-      }
-    }
-    return files;
+    return collectRepoLintDartFilesUnderRelativeRoots(
+      root,
+      repoLintIdentifierLiteralScanRoots,
+    );
   }
 
   final files = <File>[];
@@ -169,7 +151,10 @@ List<File> _collectCandidateFiles(String root, List<String> requestedPaths) {
       continue;
     }
     final normalizedRelPath = p.normalize(relPath);
-    if (!_isInScanRoots(normalizedRelPath)) {
+    if (!repoLintPathIsUnderLiteralScanRoots(
+      normalizedRelPath,
+      repoLintIdentifierLiteralScanRoots,
+    )) {
       continue;
     }
     final file = File(p.join(root, normalizedRelPath));
@@ -178,38 +163,6 @@ List<File> _collectCandidateFiles(String root, List<String> requestedPaths) {
     }
   }
   return files;
-}
-
-bool _isInScanRoots(String relPath) {
-  final normalized = relPath.replaceAll('\\', '/');
-  for (final root in _scanRoots) {
-    if (normalized == root || normalized.startsWith('$root/')) {
-      return true;
-    }
-  }
-  return false;
-}
-
-bool _shouldSkipFile(String relPath) {
-  final normalized = '/${relPath.replaceAll('\\', '/')}';
-  if (!normalized.contains('/lib/')) {
-    return true;
-  }
-  if (_excludedPaths.contains(relPath)) {
-    return true;
-  }
-  if (relPath.endsWith('.g.dart') ||
-      relPath.endsWith('.freezed.dart') ||
-      relPath.endsWith('.mocks.dart') ||
-      relPath.endsWith('.gen.dart')) {
-    return true;
-  }
-  for (final marker in _excludedDirMarkers) {
-    if (normalized.contains(marker)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 Set<String> _loadCanonicalWorkTargets(String root) {

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -2,8 +2,8 @@
 # SPEC: SPEC/program/repo-lint.md
 version: 1
 
-# Domain lib scan roots / excludes for AST rules aligned with exception-enforcement:
-# see tool/ct_repo_lint_scan_contract.dart (single source of truth).
+# Scan contract (Dart): domain lib trees + identifier-literal roots/skip helpers —
+# tool/ct_repo_lint_scan_contract.dart
 shared_scan_notes:
   dart_contract: tool/ct_repo_lint_scan_contract.dart
   exclude_path_globs:

--- a/tool/ct_repo_lint_scan_contract.dart
+++ b/tool/ct_repo_lint_scan_contract.dart
@@ -65,3 +65,88 @@ List<File> collectRepoLintDomainDartFiles(String repoRoot) {
   }
   return files;
 }
+
+// --- Identifier-literal checkers (tech / work-target / civilian unit type) ---
+
+/// Scan roots for tech / work-target / civilian literal checkers (historical
+/// layout: top-level `app`, `ctterm`, `packages`, `tool` — not `ctdev/lib`).
+const List<String> repoLintIdentifierLiteralScanRoots = <String>[
+  'app',
+  'ctterm',
+  'packages',
+  'tool',
+];
+
+/// Path fragments that mark fixture / golden trees excluded from scans.
+const List<String> repoLintFixtureDirPathMarkers = <String>[
+  '/test_data/',
+  '/testdata/',
+  '/fixtures/',
+  '/fixture/',
+  '/golden/',
+  '/goldens/',
+];
+
+/// True when [relativePathFromRepo] lies under one of [roots] (POSIX-style
+/// segments after normalizing backslashes).
+bool repoLintPathIsUnderLiteralScanRoots(
+  String relativePathFromRepo,
+  List<String> roots,
+) {
+  final normalized = relativePathFromRepo.replaceAll('\\', '/');
+  for (final root in roots) {
+    if (normalized == root || normalized.startsWith('$root/')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Collects every `.dart` file under [roots]; callers filter with
+/// [repoLintIdentifierLiteralShouldSkipFile].
+List<File> collectRepoLintDartFilesUnderRelativeRoots(
+  String repoRoot,
+  List<String> roots,
+) {
+  final files = <File>[];
+  for (final relRoot in roots) {
+    final absRoot = p.join(repoRoot, relRoot);
+    final dir = Directory(absRoot);
+    if (!dir.existsSync()) {
+      continue;
+    }
+    for (final entity in dir.listSync(recursive: true, followLinks: false)) {
+      if (entity is File && entity.path.endsWith('.dart')) {
+        files.add(entity);
+      }
+    }
+  }
+  return files;
+}
+
+/// Shared skip logic for identifier literal checkers: must live under `lib/`,
+/// not be generated, not match [excludedPaths], and not sit under fixture dirs.
+bool repoLintIdentifierLiteralShouldSkipFile(
+  String relativePathFromRepo,
+  Set<String> excludedPaths,
+) {
+  final slashPath = '/${relativePathFromRepo.replaceAll('\\', '/')}';
+  if (!slashPath.contains('/lib/')) {
+    return true;
+  }
+  if (excludedPaths.contains(relativePathFromRepo)) {
+    return true;
+  }
+  if (relativePathFromRepo.endsWith('.g.dart') ||
+      relativePathFromRepo.endsWith('.freezed.dart') ||
+      relativePathFromRepo.endsWith('.mocks.dart') ||
+      relativePathFromRepo.endsWith('.gen.dart')) {
+    return true;
+  }
+  for (final marker in repoLintFixtureDirPathMarkers) {
+    if (slashPath.contains(marker)) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Slice

Extends `tool/ct_repo_lint_scan_contract.dart` with the **tech / work-target / civilian** literal checker scan model: `repoLintIdentifierLiteralScanRoots` (`app`, `ctterm`, `packages`, `tool`), shared fixture-dir markers, `lib/` gating, and generated suffix handling. Refactors the three `check_*_constants.dart` tools to call the shared helpers instead of triplicating `_scanRoots` / `_shouldSkipFile` / collection loops.

## Deferred

- `check_canonical_province_tile_keys.dart` and `check_app_hardcoded_ui_strings.dart` (different coverage shapes).
- SARIF / manifest-driven roots.

## Tests

- `dart test test/ct_repo_lint_scan_contract_test.dart test/check_work_target_constants_test.dart test/check_civilian_unit_type_constants_test.dart`
- `dart analyze` on touched tool sources

Refs #1730

Made with [Cursor](https://cursor.com)