### PR TITLE
SPEC + skills: backlog label workflow chain

### DIFF
--- a/.cursor/skills/backlog-implement-agent/SKILL.md
+++ b/.cursor/skills/backlog-implement-agent/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: backlog-implement-agent
+description: Picks one open GitHub issue labeled backlog:implementation, applies implement-github-issue strictly to deliver a complete implementation or a valid scoped slice, opens a PR documenting implemented vs deferred work, and relabels the issue to backlog:verification only when no outstanding work remains.
+---
+
+# Backlog Implement Agent (ColonizeThis)
+
+## When this applies
+
+Use when the user asks to run backlog implementation workflow and move one issue forward from `backlog:implementation`.
+
+## Required dependencies
+
+Before executing this skill:
+
+- Read and apply `.cursor/skills/implement-github-issue/SKILL.md` strictly for issue quality gate, SPEC-first behavior, slicing rules, implementation quality, testing, and PR workflow.
+- Follow `AGENTS.md`, `CONTRIBUTING.md`, and repository rules.
+
+Do not weaken or substitute the implementation method from `implement-github-issue`.
+
+## Workflow
+
+### 1) Select one candidate issue
+
+Pick any open issue with label `backlog:implementation`.
+
+Example:
+
+```bash
+gh issue list --state open --label "backlog:implementation" --limit 100 --json number,title,url,labels,updatedAt
+```
+
+Selection policy:
+
+- Prefer oldest `updatedAt` first unless the user specifies a different ordering.
+- If no matching issue exists, report that and stop without side effects.
+
+### 2) Determine scope for this run
+
+For the selected issue, decide whether to implement fully or as a slice:
+
+- Prefer slicing/scoping criteria already present in the issue body (subtasks, phases, explicit boundaries).
+- If not explicit, apply `.cursor/skills/implement-github-issue/SKILL.md` scope triage and choose one isolatable, testable slice when needed.
+- Keep scope explicit and reviewable before changing code.
+
+### 3) Execute strict implement-github-issue workflow
+
+- Run the full readiness gate and SPEC updates if needed.
+- Implement only SPEC-authorized behavior.
+- Add/adjust tests (positive and negative where applicable) mapped to targeted ACs.
+- Run relevant test commands until green.
+- Create a PR targeting `dev` using neutral issue reference (`Refs #<n>` or equivalent) and never auto-close the issue.
+
+### 4) Document implemented vs deferred work in PR
+
+In the PR body, include:
+
+- What was implemented in this PR.
+- What remains deferred (if any) and why.
+- Which ACs/spec sections are covered now vs left for follow-up.
+
+The reviewer must be able to tell whether the PR is full completion or a partial slice.
+
+### 5) Decide issue completion status
+
+Complete condition:
+
+- The issue requirements are fully implemented and validated.
+- No substantive work remains for the issue.
+
+Partial condition:
+
+- Any material work remains (including intentionally deferred scope).
+
+### 6) Move label only when complete
+
+If complete:
+
+- Remove `backlog:implementation`
+- Add `backlog:verification`
+
+If partial:
+
+- Leave `backlog:implementation` in place.
+
+Example completion command:
+
+```bash
+gh issue edit <issue-number> --remove-label "backlog:implementation" --add-label "backlog:verification"
+```
+
+Do not apply `backlog:verification` while outstanding work remains.
+
+## Output in chat
+
+After completion, report:
+
+- Issue number/title/URL implemented.
+- Scope decision (`FULL` or `SLICE`) and rationale.
+- PR URL and whether it represents full completion or partial delivery.
+- Implemented work and deferred work summary.
+- Label transition performed (or explicitly not performed, with reason).
+
+## Guardrails
+
+- Implement exactly one issue per run unless user requests batching.
+- Never close the issue in this workflow.
+- If `gh` is unavailable or fails, return prepared PR body text and exact commands needed for manual issue label transition.
+- If labels change unexpectedly during the run, re-read current labels and apply the intended final state idempotently.

