### PR TITLE
Add turn trace schema contracts and validation tests (slice for #2218)

### DIFF
--- a/SPEC/program/turn-resolution-json-trace-schema-reference.md
+++ b/SPEC/program/turn-resolution-json-trace-schema-reference.md
@@ -1,0 +1,53 @@
+# Turn Trace Schema Reference (V1)
+
+Field reference for the versioned schemas introduced for issue #2218.
+
+---
+
+## `turn-trace-ai-v1.schema.json`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `schemaVersion` | string | yes | Must equal `1.0.0`. |
+| `factionId` | string | yes | AI-controlled faction identifier. |
+| `state` | object | yes | Decision context block. |
+| `state.winningCandidate` | object | yes | Candidate selected by AI. |
+| `state.topAlternates` | array<object> | yes | Ranked non-winning candidates. |
+| `state.aggregates` | object | yes | Aggregated scoring/input signals. |
+| `thresholds` | object | yes | Threshold and gate data. |
+| `thresholds.constants` | object | yes | Rule constants used by planner. |
+| `thresholds.derived` | object | yes | Derived threshold values. |
+| `thresholds.effective` | object | yes | Runtime effective thresholds. |
+| `thresholds.gatingChecks` | array<object> | yes | Gate checks used for filtering/approval. |
+| `outcome` | object | yes | Emitted planner outcomes. |
+| `outcome.finalOrders` | array<object> | yes | Final orders emitted for the faction. |
+| `outcome.domainOutputs` | object | yes | Domain planner diagnostics. |
+
+## `turn-trace-resolution-v1.schema.json`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `schemaVersion` | string | yes | Must equal `1.0.0`. |
+| `turnNumber` | integer | yes | `>= 1`. |
+| `phases` | array<object> | yes | Ordered phase traces. |
+| `phases[].phase` | string | yes | Stable phase token. |
+| `phases[].beforeState` | object | yes | State projection before phase execution. |
+| `phases[].afterState` | object | yes | State projection after phase execution. |
+| `phases[].orderEvents` | array<object> | yes | Order-application events in apply order. |
+| `phases[].orderEvents[].sequence` | integer | yes | `>= 0`, monotonic within a phase. |
+| `phases[].orderEvents[].phase` | string | yes | Phase token for the event. |
+| `phases[].orderEvents[].eventType` | string | yes | Event discriminator token. |
+| `phases[].orderEvents[].orderType` | string | no | Optional order subtype token. |
+| `phases[].orderEvents[].actorFactionId` | string | no | Optional acting faction ID. |
+
+## `turn-trace-merged-v1.schema.json`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `schemaVersion` | string | yes | Must equal `1.0.0`. |
+| `meta` | object | yes | Turn/document identity metadata. |
+| `meta.gameId` | string | yes | Stable game/session identifier. |
+| `meta.turnNumber` | integer | yes | `>= 1`. |
+| `meta.capturedAtUtc` | string (`date-time`) | yes | RFC3339 UTC timestamp. |
+| `ai` | array<object> | yes | AI section list; each item follows AI v1 schema. |
+| `turnResolution` | object | yes | Turn-resolution section; follows resolution v1 schema. |

--- a/SPEC/program/turn-resolution-json-trace.md
+++ b/SPEC/program/turn-resolution-json-trace.md
@@ -1,0 +1,109 @@
+# Turn Resolution JSON Trace
+
+**SPEC/program** - Debug-only structured trace contracts for turn resolution and AI planner diagnostics. This document defines schema contracts only. Runtime wiring and export lifecycle are specified in follow-up slices.
+
+---
+
+## Scope
+
+This spec authorizes the versioned JSON contracts used by issue #2218:
+
+- `turn-trace-ai-v1.schema.json`
+- `turn-trace-resolution-v1.schema.json`
+- `turn-trace-merged-v1.schema.json`
+
+These schemas define diagnostic payload shape for:
+
+1. Per-AI decision traces.
+2. Per-phase turn-resolution execution traces.
+3. One merged logical-turn document.
+
+---
+
+## Versioning
+
+- `schemaVersion` is required on every top-level schema document.
+- Initial schema version is `1.0.0`.
+- Version bumps:
+  - Backward-compatible additive fields -> minor bump.
+  - Breaking field removals or type changes -> major bump.
+- Merged trace documents must use a version string that matches the merged schema.
+
+---
+
+## Contracts
+
+### AI trace (`turn-trace-ai-v1.schema.json`)
+
+Required top-level fields:
+
+- `schemaVersion`: string.
+- `factionId`: string.
+- `state`: object.
+- `thresholds`: object.
+- `outcome`: object.
+
+State section requires:
+
+- `winningCandidate`: object.
+- `topAlternates`: array.
+- `aggregates`: object.
+
+Thresholds section requires:
+
+- `constants`: object.
+- `derived`: object.
+- `effective`: object.
+- `gatingChecks`: array.
+
+Outcome section requires:
+
+- `finalOrders`: array.
+- `domainOutputs`: object.
+
+### Turn-resolution trace (`turn-trace-resolution-v1.schema.json`)
+
+Required top-level fields:
+
+- `schemaVersion`: string.
+- `turnNumber`: integer (`>= 1`).
+- `phases`: array.
+
+Each phase entry requires:
+
+- `phase`: string.
+- `beforeState`: object.
+- `afterState`: object.
+- `orderEvents`: array.
+
+Each order event requires:
+
+- `sequence`: integer (`>= 0`).
+- `phase`: string.
+- `eventType`: string.
+
+### Merged trace (`turn-trace-merged-v1.schema.json`)
+
+Required top-level fields:
+
+- `schemaVersion`: string.
+- `meta`: object.
+- `ai`: array.
+- `turnResolution`: object.
+
+Meta section requires:
+
+- `gameId`: string.
+- `turnNumber`: integer (`>= 1`).
+- `capturedAtUtc`: RFC3339 timestamp string.
+
+`ai` entries must validate against AI trace schema, and `turnResolution` must validate against turn-resolution schema.
+
+---
+
+## Acceptance Criteria
+
+- Given a JSON payload intended as an AI trace, when validated against `turn-trace-ai-v1.schema.json`, then validation passes only if `state`, `thresholds`, and `outcome` sections all satisfy required fields and types.
+- Given a JSON payload intended as a turn-resolution trace, when validated against `turn-trace-resolution-v1.schema.json`, then validation passes only if each phase contains `beforeState`, `afterState`, and ordered `orderEvents` entries with non-negative `sequence`.
+- Given a JSON payload intended as a merged logical-turn trace, when validated against `turn-trace-merged-v1.schema.json`, then validation passes only if `meta`, `ai`, and `turnResolution` are present and nested sections satisfy referenced contracts.
+- Given a payload with missing required fields for any of the three trace schemas, when validated, then validation fails deterministically with at least one schema violation.

--- a/packages/colonizethis_logic/lib/colonizethis_logic.dart
+++ b/packages/colonizethis_logic/lib/colonizethis_logic.dart
@@ -35,6 +35,7 @@ export 'src/setup/setup_exceptions.dart';
 // Turn
 export 'src/turn/economy_debt_rules.dart';
 export 'src/turn/research_resolver.dart';
+export 'src/turn/trace/turn_trace_contracts.dart';
 export 'src/turn/turn_resolution_result.dart';
 export 'src/turn/turn_resolver.dart';
 export 'src/turn/turn_news_digest.dart';

--- a/packages/colonizethis_logic/lib/src/turn/trace/turn-trace-ai-v1.schema.json
+++ b/packages/colonizethis_logic/lib/src/turn/trace/turn-trace-ai-v1.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://colonizethis.dev/schemas/turn-trace-ai-v1.schema.json",
+  "title": "ColonizeThis AI Decision Trace V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "factionId",
+    "state",
+    "thresholds",
+    "outcome"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "factionId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "state": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "winningCandidate",
+        "topAlternates",
+        "aggregates"
+      ],
+      "properties": {
+        "winningCandidate": {
+          "type": "object"
+        },
+        "topAlternates": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "aggregates": {
+          "type": "object"
+        }
+      }
+    },
+    "thresholds": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "constants",
+        "derived",
+        "effective",
+        "gatingChecks"
+      ],
+      "properties": {
+        "constants": {
+          "type": "object"
+        },
+        "derived": {
+          "type": "object"
+        },
+        "effective": {
+          "type": "object"
+        },
+        "gatingChecks": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "outcome": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "finalOrders",
+        "domainOutputs"
+      ],
+      "properties": {
+        "finalOrders": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "domainOutputs": {
+          "type": "object"
+        }
+      }
+    }
+  }
+}

