### PR TITLE
perf(logic): O(1) FleetMission lookup for naval orders (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/naval_mission_orders.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_mission_orders.dart
@@ -1,4 +1,3 @@
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
@@ -6,12 +5,13 @@ import '../diplomacy/diplomacy_relation_lookup.dart';
 import 'naval.dart';
 import 'province_lookup.dart';
 
-FleetMission _fleetMissionFromOrderName(String name) {
-  for (final m in FleetMission.values) {
-    if (m.name == name) return m;
-  }
-  return FleetMission.none;
-}
+/// O(1) mission lookup for naval order strings (Refs #2394).
+final _fleetMissionByOrderName = <String, FleetMission>{
+  for (final m in FleetMission.values) m.name: m,
+};
+
+FleetMission _fleetMissionFromOrderName(String name) =>
+    _fleetMissionByOrderName[name] ?? FleetMission.none;
 
 List<Fleet> _applySingleNavalMissionOrder({
   required Game game,


### PR DESCRIPTION
## Summary
- Replace `_fleetMissionFromOrderName` linear scan over `FleetMission.values` with a library-level `Map<String, FleetMission>` built once (same pattern as visibility-level maps elsewhere).
- Drop unused `colonizethis_data` import (now satisfied via models / other imports).

## Scope / issue alignment
Implements a small **Refs #2394** hot-path cleanup (string mission → enum); behavior and deterministic ordering unchanged.

**Deferred:** `fleets.indexWhere` in the same file (list index for in-place updates) — would need a larger refactor to avoid O(fleets) per order safely.

## SPEC
No change — internal implementation detail only (`SPEC/program/turn-resolution.md` / order application semantics unchanged).

## Tests
- `dart test` in `packages/colonizethis_logic` (full suite, 1542 tests)

Refs #2394

Made with [Cursor](https://cursor.com)