### PR TITLE
docs(contributing): pub outdated intentional caps (Refs #2073)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,16 @@ GitHub Actions workflows that install Flutter (see `.github/workflows/quality.ym
 
 If `dart pub get` or `flutter pub get` fails while resolving hosted packages with **`FormatException: advisoriesUpdated must be a String`**, upgrade your Flutter/Dart install to at least this pair (or newer stable that remains compatible with the repo’s `environment.sdk` lower bound in each `pubspec.yaml`).
 
+### `dart pub outdated` / “Latest” vs what the workspace resolves
+
+`dart pub outdated` and `flutter pub outdated` compare the lockfile to **pub.dev “Latest”**; several rows often stay behind even on a healthy workspace. Common reasons in this repo:
+
+- **`test` / `test_api` / `test_core`:** Flutter’s **`flutter_test`** (from the SDK) pins **`test_api`** to the version shipped with that Flutter release. The standalone **`test`** package may therefore sit **below** pub.dev “Latest” (for example when Latest needs a newer `test_api`) until a **newer Flutter stable** relaxes that pin. This is expected; do not “fix” it by forcing `dependency_overrides` on `test_api` for normal work.
+- **`analyzer` / `analyzer_plugin` / `_fe_analyzer_shared`:** **`colonizethis_exception_lint`** and **`custom_lint_builder`** must agree on an **`analyzer`** major. **`analyzer_plugin` 0.14.x** depends on **`analyzer` 13**, while today’s **`custom_lint_builder`** line stays on **`analyzer` ^8.x**—so the workspace intentionally holds **`analyzer` ^8** and **`analyzer_plugin` ^0.13.x`** until upstream `custom_lint` packages publish a compatible analyzer-13 stack. Treat that gap as an **intentional cap**, not a stale lockfile.
+- **Other transitives (`xml`, `inspector`, …):** May lag “Latest” until a **direct** dependency raises its constraints; the solver picks the **newest jointly resolvable** graph across all workspace members.
+
+When bumping dependencies, prefer **`dart pub upgrade`** / **`flutter pub upgrade`** (and coordinated `pubspec.yaml` edits) over overrides; if a row cannot move yet, note the **blocker** (SDK pin or shared dev-tool stack) in the PR or issue.
+
 ## Pre-PR Checklist
 
 Before opening a pull request, ensure the following:


### PR DESCRIPTION
## Implemented (this PR)

- Extend **CONTRIBUTING.md** (Flutter/Dart section) with a subsection explaining why `dart pub outdated` / **Latest** often diverges from the committed lockfile in this workspace:
  - **`test` / `test_api`**: `flutter_test` SDK pin on `test_api` (do not override for routine work).
  - **`analyzer` / `analyzer_plugin`**: `custom_lint_builder` on analyzer ^8 vs `analyzer_plugin` 0.14 requiring analyzer 13 — intentional cap until upstream aligns.
  - **Transitives** (`xml`, `inspector`, …): newest jointly resolvable graph across workspace members.

## Deferred (issue #2073)

- Full coordinated **major** bumps (`analyzer` 13, `xml` 7, `inspector` 4, etc.) once **custom_lint** / **custom_lint_builder** publish an analyzer-13–compatible release (or the issue is rescoped).
- Raising **`test`** to pub.dev Latest when **Flutter** ships a `test_api` pin that allows it.

## AC / spec coverage

- Addresses the issue’s call to **document intentional dependency caps** and contributor expectations around **pub outdated** noise after the Flutter pin / lockfile slices landed.
- **SPEC:** none (toolchain/contributor docs only; no GDD/TDD behavior change).

## Tests / CI

- Documentation-only change; no code or lockfile edits.

Refs #2073

Made with [Cursor](https://cursor.com)