### PR TITLE
refactor(repo-lint): add widget build-size AST gate

### DIFF
--- a/SPEC/program/disallowed-ast-patterns.md
+++ b/SPEC/program/disallowed-ast-patterns.md
@@ -47,6 +47,19 @@ type safety and hides intent in APIs and state declarations.
 
 Rule id: `strict_raw_types` (`match.kind`: `raw_named_type`,
 `match.type_names`: `List|Map|Set|Iterable|Future|Stream`).
+
+### Widget `build()` body line span
+
+In runtime domain code, a widget class `build()` method body is disallowed when
+its physical line span exceeds **60** lines.
+
+Rationale: oversized build methods hide UI intent, make reviews harder, and
+encourage cross-concern coupling instead of extracting sub-widgets.
+
+Rule id: `widget_build_method_too_long` (`match.kind`:
+`method_body_line_span`, `match.function_name`: `build`,
+`match.max_body_line_span`: `60`,
+`match.require_widget_class_extends`: `true`).
 ### Coverage
 
 Enforcement walks the same domain trees via `tool/ct_repo_lint_scan_contract.dart` (`collectRepoLintDomainDartFiles`), aligned with `SPEC/program/exception-enforcement.md` coverage:
@@ -89,3 +102,14 @@ Generated files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`) and tests (`**/te
   `List<int> values = <int>[];`, **when** the disallowed AST checker runs,
   **then** it does not report a `strict_raw_types` violation for that
   declaration.
+
+- **Given** runtime Dart source with a class extending `StatelessWidget` or
+  `StatefulWidget` where the `build()` method body spans more than 60 physical
+  lines, **when** the disallowed AST checker runs, **then** it reports at least
+  one violation for `widget_build_method_too_long` with the correct file and
+  line.
+
+- **Given** runtime Dart source with a class extending `StatelessWidget` or
+  `StatefulWidget` where the `build()` method body spans 60 physical lines or
+  fewer, **when** the disallowed AST checker runs, **then** it does not report
+  a `widget_build_method_too_long` violation for that method.

--- a/test/check_disallowed_ast_patterns_test.dart
+++ b/test/check_disallowed_ast_patterns_test.dart
@@ -30,6 +30,13 @@ rules:
         - Iterable
         - Future
         - Stream
+  - id: widget_build_method_too_long
+    message: 'widget build body too long'
+    match:
+      kind: method_body_line_span
+      function_name: build
+      max_body_line_span: 3
+      require_widget_class_extends: true
 ''';
 
 void main() {
@@ -273,6 +280,88 @@ class X {
 
 class X {
   Map value = {};
+}
+''';
+      expect(
+        findDisallowedAstViolations('packages/foo/lib/x.dart', src, rules),
+        isEmpty,
+      );
+    });
+
+    test('flags overlong widget build() body', () {
+      const src = r'''
+import 'package:flutter/widgets.dart';
+
+class X extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final a = 1;
+    final b = 2;
+    return Text('$a$b');
+  }
+}
+''';
+      final v = findDisallowedAstViolations(
+        'packages/foo/lib/x.dart',
+        src,
+        rules,
+      );
+      expect(v, isNotEmpty);
+      expect(v.first.ruleId, 'widget_build_method_too_long');
+    });
+
+    test('allows short widget build() body', () {
+      const src = r'''
+import 'package:flutter/widgets.dart';
+
+class X extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox();
+  }
+}
+''';
+      expect(
+        findDisallowedAstViolations('packages/foo/lib/x.dart', src, rules),
+        isEmpty,
+      );
+    });
+
+    test('ignores build() in non-widget classes', () {
+      const src = r'''
+class NotAWidget {
+  Object build() {
+    final a = 1;
+    final b = 2;
+    final c = 3;
+    return a + b + c;
+  }
+}
+''';
+      expect(
+        findDisallowedAstViolations('packages/foo/lib/x.dart', src, rules),
+        isEmpty,
+      );
+    });
+
+    test('widget_build_method_too_long respects suppression comment', () {
+      const src = r'''
+import 'package:flutter/widgets.dart';
+
+class X extends StatefulWidget {
+  const X({super.key});
+  @override
+  State<X> createState() => _XState();
+}
+
+class _XState extends State<X> {
+  @override
+  // ignore: disallowed_ast_widget_build_method_too_long
+  Widget build(BuildContext context) {
+    final a = 1;
+    final b = 2;
+    return Text('$a$b');
+  }
 }
 ''';
       expect(

--- a/tool/check_disallowed_ast_patterns.dart
+++ b/tool/check_disallowed_ast_patterns.dart
@@ -212,6 +212,9 @@ List<DisallowedPatternRule> _parseRulesYaml(Object? yamlRoot) {
           cascadedMethodNames: names,
           commentSubstring: null,
           rawNamedTypeNames: const {},
+          functionName: null,
+          maxBodyLineSpan: null,
+          requireWidgetClassExtends: false,
         ),
       );
     } else if (kind == 'stream_where_is_map_as') {
@@ -223,6 +226,9 @@ List<DisallowedPatternRule> _parseRulesYaml(Object? yamlRoot) {
           cascadedMethodNames: const {},
           commentSubstring: null,
           rawNamedTypeNames: const {},
+          functionName: null,
+          maxBodyLineSpan: null,
+          requireWidgetClassExtends: false,
         ),
       );
     } else if (kind == 'comment_substring') {
@@ -238,6 +244,9 @@ List<DisallowedPatternRule> _parseRulesYaml(Object? yamlRoot) {
           cascadedMethodNames: const {},
           commentSubstring: needle,
           rawNamedTypeNames: const {},
+          functionName: null,
+          maxBodyLineSpan: null,
+          requireWidgetClassExtends: false,
         ),
       );
     } else if (kind == 'raw_named_type') {
@@ -263,6 +272,35 @@ List<DisallowedPatternRule> _parseRulesYaml(Object? yamlRoot) {
           cascadedMethodNames: const {},
           commentSubstring: null,
           rawNamedTypeNames: names,
+          functionName: null,
+          maxBodyLineSpan: null,
+          requireWidgetClassExtends: false,
+        ),
+      );
+    } else if (kind == 'method_body_line_span') {
+      final functionName = match['function_name']?.toString();
+      final maxBodyLineSpan = int.tryParse(
+        match['max_body_line_span']?.toString() ?? '',
+      );
+      final requireWidgetClassExtends =
+          match['require_widget_class_extends'] == true;
+      if (functionName == null ||
+          functionName.isEmpty ||
+          maxBodyLineSpan == null ||
+          maxBodyLineSpan < 1) {
+        continue;
+      }
+      out.add(
+        DisallowedPatternRule(
+          id: id,
+          message: message,
+          kind: DisallowedAstMatchKind.methodBodyLineSpan,
+          cascadedMethodNames: const {},
+          commentSubstring: null,
+          rawNamedTypeNames: const {},
+          functionName: functionName,
+          maxBodyLineSpan: maxBodyLineSpan,
+          requireWidgetClassExtends: requireWidgetClassExtends,
         ),
       );
     }
