### PR TITLE
repo-lint: run manifest Dart checkers in-process

### DIFF
--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -9,11 +9,13 @@
 | `tool/ct_repo_lint_manifest.yaml` | Lists **rules** with stable **`rule_id`**, **group**, human title, SPEC path, and how to invoke the checker |
 | `tool/ct_repo_lint.dart` | Orchestrator: loads manifest, runs rules in order, stops on first failure |
 | `tool/ct_repo_lint_lib.dart` | Parse/execute helpers (also covered by `test/ct_repo_lint_test.dart`) |
-| `tool/ct_repo_lint_scan_contract.dart` | **Shared scan contract:** (1) `collectRepoLintDomainDartFiles` + predicates for exception / disallowed-AST **`lib/`** trees; (2) identifier-literal roots/skip helpers; (3) canonical province tile-key collection (`collectRepoLintCanonicalProvinceTileKeyDartFiles`); (4) app UI gate (`collectRepoLintAppLibDartFilesSorted`, `repoLintAppLibHardcodedUiVisitorShouldSkip`) — see `test/ct_repo_lint_scan_contract_test.dart` |
+| `tool/ct_repo_lint_scan_contract.dart` | **Shared scan contract:** (1) `collectRepoLintDomainDartFiles` + predicates for exception / disallowed-AST **`lib/`** trees; (2) identifier-literal roots/skip helpers; (3) canonical province tile-key collection (`collectRepoLintCanonicalProvinceTileKeyDartFiles`); (4) app UI gate (`collectRepoLintAppLibDartFilesSorted`, `repoLintAppLibHardcodedUiVisitorShouldSkip`); (5) `repoLintSplitRelativeDartPathsArg` for PR incremental path lists — see `test/ct_repo_lint_scan_contract_test.dart` |
 
 ## Rule IDs and groups
 
-Each rule has a stable `rule_id` (prefix `repo.`). **Groups** (non-exhaustive): `structure`, `architecture`, `identifiers`, `exceptions`, `game_invariants`, `ui_i18n`. Violation text from underlying tools should include **file path and line** (and column when the checker provides it). The orchestrator prints a banner `--- [rule_id] title ---` before each subprocess so logs stay attributable.
+Each rule has a stable `rule_id` (prefix `repo.`). **Groups** (non-exhaustive): `structure`, `architecture`, `identifiers`, `exceptions`, `game_invariants`, `ui_i18n`. Violation text from underlying tools should include **file path and line** (and column when the checker provides it). The orchestrator prints a banner `--- [rule_id] title ---` before each rule so logs stay attributable.
+
+**Dart `runner` rules** listed in the manifest are executed **in-process** by `ct_repo_lint_lib.dart` (calling `runCheck…` entrypoints on the existing `tool/check_*.dart` modules). Unknown `rule_id` values or future scripts without an in-process binding still use `dart run <script>` as a fallback. Standalone `dart run tool/check_*.dart` remains supported via thin `main()` wrappers.
 
 ## CI contract
 
@@ -29,7 +31,7 @@ Rules marked `pr_incremental: true` in the manifest receive `--files <csv>` when
 Do **not** add new top-level `tool/check_*.dart` **entrypoints** for CI without updating this SPEC and the manifest. Prefer:
 
 1. Add a row under `rules:` in `tool/ct_repo_lint_manifest.yaml` with a new stable `rule_id`.
