### PR TITLE
Add CtLoadingIndicator repo lint (slice for #2180)

### DIFF
--- a/app/lib/features/game/flame/turn_resolution_processing_dialog.dart
+++ b/app/lib/features/game/flame/turn_resolution_processing_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import '../../../../widgets/ct_dialog_shell.dart';
+import '../../../../widgets/ct_loading_indicator.dart';
 
 class TurnResolutionProcessingDialog extends StatelessWidget {
   const TurnResolutionProcessingDialog({required this.phaseText, super.key});
@@ -23,11 +24,11 @@ class TurnResolutionProcessingDialog extends StatelessWidget {
             const SizedBox(height: 12),
             Row(
               children: [
-                const SizedBox(
-                  width: 16,
-                  height: 16,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                ),
+            const CtLoadingIndicator(
+              size: 16,
+              strokeWidth: 2,
+              center: false,
+            ),
                 const SizedBox(width: 10),
                 Expanded(child: Text(phaseText)),
               ],

--- a/tool/check_app_ct_loading_indicator.dart
+++ b/tool/check_app_ct_loading_indicator.dart
@@ -1,0 +1,76 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// PR-blocking structural check: CircularProgressIndicator usage in app/lib.
+///
+/// Enforces that runtime code in `app/lib/` uses the shared CtLoadingIndicator
+/// widget instead of ad-hoc CircularProgressIndicator instances.
+///
+/// Allowed:
+/// - Direct CircularProgressIndicator usage in `app/lib/widgets/ct_loading_indicator.dart`
+///
+/// Disallowed:
+/// - Any other `CircularProgressIndicator` constructor calls under `app/lib/`
+int runCheckAppCtLoadingIndicator(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+
+  final appLibDir = Directory(p.join(repoRoot, 'app', 'lib'));
+  if (!appLibDir.existsSync()) {
+    logE('check_app_ct_loading_indicator: app/lib not found.');
+    return 1;
+  }
+
+  const allowedRelativePath = 'app/lib/widgets/ct_loading_indicator.dart';
+  final violations = <String>[];
+
+  for (final entity in appLibDir.listSync(recursive: true, followLinks: false)) {
+    if (entity is! File || !entity.path.endsWith('.dart')) {
+      continue;
+    }
+
+    final relativePath = p.relative(entity.path, from: repoRoot);
+    if (relativePath == allowedRelativePath) {
+      continue;
+    }
+
+    final lines = const LineSplitter().convert(entity.readAsStringSync());
+    for (var i = 0; i < lines.length; i++) {
+      final line = lines[i];
+      final trimmed = line.trimLeft();
+      if (trimmed.startsWith('//')) {
+        continue;
+      }
+      if (!line.contains('CircularProgressIndicator')) {
+        continue;
+      }
+      violations.add('$relativePath:${i + 1}: ${line.trim()}');
+    }
+  }
+
+  if (violations.isEmpty) {
+    logI('check_app_ct_loading_indicator: no violations found.');
+    return 0;
+  }
+
+  logE(
+    'check_app_ct_loading_indicator: found ${violations.length} violation(s) '
+    'in app/lib (CircularProgressIndicator outside ct_loading_indicator.dart):',
+  );
+  for (final violation in violations) {
+    logE(' - $violation');
+  }
+
+  return 1;
+}
+
+void main() {
+  exit(runCheckAppCtLoadingIndicator(Directory.current.path));
+}
+

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -208,6 +208,13 @@ rules:
     runner: dart
     script: tool/check_land_province_bucket_keys.dart
 
+  - rule_id: repo.app_ct_loading_indicator
+    group: ui_structure
+    title: app/lib must use CtLoadingIndicator instead of raw CircularProgressIndicator
+    spec: SPEC/program/repo-lint.md
+    runner: dart
+    script: tool/check_app_ct_loading_indicator.dart
+
   - rule_id: repo.logic_dual_region_province_field_access
     group: architecture
     title: colonizethis_logic limits direct oldWorld/newWorld province list access


### PR DESCRIPTION
## Summary

This PR adds a repo-lint rule to enforce usage of the shared `CtLoadingIndicator` widget in `app/lib` and migrates the remaining inline `CircularProgressIndicator` usage accordingly.

- Introduces `tool/check_app_ct_loading_indicator.dart` and wires it into `tool/ct_repo_lint_manifest.yaml` as `repo.app_ct_loading_indicator`.
- Refactors `TurnResolutionProcessingDialog` to use `CtLoadingIndicator` instead of an ad-hoc `CircularProgressIndicator`.

## Scope

**Scope type:** SLICE for #2180.

**In scope:**
- Structural repo-lint coverage for `CircularProgressIndicator` in `app/lib` so new usages go through `CtLoadingIndicator`.
- One small UI refactor in `turn_resolution_processing_dialog.dart` to comply with the new rule (no behavioral changes intended).

**Out of scope (still remaining for #2180):**
- Generic duplicate-helper lint (`repo.app_no_duplicate_helpers`) for identical function bodies.
- Any additional structural dedup for split/move dialog pairs and military/naval panels.
- New tests specific to the lint tool itself (manual `dart run tool/ct_repo_lint.dart --rule repo.app_ct_loading_indicator` run in this slice instead).

## SPEC and issue alignment

- Aligns with issue #2180's CI/enforcement section by adding a `CtLoadingIndicator`-focused repo-lint gate.
- Behavior remains the same: the processing dialog still shows a 16x16 spinner with strokeWidth 2 alongside the phase text.

## Tests and checks

- `dart run tool/check_app_ct_loading_indicator.dart`
- `dart run tool/ct_repo_lint.dart --rule repo.app_ct_loading_indicator`
- `cd app && flutter test test/train_unit_dialog_helper_test.dart`

All of the above pass locally.

## Issue reference

Refs #2180

