### PR TITLE
fix(data): remove raw map casts in map topology (Refs #1912)

### DIFF
--- a/packages/colonizethis_data/lib/src/map_topology.dart
+++ b/packages/colonizethis_data/lib/src/map_topology.dart
@@ -21,12 +21,16 @@ class MapTopology {
     final edgesList = json[_keyEdges] as List<dynamic>? ?? [];
     final edges = edgesList.map<TopologyEdge>((e) {
       if (e is List<dynamic>) return TopologyEdge.fromJsonList(e);
-      return TopologyEdge.fromJson(Map<String, dynamic>.from(e as Map));
+      return TopologyEdge.fromJson(
+        Map<String, dynamic>.from(e as Map<Object?, Object?>),
+      );
     }).toList();
     return MapTopology(
       nodes: nodesList
           .map(
-            (e) => TopologyNode.fromJson(Map<String, dynamic>.from(e as Map)),
+            (e) => TopologyNode.fromJson(
+              Map<String, dynamic>.from(e as Map<Object?, Object?>),
+            ),
           )
           .toList(),
       edges: edges,


### PR DESCRIPTION
## Summary
- Refactors `packages/colonizethis_data/lib/src/map_topology.dart` to replace raw `Map` casts in JSON parsing with explicit `Map<Object?, Object?>` conversions.
- Keeps parsing behavior unchanged while eliminating `strict_raw_types` violations in this load path.
- Implements one isolated compliance slice under issue #1912.

## Scope
- In scope: `colonizethis_data` map topology JSON cast cleanup.
- Deferred: remaining `strict_raw_types` violations in other packages/files tracked under #1912.

## Test plan
- [x] `dart test packages/colonizethis_data`
- [x] `dart run tool/check_disallowed_ast_patterns.dart --files=packages/colonizethis_data/lib/src/map_topology.dart`

Refs #1912

Made with [Cursor](https://cursor.com)