### PR TITLE
refactor(repo-lint): shrink control-flow allowlist for sim scenarios

### DIFF
--- a/tool/control_flow_nesting_depth_allowlist.yaml
+++ b/tool/control_flow_nesting_depth_allowlist.yaml
@@ -153,11 +153,5 @@ allowed_depth_ge4:
     symbol: RegionMapPainter.paint
   - file: tool/sim_scenarios/lib/state_verifier.dart
     symbol: StateVerifier._verifyAssertion
-  - file: tool/sim_scenarios/lib/state_verifier.dart
-    symbol: StateVerifier._getUnitsInProvince
-  - file: tool/sim_scenarios/lib/scenario_runner.dart
-    symbol: ScenarioRunner._initializeGame
   - file: tool/sim_scenarios/lib/scenario_runner.dart
     symbol: ScenarioRunner._applySetup
-  - file: tool/sim_scenarios/lib/order_script.dart
-    symbol: parseOrderCommands

--- a/tool/sim_scenarios/lib/order_script.dart
+++ b/tool/sim_scenarios/lib/order_script.dart
@@ -16,6 +16,48 @@ T? _firstWhereOrNull<T>(Iterable<T> items, bool Function(T) test) {
 /// Parses a list of OrderCommand into the game's Orders object.
 Orders parseOrderCommands(List<OrderCommand> commands, Game game) {
   final gameWithArmies = ensureMilitaryArmiesForGame(game);
+  final acc = _OrderAccumulator();
+
+  for (final cmd in commands) {
+    switch (cmd.type) {
+      case 'move':
+        _handleMoveCommand(acc, cmd, gameWithArmies);
+        break;
+
+      case 'build':
+        _handleBuildCommand(acc, cmd);
+        break;
+
+      case 'work':
+        _handleWorkCommand(acc, cmd);
+        break;
+
+      case 'diplomatic':
+        _handleDiplomaticCommand(acc, cmd);
+        break;
+
+      case 'research':
+        _handleResearchCommand(acc, cmd);
+        break;
+
+      case 'naval_move':
+        _handleNavalMoveCommand(acc, cmd);
+        break;
+
+      case 'naval_mission':
+        _handleNavalMissionCommand(acc, cmd);
+        break;
+
+      default:
+        // Unknown order type - skip
+        break;
+    }
+  }
+
+  return acc.buildOrders();
+}
+
+final class _OrderAccumulator {
   final moveOrdersByPlayerId = <String, List<MoveOrder>>{};
   final armyMoveOrdersByPlayerId = <String, List<ArmyMoveOrder>>{};
   final buildUnitOrdersByPlayerId = <String, List<BuildUnitOrder>>{};
@@ -25,156 +67,137 @@ Orders parseOrderCommands(List<OrderCommand> commands, Game game) {
   final navalMoveOrdersByPlayerId = <String, List<NavalMoveOrder>>{};
   final navalMissionOrdersByPlayerId = <String, List<NavalMissionOrder>>{};
 
-  for (final cmd in commands) {
-    switch (cmd.type) {
-      case 'move':
-        final unitId = cmd.unit ?? '';
-        final destination = cmd.to ?? '';
-        final allUnits = <Unit>[
-          ...gameWithArmies.worldState.oldWorld.units,
-          ...gameWithArmies.worldState.newWorld.units,
-        ];
-        final unit = _firstWhereOrNull(allUnits, (u) => u.id == unitId);
-        if (unit != null && isMilitaryUnit(unit.type)) {
-          final army = _firstWhereOrNull(
-            gameWithArmies.worldState.armies,
-            (a) =>
-                a.ownerId == cmd.player && a.regimentUnitIds.contains(unitId),
-          );
-          if (army != null) {
-            final list = armyMoveOrdersByPlayerId.putIfAbsent(
-              cmd.player,
-              () => [],
-            );
-            final alreadyQueued = list.any(
-              (o) =>
-                  o.armyId == army.id && o.destinationProvinceId == destination,
-            );
-            if (!alreadyQueued) {
-              list.add(
-                ArmyMoveOrder(
-                  armyId: army.id,
-                  destinationProvinceId: destination,
-                ),
-              );
-            }
-            break;
-          }
-        }
-        moveOrdersByPlayerId
-            .putIfAbsent(cmd.player, () => [])
-            .add(
-              MoveOrder(
-                unitId: unitId,
-                destinationTileKey: '$destination|0|0',
-              ),
-            );
-        break;
-
-      case 'build':
-        final unitType = cmd.unitType ?? 'infantry';
-        final isMilitary =
-            buildUnitCategoryForUnitType(unitType) ==
-            BuildUnitCategory.military;
-        final buildOrder = BuildUnitOrder(
-          unitType: unitType,
-          isMilitary: isMilitary,
-          spawnProvinceId: cmd.inProvince ?? '',
-        );
-        buildUnitOrdersByPlayerId
-            .putIfAbsent(cmd.player, () => [])
-            .add(buildOrder);
-        break;
-
-      case 'work':
-        // Work orders need unit ID and target. For tile-level work the scenario
-        // should provide targetTileKey; otherwise empty string is used.
-        final workOrder = WorkOrder(
-          unitId: cmd.unit ?? '',
-          target: cmd.workType ?? kWorkTargetExplore,
-          targetTileKey: cmd.targetTileKey ?? '',
-        );
-        workOrdersByPlayerId.putIfAbsent(cmd.player, () => []).add(workOrder);
-        break;
-
-      case 'diplomatic':
-        final typeName = cmd.diplomaticType ?? 'declareWar';
-        final diploType = DiplomaticOrderType.values.firstWhere(
-          (e) => e.name == typeName,
-          orElse: () => DiplomaticOrderType.declareWar,
-        );
-        final overtureStage = cmd.overtureStage != null
-            ? OvertureStage.values.firstWhere(
-                (e) => e.name == cmd.overtureStage,
-                orElse: () => OvertureStage.none,
-              )
-            : null;
-        final diploOrder = DiplomaticOrder(
-          type: diploType,
-          targetFactionId: cmd.targetFactionId ?? '',
-          amount: cmd.amount,
-          overtureStage: overtureStage,
-        );
-        diplomaticOrdersByPlayerId
-            .putIfAbsent(cmd.player, () => [])
-            .add(diploOrder);
-        break;
-
-      case 'research':
-        // Default slot 0 with low funding for tests
-        final researchOrder = ResearchOrder(
-          slotIndex: cmd.slotIndex ?? 0,
-          techId: cmd.techId ?? '',
-          funding: ResearchFundingLevel.low,
-        );
-        researchOrdersByPlayerId
-            .putIfAbsent(cmd.player, () => [])
-            .add(researchOrder);
-        break;
-
-      case 'naval_move':
-        final portId = cmd.destinationPortProvinceId;
-        final isDock = portId != null && portId.isNotEmpty;
-        final navalMoveOrder = isDock
-            ? NavalMoveOrder(
-                fleetId: cmd.fleetId ?? '',
-                destinationPortProvinceId: portId,
-              )
-            : NavalMoveOrder(
-                fleetId: cmd.fleetId ?? '',
-                destinationSeaZoneId: cmd.destinationSeaZoneId ?? '',
-              );
-        navalMoveOrdersByPlayerId
-            .putIfAbsent(cmd.player, () => [])
-            .add(navalMoveOrder);
-        break;
-
-      case 'naval_mission':
-        final navalMissionOrder = NavalMissionOrder(
-          fleetId: cmd.fleetId ?? '',
-          mission: cmd.mission ?? 'patrol',
-          targetPortId: cmd.targetPortId,
-          targetProvinceId: cmd.targetProvinceId,
-        );
-        navalMissionOrdersByPlayerId
-            .putIfAbsent(cmd.player, () => [])
-            .add(navalMissionOrder);
-        break;
-
-      default:
-        // Unknown order type - skip
-        break;
-    }
+  Orders buildOrders() {
+    return Orders(
+      moveOrdersByPlayerId: moveOrdersByPlayerId,
+      armyMoveOrdersByPlayerId: armyMoveOrdersByPlayerId,
+      buildUnitOrdersByPlayerId: buildUnitOrdersByPlayerId,
+      workOrdersByPlayerId: workOrdersByPlayerId,
+      diplomaticOrdersByPlayerId: diplomaticOrdersByPlayerId,
+      researchOrdersByPlayerId: researchOrdersByPlayerId,
+      navalMoveOrdersByPlayerId: navalMoveOrdersByPlayerId,
+      navalMissionOrdersByPlayerId: navalMissionOrdersByPlayerId,
+    );
   }
+}
 
-  return Orders(
-    moveOrdersByPlayerId: moveOrdersByPlayerId,
-    armyMoveOrdersByPlayerId: armyMoveOrdersByPlayerId,
-    buildUnitOrdersByPlayerId: buildUnitOrdersByPlayerId,
-    workOrdersByPlayerId: workOrdersByPlayerId,
-    diplomaticOrdersByPlayerId: diplomaticOrdersByPlayerId,
-    researchOrdersByPlayerId: researchOrdersByPlayerId,
-    navalMoveOrdersByPlayerId: navalMoveOrdersByPlayerId,
-    navalMissionOrdersByPlayerId: navalMissionOrdersByPlayerId,
+void _handleMoveCommand(_OrderAccumulator acc, OrderCommand cmd, Game game) {
+  final unitId = cmd.unit ?? '';
+  final destination = cmd.to ?? '';
+  final allUnits = <Unit>[
+    ...game.worldState.oldWorld.units,
+    ...game.worldState.newWorld.units,
+  ];
+  final unit = _firstWhereOrNull(allUnits, (u) => u.id == unitId);
+  if (_tryQueueArmyMove(acc, cmd, game, unitId, destination, unit)) {
+    return;
+  }
+  acc.moveOrdersByPlayerId.putIfAbsent(cmd.player, () => []).add(
+    MoveOrder(unitId: unitId, destinationTileKey: '$destination|0|0'),
   );
+}
+
+bool _tryQueueArmyMove(
+  _OrderAccumulator acc,
+  OrderCommand cmd,
+  Game game,
+  String unitId,
+  String destination,
+  Unit? unit,
+) {
+  if (unit == null || !isMilitaryUnit(unit.type)) {
+    return false;
+  }
+  final army = _firstWhereOrNull(
+    game.worldState.armies,
+    (a) => a.ownerId == cmd.player && a.regimentUnitIds.contains(unitId),
+  );
+  if (army == null) {
+    return false;
+  }
+  final list = acc.armyMoveOrdersByPlayerId.putIfAbsent(cmd.player, () => []);
+  final alreadyQueued =
+      list.any((o) => o.armyId == army.id && o.destinationProvinceId == destination);
+  if (!alreadyQueued) {
+    list.add(ArmyMoveOrder(armyId: army.id, destinationProvinceId: destination));
+  }
+  return true;
+}
+
+void _handleBuildCommand(_OrderAccumulator acc, OrderCommand cmd) {
+  final unitType = cmd.unitType ?? 'infantry';
+  final isMilitary =
+      buildUnitCategoryForUnitType(unitType) == BuildUnitCategory.military;
+  final buildOrder = BuildUnitOrder(
+    unitType: unitType,
+    isMilitary: isMilitary,
+    spawnProvinceId: cmd.inProvince ?? '',
+  );
+  acc.buildUnitOrdersByPlayerId.putIfAbsent(cmd.player, () => []).add(buildOrder);
+}
+
+void _handleWorkCommand(_OrderAccumulator acc, OrderCommand cmd) {
+  final workOrder = WorkOrder(
+    unitId: cmd.unit ?? '',
+    target: cmd.workType ?? kWorkTargetExplore,
+    targetTileKey: cmd.targetTileKey ?? '',
+  );
+  acc.workOrdersByPlayerId.putIfAbsent(cmd.player, () => []).add(workOrder);
+}
+
+void _handleDiplomaticCommand(_OrderAccumulator acc, OrderCommand cmd) {
+  final typeName = cmd.diplomaticType ?? 'declareWar';
+  final diploType = DiplomaticOrderType.values.firstWhere(
+    (e) => e.name == typeName,
+    orElse: () => DiplomaticOrderType.declareWar,
+  );
+  final overtureStage = cmd.overtureStage != null
+      ? OvertureStage.values.firstWhere(
+          (e) => e.name == cmd.overtureStage,
+          orElse: () => OvertureStage.none,
+        )
+      : null;
+  final diploOrder = DiplomaticOrder(
+    type: diploType,
+    targetFactionId: cmd.targetFactionId ?? '',
+    amount: cmd.amount,
+    overtureStage: overtureStage,
+  );
+  acc.diplomaticOrdersByPlayerId.putIfAbsent(cmd.player, () => []).add(diploOrder);
+}
+
+void _handleResearchCommand(_OrderAccumulator acc, OrderCommand cmd) {
+  final researchOrder = ResearchOrder(
+    slotIndex: cmd.slotIndex ?? 0,
+    techId: cmd.techId ?? '',
+    funding: ResearchFundingLevel.low,
+  );
+  acc.researchOrdersByPlayerId.putIfAbsent(cmd.player, () => []).add(researchOrder);
+}
+
+void _handleNavalMoveCommand(_OrderAccumulator acc, OrderCommand cmd) {
+  final portId = cmd.destinationPortProvinceId;
+  final isDock = portId != null && portId.isNotEmpty;
+  final navalMoveOrder = isDock
+      ? NavalMoveOrder(
+          fleetId: cmd.fleetId ?? '',
+          destinationPortProvinceId: portId,
+        )
+      : NavalMoveOrder(
+          fleetId: cmd.fleetId ?? '',
+          destinationSeaZoneId: cmd.destinationSeaZoneId ?? '',
+        );
+  acc.navalMoveOrdersByPlayerId.putIfAbsent(cmd.player, () => []).add(navalMoveOrder);
+}
+
+void _handleNavalMissionCommand(_OrderAccumulator acc, OrderCommand cmd) {
+  final navalMissionOrder = NavalMissionOrder(
+    fleetId: cmd.fleetId ?? '',
+    mission: cmd.mission ?? 'patrol',
+    targetPortId: cmd.targetPortId,
+    targetProvinceId: cmd.targetProvinceId,
+  );
+  acc.navalMissionOrdersByPlayerId
+      .putIfAbsent(cmd.player, () => [])
+      .add(navalMissionOrder);
 }

--- a/tool/sim_scenarios/lib/scenario_runner.dart
+++ b/tool/sim_scenarios/lib/scenario_runner.dart
@@ -242,39 +242,49 @@ class ScenarioRunner {
   }
 
   Future<ScenarioContext?> _initializeGame(Scenario scenario) async {
-    if (scenario.init.type == 'fresh') {
-      GameInitResult result;
-      if (scenario.init.config != null) {
-        result = await gameFactory.createFreshGameFromJson(
-          scenario.init.config!,
-        );
-      } else {
-        // Default fresh game
-        result = await gameFactory.createFreshGame(GameSetupConfig(seed: 42));
-      }
-      return ScenarioContext(
-        game: result.game,
-        topology: result.topology,
-        topologyByRegion: result.topologyByRegion,
-        tileMapByRegion: result.tileMapByRegion,
-      );
-    } else if (scenario.init.type == 'fromTopology') {
-      final result = await gameFactory.createFromTopology(scenario.init);
-      return ScenarioContext(
-        game: result.game,
-        topology: result.topology,
-        topologyByRegion: result.topologyByRegion,
-        tileMapByRegion: result.tileMapByRegion,
-      );
-    } else if (scenario.init.type == 'saved') {
-      if (scenario.init.gameId != null) {
-        final game = await gameFactory.loadSavedGame(scenario.init.gameId!);
-        if (game != null) {
-          return ScenarioContext(game: game);
-        }
-      }
+    switch (scenario.init.type) {
+      case 'fresh':
+        return _initializeFreshGame(scenario);
+      case 'fromTopology':
+        return _initializeFromTopology(scenario);
+      case 'saved':
+        return _initializeSavedGame(scenario);
+      default:
+        return null;
     }
-    return null;
+  }
+
+  Future<ScenarioContext> _initializeFreshGame(Scenario scenario) async {
+    final result = scenario.init.config != null
+        ? await gameFactory.createFreshGameFromJson(scenario.init.config!)
+        : await gameFactory.createFreshGame(GameSetupConfig(seed: 42));
+    return _toScenarioContext(result);
+  }
+
+  Future<ScenarioContext> _initializeFromTopology(Scenario scenario) async {
+    final result = await gameFactory.createFromTopology(scenario.init);
+    return _toScenarioContext(result);
+  }
+
+  Future<ScenarioContext?> _initializeSavedGame(Scenario scenario) async {
+    final gameId = scenario.init.gameId;
+    if (gameId == null) {
+      return null;
+    }
+    final game = await gameFactory.loadSavedGame(gameId);
+    if (game == null) {
+      return null;
+    }
+    return ScenarioContext(game: game);
+  }
+
+  ScenarioContext _toScenarioContext(GameInitResult result) {
+    return ScenarioContext(
+      game: result.game,
+      topology: result.topology,
+      topologyByRegion: result.topologyByRegion,
+      tileMapByRegion: result.tileMapByRegion,
+    );
   }
 
   /// Applies scenario setup (unit injection, etc.). Returns updated game.

--- a/tool/sim_scenarios/lib/state_verifier.dart
+++ b/tool/sim_scenarios/lib/state_verifier.dart
@@ -736,35 +736,19 @@ class StateVerifier {
 
   List<Unit> _getUnitsInProvince(
       Game game, String? regionId, String provinceId) {
-    final units = <Unit>[];
-
-    // If region is specified, only check that region's units
     if (regionId != null) {
       final regionData = _getRegionData(game, regionId);
-      if (regionData != null) {
-        for (final unit in regionData.units) {
-          if (unit.locationProvinceId == provinceId) {
-            units.add(unit);
-          }
-        }
+      if (regionData == null) {
+        return const [];
       }
-      return units;
+      return regionData.units
+          .where((unit) => unit.locationProvinceId == provinceId)
+          .toList();
     }
-
-    // If no region, check both oldWorld and newWorld units
-    for (final unit in game.worldState.oldWorld.units) {
-      if (unit.locationProvinceId == provinceId) {
-        units.add(unit);
-      }
-    }
-
-    for (final unit in game.worldState.newWorld.units) {
-      if (unit.locationProvinceId == provinceId) {
-        units.add(unit);
-      }
-    }
-
-    return units;
+    return [
+      ...game.worldState.oldWorld.units,
+      ...game.worldState.newWorld.units,
+    ].where((unit) => unit.locationProvinceId == provinceId).toList();
   }
 
   _CountMatchResult _matchCount(


### PR DESCRIPTION
## Summary
- Refactors `tool/sim_scenarios` control-flow-heavy helpers (`parseOrderCommands`, `_initializeGame`, `_getUnitsInProvince`) into smaller helper units while preserving behavior.
- Removes the corresponding legacy nesting exemptions from `tool/control_flow_nesting_depth_allowlist.yaml`.
- Keeps `repo.control_flow_nesting_depth` green with fewer grandfathered rows.

## Scope
- This PR delivers a **partial control-flow nesting slice** for #1912 focused on `tool/sim_scenarios`.
- Deferred from #1912: remaining allowlist rows across `packages/*`, `app/`, and `ctdev/`, plus final checker/spec allowlist removal.

## Test plan
- [x] `dart analyze tool/sim_scenarios/lib/order_script.dart tool/sim_scenarios/lib/scenario_runner.dart tool/sim_scenarios/lib/state_verifier.dart`
- [x] `dart run tool/check_control_flow_nesting_depth.dart`
- [x] `dart run tool/ct_repo_lint.dart --rule repo.control_flow_nesting_depth`
- [x] `dart test tool/sim_scenarios/test`

Refs #1912

Made with [Cursor](https://cursor.com)