### PR TITLE
Add isolate turn-resolution runner with phase progress (slice 2)

### DIFF
--- a/SPEC/ui/next-turn-confirmation.md
+++ b/SPEC/ui/next-turn-confirmation.md
@@ -41,6 +41,14 @@ When the player clicks the "Next turn" button in the top bar, a confirmation dia
   - Hamburger menu remains available from the top bar.
   - The modal cannot be dismissed by outside tap or back/escape.
 
+### Turn-resolution active state (slice 2)
+
+- Scope: this slice moves heavy turn-resolution execution to a worker isolate and streams live phase labels into the processing modal.
+- AI order generation remains on the main isolate before worker spawn; the worker receives merged orders payload.
+- The worker emits per-phase start/end progress events through a typed callback (`TurnPhaseProgressMarker`) and the UI updates phase text on `start`.
+- Terminal success and terminal failure both close the modal; success applies the resolved result and failure shows the existing error snackbar.
+- Existing pending-human-input outcomes (overture/intervention/call-to-arms) remain valid terminal outputs for post-resolution UI flow.
+
 ---
 
 ## Acceptance criteria

--- a/app/lib/core/services/game_service.dart
+++ b/app/lib/core/services/game_service.dart
@@ -692,4 +692,9 @@ class GameService {
       );
     }
   }
+
+  /// Emits app-level events and persistence side effects for externally resolved turns.
+  void handleExternallyResolvedTurnResult(TurnResolutionResult result) {
+    _emitTurnResolutionEvents(result);
+  }
 }