-2. Implement or extend logic in a **library** or existing checker module; keep a single `main()` wrapper only if required for `dart run`, and wire it from the manifest.
+2. Implement or extend logic in a **library** or existing checker module; expose `int runCheck…(String repoRoot, …)` for `ct_repo_lint_lib.dart` to call in-process, keep a thin `main()` that `exit(runCheck…(…))` for `dart run`, and register the manifest row. Add a `switch` arm in `_tryRunDartRuleInProcess` when introducing a new stable `rule_id`.
 3. When a new checker scans the **same domain `lib/` tree** as exception / disallowed-AST enforcement, reuse **`collectRepoLintDomainDartFiles`** (and related predicates) from **`tool/ct_repo_lint_scan_contract.dart`**. When it matches **tech / work-target / civilian** literal scans (`app`, `ctterm`, `packages`, `tool` trees, `lib/`-gated, fixture-dir markers), reuse **`repoLintIdentifierLiteralScanRoots`** and **`repoLintIdentifierLiteralShouldSkipFile`** with a checker-local `excludedPaths` set. For **canonical province `targetTileKey`** coverage, reuse **`collectRepoLintCanonicalProvinceTileKeyDartFiles`** (tests/generated + checker excludes only — not fixture-dir markers). For **`app/lib` UI copy**, reuse **`collectRepoLintAppLibDartFilesSorted`** and **`repoLintAppLibHardcodedUiVisitorShouldSkip`**.
 4. Align wording with `colonizethis_exception_lint` (and similar) when the same policy exists in the analyzer.
 

--- a/test/ct_repo_lint_scan_contract_test.dart
+++ b/test/ct_repo_lint_scan_contract_test.dart
@@ -286,4 +286,23 @@ void main() {
       expect(p.basename(got[1].path), 'b.dart');
     });
   });
+
+  group('repoLintSplitRelativeDartPathsArg', () {
+    test('splits commas and newlines and trims', () {
+      expect(repoLintSplitRelativeDartPathsArg(''), isEmpty);
+      expect(repoLintSplitRelativeDartPathsArg('  '), isEmpty);
+      expect(repoLintSplitRelativeDartPathsArg('a.dart,b.dart'), [
+        'a.dart',
+        'b.dart',
+      ]);
+      expect(repoLintSplitRelativeDartPathsArg('a.dart\nb.dart'), [
+        'a.dart',
+        'b.dart',
+      ]);
+      expect(repoLintSplitRelativeDartPathsArg(' a.dart , b.dart '), [
+        'a.dart',
+        'b.dart',
+      ]);
+    });
+  });
 }

--- a/tool/check_app_hardcoded_ui_strings.dart
+++ b/tool/check_app_hardcoded_ui_strings.dart
@@ -13,13 +13,18 @@ import 'ct_repo_lint_scan_contract.dart';
 ///
 /// Uses the Dart AST (not line regexes) so multiline `Text(\n  '…',\n)` and
 /// adjacent string literals are detected. Supplements `hardcoded_strings_lint`.
