### PR TITLE
Centralize colonizethis_map pipe splits and add CI gate (Refs #2087)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -433,6 +433,9 @@ jobs:
       - name: Test canonical province tile-key checker (SPEC/game/world-model-identity.md)
         run: dart test test/check_canonical_province_tile_keys_test.dart --reporter=compact
 
+      - name: Test colonizethis_map lib pipe-split gate (Refs #2087)
+        run: dart test test/check_colonizethis_map_lib_pipe_splits_test.dart --reporter=compact
+
       - name: Wang incremental assets gate (Python)
         run: |
           set -euo pipefail

--- a/packages/colonizethis_map/lib/src/init_game_map_view_builder_cells_markers_part.dart
+++ b/packages/colonizethis_map/lib/src/init_game_map_view_builder_cells_markers_part.dart
@@ -70,48 +70,52 @@ List<CapitalMarkerView> _buildCapitalMarkers({
   required String regionId,
 }) {
   final capitals = <CapitalMarkerView>[];
-  _appendCapitalMarkers(
-    capitals: capitals,
-    regionId: regionId,
-    factions: game.players,
-    idOf: (player) => player.id,
-    displayNameOf: (player) => player.displayName,
-    capitalOf: (player) {
-      final capital = player.capitalTile;
-      if (capital == null) {
-        return null;
-      }
-      return (regionId: capital.regionId, x: capital.x, y: capital.y);
-    },
-  );
-  _appendCapitalMarkers(
-    capitals: capitals,
-    regionId: regionId,
-    factions: game.minorNations,
-    idOf: (nation) => nation.id,
-    displayNameOf: (nation) => nation.displayName ?? nation.id,
-    capitalOf: (nation) {
-      final capital = nation.capitalTile;
-      if (capital == null) {
-        return null;
-      }
-      return (regionId: capital.regionId, x: capital.x, y: capital.y);
-    },
-  );
-  _appendCapitalMarkers(
-    capitals: capitals,
-    regionId: regionId,
-    factions: game.tribes,
-    idOf: (tribe) => tribe.id,
-    displayNameOf: (tribe) => tribe.displayName ?? tribe.id,
-    capitalOf: (tribe) {
-      final capital = tribe.capitalTile;
-      if (capital == null) {
-        return null;
-      }
-      return (regionId: capital.regionId, x: capital.x, y: capital.y);
-    },
-  );
+  for (final append in <void Function()>[
+    () => _appendCapitalMarkers(
+      capitals: capitals,
+      regionId: regionId,
+      factions: game.players,
+      idOf: (player) => player.id,
+      displayNameOf: (player) => player.displayName,
+      capitalOf: (player) {
+        final capital = player.capitalTile;
+        if (capital == null) {
+          return null;
+        }
+        return (regionId: capital.regionId, x: capital.x, y: capital.y);
+      },
+    ),
+    () => _appendCapitalMarkers(
+      capitals: capitals,
+      regionId: regionId,
+      factions: game.minorNations,
+      idOf: (nation) => nation.id,
+      displayNameOf: (nation) => nation.displayName ?? nation.id,
+      capitalOf: (nation) {
+        final capital = nation.capitalTile;
+        if (capital == null) {
+          return null;
+        }
+        return (regionId: capital.regionId, x: capital.x, y: capital.y);
+      },
+    ),
+    () => _appendCapitalMarkers(
+      capitals: capitals,
+      regionId: regionId,
+      factions: game.tribes,
+      idOf: (tribe) => tribe.id,
+      displayNameOf: (tribe) => tribe.displayName ?? tribe.id,
+      capitalOf: (tribe) {
+        final capital = tribe.capitalTile;
+        if (capital == null) {
+          return null;
+        }
+        return (regionId: capital.regionId, x: capital.x, y: capital.y);
+      },
+    ),
+  ]) {
+    append();
+  }
   return capitals;
 }
 

--- a/packages/colonizethis_map/lib/src/init_game_map_view_builder_fleet_markers_part.dart
+++ b/packages/colonizethis_map/lib/src/init_game_map_view_builder_fleet_markers_part.dart
@@ -91,7 +91,7 @@ String? _fleetMarkerTileKeyForLocationScope({
 }) {
   if (scopeKey.startsWith('sea:')) {
     final zoneKey = scopeKey.substring(4);
-    final local = zoneKey.contains('|') ? zoneKey.split('|').last : zoneKey;
+    final local = lastPipeSegment(zoneKey);
     return seaZoneCentroidTileKey(
       tileMap: tileMap,
       regionId: regionId,

--- a/packages/colonizethis_map/lib/src/port_icon_placement.dart
+++ b/packages/colonizethis_map/lib/src/port_icon_placement.dart
@@ -93,17 +93,7 @@ String? localProvinceIdFromPortsSeaboardKey(
   String seaboardKey,
   String regionId,
 ) {
-  final parts = seaboardKey.split('|');
-  if (parts.length >= 3) {
-    if (parts[0] != regionId) {
-      return null;
-    }
-    return parts[1];
-  }
-  if (parts.length == 2) {
-    return parts[0];
-  }
-  return null;
+  return tryLocalProvinceIdFromPortsSeaboardKey(seaboardKey, regionId);
 }
 
 /// Authoritative **land** port tile key from [Game.worldState.portsByProvinceSeaboard]

--- a/packages/colonizethis_map/lib/src/tile_key_util.dart
+++ b/packages/colonizethis_map/lib/src/tile_key_util.dart
@@ -27,3 +27,37 @@ ParsedMapTileSuffixXY? tryParseMapTileKeySuffixXY(String tileKey) {
   }
   return (x: x, y: y);
 }
+
+/// Returns [a, b] when [s] splits into exactly two segments (e.g. topology edge ids).
+List<String>? trySplitExactlyTwoPipeSegments(String s) {
+  final parts = s.split('|');
+  if (parts.length != 2) {
+    return null;
+  }
+  return parts;
+}
+
+/// Last `|` segment, or [delimited] when there is no delimiter (same as a single-segment split).
+String lastPipeSegment(String delimited) {
+  final parts = delimited.split('|');
+  return parts.last;
+}
+
+/// Local province id from a `portsByProvinceSeaboard` map **key** for [regionId].
+/// SPEC/ui/town-port-icons.md.
+String? tryLocalProvinceIdFromPortsSeaboardKey(
+  String seaboardKey,
+  String regionId,
+) {
+  final parts = seaboardKey.split('|');
+  if (parts.length >= 3) {
+    if (parts[0] != regionId) {
+      return null;
+    }
+    return parts[1];
+  }
+  if (parts.length == 2) {
+    return parts[0];
+  }
+  return null;
+}

--- a/packages/colonizethis_map/lib/src/topology_inference.dart
+++ b/packages/colonizethis_map/lib/src/topology_inference.dart
@@ -2,6 +2,8 @@
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 
+import 'tile_key_util.dart';
+
 /// Infers MapTopology from a tile map result. SPEC/program/tile-map-gen-resources.md § Topology inference.
 /// Collects unique region ids from grid; classifies province vs sea zone; builds edges from adjacencies.
 MapTopology inferTopologyFromTileMap(
@@ -26,8 +28,8 @@ MapTopology inferTopologyFromTileMap(
   final pairs = result.adjacentRegionPairs();
   final edges = <TopologyEdge>[];
   for (final pair in pairs) {
-    final parts = pair.split('|');
-    if (parts.length == 2) {
+    final parts = trySplitExactlyTwoPipeSegments(pair);
+    if (parts != null) {
       edges.add(TopologyEdge(id1: parts[0], id2: parts[1]));
     }
   }

--- a/packages/colonizethis_map/test/tile_key_util_test.dart
+++ b/packages/colonizethis_map/test/tile_key_util_test.dart
@@ -31,4 +31,43 @@ void main() {
       expect(tryParseMapTileKeySuffixXY('oldWorld|p4|12|y'), isNull);
     });
   });
+
+  group('trySplitExactlyTwoPipeSegments', () {
+    test('parses exactly two segments', () {
+      expect(trySplitExactlyTwoPipeSegments('a|b'), ['a', 'b']);
+      expect(trySplitExactlyTwoPipeSegments('a|b|c'), isNull);
+      expect(trySplitExactlyTwoPipeSegments('a'), isNull);
+    });
+  });
+
+  group('lastPipeSegment', () {
+    test('returns last segment when pipes present', () {
+      expect(lastPipeSegment('r|s1'), 's1');
+      expect(lastPipeSegment('oldWorld|p1|2|3'), '3');
+    });
+
+    test('returns whole string when no pipe', () {
+      expect(lastPipeSegment('s1'), 's1');
+    });
+  });
+
+  group('tryLocalProvinceIdFromPortsSeaboardKey', () {
+    test('parses three-part key with region match', () {
+      expect(
+        tryLocalProvinceIdFromPortsSeaboardKey('oldWorld|p9|seaboard', 'oldWorld'),
+        'p9',
+      );
+    });
+
+    test('returns null when region mismatches', () {
+      expect(
+        tryLocalProvinceIdFromPortsSeaboardKey('newWorld|p9|seaboard', 'oldWorld'),
+        isNull,
+      );
+    });
+
+    test('parses two-part key as local id only', () {
+      expect(tryLocalProvinceIdFromPortsSeaboardKey('p9|x', 'oldWorld'), 'p9');
+    });
+  });
 }

--- a/test/check_colonizethis_map_lib_pipe_splits_test.dart
+++ b/test/check_colonizethis_map_lib_pipe_splits_test.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../tool/check_colonizethis_map_lib_pipe_splits.dart';
+
+void main() {
+  group('findColonizethisMapLibPipeSplitViolations', () {
+    test('allows .split only in tile_key_util.dart', () {
+      const src = "final parts = tileKey.split('|');\n";
+      expect(
+        findColonizethisMapLibPipeSplitViolations(
+          relativePath: 'packages/colonizethis_map/lib/src/tile_key_util.dart',
+          source: src,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('flags .split in other map lib files', () {
+      const src = "void f(String k) {\n  final p = k.split('|');\n}\n";
+      final v = findColonizethisMapLibPipeSplitViolations(
+        relativePath: 'packages/colonizethis_map/lib/src/other.dart',
+        source: src,
+      );
+      expect(v, isNotEmpty);
+      expect(v.first.line, 2);
+    });
+
+    test('ignores paths outside colonizethis_map lib', () {
+      const src = "void f(String k) {\n  final p = k.split('|');\n}\n";
+      expect(
+        findColonizethisMapLibPipeSplitViolations(
+          relativePath: 'packages/colonizethis_logic/lib/x.dart',
+          source: src,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('repo map package lib passes gate', () {
+      expect(runCheckColonizethisMapLibPipeSplits(Directory.current.path), 0);
+    });
+  });
+}

--- a/tool/check_colonizethis_map_lib_pipe_splits.dart
+++ b/tool/check_colonizethis_map_lib_pipe_splits.dart
@@ -1,0 +1,114 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// Repo-relative path to the only library file allowed to call `.split('|')` / `.split("|")`.
+const _allowedPipeSplitLibFile = 'packages/colonizethis_map/lib/src/tile_key_util.dart';
+
+/// Matches `.split('|')`, `.split("|")`, `.split(r'|')`, `.split(r"|")` with optional spaces.
+final _pipeSplitLiteralPattern = RegExp(
+  r'''\.split\s*\(\s*r?['"]\|['"]\s*\)''',
+);
+
+/// One `.split('|'|"|…)` use outside [tile_key_util.dart](packages/colonizethis_map/lib/src/tile_key_util.dart).
+final class ColonizethisMapPipeSplitViolation {
+  const ColonizethisMapPipeSplitViolation({
+    required this.path,
+    required this.line,
+    required this.snippet,
+  });
+
+  final String path;
+  final int line;
+  final String snippet;
+}
+
+/// Returns violations for [relativePath] / [source] under `packages/colonizethis_map/lib/`.
+List<ColonizethisMapPipeSplitViolation> findColonizethisMapLibPipeSplitViolations({
+  required String relativePath,
+  required String source,
+}) {
+  final normalized = p.normalize(relativePath);
+  final mapLibPrefix =
+      p.join('packages', 'colonizethis_map', 'lib') + p.separator;
+  if (!normalized.startsWith(mapLibPrefix)) {
+    return const [];
+  }
+  if (normalized == p.normalize(_allowedPipeSplitLibFile)) {
+    return const [];
+  }
+  final violations = <ColonizethisMapPipeSplitViolation>[];
+  final lines = const LineSplitter().convert(source);
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i];
+    final code = _stripTrailingLineComment(line);
+    if (!_pipeSplitLiteralPattern.hasMatch(code)) {
+      continue;
+    }
+    violations.add(
+      ColonizethisMapPipeSplitViolation(
+        path: relativePath,
+        line: i + 1,
+        snippet: line.trim(),
+      ),
+    );
+  }
+  return violations;
+}
+
+String _stripTrailingLineComment(String line) {
+  final idx = line.indexOf('//');
+  if (idx < 0) {
+    return line;
+  }
+  return line.substring(0, idx);
+}
+
+/// PR-blocking gate: all pipe-delimited string splits in `colonizethis_map` lib live in
+/// [tile_key_util.dart](packages/colonizethis_map/lib/src/tile_key_util.dart) (GitHub #2087).
+int runCheckColonizethisMapLibPipeSplits(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+  final root = p.normalize(repoRoot);
+  final libDir = Directory(p.join(root, 'packages', 'colonizethis_map', 'lib'));
+  if (!libDir.existsSync()) {
+    logE('check_colonizethis_map_lib_pipe_splits: missing ${libDir.path}');
+    return 1;
+  }
+
+  final violations = <ColonizethisMapPipeSplitViolation>[];
+  for (final entity in libDir.listSync(recursive: true, followLinks: false)) {
+    if (entity is! File || !entity.path.endsWith('.dart')) {
+      continue;
+    }
+    final rel = p.normalize(p.relative(entity.path, from: root));
+    final src = entity.readAsStringSync();
+    violations.addAll(
+      findColonizethisMapLibPipeSplitViolations(relativePath: rel, source: src),
+    );
+  }
+
+  if (violations.isEmpty) {
+    logI('check_colonizethis_map_lib_pipe_splits: no violations found.');
+    return 0;
+  }
+
+  logE(
+    'check_colonizethis_map_lib_pipe_splits: pipe-delimited .split(...) must live only in '
+    '$_allowedPipeSplitLibFile (${violations.length} violation(s)):',
+  );
+  for (final v in violations) {
+    logE(' - ${v.path}:${v.line}: ${v.snippet}');
+  }
+  return 1;
+}
+
+void main(List<String> args) {
+  final code = runCheckColonizethisMapLibPipeSplits(Directory.current.path);
+  exit(code);
+}


### PR DESCRIPTION
## Summary

Completes remaining **#2087** acceptance items around owning pipe-delimited string splitting in `packages/colonizethis_map/lib/src/tile_key_util.dart` and adds a PR-blocking gate.

## Changes

- **tile_key_util:** Add `trySplitExactlyTwoPipeSegments` (topology adjacency pairs), `lastPipeSegment` (fleet sea-zone keys), and `tryLocalProvinceIdFromPortsSeaboardKey` (ports seaboard map keys). Unit tests extended.
- **Call sites:** `topology_inference.dart`, `init_game_map_view_builder_fleet_markers_part.dart`, and `port_icon_placement.dart` delegate to those helpers (no `.split('|')` outside `tile_key_util.dart`).
- **Capital markers:** Single `for` loop over faction append runners in `_buildCapitalMarkers` (players, minor nations, tribes).
- **CI:** New `test/check_colonizethis_map_lib_pipe_splits_test.dart` plus `tool/check_colonizethis_map_lib_pipe_splits.dart`; `quality.yml` runs the test next to other repo convention gates.

## Out of scope / already on dev

Large rename/restructure of builder part files and `TileMapGenerator` field wiring were already addressed on `dev` before this slice; this PR finishes the **single-module pipe split** and **capital dispatch** AC tightening plus the **CI gate** called out in the issue.

## Tests

- `dart test test/check_colonizethis_map_lib_pipe_splits_test.dart`
- `cd packages/colonizethis_map && dart test`

Refs #2087

Made with [Cursor](https://cursor.com)