### PR TITLE
Refactor work order validator to retire one function-size allowlist row

### DIFF
--- a/SPEC/program/function-size.md
+++ b/SPEC/program/function-size.md
@@ -8,7 +8,7 @@ runtime domain Dart code.
 | Artifact | Role |
 |----------|------|
 | `tool/check_function_size.dart` | Analyzer-based checker and CLI |
-| `tool/function_size_allowlist.yaml` | Grandfathered `(file, symbol)` rows with a shrink-only `max_measured_lines` cap |
+| `tool/function_size_allowlist.yaml` | **Legacy:** grandfathered `(file, symbol)` rows for symbols still over 200 measured lines; shrink-only until rows are retired |
 
 ## Scan scope
 
@@ -27,7 +27,7 @@ excluded by the shared scan contract.
 - All other lines count, including braces and block-comment lines.
 - Failure threshold is measured line count **>200**.
 
-## Allowlist contract (shrink-only)
+## Legacy allowlist contract (shrink-only)
 
 `tool/function_size_allowlist.yaml` uses:
 
@@ -41,15 +41,17 @@ allowed_over_20:
 - If a symbol is allowlisted, the checker allows it only while measured lines
   stay `<= max_measured_lines`.
 - The top-level key name remains `allowed_over_20` for backward compatibility.
+- Only symbols currently measured above 200 belong in this legacy file.
 - If measured lines grow above the listed max, the checker fails.
-- New allowlist rows are not a default fix; prefer extracting helpers and
-  reducing measured lines.
+- New allowlist rows are disallowed by default; prefer extracting helpers and
+  reducing measured lines, then deleting legacy rows.
 
 ## Acceptance criteria
 
 - Given repository root as cwd, when CI runs `dart run tool/ct_repo_lint.dart`,
