### PR TITLE
Refactor logic ship-skip tests into shared support helper

### DIFF
--- a/packages/colonizethis_logic/test/orders_application_military_ship_skip_test.dart
+++ b/packages/colonizethis_logic/test/orders_application_military_ship_skip_test.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'orders_application_military_ship_skip_test_support.dart';
 
 void main() {
   group('applyBuildAndWorkOrders military and ship skip branches', () {
@@ -250,16 +251,13 @@ void main() {
         },
       );
       final next = applyBuildAndWorkOrders(game, orders); // no topology
-      expect(next.worldState.fleets, isEmpty);
-      final nextPlayer = next.players.single;
-      expect(nextPlayer.treasury, player.treasury - shipEcon.buildTreasuryCost);
-      expect(nextPlayer.workerPool.peasants, 0);
-      for (final e in shipEcon.buildInputs.entries) {
-        expect(
-          nextPlayer.stockpile.quantityOf(e.key),
-          stockpile.quantityOf(e.key) - e.value,
-        );
-      }
+      expectShipBuildSpentButNoFleet(
+        next: next,
+        baselinePlayer: player,
+        baselineStockpile: stockpile,
+        buildTreasuryCost: shipEcon.buildTreasuryCost,
+        buildInputs: shipEcon.buildInputs,
+      );
     });
 
     test('ship build with capitalProvinceId null does not add fleet', () {
@@ -321,16 +319,13 @@ void main() {
         },
       );
       final next = applyBuildAndWorkOrders(game, orders, topology: topology);
-      expect(next.worldState.fleets, isEmpty);
-      final nextPlayer = next.players.single;
-      expect(nextPlayer.treasury, player.treasury - shipEcon.buildTreasuryCost);
-      expect(nextPlayer.workerPool.peasants, 0);
-      for (final e in shipEcon.buildInputs.entries) {
-        expect(
-          nextPlayer.stockpile.quantityOf(e.key),
-          stockpile.quantityOf(e.key) - e.value,
-        );
-      }
+      expectShipBuildSpentButNoFleet(
+        next: next,
+        baselinePlayer: player,
+        baselineStockpile: stockpile,
+        buildTreasuryCost: shipEcon.buildTreasuryCost,
+        buildInputs: shipEcon.buildInputs,
+      );
     });
 
     test('ship build with capital not adjacent to sea does not add ship', () {
@@ -392,16 +387,13 @@ void main() {
         },
       );
       final next = applyBuildAndWorkOrders(game, orders, topology: topology);
-      expect(next.worldState.fleets, isEmpty);
-      final nextPlayer = next.players.single;
-      expect(nextPlayer.treasury, player.treasury - shipEcon.buildTreasuryCost);
-      expect(nextPlayer.workerPool.peasants, 0);
-      for (final e in shipEcon.buildInputs.entries) {
-        expect(
-          nextPlayer.stockpile.quantityOf(e.key),
-          stockpile.quantityOf(e.key) - e.value,
-        );
-      }
+      expectShipBuildSpentButNoFleet(
+        next: next,
+        baselinePlayer: player,
+        baselineStockpile: stockpile,
+        buildTreasuryCost: shipEcon.buildTreasuryCost,
+        buildInputs: shipEcon.buildInputs,
+      );
     });
   });
 }

--- a/packages/colonizethis_logic/test/orders_application_military_ship_skip_test_support.dart
+++ b/packages/colonizethis_logic/test/orders_application_military_ship_skip_test_support.dart
@@ -1,0 +1,21 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void expectShipBuildSpentButNoFleet({
+  required Game next,
+  required Player baselinePlayer,
+  required Stockpile baselineStockpile,
+  required int buildTreasuryCost,
+  required Map<String, int> buildInputs,
+}) {
+  expect(next.worldState.fleets, isEmpty);
+  final nextPlayer = next.players.single;
+  expect(nextPlayer.treasury, baselinePlayer.treasury - buildTreasuryCost);
+  expect(nextPlayer.workerPool.peasants, 0);
+  for (final entry in buildInputs.entries) {
+    expect(
+      nextPlayer.stockpile.quantityOf(entry.key),
+      baselineStockpile.quantityOf(entry.key) - entry.value,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Extract `expectShipBuildSpentButNoFleet` into a dedicated logic test support file for repeated ship-build skip assertions.
- Refactor `orders_application_military_ship_skip_test.dart` to use the shared helper in three tests.
- Keep the test file below the 400-line gate (`399` lines) while preserving assertion coverage.

## Scope classification
- **SLICE** for #2216 (not full completion).

## Implemented in this PR
- New support file: `packages/colonizethis_logic/test/orders_application_military_ship_skip_test_support.dart`
- Reduced duplication in: `packages/colonizethis_logic/test/orders_application_military_ship_skip_test.dart`

## Deferred work
- Additional fixture consolidation and support extraction across other large files.
- Further logical file splits to reduce remaining `>400`-line files in `packages/colonizethis_logic/test/`.

## Acceptance criteria coverage in this slice
- Advances "support-file extraction" by adding one additional `*_test_support.dart` focused on a repeated assertion pattern.
- Advances file-size reduction by bringing one previously oversized test file under the 400-line threshold.
- Does **not** complete all issue ACs.

## Test plan
- [x] `dart test test/check_logic_test_file_size_test.dart --reporter=compact`
- [x] `dart test packages/colonizethis_logic/test/orders_application_military_ship_skip_test.dart --reporter=compact`

Refs #2216

Made with [Cursor](https://cursor.com)