### PR TITLE
fix(ui): show Explore selection highlights across regions (Refs #1916)

### DIFF
--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -244,6 +244,32 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
 
   Set<String>? get _validTileKeysForSelection => _cachedValidTileKeys;
 
+  int? _preferredRegionIndexForValidSelection(Set<String> validTileKeys) {
+    if (validTileKeys.isEmpty) {
+      return null;
+    }
+    final currentRegionId = _currentRegion.regionId;
+    final hasCurrent = validTileKeys.any(
+      (tileKey) => tileKey.startsWith('$currentRegionId|'),
+    );
+    if (hasCurrent) {
+      return null;
+    }
+    final hasOldWorld = validTileKeys.any(
+      (tileKey) => tileKey.startsWith('$kRegionOldWorld|'),
+    );
+    final hasNewWorld = validTileKeys.any(
+      (tileKey) => tileKey.startsWith('$kRegionNewWorld|'),
+    );
+    if (hasOldWorld && !hasNewWorld) {
+      return 0;
+    }
+    if (hasNewWorld && !hasOldWorld) {
+      return 1;
+    }
+    return null;
+  }
+
   void _computeValidTileKeysForSelection() {
     if (_workTargetSelection == null) {
       _cachedValidTileKeys = null;
@@ -440,6 +466,15 @@ class _GameMapAreaState extends ConsumerState<GameMapArea> {
     setState(() {
       _workTargetSelection = (unit: unit, workTarget: workTarget);
       _computeValidTileKeysForSelection();
+      final validTileKeys = _cachedValidTileKeys;
+      if (validTileKeys != null) {
+        final preferredRegionIndex = _preferredRegionIndexForValidSelection(
+          validTileKeys,
+        );
+        if (preferredRegionIndex != null) {
+          _regionIndex = preferredRegionIndex;
+        }
+      }
     });
   }
 

--- a/app/macos/Podfile.lock
+++ b/app/macos/Podfile.lock
@@ -1,21 +1,33 @@
 PODS:
   - FlutterMacOS (1.0.0)
+  - screen_retriever_macos (0.0.1):
+    - FlutterMacOS
   - url_launcher_macos (0.0.1):
+    - FlutterMacOS
+  - window_manager (0.5.0):
     - FlutterMacOS
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
+  - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
 
 EXTERNAL SOURCES:
   FlutterMacOS:
     :path: Flutter/ephemeral
+  screen_retriever_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
   url_launcher_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
+  window_manager:
+    :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
 
 SPEC CHECKSUMS:
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
   url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd
+  window_manager: b729e31d38fb04905235df9ea896128991cad99e
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
 

--- a/app/test/game_map_area_test.dart
+++ b/app/test/game_map_area_test.dart
@@ -733,7 +733,7 @@ void main() {
   );
 
   testWidgets(
-    'work target selection caches global valid tile keys across region switches',
+    'work target selection auto-switches to region with valid tiles when current tab has none',
     (WidgetTester tester) async {
       final init = getDebugInitGameResult();
       final game = init.game;
@@ -778,8 +778,8 @@ void main() {
             tileMapByRegion: init.tileMapByRegion,
           );
           final hasOldWorld = valid.any((k) => k.startsWith('oldWorld|'));
-          final hasOnlyOldWorld = hasOldWorld &&
-              !valid.any((k) => k.startsWith('newWorld|'));
+          final hasOnlyOldWorld =
+              hasOldWorld && !valid.any((k) => k.startsWith('newWorld|'));
           if (hasOnlyOldWorld) {
             offTabSelection = (unitId: unit.id, workTarget: workTarget);
             break;
@@ -834,18 +834,16 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 16));
 
-      final beforeSwitchRegionMap = tester
+      final autoSwitchedRegionMap = tester
           .widgetList<CtRegionMap>(find.byType(CtRegionMap))
           .first;
-      final beforeSwitchValidKeys = beforeSwitchRegionMap.validTileKeys;
-      expect(beforeSwitchValidKeys, isNotNull);
+      final autoSwitchedValidKeys = autoSwitchedRegionMap.validTileKeys;
+      expect(autoSwitchedRegionMap.region.regionId, kRegionOldWorld);
+      expect(autoSwitchedValidKeys, isNotNull);
       expect(
-        beforeSwitchValidKeys!.every((k) => k.startsWith('oldWorld|')),
+        autoSwitchedValidKeys!.every((k) => k.startsWith('oldWorld|')),
         isTrue,
       );
-      await tester.tap(find.text('Old World'));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 16));
 
       final afterSwitchRegionMap = tester
           .widgetList<CtRegionMap>(find.byType(CtRegionMap))
@@ -1052,62 +1050,61 @@ void main() {
     expect(regionMap.validTileKeys, isNull);
   });
 
-  testWidgets(
-    'selection mode blocks non-selection map interaction callbacks',
-    (WidgetTester tester) async {
-      final init = getDebugInitGameResult();
-      final game = init.game;
-      final mapViewData = init.mapViewData;
-      final bus = AppEventBus.create();
-      addTearDown(bus.dispose);
+  testWidgets('selection mode blocks non-selection map interaction callbacks', (
+    WidgetTester tester,
+  ) async {
+    final init = getDebugInitGameResult();
+    final game = init.game;
+    final mapViewData = init.mapViewData;
+    final bus = AppEventBus.create();
+    addTearDown(bus.dispose);
 
-      final sampleUnitId = game.worldState.oldWorld.units.isNotEmpty
-          ? game.worldState.oldWorld.units.first.id
-          : game.worldState.newWorld.units.first.id;
+    final sampleUnitId = game.worldState.oldWorld.units.isNotEmpty
+        ? game.worldState.oldWorld.units.first.id
+        : game.worldState.newWorld.units.first.id;
 
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            appEventBusProvider.overrideWith((ref) => bus),
-            currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
-            gamesBoxProvider.overrideWith((ref) => gamesBox),
-            gameServiceProvider.overrideWith(
-              (ref) => GameService(gamesBox, GameSaveAdapter()),
-            ),
-            currentOrdersProvider.overrideWith(
-              () => CurrentOrdersNotifier(const Orders()),
-            ),
-            mapViewDataProvider.overrideWith((ref) => mapViewData),
-          ],
-          child: MaterialApp(
-            home: Scaffold(
-              body: GameMapArea(game: game, mapViewData: mapViewData),
-            ),
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appEventBusProvider.overrideWith((ref) => bus),
+          currentGameProvider.overrideWith(() => CurrentGameNotifier(game)),
+          gamesBoxProvider.overrideWith((ref) => gamesBox),
+          gameServiceProvider.overrideWith(
+            (ref) => GameService(gamesBox, GameSaveAdapter()),
+          ),
+          currentOrdersProvider.overrideWith(
+            () => CurrentOrdersNotifier(const Orders()),
+          ),
+          mapViewDataProvider.overrideWith((ref) => mapViewData),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: GameMapArea(game: game, mapViewData: mapViewData),
           ),
         ),
-      );
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 16));
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
 
