### PR TITLE
test(logic): pending-order civilian legality coverage (Refs #1892)

### DIFF
--- a/packages/colonizethis_logic/test/combat_resolver_test.dart
+++ b/packages/colonizethis_logic/test/combat_resolver_test.dart
@@ -1132,6 +1132,90 @@ void main() {
     );
 
     test(
+      'combat conquest relocates idle foreign civilian with stale assignment '
+      'tracking but no currentWork to owner capital',
+      () {
+        const ow = 'oldWorld';
+        const provinceId = '$ow|P1';
+        const tileKey = '$ow|P1|0|0';
+        const cCapProvince = '$ow|C1';
+        const cCapTile = '$ow|C1|0|0';
+
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(id: provinceId, regionId: ow, ownerId: 'def'),
+                Province(id: cCapProvince, regionId: ow, ownerId: 'civ'),
+              ],
+              units: [
+                Unit(
+                  id: 'att1',
+                  type: 'grenadiers',
+                  ownerId: 'att',
+                  locationProvinceId: provinceId,
+                ),
+                Unit(
+                  id: 'def1',
+                  type: 'peasant_levies',
+                  ownerId: 'def',
+                  locationProvinceId: provinceId,
+                ),
+                Unit(
+                  id: 'civ1',
+                  type: 'Builder',
+                  ownerId: 'civ',
+                  locationProvinceId: provinceId,
+                  tileKey: tileKey,
+                  status: UnitStatus.idle,
+                  originTileKey: tileKey,
+                  assignedTileKey: tileKey,
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'att', displayName: 'Attacker', isHuman: true),
+            Player(id: 'def', displayName: 'Defender', isHuman: true),
+            Player(
+              id: 'civ',
+              displayName: 'CivOwner',
+              isHuman: false,
+              capitalProvinceId: cCapProvince,
+              capitalTile: CapitalTile(regionId: ow, provinceId: 'C1', x: 0, y: 0),
+            ),
+          ],
+        );
+
+        const ctx = BattleContext(
+          provinceId: provinceId,
+          regionId: ow,
+          defenderFactionId: 'def',
+          defenderUnitIds: ['def1'],
+          attackers: [
+            AttackingSide(factionId: 'att', unitIds: ['att1'], generalMedals: 0),
+          ],
+          fortLevel: 0,
+          terrain: 'plains',
+        );
+
+        final after = resolveBattleContext(game, ctx);
+        final relocated = after.worldState.oldWorld.units
+            .where((u) => u.id == 'civ1')
+            .single;
+        expect(relocated.tileKey, cCapTile);
+        expect(relocated.locationProvinceId, cCapProvince);
+        expect(relocated.status, UnitStatus.idle);
+        expect(relocated.currentWork, isNull);
+        expect(relocated.originTileKey, isNull);
+        expect(relocated.assignedTileKey, isNull);
+      },
+    );
+
+    test(
       'general medals provide morale aura bonus (5% per medal, max 20%)',
       () {
         expect(moraleMultiplierForGeneralMedals(0), 1.0);

--- a/packages/colonizethis_logic/test/diplomacy_resolver_phase_test.dart
+++ b/packages/colonizethis_logic/test/diplomacy_resolver_phase_test.dart
@@ -474,6 +474,92 @@ void main() {
       },
     );
 
+    test(
+      'join empire relocates idle foreign civilian with stale assignment '
+      'tracking but no currentWork to owner capital',
+      () {
+        const ow = 'oldWorld';
+        const absorbedProvince = '$ow|m1';
+        const absorbedTile = '$ow|m1|0|0';
+        const foreignCapProvince = '$ow|c1';
+        const foreignCapTile = '$ow|c1|0|0';
+
+        var game = baseGame().copyWith(
+          players: const [
+            Player(id: 'gp1', displayName: 'GP1', isHuman: true, treasury: 15000),
+            Player(
+              id: 'gp2',
+              displayName: 'GP2',
+              isHuman: false,
+              capitalProvinceId: foreignCapProvince,
+              capitalTile: CapitalTile(regionId: ow, provinceId: 'c1', x: 0, y: 0),
+            ),
+          ],
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(id: absorbedProvince, regionId: ow, ownerId: 'minor1'),
+                Province(id: foreignCapProvince, regionId: ow, ownerId: 'gp2'),
+              ],
+              units: [
+                Unit(
+                  id: 'foreign_builder',
+                  type: 'Builder',
+                  ownerId: 'gp2',
+                  locationProvinceId: absorbedProvince,
+                  tileKey: absorbedTile,
+                  status: UnitStatus.idle,
+                  originTileKey: absorbedTile,
+                  assignedTileKey: absorbedTile,
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+          ),
+          overtureStates: const [
+            OvertureState(
+              gpId: 'gp1',
+              targetId: 'minor1',
+              stage: OvertureStage.nap,
+              sinceTurn: 0,
+            ),
+          ],
+          diplomacyRelations: const [
+            DiplomacyRelation(
+              factionId1: 'gp1',
+              factionId2: 'minor1',
+              score: 60,
+              level: RelationLevel.friendly,
+            ),
+          ],
+        );
+
+        final orders = Orders(
+          diplomaticOrdersByPlayerId: {
+            'gp1': const [
+              DiplomaticOrder(
+                type: DiplomaticOrderType.establishOverture,
+                targetFactionId: 'minor1',
+                overtureStage: OvertureStage.joinEmpire,
+              ),
+            ],
+          },
+        );
+
+        final after = resolveDiplomacyPhase(game, orders).game;
+        final relocated = after.worldState.oldWorld.units
+            .where((u) => u.id == 'foreign_builder')
+            .single;
+        expect(relocated.tileKey, foreignCapTile);
+        expect(relocated.locationProvinceId, foreignCapProvince);
+        expect(relocated.status, UnitStatus.idle);
+        expect(relocated.currentWork, isNull);
+        expect(relocated.originTileKey, isNull);
+        expect(relocated.assignedTileKey, isNull);
+      },
+    );
+
     test('join empire not applied when treasury below cost: minor unchanged', () {
       const ow = 'oldWorld';
       var game = baseGame().copyWith(

--- a/packages/colonizethis_logic/test/world/civilian_ownership_legality_test.dart
+++ b/packages/colonizethis_logic/test/world/civilian_ownership_legality_test.dart
@@ -77,6 +77,32 @@ void main() {
       expect(relocated.assignedTileKey, isNull);
     });
 
+    test(
+      'relocates idle civilian with stale assignment tracking but no currentWork',
+      () {
+      final unit = Unit(
+        id: 'u1',
+        type: 'Builder',
+        ownerId: 'gp2',
+        locationProvinceId: changedProvinceId,
+        tileKey: changedTile,
+        status: UnitStatus.idle,
+        originTileKey: changedTile,
+        assignedTileKey: changedTile,
+      );
+      final result = relocateIllegalCiviliansInChangedProvinces(
+        baseGame(units: [unit]),
+        changedProvinceIds: {changedProvinceId},
+      );
+      final relocated = result.worldState.oldWorld.units.single;
+      expect(relocated.tileKey, capitalTile);
+      expect(relocated.locationProvinceId, capitalProvinceId);
+      expect(relocated.status, UnitStatus.idle);
+      expect(relocated.currentWork, isNull);
+      expect(relocated.originTileKey, isNull);
+      expect(relocated.assignedTileKey, isNull);
+    });
+
     test('does not evaluate civilians outside changed provinces', () {
       final unit = Unit(
         id: 'u1',


### PR DESCRIPTION
## Summary
Closes the remaining verification gap for **#1892** Phase 2: civilians in a **pending-order / pre-application** shape (`UnitStatus.idle`, no `currentWork`, but non-null `originTileKey` / `assignedTileKey` on a tile that becomes illegal after an ownership change) are relocated to the owner capital and fully normalized, matching working civilians.

## Changes
- `civilian_ownership_legality_test.dart`: direct `relocateIllegalCiviliansInChangedProvinces` coverage.
- `combat_resolver_test.dart`: `resolveBattleContext` after province flip.
- `diplomacy_resolver_phase_test.dart`: Join Empire path after minor absorption.

## Tests
```bash
dart test packages/colonizethis_logic/test/world/civilian_ownership_legality_test.dart \
  packages/colonizethis_logic/test/combat_resolver_test.dart \
  packages/colonizethis_logic/test/diplomacy_resolver_phase_test.dart
```

Refs #1892

Made with [Cursor](https://cursor.com)