### PR TITLE
Share portsByProvinceSeaboard registry key parsing (#2149)

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
+++ b/packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import '../setup/capital_choice.dart';
 import '../setup/town_capital_occupancy.dart';
 import 'player_state_pipeline.dart';
+import 'port_seaboard_registry_key.dart';
 import 'province_lookup.dart';
 import 'capital_reassignment_fatal.dart';
 
@@ -198,11 +199,9 @@ Game applyGreatPowerFall(
 
   final portsByProvince = <String, List<String>>{};
   game.worldState.portsByProvinceSeaboard.forEach((key, _) {
-    final parts = key.split('|');
-    if (parts.length >= 3) {
-      final provinceId = '${parts[0]}|${parts[1]}';
-      portsByProvince.putIfAbsent(provinceId, () => []).add(key);
-    }
+    final decoded = decodePortSeaboardRegistryKey(key);
+    if (decoded == null || !decoded.isPrefixedKey) return;
+    portsByProvince.putIfAbsent(decoded.fullProvinceId, () => []).add(key);
   });
 
   for (final player in game.players) {

--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -4,6 +4,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../utils/graph_traversal.dart';
 import 'naval.dart';
+import 'port_seaboard_registry_key.dart';
 import 'province_lookup.dart';
 import 'tile_key_coordinates.dart';
 import 'topology_helpers.dart';
@@ -203,14 +204,9 @@ Set<String> _ownedProvinceIdsForPlayer(Game game, String playerId) {
 Map<String, (String, String)> _portToProvinceSeaZone(WorldState worldState) {
   final out = <String, (String, String)>{};
   for (final e in worldState.portsByProvinceSeaboard.entries) {
-    final key = e.key;
-    final tileKey = e.value;
-    final parts = key.split('|');
-    if (parts.length >= 3) {
-      out[tileKey] = ('${parts[0]}|${parts[1]}', parts[2]);
-    } else if (parts.length >= 2) {
-      out[tileKey] = (parts[0], parts[1]);
-    }
+    final decoded = decodePortSeaboardRegistryKey(e.key);
+    if (decoded == null) continue;
+    out[e.value] = (decoded.fullProvinceId, decoded.seaZoneId);
   }
   return out;
 }
@@ -449,7 +445,7 @@ Set<String> _seaConnectedPortKeysForCapital({
     );
     final seaReachable = _seaZonesReachableBySeaPath(topology, capitalSeaZones);
     for (final entry in worldState.portsByProvinceSeaboard.entries) {
-      final portMeta = _decodePortEntry(entry.key);
+      final portMeta = decodePortSeaboardRegistryKey(entry.key);
       if (portMeta == null) continue;
       if (blockadedPortProvinces.contains(portMeta.fullProvinceId)) continue;
       final seaZoneIdForReachable = prefixedTopology && portMeta.isPrefixedKey
@@ -480,33 +476,6 @@ String? _fullProvinceIdFromTileKey(String tileKey) {
   final coords = parseTileKeyCoordinates(tileKey);
   if (coords == null) return null;
   return '${coords.regionId}|${coords.provinceLocalId}';
-}
-
-({
-  String fullProvinceId,
-  String seaZoneId,
-  String regionId,
-  bool isPrefixedKey,
-})?
-_decodePortEntry(String portKey) {
-  final parts = portKey.split('|');
-  if (parts.length >= 3) {
-    return (
-      fullProvinceId: '${parts[0]}|${parts[1]}',
-      seaZoneId: parts[2],
-      regionId: parts[0],
-      isPrefixedKey: true,
-    );
-  }
-  if (parts.length >= 2) {
-    return (
-      fullProvinceId: parts[0],
-      seaZoneId: parts[1],
-      regionId: '',
-      isPrefixedKey: false,
-    );
-  }
-  return null;
 }
 
 /// § Connectivity (Game Rule) Town rule: 4-adjacent to a connected town in the **same** province.

--- a/packages/colonizethis_logic/lib/src/world/port_seaboard_registry_key.dart
+++ b/packages/colonizethis_logic/lib/src/world/port_seaboard_registry_key.dart
@@ -1,0 +1,33 @@
+/// Decodes keys from [WorldState.portsByProvinceSeaboard].
+///
+/// Supported formats:
+/// - Prefixed: `regionId|provinceLocalId|seaZoneId` (three or more segments;
+///   [fullProvinceId] is `regionId|provinceLocalId`).
+/// - Legacy: `provinceId|seaZoneId` (exactly two segments; [fullProvinceId] is
+///   [parts[0]] as stored).
+({
+  String fullProvinceId,
+  String seaZoneId,
+  String regionId,
+  bool isPrefixedKey,
+})?
+decodePortSeaboardRegistryKey(String key) {
+  final parts = key.split('|');
+  if (parts.length >= 3) {
+    return (
+      fullProvinceId: '${parts[0]}|${parts[1]}',
+      seaZoneId: parts[2],
+      regionId: parts[0],
+      isPrefixedKey: true,
+    );
+  }
+  if (parts.length >= 2) {
+    return (
+      fullProvinceId: parts[0],
+      seaZoneId: parts[1],
+      regionId: '',
+      isPrefixedKey: false,
+    );
+  }
+  return null;
+}

--- a/packages/colonizethis_logic/test/world/port_seaboard_registry_key_test.dart
+++ b/packages/colonizethis_logic/test/world/port_seaboard_registry_key_test.dart
@@ -1,0 +1,29 @@
+import 'package:colonizethis_logic/src/world/port_seaboard_registry_key.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('decodePortSeaboardRegistryKey', () {
+    test('parses prefixed region|province|sea keys', () {
+      final d = decodePortSeaboardRegistryKey('oldWorld|P1|seaA');
+      expect(d, isNotNull);
+      expect(d!.fullProvinceId, 'oldWorld|P1');
+      expect(d.seaZoneId, 'seaA');
+      expect(d.regionId, 'oldWorld');
+      expect(d.isPrefixedKey, isTrue);
+    });
+
+    test('parses legacy provinceId|sea keys', () {
+      final d = decodePortSeaboardRegistryKey('P1|seaB');
+      expect(d, isNotNull);
+      expect(d!.fullProvinceId, 'P1');
+      expect(d.seaZoneId, 'seaB');
+      expect(d.regionId, '');
+      expect(d.isPrefixedKey, isFalse);
+    });
+
+    test('returns null for empty or single-segment keys', () {
+      expect(decodePortSeaboardRegistryKey(''), isNull);
+      expect(decodePortSeaboardRegistryKey('onlyOne'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `decodePortSeaboardRegistryKey` in `port_seaboard_registry_key.dart` as the single place that splits `portsByProvinceSeaboard` map keys into full province id, sea zone id, and prefixed vs legacy shape.
- Route `connectivity_resolver.dart` (`_portToProvinceSeaZone` and sea-reach port iteration) through the shared decoder; remove the private duplicate `_decodePortEntry`.
- Route `capital_and_gp_fall.dart` port grouping through the same helper, still **only** indexing prefixed (three-or-more-segment) keys so GP-fall behavior matches the previous `parts.length >= 3` gate.

## Scope in this PR
- **SLICE** for GitHub #2149: deduplicate pipe-delimited **port registry** key parsing (distinct from `parseTileKeyCoordinates` tile keys).
- **Deferred:** order-suggestion pipeline decomposition, expanded dual-region checker, remaining `split('|')` uses that are not `portsByProvinceSeaboard` keys (e.g. diplomacy pair keys, `naval.dart` province id segments), and other #2149 ACs.

## Acceptance criteria coverage
- Centralizes repeated `split('|')` parsing for `portsByProvinceSeaboard` keys at two production callsites; adds unit tests for prefixed, legacy, and invalid keys.
- Does **not** complete the full #2149 checklist (order suggestions, CI checker extension, etc.).

## Test plan
- [x] `dart run tool/check_logic_dual_region_province_field_access.dart`
- [x] `dart test packages/colonizethis_logic/test/world/port_seaboard_registry_key_test.dart`
- [x] `dart test` (full `colonizethis_logic` package)

Refs #2149

Made with [Cursor](https://cursor.com)