### PR TITLE
Refactor stream event buses: whereType extension + AST gate (Refs #1640)

### DIFF
--- a/SPEC/program/disallowed-ast-patterns.md
+++ b/SPEC/program/disallowed-ast-patterns.md
@@ -17,6 +17,14 @@ In runtime domain code, a **cascade section** that invokes `.clear()` (`..clear(
 
 Rationale: `clear()` returns `void`; the cascade form suggests chaining a result and is easy to misread.
 
+### Redundant `.where` + `is` + `.map` + `as` on `Stream` / `Iterable`
+
+In runtime domain code, chaining **`.where((x) => x is SomeType).map((x) => x as SomeType)`** is disallowed. Prefer **`.whereType<SomeType>()`** on **`Iterable`** (`dart:core`). The Dart **`Stream`** API does not provide `whereType`; event buses and similar code should call the shared **`CtStreamWhereType`** extension in `colonizethis_models` (or an equivalent non-chained implementation), not the `where`+`map` chain.
+
+Rationale: The filter-then-cast chain duplicates work and is harder to read than a single typed narrowing step.
+
+Rule id: `stream_where_is_map_as` (`match.kind`: `stream_where_is_map_as`).
+
 ### Coverage
 
 Enforcement walks the same domain trees via `tool/ct_repo_lint_scan_contract.dart` (`collectRepoLintDomainDartFiles`), aligned with `SPEC/program/exception-enforcement.md` coverage:
@@ -39,3 +47,9 @@ Generated files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`) and tests (`**/te
 - **Given** runtime Dart source containing a cascaded method invocation `..clear()`, **when** the disallowed AST checker runs, **then** it reports at least one violation with the correct file and line.
 - **Given** runtime Dart source that calls `.clear()` without a cascade, **when** the checker runs, **then** it does not report a violation for that call.
 - **Given** runtime Dart source with `// ignore: disallowed_ast_cascade_void_clear` on the violating line or the line above, **when** the checker runs, **then** it does not report that violation.
+
+- **Given** runtime Dart source that chains `.where((p) => p is T).map((p) => p as T)` on a receiver (for example a `Stream` or `Iterable`), **when** the disallowed AST checker runs, **then** it reports at least one violation for rule `stream_where_is_map_as` with the correct file and line (the `.map` invocation).
+
+- **Given** runtime Dart source that uses `.whereType<T>()` instead of that chain, **when** the checker runs, **then** it does not report a violation for `stream_where_is_map_as`.
+
+- **Given** runtime Dart source with `// ignore: disallowed_ast_stream_where_is_map_as` on the violating line or the line above, **when** the checker runs, **then** it does not report that violation for `stream_where_is_map_as`.

--- a/packages/colonizethis_logic/lib/src/event_bus/game_event_bus.dart
+++ b/packages/colonizethis_logic/lib/src/event_bus/game_event_bus.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_models/stream_where_type.dart';
 
 import '../game_events.dart';
 
@@ -9,12 +10,6 @@ import '../game_events.dart';
 const int kGameEventLogSummaryMaxChars = 500;
 
 final _gameEventLog = packageLogger();
-
-extension _GameEventStreamWhereType on Stream<GameEvent> {
-  Stream<T> whereType<T extends GameEvent>() {
-    return where((event) => event is T).map((event) => event as T);
-  }
-}
 
 String _gameEventPayloadSummary(GameEvent event) {
   return switch (event) {

--- a/packages/colonizethis_models/lib/colonizethis_models.dart
+++ b/packages/colonizethis_models/lib/colonizethis_models.dart
@@ -38,5 +38,6 @@ export 'src/economy_plan.dart';
 export 'src/strategic_order_result.dart';
 export 'src/app_event_bus.dart';
 export 'src/app_events.dart';
+export 'src/stream_where_type.dart';
 export 'src/dossier_evidence.dart';
 export 'src/events/dialogue_event_bus.dart';

--- a/packages/colonizethis_models/lib/src/app_event_bus.dart
+++ b/packages/colonizethis_models/lib/src/app_event_bus.dart
@@ -13,6 +13,7 @@
 import 'dart:async';
 
 import 'app_events.dart';
+import 'stream_where_type.dart';
 
 class AppEventBus {
   AppEventBus._() : _controller = StreamController<AppEvent>.broadcast();
@@ -34,8 +35,7 @@ class AppEventBus {
 
   Stream<AppEvent> get stream => _controller.stream;
 
-  Stream<T> on<T extends AppEvent>() =>
-      _controller.stream.where((e) => e is T).map((e) => e as T);
+  Stream<T> on<T extends AppEvent>() => _controller.stream.whereType<T>();
 
   Stream<UIActionEvent> get uiActionEvents => on<UIActionEvent>();
 

--- a/packages/colonizethis_models/lib/src/events/dialogue_event_bus.dart
+++ b/packages/colonizethis_models/lib/src/events/dialogue_event_bus.dart
@@ -1,12 +1,7 @@
 import 'dart:async';
 
 import '../ai_events.dart';
-
-extension _DialogueEventStreamWhereType on Stream<DialogueEvent> {
-  Stream<T> whereType<T extends DialogueEvent>() {
-    return where((event) => event is T).map((event) => event as T);
-  }
-}
+import '../stream_where_type.dart';
 
 abstract class DialogueEventBus {
   void publish(DialogueEvent event);

--- a/packages/colonizethis_models/lib/src/stream_where_type.dart
+++ b/packages/colonizethis_models/lib/src/stream_where_type.dart
@@ -1,0 +1,19 @@
+import 'dart:async';
+
+/// Typed narrowing for streams, matching [Iterable.whereType].
+///
+/// The Dart SDK does not define [Stream.whereType]; event buses use this
+/// instead of chaining `.where((e) => e is T).map((e) => e as T)`.
+extension CtStreamWhereType<S> on Stream<S> {
+  Stream<T> whereType<T extends S>() {
+    return transform(
+      StreamTransformer<S, T>.fromHandlers(
+        handleData: (data, sink) {
+          if (data is T) {
+            sink.add(data);
+          }
+        },
+      ),
+    );
+  }
+}

--- a/packages/colonizethis_models/lib/stream_where_type.dart
+++ b/packages/colonizethis_models/lib/stream_where_type.dart
@@ -1,0 +1,1 @@
+export 'src/stream_where_type.dart';

--- a/packages/colonizethis_models/test/stream_where_type_test.dart
+++ b/packages/colonizethis_models/test/stream_where_type_test.dart
@@ -1,7 +1,7 @@
+import 'package:colonizethis_test/test.dart';
 import 'dart:async';
 
 import 'package:colonizethis_models/stream_where_type.dart';
-import 'package:test/test.dart';
 
 void main() {
   test('whereType emits only elements that are T', () async {

--- a/packages/colonizethis_models/test/stream_where_type_test.dart
+++ b/packages/colonizethis_models/test/stream_where_type_test.dart
@@ -1,0 +1,15 @@
+import 'dart:async';
+
+import 'package:colonizethis_models/stream_where_type.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('whereType emits only elements that are T', () async {
+    final out = await Stream<num>.fromIterable([
+      1,
+      2.5,
+      3,
+    ]).whereType<int>().toList();
+    expect(out, [1, 3]);
+  });
+}

--- a/test/check_disallowed_ast_patterns_test.dart
+++ b/test/check_disallowed_ast_patterns_test.dart
@@ -10,6 +10,10 @@ rules:
       kind: cascaded_method_invocation
       method_names:
         - clear
+  - id: stream_where_is_map_as
+    message: 'use whereType'
+    match:
+      kind: stream_where_is_map_as
 ''';
 
 void main() {
@@ -100,6 +104,89 @@ void f(List<int> a) {
           src,
           rules,
         ),
+        isEmpty,
+      );
+    });
+
+    test('flags .where is .map as chain', () {
+      const src = r'''
+import 'dart:async';
+
+Stream<int> f(Stream<num> s) =>
+    s.where((e) => e is int).map((e) => e as int);
+''';
+      final v = findDisallowedAstViolations(
+        'packages/foo/lib/x.dart',
+        src,
+        rules,
+      );
+      expect(v, isNotEmpty);
+      expect(v.first.ruleId, 'stream_where_is_map_as');
+      expect(v.first.line, greaterThan(0));
+    });
+
+    test('allows whereType', () {
+      const src = r'''
+import 'dart:async';
+
+Stream<int> f(Stream<num> s) => s.whereType<int>();
+''';
+      expect(
+        findDisallowedAstViolations('packages/foo/lib/x.dart', src, rules),
+        isEmpty,
+      );
+    });
+
+    test('allows where+map without is/as pattern', () {
+      const src = r'''
+Iterable<String> f(Iterable<Object?> xs) =>
+    xs.where((x) => x != null).map((x) => x as String);
+''';
+      expect(
+        findDisallowedAstViolations('packages/foo/lib/x.dart', src, rules),
+        isEmpty,
+      );
+    });
+
+    test('stream_where_is_map_as respects same-line ignore', () {
+      const src = r'''
+import 'dart:async';
+
+Stream<int> f(Stream<num> s) =>
+    s.where((e) => e is int).map((e) => e as int); // ignore: disallowed_ast_stream_where_is_map_as
+''';
+      expect(
+        findDisallowedAstViolations('packages/foo/lib/x.dart', src, rules),
+        isEmpty,
+      );
+    });
+
+    test('stream_where_is_map_as respects ignore on previous line', () {
+      const src = r'''
+import 'dart:async';
+
+Stream<int> f(Stream<num> s) {
+  // ignore: disallowed_ast_stream_where_is_map_as
+  return s.where((e) => e is int).map((e) => e as int);
+}
+''';
+      expect(
+        findDisallowedAstViolations('packages/foo/lib/x.dart', src, rules),
+        isEmpty,
+      );
+    });
+
+    test('stream_where_is_map_as respects ignore_for_file', () {
+      const src = r'''
+// ignore_for_file: disallowed_ast_stream_where_is_map_as
+
+import 'dart:async';
+
+Stream<int> f(Stream<num> s) =>
+    s.where((e) => e is int).map((e) => e as int);
+''';
+      expect(
+        findDisallowedAstViolations('packages/foo/lib/x.dart', src, rules),
         isEmpty,
       );
     });

--- a/tool/check_disallowed_ast_patterns.dart
+++ b/tool/check_disallowed_ast_patterns.dart
@@ -144,7 +144,17 @@ List<DisallowedPatternRule> _parseRulesYaml(Object? yamlRoot) {
         DisallowedPatternRule(
           id: id,
           message: message,
+          kind: DisallowedAstMatchKind.cascadedMethodInvocation,
           cascadedMethodNames: names,
+        ),
+      );
+    } else if (kind == 'stream_where_is_map_as') {
+      out.add(
+        DisallowedPatternRule(
+          id: id,
+          message: message,
+          kind: DisallowedAstMatchKind.streamWhereIsMapAs,
+          cascadedMethodNames: const {},
         ),
       );
     }
@@ -175,15 +185,20 @@ bool _isSuppressedAtLine(String source, int lineNumber1Based, String ruleId) {
   return false;
 }
 
+/// Kinds of structural matches defined in [tool/disallowed_ast_patterns.yaml].
+enum DisallowedAstMatchKind { cascadedMethodInvocation, streamWhereIsMapAs }
+
 class DisallowedPatternRule {
   const DisallowedPatternRule({
     required this.id,
     required this.message,
+    required this.kind,
     required this.cascadedMethodNames,
   });
 
   final String id;
   final String message;
+  final DisallowedAstMatchKind kind;
   final Set<String> cascadedMethodNames;
 }
 
@@ -201,6 +216,114 @@ class DisallowedAstViolation {
   final String message;
 }
 
+Expression _unwrapParenthesized(Expression expr) {
+  var e = expr;
+  while (e is ParenthesizedExpression) {
+    e = e.expression;
+  }
+  return e;
+}
+
+String? _singleFormalParameterId(FormalParameterList? list) {
+  if (list == null || list.parameters.length != 1) {
+    return null;
+  }
+  return _formalParameterId(list.parameters.first);
+}
+
+String? _formalParameterId(FormalParameter param) {
+  if (param is SimpleFormalParameter) {
+    return param.name?.lexeme;
+  }
+  if (param is DefaultFormalParameter) {
+    return _formalParameterId(param.parameter);
+  }
+  return null;
+}
+
+Expression? _expressionFromFunctionBody(FunctionBody body) {
+  if (body is ExpressionFunctionBody) {
+    return body.expression;
+  }
+  if (body is BlockFunctionBody) {
+    final stmts = body.block.statements;
+    if (stmts.length != 1) {
+      return null;
+    }
+    final first = stmts.first;
+    if (first is! ReturnStatement) {
+      return null;
+    }
+    return first.expression;
+  }
+  return null;
+}
+
+bool _whereCallbackIsParamIsTypeCheck(FunctionExpression fn) {
+  final paramId = _singleFormalParameterId(fn.parameters);
+  if (paramId == null) {
+    return false;
+  }
+  final bodyExpr = _expressionFromFunctionBody(fn.body);
+  if (bodyExpr == null) {
+    return false;
+  }
+  final inner = _unwrapParenthesized(bodyExpr);
+  if (inner is! IsExpression) {
+    return false;
+  }
+  final left = _unwrapParenthesized(inner.expression);
+  if (left is! SimpleIdentifier) {
+    return false;
+  }
+  return left.name == paramId;
+}
+
+bool _mapCallbackIsParamAsCast(FunctionExpression fn) {
+  final paramId = _singleFormalParameterId(fn.parameters);
+  if (paramId == null) {
+    return false;
+  }
+  final bodyExpr = _expressionFromFunctionBody(fn.body);
+  if (bodyExpr == null) {
+    return false;
+  }
+  final inner = _unwrapParenthesized(bodyExpr);
+  if (inner is! AsExpression) {
+    return false;
+  }
+  final subj = _unwrapParenthesized(inner.expression);
+  if (subj is! SimpleIdentifier) {
+    return false;
+  }
+  return subj.name == paramId;
+}
+
+bool _isRedundantWhereIsMapAsChain(MethodInvocation node) {
+  if (node.methodName.name != 'map') {
+    return false;
+  }
+  final target = node.target;
+  if (target is! MethodInvocation) {
+    return false;
+  }
+  if (target.methodName.name != 'where') {
+    return false;
+  }
+  final whereArgs = target.argumentList.arguments;
+  final mapArgs = node.argumentList.arguments;
+  if (whereArgs.length != 1 || mapArgs.length != 1) {
+    return false;
+  }
+  final whereArg = whereArgs.first;
+  final mapArg = mapArgs.first;
+  if (whereArg is! FunctionExpression || mapArg is! FunctionExpression) {
+    return false;
+  }
+  return _whereCallbackIsParamIsTypeCheck(whereArg) &&
+      _mapCallbackIsParamAsCast(mapArg);
+}
+
 class _DisallowedAstVisitor extends RecursiveAstVisitor<void> {
   _DisallowedAstVisitor(this.path, this.source, this.lineInfo, this.rules);
 
@@ -210,32 +333,43 @@ class _DisallowedAstVisitor extends RecursiveAstVisitor<void> {
   final List<DisallowedPatternRule> rules;
   final List<DisallowedAstViolation> violations = [];
 
-  @override
-  void visitMethodInvocation(MethodInvocation node) {
-    if (!node.isCascaded) {
-      super.visitMethodInvocation(node);
+  void _recordIfAllowed(AstNode anchor, DisallowedPatternRule rule) {
+    final line = lineInfo.getLocation(anchor.offset).lineNumber;
+    if (_fileIgnoresRule(source, rule.id)) {
       return;
     }
-    final name = node.methodName.name;
+    if (_isSuppressedAtLine(source, line, rule.id)) {
+      return;
+    }
+    violations.add(
+      DisallowedAstViolation(
+        path: path,
+        line: line,
+        ruleId: rule.id,
+        message: rule.message,
+      ),
+    );
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
     for (final rule in rules) {
-      if (!rule.cascadedMethodNames.contains(name)) {
-        continue;
+      if (rule.kind == DisallowedAstMatchKind.streamWhereIsMapAs &&
+          _isRedundantWhereIsMapAsChain(node)) {
+        _recordIfAllowed(node, rule);
       }
-      final line = lineInfo.getLocation(node.offset).lineNumber;
-      if (_fileIgnoresRule(source, rule.id)) {
-        continue;
+    }
+    if (node.isCascaded) {
+      final name = node.methodName.name;
+      for (final rule in rules) {
+        if (rule.kind != DisallowedAstMatchKind.cascadedMethodInvocation) {
+          continue;
+        }
+        if (!rule.cascadedMethodNames.contains(name)) {
+          continue;
+        }
+        _recordIfAllowed(node, rule);
       }
-      if (_isSuppressedAtLine(source, line, rule.id)) {
-        continue;
-      }
-      violations.add(
-        DisallowedAstViolation(
-          path: path,
-          line: line,
-          ruleId: rule.id,
-          message: rule.message,
-        ),
-      );
     }
     super.visitMethodInvocation(node);
   }

--- a/tool/disallowed_ast_patterns.yaml
+++ b/tool/disallowed_ast_patterns.yaml
@@ -12,3 +12,9 @@ rules:
       kind: cascaded_method_invocation
       method_names:
         - clear
+  - id: stream_where_is_map_as
+    message: >-
+      Do not chain .where((x) => x is T).map((x) => x as T); use
+      .whereType<T>() on Stream or Iterable instead.
+    match:
+      kind: stream_where_is_map_as


### PR DESCRIPTION
## Refs #1640

## Summary
- Replace redundant `.where((e) => e is T).map((e) => e as T)` on event bus streams with a single typed narrowing step via new `CtStreamWhereType` (`packages/colonizethis_models/lib/src/stream_where_type.dart`). Dart's `Stream` API does not provide `whereType`; this matches `Iterable.whereType` semantics using `StreamTransformer`.
- Remove duplicate private extensions from dialogue and game event bus files; `DefaultGameEventBus` imports `package:colonizethis_models/stream_where_type.dart`.
- Add disallowed AST rule `stream_where_is_map_as` (`match.kind`: `stream_where_is_map_as`) in `tool/check_disallowed_ast_patterns.dart`, `tool/disallowed_ast_patterns.yaml`, and `SPEC/program/disallowed-ast-patterns.md`, with unit tests in `test/check_disallowed_ast_patterns_test.dart`.
- Add `packages/colonizethis_models/test/stream_where_type_test.dart`.

## Tests run
- `dart test test/check_disallowed_ast_patterns_test.dart`
- `dart run tool/ct_repo_lint.dart`
- `dart test packages/colonizethis_models/test/stream_where_type_test.dart`
- `dart test packages/colonizethis_logic/test/event_bus/game_event_bus_test.dart`
- `flutter test app/test/app_event_bus_test.dart`

## Out of scope
- Optional follow-up from the issue: rule for `.where((e) => e is T).cast<T>()` (not in AC).

Made with [Cursor](https://cursor.com)