### PR TITLE
Improve colonizethis_data coverage and add explicit meta dependency

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -471,6 +471,10 @@ jobs:
         if: needs.changes.outputs.tests == 'true'
         run: tool/check_coverage_threshold.sh 90 packages/colonizethis_logic packages/colonizethis_map packages/colonizethis_ai
 
+      - name: Coverage gate (data >= 80%)
+        if: needs.changes.outputs.tests == 'true'
+        run: tool/check_coverage_threshold.sh 80 packages/colonizethis_data
+
       - name: sim_scenarios integration gate (all scenarios must pass)
         if: needs.changes.outputs.tests == 'true'
         run: melos run sim_scenarios

--- a/packages/colonizethis_data/pubspec.yaml
+++ b/packages/colonizethis_data/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   logger: ^2.0.2
+  meta: ^1.17.0
   yaml: ^3.1.3
   colonizethis_logger:
   colonizethis_models:

--- a/packages/colonizethis_data/test/naming_rules_test.dart
+++ b/packages/colonizethis_data/test/naming_rules_test.dart
@@ -1,0 +1,83 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('naming rules', () {
+    test('allGreatPowerIds matches config ids exactly', () {
+      final idsFromConfig = defaultNamingConfig.greatPowers
+          .map((gp) => gp.id)
+          .toList();
+      expect(idsFromConfig, allGreatPowerIds);
+      expect(idsFromConfig.toSet().length, idsFromConfig.length);
+    });
+
+    test('default naming config has expected top-level counts', () {
+      expect(defaultNamingConfig.greatPowers, hasLength(7));
+      expect(defaultNamingConfig.minorNations, hasLength(6));
+      expect(defaultNamingConfig.tribes, hasLength(10));
+    });
+
+    test('every naming entry has required non-empty fields', () {
+      for (final gp in defaultNamingConfig.greatPowers) {
+        expect(gp.id, isNotEmpty);
+        expect(gp.countryName, isNotEmpty);
+        expect(gp.adjective, isNotEmpty);
+        expect(gp.capitalCityName, isNotEmpty);
+        expect(gp.leaderVariants, isNotEmpty);
+        for (final variant in gp.leaderVariants) {
+          expect(variant.id, isNotEmpty);
+          expect(variant.name, isNotEmpty);
+          expect(variant.leaderKey, isNotEmpty);
+          expect(variant.provinceNamePool, isNotEmpty);
+        }
+      }
+
+      for (final minor in defaultNamingConfig.minorNations) {
+        expect(minor.id, isNotEmpty);
+        expect(minor.displayName, isNotEmpty);
+        expect(minor.provinceNamePool, isNotEmpty);
+      }
+
+      for (final tribe in defaultNamingConfig.tribes) {
+        expect(tribe.id, isNotEmpty);
+        expect(tribe.displayName, isNotEmpty);
+        expect(tribe.provinceNamePool, isNotEmpty);
+      }
+    });
+
+    test('resolved config lookups return values for known ids', () {
+      expect(defaultNamingConfig.gpById('england')?.countryName, 'England');
+      expect(defaultNamingConfig.minorById('minor2')?.displayName, 'Germany');
+      expect(defaultNamingConfig.tribeById('tribe3')?.displayName, 'Inca');
+    });
+
+    test('resolved config lookups return null for unknown ids', () {
+      expect(defaultNamingConfig.gpById('missing_gp'), isNull);
+      expect(defaultNamingConfig.minorById('missing_minor'), isNull);
+      expect(defaultNamingConfig.tribeById('missing_tribe'), isNull);
+    });
+
+    test('prussia variants and helper methods resolve correctly', () {
+      final prussia = defaultNamingConfig.gpById('prussia');
+      expect(prussia, isNotNull);
+      expect(prussia!.hasMultipleVariants, isTrue);
+      expect(prussia.defaultLeaderVariantId, prussiaVariantFrederickTheGreat);
+      expect(
+        prussia.variantById(prussiaVariantFrederickWilliam).id,
+        prussiaVariantFrederickWilliam,
+      );
+      expect(
+        prussia.variantById('missing').id,
+        prussiaVariantFrederickTheGreat,
+      );
+
+      expect(
+        defaultNamingConfig.defaultLeaderVariantId('prussia'),
+        prussiaVariantFrederickTheGreat,
+      );
+      expect(defaultNamingConfig.defaultLeaderVariantId('missing_gp'), isEmpty);
+      expect(defaultNamingConfig.hasMultipleLeaderVariants('prussia'), isTrue);
+      expect(defaultNamingConfig.hasMultipleLeaderVariants('england'), isFalse);
+    });
+  });
+}

