### PR TITLE
fix(repo-lint): gate localSegment helper to boundary files

### DIFF
--- a/SPEC/program/disallowed-ast-patterns.md
+++ b/SPEC/program/disallowed-ast-patterns.md
@@ -118,6 +118,20 @@ Rule ids:
   `unprefixed_province_id_string_literal_argument`,
   `match.method_names`: `localIdFrom`,
   `match.argument_index`: `0`)
+
+### `localSegmentFromStoredGameState` outside approved boundary adapters
+
+In runtime domain code, `ProvinceId.localSegmentFromStoredGameState(...)` is
+disallowed outside explicit boundary adapters for save/load compatibility,
+topology node alignment, and tile-key bridge logic.
+
+Rationale: this helper intentionally tolerates legacy bare local ids; allowing
+it in general runtime identity paths can reintroduce ambiguous province-id
+handling.
+
+Rule id: `province_local_segment_boundary_only` (`match.kind`:
+`province_local_segment_boundary_only`, `match.allowed_relative_paths`:
+manifested allowlist of boundary files).
 ### Coverage
 
 Enforcement walks the same domain trees via `tool/ct_repo_lint_scan_contract.dart` (`collectRepoLintDomainDartFiles`), aligned with `SPEC/program/exception-enforcement.md` coverage:
@@ -210,3 +224,15 @@ Generated files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`) and tests (`**/te
   literal to `ProvinceId.localIdFrom`, **when** the disallowed AST checker
   runs, **then** it does not report a
   `province_local_id_from_unprefixed_literal` violation.
+
+- **Given** runtime Dart source that calls
+  `ProvinceId.localSegmentFromStoredGameState(...)` from a file that is not in
+  the configured allowlist, **when** the disallowed AST checker runs, **then**
+  it reports at least one violation for
+  `province_local_segment_boundary_only` with the correct file and line.
+
+- **Given** runtime Dart source that calls
+  `ProvinceId.localSegmentFromStoredGameState(...)` from a configured
+  allowlisted boundary file, **when** the disallowed AST checker runs, **then**
+  it does not report a `province_local_segment_boundary_only` violation for
+  that call.

--- a/test/check_disallowed_ast_patterns_test.dart
+++ b/test/check_disallowed_ast_patterns_test.dart
@@ -61,6 +61,12 @@ rules:
       method_names:
         - localIdFrom
       argument_index: 0
+  - id: province_local_segment_boundary_only
+    message: 'localSegmentFromStoredGameState is boundary-only'
+    match:
+      kind: province_local_segment_boundary_only
+      allowed_relative_paths:
+        - packages/foo/lib/allowed.dart
 ''';
 
 void main() {
@@ -480,6 +486,42 @@ bool ok(String provinceId) => ProvinceId.localIdFrom(provinceId) == 'p1';
       );
     });
 
+    test(
+      'flags ProvinceId.localSegmentFromStoredGameState outside allowlist',
+      () {
+        const src = r'''
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+String bad(String provinceId) =>
+    ProvinceId.localSegmentFromStoredGameState(provinceId);
+''';
+        final v = findDisallowedAstViolations(
+          'packages/foo/lib/not_allowed.dart',
+          src,
+          rules,
+        );
+        expect(v, isNotEmpty);
+        expect(v.first.ruleId, 'province_local_segment_boundary_only');
+      },
+    );
+
+    test('allows ProvinceId.localSegmentFromStoredGameState in allowlist', () {
+      const src = r'''
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+String ok(String provinceId) =>
+    ProvinceId.localSegmentFromStoredGameState(provinceId);
+''';
+      expect(
+        findDisallowedAstViolations(
+          'packages/foo/lib/allowed.dart',
+          src,
+          rules,
+        ).where((e) => e.ruleId == 'province_local_segment_boundary_only'),
+        isEmpty,
+      );
+    });
+
     test('flags sea-zone bucket lookup without canonical key helper', () {
       const src = r'''
 class X {
@@ -516,7 +558,9 @@ class X {
           'packages/foo/lib/x.dart',
           src,
           rules,
-        ).where((e) => e.ruleId == 'sea_zone_bucket_lookup_without_canonical_key'),
+        ).where(
+          (e) => e.ruleId == 'sea_zone_bucket_lookup_without_canonical_key',
+        ),
         isEmpty,
       );
     });

