### PR TITLE
docs(spec): dart non-comment line size rule + #1912 terminology (Refs #1912)

### DIFF
--- a/SPEC/program/dart-file-non-comment-line-size.md
+++ b/SPEC/program/dart-file-non-comment-line-size.md
@@ -1,0 +1,65 @@
+# Dart file non-comment line size (repo lint)
+
+**SPEC/program** — repository-wide gate on **non-comment** source lines in Dart
+files. Umbrella policy: `SPEC/program/repo-lint.md` (**no violation allowlists**).
+
+## Source of truth
+
+| Artifact | Role |
+|----------|------|
+| `tool/check_dart_file_non_comment_line_size.dart` | Walker, counter, CLI |
+| `tool/ct_repo_lint_manifest.yaml` | Registers rule `repo.dart_file_non_comment_line_size` |
+
+## Scan scope
+
+- The checker walks the repository tree from the repo root, skipping directory
+  names such as `.git`, `.dart_tool`, `build`, `.pub-cache`, `.cursor`, and
+  similar tooling trees (see checker source for the authoritative set).
+- Only `*.dart` files are considered.
+
+## Measurement contract
+
+- **Non-comment lines:** a line contributes to the count when, after stripping
+  `//` line comments, `/* … */` block comments, and string/comment state handling
+  defined in the checker, the line still contains countable code (same algorithm
+  as `countNonCommentLinesFromSource` in the checker implementation).
+- **Failure threshold:** strictly **greater than 1000** non-comment lines fails
+  the file (1000 inclusive passes).
+
+## Generated and tooling outputs (scope-only exclusions)
+
+Per `SPEC/program/repo-lint.md`, excluding **whole generated files** from this
+rule is **scope wiring**, not a keyed violation waiver.
+
+The checker skips any repo-relative path that:
+
+- Ends with `.g.dart`, `.freezed.dart`, `.mocks.dart`, or `.gen.dart`, or
+- Contains the substring `app/lib/l10n/app_localizations_`, or
+- Contains the substring `app/lib/l10n/app_l10n_flutter_gen_`.
+
+There is **no** YAML or keyed table that raises the effective line cap for a
+specific hand-written library file.
+
+## Acceptance criteria
+
+- Given a temporary workspace whose only Dart file is a hand-written
+  `packages/example/lib/huge.dart` with more than 1000 non-comment lines, when
+  the System runs `runCheckDartFileNonCommentLineSize` with that workspace root,
+  then the checker exits non-zero and the error output names `huge.dart` and
+  reports a line count strictly greater than 1000.
+
+- Given a temporary workspace containing only a Dart file whose repo-relative
+  path ends with `.gen.dart` and whose non-comment line count exceeds 1000,
+  when the System runs `runCheckDartFileNonCommentLineSize`, then the checker
+  exits zero and does not list that file as a violation.
+
+- Given a temporary workspace containing only
+  `app/lib/l10n/app_l10n_flutter_gen_en.dart` with more than 1000 non-comment
+  lines, when the System runs `runCheckDartFileNonCommentLineSize`, then the
+  checker exits zero and does not list that path as a violation.
+
+- Given the repository root as cwd, when CI runs
+  `dart run tool/ct_repo_lint.dart` and rule `repo.dart_file_non_comment_line_size`
+  is in scope for the job, then the rule uses the measurement and exclusions
+  above and does not load keyed waiver data to waive failures for in-scope
+  hand-written Dart files.

--- a/SPEC/program/repo-and-packages.md
+++ b/SPEC/program/repo-and-packages.md
@@ -70,11 +70,11 @@ colonizethis_data    (no package deps)
 - **Given** the main logic public barrel `packages/colonizethis_logic/lib/colonizethis_logic.dart`, **when** static analysis inspects exported libraries, **then** no `src/ai/*` export is present; AI internals stay outside the broad logic export surface.
 - **Given** Dart source under `app/lib` except `app/lib/config/app_assets.dart` and `app/lib/config/app_constants.dart`, **when** static analysis inspects string literals, **then** direct asset path literals matching `assets/...` or `packages/<pkg>/assets/...` are rejected and diagnostics include file, line, and reason.
 - **Given** an app runtime asset reference in `app/lib`, **when** the code compiles, **then** the reference uses root-relative path constants in `app/lib/config/app_constants.dart` (re-exported from `app/lib/config/app_assets.dart`) and/or path builders such as `terrainTileAssetPath` in `app/lib/config/app_assets.dart`.
