### PR TITLE
perf(logic): town-rule worklist + port map reuse in connectivity (Refs #2268)

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -7,7 +7,6 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import '../utils/graph_traversal.dart';
 import '../diplomacy/diplomacy_relation_lookup.dart';
 import 'connectivity_blockade_target.dart';
-import 'naval.dart';
 import 'port_seaboard_registry_key.dart';
 import 'province_lookup.dart';
 import 'tile_key_coordinates.dart';
@@ -208,9 +207,12 @@ Map<String, (String, String)> _portToProvinceSeaZone(WorldState worldState) {
   return out;
 }
 
-int _transportLevelAtTile(WorldState worldState, String tileKey) {
-  final portInfo = _portToProvinceSeaZone(worldState);
-  if (portInfo.containsKey(tileKey)) return 4;
+int _transportLevelAtTile(
+  WorldState worldState,
+  String tileKey,
+  Map<String, (String, String)> portTileToProvinceSeaZone,
+) {
+  if (portTileToProvinceSeaZone.containsKey(tileKey)) return 4;
   final r = worldState.tileState.roadLevel(tileKey);
   return r > 0 ? r : 0;
 }
@@ -277,12 +279,17 @@ ConnectivityResult _connectedTilesForPlayer({
   final portInfo = _portToProvinceSeaZone(worldState);
   final connected = <String>{capitalKey};
   final pathCap = <String, int>{};
-  pathCap[capitalKey] = _transportLevelAtTile(worldState, capitalKey);
+  pathCap[capitalKey] = _transportLevelAtTile(
+    worldState,
+    capitalKey,
+    portInfo,
+  );
   _runConnectivityPropagation(
     queue: Queue<String>()..add(capitalKey),
     connected: connected,
     pathCap: pathCap,
     worldState: worldState,
+    portTileToProvinceSeaZone: portInfo,
     tileMapByRegion: tileMapByRegion,
     provinceIdsByType: provinceIdsByType,
     ownedProvinceIds: owned,
@@ -331,6 +338,7 @@ ConnectivityResult _connectedTilesForPlayer({
     connected: connected,
     pathCap: pathCap,
     worldState: worldState,
+    portTileToProvinceSeaZone: portInfo,
     tileMapByRegion: tileMapByRegion,
     provinceIdsByType: provinceIdsByType,
     ownedProvinceIds: owned,
@@ -356,6 +364,7 @@ ConnectivityResult _connectedTilesForPlayer({
     tileMapByRegion: tileMapByRegion,
     provinceIdsByType: provinceIdsByType,
     worldState: worldState,
+    portTileToProvinceSeaZone: portInfo,
     connected: connected,
     pathCap: pathCap,
   );
@@ -372,6 +381,7 @@ void _runConnectivityPropagation({
   required Set<String> connected,
   required Map<String, int> pathCap,
   required WorldState worldState,
+  required Map<String, (String, String)> portTileToProvinceSeaZone,
   required Map<String, TileMapResult> tileMapByRegion,
   required Set<String> provinceIdsByType,
   required Set<String> ownedProvinceIds,
@@ -406,7 +416,8 @@ void _runConnectivityPropagation({
         provinceIdsByType,
       );
     },
-    transportLevelAt: (neighbor) => _transportLevelAtTile(worldState, neighbor),
+    transportLevelAt: (neighbor) =>
+        _transportLevelAtTile(worldState, neighbor, portTileToProvinceSeaZone),
   );
 }
 
@@ -483,39 +494,74 @@ void _applyTownRuleConnectivityClosure({
   required Map<String, TileMapResult> tileMapByRegion,
   required Set<String> provinceIdsByType,
   required WorldState worldState,
+  required Map<String, (String, String)> portTileToProvinceSeaZone,
   required Set<String> connected,
   required Map<String, int> pathCap,
 }) {
-  var changed = true;
-  while (changed) {
-    changed = false;
-    for (final province in allProvinces(game.worldState)) {
-      if (province.ownerId != playerId) continue;
-      final tk = province.townTileKey;
-      if (tk == null || !connected.contains(tk)) continue;
-      final coords = parseTileKeyCoordinates(tk);
-      if (coords == null) continue;
-      if (coords.x < 0 || coords.y < 0) continue;
-      final map = tileMapByRegion[coords.regionId];
-      if (map == null) continue;
-      for (final d in [(0, -1), (1, 0), (0, 1), (-1, 0)]) {
-        final nx = coords.x + d.$1;
-        final ny = coords.y + d.$2;
-        if (nx < 0 || nx >= map.width || ny < 0 || ny >= map.height) continue;
-        final cell = map.cell(nx, ny);
-        if (!_isLandProvinceGridCell(
-          cell,
-          coords.regionId,
-          provinceIdsByType,
-        )) {
-          continue;
-        }
-        if (cell != coords.provinceLocalId) continue;
-        final nKey = CapitalTile.tileKey(coords.regionId, province.id, nx, ny);
-        if (connected.contains(nKey)) continue;
-        connected.add(nKey);
-        pathCap[nKey] = pathCap[tk] ?? _transportLevelAtTile(worldState, tk);
-        changed = true;
+  final townByTileKey = <String, Province>{};
+  for (final province in allProvinces(game.worldState)) {
+    if (province.ownerId != playerId) continue;
+    final tk = province.townTileKey;
+    if (tk == null) continue;
+    townByTileKey[tk] = province;
+  }
+
+  final pendingTowns = Queue<String>();
+  final queuedTowns = <String>{};
+  final expandedTowns = <String>{};
+
+  void enqueueTownForExpansion(String tk) {
+    if (!connected.contains(tk)) return;
+    assert(
+      !expandedTowns.contains(tk),
+      'town-rule worklist must not re-enqueue an already-expanded town tile: $tk',
+    );
+    if (!queuedTowns.add(tk)) return;
+    pendingTowns.add(tk);
+  }
+
+  for (final province in allProvinces(game.worldState)) {
+    if (province.ownerId != playerId) continue;
+    final tk = province.townTileKey;
+    if (tk == null) continue;
+    enqueueTownForExpansion(tk);
+  }
+
+  while (pendingTowns.isNotEmpty) {
+    final tk = pendingTowns.removeFirst();
+    queuedTowns.remove(tk);
+    expandedTowns.add(tk);
+
+    final province = townByTileKey[tk];
+    if (province == null) continue;
+
+    final coords = parseTileKeyCoordinates(tk);
+    if (coords == null) continue;
+    if (coords.x < 0 || coords.y < 0) continue;
+    final map = tileMapByRegion[coords.regionId];
+    if (map == null) continue;
+
+    for (final d in [(0, -1), (1, 0), (0, 1), (-1, 0)]) {
+      final nx = coords.x + d.$1;
+      final ny = coords.y + d.$2;
+      if (nx < 0 || nx >= map.width || ny < 0 || ny >= map.height) continue;
+      final cell = map.cell(nx, ny);
+      if (!_isLandProvinceGridCell(
+        cell,
+        coords.regionId,
+        provinceIdsByType,
+      )) {
+        continue;
+      }
+      if (cell != coords.provinceLocalId) continue;
+      final nKey = CapitalTile.tileKey(coords.regionId, province.id, nx, ny);
+      if (connected.contains(nKey)) continue;
+      connected.add(nKey);
+      pathCap[nKey] =
+          pathCap[tk] ??
+          _transportLevelAtTile(worldState, tk, portTileToProvinceSeaZone);
+      if (townByTileKey.containsKey(nKey)) {
+        enqueueTownForExpansion(nKey);
       }
     }
   }

--- a/packages/colonizethis_logic/test/connectivity_resolver_town_closure_worklist_test.dart
+++ b/packages/colonizethis_logic/test/connectivity_resolver_town_closure_worklist_test.dart
@@ -1,0 +1,127 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+
+void main() {
+  group('ConnectivityResolver town-rule worklist', () {
+    test(
+      'multi-province owner with several towns completes (no redundant town enqueue)',
+      () {
+        const ow = 'oldWorld';
+        final grid = [
+          ['p1', 'p2', 'p3'],
+          ['p1', 'p2', 'p3'],
+        ];
+        final tileMap = TileMapResult(width: 3, height: 2, grid: grid);
+        final topology = MapTopology(
+          nodes: [
+            TopologyNode(id: 'p1', regionId: ow, type: TopologyNodeType.province),
+            TopologyNode(id: 'p2', regionId: ow, type: TopologyNodeType.province),
+            TopologyNode(id: 'p3', regionId: ow, type: TopologyNodeType.province),
+          ],
+          edges: [],
+        );
+        final cap = CapitalTile(regionId: ow, provinceId: '$ow|p1', x: 0, y: 0);
+        final tileState = TileMapState()
+            .setRoadLevel('oldWorld|p1|0|0', 1)
+            .setRoadLevel('oldWorld|p1|1|0', 1)
+            .setRoadLevel('oldWorld|p1|2|0', 1)
+            .setRoadLevel('oldWorld|p2|1|0', 1)
+            .setRoadLevel('oldWorld|p2|2|0', 1)
+            .setRoadLevel('oldWorld|p3|2|0', 1);
+        final player = Player(
+          id: 'pl1',
+          displayName: 'Spain',
+          isHuman: true,
+          capitalProvinceId: '$ow|p1',
+          capitalTile: cap,
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+            oldWorld: RegionData(provinces: [
+              Province(
+                id: '$ow|p1',
+                regionId: ow,
+                ownerId: 'pl1',
+                townTileKey: 'oldWorld|p1|0|0',
+              ),
+              Province(
+                id: '$ow|p2',
+                regionId: ow,
+                ownerId: 'pl1',
+                townTileKey: 'oldWorld|p2|1|0',
+              ),
+              Province(
+                id: '$ow|p3',
+                regionId: ow,
+                ownerId: 'pl1',
+                townTileKey: 'oldWorld|p3|2|0',
+              ),
+            ]),
+            newWorld: const RegionData(),
+            tileState: tileState,
+          ),
+          players: [player],
+        );
+        final result = resolveConnectivity(
+          game: game,
+          tileMapByRegion: {ow: tileMap},
+          topology: topology,
+        );
+        final connected = result['pl1']!.connected;
+        expect(connected.contains('oldWorld|p1|0|0'), isTrue);
+        expect(connected.contains('oldWorld|p3|2|0'), isTrue);
+        expect(connected.length, greaterThanOrEqualTo(6));
+      },
+    );
+
+    test('many port registry entries reuse single port map per player resolve', () {
+      const ow = 'oldWorld';
+      final grid = [
+        ['p1', 'p1'],
+        ['p1', 'p1'],
+      ];
+      final tileMap = TileMapResult(width: 2, height: 2, grid: grid);
+      final topology = MapTopology(
+        nodes: [TopologyNode(id: 'p1', regionId: ow, type: TopologyNodeType.province)],
+        edges: [],
+      );
+      final cap = CapitalTile(regionId: ow, provinceId: '$ow|p1', x: 0, y: 0);
+      final ports = <String, String>{
+        for (var i = 0; i < 40; i++) '$ow|p1|sea$i': 'oldWorld|p1|1|0',
+      };
+      final tileState = TileMapState()
+          .setRoadLevel('oldWorld|p1|0|0', 1)
+          .setRoadLevel('oldWorld|p1|1|0', 1);
+      final player = Player(
+        id: 'pl1',
+        displayName: 'Spain',
+        isHuman: true,
+        capitalProvinceId: '$ow|p1',
+        capitalTile: cap,
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: TurnState(turnNumber: 1, phase: TurnPhase.orders),
+          oldWorld: RegionData(provinces: [
+            Province(id: '$ow|p1', regionId: ow, ownerId: 'pl1'),
+          ]),
+          newWorld: const RegionData(),
+          tileState: tileState,
+          portsByProvinceSeaboard: ports,
+        ),
+        players: [player],
+      );
+      final result = resolveConnectivity(
+        game: game,
+        tileMapByRegion: {ow: tileMap},
+        topology: topology,
+      );
+      expect(result['pl1']!.connected.contains('oldWorld|p1|1|0'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Implements **AC-7** and **AC-8** from #2268 for `colonizethis_logic` connectivity resolution: worklist-based § Town-rule closure (no full `allProvinces` rescans per outer iteration) and reuse of a single `_portToProvinceSeaZone` map per player resolve for transport-level lookups during BFS and town closure.

## Implemented (this PR)
- **AC-7:** `_applyTownRuleConnectivityClosure` now schedules owned towns that are in the connected set on a `Queue`, expands 4-neighbors per town once, and enqueues a town when it first becomes connected via closure. Debug `assert` guards against re-enqueueing a town after it has already been expanded (matches AC wording; tests run with assertions enabled).
- **AC-8:** `_transportLevelAtTile` takes the precomputed `portTileToProvinceSeaZone` map built once in `_connectedTilesForPlayer`; `_runConnectivityPropagation` and town closure pass it through so `_portToProvinceSeaZone` is not rebuilt on every neighbor / town-cap lookup.
- **Tests:** `connectivity_resolver_town_closure_worklist_test.dart` — multi-province multi-town scenario; stress case with a large `portsByProvinceSeaboard` map (behavioral smoke for cached port lookups).
- Removed unused `naval.dart` import from `connectivity_resolver.dart` (analyzer).

## Deferred (not in this PR)
- **AC-10:** Performance characterization test (`turn_characterization_test.dart`) and quality-job wiring.
- **AC-11:** Full-package regression / coverage / `sim_scenarios` are CI-wide; not re-run as a complete gate in this slice beyond targeted `connectivity_resolver*` tests and new tests.

## SPEC
None (pure optimization; issue and GDD already treat this as semantics-preserving).

## Tests run
- `dart test test/connectivity_resolver_test.dart test/connectivity_resolver_sea_test.dart test/connectivity_resolver_blockade_test.dart test/connectivity_resolver_blockade_additional_test.dart test/connectivity_resolver_town_closure_worklist_test.dart` (from `packages/colonizethis_logic`)

Refs #2268


Made with [Cursor](https://cursor.com)