### PR TITLE
docs(spec): game widgets file size rule for #1912 (Refs #1912)

### DIFF
--- a/SPEC/program/game-widgets-file-size.md
+++ b/SPEC/program/game-widgets-file-size.md
@@ -1,0 +1,53 @@
+# Game widgets file size (repo lint)
+
+**SPEC/program** — physical line limit for Dart sources under the in-game Flutter
+widget tree. Umbrella policy: `SPEC/program/repo-lint.md` (**no violation
+allowlists**).
+
+## Source of truth
+
+| Artifact | Role |
+|----------|------|
+| `tool/check_game_widgets_file_size.dart` | Walker, counter, CLI |
+| `tool/ct_repo_lint_manifest.yaml` | Registers rule `repo.game_widgets_file_size` |
+
+## Scan scope
+
+- Recursive listing under
+  `app/lib/features/game/widgets/` (repository-relative).
+- Only files ending in `.dart` are measured.
+- If that directory is missing, the checker fails the run (repository layout
+  contract for the ColonizeThis app).
+
+## Measurement contract
+
+- **Physical lines:** `LineSplitter` line count of the file’s UTF-8 text (same
+  as `const LineSplitter().convert(content).length` in the checker).
+- **Threshold:** each scanned file must have **700** physical lines or fewer
+  (701 or more fails).
+
+There is **no** YAML, keyed table, or per-file exemption that raises the
+effective cap for a specific path.
+
+## Acceptance criteria
+
+- Given a temporary workspace that contains
+  `app/lib/features/game/widgets/over.dart` with **701** physical lines and no
+  other violating files, when the System runs `runCheckGameWidgetsFileSize` with
+  that workspace root, then the checker exits non-zero and the error output
+  names `over.dart` and reports a line count strictly greater than 700.
+
+- Given a temporary workspace whose only matching file is
+  `app/lib/features/game/widgets/ok.dart` with exactly **700** physical lines,
+  when the System runs `runCheckGameWidgetsFileSize`, then the checker exits
+  zero.
+
+- Given a temporary workspace that does not contain the directory
+  `app/lib/features/game/widgets/`, when the System runs
+  `runCheckGameWidgetsFileSize`, then the checker exits non-zero and reports that
+  the widgets directory was not found.
+
+- Given the repository root as cwd, when CI runs
+  `dart run tool/ct_repo_lint.dart` and rule `repo.game_widgets_file_size` is in
+  scope, then the rule enforces the threshold above and does not load keyed
+  waiver data to waive failures for in-scope Dart files.

