### PR TITLE
E2E: New World sea-going fleet path (Refs #1831)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -258,7 +258,7 @@ jobs:
         uses: GabrielBB/xvfb-action@v1.7
         with:
           working-directory: app
-          run: bash -lc "set -euo pipefail; flutter test integration_test/new_game_capital_panel_e2e_test.dart -d linux --dart-define=CT_E2E=true --reporter=compact; flutter test integration_test/new_game_full_turn_e2e_test.dart -d linux --dart-define=CT_E2E=true --reporter=compact"
+          run: bash -lc "set -euo pipefail; flutter test integration_test/new_game_capital_panel_e2e_test.dart -d linux --dart-define=CT_E2E=true --reporter=compact; flutter test integration_test/new_game_full_turn_e2e_test.dart -d linux --dart-define=CT_E2E=true --reporter=compact; flutter test integration_test/new_game_fleet_reaches_new_world_e2e_test.dart -d linux --dart-define=CT_E2E=true --reporter=compact"
 
   quality:
     needs: changes

--- a/SPEC/program/e2e-integration-tests.md
+++ b/SPEC/program/e2e-integration-tests.md
@@ -22,10 +22,12 @@
 | `kCtE2ESelectFirstValidWorkTileKey` | Map overlay: pick first valid tile for civilian work-target selection (E2E). |
 | `kCtE2EOpenFirstCivilianMarkerPanelKey` | Map overlay: open tile-scoped civilian panel for first civilian marker. |
 | `kCtE2EOpenFirstFleetMarkerPanelKey` | Map overlay: open tile-scoped naval panel for first fleet marker. |
+| `kCtE2ERegionTabNewWorldKey` | Map HUD: **New World** region `CtChoiceChip` (Keyed subtree for e2e taps / finders). |
+| `kCtE2EMoveFleetDialogScrollRootKey` | `MoveFleetDialog` scroll body (`SingleChildScrollView` child) for `scrollUntilVisible` on long destination lists. |
 | `kGameMapNextTurnButtonKey` | Next-turn control on the map HUD (`game_screen_shared.dart`). |
 | `ctE2eLastPanelSnapshot` | Province overlay: updated while open with valid `selectedTileKey`; cleared when closed. Separate **civilian / naval / production** snapshot updaters in `ct_e2e_last_panel_snapshot.dart` for those panels. |
 
-**Code:** `app/lib/config/ct_e2e.dart`, `app/lib/config/ct_e2e_last_panel_snapshot.dart`, `app/lib/features/game/flame/game_screen_shared.dart` (next-turn key).
+**Code:** `app/lib/config/ct_e2e.dart`, `app/lib/config/ct_e2e_last_panel_snapshot.dart`, `app/lib/features/game/flame/game_screen_shared.dart` (next-turn key), `app/lib/features/game/flame/game_map_controls.dart` (region tab keys), `app/lib/features/game/widgets/move_fleet_dialog.dart` (move dialog scroll root).
 
 **Expected-line mirrors:** `app/lib/test_support/civilian_units_panel_e2e_expected_lines.dart`, `naval_units_panel_e2e_expected_lines.dart`, `production_panel_e2e_expected_lines.dart` (keep aligned with widgets).
 
@@ -44,6 +46,11 @@ flutter config --enable-linux-desktop
 flutter test integration_test/new_game_capital_panel_e2e_test.dart \
   -d linux \
   --dart-define=CT_E2E=true
+
+# New World naval reach (multi-turn, widget-only success):
+flutter test integration_test/new_game_fleet_reaches_new_world_e2e_test.dart \
+  -d linux \
+  --dart-define=CT_E2E=true
 ```
 
 Headed desktop on a dev machine without Xvfb: use **`-d macos`** or **`-d linux`** from a normal graphical session.
@@ -51,7 +58,7 @@ Headed desktop on a dev machine without Xvfb: use **`-d macos`** or **`-d linux`
 ## CI
 
 - Job **`app_e2e_linux`** in `.github/workflows/quality.yml` runs after **`app_tests_shard`** and does **not** block **`quality_app_coverage`**.
-- Ubuntu installs **clang / cmake / ninja / GTK** deps, enables **linux** desktop, then runs **`new_game_capital_panel_e2e_test.dart`** and **`new_game_full_turn_e2e_test.dart`** under **[GabrielBB/xvfb-action](https://github.com/GabrielBB/xvfb-action)** (Xvfb + `DISPLAY`).
+- Ubuntu installs **clang / cmake / ninja / GTK** deps, enables **linux** desktop, then runs **`new_game_capital_panel_e2e_test.dart`**, **`new_game_full_turn_e2e_test.dart`**, and **`new_game_fleet_reaches_new_world_e2e_test.dart`** under **[GabrielBB/xvfb-action](https://github.com/GabrielBB/xvfb-action)** (Xvfb + `DISPLAY`).
 - Widget/coverage jobs use **`flutter test test/`** only so `integration_test/` is not executed on the VM shard runner.
 
 ## Expectations helper

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -1,0 +1,475 @@
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:colonizethis_app/config/ct_e2e.dart';
+import 'package:colonizethis_app/features/game/dialogue/game_start_intro_overlay.dart';
+import 'package:colonizethis_app/features/game/flame/game_screen_shared.dart';
+import 'package:colonizethis_app/l10n/app_localizations.dart';
+import 'package:colonizethis_app/main.dart' show bootstrapForIntegrationTest;
+import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
+import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+/// Drive frames without [WidgetTester.pumpAndSettle] (Flame + progress spinners).
+Future<void> _pumpFor(WidgetTester tester, Duration total) async {
+  const step = Duration(milliseconds: 50);
+  var elapsed = Duration.zero;
+  while (elapsed < total) {
+    await tester.pump(step);
+    elapsed += step;
+  }
+}
+
+Future<void> _waitUntilFound(
+  WidgetTester tester,
+  Finder finder, {
+  required Duration timeout,
+}) async {
+  final sw = Stopwatch()..start();
+  while (sw.elapsed < timeout) {
+    await tester.pump(const Duration(milliseconds: 100));
+    if (finder.evaluate().isNotEmpty) {
+      return;
+    }
+  }
+  fail(
+    'Timed out after ${timeout.inSeconds}s waiting for $finder. '
+    'Last exception: ${tester.takeException()}',
+  );
+}
+
+/// Dismisses blocking bottom sheets, dialog shells, snackbars, and generic OKs.
+Future<void> _dismissTransientUi(WidgetTester tester) async {
+  if (find.byType(SnackBar).evaluate().isNotEmpty) {
+    final snackAction = find.descendant(
+      of: find.byType(SnackBar),
+      matching: find.byType(TextButton),
+    );
+    if (snackAction.hitTestable().evaluate().isNotEmpty) {
+      await tester.tap(snackAction.first, warnIfMissed: false);
+      await _pumpFor(tester, const Duration(milliseconds: 200));
+      return;
+    }
+  }
+  final ok = find.text('OK').hitTestable();
+  if (ok.evaluate().isNotEmpty) {
+    await tester.tap(ok.first, warnIfMissed: false);
+    await _pumpFor(tester, const Duration(milliseconds: 200));
+    return;
+  }
+  if (find.byType(AlertDialog).evaluate().isNotEmpty) {
+    for (final label in ['Close', 'OK', 'Cancel']) {
+      final hit = find
+          .descendant(of: find.byType(AlertDialog), matching: find.text(label))
+          .hitTestable();
+      if (hit.evaluate().isNotEmpty) {
+        await tester.tap(hit.first, warnIfMissed: false);
+        await _pumpFor(tester, const Duration(milliseconds: 250));
+        return;
+      }
+    }
+    await tester.binding.handlePopRoute();
+    await _pumpFor(tester, const Duration(milliseconds: 200));
+    return;
+  }
+  if (find.byType(BottomSheet).evaluate().isNotEmpty) {
+    await _closeBottomSheet(tester);
+  }
+  if (find.byType(CtDialogShell).evaluate().isNotEmpty) {
+    final closeCandidates = <Finder>[
+      find.text('Cancel'),
+      find.text('Close'),
+      find.byIcon(Icons.close),
+      find.byIcon(Icons.arrow_back),
+    ];
+    for (final candidate in closeCandidates) {
+      final tappable = candidate.hitTestable();
+      if (tappable.evaluate().isNotEmpty) {
+        await tester.tap(tappable.first, warnIfMissed: false);
+        await _pumpFor(tester, const Duration(milliseconds: 150));
+        return;
+      }
+    }
+    await tester.binding.handlePopRoute();
+    await _pumpFor(tester, const Duration(milliseconds: 150));
+  }
+}
+
+Future<void> _closeBottomSheet(WidgetTester tester) async {
+  bool anyPanelOpen() => find.byType(BottomSheet).evaluate().isNotEmpty;
+
+  if (!anyPanelOpen()) {
+    return;
+  }
+
+  final sw = Stopwatch()..start();
+  while (sw.elapsed < const Duration(seconds: 5)) {
+    if (!anyPanelOpen()) {
+      return;
+    }
+    await tester.binding.handlePopRoute();
+    await _pumpFor(tester, const Duration(milliseconds: 250));
+  }
+
+  fail('Timed out closing bottom sheet; panels remained visible');
+}
+
+Future<void> _bootstrapNewGameToMap(WidgetTester tester) async {
+  await tester.tap(find.text('New Game'));
+  await _waitUntilFound(
+    tester,
+    find.text('Start'),
+    timeout: const Duration(seconds: 30),
+  );
+
+  final startButton = find.ancestor(
+    of: find.text('Start'),
+    matching: find.byType(CtNinePatchButton),
+  );
+  expect(startButton, findsOneWidget);
+
+  final shellScrollable = find.descendant(
+    of: find.byType(CtDialogShell),
+    matching: find.byType(Scrollable),
+  );
+  await tester.dragUntilVisible(
+    startButton,
+    shellScrollable,
+    const Offset(0, -120),
+  );
+  await tester.pump(const Duration(milliseconds: 200));
+  await tester.ensureVisible(startButton);
+  await tester.tap(startButton);
+  await tester.pump();
+
+  final setupDeadline = DateTime.now().add(const Duration(minutes: 6));
+  var reachedMap = false;
+  while (DateTime.now().isBefore(setupDeadline)) {
+    await tester.pump(const Duration(milliseconds: 100));
+    if (find.text('Could not create game').evaluate().isNotEmpty) {
+      fail(
+        'New game setup failed (error dialog). '
+        'Exception: ${tester.takeException()}',
+      );
+    }
+    final introOpen = find.byType(GameStartIntroOverlay).evaluate().isNotEmpty;
+    if (introOpen) {
+      if (find.text('Continue').evaluate().isNotEmpty) {
+        await tester.tap(find.text('Continue').first);
+        await tester.pump(const Duration(milliseconds: 200));
+      } else if (find.text('I shall.').evaluate().isNotEmpty) {
+        await tester.tap(find.text('I shall.').first);
+        await tester.pump(const Duration(milliseconds: 200));
+      }
+      continue;
+    }
+    final creating = find.text('Creating game').evaluate().isNotEmpty;
+    if (creating) {
+      continue;
+    }
+    if (find.byKey(kHomeToCapitalButtonKey).evaluate().isNotEmpty) {
+      reachedMap = true;
+      break;
+    }
+  }
+  expect(reachedMap, isTrue);
+  expect(find.byKey(kHomeToCapitalButtonKey), findsOneWidget);
+  await tester.pump(const Duration(milliseconds: 500));
+}
+
+Future<void> _expandEachExpansionTileOnce(WidgetTester tester) async {
+  for (var safety = 0; safety < 32; safety++) {
+    final tiles = find.byType(ExpansionTile);
+    final n = tiles.evaluate().length;
+    if (n == 0) return;
+
+    var expandedOne = false;
+    for (var j = 0; j < n; j++) {
+      final expandIcon = find.descendant(
+        of: tiles.at(j),
+        matching: find.byIcon(Icons.expand_more),
+      );
+      if (expandIcon.evaluate().isEmpty) continue;
+      final iconHit = expandIcon.first;
+      await tester.ensureVisible(iconHit);
+      await _pumpFor(tester, const Duration(milliseconds: 80));
+      await tester.tap(iconHit, warnIfMissed: false);
+      await _pumpFor(tester, const Duration(milliseconds: 250));
+      expandedOne = true;
+      break;
+    }
+    if (!expandedOne) return;
+  }
+}
+
+Future<void> _openNavalPanel(WidgetTester tester) async {
+  final navalPanel = find.byKey(kCtE2ENavalPanelRootKey);
+  final btn = find.byKey(kEmpireNavalUnitsButtonKey);
+  final sw = Stopwatch()..start();
+  while (sw.elapsed < const Duration(seconds: 45)) {
+    await tester.pump(const Duration(milliseconds: 100));
+    if (navalPanel.evaluate().isNotEmpty) {
+      return;
+    }
+    if (find.byType(BottomSheet).evaluate().isNotEmpty) {
+      await _closeBottomSheet(tester);
+      continue;
+    }
+    if (find.byType(AlertDialog).evaluate().isNotEmpty) {
+      await _dismissTransientUi(tester);
+      continue;
+    }
+    if (find.byType(CtDialogShell).evaluate().isNotEmpty) {
+      await _dismissTransientUi(tester);
+      continue;
+    }
+    final hit = btn.hitTestable();
+    if (hit.evaluate().isNotEmpty) {
+      await tester.tap(hit.first, warnIfMissed: false);
+      await _pumpFor(tester, const Duration(milliseconds: 400));
+    } else {
+      await _dismissTransientUi(tester);
+    }
+  }
+  fail(
+    'Timed out opening naval panel. Last exception: ${tester.takeException()}',
+  );
+}
+
+Finder _radioListTilesInAlertDialogs() {
+  return find.descendant(
+    of: find.byType(AlertDialog),
+    matching: find.byWidgetPredicate(
+      (w) => w.runtimeType.toString().startsWith('RadioListTile<'),
+    ),
+  );
+}
+
+/// Prefer cross-region warp row (English copy); else first adjacent sea tile.
+Future<void> _pickMoveDestinationAndConfirm(WidgetTester tester) async {
+  await _pumpFor(tester, const Duration(milliseconds: 200));
+  final warp = find.textContaining('links to New World');
+  if (warp.evaluate().isNotEmpty) {
+    final scrollRoot = find.byKey(kCtE2EMoveFleetDialogScrollRootKey);
+    if (scrollRoot.evaluate().isNotEmpty) {
+      final scrollable = find.descendant(
+        of: scrollRoot,
+        matching: find.byType(Scrollable),
+      );
+      if (scrollable.evaluate().isNotEmpty) {
+        await tester.scrollUntilVisible(warp.first, 80, scrollable: scrollable);
+      }
+    }
+    final hit = warp.hitTestable();
+    expect(hit, findsWidgets);
+    await tester.tap(hit.first, warnIfMissed: false);
+  } else {
+    final seaRadio = _radioListTilesInAlertDialogs();
+    expect(seaRadio, findsWidgets);
+    await tester.tap(seaRadio.first, warnIfMissed: false);
+  }
+  await _pumpFor(tester, const Duration(milliseconds: 200));
+  final confirm = find.text('Confirm').hitTestable();
+  expect(confirm, findsWidgets);
+  await tester.tap(confirm.first, warnIfMissed: false);
+  await _pumpFor(tester, const Duration(seconds: 1));
+}
+
+Future<void> _tryNavalMoveSegment(
+  WidgetTester tester,
+  AppLocalizations l10n,
+) async {
+  await _openNavalPanel(tester);
+  await _expandEachExpansionTileOnce(tester);
+  await _tapMoveOnFirstNonHomeFleet(tester);
+  await _pumpFor(tester, const Duration(milliseconds: 300));
+  if (find.text(l10n.moveFleet_noAdjacentSeaZones).evaluate().isNotEmpty) {
+    final cancel = find.text(l10n.common_cancel).hitTestable();
+    expect(cancel, findsOneWidget);
+    await tester.tap(cancel, warnIfMissed: false);
+    await _pumpFor(tester, const Duration(milliseconds: 250));
+    return;
+  }
+  if (find.byType(AlertDialog).evaluate().isNotEmpty) {
+    await _pickMoveDestinationAndConfirm(tester);
+  }
+}
+
+Future<void> _tapMoveOnFirstNonHomeFleet(WidgetTester tester) async {
+  final navalRoot = find.byKey(kCtE2ENavalPanelRootKey);
+  final tiles = find.descendant(
+    of: navalRoot,
+    matching: find.byType(ExpansionTile),
+  );
+  expect(tiles, findsWidgets);
+  final n = tiles.evaluate().length;
+  for (var i = 0; i < n; i++) {
+    final sub = tiles.at(i);
+    final home = find.descendant(of: sub, matching: find.text('Home Fleet'));
+    if (home.evaluate().isNotEmpty) {
+      continue;
+    }
+    final fleetTitle = find.descendant(
+      of: sub,
+      matching: find.byWidgetPredicate(
+        (w) => w is Text && (w.data?.startsWith('Fleet ') ?? false),
+      ),
+    );
+    if (fleetTitle.evaluate().isEmpty) {
+      continue;
+    }
+    final move = find.descendant(of: sub, matching: find.text('Move'));
+    if (move.evaluate().isEmpty) {
+      continue;
+    }
+    final hit = move.hitTestable();
+    expect(hit, findsWidgets);
+    await tester.tap(hit.first, warnIfMissed: false);
+    await _pumpFor(tester, const Duration(milliseconds: 400));
+    return;
+  }
+  fail(
+    'No Move control for a non-home fleet row. '
+    'Last exception: ${tester.takeException()}',
+  );
+}
+
+/// Widget-only: a **non–home** fleet row shows [unitsPanelRegionLabel] for New World
+/// in the subtitle location line (`New World — …` per `naval_tree_builder.dart`).
+bool _navalPanelShowsNonHomeFleetInNewWorld(WidgetTester tester) {
+  final naval = find.byKey(kCtE2ENavalPanelRootKey);
+  if (naval.evaluate().isEmpty) {
+    return false;
+  }
+  final tiles = find.descendant(
+    of: naval,
+    matching: find.byType(ExpansionTile),
+  );
+  final n = tiles.evaluate().length;
+  for (var i = 0; i < n; i++) {
+    final sub = tiles.at(i);
+    final fleetTitle = find.descendant(
+      of: sub,
+      matching: find.byWidgetPredicate(
+        (w) => w is Text && (w.data?.startsWith('Fleet ') ?? false),
+      ),
+    );
+    if (fleetTitle.evaluate().isEmpty) {
+      continue;
+    }
+    final loc = find.descendant(
+      of: sub,
+      matching: find.byWidgetPredicate(
+        (w) =>
+            w is Text && (w.data != null) && w.data!.startsWith('New World —'),
+      ),
+    );
+    if (loc.evaluate().isNotEmpty) {
+      return true;
+    }
+  }
+  return false;
+}
+
+Future<void> _splitHomeFleetOnce(WidgetTester tester) async {
+  await tester.tap(find.byKey(kEmpireNavalUnitsButtonKey));
+  await _pumpFor(tester, const Duration(milliseconds: 400));
+  await _waitUntilFound(
+    tester,
+    find.byKey(kCtE2ENavalPanelRootKey),
+    timeout: const Duration(seconds: 20),
+  );
+  await _expandEachExpansionTileOnce(tester);
+  final navalPanelRoot = find.byKey(kCtE2ENavalPanelRootKey);
+  final split = find.descendant(
+    of: navalPanelRoot,
+    matching: find.text('Split'),
+  );
+  expect(split, findsWidgets);
+  await tester.tap(split.first);
+  await _pumpFor(tester, const Duration(milliseconds: 400));
+
+  final moveOneRight = find.descendant(
+    of: find.byType(CtDialogShell),
+    matching: find.widgetWithText(CtNinePatchButton, '>'),
+  );
+  expect(moveOneRight, findsWidgets);
+  await tester.tap(moveOneRight.first);
+  await _pumpFor(tester, const Duration(milliseconds: 200));
+  await tester.tap(find.text('Confirm Split'));
+  await _pumpFor(tester, const Duration(seconds: 1));
+  await _expandEachExpansionTileOnce(tester);
+}
+
+Future<void> _advanceOneHumanTurn(
+  WidgetTester tester,
+  AppLocalizations l10n,
+) async {
+  await tester.tap(find.byKey(kGameMapNextTurnButtonKey));
+  await _pumpFor(tester, const Duration(milliseconds: 400));
+  final confirmNextTurn = find.text(l10n.common_yes).hitTestable();
+  if (confirmNextTurn.evaluate().isNotEmpty) {
+    await tester.tap(confirmNextTurn.first, warnIfMissed: false);
+  }
+  await _pumpFor(tester, const Duration(seconds: 2));
+}
+
+void main() {
+  suppressLogsForTests();
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'new game → non-home fleet at sea in New World (≤10 Next turn taps)',
+    (WidgetTester tester) async {
+      expect(
+        kCtE2EEnabled,
+        isTrue,
+        reason:
+            'Run with: flutter test integration_test/... --dart-define=CT_E2E=true',
+      );
+
+      await tester.binding.setSurfaceSize(const Size(1280, 720));
+      await bootstrapForIntegrationTest();
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 2));
+
+      await _bootstrapNewGameToMap(tester);
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      await _splitHomeFleetOnce(tester);
+      await _closeBottomSheet(tester);
+
+      for (var turnIdx = 0; turnIdx < 10; turnIdx++) {
+        await _dismissTransientUi(tester);
+        await _openNavalPanel(tester);
+        if (_navalPanelShowsNonHomeFleetInNewWorld(tester)) {
+          await _closeBottomSheet(tester);
+          return;
+        }
+        await _closeBottomSheet(tester);
+
+        await _tryNavalMoveSegment(tester, l10n);
+        await _closeBottomSheet(tester);
+
+        if (_navalPanelShowsNonHomeFleetInNewWorld(tester)) {
+          return;
+        }
+
+        await _advanceOneHumanTurn(tester, l10n);
+        await _dismissTransientUi(tester);
+      }
+
+      await _dismissTransientUi(tester);
+      await _openNavalPanel(tester);
+      if (!_navalPanelShowsNonHomeFleetInNewWorld(tester)) {
+        fail(
+          'After 10 Next turn resolutions, no non-home fleet row shows '
+          'location text starting with "New World —" under '
+          'kCtE2ENavalPanelRootKey. Last exception: ${tester.takeException()}',
+        );
+      }
+      await _closeBottomSheet(tester);
+    },
+  );
+}

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -39,6 +39,10 @@ Future<void> _waitUntilFound(
 }
 
 /// Dismisses blocking bottom sheets, dialog shells, snackbars, and generic OKs.
+///
+/// [AlertDialog] handling uses common action labels (including **Close** for
+/// prior-turn [TurnNewsDialog], `SPEC/ui/turn-news-dialog.md`) plus
+/// [WidgetsBinding.handlePopRoute] if none match.
 Future<void> _dismissTransientUi(WidgetTester tester) async {
   if (find.byType(SnackBar).evaluate().isNotEmpty) {
     final snackAction = find.descendant(
@@ -58,7 +62,7 @@ Future<void> _dismissTransientUi(WidgetTester tester) async {
     return;
   }
   if (find.byType(AlertDialog).evaluate().isNotEmpty) {
-    for (final label in ['Close', 'OK', 'Cancel']) {
+    for (final label in ['Close', 'OK', 'Cancel', 'Yes']) {
       final hit = find
           .descendant(of: find.byType(AlertDialog), matching: find.text(label))
           .hitTestable();
@@ -236,6 +240,17 @@ Future<void> _openNavalPanel(WidgetTester tester) async {
   );
 }
 
+/// Selects the New World map region via [kCtE2ERegionTabNewWorldKey] when present
+/// (reduces ambiguous "New World" text on screen; `SPEC/program/e2e-integration-tests.md`).
+Future<void> _tapNewWorldRegionTabIfPresent(WidgetTester tester) async {
+  final tab = find.byKey(kCtE2ERegionTabNewWorldKey).hitTestable();
+  if (tab.evaluate().isEmpty) {
+    return;
+  }
+  await tester.tap(tab.first, warnIfMissed: false);
+  await _pumpFor(tester, const Duration(milliseconds: 250));
+}
+
 Finder _radioListTilesInAlertDialogs() {
   return find.descendant(
     of: find.byType(AlertDialog),
@@ -246,7 +261,10 @@ Finder _radioListTilesInAlertDialogs() {
 }
 
 /// Prefer cross-region warp row (English copy); else first adjacent sea tile.
-Future<void> _pickMoveDestinationAndConfirm(WidgetTester tester) async {
+Future<void> _pickMoveDestinationAndConfirm(
+  WidgetTester tester,
+  AppLocalizations l10n,
+) async {
   await _pumpFor(tester, const Duration(milliseconds: 200));
   final warp = find.textContaining('links to New World');
   if (warp.evaluate().isNotEmpty) {
@@ -269,7 +287,7 @@ Future<void> _pickMoveDestinationAndConfirm(WidgetTester tester) async {
     await tester.tap(seaRadio.first, warnIfMissed: false);
   }
   await _pumpFor(tester, const Duration(milliseconds: 200));
-  final confirm = find.text('Confirm').hitTestable();
+  final confirm = find.text(l10n.common_confirm).hitTestable();
   expect(confirm, findsWidgets);
   await tester.tap(confirm.first, warnIfMissed: false);
   await _pumpFor(tester, const Duration(seconds: 1));
@@ -279,10 +297,13 @@ Future<void> _tryNavalMoveSegment(
   WidgetTester tester,
   AppLocalizations l10n,
 ) async {
+  await _tapNewWorldRegionTabIfPresent(tester);
   await _openNavalPanel(tester);
   await _expandEachExpansionTileOnce(tester);
   await _tapMoveOnFirstNonHomeFleet(tester);
   await _pumpFor(tester, const Duration(milliseconds: 300));
+  // No legal sea-step this turn: close dialog and rely on the outer loop +
+  // next turn (Refs #1831 heuristic path).
   if (find.text(l10n.moveFleet_noAdjacentSeaZones).evaluate().isNotEmpty) {
     final cancel = find.text(l10n.common_cancel).hitTestable();
     expect(cancel, findsOneWidget);
@@ -291,7 +312,7 @@ Future<void> _tryNavalMoveSegment(
     return;
   }
   if (find.byType(AlertDialog).evaluate().isNotEmpty) {
-    await _pickMoveDestinationAndConfirm(tester);
+    await _pickMoveDestinationAndConfirm(tester, l10n);
   }
 }
 
@@ -371,7 +392,10 @@ bool _navalPanelShowsNonHomeFleetInNewWorld(WidgetTester tester) {
   return false;
 }
 
-Future<void> _splitHomeFleetOnce(WidgetTester tester) async {
+Future<void> _splitHomeFleetOnce(
+  WidgetTester tester,
+  AppLocalizations l10n,
+) async {
   await tester.tap(find.byKey(kEmpireNavalUnitsButtonKey));
   await _pumpFor(tester, const Duration(milliseconds: 400));
   await _waitUntilFound(
@@ -396,7 +420,7 @@ Future<void> _splitHomeFleetOnce(WidgetTester tester) async {
   expect(moveOneRight, findsWidgets);
   await tester.tap(moveOneRight.first);
   await _pumpFor(tester, const Duration(milliseconds: 200));
-  await tester.tap(find.text('Confirm Split'));
+  await tester.tap(find.text(l10n.splitFleet_confirm));
   await _pumpFor(tester, const Duration(seconds: 1));
   await _expandEachExpansionTileOnce(tester);
 }
@@ -437,11 +461,12 @@ void main() {
 
       final l10n = lookupAppLocalizations(const Locale('en'));
 
-      await _splitHomeFleetOnce(tester);
+      await _splitHomeFleetOnce(tester, l10n);
       await _closeBottomSheet(tester);
 
       for (var turnIdx = 0; turnIdx < 10; turnIdx++) {
         await _dismissTransientUi(tester);
+        await _tapNewWorldRegionTabIfPresent(tester);
         await _openNavalPanel(tester);
         if (_navalPanelShowsNonHomeFleetInNewWorld(tester)) {
           await _closeBottomSheet(tester);
@@ -461,6 +486,7 @@ void main() {
       }
 
       await _dismissTransientUi(tester);
+      await _tapNewWorldRegionTabIfPresent(tester);
       await _openNavalPanel(tester);
       if (!_navalPanelShowsNonHomeFleetInNewWorld(tester)) {
         fail(

--- a/app/lib/config/ct_e2e.dart
+++ b/app/lib/config/ct_e2e.dart
@@ -44,3 +44,13 @@ const Key kCtE2EOpenFirstCivilianMarkerPanelKey = Key(
 const Key kCtE2EOpenFirstFleetMarkerPanelKey = Key(
   'ct_e2e_open_first_fleet_marker_panel',
 );
+
+// ignore: public_member_api_docs
+/// Map controls: region chip for **New World** (narrow finder surface for e2e).
+const Key kCtE2ERegionTabNewWorldKey = Key('ct_e2e_region_tab_new_world');
+
+// ignore: public_member_api_docs
+/// [MoveFleetDialog] scroll body root (destinations list) for e2e scroll-until-visible.
+const Key kCtE2EMoveFleetDialogScrollRootKey = Key(
+  'ct_e2e_move_fleet_dialog_scroll_root',
+);

--- a/app/lib/features/game/flame/game_map_controls.dart
+++ b/app/lib/features/game/flame/game_map_controls.dart
@@ -120,6 +120,8 @@ class _GameMapControlsState extends State<GameMapControls> {
                 onSelected: (_) => widget.onRegionIndexChanged(0),
               ),
               const SizedBox(width: 8),
+              // E2E-only wrapper: same layout as bare chip; adds a stable subtree key
+              // for integration tests (`kCtE2ERegionTabNewWorldKey`).
               if (kCtE2EEnabled)
                 KeyedSubtree(
                   key: kCtE2ERegionTabNewWorldKey,

--- a/app/lib/features/game/flame/game_map_controls.dart
+++ b/app/lib/features/game/flame/game_map_controls.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import '../../../config/app_assets.dart';
+import '../../../config/ct_e2e.dart';
 import '../../../widgets/ct_choice_chip.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/strict_asset_icon.dart';
@@ -119,11 +120,21 @@ class _GameMapControlsState extends State<GameMapControls> {
                 onSelected: (_) => widget.onRegionIndexChanged(0),
               ),
               const SizedBox(width: 8),
-              CtChoiceChip(
-                label: Text(l10n.region_newWorld),
-                selected: widget.regionIndex == 1,
-                onSelected: (_) => widget.onRegionIndexChanged(1),
-              ),
+              if (kCtE2EEnabled)
+                KeyedSubtree(
+                  key: kCtE2ERegionTabNewWorldKey,
+                  child: CtChoiceChip(
+                    label: Text(l10n.region_newWorld),
+                    selected: widget.regionIndex == 1,
+                    onSelected: (_) => widget.onRegionIndexChanged(1),
+                  ),
+                )
+              else
+                CtChoiceChip(
+                  label: Text(l10n.region_newWorld),
+                  selected: widget.regionIndex == 1,
+                  onSelected: (_) => widget.onRegionIndexChanged(1),
+                ),
               const SizedBox(width: 10),
               GestureDetector(
                 key: kTreasuryIndicatorKey,

--- a/app/lib/features/game/widgets/move_fleet_dialog.dart
+++ b/app/lib/features/game/widgets/move_fleet_dialog.dart
@@ -7,6 +7,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../../../config/ct_e2e.dart';
 import '../../../l10n/l10n.dart';
 import '../utils/map_location_resolver.dart';
 import '../utils/sea_zone_name_resolver.dart';
@@ -198,6 +199,28 @@ class _MoveFleetDialogState extends State<MoveFleetDialog> {
         ? l10n.moveFleet_title(fleetLabel)
         : l10n.moveFleet_titleWithDestinations(fleetLabel, picks.length);
 
+    final moveColumns = Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (seaPicks.isNotEmpty) ...[
+          Text(
+            l10n.moveFleet_seaZonesSection,
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+          ...seaPicks.map(_row),
+        ],
+        if (portPicks.isNotEmpty) ...[
+          if (seaPicks.isNotEmpty) const SizedBox(height: 12),
+          Text(
+            l10n.moveFleet_provincesDockSection,
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+          ...portPicks.map(_row),
+        ],
+      ],
+    );
+
     return AlertDialog(
       title: Text(titleText),
       content: SizedBox(
@@ -205,27 +228,12 @@ class _MoveFleetDialogState extends State<MoveFleetDialog> {
         child: picks.isEmpty
             ? Text(l10n.moveFleet_noAdjacentSeaZones)
             : SingleChildScrollView(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    if (seaPicks.isNotEmpty) ...[
-                      Text(
-                        l10n.moveFleet_seaZonesSection,
-                        style: const TextStyle(fontWeight: FontWeight.bold),
-                      ),
-                      ...seaPicks.map(_row),
-                    ],
-                    if (portPicks.isNotEmpty) ...[
-                      if (seaPicks.isNotEmpty) const SizedBox(height: 12),
-                      Text(
-                        l10n.moveFleet_provincesDockSection,
-                        style: const TextStyle(fontWeight: FontWeight.bold),
-                      ),
-                      ...portPicks.map(_row),
-                    ],
-                  ],
-                ),
+                child: kCtE2EEnabled
+                    ? KeyedSubtree(
+                        key: kCtE2EMoveFleetDialogScrollRootKey,
+                        child: moveColumns,
+                      )
+                    : moveColumns,
               ),
       ),
       actions: [


### PR DESCRIPTION
## Summary

Implements GitHub issue #1831: a dedicated Linux `integration_test` that drives the default new-game path (seed 42, `CT_E2E=true`, English) until a **non–home** fleet row in the naval panel shows a **New World** location line (`New World — …` per `naval_tree_builder` / `unitsPanelRegionLabel`), using **widget-only** finders under `kCtE2ENavalPanelRootKey`.

Adds `kCtE2ERegionTabNewWorldKey` and `kCtE2EMoveFleetDialogScrollRootKey`, extends transient dismiss for **Turn news** (`AlertDialog` + Close) and generic alerts, prefers **links to New World** in the move dialog when present, and registers the test in `app_e2e_linux`.

## Acceptance criteria (this PR)

- Given `CT_E2E=true` on desktop, the new test completes within **≤10** Next turn resolutions after map load (or fewer when success is earlier).
- Success is asserted **only via widget finders** (ExpansionTile + `Fleet ` title + subtitle `New World —`), not via `Game` / snapshot objects.
- CI `app_e2e_linux` runs `flutter test integration_test/new_game_fleet_reaches_new_world_e2e_test.dart` with `--dart-define=CT_E2E=true`.

## SPEC

- `SPEC/program/e2e-integration-tests.md`: new keys, CI list, local run example.

## Tests

- `flutter test integration_test/new_game_fleet_reaches_new_world_e2e_test.dart -d macos --dart-define=CT_E2E=true` (pass)

Refs #1831

Made with [Cursor](https://cursor.com)