### PR TITLE
Add transport overlay visual sanity gate for atlas content

### DIFF
--- a/SPEC/ui/pytool-image-tools.md
+++ b/SPEC/ui/pytool-image-tools.md
@@ -196,7 +196,9 @@ python3 pytool/wang_incremental_64.py --run-dir /path/to/other_run --init
 - All masks `0..15` exist for both families.
 - Every tile `bounding_box` is unique, 64px grid-aligned, and inside atlas dimensions.
 - `app/assets/data/map_terrain_tilesets.json` includes `transport_tilesets.road` and `transport_tilesets.rail` entries pointing to the emitted atlas/spec files.
+- Atlas PNGs contain substantive rendered content (not near-empty placeholders): each 256x256 transport atlas must have at least 2,500 non-transparent pixels.
 - App tests covering transport contract pass (`flutter test test/transport_overlay_assets_test.dart` and `flutter test test/transport_overlay_tileset_cache_test.dart`).
+- Visual sanity test passes (`flutter test test/transport_overlay_visual_sanity_test.dart`).
 
 This contract is normative for issue #1775 transport overlays and future atlas refreshes.
 

--- a/app/test/transport_overlay_visual_sanity_test.dart
+++ b/app/test/transport_overlay_visual_sanity_test.dart
@@ -1,0 +1,47 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:colonizethis_test/test.dart';
+import 'package:flutter/services.dart';
+
+const _kMinOpaquePixelsPerTransportAtlas = 2500;
+
+Future<int> _countOpaquePixels(String assetPath) async {
+  final data = await rootBundle.load(assetPath);
+  final codec = await ui.instantiateImageCodec(data.buffer.asUint8List());
+  final frame = await codec.getNextFrame();
+  final image = frame.image;
+  final rgba = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  if (rgba == null) {
+    throw StateError('Failed to decode RGBA bytes for $assetPath');
+  }
+
+  final bytes = rgba.buffer.asUint8List();
+  var opaqueCount = 0;
+  for (var i = 3; i < bytes.length; i += 4) {
+    if (bytes[i] > 0) {
+      opaqueCount++;
+    }
+  }
+  return opaqueCount;
+}
+
+void main() {
+  test('transport overlay atlases are not near-empty placeholders', () async {
+    const atlasAssets = <String>[
+      'assets/images/terrain/tilesets/tileset_transport_road_64.png',
+      'assets/images/terrain/tilesets/tileset_transport_rail_64.png',
+    ];
+
+    for (final assetPath in atlasAssets) {
+      final opaquePixels = await _countOpaquePixels(assetPath);
+      expect(
+        opaquePixels,
+        greaterThanOrEqualTo(_kMinOpaquePixelsPerTransportAtlas),
+        reason:
+            '$assetPath contains too few visible pixels ($opaquePixels), expected at least '
+            '$_kMinOpaquePixelsPerTransportAtlas',
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Add `transport_overlay_visual_sanity_test.dart` to assert both transport atlas PNGs contain substantive rendered content (minimum opaque pixel threshold).
- Update `SPEC/ui/pytool-image-tools.md` transport contract validation checklist to require this visual-content sanity gate.
- Refs #1819.

## Implemented in this PR (slice)
- SPEC-authorized validation extension for transport overlay atlas quality.
- Automated regression test that fails if shipped road/rail atlases become near-empty placeholders.

## Deferred work
- Running the PixelLab generation pipeline and replacing atlases with fresh generated art remains deferred.
- Provenance/state artifact decisions (`state.json` and intermediates) remain deferred.
- Full manual visual seam QA for masks 0..15 with newly generated art remains deferred.

## AC coverage
- Covered now: preventative guard for placeholder regression and transport validation contract hardening.
- Still pending for full issue completion: authoritative PixelLab-generated road/rail atlas refresh and provenance documentation.

## Test plan
- [x] `flutter test test/transport_overlay_visual_sanity_test.dart`
- [x] `flutter test test/transport_overlay_assets_test.dart test/transport_overlay_tileset_cache_test.dart test/transport_overlay_mask_test.dart test/transport_overlay_render_policy_test.dart`

Made with [Cursor](https://cursor.com)