### PR TITLE
Extract test fixtures and split oversized logic tests (slice for #2216)

### DIFF
--- a/packages/colonizethis_logic/test/event_dialogue_reactive_test.dart
+++ b/packages/colonizethis_logic/test/event_dialogue_reactive_test.dart
@@ -1,0 +1,282 @@
+// Tests for reactive event dialogue (forts on border, human attack)
+// and additional event/reactive situations (tech, capital, colony, spies).
+// Battles / era / negotiation live in event_dialogue_test.dart.
+// SPEC/ai/dialogue-and-mood.md, SPEC/program/ai-events-and-dossier.md.
+
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'event_dialogue_test_support.dart';
+
+void main() {
+  group('dialogueEventsForReactiveFortsOnBorder', () {
+    final topology = MapTopology(
+      nodes: const [
+        TopologyNode(
+          id: 'P1',
+          regionId: 'ow',
+          type: TopologyNodeType.province,
+        ),
+        TopologyNode(
+          id: 'P2',
+          regionId: 'ow',
+          type: TopologyNodeType.province,
+        ),
+      ],
+      edges: const [TopologyEdge(id1: 'P1', id2: 'P2')],
+    );
+
+    test('returns empty when builder is AI', () {
+      final game = dialogueGame(
+        oldWorldProvinces: const [
+          Province(id: 'ow|P1', regionId: 'ow', ownerId: 'gp2'),
+          Province(id: 'ow|P2', regionId: 'ow', ownerId: 'gp1'),
+        ],
+        players: const [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true),
+          Player(id: 'gp2', displayName: 'AI', isHuman: false),
+        ],
+      );
+      final events = dialogueEventsForReactiveFortsOnBorder(
+        game,
+        topology,
+        'gp2',
+        'ow|P2',
+        0,
+      );
+      expect(events, isEmpty);
+    });
+
+    test(
+      'emits one event per AI neighbor when human builds fort on border',
+      () {
+        final game = dialogueGame(
+          oldWorldProvinces: const [
+            Province(id: 'ow|P1', regionId: 'ow', ownerId: 'gp2'),
+            Province(id: 'ow|P2', regionId: 'ow', ownerId: 'gp1'),
+          ],
+          players: const [
+            Player(id: 'gp1', displayName: 'Human', isHuman: true),
+            Player(id: 'gp2', displayName: 'AI', isHuman: false),
+          ],
+        );
+        final events = dialogueEventsForReactiveFortsOnBorder(
+          game,
+          topology,
+          'gp1',
+          'ow|P2',
+          0,
+        );
+        expect(events.length, 1);
+        expect(events.first.leaderId, 'gp2');
+        expect(events.first.category, 'reactive');
+        expect(events.first.situation, 'forts_on_border');
+        expect(events.first.variables['otherNation'], 'gp1');
+        expect(events.first.variables['province'], 'ow|P2');
+      },
+    );
+
+    test('resolves owner from newWorld when fort built in newWorld', () {
+      const nw = 'newWorld';
+      final newWorldTopology = MapTopology(
+        nodes: const [
+          TopologyNode(id: 'N1', regionId: nw, type: TopologyNodeType.province),
+          TopologyNode(id: 'N2', regionId: nw, type: TopologyNodeType.province),
+        ],
+        edges: const [TopologyEdge(id1: 'N1', id2: 'N2')],
+      );
+      final game = dialogueGame(
+        newWorldProvinces: const [
+          Province(id: 'newWorld|N1', regionId: nw, ownerId: 'gp1'),
+          Province(id: 'newWorld|N2', regionId: nw, ownerId: 'gp2'),
+        ],
+        players: const [
+          Player(id: 'gp1', displayName: 'Human', isHuman: true),
+          Player(id: 'gp2', displayName: 'AI', isHuman: false),
+        ],
+      );
+      final events = dialogueEventsForReactiveFortsOnBorder(
+        game,
+        newWorldTopology,
+        'gp1',
+        'newWorld|N1',
+        0,
+      );
+      expect(events.length, 1);
+      expect(events.first.leaderId, 'gp2');
+      expect(events.first.variables['province'], 'newWorld|N1');
+    });
+  });
+
+  group('dialogueEventsForReactiveHumanAttack', () {
+    test('emits attack_on_ally for AI allied with defender', () {
+      final game = dialogueGame(
+        turnNumber: 5,
+        players: const [
+          Player(id: 'human', displayName: 'Human', isHuman: true),
+          Player(id: 'ai1', displayName: 'AI', isHuman: false),
+          Player(id: 'ai2', displayName: 'AI Defender', isHuman: false),
+        ],
+        diplomacyRelations: const [
+          DiplomacyRelation(
+            factionId1: 'ai1',
+            factionId2: 'ai2',
+            level: RelationLevel.allied,
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      final events = dialogueEventsForReactiveHumanAttack(
+        game,
+        attackerFactionId: 'human',
+        defenderFactionId: 'ai2',
+        provinceId: 'oldWorld|P1',
+        turnNumber: 5,
+        seed: 1,
+      );
+      expect(events.length, 1);
+      expect(events.first.leaderId, 'ai1');
+      expect(events.first.situation, 'attack_on_ally');
+    });
+
+    test('emits attack_on_minor and attack_on_tribe for AI with embassy', () {
+      final game = dialogueGame(
+        turnNumber: 5,
+        players: const [
+          Player(id: 'human', displayName: 'Human', isHuman: true),
+          Player(id: 'ai1', displayName: 'AI', isHuman: false),
+        ],
+        minorNations: const [MinorNation(id: 'mn1')],
+        tribes: const [Tribe(id: 'tr1')],
+        overtureStates: const [
+          OvertureState(
+            gpId: 'ai1',
+            targetId: 'mn1',
+            stage: OvertureStage.embassy,
+          ),
+          OvertureState(
+            gpId: 'ai1',
+            targetId: 'tr1',
+            stage: OvertureStage.embassy,
+          ),
+        ],
+      );
+      final minorEvents = dialogueEventsForReactiveHumanAttack(
+        game,
+        attackerFactionId: 'human',
+        defenderFactionId: 'mn1',
+        provinceId: 'oldWorld|P9',
+        turnNumber: 5,
+        seed: 1,
+      );
+      final tribeEvents = dialogueEventsForReactiveHumanAttack(
+        game,
+        attackerFactionId: 'human',
+        defenderFactionId: 'tr1',
+        provinceId: 'newWorld|N2',
+        turnNumber: 5,
+        seed: 1,
+      );
+      expect(minorEvents.single.situation, 'attack_on_minor');
+      expect(tribeEvents.single.situation, 'attack_on_tribe');
+    });
+  });
+
+  group('additional event/reactive situations', () {
+    test('tech_discovered emits for AI discoverer only', () {
+      final game = dialogueGame(
+        turnNumber: 8,
+        players: const [
+          Player(id: 'h1', displayName: 'Human', isHuman: true),
+          Player(id: 'a1', displayName: 'AI', isHuman: false),
+        ],
+      );
+      final aiEvents = dialogueEventsForTechDiscovered(
+        game,
+        discovererId: 'a1',
+        techId: 'rifling',
+        turnNumber: 8,
+        seed: 0,
+      );
+      final humanEvents = dialogueEventsForTechDiscovered(
+        game,
+        discovererId: 'h1',
+        techId: 'rifling',
+        turnNumber: 8,
+        seed: 0,
+      );
+      expect(aiEvents.single.situation, 'tech_discovered');
+      expect(humanEvents, isEmpty);
+    });
+
+    test('capital_threatened emits when human attacker targets AI capital', () {
+      final game = dialogueGame(
+        turnNumber: 3,
+        players: const [
+          Player(id: 'h1', displayName: 'Human', isHuman: true),
+          Player(
+            id: 'a1',
+            displayName: 'AI',
+            isHuman: false,
+            capitalProvinceId: 'oldWorld|P2',
+          ),
+        ],
+      );
+      final events = dialogueEventsForCapitalThreatened(
+        game,
+        capitalOwnerId: 'a1',
+        provinceId: 'oldWorld|P2',
+        attackerFactionIds: const ['h1'],
+        turnNumber: 3,
+        seed: 0,
+      );
+      expect(events.single.situation, 'capital_threatened');
+    });
+
+    test('colony_founded emits only for null->AI owner in New World', () {
+      final game = dialogueGame(
+        turnNumber: 10,
+        players: const [Player(id: 'a1', displayName: 'AI', isHuman: false)],
+      );
+      final yes = dialogueEventsForColonyFounded(
+        game,
+        provinceId: 'newWorld|N1',
+        previousOwnerId: null,
+        newOwnerId: 'a1',
+        turnNumber: 10,
+        seed: 0,
+      );
+      final no = dialogueEventsForColonyFounded(
+        game,
+        provinceId: 'oldWorld|P1',
+        previousOwnerId: null,
+        newOwnerId: 'a1',
+        turnNumber: 10,
+        seed: 0,
+      );
+      expect(yes.single.situation, 'colony_founded');
+      expect(no, isEmpty);
+    });
+
+    test('spies_caught emits only for AI speaker and human spy owner', () {
+      final game = dialogueGame(
+        turnNumber: 7,
+        players: const [
+          Player(id: 'h1', displayName: 'Human', isHuman: true),
+          Player(id: 'a1', displayName: 'AI', isHuman: false),
+        ],
+      );
+      final events = dialogueEventsForReactiveSpiesCaught(
+        game,
+        speakerId: 'a1',
+        caughtSpyOwnerId: 'h1',
+        provinceId: 'oldWorld|P4',
+        turnNumber: 7,
+        seed: 0,
+      );
+      expect(events.single.situation, 'spies_caught');
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/event_dialogue_test.dart
+++ b/packages/colonizethis_logic/test/event_dialogue_test.dart
@@ -1,9 +1,13 @@
-// Tests for event dialogue (battle result, reactive, negotiation). SPEC/ai/dialogue-and-mood.md, SPEC/program/ai-events-and-dossier.md.
+// Tests for event dialogue (battle result, era change, negotiation).
+// Reactive and additional event-dialogue rules live in
+// event_dialogue_reactive_test.dart.
+// SPEC/ai/dialogue-and-mood.md, SPEC/program/ai-events-and-dossier.md.
 
 import 'package:colonizethis_test/test.dart';
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'event_dialogue_test_support.dart';
 
 void main() {
   group('dialogueEventsForLandBattleResult', () {
@@ -11,13 +15,8 @@ void main() {
       'AI victor and AI loser both emit event with era from turn-time mapping',
       () {
         const mapping = TurnTimeMapping.gdd01;
-        final game = Game(
-          id: 'g1',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-            oldWorld: const RegionData(),
-            newWorld: const RegionData(),
-          ),
+        final game = dialogueGame(
+          turnNumber: 2,
           players: const [
             Player(id: 'gp1', displayName: 'Human', isHuman: true),
             Player(id: 'gp2', displayName: 'AI Victor', isHuman: false),
@@ -49,13 +48,8 @@ void main() {
     );
 
     test('human victor returns no dialogue for victor', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
+      final game = dialogueGame(
+        turnNumber: 2,
         players: const [
           Player(id: 'gp1', displayName: 'Human', isHuman: true),
           Player(id: 'gp2', displayName: 'AI', isHuman: false),
@@ -75,13 +69,8 @@ void main() {
     });
 
     test('human loser returns only battle_won for AI victor', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
+      final game = dialogueGame(
+        turnNumber: 2,
         players: const [
           Player(id: 'gp1', displayName: 'Human', isHuman: true),
           Player(id: 'gp2', displayName: 'AI', isHuman: false),
@@ -103,13 +92,8 @@ void main() {
 
   group('dialogueEventsForNavalBattleResult', () {
     test('AI victor and AI loser both emit event', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
+      final game = dialogueGame(
+        turnNumber: 3,
         players: const [
           Player(id: 'gp1', displayName: 'Human', isHuman: true),
           Player(id: 'gp2', displayName: 'AI Victor', isHuman: false),
@@ -136,13 +120,7 @@ void main() {
     });
 
     test('human victor returns only battle_lost for AI loser', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
+      final game = dialogueGame(
         players: const [
           Player(id: 'gp1', displayName: 'Human', isHuman: true),
           Player(id: 'gp2', displayName: 'AI', isHuman: false),
@@ -174,13 +152,8 @@ void main() {
 
   group('dialogueEventsForEraChange', () {
     test('emits one event per AI leader with era_change situation', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 100),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
+      final game = dialogueGame(
+        turnNumber: 100,
         players: const [
           Player(id: 'gp1', displayName: 'Human', isHuman: true),
           Player(id: 'gp2', displayName: 'AI', isHuman: false),
@@ -204,13 +177,8 @@ void main() {
     });
 
     test('emits no events when all players are human', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 100),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
+      final game = dialogueGame(
+        turnNumber: 100,
         players: const [
           Player(id: 'gp1', displayName: 'Human', isHuman: true),
           Player(id: 'gp2', displayName: 'Human', isHuman: true),
@@ -223,140 +191,6 @@ void main() {
         0,
       );
       expect(events, isEmpty);
-    });
-  });
-
-  group('dialogueEventsForReactiveFortsOnBorder', () {
-    test('returns empty when builder is AI', () {
-      final topology = MapTopology(
-        nodes: const [
-          TopologyNode(
-            id: 'P1',
-            regionId: 'ow',
-            type: TopologyNodeType.province,
-          ),
-          TopologyNode(
-            id: 'P2',
-            regionId: 'ow',
-            type: TopologyNodeType.province,
-          ),
-        ],
-        edges: const [TopologyEdge(id1: 'P1', id2: 'P2')],
-      );
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            provinces: [
-              Province(id: 'ow|P1', regionId: 'ow', ownerId: 'gp2'),
-              Province(id: 'ow|P2', regionId: 'ow', ownerId: 'gp1'),
-            ],
-          ),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'gp1', displayName: 'Human', isHuman: true),
-          Player(id: 'gp2', displayName: 'AI', isHuman: false),
-        ],
-      );
-      final events = dialogueEventsForReactiveFortsOnBorder(
-        game,
-        topology,
-        'gp2',
-        'ow|P2',
-        0,
-      );
-      expect(events, isEmpty);
-    });
-
-    test(
-      'emits one event per AI neighbor when human builds fort on border',
-      () {
-        final topology = MapTopology(
-          nodes: const [
-            TopologyNode(
-              id: 'P1',
-              regionId: 'ow',
-              type: TopologyNodeType.province,
-            ),
-            TopologyNode(
-              id: 'P2',
-              regionId: 'ow',
-              type: TopologyNodeType.province,
-            ),
-          ],
-          edges: const [TopologyEdge(id1: 'P1', id2: 'P2')],
-        );
-        final game = Game(
-          id: 'g1',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-            oldWorld: RegionData(
-              provinces: [
-                Province(id: 'ow|P1', regionId: 'ow', ownerId: 'gp2'),
-                Province(id: 'ow|P2', regionId: 'ow', ownerId: 'gp1'),
-              ],
-            ),
-            newWorld: const RegionData(),
-          ),
-          players: const [
-            Player(id: 'gp1', displayName: 'Human', isHuman: true),
-            Player(id: 'gp2', displayName: 'AI', isHuman: false),
-          ],
-        );
-        final events = dialogueEventsForReactiveFortsOnBorder(
-          game,
-          topology,
-          'gp1',
-          'ow|P2',
-          0,
-        );
-        expect(events.length, 1);
-        expect(events.first.leaderId, 'gp2');
-        expect(events.first.category, 'reactive');
-        expect(events.first.situation, 'forts_on_border');
-        expect(events.first.variables['otherNation'], 'gp1');
-        expect(events.first.variables['province'], 'ow|P2');
-      },
-    );
-
-    test('resolves owner from newWorld when fort built in newWorld', () {
-      const nw = 'newWorld';
-      final topology = MapTopology(
-        nodes: const [
-          TopologyNode(id: 'N1', regionId: nw, type: TopologyNodeType.province),
-          TopologyNode(id: 'N2', regionId: nw, type: TopologyNodeType.province),
-        ],
-        edges: const [TopologyEdge(id1: 'N1', id2: 'N2')],
-      );
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: const RegionData(),
-          newWorld: RegionData(
-            provinces: [
-              Province(id: 'newWorld|N1', regionId: nw, ownerId: 'gp1'),
-              Province(id: 'newWorld|N2', regionId: nw, ownerId: 'gp2'),
-            ],
-          ),
-        ),
-        players: const [
-          Player(id: 'gp1', displayName: 'Human', isHuman: true),
-          Player(id: 'gp2', displayName: 'AI', isHuman: false),
-        ],
-      );
-      final events = dialogueEventsForReactiveFortsOnBorder(
-        game,
-        topology,
-        'gp1',
-        'newWorld|N1',
-        0,
-      );
-      expect(events.length, 1);
-      expect(events.first.leaderId, 'gp2');
-      expect(events.first.variables['province'], 'newWorld|N1');
     });
   });
 
@@ -386,206 +220,6 @@ void main() {
       expect(e.category, 'negotiation');
       expect(e.situation, 'opening');
       expect(e.mood, isNull);
-    });
-  });
-
-  group('dialogueEventsForReactiveHumanAttack', () {
-    test('emits attack_on_ally for AI allied with defender', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 5),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'human', displayName: 'Human', isHuman: true),
-          Player(id: 'ai1', displayName: 'AI', isHuman: false),
-          Player(id: 'ai2', displayName: 'AI Defender', isHuman: false),
-        ],
-        diplomacyRelations: const [
-          DiplomacyRelation(
-            factionId1: 'ai1',
-            factionId2: 'ai2',
-            level: RelationLevel.allied,
-            state: RelationState.atPeace,
-          ),
-        ],
-      );
-      final events = dialogueEventsForReactiveHumanAttack(
-        game,
-        attackerFactionId: 'human',
-        defenderFactionId: 'ai2',
-        provinceId: 'oldWorld|P1',
-        turnNumber: 5,
-        seed: 1,
-      );
-      expect(events.length, 1);
-      expect(events.first.leaderId, 'ai1');
-      expect(events.first.situation, 'attack_on_ally');
-    });
-
-    test('emits attack_on_minor and attack_on_tribe for AI with embassy', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 5),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'human', displayName: 'Human', isHuman: true),
-          Player(id: 'ai1', displayName: 'AI', isHuman: false),
-        ],
-        minorNations: const [MinorNation(id: 'mn1')],
-        tribes: const [Tribe(id: 'tr1')],
-        overtureStates: const [
-          OvertureState(
-            gpId: 'ai1',
-            targetId: 'mn1',
-            stage: OvertureStage.embassy,
-          ),
-          OvertureState(
-            gpId: 'ai1',
-            targetId: 'tr1',
-            stage: OvertureStage.embassy,
-          ),
-        ],
-      );
-      final minorEvents = dialogueEventsForReactiveHumanAttack(
-        game,
-        attackerFactionId: 'human',
-        defenderFactionId: 'mn1',
-        provinceId: 'oldWorld|P9',
-        turnNumber: 5,
-        seed: 1,
-      );
-      final tribeEvents = dialogueEventsForReactiveHumanAttack(
-        game,
-        attackerFactionId: 'human',
-        defenderFactionId: 'tr1',
-        provinceId: 'newWorld|N2',
-        turnNumber: 5,
-        seed: 1,
-      );
-      expect(minorEvents.single.situation, 'attack_on_minor');
-      expect(tribeEvents.single.situation, 'attack_on_tribe');
-    });
-  });
-
-  group('additional event/reactive situations', () {
-    test('tech_discovered emits for AI discoverer only', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 8),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'h1', displayName: 'Human', isHuman: true),
-          Player(id: 'a1', displayName: 'AI', isHuman: false),
-        ],
-      );
-      final aiEvents = dialogueEventsForTechDiscovered(
-        game,
-        discovererId: 'a1',
-        techId: 'rifling',
-        turnNumber: 8,
-        seed: 0,
-      );
-      final humanEvents = dialogueEventsForTechDiscovered(
-        game,
-        discovererId: 'h1',
-        techId: 'rifling',
-        turnNumber: 8,
-        seed: 0,
-      );
-      expect(aiEvents.single.situation, 'tech_discovered');
-      expect(humanEvents, isEmpty);
-    });
-
-    test('capital_threatened emits when human attacker targets AI capital', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'h1', displayName: 'Human', isHuman: true),
-          Player(
-            id: 'a1',
-            displayName: 'AI',
-            isHuman: false,
-            capitalProvinceId: 'oldWorld|P2',
-          ),
-        ],
-      );
-      final events = dialogueEventsForCapitalThreatened(
-        game,
-        capitalOwnerId: 'a1',
-        provinceId: 'oldWorld|P2',
-        attackerFactionIds: const ['h1'],
-        turnNumber: 3,
-        seed: 0,
-      );
-      expect(events.single.situation, 'capital_threatened');
-    });
-
-    test('colony_founded emits only for null->AI owner in New World', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 10),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [Player(id: 'a1', displayName: 'AI', isHuman: false)],
-      );
-      final yes = dialogueEventsForColonyFounded(
-        game,
-        provinceId: 'newWorld|N1',
-        previousOwnerId: null,
-        newOwnerId: 'a1',
-        turnNumber: 10,
-        seed: 0,
-      );
-      final no = dialogueEventsForColonyFounded(
-        game,
-        provinceId: 'oldWorld|P1',
-        previousOwnerId: null,
-        newOwnerId: 'a1',
-        turnNumber: 10,
-        seed: 0,
-      );
-      expect(yes.single.situation, 'colony_founded');
-      expect(no, isEmpty);
-    });
-
-    test('spies_caught emits only for AI speaker and human spy owner', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 7),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'h1', displayName: 'Human', isHuman: true),
-          Player(id: 'a1', displayName: 'AI', isHuman: false),
-        ],
-      );
-      final events = dialogueEventsForReactiveSpiesCaught(
-        game,
-        speakerId: 'a1',
-        caughtSpyOwnerId: 'h1',
-        provinceId: 'oldWorld|P4',
-        turnNumber: 7,
-        seed: 0,
-      );
-      expect(events.single.situation, 'spies_caught');
     });
   });
 }

