### PR TITLE
perf(logic): single-pass army id lookup in split and migration (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/army_commands.dart
+++ b/packages/colonizethis_logic/lib/src/world/army_commands.dart
@@ -55,10 +55,15 @@ Game applyArmySplit({
 }) {
   if (unitIdsToMove.isEmpty) return game;
 
-  final sourceList =
-      game.worldState.armies.where((a) => a.id == sourceArmyId).toList();
-  final source = sourceList.isEmpty ? null : sourceList.first;
-  if (source == null || source.ownerId != playerId) return game;
+  Army? found;
+  for (final a in game.worldState.armies) {
+    if (a.id == sourceArmyId) {
+      found = a;
+      break;
+    }
+  }
+  if (found == null || found.ownerId != playerId) return game;
+  final source = found;
   if (source.isHomeArmy) {
     // Home army may split per SPEC (naval parity).
   }

--- a/packages/colonizethis_logic/lib/src/world/army_migration.dart
+++ b/packages/colonizethis_logic/lib/src/world/army_migration.dart
@@ -367,9 +367,13 @@ List<Army> _retargetArmyStation(
     )
     .toList();
 
+/// First matching army by id. Single-pass scan; avoids `.where(...).toList()`
+/// allocation on migration paths (Refs #2394, SPEC/program/turn-resolution.md).
 Army? _armyById(List<Army> armies, String armyId) {
-  final armyList = armies.where((a) => a.id == armyId).toList();
-  return armyList.isEmpty ? null : armyList.first;
+  for (final a in armies) {
+    if (a.id == armyId) return a;
+  }
+  return null;
 }
 
 ({List<Unit> owUnits, List<Unit> nwUnits}) _moveRegimentToProvince({


### PR DESCRIPTION
## Summary
Implements another **Refs #2394** slice from Category C (linear scans / avoidable allocations): replace `armies.where((a) => a.id == …).toList()` first-match patterns with a single linear pass that returns on first hit, matching the approach already used in `ArmyMoveValidator` when `armiesById` is omitted.

## Scope
- `army_commands.dart` — `applyArmySplit` source army resolution.
- `army_migration.dart` — private `_armyById` helper.

## Out of scope
- `applyArmyCombine` multi-id selection (still filters by `armyIds.contains`; different shape).
- Open PRs **#2403** / **#2407** (connectivity / army-move suggestion caches) — unchanged.

## SPEC
No behavior change; performance-only cleanup authorized by **#2394** and `SPEC/program/turn-resolution.md` / `SPEC/program/order-suggestions.md` (determinism preserved).

## Tests
- `dart analyze` on touched files — clean.
- `dart test test/army_integration_combine_split_test.dart test/army_integration_test.dart test/army_integration_ensure_reconcile_test.dart` — pass.

Refs #2394

Made with [Cursor](https://cursor.com)