@@ -299,6 +337,7 @@ enum DisallowedAstMatchKind {
   streamWhereIsMapAs,
   commentSubstring,
   rawNamedType,
+  methodBodyLineSpan,
 }
 
 class DisallowedPatternRule {
@@ -309,6 +348,9 @@ class DisallowedPatternRule {
     required this.cascadedMethodNames,
     required this.commentSubstring,
     required this.rawNamedTypeNames,
+    required this.functionName,
+    required this.maxBodyLineSpan,
+    required this.requireWidgetClassExtends,
   });
 
   final String id;
@@ -317,6 +359,9 @@ class DisallowedPatternRule {
   final Set<String> cascadedMethodNames;
   final String? commentSubstring;
   final Set<String> rawNamedTypeNames;
+  final String? functionName;
+  final int? maxBodyLineSpan;
+  final bool requireWidgetClassExtends;
 }
 
 class DisallowedAstViolation {
@@ -507,5 +552,46 @@ class _DisallowedAstVisitor extends RecursiveAstVisitor<void> {
       _recordIfAllowed(node, rule);
     }
     super.visitNamedType(node);
+  }
+
+  @override
+  void visitMethodDeclaration(MethodDeclaration node) {
+    for (final rule in rules) {
+      if (rule.kind != DisallowedAstMatchKind.methodBodyLineSpan) {
+        continue;
+      }
+      if (node.name.lexeme != rule.functionName) {
+        continue;
+      }
+      if (rule.requireWidgetClassExtends &&
+          !_methodBelongsToWidgetClass(node)) {
+        continue;
+      }
+      final bodyLineSpan = _lineSpan(node.body);
+      final maxBodyLineSpan = rule.maxBodyLineSpan!;
+      if (bodyLineSpan > maxBodyLineSpan) {
+        _recordIfAllowed(node, rule);
+      }
+    }
+    super.visitMethodDeclaration(node);
+  }
+
+  bool _methodBelongsToWidgetClass(MethodDeclaration node) {
+    final parent = node.parent;
+    if (parent is! ClassDeclaration) {
+      return false;
+    }
+    final extendsClause = parent.extendsClause;
+    if (extendsClause == null) {
+      return false;
+    }
+    final superName = extendsClause.superclass.name2.lexeme;
+    return superName == 'StatelessWidget' || superName == 'StatefulWidget';
+  }
+
+  int _lineSpan(AstNode node) {
+    final start = lineInfo.getLocation(node.offset).lineNumber;
+    final end = lineInfo.getLocation(node.end).lineNumber;
+    return end - start + 1;
   }
 }

--- a/tool/disallowed_ast_patterns.yaml
+++ b/tool/disallowed_ast_patterns.yaml
@@ -39,3 +39,12 @@ rules:
         - Iterable
         - Future
         - Stream
+  - id: widget_build_method_too_long
+    message: >-
+      Do not allow widget build() method bodies above 60 physical lines.
+      Extract sub-widgets or helper builders to keep build logic readable.
+    match:
+      kind: method_body_line_span
+      function_name: build
+      max_body_line_span: 60
+      require_widget_class_extends: true


### PR DESCRIPTION
## Summary
- Add a new disallowed AST matcher kind (`method_body_line_span`) and wire `widget_build_method_too_long` to flag widget `build()` bodies longer than 60 physical lines.
- Update `tool/disallowed_ast_patterns.yaml` and extend checker tests for positive, negative, non-widget, and suppression cases.
- Update `SPEC/program/disallowed-ast-patterns.md` with the new policy and Given/When/Then acceptance criteria.

## Scope
- Implements one isolatable enforcement slice for #1878: CI guardrail for widget build-method size.
- Deferred to follow-up slices: refactoring existing oversized widget build methods and broader app structural decomposition.

## Test plan
- [x] `dart test test/check_disallowed_ast_patterns_test.dart`
- [x] `dart run tool/check_disallowed_ast_patterns.dart --files tool/check_disallowed_ast_patterns.dart,test/check_disallowed_ast_patterns_test.dart`

Refs #1878

Made with [Cursor](https://cursor.com)