--- a/.cursor/skills/backlog-refine-agent/SKILL.md
+++ b/.cursor/skills/backlog-refine-agent/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: backlog-refine-agent
+description: Picks one open GitHub issue labeled backlog:refinement, applies refine-github-issue strictly against all comment feedback, updates the issue body directly, and relabels to backlog:review when fully resolved or backlog:clarification when uncertainties remain.
+---
+
+# Backlog Refine Agent (ColonizeThis)
+
+## When this applies
+
+Use when the user asks to run backlog refinement workflow and move one issue forward from `backlog:refinement`.
+
+## Required dependencies
+
+Before executing this skill:
+
+- Read and apply `.cursor/skills/refine-github-issue/SKILL.md` strictly for comment-to-edit handling, SPEC contradiction handling, and clarification handling.
+- Follow `AGENTS.md` and repository rules.
+
+Do not weaken or substitute the refinement method from `refine-github-issue`.
+
+## Workflow
+
+### 1) Select one candidate issue
+
+Pick any open issue with label `backlog:refinement`.
+
+Example:
+
+```bash
+gh issue list --state open --label "backlog:refinement" --limit 100 --json number,title,url,labels,updatedAt
+```
+
+Selection policy:
+
+- Prefer oldest `updatedAt` first unless the user specifies a different ordering.
+- If no matching issue exists, report that and stop without side effects.
+
+### 2) Gather issue context and feedback
+
+For the selected issue:
+
+- Load issue details (`title`, `body`, `labels`, `url`, `comments`).
+- Inventory all actionable comment feedback items.
+- Carefully review relevant `SPEC/` and repository code when needed to determine whether each feedback item can be resolved directly.
+
+### 3) Apply strict refine-github-issue workflow
+
+- Process each feedback item using `.cursor/skills/refine-github-issue/SKILL.md`.
+- Update the issue body directly so accepted feedback is reflected in the issue text.
+- Do not leave comment-raised requirements only in discussion threads.
+
+Use:
+
+```bash
+gh issue edit <issue-number> --body-file path/to/new-body.md
+```
+
+### 4) Decide resolved vs uncertain
+
+After refinement, decide whether all comment-raised items are adequately addressed.
+
+Resolved condition:
+
+- All inventoried feedback items are addressed in the updated issue body.
+- No material uncertainty remains in issue scope, intended behavior, or acceptance criteria.
+- Scope is reasonable and not too large for one coherent issue.
+
+Uncertain condition (any one is enough):
+
+- One or more feedback items cannot be confidently resolved from comments, SPEC, and code.
+- Material ambiguity remains in issue scope, behavior, or AC definitions.
+- Scope is too large and should be split before review.
+
+### 5) Post uncertainty comment when needed
+
+If uncertain:
+
+- Post one consolidated issue comment listing every remaining uncertainty as a numbered list.
+- Include what was checked (comments/SPEC/code) and what exact clarification is needed.
+
+Example:
+
+```bash
+gh issue comment <issue-number> --body "$(cat <<'EOF'
+Remaining uncertainties:
+1. ...
+2. ...
+EOF
+)"
+```
+
+### 6) Move label according to decision
+
+Replace `backlog:refinement` with exactly one next-state label.
+
+If resolved:
+
+- Remove `backlog:refinement`
+- Add `backlog:review`
+
+If uncertain:
+
+- Remove `backlog:refinement`
+- Add `backlog:clarification`
+- Product owner then performs clarification decisions while the issue is in `backlog:clarification`.
+
+Example commands:
+
+```bash
+# resolved
+gh issue edit <issue-number> --remove-label "backlog:refinement" --add-label "backlog:review"
+
+# uncertain
+gh issue edit <issue-number> --remove-label "backlog:refinement" --add-label "backlog:clarification"
+```
+
+Do not leave both destination labels on the same issue.
+
+## Output in chat
+
+After completion, report:
+
+- Issue number/title/URL refined.
+- Decision (`RESOLVED` or `UNCERTAIN`).
+- Issue body update confirmation.
+- Uncertainty comment confirmation (if posted).
+- Label transition performed.
+
+## Guardrails
+
+- Refine exactly one issue per run unless user requests batching.
+- Never close the issue in this workflow.
+- If `gh` is unavailable or fails, return the prepared issue body text, uncertainty comment text (if needed), and exact label-edit commands for manual execution.
+- If issue labels are unexpectedly changed by others during the run, re-read labels before editing and apply the intended final state idempotently.

