### PR TITLE
Refactor order suggestion acceptance helper duplication (Refs #2237)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_build_research.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_build_research.dart
@@ -7,7 +7,6 @@ import '../world/province_lookup.dart';
 import '../world/unit_lookup.dart';
 import 'build_rail_work_rules.dart';
 import 'draft_orders_mutations.dart';
-import 'order_engine.dart';
 import 'order_suggestion_context.dart';
 import 'order_suggestion_helpers.dart';
 import 'orders_application_helpers.dart';
@@ -153,61 +152,6 @@ List<ResearchOrder> suggestResearchOrders(
   return suggestions;
 }
 
-bool _isMoveOrderAccepted(
-  Game game,
-  MapTopology topology,
-  String playerId,
-  Orders baseOrders,
-  MoveOrder candidate,
-) {
-  final engine = OrderEngine(initialOrders: baseOrders);
-  final result = engine.addMoveOrderWithContext(
-    game,
-    topology,
-    playerId,
-    candidate,
-  );
-  return result.isAccepted;
-}
-
-bool _isArmyMoveOrderAccepted(
-  Game game,
-  MapTopology topology,
-  String playerId,
-  Orders baseOrders,
-  ArmyMoveOrder candidate,
-) {
-  final merged = applyArmyMoveOrderForPlayer(baseOrders, playerId, candidate);
-  final engine = OrderEngine(initialOrders: merged);
-  final results = engine.validatePlayerOrdersWithContext(
-    game,
-    topology,
-    playerId,
-  );
-  if (results.isEmpty) return false;
-  return results.every((r) => r.isAccepted);
-}
-
-bool _isWorkOrderAccepted(
-  Game game,
-  MapTopology topology,
-  String playerId,
-  Orders baseOrders,
-  WorkOrder candidate, {
-  Map<String, TileMapResult>? tileMapByRegion,
-}) {
-  bumpOrderSuggestionWorkOrderAcceptanceProbeIfTracking();
-  final engine = OrderEngine(initialOrders: baseOrders);
-  final result = engine.addWorkOrderWithContext(
-    game,
-    topology,
-    playerId,
-    candidate,
-    tileMapByRegion: tileMapByRegion,
-  );
-  return result.isAccepted;
-}
-
 /// Returns the set of tile keys that are valid targets for a work order
 /// (unitId, workTarget) given [currentOrders]. Used by the app to highlight
 /// valid tiles when the player is assigning work. SPEC/ui/civilian-units-panel.md.
@@ -254,7 +198,7 @@ Set<String> getValidWorkOrderTileKeys(
       target: workTarget,
       targetTileKey: tileKey,
     );
-    if (_isWorkOrderAccepted(
+    if (isWorkOrderAccepted(
       game,
       topology,
       playerId,
@@ -353,7 +297,7 @@ Set<String> getValidWorkOrderTileKeysWithVisibility({
       target: workTarget,
       targetTileKey: tileKey,
     );
-    if (_isWorkOrderAccepted(
+    if (isWorkOrderAccepted(
       game,
       topology,
       playerId,
@@ -376,7 +320,8 @@ Set<String> _partiallyRevealedProvinceCacheForPlayer({
   required PlayerView view,
 }) {
   final cached = <String>{};
-  for (final regionEntry in game.worldState.tileKeysByRegionAndProvince.entries) {
+  for (final regionEntry
+      in game.worldState.tileKeysByRegionAndProvince.entries) {
     for (final provinceEntry in regionEntry.value.entries) {
       final provinceId = provinceEntry.key;
       if (!ProvinceId.isPrefixed(provinceId)) continue;
@@ -388,7 +333,10 @@ Set<String> _partiallyRevealedProvinceCacheForPlayer({
   return cached;
 }
 
-bool _hasMixedKnownAndUnknownVisibility(PlayerView view, List<String> tileKeys) {
+bool _hasMixedKnownAndUnknownVisibility(
+  PlayerView view,
+  List<String> tileKeys,
+) {
   var hasKnown = false;
   var hasUnknown = false;
   for (final tileKey in tileKeys) {
@@ -545,23 +493,6 @@ void _addCandidateTilesForStealTech({
       result.add(tiles.first);
     }
   }
-}
-
-bool _isBuildOrderAccepted(
-  Game game,
-  MapTopology topology,
-  String playerId,
-  Orders baseOrders,
-  BuildUnitOrder candidate,
-) {
-  final engine = OrderEngine(initialOrders: baseOrders);
-  final result = engine.addBuildOrderWithContext(
-    game,
-    topology,
-    playerId,
-    candidate,
-  );
-  return result.isAccepted;
 }
 
 /// Context for [_workTargetPrefilters] map dispatch (work-target tile pre-filter).

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
@@ -6,7 +6,6 @@ import '../world/naval.dart';
 import '../world/player_view.dart';
 import '../world/province_lookup.dart';
 import '../world/topology_helpers.dart';
-import 'order_engine.dart';
 import 'order_suggestion_context.dart';
 import 'orders_application_helpers.dart';
 
@@ -31,7 +30,7 @@ void _addAcceptedSeaZoneCandidates({
       fleetId: fleet.id,
       destinationSeaZoneId: destId,
     );
-    if (_isNavalMoveOrderAccepted(
+    if (isNavalMoveOrderAccepted(
       game,
       topology,
       playerId,
@@ -64,8 +63,7 @@ void _addAcceptedDockCandidatesForSeaFleet({
     final fullProvinceId = ProvinceId.isPrefixed(localId)
         ? localId
         : ProvinceId.full(zoneRegionId, localId);
-    if (existingByFleet[fleet.id]?.contains('port:$fullProvinceId') ??
-        false) {
+    if (existingByFleet[fleet.id]?.contains('port:$fullProvinceId') ?? false) {
       continue;
     }
     final province = game.worldState.tryGetProvince(fullProvinceId);
@@ -74,7 +72,7 @@ void _addAcceptedDockCandidatesForSeaFleet({
       fleetId: fleet.id,
       destinationPortProvinceId: fullProvinceId,
     );
-    if (_isNavalMoveOrderAccepted(
+    if (isNavalMoveOrderAccepted(
       game,
       topology,
       playerId,
@@ -109,7 +107,7 @@ void _addAcceptedMovesFromPortFleet({
       fleetId: fleet.id,
       destinationSeaZoneId: destId,
     );
-    if (_isNavalMoveOrderAccepted(
+    if (isNavalMoveOrderAccepted(
       game,
       topology,
       playerId,
@@ -225,7 +223,7 @@ List<NavalMissionOrder> suggestNavalMissionOrders(
         fleetId: fleet.id,
         mission: mission.name,
       );
-      if (_isNavalMissionOrderAccepted(
+      if (isNavalMissionOrderAccepted(
         game,
         topology,
         playerId,
@@ -249,59 +247,6 @@ List<NavalMissionOrder> suggestNavalMissionOrders(
     'suggestNavalMissionOrders full list ${suggestions.map((o) => "fleetId=${o.fleetId} mission=${o.mission}").join(", ")}',
   );
   return suggestions;
-}
-
-bool _isNavalMoveOrderAccepted(
-  Game game,
-  MapTopology topology,
-  String playerId,
-  Orders baseOrders,
-  NavalMoveOrder candidate,
-) {
-  final engine = OrderEngine(initialOrders: baseOrders);
-  final result = engine.addNavalMoveOrderWithContext(
-    game,
-    topology,
-    playerId,
-    candidate,
-  );
-  return result.isAccepted;
-}
-
-bool _isNavalMissionOrderAccepted(
-  Game game,
-  MapTopology topology,
-  String playerId,
-  Orders baseOrders,
-  NavalMissionOrder candidate,
-) {
-  final engine = OrderEngine(initialOrders: baseOrders);
-  final result = engine.addNavalMissionOrderWithContext(
-    game,
-    topology,
-    playerId,
-    candidate,
-  );
-  return result.isAccepted;
-}
-
-bool _isDiplomaticOrderAccepted(
-  Game game,
-  MapTopology topology,
-  String playerId,
-  Orders baseOrders,
-  DiplomaticOrder candidate, {
-  Map<String, TileMapResult>? tileMapByRegion,
-}) {
-  final engine = OrderEngine(initialOrders: baseOrders);
-  final result = engine.addDiplomaticOrderWithContext(
-    game,
-    topology,
-    playerId,
-    candidate,
-    tileMapByRegion: tileMapByRegion,
-  );
-  return result.isAccepted;
 }
 
 /// Trial append for suggestion enumeration. SPEC/program/order-suggestions.md.
@@ -556,7 +501,7 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
           candidate.type == DiplomaticOrderType.setSubsidy) {
         continue;
       }
-      if (!_isDiplomaticOrderAccepted(
+      if (!isDiplomaticOrderAccepted(
         game,
         topology,
         playerId,
@@ -580,7 +525,7 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
           candidate.type != DiplomaticOrderType.setSubsidy) {
         continue;
       }
-      if (!_isDiplomaticOrderAccepted(
+      if (!isDiplomaticOrderAccepted(
         game,
         topology,
         playerId,


### PR DESCRIPTION
## Summary
- Remove duplicated private `_isXxxOrderAccepted` helper implementations from `order_suggestion_build_research.dart` and `order_suggestion_naval_diplomatic.dart`.
- Route those call sites through shared acceptance wrappers in `order_suggestion_context.dart`.
- Keep behavior unchanged while reducing duplicate validation-probe plumbing in preparation for issue #2237 incremental validation work.

## Implemented in this PR
- P2 helper consolidation subset from issue #2237 for move/work/build/naval/diplomatic acceptance helper duplication.
- Import cleanup and call-site rewiring to shared context helpers.

## Deferred from issue #2237
- Incremental candidate validation pipeline (A primary hot path).
- Trusted/untrusted turn resolver split and trusted entry point (B).
- Candidate-probe algorithm/spec updates and equivalence/performance AC implementation.

## Test plan
- [x] `flutter test test/order_suggestion_context_helpers_test.dart test/order_suggestion_core_part1_test.dart test/order_suggestion_core_part2_test.dart test/order_suggestion_core_part2_naval_mission_test.dart test/order_suggestion_diplomacy_filter_test.dart` (run in `packages/colonizethis_logic`)

Refs #2237

Made with [Cursor](https://cursor.com)