### PR TITLE
Pin Flutter 3.41.9 in CI and document toolchain baseline (Refs #2073)

### DIFF
--- a/.github/workflows/app-android-release.yml
+++ b/.github/workflows/app-android-release.yml
@@ -22,6 +22,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: '3.41.9'
           cache: true
 
       - name: Install dependencies

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -113,6 +113,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: '3.41.9'
           cache: true
 
       - name: Resolve dependencies (workspace)
@@ -198,6 +199,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: '3.41.9'
           cache: true
 
       - name: Install Linux desktop build dependencies
@@ -285,6 +287,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: '3.41.9'
           cache: true
 
       - name: Download app test cache
@@ -353,6 +356,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: '3.41.9'
           cache: true
 
       - name: Install melos

--- a/.github/workflows/widgetbook-release.yml
+++ b/.github/workflows/widgetbook-release.yml
@@ -22,6 +22,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: '3.41.9'
           cache: true
 
       - name: Install dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,12 @@ All contributions must be submitted via a Pull Request (PR).
 - **Default target branch**: `dev`
 - Unless explicitly required, PRs should target `dev` rather than `main` or other branches.
 
+## Flutter and Dart (match CI)
+
+GitHub Actions workflows that install Flutter (see `.github/workflows/quality.yml`, `app-android-release.yml`, and `widgetbook-release.yml`) pin **`flutter-version: '3.41.9'`** on the stable channel, which bundles **Dart 3.11.5**. Use the same Flutter stable locally so dependency resolution and pub.dev advisories decoding match CI.
+
+If `dart pub get` or `flutter pub get` fails while resolving hosted packages with **`FormatException: advisoriesUpdated must be a String`**, upgrade your Flutter/Dart install to at least this pair (or newer stable that remains compatible with the repo’s `environment.sdk` lower bound in each `pubspec.yaml`).
+
 ## Pre-PR Checklist
 
 Before opening a pull request, ensure the following:


### PR DESCRIPTION
## Summary

Implements the **CI pin + contributor alignment** slice for **#2073**: every workflow that uses `subosito/flutter-action@v2` now sets `flutter-version: '3.41.9'` on the stable channel (Dart **3.11.5** per Flutter release notes). `CONTRIBUTING.md` documents the same baseline and triage for the `advisoriesUpdated must be a String` failure mode.

## Scope (this PR)

- `.github/workflows/quality.yml` (all four Flutter setup steps)
- `.github/workflows/app-android-release.yml`
- `.github/workflows/widgetbook-release.yml`
- `CONTRIBUTING.md` — new **Flutter and Dart (match CI)** section

## Intentionally deferred (issue ACs still open for follow-up)

- Full workspace **dependency upgrade to Latest** and coordinated lockfile refresh across every member (large, separate change set).
- Raising `environment.sdk` lower bound beyond `>=3.11.0` unless the team chooses it for clarity.

## Verification

- Local `dart pub get` at repo root succeeds on this agent’s SDK (no advisories decode failure observed here).
- **GitHub Actions:** this PR’s Quality workflow run is the authoritative check that the pinned SDK resolves hosted packages without the reported `FormatException`; please note pass/fail on the issue after merge if useful for closure.

Refs #2073

Made with [Cursor](https://cursor.com)