### PR TITLE
Add dead-file repo lint for colonizethis_logic (slice for #2201)

### DIFF
--- a/tool/check_logic_dead_files.dart
+++ b/tool/check_logic_dead_files.dart
@@ -1,0 +1,237 @@
+import 'dart:collection';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+const _logicPackageRelative = 'packages/colonizethis_logic';
+const _logicLibRelative = 'packages/colonizethis_logic/lib';
+const _logicSrcRelative = 'packages/colonizethis_logic/lib/src';
+const _knownDeferredDeadFiles = <String>{
+  'packages/colonizethis_logic/lib/src/ai/ai_planner.dart',
+  'packages/colonizethis_logic/lib/src/ai/sim_game_ai.dart',
+};
+
+final RegExp _directivePattern = RegExp(
+  "^\\s*(import|export|part|part\\s+of)\\s+['\\\"]([^'\\\"]+)['\\\"]",
+  multiLine: true,
+);
+
+void main() {
+  exit(runCheckLogicDeadFiles(Directory.current.path));
+}
+
+int runCheckLogicDeadFiles(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+
+  final root = p.normalize(repoRoot);
+  final logicPackageDir = Directory(p.join(root, _logicPackageRelative));
+  final libDir = Directory(p.join(root, _logicLibRelative));
+  final srcDir = Directory(p.join(root, _logicSrcRelative));
+
+  if (!logicPackageDir.existsSync()) {
+    logE('ERROR: Missing package directory: $_logicPackageRelative');
+    return 1;
+  }
+  if (!libDir.existsSync()) {
+    logE('ERROR: Missing logic lib directory: $_logicLibRelative');
+    return 1;
+  }
+  if (!srcDir.existsSync()) {
+    logE('ERROR: Missing logic src directory: $_logicSrcRelative');
+    return 1;
+  }
+
+  final libFiles = _listDartFiles(libDir.path);
+  final srcFiles = _listDartFiles(srcDir.path).toSet();
+  final exportedEdges = <String, Set<String>>{};
+  final importedSrcFiles = <String>{};
+  final partOfFiles = <String>{};
+
+  for (final filePath in libFiles) {
+    final directives = _parseDirectives(filePath);
+    final sourceRelative = _relativeToRoot(filePath, root);
+    for (final directive in directives) {
+      if (directive.kind == _DirectiveKind.partOf) {
+        partOfFiles.add(sourceRelative);
+        continue;
+      }
+
+      final targetPath = _resolveTargetPath(
+        sourcePath: filePath,
+        target: directive.target,
+        repoRoot: root,
+      );
+      if (targetPath == null) {
+        continue;
+      }
+      if (!targetPath.endsWith('.dart') || !File(targetPath).existsSync()) {
+        continue;
+      }
+
+      final targetRelative = _relativeToRoot(targetPath, root);
+      if (directive.kind == _DirectiveKind.import &&
+          srcFiles.contains(targetPath)) {
+        importedSrcFiles.add(targetRelative);
+      }
+      if (directive.kind == _DirectiveKind.export) {
+        exportedEdges
+            .putIfAbsent(sourceRelative, () => <String>{})
+            .add(targetRelative);
+      }
+    }
+  }
+
+  final barrelRoots = _listDartFiles(libDir.path)
+      .where((filePath) => p.dirname(filePath) == libDir.path)
+      .map((filePath) => _relativeToRoot(filePath, root))
+      .toSet();
+  final exportReachabilityRoots = <String>{...barrelRoots, ...importedSrcFiles};
+  final exportReachable = _collectReachableExports(
+    exportReachabilityRoots,
+    exportedEdges,
+  );
+
+  final deadFiles = <String>[];
+  for (final srcPath in srcFiles) {
+    final relative = _relativeToRoot(srcPath, root);
+    if (partOfFiles.contains(relative)) {
+      continue;
+    }
+    final isImportedByLib = importedSrcFiles.contains(relative);
+    final isReachableByBarrelExport = exportReachable.contains(relative);
+    if (!isImportedByLib && !isReachableByBarrelExport) {
+      deadFiles.add(relative);
+    }
+  }
+
+  deadFiles.sort();
+  final actionableDeadFiles =
+      deadFiles
+          .where((file) => !_knownDeferredDeadFiles.contains(file))
+          .toList()
+        ..sort();
+
+  if (actionableDeadFiles.isEmpty) {
+    if (deadFiles.isNotEmpty) {
+      logI(
+        'Logic dead-file check found only deferred exceptions: '
+        '${deadFiles.join(', ')}',
+      );
+    }
+    logI(
+      'Logic dead-file check passed: no unreferenced files under '
+      '$_logicSrcRelative.',
+    );
+    return 0;
+  }
+
+  logE(
+    'ERROR: Found ${actionableDeadFiles.length} dead files under '
+    '$_logicSrcRelative.\n'
+    'A file is dead when it is not a `part of` file, not imported by any '
+    'file under `packages/colonizethis_logic/lib/**`, and not reachable from '
+    'barrel exports rooted at `packages/colonizethis_logic/lib/*.dart`.',
+  );
+  for (final file in actionableDeadFiles) {
+    logE(file);
+  }
+  return 1;
+}
+
+Set<String> _collectReachableExports(
+  Set<String> roots,
+  Map<String, Set<String>> exportedEdges,
+) {
+  final visited = <String>{};
+  final queue = Queue<String>()..addAll(roots);
+
+  while (queue.isNotEmpty) {
+    final current = queue.removeFirst();
+    if (!visited.add(current)) {
+      continue;
+    }
+    final exports = exportedEdges[current];
+    if (exports == null) {
+      continue;
+    }
+    for (final target in exports) {
+      queue.add(target);
+    }
+  }
+  return visited;
+}
+
+List<String> _listDartFiles(String dirPath) {
+  final dir = Directory(dirPath);
+  return dir
+      .listSync(recursive: true, followLinks: false)
+      .whereType<File>()
+      .map((file) => p.normalize(file.path))
+      .where((filePath) => filePath.endsWith('.dart'))
+      .toList();
+}
+
+String _relativeToRoot(String filePath, String repoRoot) {
+  return p.normalize(p.relative(filePath, from: repoRoot));
+}
+
+List<_Directive> _parseDirectives(String filePath) {
+  final content = File(filePath).readAsStringSync();
+  final directives = <_Directive>[];
+  for (final match in _directivePattern.allMatches(content)) {
+    final kindText = match.group(1);
+    final target = match.group(2);
+    if (kindText == null || target == null) {
+      continue;
+    }
+    final kind = switch (kindText) {
+      'import' => _DirectiveKind.import,
+      'export' => _DirectiveKind.export,
+      'part' => _DirectiveKind.part,
+      'part of' => _DirectiveKind.partOf,
+      _ => null,
+    };
+    if (kind == null) {
+      continue;
+    }
+    directives.add(_Directive(kind: kind, target: target));
+  }
+  return directives;
+}
+
+String? _resolveTargetPath({
+  required String sourcePath,
+  required String target,
+  required String repoRoot,
+}) {
+  if (target.startsWith('dart:')) {
+    return null;
+  }
+  if (target.startsWith('package:')) {
+    const packagePrefix = 'package:colonizethis_logic/';
+    if (!target.startsWith(packagePrefix)) {
+      return null;
+    }
+    final packageRelative = target.substring(packagePrefix.length);
+    return p.normalize(
+      p.join(repoRoot, _logicPackageRelative, 'lib', packageRelative),
+    );
+  }
+
+  final sourceDir = p.dirname(sourcePath);
+  return p.normalize(p.join(sourceDir, target));
+}
+
+enum _DirectiveKind { import, export, part, partOf }
+
+final class _Directive {
+  const _Directive({required this.kind, required this.target});
+
+  final _DirectiveKind kind;
+  final String target;
+}

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -27,6 +27,13 @@ rules:
     runner: shell
     argv: [tool/check_logic_ai_decoupling.sh]
 
+  - rule_id: repo.logic_dead_files
+    group: architecture
+    title: colonizethis_logic dead-file detection under lib/src
+    spec: SPEC/program/repo-lint.md
+    runner: dart
+    script: tool/check_logic_dead_files.dart
+
   - rule_id: repo.app_lib_no_broad_suggest_work_orders
     group: architecture
     title: app/lib must not call broad suggestWorkOrders (Refs #2133)


### PR DESCRIPTION
## Summary
- Add `tool/check_logic_dead_files.dart` and wire it into `ct_repo_lint` as `repo.logic_dead_files`.
- Implement dead-file detection rules for `packages/colonizethis_logic/lib/src/**`: exclude `part of` files, treat `lib/**` import reachability as live, and treat export reachability from root barrels/imported src barrels as live.
- Keep `src/ai/ai_planner.dart` and `src/ai/sim_game_ai.dart` explicitly deferred via checker exceptions to match issue non-goals pending product decision.

## Implemented vs deferred
### Implemented in this PR
- CI enforcement slice from issue #2201: dead-file detection and manifest integration.
- Validation run:
  - `dart run tool/check_logic_dead_files.dart`
  - `dart run tool/ct_repo_lint.dart --rule repo.logic_dead_files`

### Deferred
- Dead file removals and export pruning listed in #2201 are **not** performed here.
- In particular, AI files remain deferred by issue design pending product direction.

## AC coverage in this slice
- Covered now:
  - New CI check prevents reintroduction of dead files (with explicit temporary exceptions).
- Left for follow-up:
  - Dead-source/test deletions and barrel pruning tasks.

Refs #2201

Made with [Cursor](https://cursor.com)