### PR TITLE
refactor(app): share e2e wait helpers and trim fleet move waits (Refs #2336)

### DIFF
--- a/app/integration_test/e2e_test_shared.dart
+++ b/app/integration_test/e2e_test_shared.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class E2ePerfLog {
+  E2ePerfLog(this.testName);
+
+  final String testName;
+  final Map<String, int> _counters = <String, int>{};
+
+  void bumpCounter(String name, {int by = 1, String? meta}) {
+    _counters[name] = (_counters[name] ?? 0) + by;
+    final metaPart = meta == null ? '' : '|meta=$meta';
+    debugPrint(
+      'E2E_COUNTER|test=$testName|name=$name|value=${_counters[name]}$metaPart',
+    );
+  }
+
+  void timing(String phase, Duration elapsed, {String? meta}) {
+    final metaPart = meta == null ? '' : '|meta=$meta';
+    debugPrint(
+      'E2E_TIMING|test=$testName|phase=$phase|ms=${elapsed.inMilliseconds}$metaPart',
+    );
+  }
+}
+
+Future<void> e2ePumpFor(WidgetTester tester, Duration total) async {
+  const step = Duration(milliseconds: 50);
+  var elapsed = Duration.zero;
+  while (elapsed < total) {
+    await tester.pump(step);
+    elapsed += step;
+  }
+}
+
+Future<void> e2eWaitUntilFound(
+  WidgetTester tester,
+  Finder finder, {
+  required Duration timeout,
+  Duration diagnoseAfter = Duration.zero,
+  E2ePerfLog? perf,
+  String phaseName = 'wait_until_found',
+}) async {
+  final sw = Stopwatch()..start();
+  perf?.bumpCounter('wait_until_found_calls', meta: 'phase=$phaseName');
+  var stepMs = 25;
+  while (sw.elapsed < timeout) {
+    if (finder.evaluate().isNotEmpty) {
+      perf?.timing(phaseName, sw.elapsed, meta: 'result=found');
+      return;
+    }
+    await tester.pump(Duration(milliseconds: stepMs));
+    if (stepMs < 100) {
+      stepMs += 25;
+    }
+  }
+  if (diagnoseAfter > Duration.zero) {
+    await e2ePumpFor(tester, diagnoseAfter);
+  }
+  perf?.timing(phaseName, sw.elapsed, meta: 'result=timeout');
+  fail(
+    'Timed out after ${timeout.inSeconds}s waiting for $finder. '
+    'Last exception: ${tester.takeException()}',
+  );
+}

--- a/app/integration_test/new_game_capital_panel_e2e_test.dart
+++ b/app/integration_test/new_game_capital_panel_e2e_test.dart
@@ -11,6 +11,7 @@ import 'package:colonizethis_app/features/game/flame/province_label_icon_cache.d
 import 'package:colonizethis_app/features/game/flame/resource_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/game_screen_shared.dart';
 import 'package:colonizethis_app/features/game/flame/town_icon_cache.dart';
+import 'e2e_test_shared.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_app/main.dart' show bootstrapForIntegrationTest;
 import 'package:colonizethis_app/test_support/province_panel_e2e_expected_lines.dart';
@@ -21,39 +22,13 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-class _E2ePerfLog {
-  _E2ePerfLog(this.testName);
-
-  final String testName;
-  final Map<String, int> _counters = <String, int>{};
-
-  void bumpCounter(String name, {int by = 1, String? meta}) {
-    _counters[name] = (_counters[name] ?? 0) + by;
-    final metaPart = meta == null ? '' : '|meta=$meta';
-    debugPrint(
-      'E2E_COUNTER|test=$testName|name=$name|value=${_counters[name]}$metaPart',
-    );
-  }
-
-  void timing(String phase, Duration elapsed, {String? meta}) {
-    final metaPart = meta == null ? '' : '|meta=$meta';
-    debugPrint(
-      'E2E_TIMING|test=$testName|phase=$phase|ms=${elapsed.inMilliseconds}$metaPart',
-    );
-  }
-}
+typedef _E2ePerfLog = E2ePerfLog;
 
 /// Drive frames without [WidgetTester.pumpAndSettle]: new-game progress uses a
 /// non-idle [CircularProgressIndicator], and the in-game Flame view keeps tickers
 /// active, so settle would hang or time out indefinitely.
-Future<void> _pumpFor(WidgetTester tester, Duration total) async {
-  const step = Duration(milliseconds: 50);
-  var elapsed = Duration.zero;
-  while (elapsed < total) {
-    await tester.pump(step);
-    elapsed += step;
-  }
-}
+Future<void> _pumpFor(WidgetTester tester, Duration total) =>
+    e2ePumpFor(tester, total);
 
 Future<void> _waitUntilFound(
   WidgetTester tester,
@@ -62,25 +37,14 @@ Future<void> _waitUntilFound(
   Duration diagnoseAfter = Duration.zero,
   _E2ePerfLog? perf,
   String phaseName = 'wait_until_found',
-}) async {
-  final sw = Stopwatch()..start();
-  perf?.bumpCounter('wait_until_found_calls', meta: 'phase=$phaseName');
-  while (sw.elapsed < timeout) {
-    await tester.pump(const Duration(milliseconds: 100));
-    if (finder.evaluate().isNotEmpty) {
-      perf?.timing(phaseName, sw.elapsed, meta: 'result=found');
-      return;
-    }
-  }
-  if (diagnoseAfter > Duration.zero) {
-    await _pumpFor(tester, diagnoseAfter);
-  }
-  perf?.timing(phaseName, sw.elapsed, meta: 'result=timeout');
-  fail(
-    'Timed out after ${timeout.inSeconds}s waiting for $finder. '
-    'Last exception: ${tester.takeException()}',
-  );
-}
+}) => e2eWaitUntilFound(
+  tester,
+  finder,
+  timeout: timeout,
+  diagnoseAfter: diagnoseAfter,
+  perf: perf,
+  phaseName: phaseName,
+);
 
 void _collectTextPreorder(Element element, List<String> out) {
   final w = element.widget;

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
@@ -1,27 +1,5 @@
 part of 'new_game_fleet_reaches_new_world_e2e_test.dart';
 
-class _E2ePerfLog {
-  _E2ePerfLog(this.testName);
-
-  final String testName;
-  final Map<String, int> _counters = <String, int>{};
-
-  void bumpCounter(String name, {int by = 1, String? meta}) {
-    _counters[name] = (_counters[name] ?? 0) + by;
-    final metaPart = meta == null ? '' : '|meta=$meta';
-    debugPrint(
-      'E2E_COUNTER|test=$testName|name=$name|value=${_counters[name]}$metaPart',
-    );
-  }
-
-  void timing(String phase, Duration elapsed, {String? meta}) {
-    final metaPart = meta == null ? '' : '|meta=$meta';
-    debugPrint(
-      'E2E_TIMING|test=$testName|phase=$phase|ms=${elapsed.inMilliseconds}$metaPart',
-    );
-  }
-}
-
 /// Locked full-init may succeed only after [GameService] bumps `mapSeed` on a
 /// topology/assigner retry (`effectiveSeed + 100003`, …), producing longer
 /// coast→warp→New World paths than nominal seed-42 alone. Keep this above the
@@ -40,41 +18,6 @@ const Duration _kBootstrapNewGameOverallCap = Duration(seconds: 60);
 ///
 /// E2E policy caps wall-clock runtime to 5 minutes so PR feedback remains fast.
 const Duration _kFleetE2eMaxWallClock = Duration(minutes: 5);
-
-/// Drive frames without [WidgetTester.pumpAndSettle] (Flame + progress spinners).
-Future<void> _pumpFor(WidgetTester tester, Duration total) async {
-  const step = Duration(milliseconds: 50);
-  var elapsed = Duration.zero;
-  while (elapsed < total) {
-    await tester.pump(step);
-    elapsed += step;
-  }
-}
-
-Future<void> _waitUntilFound(
-  WidgetTester tester,
-  Finder finder, {
-  Duration timeout = _kMaxUiResponseWait,
-  _E2ePerfLog? perf,
-  String phaseName = 'wait_until_found',
-}) async {
-  final cap = timeout > _kMaxUiResponseWait ? _kMaxUiResponseWait : timeout;
-  final sw = Stopwatch()..start();
-  perf?.bumpCounter('wait_until_found_calls', meta: 'phase=$phaseName');
-  while (sw.elapsed < cap) {
-    await tester.pump(const Duration(milliseconds: 50));
-    if (finder.evaluate().isNotEmpty) {
-      perf?.timing(phaseName, sw.elapsed, meta: 'result=found');
-      return;
-    }
-  }
-  perf?.timing(phaseName, sw.elapsed, meta: 'result=timeout');
-  fail(
-    'Timed out after ${cap.inSeconds}s waiting for $finder '
-    '(max UI response ${_kMaxUiResponseWait.inSeconds}s). '
-    'Last exception: ${tester.takeException()}',
-  );
-}
 
 /// Dismisses blocking bottom sheets, dialog shells, snackbars, and generic OKs.
 ///
@@ -373,7 +316,12 @@ Future<void> _pickMoveDestinationAndConfirm(
   }
 
   ensureBudget('start');
-  await _pumpFor(tester, const Duration(milliseconds: 200));
+  await _waitUntilFound(
+    tester,
+    find.byType(AlertDialog),
+    timeout: const Duration(seconds: 2),
+    phaseName: 'wait_until_found_move_dialog',
+  );
   final warpSuffix = l10n.moveFleet_warpLinkToRegion(
     unitsPanelRegionLabel('newWorld'),
   );
@@ -394,10 +342,10 @@ Future<void> _pickMoveDestinationAndConfirm(
     }
     if (scrollable.evaluate().isNotEmpty) {
       final sc = scrollable.first;
-      for (var i = 0; i < 36 && warp.hitTestable().evaluate().isEmpty; i++) {
+      for (var i = 0; i < 24 && warp.hitTestable().evaluate().isEmpty; i++) {
         ensureBudget('warp drag $i');
         await tester.drag(sc, const Offset(0, -120));
-        await _pumpFor(tester, const Duration(milliseconds: 50));
+        await tester.pump(const Duration(milliseconds: 25));
       }
       if (warp.hitTestable().evaluate().isEmpty) {
         fail(
@@ -425,12 +373,23 @@ Future<void> _pickMoveDestinationAndConfirm(
     expect(seaRadio, findsWidgets);
     await tester.tap(seaRadio.first, warnIfMissed: false);
   }
-  await _pumpFor(tester, const Duration(milliseconds: 200));
+  await _waitUntilFound(
+    tester,
+    find.text(l10n.common_confirm),
+    timeout: const Duration(seconds: 2),
+    phaseName: 'wait_until_found_move_confirm',
+  );
   ensureBudget('confirm');
   final confirm = find.text(l10n.common_confirm).hitTestable();
   expect(confirm, findsWidgets);
   await tester.tap(confirm.first, warnIfMissed: false);
-  await _pumpFor(tester, const Duration(milliseconds: 300));
+  final dialogGone = Stopwatch()..start();
+  while (dialogGone.elapsed < const Duration(seconds: 2)) {
+    if (find.byType(AlertDialog).evaluate().isEmpty) {
+      break;
+    }
+    await tester.pump(const Duration(milliseconds: 25));
+  }
   ensureBudget('after confirm');
 }
 
@@ -457,14 +416,25 @@ Future<void> _tryNavalMoveSegment(
     );
     return;
   }
-  await _pumpFor(tester, const Duration(milliseconds: 300));
+  await _waitUntilFound(
+    tester,
+    find.byType(AlertDialog),
+    timeout: const Duration(seconds: 2),
+    phaseName: 'wait_until_found_move_dialog_after_tap',
+  );
   // No legal sea-step this turn: close dialog and rely on the outer loop +
   // next turn (Refs #1831 heuristic path).
   if (find.text(l10n.moveFleet_noAdjacentSeaZones).evaluate().isNotEmpty) {
     final cancel = find.text(l10n.common_cancel).hitTestable();
     expect(cancel, findsOneWidget);
     await tester.tap(cancel, warnIfMissed: false);
-    await _pumpFor(tester, const Duration(milliseconds: 250));
+    final cancelGone = Stopwatch()..start();
+    while (cancelGone.elapsed < const Duration(seconds: 2)) {
+      if (find.byType(AlertDialog).evaluate().isEmpty) {
+        break;
+      }
+      await tester.pump(const Duration(milliseconds: 25));
+    }
     perf?.timing(
       'fleet_move_segment',
       phaseSw.elapsed,

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:colonizethis_app/config/ct_e2e.dart';
 import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
 import 'package:colonizethis_app/features/game/widgets/units/shared/units_panel_region_label.dart';
+import 'e2e_test_shared.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart'
     show
         OrderEngine,
@@ -28,6 +29,25 @@ import 'package:integration_test/integration_test.dart';
 
 part 'new_game_fleet_reaches_new_world_e2e_helpers.dart';
 part 'new_game_fleet_reaches_new_world_e2e_helpers_part2.dart';
+
+typedef _E2ePerfLog = E2ePerfLog;
+
+Future<void> _pumpFor(WidgetTester tester, Duration total) =>
+    e2ePumpFor(tester, total);
+
+Future<void> _waitUntilFound(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = _kMaxUiResponseWait,
+  _E2ePerfLog? perf,
+  String phaseName = 'wait_until_found',
+}) => e2eWaitUntilFound(
+  tester,
+  finder,
+  timeout: timeout,
+  perf: perf,
+  phaseName: phaseName,
+);
 
 void main() {
   suppressLogsForTests();

--- a/app/integration_test/new_game_full_turn_e2e_test.dart
+++ b/app/integration_test/new_game_full_turn_e2e_test.dart
@@ -11,6 +11,7 @@ import 'package:colonizethis_app/features/game/flame/province_label_icon_cache.d
 import 'package:colonizethis_app/features/game/flame/resource_icon_cache.dart';
 import 'package:colonizethis_app/features/game/flame/game_screen_shared.dart';
 import 'package:colonizethis_app/features/game/flame/town_icon_cache.dart';
+import 'e2e_test_shared.dart';
 import 'package:colonizethis_app/l10n/l10n.dart';
 import 'package:colonizethis_app/main.dart' show bootstrapForIntegrationTest;
 import 'package:colonizethis_app/test_support/civilian_units_panel_e2e_expected_lines.dart';
@@ -25,36 +26,10 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-class _E2ePerfLog {
-  _E2ePerfLog(this.testName);
+typedef _E2ePerfLog = E2ePerfLog;
 
-  final String testName;
-  final Map<String, int> _counters = <String, int>{};
-
-  void bumpCounter(String name, {int by = 1, String? meta}) {
-    _counters[name] = (_counters[name] ?? 0) + by;
-    final metaPart = meta == null ? '' : '|meta=$meta';
-    debugPrint(
-      'E2E_COUNTER|test=$testName|name=$name|value=${_counters[name]}$metaPart',
-    );
-  }
-
-  void timing(String phase, Duration elapsed, {String? meta}) {
-    final metaPart = meta == null ? '' : '|meta=$meta';
-    debugPrint(
-      'E2E_TIMING|test=$testName|phase=$phase|ms=${elapsed.inMilliseconds}$metaPart',
-    );
-  }
-}
-
-Future<void> _pumpFor(WidgetTester tester, Duration total) async {
-  const step = Duration(milliseconds: 50);
-  var elapsed = Duration.zero;
-  while (elapsed < total) {
-    await tester.pump(step);
-    elapsed += step;
-  }
-}
+Future<void> _pumpFor(WidgetTester tester, Duration total) =>
+    e2ePumpFor(tester, total);
 
 Future<void> _waitUntilFound(
   WidgetTester tester,
@@ -62,22 +37,13 @@ Future<void> _waitUntilFound(
   required Duration timeout,
   _E2ePerfLog? perf,
   String phaseName = 'wait_until_found',
-}) async {
-  final sw = Stopwatch()..start();
-  perf?.bumpCounter('wait_until_found_calls', meta: 'phase=$phaseName');
-  while (sw.elapsed < timeout) {
-    await tester.pump(const Duration(milliseconds: 100));
-    if (finder.evaluate().isNotEmpty) {
-      perf?.timing(phaseName, sw.elapsed, meta: 'result=found');
-      return;
-    }
-  }
-  perf?.timing(phaseName, sw.elapsed, meta: 'result=timeout');
-  fail(
-    'Timed out after ${timeout.inSeconds}s waiting for $finder. '
-    'Last exception: ${tester.takeException()}',
-  );
-}
+}) => e2eWaitUntilFound(
+  tester,
+  finder,
+  timeout: timeout,
+  perf: perf,
+  phaseName: phaseName,
+);
 
 Future<void> _dismissTransientUi(
   WidgetTester tester, {


### PR DESCRIPTION
## Summary
- Extract shared `E2ePerfLog`, adaptive wait, and frame-pump helpers into `app/integration_test/e2e_test_shared.dart`, then wire the capital panel, full-turn, and fleet suites to use the shared helper surface.
- Reduce high-cost fixed waits in the fleet move path by replacing fixed post-tap delays with condition waits and shorter dialog-close polling, and cap move-dialog drag probes from 36 to 24 for faster fallback scanning.
- Keep this PR as a targeted slice toward #2336 focused on helper de-duplication and H1–H4-adjacent move-loop wait reductions without changing production app/game logic.

## Implemented in this PR
- Shared helper extraction for:
  - perf counters/timing log utility
  - adaptive `waitUntilFound` polling helper
  - fixed-step pump helper
- Fleet move wait-path tightening in:
  - `_tryNavalMoveSegment`
  - `_pickMoveDestinationAndConfirm`

## Deferred Work
- Remaining #2336 AC scope (including full H1–H10 coverage, serial asset preload once/parallelization, broader helper extraction set, and baseline-vs-after runtime measurement table AC8–AC10 evidence) is intentionally deferred to follow-up slices.

## Test plan
- [x] `flutter analyze integration_test/e2e_test_shared.dart integration_test/new_game_fleet_reaches_new_world_e2e_test.dart integration_test/new_game_full_turn_e2e_test.dart integration_test/new_game_capital_panel_e2e_test.dart`
- [ ] `flutter test integration_test/new_game_fleet_reaches_new_world_e2e_test.dart --dart-define=CT_E2E=true`
- [ ] `flutter test integration_test/new_game_full_turn_e2e_test.dart --dart-define=CT_E2E=true`
- [ ] `flutter test integration_test/new_game_capital_panel_e2e_test.dart --dart-define=CT_E2E=true`

Refs #2336

Made with [Cursor](https://cursor.com)