### PR TITLE
docs(skills): verify-github-issue uses gh; post comment only

### DIFF
--- a/.cursor/skills/backlog-verify-agent/SKILL.md
+++ b/.cursor/skills/backlog-verify-agent/SKILL.md
@@ -13,7 +13,7 @@ Use when the user asks to run backlog verification workflow and move one issue f
 
 Before executing this skill:
 
-- Read and apply `.cursor/skills/verify-github-issue/SKILL.md` strictly for acceptance-criteria closure method, evidence standards, and gap reporting.
+- Read and apply `.cursor/skills/verify-github-issue/SKILL.md` strictly for verification method, evidence standards, gap reporting, and posting the comment on the issue.
 - Follow `AGENTS.md` and repository rules.
 
 Do not weaken or substitute the verification method from `verify-github-issue`.
@@ -48,9 +48,9 @@ For the selected issue:
 Post one consolidated issue comment with:
 
 - Verification outcome (`COMPLETE` or `GAPS REMAIN`).
-- AC/spec/test closure summary per `verify-github-issue`.
+- AC/spec/test mapping summary per `verify-github-issue`.
 - Explicit gap list and required follow-ups when incomplete.
-- Explicit readiness statement when complete (state that the issue is ready to close).
+- When complete, state clearly that verification found no material gaps (per `verify-github-issue`); do not instruct closing the issue.
 
 Use `gh` to post:
 

--- a/.cursor/skills/create-github-issue/SKILL.md
+++ b/.cursor/skills/create-github-issue/SKILL.md
@@ -121,5 +121,5 @@ Always preserve the complete draft on fallback; it is the backup deliverable.
 
 ## Related
 
-- For **verifying or closing** an existing issue: see [.cursor/skills/verify-github-issue/SKILL.md](../verify-github-issue/SKILL.md).
+- For **verifying** an existing issue: see [.cursor/skills/verify-github-issue/SKILL.md](../verify-github-issue/SKILL.md).
 - For **implementation** after the issue exists: **AGENTS.md**, **CONTRIBUTING.md**, and `.cursor/rules/` (testing, SPEC-required, etc.).

--- a/.cursor/skills/implement-github-issue/SKILL.md
+++ b/.cursor/skills/implement-github-issue/SKILL.md
@@ -9,7 +9,7 @@ description: Implements a fix from a GitHub issue number or URL after validating
 
 The user provides a GitHub **issue number** or **issue URL** (and repo context if ambiguous) and wants the agent to **implement** the described work—not only to plan, verify, or file an issue.
 
-**Related skills:** Use [verify-github-issue](../verify-github-issue/SKILL.md) when the goal is verification or closure only; use [plan-feature](../plan-feature/SKILL.md) when the goal is planning and issue creation without code changes.
+**Related skills:** Use [verify-github-issue](../verify-github-issue/SKILL.md) when the goal is verification only; use [plan-feature](../plan-feature/SKILL.md) when the goal is planning and issue creation without code changes.
 
 ## Non-negotiables
 

--- a/.cursor/skills/plan-feature/SKILL.md
+++ b/.cursor/skills/plan-feature/SKILL.md
@@ -151,5 +151,5 @@ Same as sibling skill: always preserve the full draft if `gh` cannot create the 
 ## Related
 
 - **Bug / gap reports → structured issue (read-only):** [.cursor/skills/create-github-issue/SKILL.md](../create-github-issue/SKILL.md)
-- **Verify or close issues:** [.cursor/skills/verify-github-issue/SKILL.md](../verify-github-issue/SKILL.md)
+- **Verify issues:** [.cursor/skills/verify-github-issue/SKILL.md](../verify-github-issue/SKILL.md)
 - **After the issue exists:** implementation follows **AGENTS.md**, **CONTRIBUTING.md**, and `.cursor/rules/` (SPEC-first, testing, UI wiring).

--- a/.cursor/skills/review-github-issue/SKILL.md
+++ b/.cursor/skills/review-github-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-github-issue
 description: |-
-  Reviews a GitHub issue for coherence between its stated purpose and its proposed approach (design, scope, ACs). Produces a consolidated comment: primary focus is purpose↔method gaps and internal contradictions; code/spec/test evidence only when needed to show the proposed method cannot satisfy the purpose. Use before implementation; use verify-github-issue for issue vs implementation/SPEC/tests closure.
+  Reviews a GitHub issue for coherence between its stated purpose and its proposed approach (design, scope, ACs). Produces a consolidated comment: primary focus is purpose↔method gaps and internal contradictions; code/spec/test evidence only when needed to show the proposed method cannot satisfy the purpose. Use before implementation; use verify-github-issue for AC↔implementation/SPEC/tests verification posted on the issue.
 
   Examples:
   - user: "Review issue #42" → state purpose, assess whether the proposed method plausibly achieves it, flag internal gaps; repo evidence only if method cannot satisfy purpose