--- a/.cursor/skills/backlog-review-agent/SKILL.md
+++ b/.cursor/skills/backlog-review-agent/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: backlog-review-agent
+description: Picks an open GitHub issue labeled backlog:review, performs a strict purpose↔method review using review-github-issue criteria, posts a consolidated review comment, and advances the issue to backlog:implementation or backlog:refinement based on whether all P0/P1/P2 items are addressed.
+---
+
+# Backlog Review Agent (ColonizeThis)
+
+## When this applies
+
+Use when the user asks to run backlog review workflow and move one issue forward from `backlog:review`.
+
+## Required dependencies
+
+Before executing this skill:
+
+- Read and apply `.cursor/skills/review-github-issue/SKILL.md` strictly for analysis method, priority assignment, and review output quality bar.
+- Follow `AGENTS.md` and repository rules.
+
+Do not weaken or substitute the review method from `review-github-issue`.
+
+## Workflow
+
+### 1) Select one candidate issue
+
+Pick any open issue with label `backlog:review`.
+
+Example:
+
+```bash
+gh issue list --state open --label "backlog:review" --limit 100 --json number,title,url,labels,updatedAt
+```
+
+Selection policy:
+
+- Prefer oldest `updatedAt` first unless the user specifies a different ordering.
+- If no matching issue exists, report that and stop without side effects.
+
+### 2) Run strict review-github-issue analysis
+
+For the selected issue:
+
+- Load issue details (`title`, `body`, `labels`, `comments`, `url`).
+- Perform the full purpose↔method review exactly as defined in `review-github-issue`.
+- Identify all findings with explicit priorities (`P0`, `P1`, `P2`) and concrete remedies.
+
+### 3) Build and post consolidated review comment
+
+Post a single structured issue comment containing:
+
+- Purpose statement.
+- Purpose↔method findings with evidence and remedy.
+- Internal consistency findings.
+- Summary with `P0/P1/P2` counts and decision.
+
+Use `gh` to post:
+
+```bash
+gh issue comment <issue-number> --body "$(cat <<'EOF'
+<review comment>
+EOF
+)"
+```
+
+### 4) Decide pass vs fail
+
+Pass condition:
+
+- All `P0/P1/P2` concerns are addressed in the issue as currently written.
+- In practice, this means no unresolved `P0`, `P1`, or `P2` review findings remain.
+
+Fail condition:
+
+- Any unresolved `P0`, `P1`, or `P2` finding exists.
+
+### 5) Move label according to decision
+
+Replace `backlog:review` with exactly one next-state label.
+
+If pass:
+
+- Remove `backlog:review`
+- Add `backlog:implementation`
+
+If fail:
+
+- Remove `backlog:review`
+- Add `backlog:refinement`
+
+Example commands:
+
+```bash
+# pass
+gh issue edit <issue-number> --remove-label "backlog:review" --add-label "backlog:implementation"
+
+# fail
+gh issue edit <issue-number> --remove-label "backlog:review" --add-label "backlog:refinement"
+```
+
+Do not leave both destination labels on the same issue.
+
+## Output in chat
+
+After completion, report:
+
+- Issue number/title/URL reviewed.
+- Decision (`PASS` or `FAIL`).
+- Posted comment confirmation.
+- Label transition performed.
+
+## Guardrails
+
+- Review exactly one issue per run unless user requests batching.
+- Never close the issue in this workflow.
+- If `gh` is unavailable or fails, return the prepared comment and exact label-edit commands for manual execution.
+- If issue labels are unexpectedly changed by others during the run, re-read labels before editing and apply the intended final state idempotently.

