### PR TITLE
Refactor issue 2149 slice: canonical tile parse in order visibility

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
@@ -8,6 +8,7 @@ import '../world/province_lookup.dart';
 import '../world/topology_helpers.dart';
 import 'order_engine.dart';
 import 'order_suggestion_context.dart';
+import 'orders_application_helpers.dart';
 
 void _addAcceptedSeaZoneCandidates({
   required Game game,
@@ -503,10 +504,10 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
 
   for (final entry in view.visibilityByTile.entries) {
     if (entry.value == VisibilityLevel.unknown) continue;
-    final parts = entry.key.split('|');
-    if (parts.length != 4) continue;
-    final regionId = parts[0];
-    final provinceLocalId = parts[1];
+    final parsed = parseTileKeyCoordinates(entry.key);
+    if (parsed == null) continue;
+    final regionId = parsed.regionId;
+    final provinceLocalId = parsed.provinceLocalId;
     final provinceId = ProvinceId.full(regionId, provinceLocalId);
     final province = view.provinceByRegionAndId(regionId, provinceId);
     final ownerId = province?.ownerId;

--- a/packages/colonizethis_logic/lib/src/orders/order_visibility.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_visibility.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import '../constants.dart';
 import '../world/player_view.dart';
 import '../world/province_lookup.dart';
+import 'orders_application_helpers.dart';
 import 'partial_province_reveal.dart';
 
 /// Order visibility rules. SPEC/program/fog-and-exploration-resolution.md.
@@ -27,10 +28,10 @@ bool provinceHasAtLeastVisibility(
       ? ProvinceId.localIdFrom(provinceId)
       : provinceId;
   return view.visibilityByTile.entries.any((e) {
-    final parts = e.key.split('|');
-    if (parts.length != 4) return false;
-    return parts[0] == regionId &&
-        parts[1] == localId &&
+    final parsed = parseTileKeyCoordinates(e.key);
+    if (parsed == null) return false;
+    return parsed.regionId == regionId &&
+        parsed.provinceLocalId == localId &&
         _visibilityAtLeast(e.value, min);
   });
 }
@@ -99,9 +100,9 @@ String regionIdForUnit(PlayerView view, Unit unit) {
     }
   }
   for (final tileKey in view.visibilityByTile.keys) {
-    final parts = tileKey.split('|');
-    if (parts.length == 4 && parts[1] == unit.locationProvinceId) {
-      return parts[0];
+    final parsed = parseTileKeyCoordinates(tileKey);
+    if (parsed != null && parsed.provinceLocalId == unit.locationProvinceId) {
+      return parsed.regionId;
     }
   }
   if (!ProvinceId.isPrefixed(unit.locationProvinceId)) {

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -356,12 +356,7 @@ BuildWorkState _advanceWorkUnitTick(
         replaceProvinces,
       );
     }
-    unitsById[unitKey] = u.copyWith(
-      status: UnitStatus.idle,
-      clearOriginTileKey: true,
-      clearAssignedTileKey: true,
-      clearCurrentWork: true,
-    );
+    unitsById[unitKey] = cancelUnitWork(u, restoredTile: u.tileKey);
     return oldWorldUnits
         ? next.copyWith(work: next.work.copyWith(oldUnitsById: unitsById))
         : next.copyWith(work: next.work.copyWith(newUnitsById: unitsById));

--- a/packages/colonizethis_logic/lib/src/orders/orders_application_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_helpers.dart
@@ -2,17 +2,13 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../world/tile_key_coordinates.dart' as tile_key_coordinates;
 import 'build_rail_work_rules.dart';
 
 /// Canonical tile-key coordinate parser for `regionId|provinceId|x|y`.
 ({String regionId, String provinceLocalId, int x, int y})?
 parseTileKeyCoordinates(String tileKey) {
-  final parts = tileKey.split('|');
-  if (parts.length != 4) return null;
-  final x = int.tryParse(parts[2]);
-  final y = int.tryParse(parts[3]);
-  if (x == null || y == null) return null;
-  return (regionId: parts[0], provinceLocalId: parts[1], x: x, y: y);
+  return tile_key_coordinates.parseTileKeyCoordinates(tileKey);
 }
 
 /// Clears active work state for a unit and restores its pre-assignment tile.

--- a/packages/colonizethis_logic/lib/src/world/fog_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/fog_resolution.dart
@@ -10,6 +10,7 @@ import 'naval_resolution.dart'
         landTileKeysForProvinceBucket;
 import 'player_view.dart';
 import 'province_lookup.dart' hide landTileKeysForProvinceBucket;
+import 'tile_key_coordinates.dart';
 import 'unit_lookup.dart';
 
 void _fogFullyVisibleTilesForSpyExpiry(
@@ -140,9 +141,12 @@ Map<String, Map<String, String>> applyFogDecay(
     final navalCoastalIntel = navalCoastalIntelByPlayer[playerId] ?? const {};
 
     for (final tileKey in visibility.keys.toList()) {
-      final parts = tileKey.split('|');
-      if (parts.length != 4) continue;
-      final fullProvinceId = ProvinceId.full(parts[0], parts[1]);
+      final parsedTile = parseTileKeyCoordinates(tileKey);
+      if (parsedTile == null) continue;
+      final fullProvinceId = ProvinceId.full(
+        parsedTile.regionId,
+        parsedTile.provinceLocalId,
+      );
       final ownerId = ownerByProvince[fullProvinceId];
       if (ownerId == null || ownerId == playerId) continue;
       if (hasExplorerIn.contains(fullProvinceId)) continue;

--- a/packages/colonizethis_logic/lib/src/world/province_ownership_transfer.dart
+++ b/packages/colonizethis_logic/lib/src/world/province_ownership_transfer.dart
@@ -237,21 +237,14 @@ _applyCanonicalSingleProvinceOwnershipTransferCore(
     newOwnerId,
   );
 
-  final newRegion = RegionData(
-    provinces: updatedProvinces,
-    units: updatedUnits,
-  );
+  final newRegion = RegionData(provinces: updatedProvinces, units: updatedUnits);
 
   var nextWs = game.worldState.copyWith(
     fleets: updatedFleets,
     purchasedTilesByTileKey: purchasedAfter,
     spyRevealTurnsByPlayer: spyNext,
   );
-  if (regionId == kRegionOldWorld) {
-    nextWs = nextWs.copyWith(oldWorld: newRegion);
-  } else {
-    nextWs = nextWs.copyWith(newWorld: newRegion);
-  }
+  nextWs = nextWs.updateRegionById(regionId, (_) => newRegion);
 
   var nextGame = game.copyWith(worldState: nextWs);
 

--- a/packages/colonizethis_logic/lib/src/world/tile_key_coordinates.dart
+++ b/packages/colonizethis_logic/lib/src/world/tile_key_coordinates.dart
@@ -1,0 +1,10 @@
+/// Canonical tile-key coordinate parser for `regionId|provinceId|x|y`.
+({String regionId, String provinceLocalId, int x, int y})?
+parseTileKeyCoordinates(String tileKey) {
+  final parts = tileKey.split('|');
+  if (parts.length != 4) return null;
+  final x = int.tryParse(parts[2]);
+  final y = int.tryParse(parts[3]);
+  if (x == null || y == null) return null;
+  return (regionId: parts[0], provinceLocalId: parts[1], x: x, y: y);
+}

--- a/packages/colonizethis_logic/test/world/tile_key_coordinates_test.dart
+++ b/packages/colonizethis_logic/test/world/tile_key_coordinates_test.dart
@@ -1,0 +1,21 @@
+import 'package:colonizethis_logic/src/world/tile_key_coordinates.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('parseTileKeyCoordinates (world canonical helper)', () {
+    test('parses valid tile keys', () {
+      final parsed = parseTileKeyCoordinates('oldWorld|P1|3|9');
+      expect(parsed, isNotNull);
+      expect(parsed!.regionId, 'oldWorld');
+      expect(parsed.provinceLocalId, 'P1');
+      expect(parsed.x, 3);
+      expect(parsed.y, 9);
+    });
+
+    test('returns null for malformed tile keys', () {
+      expect(parseTileKeyCoordinates('oldWorld|P1|3'), isNull);
+      expect(parseTileKeyCoordinates('oldWorld|P1|x|9'), isNull);
+      expect(parseTileKeyCoordinates('oldWorld|P1|3|y'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Reuses the canonical `parseTileKeyCoordinates` helper in order visibility and diplomatic suggestion tile-key iteration paths, replacing local `split('|')` parsing in those callsites.
- Reuses `cancelUnitWork` for completed-work unit cleanup in `orders_application.dart` so all work-state clear paths share one helper.
- Replaces manual `oldWorld/newWorld` write branching in canonical province ownership transfer with `updateRegionById`, keeping region updates on the shared abstraction path.
- Preserves behavior by keeping completed work units on their current tile via `cancelUnitWork(..., restoredTile: u.tileKey)`.

## Implemented in this PR
- Updated `order_visibility.dart` to parse tile keys through `parseTileKeyCoordinates` in `provinceHasAtLeastVisibility` and `regionIdForUnit`.
- Updated `order_suggestion_naval_diplomatic.dart` to use `parseTileKeyCoordinates` while discovering known faction ownership from visibility tiles.
- Updated `orders_application.dart` to replace inline work-completion reset copyWith block with `cancelUnitWork`.
- Updated `province_ownership_transfer.dart` to replace manual region copyWith branching with `updateRegionById(regionId, ...)`.

## Deferred
- Broader replacement of inline tile-key parsing across all remaining `colonizethis_logic` non-order modules.
- Remaining issue #2149 ACs not covered by this slice (including any still-open checker/surface cleanup beyond these order callsites).

## Acceptance criteria coverage (issue #2149)
- Partial progress toward canonical tile-key parsing adoption: covered key order visibility/diplomatic callsites.
- Partial progress toward single-helper work cancellation/reset behavior: completed-work cleanup now uses `cancelUnitWork`.
- Partial progress toward canonical region update abstraction: canonical ownership transfer now uses `updateRegionById` instead of direct region branch writes.
- Issue remains partial; follow-up slices required for full completion.

## Test plan
- [x] `dart test packages/colonizethis_logic/test/orders/orders_application_helpers_test.dart packages/colonizethis_logic/test/order_visibility_test.dart packages/colonizethis_logic/test/order_suggestion_diplomacy_filter_test.dart packages/colonizethis_logic/test/orders_application_work_completion_test.dart`
- [x] `dart test packages/colonizethis_logic/test/world/province_ownership_transfer_test.dart`
- [x] `dart run tool/check_logic_dual_region_province_field_access.dart`

Refs #2149

Made with [Cursor](https://cursor.com)