### PR TITLE
Align custom-exceptions repo lint with no-waiver policy (Refs #1912)

### DIFF
--- a/SPEC/program/exception-enforcement.md
+++ b/SPEC/program/exception-enforcement.md
@@ -6,6 +6,8 @@ Prevent generic exception usage in domain runtime code and enforce domain-specif
 
 This spec defines a phased AST-based enforcement flow that is compatible with the current repository shape and CI workflow.
 
+**Umbrella policy:** `SPEC/program/repo-lint.md` forbids violation allowlists for `repo.*` rules. `repo.custom_exceptions` must not load keyed waiver YAML or other tables whose purpose is to waive failures for specific symbols or files while CI passes.
+
 ## Source Of Truth
 
 - Game logic behavior remains defined by `SPEC/game/**`.
@@ -52,7 +54,7 @@ The checker:
 2. Visits `ThrowExpression` nodes.
 3. Detects disallowed generic throws: `ArgumentError` / `Exception` as `InstanceCreationExpression` (e.g. `throw const ArgumentError(...)`) or as implicit-constructor `MethodInvocation` with a null target (e.g. `throw ArgumentError(...)` / `throw Exception(...)`), and `ArgumentError.value(...)` (static `MethodInvocation` on `ArgumentError`).
 4. Reports file + line + disallowed form for each violation.
-5. Fails CI on violations (Phase 2+ may introduce an explicit path allowlist for documented interop boundaries).
+5. Fails CI on violations. Any future broader thrown-type policy must follow `SPEC/program/repo-lint.md`: **scope-only** exclusions (whole paths, generated trees, env-gated scan roots) are allowed; **keyed** per-symbol or per-file waiver tables are not.
 
 ## Rollout Model
 
@@ -65,13 +67,13 @@ The checker:
 
 ### Phase 2+
 
-- Expand to broader thrown-type validation policy per domain (e.g. path glob → allowed base types).
+- Expand to broader thrown-type validation per domain using additional AST rules or closed declaration surfaces, without introducing keyed violation waivers (see `SPEC/program/repo-lint.md`).
 - Keep checker mandatory in CI and apply the same migration pattern to any newly introduced runtime packages.
 
 ## Acceptance Criteria
 
-- AST checker exists and runs from repository root.
-- The same rules are available as a `custom_lint` rule (`colonizethis_exception_lint`) in scoped packages so IDEs surface violations during normal analysis.
-- Checker scans all runtime domains listed above.
-- New generic exception throws fail checks unless explicitly allowlisted.
-- Setup domain migration uses `SetupValidationException` for validation failures.
+- Given repository root as cwd, when a maintainer runs `dart run tool/check_custom_exceptions.dart` (or `dart run tool/ct_repo_lint.dart` for rule `repo.custom_exceptions`), then the checker executes and exits `0` only when no scanned in-scope file contains a forbidden generic throw.
+- Given a workspace package `packages/*/lib/**/*.dart` file that contains `throw ArgumentError(...)`, `throw ArgumentError.value(...)`, or `throw Exception(...)`, when the checker scans that file, then the run fails and output includes that file path, line number, and the disallowed exception form.
+- Given a repository layout that includes a legacy keyed-waiver-shaped YAML file under `tool/` (for example a decoy `legacy_custom_exception_waiver_table.yaml`), when `runCheckCustomExceptions` runs, then the checker still fails if an in-scope file violates the policy, because no keyed waiver data is loaded.
+- Given the same rules are wired as `custom_lint` in workspace packages, when a developer analyzes scoped `lib/` code in the IDE, then diagnostics align with the CI checker for the same patterns.
+- Given setup validation code in `packages/colonizethis_logic/lib/src/setup/**`, when validation must signal failure, then it uses `SetupValidationException` (or another domain-specific type), not `ArgumentError` / `Exception` as defined in [Policy](#policy).

--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -22,6 +22,8 @@
 
 **Implementation status (GitHub #1912, tech id literals):** `repo.tech_id_constants` treats the string values of every `const String kTechId*` in `packages/colonizethis_data/lib/src/tech_ids.dart` as the canonical tech-id set (replacing the prior `tech_catalog.dart` map-key scrape). `tech_catalog.dart` uses those same constants for map keys and `TechDefinition` ids so the catalog stays aligned with the checker.
 
+**Implementation status (GitHub #1912, custom exceptions):** `repo.custom_exceptions` (`tool/check_custom_exceptions.dart` + `packages/colonizethis_exception_lint`) enforces the generic-throw ban on in-scope domain files only; it does **not** read keyed waiver YAML or per-symbol / per-file exemption tables. Whole-tree scope follows `collectRepoLintDomainDartFiles` / `shouldEnforceDomainExceptions` (generated suffixes and test-path skips are scope wiring, not violation waivers). Per-rule contract: `SPEC/program/exception-enforcement.md`.
+
 ### Acceptance criteria (policy)
 
 - Given a `repo.*` rule implementation, when a maintainer audits it for waiver data, then the maintainer finds no keyed tables loaded solely to raise effective limits for specific in-scope symbols or files.
@@ -156,6 +158,7 @@ Do **not** add new top-level `tool/check_*.dart` **entrypoints** for CI without 
 - Given the repository root as cwd, when CI runs `dart run tool/ct_repo_lint.dart` with the workflow env, then all manifest rules applicable to that job execute and failures surface with `rule_id` in the orchestrator banner.
 - Given a contributor adds a convention, when they follow CONTRIBUTING and this doc, then they register the rule in the manifest rather than adding a new standalone Quality workflow step for the same concern.
 - Given the [Policy: no violation allowlists](#policy-no-violation-allowlists-repo-lint) section, when `repo.function_size`, `repo.control_flow_nesting_depth`, or `repo.part_unit_size` runs, then that checker does not load keyed waiver data and the matching per-rule SPEC documents universal enforcement only.
+- Given the same policy section, when `repo.custom_exceptions` runs, then that checker does not load keyed waiver data and `SPEC/program/exception-enforcement.md` documents enforcement with scope-only skips (generated suffixes, test paths, and the shared domain file collector) only.
 - Given app game feature code, when `dart run tool/ct_repo_lint.dart` runs rule `repo.no_screen_in_game_widgets`, then no file matching `*_screen.dart` exists under `app/lib/features/game/widgets/**`.
 - Given app game widget Dart files under `app/lib/features/game/widgets/**`, when `dart run tool/ct_repo_lint.dart` runs rule `repo.game_widgets_file_size`, then each scanned file has at most 700 physical lines, the run fails listing each violating path when any file exceeds 700, and the checker does not load keyed waiver data.
 - Given repository Dart files excluding generated suffixes (`.g.dart`, `.freezed.dart`, `.mocks.dart`, `.gen.dart`) and generated app l10n paths under `app/lib/l10n/` matching the checker’s prefix list, when `dart run tool/ct_repo_lint.dart` runs rule `repo.dart_file_non_comment_line_size`, then each remaining scanned file has at most 1000 non-comment lines and the run fails while listing every violating file when any file is strictly greater than 1000.

--- a/test/check_custom_exceptions_test.dart
+++ b/test/check_custom_exceptions_test.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../tool/check_custom_exceptions.dart';
+
+void main() {
+  group('runCheckCustomExceptions', () {
+    test('fails when package lib contains throw Exception()', () {
+      final temp = Directory.systemTemp.createTempSync('custom-ex-');
+      try {
+        final libDir = Directory(
+          p.join(temp.path, 'packages', 'colonizethis_logic', 'lib', 'src'),
+        )..createSync(recursive: true);
+        File(p.join(libDir.path, 'bad.dart')).writeAsStringSync(r'''
+void f() {
+  throw Exception('nope');
+}
+''');
+
+        final errors = <String>[];
+        final exitCode = runCheckCustomExceptions(
+          temp.path,
+          info: (_) {},
+          err: errors.add,
+        );
+        expect(exitCode, 1);
+        expect(errors.join('\n'), contains('bad.dart'));
+        expect(errors.join('\n'), contains('Exception'));
+      } finally {
+        temp.deleteSync(recursive: true);
+      }
+    });
+
+    test(
+      'fails on violation; legacy keyed waiver YAML under tool/ is not read',
+      () {
+        final temp = Directory.systemTemp.createTempSync('custom-ex-legacy-');
+        try {
+          final libDir = Directory(
+            p.join(temp.path, 'packages', 'colonizethis_logic', 'lib', 'src'),
+          )..createSync(recursive: true);
+          File(p.join(libDir.path, 'bad.dart')).writeAsStringSync(r'''
+void f() {
+  throw Exception('nope');
+}
+''');
+          final toolDir = Directory(p.join(temp.path, 'tool'))
+            ..createSync(recursive: true);
+          File(
+            p.join(toolDir.path, 'legacy_custom_exception_waiver_table.yaml'),
+          ).writeAsStringSync('''
+# Decoy: historical repo-lint keyed waiver shape; checker must not load this.
+exempt_files:
+  - packages/colonizethis_logic/lib/src/bad.dart
+''');
+
+          final errors = <String>[];
+          final exitCode = runCheckCustomExceptions(
+            temp.path,
+            info: (_) {},
+            err: errors.add,
+          );
+          expect(exitCode, 1);
+          expect(errors.join('\n'), contains('bad.dart'));
+          expect(errors.join('\n'), contains('Exception'));
+        } finally {
+          temp.deleteSync(recursive: true);
+        }
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Phased slice for **#1912** (remove repo-lint grandfather allowlists): `repo.custom_exceptions` already enforced generic throws without reading keyed waiver YAML. This PR **locks that contract in SPEC**, removes **stale allowlist / Phase 2+ waiver** wording from `exception-enforcement.md`, and adds a **regression test** (decoy YAML under `tool/`) matching the pattern used for function-size / part-unit-size.

## Acceptance criteria (this PR)

- SPEC and umbrella `repo-lint.md` state that `repo.custom_exceptions` does not load keyed waiver tables; scope-only skips only.
- `exception-enforcement.md` ACs are test-targetable (Given–When–Then).
- Root test proves a legacy-shaped waiver file does not suppress violations.

## SPEC

- `SPEC/program/repo-lint.md` — implementation status + AC for `repo.custom_exceptions`
- `SPEC/program/exception-enforcement.md` — umbrella policy, rollout text, AC refresh

## Tests

- `dart pub get`
- `dart test test/check_custom_exceptions_test.dart`

## Out of scope

- Full #1912 completion (other rules / refactors) remains for follow-up PRs.

Refs #1912

Made with [Cursor](https://cursor.com)