### PR TITLE
Wire debug turn trace export in app/ctdev (slice for #2218)

### DIFF
--- a/app/lib/core/services/game_service.dart
+++ b/app/lib/core/services/game_service.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_app/config/ct_debug_console.dart';
 import 'package:colonizethis_app/package_logger.dart';
 import 'package:colonizethis_app/perf/app_perf_trace.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
@@ -29,10 +30,18 @@ final _mapGenPassLog = packageLogger('tile_map');
 /// Loads/saves games and advances turn. SPEC/project/phase-1: app invokes TurnResolver and persists via colonizethis_save.
 /// Phase 2: createNewGame uses full game-setup pipeline; nextTurn requires cached/persisted map data.
 class GameService {
-  GameService(this._box, this._adapter);
+  GameService(
+    this._box,
+    this._adapter, {
+    bool? turnTraceEnabled,
+    this.turnTraceRootDirectory = 'tmp',
+  }) : _turnTraceEnabled = turnTraceEnabled ?? kCtDebugConsoleEnabled;
 
   final Box<dynamic> _box;
   final GameSaveAdapter _adapter;
+  final bool _turnTraceEnabled;
+  final String turnTraceRootDirectory;
+  final Map<String, _TurnTraceSession> _turnTraceSessionsByGameId = {};
 
   /// Optional app-level bus for [GameToUIEvent] (turn complete, new game, overtures, etc.).
   /// When set, those events are emitted from turn resolution and [createNewGame].
@@ -211,13 +220,15 @@ class GameService {
     final resolvedOrders = aiOrders != null
         ? mergeOrderLists(humanOrders: humanOrders, aiOrders: aiOrders)
         : humanOrders;
-    final result = resolveTurnForGame(
+    final result = _resolveTurnWithTrace(
       game: current,
-      topology: topo,
-      orders: resolvedOrders,
-      tileMapByRegion: tileMaps,
-      eventBus: logicEventBus,
-      onGameEvent: onGameEvent,
+      config: TurnResolverConfig(
+        topology: topo,
+        orders: resolvedOrders,
+        tileMapByRegion: tileMaps,
+        eventBus: logicEventBus,
+        onGameEvent: onGameEvent,
+      ),
     );
     _emitTurnResolutionEvents(result);
     return result;
@@ -233,14 +244,17 @@ class GameService {
     final mapData = _requiredMapDataView(game.id);
     final topo = mapData.combinedTopology;
     final tileMaps = mapData.tileMapByRegion;
-    final result = resumeTurnResolutionWithCallToArmsDecisions(
+    final result = _resolveTurnWithTrace(
       game: game,
-      decisions: decisions,
-      topology: topo,
-      orders: orders,
-      tileMapByRegion: tileMaps,
-      eventBus: logicEventBus,
-      onGameEvent: onGameEvent,
+      config: TurnResolverConfig(
+        topology: topo,
+        orders: orders,
+        tileMapByRegion: tileMaps,
+        eventBus: logicEventBus,
+        onGameEvent: onGameEvent,
+        startFromPhase: TurnPhase.diplomacy,
+        callToArmsDecisions: decisions,
+      ),
     );
     _emitTurnResolutionEvents(result);
     return result;
@@ -251,7 +265,7 @@ class GameService {
   /// When [TurnResolutionComplete], saves the game. SPEC/program/dialogue-system.md.
   TurnResolutionResult resumeOvertureDecisions(
     Game game,
-    List<OvertureOffer> pendingOvertures,
+    List<OvertureOffer> _pendingOvertures,
     List<OvertureDecision> decisions,
     Orders orders, {
     void Function(GameEvent)? onGameEvent,
@@ -259,15 +273,17 @@ class GameService {
     final mapData = _requiredMapDataView(game.id);
     final topo = mapData.combinedTopology;
     final tileMaps = mapData.tileMapByRegion;
-    final result = resumeTurnResolutionWithOvertureDecisions(
+    final result = _resolveTurnWithTrace(
       game: game,
-      pendingOvertures: pendingOvertures,
-      decisions: decisions,
-      topology: topo,
-      orders: orders,
-      tileMapByRegion: tileMaps,
-      eventBus: logicEventBus,
-      onGameEvent: onGameEvent,
+      config: TurnResolverConfig(
+        topology: topo,
+        orders: orders,
+        tileMapByRegion: tileMaps,
+        eventBus: logicEventBus,
+        onGameEvent: onGameEvent,
+        startFromPhase: TurnPhase.diplomacy,
+        overtureDecisions: decisions,
+      ),
     );
     _emitTurnResolutionEvents(result);
     return result;
@@ -283,14 +299,17 @@ class GameService {
     final mapData = _requiredMapDataView(game.id);
     final topo = mapData.combinedTopology;
     final tileMaps = mapData.tileMapByRegion;
-    final result = resumeTurnResolutionWithInterventionDecisions(
+    final result = _resolveTurnWithTrace(
       game: game,
-      decisions: decisions,
-      topology: topo,
-      orders: orders,
-      tileMapByRegion: tileMaps,
-      eventBus: logicEventBus,
-      onGameEvent: onGameEvent,
+      config: TurnResolverConfig(
+        topology: topo,
+        orders: orders,
+        tileMapByRegion: tileMaps,
+        eventBus: logicEventBus,
+        onGameEvent: onGameEvent,
+        startFromPhase: TurnPhase.diplomacy,
+        interventionDecisions: decisions,
+      ),
     );
     _emitTurnResolutionEvents(result);
     return result;
@@ -313,6 +332,95 @@ class GameService {
       tileMapByRegion: tileMapByRegion,
     );
     return requireTurnResolutionComplete(result);
+  }
+
+  TurnResolutionResult _resolveTurnWithTrace({
+    required Game game,
+    required TurnResolverConfig config,
+  }) {
+    if (!_turnTraceEnabled) {
+      return resolveTurnForGameWithConfig(game: game, config: config);
+    }
+    final session = _turnTraceSessionsByGameId.putIfAbsent(
+      game.id,
+      () => _TurnTraceSession(startedAtUtc: DateTime.now().toUtc()),
+    );
+    final tracedConfig = TurnResolverConfig(
+      topology: config.topology,
+      orders: config.orders,
+      tileMapByRegion: config.tileMapByRegion,
+      topologyByRegion: config.topologyByRegion,
+      extractedByPlayerId: config.extractedByPlayerId,
+      defaultAssignments: config.defaultAssignments,
+      defaultAssignmentsByPlayerId: config.defaultAssignmentsByPlayerId,
+      eventBus: config.eventBus,
+      onDialogue: config.onDialogue,
+      onGameEvent: config.onGameEvent,
+      onProductionComplete: config.onProductionComplete,
+      startFromPhase: config.startFromPhase,
+      overtureDecisions: config.overtureDecisions,
+      interventionDecisions: config.interventionDecisions,
+      callToArmsDecisions: config.callToArmsDecisions,
+      phaseHandlerOverrides: config.phaseHandlerOverrides,
+      onPhaseProgress: config.onPhaseProgress,
+      onTurnTracePhase: session.phases.add,
+    );
+    final result = resolveTurnForGameWithConfig(
+      game: game,
+      config: tracedConfig,
+    );
+    if (result is TurnResolutionComplete) {
+      _exportTurnTrace(
+        gameAtResolutionStart: game,
+        turnEndState: result.game,
+        phases: session.phases,
+        turnStartAt: session.startedAtUtc,
+      );
+      _turnTraceSessionsByGameId.remove(game.id);
+    }
+    return result;
+  }
+
+  void _exportTurnTrace({
+    required Game gameAtResolutionStart,
+    required Game turnEndState,
+    required List<TurnTracePhaseTrace> phases,
+    required DateTime turnStartAt,
+  }) {
+    final now = DateTime.now().toUtc();
+    final document = TurnTraceMergedDocument(
+      schemaVersion: kTurnTraceSchemaVersionV1,
+      meta: TurnTraceMeta(
+        gameId: gameAtResolutionStart.id,
+        turnNumber: gameAtResolutionStart.worldState.turnState.turnNumber,
+        traceEnabled: true,
+        source: 'app',
+        exportedAt: now.toIso8601String(),
+        turnStartAt: turnStartAt.toIso8601String(),
+        turnEndAt: now.toIso8601String(),
+      ),
+      ai: const <TurnTraceAiSection>[],
+      turnResolution: TurnTraceResolutionSection(
+        phases: List<TurnTracePhaseTrace>.unmodifiable(phases),
+      ),
+    );
+    TurnTraceFileExporter(rootDirectory: turnTraceRootDirectory)
+        .export(document)
+        .then((file) {
+          packageLogger('logic').d(
+            'logic: turn_trace_exported gameId=${gameAtResolutionStart.id} '
+            'turn=${gameAtResolutionStart.worldState.turnState.turnNumber} '
+            'nextTurn=${turnEndState.worldState.turnState.turnNumber} '
+            'path=${file.path}',
+          );
+        })
+        .catchError((Object error, StackTrace stackTrace) {
+          packageLogger('logic').e(
+            'logic: turn_trace_export_failed gameId=${gameAtResolutionStart.id}',
+            error: error,
+            stackTrace: stackTrace,
+          );
+        });
   }
 
   /// Number of coarse progress steps reported by [createNewGameAsync]. SPEC/ui/game-initializing.md.
@@ -697,4 +805,11 @@ class GameService {
   void handleExternallyResolvedTurnResult(TurnResolutionResult result) {
     _emitTurnResolutionEvents(result);
   }
+}
+
+class _TurnTraceSession {
+  _TurnTraceSession({required this.startedAtUtc});
+
+  final DateTime startedAtUtc;
+  final List<TurnTracePhaseTrace> phases = <TurnTracePhaseTrace>[];
 }

--- a/app/test/game_service_cache_test.dart
+++ b/app/test/game_service_cache_test.dart
@@ -1,4 +1,5 @@
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -155,5 +156,64 @@ void main() {
       final g = service.createNewGame(config: config);
       expect(g.id, startsWith('game_'));
     });
+
+    test(
+      'runTurnResolution exports merged turn trace when debug trace is enabled',
+      () async {
+        final traceRoot = await Directory.systemTemp.createTemp(
+          'ct_turn_trace_app_',
+        );
+        addTearDown(() async {
+          if (await traceRoot.exists()) {
+            await traceRoot.delete(recursive: true);
+          }
+        });
+        final traceService = GameService(
+          box,
+          GameSaveAdapter(),
+          turnTraceEnabled: true,
+          turnTraceRootDirectory: traceRoot.path,
+        );
+        final config = GameSetupConfig(
+          selectedGreatPowerIds: ['england'],
+          continentCount: 1,
+          minorNationCount: 0,
+          tribeCount: 1,
+          numProvincesOldWorld: 3,
+          numProvincesNewWorld: 2,
+        );
+        final game = traceService.createNewGame(
+          id: 'trace_app_game',
+          config: config,
+        );
+
+        final result = traceService.runTurnResolution(
+          game,
+          orders: const Orders(),
+        );
+        expect(result, isA<TurnResolutionComplete>());
+
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        final traceDir = Directory('${traceRoot.path}/turn-traces/${game.id}');
+        expect(await traceDir.exists(), isTrue);
+        final files = traceDir
+            .listSync()
+            .whereType<File>()
+            .where((file) => file.path.endsWith('.json'))
+            .toList();
+        expect(files.length, 1);
+        final payload =
+            jsonDecode(await files.single.readAsString())
+                as Map<String, dynamic>;
+        expect(payload['schemaVersion'], 'v1');
+        final meta = payload['meta'] as Map<String, dynamic>;
+        expect(meta['source'], 'app');
+        expect(meta['traceEnabled'], isTrue);
+        final phases =
+            ((payload['turnResolution'] as Map<String, dynamic>)['phases']
+                as List<dynamic>);
+        expect(phases, isNotEmpty);
+      },
+    );
   });
 }

--- a/ctdev/lib/sim_game_controller.dart
+++ b/ctdev/lib/sim_game_controller.dart
@@ -3,7 +3,8 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_logic/src/ai/ai_planner.dart'
     show generateOrdersForGame, generateOrdersForPlayer;
-import 'package:colonizethis_logic/src/ai/sim_game_ai.dart' show defaultSimGameAi;
+import 'package:colonizethis_logic/src/ai/sim_game_ai.dart'
+    show defaultSimGameAi;
 import 'package:colonizethis_logic/src/setup/hidden_agenda_assignment.dart'
     show assignHiddenAgendasForGame;
 import 'package:colonizethis_map/colonizethis_map.dart';
@@ -61,11 +62,14 @@ class SimGameController {
     required int baseSeed,
     this.useSimGameAi = true,
     this.useFullAI = false,
-  })  : _game = _forceAllGpsAiControlled(
-            _ensureAiSeedsForSim(initialGame, baseSeed)),
-        _topology = topology,
-        _tileMapByRegion = tileMapByRegion,
-        _baseSeed = baseSeed {
+    this.turnTraceEnabled = false,
+    this.turnTraceRootDirectory = 'tmp',
+  }) : _game = _forceAllGpsAiControlled(
+         _ensureAiSeedsForSim(initialGame, baseSeed),
+       ),
+       _topology = topology,
+       _tileMapByRegion = tileMapByRegion,
+       _baseSeed = baseSeed {
     if (!useSimGameAi && useFullAI) {
       _game = assignHiddenAgendasForGame(_game);
     }
@@ -81,11 +85,14 @@ class SimGameController {
 
   /// When true and useSimGameAi is false, use Phase 6 full AI (personalities, hidden agendas, naval orders). When false, use Phase 4 simple AI.
   final bool useFullAI;
+  final bool turnTraceEnabled;
+  final String turnTraceRootDirectory;
 
   /// Base seed used for sim; also fallback for turnSeed when a GP has no aiSeed.
   int get baseSeed => _baseSeed;
 
   final Map<String, Orders> _pendingOrdersByPlayerId = {};
+
   /// When using full AI, economy plans per player for production phase. Cleared on resolve.
   final Map<String, EconomyPlan> _pendingEconomyPlansByPlayerId = {};
   final List<SimOrderHistoryEntry> _orderHistory = [];
@@ -97,17 +104,15 @@ class SimGameController {
   MapTopology get topology => _topology;
   Map<String, TileMapResult> get tileMapByRegion => _tileMapByRegion;
   Map<String, MapTopology> get topologyByRegion => {
-        'oldWorld': MapTopology(
-          nodes:
-              _topology.nodes.where((n) => n.regionId == 'oldWorld').toList(),
-          edges: _topology.edges,
-        ),
-        'newWorld': MapTopology(
-          nodes:
-              _topology.nodes.where((n) => n.regionId == 'newWorld').toList(),
-          edges: _topology.edges,
-        ),
-      };
+    'oldWorld': MapTopology(
+      nodes: _topology.nodes.where((n) => n.regionId == 'oldWorld').toList(),
+      edges: _topology.edges,
+    ),
+    'newWorld': MapTopology(
+      nodes: _topology.nodes.where((n) => n.regionId == 'newWorld').toList(),
+      edges: _topology.edges,
+    ),
+  };
 
   List<SimOrderHistoryEntry> get orderHistory =>
       List.unmodifiable(_orderHistory);
@@ -294,7 +299,9 @@ class SimGameController {
         navalByPlayer.putIfAbsent(pid, () => <NavalMoveOrder>[]).addAll(list);
       });
       o.navalMissionOrdersByPlayerId.forEach((pid, list) {
-        missionByPlayer.putIfAbsent(pid, () => <NavalMissionOrder>[]).addAll(list);
+        missionByPlayer
+            .putIfAbsent(pid, () => <NavalMissionOrder>[])
+            .addAll(list);
       });
     }
 
@@ -316,17 +323,64 @@ class SimGameController {
     _recordOrderHistory(orders);
     _lastTurnCombatSummaries.clear();
     final before = _game;
-    final next = requireTurnResolutionComplete(validateOrdersAndResolveTurn(
-      game: _game,
-      topology: _topology,
-      orders: orders,
-      tileMapByRegion: _tileMapByRegion,
-      defaultAssignments: const [],
-      defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
-      onGameEvent: _recordCombatGameEvent,
-    ));
+    final phaseTraces = <TurnTracePhaseTrace>[];
+    final next = requireTurnResolutionComplete(
+      validateOrdersAndResolveTurn(
+        game: _game,
+        topology: _topology,
+        orders: orders,
+        tileMapByRegion: _tileMapByRegion,
+        defaultAssignments: const [],
+        defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+        onGameEvent: _recordCombatGameEvent,
+        onTurnTracePhase: turnTraceEnabled ? phaseTraces.add : null,
+      ),
+    );
     _game = next;
+    if (turnTraceEnabled) {
+      _exportTurnTrace(before: before, after: next, phases: phaseTraces);
+    }
     _recordTurnLog(before: before, after: next);
+  }
+
+  void _exportTurnTrace({
+    required Game before,
+    required Game after,
+    required List<TurnTracePhaseTrace> phases,
+  }) {
+    final now = DateTime.now().toUtc();
+    final document = TurnTraceMergedDocument(
+      schemaVersion: kTurnTraceSchemaVersionV1,
+      meta: TurnTraceMeta(
+        gameId: before.id,
+        turnNumber: before.worldState.turnState.turnNumber,
+        traceEnabled: true,
+        source: 'ctdev',
+        exportedAt: now.toIso8601String(),
+        turnEndAt: now.toIso8601String(),
+      ),
+      ai: const <TurnTraceAiSection>[],
+      turnResolution: TurnTraceResolutionSection(
+        phases: List<TurnTracePhaseTrace>.unmodifiable(phases),
+      ),
+    );
+    TurnTraceFileExporter(rootDirectory: turnTraceRootDirectory)
+        .export(document)
+        .then((file) {
+          _ctdevSimLog.d(
+            'logic: turn_trace_exported gameId=${before.id} '
+            'turn=${before.worldState.turnState.turnNumber} '
+            'nextTurn=${after.worldState.turnState.turnNumber} '
+            'path=${file.path}',
+          );
+        })
+        .catchError((Object error, StackTrace stackTrace) {
+          _ctdevSimLog.e(
+            'logic: turn_trace_export_failed gameId=${before.id}',
+            error: error,
+            stackTrace: stackTrace,
+          );
+        });
   }
 
   void _recordCombatGameEvent(GameEvent event) {
@@ -368,10 +422,12 @@ class SimGameController {
 
     final provinceNamesByRegionAndId = <String, String>{};
     for (final p in _game.worldState.oldWorld.provinces) {
-      provinceNamesByRegionAndId['${p.regionId}|${p.id}'] = p.displayName ?? p.id;
+      provinceNamesByRegionAndId['${p.regionId}|${p.id}'] =
+          p.displayName ?? p.id;
     }
     for (final p in _game.worldState.newWorld.provinces) {
-      provinceNamesByRegionAndId['${p.regionId}|${p.id}'] = p.displayName ?? p.id;
+      provinceNamesByRegionAndId['${p.regionId}|${p.id}'] =
+          p.displayName ?? p.id;
     }
     String provinceLabelInRegion(String regionId, String id) =>
         provinceNamesByRegionAndId['$regionId|$id'] ?? id;
@@ -382,13 +438,16 @@ class SimGameController {
       final builds = orders.buildUnitOrdersByPlayerId[playerId] ?? const [];
       final works = orders.workOrdersByPlayerId[playerId] ?? const [];
       final diplo =
-          orders.diplomaticOrdersByPlayerId[playerId] ?? const <DiplomaticOrder>[];
+          orders.diplomaticOrdersByPlayerId[playerId] ??
+          const <DiplomaticOrder>[];
       final research =
           orders.researchOrdersByPlayerId[playerId] ?? const <ResearchOrder>[];
       final naval =
-          orders.navalMoveOrdersByPlayerId[playerId] ?? const <NavalMoveOrder>[];
+          orders.navalMoveOrdersByPlayerId[playerId] ??
+          const <NavalMoveOrder>[];
       final mission =
-          orders.navalMissionOrdersByPlayerId[playerId] ?? const <NavalMissionOrder>[];
+          orders.navalMissionOrdersByPlayerId[playerId] ??
+          const <NavalMissionOrder>[];
 
       if (moves.isEmpty &&
           builds.isEmpty &&
@@ -402,25 +461,35 @@ class SimGameController {
 
       final engine = OrderEngine(
         initialOrders: Orders(
-          moveOrdersByPlayerId:
-              moves.isEmpty ? const {} : {playerId: List.of(moves)},
-          buildUnitOrdersByPlayerId:
-              builds.isEmpty ? const {} : {playerId: List.of(builds)},
-          workOrdersByPlayerId:
-              works.isEmpty ? const {} : {playerId: List.of(works)},
-          diplomaticOrdersByPlayerId:
-              diplo.isEmpty ? const {} : {playerId: List.of(diplo)},
-          researchOrdersByPlayerId:
-              research.isEmpty ? const {} : {playerId: List.of(research)},
-          navalMoveOrdersByPlayerId:
-              naval.isEmpty ? const {} : {playerId: List.of(naval)},
-          navalMissionOrdersByPlayerId:
-              mission.isEmpty ? const {} : {playerId: List.of(mission)},
+          moveOrdersByPlayerId: moves.isEmpty
+              ? const {}
+              : {playerId: List.of(moves)},
+          buildUnitOrdersByPlayerId: builds.isEmpty
+              ? const {}
+              : {playerId: List.of(builds)},
+          workOrdersByPlayerId: works.isEmpty
+              ? const {}
+              : {playerId: List.of(works)},
+          diplomaticOrdersByPlayerId: diplo.isEmpty
+              ? const {}
+              : {playerId: List.of(diplo)},
+          researchOrdersByPlayerId: research.isEmpty
+              ? const {}
+              : {playerId: List.of(research)},
+          navalMoveOrdersByPlayerId: naval.isEmpty
+              ? const {}
+              : {playerId: List.of(naval)},
+          navalMissionOrdersByPlayerId: mission.isEmpty
+              ? const {}
+              : {playerId: List.of(mission)},
         ),
       );
 
-      final results =
-          engine.validatePlayerOrdersWithContext(_game, _topology, playerId);
+      final results = engine.validatePlayerOrdersWithContext(
+        _game,
+        _topology,
+        playerId,
+      );
       var resultIndex = 0;
 
       OrderValidationResult nextResult() {
@@ -436,9 +505,7 @@ class SimGameController {
 
       for (final o in moves) {
         final unit = unitsById[o.unitId];
-        final unitLabel = unit != null
-            ? '${unit.id} (${unit.type})'
-            : o.unitId;
+        final unitLabel = unit != null ? '${unit.id} (${unit.type})' : o.unitId;
         final regionId = unit != null
             ? (Unit.regionIdFromTileKey(unit.tileKey) ?? 'oldWorld')
             : 'oldWorld';
@@ -446,8 +513,7 @@ class SimGameController {
             ? provinceLabelInRegion(regionId, unit.locationProvinceId)
             : '?';
         final destTile = o.destinationTileKey;
-        final destRegion =
-            Unit.regionIdFromTileKey(destTile) ?? regionId;
+        final destRegion = Unit.regionIdFromTileKey(destTile) ?? regionId;
         final destProv = Unit.provinceIdFromTileKey(destTile);
         final dest = destProv != null
             ? provinceLabelInRegion(destRegion, destProv)
@@ -485,22 +551,26 @@ class SimGameController {
 
       for (final o in works) {
         final unit = unitsById[o.unitId];
-        final unitLabel = unit != null
-            ? '${unit.id} (${unit.type})'
-            : o.unitId;
+        final unitLabel = unit != null ? '${unit.id} (${unit.type})' : o.unitId;
         final unitRegion = unit != null
             ? (Unit.regionIdFromTileKey(unit.tileKey) ?? 'oldWorld')
             : 'oldWorld';
-        final targetRegion = Unit.regionIdFromTileKey(o.targetTileKey) ?? unitRegion;
+        final targetRegion =
+            Unit.regionIdFromTileKey(o.targetTileKey) ?? unitRegion;
         final currentProvince = unit != null
             ? provinceLabelInRegion(unitRegion, unit.locationProvinceId)
             : '?';
         final targetProvince = provinceLabelInRegion(
-            targetRegion, Unit.provinceIdFromTileKey(o.targetTileKey) ?? '');
-        final currentTile = (unit != null && unit.tileKey != null && unit.tileKey!.isNotEmpty)
+          targetRegion,
+          Unit.provinceIdFromTileKey(o.targetTileKey) ?? '',
+        );
+        final currentTile =
+            (unit != null && unit.tileKey != null && unit.tileKey!.isNotEmpty)
             ? formatTileKey(unit.tileKey!)
             : '?';
-        final targetTile = o.targetTileKey.isNotEmpty ? formatTileKey(o.targetTileKey) : '?';
+        final targetTile = o.targetTileKey.isNotEmpty
+            ? formatTileKey(o.targetTileKey)
+            : '?';
         final validation = nextResult();
         _orderHistory.add(
           SimOrderHistoryEntry(
@@ -508,7 +578,8 @@ class SimGameController {
             playerId: playerId,
             playerName: player.displayName,
             orderType: 'work',
-            summary: 'Work $unitLabel at $currentTile ($currentProvince) → ${o.target} at $targetTile ($targetProvince)',
+            summary:
+                'Work $unitLabel at $currentTile ($currentProvince) → ${o.target} at $targetTile ($targetProvince)',
             status: validation.status,
             reason: validation.reason,
           ),
@@ -628,30 +699,27 @@ class SimGameController {
 String? _combatEventUiLine(GameEvent event) {
   switch (event) {
     case CombatResultEvent(
-        :final provinceId,
-        :final attackerId,
-        :final defenderId,
-        :final winnerId,
-        :final casualties,
-      ):
+      :final provinceId,
+      :final attackerId,
+      :final defenderId,
+      :final winnerId,
+      :final casualties,
+    ):
       final cas = casualties.isEmpty ? '' : ' casualties=$casualties';
       return 'Land combat $provinceId: $attackerId vs $defenderId → '
           '$winnerId$cas';
     case NavalCombatResultEvent(
-        :final seaZoneId,
-        :final side1OwnerId,
-        :final side2OwnerId,
-        :final outcomeName,
-        :final winnerOwnerId,
-        :final side1Retreated,
-        :final side2Retreated,
-      ):
+      :final seaZoneId,
+      :final side1OwnerId,
+      :final side2OwnerId,
+      :final outcomeName,
+      :final winnerOwnerId,
+      :final side1Retreated,
+      :final side2Retreated,
+    ):
       final w = winnerOwnerId != null ? ' winner=$winnerOwnerId' : '';
       final r = (side1Retreated || side2Retreated)
-          ? ' retreat=${[
-              if (side1Retreated) 'side1',
-              if (side2Retreated) 'side2',
-            ].join(',')}'
+          ? ' retreat=${[if (side1Retreated) 'side1', if (side2Retreated) 'side2'].join(',')}'
           : '';
       return 'Naval combat sea $seaZoneId: $side1OwnerId vs '
           '$side2OwnerId → $outcomeName$w$r';

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -17,6 +17,7 @@ import 'turn_order_acceptance.dart';
 import 'turn_phase_runner.dart';
 import 'turn_resolution_result.dart';
 import 'turn_resolution_sequence.dart';
+import 'trace/turn_trace_contracts.dart';
 export 'turn_resolution_sequence.dart';
 import 'turn_resolver_config.dart';
 export 'turn_resolver_config.dart';
@@ -74,6 +75,7 @@ TurnResolutionResult resolveTurnForGameFromOrderEngine({
   GameEventBus? eventBus,
   void Function(DialogueEvent)? onDialogue,
   void Function(GameEvent)? onGameEvent,
+  void Function(TurnTracePhaseTrace phaseTrace)? onTurnTracePhase,
 }) {
   final merged = mergeOrderLists(
     humanOrders: orderEngine.orders,
@@ -91,6 +93,7 @@ TurnResolutionResult resolveTurnForGameFromOrderEngine({
     extractedByPlayerId: extractedByPlayerId,
     defaultAssignments: defaultAssignments,
     defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+    onTurnTracePhase: onTurnTracePhase,
   );
 }
 
@@ -108,6 +111,7 @@ TurnResolutionResult validateOrdersAndResolveTurn({
   GameEventBus? eventBus,
   void Function(DialogueEvent)? onDialogue,
   void Function(GameEvent)? onGameEvent,
+  void Function(TurnTracePhaseTrace phaseTrace)? onTurnTracePhase,
 }) {
   final engine = OrderEngine(initialOrders: orders);
   final filtered = filterAcceptedOrdersForAllPlayers(
@@ -130,6 +134,7 @@ TurnResolutionResult validateOrdersAndResolveTurn({
     extractedByPlayerId: extractedByPlayerId,
     defaultAssignments: defaultAssignments,
     defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+    onTurnTracePhase: onTurnTracePhase,
   );
 }
 
@@ -158,6 +163,7 @@ TurnResolutionResult resolveTurnForGame({
   List<CallToArmsDecision>? callToArmsDecisions,
   void Function(TurnPhase phase, TurnPhaseProgressMarker marker)?
   onPhaseProgress,
+  void Function(TurnTracePhaseTrace phaseTrace)? onTurnTracePhase,
 }) {
   return resolveTurnForGameWithConfig(
     game: game,
@@ -178,6 +184,7 @@ TurnResolutionResult resolveTurnForGame({
       interventionDecisions: interventionDecisions,
       callToArmsDecisions: callToArmsDecisions,
       onPhaseProgress: onPhaseProgress,
+      onTurnTracePhase: onTurnTracePhase,
     ),
   );
 }


### PR DESCRIPTION
## Summary
- wire debug-only merged turn-trace export in `GameService`, gated by `CT_DEBUG_CONSOLE` (or explicit constructor override), with pending/resume phase accumulation and export-on-complete behavior
- wire ctdev `SimGameController` to emit merged turn traces for completed turns when enabled, using the same schema contracts/exporter pathing
- add app test coverage for trace export artifact generation and expose `onTurnTracePhase` plumbing through turn resolver entry points used by ctdev

## Scope for this PR
- Partial slice for #2218 focused on exporting merged turn-resolution phase traces and host wiring.
- This PR does **not** implement AI decision trace payload capture (`state/thresholds/outcome`) yet; exports currently use an empty `ai` array.
- This PR does **not** add quick-battle tactical internals to AI trace sections yet.

## AC coverage in this slice
- covered now:
  - app debug gate integration (`CT_DEBUG_CONSOLE`) for trace export enablement path
  - merged trace file emission using `tmp/turn-traces/{gameId}/turn-{turnNumber}-{timestamp}.json`
  - retention/path behavior remains via existing `TurnTraceFileExporter` tests
  - pending/resume phase accumulation in app service until terminal completion
  - ctdev trace export wiring with shared schema contracts
- deferred to follow-up slices:
  - full AI matrix payloads (`state`, `thresholds`, `outcome` content)
  - order-level event sequence capture in `orderEvents`
  - performance budget instrumentation/assertions

## Tests
- `dart/flutter test` in `app`: `test/game_service_cache_test.dart`
- `dart/flutter test` in `packages/colonizethis_logic`:
  - `test/turn_phase_runner_phase_overrides_test.dart`
  - `test/turn_trace_schema_validation_test.dart`
  - `test/turn_trace_file_exporter_test.dart`

Refs #2218

Made with [Cursor](https://cursor.com)