### PR TITLE
refactor(logic): importable setup town modules (Refs #1879)

### DIFF
--- a/SPEC/program/game-setup-pipeline.md
+++ b/SPEC/program/game-setup-pipeline.md
@@ -56,6 +56,7 @@ Entry point: `runInitGame(config, options)` in colonizethis_logic. CLI tool: [in
 - **Phase:** Pre-game (before turn 0).
 - **Upstream:** colonizethis_data (config, ruleset merge), colonizethis_map (map generation).
 - **Downstream:** App (`GameService.createNewGame`, `GameService.createNewGameAsync` with coarse progress per SPEC/ui/game-initializing.md), init_game CLI tool, ctdev debug views.
+- **Town helpers (importable):** `assignProvinceTowns` lives in `packages/colonizethis_logic/lib/src/setup/game_setup_helpers_towns.dart`; centroid/BFS ranking helpers live in `game_setup_town_tile_ranking.dart`. `game_setup_helpers.dart` re-exports town APIs for existing `import 'game_setup_helpers.dart'` barrels while retaining `part` fragments for naming/bootstrap until those are split the same way.
 
 ## Constraints
 

--- a/packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
@@ -1,17 +1,16 @@
-import 'dart:math';
-
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
 import '../world/naval.dart';
 import '../world/ship_instance_allocate.dart';
-import 'capital_choice.dart';
 import 'game_setup_context.dart';
 import 'game_setup_create.dart';
+import 'game_setup_helpers_towns.dart';
 import 'province_name_fallback.dart';
 
-part 'game_setup_helpers_towns.dart';
+export 'game_setup_helpers_towns.dart';
+
 part 'game_setup_helpers_naming.dart';
 part 'game_setup_helpers_bootstrap.dart';
 
@@ -127,66 +126,6 @@ List<String> provinceIdsFromTopology(MapTopology topology) {
       .where((n) => n.type == TopologyNodeType.province)
       .map((n) => n.id)
       .toList();
-}
-
-({int x, int y}) provinceTownCentroidFromTileKeys(List<String> tiles) {
-  final c = roundedCentroidFromTileKeys(tiles);
-  if (c != null) return c;
-  final xy = parseTileKeyCellXY(tiles.first);
-  return (x: xy?.$1 ?? 0, y: xy?.$2 ?? 0);
-}
-
-int compareTownTileCandidates(
-  String a,
-  String b, {
-  required int centroidX,
-  required int centroidY,
-  required Map<String, int> bfsFromCapital,
-}) {
-  final da = tileDistanceSquaredToCentroid(a, centroidX: centroidX, centroidY: centroidY);
-  final db = tileDistanceSquaredToCentroid(b, centroidX: centroidX, centroidY: centroidY);
-  if (da != db) return da.compareTo(db);
-  final ba = bfsDistanceOrUnreachable(a, bfsFromCapital);
-  final bb = bfsDistanceOrUnreachable(b, bfsFromCapital);
-  if (ba != bb) return ba.compareTo(bb);
-  return a.compareTo(b);
-}
-
-int tileDistanceSquaredToCentroid(
-  String tileKey, {
-  required int centroidX,
-  required int centroidY,
-}) {
-  final xy = parseTileKeyCellXY(tileKey);
-  if (xy == null) return 1 << 30;
-  final dx = xy.$1 - centroidX;
-  final dy = xy.$2 - centroidY;
-  return dx * dx + dy * dy;
-}
-
-int bfsDistanceOrUnreachable(String tileKey, Map<String, int> bfsFromCapital) {
-  const unreachable = 999999;
-  return bfsFromCapital[tileKey] ?? unreachable;
-}
-
-String pickTownTileByCentroidAndBfs({
-  required List<String> candidates,
-  required int centroidX,
-  required int centroidY,
-  required Map<String, int> bfsFromCapital,
-}) {
-  return candidates.reduce(
-    (best, candidate) => compareTownTileCandidates(
-          candidate,
-          best,
-          centroidX: centroidX,
-          centroidY: centroidY,
-          bfsFromCapital: bfsFromCapital,
-        ) <
-        0
-        ? candidate
-        : best,
-  );
 }
 
 /// Re-runs §7d province town assignment after the caller mutates provinces or maps.

--- a/packages/colonizethis_logic/lib/src/setup/game_setup_helpers_towns.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup_helpers_towns.dart
@@ -1,4 +1,9 @@
-part of 'game_setup_helpers.dart';
+// SPEC/program/game-setup-pipeline.md §7d — province town assignment (importable library).
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'game_setup_context.dart';
+import 'game_setup_town_tile_ranking.dart';
 
 /// 7d. Province town assignment. For each province, set townTileKey: capital province = capital tile;
 /// otherwise branch eligibility (seaboard, same-region BFS, overseas port) then centroid tie-break,

--- a/packages/colonizethis_logic/lib/src/setup/game_setup_town_tile_ranking.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup_town_tile_ranking.dart
@@ -1,0 +1,62 @@
+// SPEC/program/game-setup-pipeline.md §7d — town tile ranking (centroid, BFS tie-break).
+import 'package:colonizethis_data/colonizethis_data.dart';
+
+({int x, int y}) provinceTownCentroidFromTileKeys(List<String> tiles) {
+  final c = roundedCentroidFromTileKeys(tiles);
+  if (c != null) return c;
+  final xy = parseTileKeyCellXY(tiles.first);
+  return (x: xy?.$1 ?? 0, y: xy?.$2 ?? 0);
+}
+
+int compareTownTileCandidates(
+  String a,
+  String b, {
+  required int centroidX,
+  required int centroidY,
+  required Map<String, int> bfsFromCapital,
+}) {
+  final da = tileDistanceSquaredToCentroid(a, centroidX: centroidX, centroidY: centroidY);
+  final db = tileDistanceSquaredToCentroid(b, centroidX: centroidX, centroidY: centroidY);
+  if (da != db) return da.compareTo(db);
+  final ba = bfsDistanceOrUnreachable(a, bfsFromCapital);
+  final bb = bfsDistanceOrUnreachable(b, bfsFromCapital);
+  if (ba != bb) return ba.compareTo(bb);
+  return a.compareTo(b);
+}
+
+int tileDistanceSquaredToCentroid(
+  String tileKey, {
+  required int centroidX,
+  required int centroidY,
+}) {
+  final xy = parseTileKeyCellXY(tileKey);
+  if (xy == null) return 1 << 30;
+  final dx = xy.$1 - centroidX;
+  final dy = xy.$2 - centroidY;
+  return dx * dx + dy * dy;
+}
+
+int bfsDistanceOrUnreachable(String tileKey, Map<String, int> bfsFromCapital) {
+  const unreachable = 999999;
+  return bfsFromCapital[tileKey] ?? unreachable;
+}
+
+String pickTownTileByCentroidAndBfs({
+  required List<String> candidates,
+  required int centroidX,
+  required int centroidY,
+  required Map<String, int> bfsFromCapital,
+}) {
+  return candidates.reduce(
+    (best, candidate) => compareTownTileCandidates(
+          candidate,
+          best,
+          centroidX: centroidX,
+          centroidY: centroidY,
+          bfsFromCapital: bfsFromCapital,
+        ) <
+        0
+        ? candidate
+        : best,
+  );
+}

--- a/packages/colonizethis_logic/test/game_setup_town_tile_ranking_test.dart
+++ b/packages/colonizethis_logic/test/game_setup_town_tile_ranking_test.dart
@@ -1,0 +1,50 @@
+import 'package:colonizethis_logic/src/setup/game_setup_town_tile_ranking.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('compareTownTileCandidates', () {
+    test('prefers tile closer to centroid when BFS equal', () {
+      const cx = 5;
+      const cy = 5;
+      const bfs = <String, int>{};
+      final a = 'r|p|5|5';
+      final b = 'r|p|0|0';
+      expect(
+        compareTownTileCandidates(a, b, centroidX: cx, centroidY: cy, bfsFromCapital: bfs),
+        lessThan(0),
+      );
+    });
+
+    test('breaks ties with lexicographic tile key when centroid and BFS tie', () {
+      const cx = 5;
+      const cy = 5;
+      const bfs = <String, int>{};
+      final closerLex = 'r|p|4|5';
+      final fartherLex = 'r|p|6|5';
+      expect(
+        compareTownTileCandidates(
+          closerLex,
+          fartherLex,
+          centroidX: cx,
+          centroidY: cy,
+          bfsFromCapital: bfs,
+        ),
+        lessThan(0),
+      );
+    });
+  });
+
+  group('pickTownTileByCentroidAndBfs', () {
+    test('returns sole candidate', () {
+      expect(
+        pickTownTileByCentroidAndBfs(
+          candidates: const ['r|p|0|0'],
+          centroidX: 0,
+          centroidY: 0,
+          bfsFromCapital: const {},
+        ),
+        'r|p|0|0',
+      );
+    });
+  });
+}

