### PR TITLE
docs(spec): codify workspace outdated audit workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,23 @@ If `dart pub get` or `flutter pub get` fails while resolving hosted packages wit
 
 When bumping dependencies, prefer **`dart pub upgrade`** / **`flutter pub upgrade`** (and coordinated `pubspec.yaml` edits) over overrides; if a row cannot move yet, note the **blocker** (SDK pin or shared dev-tool stack) in the PR or issue.
 
+### Workspace outdated audit command set (GitHub #2073)
+
+Run this sequence from a clean checkout on the pinned Flutter/Dart toolchain:
+
+```bash
+dart pub outdated
+cd app && flutter pub outdated && cd ..
+cd ctdev && flutter pub outdated && cd ..
+cd widgetbook_host && flutter pub outdated && cd ..
+```
+
+Interpretation:
+
+- If a package is below **Resolvable**, treat it as actionable implementation work (constraints/lockfile are lagging).
+- If a package is at **Resolvable** but below **Latest**, verify it is covered by one of the intentional caps documented above before considering the issue complete.
+- Record the audit result in the linked issue/PR so reviewers can distinguish solved vs deferred dependency gaps.
+
 ## Pre-PR Checklist
 
 Before opening a pull request, ensure the following:

--- a/SPEC/program/pub-workspace-toolchain.md
+++ b/SPEC/program/pub-workspace-toolchain.md
@@ -30,3 +30,9 @@
 - **`dart pub get`** at the repository root after a clean cache is the primary smoke test for advisories + workspace resolution on the pinned SDK.
 - **`dart run tool/run_workspace_analyze_errors_only.dart`** and **`dart run tool/ct_repo_lint.dart`** exercise the post-resolution graph used in **Quality** CI.
 - **GitHub Actions:** Confirm the latest **`quality`** workflow run for **`dev`** completed successfully (includes `pub get` / Flutter install under the pin). Record the outcome on **#2073** when auditing acceptance criteria.
+
+## Workspace outdated audit (manual)
+
+- **Given** a maintainer is validating dependency-refresh progress for #2073, **when** they run `flutter pub outdated` from each Flutter package root (`app/`, `ctdev/`, `widgetbook_host/`) and `dart pub outdated` from the repository root (Pub workspace host), **then** the combined output is the authoritative audit for direct and transitive version drift in this repository.
+- **Given** an outdated row remains below pub.dev **Latest**, **when** the row is constrained by the pinned Flutter SDK (`flutter_test` -> `test_api`) or the documented `analyzer`/`custom_lint_builder` stack cap, **then** that row is treated as an intentional exception and must match the rationale documented in **[CONTRIBUTING.md](../../CONTRIBUTING.md)**.
+- **Given** an outdated row remains below **Resolvable** (not just below **Latest**), **when** no intentional exception applies, **then** follow-up implementation work is required on #2073 (constraint update, coordinated major bump, or lockfile refresh) before the issue can be considered complete.


### PR DESCRIPTION
## Summary
- Add an explicit workspace outdated audit command set in `CONTRIBUTING.md` (`dart pub outdated` at root plus `flutter pub outdated` in `app/`, `ctdev/`, and `widgetbook_host/`).
- Extend `SPEC/program/pub-workspace-toolchain.md` with Given-When-Then criteria for classifying outdated rows as intentional caps vs actionable follow-up work.
- Document that rows below **Resolvable** (without an intentional cap) are incomplete #2073 implementation work.

## Implemented vs deferred
- **Implemented in this PR:** Maintainer-facing policy and procedure to run and interpret workspace outdated audits consistently for #2073.
- **Deferred:** Coordinated major dependency bumps (including analyzer/custom_lint stack) and any lockfile/constraint updates needed to move currently capped rows; those require follow-up implementation PRs once blockers are resolved.

## Test plan
- [x] `dart pub get`
- [x] `dart run tool/ct_repo_lint.dart`

Refs #2073

Made with [Cursor](https://cursor.com)