-  then rule `repo.function_size` runs and fails on any non-allowlisted symbol
-  measured over 200 lines with file, line, and symbol in output.
+  then rule `repo.function_size` runs and fails on any symbol measured over 200
+  lines unless that symbol appears in the legacy allowlist with a sufficient
+  shrink-only `max_measured_lines` cap.
 - Given an allowlisted symbol and measured lines below or equal to its
   `max_measured_lines`, when the checker runs, then it does not fail for that
   symbol.

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
@@ -76,34 +76,15 @@ class WorkOrderValidator extends OrderValidator {
       previousRejected: previousRejected,
       body: () {
         final unit = _context.unitsById[o.unitId];
-        if (unit == null || unit.ownerId != _context.playerId) {
+        final unitValidation = _validateOwnedUnseenUnit(o, unit);
+        if (unitValidation != null) return unitValidation;
+        final validatedUnit = unit;
+        if (validatedUnit == null) {
           return OrderValidationResult.rejected('Unit not found');
         }
-        if (_seenUnitIds.contains(o.unitId)) {
-          return OrderValidationResult.rejected(
-            'Only one work order per unit is allowed each turn',
-          );
-        }
-        _seenUnitIds.add(o.unitId);
-        if (unit.currentWork != null) {
-          return OrderValidationResult.rejected(
-            'Unit already has a work order; cancel first',
-          );
-        }
-        if (_context.civilianDraftMoveUnitIds.contains(o.unitId)) {
-          return OrderValidationResult.rejected(kReasonCivilianMoveXorWorkOrder);
-        }
-        final type = unit.type;
-        if (!isWorkOrderTargetAllowedForUnitType(type, o.target)) {
-          return OrderValidationResult.rejected(
-            'Invalid work target for unit type',
-          );
-        }
-        if (o.targetTileKey.isEmpty) {
-          return OrderValidationResult.rejected(
-            'Work order requires a target tile',
-          );
-        }
+        final type = validatedUnit.type;
+        final targetValidation = _validateWorkTargetAndTile(o, type);
+        if (targetValidation != null) return targetValidation;
 
         final targetProvinceId = Unit.provinceIdFromTileKey(o.targetTileKey);
         final province = targetProvinceId != null
@@ -111,51 +92,25 @@ class WorkOrderValidator extends OrderValidator {
             : null;
         final ownerId = province?.ownerId;
 
-        final preCtx = WorkOrderTargetPrecheckContext(
-          game: _context.game,
-          player: _context.player,
-          playerId: _context.playerId,
-          treasury: _treasury,
-          civilianEmbassyWorkAllowed: _civilianWorkAllowedInMinorTribeProvince,
-        );
-        final preResult = runWorkOrderTargetPrecheck(
-          preCtx,
-          o,
-          targetProvinceId,
-          ownerId,
-          type,
+        final preResult = _runTargetPrecheck(
+          o: o,
+          targetProvinceId: targetProvinceId,
+          ownerId: ownerId,
+          type: type,
         );
         if (preResult != null) {
           return preResult;
         }
 
-        if (!isExplorerUnit(type) &&
-            !kWorkTargetsSkippingDefaultForeignProvinceCheck.contains(
-              o.target,
-            )) {
-          final controlled = isTileControlledByPlayer(
-            _context.game,
-            _context.playerId,
-            o.targetTileKey,
-          );
-          final embassyWork = _civilianWorkAllowedInMinorTribeProvince(
-            type,
-            ownerId,
-          );
-          if (!controlled && !embassyWork) {
-            return OrderValidationResult.rejected(
-              'Cannot work in foreign province',
-            );
-          }
-        }
+        final foreignProvinceResult = _validateForeignProvinceWork(
+          o: o,
+          type: type,
+          ownerId: ownerId,
+        );
+        if (foreignProvinceResult != null) return foreignProvinceResult;
 
-        if (isDevExclusiveUnitType(type) &&
-            isDevExclusiveWorkTarget(o.target) &&
-            _context.devExclusiveTiles.contains(o.targetTileKey)) {
-          return OrderValidationResult.rejected(
-            'Tile already has development or purchase work for this player',
-          );
-        }
+        final devExclusiveResult = _validateDevExclusiveWorkTarget(o, type);
+        if (devExclusiveResult != null) return devExclusiveResult;
 
         final materialRuleResult = _validateMaterialAndTechRules(
           o,
@@ -165,7 +120,7 @@ class WorkOrderValidator extends OrderValidator {
 
         if (!workOrderVisibilityOk(
           _context.view,
-          unit,
+          validatedUnit,
           o.target,
           o.targetTileKey,
         )) {
@@ -197,6 +152,99 @@ class WorkOrderValidator extends OrderValidator {
 
         return OrderValidationResult.accepted();
       },
+    );
+  }
+
+  OrderValidationResult? _validateOwnedUnseenUnit(WorkOrder o, Unit? unit) {
+    if (unit == null || unit.ownerId != _context.playerId) {
+      return OrderValidationResult.rejected('Unit not found');
+    }
+    if (_seenUnitIds.contains(o.unitId)) {
+      return OrderValidationResult.rejected(
+        'Only one work order per unit is allowed each turn',
+      );
+    }
+    _seenUnitIds.add(o.unitId);
+    if (unit.currentWork != null) {
+      return OrderValidationResult.rejected(
+        'Unit already has a work order; cancel first',
+      );
+    }
+    if (_context.civilianDraftMoveUnitIds.contains(o.unitId)) {
+      return OrderValidationResult.rejected(kReasonCivilianMoveXorWorkOrder);
+    }
+    return null;
+  }
+
+  OrderValidationResult? _validateWorkTargetAndTile(WorkOrder o, String type) {
+    if (!isWorkOrderTargetAllowedForUnitType(type, o.target)) {
+      return OrderValidationResult.rejected(
+        'Invalid work target for unit type',
+      );
+    }
+    if (o.targetTileKey.isEmpty) {
+      return OrderValidationResult.rejected(
+        'Work order requires a target tile',
+      );
+    }
+    return null;
+  }
+
+  OrderValidationResult? _runTargetPrecheck({
+    required WorkOrder o,
+    required String? targetProvinceId,
+    required String? ownerId,
+    required String type,
+  }) {
+    final preCtx = WorkOrderTargetPrecheckContext(
+      game: _context.game,
+      player: _context.player,
+      playerId: _context.playerId,
+      treasury: _treasury,
+      civilianEmbassyWorkAllowed: _civilianWorkAllowedInMinorTribeProvince,
+    );
+    return runWorkOrderTargetPrecheck(
+      preCtx,
+      o,
+      targetProvinceId,
+      ownerId,
+      type,
+    );
+  }
+
+  OrderValidationResult? _validateForeignProvinceWork({
+    required WorkOrder o,
+    required String type,
+    required String? ownerId,
+  }) {
+    if (isExplorerUnit(type) ||
+        kWorkTargetsSkippingDefaultForeignProvinceCheck.contains(o.target)) {
+      return null;
+    }
+    final controlled = isTileControlledByPlayer(
+      _context.game,
+      _context.playerId,
+      o.targetTileKey,
+    );
+    final embassyWork = _civilianWorkAllowedInMinorTribeProvince(type, ownerId);
+    if (controlled || embassyWork) {
+      return null;
+    }
+    return OrderValidationResult.rejected('Cannot work in foreign province');
+  }
+
+  OrderValidationResult? _validateDevExclusiveWorkTarget(
+    WorkOrder o,
+    String type,
+  ) {
+    if (!isDevExclusiveUnitType(type) || !isDevExclusiveWorkTarget(o.target)) {
+      return null;
+    }
+    if (!_context.devExclusiveTiles.contains(o.targetTileKey)) {
+      return null;
+    }
+    return OrderValidationResult.rejected(
+      'Tile already has development or purchase work for this player',
     );
   }
 

--- a/tool/function_size_allowlist.yaml
+++ b/tool/function_size_allowlist.yaml
@@ -475,9 +475,6 @@ allowed_over_20:
   - file: packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
     symbol: WorkOrderValidator._civilianWorkAllowedInMinorTribeProvince
     max_measured_lines: 23
-  - file: packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
-    symbol: WorkOrderValidator.validate
-    max_measured_lines: 210
   - file: packages/colonizethis_logic/lib/src/setup/capital_choice.dart
     symbol: _isTileAdjacentToSea
     max_measured_lines: 21


### PR DESCRIPTION
## Summary
- refactors `WorkOrderValidator.validate` into focused helper methods while preserving validation behavior and side effects
- removes the legacy `WorkOrderValidator.validate` entry from `tool/function_size_allowlist.yaml` now that the symbol is below the 200-line threshold
- updates `SPEC/program/function-size.md` wording to clarify legacy allowlist usage and phased retirement expectations

## Scope
This PR implements one incremental slice of issue #1912 for function-size allowlist retirement.

Deferred to follow-up slices:
- remaining legacy allowlist rows for other symbols still above 200 measured lines
- broader no-allowlist enforcement work tracked by #1912

## Test plan
- [x] `dart run tool/check_function_size.dart`
- [x] `dart test packages/colonizethis_logic/test/order_engine_validate_work_single_order_per_unit_test.dart`

Refs #1912

Made with [Cursor](https://cursor.com)