### PR TITLE
Add selected-unit work target availability API for civilian panel paths

### DIFF
--- a/SPEC/program/order-suggestions.md
+++ b/SPEC/program/order-suggestions.md
@@ -154,6 +154,59 @@ For `explore`, step (1) must use the same per-player partially-revealed-province
 
 ---
 
+### `getAvailableWorkTargetsForUnit`
+
+**Purpose:** Returns per-target work availability for a **single civilian unit** without scanning other units, with a cheap pre-assign gating layer that short-circuits when the unit is already represented in the draft order list or has pending work.
+
+**Signature:**
+```dart
+AvailableWorkTargetsForUnit getAvailableWorkTargetsForUnit({
+  required PlayerView view,
+  required Game game,
+  required MapTopology topology,
+  required Orders currentOrders,
+  required String unitId,
+  Map<String, TileMapResult>? tileMapByRegion,
+});
+```
+
+**Return type:**
+- `unitId`: the queried unit id.
+- `assignable`: `true` when at least one work target has non-empty valid tiles; `false` otherwise.
+- `blockedReason`: nullable; when `assignable == false` contains a stable reason token such as:
+  - `unit_not_found_or_not_owned`
+  - `unit_has_current_work`
+  - `unit_has_pending_work_order`
+  - `unit_has_pending_move_order`
+  - `no_work_targets_for_unit_type`
+  - `no_valid_work_targets`
+- `validTileKeysByTarget`: map from work-target id to the **set** of valid tile keys for that unit and target (visibility + engine validated), matching `getValidWorkOrderTileKeysWithVisibility` semantics.
+
+**Behavior:**
+1. Look up `unitId` in world state and verify ownership for `view.playerId`. If not found or not owned, return `assignable = false` with `blockedReason = unit_not_found_or_not_owned`.
+2. Compute:
+   - whether the unit has `currentWork` in world state,
+   - whether `currentOrders.workOrdersByPlayerId[view.playerId]` already contains any work order for this `unitId`,
+   - whether `currentOrders.moveOrdersByPlayerId[view.playerId]` contains a move order for this `unitId`.
+3. If any of the above is true, return `assignable = false`, `validTileKeysByTarget = {}`, and a `blockedReason` token indicating the first matching condition. **Do not** call `getValidWorkOrderTileKeysWithVisibility` or the order engine in this branch.
+4. Determine allowed work targets for the unit type from `workOrderTargetsByUnitType`. If empty, return `assignable = false`, `blockedReason = no_work_targets_for_unit_type`, `validTileKeysByTarget = {}`.
+5. For each allowed work target, call `getValidWorkOrderTileKeysWithVisibility` with the same arguments (`game`, `topology`, `view`, `unitId`, `workTarget`, `currentOrders`, `tileMapByRegion`) and, when the returned set is non-empty, insert an entry into `validTileKeysByTarget` for that target.
+6. Set `assignable = validTileKeysByTarget.isNotEmpty`. When `assignable == true`, `blockedReason` is `null`; otherwise `blockedReason = no_valid_work_targets`.
+
+**Consumers:**
+- App UI (`availableWorkTargetsProvider` and explorer/builder shortcut flows) for **per-unit** Assign enablement and valid-tile enumeration.
+- Must not be used by AI; AI consumers continue to use `suggestWorkOrders`.
+
+**Acceptance criteria (selected-unit availability)**
+
+- Given a Great Power player, a builder `B1` owned by that player, and `currentOrders` containing a pending work order for `B1`, when the system calls `getAvailableWorkTargetsForUnit` for `unitId = B1`, then the result has `assignable = false`, `validTileKeysByTarget = {}`, and `blockedReason` equal to one of:
+  - `unit_has_current_work`
+  - `unit_has_pending_work_order`.
+- Given the same setup and instrumentation counting `isWorkOrderAccepted` invocations in the order engine, when `getAvailableWorkTargetsForUnit` returns a blocked result as above, then the instrumentation counter for `isWorkOrderAccepted` attributable to that call remains `0`.
+- Given a Great Power player, an idle builder `B2` owned by that player, and at least one tile that is a valid `build_improvement` target for `B2`, when the system calls `getAvailableWorkTargetsForUnit` for `unitId = B2`, then the result has `assignable = true`, `blockedReason = null`, and `validTileKeysByTarget['build_improvement']` contains at least one tile key.
+
+---
+
 ## Suggestion observability (debug)
 
 When diagnosing why a civilian work target is missing from Assign / AI suggestions, `suggestWorkOrders` may emit **summary-only** `logger` **`debug`** lines (prefix `logic.order_suggestion`, token `suggest_work`): **per unit** (`unitId`, `unitType`, `region`, `at` province) and **per work target** one line with `outcome=` `included` or `excluded`, optional `tile=`, and for exclusions a **stable** `reason=` token (e.g. `visibility`, `no_valid_tile`, `no_single_hop`, `duplicate_pending`, `engine_rejected`, `not_applicable`). **No** per-candidate-tile log flood. Tests in `colonizethis_logic` assert the contract for representative fixtures (Refs GitHub #1869).

--- a/app/lib/providers/games_provider.dart
+++ b/app/lib/providers/games_provider.dart
@@ -86,21 +86,25 @@ final availableWorkTargetsProvider = Provider<Map<String, List<String>>>((ref) {
   final humanPlayerId = game.players.firstWhere((p) => p.isHuman).id;
   final view = buildPlayerView(game, topology, humanPlayerId);
 
-  final suggestions = suggestWorkOrders(
-    view,
-    game,
-    topology,
-    orders,
-    tileMapByRegion: mapData?.tileMapByRegion,
-  );
-
   final byUnitId = <String, List<String>>{};
-  for (final order in suggestions) {
-    byUnitId.putIfAbsent(order.unitId, () => []).add(order.target);
+  for (final unit in view.ownUnits) {
+    final availability = getAvailableWorkTargetsForUnit(
+      view: view,
+      game: game,
+      topology: topology,
+      currentOrders: orders,
+      unitId: unit.id,
+      tileMapByRegion: mapData?.tileMapByRegion,
+    );
+    if (!availability.assignable ||
+        availability.validTileKeysByTarget.isEmpty) {
+      continue;
+    }
+    byUnitId[unit.id] = availability.validTileKeysByTarget.keys
+        .toSet()
+        .toList();
   }
-  return {
-    for (final e in byUnitId.entries) e.key: e.value.toSet().toList(),
-  };
+  return byUnitId;
 });
 
 /// Tile keys reserved for the human player’s Builder/Engineer/Merchant

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -44,8 +44,6 @@ export 'order_suggestion_naval_diplomatic.dart'
         suggestDiplomaticOrders,
         suggestNavalMissionOrders,
         suggestNavalMoveOrders;
-export 'order_suggestion_work.dart'
-    show
-        AvailableWorkTargetsForUnit,
-        getAvailableWorkTargetsForUnit,
-        suggestWorkOrders;
+export 'order_suggestion_work.dart' show suggestWorkOrders;
+export 'order_suggestion_work_availability.dart'
+    show AvailableWorkTargetsForUnit, getAvailableWorkTargetsForUnit;

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion.dart
@@ -44,4 +44,8 @@ export 'order_suggestion_naval_diplomatic.dart'
         suggestDiplomaticOrders,
         suggestNavalMissionOrders,
         suggestNavalMoveOrders;
-export 'order_suggestion_work.dart' show suggestWorkOrders;
+export 'order_suggestion_work.dart'
+    show
+        AvailableWorkTargetsForUnit,
+        getAvailableWorkTargetsForUnit,
+        suggestWorkOrders;

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
@@ -13,6 +13,20 @@ import 'partial_province_reveal.dart';
 import 'orders_application_helpers.dart';
 import 'unit_type_helpers.dart';
 
+class AvailableWorkTargetsForUnit {
+  const AvailableWorkTargetsForUnit({
+    required this.unitId,
+    required this.assignable,
+    required this.blockedReason,
+    required this.validTileKeysByTarget,
+  });
+
+  final String unitId;
+  final bool assignable;
+  final String? blockedReason;
+  final Map<String, Set<String>> validTileKeysByTarget;
+}
+
 void _suggestionWorkLog({
   required String unitId,
   required String unitType,
@@ -476,13 +490,90 @@ List<WorkOrder> suggestWorkOrders(
   orderSuggestionLog.d(
     'suggestWorkOrders player=$playerId candidates=${suggestions.length}',
   );
-  orderSuggestionLog.d(
-    'suggestWorkOrders full list ${suggestions.map((o) => "${o.unitId}:${o.target}").toList()}',
-  );
   if (suggestions.isEmpty) {
     orderSuggestionLog.w('suggestWorkOrders no candidates player=$playerId');
   }
   return suggestions;
+}
+
+AvailableWorkTargetsForUnit getAvailableWorkTargetsForUnit({
+  required PlayerView view,
+  required Game game,
+  required MapTopology topology,
+  required Orders currentOrders,
+  required String unitId,
+  Map<String, TileMapResult>? tileMapByRegion,
+}) {
+  final playerId = view.playerId;
+  final unitsById = unitsByIdFromWorld(game.worldState);
+  final unit = unitsById[unitId];
+  if (unit == null || unit.ownerId != playerId) {
+    return AvailableWorkTargetsForUnit(
+      unitId: unitId,
+      assignable: false,
+      blockedReason: 'unit_not_found_or_not_owned',
+      validTileKeysByTarget: const {},
+    );
+  }
+
+  final existingWork =
+      currentOrders.workOrdersByPlayerId[playerId] ?? const <WorkOrder>[];
+  final hasPendingWorkOrderForUnit = existingWork.any(
+    (o) => o.unitId == unitId,
+  );
+  final moveOrders =
+      currentOrders.moveOrdersByPlayerId[playerId] ?? const <MoveOrder>[];
+  final hasPendingMoveOrderForUnit = moveOrders.any((m) => m.unitId == unitId);
+
+  if (unit.currentWork != null ||
+      hasPendingWorkOrderForUnit ||
+      hasPendingMoveOrderForUnit) {
+    final reason = unit.currentWork != null
+        ? 'unit_has_current_work'
+        : hasPendingWorkOrderForUnit
+        ? 'unit_has_pending_work_order'
+        : 'unit_has_pending_move_order';
+    return AvailableWorkTargetsForUnit(
+      unitId: unitId,
+      assignable: false,
+      blockedReason: reason,
+      validTileKeysByTarget: const {},
+    );
+  }
+
+  final allowedTargets = workOrderTargetsByUnitType[unit.type];
+  if (allowedTargets == null || allowedTargets.isEmpty) {
+    return AvailableWorkTargetsForUnit(
+      unitId: unitId,
+      assignable: false,
+      blockedReason: 'no_work_targets_for_unit_type',
+      validTileKeysByTarget: const {},
+    );
+  }
+
+  final validByTarget = <String, Set<String>>{};
+
+  for (final target in allowedTargets) {
+    final tiles = getValidWorkOrderTileKeysWithVisibility(
+      game: game,
+      topology: topology,
+      view: view,
+      unitId: unitId,
+      workTarget: target,
+      currentOrders: currentOrders,
+      tileMapByRegion: tileMapByRegion,
+    );
+    if (tiles.isNotEmpty) {
+      validByTarget[target] = tiles.toSet();
+    }
+  }
+
+  return AvailableWorkTargetsForUnit(
+    unitId: unitId,
+    assignable: validByTarget.isNotEmpty,
+    blockedReason: validByTarget.isNotEmpty ? null : 'no_valid_work_targets',
+    validTileKeysByTarget: validByTarget,
+  );
 }
 
 void _addWorkSuggestionsForUnit({

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
@@ -13,20 +13,6 @@ import 'partial_province_reveal.dart';
 import 'orders_application_helpers.dart';
 import 'unit_type_helpers.dart';
 
-class AvailableWorkTargetsForUnit {
-  const AvailableWorkTargetsForUnit({
-    required this.unitId,
-    required this.assignable,
-    required this.blockedReason,
-    required this.validTileKeysByTarget,
-  });
-
-  final String unitId;
-  final bool assignable;
-  final String? blockedReason;
-  final Map<String, Set<String>> validTileKeysByTarget;
-}
-
 void _suggestionWorkLog({
   required String unitId,
   required String unitType,
@@ -494,86 +480,6 @@ List<WorkOrder> suggestWorkOrders(
     orderSuggestionLog.w('suggestWorkOrders no candidates player=$playerId');
   }
   return suggestions;
-}
-
-AvailableWorkTargetsForUnit getAvailableWorkTargetsForUnit({
-  required PlayerView view,
-  required Game game,
-  required MapTopology topology,
-  required Orders currentOrders,
-  required String unitId,
-  Map<String, TileMapResult>? tileMapByRegion,
-}) {
-  final playerId = view.playerId;
-  final unitsById = unitsByIdFromWorld(game.worldState);
-  final unit = unitsById[unitId];
-  if (unit == null || unit.ownerId != playerId) {
-    return AvailableWorkTargetsForUnit(
-      unitId: unitId,
-      assignable: false,
-      blockedReason: 'unit_not_found_or_not_owned',
-      validTileKeysByTarget: const {},
-    );
-  }
-
-  final existingWork =
-      currentOrders.workOrdersByPlayerId[playerId] ?? const <WorkOrder>[];
-  final hasPendingWorkOrderForUnit = existingWork.any(
-    (o) => o.unitId == unitId,
-  );
-  final moveOrders =
-      currentOrders.moveOrdersByPlayerId[playerId] ?? const <MoveOrder>[];
-  final hasPendingMoveOrderForUnit = moveOrders.any((m) => m.unitId == unitId);
-
-  if (unit.currentWork != null ||
-      hasPendingWorkOrderForUnit ||
-      hasPendingMoveOrderForUnit) {
-    final reason = unit.currentWork != null
-        ? 'unit_has_current_work'
-        : hasPendingWorkOrderForUnit
-        ? 'unit_has_pending_work_order'
-        : 'unit_has_pending_move_order';
-    return AvailableWorkTargetsForUnit(
-      unitId: unitId,
-      assignable: false,
-      blockedReason: reason,
-      validTileKeysByTarget: const {},
-    );
-  }
-
-  final allowedTargets = workOrderTargetsByUnitType[unit.type];
-  if (allowedTargets == null || allowedTargets.isEmpty) {
-    return AvailableWorkTargetsForUnit(
-      unitId: unitId,
-      assignable: false,
-      blockedReason: 'no_work_targets_for_unit_type',
-      validTileKeysByTarget: const {},
-    );
-  }
-
-  final validByTarget = <String, Set<String>>{};
-
-  for (final target in allowedTargets) {
-    final tiles = getValidWorkOrderTileKeysWithVisibility(
-      game: game,
-      topology: topology,
-      view: view,
-      unitId: unitId,
-      workTarget: target,
-      currentOrders: currentOrders,
-      tileMapByRegion: tileMapByRegion,
-    );
-    if (tiles.isNotEmpty) {
-      validByTarget[target] = tiles.toSet();
-    }
-  }
-
-  return AvailableWorkTargetsForUnit(
-    unitId: unitId,
-    assignable: validByTarget.isNotEmpty,
-    blockedReason: validByTarget.isNotEmpty ? null : 'no_valid_work_targets',
-    validTileKeysByTarget: validByTarget,
-  );
 }
 
 void _addWorkSuggestionsForUnit({

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_availability.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_availability.dart
@@ -1,0 +1,100 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../world/player_view.dart';
+import '../world/unit_lookup.dart';
+import 'order_suggestion_build_research.dart';
+
+class AvailableWorkTargetsForUnit {
+  const AvailableWorkTargetsForUnit({
+    required this.unitId,
+    required this.assignable,
+    required this.blockedReason,
+    required this.validTileKeysByTarget,
+  });
+
+  final String unitId;
+  final bool assignable;
+  final String? blockedReason;
+  final Map<String, Set<String>> validTileKeysByTarget;
+}
+
+AvailableWorkTargetsForUnit getAvailableWorkTargetsForUnit({
+  required PlayerView view,
+  required Game game,
+  required MapTopology topology,
+  required Orders currentOrders,
+  required String unitId,
+  Map<String, TileMapResult>? tileMapByRegion,
+}) {
+  final playerId = view.playerId;
+  final unitsById = unitsByIdFromWorld(game.worldState);
+  final unit = unitsById[unitId];
+  if (unit == null || unit.ownerId != playerId) {
+    return AvailableWorkTargetsForUnit(
+      unitId: unitId,
+      assignable: false,
+      blockedReason: 'unit_not_found_or_not_owned',
+      validTileKeysByTarget: const {},
+    );
+  }
+
+  final existingWork =
+      currentOrders.workOrdersByPlayerId[playerId] ?? const <WorkOrder>[];
+  final hasPendingWorkOrderForUnit = existingWork.any(
+    (o) => o.unitId == unitId,
+  );
+  final moveOrders =
+      currentOrders.moveOrdersByPlayerId[playerId] ?? const <MoveOrder>[];
+  final hasPendingMoveOrderForUnit = moveOrders.any((m) => m.unitId == unitId);
+
+  if (unit.currentWork != null ||
+      hasPendingWorkOrderForUnit ||
+      hasPendingMoveOrderForUnit) {
+    final reason = unit.currentWork != null
+        ? 'unit_has_current_work'
+        : hasPendingWorkOrderForUnit
+            ? 'unit_has_pending_work_order'
+            : 'unit_has_pending_move_order';
+    return AvailableWorkTargetsForUnit(
+      unitId: unitId,
+      assignable: false,
+      blockedReason: reason,
+      validTileKeysByTarget: const {},
+    );
+  }
+
+  final allowedTargets = workOrderTargetsByUnitType[unit.type];
+  if (allowedTargets == null || allowedTargets.isEmpty) {
+    return AvailableWorkTargetsForUnit(
+      unitId: unitId,
+      assignable: false,
+      blockedReason: 'no_work_targets_for_unit_type',
+      validTileKeysByTarget: const {},
+    );
+  }
+
+  final validByTarget = <String, Set<String>>{};
+
+  for (final target in allowedTargets) {
+    final tiles = getValidWorkOrderTileKeysWithVisibility(
+      game: game,
+      topology: topology,
+      view: view,
+      unitId: unitId,
+      workTarget: target,
+      currentOrders: currentOrders,
+      tileMapByRegion: tileMapByRegion,
+    );
+    if (tiles.isNotEmpty) {
+      validByTarget[target] = tiles.toSet();
+    }
+  }
+
+  return AvailableWorkTargetsForUnit(
+    unitId: unitId,
+    assignable: validByTarget.isNotEmpty,
+    blockedReason: validByTarget.isNotEmpty ? null : 'no_valid_work_targets',
+    validTileKeysByTarget: validByTarget,
+  );
+}

--- a/packages/colonizethis_logic/test/available_work_targets_for_unit_test.dart
+++ b/packages/colonizethis_logic/test/available_work_targets_for_unit_test.dart
@@ -1,0 +1,164 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+void main() {
+  group('getAvailableWorkTargetsForUnit', () {
+    test('short-circuits when unit already has pending work order', () {
+      const playerId = 'gp1';
+      const ow = 'oldWorld';
+      const provinceId = '$ow|p1';
+      const tileKey = '$ow|p1|0|0';
+
+      final player = Player(
+        id: playerId,
+        displayName: 'GP',
+        isHuman: false,
+        treasury: 500,
+        workerPool: const WorkerPool(peasants: 1),
+      );
+
+      final province = Province(
+        id: provinceId,
+        regionId: ow,
+        ownerId: playerId,
+      );
+
+      final builder = Unit(
+        id: 'u1',
+        type: kUnitTypeBuilder,
+        ownerId: playerId,
+        locationProvinceId: provinceId,
+        tileKey: tileKey,
+      );
+
+      final existingOrder = WorkOrder(
+        unitId: builder.id,
+        target: kWorkTargetBuildImprovement,
+        targetTileKey: tileKey,
+      );
+
+      final world = WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: RegionData(provinces: [province], units: [builder]),
+        newWorld: const RegionData(),
+        playerVisibilityByTile: const {
+          playerId: {tileKey: 'fullyVisible'},
+        },
+        tileKeysByRegionAndProvince: {
+          ow: {
+            provinceId: [tileKey],
+          },
+        },
+        resourceByTileKey: {tileKey: 'grain'},
+        tileState: const TileMapState(improvementByTile: {}),
+      );
+
+      final game = Game(id: 'g1', worldState: world, players: [player]);
+
+      final topology = const MapTopology(
+        nodes: [
+          TopologyNode(id: 'p1', regionId: ow, type: TopologyNodeType.province),
+        ],
+        edges: [],
+      );
+
+      final view = buildPlayerView(game, topology, playerId);
+      final currentOrders = Orders(
+        workOrdersByPlayerId: {
+          playerId: [existingOrder],
+        },
+      );
+
+      final availability = getAvailableWorkTargetsForUnit(
+        view: view,
+        game: game,
+        topology: topology,
+        currentOrders: currentOrders,
+        unitId: builder.id,
+      );
+
+      expect(availability.assignable, isFalse);
+      expect(availability.validTileKeysByTarget, isEmpty);
+      expect(
+        availability.blockedReason,
+        anyOf('unit_has_pending_work_order', 'unit_has_current_work'),
+      );
+    });
+
+    test('returns targets when unit is idle and has valid tiles', () {
+      const playerId = 'gp1';
+      const ow = 'oldWorld';
+      const provinceId = '$ow|p1';
+      const tileKnown = '$ow|p1|0|0';
+      const tileUnknown = '$ow|p1|1|0';
+
+      final player = Player(
+        id: playerId,
+        displayName: 'GP',
+        isHuman: false,
+        treasury: 500,
+        workerPool: const WorkerPool(peasants: 1),
+      );
+
+      final province = Province(
+        id: provinceId,
+        regionId: ow,
+        ownerId: playerId,
+      );
+
+      final explorer = Unit(
+        id: 'u1',
+        type: kUnitTypeExplorer,
+        ownerId: playerId,
+        locationProvinceId: provinceId,
+        tileKey: tileKnown,
+      );
+
+      final world = WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: RegionData(provinces: [province], units: [explorer]),
+        newWorld: const RegionData(),
+        playerVisibilityByTile: const {
+          playerId: {tileKnown: 'fullyVisible', tileUnknown: 'unknown'},
+        },
+        tileKeysByRegionAndProvince: {
+          ow: {
+            provinceId: [tileKnown, tileUnknown],
+          },
+        },
+      );
+
+      final game = Game(id: 'g2', worldState: world, players: [player]);
+
+      final topology = const MapTopology(
+        nodes: [
+          TopologyNode(id: 'p1', regionId: ow, type: TopologyNodeType.province),
+        ],
+        edges: [],
+      );
+
+      final view = buildPlayerView(game, topology, playerId);
+      const currentOrders = Orders();
+
+      final availability = getAvailableWorkTargetsForUnit(
+        view: view,
+        game: game,
+        topology: topology,
+        currentOrders: currentOrders,
+        unitId: explorer.id,
+      );
+
+      expect(availability.assignable, isTrue);
+      expect(availability.blockedReason, isNull);
+      expect(
+        availability.validTileKeysByTarget.keys,
+        contains(kWorkTargetExplore),
+      );
+      final tilesForTarget =
+          availability.validTileKeysByTarget[kWorkTargetExplore]!;
+      expect(tilesForTarget, contains(tileKnown));
+    });
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1061,10 +1061,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      sha256: 85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   url_launcher_windows:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- Add `getAvailableWorkTargetsForUnit` + `AvailableWorkTargetsForUnit` in logic with early short-circuit gating when a unit already has pending/current work (or pending move), and expose it via `order_suggestion.dart`.
- Switch app `availableWorkTargetsProvider` to use selected-unit availability instead of broad `suggestWorkOrders` enumeration.
- Remove unbounded `suggestWorkOrders full list ...` debug payload and keep bounded candidate-count summary logging.
- Add regression coverage for the selected-unit API (`available_work_targets_for_unit_test.dart`) and update SPEC (`SPEC/program/order-suggestions.md`) to define the new API contract and ACs.

## Implemented in this PR
- **Implemented**: selected-unit API and app wiring for per-unit work-target availability in panel-open paths.
- **Implemented**: bounded suggestion logging behavior by removing full-list serialization.
- **Implemented**: focused logic tests + targeted app/provider tests.

## Deferred / Out of scope
- **Deferred**: broader migration of all UI entry points listed in issue policy (beyond `availableWorkTargetsProvider`) and dedicated instrumentation/perf guardrails in ACs that require larger fixture/perf harness work.
- **Deferred**: any AI-path changes; broad `suggestWorkOrders` remains available for AI/batch consumers.

## SPEC / AC coverage
- **Covered now**: selected-unit API shape + short-circuit behavior and app provider usage for unit-scoped availability.
- **Left for follow-up**: full issue-wide performance guard suite and additional UI-path call-site migration checks.

## Test plan
- [x] `cd packages/colonizethis_logic && dart test test/available_work_targets_for_unit_test.dart test/order_suggestion_work_logging_test.dart`
- [x] `cd app && flutter test test/games_provider_test.dart test/providers_game_map_workflow_test.dart`

Refs #2133

Made with [Cursor](https://cursor.com)