### PR TITLE
chore(pub): workspace SDK floor 3.11.5 (Refs #2073)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ All contributions must be submitted via a Pull Request (PR).
 
 GitHub Actions workflows that install Flutter (see `.github/workflows/quality.yml`, `app-android-release.yml`, and `widgetbook-release.yml`) pin **`flutter-version: '3.41.9'`** on the stable channel, which bundles **Dart 3.11.5**. Use the same Flutter stable locally so dependency resolution and pub.dev advisories decoding match CI.
 
+Every workspace `pubspec.yaml` declares **`environment.sdk: '>=3.11.5 <4.0.0'`** so pure Dart packages are not advertised as compatible with a Dart older than the one shipped with that Flutter pin.
+
 If `dart pub get` or `flutter pub get` fails while resolving hosted packages with **`FormatException: advisoriesUpdated must be a String`**, upgrade your Flutter/Dart install to at least this pair (or newer stable that remains compatible with the repo’s `environment.sdk` lower bound in each `pubspec.yaml`).
 
 ### `dart pub outdated` / “Latest” vs what the workspace resolves

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   flutter:

--- a/ctdev/pubspec.yaml
+++ b/ctdev/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.1.0
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   flutter:

--- a/packages/colonizethis_ai/pubspec.yaml
+++ b/packages/colonizethis_ai/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/colonizethisv3/colonizethisv3
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   logger: ^2.0.2

--- a/packages/colonizethis_data/pubspec.yaml
+++ b/packages/colonizethis_data/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/colonizethisv3/colonizethisv3
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   logger: ^2.0.2

--- a/packages/colonizethis_debug_console/pubspec.yaml
+++ b/packages/colonizethis_debug_console/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/colonizethisv3/colonizethisv3
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   colonizethis_logic:

--- a/packages/colonizethis_exception_lint/pubspec.yaml
+++ b/packages/colonizethis_exception_lint/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   analyzer: ^8.4.0

--- a/packages/colonizethis_logger/pubspec.yaml
+++ b/packages/colonizethis_logger/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/colonizethisv3/colonizethisv3
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   logger: ^2.0.2

--- a/packages/colonizethis_logic/pubspec.yaml
+++ b/packages/colonizethis_logic/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/colonizethisv3/colonizethisv3
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   logger: ^2.0.2

--- a/packages/colonizethis_map/pubspec.yaml
+++ b/packages/colonizethis_map/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/colonizethisv3/colonizethisv3
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   logger: ^2.0.2

--- a/packages/colonizethis_models/pubspec.yaml
+++ b/packages/colonizethis_models/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/colonizethisv3/colonizethisv3
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dev_dependencies:
   colonizethis_data:

--- a/packages/colonizethis_save/pubspec.yaml
+++ b/packages/colonizethis_save/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/colonizethisv3/colonizethisv3
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   logger: ^2.0.2

--- a/packages/colonizethis_test/pubspec.yaml
+++ b/packages/colonizethis_test/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/colonizethisv3/colonizethisv3
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   colonizethis_logger: any

--- a/packages/session_log_buffer/pubspec.yaml
+++ b/packages/session_log_buffer/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   colonizethis_logger: any

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1202,5 +1202,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
+  dart: ">=3.11.5 <4.0.0"
   flutter: ">=3.41.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: colonizethis
 publish_to: none
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 workspace:
   - app

--- a/tool/check_gdd_coverage/pubspec.yaml
+++ b/tool/check_gdd_coverage/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   colonizethis_logger: any

--- a/tool/generate_map/pubspec.yaml
+++ b/tool/generate_map/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   colonizethis_data:

--- a/tool/init_game/pubspec.yaml
+++ b/tool/init_game/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   colonizethis_logger:

--- a/tool/show_tech/pubspec.yaml
+++ b/tool/show_tech/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ">=3.11.0 <4.0.0"
+  sdk: ">=3.11.5 <4.0.0"
 
 dependencies:
   colonizethis_logger: any

--- a/tool/sim_combat/pubspec.yaml
+++ b/tool/sim_combat/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   colonizethis_logger:

--- a/tool/sim_combat_montecarlo/pubspec.yaml
+++ b/tool/sim_combat_montecarlo/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   colonizethis_logger:

--- a/tool/sim_economy/pubspec.yaml
+++ b/tool/sim_economy/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   colonizethis_logger:

--- a/tool/sim_scenarios/pubspec.yaml
+++ b/tool/sim_scenarios/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
   colonizethis_logger:

--- a/widgetbook_host/pubspec.yaml
+++ b/widgetbook_host/pubspec.yaml
@@ -21,7 +21,7 @@ resolution: workspace
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
+  sdk: '>=3.11.5 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
## Scope (this PR)

- Raise `environment.sdk` lower bound from **`>=3.11.0`** to **`>=3.11.5`** across all workspace `pubspec.yaml` files (matches Dart bundled with CI-pinned Flutter **3.41.9** per issue and `CONTRIBUTING.md`).
- Refresh root `pubspec.lock` `sdks:` stanza only (solver metadata).
- Document the declared floor explicitly in `CONTRIBUTING.md` next to the Flutter/Dart baseline.

## Deferred (still on #2073)

- Full “Latest column” / `dart pub upgrade --major-versions` sweep (blocked in part by `custom_lint_builder` / `analyzer` stack as already documented in `CONTRIBUTING.md`).
- Any further dependency graph work beyond aligning the documented minimum SDK with CI.

## AC / spec mapping

- Addresses **`environment.sdk` vs pinned Flutter** from #2073 (optional `>=3.11.5` clarity) and keeps contributor docs consistent with the pinned toolchain.
- Does **not** complete the issue’s broader workspace dependency-refresh checklist.

## Validation

- `dart pub get` (repo root)
- `dart run tool/run_workspace_analyze_errors_only.dart`
- `dart run tool/ct_repo_lint.dart`

Refs #2073

Made with [Cursor](https://cursor.com)