### PR TITLE
docs(skills): refocus review-github-issue on purpose vs method

### DIFF
--- a/.cursor/skills/review-github-issue/SKILL.md
+++ b/.cursor/skills/review-github-issue/SKILL.md
@@ -1,25 +1,152 @@
 ---
 name: review-github-issue
 description: |-
-  Review a GitHub issue against existing code, specs, and tests to identify gaps, inconsistencies, and misalignments. Builds a consolidated comment highlighting each problem, priority, and suggested remedy. Use when user asks to review, audit, or triage an issue; to find gaps before implementation; or to prepare for a fix PR.
+  Reviews a GitHub issue for coherence between its stated purpose and its proposed approach (design, scope, ACs). Produces a consolidated comment: primary focus is purpose↔method gaps and internal contradictions; code/spec/test evidence only when needed to show the proposed method cannot satisfy the purpose. Use before implementation; use verify-github-issue for issue vs implementation/SPEC/tests closure.
 
   Examples:
-  - user: "Review issue #42" → load issue, trace ACs to code/specs/tests, output gap analysis with priorities
-  - user: "Audit this bug report for inconsistencies" → identify what issue intends to solve, verify each item aligns
-  - user: "Find gaps in issue before starting work" → rigorous review against existing implementation
-  - user: "Triage this issue against our specs" → map issue items to SPEC sections, flag contradictions
+  - user: "Review issue #42" → state purpose, assess whether the proposed method plausibly achieves it, flag internal gaps; repo evidence only if method cannot satisfy purpose
+  - user: "Audit this bug report" → extract goal vs proposed fix; flag mismatches, missing how, contradictions in the text
+  - user: "Find gaps in issue before starting work" → purpose–method alignment and thin-issue contradictions first; defer full AC→code mapping to verify
+  - user: "Triage this issue" → clarify purpose, scope, and whether the described approach hangs together
 ---
 
 # Review a GitHub Issue (ColonizeThis)
 
-This skill is maintained at [`.opencode/skills/review-github-issue/SKILL.md`](.opencode/skills/review-github-issue/SKILL.md).
+This skill is maintained in sync with **[`.opencode/skills/review-github-issue/SKILL.md`](../../../.opencode/skills/review-github-issue/SKILL.md)**.
 
-The unified skill body contains:
-- Full workflow (load issue → identify purpose → trace to code/specs/tests → identify gaps → assess priority → build consolidated comment)
-- Output template
-- Quality bar
-- Related skill references
+The unified skill body is duplicated below so Cursor agents load the full workflow from `.cursor/skills/` without resolving cross-folder links.
 
-**Canonical location:** `.opencode/skills/review-github-issue/`
+---
 
