### PR TITLE
Refactor rule routing to reduce directive bloat

### DIFF
--- a/.cursor/rules/colonizethis-assets.mdc
+++ b/.cursor/rules/colonizethis-assets.mdc
@@ -1,6 +1,6 @@
 ---
 description: Asset directory layout, naming, and loading conventions
-globs: "**/*.dart,**/pubspec.yaml,**/assets/**"
+globs: "**/pubspec.yaml,**/assets/**,app/lib/**/asset*.dart,app/lib/**/assets*.dart,app/lib/**/sprite*.dart,packages/*/lib/**/asset*.dart,packages/*/lib/**/assets*.dart,packages/*/lib/**/sprite*.dart"
 alwaysApply: false
 ---
 

--- a/.cursor/rules/colonizethis-code-review.mdc
+++ b/.cursor/rules/colonizethis-code-review.mdc
@@ -1,6 +1,6 @@
 ---
 description: Code review checklist — concrete thresholds and repo paths; principles in other rules
-globs: "**/*.dart"
+globs: "app/lib/**/*.dart,packages/*/lib/**/*.dart,tool/**/*.dart"
 alwaysApply: false
 ---
 

--- a/.cursor/rules/colonizethis-component-structure.mdc
+++ b/.cursor/rules/colonizethis-component-structure.mdc
@@ -1,6 +1,6 @@
 ---
 description: Folder layout and component reusability for game and UI
-globs: "**/*.dart"
+globs: "app/lib/**/*.dart,packages/*/lib/**/*.dart,tool/**/*.dart"
 alwaysApply: false
 ---
 

--- a/.cursor/rules/colonizethis-lifecycle.mdc
+++ b/.cursor/rules/colonizethis-lifecycle.mdc
@@ -1,6 +1,6 @@
 ---
 description: Flame and Flutter component lifecycle conventions
-globs: "**/*.dart"
+globs: "app/lib/game/**/*.dart,app/lib/widgets/**/*.dart,app/lib/ui/**/*.dart,app/lib/screens/**/*.dart,app/lib/pages/**/*.dart"
 alwaysApply: false
 ---
 

