### PR TITLE
logic: single sort for defender armies in detectConflicts (Refs #2316)

### DIFF
--- a/packages/colonizethis_logic/lib/src/combat/conflict_detection.dart
+++ b/packages/colonizethis_logic/lib/src/combat/conflict_detection.dart
@@ -262,16 +262,15 @@ List<BattleContext> detectConflicts(Game game, Orders orders) {
         ..retainWhere(
           (army) => army.regimentUnitIds.any(defenderUnitIdSet.contains),
         )
-        ..sort((a, b) => a.id.compareTo(b.id));
-      String? primaryDefenderArmyId;
-      if (defenderArmies.isNotEmpty) {
-        defenderArmies.sort((a, b) {
+        ..sort((a, b) {
           final countCmp = b.regimentUnitIds.length.compareTo(
             a.regimentUnitIds.length,
           );
           if (countCmp != 0) return countCmp;
           return a.id.compareTo(b.id);
         });
+      String? primaryDefenderArmyId;
+      if (defenderArmies.isNotEmpty) {
         primaryDefenderArmyId = defenderArmies.first.id;
       }
 


### PR DESCRIPTION
## Refs #2316

### Implemented in this PR
- `detectConflicts`: remove redundant first sort (by army id only) of the defender army list; the list was immediately re-sorted by regiment count then id. Final ordering and `primaryDefenderArmyId` are unchanged; one fewer `O(k log k)` sort per province that builds a battle context.

### Context
Upstream `dev` already contains most of the issue’s listed hot-path wins (guarded `toJson` in `turn_phase_runner`, hoisted maps in movement/army paths, trade interception single scan, province visibility index, quick battle gun HP path, etc.). This PR is a small additional slice aligned with the issue’s conflict-detection / redundant-work theme.

### Deferred (still on #2316)
- Remaining P0–P2 items from the issue body where not already satisfied on `dev` (e.g. further CI/lint gates, characterization ceilings, any follow-ups not covered here).

### Tests
- `dart test test/conflict_detection_test.dart test/conflict_detection_army_index_test.dart` (colonizethis_logic)

### SPEC
- None (semantics-preserving optimization only).


Made with [Cursor](https://cursor.com)