### PR TITLE
perf(logic): naval retreat zone scan uses fleets-by-zone index (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
@@ -45,14 +45,28 @@ String? _firstFriendlyOrNeutralRetreatZone(
   String ownerId,
 ) {
   final hostileByOwner = hostileFactionsByFaction(game);
+  final hostileToOwner = hostileByOwner[ownerId];
+  // Single pass over fleets, then O(fleets-in-zone) per adjacent zone (Refs #2394).
+  final fleetsAtSeaByZoneId = <String, List<Fleet>>{};
+  for (final fleet in game.worldState.fleets) {
+    if (!fleet.isAtSea) continue;
+    final z = fleet.seaZoneId;
+    if (z == null) continue;
+    (fleetsAtSeaByZoneId[z] ??= <Fleet>[]).add(fleet);
+  }
   for (final adj in _adjacentSeaZones(topology, fromSeaZoneId)) {
-    final hostileOwnersPresent = game.worldState.fleets.any(
-      (fleet) =>
-          fleet.isAtSea &&
-          fleet.seaZoneId == adj &&
-          fleet.ownerId != ownerId &&
-          (hostileByOwner[ownerId]?.contains(fleet.ownerId) ?? false),
-    );
+    final inZone = fleetsAtSeaByZoneId[adj];
+    if (inZone == null || inZone.isEmpty) {
+      return adj;
+    }
+    var hostileOwnersPresent = false;
+    for (final fleet in inZone) {
+      if (fleet.ownerId != ownerId &&
+          (hostileToOwner?.contains(fleet.ownerId) ?? false)) {
+        hostileOwnersPresent = true;
+        break;
+      }
+    }
     if (!hostileOwnersPresent) return adj;
   }
   return null;


### PR DESCRIPTION
## Summary
Slice for **#2394** (Category E / naval hot path): `_firstFriendlyOrNeutralRetreatZone` no longer runs `fleets.any(...)` over the **entire** fleet list for **each** adjacent sea zone. It builds a **single-pass** map from `seaZoneId` → at-sea fleets, then checks only fleets present in that zone.

## Behavior
- **Unchanged:** Retreat eligibility and chosen retreat zone (first adjacent zone without hostile at-sea presence per existing rules).
- **Determinism:** Fleet iteration order matches the prior full-scan order (world fleet list); short-circuit on first hostile in zone matches `.any` semantics.

## Spec
Internal performance optimization authorized by `SPEC/program/turn-resolution.md` (bounded work, no semantic change) and issue #2394 scope.

## Tests
- `dart test test/naval_behavior_scenarios_test.dart test/naval_combat_resolver_resolution_test.dart test/naval_test_part1_ship_reveal_test.dart` (colonizethis_logic)

## Out of scope
- Broader naval combat data structures, `applyNavalBattleResults` filtering, or other #2394 slices (separate PRs).

Refs #2394

Made with [Cursor](https://cursor.com)