### PR TITLE
refactor(ui): split remaining oversized widget build methods

### DIFF
--- a/app/lib/features/game/flame/game_map_corner_controls.dart
+++ b/app/lib/features/game/flame/game_map_corner_controls.dart
@@ -25,63 +25,57 @@ class GameMapCornerControls extends StatelessWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Material(
+        _MapCornerIconButton(
           key: kBaseLayerCycleButtonKey,
-          color: Colors.white.withValues(alpha: 0.9),
-          child: Tooltip(
-            message: l10n.mapCorner_tooltipBaseLayer,
-            child: InkWell(
-              onTap: onCycleBaseLayerDisplayMode,
-              child: Padding(
-                padding: const EdgeInsets.all(6),
-                child: StrictAssetIcon(
-                  assetPath: '${kAppIconAssetPrefix}ui_icon_layer_toggle.png',
-                  width: 20,
-                  height: 20,
-                ),
-              ),
-            ),
-          ),
+          tooltip: l10n.mapCorner_tooltipBaseLayer,
+          onTap: onCycleBaseLayerDisplayMode,
+          assetPath: '${kAppIconAssetPrefix}ui_icon_layer_toggle.png',
         ),
         const SizedBox(width: 4),
-        Material(
+        _MapCornerIconButton(
           key: kHomeToCapitalButtonKey,
-          color: Colors.white.withValues(alpha: 0.9),
-          child: Tooltip(
-            message: l10n.mapCorner_tooltipCenterCapital,
-            child: InkWell(
-              onTap: onCenterOnHomeCapital,
-              child: Padding(
-                padding: const EdgeInsets.all(6),
-                child: StrictAssetIcon(
-                  assetPath: '${kAppIconAssetPrefix}ui_icon_home_capital.png',
-                  width: 20,
-                  height: 20,
-                ),
-              ),
-            ),
-          ),
+          tooltip: l10n.mapCorner_tooltipCenterCapital,
+          onTap: onCenterOnHomeCapital,
+          assetPath: '${kAppIconAssetPrefix}ui_icon_home_capital.png',
         ),
         const SizedBox(width: 4),
-        Material(
+        _MapCornerIconButton(
           key: kMapDisplayOptionsButtonKey,
-          color: Colors.white.withValues(alpha: 0.9),
-          child: Tooltip(
-            message: l10n.mapCorner_tooltipMapDisplayOptions,
-            child: InkWell(
-              onTap: onOpenMapDisplayOptions,
-              child: Padding(
-                padding: const EdgeInsets.all(6),
-                child: StrictAssetIcon(
-                  assetPath: '${kAppIconAssetPrefix}ui_icon_map_options.png',
-                  width: 20,
-                  height: 20,
-                ),
-              ),
-            ),
-          ),
+          tooltip: l10n.mapCorner_tooltipMapDisplayOptions,
+          onTap: onOpenMapDisplayOptions,
+          assetPath: '${kAppIconAssetPrefix}ui_icon_map_options.png',
         ),
       ],
+    );
+  }
+}
+
+class _MapCornerIconButton extends StatelessWidget {
+  const _MapCornerIconButton({
+    super.key,
+    required this.tooltip,
+    required this.onTap,
+    required this.assetPath,
+  });
+
+  final String tooltip;
+  final VoidCallback onTap;
+  final String assetPath;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.white.withValues(alpha: 0.9),
+      child: Tooltip(
+        message: tooltip,
+        child: InkWell(
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.all(6),
+            child: StrictAssetIcon(assetPath: assetPath, width: 20, height: 20),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/app/lib/features/game/widgets/military_units_panel.dart
+++ b/app/lib/features/game/widgets/military_units_panel.dart
@@ -125,115 +125,157 @@ class _MilitaryUnitsPanelState extends State<MilitaryUnitsPanel> {
 
     return UnitsPanelShell(
       title: l10n.military_units_title,
-      actions: [
-        if (hasAny && flat.isNotEmpty) ...[
-          Tooltip(
-            message: headerCheckbox == true
-                ? l10n.military_units_deselectAllArmies
-                : l10n.military_units_selectAllArmies,
-            child: Checkbox(
-              tristate: true,
-              value: headerCheckbox,
-              onChanged: (_) => _onHeaderSelectAllTapped(flat),
-              visualDensity: VisualDensity.compact,
-              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-            ),
-          ),
-          const SizedBox(width: 4),
-          CtNinePatchButton(
-            onPressed: canCombine ? () => _performCombine(flat) : null,
-            enabled: canCombine,
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-            minHeight: 32,
-            child: Text(l10n.common_combine),
-          ),
-        ],
-        CtNinePatchButton(
-          onPressed: () {
-            widget.bus.emit(const ClosePanelEvent());
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              widget.bus.emit(OpenDialogEvent(trainMilitaryDialogId));
-            });
-          },
-          child: Text(l10n.common_train),
-        ),
-      ],
+      actions: _buildActions(
+        l10n: l10n,
+        hasAny: hasAny,
+        flat: flat,
+        canCombine: canCombine,
+        headerCheckbox: headerCheckbox,
+      ),
       hasContent: hasAny,
-      listChildren: [
-        for (final group in groups) ...[
-          RegionSectionHeader(label: unitsPanelRegionLabel(group.regionKey)),
-          for (final loc in group.provinces) ...[
-            LocationSectionHeader(
-              label: loc.displayLabel,
-              regionLabel: unitsPanelRegionLabel(loc.regionId),
-            ),
-            for (final block in loc.armies)
-              _ArmyExpansionTile(
-                block: block,
-                l10n: l10n,
-                stationedProvinceDisplayLabel:
-                    armyStationedProvinceDisplayLabel(widget.game, block.army),
-                draftArmyMoveLine: armyDraftMoveLineForArmy(
-                  game: widget.game,
-                  humanPlayerId: widget.humanPlayerId,
-                  armyId: block.army.id,
-                  draftOrders: widget.draftOrders,
-                ),
-                isSelectedForCombine: _selectedArmyIds.contains(block.army.id),
-                onCombineSelectionToggle: () =>
-                    _toggleArmySelection(block.army.id),
-                onLocate:
-                    block.rows.isNotEmpty && block.rows.first.tileKey != null
-                    ? () {
-                        widget.bus.emit(const ClosePanelEvent());
-                        WidgetsBinding.instance.addPostFrameCallback((_) {
-                          widget.bus.emit(
-                            LocateMapTileEvent(
-                              tileKey: block.rows.first.tileKey!,
-                              regionId: block.regionKey,
-                            ),
-                          );
-                        });
-                      }
-                    : null,
-                onSplit: block.army.regimentUnitIds.length >= 2
-                    ? () => _openSplitDialog(block)
-                    : null,
-                onMove:
-                    !block.army.isHomeArmy &&
-                        block.army.regimentUnitIds.isNotEmpty
-                    ? () => _openMoveDialog(block)
-                    : null,
-              ),
-          ],
-          for (final loc in group.seaLocations) ...[
-            LocationSectionHeader(
-              label: loc.displayLabel,
-              regionLabel: unitsPanelRegionLabel(loc.regionId),
-            ),
-            for (final row in loc.rows)
-              _ShipRow(
-                row: row,
-                l10n: l10n,
-                onTap: row.tileKey == null
-                    ? null
-                    : () {
-                        widget.bus.emit(const ClosePanelEvent());
-                        WidgetsBinding.instance.addPostFrameCallback((_) {
-                          widget.bus.emit(
-                            LocateMapTileEvent(
-                              tileKey: row.tileKey!,
-                              regionId: row.regionId,
-                            ),
-                          );
-                        });
-                      },
-              ),
-          ],
-        ],
-      ],
+      listChildren: _buildListChildren(groups, l10n),
       emptyMessage: l10n.military_units_empty,
     );
+  }
+
+  List<Widget> _buildActions({
+    required AppLocalizations l10n,
+    required bool hasAny,
+    required List<ArmyBlock> flat,
+    required bool canCombine,
+    required bool? headerCheckbox,
+  }) {
+    return [
+      if (hasAny && flat.isNotEmpty) ...[
+        Tooltip(
+          message: headerCheckbox == true
+              ? l10n.military_units_deselectAllArmies
+              : l10n.military_units_selectAllArmies,
+          child: Checkbox(
+            tristate: true,
+            value: headerCheckbox,
+            onChanged: (_) => _onHeaderSelectAllTapped(flat),
+            visualDensity: VisualDensity.compact,
+            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ),
+        ),
+        const SizedBox(width: 4),
+        CtNinePatchButton(
+          onPressed: canCombine ? () => _performCombine(flat) : null,
+          enabled: canCombine,
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+          minHeight: 32,
+          child: Text(l10n.common_combine),
+        ),
+      ],
+      CtNinePatchButton(
+        onPressed: _openTrainDialog,
+        child: Text(l10n.common_train),
+      ),
+    ];
+  }
+
+  void _openTrainDialog() {
+    widget.bus.emit(const ClosePanelEvent());
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      widget.bus.emit(OpenDialogEvent(trainMilitaryDialogId));
+    });
+  }
+
+  List<Widget> _buildListChildren(
+    List<RegionMilitaryGroup> groups,
+    AppLocalizations l10n,
+  ) {
+    return [
+      for (final group in groups) ...[
+        RegionSectionHeader(label: unitsPanelRegionLabel(group.regionKey)),
+        ..._buildProvinceLocationChildren(group, l10n),
+        ..._buildSeaLocationChildren(group, l10n),
+      ],
+    ];
+  }
+
+  List<Widget> _buildProvinceLocationChildren(
+    RegionMilitaryGroup group,
+    AppLocalizations l10n,
+  ) {
+    return [
+      for (final loc in group.provinces) ...[
+        LocationSectionHeader(
+          label: loc.displayLabel,
+          regionLabel: unitsPanelRegionLabel(loc.regionId),
+        ),
+        for (final block in loc.armies) _buildArmyTile(block, l10n),
+      ],
+    ];
+  }
+
+  Widget _buildArmyTile(ArmyBlock block, AppLocalizations l10n) {
+    return _ArmyExpansionTile(
+      block: block,
+      l10n: l10n,
+      stationedProvinceDisplayLabel: armyStationedProvinceDisplayLabel(
+        widget.game,
+        block.army,
+      ),
+      draftArmyMoveLine: armyDraftMoveLineForArmy(
+        game: widget.game,
+        humanPlayerId: widget.humanPlayerId,
+        armyId: block.army.id,
+        draftOrders: widget.draftOrders,
+      ),
+      isSelectedForCombine: _selectedArmyIds.contains(block.army.id),
+      onCombineSelectionToggle: () => _toggleArmySelection(block.army.id),
+      onLocate: _armyLocateCallback(block),
+      onSplit: block.army.regimentUnitIds.length >= 2
+          ? () => _openSplitDialog(block)
+          : null,
+      onMove: !block.army.isHomeArmy && block.army.regimentUnitIds.isNotEmpty
+          ? () => _openMoveDialog(block)
+          : null,
+    );
+  }
+
+  VoidCallback? _armyLocateCallback(ArmyBlock block) {
+    if (block.rows.isEmpty || block.rows.first.tileKey == null) {
+      return null;
+    }
+    return () => _emitLocateMapTile(
+      tileKey: block.rows.first.tileKey!,
+      regionId: block.regionKey,
+    );
+  }
+
+  List<Widget> _buildSeaLocationChildren(
+    RegionMilitaryGroup group,
+    AppLocalizations l10n,
+  ) {
+    return [
+      for (final loc in group.seaLocations) ...[
+        LocationSectionHeader(
+          label: loc.displayLabel,
+          regionLabel: unitsPanelRegionLabel(loc.regionId),
+        ),
+        for (final row in loc.rows)
+          _ShipRow(
+            row: row,
+            l10n: l10n,
+            onTap: row.tileKey == null
+                ? null
+                : () => _emitLocateMapTile(
+                    tileKey: row.tileKey!,
+                    regionId: row.regionId,
+                  ),
+          ),
+      ],
+    ];
+  }
+
+  void _emitLocateMapTile({required String tileKey, required String regionId}) {
+    widget.bus.emit(const ClosePanelEvent());
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      widget.bus.emit(LocateMapTileEvent(tileKey: tileKey, regionId: regionId));
+    });
   }
 }
 
