### PR TITLE
Run repo.logic_dead_files in-process in ct_repo_lint

### DIFF
--- a/tool/ct_repo_lint_lib.dart
+++ b/tool/ct_repo_lint_lib.dart
@@ -23,6 +23,7 @@ import 'check_flutter_action_pins.dart';
 import 'check_function_size.dart';
 import 'check_game_widgets_file_size.dart';
 import 'check_land_province_bucket_keys.dart';
+import 'check_logic_dead_files.dart';
 import 'check_logic_dual_region_province_field_access.dart';
 import 'check_no_flame_in_widgets.dart';
 import 'check_no_screen_in_game_widgets.dart';
@@ -766,6 +767,8 @@ int? _tryRunDartRuleInProcess({
       return runCheckLandProvinceBucketKeys(repoRoot);
     case 'repo.logic_dual_region_province_field_access':
       return runCheckLogicDualRegionProvinceFieldAccess(repoRoot);
+    case 'repo.logic_dead_files':
+      return runCheckLogicDeadFiles(repoRoot);
     case 'repo.app_hardcoded_ui_strings':
       return runCheckAppHardcodedUiStrings(repoRoot);
     case 'repo.app_no_duplicate_helpers':


### PR DESCRIPTION
## Summary
Registers `repo.logic_dead_files` in `ct_repo_lint_lib.dart` so the orchestrator calls `runCheckLogicDeadFiles` in-process (same behavior as `dart run tool/check_logic_dead_files.dart`), per SPEC/program/repo-lint.md guidance for manifest Dart rules.

## Implemented (this PR)
- Import `check_logic_dead_files.dart` and add `case 'repo.logic_dead_files':` in `_tryRunDartRuleInProcess`.

## Deferred (issue #2201 context)
- **Category A bulk deletion** from the issue body is **obsolete for current `dev`**: the listed turn phases, order validators, economy preview, unit availability, and work-order duration code are **wired** (`turn_phase_runner` → `phases.dart`, `order_engine` → `order_validators.dart`, app imports for previews, etc.). Removing them would break the build.
- **Barrel / category B**: `lib/colonizethis_logic.dart` already carries #2201 notes and narrowed exports on `dev`.
- **CI guard**: `tool/check_logic_dead_files.dart`, manifest rule `repo.logic_dead_files`, `SPEC/program/repo-lint.md` subsection, and `test/check_logic_dead_files_test.dart` are already present; this PR only completes the in-process binding.

## Tests
- `dart run tool/ct_repo_lint.dart --rule repo.logic_dead_files`
- `dart test test/ct_repo_lint_test.dart --reporter=compact`

Refs #2201

Made with [Cursor](https://cursor.com)