### PR TITLE
refactor(ai): extract strategic dialogue/mood emission (Refs #2289)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/planning/strategic_ai.dart
@@ -10,7 +10,7 @@ import 'economy_planner.dart';
 import '../goal_manager.dart';
 import 'ai_order_reporting.dart';
 import 'ai_trace_builder.dart';
-import '../social/mood_state_machine.dart';
+import '../social/strategic_dialogue_emission.dart';
 import '../perception.dart';
 
 final _log = packageLogger();
@@ -108,7 +108,7 @@ StrategicOrderTraceResult generateStrategicOrdersWithTrace({
   _log.i(
     'generated orders nationId=$nationId move=$moveCount armyMove=$armyMoveCount build=$buildCount work=$workCount research=$researchCount',
   );
-  _emitDialogueAndMood(
+  emitStrategicDialogueAndMood(
     config: config,
     seeds: seeds,
     onDialogue: onDialogue,
@@ -133,40 +133,4 @@ StrategicOrderTraceResult generateStrategicOrdersWithTrace({
       finalOrders: finalOrders,
     ),
   );
-}
-
-void _emitDialogueAndMood({
-  required AIConfig config,
-  required AISeedBundle seeds,
-  void Function(DialogueEvent)? onDialogue,
-  void Function(PortraitMoodEvent)? onMood,
-}) {
-  // Optional dialogue/mood emission (deterministic from dialogueSeed).
-  // SPEC/ai/dialogue-and-mood.md § When to emit:
-  // Strategic AI may emit optional agenda/comment and base mood once every
-  // kDialogueTurnsBetweenComments turns per leader, when
-  // `dialogueSeed % kDialogueTurnsBetweenComments == 0`.
-  if (onDialogue != null &&
-      seeds.dialogueSeed % kDialogueTurnsBetweenComments == 0) {
-    onDialogue(
-      DialogueEvent(
-        leaderId: config.leaderId,
-        category: 'agenda',
-        situation: 'comment',
-        era: 'earlyModern',
-        variables: const {},
-      ),
-    );
-  }
-  if (onMood != null &&
-      seeds.dialogueSeed % kDialogueTurnsBetweenComments == 0) {
-    onMood(
-      PortraitMoodEvent(
-        leaderId: config.leaderId,
-        fromMood: kDefaultMood,
-        toMood: kDefaultMood,
-        durationMs: 0,
-      ),
-    );
-  }
 }

--- a/packages/colonizethis_ai/lib/src/social/strategic_dialogue_emission.dart
+++ b/packages/colonizethis_ai/lib/src/social/strategic_dialogue_emission.dart
@@ -1,0 +1,47 @@
+// Optional strategic dialogue/mood emission on deterministic cadence.
+// SPEC/ai/dialogue-and-mood.md § When to emit.
+
+import 'package:colonizethis_data/colonizethis_data.dart'
+    show kDialogueTurnsBetweenComments;
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'mood_state_machine.dart';
+
+/// Emits optional agenda-flavoured dialogue and a matching base [PortraitMoodEvent]
+/// when [seeds.dialogueSeed] hits the strategic cadence
+/// (`dialogueSeed % kDialogueTurnsBetweenComments == 0`).
+void emitStrategicDialogueAndMood({
+  required AIConfig config,
+  required AISeedBundle seeds,
+  void Function(DialogueEvent)? onDialogue,
+  void Function(PortraitMoodEvent)? onMood,
+}) {
+  // Optional dialogue/mood emission (deterministic from dialogueSeed).
+  // SPEC/ai/dialogue-and-mood.md § When to emit:
+  // Strategic AI may emit optional agenda/comment and base mood once every
+  // kDialogueTurnsBetweenComments turns per leader, when
+  // `dialogueSeed % kDialogueTurnsBetweenComments == 0`.
+  if (onDialogue != null &&
+      seeds.dialogueSeed % kDialogueTurnsBetweenComments == 0) {
+    onDialogue(
+      DialogueEvent(
+        leaderId: config.leaderId,
+        category: 'agenda',
+        situation: 'comment',
+        era: 'earlyModern',
+        variables: const {},
+      ),
+    );
+  }
+  if (onMood != null &&
+      seeds.dialogueSeed % kDialogueTurnsBetweenComments == 0) {
+    onMood(
+      PortraitMoodEvent(
+        leaderId: config.leaderId,
+        fromMood: kDefaultMood,
+        toMood: kDefaultMood,
+        durationMs: 0,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Extracts optional strategic-layer `DialogueEvent` / `PortraitMoodEvent` emission from `planning/strategic_ai.dart` into `social/strategic_dialogue_emission.dart` as `emitStrategicDialogueAndMood`, matching the issue goal of separating dialogue/mood emission from the strategic orchestration entrypoint (see proposed split under **strategic_ai.dart** in #2289).

## Scope
- **In scope:** Mechanical move only; same cadence (`dialogueSeed % kDialogueTurnsBetweenComments == 0`), same payloads, same imports boundary (models + dialogue catalog constant).
- **Deferred:** Further splits of `full_ai_planner.dart`, `diplomacy_planner.dart` (including open candidate-scoring extraction PR), directory cleanup of legacy barrel stubs, test file realignment.

## SPEC
No SPEC changes (issue non-goals: no behavior change). Behavior remains per `SPEC/ai/dialogue-and-mood.md` § strategic cadence.

## Tests
- `cd packages/colonizethis_ai && dart analyze`
- `dart run custom_lint`
- `dart test` (full package)
- `./tool/check_logic_ai_decoupling.sh`

## Issue
Refs #2289

Made with [Cursor](https://cursor.com)