### PR TITLE
refactor(logic): split diplomatic_order_validator into per-type validators (Refs #2391)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/alliance_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/alliance_validator.dart
@@ -1,0 +1,37 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../../../diplomacy/diplomacy_resolver.dart';
+import '../../order_validation_result.dart';
+import 'diplomatic_sub_validator.dart';
+
+/// Type-specific validator for [DiplomaticOrderType.alliance] orders.
+/// SPEC/program/orders.md § Diplomatic orders / alliance.
+class AllianceSubValidator implements DiplomaticSubValidator {
+  const AllianceSubValidator({required this.game, required this.playerId});
+
+  final Game game;
+  final String playerId;
+
+  @override
+  ({OrderValidationResult result, int treasury}) validate({
+    required DiplomaticOrder order,
+    required int treasury,
+  }) {
+    final targetId = order.targetFactionId;
+    if (!isGreatPower(game, targetId)) {
+      return rejectDiplomaticSub(
+        'Alliance target must be a Great Power',
+        treasury,
+      );
+    }
+    final rel = getRelation(game, playerId, targetId);
+    final atWar = rel?.atWar ?? false;
+    if (atWar) {
+      return rejectDiplomaticSub(
+        'Cannot form alliance while at war with that faction',
+        treasury,
+      );
+    }
+    return acceptDiplomaticSub(treasury);
+  }
+}

--- a/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/declare_war_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/declare_war_validator.dart
@@ -1,0 +1,27 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../../../diplomacy/diplomacy_resolver.dart';
+import '../../order_validation_result.dart';
+import 'diplomatic_sub_validator.dart';
+
+/// Type-specific validator for [DiplomaticOrderType.declareWar] orders.
+/// SPEC/program/orders.md § Diplomatic orders / declare war.
+class DeclareWarSubValidator implements DiplomaticSubValidator {
+  const DeclareWarSubValidator({required this.game, required this.playerId});
+
+  final Game game;
+  final String playerId;
+
+  @override
+  ({OrderValidationResult result, int treasury}) validate({
+    required DiplomaticOrder order,
+    required int treasury,
+  }) {
+    final rel = getRelation(game, playerId, order.targetFactionId);
+    final atPeace = rel == null || rel.atPeace;
+    if (!atPeace) {
+      return rejectDiplomaticSub('Already at war with that faction', treasury);
+    }
+    return acceptDiplomaticSub(treasury);
+  }
+}

--- a/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/diplomatic_sub_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/diplomatic_sub_validator.dart
@@ -1,0 +1,43 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../../order_validation_result.dart';
+
+/// Per-`DiplomaticOrderType` validator extracted from
+/// [DiplomaticOrderValidator] (SPEC/program/orders.md § Diplomatic orders).
+///
+/// Sub-validators only own the **type-specific** rules for one
+/// [DiplomaticOrderType]. Cross-cutting checks that apply to every diplomatic
+/// order — target existence, self-targeting, the per-target diplomatic-order
+/// cap, and recording the accepted (target, type) pair — are owned by the
+/// dispatching parent validator and run **before** the sub-validator is
+/// invoked.
+///
+/// Sub-validators are pure with respect to game state: they read [game] and
+/// the supplied current [treasury] and return an [OrderValidationResult]
+/// together with the **post-validation treasury**. Sub-validators that do
+/// not change treasury (declare war, offer peace, alliance) return [treasury]
+/// unchanged. Sub-validators that consume treasury (overtures, grant aid,
+/// set subsidy) return the debited treasury **only on accept**; on reject
+/// they return the input [treasury] unchanged so the caller can commit the
+/// new value unconditionally.
+abstract interface class DiplomaticSubValidator {
+  /// Validate the type-specific portion of [order]. Caller is responsible
+  /// for the cross-cutting target/self/cap checks before calling this.
+  ({OrderValidationResult result, int treasury}) validate({
+    required DiplomaticOrder order,
+    required int treasury,
+  });
+}
+
+/// Helper for sub-validator implementations: builds a rejected result that
+/// preserves the input treasury value (no debit on reject).
+({OrderValidationResult result, int treasury}) rejectDiplomaticSub(
+  String reason,
+  int treasury,
+) => (result: OrderValidationResult.rejected(reason), treasury: treasury);
+
+/// Helper for sub-validator implementations: builds an accepted result with
+/// the supplied (possibly debited) treasury value.
+({OrderValidationResult result, int treasury}) acceptDiplomaticSub(
+  int treasury,
+) => (result: OrderValidationResult.accepted(), treasury: treasury);

--- a/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/establish_overture_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/establish_overture_validator.dart
@@ -1,0 +1,236 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../../../constants.dart';
+import '../../../diplomacy/diplomacy_resolver.dart';
+import '../../order_validation_result.dart';
+import 'diplomatic_sub_validator.dart';
+
+/// Type-specific validator for [DiplomaticOrderType.establishOverture] orders.
+/// Owns the per-stage rules (`tradeConsulate`, `embassy`, `nap`, `joinEmpire`)
+/// and treasury debits for cost-bearing stages.
+/// SPEC/program/orders.md § Diplomatic orders / overtures.
+class EstablishOvertureSubValidator implements DiplomaticSubValidator {
+  const EstablishOvertureSubValidator({
+    required this.game,
+    required this.playerId,
+  });
+
+  final Game game;
+  final String playerId;
+
+  @override
+  ({OrderValidationResult result, int treasury}) validate({
+    required DiplomaticOrder order,
+    required int treasury,
+  }) {
+    final stage = order.overtureStage;
+    if (stage == null || stage == OvertureStage.none) {
+      return rejectDiplomaticSub(
+        'Overture stage is required for establishOverture',
+        treasury,
+      );
+    }
+    final targetId = order.targetFactionId;
+    if (!isMinorOrTribe(game, targetId) && !isGreatPower(game, targetId)) {
+      return rejectDiplomaticSub(
+        'Overtures are only valid toward Minor Nations, Tribes, or Great Powers',
+        treasury,
+      );
+    }
+    final rel = getRelation(game, playerId, targetId);
+    final atWar = rel?.atWar ?? false;
+    if (atWar) {
+      return rejectDiplomaticSub(
+        'Cannot establish overture while at war with that faction',
+        treasury,
+      );
+    }
+
+    final overture = getOverture(game, playerId, targetId);
+    final currentStage = overture?.stage ?? OvertureStage.none;
+
+    return switch (stage) {
+      OvertureStage.tradeConsulate => _validateTradeConsulate(
+        targetId,
+        currentStage,
+        treasury,
+      ),
+      OvertureStage.embassy => _validateEmbassy(
+        targetId,
+        currentStage,
+        treasury,
+      ),
+      OvertureStage.nap => _validateNap(targetId, currentStage, treasury),
+      OvertureStage.joinEmpire => _validateJoinEmpire(
+        targetId,
+        rel,
+        currentStage,
+        treasury,
+      ),
+      OvertureStage.none => rejectDiplomaticSub(
+        'Overture stage is required for establishOverture',
+        treasury,
+      ),
+    };
+  }
+
+  ({OrderValidationResult result, int treasury}) _validateTradeConsulate(
+    String targetId,
+    OvertureStage currentStage,
+    int treasury,
+  ) {
+    if (currentStage != OvertureStage.none) {
+      return rejectDiplomaticSub(
+        'Trade Consulate requires no existing overture',
+        treasury,
+      );
+    }
+    if (_minorTribeOvertureRequiresDiplomaticExpertise(
+          targetId,
+          OvertureStage.tradeConsulate,
+        ) &&
+        !_playerHasDiplomaticExpertise()) {
+      return rejectDiplomaticSub(
+        'Diplomatic Expertise tech required for overtures with Minor Nations and Tribes',
+        treasury,
+      );
+    }
+    if (treasury < overtureConsulateCost) {
+      return rejectDiplomaticSub(
+        'Insufficient treasury for Trade Consulate (need $overtureConsulateCost)',
+        treasury,
+      );
+    }
+    return acceptDiplomaticSub(treasury - overtureConsulateCost);
+  }
+
+  ({OrderValidationResult result, int treasury}) _validateEmbassy(
+    String targetId,
+    OvertureStage currentStage,
+    int treasury,
+  ) {
+    if (currentStage != OvertureStage.tradeConsulate) {
+      return rejectDiplomaticSub(
+        'Embassy requires existing Trade Consulate with that faction',
+        treasury,
+      );
+    }
+    if (_minorTribeOvertureRequiresDiplomaticExpertise(
+          targetId,
+          OvertureStage.embassy,
+        ) &&
+        !_playerHasDiplomaticExpertise()) {
+      return rejectDiplomaticSub(
+        'Diplomatic Expertise tech required for overtures with Minor Nations and Tribes',
+        treasury,
+      );
+    }
+    if (treasury < overtureEmbassyCost) {
+      return rejectDiplomaticSub(
+        'Insufficient treasury for Embassy (need $overtureEmbassyCost)',
+        treasury,
+      );
+    }
+    return acceptDiplomaticSub(treasury - overtureEmbassyCost);
+  }
+
+  ({OrderValidationResult result, int treasury}) _validateNap(
+    String targetId,
+    OvertureStage currentStage,
+    int treasury,
+  ) {
+    if (currentStage != OvertureStage.embassy) {
+      return rejectDiplomaticSub(
+        'Non-Aggression Pact requires existing Embassy with that faction',
+        treasury,
+      );
+    }
+    if (_minorTribeOvertureRequiresDiplomaticExpertise(
+          targetId,
+          OvertureStage.nap,
+        ) &&
+        !_playerHasDiplomaticExpertise()) {
+      return rejectDiplomaticSub(
+        'Diplomatic Expertise tech required for overtures with Minor Nations and Tribes',
+        treasury,
+      );
+    }
+    return acceptDiplomaticSub(treasury);
+  }
+
+  ({OrderValidationResult result, int treasury}) _validateJoinEmpire(
+    String targetId,
+    DiplomacyRelation? rel,
+    OvertureStage currentStage,
+    int treasury,
+  ) {
+    if (currentStage != OvertureStage.nap) {
+      return rejectDiplomaticSub(
+        'Join Empire requires existing Non-Aggression Pact with that faction',
+        treasury,
+      );
+    }
+    final score = rel?.score ?? relationScoreNeutral;
+    if (score < relationScoreMinFriendly) {
+      return rejectDiplomaticSub(
+        'Join Empire requires at least Friendly relations (score >= $relationScoreMinFriendly)',
+        treasury,
+      );
+    }
+    if (isGreatPower(game, targetId)) {
+      return _validateJoinEmpireTowardGreatPower(targetId, treasury);
+    }
+    if (!isMinorOrTribe(game, targetId)) {
+      return rejectDiplomaticSub(
+        'Join Empire target must be a Minor Nation, Tribe, or Great Power',
+        treasury,
+      );
+    }
+    final cost = joinEmpireCostForMinorOrTribe(game, targetId);
+    if (treasury < cost) {
+      return rejectDiplomaticSub(
+        'Join Empire requires £$cost (scales with target size); treasury is $treasury',
+        treasury,
+      );
+    }
+    return acceptDiplomaticSub(treasury);
+  }
+
+  ({OrderValidationResult result, int treasury})
+  _validateJoinEmpireTowardGreatPower(String targetId, int treasury) {
+    final submitter = game.playerById(playerId);
+    if (submitter?.techUnlocked?[kTechIdEmpireBuilding] != true) {
+      return rejectDiplomaticSub(
+        'Empire Building tech required for Join Empire toward a Great Power',
+        treasury,
+      );
+    }
+    if (!isGreatPowerNearlyDefeatedForJoinEmpire(game, targetId)) {
+      return rejectDiplomaticSub(
+        'Join Empire toward Great Power requires target to be nearly defeated (at most 3 provinces and original capital not held by target)',
+        treasury,
+      );
+    }
+    return acceptDiplomaticSub(treasury);
+  }
+
+  bool _minorTribeOvertureRequiresDiplomaticExpertise(
+    String targetId,
+    OvertureStage stage,
+  ) {
+    if (!isMinorOrTribe(game, targetId)) return false;
+    return stage == OvertureStage.tradeConsulate ||
+        stage == OvertureStage.embassy ||
+        stage == OvertureStage.nap;
+  }
+
+  bool _playerHasDiplomaticExpertise() {
+    for (final p in game.players) {
+      if (p.id == playerId) {
+        return p.techUnlocked?[kTechIdDiplomaticExpertise] == true;
+      }
+    }
+    return false;
+  }
+}

--- a/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/grant_aid_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/grant_aid_validator.dart
@@ -1,0 +1,49 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../../../diplomacy/diplomacy_resolver.dart';
+import '../../order_validation_result.dart';
+import 'diplomatic_sub_validator.dart';
+
+/// Type-specific validator for [DiplomaticOrderType.grantAid] orders.
+/// Owns amount-step rules, embassy requirement, and treasury debit on accept.
+/// SPEC/program/orders.md § Diplomatic orders / grant aid.
+class GrantAidSubValidator implements DiplomaticSubValidator {
+  const GrantAidSubValidator({required this.game, required this.playerId});
+
+  final Game game;
+  final String playerId;
+
+  @override
+  ({OrderValidationResult result, int treasury}) validate({
+    required DiplomaticOrder order,
+    required int treasury,
+  }) {
+    final amount = order.amount ?? 0;
+    if (amount <= 0) {
+      return rejectDiplomaticSub('GrantAid amount must be positive', treasury);
+    }
+    if (amount < grantAidAmountStep) {
+      return rejectDiplomaticSub(
+        'GrantAid amount must be at least £$grantAidAmountStep',
+        treasury,
+      );
+    }
+    if (amount % grantAidAmountStep != 0) {
+      return rejectDiplomaticSub(
+        'GrantAid amount must be a multiple of £$grantAidAmountStep',
+        treasury,
+      );
+    }
+    final overture = getOverture(game, playerId, order.targetFactionId);
+    if (overture == null || !overture.hasEmbassy) {
+      return rejectDiplomaticSub('Embassy required for GrantAid', treasury);
+    }
+    if (treasury < amount) {
+      return rejectDiplomaticSub(
+        'Insufficient treasury for GrantAid (need $amount)',
+        treasury,
+      );
+    }
+    return acceptDiplomaticSub(treasury - amount);
+  }
+}

--- a/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/offer_peace_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/offer_peace_validator.dart
@@ -1,0 +1,30 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../../../diplomacy/diplomacy_resolver.dart';
+import '../../order_validation_result.dart';
+import 'diplomatic_sub_validator.dart';
+
+/// Type-specific validator for [DiplomaticOrderType.offerPeace] orders.
+/// SPEC/program/orders.md § Diplomatic orders / offer peace.
+class OfferPeaceSubValidator implements DiplomaticSubValidator {
+  const OfferPeaceSubValidator({required this.game, required this.playerId});
+
+  final Game game;
+  final String playerId;
+
+  @override
+  ({OrderValidationResult result, int treasury}) validate({
+    required DiplomaticOrder order,
+    required int treasury,
+  }) {
+    final rel = getRelation(game, playerId, order.targetFactionId);
+    final atWar = rel?.atWar ?? false;
+    if (!atWar) {
+      return rejectDiplomaticSub(
+        'Cannot offer peace when not at war with that faction',
+        treasury,
+      );
+    }
+    return acceptDiplomaticSub(treasury);
+  }
+}

--- a/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/set_subsidy_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/set_subsidy_validator.dart
@@ -1,0 +1,55 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../../../diplomacy/diplomacy_resolver.dart';
+import '../../order_validation_result.dart';
+import 'diplomatic_sub_validator.dart';
+
+/// Type-specific validator for [DiplomaticOrderType.setSubsidy] orders.
+/// Owns amount-step rules, consulate requirement, and treasury debit on accept.
+/// SPEC/program/orders.md § Diplomatic orders / set subsidy.
+class SetSubsidySubValidator implements DiplomaticSubValidator {
+  const SetSubsidySubValidator({required this.game, required this.playerId});
+
+  final Game game;
+  final String playerId;
+
+  @override
+  ({OrderValidationResult result, int treasury}) validate({
+    required DiplomaticOrder order,
+    required int treasury,
+  }) {
+    final amount = order.amount ?? 0;
+    if (amount <= 0) {
+      return rejectDiplomaticSub(
+        'SetSubsidy amount must be positive',
+        treasury,
+      );
+    }
+    if (amount < setSubsidyAmountStep) {
+      return rejectDiplomaticSub(
+        'SetSubsidy amount must be at least £$setSubsidyAmountStep',
+        treasury,
+      );
+    }
+    if (amount % setSubsidyAmountStep != 0) {
+      return rejectDiplomaticSub(
+        'SetSubsidy amount must be a multiple of £$setSubsidyAmountStep',
+        treasury,
+      );
+    }
+    final overture = getOverture(game, playerId, order.targetFactionId);
+    if (overture == null || !overture.hasConsulate) {
+      return rejectDiplomaticSub(
+        'Consulate or Embassy required for SetSubsidy',
+        treasury,
+      );
+    }
+    if (treasury < amount) {
+      return rejectDiplomaticSub(
+        'Insufficient treasury for SetSubsidy (need $amount)',
+        treasury,
+      );
+    }
+    return acceptDiplomaticSub(treasury - amount);
+  }
+}

--- a/packages/colonizethis_logic/lib/src/orders/validators/diplomatic_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/diplomatic_order_validator.dart
@@ -1,14 +1,25 @@
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../constants.dart';
 import '../../diplomacy/diplomacy_resolver.dart';
 import '../order_validation_result.dart';
 
+import 'diplomatic/alliance_validator.dart';
+import 'diplomatic/declare_war_validator.dart';
+import 'diplomatic/diplomatic_sub_validator.dart';
+import 'diplomatic/establish_overture_validator.dart';
+import 'diplomatic/grant_aid_validator.dart';
+import 'diplomatic/offer_peace_validator.dart';
+import 'diplomatic/set_subsidy_validator.dart';
 import 'stateful_validator.dart';
 
 /// Validates diplomatic orders for a single player in submission order.
 /// SPEC/program/orders.md § Diplomatic orders.
+///
+/// Cross-cutting checks (target existence, self-targeting, the per-target
+/// diplomatic-order cap) live here. Type-specific rules are dispatched to
+/// per-type [DiplomaticSubValidator] implementations under
+/// `lib/src/orders/validators/diplomatic/`.
 class DiplomaticOrderValidator extends StatefulValidator {
   final Game _game;
   final String _playerId;
@@ -16,6 +27,8 @@ class DiplomaticOrderValidator extends StatefulValidator {
   /// Types already accepted toward each target this turn. SPEC/program/orders.md § diplomatic cap.
   final Map<String, Set<DiplomaticOrderType>> _typesByTarget =
       <String, Set<DiplomaticOrderType>>{};
+
+  late final Map<DiplomaticOrderType, DiplomaticSubValidator> _subValidators;
 
   DiplomaticOrderValidator({
     required Game game,
@@ -28,15 +41,39 @@ class DiplomaticOrderValidator extends StatefulValidator {
          treasuryState: initialTreasury,
          workerPoolState:
              game.playerById(playerId)?.workerPool ?? WorkerPool.empty,
-       );
+       ) {
+    _subValidators = <DiplomaticOrderType, DiplomaticSubValidator>{
+      DiplomaticOrderType.declareWar: DeclareWarSubValidator(
+        game: _game,
+        playerId: _playerId,
+      ),
+      DiplomaticOrderType.offerPeace: OfferPeaceSubValidator(
+        game: _game,
+        playerId: _playerId,
+      ),
+      DiplomaticOrderType.alliance: AllianceSubValidator(
+        game: _game,
+        playerId: _playerId,
+      ),
+      DiplomaticOrderType.establishOverture: EstablishOvertureSubValidator(
+        game: _game,
+        playerId: _playerId,
+      ),
+      DiplomaticOrderType.grantAid: GrantAidSubValidator(
+        game: _game,
+        playerId: _playerId,
+      ),
+      DiplomaticOrderType.setSubsidy: SetSubsidySubValidator(
+        game: _game,
+        playerId: _playerId,
+      ),
+    };
+  }
 
   int get treasury => treasuryState;
 
   ({OrderValidationResult result, int treasury}) _reject(String reason) =>
       (result: OrderValidationResult.rejected(reason), treasury: treasuryState);
-
-  ({OrderValidationResult result, int treasury}) _accept() =>
-      (result: OrderValidationResult.accepted(), treasury: treasuryState);
 
   ({OrderValidationResult result, int treasury}) _acceptRecordingTarget(
     String targetId,
@@ -45,7 +82,7 @@ class DiplomaticOrderValidator extends StatefulValidator {
     _typesByTarget
         .putIfAbsent(targetId, () => <DiplomaticOrderType>{})
         .add(type);
-    return _accept();
+    return (result: OrderValidationResult.accepted(), treasury: treasuryState);
   }
 
   bool _canAddDiplomaticOrder(String targetId, DiplomaticOrderType type) {
@@ -98,286 +135,14 @@ class DiplomaticOrderValidator extends StatefulValidator {
       );
     }
 
-    final rel = getRelation(_game, _playerId, targetId);
-    final atWar = rel?.atWar ?? false;
-    final atPeace = rel == null || rel.atPeace;
-
-    switch (order.type) {
-      case DiplomaticOrderType.declareWar:
-        if (!atPeace) {
-          return _reject('Already at war with that faction');
-        }
-        return _acceptRecordingTarget(targetId, order.type);
-
-      case DiplomaticOrderType.offerPeace:
-        if (!atWar) {
-          return _reject(
-            'Cannot offer peace when not at war with that faction',
-          );
-        }
-        return _acceptRecordingTarget(targetId, order.type);
-
-      case DiplomaticOrderType.alliance:
-        if (!isGreatPower(_game, targetId)) {
-          return _reject('Alliance target must be a Great Power');
-        }
-        if (atWar) {
-          return _reject('Cannot form alliance while at war with that faction');
-        }
-        return _acceptRecordingTarget(targetId, order.type);
-
-      case DiplomaticOrderType.establishOverture:
-        return _validateEstablishOverture(order, targetId, rel, atWar: atWar);
-
-      case DiplomaticOrderType.grantAid:
-        return _validateGrantAid(targetId, order);
-
-      case DiplomaticOrderType.setSubsidy:
-        return _validateSetSubsidy(targetId, order);
+    final subResult = _subValidators[order.type]!.validate(
+      order: order,
+      treasury: treasuryState,
+    );
+    if (!subResult.result.isAccepted) {
+      return (result: subResult.result, treasury: treasuryState);
     }
-  }
-
-  ({OrderValidationResult result, int treasury}) _validateEstablishOverture(
-    DiplomaticOrder order,
-    String targetId,
-    DiplomacyRelation? rel, {
-    required bool atWar,
-  }) {
-    final stage = order.overtureStage;
-    if (stage == null || stage == OvertureStage.none) {
-      return _reject('Overture stage is required for establishOverture');
-    }
-    if (!isMinorOrTribe(_game, targetId) && !isGreatPower(_game, targetId)) {
-      return _reject(
-        'Overtures are only valid toward Minor Nations, Tribes, or Great Powers',
-      );
-    }
-    if (atWar) {
-      return _reject(
-        'Cannot establish overture while at war with that faction',
-      );
-    }
-
-    final overture = getOverture(_game, _playerId, targetId);
-    final currentStage = overture?.stage ?? OvertureStage.none;
-
-    return switch (stage) {
-      OvertureStage.tradeConsulate => _validateOvertureTradeConsulate(
-        order,
-        targetId,
-        currentStage,
-      ),
-      OvertureStage.embassy => _validateOvertureEmbassy(
-        order,
-        targetId,
-        currentStage,
-      ),
-      OvertureStage.nap => _validateOvertureNap(order, targetId, currentStage),
-      OvertureStage.joinEmpire => _validateOvertureJoinEmpire(
-        order,
-        targetId,
-        rel,
-        currentStage,
-      ),
-      OvertureStage.none => _reject(
-        'Overture stage is required for establishOverture',
-      ),
-    };
-  }
-
-  ({OrderValidationResult result, int treasury})
-  _validateOvertureTradeConsulate(
-    DiplomaticOrder order,
-    String targetId,
-    OvertureStage currentStage,
-  ) {
-    if (currentStage != OvertureStage.none) {
-      return _reject('Trade Consulate requires no existing overture');
-    }
-    final stage = OvertureStage.tradeConsulate;
-    if (_minorTribeOvertureRequiresDiplomaticExpertise(targetId, stage) &&
-        !_playerHasDiplomaticExpertise()) {
-      return _reject(
-        'Diplomatic Expertise tech required for overtures with Minor Nations and Tribes',
-      );
-    }
-    if (treasuryState < overtureConsulateCost) {
-      return _reject(
-        'Insufficient treasury for Trade Consulate (need $overtureConsulateCost)',
-      );
-    }
-    treasuryState -= overtureConsulateCost;
+    treasuryState = subResult.treasury;
     return _acceptRecordingTarget(targetId, order.type);
-  }
-
-  ({OrderValidationResult result, int treasury}) _validateOvertureEmbassy(
-    DiplomaticOrder order,
-    String targetId,
-    OvertureStage currentStage,
-  ) {
-    if (currentStage != OvertureStage.tradeConsulate) {
-      return _reject(
-        'Embassy requires existing Trade Consulate with that faction',
-      );
-    }
-    final stage = OvertureStage.embassy;
-    if (_minorTribeOvertureRequiresDiplomaticExpertise(targetId, stage) &&
-        !_playerHasDiplomaticExpertise()) {
-      return _reject(
-        'Diplomatic Expertise tech required for overtures with Minor Nations and Tribes',
-      );
-    }
-    if (treasuryState < overtureEmbassyCost) {
-      return _reject(
-        'Insufficient treasury for Embassy (need $overtureEmbassyCost)',
-      );
-    }
-    treasuryState -= overtureEmbassyCost;
-    return _acceptRecordingTarget(targetId, order.type);
-  }
-
-  ({OrderValidationResult result, int treasury}) _validateOvertureNap(
-    DiplomaticOrder order,
-    String targetId,
-    OvertureStage currentStage,
-  ) {
-    if (currentStage != OvertureStage.embassy) {
-      return _reject(
-        'Non-Aggression Pact requires existing Embassy with that faction',
-      );
-    }
-    final stage = OvertureStage.nap;
-    if (_minorTribeOvertureRequiresDiplomaticExpertise(targetId, stage) &&
-        !_playerHasDiplomaticExpertise()) {
-      return _reject(
-        'Diplomatic Expertise tech required for overtures with Minor Nations and Tribes',
-      );
-    }
-    return _acceptRecordingTarget(targetId, order.type);
-  }
-
-  ({OrderValidationResult result, int treasury}) _validateOvertureJoinEmpire(
-    DiplomaticOrder order,
-    String targetId,
-    DiplomacyRelation? rel,
-    OvertureStage currentStage,
-  ) {
-    if (currentStage != OvertureStage.nap) {
-      return _reject(
-        'Join Empire requires existing Non-Aggression Pact with that faction',
-      );
-    }
-    final score = rel?.score ?? relationScoreNeutral;
-    if (score < relationScoreMinFriendly) {
-      return _reject(
-        'Join Empire requires at least Friendly relations (score >= $relationScoreMinFriendly)',
-      );
-    }
-    if (isGreatPower(_game, targetId)) {
-      return _validateJoinEmpireTowardGreatPower(order, targetId);
-    }
-    if (!isMinorOrTribe(_game, targetId)) {
-      return _reject(
-        'Join Empire target must be a Minor Nation, Tribe, or Great Power',
-      );
-    }
-    final cost = joinEmpireCostForMinorOrTribe(_game, targetId);
-    if (treasuryState < cost) {
-      return _reject(
-        'Join Empire requires £$cost (scales with target size); treasury is $treasuryState',
-      );
-    }
-    return _acceptRecordingTarget(targetId, order.type);
-  }
-
-  ({OrderValidationResult result, int treasury})
-  _validateJoinEmpireTowardGreatPower(DiplomaticOrder order, String targetId) {
-    final submitter = _game.playerById(_playerId);
-    if (submitter?.techUnlocked?[kTechIdEmpireBuilding] != true) {
-      return _reject(
-        'Empire Building tech required for Join Empire toward a Great Power',
-      );
-    }
-    if (!isGreatPowerNearlyDefeatedForJoinEmpire(_game, targetId)) {
-      return _reject(
-        'Join Empire toward Great Power requires target to be nearly defeated (at most 3 provinces and original capital not held by target)',
-      );
-    }
-    return _acceptRecordingTarget(targetId, order.type);
-  }
-
-  ({OrderValidationResult result, int treasury}) _validateGrantAid(
-    String targetId,
-    DiplomaticOrder order,
-  ) {
-    final amount = order.amount ?? 0;
-    if (amount <= 0) {
-      return _reject('GrantAid amount must be positive');
-    }
-    if (amount < grantAidAmountStep) {
-      return _reject('GrantAid amount must be at least £$grantAidAmountStep');
-    }
-    if (amount % grantAidAmountStep != 0) {
-      return _reject(
-        'GrantAid amount must be a multiple of £$grantAidAmountStep',
-      );
-    }
-    final overture = getOverture(_game, _playerId, targetId);
-    if (overture == null || !overture.hasEmbassy) {
-      return _reject('Embassy required for GrantAid');
-    }
-    if (treasuryState < amount) {
-      return _reject('Insufficient treasury for GrantAid (need $amount)');
-    }
-    treasuryState -= amount;
-    return _acceptRecordingTarget(targetId, order.type);
-  }
-
-  ({OrderValidationResult result, int treasury}) _validateSetSubsidy(
-    String targetId,
-    DiplomaticOrder order,
-  ) {
-    final amount = order.amount ?? 0;
-    if (amount <= 0) {
-      return _reject('SetSubsidy amount must be positive');
-    }
-    if (amount < setSubsidyAmountStep) {
-      return _reject(
-        'SetSubsidy amount must be at least £$setSubsidyAmountStep',
-      );
-    }
-    if (amount % setSubsidyAmountStep != 0) {
-      return _reject(
-        'SetSubsidy amount must be a multiple of £$setSubsidyAmountStep',
-      );
-    }
-    final overture = getOverture(_game, _playerId, targetId);
-    if (overture == null || !overture.hasConsulate) {
-      return _reject('Consulate or Embassy required for SetSubsidy');
-    }
-    if (treasuryState < amount) {
-      return _reject('Insufficient treasury for SetSubsidy (need $amount)');
-    }
-    treasuryState -= amount;
-    return _acceptRecordingTarget(targetId, order.type);
-  }
-
-  bool _minorTribeOvertureRequiresDiplomaticExpertise(
-    String targetId,
-    OvertureStage stage,
-  ) {
-    if (!isMinorOrTribe(_game, targetId)) return false;
-    return stage == OvertureStage.tradeConsulate ||
-        stage == OvertureStage.embassy ||
-        stage == OvertureStage.nap;
-  }
-
-  bool _playerHasDiplomaticExpertise() {
-    for (final p in _game.players) {
-      if (p.id == _playerId) {
-        return p.techUnlocked?[kTechIdDiplomaticExpertise] == true;
-      }
-    }
-    return false;
   }
 }

--- a/packages/colonizethis_logic/test/orders/validators/diplomatic/diplomatic_sub_validators_aid_test.dart
+++ b/packages/colonizethis_logic/test/orders/validators/diplomatic/diplomatic_sub_validators_aid_test.dart
@@ -1,0 +1,210 @@
+/// Direct unit tests for the economic sub-validators (`GrantAid`,
+/// `SetSubsidy`) extracted under #2391 AC10. Covers amount-step rules,
+/// embassy/consulate gating, treasury insufficiency, and the
+/// debit-on-accept / preserve-on-reject contract.
+/// SPEC/program/orders.md § Diplomatic orders / aid and subsidy.
+library;
+
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logic/src/orders/validators/diplomatic/grant_aid_validator.dart';
+import 'package:colonizethis_logic/src/orders/validators/diplomatic/set_subsidy_validator.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'diplomatic_sub_validators_test_support.dart';
+
+void main() {
+  group('GrantAidSubValidator', () {
+    test('rejects non-positive amount', () {
+      final v = GrantAidSubValidator(
+        game: gpMinorGame(overtureStage: OvertureStage.embassy),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.grantAid,
+          targetFactionId: 'minor1',
+          amount: 0,
+        ),
+        treasury: 5000,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('must be positive'));
+      expect(r.treasury, 5000);
+    });
+
+    test('rejects when amount is below the step', () {
+      final v = GrantAidSubValidator(
+        game: gpMinorGame(overtureStage: OvertureStage.embassy),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: DiplomaticOrder(
+          type: DiplomaticOrderType.grantAid,
+          targetFactionId: 'minor1',
+          amount: grantAidAmountStep - 1,
+        ),
+        treasury: 5000,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('at least'));
+    });
+
+    test('rejects amount that is not a multiple of the step', () {
+      final v = GrantAidSubValidator(
+        game: gpMinorGame(overtureStage: OvertureStage.embassy),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: DiplomaticOrder(
+          type: DiplomaticOrderType.grantAid,
+          targetFactionId: 'minor1',
+          amount: grantAidAmountStep + 1,
+        ),
+        treasury: 5000,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('multiple of'));
+    });
+
+    test('rejects without embassy', () {
+      final v = GrantAidSubValidator(
+        game: gpMinorGame(overtureStage: OvertureStage.tradeConsulate),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.grantAid,
+          targetFactionId: 'minor1',
+          amount: 1000,
+        ),
+        treasury: 5000,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('Embassy required'));
+    });
+
+    test('rejects when treasury below amount and preserves treasury', () {
+      final v = GrantAidSubValidator(
+        game: gpMinorGame(overtureStage: OvertureStage.embassy),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.grantAid,
+          targetFactionId: 'minor1',
+          amount: 1000,
+        ),
+        treasury: 500,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('Insufficient treasury'));
+      expect(r.treasury, 500);
+    });
+
+    test('accepts and debits treasury by the amount', () {
+      final v = GrantAidSubValidator(
+        game: gpMinorGame(overtureStage: OvertureStage.embassy),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.grantAid,
+          targetFactionId: 'minor1',
+          amount: 1000,
+        ),
+        treasury: 5000,
+      );
+      expect(r.result.status, OrderValidationStatus.accepted);
+      expect(r.treasury, 4000);
+    });
+  });
+
+  group('SetSubsidySubValidator', () {
+    test('rejects non-positive amount', () {
+      final v = SetSubsidySubValidator(
+        game: gpMinorGame(overtureStage: OvertureStage.tradeConsulate),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.setSubsidy,
+          targetFactionId: 'minor1',
+          amount: 0,
+        ),
+        treasury: 5000,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('must be positive'));
+    });
+
+    test('rejects amount not a multiple of the step', () {
+      final v = SetSubsidySubValidator(
+        game: gpMinorGame(overtureStage: OvertureStage.tradeConsulate),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: DiplomaticOrder(
+          type: DiplomaticOrderType.setSubsidy,
+          targetFactionId: 'minor1',
+          amount: setSubsidyAmountStep + 1,
+        ),
+        treasury: 5000,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('multiple of'));
+    });
+
+    test('rejects without consulate or embassy', () {
+      final v = SetSubsidySubValidator(
+        game: gpMinorGame(overtureStage: OvertureStage.none),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.setSubsidy,
+          targetFactionId: 'minor1',
+          amount: 100,
+        ),
+        treasury: 5000,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('Consulate or Embassy required'));
+    });
+
+    test('accepts with consulate and debits treasury', () {
+      final v = SetSubsidySubValidator(
+        game: gpMinorGame(overtureStage: OvertureStage.tradeConsulate),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.setSubsidy,
+          targetFactionId: 'minor1',
+          amount: 100,
+        ),
+        treasury: 5000,
+      );
+      expect(r.result.status, OrderValidationStatus.accepted);
+      expect(r.treasury, 4900);
+    });
+
+    test('rejects when treasury is below subsidy amount', () {
+      final v = SetSubsidySubValidator(
+        game: gpMinorGame(overtureStage: OvertureStage.embassy),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.setSubsidy,
+          targetFactionId: 'minor1',
+          amount: 100,
+        ),
+        treasury: 50,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('Insufficient treasury'));
+      expect(r.treasury, 50);
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/orders/validators/diplomatic/diplomatic_sub_validators_relations_test.dart
+++ b/packages/colonizethis_logic/test/orders/validators/diplomatic/diplomatic_sub_validators_relations_test.dart
@@ -1,0 +1,136 @@
+/// Direct unit tests for relation-based sub-validators
+/// (`DeclareWar`, `OfferPeace`, `Alliance`) extracted under #2391 AC10.
+/// SPEC/program/orders.md § Diplomatic orders.
+library;
+
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logic/src/orders/validators/diplomatic/alliance_validator.dart';
+import 'package:colonizethis_logic/src/orders/validators/diplomatic/declare_war_validator.dart';
+import 'package:colonizethis_logic/src/orders/validators/diplomatic/offer_peace_validator.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'diplomatic_sub_validators_test_support.dart';
+
+void main() {
+  group('DeclareWarSubValidator', () {
+    test('accepts when at peace and leaves treasury unchanged', () {
+      final v = DeclareWarSubValidator(
+        game: twoGpGame(state: RelationState.atPeace),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.declareWar,
+          targetFactionId: 'gp2',
+        ),
+        treasury: 1234,
+      );
+      expect(r.result.status, OrderValidationStatus.accepted);
+      expect(r.treasury, 1234);
+    });
+
+    test('rejects when already at war and preserves treasury', () {
+      final v = DeclareWarSubValidator(
+        game: twoGpGame(state: RelationState.atWar),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.declareWar,
+          targetFactionId: 'gp2',
+        ),
+        treasury: 999,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('Already at war'));
+      expect(r.treasury, 999);
+    });
+  });
+
+  group('OfferPeaceSubValidator', () {
+    test('accepts when at war and leaves treasury unchanged', () {
+      final v = OfferPeaceSubValidator(
+        game: twoGpGame(state: RelationState.atWar),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.offerPeace,
+          targetFactionId: 'gp2',
+        ),
+        treasury: 0,
+      );
+      expect(r.result.status, OrderValidationStatus.accepted);
+      expect(r.treasury, 0);
+    });
+
+    test('rejects when not at war', () {
+      final v = OfferPeaceSubValidator(
+        game: twoGpGame(state: RelationState.atPeace),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.offerPeace,
+          targetFactionId: 'gp2',
+        ),
+        treasury: 100,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('not at war'));
+      expect(r.treasury, 100);
+    });
+  });
+
+  group('AllianceSubValidator', () {
+    test('rejects when target is not a Great Power', () {
+      final v = AllianceSubValidator(
+        game: gpMinorGame(),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.alliance,
+          targetFactionId: 'minor1',
+        ),
+        treasury: 5000,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('must be a Great Power'));
+      expect(r.treasury, 5000);
+    });
+
+    test('rejects when at war with the target Great Power', () {
+      final v = AllianceSubValidator(
+        game: twoGpGame(state: RelationState.atWar),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.alliance,
+          targetFactionId: 'gp2',
+        ),
+        treasury: 5000,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('Cannot form alliance while at war'));
+    });
+
+    test('accepts when target is a Great Power and at peace', () {
+      final v = AllianceSubValidator(
+        game: twoGpGame(state: RelationState.atPeace),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.alliance,
+          targetFactionId: 'gp2',
+        ),
+        treasury: 5000,
+      );
+      expect(r.result.status, OrderValidationStatus.accepted);
+      expect(r.treasury, 5000);
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/orders/validators/diplomatic/diplomatic_sub_validators_test_support.dart
+++ b/packages/colonizethis_logic/test/orders/validators/diplomatic/diplomatic_sub_validators_test_support.dart
@@ -1,0 +1,69 @@
+/// Shared fixtures for the per-`DiplomaticOrderType` sub-validator tests
+/// extracted under #2391 AC10.
+library;
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+Game gpMinorGame({
+  RelationState relationState = RelationState.atPeace,
+  int relationScore = 50,
+  OvertureStage overtureStage = OvertureStage.none,
+  Map<String, bool>? techUnlocked,
+}) {
+  return Game(
+    id: 'g1',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+      oldWorld: const RegionData(),
+      newWorld: const RegionData(),
+    ),
+    players: [
+      Player(
+        id: 'gp1',
+        displayName: 'GP1',
+        isHuman: true,
+        techUnlocked: techUnlocked ?? const {kTechIdDiplomaticExpertise: true},
+      ),
+    ],
+    minorNations: const [MinorNation(id: 'minor1', displayName: 'Minor 1')],
+    diplomacyRelations: [
+      DiplomacyRelation(
+        factionId1: 'gp1',
+        factionId2: 'minor1',
+        state: relationState,
+        score: relationScore,
+      ),
+    ],
+    overtureStates: [
+      OvertureState(
+        gpId: 'gp1',
+        targetId: 'minor1',
+        stage: overtureStage,
+        sinceTurn: 0,
+      ),
+    ],
+  );
+}
+
+Game twoGpGame({RelationState state = RelationState.atPeace}) {
+  return Game(
+    id: 'g1',
+    worldState: WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+      oldWorld: const RegionData(),
+      newWorld: const RegionData(),
+    ),
+    players: const [
+      Player(id: 'gp1', displayName: 'GP1', isHuman: true),
+      Player(id: 'gp2', displayName: 'GP2', isHuman: false),
+    ],
+    diplomacyRelations: [
+      DiplomacyRelation(
+        factionId1: 'gp1',
+        factionId2: 'gp2',
+        state: state,
+      ),
+    ],
+  );
+}