--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -16,6 +16,8 @@
 
 **Implementation status (GitHub #1912, dart file size):** `repo.dart_file_non_comment_line_size` enforces a universal **1000** non-comment-line cap for scanned hand-written Dart; it skips only **generated whole paths** (suffixes `.g.dart`, `.freezed.dart`, `.mocks.dart`, `.gen.dart`, and generated Flutter l10n path prefixes under `app/lib/l10n/`). Per-rule contract: `SPEC/program/dart-file-non-comment-line-size.md`.
 
+**Implementation status (GitHub #1912, game widgets file size):** `repo.game_widgets_file_size` enforces a universal **700** physical-line cap for every `.dart` file under `app/lib/features/game/widgets/**` with no keyed waivers. Per-rule contract: `SPEC/program/game-widgets-file-size.md`.
+
 **Implementation status (GitHub #1912, tech id literals):** `repo.tech_id_constants` treats the string values of every `const String kTechId*` in `packages/colonizethis_data/lib/src/tech_ids.dart` as the canonical tech-id set (replacing the prior `tech_catalog.dart` map-key scrape). `tech_catalog.dart` uses those same constants for map keys and `TechDefinition` ids so the catalog stays aligned with the checker.
 
 ### Acceptance criteria (policy)
@@ -39,7 +41,7 @@
 | `tool/check_app_event_handler_scope_logic_boundary.dart` | Enforce that `app/lib/core/services/app_event_handler_scope.dart` has no direct import from `app/lib/features/game/logic/**`; rule `repo.app_event_handler_scope_logic_boundary` |
 | `tool/check_no_flame_in_widgets.dart` | Disallow direct `package:flame/*` **import** and **export** lines (single- or double-quoted URI) under `app/lib/widgets/**`; rule `repo.no_flame_in_widgets` |
 | `tool/check_no_screen_in_game_widgets.dart` | Disallow `*_screen.dart` files under `app/lib/features/game/widgets/**`; rule `repo.no_screen_in_game_widgets` |
-| `tool/check_game_widgets_file_size.dart` | Enforce `app/lib/features/game/widgets/**` Dart files at **700 physical lines or fewer**; rule `repo.game_widgets_file_size` |
+| `tool/check_game_widgets_file_size.dart` | Enforce `app/lib/features/game/widgets/**` Dart files at **700 physical lines or fewer** — see `SPEC/program/game-widgets-file-size.md`; rule `repo.game_widgets_file_size` |
 | `tool/check_dart_file_non_comment_line_size.dart` | Enforce repository-wide Dart files at **1000 non-comment lines or fewer** (fail when strictly greater), excluding generated suffixes and generated l10n path prefixes — see `SPEC/program/dart-file-non-comment-line-size.md`; rule `repo.dart_file_non_comment_line_size` |
 | `tool/check_land_province_bucket_keys.dart` | For guarded explore/fog/news paths, disallow local-only land-province tile-bucket lookups (`tileKeysByRegionAndProvince[region]?[localId]`); require canonical full-id buckets only; rule `repo.land_province_bucket_keys` |
 
@@ -148,7 +150,7 @@ Do **not** add new top-level `tool/check_*.dart` **entrypoints** for CI without 
 - Given a contributor adds a convention, when they follow CONTRIBUTING and this doc, then they register the rule in the manifest rather than adding a new standalone Quality workflow step for the same concern.
 - Given the [Policy: no violation allowlists](#policy-no-violation-allowlists-repo-lint) section, when `repo.function_size`, `repo.control_flow_nesting_depth`, or `repo.part_unit_size` runs, then that checker does not load keyed waiver data and the matching per-rule SPEC documents universal enforcement only.
 - Given app game feature code, when `dart run tool/ct_repo_lint.dart` runs rule `repo.no_screen_in_game_widgets`, then no file matching `*_screen.dart` exists under `app/lib/features/game/widgets/**`.
-- Given app game widget files, when `dart run tool/ct_repo_lint.dart` runs rule `repo.game_widgets_file_size`, then each Dart file under `app/lib/features/game/widgets/**` has 700 physical lines or fewer.
+- Given app game widget Dart files under `app/lib/features/game/widgets/**`, when `dart run tool/ct_repo_lint.dart` runs rule `repo.game_widgets_file_size`, then each scanned file has at most 700 physical lines, the run fails listing each violating path when any file exceeds 700, and the checker does not load keyed waiver data.
 - Given repository Dart files excluding generated suffixes (`.g.dart`, `.freezed.dart`, `.mocks.dart`, `.gen.dart`) and generated app l10n paths under `app/lib/l10n/` matching the checker’s prefix list, when `dart run tool/ct_repo_lint.dart` runs rule `repo.dart_file_non_comment_line_size`, then each remaining scanned file has at most 1000 non-comment lines and the run fails while listing every violating file when any file is strictly greater than 1000.
 - Given `packages/colonizethis_debug_console/lib/**` imports only allowlisted `colonizethis_logic` contract entrypoints, when `dart run tool/ct_repo_lint.dart` runs rule `repo.debug_console_logic_contract_boundary`, then the rule passes without violations.
 - Given any debug-console file imports `package:colonizethis_logic/src/**` or another non-allowlisted `package:colonizethis_logic/...` entrypoint, when repo lint runs rule `repo.debug_console_logic_contract_boundary`, then the run fails and reports file path, line, and disallowed import context in checker output.

--- a/test/check_game_widgets_file_size_test.dart
+++ b/test/check_game_widgets_file_size_test.dart
@@ -28,6 +28,23 @@ void main() {
     expect(logs.join('\n'), contains('701 physical lines > 700'));
   });
 
+  test('fails when game widgets directory is missing', () {
+    final temp = Directory.systemTemp.createTempSync(
+      'check_game_widgets_file_size_no_dir_',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    final logs = <String>[];
+    final code = runCheckGameWidgetsFileSize(
+      temp.path,
+      info: logs.add,
+      err: logs.add,
+    );
+
+    expect(code, 1);
+    expect(logs.join('\n'), contains('widgets not found'));
+  });
+
   test('passes when all game widget files are at or below 700 lines', () {
     final temp = Directory.systemTemp.createTempSync(
       'check_game_widgets_file_size_pass_',

--- a/test/ct_repo_lint_test.dart
+++ b/test/ct_repo_lint_test.dart
@@ -51,6 +51,10 @@ void main() {
         'SPEC/program/dart-file-non-comment-line-size.md',
       );
       expect(
+        rules.firstWhere((r) => r.ruleId == 'repo.game_widgets_file_size').spec,
+        'SPEC/program/game-widgets-file-size.md',
+      );
+      expect(
         rules
             .firstWhere((r) => r.ruleId == 'repo.app_hardcoded_ui_strings')
             .includeOnlyWhenEnvName,

--- a/tool/check_game_widgets_file_size.dart
+++ b/tool/check_game_widgets_file_size.dart
@@ -1,3 +1,5 @@
+// Physical line limit for game feature widgets (`repo.game_widgets_file_size`).
+// SPEC: SPEC/program/game-widgets-file-size.md
 import 'dart:convert';
 import 'dart:io';
 
@@ -7,8 +9,6 @@ const _maxPhysicalLines = 700;
 
 /// PR-blocking structural check: files under
 /// `app/lib/features/game/widgets/**` must stay at or below 700 physical lines.
-///
-/// SPEC: SPEC/program/repo-lint.md
 int runCheckGameWidgetsFileSize(
   String repoRoot, {
   void Function(String line)? info,

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -140,7 +140,7 @@ rules:
   - rule_id: repo.game_widgets_file_size
     group: structure
     title: app/lib/features/game/widgets files must stay at or below 700 lines
-    spec: SPEC/program/repo-lint.md
+    spec: SPEC/program/game-widgets-file-size.md
     runner: dart
     script: tool/check_game_widgets_file_size.dart
 


### PR DESCRIPTION
## Summary

Follow-up **#1912** slice: add a dedicated per-rule SPEC for `repo.game_widgets_file_size`, wire the manifest and checker to it, and align `repo-lint.md` implementation status and acceptance criteria with the no–violation-allowlist umbrella policy.

**Deferred:** Remaining manifest rules still anchored only in `repo-lint.md`; any code refactors beyond documentation; full #1912 closure.

## Acceptance criteria (this PR)

- Per-rule SPEC documents scan scope, 700-line physical measurement, missing-directory behavior, and no keyed waivers.
- Manifest `spec:` and checker header reference that document.
- `repo-lint.md` records #1912 implementation status and tightens the game-widgets AC.
- Tests cover missing `app/lib/features/game/widgets/` and manifest `spec` path.

## SPEC

- `SPEC/program/game-widgets-file-size.md` (new)
- `SPEC/program/repo-lint.md`

## Tests

- `dart test test/check_game_widgets_file_size_test.dart test/ct_repo_lint_test.dart`

Refs #1912

Made with [Cursor](https://cursor.com)