### PR TITLE
fix(repo-lint): enforce app_event_handler_scope logic boundary

### DIFF
--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -31,6 +31,7 @@ Grandfather YAMLs named in the table below are **legacy** until removed; **do no
 | `tool/check_function_size.dart` | Function measured-line threshold (`SPEC/program/function-size.md`); rule `repo.function_size` |
 | `tool/check_part_unit_size.dart` | Dart `part` fragment physical line limit (`SPEC/program/part-unit-size.md`); rule `repo.part_unit_size` |
 | `tool/check_debug_console_logic_contract_boundary.dart` | AST-enforced import allowlist for debug-console -> logic boundary; rule `repo.debug_console_logic_contract_boundary` |
+| `tool/check_app_event_handler_scope_logic_boundary.dart` | Enforce that `app/lib/core/services/app_event_handler_scope.dart` has no direct import from `app/lib/features/game/logic/**`; rule `repo.app_event_handler_scope_logic_boundary` |
 | `tool/check_no_flame_in_widgets.dart` | Disallow direct `package:flame/*` **import** and **export** lines (single- or double-quoted URI) under `app/lib/widgets/**`; rule `repo.no_flame_in_widgets` |
 | `tool/check_no_screen_in_game_widgets.dart` | Disallow `*_screen.dart` files under `app/lib/features/game/widgets/**`; rule `repo.no_screen_in_game_widgets` |
 | `tool/check_game_widgets_file_size.dart` | Enforce `app/lib/features/game/widgets/**` Dart files at **700 physical lines or fewer**; rule `repo.game_widgets_file_size` |
@@ -83,3 +84,5 @@ Do **not** add new top-level `tool/check_*.dart` **entrypoints** for CI without 
 - Given app game widget files, when `dart run tool/ct_repo_lint.dart` runs rule `repo.game_widgets_file_size`, then each Dart file under `app/lib/features/game/widgets/**` has 700 physical lines or fewer.
 - Given `packages/colonizethis_debug_console/lib/**` imports only allowlisted `colonizethis_logic` contract entrypoints, when `dart run tool/ct_repo_lint.dart` runs rule `repo.debug_console_logic_contract_boundary`, then the rule passes without violations.
 - Given any debug-console file imports `package:colonizethis_logic/src/**` or another non-allowlisted `package:colonizethis_logic/...` entrypoint, when repo lint runs rule `repo.debug_console_logic_contract_boundary`, then the run fails and reports file path, line, and disallowed import context in checker output.
+- Given `app/lib/core/services/app_event_handler_scope.dart` has no direct imports from `package:colonizethis_app/features/game/logic/**`, when repo lint runs rule `repo.app_event_handler_scope_logic_boundary`, then the rule passes without violations.
+- Given `app/lib/core/services/app_event_handler_scope.dart` directly imports any `package:colonizethis_app/features/game/logic/**` path, when repo lint runs rule `repo.app_event_handler_scope_logic_boundary`, then the run fails and reports file path and line number.

--- a/test/check_app_event_handler_scope_logic_boundary_test.dart
+++ b/test/check_app_event_handler_scope_logic_boundary_test.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../tool/check_app_event_handler_scope_logic_boundary.dart';
+
+void main() {
+  test(
+    'runCheckAppEventHandlerScopeLogicBoundary fails when scope imports game logic directly',
+    () {
+      final tempDir = Directory.systemTemp.createTempSync(
+        'check_app_event_handler_scope_logic_boundary_test_',
+      );
+      addTearDown(() => tempDir.deleteSync(recursive: true));
+      final targetPath = p.join(
+        tempDir.path,
+        'app',
+        'lib',
+        'core',
+        'services',
+        'app_event_handler_scope.dart',
+      );
+      File(targetPath)
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
+import 'package:colonizethis_app/features/game/logic/some_logic.dart';
+''');
+
+      final stderrLines = <String>[];
+      final code = runCheckAppEventHandlerScopeLogicBoundary(
+        tempDir.path,
+        err: stderrLines.add,
+      );
+      expect(code, 1);
+      expect(
+        stderrLines.join('\n'),
+        contains('direct import from features/game/logic is disallowed'),
+      );
+    },
+  );
+
+  test(
+    'runCheckAppEventHandlerScopeLogicBoundary passes when scope avoids game logic imports',
+    () {
+      final tempDir = Directory.systemTemp.createTempSync(
+        'check_app_event_handler_scope_logic_boundary_test_',
+      );
+      addTearDown(() => tempDir.deleteSync(recursive: true));
+      final targetPath = p.join(
+        tempDir.path,
+        'app',
+        'lib',
+        'core',
+        'services',
+        'app_event_handler_scope.dart',
+      );
+      File(targetPath)
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
+import 'package:colonizethis_app/app.dart';
+import 'package:flutter/widgets.dart';
+''');
+
+      final stdoutLines = <String>[];
+      final code = runCheckAppEventHandlerScopeLogicBoundary(
+        tempDir.path,
+        info: stdoutLines.add,
+      );
+      expect(code, 0);
+      expect(stdoutLines.join('\n'), contains('no violations found'));
+    },
+  );
+}

