### PR TITLE
Support desktop startup maximize with persisted window state

### DIFF
--- a/SPEC/program/desktop-window-startup.md
+++ b/SPEC/program/desktop-window-startup.md
@@ -1,0 +1,46 @@
+# Desktop window startup
+
+**SPEC/program** - Desktop startup policy for `app/` window state on macOS (required) and Linux (best effort), with Windows optional when a Windows runner exists in branch scope.
+
+## 1. Scope
+
+- Platforms: macOS required; Linux best effort; Windows best effort only if the implementation branch includes a Windows runner.
+- Applies to the app's single desktop window.
+- Does not change web or mobile startup behavior.
+
+## 2. Startup policy
+
+- The system persists desktop preference `desktop.startupMaximized` in the Hive `settings` box.
+- Default preference is `true`.
+- The system persists the last desktop window state at `desktop.lastWindowState` with:
+  - `x` (double)
+  - `y` (double)
+  - `width` (double)
+  - `height` (double)
+  - `maximized` (bool)
+- Restore data is considered invalid when required fields are missing, non-finite, non-numeric, wrong type, or width/height are below desktop minimum size.
+- Startup decision order:
+  1. Use valid restored window state.
+  2. Otherwise, if `desktop.startupMaximized == true`, open maximized.
+  3. Otherwise, open at default size.
+
+## 3. Desktop window constraints
+
+- Desktop minimum window size is `800x600`.
+- Default desktop window size fallback is `1280x720`.
+- Startup resize/flicker is acceptable.
+- Multi-window behavior is out of scope.
+
+## 4. Menu behavior
+
+- Desktop app menu includes a user-facing toggle: `Open maximized on startup`.
+- Toggle updates and persists `desktop.startupMaximized` immediately.
+
+## 5. Acceptance criteria (Given-When-Then)
+
+- Given desktop launch with no valid stored window state and `desktop.startupMaximized=true`, when startup policy runs, then the system opens the window maximized.
+- Given desktop launch with valid stored non-maximized window bounds, when startup policy runs, then the system restores those bounds and does not force maximized startup.
+- Given desktop launch with invalid stored window state data, when startup policy runs, then the system ignores restore data and applies the maximize/default fallback based on `desktop.startupMaximized`.
+- Given desktop launch with no valid restore data and `desktop.startupMaximized=false`, when startup policy runs, then the system opens non-maximized with a minimum size of `800x600`.
+- Given the user toggles `Open maximized on startup` from the desktop menu, when the action completes, then the system persists the updated boolean in the Hive `settings` box.
+- Given web or mobile launch, when the app starts with this feature present, then startup behavior is unchanged from previous baseline.

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:colonizethis_app/l10n/app_localizations.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_app/config/desktop_window_settings.dart';
+import 'package:colonizethis_app/providers/settings_provider.dart';
 
 import 'config/routes.dart';
 import 'config/themes.dart';
@@ -10,12 +14,20 @@ import 'config/themes.dart';
 /// Used by macOS menubar (View → Debug log) to push the debug log route.
 final GlobalKey<NavigatorState> appNavigatorKey = GlobalKey<NavigatorState>();
 
