### PR TITLE
Complete #2237 AC2/AC3: suggestion path skips OrderEngine full-pass

### DIFF
--- a/packages/colonizethis_ai/test/full_ai_no_order_engine_validate_test.dart
+++ b/packages/colonizethis_ai/test/full_ai_no_order_engine_validate_test.dart
@@ -1,0 +1,48 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  group('Full AI + suggestion path (Refs #2237 AC2)', () {
+    tearDown(() {
+      setOrderEngineValidatePlayerOrdersWithContextTrackingForTests(false);
+    });
+
+    test('generateOrdersForPlayerFullAI does not call OrderEngine full-pass', () {
+      setOrderEngineValidatePlayerOrdersWithContextTrackingForTests(true);
+
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: const RegionData(provinces: [], units: []),
+          newWorld: const RegionData(provinces: [], units: []),
+        ),
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'England',
+            isHuman: false,
+            leaderKey: 'victoria',
+          ),
+        ],
+        hiddenAgendaByGpId: const {'gp1': 'peacemaker'},
+      );
+      const topology = MapTopology(nodes: [], edges: []);
+
+      generateOrdersForPlayerFullAI(game, topology, 'gp1');
+
+      expect(
+        orderEngineValidatePlayerOrdersWithContextInvocationCountForTests,
+        0,
+        reason:
+            'AI order generation must stay on incremental suggestion validation, '
+            'not OrderEngine.validatePlayerOrdersWithContext (Refs #2237 AC2).',
+      );
+    });
+  });
+}

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -19,6 +19,22 @@ part 'order_engine.g.dart';
 
 final _log = packageLogger();
 
+// --- Test-only instrumentation (Refs #2237 AC2) ---
+bool _trackValidatePlayerOrdersWithContextInvocationsForTests = false;
+int _validatePlayerOrdersWithContextInvocationCountForTests = 0;
+
+/// Test hook: when enabled, counts every call to [OrderEngine.validatePlayerOrdersWithContext].
+void setOrderEngineValidatePlayerOrdersWithContextTrackingForTests(
+  bool enabled,
+) {
+  _trackValidatePlayerOrdersWithContextInvocationsForTests = enabled;
+  _validatePlayerOrdersWithContextInvocationCountForTests = 0;
+}
+
+/// Test hook: invocations counted while tracking is enabled (Refs #2237).
+int get orderEngineValidatePlayerOrdersWithContextInvocationCountForTests =>
+    _validatePlayerOrdersWithContextInvocationCountForTests;
+
 /// Appends one [OrderValidationResult] per order; short-circuits when [rejected].
 /// Returns the new rejected flag (true if any result was rejected).
 bool _appendValidationResults<T>(
@@ -163,7 +179,12 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
     }
     final r = results.last;
     if (!r.isAccepted) {
-      _log.w('$orderLabel order rejected player=$playerId reason=${r.reason}');
+      // Keep diagnostics bounded on probe-heavy paths by suppressing repeated
+      // cascade rejections ("Previous invalid"), while preserving first-cause
+      // rejection logging for debugging. Refs #2237 AC3.
+      if (r.reason != previousInvalidOrderResult.reason) {
+        _log.w('$orderLabel order rejected player=$playerId reason=${r.reason}');
+      }
     }
     return r;
   }