-- **Given** Dart source under `app/`, `packages/`, and `tool/`, **when** static analysis inspects executable AST string literals, **then** raw literals equal to canonical tech IDs are rejected outside allowlisted declaration/config and fixture paths.
+- **Given** Dart source under `app/`, `packages/`, and `tool/`, **when** static analysis inspects executable AST string literals, **then** raw literals equal to canonical tech IDs are rejected outside canonical declaration sources, generated outputs skipped as whole paths by the identifier-literal scan contract, and approved fixture or test-data paths, with **no** keyed per-symbol waivers (see `SPEC/program/repo-lint.md` — policy distinguishes scope-only wiring from violation allowlists).
 - **Given** the tech-ID convention gate reports a violation, **when** a developer inspects the output, **then** each violation includes file path, line, column, and the offending tech ID literal for direct remediation.
-- **Given** Dart source under `app/`, `packages/`, and `tool/`, **when** static analysis inspects executable AST string literals, **then** raw literals equal to canonical work target IDs are rejected outside the allowlisted work-target declaration file and fixture paths.
+- **Given** Dart source under `app/`, `packages/`, and `tool/`, **when** static analysis inspects executable AST string literals, **then** raw literals equal to canonical work target IDs are rejected outside the canonical work-target declaration file, whole-file scope skips for generated or catalog surfaces documented in `tool/check_work_target_constants.dart`, and approved fixture paths, with **no** keyed per-symbol waivers.
 - **Given** the work-target convention gate reports a violation, **when** a developer inspects the output, **then** each violation includes file path, line, column, and the offending work target literal with a suggested `kWorkTarget*` constant when available.
-- **Given** Dart source under `app/`, `packages/`, and `tool/`, **when** static analysis inspects executable AST string literals, **then** raw literals equal to canonical civilian unit type ids (`Explorer`, `Builder`, `Engineer`, `Spy`, `Merchant`, `Rail Builder` per `SPEC/game/civilian-units.md`) are rejected outside `packages/colonizethis_models/lib/src/civilian_unit_type_ids.dart`, approved fixture/test-data paths, and an explicit allowlist for ambiguous spellings (e.g. naval ship category vs civilian `Merchant`, personality archetype display strings).
+- **Given** Dart source under `app/`, `packages/`, and `tool/`, **when** static analysis inspects executable AST string literals, **then** raw literals equal to canonical civilian unit type ids (`Explorer`, `Builder`, `Engineer`, `Spy`, `Merchant`, `Rail Builder` per `SPEC/game/civilian-units.md`) are rejected outside `packages/colonizethis_models/lib/src/civilian_unit_type_ids.dart`, approved fixture/test-data paths, and the single whole-file scope skip for `packages/colonizethis_data/lib/src/ai_personality_config.dart` (personality display strings that may collide with civilian spellings), with **no** keyed per-symbol waivers.
 - **Given** the civilian unit type convention gate reports a violation, **when** a developer inspects the output, **then** each violation includes file path, line, column, and the offending literal with a suggested `kUnitType*` constant when available.
 
 ### Automated guard gate (CI)
@@ -93,23 +93,23 @@ Guard behavior:
 - Fails if `packages/colonizethis_logic/test/**` imports `package:colonizethis_ai/...`.
 - Fails if `packages/colonizethis_logic/lib/colonizethis_logic.dart` exports any `src/ai/*` library.
 - Fails if `app/lib/**` contains direct `assets/...` or `packages/<pkg>/assets/...` string literals outside `app/lib/config/app_assets.dart` and `app/lib/config/app_constants.dart`.