-class App extends StatelessWidget {
+class App extends ConsumerWidget {
   const App({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final rootL10n = lookupAppLocalizations(const Locale('en'));
+    final settings = ref.watch(settingsProvider);
+    final startupMaximized =
+        settings[DesktopWindowSettingsKeys.startupMaximized] as bool? ?? true;
+    final isDesktopMenuPlatform =
+        !kIsWeb &&
+        (defaultTargetPlatform == TargetPlatform.macOS ||
+            defaultTargetPlatform == TargetPlatform.linux ||
+            defaultTargetPlatform == TargetPlatform.windows);
     final app = MaterialApp(
       navigatorKey: appNavigatorKey,
       onGenerateTitle: (context) => appL10n(context).app_title,
@@ -41,11 +53,22 @@ class App extends StatelessWidget {
                 AppEventBus().emit(const NavigateToRouteEvent(Routes.debugLog));
               },
             ),
+            if (isDesktopMenuPlatform)
+              PlatformMenuItem(
+                label:
+                    '${rootL10n.menu_openMaximizedOnStartup}: ${startupMaximized ? rootL10n.common_on : rootL10n.common_off}',
+                onSelected: () {
+                  ref
+                      .read(settingsProvider.notifier)
+                      .setValue(
+                        DesktopWindowSettingsKeys.startupMaximized,
+                        !startupMaximized,
+                      );
+                },
+              ),
           ],
         ),
-        if (PlatformProvidedMenuItem.hasMenu(
-          PlatformProvidedMenuItemType.quit,
-        ))
+        if (PlatformProvidedMenuItem.hasMenu(PlatformProvidedMenuItemType.quit))
           const PlatformProvidedMenuItem(
             type: PlatformProvidedMenuItemType.quit,
           ),

--- a/app/lib/config/constants.dart
+++ b/app/lib/config/constants.dart
@@ -14,3 +14,15 @@ abstract final class HiveBoxNames {
   static const String games = 'games';
   static const String offlineQueue = 'offline_queue';
 }
+
+/// Desktop window minimum width in logical pixels.
+const double kDesktopWindowMinWidth = 800;
+
+/// Desktop window minimum height in logical pixels.
+const double kDesktopWindowMinHeight = 600;
+
+/// Desktop window fallback width in logical pixels.
+const double kDesktopWindowDefaultWidth = 1280;
+
+/// Desktop window fallback height in logical pixels.
+const double kDesktopWindowDefaultHeight = 720;

--- a/app/lib/config/desktop_window_settings.dart
+++ b/app/lib/config/desktop_window_settings.dart
@@ -1,0 +1,87 @@
+import 'dart:ui' show Rect;
+
+import 'constants.dart';
+
+abstract final class DesktopWindowSettingsKeys {
+  static const String startupMaximized = 'desktop.startupMaximized';
+  static const String lastWindowState = 'desktop.lastWindowState';
+}
+
+class DesktopWindowState {
+  const DesktopWindowState({
+    required this.x,
+    required this.y,
+    required this.width,
+    required this.height,
+    required this.maximized,
+  });
+
+  final double x;
+  final double y;
+  final double width;
+  final double height;
+  final bool maximized;
+
+  Rect toRect() => Rect.fromLTWH(x, y, width, height);
+
+  Map<String, Object> toMap() => <String, Object>{
+    'x': x,
+    'y': y,
+    'width': width,
+    'height': height,
+    'maximized': maximized,
+  };
+
+  static DesktopWindowState? fromSettingsValue(Object? value) {
+    if (value is! Map) {
+      return null;
+    }
+    final x = _readFiniteDouble(value['x']);
+    final y = _readFiniteDouble(value['y']);
+    final width = _readFiniteDouble(value['width']);
+    final height = _readFiniteDouble(value['height']);
+    final maximized = value['maximized'];
+    if (x == null || y == null || width == null || height == null) {
+      return null;
+    }
+    if (maximized is! bool) {
+      return null;
+    }
+    if (width < kDesktopWindowMinWidth || height < kDesktopWindowMinHeight) {
+      return null;
+    }
+    if (!_isWithinReasonableBounds(x, y, width, height)) {
+      return null;
+    }
+    return DesktopWindowState(
+      x: x,
+      y: y,
+      width: width,
+      height: height,
+      maximized: maximized,
+    );
+  }
+
+  static bool _isWithinReasonableBounds(
+    double x,
+    double y,
+    double width,
+    double height,
+  ) {
+    const limit = 50000.0;
+    return x.abs() < limit &&
+        y.abs() < limit &&
+        width.abs() < limit &&
+        height.abs() < limit;
+  }
+
+  static double? _readFiniteDouble(Object? value) {
+    if (value is num) {
+      final converted = value.toDouble();
+      if (converted.isFinite) {
+        return converted;
+      }
+    }
+    return null;
+  }
+}

--- a/app/lib/core/services/desktop_window_startup_service.dart
+++ b/app/lib/core/services/desktop_window_startup_service.dart
@@ -1,0 +1,172 @@
+import 'dart:io' show Platform;
+import 'dart:ui' show Size;
+
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/config/desktop_window_settings.dart';
+import 'package:colonizethis_app/package_logger.dart';
+import 'package:hive/hive.dart';
+import 'package:window_manager/window_manager.dart';
+
+enum DesktopStartupMode { restoreState, maximize, defaultSize }
+
+class DesktopStartupDecision {
+  const DesktopStartupDecision({
+    required this.mode,
+    required this.restoreState,
+  });
+
+  final DesktopStartupMode mode;
+  final DesktopWindowState? restoreState;
+
+  static DesktopStartupDecision resolve({
+    required DesktopWindowState? restoreState,
+    required bool startupMaximized,
+  }) {
+    if (restoreState != null) {
+      return DesktopStartupDecision(
+        mode: DesktopStartupMode.restoreState,
+        restoreState: restoreState,
+      );
+    }
+    if (startupMaximized) {
+      return const DesktopStartupDecision(
+        mode: DesktopStartupMode.maximize,
+        restoreState: null,
+      );
+    }
+    return const DesktopStartupDecision(
+      mode: DesktopStartupMode.defaultSize,
+      restoreState: null,
+    );
+  }
+}
+
+class DesktopWindowStartupService with WindowListener {
+  DesktopWindowStartupService._();
+
+  static final DesktopWindowStartupService _instance =
+      DesktopWindowStartupService._();
+
+  bool _listenerRegistered = false;
+  bool _initialized = false;
+
+  static bool get isSupportedDesktop =>
+      Platform.isMacOS || Platform.isLinux || Platform.isWindows;
+
+  static Future<void> initializeIfSupported() async {
+    if (!isSupportedDesktop) {
+      return;
+    }
+    await _instance._initialize();
+  }
+
+  Future<void> _initialize() async {
+    if (_initialized) {
+      return;
+    }
+    _initialized = true;
+    await windowManager.ensureInitialized();
+
+    final settings = Hive.box<dynamic>(HiveBoxNames.settings);
+    final startupMaximized = _readStartupPreference(settings);
+    final restoreState = DesktopWindowState.fromSettingsValue(
+      settings.get(DesktopWindowSettingsKeys.lastWindowState),
+    );
+    final decision = DesktopStartupDecision.resolve(
+      restoreState: restoreState,
+      startupMaximized: startupMaximized,
+    );
+
+    await windowManager.waitUntilReadyToShow(
+      WindowOptions(
+        size: const Size(
+          kDesktopWindowDefaultWidth,
+          kDesktopWindowDefaultHeight,
+        ),
+        minimumSize: const Size(
+          kDesktopWindowMinWidth,
+          kDesktopWindowMinHeight,
+        ),
+        center: decision.mode == DesktopStartupMode.defaultSize,
+      ),
+      () async {
+        await windowManager.setMinimumSize(
+          const Size(kDesktopWindowMinWidth, kDesktopWindowMinHeight),
+        );
+        switch (decision.mode) {
+          case DesktopStartupMode.restoreState:
+            final state = decision.restoreState;
+            if (state != null) {
+              await windowManager.setBounds(state.toRect());
+              if (state.maximized) {
+                await windowManager.maximize();
+              }
+            }
+            break;
+          case DesktopStartupMode.maximize:
+            await windowManager.maximize();
+            break;
+          case DesktopStartupMode.defaultSize:
+            // WindowOptions covers default-size startup.
+            break;
+        }
+        await windowManager.show();
+        await windowManager.focus();
+      },
+    );
+
+    if (!_listenerRegistered) {
+      windowManager.addListener(this);
+      _listenerRegistered = true;
+    }
+    await _persistCurrentWindowState(settings);
+  }
+
+  bool _readStartupPreference(Box<dynamic> settings) {
+    final raw = settings.get(DesktopWindowSettingsKeys.startupMaximized);
+    if (raw is bool) {
+      return raw;
+    }
+    settings.put(DesktopWindowSettingsKeys.startupMaximized, true);
+    return true;
+  }
+
+  @override
+  Future<void> onWindowMove() => _saveStateSafely();
+
+  @override
+  Future<void> onWindowResize() => _saveStateSafely();
+
+  @override
+  Future<void> onWindowMaximize() => _saveStateSafely();
+
+  @override
+  Future<void> onWindowUnmaximize() => _saveStateSafely();
+
+  Future<void> _saveStateSafely() async {
+    try {
+      final settings = Hive.box<dynamic>(HiveBoxNames.settings);
+      await _persistCurrentWindowState(settings);
+    } catch (e, st) {
+      packageLogger(
+        'app',
+      ).w('desktop window state persistence failed', error: e, stackTrace: st);
+    }
+  }
+
+  Future<void> _persistCurrentWindowState(Box<dynamic> settings) async {
+    final bounds = await windowManager.getBounds();
+    final isMaximized = await windowManager.isMaximized();
+    final state = DesktopWindowState(
+      x: bounds.left,
+      y: bounds.top,
+      width: bounds.width,
+      height: bounds.height,
+      maximized: isMaximized,
+    );
+    await settings.put(
+      DesktopWindowSettingsKeys.lastWindowState,
+      state.toMap(),
+    );
+  }
+}

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -12,6 +12,10 @@
   "@menu_debugLog": {
     "description": "Platform menu item label that navigates to the debug log viewer."
   },
+  "menu_openMaximizedOnStartup": "Open maximized on startup",
+  "@menu_openMaximizedOnStartup": {
+    "description": "Platform menu item label for toggling desktop startup maximization."
+  },
   "mainMenu_title": "ColonizeThis V3",
   "@mainMenu_title": {
     "description": "Main menu title text when not using the pixel-art logo."
@@ -107,6 +111,14 @@
   "common_yes": "Yes",
   "@common_yes": {
     "description": "Generic 'Yes' button label."
+  },
+  "common_on": "On",
+  "@common_on": {
+    "description": "Generic enabled state label."
+  },
+  "common_off": "Off",
+  "@common_off": {
+    "description": "Generic disabled state label."
   },
   "common_confirm": "Confirm",
   "@common_confirm": {

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -12,6 +12,7 @@ import 'config/constants.dart';
 import 'config/ct_e2e.dart';
 import 'config/map_terrain_config.dart';
 import 'core/services/app_event_handler_scope.dart';
+import 'core/services/desktop_window_startup_service.dart';
 
 /// Opens one Hive box; failures are isolated so another box (e.g. games) still opens.
 Future<void> _openHiveBoxSafely(String name) async {
@@ -32,6 +33,7 @@ Future<void> bootstrapApp({
   required Future<void> Function() ensureMapTerrainLoaded,
   required Future<void> Function() initHive,
   required Future<void> Function(String name) openHiveBoxSafely,
+  required Future<void> Function() ensureDesktopWindowStartup,
   required void Function(Widget app) runAppFn,
 }) async {
   ensureBindingInitialized();
@@ -41,6 +43,7 @@ Future<void> bootstrapApp({
   await openHiveBoxSafely(HiveBoxNames.settings);
   await openHiveBoxSafely(HiveBoxNames.games);
   await openHiveBoxSafely(HiveBoxNames.offlineQueue);
+  await ensureDesktopWindowStartup();
   runAppFn(const ProviderScope(child: AppEventHandlerScope(child: App())));
 }
 
@@ -66,6 +69,7 @@ Future<void> bootstrapForIntegrationTest() async {
       await Hive.initFlutter();
     },
     openHiveBoxSafely: _openHiveBoxSafely,
+    ensureDesktopWindowStartup: () async {},
     runAppFn: runApp,
   );
 }
@@ -79,6 +83,8 @@ void main() {
         ensureMapTerrainLoaded: MapTerrainConfig.ensureLoaded,
         initHive: Hive.initFlutter,
         openHiveBoxSafely: _openHiveBoxSafely,
+        ensureDesktopWindowStartup:
+            DesktopWindowStartupService.initializeIfSupported,
         runAppFn: runApp,
       );
     },

--- a/app/lib/providers/settings_provider.dart
+++ b/app/lib/providers/settings_provider.dart
@@ -1,16 +1,39 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
 
-/// Stub provider for user settings. Phase 0: no real state; Phase 1+ wires to Hive.
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/config/desktop_window_settings.dart';
+
 class SettingsNotifier extends Notifier<Map<String, Object?>> {
   @override
-  Map<String, Object?> build() => const {};
+  Map<String, Object?> build() {
+    if (!Hive.isBoxOpen(HiveBoxNames.settings)) {
+      return const {};
+    }
+    final box = Hive.box<dynamic>(HiveBoxNames.settings);
+    final startupMaximized =
+        box.get(DesktopWindowSettingsKeys.startupMaximized) as bool? ?? true;
+    box.put(DesktopWindowSettingsKeys.startupMaximized, startupMaximized);
+    final next = <String, Object?>{
+      for (final key in box.keys) key.toString(): box.get(key),
+    };
+    next[DesktopWindowSettingsKeys.startupMaximized] = startupMaximized;
+    return next;
+  }
 
   void replaceAll(Map<String, Object?> next) {
     state = next;
+    if (Hive.isBoxOpen(HiveBoxNames.settings)) {
+      final box = Hive.box<dynamic>(HiveBoxNames.settings);
+      box.putAll(next);
+    }
   }
 
   void setValue(String key, Object? value) {
     state = {...state, key: value};
+    if (Hive.isBoxOpen(HiveBoxNames.settings)) {
+      Hive.box<dynamic>(HiveBoxNames.settings).put(key, value);
+    }
   }
 }
 

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   colonizethis_ai:
   widgetbook: ^3.22.0
   google_fonts: ^6.3.3
+  window_manager: ^0.5.1
 
 dev_dependencies:
   colonizethis_test:

--- a/app/test/constants_test.dart
+++ b/app/test/constants_test.dart
@@ -13,6 +13,13 @@ void main() {
     expect(HiveBoxNames.offlineQueue, 'offline_queue');
   });
 
+  test('desktop window constants are stable', () {
+    expect(kDesktopWindowMinWidth, 800);
+    expect(kDesktopWindowMinHeight, 600);
+    expect(kDesktopWindowDefaultWidth, 1280);
+    expect(kDesktopWindowDefaultHeight, 720);
+  });
+
   test('RoutePaths strings are stable (no heavy routes.dart import)', () {
     expect(RoutePaths.shell, '/');
     expect(RoutePaths.game, '/game');

--- a/app/test/desktop_window_startup_service_test.dart
+++ b/app/test/desktop_window_startup_service_test.dart
@@ -1,0 +1,76 @@
+import 'package:colonizethis_app/config/desktop_window_settings.dart';
+import 'package:colonizethis_app/core/services/desktop_window_startup_service.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  group('DesktopWindowState.fromSettingsValue', () {
+    test('parses valid state map', () {
+      final parsed = DesktopWindowState.fromSettingsValue(const {
+        'x': 10,
+        'y': 20,
+        'width': 1280,
+        'height': 720,
+        'maximized': false,
+      });
+
+      expect(parsed, isNotNull);
+      expect(parsed!.width, 1280);
+      expect(parsed.height, 720);
+      expect(parsed.maximized, isFalse);
+    });
+
+    test('returns null for malformed payload', () {
+      final parsed = DesktopWindowState.fromSettingsValue(const {
+        'x': 10,
+        'y': 20,
+        'width': 640,
+        'height': 300,
+        'maximized': 'yes',
+      });
+
+      expect(parsed, isNull);
+    });
+  });
+
+  group('DesktopStartupDecision.resolve', () {
+    test('restore state wins over maximize preference', () {
+      const state = DesktopWindowState(
+        x: 0,
+        y: 0,
+        width: 1280,
+        height: 720,
+        maximized: false,
+      );
+      final decision = DesktopStartupDecision.resolve(
+        restoreState: state,
+        startupMaximized: true,
+      );
+
+      expect(decision.mode, DesktopStartupMode.restoreState);
+      expect(decision.restoreState, state);
+    });
+
+    test('falls back to maximize when no restore state', () {
+      final decision = DesktopStartupDecision.resolve(
+        restoreState: null,
+        startupMaximized: true,
+      );
+
+      expect(decision.mode, DesktopStartupMode.maximize);
+      expect(decision.restoreState, isNull);
+    });
+
+    test('falls back to default size when maximize preference is disabled', () {
+      final decision = DesktopStartupDecision.resolve(
+        restoreState: null,
+        startupMaximized: false,
+      );
+
+      expect(decision.mode, DesktopStartupMode.defaultSize);
+      expect(decision.restoreState, isNull);
+    });
+  });
+}

--- a/app/test/main_bootstrap_test.dart
+++ b/app/test/main_bootstrap_test.dart
@@ -20,6 +20,7 @@ void main() {
           ensureMapTerrainLoaded: () async {},
           initHive: () async {},
           openHiveBoxSafely: (_) async {},
+          ensureDesktopWindowStartup: () async {},
           runAppFn: (_) {
             runAppZone = Zone.current;
           },
@@ -58,6 +59,9 @@ void main() {
         callOrder.add('box:$name');
         openedBoxes.add(name);
       },
+      ensureDesktopWindowStartup: () async {
+        callOrder.add('desktop');
+      },
       runAppFn: (Widget app) {
         callOrder.add('runApp');
       },
@@ -73,6 +77,7 @@ void main() {
         'box:${HiveBoxNames.settings}',
         'box:${HiveBoxNames.games}',
         'box:${HiveBoxNames.offlineQueue}',
+        'desktop',
         'runApp',
       ]),
     );

--- a/app/test/settings_provider_test.dart
+++ b/app/test/settings_provider_test.dart
@@ -1,26 +1,50 @@
+import 'dart:io';
+
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/config/desktop_window_settings.dart';
 import 'package:colonizethis_app/providers/settings_provider.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
 
 void main() {
   suppressLogsForTests();
 
-  test('settingsProvider replaceAll and setValue update settings map', () {
-    final container = ProviderContainer();
-    addTearDown(container.dispose);
+  test(
+    'settingsProvider replaceAll and setValue update settings map',
+    () async {
+      final dir = await Directory.systemTemp.createTemp(
+        'ct_settings_provider_',
+      );
+      Hive.init(dir.path);
+      await Hive.openBox<dynamic>(HiveBoxNames.settings);
+      addTearDown(() async {
+        await Hive.close();
+        await dir.delete(recursive: true);
+      });
 
-    final notifier = container.read(settingsProvider.notifier);
-    expect(container.read(settingsProvider), isEmpty);
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
 
-    notifier.replaceAll(const {'musicVolume': 8});
-    expect(container.read(settingsProvider), const {'musicVolume': 8});
+      final notifier = container.read(settingsProvider.notifier);
+      expect(
+        container.read(
+          settingsProvider,
+        )[DesktopWindowSettingsKeys.startupMaximized],
+        isTrue,
+      );
 
-    notifier.setValue('musicVolume', 10);
-    notifier.setValue('language', 'en');
-    expect(
-      container.read(settingsProvider),
-      const {'musicVolume': 10, 'language': 'en'},
-    );
-  });
+      notifier.replaceAll(const {'musicVolume': 8});
+      expect(container.read(settingsProvider), const {'musicVolume': 8});
+
+      notifier.setValue('musicVolume', 10);
+      notifier.setValue('language', 'en');
+      expect(container.read(settingsProvider), const {
+        'musicVolume': 10,
+        'language': 'en',
+      });
+      expect(Hive.box<dynamic>(HiveBoxNames.settings).get('musicVolume'), 10);
+    },
+  );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -796,6 +796,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  screen_retriever:
+    dependency: transitive
+    description:
+      name: screen_retriever
+      sha256: "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_linux:
+    dependency: transitive
+    description:
+      name: screen_retriever_linux
+      sha256: f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_macos:
+    dependency: transitive
+    description:
+      name: screen_retriever_macos
+      sha256: "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_platform_interface:
+    dependency: transitive
+    description:
+      name: screen_retriever_platform_interface
+      sha256: ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_windows:
+    dependency: transitive
+    description:
+      name: screen_retriever_windows
+      sha256: "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   shelf:
     dependency: transitive
     description:
@@ -1097,6 +1137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.11.0"
+  window_manager:
+    dependency: transitive
+    description:
+      name: window_manager
+      sha256: "7eb6d6c4164ec08e1bf978d6e733f3cebe792e2a23fb07cbca25c2872bfdbdcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
   xdg_directories:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- add SPEC/program desktop startup-window policy with explicit restore-first decision order and desktop-only menu toggle behavior
- implement desktop startup window handling via `window_manager` with persisted Hive settings (`desktop.startupMaximized`, `desktop.lastWindowState`) and min-size enforcement (`800x600`)
- add a desktop View-menu toggle for startup maximize preference and wire settings provider persistence so user choice survives relaunches
- add focused tests for startup policy/state validation plus bootstrap + settings coverage updates

## Test plan
- [x] `cd app && flutter test test/main_bootstrap_test.dart test/settings_provider_test.dart test/constants_test.dart test/desktop_window_startup_service_test.dart`

## Scope notes
- macOS + Linux desktop behavior is implemented through Dart desktop window integration
- Windows runner files are not present in this branch; Windows-specific runner wiring is deferred

Refs #1884

Made with [Cursor](https://cursor.com)