@@ -270,101 +312,107 @@ class _ArmyExpansionTile extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(left: 8),
       child: ExpansionTile(
-        title: UnitsEntityActionRow(
-          details: Row(
-            children: [
-              Checkbox(
-                value: isSelectedForCombine,
-                onChanged: (_) => onCombineSelectionToggle(),
-                visualDensity: VisualDensity.compact,
-                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              ),
-              const SizedBox(width: 4),
-              Flexible(
-                child: Text(_armyTitle(), overflow: TextOverflow.ellipsis),
-              ),
-              if (onLocate != null) ...[
-                const SizedBox(width: 4),
-                IconButton(
-                  tooltip: l10n.common_locate,
-                  onPressed: onLocate,
-                  icon: const Icon(Icons.my_location),
-                  iconSize: 18,
-                  visualDensity: VisualDensity.compact,
-                ),
-              ],
-            ],
-          ),
-          actions: [
-            if (onMove != null)
-              UnitsEntityAction(
-                tooltip: l10n.common_move,
-                icon: Icons.route,
-                label: l10n.common_move,
-                onPressed: onMove,
-              ),
-            if (onSplit != null)
-              UnitsEntityAction(
-                tooltip: l10n.common_split,
-                icon: Icons.call_split,
-                label: l10n.common_split,
-                onPressed: onSplit,
-              ),
-          ],
-        ),
-        subtitle: Text(
-          draftArmyMoveLine == null
-              ? l10n.military_units_armySubtitle(
-                  block.army.regimentUnitIds.length,
-                  stationedProvinceDisplayLabel,
-                )
-              : l10n.military_units_armySubtitleWithDraft(
-                  block.army.regimentUnitIds.length,
-                  stationedProvinceDisplayLabel,
-                  draftArmyMoveLine!,
-                ),
-        ),
+        title: _buildTitleRow(),
+        subtitle: Text(_subtitleText()),
         dense: true,
+        children: _buildChildren(),
+      ),
+    );
+  }
+
+  Widget _buildTitleRow() {
+    return UnitsEntityActionRow(
+      details: Row(
         children: [
-          if (block.rows.isEmpty)
-            ListTile(
-              title: Text(l10n.military_units_noRegimentsAssigned),
-              dense: true,
-            )
-          else ...[
-            for (final row in block.rows)
-              _RegimentRow(row: row, l10n: l10n, onTap: null),
-          ],
-          Padding(
-            padding: const EdgeInsets.all(8),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                if (onMove != null) ...[
-                  CtNinePatchButton(
-                    onPressed: onMove,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 8,
-                    ),
-                    minHeight: 36,
-                    child: Text(l10n.common_move),
-                  ),
-                  const SizedBox(width: 8),
-                ],
-                if (onSplit != null)
-                  CtNinePatchButton(
-                    onPressed: onSplit,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 8,
-                    ),
-                    minHeight: 36,
-                    child: Text(l10n.common_split),
-                  ),
-              ],
-            ),
+          Checkbox(
+            value: isSelectedForCombine,
+            onChanged: (_) => onCombineSelectionToggle(),
+            visualDensity: VisualDensity.compact,
+            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
           ),
+          const SizedBox(width: 4),
+          Flexible(child: Text(_armyTitle(), overflow: TextOverflow.ellipsis)),
+          if (onLocate != null) ...[
+            const SizedBox(width: 4),
+            IconButton(
+              tooltip: l10n.common_locate,
+              onPressed: onLocate,
+              icon: const Icon(Icons.my_location),
+              iconSize: 18,
+              visualDensity: VisualDensity.compact,
+            ),
+          ],
+        ],
+      ),
+      actions: [
+        if (onMove != null)
+          UnitsEntityAction(
+            tooltip: l10n.common_move,
+            icon: Icons.route,
+            label: l10n.common_move,
+            onPressed: onMove,
+          ),
+        if (onSplit != null)
+          UnitsEntityAction(
+            tooltip: l10n.common_split,
+            icon: Icons.call_split,
+            label: l10n.common_split,
+            onPressed: onSplit,
+          ),
+      ],
+    );
+  }
+
+  String _subtitleText() {
+    if (draftArmyMoveLine == null) {
+      return l10n.military_units_armySubtitle(
+        block.army.regimentUnitIds.length,
+        stationedProvinceDisplayLabel,
+      );
+    }
+    return l10n.military_units_armySubtitleWithDraft(
+      block.army.regimentUnitIds.length,
+      stationedProvinceDisplayLabel,
+      draftArmyMoveLine!,
+    );
+  }
+
+  List<Widget> _buildChildren() {
+    return [
+      if (block.rows.isEmpty)
+        ListTile(
+          title: Text(l10n.military_units_noRegimentsAssigned),
+          dense: true,
+        )
+      else
+        for (final row in block.rows)
+          _RegimentRow(row: row, l10n: l10n, onTap: null),
+      _buildFooterButtons(),
+    ];
+  }
+
+  Widget _buildFooterButtons() {
+    return Padding(
+      padding: const EdgeInsets.all(8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          if (onMove != null) ...[
+            CtNinePatchButton(
+              onPressed: onMove,
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              minHeight: 36,
+              child: Text(l10n.common_move),
+            ),
+            const SizedBox(width: 8),
+          ],
+          if (onSplit != null)
+            CtNinePatchButton(
+              onPressed: onSplit,
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              minHeight: 36,
+              child: Text(l10n.common_split),
+            ),
         ],
       ),
     );

