### PR TITLE
Refactor dual-region access in fall and turn news digest

### DIFF
--- a/packages/colonizethis_logic/lib/src/turn/turn_news_digest.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_news_digest.dart
@@ -72,26 +72,24 @@ import '../world/province_lookup.dart';
 
 List<TurnNewsProvinceCapturedLine> _provinceCaptureLines(Game start, Game end) {
   final out = <TurnNewsProvinceCapturedLine>[];
-  for (final region in [end.worldState.oldWorld, end.worldState.newWorld]) {
-    for (final prov in region.provinces) {
-      final pid = _fullProvinceId(prov);
-      final before = _ownerForProvince(start, pid);
-      final after = _ownerForProvince(end, pid);
-      // Same predicate as emitProvinceCapturedEvents: both owners non-empty faction
-      // ids and owner changed (no null/empty "new owner" capture). See SPEC/game/world-model.md.
-      if (before != null &&
-          before.isNotEmpty &&
-          after != null &&
-          after.isNotEmpty &&
-          before != after) {
-        out.add(
-          TurnNewsProvinceCapturedLine(
-            provinceId: pid,
-            previousOwnerId: before,
-            newOwnerId: after,
-          ),
-        );
-      }
+  for (final prov in allProvinces(end.worldState)) {
+    final pid = _fullProvinceId(prov);
+    final before = _ownerForProvince(start, pid);
+    final after = _ownerForProvince(end, pid);
+    // Same predicate as emitProvinceCapturedEvents: both owners non-empty faction
+    // ids and owner changed (no null/empty "new owner" capture). See SPEC/game/world-model.md.
+    if (before != null &&
+        before.isNotEmpty &&
+        after != null &&
+        after.isNotEmpty &&
+        before != after) {
+      out.add(
+        TurnNewsProvinceCapturedLine(
+          provinceId: pid,
+          previousOwnerId: before,
+          newOwnerId: after,
+        ),
+      );
     }
   }
   out.sort((a, b) => a.provinceId.compareTo(b.provinceId));
@@ -99,14 +97,7 @@ List<TurnNewsProvinceCapturedLine> _provinceCaptureLines(Game start, Game end) {
 }
 
 String? _ownerForProvince(Game g, String fullProvinceId) {
-  for (final region in [g.worldState.oldWorld, g.worldState.newWorld]) {
-    for (final p in region.provinces) {
-      if (_fullProvinceId(p) == fullProvinceId) {
-        return p.ownerId;
-      }
-    }
-  }
-  return null;
+  return g.worldState.tryGetProvince(fullProvinceId)?.ownerId;
 }
 
 String _fullProvinceId(Province p) =>
@@ -228,18 +219,16 @@ List<TurnNewsProvinceDiscoveredLine> _provinceDiscoveryLines({
 }) {
   final out = <TurnNewsProvinceDiscoveredLine>[];
   final seen = <String>{};
-  for (final region in [end.worldState.oldWorld, end.worldState.newWorld]) {
-    for (final p in region.provinces) {
-      final pid = _fullProvinceId(p);
-      if (seen.contains(pid)) continue;
-      seen.add(pid);
-      if (readDone.contains(pid)) continue;
-      final was = _provinceKnownToAnyGp(start, p);
-      final now = _provinceKnownToAnyGp(end, p);
-      if (!was && now) {
-        out.add(TurnNewsProvinceDiscoveredLine(provinceId: pid));
-        writeDone.add(pid);
-      }
+  for (final p in allProvinces(end.worldState)) {
+    final pid = _fullProvinceId(p);
+    if (seen.contains(pid)) continue;
+    seen.add(pid);
+    if (readDone.contains(pid)) continue;
+    final was = _provinceKnownToAnyGp(start, p);
+    final now = _provinceKnownToAnyGp(end, p);
+    if (!was && now) {
+      out.add(TurnNewsProvinceDiscoveredLine(provinceId: pid));
+      writeDone.add(pid);
     }
   }
   out.sort((a, b) => a.provinceId.compareTo(b.provinceId));

--- a/packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
+++ b/packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
@@ -237,8 +237,9 @@ Game applyGreatPowerFall(
       return RegionData(provinces: updatedProvinces, units: remainingUnits);
     }
 
-    final newOldWorld = transferRegion(game.worldState.oldWorld);
-    final newNewWorld = transferRegion(game.worldState.newWorld);
+    final updatedWorldState = game.worldState.mapBothRegions(
+      (_, region) => transferRegion(region),
+    );
 
     final remainingFleets = game.worldState.fleets
         .where((f) => f.ownerId != playerId)
@@ -246,11 +247,7 @@ Game applyGreatPowerFall(
 
     game = game
         .copyWith(
-          worldState: game.worldState.copyWith(
-            oldWorld: newOldWorld,
-            newWorld: newNewWorld,
-            fleets: remainingFleets,
-          ),
+          worldState: updatedWorldState.copyWith(fleets: remainingFleets),
         )
         .mapPlayers(
           (p) => p.id == playerId

--- a/packages/colonizethis_logic/lib/src/world/province_ownership_transfer.dart
+++ b/packages/colonizethis_logic/lib/src/world/province_ownership_transfer.dart
@@ -1,7 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../constants.dart';
 import 'army_migration.dart';
 import 'civilian_tile_occupancy.dart';
 import 'civilian_ownership_legality.dart';
@@ -129,9 +128,13 @@ void _validateCanonicalTransfer(
 
   final canonicalId = row.canonicalProvinceId;
   final regionId = row.province.regionId;
-  final region = regionId == kRegionOldWorld
-      ? game.worldState.oldWorld
-      : game.worldState.newWorld;
+  final region = regionDataForId(game.worldState, regionId);
+  if (region == null) {
+    throw StateError(
+      'Canonical province transfer: region not found for province '
+      '$canonicalId (regionId=$regionId)',
+    );
+  }
   if (!region.provinces.any((p) => p.id == canonicalId)) {
     throw StateError(
       'Canonical province transfer: province missing from region data '
@@ -190,9 +193,13 @@ _applyCanonicalSingleProvinceOwnershipTransferCore(
   )!;
   final canonicalId = row.canonicalProvinceId;
   final regionId = row.province.regionId;
-  final region = regionId == kRegionOldWorld
-      ? game.worldState.oldWorld
-      : game.worldState.newWorld;
+  final region = regionDataForId(game.worldState, regionId);
+  if (region == null) {
+    throw StateError(
+      'Canonical province transfer: region not found for province '
+      '$canonicalId (regionId=$regionId)',
+    );
+  }
 
   final pIdx = region.provinces.indexWhere((p) => p.id == canonicalId);
   if (pIdx < 0) {
@@ -237,7 +244,10 @@ _applyCanonicalSingleProvinceOwnershipTransferCore(
     newOwnerId,
   );
 
-  final newRegion = RegionData(provinces: updatedProvinces, units: updatedUnits);
+  final newRegion = RegionData(
+    provinces: updatedProvinces,
+    units: updatedUnits,
+  );
 
   var nextWs = game.worldState.copyWith(
     fleets: updatedFleets,
@@ -308,9 +318,13 @@ applyCanonicalSingleProvinceOwnershipTransferWithResult(
   )!;
   final canonicalId = row.canonicalProvinceId;
   final regionId = row.province.regionId;
-  final region = regionId == kRegionOldWorld
-      ? game.worldState.oldWorld
-      : game.worldState.newWorld;
+  final region = regionDataForId(game.worldState, regionId);
+  if (region == null) {
+    throw StateError(
+      'Canonical province transfer: region not found for province '
+      '$canonicalId (regionId=$regionId)',
+    );
+  }
 
   var regimentsTransferred = 0;
   for (final u in region.units) {


### PR DESCRIPTION
## Summary
- replace manual `oldWorld/newWorld` reassignment in `applyGreatPowerFall` with `WorldState.mapBothRegions(...)`
- replace direct dual-region province iteration in `turn_news_digest.dart` with canonical province lookup helpers
- keep behavior unchanged while reducing non-canonical dual-region branching lines for issue `#2149`

## Scope in this PR
- **Implemented now:** one focused refactor slice for dual-region helper adoption in world fall/reassignment and digest capture/discovery paths
- **Deferred:** broader issue scope (order suggestion pipeline/cancellation helper/checker/doc updates and any remaining #2149 subtasks not touched here) remains outside this slice

## Acceptance criteria coverage
- advances the issue goal to eliminate non-exception manual dual-region access by replacing two production callsites with canonical helpers
- does not claim full issue completion; additional #2149 ACs remain for follow-up slices

## Test plan
- [x] `dart run tool/check_logic_dual_region_province_field_access.dart`
- [x] `dart test packages/colonizethis_logic/test`

Refs #2149

Made with [Cursor](https://cursor.com)