--- a/packages/colonizethis_logic/lib/src/turn/trace/turn-trace-merged-v1.schema.json
+++ b/packages/colonizethis_logic/lib/src/turn/trace/turn-trace-merged-v1.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://colonizethis.dev/schemas/turn-trace-merged-v1.schema.json",
+  "title": "ColonizeThis Merged Turn Trace V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "meta",
+    "ai",
+    "turnResolution"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "meta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "gameId",
+        "turnNumber",
+        "capturedAtUtc"
+      ],
+      "properties": {
+        "gameId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "turnNumber": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "capturedAtUtc": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "ai": {
+      "type": "array",
+      "items": {
+        "$ref": "turn-trace-ai-v1.schema.json"
+      }
+    },
+    "turnResolution": {
+      "$ref": "turn-trace-resolution-v1.schema.json"
+    }
+  }
+}

--- a/packages/colonizethis_logic/lib/src/turn/trace/turn-trace-resolution-v1.schema.json
+++ b/packages/colonizethis_logic/lib/src/turn/trace/turn-trace-resolution-v1.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://colonizethis.dev/schemas/turn-trace-resolution-v1.schema.json",
+  "title": "ColonizeThis Turn Resolution Trace V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "turnNumber",
+    "phases"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "turnNumber": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "phases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "phase",
+          "beforeState",
+          "afterState",
+          "orderEvents"
+        ],
+        "properties": {
+          "phase": {
+            "type": "string",
+            "minLength": 1
+          },
+          "beforeState": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "afterState": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "orderEvents": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "sequence",
+                "phase",
+                "eventType"
+              ],
+              "properties": {
+                "sequence": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "phase": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "eventType": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "orderType": {
+                  "type": "string"
+                },
+                "actorFactionId": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/colonizethis_logic/lib/src/turn/trace/turn_trace_contracts.dart
+++ b/packages/colonizethis_logic/lib/src/turn/trace/turn_trace_contracts.dart
@@ -1,0 +1,143 @@
+library;
+
+const String kTurnTraceSchemaVersionV1 = '1.0.0';
+
+class TurnTraceMergedDocument {
+  const TurnTraceMergedDocument({
+    required this.schemaVersion,
+    required this.meta,
+    required this.ai,
+    required this.turnResolution,
+  });
+
+  final String schemaVersion;
+  final TurnTraceMeta meta;
+  final List<TurnTraceAiSection> ai;
+  final TurnTraceResolutionSection turnResolution;
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'schemaVersion': schemaVersion,
+      'meta': meta.toJson(),
+      'ai': ai.map((section) => section.toJson()).toList(growable: false),
+      'turnResolution': turnResolution.toJson(),
+    };
+  }
+}
+
+class TurnTraceMeta {
+  const TurnTraceMeta({
+    required this.gameId,
+    required this.turnNumber,
+    required this.capturedAtUtc,
+  });
+
+  final String gameId;
+  final int turnNumber;
+  final String capturedAtUtc;
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'gameId': gameId,
+      'turnNumber': turnNumber,
+      'capturedAtUtc': capturedAtUtc,
+    };
+  }
+}
+
+class TurnTraceAiSection {
+  const TurnTraceAiSection({
+    required this.schemaVersion,
+    required this.factionId,
+    required this.state,
+    required this.thresholds,
+    required this.outcome,
+  });
+
+  final String schemaVersion;
+  final String factionId;
+  final Map<String, Object?> state;
+  final Map<String, Object?> thresholds;
+  final Map<String, Object?> outcome;
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'schemaVersion': schemaVersion,
+      'factionId': factionId,
+      'state': state,
+      'thresholds': thresholds,
+      'outcome': outcome,
+    };
+  }
+}
+
+class TurnTraceResolutionSection {
+  const TurnTraceResolutionSection({
+    required this.schemaVersion,
+    required this.turnNumber,
+    required this.phases,
+  });
+
+  final String schemaVersion;
+  final int turnNumber;
+  final List<TurnTracePhaseTrace> phases;
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'schemaVersion': schemaVersion,
+      'turnNumber': turnNumber,
+      'phases': phases.map((phase) => phase.toJson()).toList(growable: false),
+    };
+  }
+}
+
+class TurnTracePhaseTrace {
+  const TurnTracePhaseTrace({
+    required this.phase,
+    required this.beforeState,
+    required this.afterState,
+    required this.orderEvents,
+  });
+
+  final String phase;
+  final Map<String, Object?> beforeState;
+  final Map<String, Object?> afterState;
+  final List<TurnTraceOrderEvent> orderEvents;
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'phase': phase,
+      'beforeState': beforeState,
+      'afterState': afterState,
+      'orderEvents': orderEvents
+          .map((event) => event.toJson())
+          .toList(growable: false),
+    };
+  }
+}
+
+class TurnTraceOrderEvent {
+  const TurnTraceOrderEvent({
+    required this.sequence,
+    required this.phase,
+    required this.eventType,
+    this.orderType,
+    this.actorFactionId,
+  });
+
+  final int sequence;
+  final String phase;
+  final String eventType;
+  final String? orderType;
+  final String? actorFactionId;
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'sequence': sequence,
+      'phase': phase,
+      'eventType': eventType,
+      if (orderType != null) 'orderType': orderType,
+      if (actorFactionId != null) 'actorFactionId': actorFactionId,
+    };
+  }
+}