--- a/app/lib/features/game/widgets/technology_panel.dart
+++ b/app/lib/features/game/widgets/technology_panel.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
+import '../../../l10n/app_localizations.dart';
 import '../../../l10n/l10n.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/ct_panel.dart';
@@ -25,163 +26,234 @@ class TechnologyPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = appL10n(context);
-    final techUnlocked = player.techUnlocked ?? {};
-    final researchedIds = techUnlocked.entries
-        .where((e) => e.value)
-        .map((e) => e.key)
-        .toList()
-      ..sort((a, b) {
-        final ta = techById(a);
-        final tb = techById(b);
-        final eraA = ta?.era ?? 999;
-        final eraB = tb?.era ?? 999;
-        final eraCmp = eraA.compareTo(eraB);
-        if (eraCmp != 0) return eraCmp;
-        return techDisplayName(a).compareTo(techDisplayName(b));
-      });
-    final progress = player.researchProgressByTechId ?? {};
+    final researchedIds = _sortedResearchedTechIds();
+    final progress = player.researchProgressByTechId ?? const <String, int>{};
     final slots = player.researchSlots ?? 3;
     final humanPlayerId = player.id;
-    final researchOrdersForPlayer =
-        currentOrders.researchOrdersByPlayerId[humanPlayerId] ??
-            const <ResearchOrder>[];
+    final researchOrdersForPlayer = _researchOrdersForPlayer(humanPlayerId);
+    final canEdit = onOrdersChanged != null;
 
     return Padding(
       padding: const EdgeInsets.all(16),
       child: CtPanel(
         padding: const EdgeInsets.all(16),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              l10n.technologyPanel_title(player.displayName),
-              style: Theme.of(context).textTheme.titleMedium,
-            ),
-            const SizedBox(height: 8),
-            Text(l10n.technologyPanel_researchSlotsCount(slots)),
-            const SizedBox(height: 8),
-            Text(
-              l10n.technologyPanel_researchSlots,
-              style: Theme.of(context).textTheme.labelLarge,
-            ),
-            const SizedBox(height: 4),
-            Column(
-              children: List.generate(slots, (index) {
-                ResearchOrder? order;
-                for (final o in researchOrdersForPlayer) {
-                  if (o.slotIndex == index) {
-                    order = o;
-                  }
-                }
-                final techId = order?.techId.isNotEmpty == true
-                    ? order!.techId
-                    : null;
-                final tech = techId != null ? techById(techId) : null;
-                final displayName = techId != null
-                    ? techDisplayName(techId)
-                    : l10n.technologyPanel_empty;
-                final techProgress =
-                    techId != null ? (progress[techId] ?? 0) : 0;
-                final cost = tech?.cost ?? 0;
-                final hasTech = techId != null;
-                final canEdit = onOrdersChanged != null;
-                return ListTile(
-                  contentPadding: EdgeInsets.zero,
-                  title: Text(l10n.technologyPanel_slot(index + 1)),
-                  subtitle: hasTech
-                      ? Text(
-                          l10n.technologyPanel_slotSubtitle(
-                            displayName,
-                            techProgress,
-                            cost > 0 ? '$cost' : '—',
-                          ),
-                        )
-                      : Text(l10n.technologyPanel_noTechAssigned),
-                  trailing: canEdit
-                      ? Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            if (hasTech)
-                              CtNinePatchButton(
-                                onPressed: () {
-                                  _cancelSlot(
-                                    context: context,
-                                    slotIndex: index,
-                                    humanPlayerId: humanPlayerId,
-                                    currentOrders: currentOrders,
-                                    onOrdersChanged: onOrdersChanged!,
-                                  );
-                                },
-                                child: Text(l10n.common_cancel),
-                              ),
-                            const SizedBox(width: 4),
-                            CtNinePatchButton(
-                              onPressed: () {
-                                _showAssignDialog(
-                                  context: context,
-                                  game: game,
-                                  slotIndex: index,
-                                  humanPlayerId: humanPlayerId,
-                                  currentOrders: currentOrders,
-                                  player: player,
-                                  onOrdersChanged: onOrdersChanged!,
-                                );
-                              },
-                              child: Text(l10n.technologyPanel_chooseTech),
-                            ),
-                          ],
-                        )
-                      : null,
-                );
-              }),
-            ),
-            const SizedBox(height: 12),
-            Divider(color: Theme.of(context).dividerColor),
-            const SizedBox(height: 8),
-            Text(
-              l10n.technologyPanel_researched(researchedIds.length),
-              style: Theme.of(context).textTheme.labelLarge,
-            ),
-            const SizedBox(height: 4),
-            if (researchedIds.isEmpty)
-              Text(l10n.technologyPanel_noneYet)
-            else
-              Wrap(
-                spacing: 4,
-                runSpacing: 4,
-                children: researchedIds
-                    .map(
-                      (id) => Chip(
-                        label: Text(techDisplayName(id)),
-                        labelStyle: Theme.of(context).textTheme.bodySmall,
-                      ),
-                    )
-                    .toList(),
-              ),
-            if (progress.isNotEmpty) ...[
-              const SizedBox(height: 12),
-              Text(
-                l10n.technologyPanel_inProgress,
-                style: Theme.of(context).textTheme.labelLarge,
-              ),
-              const SizedBox(height: 4),
-              ...progress.entries.map(
-                (e) => Padding(
-                  padding: const EdgeInsets.only(bottom: 4),
-                  child: Text(
-                    l10n.technologyPanel_progressLine(
-                      techDisplayName(e.key),
-                      e.value,
-                    ),
-                    style: Theme.of(context).textTheme.bodySmall,
-                  ),
-                ),
-              ),
-            ],
-          ],
+        child: _buildPanelContent(
+          context: context,
+          l10n: l10n,
+          researchedIds: researchedIds,
+          progress: progress,
+          slots: slots,
+          humanPlayerId: humanPlayerId,
+          researchOrdersForPlayer: researchOrdersForPlayer,
+          canEdit: canEdit,
         ),
       ),