--- a/packages/colonizethis_logic/test/event_dialogue_test_support.dart
+++ b/packages/colonizethis_logic/test/event_dialogue_test_support.dart
@@ -1,0 +1,40 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Shared `Game` fixture for `event_dialogue_test.dart` and its split files.
+///
+/// Most dialogue tests construct a near-identical empty-world or
+/// minimal-province game (orders phase) varying only by `turnNumber`,
+/// `players`, optional region provinces, and a handful of optional
+/// diplomacy / overture / minor-nation / tribe fields. This helper
+/// centralizes that boilerplate.
+///
+/// Refs waigore/colonizethis#2216 (consolidate duplicated test setup).
+Game dialogueGame({
+  String id = 'g1',
+  int turnNumber = 1,
+  required List<Player> players,
+  List<Province> oldWorldProvinces = const [],
+  List<Province> newWorldProvinces = const [],
+  List<DiplomacyRelation> diplomacyRelations = const [],
+  List<MinorNation> minorNations = const [],
+  List<Tribe> tribes = const [],
+  List<OvertureState> overtureStates = const [],
+}) {
+  return Game(
+    id: id,
+    worldState: WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: turnNumber),
+      oldWorld: oldWorldProvinces.isEmpty
+          ? const RegionData()
+          : RegionData(provinces: oldWorldProvinces),
+      newWorld: newWorldProvinces.isEmpty
+          ? const RegionData()
+          : RegionData(provinces: newWorldProvinces),
+    ),
+    players: players,
+    diplomacyRelations: diplomacyRelations,
+    minorNations: minorNations,
+    tribes: tribes,
+    overtureStates: overtureStates,
+  );
+}

