### PR TITLE
refactor(map-test): add focused view-builder slice assertions

### DIFF
--- a/packages/colonizethis_map/test/init_game_map_view_builder_slice_test.dart
+++ b/packages/colonizethis_map/test/init_game_map_view_builder_slice_test.dart
@@ -10,6 +10,7 @@ Game _minimalGame({
   List<Unit> newWorldUnits = const [],
   List<Fleet> fleets = const [],
   List<Player> players = const [],
+  Map<String, String> portsByProvinceSeaboard = const {},
 }) {
   return Game(
     id: 'slice-test',
@@ -18,6 +19,7 @@ Game _minimalGame({
       oldWorld: RegionData(provinces: oldWorldProvinces, units: oldWorldUnits),
       newWorld: RegionData(provinces: newWorldProvinces, units: newWorldUnits),
       fleets: fleets,
+      portsByProvinceSeaboard: portsByProvinceSeaboard,
     ),
     players: players,
     minorNations: const [],
@@ -150,6 +152,126 @@ void main() {
       expect(presence.regimentCount, 1);
       expect(presence.shipCount, 1);
       expect(presence.intelVisible, isTrue);
+    });
+
+    test('marker helpers expose capitals ports towns and warps', () {
+      final tileMap = TileMapResult(
+        width: 2,
+        height: 1,
+        grid: [
+          ['p1', 's1'],
+        ],
+      );
+      final newWorldSea = TileMapResult(
+        width: 1,
+        height: 1,
+        grid: [
+          ['s9'],
+        ],
+      );
+      final topology = _singleProvinceAndSeaTopology('oldWorld');
+      final newWorldTopology = MapTopology(
+        nodes: const [
+          TopologyNode(
+            id: 's9',
+            regionId: 'newWorld',
+            type: TopologyNodeType.seaZone,
+          ),
+        ],
+        edges: const [],
+      );
+      final game = _minimalGame(
+        oldWorldProvinces: const [
+          Province(
+            id: 'oldWorld|p1',
+            regionId: 'oldWorld',
+            townTileKey: 'oldWorld|p1|0|0',
+          ),
+        ],
+        newWorldProvinces: const [],
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'GP1',
+            isHuman: true,
+            capitalTile: CapitalTile(
+              regionId: 'oldWorld',
+              provinceId: 'oldWorld|p1',
+              x: 0,
+              y: 0,
+            ),
+          ),
+        ],
+        portsByProvinceSeaboard: const {
+          'oldWorld|p1|s1': 'oldWorld|p1|0|0',
+        },
+      );
+
+      final view = buildInitGameMapViewData(
+        game: game,
+        tileMapByRegion: {'oldWorld': tileMap, 'newWorld': newWorldSea},
+        topologyByRegion: {'oldWorld': topology, 'newWorld': newWorldTopology},
+        cellSize: 8,
+        warpLinks: const [
+          WarpLink(
+            regionId: 'oldWorld',
+            seaZoneId: 's1',
+            otherRegionId: 'newWorld',
+            otherSeaZoneId: 's9',
+          ),
+        ],
+      );
+
+      expect(view.oldWorld.capitalMarkers.length, 1);
+      expect(view.oldWorld.capitalMarkers.single.factionId, 'gp1');
+      expect(view.oldWorld.portMarkers.length, 1);
+      expect(view.oldWorld.portMarkers.single.provinceId, 'p1');
+      expect(view.oldWorld.townMarkers.length, 1);
+      expect(view.oldWorld.townMarkers.single.isPort, isTrue);
+      expect(view.oldWorld.townMarkers.single.touchesSea, isTrue);
+      expect(view.oldWorld.warpMarkers.length, 1);
+      expect(view.oldWorld.warpMarkers.single.seaZoneId, 's1');
+      expect(view.oldWorld.warpMarkers.single.otherRegionId, 'newWorld');
+    });
+
+    test('cell helper applies visibility and extraction overlays', () {
+      final tileMap = TileMapResult(
+        width: 1,
+        height: 1,
+        grid: [
+          ['p1'],
+        ],
+      );
+      final seaOnly = TileMapResult(
+        width: 1,
+        height: 1,
+        grid: [
+          ['s1'],
+        ],
+      );
+      final topology = _singleProvinceAndSeaTopology('oldWorld');
+      final newWorldTopology = _singleProvinceAndSeaTopology('newWorld');
+      final game = _minimalGame(
+        oldWorldProvinces: const [Province(id: 'oldWorld|p1', regionId: 'oldWorld')],
+        newWorldProvinces: const [],
+      );
+
+      final view = buildInitGameMapViewData(
+        game: game,
+        tileMapByRegion: {'oldWorld': tileMap, 'newWorld': seaOnly},
+        topologyByRegion: {'oldWorld': topology, 'newWorld': newWorldTopology},
+        cellSize: 8,
+        visibilityByTile: const {'oldWorld|p1|0|0': TileVisibility.fogged},
+        resourceExtractionUnitsByTile: const {'oldWorld|p1|0|0': 9},
+        resourceExtractionEffectiveUnitsByTile: const {'oldWorld|p1|0|0': 7},
+        resourceExtractionBlockedUnitsByTile: const {'oldWorld|p1|0|0': 2},
+      );
+
+      final cell = view.oldWorld.cells.single;
+      expect(cell.visibility, TileVisibility.fogged);
+      expect(cell.resourceExtractionUnits, 9);
+      expect(cell.resourceExtractionEffectiveUnits, 7);
+      expect(cell.resourceExtractionBlockedUnits, 2);
     });
   });
 }


### PR DESCRIPTION
## Summary
- add focused slice tests for extracted `init_game_map_view_builder` concerns: capitals, ports, towns, warp markers, and cell visibility/extraction overlays
- extend `_minimalGame` test fixture to pass `portsByProvinceSeaboard` so marker scenarios can be assembled without broad integration setup
- satisfy the remaining #1886 acceptance-criteria gap requiring focused tests for extracted helper behavior

## Test plan
- [x] `cd packages/colonizethis_map && dart test test/init_game_map_view_builder_slice_test.dart`
- [x] `cd packages/colonizethis_map && dart test --coverage=coverage`
- [x] `tool/check_coverage_threshold.sh 90 packages/colonizethis_map`

Refs #1886

Made with [Cursor](https://cursor.com)