### PR TITLE
test: cover #2025 flip_province verification gaps

### DIFF
--- a/SPEC/ui/debug-console-panel.md
+++ b/SPEC/ui/debug-console-panel.md
@@ -50,3 +50,10 @@
 - Given panel input `/flip_province oldWorld New Bordeaux`, when the player submits and parser validation succeeds, then the system emits one `FlipDebugProvinceOwnershipEvent` with `regionId=oldWorld` and `provinceDisplayName=New Bordeaux`.
 - Given panel input `/flip_province oldWorld` or `/flip_province` with missing arguments, when the player submits, then the UI layer emits no `FlipDebugProvinceOwnershipEvent` and shows deterministic usage feedback.
 - Given panel input is focused and command history contains at least one command, when the player presses `ArrowUp` then `ArrowDown`, then the UI layer updates the input text to older/newer history entries in order.
+
+---
+
+## Automated verification (`/flip_province`)
+
+- **App handler and JSON persistence parity:** `app/test/app_event_handler_scope_test.dart` (`applyDebugFlipProvinceOwnership` — success, Orders-phase gate, unknown-to-human, already-owned, ambiguous name, not found, null owner, `Game.fromJson` / `toJson` round-trip).
+- **Logic downstream after canonical transfer:** `packages/colonizethis_logic/test/debug_flip_province_turn_downstream_test.dart` (`emitProvinceCapturedEvents`, `resolveConnectivity` via `runExtractionPhase`, `findMilitaryVictoryWinner`, `runEndOfTurnPhase`).

--- a/app/test/app_event_handler_scope_test.dart
+++ b/app/test/app_event_handler_scope_test.dart
@@ -466,5 +466,175 @@ void main() {
       expect(result.game, isNull);
       expect(result.message, contains('unknown to human player'));
     });
+
+    test('rejects already human-owned province', () {
+      final game = _baseGame(
+        phase: TurnPhase.orders,
+        ownerId: 'human_1',
+        humanVisibility: 'fogged',
+      );
+      const event = FlipDebugProvinceOwnershipEvent(
+        humanPlayerId: 'human_1',
+        regionId: 'oldWorld',
+        provinceDisplayName: 'New Bordeaux',
+      );
+
+      final result = applyDebugFlipProvinceOwnership(
+        currentGame: game,
+        event: event,
+        combinedTopology: const MapTopology(),
+      );
+
+      expect(result.game, isNull);
+      expect(result.message, contains('already human-owned'));
+    });
+
+    test('rejects ambiguous province display name in region', () {
+      final game = Game(
+        id: 'g-flip-amb',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(
+                id: 'oldWorld|P1',
+                regionId: 'oldWorld',
+                ownerId: 'ai_1',
+                displayName: 'New Bordeaux',
+              ),
+              Province(
+                id: 'oldWorld|P2',
+                regionId: 'oldWorld',
+                ownerId: 'ai_1',
+                displayName: 'new bordeaux',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: const {
+            'oldWorld': {
+              'P1': ['oldWorld|P1|0|0'],
+              'P2': ['oldWorld|P2|0|0'],
+            },
+          },
+          playerVisibilityByTile: {
+            'human_1': {
+              'oldWorld|P1|0|0': 'fogged',
+              'oldWorld|P2|0|0': 'fogged',
+            },
+          },
+        ),
+        players: const [
+          Player(id: 'human_1', displayName: 'Human', isHuman: true),
+          Player(id: 'ai_1', displayName: 'AI', isHuman: false),
+        ],
+      );
+      const event = FlipDebugProvinceOwnershipEvent(
+        humanPlayerId: 'human_1',
+        regionId: 'oldWorld',
+        provinceDisplayName: 'New Bordeaux',
+      );
+
+      final result = applyDebugFlipProvinceOwnership(
+        currentGame: game,
+        event: event,
+        combinedTopology: const MapTopology(),
+      );
+
+      expect(result.game, isNull);
+      expect(result.message, contains('ambiguous'));
+    });
+
+    test('rejects province display name not found in region', () {
+      final game = _baseGame(
+        phase: TurnPhase.orders,
+        ownerId: 'ai_1',
+        humanVisibility: 'fogged',
+      );
+      const event = FlipDebugProvinceOwnershipEvent(
+        humanPlayerId: 'human_1',
+        regionId: 'oldWorld',
+        provinceDisplayName: 'Nonexistent Province',
+      );
+
+      final result = applyDebugFlipProvinceOwnership(
+        currentGame: game,
+        event: event,
+        combinedTopology: const MapTopology(),
+      );
+
+      expect(result.game, isNull);
+      expect(result.message, contains('not found'));
+    });
+
+    test('rejects province with no current owner', () {
+      final game = Game(
+        id: 'g-flip-null-owner',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(
+                id: 'oldWorld|P1',
+                regionId: 'oldWorld',
+                ownerId: null,
+                displayName: 'New Bordeaux',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: const {
+            'oldWorld': {
+              'P1': ['oldWorld|P1|0|0'],
+            },
+          },
+          playerVisibilityByTile: {
+            'human_1': {'oldWorld|P1|0|0': 'fogged'},
+          },
+        ),
+        players: const [
+          Player(id: 'human_1', displayName: 'Human', isHuman: true),
+          Player(id: 'ai_1', displayName: 'AI', isHuman: false),
+        ],
+      );
+      const event = FlipDebugProvinceOwnershipEvent(
+        humanPlayerId: 'human_1',
+        regionId: 'oldWorld',
+        provinceDisplayName: 'New Bordeaux',
+      );
+
+      final result = applyDebugFlipProvinceOwnership(
+        currentGame: game,
+        event: event,
+        combinedTopology: const MapTopology(),
+      );
+
+      expect(result.game, isNull);
+      expect(result.message, contains('no current owner'));
+    });
+
+    test('JSON round-trip preserves flip outcome (persistence parity)', () {
+      final game = _baseGame(
+        phase: TurnPhase.orders,
+        ownerId: 'ai_1',
+        humanVisibility: 'fogged',
+      );
+      const event = FlipDebugProvinceOwnershipEvent(
+        humanPlayerId: 'human_1',
+        regionId: 'oldWorld',
+        provinceDisplayName: 'New Bordeaux',
+      );
+
+      final result = applyDebugFlipProvinceOwnership(
+        currentGame: game,
+        event: event,
+        combinedTopology: const MapTopology(),
+      );
+
+      expect(result.game, isNotNull);
+      final restored = Game.fromJson(result.game!.toJson());
+      expect(restored.worldState.oldWorld.provinces.single.ownerId, 'human_1');
+      expect(restored.worldState.oldWorld.units.single.ownerId, 'human_1');
+    });
   });
 }

