### PR TITLE
fix(repo-lint): enforce function-size scope across repository packages

### DIFF
--- a/SPEC/program/function-size.md
+++ b/SPEC/program/function-size.md
@@ -13,8 +13,7 @@ runtime domain Dart code.
 
 The checker walks `collectRepoLintDomainDartFiles` and scopes to:
 
-- `packages/colonizethis_logic/lib/src/**`
-- `packages/colonizethis_map/lib/src/**`
+- `packages/*/lib/**`
 
 Tests and generated files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`) remain
 excluded by the shared scan contract.

--- a/test/check_function_size_test.dart
+++ b/test/check_function_size_test.dart
@@ -56,6 +56,33 @@ int f() {
       }
     });
 
+    test('fails for oversized functions in non-logic packages', () {
+      final temp = Directory.systemTemp.createTempSync('fn-size-data-');
+      try {
+        final libDir = Directory(
+          p.join(temp.path, 'packages', 'colonizethis_data', 'lib', 'src'),
+        )..createSync(recursive: true);
+        File(
+          p.join(libDir.path, 'big.dart'),
+        ).writeAsStringSync(giantFunctionSource(statements: 210));
+
+        final errors = <String>[];
+        final exitCode = runCheckFunctionSize(
+          temp.path,
+          info: (_) {},
+          err: errors.add,
+        );
+        expect(exitCode, 1);
+        expect(
+          errors.join('\n'),
+          contains('packages/colonizethis_data/lib/src/big.dart'),
+        );
+        expect(errors.join('\n'), contains('giant'));
+      } finally {
+        temp.deleteSync(recursive: true);
+      }
+    });
+
     test('fails even when legacy waiver yaml is present', () {
       final temp = Directory.systemTemp.createTempSync('fn-size-legacy-');
       try {

--- a/tool/check_function_size.dart
+++ b/tool/check_function_size.dart
@@ -10,10 +10,6 @@ import 'package:path/path.dart' as p;
 import 'ct_repo_lint_scan_contract.dart';
 
 const _failThreshold = 200;
-const _scopePrefixes = <String>[
-  'packages/colonizethis_logic/lib/src/',
-  'packages/colonizethis_map/lib/src/',
-];
 
 int runCheckFunctionSize(
   String repoRoot, {
@@ -22,9 +18,10 @@ int runCheckFunctionSize(
 }) {
   final logI = info ?? stdout.writeln;
   final logE = err ?? stderr.writeln;
+  final packageLibPrefixes = _collectPackageLibPrefixes(repoRoot);
   final files = collectRepoLintDomainDartFiles(repoRoot).where((file) {
     final rel = p.relative(file.path, from: repoRoot);
-    return _scopePrefixes.any(rel.startsWith);
+    return packageLibPrefixes.any(rel.startsWith);
   });
   final violations = <String>[];
 
@@ -53,6 +50,23 @@ int runCheckFunctionSize(
     logE(' - $violation');
   }
   return 1;
+}
+
+List<String> _collectPackageLibPrefixes(String repoRoot) {
+  final packagesDir = Directory(p.join(repoRoot, 'packages'));
+  if (!packagesDir.existsSync()) {
+    return const [];
+  }
+  final prefixes = <String>[];
+  for (final entity in packagesDir.listSync(followLinks: false)) {
+    if (entity is! Directory) {
+      continue;
+    }
+    final packageName = p.basename(entity.path);
+    prefixes.add('packages/$packageName/lib/');
+  }
+  prefixes.sort();
+  return prefixes;
 }
 
 void _scanCompilationUnit({


### PR DESCRIPTION
## Summary
- extend `repo.function_size` scan scope from two hardcoded packages to all `packages/*/lib/**`
- keep the 200-line threshold and existing measured-line behavior unchanged
- add a regression test that proves oversized functions in non-logic packages fail the check

## SPEC
- update `SPEC/program/function-size.md` scan scope to `packages/*/lib/**`

## Test plan
- [x] `dart run tool/check_function_size.dart`
- [x] `dart test test/check_function_size_test.dart test/check_no_flame_in_widgets_test.dart test/check_game_widgets_file_size_test.dart`

Refs #2003

Made with [Cursor](https://cursor.com)