### PR TITLE
refactor(logic): extract combat engagement resolution module (Refs #2288)

### DIFF
--- a/packages/colonizethis_logic/lib/src/combat/combat_engagement.dart
+++ b/packages/colonizethis_logic/lib/src/combat/combat_engagement.dart
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/// Deterministic single-engagement strength ratio and casualty resolution.
+/// SPEC/program/combat-resolution.md.
+library;
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'combat_constants.dart';
+import 'combat_loss_profile.dart';
+import 'combat_types.dart';
+import 'military_strength.dart';
+
+/// Resolves one engagement: attacker vs defender.
+/// SPEC/program/combat-resolution.md.
+EngagementOutcome resolveEngagement({
+  required List<Unit> attackerUnits,
+  required List<Unit> defenderUnits,
+  int generalMedals = 0,
+  required int fortLevel,
+  required String terrain,
+  int defenderEffectiveMilitaryLevel = kDefaultEffectiveMilitaryEra,
+  double attackerMoraleMultiplier = kNeutralMoraleMultiplier,
+  double defenderMoraleMultiplier = kNeutralMoraleMultiplier,
+  double attackerLeaderMultiplier = kNeutralLeaderMultiplier,
+  double defenderLeaderMultiplier = kNeutralLeaderMultiplier,
+}) {
+  final attStr = aggregateStrength(attackerUnits, kDefaultEffectiveMilitaryEra);
+  var defStr = aggregateStrength(defenderUnits, defenderEffectiveMilitaryLevel);
+
+  final terrainMod =
+      terrainModifiers[terrain] ??
+      (kNeutralTerrainAttackerModifier, kNeutralTerrainDefenderModifier);
+  var effAtt =
+      attStr *
+      terrainMod.$1 *
+      attackerMoraleMultiplier *
+      attackerLeaderMultiplier;
+  var effDef =
+      defStr *
+      terrainMod.$2 *
+      defenderMoraleMultiplier *
+      defenderLeaderMultiplier;
+
+  if (fortLevel >= kMinFortLevelForCombatModifiers &&
+      fortLevel <= kMaxFortLevelForCombatModifiers) {
+    final reduction = fortDamageReduction[fortLevel];
+    effAtt *= (kUnityAttackerStrengthMultiplier - reduction);
+    final emplaced = fortGunCount[fortLevel] * fortEmplacedStrength[fortLevel];
+    effDef += emplaced;
+  }
+
+  // Wall HP soaks damage before it applies to defender casualty ratio. SPEC/game/siege-mechanics.md.
+  var effAttForRatio = effAtt;
+  if (fortLevel >= kMinFortLevelForCombatModifiers &&
+      fortLevel <= kMaxFortLevelForCombatModifiers) {
+    final wallHp = wallHpByFortLevel[fortLevel];
+    effAttForRatio = (effAtt - wallHp).clamp(
+      kEffectiveAttackForRatioClampMin,
+      kEffectiveAttackForRatioClampMax,
+    );
+  }
+
+  final attackerCasualties = <String>[];
+  final defenderCasualties = <String>[];
+
+  if (effAttForRatio <= 0 && effDef <= 0) {
+    return EngagementOutcome(
+      result: EngagementResult.stalemate,
+      attackerCasualties: attackerCasualties,
+      defenderCasualties: defenderCasualties,
+      attackerStrength: attStr,
+      defenderStrength: defStr,
+    );
+  }
+
+  final ratio = effDef > 0 ? effAttForRatio / effDef : kNoDefenderRatioFallback;
+  final attackerLowMorale = attackerMoraleMultiplier < defenderMoraleMultiplier;
+
+  return _resolveByRatio(
+    ratio: ratio,
+    attackerLowMorale: attackerLowMorale,
+    attackerUnits: attackerUnits,
+    defenderUnits: defenderUnits,
+    attStr: attStr,
+    defStr: defStr,
+  );
+}
+
+EngagementOutcome _resolveByRatio({
+  required double ratio,
+  required bool attackerLowMorale,
+  required List<Unit> attackerUnits,
+  required List<Unit> defenderUnits,
+  required double attStr,
+  required double defStr,
+}) {
+  final profile = combatLossProfileForStrengthRatio(
+    attackerDefenderStrengthRatio: ratio,
+    attackerLowMorale: attackerLowMorale,
+  );
+  return _buildOutcome(
+    attackerUnits: attackerUnits,
+    defenderUnits: defenderUnits,
+    attLossFrac: profile.attackerLossFraction,
+    defLossFrac: profile.defenderLossFraction,
+    attStr: attStr,
+    defStr: defStr,
+    bluntAttackerVictory: profile.bluntsAttackerVictory,
+    bothDeadResult: _engagementResultForMutualElimination(
+      profile.mutualEliminationOutcome,
+    ),
+  );
+}
+
+EngagementResult _engagementResultForMutualElimination(
+  CombatMutualEliminationOutcome outcome,
+) {
+  return switch (outcome) {
+    CombatMutualEliminationOutcome.attackerVictory =>
+      EngagementResult.attackerVictory,
+    CombatMutualEliminationOutcome.defenderVictory =>
+      EngagementResult.defenderVictory,
+    CombatMutualEliminationOutcome.mutualAnnihilation =>
+      EngagementResult.mutualAnnihilation,
+  };
+}
+
+EngagementOutcome _buildOutcome({
+  required List<Unit> attackerUnits,
+  required List<Unit> defenderUnits,
+  required double attLossFrac,
+  required double defLossFrac,
+  required double attStr,
+  required double defStr,
+  bool bluntAttackerVictory = false,
+  EngagementResult bothDeadResult = EngagementResult.mutualAnnihilation,
+}) {
+  final attLoss = combatCasualtyCount(
+    unitCount: attackerUnits.length,
+    lossFraction: attLossFrac,
+  );
+  final defLoss = combatCasualtyCount(
+    unitCount: defenderUnits.length,
+    lossFraction: defLossFrac,
+  );
+
+  final attackerCasualties = [
+    for (var i = 0; i < attLoss; i++) attackerUnits[i].id,
+  ];
+  final defenderCasualties = [
+    for (var i = 0; i < defLoss; i++) defenderUnits[i].id,
+  ];
+
+  final attSurvivors = attackerUnits.length - attLoss;
+  final defSurvivors = defenderUnits.length - defLoss;
+
+  EngagementResult result;
+  if (attSurvivors <= 0 && defSurvivors <= 0) {
+    result = bothDeadResult;
+  } else if (attSurvivors <= 0) {
+    result = EngagementResult.defenderVictory;
+  } else if (defSurvivors <= 0) {
+    result = bluntAttackerVictory
+        ? EngagementResult.stalemate
+        : EngagementResult.attackerVictory;
+  } else {
+    result = EngagementResult.stalemate;
+  }
+
+  return EngagementOutcome(
+    result: result,
+    attackerCasualties: attackerCasualties,
+    defenderCasualties: defenderCasualties,
+    attackerStrength: attStr,
+    defenderStrength: defStr,
+  );
+}

--- a/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
@@ -11,13 +11,14 @@ import '../world/province_ownership_transfer.dart';
 import '../world/unit_lookup.dart';
 import 'battle_general_assignment.dart';
 import 'combat_constants.dart';
-import 'combat_loss_profile.dart';
+import 'combat_engagement.dart';
 import 'combat_types.dart';
 import 'conflict_detection.dart';
 import 'leader_bonus_helpers.dart';
 import 'military_strength.dart';
 
 export 'combat_constants.dart';
+export 'combat_engagement.dart' show resolveEngagement;
 export 'combat_types.dart';
 
 final _combatLog = packageLogger();
@@ -516,172 +517,6 @@ int _deploymentLimitForFaction(Game game, String factionId, int generalMedals) {
       ? deploymentLimitWithNationalism
       : deploymentLimitBase;
   return baseLimit + generalMedals;
-}
-
-/// Resolves one engagement: attacker vs defender.
-/// SPEC/program/combat-resolution.md.
-EngagementOutcome resolveEngagement({
-  required List<Unit> attackerUnits,
-  required List<Unit> defenderUnits,
-  int generalMedals = 0,
-  required int fortLevel,
-  required String terrain,
-  int defenderEffectiveMilitaryLevel = kDefaultEffectiveMilitaryEra,
-  double attackerMoraleMultiplier = kNeutralMoraleMultiplier,
-  double defenderMoraleMultiplier = kNeutralMoraleMultiplier,
-  double attackerLeaderMultiplier = kNeutralLeaderMultiplier,
-  double defenderLeaderMultiplier = kNeutralLeaderMultiplier,
-}) {
-  final attStr = aggregateStrength(attackerUnits, kDefaultEffectiveMilitaryEra);
-  var defStr = aggregateStrength(defenderUnits, defenderEffectiveMilitaryLevel);
-
-  final terrainMod =
-      terrainModifiers[terrain] ??
-      (kNeutralTerrainAttackerModifier, kNeutralTerrainDefenderModifier);
-  var effAtt =
-      attStr *
-      terrainMod.$1 *
-      attackerMoraleMultiplier *
-      attackerLeaderMultiplier;
-  var effDef =
-      defStr *
-      terrainMod.$2 *
-      defenderMoraleMultiplier *
-      defenderLeaderMultiplier;
-
-  if (fortLevel >= kMinFortLevelForCombatModifiers &&
-      fortLevel <= kMaxFortLevelForCombatModifiers) {
-    final reduction = fortDamageReduction[fortLevel];
-    effAtt *= (kUnityAttackerStrengthMultiplier - reduction);
-    final emplaced = fortGunCount[fortLevel] * fortEmplacedStrength[fortLevel];
-    effDef += emplaced;
-  }
-
-  // Wall HP soaks damage before it applies to defender casualty ratio. SPEC/game/siege-mechanics.md.
-  var effAttForRatio = effAtt;
-  if (fortLevel >= kMinFortLevelForCombatModifiers &&
-      fortLevel <= kMaxFortLevelForCombatModifiers) {
-    final wallHp = wallHpByFortLevel[fortLevel];
-    effAttForRatio = (effAtt - wallHp).clamp(
-      kEffectiveAttackForRatioClampMin,
-      kEffectiveAttackForRatioClampMax,
-    );
-  }
-
-  final attackerCasualties = <String>[];
-  final defenderCasualties = <String>[];
-
-  if (effAttForRatio <= 0 && effDef <= 0) {
-    return EngagementOutcome(
-      result: EngagementResult.stalemate,
-      attackerCasualties: attackerCasualties,
-      defenderCasualties: defenderCasualties,
-      attackerStrength: attStr,
-      defenderStrength: defStr,
-    );
-  }
-
-  final ratio = effDef > 0 ? effAttForRatio / effDef : kNoDefenderRatioFallback;
-  final attackerLowMorale = attackerMoraleMultiplier < defenderMoraleMultiplier;
-
-  return _resolveByRatio(
-    ratio: ratio,
-    attackerLowMorale: attackerLowMorale,
-    attackerUnits: attackerUnits,
-    defenderUnits: defenderUnits,
-    attStr: attStr,
-    defStr: defStr,
-  );
-}
-
-EngagementOutcome _resolveByRatio({
-  required double ratio,
-  required bool attackerLowMorale,
-  required List<Unit> attackerUnits,
-  required List<Unit> defenderUnits,
-  required double attStr,
-  required double defStr,
-}) {
-  final profile = combatLossProfileForStrengthRatio(
-    attackerDefenderStrengthRatio: ratio,
-    attackerLowMorale: attackerLowMorale,
-  );
-  return _buildOutcome(
-    attackerUnits: attackerUnits,
-    defenderUnits: defenderUnits,
-    attLossFrac: profile.attackerLossFraction,
-    defLossFrac: profile.defenderLossFraction,
-    attStr: attStr,
-    defStr: defStr,
-    bluntAttackerVictory: profile.bluntsAttackerVictory,
-    bothDeadResult: _engagementResultForMutualElimination(
-      profile.mutualEliminationOutcome,
-    ),
-  );
-}
-
-EngagementResult _engagementResultForMutualElimination(
-  CombatMutualEliminationOutcome outcome,
-) {
-  return switch (outcome) {
-    CombatMutualEliminationOutcome.attackerVictory =>
-      EngagementResult.attackerVictory,
-    CombatMutualEliminationOutcome.defenderVictory =>
-      EngagementResult.defenderVictory,
-    CombatMutualEliminationOutcome.mutualAnnihilation =>
-      EngagementResult.mutualAnnihilation,
-  };
-}
-
-EngagementOutcome _buildOutcome({
-  required List<Unit> attackerUnits,
-  required List<Unit> defenderUnits,
-  required double attLossFrac,
-  required double defLossFrac,
-  required double attStr,
-  required double defStr,
-  bool bluntAttackerVictory = false,
-  EngagementResult bothDeadResult = EngagementResult.mutualAnnihilation,
-}) {
-  final attLoss = combatCasualtyCount(
-    unitCount: attackerUnits.length,
-    lossFraction: attLossFrac,
-  );
-  final defLoss = combatCasualtyCount(
-    unitCount: defenderUnits.length,
-    lossFraction: defLossFrac,
-  );
-
-  final attackerCasualties = [
-    for (var i = 0; i < attLoss; i++) attackerUnits[i].id,
-  ];
-  final defenderCasualties = [
-    for (var i = 0; i < defLoss; i++) defenderUnits[i].id,
-  ];
-
-  final attSurvivors = attackerUnits.length - attLoss;
-  final defSurvivors = defenderUnits.length - defLoss;
-
-  EngagementResult result;
-  if (attSurvivors <= 0 && defSurvivors <= 0) {
-    result = bothDeadResult;
-  } else if (attSurvivors <= 0) {
-    result = EngagementResult.defenderVictory;
-  } else if (defSurvivors <= 0) {
-    result = bluntAttackerVictory
-        ? EngagementResult.stalemate
-        : EngagementResult.attackerVictory;
-  } else {
-    result = EngagementResult.stalemate;
-  }
-
-  return EngagementOutcome(
-    result: result,
-    attackerCasualties: attackerCasualties,
-    defenderCasualties: defenderCasualties,
-    attackerStrength: attStr,
-    defenderStrength: defStr,
-  );
 }
 
 /// Morale aura from general medals. SPEC/game/military-generals.md:

--- a/packages/colonizethis_logic/lib/src/combat/combat_resolver_probabilistic.dart
+++ b/packages/colonizethis_logic/lib/src/combat/combat_resolver_probabilistic.dart
@@ -9,7 +9,7 @@ import 'dart:math';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import 'combat_resolver.dart';
+import 'combat_types.dart';
 import 'military_strength.dart';
 
 /// Maximum number of combat rounds per engagement.
@@ -102,15 +102,16 @@ ProbabilisticEngagementOutcome resolveEngagementProbabilistic({
   final roundResults = <ProbabilisticRoundResult>[];
 
   final initialAttStr = _aggregateStrength(attackerUnits, 4);
-  final initialDefStr =
-      _aggregateStrength(defenderUnits, defenderEffectiveMilitaryLevel);
+  final initialDefStr = _aggregateStrength(
+    defenderUnits,
+    defenderEffectiveMilitaryLevel,
+  );
 
   for (var round = 1; round <= maxCombatRounds; round++) {
     if (attList.isEmpty || defList.isEmpty) break;
 
     final rawAtt = _aggregateStrength(attList, 4);
-    final rawDef =
-        _aggregateStrength(defList, defenderEffectiveMilitaryLevel);
+    final rawDef = _aggregateStrength(defList, defenderEffectiveMilitaryLevel);
 
     final terrainMod = terrainModifiers[terrain] ?? (1.0, 1.0);
     var effAtt = rawAtt * terrainMod.$1 * attackerMoraleMultiplier;
@@ -119,7 +120,8 @@ ProbabilisticEngagementOutcome resolveEngagementProbabilistic({
     if (fortLevel >= 1 && fortLevel <= 3) {
       final reduction = fortDamageReduction[fortLevel];
       effAtt *= (1.0 - reduction);
-      final emplaced = fortGunCount[fortLevel] * fortEmplacedStrength[fortLevel];
+      final emplaced =
+          fortGunCount[fortLevel] * fortEmplacedStrength[fortLevel];
       effDef += emplaced;
     }
 
@@ -133,17 +135,18 @@ ProbabilisticEngagementOutcome resolveEngagementProbabilistic({
     double pAtt = 0.5;
     double pDef = 0.5;
     if (total > 0) {
-      pAtt = (effAttForRatio / total).clamp(hitProbabilityMin, hitProbabilityMax);
+      pAtt = (effAttForRatio / total).clamp(
+        hitProbabilityMin,
+        hitProbabilityMax,
+      );
       pDef = (effDef / total).clamp(hitProbabilityMin, hitProbabilityMax);
     }
 
     final lambdaDef = combatLethalityK * pAtt;
     final lambdaAtt = combatLethalityK * pDef;
 
-    final nDefCas = _poissonSample(lambdaDef, rng)
-        .clamp(0, defList.length);
-    final nAttCas = _poissonSample(lambdaAtt, rng)
-        .clamp(0, attList.length);
+    final nDefCas = _poissonSample(lambdaDef, rng).clamp(0, defList.length);
+    final nAttCas = _poissonSample(lambdaAtt, rng).clamp(0, attList.length);
 
     final defCasIds = _selectCasualtiesWeighted(
       defList,
@@ -151,12 +154,7 @@ ProbabilisticEngagementOutcome resolveEngagementProbabilistic({
       defenderEffectiveMilitaryLevel,
       rng,
     );
-    final attCasIds = _selectCasualtiesWeighted(
-      attList,
-      nAttCas,
-      4,
-      rng,
-    );
+    final attCasIds = _selectCasualtiesWeighted(attList, nAttCas, 4, rng);
 
     for (final id in defCasIds) {
       defList = defList.where((u) => u.id != id).toList();
@@ -167,21 +165,23 @@ ProbabilisticEngagementOutcome resolveEngagementProbabilistic({
       allAttackerCasualties.add(id);
     }
 
-    roundResults.add(ProbabilisticRoundResult(
-      roundNumber: round,
-      rawAttackerStrength: rawAtt,
-      rawDefenderStrength: rawDef,
-      effectiveAttackerStrength: effAtt,
-      effectiveDefenderStrength: effDef,
-      probabilityAttackerHits: pAtt,
-      probabilityDefenderHits: pDef,
-      lambdaDefender: lambdaDef,
-      lambdaAttacker: lambdaAtt,
-      defenderCasualties: defCasIds,
-      attackerCasualties: attCasIds,
-      attackersRemaining: attList.length,
-      defendersRemaining: defList.length,
-    ));
+    roundResults.add(
+      ProbabilisticRoundResult(
+        roundNumber: round,
+        rawAttackerStrength: rawAtt,
+        rawDefenderStrength: rawDef,
+        effectiveAttackerStrength: effAtt,
+        effectiveDefenderStrength: effDef,
+        probabilityAttackerHits: pAtt,
+        probabilityDefenderHits: pDef,
+        lambdaDefender: lambdaDef,
+        lambdaAttacker: lambdaAtt,
+        defenderCasualties: defCasIds,
+        attackerCasualties: attCasIds,
+        attackersRemaining: attList.length,
+        defendersRemaining: defList.length,
+      ),
+    );
 
     if (attList.isEmpty || defList.isEmpty) break;
   }


### PR DESCRIPTION
## Summary
Refs #2288

Extracts deterministic single-engagement resolution (`resolveEngagement` and ratio/casualty helpers) from `combat_resolver.dart` into a dedicated `combat_engagement.dart` library. `combat_resolver.dart` re-exports `resolveEngagement` so the public barrel surface (`colonizethis_logic.dart` → `combat_resolver.dart`) stays unchanged for consumers.

## Scope implemented
- New `packages/colonizethis_logic/lib/src/combat/combat_engagement.dart` (~165 LOC) with `resolveEngagement`, `_resolveByRatio`, `_engagementResultForMutualElimination`, `_buildOutcome` (moved verbatim).
- `combat_resolver.dart` trimmed (~693 → ~527 physical lines) while preserving `resolveBattleContext` orchestration, initiative sort, post-battle assembly, and exports.
- `combat_resolver_probabilistic.dart` now imports `combat_types.dart` instead of `combat_resolver.dart`, avoiding an unnecessary dependency on the full battle resolver for enum types only.

## Deferred (issue remainder)
- Further splits of `combat_resolver.dart` orchestration, `game_setup_ownership` / `capital_choice`, barrel narrowing, remaining test-directory moves, and coverage baseline PR note per issue ACs.

## Tests run
- `dart analyze lib/src/combat/`
- `cd packages/colonizethis_logic && dart test test/combat_resolver_test_part1_test.dart test/combat_resolver_test_part2_test.dart test/combat_resolver_probabilistic_test.dart`
- `cd tool/sim_combat && dart test`

## SPEC
No spec change (behavior-neutral refactor aligned with SPEC/program/combat-resolution.md).

Made with [Cursor](https://cursor.com)