### PR TITLE
feat(naval): add Scope B Home Fleet selected-ship transfer

### DIFF
--- a/SPEC/program/naval-movement-resolution.md
+++ b/SPEC/program/naval-movement-resolution.md
@@ -74,6 +74,8 @@ For current product, trade/transport interception also uses hardcoded constants 
 
 A `join_home_fleet` order is valid only when the fleet is **in port at the player's capital province**. On apply: merge that fleet's ships into the home fleet and remove the sea-going fleet.
 
+This movement-order contract is distinct from the immediate UI fleet-management transfer flow in `SPEC/ui/naval-units-fleet-management.md` (selected-ship transfer into Home Fleet). Scope B transfer behavior does not broaden `join_home_fleet` order validation unless this section is explicitly revised.
+
 **Build Ship:**
 
 BuildUnitOrder for naval type; spawns in home fleet (in port at capital). Costs from colonizethis_data ship economy catalog.

--- a/SPEC/ui/naval-units-fleet-management.md
+++ b/SPEC/ui/naval-units-fleet-management.md
@@ -49,6 +49,20 @@ Players need to reorganize their fleets:
 | Home Fleet | **May** be selected and combined. When checked with other fleets, Home Fleet is **always** the merge target. |
 | Empty fleets | After combining, any non-Home fleet with no ships is removed. Home Fleet is **never** deleted when empty. |
 
