### PR TITLE
CI: OpenCode post-e2e review in Quality workflow

### DIFF
--- a/.github/workflows/app-android-release.yml
+++ b/.github/workflows/app-android-release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/enable-automerge.yml
+++ b/.github/workflows/enable-automerge.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,9 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
+      opencode_scope: ${{ steps.filter.outputs.opencode_scope }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect source changes
         id: filter
@@ -43,6 +44,15 @@ jobs:
               - 'tool/embed_tech_effect_summary.dart'
               - 'tool/generate_order_engine_slots.dart'
               - 'tool/verify_order_engine_codegen.sh'
+            # True when any changed path is outside repo-root dot-directories (CI/editor meta). OpenCode
+            # review is skipped when the PR only touches those paths (e.g. .github, .cursor).
+            opencode_scope:
+              - '**'
+              - '!.cursor/**'
+              - '!.github/**'
+              - '!.vscode/**'
+              - '!.idea/**'
+              - '!.husky/**'
 
   # Resolved pub cache + .dart_tool + gen-l10n; flutter analyze gate; then pack for shards (--no-pub).
   # Jobs always run after `changes` so required branch checks get success (not skip) when the path filter
@@ -62,7 +72,7 @@ jobs:
 
       - name: Checkout
         if: needs.changes.outputs.tests == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Flutter
         if: needs.changes.outputs.tests == 'true'
@@ -151,7 +161,7 @@ jobs:
 
       - name: Checkout
         if: needs.changes.outputs.tests == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Flutter
         if: needs.changes.outputs.tests == 'true'
@@ -212,7 +222,7 @@ jobs:
 
       - name: Checkout
         if: needs.changes.outputs.tests == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Flutter
         if: needs.changes.outputs.tests == 'true'
@@ -267,7 +277,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -450,7 +460,7 @@ jobs:
 
       - name: Checkout
         if: needs.changes.outputs.tests == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install lcov
         if: needs.changes.outputs.tests == 'true'
@@ -480,3 +490,105 @@ jobs:
       - name: App coverage gate (app/lib/ >= 80%)
         if: needs.changes.outputs.tests == 'true'
         run: tool/check_coverage_threshold.sh 80 app
+
+  # OpenCode post-e2e review: same workflow as Quality; runs only for same-repo PRs into dev after
+  # app_e2e_linux succeeds, and when the PR changes paths outside dot-prefixed meta dirs (see changes.opencode_scope).
+  # The model posts/updates a PR comment; the verdict job greps that comment for
+  # <!-- ct-opencode-verdict:PASS --> or <!-- ct-opencode-verdict:FAIL --> (see prompt).
+  opencode_review:
+    name: OpenCode review
+    needs: [changes, app_e2e_linux]
+    if: >-
+      github.base_ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.changes.result == 'success' &&
+      needs.changes.outputs.opencode_scope == 'true' &&
+      needs.app_e2e_linux.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      pull-requests: write
+      issues: write
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run OpenCode (PR review)
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_GO_API_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          model: ${{ vars.OPENCODE_REVIEW_MODEL || 'opencode-go/minimax-m2.7' }}
+          use_github_token: true
+          prompt: |
+            You are the final OpenCode reviewer for this pull request after Linux app e2e tests passed.
+
+            The repository is checked out in the workspace. Read and apply these files in full:
+            - .cursor/rules/colonizethis-code-review.mdc
+            - .cursor/rules/colonizethis-component-structure.mdc
+
+            Also verify:
+            - The PR diff implements what linked closing issues and the PR description request (use GitHub context available to you).
+            - SPEC documents under SPEC/ stay aligned with code for behavior touched by this diff.
+
+            Deliverables (must all be satisfied):
+            1) Put **all** detailed review text in **one** GitHub pull request **issue comment** on this PR (the main PR conversation). Do not rely on CI or workflow logs for the long-form review; the PR comment is the source of truth for details.
+
+            2) **Single sticky comment**: If a PR issue comment already exists whose body contains the literal HTML marker `<!-- ct-opencode-quality-review -->`, **edit that same comment** with your updated review (keep the marker in the updated body). If none exists, create **one** new PR issue comment that includes that marker exactly once.
+
+            3) **Machine-readable verdict** (strict): The comment body MUST contain **exactly one** of the following literal substrings, copied verbatim (including angle brackets and colons), and MUST NOT contain the other:
+            - `<!-- ct-opencode-verdict:PASS -->` when the outcome is pass
+            - `<!-- ct-opencode-verdict:FAIL -->` when the outcome is fail
+            CI greps the latest sticky review comment for these markers. Put the verdict marker on its own line near the top (after the sticky marker is fine).
+
+            4) Choose `<!-- ct-opencode-verdict:FAIL -->` if anything material must change before merge (bugs, spec violations, missing tests for critical behavior, violations of the rule files above, or mismatch with linked issue intent). Otherwise choose `<!-- ct-opencode-verdict:PASS -->`. Use Markdown for all human-readable detail around the markers as you see fit.
+
+  opencode_review_verdict:
+    name: OpenCode review verdict
+    needs: [opencode_review]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Skip when OpenCode review did not run
+        if: needs.opencode_review.result == 'skipped'
+        run: echo "OpenCode review not applicable for this run."; exit 0
+
+      - name: Fail when OpenCode review job failed or was cancelled
+        if: needs.opencode_review.result != 'skipped' && needs.opencode_review.result != 'success'
+        run: |
+          echo "::error::OpenCode review job ended with ${{ needs.opencode_review.result }}"
+          exit 1
+
+      - name: Enforce verdict from PR comment
+        if: needs.opencode_review.result == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 36); do
+            body="$(
+              gh api "repos/${GITHUB_REPOSITORY}/issues/${{ github.event.pull_request.number }}/comments?per_page=100" \
+                --jq '([.[] | select(.body | contains("<!-- ct-opencode-quality-review -->"))] | sort_by(.id) | reverse | .[0].body) // empty'
+            )"
+            if [ -n "${body}" ]; then
+              if printf '%s' "${body}" | grep -Fq '<!-- ct-opencode-verdict:FAIL -->'; then
+                echo "::error::OpenCode verdict is FAIL (<!-- ct-opencode-verdict:FAIL -->) — see the sticky PR comment."
+                exit 1
+              fi
+              if printf '%s' "${body}" | grep -Fq '<!-- ct-opencode-verdict:PASS -->'; then
+                echo "OpenCode verdict: PASS"
+                exit 0
+              fi
+            fi
+            sleep 5
+          done
+          echo "::error::Timed out waiting for sticky OpenCode comment with <!-- ct-opencode-verdict:PASS --> or <!-- ct-opencode-verdict:FAIL -->"
+          exit 1

--- a/.github/workflows/widgetbook-release.yml
+++ b/.github/workflows/widgetbook-release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- Integrates **OpenCode** (`anomalyco/opencode/github@latest`) into the **Quality** workflow after **`app_e2e_linux`** succeeds, for same-repo PRs targeting **`dev`**.
- Adds **`opencode_review_verdict`** to enforce **`<!-- ct-opencode-verdict:PASS -->`** / **`FAIL`** from the sticky PR comment (no artifacts).
- Skips OpenCode when the PR only changes paths under repo-root dot-meta dirs (`.cursor`, `.github`, `.vscode`, `.idea`, `.husky`) via **`changes.outputs.opencode_scope`**.
- Bumps **`actions/checkout`** to **v6** in app-android-release, widgetbook-release, and enable-automerge workflows.

## Notes
- Requires repo secret **`OPENCODE_GO_API_KEY`** and optional variable **`OPENCODE_REVIEW_MODEL`** (defaults to **`opencode-go/minimax-m2.7`** in workflow).
- Update branch protection required checks if needed: **`Quality / OpenCode review verdict`** (and optionally **`Quality / OpenCode review`**).

Made with [Cursor](https://cursor.com)