### PR TITLE
refactor(logic): canonical hostile faction graph (Phase A for #2178)

### DIFF
--- a/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../diplomacy/diplomacy_relation_lookup.dart';
 import 'military_strength.dart';
 
 final _log = packageLogger();
@@ -135,12 +136,7 @@ BattleContextSea normalizeNavalBattleSidesForAttacker(
 /// Conflict detection: returns contested sea zones with two hostile sides.
 /// Populates mission per side from fleet state for retreat aggression.
 List<BattleContextSea> detectNavalConflicts(Game game) {
-  final atWar = <String, Set<String>>{};
-  for (final rel in game.diplomacyRelations) {
-    if (rel.state != RelationState.atWar) continue;
-    atWar.putIfAbsent(rel.factionId1, () => <String>{}).add(rel.factionId2);
-    atWar.putIfAbsent(rel.factionId2, () => <String>{}).add(rel.factionId1);
-  }
+  final atWar = hostileFactionsByFaction(game);
   final byZone = <String, Map<String, List<ShipInstance>>>{};
   final missionByZoneOwner = <String, Map<String, FleetMission>>{};
   for (final f in game.worldState.fleets) {

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
@@ -197,6 +197,25 @@ bool factionsAtWar(Game game, String a, String b) {
   return rel?.atWar ?? false;
 }
 
+/// Undirected adjacency: for each faction id, the set of faction ids at war
+/// with it (from [game.diplomacyRelations], using [DiplomacyRelation.atWar]).
+///
+/// Used by naval visibility, naval combat conflict detection, and sea trade
+/// interception. Issue #2178 Phase A; keep in sync with [factionsAtWar].
+Map<String, Set<String>> hostileFactionsByFaction(Game game) {
+  final out = <String, Set<String>>{};
+  for (final rel in game.diplomacyRelations) {
+    if (!rel.atWar) continue;
+    out.putIfAbsent(rel.factionId1, () => <String>{}).add(rel.factionId2);
+    out.putIfAbsent(rel.factionId2, () => <String>{}).add(rel.factionId1);
+  }
+  return out;
+}
+
+/// Faction ids currently at war with [playerId] (empty if none or unknown).
+Set<String> enemiesOf(Game game, String playerId) =>
+    hostileFactionsByFaction(game)[playerId] ?? const <String>{};
+
 /// True if [playerId] may attack [targetOwnerId]: at war or declaring war this turn.
 /// Used by move validator for GP and Minor/Tribe attack checks. SPEC/program/orders.md.
 bool canAttackWithWarOrDeclaring(

--- a/packages/colonizethis_logic/lib/src/economy/sea_transport.dart
+++ b/packages/colonizethis_logic/lib/src/economy/sea_transport.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../diplomacy/diplomacy_relation_lookup.dart';
 import '../world/naval.dart';
 
 final _log = packageLogger();
@@ -164,17 +165,6 @@ class TradeInterceptionResult {
   final List<Fleet> updatedFleets;
 }
 
-/// Enemies at war with [playerId]. From game.diplomacyRelations.
-Set<String> _enemiesAtWar(Game game, String playerId) {
-  final set = <String>{};
-  for (final rel in game.diplomacyRelations) {
-    if (rel.state != RelationState.atWar) continue;
-    if (rel.factionId1 == playerId) set.add(rel.factionId2);
-    if (rel.factionId2 == playerId) set.add(rel.factionId1);
-  }
-  return set;
-}
-
 /// Intercept score and whether any enemy has Blockade mission.
 (int interceptScore, bool hasBlockade) _interceptScoreAndBlockade(
   List<Fleet> fleets,
@@ -252,7 +242,7 @@ TradeInterceptionResult applyTradeInterception(
     );
   }
 
-  final enemies = _enemiesAtWar(game, playerId);
+  final enemies = enemiesOf(game, playerId);
   if (enemies.isEmpty) {
     final unchanged = Map<CommodityId, int>.from(overseasDelivered);
     _logExtractionAutoTransportInterception(

--- a/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
@@ -100,16 +100,6 @@ Map<String, Map<String, String>> _revealProvinceTilesForPlayer(
     ..[playerId] = vis;
 }
 
-Map<String, Set<String>> _atWarByFaction(Game game) {
-  final out = <String, Set<String>>{};
-  for (final rel in game.diplomacyRelations) {
-    if (rel.state != RelationState.atWar) continue;
-    out.putIfAbsent(rel.factionId1, () => <String>{}).add(rel.factionId2);
-    out.putIfAbsent(rel.factionId2, () => <String>{}).add(rel.factionId1);
-  }
-  return out;
-}
-
 List<String> _adjacentSeaZones(MapTopology topology, String seaZoneId) {
   final out = <String>[];
   for (final e in topology.edges) {
@@ -128,7 +118,7 @@ String? _firstFriendlyOrNeutralRetreatZone(
   String fromSeaZoneId,
   String ownerId,
 ) {
-  final hostileByOwner = _atWarByFaction(game);
+  final hostileByOwner = hostileFactionsByFaction(game);
   for (final adj in _adjacentSeaZones(topology, fromSeaZoneId)) {
     final hostileOwnersPresent = game.worldState.fleets.any(
       (fleet) =>

--- a/packages/colonizethis_logic/test/hostile_factions_by_faction_test.dart
+++ b/packages/colonizethis_logic/test/hostile_factions_by_faction_test.dart
@@ -1,0 +1,80 @@
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  Game minimalGame(List<DiplomacyRelation> relations) => Game(
+    id: 'g',
+    worldState: const WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: 0),
+      oldWorld: RegionData(),
+      newWorld: RegionData(),
+    ),
+    players: const [
+      Player(id: 'a', displayName: 'A', isHuman: true),
+      Player(id: 'b', displayName: 'B', isHuman: false),
+      Player(id: 'c', displayName: 'C', isHuman: false),
+    ],
+    diplomacyRelations: relations,
+  );
+
+  test(
+    'Given no diplomacy rows When hostileFactionsByFaction Then empty map',
+    () {
+      final g = minimalGame(const []);
+      expect(hostileFactionsByFaction(g), isEmpty);
+      expect(enemiesOf(g, 'a'), isEmpty);
+    },
+  );
+
+  test(
+    'Given at-war pair When hostileFactionsByFaction Then symmetric edges',
+    () {
+      final g = minimalGame(const [
+        DiplomacyRelation(
+          factionId1: 'a',
+          factionId2: 'b',
+          state: RelationState.atWar,
+        ),
+      ]);
+      final m = hostileFactionsByFaction(g);
+      expect(m['a'], {'b'});
+      expect(m['b'], {'a'});
+      expect(factionsAtWar(g, 'a', 'b'), isTrue);
+      expect(enemiesOf(g, 'a'), {'b'});
+      expect(enemiesOf(g, 'b'), {'a'});
+    },
+  );
+
+  test('Given three-party war star When graph Then hub sees both leaves', () {
+    final g = minimalGame(const [
+      DiplomacyRelation(
+        factionId1: 'a',
+        factionId2: 'b',
+        state: RelationState.atWar,
+      ),
+      DiplomacyRelation(
+        factionId1: 'a',
+        factionId2: 'c',
+        state: RelationState.atWar,
+      ),
+    ]);
+    final m = hostileFactionsByFaction(g);
+    expect(m['a'], {'b', 'c'});
+    expect(m['b'], {'a'});
+    expect(m['c'], {'a'});
+    expect(enemiesOf(g, 'a'), {'b', 'c'});
+  });
+
+  test('Given atPeace only When hostileFactionsByFaction Then no edges', () {
+    final g = minimalGame(const [
+      DiplomacyRelation(
+        factionId1: 'a',
+        factionId2: 'b',
+        state: RelationState.atPeace,
+      ),
+    ]);
+    expect(hostileFactionsByFaction(g), isEmpty);
+    expect(factionsAtWar(g, 'a', 'b'), isFalse);
+  });
+}

--- a/packages/colonizethis_logic/test/hostile_factions_by_faction_test.dart
+++ b/packages/colonizethis_logic/test/hostile_factions_by_faction_test.dart
@@ -1,6 +1,6 @@
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 void main() {
   Game minimalGame(List<DiplomacyRelation> relations) => Game(


### PR DESCRIPTION
## Summary

Implements **Phase A** of [#2178](https://github.com/waigore/colonizethisv3/issues/2178): a single canonical builder for at-war faction adjacency, with call sites in `naval_resolution.dart`, `naval_combat_resolver.dart`, and `sea_transport.dart` migrated off duplicated `diplomacyRelations` scans.

Refs #2178

## Implemented in this PR

- `hostileFactionsByFaction(Game)` and `enemiesOf(Game, playerId)` in `diplomacy_relation_lookup.dart`, aligned with `factionsAtWar` via `DiplomacyRelation.atWar`.
- Removed private `_atWarByFaction` / inline loops at the three issue-listed sites.
- New unit tests: empty game, symmetric pair, three-party hub, at-peace ignored.

## Deferred (same issue, follow-up PRs)

- **Phase B–D** from #2178: naval/fog file splits, connectivity extraction, combat pure helpers, line-count targets, additional helper tests.
- Other duplicate `rel.atWar` / relation scans elsewhere in the package (e.g. purchase land) were out of scope for this slice.

## AC coverage (this slice)

| AC | Status |
|----|--------|
| Canonical at-war adjacency; naval_resolution, naval_combat_resolver, sea_transport use it | **Done** for those three modules |
| naval_resolution line count / splits | **Not in this PR** (Phase B) |
| fog_resolution tested helpers | **Not in this PR** (Phase B) |
| connectivity_resolver extraction | **Not in this PR** (Phase C) |
| combat_resolver / quick_battle pure modules | **Not in this PR** (Phase D) |
| ≥90% logic coverage | Existing suite + new tests; full `dart test packages/colonizethis_logic/test` run locally |

## Coordination

Sibling effort [#2149](https://github.com/waigore/colonizethisv3/issues/2149): this changeset does not touch order-suggestion or `orders_application*` / `order_suggestion_work*` hotspots.

## Tests

`dart test` in `packages/colonizethis_logic` (full package test run).

Made with [Cursor](https://cursor.com)