--- a/.cursor/skills/backlog-verify-agent/SKILL.md
+++ b/.cursor/skills/backlog-verify-agent/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: backlog-verify-agent
+description: Picks one open GitHub issue labeled backlog:verification, applies verify-github-issue strictly to confirm implementation completeness, posts a verification comment, and relabels to backlog:acceptance when complete or backlog:implementation when gaps remain.
+---
+
+# Backlog Verify Agent (ColonizeThis)
+
+## When this applies
+
+Use when the user asks to run backlog verification workflow and move one issue forward from `backlog:verification`.
+
+## Required dependencies
+
+Before executing this skill:
+
+- Read and apply `.cursor/skills/verify-github-issue/SKILL.md` strictly for acceptance-criteria closure method, evidence standards, and gap reporting.
+- Follow `AGENTS.md` and repository rules.
+
+Do not weaken or substitute the verification method from `verify-github-issue`.
+
+## Workflow
+
+### 1) Select one candidate issue
+
+Pick any open issue with label `backlog:verification`.
+
+Example:
+
+```bash
+gh issue list --state open --label "backlog:verification" --limit 100 --json number,title,url,labels,updatedAt
+```
+
+Selection policy:
+
+- Prefer oldest `updatedAt` first unless the user specifies a different ordering.
+- If no matching issue exists, report that and stop without side effects.
+
+### 2) Run strict verify-github-issue analysis
+
+For the selected issue:
+
+- Load issue details (`title`, `body`, `labels`, `comments`, `url`).
+- Apply `.cursor/skills/verify-github-issue/SKILL.md` strictly to verify whether implementation is complete with no gaps.
+- Enumerate every remaining gap with concrete evidence when any are found.
+
+### 3) Post verification comment
+
+Post one consolidated issue comment with:
+
+- Verification outcome (`COMPLETE` or `GAPS REMAIN`).
+- AC/spec/test closure summary per `verify-github-issue`.
+- Explicit gap list and required follow-ups when incomplete.
+- Explicit readiness statement when complete (state that the issue is ready to close).
+
+Use `gh` to post:
+
+```bash
+gh issue comment <issue-number> --body "$(cat <<'EOF'
+<verification comment>
+EOF
+)"
+```
+
+### 4) Decide completion status
+
+Complete condition:
+
+- `verify-github-issue` confirms full implementation with no remaining material gaps.
+
+Incomplete condition:
+
+- Any unresolved implementation/spec/test/AC gap remains.
+
+### 5) Move label according to decision
+
+Replace `backlog:verification` with exactly one next-state label.
+
+If complete:
+
+- Remove `backlog:verification`
+- Add `backlog:acceptance`
+- Product owner then performs final acceptance decisioning while the issue is in `backlog:acceptance`.
+
+If incomplete:
+
+- Remove `backlog:verification`
+- Add `backlog:implementation`
+
+Example commands:
+
+```bash
+# complete
+gh issue edit <issue-number> --remove-label "backlog:verification" --add-label "backlog:acceptance"
+
+# incomplete
+gh issue edit <issue-number> --remove-label "backlog:verification" --add-label "backlog:implementation"
+```
+
+Do not leave both destination labels on the same issue.
+
+## Output in chat
+
+After completion, report:
+
+- Issue number/title/URL verified.
+- Decision (`COMPLETE` or `INCOMPLETE`).
+- Posted comment confirmation.
+- Label transition performed.
+
+## Guardrails
+
+- Verify exactly one issue per run unless user requests batching.
+- Never close the issue in this workflow.
+- If `gh` is unavailable or fails, return the prepared verification comment and exact label-edit commands for manual execution.
+- If issue labels are unexpectedly changed by others during the run, re-read labels before editing and apply the intended final state idempotently.

--- a/.opencode/skills/backlog-implement-agent/SKILL.md
+++ b/.opencode/skills/backlog-implement-agent/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: backlog-implement-agent
+description: Picks one open GitHub issue labeled backlog:implementation, applies implement-github-issue strictly to implement either full issue scope or a valid slice, opens a PR that clearly states implemented and deferred work, and relabels to backlog:verification only when nothing remains.
+---
+
+# Backlog Implement Agent (OpenCode)
+
+## Source of truth
+
+Use `.cursor/skills/backlog-implement-agent/SKILL.md` as the authoritative workflow, scope decision criteria, PR disclosure requirements, and label transition rules.
+
+## OpenCode adaptation
+
+When running in OpenCode:
+
+- Keep the same one-issue-per-run behavior unless the user explicitly requests batching.
+- Use `gh issue list` to select from open issues labeled `backlog:implementation`.
+- Apply `.cursor/skills/implement-github-issue/SKILL.md` strictly for readiness gates, SPEC updates, implementation, tests, and PR flow.
+- Decide full vs slice scope using issue-defined slicing first; otherwise follow implement-github-issue large-scope triage.
+- Ensure the PR body explicitly states:
+  - what was implemented in this PR
+  - what was deferred (if anything)
+  - why any deferred work remains
+- Relabel only when complete:
+  - Complete: remove `backlog:implementation`, add `backlog:verification`
+  - Partial: keep `backlog:implementation`
+- Do not close issues in this workflow.
+
+## Required references
+
+Before execution, read:
+
+- `.cursor/skills/backlog-implement-agent/SKILL.md`
+- `.cursor/skills/implement-github-issue/SKILL.md`

--- a/.opencode/skills/backlog-refine-agent/SKILL.md
+++ b/.opencode/skills/backlog-refine-agent/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: backlog-refine-agent
+description: Picks one open GitHub issue labeled backlog:refinement, applies refine-github-issue strictly to comment feedback, updates the issue body directly, then relabels to backlog:review if fully resolved or backlog:clarification if uncertainties remain.
+---
+
+# Backlog Refine Agent (OpenCode)
+
+## Source of truth
+
+Use `.cursor/skills/backlog-refine-agent/SKILL.md` as the authoritative workflow, uncertainty criteria, and label transition rules.
+
+## OpenCode adaptation
+
+When running in OpenCode:
+
+- Keep the same one-issue-per-run behavior unless the user explicitly requests batching.
+- Use `gh issue list` to select from open issues labeled `backlog:refinement`.
+- Apply `.cursor/skills/refine-github-issue/SKILL.md` strictly before deciding label transition.
+- Update the issue body directly via `gh issue edit --body-file`.
+- Before escalating uncertainty, check issue comments, relevant `SPEC/`, and code for resolvable answers.
+- If unresolved uncertainties remain, post one consolidated uncertainty comment.
+- Replace `backlog:refinement` with exactly one label:
+  - Resolved: `backlog:review`
+  - Uncertain: `backlog:clarification`
+- When relabeled to `backlog:clarification`, the product owner performs clarification decisions while the agent controls label transitions.
+- Never close issues in this workflow.
+
+## Required references
+
+Before execution, read:
+
+- `.cursor/skills/backlog-refine-agent/SKILL.md`
+- `.cursor/skills/refine-github-issue/SKILL.md`

