### PR TITLE
docs: test/integration_test lint scope and CI semantics (Refs #2014)

### DIFF
--- a/.cursor/rules/colonizethis-testing.mdc
+++ b/.cursor/rules/colonizethis-testing.mdc
@@ -12,5 +12,6 @@ alwaysApply: false
 - **E2E / integration UI tests:** For `**/integration_test/**` and other UI-heavy e2e, follow `colonizethis-e2e-ui-stability.mdc` (deterministic finders, visibility before interaction, avoid layout-coupled `tapAt`/gestures unless unavoidable).
 - **Layers:** **Unit** — pure logic, models, services (no Flutter/Flame); mock deps. **Widget** — Flutter; `flutter_test`, `pumpWidget`; mock state/providers. **Game/component** — Flame in isolation (minimal `FlameGame` + component); test `onLoad`, `update`, removal.
 - **Layout:** `test/` mirrors `lib/`; **`*_test.dart`**; group by feature or class.
+- **Static analysis on tests:** `test/` and `integration_test/` are **in scope** for the same lint/analyze policy as `lib/` where tooling supports it (exclusions for generated/fixtures per **[SPEC/program/repo-lint.md](../../SPEC/program/repo-lint.md)** *Test and `integration_test/` static analysis scope*; `custom_lint` policy in **[SPEC/program/exception-enforcement.md](../../SPEC/program/exception-enforcement.md)**). Phasing and CI semantics: **Refs #2014**.
 - **Mocks:** mockito or mocktail; for Flame use minimal game or mock `Game`.
 - **Critical paths:** Combat, economy, save/load, **ruleset loading** — prioritize coverage here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,18 @@ If your GitHub role **cannot add labels**, state in the PR description that you 
 
 Repository-wide checks (beyond `dart analyze` / `custom_lint`) run through **`dart run tool/ct_repo_lint.dart`**, driven by **`tool/ct_repo_lint_manifest.yaml`**. When adding a new convention for CI, register a **stable `rule_id`** there and document it in **[SPEC/program/repo-lint.md](./SPEC/program/repo-lint.md)**—avoid new standalone `tool/check_*.dart` workflow steps without updating that manifest.
 
+### Tests and `integration_test/` in lint scope (phased)
+
+**Authoritative detail:** **[SPEC/program/repo-lint.md](./SPEC/program/repo-lint.md)** — section *Test and `integration_test/` static analysis scope* (GitHub #2014).
+
+Summary for contributors and CI authors:
+
+- **`test/`** and **`integration_test/`** are **targets for parity** with `lib/` for static gates where the tool applies; **generated, golden, and fixture trees** stay excluded per SPEC.
+- **Mergeable slices:** Work lands in **≤ 5** PRs; each must keep **`dev` required checks green**. Do not widen **fatal** test enforcement without **co-fixes** in the same PR or a **SPEC-documented** audit/baseline transition.
+- **`dart analyze` / `flutter analyze` (error-only CI steps):** Fail only on **analyzer errors**, not warnings, unless policy changes.
+- **`ct_repo_lint` and binary AST scripts:** **Pass/fail** on violations (not the same as “analyzer errors only”).
+- **Workflows:** Today **`.github/workflows/quality.yml`** runs `ct_repo_lint`, domain `custom_lint`, and (in **`app_tests_cache`**) `flutter analyze` under `app/` plus `check_long_string_switches`. When adding workspace-wide analyze steps, document **which job** runs them and use **`dart analyze`** vs **`flutter analyze`** per package type; update this file and SPEC in the same PR.
+
 ## macOS Flutter build troubleshooting: Swift priors ReadError
 
 If `flutter run -d macos` or `flutter build macos` intermittently fails while compiling CocoaPods plugins with output that includes:

--- a/SPEC/program/exception-enforcement.md
+++ b/SPEC/program/exception-enforcement.md
@@ -42,6 +42,10 @@ The repository enforces the same policy in two places (shared implementation in 
 1. **CI / CLI:** Quality runs `dart run tool/ct_repo_lint.dart` (rule `repo.custom_exceptions`; see [repo-lint.md](repo-lint.md)), which invokes `tool/check_custom_exceptions.dart`. Direct run: `dart run tool/check_custom_exceptions.dart` (also `melos run check_custom_exceptions`). File discovery uses `tool/ct_repo_lint_scan_contract.dart` (`collectRepoLintDomainDartFiles`), same as the disallowed-AST checker.
 2. **IDE / analyzer:** `custom_lint` with package `colonizethis_exception_lint`, wired in every workspace package that contains scoped runtime `lib/` code (see each package `pubspec.yaml` + `analysis_options.yaml`). Run locally per package via `dart run custom_lint`, or `bash tool/run_custom_lint_domain_exceptions.sh` for all wired packages. CI runs the same script after the root checker.
 
+### `test/` and `integration_test/` (GitHub #2014)
+
+**Target parity:** For every package wired by `tool/run_custom_lint_domain_exceptions.sh`, **`test/`** and **`integration_test/`** should reach the **same analyzer diagnostic bar as `lib/`** (zero `error`-severity issues from `custom_lint` / analyzer for those rules), with the same generated-file exclusions as runtime code. **Land enforcement in phased PRs** so `dev` stays green: fix violations before or with any CI tightening; see [repo-lint.md](repo-lint.md) section *Test and `integration_test/` static analysis scope* for mergeability and analyzer vs binary-tool semantics.
+
 The checker:
 
 1. Parses Dart files with analyzer.

--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -48,6 +48,48 @@ Each rule has a stable `rule_id` (prefix `repo.`). **Groups** (non-exhaustive): 
 - **Quality workflow:** One step runs `dart run tool/ct_repo_lint.dart` after OrderEngine codegen verification. Gates that are **not** bundled repo-lint rules stay separate (e.g. `tool/verify_order_engine_codegen.sh`, coverage thresholds, `custom_lint`, package tests).
 - **App UI string gate:** Rule `repo.app_hardcoded_ui_strings` runs only when `CT_REPO_LINT_INCLUDE_APP` is exactly `true` (workflow sets this from path filters when app/package paths changed).
 
+## Test and `integration_test/` static analysis scope (GitHub #2014)
+
+**Goal:** `test/` and `integration_test/` Dart are **first-class** for the same categories of static gates as `lib/` where the toolchain and rule design apply. **Generated code, goldens, fixtures, and similar trees stay excluded** (see [Shared exclusions](#shared-exclusions-testintegration_test-generation-and-fixtures)).
+
+**Phasing:** Land in **at most five mergeable slices** on `dev`. Each merged slice **must keep required CI green**. Do **not** widen **fatal** enforcement under `test/` / `integration_test/` (manifest rules, `ct_repo_lint_scan_contract` collectors, binary AST checkers) unless violations are **fixed in the same PR** **or** an intermediate slice uses a **SPEC-documented** non-fatal / audit / baseline mechanism for that transition (recorded in this doc or the rule’s SPEC with an issue link).
+
+### Failure semantics (do not conflate)
+
+| Mechanism | CI interpretation |
+|-----------|---------------------|
+| **`dart analyze` / `flutter analyze`** (**when CI uses error-only parsing**) | Fail the job only on **analyzer `error` severity** lines; **warnings and infos do not fail** the gate unless project policy explicitly changes. |
+| **`dart run tool/ct_repo_lint.dart`** and manifest-driven `runner` rules | **Binary pass/fail** per rule design (`exit` non-zero on violation); not governed by “analyzer errors only.” |
+| **`custom_lint` / `dart run custom_lint`** | Treat as **analyzer diagnostics** (same severity model as `dart analyze` for the plugin); CI should match the wired script’s contract (see [exception-enforcement.md](exception-enforcement.md)). |
+| **Standalone AST scripts** (e.g. `dart tool/check_long_string_switches.dart`) | **Binary** on their own thresholds unless a SPEC says otherwise. |
+
+### Shared exclusions (test/integration_test, generation, fixtures)
+
+Across tools that intentionally share skip logic, exclude at minimum:
+
+- Suffixes: `*.g.dart`, `*.freezed.dart`, `*.mocks.dart`, `*.gen.dart` (and any other generated suffixes called out per package).
+- Path fragments (fixture / golden trees): see `repoLintFixtureDirPathMarkers` in `tool/ct_repo_lint_scan_contract.dart` (`/test_data/`, `/fixtures/`, `/golden/`, etc.) wherever that helper applies.
+
+`tool/check_long_string_switches.dart` does **not** use `collectRepoLintDomainDartFiles`; it walks repo `.dart` files with its **own** exclusions (e.g. `.dart_tool`, `.pub-cache`, `build`, `*.g.dart`, and the tech embed path). Treat it as **already covering tests** unless SPEC is intentionally updated to narrow exclusions.
+
+### Scan contract vs lib-only checkers (today → target)
+
+**Domain lib collector** `collectRepoLintDomainDartFiles` in `tool/ct_repo_lint_scan_contract.dart` walks `lib/` under scan roots and **skips** paths matching `repoLintPathIsExcludedTestOrGeneratedDart` (`*/test/*`, `*_test.dart`, generated). Checkers that depend on it today include (non-exhaustive): `check_disallowed_ast_patterns`, `check_repeated_magic_numbers`, `check_custom_exceptions`, `check_function_size`, `check_part_unit_size`, `check_control_flow_nesting_depth`; `check_debug_console_logic_contract_boundary` delegates to the disallowed-AST checker.
+
+**Identifier-literal helpers** `repoLintIdentifierLiteralShouldSkipFile`, **canonical tile-key** `collectRepoLintCanonicalProvinceTileKeyDartFiles` / `repoLintCanonicalProvinceTileKeyShouldSkipFile`, **app UI** `repoLintAppLibHardcodedUiVisitorShouldSkip` in the same contract file apply additional lib- or app-centric filters. **Including `test/` / `integration_test/`** for a rule is **implementation work** in later slices: update helpers and **fix or baseline** violations so `dev` stays green.
+
+### CI workflow parity
+
+**Today:** `.github/workflows/quality.yml` is the **only** workflow (as of the #2014 documentation slice) that runs `ct_repo_lint`, domain `custom_lint`, and (in `app_tests_cache`) `flutter analyze` plus `check_long_string_switches`. Any **additional** workflow that runs the same class of checks **must** match the **scope and exclusions** documented here.
+
+**Analyzer matrix (future slice):** When workspace-wide `dart analyze` / `flutter analyze` is added, the implementing PR **must state which job** (`quality`, `app_tests_cache`, or a new job) hosts each step; use **`dart analyze`** for pure Dart packages and **`flutter analyze`** for Flutter packages; mirror any local gate scripts (e.g. `tool/run_quality_gate_tests.sh`) and **CONTRIBUTING.md**.
+
+### Acceptance criteria (#2014 documentation)
+
+- Given this section and CONTRIBUTING, when a maintainer widens a fatal repo rule to `test/`, then the change either **co-fixes violations** in the same PR or documents an allowed **audit/baseline** transition in SPEC with tracking reference.
+- Given `.github/workflows/quality.yml`, when a contributor adds a new job that runs `ct_repo_lint`, domain `custom_lint`, or package analyze steps, then that job follows the **failure semantics** table above and the **exclusion** rules in this section unless a narrower rule SPEC explicitly overrides.
+- Given `tool/check_long_string_switches.dart`, when triaging #2014, then implementers treat long-string switch coverage as **already including tests** unless a deliberate SPEC change narrows scope.
+
 ## PR incremental scans
 
 Rules marked `pr_incremental: true` in the manifest receive `--files <csv>` when `GITHUB_BASE_REF` is set and `git fetch` / `git diff origin/<base>...HEAD -- '*.dart'` succeeds and yields paths—matching the previous inline `quality.yml` behavior. Use `--force-full-scan` to disable incremental arguments locally or in scripts.


### PR DESCRIPTION
## Scope

**Slice 1 of 5** for GitHub #2014: SPEC and contributor/testing documentation only. No workflow, scan-contract, or analyzer behavior changes — keeps `dev` green.

## What changed

- **`SPEC/program/repo-lint.md`:** New section *Test and `integration_test/` static analysis scope* — phased mergeability (≤5 PRs), exclusions (generated/fixtures), **analyzer errors-only** vs **binary** `ct_repo_lint` / AST tools, `check_long_string_switches` already covering tests, scan-contract checker inventory, workflow parity (`quality.yml` only today), future analyzer job documentation requirement.
- **`CONTRIBUTING.md`:** Summary under repo lint with pointers to SPEC and current `quality.yml` / `app_tests_cache` jobs.
- **`SPEC/program/exception-enforcement.md`:** `custom_lint` target parity for `test/` and `integration_test/`, phased enforcement, link to repo-lint section.
- **`.cursor/rules/colonizethis-testing.mdc`:** Static analysis on tests in scope; Refs #2014.

## Deferred (follow-up PRs)

- `custom_lint` zero errors in all wired package test trees.
- Workspace `dart analyze` / `flutter analyze` matrix and `run_quality_gate_tests.sh` alignment.
- `ct_repo_lint` scan contract + manifest widening with co-fixes or baselines.
- AST checkers using `collectRepoLintDomainDartFiles` / related skips — include tests with aligned exclusions.
- Tooling tests for scan inclusion when implementation lands.

## Tests

Documentation-only; no code or workflow changes.

Refs #2014

Made with [Cursor](https://cursor.com)