### PR TITLE
test(logic): AC-10 turn characterization for connectivity hot paths (Refs #2268)

### DIFF
--- a/packages/colonizethis_logic/lib/src/utils/graph_traversal.dart
+++ b/packages/colonizethis_logic/lib/src/utils/graph_traversal.dart
@@ -65,12 +65,14 @@ Map<T, int> landmassIdsFromProvinceAdjacency<T>(Map<T, Set<T>> neighbours) {
 Set<T> breadthFirstReachableInSubgraph<T>(
   Iterable<T> seeds,
   Map<T, Set<T>> adjacency,
-  Set<T> universe,
-) {
+  Set<T> universe, {
+  void Function()? onDequeue,
+}) {
   final reachable = <T>{...seeds};
   final queue = Queue<T>()..addAll(seeds);
   while (queue.isNotEmpty) {
     final z = queue.removeFirst();
+    onDequeue?.call();
     for (final n in adjacency[z] ?? <T>{}) {
       if (!universe.contains(n)) continue;
       if (reachable.contains(n)) continue;
@@ -94,9 +96,11 @@ void propagateConnectivityBottleneckQueue({
   required bool Function(String tileKey) shouldExpandEdgesFrom,
   required Iterable<String> Function(String tileKey) neighborsOf,
   required int Function(String neighborKey) transportLevelAt,
+  void Function()? onDequeue,
 }) {
   while (queue.isNotEmpty) {
     final key = queue.removeFirst();
+    onDequeue?.call();
     if (!shouldExpandEdgesFrom(key)) continue;
     final bottleneckU = pathCap[key] ?? 0;
     for (final neighbor in neighborsOf(key)) {

--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -14,6 +14,37 @@ import 'topology_helpers.dart';
 
 final _log = packageLogger();
 
+/// Counters for connectivity hot paths (Refs #2268 AC-10); used with
+/// [setConnectivityHotPathMetricsForTests] from tests only.
+class ConnectivityHotPathMetrics {
+  int townRuleWorklistDequeues = 0;
+  int connectivityBottleneckDequeues = 0;
+  int seaZoneBreadthFirstDequeues = 0;
+
+  /// Sum of tile bottleneck propagation dequeues and sea-zone plain BFS dequeues.
+  int get connectivityBfsTotalDequeues =>
+      connectivityBottleneckDequeues + seaZoneBreadthFirstDequeues;
+}
+
+ConnectivityHotPathMetrics? _connectivityHotPathMetricsForTests;
+
+/// When non-null, connectivity resolution increments [metrics] (test hook).
+void setConnectivityHotPathMetricsForTests(ConnectivityHotPathMetrics? metrics) {
+  _connectivityHotPathMetricsForTests = metrics;
+}
+
+void _recordTownRuleWorklistDequeue() {
+  _connectivityHotPathMetricsForTests?.townRuleWorklistDequeues++;
+}
+
+void _recordConnectivityBottleneckDequeue() {
+  _connectivityHotPathMetricsForTests?.connectivityBottleneckDequeues++;
+}
+
+void _recordSeaZoneBfsDequeue() {
+  _connectivityHotPathMetricsForTests?.seaZoneBreadthFirstDequeues++;
+}
+
 /// Result of connectivity resolution: connected tile set and per-tile path transport cap.
 /// SPEC/game/capital-and-connectivity, extraction-and-improvements: effective yield is
 /// capped by min transport level along path to town then to capital; [pathTransportCap]
@@ -144,6 +175,7 @@ Set<String> _seaZonesReachableBySeaPath(
     startSeaZoneIds,
     neighbours,
     seaZoneIds,
+    onDequeue: _recordSeaZoneBfsDequeue,
   );
 }
 
@@ -391,6 +423,7 @@ void _runConnectivityPropagation({
     queue: queue,
     connected: connected,
     pathCap: pathCap,
+    onDequeue: _recordConnectivityBottleneckDequeue,
     shouldExpandEdgesFrom: (key) {
       final coords = parseTileKeyCoordinates(key);
       if (coords == null) return false;
@@ -529,6 +562,7 @@ void _applyTownRuleConnectivityClosure({
 
   while (pendingTowns.isNotEmpty) {
     final tk = pendingTowns.removeFirst();
+    _recordTownRuleWorklistDequeue();
     queuedTowns.remove(tk);
     expandedTowns.add(tk);
 

--- a/packages/colonizethis_logic/test/performance/turn_characterization_test.dart
+++ b/packages/colonizethis_logic/test/performance/turn_characterization_test.dart
@@ -1,0 +1,176 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Large synthetic game for Refs #2268 AC-10 (connectivity hot-path bounds under load).
+Game _largeScaleGame() {
+  const ow = 'oldWorld';
+  const nw = 'newWorld';
+  const provinceCountPerRegion = 50;
+  const playerIds = ['p1', 'p2', 'p3', 'p4', 'p5', 'p6'];
+
+  List<Province> provincesForRegion(String regionId, String idPrefix) {
+    final out = <Province>[];
+    for (var i = 0; i < provinceCountPerRegion; i++) {
+      final local = '$idPrefix$i';
+      final full = '$regionId|$local';
+      final owner = playerIds[i % playerIds.length];
+      final cap = CapitalTile(
+        regionId: regionId,
+        provinceId: full,
+        x: i,
+        y: 0,
+      );
+      out.add(
+        Province(
+          id: full,
+          regionId: regionId,
+          ownerId: owner,
+          townTileKey: cap.toTileKey(),
+        ),
+      );
+    }
+    return out;
+  }
+
+  final oldProvinces = provincesForRegion(ow, 'P');
+  final newProvinces = provincesForRegion(nw, 'N');
+
+  var tileState = TileMapState();
+  for (var i = 0; i < provinceCountPerRegion; i++) {
+    tileState = tileState.setRoadLevel('$ow|P$i|${i}|0', 1);
+    tileState = tileState.setRoadLevel('$nw|N$i|${i}|0', 1);
+  }
+
+  final units = <Unit>[];
+  for (var u = 0; u < 220; u++) {
+    final i = u % provinceCountPerRegion;
+    final owner = playerIds[i % playerIds.length];
+    units.add(
+      Unit(
+        id: 'u$u',
+        type: 'musketeers',
+        ownerId: owner,
+        locationProvinceId: '$ow|P$i',
+      ),
+    );
+  }
+
+  final players = <Player>[];
+  for (var p = 0; p < playerIds.length; p++) {
+    final pid = playerIds[p];
+    final capIndex = p * 7 % provinceCountPerRegion;
+    final full = '$ow|P$capIndex';
+    final cap = CapitalTile(regionId: ow, provinceId: full, x: capIndex, y: 0);
+    players.add(
+      Player(
+        id: pid,
+        displayName: pid,
+        isHuman: true,
+        treasury: 1000,
+        militaryLevel: 2,
+        capitalProvinceId: full,
+        capitalTile: cap,
+      ),
+    );
+  }
+
+  return Game(
+    id: 'scale-g1',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+      oldWorld: RegionData(provinces: oldProvinces, units: units),
+      newWorld: RegionData(provinces: newProvinces, units: const []),
+      tileState: tileState,
+    ),
+    players: players,
+  );
+}
+
+MapTopology _stripTopology() {
+  const ow = 'oldWorld';
+  const nw = 'newWorld';
+  const n = 50;
+  final nodes = <TopologyNode>[
+    ...List.generate(
+      n,
+      (i) => TopologyNode(
+        id: 'P$i',
+        regionId: ow,
+        type: TopologyNodeType.province,
+      ),
+    ),
+    ...List.generate(
+      n,
+      (i) => TopologyNode(
+        id: 'N$i',
+        regionId: nw,
+        type: TopologyNodeType.province,
+      ),
+    ),
+  ];
+  return MapTopology(nodes: nodes, edges: const []);
+}
+
+void main() {
+  group('Turn characterization (Refs #2268 AC-10)', () {
+    tearDown(() {
+      setConnectivityHotPathMetricsForTests(null);
+    });
+
+    test(
+      'full turn on large synthetic game keeps connectivity hot-path work bounded',
+      () {
+        final game = _largeScaleGame();
+        final topology = _stripTopology();
+        const ow = 'oldWorld';
+        const nw = 'newWorld';
+        const w = 50;
+        final tileMapByRegion = {
+          ow: TileMapResult(width: w, height: 1, grid: [List.generate(w, (i) => 'P$i')]),
+          nw: TileMapResult(width: w, height: 1, grid: [List.generate(w, (i) => 'N$i')]),
+        };
+
+        final provinceCount = allProvinces(game.worldState).length;
+        expect(provinceCount, 100);
+
+        final unitCount =
+            game.worldState.oldWorld.units.length +
+            game.worldState.newWorld.units.length;
+        expect(unitCount, greaterThanOrEqualTo(200));
+        expect(game.players.length, greaterThanOrEqualTo(6));
+
+        final totalTiles = tileMapByRegion.values.fold<int>(
+          0,
+          (a, m) => a + m.width * m.height,
+        );
+        expect(totalTiles, 100);
+
+        final metrics = ConnectivityHotPathMetrics();
+        setConnectivityHotPathMetricsForTests(metrics);
+
+        final next = requireTurnResolutionComplete(
+          resolveTurnForGame(
+            game: game,
+            topology: topology,
+            orders: const Orders(),
+            tileMapByRegion: tileMapByRegion,
+          ),
+        );
+
+        expect(next.worldState.turnState.turnNumber, 1);
+
+        // (a) Town-rule worklist: each dequeue expands at most one town tile; bounded by provinces.
+        expect(
+          metrics.townRuleWorklistDequeues,
+          lessThanOrEqualTo(provinceCount),
+        );
+
+        // (b) AC-10: connectivity BFS total dequeues ≤ total tile cells (this fixture
+        // keeps per-player connected footprints small so the aggregate stays tight).
+        expect(metrics.connectivityBfsTotalDequeues, lessThanOrEqualTo(totalTiles));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Implements **AC-10** from issue #2268: a performance characterization test that runs a full `resolveTurnForGame` on a large synthetic game and asserts iteration/dequeue bounds using **iteration counts only** (no wall-clock).

## Implemented in this PR
- `ConnectivityHotPathMetrics` plus `setConnectivityHotPathMetricsForTests` (test hook) on the connectivity resolver path.
- Optional `onDequeue` callbacks on `breadthFirstReachableInSubgraph` and `propagateConnectivityBottleneckQueue` (default null; zero production overhead when unset).
- New `packages/colonizethis_logic/test/performance/turn_characterization_test.dart`: ≥6 players, ≥50 provinces per region, ≥220 units; asserts:
  - (a) town-rule worklist dequeues ≤ total province count
  - (b) aggregate connectivity BFS dequeues (bottleneck + sea-zone plain BFS) ≤ total tile cells for this fixture

## Deferred (not claimed as issue-complete)
- **AC-11** repo-wide gates (`sim_scenarios`, coverage script) are not re-run as part of this slice; recommend `verify-github-issue` after merge.
- Issue body checkboxes / label move to `backlog:verification` should wait until AC-11 is explicitly closed on the issue thread.

## Tests
- `dart test test/performance/turn_characterization_test.dart`
- `dart test` (full `colonizethis_logic` package)

Refs #2268

Made with [Cursor](https://cursor.com)