### PR TITLE
Strengthen turn-trace schema contract validation (slice for #2218)

### DIFF
--- a/packages/colonizethis_logic/test/turn_trace_schema_validation_test.dart
+++ b/packages/colonizethis_logic/test/turn_trace_schema_validation_test.dart
@@ -169,4 +169,64 @@ void main() {
       expect(schema.validate(invalid).isValid, isFalse);
     },
   );
+
+  test(
+    'merged schema rejects invalid schemaVersion and unknown top-level fields',
+    () async {
+      final schema = await createSchema('merged-trace.v1.schema.json');
+      final valid = <String, Object?>{
+        'schemaVersion': 'v1.1',
+        'meta': <String, Object?>{
+          'gameId': 'game-123',
+          'turnNumber': 22,
+          'traceEnabled': true,
+          'exportedAt': '2026-05-08T06:00:00Z',
+        },
+        'ai': <Object?>[
+          <String, Object?>{
+            'factionId': 'gp-france',
+            'state': <String, Object?>{
+              'winningCandidate': <String, Object?>{'id': 'candidate-1'},
+              'topAlternates': <Object?>[],
+              'aggregates': <String, Object?>{},
+            },
+            'thresholds': <String, Object?>{
+              'constants': <String, Object?>{},
+              'derived': <String, Object?>{},
+              'effective': <String, Object?>{},
+              'gates': <Object?>[],
+            },
+            'outcome': <String, Object?>{
+              'finalAggregatedOrders': <Object?>[],
+              'domainOutputs': <String, Object?>{},
+            },
+          },
+        ],
+        'turnResolution': <String, Object?>{
+          'phases': <Object?>[
+            <String, Object?>{
+              'phaseId': 'combat',
+              'beforeState': <String, Object?>{},
+              'afterState': <String, Object?>{},
+              'orderEvents': <Object?>[
+                <String, Object?>{
+                  'sequence': 0,
+                  'orderId': 'order-1',
+                  'eventType': 'order_applied',
+                },
+              ],
+            },
+          ],
+        },
+      };
+      final invalidVersion = Map<String, Object?>.from(valid)
+        ..['schemaVersion'] = '1.1';
+      final invalidUnknownTopLevel = Map<String, Object?>.from(valid)
+        ..['unexpectedField'] = true;
+
+      expect(schema.validate(valid).isValid, isTrue);
+      expect(schema.validate(invalidVersion).isValid, isFalse);
+      expect(schema.validate(invalidUnknownTopLevel).isValid, isFalse);
+    },
+  );
 }

