### PR TITLE
Refs #2071: route connectivity bottleneck BFS through graph_traversal; absorption docs and tests

### DIFF
--- a/packages/colonizethis_logic/lib/src/diplomacy/faction_absorption_engine.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/faction_absorption_engine.dart
@@ -121,6 +121,13 @@ Game _absorbIntoGp(
   );
   next = bulk.game;
 
+  // Great Power absorption remaps GP-only game fields (`generals`,
+  // `purchasedTilesByTileKey`, `playerProspectedTiles`, AI metadata maps,
+  // `politicalGlyphByPlayerId`, `subsidyStates`). Minor/Tribe targets are not
+  // GPs: `SPEC/game/diplomacy.md` Join Empire mandates province/unit/fleet
+  // transfer and relation cleanup for them, but does **not** require those
+  // GP-only cleanups on the minor path—so the branch below is intentionally
+  // GP-only (avoids conflating nation ids with player-owned persistence).
   if (kind == _AbsorptionKind.greatPower) {
     final generals = next.generals
         .map(

--- a/packages/colonizethis_logic/lib/src/utils/graph_traversal.dart
+++ b/packages/colonizethis_logic/lib/src/utils/graph_traversal.dart
@@ -1,9 +1,9 @@
 import 'dart:collection';
 
-/// Shared undirected graph traversals. Refactor slice for waigore/colonizethis#2071.
+/// Shared graph traversals. Refactor slice for waigore/colonizethis#2071.
 ///
-/// **Not a substitute for** domain-specific queues (e.g. tile connectivity with
-/// per-edge transport caps in connectivity resolution).
+/// Includes [propagateConnectivityBottleneckQueue] for capital connectivity
+/// (per-edge transport caps; not the same as [breadthFirstReachableInSubgraph]).
 
 /// Connected components of the subgraph induced by [subset].
 ///
@@ -79,4 +79,57 @@ Set<T> breadthFirstReachableInSubgraph<T>(
     }
   }
   return reachable;
+}
+
+/// Propagates tile connectivity using [queue], updating [pathCap] bottleneck
+/// caps per neighbor (max candidate path min transport). Tiles may be re-queued
+/// when their cap improves; this is **not** a plain undirected BFS.
+///
+/// Callers supply predicates and neighbor iteration; see
+/// `connectivity_resolver.dart` § capital land connectivity.
+void propagateConnectivityBottleneckQueue({
+  required List<String> queue,
+  required Set<String> connected,
+  required Map<String, int> pathCap,
+  required bool Function(String tileKey) shouldExpandEdgesFrom,
+  required Iterable<String> Function(String tileKey) neighborsOf,
+  required int Function(String neighborKey) transportLevelAt,
+}) {
+  while (queue.isNotEmpty) {
+    final key = queue.removeAt(0);
+    if (!shouldExpandEdgesFrom(key)) continue;
+    final bottleneckU = pathCap[key] ?? 0;
+    for (final neighbor in neighborsOf(key)) {
+      final transportN = transportLevelAt(neighbor);
+      final candidate = bottleneckU < transportN ? bottleneckU : transportN;
+      _relaxBottleneckNeighbor(
+        neighbor: neighbor,
+        candidate: candidate,
+        connected: connected,
+        pathCap: pathCap,
+        queue: queue,
+      );
+    }
+  }
+}
+
+void _relaxBottleneckNeighbor({
+  required String neighbor,
+  required int candidate,
+  required Set<String> connected,
+  required Map<String, int> pathCap,
+  required List<String> queue,
+}) {
+  final existing = pathCap[neighbor] ?? -1;
+  if (candidate > existing) {
+    pathCap[neighbor] = candidate;
+    connected.add(neighbor);
+    queue.add(neighbor);
+    return;
+  }
+  if (!connected.contains(neighbor)) {
+    connected.add(neighbor);
+    pathCap[neighbor] = candidate;
+    queue.add(neighbor);
+  }
 }

