### PR TITLE
Refactor map marker panel opens onto app bus

### DIFF
--- a/app/lib/features/game/flame/game_map_area_part2.dart
+++ b/app/lib/features/game/flame/game_map_area_part2.dart
@@ -117,28 +117,10 @@ mixin _GameMapAreaStatePart2
                               _workTargetSelection != null
                               ? _cancelWorkTargetSelection
                               : null,
-                          onCivilianTileTapped: (tileKey) {
-                            String? initialSelectedUnitId;
-                            for (final marker
-                                in projectedRegion.civilianTileMarkers) {
-                              if (marker.tileKey == tileKey &&
-                                  marker.unitIds.isNotEmpty) {
-                                initialSelectedUnitId = marker.unitIds.first;
-                                break;
-                              }
-                            }
+                          onCivilianTileStateChanged: (tileKey) {
                             setState(() {
                               _selectedCivilianTileKey = tileKey;
                             });
-                            ref
-                                .read(appEventBusProvider)
-                                .emit(
-                                  ct_models.OpenCivilianUnitsPanelEvent(
-                                    tileScopeTileKey: tileKey,
-                                    initialSelectedUnitId:
-                                        initialSelectedUnitId,
-                                  ),
-                                );
                           },
                           onCivilianTileSelectionCleared: () {
                             if (_selectedCivilianTileKey == null) return;
@@ -146,22 +128,6 @@ mixin _GameMapAreaStatePart2
                               _selectedCivilianTileKey = null;
                             });
                           },
-                          onFleetMarkerTapped:
-                              (
-                                locationScopeKey,
-                                initialFleetId,
-                                markerTileKey,
-                              ) {
-                                ref
-                                    .read(appEventBusProvider)
-                                    .emit(
-                                      ct_models.OpenNavalUnitsPanelEvent(
-                                        locationScopeKey: locationScopeKey,
-                                        initialSelectedFleetId: initialFleetId,
-                                        tileScopeTileKey: markerTileKey,
-                                      ),
-                                    );
-                              },
                           bus: ref.read(appEventBusProvider),
                           onRegionViewportSnapshot: _onRegionViewportSnapshot,
                           zoomMultiplier: _mapViewState.zoomMultiplier,

