### PR TITLE
fix(models): hard-fail unprefixed province ids in save-load paths

### DIFF
--- a/SPEC/game/world-model-identity.md
+++ b/SPEC/game/world-model-identity.md
@@ -14,7 +14,9 @@ In a multi-region world, **province lookup must always use regionId + provinceId
 
 All province ids stored in game state (e.g. Province id, Unit province location, Player capital, order fields) use a **prefixed** form: `regionId|localId` (e.g. `oldWorld|p1`, `newWorld|nw1`). This makes every province id globally unique and prevents a province from being resolved in the wrong region.
 
-**Unit placement in code:** The [Unit](world-model.md) model’s public canonical field is `locationProvinceId` (tile-derived when `tileKey` is set). Saves use the JSON property `provinceId` as the serialized canonical value, not a second competing concept; `fromJson` may repair legacy drift between `tileKey` and an old `provinceId` on load.
+**Unit placement in code:** The [Unit](world-model.md) model’s public canonical field is `locationProvinceId` (tile-derived when `tileKey` is set). Saves use the JSON property `provinceId` as the serialized canonical value, not a second competing concept; `fromJson` may repair drift between `tileKey` and `provinceId` only when both values are canonical prefixed province ids.
+
+**Load strictness for province-referencing fields:** Save/load must hard-fail when any province-referencing field carries an unprefixed local id. This includes persisted province ids in `Province.id`, `Unit.provinceId`, `Army.stationedProvinceId`, and capital or order province-id fields such as `Player.capitalProvinceId`, `MinorNation.capitalProvinceId`, `Tribe.capitalProvinceId`, `ArmyMoveOrder.destinationProvinceId`, and `BuildCivilianOrder.spawnProvinceId`.
 
 ---
 
@@ -63,6 +65,10 @@ Province lookup **MUST** be by **full disambiguated id** (`regionId|localId`). R
 - Given any game logic that is asked to resolve a province identifier and provided with a string that does not contain a `|` prefix separator or a pair of `(regionId, provinceId)` values that match a known province  
   When the System attempts to perform the lookup  
   Then the System treats the request as a logic error and does not fall back to a default region, does not guess a region by name pattern, and does not silently resolve the identifier to a different region’s province.
+
+- Given a save payload where any province-referencing field stores an unprefixed local id (for example `p1` instead of `oldWorld|p1`)  
+  When the System deserializes game-state models  
+  Then the System fails load with an explicit validation error and does not auto-repair or infer a region prefix.
 
 
 ---

