### PR TITLE
perf(logic): hoist GP ids and cache moved-into set in detectConflicts (Refs #2316)

### DIFF
--- a/packages/colonizethis_logic/lib/src/combat/conflict_detection.dart
+++ b/packages/colonizethis_logic/lib/src/combat/conflict_detection.dart
@@ -114,11 +114,10 @@ List<BattleContext> detectConflicts(Game game, Orders orders) {
     game.worldState.armies,
   );
   final unitById = unitsByIdFromWorld(game.worldState);
+  final gpIds = {for (final p in game.players) p.id};
 
   void processRegion(RegionData region) {
     if (region.units.isEmpty) return;
-
-    final gpIds = {for (final p in game.players) p.id};
 
     final unitsByProvince = <String, List<Unit>>{};
     for (final u in region.units) {
@@ -181,6 +180,8 @@ List<BattleContext> detectConflicts(Game game, Orders orders) {
 
       final province = provinceById[provinceId];
       if (province == null) continue;
+      final factionsMovedIntoProvince =
+          movedIntoByFaction[provinceId] ?? const <String>{};
       final ownerId = province.ownerId;
 
       String defenderFactionId;
@@ -189,7 +190,7 @@ List<BattleContext> detectConflicts(Game game, Orders orders) {
           factionsPresent.contains(ownerId)) {
         defenderFactionId = ownerId;
       } else {
-        final movers = movedIntoByFaction[provinceId] ?? {};
+        final movers = factionsMovedIntoProvince;
         final nonMovers = factionsPresent.difference(movers);
         if (nonMovers.isEmpty) {
           defenderFactionId = factionsPresent.reduce(
@@ -202,7 +203,7 @@ List<BattleContext> detectConflicts(Game game, Orders orders) {
         }
       }
 
-      final attackerFactionIds = (movedIntoByFaction[provinceId] ?? {})
+      final attackerFactionIds = factionsMovedIntoProvince
           .where((f) => f != defenderFactionId && gpIds.contains(f))
           .toList();
       final attackerFactionIdSet = attackerFactionIds.toSet();


### PR DESCRIPTION
## Refs #2316

### Implemented in this PR
- `detectConflicts`: build the great-power id `Set` once per call (used for both `oldWorld` and `newWorld` region passes) instead of once per region.
- Per contested province, cache `movedIntoByFaction[provinceId]` once as `factionsMovedIntoProvince` (replacing three separate map lookups with the same semantics; empty case uses `const <String>{}`).

### Deferred (still on #2316)
- Remaining P0–P3 / CI items from the issue where not already satisfied on `dev` (e.g. repo lint gates, characterization ceilings, any other follow-ups).

### Tests
- `dart test test/conflict_detection_test.dart test/conflict_detection_army_index_test.dart` (`colonizethis_logic`)

### SPEC
- None (semantics-preserving optimization only).


Made with [Cursor](https://cursor.com)