--- a/packages/colonizethis_logic/test/debug_flip_province_turn_downstream_test.dart
+++ b/packages/colonizethis_logic/test/debug_flip_province_turn_downstream_test.dart
@@ -1,0 +1,155 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logic/src/constants.dart';
+import 'package:colonizethis_logic/src/turn/end_of_turn_resolver.dart';
+import 'package:colonizethis_logic/src/turn/phases/extraction_phase.dart';
+import 'package:colonizethis_logic/src/turn/turn_resolution_events.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+/// Regression for GitHub #2025 AC: after command-style canonical ownership
+/// transfer, persistence round-trip and named turn-resolution hooks stay usable
+/// (emitProvinceCapturedEvents, resolveConnectivity via extraction,
+/// findMilitaryVictoryWinner, runEndOfTurnPhase distant/coastal fog passes).
+void main() {
+  group('Debug flip province (#2025) post-transfer turn downstream', () {
+    const pid = '$kRegionOldWorld|p1';
+    const tileKey = '$kRegionOldWorld|p1|1|1';
+
+    Game gameBeforeFlip() {
+      return Game(
+        id: 'g-flip-downstream',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
+          oldWorld: RegionData(
+            provinces: [
+              Province(
+                id: pid,
+                regionId: kRegionOldWorld,
+                ownerId: 'ai_1',
+                displayName: 'New Bordeaux',
+              ),
+            ],
+            units: [
+              Unit(
+                id: 'r1',
+                type: 'musketeers',
+                ownerId: 'ai_1',
+                locationProvinceId: pid,
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: const {
+            kRegionOldWorld: {
+              'p1': [tileKey],
+            },
+          },
+          playerVisibilityByTile: {
+            'human_1': {tileKey: VisibilityLevel.fogged.name},
+            'ai_1': {tileKey: VisibilityLevel.fullyVisible.name},
+          },
+        ),
+        players: const [
+          Player(
+            id: 'human_1',
+            displayName: 'Human',
+            isHuman: true,
+            capitalProvinceId: pid,
+            capitalTile: CapitalTile(
+              regionId: kRegionOldWorld,
+              provinceId: pid,
+              x: 1,
+              y: 1,
+            ),
+          ),
+          Player(id: 'ai_1', displayName: 'AI', isHuman: false),
+        ],
+      );
+    }
+
+    Map<String, String?> ownershipSnapshot(Game g) {
+      final m = <String, String?>{};
+      for (final p in g.worldState.oldWorld.provinces) {
+        m[p.id] = p.ownerId;
+      }
+      for (final p in g.worldState.newWorld.provinces) {
+        m[p.id] = p.ownerId;
+      }
+      return m;
+    }
+
+    test(
+      'canonical transfer JSON round-trip and downstream phase hooks stay coherent',
+      () {
+        final before = gameBeforeFlip();
+        final previous = ownershipSnapshot(before);
+
+        final out = applyCanonicalSingleProvinceOwnershipTransferWithResult(
+          before,
+          targetProvinceId: pid,
+          oldOwnerId: 'ai_1',
+          newOwnerId: 'human_1',
+        );
+        final flipped = out.game;
+
+        final rt = Game.fromJson(flipped.toJson());
+        expect(rt.worldState.oldWorld.provinces.single.ownerId, 'human_1');
+        expect(
+          rt.worldState.oldWorld.units.singleWhere((u) => u.id == 'r1').ownerId,
+          'human_1',
+        );
+
+        final captured = <GameEvent>[];
+        emitProvinceCapturedEvents(
+          previous,
+          flipped,
+          before.worldState.turnState.turnNumber,
+          null,
+          captured.add,
+          null,
+        );
+        expect(captured, hasLength(1));
+        final pe = captured.single as ProvinceCapturedEvent;
+        expect(pe.provinceId, pid);
+        expect(pe.previousOwnerId, 'ai_1');
+        expect(pe.newOwnerId, 'human_1');
+
+        expect(findMilitaryVictoryWinner(flipped), isNull);
+
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'p1',
+              regionId: kRegionOldWorld,
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: const [],
+        );
+        final grid = [
+          ['p1', 'p1', 'p1'],
+          ['p1', 'p1', 'p1'],
+          ['p1', 'p1', 'p1'],
+        ];
+        final tileMap = TileMapResult(width: 3, height: 3, grid: grid);
+        final afterExtract = runExtractionPhase(flipped, topology, {
+          kRegionOldWorld: tileMap,
+        }, const <String, Map<CommodityId, int>>{});
+        expect(
+          afterExtract.worldState.oldWorld.provinces.single.ownerId,
+          'human_1',
+        );
+
+        final afterEot = runEndOfTurnPhase(
+          flipped,
+          topology: topology,
+          onDialogue: null,
+        );
+        expect(afterEot.worldState.turnState.turnNumber, 4);
+        expect(afterEot.worldState.turnState.phase, TurnPhase.orders);
+        expect(afterEot.victory, isNull);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Closes the test/SPEC gaps identified when verifying [GitHub #2025](https://github.com/waigore/colonizethisv3/issues/2025) (missing negative cases, persistence round-trip, and post-flip turn-downstream hooks).

## Changes
- **App:** `app/test/app_event_handler_scope_test.dart` — `applyDebugFlipProvinceOwnership`: already human-owned, ambiguous display name (case-insensitive match), display name not found, null province owner, and `Game.fromJson` / `toJson` round-trip after a successful flip.
- **Logic:** `packages/colonizethis_logic/test/debug_flip_province_turn_downstream_test.dart` — after `applyCanonicalSingleProvinceOwnershipTransferWithResult`, asserts JSON round-trip, `emitProvinceCapturedEvents`, `runExtractionPhase` (connectivity), `findMilitaryVictoryWinner`, and `runEndOfTurnPhase` on the post-transfer game.
- **SPEC:** `SPEC/ui/debug-console-panel.md` — "Automated verification" section listing the above test entrypoints.

## Tests run
- `dart test packages/colonizethis_logic/test/debug_flip_province_turn_downstream_test.dart`
- `flutter test app/test/app_event_handler_scope_test.dart`

## Notes
- Does **not** close #2025 (issue still depends on #2026 per issue text). No auto-close phrasing.

Refs #2025

Made with [Cursor](https://cursor.com)