### PR TITLE
refactor(repo-lint): add game widgets file-size guard

### DIFF
--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -32,6 +32,7 @@ Grandfather YAMLs named in the table below are **legacy** until removed; **do no
 | `tool/check_part_unit_size.dart` | Dart `part` fragment physical line limit (`SPEC/program/part-unit-size.md`); rule `repo.part_unit_size` |
 | `tool/check_no_flame_in_widgets.dart` | Disallow direct `package:flame/*` **import** and **export** lines (single- or double-quoted URI) under `app/lib/widgets/**`; rule `repo.no_flame_in_widgets` |
 | `tool/check_no_screen_in_game_widgets.dart` | Disallow `*_screen.dart` files under `app/lib/features/game/widgets/**`; rule `repo.no_screen_in_game_widgets` |
+| `tool/check_game_widgets_file_size.dart` | Enforce `app/lib/features/game/widgets/**` Dart files at **700 physical lines or fewer**; rule `repo.game_widgets_file_size` |
 | `tool/check_land_province_bucket_keys.dart` | For guarded explore/fog/news paths, disallow local-only land-province tile-bucket lookups (`tileKeysByRegionAndProvince[region]?[localId]`); require canonical full-id buckets only; rule `repo.land_province_bucket_keys` |
 
 ## Rule IDs and groups
