### PR TITLE
Repo lint: canonical + app/lib scan contract (Refs #1730)

### DIFF
--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -9,7 +9,7 @@
 | `tool/ct_repo_lint_manifest.yaml` | Lists **rules** with stable **`rule_id`**, **group**, human title, SPEC path, and how to invoke the checker |
 | `tool/ct_repo_lint.dart` | Orchestrator: loads manifest, runs rules in order, stops on first failure |
 | `tool/ct_repo_lint_lib.dart` | Parse/execute helpers (also covered by `test/ct_repo_lint_test.dart`) |
-| `tool/ct_repo_lint_scan_contract.dart` | **Shared scan contract:** (1) `collectRepoLintDomainDartFiles` + predicates for exception / disallowed-AST-style **`lib/`** trees; (2) `repoLintIdentifierLiteralScanRoots`, `collectRepoLintDartFilesUnderRelativeRoots`, and `repoLintIdentifierLiteralShouldSkipFile` for tech / work-target / civilian literal checkers (`test/ct_repo_lint_scan_contract_test.dart`) |
+| `tool/ct_repo_lint_scan_contract.dart` | **Shared scan contract:** (1) `collectRepoLintDomainDartFiles` + predicates for exception / disallowed-AST **`lib/`** trees; (2) identifier-literal roots/skip helpers; (3) canonical province tile-key collection (`collectRepoLintCanonicalProvinceTileKeyDartFiles`); (4) app UI gate (`collectRepoLintAppLibDartFilesSorted`, `repoLintAppLibHardcodedUiVisitorShouldSkip`) — see `test/ct_repo_lint_scan_contract_test.dart` |
 
 ## Rule IDs and groups
 
@@ -30,7 +30,7 @@ Do **not** add new top-level `tool/check_*.dart` **entrypoints** for CI without 
 
 1. Add a row under `rules:` in `tool/ct_repo_lint_manifest.yaml` with a new stable `rule_id`.
 2. Implement or extend logic in a **library** or existing checker module; keep a single `main()` wrapper only if required for `dart run`, and wire it from the manifest.
-3. When a new checker scans the **same domain `lib/` tree** as exception / disallowed-AST enforcement, reuse **`collectRepoLintDomainDartFiles`** (and related predicates) from **`tool/ct_repo_lint_scan_contract.dart`**. When it matches **tech / work-target / civilian** literal scans (`app`, `ctterm`, `packages`, `tool` trees, `lib/`-gated, fixture-dir markers), reuse **`repoLintIdentifierLiteralScanRoots`** and **`repoLintIdentifierLiteralShouldSkipFile`** with a checker-local `excludedPaths` set.
+3. When a new checker scans the **same domain `lib/` tree** as exception / disallowed-AST enforcement, reuse **`collectRepoLintDomainDartFiles`** (and related predicates) from **`tool/ct_repo_lint_scan_contract.dart`**. When it matches **tech / work-target / civilian** literal scans (`app`, `ctterm`, `packages`, `tool` trees, `lib/`-gated, fixture-dir markers), reuse **`repoLintIdentifierLiteralScanRoots`** and **`repoLintIdentifierLiteralShouldSkipFile`** with a checker-local `excludedPaths` set. For **canonical province `targetTileKey`** coverage, reuse **`collectRepoLintCanonicalProvinceTileKeyDartFiles`** (tests/generated + checker excludes only — not fixture-dir markers). For **`app/lib` UI copy**, reuse **`collectRepoLintAppLibDartFilesSorted`** and **`repoLintAppLibHardcodedUiVisitorShouldSkip`**.
 4. Align wording with `colonizethis_exception_lint` (and similar) when the same policy exists in the analyzer.
 
 ## CLI options
@@ -40,7 +40,6 @@ Do **not** add new top-level `tool/check_*.dart` **entrypoints** for CI without 
 ## Follow-ups (out of scope for initial landing)
 
 - SARIF output for GitHub annotations.
-- Align **canonical province tile-key** and **app hardcoded UI string** checkers with the same contract patterns where it reduces duplication without changing coverage.
 - Optionally lift shared roots into the manifest once all consumers read it.
 
 ## Acceptance criteria

--- a/test/ct_repo_lint_scan_contract_test.dart
+++ b/test/ct_repo_lint_scan_contract_test.dart
@@ -165,4 +165,125 @@ void main() {
       );
     });
   });
