### PR TITLE
ci(docs): scope OpenCode review; CONTRIBUTING help wanted

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2,6 +2,12 @@ name: Quality
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
     branches:
       - main
       - dev
@@ -492,7 +498,8 @@ jobs:
         run: tool/check_coverage_threshold.sh 80 app
 
   # OpenCode post-e2e review: same workflow as Quality; runs only for same-repo PRs into dev after
-  # app_e2e_linux succeeds, and when the PR changes paths outside dot-prefixed meta dirs (see changes.opencode_scope).
+  # app_e2e_linux succeeds, when the PR changes paths outside dot-prefixed meta dirs (see changes.opencode_scope),
+  # and when either the PR has the `help wanted` label or more than 10 files changed (otherwise skipped).
   # The model posts/updates a PR comment; the verdict job greps that comment for
   # <!-- ct-opencode-verdict:PASS --> or <!-- ct-opencode-verdict:FAIL --> (see prompt).
   opencode_review:
@@ -503,7 +510,8 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       needs.changes.result == 'success' &&
       needs.changes.outputs.opencode_scope == 'true' &&
-      needs.app_e2e_linux.result == 'success'
+      needs.app_e2e_linux.result == 'success' &&
+      (contains(github.event.pull_request.labels.*.name, 'help wanted') || github.event.pull_request.changed_files > 10)
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -564,7 +572,10 @@ jobs:
     steps:
       - name: Skip when OpenCode review did not run
         if: needs.opencode_review.result == 'skipped'
-        run: echo "OpenCode review not applicable for this run."; exit 0
+        run: |
+          echo "OpenCode review did not run (skipped): not applicable for this PR run—for example wrong base branch,"
+          echo "fork PR, path-only meta changes, e2e not green, or gate scope (needs label 'help wanted' or >10 changed files per workflow)."
+          exit 0
 
       - name: Fail when OpenCode review job failed or was cancelled
         if: needs.opencode_review.result != 'skipped' && needs.opencode_review.result != 'success'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,20 @@ Before opening a pull request, ensure the following:
 - [ ] **Implementation aligned**: I have aligned the implementation (and tests) with the updated specs and ACs.
 - [ ] **Logging aligned**: If the change adds or alters logging (messages, levels, prefixes, or new emissions such as game events), I have checked it against **[SPEC/program/logging/logging.md](./SPEC/program/logging/logging.md)** and the relevant annexes ([map-generation](./SPEC/program/logging/map-generation.md), [turn-resolution](./SPEC/program/logging/turn-resolution.md), [ai-actions](./SPEC/program/logging/ai-actions.md), [events](./SPEC/program/logging/events.md)) and against host sink specs where applicable ([ctdev-logging.md](./SPEC/program/ctdev-logging.md), [debug-log-viewer.md](./SPEC/program/debug-log-viewer.md), [test-logging.md](./SPEC/program/test-logging.md)).
 - [ ] **Coverage quality gate met**: I have ensured that test coverage meets the project's quality gate requirements (90% for logic/ai/map packages; 80% elsewhere).
+- [ ] **OpenCode / help wanted**: I have read [OpenCode review and the help wanted label](#opencode-review-and-the-help-wanted-label) and applied the label when appropriate (see that section if I cannot add labels myself).
+
+## OpenCode review and the help wanted label
+
+The Quality workflow can run an **OpenCode** post–e2e PR review when the PR is in scope for that gate. To **request** that review, add the GitHub label **`help wanted`** (exact name). Heuristics—use your judgment; **when in doubt, add the label**:
+
+- The PR **touches multiple packages** (or crosses major boundaries such as app + logic + map in one change set).
+- The PR is a **large refactor** (wide renames, structural moves, or behavior changes across many call sites).
+
+Apply **`help wanted` for any PR you consider sufficiently complex by the above**, **even if** the PR already changes **more than ten files** (the workflow may also run OpenCode on large diffs without the label; the label makes intent explicit).
+
+**When to add the label:** Prefer adding **`help wanted` when you open the PR** so a passing run can pick up OpenCode without an extra cycle. If you add it later, the **Quality** workflow also runs on the **`labeled`** event, so adding `help wanted` after open will **re-run** checks and allow the gate to apply on the new run (subject to the same branch and path rules as always).
+
+If your GitHub role **cannot add labels**, state in the PR description that you want the **`help wanted`** label applied for OpenCode review (or ask a maintainer during triage).
 
 ## Repo convention lint
 


### PR DESCRIPTION
## Summary

- **OpenCode gate:** `opencode_review` runs only when existing conditions hold **and** either the PR has the `help wanted` label or more than 10 files changed.
- **Required verdict:** `opencode_review_verdict` still exits successfully when the review job is skipped; skip log mentions the new scope rule.
- **CONTRIBUTING:** Pre-PR checklist item plus a section on when to apply `help wanted` (heuristics, when in doubt, explicit label even for large PRs, label-at-open vs maintainer/description if no permission).
- **Workflow trigger:** Quality `pull_request` types now include `labeled` (alongside opened, synchronize, reopened, ready_for_review) so adding `help wanted` after open re-runs the workflow.

## Motivation

Reduce default OpenCode cost while keeping opt-in review for complex or community-requested work, with docs and CI aligned.

Made with [Cursor](https://cursor.com)