--- a/packages/colonizethis_logic/test/turn_trace_schema_validation_test.dart
+++ b/packages/colonizethis_logic/test/turn_trace_schema_validation_test.dart
@@ -71,6 +71,41 @@ void main() {
   );
 
   test(
+    'ai schema rejects unknown top-level fields and missing outcome payload keys',
+    () async {
+      final schema = await createSchema('ai-trace.v1.schema.json');
+      final valid = <String, Object?>{
+        'factionId': 'gp-spain',
+        'state': <String, Object?>{
+          'winningCandidate': <String, Object?>{'id': 'candidate-1'},
+          'topAlternates': <Object?>[],
+          'aggregates': <String, Object?>{'pressure': 7},
+        },
+        'thresholds': <String, Object?>{
+          'constants': <String, Object?>{},
+          'derived': <String, Object?>{},
+          'effective': <String, Object?>{},
+          'gates': <Object?>[],
+        },
+        'outcome': <String, Object?>{
+          'domainOutputs': <String, Object?>{},
+          'finalAggregatedOrders': <Object?>[],
+        },
+      };
+      final invalidUnknownField = Map<String, Object?>.from(valid)
+        ..['unexpected'] = <String, Object?>{};
+      final invalidOutcome = Map<String, Object?>.from(valid)
+        ..['outcome'] = <String, Object?>{
+          'domainOutputs': <String, Object?>{},
+        };
+
+      expect(schema.validate(valid).isValid, isTrue);
+      expect(schema.validate(invalidUnknownField).isValid, isFalse);
+      expect(schema.validate(invalidOutcome).isValid, isFalse);
+    },
+  );
+
+  test(
     'resolution schema validates ordered phase payload and rejects malformed events',
     () async {
       final schema = await createSchema('turn-resolution-trace.v1.schema.json');
@@ -109,6 +144,65 @@ void main() {
 
       expect(schema.validate(valid).isValid, isTrue);
       expect(schema.validate(invalid).isValid, isFalse);
+    },
+  );
+
+  test(
+    'resolution schema rejects unknown phase fields and missing order event keys',
+    () async {
+      final schema = await createSchema('turn-resolution-trace.v1.schema.json');
+      final valid = <String, Object?>{
+        'phases': <Object?>[
+          <String, Object?>{
+            'phaseId': 'support',
+            'beforeState': <String, Object?>{},
+            'afterState': <String, Object?>{},
+            'orderEvents': <Object?>[
+              <String, Object?>{
+                'sequence': 1,
+                'orderId': 'order-100',
+                'eventType': 'order_applied',
+              },
+            ],
+          },
+        ],
+      };
+      final invalidUnknownPhaseField = <String, Object?>{
+        'phases': <Object?>[
+          <String, Object?>{
+            'phaseId': 'support',
+            'beforeState': <String, Object?>{},
+            'afterState': <String, Object?>{},
+            'orderEvents': <Object?>[
+              <String, Object?>{
+                'sequence': 1,
+                'orderId': 'order-100',
+                'eventType': 'order_applied',
+              },
+            ],
+            'unexpectedField': true,
+          },
+        ],
+      };
+      final invalidMissingOrderEventType = <String, Object?>{
+        'phases': <Object?>[
+          <String, Object?>{
+            'phaseId': 'support',
+            'beforeState': <String, Object?>{},
+            'afterState': <String, Object?>{},
+            'orderEvents': <Object?>[
+              <String, Object?>{
+                'sequence': 1,
+                'orderId': 'order-100',
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(schema.validate(valid).isValid, isTrue);
+      expect(schema.validate(invalidUnknownPhaseField).isValid, isFalse);
+      expect(schema.validate(invalidMissingOrderEventType).isValid, isFalse);
     },
   );
 


### PR DESCRIPTION
## Summary
- Tighten JSON schema conformance coverage for merged, AI, and turn-resolution trace documents by adding explicit negative tests for invalid payload shapes and unknown fields.
- Keep this slice limited to schema validation hardening in `colonizethis_logic` tests to improve CI enforcement of the existing v1 contract.
- Refs #2218

## Implemented in this PR
- Added `merged schema rejects invalid schemaVersion and unknown top-level fields` coverage in `packages/colonizethis_logic/test/turn_trace_schema_validation_test.dart`.
- Added `ai schema rejects unknown top-level fields and missing outcome payload keys` coverage to enforce strict top-level contract shape and required outcome fields.
- Added `resolution schema rejects unknown phase fields and missing order event keys` coverage to enforce strict phase object shape and required order-event keys.
- Verified accepted semver-style schema version input (`v1.1`) and rejection behavior for:
  - non-prefixed version string (`1.1`), and
  - unexpected top-level properties where forbidden by schema.

## Deferred work (remaining issue scope)
- Runtime trace capture and wiring in app/ctdev execution paths.
- AI/state/threshold/outcome capture internals across planners and tactical flows.
- Turn-resolution phase snapshot and order-event sequence capture integration.
- Logical-turn merge/export lifecycle, configurable export directory, and retention policy.
- End-to-end export pipeline and performance-budget validation.

## AC/Spec coverage for this slice
- Advances explicit JSON schema contract enforcement aspects of #2218 by strengthening negative validation behavior for merged, AI, and turn-resolution trace documents.
- Does not claim completion of turn-resolution trace runtime behavior ACs.

## Tests
- `cd packages/colonizethis_logic && flutter test test/turn_trace_schema_validation_test.dart`

Made with [Cursor](https://cursor.com)