### PR TITLE
Refactor #2149 slice: centralize province transfer region lookup

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/province_ownership_transfer.dart
+++ b/packages/colonizethis_logic/lib/src/world/province_ownership_transfer.dart
@@ -1,7 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../constants.dart';
 import 'army_migration.dart';
 import 'civilian_tile_occupancy.dart';
 import 'civilian_ownership_legality.dart';
@@ -129,9 +128,13 @@ void _validateCanonicalTransfer(
 
   final canonicalId = row.canonicalProvinceId;
   final regionId = row.province.regionId;
-  final region = regionId == kRegionOldWorld
-      ? game.worldState.oldWorld
-      : game.worldState.newWorld;
+  final region = regionDataForId(game.worldState, regionId);
+  if (region == null) {
+    throw StateError(
+      'Canonical province transfer: region not found for province '
+      '$canonicalId (regionId=$regionId)',
+    );
+  }
   if (!region.provinces.any((p) => p.id == canonicalId)) {
     throw StateError(
       'Canonical province transfer: province missing from region data '
@@ -190,9 +193,13 @@ _applyCanonicalSingleProvinceOwnershipTransferCore(
   )!;
   final canonicalId = row.canonicalProvinceId;
   final regionId = row.province.regionId;
-  final region = regionId == kRegionOldWorld
-      ? game.worldState.oldWorld
-      : game.worldState.newWorld;
+  final region = regionDataForId(game.worldState, regionId);
+  if (region == null) {
+    throw StateError(
+      'Canonical province transfer: region not found for province '
+      '$canonicalId (regionId=$regionId)',
+    );
+  }
 
   final pIdx = region.provinces.indexWhere((p) => p.id == canonicalId);
   if (pIdx < 0) {
@@ -237,7 +244,10 @@ _applyCanonicalSingleProvinceOwnershipTransferCore(
     newOwnerId,
   );
 
-  final newRegion = RegionData(provinces: updatedProvinces, units: updatedUnits);
+  final newRegion = RegionData(
+    provinces: updatedProvinces,
+    units: updatedUnits,
+  );
 
   var nextWs = game.worldState.copyWith(
     fleets: updatedFleets,
@@ -308,9 +318,13 @@ applyCanonicalSingleProvinceOwnershipTransferWithResult(
   )!;
   final canonicalId = row.canonicalProvinceId;
   final regionId = row.province.regionId;
-  final region = regionId == kRegionOldWorld
-      ? game.worldState.oldWorld
-      : game.worldState.newWorld;
+  final region = regionDataForId(game.worldState, regionId);
+  if (region == null) {
+    throw StateError(
+      'Canonical province transfer: region not found for province '
+      '$canonicalId (regionId=$regionId)',
+    );
+  }
 
   var regimentsTransferred = 0;
   for (final u in region.units) {


### PR DESCRIPTION
## Summary
- Replace manual `regionId == kRegionOldWorld` branching in canonical province ownership transfer paths with `regionDataForId(...)` lookups.
- Keep transfer behavior unchanged while centralizing dual-region access in the world lookup helper API.
- Refs #2149.

## Implemented in this slice
- `packages/colonizethis_logic/lib/src/world/province_ownership_transfer.dart`
  - `_validateCanonicalTransfer` now resolves region data via `regionDataForId(...)` and throws a clear error if region data is missing.
  - `_applyCanonicalSingleProvinceOwnershipTransferCore` now uses `regionDataForId(...)` instead of direct old/new-world ternary branching.
  - `applyCanonicalSingleProvinceOwnershipTransferWithResult` now uses `regionDataForId(...)` for the same region lookup path.

## Deferred work
- Remaining #2149 scope stays deferred, including order-suggestion decomposition completion, broader dual-region cleanup beyond this file, and any remaining CI budget reductions needed for full issue closure.

## AC / spec coverage in this PR
- Advances AC: replace non-exception manual dual-region branching with centralized lookup/update helpers.
- No gameplay rule changes; this is behavior-preserving refactor alignment with `SPEC/program/logic-dual-region-province-access.md`.

## Test plan
- [x] `dart test packages/colonizethis_logic/test/world/province_ownership_transfer_test.dart`
- [x] `dart run tool/check_logic_dual_region_province_field_access.dart`

Made with [Cursor](https://cursor.com)