### PR TITLE
refactor(logic): extract combat loss profile helper (#2178 Phase D slice)

### DIFF
--- a/packages/colonizethis_logic/lib/src/combat/combat_loss_profile.dart
+++ b/packages/colonizethis_logic/lib/src/combat/combat_loss_profile.dart
@@ -1,0 +1,90 @@
+const double _strongAttackerRatioThreshold = 1.5;
+const double _bluntAttackerVictoryUpperRatio = 4.0;
+const double _strongDefenderRatioThreshold = 0.67;
+const double _attackerEdgeRatioThreshold = 1.0;
+const double _bluntAttackerLossFraction = 0.6;
+const double _bluntDefenderLossFraction = 0.4;
+const double _strongAttackerLossFraction = 0.15;
+const double _strongDefenderLossFraction = 1.0;
+const double _strongDefenderAttackerLossFraction = 1.0;
+const double _strongDefenderDefenderLossFraction = 0.15;
+const double _attackerEdgeAttackerLossFraction = 0.3;
+const double _attackerEdgeDefenderLossFraction = 0.6;
+const double _defaultAttackerLossFraction = 0.5;
+const double _defaultDefenderLossFraction = 0.4;
+const int _minCasualtySlots = 0;
+
+enum CombatMutualEliminationOutcome {
+  attackerVictory,
+  defenderVictory,
+  mutualAnnihilation,
+}
+
+class CombatLossProfile {
+  const CombatLossProfile({
+    required this.attackerLossFraction,
+    required this.defenderLossFraction,
+    required this.bluntsAttackerVictory,
+    required this.mutualEliminationOutcome,
+  });
+
+  final double attackerLossFraction;
+  final double defenderLossFraction;
+  final bool bluntsAttackerVictory;
+  final CombatMutualEliminationOutcome mutualEliminationOutcome;
+}
+
+CombatLossProfile combatLossProfileForStrengthRatio({
+  required double attackerDefenderStrengthRatio,
+  required bool attackerLowMorale,
+}) {
+  final ratio = attackerDefenderStrengthRatio;
+  if (ratio >= _strongAttackerRatioThreshold &&
+      attackerLowMorale &&
+      ratio < _bluntAttackerVictoryUpperRatio) {
+    return const CombatLossProfile(
+      attackerLossFraction: _bluntAttackerLossFraction,
+      defenderLossFraction: _bluntDefenderLossFraction,
+      bluntsAttackerVictory: true,
+      mutualEliminationOutcome:
+          CombatMutualEliminationOutcome.mutualAnnihilation,
+    );
+  }
+  if (ratio >= _strongAttackerRatioThreshold) {
+    return const CombatLossProfile(
+      attackerLossFraction: _strongAttackerLossFraction,
+      defenderLossFraction: _strongDefenderLossFraction,
+      bluntsAttackerVictory: false,
+      mutualEliminationOutcome: CombatMutualEliminationOutcome.attackerVictory,
+    );
+  }
+  if (ratio <= _strongDefenderRatioThreshold) {
+    return const CombatLossProfile(
+      attackerLossFraction: _strongDefenderAttackerLossFraction,
+      defenderLossFraction: _strongDefenderDefenderLossFraction,
+      bluntsAttackerVictory: false,
+      mutualEliminationOutcome: CombatMutualEliminationOutcome.defenderVictory,
+    );
+  }
+  if (ratio >= _attackerEdgeRatioThreshold) {
+    return const CombatLossProfile(
+      attackerLossFraction: _attackerEdgeAttackerLossFraction,
+      defenderLossFraction: _attackerEdgeDefenderLossFraction,
+      bluntsAttackerVictory: false,
+      mutualEliminationOutcome: CombatMutualEliminationOutcome.attackerVictory,
+    );
+  }
+  return const CombatLossProfile(
+    attackerLossFraction: _defaultAttackerLossFraction,
+    defenderLossFraction: _defaultDefenderLossFraction,
+    bluntsAttackerVictory: false,
+    mutualEliminationOutcome: CombatMutualEliminationOutcome.mutualAnnihilation,
+  );
+}
+
+int combatCasualtyCount({
+  required int unitCount,
+  required double lossFraction,
+}) {
+  return (unitCount * lossFraction).ceil().clamp(_minCasualtySlots, unitCount);
+}

--- a/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
@@ -10,6 +10,7 @@ import '../world/province_lookup.dart';
 import '../world/province_ownership_transfer.dart';
 import '../world/unit_lookup.dart';
 import 'battle_general_assignment.dart';
+import 'combat_loss_profile.dart';
 import 'conflict_detection.dart';
 import 'leader_bonus_helpers.dart';
 import 'military_strength.dart';
@@ -19,20 +20,6 @@ final _combatLog = packageLogger();
 const String kRecoveryUnitPrefix = 'recover_';
 const double kGarrisonRecoveryFraction = 0.2;
 const double kNoDefenderRatioFallback = 10.0;
-const double kStrongAttackerRatioThreshold = 1.5;
-const double kBluntAttackerVictoryUpperRatio = 4.0;
-const double kStrongDefenderRatioThreshold = 0.67;
-const double kAttackerEdgeRatioThreshold = 1.0;
-const double kBluntAttackerLossFraction = 0.6;
-const double kBluntDefenderLossFraction = 0.4;
-const double kStrongAttackerLossFraction = 0.15;
-const double kStrongDefenderLossFraction = 1.0;
-const double kStrongDefenderAttackerLossFraction = 1.0;
-const double kStrongDefenderDefenderLossFraction = 0.15;
-const double kAttackerEdgeAttackerLossFraction = 0.3;
-const double kAttackerEdgeDefenderLossFraction = 0.6;
-const double kDefaultAttackerLossFraction = 0.5;
-const double kDefaultDefenderLossFraction = 0.4;
 
 /// When feeding coverage is omitted for a faction, treat as full supply.
 const double kDefaultFeedingCoverageMultiplier = 1.0;
@@ -74,9 +61,6 @@ const int kInitiativeTieBreakRngUpperExclusive = 1 << 31;
 
 /// Cavalry share when an army lists no regiments (sort key only).
 const double kZeroCavalryShareWhenNoUnits = 0.0;
-
-/// Minimum casualty slots when applying fractional losses (obvious index floor).
-const int kMinCasualtySlots = 0;
 
 /// Result of one engagement. SPEC/game/combat.md.
 enum EngagementResult {
@@ -267,7 +251,6 @@ Game resolveBattleContext(
     ctx: ctx,
     allCasualties: allCasualties,
     unitsById: unitsById,
-    provinceOwnerId: provinceOwnerId,
     defenderFactionId: ctx.defenderFactionId,
     survivingAttackerFactionId: survivingAttackerFactionId,
     defenderUnitIds: defenderUnitIds,
@@ -486,7 +469,6 @@ Game _buildResolvedBattleGame({
   required BattleContext ctx,
   required Set<String> allCasualties,
   required Map<String, Unit> unitsById,
-  required String provinceOwnerId,
   required String defenderFactionId,
   required String? survivingAttackerFactionId,
   required List<String> defenderUnitIds,
@@ -496,13 +478,11 @@ Game _buildResolvedBattleGame({
       .toList();
 
   var updatedProvinces = region.provinces;
-  var ownerId = provinceOwnerId;
   var provinceChangedOwner = false;
   if (defenderUnitIds.isEmpty && survivingAttackerFactionId != null) {
     final idx = updatedProvinces.indexWhere((p) => p.id == ctx.provinceId);
     if (idx >= 0) {
       provinceChangedOwner = true;
-      ownerId = survivingAttackerFactionId;
     }
   }
 
@@ -678,55 +658,6 @@ EngagementOutcome resolveEngagement({
   );
 }
 
-({
-  double attLossFrac,
-  double defLossFrac,
-  bool bluntAttackerVictory,
-  EngagementResult bothDeadResult,
-})
-_lossFractionsForRatio(double ratio, bool attackerLowMorale) {
-  if (ratio >= kStrongAttackerRatioThreshold &&
-      attackerLowMorale &&
-      ratio < kBluntAttackerVictoryUpperRatio) {
-    return (
-      attLossFrac: kBluntAttackerLossFraction,
-      defLossFrac: kBluntDefenderLossFraction,
-      bluntAttackerVictory: true,
-      bothDeadResult: EngagementResult.mutualAnnihilation,
-    );
-  }
-  if (ratio >= kStrongAttackerRatioThreshold) {
-    return (
-      attLossFrac: kStrongAttackerLossFraction,
-      defLossFrac: kStrongDefenderLossFraction,
-      bluntAttackerVictory: false,
-      bothDeadResult: EngagementResult.attackerVictory,
-    );
-  }
-  if (ratio <= kStrongDefenderRatioThreshold) {
-    return (
-      attLossFrac: kStrongDefenderAttackerLossFraction,
-      defLossFrac: kStrongDefenderDefenderLossFraction,
-      bluntAttackerVictory: false,
-      bothDeadResult: EngagementResult.defenderVictory,
-    );
-  }
-  if (ratio >= kAttackerEdgeRatioThreshold) {
-    return (
-      attLossFrac: kAttackerEdgeAttackerLossFraction,
-      defLossFrac: kAttackerEdgeDefenderLossFraction,
-      bluntAttackerVictory: false,
-      bothDeadResult: EngagementResult.attackerVictory,
-    );
-  }
-  return (
-    attLossFrac: kDefaultAttackerLossFraction,
-    defLossFrac: kDefaultDefenderLossFraction,
-    bluntAttackerVictory: false,
-    bothDeadResult: EngagementResult.mutualAnnihilation,
-  );
-}
-
 EngagementOutcome _resolveByRatio({
   required double ratio,
   required bool attackerLowMorale,
@@ -735,17 +666,35 @@ EngagementOutcome _resolveByRatio({
   required double attStr,
   required double defStr,
 }) {
-  final frac = _lossFractionsForRatio(ratio, attackerLowMorale);
+  final profile = combatLossProfileForStrengthRatio(
+    attackerDefenderStrengthRatio: ratio,
+    attackerLowMorale: attackerLowMorale,
+  );
   return _buildOutcome(
     attackerUnits: attackerUnits,
     defenderUnits: defenderUnits,
-    attLossFrac: frac.attLossFrac,
-    defLossFrac: frac.defLossFrac,
+    attLossFrac: profile.attackerLossFraction,
+    defLossFrac: profile.defenderLossFraction,
     attStr: attStr,
     defStr: defStr,
-    bluntAttackerVictory: frac.bluntAttackerVictory,
-    bothDeadResult: frac.bothDeadResult,
+    bluntAttackerVictory: profile.bluntsAttackerVictory,
+    bothDeadResult: _engagementResultForMutualElimination(
+      profile.mutualEliminationOutcome,
+    ),
   );
+}
+
+EngagementResult _engagementResultForMutualElimination(
+  CombatMutualEliminationOutcome outcome,
+) {
+  return switch (outcome) {
+    CombatMutualEliminationOutcome.attackerVictory =>
+      EngagementResult.attackerVictory,
+    CombatMutualEliminationOutcome.defenderVictory =>
+      EngagementResult.defenderVictory,
+    CombatMutualEliminationOutcome.mutualAnnihilation =>
+      EngagementResult.mutualAnnihilation,
+  };
 }
 
 EngagementOutcome _buildOutcome({
@@ -758,13 +707,13 @@ EngagementOutcome _buildOutcome({
   bool bluntAttackerVictory = false,
   EngagementResult bothDeadResult = EngagementResult.mutualAnnihilation,
 }) {
-  final attLoss = (attackerUnits.length * attLossFrac).ceil().clamp(
-    kMinCasualtySlots,
-    attackerUnits.length,
+  final attLoss = combatCasualtyCount(
+    unitCount: attackerUnits.length,
+    lossFraction: attLossFrac,
   );
-  final defLoss = (defenderUnits.length * defLossFrac).ceil().clamp(
-    kMinCasualtySlots,
-    defenderUnits.length,
+  final defLoss = combatCasualtyCount(
+    unitCount: defenderUnits.length,
+    lossFraction: defLossFrac,
   );
 
   final attackerCasualties = [

--- a/packages/colonizethis_logic/test/combat_loss_profile_test.dart
+++ b/packages/colonizethis_logic/test/combat_loss_profile_test.dart
@@ -1,0 +1,82 @@
+import 'package:colonizethis_logic/src/combat/combat_loss_profile.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('combatLossProfileForStrengthRatio', () {
+    test('blunts strong attacker victory when attacker morale is lower', () {
+      final profile = combatLossProfileForStrengthRatio(
+        attackerDefenderStrengthRatio: 2,
+        attackerLowMorale: true,
+      );
+
+      expect(profile.attackerLossFraction, 0.6);
+      expect(profile.defenderLossFraction, 0.4);
+      expect(profile.bluntsAttackerVictory, isTrue);
+      expect(
+        profile.mutualEliminationOutcome,
+        CombatMutualEliminationOutcome.mutualAnnihilation,
+      );
+    });
+
+    test('uses decisive attacker band at the blunt upper bound', () {
+      final profile = combatLossProfileForStrengthRatio(
+        attackerDefenderStrengthRatio: 4,
+        attackerLowMorale: true,
+      );
+
+      expect(profile.attackerLossFraction, 0.15);
+      expect(profile.defenderLossFraction, 1.0);
+      expect(profile.bluntsAttackerVictory, isFalse);
+      expect(
+        profile.mutualEliminationOutcome,
+        CombatMutualEliminationOutcome.attackerVictory,
+      );
+    });
+
+    test('keeps exact ratio thresholds in the documented bands', () {
+      final attackerEdge = combatLossProfileForStrengthRatio(
+        attackerDefenderStrengthRatio: 1,
+        attackerLowMorale: false,
+      );
+      final strongAttacker = combatLossProfileForStrengthRatio(
+        attackerDefenderStrengthRatio: 1.5,
+        attackerLowMorale: false,
+      );
+      final strongDefender = combatLossProfileForStrengthRatio(
+        attackerDefenderStrengthRatio: 0.67,
+        attackerLowMorale: false,
+      );
+
+      expect(attackerEdge.attackerLossFraction, 0.3);
+      expect(attackerEdge.defenderLossFraction, 0.6);
+      expect(strongAttacker.attackerLossFraction, 0.15);
+      expect(strongAttacker.defenderLossFraction, 1.0);
+      expect(strongDefender.attackerLossFraction, 1.0);
+      expect(strongDefender.defenderLossFraction, 0.15);
+    });
+
+    test('uses default close-fight profile below attacker edge', () {
+      final profile = combatLossProfileForStrengthRatio(
+        attackerDefenderStrengthRatio: 0.9,
+        attackerLowMorale: false,
+      );
+
+      expect(profile.attackerLossFraction, 0.5);
+      expect(profile.defenderLossFraction, 0.4);
+      expect(profile.bluntsAttackerVictory, isFalse);
+      expect(
+        profile.mutualEliminationOutcome,
+        CombatMutualEliminationOutcome.mutualAnnihilation,
+      );
+    });
+  });
+
+  group('combatCasualtyCount', () {
+    test('rounds fractional losses up and clamps to available units', () {
+      expect(combatCasualtyCount(unitCount: 3, lossFraction: 0.15), 1);
+      expect(combatCasualtyCount(unitCount: 5, lossFraction: 0), 0);
+      expect(combatCasualtyCount(unitCount: 2, lossFraction: 1.5), 2);
+      expect(combatCasualtyCount(unitCount: 0, lossFraction: 0.6), 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase **D** slice for #2178: extract auto-resolve combat ratio/loss-band selection and casualty count rounding from `combat_resolver.dart` into a dedicated pure helper module.

Refs #2178

## Implemented in this PR

- Added `combat_loss_profile.dart` for deterministic auto-resolve loss profile selection:
  - strong attacker / strong defender / attacker-edge / close-fight ratio bands
  - lower-attacker-morale blunted attacker-victory branch
  - mutual-elimination outcome metadata for the resolver to map back to `EngagementResult`
- Updated `resolveEngagement` internals to delegate loss profile lookup and casualty-count rounding to the new helper without changing public combat behavior.
- Removed an unused ownership-tracking local/parameter inside the touched resolver helper while preserving the existing canonical ownership-transfer path.
- Added direct unit tests for exact ratio thresholds, blunted victory ordering, default close-fight behavior, and casualty rounding/clamping.

## Deferred (same issue)

- Further `naval_resolution.dart` decomposition toward the line-count/split target.
- Additional `fog_resolution.dart` decomposition beyond merged #2181.
- Additional `connectivity_resolver.dart` decomposition beyond merged #2182.
- Broader combat resolver decomposition beyond this loss-profile slice.

## AC coverage (this slice)

| #2178 AC | Status |
|----------|--------|
| Canonical at-war adjacency API dedupe | Already merged in #2179 |
| `naval_resolution.dart` decomposition | Deferred |
| `fog_resolution.dart` helper extractions | Partial in #2181 |
| `connectivity_resolver.dart`: extracted, tested unit | Already merged in #2182 |
| Combat extracted pure module + tests | **Covered in this PR** |
| `dart test packages/colonizethis_logic/test` green with policy threshold maintained | **Covered in this PR run** |

## Tests

- `cd packages/colonizethis_logic && dart test test/combat_loss_profile_test.dart && dart test test/combat_resolver_test_part1_test.dart test/characterization/combat_engagement_snapshot_test.dart && dart test`
- `cd packages/colonizethis_logic && dart test test/combat_loss_profile_test.dart && dart test`
- `cd packages/colonizethis_logic && dart test --coverage=coverage -j 4 --reporter=compact && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=. && ../../tool/check_coverage_threshold.sh 90 packages/colonizethis_logic` *(tests and LCOV generation passed; threshold script could not run because local `lcov` binary is missing)*
- Parsed generated `coverage/lcov.info`: `colonizethis_logic` line coverage `10777/11883` = `90.69%`.
- `cd packages/colonizethis_logic && dart analyze` *(reports existing warnings/infos; no touched-file warning remains)*

Made with [Cursor](https://cursor.com)


**Coordination:** Order/region refactor work is tracked in #2149; this PR remains scoped to #2178 (naval/fog/connectivity/combat seams) per that issue non-goals.
