### PR TITLE
Refactor shared train dialog helpers (slice for #2180)

### DIFF
--- a/app/lib/features/game/widgets/train_civilians_dialog.dart
+++ b/app/lib/features/game/widgets/train_civilians_dialog.dart
@@ -50,23 +50,25 @@ class _TrainCiviliansDialogState extends State<TrainCiviliansDialog> {
   }
 
   Player? get _player {
-    for (final p in widget.game.players) {
-      if (p.id == widget.humanPlayerId) return p;
-    }
-    return null;
+    return trainDialogPlayerById(
+      players: widget.game.players,
+      playerId: widget.humanPlayerId,
+    );
   }
 
-  bool get _hasCapital => _player?.capitalProvinceId != null;
+  bool get _hasCapital => trainDialogHasCapital(_player);
 
-  int get _treasury => _player?.treasury ?? 0;
+  int get _treasury => trainDialogTreasury(_player);
   int get _paperStockpile => _player?.stockpile.quantityOf('paper') ?? 0;
 
-  Map<String, bool> get _techUnlocked => _player?.techUnlocked ?? const {};
+  Map<String, bool> get _techUnlocked => trainDialogTechUnlocked(_player);
 
   bool _isLocked(String unitType) {
-    final techId = unlockingTechByCivilianId[unitType];
-    if (techId == null) return false;
-    return _techUnlocked[techId] != true;
+    return trainDialogIsLocked(
+      unitType: unitType,
+      unlockingTechByUnitType: unlockingTechByCivilianId,
+      techUnlocked: _techUnlocked,
+    );
   }
 
   int _totalTreasuryCost() {

--- a/app/lib/features/game/widgets/train_military_dialog.dart
+++ b/app/lib/features/game/widgets/train_military_dialog.dart
@@ -47,25 +47,27 @@ class _TrainMilitaryDialogState extends State<TrainMilitaryDialog> {
   }
 
   Player? get _player {
-    for (final p in widget.game.players) {
-      if (p.id == widget.humanPlayerId) return p;
-    }
-    return null;
+    return trainDialogPlayerById(
+      players: widget.game.players,
+      playerId: widget.humanPlayerId,
+    );
   }
 
-  bool get _hasCapital => _player?.capitalProvinceId != null;
+  bool get _hasCapital => trainDialogHasCapital(_player);
 
-  int get _treasury => _player?.treasury ?? 0;
+  int get _treasury => trainDialogTreasury(_player);
   int get _peasants => _player?.workerPool.peasants ?? 0;
-  Map<String, bool> get _techUnlocked => _player?.techUnlocked ?? const {};
+  Map<String, bool> get _techUnlocked => trainDialogTechUnlocked(_player);
 
   int _stockpileQty(String commodityId) =>
       _player?.stockpile.quantityOf(commodityId) ?? 0;
 
   bool _isLocked(String unitType) {
-    final techId = unlockingTechByRegimentId[unitType];
-    if (techId == null) return false;
-    return _techUnlocked[techId] != true;
+    return trainDialogIsLocked(
+      unitType: unitType,
+      unlockingTechByUnitType: unlockingTechByRegimentId,
+      techUnlocked: _techUnlocked,
+    );
   }
 
   int _totalTreasuryCost() {

--- a/app/lib/features/game/widgets/train_unit_dialog_helper.dart
+++ b/app/lib/features/game/widgets/train_unit_dialog_helper.dart
@@ -62,3 +62,35 @@ Map<String, int> decrementTrainDialogCount(Map<String, int> counts, String id) {
 Map<String, int> resetTrainDialogCounts(Map<String, int> counts) {
   return {for (final id in counts.keys) id: 0};
 }
+
+Player? trainDialogPlayerById({
+  required Iterable<Player> players,
+  required String playerId,
+}) {
+  for (final player in players) {
+    if (player.id == playerId) return player;
+  }
+  return null;
+}
+
+bool trainDialogHasCapital(Player? player) {
+  return player?.capitalProvinceId != null;
+}
+
+int trainDialogTreasury(Player? player) {
+  return player?.treasury ?? 0;
+}
+
+Map<String, bool> trainDialogTechUnlocked(Player? player) {
+  return player?.techUnlocked ?? const {};
+}
+
+bool trainDialogIsLocked({
+  required String unitType,
+  required Map<String, String> unlockingTechByUnitType,
+  required Map<String, bool> techUnlocked,
+}) {
+  final techId = unlockingTechByUnitType[unitType];
+  if (techId == null) return false;
+  return techUnlocked[techId] != true;
+}

--- a/app/test/train_unit_dialog_helper_test.dart
+++ b/app/test/train_unit_dialog_helper_test.dart
@@ -104,4 +104,79 @@ void main() {
       expect(reset, equals(const {kUnitTypeBuilder: 0, kUnitTypeExplorer: 0}));
     });
   });
+
+  group('shared player/lock helpers', () {
+    const playerId = 'p1';
+    const otherPlayerId = 'p2';
+
+    final player = Player(
+      id: playerId,
+      displayName: 'Player 1',
+      isHuman: true,
+      treasury: 120,
+      capitalProvinceId: 'r1|cap',
+      techUnlocked: const {'bronzeWorking': true},
+    );
+    final otherPlayer = Player(
+      id: otherPlayerId,
+      displayName: 'Player 2',
+      isHuman: false,
+    );
+
+    test('finds player by id and exposes shared fields', () {
+      final found = trainDialogPlayerById(
+        players: [otherPlayer, player],
+        playerId: playerId,
+      );
+
+      expect(found?.id, playerId);
+      expect(trainDialogHasCapital(found), isTrue);
+      expect(trainDialogTreasury(found), 120);
+      expect(
+        trainDialogTechUnlocked(found),
+        equals(const {'bronzeWorking': true}),
+      );
+    });
+
+    test('returns null-safe defaults when player is missing', () {
+      final found = trainDialogPlayerById(
+        players: [otherPlayer],
+        playerId: playerId,
+      );
+
+      expect(found, isNull);
+      expect(trainDialogHasCapital(found), isFalse);
+      expect(trainDialogTreasury(found), 0);
+      expect(trainDialogTechUnlocked(found), isEmpty);
+    });
+
+    test('resolves locked status from tech requirements', () {
+      expect(
+        trainDialogIsLocked(
+          unitType: 'Infantry',
+          unlockingTechByUnitType: const {'Infantry': 'bronzeWorking'},
+          techUnlocked: const {'bronzeWorking': true},
+        ),
+        isFalse,
+      );
+
+      expect(
+        trainDialogIsLocked(
+          unitType: 'Infantry',
+          unlockingTechByUnitType: const {'Infantry': 'bronzeWorking'},
+          techUnlocked: const {'bronzeWorking': false},
+        ),
+        isTrue,
+      );
+
+      expect(
+        trainDialogIsLocked(
+          unitType: 'Worker',
+          unlockingTechByUnitType: const {'Infantry': 'bronzeWorking'},
+          techUnlocked: const {},
+        ),
+        isFalse,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Extract shared train-dialog helpers for player lookup, capital/treasury/tech accessors, and lock-state resolution into `train_unit_dialog_helper.dart`.
- Update `train_military_dialog.dart` and `train_civilians_dialog.dart` to consume shared helpers instead of duplicating the same logic.
- Extend `train_unit_dialog_helper_test.dart` with positive/negative coverage for the new shared helper behavior.

## Acceptance criteria coverage in this PR
- Covered now:
  - Train dialogs no longer duplicate `_player`, `_hasCapital`, `_treasury`, `_techUnlocked`, and lock-resolution logic.
  - Shared helper behavior is validated with focused tests.
- Deferred:
  - Shared extraction for train-dialog `_increment` / `_decrement` / `_reset` wrappers.
  - CI AST regression rules and remaining issue-wide dedup work.

## Tests
- `cd app && flutter test test/train_unit_dialog_helper_test.dart`

Refs #2180

Made with [Cursor](https://cursor.com)