### PR TITLE
refactor(logic): split setup ownership and capital tile scan (Refs #2288)

### DIFF
--- a/packages/colonizethis_logic/lib/src/setup/capital_choice.dart
+++ b/packages/colonizethis_logic/lib/src/setup/capital_choice.dart
@@ -3,13 +3,14 @@ import 'dart:collection';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../constants.dart';
 import '../world/province_lookup.dart';
 import '../world/player_state_pipeline.dart';
 import 'setup_exceptions.dart';
 
 export 'package:colonizethis_data/colonizethis_data.dart'
     show isProvinceSeaBound;
+
+part 'capital_choice_capital_tile_scan.dart';
 
 /// Capital-choice phase stub. SPEC/game/capital-choice-phase.
 ///
@@ -21,155 +22,6 @@ export 'package:colonizethis_data/colonizethis_data.dart'
 /// - B: interior and not adjacent to another province
 /// - C: all remaining tiles
 enum CapitalTileClass { a, b, c }
-
-final class _CapitalTileCandidateScan {
-  int? classAx;
-  int? classAy;
-  int? classBx;
-  int? classBy;
-  int? classCx;
-  int? classCy;
-  int? classCCoastalX;
-  int? classCCoastalY;
-
-  void mergeClassC(int x, int y, TileMapResult tileMap, MapTopology topology) {
-    if (classCx == null) {
-      classCx = x;
-      classCy = y;
-    }
-    if (_isTileAdjacentToSea(x, y, tileMap, topology) &&
-        classCCoastalX == null) {
-      classCCoastalX = x;
-      classCCoastalY = y;
-    }
-  }
-
-  void accept(
-    CapitalTileClass tileClass,
-    int x,
-    int y,
-    TileMapResult tileMap,
-    MapTopology topology,
-  ) {
-    if (tileClass == CapitalTileClass.a) {
-      if (classAx == null) {
-        classAx = x;
-        classAy = y;
-      }
-      return;
-    }
-    if (tileClass == CapitalTileClass.b) {
-      if (classBx == null) {
-        classBx = x;
-        classBy = y;
-      }
-      return;
-    }
-    mergeClassC(x, y, tileMap, topology);
-  }
-}
-
-({
-  int? classAx,
-  int? classAy,
-  int? classBx,
-  int? classBy,
-  int? classCx,
-  int? classCy,
-  int? classCCoastalX,
-  int? classCCoastalY,
-})
-_scanCapitalTileCandidates({
-  required TileMapResult tileMap,
-  required MapTopology topology,
-  required String localProvinceId,
-  required Set<String> provinceIds,
-}) {
-  final acc = _CapitalTileCandidateScan();
-  for (var y = 0; y < tileMap.height; y++) {
-    for (var x = 0; x < tileMap.width; x++) {
-      if (tileMap.cell(x, y) != localProvinceId) continue;
-      final tileClass = classifyCapitalTile(
-        x: x,
-        y: y,
-        tileMap: tileMap,
-        topology: topology,
-        localProvinceId: localProvinceId,
-        provinceIds: provinceIds,
-      );
-      acc.accept(tileClass, x, y, tileMap, topology);
-    }
-  }
-  return (
-    classAx: acc.classAx,
-    classAy: acc.classAy,
-    classBx: acc.classBx,
-    classBy: acc.classBy,
-    classCx: acc.classCx,
-    classCy: acc.classCy,
-    classCCoastalX: acc.classCCoastalX,
-    classCCoastalY: acc.classCCoastalY,
-  );
-}
-
-String _capitalProvinceIdFromSeaBoundOrFallback(
-  List<String> ownedProvinceIds,
-  MapTopology topology, {
-  required bool requireSeaBound,
-}) {
-  final seaBound =
-      ownedProvinceIds
-          .where(
-            (id) => isProvinceSeaBound(topology, ProvinceId.localIdFrom(id)),
-          )
-          .toList()
-        ..sort();
-  if (seaBound.isNotEmpty) return seaBound.first;
-  if (requireSeaBound) {
-    throw NoSeaBoundCapitalProvinceException(
-      details:
-          'No sea-bound province among $ownedProvinceIds; setup must assign at least one sea-bound per faction',
-    );
-  }
-  return (List<String>.from(ownedProvinceIds)..sort()).first;
-}
-
-(int, int) _capitalTileXYFromScan({
-  required bool requireSeaBound,
-  required String provinceId,
-  required String regionId,
-  required int? classAx,
-  required int? classAy,
-  required int? classBx,
-  required int? classBy,
-  required int? classCx,
-  required int? classCy,
-  required int? classCCoastalX,
-  required int? classCCoastalY,
-}) {
-  if (classAx != null && classAy != null) {
-    return (classAx, classAy);
-  }
-  if (requireSeaBound) {
-    if (classCCoastalX != null && classCCoastalY != null) {
-      return (classCCoastalX, classCCoastalY);
-    }
-    throw NoCoastalCapitalTileForGpException(
-      details:
-          'No coastal tile found in sea-bound province $provinceId in region $regionId',
-    );
-  }
-  if (classBx != null && classBy != null) {
-    return (classBx, classBy);
-  }
-  if (classCx != null && classCy != null) {
-    return (classCx, classCy);
-  }
-  throw SetupTopologyDataException(
-    code: 'capital_tile_not_found',
-    details: 'No tile found in province $provinceId in region $regionId',
-  );
-}
 
 /// Picks a capital province and tile for a faction. SPEC/game/capital-choice-phase#auto-choice-game-setup.
 /// [ownedProvinceIds] and [regionId] come from assignment; [topology] and [tileMap] are for that region.

--- a/packages/colonizethis_logic/lib/src/setup/capital_choice_capital_tile_scan.dart
+++ b/packages/colonizethis_logic/lib/src/setup/capital_choice_capital_tile_scan.dart
@@ -1,0 +1,150 @@
+part of 'capital_choice.dart';
+
+final class _CapitalTileCandidateScan {
+  int? classAx;
+  int? classAy;
+  int? classBx;
+  int? classBy;
+  int? classCx;
+  int? classCy;
+  int? classCCoastalX;
+  int? classCCoastalY;
+
+  void mergeClassC(int x, int y, TileMapResult tileMap, MapTopology topology) {
+    if (classCx == null) {
+      classCx = x;
+      classCy = y;
+    }
+    if (_isTileAdjacentToSea(x, y, tileMap, topology) &&
+        classCCoastalX == null) {
+      classCCoastalX = x;
+      classCCoastalY = y;
+    }
+  }
+
+  void accept(
+    CapitalTileClass tileClass,
+    int x,
+    int y,
+    TileMapResult tileMap,
+    MapTopology topology,
+  ) {
+    if (tileClass == CapitalTileClass.a) {
+      if (classAx == null) {
+        classAx = x;
+        classAy = y;
+      }
+      return;
+    }
+    if (tileClass == CapitalTileClass.b) {
+      if (classBx == null) {
+        classBx = x;
+        classBy = y;
+      }
+      return;
+    }
+    mergeClassC(x, y, tileMap, topology);
+  }
+}
+
+({
+  int? classAx,
+  int? classAy,
+  int? classBx,
+  int? classBy,
+  int? classCx,
+  int? classCy,
+  int? classCCoastalX,
+  int? classCCoastalY,
+})
+_scanCapitalTileCandidates({
+  required TileMapResult tileMap,
+  required MapTopology topology,
+  required String localProvinceId,
+  required Set<String> provinceIds,
+}) {
+  final acc = _CapitalTileCandidateScan();
+  for (var y = 0; y < tileMap.height; y++) {
+    for (var x = 0; x < tileMap.width; x++) {
+      if (tileMap.cell(x, y) != localProvinceId) continue;
+      final tileClass = classifyCapitalTile(
+        x: x,
+        y: y,
+        tileMap: tileMap,
+        topology: topology,
+        localProvinceId: localProvinceId,
+        provinceIds: provinceIds,
+      );
+      acc.accept(tileClass, x, y, tileMap, topology);
+    }
+  }
+  return (
+    classAx: acc.classAx,
+    classAy: acc.classAy,
+    classBx: acc.classBx,
+    classBy: acc.classBy,
+    classCx: acc.classCx,
+    classCy: acc.classCy,
+    classCCoastalX: acc.classCCoastalX,
+    classCCoastalY: acc.classCCoastalY,
+  );
+}
+
+String _capitalProvinceIdFromSeaBoundOrFallback(
+  List<String> ownedProvinceIds,
+  MapTopology topology, {
+  required bool requireSeaBound,
+}) {
+  final seaBound =
+      ownedProvinceIds
+          .where(
+            (id) => isProvinceSeaBound(topology, ProvinceId.localIdFrom(id)),
+          )
+          .toList()
+        ..sort();
+  if (seaBound.isNotEmpty) return seaBound.first;
+  if (requireSeaBound) {
+    throw NoSeaBoundCapitalProvinceException(
+      details:
+          'No sea-bound province among $ownedProvinceIds; setup must assign at least one sea-bound per faction',
+    );
+  }
+  return (List<String>.from(ownedProvinceIds)..sort()).first;
+}
+
+(int, int) _capitalTileXYFromScan({
+  required bool requireSeaBound,
+  required String provinceId,
+  required String regionId,
+  required int? classAx,
+  required int? classAy,
+  required int? classBx,
+  required int? classBy,
+  required int? classCx,
+  required int? classCy,
+  required int? classCCoastalX,
+  required int? classCCoastalY,
+}) {
+  if (classAx != null && classAy != null) {
+    return (classAx, classAy);
+  }
+  if (requireSeaBound) {
+    if (classCCoastalX != null && classCCoastalY != null) {
+      return (classCCoastalX, classCCoastalY);
+    }
+    throw NoCoastalCapitalTileForGpException(
+      details:
+          'No coastal tile found in sea-bound province $provinceId in region $regionId',
+    );
+  }
+  if (classBx != null && classBy != null) {
+    return (classBx, classBy);
+  }
+  if (classCx != null && classCy != null) {
+    return (classCx, classCy);
+  }
+  throw SetupTopologyDataException(
+    code: 'capital_tile_not_found',
+    details: 'No tile found in province $provinceId in region $regionId',
+  );
+}

--- a/packages/colonizethis_logic/lib/src/setup/game_setup_create.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup_create.dart
@@ -10,6 +10,7 @@ import 'capital_choice.dart';
 import 'game_setup_context.dart';
 import 'game_setup_helpers.dart';
 import 'game_setup_ownership.dart';
+import 'game_setup_topology.dart';
 import 'gp_old_world_resource_redistribution.dart';
 import 'gp_old_world_terrain_redistribution.dart';
 import 'gp_starting_grain.dart';

--- a/packages/colonizethis_logic/lib/src/setup/game_setup_ownership.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup_ownership.dart
@@ -5,27 +5,12 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../utils/graph_traversal.dart';
 import 'capital_choice.dart';
+import 'game_setup_topology.dart';
 import 'locked_province_assigner.dart';
 import 'province_assignment.dart';
 import 'setup_exceptions.dart';
 
-Map<String, Set<String>> provinceNeighboursFromTopology(MapTopology topology) {
-  final provinces = {
-    for (final n in topology.nodes)
-      if (n.type == TopologyNodeType.province) n.id,
-  };
-  final neighbours = <String, Set<String>>{
-    for (final id in provinces) id: <String>{},
-  };
-  for (final edge in topology.edges) {
-    final a = edge.id1;
-    final b = edge.id2;
-    if (!provinces.contains(a) || !provinces.contains(b)) continue;
-    neighbours[a]!.add(b);
-    neighbours[b]!.add(a);
-  }
-  return neighbours;
-}
+part 'game_setup_ownership_gp_packing.dart';
 
 Game assignCapitalsForFactions({
   required Game game,
@@ -69,129 +54,6 @@ Game assignCapitalsForFactions({
     );
   }
   return game;
-}
-
-/// Upper bound on how many OW provinces all Great Powers can own together when each GP
-/// is confined to one P–P landmass and each GP needs a sea-bound seed on that landmass.
-/// Uses the union of landmasses that receive at least one GP; spreading GPs across
-/// separate landmasses maximizes that union (see SPEC/game/game-setup.md).
-int _maxFeasibleGpProvinceBudgetOnLandmasses({
-  required Map<int, int> landmassSizes,
-  required Map<int, int> seaBoundCountByLandmass,
-  required int gpCount,
-}) {
-  final eligible =
-      landmassSizes.keys
-          .where((lm) => (seaBoundCountByLandmass[lm] ?? 0) >= 1)
-          .toList()
-        ..sort((a, b) => landmassSizes[b]!.compareTo(landmassSizes[a]!));
-
-  if (eligible.isEmpty) {
-    return 0;
-  }
-
-  final totalSeaSlots = eligible.fold<int>(
-    0,
-    (sum, lm) => sum + (seaBoundCountByLandmass[lm] ?? 0),
-  );
-  if (totalSeaSlots < gpCount) {
-    return 0;
-  }
-
-  if (gpCount <= eligible.length) {
-    return eligible
-        .take(gpCount)
-        .fold<int>(0, (sum, lm) => sum + landmassSizes[lm]!);
-  }
-
-  return eligible.fold<int>(0, (sum, lm) => sum + landmassSizes[lm]!);
-}
-
-/// Result of greedy GP→landmass assignment (largest-targets first).
-typedef _GpLandmassPackResult = ({
-  Map<String, int> gpLandmassAssignments,
-  Map<String, int> targetPerGp,
-  List<String> sortedGpIds,
-});
-
-/// Tries to place each GP on one landmass with sea-cap and per-landmass target sums.
-_GpLandmassPackResult? _tryPackGpsOntoLandmassesGreedy({
-  required List<String> gpIds,
-  required int gpProvinceBudget,
-  required Map<int, int> landmassSizes,
-  required List<int> sortedLandmasses,
-  required Map<int, int> seaBoundCountByLandmass,
-}) {
-  final targetPerGp = computeFairTargets(gpIds, gpProvinceBudget);
-  final gpLandmassAssignments = <String, int>{};
-  final targetUsedOnLandmass = <int, int>{
-    for (final lm in landmassSizes.keys) lm: 0,
-  };
-  final gpCountOnLandmass = <int, int>{
-    for (final lm in landmassSizes.keys) lm: 0,
-  };
-
-  final sortedGpIds = gpIds.toList()
-    ..sort((a, b) => targetPerGp[b]!.compareTo(targetPerGp[a]!));
-
-  for (final gpId in sortedGpIds) {
-    final target = targetPerGp[gpId]!;
-    int? bestLm;
-    var bestSlack = 1 << 30;
-    for (final lm in sortedLandmasses) {
-      final seaCap = seaBoundCountByLandmass[lm] ?? 0;
-      if (gpCountOnLandmass[lm]! >= seaCap) continue;
-      if (targetUsedOnLandmass[lm]! + target > landmassSizes[lm]!) continue;
-      final slack = landmassSizes[lm]! - (targetUsedOnLandmass[lm]! + target);
-      if (slack < bestSlack) {
-        bestSlack = slack;
-        bestLm = lm;
-      }
-    }
-    if (bestLm == null) {
-      return null;
-    }
-    gpLandmassAssignments[gpId] = bestLm;
-    targetUsedOnLandmass[bestLm] = targetUsedOnLandmass[bestLm]! + target;
-    gpCountOnLandmass[bestLm] = gpCountOnLandmass[bestLm]! + 1;
-  }
-
-  return (
-    gpLandmassAssignments: gpLandmassAssignments,
-    targetPerGp: targetPerGp,
-    sortedGpIds: sortedGpIds,
-  );
-}
-
-/// Largest budget in [gpCount, cap] for which [computeFairTargets] + greedy packing succeeds.
-int _largestFeasibleGpProvinceBudgetByPacking({
-  required List<String> gpIds,
-  required int gpCount,
-  required int cap,
-  required Map<int, int> landmassSizes,
-  required List<int> sortedLandmasses,
-  required Map<int, int> seaBoundCountByLandmass,
-}) {
-  var lo = gpCount;
-  var hi = cap;
-  var best = gpCount - 1;
-  while (lo <= hi) {
-    final mid = (lo + hi) ~/ 2;
-    final pack = _tryPackGpsOntoLandmassesGreedy(
-      gpIds: gpIds,
-      gpProvinceBudget: mid,
-      landmassSizes: landmassSizes,
-      sortedLandmasses: sortedLandmasses,
-      seaBoundCountByLandmass: seaBoundCountByLandmass,
-    );
-    if (pack != null) {
-      best = mid;
-      lo = mid + 1;
-    } else {
-      hi = mid - 1;
-    }
-  }
-  return best;
 }
 
 List<String> _lockedGrowthOrder(

--- a/packages/colonizethis_logic/lib/src/setup/game_setup_ownership_gp_packing.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup_ownership_gp_packing.dart
@@ -1,0 +1,124 @@
+part of 'game_setup_ownership.dart';
+
+/// Upper bound on how many OW provinces all Great Powers can own together when each GP
+/// is confined to one P–P landmass and each GP needs a sea-bound seed on that landmass.
+/// Uses the union of landmasses that receive at least one GP; spreading GPs across
+/// separate landmasses maximizes that union (see SPEC/game/game-setup.md).
+int _maxFeasibleGpProvinceBudgetOnLandmasses({
+  required Map<int, int> landmassSizes,
+  required Map<int, int> seaBoundCountByLandmass,
+  required int gpCount,
+}) {
+  final eligible =
+      landmassSizes.keys
+          .where((lm) => (seaBoundCountByLandmass[lm] ?? 0) >= 1)
+          .toList()
+        ..sort((a, b) => landmassSizes[b]!.compareTo(landmassSizes[a]!));
+
+  if (eligible.isEmpty) {
+    return 0;
+  }
+
+  final totalSeaSlots = eligible.fold<int>(
+    0,
+    (sum, lm) => sum + (seaBoundCountByLandmass[lm] ?? 0),
+  );
+  if (totalSeaSlots < gpCount) {
+    return 0;
+  }
+
+  if (gpCount <= eligible.length) {
+    return eligible
+        .take(gpCount)
+        .fold<int>(0, (sum, lm) => sum + landmassSizes[lm]!);
+  }
+
+  return eligible.fold<int>(0, (sum, lm) => sum + landmassSizes[lm]!);
+}
+
+/// Result of greedy GP→landmass assignment (largest-targets first).
+typedef _GpLandmassPackResult = ({
+  Map<String, int> gpLandmassAssignments,
+  Map<String, int> targetPerGp,
+  List<String> sortedGpIds,
+});
+
+/// Tries to place each GP on one landmass with sea-cap and per-landmass target sums.
+_GpLandmassPackResult? _tryPackGpsOntoLandmassesGreedy({
+  required List<String> gpIds,
+  required int gpProvinceBudget,
+  required Map<int, int> landmassSizes,
+  required List<int> sortedLandmasses,
+  required Map<int, int> seaBoundCountByLandmass,
+}) {
+  final targetPerGp = computeFairTargets(gpIds, gpProvinceBudget);
+  final gpLandmassAssignments = <String, int>{};
+  final targetUsedOnLandmass = <int, int>{
+    for (final lm in landmassSizes.keys) lm: 0,
+  };
+  final gpCountOnLandmass = <int, int>{
+    for (final lm in landmassSizes.keys) lm: 0,
+  };
+
+  final sortedGpIds = gpIds.toList()
+    ..sort((a, b) => targetPerGp[b]!.compareTo(targetPerGp[a]!));
+
+  for (final gpId in sortedGpIds) {
+    final target = targetPerGp[gpId]!;
+    int? bestLm;
+    var bestSlack = 1 << 30;
+    for (final lm in sortedLandmasses) {
+      final seaCap = seaBoundCountByLandmass[lm] ?? 0;
+      if (gpCountOnLandmass[lm]! >= seaCap) continue;
+      if (targetUsedOnLandmass[lm]! + target > landmassSizes[lm]!) continue;
+      final slack = landmassSizes[lm]! - (targetUsedOnLandmass[lm]! + target);
+      if (slack < bestSlack) {
+        bestSlack = slack;
+        bestLm = lm;
+      }
+    }
+    if (bestLm == null) {
+      return null;
+    }
+    gpLandmassAssignments[gpId] = bestLm;
+    targetUsedOnLandmass[bestLm] = targetUsedOnLandmass[bestLm]! + target;
+    gpCountOnLandmass[bestLm] = gpCountOnLandmass[bestLm]! + 1;
+  }
+
+  return (
+    gpLandmassAssignments: gpLandmassAssignments,
+    targetPerGp: targetPerGp,
+    sortedGpIds: sortedGpIds,
+  );
+}
+
+/// Largest budget in [gpCount, cap] for which [computeFairTargets] + greedy packing succeeds.
+int _largestFeasibleGpProvinceBudgetByPacking({
+  required List<String> gpIds,
+  required int gpCount,
+  required int cap,
+  required Map<int, int> landmassSizes,
+  required List<int> sortedLandmasses,
+  required Map<int, int> seaBoundCountByLandmass,
+}) {
+  var lo = gpCount;
+  var hi = cap;
+  var best = gpCount - 1;
+  while (lo <= hi) {
+    final mid = (lo + hi) ~/ 2;
+    final pack = _tryPackGpsOntoLandmassesGreedy(
+      gpIds: gpIds,
+      gpProvinceBudget: mid,
+      landmassSizes: landmassSizes,
+      sortedLandmasses: sortedLandmasses,
+      seaBoundCountByLandmass: seaBoundCountByLandmass,
+    );
+    if (pack != null) {
+      best = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return best;
+}

--- a/packages/colonizethis_logic/lib/src/setup/game_setup_topology.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup_topology.dart
@@ -1,0 +1,20 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+
+/// Province–province adjacency from topology edges (P–P links only).
+Map<String, Set<String>> provinceNeighboursFromTopology(MapTopology topology) {
+  final provinces = {
+    for (final n in topology.nodes)
+      if (n.type == TopologyNodeType.province) n.id,
+  };
+  final neighbours = <String, Set<String>>{
+    for (final id in provinces) id: <String>{},
+  };
+  for (final edge in topology.edges) {
+    final a = edge.id1;
+    final b = edge.id2;
+    if (!provinces.contains(a) || !provinces.contains(b)) continue;
+    neighbours[a]!.add(b);
+    neighbours[b]!.add(a);
+  }
+  return neighbours;
+}


### PR DESCRIPTION
## Summary
Refs #2288 (partial slice toward coordinated setup refactor).

## Implemented in this PR
- Move `provinceNeighboursFromTopology` to new `game_setup_topology.dart`; `game_setup_create.dart` imports it directly alongside ownership.
- Move GP Old World landmass budget / greedy pack / binary-search budget helpers into `game_setup_ownership_gp_packing.dart` (`part of` `game_setup_ownership.dart`) so private symbols stay library-private.
- Move capital-tile candidate scan, sea-bound province pick, and tile XY resolution into `capital_choice_capital_tile_scan.dart` (`part of` `capital_choice.dart`).

## Line-count outcome (physical lines)
- `game_setup_ownership.dart`: **781 → 643** (under 700)
- `capital_choice.dart`: **717 → 570** (under 700)

## Deferred (issue scope still open)
- `combat_resolver.dart` still >700 if applicable; further `game_setup_ownership` extractions; coordinated setup phase polish; 16 large test splits; test directory mirrors; barrel narrowing; coverage baseline PR note per issue AC.

## SPEC
No behavior change; no SPEC edits (refactor-only per issue non-goals).

## Tests
- `dart test test/capital_choice_test.dart test/game_setup_variants_and_naming_test.dart` (packages/colonizethis_logic)

## Label
Issue remains `backlog:implementation` until remaining #2288 ACs land.

Made with [Cursor](https://cursor.com)