--- a/.cursor/rules/routing-index.md
+++ b/.cursor/rules/routing-index.md
@@ -1,0 +1,55 @@
+## Purpose
+
+Reduce irrelevant rule overlays by defining one routing map for rule applicability and precedence, while preserving normative policy text in `.cursor/rules/*.mdc`.
+
+## Rule Inventory
+
+| Rule file | Policy owner |
+|---|---|
+| `colonizethis-spec-required.mdc` | SPEC governance |
+| `colonizethis-core-principles.mdc` | Architecture and code standards |
+| `colonizethis-logging-file.mdc` | Logging standards |
+| `colonizethis-logic-ai-decoupling.mdc` | Package-boundary governance |
+| `colonizethis-tools.mdc` | Tooling workflow |
+| `colonizethis-testing.mdc` | Test policy and coverage |
+| `colonizethis-e2e-ui-stability.mdc` | E2E UI stability |
+| `colonizethis-ui-design.mdc` | UI conventions |
+| `colonizethis-component-structure.mdc` | Code organization |
+| `colonizethis-code-review.mdc` | Review thresholds |
+| `colonizethis-lifecycle.mdc` | Flutter/Flame lifecycle |
+| `colonizethis-assets.mdc` | Asset and pubspec conventions |
+| `colonizethis-acceptance-criteria.mdc` | SPEC acceptance criteria quality |
+
+## Applicability Matrix (Before -> After)
+
+| Context | Before applied rules (observed) | After applied rules (targeted) | Change intent |
+|---|---|---|---|
+| Generic Dart implementation in `app/lib/**` | always-applied + `component-structure` + `code-review` + `lifecycle` + `assets` via broad `**/*.dart` | always-applied + `component-structure` + `code-review` (plus targeted overlays only) | Remove lifecycle/asset over-application from default implementation flow |
+| Flutter widget/UI work (`**/lib/widgets/**`, `**/lib/ui/**`) | above set + `ui-design` | always-applied + `ui-design` + targeted `component-structure`/`code-review` + `lifecycle` | Keep UI constraints while applying lifecycle only in lifecycle-relevant paths |
+| Tests (`**/*_test.dart`, `**/test/**`, `**/integration_test/**`) | testing/e2e + broad Dart overlays | testing/e2e first; general Dart overlays apply only where glob-matched | Prioritize test directives and reduce unrelated guidance |
+| Asset and pubspec edits (`**/assets/**`, `**/pubspec.yaml`) | `assets` plus broad Dart overlays | `assets` focused guidance + always-applied baseline only | Prevent non-asset directive bleed |
+| Tooling facade code (`tool/**`) | `tools` plus broad overlays | `tools` primary + targeted structural/review overlays | Preserve tooling rules and remove unrelated overlays |
+| Logic <-> AI boundary work (`packages/colonizethis_logic/**`, `packages/colonizethis_ai/**`) | always-applied decoupling + multiple broad overlays | always-applied decoupling + targeted path overlays only | Preserve strict decoupling while reducing collateral directives |
+| OpenCode skill docs (`.opencode/skills/**`) | duplicated routing prose in references | references point to this index + source `.mdc` files | Avoid duplicated normative summaries |
+
+## Precedence Model
+
+1. Always-applied rules are baseline for every task.
+2. Context-specific rules apply by frontmatter `globs`.
+3. If two context rules conflict, the more specific rule/path takes precedence.
+4. Normative policy text remains authoritative only in source `.mdc` files.
+
+## Non-Duplication Contract
+
+- `AGENTS.md` and `.opencode/skills/**/references/*.md` must not restate normative policy text from `.mdc` files.
+- These documents may summarize routing, list rule files, and link to authoritative sources.
+- Any policy wording changes must be made in the corresponding `.mdc` file, not in routing pointers.
+
+## Change Protocol
+
+When adding or changing a rule:
+
+1. Update the rule file under `.cursor/rules/`.
+2. Update this routing index matrix and inventory.
+3. Run `dart test test/check_rule_routing_test.dart`.
+4. Ensure references (`AGENTS.md`, OpenCode docs) remain pointer-only and non-duplicative.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -440,6 +440,9 @@ jobs:
       - name: Test colonizethis_map lib pipe-split checker (SPEC/program/map-visualization.md)
         run: dart test test/check_colonizethis_map_lib_pipe_split_test.dart --reporter=compact
 
