### PR TITLE
perf(logic): hoist per-order/per-battle computation in alliance, naval, connectivity, and combat hot paths

### DIFF
--- a/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
@@ -236,23 +236,26 @@ List<BattleContextSea> filterBattlesByInterception(
 ) {
   if (battles.isEmpty) return battles;
   final rng = _SeededRng(seed);
+
+  // Pre-index moved fleets at sea by (seaZoneId, ownerId) to avoid O(fleets)
+  // scan per battle.
+  final movedAtSeaByZoneAndOwner = <String, Set<String>>{};
+  for (final f in game.worldState.fleets) {
+    if (!f.isAtSea || f.seaZoneId == null) continue;
+    if (!movedFleetIds.contains(f.id)) continue;
+    movedAtSeaByZoneAndOwner
+        .putIfAbsent('${f.seaZoneId}|${f.ownerId}', () => {})
+        .add(f.id);
+  }
+
+  bool ownerMovedInZone(String ownerId, String zone) =>
+      movedAtSeaByZoneAndOwner.containsKey('$zone|$ownerId');
+
   final out = <BattleContextSea>[];
   for (final battle in battles) {
     final zone = battle.seaZoneId;
-    final owner1Moved = game.worldState.fleets.any(
-      (f) =>
-          f.isAtSea &&
-          f.seaZoneId == zone &&
-          f.ownerId == battle.side1.ownerId &&
-          movedFleetIds.contains(f.id),
-    );
-    final owner2Moved = game.worldState.fleets.any(
-      (f) =>
-          f.isAtSea &&
-          f.seaZoneId == zone &&
-          f.ownerId == battle.side2.ownerId &&
-          movedFleetIds.contains(f.id),
-    );
+    final owner1Moved = ownerMovedInZone(battle.side1.ownerId, zone);
+    final owner2Moved = ownerMovedInZone(battle.side2.ownerId, zone);
     final side1InterceptScore = _fleetInterceptScore(battle.side1.shipTypeIds);
     final side2InterceptScore = _fleetInterceptScore(battle.side2.shipTypeIds);
     final side1FleeScore = _fleetFleeScore(battle.side1.shipTypeIds);

--- a/packages/colonizethis_logic/lib/src/combat/quick_battle_resolver_outcome.dart
+++ b/packages/colonizethis_logic/lib/src/combat/quick_battle_resolver_outcome.dart
@@ -96,24 +96,24 @@ int _sumAliveGunHp(List<_MutableEmplacedGun> guns) {
 
 void _applyRoundRobinGunHpDamage(List<_MutableEmplacedGun> guns, int amount) {
   if (amount <= 0) return;
-  // Maintain the alive list incrementally to avoid O(amount * n log n) work:
-  // sort once up front, then only rebuild when a gun reaches 0 HP. The list
-  // is sorted by id, so surviving guns retain their relative order, which is
-  // the determinism guarantee the original per-iteration rebuild provides.
-  var alive = guns.where((g) => g.hp > 0).toList()
+  // Sort once up front by id for determinism; then remove dead guns in-place
+  // instead of rebuilding the whole list from [guns] on each death.
+  final alive = guns.where((g) => g.hp > 0).toList()
     ..sort((a, b) => a.id.compareTo(b.id));
   if (alive.isEmpty) return;
   var remaining = amount;
-  var turn = 0;
-  while (remaining > 0) {
-    final target = alive[turn % alive.length];
+  var idx = 0;
+  while (remaining > 0 && alive.isNotEmpty) {
+    idx = idx % alive.length;
+    final target = alive[idx];
     target.hp -= 1;
     remaining--;
-    turn++;
     if (target.hp <= 0) {
-      alive = guns.where((g) => g.hp > 0).toList()
-        ..sort((a, b) => a.id.compareTo(b.id));
-      if (alive.isEmpty) break;
+      alive.removeAt(idx);
+      // idx stays the same so the next gun (now shifted into this slot) is
+      // processed next; no need to increment.
+    } else {
+      idx++;
     }
   }
 }

--- a/packages/colonizethis_logic/lib/src/diplomacy/alliance_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/alliance_resolver.dart
@@ -13,10 +13,11 @@ Game resolveJoinEmpireColony(
   Map<String, List<DiplomaticOrder>> diploByPlayer,
   int turn,
 ) {
+  var factionMembership = DiplomacyFactionMembership.from(game);
   for (final entry in diploByPlayer.entries) {
     final gpId = entry.key;
     for (final order in entry.value) {
-      final factionMembership = DiplomacyFactionMembership.from(game);
+      final prev = game;
       game = _resolveJoinEmpireOrderIfApplicable(
         game,
         gpId,
@@ -24,6 +25,9 @@ Game resolveJoinEmpireColony(
         turn,
         factionMembership,
       );
+      if (!identical(game, prev)) {
+        factionMembership = DiplomacyFactionMembership.from(game);
+      }
     }
   }
   return game;

--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -122,6 +122,8 @@ Map<String, ConnectivityResult> resolveConnectivity({
   final blockadedByPlayer =
       blockadedPortProvincesByPlayerId ??
       computeBlockadedPortProvincesByPlayer(game, topology);
+  // Pre-compute once for all players; worldState is fixed across the player loop.
+  final portInfo = _portToProvinceSeaZone(game.worldState);
   final result = <String, ConnectivityResult>{};
 
   for (final player in game.players) {
@@ -139,6 +141,7 @@ Map<String, ConnectivityResult> resolveConnectivity({
       tileMapByRegion: tileMapByRegion,
       topology: topology,
       provinceIdsByType: provinceIdsByType,
+      portInfo: portInfo,
       blockadedPortProvinces: blockadedByPlayer[player.id] ?? const {},
     );
     result[player.id] = cr;
@@ -296,6 +299,7 @@ ConnectivityResult _connectedTilesForPlayer({
   required Map<String, TileMapResult> tileMapByRegion,
   required MapTopology topology,
   required Set<String> provinceIdsByType,
+  required Map<String, (String, String)> portInfo,
   Set<String> blockadedPortProvinces = const {},
 }) {
   final worldState = game.worldState;
@@ -310,7 +314,6 @@ ConnectivityResult _connectedTilesForPlayer({
   if (mapOpt == null) return const ConnectivityResult(connected: {});
 
   final capitalKey = capital.toTileKey();
-  final portInfo = _portToProvinceSeaZone(worldState);
   final connected = <String>{capitalKey};
   final pathCap = <String, int>{};
   pathCap[capitalKey] = _transportLevelAtTile(worldState, capitalKey, portInfo);

--- a/tool/logic_all_provinces_sanctions.yaml
+++ b/tool/logic_all_provinces_sanctions.yaml
@@ -16,13 +16,13 @@ sanctions:
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
   - path: packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
-    line: 226
+    line: 229
     rationale: Global connectivity / capital path checks require all province rows.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
   - path: packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
-    line: 533
+    line: 536
     rationale: Global connectivity evaluation iterates all provinces.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2278


### PR DESCRIPTION
## Summary

Partial slice of #2316: eliminate per-iteration expensive object construction and repeated fleet/port scans across four hot-path sites in `colonizethis_logic`.

## Implemented in this PR

### 1. `diplomacy/alliance_resolver.dart` — issue item #18
- `DiplomacyFactionMembership.from(game)` was constructed inside the inner order loop (O(orders) constructions per player).
- Now built once before the outer player loop and only rebuilt when `game` mutates (i.e., on a successful `joinEmpire` absorption), preserving correctness.

### 2. `combat/naval_combat_resolver.dart` — issue item #20
- `filterBattlesByInterception`: two `game.worldState.fleets.any(...)` calls per battle each scanned all fleets.
- Replaced with a single pre-index pass over fleets into a `Map<"seaZoneId|ownerId", Set<fleetId>>` before the battle loop, giving O(1) per-battle moved-owner lookups.

### 3. `world/connectivity_resolver.dart` — issue item #16
- `_portToProvinceSeaZone(worldState)` was called once per player inside `_connectedTilesForPlayer` despite the worldState being fixed across the player loop in `resolveConnectivity`.
- Pre-computed once in `resolveConnectivity` and passed as a required parameter, eliminating redundant per-player port-map builds.

### 4. `combat/quick_battle_resolver_outcome.dart` — issue item #8
- `_applyRoundRobinGunHpDamage` previously rebuilt the entire alive-gun list from scratch (full scan + sort) on every gun death.
- Now removes the dead gun from the alive list in-place and advances the index correctly, avoiding O(guns) scan+sort per death.

## Deferred work

All other #2316 optimization items not listed above remain deferred (items #1, #2, #3, #4, #5, #6, #7, #9, #10, #11, #12, #13, #14, #15, #17, #19, #21, #22, #23). Many of these have already been addressed in prior PRs; see the issue for current status.

## AC / issue coverage now

- Alliance order loop: `DiplomacyFactionMembership` not rebuilt per order — **addressed**.
- Fleet scan per battle: O(1) lookup replaces O(fleets) scans in `filterBattlesByInterception` — **addressed**.
- Port-info map not rebuilt per player in connectivity — **addressed**.
- `_applyRoundRobinGunHpDamage` no full-rebuild on gun death — **addressed**.

## Tests

- `dart test packages/colonizethis_logic/test/combat/ packages/colonizethis_logic/test/diplomacy/ packages/colonizethis_logic/test/world/` — all 86 tests passed.
- 6 pre-existing failures in `turn_trace_schema_validation_test.dart` (missing schema files, unrelated to this PR) are unchanged.

Refs #2316

Made with [Cursor](https://cursor.com)