+    );
+  }
+
+  Widget _buildPanelContent({
+    required BuildContext context,
+    required AppLocalizations l10n,
+    required List<String> researchedIds,
+    required Map<String, int> progress,
+    required int slots,
+    required String humanPlayerId,
+    required List<ResearchOrder> researchOrdersForPlayer,
+    required bool canEdit,
+  }) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n.technologyPanel_title(player.displayName),
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: 8),
+        Text(l10n.technologyPanel_researchSlotsCount(slots)),
+        const SizedBox(height: 8),
+        Text(
+          l10n.technologyPanel_researchSlots,
+          style: Theme.of(context).textTheme.labelLarge,
+        ),
+        const SizedBox(height: 4),
+        Column(
+          children: List.generate(
+            slots,
+            (index) => _buildResearchSlotTile(
+              context: context,
+              l10n: l10n,
+              index: index,
+              progress: progress,
+              humanPlayerId: humanPlayerId,
+              researchOrdersForPlayer: researchOrdersForPlayer,
+              canEdit: canEdit,
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        Divider(color: Theme.of(context).dividerColor),
+        const SizedBox(height: 8),
+        Text(
+          l10n.technologyPanel_researched(researchedIds.length),
+          style: Theme.of(context).textTheme.labelLarge,
+        ),
+        const SizedBox(height: 4),
+        if (researchedIds.isEmpty)
+          Text(l10n.technologyPanel_noneYet)
+        else
+          Wrap(
+            spacing: 4,
+            runSpacing: 4,
+            children: researchedIds
+                .map(
+                  (id) => Chip(
+                    label: Text(techDisplayName(id)),
+                    labelStyle: Theme.of(context).textTheme.bodySmall,
+                  ),
+                )
+                .toList(),
+          ),
+        if (progress.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          Text(
+            l10n.technologyPanel_inProgress,
+            style: Theme.of(context).textTheme.labelLarge,
+          ),
+          const SizedBox(height: 4),
+          ...progress.entries.map(
+            (entry) => Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: Text(
+                l10n.technologyPanel_progressLine(
+                  techDisplayName(entry.key),
+                  entry.value,
+                ),
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  List<String> _sortedResearchedTechIds() {
+    final techUnlocked = player.techUnlocked ?? const <String, bool>{};
+    final researchedIds = techUnlocked.entries
+        .where((entry) => entry.value)
+        .map((entry) => entry.key)
+        .toList();
+    researchedIds.sort(_sortTechIdsByEraThenName);
+    return researchedIds;
+  }
+
+  int _sortTechIdsByEraThenName(String a, String b) {
+    final eraA = techById(a)?.era ?? 999;
+    final eraB = techById(b)?.era ?? 999;
+    final eraCmp = eraA.compareTo(eraB);
+    if (eraCmp != 0) {
+      return eraCmp;
+    }
+    return techDisplayName(a).compareTo(techDisplayName(b));
+  }
+
+  List<ResearchOrder> _researchOrdersForPlayer(String playerId) {
+    return currentOrders.researchOrdersByPlayerId[playerId] ??
+        const <ResearchOrder>[];
+  }
+
+  Widget _buildResearchSlotTile({
+    required BuildContext context,
+    required AppLocalizations l10n,
+    required int index,
+    required Map<String, int> progress,
+    required String humanPlayerId,
+    required List<ResearchOrder> researchOrdersForPlayer,
+    required bool canEdit,
+  }) {
+    final order = _researchOrderForSlot(researchOrdersForPlayer, index);
+    final techId = _slotTechId(order);
+    final tech = techId == null ? null : techById(techId);
+    final displayName = techId == null
+        ? l10n.technologyPanel_empty
+        : techDisplayName(techId);
+    final techProgress = techId == null ? 0 : (progress[techId] ?? 0);
+    final cost = tech?.cost ?? 0;
+    final hasTech = techId != null;
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      title: Text(l10n.technologyPanel_slot(index + 1)),
+      subtitle: hasTech
+          ? Text(
+              l10n.technologyPanel_slotSubtitle(
+                displayName,
+                techProgress,
+                cost > 0 ? '$cost' : '—',
+              ),
+            )
+          : Text(l10n.technologyPanel_noTechAssigned),
+      trailing: canEdit
+          ? _buildSlotActions(context, l10n, index, humanPlayerId, hasTech)
+          : null,
+    );
+  }
+
+  ResearchOrder? _researchOrderForSlot(List<ResearchOrder> orders, int index) {
+    for (final order in orders) {
+      if (order.slotIndex == index) {
+        return order;
+      }
+    }
+    return null;
+  }
+
+  String? _slotTechId(ResearchOrder? order) {
+    if (order == null || order.techId.isEmpty) {
+      return null;
+    }
+    return order.techId;
+  }
+
+  Widget _buildSlotActions(
+    BuildContext context,
+    AppLocalizations l10n,
+    int index,
+    String humanPlayerId,
+    bool hasTech,
+  ) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (hasTech)
+          CtNinePatchButton(
+            onPressed: () {
+              _cancelSlot(
+                context: context,
+                slotIndex: index,
+                humanPlayerId: humanPlayerId,
+                currentOrders: currentOrders,
+                onOrdersChanged: onOrdersChanged!,
+              );
+            },
+            child: Text(l10n.common_cancel),
+          ),
+        const SizedBox(width: 4),
+        CtNinePatchButton(
+          onPressed: () {
+            _showAssignDialog(
+              context: context,
+              game: game,
+              slotIndex: index,
+              humanPlayerId: humanPlayerId,
+              currentOrders: currentOrders,
+              player: player,
+              onOrdersChanged: onOrdersChanged!,
+            );
+          },
+          child: Text(l10n.technologyPanel_chooseTech),
+        ),
+      ],
     );
   }
 }
@@ -199,7 +271,7 @@ void _showAssignDialog({
   final techUnlocked = player.techUnlocked ?? {};
   final existingOrders =
       currentOrders.researchOrdersByPlayerId[humanPlayerId] ??
-          const <ResearchOrder>[];
+      const <ResearchOrder>[];
   final currentlyAssignedIds = existingOrders
       .where((o) => o.techId.isNotEmpty)
       .map((o) => o.techId)
@@ -213,15 +285,16 @@ void _showAssignDialog({
   final choosableIds = researchableIds
       .where((id) => !currentlyAssignedIds.contains(id))
       .toList();
-  final availableTechs = choosableIds
-      .map((id) => techById(id))
-      .whereType<TechDefinition>()
-      .toList()
-    ..sort((a, b) {
-      final eraCmp = a.era.compareTo(b.era);
-      if (eraCmp != 0) return eraCmp;
-      return techDisplayName(a.id).compareTo(techDisplayName(b.id));
-    });
+  final availableTechs =
+      choosableIds
+          .map((id) => techById(id))
+          .whereType<TechDefinition>()
+          .toList()
+        ..sort((a, b) {
+          final eraCmp = a.era.compareTo(b.era);
+          if (eraCmp != 0) return eraCmp;
+          return techDisplayName(a.id).compareTo(techDisplayName(b.id));
+        });
 
   showModalBottomSheet<void>(
     context: context,
@@ -271,8 +344,9 @@ Orders _assignTechToSlot({
   required List<ResearchOrder> existingOrders,
 }) {
   final ordersForPlayer = List<ResearchOrder>.from(existingOrders);
-  final existingIndex =
-      ordersForPlayer.indexWhere((o) => o.slotIndex == slotIndex);
+  final existingIndex = ordersForPlayer.indexWhere(
+    (o) => o.slotIndex == slotIndex,
+  );
   final funding = existingIndex >= 0
       ? ordersForPlayer[existingIndex].funding
       : ResearchFundingLevel.medium;
@@ -304,7 +378,7 @@ void _cancelSlot({
   final l10n = appL10n(context);
   final existingOrders =
       currentOrders.researchOrdersByPlayerId[humanPlayerId] ??
-          const <ResearchOrder>[];
+      const <ResearchOrder>[];
   final remaining = existingOrders
       .where((o) => o.slotIndex != slotIndex)
       .toList(growable: false);
@@ -312,9 +386,7 @@ void _cancelSlot({
     ...currentOrders.researchOrdersByPlayerId,
     humanPlayerId: remaining,
   };
-  final updated = currentOrders.copyWith(
-    researchOrdersByPlayerId: updatedMap,
-  );
+  final updated = currentOrders.copyWith(researchOrdersByPlayerId: updatedMap);
   final messenger = ScaffoldMessenger.maybeOf(context);
   messenger?.showSnackBar(
     SnackBar(content: Text(l10n.technologyPanel_slotCancelled)),

--- a/app/lib/features/game/widgets/train_civilians_dialog.dart
+++ b/app/lib/features/game/widgets/train_civilians_dialog.dart
@@ -156,84 +156,99 @@ class _TrainCiviliansDialogState extends State<TrainCiviliansDialog> {
           _applyOrders();
         }
       },
-      child: CtDialogShell(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 16, 8, 8),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      l10n.trainCivilians_title,
-                      style: Theme.of(context).textTheme.titleMedium,
-                    ),
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.close),
-                    onPressed: () => Navigator.of(context).pop(),
-                  ),
-                ],
-              ),
+      child: CtDialogShell(child: _buildDialogContent(context, l10n)),
+    );
+  }
+
+  Widget _buildDialogContent(BuildContext context, AppLocalizations l10n) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _buildHeader(context, l10n),
+        const Divider(height: 1),
+        if (!_hasCapital)
+          _buildNoCapitalMessage(context, l10n)
+        else
+          ..._buildBody(l10n),
+      ],
+    );
+  }
+
+  Widget _buildHeader(BuildContext context, AppLocalizations l10n) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 8, 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              l10n.trainCivilians_title,
+              style: Theme.of(context).textTheme.titleMedium,
             ),