--- a/tool/function_size_allowlist.yaml
+++ b/tool/function_size_allowlist.yaml
@@ -524,9 +524,6 @@ allowed_over_20:
     symbol: _buildPoliticalGlyphByPlayerId
     max_measured_lines: 48
   - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
-    symbol: _compareTownTileCandidates
-    max_measured_lines: 23
-  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
     symbol: _landmassesSortedDescDiag
     max_measured_lines: 23
   - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
@@ -540,9 +537,6 @@ allowed_over_20:
     max_measured_lines: 22
   - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
     symbol: _namingResolveEmptyPoolNonCapital
-    max_measured_lines: 22
-  - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
-    symbol: _pickTownTileByCentroidAndBfs
     max_measured_lines: 22
   - file: packages/colonizethis_logic/lib/src/setup/game_setup_helpers.dart
     symbol: buildCombinedTopology


### PR DESCRIPTION
## Summary

Next slice for **#1879**: `game_setup_helpers_towns.dart` is no longer a `part` of `game_setup_helpers.dart`. Town tile ranking helpers live in a new importable library `game_setup_town_tile_ranking.dart`. `game_setup_helpers.dart` still hosts naming/bootstrap `part` files and **re-exports** town APIs so existing `import 'game_setup_helpers.dart'` call sites stay unchanged.

## Acceptance criteria (this PR)

- §7d town assignment can be imported from `game_setup_helpers_towns.dart` without pulling the whole helpers part-library graph.
- Centroid/BFS ranking is unit-tested in isolation.
- No new function-size allowlist rows; removed two **stale** rows (wrong symbol names, unused).

## SPEC

- `SPEC/program/game-setup-pipeline.md` — Integration bullet documents importable town modules.

## Tests

- `dart test` on: `game_setup_town_tile_ranking_test.dart`, `game_setup_creation_and_assignment_test.dart`, `game_setup_landmass_visibility_and_gp_test.dart`, `game_setup_variants_and_naming_test.dart`, `characterization/game_setup_snapshot_test.dart`
- `dart run tool/check_function_size.dart`
- `dart run tool/check_part_unit_size.dart`

## Deferred

- Convert `game_setup_helpers_naming.dart` / `game_setup_helpers_bootstrap.dart` from `part` to standalone libraries in a follow-up PR.

Refs #1879

Made with [Cursor](https://cursor.com)