### PR TITLE
Startup perf tracing and themed game-start intro spinner

### DIFF
--- a/SPEC/program/flutter-performance-tracing.md
+++ b/SPEC/program/flutter-performance-tracing.md
@@ -1,0 +1,44 @@
+# Flutter performance tracing (new-game → game screen)
+
+**Scope:** Optional instrumentation to attribute wall time after **New Game** completes until the **game screen** is interactable (GitHub #1710). Complements manual **profile/release** DevTools sessions; does not replace them.
+
+---
+
+## Timeline (Dart DevTools → Performance)
+
+Markers use prefix **`CtAppPerf.`** (filter in the timeline).
+
+| Marker | When |
+|--------|------|
+| `CtAppPerf.newGameAsync.begin` | First line of `GameService.createNewGameAsync` (after initial UI yield). |
+| `CtAppPerf.newGameAsync.phase_0` … `phase_4` | Immediately before each coarse setup phase (aligned with `onProgress` indices 0–4). |
+| `CtAppPerf.newGameAsync.complete` | After persist; immediately before returning the new `Game`. |
+| `CtAppPerf.navigate.game` | Immediately before emitting `NavigateToRouteEvent(Routes.game)` from new-game setup. |
+| `CtAppPerf.mapViewDataProvider.build` | Synchronous `mapViewDataProvider` body (single timeline slice per invalidation). |
+| `CtAppPerf.intro.asset_load.begin` / `end` | Before/after loading the intro Yarn asset string. |
+| `CtAppPerf.intro.dialogue_begin` | Immediately before `DialogueRunner.startDialogue`. |
+| `CtAppPerf.intro.first_line` | First `onStateChanged` callback where `line != null`. |
+
+---
+
+## Log lines (app package, `info`)
+
+Correlate with session buffer / grep. Messages omit repeating the logger prefix per `SPEC/program/logging/logging.md`.
+
+| Message token | Logger sub-prefix | When |
+|---------------|-------------------|------|
+| `newGameAsync begin gameId=…` | (default app) | Start of `createNewGameAsync`. |
+| `newGameAsync phase step=N total=5` | (default app) | Before each phase `N` (same indices as `onProgress`). |
+| `newGameAsync complete gameId=…` | (default app) | After save, before return. |
+| `game_intro asset_load begin asset=…` | `dialogue` | Before `loadString` for intro Yarn. |
+| `game_intro asset_load end` | `dialogue` | After parse; includes `chars=` count. |
+| `game_intro dialogue_begin node=…` | `dialogue` | Before `startDialogue`. |
+| `game_intro first_line_shown` | `dialogue` | First non-null dialogue line in overlay. |
+
+---
+
+## Acceptance criteria
+
+- Given the developer records a **profile** or **release** timeline while starting a new game, when they filter the Dart timeline by `CtAppPerf`, then the timeline shows the markers in the table above in a plausible order (setup phases before `navigate.game`, then `mapViewDataProvider.build`, then intro markers as applicable).
+
+- Given the app logger is configured at **info** for the app package, when a new game is created and the game-start intro runs, then log output includes `newGameAsync phase` lines with `step=` `0` through `4` and `game_intro` lines through `first_line_shown` on the success path.

--- a/SPEC/program/logging/logging.md
+++ b/SPEC/program/logging/logging.md
@@ -15,6 +15,7 @@
 | Ctdev file / Sim Log / pre-sim buffer | [ctdev-logging.md](../ctdev-logging.md) |
 | Test runs (suppress logger) | [test-logging.md](../test-logging.md) |
 | Prefix helper (`CtLogger`, factories) | [colonizethis-logger.md](../colonizethis-logger.md) |
+| Flutter timeline + startup log tokens (new-game → game screen) | [flutter-performance-tracing.md](../flutter-performance-tracing.md) |
 
 ---
 

--- a/app/lib/core/services/game_service.dart
+++ b/app/lib/core/services/game_service.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_app/package_logger.dart';
+import 'package:colonizethis_app/perf/app_perf_trace.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -358,20 +359,30 @@ class GameService {
     final cfg = config ?? GameSetupConfig.defaultConfig;
     final effectiveSeed = resolveEffectiveSetupSeed(cfg.seed);
     const total = newGameSetupProgressStepCount;
+    final log = packageLogger();
     Future<void> yieldUi() => Future<void>.delayed(Duration.zero);
 
     // Let any pending frame (e.g. progress modal paint) run before step 0 work.
     await yieldUi();
 
-    onProgress?.call(0, total);
+    void reportPhase(int stepIndex) {
+      ctAppPerfInstant('newGameAsync.phase_$stepIndex');
+      log.i('newGameAsync phase step=$stepIndex total=$total gameId=$gameId');
+      onProgress?.call(stepIndex, total);
+    }
+
+    ctAppPerfInstant('newGameAsync.begin');
+    log.i('newGameAsync begin gameId=$gameId');
+
+    reportPhase(0);
     await yieldUi();
     final (tileMapOW, topoOW) = _generateTileMapOldWorld(cfg, effectiveSeed);
 
-    onProgress?.call(1, total);
+    reportPhase(1);
     await yieldUi();
     final (tileMapNW, topoNW) = _generateTileMapNewWorld(cfg, effectiveSeed);
 
-    onProgress?.call(2, total);
+    reportPhase(2);
     await yieldUi();
     final warpLinks = _generateWarpLinks(
       effectiveSeed: effectiveSeed,
@@ -381,7 +392,7 @@ class GameService {
       topoNW: topoNW,
     );
 
-    onProgress?.call(3, total);
+    reportPhase(3);
     await yieldUi();
     final setupResult = createGameFromGeneratedMaps(
       config: cfg,
@@ -396,9 +407,11 @@ class GameService {
     );
     final result = _setupResultWithFinalizedGame(setupResult, effectiveSeed);
 
-    onProgress?.call(4, total);
+    reportPhase(4);
     await yieldUi();
     _persistNewGame(gameId: gameId, result: result);
+    ctAppPerfInstant('newGameAsync.complete');
+    log.i('newGameAsync complete gameId=$gameId');
     return result.game;
   }
 

--- a/app/lib/features/game/dialogue/game_start_intro_overlay.dart
+++ b/app/lib/features/game/dialogue/game_start_intro_overlay.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_app/config/app_assets.dart';
 import 'package:colonizethis_app/package_logger.dart';
+import 'package:colonizethis_app/perf/app_perf_trace.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 import 'package:jenny/jenny.dart';
@@ -8,6 +9,23 @@ import '../../../../l10n/l10n.dart';
 import '../../../../widgets/ct_dialog_shell.dart';
 import '../../../../widgets/ct_nine_patch_button.dart';
 import 'ct_dialogue_view.dart';
+
+/// Spinner while intro dialogue lines are not yet available. Uses [ThemeData.colorScheme]
+/// so the control matches the app shell (GitHub #1710).
+class GameStartIntroLoadingIndicator extends StatelessWidget {
+  const GameStartIntroLoadingIndicator({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: CircularProgressIndicator(
+        strokeWidth: 2,
+        color: theme.colorScheme.primary,
+      ),
+    );
+  }
+}
 
 /// Modal overlay that shows the game-start intro dialogue (archaic language) and
 /// blocks until the player dismisses it. SPEC/ai/dialogue-management.md § First dialogue emission point.
@@ -38,6 +56,7 @@ class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
   DialogueRunner? _runner;
   Object? _loadError;
   bool _dialogueFinished = false;
+  bool _loggedFirstLine = false;
 
   @override
   void initState() {
@@ -49,7 +68,11 @@ class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
     final log = widget.logger ?? packageLogger('dialogue');
     try {
       final bundle = widget.assetBundle ?? rootBundle;
+      ctAppPerfInstant('intro.asset_load.begin');
+      log.i('game_intro asset_load begin asset=$kDialogueGameIntroAsset');
       final text = await bundle.loadString(kDialogueGameIntroAsset);
+      ctAppPerfInstant('intro.asset_load.end');
+      log.i('game_intro asset_load end chars=${text.length}');
       final project = YarnProject();
       project.parse(text);
       if (!project.nodes.containsKey(_kIntroNode)) {
@@ -63,6 +86,11 @@ class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
         dialogueViews: [view],
       );
       view.onStateChanged = (line, choice) {
+        if (!_loggedFirstLine && line != null) {
+          _loggedFirstLine = true;
+          ctAppPerfInstant('intro.first_line');
+          log.i('game_intro first_line_shown');
+        }
         if (mounted) setState(() {});
       };
       if (!mounted) return;
@@ -70,6 +98,8 @@ class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
         _view = view;
         _runner = runner;
       });
+      ctAppPerfInstant('intro.dialogue_begin');
+      log.i('game_intro dialogue_begin node=$_kIntroNode');
       await runner.startDialogue(_kIntroNode);
       if (!mounted) return;
       setState(() => _dialogueFinished = true);
@@ -89,6 +119,7 @@ class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
   @override
   Widget build(BuildContext context) {
     final l10n = appL10n(context);
+    final theme = Theme.of(context);
     if (_loadError != null) {
       return Stack(
         children: [
@@ -145,7 +176,9 @@ class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
                     if (line != null) ...[
                       Text(
                         line.text,
-                        style: Theme.of(context).textTheme.bodyLarge,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurface,
+                        ),
                       ),
                       const SizedBox(height: 16),
                       Align(
@@ -166,7 +199,7 @@ class _GameStartIntroOverlayState extends State<GameStartIntroOverlay> {
                         ),
                       ),
                     ] else
-                      const Center(child: CircularProgressIndicator()),
+                      const GameStartIntroLoadingIndicator(),
                   ],
                 ),
               ),

--- a/app/lib/features/shell/new_game_setup_flow.dart
+++ b/app/lib/features/shell/new_game_setup_flow.dart
@@ -12,6 +12,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:colonizethis_app/app.dart';
 import 'package:colonizethis_app/config/routes.dart';
+import 'package:colonizethis_app/perf/app_perf_trace.dart';
 import 'package:colonizethis_app/core/services/game_service.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
@@ -83,6 +84,7 @@ Future<void> runNewGameSetupAfterLeaderPick({
     switch (outcome) {
       case _NewGameOutcomeSuccess(:final game):
         container.read(currentGameProvider.notifier).setGame(game);
+        ctAppPerfInstant('navigate.game');
         bus.emit(const NavigateToRouteEvent(Routes.game));
         return;
       case _NewGameOutcomeFailure(:final error):

--- a/app/lib/perf/app_perf_trace.dart
+++ b/app/lib/perf/app_perf_trace.dart
@@ -1,0 +1,14 @@
+import 'dart:developer' as developer;
+
+/// Flutter DevTools timeline markers for new-game → game-screen startup.
+/// Names are prefixed with [kAppPerfTimelinePrefix] for filtering (GitHub #1710,
+/// SPEC/program/flutter-performance-tracing.md).
+const String kAppPerfTimelinePrefix = 'CtAppPerf';
+
+void ctAppPerfInstant(String name) {
+  developer.Timeline.instantSync('$kAppPerfTimelinePrefix.$name');
+}
+
+T ctAppPerfSync<T>(String name, T Function() action) {
+  return developer.Timeline.timeSync('$kAppPerfTimelinePrefix.$name', action);
+}

--- a/app/lib/providers/map_view_provider.dart
+++ b/app/lib/providers/map_view_provider.dart
@@ -4,6 +4,7 @@ import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../config/map_terrain_config.dart';
+import '../perf/app_perf_trace.dart';
 import 'game_service_provider.dart';
 import 'games_provider.dart';
 
@@ -55,84 +56,87 @@ final mapProvinceNamesVisibleProvider =
 final mapViewDataProvider = Provider<InitGameMapViewData?>((ref) {
   final game = ref.watch(currentGameProvider);
   if (game == null) return null;
-  final service = ref.watch(gameServiceProvider);
-  final mapData = service.getMapData(game.id);
-  if (mapData == null) {
-    throw StateError('Missing required map data for gameId=${game.id}');
-  }
-  final colorOverride = greatPowerColorOverrideFromGame(game);
-
-  final humanPlayerId =
-      game.players.where((p) => p.isHuman).map((p) => p.id).firstOrNull ??
-      game.players.first.id;
-  final topology = mapData.combinedTopology;
-  final view = buildPlayerView(game, topology, humanPlayerId);
-  final humanPlayer =
-      game.players.where((p) => p.id == humanPlayerId).firstOrNull ??
-      game.players.first;
-
-  final visibilityByTile = <String, TileVisibility>{};
-  view.visibilityByTile.forEach((tileKey, level) {
-    late TileVisibility visibility;
-    switch (level) {
-      case VisibilityLevel.fullyVisible:
-        visibility = TileVisibility.visible;
-        break;
-      case VisibilityLevel.fogged:
-      case VisibilityLevel.revealed:
-        visibility = TileVisibility.fogged;
-        break;
-      case VisibilityLevel.unknown:
-        visibility = TileVisibility.unrevealed;
-        break;
+  return ctAppPerfSync('mapViewDataProvider.build', () {
+    final service = ref.watch(gameServiceProvider);
+    final mapData = service.getMapData(game.id);
+    if (mapData == null) {
+      throw StateError('Missing required map data for gameId=${game.id}');
     }
-    visibilityByTile[tileKey] = visibility;
-  });
+    final colorOverride = greatPowerColorOverrideFromGame(game);
 
-  final connectivity = resolveConnectivity(
-    game: game,
-    tileMapByRegion: mapData.tileMapByRegion,
-    topology: topology,
-  );
-  final connectivityForHuman = connectivity[humanPlayer.id];
-  final resourceExtractionUnitsByTile = <String, int>{};
-  if (connectivityForHuman != null) {
-    final portTileKeys = game.worldState.portsByProvinceSeaboard.values.toSet();
-    final prospected =
-        game.worldState.playerProspectedTiles[humanPlayer.id] ??
-        const <String>{};
-    for (final tileKey in connectivityForHuman.connected) {
-      final contribution = computeTileExtractionContributionForPlayer(
-        game: game,
-        tileMapByRegion: mapData.tileMapByRegion,
-        player: humanPlayer,
-        tileKey: tileKey,
-        connectedTileKeys: connectivityForHuman.connected,
-        pathTransportCap: connectivityForHuman.pathTransportCap,
-        connectedByRoadRule: connectivityForHuman.connectedByRoadRule,
-        portTileKeys: portTileKeys,
-        prospectedTileKeys: prospected,
-        capitalRegionId: humanPlayer.capitalTile?.regionId,
-        techCapForPlayer: (id) {
-          final player = game.playerById(id);
-          return extractionCapForUnlocked(player?.techUnlocked);
-        },
-      );
-      if (contribution == null) {
-        continue;
+    final humanPlayerId =
+        game.players.where((p) => p.isHuman).map((p) => p.id).firstOrNull ??
+        game.players.first.id;
+    final topology = mapData.combinedTopology;
+    final view = buildPlayerView(game, topology, humanPlayerId);
+    final humanPlayer =
+        game.players.where((p) => p.id == humanPlayerId).firstOrNull ??
+        game.players.first;
+
+    final visibilityByTile = <String, TileVisibility>{};
+    view.visibilityByTile.forEach((tileKey, level) {
+      late TileVisibility visibility;
+      switch (level) {
+        case VisibilityLevel.fullyVisible:
+          visibility = TileVisibility.visible;
+          break;
+        case VisibilityLevel.fogged:
+        case VisibilityLevel.revealed:
+          visibility = TileVisibility.fogged;
+          break;
+        case VisibilityLevel.unknown:
+          visibility = TileVisibility.unrevealed;
+          break;
       }
-      resourceExtractionUnitsByTile[tileKey] = contribution.units;
-    }
-  }
+      visibilityByTile[tileKey] = visibility;
+    });
 
-  return buildInitGameMapViewData(
-    game: game,
-    tileMapByRegion: mapData.tileMapByRegion,
-    topologyByRegion: mapData.topologyByRegion,
-    cellSize: MapTerrainConfig.instance.mapCellSizePx,
-    greatPowerColorOverride: colorOverride,
-    visibilityByTile: visibilityByTile,
-    warpLinks: mapData.warpLinks,
-    resourceExtractionUnitsByTile: resourceExtractionUnitsByTile,
-  );
+    final connectivity = resolveConnectivity(
+      game: game,
+      tileMapByRegion: mapData.tileMapByRegion,
+      topology: topology,
+    );
+    final connectivityForHuman = connectivity[humanPlayer.id];
+    final resourceExtractionUnitsByTile = <String, int>{};
+    if (connectivityForHuman != null) {
+      final portTileKeys = game.worldState.portsByProvinceSeaboard.values
+          .toSet();
+      final prospected =
+          game.worldState.playerProspectedTiles[humanPlayer.id] ??
+          const <String>{};
+      for (final tileKey in connectivityForHuman.connected) {
+        final contribution = computeTileExtractionContributionForPlayer(
+          game: game,
+          tileMapByRegion: mapData.tileMapByRegion,
+          player: humanPlayer,
+          tileKey: tileKey,
+          connectedTileKeys: connectivityForHuman.connected,
+          pathTransportCap: connectivityForHuman.pathTransportCap,
+          connectedByRoadRule: connectivityForHuman.connectedByRoadRule,
+          portTileKeys: portTileKeys,
+          prospectedTileKeys: prospected,
+          capitalRegionId: humanPlayer.capitalTile?.regionId,
+          techCapForPlayer: (id) {
+            final player = game.playerById(id);
+            return extractionCapForUnlocked(player?.techUnlocked);
+          },
+        );
+        if (contribution == null) {
+          continue;
+        }
+        resourceExtractionUnitsByTile[tileKey] = contribution.units;
+      }
+    }
+
+    return buildInitGameMapViewData(
+      game: game,
+      tileMapByRegion: mapData.tileMapByRegion,
+      topologyByRegion: mapData.topologyByRegion,
+      cellSize: MapTerrainConfig.instance.mapCellSizePx,
+      greatPowerColorOverride: colorOverride,
+      visibilityByTile: visibilityByTile,
+      warpLinks: mapData.warpLinks,
+      resourceExtractionUnitsByTile: resourceExtractionUnitsByTile,
+    );
+  });
 });

--- a/app/test/app_perf_trace_test.dart
+++ b/app/test/app_perf_trace_test.dart
@@ -1,7 +1,12 @@
-import 'package:colonizethis_app/perf/app_perf_trace.dart';
+// Log suppression first (SPEC/program/test-logging.md); then Flutter test API.
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:colonizethis_app/perf/app_perf_trace.dart';
+
 void main() {
+  suppressLogsForTests();
+
   test('ctAppPerfSync returns value from action', () {
     final v = ctAppPerfSync('test.block', () => 42);
     expect(v, 42);

--- a/app/test/app_perf_trace_test.dart
+++ b/app/test/app_perf_trace_test.dart
@@ -1,0 +1,13 @@
+import 'package:colonizethis_app/perf/app_perf_trace.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('ctAppPerfSync returns value from action', () {
+    final v = ctAppPerfSync('test.block', () => 42);
+    expect(v, 42);
+  });
+
+  test('ctAppPerfInstant does not throw', () {
+    expect(() => ctAppPerfInstant('test.instant'), returnsNormally);
+  });
+}

--- a/app/test/dialogue_acceptance_test.dart
+++ b/app/test/dialogue_acceptance_test.dart
@@ -5,7 +5,8 @@ import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:colonizethis_app/features/game/dialogue/game_start_intro_overlay.dart';
+import 'package:colonizethis_app/features/game/dialogue/game_start_intro_overlay.dart'
+    show GameStartIntroLoadingIndicator, GameStartIntroOverlay;
 import 'package:colonizethis_app/features/game/dialogue/overture_dialogue_overlay.dart';
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
@@ -20,52 +21,80 @@ class _ThrowingAssetBundle extends Fake implements AssetBundle {
 void main() {
   suppressLogsForTests();
 
-  group('GameStartIntroOverlay — SPEC/ai/dialogue-management.md § First dialogue emission point', () {
-    testWidgets(
-      'AC: asset load failure shows error shell; Continue invokes onDismissed',
-      (WidgetTester tester) async {
-        var dismissed = false;
+  group(
+    'GameStartIntroOverlay — SPEC/ai/dialogue-management.md § First dialogue emission point',
+    () {
+      testWidgets('GameStartIntroLoadingIndicator uses ColorScheme.primary', (
+        WidgetTester tester,
+      ) async {
+        const seedColor = Color(0xFF112233);
+        final theme = ThemeData(
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: seedColor,
+            brightness: Brightness.dark,
+          ),
+          useMaterial3: true,
+        );
         await tester.pumpWidget(
           MaterialApp(
-            home: GameStartIntroOverlay(
-              assetBundle: _ThrowingAssetBundle(),
-              onDismissed: () => dismissed = true,
-              child: const SizedBox(),
-            ),
+            theme: theme,
+            home: const Scaffold(body: GameStartIntroLoadingIndicator()),
           ),
         );
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 200));
-        expect(
-          find.textContaining('Could not load intro dialogue'),
-          findsOneWidget,
+        final indicator = tester.widget<CircularProgressIndicator>(
+          find.byType(CircularProgressIndicator),
         );
-        await tester.tap(find.text('Continue'));
-        await tester.pump();
-        expect(dismissed, isTrue);
-      },
-    );
+        expect(indicator.color, theme.colorScheme.primary);
+        expect(indicator.strokeWidth, 2);
+      });
 
-    testWidgets('AC: modal uses CtDialogShell and blocks; intro text and Continue present',
+      testWidgets(
+        'AC: asset load failure shows error shell; Continue invokes onDismissed',
         (WidgetTester tester) async {
-      var dismissed = false;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: GameStartIntroOverlay(
-            onDismissed: () => dismissed = true,
-            child: const SizedBox(),
-          ),
-        ),
+          var dismissed = false;
+          await tester.pumpWidget(
+            MaterialApp(
+              home: GameStartIntroOverlay(
+                assetBundle: _ThrowingAssetBundle(),
+                onDismissed: () => dismissed = true,
+                child: const SizedBox(),
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 200));
+          expect(
+            find.textContaining('Could not load intro dialogue'),
+            findsOneWidget,
+          );
+          await tester.tap(find.text('Continue'));
+          await tester.pump();
+          expect(dismissed, isTrue);
+        },
       );
-      await tester.pump(const Duration(milliseconds: 100));
-      await tester.pumpAndSettle(const Duration(seconds: 5));
-      expect(find.byType(CtDialogShell), findsOneWidget);
-      expect(dismissed, isFalse);
-      expect(find.textContaining('imperialism'), findsOneWidget);
-      expect(find.byType(CtNinePatchButton), findsWidgets);
-    });
 
-  });
+      testWidgets(
+        'AC: modal uses CtDialogShell and blocks; intro text and Continue present',
+        (WidgetTester tester) async {
+          var dismissed = false;
+          await tester.pumpWidget(
+            MaterialApp(
+              home: GameStartIntroOverlay(
+                onDismissed: () => dismissed = true,
+                child: const SizedBox(),
+              ),
+            ),
+          );
+          await tester.pump(const Duration(milliseconds: 100));
+          await tester.pumpAndSettle(const Duration(seconds: 5));
+          expect(find.byType(CtDialogShell), findsOneWidget);
+          expect(dismissed, isFalse);
+          expect(find.textContaining('imperialism'), findsOneWidget);
+          expect(find.byType(CtNinePatchButton), findsWidgets);
+        },
+      );
+    },
+  );
 
   group('OvertureDialogueOverlay — SPEC/ui/dialogue-presentation.md AC', () {
     Game minimalGame() {
@@ -77,58 +106,56 @@ void main() {
           newWorld: RegionData(),
         ),
         players: [
-          Player(
-            id: 'gp1',
-            displayName: 'France',
-            isHuman: false,
-            treasury: 0,
-          ),
+          Player(id: 'gp1', displayName: 'France', isHuman: false, treasury: 0),
         ],
       );
     }
 
-    testWidgets('AC: modal with CtDialogShell; Accept/Reject per offer; Submit calls onDecisions with OvertureDecision list',
-        (WidgetTester tester) async {
-      List<OvertureDecision>? captured;
-      final game = minimalGame();
-      final offers = [
-        const OvertureOffer(
-          offererGpId: 'gp1',
-          targetFactionId: 'gp2',
-          stage: OvertureStage.embassy,
-        ),
-      ];
-      await tester.pumpWidget(
-        MaterialApp(
-          home: OvertureDialogueOverlay(
-            game: game,
-            pendingOvertures: offers,
-            skipIntroForTest: true,
-            onDecisions: (decisions) => captured = decisions,
-            child: const SizedBox(),
+    testWidgets(
+      'AC: modal with CtDialogShell; Accept/Reject per offer; Submit calls onDecisions with OvertureDecision list',
+      (WidgetTester tester) async {
+        List<OvertureDecision>? captured;
+        final game = minimalGame();
+        final offers = [
+          const OvertureOffer(
+            offererGpId: 'gp1',
+            targetFactionId: 'gp2',
+            stage: OvertureStage.embassy,
           ),
-        ),
-      );
-      await tester.pumpAndSettle(const Duration(seconds: 1));
-      expect(find.byType(CtDialogShell), findsOneWidget);
-      expect(find.text('Diplomatic overtures'), findsOneWidget);
-      expect(find.text('Accept'), findsWidgets);
-      expect(find.text('Reject'), findsWidgets);
-      expect(find.text('Submit'), findsOneWidget);
-      await tester.tap(find.text('Reject'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('Submit'));
-      await tester.pumpAndSettle();
-      expect(captured, isNotNull);
-      expect(captured!.length, 1);
-      expect(captured!.single.offererGpId, 'gp1');
-      expect(captured!.single.targetFactionId, 'gp2');
-      expect(captured!.single.stage, OvertureStage.embassy);
-      expect(captured!.single.accepted, isFalse);
-    });
+        ];
+        await tester.pumpWidget(
+          MaterialApp(
+            home: OvertureDialogueOverlay(
+              game: game,
+              pendingOvertures: offers,
+              skipIntroForTest: true,
+              onDecisions: (decisions) => captured = decisions,
+              child: const SizedBox(),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle(const Duration(seconds: 1));
+        expect(find.byType(CtDialogShell), findsOneWidget);
+        expect(find.text('Diplomatic overtures'), findsOneWidget);
+        expect(find.text('Accept'), findsWidgets);
+        expect(find.text('Reject'), findsWidgets);
+        expect(find.text('Submit'), findsOneWidget);
+        await tester.tap(find.text('Reject'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Submit'));
+        await tester.pumpAndSettle();
+        expect(captured, isNotNull);
+        expect(captured!.length, 1);
+        expect(captured!.single.offererGpId, 'gp1');
+        expect(captured!.single.targetFactionId, 'gp2');
+        expect(captured!.single.stage, OvertureStage.embassy);
+        expect(captured!.single.accepted, isFalse);
+      },
+    );
 
-    testWidgets('AC: pixel-art — CtDialogShell and CtNinePatchButton used',
-        (WidgetTester tester) async {
+    testWidgets('AC: pixel-art — CtDialogShell and CtNinePatchButton used', (
+      WidgetTester tester,
+    ) async {
       final game = minimalGame();
       final offers = [
         const OvertureOffer(


### PR DESCRIPTION
## Refs #1710

Partial delivery for Android new-game → game-screen performance work: **Phase A instrumentation** (Dart DevTools `CtAppPerf.*` timeline markers + correlated `info` logs) and a **small UX fix** for the game-start intro loading state so the spinner uses `ColorScheme.primary` (matching the new-game progress dialog) instead of the default Material look.

### SPEC
- `SPEC/program/flutter-performance-tracing.md` — marker names, log tokens, ACs for trace/log correlation
- `SPEC/program/logging/logging.md` — index row linking the tracing doc

### Out of scope (issue follow-up)
- Attaching a Galaxy A56 **profile** trace to the PR (requires device); use the new `CtAppPerf` filter in DevTools after this lands
- Deeper hotspots (`mapViewDataProvider` isolate work, nine-patch preload, etc.) once baseline traces exist

### Tests
`cd app && flutter test test/app_perf_trace_test.dart test/dialogue_acceptance_test.dart test/game_service_integration_test.dart`

Made with [Cursor](https://cursor.com)