### PR TITLE
Add trace export path and retention foundation (slice for #2218)

### DIFF
--- a/SPEC/program/turn-resolution-json-trace.md
+++ b/SPEC/program/turn-resolution-json-trace.md
@@ -20,6 +20,8 @@ These schemas define diagnostic payload shape for:
 
 This spec also authorizes phase-level snapshot capture hooks in the turn
 resolver as non-exporting runtime plumbing for issue #2218 follow-up slices.
+This spec authorizes turn-trace file export path and retention behavior for
+debug tracing outputs.
 
 ---
 
@@ -100,6 +102,17 @@ Meta section requires:
 
 `ai` entries must validate against AI trace schema, and `turnResolution` must validate against turn-resolution schema.
 
+### Trace file export path and retention
+
+- Default trace root directory is repo-root `tmp/`.
+- Export path pattern is
+  `tmp/turn-traces/{gameId}/turn-{turnNumber}-{timestamp}.json`.
+- `timestamp` uses UTC sortable filename format `YYYYMMDDTHHMMSSmmmZ`.
+- A configurable trace root directory override is allowed for ctdev/app startup
+  wiring slices, while keeping the same sub-path and filename pattern.
+- Retention keeps at most 10 `.json` trace files per `gameId` directory by
+  pruning oldest files first.
+
 ---
 
 ## Acceptance Criteria
@@ -109,3 +122,6 @@ Meta section requires:
 - Given a JSON payload intended as a merged logical-turn trace, when validated against `merged-trace.v1.schema.json`, then validation passes only if `meta`, `ai`, and `turnResolution` are present and nested sections satisfy referenced contracts.
 - Given a payload with missing required fields for any of the three trace schemas, when validated, then validation fails deterministically with at least one schema violation.
 - Given turn resolution runs with `TurnResolverConfig.onTurnTracePhase` set, when each phase resolves (including pending-exit phases), then the callback receives one `TurnTracePhaseTrace` payload per phase containing `phaseId`, full `beforeState`, full `afterState`, and an ordered `orderEvents` array (which may be empty until order-event hooks are wired).
+- Given no custom trace root override is provided, when the system exports a merged turn trace for `gameId = G` and `turnNumber = N`, then the system writes one JSON file to `tmp/turn-traces/G/` using filename pattern `turn-N-YYYYMMDDTHHMMSSmmmZ.json`.
+- Given a custom trace root override path `R` is provided, when the system exports a merged turn trace for `gameId = G`, then the system writes to `R/turn-traces/G/` and keeps the same filename pattern.
+- Given a game trace directory contains more than 10 trace JSON files after a new export, when retention runs, then the system deletes oldest files first until exactly 10 files remain in that gameId directory.

--- a/packages/colonizethis_logic/lib/colonizethis_logic.dart
+++ b/packages/colonizethis_logic/lib/colonizethis_logic.dart
@@ -36,6 +36,7 @@ export 'src/setup/setup_exceptions.dart';
 export 'src/turn/economy_debt_rules.dart';
 export 'src/turn/research_resolver.dart';
 export 'src/turn/trace/turn_trace_contracts.dart';
+export 'src/turn/trace/turn_trace_file_exporter.dart';
 export 'src/turn/turn_resolution_result.dart';
 export 'src/turn/turn_resolver.dart';
 export 'src/turn/turn_news_digest.dart';

--- a/packages/colonizethis_logic/lib/src/turn/trace/turn_trace_file_exporter.dart
+++ b/packages/colonizethis_logic/lib/src/turn/trace/turn_trace_file_exporter.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:colonizethis_logic/src/turn/trace/turn_trace_contracts.dart';
+
+class TurnTraceFileExporter {
+  TurnTraceFileExporter({this.rootDirectory = 'tmp', this.maxFilesPerGame = 10})
+    : assert(maxFilesPerGame > 0, 'maxFilesPerGame must be positive');
+
+  final String rootDirectory;
+  final int maxFilesPerGame;
+
+  Future<File> export(TurnTraceMergedDocument document) async {
+    final gameId = document.meta.gameId;
+    final turnNumber = document.meta.turnNumber;
+    final exportedAt =
+        DateTime.tryParse(document.meta.exportedAt)?.toUtc() ??
+        DateTime.now().toUtc();
+    final directoryPath = '$rootDirectory/turn-traces/$gameId';
+    final directory = Directory(directoryPath);
+    if (!await directory.exists()) {
+      await directory.create(recursive: true);
+    }
+    final timestamp = _formatTimestamp(exportedAt);
+    final fileName = 'turn-$turnNumber-$timestamp.json';
+    final file = File('${directory.path}/$fileName');
+    final jsonContent = const JsonEncoder.withIndent(
+      '  ',
+    ).convert(document.toJson());
+    await file.writeAsString('$jsonContent\n');
+    await _pruneOlderTraces(directory: directory, keep: maxFilesPerGame);
+    return file;
+  }
+
+  Future<void> _pruneOlderTraces({
+    required Directory directory,
+    required int keep,
+  }) async {
+    final files = <File>[];
+    await for (final entity in directory.list(followLinks: false)) {
+      if (entity is File && entity.path.endsWith('.json')) {
+        files.add(entity);
+      }
+    }
+    if (files.length <= keep) {
+      return;
+    }
+    files.sort((File a, File b) {
+      final aName = a.uri.pathSegments.isEmpty
+          ? a.path
+          : a.uri.pathSegments.last;
+      final bName = b.uri.pathSegments.isEmpty
+          ? b.path
+          : b.uri.pathSegments.last;
+      final aTimestamp = _extractTimestampToken(aName);
+      final bTimestamp = _extractTimestampToken(bName);
+      final timestampCompare = aTimestamp.compareTo(bTimestamp);
+      if (timestampCompare != 0) {
+        return timestampCompare;
+      }
+      return aName.compareTo(bName);
+    });
+    final deleteCount = files.length - keep;
+    for (var index = 0; index < deleteCount; index++) {
+      await files[index].delete();
+    }
+  }
+
+  String _formatTimestamp(DateTime value) {
+    final year = value.year.toString().padLeft(4, '0');
+    final month = value.month.toString().padLeft(2, '0');
+    final day = value.day.toString().padLeft(2, '0');
+    final hour = value.hour.toString().padLeft(2, '0');
+    final minute = value.minute.toString().padLeft(2, '0');
+    final second = value.second.toString().padLeft(2, '0');
+    final millisecond = value.millisecond.toString().padLeft(3, '0');
+    return '${year}${month}${day}T${hour}${minute}${second}${millisecond}Z';
+  }
+
+  String _extractTimestampToken(String fileName) {
+    if (!fileName.endsWith('.json')) {
+      return '';
+    }
+    final withoutExt = fileName.substring(0, fileName.length - '.json'.length);
+    final lastDash = withoutExt.lastIndexOf('-');
+    if (lastDash < 0 || lastDash == withoutExt.length - 1) {
+      return '';
+    }
+    return withoutExt.substring(lastDash + 1);
+  }
+}

--- a/packages/colonizethis_logic/test/turn_trace_file_exporter_test.dart
+++ b/packages/colonizethis_logic/test/turn_trace_file_exporter_test.dart
@@ -1,0 +1,124 @@
+import 'dart:io';
+
+import 'package:colonizethis_logic/src/turn/trace/turn_trace_contracts.dart';
+import 'package:colonizethis_logic/src/turn/trace/turn_trace_file_exporter.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  late Directory tempRoot;
+
+  setUp(() async {
+    tempRoot = await Directory.systemTemp.createTemp(
+      'turn_trace_file_exporter_test_',
+    );
+  });
+
+  tearDown(() async {
+    if (await tempRoot.exists()) {
+      await tempRoot.delete(recursive: true);
+    }
+  });
+
+  test(
+    'exports to tmp/turn-traces/{gameId}/turn-{turnNumber}-{timestamp}.json',
+    () async {
+      final exporter = TurnTraceFileExporter(rootDirectory: tempRoot.path);
+      final document = _document(
+        gameId: 'game-42',
+        turnNumber: 7,
+        exportedAt: '2026-05-08T07:10:11.123Z',
+      );
+
+      final file = await exporter.export(document);
+
+      final expectedDirectory = '${tempRoot.path}/turn-traces/game-42';
+      expect(file.path.startsWith(expectedDirectory), isTrue);
+      final fileName = file.uri.pathSegments.last;
+      expect(fileName, 'turn-7-20260508T071011123Z.json');
+      expect(await file.exists(), isTrue);
+    },
+  );
+
+  test(
+    'prunes oldest traces to keep only latest ten files per gameId',
+    () async {
+      final exporter = TurnTraceFileExporter(rootDirectory: tempRoot.path);
+
+      for (var turn = 1; turn <= 12; turn++) {
+        final timestamp = DateTime.utc(2026, 5, 8, 7, 0, turn);
+        final document = _document(
+          gameId: 'game-retain',
+          turnNumber: turn,
+          exportedAt: timestamp.toIso8601String(),
+        );
+        await exporter.export(document);
+      }
+
+      final directory = Directory('${tempRoot.path}/turn-traces/game-retain');
+      final files =
+          directory
+              .listSync()
+              .whereType<File>()
+              .map((file) => file.uri.pathSegments.last)
+              .toList()
+            ..sort();
+      expect(files.length, 10);
+      expect(files.contains('turn-1-20260508T070001000Z.json'), isFalse);
+      expect(files.contains('turn-2-20260508T070002000Z.json'), isFalse);
+      expect(files.contains('turn-12-20260508T070012000Z.json'), isTrue);
+    },
+  );
+}
+
+TurnTraceMergedDocument _document({
+  required String gameId,
+  required int turnNumber,
+  required String exportedAt,
+}) {
+  return TurnTraceMergedDocument(
+    schemaVersion: kTurnTraceSchemaVersionV1,
+    meta: TurnTraceMeta(
+      gameId: gameId,
+      turnNumber: turnNumber,
+      traceEnabled: true,
+      source: 'ctdev',
+      exportedAt: exportedAt,
+    ),
+    ai: const <TurnTraceAiSection>[
+      TurnTraceAiSection(
+        factionId: 'gp-france',
+        state: <String, Object?>{
+          'winningCandidate': <String, Object?>{'id': 'candidate-1'},
+          'topAlternates': <Object?>[],
+          'aggregates': <String, Object?>{},
+        },
+        thresholds: <String, Object?>{
+          'constants': <String, Object?>{},
+          'derived': <String, Object?>{},
+          'effective': <String, Object?>{},
+          'gates': <Object?>[],
+        },
+        outcome: <String, Object?>{
+          'finalAggregatedOrders': <Object?>[],
+          'domainOutputs': <String, Object?>{},
+        },
+      ),
+    ],
+    turnResolution: const TurnTraceResolutionSection(
+      phases: <TurnTracePhaseTrace>[
+        TurnTracePhaseTrace(
+          phaseId: 'movement',
+          beforeState: <String, Object?>{'units': 3},
+          afterState: <String, Object?>{'units': 2},
+          orderEvents: <TurnTraceOrderEvent>[
+            TurnTraceOrderEvent(
+              sequence: 0,
+              orderId: 'order-1',
+              eventType: 'order_applied',
+            ),
+          ],
+        ),
+      ],
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- Add `TurnTraceFileExporter` in logic to emit merged trace JSON files using default path `tmp/turn-traces/{gameId}/turn-{turnNumber}-{timestamp}.json`.
- Add rolling retention pruning to keep only the latest 10 JSON traces per `gameId` directory.
- Update turn-trace SPEC acceptance criteria and add focused exporter tests for path pattern and retention behavior.

## Implemented in this PR
- Logic-side file export utility for merged turn-trace documents.
- Startup-overridable trace root directory support in the exporter API.
- Deterministic timestamped filename generation for trace files.
- Retention pruning of oldest files beyond 10 traces per gameId.
- Unit tests covering export path pattern and retention behavior.

## Deferred for #2218
- App-side `CT_DEBUG_CONSOLE=true` startup gating and ctdev wiring.
- Full AI + phase merge accumulator lifecycle (including pending/resume turn completion semantics).
- End-to-end trace emission trigger at full logical turn completion and full export pipeline integration.
- Additional schema-validation/export lifecycle coverage beyond this filesystem foundation slice.

This PR is a partial implementation slice.

Refs #2218

## Test Plan
- [x] `cd packages/colonizethis_logic && dart test test/turn_trace_file_exporter_test.dart test/turn_trace_schema_validation_test.dart test/turn_phase_runner_phase_overrides_test.dart`

Made with [Cursor](https://cursor.com)