### PR TITLE
Remove no-op quality workflow gates

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -24,7 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
-      opencode_scope: ${{ steps.filter.outputs.opencode_scope }}
       infra_daytona: ${{ steps.filter.outputs.infra_daytona }}
     steps:
       - name: Checkout
@@ -51,15 +50,6 @@ jobs:
               - 'tool/embed_tech_effect_summary.dart'
               - 'tool/generate_order_engine_slots.dart'
               - 'tool/verify_order_engine_codegen.sh'
-            # True when any changed path is outside repo-root dot-directories (CI/editor meta). OpenCode
-            # review is skipped when the PR only touches those paths (e.g. .github, .cursor).
-            opencode_scope:
-              - '**'
-              - '!.cursor/**'
-              - '!.github/**'
-              - '!.vscode/**'
-              - '!.idea/**'
-              - '!.husky/**'
             infra_daytona:
               - 'infra/**'
 
@@ -165,8 +155,8 @@ jobs:
           path: app-test-cache.tar.gz
           retention-days: 2
 
-  # Linux compile gate: parallel to `app_tests_shard` (same cache). Not wired into `app_e2e_linux`
-  # (e2e job is intentionally a no-op); add this job to branch protection if merges must wait on it.
+  # Linux compile gate: parallel to `app_tests_shard` (same cache).
+  # Add this job to branch protection if merges must wait on it.
   app_build_linux:
     name: App Linux desktop build (release)
     needs: [changes, app_tests_cache]
@@ -316,26 +306,6 @@ jobs:
           name: app-lcov-shard-${{ matrix.shard }}
           path: app/coverage/lcov.shard${{ matrix.shard }}.info
           retention-days: 2
-
-  # No integration_test runs: single skip step (see SPEC/program/e2e-integration-tests.md).
-  app_e2e_linux:
-    name: App e2e (Linux desktop + xvfb)
-    needs: [changes, app_tests_shard]
-    if: |
-      always() &&
-      needs.changes.result == 'success' &&
-      (
-        needs.changes.outputs.tests != 'true' ||
-        needs.app_tests_shard.result == 'success'
-      )
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    steps:
-      - name: Skip app e2e (temporarily disabled for CI stability/speed)
-        run: |
-          echo "app_e2e_linux gate intentionally skipped."
-          echo "Reason: e2e tests are currently flaky and too slow for PR quality pace."
-          echo "Behavior: this job remains as a required gate but does not execute integration_test suites."
 
   quality:
     needs: changes
@@ -585,81 +555,3 @@ jobs:
         if: needs.changes.outputs.tests == 'true'
         run: tool/check_coverage_threshold.sh 80 app
 
-  # OpenCode post-quality review: same workflow as Quality; runs only for same-repo PRs into dev after
-  # app_e2e_linux succeeds (currently a no-op required gate), when the PR changes paths outside dot-prefixed meta dirs (see changes.opencode_scope),
-  # and when either the PR has the `help wanted` label or more than 10 files changed (otherwise skipped).
-  # CI currently does not invoke OpenCode or enforce PR-comment verdicts (no-op); prompt is preserved on the job below.
-  opencode_review:
-    name: OpenCode review
-    needs: [changes, app_e2e_linux]
-    if: >-
-      github.base_ref == 'dev' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      needs.changes.result == 'success' &&
-      needs.changes.outputs.opencode_scope == 'true' &&
-      needs.app_e2e_linux.result == 'success' &&
-      (contains(github.event.pull_request.labels.*.name, 'help wanted') || github.event.pull_request.changed_files > 10)
-    runs-on: ubuntu-latest
-    # Large PRs can exceed 45m (tooling + diff reads + a long sticky-comment PATCH); cancellation fails the verdict gate.
-    timeout-minutes: 90
-    permissions:
-      pull-requests: write
-      issues: write
-      id-token: write
-      # OpenCode ends with `git push` when the workspace has local commits; the checkout
-      # token must allow contents writes and stay configured for HTTPS (persist-credentials).
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: true
-
-      # OpenCode invocation disabled (flaky); gate remains defined for branch protection / re-enable.
-      # Original model: ${{ vars.OPENCODE_REVIEW_MODEL || 'opencode-go/minimax-m2.7' }} (see anomalyco/opencode/github@latest `with.model`).
-      - name: Run OpenCode (PR review)
-        run: |
-          echo "OpenCode review gate is a no-op (OpenCode not invoked in CI)."
-        env:
-          # Preserved verbatim for restore; not passed to any runner service while disabled.
-          OPENCODE_REVIEW_PROMPT_PRESERVED: |
-            You are the final OpenCode reviewer for this pull request after the app_e2e_linux quality gate passed.
-
-            The repository is checked out in the workspace. Read and apply these files in full:
-            - .cursor/rules/colonizethis-code-review.mdc
-            - .cursor/rules/colonizethis-component-structure.mdc
-
-            Also verify:
-            - The PR diff implements what linked closing issues and the PR description request (use GitHub context available to you).
-            - SPEC documents under SPEC/ stay aligned with code for behavior touched by this diff.
-
-            Deliverables (must all be satisfied):
-            1) Put **all** detailed review text in **one** GitHub pull request **issue comment** on **this** pull request (use the PR number from the active review context, not linked issue numbers). Do not rely on CI or workflow logs for the long-form review; the PR comment is the source of truth for details.
-
-            2) **Single sticky comment only**: If a PR issue comment already exists whose body contains the literal HTML marker `<!-- ct-opencode-quality-review -->`, **edit that same comment** with your updated review (keep the marker in the updated body). If none exists, create **one** new PR issue comment that includes that marker exactly once. **Do not** post any **other** new issue comments on this PR for this review (no follow-up “review complete”, session recap, or duplicate summaries—optional links may appear only inside that sticky comment body).
-
-            3) **Comment body layout** (strict — CI parses line 1 and HTML markers):
-            - **Line 1** must be exactly the ASCII word `PASS` or `FAIL` (uppercase, no backticks, no markdown, no leading/trailing spaces).
-            - **Line 2** must be empty (no spaces).
-            - **Line 3** must be exactly: `<!-- ct-opencode-quality-review -->`
-            - **Line 4** must be exactly one of the following (must match line 1: use PASS line only with `PASS` on line 1, FAIL line only with `FAIL` on line 1):
-              - `<!-- ct-opencode-verdict:PASS -->`
-              - `<!-- ct-opencode-verdict:FAIL -->`
-            - **Line 5** must be empty.
-            - From **line 6** onward, use Markdown for the full human-readable review.
-
-            4) Use line 1 `FAIL` and line 4 `<!-- ct-opencode-verdict:FAIL -->` if anything material must change before merge (bugs, spec violations, missing tests for critical behavior, violations of the rule files above, or mismatch with linked issue intent). Otherwise use `PASS` and `<!-- ct-opencode-verdict:PASS -->`.
-
-  opencode_review_verdict:
-    name: OpenCode review verdict
-    needs: [opencode_review]
-    if: always()
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    steps:
-      # Verdict parsing disabled with OpenCode no-op; prior jq/sed logic preserved in git history.
-      - name: OpenCode review verdict (no-op)
-        run: |
-          echo "OpenCode review verdict gate is a no-op. opencode_review result: ${{ needs.opencode_review.result }}"