--- a/test/ct_repo_lint_test.dart
+++ b/test/ct_repo_lint_test.dart
@@ -18,6 +18,7 @@ void main() {
       expect(ids, contains('repo.custom_exceptions'));
       expect(ids, contains('repo.disallowed_ast_patterns'));
       expect(ids, contains('repo.debug_console_logic_contract_boundary'));
+      expect(ids, contains('repo.app_event_handler_scope_logic_boundary'));
       expect(ids, contains('repo.control_flow_nesting_depth'));
       expect(ids, contains('repo.repeated_magic_numbers'));
       expect(ids, contains('repo.function_size'));

--- a/tool/check_app_event_handler_scope_logic_boundary.dart
+++ b/tool/check_app_event_handler_scope_logic_boundary.dart
@@ -1,0 +1,63 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+const _targetRelativePath = 'app/lib/core/services/app_event_handler_scope.dart';
+const _disallowedImportNeedle = 'package:colonizethis_app/features/game/logic/';
+
+/// Enforces app-event scope boundary:
+/// `app_event_handler_scope.dart` must not directly import
+/// `features/game/logic/**`.
+///
+/// SPEC: SPEC/program/repo-lint.md
+int runCheckAppEventHandlerScopeLogicBoundary(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+  final filePath = p.join(repoRoot, _targetRelativePath);
+  final file = File(filePath);
+  if (!file.existsSync()) {
+    logE(
+      'check_app_event_handler_scope_logic_boundary: target not found: $_targetRelativePath',
+    );
+    return 1;
+  }
+
+  final lines = file.readAsLinesSync();
+  final violations = <String>[];
+  for (var i = 0; i < lines.length; i++) {
+    final trimmed = lines[i].trim();
+    if (trimmed.startsWith('//')) {
+      continue;
+    }
+    if (!trimmed.startsWith('import ')) {
+      continue;
+    }
+    if (!trimmed.contains(_disallowedImportNeedle)) {
+      continue;
+    }
+    violations.add(
+      '$_targetRelativePath:${i + 1}: direct import from features/game/logic is disallowed',
+    );
+  }
+
+  if (violations.isEmpty) {
+    logI('check_app_event_handler_scope_logic_boundary: no violations found.');
+    return 0;
+  }
+
+  logE(
+    'check_app_event_handler_scope_logic_boundary: found ${violations.length} violation(s):',
+  );
+  for (final violation in violations) {
+    logE(' - $violation');
+  }
+  return 1;
+}
+
+void main() {
+  exit(runCheckAppEventHandlerScopeLogicBoundary(Directory.current.path));
+}

--- a/tool/ct_repo_lint_lib.dart
+++ b/tool/ct_repo_lint_lib.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
 import 'check_app_hardcoded_ui_strings.dart';
+import 'check_app_event_handler_scope_logic_boundary.dart';
 import 'check_asset_path_constants.dart';
 import 'check_canonical_province_tile_keys.dart';
 import 'check_civilian_unit_type_constants.dart';
@@ -698,6 +699,8 @@ int? _tryRunDartRuleInProcess({
         repoRoot,
         incrementalRelativeDartPaths: incrementalPaths,
       );
+    case 'repo.app_event_handler_scope_logic_boundary':
+      return runCheckAppEventHandlerScopeLogicBoundary(repoRoot);
     case 'repo.control_flow_nesting_depth':
       return runCheckControlFlowNestingDepth(repoRoot);
     case 'repo.repeated_magic_numbers':

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -88,6 +88,13 @@ rules:
     script: tool/check_debug_console_logic_contract_boundary.dart
     pr_incremental: true
 
+  - rule_id: repo.app_event_handler_scope_logic_boundary
+    group: architecture
+    title: app_event_handler_scope must not import features/game/logic directly
+    spec: SPEC/program/repo-lint.md
+    runner: dart
+    script: tool/check_app_event_handler_scope_logic_boundary.dart
+
   - rule_id: repo.control_flow_nesting_depth
     group: structure
     title: Control-flow nesting depth (if/for/while/switch)


### PR DESCRIPTION
## Summary
- Add `repo.app_event_handler_scope_logic_boundary` to enforce that `app/lib/core/services/app_event_handler_scope.dart` does not import `app/lib/features/game/logic/**` directly.
- Wire the new checker into `ct_repo_lint` manifest + in-process execution and document the rule in `SPEC/program/repo-lint.md`.
- Add focused tests for the checker and manifest presence.

## Test plan
- [x] `dart test test/check_app_event_handler_scope_logic_boundary_test.dart test/ct_repo_lint_test.dart`
- [x] `dart run tool/check_app_event_handler_scope_logic_boundary.dart`
- [x] `dart run tool/ct_repo_lint.dart --rule repo.app_event_handler_scope_logic_boundary`

## Scope notes
- This PR implements one isolatable closure-evidence slice for #2003.
- Deferred from #2003: full analyzer-hygiene cleanup across existing pre-existing `flutter analyze` diagnostics.

Refs #2003

Made with [Cursor](https://cursor.com)