@@ -78,3 +79,4 @@ Do **not** add new top-level `tool/check_*.dart` **entrypoints** for CI without 
 - Given a contributor adds a convention, when they follow CONTRIBUTING and this doc, then they register the rule in the manifest rather than adding a new standalone Quality workflow step for the same concern.
 - Given the [Policy: no violation allowlists](#policy-no-violation-allowlists-repo-lint) section, when implementation work completes for a legacy checker still loading grandfather YAML, then that checker, its tests, and the per-rule SPEC no longer document or depend on violation allowlists.
 - Given app game feature code, when `dart run tool/ct_repo_lint.dart` runs rule `repo.no_screen_in_game_widgets`, then no file matching `*_screen.dart` exists under `app/lib/features/game/widgets/**`.
+- Given app game widget files, when `dart run tool/ct_repo_lint.dart` runs rule `repo.game_widgets_file_size`, then each Dart file under `app/lib/features/game/widgets/**` has 700 physical lines or fewer.

--- a/test/check_game_widgets_file_size_test.dart
+++ b/test/check_game_widgets_file_size_test.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../tool/check_game_widgets_file_size.dart';
+
+void main() {
+  test('fails when a game widget file exceeds 700 lines', () {
+    final temp = Directory.systemTemp.createTempSync(
+      'check_game_widgets_file_size_fail_',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    final violatingFile = File(
+      '${temp.path}/app/lib/features/game/widgets/huge_panel.dart',
+    )..createSync(recursive: true);
+    violatingFile.writeAsStringSync(List.filled(701, '// line').join('\n'));
+
+    final logs = <String>[];
+    final code = runCheckGameWidgetsFileSize(
+      temp.path,
+      info: logs.add,
+      err: logs.add,
+    );
+
+    expect(code, 1);
+    expect(logs.join('\n'), contains('huge_panel.dart'));
+    expect(logs.join('\n'), contains('701 physical lines > 700'));
+  });
+
+  test('passes when all game widget files are at or below 700 lines', () {
+    final temp = Directory.systemTemp.createTempSync(
+      'check_game_widgets_file_size_pass_',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    final okFile = File('${temp.path}/app/lib/features/game/widgets/panel.dart')
+      ..createSync(recursive: true);
+    okFile.writeAsStringSync(List.filled(700, '// line').join('\n'));
+
+    final code = runCheckGameWidgetsFileSize(temp.path);
+    expect(code, 0);
+  });
+}

--- a/test/ct_repo_lint_test.dart
+++ b/test/ct_repo_lint_test.dart
@@ -22,6 +22,7 @@ void main() {
       expect(ids, contains('repo.function_size'));
       expect(ids, contains('repo.part_unit_size'));
       expect(ids, contains('repo.no_flame_in_widgets'));
+      expect(ids, contains('repo.game_widgets_file_size'));
       expect(ids, contains('repo.land_province_bucket_keys'));
       expect(ids, contains('repo.app_hardcoded_ui_strings'));
       expect(

--- a/tool/check_game_widgets_file_size.dart
+++ b/tool/check_game_widgets_file_size.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+const _maxPhysicalLines = 700;
+
+/// PR-blocking structural check: files under
+/// `app/lib/features/game/widgets/**` must stay at or below 700 physical lines.
+///
+/// SPEC: SPEC/program/repo-lint.md
+int runCheckGameWidgetsFileSize(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+  final widgetsDir = Directory(
+    p.join(repoRoot, 'app', 'lib', 'features', 'game', 'widgets'),
+  );
+  if (!widgetsDir.existsSync()) {
+    logE(
+      'check_game_widgets_file_size: app/lib/features/game/widgets not found.',
+    );
+    return 1;
+  }
+
+  final violations = <String>[];
+  for (final entity in widgetsDir.listSync(
+    recursive: true,
+    followLinks: false,
+  )) {
+    if (entity is! File || !entity.path.endsWith('.dart')) {
+      continue;
+    }
+    final relativePath = p.relative(entity.path, from: repoRoot);
+    final physicalLines = const LineSplitter()
+        .convert(entity.readAsStringSync())
+        .length;
+    if (physicalLines <= _maxPhysicalLines) {
+      continue;
+    }
+    violations.add(
+      '$relativePath ($physicalLines physical lines > $_maxPhysicalLines)',
+    );
+  }
+
+  if (violations.isEmpty) {
+    logI('check_game_widgets_file_size: no violations found.');
+    return 0;
+  }
+
+  logE(
+    'check_game_widgets_file_size: found ${violations.length} violation(s) under app/lib/features/game/widgets:',
+  );
+  for (final violation in violations) {
+    logE(' - $violation');
+  }
+  return 1;
+}
+
+void main() {
+  exit(runCheckGameWidgetsFileSize(Directory.current.path));
+}

--- a/tool/ct_repo_lint_lib.dart
+++ b/tool/ct_repo_lint_lib.dart
@@ -12,6 +12,7 @@ import 'check_control_flow_nesting_depth.dart';
 import 'check_custom_exceptions.dart';
 import 'check_disallowed_ast_patterns.dart';
 import 'check_function_size.dart';
+import 'check_game_widgets_file_size.dart';
 import 'check_land_province_bucket_keys.dart';
 import 'check_no_flame_in_widgets.dart';
 import 'check_no_screen_in_game_widgets.dart';
@@ -697,6 +698,8 @@ int? _tryRunDartRuleInProcess({
       return runCheckRepeatedMagicNumbers(repoRoot);
     case 'repo.function_size':
       return runCheckFunctionSize(repoRoot);
+    case 'repo.game_widgets_file_size':
+      return runCheckGameWidgetsFileSize(repoRoot);
     case 'repo.part_unit_size':
       return runCheckPartUnitSize(repoRoot);
     case 'repo.no_flame_in_widgets':

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -122,6 +122,13 @@ rules:
     runner: dart
     script: tool/check_no_screen_in_game_widgets.dart
 
+  - rule_id: repo.game_widgets_file_size
+    group: structure
+    title: app/lib/features/game/widgets files must stay at or below 700 lines
+    spec: SPEC/program/repo-lint.md
+    runner: dart
+    script: tool/check_game_widgets_file_size.dart
+
   - rule_id: repo.canonical_province_tile_keys
     group: game_invariants
     title: Province WorkOrder targetTileKey literals use full tile shape


### PR DESCRIPTION
## Summary
- add new repo-lint rule `repo.game_widgets_file_size` to enforce a 700-line cap for Dart files under `app/lib/features/game/widgets/**`
- wire the rule into `ct_repo_lint` manifest + in-process dispatcher
- add SPEC and unit-test coverage for the new guardrail

## Scope
- Implements one isolated slice of #1878: CI enforcement for oversized game widget files.
- Deferred from #1878: broader widget/function decomposition and additional architecture refactors.

## Testing
- [x] `dart test test/check_game_widgets_file_size_test.dart test/ct_repo_lint_test.dart test/check_no_screen_in_game_widgets_test.dart`
- [x] `dart run tool/ct_repo_lint.dart --rule repo.game_widgets_file_size`

Refs #1878

Made with [Cursor](https://cursor.com)