-            const Divider(height: 1),
-            if (!_hasCapital)
-              Padding(
-                padding: const EdgeInsets.all(16),
-                child: Text(
-                  l10n.trainUnits_noCapital,
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: Theme.of(context).colorScheme.error,
-                  ),
-                ),
-              )
-            else ...[
-              _ResourceBar(
-                treasury: _treasury,
-                paperStockpile: _paperStockpile,
-                deficitHint: _deficitHint,
-                l10n: l10n,
-              ),
-              const Divider(height: 1),
-              Padding(
-                padding: const EdgeInsets.symmetric(vertical: 8),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    for (final econ in CivilianEconomyCatalog.all)
-                      _UnitTypeRow(
-                        econ: econ,
-                        count: _counts[econ.id] ?? 0,
-                        isLocked: _isLocked(econ.id),
-                        techRequiredLabel: _techRequiredLabel(econ.id),
-                        canIncrement: _canAffordIncrement(econ.id),
-                        canDecrement: (_counts[econ.id] ?? 0) > 0,
-                        onIncrement: () => _increment(econ.id),
-                        onDecrement: () => _decrement(econ.id),
-                      ),
-                  ],
-                ),
-              ),
-              const Divider(height: 1),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    CtNinePatchButton(
-                      onPressed: _reset,
-                      child: Text(l10n.common_reset),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ],
+          ),
+          IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNoCapitalMessage(BuildContext context, AppLocalizations l10n) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Text(
+        l10n.trainUnits_noCapital,
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+          color: Theme.of(context).colorScheme.error,
         ),
       ),
     );