--- a/packages/colonizethis_logic/test/evidence_rules_isolationist_test.dart
+++ b/packages/colonizethis_logic/test/evidence_rules_isolationist_test.dart
@@ -1,0 +1,133 @@
+// Tests for isolationist call-to-arms refusal evidence rule.
+// SPEC/ai/hidden-agendas.md, SPEC/program/ai-events-and-dossier.md.
+
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'evidence_rules_test_support.dart';
+
+void main() {
+  group('evidenceForIsolationistCallToArmsRefuse', () {
+    Game ctaRefuseGame({
+      required bool allyIsAi,
+      required bool atPeaceWithDefender,
+    }) {
+      return evidenceGame(
+        turnNumber: 3,
+        players: [
+          const Player(id: 'observer', displayName: 'Human', isHuman: true),
+          Player(id: 'ally', displayName: 'Ally', isHuman: !allyIsAi),
+          const Player(id: 'defender', displayName: 'Defender', isHuman: false),
+        ],
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: 'ally',
+            factionId2: 'defender',
+            score: 50,
+            level: RelationLevel.friendly,
+            state: atPeaceWithDefender
+                ? RelationState.atPeace
+                : RelationState.atWar,
+          ),
+        ],
+      );
+    }
+
+    test(
+      'AI refusing call to arms while at peace with defender adds isolationist +2',
+      () {
+        final game = ctaRefuseGame(
+          allyIsAi: true,
+          atPeaceWithDefender: true,
+        );
+        final entries = evidenceForIsolationistCallToArmsRefuse(
+          game,
+          'ally',
+          'defender',
+          3,
+        );
+        expect(entries.length, 1);
+        expect(entries.single.observerId, 'observer');
+        expect(entries.single.subjectId, 'ally');
+        expect(entries.single.agendaType, 'isolationist');
+        expect(entries.single.scoreDelta, 2);
+        expect(entries.single.turnNumber, 3);
+        expect(entries.single.description, contains('declined call to arms'));
+      },
+    );
+
+    test('empty when ally and defender are at war', () {
+      final game = ctaRefuseGame(
+        allyIsAi: true,
+        atPeaceWithDefender: false,
+      );
+      final entries = evidenceForIsolationistCallToArmsRefuse(
+        game,
+        'ally',
+        'defender',
+        3,
+      );
+      expect(entries, isEmpty);
+    });
+
+    test('human ally returns no evidence', () {
+      final game = ctaRefuseGame(
+        allyIsAi: false,
+        atPeaceWithDefender: true,
+      );
+      final entries = evidenceForIsolationistCallToArmsRefuse(
+        game,
+        'ally',
+        'defender',
+        3,
+      );
+      expect(entries, isEmpty);
+    });
+
+    test('no human observer returns no evidence', () {
+      final game = evidenceGame(
+        turnNumber: 3,
+        players: const [
+          Player(id: 'ai1', displayName: 'AI1', isHuman: false),
+          Player(id: 'ai2', displayName: 'AI2', isHuman: false),
+          Player(id: 'defender', displayName: 'Defender', isHuman: false),
+        ],
+        diplomacyRelations: const [
+          DiplomacyRelation(
+            factionId1: 'ai1',
+            factionId2: 'defender',
+            score: 50,
+            level: RelationLevel.friendly,
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      final entries = evidenceForIsolationistCallToArmsRefuse(
+        game,
+        'ai1',
+        'defender',
+        3,
+      );
+      expect(entries, isEmpty);
+    });
+
+    test('empty when no relation exists between ally and defender', () {
+      final game = evidenceGame(
+        turnNumber: 3,
+        players: const [
+          Player(id: 'observer', displayName: 'Human', isHuman: true),
+          Player(id: 'ally', displayName: 'Ally', isHuman: false),
+          Player(id: 'defender', displayName: 'Defender', isHuman: false),
+        ],
+      );
+      final entries = evidenceForIsolationistCallToArmsRefuse(
+        game,
+        'ally',
+        'defender',
+        3,
+      );
+      expect(entries, isEmpty);
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/evidence_rules_test.dart
+++ b/packages/colonizethis_logic/test/evidence_rules_test.dart
@@ -1,21 +1,21 @@
-// Tests for dossier evidence rules. SPEC/ai/hidden-agendas.md, SPEC/program/ai-events-and-dossier.md.
+// Tests for battle-victory and research/spy dossier evidence rules.
+// Diplomacy / war-peace / isolationist rules live in sibling files:
+//  - evidence_rules_war_peace_test.dart
+//  - evidence_rules_isolationist_test.dart
+// SPEC/ai/hidden-agendas.md, SPEC/program/ai-events-and-dossier.md.
 
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'evidence_rules_test_support.dart';
 
 void main() {
   group('evidenceForLandBattleVictory', () {
     test(
       'AI victor vs defender appends warmonger evidence for human observer',
       () {
-        final game = Game(
-          id: 'g1',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-            oldWorld: const RegionData(),
-            newWorld: const RegionData(),
-          ),
+        final game = evidenceGame(
           players: const [
             Player(id: 'gp1', displayName: 'Human', isHuman: true),
             Player(
@@ -43,13 +43,7 @@ void main() {
     );
 
     test('AI victor vs non-weaker defender gives scoreDelta 1', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
+      final game = evidenceGame(
         players: const [
           Player(id: 'gp1', displayName: 'Human', isHuman: true),
           Player(
@@ -74,13 +68,7 @@ void main() {
     });
 
     test('human victor returns no evidence', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
+      final game = evidenceGame(
         players: const [
           Player(id: 'gp1', displayName: 'Human', isHuman: true),
           Player(id: 'gp2', displayName: 'AI', isHuman: false),
@@ -91,13 +79,7 @@ void main() {
     });
 
     test('no human observer returns no evidence', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
+      final game = evidenceGame(
         players: const [
           Player(id: 'gp1', displayName: 'AI1', isHuman: false),
           Player(id: 'gp2', displayName: 'AI2', isHuman: false),
@@ -110,13 +92,7 @@ void main() {
 
   group('evidenceForNavalBattleVictory', () {
     test('AI victor appends warmonger evidence for human observer', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
+      final game = evidenceGame(
         players: const [
           Player(id: 'gp1', displayName: 'Human', isHuman: true),
           Player(id: 'gp2', displayName: 'AI', isHuman: false),
@@ -133,13 +109,7 @@ void main() {
     });
 
     test('human victor returns no evidence', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
+      final game = evidenceGame(
         players: const [
           Player(id: 'gp1', displayName: 'Human', isHuman: true),
           Player(id: 'gp2', displayName: 'AI', isHuman: false),
@@ -150,339 +120,10 @@ void main() {
     });
   });
 
-  group('evidenceForDeclareWar', () {
-    test(
-      'AI declaring war on weaker allied GP adds backstabber and warmonger evidence',
-      () {
-        final game = Game(
-          id: 'g1',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-            oldWorld: const RegionData(),
-            newWorld: const RegionData(),
-          ),
-          players: const [
-            Player(
-              id: 'human',
-              displayName: 'Human',
-              isHuman: true,
-              militaryLevel: 3,
-            ),
-            Player(
-              id: 'ai',
-              displayName: 'AI',
-              isHuman: false,
-              militaryLevel: 5,
-            ),
-            Player(
-              id: 'ally',
-              displayName: 'Ally',
-              isHuman: false,
-              militaryLevel: 2,
-            ),
-          ],
-          diplomacyRelations: const [
-            DiplomacyRelation(
-              factionId1: 'ai',
-              factionId2: 'ally',
-              level: RelationLevel.allied,
-            ),
-          ],
-        );
-
-        final entries = evidenceForDeclareWar(game, 'ai', 'ally', 2);
-
-        expect(entries.length, 2);
-        final backstabberEntries = entries
-            .where((e) => e.agendaType == 'backstabber')
-            .toList();
-        final warmongerEntries = entries
-            .where((e) => e.agendaType == 'warmonger')
-            .toList();
-
-        expect(backstabberEntries.length, 1);
-        expect(backstabberEntries.first.observerId, 'human');
-        expect(backstabberEntries.first.subjectId, 'ai');
-        expect(backstabberEntries.first.scoreDelta, 3);
-        expect(backstabberEntries.first.description, contains('ally'));
-
-        expect(warmongerEntries.length, 1);
-        expect(warmongerEntries.first.observerId, 'human');
-        expect(warmongerEntries.first.subjectId, 'ai');
-        expect(warmongerEntries.first.scoreDelta, 2);
-        expect(warmongerEntries.first.description, contains('weaker'));
-      },
-    );
-
-    test(
-      'AI declaring war on weaker non-allied GP only adds warmonger evidence',
-      () {
-        final game = Game(
-          id: 'g1',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-            oldWorld: const RegionData(),
-            newWorld: const RegionData(),
-          ),
-          players: const [
-            Player(
-              id: 'human',
-              displayName: 'Human',
-              isHuman: true,
-              militaryLevel: 3,
-            ),
-            Player(
-              id: 'ai',
-              displayName: 'AI',
-              isHuman: false,
-              militaryLevel: 5,
-            ),
-            Player(
-              id: 'target',
-              displayName: 'Target',
-              isHuman: false,
-              militaryLevel: 2,
-            ),
-          ],
-        );
-
-        final entries = evidenceForDeclareWar(game, 'ai', 'target', 2);
-
-        expect(entries.length, 1);
-        expect(entries.first.agendaType, 'warmonger');
-        expect(entries.first.observerId, 'human');
-        expect(entries.first.subjectId, 'ai');
-        expect(entries.first.scoreDelta, 2);
-        expect(entries.first.description, contains('weaker'));
-      },
-    );
-
-    test(
-      'AI declaring war on allied non-weaker GP only adds backstabber evidence',
-      () {
-        final game = Game(
-          id: 'g1',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-            oldWorld: const RegionData(),
-            newWorld: const RegionData(),
-          ),
-          players: const [
-            Player(
-              id: 'human',
-              displayName: 'Human',
-              isHuman: true,
-              militaryLevel: 3,
-            ),
-            Player(
-              id: 'ai',
-              displayName: 'AI',
-              isHuman: false,
-              militaryLevel: 2,
-            ),
-            Player(
-              id: 'ally',
-              displayName: 'Ally',
-              isHuman: false,
-              militaryLevel: 5,
-            ),
-          ],
-          diplomacyRelations: const [
-            DiplomacyRelation(
-              factionId1: 'ai',
-              factionId2: 'ally',
-              level: RelationLevel.allied,
-            ),
-          ],
-        );
-
-        final entries = evidenceForDeclareWar(game, 'ai', 'ally', 2);
-
-        expect(entries.length, 1);
-        expect(entries.first.agendaType, 'backstabber');
-        expect(entries.first.observerId, 'human');
-        expect(entries.first.subjectId, 'ai');
-        expect(entries.first.scoreDelta, 3);
-        expect(entries.first.description, contains('ally'));
-      },
-    );
-
-    test('human actor returns no evidence', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'human', displayName: 'Human', isHuman: true),
-          Player(id: 'ai', displayName: 'AI', isHuman: false),
-        ],
-      );
-
-      final entries = evidenceForDeclareWar(game, 'human', 'ai', 2);
-
-      expect(entries, isEmpty);
-    });
-
-    test('no human observer returns no evidence', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'ai', displayName: 'AI', isHuman: false),
-          Player(id: 'other', displayName: 'Other', isHuman: false),
-        ],
-      );
-
-      final entries = evidenceForDeclareWar(game, 'ai', 'other', 2);
-
-      expect(entries, isEmpty);
-    });
-  });
-
-  group('evidenceForOfferPeace', () {
-    test('AI offering peace adds peacemaker evidence for human observer', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'human', displayName: 'Human', isHuman: true),
-          Player(id: 'ai', displayName: 'AI', isHuman: false),
-        ],
-      );
-
-      final entries = evidenceForOfferPeace(game, 'ai', 'human', 2);
-
-      expect(entries.length, 1);
-      final entry = entries.first;
-      expect(entry.agendaType, 'peacemaker');
-      expect(entry.observerId, 'human');
-      expect(entry.subjectId, 'ai');
-      expect(entry.scoreDelta, 1);
-      expect(entry.description, contains('peace'));
-    });
-
-    test('human offering peace returns no evidence', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'human', displayName: 'Human', isHuman: true),
-          Player(id: 'ai', displayName: 'AI', isHuman: false),
-        ],
-      );
-
-      final entries = evidenceForOfferPeace(game, 'human', 'ai', 2);
-
-      expect(entries, isEmpty);
-    });
-
-    test('no human observer returns no evidence', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 2),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'ai', displayName: 'AI', isHuman: false),
-          Player(id: 'other', displayName: 'Other', isHuman: false),
-        ],
-      );
-
-      final entries = evidenceForOfferPeace(game, 'ai', 'other', 2);
-
-      expect(entries, isEmpty);
-    });
-  });
-
-  group('evidenceForDeclareWar treaty-break window', () {
-    test(
-      'adds backstabber when war follows callToArmsRefused within 3 turns',
-      () {
-        final game = Game(
-          id: 'g1',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 6),
-            oldWorld: const RegionData(),
-            newWorld: const RegionData(),
-          ),
-          players: const [
-            Player(
-              id: 'human',
-              displayName: 'Human',
-              isHuman: true,
-              militaryLevel: 5,
-            ),
-            Player(
-              id: 'ai',
-              displayName: 'AI',
-              isHuman: false,
-              militaryLevel: 5,
-            ),
-            Player(
-              id: 'target',
-              displayName: 'Target',
-              isHuman: false,
-              militaryLevel: 5,
-            ),
-          ],
-          diplomacyRelations: const [
-            DiplomacyRelation(
-              factionId1: 'ai',
-              factionId2: 'target',
-              level: RelationLevel.friendly,
-              state: RelationState.atPeace,
-            ),
-          ],
-          diplomaticHistoryEvents: [
-            DiplomaticEvent(
-              turn: 5,
-              intraTurnIndex: 0,
-              type: DiplomaticEventType.callToArmsRefused,
-              participants: {'ai', 'target'},
-              fromFactionId: 'ai',
-              toFactionId: 'target',
-            ),
-          ],
-        );
-
-        final entries = evidenceForDeclareWar(game, 'ai', 'target', 6);
-
-        expect(entries.length, 1);
-        expect(entries.single.agendaType, 'backstabber');
-        expect(entries.single.scoreDelta, 3);
-      },
-    );
-  });
-
   group('evidenceForEnvyResearchMirror', () {
     Game baseMirrorGame({required int refTurn, required int currentTurn}) {
-      return Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: TurnState(
-            phase: TurnPhase.orders,
-            turnNumber: currentTurn,
-          ),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
+      return evidenceGame(
+        turnNumber: currentTurn,
         players: const [
           Player(id: 'human', displayName: 'Human', isHuman: true),
           Player(id: 'ai', displayName: 'AI', isHuman: false),
@@ -557,13 +198,8 @@ void main() {
 
   group('evidenceForAiStealTechResolved', () {
     Game baseSpyEvidenceGame() {
-      return Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 4),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
+      return evidenceGame(
+        turnNumber: 4,
         players: const [
           Player(id: 'human', displayName: 'Human', isHuman: true),
           Player(id: 'ai', displayName: 'AI', isHuman: false),
@@ -614,13 +250,8 @@ void main() {
     });
 
     test('no human observer returns no evidence', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 4),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
+      final game = evidenceGame(
+        turnNumber: 4,
         players: const [
           Player(id: 'ai1', displayName: 'AI1', isHuman: false),
           Player(id: 'ai2', displayName: 'AI2', isHuman: false),
@@ -631,149 +262,6 @@ void main() {
         'ai1',
         4,
         success: false,
-      );
-      expect(entries, isEmpty);
-    });
-  });
-
-  group('evidenceForIsolationistCallToArmsRefuse', () {
-    Game ctaRefuseGame({
-      required bool allyIsAi,
-      required bool atPeaceWithDefender,
-    }) {
-      return Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: [
-          const Player(id: 'observer', displayName: 'Human', isHuman: true),
-          Player(
-            id: 'ally',
-            displayName: 'Ally',
-            isHuman: !allyIsAi,
-          ),
-          const Player(id: 'defender', displayName: 'Defender', isHuman: false),
-        ],
-        diplomacyRelations: [
-          DiplomacyRelation(
-            factionId1: 'ally',
-            factionId2: 'defender',
-            score: 50,
-            level: RelationLevel.friendly,
-            state: atPeaceWithDefender
-                ? RelationState.atPeace
-                : RelationState.atWar,
-          ),
-        ],
-      );
-    }
-
-    test(
-      'AI refusing call to arms while at peace with defender adds isolationist +2',
-      () {
-        final game = ctaRefuseGame(
-          allyIsAi: true,
-          atPeaceWithDefender: true,
-        );
-        final entries = evidenceForIsolationistCallToArmsRefuse(
-          game,
-          'ally',
-          'defender',
-          3,
-        );
-        expect(entries.length, 1);
-        expect(entries.single.observerId, 'observer');
-        expect(entries.single.subjectId, 'ally');
-        expect(entries.single.agendaType, 'isolationist');
-        expect(entries.single.scoreDelta, 2);
-        expect(entries.single.turnNumber, 3);
-        expect(entries.single.description, contains('declined call to arms'));
-      },
-    );
-
-    test('empty when ally and defender are at war', () {
-      final game = ctaRefuseGame(
-        allyIsAi: true,
-        atPeaceWithDefender: false,
-      );
-      final entries = evidenceForIsolationistCallToArmsRefuse(
-        game,
-        'ally',
-        'defender',
-        3,
-      );
-      expect(entries, isEmpty);
-    });
-
-    test('human ally returns no evidence', () {
-      final game = ctaRefuseGame(
-        allyIsAi: false,
-        atPeaceWithDefender: true,
-      );
-      final entries = evidenceForIsolationistCallToArmsRefuse(
-        game,
-        'ally',
-        'defender',
-        3,
-      );
-      expect(entries, isEmpty);
-    });
-
-    test('no human observer returns no evidence', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'ai1', displayName: 'AI1', isHuman: false),
-          Player(id: 'ai2', displayName: 'AI2', isHuman: false),
-          Player(id: 'defender', displayName: 'Defender', isHuman: false),
-        ],
-        diplomacyRelations: [
-          DiplomacyRelation(
-            factionId1: 'ai1',
-            factionId2: 'defender',
-            score: 50,
-            level: RelationLevel.friendly,
-            state: RelationState.atPeace,
-          ),
-        ],
-      );
-      final entries = evidenceForIsolationistCallToArmsRefuse(
-        game,
-        'ai1',
-        'defender',
-        3,
-      );
-      expect(entries, isEmpty);
-    });
-
-    test('empty when no relation exists between ally and defender', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 3),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'observer', displayName: 'Human', isHuman: true),
-          Player(id: 'ally', displayName: 'Ally', isHuman: false),
-          Player(id: 'defender', displayName: 'Defender', isHuman: false),
-        ],
-        diplomacyRelations: const [],
-      );
-      final entries = evidenceForIsolationistCallToArmsRefuse(
-        game,
-        'ally',
-        'defender',
-        3,
       );
       expect(entries, isEmpty);
     });

