### PR TITLE
docs(spec): pub workspace toolchain (#2073)

### DIFF
--- a/SPEC/program/pub-workspace-toolchain.md
+++ b/SPEC/program/pub-workspace-toolchain.md
@@ -1,0 +1,32 @@
+# Pub workspace toolchain
+
+**SPEC/program** — Authoritative notes for Dart/Flutter SDK alignment, `pub.dev` resolution, and workspace lockfile policy. Tracks **GitHub #2073** (pub advisories decode + dependency refresh). Does not define game or simulation behavior.
+
+---
+
+## Goals
+
+- **Given** a maintainer runs `dart pub get` or `flutter pub get` from any workspace member against the default `pub.dev` hosted source, **when** the toolchain matches the documented CI pin (see below), **then** dependency acquisition completes without `FormatException: advisoriesUpdated must be a String` failures from the SDK’s `pub` advisories decode path.
+- **Given** the pinned SDK, **when** the solver runs `dart pub upgrade` / `flutter pub upgrade` (and optional `--major-versions` where policy allows), **then** direct and transitive versions are the **newest jointly resolvable** graph; any row in `pub outdated` that remains below pub.dev “Latest” is either **unblocked later by a Flutter/SDK release** or listed as an **intentional exception** in **[CONTRIBUTING.md](../../CONTRIBUTING.md)** (same section this spec references—do not duplicate long rationale here).
+
+---
+
+## CI and local SDK
+
+- GitHub Actions installs Flutter via `subosito/flutter-action@v2` with an explicit **`flutter-version`** pin (`3.41.9` at time of writing) on **`.github/workflows/quality.yml`**, **`app-android-release.yml`**, and **`widgetbook-release.yml`**. That stable release bundles **Dart 3.11.5**.
+- **CONTRIBUTING.md** states the same minimum for local development so resolution, advisories behavior, and analyzer output match automation.
+- Workspace `pubspec.yaml` files use **`environment.sdk: '>=3.11.5 <4.0.0'`** so pure-Dart packages do not claim compatibility below the Dart shipped with the supported Flutter pin.
+
+---
+
+## Intentional dependency caps
+
+ Maintainer-facing detail (Flutter `test_api` pin, `analyzer` / **`custom_lint_builder`** / **`custom_lint`** stack, and related transitives) lives in **CONTRIBUTING.md** under **`dart pub outdated` / “Latest” vs what the workspace resolves**. Those caps are the **documented intentional exceptions** for **#2073** acceptance criteria until upstream publishes a compatible **`custom_lint_builder`** (or the project migrates lint integration per a future issue).
+
+---
+
+## Verification (manual)
+
+- **`dart pub get`** at the repository root after a clean cache is the primary smoke test for advisories + workspace resolution on the pinned SDK.
+- **`dart run tool/run_workspace_analyze_errors_only.dart`** and **`dart run tool/ct_repo_lint.dart`** exercise the post-resolution graph used in **Quality** CI.
+- **GitHub Actions:** Confirm the latest **`quality`** workflow run for **`dev`** completed successfully (includes `pub get` / Flutter install under the pin). Record the outcome on **#2073** when auditing acceptance criteria.

--- a/SPEC/program/repo-and-packages.md
+++ b/SPEC/program/repo-and-packages.md
@@ -114,6 +114,12 @@ Asset-path guard remediation:
 
 ---
 
+## Pub workspace toolchain
+
+Dart/Flutter pin, `pub.dev` advisories expectations, and intentional “not at Latest” dependency caps (until upstream unblocks) are documented in **[pub-workspace-toolchain.md](pub-workspace-toolchain.md)** and **[CONTRIBUTING.md](../../CONTRIBUTING.md)**. See **GitHub #2073** for the rolling upgrade issue.
+
+---
+
 ## Flutter app `lib/` structure (TDD 15)
 
 Structure under `app/lib/`:


### PR DESCRIPTION
## Refs #2073

## Scope (SLICE)

Adds **SPEC/program** authority for Dart/Flutter + pub workspace policy already reflected in CI and **[CONTRIBUTING.md](../../CONTRIBUTING.md)**. Full `pub outdated` “Latest” sweep and **analyzer 13** / **custom_lint** coordination remain **deferred** until upstream `custom_lint_builder` supports it (per issue triage and CONTRIBUTING).

## Implemented

- **[SPEC/program/pub-workspace-toolchain.md](SPEC/program/pub-workspace-toolchain.md)** — SDK pin alignment, `pub get` / advisories smoke expectations, pointer to CONTRIBUTING for intentional caps, manual verification notes (incl. GH Actions `quality` on `dev`).
- **[SPEC/program/repo-and-packages.md](SPEC/program/repo-and-packages.md)** — short cross-link to the new spec and **#2073**.

## Deferred (not this PR)

- Coordinated `dart pub upgrade --major-versions` / analyzer–custom_lint stack bumps.
- Clearing remaining `pub outdated` rows below “Latest” except where blocked by Flutter SDK pins or custom_lint.

## AC / spec coverage

| Area | This PR |
|------|--------|
| Documented intentional dependency exceptions (TDD anchoring) | **Yes** — new program spec + CONTRIBUTING cross-ref |
| Workspace direct deps at pub.dev Latest | **No** — still capped; documented blockers unchanged |
| CI / `pub get` without advisories decode failure | **Already on `dev`** (prior slices); local validation: `dart pub get`, `dart run tool/run_workspace_analyze_errors_only.dart`, `dart run tool/ct_repo_lint.dart` green |

## Tests / checks run

- `dart pub get`
- `dart run tool/run_workspace_analyze_errors_only.dart`
- `dart run tool/ct_repo_lint.dart`

## Label

Issue stays **`backlog:implementation`** until merged follow-ups complete remaining #2073 ACs (per backlog policy).

Made with [Cursor](https://cursor.com)