### PR TITLE
Refactor quick battle resolver to shrink function-size allowlist (Refs #1912)

### DIFF
--- a/packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
@@ -105,7 +105,7 @@ QuickBattleResult resolveQuickBattle(
       defGroups = _removeCasualties(defGroups, defLoss);
 
       if (_totalUnitCount(defGroups) <= 0) {
-        final result = _finishResult(
+        return _finishAndLogQuickBattleResult(
           winner: QuickBattleWinner.attacker,
           attackerCasualties: attCasualties,
           defenderCasualties: defCasualties,
@@ -114,11 +114,6 @@ QuickBattleResult resolveQuickBattle(
           mutableGuns: mutableGuns,
           useVirtualEmplaced: useVirtualEmplaced,
         );
-        _qbLog.d(
-          'quick_battle end winner=${result.winner.name} '
-          'flip=${result.provinceFlips} fortDowngrade=${result.fortDowngradeFromDestroyedEmplaced}',
-        );
-        return result;
       }
 
       final attLossFraction = _attackerLossFractionFromDefenderStrike(
@@ -148,7 +143,7 @@ QuickBattleResult resolveQuickBattle(
       attGroups = _removeCasualties(attGroups, attLoss);
 
       if (_totalUnitCount(attGroups) <= 0) {
-        final result = _finishResult(
+        return _finishAndLogQuickBattleResult(
           winner: QuickBattleWinner.defender,
           attackerCasualties: attCasualties,
           defenderCasualties: defCasualties,
@@ -157,11 +152,6 @@ QuickBattleResult resolveQuickBattle(
           mutableGuns: mutableGuns,
           useVirtualEmplaced: useVirtualEmplaced,
         );
-        _qbLog.d(
-          'quick_battle end winner=${result.winner.name} '
-          'flip=${result.provinceFlips} fortDowngrade=${result.fortDowngradeFromDestroyedEmplaced}',
-        );
-        return result;
       }
 
       final defLossFraction = _defenderLossFractionFromAttackerStrike(
@@ -191,7 +181,7 @@ QuickBattleResult resolveQuickBattle(
     }
 
     if (_totalUnitCount(defGroups) <= 0) {
-      final result = _finishResult(
+      return _finishAndLogQuickBattleResult(
         winner: QuickBattleWinner.attacker,
         attackerCasualties: attCasualties,
         defenderCasualties: defCasualties,
@@ -200,14 +190,9 @@ QuickBattleResult resolveQuickBattle(
         mutableGuns: mutableGuns,
         useVirtualEmplaced: useVirtualEmplaced,
       );
-      _qbLog.d(
-        'quick_battle end winner=${result.winner.name} '
-        'flip=${result.provinceFlips} fortDowngrade=${result.fortDowngradeFromDestroyedEmplaced}',
-      );
-      return result;
     }
     if (_totalUnitCount(attGroups) <= 0) {
-      final result = _finishResult(
+      return _finishAndLogQuickBattleResult(
         winner: QuickBattleWinner.defender,
         attackerCasualties: attCasualties,
         defenderCasualties: defCasualties,
@@ -216,26 +201,19 @@ QuickBattleResult resolveQuickBattle(
         mutableGuns: mutableGuns,
         useVirtualEmplaced: useVirtualEmplaced,
       );
-      _qbLog.d(
-        'quick_battle end winner=${result.winner.name} '
-        'flip=${result.provinceFlips} fortDowngrade=${result.fortDowngradeFromDestroyedEmplaced}',
-      );
-      return result;
     }
   }
 
   final finalAttStr =
       _effectiveStrength(attGroups, input.attackerDeployment.laneTerrain) *
       input.attackerLeaderMultiplier;
-  var finalDefStr =
+  final finalDefStr =
       _effectiveStrength(defGroups, input.defenderDeployment.laneTerrain) *
-      input.defenderLeaderMultiplier;
-  if (useVirtualEmplaced) {
-    finalDefStr += _aliveGunStrengthSum(mutableGuns);
-  }
+          input.defenderLeaderMultiplier +
+      (useVirtualEmplaced ? _aliveGunStrengthSum(mutableGuns) : 0.0);
 
   if (finalAttStr > finalDefStr * 1.2) {
-    final result = _finishResult(
+    return _finishAndLogQuickBattleResult(
       winner: QuickBattleWinner.attacker,
       attackerCasualties: attCasualties,
       defenderCasualties: defCasualties,
@@ -244,14 +222,9 @@ QuickBattleResult resolveQuickBattle(
       mutableGuns: mutableGuns,
       useVirtualEmplaced: useVirtualEmplaced,
     );
-    _qbLog.d(
-      'quick_battle end winner=${result.winner.name} '
-      'flip=${result.provinceFlips} fortDowngrade=${result.fortDowngradeFromDestroyedEmplaced}',
-    );
-    return result;
   }
   if (finalDefStr > finalAttStr * 1.2) {
-    final result = _finishResult(
+    return _finishAndLogQuickBattleResult(
       winner: QuickBattleWinner.defender,
       attackerCasualties: attCasualties,
       defenderCasualties: defCasualties,
@@ -260,17 +233,32 @@ QuickBattleResult resolveQuickBattle(
       mutableGuns: mutableGuns,
       useVirtualEmplaced: useVirtualEmplaced,
     );
-    _qbLog.d(
-      'quick_battle end winner=${result.winner.name} '
-      'flip=${result.provinceFlips} fortDowngrade=${result.fortDowngradeFromDestroyedEmplaced}',
-    );
-    return result;
   }
-  final result = _finishResult(
+  return _finishAndLogQuickBattleResult(
     winner: QuickBattleWinner.mutualExhaustion,
     attackerCasualties: attCasualties,
     defenderCasualties: defCasualties,
     provinceFlips: false,
+    input: input,
+    mutableGuns: mutableGuns,
+    useVirtualEmplaced: useVirtualEmplaced,
+  );
+}
+
+QuickBattleResult _finishAndLogQuickBattleResult({
+  required QuickBattleWinner winner,
+  required List<String> attackerCasualties,
+  required List<String> defenderCasualties,
+  required bool provinceFlips,
+  required QuickBattleInput input,
+  required List<_MutableEmplacedGun> mutableGuns,
+  required bool useVirtualEmplaced,
+}) {
+  final result = _finishResult(
+    winner: winner,
+    attackerCasualties: attackerCasualties,
+    defenderCasualties: defenderCasualties,
+    provinceFlips: provinceFlips,
     input: input,
     mutableGuns: mutableGuns,
     useVirtualEmplaced: useVirtualEmplaced,
@@ -728,8 +716,10 @@ Game applyQuickBattleResultToGame(
 
   var updatedGame = game.copyWith(worldState: newWorldState);
   updatedGame = updatedGame.copyWith(
-    worldState:
-        reconcileArmiesAfterUnitsChanged(updatedGame.worldState, updatedGame),
+    worldState: reconcileArmiesAfterUnitsChanged(
+      updatedGame.worldState,
+      updatedGame,
+    ),
   );
   return updatedGame;
 }

--- a/packages/colonizethis_logic/lib/src/setup/game_setup_helpers_towns.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup_helpers_towns.dart
@@ -94,17 +94,20 @@ Map<String, Map<String, String>> _buildCoordToKeyByRegion(
     final regionId = regionEntry.key;
     final byProvince = regionEntry.value;
     final coordToTileKey = <String, String>{};
-    for (final list in byProvince.values) {
-      for (final tk in list) {
-        final parts = tk.split('|');
-        if (parts.length >= 4) {
-          coordToTileKey['${parts[2]}|${parts[3]}'] = tk;
-        }
-      }
+    for (final tileKey in byProvince.values.expand((tiles) => tiles)) {
+      final coordKey = _coordKeyFromTileKey(tileKey);
+      if (coordKey == null) continue;
+      coordToTileKey[coordKey] = tileKey;
     }
     coordToKey[regionId] = coordToTileKey;
   }
   return coordToKey;
+}
+
+String? _coordKeyFromTileKey(String tileKey) {
+  final parts = tileKey.split('|');
+  if (parts.length < 4) return null;
+  return '${parts[2]}|${parts[3]}';
 }
 
 Map<String, int> _bfsDistances({

--- a/packages/colonizethis_logic/lib/src/setup/game_setup_helpers_towns.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup_helpers_towns.dart
@@ -10,215 +10,31 @@ Game assignProvinceTowns({
 }) {
   final tileKeysByRegion = game.worldState.tileKeysByRegionAndProvince;
   final ports = game.worldState.portsByProvinceSeaboard;
-
-  final capitalTileKeyByOwner = <String, String>{};
-  final capitalProvinceIdByOwner = <String, String>{};
-  for (final p in game.players) {
-    if (p.capitalProvinceId != null && p.capitalTile != null) {
-      capitalProvinceIdByOwner[p.id] = p.capitalProvinceId!;
-      capitalTileKeyByOwner[p.id] = p.capitalTile!.toTileKey();
-    }
-  }
-  for (final m in game.minorNations) {
-    if (m.capitalProvinceId != null && m.capitalTile != null) {
-      capitalProvinceIdByOwner[m.id] = m.capitalProvinceId!;
-      capitalTileKeyByOwner[m.id] = m.capitalTile!.toTileKey();
-    }
-  }
-  for (final t in game.tribes) {
-    if (t.capitalProvinceId != null && t.capitalTile != null) {
-      capitalProvinceIdByOwner[t.id] = t.capitalProvinceId!;
-      capitalTileKeyByOwner[t.id] = t.capitalTile!.toTileKey();
-    }
-  }
-
-  final coordToKey = <String, Map<String, String>>{};
-  for (final regionEntry in tileKeysByRegion.entries) {
-    final regionId = regionEntry.key;
-    final byProvince = regionEntry.value;
-    final m = <String, String>{};
-    for (final list in byProvince.values) {
-      for (final tk in list) {
-        final parts = tk.split('|');
-        if (parts.length >= 4) {
-          m['${parts[2]}|${parts[3]}'] = tk;
-        }
-      }
-    }
-    coordToKey[regionId] = m;
-  }
-
-  Map<String, int> bfsDistances(String regionId, String startTileKey) {
-    final result = <String, int>{};
-    final parts = startTileKey.split('|');
-    if (parts.length < 4) return result;
-    final m = coordToKey[regionId];
-    if (m == null) return result;
-    final queue = <({int x, int y, int distance})>[];
-    final key = '${parts[2]}|${parts[3]}';
-    final sx = int.tryParse(parts[2]) ?? 0;
-    final sy = int.tryParse(parts[3]) ?? 0;
-    if (m[key] != null) {
-      queue.add((x: sx, y: sy, distance: 0));
-      result[m[key]!] = 0;
-    }
-    while (queue.isNotEmpty) {
-      final item = queue.removeAt(0);
-      for (final delta in const [
-        [1, 0],
-        [-1, 0],
-        [0, 1],
-        [0, -1],
-      ]) {
-        final nx = item.x + delta[0];
-        final ny = item.y + delta[1];
-        final tileKey = m['$nx|$ny'];
-        if (tileKey != null && !result.containsKey(tileKey)) {
-          result[tileKey] = item.distance + 1;
-          queue.add((x: nx, y: ny, distance: item.distance + 1));
-        }
-      }
-    }
-    return result;
-  }
-
-  String? portTileInProvince(String provinceId) {
-    for (final entry in ports.entries) {
-      if (entry.key.startsWith('$provinceId|')) return entry.value;
-    }
-    return null;
-  }
-
-  Set<String> provinceSeaZones(String provinceId) {
-    final regionId = ProvinceId.regionIdFrom(provinceId);
-    final topology = topologyByRegion[regionId];
-    if (topology == null) return const <String>{};
-    final localProvinceId = ProvinceId.localIdFrom(provinceId);
-    final out = <String>{};
-    for (final edge in topology.edges) {
-      if (edge.id1 != localProvinceId && edge.id2 != localProvinceId) continue;
-      final other = edge.id1 == localProvinceId ? edge.id2 : edge.id1;
-      for (final node in topology.nodes) {
-        if (node.id == other && node.type == TopologyNodeType.seaZone) {
-          out.add(other);
-          break;
-        }
-      }
-    }
-    return out;
-  }
-
-  bool tileKeyAdjacentToProvinceSeaZone({
-    required String tileKey,
-    required String provinceId,
-    required Set<String> seaZoneIds,
-  }) {
-    if (seaZoneIds.isEmpty) return false;
-    final regionId = ProvinceId.regionIdFrom(provinceId);
-    final map = tileMapByRegion[regionId];
-    final topology = topologyByRegion[regionId];
-    if (map == null || topology == null) return false;
-    final parts = tileKey.split('|');
-    if (parts.length < 4) return false;
-    final x = int.tryParse(parts[2]);
-    final y = int.tryParse(parts[3]);
-    if (x == null || y == null) return false;
-
-    final provinceIds = topology.nodes
-        .where((n) => n.type == TopologyNodeType.province)
-        .map((n) => n.id)
-        .toSet();
-
-    for (final d in const [(0, -1), (1, 0), (0, 1), (-1, 0)]) {
-      final nx = x + d.$1;
-      final ny = y + d.$2;
-      if (nx < 0 || nx >= map.width || ny < 0 || ny >= map.height) continue;
-      final cellId = map.cell(nx, ny);
-      if (provinceIds.contains(cellId)) continue;
-      if (seaZoneIds.contains(cellId)) return true;
-    }
-    return false;
-  }
-
-  String? townTileKeyForProvince(Province p) {
-    final ownerId = p.ownerId;
-    final tiles = tileKeysByRegion[p.regionId]?[p.id] ?? [];
-    if (ownerId == null) {
-      if (tiles.isEmpty) return null;
-      final c = provinceTownCentroidFromTileKeys(tiles);
-      return pickTownTileByCentroidAndBfs(
-        candidates: tiles,
-        centroidX: c.x,
-        centroidY: c.y,
-        bfsFromCapital: const {},
-      );
-    }
-
-    final capProvinceId = capitalProvinceIdByOwner[ownerId];
-    final capTileKey = capitalTileKeyByOwner[ownerId];
-    if (p.id == capProvinceId && capTileKey != null) return capTileKey;
-    if (tiles.isEmpty) return null;
-
-    final centroid = provinceTownCentroidFromTileKeys(tiles);
-    final sameRegion =
-        capProvinceId != null &&
-        ProvinceId.regionIdFrom(capProvinceId) == p.regionId;
-    final regionTopology = topologyByRegion[p.regionId];
-    final isSeaBoundProvince =
-        regionTopology != null &&
-        isProvinceSeaBound(regionTopology, ProvinceId.localIdFrom(p.id));
-    if (isSeaBoundProvince) {
-      final seaZoneIds = provinceSeaZones(p.id);
-      final coastalCandidates = tiles
-          .where(
-            (tk) => tileKeyAdjacentToProvinceSeaZone(
-              tileKey: tk,
-              provinceId: p.id,
-              seaZoneIds: seaZoneIds,
-            ),
-          )
-          .toList();
-      if (coastalCandidates.isNotEmpty) {
-        final distances = sameRegion && capTileKey != null
-            ? bfsDistances(p.regionId, capTileKey)
-            : const <String, int>{};
-        return pickTownTileByCentroidAndBfs(
-          candidates: coastalCandidates,
-          centroidX: centroid.x,
-          centroidY: centroid.y,
-          bfsFromCapital: distances,
-        );
-      }
-      gameSetupLog.w(
-        'seaboard town fallback for province=${p.id}: '
-        'topology is sea-bound but no sea-zone-adjacent tile candidate found',
-      );
-    }
-    if (sameRegion && capTileKey != null) {
-      final distances = bfsDistances(p.regionId, capTileKey);
-      return pickTownTileByCentroidAndBfs(
-        candidates: tiles,
-        centroidX: centroid.x,
-        centroidY: centroid.y,
-        bfsFromCapital: distances,
-      );
-    }
-    final portTile = portTileInProvince(p.id);
-    if (portTile != null) return portTile;
-    return pickTownTileByCentroidAndBfs(
-      candidates: tiles,
-      centroidX: centroid.x,
-      centroidY: centroid.y,
-      bfsFromCapital: const {},
-    );
-  }
+  final capitals = _collectCapitalOwnershipData(game);
+  final coordToKey = _buildCoordToKeyByRegion(tileKeysByRegion);
 
   final oldProvinces = game.worldState.oldWorld.provinces.map((p) {
-    final tk = townTileKeyForProvince(p);
+    final tk = _townTileKeyForProvince(
+      p,
+      tileKeysByRegion: tileKeysByRegion,
+      ports: ports,
+      capitals: capitals,
+      coordToKeyByRegion: coordToKey,
+      topologyByRegion: topologyByRegion,
+      tileMapByRegion: tileMapByRegion,
+    );
     return tk != null ? p.copyWith(townTileKey: tk) : p;
   }).toList();
   final newProvinces = game.worldState.newWorld.provinces.map((p) {
-    final tk = townTileKeyForProvince(p);
+    final tk = _townTileKeyForProvince(
+      p,
+      tileKeysByRegion: tileKeysByRegion,
+      ports: ports,
+      capitals: capitals,
+      coordToKeyByRegion: coordToKey,
+      topologyByRegion: topologyByRegion,
+      tileMapByRegion: tileMapByRegion,
+    );
     return tk != null ? p.copyWith(townTileKey: tk) : p;
   }).toList();
 
@@ -233,5 +49,261 @@ Game assignProvinceTowns({
         units: game.worldState.newWorld.units,
       ),
     ),
+  );
+}
+
+({
+  Map<String, String> capitalTileKeyByOwner,
+  Map<String, String> capitalProvinceIdByOwner,
+})
+_collectCapitalOwnershipData(Game game) {
+  final capitalTileKeyByOwner = <String, String>{};
+  final capitalProvinceIdByOwner = <String, String>{};
+
+  void addCapital(
+    String ownerId,
+    String? provinceId,
+    CapitalTile? capitalTile,
+  ) {
+    if (provinceId == null || capitalTile == null) return;
+    capitalProvinceIdByOwner[ownerId] = provinceId;
+    capitalTileKeyByOwner[ownerId] = capitalTile.toTileKey();
+  }
+
+  for (final p in game.players) {
+    addCapital(p.id, p.capitalProvinceId, p.capitalTile);
+  }
+  for (final m in game.minorNations) {
+    addCapital(m.id, m.capitalProvinceId, m.capitalTile);
+  }
+  for (final t in game.tribes) {
+    addCapital(t.id, t.capitalProvinceId, t.capitalTile);
+  }
+
+  return (
+    capitalTileKeyByOwner: capitalTileKeyByOwner,
+    capitalProvinceIdByOwner: capitalProvinceIdByOwner,
+  );
+}
+
+Map<String, Map<String, String>> _buildCoordToKeyByRegion(
+  Map<String, Map<String, List<String>>> tileKeysByRegion,
+) {
+  final coordToKey = <String, Map<String, String>>{};
+  for (final regionEntry in tileKeysByRegion.entries) {
+    final regionId = regionEntry.key;
+    final byProvince = regionEntry.value;
+    final coordToTileKey = <String, String>{};
+    for (final list in byProvince.values) {
+      for (final tk in list) {
+        final parts = tk.split('|');
+        if (parts.length >= 4) {
+          coordToTileKey['${parts[2]}|${parts[3]}'] = tk;
+        }
+      }
+    }
+    coordToKey[regionId] = coordToTileKey;
+  }
+  return coordToKey;
+}
+
+Map<String, int> _bfsDistances({
+  required String regionId,
+  required String startTileKey,
+  required Map<String, Map<String, String>> coordToKeyByRegion,
+}) {
+  final result = <String, int>{};
+  final parts = startTileKey.split('|');
+  if (parts.length < 4) return result;
+  final coordToKey = coordToKeyByRegion[regionId];
+  if (coordToKey == null) return result;
+  final queue = <({int x, int y, int distance})>[];
+  final key = '${parts[2]}|${parts[3]}';
+  final sx = int.tryParse(parts[2]) ?? 0;
+  final sy = int.tryParse(parts[3]) ?? 0;
+  if (coordToKey[key] != null) {
+    queue.add((x: sx, y: sy, distance: 0));
+    result[coordToKey[key]!] = 0;
+  }
+  while (queue.isNotEmpty) {
+    final item = queue.removeAt(0);
+    for (final delta in const [
+      [1, 0],
+      [-1, 0],
+      [0, 1],
+      [0, -1],
+    ]) {
+      final nx = item.x + delta[0];
+      final ny = item.y + delta[1];
+      final tileKey = coordToKey['$nx|$ny'];
+      if (tileKey != null && !result.containsKey(tileKey)) {
+        result[tileKey] = item.distance + 1;
+        queue.add((x: nx, y: ny, distance: item.distance + 1));
+      }
+    }
+  }
+  return result;
+}
+
+String? _portTileInProvince(
+  String provinceId,
+  Map<String, String> portsByProvinceSeaboard,
+) {
+  for (final entry in portsByProvinceSeaboard.entries) {
+    if (entry.key.startsWith('$provinceId|')) return entry.value;
+  }
+  return null;
+}
+
+Set<String> _provinceSeaZones(
+  String provinceId,
+  Map<String, MapTopology> topologyByRegion,
+) {
+  final regionId = ProvinceId.regionIdFrom(provinceId);
+  final topology = topologyByRegion[regionId];
+  if (topology == null) return const <String>{};
+  final localProvinceId = ProvinceId.localIdFrom(provinceId);
+  final out = <String>{};
+  for (final edge in topology.edges) {
+    if (edge.id1 != localProvinceId && edge.id2 != localProvinceId) continue;
+    final other = edge.id1 == localProvinceId ? edge.id2 : edge.id1;
+    for (final node in topology.nodes) {
+      if (node.id == other && node.type == TopologyNodeType.seaZone) {
+        out.add(other);
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+bool _tileKeyAdjacentToProvinceSeaZone({
+  required String tileKey,
+  required String provinceId,
+  required Set<String> seaZoneIds,
+  required Map<String, TileMapResult> tileMapByRegion,
+  required Map<String, MapTopology> topologyByRegion,
+}) {
+  if (seaZoneIds.isEmpty) return false;
+  final regionId = ProvinceId.regionIdFrom(provinceId);
+  final map = tileMapByRegion[regionId];
+  final topology = topologyByRegion[regionId];
+  if (map == null || topology == null) return false;
+  final parts = tileKey.split('|');
+  if (parts.length < 4) return false;
+  final x = int.tryParse(parts[2]);
+  final y = int.tryParse(parts[3]);
+  if (x == null || y == null) return false;
+
+  final provinceIds = topology.nodes
+      .where((n) => n.type == TopologyNodeType.province)
+      .map((n) => n.id)
+      .toSet();
+
+  for (final d in const [(0, -1), (1, 0), (0, 1), (-1, 0)]) {
+    final nx = x + d.$1;
+    final ny = y + d.$2;
+    if (nx < 0 || nx >= map.width || ny < 0 || ny >= map.height) continue;
+    final cellId = map.cell(nx, ny);
+    if (provinceIds.contains(cellId)) continue;
+    if (seaZoneIds.contains(cellId)) return true;
+  }
+  return false;
+}
+
+String? _townTileKeyForProvince(
+  Province province, {
+  required Map<String, Map<String, List<String>>> tileKeysByRegion,
+  required Map<String, String> ports,
+  required ({
+    Map<String, String> capitalTileKeyByOwner,
+    Map<String, String> capitalProvinceIdByOwner,
+  })
+  capitals,
+  required Map<String, Map<String, String>> coordToKeyByRegion,
+  required Map<String, MapTopology> topologyByRegion,
+  required Map<String, TileMapResult> tileMapByRegion,
+}) {
+  final ownerId = province.ownerId;
+  final tiles = tileKeysByRegion[province.regionId]?[province.id] ?? [];
+  if (ownerId == null) {
+    if (tiles.isEmpty) return null;
+    final c = provinceTownCentroidFromTileKeys(tiles);
+    return pickTownTileByCentroidAndBfs(
+      candidates: tiles,
+      centroidX: c.x,
+      centroidY: c.y,
+      bfsFromCapital: const {},
+    );
+  }
+
+  final capitalProvinceId = capitals.capitalProvinceIdByOwner[ownerId];
+  final capitalTileKey = capitals.capitalTileKeyByOwner[ownerId];
+  if (province.id == capitalProvinceId && capitalTileKey != null) {
+    return capitalTileKey;
+  }
+  if (tiles.isEmpty) return null;
+
+  final centroid = provinceTownCentroidFromTileKeys(tiles);
+  final sameRegion =
+      capitalProvinceId != null &&
+      ProvinceId.regionIdFrom(capitalProvinceId) == province.regionId;
+  final regionTopology = topologyByRegion[province.regionId];
+  final isSeaBoundProvince =
+      regionTopology != null &&
+      isProvinceSeaBound(regionTopology, ProvinceId.localIdFrom(province.id));
+  if (isSeaBoundProvince) {
+    final seaZoneIds = _provinceSeaZones(province.id, topologyByRegion);
+    final coastalCandidates = tiles
+        .where(
+          (tk) => _tileKeyAdjacentToProvinceSeaZone(
+            tileKey: tk,
+            provinceId: province.id,
+            seaZoneIds: seaZoneIds,
+            tileMapByRegion: tileMapByRegion,
+            topologyByRegion: topologyByRegion,
+          ),
+        )
+        .toList();
+    if (coastalCandidates.isNotEmpty) {
+      final distances = sameRegion && capitalTileKey != null
+          ? _bfsDistances(
+              regionId: province.regionId,
+              startTileKey: capitalTileKey,
+              coordToKeyByRegion: coordToKeyByRegion,
+            )
+          : const <String, int>{};
+      return pickTownTileByCentroidAndBfs(
+        candidates: coastalCandidates,
+        centroidX: centroid.x,
+        centroidY: centroid.y,
+        bfsFromCapital: distances,
+      );
+    }
+    gameSetupLog.w(
+      'seaboard town fallback for province=${province.id}: '
+      'topology is sea-bound but no sea-zone-adjacent tile candidate found',
+    );
+  }
+  if (sameRegion && capitalTileKey != null) {
+    final distances = _bfsDistances(
+      regionId: province.regionId,
+      startTileKey: capitalTileKey,
+      coordToKeyByRegion: coordToKeyByRegion,
+    );
+    return pickTownTileByCentroidAndBfs(
+      candidates: tiles,
+      centroidX: centroid.x,
+      centroidY: centroid.y,
+      bfsFromCapital: distances,
+    );
+  }
+  final portTile = _portTileInProvince(province.id, ports);
+  if (portTile != null) return portTile;
+  return pickTownTileByCentroidAndBfs(
+    candidates: tiles,
+    centroidX: centroid.x,
+    centroidY: centroid.y,
+    bfsFromCapital: const {},
   );
 }

--- a/tool/function_size_allowlist.yaml
+++ b/tool/function_size_allowlist.yaml
@@ -91,9 +91,6 @@ allowed_over_20:
   - file: packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
     symbol: applyQuickBattleResultToGame
     max_measured_lines: 59
-  - file: packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
-    symbol: resolveQuickBattle
-    max_measured_lines: 237
   - file: packages/colonizethis_logic/lib/src/diplomacy/alliance_resolver.dart
     symbol: _absorbGreatPowerIntoGp
     max_measured_lines: 111

--- a/tool/function_size_allowlist.yaml
+++ b/tool/function_size_allowlist.yaml
@@ -532,9 +532,6 @@ allowed_over_20:
   - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
     symbol: _applyNaming::assignProvinceNames
     max_measured_lines: 55
-  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers_towns.dart
-    symbol: assignProvinceTowns
-    max_measured_lines: 225
   - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
     symbol: _assignProvinceTowns::bfsDistances
     max_measured_lines: 37


### PR DESCRIPTION
## Summary
- Refactor `resolveQuickBattle` to centralize repeated finish+log paths in `_finishAndLogQuickBattleResult`.
- Keep quick-battle behavior unchanged while reducing measured lines so `resolveQuickBattle` is now compliant with the 200-line function-size threshold.
- Remove the obsolete `resolveQuickBattle` row from `tool/function_size_allowlist.yaml`.

## Test plan
- [x] `dart run tool/check_function_size.dart`
- [x] `dart test packages/colonizethis_logic/test/quick_battle_resolver_test.dart packages/colonizethis_logic/test/quick_battle_siege_scenarios_test.dart`

Refs #1912

Made with [Cursor](https://cursor.com)