### PR TITLE
Add phase snapshot trace hook plumbing (slice for #2218)

### DIFF
--- a/SPEC/program/turn-resolution-json-trace.md
+++ b/SPEC/program/turn-resolution-json-trace.md
@@ -1,6 +1,6 @@
 # Turn Resolution JSON Trace
 
-**SPEC/program** - Debug-only structured trace contracts for turn resolution and AI planner diagnostics. This document defines schema contracts only. Runtime wiring and export lifecycle are specified in follow-up slices.
+**SPEC/program** - Debug-only structured trace contracts for turn resolution and AI planner diagnostics.
 
 ---
 
@@ -17,6 +17,9 @@ These schemas define diagnostic payload shape for:
 1. Per-AI decision traces.
 2. Per-phase turn-resolution execution traces.
 3. One merged logical-turn document.
+
+This spec also authorizes phase-level snapshot capture hooks in the turn
+resolver as non-exporting runtime plumbing for issue #2218 follow-up slices.
 
 ---
 
@@ -105,3 +108,4 @@ Meta section requires:
 - Given a JSON payload intended as a turn-resolution trace, when validated against `turn-resolution-trace.v1.schema.json`, then validation passes only if each phase contains `beforeState`, `afterState`, and ordered `orderEvents` entries with non-negative `sequence`.
 - Given a JSON payload intended as a merged logical-turn trace, when validated against `merged-trace.v1.schema.json`, then validation passes only if `meta`, `ai`, and `turnResolution` are present and nested sections satisfy referenced contracts.
 - Given a payload with missing required fields for any of the three trace schemas, when validated, then validation fails deterministically with at least one schema violation.
+- Given turn resolution runs with `TurnResolverConfig.onTurnTracePhase` set, when each phase resolves (including pending-exit phases), then the callback receives one `TurnTracePhaseTrace` payload per phase containing `phaseId`, full `beforeState`, full `afterState`, and an ordered `orderEvents` array (which may be empty until order-event hooks are wired).

--- a/packages/colonizethis_logic/lib/src/turn/turn_phase_runner.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_phase_runner.dart
@@ -10,6 +10,7 @@ import 'turn_resolution_events.dart';
 import 'turn_resolution_result.dart';
 import 'turn_resolution_sequence.dart';
 import 'turn_resolver_config.dart';
+import 'trace/turn_trace_contracts.dart';
 import 'phases.dart';
 
 final _log = packageLogger();
@@ -37,6 +38,7 @@ TurnResolutionResult runTurnResolutionPipeline({
     if (i < phaseIndex) continue;
     config.onPhaseProgress?.call(phase, TurnPhaseProgressMarker.start);
     _log.i('phase ${phase.name} start');
+    final beforeState = acc.game.toJson();
     final handler = handlers[phase];
     if (handler == null) {
       throw StateError('No turn phase handler registered for ${phase.name}');
@@ -44,8 +46,20 @@ TurnResolutionResult runTurnResolutionPipeline({
     final outcome = handler(acc, config, turn);
     switch (outcome) {
       case TurnPhaseStepExit(:final result):
+        _emitPhaseTrace(
+          config: config,
+          phase: phase,
+          beforeState: beforeState,
+          afterState: _phaseExitStateSnapshot(result),
+        );
         return result;
       case TurnPhaseStepContinue(:final pipeline):
+        _emitPhaseTrace(
+          config: config,
+          phase: phase,
+          beforeState: beforeState,
+          afterState: pipeline.game.toJson(),
+        );
         acc = pipeline;
     }
     _log.i('phase ${phase.name} end');
@@ -65,6 +79,31 @@ TurnResolutionResult runTurnResolutionPipeline({
     end: acc.game,
   );
   return TurnResolutionComplete(news.game, turnNewsDigest: news.digest);
+}
+
+void _emitPhaseTrace({
+  required TurnResolverConfig config,
+  required TurnPhase phase,
+  required Map<String, Object?> beforeState,
+  required Map<String, Object?> afterState,
+}) {
+  config.onTurnTracePhase?.call(
+    TurnTracePhaseTrace(
+      phaseId: phase.name,
+      beforeState: beforeState,
+      afterState: afterState,
+      orderEvents: const <TurnTraceOrderEvent>[],
+    ),
+  );
+}
+
+Map<String, Object?> _phaseExitStateSnapshot(TurnResolutionResult result) {
+  return switch (result) {
+    TurnResolutionComplete(:final game) => game.toJson(),
+    TurnResolutionPendingOvertures(:final game) => game.toJson(),
+    TurnResolutionPendingIntervention(:final game) => game.toJson(),
+    TurnResolutionPendingCallToArms(:final game) => game.toJson(),
+  };
 }
 
 Map<TurnPhase, TurnPhaseHandler> _defaultTurnPhaseHandlers() {

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver_config.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver_config.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../event_bus/game_event_bus.dart';
 import '../game_events.dart' show GameEvent;
+import 'trace/turn_trace_contracts.dart';
 import 'turn_pipeline_state.dart';
 import 'turn_resolution_result.dart';
 
@@ -36,6 +37,7 @@ class TurnResolverConfig {
     this.callToArmsDecisions,
     this.phaseHandlerOverrides,
     this.onPhaseProgress,
+    this.onTurnTracePhase,
   });
 
   final MapTopology topology;
@@ -65,4 +67,8 @@ class TurnResolverConfig {
   /// Optional callback invoked at each phase start/end during pipeline execution.
   final void Function(TurnPhase phase, TurnPhaseProgressMarker marker)?
   onPhaseProgress;
+
+  /// Optional debug trace callback for per-phase snapshots captured during
+  /// turn resolution. This hook is observational and must not mutate state.
+  final void Function(TurnTracePhaseTrace phaseTrace)? onTurnTracePhase;
 }

--- a/packages/colonizethis_logic/test/turn_phase_runner_phase_overrides_test.dart
+++ b/packages/colonizethis_logic/test/turn_phase_runner_phase_overrides_test.dart
@@ -115,4 +115,43 @@ void main() {
     expect(events.first.$2, TurnPhaseProgressMarker.start);
     expect(events.last.$2, TurnPhaseProgressMarker.end);
   });
+
+  test('phase trace callback emits before and after snapshots per phase', () {
+    final topology = MapTopology(
+      nodes: const [
+        TopologyNode(
+          id: 'P1',
+          regionId: 'oldWorld',
+          type: TopologyNodeType.province,
+        ),
+      ],
+      edges: const [],
+    );
+    final game = TestFixtures.minimalGame(
+      id: 'g1',
+      turnNumber: 0,
+      players: const [Player(id: 'p1', displayName: 'A', isHuman: true)],
+      oldWorld: RegionData(
+        provinces: [Province(id: 'oldWorld|P1', regionId: 'oldWorld')],
+      ),
+    );
+    final traces = <TurnTracePhaseTrace>[];
+
+    resolveTurnForGameWithConfig(
+      game: game,
+      config: TurnResolverConfig(
+        topology: topology,
+        orders: const Orders(),
+        onTurnTracePhase: traces.add,
+      ),
+    );
+
+    expect(traces, isNotEmpty);
+    expect(traces.first.phaseId, TurnPhase.orders.name);
+    expect(traces.first.beforeState, isNotEmpty);
+    expect(traces.first.afterState, isNotEmpty);
+    expect(traces.first.orderEvents, isEmpty);
+    expect(traces.last.phaseId, TurnPhase.endOfTurn.name);
+    expect(traces.last.afterState['worldState'], isA<Map<String, dynamic>>());
+  });
 }


### PR DESCRIPTION
## Summary
- Add an observational `TurnResolverConfig.onTurnTracePhase` callback so turn resolution can emit structured per-phase trace payloads without mutating gameplay flow.
- Emit one `TurnTracePhaseTrace` payload for each resolved phase (including pending-exit phases), capturing full `beforeState`/`afterState` snapshots and ordered `orderEvents` placeholder arrays.
- Extend `turn_phase_runner_phase_overrides_test.dart` to verify the new callback contract and update `SPEC/program/turn-resolution-json-trace.md` to authorize this runtime plumbing slice.

## Implemented in this PR
- S3 groundwork: phase-level trace hook wiring in resolver runtime.
- Test coverage for callback emission and payload shape expectations.
- SPEC authorization update for callback behavior.

## Deferred (not in this slice)
- AI tracer wrappers (`S2`), order-level event instrumentation in hooks (`S3` completion), cross-resume accumulator (`S4`), exporter/config/retention (`S5`), app+ctdev gate wiring (`S6`), and end-to-end merged trace export tests/perf checks (`S7`).
- This PR intentionally does not write trace files yet.

## Tests
- `dart test test/turn_phase_runner_phase_overrides_test.dart test/turn_trace_schema_validation_test.dart`

Refs #2218

Made with [Cursor](https://cursor.com)