### PR TITLE
Processing Turn: await first frame before isolate payload (Refs #2277)

### DIFF
--- a/SPEC/ui/next-turn-confirmation.md
+++ b/SPEC/ui/next-turn-confirmation.md
@@ -45,6 +45,7 @@ When the player clicks the "Next turn" button in the top bar, a confirmation dia
 
 - Scope: this slice moves heavy turn-resolution execution to a worker isolate and streams live phase labels into the processing modal.
 - **Map and Flame-canvas next-turn paths (`TurnResolutionRunner`):** Full AI order generation and **`mergeOrderLists`** run **inside the same worker isolate** as trusted-path resolution so the main UI thread only serializes inputs, spawns the worker, and applies the terminal result (Refs **#2277**). Any other entry points must be migrated the same way when added.
+- After the shell schedules the non-dismissible `Processing Turn` dialog, it **awaits [SchedulerBinding.endOfFrame](https://api.flutter.dev/flutter/scheduler/SchedulerBinding/endOfFrame.html)** via **`awaitTurnResolutionProcessingDialogFirstPaint`** (`turn_resolution_progress_labels.dart`) so the modal can paint **before** `TurnResolutionRunner.startResolution` begins main-isolate spawn-payload serialization.
 - The worker emits per-phase start/end progress events through a typed callback (`TurnPhaseProgressMarker`) and the UI updates phase text on `start` (including synthetic **`aiPlanning`** before Full AI runs).
 - Terminal success and terminal failure both close the modal; success applies the resolved result and failure shows the existing error snackbar.
 - Existing pending-human-input outcomes (overture/intervention/call-to-arms) remain valid terminal outputs for post-resolution UI flow.

--- a/app/lib/features/game/flame/game_map_area_part1.dart
+++ b/app/lib/features/game/flame/game_map_area_part1.dart
@@ -506,7 +506,7 @@ mixin _GameMapAreaStatePart1 on ConsumerState<GameMapArea> {
         ),
       ),
     );
-    await Future<void>.delayed(Duration.zero);
+    await awaitTurnResolutionProcessingDialogFirstPaint();
     try {
       final session = runner.startResolution(
         game: game,

--- a/app/lib/features/game/flame/game_screen.dart
+++ b/app/lib/features/game/flame/game_screen.dart
@@ -117,7 +117,7 @@ Future<void> _runFlameCanvasNextTurn(
       ),
     ),
   );
-  await Future<void>.delayed(Duration.zero);
+  await awaitTurnResolutionProcessingDialogFirstPaint();
 
   StreamSubscription<TurnResolutionProgressEvent>? progressSub;
   try {

--- a/app/lib/features/game/flame/turn_resolution_progress_labels.dart
+++ b/app/lib/features/game/flame/turn_resolution_progress_labels.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/scheduler.dart';
+
 /// User-visible labels for [TurnResolutionRunner] progress `phase` ids (worker
 /// isolate + resolver). Refs #2277.
 String turnResolutionProgressPhaseLabel(String phase) {
@@ -18,4 +20,12 @@ String turnResolutionProgressPhaseLabel(String phase) {
     'endOfTurn' => 'Finalizing turn...',
     _ => 'Resolving turn...',
   };
+}
+
+/// After scheduling [TurnResolutionProcessingDialog] (non-awaited
+/// [showDialog]), waits until the next frame is presented so the modal can
+/// paint before [TurnResolutionRunner.startResolution] runs main-isolate work
+/// (spawn payload serialization). Refs #2277.
+Future<void> awaitTurnResolutionProcessingDialogFirstPaint() async {
+  await SchedulerBinding.instance.endOfFrame;
 }

--- a/app/test/turn_resolution_processing_dialog_test.dart
+++ b/app/test/turn_resolution_processing_dialog_test.dart
@@ -1,6 +1,7 @@
 // Turn-resolution processing modal (#2160).
 
 import 'package:colonizethis_app/features/game/flame/turn_resolution_processing_dialog.dart';
+import 'package:colonizethis_app/features/game/flame/turn_resolution_progress_labels.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
@@ -30,4 +31,16 @@ void main() {
     expect(pop.canPop, isFalse);
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
   });
+
+  testWidgets(
+    'awaitTurnResolutionProcessingDialogFirstPaint completes after a frame',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: SizedBox.shrink())),
+      );
+      final done = awaitTurnResolutionProcessingDialogFirstPaint();
+      await tester.pump();
+      await done;
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Partial delivery for **Refs #2277**: after PR #2283 moved Full AI + resolution to a worker isolate, the main isolate still runs **synchronous spawn-payload serialization** (`toJson` for game, orders, topology, tile maps) inside `TurnResolutionRunner.startResolution` before `Isolate.spawn` returns. The UI used `Future.delayed(Duration.zero)`, which does **not** guarantee the Processing Turn dialog has painted.

## Implemented

- `awaitTurnResolutionProcessingDialogFirstPaint()` — awaits `SchedulerBinding.instance.endOfFrame` so the next frame is presented before `startResolution`.
- **Flame canvas** (`game_screen.dart`) and **map** (`game_map_area_part1.dart`) next-turn paths call it instead of `Duration.zero`.
- **SPEC:** `SPEC/ui/next-turn-confirmation.md` slice 2 — documents the first-frame gate.
- **Test:** widget test that the await helper completes after `pump`.

## Deferred (issue scope remains large)

- Granular worker progress (`aiStageA`–`G`, suggestion pool phases) vs single `aiPlanning`.
- Pure-Dart tile-selection cache extraction (B1), staged planner refactor, additional ACs from the issue checklist.
- Any further main-isolate serialization mitigation beyond first-frame modal paint.

## AC coverage (this PR)

- Supports the spirit of: modal painted before remaining main-isolate work after confirm; does **not** alone satisfy full #2277 AC set.

## Verification

`cd app && flutter test test/turn_resolution_processing_dialog_test.dart`

Refs #2277

Made with [Cursor](https://cursor.com)