### PR TITLE
Populate turn trace AI sections (slice for #2218)

### DIFF
--- a/app/lib/core/services/game_service.dart
+++ b/app/lib/core/services/game_service.dart
@@ -371,11 +371,16 @@ class GameService {
       config: tracedConfig,
     );
     if (result is TurnResolutionComplete) {
+      final aiTraceSections = _buildAiTraceSections(
+        gameAtResolutionStart: game,
+        orders: config.orders,
+      );
       _exportTurnTrace(
         gameAtResolutionStart: game,
         turnEndState: result.game,
         phases: session.phases,
         turnStartAt: session.startedAtUtc,
+        ai: aiTraceSections,
       );
       _turnTraceSessionsByGameId.remove(game.id);
     }
@@ -387,6 +392,7 @@ class GameService {
     required Game turnEndState,
     required List<TurnTracePhaseTrace> phases,
     required DateTime turnStartAt,
+    required List<TurnTraceAiSection> ai,
   }) {
     final now = DateTime.now().toUtc();
     final document = TurnTraceMergedDocument(
@@ -400,7 +406,7 @@ class GameService {
         turnStartAt: turnStartAt.toIso8601String(),
         turnEndAt: now.toIso8601String(),
       ),
-      ai: const <TurnTraceAiSection>[],
+      ai: ai,
       turnResolution: TurnTraceResolutionSection(
         phases: List<TurnTracePhaseTrace>.unmodifiable(phases),
       ),
@@ -422,6 +428,173 @@ class GameService {
             stackTrace: stackTrace,
           );
         });
