### PR TITLE
perf(logic): single army ensure in generateOrdersForGame (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/ai/ai_planner.dart
+++ b/packages/colonizethis_logic/lib/src/ai/ai_planner.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../world/army_migration.dart';
 import 'ai_control.dart';
 import 'simple_ai_heuristics.dart';
 
@@ -16,6 +17,7 @@ Orders generateOrdersForPlayer(
   MapTopology topology,
   String playerId, {
   Map<String, TileMapResult>? tileMapByRegion,
+  bool armiesAlreadyEnsured = false,
 }) {
   final player = game.playerById(playerId);
   if (player == null || !isAiControlled(game, player.id)) {
@@ -30,6 +32,7 @@ Orders generateOrdersForPlayer(
     player.id,
     turnSeed,
     tileMapByRegion: tileMapByRegion,
+    armiesAlreadyEnsured: armiesAlreadyEnsured,
   );
 }
 
@@ -55,23 +58,41 @@ Orders generateOrdersForGame(
   final workByPlayer = <String, List<WorkOrder>>{};
   final researchByPlayer = <String, List<ResearchOrder>>{};
 
+  final ensuredGame = ensureMilitaryArmiesForGame(game);
   for (final player in game.players) {
     if (!isAiControlled(game, player.id)) continue;
     final ordersForPlayer = generateOrdersForPlayer(
-      game,
+      ensuredGame,
       topology,
       player.id,
       tileMapByRegion: tileMapByRegion,
+      armiesAlreadyEnsured: true,
     );
-    _addOrdersIfNonEmpty(moveByPlayer, player.id, ordersForPlayer.moveOrdersByPlayerId[player.id]);
+    _addOrdersIfNonEmpty(
+      moveByPlayer,
+      player.id,
+      ordersForPlayer.moveOrdersByPlayerId[player.id],
+    );
     _addOrdersIfNonEmpty(
       armyMoveByPlayer,
       player.id,
       ordersForPlayer.armyMoveOrdersByPlayerId[player.id],
     );
-    _addOrdersIfNonEmpty(buildByPlayer, player.id, ordersForPlayer.buildUnitOrdersByPlayerId[player.id]);
-    _addOrdersIfNonEmpty(workByPlayer, player.id, ordersForPlayer.workOrdersByPlayerId[player.id]);
-    _addOrdersIfNonEmpty(researchByPlayer, player.id, ordersForPlayer.researchOrdersByPlayerId[player.id]);
+    _addOrdersIfNonEmpty(
+      buildByPlayer,
+      player.id,
+      ordersForPlayer.buildUnitOrdersByPlayerId[player.id],
+    );
+    _addOrdersIfNonEmpty(
+      workByPlayer,
+      player.id,
+      ordersForPlayer.workOrdersByPlayerId[player.id],
+    );
+    _addOrdersIfNonEmpty(
+      researchByPlayer,
+      player.id,
+      ordersForPlayer.researchOrdersByPlayerId[player.id],
+    );
   }
 
   return Orders(

--- a/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
+++ b/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
@@ -247,13 +247,18 @@ Orders generateOrdersWithSimpleHeuristics(
   String playerId,
   int turnSeed, {
   Map<String, TileMapResult>? tileMapByRegion,
+
+  /// When true, [game] was already passed through [ensureMilitaryArmiesForGame]
+  /// (for example by [generateOrdersForGame]). Skips a redundant per-player
+  /// reconcile + `_armiesMatchUnits` full-unit scan (Refs #2394).
+  bool armiesAlreadyEnsured = false,
 }) {
   final player = game.playerById(playerId);
   if (player == null) {
     return const Orders();
   }
 
-  final g = ensureMilitaryArmiesForGame(game);
+  final g = armiesAlreadyEnsured ? game : ensureMilitaryArmiesForGame(game);
   final rng = math.Random(turnSeed);
   var current = const Orders();
   final view = buildPlayerView(g, topology, player.id);

--- a/packages/colonizethis_logic/test/ai/ai_planner_generate_orders_for_game_test.dart
+++ b/packages/colonizethis_logic/test/ai/ai_planner_generate_orders_for_game_test.dart
@@ -1,0 +1,148 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/src/ai/ai_control.dart';
+import 'package:colonizethis_logic/src/ai/ai_planner.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+void main() {
+  group('generateOrdersForGame', () {
+    test(
+      'matches per-AI generateOrdersForPlayer aggregate (army ensure parity)',
+      () {
+        const topology = MapTopology(
+          nodes: [
+            TopologyNode(
+              id: 'P1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'P2',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: [TopologyEdge(id1: 'P1', id2: 'P2')],
+        );
+
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: RegionData(
+              provinces: const [
+                Province(
+                  id: 'oldWorld|P1',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp1',
+                ),
+                Province(
+                  id: 'oldWorld|P2',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp2',
+                ),
+              ],
+              units: [
+                Unit(
+                  id: 'u1',
+                  type: 'grenadiers',
+                  ownerId: 'gp1',
+                  locationProvinceId: 'oldWorld|P1',
+                ),
+                Unit(
+                  id: 'u2',
+                  type: 'grenadiers',
+                  ownerId: 'gp2',
+                  locationProvinceId: 'oldWorld|P2',
+                ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            playerVisibilityByTile: const {
+              'gp1': {
+                'oldWorld|P1|0|0': 'fullyVisible',
+                'oldWorld|P2|0|0': 'fullyVisible',
+              },
+              'gp2': {
+                'oldWorld|P1|0|0': 'fullyVisible',
+                'oldWorld|P2|0|0': 'fullyVisible',
+              },
+            },
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'AI 1', isHuman: false),
+            Player(id: 'gp2', displayName: 'AI 2', isHuman: false),
+          ],
+          diplomacyRelations: const [
+            DiplomacyRelation(
+              factionId1: 'gp1',
+              factionId2: 'gp2',
+              state: RelationState.atWar,
+            ),
+          ],
+          globalGameSeed: 11,
+          aiSeedByGpId: {'gp1': 101, 'gp2': 202},
+        );
+
+        final aggregated = generateOrdersForGame(game, topology);
+
+        final moveByPlayer = <String, List<MoveOrder>>{};
+        final armyMoveByPlayer = <String, List<ArmyMoveOrder>>{};
+        final buildByPlayer = <String, List<BuildUnitOrder>>{};
+        final workByPlayer = <String, List<WorkOrder>>{};
+        final researchByPlayer = <String, List<ResearchOrder>>{};
+        void addIfNonEmpty<T>(
+          Map<String, List<T>> aggregate,
+          String playerId,
+          List<T>? list,
+        ) {
+          if (list != null && list.isNotEmpty) {
+            aggregate[playerId] = list;
+          }
+        }
+
+        for (final player in game.players) {
+          if (!isAiControlled(game, player.id)) continue;
+          final one = generateOrdersForPlayer(game, topology, player.id);
+          addIfNonEmpty(
+            moveByPlayer,
+            player.id,
+            one.moveOrdersByPlayerId[player.id],
+          );
+          addIfNonEmpty(
+            armyMoveByPlayer,
+            player.id,
+            one.armyMoveOrdersByPlayerId[player.id],
+          );
+          addIfNonEmpty(
+            buildByPlayer,
+            player.id,
+            one.buildUnitOrdersByPlayerId[player.id],
+          );
+          addIfNonEmpty(
+            workByPlayer,
+            player.id,
+            one.workOrdersByPlayerId[player.id],
+          );
+          addIfNonEmpty(
+            researchByPlayer,
+            player.id,
+            one.researchOrdersByPlayerId[player.id],
+          );
+        }
+
+        final manual = Orders(
+          moveOrdersByPlayerId: moveByPlayer,
+          armyMoveOrdersByPlayerId: armyMoveByPlayer,
+          buildUnitOrdersByPlayerId: buildByPlayer,
+          workOrdersByPlayerId: workByPlayer,
+          diplomaticOrdersByPlayerId: const {},
+          researchOrdersByPlayerId: researchByPlayer,
+          navalMoveOrdersByPlayerId: const {},
+        );
+
+        expect(aggregated, equals(manual));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Implements the **Category F** item from #2394: `ensureMilitaryArmiesForGame` was invoked once per AI-controlled GP inside `generateOrdersForGame`, each time running `_armiesMatchUnits` (full `allUnitsFromWorld` scan). The reconciled snapshot is identical for every call on the same input `Game`, so we reconcile **once** before the per-GP loop and pass `armiesAlreadyEnsured: true` into `generateOrdersWithSimpleHeuristics`.

## Scope
- `packages/colonizethis_logic/lib/src/ai/ai_planner.dart` — single `ensureMilitaryArmiesForGame` + threaded flag.
- `packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart` — optional `armiesAlreadyEnsured` (default preserves single-player / ctdev / direct callers).
- **Tests:** `test/ai/ai_planner_generate_orders_for_game_test.dart` — aggregate orders from `generateOrdersForGame` must equal manual merge of per-`generateOrdersForPlayer` calls (negative drift guard).

## Deferred
- Other #2394 slices (validator sharing, AST lints, benchmarks) remain for separate PRs.

## SPEC / AC
- No semantic change; performance-only path authorized under #2394 and `SPEC/program/order-suggestions.md` / turn-resolution throughput guidance.

Refs #2394

Made with [Cursor](https://cursor.com)