--- a/SPEC/program/e2e-integration-tests.md
+++ b/SPEC/program/e2e-integration-tests.md
@@ -65,8 +65,8 @@ Headed desktop on a dev machine without Xvfb: use **`-d macos`** or **`-d linux`
 
 ## CI
 
-- Job **`app_build_linux`** in `.github/workflows/quality.yml` runs in parallel with **`app_tests_shard`** (both need **`app_tests_cache`**). When test-relevant paths change, it restores the same pub + `gen-l10n` artifact as the shard runners, installs **clang / cmake / ninja / pkg-config / GTK / lzma** build deps on Ubuntu, then runs **`flutter build linux --release --no-pub`** under `app/`, then verifies tracked hand **`app/lib/l10n/*.dart`** files still exist and match **`git`** (Refs #2074). It is **not** a dependency of **`app_e2e_linux`**; add **`App Linux desktop build (release)`** to branch protection required checks if merges should wait on it.
-- Job **`app_e2e_linux`** runs after **`app_tests_shard`** only; it remains a required gate for branch protection but is currently a **no-op** (integration suites are not executed on the PR VM for stability/speed—the step only logs that e2e is intentionally skipped). It does **not** block **`quality_app_coverage`** beyond the existing `needs` graph.
+- Job **`app_build_linux`** in `.github/workflows/quality.yml` runs in parallel with **`app_tests_shard`** (both need **`app_tests_cache`**). When test-relevant paths change, it restores the same pub + `gen-l10n` artifact as the shard runners, installs **clang / cmake / ninja / pkg-config / GTK / lzma** build deps on Ubuntu, then runs **`flutter build linux --release --no-pub`** under `app/`, then verifies tracked hand **`app/lib/l10n/*.dart`** files still exist and match **`git`** (Refs #2074). Add **`App Linux desktop build (release)`** to branch protection required checks if merges should wait on Linux desktop compile validation.
+- The PR `quality` workflow does not currently run a separate **`app_e2e_linux`** gate; end-to-end coverage is tracked through dedicated e2e workflows and local verification steps instead of an always-present no-op lane.
 - Widget/coverage jobs use **`flutter test test/`** only so `integration_test/` is not executed on the VM shard runner.
 
 ## Expectations helper


### PR DESCRIPTION
## Summary
- remove `app_e2e_linux`, `opencode_review`, and `opencode_review_verdict` from `.github/workflows/quality.yml` after confirming each was an echo-only no-op gate
- remove the now-unused `changes.outputs.opencode_scope` output/filter wiring tied only to the removed OpenCode jobs
- update `SPEC/program/e2e-integration-tests.md` CI section so docs match the workflow behavior

## Test plan
- [x] Inspect workflow jobs to verify target gates are no-op/skip-only
- [x] Confirm no remaining references to `app_e2e_linux`, `opencode_review`, `opencode_review_verdict`, or `opencode_scope` in `quality.yml`
- [x] Run lints on touched files (`quality.yml`, `SPEC/program/e2e-integration-tests.md`)
- [ ] Let GitHub Actions run on this PR

Made with [Cursor](https://cursor.com)