### PR TITLE
Add turn-resolution processing modal UI guardrails (slice 1)

### DIFF
--- a/SPEC/ui/next-turn-confirmation.md
+++ b/SPEC/ui/next-turn-confirmation.md
@@ -27,7 +27,19 @@ When the player clicks the "Next turn" button in the top bar, a confirmation dia
 1. Player clicks "Next turn" button.
 2. Confirmation dialog appears with "No" and "Yes" buttons.
 3. Player clicks "No" → dialog closes, turn does not advance.
-4. Player clicks "Yes" → dialog closes, turn advances (existing `_onNextTurn` logic executes).
+4. Player clicks "Yes" → dialog closes, the system enters turn-resolution active state.
+5. During turn-resolution active state, the UI shows a non-dismissible modal titled `Processing Turn`.
+6. After turn resolution completes or fails, the modal closes and controls return to normal.
+
+### Turn-resolution active state (slice 1)
+
+- Scope: this slice covers UI gating and completion/error handling around existing turn resolution execution.
+- Deferred: worker-isolate execution and per-phase live text updates are handled in later slices.
+- While active:
+  - The top-bar Next Turn button is disabled.
+  - Map interaction inputs are blocked.
+  - Hamburger menu remains available from the top bar.
+  - The modal cannot be dismissed by outside tap or back/escape.
 
 ---
 
@@ -35,8 +47,12 @@ When the player clicks the "Next turn" button in the top bar, a confirmation dia
 
 - **Given** the player is on the game screen, **when** they click the "Next turn" button, **then** a confirmation dialog appears.
 - **Given** the confirmation dialog is shown, **when** the player clicks "No", **then** the dialog closes and the turn does not advance.
-- **Given** the confirmation dialog is shown, **when** the player clicks "Yes", **then** the dialog closes and the turn advances (existing `_onNextTurn` executes).
+- **Given** the confirmation dialog is shown, **when** the player clicks "Yes", **then** the dialog closes and the system enters turn-resolution active state.
 - **Given** the dialog is shown, **when** the player presses Escape or taps outside the dialog, **then** it behaves as "No" (aborts).
+- **Given** turn-resolution active state is true, **when** the game map is visible, **then** the UI shows a modal titled `Processing Turn` and the modal is not dismissible by outside tap or back/escape.
+- **Given** turn-resolution active state is true, **when** the player attempts to press Next Turn, **then** the Next Turn button is disabled and no second resolution starts.
+- **Given** turn-resolution active state is true, **when** the player interacts with map content, **then** the map interaction is blocked while the hamburger menu remains available.
+- **Given** turn resolution reaches terminal success or terminal failure, **when** the terminal outcome is processed, **then** the processing modal closes and turn-resolution active state becomes false.
 
 ---
 

--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -38,6 +38,9 @@ import 'debug_console_overlay_panel.dart';
 import 'game_map_area_state_logic.dart';
 import 'per_player_work_target_selection_cache.dart';
 import 'next_turn_confirmation_dialog.dart';
+import 'turn_resolution_flow.dart';
+import 'turn_resolution_processing_dialog.dart';
+import 'turn_resolution_result_applier.dart';
 import '../utils/map_location_resolver.dart';
 import '../widgets/player_turn_event_feed.dart';
 
@@ -56,5 +59,4 @@ class GameMapArea extends ConsumerStatefulWidget {
 }
 
 class _GameMapAreaState extends ConsumerState<GameMapArea>
-    with _GameMapAreaStatePart1, _GameMapAreaStatePart2 {
-}
+    with _GameMapAreaStatePart1, _GameMapAreaStatePart2 {}

--- a/app/lib/features/game/flame/game_map_area_part1.dart
+++ b/app/lib/features/game/flame/game_map_area_part1.dart
@@ -518,9 +518,10 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
       applyTurnResolutionResult(ref, result);
     } catch (_) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Turn resolution failed.')),