+  }
+
+  List<TurnTraceAiSection> _buildAiTraceSections({
+    required Game gameAtResolutionStart,
+    required Orders orders,
+  }) {
+    final aiPlayers = gameAtResolutionStart.players
+        .where(
+          (player) => gameAtResolutionStart.aiControlByGpId[player.id] ?? false,
+        )
+        .toList(growable: false);
+    if (aiPlayers.isEmpty) {
+      return const <TurnTraceAiSection>[];
+    }
+    final sections = <TurnTraceAiSection>[];
+    for (final player in aiPlayers) {
+      final ordersByDomain = _orderCountsByDomain(player.id, orders);
+      final finalOrders = _finalAggregatedOrders(player.id, orders);
+      sections.add(
+        TurnTraceAiSection(
+          factionId: player.id,
+          state: <String, Object?>{
+            'winningCandidate': <String, Object?>{
+              'selection': 'submitted_orders',
+              'orderCount': finalOrders.length,
+            },
+            'topAlternates': const <Object?>[],
+            'aggregates': <String, Object?>{
+              'totalOrders': finalOrders.length,
+              'ordersByDomain': ordersByDomain,
+            },
+            'decisionContext': <String, Object?>{
+              'turnNumber':
+                  gameAtResolutionStart.worldState.turnState.turnNumber,
+            },
+          },
+          thresholds: const <String, Object?>{
+            'constants': <String, Object?>{},
+            'derived': <String, Object?>{},
+            'effective': <String, Object?>{},
+            'gates': <Object?>[],
+          },
+          outcome: <String, Object?>{
+            'domainOutputs': ordersByDomain,
+            'finalAggregatedOrders': finalOrders,
+            'emittedOrderCount': finalOrders.length,
+          },
+        ),
+      );
+    }
+    return List<TurnTraceAiSection>.unmodifiable(sections);
+  }
+
+  Map<String, Object?> _orderCountsByDomain(String playerId, Orders orders) {
+    return <String, Object?>{
+      'move':
+          (orders.moveOrdersByPlayerId[playerId] ?? const <MoveOrder>[]).length,
+      'armyMove':
+          (orders.armyMoveOrdersByPlayerId[playerId] ?? const <ArmyMoveOrder>[])
+              .length,
+      'build':
+          (orders.buildUnitOrdersByPlayerId[playerId] ??
+                  const <BuildUnitOrder>[])
+              .length,
+      'work':
+          (orders.workOrdersByPlayerId[playerId] ?? const <WorkOrder>[]).length,
+      'diplomatic':
+          (orders.diplomaticOrdersByPlayerId[playerId] ??
+                  const <DiplomaticOrder>[])
+              .length,
+      'research':
+          (orders.researchOrdersByPlayerId[playerId] ?? const <ResearchOrder>[])
+              .length,
+      'navalMove':
+          (orders.navalMoveOrdersByPlayerId[playerId] ??
+                  const <NavalMoveOrder>[])
+              .length,
+      'navalMission':
+          (orders.navalMissionOrdersByPlayerId[playerId] ??
+                  const <NavalMissionOrder>[])
+              .length,
+    };
+  }
+
+  List<Map<String, Object?>> _finalAggregatedOrders(
+    String playerId,
+    Orders orders,
+  ) {
+    final aggregated = <Map<String, Object?>>[];
+    for (final order
+        in orders.moveOrdersByPlayerId[playerId] ?? const <MoveOrder>[]) {
+      aggregated.add(<String, Object?>{
+        'domain': 'move',
+        'unitId': order.unitId,
+        'destinationTileKey': order.destinationTileKey,
+      });
+    }
+    for (final order
+        in orders.armyMoveOrdersByPlayerId[playerId] ??
+            const <ArmyMoveOrder>[]) {
+      aggregated.add(<String, Object?>{
+        'domain': 'armyMove',
+        'armyId': order.armyId,
+        'destinationProvinceId': order.destinationProvinceId,
+      });
+    }
+    for (final order
+        in orders.buildUnitOrdersByPlayerId[playerId] ??
+            const <BuildUnitOrder>[]) {
+      aggregated.add(<String, Object?>{
+        'domain': 'build',
+        'unitType': order.unitType,
+        'spawnProvinceId': order.spawnProvinceId,
+      });
+    }
+    for (final order
+        in orders.workOrdersByPlayerId[playerId] ?? const <WorkOrder>[]) {
+      aggregated.add(<String, Object?>{
+        'domain': 'work',
+        'unitId': order.unitId,
+        'targetTileKey': order.targetTileKey,
+        'target': order.target,
+      });
+    }
+    for (final order
+        in orders.diplomaticOrdersByPlayerId[playerId] ??
+            const <DiplomaticOrder>[]) {
+      aggregated.add(<String, Object?>{
+        'domain': 'diplomatic',
+        'type': order.type.name,
+        'targetFactionId': order.targetFactionId,
+        if (order.amount != null) 'amount': order.amount,
+      });
+    }
+    for (final order
+        in orders.researchOrdersByPlayerId[playerId] ??
+            const <ResearchOrder>[]) {
+      aggregated.add(<String, Object?>{
+        'domain': 'research',
+        'slotIndex': order.slotIndex,
+        'techId': order.techId,
+        'funding': order.funding.name,
+      });
+    }
+    for (final order
+        in orders.navalMoveOrdersByPlayerId[playerId] ??
+            const <NavalMoveOrder>[]) {
+      aggregated.add(<String, Object?>{
+        'domain': 'navalMove',
+        'fleetId': order.fleetId,
+        'isDock': order.isDock,
+        'destinationSeaZoneId': order.destinationSeaZoneId,
+        'destinationPortProvinceId': order.destinationPortProvinceId,
+      });
+    }
+    for (final order
+        in orders.navalMissionOrdersByPlayerId[playerId] ??
+            const <NavalMissionOrder>[]) {
+      aggregated.add(<String, Object?>{
+        'domain': 'navalMission',
+        'fleetId': order.fleetId,
+        'mission': order.mission,
+        'targetProvinceId': order.targetProvinceId,
+        'targetPortId': order.targetPortId,
+      });
+    }
+    return List<Map<String, Object?>>.unmodifiable(aggregated);
   }
 
   /// Number of coarse progress steps reported by [createNewGameAsync]. SPEC/ui/game-initializing.md.