--- a/packages/colonizethis_logic/test/evidence_rules_test_support.dart
+++ b/packages/colonizethis_logic/test/evidence_rules_test_support.dart
@@ -1,0 +1,36 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Shared `Game` fixture for `evidence_rules_test.dart`.
+///
+/// Most evidence rule tests construct a near-identical empty-world game
+/// (orders phase, empty `oldWorld` / `newWorld`) varying only by
+/// `turnNumber`, `players`, and a handful of optional diplomacy/AI fields.
+/// This helper centralizes that boilerplate.
+///
+/// Refs waigore/colonizethis#2216 (consolidate duplicated test setup).
+Game evidenceGame({
+  String id = 'g1',
+  int turnNumber = 2,
+  required List<Player> players,
+  List<DiplomacyRelation> diplomacyRelations = const [],
+  List<DiplomaticEvent> diplomaticHistoryEvents = const [],
+  Map<String, bool> aiControlByGpId = const {},
+  String? lastHumanCompletedResearchCategory,
+  int? lastHumanResearchCategoryCompletionTurn,
+}) {
+  return Game(
+    id: id,
+    worldState: WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: turnNumber),
+      oldWorld: const RegionData(),
+      newWorld: const RegionData(),
+    ),
+    players: players,
+    diplomacyRelations: diplomacyRelations,
+    diplomaticHistoryEvents: diplomaticHistoryEvents,
+    aiControlByGpId: aiControlByGpId,
+    lastHumanCompletedResearchCategory: lastHumanCompletedResearchCategory,
+    lastHumanResearchCategoryCompletionTurn:
+        lastHumanResearchCategoryCompletionTurn,
+  );
+}

