### PR TITLE
perf(logic): army combine single-pass selection (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/army_commands.dart
+++ b/packages/colonizethis_logic/lib/src/world/army_commands.dart
@@ -9,9 +9,13 @@ Game applyArmyCombine({
 }) {
   if (armyIds.length < 2) return game;
 
-  final selected = game.worldState.armies
-      .where((a) => armyIds.contains(a.id) && a.ownerId == playerId)
-      .toList();
+  final idSet = armyIds.toSet();
+  final selected = <Army>[];
+  for (final a in game.worldState.armies) {
+    if (a.ownerId == playerId && idSet.contains(a.id)) {
+      selected.add(a);
+    }
+  }
   if (selected.length < 2) return game;
 
   final province = selected.first.stationedProvinceId;
@@ -20,9 +24,15 @@ Game applyArmyCombine({
   }
 
   Army target;
-  final home = selected.where((a) => a.isHomeArmy).toList();
-  if (home.isNotEmpty) {
-    target = home.first;
+  Army? homeArmy;
+  for (final a in selected) {
+    if (a.isHomeArmy) {
+      homeArmy = a;
+      break;
+    }
+  }
+  if (homeArmy != null) {
+    target = homeArmy;
   } else {
     final sorted = [...selected]..sort((a, b) => a.id.compareTo(b.id));
     target = sorted.first;


### PR DESCRIPTION
## Summary

Implements another **Category C** slice from [#2394](https://github.com/waigore/colonizethisv3/issues/2394): avoid `Iterable.where` chains and intermediate lists when resolving armies for `applyArmyCombine`.

## Changes

- Build a `Set` of requested army ids once, then **one pass** over `worldState.armies` to collect the player-owned matches (same iteration order and selection semantics as before).
- Pick the home-army merge target with a **single early-exit scan** over the small `selected` list instead of `where(...).toList()`.

## SPEC / behavior

- **No semantic change** to combine/split rules (`SPEC/ui/military-units-army-management.md` / military armies GDD). Performance and allocation profile only.
- `applyArmySplit` already used a single-pass lookup on `dev`; this PR completes the same style for the combine path.

## Tests

- `dart analyze lib/src/world/army_commands.dart`
- `dart test test/army_integration_combine_split_test.dart`

## Out of scope

- Broader `army_migration` / UI call-site caching (separate slices if still hot in profiles).
- Issue #2394 remains open until parent checklist / other PRs land; this PR **does not** close it.

Refs #2394

Made with [Cursor](https://cursor.com)