--- a/app/test/game_service_cache_test.dart
+++ b/app/test/game_service_cache_test.dart
@@ -186,9 +186,12 @@ void main() {
           id: 'trace_app_game',
           config: config,
         );
+        final aiEnabledGame = game.copyWith(
+          aiControlByGpId: {for (final player in game.players) player.id: true},
+        );
 
         final result = traceService.runTurnResolution(
-          game,
+          aiEnabledGame,
           orders: const Orders(),
         );
         expect(result, isA<TurnResolutionComplete>());
@@ -213,6 +216,13 @@ void main() {
             ((payload['turnResolution'] as Map<String, dynamic>)['phases']
                 as List<dynamic>);
         expect(phases, isNotEmpty);
+        final ai = payload['ai'] as List<dynamic>;
+        expect(ai, isNotEmpty);
+        final firstAi = ai.first as Map<String, dynamic>;
+        expect(firstAi['factionId'], isNotEmpty);
+        expect(firstAi['state'], isA<Map<String, dynamic>>());
+        expect(firstAi['thresholds'], isA<Map<String, dynamic>>());
+        expect(firstAi['outcome'], isA<Map<String, dynamic>>());
       },
     );
   });

--- a/ctdev/lib/sim_game_controller.dart
+++ b/ctdev/lib/sim_game_controller.dart
@@ -340,7 +340,12 @@ class SimGameController {
     );
     _game = next;
     if (turnTraceEnabled) {
-      _exportTurnTrace(before: before, after: next, phases: phaseTraces);
+      _exportTurnTrace(
+        before: before,
+        after: next,
+        phases: phaseTraces,
+        orders: orders,
+      );
     }
     _recordTurnLog(before: before, after: next);
   }
@@ -349,6 +354,7 @@ class SimGameController {
     required Game before,
     required Game after,
     required List<TurnTracePhaseTrace> phases,
+    required Orders orders,
   }) {
     final now = DateTime.now().toUtc();
     final document = TurnTraceMergedDocument(
@@ -361,7 +367,7 @@ class SimGameController {
         exportedAt: now.toIso8601String(),
         turnEndAt: now.toIso8601String(),
       ),
-      ai: const <TurnTraceAiSection>[],
+      ai: _buildAiTraceSections(before: before, orders: orders),
       turnResolution: TurnTraceResolutionSection(
         phases: List<TurnTracePhaseTrace>.unmodifiable(phases),
       ),
@@ -383,6 +389,170 @@ class SimGameController {
             stackTrace: stackTrace,
           );
         });