--- a/packages/colonizethis_logic/test/evidence_rules_war_peace_test.dart
+++ b/packages/colonizethis_logic/test/evidence_rules_war_peace_test.dart
@@ -1,0 +1,278 @@
+// Tests for declare-war / offer-peace / treaty-break dossier evidence rules.
+// SPEC/ai/hidden-agendas.md, SPEC/program/ai-events-and-dossier.md.
+
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'evidence_rules_test_support.dart';
+
+void main() {
+  group('evidenceForDeclareWar', () {
+    test(
+      'AI declaring war on weaker allied GP adds backstabber and warmonger evidence',
+      () {
+        final game = evidenceGame(
+          players: const [
+            Player(
+              id: 'human',
+              displayName: 'Human',
+              isHuman: true,
+              militaryLevel: 3,
+            ),
+            Player(
+              id: 'ai',
+              displayName: 'AI',
+              isHuman: false,
+              militaryLevel: 5,
+            ),
+            Player(
+              id: 'ally',
+              displayName: 'Ally',
+              isHuman: false,
+              militaryLevel: 2,
+            ),
+          ],
+          diplomacyRelations: const [
+            DiplomacyRelation(
+              factionId1: 'ai',
+              factionId2: 'ally',
+              level: RelationLevel.allied,
+            ),
+          ],
+        );
+
+        final entries = evidenceForDeclareWar(game, 'ai', 'ally', 2);
+
+        expect(entries.length, 2);
+        final backstabberEntries = entries
+            .where((e) => e.agendaType == 'backstabber')
+            .toList();
+        final warmongerEntries = entries
+            .where((e) => e.agendaType == 'warmonger')
+            .toList();
+
+        expect(backstabberEntries.length, 1);
+        expect(backstabberEntries.first.observerId, 'human');
+        expect(backstabberEntries.first.subjectId, 'ai');
+        expect(backstabberEntries.first.scoreDelta, 3);
+        expect(backstabberEntries.first.description, contains('ally'));
+
+        expect(warmongerEntries.length, 1);
+        expect(warmongerEntries.first.observerId, 'human');
+        expect(warmongerEntries.first.subjectId, 'ai');
+        expect(warmongerEntries.first.scoreDelta, 2);
+        expect(warmongerEntries.first.description, contains('weaker'));
+      },
+    );
+
+    test(
+      'AI declaring war on weaker non-allied GP only adds warmonger evidence',
+      () {
+        final game = evidenceGame(
+          players: const [
+            Player(
+              id: 'human',
+              displayName: 'Human',
+              isHuman: true,
+              militaryLevel: 3,
+            ),
+            Player(
+              id: 'ai',
+              displayName: 'AI',
+              isHuman: false,
+              militaryLevel: 5,
+            ),
+            Player(
+              id: 'target',
+              displayName: 'Target',
+              isHuman: false,
+              militaryLevel: 2,
+            ),
+          ],
+        );
+
+        final entries = evidenceForDeclareWar(game, 'ai', 'target', 2);
+
+        expect(entries.length, 1);
+        expect(entries.first.agendaType, 'warmonger');
+        expect(entries.first.observerId, 'human');
+        expect(entries.first.subjectId, 'ai');
+        expect(entries.first.scoreDelta, 2);
+        expect(entries.first.description, contains('weaker'));
+      },
+    );
+
+    test(
+      'AI declaring war on allied non-weaker GP only adds backstabber evidence',
+      () {
+        final game = evidenceGame(
+          players: const [
+            Player(
+              id: 'human',
+              displayName: 'Human',
+              isHuman: true,
+              militaryLevel: 3,
+            ),
+            Player(
+              id: 'ai',
+              displayName: 'AI',
+              isHuman: false,
+              militaryLevel: 2,
+            ),
+            Player(
+              id: 'ally',
+              displayName: 'Ally',
+              isHuman: false,
+              militaryLevel: 5,
+            ),
+          ],
+          diplomacyRelations: const [
+            DiplomacyRelation(
+              factionId1: 'ai',
+              factionId2: 'ally',
+              level: RelationLevel.allied,
+            ),
+          ],
+        );
+
+        final entries = evidenceForDeclareWar(game, 'ai', 'ally', 2);
+
+        expect(entries.length, 1);
+        expect(entries.first.agendaType, 'backstabber');
+        expect(entries.first.observerId, 'human');
+        expect(entries.first.subjectId, 'ai');
+        expect(entries.first.scoreDelta, 3);
+        expect(entries.first.description, contains('ally'));
+      },
+    );
+
+    test('human actor returns no evidence', () {
+      final game = evidenceGame(
+        players: const [
+          Player(id: 'human', displayName: 'Human', isHuman: true),
+          Player(id: 'ai', displayName: 'AI', isHuman: false),
+        ],
+      );
+
+      final entries = evidenceForDeclareWar(game, 'human', 'ai', 2);
+
+      expect(entries, isEmpty);
+    });
+
+    test('no human observer returns no evidence', () {
+      final game = evidenceGame(
+        players: const [
+          Player(id: 'ai', displayName: 'AI', isHuman: false),
+          Player(id: 'other', displayName: 'Other', isHuman: false),
+        ],
+      );
+
+      final entries = evidenceForDeclareWar(game, 'ai', 'other', 2);
+
+      expect(entries, isEmpty);
+    });
+  });
+
+  group('evidenceForOfferPeace', () {
+    test('AI offering peace adds peacemaker evidence for human observer', () {
+      final game = evidenceGame(
+        players: const [
+          Player(id: 'human', displayName: 'Human', isHuman: true),
+          Player(id: 'ai', displayName: 'AI', isHuman: false),
+        ],
+      );
+
+      final entries = evidenceForOfferPeace(game, 'ai', 'human', 2);
+
+      expect(entries.length, 1);
+      final entry = entries.first;
+      expect(entry.agendaType, 'peacemaker');
+      expect(entry.observerId, 'human');
+      expect(entry.subjectId, 'ai');
+      expect(entry.scoreDelta, 1);
+      expect(entry.description, contains('peace'));
+    });
+
+    test('human offering peace returns no evidence', () {
+      final game = evidenceGame(
+        players: const [
+          Player(id: 'human', displayName: 'Human', isHuman: true),
+          Player(id: 'ai', displayName: 'AI', isHuman: false),
+        ],
+      );
+
+      final entries = evidenceForOfferPeace(game, 'human', 'ai', 2);
+
+      expect(entries, isEmpty);
+    });
+
+    test('no human observer returns no evidence', () {
+      final game = evidenceGame(
+        players: const [
+          Player(id: 'ai', displayName: 'AI', isHuman: false),
+          Player(id: 'other', displayName: 'Other', isHuman: false),
+        ],
+      );
+
+      final entries = evidenceForOfferPeace(game, 'ai', 'other', 2);
+
+      expect(entries, isEmpty);
+    });
+  });
+
+  group('evidenceForDeclareWar treaty-break window', () {
+    test(
+      'adds backstabber when war follows callToArmsRefused within 3 turns',
+      () {
+        final game = evidenceGame(
+          turnNumber: 6,
+          players: const [
+            Player(
+              id: 'human',
+              displayName: 'Human',
+              isHuman: true,
+              militaryLevel: 5,
+            ),
+            Player(
+              id: 'ai',
+              displayName: 'AI',
+              isHuman: false,
+              militaryLevel: 5,
+            ),
+            Player(
+              id: 'target',
+              displayName: 'Target',
+              isHuman: false,
+              militaryLevel: 5,
+            ),
+          ],
+          diplomacyRelations: const [
+            DiplomacyRelation(
+              factionId1: 'ai',
+              factionId2: 'target',
+              level: RelationLevel.friendly,
+              state: RelationState.atPeace,
+            ),
+          ],
+          diplomaticHistoryEvents: const [
+            DiplomaticEvent(
+              turn: 5,
+              intraTurnIndex: 0,
+              type: DiplomaticEventType.callToArmsRefused,
+              participants: {'ai', 'target'},
+              fromFactionId: 'ai',
+              toFactionId: 'target',
+            ),
+          ],
+        );
+
+        final entries = evidenceForDeclareWar(game, 'ai', 'target', 6);
+
+        expect(entries.length, 1);
+        expect(entries.single.agendaType, 'backstabber');
+        expect(entries.single.scoreDelta, 3);
+      },
+    );
+  });
+}