-**References:** `.opencode/skills/review-github-issue/references/review-reference.md`
+## When this applies
+
+The user supplies a **GitHub issue number** (e.g. `42`) or **issue URL** and asks to **review**, **audit**, or **triage** the issue **before implementation**.
+
+The goal is a **consolidated comment** whose **primary** analysis is:
+
+- **Purpose ↔ method**: gaps or tensions between **what the issue purportedly addresses** (its purpose / outcome) and **how it proposes to get there** (design, steps, scope, dependencies, acceptance criteria as a solution shape).
+
+This skill is **not** centered on re-deriving **“issue description vs current SPEC/implementation/tests”** as the main output. That reconciliation should already live in a well-written issue; **systematic** mapping of acceptance criteria to code, specs, and tests for closure belongs in **`.cursor/skills/verify-github-issue/SKILL.md`**.
+
+## Boundary: review vs verify
+
+| Skill | Primary question | Typical evidence |
+|-------|------------------|------------------|
+| **review-github-issue** (this) | Does the **purpose** align with the **proposed method**? Are there **internal** contradictions or missing “how”? | Issue text (quotes); repo/SPEC/tests **only** when needed to show the method **cannot** satisfy the purpose |
+| **verify-github-issue** | Does the **work** satisfy the issue’s ACs against **implementation, SPEC, and tests**? | Code paths, SPEC sections, tests, CI/coverage |
+
+## Non-negotiables (repo policy)
+
+Follow **[AGENTS.md](../../../AGENTS.md)** (Cursor rules under `.cursor/rules/`) and **[CONTRIBUTING.md](../../../CONTRIBUTING.md)**.
+
+- **SPEC-first**: The issue’s purpose must not imply behavior that contradicts GDD/TDD; if the **proposed method** would do so, that is **in scope** here (purpose–method feasibility), and may require SPEC updates before implementation.
+- **Gap grounding**:
+  - **Primary gaps** (purpose vs method, internal inconsistency, out-of-scope items) must be grounded in **the issue text** (short quotes or paraphrase with pointer to section).
+  - **Repo/SPEC/test evidence** is required **only when** it directly supports the claim that the **proposed method cannot satisfy** the **stated purpose** (e.g. non-negotiable architecture boundary, impossible sequencing, missing hook that the method assumes). Label remaining uncertainty as **hypothesis** and how to verify.
+- **Priority framing**: Distinguish **blocks drafting or implementing from this issue** from **follow-up** clarifications.
+
+## Workflow
+
+### 1. Load the issue
+
+Run:
+
+```bash
+gh issue view <n> --json title,body,labels,state,url,comments
+```
+
+or use the web UI. Confirm state is **open** (unless the user explicitly asked about a closed issue).
+
+### 2. Identify the purpose
+
+Ask: **“What is this issue intending to solve or change?”**
+
+- Extract the **goal / outcome** from title + body—not only symptoms or a single proposed patch.
+- If the purpose is unclear or overloaded, state that and propose a **single-sentence purpose** the issue should adopt.
+
+This purpose is the **anchor** for all purpose–method checks.
+
+### 3. Extract the proposed method
+
+Identify **how** the issue says the purpose should be achieved:
+
+- Proposed **design**, **steps**, **files/modules** mentioned, **API or event** shapes, **scope** (in/out), **dependencies**, **risks**, and **acceptance criteria** insofar as they define the solution—not as a checklist against the whole repo.
+
+### 4. Primary analysis: purpose ↔ method and internal consistency
+
+**Do this first** (mostly from the issue alone):
+
+- **Alignment**: Does each major part of the proposed method **contribute** to the stated purpose? Flag **out-of-scope**, **under-specified**, or **misaligned** pieces.
+- **Internal contradictions**: Title vs body; AC vs proposed fix; scope vs labels/milestone; duplicate or conflicting requirements.
+- **Thin issues**: If purpose is somewhat clear but **how** is missing or self-contradictory, **flag that as the main finding**—do **not** substitute a full repository audit for missing method text.
+
+### 5. Conditional deep trace (code, SPEC, tests)
+
+Search the repo **only when** step 4 shows (or strongly suggests) that the **method cannot satisfy the purpose**, including:
+
+- Hard **architecture** or **package-boundary** constraints (e.g. logic ↔ AI decoupling).
+- **SPEC-first** violations implied by the method.
+- Claims that a hook, type, or behavior **exists** when a quick check shows it does **not**—**if** that absence blocks the described approach.
+
+Do **not** perform a full item-by-item ✅/⚠️/❌ inventory against the codebase as the default output of this skill; that is **verify** territory.
+
+When repo evidence is used, cite **minimal** paths or SPEC sections—enough to justify the purpose–method conclusion.
+
+### 6. Assess priority for each problem
+
+| Priority | Meaning |
+|----------|---------|
+| **P0 (blocks)** | The issue, as written, cannot be implemented or agreed without resolving this (e.g. purpose–method contradiction, method impossible under repo rules). |
+| **P1 (important)** | Material ambiguity or misalignment; should be fixed before or during implementation planning. |
+| **P2 (follow-up)** | Clarifications, polish, or deferrable scope notes. |
+
+### 7. Build consolidated comment
+
+Output a single structured comment with:
+
+1. **Purpose statement** — one sentence (from step 2; or your proposed sentence if the issue was unclear).
+2. **Purpose–method review** — bullet or table: each problem, evidence (issue quote and, if applicable, minimal code/SPEC/test pointer), priority, **suggested remedy** (edit issue text, split issue, adjust design, or point to SPEC work).
+3. **Optional**: One line pointing to **verify-github-issue** when the issue is internally coherent and the next step is AC↔implementation proof.
+
+Use a neutral, factual tone. Do not close the issue.
+
+### 8. Present findings
+
+- Paste the consolidated comment in chat for the user to post.
+- Include the issue URL and number.
+- If `gh` is available and the user requests, offer to post as a comment:
+
+  ```bash
+  gh issue comment <n> --body "<comment>"
+  ```
+
+## Quality bar
+
+- **Primary** findings are visible without reading the whole codebase: purpose–method and **in-issue** consistency.
+- Repo/SPEC/test citations appear **only** where they **directly** support “this method cannot achieve this purpose” (per project policy: evidence type **B**).
+- If speculation is necessary, label **hypothesis** and suggest how to verify (often via **verify** after a fix PR).
+
+## Output template
+
+```markdown
+## Issue purpose
+[One sentence]
+
+## Purpose ↔ method
+- [Gap or alignment note — quote issue where useful]
+  - Evidence: [issue excerpt; optional minimal code/SPEC/test if feasibility]
+  - Priority: P0|P1|P2
+  - Remedy: [concrete issue/spec/plan edit]
+
+## Internal consistency
+- [Or “None noted.”]
+
+## Summary
+[P0/P1/P2 counts]. [If appropriate: next step is verify-github-issue against implementation/SPEC/tests.]
+```
+
+## Related skills
+
+- **Implement**: `.cursor/skills/implement-github-issue-fix/SKILL.md`
+- **Verify / close** (issue vs implementation, SPEC, tests): `.cursor/skills/verify-github-issue/SKILL.md`
+- Tracing hints (when step 5 applies): `.opencode/skills/review-github-issue/references/review-reference.md`