--- a/packages/colonizethis_models/lib/src/army.dart
+++ b/packages/colonizethis_models/lib/src/army.dart
@@ -1,3 +1,5 @@
+import 'province_id.dart';
+
 /// Land military army: container for regiment unit ids. SPEC/game/military-armies.md.
 class Army {
   const Army({
@@ -12,6 +14,7 @@ class Army {
   final String id;
   final String ownerId;
   final String regionId;
+
   /// Prefixed province id where this army is stationed.
   final String stationedProvinceId;
   final List<String> regimentUnitIds;
@@ -36,13 +39,13 @@ class Army {
   }
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'ownerId': ownerId,
-        'regionId': regionId,
-        'stationedProvinceId': stationedProvinceId,
-        'regimentUnitIds': regimentUnitIds,
-        if (isHomeArmy) 'isHomeArmy': true,
-      };
+    'id': id,
+    'ownerId': ownerId,
+    'regionId': regionId,
+    'stationedProvinceId': stationedProvinceId,
+    'regimentUnitIds': regimentUnitIds,
+    if (isHomeArmy) 'isHomeArmy': true,
+  };
 
   static Army fromJson(Map<String, dynamic> json) {
     final idsRaw = json['regimentUnitIds'] as List<dynamic>? ?? [];
@@ -50,7 +53,10 @@ class Army {
       id: json['id'] as String,
       ownerId: json['ownerId'] as String,
       regionId: json['regionId'] as String,
-      stationedProvinceId: json['stationedProvinceId'] as String,
+      stationedProvinceId: ProvinceId.requirePrefixed(
+        json['stationedProvinceId'] as String,
+        fieldName: 'Army.stationedProvinceId',
+      ),
       regimentUnitIds: idsRaw.map((e) => e.toString()).toList(),
       isHomeArmy: json['isHomeArmy'] == true,
     );
@@ -70,13 +76,13 @@ class Army {
 
   @override
   int get hashCode => Object.hash(
-        id,
-        ownerId,
-        regionId,
-        stationedProvinceId,
-        Object.hashAll(regimentUnitIds),
-        isHomeArmy,
-      );
+    id,
+    ownerId,
+    regionId,
+    stationedProvinceId,
+    Object.hashAll(regimentUnitIds),
+    isHomeArmy,
+  );
 
   static bool _listEquals(List<String> a, List<String> b) {
     if (a.length != b.length) return false;

--- a/packages/colonizethis_models/lib/src/minor_nation.dart
+++ b/packages/colonizethis_models/lib/src/minor_nation.dart
@@ -41,7 +41,7 @@ class MinorNation {
       ),
       capitalTile: capitalTileRaw is Map<String, dynamic>
           ? CapitalTile.fromJson(capitalTileRaw)
-          : (capitalTileRaw is Map
+          : (capitalTileRaw is Map<Object?, Object?>
                 ? CapitalTile.fromJson(
                     Map<String, dynamic>.from(capitalTileRaw),
                   )

--- a/packages/colonizethis_models/lib/src/minor_nation.dart
+++ b/packages/colonizethis_models/lib/src/minor_nation.dart
@@ -1,4 +1,5 @@
 import 'capital_tile.dart';
+import 'province_id.dart';
 
 /// Minor Nation faction. SPEC/game/factions.md.
 /// Old World only; capital assigned at game setup.
@@ -21,24 +22,30 @@ class MinorNation {
   final int effectiveMilitaryLevel;
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        if (displayName != null) 'displayName': displayName,
-        if (capitalProvinceId != null) 'capitalProvinceId': capitalProvinceId,
-        if (capitalTile != null) 'capitalTile': capitalTile!.toJson(),
-        if (effectiveMilitaryLevel != 1) 'effectiveMilitaryLevel': effectiveMilitaryLevel,
-      };
+    'id': id,
+    if (displayName != null) 'displayName': displayName,
+    if (capitalProvinceId != null) 'capitalProvinceId': capitalProvinceId,
+    if (capitalTile != null) 'capitalTile': capitalTile!.toJson(),
+    if (effectiveMilitaryLevel != 1)
+      'effectiveMilitaryLevel': effectiveMilitaryLevel,
+  };
 
   static MinorNation fromJson(Map<String, dynamic> json) {
     final capitalTileRaw = json['capitalTile'];
     return MinorNation(
       id: json['id'] as String,
       displayName: json['displayName'] as String?,
-      capitalProvinceId: json['capitalProvinceId'] as String?,
+      capitalProvinceId: ProvinceId.requirePrefixedOrNull(
+        json['capitalProvinceId'] as String?,
+        fieldName: 'MinorNation.capitalProvinceId',
+      ),
       capitalTile: capitalTileRaw is Map<String, dynamic>
           ? CapitalTile.fromJson(capitalTileRaw)
           : (capitalTileRaw is Map
-              ? CapitalTile.fromJson(Map<String, dynamic>.from(capitalTileRaw))
-              : null),
+                ? CapitalTile.fromJson(
+                    Map<String, dynamic>.from(capitalTileRaw),
+                  )
+                : null),
       effectiveMilitaryLevel: (json['effectiveMilitaryLevel'] as int?) ?? 1,
     );
   }
@@ -55,7 +62,8 @@ class MinorNation {
       displayName: displayName ?? this.displayName,
       capitalProvinceId: capitalProvinceId ?? this.capitalProvinceId,
       capitalTile: capitalTile ?? this.capitalTile,
-      effectiveMilitaryLevel: effectiveMilitaryLevel ?? this.effectiveMilitaryLevel,
+      effectiveMilitaryLevel:
+          effectiveMilitaryLevel ?? this.effectiveMilitaryLevel,
     );
   }
 
@@ -71,6 +79,11 @@ class MinorNation {
           effectiveMilitaryLevel == other.effectiveMilitaryLevel;
 
   @override
-  int get hashCode =>
-      Object.hash(id, displayName, capitalProvinceId, capitalTile, effectiveMilitaryLevel);
+  int get hashCode => Object.hash(
+    id,
+    displayName,
+    capitalProvinceId,
+    capitalTile,
+    effectiveMilitaryLevel,
+  );
 }

--- a/packages/colonizethis_models/lib/src/orders.dart
+++ b/packages/colonizethis_models/lib/src/orders.dart
@@ -367,9 +367,13 @@ class ArmyMoveOrder {
   };
 
   static ArmyMoveOrder fromJson(Map<String, dynamic> json) {
+    final destinationProvinceId = ProvinceId.requirePrefixed(
+      json['destinationProvinceId'] as String,
+      fieldName: 'ArmyMoveOrder.destinationProvinceId',
+    );
     return ArmyMoveOrder(
       armyId: json['armyId'] as String,
-      destinationProvinceId: json['destinationProvinceId'] as String,
+      destinationProvinceId: destinationProvinceId,
     );
   }
 
@@ -522,10 +526,14 @@ class BuildUnitOrder {
   };
 
   static BuildUnitOrder fromJson(Map<String, dynamic> json) {
+    final spawnProvinceId = ProvinceId.requirePrefixed(
+      json['spawnProvinceId'] as String,
+      fieldName: 'BuildUnitOrder.spawnProvinceId',
+    );
     return BuildUnitOrder(
       unitType: json['unitType'] as String,
       isMilitary: json['isMilitary'] as bool? ?? false,
-      spawnProvinceId: json['spawnProvinceId'] as String,
+      spawnProvinceId: spawnProvinceId,
     );
   }
 

--- a/packages/colonizethis_models/lib/src/orders.dart
+++ b/packages/colonizethis_models/lib/src/orders.dart
@@ -88,7 +88,11 @@ class Orders {
     moveRaw.forEach((key, value) {
       final playerId = key.toString();
       final list = (value as List<dynamic>? ?? [])
-          .map((e) => MoveOrder.fromJson(Map<String, dynamic>.from(e as Map)))
+          .map(
+            (e) => MoveOrder.fromJson(
+              Map<String, dynamic>.from(e as Map<Object?, Object?>),
+            ),
+          )
           .toList();
       moveByPlayerId[playerId] = list;
     });
@@ -100,7 +104,9 @@ class Orders {
       final playerId = key.toString();
       final list = (value as List<dynamic>? ?? [])
           .map(
-            (e) => ArmyMoveOrder.fromJson(Map<String, dynamic>.from(e as Map)),
+            (e) => ArmyMoveOrder.fromJson(
+              Map<String, dynamic>.from(e as Map<Object?, Object?>),
+            ),
           )
           .toList();
       armyMoveByPlayerId[playerId] = list;
@@ -113,7 +119,9 @@ class Orders {
       final playerId = key.toString();
       final list = (value as List<dynamic>? ?? [])
           .map(
-            (e) => BuildUnitOrder.fromJson(Map<String, dynamic>.from(e as Map)),
+            (e) => BuildUnitOrder.fromJson(
+              Map<String, dynamic>.from(e as Map<Object?, Object?>),
+            ),
           )
           .toList();
       buildByPlayerId[playerId] = list;
@@ -125,7 +133,11 @@ class Orders {
     workRaw.forEach((key, value) {
       final playerId = key.toString();
       final list = (value as List<dynamic>? ?? [])
-          .map((e) => WorkOrder.fromJson(Map<String, dynamic>.from(e as Map)))
+          .map(
+            (e) => WorkOrder.fromJson(
+              Map<String, dynamic>.from(e as Map<Object?, Object?>),
+            ),
+          )
           .toList();
       workByPlayerId[playerId] = list;
     });
@@ -137,8 +149,9 @@ class Orders {
       final playerId = key.toString();
       final list = (value as List<dynamic>? ?? [])
           .map(
-            (e) =>
-                DiplomaticOrder.fromJson(Map<String, dynamic>.from(e as Map)),
+            (e) => DiplomaticOrder.fromJson(
+              Map<String, dynamic>.from(e as Map<Object?, Object?>),
+            ),
           )
           .toList();
       diploByPlayerId[playerId] = list;
@@ -151,7 +164,9 @@ class Orders {
       final playerId = key.toString();
       final list = (value as List<dynamic>? ?? [])
           .map(
-            (e) => ResearchOrder.fromJson(Map<String, dynamic>.from(e as Map)),
+            (e) => ResearchOrder.fromJson(
+              Map<String, dynamic>.from(e as Map<Object?, Object?>),
+            ),
           )
           .toList();
       researchByPlayerId[playerId] = list;
@@ -164,7 +179,9 @@ class Orders {
       final playerId = key.toString();
       final list = (value as List<dynamic>? ?? [])
           .map(
-            (e) => NavalMoveOrder.fromJson(Map<String, dynamic>.from(e as Map)),
+            (e) => NavalMoveOrder.fromJson(
+              Map<String, dynamic>.from(e as Map<Object?, Object?>),
+            ),
           )
           .toList();
       navalByPlayerId[playerId] = list;
@@ -177,8 +194,9 @@ class Orders {
       final playerId = key.toString();
       final list = (value as List<dynamic>? ?? [])
           .map(
-            (e) =>
-                NavalMissionOrder.fromJson(Map<String, dynamic>.from(e as Map)),
+            (e) => NavalMissionOrder.fromJson(
+              Map<String, dynamic>.from(e as Map<Object?, Object?>),
+            ),
           )
           .toList();
       missionByPlayerId[playerId] = list;

--- a/packages/colonizethis_models/lib/src/player.dart
+++ b/packages/colonizethis_models/lib/src/player.dart
@@ -1,4 +1,5 @@
 import 'capital_tile.dart';
+import 'province_id.dart';
 import 'stockpile.dart';
 import 'worker_pool.dart';
 
@@ -138,7 +139,10 @@ class Player {
       stockpile: _readStockpile(),
       workerPool: _readWorkerPool(),
       treasury: _readTreasury(),
-      capitalProvinceId: json['capitalProvinceId'] as String?,
+      capitalProvinceId: ProvinceId.requirePrefixedOrNull(
+        json['capitalProvinceId'] as String?,
+        fieldName: 'Player.capitalProvinceId',
+      ),
       capitalTile: _readCapitalTile(),
       techUnlocked: _readTechUnlocked(),
       militaryLevel: (json['militaryLevel'] as int?),

--- a/packages/colonizethis_models/lib/src/player.dart
+++ b/packages/colonizethis_models/lib/src/player.dart
@@ -85,7 +85,7 @@ class Player {
       if (raw is Map<String, dynamic>) {
         return Stockpile.fromJson(raw);
       }
-      if (raw is Map) {
+      if (raw is Map<Object?, Object?>) {
         return Stockpile.fromJson(Map<String, dynamic>.from(raw));
       }
       return Stockpile.empty;
@@ -96,7 +96,7 @@ class Player {
       if (raw is Map<String, dynamic>) {
         return WorkerPool.fromJson(raw);
       }
-      if (raw is Map) {
+      if (raw is Map<Object?, Object?>) {
         return WorkerPool.fromJson(Map<String, dynamic>.from(raw));
       }
       return WorkerPool.empty;
@@ -111,14 +111,14 @@ class Player {
     CapitalTile? _readCapitalTile() {
       final raw = json['capitalTile'];
       if (raw is Map<String, dynamic>) return CapitalTile.fromJson(raw);
-      if (raw is Map)
+      if (raw is Map<Object?, Object?>)
         return CapitalTile.fromJson(Map<String, dynamic>.from(raw));
       return null;
     }
 
     Map<String, bool>? _readTechUnlocked() {
       final raw = json['techUnlocked'];
-      if (raw is! Map) return null;
+      if (raw is! Map<Object?, Object?>) return null;
       return Map<String, bool>.from(
         raw.map((k, v) => MapEntry(k.toString(), v == true)),
       );
@@ -126,7 +126,7 @@ class Player {
 
     Map<String, int>? _readResearchProgress() {
       final raw = json['researchProgressByTechId'];
-      if (raw is! Map) return null;
+      if (raw is! Map<Object?, Object?>) return null;
       return Map<String, int>.from(
         raw.map((k, v) => MapEntry(k.toString(), (v as num?)?.toInt() ?? 0)),
       );

--- a/packages/colonizethis_models/lib/src/province.dart
+++ b/packages/colonizethis_models/lib/src/province.dart
@@ -1,3 +1,5 @@
+import 'province_id.dart';
+
 /// One map province in a region. SPEC/game/world-model.
 /// Phase 3: fortLevel (0–3), terrain for combat. SPEC/game/siege-mechanics.md.
 /// Town: townTileKey and townDevelopmentLevel for extraction. SPEC/game/capital-and-connectivity.md.
@@ -16,6 +18,7 @@ class Province {
   final String id;
   final String regionId;
   final String? ownerId;
+
   /// Optional human-readable name (from ruleset naming config).
   final String? displayName;
 
@@ -32,19 +35,23 @@ class Province {
   final int townDevelopmentLevel;
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'regionId': regionId,
-        'ownerId': ownerId,
-        if (displayName != null) 'displayName': displayName,
-        if (fortLevel != 0) 'fortLevel': fortLevel,
-        if (terrain != 'plains') 'terrain': terrain,
-        if (townTileKey != null) 'townTileKey': townTileKey,
-        if (townDevelopmentLevel != 0) 'townDevelopmentLevel': townDevelopmentLevel,
-      };
+    'id': id,
+    'regionId': regionId,
+    'ownerId': ownerId,
+    if (displayName != null) 'displayName': displayName,
+    if (fortLevel != 0) 'fortLevel': fortLevel,
+    if (terrain != 'plains') 'terrain': terrain,
+    if (townTileKey != null) 'townTileKey': townTileKey,
+    if (townDevelopmentLevel != 0) 'townDevelopmentLevel': townDevelopmentLevel,
+  };
 
   static Province fromJson(Map<String, dynamic> json) {
+    final provinceId = ProvinceId.requirePrefixed(
+      json['id'] as String,
+      fieldName: 'Province.id',
+    );
     return Province(
-      id: json['id'] as String,
+      id: provinceId,
       regionId: json['regionId'] as String,
       ownerId: json['ownerId'] as String?,
       displayName: json['displayName'] as String?,
@@ -92,6 +99,14 @@ class Province {
           townDevelopmentLevel == other.townDevelopmentLevel;
 
   @override
-  int get hashCode =>
-      Object.hash(id, regionId, ownerId, displayName, fortLevel, terrain, townTileKey, townDevelopmentLevel);
+  int get hashCode => Object.hash(
+    id,
+    regionId,
+    ownerId,
+    displayName,
+    fortLevel,
+    terrain,
+    townTileKey,
+    townDevelopmentLevel,
+  );
 }

--- a/packages/colonizethis_models/lib/src/province_id.dart
+++ b/packages/colonizethis_models/lib/src/province_id.dart
@@ -1,3 +1,5 @@
+import 'model_validation_exception.dart';
+
 /// Helpers for prefixed province ids: "regionId|localId".
 /// All game-state province ids must be prefixed so a province cannot be
 /// located in the wrong region. SPEC/game/world-model.
@@ -35,6 +37,26 @@ class ProvinceId {
 
   /// True if [id] looks prefixed (contains "|").
   static bool isPrefixed(String id) => id.contains('|');
+
+  /// Returns [provinceId] when it is prefixed; otherwise throws [ModelValidationException].
+  static String requirePrefixed(
+    String provinceId, {
+    String fieldName = 'provinceId',
+  }) {
+    if (isPrefixed(provinceId)) return provinceId;
+    throw ModelValidationException(
+      '$fieldName must be prefixed (regionId|localId): "$provinceId"',
+    );
+  }
+
+  /// Returns null when [provinceId] is null; otherwise enforces prefixed format.
+  static String? requirePrefixedOrNull(
+    String? provinceId, {
+    String fieldName = 'provinceId',
+  }) {
+    if (provinceId == null) return null;
+    return requirePrefixed(provinceId, fieldName: fieldName);
+  }
 
   /// Local province id segment when normalizing persisted or capital data that
   /// may still use bare local ids. Prefixed values use [localIdFrom]; bare

--- a/packages/colonizethis_models/lib/src/tribe.dart
+++ b/packages/colonizethis_models/lib/src/tribe.dart
@@ -41,7 +41,7 @@ class Tribe {
       ),
       capitalTile: capitalTileRaw is Map<String, dynamic>
           ? CapitalTile.fromJson(capitalTileRaw)
-          : (capitalTileRaw is Map
+          : (capitalTileRaw is Map<Object?, Object?>
                 ? CapitalTile.fromJson(
                     Map<String, dynamic>.from(capitalTileRaw),
                   )

--- a/packages/colonizethis_models/lib/src/tribe.dart
+++ b/packages/colonizethis_models/lib/src/tribe.dart
@@ -1,4 +1,5 @@
 import 'capital_tile.dart';
+import 'province_id.dart';
 
 /// Tribe faction. SPEC/game/factions.md.
 /// New World only; capital assigned at game setup.
@@ -21,24 +22,30 @@ class Tribe {
   final int effectiveMilitaryLevel;
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        if (displayName != null) 'displayName': displayName,
-        if (capitalProvinceId != null) 'capitalProvinceId': capitalProvinceId,
-        if (capitalTile != null) 'capitalTile': capitalTile!.toJson(),
-        if (effectiveMilitaryLevel != 1) 'effectiveMilitaryLevel': effectiveMilitaryLevel,
-      };
+    'id': id,
+    if (displayName != null) 'displayName': displayName,
+    if (capitalProvinceId != null) 'capitalProvinceId': capitalProvinceId,
+    if (capitalTile != null) 'capitalTile': capitalTile!.toJson(),
+    if (effectiveMilitaryLevel != 1)
+      'effectiveMilitaryLevel': effectiveMilitaryLevel,
+  };
 
   static Tribe fromJson(Map<String, dynamic> json) {
     final capitalTileRaw = json['capitalTile'];
     return Tribe(
       id: json['id'] as String,
       displayName: json['displayName'] as String?,
-      capitalProvinceId: json['capitalProvinceId'] as String?,
+      capitalProvinceId: ProvinceId.requirePrefixedOrNull(
+        json['capitalProvinceId'] as String?,
+        fieldName: 'Tribe.capitalProvinceId',
+      ),
       capitalTile: capitalTileRaw is Map<String, dynamic>
           ? CapitalTile.fromJson(capitalTileRaw)
           : (capitalTileRaw is Map
-              ? CapitalTile.fromJson(Map<String, dynamic>.from(capitalTileRaw))
-              : null),
+                ? CapitalTile.fromJson(
+                    Map<String, dynamic>.from(capitalTileRaw),
+                  )
+                : null),
       effectiveMilitaryLevel: (json['effectiveMilitaryLevel'] as int?) ?? 1,
     );
   }
@@ -55,7 +62,8 @@ class Tribe {
       displayName: displayName ?? this.displayName,
       capitalProvinceId: capitalProvinceId ?? this.capitalProvinceId,
       capitalTile: capitalTile ?? this.capitalTile,
-      effectiveMilitaryLevel: effectiveMilitaryLevel ?? this.effectiveMilitaryLevel,
+      effectiveMilitaryLevel:
+          effectiveMilitaryLevel ?? this.effectiveMilitaryLevel,
     );
   }
 
@@ -71,6 +79,11 @@ class Tribe {
           effectiveMilitaryLevel == other.effectiveMilitaryLevel;
 
   @override
-  int get hashCode =>
-      Object.hash(id, displayName, capitalProvinceId, capitalTile, effectiveMilitaryLevel);
+  int get hashCode => Object.hash(
+    id,
+    displayName,
+    capitalProvinceId,
+    capitalTile,
+    effectiveMilitaryLevel,
+  );
 }

--- a/packages/colonizethis_models/lib/src/unit.dart
+++ b/packages/colonizethis_models/lib/src/unit.dart
@@ -135,7 +135,7 @@ class Unit {
       assignedTileKey: json['assignedTileKey'] as String?,
       currentWork: cw is Map<String, dynamic>
           ? CurrentWork.fromJson(cw)
-          : cw is Map
+          : cw is Map<Object?, Object?>
           ? CurrentWork.fromJson(Map<String, dynamic>.from(cw))
           : null,
     );

--- a/packages/colonizethis_models/lib/src/unit.dart
+++ b/packages/colonizethis_models/lib/src/unit.dart
@@ -1,4 +1,5 @@
 import 'current_work.dart';
+import 'province_id.dart';
 
 /// Normalizes persisted province id: tile-derived wins when [tileKey] is set.
 String _storedProvinceIdForTileAndLocation(
@@ -114,7 +115,10 @@ class Unit {
   static Unit fromJson(Map<String, dynamic> json) {
     final cw = json['currentWork'];
     final tileKey = json['tileKey'] as String?;
-    final rawProvince = json['provinceId'] as String;
+    final rawProvince = ProvinceId.requirePrefixed(
+      json['provinceId'] as String,
+      fieldName: 'Unit.provinceId',
+    );
     final normalizedStored = _storedProvinceIdForTileAndLocation(
       tileKey,
       rawProvince,

--- a/packages/colonizethis_models/test/game_test.dart
+++ b/packages/colonizethis_models/test/game_test.dart
@@ -184,7 +184,7 @@ void main() {
       final minor = MinorNation(
         id: 'min1',
         displayName: 'Portugal',
-        capitalProvinceId: 'prov1',
+        capitalProvinceId: 'oldWorld|prov1',
         capitalTile: const CapitalTile(
           regionId: 'oldWorld',
           provinceId: 'prov1',
@@ -195,7 +195,7 @@ void main() {
       final tribe = Tribe(
         id: 'tribe1',
         displayName: 'Aztec',
-        capitalProvinceId: 'nw1',
+        capitalProvinceId: 'newWorld|nw1',
         capitalTile: const CapitalTile(
           regionId: 'newWorld',
           provinceId: 'nw1',
@@ -221,7 +221,7 @@ void main() {
       final round = Game.fromJson(json);
       expect(round.minorNations.length, 1);
       expect(round.minorNations.first.id, 'min1');
-      expect(round.minorNations.first.capitalProvinceId, 'prov1');
+      expect(round.minorNations.first.capitalProvinceId, 'oldWorld|prov1');
       expect(round.tribes.length, 1);
       expect(round.tribes.first.id, 'tribe1');
       expect(round.tribes.first.capitalTile?.x, 1);

--- a/packages/colonizethis_models/test/orders_test.dart
+++ b/packages/colonizethis_models/test/orders_test.dart
@@ -11,13 +11,27 @@ void main() {
     test('toJson/fromJson round-trip with data', () {
       const o = Orders(
         moveOrdersByPlayerId: {
-          'p1': [MoveOrder(unitId: 'u1', destinationTileKey: 'oldWorld|prov1|0|0')],
+          'p1': [
+            MoveOrder(unitId: 'u1', destinationTileKey: 'oldWorld|prov1|0|0'),
+          ],
         },
         buildUnitOrdersByPlayerId: {
-          'p1': [BuildUnitOrder(unitType: 'Regiment', isMilitary: true, spawnProvinceId: 'prov1')],
+          'p1': [
+            BuildUnitOrder(
+              unitType: 'Regiment',
+              isMilitary: true,
+              spawnProvinceId: 'oldWorld|prov1',
+            ),
+          ],
         },
         workOrdersByPlayerId: {
-          'p1': [WorkOrder(unitId: 'u1', target: 'build_mine', targetTileKey: 'oldWorld|prov1|0|0')],
+          'p1': [
+            WorkOrder(
+              unitId: 'u1',
+              target: 'build_mine',
+              targetTileKey: 'oldWorld|prov1|0|0',
+            ),
+          ],
         },
       );
       final o2 = Orders.fromJson(o.toJson());
@@ -32,24 +46,52 @@ void main() {
     test('equality', () {
       const a = Orders(
         moveOrdersByPlayerId: {
-          'p1': [MoveOrder(unitId: 'u1', destinationTileKey: 'oldWorld|prov1|0|0')],
+          'p1': [
+            MoveOrder(unitId: 'u1', destinationTileKey: 'oldWorld|prov1|0|0'),
+          ],
         },
         buildUnitOrdersByPlayerId: {
-          'p1': [BuildUnitOrder(unitType: 'Regiment', isMilitary: true, spawnProvinceId: 'prov1')],
+          'p1': [
+            BuildUnitOrder(
+              unitType: 'Regiment',
+              isMilitary: true,
+              spawnProvinceId: 'oldWorld|prov1',
+            ),
+          ],
         },
         workOrdersByPlayerId: {
-          'p1': [WorkOrder(unitId: 'u1', target: 'build_mine', targetTileKey: 'oldWorld|prov1|0|0')],
+          'p1': [
+            WorkOrder(
+              unitId: 'u1',
+              target: 'build_mine',
+              targetTileKey: 'oldWorld|prov1|0|0',
+            ),
+          ],
         },
       );
       const b = Orders(
         moveOrdersByPlayerId: {
-          'p1': [MoveOrder(unitId: 'u1', destinationTileKey: 'oldWorld|prov1|0|0')],
+          'p1': [
+            MoveOrder(unitId: 'u1', destinationTileKey: 'oldWorld|prov1|0|0'),
+          ],
         },
         buildUnitOrdersByPlayerId: {
-          'p1': [BuildUnitOrder(unitType: 'Regiment', isMilitary: true, spawnProvinceId: 'prov1')],
+          'p1': [
+            BuildUnitOrder(
+              unitType: 'Regiment',
+              isMilitary: true,
+              spawnProvinceId: 'oldWorld|prov1',
+            ),
+          ],
         },
         workOrdersByPlayerId: {
-          'p1': [WorkOrder(unitId: 'u1', target: 'build_mine', targetTileKey: 'oldWorld|prov1|0|0')],
+          'p1': [
+            WorkOrder(
+              unitId: 'u1',
+              target: 'build_mine',
+              targetTileKey: 'oldWorld|prov1|0|0',
+            ),
+          ],
         },
       );
       expect(a, b);
@@ -66,16 +108,53 @@ void main() {
     test('equality false when different', () {
       const a = Orders(
         moveOrdersByPlayerId: {
-          'p1': [MoveOrder(unitId: 'u1', destinationTileKey: 'oldWorld|prov1|0|0')],
+          'p1': [
+            MoveOrder(unitId: 'u1', destinationTileKey: 'oldWorld|prov1|0|0'),
+          ],
         },
       );
       const b = Orders(
         moveOrdersByPlayerId: {
-          'p2': [MoveOrder(unitId: 'u1', destinationTileKey: 'oldWorld|prov2|0|0')],
+          'p2': [
+            MoveOrder(unitId: 'u1', destinationTileKey: 'oldWorld|prov2|0|0'),
+          ],
         },
       );
       expect(a == b, false);
       expect(a == Object(), false);
+    });
+
+    test(
+      'fromJson throws for unprefixed army move destination province id',
+      () {
+        expect(
+          () => Orders.fromJson({
+            'armyMoveOrdersByPlayerId': {
+              'p1': [
+                {'armyId': 'a1', 'destinationProvinceId': 'p1'},
+              ],
+            },
+          }),
+          throwsA(isA<ArgumentError>()),
+        );
+      },
+    );
+
+    test('fromJson throws for unprefixed build-unit spawn province id', () {
+      expect(
+        () => Orders.fromJson({
+          'buildUnitOrdersByPlayerId': {
+            'p1': [
+              {
+                'unitType': 'Regiment',
+                'isMilitary': true,
+                'spawnProvinceId': 'p1',
+              },
+            ],
+          },
+        }),
+        throwsA(isA<ArgumentError>()),
+      );
     });
   });
 }

--- a/packages/colonizethis_models/test/player_test.dart
+++ b/packages/colonizethis_models/test/player_test.dart
@@ -39,17 +39,29 @@ void main() {
         id: 'p1',
         displayName: 'Spain',
         isHuman: true,
-        capitalProvinceId: 'p1',
+        capitalProvinceId: 'oldWorld|p1',
         capitalTile: cap,
         techUnlocked: {'road_construction': true},
       );
       final p2 = Player.fromJson(p.toJson());
-      expect(p2.capitalProvinceId, 'p1');
+      expect(p2.capitalProvinceId, 'oldWorld|p1');
       expect(p2.capitalTile?.regionId, 'oldWorld');
       expect(p2.capitalTile?.provinceId, 'p1');
       expect(p2.capitalTile?.x, 2);
       expect(p2.capitalTile?.y, 3);
       expect(p2.techUnlocked?['road_construction'], true);
+    });
+
+    test('fromJson throws for unprefixed capitalProvinceId', () {
+      expect(
+        () => Player.fromJson({
+          'id': 'p1',
+          'displayName': 'Spain',
+          'isHuman': true,
+          'capitalProvinceId': 'p1',
+        }),
+        throwsA(isA<ArgumentError>()),
+      );
     });
   });
 }

--- a/packages/colonizethis_models/test/province_test.dart
+++ b/packages/colonizethis_models/test/province_test.dart
@@ -4,27 +4,35 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 void main() {
   group('Province', () {
     test('toJson/fromJson round-trip with owner', () {
-      const p = Province(id: 'prov1', regionId: 'oldWorld', ownerId: 'p1');
+      const p = Province(
+        id: 'oldWorld|prov1',
+        regionId: 'oldWorld',
+        ownerId: 'p1',
+      );
       final json = p.toJson();
       final p2 = Province.fromJson(json);
-      expect(p2.id, 'prov1');
+      expect(p2.id, 'oldWorld|prov1');
       expect(p2.regionId, 'oldWorld');
       expect(p2.ownerId, 'p1');
     });
     test('toJson/fromJson round-trip without owner', () {
-      const p = Province(id: 'prov2', regionId: 'newWorld', ownerId: null);
+      const p = Province(
+        id: 'newWorld|prov2',
+        regionId: 'newWorld',
+        ownerId: null,
+      );
       final p2 = Province.fromJson(p.toJson());
       expect(p2.ownerId, null);
     });
     test('equality', () {
-      const a = Province(id: 'p1', regionId: 'oldWorld', ownerId: 'x');
-      const b = Province(id: 'p1', regionId: 'oldWorld', ownerId: 'x');
+      const a = Province(id: 'oldWorld|p1', regionId: 'oldWorld', ownerId: 'x');
+      const b = Province(id: 'oldWorld|p1', regionId: 'oldWorld', ownerId: 'x');
       expect(a, b);
       expect(a.hashCode, b.hashCode);
     });
     test('fortLevel and terrain round-trip', () {
       const p = Province(
-        id: 'p1',
+        id: 'oldWorld|p1',
         regionId: 'oldWorld',
         fortLevel: 2,
         terrain: 'forest',
@@ -35,17 +43,24 @@ void main() {
     });
     test('fortLevel defaults 0, terrain defaults plains', () {
       final p = Province.fromJson({
-        'id': 'p1',
+        'id': 'oldWorld|p1',
         'regionId': 'oldWorld',
       });
       expect(p.fortLevel, 0);
       expect(p.terrain, 'plains');
     });
     test('equality false when different', () {
-      const a = Province(id: 'p1', regionId: 'oldWorld', ownerId: 'x');
-      const b = Province(id: 'p2', regionId: 'oldWorld', ownerId: 'x');
+      const a = Province(id: 'oldWorld|p1', regionId: 'oldWorld', ownerId: 'x');
+      const b = Province(id: 'oldWorld|p2', regionId: 'oldWorld', ownerId: 'x');
       expect(a == b, false);
       expect(a == Object(), false);
+    });
+
+    test('fromJson throws for unprefixed province id', () {
+      expect(
+        () => Province.fromJson({'id': 'p1', 'regionId': 'oldWorld'}),
+        throwsA(isA<ArgumentError>()),
+      );
     });
   });
 }

--- a/packages/colonizethis_models/test/region_data_test.dart
+++ b/packages/colonizethis_models/test/region_data_test.dart
@@ -6,14 +6,14 @@ void main() {
     test('toJson/fromJson round-trip', () {
       final r = RegionData(
         provinces: const [
-          Province(id: 'p1', regionId: 'oldWorld', ownerId: null),
+          Province(id: 'oldWorld|p1', regionId: 'oldWorld', ownerId: null),
         ],
         units: [
           Unit(
             id: 'u1',
             type: 'infantry',
             ownerId: 'p1',
-            locationProvinceId: 'p1',
+            locationProvinceId: 'oldWorld|p1',
           ),
         ],
       );

--- a/packages/colonizethis_models/test/unit_test.dart
+++ b/packages/colonizethis_models/test/unit_test.dart
@@ -8,7 +8,7 @@ void main() {
         id: 'u1',
         type: 'infantry',
         ownerId: 'p1',
-        locationProvinceId: 'prov1',
+        locationProvinceId: 'oldWorld|prov1',
         status: UnitStatus.working,
         medals: 2,
         originTileKey: 'oldWorld|p1|0|0',
@@ -18,7 +18,7 @@ void main() {
       expect(u2.id, 'u1');
       expect(u2.type, 'infantry');
       expect(u2.ownerId, 'p1');
-      expect(u2.locationProvinceId, 'prov1');
+      expect(u2.locationProvinceId, 'oldWorld|prov1');
       expect(u2.status, UnitStatus.working);
       expect(u2.medals, 2);
       expect(u2.originTileKey, 'oldWorld|p1|0|0');
@@ -29,13 +29,13 @@ void main() {
         id: 'u1',
         type: 'inf',
         ownerId: 'p1',
-        locationProvinceId: 'prov1',
+        locationProvinceId: 'oldWorld|prov1',
       );
       final b = Unit(
         id: 'u1',
         type: 'inf',
         ownerId: 'p1',
-        locationProvinceId: 'prov1',
+        locationProvinceId: 'oldWorld|prov1',
       );
       expect(a, b);
       expect(a.hashCode, b.hashCode);
@@ -45,7 +45,7 @@ void main() {
         'id': 'u1',
         'type': 'infantry',
         'ownerId': 'p1',
-        'provinceId': 'prov1',
+        'provinceId': 'oldWorld|prov1',
       });
       expect(u.medals, 0);
     });
@@ -54,13 +54,13 @@ void main() {
         id: 'u1',
         type: 'inf',
         ownerId: 'p1',
-        locationProvinceId: 'prov1',
+        locationProvinceId: 'oldWorld|prov1',
       );
       final b = Unit(
         id: 'u2',
         type: 'inf',
         ownerId: 'p1',
-        locationProvinceId: 'prov1',
+        locationProvinceId: 'oldWorld|prov1',
       );
       expect(a == b, false);
       expect(a == Object(), false);
@@ -75,6 +75,18 @@ void main() {
       });
       expect(u.locationProvinceId, 'oldWorld|right');
       expect(u.toJson()['provinceId'], 'oldWorld|right');
+    });
+
+    test('fromJson throws for unprefixed provinceId', () {
+      expect(
+        () => Unit.fromJson({
+          'id': 'u1',
+          'type': 'infantry',
+          'ownerId': 'p1',
+          'provinceId': 'prov1',
+        }),
+        throwsA(isA<ArgumentError>()),
+      );
     });
   });
 }

--- a/packages/colonizethis_models/test/world_state_test.dart
+++ b/packages/colonizethis_models/test/world_state_test.dart
@@ -8,7 +8,11 @@ void main() {
         turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 3),
         oldWorld: const RegionData(
           provinces: [
-            Province(id: 'p1', regionId: 'oldWorld', ownerId: 'player1'),
+            Province(
+              id: 'oldWorld|p1',
+              regionId: 'oldWorld',
+              ownerId: 'player1',
+            ),
           ],
           units: [],
         ),
@@ -17,7 +21,7 @@ void main() {
       final state2 = WorldState.fromJson(state.toJson());
       expect(state2.turnState.turnNumber, 3);
       expect(state2.oldWorld.provinces.length, 1);
-      expect(state2.oldWorld.provinces.first.id, 'p1');
+      expect(state2.oldWorld.provinces.first.id, 'oldWorld|p1');
     });
     test('copyWith', () {
       final state = WorldState(
@@ -97,6 +101,25 @@ void main() {
       expect(state.tileKeysByRegionAndProvince[regionId]?[prefixedSeaId], [
         seaTile,
       ]);
+    });
+
+    test('fromJson rejects unprefixed province ids in region provinces', () {
+      final json = <String, dynamic>{
+        'turnState': const TurnState(
+          phase: TurnPhase.orders,
+          turnNumber: 1,
+        ).toJson(),
+        'oldWorld': const RegionData(
+          provinces: [Province(id: 'oldWorld|p1', regionId: 'oldWorld')],
+        ).toJson(),
+        'newWorld': const RegionData(
+          provinces: [Province(id: 'newWorld|n1', regionId: 'newWorld')],
+        ).toJson(),
+      };
+      (json['oldWorld'] as Map<String, dynamic>)['provinces'] = [
+        {'id': 'p1', 'regionId': 'oldWorld'},
+      ];
+      expect(() => WorldState.fromJson(json), throwsA(isA<ArgumentError>()));
     });
   });
 }

--- a/packages/colonizethis_save/test/game_save_adapter_test.dart
+++ b/packages/colonizethis_save/test/game_save_adapter_test.dart
@@ -30,7 +30,11 @@ void main() {
           turnState: const TurnState(phase: TurnPhase.endOfTurn, turnNumber: 5),
           oldWorld: const RegionData(
             provinces: [
-              Province(id: 'p1', regionId: 'oldWorld', ownerId: 'player1'),
+              Province(
+                id: 'oldWorld|p1',
+                regionId: 'oldWorld',
+                ownerId: 'player1',
+              ),
             ],
             units: [],
           ),
@@ -269,7 +273,7 @@ void main() {
           turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
           oldWorld: RegionData(
             provinces: [
-              Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
+              Province(id: 'oldWorld|p1', regionId: 'oldWorld', ownerId: 'pl1'),
             ],
           ),
           newWorld: const RegionData(),
@@ -281,10 +285,10 @@ void main() {
             id: 'pl1',
             displayName: 'Spain',
             isHuman: true,
-            capitalProvinceId: 'p1',
+            capitalProvinceId: 'oldWorld|p1',
             capitalTile: CapitalTile(
               regionId: 'oldWorld',
-              provinceId: 'p1',
+              provinceId: 'oldWorld|p1',
               x: 0,
               y: 0,
             ),
@@ -303,7 +307,7 @@ void main() {
         loaded.worldState.portsByProvinceSeaboard['p1|sea1'],
         'oldWorld|p1|0|0',
       );
-      expect(loaded.players.single.capitalProvinceId, 'p1');
+      expect(loaded.players.single.capitalProvinceId, 'oldWorld|p1');
       expect(loaded.players.single.capitalTile?.regionId, 'oldWorld');
       expect(loaded.players.single.capitalTile?.x, 0);
       expect(loaded.players.single.capitalTile?.y, 0);
@@ -334,7 +338,11 @@ void main() {
             turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
             oldWorld: RegionData(
               provinces: [
-                Province(id: 'p1', regionId: 'oldWorld', ownerId: 'pl1'),
+                Province(
+                  id: 'oldWorld|p1',
+                  regionId: 'oldWorld',
+                  ownerId: 'pl1',
+                ),
               ],
               units: [unit],
             ),
@@ -362,7 +370,7 @@ void main() {
           oldWorld: RegionData(
             provinces: [
               Province(
-                id: 'p1',
+                id: 'oldWorld|p1',
                 regionId: 'oldWorld',
                 ownerId: 'pl1',
                 fortLevel: 2,


### PR DESCRIPTION
## Summary
- enforce strict prefixed province-id validation for model deserialization in `Province`, `Unit`, `Player`, `MinorNation`, `Tribe`, `Army`, `ArmyMoveOrder`, and `BuildUnitOrder`
- update `SPEC/game/world-model-identity.md` to codify hard-fail load behavior for unprefixed province-referencing fields and add explicit AC coverage
- migrate model tests to canonical prefixed ids and add negative tests proving unprefixed payloads fail load

## Test plan
- [x] `dart test packages/colonizethis_models/test`
- [x] `dart test packages/colonizethis_logic/test/province_lookup_test.dart`
- [x] `dart test test/check_disallowed_ast_patterns_test.dart`

Refs #1965

Made with [Cursor](https://cursor.com)