### PR TITLE
chore(pub): bump app flame to ^1.37.0 (Refs #2073)

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  flame: ^1.36.0
+  flame: ^1.37.0
   jenny: ^1.5.1
   logger: ^2.0.2
   flutter_riverpod: ^3.3.1


### PR DESCRIPTION
## Summary

Raises the app direct dependency on **Flame** from `^1.36.0` to `^1.37.0` so the declared constraint matches the **already-resolved** workspace graph (root `pubspec.lock` was on 1.37.0 after #2103). No lockfile delta.

## Implemented (this PR)

- `app/pubspec.yaml`: `flame: ^1.37.0`

## Deferred (issue #2073)

- Open **PR #2107** (workspace `environment.sdk` floor **3.11.5**) — merge blocked here by branch protection; needs maintainer merge.
- Coordinated `dart pub upgrade --major-versions` / **analyzer 13** + `custom_lint` stack (per CONTRIBUTING and issue triage).
- Broader “pub.dev Latest column” sweep where the solver or Flutter `test_api` pin still caps rows.

## Tests / gates (local)

- `dart run tool/run_workspace_analyze_errors_only.dart`
- `dart run tool/ct_repo_lint.dart`
- `cd app && flutter test test/` (945 tests)

Refs #2073

Made with [Cursor](https://cursor.com)