### PR TITLE
perf(logic): purchase_land prefilter uses DiplomacyFactionMembership (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_tile_prefilter.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_tile_prefilter.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../diplomacy/diplomacy_resolver.dart';
 import '../world/province_lookup.dart';
 import 'build_rail_work_rules.dart';
 import 'orders_application_helpers.dart';
@@ -240,9 +241,7 @@ void _prefilterWtStealTech(_WorkTilePrefilterCtx c) {
 }
 
 void _prefilterWtPurchaseLand(_WorkTilePrefilterCtx c) {
-  final gpIds = c.game.players.map((p) => p.id).toSet();
-  final minorIds = c.game.minorNations.map((m) => m.id).toSet();
-  final tribeIds = c.game.tribes.map((t) => t.id).toSet();
+  final factionMembership = DiplomacyFactionMembership.from(c.game);
   _forEachPrefixedProvinceTile(
     tileKeysByRegion: c.tileKeysByRegion,
     onTile: (provinceId, tileKey) {
@@ -250,8 +249,8 @@ void _prefilterWtPurchaseLand(_WorkTilePrefilterCtx c) {
       if (province == null) return;
       final ownerId = province.ownerId;
       if (ownerId == null) return;
-      if (gpIds.contains(ownerId)) return;
-      if (!minorIds.contains(ownerId) && !tribeIds.contains(ownerId)) {
+      if (factionMembership.isGreatPower(ownerId)) return;
+      if (!factionMembership.isMinorOrTribe(ownerId)) {
         return;
       }
       final resourceId = c.resourceByTile[tileKey];

--- a/packages/colonizethis_logic/test/orders/order_suggestion_work_tile_prefilter_purchase_land_test.dart
+++ b/packages/colonizethis_logic/test/orders/order_suggestion_work_tile_prefilter_purchase_land_test.dart
@@ -2,7 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/src/constants.dart';
 import 'package:colonizethis_logic/src/orders/order_suggestion_work_tile_prefilter.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 void main() {
   group('rawCandidateTilesForWorkTarget (purchase_land)', () {

--- a/packages/colonizethis_logic/test/orders/order_suggestion_work_tile_prefilter_purchase_land_test.dart
+++ b/packages/colonizethis_logic/test/orders/order_suggestion_work_tile_prefilter_purchase_land_test.dart
@@ -1,0 +1,109 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/src/constants.dart';
+import 'package:colonizethis_logic/src/orders/order_suggestion_work_tile_prefilter.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('rawCandidateTilesForWorkTarget (purchase_land)', () {
+    test(
+      'includes resource tiles in minor-owned provinces, excludes GP-owned',
+      () {
+        const playerId = 'gp1';
+        const ow = 'oldWorld';
+        final player = Player(
+          id: playerId,
+          displayName: 'GP',
+          isHuman: false,
+          treasury: 500,
+        );
+        final ownProvince = Province(
+          id: '$ow|p1',
+          regionId: ow,
+          ownerId: playerId,
+        );
+        final minorProvince = Province(
+          id: '$ow|minor1',
+          regionId: ow,
+          ownerId: 'minor1',
+        );
+        const minorTile = 'oldWorld|minor1|0|0';
+        const gpTile = 'oldWorld|p1|0|0';
+        final world = WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [ownProvince, minorProvince],
+            units: const [],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: {
+            ow: {
+              '$ow|p1': [gpTile],
+              '$ow|minor1': [minorTile],
+            },
+          },
+          resourceByTileKey: {minorTile: 'grain', gpTile: 'timber'},
+        );
+        final game = Game(
+          id: 'g1',
+          worldState: world,
+          players: [player],
+          minorNations: const [
+            MinorNation(id: 'minor1', displayName: 'Minor 1'),
+          ],
+        );
+
+        final tiles = rawCandidateTilesForWorkTarget(
+          game: game,
+          playerId: playerId,
+          workTarget: kWorkTargetPurchaseLand,
+        );
+
+        expect(tiles, contains(minorTile));
+        expect(tiles, isNot(contains(gpTile)));
+      },
+    );
+
+    test('includes resource tiles in tribe-owned provinces', () {
+      const playerId = 'gp1';
+      const ow = 'oldWorld';
+      final player = Player(
+        id: playerId,
+        displayName: 'GP',
+        isHuman: false,
+        treasury: 500,
+      );
+      final tribeProvince = Province(
+        id: '$ow|tribe1',
+        regionId: ow,
+        ownerId: 'tribe1',
+      );
+      const tribeTile = 'oldWorld|tribe1|0|0';
+      final world = WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: RegionData(provinces: [tribeProvince], units: const []),
+        newWorld: const RegionData(),
+        tileKeysByRegionAndProvince: {
+          ow: {
+            '$ow|tribe1': [tribeTile],
+          },
+        },
+        resourceByTileKey: {tribeTile: 'grain'},
+      );
+      final game = Game(
+        id: 'g1',
+        worldState: world,
+        players: [player],
+        tribes: const [Tribe(id: 'tribe1', displayName: 'Tribe 1')],
+      );
+
+      final tiles = rawCandidateTilesForWorkTarget(
+        game: game,
+        playerId: playerId,
+        workTarget: kWorkTargetPurchaseLand,
+      );
+
+      expect(tiles, contains(tribeTile));
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/orders/work_handlers/purchase_land_work_handler_test.dart
+++ b/packages/colonizethis_logic/test/orders/work_handlers/purchase_land_work_handler_test.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart'
-    show Stockpile, kTechIdMerchantCompanies;
+    show kTechIdMerchantCompanies;
 import 'package:colonizethis_logic/src/constants.dart';
 import 'package:colonizethis_logic/src/orders/orders_application_context.dart';
 import 'package:colonizethis_logic/src/orders/purchase_land_work_completion.dart';

--- a/tool/logic_all_provinces_sanctions.yaml
+++ b/tool/logic_all_provinces_sanctions.yaml
@@ -40,14 +40,14 @@ sanctions:
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
   - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_work_tile_prefilter.dart
-    line: 52
-    rationale: Build suggestions scan province context across regions.
+    line: 53
+    rationale: Work tile prefilter collects owned province ids via all provinces.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
   - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_work_tile_prefilter.dart
-    line: 109
-    rationale: Research/build suggestion enumeration over all provinces.
+    line: 110
+    rationale: Town work targets enumerate town tiles across owned provinces in both regions.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 


### PR DESCRIPTION
## Scope
Slice of waigore/colonizethisv3#2394 (Category F — duplicate / aligned faction classification): `purchase_land` work-target tile prefilter now builds `DiplomacyFactionMembership.from(game)` once per prefilter invocation and uses `isGreatPower` / `isMinorOrTribe` instead of three parallel `Set` constructions from `players` / `minorNations` / `tribes`.

No change to which tiles are admitted; same O(1) per-tile checks, one consistent classification path with diplomacy resolution.

## SPEC
Internal optimization only; semantics unchanged. Throughput guidance: `SPEC/program/order-suggestions.md`, turn-resolution budget rule; issue #2394 non-goals preserved.

## Tests
- Added `packages/colonizethis_logic/test/orders/order_suggestion_work_tile_prefilter_purchase_land_test.dart` (minor + tribe resource tiles included; GP-owned resource tile excluded).
- Ran: `cd packages/colonizethis_logic && dart test test/orders/order_suggestion_work_tile_prefilter_purchase_land_test.dart test/order_suggestion_core_part2_test.dart`

## Deferred
Remaining Category A–E/F items on #2394 for other PRs.

Refs #2394

Made with [Cursor](https://cursor.com)