### PR TITLE
Seaboard/port audit for sim_scenarios (Refs #1766)

### DIFF
--- a/SPEC/program/sim-scenarios.md
+++ b/SPEC/program/sim-scenarios.md
@@ -252,3 +252,21 @@ Markdown report with:
 - Entry: `melos run sim_scenarios`
 - Depends on: `runInitGame()` from colonizethis_logic, `GameSaveAdapter` from colonizethis_save
 - Shares init code with ctdev via `init_game_orchestrator.dart`
+
+---
+
+## Seaboard and port audit (GitHub [#1766](https://github.com/waigore/colonizethisv3/issues/1766))
+
+**Purpose:** After each scenario’s game is initialized and optional `setup` is applied, the runner performs a **seaboard / port data audit** so invalid `portsByProvinceSeaboard` geometry or missing capital-port registry entries fail **before** map view construction. Complements strict harbor placement in [town-port-icons.md](../ui/town-port-icons.md) (GitHub [#1761](https://github.com/waigore/colonizethisv3/issues/1761)).
+
+**Where:** `tool/sim_scenarios/lib/seaboard_port_audit.dart`, invoked from `tool/sim_scenarios/lib/scenario_runner.dart` immediately after setup.
+
+**Predicate (summary):**
+
+- **Seaboard province:** same as map view / capital setup — province node with a **P↔S** topology edge to a **sea zone** node in that region’s topology (local sea zone ids), per [map-topology.md](../game/map-topology.md) and `init_game_map_view_builder` coastal detection.
+- **Drawable sea cell:** for every `portsByProvinceSeaboard` entry, `computePortDrawableSeaCellForMap` (colonizethis_map) must not throw for that entry’s port tile key and the region’s tile map + sea zone id set.
+- **Capital port completeness:** for each Great Power, Minor Nation, and Tribe with a **capital tile** in a region whose topology marks that capital province as **sea-bound** (`isProvinceSeaBound`), every adjacent sea zone in that topology must have a matching `portsByProvinceSeaboard` key `fullProvinceId|seaZoneId` (same shape as `applyCapitalPortAndRoad` in capital setup). Inland capitals are not checked for port registry completeness.
+
+**Skipped audit:** Init paths without both `tileMapByRegion` and `topologyByRegion` (e.g. `saved` scenarios that load a game without map data in the runner) skip the audit and record `skipped: true` in the JSON summary; they do **not** fail the scenario on that basis alone.
+
+**Output:** Batch and single-scenario runs append a fenced **JSON** block after the markdown report with `seaboardPortAuditVersion` and per-scenario `portAudit` objects (`skipped`, `skipReason`, `failures` with structured fields). Any non-skipped audit failure fails the scenario run and exits non-zero (same CI gate as `melos run sim_scenarios`).

--- a/tool/sim_scenarios/bin/sim_scenarios.dart
+++ b/tool/sim_scenarios/bin/sim_scenarios.dart
@@ -5,6 +5,7 @@
 //   dart run sim_scenarios --scenario=path.json     # Run specific scenario
 //   dart run sim_scenarios --directory=path/to/scenarios  # Run all in directory
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/args.dart';
@@ -98,6 +99,13 @@ void main(List<String> args) async {
     final report = formatScenarioReport(result);
     _log.i('run report\n$report');
     print(report);
+    final auditJson = seaboardPortAuditJson(
+      BatchResult(results: [result], runTime: DateTime.now()),
+    );
+    print('');
+    print('```json');
+    print(const JsonEncoder.withIndent('  ').convert(auditJson));
+    print('```');
     exit(result.passed ? 0 : 1);
   } else {
     // Run all scenarios in directory
@@ -113,9 +121,29 @@ void main(List<String> args) async {
     final report = formatBatchReport(batchResult);
     _log.i('run report\n$report');
     print(report);
+    final auditJson = seaboardPortAuditJson(batchResult);
+    print('');
+    print('```json');
+    print(const JsonEncoder.withIndent('  ').convert(auditJson));
+    print('```');
     exit(batchResult.failed > 0 ? 1 : 0);
   }
 }
+
+/// Machine-readable seaboard/port audit summary (GitHub #1766).
+Map<String, Object?> seaboardPortAuditJson(BatchResult batch) => {
+      'seaboardPortAuditVersion': 1,
+      'refs': {'issue1766': 'https://github.com/waigore/colonizethisv3/issues/1766'},
+      'scenarios': [
+        for (final r in batch.results)
+          {
+            'scenario': r.scenarioName,
+            'scenarioPassed': r.passed,
+            if (r.seaboardPortAudit != null)
+              'portAudit': r.seaboardPortAudit!.toJsonObject(),
+          },
+      ],
+    };
 
 /// Formats a batch result as markdown.
 String formatBatchReport(BatchResult batch) {

--- a/tool/sim_scenarios/lib/game_factory.dart
+++ b/tool/sim_scenarios/lib/game_factory.dart
@@ -17,11 +17,15 @@ class GameInitResult {
   const GameInitResult({
     required this.game,
     this.topology,
+    this.topologyByRegion,
     this.tileMapByRegion,
   });
 
   final Game game;
+  /// Combined topology (prefixed ids) for turn resolution.
   final MapTopology? topology;
+  /// Per-region topology with local node ids (capital setup, map drawable checks).
+  final Map<String, MapTopology>? topologyByRegion;
   final Map<String, TileMapResult>? tileMapByRegion;
 }
 
@@ -44,6 +48,7 @@ class GameFactory {
     return GameInitResult(
       game: result.game,
       topology: result.combinedTopology,
+      topologyByRegion: result.topologyByRegion,
       tileMapByRegion: result.tileMapByRegion,
     );
   }
@@ -165,6 +170,7 @@ class GameFactory {
     return GameInitResult(
       game: game,
       topology: setupResult.combinedTopology,
+      topologyByRegion: setupResult.topologyByRegion,
       tileMapByRegion: setupResult.tileMapByRegion,
     );
   }

--- a/tool/sim_scenarios/lib/scenario_runner.dart
+++ b/tool/sim_scenarios/lib/scenario_runner.dart
@@ -9,6 +9,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'game_factory.dart';
 import 'order_script.dart';
 import 'scenario.dart';
+import 'seaboard_port_audit.dart';
 import 'state_verifier.dart';
 
 /// Holds game state for scenario execution.
@@ -16,11 +17,13 @@ class ScenarioContext {
   const ScenarioContext({
     required this.game,
     this.topology,
+    this.topologyByRegion,
     this.tileMapByRegion,
   });
 
   final Game game;
   final MapTopology? topology;
+  final Map<String, MapTopology>? topologyByRegion;
   final Map<String, TileMapResult>? tileMapByRegion;
 }
 
@@ -32,6 +35,7 @@ class ScenarioResult {
     required this.failures,
     this.finalState,
     this.turnResults = const {},
+    this.seaboardPortAudit,
   });
 
   final String scenarioName;
@@ -39,6 +43,8 @@ class ScenarioResult {
   final List<String> failures;
   final Game? finalState;
   final Map<int, TurnResult> turnResults;
+  /// GitHub #1766 — null if audit did not run (e.g. init failed before context).
+  final SeaboardPortAuditOutcome? seaboardPortAudit;
 }
 
 /// Result of a single turn within a scenario.
@@ -102,7 +108,28 @@ class ScenarioRunner {
         currentContext = ScenarioContext(
           game: _applySetup(currentContext.game, scenario.setup!),
           topology: currentContext.topology,
+          topologyByRegion: currentContext.topologyByRegion,
           tileMapByRegion: currentContext.tileMapByRegion,
+        );
+      }
+
+      final maps = currentContext.tileMapByRegion;
+      final topoByRegion = currentContext.topologyByRegion;
+      final SeaboardPortAuditOutcome portAudit;
+      if (maps != null &&
+          topoByRegion != null &&
+          maps.isNotEmpty &&
+          topoByRegion.isNotEmpty) {
+        portAudit = runSeaboardPortAudit(
+          game: currentContext.game,
+          tileMapByRegion: maps,
+          topologyByRegion: topoByRegion,
+        );
+      } else {
+        portAudit = SeaboardPortAuditOutcome(
+          skipped: true,
+          skipReason:
+              'missing tileMapByRegion or topologyByRegion (e.g. saved-game init without maps)',
         );
       }
 
@@ -114,6 +141,7 @@ class ScenarioRunner {
         final contextForTurn = ScenarioContext(
           game: gameForTurn,
           topology: currentContext.topology,
+          topologyByRegion: currentContext.topologyByRegion,
           tileMapByRegion: currentContext.tileMapByRegion,
         );
         // Parse orders
@@ -132,6 +160,7 @@ class ScenarioRunner {
         currentContext = ScenarioContext(
           game: nextGame,
           topology: currentContext.topology,
+          topologyByRegion: currentContext.topologyByRegion,
           tileMapByRegion: currentContext.tileMapByRegion,
         );
 
@@ -164,12 +193,17 @@ class ScenarioRunner {
       }
       allFailures.addAll(finalResult.failures);
 
+      if (!portAudit.skipped && !portAudit.passed) {
+        allFailures.addAll(portAudit.failures.map((f) => f.message));
+      }
+
       return ScenarioResult(
         scenarioName: scenario.name,
         passed: allFailures.isEmpty,
         failures: allFailures,
         finalState: currentContext.game,
         turnResults: turnResults,
+        seaboardPortAudit: portAudit,
       );
     } catch (e, stack) {
       return ScenarioResult(
@@ -221,6 +255,7 @@ class ScenarioRunner {
       return ScenarioContext(
         game: result.game,
         topology: result.topology,
+        topologyByRegion: result.topologyByRegion,
         tileMapByRegion: result.tileMapByRegion,
       );
     } else if (scenario.init.type == 'fromTopology') {
@@ -228,6 +263,7 @@ class ScenarioRunner {
       return ScenarioContext(
         game: result.game,
         topology: result.topology,
+        topologyByRegion: result.topologyByRegion,
         tileMapByRegion: result.tileMapByRegion,
       );
     } else if (scenario.init.type == 'saved') {

--- a/tool/sim_scenarios/lib/seaboard_port_audit.dart
+++ b/tool/sim_scenarios/lib/seaboard_port_audit.dart
@@ -1,0 +1,280 @@
+// Seaboard / port data audit for sim_scenarios. GitHub #1766, SPEC/game/capital-and-connectivity.md,
+// SPEC/ui/town-port-icons.md. Aligns seaboard detection with init_game_map_view_builder (P–S topology
+// edges + sea zone node ids) and validates drawable sea cells for every portsByProvinceSeaboard entry.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// One failure row for machine-readable reporting (JSON) and stderr messages.
+class SeaboardPortAuditFailure {
+  const SeaboardPortAuditFailure({
+    required this.kind,
+    required this.message,
+    this.region,
+    this.provinceId,
+    this.seaboardKey,
+    this.portTileKey,
+    this.factionId,
+    this.seaZoneId,
+  });
+
+  /// `drawable_error` | `missing_capital_port` | `malformed_port_entry`
+  final String kind;
+  final String message;
+  final String? region;
+  final String? provinceId;
+  final String? seaboardKey;
+  final String? portTileKey;
+  final String? factionId;
+  final String? seaZoneId;
+
+  Map<String, Object?> toJsonObject() => {
+        'kind': kind,
+        'message': message,
+        if (region != null) 'region': region,
+        if (provinceId != null) 'provinceId': provinceId,
+        if (seaboardKey != null) 'seaboardKey': seaboardKey,
+        if (portTileKey != null) 'portTileKey': portTileKey,
+        if (factionId != null) 'factionId': factionId,
+        if (seaZoneId != null) 'seaZoneId': seaZoneId,
+      };
+
+  @override
+  String toString() => message;
+}
+
+/// Outcome of [runSeaboardPortAudit].
+class SeaboardPortAuditOutcome {
+  const SeaboardPortAuditOutcome({
+    required this.skipped,
+    this.skipReason,
+    this.failures = const [],
+  });
+
+  final bool skipped;
+  final String? skipReason;
+  final List<SeaboardPortAuditFailure> failures;
+
+  bool get passed => failures.isEmpty;
+
+  Map<String, Object?> toJsonObject() => {
+        'skipped': skipped,
+        if (skipReason != null) 'skipReason': skipReason,
+        'failureCount': failures.length,
+        'failures': [for (final f in failures) f.toJsonObject()],
+      };
+}
+
+Set<String> _seaZoneNodeIds(MapTopology topology) => {
+      for (final n in topology.nodes)
+        if (n.type == TopologyNodeType.seaZone) n.id,
+    };
+
+TopologyNode? _nodeById(MapTopology topology, String id) {
+  for (final n in topology.nodes) {
+    if (n.id == id) return n;
+  }
+  return null;
+}
+
+/// Same rule as [applyCapitalPortAndRoad]: sea zones sharing a topology edge with [localProvinceId].
+Set<String> _seaZonesAdjacentToProvince(
+  MapTopology topology,
+  String localProvinceId,
+) {
+  final out = <String>{};
+  for (final edge in topology.edges) {
+    if (edge.id1 != localProvinceId && edge.id2 != localProvinceId) {
+      continue;
+    }
+    final other = edge.id1 == localProvinceId ? edge.id2 : edge.id1;
+    final node = _nodeById(topology, other);
+    if (node != null && node.type == TopologyNodeType.seaZone) {
+      out.add(other);
+    }
+  }
+  return out;
+}
+
+/// Parses `portsByProvinceSeaboard` keys: `regionId|localProvinceId|seaZoneId` or legacy `province|sea`.
+(String? fullProvinceId, String? seaZoneId, String? error) _parseSeaboardKey(String key) {
+  final parts = key.split('|');
+  if (parts.length >= 3) {
+    return ('${parts[0]}|${parts[1]}', parts[2], null);
+  }
+  if (parts.length >= 2) {
+    return (parts[0], parts[1], null);
+  }
+  return (null, null, 'seaboard key has fewer than 2 segments: "$key"');
+}
+
+/// Validates port registry and capital seaboard completeness per SPEC/game/capital-and-connectivity.md
+/// § Capital Setup (shared [applyCapitalPortAndRoad] for GPs, minors, tribes on sea-bound capitals).
+SeaboardPortAuditOutcome runSeaboardPortAudit({
+  required Game game,
+  required Map<String, TileMapResult> tileMapByRegion,
+  required Map<String, MapTopology> topologyByRegion,
+}) {
+  if (tileMapByRegion.isEmpty) {
+    return const SeaboardPortAuditOutcome(
+      skipped: true,
+      skipReason: 'tileMapByRegion is empty',
+    );
+  }
+  if (topologyByRegion.isEmpty) {
+    return const SeaboardPortAuditOutcome(
+      skipped: true,
+      skipReason: 'topologyByRegion is empty',
+    );
+  }
+
+  final failures = <SeaboardPortAuditFailure>[];
+  final ports = game.worldState.portsByProvinceSeaboard;
+
+  for (final e in ports.entries) {
+    final key = e.key;
+    final portTileKey = e.value;
+    final parsed = _parseSeaboardKey(key);
+    if (parsed.$3 != null) {
+      failures.add(
+        SeaboardPortAuditFailure(
+          kind: 'malformed_port_entry',
+          message:
+              '[seaboard-port-audit] malformed seaboardKey="$key": ${parsed.$3}',
+          seaboardKey: key,
+          portTileKey: portTileKey,
+        ),
+      );
+      continue;
+    }
+    final fullProvinceId = parsed.$1!;
+    final seaZoneIdFromKey = parsed.$2!;
+
+    final tileParts = portTileKey.split('|');
+    if (tileParts.length < 4) {
+      failures.add(
+        SeaboardPortAuditFailure(
+          kind: 'malformed_port_entry',
+          message:
+              '[seaboard-port-audit] port tile key must have 4 segments for '
+              'seaboardKey="$key" got "$portTileKey"',
+          seaboardKey: key,
+          portTileKey: portTileKey,
+          provinceId: fullProvinceId,
+        ),
+      );
+      continue;
+    }
+    final regionId = tileParts[0];
+    final tileMap = tileMapByRegion[regionId];
+    final topology = topologyByRegion[regionId];
+    if (tileMap == null || topology == null) {
+      failures.add(
+        SeaboardPortAuditFailure(
+          kind: 'malformed_port_entry',
+          message:
+              '[seaboard-port-audit] missing tile map or topology for region '
+              '$regionId (seaboardKey="$key" portTileKey="$portTileKey")',
+          region: regionId,
+          seaboardKey: key,
+          portTileKey: portTileKey,
+          provinceId: fullProvinceId,
+        ),
+      );
+      continue;
+    }
+
+    final seaZoneIds = _seaZoneNodeIds(topology);
+    if (!seaZoneIds.contains(seaZoneIdFromKey)) {
+      failures.add(
+        SeaboardPortAuditFailure(
+          kind: 'malformed_port_entry',
+          message:
+              '[seaboard-port-audit] seaZoneId "$seaZoneIdFromKey" from seaboardKey '
+              '"$key" is not a sea zone node in region $regionId topology',
+          region: regionId,
+          seaboardKey: key,
+          seaZoneId: seaZoneIdFromKey,
+          provinceId: fullProvinceId,
+        ),
+      );
+      continue;
+    }
+
+    try {
+      computePortDrawableSeaCellForMap(
+        tileMap: tileMap,
+        seaZoneIds: seaZoneIds,
+        portTileKey: portTileKey,
+        contextLabel: 'audit seaboardKey=$key',
+      );
+    } on PortDrawableSeaCellException catch (ex) {
+      failures.add(
+        SeaboardPortAuditFailure(
+          kind: 'drawable_error',
+          message:
+              '[seaboard-port-audit] drawable_error region=$regionId '
+              'province=$fullProvinceId seaboardKey="$key" '
+              'portTileKey="$portTileKey" detail=$ex',
+          region: regionId,
+          provinceId: fullProvinceId,
+          seaboardKey: key,
+          portTileKey: portTileKey,
+        ),
+      );
+    }
+  }
+
+  void checkFaction({
+    required String factionId,
+    required CapitalTile? capitalTile,
+  }) {
+    if (capitalTile == null) {
+      return;
+    }
+    final regionId = capitalTile.regionId;
+    final topology = topologyByRegion[regionId];
+    final tileMap = tileMapByRegion[regionId];
+    if (topology == null || tileMap == null) {
+      return;
+    }
+    final fullProvinceId = capitalTile.provinceId;
+    final localId = ProvinceId.localIdFrom(fullProvinceId);
+    if (!isProvinceSeaBound(topology, localId)) {
+      return;
+    }
+    final adjacentSeas = _seaZonesAdjacentToProvince(topology, localId);
+    for (final sea in adjacentSeas) {
+      final expectedKey = '$fullProvinceId|$sea';
+      if (!ports.containsKey(expectedKey)) {
+        failures.add(
+          SeaboardPortAuditFailure(
+            kind: 'missing_capital_port',
+            message:
+                '[seaboard-port-audit] missing_capital_port faction=$factionId '
+                'region=$regionId province=$fullProvinceId seaZone=$sea '
+                '(expected portsByProvinceSeaboard key "$expectedKey")',
+            region: regionId,
+            provinceId: fullProvinceId,
+            factionId: factionId,
+            seaZoneId: sea,
+          ),
+        );
+      }
+    }
+  }
+
+  for (final p in game.players) {
+    checkFaction(factionId: p.id, capitalTile: p.capitalTile);
+  }
+  for (final m in game.minorNations) {
+    checkFaction(factionId: m.id, capitalTile: m.capitalTile);
+  }
+  for (final t in game.tribes) {
+    checkFaction(factionId: t.id, capitalTile: t.capitalTile);
+  }
+
+  return SeaboardPortAuditOutcome(skipped: false, failures: failures);
+}

--- a/tool/sim_scenarios/test/seaboard_port_audit_test.dart
+++ b/tool/sim_scenarios/test/seaboard_port_audit_test.dart
@@ -1,0 +1,138 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:sim_scenarios/seaboard_port_audit.dart';
+
+void main() {
+  group('runSeaboardPortAudit', () {
+    final topology = MapTopology(
+      nodes: const [
+        TopologyNode(id: 'p1', regionId: 'oldWorld', type: TopologyNodeType.province),
+        TopologyNode(id: 's1', regionId: 'oldWorld', type: TopologyNodeType.seaZone),
+      ],
+      edges: const [TopologyEdge(id1: 'p1', id2: 's1')],
+    );
+
+    final tileMapPass = TileMapResult(
+      width: 3,
+      height: 1,
+      grid: [
+        ['p1', 'p1', 's1'],
+      ],
+    );
+
+    WorldState emptyWorld({Map<String, String> ports = const {}}) {
+      return WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+        oldWorld: const RegionData(provinces: [], units: []),
+        newWorld: const RegionData(provinces: [], units: []),
+        portsByProvinceSeaboard: ports,
+      );
+    }
+
+    test('passes when port tile has orthogonal sea and capital ports complete', () {
+      final game = Game(
+        id: 'audit_test',
+        worldState: emptyWorld(
+          ports: {'oldWorld|p1|s1': 'oldWorld|p1|1|0'},
+        ),
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'GP1',
+            isHuman: true,
+            capitalProvinceId: 'oldWorld|p1',
+            capitalTile: CapitalTile(
+              regionId: 'oldWorld',
+              provinceId: 'oldWorld|p1',
+              x: 0,
+              y: 0,
+            ),
+          ),
+        ],
+      );
+      final outcome = runSeaboardPortAudit(
+        game: game,
+        tileMapByRegion: {'oldWorld': tileMapPass},
+        topologyByRegion: {'oldWorld': topology},
+      );
+      expect(outcome.skipped, false);
+      expect(outcome.passed, true);
+      expect(outcome.failures, isEmpty);
+    });
+
+    test('reports drawable_error when port tile has no orthogonal sea cell', () {
+      final tileMapFail = TileMapResult(
+        width: 2,
+        height: 2,
+        grid: [
+          ['p1', 'p1'],
+          ['p1', 'p1'],
+        ],
+      );
+      final game = Game(
+        id: 'audit_test',
+        worldState: emptyWorld(
+          ports: {'oldWorld|p1|s1': 'oldWorld|p1|0|0'},
+        ),
+        players: const [],
+      );
+      final outcome = runSeaboardPortAudit(
+        game: game,
+        tileMapByRegion: {'oldWorld': tileMapFail},
+        topologyByRegion: {'oldWorld': topology},
+      );
+      expect(outcome.passed, false);
+      expect(outcome.failures, isNotEmpty);
+      expect(outcome.failures.first.kind, 'drawable_error');
+      expect(outcome.failures.first.seaboardKey, 'oldWorld|p1|s1');
+      expect(outcome.failures.first.portTileKey, 'oldWorld|p1|0|0');
+    });
+
+    test('reports missing_capital_port for sea-bound capital without registry entry',
+        () {
+      final game = Game(
+        id: 'audit_test',
+        worldState: emptyWorld(ports: {}),
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'GP1',
+            isHuman: true,
+            capitalProvinceId: 'oldWorld|p1',
+            capitalTile: CapitalTile(
+              regionId: 'oldWorld',
+              provinceId: 'oldWorld|p1',
+              x: 0,
+              y: 0,
+            ),
+          ),
+        ],
+      );
+      final outcome = runSeaboardPortAudit(
+        game: game,
+        tileMapByRegion: {'oldWorld': tileMapPass},
+        topologyByRegion: {'oldWorld': topology},
+      );
+      expect(outcome.passed, false);
+      expect(outcome.failures.single.kind, 'missing_capital_port');
+      expect(outcome.failures.single.factionId, 'gp1');
+      expect(outcome.failures.single.seaZoneId, 's1');
+    });
+
+    test('skips when tileMapByRegion is empty', () {
+      final game = Game(
+        id: 'audit_test',
+        worldState: emptyWorld(),
+        players: const [],
+      );
+      final outcome = runSeaboardPortAudit(
+        game: game,
+        tileMapByRegion: {},
+        topologyByRegion: {'oldWorld': topology},
+      );
+      expect(outcome.skipped, true);
+      expect(outcome.skipReason, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements the **sim_scenarios** seaboard and `portsByProvinceSeaboard` audit from GitHub #1766, aligned with #1761 strict harbor drawable rules.

## Scope

- **Drawable check:** For every `portsByProvinceSeaboard` entry, calls `computePortDrawableSeaCellForMap` with the scenario region tile map and topology sea zone ids (same bar as map view).
- **Capital port completeness:** For each GP, minor, and tribe with a capital tile in a **sea-bound** province (P–S topology edge), asserts a registry key exists for every adjacent sea zone (`applyCapitalPortAndRoad` shape: `fullProvinceId|seaZoneId`). Inland capitals are excluded.
- **Runner integration:** Runs after init and optional `setup`; failures merge into scenario failures (CI already runs `melos run sim_scenarios`).
- **Reporting:** Appends a fenced JSON block with per-scenario `portAudit` (`skipped`, `failures` with kind/region/province/seaboardKey/portTileKey where applicable).
- **Skipped:** Init without both `tileMapByRegion` and `topologyByRegion` (e.g. saved-game path without maps) skips audit without failing the scenario for that alone.

## SPEC

- `SPEC/program/sim-scenarios.md` — new **Seaboard and port audit** section.

## Tests

- `tool/sim_scenarios/test/seaboard_port_audit_test.dart` — pass, drawable_error, missing_capital_port, skip-empty-maps.
- `melos run sim_scenarios` (full catalog) and `dart test` in `tool/sim_scenarios`.

## References

Refs #1766  
Refs #1761

Does **not** close #1766 (follow-up: broader overseas multi-seaboard completeness if product wants it).

Made with [Cursor](https://cursor.com)