+  }
+
+  List<TurnTraceAiSection> _buildAiTraceSections({
+    required Game before,
+    required Orders orders,
+  }) {
+    final aiPlayers = before.players
+        .where((player) => before.aiControlByGpId[player.id] ?? false)
+        .toList(growable: false);
+    if (aiPlayers.isEmpty) {
+      return const <TurnTraceAiSection>[];
+    }
+    final sections = <TurnTraceAiSection>[];
+    for (final player in aiPlayers) {
+      final ordersByDomain = _orderCountsByDomain(player.id, orders);
+      final finalOrders = _finalAggregatedOrders(player.id, orders);
+      sections.add(
+        TurnTraceAiSection(
+          factionId: player.id,
+          state: <String, Object?>{
+            'winningCandidate': <String, Object?>{
+              'selection': 'submitted_orders',
+              'orderCount': finalOrders.length,
+            },
+            'topAlternates': const <Object?>[],
+            'aggregates': <String, Object?>{
+              'totalOrders': finalOrders.length,
+              'ordersByDomain': ordersByDomain,
+            },
+            'decisionContext': <String, Object?>{
+              'turnNumber': before.worldState.turnState.turnNumber,
+            },
+          },
+          thresholds: const <String, Object?>{
+            'constants': <String, Object?>{},
+            'derived': <String, Object?>{},
+            'effective': <String, Object?>{},
+            'gates': <Object?>[],
+          },
+          outcome: <String, Object?>{
+            'domainOutputs': ordersByDomain,
+            'finalAggregatedOrders': finalOrders,
+            'emittedOrderCount': finalOrders.length,
+          },
+        ),
+      );
+    }
+    return List<TurnTraceAiSection>.unmodifiable(sections);
+  }
+
+  Map<String, Object?> _orderCountsByDomain(String playerId, Orders orders) {
+    return <String, Object?>{
+      'move':
+          (orders.moveOrdersByPlayerId[playerId] ?? const <MoveOrder>[]).length,
+      'armyMove':
+          (orders.armyMoveOrdersByPlayerId[playerId] ?? const <ArmyMoveOrder>[])
+              .length,
+      'build':
+          (orders.buildUnitOrdersByPlayerId[playerId] ??
+                  const <BuildUnitOrder>[])
+              .length,
+      'work':
+          (orders.workOrdersByPlayerId[playerId] ?? const <WorkOrder>[]).length,
+      'diplomatic':
+          (orders.diplomaticOrdersByPlayerId[playerId] ??
+                  const <DiplomaticOrder>[])
+              .length,
+      'research':
+          (orders.researchOrdersByPlayerId[playerId] ?? const <ResearchOrder>[])
+              .length,
+      'navalMove':
+          (orders.navalMoveOrdersByPlayerId[playerId] ??
+                  const <NavalMoveOrder>[])
+              .length,
+      'navalMission':
+          (orders.navalMissionOrdersByPlayerId[playerId] ??
+                  const <NavalMissionOrder>[])
+              .length,
+    };
+  }
+
+  List<Map<String, Object?>> _finalAggregatedOrders(
+    String playerId,
+    Orders orders,
+  ) {
+    final aggregated = <Map<String, Object?>>[];
+    for (final order
+        in orders.moveOrdersByPlayerId[playerId] ?? const <MoveOrder>[]) {
+      aggregated.add(<String, Object?>{
+        'domain': 'move',
+        'unitId': order.unitId,
+        'destinationTileKey': order.destinationTileKey,
+      });
+    }
+    for (final order
+        in orders.armyMoveOrdersByPlayerId[playerId] ??
+            const <ArmyMoveOrder>[]) {
+      aggregated.add(<String, Object?>{
+        'domain': 'armyMove',
+        'armyId': order.armyId,
+        'destinationProvinceId': order.destinationProvinceId,
+      });
+    }
+    for (final order
+        in orders.buildUnitOrdersByPlayerId[playerId] ??
+            const <BuildUnitOrder>[]) {
+      aggregated.add(<String, Object?>{
+        'domain': 'build',
+        'unitType': order.unitType,
+        'spawnProvinceId': order.spawnProvinceId,
+      });
+    }
+    for (final order
+        in orders.workOrdersByPlayerId[playerId] ?? const <WorkOrder>[]) {
+      aggregated.add(<String, Object?>{
+        'domain': 'work',
+        'unitId': order.unitId,
+        'targetTileKey': order.targetTileKey,
+        'target': order.target,
+      });
+    }
+    for (final order
+        in orders.diplomaticOrdersByPlayerId[playerId] ??
+            const <DiplomaticOrder>[]) {
+      aggregated.add(<String, Object?>{
+        'domain': 'diplomatic',
+        'type': order.type.name,
+        'targetFactionId': order.targetFactionId,
+        if (order.amount != null) 'amount': order.amount,
+      });
+    }
+    for (final order
+        in orders.researchOrdersByPlayerId[playerId] ??
+            const <ResearchOrder>[]) {
+      aggregated.add(<String, Object?>{
+        'domain': 'research',
+        'slotIndex': order.slotIndex,
+        'techId': order.techId,
+        'funding': order.funding.name,
+      });
+    }
+    for (final order
+        in orders.navalMoveOrdersByPlayerId[playerId] ??
+            const <NavalMoveOrder>[]) {
+      aggregated.add(<String, Object?>{
+        'domain': 'navalMove',
+        'fleetId': order.fleetId,
+        'isDock': order.isDock,
+        'destinationSeaZoneId': order.destinationSeaZoneId,
+        'destinationPortProvinceId': order.destinationPortProvinceId,
+      });
+    }
+    for (final order
+        in orders.navalMissionOrdersByPlayerId[playerId] ??
+            const <NavalMissionOrder>[]) {
+      aggregated.add(<String, Object?>{
+        'domain': 'navalMission',
+        'fleetId': order.fleetId,
+        'mission': order.mission,
+        'targetProvinceId': order.targetProvinceId,
+        'targetPortId': order.targetPortId,
+      });
+    }
+    return List<Map<String, Object?>>.unmodifiable(aggregated);
   }
 
   void _recordCombatGameEvent(GameEvent event) {

--- a/ctdev/test/sim_game_controller_test.dart
+++ b/ctdev/test/sim_game_controller_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
@@ -24,9 +27,7 @@ void main() {
             type: TopologyNodeType.province,
           ),
         ],