--- a/tool/check_disallowed_ast_patterns.dart
+++ b/tool/check_disallowed_ast_patterns.dart
@@ -217,6 +217,7 @@ List<DisallowedPatternRule> _parseRulesYaml(Object? yamlRoot) {
           requireWidgetClassExtends: false,
           argumentIndex: null,
           invocationMethodNames: const {},
+          allowedRelativePaths: const {},
         ),
       );
     } else if (kind == 'stream_where_is_map_as') {
@@ -233,6 +234,7 @@ List<DisallowedPatternRule> _parseRulesYaml(Object? yamlRoot) {
           requireWidgetClassExtends: false,
           argumentIndex: null,
           invocationMethodNames: const {},
+          allowedRelativePaths: const {},
         ),
       );
     } else if (kind == 'comment_substring') {
@@ -253,6 +255,7 @@ List<DisallowedPatternRule> _parseRulesYaml(Object? yamlRoot) {
           requireWidgetClassExtends: false,
           argumentIndex: null,
           invocationMethodNames: const {},
+          allowedRelativePaths: const {},
         ),
       );
     } else if (kind == 'raw_named_type') {
@@ -283,6 +286,7 @@ List<DisallowedPatternRule> _parseRulesYaml(Object? yamlRoot) {
           requireWidgetClassExtends: false,
           argumentIndex: null,
           invocationMethodNames: const {},
+          allowedRelativePaths: const {},
         ),
       );
     } else if (kind == 'method_body_line_span') {
@@ -311,6 +315,7 @@ List<DisallowedPatternRule> _parseRulesYaml(Object? yamlRoot) {
           requireWidgetClassExtends: requireWidgetClassExtends,
           argumentIndex: null,
           invocationMethodNames: const {},
+          allowedRelativePaths: const {},
         ),
       );
     } else if (kind == 'unprefixed_province_id_string_literal_argument') {
@@ -347,6 +352,7 @@ List<DisallowedPatternRule> _parseRulesYaml(Object? yamlRoot) {
           requireWidgetClassExtends: false,
           argumentIndex: argumentIndex,
           invocationMethodNames: names,
+          allowedRelativePaths: const {},
         ),
       );
     } else if (kind == 'sea_zone_local_id_extraction') {
@@ -363,6 +369,7 @@ List<DisallowedPatternRule> _parseRulesYaml(Object? yamlRoot) {
           requireWidgetClassExtends: false,
           argumentIndex: null,
           invocationMethodNames: const {},
+          allowedRelativePaths: const {},
         ),
       );
     } else if (kind == 'sea_zone_bucket_lookup_without_canonical_key') {
@@ -379,6 +386,38 @@ List<DisallowedPatternRule> _parseRulesYaml(Object? yamlRoot) {
           requireWidgetClassExtends: false,
           argumentIndex: null,
           invocationMethodNames: const {},
+          allowedRelativePaths: const {},
+        ),
+      );
+    } else if (kind == 'province_local_segment_boundary_only') {
+      final allowedPathsNode = match['allowed_relative_paths'];
+      if (allowedPathsNode is! YamlList) {
+        continue;
+      }
+      final allowedRelativePaths = <String>{};
+      for (final p in allowedPathsNode.nodes) {
+        final s = p.value?.toString();
+        if (s != null && s.isNotEmpty) {
+          allowedRelativePaths.add(s);
+        }
+      }
+      if (allowedRelativePaths.isEmpty) {
+        continue;
+      }
+      out.add(
+        DisallowedPatternRule(
+          id: id,
+          message: message,
+          kind: DisallowedAstMatchKind.provinceLocalSegmentBoundaryOnly,
+          cascadedMethodNames: const {},
+          commentSubstring: null,
+          rawNamedTypeNames: const {},
+          functionName: null,
+          maxBodyLineSpan: null,
+          requireWidgetClassExtends: false,
+          argumentIndex: null,
+          invocationMethodNames: const {},
+          allowedRelativePaths: allowedRelativePaths,
         ),
       );
     }
