### PR TITLE
Isolate turn trace: merge phase traces with full-AI export (Refs #2218)

### DIFF
--- a/SPEC/program/turn-resolution-json-trace.md
+++ b/SPEC/program/turn-resolution-json-trace.md
@@ -135,6 +135,16 @@ Meta section requires:
 - Retention keeps at most 10 `.json` trace files per `gameId` directory by
   pruning oldest files first.
 
+### App worker-isolate path
+
+When the Flutter app resolves a turn in a worker isolate (`TurnResolutionRunner`,
+`SPEC/program/turn-resolution.md`), AI orders and `FullAIResult.aiTraceSections`
+are computed on the main isolate before the worker runs. When debug turn tracing
+is enabled, phase traces and order events are collected inside the isolate and
+returned with the terminal result; the app merges those phase payloads with the
+main-isolate AI sections and writes the same merged JSON document as the
+in-process `GameService.runTurnResolution` path.
+
 ---
 
 ## Acceptance Criteria

--- a/app/lib/core/services/game_service.dart
+++ b/app/lib/core/services/game_service.dart
@@ -43,6 +43,9 @@ class GameService {
   final String turnTraceRootDirectory;
   final Map<String, _TurnTraceSession> _turnTraceSessionsByGameId = {};
 
+  /// Whether merged JSON turn traces are emitted (app debug console gate).
+  bool get isTurnTraceEnabled => _turnTraceEnabled;
+
   /// Optional app-level bus for [GameToUIEvent] (turn complete, new game, overtures, etc.).
   /// When set, those events are emitted from turn resolution and [createNewGame].
   /// Logic-layer [GameEvent] still uses [runTurnResolution] / [resumeOvertureDecisions]
@@ -988,6 +991,27 @@ class GameService {
   /// Emits app-level events and persistence side effects for externally resolved turns.
   void handleExternallyResolvedTurnResult(TurnResolutionResult result) {
     _emitTurnResolutionEvents(result);
+  }
+
+  /// Writes merged turn trace after resolution ran outside [runTurnResolution]
+  /// (e.g. worker isolate). No-op when [isTurnTraceEnabled] is false.
+  void exportTurnTraceForExternallyResolvedTurn({
+    required Game gameAtResolutionStart,
+    required Game turnEndState,
+    required List<TurnTracePhaseTrace> phases,
+    required List<TurnTraceAiSection> ai,
+    required DateTime turnStartAtUtc,
+  }) {
+    if (!_turnTraceEnabled) {
+      return;
+    }
+    _exportTurnTrace(
+      gameAtResolutionStart: gameAtResolutionStart,
+      turnEndState: turnEndState,
+      phases: phases,
+      turnStartAt: turnStartAtUtc,
+      ai: ai,
+    );
   }
 }
 

--- a/app/lib/core/services/turn_resolution_runner.dart
+++ b/app/lib/core/services/turn_resolution_runner.dart
@@ -26,8 +26,25 @@ sealed class TurnResolutionTerminalEvent {
 }
 
 class TurnResolutionTerminalComplete extends TurnResolutionTerminalEvent {
-  const TurnResolutionTerminalComplete(this.result);
+  const TurnResolutionTerminalComplete(
+    this.result, {
+    this.turnTracePhases,
+    this.aiTraceSections,
+    this.turnTraceStartedAtUtc,
+  });
+
   final TurnResolutionResult result;
+
+  /// Phase-level traces from the worker isolate when [TurnResolutionRunner]
+  /// was started with `turnTraceEnabled: true`.
+  final List<TurnTracePhaseTrace>? turnTracePhases;
+
+  /// Full-AI diagnostic sections captured on the main isolate before the worker
+  /// ran; aligned with [turnTracePhases] when tracing is enabled.
+  final List<TurnTraceAiSection>? aiTraceSections;
+
+  /// UTC time tracing started for this resolution (after AI orders merged).
+  final DateTime? turnTraceStartedAtUtc;
 }
 
 class TurnResolutionTerminalError extends TurnResolutionTerminalEvent {
@@ -66,6 +83,7 @@ class TurnResolutionRunner {
     required Orders orders,
     required MapTopology topology,
     required Map<String, TileMapResult> tileMapByRegion,
+    bool turnTraceEnabled = false,
   }) {
     if (_active) {
       throw StateError('Turn resolution already active');
@@ -97,15 +115,20 @@ class TurnResolutionRunner {
     }
 
     try {
-      final aiOrders = generateOrdersForGameFullAI(
+      final fullAi = generateOrdersForGameFullAI(
         game,
         topology,
         tileMapByRegion: tileMapByRegion,
-      ).orders;
+      );
       final mergedOrders = mergeOrderLists(
         humanOrders: orders,
-        aiOrders: aiOrders,
+        aiOrders: fullAi.orders,
       );
+      final traceStartedAt =
+          turnTraceEnabled ? DateTime.now().toUtc() : null;
+      final aiTraceForExport = turnTraceEnabled
+          ? List<TurnTraceAiSection>.unmodifiable(fullAi.aiTraceSections)
+          : null;
 
       sub = receivePort.listen((dynamic message) async {
         if (message is! Map<Object?, Object?>) {
@@ -129,12 +152,37 @@ class TurnResolutionRunner {
             'logic: turn_resolution_runner session_complete sessionId=$sessionId '
             'outcome=success',
           );
-          final terminal = TurnResolutionTerminalComplete(
-            _decodeTurnResolutionResult(
-              Map<String, dynamic>.from(
-                message['result'] as Map<Object?, Object?>,
-              ),
+          final decodedResult = _decodeTurnResolutionResult(
+            Map<String, dynamic>.from(
+              message['result'] as Map<Object?, Object?>,
             ),
+          );
+          final phasesPayload = message['turnTracePhases'];
+          final List<TurnTracePhaseTrace>? decodedPhases;
+          if (phasesPayload is List) {
+            decodedPhases = phasesPayload
+                .map(
+                  (dynamic e) => TurnTracePhaseTrace.fromJson(
+                    Map<String, Object?>.fromEntries(
+                      (e as Map<Object?, Object?>).entries.map(
+                        (MapEntry<Object?, Object?> entry) =>
+                            MapEntry<String, Object?>(
+                              entry.key as String,
+                              entry.value,
+                            ),
+                      ),
+                    ),
+                  ),
+                )
+                .toList(growable: false);
+          } else {
+            decodedPhases = null;
+          }
+          final terminal = TurnResolutionTerminalComplete(
+            decodedResult,
+            turnTracePhases: decodedPhases,
+            aiTraceSections: aiTraceForExport,
+            turnTraceStartedAtUtc: traceStartedAt,
           );
           if (!doneCompleter.isCompleted) {
             doneCompleter.complete(terminal);
@@ -172,6 +220,7 @@ class TurnResolutionRunner {
             'tileMapByRegion': tileMapByRegion.map(
               (k, v) => MapEntry(k, v.toJson()),
             ),
+            'turnTraceEnabled': turnTraceEnabled,
           })
           .then((spawned) {
             isolate = spawned;
@@ -243,6 +292,9 @@ void _turnResolutionIsolateMain(Map<String, Object?> args) {
         ),
       ),
     );
+    final turnTraceEnabled = args['turnTraceEnabled'] == true;
+    final phaseTraces = <TurnTracePhaseTrace>[];
+    final traceRuntime = turnTraceEnabled ? TurnTraceRuntime() : null;
     final result = validateOrdersAndResolveTurnFromTrustedOrders(
       game: game,
       topology: topology,
@@ -255,10 +307,15 @@ void _turnResolutionIsolateMain(Map<String, Object?> args) {
           'marker': marker.name,
         });
       },
+      onTurnTracePhase: turnTraceEnabled ? phaseTraces.add : null,
+      turnTraceRuntime: traceRuntime,
     );
     sendPort.send({
       'kind': 'success',
       'result': _encodeTurnResolutionResult(result),
+      if (turnTraceEnabled)
+        'turnTracePhases':
+            phaseTraces.map((TurnTracePhaseTrace p) => p.toJson()).toList(),
     });
   } catch (e, st) {
     sendPort.send({

--- a/app/lib/core/services/turn_resolution_runner.dart
+++ b/app/lib/core/services/turn_resolution_runner.dart
@@ -159,10 +159,10 @@ class TurnResolutionRunner {
           );
           final phasesPayload = message['turnTracePhases'];
           final List<TurnTracePhaseTrace>? decodedPhases;
-          if (phasesPayload is List) {
+          if (phasesPayload is List<Object?>) {
             decodedPhases = phasesPayload
                 .map(
-                  (dynamic e) => TurnTracePhaseTrace.fromJson(
+                  (Object? e) => TurnTracePhaseTrace.fromJson(
                     Map<String, Object?>.fromEntries(
                       (e as Map<Object?, Object?>).entries.map(
                         (MapEntry<Object?, Object?> entry) =>

--- a/app/lib/features/game/flame/game_map_area_part1.dart
+++ b/app/lib/features/game/flame/game_map_area_part1.dart
@@ -513,6 +513,7 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
         orders: orders,
         topology: mapData.combinedTopology,
         tileMapByRegion: mapData.tileMapByRegion,
+        turnTraceEnabled: service.isTurnTraceEnabled,
       );
       final activeSessionId = session.sessionId;
       _turnResolutionProgressSub?.cancel();
@@ -529,12 +530,25 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
         return;
       }
       switch (terminal) {
-        case TurnResolutionTerminalComplete():
-          service.handleExternallyResolvedTurnResult(terminal.result);
-          applyTurnResolutionResult(ref, terminal.result);
-        case TurnResolutionTerminalError():
+        case TurnResolutionTerminalComplete c:
+          service.handleExternallyResolvedTurnResult(c.result);
+          if (service.isTurnTraceEnabled &&
+              c.result is TurnResolutionComplete &&
+              c.turnTracePhases != null &&
+              c.turnTraceStartedAtUtc != null) {
+            final complete = c.result as TurnResolutionComplete;
+            service.exportTurnTraceForExternallyResolvedTurn(
+              gameAtResolutionStart: game,
+              turnEndState: complete.game,
+              phases: c.turnTracePhases!,
+              ai: c.aiTraceSections ?? const <TurnTraceAiSection>[],
+              turnStartAtUtc: c.turnTraceStartedAtUtc!,
+            );
+          }
+          applyTurnResolutionResult(ref, c.result);
+        case TurnResolutionTerminalError e:
           messenger.showSnackBar(SnackBar(content: Text(failureMessage)));
-          throw StateError(terminal.errorMessage);
+          throw StateError(e.errorMessage);
       }
     } catch (_) {
       if (mounted) {

--- a/app/test/turn_resolution_runner_test.dart
+++ b/app/test/turn_resolution_runner_test.dart
@@ -2,6 +2,7 @@
 
 import 'package:colonizethis_app/core/services/turn_resolution_runner.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter_test/flutter_test.dart';
@@ -65,6 +66,28 @@ void main() {
         );
         await session.done;
         expect(runner.isActive, isFalse);
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
+
+    test(
+      'turnTraceEnabled attaches phase traces and timestamps to terminal',
+      () async {
+        final runner = TurnResolutionRunner();
+        final session = runner.startResolution(
+          game: game,
+          orders: const Orders(),
+          topology: topology,
+          tileMapByRegion: tileMapByRegion,
+          turnTraceEnabled: true,
+        );
+        final terminal = await session.done;
+        expect(terminal, isA<TurnResolutionTerminalComplete>());
+        final c = terminal as TurnResolutionTerminalComplete;
+        expect(c.turnTracePhases, isNotNull);
+        expect(c.turnTracePhases, isNotEmpty);
+        expect(c.turnTraceStartedAtUtc, isNotNull);
+        expect(c.aiTraceSections, isNotNull);
       },
       timeout: const Timeout(Duration(seconds: 60)),
     );

--- a/packages/colonizethis_logic/lib/src/orders/orders_application.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application.dart
@@ -15,6 +15,7 @@ import 'orders_application_completed_work.dart';
 import 'orders_application_context.dart';
 import 'orders_application_helpers.dart';
 import 'orders_application_work_phase.dart';
+import '../turn/trace/turn_trace_runtime.dart';
 
 /// Order application helpers for build and work phases.
 /// SPEC/program/orders.md
@@ -53,6 +54,7 @@ Game applyBuildAndWorkOrders(
   MapTopology? topology,
   Map<String, TileMapResult>? tileMapByRegion,
   void Function(DialogueEvent)? onDialogue,
+  WorkOrderTraceCallback? onWorkOrderTrace,
 }) {
   final buildOrders = orders.buildUnitOrdersByPlayerId;
   final workOrders = orders.workOrdersByPlayerId;
@@ -95,6 +97,7 @@ Game applyBuildAndWorkOrders(
     topology: topology,
     tileMapByRegion: tileMapByRegion,
     onDialogue: onDialogue,
+    onWorkOrderTrace: onWorkOrderTrace,
     work: work,
   );
 

--- a/packages/colonizethis_logic/lib/src/orders/orders_application_context.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_context.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../turn/trace/turn_trace_runtime.dart';
 import '../world/army_ids.dart';
 
 final ordersApplicationLog = packageLogger();
@@ -74,6 +75,7 @@ class BuildWorkState {
     this.topology,
     this.tileMapByRegion,
     this.onDialogue,
+    this.onWorkOrderTrace,
     required this.work,
   });
 
@@ -83,6 +85,7 @@ class BuildWorkState {
   final MapTopology? topology;
   final Map<String, TileMapResult>? tileMapByRegion;
   final void Function(DialogueEvent)? onDialogue;
+  final WorkOrderTraceCallback? onWorkOrderTrace;
   final WorkOrderState work;
 
   BuildWorkState copyWith({
@@ -92,6 +95,7 @@ class BuildWorkState {
     MapTopology? topology,
     Map<String, TileMapResult>? tileMapByRegion,
     void Function(DialogueEvent)? onDialogue,
+    WorkOrderTraceCallback? onWorkOrderTrace,
     WorkOrderState? work,
   }) {
     return BuildWorkState(
@@ -101,6 +105,7 @@ class BuildWorkState {
       topology: topology ?? this.topology,
       tileMapByRegion: tileMapByRegion ?? this.tileMapByRegion,
       onDialogue: onDialogue ?? this.onDialogue,
+      onWorkOrderTrace: onWorkOrderTrace ?? this.onWorkOrderTrace,
       work: work ?? this.work,
     );
   }

--- a/packages/colonizethis_logic/lib/src/orders/orders_application_work_phase.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_work_phase.dart
@@ -39,21 +39,42 @@ BuildWorkState runWorkPhase(
 
     for (final order in workOrders[player.id] ?? const []) {
       final u = context.lookupUnit(order.unitId);
-      if (u == null) continue;
+      if (u == null) {
+        current.onWorkOrderTrace?.call(
+          playerId: player.id,
+          order: order,
+          applied: false,
+          ignoreReason: 'unit_not_found',
+        );
+        continue;
+      }
       final targetTileKey = order.targetTileKey;
       final hasValidTarget = targetTileKey.isNotEmpty;
+      var handled = false;
+      var applied = false;
       for (final handler in _workOrderHandlers) {
         if (!handler.supports(order.target)) continue;
-        if (handler.tryApply(
+        handled = handler.tryApply(
           context,
           order,
           u,
           targetTileKey,
           hasValidTarget,
-        )) {
-          break;
-        }
+        );
+        if (!handled) continue;
+        final nextUnit = context.lookupUnit(order.unitId);
+        final nextWork = nextUnit?.currentWork;
+        applied = nextWork != null && nextWork.workTarget == order.target;
+        break;
       }
+      current.onWorkOrderTrace?.call(
+        playerId: player.id,
+        order: order,
+        applied: applied,
+        ignoreReason: handled
+            ? (applied ? null : 'order_rejected')
+            : 'unsupported_target',
+      );
     }
 
     context.persistPlayerSnapshot();

--- a/packages/colonizethis_logic/lib/src/turn/phases/build_work_phase.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases/build_work_phase.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../orders/orders_application.dart';
+import '../trace/turn_trace_runtime.dart';
 
 Game runBuildWorkPhase(
   Game game,
@@ -9,6 +10,7 @@ Game runBuildWorkPhase(
   MapTopology topology,
   Map<String, TileMapResult>? tileMapByRegion, {
   void Function(DialogueEvent)? onDialogue,
+  WorkOrderTraceCallback? onWorkOrderTrace,
 }) {
   return applyBuildAndWorkOrders(
     game,
@@ -16,5 +18,6 @@ Game runBuildWorkPhase(
     topology: topology,
     tileMapByRegion: tileMapByRegion,
     onDialogue: onDialogue,
+    onWorkOrderTrace: onWorkOrderTrace,
   );
 }

--- a/packages/colonizethis_logic/lib/src/turn/trace/turn_trace_contracts.dart
+++ b/packages/colonizethis_logic/lib/src/turn/trace/turn_trace_contracts.dart
@@ -114,10 +114,10 @@ class TurnTracePhaseTrace {
 
   factory TurnTracePhaseTrace.fromJson(Map<String, Object?> json) {
     final orderEventsRaw = json['orderEvents'];
-    final orderEvents = orderEventsRaw is List
+    final orderEvents = orderEventsRaw is List<Object?>
         ? orderEventsRaw
             .map(
-              (dynamic e) => TurnTraceOrderEvent.fromJson(
+              (Object? e) => TurnTraceOrderEvent.fromJson(
                 _stringObjectMapFromDynamic(e),
               ),
             )

--- a/packages/colonizethis_logic/lib/src/turn/trace/turn_trace_contracts.dart
+++ b/packages/colonizethis_logic/lib/src/turn/trace/turn_trace_contracts.dart
@@ -112,6 +112,28 @@ class TurnTracePhaseTrace {
     this.effects,
   });
 
+  factory TurnTracePhaseTrace.fromJson(Map<String, Object?> json) {
+    final orderEventsRaw = json['orderEvents'];
+    final orderEvents = orderEventsRaw is List
+        ? orderEventsRaw
+            .map(
+              (dynamic e) => TurnTraceOrderEvent.fromJson(
+                _stringObjectMapFromDynamic(e),
+              ),
+            )
+            .toList(growable: false)
+        : const <TurnTraceOrderEvent>[];
+    return TurnTracePhaseTrace(
+      phaseId: json['phaseId']! as String,
+      beforeState: _stringObjectMapFromDynamic(json['beforeState']),
+      afterState: _stringObjectMapFromDynamic(json['afterState']),
+      orderEvents: orderEvents,
+      effects: json['effects'] == null
+          ? null
+          : _stringObjectMapFromDynamic(json['effects']),
+    );
+  }
+
   final String phaseId;
   final Map<String, Object?> beforeState;
   final Map<String, Object?> afterState;
@@ -140,6 +162,18 @@ class TurnTraceOrderEvent {
     this.payload,
   });
 
+  factory TurnTraceOrderEvent.fromJson(Map<String, Object?> json) {
+    return TurnTraceOrderEvent(
+      sequence: (json['sequence'] as num).toInt(),
+      orderId: json['orderId']! as String,
+      eventType: json['eventType']! as String,
+      timestamp: json['timestamp'] as String?,
+      payload: json['payload'] == null
+          ? null
+          : _stringObjectMapFromDynamic(json['payload']),
+    );
+  }
+
   final int sequence;
   final String orderId;
   final String eventType;
@@ -155,4 +189,14 @@ class TurnTraceOrderEvent {
       if (payload != null) 'payload': payload,
     };
   }
+}
+
+Map<String, Object?> _stringObjectMapFromDynamic(Object? value) {
+  final raw = value as Map<Object?, Object?>;
+  return Map<String, Object?>.fromEntries(
+    raw.entries.map(
+      (MapEntry<Object?, Object?> e) =>
+          MapEntry<String, Object?>(e.key as String, e.value),
+    ),
+  );
 }

--- a/packages/colonizethis_logic/lib/src/turn/trace/turn_trace_runtime.dart
+++ b/packages/colonizethis_logic/lib/src/turn/trace/turn_trace_runtime.dart
@@ -20,6 +20,14 @@ typedef BundledWorkMoveTraceCallback =
       String? ignoreReason,
     });
 
+typedef WorkOrderTraceCallback =
+    void Function({
+      required String playerId,
+      required WorkOrder order,
+      required bool applied,
+      String? ignoreReason,
+    });
+
 /// Mutable per-turn-resolution buffer for order-level trace events within the
 /// current phase. Cleared at each phase boundary by [turn_phase_runner]; read
 /// via [snapshotPhaseOrderEvents] when emitting [TurnTracePhaseTrace].
@@ -79,6 +87,26 @@ class TurnTraceRuntime {
             'destinationProvinceId': destinationProvinceId,
           if (destinationTileKey != null)
             'destinationTileKey': destinationTileKey,
+          if (ignoreReason != null) 'ignoreReason': ignoreReason,
+        },
+      ),
+    );
+  }
+
+  /// Records one work-order handling decision in build/work phase order.
+  void handleWorkOrderTrace({
+    required String playerId,
+    required WorkOrder order,
+    required bool applied,
+    String? ignoreReason,
+  }) {
+    _phaseOrderEvents.add(
+      TurnTraceOrderEvent(
+        sequence: _nextSequence++,
+        orderId: 'work:$playerId:${order.unitId}:${order.target}',
+        eventType: applied ? 'work_order_applied' : 'work_order_skipped',
+        payload: <String, Object?>{
+          'targetTileKey': order.targetTileKey,
           if (ignoreReason != null) 'ignoreReason': ignoreReason,
         },
       ),

--- a/packages/colonizethis_logic/lib/src/turn/turn_phase_runner.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_phase_runner.dart
@@ -358,6 +358,7 @@ TurnPhaseStepOutcome _runBuildWorkPhaseHandler(
     config.topology,
     config.tileMapByRegion,
     onDialogue: config.onDialogue,
+    onWorkOrderTrace: config.turnTraceRuntime?.handleWorkOrderTrace,
   );
   emitWorkOrderCompletedEvents(
     stateBeforeBuildWork,

--- a/packages/colonizethis_logic/test/turn_trace_contracts_json_roundtrip_test.dart
+++ b/packages/colonizethis_logic/test/turn_trace_contracts_json_roundtrip_test.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_logic/src/turn/trace/turn_trace_contracts.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 void main() {
   test('TurnTracePhaseTrace round-trips through toJson / fromJson', () {

--- a/packages/colonizethis_logic/test/turn_trace_contracts_json_roundtrip_test.dart
+++ b/packages/colonizethis_logic/test/turn_trace_contracts_json_roundtrip_test.dart
@@ -1,0 +1,31 @@
+import 'package:colonizethis_logic/src/turn/trace/turn_trace_contracts.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('TurnTracePhaseTrace round-trips through toJson / fromJson', () {
+    const original = TurnTracePhaseTrace(
+      phaseId: 'movement',
+      beforeState: <String, Object?>{'k': 1, 'nested': <String, Object?>{}},
+      afterState: <String, Object?>{'k': 2},
+      orderEvents: <TurnTraceOrderEvent>[
+        TurnTraceOrderEvent(
+          sequence: 0,
+          orderId: 'm1',
+          eventType: 'civilian_move_applied',
+          payload: <String, Object?>{'unitId': 'u1'},
+        ),
+      ],
+      effects: <String, Object?>{'x': true},
+    );
+    final decoded = TurnTracePhaseTrace.fromJson(original.toJson());
+    expect(decoded.phaseId, original.phaseId);
+    expect(decoded.beforeState, original.beforeState);
+    expect(decoded.afterState, original.afterState);
+    expect(decoded.orderEvents.length, 1);
+    expect(decoded.orderEvents.first.sequence, 0);
+    expect(decoded.orderEvents.first.orderId, 'm1');
+    expect(decoded.orderEvents.first.eventType, 'civilian_move_applied');
+    expect(decoded.orderEvents.first.payload, original.orderEvents.first.payload);
+    expect(decoded.effects, original.effects);
+  });
+}

--- a/packages/colonizethis_logic/test/turn_trace_movement_order_events_test.dart
+++ b/packages/colonizethis_logic/test/turn_trace_movement_order_events_test.dart
@@ -124,94 +124,97 @@ void main() {
       },
     );
 
-    test('bundled work move trace records skipped attempts in movement phase', () {
-      const ow = 'oldWorld';
-      final topology = MapTopology(
-        nodes: const [
-          TopologyNode(
-            id: 'oldWorld|P1',
-            regionId: ow,
-            type: TopologyNodeType.province,
-          ),
-          TopologyNode(
-            id: 'oldWorld|P2',
-            regionId: ow,
-            type: TopologyNodeType.province,
-          ),
-        ],
-        edges: const [TopologyEdge(id1: 'oldWorld|P1', id2: 'oldWorld|P2')],
-      );
-      final game = Game(
-        id: 'g',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
-          oldWorld: RegionData(
-            provinces: const [
-              Province(id: 'oldWorld|P1', regionId: ow, ownerId: 'p1'),
-              Province(id: 'oldWorld|P2', regionId: ow, ownerId: 'p1'),
-            ],
-            units: [
-              Unit(
-                id: 'u1',
-                type: kUnitTypeMerchant,
-                ownerId: 'p1',
-                locationProvinceId: 'oldWorld|P1',
-                tileKey: 'oldWorld|P1|0|0',
-              ),
-              Unit(
-                id: 'u2',
-                type: kUnitTypeMerchant,
-                ownerId: 'p1',
-                locationProvinceId: 'oldWorld|P1',
-                tileKey: 'oldWorld|P1|1|1',
-              ),
-            ],
-          ),
-          newWorld: const RegionData(),
-          tileKeysByRegionAndProvince: const {
-            ow: {
-              'oldWorld|P2': ['oldWorld|P2|2|2'],
-            },
-          },
-        ),
-        players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
-      );
-      final orders = Orders(
-        workOrdersByPlayerId: {
-          'p1': [
-            const WorkOrder(
-              unitId: 'u1',
-              target: 'build_farm',
-              targetTileKey: 'oldWorld|P2|2|2',
+    test(
+      'bundled work move trace records skipped attempts in movement phase',
+      () {
+        const ow = 'oldWorld';
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'oldWorld|P1',
+              regionId: ow,
+              type: TopologyNodeType.province,
             ),
-            const WorkOrder(
-              unitId: 'u2',
-              target: kWorkTargetExplore,
-              targetTileKey: 'oldWorld|P1|1|1',
+            TopologyNode(
+              id: 'oldWorld|P2',
+              regionId: ow,
+              type: TopologyNodeType.province,
             ),
           ],
-        },
-      );
-      final traces = <TurnTracePhaseTrace>[];
-      final runtime = TurnTraceRuntime();
-      resolveTurnForGameWithConfig(
-        game: game,
-        config: TurnResolverConfig(
-          topology: topology,
-          orders: orders,
-          onTurnTracePhase: traces.add,
-          turnTraceRuntime: runtime,
-        ),
-      );
+          edges: const [TopologyEdge(id1: 'oldWorld|P1', id2: 'oldWorld|P2')],
+        );
+        final game = Game(
+          id: 'g',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(id: 'oldWorld|P1', regionId: ow, ownerId: 'p1'),
+                Province(id: 'oldWorld|P2', regionId: ow, ownerId: 'p1'),
+              ],
+              units: [
+                Unit(
+                  id: 'u1',
+                  type: kUnitTypeMerchant,
+                  ownerId: 'p1',
+                  locationProvinceId: 'oldWorld|P1',
+                  tileKey: 'oldWorld|P1|0|0',
+                ),
+                Unit(
+                  id: 'u2',
+                  type: kUnitTypeMerchant,
+                  ownerId: 'p1',
+                  locationProvinceId: 'oldWorld|P1',
+                  tileKey: 'oldWorld|P1|1|1',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            tileKeysByRegionAndProvince: const {
+              ow: {
+                'oldWorld|P2': ['oldWorld|P2|2|2'],
+              },
+            },
+          ),
+          players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+        );
+        final orders = Orders(
+          workOrdersByPlayerId: {
+            'p1': [
+              const WorkOrder(
+                unitId: 'u1',
+                target: 'build_farm',
+                targetTileKey: 'oldWorld|P2|2|2',
+              ),
+              const WorkOrder(
+                unitId: 'u2',
+                target: kWorkTargetExplore,
+                targetTileKey: 'oldWorld|P1|1|1',
+              ),
+            ],
+          },
+        );
+        final traces = <TurnTracePhaseTrace>[];
+        final runtime = TurnTraceRuntime();
+        resolveTurnForGameWithConfig(
+          game: game,
+          config: TurnResolverConfig(
+            topology: topology,
+            orders: orders,
+            onTurnTracePhase: traces.add,
+            turnTraceRuntime: runtime,
+          ),
+        );
 
-      final movementTrace = traces.firstWhere(
-        (t) => t.phaseId == TurnPhase.movement.name,
-      );
-      expect(
-        movementTrace.orderEvents.map((event) => event.eventType),
-        contains('bundled_work_move_skipped'),
-      );
-    });
+        final movementTrace = traces.firstWhere(
+          (t) => t.phaseId == TurnPhase.movement.name,
+        );
+        expect(
+          movementTrace.orderEvents.map((event) => event.eventType),
+          contains('bundled_work_move_skipped'),
+        );
+      },
+    );
 
     test('runtime records bundled work move applied event payload', () {
       final runtime = TurnTraceRuntime();
@@ -232,6 +235,88 @@ void main() {
       expect(event.orderId, 'work:p1:u1:build_farm');
       expect(event.payload?['destinationProvinceId'], 'oldWorld|P2');
       expect(event.payload?['destinationTileKey'], 'oldWorld|P2|2|2');
+    });
+
+    test('full pipeline build_work phase includes work order trace events', () {
+      const ow = 'oldWorld';
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(
+            id: 'oldWorld|P1',
+            regionId: ow,
+            type: TopologyNodeType.province,
+          ),
+        ],
+        edges: const [],
+      );
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: 'oldWorld|P1', regionId: ow, ownerId: 'p1'),
+            ],
+            units: [
+              Unit(
+                id: 'u1',
+                type: kUnitTypeEngineer,
+                ownerId: 'p1',
+                locationProvinceId: 'oldWorld|P1',
+                tileKey: 'oldWorld|P1|0|0',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: const {
+            ow: {
+              'oldWorld|P1': ['oldWorld|P1|0|0'],
+            },
+          },
+        ),
+        players: const [
+          Player(
+            id: 'p1',
+            displayName: 'P1',
+            isHuman: true,
+            stockpile: Stockpile(quantities: {'wood': 100}),
+          ),
+        ],
+      );
+      final orders = Orders(
+        workOrdersByPlayerId: const {
+          'p1': [
+            WorkOrder(
+              unitId: 'u1',
+              target: kWorkTargetBuildRoad,
+              targetTileKey: 'oldWorld|P1|0|0',
+            ),
+          ],
+        },
+      );
+      final traces = <TurnTracePhaseTrace>[];
+      final runtime = TurnTraceRuntime();
+      resolveTurnForGameWithConfig(
+        game: game,
+        config: TurnResolverConfig(
+          topology: topology,
+          orders: orders,
+          onTurnTracePhase: traces.add,
+          turnTraceRuntime: runtime,
+        ),
+      );
+
+      final buildWorkTrace = traces.firstWhere(
+        (t) => t.phaseId == TurnPhase.buildWork.name,
+      );
+      expect(
+        buildWorkTrace.orderEvents.map((event) => event.eventType),
+        contains('work_order_skipped'),
+      );
+      expect(
+        buildWorkTrace.orderEvents.map((event) => event.orderId),
+        contains('work:p1:u1:build_road'),
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
Implements the missing app path for issue #2218 where **map next-turn** uses `TurnResolutionRunner` (worker isolate): merged JSON traces were never written, and full-AI `aiTraceSections` from the main isolate were not combined with phase execution data from the worker.

## Implemented
- `TurnResolutionRunner.startResolution(..., turnTraceEnabled: ...)`: when enabled, the isolate wires `onTurnTracePhase` + `TurnTraceRuntime`; success payload includes serialized phase traces. Main isolate attaches `FullAIResult.aiTraceSections` and resolution start timestamp to `TurnResolutionTerminalComplete`.
- `GameService.exportTurnTraceForExternallyResolvedTurn` + `isTurnTraceEnabled`: writes the same merged document as `runTurnResolution` after external (isolate) completion.
- `GameMapArea` passes `turnTraceEnabled: service.isTurnTraceEnabled` and exports on `TurnResolutionComplete`.
- `TurnTracePhaseTrace.fromJson` / `TurnTraceOrderEvent.fromJson` for decoding isolate maps.
- Added `work_order_applied` / `work_order_skipped` trace events from build/work phase order handling via `TurnTraceRuntime.handleWorkOrderTrace`, wired through `runBuildWorkPhase`.
- SPEC: `SPEC/program/turn-resolution-json-trace.md` — app worker-isolate merge behavior.
- Tests: logic JSON roundtrip; runner test asserting trace fields when `turnTraceEnabled: true`; pipeline test asserting build/work phase emits work-order trace events.

## Deferred (issue #2218 remains open)
- Additional order-event hooks outside movement + build/work (for example deeper combat/naval/order-application internals) and remaining AC gaps (performance verification, etc.) per issue verification comment.
- Resume-only diplomacy paths still use `runTurnResolution` without re-supplying AI trace (unchanged; session behavior as before).

## Tests
- `cd packages/colonizethis_logic && dart test test/turn_trace_contracts_json_roundtrip_test.dart`
- `cd packages/colonizethis_logic && dart test test/turn_trace_movement_order_events_test.dart`
- `cd app && flutter test test/turn_resolution_runner_test.dart`

Refs #2218

Made with [Cursor](https://cursor.com)