@@ -26,7 +26,7 @@ The goal is a **consolidated comment** whose **primary** analysis is:
 
 - **Purpose ↔ method**: gaps or tensions between **what the issue purportedly addresses** (its purpose / outcome) and **how it proposes to get there** (design, steps, scope, dependencies, acceptance criteria as a solution shape).
 
-This skill is **not** centered on re-deriving **“issue description vs current SPEC/implementation/tests”** as the main output. That reconciliation should already live in a well-written issue; **systematic** mapping of acceptance criteria to code, specs, and tests for closure belongs in **`.cursor/skills/verify-github-issue/SKILL.md`**.
+This skill is **not** centered on re-deriving **“issue description vs current SPEC/implementation/tests”** as the main output. That reconciliation should already live in a well-written issue; **systematic** mapping of acceptance criteria to code, specs, and tests belongs in **`.cursor/skills/verify-github-issue/SKILL.md`** (posted as an issue comment).
 
 ## Boundary: review vs verify
 
@@ -148,5 +148,5 @@ Use a neutral, factual tone. Do not close the issue.
 ## Related skills
 
 - **Implement**: `.cursor/skills/implement-github-issue/SKILL.md`
-- **Verify / close** (issue vs implementation, SPEC, tests): `.cursor/skills/verify-github-issue/SKILL.md`
+- **Verify** (issue vs implementation, SPEC, tests): `.cursor/skills/verify-github-issue/SKILL.md`
 - Tracing hints (when step 5 applies): `.opencode/skills/review-github-issue/references/review-reference.md`

--- a/.cursor/skills/verify-github-issue/SKILL.md
+++ b/.cursor/skills/verify-github-issue/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: verify-github-issue
-description: Verifies one open GitHub issue is fully satisfied against acceptance criteria, specs, tests, and CONTRIBUTING workflow; proposes concrete gap fixes or drafts a closing comment and close steps. Use when the user gives an issue number or issue URL and wants verification, gap analysis, or issue closure aligned with dev-branch PRs.
+description: Verifies one open GitHub issue against acceptance criteria, specs, tests, and CONTRIBUTING workflow; uses the gh CLI directly to read the issue and post a consolidated verification comment; proposes concrete gap fixes when work is incomplete. Use when the user gives an issue number or issue URL and wants verification or gap analysis aligned with dev-branch PRs.
 ---
 
-# Verify and close a GitHub issue (ColonizeThis)
+# Verify a GitHub issue (ColonizeThis)
 
 ## When this applies
 
@@ -21,13 +21,17 @@ Follow **[AGENTS.md](../../../AGENTS.md)** (Cursor rules under `.cursor/rules/`)
 
 Also respect **SPEC-first** (`colonizethis-spec-required.mdc`): no behavior that contradicts GDD/TDD; extend SPEC before implementing unauthorized scope.
 
+## GitHub CLI (`gh`) — required path
+
+Use the **`gh`** binary **directly** from the workspace repo clone. Issue **read** uses **`gh issue view`**; posting the verification uses **`gh issue comment`**.
+
 ## Workflow
 
 1. **Load the issue**  
-   Use authenticated GitHub access when available (e.g. `gh issue view <n> --json title,body,labels,state,url` or the web UI). Confirm state is **open**.
+   Run **`gh issue view <n> --json title,body,labels,state,url`** (add **`--repo owner/name`** when the issue is not on the clone’s default remote). Confirm state is **open**.
 
 2. **Extract requirements**  
-   From the issue body (and comments): goals, **acceptance criteria**, links to SPEC/files, edge cases. If ACs are missing or vague, **state that gap** and propose minimal AC text before claiming full resolution.
+   From the issue body (and comments): goals, **acceptance criteria**, links to SPEC/files, edge cases. If ACs are missing or vague, **state that gap** and propose minimal AC text before claiming full verification.
 
 3. **Trace to code and specs**  
    Search the repo for implementations, related PRs/commits, and SPEC sections. Map each AC item to: implemented / partial / missing / unknown.
@@ -38,38 +42,40 @@ Also respect **SPEC-first** (`colonizethis-spec-required.mdc`): no behavior that
 5. **Branch and PR posture**  
    Any fix must be described as a PR **into `dev`**, following CONTRIBUTING pre-PR checklist (SPEC/AC updates, logging alignment if applicable, coverage).
 
-6. **Output**
+6. **Post the verification on GitHub**  
+   **Always** publish the result as an **issue comment** on that issue (same number/repo as step 1) using **`gh issue comment`**: `gh issue comment <n> --body-file <path>` or `gh issue comment <n> --body "<markdown>"`. Use **`--repo owner/name`** when the issue is not on the clone’s default remote.
+
+7. **Comment body**
 
    **If there are gaps**  
