### PR TITLE
test(logic): harden locked assigner AC-14/15 and AC-12 seed (Refs #1861)

### DIFF
--- a/SPEC/program/locked-province-assigner.md
+++ b/SPEC/program/locked-province-assigner.md
@@ -35,8 +35,8 @@ If search still fails: **`StateError`** from assigner; orchestration maps assign
 
 ## Tests
 
-- **AC-14 / AC-15:** `packages/colonizethis_logic/test/locked_assigner_mechanics_test.dart` — small hand-crafted topology; AC-14 asserts ≥1 backtrack; AC-15 asserts deterministic owner map and bounded backtracks across duplicate runs.
-- **AC-11 / AC-12:** `init_game_orchestrator_test.dart` — twenty fixed seeds for locked profile; determinism of OW ownership string for one seed. When a run’s OW **and** NW topologies both match the locked multisets, tests assert **AC-1–AC-9** predicates (province quotas, P–P connectivity, sea-bound seeds, continent role counts, NW tribe layout); when multisets do not match procedural output, those ACs are out of scope for that run until generator gates land.
+- **AC-14 / AC-15:** `packages/colonizethis_logic/test/locked_assigner_mechanics_test.dart` — five-province hand-crafted topology (`a–m–{d,g}`, `d–w`) with mandatory seed `a`, targets `A:3` / `B:2`, ranked neighbor choice at depth **2** (stack length after `a` and `m`) so the first tried expansion is infeasible for `B` and the assigner performs **exactly one** undo (`LockedAssignerObservation.backtracks == 1`). **AC-14** asserts that map plus `backtracks >= 1` (golden `1`). **AC-15** runs the same call twice and asserts identical owner maps, identical `backtracks`, identical `capitalRestarts` (fixture expects `0`), and `backtracks < 50` (non-thrash guard), so duplicate runs exercise the same DFS / tabu bookkeeping surface as the single-run AC-14 test.
+- **AC-11 / AC-12:** `init_game_orchestrator_test.dart` — twenty fixed seeds for locked profile; **AC-12** repeats full setup twice using **one of those same seeds** (currently `17011`) and asserts identical Old World `province id → owner id` strings. When a run’s OW **and** NW topologies both match the locked multisets, tests assert **AC-1–AC-9** predicates (province quotas, P–P connectivity, sea-bound seeds, continent role counts, NW tribe layout); when multisets do not match procedural output, those ACs are out of scope for that run until generator gates land.
 
 ## Shared helpers
 

--- a/packages/colonizethis_logic/test/init_game_orchestrator_test.dart
+++ b/packages/colonizethis_logic/test/init_game_orchestrator_test.dart
@@ -462,7 +462,8 @@ void main() {
     test(
       'AC-12 locked full-init profile: same seed yields identical OW owners',
       () {
-        const s = 900_003;
+        // Must match one of the AC-11 regression seeds (#1861 / #1822).
+        const s = 17011;
         final config = lockedFullInitConfig(seed: s);
         const options = InitGameOptions(cellSize: 8, renderPng: false);
         final a = runInitGame(config: config, options: options);

--- a/packages/colonizethis_logic/test/locked_assigner_mechanics_test.dart
+++ b/packages/colonizethis_logic/test/locked_assigner_mechanics_test.dart
@@ -1,13 +1,15 @@
 import 'package:colonizethis_logic/src/setup/locked_province_assigner.dart';
 import 'package:colonizethis_test/test.dart';
 
-/// Hand-tuned 4-node topology (brute-found) where the first ranked expansion
-/// dead-ends and the assigner undoes at least one placement (#1830 AC-14).
+/// Five-province topology: only `m` from mandatory `a`; at depth 2 from `m`,
+/// `d` ranks before `g` (higher P–P degree) but `d` first makes `B` infeasible,
+/// so the assigner backtracks once then takes `g` (#1861 / SPEC).
 const _ac14Neighbours = <String, Set<String>>{
-  'a': {'c', 'd'},
-  'b': {'c'},
-  'c': {'a', 'b'},
-  'd': {'a'},
+  'a': {'m'},
+  'm': {'a', 'd', 'g'},
+  'd': {'m', 'w'},
+  'g': {'m'},
+  'w': {'d'},
 };
 
 void main() {
@@ -71,24 +73,30 @@ void main() {
     test('AC-14 completes AC-14 topology with phased seeding (A mandatory a)', () {
       final obs = LockedAssignerObservation();
       final m = assignTerritoriesLockedOnLandmass(
-        landmassProvinceIds: {'a', 'b', 'c', 'd'},
+        landmassProvinceIds: {'a', 'm', 'd', 'g', 'w'},
         neighbours: _ac14Neighbours,
         growthOrder: const ['A', 'B'],
-        targetPerFaction: const {'A': 2, 'B': 2},
+        targetPerFaction: const {'A': 3, 'B': 2},
         mandatorySeedProvinceByFaction: const {'A': 'a'},
         backtrackLimitPerFaction: 500,
         observation: obs,
       );
-      expect(m, const {'a': 'A', 'd': 'A', 'b': 'B', 'c': 'B'});
+      expect(m, const {'a': 'A', 'm': 'A', 'g': 'A', 'w': 'B', 'd': 'B'});
+      expect(
+        obs.backtracks,
+        1,
+        reason:
+            'AC-14: exactly one undo/backtrack for this fixture (SPEC locked-province-assigner)',
+      );
     });
 
     test('AC-15 deterministic completion without thrash on same topology', () {
       Map<String, String> runOnce(LockedAssignerObservation? obs) {
         return assignTerritoriesLockedOnLandmass(
-          landmassProvinceIds: {'a', 'b', 'c', 'd'},
+          landmassProvinceIds: {'a', 'm', 'd', 'g', 'w'},
           neighbours: _ac14Neighbours,
           growthOrder: const ['A', 'B'],
-          targetPerFaction: const {'A': 2, 'B': 2},
+          targetPerFaction: const {'A': 3, 'B': 2},
           mandatorySeedProvinceByFaction: const {'A': 'a'},
           backtrackLimitPerFaction: 500,
           observation: obs,
@@ -101,6 +109,9 @@ void main() {
       final m2 = runOnce(o2);
       expect(m1, m2);
       expect(o1.backtracks, o2.backtracks);
+      expect(o1.capitalRestarts, o2.capitalRestarts);
+      expect(o1.backtracks, 1, reason: 'same golden search cost as AC-14');
+      expect(o1.capitalRestarts, 0);
       expect(o1.backtracks, lessThan(50), reason: 'anti-thrash guard');
     });
   });


### PR DESCRIPTION
## Summary

Implements GitHub **#1861**: strengthen locked-assigner mechanics tests and align AC-12 with the AC-11 seed list, with SPEC updates.

## Acceptance criteria (this PR)

- **AC-14:** Fixture guarantees an observable undo path with a golden `backtracks == 1` (not only a correct final map).
- **AC-15:** Duplicate runs assert identical owner maps, identical `backtracks`, identical `capitalRestarts`, golden `backtracks`, and the existing anti-thrash bound.
- **AC-12:** Determinism test uses seed `17011`, which is one of the twenty AC-11 literals.

## SPEC

- `SPEC/program/locked-province-assigner.md` — Tests section documents the five-node fixture, golden backtrack count, AC-15 counter assertions, and AC-12 seed choice.

## Tests

- `dart test` in `packages/colonizethis_logic` (full suite, 1119+ tests).

Refs #1861

Made with [Cursor](https://cursor.com)