### PR TITLE
Add CI repo-lint for logic dual-region province access (Refs #2071)

### DIFF
--- a/SPEC/program/logic-dual-region-province-access.md
+++ b/SPEC/program/logic-dual-region-province-access.md
@@ -1,0 +1,26 @@
+# Logic package: dual-region province field access (repo lint)
+
+**SPEC/program** — Enforces GitHub [#2071](https://github.com/waigore/colonizethis/issues/2071) guidance: avoid scattered `RegionData.provinces` walks via `worldState.oldWorld` / `worldState.newWorld` in `colonizethis_logic` production sources.
+
+## Policy
+
+- **Canonical implementation:** `packages/colonizethis_logic/lib/src/world/province_lookup.dart` may use `oldWorld.provinces` and `newWorld.provinces` to implement `allProvinces`, `WorldState.allProvinces()`, region-scoped lookup, and related helpers.
+- **Elsewhere under** `packages/colonizethis_logic/lib/src/**`: prefer `allProvinces(world)` or the `WorldState` province lookup extension methods so dual-region iteration stays centralized.
+- **Exceptions:** Old-World–only rules (e.g. military victory province counts, GP Old World redistribution) may still touch `oldWorld.provinces` directly when the GDD scope is explicitly Old World only. Such sites are counted toward the **global line budget** below so the total stays small and reviewable.
+
+## CI rule
+
+| Field | Value |
+|-------|--------|
+| `rule_id` | `repo.logic_dual_region_province_field_access` |
+| Checker | `tool/check_logic_dual_region_province_field_access.dart` |
+| Scan root | `packages/colonizethis_logic/lib/src/` (non-generated `.dart` only) |
+| Excluded file | `packages/colonizethis_logic/lib/src/world/province_lookup.dart` |
+| Budget | At most **10** physical source lines (total) outside the excluded file may contain the substring `oldWorld.provinces` or `newWorld.provinces`. |
+
+Raising the budget requires a SPEC update in this file and a maintainer-reviewed PR (same PR as the checker constant change).
+
+## Acceptance criteria
+
+- Given the repository at `dev` with `packages/colonizethis_logic/lib/src/**` sources, when CI runs `dart run tool/ct_repo_lint.dart` including rule `repo.logic_dual_region_province_field_access`, then the checker counts matching lines outside `province_lookup.dart` and the run passes when the count is at most 10.
+- Given a contributor adds an 11th matching line outside `province_lookup.dart` without updating the budget in this SPEC and the checker constant, when repo lint runs, then the run fails and lists each `path:line` hit.

--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -53,6 +53,7 @@
 | `tool/check_game_widgets_file_size.dart` | Enforce `app/lib/features/game/widgets/**` Dart files at **700 physical lines or fewer** — see `SPEC/program/game-widgets-file-size.md`; rule `repo.game_widgets_file_size` |
 | `tool/check_dart_file_non_comment_line_size.dart` | Enforce repository-wide Dart files at **1000 non-comment lines or fewer** (fail when strictly greater), excluding generated suffixes and generated l10n path prefixes — see `SPEC/program/dart-file-non-comment-line-size.md`; rule `repo.dart_file_non_comment_line_size` |
 | `tool/check_land_province_bucket_keys.dart` | For guarded explore/fog/news paths, disallow local-only land-province tile-bucket lookups (`tileKeysByRegionAndProvince[region]?[localId]`); require canonical full-id buckets only; rule `repo.land_province_bucket_keys` |
+| `tool/check_logic_dual_region_province_field_access.dart` | Caps direct `oldWorld.provinces` / `newWorld.provinces` references in `packages/colonizethis_logic/lib/src/**` outside `province_lookup.dart` (GitHub #2071); rule `repo.logic_dual_region_province_field_access` — see `SPEC/program/logic-dual-region-province-access.md` |
 
 ## Rule IDs and groups
 
@@ -169,3 +170,4 @@ Do **not** add new top-level `tool/check_*.dart` **entrypoints** for CI without 
 - Given any debug-console file imports `package:colonizethis_logic/src/**` or another `package:colonizethis_logic/...` URI outside that closed contract set, when repo lint runs rule `repo.debug_console_logic_contract_boundary`, then the run fails and reports file path, line, and disallowed import context in checker output.
 - Given `app/lib/core/services/app_event_handler_scope.dart` has no direct imports from `package:colonizethis_app/features/game/logic/**`, when repo lint runs rule `repo.app_event_handler_scope_logic_boundary`, then the rule passes without violations.
 - Given `app/lib/core/services/app_event_handler_scope.dart` directly imports any `package:colonizethis_app/features/game/logic/**` path, when repo lint runs rule `repo.app_event_handler_scope_logic_boundary`, then the run fails and reports file path and line number.
+- Given `packages/colonizethis_logic/lib/src/**` Dart sources excluding `world/province_lookup.dart`, when repo lint runs rule `repo.logic_dual_region_province_field_access`, then at most 10 physical lines contain `oldWorld.provinces` or `newWorld.provinces`, and the checker does not use keyed waiver tables (whole-file exclusion of the canonical helper only).

--- a/test/check_logic_dual_region_province_field_access_test.dart
+++ b/test/check_logic_dual_region_province_field_access_test.dart
@@ -1,0 +1,38 @@
+import 'package:test/test.dart';
+
+import '../tool/check_logic_dual_region_province_field_access.dart';
+
+void main() {
+  group('logicDualRegionProvinceFieldAccessLineMatches', () {
+    test('matches oldWorld.provinces', () {
+      expect(
+        logicDualRegionProvinceFieldAccessLineMatches(
+          'for (final p in game.worldState.oldWorld.provinces) {',
+        ),
+        isTrue,
+      );
+    });
+
+    test('matches newWorld.provinces', () {
+      expect(
+        logicDualRegionProvinceFieldAccessLineMatches(
+          'game.worldState.newWorld.provinces',
+        ),
+        isTrue,
+      );
+    });
+
+    test('ignores allProvinces', () {
+      expect(
+        logicDualRegionProvinceFieldAccessLineMatches(
+          'for (final p in allProvinces(game.worldState)) {',
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  test('current repo passes dual-region province field access gate', () {
+    expect(runCheckLogicDualRegionProvinceFieldAccess('.', info: (_) {}), 0);
+  });
+}

--- a/test/ct_repo_lint_test.dart
+++ b/test/ct_repo_lint_test.dart
@@ -27,6 +27,7 @@ void main() {
       expect(ids, contains('repo.game_widgets_file_size'));
       expect(ids, contains('repo.dart_file_non_comment_line_size'));
       expect(ids, contains('repo.land_province_bucket_keys'));
+      expect(ids, contains('repo.logic_dual_region_province_field_access'));
       expect(ids, contains('repo.app_hardcoded_ui_strings'));
       expect(
         rules

--- a/tool/check_logic_dual_region_province_field_access.dart
+++ b/tool/check_logic_dual_region_province_field_access.dart
@@ -1,0 +1,93 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// Canonical dual-region province iteration lives here; all other logic `lib/src`
+/// code should prefer `allProvinces` / `WorldState.allProvinces()` (GitHub #2071).
+const _canonicalRelativePath =
+    'packages/colonizethis_logic/lib/src/world/province_lookup.dart';
+
+const _scanDirRelative = 'packages/colonizethis_logic/lib/src';
+
+/// Target from #2071: keep direct field access rare; small buffer over current count.
+const _maxMatchingLinesOutsideCanonical = 10;
+
+final RegExp _generatedSuffix = RegExp(
+  r'\.(g|freezed|mocks|gen)\.dart$',
+);
+
+bool logicDualRegionProvinceFieldAccessLineMatches(String line) {
+  return line.contains('oldWorld.provinces') || line.contains('newWorld.provinces');
+}
+
+/// Used by `ct_repo_lint` in-process; [info] / [err] default to stdout/stderr.
+int runCheckLogicDualRegionProvinceFieldAccess(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+  final root = p.normalize(repoRoot);
+  final scanRoot = Directory(p.join(root, _scanDirRelative));
+  if (!scanRoot.existsSync()) {
+    logE('ERROR: Expected logic lib tree missing: $_scanDirRelative');
+    return 1;
+  }
+
+  final hits = <LogicDualRegionProvinceFieldHit>[];
+  for (final entity in scanRoot.listSync(recursive: true, followLinks: false)) {
+    if (entity is! File) continue;
+    final fullPath = p.normalize(entity.path);
+    if (!fullPath.endsWith('.dart')) continue;
+    if (_generatedSuffix.hasMatch(fullPath)) continue;
+    final relative = p.relative(fullPath, from: root);
+    if (p.normalize(relative) == _canonicalRelativePath) continue;
+
+    final lines = entity.readAsLinesSync();
+    for (var i = 0; i < lines.length; i++) {
+      final line = lines[i];
+      if (logicDualRegionProvinceFieldAccessLineMatches(line)) {
+        hits.add(
+          LogicDualRegionProvinceFieldHit(
+            path: p.normalize(relative),
+            line: i + 1,
+          ),
+        );
+      }
+    }
+  }
+
+  if (hits.length <= _maxMatchingLinesOutsideCanonical) {
+    logI(
+      'Logic dual-region province field access check passed '
+      '(${hits.length}/$_maxMatchingLinesOutsideCanonical lines outside $_canonicalRelativePath).',
+    );
+    return 0;
+  }
+
+  logE(
+    'ERROR: Too many direct oldWorld.provinces / newWorld.provinces references '
+    'outside $_canonicalRelativePath '
+    '(${hits.length} > $_maxMatchingLinesOutsideCanonical). '
+    'Prefer allProvinces(world) or WorldState.allProvinces() per SPEC/program/logic-dual-region-province-access.md.',
+  );
+  for (final h in hits) {
+    logE('${h.path}:${h.line}');
+  }
+  return 1;
+}
+
+void main() {
+  exit(runCheckLogicDualRegionProvinceFieldAccess(Directory.current.path));
+}
+
+final class LogicDualRegionProvinceFieldHit {
+  const LogicDualRegionProvinceFieldHit({
+    required this.path,
+    required this.line,
+  });
+
+  final String path;
+  final int line;
+}

--- a/tool/ct_repo_lint_lib.dart
+++ b/tool/ct_repo_lint_lib.dart
@@ -17,6 +17,7 @@ import 'check_disallowed_ast_patterns.dart';
 import 'check_function_size.dart';
 import 'check_game_widgets_file_size.dart';
 import 'check_land_province_bucket_keys.dart';
+import 'check_logic_dual_region_province_field_access.dart';
 import 'check_no_flame_in_widgets.dart';
 import 'check_no_screen_in_game_widgets.dart';
 import 'check_part_unit_size.dart';
@@ -740,6 +741,8 @@ int? _tryRunDartRuleInProcess({
       return runCheckCanonicalProvinceTileKeys(repoRoot);
     case 'repo.land_province_bucket_keys':
       return runCheckLandProvinceBucketKeys(repoRoot);
+    case 'repo.logic_dual_region_province_field_access':
+      return runCheckLogicDualRegionProvinceFieldAccess(repoRoot);
     case 'repo.app_hardcoded_ui_strings':
       return runCheckAppHardcodedUiStrings(repoRoot);
     default:

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -166,6 +166,13 @@ rules:
     runner: dart
     script: tool/check_land_province_bucket_keys.dart
 
+  - rule_id: repo.logic_dual_region_province_field_access
+    group: architecture
+    title: colonizethis_logic limits direct oldWorld/newWorld province list access
+    spec: SPEC/program/logic-dual-region-province-access.md
+    runner: dart
+    script: tool/check_logic_dual_region_province_field_access.dart
+
   - rule_id: repo.app_hardcoded_ui_strings
     group: ui_i18n
     title: No hardcoded user-visible UI strings in app/lib (AST gate)


### PR DESCRIPTION
## Summary

Implements the **CI enforcement** slice from GitHub #2071: cap direct `oldWorld.provinces` / `newWorld.provinces` usage in `packages/colonizethis_logic/lib/src/**` outside the canonical `province_lookup.dart` funnel.

Large refactor items from #2071 (mapPlayers, ProjectedCostEngine, FactionAbsorptionEngine, fixtures, characterization tests) are already on `dev`; this PR locks the dual-region iteration hygiene with a manifest rule so regressions fail CI.

## Acceptance criteria (this PR)

- New `repo.logic_dual_region_province_field_access` rule passes on current tree (8/10 budget lines).
- SPEC documents policy, budget, and how to raise the cap.
- Tests cover the line predicate and full-repo gate.

## SPEC

- `SPEC/program/logic-dual-region-province-access.md` (new)
- `SPEC/program/repo-lint.md` (rule table + AC)

## Tests

- `dart analyze tool/check_logic_dual_region_province_field_access.dart tool/ct_repo_lint_lib.dart`
- `dart test test/check_logic_dual_region_province_field_access_test.dart test/ct_repo_lint_test.dart`
- `dart run tool/ct_repo_lint.dart --rule repo.logic_dual_region_province_field_access`

## Out of scope

- Further migrations of the remaining 8 intentional lines (OW-only rules, markdown setup dump, log string).
- Naval/move `StatefulValidator` inheritance (not in #2071 Phase-1 three-validator set).

Refs #2071

Made with [Cursor](https://cursor.com)