--- a/.opencode/skills/backlog-review-agent/SKILL.md
+++ b/.opencode/skills/backlog-review-agent/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: backlog-review-agent
+description: Picks an open GitHub issue labeled backlog:review, runs strict review-github-issue analysis, posts a consolidated issue comment with findings, and relabels to backlog:implementation (pass) or backlog:refinement (fail).
+---
+
+# Backlog Review Agent (OpenCode)
+
+## Source of truth
+
+Use `.cursor/skills/backlog-review-agent/SKILL.md` as the authoritative workflow, pass/fail criteria, and label transition rules.
+
+## OpenCode adaptation
+
+When running in OpenCode:
+
+- Keep the same one-issue-per-run behavior unless the user explicitly requests batching.
+- Use `gh issue list` to select from open issues labeled `backlog:review`.
+- Apply `.cursor/skills/review-github-issue/SKILL.md` strictly before making a decision.
+- Post the consolidated review as an issue comment via `gh issue comment`.
+- Replace `backlog:review` with exactly one label:
+  - Pass: `backlog:implementation`
+  - Fail: `backlog:refinement`
+- Do not close issues as part of this workflow.
+
+## Required references
+
+Before execution, read:
+
+- `.cursor/skills/backlog-review-agent/SKILL.md`
+- `.cursor/skills/review-github-issue/SKILL.md`

--- a/.opencode/skills/backlog-verify-agent/SKILL.md
+++ b/.opencode/skills/backlog-verify-agent/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: backlog-verify-agent
+description: Picks one open GitHub issue labeled backlog:verification, applies verify-github-issue strictly to verify completion, posts a consolidated verification comment, and relabels to backlog:acceptance (complete) or backlog:implementation (gaps remain).
+---
+
+# Backlog Verify Agent (OpenCode)
+
+## Source of truth
+
+Use `.cursor/skills/backlog-verify-agent/SKILL.md` as the authoritative workflow, completion criteria, comment requirements, and label transition rules.
+
+## OpenCode adaptation
+
+When running in OpenCode:
+
+- Keep the same one-issue-per-run behavior unless the user explicitly requests batching.
+- Use `gh issue list` to select from open issues labeled `backlog:verification`.
+- Apply `.cursor/skills/verify-github-issue/SKILL.md` strictly before deciding.
+- Post one consolidated verification comment via `gh issue comment`.
+- If complete with no gaps, include that the issue is ready to close.
+- Replace `backlog:verification` with exactly one label:
+  - Complete: `backlog:acceptance`
+  - Incomplete: `backlog:implementation`
+- When relabeled to `backlog:acceptance`, the product owner performs final acceptance decisioning while the agent controls label transitions.
+- Do not close issues in this workflow.
+
+## Required references
+
+Before execution, read:
+
+- `.cursor/skills/backlog-verify-agent/SKILL.md`
+- `.cursor/skills/verify-github-issue/SKILL.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,10 @@ Skills live under `.cursor/skills/<name>/SKILL.md`. When a skill matches the tas
 | `fix-pr` | Unblock a PR by fixing failing checks and quality gates. |
 | `implement-github-issue` | User gives an issue **#** or **URL**; validate problem/design/testable ACs, update **SPEC** if needed, implement, add positive/negative tests, open PR to **`dev`** with **`Refs #…`** (do **not** auto-close). Very large issues: one isolatable slice only. |
 | `merge-dev-into-android-build` | Merge `dev` into `build/app/android` for APK build workflows. |
