### PR TITLE
perf(logic): faction membership for civilian tile occupancy hot paths (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/bundled_civilian_work_order.dart
+++ b/packages/colonizethis_logic/lib/src/orders/bundled_civilian_work_order.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../diplomacy/diplomacy_resolver.dart';
 import '../world/player_view.dart';
 import '../world/province_lookup.dart';
 import 'order_validation_result.dart';
@@ -92,6 +93,7 @@ String? firstLegalBundledEntryTileKeyInProvince({
   required List<DiplomaticOrder> diplomaticOrders,
 }) {
   const moveValidator = MoveValidator();
+  final factionMembership = DiplomacyFactionMembership.from(game);
   final regionId = ProvinceId.regionIdFrom(destProvinceFullId);
 
   bool isMoveAccepted(String tileKey) {
@@ -104,6 +106,7 @@ String? firstLegalBundledEntryTileKeyInProvince({
       view,
       topology,
       previousRejected: false,
+      factionMembership: factionMembership,
     );
     return moveRes.isAccepted;
   }

--- a/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
@@ -112,6 +112,7 @@ class IncrementalCandidateValidator {
           view,
           topology,
           previousRejected: false,
+          factionMembership: _factionMembership(),
         )
         .isAccepted;
     if (!standalone) return false;
@@ -220,6 +221,7 @@ class IncrementalCandidateValidator {
         civilianDraftMoveUnitIds: _civilianDraftMoveUnitIds(),
         diplomaticOrders: diplomaticOrders,
         topology: topology,
+        factionMembership: _factionMembership(),
       ),
       stockpile: economy.stockpile,
       treasury: economy.treasury,
@@ -303,6 +305,7 @@ class IncrementalCandidateValidator {
         civilianDraftMoveUnitIds: _civilianDraftMoveUnitIds(),
         diplomaticOrders: diplomaticOrders,
         topology: topology,
+        factionMembership: _factionMembership(),
       ),
       stockpile: afterBuild.stockpile,
       treasury: afterBuild.treasury,

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'order_projections.dart';
+import '../diplomacy/diplomacy_resolver.dart';
 import '../world/player_view.dart';
 import '../world/unit_lookup.dart';
 import '../constants.dart';
@@ -100,6 +101,7 @@ typedef OrderValidatorFactory = OrderValidators Function(
   Set<String> devExclusiveTiles,
   Stockpile stockpile,
   int treasury,
+  DiplomacyFactionMembership factionMembership,
 );
 
 class OrderValidators {
@@ -276,6 +278,7 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
         civilianDraftMoveUnitIds.add(m.unitId);
       }
     }
+    final factionMembership = DiplomacyFactionMembership.from(game);
     var validators = _validatorFactory(
       game,
       player,
@@ -289,6 +292,7 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
       devExclusiveTiles,
       stockpile,
       treasury,
+      factionMembership,
     );
 
     OrderValidationResult validateMove(MoveOrder o, bool previousRejected) {
@@ -301,6 +305,7 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
         view,
         topology,
         previousRejected: previousRejected,
+        factionMembership: factionMembership,
       );
     }
 
@@ -312,6 +317,7 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
         diplomatic,
         view,
         topology,
+        factionMembership: factionMembership,
       );
     }
 
@@ -342,6 +348,7 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
       devExclusiveTiles,
       stockpile,
       treasury,
