### PR TITLE
Optimize army migration membership lookup hot path

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/army_migration.dart
+++ b/packages/colonizethis_logic/lib/src/world/army_migration.dart
@@ -46,6 +46,7 @@ bool _armiesMatchUnits(Game game) {
   final militaryUnits = allUnitsFromWorld(
     ws,
   ).where((u) => isMilitaryUnit(u.type)).toList();
+  final militaryUnitIds = {for (final unit in militaryUnits) unit.id};
   if (ws.armies.isEmpty) {
     return militaryUnits.isEmpty;
   }
@@ -60,7 +61,7 @@ bool _armiesMatchUnits(Game game) {
     if (claimed[u.id] == null) return false;
   }
   for (final uid in claimed.keys) {
-    if (!militaryUnits.any((u) => u.id == uid)) return false;
+    if (!militaryUnitIds.contains(uid)) return false;
   }
   for (final a in ws.armies) {
     for (final uid in a.regimentUnitIds) {


### PR DESCRIPTION
## Summary
- Replace `_armiesMatchUnits` claimed-unit membership verification from repeated linear scans to O(1) set lookup via a precomputed military unit id set.
- Keep behavior unchanged; only hot-path validation cost is reduced.
- Refs #2316

## Implemented in this PR
- `packages/colonizethis_logic/lib/src/world/army_migration.dart`
  - Build `militaryUnitIds` once from `militaryUnits`.
  - Use `militaryUnitIds.contains(uid)` instead of `militaryUnits.any(...)` in the claimed-id validation loop.

## Deferred work
- Remaining #2316 optimization items across turn, combat, fog, and other world/economy hotspots are intentionally deferred to follow-up slices.
- This PR is a partial delivery focused on one isolatable item (issue item #14).

## AC / issue coverage now
- Addresses: "_armiesMatchUnits uses militaryUnits.any(...) for each claimed id; use a Set for membership."
- Not yet addressed: other issue ACs and optimization items.

## Test plan
- [x] `cd packages/colonizethis_logic && dart test test/army_integration_ensure_reconcile_test.dart`

Made with [Cursor](https://cursor.com)