-        edges: const [
-          TopologyEdge(id1: 'P1', id2: 'P2'),
-        ],
+        edges: const [TopologyEdge(id1: 'P1', id2: 'P2')],
       );
 
       final game = Game(
@@ -108,9 +109,7 @@ void main() {
             type: TopologyNodeType.province,
           ),
         ],
-        edges: const [
-          TopologyEdge(id1: 'P1', id2: 'P2'),
-        ],
+        edges: const [TopologyEdge(id1: 'P1', id2: 'P2')],
       );
 
       final game = Game(
@@ -174,7 +173,12 @@ void main() {
 
       controller.stepFullTurn();
 
-      expect(controller.orderHistory, isNotEmpty, reason: 'AI uses suggestion API; visibility must be set so moves are suggested');
+      expect(
+        controller.orderHistory,
+        isNotEmpty,
+        reason:
+            'AI uses suggestion API; visibility must be set so moves are suggested',
+      );
       for (final entry in controller.orderHistory) {
         expect(entry.turnNumber, 0);
         expect(entry.playerId, 'p1');
@@ -195,9 +199,7 @@ void main() {
             type: TopologyNodeType.province,
           ),
         ],
-        edges: const [
-          TopologyEdge(id1: 'P1', id2: 'P2'),
-        ],
+        edges: const [TopologyEdge(id1: 'P1', id2: 'P2')],
       );
 
       final game = Game(
@@ -291,22 +293,134 @@ void main() {
 
       controller.advanceTurnForTesting(orders);
 
-      final researchEntries =
-          controller.orderHistory.where((e) => e.orderType == 'research').toList();
+      final researchEntries = controller.orderHistory
+          .where((e) => e.orderType == 'research')
+          .toList();
       expect(researchEntries, hasLength(1));
       expect(researchEntries.single.summary, contains('Printing Press'));
       expect(researchEntries.single.status, OrderValidationStatus.accepted);
 
-      final navalEntries =
-          controller.orderHistory.where((e) => e.orderType == 'naval_move').toList();
+      final navalEntries = controller.orderHistory
+          .where((e) => e.orderType == 'naval_move')
+          .toList();
       expect(navalEntries, hasLength(1));
       expect(navalEntries.single.status, OrderValidationStatus.rejected);
 
-      final moveEntries =
-          controller.orderHistory.where((e) => e.orderType == 'move').toList();
+      final moveEntries = controller.orderHistory
+          .where((e) => e.orderType == 'move')
+          .toList();
       expect(moveEntries, hasLength(1));
       expect(moveEntries.single.status, OrderValidationStatus.accepted);
     });
+
+    test('turn trace export includes AI sections when enabled', () async {
+      final traceRoot = await Directory.systemTemp.createTemp(
+        'ct_turn_trace_ctdev_',
+      );
+      addTearDown(() async {
+        if (await traceRoot.exists()) {
+          await traceRoot.delete(recursive: true);
+        }
+      });
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(
+            id: 'P1',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'P2',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+        ],
+        edges: const [TopologyEdge(id1: 'P1', id2: 'P2')],
+      );
+
+      final game = Game(
+        id: 'g_trace',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'oldWorld|P1', regionId: 'oldWorld', ownerId: 'p1'),
+              Province(id: 'oldWorld|P2', regionId: 'oldWorld', ownerId: 'p1'),
+            ],
+            units: [
+              Unit(
+                id: 'u1',
+                type: 'grenadiers',
+                ownerId: 'p1',
+                locationProvinceId: 'oldWorld|P1',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          playerVisibilityByTile: const {
+            'p1': {
+              'oldWorld|P1|0|0': 'fullyVisible',
+              'oldWorld|P2|0|0': 'fullyVisible',
+            },
+          },
+        ),
+        players: const [
+          Player(id: 'p1', displayName: 'Power 1', isHuman: true),
+        ],
+      );
+
+      final tileMapByRegion = <String, TileMapResult>{
+        'oldWorld': TileMapResult(
+          width: 1,
+          height: 2,
+          grid: const [
+            ['P1'],
+            ['P2'],
+          ],
+          resourceGrid: const [
+            [Resource.grain],
+            [Resource.grain],
+          ],
+        ),
+        'newWorld': TileMapResult(
+          width: 0,
+          height: 0,
+          grid: const [],
+          resourceGrid: const [],
+        ),
+      };
+
+      final controller = SimGameController(
+        initialGame: game,
+        topology: topology,
+        tileMapByRegion: tileMapByRegion,
+        baseSeed: 123,
+        turnTraceEnabled: true,
+        turnTraceRootDirectory: traceRoot.path,
+      );
+      controller.stepFullTurn();
+
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      final traceDir = Directory('${traceRoot.path}/turn-traces/${game.id}');
+      expect(await traceDir.exists(), isTrue);
+      final files = traceDir
+          .listSync()
+          .whereType<File>()
+          .where((file) => file.path.endsWith('.json'))
+          .toList();
+      expect(files, hasLength(1));
+      final payload =
+          jsonDecode(await files.single.readAsString()) as Map<String, dynamic>;
+      expect(payload['schemaVersion'], 'v1');
+      final meta = payload['meta'] as Map<String, dynamic>;
+      expect(meta['source'], 'ctdev');
+      final ai = payload['ai'] as List<dynamic>;
+      expect(ai, isNotEmpty);
+      final firstAi = ai.first as Map<String, dynamic>;
+      expect(firstAi['factionId'], 'p1');
+      expect(firstAi['state'], isA<Map<String, dynamic>>());
+      expect(firstAi['thresholds'], isA<Map<String, dynamic>>());
+      expect(firstAi['outcome'], isA<Map<String, dynamic>>());
+    });
   });
 }
