### PR TITLE
Refactor loading indicator + themed color dedup (slice for #2180)

### DIFF
--- a/app/lib/config/themes.dart
+++ b/app/lib/config/themes.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
+const Color darkWood = Color(0xFF5D3A1A);
+
 /// App themes. Phase 6: pixel-art canon and styling per UXD apply to existing UIs (03a–03m).
 /// Asset pipeline: `assets/images/` (terrain, nine-patch, main menu art); `assets/icons/` (`ui_icon_*.png`); load via rootBundle or Flame cache.
 class AppThemes {
@@ -14,7 +16,6 @@ class AppThemes {
   static ThemeData get colonial {
     const Color parchment = Color(0xFFF5F5DC);
     const Color colonialBrown = Color(0xFF8B4513);
-    const Color darkWood = Color(0xFF5D3A1A);
     const Color goldBrass = Color(0xFFC9A227);
     const Color textPrimary = Color(0xFF212121);
     const Color textSecondary = Color(0xFF757575);

--- a/app/lib/features/game/dialogue/game_start_intro_overlay.dart
+++ b/app/lib/features/game/dialogue/game_start_intro_overlay.dart
@@ -7,6 +7,7 @@ import 'package:jenny/jenny.dart';
 
 import '../../../../l10n/l10n.dart';
 import '../../../../widgets/ct_dialog_shell.dart';
+import '../../../../widgets/ct_loading_indicator.dart';
 import '../../../../widgets/ct_nine_patch_button.dart';
 import 'ct_dialogue_view.dart';
 
@@ -18,12 +19,7 @@ class GameStartIntroLoadingIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Center(
-      child: CircularProgressIndicator(
-        strokeWidth: 2,
-        color: theme.colorScheme.primary,
-      ),
-    );
+    return CtLoadingIndicator(strokeWidth: 2, color: theme.colorScheme.primary);
   }
 }
 

--- a/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/intervention_dialogue_overlay.dart
@@ -10,6 +10,7 @@ import 'package:jenny/jenny.dart';
 
 import '../../../../l10n/l10n.dart';
 import '../../../../widgets/ct_dialog_shell.dart';
+import '../../../../widgets/ct_loading_indicator.dart';
 import '../../../../widgets/ct_nine_patch_button.dart';
 import 'ct_dialogue_view.dart';
 
@@ -275,7 +276,7 @@ class _InterventionDialogueOverlayState
               child: CtDialogShell(
                 child: const Padding(
                   padding: EdgeInsets.all(24),
-                  child: CircularProgressIndicator(),
+                  child: CtLoadingIndicator(),
                 ),
               ),
             ),
@@ -317,7 +318,7 @@ class _InterventionDialogueOverlayState
                   ),
                 ),
               ] else
-                const Center(child: CircularProgressIndicator()),
+                const CtLoadingIndicator(),
             ],
           ),
         ),

--- a/app/lib/features/game/dialogue/overture_dialogue_overlay.dart
+++ b/app/lib/features/game/dialogue/overture_dialogue_overlay.dart
@@ -8,6 +8,7 @@ import 'package:jenny/jenny.dart';
 
 import '../../../../l10n/l10n.dart';
 import '../../../../widgets/ct_dialog_shell.dart';
+import '../../../../widgets/ct_loading_indicator.dart';
 import '../../../../widgets/ct_nine_patch_button.dart';
 import 'ct_dialogue_view.dart';
 
@@ -204,7 +205,7 @@ class _OvertureDialogueOverlayState extends State<OvertureDialogueOverlay> {
                           ),
                         ),
                       ] else
-                        const Center(child: CircularProgressIndicator()),
+                        const CtLoadingIndicator(),
                     ],
                   ),
                 ),

--- a/app/lib/features/shell/new_game_setup_flow.dart
+++ b/app/lib/features/shell/new_game_setup_flow.dart
@@ -20,6 +20,7 @@ import 'package:colonizethis_app/providers/game_service_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/features/shell/new_game_setup_seed_for_attempt.dart';
 import 'package:colonizethis_app/widgets/ct_dialog_shell.dart';
