### PR TITLE
test(app): cover endOfTurn Finalizing label for #2277 AC2

### DIFF
--- a/app/test/turn_resolution_progress_labels_test.dart
+++ b/app/test/turn_resolution_progress_labels_test.dart
@@ -8,6 +8,10 @@ void main() {
       'Planning AI orders...',
     );
     expect(turnResolutionProgressPhaseLabel('orders'), isNotEmpty);
+    expect(
+      turnResolutionProgressPhaseLabel('endOfTurn'),
+      'Finalizing turn...',
+    );
     expect(turnResolutionProgressPhaseLabel('unknownPhase'), 'Resolving turn...');
   });
 }


### PR DESCRIPTION
## Summary
Refs #2277.

Adds an explicit assertion that `turnResolutionProgressPhaseLabel('endOfTurn')` returns **Finalizing turn...**, closing the verification gap called out on the issue (progress label tests previously skipped the resolver `endOfTurn` phase).

## Implemented in this PR
- `app/test/turn_resolution_progress_labels_test.dart`: expect `endOfTurn` → `Finalizing turn...`.

## Deferred / already covered elsewhere
- Turn advancement after a full worker resolution is already asserted in `app/test/turn_resolution_runner_test.dart` (`successful resolution advances the game turn`, merged via prior #2277 work).
- Issue label **backlog:implementation** → **backlog:verification** should wait until this PR is merged and any owner macOS re-check is satisfied (per backlog workflow).

## Tests
- `cd app && flutter test test/turn_resolution_progress_labels_test.dart`


Made with [Cursor](https://cursor.com)