--- a/packages/colonizethis_logic/pubspec.yaml
+++ b/packages/colonizethis_logic/pubspec.yaml
@@ -22,4 +22,5 @@ dev_dependencies:
   colonizethis_test:
   coverage: ^1.15.0
   custom_lint: ^0.8.1
+  json_schema: ^5.2.2
   test: ^1.24.0

--- a/packages/colonizethis_logic/test/turn_trace_schema_validation_test.dart
+++ b/packages/colonizethis_logic/test/turn_trace_schema_validation_test.dart
@@ -1,0 +1,179 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:colonizethis_logic/src/turn/trace/turn_trace_contracts.dart';
+import 'package:json_schema/json_schema.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final schemaDir = Directory('lib/src/turn/trace');
+
+  Future<Map<String, dynamic>> loadSchema(String fileName) async {
+    final file = File('${schemaDir.path}/$fileName');
+    final content = await file.readAsString();
+    return jsonDecode(content) as Map<String, dynamic>;
+  }
+
+  Future<JsonSchema> createSchema(String fileName) async {
+    final schemaMap = await loadSchema(fileName);
+    final fetchedFromUri = Uri.parse(
+      'https://colonizethis.dev/schemas/$fileName',
+    );
+    return JsonSchema.createAsync(
+      schemaMap,
+      fetchedFromUri: fetchedFromUri,
+      refProvider: RefProvider.async((String ref) async {
+        final uri = Uri.parse(ref);
+        final refName = uri.pathSegments.isEmpty ? '' : uri.pathSegments.last;
+        if (refName.isEmpty) {
+          return null;
+        }
+        return loadSchema(refName);
+      }),
+    );
+  }
+
+  test(
+    'ai schema validates expected payload and rejects missing required keys',
+    () async {
+      final schema = await createSchema('turn-trace-ai-v1.schema.json');
+      final valid = <String, Object?>{
+        'schemaVersion': kTurnTraceSchemaVersionV1,
+        'factionId': 'gp-england',
+        'state': <String, Object?>{
+          'winningCandidate': <String, Object?>{'id': 'candidate-1'},
+          'topAlternates': <Object?>[
+            <String, Object?>{'id': 'candidate-2'},
+          ],
+          'aggregates': <String, Object?>{'threat': 22},
+        },
+        'thresholds': <String, Object?>{
+          'constants': <String, Object?>{'warRisk': 10},
+          'derived': <String, Object?>{'warRiskEffective': 12},
+          'effective': <String, Object?>{'warRiskGate': 14},
+          'gatingChecks': <Object?>[
+            <String, Object?>{'name': 'can_attack', 'passed': true},
+          ],
+        },
+        'outcome': <String, Object?>{
+          'finalOrders': <Object?>[
+            <String, Object?>{'type': 'move', 'province': 'eu|001'},
+          ],
+          'domainOutputs': <String, Object?>{
+            'diplomacy': <String, Object?>{'action': 'none'},
+          },
+        },
+      };
+      final invalid = Map<String, Object?>.from(valid)..remove('thresholds');
+
+      expect(schema.validate(valid).isValid, isTrue);
+      expect(schema.validate(invalid).isValid, isFalse);
+    },
+  );
+
+  test(
+    'resolution schema validates ordered phase payload and rejects malformed events',
+    () async {
+      final schema = await createSchema('turn-trace-resolution-v1.schema.json');
+      final valid = <String, Object?>{
+        'schemaVersion': kTurnTraceSchemaVersionV1,
+        'turnNumber': 7,
+        'phases': <Object?>[
+          <String, Object?>{
+            'phase': 'movement',
+            'beforeState': <String, Object?>{'units': 12},
+            'afterState': <String, Object?>{'units': 10},
+            'orderEvents': <Object?>[
+              <String, Object?>{
+                'sequence': 0,
+                'phase': 'movement',
+                'eventType': 'order_applied',
+                'orderType': 'move',
+              },
+            ],
+          },
+        ],
+      };
+      final invalid = <String, Object?>{
+        'schemaVersion': kTurnTraceSchemaVersionV1,
+        'turnNumber': 7,
+        'phases': <Object?>[
+          <String, Object?>{
+            'phase': 'movement',
+            'beforeState': <String, Object?>{},
+            'afterState': <String, Object?>{},
+            'orderEvents': <Object?>[
+              <String, Object?>{
+                'sequence': -1,
+                'phase': 'movement',
+                'eventType': 'order_applied',
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(schema.validate(valid).isValid, isTrue);
+      expect(schema.validate(invalid).isValid, isFalse);
+    },
+  );
+
+  test(
+    'merged schema validates composed document and rejects missing sections',
+    () async {
+      final schema = await createSchema('turn-trace-merged-v1.schema.json');
+      final merged = TurnTraceMergedDocument(
+        schemaVersion: kTurnTraceSchemaVersionV1,
+        meta: const TurnTraceMeta(
+          gameId: 'game-123',
+          turnNumber: 12,
+          capturedAtUtc: '2026-05-08T03:10:00Z',
+        ),
+        ai: const <TurnTraceAiSection>[
+          TurnTraceAiSection(
+            schemaVersion: kTurnTraceSchemaVersionV1,
+            factionId: 'gp-france',
+            state: <String, Object?>{
+              'winningCandidate': <String, Object?>{'id': 'candidate-1'},
+              'topAlternates': <Object?>[],
+              'aggregates': <String, Object?>{'threat': 14},
+            },
+            thresholds: <String, Object?>{
+              'constants': <String, Object?>{},
+              'derived': <String, Object?>{},
+              'effective': <String, Object?>{},
+              'gatingChecks': <Object?>[],
+            },
+            outcome: <String, Object?>{
+              'finalOrders': <Object?>[],
+              'domainOutputs': <String, Object?>{},
+            },
+          ),
+        ],
+        turnResolution: const TurnTraceResolutionSection(
+          schemaVersion: kTurnTraceSchemaVersionV1,
+          turnNumber: 12,
+          phases: <TurnTracePhaseTrace>[
+            TurnTracePhaseTrace(
+              phase: 'combat',
+              beforeState: <String, Object?>{'battles': 2},
+              afterState: <String, Object?>{'battles': 0},
+              orderEvents: <TurnTraceOrderEvent>[
+                TurnTraceOrderEvent(
+                  sequence: 0,
+                  phase: 'combat',
+                  eventType: 'battle_resolved',
+                ),
+              ],
+            ),
+          ],
+        ),
+      ).toJson();
+      final invalid = Map<String, Object?>.from(merged)
+        ..remove('turnResolution');
+
+      expect(schema.validate(merged).isValid, isTrue);
+      expect(schema.validate(invalid).isValid, isFalse);
+    },
+  );
+}

--- a/packages/colonizethis_logic/test/turn_trace_schema_validation_test.dart
+++ b/packages/colonizethis_logic/test/turn_trace_schema_validation_test.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 
 import 'package:colonizethis_logic/src/turn/trace/turn_trace_contracts.dart';
 import 'package:json_schema/json_schema.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 void main() {
   final schemaDir = Directory('lib/src/turn/trace');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -508,6 +508,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.11.0"
+  json_schema:
+    dependency: transitive
+    description:
+      name: json_schema
+      sha256: f37d9c3fdfe8c9aae55fdfd5af815d24ce63c3a0f6a2c1f0982c30f43643fa1a
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -788,6 +796,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
   record_use:
     dependency: transitive
     description:
@@ -804,6 +820,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  rfc_6901:
+    dependency: transitive
+    description:
+      name: rfc_6901
+      sha256: "6a43b1858dca2febaf93e15639aa6b0c49ccdfd7647775f15a499f872b018154"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   riverpod:
     dependency: transitive
     description:
@@ -1009,6 +1033,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  uri:
+    dependency: transitive
+    description:
+      name: uri
+      sha256: "889eea21e953187c6099802b7b4cf5219ba8f3518f604a1033064d45b1b8268a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   url_launcher:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- Add SPEC docs for turn-resolution JSON trace schema contracts and field reference (`v1`, `schemaVersion=1.0.0`).
- Introduce logic-side typed trace contract DTOs and three versioned JSON Schema files for AI traces, turn-resolution phase traces, and the merged logical-turn trace.
- Add schema validation tests (positive + negative) covering all three schema documents and composed merged payload validation.

## Scope in this PR
- This PR is a **partial delivery (S1)** for #2218: contracts, schemas, and validation test foundation only.
- Deferred to follow-up slices: runtime capture hooks (AI + phase execution), pending/resume merge accumulator, app/ctdev enablement gates, exporter + retention, and performance overhead checks.

## SPEC
- `SPEC/program/turn-resolution-json-trace.md`
- `SPEC/program/turn-resolution-json-trace-schema-reference.md`

## Test plan
- [x] `cd packages/colonizethis_logic && dart test test/turn_trace_schema_validation_test.dart`

Refs #2218

Made with [Cursor](https://cursor.com)