--- a/packages/colonizethis_logic/test/military_strength_test.dart
+++ b/packages/colonizethis_logic/test/military_strength_test.dart
@@ -5,21 +5,13 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
+import 'military_strength_test_support.dart';
+
 void main() {
   group('aggregateMilitaryStrengthForPlayer', () {
     test('returns 0 for empty army', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: const RegionData(units: []),
-          newWorld: const RegionData(units: []),
-        ),
-        players: const [
-          Player(id: 'france', displayName: 'France', isHuman: true),
-        ],
-        minorNations: const [],
-        tribes: const [],
+      final game = militaryStrengthGame(
+        players: const [franceGreatPower],
       );
 
       final strength = aggregateMilitaryStrengthForPlayer(game, 'france');
@@ -27,40 +19,16 @@ void main() {
     });
 
     test('calculates strength for Great Power units with medals', () {
-      // Create a game with a Great Power (France) that has units
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            units: [
-              // Grenadiers: FPN=10, FPM=8, era=3, medals=2 -> multiplier=1.2
-              // Strength = (10+8) * 1.2 = 21.6
-              Unit(
-                id: 'u1',
-                type: 'grenadiers',
-                ownerId: 'france',
-                locationProvinceId: 'paris',
-                medals: 2,
-              ),
-              // Musketeers: FPN=7, FPM=2, era=2, medals=0 -> multiplier=1.0
-              // Strength = (7+2) * 1.0 = 9.0
-              Unit(
-                id: 'u2',
-                type: 'musketeers',
-                ownerId: 'france',
-                locationProvinceId: 'paris',
-                medals: 0,
-              ),
-            ],
-          ),
-          newWorld: const RegionData(units: []),
-        ),
-        players: const [
-          Player(id: 'france', displayName: 'France', isHuman: true),
+      // Grenadiers: FPN=10, FPM=8, era=3, medals=2 -> multiplier=1.2
+      // Strength = (10+8) * 1.2 = 21.6
+      // Musketeers: FPN=7, FPM=2, era=2, medals=0 -> multiplier=1.0
+      // Strength = (7+2) * 1.0 = 9.0
+      final game = militaryStrengthGame(
+        oldWorldUnits: [
+          testUnit(id: 'u1', type: 'grenadiers', medals: 2),
+          testUnit(id: 'u2', type: 'musketeers'),
         ],
-        minorNations: const [],
-        tribes: const [],
+        players: const [franceGreatPower],
       );
 
       final strength = aggregateMilitaryStrengthForPlayer(game, 'france');
@@ -69,26 +37,16 @@ void main() {
     });
 
     test('uses effective military level for Minor Nation', () {
-      // Minor Nations use their effectiveMilitaryLevel, not era 4
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            units: [
-              // Peasant levies: era=1, effectiveEra=1 (minor level) -> no downgrade
-              Unit(
-                id: 'u1',
-                type: 'peasant_levies',
-                ownerId: 'minor1',
-                locationProvinceId: 'p1',
-                medals: 0,
-              ),
-            ],
+      // Peasant levies: era=1, effectiveEra=1 (minor level) -> no downgrade
+      final game = militaryStrengthGame(
+        oldWorldUnits: [
+          testUnit(
+            id: 'u1',
+            type: 'peasant_levies',
+            ownerId: 'minor1',
+            locationProvinceId: 'p1',
           ),
-          newWorld: const RegionData(units: []),
-        ),
-        players: const [],
+        ],
         minorNations: const [
           MinorNation(
             id: 'minor1',
@@ -96,7 +54,6 @@ void main() {
             effectiveMilitaryLevel: 1,
           ),
         ],
-        tribes: const [],
       );
 
       final strength = aggregateMilitaryStrengthForPlayer(game, 'minor1');
@@ -106,26 +63,16 @@ void main() {
     });
 
     test('uses effective military level for Tribe', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            units: [
-              // Cossacks: era=2, effectiveEra=1 (tribe level) -> should downgrade
-              Unit(
-                id: 'u1',
-                type: 'cossacks',
-                ownerId: 'tribe1',
-                locationProvinceId: 'p1',
-                medals: 0,
-              ),
-            ],
+      // Cossacks: era=2, effectiveEra=1 (tribe level) -> should downgrade
+      final game = militaryStrengthGame(
+        oldWorldUnits: [
+          testUnit(
+            id: 'u1',
+            type: 'cossacks',
+            ownerId: 'tribe1',
+            locationProvinceId: 'p1',
           ),
-          newWorld: const RegionData(units: []),
-        ),
-        players: const [],
-        minorNations: const [],
+        ],
         tribes: const [
           Tribe(
             id: 'tribe1',
@@ -142,69 +89,27 @@ void main() {
     });
 
     test('Great Power uses era 4 (does not downgrade era 3 units)', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            units: [
-              // Grenadiers: era=3, GP uses era 4 so no downgrade
-              Unit(
-                id: 'u1',
-                type: 'grenadiers',
-                ownerId: 'france',
-                locationProvinceId: 'paris',
-                medals: 0,
-              ),
-            ],
-          ),
-          newWorld: const RegionData(units: []),
-        ),
-        players: const [
-          Player(id: 'france', displayName: 'France', isHuman: true),
+      // Grenadiers: era=3, GP uses era 4 so no downgrade
+      final game = militaryStrengthGame(
+        oldWorldUnits: [
+          testUnit(id: 'u1', type: 'grenadiers'),
         ],
-        minorNations: const [],
-        tribes: const [],
+        players: const [franceGreatPower],
       );
 
       final strength = aggregateMilitaryStrengthForPlayer(game, 'france');
-      // Grenadiers: FPN=10, FPM=8, era=3, era 4 effective -> no downgrade needed
-      // (since unit era < effective era)
+      // Grenadiers: FPN=10, FPM=8, era=3, era 4 effective -> no downgrade
       // Strength = (10+8) * 1.0 = 18.0
       expect(strength, equals(18.0));
     });
 
     test('skips units with unknown regiment types', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            units: [
-              // Unknown type should be skipped
-              Unit(
-                id: 'u1',
-                type: 'unknown_unit_type',
-                ownerId: 'france',
-                locationProvinceId: 'paris',
-                medals: 0,
-              ),
-              Unit(
-                id: 'u2',
-                type: 'musketeers',
-                ownerId: 'france',
-                locationProvinceId: 'paris',
-                medals: 0,
-              ),
-            ],
-          ),
-          newWorld: const RegionData(units: []),
-        ),
-        players: const [
-          Player(id: 'france', displayName: 'France', isHuman: true),
+      final game = militaryStrengthGame(
+        oldWorldUnits: [
+          testUnit(id: 'u1', type: 'unknown_unit_type'),
+          testUnit(id: 'u2', type: 'musketeers'),
         ],
-        minorNations: const [],
-        tribes: const [],
+        players: const [franceGreatPower],
       );
 
       final strength = aggregateMilitaryStrengthForPlayer(game, 'france');
@@ -213,38 +118,18 @@ void main() {
     });
 
     test('aggregates units from both Old World and New World', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            units: [
-              Unit(
-                id: 'u1',
-                type: 'musketeers',
-                ownerId: 'france',
-                locationProvinceId: 'paris',
-                medals: 0,
-              ),
-            ],
-          ),
-          newWorld: RegionData(
-            units: [
-              Unit(
-                id: 'u2',
-                type: 'musketeers',
-                ownerId: 'france',
-                locationProvinceId: 'new_york',
-                medals: 0,
-              ),
-            ],
-          ),
-        ),
-        players: const [
-          Player(id: 'france', displayName: 'France', isHuman: true),
+      final game = militaryStrengthGame(
+        oldWorldUnits: [
+          testUnit(id: 'u1', type: 'musketeers'),
         ],
-        minorNations: const [],
-        tribes: const [],
+        newWorldUnits: [
+          testUnit(
+            id: 'u2',
+            type: 'musketeers',
+            locationProvinceId: 'new_york',
+          ),
+        ],
+        players: const [franceGreatPower],
       );
 
       // 9.0 (OW: 7+2) + 9.0 (NW: 7+2) = 18.0
@@ -253,36 +138,20 @@ void main() {
     });
 
     test('only includes units owned by the specified player', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            units: [
-              Unit(
-                id: 'u1',
-                type: 'musketeers',
-                ownerId: 'france',
-                locationProvinceId: 'paris',
-                medals: 0,
-              ),
-              Unit(
-                id: 'u2',
-                type: 'musketeers',
-                ownerId: 'prussia',
-                locationProvinceId: 'berlin',
-                medals: 0,
-              ),
-            ],
+      final game = militaryStrengthGame(
+        oldWorldUnits: [
+          testUnit(id: 'u1', type: 'musketeers'),
+          testUnit(
+            id: 'u2',
+            type: 'musketeers',
+            ownerId: 'prussia',
+            locationProvinceId: 'berlin',
           ),
-          newWorld: const RegionData(units: []),
-        ),
+        ],
         players: const [
-          Player(id: 'france', displayName: 'France', isHuman: true),
+          franceGreatPower,
           Player(id: 'prussia', displayName: 'Prussia', isHuman: false),
         ],
-        minorNations: const [],
-        tribes: const [],
       );
 
       // France's strength should only include their own units
@@ -296,69 +165,47 @@ void main() {
     });
 
     test('applies medal multiplier correctly (0-4 medals)', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            units: [
-              // 0 medals: multiplier 1.0
-              Unit(
-                id: 'u0',
-                type: 'musketeers',
-                ownerId: 'france',
-                locationProvinceId: 'p0',
-                medals: 0,
-              ),
-              // 1 medal: multiplier 1.1
-              Unit(
-                id: 'u1',
-                type: 'musketeers',
-                ownerId: 'france',
-                locationProvinceId: 'p1',
-                medals: 1,
-              ),
-              // 2 medals: multiplier 1.2
-              Unit(
-                id: 'u2',
-                type: 'musketeers',
-                ownerId: 'france',
-                locationProvinceId: 'p2',
-                medals: 2,
-              ),
-              // 3 medals: multiplier 1.3
-              Unit(
-                id: 'u3',
-                type: 'musketeers',
-                ownerId: 'france',
-                locationProvinceId: 'p3',
-                medals: 3,
-              ),
-              // 4 medals: multiplier 1.4
-              Unit(
-                id: 'u4',
-                type: 'musketeers',
-                ownerId: 'france',
-                locationProvinceId: 'p4',
-                medals: 4,
-              ),
-              // 5+ medals: clamped to 4, multiplier 1.4
-              Unit(
-                id: 'u5',
-                type: 'musketeers',
-                ownerId: 'france',
-                locationProvinceId: 'p5',
-                medals: 10,
-              ),
-            ],
+      final game = militaryStrengthGame(
+        oldWorldUnits: [
+          // 0 medals: multiplier 1.0
+          testUnit(id: 'u0', type: 'musketeers', locationProvinceId: 'p0'),
+          // 1 medal: multiplier 1.1
+          testUnit(
+            id: 'u1',
+            type: 'musketeers',
+            locationProvinceId: 'p1',
+            medals: 1,
           ),
-          newWorld: const RegionData(units: []),
-        ),
-        players: const [
-          Player(id: 'france', displayName: 'France', isHuman: true),
+          // 2 medals: multiplier 1.2
+          testUnit(
+            id: 'u2',
+            type: 'musketeers',
+            locationProvinceId: 'p2',
+            medals: 2,
+          ),
+          // 3 medals: multiplier 1.3
+          testUnit(
+            id: 'u3',
+            type: 'musketeers',
+            locationProvinceId: 'p3',
+            medals: 3,
+          ),
+          // 4 medals: multiplier 1.4
+          testUnit(
+            id: 'u4',
+            type: 'musketeers',
+            locationProvinceId: 'p4',
+            medals: 4,
+          ),
+          // 5+ medals: clamped to 4, multiplier 1.4
+          testUnit(
+            id: 'u5',
+            type: 'musketeers',
+            locationProvinceId: 'p5',
+            medals: 10,
+          ),
         ],
-        minorNations: const [],
-        tribes: const [],
+        players: const [franceGreatPower],
       );
 
       final strength = aggregateMilitaryStrengthForPlayer(game, 'france');
@@ -374,28 +221,11 @@ void main() {
     });
 
     test('is deterministic - same inputs produce same output', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            units: [
-              Unit(
-                id: 'u1',
-                type: 'grenadiers',
-                ownerId: 'france',
-                locationProvinceId: 'paris',
-                medals: 3,
-              ),
-            ],
-          ),
-          newWorld: const RegionData(units: []),
-        ),
-        players: const [
-          Player(id: 'france', displayName: 'France', isHuman: true),
+      final game = militaryStrengthGame(
+        oldWorldUnits: [
+          testUnit(id: 'u1', type: 'grenadiers', medals: 3),
         ],
-        minorNations: const [],
-        tribes: const [],
+        players: const [franceGreatPower],
       );
 
       final strength1 = aggregateMilitaryStrengthForPlayer(game, 'france');
@@ -407,18 +237,8 @@ void main() {
     });
 
     test('returns non-negative value', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: const RegionData(units: []),
-          newWorld: const RegionData(units: []),
-        ),
-        players: const [
-          Player(id: 'france', displayName: 'France', isHuman: true),
-        ],
-        minorNations: const [],
-        tribes: const [],
+      final game = militaryStrengthGame(
+        players: const [franceGreatPower],
       );
 
       final strength = aggregateMilitaryStrengthForPlayer(game, 'france');
