### PR TITLE
ct_repo_lint: optional SARIF report (Refs #1730)

### DIFF
--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -35,11 +35,16 @@ Do **not** add new top-level `tool/check_*.dart` **entrypoints** for CI without 
 
 ## CLI options
 
-`dart run tool/ct_repo_lint.dart --help` — `--list`, `--rule`, `--group`, `--manifest`, `--verbose`, `--force-full-scan`.
+`dart run tool/ct_repo_lint.dart --help` — `--list`, `--rule`, `--group`, `--manifest`, `--verbose`, `--force-full-scan`, `--sarif <path>`.
+
+### SARIF (GitHub annotations / code scanning)
+
+- **`--sarif <path>`** or **`--sarif=-`** (stdout): after the run, write **SARIF 2.1.0** with one **result** per failed rule (`level: error`, `message` points to full log for file:line detail). The tool **runs all selected rules** when SARIF is requested (it does not stop at the first failure) so the report lists every failing gate. Checker **stdout** is relayed to **stderr** in this mode so the SARIF stream (file or `-`) stays valid JSON.
+- **`--list` and `--sarif` are mutually exclusive.**
+- Upload in CI (optional): e.g. `github/codeql-action/upload-sarif` with the generated file; wire paths and permissions per GitHub’s current docs.
 
 ## Follow-ups (out of scope for initial landing)
 
-- SARIF output for GitHub annotations.
 - Align **canonical province tile-key** and **app hardcoded UI string** checkers with the same contract patterns where it reduces duplication without changing coverage.
 - Optionally lift shared roots into the manifest once all consumers read it.
 

--- a/test/ct_repo_lint_sarif_test.dart
+++ b/test/ct_repo_lint_sarif_test.dart
@@ -1,0 +1,101 @@
+import 'dart:convert';
+
+import 'package:test/test.dart';
+
+import '../tool/ct_repo_lint_lib.dart';
+
+RepoLintRule _dartRule(String id, {String spec = 'SPEC/x.md'}) {
+  return RepoLintRule(
+    ruleId: id,
+    group: 'g',
+    title: 'Title $id',
+    spec: spec,
+    runner: 'dart',
+    argv: const [],
+    script: 'tool/x.dart',
+    prIncremental: false,
+    includeOnlyWhenEnvName: null,
+    includeOnlyWhenEnvValue: null,
+  );
+}
+
+RepoLintRule _shellRule() {
+  return RepoLintRule(
+    ruleId: 'repo.shell',
+    group: 'g',
+    title: 'Shell gate',
+    spec: '',
+    runner: 'shell',
+    argv: const ['tool/check_test_imports.sh'],
+    script: null,
+    prIncremental: false,
+    includeOnlyWhenEnvName: null,
+    includeOnlyWhenEnvValue: null,
+  );
+}
+
+void main() {
+  group('buildCtRepoLintSarifObject', () {
+    test('empty failures yields empty results', () {
+      final r = _dartRule('repo.ok');
+      final obj = buildCtRepoLintSarifObject(
+        executedRules: [r],
+        failures: const [],
+      );
+      expect(obj['version'], '2.1.0');
+      final runs = obj['runs']! as List<Object?>;
+      final run = runs.single! as Map<String, Object?>;
+      final results = run['results']! as List<Object?>;
+      expect(results, isEmpty);
+      final tool = run['tool']! as Map<String, Object?>;
+      final driver = tool['driver']! as Map<String, Object?>;
+      final rules = driver['rules']! as List<Object?>;
+      expect(rules.length, 1);
+    });
+
+    test('failure references ruleIndex and script or argv', () {
+      final a = _dartRule('repo.a', spec: 'SPEC/program/a.md');
+      final b = _shellRule();
+      final obj = buildCtRepoLintSarifObject(
+        executedRules: [a, b],
+        failures: [(rule: a, exitCode: 2), (rule: b, exitCode: 1)],
+      );
+      final runs = obj['runs']! as List<Object?>;
+      final run = runs.single! as Map<String, Object?>;
+      final results = run['results']! as List<Object?>;
+      expect(results.length, 2);
+
+      final first = results[0]! as Map<String, Object?>;
+      expect(first['ruleId'], 'repo.a');
+      expect(first['ruleIndex'], 0);
+      final loc0 =
+          (first['locations']! as List<Object?>).single!
+              as Map<String, Object?>;
+      final phys0 = loc0['physicalLocation']! as Map<String, Object?>;
+      final art0 = phys0['artifactLocation']! as Map<String, Object?>;
+      expect(art0['uri'], 'tool/x.dart');
+
+      final second = results[1]! as Map<String, Object?>;
+      expect(second['ruleId'], 'repo.shell');
+      expect(second['ruleIndex'], 1);
+      final loc1 =
+          (second['locations']! as List<Object?>).single!
+              as Map<String, Object?>;
+      final phys1 = loc1['physicalLocation']! as Map<String, Object?>;
+      final art1 = phys1['artifactLocation']! as Map<String, Object?>;
+      expect(art1['uri'], 'tool/check_test_imports.sh');
+    });
+  });
+
+  group('encodeCtRepoLintSarif', () {
+    test('produces decodable JSON', () {
+      final r = _dartRule('repo.z');
+      final text = encodeCtRepoLintSarif(
+        executedRules: [r],
+        failures: const [],
+      );
+      final decoded = jsonDecode(text) as Map<String, Object?>;
+      expect(decoded['version'], '2.1.0');
+    });
+  });
+}

--- a/test/ct_repo_lint_test.dart
+++ b/test/ct_repo_lint_test.dart
@@ -54,4 +54,15 @@ void main() {
     expect(out, contains('repo.custom_exceptions'));
     expect(out, contains('repo.test_imports'));
   });
