### PR TITLE
Refactor civilian build validation test setup (slice for #2216)

### DIFF
--- a/packages/colonizethis_logic/test/order_engine_validate_build_civilian_test.dart
+++ b/packages/colonizethis_logic/test/order_engine_validate_build_civilian_test.dart
@@ -3,350 +3,108 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'order_engine_validate_build_civilian_test_support.dart';
+
 void main() {
   group('OrderEngine', () {
     group('validateBuild (civilian)', () {
-      const ow = 'oldWorld';
-      final topology = MapTopology(
-        nodes: const [
-          TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
-        ],
-        edges: const [],
-      );
-
       test('rejects unknown unit type', () {
-        final game = Game(
-          id: 'g1',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-            oldWorld: RegionData(
-              provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
-              units: [],
-            ),
-            newWorld: const RegionData(),
-          ),
-          players: [
-            Player(
-              id: 'p1',
-              displayName: 'P1',
-              isHuman: true,
-              capitalProvinceId: '$ow|P1',
-              capitalTile: const CapitalTile(
-                regionId: ow,
-                provinceId: 'P1',
-                x: 0,
-                y: 0,
-              ),
-              stockpile: const Stockpile(),
-              workerPool: const WorkerPool(peasants: 0),
-              treasury: 5000,
-            ),
-          ],
-        );
-        final engine = OrderEngine();
-        engine.addBuildOrder(
-          'p1',
+        final result = validateSingleBuildUnitOrder(
+          buildCivilianValidationGame(treasury: 5000),
           BuildUnitOrder(
             unitType: 'UnknownTypeXyz',
             isMilitary:
                 buildUnitCategoryForUnitType('UnknownTypeXyz') ==
                 BuildUnitCategory.military,
-            spawnProvinceId: '$ow|P1',
+            spawnProvinceId: '$oldWorldRegionId|P1',
           ),
         );
-        final results = engine.validatePlayerOrdersWithContext(
-          game,
-          topology,
-          'p1',
-        );
-        expect(results.single.status, OrderValidationStatus.rejected);
-        expect(results.single.reason, 'Insufficient resources');
+        expect(result.status, OrderValidationStatus.rejected);
+        expect(result.reason, 'Insufficient resources');
       });
 
       test('rejects Builder when treasury too low', () {
-        final game = Game(
-          id: 'g1',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-            oldWorld: RegionData(
-              provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
-              units: [],
-            ),
-            newWorld: const RegionData(),
-          ),
-          players: [
-            Player(
-              id: 'p1',
-              displayName: 'P1',
-              isHuman: true,
-              capitalProvinceId: '$ow|P1',
-              capitalTile: const CapitalTile(
-                regionId: ow,
-                provinceId: 'P1',
-                x: 0,
-                y: 0,
-              ),
-              stockpile: Stockpile().applyDelta(CommodityCatalog.paper.id, 5),
-              workerPool: const WorkerPool(peasants: 0),
-              treasury: 999,
-            ),
-          ],
-        );
-        final engine = OrderEngine();
-        engine.addBuildOrder(
-          'p1',
+        final result = validateSingleBuildUnitOrder(
+          buildCivilianValidationGame(treasury: 999, paper: 5),
           BuildUnitOrder(
             unitType: kUnitTypeBuilder,
             isMilitary:
                 buildUnitCategoryForUnitType(kUnitTypeBuilder) ==
                 BuildUnitCategory.military,
-            spawnProvinceId: '$ow|P1',
+            spawnProvinceId: '$oldWorldRegionId|P1',
           ),
         );
-        final results = engine.validatePlayerOrdersWithContext(
-          game,
-          topology,
-          'p1',
-        );
-        expect(results.single.status, OrderValidationStatus.rejected);
-        expect(results.single.reason, 'Insufficient treasury');
+        expect(result.status, OrderValidationStatus.rejected);
+        expect(result.reason, 'Insufficient treasury');
       });
 
       test('rejects Builder when paper insufficient', () {
-        final game = Game(
-          id: 'g1',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-            oldWorld: RegionData(
-              provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
-              units: [],
-            ),
-            newWorld: const RegionData(),
-          ),
-          players: [
-            Player(
-              id: 'p1',
-              displayName: 'P1',
-              isHuman: true,
-              capitalProvinceId: '$ow|P1',
-              capitalTile: const CapitalTile(
-                regionId: ow,
-                provinceId: 'P1',
-                x: 0,
-                y: 0,
-              ),
-              stockpile: const Stockpile(),
-              workerPool: const WorkerPool(peasants: 0),
-              treasury: 2000,
-            ),
-          ],
-        );
-        final engine = OrderEngine();
-        engine.addBuildOrder(
-          'p1',
+        final result = validateSingleBuildUnitOrder(
+          buildCivilianValidationGame(treasury: 2000),
           BuildUnitOrder(
             unitType: kUnitTypeBuilder,
             isMilitary:
                 buildUnitCategoryForUnitType(kUnitTypeBuilder) ==
                 BuildUnitCategory.military,
-            spawnProvinceId: '$ow|P1',
+            spawnProvinceId: '$oldWorldRegionId|P1',
           ),
         );
-        final results = engine.validatePlayerOrdersWithContext(
-          game,
-          topology,
-          'p1',
-        );
-        expect(results.single.status, OrderValidationStatus.rejected);
-        expect(results.single.reason, 'Insufficient materials');
+        expect(result.status, OrderValidationStatus.rejected);
+        expect(result.reason, 'Insufficient materials');
       });
 
       test('rejects Merchant when merchant_companies not unlocked', () {
-        final game = Game(
-          id: 'g1',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-            oldWorld: RegionData(
-              provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
-              units: [],
-            ),
-            newWorld: const RegionData(),
-          ),
-          players: [
-            Player(
-              id: 'p1',
-              displayName: 'P1',
-              isHuman: true,
-              capitalProvinceId: '$ow|P1',
-              capitalTile: const CapitalTile(
-                regionId: ow,
-                provinceId: 'P1',
-                x: 0,
-                y: 0,
-              ),
-              stockpile: Stockpile().applyDelta(CommodityCatalog.paper.id, 5),
-              workerPool: const WorkerPool(peasants: 0),
-              treasury: 3000,
-              techUnlocked: {},
-            ),
-          ],
-        );
-        final engine = OrderEngine();
-        engine.addBuildOrder(
-          'p1',
+        final result = validateSingleBuildUnitOrder(
+          buildCivilianValidationGame(treasury: 3000, paper: 5),
           BuildUnitOrder(
             unitType: kUnitTypeMerchant,
             isMilitary:
                 buildUnitCategoryForUnitType(kUnitTypeMerchant) ==
                 BuildUnitCategory.military,
-            spawnProvinceId: '$ow|P1',
+            spawnProvinceId: '$oldWorldRegionId|P1',
           ),
         );
-        final results = engine.validatePlayerOrdersWithContext(
-          game,
-          topology,
-          'p1',
-        );
-        expect(results.single.status, OrderValidationStatus.rejected);
-        expect(results.single.reason, 'Required technology not unlocked');
+        expect(result.status, OrderValidationStatus.rejected);
+        expect(result.reason, 'Required technology not unlocked');
       });
 
       test('accepts Builder when treasury and paper sufficient', () {
-        final game = Game(
-          id: 'g1',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-            oldWorld: RegionData(
-              provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
-              units: [],
-            ),
-            newWorld: const RegionData(),
-          ),
-          players: [
-            Player(
-              id: 'p1',
-              displayName: 'P1',
-              isHuman: true,
-              capitalProvinceId: '$ow|P1',
-              capitalTile: const CapitalTile(
-                regionId: ow,
-                provinceId: 'P1',
-                x: 0,
-                y: 0,
-              ),
-              stockpile: Stockpile().applyDelta(CommodityCatalog.paper.id, 5),
-              workerPool: const WorkerPool(peasants: 0),
-              treasury: 2000,
-            ),
-          ],
-        );
-        final engine = OrderEngine();
-        engine.addBuildOrder(
-          'p1',
+        final result = validateSingleBuildUnitOrder(
+          buildCivilianValidationGame(treasury: 2000, paper: 5),
           BuildUnitOrder(
             unitType: kUnitTypeBuilder,
             isMilitary:
                 buildUnitCategoryForUnitType(kUnitTypeBuilder) ==
                 BuildUnitCategory.military,
-            spawnProvinceId: '$ow|P1',
+            spawnProvinceId: '$oldWorldRegionId|P1',
           ),
         );
-        final results = engine.validatePlayerOrdersWithContext(
-          game,
-          topology,
-          'p1',
-        );
-        expect(results.single.status, OrderValidationStatus.accepted);
+        expect(result.status, OrderValidationStatus.accepted);
       });
 
       test('accepts Merchant when tech and resources ok', () {
-        final game = Game(
-          id: 'g1',
-          worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
-            oldWorld: RegionData(
-              provinces: [Province(id: '$ow|P1', regionId: ow, ownerId: 'p1')],
-              units: [],
-            ),
-            newWorld: const RegionData(),
+        final result = validateSingleBuildUnitOrder(
+          buildCivilianValidationGame(
+            treasury: 3000,
+            paper: 5,
+            techUnlocked: const {kTechIdMerchantCompanies: true},
           ),
-          players: [
-            Player(
-              id: 'p1',
-              displayName: 'P1',
-              isHuman: true,
-              capitalProvinceId: '$ow|P1',
-              capitalTile: const CapitalTile(
-                regionId: ow,
-                provinceId: 'P1',
-                x: 0,
-                y: 0,
-              ),
-              stockpile: Stockpile().applyDelta(CommodityCatalog.paper.id, 5),
-              workerPool: const WorkerPool(peasants: 0),
-              treasury: 3000,
-              techUnlocked: {kTechIdMerchantCompanies: true},
-            ),
-          ],
-        );
-        final engine = OrderEngine();
-        engine.addBuildOrder(
-          'p1',
           BuildUnitOrder(
             unitType: kUnitTypeMerchant,
             isMilitary:
                 buildUnitCategoryForUnitType(kUnitTypeMerchant) ==
                 BuildUnitCategory.military,
-            spawnProvinceId: '$ow|P1',
+            spawnProvinceId: '$oldWorldRegionId|P1',
           ),
         );
-        final results = engine.validatePlayerOrdersWithContext(
-          game,
-          topology,
-          'p1',
-        );
-        expect(results.single.status, OrderValidationStatus.accepted);
+        expect(result.status, OrderValidationStatus.accepted);
       });
 
       test(
         'accepts build when spawnProvinceId is empty (falls back to capital)',
         () {
-          final game = Game(
-            id: 'g1',
-            worldState: WorldState(
-              turnState: const TurnState(
-                phase: TurnPhase.orders,
-                turnNumber: 0,
-              ),
-              oldWorld: RegionData(
-                provinces: [
-                  Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
-                ],
-                units: [],
-              ),
-              newWorld: const RegionData(),
-            ),
-            players: [
-              Player(
-                id: 'p1',
-                displayName: 'P1',
-                isHuman: true,
-                capitalProvinceId: '$ow|P1',
-                capitalTile: const CapitalTile(
-                  regionId: ow,
-                  provinceId: 'P1',
-                  x: 0,
-                  y: 0,
-                ),
-                stockpile: Stockpile().applyDelta(CommodityCatalog.paper.id, 5),
-                workerPool: const WorkerPool(peasants: 0),
-                treasury: 2000,
-              ),
-            ],
-          );
-          final engine = OrderEngine();
-          engine.addBuildOrder(
-            'p1',
+          final result = validateSingleBuildUnitOrder(
+            buildCivilianValidationGame(treasury: 2000, paper: 5),
             BuildUnitOrder(
               unitType: kUnitTypeBuilder,
               isMilitary:
@@ -355,69 +113,39 @@ void main() {
               spawnProvinceId: '',
             ),
           );
-          final results = engine.validatePlayerOrdersWithContext(
-            game,
-            topology,
-            'p1',
-          );
-          expect(results.single.status, OrderValidationStatus.accepted);
+          expect(result.status, OrderValidationStatus.accepted);
         },
       );
 
       test(
         'accepts build when spawnProvinceId is foreign (falls back to capital)',
         () {
-          final game = Game(
-            id: 'g1',
-            worldState: WorldState(
-              turnState: const TurnState(
-                phase: TurnPhase.orders,
-                turnNumber: 0,
-              ),
-              oldWorld: RegionData(
-                provinces: [
-                  Province(id: '$ow|P1', regionId: ow, ownerId: 'p1'),
-                  Province(id: '$ow|P2', regionId: ow, ownerId: 'p2'),
-                ],
-                units: [],
-              ),
-              newWorld: const RegionData(),
-            ),
-            players: [
-              Player(
-                id: 'p1',
-                displayName: 'P1',
-                isHuman: true,
-                capitalProvinceId: '$ow|P1',
-                capitalTile: const CapitalTile(
-                  regionId: ow,
-                  provinceId: 'P1',
-                  x: 0,
-                  y: 0,
+          final result = validateSingleBuildUnitOrder(
+            buildCivilianValidationGame(
+              treasury: 2000,
+              paper: 5,
+              provinces: const [
+                Province(
+                  id: '$oldWorldRegionId|P1',
+                  regionId: oldWorldRegionId,
+                  ownerId: 'p1',
                 ),
-                stockpile: Stockpile().applyDelta(CommodityCatalog.paper.id, 5),
-                workerPool: const WorkerPool(peasants: 0),
-                treasury: 2000,
-              ),
-            ],
-          );
-          final engine = OrderEngine();
-          engine.addBuildOrder(
-            'p1',
+                Province(
+                  id: '$oldWorldRegionId|P2',
+                  regionId: oldWorldRegionId,
+                  ownerId: 'p2',
+                ),
+              ],
+            ),
             BuildUnitOrder(
               unitType: kUnitTypeBuilder,
               isMilitary:
                   buildUnitCategoryForUnitType(kUnitTypeBuilder) ==
                   BuildUnitCategory.military,
-              spawnProvinceId: '$ow|P2',
+              spawnProvinceId: '$oldWorldRegionId|P2',
             ),
           );
-          final results = engine.validatePlayerOrdersWithContext(
-            game,
-            topology,
-            'p1',
-          );
-          expect(results.single.status, OrderValidationStatus.accepted);
+          expect(result.status, OrderValidationStatus.accepted);
         },
       );
     });

--- a/packages/colonizethis_logic/test/order_engine_validate_build_civilian_test_support.dart
+++ b/packages/colonizethis_logic/test/order_engine_validate_build_civilian_test_support.dart
@@ -1,0 +1,74 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+const oldWorldRegionId = 'oldWorld';
+
+final buildCivilianTopology = MapTopology(
+  nodes: const [
+    TopologyNode(
+      id: 'P1',
+      regionId: oldWorldRegionId,
+      type: TopologyNodeType.province,
+    ),
+  ],
+  edges: const [],
+);
+
+Game buildCivilianValidationGame({
+  int treasury = 2000,
+  int paper = 0,
+  Map<String, bool> techUnlocked = const {},
+  List<Province> provinces = const [
+    Province(
+      id: '$oldWorldRegionId|P1',
+      regionId: oldWorldRegionId,
+      ownerId: 'p1',
+    ),
+  ],
+}) {
+  var stockpile = const Stockpile();
+  if (paper > 0) {
+    stockpile = stockpile.applyDelta(CommodityCatalog.paper.id, paper);
+  }
+  return Game(
+    id: 'g1',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+      oldWorld: RegionData(provinces: provinces, units: const []),
+      newWorld: const RegionData(),
+    ),
+    players: [
+      Player(
+        id: 'p1',
+        displayName: 'P1',
+        isHuman: true,
+        capitalProvinceId: '$oldWorldRegionId|P1',
+        capitalTile: const CapitalTile(
+          regionId: oldWorldRegionId,
+          provinceId: 'P1',
+          x: 0,
+          y: 0,
+        ),
+        stockpile: stockpile,
+        workerPool: const WorkerPool(peasants: 0),
+        treasury: treasury,
+        techUnlocked: techUnlocked,
+      ),
+    ],
+  );
+}
+
+OrderValidationResult validateSingleBuildUnitOrder(
+  Game game,
+  BuildUnitOrder order,
+) {
+  final engine = OrderEngine()..addBuildOrder('p1', order);
+  final results = engine.validatePlayerOrdersWithContext(
+    game,
+    buildCivilianTopology,
+    'p1',
+  );
+  return results.single;
+}


### PR DESCRIPTION
## Summary
- extract shared setup/validation helpers for civilian build-order tests into `order_engine_validate_build_civilian_test_support.dart`
- refactor `order_engine_validate_build_civilian_test.dart` to reuse helpers and keep assertions focused on behavior
- bring this test file under the `<= 400` line gate to continue issue #2216 test-size ratchet work

## Test plan
- [x] `dart test packages/colonizethis_logic/test/order_engine_validate_build_civilian_test.dart --reporter=compact`
- [x] `dart run tool/check_logic_test_file_size.dart packages/colonizethis_logic/test/order_engine_validate_build_civilian_test.dart`
- [x] `dart run tool/check_logic_test_file_size.dart` (violation count reduced 46 -> 45)

Refs #2216

Made with [Cursor](https://cursor.com)