### PR TITLE
perf(e2e): parallel decode and adaptive waits (Refs #2336)

### DIFF
--- a/app/integration_test/e2e_test_shared.dart
+++ b/app/integration_test/e2e_test_shared.dart
@@ -1,4 +1,8 @@
+import 'dart:async';
+import 'dart:ui' as ui;
+
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class E2ePerfLog {
@@ -61,4 +65,73 @@ Future<void> e2eWaitUntilFound(
     'Timed out after ${timeout.inSeconds}s waiting for $finder. '
     'Last exception: ${tester.takeException()}',
   );
+}
+
+/// Returns after the first [Finder] has at least one hit-testable match.
+Future<void> e2eWaitUntilAnyFinderHitTestable(
+  WidgetTester tester,
+  List<Finder> finders, {
+  required Duration timeout,
+  E2ePerfLog? perf,
+  String phaseName = 'wait_until_any',
+}) async {
+  if (finders.isEmpty) {
+    return;
+  }
+  final sw = Stopwatch()..start();
+  perf?.bumpCounter('wait_until_any_calls', meta: 'phase=$phaseName');
+  var stepMs = 25;
+  while (sw.elapsed < timeout) {
+    for (final finder in finders) {
+      if (finder.hitTestable().evaluate().isNotEmpty) {
+        perf?.timing(phaseName, sw.elapsed, meta: 'result=found');
+        return;
+      }
+    }
+    await tester.pump(Duration(milliseconds: stepMs));
+    if (stepMs < 100) {
+      stepMs += 25;
+    }
+  }
+  perf?.timing(phaseName, sw.elapsed, meta: 'result=timeout');
+  fail(
+    'Timed out after ${timeout.inSeconds}s waiting for any of $finders. '
+    'Last exception: ${tester.takeException()}',
+  );
+}
+
+/// Loads and decodes each path with bounded concurrency (overlapping I/O +
+/// image decode completion) instead of strictly serial awaits.
+Future<List<String>> e2eDecodePngAssetPathsParallel(
+  List<String> assetPaths, {
+  int batchSize = 8,
+}) async {
+  final failures = <String>[];
+  for (var i = 0; i < assetPaths.length; i += batchSize) {
+    final end = i + batchSize > assetPaths.length
+        ? assetPaths.length
+        : i + batchSize;
+    final chunk = assetPaths.sublist(i, end);
+    final chunkFailures = await Future.wait(
+      chunk.map((assetPath) async {
+        try {
+          final data = await rootBundle.load(assetPath);
+          final bytes = data.buffer.asUint8List();
+          final completer = Completer<ui.Image>();
+          ui.decodeImageFromList(bytes, completer.complete);
+          final image = await completer.future;
+          image.dispose();
+          return null;
+        } catch (e) {
+          return '$assetPath ($e)';
+        }
+      }),
+    );
+    for (final message in chunkFailures) {
+      if (message != null) {
+        failures.add(message);
+      }
+    }
+  }
+  return failures;
 }

--- a/app/integration_test/new_game_capital_panel_e2e_test.dart
+++ b/app/integration_test/new_game_capital_panel_e2e_test.dart
@@ -1,6 +1,3 @@
-import 'dart:async';
-import 'dart:ui' as ui;
-
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:colonizethis_app/config/ct_e2e.dart';
 import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
@@ -111,19 +108,7 @@ Future<void> _ensureAllRelocated64pxPngsLoad() async {
         'Relocated 64px PNG manifest entries do not match expected map icon families.',
   );
 
-  final failures = <String>[];
-  for (final assetPath in assets) {
-    try {
-      final data = await rootBundle.load(assetPath);
-      final bytes = data.buffer.asUint8List();
-      final completer = Completer<ui.Image>();
-      ui.decodeImageFromList(bytes, completer.complete);
-      final image = await completer.future;
-      image.dispose();
-    } catch (e) {
-      failures.add('$assetPath ($e)');
-    }
-  }
+  final failures = await e2eDecodePngAssetPathsParallel(assets);
 
   expect(
     failures,
@@ -192,7 +177,7 @@ void main() {
 
     // Progress dialog spins forever → never use pumpAndSettle here. Also dismiss
     // game-start intro (Yarn) once the map exists under the overlay.
-    final setupDeadline = DateTime.now().add(const Duration(minutes: 6));
+    final setupDeadline = DateTime.now().add(const Duration(seconds: 60));
     var reachedMap = false;
     while (DateTime.now().isBefore(setupDeadline)) {
       await tester.pump(const Duration(milliseconds: 100));

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
@@ -215,6 +215,21 @@ Future<void> _expandEachExpansionTileOnce(WidgetTester tester) async {
   }
 }
 
+Future<bool> _pollUntilNavalPanelVisible(
+  WidgetTester tester,
+  Finder navalPanel,
+  Duration budget,
+) async {
+  final poll = Stopwatch()..start();
+  while (poll.elapsed < budget) {
+    await tester.pump(const Duration(milliseconds: 25));
+    if (navalPanel.evaluate().isNotEmpty) {
+      return true;
+    }
+  }
+  return false;
+}
+
 Future<void> _openNavalPanel(WidgetTester tester, {_E2ePerfLog? perf}) async {
   final phaseSw = Stopwatch()..start();
   final navalPanel = find.byKey(kCtE2ENavalPanelRootKey);
@@ -242,26 +257,26 @@ Future<void> _openNavalPanel(WidgetTester tester, {_E2ePerfLog? perf}) async {
     final markerHit = markerBtn.hitTestable();
     if (markerHit.evaluate().isNotEmpty) {
       await tester.tap(markerHit.first, warnIfMissed: false);
-      final poll = Stopwatch()..start();
-      while (poll.elapsed < const Duration(seconds: 2)) {
-        await tester.pump(const Duration(milliseconds: 25));
-        if (navalPanel.evaluate().isNotEmpty) {
-          perf?.timing('open_panel_naval', phaseSw.elapsed);
-          return;
-        }
+      if (await _pollUntilNavalPanelVisible(
+        tester,
+        navalPanel,
+        const Duration(seconds: 2),
+      )) {
+        perf?.timing('open_panel_naval', phaseSw.elapsed);
+        return;
       }
       continue;
     }
     final railHit = btn.hitTestable();
     if (railHit.evaluate().isNotEmpty) {
       await tester.tap(railHit.first, warnIfMissed: false);
-      final poll = Stopwatch()..start();
-      while (poll.elapsed < const Duration(seconds: 3)) {
-        await tester.pump(const Duration(milliseconds: 25));
-        if (navalPanel.evaluate().isNotEmpty) {
-          perf?.timing('open_panel_naval', phaseSw.elapsed);
-          return;
-        }
+      if (await _pollUntilNavalPanelVisible(
+        tester,
+        navalPanel,
+        const Duration(seconds: 3),
+      )) {
+        perf?.timing('open_panel_naval', phaseSw.elapsed);
+        return;
       }
     } else {
       await _dismissTransientUi(tester, perf: perf);

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
@@ -242,13 +242,27 @@ Future<void> _openNavalPanel(WidgetTester tester, {_E2ePerfLog? perf}) async {
     final markerHit = markerBtn.hitTestable();
     if (markerHit.evaluate().isNotEmpty) {
       await tester.tap(markerHit.first, warnIfMissed: false);
-      await _pumpFor(tester, const Duration(milliseconds: 250));
+      final poll = Stopwatch()..start();
+      while (poll.elapsed < const Duration(seconds: 2)) {
+        await tester.pump(const Duration(milliseconds: 25));
+        if (navalPanel.evaluate().isNotEmpty) {
+          perf?.timing('open_panel_naval', phaseSw.elapsed);
+          return;
+        }
+      }
       continue;
     }
     final railHit = btn.hitTestable();
     if (railHit.evaluate().isNotEmpty) {
       await tester.tap(railHit.first, warnIfMissed: false);
-      await _pumpFor(tester, const Duration(milliseconds: 400));
+      final poll = Stopwatch()..start();
+      while (poll.elapsed < const Duration(seconds: 3)) {
+        await tester.pump(const Duration(milliseconds: 25));
+        if (navalPanel.evaluate().isNotEmpty) {
+          perf?.timing('open_panel_naval', phaseSw.elapsed);
+          return;
+        }
+      }
     } else {
       await _dismissTransientUi(tester, perf: perf);
     }
@@ -342,10 +356,17 @@ Future<void> _pickMoveDestinationAndConfirm(
     }
     if (scrollable.evaluate().isNotEmpty) {
       final sc = scrollable.first;
-      for (var i = 0; i < 24 && warp.hitTestable().evaluate().isEmpty; i++) {
+      if (warp.hitTestable().evaluate().isEmpty) {
+        try {
+          await tester.scrollUntilVisible(warp.first, 200, scrollable: sc);
+        } catch (_) {
+          // Row may not be built yet; fall back to drag probing below.
+        }
+      }
+      for (var i = 0; i < 20 && warp.hitTestable().evaluate().isEmpty; i++) {
         ensureBudget('warp drag $i');
         await tester.drag(sc, const Offset(0, -120));
-        await tester.pump(const Duration(milliseconds: 25));
+        await tester.pump();
       }
       if (warp.hitTestable().evaluate().isEmpty) {
         fail(

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -49,7 +49,12 @@ Future<bool> _tapMoveOnFirstNonHomeFleet(WidgetTester tester) async {
           final iconHit = expandIcon.first;
           await tester.ensureVisible(iconHit);
           await tester.tap(iconHit, warnIfMissed: false);
-          await _pumpFor(tester, const Duration(milliseconds: 180));
+          await _waitUntilFound(
+            tester,
+            find.descendant(of: sub, matching: find.text('Move')),
+            timeout: const Duration(seconds: 3),
+            phaseName: 'wait_until_found_move_after_expand',
+          );
         }
         move = find.descendant(of: sub, matching: find.text('Move'));
       }
@@ -68,14 +73,24 @@ Future<bool> _tapMoveOnFirstNonHomeFleet(WidgetTester tester) async {
       }
       if (loc.evaluate().isNotEmpty) {
         await tester.tap(hit.first, warnIfMissed: false);
-        await _pumpFor(tester, const Duration(milliseconds: 400));
+        await _waitUntilFound(
+          tester,
+          find.byType(AlertDialog),
+          timeout: const Duration(seconds: 3),
+          phaseName: 'wait_until_found_move_dialog_after_move_tap',
+        );
         return true;
       }
       fallbackMove ??= hit.first;
     }
     if (fallbackMove != null) {
       await tester.tap(fallbackMove, warnIfMissed: false);
-      await _pumpFor(tester, const Duration(milliseconds: 400));
+      await _waitUntilFound(
+        tester,
+        find.byType(AlertDialog),
+        timeout: const Duration(seconds: 3),
+        phaseName: 'wait_until_found_move_dialog_after_move_tap_fallback',
+      );
       return true;
     }
     if (allowExpandAllFallback) {
@@ -395,7 +410,6 @@ Future<void> _splitHomeFleetOnce(
 }) async {
   final phaseSw = Stopwatch()..start();
   await tester.tap(find.byKey(kEmpireNavalUnitsButtonKey));
-  await _pumpFor(tester, const Duration(milliseconds: 400));
   await _waitUntilFound(
     tester,
     find.byKey(kCtE2ENavalPanelRootKey),
@@ -409,8 +423,16 @@ Future<void> _splitHomeFleetOnce(
     matching: find.text('Split'),
   );
   expect(split, findsWidgets);
-  await tester.tap(split.first);
-  await _pumpFor(tester, const Duration(milliseconds: 400));
+  await tester.tap(split.first, warnIfMissed: false);
+  await _waitUntilFound(
+    tester,
+    find.descendant(
+      of: find.byType(CtDialogShell),
+      matching: find.widgetWithText(CtNinePatchButton, '>'),
+    ),
+    timeout: const Duration(seconds: 4),
+    phaseName: 'wait_until_found_split_nudge_right',
+  );
 
   final moveOneRight = find.descendant(
     of: find.byType(CtDialogShell),
@@ -418,9 +440,14 @@ Future<void> _splitHomeFleetOnce(
   );
   expect(moveOneRight, findsWidgets);
   await tester.tap(moveOneRight.first);
-  await _pumpFor(tester, const Duration(milliseconds: 200));
+  await _waitUntilFound(
+    tester,
+    find.text(l10n.splitFleet_confirm),
+    timeout: const Duration(seconds: 4),
+    phaseName: 'wait_until_found_split_confirm',
+  );
   await tester.tap(find.text(l10n.splitFleet_confirm));
-  await _pumpFor(tester, const Duration(milliseconds: 300));
+  await _pumpFor(tester, const Duration(milliseconds: 120));
   await _expandEachExpansionTileOnce(tester);
   perf?.timing('fleet_split', phaseSw.elapsed);
 }
@@ -453,7 +480,7 @@ Future<void> _openCivilianPanelFleetE2e(WidgetTester tester) async {
       return false;
     }
     await tester.tap(tappable.first, warnIfMissed: false);
-    await _pumpFor(tester, const Duration(milliseconds: 250));
+    await tester.pump();
     final openDeadline = DateTime.now().add(const Duration(seconds: 3));
     while (DateTime.now().isBefore(openDeadline)) {
       await tester.pump(const Duration(milliseconds: 100));
@@ -499,7 +526,7 @@ Future<bool> _anyExplorerHasEnabledExploreAssignFleetE2e(
   );
   expect(panelScrollable, findsOneWidget);
   final visitedAssignWidgets = <int>{};
-  const maxPanelSweepSteps = 24;
+  const maxPanelSweepSteps = 16;
   for (var step = 0; step < maxPanelSweepSteps; step++) {
     final assignCandidates = find
         .descendant(of: listView, matching: find.text('Assign'))
@@ -573,4 +600,3 @@ Future<void> _advanceOneHumanTurn(
     '(before=${before ?? '(null)'}). Last exception: ${tester.takeException()}',
   );
 }
-

--- a/app/integration_test/new_game_full_turn_e2e_test.dart
+++ b/app/integration_test/new_game_full_turn_e2e_test.dart
@@ -1,6 +1,3 @@
-import 'dart:async';
-import 'dart:ui' as ui;
-
 import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:colonizethis_app/config/ct_e2e.dart';
 import 'package:colonizethis_app/config/ct_e2e_last_panel_snapshot.dart';
@@ -91,7 +88,7 @@ Future<void> _openCivilianPanel(
       return false;
     }
     await tester.tap(tappable.first, warnIfMissed: false);
-    await _pumpFor(tester, const Duration(milliseconds: 250));
+    await tester.pump();
     final openDeadline = DateTime.now().add(const Duration(seconds: 3));
     while (DateTime.now().isBefore(openDeadline)) {
       await tester.pump(const Duration(milliseconds: 100));
@@ -149,7 +146,14 @@ Future<void> _openPanelFromMarker(
       continue;
     }
     await tester.tap(tappable.first, warnIfMissed: false);
-    await _pumpFor(tester, const Duration(milliseconds: 300));
+    final openDeadline = DateTime.now().add(const Duration(seconds: 3));
+    while (DateTime.now().isBefore(openDeadline)) {
+      await tester.pump(const Duration(milliseconds: 50));
+      if (panelRoot.evaluate().isNotEmpty) {
+        perf?.timing('open_panel_from_marker', sw.elapsed);
+        return;
+      }
+    }
   }
   fail(
     'Timed out after ${timeout.inSeconds}s opening marker panel. '
@@ -206,19 +210,7 @@ Future<void> _ensureAllRelocated64pxPngsLoad() async {
   expect(assets.length, expectedAssets.length);
   expect(assets, orderedEquals(expectedSorted));
 
-  final failures = <String>[];
-  for (final assetPath in assets) {
-    try {
-      final data = await rootBundle.load(assetPath);
-      final bytes = data.buffer.asUint8List();
-      final completer = Completer<ui.Image>();
-      ui.decodeImageFromList(bytes, completer.complete);
-      final image = await completer.future;
-      image.dispose();
-    } catch (e) {
-      failures.add('$assetPath ($e)');
-    }
-  }
+  final failures = await e2eDecodePngAssetPathsParallel(assets);
   expect(failures, isEmpty);
 }
 
@@ -264,7 +256,7 @@ Future<void> _bootstrapNewGameToMap(WidgetTester tester) async {
   await tester.tap(startButton);
   await tester.pump();
 
-  final setupDeadline = DateTime.now().add(const Duration(minutes: 6));
+  final setupDeadline = DateTime.now().add(const Duration(seconds: 60));
   var reachedMap = false;
   while (DateTime.now().isBefore(setupDeadline)) {
     await tester.pump(const Duration(milliseconds: 100));
@@ -404,9 +396,18 @@ Future<void> _tapFirstAssignInCivilianPanel(WidgetTester tester) async {
     scrollable: panelScrollable,
   );
   await tester.ensureVisible(firstAssign);
-  await _pumpFor(tester, const Duration(milliseconds: 100));
+  await tester.pump();
   await tester.tap(firstAssign);
-  await _pumpFor(tester, const Duration(milliseconds: 300));
+  await e2eWaitUntilAnyFinderHitTestable(
+    tester,
+    <Finder>[
+      find.text('Build improvement'),
+      find.text('Prospect'),
+      find.text('Explore'),
+    ],
+    timeout: const Duration(seconds: 5),
+    phaseName: 'wait_until_civilian_work_menu',
+  );
 }
 
 /// Taps Assign on a [ListTile] whose title is exactly [unitTypeTitle]
@@ -460,9 +461,18 @@ Future<void> _tapAssignOnCivilianRowWithTitle(
     }
     final assignHit = assign.first;
     await tester.ensureVisible(assignHit);
-    await _pumpFor(tester, const Duration(milliseconds: 100));
+    await tester.pump();
     await tester.tap(assignHit);
-    await _pumpFor(tester, const Duration(milliseconds: 300));
+    await e2eWaitUntilAnyFinderHitTestable(
+      tester,
+      <Finder>[
+        find.text('Build improvement'),
+        find.text('Prospect'),
+        find.text('Explore'),
+      ],
+      timeout: const Duration(seconds: 5),
+      phaseName: 'wait_until_civilian_work_menu_row',
+    );
     return;
   }
   fail('No idle Assign row for unit type "$unitTypeTitle" in civilian panel');


### PR DESCRIPTION
## Summary
Implements a **slice** of #2336: reduce fixed-delay pumps and serial 64px PNG decode cost in `app/integration_test/` without touching production code.

**Refs #2336** (does not close the issue.)

## Implemented in this PR
- **Shared helpers** (`e2e_test_shared.dart`): `e2eDecodePngAssetPathsParallel` (chunked `Future.wait` over load+decode+dispose) and `e2eWaitUntilAnyFinderHitTestable` for post-Assign work menus.
- **AC3 / Bottleneck 1:** `new_game_full_turn_e2e_test.dart` and `new_game_capital_panel_e2e_test.dart` now decode relocated 64px PNGs with bounded concurrency instead of strictly serial awaits.
- **AC4 / H1–H4 (fleet):** `_tapMoveOnFirstNonHomeFleet` waits for the move `AlertDialog` after **Move** instead of a 400ms pump; expand-row path waits for **Move**; `_pickMoveDestinationAndConfirm` uses `scrollUntilVisible` when possible and `pump()` in the warp drag fallback; `_openNavalPanel` polls for the naval panel after marker/rail taps instead of fixed 250ms/400ms pumps.
- **H5–H10 (partial):** `_splitHomeFleetOnce` uses `_waitUntilFound` for naval panel, split nudge control, and confirm label; shorter tail pump after confirm; `_openCivilianPanelFleetE2e` uses `pump`+existing inner poll; `maxPanelSweepSteps` 24→16; full-turn civilian Assign flows use `e2eWaitUntilAnyFinderHitTestable`; marker panel open uses a short inner poll loop; full-turn bootstrap overall cap aligned to **60s** with fleet E2E (`new_game_full_turn_e2e_test.dart`); capital panel bootstrap cap **60s** (`new_game_capital_panel_e2e_test.dart`).

## Deferred / follow-up (still on #2336)
- **Single shared library** for all duplicated helpers (AC1–2 table in the issue): `full_turn` and `capital_panel` still carry local `_collectTextPreorder`, bootstrap bodies, etc.
- **Per-test / suite baseline table (AC8–9, ≥25% median reduction):** not captured in this run. CI does not execute these E2E tests; the implementer or reviewer should run `flutter test integration_test/ ... --dart-define=CT_E2E=true` on `dev` tip vs this branch (3 runs each per issue methodology) and attach timings to the PR or verification comment.
- **AC6–7 / AC10 (3× consecutive pass, flakiness):** needs the same local E2E runs above; not executed here.
- **Remaining H5–H10 sites** in `full_turn` (many `_pumpFor` calls in the long scenario) and **bootstrap adaptive polling** (AC5) beyond the 60s cap alignment.
- **One-shot / parallel preload fixture** across test files (issue Bottleneck 1 optional follow-up).

## Tests / checks
- `dart analyze integration_test/` (from `app/`): clean.
- Full `flutter test integration_test/` with `CT_E2E=true` not run in this agent session (wall-clock + environment); please run before merge if policy requires.

## SPEC
No SPEC change: behavior-only E2E harness edits within issue scope (`app` integration tests only).

Made with [Cursor](https://cursor.com)