+  }
+
+  List<Widget> _buildBody(AppLocalizations l10n) {
+    return [
+      _ResourceBar(
+        treasury: _treasury,
+        paperStockpile: _paperStockpile,
+        deficitHint: _deficitHint,
+        l10n: l10n,
+      ),
+      const Divider(height: 1),
+      Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final econ in CivilianEconomyCatalog.all)
+              _UnitTypeRow(
+                econ: econ,
+                count: _counts[econ.id] ?? 0,
+                isLocked: _isLocked(econ.id),
+                techRequiredLabel: _techRequiredLabel(econ.id),
+                canIncrement: _canAffordIncrement(econ.id),
+                canDecrement: (_counts[econ.id] ?? 0) > 0,
+                onIncrement: () => _increment(econ.id),
+                onDecrement: () => _decrement(econ.id),
+              ),
+          ],
+        ),
+      ),
+      const Divider(height: 1),
+      Padding(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            CtNinePatchButton(
+              onPressed: _reset,
+              child: Text(l10n.common_reset),
+            ),
+          ],
+        ),
+      ),
+    ];
   }
 }
 
@@ -325,68 +340,83 @@ class _UnitTypeRow extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Row(
-              children: [
-                if (isLocked)
-                  StrictAssetIcon(
-                    assetPath: '${kAppIconAssetPrefix}ui_icon_lock.png',
-                    width: 20,
-                    height: 20,
-                  ),
-                if (isLocked) const SizedBox(width: 4),
-                Expanded(
-                  child: Text(
-                    econ.id,
-                    style: theme.textTheme.bodyLarge?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ),
-                Text(
-                  appL10n(context).trainCivilians_costLine(
-                    _formatTreasury(econ.buildTreasuryCost),
-                    paperQty.toString(),
-                  ),
-                  style: theme.textTheme.bodyMedium,
-                ),
-              ],
-            ),
-            if (isLocked) ...[
-              const SizedBox(height: 2),
-              Text(
-                techRequiredLabel,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.error,
-                ),
-              ),
-            ],
+            _buildHeader(context, theme, paperQty),
+            ..._buildLockedHint(theme),
             const SizedBox(height: 4),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                CtNinePatchButton(
-                  onPressed: isLocked || !canDecrement ? null : onDecrement,
-                  child: const Text('−'),
-                ),
-                const SizedBox(width: 8),
-                SizedBox(
-                  width: 32,
-                  child: Text(
-                    count.toString(),
-                    textAlign: TextAlign.center,
-                    style: theme.textTheme.bodyLarge,
-                  ),
-                ),
-                const SizedBox(width: 8),
-                CtNinePatchButton(
-                  onPressed: isLocked || !canIncrement ? null : onIncrement,
-                  child: const Text('+'),
-                ),
-              ],
-            ),
+            _buildStepper(theme),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context, ThemeData theme, int paperQty) {
+    return Row(
+      children: [
+        if (isLocked)
+          StrictAssetIcon(
+            assetPath: '${kAppIconAssetPrefix}ui_icon_lock.png',
+            width: 20,
+            height: 20,
+          ),
+        if (isLocked) const SizedBox(width: 4),
+        Expanded(
+          child: Text(
+            econ.id,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        Text(
+          appL10n(context).trainCivilians_costLine(
+            _formatTreasury(econ.buildTreasuryCost),
+            paperQty.toString(),
+          ),
+          style: theme.textTheme.bodyMedium,
+        ),
+      ],
+    );
+  }
+
+  List<Widget> _buildLockedHint(ThemeData theme) {
+    if (!isLocked) {
+      return const [];
+    }
+    return [
+      const SizedBox(height: 2),
+      Text(
+        techRequiredLabel,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.error,
+        ),
+      ),
+    ];
+  }
+
+  Widget _buildStepper(ThemeData theme) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        CtNinePatchButton(
+          onPressed: isLocked || !canDecrement ? null : onDecrement,
+          child: const Text('−'),
+        ),
+        const SizedBox(width: 8),
+        SizedBox(
+          width: 32,
+          child: Text(
+            count.toString(),
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyLarge,
+          ),
+        ),
+        const SizedBox(width: 8),
+        CtNinePatchButton(
+          onPressed: isLocked || !canIncrement ? null : onIncrement,
+          child: const Text('+'),
+        ),
+      ],
     );
   }
 

