### PR TITLE
Refactor CtRegionMap export surface (slice for #2188)

### DIFF
--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -12,7 +12,7 @@ import 'package:colonizethis_map/colonizethis_map.dart'
 import 'package:colonizethis_app/l10n/l10n.dart';
 
 import '../../../config/ct_e2e.dart';
-import '../../../../widgets/ct_region_map.dart' show BaseLayerDisplayMode;
+import 'region_map_component_shared.dart' show BaseLayerDisplayMode;
 
 import '../../../../providers/app_event_bus_provider.dart';
 import '../../../../providers/debug_console_provider.dart';

--- a/app/lib/features/game/flame/game_map_area.dart
+++ b/app/lib/features/game/flame/game_map_area.dart
@@ -12,7 +12,7 @@ import 'package:colonizethis_map/colonizethis_map.dart'
 import 'package:colonizethis_app/l10n/l10n.dart';
 
 import '../../../config/ct_e2e.dart';
-import 'region_map_component_shared.dart' show BaseLayerDisplayMode;
+import 'region_map_component.dart' show BaseLayerDisplayMode;
 
 import '../../../../providers/app_event_bus_provider.dart';
 import '../../../../providers/debug_console_provider.dart';

--- a/app/lib/features/game/flame/game_map_canvas_stack.dart
+++ b/app/lib/features/game/flame/game_map_canvas_stack.dart
@@ -8,8 +8,9 @@ import 'package:colonizethis_map/colonizethis_map.dart' show RegionMapViewData;
 
 import '../../../../providers/map_province_panel_provider.dart';
 import 'game_screen_shared.dart' show kGameMapWideProvinceSidePanelWidth;
-import '../../../../widgets/ct_region_map.dart'
-    show BaseLayerDisplayMode, CtMapVisibilityMode, CtRegionMap;
+import 'region_map_component_shared.dart'
+    show BaseLayerDisplayMode, CtMapVisibilityMode;
+import '../../../../widgets/ct_region_map.dart' show CtRegionMap;
 
 import 'game_map_province_detail_side_panel.dart';
 import 'per_player_work_target_selection_cache.dart';

--- a/app/lib/features/game/flame/game_map_canvas_stack.dart
+++ b/app/lib/features/game/flame/game_map_canvas_stack.dart
@@ -8,7 +8,7 @@ import 'package:colonizethis_map/colonizethis_map.dart' show RegionMapViewData;
 
 import '../../../../providers/map_province_panel_provider.dart';
 import 'game_screen_shared.dart' show kGameMapWideProvinceSidePanelWidth;
-import 'region_map_component_shared.dart'
+import 'region_map_component.dart'
     show BaseLayerDisplayMode, CtMapVisibilityMode;
 import '../../../../widgets/ct_region_map.dart' show CtRegionMap;
 

--- a/app/lib/widgetbook/catalog.dart
+++ b/app/lib/widgetbook/catalog.dart
@@ -25,6 +25,8 @@ import '../features/game/dialogue/intervention_dialogue_overlay.dart';
 import '../features/game/widgets/train_civilians_dialog.dart';
 import '../features/game/widgets/train_military_dialog.dart';
 import '../features/game/widgets/turn_news_dialog.dart';
+import '../features/game/flame/region_map_component_shared.dart'
+    show CtMapVisibilityMode;
 import '../l10n/l10n.dart';
 import '../widgets/debug_init_game.dart';
 import '../widgets/ct_choice_chip.dart';
@@ -550,4 +552,3 @@ List<WidgetbookNode> get trainCiviliansDialogDirectories => [
     ],
   ),
 ];
-

--- a/app/lib/widgetbook/catalog.dart
+++ b/app/lib/widgetbook/catalog.dart
@@ -25,8 +25,6 @@ import '../features/game/dialogue/intervention_dialogue_overlay.dart';
 import '../features/game/widgets/train_civilians_dialog.dart';
 import '../features/game/widgets/train_military_dialog.dart';
 import '../features/game/widgets/turn_news_dialog.dart';
-import '../features/game/flame/region_map_component_shared.dart'
-    show CtMapVisibilityMode;
 import '../l10n/l10n.dart';
 import '../widgets/debug_init_game.dart';
 import '../widgets/ct_choice_chip.dart';

--- a/app/lib/widgets/ct_region_map.dart
+++ b/app/lib/widgets/ct_region_map.dart
@@ -7,10 +7,17 @@ import 'package:flutter/services.dart';
 
 import '../core/services/subscription_tracker.dart';
 import '../features/game/flame/ct_region_map_game.dart';