--- a/packages/colonizethis_data/test/quick_battle_config_test.dart
+++ b/packages/colonizethis_data/test/quick_battle_config_test.dart
@@ -1,0 +1,14 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('quick battle config', () {
+    test('constants match quick battle spec defaults', () {
+      expect(quickBattleMaxCohesion, 3);
+      expect(quickBattleMaxRounds, 3);
+      expect(quickBattleCpPerRoundMin, 2);
+      expect(quickBattleCpPerRoundMax, 3);
+      expect(quickBattleCpPerRoundMin <= quickBattleCpPerRoundMax, isTrue);
+    });
+  });
+}

--- a/packages/colonizethis_data/test/resource_rules_test.dart
+++ b/packages/colonizethis_data/test/resource_rules_test.dart
@@ -1,0 +1,55 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('resource rules', () {
+    test('default rules cover every resource for every map', () {
+      final rules = ResourceRules.defaultRules;
+      for (final resource in Resource.values) {
+        expect(rules.regionRule.containsKey(resource), isTrue);
+        expect(rules.allowedTerrains.containsKey(resource), isTrue);
+        expect(rules.defaultMarketPrice.containsKey(resource), isTrue);
+        expect(rules.allowedTerrains[resource], isNotEmpty);
+        expect(rules.defaultMarketPrice[resource]! > 0, isTrue);
+      }
+    });
+
+    test('spawn weights are inverse to market price', () {
+      final rules = ResourceRules.defaultRules;
+      expect(rules.spawnWeight(Resource.timber), closeTo(1 / 30, 1e-9));
+      expect(rules.spawnWeight(Resource.diamonds), closeTo(1 / 500, 1e-9));
+      expect(
+        rules.spawnWeight(Resource.timber) >
+            rules.spawnWeight(Resource.diamonds),
+        isTrue,
+      );
+    });
+
+    test('isAllowedInRegion enforces old world, new world, and both rules', () {
+      final rules = ResourceRules.defaultRules;
+      expect(rules.isAllowedInRegion(Resource.grain, 'oldWorld'), isTrue);
+      expect(rules.isAllowedInRegion(Resource.grain, 'newWorld'), isFalse);
+      expect(rules.isAllowedInRegion(Resource.sugarCane, 'oldWorld'), isFalse);
+      expect(rules.isAllowedInRegion(Resource.sugarCane, 'newWorld'), isTrue);
+      expect(rules.isAllowedInRegion(Resource.timber, 'oldWorld'), isTrue);
+      expect(rules.isAllowedInRegion(Resource.timber, 'newWorld'), isTrue);
+    });
+
+    test('isAllowedOnTerrain validates explicit terrain lists', () {
+      final rules = ResourceRules.defaultRules;
+      expect(rules.isAllowedOnTerrain(Resource.tin, TerrainType.swamp), isTrue);
+      expect(
+        rules.isAllowedOnTerrain(Resource.tin, TerrainType.forest),
+        isFalse,
+      );
+      expect(
+        rules.isAllowedOnTerrain(Resource.gold, TerrainType.mountain),
+        isTrue,
+      );
+      expect(
+        rules.isAllowedOnTerrain(Resource.gold, TerrainType.hills),
+        isFalse,
+      );
+    });
+  });
+}

