### PR TITLE
Fix New World ship reveal tile lookups and map visibility (Refs #1826)

### DIFF
--- a/SPEC/game/ships-and-naval.md
+++ b/SPEC/game/ships-and-naval.md
@@ -111,7 +111,13 @@ Like military and civilian **units**, each ship **hull** in play has a **stable 
 
 When a fleet **enters** a sea zone (move order), all **coastal land tiles** of provinces adjacent to that sea zone are set to **revealed** for that player, and all **water** tiles in that sea zone are set **fully visible** for that player (see [fog-and-exploration.md](fog-and-exploration.md) § Distant sea zone fog for End-of-turn re-fog when no owned adjacent coast and no fleet at sea there). This enables Explorer deployment to New World (at least one coastal tile must be revealed first). Reference: I2 03-units-civilian — "first terrain tile is uncovered when a ship enters a sea zone adjacent to the New World."
 
-Province identity for visibility updates must use **full** province id (`regionId|localId`) and **region-scoped** lookup (only provinces in the destination sea zone's region); see [world-model-identity.md](world-model-identity.md).
+Province identity for visibility updates must use **full** province id (`regionId|localId`) and **region-scoped** lookup (only provinces in the destination sea zone's region); see [world-model-identity.md](world-model-identity.md). Runtime **combined** topology uses prefixed sea/province node ids (`regionId|localId`); `WorldState.tileKeysByRegionAndProvince[regionId]` keys sea zones by **local** sea id (same as raster cell id). Ship reveal must resolve **local** sea id for water-tile lookup and **full** province id for land-tile lists (use `toFullProvinceId` / equivalent; do not double-prefix).
+
+**Acceptance (strict coastal ring on first entry into destination sea zone S in region R):**
+
+- Given fleet owner P and successful naval movement that ends in sea zone S in region R, when the System applies ship reveal for that entry, then the System sets `revealed` on P’s visibility map only for land tile keys that share a cell-grid orthogonal neighbor with at least one water tile key stored under `tileKeysByRegionAndProvince[R][L]`, where `L` is the **local** sea zone id for S (strip a leading `R|` prefix from S’s topology node id when present).
+- Given the same entry, when a land tile in a province adjacent to S in topology is not orthogonally adjacent to any water cell of S on the grid, then the System leaves that land tile’s visibility for P unchanged (typically `unknown` in the New World on first contact).
+- Given a naval move into S that is rejected or not executed, when movement resolution finishes, then the System does not apply ship reveal from that failed order for P.
 
 ---
 

--- a/SPEC/program/naval-movement-resolution.md
+++ b/SPEC/program/naval-movement-resolution.md
@@ -23,9 +23,9 @@ Resolves fleet movement orders, triggers ship-reveal for coastal provinces, and 
 
 **Ship Reveal:**
 
-On fleet entering sea zone S: for each province P with a P↔S edge (within the **destination sea zone's region** only), set coastal tiles of P to `revealed` for fleet owner. Province identity for which tiles to reveal must use full province id (`regionId|localId`) and region-scoped lookup per [world-model-identity.md](../game/world-model-identity.md). Updates visibility state per [fog-and-exploration-resolution.md](fog-and-exploration-resolution.md).
+On fleet entering sea zone S: for each province P with a P↔S edge (within the **destination sea zone's region** only), set coastal tiles of P to `revealed` for fleet owner. **Coastal** means each land tile key in P’s list is revealed only if its `(x,y)` has an orthogonal neighbor `(x±1,y)` or `(x,y±1)` matching some water tile key listed for S in `tileKeysByRegionAndProvince[regionId][L]`, where `L` is S’s **local** sea id (topology may store S as `regionId|L` in the combined graph; indexing uses `L` only). Province identity for which tiles to reveal must use full province id (`regionId|localId`) via `toFullProvinceId(regionId, topologyProvinceNodeId)` and region-scoped lookup per [world-model-identity.md](../game/world-model-identity.md). Updates visibility state per [fog-and-exploration-resolution.md](fog-and-exploration-resolution.md).
 
-Also on entering S: set all **water** tile keys belonging to S in `tileKeysByRegionAndProvince[regionId][S]` to **fully visible** for the fleet owner so open-ocean hexes are visible while the fleet is present; **End-of-turn** [distant sea zone fog](fog-and-exploration-resolution.md) may fog them again when no owned coast is adjacent and no fleet of that player is at sea in S.
+Also on entering S: set all **water** tile keys belonging to S in `tileKeysByRegionAndProvince[regionId][L]` to **fully visible** for the fleet owner so open-ocean hexes are visible while the fleet is present; **End-of-turn** [distant sea zone fog](fog-and-exploration-resolution.md) may fog them again when no owned coast is adjacent and no fleet of that player is at sea in S.
 
 On fleet **docking** at a port province (including merge into Home Fleet at capital): set **all** tiles of that province listed in `tileKeysByRegionAndProvince` to `revealed` for the fleet owner (same visibility field names as elsewhere), so unrevealed coastal hinterland from fog is uncovered when the player brings a fleet into port.
 
@@ -94,6 +94,10 @@ BuildUnitOrder for naval type; spawns in home fleet (in port at capital). Costs 
 - Owned by colonizethis_logic; numeric config from colonizethis_data.
 
 ## Acceptance Criteria
+
+- Given combined `MapTopology` sea node ids prefixed as `regionId|localSeaId` and `WorldState.tileKeysByRegionAndProvince[regionId]` keyed by `localSeaId` for water tiles  
+  When a fleet successfully enters destination sea zone S during Movement  
+  Then the System loads water tile keys from `tileKeysByRegionAndProvince[regionId][localSeaId(S)]` and applies the strict orthogonal coastal-ring land reveal and full water reveal for the fleet owner as specified in **Ship Reveal** above.
 
 - Given naval interception probability is computed for a fleet on `patrol` or `blockade` with fixed intercept and flee scores  
   When the System resolves interception in current product  

--- a/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
+++ b/app/lib/features/game/widgets/province_sea_zone_detail_overlay.dart
@@ -77,8 +77,11 @@ List<String> roadRailTileDetailLinesForTests({required int? transportLevel}) {
 }) {
   final parts = selectedTileKey.split('|');
   if (parts.length < 4 || parts[0] != regionId) return null;
-  final x = int.tryParse(parts[2]) ?? 0;
-  final y = int.tryParse(parts[3]) ?? 0;
+  final x = int.tryParse(parts[parts.length - 2]);
+  final y = int.tryParse(parts[parts.length - 1]);
+  if (x == null || y == null) {
+    return null;
+  }
   if (x < 0 || x >= regionWidth || y < 0 || y >= regionHeight) {
     return null;
   }

--- a/app/lib/providers/map_view_provider.dart
+++ b/app/lib/providers/map_view_provider.dart
@@ -74,22 +74,28 @@ final mapViewDataProvider = Provider<InitGameMapViewData?>((ref) {
         game.players.first;
 
     final visibilityByTile = <String, TileVisibility>{};
-    view.visibilityByTile.forEach((tileKey, level) {
-      late TileVisibility visibility;
-      switch (level) {
-        case VisibilityLevel.fullyVisible:
-          visibility = TileVisibility.visible;
-          break;
-        case VisibilityLevel.fogged:
-        case VisibilityLevel.revealed:
-          visibility = TileVisibility.fogged;
-          break;
-        case VisibilityLevel.unknown:
-          visibility = TileVisibility.unrevealed;
-          break;
+    final byRegion = game.worldState.tileKeysByRegionAndProvince;
+    for (final provinceMap in byRegion.values) {
+      for (final tileKeys in provinceMap.values) {
+        for (final tileKey in tileKeys) {
+          final level = view.visibilityForTile(tileKey);
+          late TileVisibility visibility;
+          switch (level) {
+            case VisibilityLevel.fullyVisible:
+              visibility = TileVisibility.visible;
+              break;
+            case VisibilityLevel.fogged:
+            case VisibilityLevel.revealed:
+              visibility = TileVisibility.fogged;
+              break;
+            case VisibilityLevel.unknown:
+              visibility = TileVisibility.unrevealed;
+              break;
+          }
+          visibilityByTile[tileKey] = visibility;
+        }
       }
-      visibilityByTile[tileKey] = visibility;
-    });
+    }
 
     final connectivity = resolveConnectivity(
       game: game,

--- a/app/test/features/game/widgets/province_sea_zone_tile_detail_helpers_test.dart
+++ b/app/test/features/game/widgets/province_sea_zone_tile_detail_helpers_test.dart
@@ -41,6 +41,18 @@ void main() {
       expect(c!.x, 3);
       expect(c.y, 4);
     });
+
+    test('parses x|y from last two segments when local id contains a pipe', () {
+      final c = tryParseProvinceOverlayTileCoords(
+        regionId: 'newWorld',
+        regionWidth: 20,
+        regionHeight: 15,
+        selectedTileKey: 'newWorld|newWorld|provA|3|4',
+      );
+      expect(c, isNotNull);
+      expect(c!.x, 3);
+      expect(c.y, 4);
+    });
   });
 
   group('tileDetailProspectedDisplayLabel', () {

--- a/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
@@ -26,6 +26,14 @@ final _log = packageLogger();
   return (x: x, y: y);
 }
 
+/// [tileKeysByRegionAndProvince] indexes sea zones by **local** sea id (raster cell id),
+/// while turn resolution may use a **combined** topology whose sea node ids are prefixed
+/// (`regionId|localSeaId`). Normalize for lookups only; fleet orders still use topology ids.
+String _localSeaZoneIdForTileIndex(String seaZoneTopologyId) =>
+    ProvinceId.isPrefixed(seaZoneTopologyId)
+        ? ProvinceId.localIdFrom(seaZoneTopologyId)
+        : seaZoneTopologyId;
+
 Set<String> _coastalTileKeysAdjacentToSeaZone({
   required List<String> provinceTileKeys,
   required List<String> seaWaterTileKeys,
@@ -368,11 +376,12 @@ Game applyNavalMovesAndShipReveal(
           regionId: destRegionId,
         );
         final vis = Map<String, String>.from(visibilityByTile[playerId] ?? {});
+        final seaZoneKeyForTiles = _localSeaZoneIdForTileIndex(destZoneId);
         final seaWaterKeys = game
             .worldState
-            .tileKeysByRegionAndProvince[destRegionId]?[destZoneId];
-        for (final localProvinceId in provinceIds) {
-          final fullProvinceId = ProvinceId.full(destRegionId, localProvinceId);
+            .tileKeysByRegionAndProvince[destRegionId]?[seaZoneKeyForTiles];
+        for (final provinceNodeId in provinceIds) {
+          final fullProvinceId = toFullProvinceId(destRegionId, provinceNodeId);
           final provinceTileKeys =
               game
                   .worldState

--- a/packages/colonizethis_logic/test/naval_test.dart
+++ b/packages/colonizethis_logic/test/naval_test.dart
@@ -304,6 +304,118 @@ void main() {
       expect(visibility?[owTile], isNull);
     });
 
+    test(
+      'combined-topology ship reveal uses local sea bucket and coastal ring only',
+      () {
+      const nw = 'newWorld';
+      const fullProv = '$nw|provA';
+      const localSeaDest = 'seaDest';
+      const localSeaOrigin = 'seaOrigin';
+      const prefixedDest = '$nw|$localSeaDest';
+      const prefixedOrigin = '$nw|$localSeaOrigin';
+      const coastalLand = '$nw|provA|1|0';
+      const inlandLand = '$nw|provA|0|0';
+      const seaDestWater = '$nw|$localSeaDest|2|0';
+      const seaDestWaterB = '$nw|$localSeaDest|2|1';
+
+      final combinedTopology = MapTopology(
+        nodes: [
+          TopologyNode(
+            id: fullProv,
+            regionId: nw,
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: prefixedDest,
+            regionId: nw,
+            type: TopologyNodeType.seaZone,
+          ),
+          TopologyNode(
+            id: prefixedOrigin,
+            regionId: nw,
+            type: TopologyNodeType.seaZone,
+          ),
+          TopologyNode(
+            id: '$nw|seaFar',
+            regionId: nw,
+            type: TopologyNodeType.seaZone,
+          ),
+        ],
+        edges: [
+          TopologyEdge(id1: fullProv, id2: prefixedDest),
+          TopologyEdge(id1: prefixedOrigin, id2: prefixedDest),
+        ],
+      );
+
+      final visStart = <String, String>{
+        for (final k in [
+          coastalLand,
+          inlandLand,
+          seaDestWater,
+          seaDestWaterB,
+          '$nw|$localSeaOrigin|0|2',
+        ])
+          k: VisibilityLevel.unknown.name,
+      };
+
+      final game = Game(
+        id: 'gCombined',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.movement, turnNumber: 0),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+          fleets: [
+            Fleet(
+              id: 'fNw',
+              ownerId: 'gp1',
+              seaZoneId: prefixedOrigin,
+              regionId: nw,
+              shipTypeIds: ['carrack'],
+            ),
+          ],
+          tileKeysByRegionAndProvince: {
+            nw: {
+              fullProv: [coastalLand, inlandLand, '$nw|provA|0|1', '$nw|provA|1|1'],
+              localSeaDest: [seaDestWater, seaDestWaterB],
+              localSeaOrigin: ['$nw|$localSeaOrigin|0|2'],
+            },
+          },
+          playerVisibilityByTile: {'gp1': visStart},
+        ),
+        players: const [Player(id: 'gp1', displayName: 'GP1', isHuman: true)],
+      );
+
+      final ordersOk = {
+        'gp1': [
+          NavalMoveOrder(fleetId: 'fNw', destinationSeaZoneId: prefixedDest),
+        ],
+      };
+      final afterOk = applyNavalMovesAndShipReveal(
+        game,
+        combinedTopology,
+        ordersOk,
+      );
+      final visOk = afterOk.worldState.playerVisibilityByTile['gp1']!;
+      expect(visOk[coastalLand], VisibilityLevel.revealed.name);
+      expect(visOk[inlandLand], VisibilityLevel.unknown.name);
+      expect(visOk[seaDestWater], VisibilityLevel.fullyVisible.name);
+      expect(visOk[seaDestWaterB], VisibilityLevel.fullyVisible.name);
+
+      final ordersBad = {
+        'gp1': [
+          NavalMoveOrder(fleetId: 'fNw', destinationSeaZoneId: '$nw|seaFar'),
+        ],
+      };
+      final afterBad = applyNavalMovesAndShipReveal(
+        game,
+        combinedTopology,
+        ordersBad,
+      );
+      final visBad = afterBad.worldState.playerVisibilityByTile['gp1']!;
+      expect(visBad[coastalLand], VisibilityLevel.unknown.name);
+      expect(visBad[seaDestWater], VisibilityLevel.unknown.name);
+    });
+
     group('firstAdjacentSeaZone', () {
       test('returns id2 when id1 matches seaZoneId', () {
         final seaOnly = MapTopology(


### PR DESCRIPTION
## Summary
Resolves incorrect first-contact behavior when fleets enter a New World sea zone: combined runtime topology uses prefixed node ids while `tileKeysByRegionAndProvince` indexes sea zones by **local** ids. Ship reveal now normalizes sea/province ids for tile-index lookups and uses `toFullProvinceId` for province tile lists.

The in-game map builds per-tile visibility from **every** tile key in `tileKeysByRegionAndProvince` via `PlayerView.visibilityForTile`, so tiles absent from the raw visibility map no longer fall through to `TileVisibility.visible` in `buildInitGameMapViewData`.

Province overlay tile coordinate parsing now reads `x|y` from the **last** two pipe segments, matching naval tile-key parsing when local ids contain `|`.

## Acceptance criteria (this PR)
- Combined-topology naval entry uses local sea bucket + full province id; only orthogonal coastal land tiles get `revealed`; invalid move applies no reveal.
- Map view visibility for unrevealed tiles stays unrevealed when the stored visibility map is sparse.
- Tile overlay parses coordinates for multi-segment tile keys.

## SPEC
- `SPEC/game/ships-and-naval.md` — strict coastal ring ACs; combined topology / local sea id note.
- `SPEC/program/naval-movement-resolution.md` — ship reveal algorithm + AC for local sea id lookup.

## Tests
- `dart test packages/colonizethis_logic/test/naval_test.dart`
- `flutter test app/test/features/game/widgets/province_sea_zone_tile_detail_helpers_test.dart`
- `flutter test app/test/map_view_provider_test.dart`

Refs #1826

Made with [Cursor](https://cursor.com)