### PR TITLE
refactor(ai): remove lib/src re-export shims (Refs #2289)

### DIFF
--- a/packages/colonizethis_ai/lib/src/diplomacy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/diplomacy_planner.dart
@@ -1,1 +1,0 @@
-export 'planning/diplomacy_planner.dart';

--- a/packages/colonizethis_ai/lib/src/dossier.dart
+++ b/packages/colonizethis_ai/lib/src/dossier.dart
@@ -1,2 +1,0 @@
-export 'perception/dossier_builder.dart';
-export 'perception/dossier_models.dart';

--- a/packages/colonizethis_ai/lib/src/goal_manager.dart
+++ b/packages/colonizethis_ai/lib/src/goal_manager.dart
@@ -1,1 +1,0 @@
-export 'planning/goal_manager.dart';

--- a/packages/colonizethis_ai/lib/src/perception.dart
+++ b/packages/colonizethis_ai/lib/src/perception.dart
@@ -1,1 +1,0 @@
-export 'perception/perception_snapshot.dart';

--- a/packages/colonizethis_ai/lib/src/perception/dossier.dart
+++ b/packages/colonizethis_ai/lib/src/perception/dossier.dart
@@ -1,1 +1,2 @@
-export '../dossier.dart';
+export 'dossier_models.dart';
+export 'dossier_builder.dart';

--- a/packages/colonizethis_ai/lib/src/perception/perception.dart
+++ b/packages/colonizethis_ai/lib/src/perception/perception.dart
@@ -1,1 +1,1 @@
-export '../perception.dart';
+export 'perception_snapshot.dart';

--- a/packages/colonizethis_ai/lib/src/planning/ai_trace_builder.dart
+++ b/packages/colonizethis_ai/lib/src/planning/ai_trace_builder.dart
@@ -2,8 +2,8 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/ai_api.dart' show TurnTraceAiSection;
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../goal_manager.dart';
-import '../perception.dart';
+import 'goal_manager.dart';
+import '../perception/perception_snapshot.dart';
 
 TurnTraceAiSection buildAiTraceSection({
   required String nationId,
@@ -117,9 +117,7 @@ TurnTraceAiSection buildAiTraceSection({
           'researchExploration': thresholds.researchExploration,
         },
       },
-      'gates': <Object?>[
-        ...goalSelectionGates(goalScores, primaryGoal),
-      ],
+      'gates': <Object?>[...goalSelectionGates(goalScores, primaryGoal)],
     },
     outcome: <String, Object?>{
       'domainOutputs': ordersByDomain,

--- a/packages/colonizethis_ai/lib/src/planning/build_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/build_planner.dart
@@ -2,7 +2,7 @@ import 'package:colonizethis_ai/package_logger.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../goal_manager.dart';
+import 'goal_manager.dart';
 import '../util/ai_random_utils.dart';
 
 final _log = packageLogger();

--- a/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
@@ -6,8 +6,8 @@ import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_logic/order_suggestion_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../goal_manager.dart';
-import '../perception.dart';
+import 'goal_manager.dart';
+import '../perception/perception_snapshot.dart';
 import '../util/ai_random_utils.dart';
 import '../util/orders_extensions.dart';
 import 'war_desire_calculator.dart';
@@ -104,6 +104,7 @@ List<int> computeDiplomaticCandidateScores({
       ),
     );
   }
+
   return candidates.map((o) {
     var s = 50;
     switch (o.type) {

--- a/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
+++ b/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
@@ -4,8 +4,8 @@ import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_logic/order_suggestion_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../goal_manager.dart';
-import '../perception.dart';
+import 'goal_manager.dart';
+import '../perception/perception_snapshot.dart';
 import '../util/orders_extensions.dart';
 import 'build_planner.dart';
 import 'diplomacy_planner.dart';

--- a/packages/colonizethis_ai/lib/src/planning/goal_manager.dart
+++ b/packages/colonizethis_ai/lib/src/planning/goal_manager.dart
@@ -3,7 +3,7 @@ import 'package:colonizethis_ai/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../util/ai_random_utils.dart';
-import '../perception.dart';
+import '../perception/perception_snapshot.dart';
 
 final _log = packageLogger();
 

--- a/packages/colonizethis_ai/lib/src/planning/move_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/move_planner.dart
@@ -4,7 +4,7 @@ import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_logic/order_suggestion_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../goal_manager.dart';
+import 'goal_manager.dart';
 import '../util/ai_random_utils.dart';
 import '../util/orders_extensions.dart';
 

--- a/packages/colonizethis_ai/lib/src/planning/naval_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/naval_planner.dart
@@ -6,7 +6,7 @@ import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_logic/order_suggestion_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../goal_manager.dart';
+import 'goal_manager.dart';
 import '../util/orders_extensions.dart';
 
 final _log = packageLogger();

--- a/packages/colonizethis_ai/lib/src/planning/research_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/research_planner.dart
@@ -6,7 +6,7 @@ import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_logic/order_suggestion_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../goal_manager.dart';
+import 'goal_manager.dart';
 import '../util/ai_random_utils.dart';
 import '../util/orders_extensions.dart';
 

--- a/packages/colonizethis_ai/lib/src/planning/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/planning/strategic_ai.dart
@@ -7,11 +7,11 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'domain_planner_orchestrator.dart';
 import 'economy_planner.dart';
-import '../goal_manager.dart';
+import 'goal_manager.dart';
 import 'ai_order_reporting.dart';
 import 'ai_trace_builder.dart';
 import '../social/mood_state_machine.dart';
-import '../perception.dart';
+import '../perception/perception_snapshot.dart';
 
 final _log = packageLogger();
 

--- a/packages/colonizethis_ai/lib/src/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/strategic_ai.dart
@@ -1,1 +1,0 @@
-export 'planning/strategic_ai.dart';


### PR DESCRIPTION
## Summary
Part of the #2289 AI package layout cleanup: remove unused one-line `lib/src/*.dart` shims that only re-exported `planning/` or `perception/` libraries, and stop routing `perception/` barrel files through those shims.

## Implemented
- Deleted `lib/src/goal_manager.dart`, `perception.dart`, `dossier.dart`, `strategic_ai.dart`, `diplomacy_planner.dart` (unused; barrel already exports canonical paths).
- `perception/perception.dart` now exports `perception_snapshot.dart` directly; `perception/dossier.dart` exports `dossier_models` + `dossier_builder` directly.
- Planning modules import `goal_manager.dart` in-package and `../perception/perception_snapshot.dart` instead of `../goal_manager.dart` / `../perception.dart`.

## Behavior
No logic or public API changes; barrel exports unchanged.

## Tests
- `dart analyze` (packages/colonizethis_ai)
- `dart test` (packages/colonizethis_ai)
- `tool/check_logic_ai_decoupling.sh`

## Issue ACs
Moves toward subdirectory-only layout (fewer stray files under `lib/src/`). Full #2289 checklist (domain split, test splits, etc.) remains for follow-up PRs.

Refs #2289

Made with [Cursor](https://cursor.com)