### PR TITLE
refactor(map): extract region view helpers and test land seed pass

### DIFF
--- a/packages/colonizethis_map/lib/src/init_game_map_view_builder.dart
+++ b/packages/colonizethis_map/lib/src/init_game_map_view_builder.dart
@@ -418,6 +418,130 @@ RegionMapViewData _buildRegionViewData({
   }
 
   final tileState = game.worldState.tileState;
+  final cells = _buildCellViewDataList(
+    regionId: regionId,
+    tileMap: tileMap,
+    seaZoneIds: seaZoneIds,
+    tileState: tileState,
+    ownerByProvinceId: ownerByProvinceId,
+    provinceDisplayNameById: provinceDisplayNameById,
+    visibilityByTile: visibilityByTile,
+    resourceExtractionUnitsByTile: resourceExtractionUnitsByTile,
+    resourceExtractionEffectiveUnitsByTile:
+        resourceExtractionEffectiveUnitsByTile,
+    resourceExtractionBlockedUnitsByTile: resourceExtractionBlockedUnitsByTile,
+  );
+
+  // Capital markers.
+  final capitals = _buildCapitalMarkers(game: game, regionId: regionId);
+
+  // Province id → representative tile (x,y) for units overlay.
+  final provinceToTile = _buildProvinceToRepresentativeTile(
+    tileMap: tileMap,
+    regionId: regionId,
+    seaZoneIds: seaZoneIds,
+  );
+
+  // Unit markers: one per unit, placed at province representative tile.
+  final unitOverlayData = _buildUnitAndCivilianMarkerData(
+    game: game,
+    regionId: regionId,
+    isOldWorld: isOldWorld,
+    provinces: provinces,
+    cells: cells,
+    provinceToTile: provinceToTile,
+  );
+  final unitMarkers = unitOverlayData.unitMarkers;
+  final playerOwnedCivilianTileMarkers = unitOverlayData.civilianTileMarkers;
+  final provincePresenceById = unitOverlayData.provincePresenceById;
+
+  // Port markers from world state.
+  final ports = _buildPortMarkers(
+    regionId: regionId,
+    portsByProvinceSeaboard: game.worldState.portsByProvinceSeaboard,
+  );
+
+  // Determine coastal provinces from topology edges (P<->S connections).
+  // A province is coastal if it has an edge to any sea zone node in [seaZoneIds].
+  final coastalProvinceIds = _buildCoastalProvinceIds(
+    topology: topology,
+    seaZoneIds: seaZoneIds,
+  );
+
+  // Town markers: one per province with a town, at the town's tile position.
+  final towns = _buildTownMarkers(
+    game: game,
+    regionId: regionId,
+    provinces: provinces,
+    ports: ports,
+    coastalProvinceIds: coastalProvinceIds,
+    tileMap: tileMap,
+    seaZoneIds: seaZoneIds,
+  );
+
+  // Sea zone id → representative tile (x,y) for warp zone markers.
+  final seaZoneToTile = _buildSeaZoneToRepresentativeTile(
+    tileMap: tileMap,
+    seaZoneIds: seaZoneIds,
+  );
+
+  // Warp zone markers: one per warp link for this region.
+  final warpMarkers = _buildWarpMarkers(
+    regionId: regionId,
+    seaZoneToTile: seaZoneToTile,
+    warpLinks: warpLinks,
+  );
+
+  // Ship presence counts by in-port province.
+  _applyInPortFleetShipCounts(
+    fleets: game.worldState.fleets,
+    regionId: regionId,
+    provincePresenceById: provincePresenceById,
+  );
+
+  final fleetTileMarkers = _buildFleetTileMarkersForRegion(
+    game: game,
+    regionId: regionId,
+    provinces: provinces,
+    tileMap: tileMap,
+    seaZoneIds: seaZoneIds,
+  );
+
+  return RegionMapViewData(
+    regionId: regionId,
+    width: tileMap.width,
+    height: tileMap.height,
+    cellSize: cellSize,
+    cells: cells,
+    capitalMarkers: capitals,
+    portMarkers: ports,
+    factionColors: factionColors,
+    greatPowerFactionIds: greatPowerFactionIds,
+    terrainColors: terrainColors,
+    unitMarkers: unitMarkers,
+    civilianTileMarkers: playerOwnedCivilianTileMarkers,
+    fleetTileMarkers: fleetTileMarkers,
+    warpMarkers: warpMarkers,
+    townMarkers: towns,
+    provinceUnitPresenceByProvinceId: provincePresenceById,
+    provincePoliticalOwnerByPrefixedProvinceId:
+        provincePoliticalOwnerByPrefixedProvinceId,
+    seaZoneDisplayNameByPrefixedId: game.worldState.seaZoneDisplayNameById,
+  );
+}
+
+List<CellViewData> _buildCellViewDataList({
+  required String regionId,
+  required TileMapResult tileMap,
+  required Set<String> seaZoneIds,
+  required TileMapState tileState,
+  required Map<String, String> ownerByProvinceId,
+  required Map<String, String> provinceDisplayNameById,
+  required Map<String, TileVisibility>? visibilityByTile,
+  required Map<String, int>? resourceExtractionUnitsByTile,
+  required Map<String, int>? resourceExtractionEffectiveUnitsByTile,
+  required Map<String, int>? resourceExtractionBlockedUnitsByTile,
+}) {
   final cells = <CellViewData>[];
   for (var y = 0; y < tileMap.height; y++) {
     for (var x = 0; x < tileMap.width; x++) {
@@ -425,7 +549,6 @@ RegionMapViewData _buildRegionViewData({
       final isSea = seaZoneIds.contains(localId);
       final terrain = tileMap.terrainAt(x, y);
       final resource = tileMap.resourceAt(x, y);
-      // Tile key for improvement/road lookup: regionId|provinceId|x|y (provinceId = regionCellId for land).
       final tileKey = '$regionId|$localId|$x|$y';
       final improvement = isSea ? null : tileState.improvementLevel(tileKey);
       final road = isSea ? null : tileState.roadLevel(tileKey);
@@ -469,8 +592,13 @@ RegionMapViewData _buildRegionViewData({
       );
     }
   }
+  return cells;
+}
 
-  // Capital markers.
+List<CapitalMarkerView> _buildCapitalMarkers({
+  required Game game,
+  required String regionId,
+}) {
   final capitals = <CapitalMarkerView>[];
   for (final p in game.players) {
     final cap = p.capitalTile;
@@ -511,8 +639,14 @@ RegionMapViewData _buildRegionViewData({
       );
     }
   }
+  return capitals;
+}
 
-  // Province id → representative tile (x,y) for units overlay.
+Map<String, (int x, int y)> _buildProvinceToRepresentativeTile({
+  required TileMapResult tileMap,
+  required String regionId,
+  required Set<String> seaZoneIds,
+}) {
   final provinceToTile = <String, (int x, int y)>{};
   for (var y = 0; y < tileMap.height; y++) {
     for (var x = 0; x < tileMap.width; x++) {
@@ -521,13 +655,25 @@ RegionMapViewData _buildRegionViewData({
         continue;
       }
       final fullProvinceId = ProvinceId.full(regionId, localId);
-      if (!provinceToTile.containsKey(fullProvinceId)) {
-        provinceToTile[fullProvinceId] = (x, y);
-      }
+      provinceToTile.putIfAbsent(fullProvinceId, () => (x, y));
     }
   }
+  return provinceToTile;
+}
 
-  // Unit markers: one per unit, placed at province representative tile.
+({
+  List<UnitMarkerView> unitMarkers,
+  List<CivilianTileMarkerView> civilianTileMarkers,
+  Map<String, ProvinceUnitPresenceView> provincePresenceById,
+})
+_buildUnitAndCivilianMarkerData({
+  required Game game,
+  required String regionId,
+  required bool isOldWorld,
+  required List<Province> provinces,
+  required List<CellViewData> cells,
+  required Map<String, (int x, int y)> provinceToTile,
+}) {
   final unitMarkers = <UnitMarkerView>[];
   final civilianUnitsByTileKey = <String, List<Unit>>{};
   final playerOwnedCivilianTileMarkers = <CivilianTileMarkerView>[];
@@ -545,7 +691,6 @@ RegionMapViewData _buildRegionViewData({
     );
   }
 
-  // Province intel visibility: true when any tile in that province is currently visible.
   for (final cell in cells) {
     if (cell.isSea || cell.visibility != TileVisibility.visible) {
       continue;
@@ -650,16 +795,21 @@ RegionMapViewData _buildRegionViewData({
     return a.tileKey.compareTo(b.tileKey);
   });
 
-  // Port markers from world state.
+  return (
+    unitMarkers: unitMarkers,
+    civilianTileMarkers: playerOwnedCivilianTileMarkers,
+    provincePresenceById: provincePresenceById,
+  );
+}
+
+List<PortMarkerView> _buildPortMarkers({
+  required String regionId,
+  required Map<String, String> portsByProvinceSeaboard,
+}) {
   final ports = <PortMarkerView>[];
-  final portsByProvinceSeaboard = game.worldState.portsByProvinceSeaboard;
   portsByProvinceSeaboard.forEach((key, tileKey) {
     final parts = tileKey.split('|');
-    if (parts.length < 4) {
-      return;
-    }
-    final regId = parts[0];
-    if (regId != regionId) {
+    if (parts.length < 4 || parts[0] != regionId) {
       return;
     }
     final fromKey = localProvinceIdFromPortsSeaboardKey(key, regionId);
@@ -679,9 +829,13 @@ RegionMapViewData _buildRegionViewData({
       ),
     );
   });
+  return ports;
+}
 
-  // Determine coastal provinces from topology edges (P<->S connections).
-  // A province is coastal if it has an edge to any sea zone node in [seaZoneIds].
+Set<String> _buildCoastalProvinceIds({
+  required MapTopology topology,
+  required Set<String> seaZoneIds,
+}) {
   final coastalProvinceIds = <String>{};
   for (final edge in topology.edges) {
     final id1Sea = seaZoneIds.contains(edge.id1);
@@ -690,8 +844,18 @@ RegionMapViewData _buildRegionViewData({
       coastalProvinceIds.add(id1Sea ? edge.id2 : edge.id1);
     }
   }
+  return coastalProvinceIds;
+}
 
-  // Town markers: one per province with a town, at the town's tile position.
+List<TownMarkerView> _buildTownMarkers({
+  required Game game,
+  required String regionId,
+  required List<Province> provinces,
+  required List<PortMarkerView> ports,
+  required Set<String> coastalProvinceIds,
+  required TileMapResult tileMap,
+  required Set<String> seaZoneIds,
+}) {
   final towns = <TownMarkerView>[];
   final portProvinceIds = ports.map((p) => p.provinceId).toSet();
   for (final p in provinces) {
@@ -700,11 +864,7 @@ RegionMapViewData _buildRegionViewData({
       continue;
     }
     final parts = townTileKey.split('|');
-    if (parts.length < 4) {
-      continue;
-    }
-    final regId = parts[0];
-    if (regId != regionId) {
+    if (parts.length < 4 || parts[0] != regionId) {
       continue;
     }
     final x = int.tryParse(parts[2]);
@@ -744,8 +904,13 @@ RegionMapViewData _buildRegionViewData({
       ),
     );
   }
+  return towns;
+}
 
-  // Sea zone id → representative tile (x,y) for warp zone markers.
+Map<String, (int x, int y)> _buildSeaZoneToRepresentativeTile({
+  required TileMapResult tileMap,
+  required Set<String> seaZoneIds,
+}) {
   final seaZoneToTile = <String, (int x, int y)>{};
   for (var y = 0; y < tileMap.height; y++) {
     for (var x = 0; x < tileMap.width; x++) {
@@ -753,51 +918,64 @@ RegionMapViewData _buildRegionViewData({
       if (!seaZoneIds.contains(localId)) {
         continue;
       }
-      if (!seaZoneToTile.containsKey(localId)) {
-        seaZoneToTile[localId] = (x, y);
-      }
+      seaZoneToTile.putIfAbsent(localId, () => (x, y));
     }
   }
+  return seaZoneToTile;
+}
 
-  // Warp zone markers: one per warp link for this region.
+List<WarpMarkerView> _buildWarpMarkers({
+  required String regionId,
+  required Map<String, (int x, int y)> seaZoneToTile,
+  required List<WarpLink>? warpLinks,
+}) {
   final warpMarkers = <WarpMarkerView>[];
-  if (warpLinks != null) {
-    for (final link in warpLinks) {
-      // Check if this link involves the current region (either as source or destination).
-      if (link.regionId == regionId) {
-        // This region is the source of the warp link.
-        final tile = seaZoneToTile[link.seaZoneId];
-        if (tile != null) {
-          warpMarkers.add(
-            WarpMarkerView(
-              x: tile.$1,
-              y: tile.$2,
-              seaZoneId: link.seaZoneId,
-              otherRegionId: link.otherRegionId,
-              otherSeaZoneId: link.otherSeaZoneId,
-            ),
-          );
-        }
-      } else if (link.otherRegionId == regionId) {
-        // This region is the destination of the warp link (reverse direction).
-        final tile = seaZoneToTile[link.otherSeaZoneId];
-        if (tile != null) {
-          warpMarkers.add(
-            WarpMarkerView(
-              x: tile.$1,
-              y: tile.$2,
-              seaZoneId: link.otherSeaZoneId,
-              otherRegionId: link.regionId,
-              otherSeaZoneId: link.seaZoneId,
-            ),
-          );
-        }
-      }
-    }
+  if (warpLinks == null) {
+    return warpMarkers;
   }
+  for (final link in warpLinks) {
+    if (link.regionId == regionId) {
+      final tile = seaZoneToTile[link.seaZoneId];
+      if (tile == null) {
+        continue;
+      }
+      warpMarkers.add(
+        WarpMarkerView(
+          x: tile.$1,
+          y: tile.$2,
+          seaZoneId: link.seaZoneId,
+          otherRegionId: link.otherRegionId,
+          otherSeaZoneId: link.otherSeaZoneId,
+        ),
+      );
+      continue;
+    }
+    if (link.otherRegionId != regionId) {
+      continue;
+    }
+    final tile = seaZoneToTile[link.otherSeaZoneId];
+    if (tile == null) {
+      continue;
+    }
+    warpMarkers.add(
+      WarpMarkerView(
+        x: tile.$1,
+        y: tile.$2,
+        seaZoneId: link.otherSeaZoneId,
+        otherRegionId: link.regionId,
+        otherSeaZoneId: link.seaZoneId,
+      ),
+    );
+  }
+  return warpMarkers;
+}
 
-  // Ship presence counts by in-port province.
-  for (final fleet in game.worldState.fleets) {
+void _applyInPortFleetShipCounts({
+  required List<Fleet> fleets,
+  required String regionId,
+  required Map<String, ProvinceUnitPresenceView> provincePresenceById,
+}) {
+  for (final fleet in fleets) {
     if (fleet.regionId != regionId || !fleet.isInPort) {
       continue;
     }
@@ -816,34 +994,4 @@ RegionMapViewData _buildRegionViewData({
       intelVisible: current.intelVisible,
     );
   }
-
-  final fleetTileMarkers = _buildFleetTileMarkersForRegion(
-    game: game,
-    regionId: regionId,
-    provinces: provinces,
-    tileMap: tileMap,
-    seaZoneIds: seaZoneIds,
-  );
-
-  return RegionMapViewData(
-    regionId: regionId,
-    width: tileMap.width,
-    height: tileMap.height,
-    cellSize: cellSize,
-    cells: cells,
-    capitalMarkers: capitals,
-    portMarkers: ports,
-    factionColors: factionColors,
-    greatPowerFactionIds: greatPowerFactionIds,
-    terrainColors: terrainColors,
-    unitMarkers: unitMarkers,
-    civilianTileMarkers: playerOwnedCivilianTileMarkers,
-    fleetTileMarkers: fleetTileMarkers,
-    warpMarkers: warpMarkers,
-    townMarkers: towns,
-    provinceUnitPresenceByProvinceId: provincePresenceById,
-    provincePoliticalOwnerByPrefixedProvinceId:
-        provincePoliticalOwnerByPrefixedProvinceId,
-    seaZoneDisplayNameByPrefixedId: game.worldState.seaZoneDisplayNameById,
-  );
 }

--- a/packages/colonizethis_map/lib/src/init_game_map_view_builder.dart
+++ b/packages/colonizethis_map/lib/src/init_game_map_view_builder.dart
@@ -715,13 +715,11 @@ _buildUnitAndCivilianMarkerData({
     final isPlayerOwnedCivilian =
         humanPlayerIds.contains(u.ownerId) && _isCivilianUnitType(u.type);
     if (isPlayerOwnedCivilian) {
-      final tileKey = u.tileKey;
-      if (tileKey != null && tileKey.isNotEmpty) {
-        final parts = tileKey.split('|');
-        if (parts.length >= 4 && parts[0] == regionId) {
-          civilianUnitsByTileKey.putIfAbsent(tileKey, () => []).add(u);
-        }
-      }
+      _addCivilianUnitToTileKeyBucket(
+        unit: u,
+        regionId: regionId,
+        civilianUnitsByTileKey: civilianUnitsByTileKey,
+      );
     }
 
     final tile = provinceToTile[u.locationProvinceId];
@@ -800,6 +798,22 @@ _buildUnitAndCivilianMarkerData({
     civilianTileMarkers: playerOwnedCivilianTileMarkers,
     provincePresenceById: provincePresenceById,
   );
+}
+
+void _addCivilianUnitToTileKeyBucket({
+  required Unit unit,
+  required String regionId,
+  required Map<String, List<Unit>> civilianUnitsByTileKey,
+}) {
+  final tileKey = unit.tileKey;
+  if (tileKey == null || tileKey.isEmpty) {
+    return;
+  }
+  final parts = tileKey.split('|');
+  if (parts.length < 4 || parts[0] != regionId) {
+    return;
+  }
+  civilianUnitsByTileKey.putIfAbsent(tileKey, () => []).add(unit);
 }
 
 List<PortMarkerView> _buildPortMarkers({

--- a/packages/colonizethis_map/lib/src/tile_map_generator.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator.dart
@@ -27,7 +27,7 @@ abstract class _TileMapGeneratorShell {
 
 class _LandSeedService {
   _LandSeedService(this._impl);
-  final _TileMapGenLandSeeds _impl;
+  final TileMapGenLandSeeds _impl;
 
   (List<(int x, int y)>, List<(int x, int y)>, List<int>) placeLandSeeds(
     Map<String, int> provinceToContinent,
@@ -175,7 +175,7 @@ class _JoinAndSeaService {
 class TileMapGenerator extends _TileMapGeneratorShell {
   factory TileMapGenerator({TileMapParams params = const TileMapParams()}) {
     final graph = TileMapGridGraph(params);
-    final landImpl = _TileMapGenLandSeeds(params);
+    final landImpl = TileMapGenLandSeeds(params);
     final terrainImpl = _TileMapGenTerrainResource(params, graph);
     final joinImpl = _TileMapGenJoinSea(params, packageLogger(), graph);
     final lakesImpl = _TileMapGenLakesProvinces(params, graph, joinImpl);

--- a/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds.dart
@@ -1,8 +1,8 @@
 part of 'tile_map_generator.dart';
 
 /// Pass 2–3: land seed placement and assignment (organic and seed-before-assignment).
-class _TileMapGenLandSeeds {
-  _TileMapGenLandSeeds(this.params);
+class TileMapGenLandSeeds {
+  TileMapGenLandSeeds(this.params);
 
   final TileMapParams params;
 

--- a/packages/colonizethis_map/lib/src/tile_map_visualization.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_visualization.dart
@@ -128,6 +128,334 @@ Iterable<String> _regionIdsFromResult(TileMapResult result) sync* {
   }
 }
 
+int _legendLineCount({
+  required bool useTerrain,
+  required MapTopology topology,
+  required bool showContinentSeeds,
+  required bool showLandSeeds,
+  required bool useLandSeedByContinent,
+  required List<int>? landSeedContinentIndices,
+  required bool hasResourceGrid,
+}) {
+  var lines = useTerrain
+      ? _titleLines + 1 + TerrainType.values.length
+      : _titleLines + topology.nodes.length;
+  if (showContinentSeeds) {
+    lines += 1;
+  }
+  if (showLandSeeds) {
+    if (useLandSeedByContinent) {
+      final maxContinent = landSeedContinentIndices!.reduce(
+        (a, b) => a > b ? a : b,
+      );
+      lines += maxContinent + 1;
+    } else {
+      lines += 1;
+    }
+  }
+  if (hasResourceGrid) {
+    lines += Resource.values.length;
+  }
+  return lines;
+}
+
+void _drawMapCells({
+  required img.Image image,
+  required TileMapResult result,
+  required int cellSize,
+  required bool useTerrain,
+  required Set<String> seaZoneIds,
+  required Map<String, (int, int, int)>? regionColors,
+}) {
+  for (var y = 0; y < result.height; y++) {
+    for (var x = 0; x < result.width; x++) {
+      final id = result.cell(x, y);
+      final (r, g, b) = useTerrain
+          ? _terrainOrSeaCellColor(result, seaZoneIds, x, y, id)
+          : regionColors![id]!;
+      img.fillRect(
+        image,
+        x1: x * cellSize,
+        y1: y * cellSize,
+        x2: (x + 1) * cellSize - 1,
+        y2: (y + 1) * cellSize - 1,
+        color: image.getColor(r, g, b),
+      );
+    }
+  }
+}
+
+(int, int, int) _terrainOrSeaCellColor(
+  TileMapResult result,
+  Set<String> seaZoneIds,
+  int x,
+  int y,
+  String id,
+) {
+  final terrain = result.terrainAt(x, y);
+  if (seaZoneIds.contains(id) || terrain == null) {
+    return seaColorRgb;
+  }
+  return terrainColorRgb[terrain]!;
+}
+
+void _drawContinentSeedMarkers({
+  required img.Image image,
+  required List<(int x, int y)> continentSeedPositions,
+  required int cellSize,
+  required img.Color black,
+}) {
+  const radius = 5;
+  final fillColor = image.getColor(
+    continentSeedMarkerRgb.$1,
+    continentSeedMarkerRgb.$2,
+    continentSeedMarkerRgb.$3,
+  );
+  for (final (sx, sy) in continentSeedPositions) {
+    final cx = sx * cellSize + cellSize ~/ 2;
+    final cy = sy * cellSize + cellSize ~/ 2;
+    img.fillCircle(image, x: cx, y: cy, radius: radius, color: fillColor);
+    img.drawCircle(image, x: cx, y: cy, radius: radius, color: black);
+  }
+}
+
+void _drawLandSeedMarkers({
+  required img.Image image,
+  required List<(int x, int y)> landSeedPositions,
+  required int cellSize,
+  required img.Color black,
+  required bool useLandSeedByContinent,
+  required List<int>? landSeedContinentIndices,
+}) {
+  const radius = 3;
+  for (var i = 0; i < landSeedPositions.length; i++) {
+    final (sx, sy) = landSeedPositions[i];
+    final (r, g, b) = useLandSeedByContinent
+        ? regionPalette[landSeedContinentIndices![i] % regionPalette.length]
+        : landSeedMarkerRgb;
+    final cx = sx * cellSize + cellSize ~/ 2;
+    final cy = sy * cellSize + cellSize ~/ 2;
+    img.fillCircle(
+      image,
+      x: cx,
+      y: cy,
+      radius: radius,
+      color: image.getColor(r, g, b),
+    );
+    img.drawCircle(image, x: cx, y: cy, radius: radius, color: black);
+  }
+}
+
+void _drawRegionIdLabels({
+  required img.Image image,
+  required TileMapResult result,
+  required int cellSize,
+}) {
+  final regionIdColor = image.getColor(
+    regionIdLabelRgb.$1,
+    regionIdLabelRgb.$2,
+    regionIdLabelRgb.$3,
+  );
+  const idInset = 2;
+  for (var y = 0; y < result.height; y++) {
+    for (var x = 0; x < result.width; x++) {
+      final id = result.cell(x, y);
+      img.drawString(
+        image,
+        id,
+        font: img.arial14,
+        x: x * cellSize + idInset,
+        y: y * cellSize + idInset,
+        color: regionIdColor,
+      );
+    }
+  }
+}
+
+void _drawResourceLettersOnMap({
+  required img.Image image,
+  required TileMapResult result,
+  required int cellSize,
+  required img.Color black,
+}) {
+  for (final glyph in tileMapResourceGlyphs(result)) {
+    drawResourceLetterAtCellCenter(
+      image,
+      letter: glyph.letter,
+      cellX: glyph.x,
+      cellY: glyph.y,
+      cellSize: cellSize,
+      color: black,
+    );
+  }
+}
+
+void _drawMapLegend({
+  required img.Image image,
+  required TileMapResult result,
+  required MapTopology topology,
+  required int mapH,
+  required img.Color black,
+  required bool useTerrain,
+  required bool showContinentSeeds,
+  required bool showLandSeeds,
+  required bool useLandSeedByContinent,
+  required List<int>? landSeedContinentIndices,
+  required Map<String, (int, int, int)>? regionColors,
+}) {
+  final legendY0 = mapH + legendPadding;
+  if (useTerrain) {
+    _drawTerrainLegend(
+      image: image,
+      result: result,
+      black: black,
+      legendY0: legendY0,
+      showContinentSeeds: showContinentSeeds,
+      showLandSeeds: showLandSeeds,
+      useLandSeedByContinent: useLandSeedByContinent,
+      landSeedContinentIndices: landSeedContinentIndices,
+    );
+    return;
+  }
+  _drawRegionLegend(
+    image: image,
+    result: result,
+    topology: topology,
+    black: black,
+    legendY0: legendY0,
+    showContinentSeeds: showContinentSeeds,
+    showLandSeeds: showLandSeeds,
+    useLandSeedByContinent: useLandSeedByContinent,
+    landSeedContinentIndices: landSeedContinentIndices,
+    regionColors: regionColors!,
+  );
+}
+
+void _drawTerrainLegend({
+  required img.Image image,
+  required TileMapResult result,
+  required img.Color black,
+  required int legendY0,
+  required bool showContinentSeeds,
+  required bool showLandSeeds,
+  required bool useLandSeedByContinent,
+  required List<int>? landSeedContinentIndices,
+}) {
+  img.drawString(
+    image,
+    'Terrain. Black = land borders; light blue = sea zone borders.',
+    font: img.arial14,
+    x: legendPadding,
+    y: legendY0,
+    color: black,
+  );
+  img.drawString(
+    image,
+    'Colors = terrain type; sea = deep blue.',
+    font: img.arial14,
+    x: legendPadding,
+    y: legendY0 + legendLineHeight,
+    color: black,
+  );
+  var row = _titleLines;
+  drawLegendSwatch(
+    image,
+    legendY0 + row * legendLineHeight,
+    seaColorRgb.$1,
+    seaColorRgb.$2,
+    seaColorRgb.$3,
+  );
+  img.drawString(
+    image,
+    'Sea',
+    font: img.arial14,
+    x: legendPadding + swatchSize + swatchGap,
+    y: legendY0 + row * legendLineHeight,
+    color: black,
+  );
+  row++;
+  for (final t in TerrainType.values) {
+    final (r, g, b) = terrainColorRgb[t]!;
+    drawLegendSwatch(image, legendY0 + row * legendLineHeight, r, g, b);
+    img.drawString(
+      image,
+      _terrainLabel(t),
+      font: img.arial14,
+      x: legendPadding + swatchSize + swatchGap,
+      y: legendY0 + row * legendLineHeight,
+      color: black,
+    );
+    row++;
+  }
+  _drawOptionalLegendSections(
+    image,
+    legendY0,
+    row,
+    showContinentSeeds: showContinentSeeds,
+    showLandSeeds: showLandSeeds,
+    useLandSeedByContinent: useLandSeedByContinent,
+    landSeedContinentIndices: landSeedContinentIndices,
+    hasResourceGrid: result.resourceGrid != null,
+  );
+}
+
+void _drawRegionLegend({
+  required img.Image image,
+  required TileMapResult result,
+  required MapTopology topology,
+  required img.Color black,
+  required int legendY0,
+  required bool showContinentSeeds,
+  required bool showLandSeeds,
+  required bool useLandSeedByContinent,
+  required List<int>? landSeedContinentIndices,
+  required Map<String, (int, int, int)> regionColors,
+}) {
+  img.drawString(
+    image,
+    'Each cell = one tile. Colors = regions (provinces / sea zones).',
+    font: img.arial14,
+    x: legendPadding,
+    y: legendY0,
+    color: black,
+  );
+  img.drawString(
+    image,
+    'P = province (land), S = sea zone. Black = land borders; light blue = sea borders.',
+    font: img.arial14,
+    x: legendPadding,
+    y: legendY0 + legendLineHeight,
+    color: black,
+  );
+  final nodesSorted = List<TopologyNode>.from(topology.nodes)
+    ..sort((a, b) => a.id.compareTo(b.id));
+  var row = _titleLines;
+  for (final n in nodesSorted) {
+    final y = legendY0 + row * legendLineHeight;
+    final c = regionColors[n.id]!;
+    drawLegendSwatch(image, y, c.$1, c.$2, c.$3);
+    img.drawString(
+      image,
+      '${n.id} (${n.type == TopologyNodeType.province ? 'P' : 'S'})',
+      font: img.arial14,
+      x: legendPadding + swatchSize + swatchGap,
+      y: y,
+      color: black,
+    );
+    row++;
+  }
+  _drawOptionalLegendSections(
+    image,
+    legendY0,
+    row,
+    showContinentSeeds: showContinentSeeds,
+    showLandSeeds: showLandSeeds,
+    useLandSeedByContinent: useLandSeedByContinent,
+    landSeedContinentIndices: landSeedContinentIndices,
+    hasResourceGrid: result.resourceGrid != null,
+  );
+}
+
 /// Renders the tile map and legend to a PNG image; returns PNG bytes.
 /// When [result.terrainGrid] is present: fill by terrain (sea = deep blue), draw province/sea borders in black, terrain legend. Otherwise: region-colored fill and region legend.
 /// When [landSeedPositions] is provided, draws a marker at each cell center and adds a legend row for land seeds.
@@ -157,26 +485,18 @@ Uint8List renderTileMapToPng(
 
   final mapW = result.width * cellSize;
   final mapH = result.height * cellSize;
-
-  var legendLines = useTerrain
-      ? _titleLines +
-            1 +
-            TerrainType
-                .values
-                .length // title + Sea + terrains
-      : _titleLines + topology.nodes.length;
-  if (showContinentSeeds) legendLines += 1;
-  if (showLandSeeds) {
-    if (useLandSeedByContinent) {
-      final maxContinent = landSeedContinentIndices.reduce(
-        (a, b) => a > b ? a : b,
-      );
-      legendLines += maxContinent + 1;
-    } else {
-      legendLines += 1;
-    }
-  }
-  if (result.resourceGrid != null) legendLines += Resource.values.length;
+  final regionColors = useTerrain
+      ? null
+      : colorMapFromIds(_regionIdsFromResult(result));
+  final legendLines = _legendLineCount(
+    useTerrain: useTerrain,
+    topology: topology,
+    showContinentSeeds: showContinentSeeds,
+    showLandSeeds: showLandSeeds,
+    useLandSeedByContinent: useLandSeedByContinent,
+    landSeedContinentIndices: landSeedContinentIndices,
+    hasResourceGrid: result.resourceGrid != null,
+  );
   final legendHeight = legendPadding * 2 + legendLines * legendLineHeight;
   final totalWidth = mapW;
   final totalHeight = mapH + legendHeight;
@@ -191,225 +511,62 @@ Uint8List renderTileMapToPng(
   );
   image.clear(white);
 
-  // Draw map: fill each cell (terrain-based or region-based).
-  if (useTerrain) {
-    for (var y = 0; y < result.height; y++) {
-      for (var x = 0; x < result.width; x++) {
-        final id = result.cell(x, y);
-        final terrain = result.terrainAt(x, y);
-        final (r, g, b) = (seaZoneIds.contains(id) || terrain == null)
-            ? seaColorRgb
-            : terrainColorRgb[terrain]!;
-        final color = image.getColor(r, g, b);
-        img.fillRect(
-          image,
-          x1: x * cellSize,
-          y1: y * cellSize,
-          x2: (x + 1) * cellSize - 1,
-          y2: (y + 1) * cellSize - 1,
-          color: color,
-        );
-      }
-    }
-  } else {
-    final colors = colorMapFromIds(_regionIdsFromResult(result));
-    for (var y = 0; y < result.height; y++) {
-      for (var x = 0; x < result.width; x++) {
-        final id = result.cell(x, y);
-        final c = colors[id]!;
-        final color = image.getColor(c.$1, c.$2, c.$3);
-        img.fillRect(
-          image,
-          x1: x * cellSize,
-          y1: y * cellSize,
-          x2: (x + 1) * cellSize - 1,
-          y2: (y + 1) * cellSize - 1,
-          color: color,
-        );
-      }
-    }
-  }
+  _drawMapCells(
+    image: image,
+    result: result,
+    cellSize: cellSize,
+    useTerrain: useTerrain,
+    seaZoneIds: seaZoneIds,
+    regionColors: regionColors,
+  );
 
   // Borders: land borders (P–P, P–S) in black; sea zone borders (S–S) in light blue.
   drawBorders(image, result, seaZoneIds, cellSize, seaZoneBorderColor);
 
-  // Continent seed markers (distinct: larger, different color, black outline).
   if (showContinentSeeds) {
-    const radius = 5;
-    final fillColor = image.getColor(
-      continentSeedMarkerRgb.$1,
-      continentSeedMarkerRgb.$2,
-      continentSeedMarkerRgb.$3,
+    _drawContinentSeedMarkers(
+      image: image,
+      continentSeedPositions: continentSeedPositions!,
+      cellSize: cellSize,
+      black: black,
     );
-    for (final (sx, sy) in continentSeedPositions) {
-      final cx = sx * cellSize + cellSize ~/ 2;
-      final cy = sy * cellSize + cellSize ~/ 2;
-      img.fillCircle(image, x: cx, y: cy, radius: radius, color: fillColor);
-      img.drawCircle(image, x: cx, y: cy, radius: radius, color: black);
-    }
   }
 
-  // Land seed markers (cell centers); color by continent when indices provided. Small circles with black outline.
   if (showLandSeeds) {
-    const radius = 3;
-    for (var i = 0; i < landSeedPositions.length; i++) {
-      final (sx, sy) = landSeedPositions[i];
-      final (r, g, b) = useLandSeedByContinent
-          ? regionPalette[landSeedContinentIndices[i] % regionPalette.length]
-          : landSeedMarkerRgb;
-      final markerColor = image.getColor(r, g, b);
-      final cx = sx * cellSize + cellSize ~/ 2;
-      final cy = sy * cellSize + cellSize ~/ 2;
-      img.fillCircle(image, x: cx, y: cy, radius: radius, color: markerColor);
-      img.drawCircle(image, x: cx, y: cy, radius: radius, color: black);
-    }
+    _drawLandSeedMarkers(
+      image: image,
+      landSeedPositions: landSeedPositions!,
+      cellSize: cellSize,
+      black: black,
+      useLandSeedByContinent: useLandSeedByContinent,
+      landSeedContinentIndices: landSeedContinentIndices,
+    );
   }
 
-  // Region id on each tile (red, top-left inset). Drawn after borders/seeds, before resource letters.
-  final regionIdColor = image.getColor(
-    regionIdLabelRgb.$1,
-    regionIdLabelRgb.$2,
-    regionIdLabelRgb.$3,
-  );
-  const idInset = 2;
-  for (var y = 0; y < result.height; y++) {
-    for (var x = 0; x < result.width; x++) {
-      final id = result.cell(x, y);
-      final tx = x * cellSize + idInset;
-      final ty = y * cellSize + idInset;
-      img.drawString(
-        image,
-        id,
-        font: img.arial14,
-        x: tx,
-        y: ty,
-        color: regionIdColor,
-      );
-    }
-  }
+  _drawRegionIdLabels(image: image, result: result, cellSize: cellSize);
 
-  // Resource letters (drawn last on map so visible).
   if (result.resourceGrid != null) {
-    for (final glyph in tileMapResourceGlyphs(result)) {
-      drawResourceLetterAtCellCenter(
-        image,
-        letter: glyph.letter,
-        cellX: glyph.x,
-        cellY: glyph.y,
-        cellSize: cellSize,
-        color: black,
-      );
-    }
+    _drawResourceLettersOnMap(
+      image: image,
+      result: result,
+      cellSize: cellSize,
+      black: black,
+    );
   }
 
-  // Legend (below map).
-  final legendY0 = mapH + legendPadding;
-  if (useTerrain) {
-    img.drawString(
-      image,
-      'Terrain. Black = land borders; light blue = sea zone borders.',
-      font: img.arial14,
-      x: legendPadding,
-      y: legendY0,
-      color: black,
-    );
-    img.drawString(
-      image,
-      'Colors = terrain type; sea = deep blue.',
-      font: img.arial14,
-      x: legendPadding,
-      y: legendY0 + legendLineHeight,
-      color: black,
-    );
-    var row = _titleLines;
-    drawLegendSwatch(
-      image,
-      legendY0 + row * legendLineHeight,
-      seaColorRgb.$1,
-      seaColorRgb.$2,
-      seaColorRgb.$3,
-    );
-    img.drawString(
-      image,
-      'Sea',
-      font: img.arial14,
-      x: legendPadding + swatchSize + swatchGap,
-      y: legendY0 + row * legendLineHeight,
-      color: black,
-    );
-    row++;
-    for (final t in TerrainType.values) {
-      final (r, g, b) = terrainColorRgb[t]!;
-      drawLegendSwatch(image, legendY0 + row * legendLineHeight, r, g, b);
-      final label = _terrainLabel(t);
-      img.drawString(
-        image,
-        label,
-        font: img.arial14,
-        x: legendPadding + swatchSize + swatchGap,
-        y: legendY0 + row * legendLineHeight,
-        color: black,
-      );
-      row++;
-    }
-    row = _drawOptionalLegendSections(
-      image,
-      legendY0,
-      row,
-      showContinentSeeds: showContinentSeeds,
-      showLandSeeds: showLandSeeds,
-      useLandSeedByContinent: useLandSeedByContinent,
-      landSeedContinentIndices: landSeedContinentIndices,
-      hasResourceGrid: result.resourceGrid != null,
-    );
-  } else {
-    img.drawString(
-      image,
-      'Each cell = one tile. Colors = regions (provinces / sea zones).',
-      font: img.arial14,
-      x: legendPadding,
-      y: legendY0,
-      color: black,
-    );
-    img.drawString(
-      image,
-      'P = province (land), S = sea zone. Black = land borders; light blue = sea borders.',
-      font: img.arial14,
-      x: legendPadding,
-      y: legendY0 + legendLineHeight,
-      color: black,
-    );
-    final colors = colorMapFromIds(_regionIdsFromResult(result));
-    final nodesSorted = List<TopologyNode>.from(topology.nodes)
-      ..sort((a, b) => a.id.compareTo(b.id));
-    var row = _titleLines;
-    for (final n in nodesSorted) {
-      final y = legendY0 + row * legendLineHeight;
-      final c = colors[n.id]!;
-      drawLegendSwatch(image, y, c.$1, c.$2, c.$3);
-      final label =
-          '${n.id} (${n.type == TopologyNodeType.province ? 'P' : 'S'})';
-      img.drawString(
-        image,
-        label,
-        font: img.arial14,
-        x: legendPadding + swatchSize + swatchGap,
-        y: y,
-        color: black,
-      );
-      row++;
-    }
-    row = _drawOptionalLegendSections(
-      image,
-      legendY0,
-      row,
-      showContinentSeeds: showContinentSeeds,
-      showLandSeeds: showLandSeeds,
-      useLandSeedByContinent: useLandSeedByContinent,
-      landSeedContinentIndices: landSeedContinentIndices,
-      hasResourceGrid: result.resourceGrid != null,
-    );
-  }
+  _drawMapLegend(
+    image: image,
+    result: result,
+    topology: topology,
+    mapH: mapH,
+    black: black,
+    useTerrain: useTerrain,
+    showContinentSeeds: showContinentSeeds,
+    showLandSeeds: showLandSeeds,
+    useLandSeedByContinent: useLandSeedByContinent,
+    landSeedContinentIndices: landSeedContinentIndices,
+    regionColors: regionColors,
+  );
 
   return img.encodePng(image);
 }

--- a/packages/colonizethis_map/test/tile_map_gen_land_seeds_test.dart
+++ b/packages/colonizethis_map/test/tile_map_gen_land_seeds_test.dart
@@ -1,0 +1,67 @@
+import 'dart:math';
+
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('TileMapGenLandSeeds', () {
+    test('placeLandSeeds returns continent and land seed metadata', () {
+      final params = TileMapParams(width: 20, height: 12, seed: 7);
+      final pass = TileMapGenLandSeeds(params);
+      final provinceToContinent = <String, int>{
+        'p1': 0,
+        'p2': 0,
+        'p3': 1,
+        'p4': 1,
+      };
+
+      final (continentSeeds, landSeeds, continentBySeedIndex) = pass
+          .placeLandSeeds(provinceToContinent, Random(7));
+
+      expect(continentSeeds.length, 2);
+      expect(landSeeds, isNotEmpty);
+      expect(continentBySeedIndex.length, landSeeds.length);
+      expect(continentBySeedIndex.toSet(), containsAll(<int>[0, 1]));
+    });
+
+    test('assignLandByLandSeeds respects the expected land budget', () {
+      final params = TileMapParams(
+        width: 20,
+        height: 20,
+        seed: 11,
+        seaFraction: 0.6,
+      );
+      final pass = TileMapGenLandSeeds(params);
+      final provinceToContinent = <String, int>{
+        'p1': 0,
+        'p2': 0,
+        'p3': 1,
+        'p4': 1,
+      };
+      final grid = List.generate(
+        params.height,
+        (_) => List.filled(params.width, 's1'),
+      );
+      final (_, landSeeds, continentBySeedIndex) = pass.placeLandSeeds(
+        provinceToContinent,
+        Random(11),
+      );
+
+      final assigned = pass.assignLandByLandSeeds(
+        grid,
+        landSeeds,
+        continentBySeedIndex,
+        provinceToContinent,
+        's1',
+      );
+
+      final landCells = assigned
+          .expand((row) => row)
+          .where((cell) => cell == '_land')
+          .length;
+      final expectedLandBudget =
+          ((1 - params.seaFraction) * params.width * params.height).round();
+      expect(landCells, expectedLandBudget);
+    });
+  });
+}

--- a/packages/colonizethis_map/test/tile_map_generation_fn_test.dart
+++ b/packages/colonizethis_map/test/tile_map_generation_fn_test.dart
@@ -1,0 +1,41 @@
+import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('defaultTileMapRegionGenerator', () {
+    test('delegates to TileMapGenerator and emits callbacks', () {
+      var logs = 0;
+      var landSeedCallbackCalled = false;
+      var continentSeedCallbackCalled = false;
+
+      final (result, topology) = defaultTileMapRegionGenerator(
+        params: const TileMapParams(
+          width: 20,
+          height: 14,
+          seed: 3,
+          seaFraction: 0.6,
+        ),
+        numProvinces: 4,
+        numContinents: 2,
+        regionId: 'oldWorld',
+        onLog: (_) => logs++,
+        onLandSeedsPlaced: (landSeeds, continents) {
+          landSeedCallbackCalled = true;
+          expect(landSeeds, isNotEmpty);
+          expect(continents.length, landSeeds.length);
+        },
+        onContinentSeedsPlaced: (continentSeeds) {
+          continentSeedCallbackCalled = true;
+          expect(continentSeeds.length, 2);
+        },
+      );
+
+      expect(result.width, 20);
+      expect(result.height, 14);
+      expect(topology.nodes, isNotEmpty);
+      expect(logs, greaterThan(0));
+      expect(landSeedCallbackCalled, isTrue);
+      expect(continentSeedCallbackCalled, isTrue);
+    });
+  });
+}

--- a/tool/check_function_size.dart
+++ b/tool/check_function_size.dart
@@ -11,7 +11,10 @@ import 'package:yaml/yaml.dart';
 import 'ct_repo_lint_scan_contract.dart';
 
 const _failThreshold = 200;
-const _logicScopePrefix = 'packages/colonizethis_logic/lib/src/';
+const _scopePrefixes = <String>[
+  'packages/colonizethis_logic/lib/src/',
+  'packages/colonizethis_map/lib/src/',
+];
 
 int runCheckFunctionSize(
   String repoRoot, {
@@ -23,7 +26,7 @@ int runCheckFunctionSize(
   final allowlist = _loadAllowlist(repoRoot);
   final files = collectRepoLintDomainDartFiles(repoRoot).where((file) {
     final rel = p.relative(file.path, from: repoRoot);
-    return rel.startsWith(_logicScopePrefix);
+    return _scopePrefixes.any(rel.startsWith);
   });
   final violations = <String>[];
 

--- a/tool/control_flow_nesting_depth_allowlist.yaml
+++ b/tool/control_flow_nesting_depth_allowlist.yaml
@@ -116,15 +116,15 @@ allowed_depth_ge4:
   - file: packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
     symbol: _TileMapGenTerrainResource._refineTerrainPatternsInComponent
   - file: packages/colonizethis_map/lib/src/tile_map_generator_land_seeds.dart
-    symbol: _TileMapGenLandSeeds._placeOneOrganicSeed
+    symbol: TileMapGenLandSeeds._placeOneOrganicSeed
   - file: packages/colonizethis_map/lib/src/tile_map_generator_land_seeds.dart
-    symbol: _TileMapGenLandSeeds._assignLandByLandSeedsWithNoJoin
+    symbol: TileMapGenLandSeeds._assignLandByLandSeedsWithNoJoin
   - file: packages/colonizethis_map/lib/src/tile_map_generator_land_seeds.dart
     symbol: scoreCoastalCell
   - file: packages/colonizethis_map/lib/src/tile_map_generator_land_seeds.dart
-    symbol: _TileMapGenLandSeeds._growCoastlines
+    symbol: TileMapGenLandSeeds._growCoastlines
   - file: packages/colonizethis_map/lib/src/tile_map_generator_land_seeds.dart
-    symbol: _TileMapGenLandSeeds.assignLandByLandSeeds
+    symbol: TileMapGenLandSeeds.assignLandByLandSeeds
   - file: app/lib/core/services/game_service.dart
     symbol: GameService._emitTurnResolutionEvents
   - file: app/lib/core/services/app_event_handler.dart

--- a/tool/function_size_allowlist.yaml
+++ b/tool/function_size_allowlist.yaml
@@ -1,6 +1,15 @@
 # Grandfathered symbols above function-size threshold (shrink-only).
-# Scope: packages/colonizethis_logic/lib/src/**
+# Scope: packages/colonizethis_logic/lib/src/** and packages/colonizethis_map/lib/src/**
 allowed_over_20:
+  - file: packages/colonizethis_map/lib/src/tile_map_generator.dart
+    symbol: TileMapGenerator.generate
+    max_measured_lines: 239
+  - file: packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
+    symbol: _TileMapGenTerrainResource._assignNonMountainTerrainsRegionGrowing
+    max_measured_lines: 264
+  - file: packages/colonizethis_map/lib/src/tile_map_visualization.dart
+    symbol: renderTileMapToPng
+    max_measured_lines: 262
   - file: packages/colonizethis_logic/lib/src/ai/ai_planner.dart
     symbol: generateOrdersForGame
     max_measured_lines: 38

--- a/tool/function_size_allowlist.yaml
+++ b/tool/function_size_allowlist.yaml
@@ -7,9 +7,6 @@ allowed_over_20:
   - file: packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
     symbol: _TileMapGenTerrainResource._assignNonMountainTerrainsRegionGrowing
     max_measured_lines: 264
-  - file: packages/colonizethis_map/lib/src/tile_map_visualization.dart
-    symbol: renderTileMapToPng
-    max_measured_lines: 262
   - file: packages/colonizethis_logic/lib/src/ai/ai_planner.dart
     symbol: generateOrdersForGame
     max_measured_lines: 38


### PR DESCRIPTION
## Summary
- extract `_buildRegionViewData` responsibilities into focused helpers in `init_game_map_view_builder.dart` to reduce function size and make map overlay behavior easier to reason about
- promote `TileMapGenLandSeeds` to a public map-generation pass seam and add direct unit coverage for seed placement/assignment behavior
- extend `tool/check_function_size.dart` to also scan `packages/colonizethis_map/lib/src/`, with explicit grandfathered map symbols tracked in `tool/function_size_allowlist.yaml`

## Test plan
- [x] `dart test test/tile_map_gen_land_seeds_test.dart test/tile_map_generation_fn_test.dart` (from `packages/colonizethis_map`)
- [x] `dart run tool/check_function_size.dart`

Refs #1886

Made with [Cursor](https://cursor.com)