### PR TITLE
refactor(logic): extract naval mission-order module (#2178)

### DIFF
--- a/.cursor/rules/colonizethis-assets.mdc
+++ b/.cursor/rules/colonizethis-assets.mdc
@@ -1,6 +1,6 @@
 ---
 description: Asset directory layout, naming, and loading conventions
-globs: "**/*.dart,**/pubspec.yaml,**/assets/**"
+globs: "**/pubspec.yaml,**/assets/**,app/lib/**/asset*.dart,app/lib/**/assets*.dart,app/lib/**/sprite*.dart,packages/*/lib/**/asset*.dart,packages/*/lib/**/assets*.dart,packages/*/lib/**/sprite*.dart"
 alwaysApply: false
 ---
 

--- a/.cursor/rules/colonizethis-code-review.mdc
+++ b/.cursor/rules/colonizethis-code-review.mdc
@@ -1,6 +1,6 @@
 ---
 description: Code review checklist — concrete thresholds and repo paths; principles in other rules
-globs: "**/*.dart"
+globs: "app/lib/**/*.dart,packages/*/lib/**/*.dart,tool/**/*.dart"
 alwaysApply: false
 ---
 

--- a/.cursor/rules/colonizethis-component-structure.mdc
+++ b/.cursor/rules/colonizethis-component-structure.mdc
@@ -1,6 +1,6 @@
 ---
 description: Folder layout and component reusability for game and UI
-globs: "**/*.dart"
+globs: "app/lib/**/*.dart,packages/*/lib/**/*.dart,tool/**/*.dart"
 alwaysApply: false
 ---
 

--- a/.cursor/rules/colonizethis-lifecycle.mdc
+++ b/.cursor/rules/colonizethis-lifecycle.mdc
@@ -1,6 +1,6 @@
 ---
 description: Flame and Flutter component lifecycle conventions
-globs: "**/*.dart"
+globs: "app/lib/game/**/*.dart,app/lib/widgets/**/*.dart,app/lib/ui/**/*.dart,app/lib/screens/**/*.dart,app/lib/pages/**/*.dart"
 alwaysApply: false
 ---
 

--- a/.cursor/rules/routing-index.md
+++ b/.cursor/rules/routing-index.md
@@ -1,0 +1,55 @@
+## Purpose
+
+Reduce irrelevant rule overlays by defining one routing map for rule applicability and precedence, while preserving normative policy text in `.cursor/rules/*.mdc`.
+
+## Rule Inventory
+
+| Rule file | Policy owner |
+|---|---|
+| `colonizethis-spec-required.mdc` | SPEC governance |
+| `colonizethis-core-principles.mdc` | Architecture and code standards |
+| `colonizethis-logging-file.mdc` | Logging standards |
+| `colonizethis-logic-ai-decoupling.mdc` | Package-boundary governance |
+| `colonizethis-tools.mdc` | Tooling workflow |
+| `colonizethis-testing.mdc` | Test policy and coverage |
+| `colonizethis-e2e-ui-stability.mdc` | E2E UI stability |
+| `colonizethis-ui-design.mdc` | UI conventions |
+| `colonizethis-component-structure.mdc` | Code organization |
+| `colonizethis-code-review.mdc` | Review thresholds |
+| `colonizethis-lifecycle.mdc` | Flutter/Flame lifecycle |
+| `colonizethis-assets.mdc` | Asset and pubspec conventions |
+| `colonizethis-acceptance-criteria.mdc` | SPEC acceptance criteria quality |
+
+## Applicability Matrix (Before -> After)
+
+| Context | Before applied rules (observed) | After applied rules (targeted) | Change intent |
+|---|---|---|---|
+| Generic Dart implementation in `app/lib/**` | always-applied + `component-structure` + `code-review` + `lifecycle` + `assets` via broad `**/*.dart` | always-applied + `component-structure` + `code-review` (plus targeted overlays only) | Remove lifecycle/asset over-application from default implementation flow |
+| Flutter widget/UI work (`**/lib/widgets/**`, `**/lib/ui/**`) | above set + `ui-design` | always-applied + `ui-design` + targeted `component-structure`/`code-review` + `lifecycle` | Keep UI constraints while applying lifecycle only in lifecycle-relevant paths |
+| Tests (`**/*_test.dart`, `**/test/**`, `**/integration_test/**`) | testing/e2e + broad Dart overlays | testing/e2e first; general Dart overlays apply only where glob-matched | Prioritize test directives and reduce unrelated guidance |
+| Asset and pubspec edits (`**/assets/**`, `**/pubspec.yaml`) | `assets` plus broad Dart overlays | `assets` focused guidance + always-applied baseline only | Prevent non-asset directive bleed |
+| Tooling facade code (`tool/**`) | `tools` plus broad overlays | `tools` primary + targeted structural/review overlays | Preserve tooling rules and remove unrelated overlays |
+| Logic <-> AI boundary work (`packages/colonizethis_logic/**`, `packages/colonizethis_ai/**`) | always-applied decoupling + multiple broad overlays | always-applied decoupling + targeted path overlays only | Preserve strict decoupling while reducing collateral directives |
+| OpenCode skill docs (`.opencode/skills/**`) | duplicated routing prose in references | references point to this index + source `.mdc` files | Avoid duplicated normative summaries |
+
+## Precedence Model
+
+1. Always-applied rules are baseline for every task.
+2. Context-specific rules apply by frontmatter `globs`.
+3. If two context rules conflict, the more specific rule/path takes precedence.
+4. Normative policy text remains authoritative only in source `.mdc` files.
+
+## Non-Duplication Contract
+
+- `AGENTS.md` and `.opencode/skills/**/references/*.md` must not restate normative policy text from `.mdc` files.
+- These documents may summarize routing, list rule files, and link to authoritative sources.
+- Any policy wording changes must be made in the corresponding `.mdc` file, not in routing pointers.
+
+## Change Protocol
+
+When adding or changing a rule:
+
+1. Update the rule file under `.cursor/rules/`.
+2. Update this routing index matrix and inventory.
+3. Run `dart test test/check_rule_routing_test.dart`.
+4. Ensure references (`AGENTS.md`, OpenCode docs) remain pointer-only and non-duplicative.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -440,6 +440,9 @@ jobs:
       - name: Test colonizethis_map lib pipe-split checker (SPEC/program/map-visualization.md)
         run: dart test test/check_colonizethis_map_lib_pipe_split_test.dart --reporter=compact
 
+      - name: Test rule routing checker (issue #2190)
+        run: dart test test/check_rule_routing_test.dart --reporter=compact
+
       - name: Wang incremental assets gate (Python)
         run: |
           set -euo pipefail

--- a/.opencode/skills/refactoring-opportunity-github-issue/references/ci-and-rules.md
+++ b/.opencode/skills/refactoring-opportunity-github-issue/references/ci-and-rules.md
@@ -2,23 +2,13 @@
 
 ## Rule routing (summary)
 
-Authoritative index: **`AGENTS.md`** (“Rule location” / tables). Rules live in **`.cursor/rules/*.mdc`**. When scanning `app/` or `packages/<pkg>/lib/**`:
+Use the canonical routing map at `.cursor/rules/routing-index.md` for:
 
-| Concern | Typical rule file |
-|---------|-------------------|
-| SPEC-first, doc boundaries | `colonizethis-spec-required.mdc` |
-| Flutter vs Flame, typing, logging, province ids, `AppEventBus` | `colonizethis-core-principles.mdc` |
-| Logic ↔ AI dependency direction | `colonizethis-logic-ai-decoupling.mdc` |
-| Folders, extraction, naming | `colonizethis-component-structure.mdc` |
-| Review checklist | `colonizethis-code-review.mdc` |
-| Widget/Flame lifecycle | `colonizethis-lifecycle.mdc` |
-| Tests, coverage expectations | `colonizethis-testing.mdc` |
-| E2E / integration tests | `colonizethis-e2e-ui-stability.mdc` |
-| UI specs / widgets | `colonizethis-ui-design.mdc` |
-| Assets / pubspec | `colonizethis-assets.mdc` |
-| AC quality in SPEC | `colonizethis-acceptance-criteria.mdc` |
+- applicability matrix (which rules apply in each context),
+- precedence (always-applied baseline + context overlays), and
+- non-duplication expectations for pointers vs policy text.
 
-Read the **frontmatter `globs`** on each `.mdc` when unsure; multiple rules can apply additively.
+Normative policy wording lives only in `.cursor/rules/*.mdc`. OpenCode references should link to those files instead of restating policy clauses.
 
 ## Existing CI gates (extension points)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Cursor rules are the source of truth for implementation and review behavior.
 
 - Path: `.cursor/rules/`
 - Format: Markdown `.mdc` with front matter (`description`, optional `globs`, `alwaysApply`)
+- Routing index: `.cursor/rules/routing-index.md` (applicability and precedence only)
 
 ## Always-applied rules
 
@@ -24,26 +25,21 @@ Cursor rules are the source of truth for implementation and review behavior.
 | `colonizethis-testing.mdc` | `**/*_test.dart`, `**/test/**/*.dart`, `**/integration_test/**/*.dart` | Test layers, critical paths, coverage policy |
 | `colonizethis-e2e-ui-stability.mdc` | `**/integration_test/**/*.dart`, `**/*_e2e_test.dart` | UI e2e stability: deterministic locators and visibility-first interactions |
 | `colonizethis-ui-design.mdc` | `SPEC/ui/**`, `**/lib/widgets/**`, `**/lib/ui/**` | UI specs, wireframes, Widgetbook/catalog, pixel-art process |
-| `colonizethis-component-structure.mdc` | `**/*.dart` | Folder conventions, extraction/reuse, naming |
-| `colonizethis-code-review.mdc` | `**/*.dart` | Review checklist and quality gates |
-| `colonizethis-lifecycle.mdc` | `**/*.dart` | Flame/Flutter lifecycle conventions |
-| `colonizethis-assets.mdc` | `**/*.dart`, `**/pubspec.yaml`, `**/assets/**` | Asset structure, naming, loading |
+| `colonizethis-component-structure.mdc` | `app/lib/**/*.dart`, `packages/*/lib/**/*.dart`, `tool/**/*.dart` | Folder conventions, extraction/reuse, naming |
+| `colonizethis-code-review.mdc` | `app/lib/**/*.dart`, `packages/*/lib/**/*.dart`, `tool/**/*.dart` | Review checklist and quality gates |
+| `colonizethis-lifecycle.mdc` | `app/lib/game/**/*.dart`, `app/lib/widgets/**/*.dart`, `app/lib/ui/**/*.dart`, `app/lib/screens/**/*.dart`, `app/lib/pages/**/*.dart` | Flame/Flutter lifecycle conventions |
+| `colonizethis-assets.mdc` | `**/pubspec.yaml`, `**/assets/**`, targeted asset-loading Dart files | Asset structure, naming, loading |
 | `colonizethis-acceptance-criteria.mdc` | `SPEC/ai/**`, `SPEC/game/**`, `SPEC/program/**`, `SPEC/ui/**` | Given–When–Then, testable AC quality |
 
 ## Rule interaction
 
 Multiple context-specific rules may apply to a single file (e.g., a UI widget may match both `ui-design` and `component-structure`). All applicable rules are **additive**; when they conflict, the more specific rule takes precedence (e.g., testing rules override general code-review for test files).
 
-## Quick reference
+## Routing reference
 
-1. **SPEC-first**: Check/extend SPEC first; implement only spec-authorized behavior. See `colonizethis-spec-required.mdc`.
-2. **Separation of concerns**: Keep Flutter UI and Flame simulation concerns separated. See `colonizethis-core-principles.mdc`.
-3. **Thin screens**: Prefer reuse; keep screens thin and delegate logic to services/controllers/components. See `colonizethis-component-structure.mdc`.
-4. **Coverage policy**: **90% for logic/ai/map packages; 80% everywhere else**. See `colonizethis-testing.mdc`.
-5. **Widget tests**: Run app/ctdev widget tests with `flutter test` (or `melos run test_app`), not `dart test app/...`. See `colonizethis-testing.mdc`.
-6. **E2E UI stability**: In UI-heavy e2e tests, prefer deterministic widget locators, scope finders to roots, and ensure visibility before taps; avoid coordinate-based gestures unless unavoidable. See `colonizethis-e2e-ui-stability.mdc`.
-7. **Logging**: Policy and annexes: `SPEC/program/logging/logging.md`; ctdev file/Sim Log: `SPEC/program/ctdev-logging.md`; use `basic_logger_file` per `colonizethis-logging-file.mdc` where file sinks apply.
-8. **Cross-panel UI orchestration**: "Panels" refers to app panels/dialogs/components. Panels should **not** directly invoke or depend on each other unless absolutely necessary. Use `AppEventBus` for cross-panel communication. See `SPEC/program/app-ui-wiring.md` and `SPEC/program/app-event-bus.md`.
+- Use `.cursor/rules/routing-index.md` to determine applicability and precedence.
+- Treat `.cursor/rules/*.mdc` files as the only normative policy source.
+- Keep this file and OpenCode references pointer-based; avoid duplicating normative rule text.
 
 For complete details, read the relevant rule file(s) in `.cursor/rules/`.
 

--- a/app/lib/features/game/flame/game_map_area_part2.dart
+++ b/app/lib/features/game/flame/game_map_area_part2.dart
@@ -117,28 +117,10 @@ mixin _GameMapAreaStatePart2
                               _workTargetSelection != null
                               ? _cancelWorkTargetSelection
                               : null,
-                          onCivilianTileTapped: (tileKey) {
-                            String? initialSelectedUnitId;
-                            for (final marker
-                                in projectedRegion.civilianTileMarkers) {
-                              if (marker.tileKey == tileKey &&
-                                  marker.unitIds.isNotEmpty) {
-                                initialSelectedUnitId = marker.unitIds.first;
-                                break;
-                              }
-                            }
+                          onCivilianTileStateChanged: (tileKey) {
                             setState(() {
                               _selectedCivilianTileKey = tileKey;
                             });
-                            ref
-                                .read(appEventBusProvider)
-                                .emit(
-                                  ct_models.OpenCivilianUnitsPanelEvent(
-                                    tileScopeTileKey: tileKey,
-                                    initialSelectedUnitId:
-                                        initialSelectedUnitId,
-                                  ),
-                                );
                           },
                           onCivilianTileSelectionCleared: () {
                             if (_selectedCivilianTileKey == null) return;
@@ -146,22 +128,6 @@ mixin _GameMapAreaStatePart2
                               _selectedCivilianTileKey = null;
                             });
                           },
-                          onFleetMarkerTapped:
-                              (
-                                locationScopeKey,
-                                initialFleetId,
-                                markerTileKey,
-                              ) {
-                                ref
-                                    .read(appEventBusProvider)
-                                    .emit(
-                                      ct_models.OpenNavalUnitsPanelEvent(
-                                        locationScopeKey: locationScopeKey,
-                                        initialSelectedFleetId: initialFleetId,
-                                        tileScopeTileKey: markerTileKey,
-                                      ),
-                                    );
-                              },
                           bus: ref.read(appEventBusProvider),
                           onRegionViewportSnapshot: _onRegionViewportSnapshot,
                           zoomMultiplier: _mapViewState.zoomMultiplier,

--- a/app/lib/features/game/flame/game_map_canvas_stack.dart
+++ b/app/lib/features/game/flame/game_map_canvas_stack.dart
@@ -34,8 +34,7 @@ class GameMapCanvasStack extends ConsumerWidget {
     required this.onTileSelectedForWork,
     required this.onWorkTargetSelectionCancelled,
     required this.selectedCivilianTileKey,
-    required this.onCivilianTileTapped,
-    this.onFleetMarkerTapped,
+    required this.onCivilianTileStateChanged,
     required this.onCivilianTileSelectionCleared,
     required this.onRegionViewportSnapshot,
     required this.zoomMultiplier,
@@ -59,13 +58,7 @@ class GameMapCanvasStack extends ConsumerWidget {
   final void Function(String tileKey)? onTileSelectedForWork;
   final VoidCallback? onWorkTargetSelectionCancelled;
   final String? selectedCivilianTileKey;
-  final void Function(String tileKey)? onCivilianTileTapped;
-  final void Function(
-    String locationScopeKey,
-    String? initialFleetId,
-    String markerTileKey,
-  )?
-  onFleetMarkerTapped;
+  final void Function(String tileKey)? onCivilianTileStateChanged;
   final VoidCallback? onCivilianTileSelectionCleared;
   final void Function(RegionMapViewportSnapshot snapshot)
   onRegionViewportSnapshot;
@@ -100,12 +93,9 @@ class GameMapCanvasStack extends ConsumerWidget {
                             .reportMapTileTapped(tk),
                   onProvinceHovered: (_) {},
                   onTileHovered: (_) {},
-                  onCivilianTileTapped: inWorkTargetSelectionMode
+                  onCivilianTileStateChanged: inWorkTargetSelectionMode
                       ? null
-                      : onCivilianTileTapped,
-                  onFleetMarkerTapped: inWorkTargetSelectionMode
-                      ? null
-                      : onFleetMarkerTapped,
+                      : onCivilianTileStateChanged,
                   onCivilianTileSelectionCleared: inWorkTargetSelectionMode
                       ? null
                       : onCivilianTileSelectionCleared,
@@ -117,7 +107,7 @@ class GameMapCanvasStack extends ConsumerWidget {
                   onTileSelected: onTileSelectedForWork,
                   onWorkTargetSelectionCancelled:
                       onWorkTargetSelectionCancelled,
-                  bus: bus,
+                  bus: inWorkTargetSelectionMode ? null : bus,
                   onViewportSnapshotChanged: onRegionViewportSnapshot,
                   zoomMultiplier: zoomMultiplier,
                 ),

--- a/app/lib/widgets/ct_region_map.dart
+++ b/app/lib/widgets/ct_region_map.dart
@@ -35,8 +35,7 @@ class CtRegionMap extends StatefulWidget {
     this.onRegionViewChanged,
     this.onProvinceHovered,
     this.onTileHovered,
-    this.onCivilianTileTapped,
-    this.onFleetMarkerTapped,
+    this.onCivilianTileStateChanged,
     this.onCivilianTileSelectionCleared,
     this.selectedTileKey,
     this.selectedCivilianTileKey,
@@ -66,13 +65,7 @@ class CtRegionMap extends StatefulWidget {
   final VoidCallback? onRegionViewChanged;
   final void Function(String? provinceId)? onProvinceHovered;
   final void Function(String? tileKey)? onTileHovered;
-  final void Function(String tileKey)? onCivilianTileTapped;
-  final void Function(
-    String locationScopeKey,
-    String? initialFleetId,
-    String markerTileKey,
-  )?
-  onFleetMarkerTapped;
+  final void Function(String tileKey)? onCivilianTileStateChanged;
   final VoidCallback? onCivilianTileSelectionCleared;
   final String? selectedTileKey;
   final String? selectedCivilianTileKey;
@@ -152,8 +145,8 @@ class _CtRegionMapState extends State<CtRegionMap> {
         widget.visibilityMode != oldWidget.visibilityMode ||
         widget.baseLayerDisplayMode != oldWidget.baseLayerDisplayMode ||
         widget.validTileKeys != oldWidget.validTileKeys ||
-        widget.onCivilianTileTapped != oldWidget.onCivilianTileTapped ||
-        widget.onFleetMarkerTapped != oldWidget.onFleetMarkerTapped ||
+        widget.onCivilianTileStateChanged !=
+            oldWidget.onCivilianTileStateChanged ||
         widget.onCivilianTileSelectionCleared !=
             oldWidget.onCivilianTileSelectionCleared ||
         widget.selectedTileKey != oldWidget.selectedTileKey ||
@@ -189,8 +182,8 @@ class _CtRegionMapState extends State<CtRegionMap> {
             widget.validTileKeys == null && oldWidget.validTileKeys != null,
         onTileSelected: widget.onTileSelected,
         onWorkTargetSelectionCancelled: widget.onWorkTargetSelectionCancelled,
-        onCivilianTileTapped: widget.onCivilianTileTapped,
-        onFleetMarkerTapped: widget.onFleetMarkerTapped,
+        onCivilianTileTapped: _handleCivilianTileTapped,
+        onFleetMarkerTapped: _handleFleetMarkerTapped,
         onCivilianTileSelectionCleared: widget.onCivilianTileSelectionCleared,
         playerViewForResources: widget.playerViewForResources,
         onViewportSnapshotChanged: widget.onViewportSnapshotChanged,
@@ -225,8 +218,8 @@ class _CtRegionMapState extends State<CtRegionMap> {
       onRegionViewChanged: widget.onRegionViewChanged,
       onProvinceHovered: widget.onProvinceHovered,
       onTileHovered: widget.onTileHovered,
-      onCivilianTileTapped: widget.onCivilianTileTapped,
-      onFleetMarkerTapped: widget.onFleetMarkerTapped,
+      onCivilianTileTapped: _handleCivilianTileTapped,
+      onFleetMarkerTapped: _handleFleetMarkerTapped,
       onCivilianTileSelectionCleared: widget.onCivilianTileSelectionCleared,
       selectedTileKey: widget.selectedTileKey,
       selectedCivilianTileKey: widget.selectedCivilianTileKey,
@@ -242,6 +235,41 @@ class _CtRegionMapState extends State<CtRegionMap> {
       playerViewForResources: widget.playerViewForResources,
       onViewportSnapshotChanged: widget.onViewportSnapshotChanged,
       initialZoomMultiplier: widget.zoomMultiplier ?? 1.0,
+    );
+  }
+
+  void _handleCivilianTileTapped(String tileKey) {
+    widget.onCivilianTileStateChanged?.call(tileKey);
+    final bus = widget.bus;
+    if (bus == null) {
+      return;
+    }
+    String? initialSelectedUnitId;
+    for (final marker in widget.region.civilianTileMarkers) {
+      if (marker.tileKey == tileKey && marker.unitIds.isNotEmpty) {
+        initialSelectedUnitId = marker.unitIds.first;
+        break;
+      }
+    }
+    bus.emit(
+      OpenCivilianUnitsPanelEvent(
+        tileScopeTileKey: tileKey,
+        initialSelectedUnitId: initialSelectedUnitId,
+      ),
+    );
+  }
+
+  void _handleFleetMarkerTapped(
+    String locationScopeKey,
+    String? initialFleetId,
+    String markerTileKey,
+  ) {
+    widget.bus?.emit(
+      OpenNavalUnitsPanelEvent(
+        locationScopeKey: locationScopeKey,
+        initialSelectedFleetId: initialFleetId,
+        tileScopeTileKey: markerTileKey,
+      ),
     );
   }
 

--- a/app/test/ct_region_map_test_support.dart
+++ b/app/test/ct_region_map_test_support.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_logic/colonizethis_logic.dart' show PlayerView;
 import 'package:colonizethis_map/colonizethis_map.dart';
-import 'package:colonizethis_models/colonizethis_models.dart' show Player;
+import 'package:colonizethis_models/colonizethis_models.dart'
+    show AppEventBus, Player;
 import 'package:flutter/material.dart';
 
 import 'package:colonizethis_app/widgets/ct_region_map.dart'
@@ -40,13 +41,14 @@ Widget ctRegionMapTestHarness({
   void Function(String?)? onProvinceHovered,
   void Function(String?)? onTileHovered,
   void Function(String)? onMapTileTappedForDetail,
-  void Function(String)? onCivilianTileTapped,
+  void Function(String)? onCivilianTileStateChanged,
   VoidCallback? onCivilianTileSelectionCleared,
   String? selectedTileKey,
   String? selectedCivilianTileKey,
   String? secondaryHighlightTileKey,
   VoidCallback? onRegionViewChanged,
   PlayerView? playerViewForResources,
+  AppEventBus? bus,
 }) {
   return MaterialApp(
     home: Scaffold(
@@ -69,12 +71,13 @@ Widget ctRegionMapTestHarness({
             onProvinceHovered: onProvinceHovered,
             onTileHovered: onTileHovered,
             onMapTileTappedForDetail: onMapTileTappedForDetail,
-            onCivilianTileTapped: onCivilianTileTapped,
+            onCivilianTileStateChanged: onCivilianTileStateChanged,
             onCivilianTileSelectionCleared: onCivilianTileSelectionCleared,
             selectedTileKey: selectedTileKey,
             selectedCivilianTileKey: selectedCivilianTileKey,
             secondaryHighlightTileKey: secondaryHighlightTileKey,
             onRegionViewChanged: onRegionViewChanged,
+            bus: bus,
           ),
         ),
       ),

--- a/app/test/ct_region_map_widget_test_part2_test.dart
+++ b/app/test/ct_region_map_widget_test_part2_test.dart
@@ -8,7 +8,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart' show TerrainType;
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart'
-    show AppEventBus, OpenProvinceDetailPanelEvent, kUnitTypeBuilder;
+    show
+        AppEventBus,
+        OpenCivilianUnitsPanelEvent,
+        OpenNavalUnitsPanelEvent,
+        OpenProvinceDetailPanelEvent,
+        kUnitTypeBuilder;
 
 import 'package:colonizethis_app/features/game/flame/resource_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
@@ -445,6 +450,13 @@ void main() {
         String? tappedCivilianTileKey;
         String? detailTileKey;
         String? selectedProvinceId;
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+        final openedPanels = <OpenCivilianUnitsPanelEvent>[];
+        final panelSub = bus.on<OpenCivilianUnitsPanelEvent>().listen(
+          openedPanels.add,
+        );
+        addTearDown(panelSub.cancel);
 
         await tester.pumpWidget(
           ctRegionMapTestHarness(
@@ -452,7 +464,9 @@ void main() {
             width: 64,
             height: 64,
             cellSizePx: 32,
-            onCivilianTileTapped: (tileKey) => tappedCivilianTileKey = tileKey,
+            bus: bus,
+            onCivilianTileStateChanged: (tileKey) =>
+                tappedCivilianTileKey = tileKey,
             onMapTileTappedForDetail: (tileKey) => detailTileKey = tileKey,
             onProvinceSelected: (id) => selectedProvinceId = id,
           ),
@@ -464,8 +478,86 @@ void main() {
         await tester.pump();
 
         expect(tappedCivilianTileKey, equals(markerTileKey));
+        expect(openedPanels, hasLength(1));
+        expect(openedPanels.single.tileScopeTileKey, equals(markerTileKey));
+        expect(openedPanels.single.initialSelectedUnitId, equals('u_builder'));
         expect(detailTileKey, isNull);
         expect(selectedProvinceId, isNull);
+      },
+      timeout: const Timeout(Duration(seconds: 5)),
+    );
+
+    testWidgets(
+      'tapping fleet marker emits naval units panel event',
+      (WidgetTester tester) async {
+        final base = ctRegionMapTestOldWorldRegion();
+        final seaTemplate = base.cells.firstWhere((c) => c.isSea);
+        const markerTileKey = 'oldWorld|sMarker|0|0';
+        final region = RegionMapViewData(
+          regionId: 'oldWorld',
+          width: 1,
+          height: 1,
+          cellSize: 24,
+          cells: [
+            CellViewData(
+              x: 0,
+              y: 0,
+              regionCellId: 'sMarker',
+              isSea: true,
+              terrainTypeId: seaTemplate.terrainTypeId,
+              terrainType: seaTemplate.terrainType,
+              ownerFactionId: seaTemplate.ownerFactionId,
+              provinceDisplayName: 'Marker Sea',
+            ),
+          ],
+          capitalMarkers: const [],
+          portMarkers: const [],
+          townMarkers: const [],
+          factionColors: base.factionColors,
+          greatPowerFactionIds: base.greatPowerFactionIds,
+          terrainColors: base.terrainColors,
+          unitMarkers: const [],
+          fleetTileMarkers: [
+            FleetTileMarkerView(
+              tileKey: markerTileKey,
+              x: 0,
+              y: 0,
+              locationScopeKey: 'sea:oldWorld|fleet_scope',
+              fleetIds: const ['fleet_1'],
+              stackCount: 1,
+            ),
+          ],
+          civilianTileMarkers: const [],
+          warpMarkers: const [],
+        );
+        final bus = AppEventBus.create();
+        addTearDown(bus.dispose);
+        final openedPanels = <OpenNavalUnitsPanelEvent>[];
+        final panelSub = bus.on<OpenNavalUnitsPanelEvent>().listen(
+          openedPanels.add,
+        );
+        addTearDown(panelSub.cancel);
+
+        await tester.pumpWidget(
+          ctRegionMapTestHarness(
+            region: region,
+            width: 64,
+            height: 64,
+            cellSizePx: 32,
+            bus: bus,
+          ),
+        );
+        await tester.pump();
+        await tester.tap(find.byType(CtRegionMap));
+        await tester.pump();
+
+        expect(openedPanels, hasLength(1));
+        expect(
+          openedPanels.single.locationScopeKey,
+          equals('sea:oldWorld|fleet_scope'),
+        );
+        expect(openedPanels.single.initialSelectedFleetId, equals('fleet_1'));
+        expect(openedPanels.single.tileScopeTileKey, equals(markerTileKey));
       },
       timeout: const Timeout(Duration(seconds: 5)),
     );
@@ -1015,7 +1107,5 @@ void main() {
       },
       timeout: const Timeout(Duration(seconds: 10)),
     );
-
-
   });
 }

--- a/app/test/game_map_area_selection_mode_test.dart
+++ b/app/test/game_map_area_selection_mode_test.dart
@@ -545,8 +545,8 @@ void main() {
 
     var regionMap = tester.widget<CtRegionMap>(find.byType(CtRegionMap).first);
     expect(regionMap.onMapTileTappedForDetail, isNotNull);
-    expect(regionMap.onCivilianTileTapped, isNotNull);
-    expect(regionMap.onFleetMarkerTapped, isNotNull);
+    expect(regionMap.onCivilianTileStateChanged, isNotNull);
+    expect(regionMap.bus, isNotNull);
 
     bus.emit(
       StartCivilianWorkTargetSelectionEvent(
@@ -560,7 +560,7 @@ void main() {
     expect(find.text('Select a tile, or click cancel'), findsOneWidget);
     regionMap = tester.widget<CtRegionMap>(find.byType(CtRegionMap).first);
     expect(regionMap.onMapTileTappedForDetail, isNull);
-    expect(regionMap.onCivilianTileTapped, isNull);
-    expect(regionMap.onFleetMarkerTapped, isNull);
+    expect(regionMap.onCivilianTileStateChanged, isNull);
+    expect(regionMap.bus, isNull);
   });
 }

--- a/packages/colonizethis_logic/lib/src/world/naval_mission_orders.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_mission_orders.dart
@@ -1,0 +1,139 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../constants.dart';
+import '../diplomacy/diplomacy_relation_lookup.dart';
+import 'naval.dart';
+import 'province_lookup.dart';
+
+FleetMission _fleetMissionFromOrderName(String name) {
+  for (final m in FleetMission.values) {
+    if (m.name == name) return m;
+  }
+  return FleetMission.none;
+}
+
+List<Fleet> _applySingleNavalMissionOrder({
+  required Game game,
+  required List<Fleet> fleets,
+  required Map<String, Fleet> fleetById,
+  required String playerId,
+  required NavalMissionOrder order,
+}) {
+  final fleet = fleetById[order.fleetId];
+  if (fleet == null || fleet.ownerId != playerId) return fleets;
+  final homeFleetId = homeFleetIdFor(playerId);
+
+  if (order.mission == 'join_home_fleet') {
+    final homeFleet = fleetById[homeFleetId];
+    if (homeFleet == null) return fleets;
+    final capitalProvinceId = game.playerById(playerId)?.capitalProvinceId;
+    if (capitalProvinceId == null ||
+        fleet.inPortAtProvinceId != capitalProvinceId) {
+      return fleets;
+    }
+    if (fleet.shipTypeIds.isEmpty) return fleets;
+    final updatedHome = homeFleet.copyWith(
+      ships: [...homeFleet.ships, ...fleet.ships],
+    );
+    final next = fleets
+        .where((f) => f.id != fleet.id)
+        .map((f) => f.id == homeFleetId ? updatedHome : f)
+        .toList();
+    fleetById[homeFleetId] = updatedHome;
+    return next;
+  }
+
+  if (fleet.id == homeFleetId) {
+    return fleets;
+  }
+  final mission = _fleetMissionFromOrderName(order.mission);
+
+  if (mission == FleetMission.blockade) {
+    final targetProvinceId = order.targetProvinceId;
+    final province =
+        targetProvinceId != null &&
+            targetProvinceId.isNotEmpty &&
+            ProvinceId.isPrefixed(targetProvinceId)
+        ? game.worldState.tryGetProvince(targetProvinceId)
+        : null;
+    final ownerId = province?.ownerId;
+    final atWar =
+        ownerId != null &&
+        ownerId != playerId &&
+        factionsAtWar(game, playerId, ownerId);
+    if (!atWar) {
+      final cleared = fleet.copyWith(
+        mission: FleetMission.none,
+        targetPortId: null,
+        targetProvinceId: null,
+      );
+      final idx = fleets.indexWhere((f) => f.id == fleet.id);
+      if (idx >= 0) {
+        final next = List<Fleet>.from(fleets)..[idx] = cleared;
+        fleetById[fleet.id] = cleared;
+        return next;
+      }
+      return fleets;
+    }
+  }
+
+  final newFleet = fleet.copyWith(
+    mission: mission,
+    targetPortId: order.targetPortId,
+    targetProvinceId: order.targetProvinceId,
+  );
+  final idx = fleets.indexWhere((f) => f.id == fleet.id);
+  if (idx >= 0) {
+    final next = List<Fleet>.from(fleets)..[idx] = newFleet;
+    fleetById[fleet.id] = newFleet;
+    return next;
+  }
+  return fleets;
+}
+
+Game applyNavalMissionOrders(
+  Game game,
+  Map<String, List<NavalMissionOrder>> navalMissionOrdersByPlayerId,
+) {
+  var fleets = List<Fleet>.from(game.worldState.fleets);
+  final fleetById = {for (final f in fleets) f.id: f};
+
+  for (final entry in navalMissionOrdersByPlayerId.entries) {
+    final playerId = entry.key;
+    for (final order in entry.value) {
+      fleets = _applySingleNavalMissionOrder(
+        game: game,
+        fleets: fleets,
+        fleetById: fleetById,
+        playerId: playerId,
+        order: order,
+      );
+    }
+  }
+
+  for (var i = 0; i < fleets.length; i++) {
+    final f = fleets[i];
+    if (f.mission != FleetMission.blockade) continue;
+    final targetProvinceId = f.targetProvinceId;
+    if (targetProvinceId == null || targetProvinceId.isEmpty) continue;
+    final province = ProvinceId.isPrefixed(targetProvinceId)
+        ? game.worldState.tryGetProvince(targetProvinceId)
+        : null;
+    final ownerId = province?.ownerId;
+    final atWar =
+        ownerId != null &&
+        ownerId != f.ownerId &&
+        factionsAtWar(game, f.ownerId, ownerId);
+    if (!atWar) {
+      fleets = List<Fleet>.from(fleets)
+        ..[i] = f.copyWith(
+          mission: FleetMission.none,
+          targetPortId: null,
+          targetProvinceId: null,
+        );
+    }
+  }
+
+  return game.copyWith(worldState: game.worldState.copyWith(fleets: fleets));
+}

--- a/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
@@ -12,6 +12,7 @@ import '../game_events.dart';
 import '../turn/turn_seed_constants.dart';
 import 'naval.dart';
 import 'naval_coastal_visibility.dart';
+import 'naval_mission_orders.dart';
 import 'province_lookup.dart' hide landTileKeysForProvinceBucket;
 import 'topology_helpers.dart';
 
@@ -22,6 +23,7 @@ export 'naval_coastal_visibility.dart'
         landTileKeysForProvinceBucket,
         revealProvinceTilesForPlayer,
         revealTilesAfterMoveToSeaZone;
+export 'naval_mission_orders.dart' show applyNavalMissionOrders;
 
 final _log = packageLogger();
 
@@ -55,138 +57,6 @@ String? _firstFriendlyOrNeutralRetreatZone(
     if (!hostileOwnersPresent) return adj;
   }
   return null;
-}
-
-FleetMission _fleetMissionFromOrderName(String name) {
-  for (final m in FleetMission.values) {
-    if (m.name == name) return m;
-  }
-  return FleetMission.none;
-}
-
-List<Fleet> _applySingleNavalMissionOrder({
-  required Game game,
-  required List<Fleet> fleets,
-  required Map<String, Fleet> fleetById,
-  required String playerId,
-  required NavalMissionOrder order,
-}) {
-  final fleet = fleetById[order.fleetId];
-  if (fleet == null || fleet.ownerId != playerId) return fleets;
-  final homeFleetId = homeFleetIdFor(playerId);
-
-  if (order.mission == 'join_home_fleet') {
-    final homeFleet = fleetById[homeFleetId];
-    if (homeFleet == null) return fleets;
-    final capitalProvinceId = game.playerById(playerId)?.capitalProvinceId;
-    if (capitalProvinceId == null ||
-        fleet.inPortAtProvinceId != capitalProvinceId) {
-      return fleets;
-    }
-    if (fleet.shipTypeIds.isEmpty) return fleets;
-    final updatedHome = homeFleet.copyWith(
-      ships: [...homeFleet.ships, ...fleet.ships],
-    );
-    final next = fleets
-        .where((f) => f.id != fleet.id)
-        .map((f) => f.id == homeFleetId ? updatedHome : f)
-        .toList();
-    fleetById[homeFleetId] = updatedHome;
-    return next;
-  }
-
-  if (fleet.id == homeFleetId) {
-    return fleets;
-  }
-  final mission = _fleetMissionFromOrderName(order.mission);
-
-  if (mission == FleetMission.blockade) {
-    final targetProvinceId = order.targetProvinceId;
-    final province =
-        targetProvinceId != null &&
-            targetProvinceId.isNotEmpty &&
-            ProvinceId.isPrefixed(targetProvinceId)
-        ? game.worldState.tryGetProvince(targetProvinceId)
-        : null;
-    final ownerId = province?.ownerId;
-    final atWar =
-        ownerId != null &&
-        ownerId != playerId &&
-        factionsAtWar(game, playerId, ownerId);
-    if (!atWar) {
-      final cleared = fleet.copyWith(
-        mission: FleetMission.none,
-        targetPortId: null,
-        targetProvinceId: null,
-      );
-      final idx = fleets.indexWhere((f) => f.id == fleet.id);
-      if (idx >= 0) {
-        final next = List<Fleet>.from(fleets)..[idx] = cleared;
-        fleetById[fleet.id] = cleared;
-        return next;
-      }
-      return fleets;
-    }
-  }
-
-  final newFleet = fleet.copyWith(
-    mission: mission,
-    targetPortId: order.targetPortId,
-    targetProvinceId: order.targetProvinceId,
-  );
-  final idx = fleets.indexWhere((f) => f.id == fleet.id);
-  if (idx >= 0) {
-    final next = List<Fleet>.from(fleets)..[idx] = newFleet;
-    fleetById[fleet.id] = newFleet;
-    return next;
-  }
-  return fleets;
-}
-
-Game applyNavalMissionOrders(
-  Game game,
-  Map<String, List<NavalMissionOrder>> navalMissionOrdersByPlayerId,
-) {
-  var fleets = List<Fleet>.from(game.worldState.fleets);
-  final fleetById = {for (final f in fleets) f.id: f};
-
-  for (final entry in navalMissionOrdersByPlayerId.entries) {
-    final playerId = entry.key;
-    for (final order in entry.value) {
-      fleets = _applySingleNavalMissionOrder(
-        game: game,
-        fleets: fleets,
-        fleetById: fleetById,
-        playerId: playerId,
-        order: order,
-      );
-    }
-  }
-
-  for (var i = 0; i < fleets.length; i++) {
-    final f = fleets[i];
-    if (f.mission != FleetMission.blockade) continue;
-    final targetProvinceId = f.targetProvinceId;
-    if (targetProvinceId == null || targetProvinceId.isEmpty) continue;
-    final province = ProvinceId.isPrefixed(targetProvinceId)
-        ? game.worldState.tryGetProvince(targetProvinceId)
-        : null;
-    final ownerId = province?.ownerId;
-    final atWar =
-        ownerId != null &&
-        ownerId != f.ownerId &&
-        factionsAtWar(game, f.ownerId, ownerId);
-    if (!atWar) {
-      fleets = List<Fleet>.from(fleets)
-        ..[i] = f.copyWith(
-          mission: FleetMission.none,
-          targetPortId: null,
-          targetProvinceId: null,
-        );
-    }
-  }
-
-  return game.copyWith(worldState: game.worldState.copyWith(fleets: fleets));
 }
 
 bool _navalMoveDestinationIsReachable({

--- a/test/check_app_widget_imports_test.dart
+++ b/test/check_app_widget_imports_test.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../tool/check_app_widget_imports.dart';
+
+void main() {
+  test('fails when non-allowlisted widget imports features path', () {
+    final temp = Directory.systemTemp.createTempSync(
+      'check_app_widget_imports_fail_',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    final violatingFile = File('${temp.path}/app/lib/widgets/bad_widget.dart')
+      ..createSync(recursive: true);
+    violatingFile.writeAsStringSync(
+      "import '../features/game/flame/ct_region_map_game.dart';\nclass A {}\n",
+    );
+
+    final logs = <String>[];
+    final code = runCheckAppWidgetImports(
+      temp.path,
+      info: logs.add,
+      err: logs.add,
+    );
+
+    expect(code, 1);
+    expect(logs.join('\n'), contains('bad_widget.dart:1'));
+  });
+
+  test('fails when non-allowlisted widget exports package features path', () {
+    final temp = Directory.systemTemp.createTempSync(
+      'check_app_widget_imports_pkg_fail_',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    final violatingFile = File('${temp.path}/app/lib/widgets/bad_export.dart')
+      ..createSync(recursive: true);
+    violatingFile.writeAsStringSync(
+      "export 'package:colonizethis_app/features/game/widgets/a.dart';\n",
+    );
+
+    expect(runCheckAppWidgetImports(temp.path, err: (_) {}), 1);
+  });
+
+  test('passes for known allowlisted bridge widget', () {
+    final temp = Directory.systemTemp.createTempSync(
+      'check_app_widget_imports_allowlist_',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    final allowlistedFile = File('${temp.path}/app/lib/widgets/ct_panel.dart')
+      ..createSync(recursive: true);
+    allowlistedFile.writeAsStringSync(
+      "export '../features/game/widgets/chrome/ct_panel.dart';\n",
+    );
+
+    expect(runCheckAppWidgetImports(temp.path), 0);
+  });
+
+  test('ignores line comments and non-feature imports', () {
+    final temp = Directory.systemTemp.createTempSync(
+      'check_app_widget_imports_comment_',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    final okFile = File('${temp.path}/app/lib/widgets/ok.dart')
+      ..createSync(recursive: true);
+    okFile.writeAsStringSync(
+      "// import '../features/game/flame/ct_region_map_game.dart';\n"
+      "import 'package:flutter/widgets.dart';\n"
+      'class A {}\n',
+    );
+
+    expect(runCheckAppWidgetImports(temp.path), 0);
+  });
+}

--- a/test/check_rule_routing_test.dart
+++ b/test/check_rule_routing_test.dart
@@ -1,0 +1,107 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../tool/check_rule_routing.dart';
+
+void main() {
+  test('passes when routing index, globs, and pointers are present', () {
+    final tempDir = Directory.systemTemp.createTempSync(
+      'check_rule_routing_pass_',
+    );
+    addTearDown(() => tempDir.deleteSync(recursive: true));
+
+    _writeFixture(tempDir.path);
+    final stdoutLines = <String>[];
+    final code = runCheckRuleRouting(tempDir.path, info: stdoutLines.add);
+
+    expect(code, 0);
+    expect(stdoutLines.join('\n'), contains('no violations found'));
+  });
+
+  test('fails when lifecycle rule still uses broad glob', () {
+    final tempDir = Directory.systemTemp.createTempSync(
+      'check_rule_routing_fail_',
+    );
+    addTearDown(() => tempDir.deleteSync(recursive: true));
+
+    _writeFixture(
+      tempDir.path,
+      lifecycleGlob: '**/*.dart',
+      includeRoutingPointerInAgents: false,
+    );
+    final stderrLines = <String>[];
+    final code = runCheckRuleRouting(tempDir.path, err: stderrLines.add);
+
+    expect(code, 1);
+    expect(
+      stderrLines.join('\n'),
+      contains('colonizethis-lifecycle.mdc must define targeted globs.'),
+    );
+    expect(
+      stderrLines.join('\n'),
+      contains('colonizethis-lifecycle.mdc still uses broad **/*.dart glob.'),
+    );
+    expect(
+      stderrLines.join('\n'),
+      contains('AGENTS.md must reference the routing index.'),
+    );
+  });
+}
+
+void _writeFixture(
+  String root, {
+  String lifecycleGlob =
+      'app/lib/game/**/*.dart,app/lib/widgets/**/*.dart,app/lib/ui/**/*.dart,app/lib/screens/**/*.dart,app/lib/pages/**/*.dart',
+  bool includeRoutingPointerInAgents = true,
+}) {
+  File(p.join(root, '.cursor', 'rules', 'routing-index.md'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync('# Routing index');
+
+  File(p.join(root, '.cursor', 'rules', 'colonizethis-component-structure.mdc'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+---
+globs: "app/lib/**/*.dart,packages/*/lib/**/*.dart,tool/**/*.dart"
+---
+''');
+
+  File(p.join(root, '.cursor', 'rules', 'colonizethis-code-review.mdc'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+---
+globs: "app/lib/**/*.dart,packages/*/lib/**/*.dart,tool/**/*.dart"
+---
+''');
+
+  File(p.join(root, '.cursor', 'rules', 'colonizethis-lifecycle.mdc'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+---
+globs: "$lifecycleGlob"
+---
+''');
+
+  File(
+      p.join(
+        root,
+        '.opencode',
+        'skills',
+        'refactoring-opportunity-github-issue',
+        'references',
+        'ci-and-rules.md',
+      ),
+    )
+    ..createSync(recursive: true)
+    ..writeAsStringSync('see .cursor/rules/routing-index.md');
+
+  File(p.join(root, 'AGENTS.md'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync(
+      includeRoutingPointerInAgents
+          ? 'see .cursor/rules/routing-index.md'
+          : 'missing routing pointer',
+    );
+}

--- a/tool/check_app_widget_imports.dart
+++ b/tool/check_app_widget_imports.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+const Set<String> _allowedFeatureBridgeWidgetFiles = {
+  'app/lib/widgets/ct_dialog_shell.dart',
+  'app/lib/widgets/ct_nine_patch_button.dart',
+  'app/lib/widgets/ct_panel.dart',
+  'app/lib/widgets/ct_region_map.dart',
+};
+
+/// PR-blocking structural check: `app/lib/widgets/**` must not import/export
+/// `app/lib/features/**` paths (except temporary bridge wrappers).
+///
+/// SPEC: SPEC/program/repo-lint.md
+int runCheckAppWidgetImports(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+  final widgetsDir = Directory(p.join(repoRoot, 'app', 'lib', 'widgets'));
+  if (!widgetsDir.existsSync()) {
+    logE('check_app_widget_imports: app/lib/widgets not found.');
+    return 1;
+  }
+
+  final featureImportLine = RegExp(
+    r'''^\s*(import|export)\s+(['"])(?:\.\./features/|package:colonizethis_app/features/)''',
+  );
+  final violations = <String>[];
+  for (final entity in widgetsDir.listSync(recursive: true, followLinks: false)) {
+    if (entity is! File || !entity.path.endsWith('.dart')) {
+      continue;
+    }
+    final relativePath = p.relative(entity.path, from: repoRoot);
+    if (_allowedFeatureBridgeWidgetFiles.contains(relativePath)) {
+      continue;
+    }
+    final lines = const LineSplitter().convert(entity.readAsStringSync());
+    for (var i = 0; i < lines.length; i++) {
+      final line = lines[i];
+      final trimmedLeft = line.trimLeft();
+      if (trimmedLeft.startsWith('//')) {
+        continue;
+      }
+      if (!featureImportLine.hasMatch(line)) {
+        continue;
+      }
+      violations.add('$relativePath:${i + 1}: ${line.trim()}');
+    }
+  }
+
+  if (violations.isEmpty) {
+    logI('check_app_widget_imports: no violations found.');
+    return 0;
+  }
+
+  logE(
+    'check_app_widget_imports: found ${violations.length} violation(s) under app/lib/widgets:',
+  );
+  for (final violation in violations) {
+    logE(' - $violation');
+  }
+  return 1;
+}
+
+void main() {
+  exit(runCheckAppWidgetImports(Directory.current.path));
+}

--- a/tool/check_rule_routing.dart
+++ b/tool/check_rule_routing.dart
@@ -1,0 +1,76 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+const Map<String, String> _requiredGlobs = {
+  '.cursor/rules/colonizethis-component-structure.mdc':
+      'app/lib/**/*.dart,packages/*/lib/**/*.dart,tool/**/*.dart',
+  '.cursor/rules/colonizethis-code-review.mdc':
+      'app/lib/**/*.dart,packages/*/lib/**/*.dart,tool/**/*.dart',
+  '.cursor/rules/colonizethis-lifecycle.mdc':
+      'app/lib/game/**/*.dart,app/lib/widgets/**/*.dart,app/lib/ui/**/*.dart,app/lib/screens/**/*.dart,app/lib/pages/**/*.dart',
+};
+
+const Set<String> _requiredPointers = {
+  'AGENTS.md',
+  '.opencode/skills/refactoring-opportunity-github-issue/references/ci-and-rules.md',
+};
+
+int runCheckRuleRouting(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logInfo = info ?? stdout.writeln;
+  final logErr = err ?? stderr.writeln;
+  final violations = <String>[];
+
+  final routingIndex = File(
+    p.join(repoRoot, '.cursor', 'rules', 'routing-index.md'),
+  );
+  if (!routingIndex.existsSync()) {
+    violations.add('missing .cursor/rules/routing-index.md');
+  }
+
+  for (final entry in _requiredGlobs.entries) {
+    final file = File(p.join(repoRoot, entry.key));
+    if (!file.existsSync()) {
+      violations.add('missing ${entry.key}');
+      continue;
+    }
+    final content = file.readAsStringSync();
+    if (!content.contains('globs: "${entry.value}"')) {
+      violations.add('${entry.key} must define targeted globs.');
+    }
+    if (content.contains('globs: "**/*.dart"')) {
+      violations.add('${entry.key} still uses broad **/*.dart glob.');
+    }
+  }
+
+  for (final relativePath in _requiredPointers) {
+    final file = File(p.join(repoRoot, relativePath));
+    if (!file.existsSync()) {
+      violations.add('missing $relativePath');
+      continue;
+    }
+    final content = file.readAsStringSync();
+    if (!content.contains('.cursor/rules/routing-index.md')) {
+      violations.add('$relativePath must reference the routing index.');
+    }
+  }
+
+  if (violations.isEmpty) {
+    logInfo('check_rule_routing: no violations found.');
+    return 0;
+  }
+
+  logErr('check_rule_routing: found ${violations.length} violation(s):');
+  for (final violation in violations) {
+    logErr(' - $violation');
+  }
+  return 1;
+}
+
+void main() {
+  exit(runCheckRuleRouting(Directory.current.path));
+}

--- a/tool/ct_repo_lint_lib.dart
+++ b/tool/ct_repo_lint_lib.dart
@@ -7,6 +7,7 @@ import 'package:yaml/yaml.dart';
 import 'check_app_hardcoded_ui_strings.dart';
 import 'check_app_event_handler_scope_logic_boundary.dart';
 import 'check_app_no_duplicate_helpers.dart';
+import 'check_app_widget_imports.dart';
 import 'check_asset_path_constants.dart';
 import 'check_canonical_province_tile_keys.dart';
 import 'check_colonizethis_map_lib_pipe_split.dart';
@@ -766,6 +767,8 @@ int? _tryRunDartRuleInProcess({
       return runCheckAppHardcodedUiStrings(repoRoot);
     case 'repo.app_no_duplicate_helpers':
       return runCheckAppNoDuplicateHelpers(repoRoot);
+    case 'repo.app_widget_imports':
+      return runCheckAppWidgetImports(repoRoot);
     default:
       return null;
   }

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -172,6 +172,13 @@ rules:
     runner: dart
     script: tool/check_no_flame_in_widgets.dart
 
+  - rule_id: repo.app_widget_imports
+    group: structure
+    title: app/lib/widgets must not import/export app/lib/features paths
+    spec: SPEC/program/repo-lint.md
+    runner: dart
+    script: tool/check_app_widget_imports.dart
+
   - rule_id: repo.no_screen_in_game_widgets
     group: structure
     title: app/lib/features/game/widgets must not contain *_screen.dart files


### PR DESCRIPTION
## Summary
- Extract naval mission-order resolution from `naval_resolution.dart` into new `naval_mission_orders.dart` module.
- Keep `applyNavalMissionOrders` import surface stable by re-exporting it from `naval_resolution.dart`.
- Continue #2178 naval decomposition work and keep sibling scope separated from #2149 order-suggestion/order-application refactors.

## Implemented vs deferred
- **Implemented in this PR:** one additional cohesive naval world module (`naval_mission_orders.dart`, 139 lines) with no behavior changes.
- **Deferred:** remaining reductions in `naval_resolution.dart` and any further decomposition beyond this slice.

## AC coverage for #2178
- Addresses AC2 alternative path by adding a second cohesive extracted naval library file under `lib/src/world/`.
- No rule or gameplay behavior changes; this is structural extraction only.

## Tests
- `dart test packages/colonizethis_logic/test/turn_resolver_resolve_turn_for_game_part3_test.dart`

Refs #2178
Refs #2149

Made with [Cursor](https://cursor.com)