### PR TITLE
Issue #1879 slice: add function-size repo lint gate

### DIFF
--- a/SPEC/program/function-size.md
+++ b/SPEC/program/function-size.md
@@ -1,0 +1,56 @@
+# Function size (repo lint)
+
+**SPEC/program** — AST gate for oversized function and method declarations in
+runtime domain Dart code.
+
+## Source of truth
+
+| Artifact | Role |
+|----------|------|
+| `tool/check_function_size.dart` | Analyzer-based checker and CLI |
+| `tool/function_size_allowlist.yaml` | Grandfathered `(file, symbol)` rows with a shrink-only `max_measured_lines` cap |
+
+## Scan scope
+
+The checker walks `collectRepoLintDomainDartFiles` and then scopes to
+`packages/colonizethis_logic/lib/src/**` for this phase.
+
+Tests and generated files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`) remain
+excluded by the shared scan contract.
+
+## Measurement contract
+
+- A function is measured by source lines from declaration start to declaration
+  end (inclusive).
+- Blank lines are excluded.
+- Single-line comments that begin with `//` are excluded.
+- All other lines count, including braces and block-comment lines.
+- Failure threshold is measured line count **>20**.
+
+## Allowlist contract (shrink-only)
+
+`tool/function_size_allowlist.yaml` uses:
+
+```yaml
+allowed_over_20:
+  - file: packages/foo/lib/src/example.dart
+    symbol: someFunction
+    max_measured_lines: 42
+```
+
+- If a symbol is allowlisted, the checker allows it only while measured lines
+  stay `<= max_measured_lines`.
+- If measured lines grow above the listed max, the checker fails.
+- New allowlist rows are not a default fix; prefer extracting helpers and
+  reducing measured lines.
+
+## Acceptance criteria
+
+- Given repository root as cwd, when CI runs `dart run tool/ct_repo_lint.dart`,
+  then rule `repo.function_size` runs and fails on any non-allowlisted symbol
+  measured over 20 lines with file, line, and symbol in output.
+- Given an allowlisted symbol and measured lines below or equal to its
+  `max_measured_lines`, when the checker runs, then it does not fail for that
+  symbol.
+- Given an allowlisted symbol whose measured lines exceed its
+  `max_measured_lines`, when the checker runs, then it fails for that symbol.

--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -13,6 +13,8 @@
 | `tool/check_repeated_magic_numbers.dart` | Repeated **hash/LCG-style** integer literals (`SPEC/program/repeated-magic-numbers.md`); rule `repo.repeated_magic_numbers` |
 | `tool/check_control_flow_nesting_depth.dart` | Control-flow nesting depth (`SPEC/program/control-flow-nesting-depth.md`); rule `repo.control_flow_nesting_depth` |
 | `tool/control_flow_nesting_depth_allowlist.yaml` | Grandfathered symbols at depth ≥4 (shrink-only; see nesting-depth SPEC) |
+| `tool/check_function_size.dart` | Function measured-line threshold (`SPEC/program/function-size.md`); rule `repo.function_size` |
+| `tool/function_size_allowlist.yaml` | Grandfathered symbols over measured-line threshold (shrink-only; see function-size SPEC) |
 
 ## Rule IDs and groups
 

--- a/test/check_function_size_test.dart
+++ b/test/check_function_size_test.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../tool/check_function_size.dart';
+
+void main() {
+  group('scanFunctionSizesFromSourceForTest', () {
+    test('counts non-empty non-// lines in function declaration span', () {
+      const source = '''
+int f() {
+  // ignored
+  final a = 1;
+
+  final b = 2;
+  return a + b;
+}
+''';
+      final sizes = scanFunctionSizesFromSourceForTest(source);
+      final f = sizes.singleWhere((e) => e.symbol == 'f');
+      expect(f.measuredLines, 5);
+    });
+  });
+
+  group('runCheckFunctionSize', () {
+    test('fails when non-allowlisted function exceeds threshold', () {
+      final temp = Directory.systemTemp.createTempSync('fn-size-');
+      try {
+        final libDir = Directory(
+          p.join(temp.path, 'packages', 'colonizethis_logic', 'lib', 'src'),
+        )..createSync(recursive: true);
+        File(p.join(libDir.path, 'big.dart')).writeAsStringSync('''
+int giant() {
+  final v1 = 1;
+  final v2 = 2;
+  final v3 = 3;
+  final v4 = 4;
+  final v5 = 5;
+  final v6 = 6;
+  final v7 = 7;
+  final v8 = 8;
+  final v9 = 9;
+  final v10 = 10;
+  final v11 = 11;
+  final v12 = 12;
+  final v13 = 13;
+  final v14 = 14;
+  final v15 = 15;
+  final v16 = 16;
+  final v17 = 17;
+  final v18 = 18;
+  final v19 = 19;
+  return v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9 + v10 + v11 + v12 + v13 + v14 + v15 + v16 + v17 + v18 + v19;
+}
+''');
+
+        final errors = <String>[];
+        final exitCode = runCheckFunctionSize(
+          temp.path,
+          info: (_) {},
+          err: errors.add,
+        );
+        expect(exitCode, 1);
+        expect(errors.join('\n'), contains('giant'));
+      } finally {
+        temp.deleteSync(recursive: true);
+      }
+    });
+
+    test('passes with allowlisted max_measured_lines', () {
+      final temp = Directory.systemTemp.createTempSync('fn-size-allow-');
+      try {
+        final libDir = Directory(
+          p.join(temp.path, 'packages', 'colonizethis_logic', 'lib', 'src'),
+        )..createSync(recursive: true);
+        File(p.join(libDir.path, 'big.dart')).writeAsStringSync('''
+int giant() {
+  final v1 = 1;
+  final v2 = 2;
+  final v3 = 3;
+  final v4 = 4;
+  final v5 = 5;
+  final v6 = 6;
+  final v7 = 7;
+  final v8 = 8;
+  final v9 = 9;
+  final v10 = 10;
+  final v11 = 11;
+  final v12 = 12;
+  final v13 = 13;
+  final v14 = 14;
+  final v15 = 15;
+  final v16 = 16;
+  final v17 = 17;
+  final v18 = 18;
+  final v19 = 19;
+  return v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9 + v10 + v11 + v12 + v13 + v14 + v15 + v16 + v17 + v18 + v19;
+}
+''');
+        final toolDir = Directory(p.join(temp.path, 'tool'))
+          ..createSync(recursive: true);
+        File(
+          p.join(toolDir.path, 'function_size_allowlist.yaml'),
+        ).writeAsStringSync('''
+allowed_over_20:
+  - file: packages/colonizethis_logic/lib/src/big.dart
+    symbol: giant
+    max_measured_lines: 22
+''');
+
+        final exitCode = runCheckFunctionSize(
+          temp.path,
+          info: (_) {},
+          err: (_) {},
+        );
+        expect(exitCode, 0);
+      } finally {
+        temp.deleteSync(recursive: true);
+      }
+    });
+  });
+}

--- a/test/ct_repo_lint_test.dart
+++ b/test/ct_repo_lint_test.dart
@@ -19,6 +19,7 @@ void main() {
       expect(ids, contains('repo.disallowed_ast_patterns'));
       expect(ids, contains('repo.control_flow_nesting_depth'));
       expect(ids, contains('repo.repeated_magic_numbers'));
+      expect(ids, contains('repo.function_size'));
       expect(ids, contains('repo.app_hardcoded_ui_strings'));
       expect(
         rules
@@ -32,8 +33,9 @@ void main() {
             .includeOnlyWhenEnvName,
         'CT_REPO_LINT_INCLUDE_APP',
       );
-      final assetRule =
-          rules.firstWhere((r) => r.ruleId == 'repo.asset_path_constants');
+      final assetRule = rules.firstWhere(
+        (r) => r.ruleId == 'repo.asset_path_constants',
+      );
       expect(assetRule.runner, 'dart');
       expect(assetRule.script, 'tool/check_asset_path_constants.dart');
     });

