### PR TITLE
perf(logic): O(1) diplomacy faction membership for hot paths (Refs #2268)

### DIFF
--- a/packages/colonizethis_logic/lib/src/diplomacy/alliance_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/alliance_resolver.dart
@@ -16,7 +16,14 @@ Game resolveJoinEmpireColony(
   for (final entry in diploByPlayer.entries) {
     final gpId = entry.key;
     for (final order in entry.value) {
-      game = _resolveJoinEmpireOrderIfApplicable(game, gpId, order, turn);
+      final factionMembership = DiplomacyFactionMembership.from(game);
+      game = _resolveJoinEmpireOrderIfApplicable(
+        game,
+        gpId,
+        order,
+        turn,
+        factionMembership,
+      );
     }
   }
   return game;
@@ -27,6 +34,7 @@ Game _resolveJoinEmpireOrderIfApplicable(
   String gpId,
   DiplomaticOrder order,
   int turn,
+  DiplomacyFactionMembership factionMembership,
 ) {
   if (order.type != DiplomaticOrderType.establishOverture) return game;
   if (order.overtureStage != OvertureStage.joinEmpire) return game;
@@ -42,11 +50,18 @@ Game _resolveJoinEmpireOrderIfApplicable(
   final score = rel?.score ?? relationScoreNeutral;
   if (score < relationScoreMinFriendly) return game;
 
-  if (isMinorOrTribe(game, targetId)) {
+  if (factionMembership.isMinorOrTribe(targetId)) {
     return _resolveJoinEmpireMinorOrTribe(game, gpId, targetId, player, turn);
   }
-  if (isGreatPower(game, targetId)) {
-    return _resolveJoinEmpireGreatPower(game, gpId, targetId, player, turn);
+  if (factionMembership.isGreatPower(targetId)) {
+    return _resolveJoinEmpireGreatPower(
+      game,
+      gpId,
+      targetId,
+      player,
+      turn,
+      factionMembership,
+    );
   }
   return game;
 }
@@ -83,9 +98,16 @@ Game _resolveJoinEmpireGreatPower(
   String targetId,
   Player player,
   int turn,
+  DiplomacyFactionMembership factionMembership,
 ) {
   if (player.techUnlocked?[kTechIdEmpireBuilding] != true) return game;
-  if (!isGreatPowerNearlyDefeatedForJoinEmpire(game, targetId)) return game;
+  if (!isGreatPowerNearlyDefeatedForJoinEmpire(
+        game,
+        targetId,
+        factionMembership: factionMembership,
+      )) {
+    return game;
+  }
 
   final cost = joinEmpireCostForMinorOrTribe(game, targetId);
   if (player.treasury < cost) return game;
@@ -127,15 +149,16 @@ Game absorbGreatPowerIntoGp(Game game, String gpId, String targetGpId) =>
 Game processAlliances(
   Game game,
   Map<String, List<DiplomaticOrder>> diploByPlayer,
-  int turn,
-) {
+  int turn, {
+  required DiplomacyFactionMembership factionMembership,
+}) {
   for (final entry in diploByPlayer.entries) {
     final gpId = entry.key;
     for (final order in entry.value) {
       if (order.type != DiplomaticOrderType.alliance) continue;
 
       final targetId = order.targetFactionId;
-      if (!isGreatPower(game, targetId)) continue;
+      if (!factionMembership.isGreatPower(targetId)) continue;
 
       final ids = canonicalPairIds(gpId, targetId);
       final relations = upsertRelation(

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -33,6 +33,35 @@ export 'intervention_resolver.dart'
 
 final diploLog = packageLogger();
 
+/// O(1) faction classification snapshot for diplomacy hot paths (Refs #2268 AC-6).
+/// Rebuild when [Game.players], [Game.minorNations], or [Game.tribes] membership
+/// changes in the same phase (for example Join Empire absorption).
+final class DiplomacyFactionMembership {
+  DiplomacyFactionMembership._(this.greatPowerIds, this.minorOrTribeIds);
+
+  factory DiplomacyFactionMembership.from(Game game) {
+    final gp = <String>{};
+    for (final p in game.players) {
+      gp.add(p.id);
+    }
+    final minorTribe = <String>{};
+    for (final m in game.minorNations) {
+      minorTribe.add(m.id);
+    }
+    for (final t in game.tribes) {
+      minorTribe.add(t.id);
+    }
+    return DiplomacyFactionMembership._(gp, minorTribe);
+  }
+
+  final Set<String> greatPowerIds;
+  final Set<String> minorOrTribeIds;
+
+  bool isGreatPower(String factionId) => greatPowerIds.contains(factionId);
+
+  bool isMinorOrTribe(String factionId) => minorOrTribeIds.contains(factionId);
+}
+
 bool isMinorOrTribe(Game game, String factionId) {
   return game.minorNations.any((m) => m.id == factionId) ||
       game.tribes.any((t) => t.id == factionId);
@@ -43,8 +72,14 @@ bool isGreatPower(Game game, String factionId) {
 }
 
 /// Target GP is "nearly defeated" for Join Empire: ≤3 provinces and does not hold its original capital tile province. SPEC/game/diplomacy.md.
-bool isGreatPowerNearlyDefeatedForJoinEmpire(Game game, String gpId) {
-  if (!isGreatPower(game, gpId)) return false;
+bool isGreatPowerNearlyDefeatedForJoinEmpire(
+  Game game,
+  String gpId, {
+  DiplomacyFactionMembership? factionMembership,
+}) {
+  final isGp =
+      factionMembership?.isGreatPower(gpId) ?? isGreatPower(game, gpId);
+  if (!isGp) return false;
   final player = game.playerById(gpId);
   final capId = player?.capitalProvinceId;
   if (capId == null) return false;
@@ -77,12 +112,14 @@ DiplomacyPhaseResult resolveDiplomacyPhase(
   var state = game;
 
   final diploByPlayer = orders.diplomaticOrdersByPlayerId;
+  var factionMembership = DiplomacyFactionMembership.from(game);
 
   // 1. Process overture offers (two-way: target accepts/rejects)
   final overtureResult = processOverturePayments(
     state,
     diploByPlayer,
     turn,
+    factionMembership: factionMembership,
     overtureDecisions: overtureDecisions,
   );
   state = overtureResult.game;
@@ -100,15 +137,22 @@ DiplomacyPhaseResult resolveDiplomacyPhase(
 
   // 3. Resolve Join Empire/Colony
   state = resolveJoinEmpireColony(state, diploByPlayer, turn);
+  factionMembership = DiplomacyFactionMembership.from(state);
 
   // 4. Process alliance proposals and responses
-  state = processAlliances(state, diploByPlayer, turn);
+  state = processAlliances(
+    state,
+    diploByPlayer,
+    turn,
+    factionMembership: factionMembership,
+  );
 
   // 5. Process Declare War and Peace
   state = processWarAndPeace(
     state,
     diploByPlayer,
     turn,
+    factionMembership: factionMembership,
     onDialogue: onDialogue,
   );
 
@@ -117,6 +161,7 @@ DiplomacyPhaseResult resolveDiplomacyPhase(
     state,
     diploByPlayer,
     turn,
+    factionMembership: factionMembership,
     interventionDecisions: interventionDecisions,
   );
   if (interventionResult.pendingInterventions != null &&
@@ -133,6 +178,7 @@ DiplomacyPhaseResult resolveDiplomacyPhase(
     state,
     diploByPlayer,
     turn,
+    factionMembership: factionMembership,
     callToArmsDecisions: callToArmsDecisions,
   );
   state = ctaResult.game;
@@ -150,7 +196,11 @@ DiplomacyPhaseResult resolveDiplomacyPhase(
 
   // 7. Process ongoing subsidies (+2 per 500 ducats, max +8 per turn)
   // Note: Convergence happens AFTER subsidies
-  state = processOngoingSubsidies(state, turn);
+  state = processOngoingSubsidies(
+    state,
+    turn,
+    factionMembership: factionMembership,
+  );
 
   // 8. Apply relation convergence (+/1 toward 50 for all non-war relations)
   state = applyRelationConvergence(state, turn);

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_subsidies_relations_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_subsidies_relations_resolver.dart
@@ -194,7 +194,11 @@ Game applyRelationModifiersAndUpdateScores(
 /// Process ongoing subsidies each turn.
 /// Deducts amount from payer treasury and improves relation by +2 per 500 ducats (max +8).
 /// Per SPEC/game/diplomacy.md.
-Game processOngoingSubsidies(Game game, int turn) {
+Game processOngoingSubsidies(
+  Game game,
+  int turn, {
+  required DiplomacyFactionMembership factionMembership,
+}) {
   var players = game.players;
   var relations = List<DiplomacyRelation>.from(game.diplomacyRelations);
   var subsidyStates = List<SubsidyState>.from(game.subsidyStates);
@@ -263,7 +267,7 @@ Game processOngoingSubsidies(Game game, int turn) {
             .clamp(0, subsidyBoostMax);
 
     // Apply relation boost (only for Minors/Tribes - GPs get treasury transfer)
-    if (isMinorOrTribe(game, targetId)) {
+    if (factionMembership.isMinorOrTribe(targetId)) {
       relations = applySubsidyBoost(
         relations: relations,
         payerId: payerId,

--- a/packages/colonizethis_logic/lib/src/diplomacy/intervention_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/intervention_resolver.dart
@@ -61,9 +61,12 @@ bool _interventionsOutstanding(
   int turn,
   String aggressorGpId,
   String defenderMinorOrTribeId,
+  DiplomacyFactionMembership factionMembership,
 ) {
   for (final p in game.players) {
-    if (!isGreatPower(game, p.id) || p.id == aggressorGpId) continue;
+    if (!factionMembership.isGreatPower(p.id) || p.id == aggressorGpId) {
+      continue;
+    }
     if (!_gpHasEmbassyOrPurchasedLandInMinorTribe(
       game,
       p.id,
@@ -162,11 +165,14 @@ InterventionResolutionResult _processInterventionsForAggressorDefender(
   required String aggressorGpId,
   required String defenderMinorOrTribeId,
   required int turn,
+  required DiplomacyFactionMembership factionMembership,
   List<InterventionDecision>? interventionDecisions,
 }) {
   final eligible = <String>[];
   for (final p in game.players) {
-    if (!isGreatPower(game, p.id) || p.id == aggressorGpId) continue;
+    if (!factionMembership.isGreatPower(p.id) || p.id == aggressorGpId) {
+      continue;
+    }
     if (!_gpHasEmbassyOrPurchasedLandInMinorTribe(
       game,
       p.id,
@@ -213,6 +219,7 @@ InterventionResolutionResult _processInterventionsForAggressorDefender(
         defenderMinorOrTribeId: defenderMinorOrTribeId,
         interveningGpId: interveningId,
         choice: d.choice,
+        factionMembership: factionMembership,
       );
       continue;
     }
@@ -229,6 +236,7 @@ InterventionResolutionResult _processInterventionsForAggressorDefender(
       defenderMinorOrTribeId: defenderMinorOrTribeId,
       interveningGpId: interveningId,
       choice: aiChoice,
+      factionMembership: factionMembership,
     );
   }
   if (pending.isNotEmpty) {
@@ -241,6 +249,7 @@ InterventionResolutionResult resolveOutstandingInterventionsForMinorTribeWars(
   Game game,
   Map<String, List<DiplomaticOrder>> diploByPlayer,
   int turn, {
+  required DiplomacyFactionMembership factionMembership,
   List<InterventionDecision>? interventionDecisions,
 }) {
   final seen = <String>{};
@@ -250,18 +259,30 @@ InterventionResolutionResult resolveOutstandingInterventionsForMinorTribeWars(
     for (final order in entry.value) {
       if (order.type != DiplomaticOrderType.declareWar) continue;
       final targetId = order.targetFactionId;
-      if (!isGreatPower(g, gpId) || !isMinorOrTribe(g, targetId)) continue;
+      if (!factionMembership.isGreatPower(gpId) ||
+          !factionMembership.isMinorOrTribe(targetId)) {
+        continue;
+      }
       final rel = getRelation(g, gpId, targetId);
       if (rel == null || !rel.atWar) continue;
       final key = '$gpId|$targetId';
       if (seen.contains(key)) continue;
       seen.add(key);
-      if (!_interventionsOutstanding(g, turn, gpId, targetId)) continue;
+      if (!_interventionsOutstanding(
+            g,
+            turn,
+            gpId,
+            targetId,
+            factionMembership,
+          )) {
+        continue;
+      }
       final pass = _processInterventionsForAggressorDefender(
         g,
         aggressorGpId: gpId,
         defenderMinorOrTribeId: targetId,
         turn: turn,
+        factionMembership: factionMembership,
         interventionDecisions: interventionDecisions,
       );
       g = pass.game;
@@ -278,16 +299,17 @@ InterventionResolutionResult resolveOutstandingInterventionsForMinorTribeWars(
 List<({String aggressor, String defender})> _gpGpWarPairsFromOrders(
   Game game,
   Map<String, List<DiplomaticOrder>> diploByPlayer,
+  DiplomacyFactionMembership factionMembership,
 ) {
   final seen = <String>{};
   final out = <({String aggressor, String defender})>[];
   for (final e in diploByPlayer.entries) {
     final aggressor = e.key;
-    if (!isGreatPower(game, aggressor)) continue;
+    if (!factionMembership.isGreatPower(aggressor)) continue;
     for (final o in e.value) {
       if (o.type != DiplomaticOrderType.declareWar) continue;
       final defender = o.targetFactionId;
-      if (!isGreatPower(game, defender)) continue;
+      if (!factionMembership.isGreatPower(defender)) continue;
       if (!factionsAtWar(game, aggressor, defender)) continue;
       final key = '$aggressor|$defender';
       if (seen.add(key)) {
@@ -483,10 +505,15 @@ CallToArmsResult processCallToArms(
   Game game,
   Map<String, List<DiplomaticOrder>> diploByPlayer,
   int turn, {
+  required DiplomacyFactionMembership factionMembership,
   List<CallToArmsDecision>? callToArmsDecisions,
 }) {
   var state = game;
-  final warPairs = _gpGpWarPairsFromOrders(state, diploByPlayer);
+  final warPairs = _gpGpWarPairsFromOrders(
+    state,
+    diploByPlayer,
+    factionMembership,
+  );
   final pending = <CallToArmsPending>[];
 
   for (final pair in warPairs) {
@@ -541,9 +568,12 @@ Game applyInterventionAgainstAggressor(
   required String defenderMinorOrTribeId,
   required String interveningGpId,
   required InterventionChoice choice,
+  DiplomacyFactionMembership? factionMembership,
 }) {
   final turn = game.worldState.turnState.turnNumber;
-  if (!isGreatPower(game, aggressorGpId)) return game;
+  final aggressorIsGp = factionMembership?.isGreatPower(aggressorGpId) ??
+      isGreatPower(game, aggressorGpId);
+  if (!aggressorIsGp) return game;
 
   if (choice == InterventionChoice.doNothing) {
     var g = _clearOverturesBetweenGpAndMinorTribe(

--- a/packages/colonizethis_logic/lib/src/diplomacy/overture_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/overture_resolver.dart
@@ -143,6 +143,7 @@ _processEstablishOvertureOrderIfApplicable({
   required String gpId,
   required DiplomaticOrder order,
   required int turn,
+  required DiplomacyFactionMembership factionMembership,
   List<OvertureDecision>? overtureDecisions,
 }) {
   if (order.type != DiplomaticOrderType.establishOverture) {
@@ -166,8 +167,8 @@ _processEstablishOvertureOrderIfApplicable({
   }
 
   final targetId = order.targetFactionId;
-  final targetIsMinorOrTribe = isMinorOrTribe(state, targetId);
-  final targetIsGp = isGreatPower(state, targetId);
+  final targetIsMinorOrTribe = factionMembership.isMinorOrTribe(targetId);
+  final targetIsGp = factionMembership.isGreatPower(targetId);
   if (!targetIsMinorOrTribe && !targetIsGp) {
     return (
       players: players,
@@ -340,6 +341,7 @@ OverturePaymentsResult processOverturePayments(
   Game game,
   Map<String, List<DiplomaticOrder>> diploByPlayer,
   int turn, {
+  required DiplomacyFactionMembership factionMembership,
   List<OvertureDecision>? overtureDecisions,
 }) {
   var players = List<Player>.from(game.players);
@@ -362,6 +364,7 @@ OverturePaymentsResult processOverturePayments(
         gpId: gpId,
         order: order,
         turn: turn,
+        factionMembership: factionMembership,
         overtureDecisions: overtureDecisions,
       );
       if (step.earlyExit != null) return step.earlyExit!;

--- a/packages/colonizethis_logic/lib/src/diplomacy/war_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/war_resolver.dart
@@ -10,17 +10,20 @@ Game processWarAndPeace(
   Game game,
   Map<String, List<DiplomaticOrder>> diploByPlayer,
   int turn, {
+  required DiplomacyFactionMembership factionMembership,
   void Function(DialogueEvent)? onDialogue,
 }) {
   final peaceOffersByPairKey = _peaceOfferPairKeysForGreatPowers(
     game,
     diploByPlayer,
+    factionMembership,
   );
   return _runWarAndPeaceOrders(
     game,
     diploByPlayer,
     turn,
     peaceOffersByPairKey,
+    factionMembership,
     onDialogue,
   );
 }
@@ -30,6 +33,7 @@ Game _runWarAndPeaceOrders(
   Map<String, List<DiplomaticOrder>> diploByPlayer,
   int turn,
   Map<String, Set<String>> peaceOffersByPairKey,
+  DiplomacyFactionMembership factionMembership,
   void Function(DialogueEvent)? onDialogue,
 ) {
   var relations = List<DiplomacyRelation>.from(game.diplomacyRelations);
@@ -43,6 +47,7 @@ Game _runWarAndPeaceOrders(
         order: order,
         turn: turn,
         peaceOffersByPairKey: peaceOffersByPairKey,
+        factionMembership: factionMembership,
         onDialogue: onDialogue,
       );
       game = updated.game;
@@ -56,6 +61,7 @@ Game _runWarAndPeaceOrders(
 Map<String, Set<String>> _peaceOfferPairKeysForGreatPowers(
   Game game,
   Map<String, List<DiplomaticOrder>> diploByPlayer,
+  DiplomacyFactionMembership factionMembership,
 ) {
   final peaceOffersByPairKey = <String, Set<String>>{};
   for (final entry in diploByPlayer.entries) {
@@ -63,7 +69,10 @@ Map<String, Set<String>> _peaceOfferPairKeysForGreatPowers(
     for (final order in entry.value) {
       if (order.type != DiplomaticOrderType.offerPeace) continue;
       final targetId = order.targetFactionId;
-      if (!isGreatPower(game, gpId) || !isGreatPower(game, targetId)) continue;
+      if (!factionMembership.isGreatPower(gpId) ||
+          !factionMembership.isGreatPower(targetId)) {
+        continue;
+      }
       final key = pairKey(gpId, targetId);
       peaceOffersByPairKey.putIfAbsent(key, () => <String>{}).add(gpId);
     }
@@ -78,6 +87,7 @@ Map<String, Set<String>> _peaceOfferPairKeysForGreatPowers(
   required DiplomaticOrder order,
   required int turn,
   required Map<String, Set<String>> peaceOffersByPairKey,
+  required DiplomacyFactionMembership factionMembership,
   void Function(DialogueEvent)? onDialogue,
 }) {
   if (order.type == DiplomaticOrderType.declareWar) {
@@ -98,6 +108,7 @@ Map<String, Set<String>> _peaceOfferPairKeysForGreatPowers(
       order: order,
       turn: turn,
       peaceOffersByPairKey: peaceOffersByPairKey,
+      factionMembership: factionMembership,
       onDialogue: onDialogue,
     );
   }
@@ -161,20 +172,23 @@ Map<String, Set<String>> _peaceOfferPairKeysForGreatPowers(
   required DiplomaticOrder order,
   required int turn,
   required Map<String, Set<String>> peaceOffersByPairKey,
+  required DiplomacyFactionMembership factionMembership,
   void Function(DialogueEvent)? onDialogue,
 }) {
   final targetId = order.targetFactionId;
   final rel = getRelation(game, gpId, targetId);
   final key = pairKey(gpId, targetId);
   final bothGreatPowers =
-      isGreatPower(game, gpId) && isGreatPower(game, targetId);
+      factionMembership.isGreatPower(gpId) &&
+      factionMembership.isGreatPower(targetId);
   final hasMutualOffer =
       bothGreatPowers ? (peaceOffersByPairKey[key]?.length ?? 0) >= 2 : true;
   if (rel == null || !rel.atWar) {
     return (game: game, relations: relations);
   }
   var bothSidesAgreed = true;
-  if (isGreatPower(game, targetId) && isGreatPower(game, gpId)) {
+  if (factionMembership.isGreatPower(targetId) &&
+      factionMembership.isGreatPower(gpId)) {
     final offerers = peaceOffersByPairKey[key] ?? const <String>{};
     bothSidesAgreed =
         offerers.contains(gpId) && offerers.contains(targetId);

--- a/packages/colonizethis_logic/test/diplomacy_faction_membership_test.dart
+++ b/packages/colonizethis_logic/test/diplomacy_faction_membership_test.dart
@@ -1,6 +1,6 @@
+import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:test/test.dart';
 
 void main() {
   test(

--- a/packages/colonizethis_logic/test/diplomacy_faction_membership_test.dart
+++ b/packages/colonizethis_logic/test/diplomacy_faction_membership_test.dart
@@ -1,0 +1,59 @@
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'DiplomacyFactionMembership matches linear-scan isMinorOrTribe / '
+    'isGreatPower for 6 GP + 10 minor/tribe (Refs #2268 AC-6)',
+    () {
+      final players = List.generate(
+        6,
+        (i) => Player(
+          id: 'gp$i',
+          displayName: 'GP $i',
+          isHuman: false,
+          treasury: 1000,
+        ),
+      );
+      final minors = List.generate(
+        5,
+        (i) => MinorNation(id: 'minor$i', displayName: 'Minor $i'),
+      );
+      final tribes = List.generate(
+        5,
+        (i) => Tribe(id: 'tribe$i', displayName: 'Tribe $i'),
+      );
+      final game = Game(
+        id: 'g-membership',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: players,
+        minorNations: minors,
+        tribes: tribes,
+      );
+      final membership = DiplomacyFactionMembership.from(game);
+      final allIds = <String>[
+        ...players.map((p) => p.id),
+        ...minors.map((m) => m.id),
+        ...tribes.map((t) => t.id),
+        'not_a_faction',
+      ];
+      for (final id in allIds) {
+        expect(
+          membership.isMinorOrTribe(id),
+          isMinorOrTribe(game, id),
+          reason: 'isMinorOrTribe($id)',
+        );
+        expect(
+          membership.isGreatPower(id),
+          isGreatPower(game, id),
+          reason: 'isGreatPower($id)',
+        );
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Implements **issue #2268 AC-6**: precomputed `Set`-backed `DiplomacyFactionMembership` replaces per-call linear scans for `isMinorOrTribe` / `isGreatPower` inside the diplomacy phase orchestration and its hot-path callees.

## Spec

No SPEC changes (behavior-neutral optimization per issue).

## Tests

- New `packages/colonizethis_logic/test/diplomacy_faction_membership_test.dart`: membership vs linear-scan equivalence for every faction id in a 6 GP + 5 minor + 5 tribe fixture, plus a non-faction id.
- Ran `dart test` for the full `colonizethis_logic` package (all tests green).

## AC coverage (this PR)

| AC | Status |
|----|--------|
| AC-1–AC-5 | Merged on `dev` (prior PRs) |
| **AC-6** | **This PR** |
| AC-7–AC-11 | Deferred |

## Deferred (follow-up PRs)

- **AC-7–AC-8:** `connectivity_resolver` worklist / port map cache.
- **AC-9–AC-11:** Performance CI gates (AST `queue.removeAt(0)`, characterization tests) per issue.

Refs #2268

Made with [Cursor](https://cursor.com)