### PR TITLE
Harden sea zone map label tests (Refs #1756)

### DIFF
--- a/app/lib/features/game/flame/region_map_component_render_orchestrator.dart
+++ b/app/lib/features/game/flame/region_map_component_render_orchestrator.dart
@@ -2,25 +2,11 @@ part of 'region_map_component.dart';
 
 extension _CtRegionMapRenderOrchestrator on CtRegionMapComponent {
   TileVisibility _visibilityForTerrain(CellViewData cell) {
-    if (visibilityMode != CtMapVisibilityMode.playerConstrained) {
-      return cell.visibility;
-    }
-    if (_isUnderFleetRevealHalo(cell.x, cell.y)) {
-      return TileVisibility.visible;
-    }
-    return cell.visibility;
-  }
-
-  bool _isUnderFleetRevealHalo(int x, int y) {
-    for (final m in region.fleetTileMarkers) {
-      if (!m.applyFleetRevealHalo) {
-        continue;
-      }
-      if (math.max((x - m.x).abs(), (y - m.y).abs()) <= 2) {
-        return true;
-      }
-    }
-    return false;
+    return visibilityForTerrainForMapCell(
+      visibilityMode: visibilityMode,
+      cell: cell,
+      fleetTileMarkers: region.fleetTileMarkers,
+    );
   }
 
   void _renderRegionMap(Canvas canvas) {

--- a/app/lib/features/game/flame/region_map_component_shared.dart
+++ b/app/lib/features/game/flame/region_map_component_shared.dart
@@ -188,6 +188,45 @@ Offset resolveSeaZoneNamePlateCenterWorld({
   return Offset(cx, cy);
 }
 
+/// True when `(x, y)` is within Chebyshev distance ≤ 2 of a fleet marker that
+/// applies the naval move-draft reveal halo. SPEC/ui/map-widget.md.
+bool isCellUnderFleetRevealHalo({
+  required int x,
+  required int y,
+  required List<FleetTileMarkerView> fleetTileMarkers,
+}) {
+  for (final m in fleetTileMarkers) {
+    if (!m.applyFleetRevealHalo) {
+      continue;
+    }
+    if (math.max((x - m.x).abs(), (y - m.y).abs()) <= 2) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Effective terrain visibility for map painting (fog + fleet reveal halo).
+///
+/// Used by the region map renderer and tests for sea zone label gating (#1756).
+TileVisibility visibilityForTerrainForMapCell({
+  required CtMapVisibilityMode visibilityMode,
+  required CellViewData cell,
+  required List<FleetTileMarkerView> fleetTileMarkers,
+}) {
+  if (visibilityMode != CtMapVisibilityMode.playerConstrained) {
+    return cell.visibility;
+  }
+  if (isCellUnderFleetRevealHalo(
+    x: cell.x,
+    y: cell.y,
+    fleetTileMarkers: fleetTileMarkers,
+  )) {
+    return TileVisibility.visible;
+  }
+  return cell.visibility;
+}
+
 /// Resolves map province-label icon ids.
 ///
 /// Capital icon is prepended, then optional presence icons follow.

--- a/app/lib/widgets/ct_region_map.dart
+++ b/app/lib/widgets/ct_region_map.dart
@@ -90,6 +90,10 @@ class _CtRegionMapGame extends FlameGame with TapDetector {
 
   late final CtRegionMapComponent _mapComponent;
 
+  /// Widget tests only: Flame [onLoad] must have completed before reading.
+  @visibleForTesting
+  CtRegionMapComponent get debugMapComponentForTest => _mapComponent;
+
   /// `m` in [kRegionMapZoomMultiplierMin]–[kRegionMapZoomMultiplierMax]; camera zoom = `m × z_fit`.
   double _zoomMultiplier = 1.0;
   bool _mapLoaded = false;

--- a/app/test/ct_region_map_widget_test.dart
+++ b/app/test/ct_region_map_widget_test.dart
@@ -13,7 +13,9 @@ import 'package:colonizethis_models/colonizethis_models.dart'
 import 'package:colonizethis_app/features/game/flame/resource_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
     show
+        CtRegionMapComponent,
         extractionDiscCentersForIconRect,
+        isCellUnderFleetRevealHalo,
         resolveProvinceLabelIconIds,
         resolveProvinceLabelPresenceIconIds,
         resolveSeaZoneNamePlateCenterWorld,
@@ -24,7 +26,8 @@ import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
         shouldApplyFogToInteriorPlainsVariantBase,
         shouldApplyFogToInteriorPlainsVariantOverlay,
         shouldApplyFogToLandBase,
-        shouldWrapProvinceLabelPresenceIcons;
+        shouldWrapProvinceLabelPresenceIcons,
+        visibilityForTerrainForMapCell;
 import 'package:colonizethis_app/features/game/flame/resource_icon_disc_palette.dart';
 import 'package:colonizethis_app/features/game/flame/civilian_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/province_label_icon_cache.dart';
@@ -34,6 +37,16 @@ import 'package:colonizethis_app/widgets/ct_region_map.dart'
     show BaseLayerDisplayMode, CtRegionMap, CtMapVisibilityMode;
 
 import 'ct_region_map_test_support.dart';
+
+CtRegionMapComponent ctRegionMapComponentFromTester(WidgetTester tester) {
+  final finder = find.byWidgetPredicate(
+    (w) => w.runtimeType.toString().startsWith('GameWidget<'),
+  );
+  expect(finder, findsOneWidget);
+  final gameWidget = tester.widget(finder);
+  final game = (gameWidget as dynamic).game;
+  return (game as dynamic).debugMapComponentForTest as CtRegionMapComponent;
+}
 
 void main() {
   suppressLogsForTests();
@@ -2025,6 +2038,136 @@ void main() {
         expect(tp.width, greaterThan(200));
       },
       timeout: const Timeout(Duration(seconds: 5)),
+    );
+
+    test(
+      'visibilityForTerrainForMapCell leaves cell visibility in full map mode',
+      () {
+        const cell = CellViewData(
+          x: 1,
+          y: 2,
+          regionCellId: 's1',
+          isSea: true,
+          visibility: TileVisibility.unrevealed,
+        );
+        expect(
+          visibilityForTerrainForMapCell(
+            visibilityMode: CtMapVisibilityMode.full,
+            cell: cell,
+            fleetTileMarkers: const [],
+          ),
+          TileVisibility.unrevealed,
+        );
+      },
+    );
+
+    test(
+      'visibilityForTerrainForMapCell keeps unrevealed sea centroid hidden when constrained and no halo',
+      () {
+        const cell = CellViewData(
+          x: 1,
+          y: 0,
+          regionCellId: 'sz',
+          isSea: true,
+          visibility: TileVisibility.unrevealed,
+        );
+        expect(
+          visibilityForTerrainForMapCell(
+            visibilityMode: CtMapVisibilityMode.playerConstrained,
+            cell: cell,
+            fleetTileMarkers: const [],
+          ),
+          TileVisibility.unrevealed,
+        );
+      },
+    );
+
+    test(
+      'visibilityForTerrainForMapCell reveals unrevealed centroid under fleet move-draft halo',
+      () {
+        const cell = CellViewData(
+          x: 1,
+          y: 0,
+          regionCellId: 'sz',
+          isSea: true,
+          visibility: TileVisibility.unrevealed,
+        );
+        final markers = [
+          FleetTileMarkerView(
+            tileKey: 'oldWorld|sz|1|0',
+            x: 1,
+            y: 0,
+            locationScopeKey: 'sea:oldWorld|sz',
+            fleetIds: const ['f1'],
+            stackCount: 1,
+            applyFleetRevealHalo: true,
+          ),
+        ];
+        expect(
+          visibilityForTerrainForMapCell(
+            visibilityMode: CtMapVisibilityMode.playerConstrained,
+            cell: cell,
+            fleetTileMarkers: markers,
+          ),
+          TileVisibility.visible,
+        );
+      },
+    );
+
+    test(
+      'isCellUnderFleetRevealHalo ignores markers without applyFleetRevealHalo',
+      () {
+        expect(
+          isCellUnderFleetRevealHalo(
+            x: 1,
+            y: 0,
+            fleetTileMarkers: [
+              FleetTileMarkerView(
+                tileKey: 'k',
+                x: 1,
+                y: 0,
+                locationScopeKey: 'sea:x',
+                fleetIds: const ['f1'],
+                stackCount: 1,
+                applyFleetRevealHalo: false,
+              ),
+            ],
+          ),
+          isFalse,
+        );
+      },
+    );
+
+    testWidgets(
+      'CtRegionMapComponent showProvinceNamesLayer false when harness disables names (#1756)',
+      (WidgetTester tester) async {
+        final region = ctRegionMapTestOldWorldRegion();
+        await tester.pumpWidget(
+          ctRegionMapTestHarness(region: region, showProvinceNamesLayer: false),
+        );
+        await tester.pump();
+        expect(
+          ctRegionMapComponentFromTester(tester).showProvinceNamesLayer,
+          isFalse,
+        );
+      },
+      timeout: const Timeout(Duration(seconds: 10)),
+    );
+
+    testWidgets(
+      'CtRegionMapComponent showProvinceNamesLayer true when harness enables names (#1756)',
+      (WidgetTester tester) async {
+        final region = ctRegionMapTestOldWorldRegion();
+        await tester.pumpWidget(
+          ctRegionMapTestHarness(region: region, showProvinceNamesLayer: true),
+        );
+        await tester.pump();
+        expect(
+          ctRegionMapComponentFromTester(tester).showProvinceNamesLayer,
+          isTrue,
+        );
+      },
+      timeout: const Timeout(Duration(seconds: 10)),
     );
   });
 }


### PR DESCRIPTION
## Summary

Adds regression coverage called out as optional follow-up for #1756: sea zone name plates share the **Show province names** toggle and use the same terrain-visibility rules as the rest of the map (including fleet move-draft reveal halo).

## Changes

- **Extract** `visibilityForTerrainForMapCell` and `isCellUnderFleetRevealHalo` in `region_map_component_shared.dart` and delegate `_visibilityForTerrain` to them (single source of truth).
- **Unit tests** for full vs player-constrained visibility, unrevealed centroid without halo, halo revealing centroid, and markers with `applyFleetRevealHalo: false`.
- **Widget tests** that `CtRegionMapComponent.showProvinceNamesLayer` matches the harness when names are off vs on.
- **Test hook** `debugMapComponentForTest` on the internal Flame game (`@visibleForTesting`) so tests can read the map component without reaching private fields across libraries.

## Testing

- `flutter test app/test/ct_region_map_widget_test.dart --name "#1756"`

Refs #1756

Made with [Cursor](https://cursor.com)