### PR TITLE
colonizethis_map: centralize non-tile pipe splits + CI gate (Refs #2087)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -437,6 +437,9 @@ jobs:
       - name: Test canonical province tile-key checker (SPEC/game/world-model-identity.md)
         run: dart test test/check_canonical_province_tile_keys_test.dart --reporter=compact
 
+      - name: Test colonizethis_map lib pipe-split checker (SPEC/program/map-visualization.md)
+        run: dart test test/check_colonizethis_map_lib_pipe_split_test.dart --reporter=compact
+
       - name: Wang incremental assets gate (Python)
         run: |
           set -euo pipefail

--- a/packages/colonizethis_map/lib/src/init_game_map_view_builder.dart
+++ b/packages/colonizethis_map/lib/src/init_game_map_view_builder.dart
@@ -8,6 +8,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'combine_region_topologies.dart';
 import 'init_game_map_view_data.dart';
+import 'map_pipe_string_util.dart';
 import 'port_icon_placement.dart';
 import 'region_constants.dart';
 import 'sea_zone_centroid_tile.dart';

--- a/packages/colonizethis_map/lib/src/init_game_map_view_builder_fleet_markers_part.dart
+++ b/packages/colonizethis_map/lib/src/init_game_map_view_builder_fleet_markers_part.dart
@@ -91,7 +91,7 @@ String? _fleetMarkerTileKeyForLocationScope({
 }) {
   if (scopeKey.startsWith('sea:')) {
     final zoneKey = scopeKey.substring(4);
-    final local = zoneKey.contains('|') ? zoneKey.split('|').last : zoneKey;
+    final local = mapPipeLastSegmentOrWhole(zoneKey);
     return seaZoneCentroidTileKey(
       tileMap: tileMap,
       regionId: regionId,

--- a/packages/colonizethis_map/lib/src/locked_full_init_tile_map_pair.dart
+++ b/packages/colonizethis_map/lib/src/locked_full_init_tile_map_pair.dart
@@ -1,10 +1,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 
 import 'map_partition_gates_exhausted.dart';
+import 'region_constants.dart';
 import 'tile_map_generator.dart';
-
-const String _kRegionOldWorld = 'oldWorld';
-const String _kRegionNewWorld = 'newWorld';
 
 const double _kDefaultSeaFraction = 0.6;
 
@@ -59,7 +57,7 @@ generateLockedFullInitTileMapPair({
     final (tileOw, topoOw) = TileMapGenerator(params: paramsOW).generate(
       numProvinces: config.numProvincesOldWorld,
       numContinents: config.continentCount,
-      regionId: _kRegionOldWorld,
+      regionId: kRegionOldWorld,
       resourceRules: ResourceRules.defaultRules,
       onLog: onLog,
       continentProvinceSizes: const [13, 13, 17, 17],
@@ -88,7 +86,7 @@ generateLockedFullInitTileMapPair({
         1,
         config.numProvincesNewWorld,
       ),
-      regionId: _kRegionNewWorld,
+      regionId: kRegionNewWorld,
       resourceRules: ResourceRules.defaultRules,
       onLog: onLog,
       continentProvinceSizes: const [6, 6, 9, 9],

--- a/packages/colonizethis_map/lib/src/map_pipe_string_util.dart
+++ b/packages/colonizethis_map/lib/src/map_pipe_string_util.dart
@@ -1,0 +1,38 @@
+// Pipe-delimited strings in colonizethis_map that are not canonical map tile
+// keys `regionId|provinceId|x|y`. Tile keys use tile_key_util.dart. GitHub #2087.
+
+/// Local province id from a `portsByProvinceSeaboard` **key** for [regionId].
+/// SPEC/ui/town-port-icons.md, GitHub #1770.
+String? mapPipeLocalProvinceIdFromPortsSeaboardKey(
+  String seaboardKey,
+  String regionId,
+) {
+  final parts = seaboardKey.split('|');
+  if (parts.length >= 3) {
+    if (parts[0] != regionId) {
+      return null;
+    }
+    return parts[1];
+  }
+  if (parts.length == 2) {
+    return parts[0];
+  }
+  return null;
+}
+
+/// Parses `left|right` when exactly two segments (e.g. topology adjacency pairs).
+(String left, String right)? mapPipeTryParseTwoPartPair(String value) {
+  final parts = value.split('|');
+  if (parts.length == 2) {
+    return (parts[0], parts[1]);
+  }
+  return null;
+}
+
+/// Last `|` segment when present; otherwise the whole string (e.g. sea-zone id).
+String mapPipeLastSegmentOrWhole(String value) {
+  if (!value.contains('|')) {
+    return value;
+  }
+  return value.split('|').last;
+}

--- a/packages/colonizethis_map/lib/src/port_icon_placement.dart
+++ b/packages/colonizethis_map/lib/src/port_icon_placement.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'map_pipe_string_util.dart';
 import 'tile_key_util.dart';
 
 /// Orthogonal scan order: North, East, South, West.
@@ -92,19 +93,7 @@ String _portPlacementContextSuffix(String? contextLabel) {
 String? localProvinceIdFromPortsSeaboardKey(
   String seaboardKey,
   String regionId,
-) {
-  final parts = seaboardKey.split('|');
-  if (parts.length >= 3) {
-    if (parts[0] != regionId) {
-      return null;
-    }
-    return parts[1];
-  }
-  if (parts.length == 2) {
-    return parts[0];
-  }
-  return null;
-}
+) => mapPipeLocalProvinceIdFromPortsSeaboardKey(seaboardKey, regionId);
 
 /// Authoritative **land** port tile key from [Game.worldState.portsByProvinceSeaboard]
 /// for [localProvinceId] in [regionId]. Null when no entry matches.

--- a/packages/colonizethis_map/lib/src/topology_inference.dart
+++ b/packages/colonizethis_map/lib/src/topology_inference.dart
@@ -2,12 +2,11 @@
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 
+import 'map_pipe_string_util.dart';
+
 /// Infers MapTopology from a tile map result. SPEC/program/tile-map-gen-resources.md § Topology inference.
 /// Collects unique region ids from grid; classifies province vs sea zone; builds edges from adjacencies.
-MapTopology inferTopologyFromTileMap(
-  TileMapResult result,
-  String regionId,
-) {
+MapTopology inferTopologyFromTileMap(TileMapResult result, String regionId) {
   final ids = <String>{};
   for (var y = 0; y < result.height; y++) {
     for (var x = 0; x < result.width; x++) {
@@ -26,15 +25,17 @@ MapTopology inferTopologyFromTileMap(
   final pairs = result.adjacentRegionPairs();
   final edges = <TopologyEdge>[];
   for (final pair in pairs) {
-    final parts = pair.split('|');
-    if (parts.length == 2) {
-      edges.add(TopologyEdge(id1: parts[0], id2: parts[1]));
+    final parsed = mapPipeTryParseTwoPartPair(pair);
+    if (parsed != null) {
+      edges.add(TopologyEdge(id1: parsed.$1, id2: parsed.$2));
     }
   }
 
-  return MapTopology(nodes: nodes..sort((a, b) => a.id.compareTo(b.id)), edges: edges);
+  return MapTopology(
+    nodes: nodes..sort((a, b) => a.id.compareTo(b.id)),
+    edges: edges,
+  );
 }
 
 /// Ids matching s + digits (e.g. s1, s2) are sea zones. Others are provinces.
 bool _isSeaZoneId(String id) => RegExp(r'^s\d+$').hasMatch(id);
-

--- a/packages/colonizethis_map/test/map_pipe_string_util_test.dart
+++ b/packages/colonizethis_map/test/map_pipe_string_util_test.dart
@@ -1,0 +1,51 @@
+import 'package:colonizethis_map/src/map_pipe_string_util.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('mapPipeLocalProvinceIdFromPortsSeaboardKey', () {
+    test('parses region|local|extra as local when region matches', () {
+      expect(
+        mapPipeLocalProvinceIdFromPortsSeaboardKey('oldWorld|p1|x', 'oldWorld'),
+        'p1',
+      );
+    });
+
+    test('returns null when region prefix mismatches', () {
+      expect(
+        mapPipeLocalProvinceIdFromPortsSeaboardKey('newWorld|p1|x', 'oldWorld'),
+        isNull,
+      );
+    });
+
+    test('two-segment key returns first segment as local id', () {
+      expect(
+        mapPipeLocalProvinceIdFromPortsSeaboardKey('p1|ignored', 'oldWorld'),
+        'p1',
+      );
+    });
+  });
+
+  group('mapPipeTryParseTwoPartPair', () {
+    test('parses exactly two segments', () {
+      final p = mapPipeTryParseTwoPartPair('a|b');
+      expect(p, isNotNull);
+      expect(p!.$1, 'a');
+      expect(p.$2, 'b');
+    });
+
+    test('returns null when not two segments', () {
+      expect(mapPipeTryParseTwoPartPair('a|b|c'), isNull);
+      expect(mapPipeTryParseTwoPartPair('a'), isNull);
+    });
+  });
+
+  group('mapPipeLastSegmentOrWhole', () {
+    test('returns whole string when no pipe', () {
+      expect(mapPipeLastSegmentOrWhole('s1'), 's1');
+    });
+
+    test('returns last segment when pipe present', () {
+      expect(mapPipeLastSegmentOrWhole('oldWorld|s3'), 's3');
+    });
+  });
+}

--- a/test/check_colonizethis_map_lib_pipe_split_test.dart
+++ b/test/check_colonizethis_map_lib_pipe_split_test.dart
@@ -1,0 +1,36 @@
+import 'package:test/test.dart';
+
+import '../tool/check_colonizethis_map_lib_pipe_split.dart';
+
+void main() {
+  group('findColonizethisMapLibPipeSplitViolations', () {
+    test('flags split pipe literal outside allowed modules', () {
+      const src = r'''
+void f(String k) {
+  final p = k.split('|');
+  print(p);
+}
+''';
+      final v = findColonizethisMapLibPipeSplitViolations(
+        relativePath: 'packages/colonizethis_map/lib/src/foo.dart',
+        source: src,
+      );
+      expect(v, isNotEmpty);
+      expect(v.first.line, greaterThan(0));
+    });
+
+    test('ignores split with other delimiter', () {
+      const src = r'''
+void f(String k) {
+  final p = k.split(',');
+  print(p);
+}
+''';
+      final v = findColonizethisMapLibPipeSplitViolations(
+        relativePath: 'packages/colonizethis_map/lib/src/foo.dart',
+        source: src,
+      );
+      expect(v, isEmpty);
+    });
+  });
+}

--- a/tool/check_colonizethis_map_lib_pipe_split.dart
+++ b/tool/check_colonizethis_map_lib_pipe_split.dart
@@ -1,0 +1,136 @@
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:path/path.dart' as p;
+
+/// Map tile keys and other pipe-delimited map strings: `.split('|')` must live
+/// only in [tile_key_util.dart] (tile keys) or [map_pipe_string_util.dart]
+/// (ports/seaboard keys, topology pairs, sea-zone scope segments). GitHub #2087.
+const _allowedSplitPipeLiteralPaths = <String>{
+  'packages/colonizethis_map/lib/src/tile_key_util.dart',
+  'packages/colonizethis_map/lib/src/map_pipe_string_util.dart',
+};
+
+const _mapLibRoot = 'packages/colonizethis_map/lib';
+
+/// Used by `ct_repo_lint` in-process; [info] / [err] default to stdout/stderr.
+int runCheckColonizethisMapLibPipeSplit(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+  final root = p.normalize(repoRoot);
+  final libDir = Directory(p.join(root, _mapLibRoot));
+  if (!libDir.existsSync()) {
+    logE('check_colonizethis_map_lib_pipe_split: missing $libDir');
+    return 1;
+  }
+
+  final violations = <ColonizethisMapLibPipeSplitViolation>[];
+  for (final file in libDir.listSync(recursive: true, followLinks: false)) {
+    if (file is! File || !file.path.endsWith('.dart')) {
+      continue;
+    }
+    final relPath = p.normalize(p.relative(file.path, from: root));
+    if (_allowedSplitPipeLiteralPaths.contains(relPath)) {
+      continue;
+    }
+    final source = file.readAsStringSync();
+    violations.addAll(
+      findColonizethisMapLibPipeSplitViolations(
+        relativePath: relPath,
+        source: source,
+      ),
+    );
+  }
+
+  if (violations.isEmpty) {
+    logI('colonizethis_map lib pipe-split check passed.');
+    return 0;
+  }
+
+  logE(
+    'ERROR: `.split(\'|\')` must only appear in ${_allowedSplitPipeLiteralPaths.join(", ")}.',
+  );
+  for (final v in violations) {
+    logE('${v.path}:${v.line}:${v.column} ${v.message}');
+  }
+  return 1;
+}
+
+void main() {
+  exit(runCheckColonizethisMapLibPipeSplit(Directory.current.path));
+}
+
+List<ColonizethisMapLibPipeSplitViolation>
+findColonizethisMapLibPipeSplitViolations({
+  required String relativePath,
+  required String source,
+}) {
+  final parsed = parseString(
+    content: source,
+    path: relativePath,
+    throwIfDiagnostics: false,
+  );
+  final visitor = _SplitPipeLiteralVisitor(
+    path: relativePath,
+    unit: parsed.unit,
+  );
+  parsed.unit.accept(visitor);
+  return visitor.violations;
+}
+
+class ColonizethisMapLibPipeSplitViolation {
+  const ColonizethisMapLibPipeSplitViolation({
+    required this.path,
+    required this.line,
+    required this.column,
+    required this.message,
+  });
+
+  final String path;
+  final int line;
+  final int column;
+  final String message;
+}
+
+class _SplitPipeLiteralVisitor extends RecursiveAstVisitor<void> {
+  _SplitPipeLiteralVisitor({required this.path, required this.unit});
+
+  final String path;
+  final CompilationUnit unit;
+  final List<ColonizethisMapLibPipeSplitViolation> violations = [];
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (node.methodName.name == 'split' && _firstArgIsPipeStringLiteral(node)) {
+      final loc = unit.lineInfo.getLocation(node.offset);
+      violations.add(
+        ColonizethisMapLibPipeSplitViolation(
+          path: path,
+          line: loc.lineNumber,
+          column: loc.columnNumber,
+          message:
+              'Disallowed `.split(\'|\')`; use tile_key_util or map_pipe_string_util.',
+        ),
+      );
+    }
+    super.visitMethodInvocation(node);
+  }
+
+  bool _firstArgIsPipeStringLiteral(MethodInvocation node) {
+    final args = node.argumentList.arguments;
+    if (args.isEmpty) {
+      return false;
+    }
+    final first = args.first;
+    if (first is SimpleStringLiteral) {
+      return first.value == '|';
+    }
+    return false;
+  }
+}

--- a/tool/ct_repo_lint_lib.dart
+++ b/tool/ct_repo_lint_lib.dart
@@ -8,6 +8,7 @@ import 'check_app_hardcoded_ui_strings.dart';
 import 'check_app_event_handler_scope_logic_boundary.dart';
 import 'check_asset_path_constants.dart';
 import 'check_canonical_province_tile_keys.dart';
+import 'check_colonizethis_map_lib_pipe_split.dart';
 import 'check_civilian_unit_type_constants.dart';
 import 'check_control_flow_nesting_depth.dart';
 import 'check_custom_exceptions.dart';
@@ -739,6 +740,8 @@ int? _tryRunDartRuleInProcess({
       );
     case 'repo.canonical_province_tile_keys':
       return runCheckCanonicalProvinceTileKeys(repoRoot);
+    case 'repo.colonizethis_map_lib_pipe_split':
+      return runCheckColonizethisMapLibPipeSplit(repoRoot);
     case 'repo.land_province_bucket_keys':
       return runCheckLandProvinceBucketKeys(repoRoot);
     case 'repo.logic_dual_region_province_field_access':

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -159,6 +159,13 @@ rules:
     runner: dart
     script: tool/check_canonical_province_tile_keys.dart
 
+  - rule_id: repo.colonizethis_map_lib_pipe_split
+    group: structure
+    title: colonizethis_map lib limits `.split('|')` to tile_key_util / map_pipe_string_util
+    spec: SPEC/program/map-visualization.md
+    runner: dart
+    script: tool/check_colonizethis_map_lib_pipe_split.dart
+
   - rule_id: repo.land_province_bucket_keys
     group: game_invariants
     title: Canonical full-id land province bucket lookups in guarded paths


### PR DESCRIPTION
## Summary

Completes the **CI / enforcement** slice for GitHub #2087: `.split('|')` in `packages/colonizethis_map/lib/` may only appear in `tile_key_util.dart` (canonical map tile keys) or the new `map_pipe_string_util.dart` (ports/seaboard dictionary keys, topology two-part adjacency pairs, sea-zone scope local segment).

## Changes

- **`map_pipe_string_util.dart`**: holds seaboard-key parsing, two-part pair parsing, and `last segment or whole` for fleet sea scope keys; `port_icon_placement`, `topology_inference`, and fleet markers delegate here.
- **`tool/check_colonizethis_map_lib_pipe_split.dart`**: AST scan over map `lib/`; integrated as `repo.colonizethis_map_lib_pipe_split` in `ct_repo_lint_manifest.yaml` / `ct_repo_lint_lib.dart`.
- **Tests**: `packages/colonizethis_map/test/map_pipe_string_util_test.dart`, `test/check_colonizethis_map_lib_pipe_split_test.dart`.
- **CI**: `quality.yml` runs the new root test file (same pattern as other checker tests).

## Out of scope (issue #2087 remainder)

Other AC items (e.g. further `TileMapGenerator` cleanup if any remains, part-file naming) were already largely addressed on `dev` before this slice; this PR only lands the **pipe-split enforcement** and the **non-tile pipe** consolidation.

## Validation

- `dart run tool/check_colonizethis_map_lib_pipe_split.dart`
- `dart test test/check_colonizethis_map_lib_pipe_split_test.dart`
- `dart test packages/colonizethis_map/test/map_pipe_string_util_test.dart` plus focused `topology_inference` / `port_icon_placement` / `tile_key_util` tests
- `dart run tool/ct_repo_lint.dart` (all rules green)

Refs #2087

Made with [Cursor](https://cursor.com)