### PR TITLE
Sanction gate for colonizethis_logic allProvinces( call sites (Refs #2278)

### DIFF
--- a/SPEC/program/logic-dual-region-province-access.md
+++ b/SPEC/program/logic-dual-region-province-access.md
@@ -26,3 +26,25 @@ Raising the budget requires a SPEC update in this file and a maintainer-reviewed
 
 - Given the repository at `dev` with `packages/colonizethis_logic/lib/src/**` sources, when CI runs `dart run tool/ct_repo_lint.dart` including rule `repo.logic_dual_region_province_field_access`, then the checker counts matching lines outside `province_lookup.dart` and `unit_lookup.dart` and the run passes when the count is at most 28.
 - Given a contributor adds a 29th matching line outside `province_lookup.dart` and `unit_lookup.dart` without updating the budget in this SPEC and the checker constant, when repo lint runs, then the run fails and lists each `path:line` hit.
+
+## `allProvinces(` call-site sanction gate (Refs **#2278**)
+
+Broad iteration via the top-level helper `allProvinces(WorldState)` or the `WorldState.allProvinces()` extension method must stay **reviewable**: every production call site under `packages/colonizethis_logic/lib/src/**` (excluding generated Dart suffixes per the shared repo-lint contract) is **explicitly listed** in `tool/logic_all_provinces_sanctions.yaml`, unless it lives in the canonical file below.
+
+| Field | Value |
+|-------|--------|
+| `rule_id` | `repo.logic_all_provinces_sanctioned_calls` |
+| Checker | `tool/check_logic_all_provinces_sanctioned_calls.dart` |
+| Allowlist | `tool/logic_all_provinces_sanctions.yaml` |
+| Scan root | `packages/colonizethis_logic/lib/src/` (non-generated `.dart` only) |
+| Excluded file | `packages/colonizethis_logic/lib/src/world/province_lookup.dart` (definitions of `allProvinces` / `WorldState.allProvinces()` and internal uses) |
+
+**Sanction workflow:** Any new `allProvinces(` / `*.allProvinces(` line in the scan root must add a `sanctions:` entry in the same PR: `path` (repo-relative), `line` (1-based physical line), short `rationale`, and pointer to this SPEC section or the approving issue. The checker fails on **unsanctioned** hits and on **stale** sanctions (YAML entry whose file/line no longer contains `allProvinces(`). Package tests under `packages/colonizethis_logic/test/**` are not scanned.
+
+### Acceptance criteria
+
+- Given the repository at `dev` with `packages/colonizethis_logic/lib/src/**` production sources, when CI runs `dart run tool/ct_repo_lint.dart` including rule `repo.logic_all_provinces_sanctioned_calls`, then every line outside `province_lookup.dart` that contains `allProvinces(` has a matching `path` + `line` entry in `tool/logic_all_provinces_sanctions.yaml` and the run passes.
+
+- Given a contributor adds a new `allProvinces(` call site under the scan root without extending `tool/logic_all_provinces_sanctions.yaml`, when repo lint runs, then the run fails and prints each unsanctioned `path:line`.
+
+- Given a contributor removes or moves a sanctioned call without updating the YAML entry, when repo lint runs, then the run fails and prints each stale `path:line` from the allowlist.

--- a/test/check_logic_all_provinces_sanctioned_calls_test.dart
+++ b/test/check_logic_all_provinces_sanctioned_calls_test.dart
@@ -1,0 +1,38 @@
+import 'package:test/test.dart';
+
+import '../tool/check_logic_all_provinces_sanctioned_calls.dart';
+
+void main() {
+  group('logicSourceLineContainsAllProvincesCall', () {
+    test('detects top-level allProvinces(', () {
+      expect(
+        logicSourceLineContainsAllProvincesCall(
+          'for (final p in allProvinces(game.worldState)) {',
+        ),
+        isTrue,
+      );
+    });
+
+    test('detects WorldState.allProvinces()', () {
+      expect(
+        logicSourceLineContainsAllProvincesCall(
+          'for (final p in game.worldState.allProvinces()) {',
+        ),
+        isTrue,
+      );
+    });
+
+    test('ignores province id substring', () {
+      expect(
+        logicSourceLineContainsAllProvincesCall(
+          'final id = "oldWorld|all_provinces_ignored";',
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  test('current repo passes allProvinces sanction gate', () {
+    expect(runCheckLogicAllProvincesSanctionedCalls('.', info: (_) {}), 0);
+  });
+}

--- a/tool/check_logic_all_provinces_sanctioned_calls.dart
+++ b/tool/check_logic_all_provinces_sanctioned_calls.dart
@@ -1,0 +1,176 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+/// Canonical dual-region province iteration; definitions live here only.
+const _canonicalProvinceLookupRelativePath =
+    'packages/colonizethis_logic/lib/src/world/province_lookup.dart';
+
+const _scanDirRelative = 'packages/colonizethis_logic/lib/src';
+const _sanctionsYamlRelative = 'tool/logic_all_provinces_sanctions.yaml';
+
+final RegExp _generatedSuffix = RegExp(r'\.(g|freezed|mocks|gen)\.dart$');
+
+/// True when [line] contains a broad `allProvinces(` invocation (top-level helper
+/// or [WorldState.allProvinces] extension call).
+bool logicSourceLineContainsAllProvincesCall(String line) {
+  return line.contains('allProvinces(');
+}
+
+typedef _SanctionKey = ({String path, int line});
+
+({Set<_SanctionKey> keys, bool ok}) _loadSanctionKeys(
+  String repoRoot,
+  void Function(String) logE,
+) {
+  final yamlFile = File(p.join(repoRoot, _sanctionsYamlRelative));
+  if (!yamlFile.existsSync()) {
+    logE('ERROR: Missing sanctions file: $_sanctionsYamlRelative');
+    return (keys: const {}, ok: false);
+  }
+  final dynamic root = loadYaml(yamlFile.readAsStringSync());
+  if (root is! YamlMap) {
+    logE('ERROR: $_sanctionsYamlRelative: expected top-level map');
+    return (keys: const {}, ok: false);
+  }
+  final list = root['sanctions'];
+  if (list is! YamlList) {
+    logE('ERROR: $_sanctionsYamlRelative: missing sanctions: list');
+    return (keys: const {}, ok: false);
+  }
+  final out = <_SanctionKey>{};
+  final seenKeys = <String>{};
+  var ok = true;
+  for (var i = 0; i < list.length; i++) {
+    final entry = list[i];
+    if (entry is! YamlMap) {
+      logE('ERROR: $_sanctionsYamlRelative: sanctions[$i] must be a map');
+      ok = false;
+      continue;
+    }
+    final pathRaw = entry['path']?.toString();
+    final lineRaw = entry['line'];
+    if (pathRaw == null || pathRaw.isEmpty) {
+      logE('ERROR: $_sanctionsYamlRelative: sanctions[$i] missing path');
+      ok = false;
+      continue;
+    }
+    final normalizedPath = p.normalize(pathRaw.replaceAll('\\', '/'));
+    final lineNum = lineRaw is int
+        ? lineRaw
+        : (lineRaw is String ? int.tryParse(lineRaw) : null);
+    if (lineNum == null || lineNum < 1) {
+      logE(
+        'ERROR: $_sanctionsYamlRelative: sanctions[$i] invalid line for '
+        '$normalizedPath',
+      );
+      ok = false;
+      continue;
+    }
+    final keyStr = '$normalizedPath:$lineNum';
+    if (!seenKeys.add(keyStr)) {
+      logE('ERROR: $_sanctionsYamlRelative: duplicate sanction $keyStr');
+      ok = false;
+      continue;
+    }
+    out.add((path: normalizedPath, line: lineNum));
+  }
+  return (keys: out, ok: ok);
+}
+
+/// Used by `ct_repo_lint` in-process; [info] / [err] default to stdout/stderr.
+int runCheckLogicAllProvincesSanctionedCalls(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  void logE(String line) {
+    final sink = err;
+    if (sink != null) {
+      sink(line);
+    } else {
+      stderr.writeln(line);
+    }
+  }
+  final root = p.normalize(repoRoot);
+  final scanRoot = Directory(p.join(root, _scanDirRelative));
+  if (!scanRoot.existsSync()) {
+    logE('ERROR: Expected logic lib tree missing: $_scanDirRelative');
+    return 1;
+  }
+
+  final loaded = _loadSanctionKeys(root, logE);
+  if (!loaded.ok) {
+    return 1;
+  }
+  final sanctioned = loaded.keys;
+
+  final hits = <_SanctionKey>{};
+  for (final entity in scanRoot.listSync(recursive: true, followLinks: false)) {
+    if (entity is! File) continue;
+    final fullPath = p.normalize(entity.path);
+    if (!fullPath.endsWith('.dart')) continue;
+    if (_generatedSuffix.hasMatch(fullPath)) continue;
+    final relative = p.normalize(p.relative(fullPath, from: root));
+    if (relative == _canonicalProvinceLookupRelativePath) {
+      continue;
+    }
+
+    final lines = entity.readAsLinesSync();
+    for (var i = 0; i < lines.length; i++) {
+      if (logicSourceLineContainsAllProvincesCall(lines[i])) {
+        hits.add((path: relative, line: i + 1));
+      }
+    }
+  }
+
+  final missingSanctions = hits.difference(sanctioned);
+  final staleSanctions = sanctioned.difference(hits);
+
+  if (missingSanctions.isEmpty && staleSanctions.isEmpty) {
+    logI(
+      'Logic allProvinces sanction check passed (${hits.length} call sites match '
+      '$_sanctionsYamlRelative).',
+    );
+    return 0;
+  }
+
+  if (missingSanctions.isNotEmpty) {
+    logE(
+      'ERROR: Unsanctioned allProvinces( call site(s) under $_scanDirRelative '
+      '(exclude $_canonicalProvinceLookupRelativePath). Add an entry to '
+      '$_sanctionsYamlRelative in the same PR, per SPEC/program/logic-dual-region-province-access.md.',
+    );
+    final sorted = missingSanctions.toList()
+      ..sort((a, b) {
+        final c = a.path.compareTo(b.path);
+        if (c != 0) return c;
+        return a.line.compareTo(b.line);
+      });
+    for (final h in sorted) {
+      logE('${h.path}:${h.line}');
+    }
+  }
+  if (staleSanctions.isNotEmpty) {
+    logE(
+      'ERROR: Stale sanction(s) in $_sanctionsYamlRelative (no matching '
+      'allProvinces( on that line). Remove or retarget the entry.',
+    );
+    final sorted = staleSanctions.toList()
+      ..sort((a, b) {
+        final c = a.path.compareTo(b.path);
+        if (c != 0) return c;
+        return a.line.compareTo(b.line);
+      });
+    for (final h in sorted) {
+      logE('${h.path}:${h.line}');
+    }
+  }
+  return 1;
+}
+
+void main() {
+  exit(runCheckLogicAllProvincesSanctionedCalls(Directory.current.path));
+}

--- a/tool/ct_repo_lint_lib.dart
+++ b/tool/ct_repo_lint_lib.dart
@@ -25,6 +25,7 @@ import 'check_game_widgets_file_size.dart';
 import 'check_land_province_bucket_keys.dart';
 import 'check_logic_test_file_size.dart';
 import 'check_logic_dead_files.dart';
+import 'check_logic_all_provinces_sanctioned_calls.dart';
 import 'check_logic_dual_region_province_field_access.dart';
 import 'check_no_flame_in_widgets.dart';
 import 'check_no_screen_in_game_widgets.dart';
@@ -781,6 +782,8 @@ int? _tryRunDartRuleInProcess({
       return runCheckLandProvinceBucketKeys(repoRoot);
     case 'repo.logic_dual_region_province_field_access':
       return runCheckLogicDualRegionProvinceFieldAccess(repoRoot);
+    case 'repo.logic_all_provinces_sanctioned_calls':
+      return runCheckLogicAllProvincesSanctionedCalls(repoRoot);
     case 'repo.logic_dead_files':
       return runCheckLogicDeadFiles(repoRoot);
     case 'repo.app_hardcoded_ui_strings':

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -258,6 +258,13 @@ rules:
     runner: dart
     script: tool/check_logic_dual_region_province_field_access.dart
 
+  - rule_id: repo.logic_all_provinces_sanctioned_calls
+    group: architecture
+    title: colonizethis_logic allProvinces( call sites must be YAML-sanctioned
+    spec: SPEC/program/logic-dual-region-province-access.md
+    runner: dart
+    script: tool/check_logic_all_provinces_sanctioned_calls.dart
+
   - rule_id: repo.app_hardcoded_ui_strings
     group: ui_i18n
     title: No hardcoded user-visible UI strings in app/lib (AST gate)

--- a/tool/logic_all_provinces_sanctions.yaml
+++ b/tool/logic_all_provinces_sanctions.yaml
@@ -1,0 +1,124 @@
+# Sanctioned `allProvinces(` / `*.allProvinces(` call sites under colonizethis_logic
+# production sources. Canonical implementation lives in province_lookup.dart (excluded
+# from scan). See SPEC/program/logic-dual-region-province-access.md.
+version: 1
+sanctions:
+  - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_work_explorer.dart
+    line: 145
+    rationale: Cross-region explorer work enumeration over partially revealed provinces.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_work_explorer.dart
+    line: 309
+    rationale: Cross-region explorer candidate materialization for suggestion pool.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+    line: 226
+    rationale: Global connectivity / capital path checks require all province rows.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+    line: 533
+    rationale: Global connectivity evaluation iterates all provinces.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/world/player_view.dart
+    line: 83
+    rationale: Player view aggregates province-level facts across both regions.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
+    line: 30
+    rationale: Diplomatic relation scoring inspects province ownership globally.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/turn/phases/movement_phase.dart
+    line: 28
+    rationale: Movement phase owner map keyed by all province ids across regions.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_build_research.dart
+    line: 390
+    rationale: Build suggestions scan province context across regions.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_build_research.dart
+    line: 463
+    rationale: Research/build suggestion enumeration over all provinces.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
+    line: 123
+    rationale: Army move suggestions need global province ownership snapshot.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/world/fog_resolution.dart
+    line: 31
+    rationale: Fog decay / visibility aggregates owners across all provinces.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/world/fog_resolution.dart
+    line: 64
+    rationale: Fog resolution builds cross-region owner maps for state updates.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
+    line: 197
+    rationale: Capital fall logic scans province ownership across regions.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/setup/town_capital_occupancy.dart
+    line: 26
+    rationale: Setup occupancy uses WorldState.allProvinces() over both regions.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/turn/turn_news_digest.dart
+    line: 75
+    rationale: Turn news digest summarizes changes across all provinces.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/turn/turn_news_digest.dart
+    line: 222
+    rationale: Turn news digest second pass over all provinces.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_work_merchant.dart
+    line: 36
+    rationale: Merchant work suggestions evaluate provinces in both regions.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_helpers.dart
+    line: 26
+    rationale: Shared order-suggestion helpers iterate all provinces.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/setup/initial_visibility.dart
+    line: 95
+    rationale: Initial visibility setup walks all province rows.
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278
+
+  - path: packages/colonizethis_logic/lib/src/diplomacy/faction_absorption_engine.dart
+    line: 50
+    rationale: Faction absorption scans province state via WorldState.allProvinces().
+    spec: SPEC/program/logic-dual-region-province-access.md
+    issue: https://github.com/waigore/colonizethisv3/issues/2278


### PR DESCRIPTION
## Summary

Implements the mandatory CI quality gate from **#2278**: every `allProvinces(` / `*.allProvinces(` call under `packages/colonizethis_logic/lib/src/**` (excluding generated suffixes) must be listed in `tool/logic_all_provinces_sanctions.yaml`, except definitions in `province_lookup.dart` which remain excluded from the scan.

## Implemented

- New checker `tool/check_logic_all_provinces_sanctioned_calls.dart` wired in-process for `repo.logic_all_provinces_sanctioned_calls`.
- Allowlist `tool/logic_all_provinces_sanctions.yaml` with one entry per current call site (20 sites).
- `SPEC/program/logic-dual-region-province-access.md`: new section documenting rule id, paths, sanction workflow, and acceptance criteria.
- Unit tests in `test/check_logic_all_provinces_sanctioned_calls_test.dart`.

## Deferred

None for the CI-gate slice described in #2278; follow-up verification on `dev` after merge is tracked on the issue.

## AC / SPEC coverage

- SPEC § `allProvinces(` call-site sanction gate — **covered** by checker + YAML + tests.
- CI: runs with existing `dart run tool/ct_repo_lint.dart` workflow (no separate job).

## Tests run

- `dart run tool/ct_repo_lint.dart --rule repo.logic_all_provinces_sanctioned_calls`
- `dart test test/check_logic_all_provinces_sanctioned_calls_test.dart`

Refs #2278

Made with [Cursor](https://cursor.com)