-- Fails if executable `StringLiteral` AST nodes equal to canonical tech IDs appear outside allowlisted tech declaration/config files and approved fixture/test-data paths.
-- Fails if executable `StringLiteral` AST nodes equal to canonical work target IDs appear outside `packages/colonizethis_logic/lib/src/constants.dart`, approved fixture/test-data paths, and an explicit temporary allowlist for generated/legacy surfaces pending migration.
+- Fails if executable `StringLiteral` AST nodes equal to canonical tech IDs appear outside canonical declaration sources, generated outputs skipped as whole paths by the scan contract, and approved fixture/test-data paths.
+- Fails if executable `StringLiteral` AST nodes equal to canonical work target IDs appear outside `packages/colonizethis_logic/lib/src/constants.dart`, approved fixture/test-data paths, and whole-file scope skips for generated or catalog surfaces encoded in `tool/check_work_target_constants.dart` (not keyed per-symbol waivers).
 - In PR CI, the tech-ID guard may scan only changed Dart files for faster feedback; if PR diff context is unavailable, it falls back to a full repository scan with the same violation rules.
 - In PR CI, the work-target guard may scan only changed Dart files for faster feedback; if PR diff context is unavailable, it falls back to a full repository scan with the same violation rules.
-- Fails if executable `StringLiteral` AST nodes equal to canonical civilian unit type ids appear outside `packages/colonizethis_models/lib/src/civilian_unit_type_ids.dart`, approved fixture/test-data paths, and the explicit allowlist in `tool/check_civilian_unit_type_constants.dart`.
+- Fails if executable `StringLiteral` AST nodes equal to canonical civilian unit type ids appear outside `packages/colonizethis_models/lib/src/civilian_unit_type_ids.dart`, approved fixture/test-data paths, and the whole-file scope skip set in `tool/check_civilian_unit_type_constants.dart` (see acceptance criteria above).
 - In PR CI, the civilian unit type guard may scan only changed Dart files for faster feedback; if PR diff context is unavailable, it falls back to a full repository scan with the same violation rules.
 
 Civilian unit type guard remediation:
 
 - Add or reuse `kUnitType*` constants in `packages/colonizethis_models/lib/src/civilian_unit_type_ids.dart` (also re-exported from `packages/colonizethis_logic/lib/src/constants.dart` for logic consumers).
-- Replace direct string literals in executable code with those constants; extend the tool allowlist only for documented ambiguous literals.
+- Replace direct string literals in executable code with those constants; extend whole-file scope skips only with SPEC updates and issue tracking—prefer constants and refactors over new waivers.
 
 Asset-path guard remediation:
 
 - Add new root-relative asset path constants in `app/lib/config/app_constants.dart`; add or extend path builders in `app/lib/config/app_assets.dart` (which re-exports the constants library).
 - Replace direct string literals in `app/lib/**` with those constants/helpers.
-- Keep exclusions explicit and minimal; allowlisted files are `app/lib/config/app_assets.dart` and `app/lib/config/app_constants.dart`.
+- Keep exclusions explicit and minimal; whole-file scope skips for asset path literals are `app/lib/config/app_assets.dart` and `app/lib/config/app_constants.dart`.
 
 ---
 

