### PR TITLE
ci: workspace analyzer + #2014 slices 2–3 (Refs #2014)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -256,6 +256,9 @@ jobs:
       - name: Resolve dependencies
         run: dart pub get
 
+      - name: Workspace analyzer gate (errors only; includes test/ and integration_test/)
+        run: dart run tool/run_workspace_analyze_errors_only.dart
+
       - name: Verify OrderEngine codegen (SPEC/program/order-engine.md)
         run: bash tool/verify_order_engine_codegen.sh
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,8 @@ If your GitHub role **cannot add labels**, state in the PR description that you 
 
 Repository-wide checks (beyond `dart analyze` / `custom_lint`) run through **`dart run tool/ct_repo_lint.dart`**, driven by **`tool/ct_repo_lint_manifest.yaml`**. When adding a new convention for CI, register a **stable `rule_id`** there and document it in **[SPEC/program/repo-lint.md](./SPEC/program/repo-lint.md)**—avoid new standalone `tool/check_*.dart` workflow steps without updating that manifest.
 
+**Workspace analyzer (GitHub #2014):** **`dart run tool/run_workspace_analyze_errors_only.dart`** (or **`melos run workspace_analyze_errors_only`**) analyzes every Pub workspace package with **`dart analyze`** or **`flutter analyze`**, failing only on **analyzer errors** (not warnings). CI runs this in the **Quality** workflow after `dart pub get`; **`tool/run_quality_gate_tests.sh`** runs the same command locally.
+
 ## macOS Flutter build troubleshooting: Swift priors ReadError
 
 If `flutter run -d macos` or `flutter build macos` intermittently fails while compiling CocoaPods plugins with output that includes:

--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -45,8 +45,9 @@ Each rule has a stable `rule_id` (prefix `repo.`). **Groups** (non-exhaustive): 
 
 ## CI contract
 
-- **Quality workflow:** One step runs `dart run tool/ct_repo_lint.dart` after OrderEngine codegen verification. Gates that are **not** bundled repo-lint rules stay separate (e.g. `tool/verify_order_engine_codegen.sh`, coverage thresholds, `custom_lint`, package tests).
+- **Quality workflow (order):** After root `dart pub get`, **`dart run tool/run_workspace_analyze_errors_only.dart`** runs **`dart analyze`** or **`flutter analyze`** for **every** `dart pub workspace list` member (including `test/` and `integration_test/`). The step **fails only on analyzer `error` diagnostics** (warnings and infos do not fail), matching `tool/run_quality_gate_tests.sh`. Entrypoint: `tool/run_workspace_analyze_errors_only.dart`; Melos: `melos run workspace_analyze_errors_only`. Then **`tool/verify_order_engine_codegen.sh`**, then **`dart run tool/ct_repo_lint.dart`**. Gates that are **not** bundled repo-lint rules stay separate (e.g. coverage thresholds, `custom_lint`, package tests).
 - **App UI string gate:** Rule `repo.app_hardcoded_ui_strings` runs only when `CT_REPO_LINT_INCLUDE_APP` is exactly `true` (workflow sets this from path filters when app/package paths changed).
+- **`app_tests_cache` job:** Still runs **`flutter analyze`** under `app/` only (errors-only grep) before packing the test cache; redundant with the app slice of the workspace gate but keeps an early signal for app-only paths.
 
 ## PR incremental scans
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,3 +87,6 @@ melos:
     ct_repo_lint:
       description: Unified manifest-driven repo convention checks. SPEC/program/repo-lint.md.
       run: dart run tool/ct_repo_lint.dart
+    workspace_analyze_errors_only:
+      description: Run dart/flutter analyze for every pub workspace member; fail on analyzer errors only (GitHub #2014).
+      run: dart run tool/run_workspace_analyze_errors_only.dart

--- a/test/run_workspace_analyze_errors_only_test.dart
+++ b/test/run_workspace_analyze_errors_only_test.dart
@@ -1,0 +1,68 @@
+import 'package:test/test.dart';
+
+import '../tool/run_workspace_analyze_errors_only.dart';
+
+void main() {
+  group('countAnalyzerErrorLines', () {
+    test('counts lines starting with optional whitespace then error', () {
+      const out = '''
+  error • Missing required parameter • lib/a.dart:1:1 • missing_required
+warning • Unused import • lib/b.dart:2:2 • unused_import
+  error • Undefined name • test/c_test.dart:3:3 • undefined_identifier
+''';
+      expect(countAnalyzerErrorLines(out), 2);
+    });
+
+    test('ignores info and warning', () {
+      const out = '''
+   info • Use const • lib/a.dart:1:1 • prefer_const
+warning • Dead code • lib/b.dart:2:2 • dead_code
+''';
+      expect(countAnalyzerErrorLines(out), 0);
+    });
+
+    test('does not count error substring inside path', () {
+      const out = r'''
+  info • See lib/error_handler.dart • lib/a.dart:1:1 • todo
+''';
+      expect(countAnalyzerErrorLines(out), 0);
+    });
+  });
+
+  group('packageDeclaresFlutterSdk', () {
+    test('true when dependencies.flutter.sdk is flutter', () {
+      expect(
+        packageDeclaresFlutterSdk('''
+name: x
+dependencies:
+  flutter:
+    sdk: flutter
+'''),
+        isTrue,
+      );
+    });
+
+    test('false for pure Dart package', () {
+      expect(
+        packageDeclaresFlutterSdk('''
+name: x
+dependencies:
+  yaml: any
+'''),
+        isFalse,
+      );
+    });
+
+    test('false when flutter is not sdk dependency', () {
+      expect(
+        packageDeclaresFlutterSdk('''
+name: x
+dependencies:
+  flutter:
+    path: ../flutter_stub
+'''),
+        isFalse,
+      );
+    });
+  });
+}

--- a/tool/run_custom_lint_domain_exceptions.sh
+++ b/tool/run_custom_lint_domain_exceptions.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Runs `dart run custom_lint` in every package wired for colonizethis_exception_lint.
+# Analyzer context includes lib/, test/, and integration_test/ the same as a normal
+# package analyze (GitHub #2014 slice: zero error-severity custom_lint issues).
 # SPEC/program/exception-enforcement.md
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/tool/run_quality_gate_tests.sh
+++ b/tool/run_quality_gate_tests.sh
@@ -30,19 +30,8 @@ for dir in packages/colonizethis_models packages/colonizethis_data packages/colo
 done
 
 echo ""
-echo "=== App localizations + analyze (before app tests; CI: app_tests_cache job) ==="
-if [ -d app ]; then
-  (cd app && flutter gen-l10n)
-  cd app
-  output=$(flutter analyze 2>&1 || true)
-  echo "$output"
-  error_count=$(echo "$output" | grep -c "^[[:space:]]*error" || true)
-  cd "$ROOT"
-  if [ "${error_count:-0}" -gt 0 ]; then
-    echo "Errors found: $error_count"
-    exit 1
-  fi
-fi
+echo "=== Workspace analyze (errors only; includes test/ + integration_test/; CI: quality job) ==="
+dart run tool/run_workspace_analyze_errors_only.dart
 
 echo ""
 echo "=== App hardcoded UI string gate (AST, app/lib/** -> l10n) ==="

--- a/tool/run_workspace_analyze_errors_only.dart
+++ b/tool/run_workspace_analyze_errors_only.dart
@@ -1,0 +1,131 @@
+// Workspace-wide `dart analyze` / `flutter analyze` with CI "errors only" semantics.
+// SPEC/program/repo-lint.md (GitHub #2014); mirrors `.github/workflows/quality.yml` grep gate.
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+/// Counts analyzer `error` diagnostics (not `warning` or `info`) for parity with:
+/// `grep -c '^[[:space:]]*error'` on `dart analyze` / `flutter analyze` output.
+int countAnalyzerErrorLines(String combinedOutput) {
+  var n = 0;
+  for (final line in const LineSplitter().convert(combinedOutput)) {
+    if (RegExp(r'^\s*error\s').hasMatch(line)) {
+      n++;
+    }
+  }
+  return n;
+}
+
+bool packageDeclaresFlutterSdk(String pubspecYaml) {
+  final root = loadYaml(pubspecYaml);
+  if (root is! YamlMap) {
+    return false;
+  }
+  final deps = root['dependencies'];
+  if (deps is! YamlMap) {
+    return false;
+  }
+  final flutter = deps['flutter'];
+  if (flutter is! YamlMap) {
+    return false;
+  }
+  return flutter['sdk'] == 'flutter';
+}
+
+Future<ProcessResult> _run(
+  String executable,
+  List<String> arguments, {
+  required String workingDirectory,
+  Map<String, String>? environment,
+}) {
+  return Process.run(
+    executable,
+    arguments,
+    workingDirectory: workingDirectory,
+    environment: environment,
+    stdoutEncoding: utf8,
+    stderrEncoding: utf8,
+    runInShell: false,
+  );
+}
+
+Future<int> main(List<String> args) async {
+  final repoRoot = Directory.current.path;
+  final rootGet = await _run('dart', ['pub', 'get'], workingDirectory: repoRoot);
+  if (rootGet.exitCode != 0) {
+    stderr.writeln('dart pub get at repo root failed (exit ${rootGet.exitCode}):');
+    stderr.writeln(rootGet.stderr);
+    stderr.writeln(rootGet.stdout);
+    return 1;
+  }
+
+  final ws = await _run('dart', ['pub', 'workspace', 'list', '--json'], workingDirectory: repoRoot);
+  if (ws.exitCode != 0) {
+    stderr.writeln(ws.stderr);
+    stderr.writeln(ws.stdout);
+    return 1;
+  }
+  final decoded = jsonDecode(ws.stdout as String) as Map<String, dynamic>;
+  final packages = (decoded['packages'] as List<dynamic>).cast<Map<String, dynamic>>();
+  packages.sort((a, b) => (a['path'] as String).compareTo(b['path'] as String));
+
+  var totalErrors = 0;
+  for (final entry in packages) {
+    final pkgPath = entry['path'] as String;
+    final name = entry['name'] as String;
+    final pubspecFile = File(p.join(pkgPath, 'pubspec.yaml'));
+    if (!pubspecFile.existsSync()) {
+      continue;
+    }
+    final pubspecText = pubspecFile.readAsStringSync();
+    final isFlutter = packageDeclaresFlutterSdk(pubspecText);
+
+    if (p.basename(pkgPath) == 'app') {
+      final gen = await _run('flutter', ['gen-l10n'], workingDirectory: pkgPath);
+      if (gen.exitCode != 0) {
+        stderr.writeln('flutter gen-l10n failed in app (exit ${gen.exitCode}):');
+        stderr.writeln(gen.stderr);
+        stderr.writeln(gen.stdout);
+        return 1;
+      }
+    }
+
+    if (isFlutter) {
+      final get = await _run('flutter', ['pub', 'get'], workingDirectory: pkgPath);
+      if (get.exitCode != 0) {
+        stderr.writeln('flutter pub get failed in $pkgPath (exit ${get.exitCode}):');
+        stderr.writeln(get.stderr);
+        stderr.writeln(get.stdout);
+        return 1;
+      }
+      final analyze = await _run('flutter', ['analyze'], workingDirectory: pkgPath);
+      final out = '${analyze.stdout}${analyze.stderr}';
+      stdout.writeln('--- flutter analyze: $name ($pkgPath) ---');
+      stdout.writeln(out.trimRight());
+      final errCount = countAnalyzerErrorLines(out);
+      if (errCount > 0) {
+        stderr.writeln('Errors in $name: $errCount');
+      }
+      totalErrors += errCount;
+    } else {
+      final analyze = await _run('dart', ['analyze'], workingDirectory: pkgPath);
+      final out = '${analyze.stdout}${analyze.stderr}';
+      stdout.writeln('--- dart analyze: $name ($pkgPath) ---');
+      stdout.writeln(out.trimRight());
+      final errCount = countAnalyzerErrorLines(out);
+      if (errCount > 0) {
+        stderr.writeln('Errors in $name: $errCount');
+      }
+      totalErrors += errCount;
+    }
+  }
+
+  if (totalErrors > 0) {
+    stderr.writeln('Workspace analyze failed: $totalErrors analyzer error(s) total.');
+    return 1;
+  }
+  stdout.writeln('Workspace analyze: no analyzer errors (warnings/infos do not fail).');
+  return 0;
+}


### PR DESCRIPTION
## Issue

Refs **#2014** — slices **2** (`custom_lint` parity on tests) and **3** (workspace `dart analyze` / `flutter analyze` CI + local gate).

## Slice 2 (`custom_lint`)

`bash tool/run_custom_lint_domain_exceptions.sh` already runs `dart run custom_lint` per wired package (full package context, including `test/` and `integration_test/` where present). On current `dev` that script reports **no issues**; this PR documents that in the shell header comment. No violation fixes were required.

## Slice 3 (analyzer CI)

- New **`tool/run_workspace_analyze_errors_only.dart`**: `dart pub get` at repo root, `dart pub workspace list --json`, per member `flutter pub get` + `flutter analyze` (when `dependencies.flutter.sdk: flutter`) or `dart analyze`; `flutter gen-l10n` in `app/` before app analyze; **fail only on lines matching analyzer `error`** (same semantics as the existing `grep` gate on `flutter analyze`).
- **`.github/workflows/quality.yml`**: step **Workspace analyzer gate** immediately after **Resolve dependencies** (before OrderEngine codegen).
- **`tool/run_quality_gate_tests.sh`**: replaces the previous app-only `flutter analyze` block with the same entrypoint.
- **`pubspec.yaml`**: Melos script `workspace_analyze_errors_only`.
- **`test/run_workspace_analyze_errors_only_test.dart`**: unit tests for error-line counting and Flutter pubspec detection.

## SPEC / docs

- `SPEC/program/repo-lint.md` — CI contract (order + `app_tests_cache` note).
- `CONTRIBUTING.md` — pointer to workspace analyzer + Melos.

## Validation

- **Not run locally** on this agent (memory-constrained host): full workspace `dart`/`flutter analyze` over all members is heavy. **Please rely on the Quality workflow** for the full gate; optional: `melos run workspace_analyze_errors_only` on a dev machine before merge.

Refs #2014

Made with [Cursor](https://cursor.com)