+| `backlog-implement-agent` | Pick one open issue labeled `backlog:implementation`, run strict `implement-github-issue` delivery, open a PR documenting implemented vs deferred scope, and relabel to `backlog:verification` only when fully complete. |
+| `backlog-review-agent` | Pick one open issue labeled `backlog:review`, run strict `review-github-issue` analysis, comment findings, then relabel to `backlog:implementation` (pass) or `backlog:refinement` (fail). |
+| `backlog-refine-agent` | Pick one open issue labeled `backlog:refinement`, run strict `refine-github-issue` updates against comment feedback, then relabel to `backlog:review` (resolved) or `backlog:clarification` (uncertain). |
+| `backlog-verify-agent` | Pick one open issue labeled `backlog:verification`, run strict `verify-github-issue` verification, post findings, then relabel to `backlog:acceptance` (complete) or `backlog:implementation` (gaps remain). |
 | `plan-feature` | Scope a feature from SPEC/code (read-only), then open a capturing issue—no implementation. |
 | `refine-github-issue` | Refine an open issue from comment feedback (repro, root cause, priorities); update the body or return numbered clarifications when feedback conflicts with SPEC. |
 | `review-pr` | Review an open pull request against issue alignment, acceptance-criteria coverage, architecture conventions, and linting compliance; post all findings as a PR comment with strict YES/CONDITIONAL YES/NO outcomes. |

--- a/SPEC/program/backlog-issue-label-workflow.md
+++ b/SPEC/program/backlog-issue-label-workflow.md
@@ -1,0 +1,113 @@
+# Backlog issue label workflow
+
+**SPEC/program** - Label-state contract for the backlog automation chain spanning review, refinement, implementation, and verification.
+
+## Purpose
+
+Define one deterministic issue-label workflow so automation and humans move backlog issues through the same lifecycle without ambiguous ownership or skipped gates.
+
+## Labels in scope
+
+- `backlog:review`
+- `backlog:refinement`
+- `backlog:implementation`
+- `backlog:verification`
+- `backlog:clarification`
+- `backlog:acceptance`
+
+## Role ownership
+
+- Automation-owned labels and transitions:
+  - `backlog:review`
+  - `backlog:refinement`
+  - `backlog:implementation`
+  - `backlog:verification`
+- Product-owner-only labels and transitions:
+  - `backlog:clarification`
+  - `backlog:acceptance`
+
+Automation must not apply, remove, or transition through product-owner-only labels.
+
+## State machine
+
+### Canonical transitions
+
+- `backlog:review` -> `backlog:implementation` (review pass)
+- `backlog:review` -> `backlog:refinement` (review fail)
+- `backlog:refinement` -> `backlog:review` (feedback fully resolved)
+- `backlog:refinement` -> `backlog:refinement` (material uncertainty remains; automation posts clarification request and waits for product-owner relabel)
+- `backlog:implementation` -> `backlog:verification` (issue fully implemented)
+- `backlog:verification` -> `backlog:implementation` (gaps remain)
+- `backlog:verification` -> `backlog:verification` (verification complete; automation posts readiness and waits for product-owner relabel)
+
+### Product owner handoffs (manual labels only)
+
+- Product owner applies `backlog:clarification` when automation has posted unresolved uncertainties and product-owner clarification work is required.
+- `backlog:clarification` -> `backlog:review` after product owner resolves uncertainty in issue scope, behavior, or acceptance criteria.
+- Product owner applies `backlog:acceptance` after reviewing verification evidence and deciding the issue is accepted.
+- `backlog:acceptance` is terminal for this workflow and indicates product-owner acceptance outcome handling is outside automation scope.
+
+## Causal link validation against skills
+
+The four backlog skills form a closed automation loop over quality gates:
+
+- Review gate decides implementation readiness or refinement need.
+- Refinement gate either returns to review or emits a clarification request for product-owner takeover.
+- Implementation gate moves to verification only when no substantive work remains.
+- Verification gate either loops back to implementation for gaps or emits an acceptance-ready handoff for product-owner relabel.
+
+This creates an auditable cause-and-effect chain where each transition is driven by explicit evidence (review findings, unresolved feedback, remaining work, or verification gaps).
+
+## Workflow invariants
+
+- Exactly one state label from this spec is active on an issue at a time.
+- Every transition removes the previous state label and adds exactly one destination label.
+- Automation never closes issues in this state workflow.
+- `backlog:verification` must not be applied when implementation work remains.
+- Only the product owner may add or remove `backlog:clarification` and `backlog:acceptance`.
+
+## Acceptance criteria
+
+- Given an open issue labeled `backlog:review`  
+  When automation performs review and unresolved `P0`, `P1`, and `P2` findings are all absent  
+  Then automation removes `backlog:review`, adds `backlog:implementation`, and posts one consolidated review comment.
+
+- Given an open issue labeled `backlog:review`  
+  When automation performs review and at least one unresolved `P0`, `P1`, or `P2` finding exists  
+  Then automation removes `backlog:review`, adds `backlog:refinement`, and posts one consolidated review comment listing those findings.
+
+- Given an open issue labeled `backlog:refinement`  
+  When automation applies feedback and all material uncertainties are resolved in the issue body  
+  Then automation removes `backlog:refinement`, adds `backlog:review`, and persists the refined issue body.
+
+- Given an open issue labeled `backlog:refinement`  
+  When automation cannot resolve at least one material uncertainty from comments, SPEC, and code evidence  
+  Then automation keeps `backlog:refinement` unchanged and posts a numbered clarification request comment for product-owner relabel to `backlog:clarification`.
+
+- Given an open issue labeled `backlog:implementation`  
+  When automation delivers only a partial implementation slice with substantive deferred work remaining  
+  Then automation keeps `backlog:implementation` unchanged and does not add `backlog:verification`.
+
+- Given an open issue labeled `backlog:implementation`  
+  When automation completes implementation with targeted acceptance-criteria coverage and no substantive deferred work  
+  Then automation removes `backlog:implementation` and adds `backlog:verification`.
+
+- Given an open issue labeled `backlog:verification`  
+  When automation verifies implementation and finds at least one unresolved acceptance-criteria, spec, or test gap  
+  Then automation removes `backlog:verification`, adds `backlog:implementation`, and posts one consolidated verification gap comment.
+
+- Given an open issue labeled `backlog:verification`  
+  When automation verifies implementation and finds no unresolved material gaps  
+  Then automation keeps `backlog:verification` unchanged and posts one consolidated verification-ready comment for product-owner relabel to `backlog:acceptance`.
+
+- Given an open issue labeled `backlog:clarification`  
+  When the product owner resolves uncertainty in issue description, scope, and acceptance criteria  
+  Then the product owner removes `backlog:clarification` and adds `backlog:review` so automation can resume.
+
+- Given an open issue labeled `backlog:acceptance`  
+  When the product owner performs final product acceptance decisioning  
+  Then the issue remains outside automation transition control unless the product owner explicitly re-labels it for further automation work.
+
+- Given an open issue in any automation-owned state label  
+  When an automation run reaches a point that requires clarification or acceptance decisioning  
+  Then automation does not add `backlog:clarification` or `backlog:acceptance` and instead posts a handoff comment instructing product-owner manual relabel.

