### PR TITLE
Finish CtRegionMap enum export removal (slice for #2188)

### DIFF
--- a/app/lib/widgetbook/catalog.dart
+++ b/app/lib/widgetbook/catalog.dart
@@ -22,13 +22,15 @@ import '../features/game/widgets/province_overlay_demo_data.dart';
 import '../features/game/widgets/tech_tree_widget.dart';
 import '../features/game/screens/technology_screen.dart';
 import '../features/game/dialogue/intervention_dialogue_overlay.dart';
+import '../features/game/flame/region_map_component.dart'
+    show CtMapVisibilityMode;
 import '../features/game/widgets/train_civilians_dialog.dart';
 import '../features/game/widgets/train_military_dialog.dart';
 import '../features/game/widgets/turn_news_dialog.dart';
 import '../l10n/l10n.dart';
 import '../widgets/debug_init_game.dart';
 import '../widgets/ct_choice_chip.dart';
-import '../widgets/debug_map_visibility_story.dart';
+import 'debug_map_visibility_story.dart';
 import '../widgets/game_setup.dart';
 import '../widgets/main_menu.dart';
 import '../widgets/ct_nine_patch_button.dart';

--- a/app/lib/widgetbook/debug_map_visibility_story.dart
+++ b/app/lib/widgetbook/debug_map_visibility_story.dart
@@ -2,10 +2,12 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:flutter/material.dart';
 
+import '../features/game/flame/region_map_component.dart'
+    show CtMapVisibilityMode;
 import '../l10n/l10n.dart';
-import 'ct_choice_chip.dart';
-import 'ct_region_map.dart';
-import 'debug_init_game.dart';
+import '../widgets/ct_choice_chip.dart';
+import '../widgets/ct_region_map.dart';
+import '../widgets/debug_init_game.dart';
 
 /// Builds InitGameMapViewData for the debug init game result, enriching it with
 /// per-tile visibility derived from the first player's PlayerView. Used by map

--- a/app/lib/widgets/ct_region_map.dart
+++ b/app/lib/widgets/ct_region_map.dart
@@ -16,9 +16,6 @@ import '../features/game/flame/region_map_viewport_snapshot.dart'
     show RegionMapViewportSnapshot;
 import '../features/game/widgets/chrome/region_map_game_viewport.dart';
 
-export '../features/game/flame/region_map_component.dart'
-    show BaseLayerDisplayMode, CtMapVisibilityMode;
-
 /// Flutter wrapper for the region map; renders via Flame. SPEC/ui/map-widget.md.
 class CtRegionMap extends StatefulWidget {
   const CtRegionMap({

--- a/app/test/ct_region_map_test_support.dart
+++ b/app/test/ct_region_map_test_support.dart
@@ -4,8 +4,9 @@ import 'package:colonizethis_models/colonizethis_models.dart'
     show AppEventBus, Player;
 import 'package:flutter/material.dart';
 
-import 'package:colonizethis_app/widgets/ct_region_map.dart'
-    show BaseLayerDisplayMode, CtRegionMap, CtMapVisibilityMode;
+import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
+    show BaseLayerDisplayMode, CtMapVisibilityMode;
+import 'package:colonizethis_app/widgets/ct_region_map.dart' show CtRegionMap;
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
 
 /// Minimal view for map tests in [CtMapVisibilityMode.playerConstrained].

--- a/app/test/ct_region_map_widget_test_part1_test.dart
+++ b/app/test/ct_region_map_widget_test_part1_test.dart
@@ -13,6 +13,8 @@ import 'package:colonizethis_models/colonizethis_models.dart'
 import 'package:colonizethis_app/features/game/flame/resource_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
     show
+        BaseLayerDisplayMode,
+        CtMapVisibilityMode,
         CtRegionMapComponent,
         extractionIndicatorDisplaySizePx,
         extractionIndicatorRectsForIconRect,
@@ -36,8 +38,7 @@ import 'package:colonizethis_app/features/game/flame/terrain_tileset.dart';
 import 'package:colonizethis_app/features/game/flame/town_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/ct_region_map_game.dart';
 import 'package:colonizethis_app/features/game/flame/transport_overlay_tileset.dart';
-import 'package:colonizethis_app/widgets/ct_region_map.dart'
-    show BaseLayerDisplayMode, CtRegionMap, CtMapVisibilityMode;
+import 'package:colonizethis_app/widgets/ct_region_map.dart' show CtRegionMap;
 
 import 'ct_region_map_test_support.dart';
 

--- a/app/test/ct_region_map_widget_test_part2_test.dart
+++ b/app/test/ct_region_map_widget_test_part2_test.dart
@@ -18,6 +18,8 @@ import 'package:colonizethis_models/colonizethis_models.dart'
 import 'package:colonizethis_app/features/game/flame/resource_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
     show
+        BaseLayerDisplayMode,
+        CtMapVisibilityMode,
         CtRegionMapComponent,
         extractionIndicatorDisplaySizePx,
         extractionIndicatorRectsForIconRect,
@@ -41,8 +43,7 @@ import 'package:colonizethis_app/features/game/flame/terrain_tileset.dart';
 import 'package:colonizethis_app/features/game/flame/town_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/ct_region_map_game.dart';
 import 'package:colonizethis_app/features/game/flame/transport_overlay_tileset.dart';
-import 'package:colonizethis_app/widgets/ct_region_map.dart'
-    show BaseLayerDisplayMode, CtRegionMap, CtMapVisibilityMode;
+import 'package:colonizethis_app/widgets/ct_region_map.dart' show CtRegionMap;
 
 import 'ct_region_map_test_support.dart';
 

--- a/app/test/ct_region_map_widget_test_part3_test.dart
+++ b/app/test/ct_region_map_widget_test_part3_test.dart
@@ -13,6 +13,8 @@ import 'package:colonizethis_models/colonizethis_models.dart'
 import 'package:colonizethis_app/features/game/flame/resource_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
     show
+        BaseLayerDisplayMode,
+        CtMapVisibilityMode,
         CtRegionMapComponent,
         extractionIndicatorDisplaySizePx,
         extractionIndicatorRectsForIconRect,
@@ -36,8 +38,7 @@ import 'package:colonizethis_app/features/game/flame/terrain_tileset.dart';
 import 'package:colonizethis_app/features/game/flame/town_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/ct_region_map_game.dart';
 import 'package:colonizethis_app/features/game/flame/transport_overlay_tileset.dart';
-import 'package:colonizethis_app/widgets/ct_region_map.dart'
-    show BaseLayerDisplayMode, CtRegionMap, CtMapVisibilityMode;
+import 'package:colonizethis_app/widgets/ct_region_map.dart' show CtRegionMap;
 
 import 'ct_region_map_test_support.dart';
 

--- a/app/test/game_map_area_event_feed_test.dart
+++ b/app/test/game_map_area_event_feed_test.dart
@@ -10,7 +10,6 @@ import 'package:colonizethis_app/providers/game_service_provider.dart';
 import 'package:colonizethis_app/providers/games_box_provider.dart';
 import 'package:colonizethis_app/providers/games_provider.dart';
 import 'package:colonizethis_app/providers/map_view_provider.dart';
-import 'package:colonizethis_app/widgets/ct_region_map.dart';
 import 'package:colonizethis_app/widgets/debug_init_game.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';

--- a/app/test/region_map_extraction_disc_indicators_test.dart
+++ b/app/test/region_map_extraction_disc_indicators_test.dart
@@ -14,13 +14,14 @@ import 'package:colonizethis_app/features/game/flame/province_label_icon_cache.d
 import 'package:colonizethis_app/features/game/flame/resource_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
     show
+        BaseLayerDisplayMode,
+        CtMapVisibilityMode,
         extractionIndicatorRectsForIconRect,
         paintResourceExtractionDiscIndicators;
 import 'package:colonizethis_app/features/game/flame/terrain_tileset.dart';
 import 'package:colonizethis_app/features/game/flame/town_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/transport_overlay_tileset.dart';
-import 'package:colonizethis_app/widgets/ct_region_map.dart'
-    show BaseLayerDisplayMode, CtRegionMap, CtMapVisibilityMode;
+import 'package:colonizethis_app/widgets/ct_region_map.dart' show CtRegionMap;
 
 void main() {
   suppressLogsForTests();

--- a/app/test/region_map_resource_transport_readability_test.dart
+++ b/app/test/region_map_resource_transport_readability_test.dart
@@ -13,10 +13,12 @@ import 'package:colonizethis_app/features/game/flame/resource_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/terrain_tileset.dart';
 import 'package:colonizethis_app/features/game/flame/town_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
-    show shouldRenderTransportOverlay;
+    show
+        BaseLayerDisplayMode,
+        CtMapVisibilityMode,
+        shouldRenderTransportOverlay;
 import 'package:colonizethis_app/features/game/flame/transport_overlay_tileset.dart';
-import 'package:colonizethis_app/widgets/ct_region_map.dart'
-    show BaseLayerDisplayMode, CtRegionMap, CtMapVisibilityMode;
+import 'package:colonizethis_app/widgets/ct_region_map.dart' show CtRegionMap;
 
 void main() {
   suppressLogsForTests();

--- a/app/test/region_map_zoom_fit_test.dart
+++ b/app/test/region_map_zoom_fit_test.dart
@@ -5,8 +5,9 @@ import 'package:colonizethis_app/features/game/flame/civilian_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/terrain_tileset.dart';
 import 'package:colonizethis_app/features/game/flame/town_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/transport_overlay_tileset.dart';
-import 'package:colonizethis_app/widgets/ct_region_map.dart'
-    show CtMapVisibilityMode, CtRegionMap;
+import 'package:colonizethis_app/features/game/flame/region_map_component.dart'
+    show CtMapVisibilityMode;
+import 'package:colonizethis_app/widgets/ct_region_map.dart' show CtRegionMap;
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/gestures.dart';


### PR DESCRIPTION
## Summary
- Remove remaining `export` of `BaseLayerDisplayMode` / `CtMapVisibilityMode` from `ct_region_map.dart` so the shared widget no longer acts as a barrel for feature-layer map enums.
- Import those enums from `region_map_component.dart` at tests and Widgetbook; move `DebugMapVisibilityStory` from `widgets/` to `widgetbook/` so visibility-mode toggles can use feature imports without tripping `check_app_widget_imports`.
- Drop an unused `ct_region_map` import from `game_map_area_event_feed_test.dart`.

## Implemented in this PR
- Completes **AC8** for #2188 (no re-exports of `features/game/flame/region_map_component.dart` symbols from `ct_region_map.dart`).
- Further progress on **AC3** (callers use explicit feature imports for map enums instead of transitive widget exports).

## Deferred work
- **AC3** remainder: `CtRegionMap` still imports concrete Flame/game classes from `features/` (abstraction + factory/host still needed).
- **AC4 / AC5**: callback-to-bus paths for cross-panel actions and civilian tile highlighting.
- **AC6 / AC7** and other CI/items as listed on the issue if still open after merge.

## Tests
- `dart run tool/check_app_widget_imports.dart`
- `dart run tool/check_subscription_tracker.dart`
- `cd app && flutter test` (focused): `ct_region_map_widget_test_part{1,2,3}_test.dart`, `region_map_zoom_fit_test.dart`, `region_map_extraction_disc_indicators_test.dart`, `region_map_resource_transport_readability_test.dart`, `game_map_area_event_feed_test.dart`

Refs #2188

Made with [Cursor](https://cursor.com)