### PR TITLE
infra: Daytona snapshot sizing and sandbox egress allowlist

### DIFF
--- a/SPEC/program/daytona-sandbox.md
+++ b/SPEC/program/daytona-sandbox.md
@@ -6,13 +6,14 @@ Authoritative operator contract for **`infra/build-daytona-snapshot`** and **`in
 
 - **linux/amd64** Ubuntu-based **tools-only** image: Flutter (`stable` resolved at **image build time**), Dart within root **`pubspec.yaml`** `environment.sdk`, Android SDK, Linux desktop build deps, **xvfb**, **git**, **gh**, **Cursor CLI** (`agent`), **OpenCode CLI** (`opencode` via npm global). **No** repository clone in the image.
 - **Clone after start** over **HTTPS** using **`GITHUB_TOKEN`** (and Daytona sandbox APIs).
+- **Egress:** **`run-sandbox-agent`** always sets **`network_block_all=False`** so DNS and arbitrary HTTPS work. When resolved CIDRs exist, it also sets **`network_allow_list`** (comma-separated **IPv4 /32**s, **max 10** per API) built from **public DNS resolvers** (**`1.1.1.1`**, **`1.0.0.1`**, **`8.8.8.8`**, **`8.8.4.4`**), optional **`DAYTONA_EXTRA_EGRESS_RESOLVER_IPV4`**, then **round-robin** one **A** record per Flutter/pub/GitHub hostname per wave (operator **`dig` / `getaddrinfo`**). If no host addresses resolve, **`network_allow_list`** is omitted. Override CIDRs with **`DAYTONA_FLUTTER_EGRESS_ALLOWLIST_CIDRS`** (truncated to **10**). If **`dart pub get`** still fails, widen the override list, extend **`infra/colonizethis_infra/network_allowlist.py`**, or fix org policy.
 - **Manual** snapshot lifecycle: operators run **`infra/build-daytona-snapshot`** to rebuild when toolchains should advance.
 
 ## Scripts (repo root relative)
 
 | Entry | Role |
 |-------|------|
-| **`infra/build-daytona-snapshot`** | Thin shim → **`python3 -m colonizethis_infra.build_daytona_snapshot`**. (1) `docker build --platform linux/amd64`. (2) Register a Daytona Snapshot via Python **`daytona.snapshot.create`** with **`on_logs`**. |
+| **`infra/build-daytona-snapshot`** | Thin shim → **`python3 -m colonizethis_infra.build_daytona_snapshot`**. (1) `docker build --platform linux/amd64`. (2) Register a Daytona Snapshot via Python **`daytona.snapshot.create`** with **`on_logs`**. Optional snapshot template sizing: pass **`--snapshot-cpu`**, **`--snapshot-memory-gib`**, and **`--snapshot-disk-gib`** together (maps to Daytona **`Resources`** on **`CreateSnapshotParams`**); omit all three for API defaults. |
 | **`infra/run-sandbox-agent`** | Thin shim → **`python3 -m colonizethis_infra.run_sandbox_agent`**. Create sandbox from snapshot → clone → run **Cursor** or **OpenCode** with the given prompt. |
 
 Install Python deps once per machine/CI: **`pip install -r infra/requirements.txt`** (see **`infra/README.md`**).
@@ -36,6 +37,8 @@ If **`AGENT`** or **`CT_AGENT`** is set (non-empty), **`run-sandbox-agent`** exi
 | **`DAYTONA_API_KEY`** | Required for Daytona API (build snapshot registration + run sandbox). |
 | **`DAYTONA_API_URL`**, **`DAYTONA_TARGET`** | Optional Daytona SDK overrides ([Configuration](https://www.daytona.io/docs/en/configuration.md)). |
 | **`DAYTONA_SNAPSHOT_NAME`** | Optional; default sticky name **`colonizethis-daytona-flutter-tools`** (constant in `infra/colonizethis_infra/constants.py`). |
+| **`DAYTONA_FLUTTER_EGRESS_ALLOWLIST_CIDRS`** | Optional; comma-separated IPv4 **CIDRs** for **`network_allow_list`** when creating the sandbox (bypasses hostname resolution). |
+| **`DAYTONA_EXTRA_EGRESS_RESOLVER_IPV4`** | Optional; comma-separated extra **DNS resolver** IPv4 addresses (no ``/32`` suffix) merged into the built-in resolver list—use when the sandbox ``resolv.conf`` lists nameservers not already covered (e.g. host-specific ``213.x``). |
 | **`GITHUB_TOKEN`** | HTTPS clone + `gh`. |
 | **`CURSOR_API_KEY`** | Required when backend is **cursor** (before invoking Cursor). |
 | **`OPENCODE_API_KEY`** | Required when backend is **opencode**. |
@@ -64,6 +67,7 @@ If **`AGENT`** or **`CT_AGENT`** is set (non-empty), **`run-sandbox-agent`** exi
 | **AC4** | `infra/test/test_ac4_cursor_api_key.py`. |
 | **AC5** | `infra/test/test_ac5_opencode_model.py`. |
 | **AC6** | `infra/test/test_ac6_flutter_doctor_integration.py` — **skipped** unless **`RUN_INFRA_FLUTTER_DOCTOR=1`** (optional slow / Docker). |
+| **AC7** | `infra/test/test_usage_missing_backend.py` + **`infra/test/test_network_allowlist.py`** — **`run-sandbox-agent`** uses **`network_block_all=False`** always; sets **`network_allow_list`** when resolved CIDRs or **`DAYTONA_FLUTTER_EGRESS_ALLOWLIST_CIDRS`** is non-empty, else omits **`network_allow_list`**. |
 
 **CI:** In **`.github/workflows/quality.yml`**, the **`quality`** job runs **`pytest infra/test`** only when the **`infra_daytona`** path filter is true (**`infra/**`** changed); Dart/app gates continue to use the existing **`tests`** filter.
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -48,3 +48,10 @@ Optional **`RUN_INFRA_FLUTTER_DOCTOR=1`**: slow integration that runs `flutter d
 ## Optional operator workflow
 
 To push a **local** image instead of declarative `Image.from_dockerfile`, see Daytona [Using local images](https://www.daytona.io/docs/snapshots.md#using-local-images) (`daytona snapshot push`). The repo’s primary path is the Python SDK (`build-daytona-snapshot` step 2).
+
+## Troubleshooting: `dart pub get` / pub.dev socket errors in a sandbox
+
+1. **`run-sandbox-agent`** sets **`network_block_all=False`** (open egress for DNS and pub). When CIDRs resolve, it also sends **`network_allow_list`** (up to **10** **IPv4 /32**s): **DNS** literals (**`1.1.1.1`**, **`1.0.0.1`**, **`8.8.8.8`**, **`8.8.4.4`**), optional **`DAYTONA_EXTRA_EGRESS_RESOLVER_IPV4`**, then **round-robin** A records across Flutter/pub/GitHub hostnames (see **`infra/colonizethis_infra/network_allowlist.py`**). If **`dig`** is missing, resolution uses **`getaddrinfo`** only. If **no** host IPs resolve, **`network_allow_list`** is omitted.
+2. **Extra DNS:** if the sandbox **``/etc/resolv.conf``** lists nameservers outside the built-in four (e.g. **``213.x``**), set **`DAYTONA_EXTRA_EGRESS_RESOLVER_IPV4`** to those comma-separated IPv4 addresses (no ``/32`` suffix).
+3. **Override:** set **`DAYTONA_FLUTTER_EGRESS_ALLOWLIST_CIDRS`** to a comma-separated CIDR list your org approves (pub/CDN edges change; widen if **`dart pub get`** still fails).
+4. If **`curl -I https://github.com`** works but **`curl -I https://pub.dev`** resets, the problem may be **upstream** to pub’s CDN, not the allowlist—coordinate with Daytona / org networking.

--- a/infra/colonizethis_infra/build_daytona_snapshot.py
+++ b/infra/colonizethis_infra/build_daytona_snapshot.py
@@ -55,7 +55,40 @@ def main(argv: list[str] | None = None) -> int:
         default=os.environ.get("DAYTONA_SNAPSHOT_NAME", DEFAULT_DAYTONA_SNAPSHOT_NAME).strip(),
         help="Daytona Snapshot name (default from DAYTONA_SNAPSHOT_NAME or built-in default).",
     )
+    p.add_argument(
+        "--snapshot-cpu",
+        type=int,
+        default=None,
+        help="Snapshot template CPU cores (use with --snapshot-memory-gib and --snapshot-disk-gib).",
+    )
+    p.add_argument(
+        "--snapshot-memory-gib",
+        type=int,
+        default=None,
+        help="Snapshot template RAM in GiB.",
+    )
+    p.add_argument(
+        "--snapshot-disk-gib",
+        type=int,
+        default=None,
+        help="Snapshot template disk in GiB.",
+    )
     ns = p.parse_args(argv)
+
+    sizing = (ns.snapshot_cpu, ns.snapshot_memory_gib, ns.snapshot_disk_gib)
+    if any(v is not None for v in sizing):
+        if any(v is None for v in sizing):
+            print(
+                "Snapshot sizing: pass all three of --snapshot-cpu, "
+                "--snapshot-memory-gib, --snapshot-disk-gib, or omit all for defaults.",
+                file=sys.stderr,
+            )
+            return 1
+        from daytona import Resources
+
+        snapshot_resources = Resources(cpu=ns.snapshot_cpu, memory=ns.snapshot_memory_gib, disk=ns.snapshot_disk_gib)
+    else:
+        snapshot_resources = None
 
     if not ns.skip_docker:
         _docker_build(image_tag=ns.image_tag)
@@ -87,6 +120,7 @@ def main(argv: list[str] | None = None) -> int:
         snapshot_name=ns.snapshot_name,
         dockerfile_path=dockerfile,
         on_logs=on_logs,
+        resources=snapshot_resources,
     )
     print(f"Registered Daytona snapshot: {ns.snapshot_name}", file=sys.stderr)
     return 0

--- a/infra/colonizethis_infra/network_allowlist.py
+++ b/infra/colonizethis_infra/network_allowlist.py
@@ -1,0 +1,169 @@
+"""Resolve Flutter / pub / GitHub hostnames to IPv4 CIDRs for Daytona ``network_allow_list``.
+
+Daytona accepts comma-separated **CIDRs**, not DNS names. We resolve well-known
+hosts used by ``dart pub``, Flutter artifact fetches, and ``git clone`` over
+HTTPS, then emit ``<ip>/32`` entries (de-duplicated).
+
+Daytona caps ``network_allow_list`` at **10** entries. After built-in DNS
+``/32``s (and optional extras from env), we add **one A record per hostname per
+wave** (round-robin) so **pub** and **GitHub** both appear before deeper waves
+fill from the same hosts.
+
+**``run-sandbox-agent``** passes this string with **`network_block_all=False`**
+so resolvers and pub.dev work; the allowlist still documents preferred egress
+CIDRs for org policy where Daytona honors it alongside open egress.
+
+Resolution runs on the **operator machine** (where ``run-sandbox-agent`` runs).
+IPs seen from your resolver may differ from those the sandbox hits; use
+``DAYTONA_FLUTTER_EGRESS_ALLOWLIST_CIDRS`` to paste org-approved CIDRs when
+needed.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+from collections.abc import Iterable
+
+# Daytona API: "Network allow list cannot contain more than 10 networks"
+_MAX_ALLOWLIST_CIDRS = 10
+
+# When ``network_block_all=True``, the sandbox still needs **DNS** reachability;
+# literal resolver IPs avoid a chicken-and-egg with hostname-derived CIDRs.
+# Order: match common Docker ``resolv.conf`` (Cloudflare first), then Google.
+_DNS_RESOLVER_IPV4: tuple[str, ...] = (
+    "1.1.1.1",
+    "1.0.0.1",
+    "8.8.8.8",
+    "8.8.4.4",
+)
+
+# Hostnames commonly hit for clone + ``dart pub get`` + Flutter tooling.
+# ``github.com`` / ``codeload`` early so the first round-robin wave covers clone.
+FLUTTER_PUB_EGRESS_HOSTS: tuple[str, ...] = (
+    "pub.dev",
+    "api.pub.dev",
+    "github.com",
+    "api.github.com",
+    "codeload.github.com",
+    "objects.githubusercontent.com",
+    "raw.githubusercontent.com",
+    "storage.googleapis.com",
+)
+
+
+def _is_ipv4(addr: str) -> bool:
+    parts = addr.split(".")
+    if len(parts) != 4:
+        return False
+    try:
+        return all(0 <= int(p) <= 255 for p in parts)
+    except ValueError:
+        return False
+
+
+def _dig_a_records(host: str) -> set[str]:
+    try:
+        proc = subprocess.run(
+            ["dig", "+short", host, "A"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return set()
+    ips: set[str] = set()
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if line and _is_ipv4(line):
+            ips.add(line)
+    return ips
+
+
+def _getaddrinfo_ipv4(host: str) -> set[str]:
+    ips: set[str] = set()
+    try:
+        infos = socket.getaddrinfo(host, 443, socket.AF_INET, socket.SOCK_STREAM)
+    except OSError:
+        return ips
+    for _fam, _typ, _proto, _canon, sockaddr in infos:
+        if len(sockaddr) < 1:
+            continue
+        ip = str(sockaddr[0])
+        if _is_ipv4(ip):
+            ips.add(ip)
+    return ips
+
+
+def ipv4_addresses_for_host(host: str) -> set[str]:
+    """Combine ``dig`` A records (when available) with ``getaddrinfo``."""
+    return _dig_a_records(host) | _getaddrinfo_ipv4(host)
+
+
+def ipv4_cidrs_for_hosts(hosts: Iterable[str]) -> str:
+    """Return comma-separated ``<ipv4>/32`` list, sorted, de-duplicated."""
+    found: set[str] = set()
+    for host in hosts:
+        found |= ipv4_addresses_for_host(host)
+    return ",".join(f"{ip}/32" for ip in sorted(found))
+
+
+def truncate_cidr_allowlist_csv(value: str, *, max_parts: int = _MAX_ALLOWLIST_CIDRS) -> str:
+    """Daytona rejects more than ``max_parts`` comma-separated CIDR tokens."""
+    parts = [p.strip() for p in value.split(",") if p.strip()]
+    return ",".join(parts[: max(1, min(max_parts, _MAX_ALLOWLIST_CIDRS))])
+
+
+def _extra_resolver_ips_from_env() -> tuple[str, ...]:
+    """Optional ``DAYTONA_EXTRA_EGRESS_RESOLVER_IPV4`` (comma-separated), e.g. host ``resolv.conf`` nameservers."""
+    raw = os.environ.get("DAYTONA_EXTRA_EGRESS_RESOLVER_IPV4", "").strip()
+    if not raw:
+        return ()
+    return tuple(p.strip() for p in raw.split(",") if p.strip())
+
+
+def prioritized_ipv4_egress_cidrs(
+    hosts: tuple[str, ...] = FLUTTER_PUB_EGRESS_HOSTS,
+    *,
+    extra_resolver_ips: tuple[str, ...] | None = None,
+    max_entries: int = _MAX_ALLOWLIST_CIDRS,
+) -> str:
+    """Up to ``max_entries`` ``/32`` CIDRs: DNS resolvers first, then round-robin host A records."""
+    seen: set[str] = set()
+    cidrs: list[str] = []
+    cap = max(1, min(max_entries, _MAX_ALLOWLIST_CIDRS))
+    extra = extra_resolver_ips if extra_resolver_ips is not None else _extra_resolver_ips_from_env()
+    dns_chain = tuple(dict.fromkeys((*_DNS_RESOLVER_IPV4, *extra)))
+    for ip in dns_chain:
+        if not _is_ipv4(ip) or ip in seen:
+            continue
+        seen.add(ip)
+        cidrs.append(f"{ip}/32")
+        if len(cidrs) >= cap:
+            return ",".join(cidrs)
+    wave = 0
+    while len(cidrs) < cap:
+        progressed = False
+        for host in hosts:
+            if len(cidrs) >= cap:
+                break
+            ips_sorted = sorted(ipv4_addresses_for_host(host))
+            if wave >= len(ips_sorted):
+                continue
+            ip = ips_sorted[wave]
+            if ip in seen:
+                continue
+            seen.add(ip)
+            cidrs.append(f"{ip}/32")
+            progressed = True
+        if not progressed:
+            break
+        wave += 1
+    return ",".join(cidrs)
+
+
+def flutter_pub_egress_allowlist_cidrs() -> str:
+    """CIDR string for ``CreateSandboxFromSnapshotParams.network_allow_list``."""
+    return prioritized_ipv4_egress_cidrs(FLUTTER_PUB_EGRESS_HOSTS)

--- a/infra/colonizethis_infra/run_sandbox_agent.py
+++ b/infra/colonizethis_infra/run_sandbox_agent.py
@@ -107,14 +107,35 @@ def run_pipeline(
     if cerr or target is None:
         return 1, cerr or "Clone target unresolved."
 
+    from colonizethis_infra.network_allowlist import (
+        flutter_pub_egress_allowlist_cidrs as _resolve_egress_cidrs,
+        truncate_cidr_allowlist_csv,
+    )
     from daytona import CreateSandboxFromSnapshotParams
 
     daytona = daytona_factory()
-    params = CreateSandboxFromSnapshotParams(
-        snapshot=_snapshot_name(),
-        env_vars={},
-        auto_stop_interval=0,
-    )
+    allow = os.environ.get("DAYTONA_FLUTTER_EGRESS_ALLOWLIST_CIDRS", "").strip()
+    if allow:
+        allow = truncate_cidr_allowlist_csv(allow)
+    else:
+        allow = _resolve_egress_cidrs()
+    if allow:
+        # Allowlist CIDRs for pub/GitHub edges while keeping general egress open so
+        # DNS (UDP) and other endpoints work; Daytona still receives the whitelist for policy.
+        params = CreateSandboxFromSnapshotParams(
+            snapshot=_snapshot_name(),
+            env_vars={},
+            auto_stop_interval=0,
+            network_block_all=False,
+            network_allow_list=allow,
+        )
+    else:
+        params = CreateSandboxFromSnapshotParams(
+            snapshot=_snapshot_name(),
+            env_vars={},
+            auto_stop_interval=0,
+            network_block_all=False,
+        )
     sandbox = daytona.create(params, timeout=0)
     sandbox.wait_for_sandbox_start(timeout=0)
 

--- a/infra/colonizethis_infra/snapshot_register.py
+++ b/infra/colonizethis_infra/snapshot_register.py
@@ -13,10 +13,16 @@ def register_tools_snapshot(
     snapshot_name: str,
     dockerfile_path: Path,
     on_logs: Callable[[str], None],
+    resources: Any | None = None,
 ) -> Any:
-    """Call `daytona.snapshot.create` with declarative image from Dockerfile."""
+    """Call `daytona.snapshot.create` with declarative image from Dockerfile.
+
+    When ``resources`` is set (Daytona ``Resources``), sandboxes created from this
+    snapshot use that CPU / memory (GiB) / disk (GiB) template unless the API
+    overrides it.
+    """
     from daytona import CreateSnapshotParams, Image
 
     image = Image.from_dockerfile(str(dockerfile_path))
-    params = CreateSnapshotParams(name=snapshot_name, image=image)
+    params = CreateSnapshotParams(name=snapshot_name, image=image, resources=resources)
     return daytona.snapshot.create(params, on_logs=on_logs)

--- a/infra/test/test_ac2_snapshot_register.py
+++ b/infra/test/test_ac2_snapshot_register.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from daytona import Resources
+
 from colonizethis_infra.constants import DEFAULT_DAYTONA_SNAPSHOT_NAME
 from colonizethis_infra.snapshot_register import register_tools_snapshot
 
@@ -36,3 +38,21 @@ def test_register_tools_snapshot_calls_create_with_params() -> None:
     from daytona import Image
 
     assert isinstance(params.image, Image)
+    assert params.resources is None
+
+
+def test_register_tools_snapshot_passes_resources_when_provided() -> None:
+    daytona = MagicMock()
+    dockerfile = Path(__file__).resolve().parent.parent / "Dockerfile"
+    res = Resources(cpu=2, memory=4, disk=8)
+
+    register_tools_snapshot(
+        daytona,
+        snapshot_name="ct_dev_base",
+        dockerfile_path=dockerfile,
+        on_logs=lambda _c: None,
+        resources=res,
+    )
+
+    params = daytona.snapshot.create.call_args.args[0]
+    assert params.resources == res

--- a/infra/test/test_network_allowlist.py
+++ b/infra/test/test_network_allowlist.py
@@ -1,0 +1,98 @@
+"""Unit tests for Daytona egress CIDR resolution (Refs #2065)."""
+
+from __future__ import annotations
+
+import pytest
+
+from colonizethis_infra import network_allowlist
+
+
+def test_truncate_cidr_allowlist_csv() -> None:
+    s = ",".join(f"{i}.0.0.0/32" for i in range(20))
+    out = network_allowlist.truncate_cidr_allowlist_csv(s)
+    assert len(out.split(",")) == 10
+
+
+def test_prioritized_round_robin_dns_then_hosts(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_ips(host: str) -> set[str]:
+        if host == "pub.dev":
+            return {f"10.0.0.{i}" for i in range(1, 20)}
+        if host == "github.com":
+            return {"20.0.0.1"}
+        return set()
+
+    monkeypatch.setattr(network_allowlist, "ipv4_addresses_for_host", fake_ips)
+    out = network_allowlist.prioritized_ipv4_egress_cidrs(
+        ("pub.dev", "github.com"),
+        extra_resolver_ips=(),
+    )
+    parts = out.split(",")
+    assert len(parts) == 10
+    assert parts[:4] == ["1.1.1.1/32", "1.0.0.1/32", "8.8.8.8/32", "8.8.4.4/32"]
+    assert "20.0.0.1/32" in parts
+    assert parts[-1].startswith("10.0.0.")
+
+
+def test_ipv4_cidrs_for_hosts_dedupes_and_sorts(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_ips(host: str) -> set[str]:
+        if host == "a.example":
+            return {"10.0.0.2", "10.0.0.1"}
+        if host == "b.example":
+            return {"10.0.0.1"}
+        return set()
+
+    monkeypatch.setattr(network_allowlist, "ipv4_addresses_for_host", fake_ips)
+    out = network_allowlist.ipv4_cidrs_for_hosts(("a.example", "b.example"))
+    assert out == "10.0.0.1/32,10.0.0.2/32"
+
+
+def test_run_pipeline_respects_daytona_flutter_egress_allowlist_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from colonizethis_infra import run_sandbox_agent
+
+    monkeypatch.delenv("AGENT", raising=False)
+    monkeypatch.delenv("CT_AGENT", raising=False)
+    monkeypatch.setenv("SANDBOX_AGENT", "opencode")
+    monkeypatch.setenv("OPENCODE_API_KEY", "k")
+    monkeypatch.setenv("DAYTONA_API_KEY", "d")
+    monkeypatch.setenv("GITHUB_TOKEN", "t")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
+    monkeypatch.setenv("DAYTONA_FLUTTER_EGRESS_ALLOWLIST_CIDRS", "203.0.113.7/32")
+
+    captured: list[object] = []
+
+    class _Sb:
+        def wait_for_sandbox_start(self, timeout: float | None = None) -> None:
+            return None
+
+        @property
+        def git(self) -> object:
+            return self
+
+        def clone(self, **kwargs: object) -> None:
+            return None
+
+        @property
+        def process(self) -> object:
+            return self
+
+        def exec(self, command: str, cwd: str | None = None, env: dict[str, str] | None = None) -> object:
+            return type("R", (), {"exit_code": 0})()
+
+    class _D:
+        def create(self, params: object, timeout: float = 60) -> object:
+            captured.append(params)
+            return _Sb()
+
+    code, err = run_sandbox_agent.run_pipeline(
+        argv_agent=None,
+        cli_repo=None,
+        cli_ref=None,
+        prompt="p",
+        cwd=None,
+        daytona_factory=_D,
+    )
+    assert err is None
+    assert code == 0
+    p = captured[0]
+    assert p.network_block_all is False
+    assert p.network_allow_list == "203.0.113.7/32"

--- a/infra/test/test_usage_missing_backend.py
+++ b/infra/test/test_usage_missing_backend.py
@@ -76,3 +76,116 @@ def test_argv_agent_overrides_sandbox_agent(monkeypatch: pytest.MonkeyPatch) -> 
     assert err is None
     assert code == 0
     assert any("agent -p" in c for c in calls)
+
+
+def test_run_pipeline_sandbox_uses_allowlist_when_cidrs_resolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When CIDR allowlist is non-empty, pass it with network_block_all=False (DNS + pub.dev friendly)."""
+    monkeypatch.delenv("AGENT", raising=False)
+    monkeypatch.delenv("CT_AGENT", raising=False)
+    monkeypatch.delenv("DAYTONA_FLUTTER_EGRESS_ALLOWLIST_CIDRS", raising=False)
+    monkeypatch.setenv("SANDBOX_AGENT", "opencode")
+    monkeypatch.setenv("OPENCODE_API_KEY", "k")
+    monkeypatch.setenv("DAYTONA_API_KEY", "d")
+    monkeypatch.setenv("GITHUB_TOKEN", "t")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
+
+    monkeypatch.setattr(
+        "colonizethis_infra.network_allowlist.flutter_pub_egress_allowlist_cidrs",
+        lambda: "8.8.8.8/32,9.9.9.9/32",
+    )
+
+    captured: list[object] = []
+
+    class _Sb:
+        def wait_for_sandbox_start(self, timeout: float | None = None) -> None:
+            return None
+
+        @property
+        def git(self) -> object:
+            return self
+
+        def clone(self, **kwargs: object) -> None:
+            return None
+
+        @property
+        def process(self) -> object:
+            return self
+
+        def exec(self, command: str, cwd: str | None = None, env: dict[str, str] | None = None) -> object:
+            return type("R", (), {"exit_code": 0})()
+
+    class _D:
+        def create(self, params: object, timeout: float = 60) -> object:
+            captured.append(params)
+            return _Sb()
+
+    code, err = run_sandbox_agent.run_pipeline(
+        argv_agent=None,
+        cli_repo=None,
+        cli_ref=None,
+        prompt="p",
+        cwd=None,
+        daytona_factory=_D,
+    )
+    assert err is None
+    assert code == 0
+    assert len(captured) == 1
+    p = captured[0]
+    assert getattr(p, "network_block_all", None) is False
+    assert getattr(p, "network_allow_list", None) == "8.8.8.8/32,9.9.9.9/32"
+
+
+def test_run_pipeline_sandbox_opens_egress_when_allowlist_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If no CIDRs resolve, fall back to network_block_all=False (no allowlist string)."""
+    monkeypatch.delenv("AGENT", raising=False)
+    monkeypatch.delenv("CT_AGENT", raising=False)
+    monkeypatch.delenv("DAYTONA_FLUTTER_EGRESS_ALLOWLIST_CIDRS", raising=False)
+    monkeypatch.setenv("SANDBOX_AGENT", "opencode")
+    monkeypatch.setenv("OPENCODE_API_KEY", "k")
+    monkeypatch.setenv("DAYTONA_API_KEY", "d")
+    monkeypatch.setenv("GITHUB_TOKEN", "t")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
+
+    monkeypatch.setattr(
+        "colonizethis_infra.network_allowlist.flutter_pub_egress_allowlist_cidrs",
+        lambda: "",
+    )
+
+    captured: list[object] = []
+
+    class _Sb:
+        def wait_for_sandbox_start(self, timeout: float | None = None) -> None:
+            return None
+
+        @property
+        def git(self) -> object:
+            return self
+
+        def clone(self, **kwargs: object) -> None:
+            return None
+
+        @property
+        def process(self) -> object:
+            return self
+
+        def exec(self, command: str, cwd: str | None = None, env: dict[str, str] | None = None) -> object:
+            return type("R", (), {"exit_code": 0})()
+
+    class _D:
+        def create(self, params: object, timeout: float = 60) -> object:
+            captured.append(params)
+            return _Sb()
+
+    code, err = run_sandbox_agent.run_pipeline(
+        argv_agent=None,
+        cli_repo=None,
+        cli_ref=None,
+        prompt="p",
+        cwd=None,
+        daytona_factory=_D,
+    )
+    assert err is None
+    assert code == 0
+    p = captured[0]
+    assert getattr(p, "network_block_all", None) is False
+    assert getattr(p, "network_allow_list", None) in (None, "")


### PR DESCRIPTION
## Summary

Daytona tooling improvements for snapshot **Resources** and sandbox **network** behavior aligned with `SPEC/program/daytona-sandbox.md`.

### Snapshot build (`build_daytona_snapshot`)

- Optional `--snapshot-cpu`, `--snapshot-memory-gib`, `--snapshot-disk-gib` (all three required together) passed to `CreateSnapshotParams.resources` via `register_tools_snapshot`.

### Sandbox egress (`run_sandbox_agent`)

- New `network_allowlist.py`: builds up to **10** IPv4 `/32` CIDRs from pub/flutter/GitHub hostnames (operator `dig` / `getaddrinfo`), with DNS literals and round-robin waves so pub and GitHub both appear within the cap.
- Env: `DAYTONA_FLUTTER_EGRESS_ALLOWLIST_CIDRS` (override, truncated to 10), `DAYTONA_EXTRA_EGRESS_RESOLVER_IPV4` (extra resolver IPs from sandbox `/etc/resolv.conf`).
- **`network_block_all=False` always**; when CIDRs resolve, also set `network_allow_list` so general egress (DNS, pub) works while still sending a whitelist for org policy where Daytona applies it.

### Docs and tests

- `SPEC/program/daytona-sandbox.md`, `infra/README.md`, AC7; `test_ac2_snapshot_register` resources case; `test_network_allowlist.py`; pipeline tests updated.

## Testing

- `PYTHONPATH=infra python3 -m pytest infra/test/` — 25 passed, 1 skipped.

Refs #2065

Made with [Cursor](https://cursor.com)