### PR TITLE
test(orders): add AC6 latency guard and AC8 snapshot coverage

### DIFF
--- a/app/test/games_provider_test.dart
+++ b/app/test/games_provider_test.dart
@@ -22,6 +22,16 @@ Duration _medianDuration(List<Duration> values) {
   return sorted[sorted.length ~/ 2];
 }
 
+String _fixtureTileVisibility({required int provinceIndex, required int tileIndex}) {
+  if (provinceIndex == 0 && tileIndex == 0) {
+    return 'fullyVisible';
+  }
+  if (tileIndex == 0) {
+    return 'fogged';
+  }
+  return 'unknown';
+}
+
 Game _buildExplorerFixtureGame({
   required String id,
   required int provinceCount,
@@ -46,13 +56,10 @@ Game _buildExplorerFixtureGame({
     for (var t = 0; t < tilesPerProvince; t++) {
       final tileKey = '$regionId|p$p|$t|0';
       tiles.add(tileKey);
-      if (p == 0 && t == 0) {
-        visibility[tileKey] = 'fullyVisible';
-      } else if (t == 0) {
-        visibility[tileKey] = 'fogged';
-      } else {
-        visibility[tileKey] = 'unknown';
-      }
+      visibility[tileKey] = _fixtureTileVisibility(
+        provinceIndex: p,
+        tileIndex: t,
+      );
     }
     byProvince[provinceId] = tiles;
   }

--- a/app/test/games_provider_test.dart
+++ b/app/test/games_provider_test.dart
@@ -17,6 +17,69 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive/hive.dart';
 
+Duration _medianDuration(List<Duration> values) {
+  final sorted = List<Duration>.from(values)..sort();
+  return sorted[sorted.length ~/ 2];
+}
+
+Game _buildExplorerFixtureGame({
+  required String id,
+  required int provinceCount,
+  required int tilesPerProvince,
+}) {
+  const playerId = 'gp1';
+  const tribeId = 'tribe1';
+  const regionId = 'oldWorld';
+  const explorerId = 'explorer_1';
+
+  final provinces = <Province>[];
+  final byProvince = <String, List<String>>{};
+  final visibility = <String, String>{};
+
+  for (var p = 0; p < provinceCount; p++) {
+    final provinceId = '$regionId|p$p';
+    final ownerId = p == 0 ? playerId : tribeId;
+    provinces.add(
+      Province(id: provinceId, regionId: regionId, ownerId: ownerId),
+    );
+    final tiles = <String>[];
+    for (var t = 0; t < tilesPerProvince; t++) {
+      final tileKey = '$regionId|p$p|$t|0';
+      tiles.add(tileKey);
+      if (p == 0 && t == 0) {
+        visibility[tileKey] = 'fullyVisible';
+      } else if (t == 0) {
+        visibility[tileKey] = 'fogged';
+      } else {
+        visibility[tileKey] = 'unknown';
+      }
+    }
+    byProvince[provinceId] = tiles;
+  }
+
+  final explorer = Unit(
+    id: explorerId,
+    type: kUnitTypeExplorer,
+    ownerId: playerId,
+    locationProvinceId: '$regionId|p0',
+    tileKey: '$regionId|p0|0|0',
+    status: UnitStatus.idle,
+  );
+
+  return Game(
+    id: id,
+    players: const [Player(id: playerId, displayName: 'Human', isHuman: true)],
+    tribes: const [Tribe(id: tribeId, displayName: 'Tribe')],
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+      oldWorld: RegionData(provinces: provinces, units: [explorer]),
+      newWorld: const RegionData(),
+      tileKeysByRegionAndProvince: {regionId: byProvince},
+      playerVisibilityByTile: {playerId: visibility},
+    ),
+  );
+}
+
 void main() {
   suppressLogsForTests();
 
@@ -42,19 +105,28 @@ void main() {
     expect(ids, isEmpty);
   });
 
-  test('availableWorkTargetIdsForUnitProvider returns empty when no current game', () {
-    final container = ProviderContainer();
-    addTearDown(container.dispose);
+  test(
+    'availableWorkTargetIdsForUnitProvider returns empty when no current game',
+    () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
 
-    expect(container.read(availableWorkTargetIdsForUnitProvider('u1')), isEmpty);
-  });
+      expect(
+        container.read(availableWorkTargetIdsForUnitProvider('u1')),
+        isEmpty,
+      );
+    },
+  );
 
-  test('devExclusiveReservedWorkTileKeysProvider empty when no current game', () {
-    final container = ProviderContainer();
-    addTearDown(container.dispose);
+  test(
+    'devExclusiveReservedWorkTileKeysProvider empty when no current game',
+    () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
 
-    expect(container.read(devExclusiveReservedWorkTileKeysProvider), isEmpty);
-  });
+      expect(container.read(devExclusiveReservedWorkTileKeysProvider), isEmpty);
+    },
+  );
 
   test('derived providers compute with a real current game', () {
     final container = ProviderContainer();
@@ -97,95 +169,20 @@ void main() {
   test(
     'availableWorkTargetIdsForUnitProvider matches getAvailableWorkTargetsForUnit',
     () {
-    final container = ProviderContainer(
-      overrides: [
-        appEventBusProvider.overrideWith((ref) {
-          final bus = AppEventBus.create();
-          ref.onDispose(bus.dispose);
-          return bus;
-        }),
-      ],
-    );
-    addTearDown(container.dispose);
-
-    final gameService = container.read(gameServiceProvider);
-    final game = gameService.createNewGame(
-      id: 'games_provider_work_targets',
-      config: GameSetupConfig(
-        selectedGreatPowerIds: const ['england', 'france'],
-        continentCount: 1,
-        minorNationCount: 0,
-        tribeCount: 1,
-        numProvincesOldWorld: 4,
-        numProvincesNewWorld: 2,
-      ),
-    );
-    container.read(currentGameProvider.notifier).setGame(game);
-
-    final humanId = game.players.firstWhere((p) => p.isHuman).id;
-    String? unitId;
-    for (final u in game.worldState.oldWorld.units) {
-      if (u.ownerId == humanId) {
-        unitId = u.id;
-        break;
-      }
-    }
-    if (unitId == null) {
-      for (final u in game.worldState.newWorld.units) {
-        if (u.ownerId == humanId) {
-          unitId = u.id;
-          break;
-        }
-      }
-    }
-    expect(unitId, isNotNull);
-
-    final mapData = gameService.getMapData(game.id);
-    final topology = mapData?.combinedTopology ?? const MapTopology();
-    final view = buildPlayerView(game, topology, humanId);
-    final orders = container.read(currentOrdersProvider);
-
-    final expected = getAvailableWorkTargetsForUnit(
-      view: view,
-      game: game,
-      topology: topology,
-      currentOrders: orders,
-      unitId: unitId!,
-      tileMapByRegion: mapData?.tileMapByRegion,
-    ).availableWorkTargetIdsSorted();
-
-    expect(
-      container.read(availableWorkTargetIdsForUnitProvider(unitId)),
-      expected,
-    );
-  });
-
-  test(
-    'pending draft work: repeated availableWorkTarget reads do not log '
-    'per-unit work order rejection spam (Refs #2133)',
-    () {
-      setOrderSuggestionWorkOrderAcceptanceProbeTrackingForTests(true);
-      addTearDown(
-        () => setOrderSuggestionWorkOrderAcceptanceProbeTrackingForTests(false),
+      final container = ProviderContainer(
+        overrides: [
+          appEventBusProvider.overrideWith((ref) {
+            final bus = AppEventBus.create();
+            ref.onDispose(bus.dispose);
+            return bus;
+          }),
+        ],
       );
-
-      final logMessages = <String>[];
-      void onLog(LogEvent e) {
-        final m = e.message;
-        if (m is String) {
-          logMessages.add(m);
-        }
-      }
-
-      Logger.addLogListener(onLog);
-      addTearDown(() => Logger.removeLogListener(onLog));
-
-      final container = ProviderContainer();
       addTearDown(container.dispose);
 
       final gameService = container.read(gameServiceProvider);
       final game = gameService.createNewGame(
-        id: 'games_provider_pending_work_log',
+        id: 'games_provider_work_targets',
         config: GameSetupConfig(
           selectedGreatPowerIds: const ['england', 'france'],
           continentCount: 1,
@@ -195,51 +192,127 @@ void main() {
           numProvincesNewWorld: 2,
         ),
       );
+      container.read(currentGameProvider.notifier).setGame(game);
 
       final humanId = game.players.firstWhere((p) => p.isHuman).id;
-      Unit? explorer;
-      for (final u in [
-        ...game.worldState.oldWorld.units,
-        ...game.worldState.newWorld.units,
-      ]) {
-        if (u.ownerId == humanId && u.type == kUnitTypeExplorer) {
-          explorer = u;
+      String? unitId;
+      for (final u in game.worldState.oldWorld.units) {
+        if (u.ownerId == humanId) {
+          unitId = u.id;
           break;
         }
       }
-      expect(explorer, isNotNull);
-      final e = explorer!;
-      expect(e.tileKey, isNotNull);
-
-      container.read(currentGameProvider.notifier).setGame(game);
-      container.read(currentOrdersProvider.notifier).replaceAll(
-        Orders(
-          workOrdersByPlayerId: {
-            humanId: [
-              WorkOrder(
-                unitId: e.id,
-                target: kWorkTargetExplore,
-                targetTileKey: e.tileKey!,
-              ),
-            ],
-          },
-        ),
-      );
-
-      for (var i = 0; i < 40; i++) {
-        container.read(availableWorkTargetIdsForUnitProvider(e.id));
+      if (unitId == null) {
+        for (final u in game.worldState.newWorld.units) {
+          if (u.ownerId == humanId) {
+            unitId = u.id;
+            break;
+          }
+        }
       }
+      expect(unitId, isNotNull);
+
+      final mapData = gameService.getMapData(game.id);
+      final topology = mapData?.combinedTopology ?? const MapTopology();
+      final view = buildPlayerView(game, topology, humanId);
+      final orders = container.read(currentOrdersProvider);
+
+      final expected = getAvailableWorkTargetsForUnit(
+        view: view,
+        game: game,
+        topology: topology,
+        currentOrders: orders,
+        unitId: unitId!,
+        tileMapByRegion: mapData?.tileMapByRegion,
+      ).availableWorkTargetIdsSorted();
 
       expect(
-        logMessages.where(
-          (m) => m.contains('Only one work order per unit is allowed each turn'),
-        ),
-        isEmpty,
-        reason: 'Layer A availability must short-circuit before order-engine probing',
+        container.read(availableWorkTargetIdsForUnitProvider(unitId)),
+        expected,
       );
-      expect(orderSuggestionWorkOrderAcceptanceProbeCountForTests, 0);
     },
   );
+
+  test('pending draft work: repeated availableWorkTarget reads do not log '
+      'per-unit work order rejection spam (Refs #2133)', () {
+    setOrderSuggestionWorkOrderAcceptanceProbeTrackingForTests(true);
+    addTearDown(
+      () => setOrderSuggestionWorkOrderAcceptanceProbeTrackingForTests(false),
+    );
+
+    final logMessages = <String>[];
+    void onLog(LogEvent e) {
+      final m = e.message;
+      if (m is String) {
+        logMessages.add(m);
+      }
+    }
+
+    Logger.addLogListener(onLog);
+    addTearDown(() => Logger.removeLogListener(onLog));
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final gameService = container.read(gameServiceProvider);
+    final game = gameService.createNewGame(
+      id: 'games_provider_pending_work_log',
+      config: GameSetupConfig(
+        selectedGreatPowerIds: const ['england', 'france'],
+        continentCount: 1,
+        minorNationCount: 0,
+        tribeCount: 1,
+        numProvincesOldWorld: 4,
+        numProvincesNewWorld: 2,
+      ),
+    );
+
+    final humanId = game.players.firstWhere((p) => p.isHuman).id;
+    Unit? explorer;
+    for (final u in [
+      ...game.worldState.oldWorld.units,
+      ...game.worldState.newWorld.units,
+    ]) {
+      if (u.ownerId == humanId && u.type == kUnitTypeExplorer) {
+        explorer = u;
+        break;
+      }
+    }
+    expect(explorer, isNotNull);
+    final e = explorer!;
+    expect(e.tileKey, isNotNull);
+
+    container.read(currentGameProvider.notifier).setGame(game);
+    container
+        .read(currentOrdersProvider.notifier)
+        .replaceAll(
+          Orders(
+            workOrdersByPlayerId: {
+              humanId: [
+                WorkOrder(
+                  unitId: e.id,
+                  target: kWorkTargetExplore,
+                  targetTileKey: e.tileKey!,
+                ),
+              ],
+            },
+          ),
+        );
+
+    for (var i = 0; i < 40; i++) {
+      container.read(availableWorkTargetIdsForUnitProvider(e.id));
+    }
+
+    expect(
+      logMessages.where(
+        (m) => m.contains('Only one work order per unit is allowed each turn'),
+      ),
+      isEmpty,
+      reason:
+          'Layer A availability must short-circuit before order-engine probing',
+    );
+    expect(orderSuggestionWorkOrderAcceptanceProbeCountForTests, 0);
+  });
 
   test('gameIdsWithIntroShownProvider defaults empty and can be updated', () {
     final container = ProviderContainer();
@@ -334,5 +407,96 @@ void main() {
     expect(s, isA<PendingDiplomacyIntervention>());
     expect((s! as PendingDiplomacyIntervention).prompts, hasLength(1));
   });
-}
 
+  test(
+    'panel-open provider latency median stays within 1.5x from early to late fixture',
+    () {
+      const explorerId = 'explorer_1';
+      const humanId = 'gp1';
+      const startTileKey = 'oldWorld|p0|0|0';
+      final earlyGame = _buildExplorerFixtureGame(
+        id: 'games_provider_perf_early',
+        provinceCount: 5,
+        tilesPerProvince: 4,
+      );
+      final lateGame = _buildExplorerFixtureGame(
+        id: 'games_provider_perf_late',
+        provinceCount: 30,
+        tilesPerProvince: 12,
+      );
+
+      final earlyContainer = ProviderContainer();
+      addTearDown(earlyContainer.dispose);
+      earlyContainer.read(currentGameProvider.notifier).setGame(earlyGame);
+      earlyContainer
+          .read(currentOrdersProvider.notifier)
+          .replaceAll(
+            const Orders(
+              workOrdersByPlayerId: {
+                humanId: [
+                  WorkOrder(
+                    unitId: explorerId,
+                    target: kWorkTargetExplore,
+                    targetTileKey: startTileKey,
+                  ),
+                ],
+              },
+            ),
+          );
+
+      final lateContainer = ProviderContainer();
+      addTearDown(lateContainer.dispose);
+      lateContainer.read(currentGameProvider.notifier).setGame(lateGame);
+      lateContainer
+          .read(currentOrdersProvider.notifier)
+          .replaceAll(
+            const Orders(
+              workOrdersByPlayerId: {
+                humanId: [
+                  WorkOrder(
+                    unitId: explorerId,
+                    target: kWorkTargetExplore,
+                    targetTileKey: startTileKey,
+                  ),
+                ],
+              },
+            ),
+          );
+
+      // Warmup avoids one-time setup noise in stopwatch samples.
+      for (var i = 0; i < 5; i++) {
+        earlyContainer.read(availableWorkTargetIdsForUnitProvider(explorerId));
+        lateContainer.read(availableWorkTargetIdsForUnitProvider(explorerId));
+      }
+
+      final earlyDurations = <Duration>[];
+      final lateDurations = <Duration>[];
+      for (var i = 0; i < 25; i++) {
+        var sw = Stopwatch()..start();
+        earlyContainer.read(availableWorkTargetIdsForUnitProvider(explorerId));
+        sw.stop();
+        earlyDurations.add(sw.elapsed);
+
+        sw = Stopwatch()..start();
+        lateContainer.read(availableWorkTargetIdsForUnitProvider(explorerId));
+        sw.stop();
+        lateDurations.add(sw.elapsed);
+      }
+
+      final earlyMedian = _medianDuration(earlyDurations);
+      final lateMedian = _medianDuration(lateDurations);
+      final denominator = earlyMedian.inMicroseconds == 0
+          ? 1
+          : earlyMedian.inMicroseconds;
+      final ratio = lateMedian.inMicroseconds / denominator;
+
+      expect(
+        ratio,
+        lessThanOrEqualTo(1.5),
+        reason:
+            'Late fixture panel-open availability should remain <=1.5x early '
+            'fixture median latency (Refs #2133 AC6).',
+      );
+    },
+  );
+}

--- a/packages/colonizethis_logic/test/order_suggestion_full_candidate_snapshot_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_full_candidate_snapshot_test.dart
@@ -1,0 +1,122 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  test(
+    'suggestWorkOrders full-candidate snapshot remains stable (Refs #2133 AC8)',
+    () {
+      const playerId = 'gp1';
+      const regionId = 'oldWorld';
+      const homeProvince = '$regionId|p_home';
+      const targetProvince = '$regionId|p_target';
+      const homeVisible = '$regionId|p_home|0|0';
+      const homeUnknown = '$regionId|p_home|1|0';
+      const targetVisible = '$regionId|p_target|0|0';
+      const targetUnknown = '$regionId|p_target|1|0';
+
+      final explorer = Unit(
+        id: 'explorer_1',
+        type: kUnitTypeExplorer,
+        ownerId: playerId,
+        locationProvinceId: homeProvince,
+        tileKey: homeVisible,
+        status: UnitStatus.idle,
+      );
+
+      final game = Game(
+        id: 'g_suggest_work_snapshot',
+        players: const [
+          Player(id: playerId, displayName: 'Human', isHuman: true),
+        ],
+        tribes: const [Tribe(id: 'tribe1', displayName: 'Tribe')],
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: homeProvince, regionId: regionId, ownerId: playerId),
+              Province(
+                id: targetProvince,
+                regionId: regionId,
+                ownerId: 'tribe1',
+              ),
+            ],
+            units: [explorer],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: const {
+            regionId: {
+              homeProvince: [homeVisible, homeUnknown],
+              targetProvince: [targetVisible, targetUnknown],
+            },
+          },
+          playerVisibilityByTile: const {
+            playerId: {
+              homeVisible: 'fullyVisible',
+              homeUnknown: 'unknown',
+              targetVisible: 'fogged',
+              targetUnknown: 'unknown',
+            },
+          },
+          resourceByTileKey: const {homeVisible: 'iron', targetVisible: 'iron'},
+        ),
+      );
+      final topology = const MapTopology(
+        nodes: [
+          TopologyNode(
+            id: 'p_home',
+            regionId: regionId,
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'p_target',
+            regionId: regionId,
+            type: TopologyNodeType.province,
+          ),
+        ],
+        edges: [TopologyEdge(id1: 'p_home', id2: 'p_target')],
+      );
+      final view = buildPlayerView(game, topology, playerId);
+
+      final suggestionsFirst = suggestWorkOrders(
+        view,
+        game,
+        topology,
+        const Orders(),
+      );
+      final suggestionsSecond = suggestWorkOrders(
+        view,
+        game,
+        topology,
+        const Orders(),
+      );
+
+      final snapshotRows = [
+        for (final order in suggestionsFirst)
+          '${order.unitId}|${order.target}|${order.targetTileKey}',
+      ];
+
+      expect(
+        snapshotRows,
+        const [
+          'explorer_1|explore|oldWorld|p_home|0|0',
+          'explorer_1|explore|oldWorld|p_target|0|0',
+          'explorer_1|prospect|oldWorld|p_home|0|0',
+          'explorer_1|prospect|oldWorld|p_target|0|0',
+        ],
+        reason:
+            'Broad suggestWorkOrders full-candidate semantics must remain stable '
+            'for deterministic explorer fixtures.',
+      );
+      expect(
+        suggestionsSecond,
+        suggestionsFirst,
+        reason:
+            'Repeated invocations should keep deterministic order and content.',
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- add an app-layer regression test in `games_provider_test.dart` that compares median panel-open availability latency between early and late fixtures and enforces `<= 1.5x` (AC6)
- add a deterministic logic snapshot test for broad `suggestWorkOrders` full-candidate explorer semantics with stable ordering/content assertions (AC8)
- keep scope test-only to complete remaining #2133 acceptance-criteria coverage without changing production behavior

## Implemented vs deferred
- **Implemented in this PR:** AC6 and AC8 test coverage additions.
- **Deferred:** none in this slice.

## Test plan
- [x] `dart test packages/colonizethis_logic/test/order_suggestion_full_candidate_snapshot_test.dart`
- [ ] `flutter test app/test/games_provider_test.dart` *(blocked in this environment: missing `assets/data/map_terrain_tilesets.json` loaded by test bootstrap; expected to run in CI/dev environments with assets present)*

Refs #2133

Made with [Cursor](https://cursor.com)