### PR TITLE
chore(workspace): align root melos constraint with current baseline

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dev_dependencies:
   colonizethis_exception_lint:
     path: packages/colonizethis_exception_lint
   image: ^4.5.4
-  melos: ^7.0.0
+  melos: ^7.6.0
   path: ^1.9.1
   test: ^1.24.0
   yaml: ^3.1.3


### PR DESCRIPTION
## Summary
- Align root `pubspec.yaml` `dev_dependencies.melos` from `^7.0.0` to `^7.6.0` so declared constraints match the current workspace baseline used in #2073 slices.
- Keep this PR intentionally scoped to declaration alignment only; no functional runtime changes.
- Refs #2073.

## Test plan
- [x] `dart pub upgrade melos`
- [x] `dart pub get`
- [x] `dart run tool/ct_repo_lint.dart --rule repo.workspace_outdated_latest_direct`
- [x] `dart run tool/ct_repo_lint.dart --rule repo.workspace_outdated_resolvable`

Made with [Cursor](https://cursor.com)