### PR TITLE
Raise check_function_size limit to 200

### DIFF
--- a/SPEC/program/function-size.md
+++ b/SPEC/program/function-size.md
@@ -25,7 +25,7 @@ excluded by the shared scan contract.
 - Blank lines are excluded.
 - Single-line comments that begin with `//` are excluded.
 - All other lines count, including braces and block-comment lines.
-- Failure threshold is measured line count **>20**.
+- Failure threshold is measured line count **>200**.
 
 ## Allowlist contract (shrink-only)
 
@@ -40,6 +40,7 @@ allowed_over_20:
 
 - If a symbol is allowlisted, the checker allows it only while measured lines
   stay `<= max_measured_lines`.
+- The top-level key name remains `allowed_over_20` for backward compatibility.
 - If measured lines grow above the listed max, the checker fails.
 - New allowlist rows are not a default fix; prefer extracting helpers and
   reducing measured lines.
@@ -48,7 +49,7 @@ allowed_over_20:
 
 - Given repository root as cwd, when CI runs `dart run tool/ct_repo_lint.dart`,
   then rule `repo.function_size` runs and fails on any non-allowlisted symbol
-  measured over 20 lines with file, line, and symbol in output.
+  measured over 200 lines with file, line, and symbol in output.
 - Given an allowlisted symbol and measured lines below or equal to its
   `max_measured_lines`, when the checker runs, then it does not fail for that
   symbol.

--- a/test/check_function_size_test.dart
+++ b/test/check_function_size_test.dart
@@ -24,36 +24,24 @@ int f() {
   });
 
   group('runCheckFunctionSize', () {
+    String giantFunctionSource({required int statements}) {
+      final body = List.generate(
+        statements,
+        (i) => '  final v${i + 1} = ${i + 1};',
+      ).join('\n');
+      final sum = List.generate(statements, (i) => 'v${i + 1}').join(' + ');
+      return 'int giant() {\n$body\n  return $sum;\n}\n';
+    }
+
     test('fails when non-allowlisted function exceeds threshold', () {
       final temp = Directory.systemTemp.createTempSync('fn-size-');
       try {
         final libDir = Directory(
           p.join(temp.path, 'packages', 'colonizethis_logic', 'lib', 'src'),
         )..createSync(recursive: true);
-        File(p.join(libDir.path, 'big.dart')).writeAsStringSync('''
-int giant() {
-  final v1 = 1;
-  final v2 = 2;
-  final v3 = 3;
-  final v4 = 4;
-  final v5 = 5;
-  final v6 = 6;
-  final v7 = 7;
-  final v8 = 8;
-  final v9 = 9;
-  final v10 = 10;
-  final v11 = 11;
-  final v12 = 12;
-  final v13 = 13;
-  final v14 = 14;
-  final v15 = 15;
-  final v16 = 16;
-  final v17 = 17;
-  final v18 = 18;
-  final v19 = 19;
-  return v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9 + v10 + v11 + v12 + v13 + v14 + v15 + v16 + v17 + v18 + v19;
-}
-''');
+        File(
+          p.join(libDir.path, 'big.dart'),
+        ).writeAsStringSync(giantFunctionSource(statements: 210));
 
         final errors = <String>[];
         final exitCode = runCheckFunctionSize(
@@ -74,30 +62,9 @@ int giant() {
         final libDir = Directory(
           p.join(temp.path, 'packages', 'colonizethis_logic', 'lib', 'src'),
         )..createSync(recursive: true);
-        File(p.join(libDir.path, 'big.dart')).writeAsStringSync('''
-int giant() {
-  final v1 = 1;
-  final v2 = 2;
-  final v3 = 3;
-  final v4 = 4;
-  final v5 = 5;
-  final v6 = 6;
-  final v7 = 7;
-  final v8 = 8;
-  final v9 = 9;
-  final v10 = 10;
-  final v11 = 11;
-  final v12 = 12;
-  final v13 = 13;
-  final v14 = 14;
-  final v15 = 15;
-  final v16 = 16;
-  final v17 = 17;
-  final v18 = 18;
-  final v19 = 19;
-  return v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9 + v10 + v11 + v12 + v13 + v14 + v15 + v16 + v17 + v18 + v19;
-}
-''');
+        File(
+          p.join(libDir.path, 'big.dart'),
+        ).writeAsStringSync(giantFunctionSource(statements: 210));
         final toolDir = Directory(p.join(temp.path, 'tool'))
           ..createSync(recursive: true);
         File(
@@ -106,7 +73,7 @@ int giant() {
 allowed_over_20:
   - file: packages/colonizethis_logic/lib/src/big.dart
     symbol: giant
-    max_measured_lines: 22
+    max_measured_lines: 220
 ''');
 
         final exitCode = runCheckFunctionSize(

--- a/tool/check_function_size.dart
+++ b/tool/check_function_size.dart
@@ -10,7 +10,7 @@ import 'package:yaml/yaml.dart';
 
 import 'ct_repo_lint_scan_contract.dart';
 
-const _failThreshold = 20;
+const _failThreshold = 200;
 const _logicScopePrefix = 'packages/colonizethis_logic/lib/src/';
 
 int runCheckFunctionSize(


### PR DESCRIPTION
## Summary
- raise `tool/check_function_size.dart` fail threshold from 20 to 200
- update `test/check_function_size_test.dart` fixtures to exceed/newly allowlist against the new threshold
- update `SPEC/program/function-size.md` to document the 200-line threshold and keep `allowed_over_20` key compatibility note

## Test plan
- [x] `dart test test/check_function_size_test.dart`
- [x] Confirm docs mention `>200` for function-size failures

Made with [Cursor](https://cursor.com)