### PR TITLE
Refactor logic region updates with updateRegionById helper (slice)

### DIFF
--- a/SPEC/program/logic-dual-region-province-access.md
+++ b/SPEC/program/logic-dual-region-province-access.md
@@ -5,6 +5,7 @@
 ## Policy
 
 - **Canonical implementation:** `packages/colonizethis_logic/lib/src/world/province_lookup.dart` may use `oldWorld.provinces` and `newWorld.provinces` to implement `allProvinces`, `WorldState.allProvinces()`, region-scoped lookup, and related helpers.
+- **Canonical region updates:** Prefer `WorldState.updateRegionById(...)` (for one-region updates) and `WorldState.mapBothRegions(...)` / `WorldState.mapBothRegionUnits(...)` (for two-region updates) over inline `if (regionId == oldWorld)` or `copyWith(oldWorld: ...)/copyWith(newWorld: ...)` branching in `lib/src/**`.
 - **Elsewhere under** `packages/colonizethis_logic/lib/src/**`: prefer `allProvinces(world)` or the `WorldState` province lookup extension methods so dual-region iteration stays centralized.
 - **Exceptions:** Old-World–only rules (e.g. military victory province counts, GP Old World redistribution) may still touch `oldWorld.provinces` directly when the GDD scope is explicitly Old World only. Such sites are counted toward the **global line budget** below so the total stays small and reviewable.
 

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -118,35 +118,44 @@ Game applyBuildAndWorkOrders(
     (w, p) => w.copyWith(newProvinces: p),
   );
 
-  final withWorld = state.game.copyWith(
-    worldState: state.game.worldState
-        .copyWith(
-          tileState: state.work.tileState,
-          playerVisibilityByTile: state.work.visibilityByTile,
-          portsByProvinceSeaboard: state.work.portsByProvinceSeaboard,
-          purchasedTilesByTileKey: state.work.purchasedTilesByTileKey,
-        )
-        .mapBothRegions(
-          (regionId, _) => RegionData(
-            provinces: regionId == kRegionOldWorld
-                ? state.work.oldProvinces
-                : state.work.newProvinces,
-            units: regionId == kRegionOldWorld
-                ? state.work.oldUnitsById.values.toList()
-                : state.work.newUnitsById.values.toList(),
-          ),
-        ),
+  final provincesByRegion = <String, List<Province>>{
+    kRegionOldWorld: state.work.oldProvinces,
+    kRegionNewWorld: state.work.newProvinces,
+  };
+  final unitsByRegion = <String, List<Unit>>{
+    kRegionOldWorld: state.work.oldUnitsById.values.toList(),
+    kRegionNewWorld: state.work.newUnitsById.values.toList(),
+  };
+  var nextWorldState = state.game.worldState.copyWith(
+    tileState: state.work.tileState,
+    playerVisibilityByTile: state.work.visibilityByTile,
+    portsByProvinceSeaboard: state.work.portsByProvinceSeaboard,
+    purchasedTilesByTileKey: state.work.purchasedTilesByTileKey,
   );
+  nextWorldState = nextWorldState.updateRegionById(
+    kRegionOldWorld,
+    (_) => RegionData(
+      provinces: provincesByRegion[kRegionOldWorld]!,
+      units: unitsByRegion[kRegionOldWorld]!,
+    ),
+  );
+  nextWorldState = nextWorldState.updateRegionById(
+    kRegionNewWorld,
+    (_) => RegionData(
+      provinces: provincesByRegion[kRegionNewWorld]!,
+      units: unitsByRegion[kRegionNewWorld]!,
+    ),
+  );
+
+  final withWorld = state.game.copyWith(worldState: nextWorldState);
 
   return withWorld.copyWith(
     players: state.work.updatedPlayers,
     worldState: withWorld.worldState
         .copyWith(purchasedTilesByTileKey: state.work.purchasedTilesByTileKey)
-        .mapBothRegionUnits((regionId, _) {
-          return regionId == kRegionOldWorld
-              ? state.work.oldUnitsById.values.toList()
-              : state.work.newUnitsById.values.toList();
-        }),
+        .mapBothRegionUnits(
+          (regionId, _) => unitsByRegion[regionId] ?? const <Unit>[],
+        ),
   );
 }
 