-        );
+        final failureMessage = appL10n(context).game_turnResolutionFailedMessage;
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(failureMessage)));
       }
       rethrow;
     } finally {

--- a/app/lib/features/game/flame/game_map_area_part1.dart
+++ b/app/lib/features/game/flame/game_map_area_part1.dart
@@ -17,6 +17,8 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
   ct_models.MapViewState _mapViewState = ct_models.MapViewState.defaults;
   final List<ct_models.GameToUIEvent> _pendingPlayerTurnEvents = [];
   List<ct_models.GameToUIEvent> _resolvedPlayerTurnEvents = const [];
+  bool _isTurnResolving = false;
+  String _turnResolutionPhaseText = 'Resolving turn...';
 
   /// Base layer display mode for map letters. SPEC/ui/empire-overview.md § Base layer display cycle.
   BaseLayerDisplayMode _baseLayerDisplayMode =
@@ -462,6 +464,9 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
   }
 
   Future<void> _onNextTurn() async {
+    if (_isTurnResolving) {
+      return;
+    }
     final game = ref.read(currentGameProvider);
     if (game == null) return;
 
@@ -474,9 +479,59 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
 
     final service = ref.read(gameServiceProvider);
     final orders = ref.read(currentOrdersProvider);
-    final newGame = service.nextTurn(game, orders: orders);
-    ref.read(currentGameProvider.notifier).setGame(newGame);
-    ref.read(currentOrdersProvider.notifier).clear();
+    final mapData = service.getMapData(game.id);
+    if (mapData == null) {
+      throw StateError('Missing required map data for gameId=${game.id}');
+    }
+
+    setState(() {
+      _isTurnResolving = true;
+      _turnResolutionPhaseText = 'Resolving turn...';
+    });
+    unawaited(
+      showDialog<void>(
+        context: context,
+        barrierDismissible: false,
+        useRootNavigator: true,
+        builder: (_) =>
+            TurnResolutionProcessingDialog(phaseText: _turnResolutionPhaseText),
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+    try {
+      final result = resolveNextTurnForGameScreen(
+        game: game,
+        orders: orders,
+        topologyForAi: mapData.combinedTopology,
+        tileMapByRegion: mapData.tileMapByRegion,
+        runTurnResolution:
+            ({required ct_models.Orders orders, ct_models.Orders? aiOrders}) =>
+                service.runTurnResolution(
+                  game,
+                  orders: orders,
+                  aiOrders: aiOrders,
+                ),
+      );
+      if (!mounted) {
+        return;
+      }
+      applyTurnResolutionResult(ref, result);
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Turn resolution failed.')),
+        );
+      }
+      rethrow;
+    } finally {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _isTurnResolving = false;
+      });
+      Navigator.of(context, rootNavigator: true).maybePop();
+    }
   }
 
   void _e2eSelectFirstValidWorkTargetTile() {

--- a/app/lib/features/game/flame/game_map_area_part2.dart
+++ b/app/lib/features/game/flame/game_map_area_part2.dart
@@ -53,6 +53,7 @@ mixin _GameMapAreaStatePart2
           onToggleSideMenu: () =>
               setState(() => _sideMenuOpen = !_sideMenuOpen),
           onNextTurn: _onNextTurn,
+          nextTurnEnabled: !_isTurnResolving,
           regionIndex: _regionIndex,
           onRegionIndexChanged: (i) =>
               setState(() => _regionIndex = i == 0 ? 0 : 1),
@@ -71,331 +72,343 @@ mixin _GameMapAreaStatePart2
             fit: StackFit.expand,
             children: [
               Positioned.fill(
-                child: Focus(
-                  autofocus: true,
-                  onKeyEvent: (node, event) {
-                    if (_workTargetSelection != null &&
-                        event is KeyDownEvent &&
-                        event.logicalKey == LogicalKeyboardKey.escape) {
-                      _cancelWorkTargetSelection();
-                      return KeyEventResult.handled;
-                    }
-                    if (_sideMenuOpen &&
-                        event is KeyDownEvent &&
-                        event.logicalKey == LogicalKeyboardKey.escape) {
-                      setState(() => _sideMenuOpen = false);
-                      return KeyEventResult.handled;
-                    }
-                    return KeyEventResult.ignored;
-                  },
-                  child: Stack(
-                    children: [
-                      GameMapCanvasStack(
-                        isNarrow: isNarrow,
-                        game: widget.game,
-                        region: projectedRegion,
-                        baseLayerDisplayMode: _baseLayerDisplayMode,
-                        showProvinceOverlay: _mapViewState.showProvinceOverlay,
-                        showProvinceOwnershipTint:
-                            _mapViewState.showProvinceOwnershipTint,
-                        showProvinceNamesLayer:
-                            _mapViewState.showProvinceNamesLayer,
-                        humanPlayerId: _humanPlayerId,
-                        playerView: humanPlayerView,
-                        workTargetSelectionCache: _workTargetSelectionCache,
-                        centerOnTileKey: _centerOnTileKey,
-                        validTileKeysForSelection: _validTileKeysForSelection,
-                        selectedCivilianTileKey: _selectedCivilianTileKey,
-                        onTileSelectedForWork: _workTargetSelection != null
-                            ? _onTileSelectedForWork
-                            : null,
-                        onWorkTargetSelectionCancelled:
-                            _workTargetSelection != null
-                            ? _cancelWorkTargetSelection
-                            : null,
-                        onCivilianTileTapped: (tileKey) {
-                          String? initialSelectedUnitId;
-                          for (final marker
-                              in projectedRegion.civilianTileMarkers) {
-                            if (marker.tileKey == tileKey &&
-                                marker.unitIds.isNotEmpty) {
-                              initialSelectedUnitId = marker.unitIds.first;
-                              break;
-                            }
-                          }
-                          setState(() {
-                            _selectedCivilianTileKey = tileKey;
-                          });
-                          ref
-                              .read(appEventBusProvider)
-                              .emit(
-                                ct_models.OpenCivilianUnitsPanelEvent(
-                                  tileScopeTileKey: tileKey,
-                                  initialSelectedUnitId: initialSelectedUnitId,
-                                ),
-                              );
-                        },
-                        onCivilianTileSelectionCleared: () {
-                          if (_selectedCivilianTileKey == null) return;
-                          setState(() {
-                            _selectedCivilianTileKey = null;
-                          });
-                        },
-                        onFleetMarkerTapped:
-                            (locationScopeKey, initialFleetId, markerTileKey) {
-                              ref
-                                  .read(appEventBusProvider)
-                                  .emit(
-                                    ct_models.OpenNavalUnitsPanelEvent(
-                                      locationScopeKey: locationScopeKey,
-                                      initialSelectedFleetId: initialFleetId,
-                                      tileScopeTileKey: markerTileKey,
-                                    ),
-                                  );
-                            },
-                        bus: ref.read(appEventBusProvider),
-                        onRegionViewportSnapshot: _onRegionViewportSnapshot,
-                        zoomMultiplier: _mapViewState.zoomMultiplier,
-                      ),
-                      if (!_sideMenuOpen)
-                        Positioned(
-                          left: 0,
-                          top: 0,
-                          bottom: 0,
-                          width: kEdgeSwipeStripWidth,
-                          child: GestureDetector(
-                            behavior: HitTestBehavior.translucent,
-                            onHorizontalDragUpdate: (details) {
-                              if (details.delta.dx > 20) {
-                                setState(() => _sideMenuOpen = true);
-                              }
-                            },
-                          ),
-                        ),
-                      Positioned(
-                        left: kEdgeSwipeStripWidth,
-                        top: 0,
-                        child: GameMapEmpireLeftRail(
+                child: IgnorePointer(
+                  ignoring: _isTurnResolving,
+                  child: Focus(
+                    autofocus: true,
+                    onKeyEvent: (node, event) {
+                      if (_workTargetSelection != null &&
+                          event is KeyDownEvent &&
+                          event.logicalKey == LogicalKeyboardKey.escape) {
+                        _cancelWorkTargetSelection();
+                        return KeyEventResult.handled;
+                      }
+                      if (_sideMenuOpen &&
+                          event is KeyDownEvent &&
+                          event.logicalKey == LogicalKeyboardKey.escape) {
+                        setState(() => _sideMenuOpen = false);
+                        return KeyEventResult.handled;
+                      }
+                      return KeyEventResult.ignored;
+                    },
+                    child: Stack(
+                      children: [
+                        GameMapCanvasStack(
+                          isNarrow: isNarrow,
                           game: widget.game,
+                          region: projectedRegion,
+                          baseLayerDisplayMode: _baseLayerDisplayMode,
+                          showProvinceOverlay:
+                              _mapViewState.showProvinceOverlay,
+                          showProvinceOwnershipTint:
+                              _mapViewState.showProvinceOwnershipTint,
+                          showProvinceNamesLayer:
+                              _mapViewState.showProvinceNamesLayer,
                           humanPlayerId: _humanPlayerId,
-                          onIconTappedWhileSelectionMode:
+                          playerView: humanPlayerView,
+                          workTargetSelectionCache: _workTargetSelectionCache,
+                          centerOnTileKey: _centerOnTileKey,
+                          validTileKeysForSelection: _validTileKeysForSelection,
+                          selectedCivilianTileKey: _selectedCivilianTileKey,
+                          onTileSelectedForWork: _workTargetSelection != null
+                              ? _onTileSelectedForWork
+                              : null,
+                          onWorkTargetSelectionCancelled:
                               _workTargetSelection != null
                               ? _cancelWorkTargetSelection
                               : null,
-                        ),
-                      ),
-                      Positioned(
-                        left: kMapOverlayEdgeInset,
-                        bottom: kMapOverlayEdgeInset,
-                        child: GameMapCornerControls(
-                          onCycleBaseLayerDisplayMode:
-                              _cycleBaseLayerDisplayMode,
-                          onCenterOnHomeCapital: _centerOnHumanCapital,
-                          onOpenMapDisplayOptions: () {
-                            showDialog<void>(
-                              context: context,
-                              builder: (context) {
-                                return AlertDialog(
-                                  title: Text(l10n.map_displayOptions_title),
-                                  content: Consumer(
-                                    builder: (context, ref, child) {
-                                      return Column(
-                                        mainAxisSize: MainAxisSize.min,
-                                        children: [
-                                          SwitchListTile(
-                                            title: Text(
-                                              l10n.map_displayOptions_showProvinceOverlay,
-                                            ),
-                                            value: _mapViewState
-                                                .showProvinceOverlay,
-                                            onChanged: (value) {
-                                              _setMapViewState(
-                                                _mapViewState.copyWith(
-                                                  showProvinceOverlay: value,
-                                                ),
-                                              );
-                                            },
-                                          ),
-                                          SwitchListTile(
-                                            title: Text(
-                                              l10n.map_displayOptions_showProvinceOwnership,
-                                            ),
-                                            value: _mapViewState
-                                                .showProvinceOwnershipTint,
-                                            onChanged: (value) {
-                                              _setMapViewState(
-                                                _mapViewState.copyWith(
-                                                  showProvinceOwnershipTint:
-                                                      value,
-                                                ),
-                                              );
-                                            },
-                                          ),
-                                          SwitchListTile(
-                                            title: Text(
-                                              l10n.map_displayOptions_showProvinceNames,
-                                            ),
-                                            value: _mapViewState
-                                                .showProvinceNamesLayer,
-                                            onChanged: (value) {
-                                              _setMapViewState(
-                                                _mapViewState.copyWith(
-                                                  showProvinceNamesLayer: value,
-                                                ),
-                                              );
-                                            },
-                                          ),
-                                        ],
-                                      );
-                                    },
+                          onCivilianTileTapped: (tileKey) {
+                            String? initialSelectedUnitId;
+                            for (final marker
+                                in projectedRegion.civilianTileMarkers) {
+                              if (marker.tileKey == tileKey &&
+                                  marker.unitIds.isNotEmpty) {
+                                initialSelectedUnitId = marker.unitIds.first;
+                                break;
+                              }
+                            }
+                            setState(() {
+                              _selectedCivilianTileKey = tileKey;
+                            });
+                            ref
+                                .read(appEventBusProvider)
+                                .emit(
+                                  ct_models.OpenCivilianUnitsPanelEvent(
+                                    tileScopeTileKey: tileKey,
+                                    initialSelectedUnitId:
+                                        initialSelectedUnitId,
                                   ),
-                                  actions: [
-                                    TextButton(
-                                      onPressed: () =>
-                                          Navigator.of(context).maybePop(),
-                                      child: Text(l10n.common_close),
-                                    ),
-                                  ],
                                 );
-                              },
-                            );
                           },
+                          onCivilianTileSelectionCleared: () {
+                            if (_selectedCivilianTileKey == null) return;
+                            setState(() {
+                              _selectedCivilianTileKey = null;
+                            });
+                          },
+                          onFleetMarkerTapped:
+                              (
+                                locationScopeKey,
+                                initialFleetId,
+                                markerTileKey,
+                              ) {
+                                ref
+                                    .read(appEventBusProvider)
+                                    .emit(
+                                      ct_models.OpenNavalUnitsPanelEvent(
+                                        locationScopeKey: locationScopeKey,
+                                        initialSelectedFleetId: initialFleetId,
+                                        tileScopeTileKey: markerTileKey,
+                                      ),
+                                    );
+                              },
+                          bus: ref.read(appEventBusProvider),
+                          onRegionViewportSnapshot: _onRegionViewportSnapshot,
+                          zoomMultiplier: _mapViewState.zoomMultiplier,
                         ),
-                      ),
-                      if (kCtE2EEnabled) ...[
+                        if (!_sideMenuOpen)
+                          Positioned(
+                            left: 0,
+                            top: 0,
+                            bottom: 0,
+                            width: kEdgeSwipeStripWidth,
+                            child: GestureDetector(
+                              behavior: HitTestBehavior.translucent,
+                              onHorizontalDragUpdate: (details) {
+                                if (details.delta.dx > 20) {
+                                  setState(() => _sideMenuOpen = true);
+                                }
+                              },
+                            ),
+                          ),
                         Positioned(
-                          right: kMapOverlayEdgeInset,
-                          top: kMapOverlayEdgeInset,
-                          child: SizedBox(
-                            width: 44,
-                            height: 44,
-                            child: Material(
-                              color: Colors.transparent,
-                              child: InkWell(
-                                key: kCtE2EOpenCapitalProvinceDetailKey,
-                                onTap: _e2eOpenHumanCapitalTileDetail,
-                              ),
-                            ),
+                          left: kEdgeSwipeStripWidth,
+                          top: 0,
+                          child: GameMapEmpireLeftRail(
+                            game: widget.game,
+                            humanPlayerId: _humanPlayerId,
+                            onIconTappedWhileSelectionMode:
+                                _workTargetSelection != null
+                                ? _cancelWorkTargetSelection
+                                : null,
                           ),
                         ),
-                        if (_workTargetSelection != null &&
-                            _cachedValidTileKeys != null &&
-                            _cachedValidTileKeys!.isNotEmpty)
+                        Positioned(
+                          left: kMapOverlayEdgeInset,
+                          bottom: kMapOverlayEdgeInset,
+                          child: GameMapCornerControls(
+                            onCycleBaseLayerDisplayMode:
+                                _cycleBaseLayerDisplayMode,
+                            onCenterOnHomeCapital: _centerOnHumanCapital,
+                            onOpenMapDisplayOptions: () {
+                              showDialog<void>(
+                                context: context,
+                                builder: (context) {
+                                  return AlertDialog(
+                                    title: Text(l10n.map_displayOptions_title),
+                                    content: Consumer(
+                                      builder: (context, ref, child) {
+                                        return Column(
+                                          mainAxisSize: MainAxisSize.min,
+                                          children: [
+                                            SwitchListTile(
+                                              title: Text(
+                                                l10n.map_displayOptions_showProvinceOverlay,
+                                              ),
+                                              value: _mapViewState
+                                                  .showProvinceOverlay,
+                                              onChanged: (value) {
+                                                _setMapViewState(
+                                                  _mapViewState.copyWith(
+                                                    showProvinceOverlay: value,
+                                                  ),
+                                                );
+                                              },
+                                            ),
+                                            SwitchListTile(
+                                              title: Text(
+                                                l10n.map_displayOptions_showProvinceOwnership,
+                                              ),
+                                              value: _mapViewState
+                                                  .showProvinceOwnershipTint,
+                                              onChanged: (value) {
+                                                _setMapViewState(
+                                                  _mapViewState.copyWith(
+                                                    showProvinceOwnershipTint:
+                                                        value,
+                                                  ),
+                                                );
+                                              },
+                                            ),
+                                            SwitchListTile(
+                                              title: Text(
+                                                l10n.map_displayOptions_showProvinceNames,
+                                              ),
+                                              value: _mapViewState
+                                                  .showProvinceNamesLayer,
+                                              onChanged: (value) {
+                                                _setMapViewState(
+                                                  _mapViewState.copyWith(
+                                                    showProvinceNamesLayer:
+                                                        value,
+                                                  ),
+                                                );
+                                              },
+                                            ),
+                                          ],
+                                        );
+                                      },
+                                    ),
+                                    actions: [
+                                      TextButton(
+                                        onPressed: () =>
+                                            Navigator.of(context).maybePop(),
+                                        child: Text(l10n.common_close),
+                                      ),
+                                    ],
+                                  );
+                                },
+                              );
+                            },
+                          ),
+                        ),
+                        if (kCtE2EEnabled) ...[
                           Positioned(
                             right: kMapOverlayEdgeInset,
-                            top: kMapOverlayEdgeInset + 48,
+                            top: kMapOverlayEdgeInset,
                             child: SizedBox(
                               width: 44,
                               height: 44,
                               child: Material(
                                 color: Colors.transparent,
                                 child: InkWell(
-                                  key: kCtE2ESelectFirstValidWorkTileKey,
-                                  onTap: _e2eSelectFirstValidWorkTargetTile,
+                                  key: kCtE2EOpenCapitalProvinceDetailKey,
+                                  onTap: _e2eOpenHumanCapitalTileDetail,
                                 ),
                               ),
                             ),
                           ),
-                        if (projectedRegion.civilianTileMarkers.isNotEmpty)
-                          Positioned(
-                            right: kMapOverlayEdgeInset,
-                            top: kMapOverlayEdgeInset + 96,
-                            child: SizedBox(
-                              width: 44,
-                              height: 44,
-                              child: Material(
-                                color: Colors.transparent,
-                                child: InkWell(
-                                  key: kCtE2EOpenFirstCivilianMarkerPanelKey,
-                                  onTap: _e2eOpenFirstCivilianMarkerPanel,
+                          if (_workTargetSelection != null &&
+                              _cachedValidTileKeys != null &&
+                              _cachedValidTileKeys!.isNotEmpty)
+                            Positioned(
+                              right: kMapOverlayEdgeInset,
+                              top: kMapOverlayEdgeInset + 48,
+                              child: SizedBox(
+                                width: 44,
+                                height: 44,
+                                child: Material(
+                                  color: Colors.transparent,
+                                  child: InkWell(
+                                    key: kCtE2ESelectFirstValidWorkTileKey,
+                                    onTap: _e2eSelectFirstValidWorkTargetTile,
+                                  ),
                                 ),
                               ),
                             ),
-                          ),
-                        if (projectedRegion.fleetTileMarkers.isNotEmpty)
-                          Positioned(
-                            right: kMapOverlayEdgeInset,
-                            top: kMapOverlayEdgeInset + 144,
-                            child: SizedBox(
-                              width: 44,
-                              height: 44,
-                              child: Material(
-                                color: Colors.transparent,
-                                child: InkWell(
-                                  key: kCtE2EOpenFirstFleetMarkerPanelKey,
-                                  onTap: _e2eOpenFirstFleetMarkerPanel,
+                          if (projectedRegion.civilianTileMarkers.isNotEmpty)
+                            Positioned(
+                              right: kMapOverlayEdgeInset,
+                              top: kMapOverlayEdgeInset + 96,
+                              child: SizedBox(
+                                width: 44,
+                                height: 44,
+                                child: Material(
+                                  color: Colors.transparent,
+                                  child: InkWell(
+                                    key: kCtE2EOpenFirstCivilianMarkerPanelKey,
+                                    onTap: _e2eOpenFirstCivilianMarkerPanel,
+                                  ),
                                 ),
                               ),
                             ),
-                          ),
-                      ],
-                      if (_sideMenuOpen) ...[
-                        Positioned.fill(
-                          child: GestureDetector(
-                            behavior: HitTestBehavior.opaque,
-                            onTap: () => setState(() => _sideMenuOpen = false),
-                            child: Container(color: Colors.black54),
-                          ),
-                        ),
-                        GameSideMenu(
-                          sideMenuOpen: _sideMenuOpen,
-                          onClose: () => setState(() => _sideMenuOpen = false),
-                        ),
-                      ],
-                      Consumer(
-                        builder: (context, ref, _) {
-                          final panelOpen = ref
-                              .watch(mapProvincePanelProvider)
-                              .overlayOpen;
-                          final rightInset = !isNarrow
-                              ? gameMapWideOverlayRightInset(
-                                  provincePanelOpen: panelOpen,
-                                )
-                              : kGameMapWideStackRightGutter;
-                          return Positioned(
-                            right: rightInset,
-                            bottom: 8,
-                            child: GameRegionMinimap(
-                              region: projectedRegion,
-                              viewportSnapshot: _regionViewportSnapshot,
-                              bus: ref.read(appEventBusProvider),
-                              cellSizePx: _currentRegion.cellSize.toDouble(),
+                          if (projectedRegion.fleetTileMarkers.isNotEmpty)
+                            Positioned(
+                              right: kMapOverlayEdgeInset,
+                              top: kMapOverlayEdgeInset + 144,
+                              child: SizedBox(
+                                width: 44,
+                                height: 44,
+                                child: Material(
+                                  color: Colors.transparent,
+                                  child: InkWell(
+                                    key: kCtE2EOpenFirstFleetMarkerPanelKey,
+                                    onTap: _e2eOpenFirstFleetMarkerPanel,
+                                  ),
+                                ),
+                              ),
                             ),
-                          );
-                        },
-                      ),
-                      if (!isNarrow)
+                        ],
+                        if (_sideMenuOpen) ...[
+                          Positioned.fill(
+                            child: GestureDetector(
+                              behavior: HitTestBehavior.opaque,
+                              onTap: () =>
+                                  setState(() => _sideMenuOpen = false),
+                              child: Container(color: Colors.black54),
+                            ),
+                          ),
+                          GameSideMenu(
+                            sideMenuOpen: _sideMenuOpen,
+                            onClose: () =>
+                                setState(() => _sideMenuOpen = false),
+                          ),
+                        ],
                         Consumer(
                           builder: (context, ref, _) {
                             final panelOpen = ref
                                 .watch(mapProvincePanelProvider)
                                 .overlayOpen;
-                            final rightInset = gameMapWideOverlayRightInset(
-                              provincePanelOpen: panelOpen,
-                            );
-                            if (!_mapViewState.showPlayerTurnEventsFeed) {
-                              return const SizedBox.shrink();
-                            }
+                            final rightInset = !isNarrow
+                                ? gameMapWideOverlayRightInset(
+                                    provincePanelOpen: panelOpen,
+                                  )
+                                : kGameMapWideStackRightGutter;
                             return Positioned(
                               right: rightInset,
-                              top: 56,
-                              child: PlayerTurnEventFeedCard(
-                                entries: feedEntries,
-                                emptyLabel: 'No player events last turn.',
+                              bottom: 8,
+                              child: GameRegionMinimap(
+                                region: projectedRegion,
+                                viewportSnapshot: _regionViewportSnapshot,
+                                bus: ref.read(appEventBusProvider),
+                                cellSizePx: _currentRegion.cellSize.toDouble(),
                               ),
                             );
                           },
                         ),
-                      if (isNarrow && _mapViewState.showPlayerTurnEventsFeed)
-                        Positioned(
-                          right: kMapOverlayEdgeInset,
-                          top: 56,
-                          child: PlayerTurnEventFeedCard(
-                            entries: feedEntries,
-                            emptyLabel: 'No player events last turn.',
+                        if (!isNarrow)
+                          Consumer(
+                            builder: (context, ref, _) {
+                              final panelOpen = ref
+                                  .watch(mapProvincePanelProvider)
+                                  .overlayOpen;
+                              final rightInset = gameMapWideOverlayRightInset(
+                                provincePanelOpen: panelOpen,
+                              );
+                              if (!_mapViewState.showPlayerTurnEventsFeed) {
+                                return const SizedBox.shrink();
+                              }
+                              return Positioned(
+                                right: rightInset,
+                                top: 56,
+                                child: PlayerTurnEventFeedCard(
+                                  entries: feedEntries,
+                                  emptyLabel: 'No player events last turn.',
+                                ),
+                              );
+                            },
                           ),
-                        ),
-                    ],
+                        if (isNarrow && _mapViewState.showPlayerTurnEventsFeed)
+                          Positioned(
+                            right: kMapOverlayEdgeInset,
+                            top: 56,
+                            child: PlayerTurnEventFeedCard(
+                              entries: feedEntries,
+                              emptyLabel: 'No player events last turn.',
+                            ),
+                          ),
+                      ],
+                    ),
                   ),
                 ),
               ),

--- a/app/lib/features/game/flame/game_map_controls.dart
+++ b/app/lib/features/game/flame/game_map_controls.dart
@@ -19,6 +19,7 @@ class GameMapControls extends StatefulWidget {
     required this.sideMenuOpen,
     required this.onToggleSideMenu,
     required this.onNextTurn,
+    required this.nextTurnEnabled,
     required this.regionIndex,
     required this.onRegionIndexChanged,
     required this.nextTurnText,
@@ -36,6 +37,7 @@ class GameMapControls extends StatefulWidget {
   final bool sideMenuOpen;
   final VoidCallback onToggleSideMenu;
   final Future<void> Function() onNextTurn;
+  final bool nextTurnEnabled;
   final int regionIndex;
   final void Function(int index) onRegionIndexChanged;
   final String nextTurnText;
@@ -109,7 +111,9 @@ class _GameMapControlsState extends State<GameMapControls> {
               Expanded(
                 child: CtNinePatchButton(
                   key: kGameMapNextTurnButtonKey,
-                  onPressed: () => widget.onNextTurn(),
+                  onPressed: widget.nextTurnEnabled
+                      ? () => widget.onNextTurn()
+                      : null,
                   child: Text(widget.nextTurnText),
                 ),
               ),

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -1,7 +1,6 @@
 export 'game_screen_shared.dart';
+export 'turn_resolution_flow.dart';
 
-import 'package:colonizethis_ai/colonizethis_ai.dart';
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flame/game.dart' hide Game;
@@ -24,6 +23,8 @@ import '../dialogue/intervention_dialogue_overlay.dart';
 import '../dialogue/overture_dialogue_overlay.dart';
 import 'game_canvas.dart';
 import 'game_map_area.dart';
+import 'turn_resolution_flow.dart';
+import 'turn_resolution_result_applier.dart';
 import 'victory_overlay.dart';
 
 /// Shows the in-game pause menu (Debug log, Resume). SPEC/program/debug-log-viewer.md.
@@ -69,46 +70,6 @@ Future<bool> _showExitToMainMenuConfirmDialog(BuildContext context) async {
     ),
   );
   return shouldExit ?? false;
-}
-
-void _applyTurnResolutionResult(WidgetRef ref, TurnResolutionResult result) {
-  final gameN = ref.read(currentGameProvider.notifier);
-  final ordersN = ref.read(currentOrdersProvider.notifier);
-  final dipN = ref.read(pendingDiplomacyProvider.notifier);
-  switch (result) {
-    case TurnResolutionComplete():
-      gameN.setGame(result.game);
-      ordersN.clear();
-      dipN.clear();
-    case TurnResolutionPendingOvertures():
-      gameN.setGame(result.game);
-      dipN.setOvertures(result.pendingOvertures);
-    case TurnResolutionPendingIntervention():
-      gameN.setGame(result.game);
-      dipN.setIntervention(result.pendingInterventions);
-    case TurnResolutionPendingCallToArms():
-      gameN.setGame(result.game);
-      dipN.setCallToArms(result.pendingCallToArms);
-  }
-}
-
-TurnResolutionResult resolveNextTurnForGameScreen({
-  required Game game,
-  required Orders orders,
-  required MapTopology topologyForAi,
-  Map<String, TileMapResult>? tileMapByRegion,
-  required TurnResolutionResult Function({
-    required Orders orders,
-    Orders? aiOrders,
-  })
-  runTurnResolution,
-}) {
-  final aiOrders = generateOrdersForGameFullAI(
-    game,
-    topologyForAi,
-    tileMapByRegion: tileMapByRegion,
-  ).orders;
-  return runTurnResolution(orders: orders, aiOrders: aiOrders);
 }
 
 /// Hosts the Flame game canvas or map. When map data exists, shows map + province/sea zone overlay.
@@ -167,7 +128,7 @@ class GameScreen extends ConsumerWidget {
                             aiOrders: aiOrders,
                           ),
                 );
-                _applyTurnResolutionResult(ref, result);
+                applyTurnResolutionResult(ref, result);
               },
               child: Text(
                 appL10n(context).game_nextTurnButton(
@@ -218,7 +179,7 @@ class GameScreen extends ConsumerWidget {
                 decisions,
                 orders,
               );
-              _applyTurnResolutionResult(ref, result);
+              applyTurnResolutionResult(ref, result);
             },
             child: content,
           );
@@ -235,7 +196,7 @@ class GameScreen extends ConsumerWidget {
                 decisions,
                 orders,
               );
-              _applyTurnResolutionResult(ref, result);
+              applyTurnResolutionResult(ref, result);
             },
             child: content,
           );
@@ -251,7 +212,7 @@ class GameScreen extends ConsumerWidget {
                 decisions,
                 orders,
               );
-              _applyTurnResolutionResult(ref, result);
+              applyTurnResolutionResult(ref, result);
             },
             child: content,
           );

--- a/app/lib/features/game/flame/turn_resolution_flow.dart
+++ b/app/lib/features/game/flame/turn_resolution_flow.dart
@@ -1,0 +1,23 @@
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+TurnResolutionResult resolveNextTurnForGameScreen({
+  required Game game,
+  required Orders orders,
+  required MapTopology topologyForAi,
+  Map<String, TileMapResult>? tileMapByRegion,
+  required TurnResolutionResult Function({
+    required Orders orders,
+    Orders? aiOrders,
+  })
+  runTurnResolution,
+}) {
+  final aiOrders = generateOrdersForGameFullAI(
+    game,
+    topologyForAi,
+    tileMapByRegion: tileMapByRegion,
+  ).orders;
+  return runTurnResolution(orders: orders, aiOrders: aiOrders);
+}

--- a/app/lib/features/game/flame/turn_resolution_processing_dialog.dart
+++ b/app/lib/features/game/flame/turn_resolution_processing_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:colonizethis_app/l10n/l10n.dart';
 import '../../../../widgets/ct_dialog_shell.dart';
 
 class TurnResolutionProcessingDialog extends StatelessWidget {
@@ -16,7 +17,7 @@ class TurnResolutionProcessingDialog extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'Processing Turn',
+              appL10n(context).game_turnResolutionProcessingTitle,
               style: Theme.of(context).textTheme.titleMedium,
             ),
             const SizedBox(height: 12),

--- a/app/lib/features/game/flame/turn_resolution_processing_dialog.dart
+++ b/app/lib/features/game/flame/turn_resolution_processing_dialog.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import '../../../../widgets/ct_dialog_shell.dart';
+
+class TurnResolutionProcessingDialog extends StatelessWidget {
+  const TurnResolutionProcessingDialog({required this.phaseText, super.key});
+
+  final String phaseText;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false,
+      child: CtDialogShell(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Processing Turn',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+                const SizedBox(width: 10),
+                Expanded(child: Text(phaseText)),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/game/flame/turn_resolution_result_applier.dart
+++ b/app/lib/features/game/flame/turn_resolution_result_applier.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+
+import '../../../../providers/games_provider.dart';
+
+void applyTurnResolutionResult(WidgetRef ref, TurnResolutionResult result) {
+  final gameN = ref.read(currentGameProvider.notifier);
+  final ordersN = ref.read(currentOrdersProvider.notifier);
+  final dipN = ref.read(pendingDiplomacyProvider.notifier);
+  switch (result) {
+    case TurnResolutionComplete():
+      gameN.setGame(result.game);
+      ordersN.clear();
+      dipN.clear();
+    case TurnResolutionPendingOvertures():
+      gameN.setGame(result.game);
+      dipN.setOvertures(result.pendingOvertures);
+    case TurnResolutionPendingIntervention():
+      gameN.setGame(result.game);
+      dipN.setIntervention(result.pendingInterventions);
+    case TurnResolutionPendingCallToArms():
+      gameN.setGame(result.game);
+      dipN.setCallToArms(result.pendingCallToArms);
+  }
+}

--- a/app/lib/l10n/app_localizations_contract.dart
+++ b/app/lib/l10n/app_localizations_contract.dart
@@ -84,6 +84,12 @@ abstract class AppLocalizations {
   /// Body text of the end-turn confirmation dialog.
   String game_nextTurnConfirm_body(int turn);
 
+  /// Title of the modal shown while next-turn resolution runs.
+  String get game_turnResolutionProcessingTitle;
+
+  /// Snackbar text shown when turn resolution fails.
+  String get game_turnResolutionFailedMessage;
+
   /// Generic 'No' button label.
   String get common_no;
 

--- a/app/lib/l10n/app_localizations_en_part1.dart
+++ b/app/lib/l10n/app_localizations_en_part1.dart
@@ -77,6 +77,12 @@ mixin _AppLocalizationsEnStrings1 on AppLocalizations {
   }
 
   @override
+  String get game_turnResolutionProcessingTitle => 'Processing Turn';
+
+  @override
+  String get game_turnResolutionFailedMessage => 'Turn resolution failed.';
+
+  @override
   String get common_no => 'No';
 
   @override

--- a/app/lib/l10n/arb/app_en.arb
+++ b/app/lib/l10n/arb/app_en.arb
@@ -104,6 +104,14 @@
       }
     }
   },
+  "game_turnResolutionFailedMessage": "Turn resolution failed.",
+  "@game_turnResolutionFailedMessage": {
+    "description": "Snackbar shown when turn resolution throws an error."
+  },
+  "game_turnResolutionProcessingTitle": "Processing Turn",
+  "@game_turnResolutionProcessingTitle": {
+    "description": "Title shown in the modal dialog while resolving the turn."
+  },
   "common_no": "No",
   "@common_no": {
     "description": "Generic 'No' button label."

--- a/app/test/game_map_controls_test.dart
+++ b/app/test/game_map_controls_test.dart
@@ -1,3 +1,4 @@
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:colonizethis_app/features/game/flame/game_map_controls.dart';
 import 'package:colonizethis_app/features/game/flame/game_screen_shared.dart'
     show kGameMapNextTurnButtonKey;
@@ -6,6 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  suppressLogsForTests();
+
   Widget _host({
     required bool nextTurnEnabled,
     required Future<void> Function() onNextTurn,

--- a/app/test/game_map_controls_test.dart
+++ b/app/test/game_map_controls_test.dart
@@ -1,0 +1,60 @@
+import 'package:colonizethis_app/features/game/flame/game_map_controls.dart';
+import 'package:colonizethis_app/features/game/flame/game_screen_shared.dart'
+    show kGameMapNextTurnButtonKey;
+import 'package:colonizethis_app/l10n/l10n.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Widget _host({
+    required bool nextTurnEnabled,
+    required Future<void> Function() onNextTurn,
+  }) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizationsBinding.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('en'),
+      home: Scaffold(
+        body: GameMapControls(
+          sideMenuOpen: false,
+          onToggleSideMenu: () {},
+          onNextTurn: onNextTurn,
+          nextTurnEnabled: nextTurnEnabled,
+          regionIndex: 0,
+          onRegionIndexChanged: (_) {},
+          nextTurnText: 'Next turn',
+          cargoUsed: 0,
+          cargoCapacity: 0,
+          treasury: 0,
+          treasuryDelta: 0,
+          playerTurnEventsFeedCount: 0,
+          showPlayerTurnEventsFeed: false,
+          onTogglePlayerTurnEventsFeed: () {},
+        ),
+      ),
+    );
+  }
+
+  testWidgets('next turn button is disabled when nextTurnEnabled is false', (
+    tester,
+  ) async {
+    var pressed = false;
+    await tester.pumpWidget(
+      _host(
+        nextTurnEnabled: false,
+        onNextTurn: () async {
+          pressed = true;
+        },
+      ),
+    );
+
+    final nextTurnButton = tester.widget<Widget>(
+      find.byKey(kGameMapNextTurnButtonKey),
+    );
+    expect(nextTurnButton, isNotNull);
+
+    await tester.tap(find.byKey(kGameMapNextTurnButtonKey));
+    await tester.pump();
+    expect(pressed, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a `Processing Turn` non-dismissible modal around `GameMapArea` next-turn execution, with explicit active-state lifecycle cleanup on success/failure.
- Disables Next Turn during active resolution and blocks map interactions via `IgnorePointer`, while keeping the top-bar hamburger menu available.
- Extracts shared turn-resolution helpers (`resolveNextTurnForGameScreen`, `applyTurnResolutionResult`) so map flow preserves pending-human-input result branches.

## Implemented in this PR
- UI gating slice for issue #2160 requirements: modal visibility/closure, reentry guard, next-turn disablement, map interaction blocking, and error feedback.
- SPEC update in `SPEC/ui/next-turn-confirmation.md` documenting this slice's behavior and AC coverage.
- New widget test for next-turn disabled behavior.

## Deferred work
- Background isolate execution for turn resolution is not included in this slice.
- Live per-phase progress updates in the modal are not included in this slice.
- AppEventHandler-level event allowlist gating during active resolution is not included in this slice.

## AC/spec coverage in this slice
- Covered now: non-dismissible processing modal lifecycle, no reentry while active, disabled Next Turn during active state, map interaction block with hamburger remaining available.
- Deferred to follow-up slices: off-UI-thread execution and per-phase progress text streaming.

## Test plan
- [x] `cd app && flutter test test/game_map_controls_test.dart test/game_screen_next_turn_ai_test.dart`

Refs #2160

Made with [Cursor](https://cursor.com)