--- a/.opencode/skills/review-github-issue/SKILL.md
+++ b/.opencode/skills/review-github-issue/SKILL.md
@@ -1,135 +1,146 @@
 ---
 name: review-github-issue
 description: |-
-  Review a GitHub issue against existing code, specs, and tests to identify gaps, inconsistencies, and misalignments. Builds a consolidated comment highlighting each problem, priority, and suggested remedy. Use when user asks to review, audit, or triage an issue; to find gaps before implementation; or to prepare for a fix PR.
+  Reviews a GitHub issue for coherence between its stated purpose and its proposed approach (design, scope, ACs). Produces a consolidated comment: primary focus is purpose↔method gaps and internal contradictions; code/spec/test evidence only when needed to show the proposed method cannot satisfy the purpose. Use before implementation; use verify-github-issue for issue vs implementation/SPEC/tests closure.
 
   Examples:
-  - user: "Review issue #42" → load issue, trace ACs to code/specs/tests, output gap analysis with priorities
-  - user: "Audit this bug report for inconsistencies" → identify what issue intends to solve, verify each item aligns
-  - user: "Find gaps in issue before starting work" → rigorous review against existing implementation
-  - user: "Triage this issue against our specs" → map issue items to SPEC sections, flag contradictions
+  - user: "Review issue #42" → state purpose, assess whether the proposed method plausibly achieves it, flag internal gaps; repo evidence only if method cannot satisfy purpose
+  - user: "Audit this bug report" → extract goal vs proposed fix; flag mismatches, missing how, contradictions in the text
+  - user: "Find gaps in issue before starting work" → purpose–method alignment and thin-issue contradictions first; defer full AC→code mapping to verify
+  - user: "Triage this issue" → clarify purpose, scope, and whether the described approach hangs together
 ---
 
 # Review a GitHub Issue (ColonizeThis)
 
 ## When this applies
 
-The user supplies a **GitHub issue number** (e.g. `42`) or **issue URL** and asks to review it against the codebase, specs, and tests. The goal is to produce a **consolidated comment** identifying gaps, inconsistencies, and misalignments—grounded in evidence from code, specs, and tests.
+The user supplies a **GitHub issue number** (e.g. `42`) or **issue URL** and asks to **review**, **audit**, or **triage** the issue **before implementation**.
+
+The goal is a **consolidated comment** whose **primary** analysis is:
+
+- **Purpose ↔ method**: gaps or tensions between **what the issue purportedly addresses** (its purpose / outcome) and **how it proposes to get there** (design, steps, scope, dependencies, acceptance criteria as a solution shape).
+
+This skill is **not** centered on re-deriving **“issue description vs current SPEC/implementation/tests”** as the main output. That reconciliation should already live in a well-written issue; **systematic** mapping of acceptance criteria to code, specs, and tests for closure belongs in **`.cursor/skills/verify-github-issue/SKILL.md`**.
+
+## Boundary: review vs verify
+
+| Skill | Primary question | Typical evidence |
+|-------|------------------|------------------|
+| **review-github-issue** (this) | Does the **purpose** align with the **proposed method**? Are there **internal** contradictions or missing “how”? | Issue text (quotes); repo/SPEC/tests **only** when needed to show the method **cannot** satisfy the purpose |
+| **verify-github-issue** | Does the **work** satisfy the issue’s ACs against **implementation, SPEC, and tests**? | Code paths, SPEC sections, tests, CI/coverage |
 
 ## Non-negotiables (repo policy)
 
