### PR TITLE
refactor(logic): extract spy fog decay helpers (#2178 Phase B slice)

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/fog_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/fog_resolution.dart
@@ -8,55 +8,11 @@ import 'naval_resolution.dart'
         canonicalSeaZoneTileBucketKey,
         coastalLandTileKeysFromNavalPresenceAtSea,
         landTileKeysForProvinceBucket;
+import 'fog_spy_reveal_decay.dart';
 import 'player_view.dart';
 import 'province_lookup.dart' hide landTileKeysForProvinceBucket;
 import 'tile_key_coordinates.dart';
 import 'unit_lookup.dart';
-
-void _fogFullyVisibleTilesForSpyExpiry(
-  Map<String, String> vis,
-  List<String> tileKeys,
-) {
-  for (final tk in tileKeys) {
-    final cur = vis[tk];
-    if (cur == VisibilityLevel.fullyVisible.name) {
-      vis[tk] = VisibilityLevel.fogged.name;
-    }
-  }
-}
-
-Map<String, int> _nextSpyTimersForPlayerAfterDecay({
-  required WorldState world,
-  required String playerId,
-  required Map<String, int> byProvince,
-  required Map<String, String?> ownerByProvinceId,
-  required Map<String, String> vis,
-}) {
-  final newByProvince = <String, int>{};
-  for (final provEntry in byProvince.entries) {
-    final provinceId = provEntry.key;
-    final turns = provEntry.value;
-
-    final ownerId = ownerByProvinceId[provinceId];
-    if (ownerId == playerId) {
-      continue;
-    }
-
-    final nextTurns = turns - 1;
-    if (nextTurns <= 0) {
-      final regionId = ProvinceId.regionIdFrom(provinceId);
-      final tileKeys = landTileKeysForProvinceBucket(
-        world,
-        regionId,
-        provinceId,
-      );
-      _fogFullyVisibleTilesForSpyExpiry(vis, tileKeys);
-    } else {
-      newByProvince[provinceId] = nextTurns;
-    }
-  }
-  return newByProvince;
-}
 
 /// Spy 5-turn fog decay: decrement timers; when they expire, set other-faction
 /// provinces back to fogged for that player. Timers MUST NOT affect a player's
@@ -80,12 +36,16 @@ applySpyRevealTimerDecay(Game game) {
     final playerId = entry.key;
     final byProvince = entry.value;
     final vis = Map<String, String>.from(visibilityByTile[playerId] ?? {});
-    final newByProvince = _nextSpyTimersForPlayerAfterDecay(
-      world: world,
+    final newByProvince = nextSpyRevealTimersByProvinceAfterDecayStep(
       playerId: playerId,
       byProvince: byProvince,
       ownerByProvinceId: ownerByProvinceId,
-      vis: vis,
+      playerVisibility: vis,
+      landTileKeysForProvince: (provinceId) => landTileKeysForProvinceBucket(
+        world,
+        ProvinceId.regionIdFrom(provinceId),
+        provinceId,
+      ),
     );
     if (newByProvince.isNotEmpty) nextSpyTimers[playerId] = newByProvince;
     visibilityByTile[playerId] = vis;

--- a/packages/colonizethis_logic/lib/src/world/fog_spy_reveal_decay.dart
+++ b/packages/colonizethis_logic/lib/src/world/fog_spy_reveal_decay.dart
@@ -1,0 +1,58 @@
+import 'player_view.dart';
+
+/// For tiles in a province whose spy-reveal timer just reached 0: if stored
+/// visibility is [VisibilityLevel.fullyVisible], set it to [VisibilityLevel.fogged];
+/// leave `unknown` and `fogged` unchanged. SPEC/program/fog-and-exploration-resolution.md
+/// (Spy fog decay).
+void downgradeFullyVisibleTilesToFoggedAfterSpyTimerExpiry(
+  Map<String, String> vis,
+  List<String> tileKeys,
+) {
+  for (final tk in tileKeys) {
+    final cur = vis[tk];
+    if (cur == VisibilityLevel.fullyVisible.name) {
+      vis[tk] = VisibilityLevel.fogged.name;
+    }
+  }
+}
+
+/// One end-of-turn decay step for a single player's spy-reveal timers.
+///
+/// Skips provinces owned by [playerId] (timers must not affect own provinces).
+/// For each other-faction province entry, decrements the turn count; when the
+/// count would reach 0 or below, applies [downgradeFullyVisibleTilesToFoggedAfterSpyTimerExpiry]
+/// using [landTileKeysForProvince] and omits that province from the returned map.
+/// Otherwise stores `turns - 1` for the province.
+///
+/// Mutates [playerVisibility] in place when a timer expires.
+/// SPEC/program/fog-and-exploration-resolution.md (Spy fog decay).
+Map<String, int> nextSpyRevealTimersByProvinceAfterDecayStep({
+  required String playerId,
+  required Map<String, int> byProvince,
+  required Map<String, String?> ownerByProvinceId,
+  required Map<String, String> playerVisibility,
+  required List<String> Function(String provinceId) landTileKeysForProvince,
+}) {
+  final newByProvince = <String, int>{};
+  for (final provEntry in byProvince.entries) {
+    final provinceId = provEntry.key;
+    final turns = provEntry.value;
+
+    final ownerId = ownerByProvinceId[provinceId];
+    if (ownerId == playerId) {
+      continue;
+    }
+
+    final nextTurns = turns - 1;
+    if (nextTurns <= 0) {
+      final tileKeys = landTileKeysForProvince(provinceId);
+      downgradeFullyVisibleTilesToFoggedAfterSpyTimerExpiry(
+        playerVisibility,
+        tileKeys,
+      );
+    } else {
+      newByProvince[provinceId] = nextTurns;
+    }
+  }
+  return newByProvince;
+}

--- a/packages/colonizethis_logic/test/fog_spy_reveal_decay_test.dart
+++ b/packages/colonizethis_logic/test/fog_spy_reveal_decay_test.dart
@@ -1,0 +1,82 @@
+import 'package:colonizethis_logic/src/world/fog_spy_reveal_decay.dart';
+import 'package:colonizethis_logic/src/world/player_view.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('downgradeFullyVisibleTilesToFoggedAfterSpyTimerExpiry', () {
+    test('Given fullyVisible tiles When timer expiry Then only those become fogged',
+        () {
+      final vis = <String, String>{
+        'ow|p1|0|0': VisibilityLevel.fullyVisible.name,
+        'ow|p1|0|1': VisibilityLevel.fogged.name,
+        'ow|p1|0|2': VisibilityLevel.unknown.name,
+      };
+      downgradeFullyVisibleTilesToFoggedAfterSpyTimerExpiry(vis, [
+        'ow|p1|0|0',
+        'ow|p1|0|1',
+        'ow|p1|0|2',
+      ]);
+      expect(vis['ow|p1|0|0'], VisibilityLevel.fogged.name);
+      expect(vis['ow|p1|0|1'], VisibilityLevel.fogged.name);
+      expect(vis['ow|p1|0|2'], VisibilityLevel.unknown.name);
+    });
+  });
+
+  group('nextSpyRevealTimersByProvinceAfterDecayStep', () {
+    test('Given own-province timer entry When decay step Then entry is ignored', () {
+      const playerId = 'england';
+      final vis = <String, String>{
+        'ow|p1|0|0': VisibilityLevel.fullyVisible.name,
+      };
+      final out = nextSpyRevealTimersByProvinceAfterDecayStep(
+        playerId: playerId,
+        byProvince: {'ow|p1': 1},
+        ownerByProvinceId: {'ow|p1': playerId},
+        playerVisibility: vis,
+        landTileKeysForProvince: (_) => ['ow|p1|0|0'],
+      );
+      expect(out, isEmpty);
+      expect(vis['ow|p1|0|0'], VisibilityLevel.fullyVisible.name);
+    });
+
+    test(
+        'Given other-faction province with turns > 1 When decay step '
+        'Then timer decrements and visibility unchanged',
+        () {
+      const playerId = 'england';
+      final vis = <String, String>{
+        'ow|p1|0|0': VisibilityLevel.fullyVisible.name,
+      };
+      final out = nextSpyRevealTimersByProvinceAfterDecayStep(
+        playerId: playerId,
+        byProvince: {'ow|p1': 3},
+        ownerByProvinceId: {'ow|p1': 'france'},
+        playerVisibility: vis,
+        landTileKeysForProvince: (_) => ['ow|p1|0|0'],
+      );
+      expect(out, {'ow|p1': 2});
+      expect(vis['ow|p1|0|0'], VisibilityLevel.fullyVisible.name);
+    });
+
+    test(
+        'Given other-faction province with turns 1 When decay step '
+        'Then timer removed and fullyVisible tiles fogged',
+        () {
+      const playerId = 'england';
+      final vis = <String, String>{
+        'ow|p1|0|0': VisibilityLevel.fullyVisible.name,
+        'ow|p1|0|1': VisibilityLevel.unknown.name,
+      };
+      final out = nextSpyRevealTimersByProvinceAfterDecayStep(
+        playerId: playerId,
+        byProvince: {'ow|p1': 1},
+        ownerByProvinceId: {'ow|p1': 'france'},
+        playerVisibility: vis,
+        landTileKeysForProvince: (_) => ['ow|p1|0|0', 'ow|p1|0|1'],
+      );
+      expect(out, isEmpty);
+      expect(vis['ow|p1|0|0'], VisibilityLevel.fogged.name);
+      expect(vis['ow|p1|0|1'], VisibilityLevel.unknown.name);
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/fog_spy_reveal_decay_test.dart
+++ b/packages/colonizethis_logic/test/fog_spy_reveal_decay_test.dart
@@ -1,6 +1,6 @@
 import 'package:colonizethis_logic/src/world/fog_spy_reveal_decay.dart';
 import 'package:colonizethis_logic/src/world/player_view.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 void main() {
   group('downgradeFullyVisibleTilesToFoggedAfterSpyTimerExpiry', () {


### PR DESCRIPTION
## Summary

Phase **B** slice for [#2178](https://github.com/waigore/colonizethisv3/issues/2178): extract spy-reveal timer decay from `fog_resolution.dart` into focused, unit-tested helpers (`fog_spy_reveal_decay.dart`). No rule or visibility behavior changes; same algorithm as before, aligned with `SPEC/program/fog-and-exploration-resolution.md`.

Refs #2178

## Implemented in this PR

- New `downgradeFullyVisibleTilesToFoggedAfterSpyTimerExpiry` and `nextSpyRevealTimersByProvinceAfterDecayStep` (tile-key list supplied by caller so tests stay fixture-light).
- `applySpyRevealTimerDecay` wired to the helpers; removed private duplicates from `fog_resolution.dart`.
- New `fog_spy_reveal_decay_test.dart`: downgrade rule, own-province skip, multi-turn decrement, expiry fogging.

## Deferred (same issue)

- Further `fog_resolution.dart` splits (e.g. `applyFogDecay`, coastal/distant sea helpers).
- `naval_resolution.dart` line-count / file splits (Phase B remainder).
- `connectivity_resolver.dart` and combat pure-module extractions (Phases C–D).
- Canonical hostile-faction graph work remains as merged in [#2179](https://github.com/waigore/colonizethisv3/pull/2179) (Phase A).

## AC coverage (this slice)

| #2178 AC | Status |
|----------|--------|
| Canonical at-war adjacency (#2179) | Already merged |
| `naval_resolution` size / splits | Not this PR |
| `fog_resolution` ≥2 new unit-tested pure helpers | **Partial:** two new tested helpers for spy timer decay; more fog helpers still in monolith |
| Connectivity / combat extractions | Not this PR |
| ≥90% logic coverage | Full `dart test` in `packages/colonizethis_logic` |

## Coordination

Sibling [#2149](https://github.com/waigore/colonizethisv3/issues/2149): no `orders_application*` / `order_suggestion_work*` edits.

## Tests

`cd packages/colonizethis_logic && dart test` (all tests passed).

Made with [Cursor](https://cursor.com)