### PR TITLE
perf(logic): explore suggestions use view province map (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_explorer.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_explorer.dart
@@ -114,11 +114,17 @@ void _addExplorerWorkSuggestionsForUnit({
     return;
   }
 
-  final provinces =
-      allProvinces(
-          game.worldState,
-        ).where((p) => partiallyRevealedProvinceCache.contains(p.id)).toList()
-        ..sort((a, b) => a.id.compareTo(b.id));
+  // [buildPlayerView] already keyed every world province in [view.provincesById];
+  // resolve only ids in the partial-reveal cache instead of scanning
+  // [allProvinces] per explorer unit (Refs #2394, SPEC/program/order-suggestions.md).
+  final provinces = <Province>[];
+  for (final id in partiallyRevealedProvinceCache) {
+    final p = view.provincesById[id] ?? tryGetProvince(game.worldState, id);
+    if (p != null) {
+      provinces.add(p);
+    }
+  }
+  provinces.sort((a, b) => a.id.compareTo(b.id));
   final acceptedExplores = <WorkOrder>[];
   var lastReason = 'no_valid_tile';
   for (final prov in provinces) {

--- a/packages/colonizethis_logic/test/orders/partial_province_reveal_test.dart
+++ b/packages/colonizethis_logic/test/orders/partial_province_reveal_test.dart
@@ -1,5 +1,7 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/src/orders/partial_province_reveal.dart';
 import 'package:colonizethis_logic/src/world/player_view.dart';
+import 'package:colonizethis_logic/src/world/province_lookup.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
@@ -74,5 +76,76 @@ void main() {
       );
       expect(ids, isEmpty);
     });
+
+    test(
+      'partial reveal ids resolve via provincesById to same set as allProvinces filter',
+      () {
+        const playerId = 'gp1';
+        const ow = 'oldWorld';
+        final p1 = Province(id: '$ow|p1', regionId: ow, ownerId: playerId);
+        final p2 = Province(id: '$ow|p2', regionId: ow, ownerId: playerId);
+        final world = WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(provinces: [p1, p2], units: const []),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: {
+            ow: {
+              '$ow|p1': ['$ow|p1|0|0', '$ow|p1|0|1'],
+              '$ow|p2': ['$ow|p2|0|0'],
+            },
+          },
+          playerVisibilityByTile: {
+            playerId: {
+              '$ow|p1|0|0': 'unknown',
+              '$ow|p1|0|1': 'fogged',
+              '$ow|p2|0|0': 'fogged',
+            },
+          },
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: world,
+          players: const [
+            Player(id: playerId, displayName: 'GP', isHuman: true),
+          ],
+        );
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'p1',
+              regionId: ow,
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'p2',
+              regionId: ow,
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: const [],
+        );
+        final view = buildPlayerView(game, topology, playerId);
+        final cache = partiallyRevealedPrefixedProvinceIdsForPlayer(
+          game: game,
+          view: view,
+        );
+        final legacy = allProvinces(game.worldState)
+            .where((p) => cache.contains(p.id))
+            .map((p) => p.id)
+            .toList()
+          ..sort();
+        final optimized = <String>[];
+        for (final id in cache) {
+          final p =
+              view.provincesById[id] ?? tryGetProvince(game.worldState, id);
+          if (p != null) {
+            optimized.add(p.id);
+          }
+        }
+        optimized.sort();
+        expect(cache, isNotEmpty);
+        expect(optimized, legacy);
+      },
+    );
   });
 }

--- a/tool/logic_all_provinces_sanctions.yaml
+++ b/tool/logic_all_provinces_sanctions.yaml
@@ -3,12 +3,6 @@
 # from scan). See SPEC/program/logic-dual-region-province-access.md.
 version: 1
 sanctions:
-  - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_work_explorer.dart
-    line: 118
-    rationale: Cross-region explorer work enumeration over partially revealed provinces.
-    spec: SPEC/program/logic-dual-region-province-access.md
-    issue: https://github.com/waigore/colonizethisv3/issues/2278
-
   - path: packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
     line: 229
     rationale: Global connectivity / capital path checks require all province rows.


### PR DESCRIPTION
## Summary
Small **#2394** slice (Category E / explorer path): `_addExplorerWorkSuggestionsForUnit` no longer runs `allProvinces` plus a membership filter for every explorer unit. It resolves each id in `partiallyRevealedProvinceCache` via `view.provincesById` (with `tryGetProvince` fallback), then sorts by full province id — same ordering as before.

## Behavior / determinism
- Same sorted province iteration order as the previous `allProvinces(...).where(cache.contains)` list.
- No change to visibility, validation, or suggestion selection semantics.

## Tests
- New equivalence test in `test/orders/partial_province_reveal_test.dart`: after `buildPlayerView`, optimized id list matches legacy `allProvinces` filter.
- Ran: `dart analyze` on touched files; `dart test test/orders/partial_province_reveal_test.dart test/order_suggestion_valid_work_tiles_part2d_test.dart`

## SPEC
No doc edits: internal hot-path optimization only; authorized by **#2394** and `SPEC/program/order-suggestions.md` throughput guidance.

## Deferred
- Other #2394 items (army-move owned-province cache in open PR #2407, multi-unit partial-reveal list sharing in #2415, validator amortization, etc.) remain for separate PRs.

Refs #2394


Made with [Cursor](https://cursor.com)