--- a/tool/check_function_size.dart
+++ b/tool/check_function_size.dart
@@ -1,0 +1,287 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/source/line_info.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+import 'ct_repo_lint_scan_contract.dart';
+
+const _failThreshold = 20;
+const _logicScopePrefix = 'packages/colonizethis_logic/lib/src/';
+
+int runCheckFunctionSize(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+  final allowlist = _loadAllowlist(repoRoot);
+  final files = collectRepoLintDomainDartFiles(repoRoot).where((file) {
+    final rel = p.relative(file.path, from: repoRoot);
+    return rel.startsWith(_logicScopePrefix);
+  });
+  final violations = <String>[];
+
+  for (final file in files) {
+    final relativePath = p.relative(file.path, from: repoRoot);
+    final content = file.readAsStringSync();
+    final parsed = parseString(content: content, path: relativePath);
+    final unit = parsed.unit;
+    final sourceLines = const LineSplitter().convert(content);
+    final lineInfo = unit.lineInfo;
+    _scanCompilationUnit(
+      unit: unit,
+      relativePath: relativePath,
+      sourceLines: sourceLines,
+      lineInfo: lineInfo,
+      allowlist: allowlist,
+      violations: violations,
+    );
+  }
+
+  if (violations.isEmpty) {
+    logI('check_function_size: no function-size violations.');
+    return 0;
+  }
+  logE('check_function_size: ${violations.length} violation(s):');
+  for (final violation in violations) {
+    logE(' - $violation');
+  }
+  return 1;
+}
+
+void _scanCompilationUnit({
+  required CompilationUnit unit,
+  required String relativePath,
+  required List<String> sourceLines,
+  required LineInfo lineInfo,
+  required Map<String, int> allowlist,
+  required List<String> violations,
+}) {
+  for (final decl in unit.declarations) {
+    if (decl is FunctionDeclaration) {
+      _scanFunction(
+        node: decl,
+        qualifiedName: decl.name.lexeme,
+        relativePath: relativePath,
+        sourceLines: sourceLines,
+        lineInfo: lineInfo,
+        allowlist: allowlist,
+        violations: violations,
+      );
+      _scanNestedLocalFunctions(
+        body: decl.functionExpression.body,
+        parentQualifiedName: decl.name.lexeme,
+        relativePath: relativePath,
+        sourceLines: sourceLines,
+        lineInfo: lineInfo,
+        allowlist: allowlist,
+        violations: violations,
+      );
+      continue;
+    }
+    if (decl is! ClassDeclaration) {
+      continue;
+    }
+    for (final member in decl.members) {
+      if (member is MethodDeclaration) {
+        final qualified = '${decl.name.lexeme}.${member.name.lexeme}';
+        _scanFunction(
+          node: member,
+          qualifiedName: qualified,
+          relativePath: relativePath,
+          sourceLines: sourceLines,
+          lineInfo: lineInfo,
+          allowlist: allowlist,
+          violations: violations,
+        );
+        _scanNestedLocalFunctions(
+          body: member.body,
+          parentQualifiedName: qualified,
+          relativePath: relativePath,
+          sourceLines: sourceLines,
+          lineInfo: lineInfo,
+          allowlist: allowlist,
+          violations: violations,
+        );
+      } else if (member is ConstructorDeclaration) {
+        final ctorSuffix = member.name == null ? '' : ':${member.name!.lexeme}';
+        final qualified = '${decl.name.lexeme}.<ctor$ctorSuffix>';
+        _scanFunction(
+          node: member,
+          qualifiedName: qualified,
+          relativePath: relativePath,
+          sourceLines: sourceLines,
+          lineInfo: lineInfo,
+          allowlist: allowlist,
+          violations: violations,
+        );
+        _scanNestedLocalFunctions(
+          body: member.body,
+          parentQualifiedName: qualified,
+          relativePath: relativePath,
+          sourceLines: sourceLines,
+          lineInfo: lineInfo,
+          allowlist: allowlist,
+          violations: violations,
+        );
+      }
+    }
+  }
+}
+
+void _scanNestedLocalFunctions({
+  required FunctionBody body,
+  required String parentQualifiedName,
+  required String relativePath,
+  required List<String> sourceLines,
+  required LineInfo lineInfo,
+  required Map<String, int> allowlist,
+  required List<String> violations,
+}) {
+  body.accept(
+    _NestedLocalFunctionCollector(
+      onLocalFunction: (node) {
+        final qualifiedName = '$parentQualifiedName::${node.name.lexeme}';
+        _scanFunction(
+          node: node,
+          qualifiedName: qualifiedName,
+          relativePath: relativePath,
+          sourceLines: sourceLines,
+          lineInfo: lineInfo,
+          allowlist: allowlist,
+          violations: violations,
+        );
+      },
+    ),
+  );
+}
+
+void _scanFunction({
+  required AstNode node,
+  required String qualifiedName,
+  required String relativePath,
+  required List<String> sourceLines,
+  required LineInfo lineInfo,
+  required Map<String, int> allowlist,
+  required List<String> violations,
+}) {
+  final start = lineInfo.getLocation(node.offset).lineNumber;
+  final end = lineInfo.getLocation(node.end).lineNumber;
+  final measured = _countMeasuredLines(sourceLines, start, end);
+  if (measured <= _failThreshold) {
+    return;
+  }
+  final key = '$relativePath|$qualifiedName';
+  final allowedMax = allowlist[key];
+  if (allowedMax != null && measured <= allowedMax) {
+    return;
+  }
+  violations.add(
+    '$relativePath:$start: `$qualifiedName` measured line count is $measured '
+    '(fail >$_failThreshold${allowedMax != null ? ', allowlisted max=$allowedMax' : ''})',
+  );
+}
+
+int _countMeasuredLines(
+  List<String> lines,
+  int startLine1Based,
+  int endLine1Based,
+) {
+  var count = 0;
+  final start = startLine1Based < 1 ? 1 : startLine1Based;
+  final end = endLine1Based > lines.length ? lines.length : endLine1Based;
+  for (var i = start; i <= end; i++) {
+    final trimmed = lines[i - 1].trim();
+    if (trimmed.isEmpty) {
+      continue;
+    }
+    if (trimmed.startsWith('//')) {
+      continue;
+    }
+    count++;
+  }
+  return count;
+}
+
+Map<String, int> _loadAllowlist(String repoRoot) {
+  final file = File(p.join(repoRoot, 'tool', 'function_size_allowlist.yaml'));
+  if (!file.existsSync()) {
+    return const {};
+  }
+  final dynamic doc = loadYaml(file.readAsStringSync());
+  if (doc is! YamlMap) {
+    return const {};
+  }
+  final node = doc['allowed_over_20'];
+  if (node is! YamlList) {
+    return const {};
+  }
+  final out = <String, int>{};
+  for (final dynamic item in node) {
+    if (item is! YamlMap) {
+      continue;
+    }
+    final filePath = item['file']?.toString();
+    final symbol = item['symbol']?.toString();
+    final maxMeasuredLines = item['max_measured_lines'];
+    if (filePath == null || symbol == null || maxMeasuredLines is! int) {
+      continue;
+    }
+    out['$filePath|$symbol'] = maxMeasuredLines;
+  }
+  return out;
+}
+
+List<({String symbol, int measuredLines, int startLine})>
+scanFunctionSizesFromSourceForTest(String source) {
+  final parsed = parseString(content: source, path: 'test.dart');
+  final unit = parsed.unit;
+  final sourceLines = const LineSplitter().convert(source);
+  final lineInfo = unit.lineInfo;
+  final out = <({String symbol, int measuredLines, int startLine})>[];
+
+  void add(AstNode node, String symbol) {
+    final start = lineInfo.getLocation(node.offset).lineNumber;
+    final end = lineInfo.getLocation(node.end).lineNumber;
+    out.add((
+      symbol: symbol,
+      measuredLines: _countMeasuredLines(sourceLines, start, end),
+      startLine: start,
+    ));
+  }
+
+  for (final decl in unit.declarations) {
+    if (decl is FunctionDeclaration) {
+      add(decl, decl.name.lexeme);
+    } else if (decl is ClassDeclaration) {
+      for (final member in decl.members) {
+        if (member is MethodDeclaration) {
+          add(member, '${decl.name.lexeme}.${member.name.lexeme}');
+        }
+      }
+    }
+  }
+  return out;
+}
+
+final class _NestedLocalFunctionCollector extends RecursiveAstVisitor<void> {
+  _NestedLocalFunctionCollector({required this.onLocalFunction});
+
+  final void Function(FunctionDeclaration node) onLocalFunction;
+
+  @override
+  void visitFunctionDeclaration(FunctionDeclaration node) {
+    onLocalFunction(node);
+    super.visitFunctionDeclaration(node);
+  }
+}
+
+void main() {
+  exit(runCheckFunctionSize(Directory.current.path));
+}