--- a/app/lib/features/game/flame/game_map_canvas_stack.dart
+++ b/app/lib/features/game/flame/game_map_canvas_stack.dart
@@ -34,8 +34,7 @@ class GameMapCanvasStack extends ConsumerWidget {
     required this.onTileSelectedForWork,
     required this.onWorkTargetSelectionCancelled,
     required this.selectedCivilianTileKey,
-    required this.onCivilianTileTapped,
-    this.onFleetMarkerTapped,
+    required this.onCivilianTileStateChanged,
     required this.onCivilianTileSelectionCleared,
     required this.onRegionViewportSnapshot,
     required this.zoomMultiplier,
@@ -59,13 +58,7 @@ class GameMapCanvasStack extends ConsumerWidget {
   final void Function(String tileKey)? onTileSelectedForWork;
   final VoidCallback? onWorkTargetSelectionCancelled;
   final String? selectedCivilianTileKey;
-  final void Function(String tileKey)? onCivilianTileTapped;
-  final void Function(
-    String locationScopeKey,
-    String? initialFleetId,
-    String markerTileKey,
-  )?
-  onFleetMarkerTapped;
+  final void Function(String tileKey)? onCivilianTileStateChanged;
   final VoidCallback? onCivilianTileSelectionCleared;
   final void Function(RegionMapViewportSnapshot snapshot)
   onRegionViewportSnapshot;
@@ -100,12 +93,9 @@ class GameMapCanvasStack extends ConsumerWidget {
                             .reportMapTileTapped(tk),
                   onProvinceHovered: (_) {},
                   onTileHovered: (_) {},
-                  onCivilianTileTapped: inWorkTargetSelectionMode
+                  onCivilianTileStateChanged: inWorkTargetSelectionMode
                       ? null
-                      : onCivilianTileTapped,
-                  onFleetMarkerTapped: inWorkTargetSelectionMode
-                      ? null
-                      : onFleetMarkerTapped,
+                      : onCivilianTileStateChanged,
                   onCivilianTileSelectionCleared: inWorkTargetSelectionMode
                       ? null
                       : onCivilianTileSelectionCleared,
@@ -117,7 +107,7 @@ class GameMapCanvasStack extends ConsumerWidget {
                   onTileSelected: onTileSelectedForWork,
                   onWorkTargetSelectionCancelled:
                       onWorkTargetSelectionCancelled,
-                  bus: bus,
+                  bus: inWorkTargetSelectionMode ? null : bus,
                   onViewportSnapshotChanged: onRegionViewportSnapshot,
                   zoomMultiplier: zoomMultiplier,
                 ),

--- a/app/lib/widgets/ct_region_map.dart
+++ b/app/lib/widgets/ct_region_map.dart
@@ -35,8 +35,7 @@ class CtRegionMap extends StatefulWidget {
     this.onRegionViewChanged,
     this.onProvinceHovered,
     this.onTileHovered,
-    this.onCivilianTileTapped,
-    this.onFleetMarkerTapped,
+    this.onCivilianTileStateChanged,
     this.onCivilianTileSelectionCleared,
     this.selectedTileKey,
     this.selectedCivilianTileKey,
@@ -66,13 +65,7 @@ class CtRegionMap extends StatefulWidget {
   final VoidCallback? onRegionViewChanged;
   final void Function(String? provinceId)? onProvinceHovered;
   final void Function(String? tileKey)? onTileHovered;
-  final void Function(String tileKey)? onCivilianTileTapped;
-  final void Function(
-    String locationScopeKey,
-    String? initialFleetId,
-    String markerTileKey,
-  )?
-  onFleetMarkerTapped;
+  final void Function(String tileKey)? onCivilianTileStateChanged;
   final VoidCallback? onCivilianTileSelectionCleared;
   final String? selectedTileKey;
   final String? selectedCivilianTileKey;
@@ -152,8 +145,8 @@ class _CtRegionMapState extends State<CtRegionMap> {
         widget.visibilityMode != oldWidget.visibilityMode ||
         widget.baseLayerDisplayMode != oldWidget.baseLayerDisplayMode ||
         widget.validTileKeys != oldWidget.validTileKeys ||
-        widget.onCivilianTileTapped != oldWidget.onCivilianTileTapped ||
-        widget.onFleetMarkerTapped != oldWidget.onFleetMarkerTapped ||
+        widget.onCivilianTileStateChanged !=
+            oldWidget.onCivilianTileStateChanged ||
         widget.onCivilianTileSelectionCleared !=
             oldWidget.onCivilianTileSelectionCleared ||
         widget.selectedTileKey != oldWidget.selectedTileKey ||
@@ -189,8 +182,8 @@ class _CtRegionMapState extends State<CtRegionMap> {
             widget.validTileKeys == null && oldWidget.validTileKeys != null,
         onTileSelected: widget.onTileSelected,
         onWorkTargetSelectionCancelled: widget.onWorkTargetSelectionCancelled,
-        onCivilianTileTapped: widget.onCivilianTileTapped,
-        onFleetMarkerTapped: widget.onFleetMarkerTapped,
+        onCivilianTileTapped: _handleCivilianTileTapped,
+        onFleetMarkerTapped: _handleFleetMarkerTapped,
         onCivilianTileSelectionCleared: widget.onCivilianTileSelectionCleared,
         playerViewForResources: widget.playerViewForResources,
         onViewportSnapshotChanged: widget.onViewportSnapshotChanged,
@@ -225,8 +218,8 @@ class _CtRegionMapState extends State<CtRegionMap> {
       onRegionViewChanged: widget.onRegionViewChanged,
       onProvinceHovered: widget.onProvinceHovered,
       onTileHovered: widget.onTileHovered,
-      onCivilianTileTapped: widget.onCivilianTileTapped,
-      onFleetMarkerTapped: widget.onFleetMarkerTapped,
+      onCivilianTileTapped: _handleCivilianTileTapped,
+      onFleetMarkerTapped: _handleFleetMarkerTapped,
       onCivilianTileSelectionCleared: widget.onCivilianTileSelectionCleared,
       selectedTileKey: widget.selectedTileKey,
       selectedCivilianTileKey: widget.selectedCivilianTileKey,
@@ -242,6 +235,41 @@ class _CtRegionMapState extends State<CtRegionMap> {
       playerViewForResources: widget.playerViewForResources,
       onViewportSnapshotChanged: widget.onViewportSnapshotChanged,
       initialZoomMultiplier: widget.zoomMultiplier ?? 1.0,
+    );
+  }
+
+  void _handleCivilianTileTapped(String tileKey) {
+    widget.onCivilianTileStateChanged?.call(tileKey);
+    final bus = widget.bus;
+    if (bus == null) {
+      return;
+    }
+    String? initialSelectedUnitId;
+    for (final marker in widget.region.civilianTileMarkers) {
+      if (marker.tileKey == tileKey && marker.unitIds.isNotEmpty) {
+        initialSelectedUnitId = marker.unitIds.first;
+        break;
+      }
+    }
+    bus.emit(
+      OpenCivilianUnitsPanelEvent(
+        tileScopeTileKey: tileKey,
+        initialSelectedUnitId: initialSelectedUnitId,
+      ),
+    );
+  }
+
+  void _handleFleetMarkerTapped(
+    String locationScopeKey,
+    String? initialFleetId,
+    String markerTileKey,
+  ) {
+    widget.bus?.emit(
+      OpenNavalUnitsPanelEvent(
+        locationScopeKey: locationScopeKey,
+        initialSelectedFleetId: initialFleetId,
+        tileScopeTileKey: markerTileKey,
+      ),
     );
   }
 

--- a/app/test/ct_region_map_test_support.dart
+++ b/app/test/ct_region_map_test_support.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_logic/colonizethis_logic.dart' show PlayerView;
 import 'package:colonizethis_map/colonizethis_map.dart';
-import 'package:colonizethis_models/colonizethis_models.dart' show Player;
+import 'package:colonizethis_models/colonizethis_models.dart'
+    show AppEventBus, Player;
 import 'package:flutter/material.dart';
 
 import 'package:colonizethis_app/widgets/ct_region_map.dart'
@@ -40,13 +41,14 @@ Widget ctRegionMapTestHarness({
   void Function(String?)? onProvinceHovered,
   void Function(String?)? onTileHovered,
   void Function(String)? onMapTileTappedForDetail,
-  void Function(String)? onCivilianTileTapped,
+  void Function(String)? onCivilianTileStateChanged,
   VoidCallback? onCivilianTileSelectionCleared,
   String? selectedTileKey,
   String? selectedCivilianTileKey,
   String? secondaryHighlightTileKey,
   VoidCallback? onRegionViewChanged,
   PlayerView? playerViewForResources,
+  AppEventBus? bus,
 }) {
   return MaterialApp(
     home: Scaffold(
@@ -69,12 +71,13 @@ Widget ctRegionMapTestHarness({
             onProvinceHovered: onProvinceHovered,
             onTileHovered: onTileHovered,
             onMapTileTappedForDetail: onMapTileTappedForDetail,
-            onCivilianTileTapped: onCivilianTileTapped,
+            onCivilianTileStateChanged: onCivilianTileStateChanged,
             onCivilianTileSelectionCleared: onCivilianTileSelectionCleared,
             selectedTileKey: selectedTileKey,
             selectedCivilianTileKey: selectedCivilianTileKey,
             secondaryHighlightTileKey: secondaryHighlightTileKey,
             onRegionViewChanged: onRegionViewChanged,
+            bus: bus,
           ),
         ),
       ),

--- a/app/test/ct_region_map_widget_test_part2_test.dart
+++ b/app/test/ct_region_map_widget_test_part2_test.dart
@@ -8,7 +8,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart' show TerrainType;
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart'
-    show AppEventBus, OpenProvinceDetailPanelEvent, kUnitTypeBuilder;
+    show
+        AppEventBus,
+        OpenCivilianUnitsPanelEvent,
+        OpenNavalUnitsPanelEvent,
+        OpenProvinceDetailPanelEvent,
+        kUnitTypeBuilder;
 
 import 'package:colonizethis_app/features/game/flame/resource_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
@@ -445,6 +450,13 @@ void main() {
         String? tappedCivilianTileKey;
         String? detailTileKey;
         String? selectedProvinceId;
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+        final openedPanels = <OpenCivilianUnitsPanelEvent>[];
+        final panelSub = bus.on<OpenCivilianUnitsPanelEvent>().listen(
+          openedPanels.add,
+        );
+        addTearDown(panelSub.cancel);
 
         await tester.pumpWidget(
           ctRegionMapTestHarness(
@@ -452,7 +464,9 @@ void main() {
             width: 64,
             height: 64,
             cellSizePx: 32,
-            onCivilianTileTapped: (tileKey) => tappedCivilianTileKey = tileKey,
+            bus: bus,
+            onCivilianTileStateChanged: (tileKey) =>
+                tappedCivilianTileKey = tileKey,
             onMapTileTappedForDetail: (tileKey) => detailTileKey = tileKey,
             onProvinceSelected: (id) => selectedProvinceId = id,
           ),
@@ -464,8 +478,86 @@ void main() {
         await tester.pump();
 
         expect(tappedCivilianTileKey, equals(markerTileKey));
+        expect(openedPanels, hasLength(1));
+        expect(openedPanels.single.tileScopeTileKey, equals(markerTileKey));
+        expect(openedPanels.single.initialSelectedUnitId, equals('u_builder'));
         expect(detailTileKey, isNull);
         expect(selectedProvinceId, isNull);
+      },
+      timeout: const Timeout(Duration(seconds: 5)),
+    );
+
+    testWidgets(
+      'tapping fleet marker emits naval units panel event',
+      (WidgetTester tester) async {
+        final base = ctRegionMapTestOldWorldRegion();
+        final seaTemplate = base.cells.firstWhere((c) => c.isSea);
+        const markerTileKey = 'oldWorld|sMarker|0|0';
+        final region = RegionMapViewData(
+          regionId: 'oldWorld',
+          width: 1,
+          height: 1,
+          cellSize: 24,
+          cells: [
+            CellViewData(
+              x: 0,
+              y: 0,
+              regionCellId: 'sMarker',
+              isSea: true,
+              terrainTypeId: seaTemplate.terrainTypeId,
+              terrainType: seaTemplate.terrainType,
+              ownerFactionId: seaTemplate.ownerFactionId,
+              provinceDisplayName: 'Marker Sea',
+            ),
+          ],
+          capitalMarkers: const [],
+          portMarkers: const [],
+          townMarkers: const [],
+          factionColors: base.factionColors,
+          greatPowerFactionIds: base.greatPowerFactionIds,
+          terrainColors: base.terrainColors,
+          unitMarkers: const [],
+          fleetTileMarkers: [
+            FleetTileMarkerView(
+              tileKey: markerTileKey,
+              x: 0,
+              y: 0,
+              locationScopeKey: 'sea:oldWorld|fleet_scope',
+              fleetIds: const ['fleet_1'],
+              stackCount: 1,
+            ),
+          ],
+          civilianTileMarkers: const [],
+          warpMarkers: const [],
+        );
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+        final openedPanels = <OpenNavalUnitsPanelEvent>[];
+        final panelSub = bus.on<OpenNavalUnitsPanelEvent>().listen(
+          openedPanels.add,
+        );
+        addTearDown(panelSub.cancel);
+
+        await tester.pumpWidget(
+          ctRegionMapTestHarness(
+            region: region,
+            width: 64,
+            height: 64,
+            cellSizePx: 32,
+            bus: bus,
+          ),
+        );
+        await tester.pump();
+        await tester.tap(find.byType(CtRegionMap));
+        await tester.pump();
+
+        expect(openedPanels, hasLength(1));
+        expect(
+          openedPanels.single.locationScopeKey,
+          equals('sea:oldWorld|fleet_scope'),
+        );
+        expect(openedPanels.single.initialSelectedFleetId, equals('fleet_1'));
+        expect(openedPanels.single.tileScopeTileKey, equals(markerTileKey));
       },
       timeout: const Timeout(Duration(seconds: 5)),
     );
@@ -1015,7 +1107,5 @@ void main() {
       },
       timeout: const Timeout(Duration(seconds: 10)),
     );
-
-
   });
 }

--- a/app/test/game_map_area_selection_mode_test.dart
+++ b/app/test/game_map_area_selection_mode_test.dart
@@ -545,8 +545,8 @@ void main() {
 
     var regionMap = tester.widget<CtRegionMap>(find.byType(CtRegionMap).first);
     expect(regionMap.onMapTileTappedForDetail, isNotNull);
-    expect(regionMap.onCivilianTileTapped, isNotNull);
-    expect(regionMap.onFleetMarkerTapped, isNotNull);
+    expect(regionMap.onCivilianTileStateChanged, isNotNull);
+    expect(regionMap.bus, isNotNull);
 
     bus.emit(
       StartCivilianWorkTargetSelectionEvent(
@@ -560,7 +560,7 @@ void main() {
     expect(find.text('Select a tile, or click cancel'), findsOneWidget);
     regionMap = tester.widget<CtRegionMap>(find.byType(CtRegionMap).first);
     expect(regionMap.onMapTileTappedForDetail, isNull);
-    expect(regionMap.onCivilianTileTapped, isNull);
-    expect(regionMap.onFleetMarkerTapped, isNull);
+    expect(regionMap.onCivilianTileStateChanged, isNull);
+    expect(regionMap.bus, isNull);
   });
 }


### PR DESCRIPTION
## Summary
- Moves `CtRegionMap` civilian and fleet marker panel-opening intents onto `AppEventBus` emissions.
- Keeps a narrow `onCivilianTileStateChanged` callback so `GameMapArea` continues to preserve `_selectedCivilianTileKey` highlighting without owning cross-panel opens.
- Disables marker bus interactions while work-target selection mode is active, preserving selection-mode behavior.

Refs #2188

## Scope
This PR is a partial slice for #2188. It covers the callback-to-bus conversion for `CtRegionMap` civilian and fleet marker taps while preserving civilian marker highlight state.

Deferred work remains for the broader `CtRegionMap` dependency-direction cleanup: removing `app/lib/widgets/ct_region_map.dart` imports/exports from `features/game/flame/**`, introducing the narrow game-host/factory abstraction, and adding the `app/lib/widgets/**` feature-import enforcement described in the issue.

## Acceptance Criteria Covered
- Cross-panel `CtRegionMap` callbacks that open Civilian/Naval panels are replaced by typed bus events.
- `_selectedCivilianTileKey` highlighting remains parent-owned through a state-only callback.
- Work-target selection mode still blocks normal marker panel opens.

## Tests
- `flutter test test/ct_region_map_widget_test_part2_test.dart test/game_map_area_selection_mode_test.dart` from `app/`
- `dart run tool/ct_repo_lint.dart --rule repo.subscription_tracker`
- `dart run tool/run_workspace_analyze_errors_only.dart`

Notes: full `flutter analyze` under `app/` reports existing warnings/infos only; no analyzer errors were present, and the repo errors-only analyzer gate passed.

Made with [Cursor](https://cursor.com)