@@ -429,20 +249,8 @@ void main() {
   group('aggregateStrength', () {
     test('aggregates strength for a list of units', () {
       final units = [
-        Unit(
-          id: 'u1',
-          type: 'musketeers',
-          ownerId: 'france',
-          locationProvinceId: 'p1',
-          medals: 0,
-        ),
-        Unit(
-          id: 'u2',
-          type: 'grenadiers',
-          ownerId: 'france',
-          locationProvinceId: 'p2',
-          medals: 0,
-        ),
+        testUnit(id: 'u1', type: 'musketeers', locationProvinceId: 'p1'),
+        testUnit(id: 'u2', type: 'grenadiers', locationProvinceId: 'p2'),
       ];
 
       // Musketeers: (7+2) * 1.0 = 9.0
@@ -455,13 +263,7 @@ void main() {
     test('downgrades units when era exceeds effective era', () {
       final units = [
         // Grenadiers era=3, effectiveEra=1 -> should downgrade to era 1 equivalent
-        Unit(
-          id: 'u1',
-          type: 'grenadiers',
-          ownerId: 'france',
-          locationProvinceId: 'p1',
-          medals: 0,
-        ),
+        testUnit(id: 'u1', type: 'grenadiers', locationProvinceId: 'p1'),
       ];
 
       // With effectiveEra=1, grenadiers (era 3) should downgrade to era 1 in same category
@@ -474,32 +276,15 @@ void main() {
 
   group('effectiveEraForFaction', () {
     test('returns 4 for Great Power', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'france', displayName: 'France', isHuman: true),
-        ],
-        minorNations: const [],
-        tribes: const [],
+      final game = militaryStrengthGame(
+        players: const [franceGreatPower],
       );
 
       expect(effectiveEraForFaction(game, 'france'), equals(4));
     });
 
     test('returns effectiveMilitaryLevel for Minor Nation', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [],
+      final game = militaryStrengthGame(
         minorNations: const [
           MinorNation(
             id: 'minor1',
@@ -507,22 +292,13 @@ void main() {
             effectiveMilitaryLevel: 2,
           ),
         ],
-        tribes: const [],
       );
 
       expect(effectiveEraForFaction(game, 'minor1'), equals(2));
     });
 
     test('returns effectiveMilitaryLevel for Tribe (capped at 1 in-game)', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [],
-        minorNations: const [],
+      final game = militaryStrengthGame(
         tribes: const [
           Tribe(
             id: 'tribe1',
@@ -536,17 +312,7 @@ void main() {
     });
 
     test('returns 4 for unknown faction', () {
-      final game = Game(
-        id: 'g1',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: const RegionData(),
-          newWorld: const RegionData(),
-        ),
-        players: const [],
-        minorNations: const [],
-        tribes: const [],
-      );
+      final game = militaryStrengthGame();
 
       expect(effectiveEraForFaction(game, 'unknown'), equals(4));
     });

--- a/packages/colonizethis_logic/test/military_strength_test_support.dart
+++ b/packages/colonizethis_logic/test/military_strength_test_support.dart
@@ -1,0 +1,54 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Shared `Game` fixture and unit shorthand for `military_strength_test.dart`.
+///
+/// Almost every test in that file constructs a `Game` with a fixed orders-phase
+/// `WorldState`, then varies units in the Old/New World and the faction
+/// composition (Great Powers vs Minor Nations vs Tribes). This helper
+/// centralizes that boilerplate so tests focus on the units and assertions.
+///
+/// Refs waigore/colonizethis#2216 (consolidate duplicated test setup).
+Game militaryStrengthGame({
+  String id = 'g1',
+  int turnNumber = 1,
+  List<Unit> oldWorldUnits = const [],
+  List<Unit> newWorldUnits = const [],
+  List<Player> players = const [],
+  List<MinorNation> minorNations = const [],
+  List<Tribe> tribes = const [],
+}) {
+  return Game(
+    id: id,
+    worldState: WorldState(
+      turnState: TurnState(phase: TurnPhase.orders, turnNumber: turnNumber),
+      oldWorld: RegionData(units: oldWorldUnits),
+      newWorld: RegionData(units: newWorldUnits),
+    ),
+    players: players,
+    minorNations: minorNations,
+    tribes: tribes,
+  );
+}
+
+/// Shorthand for the standard test player France (Great Power, human).
+const franceGreatPower = Player(
+  id: 'france',
+  displayName: 'France',
+  isHuman: true,
+);
+
+/// Shorthand `Unit` constructor for military-strength tests. Defaults match the
+/// shape used throughout `military_strength_test.dart` (medals 0).
+Unit testUnit({
+  required String id,
+  required String type,
+  String ownerId = 'france',
+  String locationProvinceId = 'paris',
+  int medals = 0,
+}) => Unit(
+  id: id,
+  type: type,
+  ownerId: ownerId,
+  locationProvinceId: locationProvinceId,
+  medals: medals,
+);


### PR DESCRIPTION
## Summary
Continues #2216 (Phase 2 + light Phase 3) by extracting subsystem-focused `*_test_support.dart` helpers and splitting the largest evidence/dialogue test files by behavioural area, dropping each affected file under the 400-line CI gate established in #2217.

## Implemented in this PR
- New support files:
  - `packages/colonizethis_logic/test/evidence_rules_test_support.dart` — `evidenceGame()` factory for the empty-world + players + optional diplomacy/AI/research-mirror pattern shared across evidence rule tests.
  - `packages/colonizethis_logic/test/event_dialogue_test_support.dart` — `dialogueGame()` factory for empty/minimal-province orders-phase games used by event-dialogue tests (supports diplomacy, minor nations, tribes, overture states).
  - `packages/colonizethis_logic/test/military_strength_test_support.dart` — `militaryStrengthGame()`, `franceGreatPower`, and `testUnit` shorthand for the unit/medal-heavy military-strength suite.
- Refactored + split tests (all under 400 lines, behaviour preserved):
  - `evidence_rules_test.dart` 781 -> 269 lines, with new sibling files `evidence_rules_war_peace_test.dart` (278) and `evidence_rules_isolationist_test.dart` (133).
  - `event_dialogue_test.dart` 591 -> 225 lines, with new sibling `event_dialogue_reactive_test.dart` (282).
  - `military_strength_test.dart` 554 -> 320 lines (no split needed after fixture adoption).

## Deferred work
- Further fixture adoption / support-file extraction across remaining oversized logic test files (e.g. `simple_ai_heuristics_test.dart`, `combat_resolver_test_part1_test.dart`, `quick_battle_resolver_test.dart`, `order_engine_*` family).
- Splitting the larger ordering/combat/connectivity tests by subsystem (Phase 3).
- Threshold ratchet from 400 -> 300 -> 200 once the legacy backlog shrinks (Phase 4).

## AC coverage now (relative to issue #2216 ACs)
- Covered now (additive across PRs):
  - **3 new** `*_test_support.dart` files added (issue requires at least 3 additional). With the two pre-existing support files, the repo now has 5.
  - **3 of 55** previously oversized logic test files are now under 400 lines (issue target: at least 10).
  - All existing logic tests still pass (`dart test` in `packages/colonizethis_logic`).
- Covered by prior PR #2217 (already merged):
  - `tool/check_logic_test_file_size.dart` exists and runs.
  - CI step in `quality.yml` runs the checker.
  - Test at `test/check_logic_test_file_size_test.dart` covers pass/fail.
- Deferred:
  - Reaching 10 of 55 oversized files reduced (currently 3) — additional slices needed.
  - Optional ratchet of the 400-line threshold.

## Test plan
- [x] `dart test test/evidence_rules_test.dart test/evidence_rules_war_peace_test.dart test/evidence_rules_isolationist_test.dart` (28 tests, all pass)
- [x] `dart test test/event_dialogue_test.dart test/event_dialogue_reactive_test.dart` (19 tests, all pass)
- [x] `dart test test/military_strength_test.dart` (17 tests, all pass)
- [x] `dart test` for `packages/colonizethis_logic` (1356 tests, all pass)
- [x] `dart run tool/check_logic_test_file_size.dart` against all 9 changed/new files (no violations)
- [x] `dart analyze` shows no new issues introduced by the changed files

Refs #2216

Made with [Cursor](https://cursor.com)