--- a/tool/ct_repo_lint_lib.dart
+++ b/tool/ct_repo_lint_lib.dart
@@ -11,6 +11,7 @@ import 'check_civilian_unit_type_constants.dart';
 import 'check_control_flow_nesting_depth.dart';
 import 'check_custom_exceptions.dart';
 import 'check_disallowed_ast_patterns.dart';
+import 'check_function_size.dart';
 import 'check_repeated_magic_numbers.dart';
 import 'check_tech_id_constants.dart';
 import 'check_work_target_constants.dart';
@@ -622,6 +623,8 @@ int? _tryRunDartRuleInProcess({
       return runCheckControlFlowNestingDepth(repoRoot);
     case 'repo.repeated_magic_numbers':
       return runCheckRepeatedMagicNumbers(repoRoot);
+    case 'repo.function_size':
+      return runCheckFunctionSize(repoRoot);
     case 'repo.tech_id_constants':
       return runCheckTechIdConstants(
         repoRoot,

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -93,6 +93,13 @@ rules:
     runner: dart
     script: tool/check_repeated_magic_numbers.dart
 
+  - rule_id: repo.function_size
+    group: structure
+    title: Function size threshold (measured lines)
+    spec: SPEC/program/function-size.md
+    runner: dart
+    script: tool/check_function_size.dart
+
   - rule_id: repo.canonical_province_tile_keys
     group: game_invariants
     title: Canonical province WorkOrder targetTileKey literals

--- a/tool/function_size_allowlist.yaml
+++ b/tool/function_size_allowlist.yaml
@@ -1,0 +1,948 @@
+# Grandfathered symbols above function-size threshold (shrink-only).
+# Scope: packages/colonizethis_logic/lib/src/**
+allowed_over_20:
+  - file: packages/colonizethis_logic/lib/src/ai/ai_planner.dart
+    symbol: generateOrdersForGame
+    max_measured_lines: 38
+  - file: packages/colonizethis_logic/lib/src/ai/sim_game_ai.dart
+    symbol: defaultSimGameAi
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
+    symbol: generateOrdersWithSimpleHeuristics
+    max_measured_lines: 191
+  - file: packages/colonizethis_logic/lib/src/combat/battle_general_assignment.dart
+    symbol: assignGeneralsForBattleContext
+    max_measured_lines: 63
+  - file: packages/colonizethis_logic/lib/src/combat/battle_general_assignment.dart
+    symbol: bindGeneralsForCombatPhase
+    max_measured_lines: 83
+  - file: packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+    symbol: _buildOutcome
+    max_measured_lines: 46
+  - file: packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+    symbol: _buildPostBattleRegion
+    max_measured_lines: 45
+  - file: packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+    symbol: _resolveByRatio
+    max_measured_lines: 45
+  - file: packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+    symbol: _sortAttackersByInitiative
+    max_measured_lines: 35
+  - file: packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+    symbol: resolveBattleContext
+    max_measured_lines: 237
+  - file: packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+    symbol: resolveEngagement
+    max_measured_lines: 65
+  - file: packages/colonizethis_logic/lib/src/combat/combat_resolver_probabilistic.dart
+    symbol: _selectCasualtiesWeighted
+    max_measured_lines: 31
+  - file: packages/colonizethis_logic/lib/src/combat/combat_resolver_probabilistic.dart
+    symbol: resolveEngagementProbabilistic
+    max_measured_lines: 109
+  - file: packages/colonizethis_logic/lib/src/combat/conflict_detection.dart
+    symbol: BattleContext.copyWith
+    max_measured_lines: 34
+  - file: packages/colonizethis_logic/lib/src/combat/conflict_detection.dart
+    symbol: detectConflicts
+    max_measured_lines: 179
+  - file: packages/colonizethis_logic/lib/src/combat/conflict_detection.dart
+    symbol: detectConflicts::processRegion
+    max_measured_lines: 163
+  - file: packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
+    symbol: applyNavalBattleResults
+    max_measured_lines: 54
+  - file: packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
+    symbol: detectNavalConflicts
+    max_measured_lines: 53
+  - file: packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
+    symbol: filterBattlesByInterception
+    max_measured_lines: 61
+  - file: packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
+    symbol: normalizeNavalBattleSidesForAttacker
+    max_measured_lines: 38
+  - file: packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
+    symbol: resolveSeaBattle
+    max_measured_lines: 90
+  - file: packages/colonizethis_logic/lib/src/combat/quick_battle_emplaced_builder.dart
+    symbol: buildQuickBattleEmplacedGuns
+    max_measured_lines: 40
+  - file: packages/colonizethis_logic/lib/src/combat/quick_battle_input_builder.dart
+    symbol: buildQuickBattleInput
+    max_measured_lines: 74
+  - file: packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
+    symbol: _aggregateActionModifiers
+    max_measured_lines: 35
+  - file: packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
+    symbol: _attackerLossFractionFromDefenderStrike
+    max_measured_lines: 27
+  - file: packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
+    symbol: _defenderEffectiveStrength
+    max_measured_lines: 23
+  - file: packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
+    symbol: _defenderLossFractionFromAttackerStrike
+    max_measured_lines: 31
+  - file: packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
+    symbol: _effectiveStrength
+    max_measured_lines: 29
+  - file: packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
+    symbol: _finishResult
+    max_measured_lines: 34
+  - file: packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
+    symbol: applyQuickBattleResultToGame
+    max_measured_lines: 59
+  - file: packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
+    symbol: resolveQuickBattle
+    max_measured_lines: 237
+  - file: packages/colonizethis_logic/lib/src/diplomacy/alliance_resolver.dart
+    symbol: _absorbGreatPowerIntoGp
+    max_measured_lines: 111
+  - file: packages/colonizethis_logic/lib/src/diplomacy/alliance_resolver.dart
+    symbol: _absorbMinorOrTribeIntoGp
+    max_measured_lines: 86
+  - file: packages/colonizethis_logic/lib/src/diplomacy/alliance_resolver.dart
+    symbol: _processAlliances
+    max_measured_lines: 50
+  - file: packages/colonizethis_logic/lib/src/diplomacy/alliance_resolver.dart
+    symbol: _resolveJoinEmpireColony
+    max_measured_lines: 62
+  - file: packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_updates.dart
+    symbol: applyGrantAidModifier
+    max_measured_lines: 31
+  - file: packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_updates.dart
+    symbol: applySubsidyBoost
+    max_measured_lines: 32
+  - file: packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_updates.dart
+    symbol: setWarStateForPair
+    max_measured_lines: 33
+  - file: packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+    symbol: resolveDiplomacyPhase
+    max_measured_lines: 72
+  - file: packages/colonizethis_logic/lib/src/diplomacy/diplomacy_subsidies_relations_resolver.dart
+    symbol: _applyRelationModifiersAndUpdateScores
+    max_measured_lines: 124
+  - file: packages/colonizethis_logic/lib/src/diplomacy/diplomacy_subsidies_relations_resolver.dart
+    symbol: _processOngoingSubsidies
+    max_measured_lines: 87
+  - file: packages/colonizethis_logic/lib/src/diplomacy/diplomacy_subsidies_relations_resolver.dart
+    symbol: _terminateAgreementsOnWar
+    max_measured_lines: 39
+  - file: packages/colonizethis_logic/lib/src/diplomacy/intervention_resolver.dart
+    symbol: _applyCallToArmsAccept
+    max_measured_lines: 29
+  - file: packages/colonizethis_logic/lib/src/diplomacy/intervention_resolver.dart
+    symbol: _applyCallToArmsRefuse
+    max_measured_lines: 61
+  - file: packages/colonizethis_logic/lib/src/diplomacy/intervention_resolver.dart
+    symbol: _cancelSubsidiesBetweenGps
+    max_measured_lines: 35
+  - file: packages/colonizethis_logic/lib/src/diplomacy/intervention_resolver.dart
+    symbol: _gpGpWarPairsFromOrders
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/diplomacy/intervention_resolver.dart
+    symbol: _interventionsOutstanding
+    max_measured_lines: 21
+  - file: packages/colonizethis_logic/lib/src/diplomacy/intervention_resolver.dart
+    symbol: _processCallToArms
+    max_measured_lines: 62
+  - file: packages/colonizethis_logic/lib/src/diplomacy/intervention_resolver.dart
+    symbol: _processInterventionsForAggressorDefender
+    max_measured_lines: 79
+  - file: packages/colonizethis_logic/lib/src/diplomacy/intervention_resolver.dart
+    symbol: _resolveOutstandingInterventionsForMinorTribeWars
+    max_measured_lines: 36
+  - file: packages/colonizethis_logic/lib/src/diplomacy/intervention_resolver.dart
+    symbol: applyInterventionAgainstAggressor
+    max_measured_lines: 95
+  - file: packages/colonizethis_logic/lib/src/diplomacy/intervention_resolver.dart
+    symbol: needsInterventionChoice
+    max_measured_lines: 23
+  - file: packages/colonizethis_logic/lib/src/diplomacy/overture_resolver.dart
+    symbol: _appendDiplomaticEvent
+    max_measured_lines: 28
+  - file: packages/colonizethis_logic/lib/src/diplomacy/overture_resolver.dart
+    symbol: _processOverturePayments
+    max_measured_lines: 136
+  - file: packages/colonizethis_logic/lib/src/diplomacy/war_resolver.dart
+    symbol: _processWarAndPeace
+    max_measured_lines: 137
+  - file: packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
+    symbol: dialogueEventsForCapitalThreatened
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
+    symbol: dialogueEventsForColonyFounded
+    max_measured_lines: 21
+  - file: packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
+    symbol: dialogueEventsForEraChange
+    max_measured_lines: 21
+  - file: packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
+    symbol: dialogueEventsForLandBattleResult
+    max_measured_lines: 36
+  - file: packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
+    symbol: dialogueEventsForNavalBattleResult
+    max_measured_lines: 35
+  - file: packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
+    symbol: dialogueEventsForReactiveFortsOnBorder
+    max_measured_lines: 41
+  - file: packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
+    symbol: dialogueEventsForReactiveHumanAttack
+    max_measured_lines: 54
+  - file: packages/colonizethis_logic/lib/src/dossier/event_dialogue.dart
+    symbol: dialogueEventsForReactiveTechFirst
+    max_measured_lines: 24
+  - file: packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+    symbol: _envyScoreAccumulatedForSubjectAndTurn
+    max_measured_lines: 23
+  - file: packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+    symbol: evidenceForAiStealTechResolved
+    max_measured_lines: 31
+  - file: packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+    symbol: evidenceForDeclareWar
+    max_measured_lines: 66
+  - file: packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+    symbol: evidenceForEnvyResearchMirror
+    max_measured_lines: 43
+  - file: packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+    symbol: evidenceForIsolationistCallToArmsRefuse
+    max_measured_lines: 32
+  - file: packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+    symbol: evidenceForLandBattleVictory
+    max_measured_lines: 34
+  - file: packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+    symbol: evidenceForNavalBattleVictory
+    max_measured_lines: 29
+  - file: packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+    symbol: evidenceForOfferPeace
+    max_measured_lines: 27
+  - file: packages/colonizethis_logic/lib/src/economy/build_cost.dart
+    symbol: _resolveBuildDeductionPlan
+    max_measured_lines: 97
+  - file: packages/colonizethis_logic/lib/src/economy/build_cost.dart
+    symbol: applyBuildCostDeduction
+    max_measured_lines: 30
+  - file: packages/colonizethis_logic/lib/src/economy/economy_consumption.dart
+    symbol: _allocateConsumption
+    max_measured_lines: 129
+  - file: packages/colonizethis_logic/lib/src/economy/economy_consumption.dart
+    symbol: consumeFoodUnits
+    max_measured_lines: 30
+  - file: packages/colonizethis_logic/lib/src/economy/economy_consumption.dart
+    symbol: resolveConsumption
+    max_measured_lines: 30
+  - file: packages/colonizethis_logic/lib/src/economy/economy_production.dart
+    symbol: resolveProduction
+    max_measured_lines: 67
+  - file: packages/colonizethis_logic/lib/src/economy/economy_riches_to_treasury.dart
+    symbol: resolveRichesToTreasury
+    max_measured_lines: 23
+  - file: packages/colonizethis_logic/lib/src/economy/economy_stockpile_preview.dart
+    symbol: previewStockpileNetDeltaByCommodityForPlayer
+    max_measured_lines: 35
+  - file: packages/colonizethis_logic/lib/src/economy/economy_stockpile_preview.dart
+    symbol: previewStockpilePhaseDeltasByCommodityForPlayer
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
+    symbol: _resourceToCommodityId
+    max_measured_lines: 40
+  - file: packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
+    symbol: computeExtraction
+    max_measured_lines: 75
+  - file: packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
+    symbol: computeTileExtractionContributionForPlayer
+    max_measured_lines: 95
+  - file: packages/colonizethis_logic/lib/src/economy/sea_transport.dart
+    symbol: _interceptScoreAndBlockade
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/economy/sea_transport.dart
+    symbol: _logExtractionAutoTransportInterception
+    max_measured_lines: 21
+  - file: packages/colonizethis_logic/lib/src/economy/sea_transport.dart
+    symbol: allocateOverseasToStockpile
+    max_measured_lines: 25
+  - file: packages/colonizethis_logic/lib/src/economy/sea_transport.dart
+    symbol: applyTradeInterception
+    max_measured_lines: 127
+  - file: packages/colonizethis_logic/lib/src/economy/sea_transport.dart
+    symbol: logExtractionAutoTransportOverseasAllocation
+    max_measured_lines: 24
+  - file: packages/colonizethis_logic/lib/src/event_bus/game_event_bus.dart
+    symbol: _gameEventPayloadSummary
+    max_measured_lines: 32
+  - file: packages/colonizethis_logic/lib/src/orders/build_rail_work_rules.dart
+    symbol: rejectionReasonForBuildRailOrder
+    max_measured_lines: 39
+  - file: packages/colonizethis_logic/lib/src/orders/build_spawn_province.dart
+    symbol: resolveBuildSpawnProvinceId
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/orders/civilian_projected_tile.dart
+    symbol: projectedCivilianTileKey
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/orders/draft_orders_mutations.dart
+    symbol: applyNavalMoveOrderForPlayer
+    max_measured_lines: 23
+  - file: packages/colonizethis_logic/lib/src/orders/economy_stockpile_preview.dart
+    symbol: applyEconomyPhasesForPreview
+    max_measured_lines: 124
+  - file: packages/colonizethis_logic/lib/src/orders/economy_stockpile_preview.dart
+    symbol: previewStockpileNetDeltaByCommodityForPlayer
+    max_measured_lines: 38
+  - file: packages/colonizethis_logic/lib/src/orders/order_engine.dart
+    symbol: OrderEngine._addOrderWithContext
+    max_measured_lines: 27
+  - file: packages/colonizethis_logic/lib/src/orders/order_engine.dart
+    symbol: OrderEngine.projectedEffects
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/orders/order_engine.dart
+    symbol: OrderEngine.validatePlayerOrdersWithContext
+    max_measured_lines: 132
+  - file: packages/colonizethis_logic/lib/src/orders/order_engine.dart
+    symbol: _appendValidationResultsWithState
+    max_measured_lines: 21
+  - file: packages/colonizethis_logic/lib/src/orders/order_merge.dart
+    symbol: _mergeByConflictKey
+    max_measured_lines: 26
+  - file: packages/colonizethis_logic/lib/src/orders/order_merge.dart
+    symbol: _mergeDiplomaticOrders
+    max_measured_lines: 26
+  - file: packages/colonizethis_logic/lib/src/orders/order_merge.dart
+    symbol: mergeOrderLists
+    max_measured_lines: 41
+  - file: packages/colonizethis_logic/lib/src/orders/order_projections.dart
+    symbol: projectOrderEffects
+    max_measured_lines: 61
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_build_research.dart
+    symbol: _preFilterWorkTargetTiles
+    max_measured_lines: 29
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_build_research.dart
+    symbol: _rawCandidateTilesForWorkTarget
+    max_measured_lines: 24
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_build_research.dart
+    symbol: getValidWorkOrderTileKeys
+    max_measured_lines: 54
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_build_research.dart
+    symbol: getValidWorkOrderTileKeysWithVisibility
+    max_measured_lines: 75
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_build_research.dart
+    symbol: suggestBuildOrders
+    max_measured_lines: 62
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_build_research.dart
+    symbol: suggestResearchOrders
+    max_measured_lines: 54
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_helpers.dart
+    symbol: filterOrdersByDiplomacy
+    max_measured_lines: 23
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
+    symbol: armyMoveCandidateDestinationProvinceIds
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
+    symbol: armyMovePickerDestinations
+    max_measured_lines: 76
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
+    symbol: suggestArmyMoveOrders
+    max_measured_lines: 53
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
+    symbol: suggestMoveOrders
+    max_measured_lines: 97
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
+    symbol: _diplomaticCandidatesForTargetOrdered
+    max_measured_lines: 83
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
+    symbol: _establishOvertureSuggestionOrder
+    max_measured_lines: 45
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
+    symbol: _prefilterWtBuildRail
+    max_measured_lines: 26
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
+    symbol: _prefilterWtPurchaseLand
+    max_measured_lines: 23
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
+    symbol: suggestDiplomaticOrders
+    max_measured_lines: 129
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
+    symbol: suggestNavalMissionOrders
+    max_measured_lines: 46
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
+    symbol: suggestNavalMoveOrders
+    max_measured_lines: 124
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
+    symbol: _addExplorerWorkSuggestionsForUnit
+    max_measured_lines: 64
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
+    symbol: _addMerchantSuggestionsForUnit
+    max_measured_lines: 45
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
+    symbol: _addProspectSuggestionIfEligible
+    max_measured_lines: 56
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
+    symbol: _addSpySuggestionsForUnit
+    max_measured_lines: 57
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
+    symbol: _addWorkSuggestionsForUnit
+    max_measured_lines: 94
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
+    symbol: _addWorkerSuggestionsForUnit
+    max_measured_lines: 52
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
+    symbol: _firstAcceptedWorkerCandidate
+    max_measured_lines: 34
+  - file: packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
+    symbol: suggestWorkOrders
+    max_measured_lines: 55
+  - file: packages/colonizethis_logic/lib/src/orders/order_visibility.dart
+    symbol: regionIdForUnit
+    max_measured_lines: 21
+  - file: packages/colonizethis_logic/lib/src/orders/orders_application.dart
+    symbol: _appendMilitaryRegimentToArmy
+    max_measured_lines: 43
+  - file: packages/colonizethis_logic/lib/src/orders/orders_application.dart
+    symbol: applyBuildAndWorkOrders
+    max_measured_lines: 296
+  - file: packages/colonizethis_logic/lib/src/orders/orders_application.dart
+    symbol: applyBuildAndWorkOrders::applyExploreCompletion
+    max_measured_lines: 27
+  - file: packages/colonizethis_logic/lib/src/orders/orders_application.dart
+    symbol: applyBuildAndWorkOrders::processWorkUnits
+    max_measured_lines: 165
+  - file: packages/colonizethis_logic/lib/src/orders/orders_application.dart
+    symbol: clearUnitCurrentWork
+    max_measured_lines: 35
+  - file: packages/colonizethis_logic/lib/src/orders/orders_application_build_phase.dart
+    symbol: _NavalBuildState.spawnHomeFleetShipIfEligible
+    max_measured_lines: 46
+  - file: packages/colonizethis_logic/lib/src/orders/orders_application_build_phase.dart
+    symbol: _runBuildPhase
+    max_measured_lines: 80
+  - file: packages/colonizethis_logic/lib/src/orders/orders_application_completed_work.dart
+    symbol: _completedWorkBuildFort
+    max_measured_lines: 35
+  - file: packages/colonizethis_logic/lib/src/orders/orders_application_completed_work.dart
+    symbol: _completedWorkBuildImprovement
+    max_measured_lines: 42
+  - file: packages/colonizethis_logic/lib/src/orders/orders_application_completed_work.dart
+    symbol: _completedWorkBuildPort
+    max_measured_lines: 29
+  - file: packages/colonizethis_logic/lib/src/orders/orders_application_completed_work.dart
+    symbol: _completedWorkBuildRail
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/orders/orders_application_completed_work.dart
+    symbol: _completedWorkBuildRoad
+    max_measured_lines: 27
+  - file: packages/colonizethis_logic/lib/src/orders/orders_application_completed_work.dart
+    symbol: _propagateRoadToAdjacentCapitalOrPort
+    max_measured_lines: 50
+  - file: packages/colonizethis_logic/lib/src/orders/orders_application_helpers.dart
+    symbol: isMineralEligibleTile
+    max_measured_lines: 26
+  - file: packages/colonizethis_logic/lib/src/orders/orders_application_work_phase.dart
+    symbol: _runWorkPhase
+    max_measured_lines: 364
+  - file: packages/colonizethis_logic/lib/src/orders/orders_application_work_phase.dart
+    symbol: _runWorkPhase::applyStandardWorkOrder
+    max_measured_lines: 30
+  - file: packages/colonizethis_logic/lib/src/orders/orders_application_work_phase.dart
+    symbol: _runWorkPhase::workTargetConfig
+    max_measured_lines: 79
+  - file: packages/colonizethis_logic/lib/src/orders/validators/army_move_validator.dart
+    symbol: ArmyMoveValidator.validate
+    max_measured_lines: 76
+  - file: packages/colonizethis_logic/lib/src/orders/validators/build_order_validator.dart
+    symbol: BuildOrderValidator.validate
+    max_measured_lines: 53
+  - file: packages/colonizethis_logic/lib/src/orders/validators/diplomatic_order_validator.dart
+    symbol: DiplomaticOrderValidator._validateOne
+    max_measured_lines: 198
+  - file: packages/colonizethis_logic/lib/src/orders/validators/move_validator.dart
+    symbol: MoveValidator.validate
+    max_measured_lines: 109
+  - file: packages/colonizethis_logic/lib/src/orders/validators/naval_order_validator.dart
+    symbol: NavalOrderValidator.validateNavalMission
+    max_measured_lines: 49
+  - file: packages/colonizethis_logic/lib/src/orders/validators/naval_order_validator.dart
+    symbol: NavalOrderValidator.validateNavalMove
+    max_measured_lines: 89
+  - file: packages/colonizethis_logic/lib/src/orders/validators/work_order_cost_calculator.dart
+    symbol: WorkOrderCostCalculator.calculateCost
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/orders/validators/work_order_target_prechecks.dart
+    symbol: precheckBuildImprovement
+    max_measured_lines: 54
+  - file: packages/colonizethis_logic/lib/src/orders/validators/work_order_target_prechecks.dart
+    symbol: precheckPurchaseLand
+    max_measured_lines: 60
+  - file: packages/colonizethis_logic/lib/src/orders/validators/work_order_target_prechecks.dart
+    symbol: precheckStealTech
+    max_measured_lines: 30
+  - file: packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+    symbol: WorkOrderValidator._civilianWorkAllowedInMinorTribeProvince
+    max_measured_lines: 23
+  - file: packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+    symbol: WorkOrderValidator.validate
+    max_measured_lines: 210
+  - file: packages/colonizethis_logic/lib/src/setup/capital_choice.dart
+    symbol: _isTileAdjacentToSea
+    max_measured_lines: 21
+  - file: packages/colonizethis_logic/lib/src/setup/capital_choice.dart
+    symbol: _isTileAdjacentToSeaZone
+    max_measured_lines: 26
+  - file: packages/colonizethis_logic/lib/src/setup/capital_choice.dart
+    symbol: _nearestCoastalTileInProvinceForSeaZone
+    max_measured_lines: 26
+  - file: packages/colonizethis_logic/lib/src/setup/capital_choice.dart
+    symbol: _shortestPathOnProvinceTiles
+    max_measured_lines: 45
+  - file: packages/colonizethis_logic/lib/src/setup/capital_choice.dart
+    symbol: applyCapitalPortAndRoad
+    max_measured_lines: 86
+  - file: packages/colonizethis_logic/lib/src/setup/capital_choice.dart
+    symbol: applyGreatPowerCapitalProvinceTownDevelopment
+    max_measured_lines: 36
+  - file: packages/colonizethis_logic/lib/src/setup/capital_choice.dart
+    symbol: classifyCapitalTile
+    max_measured_lines: 26
+  - file: packages/colonizethis_logic/lib/src/setup/capital_choice.dart
+    symbol: pickCapitalForFaction
+    max_measured_lines: 105
+  - file: packages/colonizethis_logic/lib/src/setup/capital_choice.dart
+    symbol: setCapital
+    max_measured_lines: 37
+  - file: packages/colonizethis_logic/lib/src/setup/capital_choice.dart
+    symbol: setCapitalForMinorNation
+    max_measured_lines: 30
+  - file: packages/colonizethis_logic/lib/src/setup/capital_choice.dart
+    symbol: setCapitalForTribe
+    max_measured_lines: 30
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_create.dart
+    symbol: createGameFromGeneratedMaps
+    max_measured_lines: 380
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _addStartingMilitaryAndNaval
+    max_measured_lines: 82
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _addStartingUnits
+    max_measured_lines: 94
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _addStartingUnits::civilianOwners
+    max_measured_lines: 34
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _applyNaming
+    max_measured_lines: 266
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _applyNaming::applyNamingToFaction
+    max_measured_lines: 24
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _applyNaming::assignProvinceNames
+    max_measured_lines: 55
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _assignProvinceTowns
+    max_measured_lines: 225
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _assignProvinceTowns::bfsDistances
+    max_measured_lines: 37
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _assignProvinceTowns::tileKeyAdjacentToProvinceSeaZone
+    max_measured_lines: 29
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _assignProvinceTowns::townTileKeyForProvince
+    max_measured_lines: 70
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _buildPoliticalGlyphByPlayerId
+    max_measured_lines: 48
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _compareTownTileCandidates
+    max_measured_lines: 23
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _landmassesSortedDescDiag
+    max_measured_lines: 23
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _lockedNwAssignFailureDiagnostics
+    max_measured_lines: 26
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _lockedOwAssignFailureDiagnostics
+    max_measured_lines: 44
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _namingPickNonCapitalPoolName
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _namingResolveEmptyPoolNonCapital
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: _pickTownTileByCentroidAndBfs
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+    symbol: buildCombinedTopology
+    max_measured_lines: 25
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_ownership.dart
+    symbol: _assignCapitalsForFactions
+    max_measured_lines: 43
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_ownership.dart
+    symbol: _assignFactionsMultiComponentLocked
+    max_measured_lines: 74
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_ownership.dart
+    symbol: _assignFactionsOnRemainderAuto
+    max_measured_lines: 25
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_ownership.dart
+    symbol: _assignFactionsSingleComponentLocked
+    max_measured_lines: 31
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_ownership.dart
+    symbol: _assignOldWorldOwnershipContiguous
+    max_measured_lines: 161
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_ownership.dart
+    symbol: _assignOldWorldSingleLandmass
+    max_measured_lines: 73
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_ownership.dart
+    symbol: _landmassIdsFromNeighbours
+    max_measured_lines: 21
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_ownership.dart
+    symbol: _largestFeasibleGpProvinceBudgetByPacking
+    max_measured_lines: 29
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_ownership.dart
+    symbol: _maxFeasibleGpProvinceBudgetOnLandmasses
+    max_measured_lines: 27
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_ownership.dart
+    symbol: _selectGpSeedsForLandmass
+    max_measured_lines: 46
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_ownership.dart
+    symbol: _tryPackFactionsOntoPpComponentsDfs
+    max_measured_lines: 45
+  - file: packages/colonizethis_logic/lib/src/setup/game_setup_ownership.dart
+    symbol: _tryPackGpsOntoLandmassesGreedy
+    max_measured_lines: 44
+  - file: packages/colonizethis_logic/lib/src/setup/gp_land_connectivity_repair.dart
+    symbol: gpProvincesAreLandConnected
+    max_measured_lines: 23
+  - file: packages/colonizethis_logic/lib/src/setup/gp_old_world_resource_redistribution.dart
+    symbol: _accumulateSpilloverPool
+    max_measured_lines: 35
+  - file: packages/colonizethis_logic/lib/src/setup/gp_old_world_resource_redistribution.dart
+    symbol: _applyOneQuotaPoolRound
+    max_measured_lines: 37
+  - file: packages/colonizethis_logic/lib/src/setup/gp_old_world_resource_redistribution.dart
+    symbol: _clearGreatPowerOldWorldTerrainResources
+    max_measured_lines: 31
+  - file: packages/colonizethis_logic/lib/src/setup/gp_old_world_resource_redistribution.dart
+    symbol: _countResourceOnGpTiles
+    max_measured_lines: 23
+  - file: packages/colonizethis_logic/lib/src/setup/gp_old_world_resource_redistribution.dart
+    symbol: _countResourceTilesForGp
+    max_measured_lines: 23
+  - file: packages/colonizethis_logic/lib/src/setup/gp_old_world_resource_redistribution.dart
+    symbol: _distributeQuotaPool
+    max_measured_lines: 40
+  - file: packages/colonizethis_logic/lib/src/setup/gp_old_world_resource_redistribution.dart
+    symbol: _eligibleEmptyCountForGp
+    max_measured_lines: 29
+  - file: packages/colonizethis_logic/lib/src/setup/gp_old_world_resource_redistribution.dart
+    symbol: _fairnessScore
+    max_measured_lines: 31
+  - file: packages/colonizethis_logic/lib/src/setup/gp_old_world_resource_redistribution.dart
+    symbol: _firstLexEligibleEmptyTileForGp
+    max_measured_lines: 30
+  - file: packages/colonizethis_logic/lib/src/setup/gp_old_world_resource_redistribution.dart
+    symbol: _redistributeOneResource
+    max_measured_lines: 101
+  - file: packages/colonizethis_logic/lib/src/setup/gp_old_world_resource_redistribution.dart
+    symbol: _runGpPlacementPass
+    max_measured_lines: 36
+  - file: packages/colonizethis_logic/lib/src/setup/gp_old_world_resource_redistribution.dart
+    symbol: applyGreatPowerOldWorldResourceRedistribution
+    max_measured_lines: 82
+  - file: packages/colonizethis_logic/lib/src/setup/gp_old_world_terrain_redistribution.dart
+    symbol: _collectEligibleTilesSorted
+    max_measured_lines: 33
+  - file: packages/colonizethis_logic/lib/src/setup/gp_old_world_terrain_redistribution.dart
+    symbol: _fairnessMaxAbsFracDeviation
+    max_measured_lines: 23
+  - file: packages/colonizethis_logic/lib/src/setup/gp_old_world_terrain_redistribution.dart
+    symbol: _hamiltonTargetsForType
+    max_measured_lines: 55
+  - file: packages/colonizethis_logic/lib/src/setup/gp_old_world_terrain_redistribution.dart
+    symbol: applyGreatPowerOldWorldTerrainRedistribution
+    max_measured_lines: 105
+  - file: packages/colonizethis_logic/lib/src/setup/gp_old_world_terrain_redistribution.dart
+    symbol: countTerrainOnGpOldWorldEligibleTiles
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/setup/gp_starting_grain.dart
+    symbol: applyGreatPowerStartingGrainBootstrap
+    max_measured_lines: 72
+  - file: packages/colonizethis_logic/lib/src/setup/gp_starting_grain.dart
+    symbol: selectGreatPowerBootstrapGrainTileKeysLandOnly
+    max_measured_lines: 26
+  - file: packages/colonizethis_logic/lib/src/setup/init_game_orchestrator.dart
+    symbol: formatInitGameSetupMarkdown
+    max_measured_lines: 71
+  - file: packages/colonizethis_logic/lib/src/setup/init_game_orchestrator.dart
+    symbol: runInitGame
+    max_measured_lines: 289
+  - file: packages/colonizethis_logic/lib/src/setup/init_town_roads.dart
+    symbol: _bfsParentsFromCapital
+    max_measured_lines: 31
+  - file: packages/colonizethis_logic/lib/src/setup/init_town_roads.dart
+    symbol: applyInitTownRoadsToCapitals
+    max_measured_lines: 101
+  - file: packages/colonizethis_logic/lib/src/setup/init_town_roads.dart
+    symbol: applyInitTownRoadsToCapitals::collectForFaction
+    max_measured_lines: 39
+  - file: packages/colonizethis_logic/lib/src/setup/initial_visibility.dart
+    symbol: applyInitialVisibility
+    max_measured_lines: 109
+  - file: packages/colonizethis_logic/lib/src/setup/locked_province_assigner.dart
+    symbol: _islandSizesOnLand
+    max_measured_lines: 24
+  - file: packages/colonizethis_logic/lib/src/setup/locked_province_assigner.dart
+    symbol: _phasedGrowthFeasibilityHolds
+    max_measured_lines: 47
+  - file: packages/colonizethis_logic/lib/src/setup/locked_province_assigner.dart
+    symbol: _rankLegalNeighbors
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/setup/locked_province_assigner.dart
+    symbol: _reachableTerritoryForFaction
+    max_measured_lines: 32
+  - file: packages/colonizethis_logic/lib/src/setup/locked_province_assigner.dart
+    symbol: _unassignedIslandCountOnLand
+    max_measured_lines: 21
+  - file: packages/colonizethis_logic/lib/src/setup/locked_province_assigner.dart
+    symbol: assignTerritoriesLockedOnLandmass
+    max_measured_lines: 258
+  - file: packages/colonizethis_logic/lib/src/setup/locked_province_assigner.dart
+    symbol: assignTerritoriesLockedOnLandmass::dfs
+    max_measured_lines: 121
+  - file: packages/colonizethis_logic/lib/src/setup/province_assignment.dart
+    symbol: assignTerritoriesByBfsGrowth
+    max_measured_lines: 180
+  - file: packages/colonizethis_logic/lib/src/setup/town_capital_occupancy.dart
+    symbol: collectTownAndCapitalTileKeys
+    max_measured_lines: 24
+  - file: packages/colonizethis_logic/lib/src/setup/town_capital_occupancy.dart
+    symbol: stripResourcesAndExtractionImprovementsOnTileKeys
+    max_measured_lines: 33
+  - file: packages/colonizethis_logic/lib/src/setup/warp_zone_generator.dart
+    symbol: generateWarpZones
+    max_measured_lines: 33
+  - file: packages/colonizethis_logic/lib/src/setup/warp_zone_generator.dart
+    symbol: seaZonesPerEdge
+    max_measured_lines: 50
+  - file: packages/colonizethis_logic/lib/src/turn/combat_phase_helpers.dart
+    symbol: _emitLandBattleDialogue
+    max_measured_lines: 27
+  - file: packages/colonizethis_logic/lib/src/turn/combat_phase_helpers.dart
+    symbol: runOneLandBattle
+    max_measured_lines: 170
+  - file: packages/colonizethis_logic/lib/src/turn/economy_preview_pipeline.dart
+    symbol: _applyPendingBuildOrderCostsForPreview
+    max_measured_lines: 40
+  - file: packages/colonizethis_logic/lib/src/turn/economy_preview_pipeline.dart
+    symbol: _applyPendingMaterialWorkOrderCostsForPreview
+    max_measured_lines: 57
+  - file: packages/colonizethis_logic/lib/src/turn/economy_preview_pipeline.dart
+    symbol: applyEconomyPhasesForPreview
+    max_measured_lines: 34
+  - file: packages/colonizethis_logic/lib/src/turn/economy_preview_pipeline.dart
+    symbol: economyPreviewStockpilePhaseDeltasForPlayer
+    max_measured_lines: 77
+  - file: packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
+    symbol: findMilitaryVictoryWinner
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
+    symbol: runEndOfTurnPhase
+    max_measured_lines: 51
+  - file: packages/colonizethis_logic/lib/src/turn/phases/combat_phase.dart
+    symbol: runCombatPhase
+    max_measured_lines: 96
+  - file: packages/colonizethis_logic/lib/src/turn/phases/consumption_phase.dart
+    symbol: runConsumptionPipelinePhase
+    max_measured_lines: 57
+  - file: packages/colonizethis_logic/lib/src/turn/phases/extraction_phase.dart
+    symbol: runExtractionPhase
+    max_measured_lines: 79
+  - file: packages/colonizethis_logic/lib/src/turn/phases/movement_phase.dart
+    symbol: applyCrossRegionOwnProvinceMoves
+    max_measured_lines: 88
+  - file: packages/colonizethis_logic/lib/src/turn/phases/movement_phase.dart
+    symbol: runMovementPhase
+    max_measured_lines: 113
+  - file: packages/colonizethis_logic/lib/src/turn/phases/production_phase.dart
+    symbol: runProductionPipelinePhase
+    max_measured_lines: 36
+  - file: packages/colonizethis_logic/lib/src/turn/research_resolver.dart
+    symbol: resolveResearchPhase
+    max_measured_lines: 186
+  - file: packages/colonizethis_logic/lib/src/turn/turn_news_digest.dart
+    symbol: _diplomacyLines
+    max_measured_lines: 34
+  - file: packages/colonizethis_logic/lib/src/turn/turn_news_digest.dart
+    symbol: _overtureLines
+    max_measured_lines: 31
+  - file: packages/colonizethis_logic/lib/src/turn/turn_news_digest.dart
+    symbol: _provinceCaptureLines
+    max_measured_lines: 25
+  - file: packages/colonizethis_logic/lib/src/turn/turn_news_digest.dart
+    symbol: _provinceDiscoveryLines
+    max_measured_lines: 25
+  - file: packages/colonizethis_logic/lib/src/turn/turn_news_digest.dart
+    symbol: buildTurnNewsDigestForComplete
+    max_measured_lines: 54
+  - file: packages/colonizethis_logic/lib/src/turn/turn_order_acceptance.dart
+    symbol: filterAcceptedOrdersForAllPlayers
+    max_measured_lines: 109
+  - file: packages/colonizethis_logic/lib/src/turn/turn_order_acceptance.dart
+    symbol: filterOrderList
+    max_measured_lines: 26
+  - file: packages/colonizethis_logic/lib/src/turn/turn_phase_runner.dart
+    symbol: _applyTurnPhase
+    max_measured_lines: 197
+  - file: packages/colonizethis_logic/lib/src/turn/turn_phase_runner.dart
+    symbol: runTurnResolutionPipeline
+    max_measured_lines: 36
+  - file: packages/colonizethis_logic/lib/src/turn/turn_resolution_events.dart
+    symbol: _emitPlayerProvinceDiscoveryEvents
+    max_measured_lines: 27
+  - file: packages/colonizethis_logic/lib/src/turn/turn_resolution_events.dart
+    symbol: _provinceKnownToPlayer
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/turn/turn_resolution_events.dart
+    symbol: emitOvertureAdvancedEvents
+    max_measured_lines: 29
+  - file: packages/colonizethis_logic/lib/src/turn/turn_resolution_events.dart
+    symbol: emitPlayerDiscoveryEvents
+    max_measured_lines: 31
+  - file: packages/colonizethis_logic/lib/src/turn/turn_resolution_events.dart
+    symbol: emitProvinceCapturedEvents
+    max_measured_lines: 46
+  - file: packages/colonizethis_logic/lib/src/turn/turn_resolution_events.dart
+    symbol: emitResearchCompleteEvents
+    max_measured_lines: 68
+  - file: packages/colonizethis_logic/lib/src/turn/turn_resolution_events.dart
+    symbol: emitWorkOrderCompletedEvents
+    max_measured_lines: 50
+  - file: packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+    symbol: _runWorldStatePhase
+    max_measured_lines: 24
+  - file: packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+    symbol: resolveTurnForGame
+    max_measured_lines: 40
+  - file: packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+    symbol: resolveTurnForGameFromOrderEngine
+    max_measured_lines: 32
+  - file: packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+    symbol: resumeTurnResolutionWithCallToArmsDecisions
+    max_measured_lines: 33
+  - file: packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+    symbol: resumeTurnResolutionWithInterventionDecisions
+    max_measured_lines: 33
+  - file: packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+    symbol: resumeTurnResolutionWithOvertureDecisions
+    max_measured_lines: 34
+  - file: packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+    symbol: validateOrdersAndResolveTurn
+    max_measured_lines: 36
+  - file: packages/colonizethis_logic/lib/src/world/army_commands.dart
+    symbol: applyArmyCombine
+    max_measured_lines: 37
+  - file: packages/colonizethis_logic/lib/src/world/army_commands.dart
+    symbol: applyArmySplit
+    max_measured_lines: 41
+  - file: packages/colonizethis_logic/lib/src/world/army_migration.dart
+    symbol: _armiesMatchUnits
+    max_measured_lines: 32
+  - file: packages/colonizethis_logic/lib/src/world/army_migration.dart
+    symbol: _ensureHomeArmiesExist
+    max_measured_lines: 25
+  - file: packages/colonizethis_logic/lib/src/world/army_migration.dart
+    symbol: _rebuildArmiesFromMilitaryUnits
+    max_measured_lines: 60
+  - file: packages/colonizethis_logic/lib/src/world/army_migration.dart
+    symbol: reconcileArmiesAfterUnitsChanged
+    max_measured_lines: 59
+  - file: packages/colonizethis_logic/lib/src/world/army_migration.dart
+    symbol: updateArmyStation
+    max_measured_lines: 34
+  - file: packages/colonizethis_logic/lib/src/world/army_movement.dart
+    symbol: applyArmyMoveOrdersToRegion
+    max_measured_lines: 74
+  - file: packages/colonizethis_logic/lib/src/world/army_movement.dart
+    symbol: applyCrossRegionArmyMovesWithinOwnedProvinces
+    max_measured_lines: 41
+  - file: packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
+    symbol: applyCapitalReassignmentAfterCombat
+    max_measured_lines: 122
+  - file: packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
+    symbol: applyGreatPowerFall
+    max_measured_lines: 65
+  - file: packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+    symbol: _adjacentTileKeys
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+    symbol: _applyTownRuleConnectivityClosure
+    max_measured_lines: 44
+  - file: packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+    symbol: _connectedTilesForPlayer
+    max_measured_lines: 219
+  - file: packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+    symbol: _seaZonesReachableBySeaPath
+    max_measured_lines: 29
+  - file: packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+    symbol: computeBlockadedPortProvincesByPlayer
+    max_measured_lines: 30
+  - file: packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+    symbol: resolveConnectivity
+    max_measured_lines: 38
+  - file: packages/colonizethis_logic/lib/src/world/fog_resolution.dart
+    symbol: _topologyForRegion
+    max_measured_lines: 24
+  - file: packages/colonizethis_logic/lib/src/world/fog_resolution.dart
+    symbol: applyCoastalSeaZoneFullVisibility
+    max_measured_lines: 48
+  - file: packages/colonizethis_logic/lib/src/world/fog_resolution.dart
+    symbol: applyDistantSeaZoneFogRevert
+    max_measured_lines: 53
+  - file: packages/colonizethis_logic/lib/src/world/fog_resolution.dart
+    symbol: applyFogDecay
+    max_measured_lines: 42
+  - file: packages/colonizethis_logic/lib/src/world/fog_resolution.dart
+    symbol: applySpyRevealTimerDecay
+    max_measured_lines: 46
+  - file: packages/colonizethis_logic/lib/src/world/minor_military_parity.dart
+    symbol: applyMinorMilitaryParity
+    max_measured_lines: 46
+  - file: packages/colonizethis_logic/lib/src/world/movement.dart
+    symbol: applyMoveOrdersToRegion
+    max_measured_lines: 98
+  - file: packages/colonizethis_logic/lib/src/world/movement.dart
+    symbol: isValidLandMove
+    max_measured_lines: 21
+  - file: packages/colonizethis_logic/lib/src/world/naval.dart
+    symbol: navalMoveTopologyPicksForFleet
+    max_measured_lines: 41
+  - file: packages/colonizethis_logic/lib/src/world/naval.dart
+    symbol: provinceIdsAdjacentToSeaZone
+    max_measured_lines: 28
+  - file: packages/colonizethis_logic/lib/src/world/naval.dart
+    symbol: seaZoneIdForProvince
+    max_measured_lines: 42
+  - file: packages/colonizethis_logic/lib/src/world/naval.dart
+    symbol: seaZoneIdsAdjacentToProvince
+    max_measured_lines: 26
+  - file: packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+    symbol: _coastalTileKeysAdjacentToSeaZone
+    max_measured_lines: 24
+  - file: packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+    symbol: applyNavalMissionOrders
+    max_measured_lines: 104
+  - file: packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+    symbol: applyNavalMovesAndShipReveal
+    max_measured_lines: 166
+  - file: packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+    symbol: runNavalInterceptionCombatPhase
+    max_measured_lines: 140
+  - file: packages/colonizethis_logic/lib/src/world/player_view.dart
+    symbol: buildPlayerView
+    max_measured_lines: 66
+  - file: packages/colonizethis_logic/lib/src/world/player_view.dart
+    symbol: provincePanelShowsFullTileDerivedIntel
+    max_measured_lines: 44
+  - file: packages/colonizethis_logic/lib/src/world/player_view.dart
+    symbol: resourceIdVisibleToPlayer
+    max_measured_lines: 22
+  - file: packages/colonizethis_logic/lib/src/world/topology_helpers.dart
+    symbol: seaZonesReachableBySeaPath
+    max_measured_lines: 26


### PR DESCRIPTION
## Summary
- Adds a new `repo.function_size` rule to `ct_repo_lint` and wires in a new analyzer-based checker (`tool/check_function_size.dart`).
- Enforces measured-line function threshold (`>20` fails) for `packages/colonizethis_logic/lib/src/**` with shrink-only allowlist caps.
- Adds baseline allowlist (`tool/function_size_allowlist.yaml`) and SPEC documentation (`SPEC/program/function-size.md`), plus unit tests.

## Scope
- In scope: function-size checker infrastructure + manifest integration + baseline allowlist for current logic package state.
- Deferred: refactoring allowlisted oversized functions down to <=20 lines and reducing allowlist entries over subsequent slices.

## Testing
- `dart test test/check_function_size_test.dart test/ct_repo_lint_test.dart`
- `dart run tool/check_function_size.dart`
- `dart run tool/ct_repo_lint.dart --rule repo.function_size`

Refs #1879

Made with [Cursor](https://cursor.com)