### PR TITLE
refactor(ui): slim CtDropdown build for lint threshold

### DIFF
--- a/app/lib/widgets/ct_dropdown.dart
+++ b/app/lib/widgets/ct_dropdown.dart
@@ -31,6 +31,13 @@ class CtDropdown<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    return CtNinePatchButton(
+      onPressed: () => _openPicker(context),
+      child: _buttonChild(context),
+    );
+  }
+
+  Widget _buttonChild(BuildContext context) {
     final selected = value != null && items.contains(value)
         ? _labelFor(value as T)
         : (hint ?? 'Select');
@@ -66,66 +73,62 @@ class CtDropdown<T> extends StatelessWidget {
       );
     }
 
-    return CtNinePatchButton(
-      onPressed: () async {
-        final chosen = await showDialog<T>(
-          context: context,
-          builder: (ctx) => CtDialogShell(
-            maxWidth: 320,
-            maxHeight: 400,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                if (hint != null) ...[
-                  Text(hint!, style: Theme.of(ctx).textTheme.titleMedium),
-                  const SizedBox(height: 8),
-                ],
-                ListView.builder(
-                  shrinkWrap: true,
-                  physics: const NeverScrollableScrollPhysics(),
-                  itemCount: items.length,
-                  itemBuilder: (context, index) {
-                    final v = items[index];
-                    final label = _labelFor(v);
-                    final rowLeading = itemLeading?.call(context, v);
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: 4),
-                      child: CtNinePatchButton(
-                        onPressed: () {
-                          Navigator.of(ctx).pop(v);
-                        },
-                        enabled: true,
-                        child: Align(
-                          alignment: Alignment.centerLeft,
-                          child: Row(
-                            children: [
-                              if (rowLeading != null) ...[
-                                rowLeading,
-                                const SizedBox(width: 8),
-                              ],
-                              Expanded(
-                                child: Text(
-                                  label,
-                                  overflow: TextOverflow.ellipsis,
-                                ),
-                              ),
-                            ],
+    return buttonChild;
+  }
+
+  Future<void> _openPicker(BuildContext context) async {
+    final chosen = await showDialog<T>(
+      context: context,
+      builder: (ctx) => CtDialogShell(
+        maxWidth: 320,
+        maxHeight: 400,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (hint != null) ...[
+              Text(hint!, style: Theme.of(ctx).textTheme.titleMedium),
+              const SizedBox(height: 8),
+            ],
+            ListView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: items.length,
+              itemBuilder: (context, index) {
+                final v = items[index];
+                final label = _labelFor(v);
+                final rowLeading = itemLeading?.call(context, v);
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: CtNinePatchButton(
+                    onPressed: () {
+                      Navigator.of(ctx).pop(v);
+                    },
+                    enabled: true,
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Row(
+                        children: [
+                          if (rowLeading != null) ...[
+                            rowLeading,
+                            const SizedBox(width: 8),
+                          ],
+                          Expanded(
+                            child: Text(label, overflow: TextOverflow.ellipsis),
                           ),
-                        ),
+                        ],
                       ),
-                    );
-                  },
-                ),
-              ],
+                    ),
+                  ),
+                );
+              },
             ),
-          ),
-        );
-        if (chosen != null) {
-          onChanged(chosen);
-        }
-      },
-      child: buttonChild,
+          ],
+        ),
+      ),
     );
+    if (chosen != null) {
+      onChanged(chosen);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Refactor `CtDropdown` so `build()` only wires `CtNinePatchButton` to `_openPicker` and `_buttonChild`.
- Move the expanded/collapsed row layout and the modal picker `showDialog` flow into private instance methods; behavior and UI structure are unchanged.

## Scope
- One follow-up slice for #1878: clear `widget_build_method_too_long` for `app/lib/widgets/ct_dropdown.dart`.
- Deferred: `ct_transfer_list.dart` and other remaining oversized `build()` methods.

## Test plan
- [x] `dart run tool/check_disallowed_ast_patterns.dart --files app/lib/widgets/ct_dropdown.dart`
- [x] `cd app && dart analyze lib/widgets/ct_dropdown.dart`
- [x] `cd app && flutter test test/screen_spec_acceptance_test.dart --plain-name "CtGameSetup"`

Refs #1878

Made with [Cursor](https://cursor.com)