### PR TITLE
refactor(logic): dispatch work-phase targets via handler registry

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/orders_application_work_phase.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_work_phase.dart
@@ -12,6 +12,319 @@ import 'work_handlers/purchase_land_handler.dart';
 import 'work_handlers/steal_tech_work_handler.dart';
 import 'work_handlers/standard_work_handler.dart';
 
+abstract class _WorkOrderHandler {
+  bool supports(String target);
+
+  bool tryApply(
+    _WorkOrderExecutionContext context,
+    WorkOrder order,
+    Unit unit,
+    String targetTileKey,
+    bool hasValidTarget,
+  );
+}
+
+class _WorkOrderExecutionContext {
+  _WorkOrderExecutionContext({required this.state, required this.player})
+    : stockpile = player.stockpile,
+      workers = player.workerPool,
+      treasury = player.treasury,
+      purchasedTilesByTileKey = Map<String, String>.from(
+        state.work.purchasedTilesByTileKey,
+      );
+
+  BuildWorkState state;
+  final Player player;
+  Stockpile stockpile;
+  WorkerPool workers;
+  int treasury;
+  Map<String, String> purchasedTilesByTileKey;
+
+  Unit? lookupUnit(String unitId) =>
+      state.work.oldUnitsById[unitId] ?? state.work.newUnitsById[unitId];
+
+  void updateUnit(String unitId, Unit updated) {
+    if (state.work.oldUnitsById.containsKey(unitId)) {
+      state = state.copyWith(
+        work: state.work.copyWith(
+          oldUnitsById: Map<String, Unit>.from(state.work.oldUnitsById)
+            ..[unitId] = updated,
+        ),
+      );
+    } else {
+      state = state.copyWith(
+        work: state.work.copyWith(
+          newUnitsById: Map<String, Unit>.from(state.work.newUnitsById)
+            ..[unitId] = updated,
+        ),
+      );
+    }
+  }
+
+  String regionForUnit(String unitId) =>
+      state.work.oldUnitsById.containsKey(unitId)
+      ? kRegionOldWorld
+      : kRegionNewWorld;
+
+  Province? provinceById(String id) => state.game.worldState.tryGetProvince(id);
+
+  bool canAffordMaterialCost(WorkOrderCost cost) {
+    for (final e in cost.entries) {
+      if (stockpile.quantityOf(e.key) < e.value) return false;
+    }
+    return true;
+  }
+
+  void deductMaterialCost(WorkOrderCost cost) {
+    for (final e in cost.entries) {
+      stockpile = stockpile.applyDelta(e.key, -e.value);
+    }
+  }
+
+  void persistPlayerSnapshot() {
+    state = state.copyWith(
+      work: state.work.copyWith(
+        purchasedTilesByTileKey: purchasedTilesByTileKey,
+        updatedPlayers: [
+          ...state.work.updatedPlayers,
+          player.copyWith(
+            stockpile: stockpile,
+            workerPool: workers,
+            treasury: treasury,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PurchaseLandWorkOrderHandler implements _WorkOrderHandler {
+  const _PurchaseLandWorkOrderHandler();
+
+  @override
+  bool supports(String target) => target == kWorkTargetPurchaseLand;
+
+  @override
+  bool tryApply(
+    _WorkOrderExecutionContext context,
+    WorkOrder order,
+    Unit unit,
+    String targetTileKey,
+    bool hasValidTarget,
+  ) {
+    if (!isWorkOrderTargetAllowedForUnitType(
+          unit.type,
+          kWorkTargetPurchaseLand,
+        ) ||
+        unit.currentWork != null ||
+        !hasValidTarget) {
+      return false;
+    }
+    final land = applyPurchaseLandWorkOrder(
+      state: context.state,
+      player: context.player,
+      unit: unit,
+      targetTileKey: targetTileKey,
+      treasury: context.treasury,
+      purchasedTilesByTileKey: context.purchasedTilesByTileKey,
+      provinceById: context.provinceById,
+      updateUnit: context.updateUnit,
+    );
+    context.treasury = land.treasury;
+    context.purchasedTilesByTileKey = land.purchasedTilesByTileKey;
+    context.state = context.state.copyWith(
+      work: context.state.work.copyWith(
+        purchasedTilesByTileKey: context.purchasedTilesByTileKey,
+      ),
+    );
+    return true;
+  }
+}
+
+class _StealTechWorkOrderHandler implements _WorkOrderHandler {
+  const _StealTechWorkOrderHandler();
+
+  @override
+  bool supports(String target) => target == kWorkTargetStealTech;
+
+  @override
+  bool tryApply(
+    _WorkOrderExecutionContext context,
+    WorkOrder order,
+    Unit unit,
+    String targetTileKey,
+    bool hasValidTarget,
+  ) {
+    return tryAssignStealTechWorkOrder(
+      order: order,
+      unit: unit,
+      targetTileKey: targetTileKey,
+      updateUnit: context.updateUnit,
+    );
+  }
+}
+
+class _CounterSpyWorkOrderHandler implements _WorkOrderHandler {
+  const _CounterSpyWorkOrderHandler();
+
+  @override
+  bool supports(String target) => target == kWorkTargetCounterSpy;
+
+  @override
+  bool tryApply(
+    _WorkOrderExecutionContext context,
+    WorkOrder order,
+    Unit unit,
+    String targetTileKey,
+    bool hasValidTarget,
+  ) {
+    return tryAssignCounterSpyWorkOrder(
+      order: order,
+      unit: unit,
+      targetTileKey: targetTileKey,
+      updateUnit: context.updateUnit,
+    );
+  }
+}
+
+class _ProspectWorkOrderHandler implements _WorkOrderHandler {
+  const _ProspectWorkOrderHandler();
+
+  @override
+  bool supports(String target) => target == kWorkTargetProspect;
+
+  @override
+  bool tryApply(
+    _WorkOrderExecutionContext context,
+    WorkOrder order,
+    Unit unit,
+    String targetTileKey,
+    bool hasValidTarget,
+  ) {
+    context.state = context.state.copyWith(
+      game: tryApplyProspectWorkOrder(
+        game: context.state.game,
+        tileMapByRegion: context.state.tileMapByRegion,
+        player: context.player,
+        unit: unit,
+        targetTileKey: targetTileKey,
+        updateUnit: context.updateUnit,
+      ),
+    );
+    return true;
+  }
+}
+
+class _BuildImprovementWorkOrderHandler implements _WorkOrderHandler {
+  const _BuildImprovementWorkOrderHandler();
+
+  @override
+  bool supports(String target) => target == kWorkTargetBuildImprovement;
+
+  @override
+  bool tryApply(
+    _WorkOrderExecutionContext context,
+    WorkOrder order,
+    Unit unit,
+    String targetTileKey,
+    bool hasValidTarget,
+  ) {
+    return applyStandardWorkOrder(
+      order: order,
+      unit: unit,
+      targetTileKey: targetTileKey,
+      hasValidTarget: hasValidTarget,
+      orderTarget: kWorkTargetBuildImprovement,
+      tileState: context.state.work.tileState,
+      provinceById: context.provinceById,
+      canAffordMaterialCost: context.canAffordMaterialCost,
+      deductMaterialCost: context.deductMaterialCost,
+      updateUnit: context.updateUnit,
+    );
+  }
+}
+
+class _ExploreWorkOrderHandler implements _WorkOrderHandler {
+  const _ExploreWorkOrderHandler();
+
+  @override
+  bool supports(String target) => target == kWorkTargetExplore;
+
+  @override
+  bool tryApply(
+    _WorkOrderExecutionContext context,
+    WorkOrder order,
+    Unit unit,
+    String targetTileKey,
+    bool hasValidTarget,
+  ) {
+    if (!isExplorerUnit(unit.type) ||
+        unit.currentWork != null ||
+        !hasValidTarget) {
+      return false;
+    }
+    return tryApplyExploreWorkOrder(
+      game: context.state.game,
+      order: order,
+      unit: unit,
+      targetTileKey: targetTileKey,
+      regionForUnit: context.regionForUnit,
+      updateUnit: context.updateUnit,
+    );
+  }
+}
+
+class _RemainingStandardBuildTargetsWorkOrderHandler
+    implements _WorkOrderHandler {
+  const _RemainingStandardBuildTargetsWorkOrderHandler();
+
+  @override
+  bool supports(String target) {
+    return target == kWorkTargetBuildRoad ||
+        target == kWorkTargetBuildPort ||
+        target == kWorkTargetUpgradeTown ||
+        target == kWorkTargetBuildFort ||
+        target == kWorkTargetBuildRail;
+  }
+
+  @override
+  bool tryApply(
+    _WorkOrderExecutionContext context,
+    WorkOrder order,
+    Unit unit,
+    String targetTileKey,
+    bool hasValidTarget,
+  ) {
+    return tryApplyRemainingStandardBuildTargets(
+      workTarget: order.target,
+      order: order,
+      player: context.player,
+      unit: unit,
+      targetTileKey: targetTileKey,
+      hasValidTarget: hasValidTarget,
+      tileState: context.state.work.tileState,
+      provinceById: context.provinceById,
+      canAffordMaterialCost: context.canAffordMaterialCost,
+      deductMaterialCost: context.deductMaterialCost,
+      updateUnit: context.updateUnit,
+      terrain: terrainTypeForTileKey(
+        context.state.tileMapByRegion,
+        targetTileKey,
+      ),
+    );
+  }
+}
+
+const List<_WorkOrderHandler> _workOrderHandlers = [
+  _PurchaseLandWorkOrderHandler(),
+  _StealTechWorkOrderHandler(),
+  _CounterSpyWorkOrderHandler(),
+  _ProspectWorkOrderHandler(),
+  _BuildImprovementWorkOrderHandler(),
+  _ExploreWorkOrderHandler(),
+  _RemainingStandardBuildTargetsWorkOrderHandler(),
+];
+
 BuildWorkState runWorkPhase(
   BuildWorkState state,
   BuildWorkState Function(BuildWorkState, Unit, String) applyExploreCompletion,
@@ -28,180 +341,29 @@ BuildWorkState runWorkPhase(
   var current = state;
 
   for (final player in current.game.players) {
-    var stockpile = player.stockpile;
-    var workers = player.workerPool;
-    var treasury = player.treasury;
-    var purchasedTiles = Map<String, String>.from(
-      current.work.purchasedTilesByTileKey,
-    );
-
-    Unit? lookupUnit(String unitId) =>
-        current.work.oldUnitsById[unitId] ?? current.work.newUnitsById[unitId];
-
-    void updateUnit(String unitId, Unit updated) {
-      if (current.work.oldUnitsById.containsKey(unitId)) {
-        current = current.copyWith(
-          work: current.work.copyWith(
-            oldUnitsById: Map<String, Unit>.from(current.work.oldUnitsById)
-              ..[unitId] = updated,
-          ),
-        );
-      } else {
-        current = current.copyWith(
-          work: current.work.copyWith(
-            newUnitsById: Map<String, Unit>.from(current.work.newUnitsById)
-              ..[unitId] = updated,
-          ),
-        );
-      }
-    }
-
-    String regionForUnit(String unitId) =>
-        current.work.oldUnitsById.containsKey(unitId)
-            ? kRegionOldWorld
-            : kRegionNewWorld;
-
-    Province? provinceById(String id) =>
-        current.game.worldState.tryGetProvince(id);
-
-    bool canAffordMaterialCost(WorkOrderCost cost) {
-      for (final e in cost.entries) {
-        if (stockpile.quantityOf(e.key) < e.value) return false;
-      }
-      return true;
-    }
-
-    void deductMaterialCost(WorkOrderCost cost) {
-      for (final e in cost.entries) {
-        stockpile = stockpile.applyDelta(e.key, -e.value);
-      }
-    }
+    final context = _WorkOrderExecutionContext(state: current, player: player);
 
     for (final order in workOrders[player.id] ?? const []) {
-      final u = lookupUnit(order.unitId);
+      final u = context.lookupUnit(order.unitId);
       if (u == null) continue;
       final targetTileKey = order.targetTileKey;
       final hasValidTarget = targetTileKey.isNotEmpty;
-
-      if (order.target == kWorkTargetPurchaseLand &&
-          isWorkOrderTargetAllowedForUnitType(
-            u.type,
-            kWorkTargetPurchaseLand,
-          ) &&
-          u.currentWork == null &&
-          hasValidTarget) {
-        final land = applyPurchaseLandWorkOrder(
-          state: current,
-          player: player,
-          unit: u,
-          targetTileKey: targetTileKey,
-          treasury: treasury,
-          purchasedTilesByTileKey: purchasedTiles,
-          provinceById: provinceById,
-          updateUnit: updateUnit,
-        );
-        treasury = land.treasury;
-        purchasedTiles = land.purchasedTilesByTileKey;
-        current = current.copyWith(
-          work: current.work.copyWith(purchasedTilesByTileKey: purchasedTiles),
-        );
-        continue;
-      }
-
-      if (order.target == kWorkTargetStealTech &&
-          tryAssignStealTechWorkOrder(
-            order: order,
-            unit: u,
-            targetTileKey: targetTileKey,
-            updateUnit: updateUnit,
-          )) {
-        continue;
-      }
-
-      if (order.target == kWorkTargetCounterSpy &&
-          tryAssignCounterSpyWorkOrder(
-            order: order,
-            unit: u,
-            targetTileKey: targetTileKey,
-            updateUnit: updateUnit,
-          )) {
-        continue;
-      }
-
-      if (order.target == kWorkTargetProspect) {
-        current = current.copyWith(
-          game: tryApplyProspectWorkOrder(
-            game: current.game,
-            tileMapByRegion: current.tileMapByRegion,
-            player: player,
-            unit: u,
-            targetTileKey: targetTileKey,
-            updateUnit: updateUnit,
-          ),
-        );
-      }
-      if (order.target == kWorkTargetBuildImprovement) {
-        if (applyStandardWorkOrder(
-          order: order,
-          unit: u,
-          targetTileKey: targetTileKey,
-          hasValidTarget: hasValidTarget,
-          orderTarget: kWorkTargetBuildImprovement,
-          tileState: current.work.tileState,
-          provinceById: provinceById,
-          canAffordMaterialCost: canAffordMaterialCost,
-          deductMaterialCost: deductMaterialCost,
-          updateUnit: updateUnit,
+      for (final handler in _workOrderHandlers) {
+        if (!handler.supports(order.target)) continue;
+        if (handler.tryApply(
+          context,
+          order,
+          u,
+          targetTileKey,
+          hasValidTarget,
         )) {
-          continue;
+          break;
         }
-      }
-      if (order.target == kWorkTargetExplore &&
-          isExplorerUnit(u.type) &&
-          u.currentWork == null &&
-          hasValidTarget) {
-        if (tryApplyExploreWorkOrder(
-          game: current.game,
-          order: order,
-          unit: u,
-          targetTileKey: targetTileKey,
-          regionForUnit: regionForUnit,
-          updateUnit: updateUnit,
-        )) {
-          continue;
-        }
-      }
-      if (tryApplyRemainingStandardBuildTargets(
-        workTarget: order.target,
-        order: order,
-        player: player,
-        unit: u,
-        targetTileKey: targetTileKey,
-        hasValidTarget: hasValidTarget,
-        tileState: current.work.tileState,
-        provinceById: provinceById,
-        canAffordMaterialCost: canAffordMaterialCost,
-        deductMaterialCost: deductMaterialCost,
-        updateUnit: updateUnit,
-        terrain: terrainTypeForTileKey(current.tileMapByRegion, targetTileKey),
-      )) {
-        continue;
       }
     }
 
-    current = current.copyWith(
-      work: current.work.copyWith(
-        purchasedTilesByTileKey: purchasedTiles,
-        updatedPlayers: [
-          ...current.work.updatedPlayers,
-          player.copyWith(
-            stockpile: stockpile,
-            workerPool: workers,
-            treasury: treasury,
-          ),
-        ],
-      ),
-    );
+    context.persistPlayerSnapshot();
+    current = context.state;
   }
 
   return current;


### PR DESCRIPTION
## Summary
- refactors `runWorkPhase` to route each work target through a `_WorkOrderHandler` strategy registry instead of a long inline target switch/if chain
- introduces a dedicated execution context object to keep per-player scratch state (units, treasury, stockpile, purchased tiles) in one place
- preserves existing target-specific behavior by delegating to existing handler/helper functions (`purchase_land`, `prospect`, `explore`, and standard build targets)

## Scope
- Implements a **partial slice** of #1958 focused on work-phase orchestration in `orders_application_work_phase.dart`.
- Defers broader #1958 phases (turn-phase registry follow-ups, additional decoupling opportunities) to subsequent PRs.

## Test plan
- [x] `cd packages/colonizethis_logic && dart test test/orders_application_work_order_application_part1_test.dart test/orders_application_work_order_application_part2_test.dart test/orders_application_work_order_application_part3_test.dart`

Refs #1958

Made with [Cursor](https://cursor.com)