### PR TITLE
perf(logic): O(1) diplomacy relation and overture lookups (Refs #2268)

### DIFF
--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
@@ -148,6 +148,41 @@ String relationScoreToDisplayLabel(int score) {
 /// Normalizes faction pair for lookup (consistent ordering).
 String pairKey(String a, String b) => a.compareTo(b) <= 0 ? '$a|$b' : '$b|$a';
 
+/// Lazily built per [Game] instance (issue #2268 AC-4). A new [Game] from
+/// [Game.copyWith] does not share expando state with the previous instance.
+final Expando<Map<String, DiplomacyRelation>> _gameDiplomacyRelationsByPairKey =
+    Expando<Map<String, DiplomacyRelation>>('gameDiplomacyRelationsByPairKey');
+
+/// Directed GP → Minor/Tribe overture rows, keyed by `_overtureLookupKey`.
+final Expando<Map<String, OvertureState>> _gameOvertureStatesByGpTarget =
+    Expando<Map<String, OvertureState>>('gameOvertureStatesByGpTarget');
+
+String _overtureLookupKey(String gpId, String targetId) => '$gpId|$targetId';
+
+Map<String, DiplomacyRelation> _diplomacyRelationsByPairKey(Game game) {
+  var map = _gameDiplomacyRelationsByPairKey[game];
+  if (map == null) {
+    map = <String, DiplomacyRelation>{};
+    for (final r in game.diplomacyRelations) {
+      map.putIfAbsent(pairKey(r.factionId1, r.factionId2), () => r);
+    }
+    _gameDiplomacyRelationsByPairKey[game] = map;
+  }
+  return map;
+}
+
+Map<String, OvertureState> _overtureStatesByLookupKey(Game game) {
+  var map = _gameOvertureStatesByGpTarget[game];
+  if (map == null) {
+    map = <String, OvertureState>{};
+    for (final o in game.overtureStates) {
+      map.putIfAbsent(_overtureLookupKey(o.gpId, o.targetId), () => o);
+    }
+    _gameOvertureStatesByGpTarget[game] = map;
+  }
+  return map;
+}
+
 /// Returns relation for faction pair, or null if not found.
 DiplomacyRelation? getRelation(
   Game game,
@@ -155,10 +190,7 @@ DiplomacyRelation? getRelation(
   String factionId2,
 ) {
   final key = pairKey(factionId1, factionId2);
-  for (final r in game.diplomacyRelations) {
-    if (pairKey(r.factionId1, r.factionId2) == key) return r;
-  }
-  return null;
+  return _diplomacyRelationsByPairKey(game)[key];
 }
 
 /// Finds the relation, passes it (or null) to [updater], and replaces or appends the result.
@@ -169,13 +201,17 @@ List<DiplomacyRelation> upsertRelation(
   DiplomacyRelation Function(DiplomacyRelation?) updater,
 ) {
   final key = pairKey(factionId1, factionId2);
-  final idx = relations.indexWhere(
-    (r) => pairKey(r.factionId1, r.factionId2) == key,
-  );
-  final existing = idx >= 0 ? relations[idx] : null;
+  final firstIndexByPairKey = <String, int>{};
+  for (var i = 0; i < relations.length; i++) {
+    final r = relations[i];
+    final rk = pairKey(r.factionId1, r.factionId2);
+    firstIndexByPairKey.putIfAbsent(rk, () => i);
+  }
+  final idx = firstIndexByPairKey[key];
+  final existing = idx != null ? relations[idx] : null;
   final updated = updater(existing);
   final result = List<DiplomacyRelation>.from(relations);
-  if (idx >= 0) {
+  if (idx != null) {
     result[idx] = updated;
   } else {
     result.add(updated);
@@ -185,10 +221,7 @@ List<DiplomacyRelation> upsertRelation(
 
 /// Returns overture state for GP–Minor/Tribe, or null.
 OvertureState? getOverture(Game game, String gpId, String targetId) {
-  for (final o in game.overtureStates) {
-    if (o.gpId == gpId && o.targetId == targetId) return o;
-  }
-  return null;
+  return _overtureStatesByLookupKey(game)[_overtureLookupKey(gpId, targetId)];
 }
 
 /// True when [a] and [b] are at war according to [game.diplomacyRelations].

--- a/packages/colonizethis_logic/test/diplomacy_relation_updates_test.dart
+++ b/packages/colonizethis_logic/test/diplomacy_relation_updates_test.dart
@@ -1,6 +1,26 @@
 import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_logic/src/diplomacy/diplomacy_relation_lookup.dart';
 import 'package:colonizethis_logic/src/diplomacy/diplomacy_relation_updates.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+
+DiplomacyRelation? _linearScanGetRelation(
+  Game game,
+  String factionId1,
+  String factionId2,
+) {
+  final key = pairKey(factionId1, factionId2);
+  for (final r in game.diplomacyRelations) {
+    if (pairKey(r.factionId1, r.factionId2) == key) return r;
+  }
+  return null;
+}
+
+OvertureState? _linearScanGetOverture(Game game, String gpId, String targetId) {
+  for (final o in game.overtureStates) {
+    if (o.gpId == gpId && o.targetId == targetId) return o;
+  }
+  return null;
+}
 
 void main() {
   group('applyGrantAidModifier', () {
@@ -46,5 +66,114 @@ void main() {
       expect(result[0].score, 70);
       expect(result[0].lastInteractionTurn, 3);
     });
+  });
+
+  group('AC-4 diplomacy relation / overture map lookup (Refs #2268)', () {
+    test('getRelation matches linear scan for every pair in a mixed list', () {
+      final relations = <DiplomacyRelation>[
+        const DiplomacyRelation(
+          factionId1: 'zebra',
+          factionId2: 'alpha',
+          score: 1,
+        ),
+        const DiplomacyRelation(
+          factionId1: 'gp_b',
+          factionId2: 'gp_a',
+          score: 2,
+        ),
+        const DiplomacyRelation(factionId1: 'm1', factionId2: 'm2', score: 3),
+      ];
+      final game = Game(
+        id: 't',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [],
+        diplomacyRelations: relations,
+      );
+      final ids = <String>{
+        'zebra',
+        'alpha',
+        'gp_a',
+        'gp_b',
+        'm1',
+        'm2',
+        'solo',
+      };
+      for (final a in ids) {
+        for (final b in ids) {
+          if (a == b) continue;
+          expect(
+            getRelation(game, a, b),
+            _linearScanGetRelation(game, a, b),
+            reason: 'pair ($a,$b)',
+          );
+        }
+      }
+    });
+
+    test('getOverture matches linear scan for representative keys', () {
+      final overtures = <OvertureState>[
+        const OvertureState(
+          gpId: 'gp1',
+          targetId: 't1',
+          stage: OvertureStage.tradeConsulate,
+        ),
+        const OvertureState(
+          gpId: 'gp2',
+          targetId: 't1',
+          stage: OvertureStage.embassy,
+        ),
+      ];
+      final game = Game(
+        id: 't',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [],
+        overtureStates: overtures,
+      );
+      expect(
+        getOverture(game, 'gp1', 't1'),
+        _linearScanGetOverture(game, 'gp1', 't1'),
+      );
+      expect(
+        getOverture(game, 'gp2', 't1'),
+        _linearScanGetOverture(game, 'gp2', 't1'),
+      );
+      expect(getOverture(game, 'gp1', 'missing'), isNull);
+    });
+
+    test(
+      'after upsertRelation, new Game sees updated relation via getRelation',
+      () {
+        final g0 = Game(
+          id: 't',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: const [],
+          diplomacyRelations: const [
+            DiplomacyRelation(factionId1: 'a', factionId2: 'b', score: 40),
+          ],
+        );
+        expect(getRelation(g0, 'a', 'b')?.score, 40);
+
+        final nextRelations = upsertRelation(
+          g0.diplomacyRelations,
+          'a',
+          'b',
+          (e) => e!.copyWith(score: 88),
+        );
+        final g1 = g0.copyWith(diplomacyRelations: nextRelations);
+        expect(getRelation(g1, 'b', 'a')?.score, 88);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Implements **issue #2268 AC-4** (diplomacy relation / overture lookups): `getRelation` / `getOverture` use lazily built maps on each immutable `Game` instance (Expando, same pattern as AC-2 `playerById`). `upsertRelation` resolves the target row via a first-index map keyed by `pairKey` instead of `indexWhere`.

## Spec

No SPEC changes (behavior-neutral optimization per issue).

## Tests

- Extended `packages/colonizethis_logic/test/diplomacy_relation_updates_test.dart`: map vs linear-scan equivalence for relations and overtures; `copyWith` + `upsertRelation` integration for `getRelation`.
- Ran `dart test` for the full `colonizethis_logic` package (1418 tests).

## AC coverage (this PR)

| AC | Status |
|----|--------|
| AC-1 | Done earlier (#2269) |
| AC-2 | Done earlier (#2270) |
| AC-3 | Done earlier (#2271) |
| **AC-4** | **This PR** |
| AC-5–AC-11 | Deferred |

## Deferred (follow-up PRs)

- AC-5: `provinceCountOwnedBy` cache per resolve call.
- AC-6: precomputed faction-type sets in `diplomacy_resolver`.
- AC-7–AC-8: `connectivity_resolver` worklist / port map cache.
- AC-9–AC-11: performance CI gates and regression barrier as specified in the issue.

Refs #2268

Made with [Cursor](https://cursor.com)