### PR TITLE
refactor(logic): consolidate diplomatic suggestion trial helpers

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_build_research.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_build_research.dart
@@ -23,6 +23,12 @@ List<BuildUnitOrder> suggestBuildOrders(
   final playerId = view.playerId;
   final player = view.player;
   final suggestions = <BuildUnitOrder>[];
+  final candidateValidator = buildIncrementalCandidateValidator(
+    game: game,
+    topology: topology,
+    playerId: playerId,
+    baseOrders: currentOrders,
+  );
 
   final capitalId = player.capitalProvinceId;
   if (capitalId == null) {
@@ -40,13 +46,7 @@ List<BuildUnitOrder> suggestBuildOrders(
       spawnProvinceId: capitalId,
     );
 
-    if (isBuildOrderAccepted(
-      game,
-      topology,
-      playerId,
-      currentOrders,
-      candidate,
-    )) {
+    if (isBuildOrderAcceptedWithValidator(candidateValidator, candidate)) {
       suggestions.add(candidate);
     }
   }
@@ -60,13 +60,7 @@ List<BuildUnitOrder> suggestBuildOrders(
       spawnProvinceId: capitalId,
     );
 
-    if (isBuildOrderAccepted(
-      game,
-      topology,
-      playerId,
-      currentOrders,
-      candidate,
-    )) {
+    if (isBuildOrderAcceptedWithValidator(candidateValidator, candidate)) {
       suggestions.add(candidate);
     }
   }
@@ -187,6 +181,13 @@ Set<String> getValidWorkOrderTileKeys(
     workTarget: workTarget,
     tileMapByRegion: tileMapByRegion,
   );
+  final candidateValidator = buildIncrementalCandidateValidator(
+    game: game,
+    topology: topology,
+    playerId: playerId,
+    baseOrders: currentOrders,
+    tileMapByRegion: tileMapByRegion,
+  );
   final valid = <String>{};
   for (final tileKey in raw) {
     if (isDevExclusiveWorkTarget(workTarget) &&
@@ -198,14 +199,7 @@ Set<String> getValidWorkOrderTileKeys(
       target: workTarget,
       targetTileKey: tileKey,
     );
-    if (isWorkOrderAccepted(
-      game,
-      topology,
-      playerId,
-      currentOrders,
-      candidate,
-      tileMapByRegion: tileMapByRegion,
-    )) {
+    if (isWorkOrderAcceptedWithValidator(candidateValidator, candidate)) {
       valid.add(tileKey);
     }
   }
@@ -281,6 +275,13 @@ Set<String> getValidWorkOrderTileKeysWithVisibility({
     tileMapByRegion: tileMapByRegion,
   );
   final sortedVisible = sortedVisibleWorkTargetCandidates(view, raw);
+  final candidateValidator = buildIncrementalCandidateValidator(
+    game: game,
+    topology: topology,
+    playerId: playerId,
+    baseOrders: currentOrders,
+    tileMapByRegion: tileMapByRegion,
+  );
 
   orderSuggestionLog.d(
     'getValidWorkOrderTileKeysWithVisibility visible sorted count=${sortedVisible.length}',
@@ -297,14 +298,7 @@ Set<String> getValidWorkOrderTileKeysWithVisibility({
       target: workTarget,
       targetTileKey: tileKey,
     );
-    if (isWorkOrderAccepted(
-      game,
-      topology,
-      playerId,
-      currentOrders,
-      candidate,
-      tileMapByRegion: tileMapByRegion,
-    )) {
+    if (isWorkOrderAcceptedWithValidator(candidateValidator, candidate)) {
       valid.add(tileKey);
     }
   }

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_context.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_context.dart
@@ -27,6 +27,22 @@ void bumpOrderSuggestionWorkOrderAcceptanceProbeIfTracking() {
   }
 }
 
+IncrementalCandidateValidator buildIncrementalCandidateValidator({
+  required Game game,
+  required MapTopology topology,
+  required String playerId,
+  required Orders baseOrders,
+  Map<String, TileMapResult>? tileMapByRegion,
+}) {
+  return IncrementalCandidateValidator.forPlayer(
+    game: game,
+    topology: topology,
+    playerId: playerId,
+    basePrefix: baseOrders,
+    tileMapByRegion: tileMapByRegion,
+  );
+}
+
 bool isMoveOrderAccepted(
   Game game,
   MapTopology topology,
@@ -39,11 +55,11 @@ bool isMoveOrderAccepted(
   // [validatePlayerOrdersWithContext]. SPEC/program/order-suggestions.md
   // § Incremental candidate validation; SPEC/program/order-engine.md
   // § Validation (candidate-probe context). Refs #2237.
-  final validator = IncrementalCandidateValidator.forPlayer(
+  final validator = buildIncrementalCandidateValidator(
     game: game,
     topology: topology,
     playerId: playerId,
-    basePrefix: baseOrders,
+    baseOrders: baseOrders,
   );
   return validator.isMoveAccepted(candidate);
 }
@@ -59,11 +75,11 @@ bool isArmyMoveOrderAccepted(
   // [baseOrders]'s diplomatic context without re-running full-pass
   // [validatePlayerOrdersWithContext]. SPEC/program/order-suggestions.md
   // § Incremental candidate validation. Refs #2237.
-  final validator = IncrementalCandidateValidator.forPlayer(
+  final validator = buildIncrementalCandidateValidator(
     game: game,
     topology: topology,
     playerId: playerId,
-    basePrefix: baseOrders,
+    baseOrders: baseOrders,
   );
   return validator.isArmyMoveAccepted(candidate);
 }
@@ -76,15 +92,14 @@ bool isWorkOrderAccepted(
   WorkOrder candidate, {
   Map<String, TileMapResult>? tileMapByRegion,
 }) {
-  bumpOrderSuggestionWorkOrderAcceptanceProbeIfTracking();
-  final validator = IncrementalCandidateValidator.forPlayer(
+  final validator = buildIncrementalCandidateValidator(
     game: game,
     topology: topology,
     playerId: playerId,
-    basePrefix: baseOrders,
+    baseOrders: baseOrders,
     tileMapByRegion: tileMapByRegion,
   );
-  return validator.isWorkAccepted(candidate);
+  return isWorkOrderAcceptedWithValidator(validator, candidate);
 }
 
 bool isBuildOrderAccepted(
@@ -94,13 +109,13 @@ bool isBuildOrderAccepted(
   Orders baseOrders,
   BuildUnitOrder candidate,
 ) {
-  final validator = IncrementalCandidateValidator.forPlayer(
+  final validator = buildIncrementalCandidateValidator(
     game: game,
     topology: topology,
     playerId: playerId,
-    basePrefix: baseOrders,
+    baseOrders: baseOrders,
   );
-  return validator.isBuildAccepted(candidate);
+  return isBuildOrderAcceptedWithValidator(validator, candidate);
 }
 
 bool isNavalMoveOrderAccepted(
@@ -112,11 +127,11 @@ bool isNavalMoveOrderAccepted(
 ) {
   // Stateless candidate-probe path. SPEC/program/order-suggestions.md
   // § Incremental candidate validation. Refs #2237.
-  final validator = IncrementalCandidateValidator.forPlayer(
+  final validator = buildIncrementalCandidateValidator(
     game: game,
     topology: topology,
     playerId: playerId,
-    basePrefix: baseOrders,
+    baseOrders: baseOrders,
   );
   return validator.isNavalMoveAccepted(candidate);
 }
@@ -130,11 +145,11 @@ bool isNavalMissionOrderAccepted(
 ) {
   // Stateless candidate-probe path. SPEC/program/order-suggestions.md
   // § Incremental candidate validation. Refs #2237.
-  final validator = IncrementalCandidateValidator.forPlayer(
+  final validator = buildIncrementalCandidateValidator(
     game: game,
     topology: topology,
     playerId: playerId,
-    basePrefix: baseOrders,
+    baseOrders: baseOrders,
   );
   return validator.isNavalMissionAccepted(candidate);
 }
@@ -147,14 +162,29 @@ bool isDiplomaticOrderAccepted(
   DiplomaticOrder candidate, {
   Map<String, TileMapResult>? tileMapByRegion,
 }) {
-  final validator = IncrementalCandidateValidator.forPlayer(
+  final validator = buildIncrementalCandidateValidator(
     game: game,
     topology: topology,
     playerId: playerId,
-    basePrefix: baseOrders,
+    baseOrders: baseOrders,
     tileMapByRegion: tileMapByRegion,
   );
   return validator.isDiplomaticAccepted(candidate);
+}
+
+bool isBuildOrderAcceptedWithValidator(
+  IncrementalCandidateValidator validator,
+  BuildUnitOrder candidate,
+) {
+  return validator.isBuildAccepted(candidate);
+}
+
+bool isWorkOrderAcceptedWithValidator(
+  IncrementalCandidateValidator validator,
+  WorkOrder candidate,
+) {
+  bumpOrderSuggestionWorkOrderAcceptanceProbeIfTracking();
+  return validator.isWorkAccepted(candidate);
 }
 
 Orders appendDiplomaticOrderForTrial(

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
@@ -239,38 +239,6 @@ List<NavalMissionOrder> suggestNavalMissionOrders(
   return suggestions;
 }
 
-/// Trial append for suggestion enumeration. SPEC/program/order-suggestions.md.
-Orders _appendDiplomaticOrderForTrial(
-  Orders orders,
-  String playerId,
-  DiplomaticOrder order,
-) {
-  final prev =
-      orders.diplomaticOrdersByPlayerId[playerId] ?? const <DiplomaticOrder>[];
-  return orders.copyWith(
-    diplomaticOrdersByPlayerId: {
-      ...orders.diplomaticOrdersByPlayerId,
-      playerId: [...prev, order],
-    },
-  );
-}
-
-/// Next overture stage for suggestion (none→tradeConsulate→embassy→nap→joinEmpire).
-OvertureStage? _nextOvertureStage(OvertureStage current) {
-  switch (current) {
-    case OvertureStage.none:
-      return OvertureStage.tradeConsulate;
-    case OvertureStage.tradeConsulate:
-      return OvertureStage.embassy;
-    case OvertureStage.embassy:
-      return OvertureStage.nap;
-    case OvertureStage.nap:
-      return OvertureStage.joinEmpire;
-    case OvertureStage.joinEmpire:
-      return null;
-  }
-}
-
 /// Per-target suggestion order: first candidate that passes the order engine wins.
 /// SPEC/program/order-suggestions.md § Diplomatic orders.
 List<DiplomaticOrder> _diplomaticCandidatesForTargetOrdered({
@@ -374,7 +342,7 @@ DiplomaticOrder? _establishOvertureSuggestionOrder({
 
   final existing = getOverture(game, playerId, targetId);
   final current = existing?.stage ?? OvertureStage.none;
-  final next = _nextOvertureStage(current);
+  final next = nextOvertureStage(current);
   if (next == null) return null;
   if (next == OvertureStage.tradeConsulate || next == OvertureStage.embassy) {
     final cost = next == OvertureStage.tradeConsulate
@@ -502,7 +470,7 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
         continue;
       }
       suggestions.add(candidate);
-      trialOrders = _appendDiplomaticOrderForTrial(
+      trialOrders = appendDiplomaticOrderForTrial(
         trialOrders,
         playerId,
         candidate,
@@ -526,7 +494,7 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
         continue;
       }
       suggestions.add(candidate);
-      trialOrders = _appendDiplomaticOrderForTrial(
+      trialOrders = appendDiplomaticOrderForTrial(
         trialOrders,
         playerId,
         candidate,


### PR DESCRIPTION
## Summary
- replace duplicated private helper logic in `order_suggestion_naval_diplomatic.dart` with shared `appendDiplomaticOrderForTrial` and `nextOvertureStage` from `order_suggestion_context.dart`
- keep diplomatic candidate probing behavior unchanged while centralizing incremental-candidate helper semantics in one place
- reuse one `IncrementalCandidateValidator` per suggestion pass in build/work candidate loops to avoid rebuilding validator context for every probe
- run focused equivalence/helper/suggestion tests for incremental candidate validation behavior

## Implemented in this PR
- Removed duplicate helper implementations from naval/diplomatic suggestion code.
- Updated suggestion flow to call the shared helper API used by the incremental candidate-validation path.
- Reused a single incremental validator in build and work tile-candidate loops so candidate probing avoids repeated per-candidate validator construction.

## Deferred work
- Broader issue #2237 scope (performance budget validation test, additional diagnostics tuning, and remaining cross-path optimization slices) remains deferred to follow-up PRs.

## Acceptance criteria coverage (this PR)
- Partial coverage toward AC2/AC3 by reducing remaining candidate-probe overhead in build/work suggestion paths.
- Consolidation coverage for helper de-duplication in issue analysis (`_append...` / overture progression helper de-duplication).
- No claim of full issue completion in this PR.

## Tests
- `dart test packages/colonizethis_logic/test/orders/incremental_candidate_validator_equivalence_test.dart packages/colonizethis_logic/test/orders/incremental_candidate_validator_equivalence_army_naval_test.dart packages/colonizethis_logic/test/order_suggestion_api_impl_test.dart`

Refs #2237

Made with [Cursor](https://cursor.com)