### PR TITLE
Trace bundled work movement order events (slice for #2218)

### DIFF
--- a/SPEC/program/turn-resolution-json-trace.md
+++ b/SPEC/program/turn-resolution-json-trace.md
@@ -85,10 +85,17 @@ Each order event requires:
 - `eventType`: string.
 
 When structured tracing is enabled with `TurnResolverConfig.turnTraceRuntime`
-and `onTurnTracePhase`, the Movement phase records civilian `MoveOrder`
-attempts in apply order: `civilian_move_applied` or `civilian_move_ignored`
-with optional `ignoreReason` in the event `payload`. Other phases may emit
-empty `orderEvents` until additional hooks land (GitHub #2218).
+and `onTurnTracePhase`, the Movement phase records civilian order attempts in
+apply order with these `eventType` values:
+
+- `civilian_move_applied` / `civilian_move_ignored` for direct `MoveOrder`
+  handling.
+- `bundled_work_move_applied` / `bundled_work_move_skipped` for implicit move
+  legs emitted while preparing `WorkOrder` execution.
+
+Movement event payloads include destination tile/province context and optional
+`ignoreReason` for skipped/ignored attempts. Other phases may emit empty
+`orderEvents` until additional hooks land (GitHub #2218).
 
 ### Merged trace (`merged-trace.v1.schema.json`)
 
@@ -127,7 +134,7 @@ Meta section requires:
 - Given a JSON payload intended as a turn-resolution trace, when validated against `turn-resolution-trace.v1.schema.json`, then validation passes only if each phase contains `beforeState`, `afterState`, and ordered `orderEvents` entries with non-negative `sequence`.
 - Given a JSON payload intended as a merged logical-turn trace, when validated against `merged-trace.v1.schema.json`, then validation passes only if `meta`, `ai`, and `turnResolution` are present and nested sections satisfy referenced contracts.
 - Given a payload with missing required fields for any of the three trace schemas, when validated, then validation fails deterministically with at least one schema violation.
-- Given turn resolution runs with `TurnResolverConfig.onTurnTracePhase` and `turnTraceRuntime` set, when each phase resolves (including pending-exit phases), then the callback receives one `TurnTracePhaseTrace` payload per phase containing `phaseId`, full `beforeState`, full `afterState`, and an ordered `orderEvents` array (Movement phase includes civilian move apply/ignore events when move orders are present; other phases may still emit empty `orderEvents` until further hooks land).
+- Given turn resolution runs with `TurnResolverConfig.onTurnTracePhase` and `turnTraceRuntime` set, when each phase resolves (including pending-exit phases), then the callback receives one `TurnTracePhaseTrace` payload per phase containing `phaseId`, full `beforeState`, full `afterState`, and an ordered `orderEvents` array (Movement phase includes direct civilian move apply/ignore events and bundled work move applied/skipped events when those orders are present; other phases may still emit empty `orderEvents` until further hooks land).
 - Given no custom trace root override is provided, when the system exports a merged turn trace for `gameId = G` and `turnNumber = N`, then the system writes one JSON file to `tmp/turn-traces/G/` using filename pattern `turn-N-YYYYMMDDTHHMMSSmmmZ.json`.
 - Given a custom trace root override path `R` is provided, when the system exports a merged turn trace for `gameId = G`, then the system writes to `R/turn-traces/G/` and keeps the same filename pattern.
 - Given a game trace directory contains more than 10 trace JSON files after a new export, when retention runs, then the system deletes oldest files first until exactly 10 files remain in that gameId directory.

--- a/packages/colonizethis_logic/lib/src/turn/phases/movement_phase.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases/movement_phase.dart
@@ -17,6 +17,7 @@ Game runMovementPhase(
   MapTopology topology,
   Orders orders, {
   CivilianMoveOrderTraceCallback? onCivilianMoveOrderTrace,
+  BundledWorkMoveTraceCallback? onBundledWorkMoveTrace,
 }) {
   var state = game;
 
@@ -71,7 +72,12 @@ Game runMovementPhase(
       ),
     );
   }
-  state = applyImplicitBundledCivilianWorkOrderMoves(state, topology, orders);
+  state = applyImplicitBundledCivilianWorkOrderMoves(
+    state,
+    topology,
+    orders,
+    onBundledWorkMoveTrace: onBundledWorkMoveTrace,
+  );
 
   final armyMoveOrders = orders.armyMoveOrdersByPlayerId;
   if (armyMoveOrders.isNotEmpty) {
@@ -123,8 +129,9 @@ Game runMovementPhase(
 Game applyImplicitBundledCivilianWorkOrderMoves(
   Game game,
   MapTopology topology,
-  Orders orders,
-) {
+  Orders orders, {
+  BundledWorkMoveTraceCallback? onBundledWorkMoveTrace,
+}) {
   var state = game;
   final workByPlayerId = orders.workOrdersByPlayerId;
   if (workByPlayerId.isEmpty) {
@@ -140,9 +147,21 @@ Game applyImplicitBundledCivilianWorkOrderMoves(
       final unitById = unitsByIdFromWorld(state.worldState);
       final unit = unitById[workOrder.unitId];
       if (unit == null || unit.ownerId != playerId) {
+        onBundledWorkMoveTrace?.call(
+          playerId: playerId,
+          order: workOrder,
+          applied: false,
+          ignoreReason: 'missing_or_foreign_unit',
+        );
         continue;
       }
       if (!civilianBundledWorkNeedsProvinceMoveLeg(state, unit, workOrder)) {
+        onBundledWorkMoveTrace?.call(
+          playerId: playerId,
+          order: workOrder,
+          applied: false,
+          ignoreReason: 'move_leg_not_required',
+        );
         continue;
       }
       final destination = executionProvinceFullIdFromWorkOrder(
@@ -150,6 +169,12 @@ Game applyImplicitBundledCivilianWorkOrderMoves(
         workOrder,
       );
       if (destination == null) {
+        onBundledWorkMoveTrace?.call(
+          playerId: playerId,
+          order: workOrder,
+          applied: false,
+          ignoreReason: 'destination_unresolved',
+        );
         continue;
       }
       final view = buildPlayerView(state, topology, playerId);
@@ -165,6 +190,13 @@ Game applyImplicitBundledCivilianWorkOrderMoves(
         diplomaticOrders: diplomatic,
       );
       if (destinationTile == null) {
+        onBundledWorkMoveTrace?.call(
+          playerId: playerId,
+          order: workOrder,
+          applied: false,
+          destinationProvinceId: destination,
+          ignoreReason: 'destination_tile_unavailable',
+        );
         continue;
       }
 
@@ -181,6 +213,13 @@ Game applyImplicitBundledCivilianWorkOrderMoves(
           }
           return next;
         }),
+      );
+      onBundledWorkMoveTrace?.call(
+        playerId: playerId,
+        order: workOrder,
+        applied: true,
+        destinationProvinceId: destination,
+        destinationTileKey: destinationTile,
       );
     }
   }

--- a/packages/colonizethis_logic/lib/src/turn/trace/turn_trace_runtime.dart
+++ b/packages/colonizethis_logic/lib/src/turn/trace/turn_trace_runtime.dart
@@ -2,12 +2,23 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'turn_trace_contracts.dart';
 
-typedef CivilianMoveOrderTraceCallback = void Function({
-  required String playerId,
-  required MoveOrder order,
-  required bool applied,
-  String? ignoreReason,
-});
+typedef CivilianMoveOrderTraceCallback =
+    void Function({
+      required String playerId,
+      required MoveOrder order,
+      required bool applied,
+      String? ignoreReason,
+    });
+
+typedef BundledWorkMoveTraceCallback =
+    void Function({
+      required String playerId,
+      required WorkOrder order,
+      required bool applied,
+      String? destinationProvinceId,
+      String? destinationTileKey,
+      String? ignoreReason,
+    });
 
 /// Mutable per-turn-resolution buffer for order-level trace events within the
 /// current phase. Cleared at each phase boundary by [turn_phase_runner]; read
@@ -40,6 +51,34 @@ class TurnTraceRuntime {
         eventType: applied ? 'civilian_move_applied' : 'civilian_move_ignored',
         payload: <String, Object?>{
           'destinationTileKey': order.destinationTileKey,
+          if (ignoreReason != null) 'ignoreReason': ignoreReason,
+        },
+      ),
+    );
+  }
+
+  /// Records one implicit move leg generated for a civilian [WorkOrder].
+  void handleBundledWorkMoveTrace({
+    required String playerId,
+    required WorkOrder order,
+    required bool applied,
+    String? destinationProvinceId,
+    String? destinationTileKey,
+    String? ignoreReason,
+  }) {
+    _phaseOrderEvents.add(
+      TurnTraceOrderEvent(
+        sequence: _nextSequence++,
+        orderId: 'work:$playerId:${order.unitId}:${order.target}',
+        eventType: applied
+            ? 'bundled_work_move_applied'
+            : 'bundled_work_move_skipped',
+        payload: <String, Object?>{
+          'targetTileKey': order.targetTileKey,
+          if (destinationProvinceId != null)
+            'destinationProvinceId': destinationProvinceId,
+          if (destinationTileKey != null)
+            'destinationTileKey': destinationTileKey,
           if (ignoreReason != null) 'ignoreReason': ignoreReason,
         },
       ),

--- a/packages/colonizethis_logic/lib/src/turn/turn_phase_runner.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_phase_runner.dart
@@ -88,7 +88,8 @@ void _emitPhaseTrace({
   required Map<String, Object?> beforeState,
   required Map<String, Object?> afterState,
 }) {
-  final orderEvents = config.turnTraceRuntime?.snapshotPhaseOrderEvents() ??
+  final orderEvents =
+      config.turnTraceRuntime?.snapshotPhaseOrderEvents() ??
       const <TurnTraceOrderEvent>[];
   config.onTurnTracePhase?.call(
     TurnTracePhaseTrace(
@@ -278,6 +279,8 @@ TurnPhaseStepOutcome _runMovementPhaseHandler(
         config.orders,
         onCivilianMoveOrderTrace:
             config.turnTraceRuntime?.handleCivilianMoveOrderTrace,
+        onBundledWorkMoveTrace:
+            config.turnTraceRuntime?.handleBundledWorkMoveTrace,
       ),
     ),
   );

--- a/packages/colonizethis_logic/test/turn_trace_movement_order_events_test.dart
+++ b/packages/colonizethis_logic/test/turn_trace_movement_order_events_test.dart
@@ -5,53 +5,126 @@ import 'package:colonizethis_test/test.dart';
 
 void main() {
   group('turn trace movement order events', () {
-    test('applyCivilianTileMoveOrdersToWorldRegions invokes trace for applied move',
-        () {
-      const ow = 'oldWorld';
-      final game = Game(
-        id: 'g',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            provinces: const [
-              Province(id: 'oldWorld|P1', regionId: ow, ownerId: 'p1'),
-              Province(id: 'oldWorld|P2', regionId: ow, ownerId: 'p1'),
-            ],
-            units: [
-              Unit(
-                id: 'u1',
-                type: kUnitTypeMerchant,
-                ownerId: 'p1',
-                locationProvinceId: 'oldWorld|P1',
-                tileKey: 'oldWorld|P1|0|0',
+    test(
+      'applyCivilianTileMoveOrdersToWorldRegions invokes trace for applied move',
+      () {
+        const ow = 'oldWorld';
+        final game = Game(
+          id: 'g',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(id: 'oldWorld|P1', regionId: ow, ownerId: 'p1'),
+                Province(id: 'oldWorld|P2', regionId: ow, ownerId: 'p1'),
+              ],
+              units: [
+                Unit(
+                  id: 'u1',
+                  type: kUnitTypeMerchant,
+                  ownerId: 'p1',
+                  locationProvinceId: 'oldWorld|P1',
+                  tileKey: 'oldWorld|P1|0|0',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+        );
+        const order = MoveOrder(
+          unitId: 'u1',
+          destinationTileKey: 'oldWorld|P2|3|3',
+        );
+        final runtime = TurnTraceRuntime();
+        applyCivilianTileMoveOrdersToWorldRegions(game, const {
+          'p1': [order],
+        }, onCivilianMoveOrderTrace: runtime.handleCivilianMoveOrderTrace);
+
+        final events = runtime.snapshotPhaseOrderEvents();
+        expect(events, hasLength(1));
+        expect(events.single.eventType, 'civilian_move_applied');
+        expect(events.single.orderId, 'move:p1:u1');
+        expect(events.single.sequence, 0);
+      },
+    );
+
+    test(
+      'full pipeline movement phase includes civilian move order events',
+      () {
+        const ow = 'oldWorld';
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'oldWorld|P1',
+              regionId: ow,
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'oldWorld|P2',
+              regionId: ow,
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: const [TopologyEdge(id1: 'oldWorld|P1', id2: 'oldWorld|P2')],
+        );
+        final game = Game(
+          id: 'g',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(id: 'oldWorld|P1', regionId: ow, ownerId: 'p1'),
+                Province(id: 'oldWorld|P2', regionId: ow, ownerId: 'p1'),
+              ],
+              units: [
+                Unit(
+                  id: 'u1',
+                  type: kUnitTypeMerchant,
+                  ownerId: 'p1',
+                  locationProvinceId: 'oldWorld|P1',
+                  tileKey: 'oldWorld|P1|0|0',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+        );
+        final orders = Orders(
+          moveOrdersByPlayerId: {
+            'p1': [
+              const MoveOrder(
+                unitId: 'u1',
+                destinationTileKey: 'oldWorld|P2|0|0',
               ),
             ],
+          },
+        );
+        final traces = <TurnTracePhaseTrace>[];
+        final runtime = TurnTraceRuntime();
+        resolveTurnForGameWithConfig(
+          game: game,
+          config: TurnResolverConfig(
+            topology: topology,
+            orders: orders,
+            onTurnTracePhase: traces.add,
+            turnTraceRuntime: runtime,
           ),
-          newWorld: const RegionData(),
-        ),
-        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
-      );
-      const order = MoveOrder(
-        unitId: 'u1',
-        destinationTileKey: 'oldWorld|P2|3|3',
-      );
-      final runtime = TurnTraceRuntime();
-      applyCivilianTileMoveOrdersToWorldRegions(
-        game,
-        const {
-          'p1': [order],
-        },
-        onCivilianMoveOrderTrace: runtime.handleCivilianMoveOrderTrace,
-      );
+        );
 
-      final events = runtime.snapshotPhaseOrderEvents();
-      expect(events, hasLength(1));
-      expect(events.single.eventType, 'civilian_move_applied');
-      expect(events.single.orderId, 'move:p1:u1');
-      expect(events.single.sequence, 0);
-    });
+        final movementTrace = traces.firstWhere(
+          (t) => t.phaseId == TurnPhase.movement.name,
+        );
+        expect(movementTrace.orderEvents, isNotEmpty);
+        expect(
+          movementTrace.orderEvents.map((e) => e.eventType),
+          contains('civilian_move_applied'),
+        );
+      },
+    );
 
-    test('full pipeline movement phase includes civilian move order events', () {
+    test('bundled work move trace records skipped attempts in movement phase', () {
       const ow = 'oldWorld';
       final topology = MapTopology(
         nodes: const [
@@ -66,9 +139,7 @@ void main() {
             type: TopologyNodeType.province,
           ),
         ],
-        edges: const [
-          TopologyEdge(id1: 'oldWorld|P1', id2: 'oldWorld|P2'),
-        ],
+        edges: const [TopologyEdge(id1: 'oldWorld|P1', id2: 'oldWorld|P2')],
       );
       final game = Game(
         id: 'g',
@@ -87,16 +158,37 @@ void main() {
                 locationProvinceId: 'oldWorld|P1',
                 tileKey: 'oldWorld|P1|0|0',
               ),
+              Unit(
+                id: 'u2',
+                type: kUnitTypeMerchant,
+                ownerId: 'p1',
+                locationProvinceId: 'oldWorld|P1',
+                tileKey: 'oldWorld|P1|1|1',
+              ),
             ],
           ),
           newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: const {
+            ow: {
+              'oldWorld|P2': ['oldWorld|P2|2|2'],
+            },
+          },
         ),
         players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
       );
       final orders = Orders(
-        moveOrdersByPlayerId: {
+        workOrdersByPlayerId: {
           'p1': [
-            const MoveOrder(unitId: 'u1', destinationTileKey: 'oldWorld|P2|0|0'),
+            const WorkOrder(
+              unitId: 'u1',
+              target: 'build_farm',
+              targetTileKey: 'oldWorld|P2|2|2',
+            ),
+            const WorkOrder(
+              unitId: 'u2',
+              target: 'explore',
+              targetTileKey: 'oldWorld|P1|1|1',
+            ),
           ],
         },
       );
@@ -115,11 +207,31 @@ void main() {
       final movementTrace = traces.firstWhere(
         (t) => t.phaseId == TurnPhase.movement.name,
       );
-      expect(movementTrace.orderEvents, isNotEmpty);
       expect(
-        movementTrace.orderEvents.map((e) => e.eventType),
-        contains('civilian_move_applied'),
+        movementTrace.orderEvents.map((event) => event.eventType),
+        contains('bundled_work_move_skipped'),
       );
+    });
+
+    test('runtime records bundled work move applied event payload', () {
+      final runtime = TurnTraceRuntime();
+      runtime.handleBundledWorkMoveTrace(
+        playerId: 'p1',
+        order: const WorkOrder(
+          unitId: 'u1',
+          target: 'build_farm',
+          targetTileKey: 'oldWorld|P2|2|2',
+        ),
+        applied: true,
+        destinationProvinceId: 'oldWorld|P2',
+        destinationTileKey: 'oldWorld|P2|2|2',
+      );
+
+      final event = runtime.snapshotPhaseOrderEvents().single;
+      expect(event.eventType, 'bundled_work_move_applied');
+      expect(event.orderId, 'work:p1:u1:build_farm');
+      expect(event.payload?['destinationProvinceId'], 'oldWorld|P2');
+      expect(event.payload?['destinationTileKey'], 'oldWorld|P2|2|2');
     });
   });
 }

--- a/packages/colonizethis_logic/test/turn_trace_movement_order_events_test.dart
+++ b/packages/colonizethis_logic/test/turn_trace_movement_order_events_test.dart
@@ -186,7 +186,7 @@ void main() {
             ),
             const WorkOrder(
               unitId: 'u2',
-              target: 'explore',
+              target: kWorkTargetExplore,
               targetTileKey: 'oldWorld|P1|1|1',
             ),
           ],


### PR DESCRIPTION
## Summary
- Record bundled work movement-leg trace events in the Movement phase via `TurnTraceRuntime` (`bundled_work_move_applied` / `bundled_work_move_skipped`) with destination and ignore-reason payload fields.
- Wire the new callback through movement phase execution and update the turn-trace SPEC to authorize bundled work movement events in phase `orderEvents`.
- Add/adjust tests for bundled work trace behavior and runtime event payload coverage.

## Implemented in this PR
- Bundled work move trace callback contract + runtime event recording.
- Movement phase hook plumbing into turn phase runner.
- SPEC updates for movement order event tokens and AC wording.
- Tests covering movement-phase skipped bundled events and runtime applied payload details.

## Deferred work
- This slice does **not** complete all order-level event capture for all phases/orders in #2218.
- Additional order domains (army/naval/build/combat and broader per-order sequencing) remain for follow-up slices.
- Performance-budget verification (requirement 15) remains deferred.

## AC / requirement coverage in this slice
- Advances requirement 5/6 coverage for movement-phase order event granularity by adding bundled work movement-leg events.
- Keeps existing civilian move event coverage; broad full-turn/all-order completeness remains open.

## Test plan
- [x] `cd packages/colonizethis_logic && dart test test/turn_trace_movement_order_events_test.dart test/turn_phase_runner_phase_overrides_test.dart`
- [x] `dart format` on touched Dart files
- [ ] Full package/analyzer cleanup is out of scope for this slice (existing unrelated warnings in package)

Refs #2218

Made with [Cursor](https://cursor.com)