-   - List each gap with severity (blocks closure vs follow-up).  
-   - Propose a **concrete** remedy: files to touch, SPEC updates, test cases, and PR scope.  
-   - Do **not** close the issue.
+   - List each gap with severity (blocks “verified complete” vs follow-up).  
+   - Propose a **concrete** remedy: files to touch, SPEC updates, test cases, and PR scope.
 
    **If fully addressed**  
-   - Summarize evidence: AC → implementation → tests → target branch (`dev`).  
-   - Draft a **short closing comment** for GitHub (what shipped, where, how ACs are met).  
-   - Instruct the user to **close via** `gh issue close <n> --comment "<draft>"` (or web UI) using their credentials; do not assume the agent has permission to close on their behalf.
+   - Summarize evidence: AC → implementation → tests → target branch (`dev`).
 
-## Closing comment template
+   In both cases, use a neutral, factual tone. The **only** required GitHub write for this skill is the verification **comment**—not labels, milestones, or issue state.
+
+## Verification comment template
 
 Use a neutral, factual tone:
 
 ```markdown
-Verified against the stated acceptance criteria:
+**Verification** (ACs / SPEC / tests)
 
-- [AC summary bullets tied to code/tests]
+- [AC summary bullets tied to code/tests; mark partial/missing where applicable]
 
 Implementation: [PR link or commit refs if known]. Tests: [what was run / added]. PR targets `dev` per CONTRIBUTING.
 
-Closing as complete.
+Outcome: [Complete | Gaps remain — see above].
 ```
 
-Adjust if some work landed without a merged PR yet — then **do not** recommend closure until merge criteria are met.
+If some work exists but is not merged yet, state that verification is **conditional on merge** and list what must land before a “complete” outcome.
 
 ## Tools
 
-- Prefer **`gh`** when installed and authenticated for viewing issues and closing with a comment.  
-- Use repo search and test commands as in AGENTS/CONTRIBUTING; do not invent branch or review policy.
+- **`gh`** for GitHub: `gh issue view`, **`gh issue comment`**.  
+- Repo search and test commands per AGENTS/CONTRIBUTING; do not invent branch or review policy.
 
 ## Additional resources
 

--- a/.cursor/skills/verify-github-issue/reference.md
+++ b/.cursor/skills/verify-github-issue/reference.md
@@ -20,8 +20,9 @@ Source: repo root `AGENTS.md`.
 # View issue (JSON for scripting)
 gh issue view 42 --json title,body,state,labels,url
 
-# Close with comment (user must be logged in)
-gh issue close 42 --comment "Verified: …"
+# Post verification result as an issue comment (user must be logged in)
+gh issue comment 42 --body-file verification.md
+# or: gh issue comment 42 --body "$(cat verification.md)"
 ```
 
-Replace `42` with the issue number; run from a clone of the repo with `gh auth login` completed.
+Replace `42` with the issue number; run from a clone of the repo with `gh auth login` completed. This skill’s GitHub write is the comment only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Skills live under `.cursor/skills/<name>/SKILL.md`. When a skill matches the tas
 | `refine-github-issue` | Refine an open issue from comment feedback (repro, root cause, priorities); update the body or return numbered clarifications when feedback conflicts with SPEC. |
 | `review-pr` | Review an open pull request against issue alignment, acceptance-criteria coverage, architecture conventions, and linting compliance; post all findings as a PR comment with strict YES/CONDITIONAL YES/NO outcomes. |
 | `review-github-issue` | Review an issue for **purpose ↔ proposed method** coherence and internal consistency; repo/SPEC/test evidence only when needed to show the method cannot satisfy the purpose. Consolidated comment with priorities and remedies; use **`verify-github-issue`** for AC↔implementation closure. |
-| `verify-github-issue` | Verify one open issue against ACs/specs/tests; gap analysis or closure steps. |
+| `verify-github-issue` | Verify one open issue against ACs/specs/tests; post results as an issue comment; gap analysis when incomplete. |
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Updates the `verify-github-issue` Cursor skill and aligned references:

- **Verification** is posted with `gh issue comment` (and issues are read with `gh issue view`); no web/manual fallback paths in the skill text.
- **No issue-closing** workflow; cross-links in AGENTS and other skills no longer say "verify or close."
- **backlog-verify-agent** wording adjusted so it does not instruct "ready to close."

## Files

- `.cursor/skills/verify-github-issue/SKILL.md`
- `.cursor/skills/verify-github-issue/reference.md`
- `AGENTS.md`
- `.cursor/skills/review-github-issue/SKILL.md`
- `.cursor/skills/implement-github-issue/SKILL.md`
- `.cursor/skills/plan-feature/SKILL.md`
- `.cursor/skills/create-github-issue/SKILL.md`
- `.cursor/skills/backlog-verify-agent/SKILL.md`

Made with [Cursor](https://cursor.com)