### PR TITLE
chore(opencode): mirror missing project skills via links

### DIFF
--- a/.opencode/skills/clean-local-branches/SKILL.md
+++ b/.opencode/skills/clean-local-branches/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/clean-local-branches/SKILL.md

--- a/.opencode/skills/create-github-issue/SKILL.md
+++ b/.opencode/skills/create-github-issue/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/create-github-issue/SKILL.md

--- a/.opencode/skills/fix-pr/SKILL.md
+++ b/.opencode/skills/fix-pr/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/fix-pr/SKILL.md

--- a/.opencode/skills/implement-github-issue/SKILL.md
+++ b/.opencode/skills/implement-github-issue/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/implement-github-issue/SKILL.md

--- a/.opencode/skills/merge-dev-into-android-build/SKILL.md
+++ b/.opencode/skills/merge-dev-into-android-build/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/merge-dev-into-android-build/SKILL.md

--- a/.opencode/skills/plan-feature/SKILL.md
+++ b/.opencode/skills/plan-feature/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/plan-feature/SKILL.md

--- a/.opencode/skills/refine-github-issue/SKILL.md
+++ b/.opencode/skills/refine-github-issue/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/refine-github-issue/SKILL.md

--- a/.opencode/skills/report-codebase-size/SKILL.md
+++ b/.opencode/skills/report-codebase-size/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/report-codebase-size/SKILL.md

--- a/.opencode/skills/verify-github-issue/SKILL.md
+++ b/.opencode/skills/verify-github-issue/SKILL.md
@@ -1,0 +1,1 @@
+../../../.cursor/skills/verify-github-issue/SKILL.md


### PR DESCRIPTION
## Summary
- add missing `.opencode/skills/*/SKILL.md` entries for project-local skills not already mirrored
- use symlink references to `.cursor/skills/*/SKILL.md` to avoid duplicating skill content
- keep scope to project skills only (no global `~/.cursor` skill links)

## Test plan
- [x] verify new `.opencode/skills/*/SKILL.md` entries exist
- [x] confirm each new entry is a symlink to project `.cursor/skills`
- [x] confirm no `.opencode/skills-cursor` entries remain

Made with [Cursor](https://cursor.com)