### PR TITLE
Add test: identical sea-zone display names across two runInitGame runs (Refs #1768)

### DIFF
--- a/SPEC/game/naming.md
+++ b/SPEC/game/naming.md
@@ -44,7 +44,7 @@ Order: during game setup/map creation, after province assignment and after capit
   - Same seed ⇒ same names (deterministic, reproducible).
   - Different seed ⇒ different names across games.
 - **Faction display names:** Great Powers get `countryName` (e.g. England, France); Minor Nations and Tribes get `displayName` from the naming config. These are applied to the game’s players, minorNations, and tribes so UI can show human-readable faction names.
-- **Sea-zone display names:** Every sea zone node in topology receives a non-empty display name keyed by prefixed id (`regionId|seaZoneLocalId`). Assignment is deterministic from setup seed and region-specific list (`oldWorld` list for `oldWorld`, `newWorld` list for `newWorld`).
+- **Sea-zone display names:** Every sea zone node in topology receives a non-empty display name keyed by prefixed id (`regionId|seaZoneLocalId`). Assignment is deterministic from the game setup seed and region-specific list (`oldWorld` list for `oldWorld`, `newWorld` list for `newWorld`), analogous to province pool naming: **the same setup seed and the same generated topology must always yield the same display string for each prefixed sea-zone id** when setup runs again. **Pairwise distinct** display names across all sea zones in a region are **not** required unless the GDD explicitly adds that requirement later.
 
 Pool sizes: default ruleset uses **10** names per Great Power and **5** per Minor Nation and Tribe. Tribes use historically inspired **Amerindian / indigenous** place or region names.
 

--- a/SPEC/program/game-setup-pipeline.md
+++ b/SPEC/program/game-setup-pipeline.md
@@ -95,6 +95,10 @@ These criteria are implemented and covered by automated tests where noted.
   When step **7c** naming is applied  
   Then the System assigns a non-empty display name for every sea-zone node and stores those names keyed by prefixed sea-zone id (`regionId|seaZoneLocalId`) in `WorldState`.
 
+- Given `runInitGame` is invoked twice with the same `GameSetupConfig` whose `seed` is a positive integer and with `InitGameOptions(renderPng: false)`  
+  When both runs complete successfully  
+  Then `WorldState.seaZoneDisplayNameById` on the first result’s game deep-equals that on the second (same keys and same display strings per prefixed sea-zone id) (`colonizethis_logic` `init_game_orchestrator_test.dart`).
+
 - Given `createGameFromGeneratedMaps` completes with generated terrain and resource grids for Old World and New World  
   When The System has applied steps **7b** (capitals), **7d** (towns), and **7d.strip**  
   Then **no** tile key equal to any faction `capitalTile` or any province `townTileKey` has a non-null terrain **resource** or a non-zero **extraction improvement** on that tile; **roadLevel** on those tiles may still be greater than zero where init ports/paths placed roads (`game_setup.dart` / integration tests).

--- a/packages/colonizethis_logic/test/init_game_orchestrator_test.dart
+++ b/packages/colonizethis_logic/test/init_game_orchestrator_test.dart
@@ -175,6 +175,38 @@ void main() {
       expect(result.game.globalGameSeed, k);
     });
 
+    test(
+      'same positive seed: seaZoneDisplayNameById matches across two '
+      'runInitGame calls (province-like repeatability, not label distinctness)',
+      () {
+        // End-to-end guard: full procedural OW+NW generation + topology + naming.
+        // Pairwise distinct sea-zone strings on one map are not required; stability
+        // of (regionId|localSeaZoneId) → displayName for a fixed seed is.
+        const k = 900_002;
+        final base = GameSetupConfig.defaultConfig;
+        final config = GameSetupConfig(
+          selectedGreatPowerIds: base.selectedGreatPowerIds,
+          leaderVariantByGpId: base.leaderVariantByGpId,
+          continentCount: base.continentCount,
+          minorNationCount: base.minorNationCount,
+          tribeCount: base.tribeCount,
+          numProvincesOldWorld: base.numProvincesOldWorld,
+          numProvincesNewWorld: base.numProvincesNewWorld,
+          minProvincesPerMinor: base.minProvincesPerMinor,
+          seed: k,
+          startingResources: base.startingResources,
+          enforceFairGpOldWorldAssignment: base.enforceFairGpOldWorldAssignment,
+        );
+        const options = InitGameOptions(cellSize: 8, renderPng: false);
+        final first = runInitGame(config: config, options: options);
+        final second = runInitGame(config: config, options: options);
+        expect(
+          first.game.worldState.seaZoneDisplayNameById,
+          second.game.worldState.seaZoneDisplayNameById,
+        );
+      },
+    );
+
     test('NW tile map uses effectiveSeed + 1 (OW uses effective seed)', () {
       final seedsByRegion = <String, int>{};
       (TileMapResult, MapTopology) captureSeeds({


### PR DESCRIPTION
## Summary

Implements the must-have test from issue #1768: two full `runInitGame` passes with the same `GameSetupConfig` (positive fixed seed) and `InitGameOptions(renderPng: false)` must produce identical `WorldState.seaZoneDisplayNameById`.

## SPEC

- `SPEC/game/naming.md` — Clarifies sea-zone naming is province-analogous for **repeatability** per prefixed id; **pairwise distinct** labels are not a product requirement.
- `SPEC/program/game-setup-pipeline.md` — Program acceptance criterion pointing at `init_game_orchestrator_test.dart`.

## Out of scope (deferred)

- No change to `buildSeaZoneDisplayNamesForRegion` / shuffle algorithm (issue S3); current behaviour already satisfies determinism for a fixed seed and topology.

## Tests

- `dart test test/init_game_orchestrator_test.dart` (colonizethis_logic) — all passed locally.

Refs #1768

Made with [Cursor](https://cursor.com)