+      - name: Test rule routing checker (issue #2190)
+        run: dart test test/check_rule_routing_test.dart --reporter=compact
+
       - name: Wang incremental assets gate (Python)
         run: |
           set -euo pipefail

--- a/.opencode/skills/refactoring-opportunity-github-issue/references/ci-and-rules.md
+++ b/.opencode/skills/refactoring-opportunity-github-issue/references/ci-and-rules.md
@@ -2,23 +2,13 @@
 
 ## Rule routing (summary)
 
-Authoritative index: **`AGENTS.md`** (“Rule location” / tables). Rules live in **`.cursor/rules/*.mdc`**. When scanning `app/` or `packages/<pkg>/lib/**`:
+Use the canonical routing map at `.cursor/rules/routing-index.md` for:
 
-| Concern | Typical rule file |
-|---------|-------------------|
-| SPEC-first, doc boundaries | `colonizethis-spec-required.mdc` |
-| Flutter vs Flame, typing, logging, province ids, `AppEventBus` | `colonizethis-core-principles.mdc` |
-| Logic ↔ AI dependency direction | `colonizethis-logic-ai-decoupling.mdc` |
-| Folders, extraction, naming | `colonizethis-component-structure.mdc` |
-| Review checklist | `colonizethis-code-review.mdc` |
-| Widget/Flame lifecycle | `colonizethis-lifecycle.mdc` |
-| Tests, coverage expectations | `colonizethis-testing.mdc` |
-| E2E / integration tests | `colonizethis-e2e-ui-stability.mdc` |
-| UI specs / widgets | `colonizethis-ui-design.mdc` |
-| Assets / pubspec | `colonizethis-assets.mdc` |
-| AC quality in SPEC | `colonizethis-acceptance-criteria.mdc` |
+- applicability matrix (which rules apply in each context),
+- precedence (always-applied baseline + context overlays), and
+- non-duplication expectations for pointers vs policy text.
 
-Read the **frontmatter `globs`** on each `.mdc` when unsure; multiple rules can apply additively.
+Normative policy wording lives only in `.cursor/rules/*.mdc`. OpenCode references should link to those files instead of restating policy clauses.
 
 ## Existing CI gates (extension points)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Cursor rules are the source of truth for implementation and review behavior.
 
 - Path: `.cursor/rules/`
 - Format: Markdown `.mdc` with front matter (`description`, optional `globs`, `alwaysApply`)
+- Routing index: `.cursor/rules/routing-index.md` (applicability and precedence only)
 
 ## Always-applied rules
 
@@ -24,26 +25,21 @@ Cursor rules are the source of truth for implementation and review behavior.
 | `colonizethis-testing.mdc` | `**/*_test.dart`, `**/test/**/*.dart`, `**/integration_test/**/*.dart` | Test layers, critical paths, coverage policy |
 | `colonizethis-e2e-ui-stability.mdc` | `**/integration_test/**/*.dart`, `**/*_e2e_test.dart` | UI e2e stability: deterministic locators and visibility-first interactions |
 | `colonizethis-ui-design.mdc` | `SPEC/ui/**`, `**/lib/widgets/**`, `**/lib/ui/**` | UI specs, wireframes, Widgetbook/catalog, pixel-art process |
-| `colonizethis-component-structure.mdc` | `**/*.dart` | Folder conventions, extraction/reuse, naming |
-| `colonizethis-code-review.mdc` | `**/*.dart` | Review checklist and quality gates |
-| `colonizethis-lifecycle.mdc` | `**/*.dart` | Flame/Flutter lifecycle conventions |
-| `colonizethis-assets.mdc` | `**/*.dart`, `**/pubspec.yaml`, `**/assets/**` | Asset structure, naming, loading |
+| `colonizethis-component-structure.mdc` | `app/lib/**/*.dart`, `packages/*/lib/**/*.dart`, `tool/**/*.dart` | Folder conventions, extraction/reuse, naming |
+| `colonizethis-code-review.mdc` | `app/lib/**/*.dart`, `packages/*/lib/**/*.dart`, `tool/**/*.dart` | Review checklist and quality gates |
+| `colonizethis-lifecycle.mdc` | `app/lib/game/**/*.dart`, `app/lib/widgets/**/*.dart`, `app/lib/ui/**/*.dart`, `app/lib/screens/**/*.dart`, `app/lib/pages/**/*.dart` | Flame/Flutter lifecycle conventions |
+| `colonizethis-assets.mdc` | `**/pubspec.yaml`, `**/assets/**`, targeted asset-loading Dart files | Asset structure, naming, loading |
 | `colonizethis-acceptance-criteria.mdc` | `SPEC/ai/**`, `SPEC/game/**`, `SPEC/program/**`, `SPEC/ui/**` | Given–When–Then, testable AC quality |
 
 ## Rule interaction
 
 Multiple context-specific rules may apply to a single file (e.g., a UI widget may match both `ui-design` and `component-structure`). All applicable rules are **additive**; when they conflict, the more specific rule takes precedence (e.g., testing rules override general code-review for test files).
 
-## Quick reference
+## Routing reference
 
-1. **SPEC-first**: Check/extend SPEC first; implement only spec-authorized behavior. See `colonizethis-spec-required.mdc`.
-2. **Separation of concerns**: Keep Flutter UI and Flame simulation concerns separated. See `colonizethis-core-principles.mdc`.
-3. **Thin screens**: Prefer reuse; keep screens thin and delegate logic to services/controllers/components. See `colonizethis-component-structure.mdc`.
-4. **Coverage policy**: **90% for logic/ai/map packages; 80% everywhere else**. See `colonizethis-testing.mdc`.
-5. **Widget tests**: Run app/ctdev widget tests with `flutter test` (or `melos run test_app`), not `dart test app/...`. See `colonizethis-testing.mdc`.
-6. **E2E UI stability**: In UI-heavy e2e tests, prefer deterministic widget locators, scope finders to roots, and ensure visibility before taps; avoid coordinate-based gestures unless unavoidable. See `colonizethis-e2e-ui-stability.mdc`.
-7. **Logging**: Policy and annexes: `SPEC/program/logging/logging.md`; ctdev file/Sim Log: `SPEC/program/ctdev-logging.md`; use `basic_logger_file` per `colonizethis-logging-file.mdc` where file sinks apply.
-8. **Cross-panel UI orchestration**: "Panels" refers to app panels/dialogs/components. Panels should **not** directly invoke or depend on each other unless absolutely necessary. Use `AppEventBus` for cross-panel communication. See `SPEC/program/app-ui-wiring.md` and `SPEC/program/app-event-bus.md`.
+- Use `.cursor/rules/routing-index.md` to determine applicability and precedence.
+- Treat `.cursor/rules/*.mdc` files as the only normative policy source.
+- Keep this file and OpenCode references pointer-based; avoid duplicating normative rule text.
 
 For complete details, read the relevant rule file(s) in `.cursor/rules/`.
 

--- a/test/check_rule_routing_test.dart
+++ b/test/check_rule_routing_test.dart
@@ -1,0 +1,107 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../tool/check_rule_routing.dart';
+
+void main() {
+  test('passes when routing index, globs, and pointers are present', () {
+    final tempDir = Directory.systemTemp.createTempSync(
+      'check_rule_routing_pass_',
+    );
+    addTearDown(() => tempDir.deleteSync(recursive: true));
+
+    _writeFixture(tempDir.path);
+    final stdoutLines = <String>[];
+    final code = runCheckRuleRouting(tempDir.path, info: stdoutLines.add);
+
+    expect(code, 0);
+    expect(stdoutLines.join('\n'), contains('no violations found'));
+  });
+
+  test('fails when lifecycle rule still uses broad glob', () {
+    final tempDir = Directory.systemTemp.createTempSync(
+      'check_rule_routing_fail_',
+    );
+    addTearDown(() => tempDir.deleteSync(recursive: true));
+
+    _writeFixture(
+      tempDir.path,
+      lifecycleGlob: '**/*.dart',
+      includeRoutingPointerInAgents: false,
+    );
+    final stderrLines = <String>[];
+    final code = runCheckRuleRouting(tempDir.path, err: stderrLines.add);
+
+    expect(code, 1);
+    expect(
+      stderrLines.join('\n'),
+      contains('colonizethis-lifecycle.mdc must define targeted globs.'),
+    );
+    expect(
+      stderrLines.join('\n'),
+      contains('colonizethis-lifecycle.mdc still uses broad **/*.dart glob.'),
+    );
+    expect(
+      stderrLines.join('\n'),
+      contains('AGENTS.md must reference the routing index.'),
+    );
+  });
+}
+
+void _writeFixture(
+  String root, {
+  String lifecycleGlob =
+      'app/lib/game/**/*.dart,app/lib/widgets/**/*.dart,app/lib/ui/**/*.dart,app/lib/screens/**/*.dart,app/lib/pages/**/*.dart',
+  bool includeRoutingPointerInAgents = true,
+}) {
+  File(p.join(root, '.cursor', 'rules', 'routing-index.md'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync('# Routing index');
+
+  File(p.join(root, '.cursor', 'rules', 'colonizethis-component-structure.mdc'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+---
+globs: "app/lib/**/*.dart,packages/*/lib/**/*.dart,tool/**/*.dart"
+---
+''');
+
+  File(p.join(root, '.cursor', 'rules', 'colonizethis-code-review.mdc'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+---
+globs: "app/lib/**/*.dart,packages/*/lib/**/*.dart,tool/**/*.dart"
+---
+''');
+
+  File(p.join(root, '.cursor', 'rules', 'colonizethis-lifecycle.mdc'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+---
+globs: "$lifecycleGlob"
+---
+''');
+
+  File(
+      p.join(
+        root,
+        '.opencode',
+        'skills',
+        'refactoring-opportunity-github-issue',
+        'references',
+        'ci-and-rules.md',
+      ),
+    )
+    ..createSync(recursive: true)
+    ..writeAsStringSync('see .cursor/rules/routing-index.md');
+
+  File(p.join(root, 'AGENTS.md'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync(
+      includeRoutingPointerInAgents
+          ? 'see .cursor/rules/routing-index.md'
+          : 'missing routing pointer',
+    );
+}

--- a/tool/check_rule_routing.dart
+++ b/tool/check_rule_routing.dart
@@ -1,0 +1,76 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+const Map<String, String> _requiredGlobs = {
+  '.cursor/rules/colonizethis-component-structure.mdc':
+      'app/lib/**/*.dart,packages/*/lib/**/*.dart,tool/**/*.dart',
+  '.cursor/rules/colonizethis-code-review.mdc':
+      'app/lib/**/*.dart,packages/*/lib/**/*.dart,tool/**/*.dart',
+  '.cursor/rules/colonizethis-lifecycle.mdc':
+      'app/lib/game/**/*.dart,app/lib/widgets/**/*.dart,app/lib/ui/**/*.dart,app/lib/screens/**/*.dart,app/lib/pages/**/*.dart',
+};
+
+const Set<String> _requiredPointers = {
+  'AGENTS.md',
+  '.opencode/skills/refactoring-opportunity-github-issue/references/ci-and-rules.md',
+};
+
+int runCheckRuleRouting(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logInfo = info ?? stdout.writeln;
+  final logErr = err ?? stderr.writeln;
+  final violations = <String>[];
+
+  final routingIndex = File(
+    p.join(repoRoot, '.cursor', 'rules', 'routing-index.md'),
+  );
+  if (!routingIndex.existsSync()) {
+    violations.add('missing .cursor/rules/routing-index.md');
+  }
+
+  for (final entry in _requiredGlobs.entries) {
+    final file = File(p.join(repoRoot, entry.key));
+    if (!file.existsSync()) {
+      violations.add('missing ${entry.key}');
+      continue;
+    }
+    final content = file.readAsStringSync();
+    if (!content.contains('globs: "${entry.value}"')) {
+      violations.add('${entry.key} must define targeted globs.');
+    }
+    if (content.contains('globs: "**/*.dart"')) {
+      violations.add('${entry.key} still uses broad **/*.dart glob.');
+    }
+  }
+
+  for (final relativePath in _requiredPointers) {
+    final file = File(p.join(repoRoot, relativePath));
+    if (!file.existsSync()) {
+      violations.add('missing $relativePath');
+      continue;
+    }
+    final content = file.readAsStringSync();
+    if (!content.contains('.cursor/rules/routing-index.md')) {
+      violations.add('$relativePath must reference the routing index.');
+    }
+  }
+
+  if (violations.isEmpty) {
+    logInfo('check_rule_routing: no violations found.');
+    return 0;
+  }
+
+  logErr('check_rule_routing: found ${violations.length} violation(s):');
+  for (final violation in violations) {
+    logErr(' - $violation');
+  }
+  return 1;
+}
+
+void main() {
+  exit(runCheckRuleRouting(Directory.current.path));
+}


### PR DESCRIPTION
## Summary
- add `.cursor/rules/routing-index.md` as the canonical applicability/precedence index and include a committed before/after routing matrix for representative contexts
- narrow broad `**/*.dart` routing in component-structure, code-review, lifecycle, and assets rules so lifecycle/asset guidance only overlays relevant paths
- convert AGENTS/OpenCode rule-routing content into pointer-only references to avoid duplicated normative policy text
- add `tool/check_rule_routing.dart` + `test/check_rule_routing_test.dart` and wire the test into `.github/workflows/quality.yml`

## Scope
FULL for issue #2190 acceptance criteria in this PR.

## Acceptance Criteria Coverage
- Canonical routing source: implemented at `.cursor/rules/routing-index.md`
- AGENTS/OpenCode de-dup: updated to pointer-based references
- Broad glob partitioning: completed for affected rules
- Policy preservation: no normative policy edits in always-applied/core rule text
- Before/after matrix: included in routing index
- Automated validation: added dedicated checker test in CI

## Deferred
- None.

## Test Plan
- [x] `dart test test/check_rule_routing_test.dart --reporter=compact`

Refs #2190

Made with [Cursor](https://cursor.com)