### PR TITLE
test(e2e): shared dismiss, bottom-sheet close, expansion helpers (Refs #2336)

### DIFF
--- a/SPEC/program/e2e-integration-tests.md
+++ b/SPEC/program/e2e-integration-tests.md
@@ -29,7 +29,7 @@
 
 **Code:** `app/lib/config/ct_e2e.dart`, `app/lib/config/ct_e2e_last_panel_snapshot.dart`, `app/lib/features/game/flame/game_screen_shared.dart` (next-turn key), `app/lib/features/game/flame/game_map_controls.dart` (region tab keys), `app/lib/features/game/widgets/move_fleet_dialog.dart` (move dialog scroll root).
 
-**Shared integration helpers:** `app/integration_test/e2e_test_shared.dart` — `e2eBootstrapNewGameToMap` / `e2eWaitForMapHudAfterNewGameStart`, `e2eWaitUntilFound`, `e2ePumpFor`, `e2eCollectTextPreorder`, transient UI dismissal and bottom-sheet close (`e2eDismissTransientUi`, `e2eCloseBottomSheet`), `e2eExpandEachExpansionTileOnce`, manifest + parallel 64px PNG verification (`e2eDiscoverRelocated64pxPngAssets`, `e2eEnsureRelocated64pxPngDecode`, `e2eDecodePngAssetPathsParallel`). Scenarios should call these instead of duplicating new-game→map polling or per-file asset preload (Refs GitHub #2336).
+**Shared integration helpers:** `app/integration_test/e2e_test_shared.dart` — `e2eBootstrapNewGameToMap` / `e2eWaitForMapHudAfterNewGameStart`, `e2eWaitUntilFound`, `e2ePumpFor`, `e2ePumpUntil`, `e2eCollectTextPreorder`, transient UI dismissal and bottom-sheet close (`e2eDismissTransientUi`, `e2eCloseBottomSheet`), `e2eExpandEachExpansionTileOnce`, manifest + parallel 64px PNG verification (`e2eDiscoverRelocated64pxPngAssets`, `e2eEnsureRelocated64pxPngDecode`, `e2eDecodePngAssetPathsParallel`). Scenarios should call these instead of duplicating new-game→map polling or per-file asset preload (Refs GitHub #2336).
 
 **Expected-line mirrors:** `app/lib/test_support/civilian_units_panel_e2e_expected_lines.dart`, `naval_units_panel_e2e_expected_lines.dart`, `production_panel_e2e_expected_lines.dart` (keep aligned with widgets).
 

--- a/SPEC/program/e2e-integration-tests.md
+++ b/SPEC/program/e2e-integration-tests.md
@@ -29,7 +29,7 @@
 
 **Code:** `app/lib/config/ct_e2e.dart`, `app/lib/config/ct_e2e_last_panel_snapshot.dart`, `app/lib/features/game/flame/game_screen_shared.dart` (next-turn key), `app/lib/features/game/flame/game_map_controls.dart` (region tab keys), `app/lib/features/game/widgets/move_fleet_dialog.dart` (move dialog scroll root).
 
-**Shared integration helpers:** `app/integration_test/e2e_test_shared.dart` — `e2eBootstrapNewGameToMap` / `e2eWaitForMapHudAfterNewGameStart`, `e2eWaitUntilFound`, `e2ePumpFor`, `e2eCollectTextPreorder`, manifest + parallel 64px PNG verification (`e2eDiscoverRelocated64pxPngAssets`, `e2eEnsureRelocated64pxPngDecode`, `e2eDecodePngAssetPathsParallel`). Scenarios should call these instead of duplicating new-game→map polling or per-file asset preload (Refs GitHub #2336).
+**Shared integration helpers:** `app/integration_test/e2e_test_shared.dart` — `e2eBootstrapNewGameToMap` / `e2eWaitForMapHudAfterNewGameStart`, `e2eWaitUntilFound`, `e2ePumpFor`, `e2eCollectTextPreorder`, transient UI dismissal and bottom-sheet close (`e2eDismissTransientUi`, `e2eCloseBottomSheet`), `e2eExpandEachExpansionTileOnce`, manifest + parallel 64px PNG verification (`e2eDiscoverRelocated64pxPngAssets`, `e2eEnsureRelocated64pxPngDecode`, `e2eDecodePngAssetPathsParallel`). Scenarios should call these instead of duplicating new-game→map polling or per-file asset preload (Refs GitHub #2336).
 
 **Expected-line mirrors:** `app/lib/test_support/civilian_units_panel_e2e_expected_lines.dart`, `naval_units_panel_e2e_expected_lines.dart`, `production_panel_e2e_expected_lines.dart` (keep aligned with widgets).
 

--- a/app/integration_test/e2e_test_shared.dart
+++ b/app/integration_test/e2e_test_shared.dart
@@ -115,6 +115,132 @@ Future<void> e2eWaitUntilAnyFinderHitTestable(
   );
 }
 
+/// Dismisses blocking snackbars, generic OK dialogs, [AlertDialog]s,
+/// [BottomSheet]s, and [CtDialogShell] overlays (union of fleet + full-turn
+/// E2E paths; Refs GitHub #2336).
+Future<void> e2eDismissTransientUi(
+  WidgetTester tester, {
+  E2ePerfLog? perf,
+}) async {
+  perf?.bumpCounter('dismiss_transient_ui_calls');
+  if (find.byType(SnackBar).evaluate().isNotEmpty) {
+    final snackAction = find.descendant(
+      of: find.byType(SnackBar),
+      matching: find.byType(TextButton),
+    );
+    if (snackAction.hitTestable().evaluate().isNotEmpty) {
+      await tester.tap(snackAction.first, warnIfMissed: false);
+      await e2ePumpFor(tester, const Duration(milliseconds: 200));
+      return;
+    }
+  }
+  final ok = find.text('OK').hitTestable();
+  if (ok.evaluate().isNotEmpty) {
+    await tester.tap(ok.first, warnIfMissed: false);
+    await e2ePumpFor(tester, const Duration(milliseconds: 200));
+    return;
+  }
+  if (find.byType(AlertDialog).evaluate().isNotEmpty) {
+    for (final label in ['Close', 'OK', 'Cancel', 'Yes']) {
+      final hit = find
+          .descendant(of: find.byType(AlertDialog), matching: find.text(label))
+          .hitTestable();
+      if (hit.evaluate().isNotEmpty) {
+        await tester.tap(hit.first, warnIfMissed: false);
+        await e2ePumpFor(tester, const Duration(milliseconds: 250));
+        return;
+      }
+    }
+    await tester.binding.handlePopRoute();
+    await e2ePumpFor(tester, const Duration(milliseconds: 200));
+    return;
+  }
+  if (find.byType(BottomSheet).evaluate().isNotEmpty) {
+    await e2eCloseBottomSheet(tester, perf: perf);
+  }
+  if (find.byType(CtDialogShell).evaluate().isNotEmpty) {
+    final closeCandidates = <Finder>[
+      find.text('Cancel'),
+      find.text('Close'),
+      find.byIcon(Icons.close),
+      find.byIcon(Icons.arrow_back),
+    ];
+    for (final candidate in closeCandidates) {
+      final tappable = candidate.hitTestable();
+      if (tappable.evaluate().isNotEmpty) {
+        await tester.tap(tappable.first, warnIfMissed: false);
+        await e2ePumpFor(tester, const Duration(milliseconds: 150));
+        return;
+      }
+    }
+    await tester.binding.handlePopRoute();
+    await e2ePumpFor(tester, const Duration(milliseconds: 150));
+  }
+}
+
+/// Pops an open [BottomSheet] within [timeout] using adaptive pump pacing.
+Future<void> e2eCloseBottomSheet(
+  WidgetTester tester, {
+  E2ePerfLog? perf,
+  Duration timeout = const Duration(seconds: 5),
+}) async {
+  perf?.bumpCounter('close_bottom_sheet_calls');
+  bool anyPanelOpen() => find.byType(BottomSheet).evaluate().isNotEmpty;
+
+  if (!anyPanelOpen()) {
+    return;
+  }
+
+  final sw = Stopwatch()..start();
+  var closePollMs = 25;
+  while (sw.elapsed < timeout) {
+    if (!anyPanelOpen()) {
+      perf?.timing('close_bottom_sheet', sw.elapsed);
+      return;
+    }
+    await tester.binding.handlePopRoute();
+    await tester.pump(Duration(milliseconds: closePollMs));
+    closePollMs = e2eAdaptivePollRampAfterIdle(closePollMs);
+  }
+
+  fail(
+    'Timed out after ${timeout.inSeconds}s closing bottom sheet; '
+    'panels remained visible',
+  );
+}
+
+/// Expands each visible collapsed [ExpansionTile] once per outer iteration.
+Future<void> e2eExpandEachExpansionTileOnce(WidgetTester tester) async {
+  for (var safety = 0; safety < 32; safety++) {
+    final tiles = find.byType(ExpansionTile);
+    final n = tiles.evaluate().length;
+    if (n == 0) {
+      return;
+    }
+
+    var expandedOne = false;
+    for (var j = 0; j < n; j++) {
+      final expandIcon = find.descendant(
+        of: tiles.at(j),
+        matching: find.byIcon(Icons.expand_more),
+      );
+      if (expandIcon.evaluate().isEmpty) {
+        continue;
+      }
+      final iconHit = expandIcon.first;
+      await tester.ensureVisible(iconHit);
+      await e2ePumpFor(tester, const Duration(milliseconds: 80));
+      await tester.tap(iconHit, warnIfMissed: false);
+      await e2ePumpFor(tester, const Duration(milliseconds: 250));
+      expandedOne = true;
+      break;
+    }
+    if (!expandedOne) {
+      return;
+    }
+  }
+}
+
 /// Loads and decodes each path with bounded concurrency (overlapping I/O +
 /// image decode completion) instead of strictly serial awaits.
 Future<List<String>> e2eDecodePngAssetPathsParallel(
@@ -311,7 +437,9 @@ Future<void> e2eEnsureRelocated64pxPngDecode(
   expect(
     failures,
     isEmpty,
-    reason: failures.isEmpty ? null : '$decodeFailuresPrefix\n${failures.join('\n')}',
+    reason: failures.isEmpty
+        ? null
+        : '$decodeFailuresPrefix\n${failures.join('\n')}',
   );
 }
 
@@ -322,19 +450,17 @@ Future<void> e2eEnsureRelocated64pxPngDecode(
 /// should still invoke at most once per [testWidgets] unless a future shared
 /// fixture deduplicates across tests (GitHub #2336).
 Future<void> e2eEnsureAllRelocated64pxPngsLoad() async {
-  await e2eEnsureRelocated64pxPngDecode(
-    <String>{
-      ...kCivilianIconSlugs.map(
-        (slug) => 'assets/icons/64/ui_icon_civ_$slug.png',
-      ),
-      ...kResourceIconIds.map(
-        (resourceId) => 'assets/icons/64/ui_icon_com_$resourceId.png',
-      ),
-      ...kTownIconIds.map((iconId) => 'assets/icons/64/ui_icon_com_$iconId.png'),
-      ...kProvinceLabelIconIds.map(
-        (iconId) => 'assets/icons/64/ui_icon_$iconId.png',
-      ),
-      kFleetMapIcon64PngAssetPath,
-    },
-  );
+  await e2eEnsureRelocated64pxPngDecode(<String>{
+    ...kCivilianIconSlugs.map(
+      (slug) => 'assets/icons/64/ui_icon_civ_$slug.png',
+    ),
+    ...kResourceIconIds.map(
+      (resourceId) => 'assets/icons/64/ui_icon_com_$resourceId.png',
+    ),
+    ...kTownIconIds.map((iconId) => 'assets/icons/64/ui_icon_com_$iconId.png'),
+    ...kProvinceLabelIconIds.map(
+      (iconId) => 'assets/icons/64/ui_icon_$iconId.png',
+    ),
+    kFleetMapIcon64PngAssetPath,
+  });
 }

--- a/app/integration_test/e2e_test_shared.dart
+++ b/app/integration_test/e2e_test_shared.dart
@@ -84,6 +84,34 @@ Future<void> e2eWaitUntilFound(
   );
 }
 
+/// Pumps until [condition] returns true, evaluating [condition] before the
+/// first pump and using exponential backoff on pump intervals (same cap as
+/// [e2eWaitUntilFound]). Refs GitHub #2336 (`pumpUntil` helper).
+Future<void> e2ePumpUntil(
+  WidgetTester tester,
+  bool Function() condition, {
+  required Duration timeout,
+  E2ePerfLog? perf,
+  String phaseName = 'pump_until',
+}) async {
+  final sw = Stopwatch()..start();
+  perf?.bumpCounter('pump_until_calls', meta: 'phase=$phaseName');
+  var stepMs = 25;
+  while (sw.elapsed < timeout) {
+    if (condition()) {
+      perf?.timing(phaseName, sw.elapsed, meta: 'result=met');
+      return;
+    }
+    await tester.pump(Duration(milliseconds: stepMs));
+    stepMs = math.min(500, stepMs * 2);
+  }
+  perf?.timing(phaseName, sw.elapsed, meta: 'result=timeout');
+  fail(
+    'Timed out after ${timeout.inSeconds}s in e2ePumpUntil ($phaseName). '
+    'Last exception: ${tester.takeException()}',
+  );
+}
+
 /// Returns after the first [Finder] has at least one hit-testable match.
 Future<void> e2eWaitUntilAnyFinderHitTestable(
   WidgetTester tester,

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
@@ -15,122 +15,6 @@ const Duration _kMaxUiResponseWait = Duration(seconds: 5);
 /// E2E policy caps wall-clock runtime to 5 minutes so PR feedback remains fast.
 const Duration _kFleetE2eMaxWallClock = Duration(minutes: 5);
 
-/// Dismisses blocking bottom sheets, dialog shells, snackbars, and generic OKs.
-///
-/// [AlertDialog] handling uses common action labels (including **Close** for
-/// prior-turn [TurnNewsDialog], `SPEC/ui/turn-news-dialog.md`) plus
-/// [WidgetsBinding.handlePopRoute] if none match.
-Future<void> _dismissTransientUi(
-  WidgetTester tester, {
-  E2ePerfLog? perf,
-}) async {
-  perf?.bumpCounter('dismiss_transient_ui_calls');
-  if (find.byType(SnackBar).evaluate().isNotEmpty) {
-    final snackAction = find.descendant(
-      of: find.byType(SnackBar),
-      matching: find.byType(TextButton),
-    );
-    if (snackAction.hitTestable().evaluate().isNotEmpty) {
-      await tester.tap(snackAction.first, warnIfMissed: false);
-      await e2ePumpFor(tester, const Duration(milliseconds: 200));
-      return;
-    }
-  }
-  final ok = find.text('OK').hitTestable();
-  if (ok.evaluate().isNotEmpty) {
-    await tester.tap(ok.first, warnIfMissed: false);
-    await e2ePumpFor(tester, const Duration(milliseconds: 200));
-    return;
-  }
-  if (find.byType(AlertDialog).evaluate().isNotEmpty) {
-    for (final label in ['Close', 'OK', 'Cancel', 'Yes']) {
-      final hit = find
-          .descendant(of: find.byType(AlertDialog), matching: find.text(label))
-          .hitTestable();
-      if (hit.evaluate().isNotEmpty) {
-        await tester.tap(hit.first, warnIfMissed: false);
-        await e2ePumpFor(tester, const Duration(milliseconds: 250));
-        return;
-      }
-    }
-    await tester.binding.handlePopRoute();
-    await e2ePumpFor(tester, const Duration(milliseconds: 200));
-    return;
-  }
-  if (find.byType(BottomSheet).evaluate().isNotEmpty) {
-    await _closeBottomSheet(tester, perf: perf);
-  }
-  if (find.byType(CtDialogShell).evaluate().isNotEmpty) {
-    final closeCandidates = <Finder>[
-      find.text('Cancel'),
-      find.text('Close'),
-      find.byIcon(Icons.close),
-      find.byIcon(Icons.arrow_back),
-    ];
-    for (final candidate in closeCandidates) {
-      final tappable = candidate.hitTestable();
-      if (tappable.evaluate().isNotEmpty) {
-        await tester.tap(tappable.first, warnIfMissed: false);
-        await e2ePumpFor(tester, const Duration(milliseconds: 150));
-        return;
-      }
-    }
-    await tester.binding.handlePopRoute();
-    await e2ePumpFor(tester, const Duration(milliseconds: 150));
-  }
-}
-
-Future<void> _closeBottomSheet(WidgetTester tester, {E2ePerfLog? perf}) async {
-  perf?.bumpCounter('close_bottom_sheet_calls');
-  bool anyPanelOpen() => find.byType(BottomSheet).evaluate().isNotEmpty;
-
-  if (!anyPanelOpen()) {
-    return;
-  }
-
-  final sw = Stopwatch()..start();
-  var closePollMs = 25;
-  while (sw.elapsed < _kMaxUiResponseWait) {
-    if (!anyPanelOpen()) {
-      perf?.timing('close_bottom_sheet', sw.elapsed);
-      return;
-    }
-    await tester.binding.handlePopRoute();
-    await tester.pump(Duration(milliseconds: closePollMs));
-    closePollMs = e2eAdaptivePollRampAfterIdle(closePollMs);
-  }
-
-  fail(
-    'Timed out after ${_kMaxUiResponseWait.inSeconds}s closing bottom sheet; '
-    'panels remained visible',
-  );
-}
-
-Future<void> _expandEachExpansionTileOnce(WidgetTester tester) async {
-  for (var safety = 0; safety < 32; safety++) {
-    final tiles = find.byType(ExpansionTile);
-    final n = tiles.evaluate().length;
-    if (n == 0) return;
-
-    var expandedOne = false;
-    for (var j = 0; j < n; j++) {
-      final expandIcon = find.descendant(
-        of: tiles.at(j),
-        matching: find.byIcon(Icons.expand_more),
-      );
-      if (expandIcon.evaluate().isEmpty) continue;
-      final iconHit = expandIcon.first;
-      await tester.ensureVisible(iconHit);
-      await e2ePumpFor(tester, const Duration(milliseconds: 80));
-      await tester.tap(iconHit, warnIfMissed: false);
-      await e2ePumpFor(tester, const Duration(milliseconds: 250));
-      expandedOne = true;
-      break;
-    }
-    if (!expandedOne) return;
-  }
-}
-
 Future<bool> _pollUntilNavalPanelVisible(
   WidgetTester tester,
   Finder navalPanel,
@@ -166,17 +50,21 @@ Future<void> _openNavalPanel(WidgetTester tester, {E2ePerfLog? perf}) async {
       return;
     }
     if (find.byType(BottomSheet).evaluate().isNotEmpty) {
-      await _closeBottomSheet(tester, perf: perf);
+      await e2eCloseBottomSheet(
+        tester,
+        perf: perf,
+        timeout: _kMaxUiResponseWait,
+      );
       navalPollMs = 25;
       continue;
     }
     if (find.byType(AlertDialog).evaluate().isNotEmpty) {
-      await _dismissTransientUi(tester, perf: perf);
+      await e2eDismissTransientUi(tester, perf: perf);
       navalPollMs = 25;
       continue;
     }
     if (find.byType(CtDialogShell).evaluate().isNotEmpty) {
-      await _dismissTransientUi(tester, perf: perf);
+      await e2eDismissTransientUi(tester, perf: perf);
       navalPollMs = 25;
       continue;
     }
@@ -207,7 +95,7 @@ Future<void> _openNavalPanel(WidgetTester tester, {E2ePerfLog? perf}) async {
       }
       navalPollMs = 25;
     } else {
-      await _dismissTransientUi(tester, perf: perf);
+      await e2eDismissTransientUi(tester, perf: perf);
       navalPollMs = 25;
     }
   }

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
@@ -236,13 +236,12 @@ Future<void> _pickMoveDestinationAndConfirm(
   final confirm = find.text(l10n.common_confirm).hitTestable();
   expect(confirm, findsWidgets);
   await tester.tap(confirm.first, warnIfMissed: false);
-  final dialogGone = Stopwatch()..start();
-  while (dialogGone.elapsed < const Duration(seconds: 2)) {
-    if (find.byType(AlertDialog).evaluate().isEmpty) {
-      break;
-    }
-    await tester.pump(const Duration(milliseconds: 25));
-  }
+  await e2ePumpUntil(
+    tester,
+    () => find.byType(AlertDialog).evaluate().isEmpty,
+    timeout: const Duration(seconds: 2),
+    phaseName: 'pump_until_move_dialog_closed',
+  );
   ensureBudget('after confirm');
 }
 
@@ -281,13 +280,13 @@ Future<void> _tryNavalMoveSegment(
     final cancel = find.text(l10n.common_cancel).hitTestable();
     expect(cancel, findsOneWidget);
     await tester.tap(cancel, warnIfMissed: false);
-    final cancelGone = Stopwatch()..start();
-    while (cancelGone.elapsed < const Duration(seconds: 2)) {
-      if (find.byType(AlertDialog).evaluate().isEmpty) {
-        break;
-      }
-      await tester.pump(const Duration(milliseconds: 25));
-    }
+    await e2ePumpUntil(
+      tester,
+      () => find.byType(AlertDialog).evaluate().isEmpty,
+      timeout: const Duration(seconds: 2),
+      perf: perf,
+      phaseName: 'pump_until_cancel_move_dialog_closed',
+    );
     perf?.timing(
       'fleet_move_segment',
       phaseSw.elapsed,

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -94,7 +94,7 @@ Future<bool> _tapMoveOnFirstNonHomeFleet(WidgetTester tester) async {
       return true;
     }
     if (allowExpandAllFallback) {
-      await _expandEachExpansionTileOnce(tester);
+      await e2eExpandEachExpansionTileOnce(tester);
       return false;
     }
     return false;
@@ -280,22 +280,22 @@ Future<void> _awaitNwCoastalOrVisibleLandForBundledExploreE2e({
   const maxTurns = 35;
   for (var i = 0; i < maxTurns; i++) {
     ensureUnderWallClock('NW bundled-explore readiness i=$i');
-    await _dismissTransientUi(tester);
+    await e2eDismissTransientUi(tester);
     await _tapNewWorldRegionTabIfPresent(tester);
     await _openNavalPanel(tester);
     if (_nonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot() ||
         _playerHasAnyNewWorldFoggedOrBetterFromCtSnapshot()) {
-      await _closeBottomSheet(tester);
+      await e2eCloseBottomSheet(tester);
       return;
     }
-    await _closeBottomSheet(tester);
+    await e2eCloseBottomSheet(tester);
     await _tryNavalMoveSegment(
       tester,
       l10n,
       useNewWorldMapTabFirst: true,
       allowWarpDestinations: false,
     );
-    await _closeBottomSheet(tester);
+    await e2eCloseBottomSheet(tester);
     await _advanceOneHumanTurn(tester, l10n);
   }
   // Some generated maps can keep the non-home fleet in open-ocean NW sea lanes
@@ -417,7 +417,7 @@ Future<void> _splitHomeFleetOnce(
     perf: perf,
     phaseName: 'wait_until_found_naval_panel',
   );
-  await _expandEachExpansionTileOnce(tester);
+  await e2eExpandEachExpansionTileOnce(tester);
   final navalPanelRoot = find.byKey(kCtE2ENavalPanelRootKey);
   final split = find.descendant(
     of: navalPanelRoot,
@@ -449,7 +449,7 @@ Future<void> _splitHomeFleetOnce(
   );
   await tester.tap(find.text(l10n.splitFleet_confirm));
   await e2ePumpFor(tester, const Duration(milliseconds: 120));
-  await _expandEachExpansionTileOnce(tester);
+  await e2eExpandEachExpansionTileOnce(tester);
   perf?.timing('fleet_split', phaseSw.elapsed);
 }
 
@@ -477,7 +477,7 @@ Future<void> _openCivilianPanelFleetE2e(WidgetTester tester) async {
   Future<bool> tryOpen(Finder trigger) async {
     final tappable = trigger.hitTestable();
     if (tappable.evaluate().isEmpty) {
-      await _dismissTransientUi(tester);
+      await e2eDismissTransientUi(tester);
       return false;
     }
     await tester.tap(tappable.first, warnIfMissed: false);
@@ -496,7 +496,7 @@ Future<void> _openCivilianPanelFleetE2e(WidgetTester tester) async {
     await tester.pump(const Duration(milliseconds: 100));
     if (civilianPanel.evaluate().isNotEmpty ||
         navalPanel.evaluate().isNotEmpty) {
-      await _closeBottomSheet(tester);
+      await e2eCloseBottomSheet(tester);
       continue;
     }
     if (empireRailButton.evaluate().isNotEmpty) {

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -72,7 +72,7 @@ void main() {
     final l10n = lookupAppLocalizations(const Locale('en'));
 
     await _splitHomeFleetOnce(tester, l10n, perf: perf);
-    await _closeBottomSheet(tester, perf: perf);
+    await e2eCloseBottomSheet(tester, perf: perf);
     ensureUnderWallClock('after split fleet');
 
     for (
@@ -82,11 +82,11 @@ void main() {
     ) {
       ensureUnderWallClock('turn loop start turnIdx=$turnIdx');
       perf.bumpCounter('turn_loop_iterations');
-      await _dismissTransientUi(tester, perf: perf);
+      await e2eDismissTransientUi(tester, perf: perf);
       await _tapNewWorldRegionTabIfPresent(tester);
       await _openNavalPanel(tester, perf: perf);
       if (_harnessDetectsNonHomeFleetInNewWorld(tester)) {
-        await _closeBottomSheet(tester, perf: perf);
+        await e2eCloseBottomSheet(tester, perf: perf);
         perf.timing(
           'test_total',
           testSw.elapsed,
@@ -94,10 +94,10 @@ void main() {
         );
         return;
       }
-      await _closeBottomSheet(tester, perf: perf);
+      await e2eCloseBottomSheet(tester, perf: perf);
 
       await _tryNavalMoveSegment(tester, l10n, perf: perf);
-      await _closeBottomSheet(tester, perf: perf);
+      await e2eCloseBottomSheet(tester, perf: perf);
 
       if (_harnessDetectsNonHomeFleetInNewWorld(tester)) {
         perf.timing(
@@ -109,12 +109,12 @@ void main() {
       }
 
       await _advanceOneHumanTurn(tester, l10n, perf: perf);
-      await _dismissTransientUi(tester, perf: perf);
+      await e2eDismissTransientUi(tester, perf: perf);
       ensureUnderWallClock('after turn advance turnIdx=$turnIdx');
     }
 
     ensureUnderWallClock('before final naval check');
-    await _dismissTransientUi(tester, perf: perf);
+    await e2eDismissTransientUi(tester, perf: perf);
     await _tapNewWorldRegionTabIfPresent(tester);
     await _openNavalPanel(tester, perf: perf);
     if (!_harnessDetectsNonHomeFleetInNewWorld(tester)) {
@@ -124,7 +124,7 @@ void main() {
         'Last exception: ${tester.takeException()}',
       );
     }
-    await _closeBottomSheet(tester, perf: perf);
+    await e2eCloseBottomSheet(tester, perf: perf);
     ensureUnderWallClock('test complete');
     perf.timing('test_total', testSw.elapsed, meta: 'result=final_check');
   });
@@ -165,7 +165,7 @@ void main() {
       final l10n = lookupAppLocalizations(const Locale('en'));
 
       await _splitHomeFleetOnce(tester, l10n, perf: perf);
-      await _closeBottomSheet(tester, perf: perf);
+      await e2eCloseBottomSheet(tester, perf: perf);
       ensureUnderWallClock('after split fleet');
       CtE2eNavalPanelSnapshot? lastKnownNavalSnapshot;
 
@@ -176,31 +176,31 @@ void main() {
       ) {
         ensureUnderWallClock('turn loop start turnIdx=$turnIdx');
         perf.bumpCounter('turn_loop_iterations');
-        await _dismissTransientUi(tester, perf: perf);
+        await e2eDismissTransientUi(tester, perf: perf);
         await _tapNewWorldRegionTabIfPresent(tester);
         await _openNavalPanel(tester, perf: perf);
         if (ctE2eNavalPanelSnapshot != null) {
           lastKnownNavalSnapshot = ctE2eNavalPanelSnapshot;
         }
         if (_harnessDetectsNonHomeFleetInNewWorld(tester)) {
-          await _closeBottomSheet(tester, perf: perf);
+          await e2eCloseBottomSheet(tester, perf: perf);
           break;
         }
-        await _closeBottomSheet(tester, perf: perf);
+        await e2eCloseBottomSheet(tester, perf: perf);
 
         await _tryNavalMoveSegment(tester, l10n, perf: perf);
-        await _closeBottomSheet(tester, perf: perf);
+        await e2eCloseBottomSheet(tester, perf: perf);
 
         if (_harnessDetectsNonHomeFleetInNewWorld(tester)) {
           break;
         }
 
         await _advanceOneHumanTurn(tester, l10n, perf: perf);
-        await _dismissTransientUi(tester, perf: perf);
+        await e2eDismissTransientUi(tester, perf: perf);
         ensureUnderWallClock('after turn advance turnIdx=$turnIdx');
       }
 
-      await _dismissTransientUi(tester, perf: perf);
+      await e2eDismissTransientUi(tester, perf: perf);
       await _tapNewWorldRegionTabIfPresent(tester);
       await _openNavalPanel(tester, perf: perf);
       if (ctE2eNavalPanelSnapshot != null) {
@@ -212,7 +212,7 @@ void main() {
           'Last exception: ${tester.takeException()}',
         );
       }
-      await _closeBottomSheet(tester, perf: perf);
+      await e2eCloseBottomSheet(tester, perf: perf);
       ensureUnderWallClock('fleet in NW confirmed');
 
       await _awaitNwCoastalOrVisibleLandForBundledExploreE2e(
@@ -235,7 +235,7 @@ void main() {
         final enabled = await _anyExplorerHasEnabledExploreAssignFleetE2e(
           tester,
         );
-        await _closeBottomSheet(tester, perf: perf);
+        await e2eCloseBottomSheet(tester, perf: perf);
         perf.timing(
           'bundled_explore_retry_loop',
           phaseSw.elapsed,
@@ -258,7 +258,7 @@ void main() {
         // Keep assertion strict, but retry with a small bounded loop.
         perf.bumpCounter('bundled_explore_retry_iterations');
         await _advanceOneHumanTurn(tester, l10n, perf: perf);
-        await _dismissTransientUi(tester, perf: perf);
+        await e2eDismissTransientUi(tester, perf: perf);
         await _tapNewWorldRegionTabIfPresent(tester);
         exploreEnabled = await checkExploreEnabledFromCivilianPanel();
       }

--- a/app/integration_test/new_game_full_turn_e2e_test.dart
+++ b/app/integration_test/new_game_full_turn_e2e_test.dart
@@ -16,34 +16,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-Future<void> _dismissTransientUi(
-  WidgetTester tester, {
-  E2ePerfLog? perf,
-}) async {
-  perf?.bumpCounter('dismiss_transient_ui_calls');
-  if (find.byType(BottomSheet).evaluate().isNotEmpty) {
-    await _closeBottomSheet(tester, perf: perf);
-  }
-  if (find.byType(CtDialogShell).evaluate().isNotEmpty) {
-    final closeCandidates = <Finder>[
-      find.text('Cancel'),
-      find.text('Close'),
-      find.byIcon(Icons.close),
-      find.byIcon(Icons.arrow_back),
-    ];
-    for (final candidate in closeCandidates) {
-      final tappable = candidate.hitTestable();
-      if (tappable.evaluate().isNotEmpty) {
-        await tester.tap(tappable.first, warnIfMissed: false);
-        await e2ePumpFor(tester, const Duration(milliseconds: 150));
-        return;
-      }
-    }
-    await tester.binding.handlePopRoute();
-    await e2ePumpFor(tester, const Duration(milliseconds: 150));
-  }
-}
-
 Future<void> _openCivilianPanel(
   WidgetTester tester, {
   Duration timeout = const Duration(seconds: 20),
@@ -58,7 +30,7 @@ Future<void> _openCivilianPanel(
     final tappable = trigger.hitTestable();
     if (tappable.evaluate().isEmpty) {
       // Dismiss blocking overlays/dialogs before retrying.
-      await _dismissTransientUi(tester, perf: perf);
+      await e2eDismissTransientUi(tester, perf: perf);
       return false;
     }
     await tester.tap(tappable.first, warnIfMissed: false);
@@ -77,7 +49,7 @@ Future<void> _openCivilianPanel(
     await tester.pump(const Duration(milliseconds: 100));
     if (civilianPanel.evaluate().isNotEmpty ||
         navalPanel.evaluate().isNotEmpty) {
-      await _closeBottomSheet(tester, perf: perf);
+      await e2eCloseBottomSheet(tester, perf: perf);
       continue;
     }
     if (empireRailButton.evaluate().isNotEmpty) {
@@ -116,7 +88,7 @@ Future<void> _openPanelFromMarker(
     final tappable = markerButton.hitTestable();
     if (tappable.evaluate().isEmpty) {
       // Clear transient overlays/dialogs that can block marker taps.
-      await _dismissTransientUi(tester, perf: perf);
+      await e2eDismissTransientUi(tester, perf: perf);
       continue;
     }
     await tester.tap(tappable.first, warnIfMissed: false);
@@ -135,29 +107,6 @@ Future<void> _openPanelFromMarker(
   );
 }
 
-Future<void> _closeBottomSheet(WidgetTester tester, {E2ePerfLog? perf}) async {
-  perf?.bumpCounter('close_bottom_sheet_calls');
-  bool anyPanelOpen() => find.byType(BottomSheet).evaluate().isNotEmpty;
-
-  if (!anyPanelOpen()) {
-    return;
-  }
-
-  final sw = Stopwatch()..start();
-  var closePollMs = 25;
-  while (sw.elapsed < const Duration(seconds: 5)) {
-    if (!anyPanelOpen()) {
-      perf?.timing('close_bottom_sheet', sw.elapsed);
-      return;
-    }
-    await tester.binding.handlePopRoute();
-    await tester.pump(Duration(milliseconds: closePollMs));
-    closePollMs = e2eAdaptivePollRampAfterIdle(closePollMs);
-  }
-
-  fail('Timed out closing bottom sheet; panels remained visible');
-}
-
 Future<void> _openProductionPanel(WidgetTester tester) async {
   final productionPanel = find.byKey(kCtE2EProductionPanelRootKey);
   final productionButton = find.byKey(kEmpireProductionButtonKey);
@@ -171,7 +120,7 @@ Future<void> _openProductionPanel(WidgetTester tester) async {
     }
 
     if (find.byType(BottomSheet).evaluate().isNotEmpty) {
-      await _closeBottomSheet(tester);
+      await e2eCloseBottomSheet(tester);
       prodPollMs = 25;
       continue;
     }
@@ -196,7 +145,7 @@ Future<void> _openProductionPanel(WidgetTester tester) async {
       prodPollMs = 25;
     } else {
       // Dismiss transient overlays/dialogs and retry opening from the rail.
-      await _dismissTransientUi(tester);
+      await e2eDismissTransientUi(tester);
       prodPollMs = 25;
     }
   }
@@ -338,34 +287,6 @@ Future<void> _tapAssignOnCivilianRowWithTitle(
   fail('No idle Assign row for unit type "$unitTypeTitle" in civilian panel');
 }
 
-Future<void> _expandEachExpansionTileOnce(WidgetTester tester) async {
-  // Re-query after each tap: expanding one tile rebuilds the panel, so a
-  // cached `ExpansionTile` count / `tiles.at(j)` from a prior frame can throw
-  // (e.g. index 1 when only one tile remains).
-  for (var safety = 0; safety < 32; safety++) {
-    final tiles = find.byType(ExpansionTile);
-    final n = tiles.evaluate().length;
-    if (n == 0) return;
-
-    var expandedOne = false;
-    for (var j = 0; j < n; j++) {
-      final expandIcon = find.descendant(
-        of: tiles.at(j),
-        matching: find.byIcon(Icons.expand_more),
-      );
-      if (expandIcon.evaluate().isEmpty) continue;
-      final iconHit = expandIcon.first;
-      await tester.ensureVisible(iconHit);
-      await e2ePumpFor(tester, const Duration(milliseconds: 80));
-      await tester.tap(iconHit, warnIfMissed: false);
-      await e2ePumpFor(tester, const Duration(milliseconds: 250));
-      expandedOne = true;
-      break;
-    }
-    if (!expandedOne) return;
-  }
-}
-
 void main() {
   suppressLogsForTests();
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -475,7 +396,7 @@ void main() {
       // --- Civilian (empire rail): baseline ---
       await _openCivilianPanel(tester, perf: perf);
       await expectCivilianPanelTexts();
-      await _closeBottomSheet(tester, perf: perf);
+      await e2eCloseBottomSheet(tester, perf: perf);
 
       // --- Builder: build improvement + first legal tile (e2e tap target) ---
       await _openCivilianPanel(tester, perf: perf);
@@ -484,7 +405,7 @@ void main() {
       await e2ePumpFor(tester, const Duration(milliseconds: 400));
       await tester.tap(find.byKey(kCtE2ESelectFirstValidWorkTileKey));
       await e2ePumpFor(tester, const Duration(milliseconds: 500));
-      await _closeBottomSheet(tester, perf: perf);
+      await e2eCloseBottomSheet(tester, perf: perf);
 
       // --- Explorer: prospect + first legal tile ---
       await _openCivilianPanel(tester, perf: perf);
@@ -493,19 +414,19 @@ void main() {
       await e2ePumpFor(tester, const Duration(milliseconds: 400));
       await tester.tap(find.byKey(kCtE2ESelectFirstValidWorkTileKey));
       await e2ePumpFor(tester, const Duration(milliseconds: 500));
-      await _closeBottomSheet(tester, perf: perf);
+      await e2eCloseBottomSheet(tester, perf: perf);
 
       // --- Civilian rail: after draft orders ---
       await tester.tap(find.byKey(kEmpireCivilianUnitsButtonKey));
       await e2ePumpFor(tester, const Duration(milliseconds: 400));
       await expectCivilianPanelTexts();
-      await _closeBottomSheet(tester, perf: perf);
+      await e2eCloseBottomSheet(tester, perf: perf);
 
       // --- Naval rail: collapsed ---
       await tester.tap(find.byKey(kEmpireNavalUnitsButtonKey));
       await e2ePumpFor(tester, const Duration(milliseconds: 400));
       await expectNavalPanelTexts(expanded: false);
-      await _expandEachExpansionTileOnce(tester);
+      await e2eExpandEachExpansionTileOnce(tester);
       final navalPanelRoot = find.byKey(kCtE2ENavalPanelRootKey);
       final split = find.descendant(
         of: navalPanelRoot,
@@ -526,7 +447,7 @@ void main() {
       await e2ePumpFor(tester, const Duration(seconds: 1));
 
       // Split triggers a panel refresh; ensure fleet tiles are expanded again.
-      await _expandEachExpansionTileOnce(tester);
+      await e2eExpandEachExpansionTileOnce(tester);
       final moveButtons = find.descendant(
         of: navalPanelRoot,
         matching: find.text('Move'),
@@ -562,9 +483,9 @@ void main() {
         }
       }
 
-      await _expandEachExpansionTileOnce(tester);
+      await e2eExpandEachExpansionTileOnce(tester);
       await expectNavalPanelTexts(expanded: true);
-      await _closeBottomSheet(tester, perf: perf);
+      await e2eCloseBottomSheet(tester, perf: perf);
 
       // --- Civilian + naval from first map markers (tile scope) ---
       await _openPanelFromMarker(
@@ -574,7 +495,7 @@ void main() {
         perf: perf,
       );
       await expectCivilianPanelTexts();
-      await _closeBottomSheet(tester, perf: perf);
+      await e2eCloseBottomSheet(tester, perf: perf);
 
       await _openPanelFromMarker(
         tester,
@@ -583,7 +504,7 @@ void main() {
         perf: perf,
       );
       await expectNavalPanelTexts(expanded: false);
-      await _closeBottomSheet(tester, perf: perf);
+      await e2eCloseBottomSheet(tester, perf: perf);
 
       // --- Next turn ---
       final turnBefore =

--- a/app/test/e2e_test_shared_smoke_test.dart
+++ b/app/test/e2e_test_shared_smoke_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/e2e_test_shared.dart';
+
+void main() {
+  test('e2eAdaptivePollRampAfterIdle ramps under 100ms then caps', () {
+    expect(e2eAdaptivePollRampAfterIdle(25), 50);
+    expect(e2eAdaptivePollRampAfterIdle(75), 100);
+    expect(e2eAdaptivePollRampAfterIdle(100), 100);
+  });
+
+  testWidgets('e2ePumpUntil succeeds when condition is already true', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    var calls = 0;
+    await e2ePumpUntil(
+      tester,
+      () {
+        calls++;
+        return true;
+      },
+      timeout: const Duration(seconds: 1),
+      phaseName: 'smoke_immediate',
+    );
+    expect(calls, 1);
+  });
+
+  testWidgets('e2eCloseBottomSheet no-ops when no bottom sheet', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    await e2eCloseBottomSheet(tester);
+  });
+
+  testWidgets('e2eDismissTransientUi no-ops on empty scaffold', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    await e2eDismissTransientUi(tester);
+  });
+}

--- a/app/test/e2e_test_shared_smoke_test.dart
+++ b/app/test/e2e_test_shared_smoke_test.dart
@@ -1,9 +1,11 @@
+import 'package:colonizethis_test/test.dart' show suppressLogsForTests;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../integration_test/e2e_test_shared.dart';
 
 void main() {
+  suppressLogsForTests();
   test('e2eAdaptivePollRampAfterIdle ramps under 100ms then caps', () {
     expect(e2eAdaptivePollRampAfterIdle(25), 50);
     expect(e2eAdaptivePollRampAfterIdle(75), 100);


### PR DESCRIPTION
## Summary
Centralizes three duplicated E2E helpers into `app/integration_test/e2e_test_shared.dart` and routes the full-turn and fleet-reach integration scenarios through them.

## Refs
Refs #2336 (does not close the issue).

## SPEC
- `SPEC/program/e2e-integration-tests.md`: shared-helper bullet now lists `e2eDismissTransientUi`, `e2eCloseBottomSheet`, and `e2eExpandEachExpansionTileOnce`.

## Implementation
- **`e2eDismissTransientUi`:** Union behavior from the fleet helpers path (SnackBar, standalone OK, `AlertDialog` action labels, then bottom sheet + `CtDialogShell`), replacing the slimmer full-turn-only variant so both scenarios share one dismissal policy.
- **`e2eCloseBottomSheet`:** Adaptive pop-route loop with configurable timeout (default 5s); fleet naval open path passes `timeout: _kMaxUiResponseWait` to preserve that cap.
- **`e2eExpandEachExpansionTileOnce`:** Same expansion-tile sweep as before, moved verbatim into shared.

## Tests / verification
- `cd app && dart format integration_test/...` (touched files)
- `cd app && flutter analyze integration_test/` — clean

E2E suites were not re-run locally in this pass (Linux desktop + `CT_E2E`); CI does not execute them on PR checks per issue/SPEC.

## Scope vs issue ACs
**In this PR:** AC1-style growth of shared helpers (canonical dismiss / close / expansion); partial progress on AC2 (removes duplicate private definitions for these three helpers across full-turn + fleet files).

**Deferred (follow-up PRs / existing open PRs):** Remaining private E2E helpers still local to scenarios; AC4–H1–H10 sweep beyond this slice; AC8–AC9 baseline wall-clock tables; capital-panel scenario does not call these helpers today.

Made with [Cursor](https://cursor.com)