-      var regionMap = tester.widget<CtRegionMap>(find.byType(CtRegionMap).first);
-      expect(regionMap.onMapTileTappedForDetail, isNotNull);
-      expect(regionMap.onCivilianTileTapped, isNotNull);
-      expect(regionMap.onFleetMarkerTapped, isNotNull);
+    var regionMap = tester.widget<CtRegionMap>(find.byType(CtRegionMap).first);
+    expect(regionMap.onMapTileTappedForDetail, isNotNull);
+    expect(regionMap.onCivilianTileTapped, isNotNull);
+    expect(regionMap.onFleetMarkerTapped, isNotNull);
 
-      bus.emit(
-        StartCivilianWorkTargetSelectionEvent(
-          unitId: sampleUnitId,
-          workTarget: 'explore',
-        ),
-      );
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 16));
+    bus.emit(
+      StartCivilianWorkTargetSelectionEvent(
+        unitId: sampleUnitId,
+        workTarget: 'explore',
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
 
-      expect(find.text('Select a tile, or click cancel'), findsOneWidget);
-      regionMap = tester.widget<CtRegionMap>(find.byType(CtRegionMap).first);
-      expect(regionMap.onMapTileTappedForDetail, isNull);
-      expect(regionMap.onCivilianTileTapped, isNull);
-      expect(regionMap.onFleetMarkerTapped, isNull);
-    },
-  );
+    expect(find.text('Select a tile, or click cancel'), findsOneWidget);
+    regionMap = tester.widget<CtRegionMap>(find.byType(CtRegionMap).first);
+    expect(regionMap.onMapTileTappedForDetail, isNull);
+    expect(regionMap.onCivilianTileTapped, isNull);
+    expect(regionMap.onFleetMarkerTapped, isNull);
+  });
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -796,6 +796,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  screen_retriever:
+    dependency: transitive
+    description:
+      name: screen_retriever
+      sha256: "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_linux:
+    dependency: transitive
+    description:
+      name: screen_retriever_linux
+      sha256: f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_macos:
+    dependency: transitive
+    description:
+      name: screen_retriever_macos
+      sha256: "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_platform_interface:
+    dependency: transitive
+    description:
+      name: screen_retriever_platform_interface
+      sha256: ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_windows:
+    dependency: transitive
+    description:
+      name: screen_retriever_windows
+      sha256: "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   shelf:
     dependency: transitive
     description:
@@ -1097,6 +1137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.11.0"
+  window_manager:
+    dependency: transitive
+    description:
+      name: window_manager
+      sha256: "7eb6d6c4164ec08e1bf978d6e733f3cebe792e2a23fb07cbca25c2872bfdbdcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
   xdg_directories:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- auto-switch `GameMapArea` to the region that contains valid work-target tiles when selection mode starts on an off-tab region
- keep global valid-tile cache behavior while ensuring the active tab can render yellow eligible-tile highlights immediately
- add widget coverage for the region auto-switch selection flow in `app/test/game_map_area_test.dart`

## Test plan
- [x] `cd app && flutter test test/game_map_area_test.dart`


Made with [Cursor](https://cursor.com)