### PR TITLE
Issue 2201 slice: prune unused public exports in colonizethis_logic

### DIFF
--- a/packages/colonizethis_logic/lib/colonizethis_logic.dart
+++ b/packages/colonizethis_logic/lib/colonizethis_logic.dart
@@ -37,8 +37,6 @@ export 'src/turn/turn_news_digest.dart';
 // Combat
 export 'src/combat/battle_general_assignment.dart';
 export 'src/combat/combat_mode_selection.dart';
-export 'src/combat/leader_bonus_helpers.dart'
-    show fallbackGeneralMedalsFromLeader;
 export 'src/combat/combat_resolver.dart';
 export 'src/combat/combat_resolver_probabilistic.dart';
 export 'src/combat/conflict_detection.dart';
@@ -71,11 +69,7 @@ export 'src/orders/order_suggestion.dart'
         orderSuggestionWorkOrderAcceptanceProbeCountForTests,
         setOrderSuggestionWorkOrderAcceptanceProbeTrackingForTests;
 export 'src/orders/unit_type_helpers.dart'
-    show
-        devExclusiveReservedTileKeysForPlayer,
-        devExclusiveTilesFromWorld,
-        isDevExclusiveUnitType,
-        isDevExclusiveWorkTarget;
+    show devExclusiveReservedTileKeysForPlayer;
 
 // Diplomacy
 export 'src/diplomacy/diplomacy_resolver.dart';

--- a/packages/colonizethis_logic/test/battle_general_assignment_test.dart
+++ b/packages/colonizethis_logic/test/battle_general_assignment_test.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logic/src/combat/leader_bonus_helpers.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 


### PR DESCRIPTION
## Summary
- Prune unused symbols from `packages/colonizethis_logic/lib/colonizethis_logic.dart` by removing the public export for `fallbackGeneralMedalsFromLeader` and narrowing `unit_type_helpers` exports to `devExclusiveReservedTileKeysForPlayer`.
- Keep behavior unchanged by updating the internal logic-package test to import `leader_bonus_helpers.dart` directly.
- Refs #2201

## Scope in this PR
- **Type:** SLICE (partial delivery)
- **Implemented now:** Barrel API surface pruning for two identified unused export areas.
- **Deferred:** Dead-file removals, validator/phase cleanup, candidate setup/dossier/world export validation, and any CI rule additions proposed in #2201.

## Why partial
- #2201 currently mixes stale dead-file claims with valid API-surface cleanup tasks. This slice delivers a low-risk, testable subset while leaving broader cleanup for follow-up slices.

## Acceptance-criteria mapping (current slice)
- Covered now:
  - Dead barrel `show` clauses pruned to consumer-used symbols only (targeted subset).
- Deferred:
  - All dead-file and corresponding test removals.
  - Candidate export-line validation outcomes beyond this narrowed subset.
  - New CI dead-file detection rule.

## Test plan
- [x] `cd packages/colonizethis_logic && dart test test/battle_general_assignment_test.dart`
- [ ] Full package test suite (deferred to broader cleanup slice)
- [ ] Workspace `flutter analyze` clean (repository currently has pre-existing warnings unrelated to this slice)

Made with [Cursor](https://cursor.com)