### PR TITLE
refactor(ui): split main menu build composition

### DIFF
--- a/app/lib/widgets/main_menu.dart
+++ b/app/lib/widgets/main_menu.dart
@@ -60,71 +60,18 @@ class CtMainMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = appL10n(context);
-    final Widget content = SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24),
-        child: Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 400),
-            child: SingleChildScrollView(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const SizedBox(height: 48),
-                  _buildLogo(context),
-                  if (_showAfterVictorySubtitle) ...[
-                    const SizedBox(height: 12),
-                    Text(
-                      l10n.mainMenu_subtitleAfterVictory,
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        fontStyle: FontStyle.italic,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ],
-                  const SizedBox(height: 32),
-                  _MenuButton(
-                    label: l10n.mainMenu_newGame,
-                    variant: variant,
-                    onPressed: onNewGame,
-                  ),
-                  if (resumeGameVisible) ...[
-                    const SizedBox(height: 12),
-                    _MenuButton(
-                      label: l10n.mainMenu_resumeGame,
-                      variant: variant,
-                      onPressed: onResumeGame!,
-                    ),
-                  ],
-                  const SizedBox(height: 12),
-                  _LoadGameButton(
-                    enabled: _loadGameEnabled,
-                    variant: variant,
-                    onPressed: onLoadGame,
-                  ),
-                  const SizedBox(height: 12),
-                  _MenuButton(
-                    label: l10n.mainMenu_settings,
-                    variant: variant,
-                    onPressed: onSettings,
-                  ),
-                  const SizedBox(height: 32),
-                  Text(version, style: Theme.of(context).textTheme.bodySmall),
-                  const SizedBox(height: 8),
-                  _MenuButton(
-                    label: l10n.mainMenu_quit,
-                    variant: variant,
-                    onPressed: onQuit,
-                  ),
-                  const SizedBox(height: 24),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ),
+    final content = _MainMenuBody(
+      variant: variant,
+      showAfterVictorySubtitle: _showAfterVictorySubtitle,
+      loadGameEnabled: _loadGameEnabled,
+      resumeGameVisible: resumeGameVisible,
+      version: version,
+      onNewGame: onNewGame,
+      onResumeGame: onResumeGame,
+      onLoadGame: onLoadGame,
+      onSettings: onSettings,
+      onQuit: onQuit,
+      logoBuilder: _buildLogo,
     );
 
     if (variant == MainMenuVariant.pixelArt) {
@@ -170,6 +117,153 @@ class CtMainMenu extends StatelessWidget {
         },
       ),
     );
+  }
+}
+
+class _MainMenuBody extends StatelessWidget {
+  const _MainMenuBody({
+    required this.variant,
+    required this.showAfterVictorySubtitle,
+    required this.loadGameEnabled,
+    required this.resumeGameVisible,
+    required this.version,
+    required this.onNewGame,
+    required this.onResumeGame,
+    required this.onLoadGame,
+    required this.onSettings,
+    required this.onQuit,
+    required this.logoBuilder,
+  });
+
+  final MainMenuVariant variant;
+  final bool showAfterVictorySubtitle;
+  final bool loadGameEnabled;
+  final bool resumeGameVisible;
+  final String version;
+  final VoidCallback onNewGame;
+  final VoidCallback? onResumeGame;
+  final VoidCallback onLoadGame;
+  final VoidCallback onSettings;
+  final VoidCallback onQuit;
+  final Widget Function(BuildContext context) logoBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 400),
+            child: SingleChildScrollView(
+              child: _MainMenuBodyContent(
+                variant: variant,
+                showAfterVictorySubtitle: showAfterVictorySubtitle,
+                loadGameEnabled: loadGameEnabled,
+                resumeGameVisible: resumeGameVisible,
+                version: version,
+                onNewGame: onNewGame,
+                onResumeGame: onResumeGame,
+                onLoadGame: onLoadGame,
+                onSettings: onSettings,
+                onQuit: onQuit,
+                logoBuilder: logoBuilder,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MainMenuBodyContent extends StatelessWidget {
+  const _MainMenuBodyContent({
+    required this.variant,
+    required this.showAfterVictorySubtitle,
+    required this.loadGameEnabled,
+    required this.resumeGameVisible,
+    required this.version,
+    required this.onNewGame,
+    required this.onResumeGame,
+    required this.onLoadGame,
+    required this.onSettings,
+    required this.onQuit,
+    required this.logoBuilder,
+  });
+
+  final MainMenuVariant variant;
+  final bool showAfterVictorySubtitle;
+  final bool loadGameEnabled;
+  final bool resumeGameVisible;
+  final String version;
+  final VoidCallback onNewGame;
+  final VoidCallback? onResumeGame;
+  final VoidCallback onLoadGame;
+  final VoidCallback onSettings;
+  final VoidCallback onQuit;
+  final Widget Function(BuildContext context) logoBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      mainAxisSize: MainAxisSize.min,
+      children: _menuChildren(context),
+    );
+  }
+
+  List<Widget> _menuChildren(BuildContext context) {
+    final l10n = appL10n(context);
+    return [
+      const SizedBox(height: 48),
+      logoBuilder(context),
+      if (showAfterVictorySubtitle) ...[
+        const SizedBox(height: 12),
+        Text(
+          l10n.mainMenu_subtitleAfterVictory,
+          style: Theme.of(
+            context,
+          ).textTheme.bodyMedium?.copyWith(fontStyle: FontStyle.italic),
+          textAlign: TextAlign.center,
+        ),
+      ],
+      const SizedBox(height: 32),
+      _MenuButton(
+        label: l10n.mainMenu_newGame,
+        variant: variant,
+        onPressed: onNewGame,
+      ),
+      if (resumeGameVisible) ...[
+        const SizedBox(height: 12),
+        _MenuButton(
+          label: l10n.mainMenu_resumeGame,
+          variant: variant,
+          onPressed: onResumeGame!,
+        ),
+      ],
+      const SizedBox(height: 12),
+      _LoadGameButton(
+        enabled: loadGameEnabled,
+        variant: variant,
+        onPressed: onLoadGame,
+      ),
+      const SizedBox(height: 12),
+      _MenuButton(
+        label: l10n.mainMenu_settings,
+        variant: variant,
+        onPressed: onSettings,
+      ),
+      const SizedBox(height: 32),
+      Text(version, style: Theme.of(context).textTheme.bodySmall),
+      const SizedBox(height: 8),
+      _MenuButton(
+        label: l10n.mainMenu_quit,
+        variant: variant,
+        onPressed: onQuit,
+      ),
+      const SizedBox(height: 24),
+    ];
   }
 }
 


### PR DESCRIPTION
## Summary
- Refactor `CtMainMenu` to keep the top-level widget `build()` concise by extracting menu composition into private helper widgets.
- Preserve menu behavior, callbacks, variants, and rendering semantics while reducing build-method complexity in shared `app/lib/widgets` code.
- Keep this slice aligned with the widget build-size lint guard introduced in #1943.

## Scope
- Implements one follow-up slice for #1878 focused on `app/lib/widgets/main_menu.dart`.
- Deferred: other oversized widget `build()` methods reported by `widget_build_method_too_long`.

## Test plan
- [x] `dart run tool/check_disallowed_ast_patterns.dart --files app/lib/widgets/main_menu.dart`
- [x] `cd app && flutter test test/screen_spec_acceptance_test.dart test/app_shell_routes_test.dart`

Refs #1878

Made with [Cursor](https://cursor.com)