### PR TITLE
ci: add OpenCode GitHub Actions workflow

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,33 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode-go/qwen3.6-plus


### PR DESCRIPTION
Adds `.github/workflows/opencode.yml` so maintainers can trigger [OpenCode](https://github.com/anomalyco/opencode) from GitHub comments on issues and pull request review threads.

**Triggers:** Comments containing `/oc`, `/opencode` (word-boundary or line-start), matching the workflow `if` conditions.

**Setup required:** Configure the repository secret `OPENCODE_API_KEY` for the action to authenticate.

This complements the existing OpenCode integration described in CONTRIBUTING (Quality workflow + `help wanted` label).

Made with [Cursor](https://cursor.com)