### PR TITLE
perf(logic): O(1) playerById map cache (Refs #2268)

### DIFF
--- a/packages/colonizethis_logic/lib/src/constants.dart
+++ b/packages/colonizethis_logic/lib/src/constants.dart
@@ -80,12 +80,22 @@ bool isProspectableTerrainId(String? terrainTypeId) {
   return false;
 }
 
+/// Lazily built once per [Game] instance (issue #2268 AC-2); invalidated when a
+/// new [Game] replaces the previous one via [Game.copyWith].
+final Expando<Map<String, Player>> _gamePlayersById =
+    Expando<Map<String, Player>>('gamePlayersById');
+
 /// Safe player lookup by id. Returns null if not found.
 extension GamePlayerLookup on Game {
   Player? playerById(String id) {
-    for (final p in players) {
-      if (p.id == id) return p;
+    var byId = _gamePlayersById[this];
+    if (byId == null) {
+      byId = <String, Player>{};
+      for (final p in players) {
+        byId.putIfAbsent(p.id, () => p);
+      }
+      _gamePlayersById[this] = byId;
     }
-    return null;
+    return byId[id];
   }
 }

--- a/packages/colonizethis_logic/test/constants_test.dart
+++ b/packages/colonizethis_logic/test/constants_test.dart
@@ -59,5 +59,57 @@ void main() {
       );
       expect(emptyGame.playerById('gp1'), isNull);
     });
+
+    test('lookup scales across many distinct player ids', () {
+      const count = 120;
+      final players = List<Player>.generate(
+        count,
+        (i) => Player(
+          id: 'p$i',
+          displayName: 'P$i',
+          isHuman: i.isEven,
+        ),
+      );
+      final bigGame = Game(
+        id: 'g-many',
+        worldState: WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: players,
+      );
+      for (var i = 0; i < count; i++) {
+        expect(bigGame.playerById('p$i')?.id, 'p$i');
+      }
+      expect(bigGame.playerById('missing'), isNull);
+    });
+
+    test('duplicate player ids keep first list occurrence', () {
+      final dupGame = Game(
+        id: 'g-dup',
+        worldState: WorldState(
+          turnState: TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'dup', displayName: 'First', isHuman: true),
+          Player(id: 'dup', displayName: 'Second', isHuman: false),
+        ],
+      );
+      expect(dupGame.playerById('dup')?.displayName, 'First');
+    });
+
+    test('copyWith new players list invalidates lookup for new instance', () {
+      final updated = game.copyWith(
+        players: [
+          ...game.players,
+          const Player(id: 'gp4', displayName: 'Portugal', isHuman: false),
+        ],
+      );
+      expect(game.playerById('gp4'), isNull);
+      expect(updated.playerById('gp4')?.displayName, 'Portugal');
+    });
   });
 }


### PR DESCRIPTION
## Summary

Implements **issue #2268 AC-2** (`GamePlayerLookup.playerById`): build a `Map<String, Player>` once per `Game` instance (via `Expando`) so repeated lookups are O(1). Duplicate ids keep **first** list occurrence, matching the previous linear scan.

## Implemented

- `packages/colonizethis_logic/lib/src/constants.dart`: lazy per-instance index with `putIfAbsent` for first-wins semantics.
- `packages/colonizethis_logic/test/constants_test.dart`: many-player lookup, duplicate-id behavior, and `copyWith` isolation (new `Game` gets a fresh index).

## Deferred (same issue)

- AC-3–AC-11 and remaining refactor items (unit lookup map, diplomacy relation maps, town-rule worklist, performance characterization test, etc.) per issue ordering.

## SPEC

None (optimization only; issue states no SPEC follow-up).

## Tests

- `cd packages/colonizethis_logic && dart test test/constants_test.dart`
- `cd packages/colonizethis_logic && dart test` (full package suite)

Refs #2268

Made with [Cursor](https://cursor.com)