--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -289,7 +289,7 @@ ConnectivityResult _connectedTilesForPlayer({
   final connected = <String>{capitalKey};
   final pathCap = <String, int>{};
   pathCap[capitalKey] = _transportLevelAtTile(worldState, capitalKey);
-  _propagateConnectivity(
+  _runConnectivityPropagation(
     queue: <String>[capitalKey],
     connected: connected,
     pathCap: pathCap,
@@ -297,7 +297,6 @@ ConnectivityResult _connectedTilesForPlayer({
     tileMapByRegion: tileMapByRegion,
     provinceIdsByType: provinceIdsByType,
     ownedProvinceIds: owned,
-    portInfo: portInfo,
     canExpandFrom: (tileKey) =>
         (tileKey == capitalKey) ||
         (tileState.roadLevel(tileKey) > 0) ||
@@ -338,7 +337,7 @@ ConnectivityResult _connectedTilesForPlayer({
     );
   }
 
-  _propagateConnectivity(
+  _runConnectivityPropagation(
     queue: expansionSeedQueue,
     connected: connected,
     pathCap: pathCap,
@@ -346,7 +345,6 @@ ConnectivityResult _connectedTilesForPlayer({
     tileMapByRegion: tileMapByRegion,
     provinceIdsByType: provinceIdsByType,
     ownedProvinceIds: owned,
-    portInfo: portInfo,
     canExpandFrom: (tileKey) =>
         (tileState.roadLevel(tileKey) > 0) || portInfo.containsKey(tileKey),
   );
@@ -380,9 +378,7 @@ ConnectivityResult _connectedTilesForPlayer({
   );
 }
 
-/// Queue propagation with per-tile transport bottleneck updates; not a plain
-/// graph BFS (see `lib/src/utils/graph_traversal.dart`).
-void _propagateConnectivity({
+void _runConnectivityPropagation({
   required List<String> queue,
   required Set<String> connected,
   required Map<String, int> pathCap,
@@ -390,64 +386,47 @@ void _propagateConnectivity({
   required Map<String, TileMapResult> tileMapByRegion,
   required Set<String> provinceIdsByType,
   required Set<String> ownedProvinceIds,
-  required Map<String, (String, String)> portInfo,
   required bool Function(String tileKey) canExpandFrom,
 }) {
-  while (queue.isNotEmpty) {
-    final key = queue.removeAt(0);
-    final parts = key.split('|');
-    if (parts.length != 4) continue;
-    final regionId = parts[0];
-    final localProvinceId = parts[1];
-    final fullProvinceId = '$regionId|$localProvinceId';
-    final x = int.tryParse(parts[2]) ?? -1;
-    final y = int.tryParse(parts[3]) ?? -1;
-    if (x < 0 || y < 0) continue;
-    if (!ownedProvinceIds.contains(fullProvinceId)) continue;
-    final map = tileMapByRegion[regionId];
-    if (map == null) continue;
-    if (!canExpandFrom(key)) continue;
-    final bottleneckU = pathCap[key] ?? 0;
-    for (final neighbor in _adjacentTileKeys(
-      regionId,
-      localProvinceId,
-      x,
-      y,
-      map,
-      provinceIdsByType,
-    )) {
-      final transportN = _transportLevelAtTile(worldState, neighbor);
-      final candidate = bottleneckU < transportN ? bottleneckU : transportN;
-      _updateNeighborConnectivity(
-        neighbor: neighbor,
-        candidate: candidate,
-        connected: connected,
-        pathCap: pathCap,
-        queue: queue,
+  propagateConnectivityBottleneckQueue(
+    queue: queue,
+    connected: connected,
+    pathCap: pathCap,
+    shouldExpandEdgesFrom: (key) {
+      final parts = key.split('|');
+      if (parts.length != 4) return false;
+      final regionId = parts[0];
+      final localProvinceId = parts[1];
+      final fullProvinceId = '$regionId|$localProvinceId';
+      final x = int.tryParse(parts[2]) ?? -1;
+      final y = int.tryParse(parts[3]) ?? -1;
+      if (x < 0 || y < 0) return false;
+      if (!ownedProvinceIds.contains(fullProvinceId)) return false;
+      final map = tileMapByRegion[regionId];
+      if (map == null) return false;
+      return canExpandFrom(key);
+    },
+    neighborsOf: (key) {
+      final parts = key.split('|');
+      if (parts.length != 4) return const <String>[];
+      final regionId = parts[0];
+      final localProvinceId = parts[1];
+      final x = int.tryParse(parts[2]) ?? -1;
+      final y = int.tryParse(parts[3]) ?? -1;
+      if (x < 0 || y < 0) return const <String>[];
+      final map = tileMapByRegion[regionId];
+      if (map == null) return const <String>[];
+      return _adjacentTileKeys(
+        regionId,
+        localProvinceId,
+        x,
+        y,
+        map,
+        provinceIdsByType,
       );
-    }
-  }
-}
-
-void _updateNeighborConnectivity({
-  required String neighbor,
-  required int candidate,
-  required Set<String> connected,
-  required Map<String, int> pathCap,
-  required List<String> queue,
-}) {
-  final existing = pathCap[neighbor] ?? -1;
-  if (candidate > existing) {
-    pathCap[neighbor] = candidate;
-    connected.add(neighbor);
-    queue.add(neighbor);
-    return;
-  }
-  if (!connected.contains(neighbor)) {
-    connected.add(neighbor);
-    pathCap[neighbor] = candidate;
-    queue.add(neighbor);
-  }
+    },
+    transportLevelAt: (neighbor) => _transportLevelAtTile(worldState, neighbor),
+  );
 }
 
 Set<String> _seaConnectedPortKeysForCapital({

--- a/packages/colonizethis_logic/test/diplomacy/faction_absorption_engine_test.dart
+++ b/packages/colonizethis_logic/test/diplomacy/faction_absorption_engine_test.dart
@@ -6,23 +6,166 @@ import '../test_fixtures.dart';
 
 void main() {
   group('FactionAbsorptionEngine', () {
-    test('absorbGreatPowerIntoGp is a no-op when absorber or target is missing', () {
-      final game = TestFixtures.minimalGame(
-        players: const [
-          Player(id: 'only', displayName: 'Solo', isHuman: true),
-        ],
-      );
-      expect(
-        identical(
-          game,
-          FactionAbsorptionEngine.absorbGreatPowerIntoGp(
+    test(
+      'absorbGreatPowerIntoGp is a no-op when absorber or target is missing',
+      () {
+        final game = TestFixtures.minimalGame(
+          players: const [
+            Player(id: 'only', displayName: 'Solo', isHuman: true),
+          ],
+        );
+        expect(
+          identical(
             game,
-            'gpA',
-            'gpB',
+            FactionAbsorptionEngine.absorbGreatPowerIntoGp(game, 'gpA', 'gpB'),
           ),
-        ),
-        isTrue,
-      );
-    });
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'minor absorption does not remap GP-only persisted maps (intentional)',
+      () {
+        // Tile in a province **not** transferred by bulk ownership apply, so
+        // `purchasedTilesByTileKey` is not cleared by province transfer logic.
+        const tileKey = 'oldWorld|p2|0|0';
+        final game =
+            TestFixtures.minimalGame(
+              players: const [
+                Player(
+                  id: 'gp1',
+                  displayName: 'GP',
+                  isHuman: true,
+                  treasury: 50000,
+                ),
+              ],
+              minorNations: [MinorNation(id: 'mn1', displayName: 'Minor')],
+              oldWorld: RegionData(
+                provinces: [
+                  Province(
+                    id: 'oldWorld|p1',
+                    regionId: 'oldWorld',
+                    ownerId: 'mn1',
+                    fortLevel: 0,
+                  ),
+                  Province(
+                    id: 'oldWorld|p2',
+                    regionId: 'oldWorld',
+                    ownerId: 'gp1',
+                    fortLevel: 0,
+                  ),
+                ],
+              ),
+              purchasedTilesByTileKey: {tileKey: 'mn1'},
+              playerProspectedTiles: {
+                'mn1': {'oldWorld|p1|1|1'},
+              },
+            ).copyWith(
+              generals: const [General(id: 'gen1', ownerId: 'mn1')],
+              aiControlByGpId: {'mn1': true},
+            );
+
+        final next = FactionAbsorptionEngine.absorbMinorOrTribeIntoGp(
+          game,
+          'gp1',
+          'mn1',
+          1,
+        );
+
+        expect(next.minorNations, isEmpty);
+        expect(
+          next.worldState.oldWorld.provinces
+              .singleWhere((p) => p.id == 'oldWorld|p1')
+              .ownerId,
+          'gp1',
+        );
+        expect(
+          next.worldState.purchasedTilesByTileKey[tileKey],
+          'mn1',
+          reason: 'minor path skips purchasedTilesByTileKey remapping',
+        );
+        expect(next.generals.single.ownerId, 'mn1');
+        expect(next.aiControlByGpId['mn1'], isTrue);
+        expect(next.worldState.playerProspectedTiles['mn1'], {
+          'oldWorld|p1|1|1',
+        });
+      },
+    );
+
+    test(
+      'great power absorption remaps GP-only persisted state to absorber',
+      () {
+        // Purchased entry sits on gp1-owned province so bulk transfer of gp2
+        // provinces does not strip this key; GP absorption remaps owner id.
+        const tileKey = 'oldWorld|p2|0|0';
+        final ws =
+            TestFixtures.worldStateAtOrdersPhase(
+              oldWorld: RegionData(
+                provinces: [
+                  Province(
+                    id: 'oldWorld|p1',
+                    regionId: 'oldWorld',
+                    ownerId: 'gp2',
+                    fortLevel: 0,
+                  ),
+                  Province(
+                    id: 'oldWorld|p2',
+                    regionId: 'oldWorld',
+                    ownerId: 'gp1',
+                    fortLevel: 0,
+                  ),
+                ],
+              ),
+            ).copyWith(
+              purchasedTilesByTileKey: {tileKey: 'gp2'},
+              playerProspectedTiles: {
+                'gp2': {'t1'},
+              },
+            );
+
+        final game =
+            TestFixtures.twoPlayerGame(
+              player1: const Player(
+                id: 'gp1',
+                displayName: 'A',
+                isHuman: true,
+                treasury: 100000,
+              ),
+              player2: const Player(
+                id: 'gp2',
+                displayName: 'B',
+                isHuman: false,
+                treasury: 0,
+              ),
+              worldState: ws,
+            ).copyWith(
+              generals: const [General(id: 'g1', ownerId: 'gp2')],
+              aiControlByGpId: {'gp2': true, 'gp1': false},
+              aiSeedByGpId: {'gp2': 42},
+              hiddenAgendaByGpId: {'gp2': 'hidden'},
+              politicalGlyphByPlayerId: {'gp2': 'x'},
+            );
+
+        final next = FactionAbsorptionEngine.absorbGreatPowerIntoGp(
+          game,
+          'gp1',
+          'gp2',
+        );
+
+        expect(next.players.map((p) => p.id), ['gp1']);
+        expect(next.generals.single.ownerId, 'gp1');
+        expect(next.worldState.purchasedTilesByTileKey[tileKey], 'gp1');
+        expect(
+          next.worldState.playerProspectedTiles.containsKey('gp2'),
+          isFalse,
+        );
+        expect(next.worldState.playerProspectedTiles['gp1'], contains('t1'));
+        expect(next.aiControlByGpId.containsKey('gp2'), isFalse);
+        expect(next.aiSeedByGpId.containsKey('gp2'), isFalse);
+        expect(next.hiddenAgendaByGpId.containsKey('gp2'), isFalse);
+        expect(next.politicalGlyphByPlayerId.containsKey('gp2'), isFalse);
+      },
+    );
   });
 }

--- a/packages/colonizethis_logic/test/utils/graph_traversal_test.dart
+++ b/packages/colonizethis_logic/test/utils/graph_traversal_test.dart
@@ -76,4 +76,32 @@ void main() {
       expect(r, {'a', 'b'});
     });
   });
+
+  group('propagateConnectivityBottleneckQueue', () {
+    test('relaxes neighbors with min bottleneck vs transport cap', () {
+      final connected = <String>{'a'};
+      final pathCap = <String, int>{'a': 5};
+      final queue = <String>['a'];
+      propagateConnectivityBottleneckQueue(
+        queue: queue,
+        connected: connected,
+        pathCap: pathCap,
+        shouldExpandEdgesFrom: (_) => true,
+        neighborsOf: (k) {
+          if (k == 'a') return ['b'];
+          if (k == 'b') return ['a', 'c'];
+          if (k == 'c') return ['b'];
+          return const [];
+        },
+        transportLevelAt: (n) {
+          if (n == 'b') return 10;
+          if (n == 'c') return 1;
+          return 0;
+        },
+      );
+      expect(connected, {'a', 'b', 'c'});
+      expect(pathCap['b'], 5);
+      expect(pathCap['c'], 1);
+    });
+  });
 }


### PR DESCRIPTION
## Scope (SLICE)

Addresses the two **verification follow-ups** posted on [#2071](https://github.com/waigore/colonizethisv3/issues/2071) (refactor issue remains open for `backlog:acceptance` until product sign-off).

### Implemented

1. **Graph traversal AC** — The capital-connectivity queue propagation (per-tile transport bottleneck relaxation, previously `_propagateConnectivity`) now runs through `propagateConnectivityBottleneckQueue` in `lib/src/utils/graph_traversal.dart`, with `connectivity_resolver.dart` supplying world/tile predicates. Behavior is unchanged; this satisfies the issue requirement that the fourth identified traversal live in the shared graph module.

2. **Absorption documentation + tests** — Added an explicit comment in `faction_absorption_engine.dart` before the Great Power–only branch explaining why Minor/Tribe absorption does not run GP-only persistence remaps (`SPEC/game/diplomacy.md` Join Empire). Added regression tests contrasting minor vs GP paths for `purchasedTilesByTileKey`, `generals`, `playerProspectedTiles`, and AI metadata maps. Added a small unit test for `propagateConnectivityBottleneckQueue`.

### Deferred / not in this PR

- Issue-wide acceptance and removal of `backlog:implementation` wait on **merge of this PR** and any maintainer re-verification of #2071.
- No SPEC file edits (verification gaps were code/test documentation only).

## Tests

- `dart analyze` on touched library files
- `dart test` `test/connectivity_resolver_test.dart` `test/connectivity_resolver_blockade_test.dart` `test/gp_land_connectivity_repair_test.dart`
- `dart test` `test/diplomacy/faction_absorption_engine_test.dart` `test/utils/graph_traversal_test.dart`

Refs #2071.

Made with [Cursor](https://cursor.com)