### PR TITLE
Refactor #2149 slice: canonicalize remaining tile-key coordinate splits

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/civilian_tile_occupancy.dart
+++ b/packages/colonizethis_logic/lib/src/world/civilian_tile_occupancy.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../diplomacy/diplomacy_resolver.dart';
 import 'province_lookup.dart';
+import 'tile_key_coordinates.dart';
 
 /// True when [tileKey] is a known land tile: listed in [WorldState.tileKeysByRegionAndProvince],
 /// or (fallback for sparse test worlds) a 4-part key whose enclosing prefixed province exists.
@@ -15,9 +16,9 @@ bool isLandTileKeyForGame(Game game, String tileKey) {
       if (tiles.contains(tileKey)) return true;
     }
   }
-  final parts = tileKey.split('|');
-  if (parts.length == 4) {
-    final provinceId = '${parts[0]}|${parts[1]}';
+  final coords = parseTileKeyCoordinates(tileKey);
+  if (coords != null) {
+    final provinceId = '${coords.regionId}|${coords.provinceLocalId}';
     if (tryGetProvince(ws, provinceId) != null) return true;
   }
   return false;

--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -250,11 +250,9 @@ void _removeBlockadedPortTilesExceptCapital({
   required String capitalProvinceId,
 }) {
   for (final key in connected.toList()) {
-    final parts = key.split('|');
-    if (parts.length < 2) continue;
-    final fullProvinceId = parts.length >= 3
-        ? '${parts[0]}|${parts[1]}'
-        : parts[0];
+    final coords = parseTileKeyCoordinates(key);
+    if (coords == null) continue;
+    final fullProvinceId = '${coords.regionId}|${coords.provinceLocalId}';
     if (!blockadedPortProvinces.contains(fullProvinceId)) continue;
     if (fullProvinceId == capitalProvinceId) continue;
     connected.remove(key);
@@ -306,9 +304,9 @@ ConnectivityResult _connectedTilesForPlayer({
   for (final k in connected) {
     final info = portInfo[k];
     if (info == null) continue;
-    final parts = k.split('|');
-    if (parts.isEmpty) continue;
-    if (parts[0] == capitalRegionId) capitalRegionPortKeys.add(k);
+    final coords = parseTileKeyCoordinates(k);
+    if (coords == null) continue;
+    if (coords.regionId == capitalRegionId) capitalRegionPortKeys.add(k);
   }
 
   final seaConnectedPortKeys = _seaConnectedPortKeysForCapital(


### PR DESCRIPTION
## Summary
- Replace remaining tile-key `split('|')` coordinate parsing in connectivity and land-tile occupancy paths with `parseTileKeyCoordinates(...)`.
- Keep behavior unchanged while making province-id derivation and region checks use the canonical parser.
- Refs #2149

## Implemented in this slice
- `packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart`
  - `_removeBlockadedPortTilesExceptCapital` now derives province ids via `parseTileKeyCoordinates`.
  - `_connectedTilesForPlayer` capital-region port filtering now uses parsed `regionId`.
- `packages/colonizethis_logic/lib/src/world/civilian_tile_occupancy.dart`
  - `isLandTileKeyForGame` fallback validation now uses `parseTileKeyCoordinates`.

## Deferred work
- Remaining #2149 scope (order-suggestion decomposition completion checks, wider dual-region branching cleanup/guardrails, and any still-noncanonical parsing outside this slice) remains for follow-up slices.

## AC / spec coverage in this PR
- Advances AC: canonical tile coordinate parsing helper usage across logic callsites (incremental slice).
- No gameplay rule changes; this is refactor-only alignment with existing behavior.

## Test plan
- [x] `dart test packages/colonizethis_logic/test/world/civilian_tile_occupancy_test.dart packages/colonizethis_logic/test/connectivity_resolver_test.dart packages/colonizethis_logic/test/connectivity_resolver_blockade_test.dart packages/colonizethis_logic/test/gp_land_connectivity_repair_test.dart`

Made with [Cursor](https://cursor.com)