### PR TITLE
test(app): close #2027 AC5 prospect cache coverage gap

### DIFF
--- a/app/test/per_player_work_target_selection_cache_test.dart
+++ b/app/test/per_player_work_target_selection_cache_test.dart
@@ -5,7 +5,8 @@ import 'package:colonizethis_logic/colonizethis_logic.dart'
         PlayerView,
         VisibilityLevel,
         kWorkTargetBuildImprovement,
-        kWorkTargetExplore;
+        kWorkTargetExplore,
+        kWorkTargetProspect;
 import 'package:colonizethis_models/colonizethis_models.dart' as ct_models;
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_test/flutter_test.dart';
@@ -114,6 +115,25 @@ void main() {
 
       expect(cache.get('gp1', kWorkTargetExplore), {'gp1|tile'});
       expect(cache.get('gp2', kWorkTargetExplore), {'gp2|tile'});
+    });
+
+    test('refresh stores and reads prospect membership', () {
+      final cache = PerPlayerWorkTargetSelectionCache(
+        strategies: {
+          kWorkTargetProspect: (_) => {'oldWorld|p3|4|2', 'oldWorld|p3|2|1'},
+        },
+      );
+
+      cache.refresh(snapshotForPlayer('gp1'));
+
+      expect(
+        cache.get('gp1', kWorkTargetProspect),
+        {'oldWorld|p3|4|2', 'oldWorld|p3|2|1'},
+      );
+      expect(
+        cache.sorted('gp1', kWorkTargetProspect),
+        ['oldWorld|p3|2|1', 'oldWorld|p3|4|2'],
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- add explicit `kWorkTargetProspect` coverage in `per_player_work_target_selection_cache_test.dart`
- verify `refresh` populates `prospect` entries and that `get`/`sorted` read back deterministic tile membership
- keep runtime behavior unchanged (test-only slice)

## Implemented vs Deferred
- **Implemented in this PR:** AC5 gap closure for app tests covering prospect cache sourcing/readback in `PerPlayerWorkTargetSelectionCache`
- **Deferred:** none for this issue scope; prior merged PRs already covered AC1-AC4 and this PR addresses the final outstanding AC5 item

## AC Coverage for #2027
- [x] AC5: app tests cover `prospect` cache sourcing and stale-entry rejection behavior
  - stale-entry rejection already covered by `game_map_area_state_logic_cache_filter_test.dart`
  - this PR adds explicit `prospect` cache population/readback coverage in `per_player_work_target_selection_cache_test.dart`

## Tests
- `flutter test test/per_player_work_target_selection_cache_test.dart test/game_map_area_state_logic_cache_filter_test.dart`

Refs #2027

Made with [Cursor](https://cursor.com)