### PR TITLE
fix(repo-lint): enforce part-unit-size domain-wide

### DIFF
--- a/SPEC/program/part-unit-size.md
+++ b/SPEC/program/part-unit-size.md
@@ -1,7 +1,7 @@
 # Part-Unit Size (repo lint)
 
 **SPEC/program** — repository lint gate for oversized Dart **`part` fragment**
-files in logic runtime code.
+files in repo-lint domain runtime code.
 
 **Umbrella policy:** `SPEC/program/repo-lint.md` forbids violation allowlists for
 any `repo.*` rule. This checker uses a single universal physical-line threshold
@@ -15,8 +15,7 @@ only (no keyed exemptions).
 
 ## Scan scope
 
-The checker scans `collectRepoLintDomainDartFiles` and then scopes to
-`packages/colonizethis_logic/lib/src/**`.
+The checker scans all files returned by `collectRepoLintDomainDartFiles`.
 
 Generated and test files stay excluded by the shared repo-lint scan contract.
 
@@ -38,9 +37,10 @@ leading `part of` directive are out of scope for this rule.
 
 ## Acceptance criteria
 
-- Given a Dart file under `packages/colonizethis_logic/lib/src/` that is not a
-  part fragment file per the definition above, when the checker runs, then the
-  checker does not evaluate that file for this rule.
+- Given the System scans a Dart file returned by
+  `collectRepoLintDomainDartFiles` and that file is not a part fragment file per
+  the definition above, when the checker runs, then the checker does not
+  evaluate that file for this rule.
 - Given a part fragment file whose physical line count is less than or equal to
   1000, when the checker runs, then the checker does not fail for that file.
 - Given a part fragment file whose physical line count is greater than 1000,

--- a/test/check_part_unit_size_test.dart
+++ b/test/check_part_unit_size_test.dart
@@ -55,6 +55,34 @@ void main() {
       }
     });
 
+    test('fails for oversized part fragments outside logic package', () {
+      final temp = Directory.systemTemp.createTempSync('part-size-map-over-');
+      try {
+        final mapDir = Directory(
+          p.join(temp.path, 'packages', 'colonizethis_map', 'lib', 'src'),
+        )..createSync(recursive: true);
+        final body = List.generate(1002, (_) => '  final _ = 0;').join('\n');
+        _writeDartFile(
+          p.join(mapDir.path, 'huge_part.dart'),
+          "part of 'parent.dart';\nvoid _x() {\n$body\n}\n",
+        );
+
+        final errors = <String>[];
+        final exitCode = runCheckPartUnitSize(
+          temp.path,
+          info: (_) {},
+          err: errors.add,
+        );
+        expect(exitCode, 1);
+        expect(
+          errors.join('\n'),
+          contains('colonizethis_map/lib/src/huge_part.dart'),
+        );
+      } finally {
+        temp.deleteSync(recursive: true);
+      }
+    });
+
     test('ignores library files that are not part fragments', () {
       final temp = Directory.systemTemp.createTempSync('part-size-lib-');
       try {

--- a/tool/check_part_unit_size.dart
+++ b/tool/check_part_unit_size.dart
@@ -4,7 +4,6 @@ import 'package:path/path.dart' as p;
 
 import 'ct_repo_lint_scan_contract.dart';
 
-const _logicScopePrefix = 'packages/colonizethis_logic/lib/src/';
 const _maxPartFragmentPhysicalLines = 1000;
 
 int runCheckPartUnitSize(
@@ -18,9 +17,6 @@ int runCheckPartUnitSize(
   final violations = <String>[];
   for (final file in collectRepoLintDomainDartFiles(repoRoot)) {
     final rel = p.relative(file.path, from: repoRoot);
-    if (!rel.startsWith(_logicScopePrefix)) {
-      continue;
-    }
     final content = file.readAsStringSync();
     if (!_isDartPartFragmentFile(content)) {
       continue;

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -103,7 +103,7 @@ rules:
 
   - rule_id: repo.part_unit_size
     group: structure
-    title: Dart part fragment physical line limit (logic lib)
+    title: Dart part fragment physical line limit (repo-lint domain)
     spec: SPEC/program/part-unit-size.md
     runner: dart
     script: tool/check_part_unit_size.dart


### PR DESCRIPTION
## Summary
- Remove the `check_part_unit_size` logic-package-only prefix gate so the rule applies to all files in `collectRepoLintDomainDartFiles`.
- Align `SPEC/program/part-unit-size.md` scan scope wording and AC text with universal repo-lint domain enforcement.
- Add a regression test proving oversized `part of` fragments fail outside `colonizethis_logic` (example in `colonizethis_map`).
- Update the manifest title text for `repo.part_unit_size` to reflect repo-lint domain scope.

## Scope
This PR implements one isolated Issue #1912 slice: universal scope enforcement for `repo.part_unit_size`.

Deferred to follow-up slices under #1912:
- Remaining allowlist/exemption removals and refactors in other repo-lint rules.
- Any additional SPEC alignment outside `SPEC/program/part-unit-size.md` needed by those slices.

## Test plan
- [x] `dart test test/check_part_unit_size_test.dart`
- [x] `dart test test/ct_repo_lint_test.dart`
- [x] `dart run tool/check_part_unit_size.dart`
- [x] `dart run tool/ct_repo_lint.dart --rule repo.part_unit_size`

Refs #1912

Made with [Cursor](https://cursor.com)