+
+  test('CLI rejects --list with --sarif', () {
+    final r = Process.runSync(Platform.resolvedExecutable, [
+      'run',
+      'tool/ct_repo_lint.dart',
+      '--list',
+      '--sarif=-',
+    ], workingDirectory: repoRoot);
+    expect(r.exitCode, 2);
+    expect(r.stderr.toString(), contains('--sarif'));
+  });
 }

--- a/tool/ct_repo_lint_lib.dart
+++ b/tool/ct_repo_lint_lib.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -39,6 +40,7 @@ final class RepoLintOptions {
     required this.onlyRuleId,
     required this.onlyGroup,
     required this.forceFullScan,
+    required this.sarifOutputPath,
   });
 
   final String manifestPath;
@@ -47,6 +49,10 @@ final class RepoLintOptions {
   final String? onlyRuleId;
   final String? onlyGroup;
   final bool forceFullScan;
+
+  /// When set, run every selected rule (do not stop at the first failure) and
+  /// write SARIF 2.1.0 to this path, or `-` for stdout.
+  final String? sarifOutputPath;
 }
 
 RepoLintOptions parseRepoLintArgs(List<String> args) {
@@ -56,6 +62,7 @@ RepoLintOptions parseRepoLintArgs(List<String> args) {
   var onlyRuleId = '';
   var onlyGroup = '';
   var forceFullScan = false;
+  String? sarifOutputPath;
 
   for (var i = 0; i < args.length; i++) {
     final a = args[i];
@@ -114,8 +121,26 @@ RepoLintOptions parseRepoLintArgs(List<String> args) {
       onlyGroup = args[i];
       continue;
     }
+    if (a.startsWith('--sarif=')) {
+      sarifOutputPath = a.substring('--sarif='.length);
+      continue;
+    }
+    if (a == '--sarif') {
+      i++;
+      if (i >= args.length) {
+        stderr.writeln('ct_repo_lint: --sarif requires a path or -');
+        exit(2);
+      }
+      sarifOutputPath = args[i];
+      continue;
+    }
     stderr.writeln('ct_repo_lint: unknown argument: $a');
     stderr.writeln(_usage);
+    exit(2);
+  }
+
+  if (listOnly && sarifOutputPath != null) {
+    stderr.writeln('ct_repo_lint: --sarif cannot be used with --list');
     exit(2);
   }
 
@@ -126,6 +151,7 @@ RepoLintOptions parseRepoLintArgs(List<String> args) {
     onlyRuleId: onlyRuleId.isEmpty ? null : onlyRuleId,
     onlyGroup: onlyGroup.isEmpty ? null : onlyGroup,
     forceFullScan: forceFullScan,
+    sarifOutputPath: sarifOutputPath,
   );
 }
 
@@ -142,6 +168,7 @@ Options:
   --group <name>        Run only rules in this group
   --force-full-scan     Do not pass PR incremental --files to supported rules
   --verbose, -v         Log each rule as it starts
+  --sarif <path>        After running, write SARIF 2.1.0 (run all rules; use - for stdout)
   --help, -h            Show this message
 
 Environment:
@@ -340,6 +367,15 @@ int runRepoLint({
     return 2;
   }
 
+  if (options.sarifOutputPath != null) {
+    return _runRepoLintWithSarif(
+      repoRoot: repoRoot,
+      rules: rules,
+      options: options,
+      incrementalCsv: incrementalCsv,
+    );
+  }
+
   for (final rule in rules) {
     if (options.verbose) {
       stderr.writeln('ct_repo_lint: [${rule.ruleId}] ${rule.title}');
@@ -349,6 +385,7 @@ int runRepoLint({
       repoRoot: repoRoot,
       rule: rule,
       incrementalCsv: incrementalCsv,
+      relayChildStdoutToStderr: false,
     );
     if (code != 0) {
       return code;
@@ -359,10 +396,132 @@ int runRepoLint({
   return 0;
 }
 
+int _runRepoLintWithSarif({
+  required String repoRoot,
+  required List<RepoLintRule> rules,
+  required RepoLintOptions options,
+  required String? incrementalCsv,
+}) {
+  final failures = <({RepoLintRule rule, int exitCode})>[];
+  for (final rule in rules) {
+    if (options.verbose) {
+      stderr.writeln('ct_repo_lint: [${rule.ruleId}] ${rule.title}');
+    }
+
+    final code = _runOneRule(
+      repoRoot: repoRoot,
+      rule: rule,
+      incrementalCsv: incrementalCsv,
+      relayChildStdoutToStderr: true,
+    );
+    if (code != 0) {
+      failures.add((rule: rule, exitCode: code));
+    }
+  }
+
+  final sarifText = encodeCtRepoLintSarif(
+    executedRules: rules,
+    failures: failures,
+  );
+  _writeSarifOutput(options.sarifOutputPath!, sarifText);
+
+  if (failures.isEmpty) {
+    stderr.writeln('ct_repo_lint: all ${rules.length} rule(s) passed.');
+    return 0;
+  }
+  stderr.writeln(
+    'ct_repo_lint: ${failures.length} rule(s) failed (SARIF written).',
+  );
+  return 1;
+}
+
+void _writeSarifOutput(String path, String json) {
+  final text = json.endsWith('\n') ? json : '$json\n';
+  if (path == '-') {
+    stdout.write(text);
+    return;
+  }
+  File(path).writeAsStringSync(text);
+}
+
+/// Builds SARIF 2.1.0 JSON for [executedRules] and failed runs in [failures].
+/// Exposed for tests.
+String encodeCtRepoLintSarif({
+  required List<RepoLintRule> executedRules,
+  required List<({RepoLintRule rule, int exitCode})> failures,
+}) {
+  return JsonEncoder.withIndent('  ').convert(
+    buildCtRepoLintSarifObject(
+      executedRules: executedRules,
+      failures: failures,
+    ),
+  );
+}
+
+/// SARIF object before JSON encoding. Exposed for tests.
+Map<String, Object?> buildCtRepoLintSarifObject({
+  required List<RepoLintRule> executedRules,
+  required List<({RepoLintRule rule, int exitCode})> failures,
+}) {
+  final driverRules = <Map<String, Object?>>[];
+  final ruleIndexById = <String, int>{};
+  for (var i = 0; i < executedRules.length; i++) {
+    final r = executedRules[i];
+    ruleIndexById[r.ruleId] = i;
+    driverRules.add({
+      'id': r.ruleId,
+      'name': r.title,
+      if (r.spec.isNotEmpty) 'shortDescription': {'text': 'SPEC: ${r.spec}'},
+    });
+  }
+
+  final results = <Map<String, Object?>>[];
+  for (final f in failures) {
+    final uri = f.rule.runner == 'dart'
+        ? (f.rule.script ?? 'unknown.dart')
+        : (f.rule.argv.isNotEmpty ? f.rule.argv.first : 'unknown');
+    results.add({
+      'ruleId': f.rule.ruleId,
+      'ruleIndex': ?ruleIndexById[f.rule.ruleId],
+      'level': 'error',
+      'message': {
+        'text':
+            'Convention check failed (exit ${f.exitCode}). See log output for file and line details.',
+      },
+      'locations': [
+        {
+          'physicalLocation': {
+            'artifactLocation': {'uri': uri},
+          },
+        },
+      ],
+    });
+  }
+
+  return {
+    r'$schema':
+        'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json',
+    'version': '2.1.0',
+    'runs': [
+      {
+        'tool': {
+          'driver': {
+            'name': 'ct_repo_lint',
+            'informationUri': 'https://github.com/waigore/colonizethisv3',
+            'rules': driverRules,
+          },
+        },
+        'results': results,
+      },
+    ],
+  };
+}
+
 int _runOneRule({
   required String repoRoot,
   required RepoLintRule rule,
   required String? incrementalCsv,
+  required bool relayChildStdoutToStderr,
 }) {
   stderr.writeln('ct_repo_lint: --- [${rule.ruleId}] ${rule.title} ---');
 
@@ -376,7 +535,10 @@ int _runOneRule({
       environment: Platform.environment,
       runInShell: false,
     );
-    _forwardProcessOutput(result);
+    _forwardProcessOutput(
+      result,
+      relayStdoutToStderr: relayChildStdoutToStderr,
+    );
     if (result.exitCode != 0) {
       stderr.writeln(
         'ct_repo_lint: FAILED [${rule.ruleId}] exit ${result.exitCode} (see output above)',
@@ -400,7 +562,7 @@ int _runOneRule({
     environment: Platform.environment,
     runInShell: false,
   );
-  _forwardProcessOutput(result);
+  _forwardProcessOutput(result, relayStdoutToStderr: relayChildStdoutToStderr);
   if (result.exitCode != 0) {
     stderr.writeln(
       'ct_repo_lint: FAILED [${rule.ruleId}] exit ${result.exitCode} (see output above)',
@@ -409,11 +571,18 @@ int _runOneRule({
   return result.exitCode;
 }
 
-void _forwardProcessOutput(ProcessResult result) {
+void _forwardProcessOutput(
+  ProcessResult result, {
+  required bool relayStdoutToStderr,
+}) {
   final out = result.stdout.toString();
   final err = result.stderr.toString();
   if (out.isNotEmpty) {
-    stdout.write(out);
+    if (relayStdoutToStderr) {
+      stderr.write(out);
+    } else {
+      stdout.write(out);
+    }
   }
   if (err.isNotEmpty) {
     stderr.write(err);


### PR DESCRIPTION
## Summary

Implements the **optional SARIF follow-up** from #1730: `dart run tool/ct_repo_lint.dart --sarif <path>` or `--sarif=-` writes SARIF **2.1.0** after running **all** selected rules (no early stop), one `results[]` entry per failed rule. Checker stdout is copied to **stderr** in this mode so SARIF output stays parseable.

## SPEC

- `SPEC/program/repo-lint.md`: CLI + SARIF section; removed completed SARIF bullet from follow-ups.

## Tests

- `test/ct_repo_lint_sarif_test.dart` — builder/encoder structure
- `test/ct_repo_lint_test.dart` — `--list` + `--sarif` rejected

## Commands

- `dart analyze tool/ct_repo_lint_lib.dart`
- `dart test test/ct_repo_lint_sarif_test.dart test/ct_repo_lint_test.dart`

## Out of scope

- Wiring `upload-sarif` in `quality.yml` (callers can add when desired).

Refs #1730

Made with [Cursor](https://cursor.com)