### PR TITLE
Refactor AI planner helper duplication (slice 1)

### DIFF
--- a/packages/colonizethis_ai/lib/src/ai_random_utils.dart
+++ b/packages/colonizethis_ai/lib/src/ai_random_utils.dart
@@ -1,0 +1,26 @@
+import 'dart:math' as math;
+
+/// Selects a weighted index from [weights] using [seed].
+///
+/// Returns `null` when no positive total weight exists.
+int? pickWeightedIndex(List<num> weights, int seed, {bool useIntRoll = false}) {
+  if (weights.isEmpty) return null;
+  final total = weights.fold<double>(0, (sum, value) => sum + value.toDouble());
+  if (total <= 0) return null;
+  final rng = math.Random(seed);
+  var roll = useIntRoll
+      ? rng.nextInt(total.toInt()).toDouble()
+      : rng.nextDouble() * total;
+  for (var i = 0; i < weights.length; i++) {
+    final weight = weights[i].toDouble();
+    if (weight <= 0) continue;
+    if (useIntRoll) {
+      roll -= weight;
+      if (roll < 0) return i;
+      continue;
+    }
+    if (roll < weight) return i;
+    roll -= weight;
+  }
+  return weights.length - 1;
+}

--- a/packages/colonizethis_ai/lib/src/domain_planners.dart
+++ b/packages/colonizethis_ai/lib/src/domain_planners.dart
@@ -6,8 +6,10 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_logic/order_suggestion_api.dart';
 
+import 'ai_random_utils.dart';
 import 'goal_manager.dart';
 import 'hidden_agenda.dart';
+import 'orders_extensions.dart';
 import 'perception.dart';
 
 final _log = packageLogger();
