### PR TITLE
Refactor duplicated tech and commodity UI helpers (slice for #2180)

### DIFF
--- a/app/lib/features/game/production_recipe_affordance.dart
+++ b/app/lib/features/game/production_recipe_affordance.dart
@@ -1,6 +1,8 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'utils/commodity_ui_helpers.dart';
+
 /// Maximum desired output the production panel slider allows per recipe.
 /// SPEC/ui/production-panel.md
 const int kProductionAllocationSliderCap = 50;
@@ -65,11 +67,6 @@ Map<String, int> _remainingStockByCommodity({
   return remaining;
 }
 
-String _commodityDisplayName(String commodityId) {
-  final c = CommodityCatalog.byId[commodityId];
-  return c?.displayName ?? commodityId;
-}
-
 /// Computes max desired output and bottleneck label for [recipe].
 ///
 /// Uses current stockpile minus inputs committed by **other** recipes'
@@ -127,7 +124,7 @@ RecipeAffordance computeRecipeAffordance({
     }
     final runs = runsPerInput[entry.key] ?? 0;
     if (runs == trueMax) {
-      limitingLabel = _commodityDisplayName(entry.key);
+      limitingLabel = commodityDisplayName(entry.key);
       break;
     }
   }

--- a/app/lib/features/game/utils/commodity_ui_helpers.dart
+++ b/app/lib/features/game/utils/commodity_ui_helpers.dart
@@ -1,0 +1,5 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+
+String commodityDisplayName(String commodityId) {
+  return CommodityCatalog.byId[commodityId]?.displayName ?? commodityId;
+}

--- a/app/lib/features/game/utils/tech_ui_helpers.dart
+++ b/app/lib/features/game/utils/tech_ui_helpers.dart
@@ -1,0 +1,20 @@
+import '../../../l10n/l10n.dart';
+
+String eraRoman(int era) {
+  const romans = ['I', 'II', 'III', 'IV'];
+  return era >= 1 && era <= romans.length ? romans[era - 1] : '$era';
+}
+
+String techCategoryLabelL10n(AppLocalizations l10n, String category) {
+  return switch (category) {
+    'gathering' => l10n.techTree_categoryGathering,
+    'transport' => l10n.techTree_categoryTransport,
+    'labour' => l10n.techTree_categoryLabour,
+    'civilian' => l10n.techTree_categoryCivilian,
+    'diplomacy' => l10n.techTree_categoryDiplomacy,
+    'naval' => l10n.techTree_categoryNaval,
+    'military' => l10n.techTree_categoryMilitary,
+    'new-world' => l10n.techTree_categoryNewWorld,
+    _ => category,
+  };
+}

--- a/app/lib/features/game/widgets/tech_tree_widget.dart
+++ b/app/lib/features/game/widgets/tech_tree_widget.dart
@@ -9,14 +9,13 @@ import 'package:flutter/material.dart';
 
 import '../../../config/app_assets.dart';
 import '../../../l10n/l10n.dart';
+import '../utils/tech_ui_helpers.dart';
 import '../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/strict_asset_icon.dart';
 import 'tech_effect_summary_lookup.dart';
 
-
 /// Node position for layout. Exposed for tests (column rule: A→B→C and A→C ⇒ gap between A and C).
-
 
 part 'tech_tree_widget_nodes.dart';
 part 'tech_tree_widget_legend.dart';
@@ -331,8 +330,8 @@ class TechTreeWidget extends StatelessWidget {
             const SizedBox(height: 8),
             Text(
               l10n.techTree_eraCategory(
-                _eraRoman(tech.era),
-                _categoryLabelL10n(l10n, tech.category),
+                eraRoman(tech.era),
+                techCategoryLabelL10n(l10n, tech.category),
               ),
               style: theme.textTheme.bodySmall,
             ),
@@ -384,25 +383,6 @@ class TechTreeWidget extends StatelessWidget {
     );
   }
 
-  static String _eraRoman(int era) {
-    const romans = ['I', 'II', 'III', 'IV'];
-    return era >= 1 && era <= romans.length ? romans[era - 1] : '$era';
-  }
-
-  static String _categoryLabelL10n(AppLocalizations l10n, String category) {
-    return switch (category) {
-      'gathering' => l10n.techTree_categoryGathering,
-      'transport' => l10n.techTree_categoryTransport,
-      'labour' => l10n.techTree_categoryLabour,
-      'civilian' => l10n.techTree_categoryCivilian,
-      'diplomacy' => l10n.techTree_categoryDiplomacy,
-      'naval' => l10n.techTree_categoryNaval,
-      'military' => l10n.techTree_categoryMilitary,
-      'new-world' => l10n.techTree_categoryNewWorld,
-      _ => category,
-    };
-  }
-
   static List<String> _effectSummaryLines(
     AppLocalizations l10n,
     TechDefinition tech,
@@ -420,7 +400,7 @@ class TechTreeWidget extends StatelessWidget {
     if (list.isEmpty) {
       list.add(
         l10n.techEffect_fallbackCategoryImprovement(
-          _categoryLabelL10n(l10n, tech.category),
+          techCategoryLabelL10n(l10n, tech.category),
         ),
       );
     }

--- a/app/lib/features/game/widgets/tech_tree_widget_legend.dart
+++ b/app/lib/features/game/widgets/tech_tree_widget_legend.dart
@@ -1,4 +1,3 @@
-
 /// Row label for tech tree legend samples (maps to [AppLocalizations] state strings).
 
 part of 'tech_tree_widget.dart';
@@ -33,7 +32,7 @@ class _TechTreeLegend extends StatelessWidget {
           .map(
             (e) => _LegendChip(
               color: e.value,
-              label: TechTreeWidget._categoryLabelL10n(l10n, e.key),
+              label: techCategoryLabelL10n(l10n, e.key),
             ),
           )
           .toList(),

--- a/app/lib/features/game/widgets/technology_panel.dart
+++ b/app/lib/features/game/widgets/technology_panel.dart
@@ -4,6 +4,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:flutter/material.dart';
 
 import '../../../l10n/l10n.dart';
+import '../utils/tech_ui_helpers.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/ct_panel.dart';
 
@@ -312,8 +313,8 @@ void _showAssignDialog({
             title: Text(techDisplayName(tech.id)),
             subtitle: Text(
               l10n.technologyPanel_pickSubtitle(
-                _eraRoman(tech.era),
-                _categoryLabel(tech.category),
+                eraRoman(tech.era),
+                techCategoryLabelL10n(l10n, tech.category),
                 tech.cost,
               ),
             ),
@@ -391,23 +392,4 @@ void _cancelSlot({
     SnackBar(content: Text(l10n.technologyPanel_slotCancelled)),
   );
   onOrdersChanged(updated);
-}
-
-String _categoryLabel(String category) {
-  const labels = {
-    'gathering': 'Gathering',
-    'transport': 'Transport',
-    'labour': 'Labour',
-    'civilian': 'Civilian',
-    'diplomacy': 'Diplomacy',
-    'naval': 'Naval',
-    'military': 'Military',
-    'new-world': 'New World',
-  };
-  return labels[category] ?? category;
-}
-
-String _eraRoman(int era) {
-  const romans = ['I', 'II', 'III', 'IV'];
-  return era >= 1 && era <= romans.length ? romans[era - 1] : '$era';
 }

--- a/app/lib/features/game/widgets/train_military_dialog.dart
+++ b/app/lib/features/game/widgets/train_military_dialog.dart
@@ -6,6 +6,7 @@ import '../../../l10n/l10n.dart';
 import '../../../widgets/ct_dialog_shell.dart';
 import '../../../widgets/ct_nine_patch_button.dart';
 import '../../../widgets/resource_icon.dart';
+import '../utils/commodity_ui_helpers.dart';
 import 'train_unit_dialog_helper.dart';
 
 class TrainMilitaryDialog extends StatefulWidget {
@@ -122,7 +123,7 @@ class _TrainMilitaryDialogState extends State<TrainMilitaryDialog> {
     final totalComms = _totalCommodityCosts();
     for (final e in totalComms.entries) {
       if (e.value > _stockpileQty(e.key)) {
-        deficits.add(_commodityDisplayName(e.key));
+        deficits.add(commodityDisplayName(e.key));
       }
     }
     if (deficits.isEmpty) return null;
@@ -130,10 +131,6 @@ class _TrainMilitaryDialogState extends State<TrainMilitaryDialog> {
     if (deficits.length == 2) return '${deficits[0]} and ${deficits[1]} low';
     final head = deficits.sublist(0, deficits.length - 1).join(', ');
     return '$head and ${deficits.last} low';
-  }
-
-  String _commodityDisplayName(String commodityId) {
-    return CommodityCatalog.byId[commodityId]?.displayName ?? commodityId;
   }
 
   void _increment(String unitType) {

--- a/app/test/features/game/utils/ui_helpers_test.dart
+++ b/app/test/features/game/utils/ui_helpers_test.dart
@@ -1,0 +1,29 @@
+import 'package:colonizethis_app/features/game/utils/commodity_ui_helpers.dart';
+import 'package:colonizethis_app/features/game/utils/tech_ui_helpers.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('eraRoman', () {
+    test('returns roman numerals for the first four eras', () {
+      expect(eraRoman(1), 'I');
+      expect(eraRoman(2), 'II');
+      expect(eraRoman(3), 'III');
+      expect(eraRoman(4), 'IV');
+    });
+
+    test('falls back to numeric string outside supported range', () {
+      expect(eraRoman(0), '0');
+      expect(eraRoman(5), '5');
+    });
+  });
+
+  group('commodityDisplayName', () {
+    test('returns catalog display name for known commodity', () {
+      expect(commodityDisplayName('castIron'), 'Cast iron');
+    });
+
+    test('returns input id for unknown commodity', () {
+      expect(commodityDisplayName('unknown_commodity'), 'unknown_commodity');
+    });
+  });
+}

--- a/app/test/features/game/utils/ui_helpers_test.dart
+++ b/app/test/features/game/utils/ui_helpers_test.dart
@@ -1,8 +1,11 @@
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:colonizethis_app/features/game/utils/commodity_ui_helpers.dart';
 import 'package:colonizethis_app/features/game/utils/tech_ui_helpers.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  suppressLogsForTests();
+
   group('eraRoman', () {
     test('returns roman numerals for the first four eras', () {
       expect(eraRoman(1), 'I');


### PR DESCRIPTION
## Summary
- Extract duplicated `era/category` tech UI helpers into `app/lib/features/game/utils/tech_ui_helpers.dart` and update both tech UI consumers to use localized category labels from one source.
- Extract duplicated commodity display-name lookup into `app/lib/features/game/utils/commodity_ui_helpers.dart` and reuse it in train military and production affordance paths.
- Add focused helper tests in `app/test/features/game/utils/ui_helpers_test.dart`.

## Scope in this PR
- **Implemented now (slice):**
  - `_eraRoman` deduplicated into one helper, reused by tech tree + technology panel.
  - `_categoryLabel` hardcoded English map removed from technology panel; panel now uses localized shared helper.
  - `_commodityDisplayName` deduplicated and reused by train military dialog + production affordance.
  - New tests for extracted pure helper behavior.
- **Deferred from issue #2180:**
  - Train-dialog structural base/mixin extraction.
  - `CtLoadingIndicator` extraction and replacement at all call sites.
  - Main-menu `darkWood` constant migration.
  - AST/CI lint rule additions and split/move dialog structural dedup follow-up.

## AC coverage status for #2180
- Covered in this PR:
  - `_eraRoman` single source and reused in both tech UI files.
  - Technology panel category labeling now uses l10n via shared helper.
  - `_commodityDisplayName` single source and reused in both consumers.
  - New focused tests for extracted helper functions.
- Not yet covered:
  - Remaining ACs around train dialog structure, loading indicator standardization, theme color migration, and CI guardrails.

## Test plan
- [x] `cd app && flutter test test/features/game/utils/ui_helpers_test.dart test/tech_tree_widget_core_test.dart test/production_panel_test.dart`

Refs #2180

Made with [Cursor](https://cursor.com)