-import '../features/game/flame/region_map_component_shared.dart';
+import '../features/game/flame/region_map_component.dart'
+    show
+        BaseLayerDisplayMode,
+        CtMapVisibilityMode,
+        assertCtMapPlayerViewRequired;
 import '../features/game/flame/region_map_viewport_snapshot.dart'
     show RegionMapViewportSnapshot;
 import '../features/game/widgets/chrome/region_map_game_viewport.dart';
+
+export '../features/game/flame/region_map_component.dart'
+    show BaseLayerDisplayMode, CtMapVisibilityMode;
 
 /// Flutter wrapper for the region map; renders via Flame. SPEC/ui/map-widget.md.
 class CtRegionMap extends StatefulWidget {

--- a/app/lib/widgets/ct_region_map.dart
+++ b/app/lib/widgets/ct_region_map.dart
@@ -7,16 +7,10 @@ import 'package:flutter/services.dart';
 
 import '../core/services/subscription_tracker.dart';
 import '../features/game/flame/ct_region_map_game.dart';
-import '../features/game/flame/region_map_component.dart';
+import '../features/game/flame/region_map_component_shared.dart';
 import '../features/game/flame/region_map_viewport_snapshot.dart'
     show RegionMapViewportSnapshot;
 import '../features/game/widgets/chrome/region_map_game_viewport.dart';
-
-export '../features/game/flame/region_map_component.dart'
-    show
-        assertCtMapPlayerViewRequired,
-        BaseLayerDisplayMode,
-        CtMapVisibilityMode;
 
 /// Flutter wrapper for the region map; renders via Flame. SPEC/ui/map-widget.md.
 class CtRegionMap extends StatefulWidget {

--- a/app/lib/widgets/debug_map_visibility_story.dart
+++ b/app/lib/widgets/debug_map_visibility_story.dart
@@ -2,8 +2,6 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:flutter/material.dart';
 
-import '../features/game/flame/region_map_component_shared.dart'
-    show CtMapVisibilityMode;
 import '../l10n/l10n.dart';
 import 'ct_choice_chip.dart';
 import 'ct_region_map.dart';

--- a/app/lib/widgets/debug_map_visibility_story.dart
+++ b/app/lib/widgets/debug_map_visibility_story.dart
@@ -2,6 +2,8 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:flutter/material.dart';
 
+import '../features/game/flame/region_map_component_shared.dart'
+    show CtMapVisibilityMode;
 import '../l10n/l10n.dart';
 import 'ct_choice_chip.dart';
 import 'ct_region_map.dart';
@@ -62,7 +64,8 @@ InitGameMapViewData debugMapViewDataWithVisibilityForFirstPlayer() {
 
 /// Stateful Widgetbook story for the debug map with a visibility mode toggle.
 class DebugMapVisibilityStory extends StatefulWidget {
-  const DebugMapVisibilityStory({super.key, 
+  const DebugMapVisibilityStory({
+    super.key,
     required this.showPoliticalOverlay,
   });
 
@@ -137,8 +140,8 @@ class _DebugMapVisibilityStoryState extends State<DebugMapVisibilityStory> {
               showPoliticalOverlay: widget.showPoliticalOverlay,
               cellSizePx: 28,
               visibilityMode: _visibilityMode,
-              playerViewForResources: _visibilityMode ==
-                      CtMapVisibilityMode.playerConstrained
+              playerViewForResources:
+                  _visibilityMode == CtMapVisibilityMode.playerConstrained
                   ? debugPlayerViewForFirstPlayer()
                   : null,
               showProvinceNamesLayer: _showProvinceNames,
@@ -150,4 +153,3 @@ class _DebugMapVisibilityStoryState extends State<DebugMapVisibilityStory> {
     );
   }
 }
-


### PR DESCRIPTION
## Summary
- Remove `ct_region_map.dart` re-exports of feature-layer map types so shared widget APIs stop serving as transitive feature barrels.
- Update map area and map canvas call sites to import `BaseLayerDisplayMode`/`CtMapVisibilityMode` directly from `region_map_component_shared.dart`.
- Update debug/widgetbook map stories to import `CtMapVisibilityMode` explicitly from the feature source instead of via `CtRegionMap`.

## Implemented in this PR
- ✅ AC8 (partial): `ct_region_map.dart` no longer re-exports `features/game/flame/region_map_component.dart` symbols.
- ✅ Architectural progress toward AC3: dependent callers now use explicit feature imports for these map enums.

## Deferred work
- ⏳ AC3 remaining: `CtRegionMap` still imports feature-layer game/snapshot/view classes and still requires full decoupling abstraction work.
- ⏳ AC4/AC5: callback-to-bus-event state path completion is not included in this slice.
- ⏳ Any remaining #2188 scope not listed above.

## Tests
- `dart test test/check_app_widget_imports_test.dart test/check_subscription_tracker_test.dart`

Refs #2188

Made with [Cursor](https://cursor.com)