### PR TITLE
Trace full AI planner decision sections

### DIFF
--- a/SPEC/program/turn-resolution-json-trace.md
+++ b/SPEC/program/turn-resolution-json-trace.md
@@ -65,6 +65,15 @@ Outcome section requires:
 - `finalAggregatedOrders`: array.
 - `domainOutputs`: object.
 
+Full AI planner traces populate the AI trace section from
+`colonizethis_ai` planner internals when the caller uses full AI result
+metadata. The section includes the selected strategic goal as
+`state.winningCandidate`, ranked strategic-goal alternates in
+`state.topAlternates`, world-snapshot/order/economy aggregates in
+`state.aggregates`, seed/personality/domain-weight threshold details, and the
+final per-domain order output summary. App and ctdev exporters may fall back to
+submitted-order summaries when callers provide only an `Orders` payload.
+
 ### Turn-resolution trace (`turn-resolution-trace.v1.schema.json`)
 
 Required top-level fields:
@@ -135,6 +144,8 @@ Meta section requires:
 - Given a JSON payload intended as a merged logical-turn trace, when validated against `merged-trace.v1.schema.json`, then validation passes only if `meta`, `ai`, and `turnResolution` are present and nested sections satisfy referenced contracts.
 - Given a payload with missing required fields for any of the three trace schemas, when validated, then validation fails deterministically with at least one schema violation.
 - Given turn resolution runs with `TurnResolverConfig.onTurnTracePhase` and `turnTraceRuntime` set, when each phase resolves (including pending-exit phases), then the callback receives one `TurnTracePhaseTrace` payload per phase containing `phaseId`, full `beforeState`, full `afterState`, and an ordered `orderEvents` array (Movement phase includes direct civilian move apply/ignore events and bundled work move applied/skipped events when those orders are present; other phases may still emit empty `orderEvents` until further hooks land).
+- Given the full AI planner generates orders for an AI-controlled player, when the caller reads the returned AI trace section, then the trace contains the player's `factionId`, a `state.winningCandidate.goal` strategic goal string, ranked `state.topAlternates`, `thresholds.constants`, `thresholds.derived`, `thresholds.effective`, `thresholds.gates`, and an `outcome.finalAggregatedOrders` array matching the emitted order domains.
+- Given app or ctdev turn trace export receives full AI trace sections for the resolving turn, when the merged trace is written, then the top-level `ai` array uses those full AI trace sections instead of rebuilding only submitted-order summaries.
 - Given no custom trace root override is provided, when the system exports a merged turn trace for `gameId = G` and `turnNumber = N`, then the system writes one JSON file to `tmp/turn-traces/G/` using filename pattern `turn-N-YYYYMMDDTHHMMSSmmmZ.json`.
 - Given a custom trace root override path `R` is provided, when the system exports a merged turn trace for `gameId = G`, then the system writes to `R/turn-traces/G/` and keeps the same filename pattern.
 - Given a game trace directory contains more than 10 trace JSON files after a new export, when retention runs, then the system deletes oldest files first until exactly 10 files remain in that gameId directory.

