### PR TITLE
test(app): cover single-pass civilian work upsert validation

### DIFF
--- a/app/lib/core/services/app_event_handler_scope_session_subscriptions.dart
+++ b/app/lib/core/services/app_event_handler_scope_session_subscriptions.dart
@@ -1,5 +1,11 @@
 part of 'app_event_handler_scope.dart';
 
+int civilianWorkUpsertValidationPassCountForTests = 0;
+
+void resetCivilianWorkUpsertValidationPassCountForTests() {
+  civilianWorkUpsertValidationPassCountForTests = 0;
+}
+
 extension _SessionCommands on _AppEventHandlerScopeState {
   void _applyDebugCommand(DebugCommandResult result) {
     final nextGame = result.game;
@@ -45,11 +51,17 @@ extension _SessionCommands on _AppEventHandlerScopeState {
         final game = ref.read(currentGameProvider);
         if (game != null) {
           final topo =
-              ref.read(gameServiceProvider).getMapData(game.id)?.combinedTopology ??
+              ref
+                  .read(gameServiceProvider)
+                  .getMapData(game.id)
+                  ?.combinedTopology ??
               const MapTopology();
-          final tileMaps =
-              ref.read(gameServiceProvider).getMapData(game.id)?.tileMapByRegion;
+          final tileMaps = ref
+              .read(gameServiceProvider)
+              .getMapData(game.id)
+              ?.tileMapByRegion;
           final engine = OrderEngine(initialOrders: next);
+          civilianWorkUpsertValidationPassCountForTests += 1;
           final results = engine.validatePlayerOrdersWithContext(
             game,
             topo,

--- a/app/test/app_event_handler_scope_civilian_work_test.dart
+++ b/app/test/app_event_handler_scope_civilian_work_test.dart
@@ -1,0 +1,178 @@
+import 'dart:io';
+
+import 'package:colonizethis_app/core/services/app_event_handler_scope.dart';
+import 'package:colonizethis_app/config/constants.dart';
+import 'package:colonizethis_app/providers/app_event_bus_provider.dart';
+import 'package:colonizethis_app/providers/games_provider.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart'
+    show kWorkTargetExplore, kWorkTargetProspect, kUnitTypeExplorer;
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+class _ScopeProbe extends ConsumerWidget {
+  const _ScopeProbe();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(currentOrdersProvider);
+    return const SizedBox.shrink();
+  }
+}
+
+void main() {
+  suppressLogsForTests();
+
+  setUpAll(() async {
+    Hive.init('./.dart_tool/test_hive_app_event_handler_scope_civilian_work');
+    await Hive.openBox<dynamic>(HiveBoxNames.games);
+  });
+
+  tearDownAll(() async {
+    await Hive.box<dynamic>(HiveBoxNames.games).clear();
+    await Hive.close();
+    final dir = Directory(
+      './.dart_tool/test_hive_app_event_handler_scope_civilian_work',
+    );
+    if (dir.existsSync()) {
+      await dir.delete(recursive: true);
+    }
+  });
+
+  setUp(() {
+    AppEventBus.reset();
+  });
+
+  testWidgets(
+    'civilian work upsert validates merged draft once and keeps one order per unit',
+    (tester) async {
+      final bus = AppEventBus.create();
+      resetCivilianWorkUpsertValidationPassCountForTests();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            appEventBusProvider.overrideWith((ref) {
+              ref.onDispose(bus.dispose);
+              return bus;
+            }),
+          ],
+          child: const AppEventHandlerScope(
+            child: MaterialApp(home: Scaffold(body: _ScopeProbe())),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(_ScopeProbe)),
+      );
+
+      const playerId = 'gp1';
+      const explorerId = 'u_explorer';
+      const secondExplorerId = 'u_explorer_two';
+      final game = Game(
+        id: 'g_upsert_validation_once',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(
+                id: 'oldWorld|p1',
+                regionId: 'oldWorld',
+                ownerId: playerId,
+              ),
+            ],
+            units: [
+              Unit(
+                id: explorerId,
+                type: kUnitTypeExplorer,
+                ownerId: playerId,
+                locationProvinceId: 'oldWorld|p1',
+                tileKey: 'oldWorld|p1|0|0',
+                status: UnitStatus.idle,
+              ),
+              Unit(
+                id: secondExplorerId,
+                type: kUnitTypeExplorer,
+                ownerId: playerId,
+                locationProvinceId: 'oldWorld|p1',
+                tileKey: 'oldWorld|p1|0|0',
+                status: UnitStatus.idle,
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: const {
+            'oldWorld': {
+              'oldWorld|p1': ['oldWorld|p1|0|0', 'oldWorld|p1|0|1'],
+            },
+          },
+          playerVisibilityByTile: const {
+            playerId: {
+              'oldWorld|p1|0|0': 'fullyVisible',
+              'oldWorld|p1|0|1': 'unknown',
+            },
+          },
+        ),
+        players: const [
+          Player(
+            id: playerId,
+            displayName: 'Human',
+            isHuman: true,
+            treasury: 5000,
+          ),
+        ],
+      );
+
+      container.read(currentGameProvider.notifier).setGame(game);
+      container
+          .read(currentOrdersProvider.notifier)
+          .replaceAll(
+            const Orders(
+              workOrdersByPlayerId: {
+                playerId: [
+                  WorkOrder(
+                    unitId: explorerId,
+                    target: kWorkTargetProspect,
+                    targetTileKey: 'oldWorld|p1|0|0',
+                  ),
+                  WorkOrder(
+                    unitId: secondExplorerId,
+                    target: kWorkTargetExplore,
+                    targetTileKey: 'oldWorld|p1|0|0',
+                  ),
+                ],
+              },
+            ),
+          );
+
+      bus.emit(
+        UpsertPendingCivilianWorkOrderRequestedEvent(
+          playerId: playerId,
+          workOrder: const WorkOrder(
+            unitId: explorerId,
+            target: kWorkTargetExplore,
+            targetTileKey: 'oldWorld|p1|0|0',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(civilianWorkUpsertValidationPassCountForTests, 1);
+
+      final nextOrders = container.read(currentOrdersProvider);
+      final workOrders = nextOrders.workOrdersByPlayerId[playerId] ?? const [];
+      final explorerOrders = workOrders
+          .where((o) => o.unitId == explorerId)
+          .toList();
+      expect(explorerOrders, hasLength(1));
+      expect(explorerOrders.single.target, kWorkTargetExplore);
+      expect(workOrders.where((o) => o.unitId == secondExplorerId).length, 1);
+    },
+  );
+}

--- a/packages/colonizethis_logic/test/order_suggestion_unit_availability_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_unit_availability_test.dart
@@ -94,5 +94,140 @@ void main() {
       );
       expect(orderSuggestionWorkOrderAcceptanceProbeCountForTests, 0);
     });
+
+    test(
+      'pending draft: zero probes even with high-reveal world (issue #2133 scale)',
+      () {
+        setOrderSuggestionWorkOrderAcceptanceProbeTrackingForTests(true);
+        addTearDown(
+          () =>
+              setOrderSuggestionWorkOrderAcceptanceProbeTrackingForTests(false),
+        );
+
+        const playerId = 'gp1';
+        const ow = 'oldWorld';
+        const explorerId = 'E1';
+        const tribeId = 'tribe1';
+        const partialProvinceCount = 20;
+        const extraProvinceCount = 10;
+        const tilesPerPartialProvince = 6;
+        const tilesPerDenseProvince = 10;
+
+        final player = const Player(
+          id: playerId,
+          displayName: 'Human',
+          isHuman: true,
+          treasury: 5000,
+        );
+        final provinces = <Province>[];
+        final byProvince = <String, List<String>>{};
+        final visibility = <String, String>{};
+
+        for (var p = 0; p < partialProvinceCount; p++) {
+          final provinceId = '$ow|partial$p';
+          provinces.add(
+            Province(id: provinceId, regionId: ow, ownerId: tribeId),
+          );
+          final tiles = <String>[];
+          for (var t = 0; t < tilesPerPartialProvince; t++) {
+            final tileKey = '$ow|partial$p|$t|0';
+            tiles.add(tileKey);
+            if (t == 0) {
+              visibility[tileKey] = 'fogged';
+            } else {
+              visibility[tileKey] = 'unknown';
+            }
+          }
+          byProvince[provinceId] = tiles;
+        }
+
+        for (var p = 0; p < extraProvinceCount; p++) {
+          final provinceId = '$ow|dense$p';
+          provinces.add(
+            Province(id: provinceId, regionId: ow, ownerId: tribeId),
+          );
+          final tiles = <String>[];
+          for (var t = 0; t < tilesPerDenseProvince; t++) {
+            final tileKey = '$ow|dense$p|$t|0';
+            tiles.add(tileKey);
+            visibility[tileKey] = 'fogged';
+          }
+          byProvince[provinceId] = tiles;
+        }
+
+        expect(partialProvinceCount, greaterThanOrEqualTo(20));
+        expect(
+          visibility.values.where((v) => v != 'unknown').length,
+          greaterThanOrEqualTo(100),
+        );
+
+        final startProvince = '$ow|partial0';
+        final startTile = '$ow|partial0|0|0';
+        final explorer = Unit(
+          id: explorerId,
+          type: kUnitTypeExplorer,
+          ownerId: playerId,
+          locationProvinceId: startProvince,
+          tileKey: startTile,
+          status: UnitStatus.idle,
+        );
+        final world = WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(provinces: provinces, units: [explorer]),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: {ow: byProvince},
+          playerVisibilityByTile: {playerId: visibility},
+        );
+        final game = Game(
+          id: 'g-scale',
+          worldState: world,
+          players: [player],
+          minorNations: const [],
+          tribes: const [Tribe(id: tribeId, displayName: 'Tribe')],
+        );
+        const topology = MapTopology(nodes: [], edges: []);
+
+        final pending = WorkOrder(
+          unitId: explorerId,
+          target: kWorkTargetExplore,
+          targetTileKey: startTile,
+        );
+        final orders = Orders(
+          workOrdersByPlayerId: {
+            playerId: [pending],
+          },
+        );
+        final view = buildPlayerView(game, topology, playerId);
+
+        getAvailableWorkTargetsForUnit(
+          view: view,
+          game: game,
+          topology: topology,
+          currentOrders: orders,
+          unitId: explorerId,
+        );
+        expect(orderSuggestionWorkOrderAcceptanceProbeCountForTests, 0);
+
+        getValidWorkOrderTileKeysWithVisibility(
+          game: game,
+          topology: topology,
+          view: view,
+          unitId: explorerId,
+          workTarget: kWorkTargetExplore,
+          currentOrders: orders,
+        );
+        expect(orderSuggestionWorkOrderAcceptanceProbeCountForTests, 0);
+
+        getValidWorkOrderTileKeysWithVisibility(
+          game: game,
+          topology: topology,
+          view: view,
+          unitId: explorerId,
+          workTarget: kWorkTargetProspect,
+          currentOrders: orders,
+        );
+        expect(orderSuggestionWorkOrderAcceptanceProbeCountForTests, 0);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- Add `app/test/app_event_handler_scope_civilian_work_test.dart` to exercise `UpsertPendingCivilianWorkOrderRequestedEvent` through `AppEventHandlerScope`.
- Assert the merged-draft Layer B validation runs exactly once per upsert and that only one pending work order remains for the upserted unit.
- Add a test-only counter/reset hook in `app_event_handler_scope_session_subscriptions.dart` used by the new regression test.

## Deferred scope
- This PR is a **slice** for issue #2133 focused on AC4 (single commit-time validation pass).
- AC6 performance threshold guard and AC8 explicit broad-API baseline snapshot remain deferred.

## Test plan
- [x] `flutter test test/app_event_handler_scope_civilian_work_test.dart`

Refs #2133

Made with [Cursor](https://cursor.com)