-void main() {
-  final repoRoot = Directory.current.path;
+/// Used by `ct_repo_lint` in-process; [info] / [err] default to stdout/stderr.
+int runCheckAppHardcodedUiStrings(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
   final appLib = Directory(p.join(repoRoot, 'app', 'lib'));
   if (!appLib.existsSync()) {
-    stderr.writeln('check_app_hardcoded_ui_strings: app/lib not found.');
-    exitCode = 1;
-    return;
+    logE('check_app_hardcoded_ui_strings: app/lib not found.');
+    return 1;
   }
 
   final violations = <HardcodedUiViolation>[];
@@ -30,19 +35,23 @@ void main() {
   }
 
   if (violations.isEmpty) {
-    stdout.writeln('check_app_hardcoded_ui_strings: no violations found.');
-    return;
+    logI('check_app_hardcoded_ui_strings: no violations found.');
+    return 0;
   }
 
-  stderr.writeln('Hardcoded UI string violations found in app/lib:');
+  logE('Hardcoded UI string violations found in app/lib:');
   for (final v in violations) {
-    stderr.writeln(' - ${v.path}:${v.line}: ${v.snippet}');
+    logE(' - ${v.path}:${v.line}: ${v.snippet}');
   }
-  stderr.writeln(
+  logE(
     '\nTotal violations: ${violations.length}. '
     'Move user-visible strings to AppLocalizations/ARB.',
   );
-  exitCode = 1;
+  return 1;
+}
+
+void main() {
+  exit(runCheckAppHardcodedUiStrings(Directory.current.path));
 }
 
 /// Exposed for unit tests (same behavior as production scan).

--- a/tool/check_canonical_province_tile_keys.dart
+++ b/tool/check_canonical_province_tile_keys.dart
@@ -11,8 +11,15 @@ const _provinceLevelTargets = <String>{'explore', 'steal_tech', 'counter_spy'};
 
 const _excludedPaths = <String>{'tool/check_canonical_province_tile_keys.dart'};
 
-void main() {
-  final root = p.normalize(Directory.current.path);
+/// Used by `ct_repo_lint` in-process; [info] / [err] default to stdout/stderr.
+int runCheckCanonicalProvinceTileKeys(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+  final root = p.normalize(repoRoot);
   final files = collectRepoLintCanonicalProvinceTileKeyDartFiles(
     root,
     _excludedPaths,
@@ -30,18 +37,22 @@ void main() {
   }
 
   if (violations.isEmpty) {
-    stdout.writeln('Canonical province tile-key check passed.');
-    exit(0);
+    logI('Canonical province tile-key check passed.');
+    return 0;
   }
 
-  stderr.writeln(
+  logE(
     'ERROR: Found non-canonical province-level WorkOrder targetTileKey values. '
     'Use region|province|0|0 for explore/steal_tech/counter_spy.',
   );
   for (final v in violations) {
-    stderr.writeln('${v.path}:${v.line}:${v.column} ${v.message}');
+    logE('${v.path}:${v.line}:${v.column} ${v.message}');
   }
-  exit(1);
+  return 1;
+}
+
+void main() {
+  exit(runCheckCanonicalProvinceTileKeys(Directory.current.path));
 }
 
 List<CanonicalProvinceTileKeyViolation> findCanonicalProvinceTileKeyViolations({

--- a/tool/check_civilian_unit_type_constants.dart
+++ b/tool/check_civilian_unit_type_constants.dart
@@ -23,19 +23,27 @@ const _excludedPaths = <String>{
   'packages/colonizethis_data/lib/src/ai_personality_config.dart',
 };
 
-void main(List<String> args) {
-  final parsedArgs = _parseArgs(args);
-  final root = p.normalize(Directory.current.path);
+/// Used by `ct_repo_lint` in-process; [info] / [err] default to stdout/stderr.
+int runCheckCivilianUnitTypeConstants(
+  String repoRoot, {
+  List<String>? incrementalRelativeDartPaths,
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+  final root = p.normalize(repoRoot);
   final canonicalIds = _loadCanonicalCivilianUnitTypeIds(root);
   if (canonicalIds.isEmpty) {
-    stderr.writeln(
+    logE(
       'ERROR: Could not derive canonical civilian unit type ids from '
       '$_civilianUnitTypeIdsRelPath.',
     );
-    exit(1);
+    return 1;
   }
   final constantNameById = _loadCivilianUnitTypeConstantNames(root);
-  final candidateFiles = _collectCandidateFiles(root, parsedArgs.files);
+  final requested = incrementalRelativeDartPaths ?? const <String>[];
+  final candidateFiles = _collectCandidateFiles(root, requested);
 
   final violations = <CivilianUnitTypeConstantViolation>[];
   for (final file in candidateFiles) {
@@ -55,21 +63,33 @@ void main(List<String> args) {
   }
 
   if (violations.isEmpty) {
-    stdout.writeln('Civilian unit type constant usage check passed.');
-    exit(0);
+    logI('Civilian unit type constant usage check passed.');
+    return 0;
   }
 
-  stderr.writeln(
+  logE(
     'ERROR: Found raw civilian unit type string literals in executable code. '
     'Use kUnitType* constants from colonizethis_models.',
   );
   for (final violation in violations) {
-    stderr.writeln(
+    logE(
       '${violation.path}:${violation.line}:${violation.column} '
       '${violation.message}',
     );
   }
-  exit(1);
+  return 1;
+}
+
+void main(List<String> args) {
+  final parsedArgs = _parseArgs(args);
+  exit(
+    runCheckCivilianUnitTypeConstants(
+      Directory.current.path,
+      incrementalRelativeDartPaths: parsedArgs.files.isEmpty
+          ? null
+          : parsedArgs.files,
+    ),
+  );
 }
 
 List<CivilianUnitTypeConstantViolation> findCivilianUnitTypeConstantViolations({
@@ -123,20 +143,10 @@ _ParsedArgs _parseArgs(List<String> args) {
     exit(2);
   }
   return _ParsedArgs(
-    files: filesArgValue == null ? const [] : _splitFileArg(filesArgValue),
+    files: filesArgValue == null
+        ? const []
+        : repoLintSplitRelativeDartPathsArg(filesArgValue),
   );
-}
-
-List<String> _splitFileArg(String value) {
-  if (value.trim().isEmpty) {
-    return const [];
-  }
-  final normalized = value.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
-  return normalized
-      .split(RegExp('[,\n]'))
-      .map((entry) => entry.trim())
-      .where((entry) => entry.isNotEmpty)
-      .toList(growable: false);
 }
 
 List<File> _collectCandidateFiles(String root, List<String> requestedPaths) {

--- a/tool/check_custom_exceptions.dart
+++ b/tool/check_custom_exceptions.dart
@@ -8,8 +8,15 @@ import 'ct_repo_lint_scan_contract.dart';
 /// PR-blocking check for generic exception throws in runtime domain code.
 ///
 /// SPEC: SPEC/program/exception-enforcement.md
-void main() {
-  final repoRoot = Directory.current.path;
+///
+/// Used by `ct_repo_lint` in-process; [info] / [err] default to stdout/stderr.
+int runCheckCustomExceptions(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
   final dartFiles = collectRepoLintDomainDartFiles(repoRoot);
   final violations = <CustomExceptionViolation>[];
 
@@ -20,18 +27,20 @@ void main() {
   }
 
   if (violations.isEmpty) {
-    stdout.writeln('check_custom_exceptions: no violations found.');
-    return;
+    logI('check_custom_exceptions: no violations found.');
+    return 0;
   }
 
-  stderr.writeln(
-    'check_custom_exceptions: found ${violations.length} violation(s):',
-  );
+  logE('check_custom_exceptions: found ${violations.length} violation(s):');
   for (final violation in violations) {
-    stderr.writeln(
+    logE(
       ' - ${violation.path}:${violation.line}: '
       'throwing ${violation.exceptionType} is forbidden; use a domain-specific exception type',
     );
   }
-  exitCode = 1;
+  return 1;
+}
+
+void main() {
+  exit(runCheckCustomExceptions(Directory.current.path));
 }

--- a/tool/check_disallowed_ast_patterns.dart
+++ b/tool/check_disallowed_ast_patterns.dart
@@ -13,24 +13,29 @@ import 'ct_repo_lint_scan_contract.dart';
 /// PR-blocking structural AST checks driven by [tool/disallowed_ast_patterns.yaml].
 ///
 /// SPEC: SPEC/program/disallowed-ast-patterns.md
-void main() {
-  final repoRoot = Directory.current.path;
+///
+/// Used by `ct_repo_lint` in-process; [info] / [err] default to stdout/stderr.
+int runCheckDisallowedAstPatterns(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
   final configFile = File(
     p.join(repoRoot, 'tool', 'disallowed_ast_patterns.yaml'),
   );
   if (!configFile.existsSync()) {
-    stderr.writeln('check_disallowed_ast_patterns: missing ${configFile.path}');
-    exitCode = 1;
-    return;
+    logE('check_disallowed_ast_patterns: missing ${configFile.path}');
+    return 1;
   }
 
   final rules = _loadRules(configFile.readAsStringSync());
   if (rules.isEmpty) {
-    stderr.writeln(
+    logE(
       'check_disallowed_ast_patterns: no rules in disallowed_ast_patterns.yaml',
     );
-    exitCode = 1;
-    return;
+    return 1;
   }
 
   final dartFiles = collectRepoLintDomainDartFiles(repoRoot);
@@ -45,17 +50,21 @@ void main() {
   }
 
   if (violations.isEmpty) {
-    stdout.writeln('check_disallowed_ast_patterns: no violations found.');
-    return;
+    logI('check_disallowed_ast_patterns: no violations found.');
+    return 0;
   }
 
-  stderr.writeln(
+  logE(
     'check_disallowed_ast_patterns: found ${violations.length} violation(s):',
   );
   for (final v in violations) {
-    stderr.writeln(' - ${v.path}:${v.line}: [${v.ruleId}] ${v.message}');
+    logE(' - ${v.path}:${v.line}: [${v.ruleId}] ${v.message}');
   }
-  exitCode = 1;
+  return 1;
+}
+
+void main() {
+  exit(runCheckDisallowedAstPatterns(Directory.current.path));
 }
 
 /// Exposed for unit tests (same behavior as production scan).

--- a/tool/check_tech_id_constants.dart
+++ b/tool/check_tech_id_constants.dart
@@ -18,19 +18,31 @@ const _excludedPaths = <String>{
   'tool/sim_scenarios/lib/scenario_runner.dart',
 };
 
-void main(List<String> args) {
-  final parsedArgs = _parseArgs(args);
-  final root = p.normalize(Directory.current.path);
+/// [incrementalRelativeDartPaths]: when non-null and non-empty, only those
+/// paths (repo-relative) are scanned; otherwise full scan.
+///
+/// Used by `ct_repo_lint` in-process; [info] / [err] default to stdout/stderr.
+/// Returns 0 = pass, 1 = violations or missing catalog, 2 = bad CLI args (CLI only).
+int runCheckTechIdConstants(
+  String repoRoot, {
+  List<String>? incrementalRelativeDartPaths,
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+  final root = p.normalize(repoRoot);
   final techIds = _loadCanonicalTechIds(root);
   if (techIds.isEmpty) {
-    stderr.writeln(
+    logE(
       'ERROR: Could not derive canonical tech IDs from '
       'packages/colonizethis_data/lib/src/tech_catalog.dart.',
     );
-    exit(1);
+    return 1;
   }
   final constantNameByTechId = _loadTechIdConstantNames(root);
-  final candidateFiles = _collectCandidateFiles(root, parsedArgs.files);
+  final requested = incrementalRelativeDartPaths ?? const <String>[];
+  final candidateFiles = _collectCandidateFiles(root, requested);
 
   final violations = <_Violation>[];
   for (final file in candidateFiles) {
@@ -55,21 +67,33 @@ void main(List<String> args) {
   }
 
   if (violations.isEmpty) {
-    stdout.writeln('Tech ID constant usage check passed.');
-    exit(0);
+    logI('Tech ID constant usage check passed.');
+    return 0;
   }
 
-  stderr.writeln(
+  logE(
     'ERROR: Found raw tech ID string literals in executable code. '
     'Use constants/declarations from colonizethis_data instead.',
   );
   for (final violation in violations) {
-    stderr.writeln(
+    logE(
       '${violation.path}:${violation.line}:${violation.column} '
       '${violation.message}',
     );
   }
-  exit(1);
+  return 1;
+}
+
+void main(List<String> args) {
+  final parsedArgs = _parseArgs(args);
+  exit(
+    runCheckTechIdConstants(
+      Directory.current.path,
+      incrementalRelativeDartPaths: parsedArgs.files.isEmpty
+          ? null
+          : parsedArgs.files,
+    ),
+  );
 }
 
 _ParsedArgs _parseArgs(List<String> args) {
@@ -96,20 +120,10 @@ _ParsedArgs _parseArgs(List<String> args) {
     exit(2);
   }
   return _ParsedArgs(
-    files: filesArgValue == null ? const [] : _splitFileArg(filesArgValue),
+    files: filesArgValue == null
+        ? const []
+        : repoLintSplitRelativeDartPathsArg(filesArgValue),
   );
-}
-
-List<String> _splitFileArg(String value) {
-  if (value.trim().isEmpty) {
-    return const [];
-  }
-  final normalized = value.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
-  return normalized
-      .split(RegExp('[,\n]'))
-      .map((entry) => entry.trim())
-      .where((entry) => entry.isNotEmpty)
-      .toList(growable: false);
 }
 
 List<File> _collectCandidateFiles(String root, List<String> requestedPaths) {

--- a/tool/check_work_target_constants.dart
+++ b/tool/check_work_target_constants.dart
@@ -21,19 +21,27 @@ const _excludedPaths = <String>{
   'packages/colonizethis_data/lib/src/work_order_costs.dart',
 };
 
-void main(List<String> args) {
-  final parsedArgs = _parseArgs(args);
-  final root = p.normalize(Directory.current.path);
+/// Used by `ct_repo_lint` in-process; [info] / [err] default to stdout/stderr.
+int runCheckWorkTargetConstants(
+  String repoRoot, {
+  List<String>? incrementalRelativeDartPaths,
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+  final root = p.normalize(repoRoot);
   final canonicalWorkTargets = _loadCanonicalWorkTargets(root);
   if (canonicalWorkTargets.isEmpty) {
-    stderr.writeln(
+    logE(
       'ERROR: Could not derive canonical work target IDs from '
       '$_workTargetConstantsRelPath.',
     );
-    exit(1);
+    return 1;
   }
   final constantNameByWorkTarget = _loadWorkTargetConstantNames(root);
-  final candidateFiles = _collectCandidateFiles(root, parsedArgs.files);
+  final requested = incrementalRelativeDartPaths ?? const <String>[];
+  final candidateFiles = _collectCandidateFiles(root, requested);
 
   final violations = <WorkTargetConstantViolation>[];
   for (final file in candidateFiles) {
@@ -53,21 +61,33 @@ void main(List<String> args) {
   }
 
   if (violations.isEmpty) {
-    stdout.writeln('Work target constant usage check passed.');
-    exit(0);
+    logI('Work target constant usage check passed.');
+    return 0;
   }
 
-  stderr.writeln(
+  logE(
     'ERROR: Found raw work target string literals in executable code. '
     'Use constants from colonizethis_logic.',
   );
   for (final violation in violations) {
-    stderr.writeln(
+    logE(
       '${violation.path}:${violation.line}:${violation.column} '
       '${violation.message}',
     );
   }
-  exit(1);
+  return 1;
+}
+
+void main(List<String> args) {
+  final parsedArgs = _parseArgs(args);
+  exit(
+    runCheckWorkTargetConstants(
+      Directory.current.path,
+      incrementalRelativeDartPaths: parsedArgs.files.isEmpty
+          ? null
+          : parsedArgs.files,
+    ),
+  );
 }
 
 List<WorkTargetConstantViolation> findWorkTargetConstantViolations({
@@ -121,20 +141,10 @@ _ParsedArgs _parseArgs(List<String> args) {
     exit(2);
   }
   return _ParsedArgs(
-    files: filesArgValue == null ? const [] : _splitFileArg(filesArgValue),
+    files: filesArgValue == null
+        ? const []
+        : repoLintSplitRelativeDartPathsArg(filesArgValue),
   );
-}
-
-List<String> _splitFileArg(String value) {
-  if (value.trim().isEmpty) {
-    return const [];
-  }
-  final normalized = value.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
-  return normalized
-      .split(RegExp('[,\n]'))
-      .map((entry) => entry.trim())
-      .where((entry) => entry.isNotEmpty)
-      .toList(growable: false);
 }
 
 List<File> _collectCandidateFiles(String root, List<String> requestedPaths) {

--- a/tool/ct_repo_lint_lib.dart
+++ b/tool/ct_repo_lint_lib.dart
@@ -3,6 +3,15 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
+import 'check_app_hardcoded_ui_strings.dart';
+import 'check_canonical_province_tile_keys.dart';
+import 'check_civilian_unit_type_constants.dart';
+import 'check_custom_exceptions.dart';
+import 'check_disallowed_ast_patterns.dart';
+import 'check_tech_id_constants.dart';
+import 'check_work_target_constants.dart';
+import 'ct_repo_lint_scan_contract.dart';
+
 /// One entry from [tool/ct_repo_lint_manifest.yaml].
 final class RepoLintRule {
   const RepoLintRule({
@@ -385,6 +394,20 @@ int _runOneRule({
     return result.exitCode;
   }
 
+  final inProcess = _tryRunDartRuleInProcess(
+    rule: rule,
+    repoRoot: repoRoot,
+    incrementalCsv: incrementalCsv,
+  );
+  if (inProcess != null) {
+    if (inProcess != 0) {
+      stderr.writeln(
+        'ct_repo_lint: FAILED [${rule.ruleId}] exit $inProcess (see output above)',
+      );
+    }
+    return inProcess;
+  }
+
   final script = rule.script!;
   final args = <String>['run', script];
   if (rule.prIncremental &&
@@ -407,6 +430,49 @@ int _runOneRule({
     );
   }
   return result.exitCode;
+}
+
+/// Runs manifest Dart rules in-process when wired; returns `null` to fall back
+/// to `dart run` (unknown [RepoLintRule.ruleId] or future scripts).
+int? _tryRunDartRuleInProcess({
+  required RepoLintRule rule,
+  required String repoRoot,
+  required String? incrementalCsv,
+}) {
+  List<String>? incrementalPaths;
+  if (rule.prIncremental &&
+      incrementalCsv != null &&
+      incrementalCsv.isNotEmpty) {
+    incrementalPaths = repoLintSplitRelativeDartPathsArg(incrementalCsv);
+  }
+
+  switch (rule.ruleId) {
+    case 'repo.custom_exceptions':
+      return runCheckCustomExceptions(repoRoot);
+    case 'repo.disallowed_ast_patterns':
+      return runCheckDisallowedAstPatterns(repoRoot);
+    case 'repo.tech_id_constants':
+      return runCheckTechIdConstants(
+        repoRoot,
+        incrementalRelativeDartPaths: incrementalPaths,
+      );
+    case 'repo.work_target_constants':
+      return runCheckWorkTargetConstants(
+        repoRoot,
+        incrementalRelativeDartPaths: incrementalPaths,
+      );
+    case 'repo.civilian_unit_type_constants':
+      return runCheckCivilianUnitTypeConstants(
+        repoRoot,
+        incrementalRelativeDartPaths: incrementalPaths,
+      );
+    case 'repo.canonical_province_tile_keys':
+      return runCheckCanonicalProvinceTileKeys(repoRoot);
+    case 'repo.app_hardcoded_ui_strings':
+      return runCheckAppHardcodedUiStrings(repoRoot);
+    default:
+      return null;
+  }
 }
 
 void _forwardProcessOutput(ProcessResult result) {

--- a/tool/ct_repo_lint_scan_contract.dart
+++ b/tool/ct_repo_lint_scan_contract.dart
@@ -66,6 +66,19 @@ List<File> collectRepoLintDomainDartFiles(String repoRoot) {
   return files;
 }
 
+/// Splits comma/newline-separated repo-relative paths (same as `check_* --files`).
+List<String> repoLintSplitRelativeDartPathsArg(String value) {
+  if (value.trim().isEmpty) {
+    return const [];
+  }
+  final normalized = value.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+  return normalized
+      .split(RegExp('[,\n]'))
+      .map((entry) => entry.trim())
+      .where((entry) => entry.isNotEmpty)
+      .toList(growable: false);
+}
+
 // --- Identifier-literal checkers (tech / work-target / civilian unit type) ---
 
 /// Scan roots for tech / work-target / civilian literal checkers (historical


### PR DESCRIPTION
## Summary
Phase 2 slice for unified repo lint (#1730): manifest `runner: dart` rules are executed **in-process** via `runCheck…` entrypoints on existing `tool/check_*.dart` files instead of spawning `dart run` per rule. Unknown `rule_id` values still fall back to subprocess `dart run <script>`.

## SPEC
- `SPEC/program/repo-lint.md`: in-process execution, `repoLintSplitRelativeDartPathsArg`, contributor note to wire `_tryRunDartRuleInProcess` for new Dart rules.

## Tests
- `dart analyze` (modified tool files only)
- `dart test test/ct_repo_lint_test.dart`
- `dart test test/ct_repo_lint_scan_contract_test.dart`
- Smoke: `dart run tool/ct_repo_lint.dart --rule repo.custom_exceptions`

## Out of scope
- SARIF stdout relay (if/when SARIF lands on `dev`, reconcile success-line routing with in-process `runCheck` `info` sinks).
- Removing `main()` from checkers entirely (kept for `melos` / direct `dart run`).

Refs #1730

Made with [Cursor](https://cursor.com)