### PR TITLE
chore(pub): refresh root lockfile for Dart 3.11.5 (Refs #2073)

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -544,10 +544,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -568,10 +568,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -957,26 +957,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.29.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.16"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

Regenerates the workspace root `pubspec.lock` with `dart pub get` under **Dart 3.11.5** (bundled with the repo’s CI-pinned **Flutter 3.41.9** from #2098) so the committed lock matches what contributors and Actions resolve after upgrading.

## Scope

- **In scope:** Root `pubspec.lock` only (this repo tracks a single workspace lockfile).
- **Out of scope:** Broad `pub upgrade --major-versions` / “Latest column” sweep across every direct dependency (still deferred per issue discussion after #2098).

## Verification

- `dart pub get` at repo root completes with **no** `advisoriesUpdated must be a String` errors on Dart 3.11.5.
- `dart test test/check_colonizethis_map_lib_pipe_split_test.dart` (root) — passed.

Refs #2073

Made with [Cursor](https://cursor.com)