### PR TITLE
refactor(ctterm): extract shared isCivilianUnit (Refs #1621)

### DIFF
--- a/ctterm/lib/screens/development_screen.dart
+++ b/ctterm/lib/screens/development_screen.dart
@@ -9,6 +9,7 @@ import 'package:ctterm/map_tui_mapping.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:ctterm/utils/unit_utils.dart';
 
 final _log = packageLogger();
 
@@ -125,12 +126,6 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
   /// Color for feedback message.
   Color _feedbackColor = Colors.white;
 
-  /// Check if a unit is a civilian unit (Builder, Engineer).
-  bool _isCivilianUnit(Unit unit) {
-    final type = unit.type.toLowerCase();
-    return type.contains('builder') || type.contains('engineer');
-  }
-
   /// Get all civilian units for the human player.
   List<Unit> get _playerCivilianUnits {
     final humanPlayerId = _getHumanPlayerId();
@@ -140,12 +135,12 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
     final allUnits = <Unit>[];
     allUnits.addAll(
       component.game.worldState.oldWorld.units.where(
-        (u) => u.ownerId == humanPlayerId && _isCivilianUnit(u),
+        (u) => u.ownerId == humanPlayerId && isCivilianUnit(u),
       ),
     );
     allUnits.addAll(
       component.game.worldState.newWorld.units.where(
-        (u) => u.ownerId == humanPlayerId && _isCivilianUnit(u),
+        (u) => u.ownerId == humanPlayerId && isCivilianUnit(u),
       ),
     );
     return allUnits;
@@ -1123,7 +1118,7 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
           _buildDetailRow('Location', _getProvinceName(unit)),
           _buildDetailRow(
             'Type',
-            _isCivilianUnit(unit) ? 'Civilian' : 'Military',
+            isCivilianUnit(unit) ? 'Civilian' : 'Military',
           ),
           _buildDetailRow(
             'Status',

--- a/ctterm/lib/screens/in_game_shell_screen.dart
+++ b/ctterm/lib/screens/in_game_shell_screen.dart
@@ -10,6 +10,7 @@ import 'package:ctterm/widgets/map_grid_widget.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:ctterm/map_tui_mapping.dart';
+import 'package:ctterm/utils/unit_utils.dart';
 
 final _log = packageLogger();
 
@@ -179,11 +180,6 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
     return null;
   }
 
-  bool _isCivilianUnit(Unit unit) {
-    final type = unit.type.toLowerCase();
-    return type.contains('builder') || type.contains('engineer');
-  }
-
   List<Unit> get _playerCivilianUnits {
     final game = component.game;
     final playerId = _humanPlayerId();
@@ -191,9 +187,9 @@ class _InGameShellScreenState extends State<InGameShellScreen> {
 
     final units = <Unit>[];
     units.addAll(game.worldState.oldWorld.units
-        .where((u) => u.ownerId == playerId && _isCivilianUnit(u)));
+        .where((u) => u.ownerId == playerId && isCivilianUnit(u)));
     units.addAll(game.worldState.newWorld.units
-        .where((u) => u.ownerId == playerId && _isCivilianUnit(u)));
+        .where((u) => u.ownerId == playerId && isCivilianUnit(u)));
     return units;
   }
 

--- a/ctterm/lib/utils/unit_utils.dart
+++ b/ctterm/lib/utils/unit_utils.dart
@@ -1,0 +1,7 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// True when [unit] is a civilian type (Builder, Engineer) by [Unit.type].
+bool isCivilianUnit(Unit unit) {
+  final type = unit.type.toLowerCase();
+  return type.contains('builder') || type.contains('engineer');
+}

--- a/ctterm/test/unit_utils_test.dart
+++ b/ctterm/test/unit_utils_test.dart
@@ -1,0 +1,32 @@
+// Tests for shared civilian unit detection. Refs #1621.
+
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+import 'package:ctterm/utils/unit_utils.dart';
+
+Unit _unit(String type) => Unit(
+  id: 'u1',
+  ownerId: 'gp1',
+  type: type,
+  locationProvinceId: 'oldWorld|p1',
+);
+
+void main() {
+  group('isCivilianUnit', () {
+    test('returns true for Builder (case-insensitive)', () {
+      expect(isCivilianUnit(_unit('Builder')), isTrue);
+      expect(isCivilianUnit(_unit('builder')), isTrue);
+    });
+
+    test('returns true for Engineer (case-insensitive)', () {
+      expect(isCivilianUnit(_unit('Engineer')), isTrue);
+      expect(isCivilianUnit(_unit('engineer')), isTrue);
+    });
+
+    test('returns false for military types', () {
+      expect(isCivilianUnit(_unit('Infantry')), isFalse);
+      expect(isCivilianUnit(_unit('Cavalry')), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Extract duplicated civilian unit detection from `in_game_shell_screen.dart` and `development_screen.dart` into `ctterm/lib/utils/unit_utils.dart` as `isCivilianUnit(Unit)`.

## Acceptance criteria

- Shared utility in `ctterm/lib/utils/unit_utils.dart`
- Both screens import and use it
- Tests added and full `ctterm` suite passes

## Tests

- `dart test test/unit_utils_test.dart`
- `dart test` (entire `ctterm` package)

Refs #1621

Made with [Cursor](https://cursor.com)