### PR TITLE
fix(naval-panel): keep Home Fleet visible on marker-scoped port opens

### DIFF
--- a/app/lib/features/game/widgets/utils/naval_tree_builder.dart
+++ b/app/lib/features/game/widgets/utils/naval_tree_builder.dart
@@ -249,6 +249,11 @@ buildNavalTree(
     return 'sea:$regionId|$local';
   }
 
+  String normalizedPortScope(Province province) {
+    final localProvinceId = ProvinceId.localIdFrom(province.id);
+    return 'port:${province.regionId}|$localProvinceId';
+  }
+
   String? projectedLocationScopeForFleet(Fleet fleet) {
     final move = draftMoveByFleetId[fleet.id];
     if (move != null) {
@@ -256,7 +261,7 @@ buildNavalTree(
         final pid = move.destinationPortProvinceId!;
         final province = tryGetProvince(game.worldState, pid);
         if (province != null) {
-          return 'port:${province.regionId}|${province.id}';
+          return normalizedPortScope(province);
         }
         return 'port:$pid';
       }
@@ -277,7 +282,7 @@ buildNavalTree(
         fleet.inPortAtProvinceId!,
       );
       if (province != null) {
-        return 'port:${province.regionId}|${province.id}';
+        return normalizedPortScope(province);
       }
       return 'port:${fleet.inPortAtProvinceId!}';
     }
@@ -401,7 +406,7 @@ buildNavalTree(
         final province =
             provinceMap['$regionId|$inPortId'] ?? provinceMap[inPortId];
         if (province == null) continue;
-        locationKey = 'port:${province.regionId}|${province.id}';
+        locationKey = normalizedPortScope(province);
         tileKey = tileKeyForProvinceLocation(game, province);
         locationLabel =
             '${unitsPanelRegionLabel(regionId)} — ${province.displayName ?? province.id}';
@@ -452,7 +457,7 @@ buildNavalTree(
           provinceMap['$capitalRegionId|$capitalProvinceLocalId'] ??
           provinceMap[capitalProvinceLocalId];
       if (province != null) {
-        final synLocationKey = 'port:${province.regionId}|${province.id}';
+        final synLocationKey = normalizedPortScope(province);
         final omitSynthetic =
             locationScopeKeyFilter != null &&
             locationScopeKeyFilter != synLocationKey;

--- a/app/test/naval_units_panel_test.dart
+++ b/app/test/naval_units_panel_test.dart
@@ -108,6 +108,7 @@ void main() {
     AppEventBus? bus,
     MapTopology topology = const MapTopology(),
     Orders draftOrders = const Orders(),
+    String? locationScopeKey,
   }) {
     final resolvedBus = bus ?? AppEventBus.create();
     return MaterialApp(
@@ -118,6 +119,7 @@ void main() {
           bus: resolvedBus,
           topology: topology,
           draftOrders: draftOrders,
+          locationScopeKey: locationScopeKey,
         ),
       ),
     );
@@ -2594,6 +2596,79 @@ void main() {
 
       expect(find.text('No naval units'), findsOneWidget);
     });
+
+    testWidgets(
+      'AC: Marker-scoped capital port view shows Home Fleet and not empty state',
+      (WidgetTester tester) async {
+        const humanId = 'gp_marker_scope';
+        const capitalPrefixedId = 'oldWorld|p1';
+        final homeId = homeFleetIdFor(humanId);
+        final markerScope = 'port:oldWorld|p1';
+
+        final markerScopeGame = Game(
+          id: 'g_marker_scope',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(
+                  id: capitalPrefixedId,
+                  regionId: 'oldWorld',
+                  ownerId: humanId,
+                  displayName: 'Capital Port',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: homeId,
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                inPortAtProvinceId: capitalPrefixedId,
+                ships: const [
+                  ShipInstance(id: 'home_ship_1', typeId: 'carrack'),
+                ],
+              ),
+            ],
+            tileKeysByRegionAndProvince: const {
+              'oldWorld': {
+                capitalPrefixedId: ['oldWorld|p1|0|0'],
+              },
+            },
+          ),
+          players: const [
+            Player(
+              id: humanId,
+              displayName: 'Scope Test',
+              isHuman: true,
+              capitalProvinceId: capitalPrefixedId,
+              capitalTile: CapitalTile(
+                regionId: 'oldWorld',
+                provinceId: capitalPrefixedId,
+                x: 0,
+                y: 0,
+              ),
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(
+          buildPanel(
+            game: markerScopeGame,
+            humanPlayerId: humanId,
+            locationScopeKey: markerScope,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          find.widgetWithText(ExpansionTile, 'Home Fleet'),
+          findsOneWidget,
+        );
+        expect(find.text('No naval units'), findsNothing);
+      },
+    );
 
     testWidgets('AC: Home Fleet collapsed row does not show Move action', (
       WidgetTester tester,


### PR DESCRIPTION
## Summary
- Normalize in-port naval panel scope keys to canonical `port:<region>|<localProvinceId>` so marker tap scope values match panel filtering even when province ids are stored prefixed.
- Reuse one helper in `buildNavalTree` for all port scope construction paths (projected fleet scope, row location key, synthetic Home Fleet key).
- Add a regression widget test covering marker-scoped capital-port open: Home Fleet is visible and `No naval units` is not shown.

## Test plan
- [x] `flutter test test/naval_units_panel_test.dart` (run from `app/`)
- [x] `dart analyze` on touched files via MCP (`naval_tree_builder.dart`, `naval_units_panel_test.dart`)

Refs #1913

Made with [Cursor](https://cursor.com)