-Follow **[AGENTS.md](https://github.com/AnomalyCo/colonizethisv3_6/blob/dev/AGENTS.md)** (Cursor rules under `.cursor/rules/`) and **[CONTRIBUTING.md](https://github.com/AnomalyCo/colonizethisv3_6/blob/dev/CONTRIBUTING.md)**.
+Follow **[AGENTS.md](../../../AGENTS.md)** (Cursor rules under `.cursor/rules/`) and **[CONTRIBUTING.md](../../../CONTRIBUTING.md)**.
 
-- **SPEC-first**: Every issue has an implicit or explicit **purpose** (what it intends to solve). Verify the issue actually addresses that purpose before reviewing individual items.
-- **Gap grounding**: Every problem cited must be traceable to: code implementation, SPEC section, or test. Do not speculate without flagging as hypothesis.
-- **Priority framing**: Distinguish **blocks resolution** (must fix) from **follow-up** (nice-to-have or deferred).
+- **SPEC-first**: The issue’s purpose must not imply behavior that contradicts GDD/TDD; if the **proposed method** would do so, that is **in scope** here (purpose–method feasibility), and may require SPEC updates before implementation.
+- **Gap grounding**:
+  - **Primary gaps** (purpose vs method, internal inconsistency, out-of-scope items) must be grounded in **the issue text** (short quotes or paraphrase with pointer to section).
+  - **Repo/SPEC/test evidence** is required **only when** it directly supports the claim that the **proposed method cannot satisfy** the **stated purpose** (e.g. non-negotiable architecture boundary, impossible sequencing, missing hook that the method assumes). Label remaining uncertainty as **hypothesis** and how to verify.
+- **Priority framing**: Distinguish **blocks drafting or implementing from this issue** from **follow-up** clarifications.
 
 ## Workflow
 
 ### 1. Load the issue
 
 Run:
+
 ```bash
 gh issue view <n> --json title,body,labels,state,url,comments
 ```
-or use the web UI. Confirm state is **open**.
 
-### 2. Identify the ultimate purpose
+or use the web UI. Confirm state is **open** (unless the user explicitly asked about a closed issue).
 
-Ask: **"What is this issue intending to solve?"**
+### 2. Identify the purpose
 
-- Extract the **goal** from title + body (not just the symptoms or proposed solution)
-- If the goal is unclear, state that the issue lacks a clear purpose statement and propose one
-- This purpose is the **anchor** for all subsequent alignment checks
+Ask: **“What is this issue intending to solve or change?”**
 
-### 3. Trace each issue item to code, specs, and tests
+- Extract the **goal / outcome** from title + body—not only symptoms or a single proposed patch.
+- If the purpose is unclear or overloaded, state that and propose a **single-sentence purpose** the issue should adopt.
 
-For each item in the issue (requirements, acceptance criteria, proposed fix, edge cases):
+This purpose is the **anchor** for all purpose–method checks.
 
-| Check | How |
-|-------|-----|
-| **Implementation** | Search repo for relevant modules, types, functions. Map symptom → likely code path. |
-| **Specs** | Quote or summarize specific files/sections from `SPEC/game/`, `SPEC/program/`, `SPEC/ai/`, `SPEC/ui/` that address or contradict the item. |
-| **Tests** | Note existing tests that cover this scenario vs. missing tests. |
+### 3. Extract the proposed method
 
-For each item, categorize:
-- ✅ **implemented** — matches code + specs + tests
-- ⚠️ **partial** — partially addressed but missing pieces
-- ❌ **missing** — not addressed in code or specs
-- 🔀 **contradicts** — item conflicts with existing SPEC or implementation
-- ❓ **unknown** — insufficient info; flag as hypothesis
+Identify **how** the issue says the purpose should be achieved:
 
-### 4. Identify gaps and inconsistencies
+- Proposed **design**, **steps**, **files/modules** mentioned, **API or event** shapes, **scope** (in/out), **dependencies**, **risks**, and **acceptance criteria** insofar as they define the solution—not as a checklist against the whole repo.
 
-**Gaps** (items that don't address the purpose):
-- Item exists in issue but does not contribute to the stated purpose → flag as out-of-scope or misaligned
+### 4. Primary analysis: purpose ↔ method and internal consistency
 
-**Inconsistencies** (internal contradictions):
-- Title vs. body contradiction
-- AC vs. proposed fix mismatch
-- Labels/milestones vs. actual content mismatch
+**Do this first** (mostly from the issue alone):
 
-**Gaps vs. SPEC/code**:
-- Item contradicts existing SPEC → spec bug vs. implementation bug vs. misunderstanding
-- Item has no test coverage → note as testing gap
+- **Alignment**: Does each major part of the proposed method **contribute** to the stated purpose? Flag **out-of-scope**, **under-specified**, or **misaligned** pieces.
+- **Internal contradictions**: Title vs body; AC vs proposed fix; scope vs labels/milestone; duplicate or conflicting requirements.
+- **Thin issues**: If purpose is somewhat clear but **how** is missing or self-contradictory, **flag that as the main finding**—do **not** substitute a full repository audit for missing method text.
 
-### 5. Assess priority for each problem
+### 5. Conditional deep trace (code, SPEC, tests)
+
+Search the repo **only when** step 4 shows (or strongly suggests) that the **method cannot satisfy the purpose**, including:
+
+- Hard **architecture** or **package-boundary** constraints (e.g. logic ↔ AI decoupling).
+- **SPEC-first** violations implied by the method.
+- Claims that a hook, type, or behavior **exists** when a quick check shows it does **not**—**if** that absence blocks the described approach.
+
+Do **not** perform a full item-by-item ✅/⚠️/❌ inventory against the codebase as the default output of this skill; that is **verify** territory.
+
+When repo evidence is used, cite **minimal** paths or SPEC sections—enough to justify the purpose–method conclusion.
+
+### 6. Assess priority for each problem
 
 | Priority | Meaning |
 |----------|---------|
-| **P0 (blocks)** | Issue cannot be resolved without fixing this; prevents closure |
-| **P1 (important)** | Significant misalignment; should be addressed but not blocking |
-| **P2 (follow-up)** | Nice-to-have fix, deferred, or edge case that can be handled separately |
+| **P0 (blocks)** | The issue, as written, cannot be implemented or agreed without resolving this (e.g. purpose–method contradiction, method impossible under repo rules). |
+| **P1 (important)** | Material ambiguity or misalignment; should be fixed before or during implementation planning. |
+| **P2 (follow-up)** | Clarifications, polish, or deferrable scope notes. |
 
-### 6. Build consolidated comment
+### 7. Build consolidated comment
 
 Output a single structured comment with:
 
-1. **Purpose statement** — one sentence stating what the issue intends to solve (from Step 2)
-2. **Items** (for each issue item):
-   - Status icon (✅/⚠️/❌/🔀/❓)
-   - What the item says
-   - Evidence (code paths, SPEC sections, test files)
-   - Problem if any (misaligned, contradictory, missing)
-   - Priority (P0/P1/P2)
-   - **Suggested remedy** — concrete fix or SPEC/test update
+1. **Purpose statement** — one sentence (from step 2; or your proposed sentence if the issue was unclear).
+2. **Purpose–method review** — bullet or table: each problem, evidence (issue quote and, if applicable, minimal code/SPEC/test pointer), priority, **suggested remedy** (edit issue text, split issue, adjust design, or point to SPEC work).
+3. **Optional**: One line pointing to **verify-github-issue** when the issue is internally coherent and the next step is AC↔implementation proof.
 
 Use a neutral, factual tone. Do not close the issue.
 
-### 7. Present findings
+### 8. Present findings
 
-- Paste the consolidated comment in chat for the user to post
-- Include the issue URL and number
-- If `gh` is available and user requests, offer to post as a comment:
+- Paste the consolidated comment in chat for the user to post.
+- Include the issue URL and number.
+- If `gh` is available and the user requests, offer to post as a comment:
+
   ```bash
   gh issue comment <n> --body "<comment>"
   ```
 
 ## Quality bar
 
-- Every problem must be **grounded** in code, specs, or tests—not speculation
-- If speculation is necessary, label as **hypothesis** and suggest how to verify
-- Distinguish **what the issue intends to solve** from **how it proposes to solve it**; misaligned *how* items are still gaps
-- Avoid dumping full investigation; keep to gap-level evidence
+- **Primary** findings are visible without reading the whole codebase: purpose–method and **in-issue** consistency.
+- Repo/SPEC/test citations appear **only** where they **directly** support “this method cannot achieve this purpose” (per user policy **B**).
+- If speculation is necessary, label **hypothesis** and suggest how to verify (often via **verify** after a fix PR).
 
 ## Output template
 
 ```markdown
-## Issue Purpose
-[One sentence: what this issue intends to solve]
+## Issue purpose
+[One sentence]
 
-## Review
+## Purpose ↔ method
+- [Gap or alignment note — quote issue where useful]
+  - Evidence: [issue excerpt; optional minimal code/SPEC/test if feasibility]
+  - Priority: P0|P1|P2
+  - Remedy: [concrete issue/spec/plan edit]
 
-| Item | Status | Evidence | Problem | Priority | Remedy |
-|------|--------|----------|---------|----------|--------|
-| ...  | ...    | ...      | ...     | ...      | ...    |
+## Internal consistency
+- [Or “None noted.”]
 
 ## Summary
-[P0 count] blocking, [P1 count] important, [P2 count] follow-up items.
+[P0/P1/P2 counts]. [If appropriate: next step is verify-github-issue against implementation/SPEC/tests.]
 ```
 
 ## Related skills
 
-- For **implementing a fix** after review: see `.cursor/skills/implement-github-issue-fix/SKILL.md`
-- For **verifying or closing** an issue after gaps are fixed: see `.cursor/skills/verify-github-issue/SKILL.md`
-- Tracing hints: see `.opencode/skills/review-github-issue/references/review-reference.md`
+- **Implement**: `.cursor/skills/implement-github-issue-fix/SKILL.md`
+- **Verify / close** (issue vs implementation, SPEC, tests): `.cursor/skills/verify-github-issue/SKILL.md`
+- Tracing hints (when step 5 applies): `.opencode/skills/review-github-issue/references/review-reference.md`

--- a/.opencode/skills/review-github-issue/references/review-reference.md
+++ b/.opencode/skills/review-github-issue/references/review-reference.md
@@ -1,4 +1,6 @@
-# Reference: Code, Specs, and Tests for Issue Review
+# Reference: Issue review (purpose ↔ method) and optional repo trace
+
+Use this reference when **`review-github-issue`** needs a **conditional** repo/SPEC/test trace: only to show that a **proposed method** in the issue **cannot satisfy** the issue’s **stated purpose** (architecture boundaries, SPEC-first conflicts, missing assumed hooks). Full **acceptance criteria ↔ implementation ↔ tests** mapping for closure is **`verify-github-issue`**, not this skill.
 
 ## Finding the purpose (SPEC structure)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Skills live under `.cursor/skills/<name>/SKILL.md`. When a skill matches the tas
 | `implement-github-issue-fix` | User gives an issue **#** or **URL**; validate problem/design/testable ACs, update **SPEC** if needed, implement, add positive/negative tests, open PR to **`dev`** with **`Refs #…`** (do **not** auto-close). Very large issues: one isolatable slice only. |
 | `merge-dev-into-android-build` | Merge `dev` into `build/app/android` for APK build workflows. |
 | `plan-feature-github-issue` | Scope a feature from SPEC/code (read-only), then open a capturing issue—no implementation. |
-| `review-github-issue` | Review an issue against code/specs/tests to identify gaps, inconsistencies, and misalignments. Proposes consolidated comment with priorities and remedies. |
+| `review-github-issue` | Review an issue for **purpose ↔ proposed method** coherence and internal consistency; repo/SPEC/test evidence only when needed to show the method cannot satisfy the purpose. Consolidated comment with priorities and remedies; use **`verify-github-issue`** for AC↔implementation closure. |
 | `verify-github-issue` | Verify one open issue against ACs/specs/tests; gap analysis or closure steps. |
 
 ## Contributing


### PR DESCRIPTION
## Summary

Updates **`review-github-issue`** (both `.cursor/skills/` and `.opencode/skills/`) so gap analysis centers on **purpose ↔ proposed method** and **internal issue consistency**, not on re-deriving issue vs current SPEC/implementation as the default output.

## Details

- **Primary**: alignment of stated purpose with design, scope, steps, ACs-as-solution-shape; thin issues flag missing/contradictory *how* without substituting a full repo audit.
- **Repo / SPEC / test evidence**: only when it directly supports that the **proposed method cannot satisfy** the **stated purpose** (including architecture and SPEC-first impossibility).
- **Boundary**: `verify-github-issue` owns systematic AC ↔ implementation ↔ SPEC ↔ tests closure; review points there when appropriate.
- **AGENTS.md**: skill table row updated for discoverability.
- **review-reference.md**: intro clarifies conditional trace vs verify.

## Files

- `.opencode/skills/review-github-issue/SKILL.md`
- `.cursor/skills/review-github-issue/SKILL.md` (full body + canonical link)
- `.opencode/skills/review-github-issue/references/review-reference.md`
- `AGENTS.md`

Made with [Cursor](https://cursor.com)