--- a/app/lib/core/services/turn_resolution_runner.dart
+++ b/app/lib/core/services/turn_resolution_runner.dart
@@ -1,0 +1,313 @@
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+class TurnResolutionProgressEvent {
+  const TurnResolutionProgressEvent({
+    required this.sessionId,
+    required this.phase,
+    required this.marker,
+  });
+
+  final String sessionId;
+  final String phase;
+  final String marker;
+}
+
+sealed class TurnResolutionTerminalEvent {
+  const TurnResolutionTerminalEvent();
+}
+
+class TurnResolutionTerminalComplete extends TurnResolutionTerminalEvent {
+  const TurnResolutionTerminalComplete(this.result);
+  final TurnResolutionResult result;
+}
+
+class TurnResolutionTerminalError extends TurnResolutionTerminalEvent {
+  const TurnResolutionTerminalError({
+    required this.errorMessage,
+    required this.stackTrace,
+  });
+
+  final String errorMessage;
+  final String stackTrace;
+}
+
+class TurnResolutionRunnerSession {
+  TurnResolutionRunnerSession({
+    required this.sessionId,
+    required this.progress,
+    required this.done,
+    required this.dispose,
+  });
+
+  final String sessionId;
+  final Stream<TurnResolutionProgressEvent> progress;
+  final Future<TurnResolutionTerminalEvent> done;
+  final Future<void> Function() dispose;
+}
+
+class TurnResolutionRunner {
+  TurnResolutionRunner();
+
+  bool _active = false;
+
+  bool get isActive => _active;
+
+  TurnResolutionRunnerSession startResolution({
+    required Game game,
+    required Orders orders,
+    required MapTopology topology,
+    required Map<String, TileMapResult> tileMapByRegion,
+  }) {
+    if (_active) {
+      throw StateError('Turn resolution already active');
+    }
+    _active = true;
+    final sessionId = 'turn-${DateTime.now().microsecondsSinceEpoch}';
+    final progressController = StreamController<TurnResolutionProgressEvent>();
+    final doneCompleter = Completer<TurnResolutionTerminalEvent>();
+    final receivePort = ReceivePort();
+    Isolate? isolate;
+    StreamSubscription<dynamic>? sub;
+
+    final aiOrders = generateOrdersForGameFullAI(
+      game,
+      topology,
+      tileMapByRegion: tileMapByRegion,
+    ).orders;
+    final mergedOrders = mergeOrderLists(
+      humanOrders: orders,
+      aiOrders: aiOrders,
+    );
+
+    Future<void> cleanup() async {
+      await sub?.cancel();
+      receivePort.close();
+      isolate?.kill(priority: Isolate.immediate);
+      if (!progressController.isClosed) {
+        await progressController.close();
+      }
+      _active = false;
+    }
+
+    sub = receivePort.listen((dynamic message) async {
+      if (message is! Map<Object?, Object?>) {
+        return;
+      }
+      final kind = message['kind'];
+      if (kind == 'phase') {
+        final phaseName = message['phase'] as String;
+        final markerName = message['marker'] as String;
+        progressController.add(
+          TurnResolutionProgressEvent(
+            sessionId: sessionId,
+            phase: phaseName,
+            marker: markerName,
+          ),
+        );
+        return;
+      }
+      if (kind == 'success') {
+        doneCompleter.complete(
+          TurnResolutionTerminalComplete(
+            _decodeTurnResolutionResult(
+              Map<String, dynamic>.from(message['result'] as Map),
+            ),
+          ),
+        );
+        await cleanup();
+        return;
+      }
+      if (kind == 'error') {
+        doneCompleter.complete(
+          TurnResolutionTerminalError(
+            errorMessage: (message['error'] as String?) ?? 'Unknown error',
+            stackTrace: (message['stackTrace'] as String?) ?? '',
+          ),
+        );
+        await cleanup();
+      }
+    });
+
+    Isolate.spawn<Map<String, Object?>>(_turnResolutionIsolateMain, {
+          'sendPort': receivePort.sendPort,
+          'game': game.toJson(),
+          'orders': mergedOrders.toJson(),
+          'topology': topology.toJson(),
+          'tileMapByRegion': tileMapByRegion.map(
+            (k, v) => MapEntry(k, v.toJson()),
+          ),
+        })
+        .then((spawned) {
+          isolate = spawned;
+        })
+        .catchError((Object e, StackTrace st) async {
+          doneCompleter.complete(
+            TurnResolutionTerminalError(
+              errorMessage: e.toString(),
+              stackTrace: st.toString(),
+            ),
+          );
+          await cleanup();
+        });
+
+    return TurnResolutionRunnerSession(
+      sessionId: sessionId,
+      progress: progressController.stream,
+      done: doneCompleter.future,
+      dispose: cleanup,
+    );
+  }
+}
+
+void _turnResolutionIsolateMain(Map<String, Object?> args) {
+  final sendPort = args['sendPort']! as SendPort;
+  try {
+    final game = Game.fromJson(Map<String, dynamic>.from(args['game']! as Map));
+    final orders = Orders.fromJson(
+      Map<String, dynamic>.from(args['orders']! as Map),
+    );
+    final topology = MapTopology.fromJson(
+      Map<String, dynamic>.from(args['topology']! as Map),
+    );
+    final rawTileMap = Map<String, dynamic>.from(
+      args['tileMapByRegion']! as Map,
+    );
+    final tileMapByRegion = rawTileMap.map<String, TileMapResult>(
+      (key, value) => MapEntry(
+        key,
+        TileMapResult.fromJson(Map<String, dynamic>.from(value as Map)),
+      ),
+    );
+    final result = resolveTurnForGame(
+      game: game,
+      topology: topology,
+      orders: orders,
+      tileMapByRegion: tileMapByRegion,
+      onPhaseProgress: (phase, marker) {
+        sendPort.send({
+          'kind': 'phase',
+          'phase': phase.name,
+          'marker': marker.name,
+        });
+      },
+    );
+    sendPort.send({
+      'kind': 'success',
+      'result': _encodeTurnResolutionResult(result),
+    });
+  } catch (e, st) {
+    sendPort.send({
+      'kind': 'error',
+      'error': e.toString(),
+      'stackTrace': st.toString(),
+    });
+  }
+}
+
+Map<String, Object?> _encodeTurnResolutionResult(TurnResolutionResult result) {
+  switch (result) {
+    case TurnResolutionComplete():
+      return {'type': 'complete', 'game': result.game.toJson()};
+    case TurnResolutionPendingOvertures():
+      return {
+        'type': 'pendingOvertures',
+        'game': result.game.toJson(),
+        'pendingOvertures': result.pendingOvertures
+            .map(
+              (offer) => {
+                'offererGpId': offer.offererGpId,
+                'targetFactionId': offer.targetFactionId,
+                'stage': offer.stage.name,
+              },
+            )
+            .toList(growable: false),
+      };
+    case TurnResolutionPendingIntervention():
+      return {
+        'type': 'pendingIntervention',
+        'game': result.game.toJson(),
+        'pendingInterventions': result.pendingInterventions
+            .map(
+              (prompt) => {
+                'aggressorGpId': prompt.aggressorGpId,
+                'defenderMinorOrTribeId': prompt.defenderMinorOrTribeId,
+                'interveningGpId': prompt.interveningGpId,
+              },
+            )
+            .toList(growable: false),
+      };
+    case TurnResolutionPendingCallToArms():
+      return {
+        'type': 'pendingCallToArms',
+        'game': result.game.toJson(),
+        'pendingCallToArms': result.pendingCallToArms
+            .map(
+              (pending) => {
+                'allyGpId': pending.allyGpId,
+                'defenderGpId': pending.defenderGpId,
+                'aggressorGpId': pending.aggressorGpId,
+              },
+            )
+            .toList(growable: false),
+      };
+  }
+}
+
+TurnResolutionResult _decodeTurnResolutionResult(Map<String, dynamic> json) {
+  final game = Game.fromJson(Map<String, dynamic>.from(json['game'] as Map));
+  final type = json['type'] as String;
+  switch (type) {
+    case 'complete':
+      return TurnResolutionComplete(game);
+    case 'pendingOvertures':
+      final list = (json['pendingOvertures'] as List<dynamic>)
+          .map((entry) => Map<String, dynamic>.from(entry as Map))
+          .map(
+            (entry) => OvertureOffer(
+              offererGpId: entry['offererGpId'] as String,
+              targetFactionId: entry['targetFactionId'] as String,
+              stage: OvertureStage.values.byName(entry['stage'] as String),
+            ),
+          )
+          .toList(growable: false);
+      return TurnResolutionPendingOvertures(game: game, pendingOvertures: list);
+    case 'pendingIntervention':
+      final list = (json['pendingInterventions'] as List<dynamic>)
+          .map((entry) => Map<String, dynamic>.from(entry as Map))
+          .map(
+            (entry) => InterventionPrompt(
+              aggressorGpId: entry['aggressorGpId'] as String,
+              defenderMinorOrTribeId: entry['defenderMinorOrTribeId'] as String,
+              interveningGpId: entry['interveningGpId'] as String,
+            ),
+          )
+          .toList(growable: false);
+      return TurnResolutionPendingIntervention(
+        game: game,
+        pendingInterventions: list,
+      );
+    case 'pendingCallToArms':
+      final list = (json['pendingCallToArms'] as List<dynamic>)
+          .map((entry) => Map<String, dynamic>.from(entry as Map))
+          .map(
+            (entry) => CallToArmsPending(
+              allyGpId: entry['allyGpId'] as String,
+              defenderGpId: entry['defenderGpId'] as String,
+              aggressorGpId: entry['aggressorGpId'] as String,
+            ),
+          )
+          .toList(growable: false);
+      return TurnResolutionPendingCallToArms(
+        game: game,
+        pendingCallToArms: list,
+      );
+    default:
+      throw StateError('Unknown turn resolution result type: $type');
+  }
+}

