### PR TITLE
Implement issue 2152 scoped naval panel auto-close

### DIFF
--- a/SPEC/ui/naval-units-panel.md
+++ b/SPEC/ui/naval-units-panel.md
@@ -209,3 +209,9 @@ The naval units panel participates in the Widgetbook catalog for review and test
 
 - **Given** the Move dialog is open, **when** the user taps **Cancel**, **then** the UI layer closes the dialog without emitting **`NavalMoveFleetRequestedEvent`**.
 
+- **Given** the Naval Units panel is opened with `locationScopeKey` and currently renders at least one scoped fleet row, **when** the user confirms a move from that scoped panel and the projected scoped fleet list transitions from non-empty to empty after the move draft update, **then** the UI layer emits **`ClosePanelEvent`** to dismiss the naval panel.
+
+- **Given** the Naval Units panel is opened without `locationScopeKey` (full-list mode), **when** the user confirms a fleet move, **then** the UI layer keeps the naval panel open and updates list content without emitting **`ClosePanelEvent`** for auto-close.
+
+- **Given** the Naval Units panel is opened with `locationScopeKey`, **when** the panel list becomes empty for reasons other than a move confirmation emitted from that scoped panel, **then** the UI layer does not emit **`ClosePanelEvent`** for automatic dismissal.
+

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -1,5 +1,7 @@
 // Naval units panel. SPEC/ui/naval-units-panel.md.
 
+import 'dart:async';
+
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart' show homeFleetIdFor;
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -51,10 +53,13 @@ class NavalUnitsPanel extends StatefulWidget {
 
 class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
   final Set<String> _selectedFleetIds = {};
+  final Set<String> _visibleScopedFleetIds = <String>{};
   static const double _desktopViewportThreshold = 1280;
   static const double _scaledWidthMin = 420;
   static const double _scaledWidthMax = 640;
   static const double _scaledViewportFactor = 0.36;
+  StreamSubscription<NavalMoveFleetRequestedEvent>? _moveRequestedSub;
+  bool _pendingScopedAutoCloseAfterMove = false;
 
   @override
   void initState() {
@@ -63,6 +68,20 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
     if (id != null && id.isNotEmpty) {
       _selectedFleetIds.add(id);
     }
+    _moveRequestedSub = widget.bus.on<NavalMoveFleetRequestedEvent>().listen((
+      event,
+    ) {
+      if (widget.locationScopeKey == null) return;
+      if (_visibleScopedFleetIds.contains(event.moveOrder.fleetId)) {
+        _pendingScopedAutoCloseAfterMove = true;
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _moveRequestedSub?.cancel();
+    super.dispose();
   }
 
   /// Canonical fleet id for combine/split selection (Home Fleet uses [homeFleetIdFor]).
@@ -338,6 +357,18 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.game != widget.game ||
         oldWidget.draftOrders != widget.draftOrders) {
+      final oldFlat = flattenNavalTree(
+        buildNavalTree(
+          oldWidget.game,
+          oldWidget.humanPlayerId,
+          oldWidget.topology,
+          oldWidget.draftOrders,
+          appL10n(context),
+          tileMapByRegion: oldWidget.tileMapByRegion,
+          topologyByRegion: oldWidget.topologyByRegion,
+          locationScopeKeyFilter: oldWidget.locationScopeKey,
+        ),
+      );
       final flat = flattenNavalTree(
         buildNavalTree(
           widget.game,
@@ -360,6 +391,18 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
             _selectedFleetIds.addAll(pruned);
           });
         });
+      }
+      if (_pendingScopedAutoCloseAfterMove &&
+          widget.locationScopeKey != null &&
+          oldFlat.isNotEmpty &&
+          flat.isEmpty) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          widget.bus.emit(const ClosePanelEvent());
+        });
+      }
+      if (_pendingScopedAutoCloseAfterMove) {
+        _pendingScopedAutoCloseAfterMove = false;
       }
     }
   }
@@ -442,6 +485,9 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
       locationScopeKeyFilter: widget.locationScopeKey,
     );
     final flat = flattenNavalTree(tree);
+    _visibleScopedFleetIds
+      ..clear()
+      ..addAll(flat.map((row) => row.fleetId));
     final hasAny = tree.any(
       (group) => group.homeFleet != null || group.locations.isNotEmpty,
     );

--- a/app/lib/features/game/widgets/naval_units_panel.dart
+++ b/app/lib/features/game/widgets/naval_units_panel.dart
@@ -487,9 +487,8 @@ class _NavalUnitsPanelState extends State<NavalUnitsPanel> {
       locationScopeKeyFilter: widget.locationScopeKey,
     );
     final flat = flattenNavalTree(tree);
