### PR TITLE
refactor(logic): extract naval coastal visibility helpers (#2178 Phase B slice)

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/naval_coastal_visibility.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_coastal_visibility.dart
@@ -1,0 +1,191 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'naval.dart';
+import 'player_view.dart';
+import 'province_lookup.dart' show toFullProvinceId;
+import 'sea_zone_identity.dart';
+import 'tile_key_coordinates.dart';
+
+({int x, int y})? _xyFromTileKey(String tileKey) {
+  final coords = parseTileKeyCoordinates(tileKey);
+  if (coords == null) return null;
+  return (x: coords.x, y: coords.y);
+}
+
+/// Canonical key used for sea-zone buckets in
+/// `tileKeysByRegionAndProvince[regionId][bucketKey]`.
+///
+/// Buckets must be keyed by prefixed sea-zone id (`regionId|localSeaId`) so
+/// topology ids from both per-region and combined topologies resolve through one
+/// contract.
+String canonicalSeaZoneTileBucketKey(
+  String regionId,
+  String seaZoneTopologyId,
+) => canonicalizeSeaZoneId(regionId: regionId, seaZoneId: seaZoneTopologyId);
+
+/// [tileKeysByRegionAndProvince] normally keys land provinces by full id
+/// (`regionId|localId`); some fixtures or legacy maps key by **local** id only.
+/// Ship reveal and dock visibility must resolve tiles using whichever bucket exists.
+List<String> landTileKeysForProvinceBucket(
+  WorldState ws,
+  String regionId,
+  String fullProvinceId,
+) {
+  final byProv = ws.tileKeysByRegionAndProvince[regionId];
+  if (byProv == null) return const [];
+  final byFull = byProv[fullProvinceId];
+  if (byFull != null && byFull.isNotEmpty) {
+    return byFull;
+  }
+  final localId = ProvinceId.localIdFrom(fullProvinceId);
+  return byProv[localId] ?? const [];
+}
+
+Set<String> _coastalTileKeysAdjacentToSeaZone({
+  required List<String> provinceTileKeys,
+  required List<String> seaWaterTileKeys,
+}) {
+  if (provinceTileKeys.isEmpty || seaWaterTileKeys.isEmpty) return const {};
+  final seaCoords = <String>{};
+  for (final seaTileKey in seaWaterTileKeys) {
+    final xy = _xyFromTileKey(seaTileKey);
+    if (xy == null) continue;
+    seaCoords.add('${xy.x}|${xy.y}');
+  }
+  if (seaCoords.isEmpty) return const {};
+  final coastal = <String>{};
+  const deltas = [(0, -1), (1, 0), (0, 1), (-1, 0)];
+  for (final provinceTileKey in provinceTileKeys) {
+    final xy = _xyFromTileKey(provinceTileKey);
+    if (xy == null) continue;
+    final isCoastal = deltas.any(
+      (delta) => seaCoords.contains('${xy.x + delta.$1}|${xy.y + delta.$2}'),
+    );
+    if (isCoastal) coastal.add(provinceTileKey);
+  }
+  return coastal;
+}
+
+/// Returns a new visibility map with all land tiles for [fullProvinceId]
+/// upgraded to [VisibilityLevel.fullyVisible] for [playerId]. Returns
+/// [visibilityByTile] unchanged when the province has no land tile bucket.
+Map<String, Map<String, String>> revealProvinceTilesForPlayer(
+  Game game,
+  Map<String, Map<String, String>> visibilityByTile,
+  String playerId,
+  String fullProvinceId,
+) {
+  final regionId = ProvinceId.regionIdFrom(fullProvinceId);
+  final tileKeys = landTileKeysForProvinceBucket(
+    game.worldState,
+    regionId,
+    fullProvinceId,
+  );
+  if (tileKeys.isEmpty) return visibilityByTile;
+  final vis = Map<String, String>.from(visibilityByTile[playerId] ?? {});
+  for (final tk in tileKeys) {
+    vis[tk] = VisibilityLevel.fullyVisible.name;
+  }
+  return Map<String, Map<String, String>>.from(visibilityByTile)
+    ..[playerId] = vis;
+}
+
+/// Returns a new visibility map with sea water tiles in [destZoneId] and the
+/// coastal land tiles of provinces adjacent to it set to
+/// [VisibilityLevel.fullyVisible] for [playerId].
+///
+/// Requires [provinceIdsAdjacentToSeaZone] (from `naval.dart`) for the
+/// region+sea-zone topology lookup.
+Map<String, Map<String, String>> revealTilesAfterMoveToSeaZone({
+  required Game game,
+  required MapTopology topology,
+  required Map<String, Map<String, String>> visibilityByTile,
+  required String playerId,
+  required String destRegionId,
+  required String destZoneId,
+}) {
+  final provinceIds = provinceIdsAdjacentToSeaZone(
+    topology,
+    destZoneId,
+    regionId: destRegionId,
+  );
+  final vis = Map<String, String>.from(visibilityByTile[playerId] ?? {});
+  final seaZoneKeyForTiles = canonicalSeaZoneTileBucketKey(
+    destRegionId,
+    destZoneId,
+  );
+  final seaWaterKeys = game
+      .worldState
+      .tileKeysByRegionAndProvince[destRegionId]?[seaZoneKeyForTiles];
+  for (final provinceNodeId in provinceIds) {
+    final fullProvinceId = toFullProvinceId(destRegionId, provinceNodeId);
+    final provinceTileKeys = landTileKeysForProvinceBucket(
+      game.worldState,
+      destRegionId,
+      fullProvinceId,
+    );
+    final coastalTileKeys = _coastalTileKeysAdjacentToSeaZone(
+      provinceTileKeys: provinceTileKeys,
+      seaWaterTileKeys: seaWaterKeys ?? const [],
+    );
+    for (final tk in coastalTileKeys) {
+      vis[tk] = VisibilityLevel.fullyVisible.name;
+    }
+  }
+  if (seaWaterKeys != null) {
+    for (final tk in seaWaterKeys) {
+      vis[tk] = VisibilityLevel.fullyVisible.name;
+    }
+  }
+  return Map<String, Map<String, String>>.from(visibilityByTile)
+    ..[playerId] = vis;
+}
+
+/// Land tile keys orthogonally adjacent to water in sea zones where [playerId]
+/// has a non–home fleet **at sea**. Same geometry as ship reveal in
+/// [revealTilesAfterMoveToSeaZone]; used so fog decay does not strip that
+/// coastal intel while the fleet remains offshore.
+Set<String> coastalLandTileKeysFromNavalPresenceAtSea(
+  Game game,
+  MapTopology topology,
+  String playerId,
+) {
+  final out = <String>{};
+  final ws = game.worldState;
+  final homeFleetId = homeFleetIdFor(playerId);
+  for (final f in ws.fleets) {
+    if (f.ownerId != playerId) continue;
+    if (f.id == homeFleetId) continue;
+    if (!f.isAtSea || f.seaZoneId == null) continue;
+    final destRegionId = f.regionId;
+    final destZoneId = f.seaZoneId!;
+    final provinceIds = provinceIdsAdjacentToSeaZone(
+      topology,
+      destZoneId,
+      regionId: destRegionId,
+    );
+    final seaZoneKeyForTiles = canonicalSeaZoneTileBucketKey(
+      destRegionId,
+      destZoneId,
+    );
+    final seaWaterKeys =
+        ws.tileKeysByRegionAndProvince[destRegionId]?[seaZoneKeyForTiles] ??
+        const <String>[];
+    for (final provinceNodeId in provinceIds) {
+      final fullProvinceId = toFullProvinceId(destRegionId, provinceNodeId);
+      final provinceTileKeys = landTileKeysForProvinceBucket(
+        ws,
+        destRegionId,
+        fullProvinceId,
+      );
+      out.addAll(
+        _coastalTileKeysAdjacentToSeaZone(
+          provinceTileKeys: provinceTileKeys,
+          seaWaterTileKeys: seaWaterKeys,
+        ),
+      );
+    }
+  }
+  return out;
+}

--- a/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
@@ -11,94 +11,19 @@ import '../event_bus/game_event_bus.dart';
 import '../game_events.dart';
 import '../turn/turn_seed_constants.dart';
 import 'naval.dart';
-import 'player_view.dart';
-import 'province_lookup.dart';
-import 'sea_zone_identity.dart';
-import 'tile_key_coordinates.dart';
+import 'naval_coastal_visibility.dart';
+import 'province_lookup.dart' hide landTileKeysForProvinceBucket;
 import 'topology_helpers.dart';
 
+export 'naval_coastal_visibility.dart'
+    show
+        canonicalSeaZoneTileBucketKey,
+        coastalLandTileKeysFromNavalPresenceAtSea,
+        landTileKeysForProvinceBucket,
+        revealProvinceTilesForPlayer,
+        revealTilesAfterMoveToSeaZone;
+
 final _log = packageLogger();
-
-({int x, int y})? _xyFromTileKey(String tileKey) {
-  final coords = parseTileKeyCoordinates(tileKey);
-  if (coords == null) return null;
-  return (x: coords.x, y: coords.y);
-}
-
-/// Canonical key used for sea-zone buckets in
-/// `tileKeysByRegionAndProvince[regionId][bucketKey]`.
-///
-/// Buckets must be keyed by prefixed sea-zone id (`regionId|localSeaId`) so
-/// topology ids from both per-region and combined topologies resolve through one
-/// contract.
-String canonicalSeaZoneTileBucketKey(
-  String regionId,
-  String seaZoneTopologyId,
-) => canonicalizeSeaZoneId(regionId: regionId, seaZoneId: seaZoneTopologyId);
-
-/// [tileKeysByRegionAndProvince] normally keys land provinces by full id
-/// (`regionId|localId`); some fixtures or legacy maps key by **local** id only.
-/// Ship reveal and dock visibility must resolve tiles using whichever bucket exists.
-List<String> landTileKeysForProvinceBucket(
-  WorldState ws,
-  String regionId,
-  String fullProvinceId,
-) {
-  final byProv = ws.tileKeysByRegionAndProvince[regionId];
-  if (byProv == null) return const [];
-  final byFull = byProv[fullProvinceId];
-  if (byFull != null && byFull.isNotEmpty) {
-    return byFull;
-  }
-  final localId = ProvinceId.localIdFrom(fullProvinceId);
-  return byProv[localId] ?? const [];
-}
-
-Set<String> _coastalTileKeysAdjacentToSeaZone({
-  required List<String> provinceTileKeys,
-  required List<String> seaWaterTileKeys,
-}) {
-  if (provinceTileKeys.isEmpty || seaWaterTileKeys.isEmpty) return const {};
-  final seaCoords = <String>{};
-  for (final seaTileKey in seaWaterTileKeys) {
-    final xy = _xyFromTileKey(seaTileKey);
-    if (xy == null) continue;
-    seaCoords.add('${xy.x}|${xy.y}');
-  }
-  if (seaCoords.isEmpty) return const {};
-  final coastal = <String>{};
-  const deltas = [(0, -1), (1, 0), (0, 1), (-1, 0)];
-  for (final provinceTileKey in provinceTileKeys) {
-    final xy = _xyFromTileKey(provinceTileKey);
-    if (xy == null) continue;
-    final isCoastal = deltas.any(
-      (delta) => seaCoords.contains('${xy.x + delta.$1}|${xy.y + delta.$2}'),
-    );
-    if (isCoastal) coastal.add(provinceTileKey);
-  }
-  return coastal;
-}
-
-Map<String, Map<String, String>> _revealProvinceTilesForPlayer(
-  Game game,
-  Map<String, Map<String, String>> visibilityByTile,
-  String playerId,
-  String fullProvinceId,
-) {
-  final regionId = ProvinceId.regionIdFrom(fullProvinceId);
-  final tileKeys = landTileKeysForProvinceBucket(
-    game.worldState,
-    regionId,
-    fullProvinceId,
-  );
-  if (tileKeys.isEmpty) return visibilityByTile;
-  final vis = Map<String, String>.from(visibilityByTile[playerId] ?? {});
-  for (final tk in tileKeys) {
-    vis[tk] = VisibilityLevel.fullyVisible.name;
-  }
-  return Map<String, Map<String, String>>.from(visibilityByTile)
-    ..[playerId] = vis;
-}
 
 List<String> _adjacentSeaZones(MapTopology topology, String seaZoneId) {
   final out = <String>[];
@@ -293,51 +218,6 @@ bool _navalMoveDestinationIsReachable({
   ).contains(destZoneId);
 }
 
-Map<String, Map<String, String>> _revealTilesAfterMoveToSeaZone({
-  required Game game,
-  required MapTopology topology,
-  required Map<String, Map<String, String>> visibilityByTile,
-  required String playerId,
-  required String destRegionId,
-  required String destZoneId,
-}) {
-  final provinceIds = provinceIdsAdjacentToSeaZone(
-    topology,
-    destZoneId,
-    regionId: destRegionId,
-  );
-  final vis = Map<String, String>.from(visibilityByTile[playerId] ?? {});
-  final seaZoneKeyForTiles = canonicalSeaZoneTileBucketKey(
-    destRegionId,
-    destZoneId,
-  );
-  final seaWaterKeys = game
-      .worldState
-      .tileKeysByRegionAndProvince[destRegionId]?[seaZoneKeyForTiles];
-  for (final provinceNodeId in provinceIds) {
-    final fullProvinceId = toFullProvinceId(destRegionId, provinceNodeId);
-    final provinceTileKeys = landTileKeysForProvinceBucket(
-      game.worldState,
-      destRegionId,
-      fullProvinceId,
-    );
-    final coastalTileKeys = _coastalTileKeysAdjacentToSeaZone(
-      provinceTileKeys: provinceTileKeys,
-      seaWaterTileKeys: seaWaterKeys ?? const [],
-    );
-    for (final tk in coastalTileKeys) {
-      vis[tk] = VisibilityLevel.fullyVisible.name;
-    }
-  }
-  if (seaWaterKeys != null) {
-    for (final tk in seaWaterKeys) {
-      vis[tk] = VisibilityLevel.fullyVisible.name;
-    }
-  }
-  return Map<String, Map<String, String>>.from(visibilityByTile)
-    ..[playerId] = vis;
-}
-
 ({
   List<Fleet> fleets,
   Map<String, Fleet> fleetById,
@@ -383,7 +263,7 @@ _applyDockNavalMoveOrder({
     );
   }
 
-  var nextVis = _revealProvinceTilesForPlayer(
+  var nextVis = revealProvinceTilesForPlayer(
     game,
     visibilityByTile,
     playerId,
@@ -507,7 +387,7 @@ _applySeaNavalMoveOrder({
 
   var nextVis = visibilityByTile;
   if (destRegionId != null) {
-    nextVis = _revealTilesAfterMoveToSeaZone(
+    nextVis = revealTilesAfterMoveToSeaZone(
       game: game,
       topology: topology,
       visibilityByTile: nextVis,
@@ -577,53 +457,6 @@ Game applyNavalMovesAndShipReveal(
       playerVisibilityByTile: visibilityByTile,
     ),
   );
-}
-
-/// Land tile keys orthogonally adjacent to water in sea zones where [playerId] has
-/// a non–home fleet **at sea**. Same geometry as ship reveal in this file; used so
-/// [applyFogDecay] does not strip that coastal intel while the fleet remains offshore.
-Set<String> coastalLandTileKeysFromNavalPresenceAtSea(
-  Game game,
-  MapTopology topology,
-  String playerId,
-) {
-  final out = <String>{};
-  final ws = game.worldState;
-  final homeFleetId = homeFleetIdFor(playerId);
-  for (final f in ws.fleets) {
-    if (f.ownerId != playerId) continue;
-    if (f.id == homeFleetId) continue;
-    if (!f.isAtSea || f.seaZoneId == null) continue;
-    final destRegionId = f.regionId;
-    final destZoneId = f.seaZoneId!;
-    final provinceIds = provinceIdsAdjacentToSeaZone(
-      topology,
-      destZoneId,
-      regionId: destRegionId,
-    );
-    final seaZoneKeyForTiles = canonicalSeaZoneTileBucketKey(
-      destRegionId,
-      destZoneId,
-    );
-    final seaWaterKeys =
-        ws.tileKeysByRegionAndProvince[destRegionId]?[seaZoneKeyForTiles] ??
-        const <String>[];
-    for (final provinceNodeId in provinceIds) {
-      final fullProvinceId = toFullProvinceId(destRegionId, provinceNodeId);
-      final provinceTileKeys = landTileKeysForProvinceBucket(
-        ws,
-        destRegionId,
-        fullProvinceId,
-      );
-      out.addAll(
-        _coastalTileKeysAdjacentToSeaZone(
-          provinceTileKeys: provinceTileKeys,
-          seaWaterTileKeys: seaWaterKeys,
-        ),
-      );
-    }
-  }
-  return out;
 }
 
 String? _navalBattleWinnerOwnerId(

--- a/packages/colonizethis_logic/test/naval_coastal_visibility_test.dart
+++ b/packages/colonizethis_logic/test/naval_coastal_visibility_test.dart
@@ -1,0 +1,340 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/src/world/naval_coastal_visibility.dart';
+import 'package:colonizethis_logic/src/world/player_view.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  const ow = 'oldWorld';
+  const player = 'a';
+  const enemy = 'b';
+  const fullPid = '$ow|p1';
+
+  Game gameWithBuckets({
+    Map<String, Map<String, List<String>>>?
+    tileKeysByRegionAndProvince,
+    List<Fleet> fleets = const [],
+    List<Province> oldWorldProvinces = const [],
+  }) {
+    return Game(
+      id: 'test_game',
+      worldState: WorldState(
+        turnState: const TurnState(turnNumber: 1, phase: TurnPhase.orders),
+        oldWorld: RegionData(provinces: oldWorldProvinces),
+        newWorld: const RegionData(),
+        fleets: fleets,
+        tileKeysByRegionAndProvince:
+            tileKeysByRegionAndProvince ?? const {},
+      ),
+      players: const [Player(id: player, displayName: 'A', isHuman: true)],
+    );
+  }
+
+  group('canonicalSeaZoneTileBucketKey', () {
+    test('builds a prefixed bucket key from a local sea-zone id', () {
+      expect(
+        canonicalSeaZoneTileBucketKey(ow, 'sea1'),
+        '$ow|sea1',
+      );
+    });
+
+    test('returns the input unchanged when already prefixed for region', () {
+      expect(
+        canonicalSeaZoneTileBucketKey(ow, '$ow|sea1'),
+        '$ow|sea1',
+      );
+    });
+  });
+
+  group('landTileKeysForProvinceBucket', () {
+    test('returns the full-id bucket when present', () {
+      final ws = WorldState(
+        turnState: const TurnState(turnNumber: 1, phase: TurnPhase.orders),
+        oldWorld: const RegionData(),
+        newWorld: const RegionData(),
+        tileKeysByRegionAndProvince: const {
+          ow: {
+            fullPid: ['$ow|p1|0|0', '$ow|p1|1|0'],
+          },
+        },
+      );
+
+      expect(
+        landTileKeysForProvinceBucket(ws, ow, fullPid),
+        ['$ow|p1|0|0', '$ow|p1|1|0'],
+      );
+    });
+
+    test('falls back to the local-id bucket when full-id bucket is missing', () {
+      final ws = WorldState(
+        turnState: const TurnState(turnNumber: 1, phase: TurnPhase.orders),
+        oldWorld: const RegionData(),
+        newWorld: const RegionData(),
+        tileKeysByRegionAndProvince: const {
+          ow: {
+            'p1': ['$ow|p1|0|0'],
+          },
+        },
+      );
+
+      expect(landTileKeysForProvinceBucket(ws, ow, fullPid), ['$ow|p1|0|0']);
+    });
+
+    test('returns empty when neither full nor local bucket exists', () {
+      final ws = WorldState(
+        turnState: const TurnState(turnNumber: 1, phase: TurnPhase.orders),
+        oldWorld: const RegionData(),
+        newWorld: const RegionData(),
+        tileKeysByRegionAndProvince: const {ow: {}},
+      );
+
+      expect(landTileKeysForProvinceBucket(ws, ow, fullPid), isEmpty);
+    });
+  });
+
+  group('revealProvinceTilesForPlayer', () {
+    test('upgrades all province land tiles to fullyVisible for the player', () {
+      final game = gameWithBuckets(
+        tileKeysByRegionAndProvince: const {
+          ow: {
+            fullPid: ['$ow|p1|0|0', '$ow|p1|1|0'],
+          },
+        },
+      );
+
+      final out = revealProvinceTilesForPlayer(
+        game,
+        const <String, Map<String, String>>{},
+        player,
+        fullPid,
+      );
+
+      expect(out[player]!['$ow|p1|0|0'], VisibilityLevel.fullyVisible.name);
+      expect(out[player]!['$ow|p1|1|0'], VisibilityLevel.fullyVisible.name);
+    });
+
+    test('returns the original visibility map when province has no tiles', () {
+      final game = gameWithBuckets();
+      final initial = <String, Map<String, String>>{
+        player: {'unrelated': VisibilityLevel.fogged.name},
+      };
+
+      final out = revealProvinceTilesForPlayer(game, initial, player, fullPid);
+
+      expect(identical(out, initial), isTrue);
+    });
+
+    test('does not modify visibility for other players', () {
+      final game = gameWithBuckets(
+        tileKeysByRegionAndProvince: const {
+          ow: {
+            fullPid: ['$ow|p1|0|0'],
+          },
+        },
+      );
+      final initial = <String, Map<String, String>>{
+        enemy: {'$ow|p1|0|0': VisibilityLevel.fogged.name},
+      };
+
+      final out = revealProvinceTilesForPlayer(game, initial, player, fullPid);
+
+      expect(out[player]!['$ow|p1|0|0'], VisibilityLevel.fullyVisible.name);
+      expect(out[enemy]!['$ow|p1|0|0'], VisibilityLevel.fogged.name);
+    });
+  });
+
+  group('revealTilesAfterMoveToSeaZone', () {
+    final topology = MapTopology(
+      nodes: const [
+        TopologyNode(
+          id: 'p1',
+          regionId: ow,
+          type: TopologyNodeType.province,
+        ),
+        TopologyNode(
+          id: 'sea1',
+          regionId: ow,
+          type: TopologyNodeType.seaZone,
+        ),
+      ],
+      edges: const [TopologyEdge(id1: 'sea1', id2: 'p1')],
+    );
+
+    test('reveals coastal land tiles and all sea water tiles in the zone', () {
+      final game = gameWithBuckets(
+        tileKeysByRegionAndProvince: const {
+          ow: {
+            fullPid: ['$ow|p1|0|0', '$ow|p1|2|2'],
+            '$ow|sea1': ['$ow|sea1|1|0'],
+          },
+        },
+      );
+
+      final out = revealTilesAfterMoveToSeaZone(
+        game: game,
+        topology: topology,
+        visibilityByTile: const {},
+        playerId: player,
+        destRegionId: ow,
+        destZoneId: 'sea1',
+      );
+
+      expect(out[player]!['$ow|p1|0|0'], VisibilityLevel.fullyVisible.name);
+      expect(out[player]!['$ow|sea1|1|0'], VisibilityLevel.fullyVisible.name);
+      expect(out[player]!.containsKey('$ow|p1|2|2'), isFalse);
+    });
+
+    test('returns visibility unchanged when sea zone has no tile bucket', () {
+      final game = gameWithBuckets(
+        tileKeysByRegionAndProvince: const {
+          ow: {
+            fullPid: ['$ow|p1|0|0'],
+          },
+        },
+      );
+
+      final out = revealTilesAfterMoveToSeaZone(
+        game: game,
+        topology: topology,
+        visibilityByTile: const {},
+        playerId: player,
+        destRegionId: ow,
+        destZoneId: 'sea1',
+      );
+
+      expect(out[player] ?? const {}, isEmpty);
+    });
+  });
+
+  group('coastalLandTileKeysFromNavalPresenceAtSea', () {
+    final topology = MapTopology(
+      nodes: const [
+        TopologyNode(
+          id: 'p1',
+          regionId: ow,
+          type: TopologyNodeType.province,
+        ),
+        TopologyNode(
+          id: 'sea1',
+          regionId: ow,
+          type: TopologyNodeType.seaZone,
+        ),
+      ],
+      edges: const [TopologyEdge(id1: 'sea1', id2: 'p1')],
+    );
+
+    test('returns coastal tiles for non-home fleets at sea owned by player', () {
+      final game = gameWithBuckets(
+        fleets: [
+          Fleet(
+            id: 'fleet_${player}_scout',
+            ownerId: player,
+            seaZoneId: 'sea1',
+            regionId: ow,
+            shipTypeIds: const ['carrack'],
+          ),
+        ],
+        tileKeysByRegionAndProvince: const {
+          ow: {
+            fullPid: ['$ow|p1|0|0', '$ow|p1|2|2'],
+            '$ow|sea1': ['$ow|sea1|1|0'],
+          },
+        },
+      );
+
+      final out = coastalLandTileKeysFromNavalPresenceAtSea(
+        game,
+        topology,
+        player,
+      );
+
+      expect(out, contains('$ow|p1|0|0'));
+      expect(out.contains('$ow|p1|2|2'), isFalse);
+    });
+
+    test('ignores the home fleet even when it carries ships at sea', () {
+      final game = gameWithBuckets(
+        fleets: [
+          Fleet(
+            id: 'fleet_$player',
+            ownerId: player,
+            seaZoneId: 'sea1',
+            regionId: ow,
+            shipTypeIds: const ['carrack'],
+          ),
+        ],
+        tileKeysByRegionAndProvince: const {
+          ow: {
+            fullPid: ['$ow|p1|0|0'],
+            '$ow|sea1': ['$ow|sea1|1|0'],
+          },
+        },
+      );
+
+      final out = coastalLandTileKeysFromNavalPresenceAtSea(
+        game,
+        topology,
+        player,
+      );
+
+      expect(out, isEmpty);
+    });
+
+    test('ignores fleets owned by other players', () {
+      final game = gameWithBuckets(
+        fleets: [
+          Fleet(
+            id: 'fleet_${enemy}_scout',
+            ownerId: enemy,
+            seaZoneId: 'sea1',
+            regionId: ow,
+            shipTypeIds: const ['carrack'],
+          ),
+        ],
+        tileKeysByRegionAndProvince: const {
+          ow: {
+            fullPid: ['$ow|p1|0|0'],
+            '$ow|sea1': ['$ow|sea1|1|0'],
+          },
+        },
+      );
+
+      final out = coastalLandTileKeysFromNavalPresenceAtSea(
+        game,
+        topology,
+        player,
+      );
+
+      expect(out, isEmpty);
+    });
+
+    test('ignores docked fleets (not at sea)', () {
+      final game = gameWithBuckets(
+        fleets: [
+          Fleet(
+            id: 'fleet_${player}_scout',
+            ownerId: player,
+            seaZoneId: null,
+            inPortAtProvinceId: fullPid,
+            regionId: ow,
+            shipTypeIds: const ['carrack'],
+          ),
+        ],
+        tileKeysByRegionAndProvince: const {
+          ow: {
+            fullPid: ['$ow|p1|0|0'],
+            '$ow|sea1': ['$ow|sea1|1|0'],
+          },
+        },
+      );
+
+      final out = coastalLandTileKeysFromNavalPresenceAtSea(
+        game,
+        topology,
+        player,
+      );
+
+      expect(out, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase **B** (naval) decomposition slice for #2178: extract reusable naval coastal visibility helpers from `naval_resolution.dart` into a dedicated `naval_coastal_visibility.dart` module.

Refs #2178

## Implemented in this PR

- New `lib/src/world/naval_coastal_visibility.dart` with:
  - `canonicalSeaZoneTileBucketKey` — canonical sea-zone bucket key contract.
  - `landTileKeysForProvinceBucket` — full-id bucket lookup with local-id fallback semantics, distinct from the canonical `province_lookup.dart` helper.
  - `revealProvinceTilesForPlayer` — former private reveal helper, now public for naval and dock-move pipelines.
  - `revealTilesAfterMoveToSeaZone` — former private reveal helper, now public for naval move pipelines.
  - `coastalLandTileKeysFromNavalPresenceAtSea` — fog-decay-aware coastal intel from non-home fleets at sea.
  - Private `_xyFromTileKey` and `_coastalTileKeysAdjacentToSeaZone` geometry helpers, kept file-scoped.
- `naval_resolution.dart` now imports the new file and re-exports the public symbols so existing callers (fog resolution, naval tests) keep working without changes.
- Internal call sites in `naval_resolution.dart` now call the new public reveal helpers.

Public API surface from `package:colonizethis_logic/src/world/naval_resolution.dart` is preserved (re-export).

## Deferred (same issue)

- Further `naval_resolution.dart` decomposition toward the AC ≤ ~450 line target (currently 625 lines after this slice; 791 → 625 is a 21% reduction). Remaining clusters: naval mission orders pipeline, naval move/dock orders pipeline, and naval interception combat phase.
- Broader combat resolver decomposition beyond the loss-profile slice already merged in #2183.

## #2178 AC coverage (this slice)

| #2178 AC | Status |
|----------|--------|
| Canonical at-war adjacency API dedupe | Already merged in #2179 |
| `naval_resolution.dart` decomposed into ≥2 cohesive library files | **Covered in this PR** (≥2 cohesive files achieved; line-count target deferred) |
| `fog_resolution.dart` ≥2 unit-tested helpers | Already partial in #2181 |
| `connectivity_resolver.dart`: ≥1 extracted, tested unit | Already merged in #2182 |
| Combat extracted pure module + tests | Already merged in #2183 |
| `dart test packages/colonizethis_logic/test` green with policy threshold maintained | **Covered in this PR run** |

## Tests

- `cd packages/colonizethis_logic && dart test test/naval_coastal_visibility_test.dart` — 14 new direct unit tests, all green.
- `cd packages/colonizethis_logic && dart test test/naval_test_part1_test.dart test/naval_test_part2_test.dart test/naval_behavior_scenarios_test.dart` — existing naval suites pass without modification.
- `cd packages/colonizethis_logic && dart test test/fog_resolution_test.dart` — existing fog suite passes via re-exported symbols.
- `cd packages/colonizethis_logic && dart test` — full logic test suite (1353 tests) green.
- `cd packages/colonizethis_logic && dart analyze --fatal-warnings lib/src/world/naval_resolution.dart lib/src/world/naval_coastal_visibility.dart lib/src/world/fog_resolution.dart test/naval_coastal_visibility_test.dart` — clean.

Made with [Cursor](https://cursor.com)


**Coordination:** Order/region refactor work is tracked in #2149; this PR remains scoped to #2178 (naval/fog/connectivity/combat seams) per that issue non-goals.