--- a/packages/colonizethis_logic/test/orders/validators/diplomatic/establish_overture_sub_validator_test.dart
+++ b/packages/colonizethis_logic/test/orders/validators/diplomatic/establish_overture_sub_validator_test.dart
@@ -1,0 +1,156 @@
+/// Direct unit tests for `EstablishOvertureSubValidator` extracted under
+/// #2391 AC10. Covers each per-stage rule and the treasury-debit/preserve
+/// contract on accept and reject.
+/// SPEC/program/orders.md § Diplomatic orders / overtures.
+library;
+
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logic/src/orders/validators/diplomatic/establish_overture_validator.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'diplomatic_sub_validators_test_support.dart';
+
+void main() {
+  group('EstablishOvertureSubValidator', () {
+    test('rejects when stage is missing', () {
+      final v = EstablishOvertureSubValidator(
+        game: gpMinorGame(),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.establishOverture,
+          targetFactionId: 'minor1',
+        ),
+        treasury: 5000,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('Overture stage is required'));
+    });
+
+    test('trade consulate debits treasury on accept', () {
+      final v = EstablishOvertureSubValidator(
+        game: gpMinorGame(overtureStage: OvertureStage.none),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.establishOverture,
+          targetFactionId: 'minor1',
+          overtureStage: OvertureStage.tradeConsulate,
+        ),
+        treasury: overtureConsulateCost + 100,
+      );
+      expect(r.result.status, OrderValidationStatus.accepted);
+      expect(r.treasury, 100);
+    });
+
+    test('trade consulate rejects without diplomatic_expertise', () {
+      final v = EstablishOvertureSubValidator(
+        game: gpMinorGame(techUnlocked: const {}),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.establishOverture,
+          targetFactionId: 'minor1',
+          overtureStage: OvertureStage.tradeConsulate,
+        ),
+        treasury: overtureConsulateCost + 100,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('Diplomatic Expertise'));
+      expect(r.treasury, overtureConsulateCost + 100);
+    });
+
+    test('trade consulate rejects when treasury too low (no debit)', () {
+      final v = EstablishOvertureSubValidator(
+        game: gpMinorGame(),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.establishOverture,
+          targetFactionId: 'minor1',
+          overtureStage: OvertureStage.tradeConsulate,
+        ),
+        treasury: overtureConsulateCost - 1,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('Insufficient treasury'));
+      expect(r.treasury, overtureConsulateCost - 1);
+    });
+
+    test('embassy requires existing trade consulate', () {
+      final v = EstablishOvertureSubValidator(
+        game: gpMinorGame(overtureStage: OvertureStage.none),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.establishOverture,
+          targetFactionId: 'minor1',
+          overtureStage: OvertureStage.embassy,
+        ),
+        treasury: overtureEmbassyCost + 1000,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('requires existing Trade Consulate'));
+    });
+
+    test('embassy accepts and debits treasury when consulate exists', () {
+      final v = EstablishOvertureSubValidator(
+        game: gpMinorGame(overtureStage: OvertureStage.tradeConsulate),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.establishOverture,
+          targetFactionId: 'minor1',
+          overtureStage: OvertureStage.embassy,
+        ),
+        treasury: overtureEmbassyCost + 50,
+      );
+      expect(r.result.status, OrderValidationStatus.accepted);
+      expect(r.treasury, 50);
+    });
+
+    test('nap requires existing embassy and does not debit treasury', () {
+      final v = EstablishOvertureSubValidator(
+        game: gpMinorGame(overtureStage: OvertureStage.embassy),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.establishOverture,
+          targetFactionId: 'minor1',
+          overtureStage: OvertureStage.nap,
+        ),
+        treasury: 1234,
+      );
+      expect(r.result.status, OrderValidationStatus.accepted);
+      expect(r.treasury, 1234);
+    });
+
+    test('joinEmpire rejects when relations below friendly threshold', () {
+      final v = EstablishOvertureSubValidator(
+        game: gpMinorGame(
+          overtureStage: OvertureStage.nap,
+          relationScore: relationScoreNeutral,
+        ),
+        playerId: 'gp1',
+      );
+      final r = v.validate(
+        order: const DiplomaticOrder(
+          type: DiplomaticOrderType.establishOverture,
+          targetFactionId: 'minor1',
+          overtureStage: OvertureStage.joinEmpire,
+        ),
+        treasury: 100000,
+      );
+      expect(r.result.status, OrderValidationStatus.rejected);
+      expect(r.result.reason, contains('Friendly relations'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements **AC10** from issue #2391: splits the 383-line monolithic
`DiplomaticOrderValidator._validateOne` switch into six focused
per-`DiplomaticOrderType` sub-validators under
`packages/colonizethis_logic/lib/src/orders/validators/diplomatic/`,
behind a small `DiplomaticSubValidator` interface.

The dispatcher (`DiplomaticOrderValidator`) keeps only the cross-cutting
checks (target existence, self-targeting, per-target diplomatic-order
cap) and the accept-recording bookkeeping. Type-specific reject reasons
and treasury debits live in their own files, each focused on one
`DiplomaticOrderType`.

## In scope (this PR)

New library files under `lib/src/orders/validators/diplomatic/`:

| File | Concern |
|------|---------|
| `diplomatic_sub_validator.dart` | `DiplomaticSubValidator` interface + shared `acceptDiplomaticSub` / `rejectDiplomaticSub` helpers |
| `declare_war_validator.dart` | `DeclareWarSubValidator` (28 LOC) |
| `offer_peace_validator.dart` | `OfferPeaceSubValidator` (31 LOC) |
| `alliance_validator.dart` | `AllianceSubValidator` (38 LOC) |
| `establish_overture_validator.dart` | `EstablishOvertureSubValidator` — owns per-stage `tradeConsulate` / `embassy` / `nap` / `joinEmpire` rules + treasury debits (236 LOC) |
| `grant_aid_validator.dart` | `GrantAidSubValidator` (50 LOC) |
| `set_subsidy_validator.dart` | `SetSubsidySubValidator` (56 LOC) |

`diplomatic_order_validator.dart` shrinks from **383 → 148 lines** and
becomes a thin dispatcher that wires up the six sub-validators in its
constructor.

### Tests

Direct positive + negative tests for each sub-validator (debit-on-accept
and preserve-on-reject contracts, missing/cap rules, tech gating,
embassy/consulate gating). Split into three files plus a small support
file to stay under the **400-line `repo.logic_test_file_size`** gate:

- `test/orders/validators/diplomatic/diplomatic_sub_validators_test_support.dart` (69 LOC)
- `test/orders/validators/diplomatic/diplomatic_sub_validators_relations_test.dart` (8 cases — `DeclareWar`, `OfferPeace`, `Alliance`)
- `test/orders/validators/diplomatic/establish_overture_sub_validator_test.dart` (8 cases — every stage incl. join-empire below-friendly reject)
- `test/orders/validators/diplomatic/diplomatic_sub_validators_aid_test.dart` (10 cases — `GrantAid` and `SetSubsidy`)

26 new sub-validator unit tests in total.

## Behavior preservation

- All existing reject reason strings are reproduced **verbatim** so
  string-matching tests (`order_engine_validate_diplomatic_relations_test.dart`,
  `order_engine_validate_diplomatic_aid_subsidy_test.dart`,
  `order_engine_validator_injection_test.dart`,
  `incremental_candidate_validator_equivalence_test.dart`) keep passing
  unchanged.
- Treasury debit semantics preserved exactly: sub-validators that don't
  charge a fee return the input treasury unchanged; cost-bearing
  sub-validators (`EstablishOverture` consulate/embassy stages,
  `GrantAid`, `SetSubsidy`) return debited treasury **only on accept**
  and the original value on reject. The dispatcher commits the new
  value only when the sub-validator accepts.
- Constructor signature, public method (`validate(...)`), and
  `treasury` getter on `DiplomaticOrderValidator` are unchanged — no
  caller in `OrderEngine` / `IncrementalCandidateValidator` /
  characterization tests had to change.

## Deferred (still open under #2391)

- AC5 (shared logger across ~40 files), AC6 (`ValidatorBundle` factory),
  AC7 (order_engine category descriptor loop), AC9
  (`work_order_validator` step fold), AC11–AC15 (CI lint promotion).
- AC1, AC2, AC3, AC4 are covered by other in-flight PRs (#2396, #2398,
  #2399, #2404, #2405) and remain out of scope here.

## SPEC

No SPEC change required. AC10 is a structural refactor; SPEC/program/orders.md
§ Diplomatic orders remains the source of truth for the rules being
relocated. Each sub-validator file references the relevant SPEC section
in its leading dartdoc.

## Verification

- `cd packages/colonizethis_logic && dart analyze lib/src/orders/validators/ test/orders/validators/diplomatic/` — `No issues found!`
- `cd packages/colonizethis_logic && dart test test/orders/` — `+210 / All tests passed!` (existing 184 + 26 new)
- `cd packages/colonizethis_logic && dart test test/order_engine_validate_diplomatic_relations_test.dart test/order_engine_validate_diplomatic_aid_subsidy_test.dart test/order_engine_validator_injection_test.dart test/orders/incremental_candidate_validator_equivalence_test.dart` — `+28 / All tests passed!`
- `dart run tool/check_logic_test_file_size.dart` — `no violations found.`
- `dart run tool/check_logic_dead_files.dart` — `passed: no unreferenced files`
- `dart run tool/check_dart_file_non_comment_line_size.dart` — `no violations found.`
- `dart run tool/check_function_size.dart` — `no function-size violations.`
- `dart run tool/check_logic_dual_region_province_field_access.dart` — `passed`
- `dart run tool/check_logic_all_provinces_sanctioned_calls.dart` — `passed`
- `bash tool/check_logic_ai_decoupling.sh` — `passed`
- `bash tool/check_naked_logger_usage.sh` — `No naked Logger(...) usage detected.`

Refs #2391 — does not auto-close the issue. Per the `backlog-implement-agent`
skill, remote CI is not awaited in this session.


Made with [Cursor](https://cursor.com)