### PR TITLE
chore: cap app e2e CI timeout to 10 minutes

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -218,7 +218,7 @@ jobs:
         needs.app_tests_shard.result == 'success'
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 10 # Enforce e2e runtime budget for test-performance hygiene.
     env:
       PUB_CACHE: ${{ github.workspace }}/.pub-cache
     steps:


### PR DESCRIPTION
## Summary
- Reduce the `app_e2e_linux` CI job timeout from 45 minutes to 10 minutes.
- Add a short inline comment documenting that the cap enforces test-performance hygiene.

## Test plan
- [x] Confirm workflow YAML updates in `.github/workflows/quality.yml`.
- [ ] Let CI run on this PR and verify `App e2e (Linux desktop + xvfb)` respects the 10-minute timeout.

Made with [Cursor](https://cursor.com)