--- a/packages/colonizethis_data/test/riches_prices_test.dart
+++ b/packages/colonizethis_data/test/riches_prices_test.dart
@@ -1,0 +1,42 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('riches prices', () {
+    test('riches commodity ids are stable and complete', () {
+      expect(richesCommodityIds, const [
+        'spices',
+        'silver',
+        'gold',
+        'gems',
+        'diamonds',
+      ]);
+    });
+
+    test('richesBasePrice returns expected values for riches', () {
+      expect(richesBasePrice('spices'), 50);
+      expect(richesBasePrice('silver'), 100);
+      expect(richesBasePrice('gold'), 166);
+      expect(richesBasePrice('gems'), 250);
+      expect(richesBasePrice('diamonds'), 500);
+    });
+
+    test('richesBasePrice returns zero for non-riches ids', () {
+      expect(richesBasePrice('grain'), 0);
+      expect(richesBasePrice('unknown'), 0);
+    });
+
+    test('land purchase prices use riches when available', () {
+      expect(landPurchaseBasePrice('spices'), 50);
+      expect(purchaseLandCost('spices'), 750);
+      expect(landPurchaseBasePrice('diamonds'), 500);
+      expect(purchaseLandCost('diamonds'), 7500);
+    });
+
+    test('land purchase prices fall back to default for non-riches', () {
+      expect(landPurchaseBasePrice('grain'), landPurchaseDefaultBasePrice);
+      expect(landPurchaseBasePrice('unknown'), landPurchaseDefaultBasePrice);
+      expect(purchaseLandCost('grain'), 15 * landPurchaseDefaultBasePrice);
+    });
+  });
+}

--- a/packages/colonizethis_data/test/terrain_region_rules_test.dart
+++ b/packages/colonizethis_data/test/terrain_region_rules_test.dart
@@ -1,0 +1,46 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('terrain region rules', () {
+    test('allowedTerrainsForRegion returns expected sets', () {
+      expect(
+        allowedTerrainsForRegion('oldWorld'),
+        orderedEquals(oldWorldTerrains),
+      );
+      expect(
+        allowedTerrainsForRegion('newWorld'),
+        orderedEquals(newWorldTerrains),
+      );
+      expect(
+        allowedTerrainsForRegion('unknown_region'),
+        orderedEquals(oldWorldTerrains),
+      );
+    });
+
+    test(
+      'terrainDistributionForRegion returns normalized old world fractions',
+      () {
+        final distribution = terrainDistributionForRegion('oldWorld');
+        expect(distribution.mountainFraction, closeTo(0.15, 1e-9));
+        expect(distribution.fractionFor(TerrainType.desert), 0.0);
+
+        final total =
+            distribution.mountainFraction +
+            distribution.nonMountainFractions.values.fold<double>(
+              0.0,
+              (sum, value) => sum + value,
+            );
+        expect(total, closeTo(1.0, 1e-9));
+      },
+    );
+
+    test('terrainDistributionForRegion includes desert in new world only', () {
+      final oldWorld = terrainDistributionForRegion('oldWorld');
+      final newWorld = terrainDistributionForRegion('newWorld');
+      expect(oldWorld.fractionFor(TerrainType.desert), 0.0);
+      expect(newWorld.fractionFor(TerrainType.desert), greaterThan(0.0));
+      expect(newWorld.mountainFraction, closeTo(0.15, 1e-9));
+    });
+  });
+}

