### PR TITLE
chore(pub): bump google_fonts to ^8.1.0 in app (Refs #2073)

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   colonizethis_ai:
   colonizethis_debug_console:
   widgetbook: ^3.22.0
-  google_fonts: ^6.3.3
+  google_fonts: ^8.1.0
   intl: ^0.20.2
   window_manager: ^0.5.1
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -363,10 +363,10 @@ packages:
     dependency: transitive
     description:
       name: google_fonts
-      sha256: ba03d03bcaa2f6cb7bd920e3b5027181db75ab524f8891c8bc3aa603885b8055
+      sha256: "4e9391085e524954a51e3625b7c9c7e9851dc3f376603208bb45c24b9a66255d"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.3"
+    version: "8.1.0"
   graphs:
     dependency: transitive
     description:


### PR DESCRIPTION
## References

Refs #2073 (partial delivery; does not close the issue).

## Scope

**This PR:** Raises the `colonizethis_app` direct dependency `google_fonts` from `^6.3.3` to `^8.1.0` and commits the workspace `pubspec.lock` update from `dart pub get` at the repo root. That brings this direct dependency to the current **Latest** line on pub.dev while keeping the existing analyzer / custom_lint stack on 8.x.

**Deferred on #2073:** Coordinated major work called out in the issue remains out of scope here, including the `analyzer` 13 / `custom_lint*` / `test` 1.31.x / `xml` 7.x passes and a full `flutter pub upgrade --major-versions` sweep across every Flutter workspace member.

## AC / spec coverage

- Addresses part of the issue’s workspace dependency goal for the **google_fonts** direct dependency only.
- No GDD/TDD change (tooling/deps only; aligns with the issue’s note that SPEC is not required for the advisories decode diagnosis itself).

## Validation run locally

- `dart pub get` (repo root)
- `cd app && flutter pub get && flutter analyze --no-fatal-infos --no-fatal-warnings`
- `cd app && flutter test test/themes_and_widgetbook_test.dart` (covers `AppThemes` / `GoogleFonts.cinzel` wiring)
- `dart run tool/run_workspace_analyze_errors_only.dart`
- `dart run tool/ct_repo_lint.dart`


Made with [Cursor](https://cursor.com)