### PR TITLE
perf(logic): reuse view/units in diplomatic suggestion acceptance probes (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
@@ -36,15 +36,27 @@ class IncrementalCandidateValidator {
   /// instance per suggestion pass to amortize the per-player view/unit lookup
   /// build cost across many candidate probes (the AI suggestion API enumerates
   /// many candidates per call).
+  ///
+  /// When the caller already has a [PlayerView] and/or units-by-id map for the
+  /// same `(game, topology, playerId)` tuple, pass them via [view] /
+  /// [unitsById] to skip redundant `buildPlayerView` and `unitsByIdFromWorld`
+  /// scans (Refs #2394, `SPEC/program/order-suggestions.md` § Throughput bounds).
+  /// The shared instances must match that tuple; behavior is undefined otherwise.
   factory IncrementalCandidateValidator.forPlayer({
     required Game game,
     required MapTopology topology,
     required String playerId,
     required Orders basePrefix,
     Map<String, TileMapResult>? tileMapByRegion,
+    PlayerView? view,
+    Map<String, Unit>? unitsById,
   }) {
-    final view = buildPlayerView(game, topology, playerId);
-    final unitsById = unitsByIdFromWorld(game.worldState);
+    assert(
+      view == null || view.playerId == playerId,
+      'shared PlayerView playerId must match validator playerId',
+    );
+    final actualView = view ?? buildPlayerView(game, topology, playerId);
+    final actualUnitsById = unitsById ?? unitsByIdFromWorld(game.worldState);
     final diplomaticOrders =
         basePrefix.diplomaticOrdersByPlayerId[playerId] ??
         const <DiplomaticOrder>[];
@@ -53,8 +65,8 @@ class IncrementalCandidateValidator {
       topology: topology,
       playerId: playerId,
       basePrefix: basePrefix,
-      view: view,
-      unitsById: unitsById,
+      view: actualView,
+      unitsById: actualUnitsById,
       diplomaticOrders: diplomaticOrders,
       tileMapByRegion: tileMapByRegion,
     );

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_context.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_context.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../world/player_view.dart';
 import 'draft_orders_mutations.dart';
 import 'incremental_candidate_validator.dart';
 
@@ -33,6 +34,8 @@ IncrementalCandidateValidator buildIncrementalCandidateValidator({
   required String playerId,
   required Orders baseOrders,
   Map<String, TileMapResult>? tileMapByRegion,
+  PlayerView? view,
+  Map<String, Unit>? unitsById,
 }) {
   return IncrementalCandidateValidator.forPlayer(
     game: game,
@@ -40,6 +43,8 @@ IncrementalCandidateValidator buildIncrementalCandidateValidator({
     playerId: playerId,
     basePrefix: baseOrders,
     tileMapByRegion: tileMapByRegion,
+    view: view,
+    unitsById: unitsById,
   );
 }
 
@@ -161,6 +166,13 @@ bool isDiplomaticOrderAccepted(
   Orders baseOrders,
   DiplomaticOrder candidate, {
   Map<String, TileMapResult>? tileMapByRegion,
+  /// When callers probe many candidates for the same `(game, topology,
+  /// playerId)` (for example diplomatic suggestion loops), they may pass the
+  /// same [view] / [unitsById] built once to skip redundant `buildPlayerView`
+  /// and `unitsByIdFromWorld` scans. Refs #2394; `SPEC/program/order-suggestions.md`
+  /// § Throughput bounds.
+  PlayerView? view,
+  Map<String, Unit>? unitsById,
 }) {
   final validator = buildIncrementalCandidateValidator(
     game: game,
@@ -168,6 +180,8 @@ bool isDiplomaticOrderAccepted(
     playerId: playerId,
     baseOrders: baseOrders,
     tileMapByRegion: tileMapByRegion,
+    view: view,
+    unitsById: unitsById,
   );
   return validator.isDiplomaticAccepted(candidate);
 }

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
@@ -6,6 +6,7 @@ import '../world/naval.dart';
 import '../world/player_view.dart';
 import '../world/province_lookup.dart';
 import '../world/topology_helpers.dart';
+import '../world/unit_lookup.dart';
 import 'incremental_candidate_validator.dart';
 import 'order_suggestion_context.dart';
 import 'orders_application_helpers.dart';
@@ -426,6 +427,11 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
   };
   final knownTargetIds = knownTargets.toSet();
 
+  // One world scan for the suggestion pass: every `isDiplomaticOrderAccepted`
+  // probe shares the same `(game, topology, playerId)` view/units snapshot.
+  // Refs #2394.
+  final unitsByIdForDiplomatic = unitsByIdFromWorld(game.worldState);
+
   final unionTargets = <String>{
     ...knownTargets,
     ...otherGps,
@@ -460,6 +466,8 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
         trialOrders,
         candidate,
         tileMapByRegion: tileMapByRegion,
+        view: view,
+        unitsById: unitsByIdForDiplomatic,
       )) {
         continue;
       }
@@ -484,6 +492,8 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
         trialOrders,
         candidate,
         tileMapByRegion: tileMapByRegion,
+        view: view,
+        unitsById: unitsByIdForDiplomatic,
       )) {
         continue;
       }

--- a/packages/colonizethis_logic/test/order_suggestion_context_helpers_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_context_helpers_test.dart
@@ -2,6 +2,8 @@ import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_logic/src/orders/order_suggestion_context.dart';
+import 'package:colonizethis_logic/src/world/player_view.dart';
+import 'package:colonizethis_logic/src/world/unit_lookup.dart';
 
 void main() {
   final minimalGame = Game(
@@ -112,5 +114,55 @@ void main() {
       );
       expect(accepted, isFalse);
     });
+
+    test(
+      'isDiplomaticOrderAccepted matches default path when view/units shared',
+      () {
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'A', isHuman: false),
+            Player(id: 'gp2', displayName: 'B', isHuman: false),
+          ],
+          diplomacyRelations: const [
+            DiplomacyRelation(
+              factionId1: 'gp1',
+              factionId2: 'gp2',
+              state: RelationState.atPeace,
+              level: RelationLevel.neutral,
+            ),
+          ],
+        );
+        const candidate = DiplomaticOrder(
+          type: DiplomaticOrderType.alliance,
+          targetFactionId: 'gp2',
+        );
+        final sharedView = buildPlayerView(game, topology, 'gp1');
+        final sharedUnits = unitsByIdFromWorld(game.worldState);
+        final defaultPath = isDiplomaticOrderAccepted(
+          game,
+          topology,
+          'gp1',
+          const Orders(),
+          candidate,
+        );
+        final sharedPath = isDiplomaticOrderAccepted(
+          game,
+          topology,
+          'gp1',
+          const Orders(),
+          candidate,
+          view: sharedView,
+          unitsById: sharedUnits,
+        );
+        expect(sharedPath, defaultPath);
+        expect(defaultPath, isTrue);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Implements a **#2394 Category A** slice: `suggestDiplomaticOrders` called `isDiplomaticOrderAccepted` for every candidate probe, and each call rebuilt `PlayerView` and `unitsByIdFromWorld` inside `IncrementalCandidateValidator.forPlayer`.

- `IncrementalCandidateValidator.forPlayer` and `buildIncrementalCandidateValidator` now accept optional pre-built `view` / `unitsById` (same contract as `SPEC/program/order-suggestions.md` § Throughput bounds).
- `suggestDiplomaticOrders` builds `unitsByIdFromWorld` once per suggestion pass and passes the existing suggestion `view` plus that map into every `isDiplomaticOrderAccepted` call. Each probe still constructs a fresh validator for the moving `trialOrders` prefix, but skips the redundant full-world view/unit scans.

## Deferred

- Broader sharing of a single validator instance across probes where `basePrefix` changes (would need rebinding or a different primitive).
- Other `#2394` items (Category B replay caching, AST lints, benchmarks) remain for follow-up PRs.

## Tests

- New: `order_suggestion_context_helpers_test.dart` — `isDiplomaticOrderAccepted` with shared `view`/`unitsById` matches default path; asserts accepted alliance case.
- Verified: `cd packages/colonizethis_logic && dart test` → **+1532 All tests passed!**

Refs #2394

Made with [Cursor](https://cursor.com)