--- a/app/lib/core/services/game_service.dart
+++ b/app/lib/core/services/game_service.dart
@@ -209,6 +209,7 @@ class GameService {
     Game current, {
     Orders? orders,
     Orders? aiOrders,
+    List<TurnTraceAiSection>? aiTraceSections,
     MapTopology? topology,
     Map<String, TileMapResult>? tileMapByRegion,
     void Function(GameEvent)? onGameEvent,
@@ -222,6 +223,7 @@ class GameService {
         : humanOrders;
     final result = _resolveTurnWithTrace(
       game: current,
+      aiTraceSections: aiTraceSections,
       config: TurnResolverConfig(
         topology: topo,
         orders: resolvedOrders,
@@ -336,6 +338,7 @@ class GameService {
 
   TurnResolutionResult _resolveTurnWithTrace({
     required Game game,
+    List<TurnTraceAiSection>? aiTraceSections,
     required TurnResolverConfig config,
   }) {
     if (!_turnTraceEnabled) {
@@ -345,6 +348,11 @@ class GameService {
       game.id,
       () => _TurnTraceSession(startedAtUtc: DateTime.now().toUtc()),
     );
+    if (aiTraceSections != null) {
+      session.aiTraceSections = List<TurnTraceAiSection>.unmodifiable(
+        aiTraceSections,
+      );
+    }
     final tracedConfig = TurnResolverConfig(
       topology: config.topology,
       orders: config.orders,
@@ -371,16 +379,18 @@ class GameService {
       config: tracedConfig,
     );
     if (result is TurnResolutionComplete) {
-      final aiTraceSections = _buildAiTraceSections(
-        gameAtResolutionStart: game,
-        orders: config.orders,
-      );
+      final exportedAiTraceSections =
+          session.aiTraceSections ??
+          _buildAiTraceSections(
+            gameAtResolutionStart: game,
+            orders: config.orders,
+          );
       _exportTurnTrace(
         gameAtResolutionStart: game,
         turnEndState: result.game,
         phases: session.phases,
         turnStartAt: session.startedAtUtc,
-        ai: aiTraceSections,
+        ai: exportedAiTraceSections,
       );
       _turnTraceSessionsByGameId.remove(game.id);
     }
@@ -987,4 +997,5 @@ class _TurnTraceSession {
   final DateTime startedAtUtc;
   final List<TurnTracePhaseTrace> phases = <TurnTracePhaseTrace>[];
   final TurnTraceRuntime turnTraceRuntime = TurnTraceRuntime();
+  List<TurnTraceAiSection>? aiTraceSections;
 }

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -121,12 +121,16 @@ class GameScreen extends ConsumerWidget {
                   topologyForAi: mapData.combinedTopology,
                   tileMapByRegion: mapData.tileMapByRegion,
                   runTurnResolution:
-                      ({required Orders orders, Orders? aiOrders}) =>
-                          service.runTurnResolution(
-                            game,
-                            orders: orders,
-                            aiOrders: aiOrders,
-                          ),
+                      ({
+                        required Orders orders,
+                        Orders? aiOrders,
+                        List<TurnTraceAiSection>? aiTraceSections,
+                      }) => service.runTurnResolution(
+                        game,
+                        orders: orders,
+                        aiOrders: aiOrders,
+                        aiTraceSections: aiTraceSections,
+                      ),
                 );
                 applyTurnResolutionResult(ref, result);
               },

--- a/app/lib/features/game/flame/turn_resolution_flow.dart
+++ b/app/lib/features/game/flame/turn_resolution_flow.dart
@@ -11,13 +11,18 @@ TurnResolutionResult resolveNextTurnForGameScreen({
   required TurnResolutionResult Function({
     required Orders orders,
     Orders? aiOrders,
+    List<TurnTraceAiSection>? aiTraceSections,
   })
   runTurnResolution,
 }) {
-  final aiOrders = generateOrdersForGameFullAI(
+  final aiResult = generateOrdersForGameFullAI(
     game,
     topologyForAi,
     tileMapByRegion: tileMapByRegion,
-  ).orders;
-  return runTurnResolution(orders: orders, aiOrders: aiOrders);
+  );
+  return runTurnResolution(
+    orders: orders,
+    aiOrders: aiResult.orders,
+    aiTraceSections: aiResult.aiTraceSections,
+  );
 }

--- a/app/test/game_screen_next_turn_ai_test.dart
+++ b/app/test/game_screen_next_turn_ai_test.dart
@@ -36,25 +36,38 @@ void main() {
         globalGameSeed: 1,
         aiSeedByGpId: const {'gp1': 1},
       );
-      final expectedAiOrders = generateOrdersForGameFullAI(
+      final expectedAiResult = generateOrdersForGameFullAI(
         game,
         const MapTopology(nodes: [], edges: []),
-      ).orders;
+      );
 
       Orders? capturedAiOrders;
+      List<TurnTraceAiSection>? capturedAiTraceSections;
       final result = resolveNextTurnForGameScreen(
         game: game,
         orders: const Orders(),
         topologyForAi: const MapTopology(nodes: [], edges: []),
-        runTurnResolution: ({required Orders orders, Orders? aiOrders}) {
-          capturedAiOrders = aiOrders;
-          return TurnResolutionComplete(game);
-        },
+        runTurnResolution:
+            ({
+              required Orders orders,
+              Orders? aiOrders,
+              List<TurnTraceAiSection>? aiTraceSections,
+            }) {
+              capturedAiOrders = aiOrders;
+              capturedAiTraceSections = aiTraceSections;
+              return TurnResolutionComplete(game);
+            },
       );
 
       expect(result, isA<TurnResolutionComplete>());
       expect(capturedAiOrders, isNotNull);
-      expect(capturedAiOrders, equals(expectedAiOrders));
+      expect(capturedAiOrders, equals(expectedAiResult.orders));
+      expect(
+        capturedAiTraceSections?.map((section) => section.factionId),
+        equals(
+          expectedAiResult.aiTraceSections.map((section) => section.factionId),
+        ),
+      );
     });
   });
 }

--- a/app/test/game_screen_turn_resolution_branches_test.dart
+++ b/app/test/game_screen_turn_resolution_branches_test.dart
@@ -25,6 +25,7 @@ class _PendingTurnGameService extends GameService {
     Game current, {
     Orders? orders,
     Orders? aiOrders,
+    List<TurnTraceAiSection>? aiTraceSections,
     MapTopology? topology,
     Map<String, TileMapResult>? tileMapByRegion,
     void Function(GameEvent)? onGameEvent,
@@ -51,6 +52,7 @@ class _PendingInterventionGameService extends GameService {
     Game current, {
     Orders? orders,
     Orders? aiOrders,
+    List<TurnTraceAiSection>? aiTraceSections,
     MapTopology? topology,
     Map<String, TileMapResult>? tileMapByRegion,
     void Function(GameEvent)? onGameEvent,
@@ -146,8 +148,9 @@ void main() {
       await tester.tap(find.textContaining('Next turn').last);
       await tester.pump(const Duration(milliseconds: 400));
 
-      final container =
-          ProviderScope.containerOf(tester.element(find.byType(GameScreen)));
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(GameScreen)),
+      );
       final pending = container.read(pendingDiplomacyProvider);
       expect(pending, isA<PendingDiplomacyOvertures>());
       expect((pending! as PendingDiplomacyOvertures).offers, isNotEmpty);
@@ -209,8 +212,9 @@ void main() {
       await tester.tap(find.textContaining('Next turn').last);
       await tester.pump(const Duration(milliseconds: 400));
 
-      final container =
-          ProviderScope.containerOf(tester.element(find.byType(GameScreen)));
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(GameScreen)),
+      );
       final pending = container.read(pendingDiplomacyProvider);
       expect(pending, isA<PendingDiplomacyIntervention>());
       expect((pending! as PendingDiplomacyIntervention).prompts, isNotEmpty);

--- a/app/test/game_service_test.dart
+++ b/app/test/game_service_test.dart
@@ -19,6 +19,7 @@ class _PendingOverturesGameService extends GameService {
     Game current, {
     Orders? orders,
     Orders? aiOrders,
+    List<TurnTraceAiSection>? aiTraceSections,
     MapTopology? topology,
     Map<String, TileMapResult>? tileMapByRegion,
     void Function(GameEvent)? onGameEvent,

--- a/ctdev/lib/sim_game_controller.dart
+++ b/ctdev/lib/sim_game_controller.dart
@@ -160,45 +160,53 @@ class SimGameController {
   /// Generates orders for the next Great Power that does not yet have orders
   /// for the current turn (player-by-player mode). All GPs use the selected AI.
   void generateOrdersForNextPlayer() {
+    final nextPlayer = _nextPlayerWithoutPendingOrders();
+    if (nextPlayer == null) return;
+
     final currentTurn = _game.worldState.turnState.turnNumber;
-    for (final player in _game.players) {
-      if (_pendingOrdersByPlayerId.containsKey(player.id)) continue;
-      if (useSimGameAi) {
-        final orders = defaultSimGameAi(
-          game: _game,
-          player: player,
-          topology: _topology,
-          baseSeed: _baseSeed,
-          tileMapByRegion: _tileMapByRegion,
-        );
-        _pendingOrdersByPlayerId[player.id] = orders;
-      } else if (useFullAI) {
-        final result = generateOrdersForPlayerFullAIWithTrace(
-          _game,
-          _topology,
-          player.id,
-          tileMapByRegion: _tileMapByRegion,
-        );
-        _pendingOrdersByPlayerId[player.id] = result.result.orders;
-        _pendingEconomyPlansByPlayerId[player.id] = result.result.economyPlan;
-        final aiTraceSection = result.aiTraceSection;
-        if (aiTraceSection != null) {
-          _pendingAiTraceSectionsByPlayerId[player.id] = aiTraceSection;
-        }
-      } else {
-        final orders = generateOrdersForPlayer(
-          _game,
-          _topology,
-          player.id,
-          tileMapByRegion: _tileMapByRegion,
-        );
-        _pendingOrdersByPlayerId[player.id] = orders;
-      }
-      _ctdevSimLog.i(
-        'Turn $currentTurn: generated orders for ${player.displayName} (${player.id})',
+    if (useSimGameAi) {
+      final orders = defaultSimGameAi(
+        game: _game,
+        player: nextPlayer,
+        topology: _topology,
+        baseSeed: _baseSeed,
+        tileMapByRegion: _tileMapByRegion,
       );
-      break;
+      _pendingOrdersByPlayerId[nextPlayer.id] = orders;
+    } else if (useFullAI) {
+      final result = generateOrdersForPlayerFullAIWithTrace(
+        _game,
+        _topology,
+        nextPlayer.id,
+        tileMapByRegion: _tileMapByRegion,
+      );
+      _pendingOrdersByPlayerId[nextPlayer.id] = result.result.orders;
+      _pendingEconomyPlansByPlayerId[nextPlayer.id] = result.result.economyPlan;
+      final aiTraceSection = result.aiTraceSection;
+      if (aiTraceSection != null) {
+        _pendingAiTraceSectionsByPlayerId[nextPlayer.id] = aiTraceSection;
+      }
+    } else {
+      final orders = generateOrdersForPlayer(
+        _game,
+        _topology,
+        nextPlayer.id,
+        tileMapByRegion: _tileMapByRegion,
+      );
+      _pendingOrdersByPlayerId[nextPlayer.id] = orders;
     }
+    _ctdevSimLog.i(
+      'Turn $currentTurn: generated orders for ${nextPlayer.displayName} (${nextPlayer.id})',
+    );
+  }
+
+  Player? _nextPlayerWithoutPendingOrders() {
+    for (final player in _game.players) {
+      if (!_pendingOrdersByPlayerId.containsKey(player.id)) {
+        return player;
+      }
+    }
+    return null;
   }
 
   /// Resolves one full turn from the currently accumulated per-player orders.

--- a/ctdev/lib/sim_game_controller.dart
+++ b/ctdev/lib/sim_game_controller.dart
@@ -95,6 +95,7 @@ class SimGameController {
 
   /// When using full AI, economy plans per player for production phase. Cleared on resolve.
   final Map<String, EconomyPlan> _pendingEconomyPlansByPlayerId = {};
+  final Map<String, TurnTraceAiSection> _pendingAiTraceSectionsByPlayerId = {};
   final List<SimOrderHistoryEntry> _orderHistory = [];
   final List<String> _lastTurnCombatSummaries = [];
 
@@ -172,14 +173,18 @@ class SimGameController {
         );
         _pendingOrdersByPlayerId[player.id] = orders;
       } else if (useFullAI) {
-        final result = generateOrdersForPlayerFullAI(
+        final result = generateOrdersForPlayerFullAIWithTrace(
           _game,
           _topology,
           player.id,
           tileMapByRegion: _tileMapByRegion,
         );
-        _pendingOrdersByPlayerId[player.id] = result.orders;
-        _pendingEconomyPlansByPlayerId[player.id] = result.economyPlan;
+        _pendingOrdersByPlayerId[player.id] = result.result.orders;
+        _pendingEconomyPlansByPlayerId[player.id] = result.result.economyPlan;
+        final aiTraceSection = result.aiTraceSection;
+        if (aiTraceSection != null) {
+          _pendingAiTraceSectionsByPlayerId[player.id] = aiTraceSection;
+        }
       } else {
         final orders = generateOrdersForPlayer(
           _game,
@@ -208,9 +213,14 @@ class SimGameController {
           );
     _pendingOrdersByPlayerId.clear();
     _pendingEconomyPlansByPlayerId.clear();
+    final aiTraceSections = _pendingAiTraceSectionsByPlayerId.values.toList(
+      growable: false,
+    );
+    _pendingAiTraceSectionsByPlayerId.clear();
     _advanceOneTurnFromOrders(
       combined,
       defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+      aiTraceSections: aiTraceSections,
     );
   }
 
@@ -245,6 +255,7 @@ class SimGameController {
       _advanceOneTurnFromOrders(
         result.orders,
         defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+        aiTraceSections: result.aiTraceSections,
       );
     } else {
       final combined = generateOrdersForGame(
@@ -319,6 +330,7 @@ class SimGameController {
   void _advanceOneTurnFromOrders(
     Orders orders, {
     Map<String, List<AssignedRecipe>>? defaultAssignmentsByPlayerId,
+    List<TurnTraceAiSection>? aiTraceSections,
   }) {
     _recordOrderHistory(orders);
     _lastTurnCombatSummaries.clear();
@@ -345,6 +357,7 @@ class SimGameController {
         after: next,
         phases: phaseTraces,
         orders: orders,
+        aiTraceSections: aiTraceSections,
       );
     }
     _recordTurnLog(before: before, after: next);
@@ -355,6 +368,7 @@ class SimGameController {
     required Game after,
     required List<TurnTracePhaseTrace> phases,
     required Orders orders,
+    List<TurnTraceAiSection>? aiTraceSections,
   }) {
     final now = DateTime.now().toUtc();
     final document = TurnTraceMergedDocument(
@@ -367,7 +381,9 @@ class SimGameController {
         exportedAt: now.toIso8601String(),
         turnEndAt: now.toIso8601String(),
       ),
-      ai: _buildAiTraceSections(before: before, orders: orders),
+      ai:
+          aiTraceSections ??
+          _buildAiTraceSections(before: before, orders: orders),
       turnResolution: TurnTraceResolutionSection(
         phases: List<TurnTracePhaseTrace>.unmodifiable(phases),
       ),

--- a/packages/colonizethis_ai/lib/src/full_ai_planner.dart
+++ b/packages/colonizethis_ai/lib/src/full_ai_planner.dart
@@ -19,14 +19,47 @@ StrategicOrderResult generateOrdersForPlayerFullAI(
   void Function(DialogueEvent)? onDialogue,
   void Function(PortraitMoodEvent)? onMood,
 }) {
+  return generateOrdersForPlayerFullAIWithTrace(
+    game,
+    topology,
+    playerId,
+    tileMapByRegion: tileMapByRegion,
+    orderSuggestionApi: orderSuggestionApi,
+    onDialogue: onDialogue,
+    onMood: onMood,
+  ).result;
+}
+
+class FullAIPlayerTraceResult {
+  const FullAIPlayerTraceResult({
+    required this.result,
+    required this.aiTraceSection,
+  });
+
+  final StrategicOrderResult result;
+  final TurnTraceAiSection? aiTraceSection;
+}
+
+FullAIPlayerTraceResult generateOrdersForPlayerFullAIWithTrace(
+  Game game,
+  MapTopology topology,
+  String playerId, {
+  Map<String, TileMapResult>? tileMapByRegion,
+  OrderSuggestionAPI? orderSuggestionApi,
+  void Function(DialogueEvent)? onDialogue,
+  void Function(PortraitMoodEvent)? onMood,
+}) {
   final player = game.playerById(playerId);
   if (player == null || !isAiControlled(game, player.id)) {
-    return const StrategicOrderResult(
-      orders: Orders(),
-      economyPlan: EconomyPlan(
-        productionAssignments: [],
-        cargoPreference: CargoPreference.none,
+    return const FullAIPlayerTraceResult(
+      result: StrategicOrderResult(
+        orders: Orders(),
+        economyPlan: EconomyPlan(
+          productionAssignments: [],
+          cargoPreference: CargoPreference.none,
+        ),
       ),
+      aiTraceSection: null,
     );
   }
   final view = buildPlayerView(game, topology, playerId);
@@ -46,7 +79,7 @@ StrategicOrderResult generateOrdersForPlayerFullAI(
     hiddenAgendaId: agendaId,
   );
   final suggestionAPI = orderSuggestionApi ?? const DefaultOrderSuggestionAPI();
-  return generateStrategicOrders(
+  final traced = generateStrategicOrdersWithTrace(
     game: game,
     topology: topology,
     nationId: playerId,
@@ -58,6 +91,10 @@ StrategicOrderResult generateOrdersForPlayerFullAI(
     onDialogue: onDialogue,
     onMood: onMood,
   );
+  return FullAIPlayerTraceResult(
+    result: traced.result,
+    aiTraceSection: traced.aiTraceSection,
+  );
 }
 
 /// Result of full-AI order generation for all AI GPs: merged orders and per-player economy plans.
@@ -66,9 +103,11 @@ class FullAIResult {
   const FullAIResult({
     required this.orders,
     required this.economyPlansByPlayerId,
+    this.aiTraceSections = const <TurnTraceAiSection>[],
   });
   final Orders orders;
   final Map<String, EconomyPlan> economyPlansByPlayerId;
+  final List<TurnTraceAiSection> aiTraceSections;
 }
 
 /// Generates orders and economy plans for all AI-controlled GPs using full AI. Aggregates all order types including naval.
@@ -89,10 +128,11 @@ FullAIResult generateOrdersForGameFullAI(
   final navalByPlayer = <String, List<NavalMoveOrder>>{};
   final missionByPlayer = <String, List<NavalMissionOrder>>{};
   final economyPlansByPlayerId = <String, EconomyPlan>{};
+  final aiTraceSections = <TurnTraceAiSection>[];
 
   for (final player in game.players) {
     if (!isAiControlled(game, player.id)) continue;
-    final result = generateOrdersForPlayerFullAI(
+    final traced = generateOrdersForPlayerFullAIWithTrace(
       game,
       topology,
       player.id,
@@ -101,7 +141,12 @@ FullAIResult generateOrdersForGameFullAI(
       onDialogue: onDialogue,
       onMood: onMood,
     );
+    final result = traced.result;
     economyPlansByPlayerId[player.id] = result.economyPlan;
+    final aiTraceSection = traced.aiTraceSection;
+    if (aiTraceSection != null) {
+      aiTraceSections.add(aiTraceSection);
+    }
     _addOrdersIfNonEmpty(
       moveByPlayer,
       player.id,
@@ -156,6 +201,7 @@ FullAIResult generateOrdersForGameFullAI(
       navalMissionOrdersByPlayerId: missionByPlayer,
     ),
     economyPlansByPlayerId: economyPlansByPlayerId,
+    aiTraceSections: List<TurnTraceAiSection>.unmodifiable(aiTraceSections),
   );
 }
 

--- a/packages/colonizethis_ai/lib/src/goal_manager.dart
+++ b/packages/colonizethis_ai/lib/src/goal_manager.dart
@@ -3,7 +3,6 @@ import 'package:colonizethis_ai/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'ai_random_utils.dart';
-import 'hidden_agenda.dart';
 import 'perception.dart';
 
 final _log = packageLogger();
@@ -13,30 +12,25 @@ final _log = packageLogger();
 /// Top-level strategy goals for the AI.
 enum StrategicGoal { defend, expand, conquer, trade, tech, diplomacy }
 
-/// Selects primary strategic goal from snapshot, personality, and agenda modifiers.
-/// Deterministic given [snapshot], [config], and [goalSeed].
-StrategicGoal selectPrimaryGoal(
+/// Computes the effective strategic-goal candidate scores before weighted
+/// random selection. Used by both the planner and trace export.
+Map<StrategicGoal, int> evaluateStrategicGoalScores(
   AIWorldSnapshot snapshot,
   AIConfig config,
-  int goalSeed, {
-  required String nationId,
-  required int turn,
-}) {
+) {
   final weights = getGoalWeightsForLeader(config.personalityId);
   final thresholds = getThresholdsForLeader(config.personalityId);
 
-  // Situational modifiers from snapshot.
-  int defend = weights.defend;
-  int expand = weights.expand;
-  int conquer = weights.conquer;
-  int trade = weights.trade;
-  int tech = weights.tech;
-  int diplomacy = weights.diplomacy;
+  var defend = weights.defend;
+  var expand = weights.expand;
+  var conquer = weights.conquer;
+  var trade = weights.trade;
+  var tech = weights.tech;
+  var diplomacy = weights.diplomacy;
 
   conquer += getAgendaConquerModifier(config.hiddenAgendaId);
   diplomacy += getAgendaDiplomacyModifier(config.hiddenAgendaId);
-  // Personality thresholds: war likelihood boosts conquer; peace/alliance boost diplomacy goal.
-  conquer += (thresholds.warLikelihood - 50);
+  conquer += thresholds.warLikelihood - 50;
   diplomacy +=
       ((thresholds.peaceTendency + thresholds.allianceTendency) ~/ 2) - 50;
 
@@ -53,7 +47,7 @@ StrategicGoal selectPrimaryGoal(
     expand += 15;
   }
 
-  final candidates = <StrategicGoal, int>{
+  return <StrategicGoal, int>{
     StrategicGoal.defend: defend,
     StrategicGoal.expand: expand,
     StrategicGoal.conquer: conquer,
@@ -61,23 +55,15 @@ StrategicGoal selectPrimaryGoal(
     StrategicGoal.tech: tech,
     StrategicGoal.diplomacy: diplomacy,
   };
+}
 
-  _log.d(
-    'eval leaderId=${config.leaderId} hiddenAgendaId=${config.hiddenAgendaId} goalSeed=$goalSeed '
-    'weights defend=$defend expand=$expand conquer=$conquer trade=$trade tech=$tech diplomacy=$diplomacy',
-  );
-
-  // Weighted random choice using goalSeed.
-  final candidateEntries = candidates.entries.toList();
-  final selectedIndex = pickWeightedIndex(
-    candidateEntries.map((e) => e.value).toList(),
-    goalSeed,
-    useIntRoll: true,
-  );
-  final selected = selectedIndex == null
-      ? StrategicGoal.expand
-      : candidateEntries[selectedIndex].key;
-  final majorConstraint = switch (selected) {
+String majorConstraintForStrategicGoal(
+  StrategicGoal selected,
+  AIWorldSnapshot snapshot,
+  AIConfig config,
+) {
+  final thresholds = getThresholdsForLeader(config.personalityId);
+  return switch (selected) {
     StrategicGoal.defend =>
       snapshot.threats.capitalThreatened
           ? 'capitalThreatened'
@@ -105,6 +91,44 @@ StrategicGoal selectPrimaryGoal(
           : 'none',
     _ => 'none',
   };
+}
+
+/// Selects primary strategic goal from snapshot, personality, and agenda modifiers.
+/// Deterministic given [snapshot], [config], and [goalSeed].
+StrategicGoal selectPrimaryGoal(
+  AIWorldSnapshot snapshot,
+  AIConfig config,
+  int goalSeed, {
+  required String nationId,
+  required int turn,
+}) {
+  final candidates = evaluateStrategicGoalScores(snapshot, config);
+
+  _log.d(
+    'eval leaderId=${config.leaderId} hiddenAgendaId=${config.hiddenAgendaId} goalSeed=$goalSeed '
+    'weights defend=${candidates[StrategicGoal.defend]} '
+    'expand=${candidates[StrategicGoal.expand]} '
+    'conquer=${candidates[StrategicGoal.conquer]} '
+    'trade=${candidates[StrategicGoal.trade]} '
+    'tech=${candidates[StrategicGoal.tech]} '
+    'diplomacy=${candidates[StrategicGoal.diplomacy]}',
+  );
+
+  // Weighted random choice using goalSeed.
+  final candidateEntries = candidates.entries.toList();
+  final selectedIndex = pickWeightedIndex(
+    candidateEntries.map((e) => e.value).toList(),
+    goalSeed,
+    useIntRoll: true,
+  );
+  final selected = selectedIndex == null
+      ? StrategicGoal.expand
+      : candidateEntries[selectedIndex].key;
+  final majorConstraint = majorConstraintForStrategicGoal(
+    selected,
+    snapshot,
+    config,
+  );
   _log.i(
     'selected primaryGoal=$selected nationId=$nationId turn=$turn majorConstraint=$majorConstraint',
   );

--- a/packages/colonizethis_ai/lib/src/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/strategic_ai.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_ai/package_logger.dart';
-import 'package:colonizethis_logic/ai_api.dart' show PlayerView;
+import 'package:colonizethis_logic/ai_api.dart'
+    show PlayerView, TurnTraceAiSection;
 import 'package:colonizethis_logic/order_suggestion_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
@@ -28,9 +29,46 @@ StrategicOrderResult generateStrategicOrders({
   void Function(DialogueEvent)? onDialogue,
   void Function(PortraitMoodEvent)? onMood,
 }) {
+  return generateStrategicOrdersWithTrace(
+    game: game,
+    topology: topology,
+    nationId: nationId,
+    view: view,
+    config: config,
+    seeds: seeds,
+    suggestionAPI: suggestionAPI,
+    tileMapByRegion: tileMapByRegion,
+    onDialogue: onDialogue,
+    onMood: onMood,
+  ).result;
+}
+
+class StrategicOrderTraceResult {
+  const StrategicOrderTraceResult({
+    required this.result,
+    required this.aiTraceSection,
+  });
+
+  final StrategicOrderResult result;
+  final TurnTraceAiSection aiTraceSection;
+}
+
+StrategicOrderTraceResult generateStrategicOrdersWithTrace({
+  required Game game,
+  required MapTopology topology,
+  required String nationId,
+  required PlayerView view,
+  required AIConfig config,
+  required AISeedBundle seeds,
+  required OrderSuggestionAPI suggestionAPI,
+  Map<String, TileMapResult>? tileMapByRegion,
+  void Function(DialogueEvent)? onDialogue,
+  void Function(PortraitMoodEvent)? onMood,
+}) {
   final turn = game.worldState.turnState.turnNumber;
   _log.i('generateStrategicOrders nationId=$nationId turn=$turn');
   final snapshot = AIWorldSnapshot.fromPlayerView(view, topology: topology);
+  final goalScores = evaluateStrategicGoalScores(snapshot, config);
   final primaryGoal = selectPrimaryGoal(
     snapshot,
     config,
@@ -72,7 +110,270 @@ StrategicOrderResult generateStrategicOrders({
     onDialogue: onDialogue,
     onMood: onMood,
   );
-  return StrategicOrderResult(orders: orders, economyPlan: economyPlan);
+  final result = StrategicOrderResult(orders: orders, economyPlan: economyPlan);
+  return StrategicOrderTraceResult(
+    result: result,
+    aiTraceSection: _buildAiTraceSection(
+      nationId: nationId,
+      turn: turn,
+      config: config,
+      seeds: seeds,
+      snapshot: snapshot,
+      primaryGoal: primaryGoal,
+      goalScores: goalScores,
+      economyPlan: economyPlan,
+      orders: orders,
+    ),
+  );
+}
+
+TurnTraceAiSection _buildAiTraceSection({
+  required String nationId,
+  required int turn,
+  required AIConfig config,
+  required AISeedBundle seeds,
+  required AIWorldSnapshot snapshot,
+  required StrategicGoal primaryGoal,
+  required Map<StrategicGoal, int> goalScores,
+  required EconomyPlan economyPlan,
+  required Orders orders,
+}) {
+  final ordersByDomain = _orderCountsByDomain(nationId, orders);
+  final finalOrders = _finalAggregatedOrders(nationId, orders);
+  final domainWeights = getDomainWeightsForLeader(config.personalityId);
+  final thresholds = getThresholdsForLeader(config.personalityId);
+  final selectedScore = goalScores[primaryGoal] ?? 0;
+  return TurnTraceAiSection(
+    factionId: nationId,
+    state: <String, Object?>{
+      'winningCandidate': <String, Object?>{
+        'type': 'strategicGoal',
+        'goal': primaryGoal.name,
+        'score': selectedScore,
+        'selectionMethod': 'weighted_random',
+        'majorConstraint': majorConstraintForStrategicGoal(
+          primaryGoal,
+          snapshot,
+          config,
+        ),
+      },
+      'topAlternates': _rankedGoalCandidates(goalScores, exclude: primaryGoal),
+      'aggregates': <String, Object?>{
+        'totalOrders': finalOrders.length,
+        'ordersByDomain': ordersByDomain,
+        'economyPlan': <String, Object?>{
+          'productionAssignmentCount': economyPlan.productionAssignments.length,
+          'cargoPreference': economyPlan.cargoPreference.name,
+        },
+        'snapshot': <String, Object?>{
+          'atWarWith': snapshot.threats.atWarWith,
+          'neighborProvincesHostile': snapshot.threats.neighborProvincesHostile,
+          'capitalThreatened': snapshot.threats.capitalThreatened,
+          'weakNeighbors': snapshot.opportunities.weakNeighbors,
+          'richUnexploitedProvinces':
+              snapshot.opportunities.richUnexploitedProvinces,
+          'unclaimedProvinces': snapshot.opportunities.unclaimedProvinces,
+          'workerCount': snapshot.economy.workerCount,
+          'treasury': snapshot.economy.treasury,
+          'ownProvinceCount': snapshot.economy.ownProvinceCount,
+        },
+      },
+      'decisionContext': <String, Object?>{
+        'turnNumber': turn,
+        'leaderId': config.leaderId,
+        'personalityId': config.personalityId,
+        'hiddenAgendaId': config.hiddenAgendaId,
+      },
+    },
+    thresholds: <String, Object?>{
+      'constants': <String, Object?>{
+        'seeds': <String, Object?>{
+          'perception': seeds.perceptionSeed,
+          'goal': seeds.goalSeed,
+          'economy': seeds.economySeed,
+          'military': seeds.militarySeed,
+          'diplomacy': seeds.diplomacySeed,
+          'research': seeds.researchSeed,
+          'tactical': seeds.tacticalSeed,
+          'dialogue': seeds.dialogueSeed,
+          'agenda': seeds.agendaSeed,
+        },
+      },
+      'derived': <String, Object?>{
+        'goalCandidateScores': _goalScoresJson(goalScores),
+        'domainWeights': <String, Object?>{
+          'economy': domainWeights.economy,
+          'military': domainWeights.military,
+          'diplomacy': domainWeights.diplomacy,
+          'research': domainWeights.research,
+        },
+      },
+      'effective': <String, Object?>{
+        'selectedGoal': primaryGoal.name,
+        'personalityThresholds': <String, Object?>{
+          'warLikelihood': thresholds.warLikelihood,
+          'peaceTendency': thresholds.peaceTendency,
+          'allianceTendency': thresholds.allianceTendency,
+          'researchNaval': thresholds.researchNaval,
+          'researchMilitary': thresholds.researchMilitary,
+          'researchEconomic': thresholds.researchEconomic,
+          'researchExploration': thresholds.researchExploration,
+        },
+      },
+      'gates': <Object?>[
+        <String, Object?>{
+          'gate': 'strategic_goal_selection',
+          'method': 'weighted_random',
+          'selectedGoal': primaryGoal.name,
+          'selectedScore': selectedScore,
+        },
+      ],
+    },
+    outcome: <String, Object?>{
+      'domainOutputs': ordersByDomain,
+      'finalAggregatedOrders': finalOrders,
+      'emittedOrderCount': finalOrders.length,
+    },
+  );
+}
+
+Map<String, Object?> _goalScoresJson(Map<StrategicGoal, int> goalScores) {
+  return <String, Object?>{
+    for (final entry in goalScores.entries) entry.key.name: entry.value,
+  };
+}
+
+List<Map<String, Object?>> _rankedGoalCandidates(
+  Map<StrategicGoal, int> goalScores, {
+  required StrategicGoal exclude,
+}) {
+  final entries =
+      goalScores.entries
+          .where((entry) => entry.key != exclude)
+          .toList(growable: false)
+        ..sort((a, b) => b.value.compareTo(a.value));
+  return entries
+      .take(3)
+      .map(
+        (entry) => <String, Object?>{
+          'type': 'strategicGoal',
+          'goal': entry.key.name,
+          'score': entry.value,
+        },
+      )
+      .toList(growable: false);
+}
+
+Map<String, Object?> _orderCountsByDomain(String playerId, Orders orders) {
+  return <String, Object?>{
+    'move':
+        (orders.moveOrdersByPlayerId[playerId] ?? const <MoveOrder>[]).length,
+    'armyMove':
+        (orders.armyMoveOrdersByPlayerId[playerId] ?? const <ArmyMoveOrder>[])
+            .length,
+    'build':
+        (orders.buildUnitOrdersByPlayerId[playerId] ?? const <BuildUnitOrder>[])
+            .length,
+    'work':
+        (orders.workOrdersByPlayerId[playerId] ?? const <WorkOrder>[]).length,
+    'diplomatic':
+        (orders.diplomaticOrdersByPlayerId[playerId] ??
+                const <DiplomaticOrder>[])
+            .length,
+    'research':
+        (orders.researchOrdersByPlayerId[playerId] ?? const <ResearchOrder>[])
+            .length,
+    'navalMove':
+        (orders.navalMoveOrdersByPlayerId[playerId] ?? const <NavalMoveOrder>[])
+            .length,
+    'navalMission':
+        (orders.navalMissionOrdersByPlayerId[playerId] ??
+                const <NavalMissionOrder>[])
+            .length,
+  };
+}
+
+List<Map<String, Object?>> _finalAggregatedOrders(
+  String playerId,
+  Orders orders,
+) {
+  final aggregated = <Map<String, Object?>>[];
+  for (final order
+      in orders.moveOrdersByPlayerId[playerId] ?? const <MoveOrder>[]) {
+    aggregated.add(<String, Object?>{
+      'domain': 'move',
+      'unitId': order.unitId,
+      'destinationTileKey': order.destinationTileKey,
+    });
+  }
+  for (final order
+      in orders.armyMoveOrdersByPlayerId[playerId] ?? const <ArmyMoveOrder>[]) {
+    aggregated.add(<String, Object?>{
+      'domain': 'armyMove',
+      'armyId': order.armyId,
+      'destinationProvinceId': order.destinationProvinceId,
+    });
+  }
+  for (final order
+      in orders.buildUnitOrdersByPlayerId[playerId] ??
+          const <BuildUnitOrder>[]) {
+    aggregated.add(<String, Object?>{
+      'domain': 'build',
+      'unitType': order.unitType,
+      'spawnProvinceId': order.spawnProvinceId,
+    });
+  }
+  for (final order
+      in orders.workOrdersByPlayerId[playerId] ?? const <WorkOrder>[]) {
+    aggregated.add(<String, Object?>{
+      'domain': 'work',
+      'unitId': order.unitId,
+      'targetTileKey': order.targetTileKey,
+      'target': order.target,
+    });
+  }
+  for (final order
+      in orders.diplomaticOrdersByPlayerId[playerId] ??
+          const <DiplomaticOrder>[]) {
+    aggregated.add(<String, Object?>{
+      'domain': 'diplomatic',
+      'type': order.type.name,
+      'targetFactionId': order.targetFactionId,
+      if (order.amount != null) 'amount': order.amount,
+    });
+  }
+  for (final order
+      in orders.researchOrdersByPlayerId[playerId] ?? const <ResearchOrder>[]) {
+    aggregated.add(<String, Object?>{
+      'domain': 'research',
+      'slotIndex': order.slotIndex,
+      'techId': order.techId,
+      'funding': order.funding.name,
+    });
+  }
+  for (final order
+      in orders.navalMoveOrdersByPlayerId[playerId] ??
+          const <NavalMoveOrder>[]) {
+    aggregated.add(<String, Object?>{
+      'domain': 'navalMove',
+      'fleetId': order.fleetId,
+      'isDock': order.isDock,
+      'destinationSeaZoneId': order.destinationSeaZoneId,
+      'destinationPortProvinceId': order.destinationPortProvinceId,
+    });
+  }
+  for (final order
+      in orders.navalMissionOrdersByPlayerId[playerId] ??
+          const <NavalMissionOrder>[]) {
+    aggregated.add(<String, Object?>{
+      'domain': 'navalMission',
+      'fleetId': order.fleetId,
+      'mission': order.mission,
+      'targetProvinceId': order.targetProvinceId,
+      'targetPortId': order.targetPortId,
+    });
+  }
+  return List<Map<String, Object?>>.unmodifiable(aggregated);
 }
 
 void _emitDialogueAndMood({

--- a/packages/colonizethis_ai/lib/src/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/strategic_ai.dart
@@ -141,8 +141,13 @@ TurnTraceAiSection _buildAiTraceSection({
   final ordersByDomain = _orderCountsByDomain(nationId, orders);
   final finalOrders = _finalAggregatedOrders(nationId, orders);
   final domainWeights = getDomainWeightsForLeader(config.personalityId);
+  final goalWeights = getGoalWeightsForLeader(config.personalityId);
   final thresholds = getThresholdsForLeader(config.personalityId);
   final selectedScore = goalScores[primaryGoal] ?? 0;
+  final agendaConquerModifier = getAgendaConquerModifier(config.hiddenAgendaId);
+  final agendaDiplomacyModifier = getAgendaDiplomacyModifier(
+    config.hiddenAgendaId,
+  );
   return TurnTraceAiSection(
     factionId: nationId,
     state: <String, Object?>{
@@ -198,6 +203,18 @@ TurnTraceAiSection _buildAiTraceSection({
           'dialogue': seeds.dialogueSeed,
           'agenda': seeds.agendaSeed,
         },
+        'goalWeights': <String, Object?>{
+          'defend': goalWeights.defend,
+          'expand': goalWeights.expand,
+          'conquer': goalWeights.conquer,
+          'trade': goalWeights.trade,
+          'tech': goalWeights.tech,
+          'diplomacy': goalWeights.diplomacy,
+        },
+        'agendaModifiers': <String, Object?>{
+          'conquer': agendaConquerModifier,
+          'diplomacy': agendaDiplomacyModifier,
+        },
       },
       'derived': <String, Object?>{
         'goalCandidateScores': _goalScoresJson(goalScores),
@@ -210,6 +227,8 @@ TurnTraceAiSection _buildAiTraceSection({
       },
       'effective': <String, Object?>{
         'selectedGoal': primaryGoal.name,
+        'selectedGoalScore': selectedScore,
+        'adjustedGoalScores': _goalScoresJson(goalScores),
         'personalityThresholds': <String, Object?>{
           'warLikelihood': thresholds.warLikelihood,
           'peaceTendency': thresholds.peaceTendency,
@@ -221,12 +240,7 @@ TurnTraceAiSection _buildAiTraceSection({
         },
       },
       'gates': <Object?>[
-        <String, Object?>{
-          'gate': 'strategic_goal_selection',
-          'method': 'weighted_random',
-          'selectedGoal': primaryGoal.name,
-          'selectedScore': selectedScore,
-        },
+        ..._goalSelectionGates(goalScores, primaryGoal),
       ],
     },
     outcome: <String, Object?>{
@@ -235,6 +249,25 @@ TurnTraceAiSection _buildAiTraceSection({
       'emittedOrderCount': finalOrders.length,
     },
   );
+}
+
+List<Map<String, Object?>> _goalSelectionGates(
+  Map<StrategicGoal, int> goalScores,
+  StrategicGoal selectedGoal,
+) {
+  final entries = goalScores.entries.toList(growable: false)
+    ..sort((a, b) => b.value.compareTo(a.value));
+  return entries
+      .map(
+        (entry) => <String, Object?>{
+          'gate': 'strategic_goal_selection',
+          'method': 'weighted_random',
+          'candidateGoal': entry.key.name,
+          'candidateScore': entry.value,
+          'selected': entry.key == selectedGoal,
+        },
+      )
+      .toList(growable: false);
 }
 
 Map<String, Object?> _goalScoresJson(Map<StrategicGoal, int> goalScores) {

--- a/packages/colonizethis_ai/test/full_ai_planner_test.dart
+++ b/packages/colonizethis_ai/test/full_ai_planner_test.dart
@@ -157,6 +157,21 @@ void main() {
       expect(section.outcome['domainOutputs'], isA<Map<String, Object?>>());
       expect(section.outcome['finalAggregatedOrders'], isA<List<Object?>>());
       expect(section.outcome['emittedOrderCount'], isA<int>());
+
+      final constants = section.thresholds['constants'] as Map<String, Object?>;
+      expect(constants['goalWeights'], isA<Map<String, Object?>>());
+      expect(constants['agendaModifiers'], isA<Map<String, Object?>>());
+
+      final effective = section.thresholds['effective'] as Map<String, Object?>;
+      expect(effective['selectedGoalScore'], isA<int>());
+      expect(effective['adjustedGoalScores'], isA<Map<String, Object?>>());
+
+      final gates = section.thresholds['gates'] as List<Object?>;
+      expect(gates, isNotEmpty);
+      final firstGate = gates.first as Map<String, Object?>;
+      expect(firstGate['candidateGoal'], isA<String>());
+      expect(firstGate['candidateScore'], isA<int>());
+      expect(firstGate['selected'], isA<bool>());
     });
   });
 }

--- a/packages/colonizethis_ai/test/full_ai_planner_test.dart
+++ b/packages/colonizethis_ai/test/full_ai_planner_test.dart
@@ -26,9 +26,7 @@ void main() {
   group('generateOrdersForPlayerFullAI', () {
     test('unknown player id returns empty orders and default economy plan', () {
       final game = _minimalGame(
-        players: const [
-          Player(id: 'gp1', displayName: 'AI', isHuman: false),
-        ],
+        players: const [Player(id: 'gp1', displayName: 'AI', isHuman: false)],
       );
       const topology = MapTopology(nodes: [], edges: []);
       final r = generateOrdersForPlayerFullAI(game, topology, 'no_such_gp');
@@ -39,9 +37,7 @@ void main() {
 
     test('non-AI-controlled player returns empty', () {
       final game = _minimalGame(
-        players: const [
-          Player(id: 'gp1', displayName: 'Human', isHuman: true),
-        ],
+        players: const [Player(id: 'gp1', displayName: 'Human', isHuman: true)],
         aiControlByGpId: const {'gp1': false},
       );
       const topology = MapTopology(nodes: [], edges: []);
@@ -67,7 +63,11 @@ void main() {
       expect(r.orders.moveOrdersByPlayerId['gp1'] ?? const [], isEmpty);
       expect(
         r.economyPlan.cargoPreference,
-        isIn([CargoPreference.none, CargoPreference.preferCargo, CargoPreference.strongCargo]),
+        isIn([
+          CargoPreference.none,
+          CargoPreference.preferCargo,
+          CargoPreference.strongCargo,
+        ]),
       );
     });
 
@@ -102,9 +102,7 @@ void main() {
   group('generateOrdersForGameFullAI', () {
     test('no AI players yields empty aggregate orders and economy map', () {
       final game = _minimalGame(
-        players: const [
-          Player(id: 'gp1', displayName: 'Human', isHuman: true),
-        ],
+        players: const [Player(id: 'gp1', displayName: 'Human', isHuman: true)],
       );
       const topology = MapTopology(nodes: [], edges: []);
       final r = generateOrdersForGameFullAI(game, topology);
@@ -127,6 +125,38 @@ void main() {
       final r = generateOrdersForGameFullAI(game, topology);
       expect(r.economyPlansByPlayerId.containsKey('gp1'), isTrue);
       expect(r.orders.moveOrdersByPlayerId['gp1'] ?? const [], isEmpty);
+    });
+
+    test('includes schema-shaped AI trace section for full AI player', () {
+      final game = _minimalGame(
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'England',
+            isHuman: false,
+            leaderKey: 'victoria',
+          ),
+        ],
+        aiControlByGpId: const {'gp1': true},
+        hiddenAgendaByGpId: const {'gp1': 'peacemaker'},
+      );
+      const topology = MapTopology(nodes: [], edges: []);
+
+      final r = generateOrdersForGameFullAI(game, topology);
+
+      expect(r.aiTraceSections, hasLength(1));
+      final section = r.aiTraceSections.single;
+      expect(section.factionId, 'gp1');
+      expect(section.state['winningCandidate'], isA<Map<String, Object?>>());
+      expect(section.state['topAlternates'], isA<List<Object?>>());
+      expect(section.state['aggregates'], isA<Map<String, Object?>>());
+      expect(section.thresholds['constants'], isA<Map<String, Object?>>());
+      expect(section.thresholds['derived'], isA<Map<String, Object?>>());
+      expect(section.thresholds['effective'], isA<Map<String, Object?>>());
+      expect(section.thresholds['gates'], isA<List<Object?>>());
+      expect(section.outcome['domainOutputs'], isA<Map<String, Object?>>());
+      expect(section.outcome['finalAggregatedOrders'], isA<List<Object?>>());
+      expect(section.outcome['emittedOrderCount'], isA<int>());
     });
   });
 }

--- a/packages/colonizethis_logic/lib/ai_api.dart
+++ b/packages/colonizethis_logic/lib/ai_api.dart
@@ -27,6 +27,7 @@ export 'src/orders/order_suggestion_helpers.dart'
         filterArmyMoveOrdersByDiplomacy,
         filterMoveOrdersByDiplomacy,
         getProvinceOwnerMap;
+export 'src/turn/trace/turn_trace_contracts.dart' show TurnTraceAiSection;
 export 'src/world/player_view.dart'
     show PlayerView, VisibilityLevel, buildPlayerView;
 export 'src/world/province_lookup.dart' show allProvinces;


### PR DESCRIPTION
## Summary
- Adds full-AI planner trace sections containing selected strategic goal, ranked goal alternates, seed/personality/domain-weight threshold data, world-snapshot aggregates, and emitted order summaries.
- Carries generated AI trace sections through app and ctdev trace export, while preserving the existing submitted-order fallback for callers that only provide `Orders`.
- Updates the turn trace SPEC and focused tests for the new AI trace handoff.

## Scope
Implemented slice for #2218: advances the AI trace wrapper/export gap for full AI planner decisions.

## Deferred Work
- Does not complete quick-battle tactical internals tracing.
- Does not complete order-level event capture for every non-movement phase/order domain.
- Does not add performance-budget benchmark evidence for requirement 15.

## Test Plan
- [x] `cd packages/colonizethis_ai && dart test test/full_ai_planner_test.dart`
- [x] `cd app && flutter test test/game_screen_next_turn_ai_test.dart test/game_screen_turn_resolution_branches_test.dart test/game_service_test.dart`
- [x] `cd ctdev && dart test test/sim_game_controller_test.dart`
- [x] `dart run tool/run_workspace_analyze_errors_only.dart`

Refs #2218

Made with [Cursor](https://cursor.com)