### PR TITLE
feat(app,logic): route next-turn isolate through trusted resolver path

### DIFF
--- a/app/lib/core/services/turn_resolution_runner.dart
+++ b/app/lib/core/services/turn_resolution_runner.dart
@@ -243,7 +243,7 @@ void _turnResolutionIsolateMain(Map<String, Object?> args) {
         ),
       ),
     );
-    final result = resolveTurnForGame(
+    final result = validateOrdersAndResolveTurnFromTrustedOrders(
       game: game,
       topology: topology,
       orders: orders,

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -125,6 +125,8 @@ TurnResolutionResult validateOrdersAndResolveTurn({
   GameEventBus? eventBus,
   void Function(DialogueEvent)? onDialogue,
   void Function(GameEvent)? onGameEvent,
+  void Function(TurnPhase phase, TurnPhaseProgressMarker marker)?
+  onPhaseProgress,
   void Function(TurnTracePhaseTrace phaseTrace)? onTurnTracePhase,
 }) {
   final engine = OrderEngine(initialOrders: orders);
@@ -148,6 +150,7 @@ TurnResolutionResult validateOrdersAndResolveTurn({
     extractedByPlayerId: extractedByPlayerId,
     defaultAssignments: defaultAssignments,
     defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+    onPhaseProgress: onPhaseProgress,
     onTurnTracePhase: onTurnTracePhase,
   );
 }
@@ -184,6 +187,8 @@ TurnResolutionResult validateOrdersAndResolveTurnFromTrustedOrders({
   GameEventBus? eventBus,
   void Function(DialogueEvent)? onDialogue,
   void Function(GameEvent)? onGameEvent,
+  void Function(TurnPhase phase, TurnPhaseProgressMarker marker)?
+  onPhaseProgress,
   void Function(TurnTracePhaseTrace phaseTrace)? onTurnTracePhase,
 }) {
   return resolveTurnForGame(
@@ -198,6 +203,7 @@ TurnResolutionResult validateOrdersAndResolveTurnFromTrustedOrders({
     extractedByPlayerId: extractedByPlayerId,
     defaultAssignments: defaultAssignments,
     defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+    onPhaseProgress: onPhaseProgress,
     onTurnTracePhase: onTurnTracePhase,
   );
 }

--- a/packages/colonizethis_logic/test/turn_resolver_trusted_orders_test.dart
+++ b/packages/colonizethis_logic/test/turn_resolver_trusted_orders_test.dart
@@ -68,9 +68,7 @@ void main() {
         const ow = 'oldWorld';
         final orders = Orders(
           moveOrdersByPlayerId: {
-            'p1': [
-              MoveOrder(unitId: 'u1', destinationTileKey: '$ow|P2|0|0'),
-            ],
+            'p1': [MoveOrder(unitId: 'u1', destinationTileKey: '$ow|P2|0|0')],
           },
         );
 
@@ -104,76 +102,94 @@ void main() {
     // drop it (it is dispatched to the phase pipeline, where movement-phase
     // application skips the unknown unit). The resulting state therefore
     // matches running resolveTurnForGame directly with the same Orders.
-    test(
-      'skips per-player pre-apply filter (matches resolveTurnForGame on '
-      'unfiltered orders)',
-      () {
-        final topology = buildTopology();
-        final game = buildGame();
-        const ow = 'oldWorld';
-        final orders = Orders(
-          moveOrdersByPlayerId: {
-            'p1': [
-              MoveOrder(unitId: 'u1', destinationTileKey: '$ow|P2|0|0'),
-              MoveOrder(unitId: 'u999', destinationTileKey: '$ow|P2|0|0'),
-            ],
-          },
-        );
+    test('skips per-player pre-apply filter (matches resolveTurnForGame on '
+        'unfiltered orders)', () {
+      final topology = buildTopology();
+      final game = buildGame();
+      const ow = 'oldWorld';
+      final orders = Orders(
+        moveOrdersByPlayerId: {
+          'p1': [
+            MoveOrder(unitId: 'u1', destinationTileKey: '$ow|P2|0|0'),
+            MoveOrder(unitId: 'u999', destinationTileKey: '$ow|P2|0|0'),
+          ],
+        },
+      );
 
-        final trusted = requireTurnResolutionComplete(
-          validateOrdersAndResolveTurnFromTrustedOrders(
-            game: game,
-            topology: topology,
-            orders: orders,
-          ),
-        );
-        final direct = requireTurnResolutionComplete(
-          resolveTurnForGame(
-            game: game,
-            topology: topology,
-            orders: orders,
-          ),
-        );
+      final trusted = requireTurnResolutionComplete(
+        validateOrdersAndResolveTurnFromTrustedOrders(
+          game: game,
+          topology: topology,
+          orders: orders,
+        ),
+      );
+      final direct = requireTurnResolutionComplete(
+        resolveTurnForGame(game: game, topology: topology, orders: orders),
+      );
 
-        expect(trusted.toJson(), equals(direct.toJson()));
-      },
-    );
+      expect(trusted.toJson(), equals(direct.toJson()));
+    });
 
     // AC 6 (untrusted-path preservation): Untrusted entry point still drops
     // rejected orders. Reaffirms that the new trusted entry point did not
     // alter behavior of the existing entry point. SPEC AC: untrusted-path
     // preservation.
-    test(
-      'validateOrdersAndResolveTurn still filters rejected orders for '
-      'untrusted callers',
-      () {
-        final topology = buildTopology();
-        final game = buildGame();
-        const ow = 'oldWorld';
-        final orders = Orders(
-          moveOrdersByPlayerId: {
-            'p1': [
-              MoveOrder(unitId: 'u1', destinationTileKey: '$ow|P2|0|0'),
-              MoveOrder(unitId: 'u999', destinationTileKey: '$ow|P2|0|0'),
-            ],
+    test('validateOrdersAndResolveTurn still filters rejected orders for '
+        'untrusted callers', () {
+      final topology = buildTopology();
+      final game = buildGame();
+      const ow = 'oldWorld';
+      final orders = Orders(
+        moveOrdersByPlayerId: {
+          'p1': [
+            MoveOrder(unitId: 'u1', destinationTileKey: '$ow|P2|0|0'),
+            MoveOrder(unitId: 'u999', destinationTileKey: '$ow|P2|0|0'),
+          ],
+        },
+      );
+
+      final next = requireTurnResolutionComplete(
+        validateOrdersAndResolveTurn(
+          game: game,
+          topology: topology,
+          orders: orders,
+        ),
+      );
+
+      expect(next.worldState.turnState.turnNumber, 1);
+      expect(next.worldState.oldWorld.units.length, 1);
+      expect(
+        next.worldState.oldWorld.units.single.locationProvinceId,
+        '$ow|P2',
+      );
+    });
+
+    test('forwards onPhaseProgress callbacks on trusted entry point', () {
+      final topology = buildTopology();
+      final game = buildGame();
+      const ow = 'oldWorld';
+      final orders = Orders(
+        moveOrdersByPlayerId: {
+          'p1': [MoveOrder(unitId: 'u1', destinationTileKey: '$ow|P2|0|0')],
+        },
+      );
+      final phaseEvents = <String>[];
+
+      final next = requireTurnResolutionComplete(
+        validateOrdersAndResolveTurnFromTrustedOrders(
+          game: game,
+          topology: topology,
+          orders: orders,
+          onPhaseProgress: (phase, marker) {
+            phaseEvents.add('${phase.name}:${marker.name}');
           },
-        );
+        ),
+      );
 
-        final next = requireTurnResolutionComplete(
-          validateOrdersAndResolveTurn(
-            game: game,
-            topology: topology,
-            orders: orders,
-          ),
-        );
-
-        expect(next.worldState.turnState.turnNumber, 1);
-        expect(next.worldState.oldWorld.units.length, 1);
-        expect(
-          next.worldState.oldWorld.units.single.locationProvinceId,
-          '$ow|P2',
-        );
-      },
-    );
+      expect(next.worldState.turnState.turnNumber, 1);
+      expect(phaseEvents, isNotEmpty);
+      expect(phaseEvents.first, 'orders:start');
+      expect(phaseEvents.last, 'endOfTurn:end');
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Route the Next Turn isolate flow through `validateOrdersAndResolveTurnFromTrustedOrders` so AI-produced, validated orders skip redundant pre-apply filtering in this path.
- Extend trusted resolver wiring to forward `onPhaseProgress` callbacks, preserving phase progress signaling parity with the existing untrusted entry point.
- Add/extend trusted-path resolver tests to cover unfiltered parity, untrusted-path preservation, and trusted callback forwarding.

## Implemented in this PR
- Trusted-path resolver usage in `app/lib/core/services/turn_resolution_runner.dart`.
- `onPhaseProgress` forwarding in both turn resolver entry points.
- Test coverage in `packages/colonizethis_logic/test/turn_resolver_trusted_orders_test.dart`.

## Deferred Work (Issue #2237)
- Incremental candidate validation pipeline replacing per-candidate full-pass validation probes in order suggestion modules.
- Probe-helper consolidation in suggestion modules.
- Performance-budget benchmark and candidate-equivalence tests for AC closure.
- Remaining SPEC/AC closure work beyond this trusted-path slice.

## AC Coverage in this slice
- Covered now: trusted/untrusted resolver-path behavior slice (part of AC 5/6 trajectory).
- Not covered in this PR: AC 1-4 and full AC 5-7 closure.

Refs #2237

Made with [Cursor](https://cursor.com)