### PR TITLE
refactor(logic): extract WorkSuggestionPipeline (Refs #2391)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
@@ -13,6 +13,7 @@ import 'order_suggestion_work_tile_keys.dart';
 import 'order_suggestion_work_tile_prefilter.dart';
 import 'order_suggestion_context.dart';
 import 'order_visibility.dart';
+import 'work_suggestion_pipeline.dart';
 import 'partial_province_reveal.dart';
 import 'orders_application_helpers.dart';
 import 'unit_type_helpers.dart';
@@ -21,115 +22,6 @@ part 'order_suggestion_work_explorer.dart';
 part 'order_suggestion_work_worker.dart';
 part 'order_suggestion_work_spy.dart';
 part 'order_suggestion_work_merchant.dart';
-
-void _suggestionWorkLog({
-  required String unitId,
-  required String unitType,
-  required String unitRegionId,
-  required String atProvinceId,
-  required String workTarget,
-  required String outcome,
-  String reason = '-',
-  String tile = '-',
-
-  /// When [outcome] is `included` and greater than 1 row is accepted in one
-  /// pass, emit a single summary line with `includedCount=` (Refs #2277,
-  /// SPEC/program/order-suggestions.md § Suggestion observability).
-  int? includedRowCount,
-}) {
-  final multiIncluded =
-      outcome == 'included' && includedRowCount != null && includedRowCount > 1;
-  final tileField = multiIncluded ? '-' : tile;
-  final countSuffix = multiIncluded ? ' includedCount=$includedRowCount' : '';
-  orderSuggestionLog.d(
-    'suggest_work unitId=$unitId unitType=$unitType region=$unitRegionId '
-    'at=$atProvinceId target=$workTarget outcome=$outcome reason=$reason '
-    'tile=$tileField$countSuffix',
-  );
-}
-
-typedef _SuggestionCandidatesProvider = Iterable<WorkOrder> Function();
-typedef _SuggestionCandidateAcceptor = bool Function(WorkOrder candidate);
-
-void _runWorkSuggestionPipeline({
-  required Unit unit,
-  required String unitType,
-  required String unitRegionId,
-  required String atProvinceId,
-  required String workTarget,
-  required Map<String, Set<String>> existingTargetsByUnit,
-  required List<WorkOrder> suggestions,
-  required _SuggestionCandidatesProvider candidatesProvider,
-  required _SuggestionCandidateAcceptor candidateAcceptor,
-  required String noCandidateReason,
-  String engineRejectedReason = 'engine_rejected',
-  bool includeAllAccepted = false,
-}) {
-  final existing = existingTargetsByUnit[unit.id];
-  if (existing != null && existing.contains(workTarget)) {
-    _suggestionWorkLog(
-      unitId: unit.id,
-      unitType: unitType,
-      unitRegionId: unitRegionId,
-      atProvinceId: atProvinceId,
-      workTarget: workTarget,
-      outcome: 'excluded',
-      reason: 'duplicate_pending',
-    );
-    return;
-  }
-
-  var sawCandidate = false;
-  var acceptedCount = 0;
-  var firstIncludedTile = '-';
-  for (final candidate in candidatesProvider()) {
-    sawCandidate = true;
-    if (!candidateAcceptor(candidate)) continue;
-    acceptedCount++;
-    suggestions.add(candidate);
-    existingTargetsByUnit
-        .putIfAbsent(unit.id, () => <String>{})
-        .add(workTarget);
-    if (acceptedCount == 1) {
-      firstIncludedTile = candidate.targetTileKey;
-    }
-    if (!includeAllAccepted) {
-      _suggestionWorkLog(
-        unitId: unit.id,
-        unitType: unitType,
-        unitRegionId: unitRegionId,
-        atProvinceId: atProvinceId,
-        workTarget: workTarget,
-        outcome: 'included',
-        tile: candidate.targetTileKey,
-      );
-      return;
-    }
-  }
-
-  if (acceptedCount > 0) {
-    _suggestionWorkLog(
-      unitId: unit.id,
-      unitType: unitType,
-      unitRegionId: unitRegionId,
-      atProvinceId: atProvinceId,
-      workTarget: workTarget,
-      outcome: 'included',
-      tile: firstIncludedTile,
-      includedRowCount: acceptedCount,
-    );
-  } else {
-    _suggestionWorkLog(
-      unitId: unit.id,
-      unitType: unitType,
-      unitRegionId: unitRegionId,
-      atProvinceId: atProvinceId,
-      workTarget: workTarget,
-      outcome: 'excluded',
-      reason: sawCandidate ? engineRejectedReason : noCandidateReason,
-    );
-  }
-}
 
 /// Suggests candidate work orders for explorers and civilian workers owned by
 /// [view.playerId]. Worker units (Builder, Engineer, Rail Builder): at least

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_explorer.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_explorer.dart
@@ -101,7 +101,7 @@ void _addExplorerWorkSuggestionsForUnit({
   final pendingOrClaimed = existingTargetsByUnit[unit.id];
   if (pendingOrClaimed != null && pendingOrClaimed.isNotEmpty) {
     for (final target in [kWorkTargetExplore, kWorkTargetProspect]) {
-      _suggestionWorkLog(
+      logWorkOrderSuggestion(
         unitId: unit.id,
         unitType: unit.type,
         unitRegionId: regionId,
@@ -149,7 +149,7 @@ void _addExplorerWorkSuggestionsForUnit({
     for (final chosen in acceptedExplores) {
       suggestions.add(chosen);
     }
-    _suggestionWorkLog(
+    logWorkOrderSuggestion(
       unitId: unit.id,
       unitType: unit.type,
       unitRegionId: regionId,
@@ -160,7 +160,7 @@ void _addExplorerWorkSuggestionsForUnit({
       includedRowCount: acceptedExplores.length,
     );
   } else {
-    _suggestionWorkLog(
+    logWorkOrderSuggestion(
       unitId: unit.id,
       unitType: unit.type,
       unitRegionId: regionId,
@@ -275,7 +275,7 @@ void _addProspectSuggestionIfEligible({
   final existingProspect = existingTargetsByUnit[unit.id];
   if (existingProspect != null &&
       existingProspect.contains(kWorkTargetProspect)) {
-    _suggestionWorkLog(
+    logWorkOrderSuggestion(
       unitId: unit.id,
       unitType: unit.type,
       unitRegionId: regionId,
@@ -342,7 +342,7 @@ void _addProspectSuggestionIfEligible({
     }
   }
   if (prospectRows.isEmpty) {
-    _suggestionWorkLog(
+    logWorkOrderSuggestion(
       unitId: unit.id,
       unitType: unit.type,
       unitRegionId: regionId,
@@ -360,7 +360,7 @@ void _addProspectSuggestionIfEligible({
   for (final candidate in prospectRows) {
     suggestions.add(candidate);
   }
-  _suggestionWorkLog(
+  logWorkOrderSuggestion(
     unitId: unit.id,
     unitType: unit.type,
     unitRegionId: regionId,

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_merchant.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_merchant.dart
@@ -23,7 +23,7 @@ void _addMerchantSuggestionsForUnit({
 
   final resourceByTile = game.worldState.resourceByTileKey;
   final playerIds = game.players.map((p) => p.id).toSet();
-  _runWorkSuggestionPipeline(
+  WorkSuggestionPipeline.run(
     unit: unit,
     unitType: type,
     unitRegionId: unitRegionId,

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_spy.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_spy.dart
@@ -37,7 +37,7 @@ void _addSpySuggestionsForUnit({
   );
 
   if (!allowedTargets.contains(kWorkTargetStealTech)) return;
-  _runWorkSuggestionPipeline(
+  WorkSuggestionPipeline.run(
     unit: unit,
     unitType: type,
     unitRegionId: unitRegionId,
@@ -84,7 +84,7 @@ void _addCounterSpySuggestionIfEligible({
 }) {
   if (!allowedTargets.contains(kWorkTargetCounterSpy)) return;
   if (ownerId != playerId) {
-    _suggestionWorkLog(
+    logWorkOrderSuggestion(
       unitId: unit.id,
       unitType: type,
       unitRegionId: unitRegionId,
@@ -96,7 +96,7 @@ void _addCounterSpySuggestionIfEligible({
     return;
   }
 
-  _runWorkSuggestionPipeline(
+  WorkSuggestionPipeline.run(
     unit: unit,
     unitType: type,
     unitRegionId: unitRegionId,

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_worker.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_worker.dart
@@ -34,7 +34,7 @@ void _addWorkerSuggestionsForUnit({
       },
     );
 
-    _runWorkSuggestionPipeline(
+    WorkSuggestionPipeline.run(
       unit: unit,
       unitType: type,
       unitRegionId: unitRegionId,

--- a/packages/colonizethis_logic/lib/src/orders/work_suggestion_pipeline.dart
+++ b/packages/colonizethis_logic/lib/src/orders/work_suggestion_pipeline.dart
@@ -1,0 +1,120 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'order_suggestion_context.dart';
+
+/// Emits one structured line per work-order suggestion decision (Refs #2277,
+/// SPEC/program/order-suggestions.md suggestion observability).
+void logWorkOrderSuggestion({
+  required String unitId,
+  required String unitType,
+  required String unitRegionId,
+  required String atProvinceId,
+  required String workTarget,
+  required String outcome,
+  String reason = '-',
+  String tile = '-',
+
+  /// When [outcome] is `included` and greater than 1 row is accepted in one
+  /// pass, emit a single summary line with `includedCount=` (Refs #2277,
+  /// SPEC/program/order-suggestions.md suggestion observability).
+  int? includedRowCount,
+}) {
+  final multiIncluded =
+      outcome == 'included' && includedRowCount != null && includedRowCount > 1;
+  final tileField = multiIncluded ? '-' : tile;
+  final countSuffix = multiIncluded ? ' includedCount=$includedRowCount' : '';
+  orderSuggestionLog.d(
+    'suggest_work unitId=$unitId unitType=$unitType region=$unitRegionId '
+    'at=$atProvinceId target=$workTarget outcome=$outcome reason=$reason '
+    'tile=$tileField$countSuffix',
+  );
+}
+
+typedef WorkSuggestionCandidatesProvider = Iterable<WorkOrder> Function();
+typedef WorkSuggestionCandidateAcceptor = bool Function(WorkOrder candidate);
+
+/// Shared work-order suggestion pipeline used by explorer, worker, spy, and
+/// merchant suggestion paths (Refs #2391 AC8).
+class WorkSuggestionPipeline {
+  WorkSuggestionPipeline._();
+
+  static void run({
+    required Unit unit,
+    required String unitType,
+    required String unitRegionId,
+    required String atProvinceId,
+    required String workTarget,
+    required Map<String, Set<String>> existingTargetsByUnit,
+    required List<WorkOrder> suggestions,
+    required WorkSuggestionCandidatesProvider candidatesProvider,
+    required WorkSuggestionCandidateAcceptor candidateAcceptor,
+    required String noCandidateReason,
+    String engineRejectedReason = 'engine_rejected',
+    bool includeAllAccepted = false,
+  }) {
+    final existing = existingTargetsByUnit[unit.id];
+    if (existing != null && existing.contains(workTarget)) {
+      logWorkOrderSuggestion(
+        unitId: unit.id,
+        unitType: unitType,
+        unitRegionId: unitRegionId,
+        atProvinceId: atProvinceId,
+        workTarget: workTarget,
+        outcome: 'excluded',
+        reason: 'duplicate_pending',
+      );
+      return;
+    }
+
+    var sawCandidate = false;
+    var acceptedCount = 0;
+    var firstIncludedTile = '-';
+    for (final candidate in candidatesProvider()) {
+      sawCandidate = true;
+      if (!candidateAcceptor(candidate)) continue;
+      acceptedCount++;
+      suggestions.add(candidate);
+      existingTargetsByUnit
+          .putIfAbsent(unit.id, () => <String>{})
+          .add(workTarget);
+      if (acceptedCount == 1) {
+        firstIncludedTile = candidate.targetTileKey;
+      }
+      if (!includeAllAccepted) {
+        logWorkOrderSuggestion(
+          unitId: unit.id,
+          unitType: unitType,
+          unitRegionId: unitRegionId,
+          atProvinceId: atProvinceId,
+          workTarget: workTarget,
+          outcome: 'included',
+          tile: candidate.targetTileKey,
+        );
+        return;
+      }
+    }
+
+    if (acceptedCount > 0) {
+      logWorkOrderSuggestion(
+        unitId: unit.id,
+        unitType: unitType,
+        unitRegionId: unitRegionId,
+        atProvinceId: atProvinceId,
+        workTarget: workTarget,
+        outcome: 'included',
+        tile: firstIncludedTile,
+        includedRowCount: acceptedCount,
+      );
+    } else {
+      logWorkOrderSuggestion(
+        unitId: unit.id,
+        unitType: unitType,
+        unitRegionId: unitRegionId,
+        atProvinceId: atProvinceId,
+        workTarget: workTarget,
+        outcome: 'excluded',
+        reason: sawCandidate ? engineRejectedReason : noCandidateReason,
+      );
+    }
+  }
+}

--- a/packages/colonizethis_logic/test/orders/work_suggestion_pipeline_test.dart
+++ b/packages/colonizethis_logic/test/orders/work_suggestion_pipeline_test.dart
@@ -1,0 +1,234 @@
+import 'package:colonizethis_logic/src/constants.dart';
+import 'package:colonizethis_logic/src/orders/work_suggestion_pipeline.dart';
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:logger/logger.dart';
+
+List<String> _suggestWorkLines(List<LogEvent> events) => [
+  for (final e in events)
+    if (e.message.contains('suggest_work')) e.message,
+];
+
+void main() {
+  suppressLogsForTests();
+  group('WorkSuggestionPipeline', () {
+    late List<LogEvent> capturedEvents;
+    late void Function(LogEvent) listener;
+
+    setUp(() {
+      capturedEvents = [];
+      listener = capturedEvents.add;
+      Logger.addLogListener(listener);
+      Logger.level = Level.debug;
+    });
+
+    tearDown(() {
+      Logger.removeLogListener(listener);
+      capturedEvents.clear();
+      Logger.level = Level.info;
+    });
+
+    test(
+      'duplicate pending target short-circuits without adding suggestions',
+      () {
+        const playerId = 'gp1';
+        final unit = Unit(
+          id: 'u1',
+          type: kUnitTypeBuilder,
+          ownerId: playerId,
+          locationProvinceId: 'ow|p1',
+          tileKey: 'ow|p1|0|0',
+          status: UnitStatus.idle,
+        );
+        final suggestions = <WorkOrder>[];
+        final existing = <String, Set<String>>{
+          unit.id: {kWorkTargetBuildImprovement},
+        };
+
+        WorkSuggestionPipeline.run(
+          unit: unit,
+          unitType: unit.type,
+          unitRegionId: 'ow',
+          atProvinceId: 'ow|p1',
+          workTarget: kWorkTargetBuildImprovement,
+          existingTargetsByUnit: existing,
+          suggestions: suggestions,
+          candidatesProvider: () => [
+            WorkOrder(
+              unitId: unit.id,
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: 'ow|p1|0|0',
+            ),
+          ],
+          candidateAcceptor: (_) => true,
+          noCandidateReason: 'no_valid_tile',
+        );
+
+        expect(suggestions, isEmpty);
+        final lines = _suggestWorkLines(capturedEvents);
+        expect(lines, isNotEmpty);
+        expect(lines.first, contains('reason=duplicate_pending'));
+      },
+    );
+
+    test(
+      'first accepted candidate stops iteration when includeAllAccepted is false',
+      () {
+        const playerId = 'gp1';
+        final unit = Unit(
+          id: 'u1',
+          type: kUnitTypeBuilder,
+          ownerId: playerId,
+          locationProvinceId: 'ow|p1',
+          tileKey: 'ow|p1|0|0',
+          status: UnitStatus.idle,
+        );
+        final suggestions = <WorkOrder>[];
+        final existing = <String, Set<String>>{};
+
+        WorkSuggestionPipeline.run(
+          unit: unit,
+          unitType: unit.type,
+          unitRegionId: 'ow',
+          atProvinceId: 'ow|p1',
+          workTarget: kWorkTargetBuildImprovement,
+          existingTargetsByUnit: existing,
+          suggestions: suggestions,
+          candidatesProvider: () sync* {
+            yield WorkOrder(
+              unitId: unit.id,
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: 'a',
+            );
+            yield WorkOrder(
+              unitId: unit.id,
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: 'b',
+            );
+          },
+          candidateAcceptor: (_) => true,
+          noCandidateReason: 'no_valid_tile',
+        );
+
+        expect(suggestions, hasLength(1));
+        expect(suggestions.single.targetTileKey, 'a');
+        expect(existing[unit.id], contains(kWorkTargetBuildImprovement));
+      },
+    );
+
+    test(
+      'includeAllAccepted collects multiple rows and logs includedCount',
+      () {
+        const playerId = 'gp1';
+        final unit = Unit(
+          id: 'u1',
+          type: kUnitTypeBuilder,
+          ownerId: playerId,
+          locationProvinceId: 'ow|p1',
+          tileKey: 'ow|p1|0|0',
+          status: UnitStatus.idle,
+        );
+        final suggestions = <WorkOrder>[];
+        final existing = <String, Set<String>>{};
+
+        WorkSuggestionPipeline.run(
+          unit: unit,
+          unitType: unit.type,
+          unitRegionId: 'ow',
+          atProvinceId: 'ow|p1',
+          workTarget: kWorkTargetBuildImprovement,
+          existingTargetsByUnit: existing,
+          suggestions: suggestions,
+          candidatesProvider: () sync* {
+            yield WorkOrder(
+              unitId: unit.id,
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: 'a',
+            );
+            yield WorkOrder(
+              unitId: unit.id,
+              target: kWorkTargetBuildImprovement,
+              targetTileKey: 'b',
+            );
+          },
+          candidateAcceptor: (_) => true,
+          noCandidateReason: 'no_valid_tile',
+          includeAllAccepted: true,
+        );
+
+        expect(suggestions, hasLength(2));
+        final lines = _suggestWorkLines(capturedEvents);
+        expect(lines.last, contains('includedCount=2'));
+      },
+    );
+
+    test('no candidates logs noCandidateReason', () {
+      const playerId = 'gp1';
+      final unit = Unit(
+        id: 'u1',
+        type: kUnitTypeBuilder,
+        ownerId: playerId,
+        locationProvinceId: 'ow|p1',
+        tileKey: 'ow|p1|0|0',
+        status: UnitStatus.idle,
+      );
+      final suggestions = <WorkOrder>[];
+      final existing = <String, Set<String>>{};
+
+      WorkSuggestionPipeline.run(
+        unit: unit,
+        unitType: unit.type,
+        unitRegionId: 'ow',
+        atProvinceId: 'ow|p1',
+        workTarget: kWorkTargetBuildImprovement,
+        existingTargetsByUnit: existing,
+        suggestions: suggestions,
+        candidatesProvider: () => const <WorkOrder>[],
+        candidateAcceptor: (_) => true,
+        noCandidateReason: 'custom_empty',
+      );
+
+      expect(suggestions, isEmpty);
+      final lines = _suggestWorkLines(capturedEvents);
+      expect(lines.single, contains('reason=custom_empty'));
+    });
+
+    test('rejected candidates log engineRejectedReason', () {
+      const playerId = 'gp1';
+      final unit = Unit(
+        id: 'u1',
+        type: kUnitTypeBuilder,
+        ownerId: playerId,
+        locationProvinceId: 'ow|p1',
+        tileKey: 'ow|p1|0|0',
+        status: UnitStatus.idle,
+      );
+      final suggestions = <WorkOrder>[];
+      final existing = <String, Set<String>>{};
+
+      WorkSuggestionPipeline.run(
+        unit: unit,
+        unitType: unit.type,
+        unitRegionId: 'ow',
+        atProvinceId: 'ow|p1',
+        workTarget: kWorkTargetBuildImprovement,
+        existingTargetsByUnit: existing,
+        suggestions: suggestions,
+        candidatesProvider: () => [
+          WorkOrder(
+            unitId: unit.id,
+            target: kWorkTargetBuildImprovement,
+            targetTileKey: 'a',
+          ),
+        ],
+        candidateAcceptor: (_) => false,
+        noCandidateReason: 'no_valid_tile',
+        engineRejectedReason: 'rejected_by_test',
+      );
+
+      expect(suggestions, isEmpty);
+      final lines = _suggestWorkLines(capturedEvents);
+      expect(lines.single, contains('reason=rejected_by_test'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements **issue #2391** proposed refactor item 8 (AC8 slice): introduce a dedicated `WorkSuggestionPipeline` used by all four `order_suggestion_work_*.dart` part files, with structured logging co-located in the same module.

## Scope

- **In scope:** New `lib/src/orders/work_suggestion_pipeline.dart` with `WorkSuggestionPipeline.run` (former `_runWorkSuggestionPipeline`) and `logWorkOrderSuggestion` (former `_suggestionWorkLog`). Worker, spy, merchant parts call `WorkSuggestionPipeline.run`; explorer/prospect paths use `logWorkOrderSuggestion` for the same log lines as before.
- **Deferred:** Explorer/prospect bulk flows that never used `_runWorkSuggestionPipeline` remain structurally as-is (no behavior change). Full AC8 checklist closure on the issue still depends on other open PRs and follow-up slices.

## Tests

- `dart test test/orders/work_suggestion_pipeline_test.dart`
- `dart test test/order_suggestion_work_logging_test.dart test/order_suggestion_work_logging_prospect_test.dart`

## SPEC

None (structural refactor only; issue explicitly lists no SPEC follow-up).

Refs #2391

Made with [Cursor](https://cursor.com)