### PR TITLE
perf(logic): gate hot-path debug logs on Logger.level (Refs #2316)

### DIFF
--- a/packages/colonizethis_logic/lib/src/economy/sea_transport.dart
+++ b/packages/colonizethis_logic/lib/src/economy/sea_transport.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
 
 import '../diplomacy/diplomacy_relation_lookup.dart';
 import '../world/naval.dart';
@@ -67,6 +68,7 @@ void logExtractionAutoTransportOverseasAllocation({
   required Map<CommodityId, int> allocatedToStockpile,
 }) {
   if (overseasTotals.isEmpty) return;
+  if (Level.debug.value < Logger.level.value) return;
   final overseasTotalUnits = overseasTotals.values.fold<int>(
     0,
     (a, b) => a + b,
@@ -90,6 +92,7 @@ void _logExtractionAutoTransportInterception(
   Map<CommodityId, int> before,
   Map<CommodityId, int> after,
 ) {
+  if (Level.debug.value < Logger.level.value) return;
   final beforeUnits = before.values.fold<int>(0, (s, v) => s + v);
   final afterUnits = after.values.fold<int>(0, (s, v) => s + v);
   final ids = {...before.keys, ...after.keys};

--- a/packages/colonizethis_logic/lib/src/world/army_movement.dart
+++ b/packages/colonizethis_logic/lib/src/world/army_movement.dart
@@ -10,6 +10,25 @@ import 'province_lookup.dart';
 
 final _log = packageLogger();
 
+void _logArmyMoveIgnoredHomeArmyIfDebug(String armyId) {
+  if (Level.debug.value >= Logger.level.value) {
+    _log.d('army_move ignored reason=home_army_locked armyId=$armyId');
+  }
+}
+
+void _logArmyMoveIgnoredInvalidAdjacencyIfDebug(
+  String armyId,
+  String fromLocal,
+  String toLocal,
+) {
+  if (Level.debug.value >= Logger.level.value) {
+    _log.d(
+      'army_move ignored reason=invalid_adjacency armyId=$armyId '
+      'from=$fromLocal to=$toLocal',
+    );
+  }
+}
+
 /// Applies army moves in [regionId] (same-region leg). See [applyMoveOrdersToRegion].
 ///
 /// When [onArmyMoveOrderTrace] is set, each order processed by this region pass
@@ -50,11 +69,7 @@ WorldState applyArmyMoveOrdersToRegion(
       }
       if (army.isHomeArmy) {
         ignored++;
-        if (Level.debug.value >= Logger.level.value) {
-          _log.d(
-            'army_move ignored reason=home_army_locked armyId=${order.armyId}',
-          );
-        }
+        _logArmyMoveIgnoredHomeArmyIfDebug(order.armyId);
         continue;
       }
       if (ProvinceId.regionIdFrom(army.stationedProvinceId) != regionId) {
@@ -88,12 +103,11 @@ WorldState applyArmyMoveOrdersToRegion(
           isValidLandMoveInRegion(topology, regionId, fromLocal, toLocal);
       if (!valid) {
         ignored++;
-        if (Level.debug.value >= Logger.level.value) {
-          _log.d(
-            'army_move ignored reason=invalid_adjacency armyId=${order.armyId} '
-            'from=$fromLocal to=$toLocal',
-          );
-        }
+        _logArmyMoveIgnoredInvalidAdjacencyIfDebug(
+          order.armyId,
+          fromLocal,
+          toLocal,
+        );
         onArmyMoveOrderTrace?.call(
           playerId: playerId,
           order: order,

--- a/packages/colonizethis_logic/lib/src/world/army_movement.dart
+++ b/packages/colonizethis_logic/lib/src/world/army_movement.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
 
 import '../turn/trace/turn_trace_runtime.dart';
 import 'army_migration.dart';
@@ -49,9 +50,11 @@ WorldState applyArmyMoveOrdersToRegion(
       }
       if (army.isHomeArmy) {
         ignored++;
-        _log.d(
-          'army_move ignored reason=home_army_locked armyId=${order.armyId}',
-        );
+        if (Level.debug.value >= Logger.level.value) {
+          _log.d(
+            'army_move ignored reason=home_army_locked armyId=${order.armyId}',
+          );
+        }
         continue;
       }
       if (ProvinceId.regionIdFrom(army.stationedProvinceId) != regionId) {
@@ -85,10 +88,12 @@ WorldState applyArmyMoveOrdersToRegion(
           isValidLandMoveInRegion(topology, regionId, fromLocal, toLocal);
       if (!valid) {
         ignored++;
-        _log.d(
-          'army_move ignored reason=invalid_adjacency armyId=${order.armyId} '
-          'from=$fromLocal to=$toLocal',
-        );
+        if (Level.debug.value >= Logger.level.value) {
+          _log.d(
+            'army_move ignored reason=invalid_adjacency armyId=${order.armyId} '
+            'from=$fromLocal to=$toLocal',
+          );
+        }
         onArmyMoveOrderTrace?.call(
           playerId: playerId,
           order: order,

--- a/packages/colonizethis_logic/lib/src/world/movement.dart
+++ b/packages/colonizethis_logic/lib/src/world/movement.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
 
 import '../constants.dart';
 import '../turn/trace/turn_trace_runtime.dart';
@@ -397,10 +398,12 @@ _ownerMismatchPrecheck(
   String? ownerId,
   CivilianMoveOrderTraceCallback? onCivilianMoveOrderTrace,
 }) {
-  _log.d(
-    'civilian movement ignored reason=$reason unitId=${order.unitId} '
-    'orderPlayerId=$playerId${ownerId == null ? '' : ' unitOwnerId=$ownerId'}',
-  );
+  if (Level.debug.value >= Logger.level.value) {
+    _log.d(
+      'civilian movement ignored reason=$reason unitId=${order.unitId} '
+      'orderPlayerId=$playerId${ownerId == null ? '' : ' unitOwnerId=$ownerId'}',
+    );
+  }
   onCivilianMoveOrderTrace?.call(
     playerId: playerId,
     order: order,

--- a/packages/colonizethis_logic/test/movement_logging_test.dart
+++ b/packages/colonizethis_logic/test/movement_logging_test.dart
@@ -1,5 +1,4 @@
 import 'package:colonizethis_test/test.dart';
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';

--- a/packages/colonizethis_logic/test/movement_logging_test.dart
+++ b/packages/colonizethis_logic/test/movement_logging_test.dart
@@ -124,5 +124,43 @@ void main() {
         isTrue,
       );
     });
+
+    test(
+      'applyCivilianTileMoveOrdersToWorldRegions skips per-order debug work '
+      'when Logger.level is info',
+      () {
+        Logger.level = Level.info;
+        const ow = 'oldWorld';
+        final game = Game(
+          id: 'g',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(id: 'oldWorld|P1', regionId: ow, ownerId: 'p1'),
+              ],
+              units: const [],
+            ),
+            newWorld: const RegionData(),
+          ),
+          players: const [Player(id: 'p1', displayName: 'P1', isHuman: true)],
+        );
+
+        applyCivilianTileMoveOrdersToWorldRegions(
+          game,
+          {
+            'p1': [
+              const MoveOrder(unitId: 'missing', destinationTileKey: 'oldWorld|P1|0|0'),
+            ],
+          },
+        );
+
+        final lines = _civilianMovementMessages(capturedEvents);
+        expect(
+          lines.any((m) => m.contains('civilian movement ignored')),
+          isFalse,
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Implements **P3 — Debug logging in hot paths** from [#2316](https://github.com/waigore/colonizethisv3/issues/2316): avoid eager construction of debug strings and skip extraction auto-transport debug bookkeeping when `Logger.level` filters out `Level.debug` (same threshold semantics as `package:logger` `DevelopmentFilter`: log when `event.level >= Logger.level`).

## Implemented

- `movement.dart`: guard civilian ignored-move `_log.d`
- `army_movement.dart`: guard home-army and invalid-adjacency `_log.d` inside order loops
- `sea_transport.dart`: early return from overseas-allocation and interception debug helpers when debug is off (skips fold/join work too)
- Test: when `Logger.level == Level.info`, ignored civilian move does not emit `civilian movement ignored` debug lines

## Deferred (issue #2316 — remainder not in this PR)

Many P0–P2 items in the issue are **already present on `dev`** (e.g. traced `toJson` guards, movement bundle hoists, known-province indices, sea transport single-pass scan, fog fleet index, combat round-robin fix). Remaining listed work (if any) stays on the issue for follow-up.

## Tests

```bash
cd packages/colonizethis_logic && dart test test/movement_logging_test.dart test/extraction_auto_transport_logging_test.dart
```

## Spec

No SPEC change: logging-only, no game semantics.

Refs #2316


Made with [Cursor](https://cursor.com)