### PR TITLE
perf(logic): O(1) WorldState unit id index (Refs #2268)

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/unit_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/world/unit_lookup.dart
@@ -56,28 +56,57 @@ Map<String, int> shipTypeCountsForPlayer(WorldState world, String playerId) {
   return map;
 }
 
-Unit? _firstUnitWithId(List<Unit> units, String unitId) {
-  for (final u in units) {
-    if (u.id == unitId) return u;
+/// Lazily built per [WorldState] instance (issue #2268 AC-3). A new
+/// [WorldState] from [WorldState.copyWith] gets a fresh cache via identity.
+final Expando<_WorldUnitIndex> _worldUnitIndexByState =
+    Expando<_WorldUnitIndex>('worldUnitIndexByState');
+
+/// Old-world-first id → unit plus membership sets for O(1) region checks.
+final class _WorldUnitIndex {
+  _WorldUnitIndex({
+    required this.byId,
+    required this.oldIds,
+    required this.newIds,
+  });
+
+  final Map<String, Unit> byId;
+  final Set<String> oldIds;
+  final Set<String> newIds;
+}
+
+_WorldUnitIndex _unitIndexForWorld(WorldState world) {
+  var index = _worldUnitIndexByState[world];
+  if (index != null) return index;
+
+  final byId = <String, Unit>{};
+  final oldIds = <String>{};
+  for (final u in world.oldWorld.units) {
+    oldIds.add(u.id);
+    byId.putIfAbsent(u.id, () => u);
   }
-  return null;
+  final newIds = <String>{};
+  for (final u in world.newWorld.units) {
+    newIds.add(u.id);
+    byId.putIfAbsent(u.id, () => u);
+  }
+  index = _WorldUnitIndex(byId: byId, oldIds: oldIds, newIds: newIds);
+  _worldUnitIndexByState[world] = index;
+  return index;
 }
 
 /// Cross-region unit lookup on [WorldState] (waigore/colonizethis#2071 Phase 1).
 extension WorldStateUnitLookup on WorldState {
   /// Returns the unit with [unitId] in old world first, then new world, or null.
-  Unit? tryGetUnitById(String unitId) {
-    return _firstUnitWithId(oldWorld.units, unitId) ??
-        _firstUnitWithId(newWorld.units, unitId);
-  }
+  Unit? tryGetUnitById(String unitId) => _unitIndexForWorld(this).byId[unitId];
 
   /// [kRegionOldWorld] or [kRegionNewWorld] based on which regional unit list
   /// contains [unit]'s id (old world checked first). Null if absent from both.
   String? tryGetRegionIdForUnit(Unit unit) {
-    if (_firstUnitWithId(oldWorld.units, unit.id) != null) {
+    final index = _unitIndexForWorld(this);
+    if (index.oldIds.contains(unit.id)) {
       return kRegionOldWorld;
     }
-    if (_firstUnitWithId(newWorld.units, unit.id) != null) {
+    if (index.newIds.contains(unit.id)) {
       return kRegionNewWorld;
     }
     return null;

--- a/packages/colonizethis_logic/test/world/unit_lookup_test.dart
+++ b/packages/colonizethis_logic/test/world/unit_lookup_test.dart
@@ -69,6 +69,55 @@ void main() {
       );
       expect(ws.tryGetUnitById('dup')!.type, kUnitTypeExplorer);
     });
+
+    test('500+ units per region matches linear old-then-new scan (AC-3)', () {
+      const n = 520;
+      final oldUnits = List<Unit>.generate(
+        n,
+        (i) => Unit(
+          id: 'old-$i',
+          type: kUnitTypeExplorer,
+          ownerId: 'p1',
+          locationProvinceId: 'oldWorld|P1',
+          tileKey: 'oldWorld|P1|0|0',
+        ),
+      );
+      final newUnits = List<Unit>.generate(
+        n,
+        (i) => Unit(
+          id: 'new-$i',
+          type: kUnitTypeBuilder,
+          ownerId: 'p2',
+          locationProvinceId: 'newWorld|P2',
+          tileKey: 'newWorld|P2|0|0',
+        ),
+      );
+      final ws = WorldState(
+        turnState: turn,
+        oldWorld: RegionData(units: oldUnits),
+        newWorld: RegionData(units: newUnits),
+      );
+
+      Unit? linearLookup(String unitId) {
+        for (final u in ws.oldWorld.units) {
+          if (u.id == unitId) return u;
+        }
+        for (final u in ws.newWorld.units) {
+          if (u.id == unitId) return u;
+        }
+        return null;
+      }
+
+      for (var i = 0; i < n; i++) {
+        final id = 'old-$i';
+        expect(ws.tryGetUnitById(id), same(linearLookup(id)));
+      }
+      for (var i = 0; i < n; i++) {
+        final id = 'new-$i';
+        expect(ws.tryGetUnitById(id), same(linearLookup(id)));
+      }
+      expect(ws.tryGetUnitById('missing'), isNull);
+    });
   });
 
   group('WorldStateUnitLookup.tryGetRegionIdForUnit', () {


### PR DESCRIPTION
## Summary

Implements **AC-3** from #2268: indexed cross-region unit lookup on `WorldState` instead of scanning `oldWorld.units` and `newWorld.units` for every `tryGetUnitById` / region check.

## What this PR implements

- Per-`WorldState` lazy cache via `Expando` (same invalidation model as `Game.playerById` in #2270): `Map<String, Unit>` with old-then-new `putIfAbsent` semantics, plus `Set<String>` membership for `tryGetRegionIdForUnit`.
- New scale test: 520 units per region; every lookup matches a linear old-then-new reference and `same()` instance identity.

## Deferred (still on #2268)

- AC-4 through AC-8 (diplomacy maps, province counts, faction sets, connectivity worklist/cache).
- AC-10 performance characterization test.
- AC-11 remains the global regression barrier for the full issue.

## Spec

None (pure optimization; issue states no SPEC follow-up).

## Tests

- `cd packages/colonizethis_logic && dart test test/world/unit_lookup_test.dart`

Refs #2268

Made with [Cursor](https://cursor.com)