### PR TITLE
perf(logic): index minor nations once in army diplomacy filter (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_helpers.dart
@@ -39,6 +39,9 @@ Map<String, String> getProvinceOwnerMap(Game game) {
 ///
 /// [destinationProvinceId] returns the destination province id for each order
 /// (full id: regionId|localId).
+///
+/// Minor-nation membership is indexed once per call (Refs #2394,
+/// SPEC/program/order-suggestions.md).
 List<T> filterOrdersByDiplomacy<T>(
   Game game,
   String playerId,
@@ -46,6 +49,9 @@ List<T> filterOrdersByDiplomacy<T>(
   String Function(T order) destinationProvinceId,
 ) {
   final provinceOwner = getProvinceOwnerMap(game);
+  final minorNationIds = <String>{
+    for (final mn in game.minorNations) mn.id,
+  };
   final filtered = <T>[];
   for (final m in orders) {
     final destOwner = provinceOwner[destinationProvinceId(m)];
@@ -56,7 +62,7 @@ List<T> filterOrdersByDiplomacy<T>(
     final rel = getRelation(game, playerId, destOwner);
     if (rel != null && rel.atPeace) continue;
     if (rel == null) {
-      if (game.minorNations.any((mn) => mn.id == destOwner)) continue;
+      if (minorNationIds.contains(destOwner)) continue;
     }
     filtered.add(m);
   }

--- a/packages/colonizethis_logic/test/order_suggestion_diplomacy_filter_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_diplomacy_filter_test.dart
@@ -2,12 +2,13 @@ import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+const _ow = 'oldWorld';
+
 void main() {
   group('filterMoveOrdersByDiplomacy and getProvinceOwnerMap', () {
     test('getProvinceOwnerMap returns owner by full province id', () {
-      const ow = 'oldWorld';
-      final p1 = Province(id: 'p1', regionId: ow, ownerId: 'gp1');
-      final p2 = Province(id: 'p2', regionId: ow, ownerId: 'gp2');
+      final p1 = Province(id: 'p1', regionId: _ow, ownerId: 'gp1');
+      final p2 = Province(id: 'p2', regionId: _ow, ownerId: 'gp2');
       final world = WorldState(
         turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
         oldWorld: RegionData(provinces: [p1, p2], units: []),
@@ -121,6 +122,70 @@ void main() {
       final filtered = filterMoveOrdersByDiplomacy(game, 'gp1', orders);
       expect(filtered.length, 1);
       expect(filtered.first.destinationTileKey, 'oldWorld|p2|0|0');
+    });
+  });
+
+  group('filterArmyMoveOrdersByDiplomacy', () {
+    test('drops army move into minor-owned province when no diplomacy row', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'p1', regionId: _ow, ownerId: 'gp1'),
+              Province(id: 'p2', regionId: _ow, ownerId: 'mn1'),
+            ],
+            units: [],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'A', isHuman: false),
+        ],
+        minorNations: const [
+          MinorNation(id: 'mn1', displayName: 'Minor'),
+        ],
+      );
+      const orders = [
+        ArmyMoveOrder(
+          armyId: 'a1',
+          destinationProvinceId: 'oldWorld|p2',
+        ),
+      ];
+      final filtered = filterArmyMoveOrdersByDiplomacy(game, 'gp1', orders);
+      expect(filtered, isEmpty);
+    });
+
+    test('keeps army move into tribe-owned province when no diplomacy row', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              Province(id: 'p1', regionId: _ow, ownerId: 'gp1'),
+              Province(id: 'p2', regionId: _ow, ownerId: 'tr1'),
+            ],
+            units: [],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'A', isHuman: false),
+        ],
+        tribes: const [
+          Tribe(id: 'tr1', displayName: 'Tribe'),
+        ],
+      );
+      const orders = [
+        ArmyMoveOrder(
+          armyId: 'a1',
+          destinationProvinceId: 'oldWorld|p2',
+        ),
+      ];
+      final filtered = filterArmyMoveOrdersByDiplomacy(game, 'gp1', orders);
+      expect(filtered, orders);
     });
   });
 }


### PR DESCRIPTION
## Summary
Refs #2394. `filterOrdersByDiplomacy` (used by `filterArmyMoveOrdersByDiplomacy`) previously called `game.minorNations.any(...)` for every candidate order, repeating a linear scan. Minor nation ids are now collected once per filter call and checked with O(1) set membership. Semantics are unchanged: only registered minor nations are treated as blocked when there is no diplomacy row (tribes are not included in that branch, matching prior behavior).

## SPEC / AC
- Performance-only; aligns with `SPEC/program/order-suggestions.md` throughput guidance and issue #2394 Category C (linear scans in hot paths). No GDD/TDD change.

## Tests
- Extended `packages/colonizethis_logic/test/order_suggestion_diplomacy_filter_test.dart`: minor-owned destination with no relation is dropped; tribe-owned with no relation is kept.
- Ran: `cd packages/colonizethis_logic && dart test test/order_suggestion_diplomacy_filter_test.dart`

## Out of scope
- Open PR #2427 covers broader diplomatic suggestion O(1) faction classification; this change is limited to the shared army-move diplomacy filter helper.

Refs #2394

Made with [Cursor](https://cursor.com)