### PR TITLE
refactor(ai): extract recipe scoring helpers (Refs #2289)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
@@ -5,21 +5,9 @@ import 'package:colonizethis_ai/package_logger.dart';
 import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'recipe_scoring.dart';
+
 final _log = packageLogger('economy_planner');
-
-/// Shortage target below which we consider a commodity "needed".
-const int _kShortageThreshold = 8;
-
-/// Weight for shortage component in recipe score.
-const double _kShortageWeight = 2.0;
-
-/// Weight for chain/luxury value.
-const double _kChainWeight = 1.0;
-
-/// Weight for agenda/personality modifier.
-const double _kAgendaWeight = 0.5;
-
-const int _kVeryLargeRuns = 999999;
 
 /// Runs the economy planner for one AI-controlled player. Deterministic given
 /// [game], [view], [config], and [seeds]. Returns production assignments and
@@ -120,24 +108,24 @@ List<AssignedRecipe> _allocateLabour({
   final result = <AssignedRecipe>[];
 
   // Build feasible recipes with scores. Feasible = can run at least 1 full run.
-  final candidates = <_ScoredRecipe>[];
+  final candidates = <ScoredRecipe>[];
   for (final recipe in recipes) {
     final labourPerOutput = recipe.labourPerOutput;
     if (labourPerOutput <= 0) continue;
-    final feasibleRuns = _feasibleRuns(
+    final runs = feasibleRuns(
       recipe: recipe,
       stockpile: virtual,
       remainingLabour: remainingLabour,
     );
-    if (feasibleRuns <= 0) continue;
+    if (runs <= 0) continue;
 
-    final score = _scoreRecipe(
+    final score = scoreRecipe(
       recipe: recipe,
       stockpile: virtual,
       workers: workers,
       agendaId: agendaId,
     );
-    candidates.add(_ScoredRecipe(recipe: recipe, score: score));
+    candidates.add(ScoredRecipe(recipe: recipe, score: score));
   }
 
   if (candidates.isEmpty) return result;
@@ -161,7 +149,7 @@ List<AssignedRecipe> _allocateLabour({
   for (final scored in candidates) {
     if (remainingLabour <= 0) break;
     final recipe = scored.recipe;
-    final runs = _feasibleRuns(
+    final runs = feasibleRuns(
       recipe: recipe,
       stockpile: virtual,
       remainingLabour: remainingLabour,
@@ -191,92 +179,4 @@ List<AssignedRecipe> _allocateLabour({
     'labourByRecipe=$labourByRecipe assignmentsCount=${result.length}',
   );
   return result;
-}
-
-class _ScoredRecipe {
-  _ScoredRecipe({required this.recipe, required this.score});
-  final ProductionRecipe recipe;
-  final double score;
-}
-
-int _feasibleRuns({
-  required ProductionRecipe recipe,
-  required Stockpile stockpile,
-  required int remainingLabour,
-}) {
-  if (recipe.labourPerOutput <= 0) return 0;
-  int maxByInputs = _kVeryLargeRuns;
-  for (final entry in recipe.inputQuantities.entries) {
-    final have = stockpile.quantityOf(entry.key);
-    final need = entry.value;
-    if (need <= 0) continue;
-    final runs = have ~/ need;
-    if (runs < maxByInputs) maxByInputs = runs;
-  }
-  if (maxByInputs <= 0) return 0;
-  final maxByLabour = remainingLabour ~/ recipe.labourPerOutput;
-  if (maxByLabour <= 0) return 0;
-  return maxByInputs < maxByLabour ? maxByInputs : maxByLabour;
-}
-
-double _scoreRecipe({
-  required ProductionRecipe recipe,
-  required Stockpile stockpile,
-  required WorkerPool workers,
-  required String agendaId,
-}) {
-  final outputId = recipe.outputCommodityId;
-  final have = stockpile.quantityOf(outputId);
-
-  // Shortage: prefer producing what we have little of.
-  final shortage = have < _kShortageThreshold
-      ? (_kShortageThreshold - have).toDouble()
-      : 0.0;
-
-  final chain = _recipeChainScore(outputId, workers);
-  final agenda = _recipeAgendaScore(agendaId, outputId);
-
-  return shortage * _kShortageWeight +
-      chain * _kChainWeight +
-      agenda * _kAgendaWeight;
-}
-
-/// Chain value: outputs that feed other recipes or are luxuries.
-double _recipeChainScore(String outputId, WorkerPool workers) {
-  if (outputId == CommodityCatalog.refinedSugar.id) {
-    return workers.apprentices > 0 ? 2.0 : 1.0;
-  }
-  if (outputId == CommodityCatalog.cigars.id) {
-    return workers.journeymen > 0 ? 2.0 : 1.0;
-  }
-  if (outputId == CommodityCatalog.furHats.id) {
-    return workers.masters > 0 ? 2.0 : 1.0;
-  }
-  if (outputId == CommodityCatalog.lumber.id ||
-      outputId == CommodityCatalog.castIron.id) {
-    return 0.8;
-  }
-  if (outputId == CommodityCatalog.fabric.id) {
-    return 0.5;
-  }
-  return 0.0;
-}
-
-/// Agenda: warmonger favours military-related; industrial_trader / merchant favour trade goods.
-double _recipeAgendaScore(String agendaId, String outputId) {
-  if (agendaId == 'warmonger' &&
-      (outputId == CommodityCatalog.castIron.id ||
-          outputId == CommodityCatalog.lumber.id)) {
-    return 1.0;
-  }
-  if (agendaId != 'industrial_trader' && agendaId != 'merchant') {
-    return 0.0;
-  }
-  if (outputId == CommodityCatalog.fabric.id ||
-      outputId == CommodityCatalog.refinedSugar.id ||
-      outputId == CommodityCatalog.cigars.id ||
-      outputId == CommodityCatalog.furHats.id) {
-    return 0.5;
-  }
-  return 0.0;
 }

--- a/packages/colonizethis_ai/lib/src/planning/recipe_scoring.dart
+++ b/packages/colonizethis_ai/lib/src/planning/recipe_scoring.dart
@@ -1,0 +1,107 @@
+// Recipe feasibility and scoring for economy planning. SPEC/ai/economy-planner.md.
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Shortage target below which we consider a commodity "needed".
+const int kShortageThreshold = 8;
+
+/// Weight for shortage component in recipe score.
+const double kShortageWeight = 2.0;
+
+/// Weight for chain/luxury value.
+const double kChainWeight = 1.0;
+
+/// Weight for agenda/personality modifier.
+const double kAgendaWeight = 0.5;
+
+const int kVeryLargeRuns = 999999;
+
+/// A production recipe with its computed ranking score.
+class ScoredRecipe {
+  const ScoredRecipe({required this.recipe, required this.score});
+
+  final ProductionRecipe recipe;
+  final double score;
+}
+
+/// Max full runs of [recipe] allowed by [stockpile] inputs and [remainingLabour].
+int feasibleRuns({
+  required ProductionRecipe recipe,
+  required Stockpile stockpile,
+  required int remainingLabour,
+}) {
+  if (recipe.labourPerOutput <= 0) return 0;
+  var maxByInputs = kVeryLargeRuns;
+  for (final entry in recipe.inputQuantities.entries) {
+    final have = stockpile.quantityOf(entry.key);
+    final need = entry.value;
+    if (need <= 0) continue;
+    final runs = have ~/ need;
+    if (runs < maxByInputs) maxByInputs = runs;
+  }
+  if (maxByInputs <= 0) return 0;
+  final maxByLabour = remainingLabour ~/ recipe.labourPerOutput;
+  if (maxByLabour <= 0) return 0;
+  return maxByInputs < maxByLabour ? maxByInputs : maxByLabour;
+}
+
+/// Deterministic score for ranking recipe candidates.
+double scoreRecipe({
+  required ProductionRecipe recipe,
+  required Stockpile stockpile,
+  required WorkerPool workers,
+  required String agendaId,
+}) {
+  final outputId = recipe.outputCommodityId;
+  final have = stockpile.quantityOf(outputId);
+
+  final shortage = have < kShortageThreshold
+      ? (kShortageThreshold - have).toDouble()
+      : 0.0;
+
+  final chain = _recipeChainScore(outputId, workers);
+  final agenda = _recipeAgendaScore(agendaId, outputId);
+
+  return shortage * kShortageWeight + chain * kChainWeight + agenda * kAgendaWeight;
+}
+
+/// Chain value: outputs that feed other recipes or are luxuries.
+double _recipeChainScore(String outputId, WorkerPool workers) {
+  if (outputId == CommodityCatalog.refinedSugar.id) {
+    return workers.apprentices > 0 ? 2.0 : 1.0;
+  }
+  if (outputId == CommodityCatalog.cigars.id) {
+    return workers.journeymen > 0 ? 2.0 : 1.0;
+  }
+  if (outputId == CommodityCatalog.furHats.id) {
+    return workers.masters > 0 ? 2.0 : 1.0;
+  }
+  if (outputId == CommodityCatalog.lumber.id ||
+      outputId == CommodityCatalog.castIron.id) {
+    return 0.8;
+  }
+  if (outputId == CommodityCatalog.fabric.id) {
+    return 0.5;
+  }
+  return 0.0;
+}
+
+/// Agenda: warmonger favours military-related; industrial_trader / merchant favour trade goods.
+double _recipeAgendaScore(String agendaId, String outputId) {
+  if (agendaId == 'warmonger' &&
+      (outputId == CommodityCatalog.castIron.id ||
+          outputId == CommodityCatalog.lumber.id)) {
+    return 1.0;
+  }
+  if (agendaId != 'industrial_trader' && agendaId != 'merchant') {
+    return 0.0;
+  }
+  if (outputId == CommodityCatalog.fabric.id ||
+      outputId == CommodityCatalog.refinedSugar.id ||
+      outputId == CommodityCatalog.cigars.id ||
+      outputId == CommodityCatalog.furHats.id) {
+    return 0.5;
+  }
+  return 0.0;
+}

--- a/packages/colonizethis_ai/test/recipe_scoring_test.dart
+++ b/packages/colonizethis_ai/test/recipe_scoring_test.dart
@@ -1,0 +1,102 @@
+import 'package:colonizethis_ai/src/planning/recipe_scoring.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('feasibleRuns', () {
+    test('returns 0 when inputs are insufficient', () {
+      final recipe = ProductionRecipesCatalog.fabricFromWool;
+      const stockpile = Stockpile();
+      expect(
+        feasibleRuns(
+          recipe: recipe,
+          stockpile: stockpile,
+          remainingLabour: 100,
+        ),
+        0,
+      );
+    });
+
+    test('returns 0 when remaining labour cannot fund one run', () {
+      final recipe = ProductionRecipesCatalog.fabricFromWool;
+      final stockpile = const Stockpile().applyDelta(
+        CommodityCatalog.wool.id,
+        100,
+      );
+      expect(
+        feasibleRuns(
+          recipe: recipe,
+          stockpile: stockpile,
+          remainingLabour: 1,
+        ),
+        0,
+        reason: 'labourPerOutput is 2',
+      );
+    });
+
+    test('is capped by labour when inputs are abundant', () {
+      final recipe = ProductionRecipesCatalog.fabricFromWool;
+      final stockpile = const Stockpile().applyDelta(
+        CommodityCatalog.wool.id,
+        100,
+      );
+      expect(
+        feasibleRuns(
+          recipe: recipe,
+          stockpile: stockpile,
+          remainingLabour: 5,
+        ),
+        2,
+        reason: '50 input-runs vs 5//2 labour-runs → 2',
+      );
+    });
+  });
+
+  group('scoreRecipe', () {
+    test('scores higher when output stockpile is below shortage threshold', () {
+      final recipe = ProductionRecipesCatalog.lumberFromTimber;
+      const workers = WorkerPool(peasants: 1);
+      final wellStocked = const Stockpile().applyDelta(
+        CommodityCatalog.lumber.id,
+        20,
+      );
+      const scarceOutput = Stockpile();
+      final highHave = scoreRecipe(
+        recipe: recipe,
+        stockpile: wellStocked,
+        workers: workers,
+        agendaId: 'peacemaker',
+      );
+      final lowHave = scoreRecipe(
+        recipe: recipe,
+        stockpile: scarceOutput,
+        workers: workers,
+        agendaId: 'peacemaker',
+      );
+      expect(lowHave, greaterThan(highHave));
+    });
+
+    test('merchant agenda boosts fabric relative to peacemaker', () {
+      final recipe = ProductionRecipesCatalog.fabricFromWool;
+      final stockpile = const Stockpile().applyDelta(
+        CommodityCatalog.fabric.id,
+        20,
+      );
+      const workers = WorkerPool(peasants: 1);
+      final merchant = scoreRecipe(
+        recipe: recipe,
+        stockpile: stockpile,
+        workers: workers,
+        agendaId: 'merchant',
+      );
+      final peace = scoreRecipe(
+        recipe: recipe,
+        stockpile: stockpile,
+        workers: workers,
+        agendaId: 'peacemaker',
+      );
+      expect(merchant, greaterThan(peace));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements **#2289** proposed work item 5: move recipe feasibility and scoring out of `economy_planner.dart` into `recipe_scoring.dart` under `lib/src/planning/`, matching the issue layout. No public AI API or barrel export changes.

**Refs #2289** (does not close the issue.)

## Implemented

- New `packages/colonizethis_ai/lib/src/planning/recipe_scoring.dart` with `ScoredRecipe`, `feasibleRuns`, `scoreRecipe`, and scoring constants (`kShortageThreshold`, weights, `kVeryLargeRuns`).
- `economy_planner.dart` reduced to labour allocation + cargo preference; imports the new module.
- New `test/recipe_scoring_test.dart`: `feasibleRuns` (insufficient inputs, labour gate, labour cap) and `scoreRecipe` (shortage ordering, merchant vs peacemaker agenda bias).

## Note on duplicate PR

Open PR #2359 targets the same extraction. If #2359 merges first, this branch should be dropped or rebased; if this lands first, #2359 can be closed as superseded. Same semantics and SPEC (`SPEC/ai/economy-planner.md`).

## Deferred (still on #2289)

- Further splits (`domain_planners`, `perception` test mirror, etc.) per issue body.
- Test file renames to mirror every planner file (non-AC).

## Verification

- `cd packages/colonizethis_ai && dart analyze` — clean
- `cd packages/colonizethis_ai && dart test` — full AI suite including new tests
- `tool/check_logic_ai_decoupling.sh` — passed

Made with [Cursor](https://cursor.com)