@@ -224,6 +245,9 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
     String playerId, {
     Map<String, TileMapResult>? tileMapByRegion,
   }) {
+    if (_trackValidatePlayerOrdersWithContextInvocationsForTests) {
+      _validatePlayerOrdersWithContextInvocationCountForTests++;
+    }
     final results = <OrderValidationResult>[];
     final player = game.playerById(playerId);
     if (player == null) return results;

--- a/packages/colonizethis_logic/test/order_suggestion_no_order_engine_full_pass_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_no_order_engine_full_pass_test.dart
@@ -1,0 +1,122 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  group('Suggestion enumeration skips OrderEngine full-pass (Refs #2237)', () {
+    tearDown(() {
+      setOrderEngineValidatePlayerOrdersWithContextTrackingForTests(false);
+    });
+
+    test('suggestBuildOrders does not invoke validatePlayerOrdersWithContext', () {
+      setOrderEngineValidatePlayerOrdersWithContextTrackingForTests(true);
+
+      const playerId = 'gp1';
+      const ow = 'oldWorld';
+      final player = Player(
+        id: playerId,
+        displayName: 'GP',
+        isHuman: false,
+        capitalProvinceId: '$ow|p1',
+        workerPool: const WorkerPool(peasants: 2),
+        treasury: 500,
+      );
+      final world = WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: RegionData(
+          provinces: [Province(id: '$ow|p1', regionId: ow, ownerId: playerId)],
+          units: const [],
+        ),
+        newWorld: const RegionData(),
+      );
+      final game = Game(id: 'g1', worldState: world, players: [player]);
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(
+            id: 'p1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+        ],
+        edges: [],
+      );
+      final view = buildPlayerView(game, topology, playerId);
+
+      suggestBuildOrders(view, game, topology, const Orders());
+
+      expect(
+        orderEngineValidatePlayerOrdersWithContextInvocationCountForTests,
+        0,
+        reason:
+            'Build suggestions must use incremental candidate validation, not '
+            'OrderEngine full-pass per candidate (Refs #2237 AC2).',
+      );
+    });
+
+    test('OrderEngine add-with-context still invokes full validation', () {
+      setOrderEngineValidatePlayerOrdersWithContextTrackingForTests(true);
+
+      const playerId = 'p1';
+      const ow = 'oldWorld';
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: '$ow|P1', regionId: ow, ownerId: playerId),
+              Province(id: '$ow|P2', regionId: ow, ownerId: playerId),
+            ],
+            units: [
+              Unit(
+                id: 'u1',
+                type: kUnitTypeBuilder,
+                ownerId: playerId,
+                locationProvinceId: '$ow|P1',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            playerId: {
+              'oldWorld|P1|0|0': 'fullyVisible',
+              'oldWorld|P2|0|0': 'fullyVisible',
+            },
+          },
+        ),
+        players: const [Player(id: playerId, displayName: 'P1', isHuman: true)],
+      );
+      const topology = MapTopology(
+        nodes: [
+          TopologyNode(
+            id: 'P1',
+            regionId: ow,
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'P2',
+            regionId: ow,
+            type: TopologyNodeType.province,
+          ),
+        ],
+        edges: [TopologyEdge(id1: 'P1', id2: 'P2')],
+      );
+
+      final engine = OrderEngine();
+      engine.addMoveOrderWithContext(
+        game,
+        topology,
+        playerId,
+        const MoveOrder(unitId: 'u1', destinationTileKey: '$ow|P2|0|0'),
+      );
+
+      expect(
+        orderEngineValidatePlayerOrdersWithContextInvocationCountForTests,
+        greaterThan(0),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- **AC3 (bounded diagnostics):** Skip repeated warning logs for cascade rejections with reason `Previous invalid` in `OrderEngine._addOrderWithContext`, matching the intent of open PR #2252 (this change can supersede that PR once merged).
- **AC2 (no full-pass on suggestion path):** Add test-only instrumentation counting `OrderEngine.validatePlayerOrdersWithContext` invocations, plus regression tests proving `suggestBuildOrders` and `generateOrdersForPlayerFullAI` never trigger that full-pass entry point.

## Already on `dev` from prior work (issue #2237 scope)
- Incremental candidate validation (`IncrementalCandidateValidator`), trusted turn entry point (`validateOrdersAndResolveTurnFromTrustedOrders`), app `TurnResolutionRunner` wiring, equivalence tests, and E2E Next Turn wall-clock budget (merged PR #2251).

## Implemented in this PR
- `packages/colonizethis_logic/lib/src/orders/order_engine.dart` — cascade log suppression + test hooks.
- `packages/colonizethis_logic/test/order_suggestion_no_order_engine_full_pass_test.dart` — suggestion vs `OrderEngine` regression.
- `packages/colonizethis_ai/test/full_ai_no_order_engine_validate_test.dart` — full-AI layer regression.

## Deferred / follow-up
- None required for AC2/AC3 beyond merge; issue #2237 may still want a final verification pass across all AC checkboxes once all slices land.

## Test plan
- [x] `cd packages/colonizethis_logic && dart test test/order_suggestion_no_order_engine_full_pass_test.dart test/orders/incremental_candidate_validator_equivalence_test.dart test/turn_resolver_trusted_orders_test.dart`
- [x] `cd packages/colonizethis_ai && dart test test/full_ai_no_order_engine_validate_test.dart`

Refs #2237

Made with [Cursor](https://cursor.com)