--- a/packages/colonizethis_data/test/unit_roles_test.dart
+++ b/packages/colonizethis_data/test/unit_roles_test.dart
@@ -1,15 +1,16 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
 void main() {
   group('unit roles', () {
     test('known civilian and utility unit types map to explicit roles', () {
-      expect(unitRoleForType('Explorer'), UnitRole.explorer);
-      expect(unitRoleForType('Builder'), UnitRole.civilianWorker);
-      expect(unitRoleForType('Engineer'), UnitRole.civilianWorker);
-      expect(unitRoleForType('Spy'), UnitRole.spy);
-      expect(unitRoleForType('Merchant'), UnitRole.merchant);
-      expect(unitRoleForType('Rail Builder'), UnitRole.civilianWorker);
+      expect(unitRoleForType(kUnitTypeExplorer), UnitRole.explorer);
+      expect(unitRoleForType(kUnitTypeBuilder), UnitRole.civilianWorker);
+      expect(unitRoleForType(kUnitTypeEngineer), UnitRole.civilianWorker);
+      expect(unitRoleForType(kUnitTypeSpy), UnitRole.spy);
+      expect(unitRoleForType(kUnitTypeMerchant), UnitRole.merchant);
+      expect(unitRoleForType(kUnitTypeRailBuilder), UnitRole.civilianWorker);
     });
 
     test('known regiment type maps to military role', () {

--- a/packages/colonizethis_data/test/unit_roles_test.dart
+++ b/packages/colonizethis_data/test/unit_roles_test.dart
@@ -1,0 +1,32 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('unit roles', () {
+    test('known civilian and utility unit types map to explicit roles', () {
+      expect(unitRoleForType('Explorer'), UnitRole.explorer);
+      expect(unitRoleForType('Builder'), UnitRole.civilianWorker);
+      expect(unitRoleForType('Engineer'), UnitRole.civilianWorker);
+      expect(unitRoleForType('Spy'), UnitRole.spy);
+      expect(unitRoleForType('Merchant'), UnitRole.merchant);
+      expect(unitRoleForType('Rail Builder'), UnitRole.civilianWorker);
+    });
+
+    test('known regiment type maps to military role', () {
+      expect(unitRoleForType('grenadiers'), UnitRole.military);
+      expect(isMilitaryUnit('grenadiers'), isTrue);
+      expect(canUnitInitiateCombat('grenadiers'), isTrue);
+    });
+
+    test('unknown type yields null and false role predicates', () {
+      expect(unitRoleForType('unknown_type'), isNull);
+      expect(isMilitaryUnit('unknown_type'), isFalse);
+      expect(isExplorerUnit('unknown_type'), isFalse);
+      expect(isCivilianWorkerUnit('unknown_type'), isFalse);
+      expect(isMerchantUnit('unknown_type'), isFalse);
+      expect(isSpyUnit('unknown_type'), isFalse);
+      expect(isNavalUnit('unknown_type'), isFalse);
+      expect(canUnitInitiateCombat('unknown_type'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds focused `colonizethis_data` tests for naming rules, resource rules, terrain-region distributions, unit roles, riches pricing, and quick-battle config constants.
- Declares `meta` explicitly in `packages/colonizethis_data/pubspec.yaml` to remove hidden transitive dependency reliance.
- Adds a dedicated CI coverage gate step for `packages/colonizethis_data` at 80% in `.github/workflows/quality.yml`.

## Implemented in this PR
- `naming_rules_test.dart` validates default config structure/counts, lookup behavior, and Prussia variant resolution helpers.
- `resource_rules_test.dart` validates full resource map coverage, spawn-weight inverse pricing, and region/terrain allow-list behavior.
- `terrain_region_rules_test.dart` validates allowed terrain sets and normalized terrain distribution invariants.
- `unit_roles_test.dart` validates explicit civilian role mapping, regiment military mapping, and negative/unknown-type behavior.
- `riches_prices_test.dart` validates riches base-price progression and purchase-land pricing fallback behavior.
- `quick_battle_config_test.dart` validates quick-battle constants.
- `pubspec.yaml` now lists `meta` in direct dependencies.
- CI now enforces data package coverage via `tool/check_coverage_threshold.sh 80 packages/colonizethis_data`.

## Deferred work
- None intentionally deferred for the scoped acceptance criteria in #2324.

## AC / spec coverage
- Covers naming rules, resource/terrain rules, unit role predicates, and riches pricing expectations called out in #2324.
- Enforces the package-level coverage requirement (>=80%) in CI for `colonizethis_data`.

## Validation
- `cd packages/colonizethis_data && dart pub get`
- `cd packages/colonizethis_data && dart test --coverage=coverage -j 2 --reporter=compact`
- `cd packages/colonizethis_data && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.`
- Coverage from generated `coverage/lcov.info`: `LH=1210 LF=1490` => `81.21%`
- `cd packages/colonizethis_data && dart test -j 2 --reporter=compact`
- `cd packages/colonizethis_data && dart analyze` (reports one existing pre-existing warning in `lib/src/tech_extraction.dart`)

Refs #2324

Made with [Cursor](https://cursor.com)