+      factionMembership,
     );
     rejected = _appendValidationResults(
       results,
@@ -365,6 +372,7 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
       devExclusiveTiles,
       stockpile,
       treasury,
+      factionMembership,
     );
     rejected = _appendValidationResults(
       results,
@@ -388,6 +396,7 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
       devExclusiveTiles,
       stockpile,
       treasury,
+      factionMembership,
     );
     final afterDiplomatic =
         _appendValidationResultsWithState<DiplomaticOrder, int>(
@@ -419,6 +428,7 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
       devExclusiveTiles,
       stockpile,
       treasury,
+      factionMembership,
     );
     rejected = _appendValidationResults(
       results,
@@ -480,6 +490,7 @@ OrderValidators _defaultOrderValidatorFactory(
   Set<String> devExclusiveTiles,
   Stockpile stockpile,
   int treasury,
+  DiplomacyFactionMembership factionMembership,
 ) {
   final workContext = WorkOrderValidationContext(
     game: game,
@@ -492,6 +503,7 @@ OrderValidators _defaultOrderValidatorFactory(
     civilianDraftMoveUnitIds: civilianDraftMoveUnitIds,
     diplomaticOrders: diplomaticOrders,
     topology: topology,
+    factionMembership: factionMembership,
   );
   return OrderValidators(
     moveValidator: const MoveValidator(),

--- a/packages/colonizethis_logic/lib/src/orders/validators/move_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/move_validator.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../../diplomacy/diplomacy_resolver.dart';
 import '../../world/civilian_tile_occupancy.dart';
 import '../../world/player_view.dart';
 import '../../world/province_lookup.dart';
@@ -19,9 +20,10 @@ class MoveValidator extends OrderValidator {
     Map<String, Unit> unitsById,
     List<DiplomaticOrder> diplomaticOrders,
     PlayerView view,
-    MapTopology topology,
-    {required bool previousRejected}
-  ) {
+    MapTopology topology, {
+    required bool previousRejected,
+    DiplomacyFactionMembership? factionMembership,
+  }) {
     return shortCircuitIfPreviousRejected(
       previousRejected: previousRejected,
       body: () {
@@ -61,6 +63,7 @@ class MoveValidator extends OrderValidator {
           playerId: playerId,
           unitType: unit.type,
           destinationTileKey: destTile,
+          factionMembership: factionMembership,
         )) {
           return OrderValidationResult.rejected('Invalid move');
         }

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
@@ -33,6 +33,7 @@ class WorkOrderValidationContext {
     this.civilianDraftMoveUnitIds = const <String>{},
     this.diplomaticOrders = const <DiplomaticOrder>[],
     this.topology,
+    this.factionMembership,
   });
 
   final Game game;
@@ -45,6 +46,9 @@ class WorkOrderValidationContext {
   final Set<String> civilianDraftMoveUnitIds;
   final List<DiplomaticOrder> diplomaticOrders;
   final MapTopology? topology;
+  /// When set, avoids repeated linear faction classification in tile occupancy
+  /// checks (Refs #2394).
+  final DiplomacyFactionMembership? factionMembership;
 }
 
 class WorkOrderValidator extends StatefulValidator {
@@ -138,6 +142,7 @@ class WorkOrderValidator extends StatefulValidator {
           playerId: _context.playerId,
           unitType: type,
           destinationTileKey: o.targetTileKey,
+          factionMembership: _context.factionMembership,
         )) {
           return OrderValidationResult.rejected(
             'Unit cannot occupy target tile',

--- a/packages/colonizethis_logic/lib/src/world/civilian_ownership_legality.dart
+++ b/packages/colonizethis_logic/lib/src/world/civilian_ownership_legality.dart
@@ -3,6 +3,7 @@ import 'package:colonizethis_logic/package_logger.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../diplomacy/diplomacy_resolver.dart';
 import 'civilian_tile_occupancy.dart';
 import 'province_lookup.dart';
 
@@ -18,6 +19,8 @@ Game relocateIllegalCiviliansInChangedProvinces(
 }) {
   if (changedProvinceIds.isEmpty) return game;
 
+  final factionMembership = DiplomacyFactionMembership.from(game);
+
   Unit normalizeIllegalCivilian(Unit unit) {
     if (!changedProvinceIds.contains(unit.locationProvinceId)) {
       return unit;
@@ -31,6 +34,7 @@ Game relocateIllegalCiviliansInChangedProvinces(
       playerId: unit.ownerId,
       unitType: unit.type,
       destinationTileKey: currentTileKey,
+      factionMembership: factionMembership,
     )) {
       return unit;
     }

--- a/packages/colonizethis_logic/lib/src/world/civilian_tile_occupancy.dart
+++ b/packages/colonizethis_logic/lib/src/world/civilian_tile_occupancy.dart
@@ -58,11 +58,20 @@ bool civilianMayOccupyLandTileKey({
   required String playerId,
   required String unitType,
   required String destinationTileKey,
+  /// When set, avoids per-call linear `.any()` scans over players, minors, and
+  /// tribes when classifying [ownerId] (Refs #2394, SPEC/program/order-suggestions.md).
+  DiplomacyFactionMembership? factionMembership,
 }) {
   if (!_isValidDestinationLandTile(game, destinationTileKey)) return false;
   if (_isTilePurchasedByMover(game, playerId, destinationTileKey)) return true;
   final ownerId = _provinceOwnerIdForDestination(game, destinationTileKey);
-  return _isOccupancyAllowedByProvinceOwner(game, playerId, unitType, ownerId);
+  return _isOccupancyAllowedByProvinceOwner(
+    game,
+    playerId,
+    unitType,
+    ownerId,
+    factionMembership: factionMembership,
+  );
 }
 
 bool _isValidDestinationLandTile(Game game, String destinationTileKey) =>
@@ -85,13 +94,18 @@ bool _isOccupancyAllowedByProvinceOwner(
   Game game,
   String playerId,
   String unitType,
-  String? ownerId,
-) {
+  String? ownerId, {
+  DiplomacyFactionMembership? factionMembership,
+}) {
   if (ownerId == null || ownerId.isEmpty)
     return _isExplorerMerchantOrSpy(unitType);
   if (ownerId == playerId) return true;
-  if (isGreatPower(game, ownerId)) return isSpyUnit(unitType);
-  if (isMinorOrTribe(game, ownerId)) return _isExplorerMerchantOrSpy(unitType);
+  if (isGreatPower(game, ownerId, factionMembership: factionMembership)) {
+    return isSpyUnit(unitType);
+  }
+  if (isMinorOrTribe(game, ownerId, factionMembership: factionMembership)) {
+    return _isExplorerMerchantOrSpy(unitType);
+  }
   return false;
 }
 

--- a/packages/colonizethis_logic/lib/src/world/province_ownership_transfer.dart
+++ b/packages/colonizethis_logic/lib/src/world/province_ownership_transfer.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../diplomacy/diplomacy_resolver.dart';
 import 'army_migration.dart';
 import 'civilian_tile_occupancy.dart';
 import 'civilian_ownership_legality.dart';
@@ -105,6 +106,7 @@ int _spyTimerRemovalsForProvince(
 
 int _civilianRelocationCountBefore(Game game, Set<String> changedProvinceIds) {
   var count = 0;
+  final factionMembership = DiplomacyFactionMembership.from(game);
   for (final u in allUnitsFromWorld(game.worldState)) {
     if (!changedProvinceIds.contains(u.locationProvinceId)) continue;
     if (canUnitInitiateCombat(u.type) || isShipUnitType(u.type)) continue;
@@ -115,6 +117,7 @@ int _civilianRelocationCountBefore(Game game, Set<String> changedProvinceIds) {
       playerId: u.ownerId,
       unitType: u.type,
       destinationTileKey: tileKey,
+      factionMembership: factionMembership,
     )) {
       count++;
     }

--- a/packages/colonizethis_logic/test/order_engine_validator_injection_test.dart
+++ b/packages/colonizethis_logic/test/order_engine_validator_injection_test.dart
@@ -8,6 +8,7 @@ import 'package:colonizethis_logic/src/orders/validators/diplomatic_order_valida
 import 'package:colonizethis_logic/src/orders/validators/move_validator.dart';
 import 'package:colonizethis_logic/src/orders/validators/naval_order_validator.dart';
 import 'package:colonizethis_logic/src/orders/validators/work_order_validator.dart';
+import 'package:colonizethis_logic/src/diplomacy/diplomacy_resolver.dart';
 import 'package:colonizethis_logic/src/world/player_view.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
@@ -26,6 +27,7 @@ class _AlwaysRejectMoveValidator extends MoveValidator {
     PlayerView view,
     MapTopology topology, {
     required bool previousRejected,
+    DiplomacyFactionMembership? factionMembership,
   }) {
     return OrderValidationResult.rejected('Injected move validator rejection');
   }
@@ -56,6 +58,7 @@ void main() {
         Set<String> devExclusiveTiles,
         Stockpile stockpile,
         int treasury,
+        DiplomacyFactionMembership factionMembership,
       ) {
         final workContext = WorkOrderValidationContext(
           game: game,
@@ -68,6 +71,7 @@ void main() {
           civilianDraftMoveUnitIds: civilianDraftMoveUnitIds,
           diplomaticOrders: diplomaticOrders,
           topology: topology,
+          factionMembership: factionMembership,
         );
         return OrderValidators(
           moveValidator: const _AlwaysRejectMoveValidator(),

--- a/packages/colonizethis_logic/test/world/civilian_tile_occupancy_test.dart
+++ b/packages/colonizethis_logic/test/world/civilian_tile_occupancy_test.dart
@@ -1,3 +1,4 @@
+import 'package:colonizethis_logic/src/diplomacy/diplomacy_resolver.dart';
 import 'package:colonizethis_logic/src/world/civilian_tile_occupancy.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
@@ -70,6 +71,29 @@ void main() {
           destinationTileKey: tileP2,
         ),
         isTrue,
+      );
+    });
+
+    test('factionMembership snapshot matches linear classification (Refs #2394)', () {
+      final game = gameWithProvinces([
+        Province(id: '$ow|p1', regionId: ow, ownerId: 'gp1'),
+        Province(id: '$ow|p2', regionId: ow, ownerId: 'gp2'),
+      ]);
+      final membership = DiplomacyFactionMembership.from(game);
+      expect(
+        civilianMayOccupyLandTileKey(
+          game: game,
+          playerId: 'gp1',
+          unitType: kUnitTypeSpy,
+          destinationTileKey: tileP2,
+          factionMembership: membership,
+        ),
+        civilianMayOccupyLandTileKey(
+          game: game,
+          playerId: 'gp1',
+          unitType: kUnitTypeSpy,
+          destinationTileKey: tileP2,
+        ),
       );
     });
 


### PR DESCRIPTION
## Scope
Slice for **#2394** (Category C / faction classification): avoid repeated linear `isGreatPower` / `isMinorOrTribe` scans inside `civilianMayOccupyLandTileKey` when callers already have a `DiplomacyFactionMembership` snapshot.

## Implemented
- Optional `factionMembership` on `civilianMayOccupyLandTileKey`; thread through `_isOccupancyAllowedByProvinceOwner`.
- `MoveValidator.validate` optional `factionMembership`; `OrderEngine.validatePlayerOrdersWithContext` builds **one** `DiplomacyFactionMembership.from(game)` per pass and passes it to move/army move validation and through `OrderValidatorFactory` into `WorkOrderValidationContext`.
- `IncrementalCandidateValidator`: reuse cached `_factionMembership()` for move probes and work validation contexts.
- `firstLegalBundledEntryTileKeyInProvince`: one snapshot for the bounded tile scan loop.
- `relocateIllegalCiviliansInChangedProvinces` and `_civilianRelocationCountBefore`: one snapshot per outer scan.

## API note
`OrderValidatorFactory` gains a trailing `DiplomacyFactionMembership factionMembership` parameter (injection tests updated). Callers using a custom factory must accept and forward the snapshot (typically into `WorkOrderValidationContext.factionMembership`).

## Deferred
- Broader refactors from #2394 (PlayerView build frequency, movement list copies, AST lints, benchmarks) remain for other PRs.

## Tests
- `dart test` on: `civilian_tile_occupancy_test`, `order_engine_validator_injection_test`, `move_validator_part1_test`, `movement_phase_bundled_work_test`, `incremental_candidate_validator_equivalence_test`.

Refs #2394

Made with [Cursor](https://cursor.com)