### PR TITLE
perf(logic): Queue-based BFS frontiers + AST gate (Refs #2268)

### DIFF
--- a/SPEC/program/disallowed-ast-patterns.md
+++ b/SPEC/program/disallowed-ast-patterns.md
@@ -170,6 +170,21 @@ decoupled from logic internals behind narrow contracts.
 
 Rule id: `debug_console_logic_contract_boundary` (`match.kind`:
 `scoped_package_import_contract`).
+
+### List-as-queue `queue.removeAt(0)` in `colonizethis_logic` sources
+
+In `packages/colonizethis_logic/lib/src/**`, a method invocation
+**`queue.removeAt(0)`** (receiver is the simple identifier `queue`, method
+`removeAt`, literal `0`) is disallowed.
+
+Rationale: using a growable `List` as a FIFO frontier makes each dequeue **O(n)**
+in the frontier size; **`dart:collection` `Queue.removeFirst()`** keeps
+breadth-first expansion **O(1)** per tile.
+
+Rule id: `logic_lib_list_queue_remove_at_zero` (`match.kind`:
+`simple_receiver_remove_at_zero`, `match.receiver_identifier`: `queue`,
+`match.relative_path_prefix`: `packages/colonizethis_logic/lib/src/`).
+
 ### Coverage
 
 Enforcement walks the same domain trees via `tool/ct_repo_lint_scan_contract.dart` (`collectRepoLintDomainDartFiles`), aligned with `SPEC/program/exception-enforcement.md` coverage:
@@ -287,3 +302,20 @@ Generated files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`) and tests (`**/te
   **when** the disallowed AST checker runs, **then** it reports at least one
   `debug_console_logic_contract_boundary` violation with the correct file and
   line.
+
+- **Given** runtime Dart source under
+  `packages/colonizethis_logic/lib/src/` that calls `queue.removeAt(0)`,
+  **when** the disallowed AST checker runs, **then** it reports at least one
+  violation for `logic_lib_list_queue_remove_at_zero` with the correct file
+  and line.
+
+- **Given** runtime Dart source under
+  `packages/colonizethis_logic/lib/src/` that dequeues with
+  `queue.removeFirst()` on a `Queue`, **when** the disallowed AST checker runs,
+  **then** it does not report a `logic_lib_list_queue_remove_at_zero`
+  violation for that call.
+
+- **Given** runtime Dart source outside
+  `packages/colonizethis_logic/lib/src/` that calls `queue.removeAt(0)`,
+  **when** the disallowed AST checker runs, **then** it does not report a
+  `logic_lib_list_queue_remove_at_zero` violation for that call.

--- a/packages/colonizethis_logic/lib/src/setup/capital_choice.dart
+++ b/packages/colonizethis_logic/lib/src/setup/capital_choice.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
@@ -683,9 +685,9 @@ List<(int, int)> _shortestPathOnProvinceTiles(
   final parent = <String, (int, int)>{};
   final startKey = '$fromX|$fromY';
   visited.add(startKey);
-  final queue = <(int, int)>[(fromX, fromY)];
+  final queue = Queue<(int, int)>()..add((fromX, fromY));
   while (queue.isNotEmpty) {
-    final (cx, cy) = queue.removeAt(0);
+    final (cx, cy) = queue.removeFirst();
     if (cx == toX && cy == toY) {
       final path = <(int, int)>[];
       var (px, py) = (toX, toY);

--- a/packages/colonizethis_logic/lib/src/setup/game_setup_helpers_towns.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup_helpers_towns.dart
@@ -1,4 +1,6 @@
 // SPEC/program/game-setup-pipeline.md §7d — province town assignment (importable library).
+import 'dart:collection';
+
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
@@ -221,7 +223,7 @@ Map<String, int> _bfsDistances({
   if (map == null) {
     return result;
   }
-  final queue = <({int x, int y, int distance})>[];
+  final queue = Queue<({int x, int y, int distance})>();
   final key = '${startCoords.x}|${startCoords.y}';
   final sx = startCoords.x;
   final sy = startCoords.y;
@@ -230,7 +232,7 @@ Map<String, int> _bfsDistances({
     result[map[key]!] = 0;
   }
   while (queue.isNotEmpty) {
-    final item = queue.removeAt(0);
+    final item = queue.removeFirst();
     for (final delta in const [
       [1, 0],
       [-1, 0],

--- a/packages/colonizethis_logic/lib/src/setup/gp_land_connectivity_repair.dart
+++ b/packages/colonizethis_logic/lib/src/setup/gp_land_connectivity_repair.dart
@@ -1,6 +1,8 @@
 // Legacy connectivity helper retained for tests and diagnostics (no repair pass).
 // SPEC/program/locked-province-assigner.md — product uses locked assigner only.
 
+import 'dart:collection';
+
 /// True if [gpId]'s provinces induce a single connected component on [neighbours] (P–P only).
 bool gpProvincesAreLandConnected(
   String gpId,
@@ -14,10 +16,10 @@ bool gpProvincesAreLandConnected(
   if (mine.length <= 1) return true;
   final start = mine.toList()..sort();
   final seed = start.first;
-  final queue = <String>[seed];
+  final queue = Queue<String>()..add(seed);
   final seen = <String>{seed};
   while (queue.isNotEmpty) {
-    final u = queue.removeAt(0);
+    final u = queue.removeFirst();
     for (final v in neighbours[u] ?? const <String>{}) {
       if (!mine.contains(v)) continue;
       if (seen.add(v)) queue.add(v);

--- a/packages/colonizethis_logic/lib/src/setup/province_assignment.dart
+++ b/packages/colonizethis_logic/lib/src/setup/province_assignment.dart
@@ -2,6 +2,7 @@
 /// Used by game_setup to assign Great Powers, Minor Nations, and Tribes.
 library;
 
+import 'dart:collection';
 import 'dart:math';
 
 /// True if [provinceId] shares a P–P edge with a province owned by [factionId].
@@ -75,7 +76,7 @@ bool _runBfsGrowthRound({
   required Map<String, int>? landmassIds,
   required Map<String, int>? factionLandmassIds,
   required Map<String, int> targetPerFaction,
-  required Map<String, List<String>> queues,
+  required Map<String, Queue<String>> queues,
   required Map<String, String> owners,
   required Set<String> available,
   required Map<String, int> assignedCount,
@@ -95,7 +96,7 @@ bool _runBfsGrowthRound({
     var expanded = false;
 
     while (queue.isNotEmpty && !expanded && nextTotal < total) {
-      final from = queue.removeAt(0);
+      final from = queue.removeFirst();
       final nbrOrder = (neighbours[from] ?? const <String>{}).toList()
         ..sort();
       if (neighborShuffleRandom != null) {
@@ -162,7 +163,7 @@ bool _runBfsGrowthRound({
 int _greedyAssignRemainingTerritories({
   required Set<String> available,
   required Map<String, String> owners,
-  required Map<String, List<String>> queues,
+  required Map<String, Queue<String>> queues,
   required Map<String, int> assignedCount,
   required List<String> factionIds,
   required Map<String, Set<String>> neighbours,
@@ -175,10 +176,13 @@ int _greedyAssignRemainingTerritories({
   var nextTotal = totalAssigned;
   if (available.isEmpty || nextTotal >= total) return nextTotal;
 
-  final remaining = available.toList()..sort();
-  if (neighborShuffleRandom != null) remaining.shuffle(neighborShuffleRandom);
+  final sortedRemaining = available.toList()..sort();
+  if (neighborShuffleRandom != null) {
+    sortedRemaining.shuffle(neighborShuffleRandom);
+  }
+  final remaining = Queue<String>()..addAll(sortedRemaining);
   while (remaining.isNotEmpty && nextTotal < total) {
-    final provinceId = remaining.removeAt(0);
+    final provinceId = remaining.removeFirst();
     if (!available.remove(provinceId)) continue;
 
     final chosenFactionId = _greedyPickFactionForProvince(
@@ -277,8 +281,8 @@ Map<String, String> assignTerritoriesByBfsGrowth({
   final owners = <String, String>{};
   final total = maxTotal ?? available.length;
 
-  final queues = <String, List<String>>{
-    for (final id in factionIds) id: <String>[],
+  final queues = <String, Queue<String>>{
+    for (final id in factionIds) id: Queue<String>(),
   };
   final assignedCount = <String, int>{for (final id in factionIds) id: 0};
   var totalAssigned = 0;

--- a/packages/colonizethis_logic/lib/src/utils/graph_traversal.dart
+++ b/packages/colonizethis_logic/lib/src/utils/graph_traversal.dart
@@ -88,7 +88,7 @@ Set<T> breadthFirstReachableInSubgraph<T>(
 /// Callers supply predicates and neighbor iteration; see
 /// `connectivity_resolver.dart` § capital land connectivity.
 void propagateConnectivityBottleneckQueue({
-  required List<String> queue,
+  required Queue<String> queue,
   required Set<String> connected,
   required Map<String, int> pathCap,
   required bool Function(String tileKey) shouldExpandEdgesFrom,
@@ -96,7 +96,7 @@ void propagateConnectivityBottleneckQueue({
   required int Function(String neighborKey) transportLevelAt,
 }) {
   while (queue.isNotEmpty) {
-    final key = queue.removeAt(0);
+    final key = queue.removeFirst();
     if (!shouldExpandEdgesFrom(key)) continue;
     final bottleneckU = pathCap[key] ?? 0;
     for (final neighbor in neighborsOf(key)) {
@@ -118,7 +118,7 @@ void _relaxBottleneckNeighbor({
   required int candidate,
   required Set<String> connected,
   required Map<String, int> pathCap,
-  required List<String> queue,
+  required Queue<String> queue,
 }) {
   final existing = pathCap[neighbor] ?? -1;
   if (candidate > existing) {

--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -219,7 +221,7 @@ void _tryEnqueueSeaConnectedPortExpansion({
   required Set<String> owned,
   required Map<String, TileMapResult> tileMapByRegion,
   required Map<String, int> pathCap,
-  required List<String> expansionSeedQueue,
+  required Queue<String> expansionSeedQueue,
 }) {
   if (connected.contains(portKey)) return;
   final coords = parseTileKeyCoordinates(portKey);
@@ -277,7 +279,7 @@ ConnectivityResult _connectedTilesForPlayer({
   final pathCap = <String, int>{};
   pathCap[capitalKey] = _transportLevelAtTile(worldState, capitalKey);
   _runConnectivityPropagation(
-    queue: <String>[capitalKey],
+    queue: Queue<String>()..add(capitalKey),
     connected: connected,
     pathCap: pathCap,
     worldState: worldState,
@@ -312,7 +314,7 @@ ConnectivityResult _connectedTilesForPlayer({
   );
   // When capital province is blockaded, seaConnectedPortKeys stays empty (no sea connectivity). SPEC § Blockade.
 
-  final expansionSeedQueue = <String>[];
+  final expansionSeedQueue = Queue<String>();
   for (final portKey in seaConnectedPortKeys) {
     _tryEnqueueSeaConnectedPortExpansion(
       portKey: portKey,
@@ -366,7 +368,7 @@ ConnectivityResult _connectedTilesForPlayer({
 }
 
 void _runConnectivityPropagation({
-  required List<String> queue,
+  required Queue<String> queue,
   required Set<String> connected,
   required Map<String, int> pathCap,
   required WorldState worldState,

--- a/packages/colonizethis_logic/lib/src/world/topology_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/world/topology_helpers.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:colonizethis_data/colonizethis_data.dart';
 
 /// Topology helpers shared by movement and connectivity. SPEC/game/map-topology.md.
@@ -49,9 +51,9 @@ Set<String> seaZonesReachableBySeaPath(
     }
   }
   final reachable = Set<String>.from(startSeaZoneIds);
-  final queue = List<String>.from(startSeaZoneIds);
+  final queue = Queue<String>()..addAll(startSeaZoneIds);
   while (queue.isNotEmpty) {
-    final z = queue.removeAt(0);
+    final z = queue.removeFirst();
     for (final n in neighbours[z] ?? {}) {
       if (reachable.contains(n)) continue;
       reachable.add(n);

--- a/packages/colonizethis_logic/test/utils/graph_traversal_test.dart
+++ b/packages/colonizethis_logic/test/utils/graph_traversal_test.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:colonizethis_logic/src/utils/graph_traversal.dart';
 import 'package:colonizethis_test/test.dart';
 
@@ -75,13 +77,25 @@ void main() {
       final r = breadthFirstReachableInSubgraph(['a'], adj, universe);
       expect(r, {'a', 'b'});
     });
+
+    test('expands line graph of 120 nodes within universe', () {
+      final adj = <String, Set<String>>{};
+      for (var i = 0; i < 119; i++) {
+        adj['n$i'] = {'n${i + 1}'};
+        adj['n${i + 1}'] = {'n$i'};
+      }
+      final universe = {for (var i = 0; i < 120; i++) 'n$i'};
+      final r = breadthFirstReachableInSubgraph(['n0'], adj, universe);
+      expect(r.length, 120);
+      expect(r, universe);
+    });
   });
 
   group('propagateConnectivityBottleneckQueue', () {
     test('relaxes neighbors with min bottleneck vs transport cap', () {
       final connected = <String>{'a'};
       final pathCap = <String, int>{'a': 5};
-      final queue = <String>['a'];
+      final queue = Queue<String>()..add('a');
       propagateConnectivityBottleneckQueue(
         queue: queue,
         connected: connected,

--- a/test/check_disallowed_ast_patterns_test.dart
+++ b/test/check_disallowed_ast_patterns_test.dart
@@ -83,6 +83,13 @@ rules:
       package_name: colonizethis_logic
       allowed_imports:
         - package:colonizethis_logic/debug_console_api.dart
+  - id: logic_lib_list_queue_remove_at_zero
+    message: >-
+      Do not use a List named queue as a FIFO frontier (queue.removeAt(0)).
+    match:
+      kind: simple_receiver_remove_at_zero
+      receiver_identifier: queue
+      relative_path_prefix: packages/colonizethis_logic/lib/src/
 ''';
 
 void main() {
@@ -683,6 +690,58 @@ import 'package:colonizethis_logic/colonizethis_logic.dart';
       );
       expect(violations, isNotEmpty);
       expect(violations.first.ruleId, 'debug_console_logic_contract_boundary');
+    });
+  });
+
+  group('logic_lib_list_queue_remove_at_zero', () {
+    test('flags queue.removeAt(0) under colonizethis_logic lib/src', () {
+      const src = r'''
+void f(List<String> queue) {
+  final x = queue.removeAt(0);
+}
+''';
+      final violations = findDisallowedAstViolations(
+        'packages/colonizethis_logic/lib/src/x.dart',
+        src,
+        rules,
+      );
+      expect(
+        violations.where((e) => e.ruleId == 'logic_lib_list_queue_remove_at_zero'),
+        isNotEmpty,
+      );
+    });
+
+    test('ignores queue.removeAt(0) outside lib/src tree', () {
+      const src = r'''
+void f(List<String> queue) {
+  final x = queue.removeAt(0);
+}
+''';
+      final violations = findDisallowedAstViolations(
+        'packages/colonizethis_logic/lib/x.dart',
+        src,
+        rules,
+      );
+      expect(
+        violations.where((e) => e.ruleId == 'logic_lib_list_queue_remove_at_zero'),
+        isEmpty,
+      );
+    });
+
+    test('respects same-line ignore for queue.removeAt(0)', () {
+      const src = r'''
+void f(List<String> queue) {
+  final x = queue.removeAt(0); // ignore: disallowed_ast_logic_lib_list_queue_remove_at_zero
+}
+''';
+      expect(
+        findDisallowedAstViolations(
+          'packages/colonizethis_logic/lib/src/x.dart',
+          src,
+          rules,
+        ).where((e) => e.ruleId == 'logic_lib_list_queue_remove_at_zero'),
+        isEmpty,
+      );
     });
   });
 }

--- a/tool/check_disallowed_ast_patterns.dart
+++ b/tool/check_disallowed_ast_patterns.dart
@@ -350,6 +350,38 @@ bool _looksLikeTileKeysByRegionAndProvinceLookup(IndexExpression node) {
   return src.contains('tileKeysByRegionAndProvince[');
 }
 
+bool _isSimpleReceiverRemoveAtZeroPattern(
+  MethodInvocation node,
+  DisallowedPatternRule rule,
+  String relativePath,
+) {
+  final prefix = rule.removeAtZeroReceiverPathPrefix;
+  final receiverName = rule.removeAtZeroReceiverIdentifier;
+  if (prefix == null || receiverName == null) {
+    return false;
+  }
+  final slashPath = relativePath.replaceAll('\\', '/');
+  if (!slashPath.startsWith(prefix)) {
+    return false;
+  }
+  if (node.methodName.name != 'removeAt') {
+    return false;
+  }
+  final target = node.target;
+  if (target is! SimpleIdentifier || target.name != receiverName) {
+    return false;
+  }
+  final args = node.argumentList.arguments;
+  if (args.length != 1) {
+    return false;
+  }
+  final arg0 = args.first;
+  if (arg0 is! IntegerLiteral) {
+    return false;
+  }
+  return arg0.value == 0;
+}
+
 bool _isUnprefixedProvinceIdStringLiteralInvocation(
   MethodInvocation node,
   DisallowedPatternRule rule,
@@ -416,6 +448,10 @@ class _DisallowedAstVisitor extends RecursiveAstVisitor<void> {
       } else if (rule.kind ==
               DisallowedAstMatchKind.provinceLocalSegmentBoundaryOnly &&
           _isProvinceLocalSegmentInvocation(node)) {
+        _recordIfAllowed(node, rule);
+      } else if (rule.kind ==
+              DisallowedAstMatchKind.simpleReceiverRemoveAtZero &&
+          _isSimpleReceiverRemoveAtZeroPattern(node, rule, path)) {
         _recordIfAllowed(node, rule);
       }
       if (rule.kind ==

--- a/tool/disallowed_ast_pattern_rules.dart
+++ b/tool/disallowed_ast_pattern_rules.dart
@@ -12,6 +12,7 @@ enum DisallowedAstMatchKind {
   unprefixedProvinceIdStringLiteralArgument,
   provinceLocalSegmentBoundaryOnly,
   scopedPackageImportContract,
+  simpleReceiverRemoveAtZero,
 }
 
 class DisallowedPatternRule {
@@ -31,6 +32,8 @@ class DisallowedPatternRule {
     required this.scopedRelativePathPrefixes,
     required this.packageName,
     required this.allowedPackageImports,
+    this.removeAtZeroReceiverPathPrefix,
+    this.removeAtZeroReceiverIdentifier,
   });
 
   final String id;
@@ -48,6 +51,14 @@ class DisallowedPatternRule {
   final Set<String> scopedRelativePathPrefixes;
   final String? packageName;
   final Set<String> allowedPackageImports;
+
+  /// When [kind] is [DisallowedAstMatchKind.simpleReceiverRemoveAtZero]: relative
+  /// path prefix (POSIX slashes) limiting matches, e.g. `packages/colonizethis_logic/lib/src/`.
+  final String? removeAtZeroReceiverPathPrefix;
+
+  /// When [kind] is [DisallowedAstMatchKind.simpleReceiverRemoveAtZero]: simple
+  /// identifier of the receiver for `removeAt(0)` (typically `queue`).
+  final String? removeAtZeroReceiverIdentifier;
 }
 
 class DisallowedAstViolation {
@@ -331,6 +342,37 @@ List<DisallowedPatternRule> parseDisallowedAstRulesFromYaml(Object? yamlRoot) {
           scopedRelativePathPrefixes: const {},
           packageName: null,
           allowedPackageImports: const {},
+        ),
+      );
+    } else if (kind == 'simple_receiver_remove_at_zero') {
+      final prefix =
+          match['relative_path_prefix']?.toString().replaceAll('\\', '/');
+      final receiver = match['receiver_identifier']?.toString();
+      if (prefix == null ||
+          prefix.isEmpty ||
+          receiver == null ||
+          receiver.isEmpty) {
+        continue;
+      }
+      out.add(
+        DisallowedPatternRule(
+          id: id,
+          message: message,
+          kind: DisallowedAstMatchKind.simpleReceiverRemoveAtZero,
+          cascadedMethodNames: const {},
+          commentSubstring: null,
+          rawNamedTypeNames: const {},
+          functionName: null,
+          maxBodyLineSpan: null,
+          requireWidgetClassExtends: false,
+          argumentIndex: null,
+          invocationMethodNames: const {},
+          allowedRelativePaths: const {},
+          scopedRelativePathPrefixes: const {},
+          packageName: null,
+          allowedPackageImports: const {},
+          removeAtZeroReceiverPathPrefix: prefix,
+          removeAtZeroReceiverIdentifier: receiver,
         ),
       );
     } else if (kind == 'scoped_package_import_contract') {

--- a/tool/disallowed_ast_patterns.yaml
+++ b/tool/disallowed_ast_patterns.yaml
@@ -118,3 +118,11 @@ rules:
       package_name: colonizethis_logic
       allowed_imports:
         - package:colonizethis_logic/debug_console_api.dart
+  - id: logic_lib_list_queue_remove_at_zero
+    message: >-
+      Do not use a List named queue as a FIFO frontier (queue.removeAt(0) is
+      O(n) per dequeue). Use dart:collection Queue with removeFirst() instead.
+    match:
+      kind: simple_receiver_remove_at_zero
+      receiver_identifier: queue
+      relative_path_prefix: packages/colonizethis_logic/lib/src/


### PR DESCRIPTION
## Summary

Partial delivery for [issue #2268](https://github.com/waigore/colonizethisv3/issues/2268) (**Refactor hot-path linear scans**): implements **refactor item 1** / **AC-1** (replace `List`-as-queue `removeAt(0)` with `dart:collection` `Queue.removeFirst()`) across the six logic files called out in the issue, wires **connectivity** propagation to `Queue<String>`, and lands **AC-9** as `logic_lib_list_queue_remove_at_zero` in `tool/disallowed_ast_patterns.yaml` with SPEC and unit test coverage.

**Refs #2268** (does not close; AC-2–AC-8, AC-10, AC-11 remain.)

## Implemented in this PR

- `propagateConnectivityBottleneckQueue` / `_runConnectivityPropagation` / sea port expansion seeds: `Queue<String>` + `removeFirst()`.
- Setup/world BFS sites: `province_assignment.dart`, `gp_land_connectivity_repair.dart`, `game_setup_helpers_towns.dart`, `capital_choice.dart`, `topology_helpers.dart`.
- **AC-9:** New AST match kind `simple_receiver_remove_at_zero` (receiver `queue`, `removeAt(0)`, path prefix `packages/colonizethis_logic/lib/src/`).
- **Tests:** `breadthFirstReachableInSubgraph` line graph (120 nodes); `propagateConnectivityBottleneckQueue` updated for `Queue`; three checker tests for the new rule.
- **SPEC:** `SPEC/program/disallowed-ast-patterns.md` policy + acceptance bullets.

## Deferred (follow-up PRs / same issue)

- **AC-2–AC-8, AC-10, AC-11:** `playerById` map, unit lookup index, diplomacy maps/caches, faction-type sets, town-rule worklist, port cache, performance characterization test, full regression/coverage/sim gates as listed on the issue.
- `game_setup_ownership.dart` still uses `seaBoundOnLandmass.removeAt(0)` (receiver is not `queue`; out of scope for the new AST rule shape).

## Verification

- `dart test packages/colonizethis_logic/test/utils/graph_traversal_test.dart`
- `dart test test/check_disallowed_ast_patterns_test.dart`
- `dart test` in `packages/colonizethis_logic` (full package suite)
- `dart run tool/check_disallowed_ast_patterns.dart` (no violations)
- Targeted: `connectivity_resolver_test.dart`, `province_assignment_test.dart`, `topology_helpers_test.dart`


Made with [Cursor](https://cursor.com)