### PR TITLE
Require requirement clarification in create-github-issue skill

### DIFF
--- a/.cursor/skills/create-github-issue/SKILL.md
+++ b/.cursor/skills/create-github-issue/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: create-github-issue
-description: Turns an informal issue report into a structured GitHub issue with reproduction steps, expected vs actual behavior, read-only SPEC/code investigation, and a proposed fix scope—without modifying the repository. Attempts to open the issue via GitHub CLI (gh); falls back to a paste-ready draft if gh is missing, unauthenticated, or creation fails. Use when the user describes a bug, regression, or gap and wants a filed issue, triage narrative, or fix direction before implementation.
+description: |-
+  Turns an informal issue report into a structured GitHub issue with reproduction steps, expected vs actual behavior, read-only SPEC/code investigation, and a proposed fix scope—without modifying the repository.
+
+  Always clarify requirements with the user first by reading relevant specs/code, analyzing the report against current behavior, and presenting requirement clarifications as a numbered list.
+
+  Attempts to open the issue via GitHub CLI (gh); falls back to a paste-ready draft if gh is missing, unauthenticated, or creation fails.
+
+  Use when the user describes a bug, regression, or gap and wants a filed issue, triage narrative, or fix direction before implementation.
 ---
 
 # Create a GitHub issue from a user report (read-only)
@@ -8,7 +15,7 @@ description: Turns an informal issue report into a structured GitHub issue with 
 ## Scope (strict)
 
 - **Do not** edit, create, or delete files in the repo: no code, specs, config, tests, or tooling changes.
-- **Do** clarify requirements in chat if needed, **read** specs and code to investigate, then **try to create the issue on GitHub** (see below). If creation fails, **output** the full title and body so the user can file it manually.
+- **Do** always clarify requirements in chat before drafting or filing the issue: **read** relevant specs/code, analyze against the user's stated problem/request, then present requirement clarifications in a **numbered list** and resolve unknowns with the user. After clarification, **try to create the issue on GitHub** (see below). If creation fails, **output** the full title and body so the user can file it manually.
 
 If the user asks to implement the fix, stop following this skill and switch to normal implementation workflow (e.g. AGENTS.md, CONTRIBUTING.md).
 
@@ -16,8 +23,8 @@ If the user asks to implement the fix, stop following this skill and switch to n
 
 The user provides a **narrative report** (bug, wrong behavior, missing feature, performance concern) and wants:
 
-- A **clear issue** (repro, expected, actual), and/or  
-- **Investigation** against project specs and implementation, and/or  
+- A **clear issue** (repro, expected, actual), and/or
+- **Investigation** against project specs and implementation, and/or
 - A **proposed fix** (approach and likely touch points), **without** you changing the tree.
 
 ## Workflow
@@ -35,15 +42,26 @@ From the user message(s), extract or explicitly mark as **unknown**:
 
 If any of these are ambiguous, ask **short** clarifying questions before finalizing the draft. Do not invent precise repro steps.
 
-### 2. Investigate (read-only)
+### 2. Requirement clarification (mandatory)
+
+Before drafting issue content, do a targeted read-only investigation and then clarify requirements with the user:
+
+1. Read the most relevant SPEC and code paths tied to the report.
+2. Compare user-stated behavior/request vs current intended/implemented behavior.
+3. Present a **numbered list** of requirement clarifications in chat (each item should be one requirement decision, ambiguity, or conflict).
+4. Ask for user confirmation/corrections on that numbered list.
+
+Do not proceed to draft/create the issue until this clarification step is completed.
+
+### 3. Investigate (read-only)
 
 - **Specs:** Trace the reported behavior to authoritative docs. For ColonizeThis: GDD under `SPEC/game/`, TDD under `SPEC/program/`, plus `SPEC/ai/` and `SPEC/ui/` as needed (see project SPEC-first rules). Quote or summarize **specific files/sections** that align or contradict the report.