--- a/SPEC/program/backlog-issue-label-workflow.md
+++ b/SPEC/program/backlog-issue-label-workflow.md
@@ -17,16 +17,13 @@ Define one deterministic issue-label workflow so automation and humans move back
 
 ## Role ownership
 
-- Automation-owned labels and transitions:
-  - `backlog:review`
-  - `backlog:refinement`
-  - `backlog:implementation`
-  - `backlog:verification`
-- Product-owner-only labels and transitions:
-  - `backlog:clarification`
-  - `backlog:acceptance`
+- Agent-owned relabel transitions:
+  - Agent performs all label transitions in this workflow, including transitions into and out of `backlog:clarification` and `backlog:acceptance`.
+- Product-owner-owned decisions:
+  - `backlog:clarification`: Product owner resolves ambiguity and provides final clarification direction.
+  - `backlog:acceptance`: Product owner performs final acceptance decisioning.
 
-Automation must not apply, remove, or transition through product-owner-only labels.
+Automation sets lifecycle labels; product owner performs the business decision steps for clarification and acceptance.
 
 ## State machine
 
@@ -35,16 +32,17 @@ Automation must not apply, remove, or transition through product-owner-only labe
 - `backlog:review` -> `backlog:implementation` (review pass)
 - `backlog:review` -> `backlog:refinement` (review fail)
 - `backlog:refinement` -> `backlog:review` (feedback fully resolved)
-- `backlog:refinement` -> `backlog:refinement` (material uncertainty remains; automation posts clarification request and waits for product-owner relabel)
+- `backlog:refinement` -> `backlog:clarification` (material uncertainty remains; agent relabels to hand off clarification work)
 - `backlog:implementation` -> `backlog:verification` (issue fully implemented)
 - `backlog:verification` -> `backlog:implementation` (gaps remain)
-- `backlog:verification` -> `backlog:verification` (verification complete; automation posts readiness and waits for product-owner relabel)
+- `backlog:verification` -> `backlog:acceptance` (verification complete; agent relabels for product-owner final acceptance decision)
 
-### Product owner handoffs (manual labels only)
+### Product owner handoffs
 
