### PR TITLE
perf(logic): O(1) provinceCountOwnedBy via per-Game histogram (Refs #2268)

### DIFF
--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
@@ -18,13 +18,29 @@ const int overtureEmbassyCost = 1000;
 const int joinEmpireBaseCost = 5000;
 const int joinEmpirePerProvinceCost = 2000;
 
+/// Lazily built per [Game] instance (issue #2268 AC-5). A new [Game] from
+/// [Game.copyWith] does not share expando state with the previous instance.
+final Expando<Map<String, int>> _gameProvinceCountsByOwner =
+    Expando<Map<String, int>>('gameProvinceCountsByOwner');
+
+Map<String, int> _provinceCountsByOwner(Game game) {
+  var map = _gameProvinceCountsByOwner[game];
+  if (map == null) {
+    final built = <String, int>{};
+    for (final p in allProvinces(game.worldState)) {
+      final oid = p.ownerId;
+      if (oid == null) continue;
+      built[oid] = (built[oid] ?? 0) + 1;
+    }
+    _gameProvinceCountsByOwner[game] = built;
+    map = built;
+  }
+  return map;
+}
+
 /// Returns the number of provinces owned by [factionId] (Minor or Tribe) in [game].
 int provinceCountOwnedBy(Game game, String factionId) {
-  var count = 0;
-  for (final p in allProvinces(game.worldState)) {
-    if (p.ownerId == factionId) count++;
-  }
-  return count;
+  return _provinceCountsByOwner(game)[factionId] ?? 0;
 }
 
 /// Default weights for Great Power power score. SPEC/game/diplomacy.md § Great Power power score.

--- a/packages/colonizethis_logic/test/diplomacy_relation_updates_test.dart
+++ b/packages/colonizethis_logic/test/diplomacy_relation_updates_test.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_logic/src/diplomacy/diplomacy_relation_lookup.dart';
 import 'package:colonizethis_logic/src/diplomacy/diplomacy_relation_updates.dart';
+import 'package:colonizethis_logic/src/world/province_lookup.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 DiplomacyRelation? _linearScanGetRelation(
@@ -20,6 +21,14 @@ OvertureState? _linearScanGetOverture(Game game, String gpId, String targetId) {
     if (o.gpId == gpId && o.targetId == targetId) return o;
   }
   return null;
+}
+
+int _linearScanProvinceCountOwnedBy(Game game, String factionId) {
+  var count = 0;
+  for (final p in allProvinces(game.worldState)) {
+    if (p.ownerId == factionId) count++;
+  }
+  return count;
 }
 
 void main() {
@@ -175,5 +184,73 @@ void main() {
         expect(getRelation(g1, 'b', 'a')?.score, 88);
       },
     );
+  });
+
+  group('AC-5 provinceCountOwnedBy histogram (Refs #2268)', () {
+    test('cached counts match full scan for every owner in a two-region setup', () {
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'oldWorld|a', regionId: 'oldWorld', ownerId: 'gp1'),
+              Province(id: 'oldWorld|b', regionId: 'oldWorld', ownerId: 'tribe_x'),
+              Province(id: 'oldWorld|c', regionId: 'oldWorld', ownerId: null),
+            ],
+          ),
+          newWorld: RegionData(
+            provinces: [
+              Province(id: 'newWorld|n1', regionId: 'newWorld', ownerId: 'gp1'),
+              Province(id: 'newWorld|n2', regionId: 'newWorld', ownerId: 'minor_y'),
+              Province(id: 'newWorld|n3', regionId: 'newWorld', ownerId: 'minor_y'),
+            ],
+          ),
+        ),
+        players: const [],
+      );
+      const owners = {'gp1', 'tribe_x', 'minor_y', 'nobody', ''};
+      for (final id in owners) {
+        expect(
+          provinceCountOwnedBy(game, id),
+          _linearScanProvinceCountOwnedBy(game, id),
+          reason: 'faction $id',
+        );
+      }
+      // Repeated reads use the same snapshot (histogram built once per Game).
+      expect(provinceCountOwnedBy(game, 'gp1'), 2);
+      expect(provinceCountOwnedBy(game, 'minor_y'), 2);
+    });
+
+    test('copyWith new Game instance gets counts from its own worldState', () {
+      final g0 = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'oldWorld|p1', regionId: 'oldWorld', ownerId: 'm1'),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [],
+      );
+      expect(provinceCountOwnedBy(g0, 'm1'), 1);
+
+      final g1 = g0.copyWith(
+        worldState: g0.worldState.copyWith(
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'oldWorld|p1', regionId: 'oldWorld', ownerId: 'm1'),
+              Province(id: 'oldWorld|p2', regionId: 'oldWorld', ownerId: 'm2'),
+            ],
+          ),
+        ),
+      );
+      expect(provinceCountOwnedBy(g1, 'm1'), 1);
+      expect(provinceCountOwnedBy(g1, 'm2'), 1);
+      expect(provinceCountOwnedBy(g1, 'ghost'), 0);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Implements **issue #2268 AC-5**: `provinceCountOwnedBy` no longer rescans `allProvinces()` on every call. A full ownership histogram is built **once per immutable `Game` instance** (lazy `Expando`, same lifecycle semantics as AC-4 relation maps). Lookups are O(1) per faction after the first call on that snapshot.

## Spec

No SPEC changes (behavior-neutral optimization per issue).

## Tests

- Extended `packages/colonizethis_logic/test/diplomacy_relation_updates_test.dart`: histogram vs linear-scan equivalence on a two-region fixture; `copyWith` / new `Game` gets fresh counts.
- Ran `dart test` for the full `colonizethis_logic` package (all tests green).

## AC coverage (this PR)

| AC | Status |
|----|--------|
| AC-1–AC-4 | Merged on `dev` (prior PRs) |
| **AC-5** | **This PR** |
| AC-6–AC-11 | Deferred |

## Deferred (follow-up PRs)

- **AC-6:** Precomputed `Set<String>` for `isMinorOrTribe` / `isGreatPower` in diplomacy hot loops.
- **AC-7–AC-8:** `connectivity_resolver` worklist / port map cache.
- **AC-9–AC-11:** Performance CI gates (AST `queue.removeAt(0)`, characterization tests) per issue.

Refs #2268

Made with [Cursor](https://cursor.com)