--- a/app/lib/features/game/widgets/train_military_dialog.dart
+++ b/app/lib/features/game/widgets/train_military_dialog.dart
@@ -185,85 +185,100 @@ class _TrainMilitaryDialogState extends State<TrainMilitaryDialog> {
           _applyOrders();
         }
       },
-      child: CtDialogShell(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 16, 8, 8),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      l10n.trainMilitary_title,
-                      style: Theme.of(context).textTheme.titleMedium,
-                    ),
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.close),
-                    onPressed: () => Navigator.of(context).pop(),
-                  ),
-                ],
-              ),
+      child: CtDialogShell(child: _buildDialogContent(context, l10n)),
+    );
+  }
+
+  Widget _buildDialogContent(BuildContext context, AppLocalizations l10n) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _buildHeader(context, l10n),
+        const Divider(height: 1),
+        if (!_hasCapital)
+          _buildNoCapitalMessage(context, l10n)
+        else
+          ..._buildBody(l10n),
+      ],
+    );
+  }
+
+  Widget _buildHeader(BuildContext context, AppLocalizations l10n) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 8, 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              l10n.trainMilitary_title,
+              style: Theme.of(context).textTheme.titleMedium,
             ),
-            const Divider(height: 1),
-            if (!_hasCapital)
-              Padding(
-                padding: const EdgeInsets.all(16),
-                child: Text(
-                  l10n.trainUnits_noCapital,
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: Theme.of(context).colorScheme.error,
-                  ),
-                ),
-              )
-            else ...[
-              _MilitaryResourceBar(
-                treasury: _treasury,
-                peasants: _peasants,
-                stockpile: _player?.stockpile ?? const Stockpile(),
-                deficitHint: _deficitHint,
-                l10n: l10n,
-              ),
-              const Divider(height: 1),
-              Padding(
-                padding: const EdgeInsets.symmetric(vertical: 8),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    for (final econ in RegimentEconomyCatalog.all)
-                      _RegimentRow(
-                        econ: econ,
-                        count: _counts[econ.id] ?? 0,
-                        isLocked: _isLocked(econ.id),
-                        techRequiredLabel: _techRequiredLabel(econ.id),
-                        canIncrement: _canAffordIncrement(econ.id),
-                        canDecrement: (_counts[econ.id] ?? 0) > 0,
-                        onIncrement: () => _increment(econ.id),
-                        onDecrement: () => _decrement(econ.id),
-                      ),
-                  ],
-                ),
-              ),
-              const Divider(height: 1),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    CtNinePatchButton(
-                      onPressed: _reset,
-                      child: Text(l10n.common_reset),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ],
+          ),
+          IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNoCapitalMessage(BuildContext context, AppLocalizations l10n) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Text(
+        l10n.trainUnits_noCapital,
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+          color: Theme.of(context).colorScheme.error,
         ),
       ),
     );