@@ -419,6 +458,7 @@ enum DisallowedAstMatchKind {
   seaZoneLocalIdExtraction,
   seaZoneBucketLookupWithoutCanonicalKey,
   unprefixedProvinceIdStringLiteralArgument,
+  provinceLocalSegmentBoundaryOnly,
 }
 
 class DisallowedPatternRule {
@@ -434,6 +474,7 @@ class DisallowedPatternRule {
     required this.requireWidgetClassExtends,
     required this.argumentIndex,
     required this.invocationMethodNames,
+    required this.allowedRelativePaths,
   });
 
   final String id;
@@ -447,6 +488,7 @@ class DisallowedPatternRule {
   final bool requireWidgetClassExtends;
   final int? argumentIndex;
   final Set<String> invocationMethodNames;
+  final Set<String> allowedRelativePaths;
 }
 
 class DisallowedAstViolation {
@@ -579,6 +621,14 @@ bool _isProvinceLocalIdFromInvocation(MethodInvocation node) {
       node.argumentList.arguments.length == 1;
 }
 
+bool _isProvinceLocalSegmentInvocation(MethodInvocation node) {
+  final target = node.target;
+  return target is SimpleIdentifier &&
+      target.name == 'ProvinceId' &&
+      node.methodName.name == 'localSegmentFromStoredGameState' &&
+      node.argumentList.arguments.length == 1;
+}
+
 bool _expressionLooksSeaZoneRelated(Expression expression) {
   final text = expression.toSource().toLowerCase();
   return text.contains('seazone') ||
@@ -675,6 +725,11 @@ class _DisallowedAstVisitor extends RecursiveAstVisitor<void> {
       } else if (rule.kind == DisallowedAstMatchKind.seaZoneLocalIdExtraction &&
           _isProvinceLocalIdFromInvocation(node) &&
           _expressionLooksSeaZoneRelated(node.argumentList.arguments.single)) {
+        _recordIfAllowed(node, rule);
+      } else if (rule.kind ==
+              DisallowedAstMatchKind.provinceLocalSegmentBoundaryOnly &&
+          _isProvinceLocalSegmentInvocation(node) &&
+          !rule.allowedRelativePaths.contains(path)) {
         _recordIfAllowed(node, rule);
       }
       if (rule.kind ==

--- a/tool/disallowed_ast_patterns.yaml
+++ b/tool/disallowed_ast_patterns.yaml
@@ -81,3 +81,17 @@ rules:
       method_names:
         - localIdFrom
       argument_index: 0
+  - id: province_local_segment_boundary_only
+    message: >-
+      ProvinceId.localSegmentFromStoredGameState(...) is boundary-only.
+      Use it only in approved save/load, topology, and tile-key adapter files.
+    match:
+      kind: province_local_segment_boundary_only
+      allowed_relative_paths:
+        - app/lib/features/game/widgets/utils/naval_tree_builder.dart
+        - packages/colonizethis_logic/lib/src/orders/order_visibility.dart
+        - packages/colonizethis_logic/lib/src/setup/gp_starting_grain.dart
+        - packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+        - packages/colonizethis_logic/lib/src/world/movement.dart
+        - packages/colonizethis_models/lib/src/capital_tile.dart
+        - packages/colonizethis_models/lib/src/world_state.dart


### PR DESCRIPTION
## Summary
- add a new disallowed-AST rule (`province_local_segment_boundary_only`) that flags `ProvinceId.localSegmentFromStoredGameState(...)` calls outside approved boundary adapters
- wire the new matcher into `tool/check_disallowed_ast_patterns.dart` with manifest parsing support for an allowlisted path set
- document the rule and acceptance criteria in `SPEC/program/disallowed-ast-patterns.md`, and add positive/negative checker tests

## Scope
- This is a focused #1965 follow-up slice for CI enforcement only.
- No runtime behavior changes are included.

## Tests
- `dart test test/check_disallowed_ast_patterns_test.dart`
- `dart test packages/colonizethis_models/test/province_id_test.dart`
- `dart run tool/check_disallowed_ast_patterns.dart --files=tool/check_disallowed_ast_patterns.dart`

## Deferred
- Wider local-ID identity enforcement beyond this helper-specific boundary guard remains in parent issue scope.

Refs #1965

Made with [Cursor](https://cursor.com)