--- a/packages/colonizethis_logic/lib/src/world/province_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/world/province_lookup.dart
@@ -241,4 +241,20 @@ extension WorldStateProvinceLookup on WorldState {
       ),
     );
   }
+
+  /// Updates a single region by [regionId], preserving the other region.
+  ///
+  /// Throws [StateError] when [regionId] is unknown.
+  WorldState updateRegionById(
+    String regionId,
+    RegionData Function(RegionData region) update,
+  ) {
+    if (regionId == kRegionOldWorld) {
+      return copyWith(oldWorld: update(oldWorld));
+    }
+    if (regionId == kRegionNewWorld) {
+      return copyWith(newWorld: update(newWorld));
+    }
+    throw StateError('Unknown region "$regionId"');
+  }
 }

--- a/packages/colonizethis_logic/test/province_lookup_test.dart
+++ b/packages/colonizethis_logic/test/province_lookup_test.dart
@@ -171,4 +171,35 @@ void main() {
       expect(getProvince(world, 'newWorld|n1').displayName, 'Gamma');
     });
   });
+
+  group('WorldState.updateRegionById', () {
+    test('updates oldWorld and preserves newWorld', () {
+      final updated = world.updateRegionById(
+        kRegionOldWorld,
+        (region) => RegionData(
+          provinces: [
+            ...region.provinces,
+            Province(
+              id: 'oldWorld|p3',
+              regionId: 'oldWorld',
+              displayName: 'Delta',
+            ),
+          ],
+          units: region.units,
+        ),
+      );
+
+      expect(updated.oldWorld.provinces.length, 3);
+      expect(updated.oldWorld.provinces.last.id, 'oldWorld|p3');
+      expect(updated.newWorld.provinces, hasLength(1));
+      expect(updated.newWorld.provinces.first.id, 'newWorld|n1');
+    });
+
+    test('throws for unknown region id', () {
+      expect(
+        () => world.updateRegionById('unknownRegion', (region) => region),
+        throwsStateError,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Adds `WorldState.updateRegionById(...)` in `province_lookup.dart` as the canonical single-region update helper for logic code.
- Refactors `orders_application.dart` world reconstruction to use region-keyed maps and `updateRegionById` instead of inline dual-region ternary branching.
- Updates `SPEC/program/logic-dual-region-province-access.md` to document canonical region-update helpers and adds tests for `updateRegionById`.

## Implemented in this PR
- `WorldState.updateRegionById` helper with explicit unknown-region failure.
- One representative migration site in `orders_application.dart` replacing manual old/new branching with canonical helpers.
- Unit tests covering helper behavior (success and failure path).

## Deferred work
- Remaining #2149 scope is intentionally deferred: order-suggestion pipeline decomposition, broader dual-region branch elimination across `lib/src/**`, checker expansion to units/general branching patterns, and any additional helper migrations.
- This PR is a targeted, reviewable slice to reduce risk while establishing the canonical helper path.

## AC/spec coverage in this slice
- Partially advances AC: `WorldState.updateRegionById exists` and is exercised in production code (`orders_application.dart`).
- Partially advances AC: non-exception manual branching reduction (representative site only).
- Spec updated: `SPEC/program/logic-dual-region-province-access.md` policy now documents canonical single-region update usage.

## Test plan
- [x] `dart test packages/colonizethis_logic/test/province_lookup_test.dart`
- [x] `dart test packages/colonizethis_logic/test/orders_application_clear_unit_current_work_test.dart packages/colonizethis_logic/test/orders_application_work_completion_test.dart`

Refs #2149

Made with [Cursor](https://cursor.com)