-- **Implementation:** Search and read relevant modules. Map **symptoms → likely code paths** (files, types, key functions). Stay factual; label inference as hypothesis when not proven.
+- **Implementation:** Search and read relevant modules. Map **symptoms -> likely code paths** (files, types, key functions). Stay factual; label inference as hypothesis when not proven.
 - **Tests:** Note existing tests that would fail or are missing for this scenario (read-only).
 
 Do not run destructive commands; optional **read-only** checks (e.g. search, `git show`, tests in read-only mode) are fine only if they do not require changing files—prefer static analysis when unsure.
 
-### 3. Proposed fix (design only)
+### 4. Proposed fix (design only)
 
 Output a **concrete but unapplied** plan:
 
@@ -54,9 +72,9 @@ Output a **concrete but unapplied** plan:
 - **Risks / edge cases**
 - **Suggested acceptance criteria** (testable bullets the implementer can paste into the issue)
 
-### 4. Build title and body
+### 5. Build title and body
 
-Prepare a concise **title** (≤~80 chars, imperative or clear symptom) and **body** markdown. Use this structure:
+Prepare a concise **title** (<=~80 chars, imperative or clear symptom) and **body** markdown. Use this structure:
 
 ```markdown
 ## Summary
@@ -90,7 +108,7 @@ Prepare a concise **title** (≤~80 chars, imperative or clear symptom) and **bo
 
 **Labels / milestones:** Add with `gh` only if the user asked or labels are obvious (`--label`); otherwise omit or suggest in chat after success.
 
-### 5. Create the issue (primary path)
+### 6. Create the issue (primary path)
 
 **Attempt to create the issue directly** after the draft is ready:
 
@@ -103,7 +121,7 @@ Prepare a concise **title** (≤~80 chars, imperative or clear symptom) and **bo
 
 Typical failure cases (non-exhaustive): `gh` not in PATH, `gh auth status` shows not logged in, rate limit, network error, missing `repo` scope, no permission to create issues on the repo.
 
-### 6. Fallback when creation fails
+### 7. Fallback when creation fails
 
 If `gh issue create` does not succeed:
 
@@ -118,6 +136,7 @@ Always preserve the complete draft on fallback; it is the backup deliverable.
 - Separate **facts** (from code/specs) from **hypotheses** and user report.
 - Prefer **minimal repro**; avoid dumping unrelated investigation.
 - If the report conflicts with SPEC, call that out explicitly (spec bug vs implementation bug vs misunderstanding).
+- Requirement clarifications are always shown to the user as a **numbered list** and confirmed before issue drafting/filing.
 
 ## Related
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Skills live under `.cursor/skills/<name>/SKILL.md`. When a skill matches the tas
 
 | Skill | Use when |
 |-------|----------|
-| `create-github-issue` | Turn an informal bug/report into a structured GitHub issue (read-only repo work; may use `gh`). |
+| `create-github-issue` | Turn an informal bug/report into a structured GitHub issue after read-only SPEC/code analysis and mandatory numbered requirement clarifications with the user (read-only repo work; may use `gh`). |
 | `refactoring-opportunity-github-issue` | Scan `app/` or one `packages/*` package on latest `origin/dev`, de-duplicate against open GitHub issues, match `.cursor/rules`, propose focused refactors + CI (extend existing AST/analyzer gates first), draft/file a structured issue (OpenCode copy under `.opencode/skills/`). |
 | `clean-local-branches` | Prune local branch refs, keeping `dev` and open-PR heads; never delete remote branches. |
 | `fix-pr` | Unblock a PR by fixing failing checks and quality gates. |


### PR DESCRIPTION
## Summary
- require `create-github-issue` to always perform read-only spec/code analysis and present requirement clarifications to the user as a numbered list before drafting/filing
- update the skill workflow to include a mandatory requirement-clarification step and explicit quality-bar check for numbered confirmation
- align `AGENTS.md` skill catalog wording with the updated behavior

## Test plan
- [x] Verify `.cursor/skills/create-github-issue/SKILL.md` includes the new mandatory clarification step and numbered-list requirement
- [x] Verify `AGENTS.md` description for `create-github-issue` matches the new workflow
- [x] Confirm repository has only intended doc changes in this PR

Made with [Cursor](https://cursor.com)