-


### PR DESCRIPTION
## Summary
- Populate merged turn trace `ai` sections in both app and ctdev exporters from submitted per-faction orders instead of emitting an always-empty array.
- Capture schema-compatible `state`, `thresholds`, and `outcome` objects per AI-controlled faction, including per-domain counts and `finalAggregatedOrders` payloads.
- Add regression tests in app and ctdev that assert exported traces include non-empty AI sections.

## Implemented in this slice
- Requirement coverage now addressed in this slice:
  - R4 (partial): per-AI sections are now exported with structured state/threshold/outcome payloads.
  - R5 (partial): AI outcome section now includes final aggregated emitted orders by domain.
- Files:
  - `app/lib/core/services/game_service.dart`
  - `ctdev/lib/sim_game_controller.dart`
  - `app/test/game_service_cache_test.dart`
  - `ctdev/test/sim_game_controller_test.dart`

## Deferred work
- AI internals are currently observational summaries from resolved orders, not full planner-internal candidate/threshold gate traces.
- Tactical quick-battle internals and richer per-domain planner debug fields remain for follow-up slices.
- Remaining order-event granularity/performance verification work from #2218 also remains out of scope for this PR.

## Test Plan
- [x] `cd app && flutter test test/game_service_cache_test.dart`
- [x] `cd ctdev && flutter test test/sim_game_controller_test.dart`

Refs #2218

Made with [Cursor](https://cursor.com)