-- Product owner applies `backlog:clarification` when automation has posted unresolved uncertainties and product-owner clarification work is required.
-- `backlog:clarification` -> `backlog:review` after product owner resolves uncertainty in issue scope, behavior, or acceptance criteria.
-- Product owner applies `backlog:acceptance` after reviewing verification evidence and deciding the issue is accepted.
+- Agent applies `backlog:clarification` when unresolved uncertainty requires product-owner clarification.
+- `backlog:clarification` -> `backlog:review` after the product owner resolves uncertainty in issue scope, behavior, or acceptance criteria.
+- Agent applies `backlog:acceptance` after verification indicates completion readiness.
+- Product owner reviews acceptance evidence and performs final acceptance decisioning while the issue is in `backlog:acceptance`.
 - `backlog:acceptance` is terminal for this workflow and indicates product-owner acceptance outcome handling is outside automation scope.
 
 ## Causal link validation against skills
@@ -52,9 +50,9 @@ Automation must not apply, remove, or transition through product-owner-only labe
 The four backlog skills form a closed automation loop over quality gates:
 
 - Review gate decides implementation readiness or refinement need.
-- Refinement gate either returns to review or emits a clarification request for product-owner takeover.
+- Refinement gate either returns to review or relabels to `backlog:clarification` for product-owner clarification.
 - Implementation gate moves to verification only when no substantive work remains.
-- Verification gate either loops back to implementation for gaps or emits an acceptance-ready handoff for product-owner relabel.
+- Verification gate either loops back to implementation for gaps or relabels to `backlog:acceptance` for product-owner acceptance decisioning.
 
 This creates an auditable cause-and-effect chain where each transition is driven by explicit evidence (review findings, unresolved feedback, remaining work, or verification gaps).
 
@@ -64,7 +62,8 @@ This creates an auditable cause-and-effect chain where each transition is driven
 - Every transition removes the previous state label and adds exactly one destination label.
 - Automation never closes issues in this state workflow.
 - `backlog:verification` must not be applied when implementation work remains.
-- Only the product owner may add or remove `backlog:clarification` and `backlog:acceptance`.
+- Agent relabeling is the only mechanism for state transitions in this workflow.
+- Product owner decision ownership for clarification/acceptance does not change agent relabel authority.
 
 ## Acceptance criteria
 
@@ -82,7 +81,7 @@ This creates an auditable cause-and-effect chain where each transition is driven
 
 - Given an open issue labeled `backlog:refinement`  
   When automation cannot resolve at least one material uncertainty from comments, SPEC, and code evidence  
-  Then automation keeps `backlog:refinement` unchanged and posts a numbered clarification request comment for product-owner relabel to `backlog:clarification`.
+  Then automation removes `backlog:refinement`, adds `backlog:clarification`, and posts a numbered clarification comment for product-owner decisioning.
 
 - Given an open issue labeled `backlog:implementation`  
   When automation delivers only a partial implementation slice with substantive deferred work remaining  
@@ -98,7 +97,7 @@ This creates an auditable cause-and-effect chain where each transition is driven
 
 - Given an open issue labeled `backlog:verification`  
   When automation verifies implementation and finds no unresolved material gaps  
-  Then automation keeps `backlog:verification` unchanged and posts one consolidated verification-ready comment for product-owner relabel to `backlog:acceptance`.
+  Then automation removes `backlog:verification`, adds `backlog:acceptance`, and posts one consolidated verification-ready comment for product-owner acceptance decisioning.
 
 - Given an open issue labeled `backlog:clarification`  
   When the product owner resolves uncertainty in issue description, scope, and acceptance criteria  
@@ -108,6 +107,6 @@ This creates an auditable cause-and-effect chain where each transition is driven
   When the product owner performs final product acceptance decisioning  
   Then the issue remains outside automation transition control unless the product owner explicitly re-labels it for further automation work.
 
-- Given an open issue in any automation-owned state label  
+- Given an open issue in any workflow state label  
   When an automation run reaches a point that requires clarification or acceptance decisioning  
-  Then automation does not add `backlog:clarification` or `backlog:acceptance` and instead posts a handoff comment instructing product-owner manual relabel.
+  Then automation performs the state relabel (`backlog:clarification` or `backlog:acceptance`) and the product owner performs the corresponding business decision action.


### PR DESCRIPTION
## Summary
- add `SPEC/program/backlog-issue-label-workflow.md` documenting the backlog label state machine, causal transitions, and workflow invariants
- add the backlog workflow skills under both `.cursor/skills/` and `.opencode/skills/` for review/refine/implement/verify
- align the clarification/acceptance semantics so agent-driven relabeling remains authoritative while clarification/acceptance decisions are performed by the human product owner
- register the new backlog workflow skills in `AGENTS.md`

## Test plan
- [x] documentation/skill workflow change only (no runtime code changes)
- [x] manually verified transitions are consistent across SPEC and skill docs