### PR TITLE
chore(repo-lint): harden function-size no-waiver coverage

### DIFF
--- a/SPEC/program/function-size.md
+++ b/SPEC/program/function-size.md
@@ -11,8 +11,10 @@ runtime domain Dart code.
 
 ## Scan scope
 
-The checker walks `collectRepoLintDomainDartFiles` and then scopes to
-`packages/colonizethis_logic/lib/src/**` for this phase.
+The checker walks `collectRepoLintDomainDartFiles` and scopes to:
+
+- `packages/colonizethis_logic/lib/src/**`
+- `packages/colonizethis_map/lib/src/**`
 
 Tests and generated files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`) remain
 excluded by the shared scan contract.
@@ -31,3 +33,6 @@ excluded by the shared scan contract.
 - Given repository root as cwd, when CI runs `dart run tool/ct_repo_lint.dart`,
   then rule `repo.function_size` runs and fails on any symbol measured over 200
   lines with no per-file or per-symbol exemptions.
+- Given a repo that contains a legacy waiver YAML file for function-size
+  violations, when rule `repo.function_size` runs, then the checker behavior is
+  unchanged because thresholds are enforced without keyed waiver data.

--- a/test/check_function_size_test.dart
+++ b/test/check_function_size_test.dart
@@ -33,7 +33,7 @@ int f() {
       return 'int giant() {\n$body\n  return $sum;\n}\n';
     }
 
-    test('fails when non-allowlisted function exceeds threshold', () {
+    test('fails when function exceeds threshold', () {
       final temp = Directory.systemTemp.createTempSync('fn-size-');
       try {
         final libDir = Directory(
@@ -56,7 +56,7 @@ int f() {
       }
     });
 
-    test('fails even when legacy allowlist yaml is present', () {
+    test('fails even when legacy waiver yaml is present', () {
       final temp = Directory.systemTemp.createTempSync('fn-size-legacy-');
       try {
         final libDir = Directory(
@@ -76,12 +76,15 @@ allowed_over_20:
     max_measured_lines: 220
 ''');
 
+        final errors = <String>[];
         final exitCode = runCheckFunctionSize(
           temp.path,
           info: (_) {},
-          err: (_) {},
+          err: errors.add,
         );
         expect(exitCode, 1);
+        expect(errors.join('\n'), contains('big.dart'));
+        expect(errors.join('\n'), contains('giant'));
       } finally {
         temp.deleteSync(recursive: true);
       }


### PR DESCRIPTION
## Summary
- Strengthen `check_function_size` regression coverage by asserting concrete violation output even when a legacy waiver YAML is present.
- Rename test cases to reflect strict threshold behavior rather than allowlist semantics.
- Align `SPEC/program/function-size.md` scan-scope text with checker implementation (`colonizethis_logic` + `colonizethis_map` lib roots).
- Add an explicit AC confirming legacy waiver YAML files do not alter checker outcomes.

## Scope
This PR implements one isolated Issue #1912 slice: function-size test/spec hardening for strict no-waiver behavior.

Deferred to follow-up slices under #1912:
- Removal of remaining legacy waiver mechanisms in other rules (notably control-flow nesting, which currently requires broad refactors).
- Refactor phases needed to satisfy strict enforcement where existing code still exceeds thresholds.

## Test plan
- [x] `dart test test/check_function_size_test.dart`
- [x] `dart run tool/ct_repo_lint.dart --rule repo.function_size`

Refs #1912

Made with [Cursor](https://cursor.com)