@@ -82,7 +84,7 @@ Orders runDomainPlanners({
       );
     }
     if (selection.workOrders.isNotEmpty) {
-      orders = _appendWorkOrders(orders, nationId, selection.workOrders);
+      orders = orders.appendWorkOrders(nationId, selection.workOrders);
     }
   } else if (workCandidates.isNotEmpty) {
     _log.d('work skipped nationId=$nationId weight below threshold');
@@ -103,7 +105,7 @@ Orders runDomainPlanners({
     );
     if (chosen != null) {
       _log.i('build chosen nationId=$nationId unitType=${chosen.unitType}');
-      orders = _appendBuildOrders(orders, nationId, [chosen]);
+      orders = orders.appendBuildOrders(nationId, [chosen]);
     }
   } else if (buildCandidates.isNotEmpty) {
     _log.d('build skipped nationId=$nationId weight below threshold');
@@ -190,19 +192,13 @@ Orders runDomainPlanners({
       'research eval nationId=$nationId researchThreshold=$researchThreshold '
       'candidates=${researchCandidates.map((o) => o.techId).toList()} scores=$scores',
     );
-    final total = scores.reduce((a, b) => a + b);
-    final rng = math.Random(seeds.researchSeed);
-    var r = rng.nextInt(total);
-    var idx = 0;
-    for (; idx < scores.length && r >= scores[idx]; idx++) {
-      r -= scores[idx];
-    }
-    if (idx >= researchCandidates.length) idx = researchCandidates.length - 1;
+    final idx = pickWeightedIndex(scores, seeds.researchSeed, useIntRoll: true);
+    if (idx == null) return orders;
     final chosen = researchCandidates[idx];
     _log.i(
       'research chosen nationId=$nationId techId=${chosen.techId} score=${scores[idx]}',
     );
-    orders = _appendResearchOrders(orders, nationId, [chosen]);
+    orders = orders.appendResearchOrders(nationId, [chosen]);
   } else if (researchCandidates.isNotEmpty) {
     _log.d(
       'research skipped nationId=$nationId threshold not met or no candidates',
@@ -260,21 +256,14 @@ Orders _runMovePlanner({
     return 1.0 + (atWar ? kMovePreferEnemyTerritoryBonus.toDouble() : 0);
   }).toList();
   _log.d('move scores nationId=$nationId scores=$scores');
-  final total = scores.reduce((a, b) => a + b);
-  if (total <= 0) return orders;
-  final rng = math.Random(seeds.militarySeed);
-  var r = rng.nextDouble() * total;
-  var idx = 0;
-  for (; idx < filtered.length && r > scores[idx]; idx++) {
-    r -= scores[idx];
-  }
-  if (idx >= filtered.length) idx = filtered.length - 1;
+  final idx = pickWeightedIndex(scores, seeds.militarySeed);
+  if (idx == null) return orders;
   final selected = [filtered[idx]];
   _log.i(
     'move chosen nationId=$nationId '
     'unitId=${selected.first.unitId} destinationTileKey=${selected.first.destinationTileKey}',
   );
-  return _appendMoveOrders(orders, nationId, selected);
+  return orders.appendMoveOrders(nationId, selected);
 }
 
 Orders _runArmyMovePlanner({
@@ -332,45 +321,14 @@ Orders _runArmyMovePlanner({
     final atWar = rel != null && rel.atWar;
     return 1.0 + (atWar ? kMovePreferEnemyTerritoryBonus.toDouble() : 0);
   }).toList();
-  final total = scores.reduce((a, b) => a + b);
-  if (total <= 0) return orders;
-  final rng = math.Random(seeds.militarySeed + 2000);
-  var r = rng.nextDouble() * total;
-  var idx = 0;
-  for (; idx < filtered.length && r > scores[idx]; idx++) {
-    r -= scores[idx];
-  }
-  if (idx >= filtered.length) idx = filtered.length - 1;
+  final idx = pickWeightedIndex(scores, seeds.militarySeed + 2000);
+  if (idx == null) return orders;
   final selected = filtered[idx];
   _log.i(
     'army move chosen nationId=$nationId '
     'armyId=${selected.armyId} destinationProvinceId=${selected.destinationProvinceId}',
   );
   return applyArmyMoveOrderForPlayer(orders, nationId, selected);
-}
-
-Orders _appendMoveOrders(Orders o, String playerId, List<MoveOrder> list) {
-  final existing = o.moveOrdersByPlayerId[playerId] ?? const [];
-  return o.copyWith(
-    moveOrdersByPlayerId: {
-      ...o.moveOrdersByPlayerId,
-      playerId: [...existing, ...list],
-    },
-  );
-}
-
-Orders _appendBuildOrders(
-  Orders o,
-  String playerId,
-  List<BuildUnitOrder> list,
-) {
-  final existing = o.buildUnitOrdersByPlayerId[playerId] ?? const [];
-  return o.copyWith(
-    buildUnitOrdersByPlayerId: {
-      ...o.buildUnitOrdersByPlayerId,
-      playerId: [...existing, ...list],
-    },
-  );
 }
 
 /// Scores build candidates (ships vs regiments) by cargo preference, goal, and personality.
@@ -431,39 +389,9 @@ BuildUnitOrder? _pickBuildOrder({
     'scores=$scores',
   );
 
-  final total = scores.reduce((a, b) => a + b);
-  if (total <= 0) return buildCandidates.first;
-  final rng = math.Random(seed);
-  var r = rng.nextDouble() * total;
-  for (var idx = 0; idx < buildCandidates.length; idx++) {
-    if (r < scores[idx]) return buildCandidates[idx];
-    r -= scores[idx];
-  }
-  return buildCandidates.last;
-}
-
-Orders _appendWorkOrders(Orders o, String playerId, List<WorkOrder> list) {
-  final existing = o.workOrdersByPlayerId[playerId] ?? const [];
-  return o.copyWith(
-    workOrdersByPlayerId: {
-      ...o.workOrdersByPlayerId,
-      playerId: [...existing, ...list],
-    },
-  );
-}
-
-Orders _appendResearchOrders(
-  Orders o,
-  String playerId,
-  List<ResearchOrder> list,
-) {
-  final existing = o.researchOrdersByPlayerId[playerId] ?? const [];
-  return o.copyWith(
-    researchOrdersByPlayerId: {
-      ...o.researchOrdersByPlayerId,
-      playerId: [...existing, ...list],
-    },
-  );
+  final idx = pickWeightedIndex(scores, seed);
+  if (idx == null) return buildCandidates.first;
+  return buildCandidates[idx];
 }
 
 Orders _runNavalPlanner({
@@ -511,7 +439,7 @@ Orders _runNavalPlanner({
         'naval move chosen nationId=$nationId '
         'take=$take selected=${selected.map((m) => "fleetId=${m.fleetId} destSea=${m.destinationSeaZoneId} destPort=${m.destinationPortProvinceId}").toList()}',
       );
-      o = _appendNavalMoveOrders(o, nationId, selected);
+      o = o.appendNavalMoveOrders(nationId, selected);
     }
   }
 
@@ -533,38 +461,10 @@ Orders _runNavalPlanner({
       'naval mission chosen nationId=$nationId '
       'mission=${chosen.mission} fleetId=${chosen.fleetId}',
     );
-    o = _appendNavalMissionOrders(o, nationId, [chosen]);
+    o = o.appendNavalMissionOrders(nationId, [chosen]);
   }
 
   return o;
-}
-
-Orders _appendNavalMoveOrders(
-  Orders o,
-  String playerId,
-  List<NavalMoveOrder> list,
-) {
-  final existing = o.navalMoveOrdersByPlayerId[playerId] ?? const [];
-  return o.copyWith(
-    navalMoveOrdersByPlayerId: {
-      ...o.navalMoveOrdersByPlayerId,
-      playerId: [...existing, ...list],
-    },
-  );
-}
-
-Orders _appendNavalMissionOrders(
-  Orders o,
-  String playerId,
-  List<NavalMissionOrder> list,
-) {
-  final existing = o.navalMissionOrdersByPlayerId[playerId] ?? const [];
-  return o.copyWith(
-    navalMissionOrdersByPlayerId: {
-      ...o.navalMissionOrdersByPlayerId,
-      playerId: [...existing, ...list],
-    },
-  );
 }
 
 Orders _runDiplomacyPlanner({
@@ -618,21 +518,14 @@ Orders _runDiplomacyPlanner({
     'candidates=$candidateDesc scores=$scores',
   );
 
-  final total = scores.reduce((a, b) => a + b);
-  if (total <= 0) return orders;
-  final rng = math.Random(seeds.diplomacySeed);
-  var r = rng.nextDouble() * total;
-  var idx = 0;
-  for (; idx < scores.length && r > scores[idx]; idx++) {
-    r -= scores[idx];
-  }
-  if (idx >= diploCandidates.length) idx = diploCandidates.length - 1;
+  final idx = pickWeightedIndex(scores, seeds.diplomacySeed);
+  if (idx == null) return orders;
   final chosen = diploCandidates[idx];
   _log.i(
     'diplomacy chosen nationId=$nationId '
     'type=${chosen.type}${chosen.type == DiplomaticOrderType.declareWar ? " targetFactionId=${chosen.targetFactionId}" : ""} score=${scores[idx]}',
   );
-  return _appendDiplomaticOrders(orders, nationId, [chosen]);
+  return orders.appendDiplomaticOrders(nationId, [chosen]);
 }
 
 /// Pre–weighted-random scores for diplomatic order candidates (0 = suppressed).
@@ -891,18 +784,4 @@ int _invasionCapacityAdjustment(
       .length;
   if (activeWars >= 2) score -= 15;
   return score;
-}
-
-Orders _appendDiplomaticOrders(
-  Orders o,
-  String playerId,
-  List<DiplomaticOrder> list,
-) {
-  final existing = o.diplomaticOrdersByPlayerId[playerId] ?? const [];
-  return o.copyWith(
-    diplomaticOrdersByPlayerId: {
-      ...o.diplomaticOrdersByPlayerId,
-      playerId: [...existing, ...list],
-    },
-  );
 }

--- a/packages/colonizethis_ai/lib/src/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/economy_planner.dart
@@ -19,6 +19,8 @@ const double _kChainWeight = 1.0;
 /// Weight for agenda/personality modifier.
 const double _kAgendaWeight = 0.5;
 
+const int _kVeryLargeRuns = 999999;
+
 /// Runs the economy planner for one AI-controlled player. Deterministic given
 /// [game], [view], [config], and [seeds]. Returns production assignments and
 /// cargo preference. SPEC/ai/economy-planner.md.
@@ -122,18 +124,11 @@ List<AssignedRecipe> _allocateLabour({
   for (final recipe in recipes) {
     final labourPerOutput = recipe.labourPerOutput;
     if (labourPerOutput <= 0) continue;
-    int maxByInputs = 999999;
-    for (final entry in recipe.inputQuantities.entries) {
-      final have = virtual.quantityOf(entry.key);
-      final need = entry.value;
-      if (need <= 0) continue;
-      final runs = have ~/ need;
-      if (runs < maxByInputs) maxByInputs = runs;
-    }
-    if (maxByInputs <= 0) continue;
-    final maxByLabour = remainingLabour ~/ labourPerOutput;
-    if (maxByLabour <= 0) continue;
-    final feasibleRuns = maxByInputs < maxByLabour ? maxByInputs : maxByLabour;
+    final feasibleRuns = _feasibleRuns(
+      recipe: recipe,
+      stockpile: virtual,
+      remainingLabour: remainingLabour,
+    );
     if (feasibleRuns <= 0) continue;
 
     final score = _scoreRecipe(
@@ -166,18 +161,11 @@ List<AssignedRecipe> _allocateLabour({
   for (final scored in candidates) {
     if (remainingLabour <= 0) break;
     final recipe = scored.recipe;
-    int maxByInputs = 999999;
-    for (final entry in recipe.inputQuantities.entries) {
-      final have = virtual.quantityOf(entry.key);
-      final need = entry.value;
-      if (need <= 0) continue;
-      final runs = have ~/ need;
-      if (runs < maxByInputs) maxByInputs = runs;
-    }
-    if (maxByInputs <= 0) continue;
-    final maxByLabour = remainingLabour ~/ recipe.labourPerOutput;
-    if (maxByLabour <= 0) continue;
-    final runs = maxByInputs < maxByLabour ? maxByInputs : maxByLabour;
+    final runs = _feasibleRuns(
+      recipe: recipe,
+      stockpile: virtual,
+      remainingLabour: remainingLabour,
+    );
     if (runs <= 0) continue;
 
     final labourUsed = runs * recipe.labourPerOutput;
@@ -209,6 +197,26 @@ class _ScoredRecipe {
   _ScoredRecipe({required this.recipe, required this.score});
   final ProductionRecipe recipe;
   final double score;
+}
+
+int _feasibleRuns({
+  required ProductionRecipe recipe,
+  required Stockpile stockpile,
+  required int remainingLabour,
+}) {
+  if (recipe.labourPerOutput <= 0) return 0;
+  int maxByInputs = _kVeryLargeRuns;
+  for (final entry in recipe.inputQuantities.entries) {
+    final have = stockpile.quantityOf(entry.key);
+    final need = entry.value;
+    if (need <= 0) continue;
+    final runs = have ~/ need;
+    if (runs < maxByInputs) maxByInputs = runs;
+  }
+  if (maxByInputs <= 0) return 0;
+  final maxByLabour = remainingLabour ~/ recipe.labourPerOutput;
+  if (maxByLabour <= 0) return 0;
+  return maxByInputs < maxByLabour ? maxByInputs : maxByLabour;
 }
 
 double _scoreRecipe({

--- a/packages/colonizethis_ai/lib/src/goal_manager.dart
+++ b/packages/colonizethis_ai/lib/src/goal_manager.dart
@@ -1,9 +1,8 @@
-import 'dart:math' as math;
-
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_ai/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'ai_random_utils.dart';
 import 'hidden_agenda.dart';
 import 'perception.dart';
 
@@ -19,9 +18,10 @@ enum StrategicGoal { defend, expand, conquer, trade, tech, diplomacy }
 StrategicGoal selectPrimaryGoal(
   AIWorldSnapshot snapshot,
   AIConfig config,
-  int goalSeed,
-  {required String nationId, required int turn}
-) {
+  int goalSeed, {
+  required String nationId,
+  required int turn,
+}) {
   final weights = getGoalWeightsForLeader(config.personalityId);
   final thresholds = getThresholdsForLeader(config.personalityId);
 
@@ -68,41 +68,41 @@ StrategicGoal selectPrimaryGoal(
   );
 
   // Weighted random choice using goalSeed.
-  final total = candidates.values.fold<int>(0, (a, b) => a + b);
-  if (total <= 0) return StrategicGoal.expand;
-  var r = math.Random(goalSeed).nextInt(total);
-  StrategicGoal selected = StrategicGoal.expand;
-  for (final e in candidates.entries) {
-    r -= e.value;
-    if (r < 0) {
-      selected = e.key;
-      break;
-    }
-  }
+  final candidateEntries = candidates.entries.toList();
+  final selectedIndex = pickWeightedIndex(
+    candidateEntries.map((e) => e.value).toList(),
+    goalSeed,
+    useIntRoll: true,
+  );
+  final selected = selectedIndex == null
+      ? StrategicGoal.expand
+      : candidateEntries[selectedIndex].key;
   final majorConstraint = switch (selected) {
-    StrategicGoal.defend => snapshot.threats.capitalThreatened
-        ? 'capitalThreatened'
-        : snapshot.threats.atWarWith.isNotEmpty
-            ? 'atWarWith'
-            : 'none',
-    StrategicGoal.expand => snapshot.opportunities.unclaimedProvinces > 0
-        ? 'unclaimedProvinces'
-        : snapshot.economy.workerCount < 3
-            ? 'lowWorkerCount'
-            : 'none',
-    StrategicGoal.conquer => agendaConquerModifier(config.hiddenAgendaId) != 0
-        ? 'hiddenAgendaConquerModifier'
-        : (thresholds.warLikelihood - 50) != 0
-            ? 'warLikelihoodThreshold'
-            : 'none',
+    StrategicGoal.defend =>
+      snapshot.threats.capitalThreatened
+          ? 'capitalThreatened'
+          : snapshot.threats.atWarWith.isNotEmpty
+          ? 'atWarWith'
+          : 'none',
+    StrategicGoal.expand =>
+      snapshot.opportunities.unclaimedProvinces > 0
+          ? 'unclaimedProvinces'
+          : snapshot.economy.workerCount < 3
+          ? 'lowWorkerCount'
+          : 'none',
+    StrategicGoal.conquer =>
+      agendaConquerModifier(config.hiddenAgendaId) != 0
+          ? 'hiddenAgendaConquerModifier'
+          : (thresholds.warLikelihood - 50) != 0
+          ? 'warLikelihoodThreshold'
+          : 'none',
     StrategicGoal.diplomacy =>
       agendaDiplomacyModifier(config.hiddenAgendaId) != 0
           ? 'hiddenAgendaDiplomacyModifier'
-          : ((thresholds.peaceTendency + thresholds.allianceTendency) ~/
-                      2) !=
-                  50
-              ? 'peaceAllianceTendency'
-              : 'none',
+          : ((thresholds.peaceTendency + thresholds.allianceTendency) ~/ 2) !=
+                50
+          ? 'peaceAllianceTendency'
+          : 'none',
     _ => 'none',
   };
   _log.i(

--- a/packages/colonizethis_ai/lib/src/orders_extensions.dart
+++ b/packages/colonizethis_ai/lib/src/orders_extensions.dart
@@ -1,0 +1,81 @@
+import 'package:colonizethis_logic/order_suggestion_api.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+typedef _OrdersByPlayer<T> = Map<String, List<T>>;
+
+_OrdersByPlayer<T> _appendOrdersByPlayer<T>(
+  _OrdersByPlayer<T> source,
+  String playerId,
+  List<T> list,
+) {
+  final existing = source[playerId] ?? const [];
+  return {
+    ...source,
+    playerId: [...existing, ...list],
+  };
+}
+
+extension OrdersAppendExtension on Orders {
+  Orders appendMoveOrders(String playerId, List<MoveOrder> list) => copyWith(
+    moveOrdersByPlayerId: _appendOrdersByPlayer(
+      moveOrdersByPlayerId,
+      playerId,
+      list,
+    ),
+  );
+
+  Orders appendBuildOrders(String playerId, List<BuildUnitOrder> list) =>
+      copyWith(
+        buildUnitOrdersByPlayerId: _appendOrdersByPlayer(
+          buildUnitOrdersByPlayerId,
+          playerId,
+          list,
+        ),
+      );
+
+  Orders appendWorkOrders(String playerId, List<WorkOrder> list) => copyWith(
+    workOrdersByPlayerId: _appendOrdersByPlayer(
+      workOrdersByPlayerId,
+      playerId,
+      list,
+    ),
+  );
+
+  Orders appendResearchOrders(String playerId, List<ResearchOrder> list) =>
+      copyWith(
+        researchOrdersByPlayerId: _appendOrdersByPlayer(
+          researchOrdersByPlayerId,
+          playerId,
+          list,
+        ),
+      );
+
+  Orders appendNavalMoveOrders(String playerId, List<NavalMoveOrder> list) =>
+      copyWith(
+        navalMoveOrdersByPlayerId: _appendOrdersByPlayer(
+          navalMoveOrdersByPlayerId,
+          playerId,
+          list,
+        ),
+      );
+
+  Orders appendNavalMissionOrders(
+    String playerId,
+    List<NavalMissionOrder> list,
+  ) => copyWith(
+    navalMissionOrdersByPlayerId: _appendOrdersByPlayer(
+      navalMissionOrdersByPlayerId,
+      playerId,
+      list,
+    ),
+  );
+
+  Orders appendDiplomaticOrders(String playerId, List<DiplomaticOrder> list) =>
+      copyWith(
+        diplomaticOrdersByPlayerId: _appendOrdersByPlayer(
+          diplomaticOrdersByPlayerId,
+          playerId,
+          list,
+        ),
+      );
+}

--- a/packages/colonizethis_ai/test/ai_random_utils_test.dart
+++ b/packages/colonizethis_ai/test/ai_random_utils_test.dart
@@ -1,6 +1,5 @@
 import 'package:colonizethis_ai/src/ai_random_utils.dart';
 import 'package:colonizethis_test/test.dart';
-import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('pickWeightedIndex', () {

--- a/packages/colonizethis_ai/test/ai_random_utils_test.dart
+++ b/packages/colonizethis_ai/test/ai_random_utils_test.dart
@@ -1,0 +1,24 @@
+import 'package:colonizethis_ai/src/ai_random_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('pickWeightedIndex', () {
+    test('returns null for empty and zero total weights', () {
+      expect(pickWeightedIndex(const [], 42), isNull);
+      expect(pickWeightedIndex(const [0, 0, 0], 42), isNull);
+    });
+
+    test('is deterministic for same seed and weights', () {
+      final first = pickWeightedIndex(const [1.0, 2.0, 3.0], 1001);
+      final second = pickWeightedIndex(const [1.0, 2.0, 3.0], 1001);
+      expect(first, equals(second));
+    });
+
+    test('supports tie-like deterministic selection with int roll mode', () {
+      final first = pickWeightedIndex(const [1, 1, 1], 77, useIntRoll: true);
+      final second = pickWeightedIndex(const [1, 1, 1], 77, useIntRoll: true);
+      expect(first, equals(second));
+      expect(first, inInclusiveRange(0, 2));
+    });
+  });
+}

--- a/packages/colonizethis_ai/test/ai_random_utils_test.dart
+++ b/packages/colonizethis_ai/test/ai_random_utils_test.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_ai/src/ai_random_utils.dart';
+import 'package:colonizethis_test/test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/packages/colonizethis_ai/test/orders_extensions_test.dart
+++ b/packages/colonizethis_ai/test/orders_extensions_test.dart
@@ -1,0 +1,23 @@
+import 'package:colonizethis_ai/src/orders_extensions.dart';
+import 'package:colonizethis_logic/order_suggestion_api.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('appendMoveOrders appends without mutating other players', () {
+    const base = Orders(
+      moveOrdersByPlayerId: {
+        'p1': [MoveOrder(unitId: 'u1', destinationTileKey: 'r1|a')],
+        'p2': [MoveOrder(unitId: 'u2', destinationTileKey: 'r1|b')],
+      },
+    );
+
+    final updated = base.appendMoveOrders('p1', const [
+      MoveOrder(unitId: 'u3', destinationTileKey: 'r1|c'),
+    ]);
+
+    expect(updated.moveOrdersByPlayerId['p1']?.length, 2);
+    expect(updated.moveOrdersByPlayerId['p2'], base.moveOrdersByPlayerId['p2']);
+    expect(base.moveOrdersByPlayerId['p1']?.length, 1);
+  });
+}

--- a/packages/colonizethis_ai/test/orders_extensions_test.dart
+++ b/packages/colonizethis_ai/test/orders_extensions_test.dart
@@ -2,7 +2,6 @@ import 'package:colonizethis_ai/src/orders_extensions.dart';
 import 'package:colonizethis_logic/order_suggestion_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
-import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('appendMoveOrders appends without mutating other players', () {

--- a/packages/colonizethis_ai/test/orders_extensions_test.dart
+++ b/packages/colonizethis_ai/test/orders_extensions_test.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_ai/src/orders_extensions.dart';
 import 'package:colonizethis_logic/order_suggestion_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {


### PR DESCRIPTION
## Summary
- Extract shared weighted-random selection helper into `packages/colonizethis_ai/lib/src/ai_random_utils.dart` and replace duplicated loops in goal/domain planners.
- Extract shared Orders append extension methods into `packages/colonizethis_ai/lib/src/orders_extensions.dart` and replace duplicated `_append*Orders` helpers.
- Deduplicate economy feasible-runs arithmetic into a single `_feasibleRuns` helper used in both scoring and assignment passes.

## Implemented in this PR
- Replaced weighted selection duplication in:
  - `goal_manager.dart`
  - `domain_planners.dart` (move/army/research/build/diplomacy selection paths)
- Replaced duplicated order append helpers by using `OrdersAppendExtension` methods.
- Added dedicated helper tests for deterministic weighted selection and order append map immutability behavior.

## Deferred
- Split `domain_planners.dart` below 700 lines (currently 787 physical lines).
- Remove/collapse `hidden_agenda.dart` wrappers.

These items are intentionally deferred to follow-up slices because the issue scope is broad and this PR focuses on safe behavior-preserving helper extraction.

## AC coverage for #2161
- Covered now:
  - reusable weighted-random helper and replacements
  - reusable order-append mechanism and replacements
  - feasible-runs dedupe in economy planner
  - helper-focused tests (empty/zero weights and deterministic tie behavior)
- Deferred:
  - `domain_planners.dart` <700 lines
  - `hidden_agenda.dart` removal/collapse

## Testing
- `flutter test` (in `packages/colonizethis_ai`)
- `flutter test --coverage` (in `packages/colonizethis_ai`)
- Coverage result: `94.46%` line coverage (`886/938`) via `coverage/lcov.info`

Refs #2161

Made with [Cursor](https://cursor.com)