--- a/app/lib/core/services/turn_resolution_runner.dart
+++ b/app/lib/core/services/turn_resolution_runner.dart
@@ -116,7 +116,9 @@ class TurnResolutionRunner {
         doneCompleter.complete(
           TurnResolutionTerminalComplete(
             _decodeTurnResolutionResult(
-              Map<String, dynamic>.from(message['result'] as Map),
+              Map<String, dynamic>.from(
+                message['result'] as Map<Object?, Object?>,
+              ),
             ),
           ),
         );
@@ -168,20 +170,24 @@ class TurnResolutionRunner {
 void _turnResolutionIsolateMain(Map<String, Object?> args) {
   final sendPort = args['sendPort']! as SendPort;
   try {
-    final game = Game.fromJson(Map<String, dynamic>.from(args['game']! as Map));
+    final game = Game.fromJson(
+      Map<String, dynamic>.from(args['game']! as Map<Object?, Object?>),
+    );
     final orders = Orders.fromJson(
-      Map<String, dynamic>.from(args['orders']! as Map),
+      Map<String, dynamic>.from(args['orders']! as Map<Object?, Object?>),
     );
     final topology = MapTopology.fromJson(
-      Map<String, dynamic>.from(args['topology']! as Map),
+      Map<String, dynamic>.from(args['topology']! as Map<Object?, Object?>),
     );
     final rawTileMap = Map<String, dynamic>.from(
-      args['tileMapByRegion']! as Map,
+      args['tileMapByRegion']! as Map<Object?, Object?>,
     );
     final tileMapByRegion = rawTileMap.map<String, TileMapResult>(
       (key, value) => MapEntry(
         key,
-        TileMapResult.fromJson(Map<String, dynamic>.from(value as Map)),
+        TileMapResult.fromJson(
+          Map<String, dynamic>.from(value as Map<Object?, Object?>),
+        ),
       ),
     );
     final result = resolveTurnForGame(
@@ -260,14 +266,19 @@ Map<String, Object?> _encodeTurnResolutionResult(TurnResolutionResult result) {
 }
 
 TurnResolutionResult _decodeTurnResolutionResult(Map<String, dynamic> json) {
-  final game = Game.fromJson(Map<String, dynamic>.from(json['game'] as Map));
+  final game = Game.fromJson(
+    Map<String, dynamic>.from(json['game'] as Map<Object?, Object?>),
+  );
   final type = json['type'] as String;
   switch (type) {
     case 'complete':
       return TurnResolutionComplete(game);
     case 'pendingOvertures':
       final list = (json['pendingOvertures'] as List<dynamic>)
-          .map((entry) => Map<String, dynamic>.from(entry as Map))
+          .map(
+            (entry) =>
+                Map<String, dynamic>.from(entry as Map<Object?, Object?>),
+          )
           .map(
             (entry) => OvertureOffer(
               offererGpId: entry['offererGpId'] as String,
@@ -279,7 +290,10 @@ TurnResolutionResult _decodeTurnResolutionResult(Map<String, dynamic> json) {
       return TurnResolutionPendingOvertures(game: game, pendingOvertures: list);
     case 'pendingIntervention':
       final list = (json['pendingInterventions'] as List<dynamic>)
-          .map((entry) => Map<String, dynamic>.from(entry as Map))
+          .map(
+            (entry) =>
+                Map<String, dynamic>.from(entry as Map<Object?, Object?>),
+          )
           .map(
             (entry) => InterventionPrompt(
               aggressorGpId: entry['aggressorGpId'] as String,
@@ -294,7 +308,10 @@ TurnResolutionResult _decodeTurnResolutionResult(Map<String, dynamic> json) {
       );
     case 'pendingCallToArms':
       final list = (json['pendingCallToArms'] as List<dynamic>)
-          .map((entry) => Map<String, dynamic>.from(entry as Map))
+          .map(
+            (entry) =>
+                Map<String, dynamic>.from(entry as Map<Object?, Object?>),
+          )
           .map(
             (entry) => CallToArmsPending(
               allyGpId: entry['allyGpId'] as String,

--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -12,7 +12,6 @@ import 'package:colonizethis_map/colonizethis_map.dart'
 import 'package:colonizethis_app/l10n/l10n.dart';
 
 import '../../../config/ct_e2e.dart';
-import '../../../config/ct_debug_console.dart';
 import '../../../../widgets/ct_region_map.dart' show BaseLayerDisplayMode;
 
 import '../../../../providers/app_event_bus_provider.dart';
@@ -22,6 +21,8 @@ import '../../../../providers/games_provider.dart';
 import '../../../../providers/map_province_panel_provider.dart';
 import '../../../../providers/region_minimap_provider.dart';
 import '../../../../providers/treasury_summary_provider.dart';
+import '../../../../providers/turn_resolution_runner_provider.dart';
+import '../../../core/services/turn_resolution_runner.dart';
 import 'region_map_viewport_snapshot.dart';
 import '../../../../providers/home_fleet_cargo_provider.dart';
 
@@ -38,7 +39,6 @@ import 'debug_console_overlay_panel.dart';
 import 'game_map_area_state_logic.dart';
 import 'per_player_work_target_selection_cache.dart';
 import 'next_turn_confirmation_dialog.dart';
-import 'turn_resolution_flow.dart';
 import 'turn_resolution_processing_dialog.dart';
 import 'turn_resolution_result_applier.dart';
 import '../utils/map_location_resolver.dart';

--- a/app/lib/features/game/flame/game_map_area_part1.dart
+++ b/app/lib/features/game/flame/game_map_area_part1.dart
@@ -19,6 +19,7 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
   List<ct_models.GameToUIEvent> _resolvedPlayerTurnEvents = const [];
   bool _isTurnResolving = false;
   String _turnResolutionPhaseText = 'Resolving turn...';
+  StreamSubscription<TurnResolutionProgressEvent>? _turnResolutionProgressSub;
 
   /// Base layer display mode for map letters. SPEC/ui/empire-overview.md § Base layer display cycle.
   BaseLayerDisplayMode _baseLayerDisplayMode =
@@ -211,6 +212,8 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
 
   @override
   void dispose() {
+    _turnResolutionProgressSub?.cancel();
+    _turnResolutionProgressSub = null;
     for (final s in _busSubscriptions) {
       s.cancel();
     }
@@ -476,8 +479,13 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
       currentTurn: currentTurn,
     );
     if (ok != true) return;
+    if (!mounted) return;
 
     final service = ref.read(gameServiceProvider);
+    final runner = ref.read(turnResolutionRunnerProvider);
+    final failureMessage = appL10n(context).game_turnResolutionFailedMessage;
+    final messenger = ScaffoldMessenger.of(context);
+    final rootNavigator = Navigator.of(context, rootNavigator: true);
     final orders = ref.read(currentOrdersProvider);
     final mapData = service.getMapData(game.id);
     if (mapData == null) {
@@ -499,40 +507,67 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
     );
     await Future<void>.delayed(Duration.zero);
     try {
-      final result = resolveNextTurnForGameScreen(
+      final session = runner.startResolution(
         game: game,
         orders: orders,
-        topologyForAi: mapData.combinedTopology,
+        topology: mapData.combinedTopology,
         tileMapByRegion: mapData.tileMapByRegion,
-        runTurnResolution:
-            ({required ct_models.Orders orders, ct_models.Orders? aiOrders}) =>
-                service.runTurnResolution(
-                  game,
-                  orders: orders,
-                  aiOrders: aiOrders,
-                ),
       );
+      _turnResolutionProgressSub?.cancel();
+      _turnResolutionProgressSub = session.progress.listen((event) {
+        if (!mounted || event.marker != 'start') {
+          return;
+        }
+        setState(() {
+          _turnResolutionPhaseText = _phaseLabel(event.phase);
+        });
+      });
+      final terminal = await session.done;
       if (!mounted) {
         return;
       }
-      applyTurnResolutionResult(ref, result);
+      switch (terminal) {
+        case TurnResolutionTerminalComplete():
+          service.handleExternallyResolvedTurnResult(terminal.result);
+          applyTurnResolutionResult(ref, terminal.result);
+        case TurnResolutionTerminalError():
+          messenger.showSnackBar(SnackBar(content: Text(failureMessage)));
+          throw StateError(terminal.errorMessage);
+      }
     } catch (_) {
       if (mounted) {
-        final failureMessage = appL10n(context).game_turnResolutionFailedMessage;
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(failureMessage)));
+        messenger.showSnackBar(SnackBar(content: Text(failureMessage)));
       }
       rethrow;
     } finally {
-      if (!mounted) {
-        return;
+      if (mounted) {
+        setState(() {
+          _isTurnResolving = false;
+        });
+        rootNavigator.maybePop();
       }
-      setState(() {
-        _isTurnResolving = false;
-      });
-      Navigator.of(context, rootNavigator: true).maybePop();
+      _turnResolutionProgressSub?.cancel();
+      _turnResolutionProgressSub = null;
     }
+  }
+
+  String _phaseLabel(String phase) {
+    return switch (phase) {
+      'orders' => 'Validating orders...',
+      'extraction' => 'Resolving extraction...',
+      'richesToTreasury' => 'Moving riches to treasury...',
+      'consumption' => 'Resolving consumption...',
+      'production' => 'Resolving production...',
+      'research' => 'Resolving research...',
+      'diplomacy' => 'Resolving diplomacy...',
+      'movement' => 'Resolving movement...',
+      'minorRegimentUpgrade' => 'Upgrading minor regiments...',
+      'navalInterceptionCombat' => 'Resolving naval interceptions...',
+      'combat' => 'Resolving combat...',
+      'buildWork' => 'Resolving work orders...',
+      'endOfTurn' => 'Finalizing turn...',
+      _ => 'Resolving turn...',
+    };
   }
 
   void _e2eSelectFirstValidWorkTargetTile() {

--- a/app/lib/features/game/flame/game_map_area_part1.dart
+++ b/app/lib/features/game/flame/game_map_area_part1.dart
@@ -1,5 +1,4 @@
 part of 'game_map_area.dart';
-
 mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
   int _regionIndex = 0;
   RegionMapViewportSnapshot? _regionViewportSnapshot;
@@ -20,11 +19,9 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
   bool _isTurnResolving = false;
   String _turnResolutionPhaseText = 'Resolving turn...';
   StreamSubscription<TurnResolutionProgressEvent>? _turnResolutionProgressSub;
-
   /// Base layer display mode for map letters. SPEC/ui/empire-overview.md § Base layer display cycle.
   BaseLayerDisplayMode _baseLayerDisplayMode =
       BaseLayerDisplayMode.terrainAndResourcesImprovementsRoads;
-
   @override
   void initState() {
     super.initState();
@@ -95,7 +92,6 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
       }),
     ]);
   }
-
   void _onTurnResolutionCompleteEvent(
     ct_models.TurnResolutionCompleteEvent event,
   ) {
@@ -110,7 +106,6 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
       _pendingPlayerTurnEvents.clear();
     });
   }
-
   void _refreshWorkTargetSelectionCache(ct_models.Game game) {
     final view = buildPlayerView(
       game,
@@ -129,7 +124,6 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
       ),
     );
   }
-
   void _onAppCombatResultEvent(ct_models.AppCombatResultEvent event) {
     if (event.attackerId != _humanPlayerId &&
         event.defenderId != _humanPlayerId) {
@@ -137,7 +131,6 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
     }
     _pendingPlayerTurnEvents.add(event);
   }
-
   void _onAppNavalCombatResultEvent(ct_models.AppNavalCombatResultEvent event) {
     if (event.side1OwnerId != _humanPlayerId &&
         event.side2OwnerId != _humanPlayerId) {
@@ -145,7 +138,6 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
     }
     _pendingPlayerTurnEvents.add(event);
   }
-
   void _onAppProvinceCapturedEvent(ct_models.AppProvinceCapturedEvent event) {
     if (event.previousOwnerId != _humanPlayerId &&
         event.newOwnerId != _humanPlayerId) {
@@ -153,28 +145,24 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
     }
     _pendingPlayerTurnEvents.add(event);
   }
-
   void _onAppDiplomacyChangeEvent(ct_models.AppDiplomacyChangeEvent event) {
     if (event.actorId != _humanPlayerId && event.targetId != _humanPlayerId) {
       return;
     }
     _pendingPlayerTurnEvents.add(event);
   }
-
   void _onAppResearchCompleteEvent(ct_models.AppResearchCompleteEvent event) {
     if (event.playerId != _humanPlayerId) {
       return;
     }
     _pendingPlayerTurnEvents.add(event);
   }
-
   void _onAppOrderRejectedEvent(ct_models.AppOrderRejectedEvent event) {
     if (event.playerId != _humanPlayerId) {
       return;
     }
     _pendingPlayerTurnEvents.add(event);
   }
-
   void _onAppWorkOrderCompletedEvent(
     ct_models.AppWorkOrderCompletedEvent event,
   ) {
@@ -183,7 +171,6 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
     }
     _pendingPlayerTurnEvents.add(event);
   }
-
   void _onAppPlayerProvinceDiscoveredEvent(
     ct_models.AppPlayerProvinceDiscoveredEvent event,
   ) {
@@ -192,7 +179,6 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
     }
     _pendingPlayerTurnEvents.add(event);
   }
-
   void _onAppPlayerSeaZoneDiscoveredEvent(
     ct_models.AppPlayerSeaZoneDiscoveredEvent event,
   ) {
@@ -201,7 +187,6 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
     }
     _pendingPlayerTurnEvents.add(event);
   }
-
   void _onAppOvertureAdvancedEvent(ct_models.AppOvertureAdvancedEvent event) {
     if (event.offererGpId != _humanPlayerId &&
         event.targetFactionId != _humanPlayerId) {

--- a/app/lib/providers/turn_resolution_runner_provider.dart
+++ b/app/lib/providers/turn_resolution_runner_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/services/turn_resolution_runner.dart';
+
+final turnResolutionRunnerProvider = Provider<TurnResolutionRunner>(
+  (ref) => TurnResolutionRunner(),
+);

--- a/packages/colonizethis_logic/lib/src/turn/turn_phase_runner.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_phase_runner.dart
@@ -35,6 +35,7 @@ TurnResolutionResult runTurnResolutionPipeline({
   for (var i = 0; i < turnResolutionSequence.length; i++) {
     final phase = turnResolutionSequence[i];
     if (i < phaseIndex) continue;
+    config.onPhaseProgress?.call(phase, TurnPhaseProgressMarker.start);
     _log.i('phase ${phase.name} start');
     final handler = handlers[phase];
     if (handler == null) {
@@ -48,6 +49,7 @@ TurnResolutionResult runTurnResolutionPipeline({
         acc = pipeline;
     }
     _log.i('phase ${phase.name} end');
+    config.onPhaseProgress?.call(phase, TurnPhaseProgressMarker.end);
   }
 
   _log.i('turn $turn resolve end');

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -156,6 +156,8 @@ TurnResolutionResult resolveTurnForGame({
   List<OvertureDecision>? overtureDecisions,
   List<InterventionDecision>? interventionDecisions,
   List<CallToArmsDecision>? callToArmsDecisions,
+  void Function(TurnPhase phase, TurnPhaseProgressMarker marker)?
+  onPhaseProgress,
 }) {
   return resolveTurnForGameWithConfig(
     game: game,
@@ -175,6 +177,7 @@ TurnResolutionResult resolveTurnForGame({
       overtureDecisions: overtureDecisions,
       interventionDecisions: interventionDecisions,
       callToArmsDecisions: callToArmsDecisions,
+      onPhaseProgress: onPhaseProgress,
     ),
   );
 }

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver_config.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver_config.dart
@@ -14,6 +14,8 @@ typedef TurnPhaseHandler =
       int turn,
     );
 
+enum TurnPhaseProgressMarker { start, end }
+
 /// Bundles inputs for [resolveTurnForGameWithConfig] / full turn resolution.
 class TurnResolverConfig {
   const TurnResolverConfig({
@@ -33,6 +35,7 @@ class TurnResolverConfig {
     this.interventionDecisions,
     this.callToArmsDecisions,
     this.phaseHandlerOverrides,
+    this.onPhaseProgress,
   });
 
   final MapTopology topology;
@@ -58,4 +61,8 @@ class TurnResolverConfig {
   /// key replaces the default). Used for tests and narrow customization; the
   /// default sequence and semantics remain authoritative. Refs #1958.
   final Map<TurnPhase, TurnPhaseHandler>? phaseHandlerOverrides;
+
+  /// Optional callback invoked at each phase start/end during pipeline execution.
+  final void Function(TurnPhase phase, TurnPhaseProgressMarker marker)?
+  onPhaseProgress;
 }

--- a/packages/colonizethis_logic/test/turn_phase_runner_phase_overrides_test.dart
+++ b/packages/colonizethis_logic/test/turn_phase_runner_phase_overrides_test.dart
@@ -81,4 +81,38 @@ void main() {
       );
     },
   );
+
+  test('phase progress callback emits start and end markers', () {
+    final topology = MapTopology(
+      nodes: const [
+        TopologyNode(
+          id: 'P1',
+          regionId: 'oldWorld',
+          type: TopologyNodeType.province,
+        ),
+      ],
+      edges: const [],
+    );
+    final game = TestFixtures.minimalGame(
+      id: 'g1',
+      turnNumber: 0,
+      players: const [Player(id: 'p1', displayName: 'A', isHuman: true)],
+      oldWorld: RegionData(
+        provinces: [Province(id: 'oldWorld|P1', regionId: 'oldWorld')],
+      ),
+    );
+    final events = <(TurnPhase, TurnPhaseProgressMarker)>[];
+    resolveTurnForGameWithConfig(
+      game: game,
+      config: TurnResolverConfig(
+        topology: topology,
+        orders: const Orders(),
+        onPhaseProgress: (phase, marker) => events.add((phase, marker)),
+      ),
+    );
+
+    expect(events.isNotEmpty, isTrue);
+    expect(events.first.$2, TurnPhaseProgressMarker.start);
+    expect(events.last.$2, TurnPhaseProgressMarker.end);
+  });
 }


### PR DESCRIPTION
## Summary
- adds a `TurnResolutionRunner` service that precomputes AI orders on the main isolate, runs turn resolution in a worker isolate, and streams phase progress + terminal events back to UI
- wires `GameMapArea` next-turn flow to use runner sessions, live-update processing phase text, and preserve existing terminal result application/event emission behavior
- extends logic resolver config with phase progress callbacks and adds coverage for start/end phase marker emission; updates UI spec slice notes for this implementation step

## Implemented in this PR
- Background isolate turn-resolution execution path (`app/lib/core/services/turn_resolution_runner.dart`)
- Progress stream from logic phase callbacks (`onPhaseProgress`) to processing modal phase label updates
- Main-isolate terminal handling that still applies complete/pending turn outcomes and emits existing app bus side effects
- Logic test coverage for phase progress marker callback behavior

## Deferred work
- Full dialog phase-label localization keys (current labels remain hardcoded English placeholders)
- Additional app-level unit tests around isolate runner serialization/error edge cases beyond widget + logic coverage in this slice
- Any remaining issue-2160 hardening not explicitly part of this isolate/progress slice

## AC / Spec Coverage
- Covered now: off-UI-thread turn execution path, live phase text updates during active processing modal, preserved terminal close/error behavior, and pending-human-input compatibility
- Still follow-up as needed: residual hardening/testing polish items noted above

## Test plan
- [x] `dart test test/turn_phase_runner_phase_overrides_test.dart` (in `packages/colonizethis_logic`)
- [x] `dart analyze packages/colonizethis_logic/lib/src/turn/turn_resolver_config.dart packages/colonizethis_logic/lib/src/turn/turn_phase_runner.dart packages/colonizethis_logic/lib/src/turn/turn_resolver.dart packages/colonizethis_logic/test/turn_phase_runner_phase_overrides_test.dart`
- [x] `flutter test test/game_screen_next_turn_ai_test.dart` (in `app`)
- [x] `flutter analyze lib/core/services/turn_resolution_runner.dart lib/providers/turn_resolution_runner_provider.dart lib/features/game/flame/game_map_area.dart lib/features/game/flame/game_map_area_part1.dart` (in `app`)

Refs #2160

Made with [Cursor](https://cursor.com)