+### Join Selected Ships To Home Fleet (Scope B extension)
+
+When Home Fleet is selected with exactly one non-home source fleet, combine opens a transfer dialog so the user can move a selected ship subset into Home Fleet instead of forcing an all-ships merge.
+
+- **Target:** Home Fleet is always the destination.
+- **Source:** Exactly one selected non-home fleet (same owner).
+- **Ship transfer semantics:** Player moves ship counts by type using `CtTransferList`; moved hulls preserve their instance ids and are appended to Home Fleet in source-fleet order.
+- **Source location rules (authoritative):**
+  - Source fleet is valid when it is **in port at the player's capital province**, or
+  - Source fleet is valid when it is **at sea in a sea zone adjacent to the player's capital province** under the same `MapTopology` adjacency rules used by naval transfer validation.
+- **Cross-region exclusion:** If no adjacency edge exists between source sea zone and the capital province in the current topology, transfer is not offered.
+- **Source cleanup:** If the transfer leaves source with zero ships, source fleet is removed; otherwise source remains with the unmoved ships.
+- **Home Fleet persistence:** Home Fleet always remains and stays at the capital port.
+
 ### Data changes
 
 ```dart
@@ -197,6 +211,14 @@ After any fleet operation (split or combine):
 - **Given** two fleets **at sea** in **different** sea zones, **when** both are checked, **then** **Combine** stays **disabled**.
 
 - **Given** one fleet **at sea** and one **in port**, **when** both are checked, **then** **Combine** stays **disabled** (mixed locality).
+
+- **Given** the Home Fleet and one source fleet in port at the player's capital are selected, **when** the user taps **Combine** and transfers only a subset of source ships, **then** only the selected ship instances move to Home Fleet, source fleet remains with the remainder, and Home Fleet remains at the capital port.
+
+- **Given** the Home Fleet and one source fleet at sea in a sea zone adjacent to the player's capital are selected, **when** the user confirms selected-ship transfer, **then** only the selected source ship instances move to Home Fleet and source fleet remains only if ships are left.
+
+- **Given** the Home Fleet and one source fleet are selected and every source ship is transferred, **when** the transfer is confirmed, **then** source fleet is removed and Home Fleet remains with increased ship count.
+
+- **Given** the Home Fleet and one source fleet at sea with no topology adjacency edge to the capital province are selected, **when** the user views combine availability, **then** Combine is disabled and no transfer dialog opens.
 
 ### Split
 

--- a/app/lib/core/services/app_event_handler_scope_session_subscriptions.dart
+++ b/app/lib/core/services/app_event_handler_scope_session_subscriptions.dart
@@ -55,6 +55,18 @@ extension _SessionCommands on _AppEventHandlerScopeState {
         );
         bus.emit(NavalFleetsUpdatedEvent(game: newGame));
       }),
+      bus.on<NavalTransferShipsRequestedEvent>().listen((e) {
+        final g = ref.read(currentGameProvider);
+        if (g == null) return;
+        final newGame = applyNavalTransferShipsBetweenFleets(
+          game: g,
+          humanPlayerId: e.humanPlayerId,
+          sourceFleetId: e.sourceFleetId,
+          targetFleetId: e.targetFleetId,
+          shipInstanceIdsToTransfer: e.shipInstanceIdsToTransfer,
+        );
+        bus.emit(NavalFleetsUpdatedEvent(game: newGame));
+      }),
       bus.on<NavalMoveFleetRequestedEvent>().listen((e) {
         final o = ref.read(currentOrdersProvider);
         ref

--- a/app/lib/features/game/widgets/fleet_expansion_tile.dart
+++ b/app/lib/features/game/widgets/fleet_expansion_tile.dart
@@ -1,0 +1,154 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:flutter/material.dart';
+
+import '../../../l10n/app_localizations.dart';
+import 'utils/naval_tree_builder.dart';
+import 'units/shared/units_entity_action_row.dart';
+
+class FleetExpansionTile extends StatelessWidget {
+  const FleetExpansionTile({
+    super.key,
+    required this.row,
+    required this.l10n,
+    this.onTap,
+    required this.isSelectedForCombine,
+    required this.onCombineSelectionToggle,
+    this.onSplitFleet,
+    this.onMoveFleet,
+    this.isSplitAllowed = false,
+  });
+
+  final FleetRow row;
+  final AppLocalizations l10n;
+  final VoidCallback? onTap;
+  final bool isSelectedForCombine;
+  final VoidCallback onCombineSelectionToggle;
+  final VoidCallback? onSplitFleet;
+  final VoidCallback? onMoveFleet;
+  final bool isSplitAllowed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 8),
+      child: ExpansionTile(
+        title: _buildTitle(context),
+        subtitle: _buildSubtitle(),
+        dense: true,
+        children: _buildChildren(),
+      ),
+    );
+  }
+
+  Widget _buildTitle(BuildContext context) {
+    return UnitsEntityActionRow(
+      details: _buildTitleDetails(),
+      actions: _buildTitleActions(),
+    );
+  }
+
+  Widget _buildTitleDetails() {
+    return Row(
+      children: [
+        Checkbox(
+          value: isSelectedForCombine,
+          onChanged: (_) => onCombineSelectionToggle(),
+          visualDensity: VisualDensity.compact,
+          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        ),
+        const SizedBox(width: 4),
+        Flexible(child: Text(row.label, overflow: TextOverflow.ellipsis)),
+        if (onTap != null) ...[
+          const SizedBox(width: 4),
+          IconButton(
+            tooltip: l10n.naval_units_locateFleet,
+            onPressed: onTap,
+            icon: const Icon(Icons.my_location),
+            iconSize: 18,
+            visualDensity: VisualDensity.compact,
+          ),
+        ],
+      ],
+    );
+  }
+
+  List<UnitsEntityAction> _buildTitleActions() {
+    final actions = <UnitsEntityAction>[];
+    if (onMoveFleet != null) {
+      actions.add(
+        UnitsEntityAction(
+          tooltip: l10n.common_move,
+          icon: Icons.route,
+          label: l10n.common_move,
+          onPressed: onMoveFleet,
+        ),
+      );
+    }
+    if (isSplitAllowed) {
+      actions.add(
+        UnitsEntityAction(
+          tooltip: l10n.common_split,
+          icon: Icons.call_split,
+          label: l10n.common_split,
+          onPressed: onSplitFleet,
+        ),
+      );
+    }
+    return actions;
+  }
+
+  Widget _buildSubtitle() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(row.locationLabel),
+        Text(l10n.naval_units_mission(row.missionLabel)),
+        if (row.draftNavalMoveLine != null) Text(row.draftNavalMoveLine!),
+      ],
+    );
+  }
+
+  List<Widget> _buildChildren() {
+    final children = <Widget>[
+      ..._buildShipCountTiles(),
+      ListTile(
+        title: Text(l10n.naval_units_strength(row.strength.toStringAsFixed(1))),
+        dense: true,
+      ),
+      ListTile(title: Text(l10n.naval_units_totalShips(row.totalShips))),
+      if (row.warshipCount > 0)
+        ListTile(title: Text(l10n.naval_units_warships(row.warshipCount))),
+      if (row.merchantCount > 0)
+        ListTile(title: Text(l10n.naval_units_merchants(row.merchantCount))),
+      ListTile(
+        title: Text(
+          row.isHomeFleet
+              ? l10n.naval_units_cargoCapacity(row.cargoCapacity)
+              : l10n.naval_units_cargoCapacityIfAssigned(row.cargoCapacity),
+        ),
+        dense: true,
+      ),
+    ];
+    return children;
+  }
+
+  List<Widget> _buildShipCountTiles() {
+    if (row.shipCountsByType.isEmpty) {
+      return [
+        ListTile(title: Text(l10n.naval_units_noShipsInFleet), dense: true),
+      ];
+    }
+    return [
+      for (final entry in row.shipCountsByType.entries)
+        ListTile(
+          title: Text(
+            l10n.naval_units_shipTypeCount(
+              shipTypeDisplayName(entry.key),
+              entry.value,
+            ),
+          ),
+          dense: true,
+        ),
+    ];
+  }
+}

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -7,16 +7,15 @@ import 'package:flutter/material.dart';
 
 import '../../../config/ct_e2e.dart';
 import '../../../config/ct_e2e_last_panel_snapshot.dart';
-import '../../../l10n/app_localizations.dart';
 import '../../../l10n/l10n.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
+import 'fleet_expansion_tile.dart';
 import 'utils/naval_tree_builder.dart';
 import 'move_fleet_dialog.dart';
 import 'split_fleet_dialog.dart';
 import 'transfer_to_home_fleet_dialog.dart';
 import 'units/shared/location_section_header.dart';
 import 'units/shared/region_section_header.dart';
-import 'units/shared/units_entity_action_row.dart';
 import 'units/shared/units_panel_region_label.dart';
 import 'units/shared/units_panel_shell.dart';
 
@@ -498,7 +497,7 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
         for (final group in tree) ...[
           RegionSectionHeader(label: unitsPanelRegionLabel(group.regionId)),
           if (group.homeFleet != null)
-            _FleetExpansionTile(
+            FleetExpansionTile(
               row: group.homeFleet!,
               l10n: l10n,
               onTap: group.homeFleet!.tileKey != null
@@ -524,7 +523,7 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
               regionLabel: unitsPanelRegionLabel(loc.regionId),
             ),
             for (final row in loc.fleets)
-              _FleetExpansionTile(
+              FleetExpansionTile(
                 row: row,
                 l10n: l10n,
                 onTap: row.tileKey != null
@@ -566,152 +565,5 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
       return KeyedSubtree(key: kCtE2ENavalPanelRootKey, child: panel);
     }
     return panel;
-  }
-}
-
-class _FleetExpansionTile extends StatelessWidget {
-  const _FleetExpansionTile({
-    required this.row,
-    required this.l10n,
-    this.onTap,
-    required this.isSelectedForCombine,
-    required this.onCombineSelectionToggle,
-    this.onSplitFleet,
-    this.onMoveFleet,
-    this.isSplitAllowed = false,
-  });
-
-  final FleetRow row;
-  final AppLocalizations l10n;
-  final VoidCallback? onTap;
-  final bool isSelectedForCombine;
-  final VoidCallback onCombineSelectionToggle;
-  final VoidCallback? onSplitFleet;
-  final VoidCallback? onMoveFleet;
-  final bool isSplitAllowed;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 8),
-      child: ExpansionTile(
-        title: _buildTitle(context),
-        subtitle: _buildSubtitle(),
-        dense: true,
-        children: _buildChildren(),
-      ),
-    );
-  }
-
-  Widget _buildTitle(BuildContext context) {
-    return UnitsEntityActionRow(
-      details: _buildTitleDetails(),
-      actions: _buildTitleActions(),
-    );
-  }
-
-  Widget _buildTitleDetails() {
-    return Row(
-      children: [
-        Checkbox(
-          value: isSelectedForCombine,
-          onChanged: (_) => onCombineSelectionToggle(),
-          visualDensity: VisualDensity.compact,
-          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-        ),
-        const SizedBox(width: 4),
-        Flexible(child: Text(row.label, overflow: TextOverflow.ellipsis)),
-        if (onTap != null) ...[
-          const SizedBox(width: 4),
-          IconButton(
-            tooltip: l10n.naval_units_locateFleet,
-            onPressed: onTap,
-            icon: const Icon(Icons.my_location),
-            iconSize: 18,
-            visualDensity: VisualDensity.compact,
-          ),
-        ],
-      ],
-    );
-  }
-
-  List<UnitsEntityAction> _buildTitleActions() {
-    final actions = <UnitsEntityAction>[];
-    if (onMoveFleet != null) {
-      actions.add(
-        UnitsEntityAction(
-          tooltip: l10n.common_move,
-          icon: Icons.route,
-          label: l10n.common_move,
-          onPressed: onMoveFleet,
-        ),
-      );
-    }
-    if (isSplitAllowed) {
-      actions.add(
-        UnitsEntityAction(
-          tooltip: l10n.common_split,
-          icon: Icons.call_split,
-          label: l10n.common_split,
-          onPressed: onSplitFleet,
-        ),
-      );
-    }
-    return actions;
-  }
-
-  Widget _buildSubtitle() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(row.locationLabel),
-        Text(l10n.naval_units_mission(row.missionLabel)),
-        if (row.draftNavalMoveLine != null) Text(row.draftNavalMoveLine!),
-      ],
-    );
-  }
-
-  List<Widget> _buildChildren() {
-    final children = <Widget>[
-      ..._buildShipCountTiles(),
-      ListTile(
-        title: Text(l10n.naval_units_strength(row.strength.toStringAsFixed(1))),
-        dense: true,
-      ),
-      ListTile(title: Text(l10n.naval_units_totalShips(row.totalShips))),
-      if (row.warshipCount > 0)
-        ListTile(title: Text(l10n.naval_units_warships(row.warshipCount))),
-      if (row.merchantCount > 0)
-        ListTile(title: Text(l10n.naval_units_merchants(row.merchantCount))),
-      ListTile(
-        title: Text(
-          row.isHomeFleet
-              ? l10n.naval_units_cargoCapacity(row.cargoCapacity)
-              : l10n.naval_units_cargoCapacityIfAssigned(row.cargoCapacity),
-        ),
-        dense: true,
-      ),
-    ];
-    return children;
-  }
-
-  List<Widget> _buildShipCountTiles() {
-    if (row.shipCountsByType.isEmpty) {
-      return [
-        ListTile(title: Text(l10n.naval_units_noShipsInFleet), dense: true),
-      ];
-    }
-    return [
-      for (final entry in row.shipCountsByType.entries)
-        ListTile(
-          title: Text(
-            l10n.naval_units_shipTypeCount(
-              shipTypeDisplayName(entry.key),
-              entry.value,
-            ),
-          ),
-          dense: true,
-        ),
-    ];
   }
 }

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -13,6 +13,7 @@ import '../../../widgets/ct_nine_patch_button.dart';
 import 'utils/naval_tree_builder.dart';
 import 'move_fleet_dialog.dart';
 import 'split_fleet_dialog.dart';
+import 'transfer_to_home_fleet_dialog.dart';
 import 'units/shared/location_section_header.dart';
 import 'units/shared/region_section_header.dart';
 import 'units/shared/units_entity_action_row.dart';
@@ -77,6 +78,10 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
     };
     final activeIds = _selectedFleetIds.where(rowsById.containsKey).toList();
     if (activeIds.length < 2) return false;
+    final homeTransferRows = _homeTransferRows(flat, activeIds.toSet());
+    if (homeTransferRows != null) {
+      return _isEligibleHomeTransferSource(homeTransferRows.source);
+    }
     String? locationKey;
     for (final id in activeIds) {
       final row = rowsById[id]!;
@@ -162,6 +167,15 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
     if (!_canCombineSelection(flat)) return;
 
     final selected = Set<String>.from(_selectedFleetIds);
+    final homeTransferRows = _homeTransferRows(flat, selected);
+    if (homeTransferRows != null &&
+        _isEligibleHomeTransferSource(homeTransferRows.source)) {
+      _openTransferToHomeDialog(
+        homeRow: homeTransferRows.home,
+        sourceRow: homeTransferRows.source,
+      );
+      return;
+    }
     final targetId = _combineTargetFleetId(flat, selected);
 
     FleetRow? targetRow;
@@ -209,6 +223,115 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
 
     setState(_selectedFleetIds.clear);
     widget.bus.emit(NavalFleetsUpdatedEvent(game: newGame));
+  }
+
+  ({FleetRow home, FleetRow source})? _homeTransferRows(
+    List<FleetRow> flat,
+    Set<String> selectedIds,
+  ) {
+    if (selectedIds.length != 2) return null;
+    FleetRow? home;
+    FleetRow? source;
+    for (final row in flat) {
+      final id = _selectionFleetId(row);
+      if (!selectedIds.contains(id)) continue;
+      if (row.isHomeFleet) {
+        home = row;
+      } else {
+        source = row;
+      }
+    }
+    if (home == null || source == null) return null;
+    return (home: home, source: source);
+  }
+
+  String? _humanCapitalProvinceId() {
+    for (final p in widget.game.players) {
+      if (p.id == widget.humanPlayerId) return p.capitalProvinceId;
+    }
+    return null;
+  }
+
+  bool _provinceMatchesCapital(String provinceId, String capitalProvinceId) {
+    if (provinceId == capitalProvinceId) return true;
+    final capRegionId = ProvinceId.regionIdFrom(capitalProvinceId);
+    final capLocalId = ProvinceId.localIdFrom(capitalProvinceId);
+    return provinceId == capLocalId || provinceId == '$capRegionId|$capLocalId';
+  }
+
+  bool _seaZoneAdjacentToCapital({
+    required String sourceSeaZoneId,
+    required String sourceRegionId,
+    required String capitalProvinceId,
+  }) {
+    final capRegionId = ProvinceId.regionIdFrom(capitalProvinceId);
+    final capLocalId = ProvinceId.localIdFrom(capitalProvinceId);
+    final sourceSeaLocal = sourceSeaZoneId.contains('|')
+        ? sourceSeaZoneId.split('|').last
+        : sourceSeaZoneId;
+    final sourceSeaPrefixed = sourceSeaZoneId.contains('|')
+        ? sourceSeaZoneId
+        : '$sourceRegionId|$sourceSeaZoneId';
+    final sourceSeaCandidates = <String>{
+      sourceSeaZoneId,
+      sourceSeaLocal,
+      sourceSeaPrefixed,
+    };
+    final capitalCandidates = <String>{
+      capitalProvinceId,
+      capLocalId,
+      '$capRegionId|$capLocalId',
+    };
+    for (final edge in widget.topology.edges) {
+      final a = edge.id1;
+      final b = edge.id2;
+      final aIsSea = sourceSeaCandidates.contains(a);
+      final bIsSea = sourceSeaCandidates.contains(b);
+      final aIsCap = capitalCandidates.contains(a);
+      final bIsCap = capitalCandidates.contains(b);
+      if ((aIsSea && bIsCap) || (bIsSea && aIsCap)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool _isEligibleHomeTransferSource(FleetRow sourceRow) {
+    final sourceFleet = _fleetForRow(sourceRow);
+    final capitalProvinceId = _humanCapitalProvinceId();
+    if (sourceFleet == null || capitalProvinceId == null) return false;
+    if (sourceFleet.ownerId != widget.humanPlayerId) return false;
+    if (!sourceFleet.isAtSea) {
+      final inPortId = sourceFleet.inPortAtProvinceId;
+      if (inPortId == null) return false;
+      return _provinceMatchesCapital(inPortId, capitalProvinceId);
+    }
+    final seaZoneId = sourceFleet.seaZoneId;
+    if (seaZoneId == null || seaZoneId.isEmpty) return false;
+    return _seaZoneAdjacentToCapital(
+      sourceSeaZoneId: seaZoneId,
+      sourceRegionId: sourceFleet.regionId,
+      capitalProvinceId: capitalProvinceId,
+    );
+  }
+
+  void _openTransferToHomeDialog({
+    required FleetRow homeRow,
+    required FleetRow sourceRow,
+  }) {
+    final homeFleet = _fleetForRow(homeRow);
+    final sourceFleet = _fleetForRow(sourceRow);
+    if (homeFleet == null || sourceFleet == null) return;
+    showDialog<void>(
+      context: context,
+      builder: (_) => TransferToHomeFleetDialog(
+        sourceFleet: sourceFleet,
+        homeFleet: homeFleet,
+        game: widget.game,
+        humanPlayerId: widget.humanPlayerId,
+        bus: widget.bus,
+      ),
+    );
   }
 
   @override
@@ -574,7 +697,9 @@ class _FleetExpansionTile extends StatelessWidget {
 
   List<Widget> _buildShipCountTiles() {
     if (row.shipCountsByType.isEmpty) {
-      return [ListTile(title: Text(l10n.naval_units_noShipsInFleet), dense: true)];
+      return [
+        ListTile(title: Text(l10n.naval_units_noShipsInFleet), dense: true),
+      ];
     }
     return [
       for (final entry in row.shipCountsByType.entries)

--- a/app/lib/features/game/widgets/transfer_to_home_fleet_dialog.dart
+++ b/app/lib/features/game/widgets/transfer_to_home_fleet_dialog.dart
@@ -1,0 +1,145 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter/material.dart';
+
+import '../../../l10n/l10n.dart';
+import '../../../widgets/ct_dialog_shell.dart';
+import '../../../widgets/ct_transfer_list.dart';
+import '../utils/region_labels.dart';
+import '../utils/sea_zone_name_resolver.dart';
+
+class TransferToHomeFleetDialog extends StatelessWidget {
+  const TransferToHomeFleetDialog({
+    super.key,
+    required this.sourceFleet,
+    required this.homeFleet,
+    required this.game,
+    required this.humanPlayerId,
+    required this.bus,
+  });
+
+  final Fleet sourceFleet;
+  final Fleet homeFleet;
+  final Game game;
+  final String humanPlayerId;
+  final AppEventBus bus;
+
+  Map<String, int> _countsForFleet(Fleet fleet) {
+    final counts = <String, int>{};
+    for (final typeId in fleet.shipTypeIds) {
+      counts[typeId] = (counts[typeId] ?? 0) + 1;
+    }
+    return counts;
+  }
+
+  String _fleetLocationLabel(Fleet fleet) {
+    if (fleet.isAtSea) {
+      final seaZoneId = fleet.seaZoneId ?? '';
+      final zoneName = seaZoneDisplayName(
+        game: game,
+        regionId: fleet.regionId,
+        seaZoneId: seaZoneId,
+      );
+      return '$zoneName - ${regionDisplayLabel(fleet.regionId)}';
+    }
+    final inPortId = fleet.inPortAtProvinceId;
+    if (inPortId == null) {
+      return regionDisplayLabel(fleet.regionId);
+    }
+    Province? province;
+    for (final p in game.worldState.oldWorld.provinces) {
+      if (p.id == inPortId || '${p.regionId}|${p.id}' == inPortId) {
+        province = p;
+        break;
+      }
+    }
+    if (province == null) {
+      for (final p in game.worldState.newWorld.provinces) {
+        if (p.id == inPortId || '${p.regionId}|${p.id}' == inPortId) {
+          province = p;
+          break;
+        }
+      }
+    }
+    final provinceLabel = province?.displayName ?? inPortId;
+    return '$provinceLabel - ${regionDisplayLabel(fleet.regionId)}';
+  }
+
+  void _handleConfirm(Map<String, int> sourceRemaining, BuildContext context) {
+    final sourceInitial = _countsForFleet(sourceFleet);
+    final movedByType = <String, int>{};
+    for (final entry in sourceInitial.entries) {
+      final remaining = sourceRemaining[entry.key] ?? 0;
+      final moved = entry.value - remaining;
+      if (moved > 0) {
+        movedByType[entry.key] = moved;
+      }
+    }
+    final movedShips = shipInstancesForTransferCounts(
+      sourceFleet.ships,
+      movedByType,
+    );
+    if (movedShips.isEmpty) {
+      return;
+    }
+    bus.emit(
+      NavalTransferShipsRequestedEvent(
+        humanPlayerId: humanPlayerId,
+        sourceFleetId: sourceFleet.id,
+        targetFleetId: homeFleet.id,
+        shipInstanceIdsToTransfer: movedShips.map((s) => s.id).toList(),
+      ),
+    );
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = appL10n(context);
+    final sourceInitialCounts = _countsForFleet(sourceFleet);
+    final homeInitialCounts = _countsForFleet(homeFleet);
+    return CtDialogShell(
+      maxWidth: 560,
+      maxHeight: 520,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              l10n.naval_transferToHome_dialogTitle,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 16),
+            CtTransferList(
+              listHeight: 240,
+              itemLabelBuilder: shipTypeDisplayName,
+              leftTitle: l10n.naval_transferToHome_sourceTitle(sourceFleet.id),
+              rightTitle: l10n.naval_homeFleetLabel,
+              leftSubtitle: _fleetLocationLabel(sourceFleet),
+              rightSubtitle: _fleetLocationLabel(homeFleet),
+              initialLeftCounts: sourceInitialCounts,
+              initialRightCounts: homeInitialCounts,
+              leftEmptyLabel: l10n.splitFleet_noShips,
+              rightEmptyLabel: l10n.splitFleet_noShips,
+              confirmLabel: l10n.naval_transferToHome_confirm,
+              totalLabelBuilder: (total) => l10n.splitFleet_totalShips(total),
+              canConfirm: (left, right) {
+                for (final entry in sourceInitialCounts.entries) {
+                  final remaining = left[entry.key] ?? 0;
+                  if (remaining < entry.value) {
+                    return true;
+                  }
+                }
+                return false;
+              },
+              onCancel: () => Navigator.of(context).pop(),
+              onConfirm: (left, right) => _handleConfirm(left, context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -2324,6 +2324,23 @@
       }
     }
   },
+  "naval_transferToHome_dialogTitle": "Transfer Ships to Home Fleet",
+  "@naval_transferToHome_dialogTitle": {
+    "description": "Title for selected-ship transfer into Home Fleet dialog."
+  },
+  "naval_transferToHome_sourceTitle": "Fleet {id}",
+  "@naval_transferToHome_sourceTitle": {
+    "description": "Source fleet title in transfer-to-home dialog.",
+    "placeholders": {
+      "id": {
+        "type": "String"
+      }
+    }
+  },
+  "naval_transferToHome_confirm": "Confirm Transfer",
+  "@naval_transferToHome_confirm": {
+    "description": "Confirm button label for transfer-to-home dialog."
+  },
   "diplomacy_section_greatPowers": "Great Powers",
   "@diplomacy_section_greatPowers": {
     "description": "Diplomacy list section heading."

--- a/app/test/naval_units_panel_test.dart
+++ b/app/test/naval_units_panel_test.dart
@@ -7,7 +7,10 @@ import 'dart:ui' as ui;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart'
-    show applyNavalSplitFleet, homeFleetIdFor;
+    show
+        applyNavalSplitFleet,
+        applyNavalTransferShipsBetweenFleets,
+        homeFleetIdFor;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flame/flame.dart';
@@ -35,6 +38,24 @@ StreamSubscription<NavalSplitFleetRequestedEvent> wireNavalSplitForWidgetTest({
       humanPlayerId: e.humanPlayerId,
       originalFleetId: e.originalFleetId,
       shipInstanceIdsToNewFleet: e.shipInstanceIdsToNewFleet,
+    );
+    bus.emit(NavalFleetsUpdatedEvent(game: next));
+  });
+}
+
+/// Mirrors shell handling of [NavalTransferShipsRequestedEvent] for widget tests.
+StreamSubscription<NavalTransferShipsRequestedEvent>
+wireNavalTransferForWidgetTest({
+  required AppEventBus bus,
+  required Game Function() gameSnapshot,
+}) {
+  return bus.on<NavalTransferShipsRequestedEvent>().listen((e) {
+    final next = applyNavalTransferShipsBetweenFleets(
+      game: gameSnapshot(),
+      humanPlayerId: e.humanPlayerId,
+      sourceFleetId: e.sourceFleetId,
+      targetFleetId: e.targetFleetId,
+      shipInstanceIdsToTransfer: e.shipInstanceIdsToTransfer,
     );
     bus.emit(NavalFleetsUpdatedEvent(game: next));
   });
@@ -1444,7 +1465,12 @@ void main() {
         final sub = bus.on<NavalFleetsUpdatedEvent>().listen((e) {
           updated = e;
         });
+        final subTransfer = wireNavalTransferForWidgetTest(
+          bus: bus,
+          gameSnapshot: () => homeCombineGame,
+        );
         addTearDown(sub.cancel);
+        addTearDown(subTransfer.cancel);
 
         await tester.pumpWidget(
           buildPanel(game: homeCombineGame, humanPlayerId: humanId, bus: bus),
@@ -1469,6 +1495,24 @@ void main() {
         await tester.pumpAndSettle();
 
         await tester.tap(find.widgetWithText(CtNinePatchButton, 'Combine'));
+        await tester.pumpAndSettle();
+        expect(find.text('Transfer Ships to Home Fleet'), findsOneWidget);
+        await tester.tap(find.byKey(CtTransferListKeys.leftMoveAll('fluyte')));
+        await tester.pumpAndSettle();
+        final confirmTransfer = find.widgetWithText(
+          CtNinePatchButton,
+          'Confirm Transfer',
+        );
+        expect(confirmTransfer, findsOneWidget);
+        expect(
+          tester.widget<CtNinePatchButton>(confirmTransfer).enabled,
+          isTrue,
+        );
+        final confirmTransferButton = tester.widget<CtNinePatchButton>(
+          confirmTransfer,
+        );
+        expect(confirmTransferButton.onPressed, isNotNull);
+        confirmTransferButton.onPressed!.call();
         await tester.pumpAndSettle();
 
         expect(updated, isNotNull);
@@ -1792,6 +1836,358 @@ void main() {
         await tester.pumpAndSettle();
         await tester.tap(
           find.descendant(of: portFinder, matching: find.byType(Checkbox)),
+        );
+        await tester.pumpAndSettle();
+
+        final combineBtn = tester.widget<CtNinePatchButton>(
+          find.widgetWithText(CtNinePatchButton, 'Combine'),
+        );
+        expect(combineBtn.enabled, isFalse);
+      },
+    );
+
+    testWidgets(
+      'AC: Home Fleet and adjacent sea source enable selected-ship transfer',
+      (WidgetTester tester) async {
+        const humanId = 'gp_home_adjacent';
+        const capProvince = 'oldWorld|cap1';
+        final homeId = homeFleetIdFor(humanId);
+
+        final gameAdj = Game(
+          id: 'g_home_adjacent_transfer',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(
+                  id: 'cap1',
+                  regionId: 'oldWorld',
+                  ownerId: humanId,
+                  displayName: 'Capital',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: homeId,
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                inPortAtProvinceId: capProvince,
+                ships: const [ShipInstance(id: 'home_1', typeId: 'carrack')],
+              ),
+              Fleet(
+                id: 'sea_source',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                seaZoneId: 'zone_alpha',
+                ships: const [
+                  ShipInstance(id: 'src_1', typeId: 'fluyte'),
+                  ShipInstance(id: 'src_2', typeId: 'carrack'),
+                ],
+              ),
+            ],
+          ),
+          players: const [
+            Player(
+              id: humanId,
+              displayName: 'Home adjacent tester',
+              isHuman: true,
+              capitalProvinceId: capProvince,
+              capitalTile: CapitalTile(
+                regionId: 'oldWorld',
+                provinceId: capProvince,
+                x: 0,
+                y: 0,
+              ),
+            ),
+          ],
+        );
+        const topology = MapTopology(
+          nodes: [
+            TopologyNode(
+              id: 'oldWorld|cap1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'zone_alpha',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+          ],
+          edges: [TopologyEdge(id1: 'oldWorld|cap1', id2: 'zone_alpha')],
+        );
+
+        await tester.pumpWidget(
+          buildPanel(game: gameAdj, humanPlayerId: humanId, topology: topology),
+        );
+        await tester.pumpAndSettle();
+
+        final homeFinder = find.widgetWithText(ExpansionTile, 'Home Fleet');
+        final sourceFinder = find.widgetWithText(
+          ExpansionTile,
+          'Fleet sea_source',
+        );
+        expect(homeFinder, findsOneWidget);
+        expect(sourceFinder, findsOneWidget);
+
+        await tester.tap(
+          find.descendant(of: homeFinder, matching: find.byType(Checkbox)),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.descendant(of: sourceFinder, matching: find.byType(Checkbox)),
+        );
+        await tester.pumpAndSettle();
+
+        final combineBtn = tester.widget<CtNinePatchButton>(
+          find.widgetWithText(CtNinePatchButton, 'Combine'),
+        );
+        expect(combineBtn.enabled, isTrue);
+
+        await tester.tap(find.widgetWithText(CtNinePatchButton, 'Combine'));
+        await tester.pumpAndSettle();
+        expect(find.text('Transfer Ships to Home Fleet'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'AC: Home Fleet transfer moves selected ships and keeps source when ships remain',
+      (WidgetTester tester) async {
+        const humanId = 'gp_home_transfer_apply';
+        const capProvince = 'oldWorld|cap1';
+        final homeId = homeFleetIdFor(humanId);
+
+        var gameState = Game(
+          id: 'g_home_transfer_apply',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(
+                  id: 'cap1',
+                  regionId: 'oldWorld',
+                  ownerId: humanId,
+                  displayName: 'Capital',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: homeId,
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                inPortAtProvinceId: capProvince,
+                ships: const [ShipInstance(id: 'home_1', typeId: 'carrack')],
+              ),
+              Fleet(
+                id: 'sea_source',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                seaZoneId: 'zone_alpha',
+                ships: const [
+                  ShipInstance(id: 'src_1', typeId: 'fluyte'),
+                  ShipInstance(id: 'src_2', typeId: 'carrack'),
+                ],
+              ),
+            ],
+          ),
+          players: const [
+            Player(
+              id: humanId,
+              displayName: 'Home transfer tester',
+              isHuman: true,
+              capitalProvinceId: capProvince,
+              capitalTile: CapitalTile(
+                regionId: 'oldWorld',
+                provinceId: capProvince,
+                x: 0,
+                y: 0,
+              ),
+            ),
+          ],
+        );
+        const topology = MapTopology(
+          nodes: [
+            TopologyNode(
+              id: 'oldWorld|cap1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'zone_alpha',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+          ],
+          edges: [TopologyEdge(id1: 'oldWorld|cap1', id2: 'zone_alpha')],
+        );
+        final bus = AppEventBus.create();
+        final subTransfer = wireNavalTransferForWidgetTest(
+          bus: bus,
+          gameSnapshot: () => gameState,
+        );
+        final subUpdated = bus.on<NavalFleetsUpdatedEvent>().listen((e) {
+          gameState = e.game;
+        });
+        addTearDown(subTransfer.cancel);
+        addTearDown(subUpdated.cancel);
+
+        await tester.pumpWidget(
+          buildPanel(
+            game: gameState,
+            humanPlayerId: humanId,
+            topology: topology,
+            bus: bus,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final homeFinder = find.widgetWithText(ExpansionTile, 'Home Fleet');
+        final sourceFinder = find.widgetWithText(
+          ExpansionTile,
+          'Fleet sea_source',
+        );
+        await tester.tap(
+          find.descendant(of: homeFinder, matching: find.byType(Checkbox)),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.descendant(of: sourceFinder, matching: find.byType(Checkbox)),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(find.widgetWithText(CtNinePatchButton, 'Combine'));
+        await tester.pumpAndSettle();
+
+        final moveOneFluyte = find.byKey(
+          CtTransferListKeys.leftMoveOne('fluyte'),
+        );
+        expect(moveOneFluyte, findsOneWidget);
+        await tester.tap(moveOneFluyte);
+        await tester.pumpAndSettle();
+
+        final confirmTransfer = find.widgetWithText(
+          CtNinePatchButton,
+          'Confirm Transfer',
+        );
+        expect(confirmTransfer, findsOneWidget);
+        expect(
+          tester.widget<CtNinePatchButton>(confirmTransfer).enabled,
+          isTrue,
+        );
+        final confirmTransferButton = tester.widget<CtNinePatchButton>(
+          confirmTransfer,
+        );
+        expect(confirmTransferButton.onPressed, isNotNull);
+        confirmTransferButton.onPressed!.call();
+        await tester.pumpAndSettle();
+
+        final homeFleet = gameState.worldState.fleets.firstWhere(
+          (f) => f.id == homeId,
+        );
+        final sourceFleet = gameState.worldState.fleets.firstWhere(
+          (f) => f.id == 'sea_source',
+        );
+        final homeShipIds = homeFleet.ships.map((s) => s.id).toSet();
+        final sourceShipIds = sourceFleet.ships.map((s) => s.id).toSet();
+        expect(homeShipIds.contains('src_1'), isTrue);
+        expect(sourceShipIds.contains('src_1'), isFalse);
+        expect(sourceShipIds.contains('src_2'), isTrue);
+      },
+    );
+
+    testWidgets(
+      'AC: Home Fleet and non-adjacent sea source keep Combine disabled',
+      (WidgetTester tester) async {
+        const humanId = 'gp_home_non_adjacent';
+        const capProvince = 'oldWorld|cap1';
+        final homeId = homeFleetIdFor(humanId);
+
+        final gameNonAdjacent = Game(
+          id: 'g_home_non_adjacent_transfer',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(
+                  id: 'cap1',
+                  regionId: 'oldWorld',
+                  ownerId: humanId,
+                  displayName: 'Capital',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: homeId,
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                inPortAtProvinceId: capProvince,
+                ships: const [ShipInstance(id: 'home_1', typeId: 'carrack')],
+              ),
+              Fleet(
+                id: 'sea_far',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                seaZoneId: 'zone_far',
+                ships: const [ShipInstance(id: 'src_1', typeId: 'fluyte')],
+              ),
+            ],
+          ),
+          players: const [
+            Player(
+              id: humanId,
+              displayName: 'Home non-adjacent tester',
+              isHuman: true,
+              capitalProvinceId: capProvince,
+              capitalTile: CapitalTile(
+                regionId: 'oldWorld',
+                provinceId: capProvince,
+                x: 0,
+                y: 0,
+              ),
+            ),
+          ],
+        );
+        const topology = MapTopology(
+          nodes: [
+            TopologyNode(
+              id: 'oldWorld|cap1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'zone_far',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+          ],
+          edges: [],
+        );
+
+        await tester.pumpWidget(
+          buildPanel(
+            game: gameNonAdjacent,
+            humanPlayerId: humanId,
+            topology: topology,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final homeFinder = find.widgetWithText(ExpansionTile, 'Home Fleet');
+        final sourceFinder = find.widgetWithText(
+          ExpansionTile,
+          'Fleet sea_far',
+        );
+        await tester.tap(
+          find.descendant(of: homeFinder, matching: find.byType(Checkbox)),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.descendant(of: sourceFinder, matching: find.byType(Checkbox)),
         );
         await tester.pumpAndSettle();
 
@@ -2898,7 +3294,12 @@ void main() {
         final sub = bus.on<NavalFleetsUpdatedEvent>().listen((e) {
           updated = e;
         });
+        final subTransferNeverDelete = wireNavalTransferForWidgetTest(
+          bus: bus,
+          gameSnapshot: () => homeNeverDeleteGame,
+        );
         addTearDown(sub.cancel);
+        addTearDown(subTransferNeverDelete.cancel);
 
         await tester.pumpWidget(
           buildPanel(
@@ -2924,6 +3325,24 @@ void main() {
         await tester.pumpAndSettle();
 
         await tester.tap(find.widgetWithText(CtNinePatchButton, 'Combine'));
+        await tester.pumpAndSettle();
+        expect(find.text('Transfer Ships to Home Fleet'), findsOneWidget);
+        await tester.tap(find.byKey(CtTransferListKeys.leftMoveAll('fluyte')));
+        await tester.pumpAndSettle();
+        final confirmTransfer = find.widgetWithText(
+          CtNinePatchButton,
+          'Confirm Transfer',
+        );
+        expect(confirmTransfer, findsOneWidget);
+        expect(
+          tester.widget<CtNinePatchButton>(confirmTransfer).enabled,
+          isTrue,
+        );
+        final confirmTransferButton = tester.widget<CtNinePatchButton>(
+          confirmTransfer,
+        );
+        expect(confirmTransferButton.onPressed, isNotNull);
+        confirmTransferButton.onPressed!.call();
         await tester.pumpAndSettle();
 
         expect(updated, isNotNull);

--- a/packages/colonizethis_logic/lib/src/world/naval_fleet_commands.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_fleet_commands.dart
@@ -61,3 +61,72 @@ Game applyNavalSplitFleet({
     worldState: game.worldState.copyWith(fleets: updatedFleets),
   );
 }
+
+/// Transfers selected ship instances from [sourceFleetId] into [targetFleetId].
+///
+/// Immediate UI fleet-management operation (not a turn order). Returns [game]
+/// unchanged when fleets are missing, owners mismatch, or no transferable ships
+/// are selected.
+Game applyNavalTransferShipsBetweenFleets({
+  required Game game,
+  required String humanPlayerId,
+  required String sourceFleetId,
+  required String targetFleetId,
+  required List<String> shipInstanceIdsToTransfer,
+}) {
+  if (shipInstanceIdsToTransfer.isEmpty || sourceFleetId == targetFleetId) {
+    return game;
+  }
+
+  Fleet? sourceFleet;
+  Fleet? targetFleet;
+  for (final fleet in game.worldState.fleets) {
+    if (fleet.id == sourceFleetId) {
+      sourceFleet = fleet;
+    } else if (fleet.id == targetFleetId) {
+      targetFleet = fleet;
+    }
+  }
+  if (sourceFleet == null || targetFleet == null) {
+    return game;
+  }
+  if (sourceFleet.ownerId != humanPlayerId ||
+      targetFleet.ownerId != humanPlayerId) {
+    return game;
+  }
+
+  final transferIds = shipInstanceIdsToTransfer.toSet();
+  final shipsToTransfer = <ShipInstance>[];
+  final sourceRemaining = <ShipInstance>[];
+  for (final ship in sourceFleet.ships) {
+    if (transferIds.contains(ship.id)) {
+      shipsToTransfer.add(ship);
+    } else {
+      sourceRemaining.add(ship);
+    }
+  }
+  if (shipsToTransfer.isEmpty) {
+    return game;
+  }
+
+  final updatedTarget = targetFleet.copyWith(
+    ships: [...targetFleet.ships, ...shipsToTransfer],
+    mission: FleetMission.none,
+  );
+  final sourceIsHomeFleet = sourceFleet.id == homeFleetIdFor(humanPlayerId);
+  final updatedSource = sourceFleet.copyWith(ships: sourceRemaining);
+
+  final updatedFleets = <Fleet>[
+    for (final fleet in game.worldState.fleets) ...[
+      if (fleet.id == targetFleet.id)
+        updatedTarget
+      else if (fleet.id == sourceFleet.id)
+        if (sourceRemaining.isNotEmpty || sourceIsHomeFleet) updatedSource,
+      if (fleet.id != targetFleet.id && fleet.id != sourceFleet.id) fleet,
+    ],
+  ];
+
+  return game.copyWith(
+    worldState: game.worldState.copyWith(fleets: updatedFleets),
+  );
+}

--- a/packages/colonizethis_logic/test/world/naval_fleet_commands_test.dart
+++ b/packages/colonizethis_logic/test/world/naval_fleet_commands_test.dart
@@ -127,4 +127,84 @@ void main() {
       },
     );
   });
+
+  group('applyNavalTransferShipsBetweenFleets', () {
+    test(
+      'Given subset selected When transferred Then target gains selected and source remains',
+      () {
+        final game = _gameWithFleets([
+          Fleet(
+            id: 'source',
+            ownerId: 'gp_human',
+            regionId: 'oldWorld',
+            seaZoneId: 'sea_a',
+            ships: const [
+              ShipInstance(id: 'ship_1', typeId: 'carrack'),
+              ShipInstance(id: 'ship_2', typeId: 'fluyte'),
+            ],
+          ),
+          Fleet(
+            id: homeFleetIdFor('gp_human'),
+            ownerId: 'gp_human',
+            regionId: 'oldWorld',
+            inPortAtProvinceId: 'oldWorld|cap',
+            ships: const [ShipInstance(id: 'ship_home', typeId: 'carrack')],
+          ),
+        ]);
+
+        final next = applyNavalTransferShipsBetweenFleets(
+          game: game,
+          humanPlayerId: 'gp_human',
+          sourceFleetId: 'source',
+          targetFleetId: homeFleetIdFor('gp_human'),
+          shipInstanceIdsToTransfer: const ['ship_2'],
+        );
+
+        final source = next.worldState.fleets.firstWhere(
+          (f) => f.id == 'source',
+        );
+        final target = next.worldState.fleets.firstWhere(
+          (f) => f.id == homeFleetIdFor('gp_human'),
+        );
+        expect(source.ships.map((s) => s.id).toList(), ['ship_1']);
+        expect(target.ships.map((s) => s.id).toList(), ['ship_home', 'ship_2']);
+      },
+    );
+
+    test(
+      'Given all source ships selected When transferred Then source is removed',
+      () {
+        final game = _gameWithFleets([
+          Fleet(
+            id: 'source',
+            ownerId: 'gp_human',
+            regionId: 'oldWorld',
+            seaZoneId: 'sea_a',
+            ships: const [ShipInstance(id: 'ship_1', typeId: 'carrack')],
+          ),
+          Fleet(
+            id: homeFleetIdFor('gp_human'),
+            ownerId: 'gp_human',
+            regionId: 'oldWorld',
+            inPortAtProvinceId: 'oldWorld|cap',
+            ships: const [],
+          ),
+        ]);
+
+        final next = applyNavalTransferShipsBetweenFleets(
+          game: game,
+          humanPlayerId: 'gp_human',
+          sourceFleetId: 'source',
+          targetFleetId: homeFleetIdFor('gp_human'),
+          shipInstanceIdsToTransfer: const ['ship_1'],
+        );
+
+        expect(next.worldState.fleets.any((f) => f.id == 'source'), isFalse);
+        final home = next.worldState.fleets.firstWhere(
+          (f) => f.id == homeFleetIdFor('gp_human'),
+        );
+        expect(home.ships.map((s) => s.id).toList(), ['ship_1']);
+      },
+    );
+  });
 }

--- a/packages/colonizethis_models/lib/src/app_events.dart
+++ b/packages/colonizethis_models/lib/src/app_events.dart
@@ -341,6 +341,23 @@ class NavalSplitFleetRequestedEvent extends SessionCommandEvent {
   final List<String> shipInstanceIdsToNewFleet;
 }
 
+/// Transfer selected ship instances from one existing fleet into another.
+/// Shell listener applies canonical fleet mutation and emits
+/// [NavalFleetsUpdatedEvent]. SPEC/program/app-ui-wiring.md.
+class NavalTransferShipsRequestedEvent extends SessionCommandEvent {
+  NavalTransferShipsRequestedEvent({
+    required this.humanPlayerId,
+    required this.sourceFleetId,
+    required this.targetFleetId,
+    required this.shipInstanceIdsToTransfer,
+  });
+
+  final String humanPlayerId;
+  final String sourceFleetId;
+  final String targetFleetId;
+  final List<String> shipInstanceIdsToTransfer;
+}
+
 /// Move fleet dialog confirm: shell merges [moveOrder] into current-turn draft orders.
 /// SPEC/program/app-ui-wiring.md.
 class NavalMoveFleetRequestedEvent extends SessionCommandEvent {


### PR DESCRIPTION
## Summary
- implement Scope B selected-ship transfer into Home Fleet through Naval Units panel combine flow when Home Fleet is selected with one eligible source fleet
- enforce eligibility for sources in capital port or adjacent sea zones, and preserve Home Fleet persistence plus source cleanup semantics when fully transferred
- add event/logic wiring, transfer dialog UI, SPEC clarifications, and targeted logic/widget coverage for transfer and non-adjacent rejection paths

## SPEC
- updated `SPEC/ui/naval-units-fleet-management.md` with Scope B transfer rules and ACs
- clarified in `SPEC/program/naval-movement-resolution.md` that movement-order `join_home_fleet` remains a separate contract

## Test plan
- [x] `dart test test/world/naval_fleet_commands_test.dart` (from `packages/colonizethis_logic`)
- [x] `flutter test test/naval_units_panel_test.dart` (from `app`)

Refs #2009

Made with [Cursor](https://cursor.com)