### PR TITLE
Refactor setup tile-key coordinate parsing for setup flows

### DIFF
--- a/packages/colonizethis_logic/lib/src/setup/gp_old_world_resource_redistribution.dart
+++ b/packages/colonizethis_logic/lib/src/setup/gp_old_world_resource_redistribution.dart
@@ -7,6 +7,7 @@ import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../world/tile_key_coordinates.dart';
 import 'setup_exceptions.dart';
 import 'town_capital_occupancy.dart';
 
@@ -246,11 +247,9 @@ String? _firstLexEligibleEmptyTileForGp({
 }
 
 TileMapResult _placeResourceAtKey(TileMapResult map, String key, Resource r) {
-  final parts = key.split('|');
-  if (parts.length != 4) return map;
-  final x = int.parse(parts[2]);
-  final y = int.parse(parts[3]);
-  return map.withResourceAt(x, y, r);
+  final parsed = parseTileKeyCoordinates(key);
+  if (parsed == null) return map;
+  return map.withResourceAt(parsed.x, parsed.y, r);
 }
 
 int _sumPlacedAll(Map<String, int> placed, List<String> gpIdsSorted) {

--- a/packages/colonizethis_logic/lib/src/setup/gp_starting_grain.dart
+++ b/packages/colonizethis_logic/lib/src/setup/gp_starting_grain.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../world/tile_key_coordinates.dart';
 import 'town_capital_occupancy.dart';
 
 final _log = packageLogger();
@@ -108,11 +109,9 @@ applyGreatPowerStartingGrainBootstrap({
     var tileState = ws.tileState;
     final resMap = Map<String, String>.from(ws.resourceByTileKey);
     for (final key in pickedKeys) {
-      final parts = key.split('|');
-      if (parts.length != 4) continue;
-      final x = int.parse(parts[2]);
-      final y = int.parse(parts[3]);
-      final t = map.terrainAt(x, y);
+      final parsed = parseTileKeyCoordinates(key);
+      if (parsed == null) continue;
+      final t = map.terrainAt(parsed.x, parsed.y);
       final allowedRegion = resourceRules.isAllowedInRegion(
         Resource.grain,
         cap.regionId,
@@ -120,9 +119,9 @@ applyGreatPowerStartingGrainBootstrap({
       final allowedTerrain =
           t != null && resourceRules.isAllowedOnTerrain(Resource.grain, t);
       if (!allowedRegion || !allowedTerrain) {
-        map = map.withTerrainAt(x, y, TerrainType.plains);
+        map = map.withTerrainAt(parsed.x, parsed.y, TerrainType.plains);
       }
-      map = map.withResourceAt(x, y, Resource.grain);
+      map = map.withResourceAt(parsed.x, parsed.y, Resource.grain);
       tileState = tileState.setImprovement(key, 1);
       resMap[key] = Resource.grain.name;
     }

--- a/packages/colonizethis_logic/lib/src/setup/town_capital_occupancy.dart
+++ b/packages/colonizethis_logic/lib/src/setup/town_capital_occupancy.dart
@@ -4,6 +4,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../world/province_lookup.dart';
+import '../world/tile_key_coordinates.dart';
 
 /// Every player / minor / tribe capital tile and every province [Province.townTileKey].
 /// Used to forbid resources and extraction improvements on those tiles only
@@ -48,17 +49,13 @@ stripResourcesAndExtractionImprovementsOnTileKeys(
       : null;
 
   for (final key in tileKeys) {
-    final parts = key.split('|');
-    if (parts.length != 4) continue;
-    final regionId = parts[0];
-    final x = int.tryParse(parts[2]);
-    final y = int.tryParse(parts[3]);
-    if (x == null || y == null) continue;
+    final parsed = parseTileKeyCoordinates(key);
+    if (parsed == null) continue;
 
     if (maps != null) {
-      final map = maps[regionId];
+      final map = maps[parsed.regionId];
       if (map?.resourceGrid != null) {
-        maps[regionId] = map!.withResourceAt(x, y, null);
+        maps[parsed.regionId] = map!.withResourceAt(parsed.x, parsed.y, null);
       }
     }
     resMap.remove(key);


### PR DESCRIPTION
## Summary
- Replace inline `split('|')` coordinate parsing with `parseTileKeyCoordinates` in setup resource paths.
- Centralize tile-key parsing in `town_capital_occupancy`, `gp_starting_grain`, and `gp_old_world_resource_redistribution`.
- Keep behavior unchanged while reducing duplicate parsing logic in `colonizethis_logic`.

## Implemented in this PR
- Updated setup modules to consume canonical tile-key parser helper:
  - `packages/colonizethis_logic/lib/src/setup/town_capital_occupancy.dart`
  - `packages/colonizethis_logic/lib/src/setup/gp_starting_grain.dart`
  - `packages/colonizethis_logic/lib/src/setup/gp_old_world_resource_redistribution.dart`
- Preserved existing null/invalid-key handling behavior at call sites.

## Deferred work
- Remaining issue #2149 scope is still open (including broader duplicate-pattern elimination and any remaining AC work not covered by this slice).
- This PR is a focused AC #4 slice for setup flows only.

## AC/SPEC coverage in this slice
- Advances issue #2149 canonical tile-key parsing adoption (`parseTileKeyCoordinates`) in setup code paths.
- Does not attempt full issue completion.

## Test plan
- [x] `dart test packages/colonizethis_logic/test/gp_old_world_resource_redistribution_test.dart packages/colonizethis_logic/test/gp_starting_grain_integration_test.dart`
- [x] `dart run tool/check_logic_dual_region_province_field_access.dart`

Refs #2149

Made with [Cursor](https://cursor.com)