### PR TITLE
perf(logic): defer spyRevealTurnsByPlayer deep copy until spy leaves enemy province (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/turn/phases/movement_phase.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases/movement_phase.dart
@@ -38,17 +38,26 @@ Game runMovementPhase(
     );
     final oldWorld = tiled.oldWorld;
     final newWorld = tiled.newWorld;
-    final spyTimers = Map<String, Map<String, int>>.from(
-      state.worldState.spyRevealTurnsByPlayer.map(
-        (k, v) => MapEntry(k, Map<String, int>.from(v)),
-      ),
-    );
+    // Defer the deep copy of spyRevealTurnsByPlayer until a spy actually
+    // leaves an enemy province; most turns have zero such events, so the
+    // eager copy was wasted O(players * provinces) work per move phase.
+    // Refs #2394 Category D.
+    final originalSpyTimers = state.worldState.spyRevealTurnsByPlayer;
+    Map<String, Map<String, int>>? mutableSpyTimers;
+    Map<String, int> spyTimersForOwner(String ownerId) {
+      mutableSpyTimers ??= {
+        for (final entry in originalSpyTimers.entries)
+          entry.key: Map<String, int>.from(entry.value),
+      };
+      return mutableSpyTimers!.putIfAbsent(ownerId, () => <String, int>{});
+    }
+
     void recordSpyLeft(String ownerId, String provinceId) {
       final provinceOwner = ownerByProvinceId[provinceId];
       if (provinceOwner == null || provinceOwner == ownerId) {
         return;
       }
-      spyTimers.putIfAbsent(ownerId, () => {})[provinceId] = 5;
+      spyTimersForOwner(ownerId)[provinceId] = 5;
     }
 
     void recordSpyProvinceChanges(RegionData before, RegionData after) {
@@ -72,7 +81,7 @@ Game runMovementPhase(
       worldState: state.worldState.copyWith(
         oldWorld: oldWorld,
         newWorld: newWorld,
-        spyRevealTurnsByPlayer: spyTimers,
+        spyRevealTurnsByPlayer: mutableSpyTimers ?? originalSpyTimers,
       ),
     );
   }

--- a/packages/colonizethis_logic/test/movement_phase_spy_reveal_timer_test.dart
+++ b/packages/colonizethis_logic/test/movement_phase_spy_reveal_timer_test.dart
@@ -26,7 +26,10 @@ void main() {
         final game = Game(
           id: 'g',
           worldState: WorldState(
-            turnState: const TurnState(phase: TurnPhase.movement, turnNumber: 2),
+            turnState: const TurnState(
+              phase: TurnPhase.movement,
+              turnNumber: 2,
+            ),
             oldWorld: RegionData(
               provinces: const [
                 Province(id: p1, regionId: ow, ownerId: 'spyOwner'),
@@ -90,9 +93,7 @@ void main() {
         worldState: WorldState(
           turnState: const TurnState(phase: TurnPhase.movement, turnNumber: 2),
           oldWorld: RegionData(
-            provinces: const [
-              Province(id: p2, regionId: ow, ownerId: 'enemy'),
-            ],
+            provinces: const [Province(id: p2, regionId: ow, ownerId: 'enemy')],
             units: [
               Unit(
                 id: 'spy1',
@@ -121,14 +122,188 @@ void main() {
         topology,
         const Orders(
           moveOrdersByPlayerId: {
-            'spyOwner': [
-              MoveOrder(unitId: 'spy1', destinationTileKey: tileB),
-            ],
+            'spyOwner': [MoveOrder(unitId: 'spy1', destinationTileKey: tileB)],
           },
         ),
       );
 
       expect(after.worldState.spyRevealTurnsByPlayer['spyOwner'], isNull);
+    });
+
+    test('when no spy leaves an enemy province, spyRevealTurnsByPlayer is '
+        'returned without an eager deep copy (Refs #2394 Category D)', () {
+      const ow = 'oldWorld';
+      const p1 = '$ow|p1';
+      const p2 = '$ow|p2';
+      const tileP1a = '$p1|0|0';
+      const tileP1b = '$p1|1|0';
+
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(id: p1, regionId: ow, type: TopologyNodeType.province),
+          TopologyNode(id: p2, regionId: ow, type: TopologyNodeType.province),
+        ],
+        edges: const [TopologyEdge(id1: p1, id2: p2)],
+      );
+
+      // Seed an existing spy reveal entry so we can assert identity is
+      // preserved across the move phase when no new spy event fires.
+      const existingSpyTimers = <String, Map<String, int>>{
+        'spyOwner': {p2: 3},
+      };
+
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.movement, turnNumber: 2),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: p1, regionId: ow, ownerId: 'spyOwner'),
+              Province(id: p2, regionId: ow, ownerId: 'enemy'),
+            ],
+            // A non-spy unit moving within the player's own territory must
+            // not arm a reveal timer and must not trigger any spy timer
+            // mutation.
+            units: [
+              Unit(
+                id: 'scout1',
+                type: kUnitTypeExplorer,
+                ownerId: 'spyOwner',
+                locationProvinceId: p1,
+                tileKey: tileP1a,
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: const {
+            ow: {
+              p1: [tileP1a, tileP1b],
+              p2: [],
+            },
+          },
+          spyRevealTurnsByPlayer: existingSpyTimers,
+        ),
+        players: const [
+          Player(id: 'spyOwner', displayName: 'Human spy', isHuman: true),
+          Player(id: 'enemy', displayName: 'Enemy', isHuman: false),
+        ],
+      );
+
+      final after = runMovementPhase(
+        game,
+        topology,
+        const Orders(
+          moveOrdersByPlayerId: {
+            'spyOwner': [
+              MoveOrder(unitId: 'scout1', destinationTileKey: tileP1b),
+            ],
+          },
+        ),
+      );
+
+      // Same reference is reused: the move phase did not perform an
+      // eager deep copy of spyRevealTurnsByPlayer when no spy moved.
+      expect(
+        identical(after.worldState.spyRevealTurnsByPlayer, existingSpyTimers),
+        isTrue,
+        reason:
+            'No spy reveal events should preserve the existing map '
+            'reference instead of deep-copying.',
+      );
+      expect(
+        after.worldState.spyRevealTurnsByPlayer['spyOwner']?[p2],
+        3,
+        reason: 'Existing reveal timers must be carried through unchanged.',
+      );
+    });
+
+    test('when a spy leaves an enemy province, prior reveal entries from other '
+        'owners and provinces are preserved alongside the new entry', () {
+      const ow = 'oldWorld';
+      const p1 = '$ow|p1';
+      const p2 = '$ow|p2';
+      const p3 = '$ow|p3';
+      const tileP1 = '$p1|0|0';
+      const tileP2 = '$p2|0|0';
+
+      final topology = MapTopology(
+        nodes: const [
+          TopologyNode(id: p1, regionId: ow, type: TopologyNodeType.province),
+          TopologyNode(id: p2, regionId: ow, type: TopologyNodeType.province),
+          TopologyNode(id: p3, regionId: ow, type: TopologyNodeType.province),
+        ],
+        edges: const [TopologyEdge(id1: p1, id2: p2)],
+      );
+
+      const existingSpyTimers = <String, Map<String, int>>{
+        'spyOwner': {p3: 2},
+        'otherOwner': {p3: 4},
+      };
+
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.movement, turnNumber: 2),
+          oldWorld: RegionData(
+            provinces: const [
+              Province(id: p1, regionId: ow, ownerId: 'spyOwner'),
+              Province(id: p2, regionId: ow, ownerId: 'enemy'),
+              Province(id: p3, regionId: ow, ownerId: 'enemy'),
+            ],
+            units: [
+              Unit(
+                id: 'spy1',
+                type: kUnitTypeSpy,
+                ownerId: 'spyOwner',
+                locationProvinceId: p2,
+                tileKey: tileP2,
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+          tileKeysByRegionAndProvince: const {
+            ow: {
+              p1: [tileP1],
+              p2: [tileP2],
+              p3: [],
+            },
+          },
+          spyRevealTurnsByPlayer: existingSpyTimers,
+        ),
+        players: const [
+          Player(id: 'spyOwner', displayName: 'Human spy', isHuman: true),
+          Player(id: 'enemy', displayName: 'Enemy', isHuman: false),
+        ],
+      );
+
+      final after = runMovementPhase(
+        game,
+        topology,
+        const Orders(
+          moveOrdersByPlayerId: {
+            'spyOwner': [MoveOrder(unitId: 'spy1', destinationTileKey: tileP1)],
+          },
+        ),
+      );
+
+      final spyTimers = after.worldState.spyRevealTurnsByPlayer;
+      expect(spyTimers['spyOwner']?[p2], 5, reason: 'New reveal armed.');
+      expect(
+        spyTimers['spyOwner']?[p3],
+        2,
+        reason: 'Pre-existing same-owner timer must be carried over.',
+      );
+      expect(
+        spyTimers['otherOwner']?[p3],
+        4,
+        reason: 'Unrelated owner entries must be carried over.',
+      );
+      // The lazy copy must produce a new outer map (mutated separately).
+      expect(
+        identical(spyTimers, existingSpyTimers),
+        isFalse,
+        reason: 'Once a spy event fires we must not mutate the input map.',
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

Refs #2394 — Category D (Collection copies in hot loops), site `movement_phase.dart:41-45`.

`runMovementPhase` previously deep-copied the entire nested `WorldState.spyRevealTurnsByPlayer` map unconditionally at the top of every move phase, even though only a small fraction of turns actually produce a spy-province-leave event. The copy is O(players × provinces-with-timers) and ran every turn regardless.

This PR makes the copy lazy: the original immutable map reference is reused unless `recordSpyLeft` actually fires, in which case a deep copy is materialized on first call and mutated thereafter. The resulting `WorldState.spyRevealTurnsByPlayer` value is semantically identical to the previous behavior; the only visible difference is allocation count (zero on turns with no spy reveal events).

## Scope

In scope:
- `packages/colonizethis_logic/lib/src/turn/phases/movement_phase.dart` — lazy deep-copy via a `mutableSpyTimers` nullable + `spyTimersForOwner` closure.
- `packages/colonizethis_logic/test/movement_phase_spy_reveal_timer_test.dart` — two new tests covering the lazy-copy and fan-out paths.

Deferred (separate PRs / categories of #2394 not addressed here):
- `movement_phase.dart:225-244` — bundled-work-move full-region unit list copies (Category D, other site).
- `_playerViewWithMovedUnit` per-move PlayerView clone allocation.
- All other Category A/B/C/E/F sites listed in the issue.

## SPEC alignment

- `SPEC/program/turn-resolution.md` and `colonizethis-turn-resolution-budget.mdc` authorize memoization and avoiding redundant deterministic work while preserving turn-resolution semantics. This change does both.
- No SPEC text references `spyRevealTurnsByPlayer` allocation/copy behavior; the semantic contract (timer set to 5 when a spy crosses out of an enemy province) is unchanged and validated by tests.

## Acceptance criteria mapping

From issue #2394:
- "List copies inside movement work-move loops replaced with map-based mutation or deferred copy" — this PR addresses the deferred-copy portion for `spyRevealTurnsByPlayer`. The unit-list copy at lines 225-244 is intentionally not in scope (separate slice).
- "Existing logic tests pass with identical assertions" — verified locally.
- "Turn resolution remains deterministic for fixed inputs" — verified by full sweep of movement and turn-resolver scenario tests.

## Tests

New negative test: no spy reveal event ⇒ `identical(after.worldState.spyRevealTurnsByPlayer, original)` is true (proves the eager copy is gone).
New positive test: spy reveal event ⇒ new entry is added and all pre-existing owner/province entries are preserved alongside it (proves the lazy fan-out is sound).
Existing tests (spy leaves enemy province sets timer; same-province spy move does not arm timer) remain unchanged.

Local runs:
- `dart test test/movement_phase_spy_reveal_timer_test.dart` → 4/4 pass.
- `dart test test/movement_phase*test.dart test/turn_resolver_resolve_turn_for_game_part*.dart` → 50/50 pass.
- `dart test test/world/province_ownership_transfer_test.dart test/player_view_spy_intel_test.dart test/fog_resolution_part1_test.dart test/diplomacy_resolver_phase_test_part1_test.dart test/combat_resolver_test_part2_spy_civilian_test.dart` → 26/26 pass.
- `dart analyze` on touched files: no new issues; one pre-existing info-level `unnecessary_import` on the test file (out of scope).
- `dart format --set-exit-if-changed` on touched files: clean.

PR targets `dev` and uses `Refs #2394` so the issue stays open for the remaining slices.

Made with [Cursor](https://cursor.com)