### PR TITLE
feat(trace): make app trace export directory startup-configurable

### DIFF
--- a/app/lib/config/ct_debug_console.dart
+++ b/app/lib/config/ct_debug_console.dart
@@ -4,3 +4,10 @@ const bool kCtDebugConsoleEnabled = bool.fromEnvironment(
   'CT_DEBUG_CONSOLE',
   defaultValue: false,
 );
+
+/// Optional compile-time override for JSON turn trace exports.
+/// Pass `--dart-define=CT_TURN_TRACE_DIR=/absolute/or/relative/path`.
+const String kCtTurnTraceDirectory = String.fromEnvironment(
+  'CT_TURN_TRACE_DIR',
+  defaultValue: 'tmp',
+);

--- a/app/lib/core/services/game_service.dart
+++ b/app/lib/core/services/game_service.dart
@@ -34,8 +34,10 @@ class GameService {
     this._box,
     this._adapter, {
     bool? turnTraceEnabled,
-    this.turnTraceRootDirectory = 'tmp',
-  }) : _turnTraceEnabled = turnTraceEnabled ?? kCtDebugConsoleEnabled;
+    String? turnTraceRootDirectory,
+  }) : _turnTraceEnabled = turnTraceEnabled ?? kCtDebugConsoleEnabled,
+       turnTraceRootDirectory =
+           turnTraceRootDirectory ?? kCtTurnTraceDirectory;
 
   final Box<dynamic> _box;
   final GameSaveAdapter _adapter;

--- a/app/test/game_service_cache_test.dart
+++ b/app/test/game_service_cache_test.dart
@@ -9,6 +9,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_save/colonizethis_save.dart';
 import 'package:hive/hive.dart';
 
+import 'package:colonizethis_app/config/ct_debug_console.dart';
 import 'package:colonizethis_app/core/services/game_service.dart';
 
 class _CountingGameSaveAdapter extends GameSaveAdapter {
@@ -46,6 +47,21 @@ void main() {
     test('getMapData returns null for unknown game id', () {
       final result = service.getMapData('no-such-game');
       expect(result, isNull);
+    });
+
+    test('default turn trace root directory matches startup config constant', () {
+      final defaultService = GameService(box, GameSaveAdapter());
+      expect(defaultService.turnTraceRootDirectory, kCtTurnTraceDirectory);
+    });
+
+    test('constructor turn trace root directory override takes precedence', () {
+      const overridePath = '/tmp/custom-turn-traces';
+      final overriddenService = GameService(
+        box,
+        GameSaveAdapter(),
+        turnTraceRootDirectory: overridePath,
+      );
+      expect(overriddenService.turnTraceRootDirectory, overridePath);
     });
 
     test('loadGame returns null when required map data is missing', () {


### PR DESCRIPTION
## Summary
- Add compile-time startup configuration for app turn-trace export directory via `CT_TURN_TRACE_DIR`.
- Wire `GameService` to default trace output root from startup config when no explicit constructor override is provided.
- Add tests for default-vs-override precedence on `GameService.turnTraceRootDirectory`.

## Implemented in this PR
- Added `kCtTurnTraceDirectory` in `app/lib/config/ct_debug_console.dart`.
- Updated `GameService` constructor to use startup-configured trace root by default.
- Extended `app/test/game_service_cache_test.dart` with two new coverage tests for startup default and explicit override behavior.

## Deferred work
- Remaining #2218 schema/document coverage and broader trace payload completeness requirements.
- Additional phase/AI trace depth and pending/resume lifecycle validation slices still in issue scope.

## Test plan
- `flutter test test/game_service_cache_test.dart` (run from `app/`)

Refs #2218

Made with [Cursor](https://cursor.com)