-    _visibleScopedFleetIds
-      ..clear()
-      ..addAll(flat.map((row) => row.fleetId));
+    _visibleScopedFleetIds.clear();
+    _visibleScopedFleetIds.addAll(flat.map((row) => row.fleetId));
     final hasAny = tree.any(
       (group) => group.homeFleet != null || group.locations.isNotEmpty,
     );

--- a/app/test/naval_units_panel_test_part4_test.dart
+++ b/app/test/naval_units_panel_test_part4_test.dart
@@ -145,6 +145,7 @@ void main() {
       ),
     );
   }
+
   group('NavalUnitsPanel', () {
     testWidgets('AC: Beachhead mission appears in status line', (
       WidgetTester tester,
@@ -352,6 +353,195 @@ void main() {
         expect(find.text('New World'), findsOneWidget);
         expect(find.text('Old World'), findsNothing);
         expect(find.textContaining('Fleet f1'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'AC: Scoped panel auto-closes after confirmed move empties scope',
+      (WidgetTester tester) async {
+        const humanId = 'gp_scope_autoclose_yes';
+        final bus = AppEventBus.create();
+        final closeEvents = <ClosePanelEvent>[];
+        final closeSub = bus.on<ClosePanelEvent>().listen(closeEvents.add);
+        addTearDown(closeSub.cancel);
+
+        final scopedGame = Game(
+          id: 'g_scope_autoclose_yes',
+          worldState: WorldState(
+            turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(),
+            newWorld: RegionData(),
+            fleets: [
+              Fleet(
+                id: 'f1',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                seaZoneId: 's1',
+                ships: [ShipInstance(id: 'ship_1', typeId: 'frigate')],
+              ),
+            ],
+          ),
+          players: const [
+            Player(id: humanId, displayName: 'Scoped AutoClose', isHuman: true),
+          ],
+        );
+        const topology = MapTopology(
+          nodes: [
+            TopologyNode(
+              id: 'oldWorld|s1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+            TopologyNode(
+              id: 'oldWorld|s2',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+          ],
+          edges: [TopologyEdge(id1: 'oldWorld|s1', id2: 'oldWorld|s2')],
+        );
+
+        await tester.pumpWidget(
+          _ScopedNavalPanelHarness(
+            game: scopedGame,
+            humanPlayerId: humanId,
+            bus: bus,
+            topology: topology,
+            locationScopeKey: 'sea:oldWorld|s1',
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.textContaining('Fleet f1'), findsOneWidget);
+
+        bus.emit(
+          NavalMoveFleetRequestedEvent(
+            humanPlayerId: humanId,
+            moveOrder: NavalMoveOrder(
+              fleetId: 'f1',
+              destinationSeaZoneId: 'oldWorld|s2',
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(closeEvents.length, 1);
+      },
+    );
+
+    testWidgets(
+      'AC: Full-list mode move confirm does not emit scoped auto-close event',
+      (WidgetTester tester) async {
+        const humanId = 'gp_scope_autoclose_no_full';
+        final bus = AppEventBus.create();
+        final closeEvents = <ClosePanelEvent>[];
+        final closeSub = bus.on<ClosePanelEvent>().listen(closeEvents.add);
+        addTearDown(closeSub.cancel);
+
+        final gameFull = Game(
+          id: 'g_scope_autoclose_no_full',
+          worldState: WorldState(
+            turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(),
+            newWorld: RegionData(),
+            fleets: [
+              Fleet(
+                id: 'f1',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                seaZoneId: 's1',
+                ships: [ShipInstance(id: 'ship_1', typeId: 'frigate')],
+              ),
+            ],
+          ),
+          players: const [
+            Player(id: humanId, displayName: 'Full List', isHuman: true),
+          ],
+        );
+        const topology = MapTopology(
+          nodes: [
+            TopologyNode(
+              id: 'oldWorld|s1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+            TopologyNode(
+              id: 'oldWorld|s2',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+          ],
+          edges: [TopologyEdge(id1: 'oldWorld|s1', id2: 'oldWorld|s2')],
+        );
+
+        await tester.pumpWidget(
+          _ScopedNavalPanelHarness(
+            game: gameFull,
+            humanPlayerId: humanId,
+            bus: bus,
+            topology: topology,
+            locationScopeKey: null,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        bus.emit(
+          NavalMoveFleetRequestedEvent(
+            humanPlayerId: humanId,
+            moveOrder: NavalMoveOrder(
+              fleetId: 'f1',
+              destinationSeaZoneId: 'oldWorld|s2',
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(closeEvents, isEmpty);
+      },
+    );
+
+    testWidgets(
+      'AC: Scoped empty state without move confirm does not auto-close',
+      (WidgetTester tester) async {
+        const humanId = 'gp_scope_autoclose_no_external';
+        final bus = AppEventBus.create();
+        final closeEvents = <ClosePanelEvent>[];
+        final closeSub = bus.on<ClosePanelEvent>().listen(closeEvents.add);
+        addTearDown(closeSub.cancel);
+
+        final gameScoped = Game(
+          id: 'g_scope_autoclose_no_external',
+          worldState: WorldState(
+            turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(),
+            newWorld: RegionData(),
+            fleets: [
+              Fleet(
+                id: 'f1',
+                ownerId: humanId,
+                regionId: 'oldWorld',
+                seaZoneId: 's1',
+                ships: [ShipInstance(id: 'ship_1', typeId: 'frigate')],
+              ),
+            ],
+          ),
+          players: const [
+            Player(id: humanId, displayName: 'Scoped External', isHuman: true),
+          ],
+        );
+
+        await tester.pumpWidget(
+          _ScopedNavalPanelHarness(
+            game: gameScoped,
+            humanPlayerId: humanId,
+            bus: bus,
+            topology: const MapTopology(),
+            locationScopeKey: 'sea:oldWorld|s1',
+            removeFleetOnNextFrame: true,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(closeEvents, isEmpty);
       },
     );
 
@@ -744,5 +934,89 @@ void main() {
         expect(updated, isNull);
       },
     );
+  });
+}
+
+class _ScopedNavalPanelHarness extends StatefulWidget {
+  const _ScopedNavalPanelHarness({
+    required this.game,
+    required this.humanPlayerId,
+    required this.bus,
+    required this.topology,
+    required this.locationScopeKey,
+    this.removeFleetOnNextFrame = false,
+  });
+
+  final Game game;
+  final String humanPlayerId;
+  final AppEventBus bus;
+  final MapTopology topology;
+  final String? locationScopeKey;
+  final bool removeFleetOnNextFrame;
+
+  @override
+  State<_ScopedNavalPanelHarness> createState() =>
+      _ScopedNavalPanelHarnessState();
+}
+
+class _ScopedNavalPanelHarnessState extends State<_ScopedNavalPanelHarness> {
+  late Orders _draftOrders;
+  late Game _game;
+  StreamSubscription<NavalMoveFleetRequestedEvent>? _moveSub;
+
+  @override
+  void initState() {
+    super.initState();
+    _draftOrders = const Orders();
+    _game = widget.game;
+    _moveSub = widget.bus.on<NavalMoveFleetRequestedEvent>().listen((event) {
+      if (!mounted) return;
+      setState(() {
+        _draftOrders = Orders(
+          navalMoveOrdersByPlayerId: {
+            event.humanPlayerId: [
+              NavalMoveOrder(
+                fleetId: event.moveOrder.fleetId,
+                destinationSeaZoneId: event.moveOrder.destinationSeaZoneId,
+                destinationPortProvinceId:
+                    event.moveOrder.destinationPortProvinceId,
+              ),
+            ],
+          },
+        );
+      });
     });
+    if (widget.removeFleetOnNextFrame) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        setState(() {
+          _game = _game.copyWith(
+            worldState: _game.worldState.copyWith(fleets: const []),
+          );
+        });
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _moveSub?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: NavalUnitsPanel(
+          game: _game,
+          humanPlayerId: widget.humanPlayerId,
+          bus: widget.bus,
+          topology: widget.topology,
+          draftOrders: _draftOrders,
+          locationScopeKey: widget.locationScopeKey,
+        ),
+      ),
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Implement scoped naval panel auto-close when a move confirmed from that scoped panel causes the projected scoped fleet list to transition from non-empty to empty.
- Keep full-list mode unchanged and guard against unrelated empty-state transitions by requiring a scoped move-confirm signal.
- Add SPEC ACs and widget coverage for positive and negative paths.

## Implemented vs deferred
- Implemented in this PR:
  - Scoped post-move-empty auto-close behavior via `ClosePanelEvent`.
  - Guard rails preventing auto-close in full-list mode and non-move empty transitions.
  - SPEC additions for the new scoped auto-close contract.
  - Widget tests for scoped close, full-list no-close, and scoped external-empty no-close.
- Deferred: none identified for issue scope.

## AC/spec coverage
- Covered now:
  - `SPEC/ui/naval-units-panel.md` move-related ACs for scoped auto-close and no-close guards.
- Remaining:
  - None for this issue slice.

## Test plan
- [x] `flutter test test/naval_units_panel_test_part4_test.dart`

Refs #2152

Made with [Cursor](https://cursor.com)