### PR TITLE
chore(skills): require review-pr comments and register skill

### DIFF
--- a/.cursor/skills/review-pr/SKILL.md
+++ b/.cursor/skills/review-pr/SKILL.md
@@ -64,6 +64,11 @@ Evaluate these four criteria in order:
    - Any `NO` means not merge-ready.
    - `CONDITIONAL YES` means intentionally partial and documented, but not full compliance.
 
+6. **Post findings to the PR**
+   - Post the full review output as a PR comment (do not keep findings only in local/chat output).
+   - Use GitHub CLI, e.g. `gh pr comment <number-or-url> --body "$(cat <<'EOF' ... EOF )"`.
+   - The PR comment must include every criterion result, all evidence bullets, all violations/gaps, and the final merge-readiness conclusion.
+
 ## Output format
 
 Use this exact structure:
@@ -90,6 +95,8 @@ Conclusion:
 - Merge readiness: READY | NOT READY
 - Rationale: <1-3 lines>
 ```
+
+After generating this output, publish it as a PR comment verbatim (or with only minimal formatting adjustments that preserve all findings).
 
 ## Quality bar
 

--- a/.opencode/skills/review-pr/SKILL.md
+++ b/.opencode/skills/review-pr/SKILL.md
@@ -19,6 +19,8 @@ When running in OpenCode:
   - `Linting compliance` cannot be `CONDITIONAL YES`.
   - Any lint allowlist creation/expansion is an automatic `NO`.
 - Produce the same output structure defined in the Cursor skill.
+- Post a PR comment containing the complete review findings (all criterion outcomes, evidence, violations/gaps, and conclusion), not just local/chat output.
+- Use GitHub CLI to publish the comment, e.g. `gh pr comment <number-or-url> --body "$(cat <<'EOF' ... EOF )"`.
 
 ## Required reference
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ Skills live under `.cursor/skills/<name>/SKILL.md`. When a skill matches the tas
 | `merge-dev-into-android-build` | Merge `dev` into `build/app/android` for APK build workflows. |
 | `plan-feature` | Scope a feature from SPEC/code (read-only), then open a capturing issue—no implementation. |
 | `refine-github-issue` | Refine an open issue from comment feedback (repro, root cause, priorities); update the body or return numbered clarifications when feedback conflicts with SPEC. |
+| `review-pr` | Review an open pull request against issue alignment, acceptance-criteria coverage, architecture conventions, and linting compliance; post all findings as a PR comment with strict YES/CONDITIONAL YES/NO outcomes. |
 | `review-github-issue` | Review an issue for **purpose ↔ proposed method** coherence and internal consistency; repo/SPEC/test evidence only when needed to show the method cannot satisfy the purpose. Consolidated comment with priorities and remedies; use **`verify-github-issue`** for AC↔implementation closure. |
 | `verify-github-issue` | Verify one open issue against ACs/specs/tests; gap analysis or closure steps. |
 


### PR DESCRIPTION
## Summary
- require the Cursor `review-pr` skill to post the complete review findings as a PR comment
- require the OpenCode `review-pr` skill to do the same via `gh pr comment`
- add `review-pr` to the project skill table in `AGENTS.md`

## Test plan
- [x] Confirm skill docs now include explicit PR-comment posting requirement
- [x] Confirm `AGENTS.md` includes `review-pr` in Project agent skills

Made with [Cursor](https://cursor.com)