+  }
+
+  List<Widget> _buildBody(AppLocalizations l10n) {
+    return [
+      _MilitaryResourceBar(
+        treasury: _treasury,
+        peasants: _peasants,
+        stockpile: _player?.stockpile ?? const Stockpile(),
+        deficitHint: _deficitHint,
+        l10n: l10n,
+      ),
+      const Divider(height: 1),
+      Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final econ in RegimentEconomyCatalog.all)
+              _RegimentRow(
+                econ: econ,
+                count: _counts[econ.id] ?? 0,
+                isLocked: _isLocked(econ.id),
+                techRequiredLabel: _techRequiredLabel(econ.id),
+                canIncrement: _canAffordIncrement(econ.id),
+                canDecrement: (_counts[econ.id] ?? 0) > 0,
+                onIncrement: () => _increment(econ.id),
+                onDecrement: () => _decrement(econ.id),
+              ),
+          ],
+        ),
+      ),
+      const Divider(height: 1),
+      Padding(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            CtNinePatchButton(
+              onPressed: _reset,
+              child: Text(l10n.common_reset),
+            ),
+          ],
+        ),
+      ),
+    ];
   }
 }
 
@@ -403,78 +418,97 @@ class _RegimentRow extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    regimentTypeDisplayName(econ.id),
-                    style: theme.textTheme.bodyLarge?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ),
-                Text(
-                  econ.buildTreasuryCost.toString(),
-                  style: theme.textTheme.bodyMedium,
-                ),
-              ],
-            ),
+            _buildHeader(theme),
             const SizedBox(height: 2),
-            Wrap(
-              spacing: 8,
-              runSpacing: 4,
-              children: [
-                _InlineCost(
-                  icon: const Icon(Icons.payments_outlined, size: 14),
-                  label: econ.buildTreasuryCost.toString(),
-                ),
-                _InlineCost(
-                  icon: const WorkerIcon(workerType: 'peasant', size: 14),
-                  label: 1.toString(),
-                ),
-                for (final input in econ.buildInputs.entries)
-                  _InlineCost(
-                    icon: ResourceIcon(commodityId: input.key, size: 14),
-                    label: input.value.toString(),
-                  ),
-              ],
-            ),
-            if (isLocked) ...[
-              const SizedBox(height: 2),
-              Text(
-                techRequiredLabel,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.error,
-                ),
-              ),
-            ],
+            _buildCostWrap(),
+            ..._buildLockedHint(theme),
             const SizedBox(height: 4),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                CtNinePatchButton(
-                  onPressed: isLocked || !canDecrement ? null : onDecrement,
-                  child: const Text('−'),
-                ),
-                const SizedBox(width: 8),
-                SizedBox(
-                  width: 32,
-                  child: Text(
-                    count.toString(),
-                    textAlign: TextAlign.center,
-                    style: theme.textTheme.bodyLarge,
-                  ),
-                ),
-                const SizedBox(width: 8),
-                CtNinePatchButton(
-                  onPressed: isLocked || !canIncrement ? null : onIncrement,
-                  child: const Text('+'),
-                ),
-              ],
-            ),
+            _buildStepper(theme),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildHeader(ThemeData theme) {
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            regimentTypeDisplayName(econ.id),
+            style: theme.textTheme.bodyLarge?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        Text(
+          econ.buildTreasuryCost.toString(),
+          style: theme.textTheme.bodyMedium,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCostWrap() {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 4,
+      children: [
+        _InlineCost(
+          icon: const Icon(Icons.payments_outlined, size: 14),
+          label: econ.buildTreasuryCost.toString(),
+        ),
+        _InlineCost(
+          icon: const WorkerIcon(workerType: 'peasant', size: 14),
+          label: 1.toString(),
+        ),
+        for (final input in econ.buildInputs.entries)
+          _InlineCost(
+            icon: ResourceIcon(commodityId: input.key, size: 14),
+            label: input.value.toString(),
+          ),
+      ],
+    );
+  }
+
+  List<Widget> _buildLockedHint(ThemeData theme) {
+    if (!isLocked) {
+      return const [];
+    }
+    return [
+      const SizedBox(height: 2),
+      Text(
+        techRequiredLabel,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.error,
+        ),
+      ),
+    ];
+  }
+
+  Widget _buildStepper(ThemeData theme) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        CtNinePatchButton(
+          onPressed: isLocked || !canDecrement ? null : onDecrement,
+          child: const Text('−'),
+        ),
+        const SizedBox(width: 8),
+        SizedBox(
+          width: 32,
+          child: Text(
+            count.toString(),
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyLarge,
+          ),
+        ),
+        const SizedBox(width: 8),
+        CtNinePatchButton(
+          onPressed: isLocked || !canIncrement ? null : onIncrement,
+          child: const Text('+'),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- complete the remaining app-side slice for #1878 by splitting the last oversized widget `build()` methods into helper builders
- keep behavior unchanged while reducing `build()` method body size in the affected files
- keep existing lint expectations intact (`repo.no_flame_in_widgets`, `repo.game_widgets_file_size`, and `widget_build_method_too_long`)

## Test plan
- [x] `dart format app/lib/features/game/flame/game_map_corner_controls.dart app/lib/features/game/widgets/train_civilians_dialog.dart app/lib/features/game/widgets/military_units_panel.dart app/lib/features/game/widgets/train_military_dialog.dart app/lib/features/game/widgets/technology_panel.dart`
- [x] `dart run tool/check_no_flame_in_widgets.dart`
- [x] `dart run tool/check_game_widgets_file_size.dart`
- [x] `dart run tool/check_disallowed_ast_patterns.dart` (verified no `widget_build_method_too_long` matches)
- [x] `flutter analyze app/lib/features/game/flame/game_map_corner_controls.dart app/lib/features/game/widgets/train_civilians_dialog.dart app/lib/features/game/widgets/military_units_panel.dart app/lib/features/game/widgets/train_military_dialog.dart app/lib/features/game/widgets/technology_panel.dart`

Refs #1878

Made with [Cursor](https://cursor.com)