--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -14,6 +14,8 @@
 
 **Implementation status (GitHub #1912, checker slice):** `repo.function_size`, `repo.control_flow_nesting_depth`, and `repo.part_unit_size` enforce universal thresholds only; they do **not** read keyed waiver YAML or other per-symbol / per-file exemption tables. Per-rule contracts: `SPEC/program/function-size.md`, `SPEC/program/control-flow-nesting-depth.md`, `SPEC/program/part-unit-size.md`.
 
+**Implementation status (GitHub #1912, dart file size):** `repo.dart_file_non_comment_line_size` enforces a universal **1000** non-comment-line cap for scanned hand-written Dart; it skips only **generated whole paths** (suffixes `.g.dart`, `.freezed.dart`, `.mocks.dart`, `.gen.dart`, and generated Flutter l10n path prefixes under `app/lib/l10n/`). Per-rule contract: `SPEC/program/dart-file-non-comment-line-size.md`.
+
 **Implementation status (GitHub #1912, tech id literals):** `repo.tech_id_constants` treats the string values of every `const String kTechId*` in `packages/colonizethis_data/lib/src/tech_ids.dart` as the canonical tech-id set (replacing the prior `tech_catalog.dart` map-key scrape). `tech_catalog.dart` uses those same constants for map keys and `TechDefinition` ids so the catalog stays aligned with the checker.
 
 ### Acceptance criteria (policy)
@@ -38,7 +40,7 @@
 | `tool/check_no_flame_in_widgets.dart` | Disallow direct `package:flame/*` **import** and **export** lines (single- or double-quoted URI) under `app/lib/widgets/**`; rule `repo.no_flame_in_widgets` |
 | `tool/check_no_screen_in_game_widgets.dart` | Disallow `*_screen.dart` files under `app/lib/features/game/widgets/**`; rule `repo.no_screen_in_game_widgets` |
 | `tool/check_game_widgets_file_size.dart` | Enforce `app/lib/features/game/widgets/**` Dart files at **700 physical lines or fewer**; rule `repo.game_widgets_file_size` |
-| `tool/check_dart_file_non_comment_line_size.dart` | Enforce repository-wide Dart files at **1000 non-comment lines or fewer** (fail when strictly greater), excluding generated suffixes (`.g.dart`, `.freezed.dart`, `.mocks.dart`, `.gen.dart`); rule `repo.dart_file_non_comment_line_size` |
+| `tool/check_dart_file_non_comment_line_size.dart` | Enforce repository-wide Dart files at **1000 non-comment lines or fewer** (fail when strictly greater), excluding generated suffixes and generated l10n path prefixes — see `SPEC/program/dart-file-non-comment-line-size.md`; rule `repo.dart_file_non_comment_line_size` |
 | `tool/check_land_province_bucket_keys.dart` | For guarded explore/fog/news paths, disallow local-only land-province tile-bucket lookups (`tileKeysByRegionAndProvince[region]?[localId]`); require canonical full-id buckets only; rule `repo.land_province_bucket_keys` |
 
 ## Rule IDs and groups
@@ -147,7 +149,7 @@ Do **not** add new top-level `tool/check_*.dart` **entrypoints** for CI without 
 - Given the [Policy: no violation allowlists](#policy-no-violation-allowlists-repo-lint) section, when `repo.function_size`, `repo.control_flow_nesting_depth`, or `repo.part_unit_size` runs, then that checker does not load keyed waiver data and the matching per-rule SPEC documents universal enforcement only.
 - Given app game feature code, when `dart run tool/ct_repo_lint.dart` runs rule `repo.no_screen_in_game_widgets`, then no file matching `*_screen.dart` exists under `app/lib/features/game/widgets/**`.
 - Given app game widget files, when `dart run tool/ct_repo_lint.dart` runs rule `repo.game_widgets_file_size`, then each Dart file under `app/lib/features/game/widgets/**` has 700 physical lines or fewer.
-- Given repository Dart files (excluding generated suffixes `.g.dart`, `.freezed.dart`, `.mocks.dart`, `.gen.dart`), when `dart run tool/ct_repo_lint.dart` runs rule `repo.dart_file_non_comment_line_size`, then each scanned file has at most 1000 non-comment lines and the run fails while listing every violating file when any file is strictly greater than 1000.
+- Given repository Dart files excluding generated suffixes (`.g.dart`, `.freezed.dart`, `.mocks.dart`, `.gen.dart`) and generated app l10n paths under `app/lib/l10n/` matching the checker’s prefix list, when `dart run tool/ct_repo_lint.dart` runs rule `repo.dart_file_non_comment_line_size`, then each remaining scanned file has at most 1000 non-comment lines and the run fails while listing every violating file when any file is strictly greater than 1000.
 - Given `packages/colonizethis_debug_console/lib/**` imports only allowlisted `colonizethis_logic` contract entrypoints, when `dart run tool/ct_repo_lint.dart` runs rule `repo.debug_console_logic_contract_boundary`, then the rule passes without violations.
 - Given any debug-console file imports `package:colonizethis_logic/src/**` or another non-allowlisted `package:colonizethis_logic/...` entrypoint, when repo lint runs rule `repo.debug_console_logic_contract_boundary`, then the run fails and reports file path, line, and disallowed import context in checker output.
 - Given `app/lib/core/services/app_event_handler_scope.dart` has no direct imports from `package:colonizethis_app/features/game/logic/**`, when repo lint runs rule `repo.app_event_handler_scope_logic_boundary`, then the rule passes without violations.

--- a/test/ct_repo_lint_test.dart
+++ b/test/ct_repo_lint_test.dart
@@ -44,6 +44,14 @@ void main() {
       );
       expect(
         rules
+            .firstWhere(
+              (r) => r.ruleId == 'repo.dart_file_non_comment_line_size',
+            )
+            .spec,
+        'SPEC/program/dart-file-non-comment-line-size.md',
+      );
+      expect(
+        rules
             .firstWhere((r) => r.ruleId == 'repo.app_hardcoded_ui_strings')
             .includeOnlyWhenEnvName,
         'CT_REPO_LINT_INCLUDE_APP',

--- a/tool/check_dart_file_non_comment_line_size.dart
+++ b/tool/check_dart_file_non_comment_line_size.dart
@@ -1,3 +1,5 @@
+// Repository-wide non-comment line limit (`repo.dart_file_non_comment_line_size`).
+// SPEC: SPEC/program/dart-file-non-comment-line-size.md
 import 'dart:convert';
 import 'dart:io';
 

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -147,7 +147,7 @@ rules:
   - rule_id: repo.dart_file_non_comment_line_size
     group: structure
     title: Dart files must stay at or below 1000 non-comment lines
-    spec: SPEC/program/repo-lint.md
+    spec: SPEC/program/dart-file-non-comment-line-size.md
     runner: dart
     script: tool/check_dart_file_non_comment_line_size.dart
     pr_incremental: true


### PR DESCRIPTION
## Summary

Phased work for **#1912** (remove repo-lint grandfather allowlists). This PR is a **SPEC/documentation slice**: add an authoritative per-rule contract for `repo.dart_file_non_comment_line_size`, wire the manifest to it, align umbrella `repo-lint.md` status and acceptance criteria with generated l10n exclusions, and clarify `repo-and-packages.md` language so **whole-file scope skips** and scan-contract exclusions are not confused with keyed violation allowlists.

**Deferred:** Removing/refactoring any remaining checker code paths beyond documentation; other manifest rules without dedicated per-rule SPECs; full closure of #1912.

## Acceptance criteria (this PR)

- Per-rule SPEC exists for `repo.dart_file_non_comment_line_size` with testable GWT ACs (threshold, generated suffixes, l10n path prefixes, no waiver YAML).
- Manifest `spec:` points at that document.
- Umbrella `repo-lint.md` documents #1912 implementation status for this rule and updates the repo-wide AC to mention l10n prefix exclusions.
- `repo-and-packages.md` uses scope-skip terminology consistent with `SPEC/program/repo-lint.md` policy.
- `test/ct_repo_lint_test.dart` asserts the manifest spec path for the rule.

## SPEC

- `SPEC/program/dart-file-non-comment-line-size.md` (new)
- `SPEC/program/repo-lint.md`
- `SPEC/program/repo-and-packages.md`

## Tests

- `dart test test/check_dart_file_non_comment_line_size_test.dart test/ct_repo_lint_test.dart`

Refs #1912

Made with [Cursor](https://cursor.com)