### PR TITLE
feat(app,logic): use trusted resolver path in next-turn isolate (slice for #2237)

### DIFF
--- a/app/lib/core/services/turn_resolution_runner.dart
+++ b/app/lib/core/services/turn_resolution_runner.dart
@@ -243,7 +243,7 @@ void _turnResolutionIsolateMain(Map<String, Object?> args) {
         ),
       ),
     );
-    final result = resolveTurnForGame(
+    final result = validateOrdersAndResolveTurnFromTrustedOrders(
       game: game,
       topology: topology,
       orders: orders,

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -125,6 +125,8 @@ TurnResolutionResult validateOrdersAndResolveTurn({
   GameEventBus? eventBus,
   void Function(DialogueEvent)? onDialogue,
   void Function(GameEvent)? onGameEvent,
+  void Function(TurnPhase phase, TurnPhaseProgressMarker marker)?
+  onPhaseProgress,
   void Function(TurnTracePhaseTrace phaseTrace)? onTurnTracePhase,
 }) {
   final engine = OrderEngine(initialOrders: orders);
@@ -148,6 +150,7 @@ TurnResolutionResult validateOrdersAndResolveTurn({
     extractedByPlayerId: extractedByPlayerId,
     defaultAssignments: defaultAssignments,
     defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+    onPhaseProgress: onPhaseProgress,
     onTurnTracePhase: onTurnTracePhase,
   );
 }
@@ -184,6 +187,8 @@ TurnResolutionResult validateOrdersAndResolveTurnFromTrustedOrders({
   GameEventBus? eventBus,
   void Function(DialogueEvent)? onDialogue,
   void Function(GameEvent)? onGameEvent,
+  void Function(TurnPhase phase, TurnPhaseProgressMarker marker)?
+  onPhaseProgress,
   void Function(TurnTracePhaseTrace phaseTrace)? onTurnTracePhase,
 }) {
   return resolveTurnForGame(
@@ -198,6 +203,7 @@ TurnResolutionResult validateOrdersAndResolveTurnFromTrustedOrders({
     extractedByPlayerId: extractedByPlayerId,
     defaultAssignments: defaultAssignments,
     defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+    onPhaseProgress: onPhaseProgress,
     onTurnTracePhase: onTurnTracePhase,
   );
 }

--- a/packages/colonizethis_logic/test/turn_resolver_trusted_orders_test.dart
+++ b/packages/colonizethis_logic/test/turn_resolver_trusted_orders_test.dart
@@ -68,9 +68,7 @@ void main() {
         const ow = 'oldWorld';
         final orders = Orders(
           moveOrdersByPlayerId: {
-            'p1': [
-              MoveOrder(unitId: 'u1', destinationTileKey: '$ow|P2|0|0'),
-            ],
+            'p1': [MoveOrder(unitId: 'u1', destinationTileKey: '$ow|P2|0|0')],
           },
         );
 
@@ -104,76 +102,94 @@ void main() {
     // drop it (it is dispatched to the phase pipeline, where movement-phase
     // application skips the unknown unit). The resulting state therefore
     // matches running resolveTurnForGame directly with the same Orders.
-    test(
-      'skips per-player pre-apply filter (matches resolveTurnForGame on '
-      'unfiltered orders)',
-      () {
-        final topology = buildTopology();
-        final game = buildGame();
-        const ow = 'oldWorld';
-        final orders = Orders(
-          moveOrdersByPlayerId: {
-            'p1': [
-              MoveOrder(unitId: 'u1', destinationTileKey: '$ow|P2|0|0'),
-              MoveOrder(unitId: 'u999', destinationTileKey: '$ow|P2|0|0'),
-            ],
-          },
-        );
+    test('skips per-player pre-apply filter (matches resolveTurnForGame on '
+        'unfiltered orders)', () {
+      final topology = buildTopology();
+      final game = buildGame();
+      const ow = 'oldWorld';
+      final orders = Orders(
+        moveOrdersByPlayerId: {
+          'p1': [
+            MoveOrder(unitId: 'u1', destinationTileKey: '$ow|P2|0|0'),
+            MoveOrder(unitId: 'u999', destinationTileKey: '$ow|P2|0|0'),
+          ],
+        },
+      );
 
-        final trusted = requireTurnResolutionComplete(
-          validateOrdersAndResolveTurnFromTrustedOrders(
-            game: game,
-            topology: topology,
-            orders: orders,
-          ),
-        );
-        final direct = requireTurnResolutionComplete(
-          resolveTurnForGame(
-            game: game,
-            topology: topology,
-            orders: orders,
-          ),
-        );
+      final trusted = requireTurnResolutionComplete(
+        validateOrdersAndResolveTurnFromTrustedOrders(
+          game: game,
+          topology: topology,
+          orders: orders,
+        ),
+      );
+      final direct = requireTurnResolutionComplete(
+        resolveTurnForGame(game: game, topology: topology, orders: orders),
+      );
 
-        expect(trusted.toJson(), equals(direct.toJson()));
-      },
-    );
+      expect(trusted.toJson(), equals(direct.toJson()));
+    });
 
     // AC 6 (untrusted-path preservation): Untrusted entry point still drops
     // rejected orders. Reaffirms that the new trusted entry point did not
     // alter behavior of the existing entry point. SPEC AC: untrusted-path
     // preservation.
-    test(
-      'validateOrdersAndResolveTurn still filters rejected orders for '
-      'untrusted callers',
-      () {
-        final topology = buildTopology();
-        final game = buildGame();
-        const ow = 'oldWorld';
-        final orders = Orders(
-          moveOrdersByPlayerId: {
-            'p1': [
-              MoveOrder(unitId: 'u1', destinationTileKey: '$ow|P2|0|0'),
-              MoveOrder(unitId: 'u999', destinationTileKey: '$ow|P2|0|0'),
-            ],
+    test('validateOrdersAndResolveTurn still filters rejected orders for '
+        'untrusted callers', () {
+      final topology = buildTopology();
+      final game = buildGame();
+      const ow = 'oldWorld';
+      final orders = Orders(
+        moveOrdersByPlayerId: {
+          'p1': [
+            MoveOrder(unitId: 'u1', destinationTileKey: '$ow|P2|0|0'),
+            MoveOrder(unitId: 'u999', destinationTileKey: '$ow|P2|0|0'),
+          ],
+        },
+      );
+
+      final next = requireTurnResolutionComplete(
+        validateOrdersAndResolveTurn(
+          game: game,
+          topology: topology,
+          orders: orders,
+        ),
+      );
+
+      expect(next.worldState.turnState.turnNumber, 1);
+      expect(next.worldState.oldWorld.units.length, 1);
+      expect(
+        next.worldState.oldWorld.units.single.locationProvinceId,
+        '$ow|P2',
+      );
+    });
+
+    test('forwards onPhaseProgress callbacks on trusted entry point', () {
+      final topology = buildTopology();
+      final game = buildGame();
+      const ow = 'oldWorld';
+      final orders = Orders(
+        moveOrdersByPlayerId: {
+          'p1': [MoveOrder(unitId: 'u1', destinationTileKey: '$ow|P2|0|0')],
+        },
+      );
+      final phaseEvents = <String>[];
+
+      final next = requireTurnResolutionComplete(
+        validateOrdersAndResolveTurnFromTrustedOrders(
+          game: game,
+          topology: topology,
+          orders: orders,
+          onPhaseProgress: (phase, marker) {
+            phaseEvents.add('${phase.name}:${marker.name}');
           },
-        );
+        ),
+      );
 
-        final next = requireTurnResolutionComplete(
-          validateOrdersAndResolveTurn(
-            game: game,
-            topology: topology,
-            orders: orders,
-          ),
-        );
-
-        expect(next.worldState.turnState.turnNumber, 1);
-        expect(next.worldState.oldWorld.units.length, 1);
-        expect(
-          next.worldState.oldWorld.units.single.locationProvinceId,
-          '$ow|P2',
-        );
-      },
-    );
+      expect(next.worldState.turnState.turnNumber, 1);
+      expect(phaseEvents, isNotEmpty);
+      expect(phaseEvents.first, 'orders:start');
+      expect(phaseEvents.last, 'endOfTurn:end');
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Route `app` Next Turn isolate resolution through `validateOrdersAndResolveTurnFromTrustedOrders(...)` instead of calling `resolveTurnForGame(...)` directly.
- Add `onPhaseProgress` passthrough parameters to trusted and untrusted turn-resolver wrappers so runner progress streaming remains intact.
- Extend trusted-resolver tests to assert phase-progress callback forwarding.

## Implemented in this PR
- Advances issue #2237 method (B) caller policy by making the app Next Turn path explicitly use the trusted resolver entry point.
- Preserves runner phase progress events while using the trusted entry point.
- Adds regression test coverage for trusted `onPhaseProgress` forwarding.

## Deferred work
- Issue #2237 method (A): incremental candidate validation pipeline across suggestion probing hot paths.
- Issue #2237 method (C): reducing add-with-context full-pass usage in candidate probe flows.
- Remaining ACs tied to suggestion probe consolidation/performance budgets (AC1-AC4 and AC7 full closure).

## Tests
- `dart test packages/colonizethis_logic/test/turn_resolver_trusted_orders_test.dart`
- `flutter test test/turn_resolution_runner_test.dart` (run from `app/`)

Refs #2237

Made with [Cursor](https://cursor.com)