+
+  group('repoLintPathIsUnderPackageOrRootTestTree', () {
+    test('detects repo test/ and package test dirs', () {
+      expect(repoLintPathIsUnderPackageOrRootTestTree('test/foo.dart'), isTrue);
+      expect(
+        repoLintPathIsUnderPackageOrRootTestTree(
+          p.join('packages', 'p', 'test', 'a.dart'),
+        ),
+        isTrue,
+      );
+      expect(
+        repoLintPathIsUnderPackageOrRootTestTree('packages/p/lib/a.dart'),
+        isFalse,
+      );
+    });
+  });
+
+  group('repoLintCanonicalProvinceTileKeyShouldSkipFile', () {
+    test('skips excluded, test tree, and generated suffixes', () {
+      const excluded = <String>{'tool/x.dart'};
+      expect(
+        repoLintCanonicalProvinceTileKeyShouldSkipFile('tool/x.dart', excluded),
+        isTrue,
+      );
+      expect(
+        repoLintCanonicalProvinceTileKeyShouldSkipFile(
+          p.join('packages', 'p', 'test', 'a.dart'),
+          excluded,
+        ),
+        isTrue,
+      );
+      expect(
+        repoLintCanonicalProvinceTileKeyShouldSkipFile(
+          'packages/p/lib/a.g.dart',
+          excluded,
+        ),
+        isTrue,
+      );
+      expect(
+        repoLintCanonicalProvinceTileKeyShouldSkipFile(
+          'packages/p/lib/a.gen.dart',
+          excluded,
+        ),
+        isTrue,
+      );
+      expect(
+        repoLintCanonicalProvinceTileKeyShouldSkipFile(
+          'packages/p/lib/a.dart',
+          excluded,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('collectRepoLintCanonicalProvinceTileKeyDartFiles', () {
+    test('keeps lib sources and drops tests/generated', () {
+      final tmp = Directory.systemTemp.createTempSync('ct_canon_tile_');
+      addTearDown(() {
+        if (tmp.existsSync()) {
+          tmp.deleteSync(recursive: true);
+        }
+      });
+      final repo = tmp.path;
+      File(
+        p.join(repo, 'packages', 'p', 'lib', 'keep.dart'),
+      ).createSync(recursive: true);
+      File(
+        p.join(repo, 'packages', 'p', 'lib', 'x.g.dart'),
+      ).createSync(recursive: true);
+      File(
+        p.join(repo, 'packages', 'p', 'test', 't.dart'),
+      ).createSync(recursive: true);
+
+      final got = collectRepoLintCanonicalProvinceTileKeyDartFiles(repo, {});
+      final rels = got.map((f) => p.relative(f.path, from: repo)).toSet();
+      expect(rels, contains(p.join('packages', 'p', 'lib', 'keep.dart')));
+      expect(rels, isNot(contains(p.join('packages', 'p', 'lib', 'x.g.dart'))));
+      expect(rels, isNot(contains(p.join('packages', 'p', 'test', 't.dart'))));
+    });
+  });
+
+  group('repoLintAppLibHardcodedUiVisitorShouldSkip', () {
+    test('matches historical app/lib visitor filters', () {
+      expect(
+        repoLintAppLibHardcodedUiVisitorShouldSkip('app/lib/a.dart'),
+        isFalse,
+      );
+      expect(
+        repoLintAppLibHardcodedUiVisitorShouldSkip('app/lib/a.g.dart'),
+        isTrue,
+      );
+      expect(
+        repoLintAppLibHardcodedUiVisitorShouldSkip('app/lib/foo_test.dart'),
+        isTrue,
+      );
+      expect(
+        repoLintAppLibHardcodedUiVisitorShouldSkip('app/lib/x.gen.dart'),
+        isFalse,
+      );
+    });
+  });
+
+  group('collectRepoLintAppLibDartFilesSorted', () {
+    test('returns sorted dart files under app/lib', () {
+      final tmp = Directory.systemTemp.createTempSync('ct_app_lib_');
+      addTearDown(() {
+        if (tmp.existsSync()) {
+          tmp.deleteSync(recursive: true);
+        }
+      });
+      final repo = tmp.path;
+      File(p.join(repo, 'app', 'lib', 'b.dart')).createSync(recursive: true);
+      File(p.join(repo, 'app', 'lib', 'a.dart')).createSync(recursive: true);
+
+      final got = collectRepoLintAppLibDartFilesSorted(repo);
+      expect(got.length, 2);
+      expect(p.basename(got[0].path), 'a.dart');
+      expect(p.basename(got[1].path), 'b.dart');
+    });
+  });
 }

--- a/tool/check_app_hardcoded_ui_strings.dart
+++ b/tool/check_app_hardcoded_ui_strings.dart
@@ -7,6 +7,8 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/source/line_info.dart';
 import 'package:path/path.dart' as p;
 
+import 'ct_repo_lint_scan_contract.dart';
+
 /// PR-blocking hardcoded UI string check for `app/lib/**`.
 ///
 /// Uses the Dart AST (not line regexes) so multiline `Text(\n  '…',\n)` and
@@ -21,7 +23,7 @@ void main() {
   }
 
   final violations = <HardcodedUiViolation>[];
-  for (final file in _collectAppLibDartFiles(appLib)) {
+  for (final file in collectRepoLintAppLibDartFilesSorted(repoRoot)) {
     final relativePath = p.relative(file.path, from: repoRoot);
     final content = file.readAsStringSync();
     violations.addAll(findHardcodedUiViolations(relativePath, content));
@@ -55,15 +57,7 @@ List<HardcodedUiViolation> findHardcodedUiViolations(
   if (_fileHasIgnoreForRule(content)) {
     return const [];
   }
-  if (!relativePath.endsWith('.dart')) {
-    return const [];
-  }
-  if (relativePath.contains('/test/') || relativePath.endsWith('_test.dart')) {
-    return const [];
-  }
-  if (relativePath.endsWith('.g.dart') ||
-      relativePath.endsWith('.freezed.dart') ||
-      relativePath.endsWith('.mocks.dart')) {
+  if (repoLintAppLibHardcodedUiVisitorShouldSkip(relativePath)) {
     return const [];
   }
 
@@ -75,21 +69,6 @@ List<HardcodedUiViolation> findHardcodedUiViolations(
   final visitor = _HardcodedUiVisitor(relativePath, content, parsed.lineInfo);
   parsed.unit.accept(visitor);
   return visitor.violations;
-}
-
-List<File> _collectAppLibDartFiles(Directory appLib) {
-  final files = <File>[];
-  for (final entity in appLib.listSync(recursive: true, followLinks: false)) {
-    if (entity is! File) {
-      continue;
-    }
-    if (!entity.path.endsWith('.dart')) {
-      continue;
-    }
-    files.add(entity);
-  }
-  files.sort((a, b) => a.path.compareTo(b.path));
-  return files;
 }
 
 bool _fileHasIgnoreForRule(String source) {

--- a/tool/check_canonical_province_tile_keys.dart
+++ b/tool/check_canonical_province_tile_keys.dart
@@ -5,7 +5,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:path/path.dart' as p;
 
-const _scanRoots = <String>['app', 'ctterm', 'packages', 'tool', 'test'];
+import 'ct_repo_lint_scan_contract.dart';
 
 const _provinceLevelTargets = <String>{'explore', 'steal_tech', 'counter_spy'};
 
@@ -13,11 +13,13 @@ const _excludedPaths = <String>{'tool/check_canonical_province_tile_keys.dart'};
 
 void main() {
   final root = p.normalize(Directory.current.path);
-  final files = _collectDartFiles(root);
+  final files = collectRepoLintCanonicalProvinceTileKeyDartFiles(
+    root,
+    _excludedPaths,
+  );
   final violations = <CanonicalProvinceTileKeyViolation>[];
   for (final file in files) {
     final relPath = p.normalize(p.relative(file.path, from: root));
-    if (_shouldSkipFile(relPath)) continue;
     final source = file.readAsStringSync();
     violations.addAll(
       findCanonicalProvinceTileKeyViolations(
@@ -59,41 +61,6 @@ List<CanonicalProvinceTileKeyViolation> findCanonicalProvinceTileKeyViolations({
   // is insufficient for some call sites).
   parsed.unit.accept(visitor);
   return visitor.violations;
-}
-
-List<File> _collectDartFiles(String root) {
-  final out = <File>[];
-  for (final scanRoot in _scanRoots) {
-    final dir = Directory(p.join(root, scanRoot));
-    if (!dir.existsSync()) continue;
-    for (final entity in dir.listSync(recursive: true, followLinks: false)) {
-      if (entity is File && entity.path.endsWith('.dart')) {
-        out.add(entity);
-      }
-    }
-  }
-  return out;
-}
-
-bool _shouldSkipFile(String relPath) {
-  if (_excludedPaths.contains(relPath)) return true;
-  if (_isUnderTestTree(relPath)) return true;
-  if (relPath.endsWith('.g.dart') ||
-      relPath.endsWith('.freezed.dart') ||
-      relPath.endsWith('.mocks.dart') ||
-      relPath.endsWith('.gen.dart')) {
-    return true;
-  }
-  return false;
-}
-
-/// Skip `test/` packages and repo-root tests so fixtures can use non-canonical
-/// literals while still exercising normalization behavior.
-bool _isUnderTestTree(String relPath) {
-  final norm = p.normalize(relPath);
-  if (norm.startsWith('test${p.separator}')) return true;
-  if (norm.contains('${p.separator}test${p.separator}')) return true;
-  return false;
 }
 
 class _CanonicalProvinceTileKeyVisitor extends RecursiveAstVisitor<void> {

--- a/tool/ct_repo_lint_scan_contract.dart
+++ b/tool/ct_repo_lint_scan_contract.dart
@@ -150,3 +150,96 @@ bool repoLintIdentifierLiteralShouldSkipFile(
   }
   return false;
 }
+
+// --- Canonical province tile-key checker ---
+
+/// Repo-root `test/**` or any `.../test/...` segment (normalized path).
+bool repoLintPathIsUnderPackageOrRootTestTree(String relativePathFromRepo) {
+  final norm = p.normalize(relativePathFromRepo);
+  if (norm.startsWith('test${p.separator}')) {
+    return true;
+  }
+  if (norm.contains('${p.separator}test${p.separator}')) {
+    return true;
+  }
+  return false;
+}
+
+bool repoLintPathEndsWithKnownGeneratedDartSuffix(String relativePathFromRepo) {
+  return relativePathFromRepo.endsWith('.g.dart') ||
+      relativePathFromRepo.endsWith('.freezed.dart') ||
+      relativePathFromRepo.endsWith('.mocks.dart') ||
+      relativePathFromRepo.endsWith('.gen.dart');
+}
+
+bool repoLintCanonicalProvinceTileKeyShouldSkipFile(
+  String relativePathFromRepo,
+  Set<String> excludedPaths,
+) {
+  if (excludedPaths.contains(relativePathFromRepo)) {
+    return true;
+  }
+  if (repoLintPathIsUnderPackageOrRootTestTree(relativePathFromRepo)) {
+    return true;
+  }
+  if (repoLintPathEndsWithKnownGeneratedDartSuffix(relativePathFromRepo)) {
+    return true;
+  }
+  return false;
+}
+
+/// Candidate `.dart` files for the canonical province `targetTileKey` gate (same
+/// roots as identifier-literal checkers; skips tests/generated and checker-local
+/// [excludedPaths] only — no fixture-dir heuristics).
+List<File> collectRepoLintCanonicalProvinceTileKeyDartFiles(
+  String repoRoot,
+  Set<String> excludedPaths,
+) {
+  final candidates = collectRepoLintDartFilesUnderRelativeRoots(
+    repoRoot,
+    repoLintIdentifierLiteralScanRoots,
+  );
+  final out = <File>[];
+  for (final f in candidates) {
+    final rel = p.normalize(p.relative(f.path, from: repoRoot));
+    if (!repoLintCanonicalProvinceTileKeyShouldSkipFile(rel, excludedPaths)) {
+      out.add(f);
+    }
+  }
+  return out;
+}
+
+// --- App `lib/` hardcoded UI string checker ---
+
+/// All `app/lib/**/*.dart` files, sorted by path (historical checker order).
+List<File> collectRepoLintAppLibDartFilesSorted(String repoRoot) {
+  final base = Directory(p.join(repoRoot, 'app', 'lib'));
+  if (!base.existsSync()) {
+    return <File>[];
+  }
+  final files = <File>[];
+  for (final entity in base.listSync(recursive: true, followLinks: false)) {
+    if (entity is File && entity.path.endsWith('.dart')) {
+      files.add(entity);
+    }
+  }
+  files.sort((a, b) => a.path.compareTo(b.path));
+  return files;
+}
+
+/// Skip predicate for [findHardcodedUiViolations] after `app/lib` prefix checks.
+bool repoLintAppLibHardcodedUiVisitorShouldSkip(String relativePathFromRepo) {
+  if (!relativePathFromRepo.endsWith('.dart')) {
+    return true;
+  }
+  if (relativePathFromRepo.contains('/test/') ||
+      relativePathFromRepo.endsWith('_test.dart')) {
+    return true;
+  }
+  if (relativePathFromRepo.endsWith('.g.dart') ||
+      relativePathFromRepo.endsWith('.freezed.dart') ||
+      relativePathFromRepo.endsWith('.mocks.dart')) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Slice

Wires **canonical province tile-key** and **app hardcoded UI** checkers into `tool/ct_repo_lint_scan_contract.dart`:

- Canonical: reuses `collectRepoLintDartFilesUnderRelativeRoots` + `repoLintIdentifierLiteralScanRoots`, with a **dedicated** skip path (test trees, `.g/.freezed/.mocks/.gen`, checker `excludedPaths` only — **not** identifier fixture-dir markers).
- App UI: `collectRepoLintAppLibDartFilesSorted` + `repoLintAppLibHardcodedUiVisitorShouldSkip` for the visitor (still no `.gen.dart` skip in the visitor, matching prior behavior).

## Deferred

- SARIF / manifest-owned roots (#1730 follow-ups).

## Tests

- `dart test test/ct_repo_lint_scan_contract_test.dart test/check_canonical_province_tile_keys_test.dart test/check_app_hardcoded_ui_strings_test.dart test/ct_repo_lint_test.dart`
- `dart analyze` on touched tool sources

Refs #1730

Made with [Cursor](https://cursor.com)