### PR TITLE
Document logic dead-file rule and Category B barrel rationale (Refs #2201)

### DIFF
--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -60,7 +60,20 @@
 | `tool/check_long_string_switches.dart` | Warn/fail on large string-literal switch statements/expressions (warn ≥20, fail ≥50) via manifest rule `repo.dart_long_string_switches`; uses shared repo-wide collector `collectRepoLintRepoWideDartFiles` — see `SPEC/program/show-tech-tool.md` |
 | `tool/check_land_province_bucket_keys.dart` | For guarded explore/fog/news paths, disallow local-only land-province tile-bucket lookups (`tileKeysByRegionAndProvince[region]?[localId]`); require canonical full-id buckets only; rule `repo.land_province_bucket_keys` |
 | `tool/check_logic_dual_region_province_field_access.dart` | Caps direct `oldWorld/newWorld` `provinces` / `units` references in `packages/colonizethis_logic/lib/src/**` outside canonical lookup files (`province_lookup.dart`, `unit_lookup.dart`) (GitHub #2071); rule `repo.logic_dual_region_province_field_access` — see `SPEC/program/logic-dual-region-province-access.md` |
+| `tool/check_logic_dead_files.dart` | Unreferenced `lib/src` scan for `colonizethis_logic`; rule `repo.logic_dead_files` — see subsection below |
 | `tool/check_app_no_duplicate_helpers.dart` | AST scan that pins **canonical helper symbols** extracted for #2180 (e.g. `eraRoman`, `techCategoryLabelL10n`, `commodityDisplayName`, the `trainDialog*` set) to one canonical file under `app/lib/**` and forbids reappearance of the previous private duplicates (`_eraRoman`, `_categoryLabel`, `_categoryLabelL10n`, `_commodityDisplayName`) anywhere as top-level functions or class methods (GitHub #2180); rule `repo.app_no_duplicate_helpers` |
+
+### `repo.logic_dead_files` (colonizethis_logic `lib/src` orphans)
+
+**Goal (GitHub #2201):** Fail CI when a hand-written Dart file under `packages/colonizethis_logic/lib/src/**` is neither reachable from the package `lib/**` import graph nor reachable from any **barrel** entrypoint (`packages/colonizethis_logic/lib/*.dart`) via `export` edges.
+
+**Predicate:** A file under `lib/src` is **dead** when all are true: it is not a `part of` target; it is not imported (directly or transitively from parsed `import`/`export`/`part` directives) by any file under `packages/colonizethis_logic/lib/**`; and it is not on the export-reachability closure rooted at every `lib/*.dart` top-level barrel plus any `lib/src` file already imported by `lib/**`.
+
+**Test imports:** Imports from `packages/colonizethis_logic/test/**` do **not** make a `lib/src` file live.
+
+**Deferred paths:** `lib/src/ai/ai_planner.dart` and `lib/src/ai/sim_game_ai.dart` are temporarily exempt in `tool/check_logic_dead_files.dart` until product wiring or deletion is decided (issue #2201); the checker still lists them in the pass message when they are the only findings.
+
+**Consumer note:** The root barrel may export setup/dossier/world modules that are not referenced by `app/` or `colonizethis_ai/` today; that keeps tests on a single `package:colonizethis_logic/colonizethis_logic.dart` import. Narrowing those exports is optional maintenance, not required for the dead-file rule.
 
 ## Rule IDs and groups
 

--- a/packages/colonizethis_logic/lib/colonizethis_logic.dart
+++ b/packages/colonizethis_logic/lib/colonizethis_logic.dart
@@ -11,6 +11,11 @@ export 'src/event_bus/game_event_bus.dart';
 export 'src/game_events.dart';
 export 'src/turn_to_year.dart';
 
+// Setup — GitHub #2201: these setup/dossier/world lines stay public for package
+// tests and integrators; an app/ai usage audit found no direct consumers, but
+// removing them would force broad `src/` imports in tests without shrinking
+// runtime surface meaningfully.
+
 // Setup
 export 'src/setup/capital_choice.dart';
 export 'src/setup/game_setup.dart';

--- a/test/check_logic_dead_files_test.dart
+++ b/test/check_logic_dead_files_test.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../tool/check_logic_dead_files.dart';
+
+void main() {
+  test('passes on real repo workspace', () {
+    final repoRoot = Directory.current.path;
+    final logs = <String>[];
+    final code = runCheckLogicDeadFiles(
+      repoRoot,
+      info: logs.add,
+      err: logs.add,
+    );
+    expect(code, 0, reason: logs.join('\n'));
+    expect(
+      logs.join('\n'),
+      contains('Logic dead-file check passed'),
+    );
+  });
+
+  test('fails when lib/src file is not imported or barrel-exported', () {
+    final temp = Directory.systemTemp.createTempSync('logic_dead_files_fail_');
+    addTearDown(() => temp.deleteSync(recursive: true));
+
+    final logicLib = Directory(p.join(temp.path, 'packages/colonizethis_logic/lib'))
+      ..createSync(recursive: true);
+    final logicSrc = Directory(p.join(logicLib.path, 'src'))
+      ..createSync(recursive: true);
+
+    File(p.join(logicLib.path, 'colonizethis_logic.dart')).writeAsStringSync(
+      'library colonizethis_logic;\n',
+    );
+    File(p.join(logicSrc.path, 'orphan.dart')).writeAsStringSync(
+      '// intentionally unreferenced\n',
+    );
+
+    final err = <String>[];
+    final code = runCheckLogicDeadFiles(
+      temp.path,
+      info: (_) {},
+      err: err.add,
+    );
+
+    expect(code, 1);
+    expect(err.join('\n'), contains('orphan.dart'));
+  });
+}


### PR DESCRIPTION
## Summary
Refs #2201.

## Implemented in this PR
- **SPEC:** `SPEC/program/repo-lint.md` — documents rule `repo.logic_dead_files` (goal, dead predicate, test imports excluded, deferred `ai_planner` / `sim_game_ai`, consumer note for setup/dossier/world barrel exports). Restores the source-of-truth table row for `tool/check_logic_dead_files.dart`.
- **Barrel:** Comment on `packages/colonizethis_logic/lib/colonizethis_logic.dart` recording explicit **retain** rationale for Category B–style public exports (issue AC: each candidate has an outcome).
- **Tests:** `test/check_logic_dead_files_test.dart` — real workspace passes; temp fixture fails when `lib/src` has an orphan.

## Deferred / already landed
- Dead-file **enforcement** and manifest wiring landed in #2210; barrel `show` pruning in #2212. This PR does not remove the deferred AI sources (per issue: product decision pending).
- Issue body file inventory is partly **stale** (e.g. turn phase modules are wired in `turn_phase_run.dart`); the authoritative guard is `repo.logic_dead_files`.

## Tests run
- `dart test test/check_logic_dead_files_test.dart`
- `dart analyze packages/colonizethis_logic/lib/colonizethis_logic.dart`

## Issue completion
Partial delivery: open PR remains; issue should stay **backlog:implementation** until merge and verification. AI file follow-up remains out of scope.

Made with [Cursor](https://cursor.com)