+import 'package:colonizethis_app/widgets/ct_loading_indicator.dart';
 import 'package:colonizethis_app/widgets/ct_nine_patch_button.dart';
 
 final _log = packageLogger('shell');
@@ -244,13 +245,11 @@ class _NewGameSetupProgressDialogState
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 20),
-            SizedBox(
-              width: 40,
-              height: 40,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                color: theme.colorScheme.primary,
-              ),
+            CtLoadingIndicator(
+              size: 40,
+              strokeWidth: 2,
+              color: theme.colorScheme.primary,
+              center: false,
             ),
             const SizedBox(height: 16),
             Text(_stepLabel(context, _stepIndex), textAlign: TextAlign.center),

--- a/app/lib/widgets/ct_loading_indicator.dart
+++ b/app/lib/widgets/ct_loading_indicator.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+/// Shared loading indicator for app overlays/dialogs.
+class CtLoadingIndicator extends StatelessWidget {
+  const CtLoadingIndicator({
+    super.key,
+    this.strokeWidth = 4,
+    this.size,
+    this.color,
+    this.center = true,
+  });
+
+  final double strokeWidth;
+  final double? size;
+  final Color? color;
+  final bool center;
+
+  @override
+  Widget build(BuildContext context) {
+    final indicator = SizedBox(
+      width: size,
+      height: size,
+      child: CircularProgressIndicator(strokeWidth: strokeWidth, color: color),
+    );
+    if (!center) {
+      return indicator;
+    }
+    return Center(child: indicator);
+  }
+}

--- a/app/lib/widgets/game_setup.dart
+++ b/app/lib/widgets/game_setup.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import '../config/constants.dart';
 import '../l10n/l10n.dart';
 import 'ct_dropdown.dart';
+import 'ct_loading_indicator.dart';
 import 'ct_nine_patch_button.dart';
 
 /// Visual variant of the Game Setup screen. SPEC/ui/game-setup.md; UXD 03b.
@@ -142,10 +143,10 @@ class _CtGameSetupState extends State<CtGameSetup> {
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
-                            const SizedBox(
-                              width: 20,
-                              height: 20,
-                              child: CircularProgressIndicator(strokeWidth: 2),
+                            const CtLoadingIndicator(
+                              size: 20,
+                              strokeWidth: 2,
+                              center: false,
                             ),
                             const SizedBox(width: 8),
                             Text(

--- a/app/lib/widgets/main_menu.dart
+++ b/app/lib/widgets/main_menu.dart
@@ -84,8 +84,7 @@ class CtMainMenu extends StatelessWidget {
                 kMainMenuBackgroundAsset,
                 fit: BoxFit.cover,
                 filterQuality: FilterQuality.none,
-                errorBuilder: (_, _, _) =>
-                    Container(color: const Color(0xFF5D3A1A)),
+                errorBuilder: (_, _, _) => Container(color: darkWood),
               ),
             ),
             Theme(data: AppThemes.colonialPixelArt, child: content),


### PR DESCRIPTION
## Summary
- Add `CtLoadingIndicator` in `app/lib/widgets/` and replace ad-hoc loading indicator usage in the five issue-listed files (6 call sites).
- Replace `main_menu.dart` fallback `Color(0xFF5D3A1A)` with shared `darkWood` constant from `themes.dart`.
- Keep scope intentionally narrow to this slice; no train-dialog scaffolding dedup or CI AST rule additions yet.

## Acceptance criteria coverage in this PR
- Covered now:
  - `CtLoadingIndicator` widget exists and replaces the six listed ad-hoc loading sites.
  - `main_menu.dart` uses themed `darkWood` constant instead of bare hex color.
- Deferred:
  - Train-dialog shared base/mixin extraction.
  - Additional CI regression rules in `ct_repo_lint_manifest.yaml`.
  - Remaining issue-wide dedup tasks not part of this slice.

## Tests
- `cd app && flutter test test/overture_dialogue_overlay_test.dart test/intervention_dialogue_overlay_test.dart`

Refs #2180

Made with [Cursor](https://cursor.com)