### PR TITLE
test(logic): add strict closure verification for issue 1892

### DIFF
--- a/app/test/game_map_area_test.dart
+++ b/app/test/game_map_area_test.dart
@@ -15,6 +15,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
@@ -973,4 +974,140 @@ void main() {
     expect(find.text('Select a tile, or click cancel'), findsNothing);
     expect(openedPanels, hasLength(1));
   });
+
+  testWidgets('escape key cancels work target selection mode', (
+    WidgetTester tester,
+  ) async {
+    final init = getDebugInitGameResult();
+    final game = init.game;
+    final mapViewData = init.mapViewData;
+    final bus = AppEventBus.create();
+    addTearDown(bus.dispose);
+
+    final sampleUnitId = game.worldState.oldWorld.units.isNotEmpty
+        ? game.worldState.oldWorld.units.first.id
+        : game.worldState.newWorld.units.first.id;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appEventBusProvider.overrideWith((ref) => bus),
+          currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+          gamesBoxProvider.overrideWith((ref) => gamesBox),
+          gameServiceProvider.overrideWith(
+            (ref) => GameService(gamesBox, GameSaveAdapter()),
+          ),
+          currentOrdersProvider.overrideWith(
+            () => CurrentOrdersNotifier(const Orders()),
+          ),
+          mapViewDataProvider.overrideWith((ref) => mapViewData),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: GameMapArea(game: game, mapViewData: mapViewData),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
+
+    bus.emit(
+      StartCivilianWorkTargetSelectionEvent(
+        unitId: sampleUnitId,
+        workTarget: 'explore',
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
+
+    expect(find.text('Select a tile, or click cancel'), findsOneWidget);
+    var regionMap = tester.widget<CtRegionMap>(find.byType(CtRegionMap).first);
+    expect(regionMap.validTileKeys, isNotNull);
+
+    final keyHandlerFocuses = tester
+        .widgetList<Focus>(find.byType(Focus))
+        .where((focus) => focus.onKeyEvent != null);
+    var keyHandled = false;
+    for (final focus in keyHandlerFocuses) {
+      final keyResult = focus.onKeyEvent!(
+        FocusNode(),
+        const KeyDownEvent(
+          timeStamp: Duration.zero,
+          logicalKey: LogicalKeyboardKey.escape,
+          physicalKey: PhysicalKeyboardKey.escape,
+        ),
+      );
+      if (keyResult == KeyEventResult.handled) {
+        keyHandled = true;
+        break;
+      }
+    }
+    expect(keyHandled, isTrue);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
+
+    expect(find.text('Select a tile, or click cancel'), findsNothing);
+    regionMap = tester.widget<CtRegionMap>(find.byType(CtRegionMap).first);
+    expect(regionMap.validTileKeys, isNull);
+  });
+
+  testWidgets(
+    'selection mode blocks non-selection map interaction callbacks',
+    (WidgetTester tester) async {
+      final init = getDebugInitGameResult();
+      final game = init.game;
+      final mapViewData = init.mapViewData;
+      final bus = AppEventBus.create();
+      addTearDown(bus.dispose);
+
+      final sampleUnitId = game.worldState.oldWorld.units.isNotEmpty
+          ? game.worldState.oldWorld.units.first.id
+          : game.worldState.newWorld.units.first.id;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            appEventBusProvider.overrideWith((ref) => bus),
+            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+            gamesBoxProvider.overrideWith((ref) => gamesBox),
+            gameServiceProvider.overrideWith(
+              (ref) => GameService(gamesBox, GameSaveAdapter()),
+            ),
+            currentOrdersProvider.overrideWith(
+              () => CurrentOrdersNotifier(const Orders()),
+            ),
+            mapViewDataProvider.overrideWith((ref) => mapViewData),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: GameMapArea(game: game, mapViewData: mapViewData),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+
+      var regionMap = tester.widget<CtRegionMap>(find.byType(CtRegionMap).first);
+      expect(regionMap.onMapTileTappedForDetail, isNotNull);
+      expect(regionMap.onCivilianTileTapped, isNotNull);
+      expect(regionMap.onFleetMarkerTapped, isNotNull);
+
+      bus.emit(
+        StartCivilianWorkTargetSelectionEvent(
+          unitId: sampleUnitId,
+          workTarget: 'explore',
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+
+      expect(find.text('Select a tile, or click cancel'), findsOneWidget);
+      regionMap = tester.widget<CtRegionMap>(find.byType(CtRegionMap).first);
+      expect(regionMap.onMapTileTappedForDetail, isNull);
+      expect(regionMap.onCivilianTileTapped, isNull);
+      expect(regionMap.onFleetMarkerTapped, isNull);
+    },
+  );
 }

--- a/packages/colonizethis_logic/test/world/civilian_ownership_legality_test.dart
+++ b/packages/colonizethis_logic/test/world/civilian_ownership_legality_test.dart
@@ -1,0 +1,140 @@
+import 'package:colonizethis_logic/src/world/civilian_ownership_legality.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('relocateIllegalCiviliansInChangedProvinces', () {
+    const ow = 'oldWorld';
+    const changedProvinceId = '$ow|P1';
+    const changedTile = '$ow|P1|0|0';
+    const unchangedProvinceId = '$ow|P2';
+    const unchangedTile = '$ow|P2|0|0';
+    const capitalProvinceId = '$ow|C1';
+    const capitalTile = '$ow|C1|0|0';
+
+    Game baseGame({
+      required List<Unit> units,
+      Player? owner,
+      List<Province>? oldWorldProvinces,
+    }) {
+      return Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
+          oldWorld: RegionData(
+            provinces:
+                oldWorldProvinces ??
+                const [
+                  Province(id: changedProvinceId, regionId: ow, ownerId: 'new_owner'),
+                  Province(id: unchangedProvinceId, regionId: ow, ownerId: 'new_owner'),
+                  Province(id: capitalProvinceId, regionId: ow, ownerId: 'gp2'),
+                ],
+            units: units,
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: [
+          owner ??
+              const Player(
+                id: 'gp2',
+                displayName: 'GP 2',
+                isHuman: false,
+                capitalProvinceId: capitalProvinceId,
+                capitalTile: CapitalTile(regionId: ow, provinceId: 'C1', x: 0, y: 0),
+              ),
+          const Player(id: 'new_owner', displayName: 'New Owner', isHuman: false),
+        ],
+      );
+    }
+
+    test('relocates illegal civilian in changed province and normalizes state', () {
+      final unit = Unit(
+        id: 'u1',
+        type: 'Builder',
+        ownerId: 'gp2',
+        locationProvinceId: changedProvinceId,
+        tileKey: changedTile,
+        status: UnitStatus.working,
+        currentWork: const CurrentWork(
+          workTarget: 'build_road',
+          tileKey: changedTile,
+          totalTurns: 2,
+          remainingTurns: 1,
+        ),
+        originTileKey: changedTile,
+        assignedTileKey: changedTile,
+      );
+      final result = relocateIllegalCiviliansInChangedProvinces(
+        baseGame(units: [unit]),
+        changedProvinceIds: {changedProvinceId},
+      );
+      final relocated = result.worldState.oldWorld.units.single;
+      expect(relocated.tileKey, capitalTile);
+      expect(relocated.locationProvinceId, capitalProvinceId);
+      expect(relocated.status, UnitStatus.idle);
+      expect(relocated.currentWork, isNull);
+      expect(relocated.originTileKey, isNull);
+      expect(relocated.assignedTileKey, isNull);
+    });
+
+    test('does not evaluate civilians outside changed provinces', () {
+      final unit = Unit(
+        id: 'u1',
+        type: 'Builder',
+        ownerId: 'gp2',
+        locationProvinceId: unchangedProvinceId,
+        tileKey: unchangedTile,
+      );
+      final result = relocateIllegalCiviliansInChangedProvinces(
+        baseGame(units: [unit]),
+        changedProvinceIds: {changedProvinceId},
+      );
+      final unchanged = result.worldState.oldWorld.units.single;
+      expect(unchanged.tileKey, unchangedTile);
+      expect(unchanged.locationProvinceId, unchangedProvinceId);
+    });
+
+    test('throws hard error when owner capital tile cannot be resolved', () {
+      final unit = Unit(
+        id: 'u1',
+        type: 'Builder',
+        ownerId: 'gp2',
+        locationProvinceId: changedProvinceId,
+        tileKey: changedTile,
+      );
+      final ownerWithoutCapital = const Player(
+        id: 'gp2',
+        displayName: 'GP 2',
+        isHuman: false,
+      );
+      expect(
+        () => relocateIllegalCiviliansInChangedProvinces(
+          baseGame(units: [unit], owner: ownerWithoutCapital),
+          changedProvinceIds: {changedProvinceId},
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('throws hard error when owner capital province cannot be resolved', () {
+      final unit = Unit(
+        id: 'u1',
+        type: 'Builder',
+        ownerId: 'gp2',
+        locationProvinceId: changedProvinceId,
+        tileKey: changedTile,
+      );
+      final provincesWithoutCapital = const [
+        Province(id: changedProvinceId, regionId: ow, ownerId: 'new_owner'),
+        Province(id: unchangedProvinceId, regionId: ow, ownerId: 'new_owner'),
+      ];
+      expect(
+        () => relocateIllegalCiviliansInChangedProvinces(
+          baseGame(units: [unit], oldWorldProvinces: provincesWithoutCapital),
+          changedProvinceIds: {changedProvinceId},
+        ),
+        throwsStateError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add focused tests for `relocateIllegalCiviliansInChangedProvinces` in `packages/colonizethis_logic/test/world/civilian_ownership_legality_test.dart`
- verify changed-province scoping and state normalization on illegal civilian relocation
- add strict error-path coverage for missing capital tile and unresolved capital province to close the remaining issue-closure evidence gap

## Test plan
- [x] `cd packages/colonizethis_logic && dart test test/world/civilian_ownership_legality_test.dart`

Refs #1892

Made with [Cursor](https://cursor.com)