### PR TITLE
fix(naval-panel): scope projected cross-region marker opens to destination

### DIFF
--- a/app/lib/features/game/widgets/utils/naval_tree_builder.dart
+++ b/app/lib/features/game/widgets/utils/naval_tree_builder.dart
@@ -254,6 +254,15 @@ buildNavalTree(
     return 'port:${province.regionId}|$localProvinceId';
   }
 
+  String? regionIdFromScopeKey(String? scopeKey) {
+    if (scopeKey == null || scopeKey.isEmpty) return null;
+    final colon = scopeKey.indexOf(':');
+    if (colon == -1 || colon >= scopeKey.length - 1) return null;
+    final payload = scopeKey.substring(colon + 1);
+    if (!payload.contains('|')) return null;
+    return payload.split('|').first;
+  }
+
   String? projectedLocationScopeForFleet(Fleet fleet) {
     final move = draftMoveByFleetId[fleet.id];
     if (move != null) {
@@ -294,16 +303,20 @@ buildNavalTree(
     'newWorld': game.worldState.newWorld,
   }.entries) {
     final regionId = regionEntry.key;
-    final regionTileMap = tileMapByRegion?[regionId];
-    final regionTopo = topologyByRegion?[regionId];
 
     final fleetsInRegion = game.worldState.fleets
-        .where(
-          (f) =>
-              f.ownerId == humanPlayerId &&
-              f.regionId == regionId &&
-              f.shipTypeIds.isNotEmpty,
-        )
+        .where((f) => f.ownerId == humanPlayerId && f.shipTypeIds.isNotEmpty)
+        .where((fleet) {
+          if (locationScopeKeyFilter == null) {
+            return fleet.regionId == regionId;
+          }
+          final projectedScope = projectedLocationScopeForFleet(fleet);
+          if (projectedScope != locationScopeKeyFilter) {
+            return false;
+          }
+          final scopeRegionId = regionIdFromScopeKey(projectedScope);
+          return scopeRegionId == regionId;
+        })
         .toList();
     if (fleetsInRegion.isEmpty && capitalRegionId != regionId) {
       continue;
@@ -321,6 +334,12 @@ buildNavalTree(
           projectedScope != locationScopeKeyFilter) {
         continue;
       }
+      final projectedScopeRegionId = regionIdFromScopeKey(projectedScope);
+      final rowRegionId = locationScopeKeyFilter != null
+          ? (projectedScopeRegionId ?? regionId)
+          : regionId;
+      final rowTileMap = tileMapByRegion?[rowRegionId];
+      final rowTopology = topologyByRegion?[rowRegionId];
 
       final shipCounts = <String, int>{};
       int totalShips = 0;
@@ -345,7 +364,7 @@ buildNavalTree(
           capitalRegionId != null &&
           capitalProvinceLocalId != null &&
           !isAtSea &&
-          regionId == capitalRegionId &&
+          rowRegionId == capitalRegionId &&
           inPortId != null &&
           (inPortId == capitalProvinceLocalId ||
               inPortId == '$capitalRegionId|$capitalProvinceLocalId');
@@ -356,29 +375,34 @@ buildNavalTree(
       String? tileKey;
       String locationKey;
       if (isAtSea) {
-        final seaZoneId = fleet.seaZoneId!;
+        final seaZoneId =
+            locationScopeKeyFilter != null &&
+                projectedScope != null &&
+                projectedScope.startsWith('sea:')
+            ? projectedScope.substring(4)
+            : fleet.seaZoneId!;
         final zoneKey = seaZoneId.contains('|')
             ? seaZoneId
-            : '$regionId|$seaZoneId';
+            : '$rowRegionId|$seaZoneId';
         locationKey = 'sea:$zoneKey';
         final zoneLabel = seaZoneDisplayName(
           game: game,
-          regionId: regionId,
+          regionId: rowRegionId,
           seaZoneId: zoneKey,
         );
-        locationLabel = '${unitsPanelRegionLabel(regionId)} — $zoneLabel';
+        locationLabel = '${unitsPanelRegionLabel(rowRegionId)} — $zoneLabel';
         tileKey = tileKeyForNavalFleetAtSea(
           game: game,
-          regionId: regionId,
+          regionId: rowRegionId,
           seaZoneId: zoneKey,
-          tileMap: regionTileMap,
-          regionTopology: regionTopo,
+          tileMap: rowTileMap,
+          regionTopology: rowTopology,
         );
         final row = FleetRow(
           fleetId: fleet.id,
           label: l10n.naval_fleetLabel(fleet.id),
           locationLabel: locationLabel,
-          regionId: regionId,
+          regionId: rowRegionId,
           missionLabel: fleetMissionDisplayLabel(fleet.mission),
           totalShips: totalShips,
           warshipCount: warships,
@@ -395,28 +419,36 @@ buildNavalTree(
             game: game,
             topology: topology,
             humanPlayerId: humanPlayerId,
-            fleetRegionId: regionId,
+            fleetRegionId: rowRegionId,
             fleetId: fleet.id,
             draftOrders: draftOrders,
           ),
         );
         seas.putIfAbsent(zoneKey, () => []).add(row);
       } else if (inPortId != null) {
-        final provinceMap = provinceByRegionAndId[regionId] ?? const {};
+        final provinceMap = provinceByRegionAndId[rowRegionId] ?? const {};
+        final scopePortId =
+            locationScopeKeyFilter != null &&
+                projectedScope != null &&
+                projectedScope.startsWith('port:')
+            ? projectedScope.substring(5)
+            : null;
+        final effectivePortId = scopePortId ?? inPortId;
         final province =
-            provinceMap['$regionId|$inPortId'] ?? provinceMap[inPortId];
+            provinceMap['$rowRegionId|$effectivePortId'] ??
+            provinceMap[effectivePortId];
         if (province == null) continue;
         locationKey = normalizedPortScope(province);
         tileKey = tileKeyForProvinceLocation(game, province);
         locationLabel =
-            '${unitsPanelRegionLabel(regionId)} — ${province.displayName ?? province.id}';
+            '${unitsPanelRegionLabel(rowRegionId)} — ${province.displayName ?? province.id}';
         final row = FleetRow(
           fleetId: fleet.id,
           label: isHomeFleet
               ? l10n.naval_homeFleetLabel
               : l10n.naval_fleetLabel(fleet.id),
           locationLabel: locationLabel,
-          regionId: regionId,
+          regionId: rowRegionId,
           missionLabel: fleetMissionDisplayLabel(fleet.mission),
           totalShips: totalShips,
           warshipCount: warships,
@@ -428,14 +460,14 @@ buildNavalTree(
           cargoCapacity: cargoCapacity,
           isAtSea: false,
           locationKey: locationKey,
-          inPortAtProvinceId: inPortId,
+          inPortAtProvinceId: effectivePortId,
           draftNavalMoveLine: isHomeFleet
               ? null
               : navalDraftMoveLineForFleet(
                   game: game,
                   topology: topology,
                   humanPlayerId: humanPlayerId,
-                  fleetRegionId: regionId,
+                  fleetRegionId: rowRegionId,
                   fleetId: fleet.id,
                   draftOrders: draftOrders,
                 ),

--- a/app/test/naval_units_panel_test.dart
+++ b/app/test/naval_units_panel_test.dart
@@ -2670,6 +2670,73 @@ void main() {
       },
     );
 
+    testWidgets(
+      'AC: Cross-region projected marker scope shows destination region rows',
+      (WidgetTester tester) async {
+        const humanId = 'gp_cross_region_scope';
+        final scopedGame = Game(
+          id: 'g_cross_region_scope',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'f1',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                seaZoneId: 's1',
+                ships: const [ShipInstance(id: 'ship_1', typeId: 'frigate')],
+              ),
+            ],
+          ),
+          players: const [
+            Player(id: humanId, displayName: 'Cross Scope', isHuman: true),
+          ],
+        );
+        const draftOrders = Orders(
+          navalMoveOrdersByPlayerId: {
+            humanId: [
+              NavalMoveOrder(
+                fleetId: 'f1',
+                destinationSeaZoneId: 'newWorld|s2',
+              ),
+            ],
+          },
+        );
+        const topology = MapTopology(
+          nodes: [
+            TopologyNode(
+              id: 'oldWorld|s1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+            TopologyNode(
+              id: 'newWorld|s2',
+              regionId: 'newWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+          ],
+          edges: [TopologyEdge(id1: 'oldWorld|s1', id2: 'newWorld|s2')],
+        );
+
+        await tester.pumpWidget(
+          buildPanel(
+            game: scopedGame,
+            humanPlayerId: humanId,
+            topology: topology,
+            draftOrders: draftOrders,
+            locationScopeKey: 'sea:newWorld|s2',
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('New World'), findsOneWidget);
+        expect(find.text('Old World'), findsNothing);
+        expect(find.textContaining('Fleet f1'), findsOneWidget);
+      },
+    );
+
     testWidgets('AC: Home Fleet collapsed row does not show Move action', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
## Summary
- align marker-scoped Naval Units filtering with projected cross-region destination scope instead of physical `fleet.regionId`
- compute row region/location metadata from projected destination scope when opening from map marker context
- add regression coverage for cross-region projected marker scope rendering destination-region rows in Naval Units

## Test plan
- [x] `cd app && flutter test test/naval_units_panel_test.dart --plain-name "Cross-region projected marker scope shows destination region rows"`
- [x] `cd app && flutter test test/game_map_area_state_logic_test.dart --plain-name "projectFleetMarkersForHumanDraft cross-region draft projection"`

Refs #1891

Made with [Cursor](https://cursor.com)