### PR TITLE
test(logic): add test/di Riverpod provider coverage (Refs #2288)

### DIFF
--- a/packages/colonizethis_logic/test/di/logic_providers_test.dart
+++ b/packages/colonizethis_logic/test/di/logic_providers_test.dart
@@ -1,0 +1,58 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:riverpod/riverpod.dart';
+
+import 'package:colonizethis_logic/src/di/logic_providers.dart';
+import 'package:colonizethis_logic/src/event_bus/game_event_bus.dart';
+import 'package:colonizethis_logic/src/orders/order_suggestion_api_impl.dart';
+
+void main() {
+  group('logic_providers', () {
+    test('orderSuggestionApiProvider exposes DefaultOrderSuggestionAPI', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(orderSuggestionApiProvider),
+        const DefaultOrderSuggestionAPI(),
+      );
+    });
+
+    test('gameEventBusProvider exposes DefaultGameEventBus', () {
+      final container = ProviderContainer();
+      final bus = container.read(gameEventBusProvider);
+      addTearDown(() {
+        (bus as DefaultGameEventBus).dispose();
+        container.dispose();
+      });
+
+      expect(bus, isA<DefaultGameEventBus>());
+    });
+
+    test('gameEventBusProvider reuses the same bus instance', () {
+      final container = ProviderContainer();
+      final first = container.read(gameEventBusProvider);
+      addTearDown(() {
+        (first as DefaultGameEventBus).dispose();
+        container.dispose();
+      });
+
+      final second = container.read(gameEventBusProvider);
+      expect(identical(first, second), isTrue);
+    });
+
+    test('gameEventBusProvider can be overridden for tests', () {
+      final custom = DefaultGameEventBus();
+      final container = ProviderContainer(
+        overrides: [
+          gameEventBusProvider.overrideWithValue(custom),
+        ],
+      );
+      addTearDown(() {
+        container.dispose();
+        custom.dispose();
+      });
+
+      expect(container.read(gameEventBusProvider), same(custom));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `packages/colonizethis_logic/test/di/logic_providers_test.dart` so `test/di/` is populated per #2288 (test tree mirroring `lib/src/` layout).
- Covers default `orderSuggestionApiProvider` / `gameEventBusProvider` wiring, instance reuse, and `gameEventBusProvider` override for tests.

## Spec / AC
- Refactor-only; no GDD/TDD behavior change. Aligns with #2288 acceptance item for `test/di/` containing at least one test file.

## Out of scope / deferred
- Further `game_setup_ownership` / `capital_choice` extractions and other #2288 slices remain for follow-up PRs.
- Open PR #2376 (`combat_engagement` extract) is independent; not bundled here.

## Tests
- `cd packages/colonizethis_logic && dart analyze test/di/logic_providers_test.dart`
- `cd packages/colonizethis_logic && dart test test/di/logic_providers_test.dart`

Refs #2288

Made with [Cursor](https://cursor.com)