### PR TITLE
Refactor #2149 slice: canonicalize tile-key coordinate parsing follow-ups

### DIFF
--- a/packages/colonizethis_logic/lib/src/setup/init_town_roads.dart
+++ b/packages/colonizethis_logic/lib/src/setup/init_town_roads.dart
@@ -141,10 +141,9 @@ Map<String, String> _coordToTileKey(WorldState ws, String regionId) {
   if (byProvince == null) return m;
   for (final list in byProvince.values) {
     for (final tk in list) {
-      final parts = tk.split('|');
-      if (parts.length >= 4) {
-        m['${parts[parts.length - 2]}|${parts[parts.length - 1]}'] = tk;
-      }
+      final coords = parseTileKeyCoordinates(tk);
+      if (coords == null || coords.regionId != regionId) continue;
+      m['${coords.x}|${coords.y}'] = tk;
     }
   }
   return m;

--- a/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
@@ -14,17 +14,15 @@ import 'naval.dart';
 import 'player_view.dart';
 import 'province_lookup.dart';
 import 'sea_zone_identity.dart';
+import 'tile_key_coordinates.dart';
 import 'topology_helpers.dart';
 
 final _log = packageLogger();
 
 ({int x, int y})? _xyFromTileKey(String tileKey) {
-  final parts = tileKey.split('|');
-  if (parts.length < 4) return null;
-  final x = int.tryParse(parts[parts.length - 2]);
-  final y = int.tryParse(parts[parts.length - 1]);
-  if (x == null || y == null) return null;
-  return (x: x, y: y);
+  final coords = parseTileKeyCoordinates(tileKey);
+  if (coords == null) return null;
+  return (x: coords.x, y: coords.y);
 }
 
 /// Canonical key used for sea-zone buckets in
@@ -354,7 +352,8 @@ Map<String, Map<String, String>> _revealTilesAfterMoveToSeaZone({
   List<Fleet> fleets,
   Map<String, Fleet> fleetById,
   Map<String, Map<String, String>> visibilityByTile,
-}) _applyDockNavalMoveOrder({
+})
+_applyDockNavalMoveOrder({
   required Game game,
   required MapTopology topology,
   required List<Fleet> fleets,
@@ -367,19 +366,31 @@ Map<String, Map<String, String>> _revealTilesAfterMoveToSeaZone({
 }) {
   final portProvinceId = order.destinationPortProvinceId!;
   if (!fleet.isAtSea || fleet.seaZoneId == null) {
-    return (fleets: fleets, fleetById: fleetById, visibilityByTile: visibilityByTile);
+    return (
+      fleets: fleets,
+      fleetById: fleetById,
+      visibilityByTile: visibilityByTile,
+    );
   }
   final fullProvinceId = toFullProvinceId(fleet.regionId, portProvinceId);
   final province = game.worldState.tryGetProvince(fullProvinceId);
   if (province == null || province.ownerId != playerId) {
-    return (fleets: fleets, fleetById: fleetById, visibilityByTile: visibilityByTile);
+    return (
+      fleets: fleets,
+      fleetById: fleetById,
+      visibilityByTile: visibilityByTile,
+    );
   }
   final adjacentSeaZones = seaZoneIdsAdjacentToProvince(
     topology,
     fullProvinceId,
   );
   if (!adjacentSeaZones.contains(fleet.seaZoneId)) {
-    return (fleets: fleets, fleetById: fleetById, visibilityByTile: visibilityByTile);
+    return (
+      fleets: fleets,
+      fleetById: fleetById,
+      visibilityByTile: visibilityByTile,
+    );
   }
 
   var nextVis = _revealProvinceTilesForPlayer(
@@ -411,7 +422,11 @@ Map<String, Map<String, String>> _revealTilesAfterMoveToSeaZone({
         .toList();
     fleetById[homeFleetId] = updatedHome;
     fleetById.remove(fleet.id);
-    return (fleets: nextFleets, fleetById: fleetById, visibilityByTile: nextVis);
+    return (
+      fleets: nextFleets,
+      fleetById: fleetById,
+      visibilityByTile: nextVis,
+    );
   }
 
   final portRegionId = ProvinceId.regionIdFrom(fullProvinceId);
@@ -430,7 +445,11 @@ Map<String, Map<String, String>> _revealTilesAfterMoveToSeaZone({
   if (idx >= 0) {
     final nextFleets = List<Fleet>.from(fleets)..[idx] = newFleet;
     fleetById[fleet.id] = newFleet;
-    return (fleets: nextFleets, fleetById: fleetById, visibilityByTile: nextVis);
+    return (
+      fleets: nextFleets,
+      fleetById: fleetById,
+      visibilityByTile: nextVis,
+    );
   }
   return (fleets: fleets, fleetById: fleetById, visibilityByTile: nextVis);
 }
@@ -439,7 +458,8 @@ Map<String, Map<String, String>> _revealTilesAfterMoveToSeaZone({
   List<Fleet> fleets,
   Map<String, Fleet> fleetById,
   Map<String, Map<String, String>> visibilityByTile,
-}) _applySeaNavalMoveOrder({
+})
+_applySeaNavalMoveOrder({
   required Game game,
   required MapTopology topology,
   required List<Fleet> fleets,
@@ -451,17 +471,29 @@ Map<String, Map<String, String>> _revealTilesAfterMoveToSeaZone({
 }) {
   final destZoneId = order.destinationSeaZoneId;
   if (destZoneId == null || destZoneId.isEmpty) {
-    return (fleets: fleets, fleetById: fleetById, visibilityByTile: visibilityByTile);
+    return (
+      fleets: fleets,
+      fleetById: fleetById,
+      visibilityByTile: visibilityByTile,
+    );
   }
   if (!seaZoneNodeIds(topology).contains(destZoneId)) {
-    return (fleets: fleets, fleetById: fleetById, visibilityByTile: visibilityByTile);
+    return (
+      fleets: fleets,
+      fleetById: fleetById,
+      visibilityByTile: visibilityByTile,
+    );
   }
   if (!_navalMoveDestinationIsReachable(
     topology: topology,
     fleet: fleet,
     destZoneId: destZoneId,
   )) {
-    return (fleets: fleets, fleetById: fleetById, visibilityByTile: visibilityByTile);
+    return (
+      fleets: fleets,
+      fleetById: fleetById,
+      visibilityByTile: visibilityByTile,
+    );
   }
 
   final destRegionId = regionIdForSeaZone(topology, destZoneId);
@@ -642,18 +674,10 @@ Game _applyNavalBattleVictoryDossierAndDialogue({
   if (victorId == null || loserId == null) return state;
 
   var next = state;
-  final evidence = evidenceForNavalBattleVictory(
-    next,
-    victorId,
-    loserId,
-    turn,
-  );
+  final evidence = evidenceForNavalBattleVictory(next, victorId, loserId, turn);
   if (evidence.isNotEmpty) {
     next = next.copyWith(
-      dossierEvidenceEntries: [
-        ...next.dossierEvidenceEntries,
-        ...evidence,
-      ],
+      dossierEvidenceEntries: [...next.dossierEvidenceEntries, ...evidence],
     );
   }
   final dialogueSeed =


### PR DESCRIPTION
## Summary
- replace remaining setup/naval inline tile-key coordinate splitting with `parseTileKeyCoordinates`
- update `init_town_roads.dart` coordinate index map generation to parse canonical coordinates and guard by `regionId`
- update `naval_resolution.dart` coastal adjacency tile decoding to reuse canonical tile-key parser

## Implemented in this PR
- `packages/colonizethis_logic/lib/src/setup/init_town_roads.dart`
  - `_coordToTileKey` now parses each tile key with `parseTileKeyCoordinates` instead of manual `split('|')` extraction
- `packages/colonizethis_logic/lib/src/world/naval_resolution.dart`
  - `_xyFromTileKey` now delegates to `parseTileKeyCoordinates`

## Deferred work
- issue #2149 remains partial; broader dual-region model/API cleanup and any remaining accepted AC gaps are deferred to follow-up slices

## Tests
- `dart test packages/colonizethis_logic/test/world/naval_fleet_commands_test.dart packages/colonizethis_logic/test/world/naval_home_fleet_split_movement_resolve_integration_test.dart packages/colonizethis_logic/test/naval_behavior_scenarios_test.dart`

Refs #2149

Made with [Cursor](https://cursor.com)