### PR TITLE
perf(logic): O(1) army/fleet index maps in build phase (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/orders_application_build_phase.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_build_phase.dart
@@ -3,6 +3,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
 import '../economy/projected_cost_engine.dart';
+import '../economy/sea_transport.dart';
+import '../world/army_movement.dart';
 import '../world/naval.dart';
 import '../world/ship_instance_allocate.dart';
 import 'build_spawn_province.dart';
@@ -10,14 +12,21 @@ import 'orders_application_context.dart';
 
 /// Home-fleet ship spawn when capital has a seaboard port (naval build slice, #1618).
 class _NavalBuildSession {
-  _NavalBuildSession(this._game, this._topology);
+  _NavalBuildSession(this._game, this._topology)
+      : _fleetById = fleetsByIdForWorld(_game.worldState);
 
   Game _game;
   final MapTopology _topology;
 
+  /// Cached O(1) index of [WorldState.fleets] by fleet id. Rebuilt on
+  /// [rebase] so home-fleet lookups during build orders avoid a per-order
+  /// `indexWhere` over `WorldState.fleets`. Refs #2394.
+  Map<String, Fleet> _fleetById;
+
   /// Rebases session state onto the latest build-phase game snapshot.
   void rebase(Game game) {
     _game = game;
+    _fleetById = fleetsByIdForWorld(_game.worldState);
   }
 
   /// Spawns into home fleet when affordable build was already deducted; no-op if blocked.
@@ -33,39 +42,47 @@ class _NavalBuildSession {
     );
     if (seaZoneAtCap == null) return;
 
-    var ws = _game.worldState;
-    var fleets = List<Fleet>.from(ws.fleets);
+    final ws = _game.worldState;
     final homeFleetId = homeFleetIdFor(player.id);
-    final existing = fleets.indexWhere(
-      (f) => f.id == homeFleetId && f.ownerId == player.id,
-    );
+    // O(1) home-fleet lookup via the rebased index (Refs #2394). When the map
+    // entry exists but is owned by another faction, treat as "no home fleet"
+    // for this player and create a fresh one — same semantics as the legacy
+    // `indexWhere((f) => f.id == ... && f.ownerId == ...)` predicate.
+    final mapped = _fleetById[homeFleetId];
+    final Fleet? existingFleet =
+        (mapped != null && mapped.ownerId == player.id) ? mapped : null;
     var nextSeq = ws.nextShipInstanceSeq;
-    final inferred = inferNextShipInstanceSeqFromFleets(fleets);
+    final inferred = inferNextShipInstanceSeqFromFleets(ws.fleets);
     if (nextSeq < inferred) nextSeq = inferred;
     final (seqAfter, minted) = mintShipInstances(
       nextShipInstanceSeq: nextSeq,
       typeIds: [order.unitType],
     );
     nextSeq = seqAfter;
-    if (existing >= 0) {
-      final f = fleets[existing];
-      fleets = List<Fleet>.from(fleets)
-        ..[existing] = f.copyWith(ships: [...f.ships, ...minted]);
-    } else {
-      fleets = [
-        ...fleets,
-        Fleet(
-          id: homeFleetId,
-          ownerId: player.id,
-          seaZoneId: null,
-          inPortAtProvinceId: capProvinceId,
-          regionId: regionId,
-          ships: minted,
-        ),
+    final List<Fleet> nextFleets;
+    if (existingFleet != null) {
+      final updated = existingFleet.copyWith(
+        ships: [...existingFleet.ships, ...minted],
+      );
+      nextFleets = <Fleet>[
+        for (final f in ws.fleets)
+          if (f.id == homeFleetId && f.ownerId == player.id) updated else f,
       ];
+      _fleetById[homeFleetId] = updated;
+    } else {
+      final newFleet = Fleet(
+        id: homeFleetId,
+        ownerId: player.id,
+        seaZoneId: null,
+        inPortAtProvinceId: capProvinceId,
+        regionId: regionId,
+        ships: minted,
+      );
+      nextFleets = [...ws.fleets, newFleet];
+      _fleetById[homeFleetId] = newFleet;
     }
     _game = _game.copyWith(
-      worldState: ws.copyWith(fleets: fleets, nextShipInstanceSeq: nextSeq),
+      worldState: ws.copyWith(fleets: nextFleets, nextShipInstanceSeq: nextSeq),
     );
   }
 
@@ -105,18 +122,30 @@ class _MilitaryBuildState {
     Game game,
     Player player,
     String spawnProvinceId,
-    String newUnitId,
-  ) {
-    return appendMilitaryRegimentToArmy(game, player, spawnProvinceId, newUnitId);
+    String newUnitId, {
+    Map<String, Army>? armiesById,
+  }) {
+    return appendMilitaryRegimentToArmy(
+      game,
+      player,
+      spawnProvinceId,
+      newUnitId,
+      armiesById: armiesById,
+    );
   }
 }
 
 /// One land/civilian/military build order after affordability check; keeps [runBuildPhase]
 /// nesting shallow for CI (`repo.control_flow_nesting_depth`).
+///
+/// When [armiesById] is supplied, military recruits skip the per-order
+/// `indexWhere` over `worldState.armies` via the shared O(1) snapshot. Refs
+/// #2394, SPEC/program/order-suggestions.md § Throughput bounds.
 BuildWorkState _applyAffordableBuildUnitOrder({
   required BuildWorkState current,
   required Player player,
   required BuildUnitOrder order,
+  Map<String, Army>? armiesById,
 }) {
   final category = buildUnitCategoryForUnitType(order.unitType);
   if (category == BuildUnitCategory.unknown) return current;
@@ -168,6 +197,7 @@ BuildWorkState _applyAffordableBuildUnitOrder({
       player,
       spawnProvinceId,
       newUnit.id,
+      armiesById: armiesById,
     );
   }
 
@@ -175,11 +205,19 @@ BuildWorkState _applyAffordableBuildUnitOrder({
 }
 
 /// Applies build orders for all players. Returns state with updated [game] and unit maps.
+///
+/// Maintains an O(1) `Map<String, Army>` snapshot across all military recruits
+/// in the phase so [_applyAffordableBuildUnitOrder] avoids a per-order
+/// `indexWhere` over `WorldState.armies`. Refs #2394,
+/// SPEC/program/order-suggestions.md § Throughput bounds.
 BuildWorkState runBuildPhase(BuildWorkState state) {
   final naval = state.topology != null
       ? _NavalBuildSession(state.game, state.topology!)
       : null;
   var current = naval != null ? state.copyWith(game: naval.game) : state;
+  // Mutable O(1) army index reused across every recruit in this phase; the
+  // helper mutates it in place when armies are added or updated. Refs #2394.
+  final armiesById = armiesByIdForWorld(current.game.worldState);
 
   for (final player in current.game.players) {
     var workers = player.workerPool;
@@ -223,6 +261,7 @@ BuildWorkState runBuildPhase(BuildWorkState state) {
         current: current,
         player: player,
         order: order,
+        armiesById: armiesById,
       );
     }
 

--- a/packages/colonizethis_logic/lib/src/orders/orders_application_context.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_context.dart
@@ -4,6 +4,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../turn/trace/turn_trace_runtime.dart';
 import '../world/army_ids.dart';
+import '../world/army_movement.dart';
 
 final ordersApplicationLog = packageLogger();
 
@@ -112,12 +113,26 @@ class BuildWorkState {
 }
 
 /// Returns [game] with [newUnitId] appended to the appropriate army for [player].
+///
+/// When [armiesById] is supplied it MUST be a snapshot of `game.worldState.armies`
+/// keyed by army id (see [armiesByIdForWorld]). It enables O(1) existence
+/// lookup and bypasses the per-call `indexWhere` over `worldState.armies`,
+/// which would otherwise be O(armyCount) per recruited unit and degrade build
+/// phases that spawn many regiments for the same player. Refs #2394,
+/// SPEC/program/order-suggestions.md § Throughput bounds.
+///
+/// The function mutates [armiesById] in place so subsequent calls observe the
+/// just-updated/added entry: callers can build the map once at the start of a
+/// build phase and pass the same reference across every recruit. Pass `null`
+/// (or omit) to fall back to a single-pass scan that preserves the legacy
+/// behavior for one-off uses.
 Game appendMilitaryRegimentToArmy(
   Game game,
   Player player,
   String spawnProvinceId,
-  String newUnitId,
-) {
+  String newUnitId, {
+  Map<String, Army>? armiesById,
+}) {
   final cap = player.capitalProvinceId;
   final atHome =
       cap != null &&
@@ -131,15 +146,28 @@ Game appendMilitaryRegimentToArmy(
       : fieldArmyIdFor(player.id, spawnProvinceId);
   final ws = game.worldState;
   final regionId = ProvinceId.regionIdFrom(spawnProvinceId);
-  final idx = ws.armies.indexWhere(
-    (a) => a.id == armyId && a.ownerId == player.id,
-  );
-  if (idx >= 0) {
-    final a = ws.armies[idx];
-    final updated = a.copyWith(
-      regimentUnitIds: [...a.regimentUnitIds, newUnitId],
+
+  // O(1) hot-path: when the caller supplied a snapshot map, look up by id and
+  // require ownership match; missing entries fall back to the linear scan in
+  // case the supplied map was built before a recent army insertion. Refs #2394.
+  final Army? existing;
+  if (armiesById != null) {
+    final candidate = armiesById[armyId];
+    existing = (candidate != null && candidate.ownerId == player.id)
+        ? candidate
+        : _firstArmyByIdAndOwner(ws.armies, armyId, player.id);
+  } else {
+    existing = _firstArmyByIdAndOwner(ws.armies, armyId, player.id);
+  }
+  if (existing != null) {
+    final updated = existing.copyWith(
+      regimentUnitIds: [...existing.regimentUnitIds, newUnitId],
     );
-    final next = List<Army>.from(ws.armies)..[idx] = updated;
+    final next = <Army>[
+      for (final a in ws.armies)
+        if (a.id == armyId && a.ownerId == player.id) updated else a,
+    ];
+    armiesById?[armyId] = updated;
     return game.copyWith(worldState: ws.copyWith(armies: next));
   }
   final stationed = atHome ? cap : spawnProvinceId;
@@ -152,5 +180,13 @@ Game appendMilitaryRegimentToArmy(
     isHomeArmy: atHome,
   );
   final next = [...ws.armies, newArmy]..sort((a, b) => a.id.compareTo(b.id));
+  armiesById?[newArmy.id] = newArmy;
   return game.copyWith(worldState: ws.copyWith(armies: next));
+}
+
+Army? _firstArmyByIdAndOwner(List<Army> armies, String armyId, String ownerId) {
+  for (final a in armies) {
+    if (a.id == armyId && a.ownerId == ownerId) return a;
+  }
+  return null;
 }

--- a/packages/colonizethis_logic/lib/src/world/army_movement.dart
+++ b/packages/colonizethis_logic/lib/src/world/army_movement.dart
@@ -8,6 +8,18 @@ import 'army_migration.dart';
 import 'movement.dart';
 import 'province_lookup.dart';
 
+/// Single-pass index of [WorldState.armies] by army id for O(1) lookups (Refs
+/// #2394, SPEC/program/order-suggestions.md — incremental validation throughput
+/// bounds).
+///
+/// Callers that iterate over many build/recruit orders against a stable
+/// [WorldState] snapshot should build once and reuse the resulting map instead
+/// of issuing a per-order `indexWhere`/`firstWhereOrNull` scan over
+/// [WorldState.armies].
+Map<String, Army> armiesByIdForWorld(WorldState world) {
+  return {for (final a in world.armies) a.id: a};
+}
+
 void _logArmyMoveIgnoredHomeArmyIfDebug(String armyId) {
   if (Level.debug.value >= Logger.level.value) {
     logicLog.d('army_move ignored reason=home_army_locked armyId=$armyId');
@@ -48,7 +60,7 @@ WorldState applyArmyMoveOrdersToRegion(
     return worldState;
   }
 
-  final armyById = {for (final a in worldState.armies) a.id: a};
+  final armyById = armiesByIdForWorld(worldState);
   var ws = worldState;
   var applied = 0;
   var ignored = 0;
@@ -156,7 +168,7 @@ applyCrossRegionArmyMovesWithinOwnedProvinces({
 }) {
   var ws = worldState;
   final remaining = <String, List<ArmyMoveOrder>>{};
-  final armyById = {for (final army in ws.armies) army.id: army};
+  final armyById = armiesByIdForWorld(ws);
 
   for (final entry in armyMoveOrdersByPlayerId.entries) {
     final playerId = entry.key;

--- a/packages/colonizethis_logic/test/orders/append_military_regiment_armies_by_id_test.dart
+++ b/packages/colonizethis_logic/test/orders/append_military_regiment_armies_by_id_test.dart
@@ -1,0 +1,234 @@
+/// Equivalence + in-place-mutation tests for the optional `armiesById`
+/// snapshot threaded into [appendMilitaryRegimentToArmy] (Refs #2394;
+/// SPEC/program/order-suggestions.md § Throughput bounds).
+///
+/// Verifies:
+///
+/// - The map and scan paths produce identical Game results for both the
+///   "append to existing army" and "create new army" branches.
+/// - The supplied `armiesById` is mutated in place so subsequent calls
+///   observe the just-updated/added army (eliminating the per-recruit
+///   `indexWhere` over `worldState.armies`).
+/// - A partial map still resolves correctly via the single-pass fallback.
+library;
+
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  const playerId = 'p1';
+  const capProvinceId = 'oldWorld|P1';
+
+  Player buildPlayer() => Player(
+        id: playerId,
+        displayName: 'P1',
+        isHuman: true,
+        capitalProvinceId: capProvinceId,
+        stockpile: const Stockpile(),
+        workerPool: const WorkerPool(peasants: 10),
+        treasury: 10000,
+      );
+
+  Game emptyArmyGame() {
+    final world = WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+      oldWorld: const RegionData(
+        provinces: [
+          Province(id: capProvinceId, regionId: 'oldWorld', ownerId: playerId),
+        ],
+        units: [],
+      ),
+      newWorld: const RegionData(),
+    );
+    return Game(id: 'g', worldState: world, players: [buildPlayer()]);
+  }
+
+  Game gameWithExistingHomeArmy() {
+    final existing = Army(
+      id: homeArmyIdFor(playerId),
+      ownerId: playerId,
+      regionId: 'oldWorld',
+      stationedProvinceId: capProvinceId,
+      regimentUnitIds: const ['u_existing'],
+      isHomeArmy: true,
+    );
+    final world = WorldState(
+      turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+      oldWorld: const RegionData(
+        provinces: [
+          Province(id: capProvinceId, regionId: 'oldWorld', ownerId: playerId),
+        ],
+        units: [],
+      ),
+      newWorld: const RegionData(),
+      armies: [existing],
+    );
+    return Game(id: 'g', worldState: world, players: [buildPlayer()]);
+  }
+
+  group('appendMilitaryRegimentToArmy armiesById equivalence (Refs #2394)', () {
+    test('create-new-army path matches with and without armiesById', () {
+      final game = emptyArmyGame();
+      final viaMap = appendMilitaryRegimentToArmy(
+        game,
+        game.players.single,
+        capProvinceId,
+        'u_new',
+        armiesById: armiesByIdForWorld(game.worldState),
+      );
+      final viaScan = appendMilitaryRegimentToArmy(
+        game,
+        game.players.single,
+        capProvinceId,
+        'u_new',
+      );
+
+      expect(viaMap.worldState.armies.length, viaScan.worldState.armies.length);
+      expect(viaMap.worldState.armies.single.id, viaScan.worldState.armies.single.id);
+      expect(
+        viaMap.worldState.armies.single.regimentUnitIds,
+        viaScan.worldState.armies.single.regimentUnitIds,
+      );
+      expect(
+        viaMap.worldState.armies.single.isHomeArmy,
+        viaScan.worldState.armies.single.isHomeArmy,
+      );
+    });
+
+    test('append-existing-army path matches with and without armiesById', () {
+      final game = gameWithExistingHomeArmy();
+      final viaMap = appendMilitaryRegimentToArmy(
+        game,
+        game.players.single,
+        capProvinceId,
+        'u_new',
+        armiesById: armiesByIdForWorld(game.worldState),
+      );
+      final viaScan = appendMilitaryRegimentToArmy(
+        game,
+        game.players.single,
+        capProvinceId,
+        'u_new',
+      );
+
+      expect(viaMap.worldState.armies.length, 1);
+      expect(viaScan.worldState.armies.length, 1);
+      expect(
+        viaMap.worldState.armies.single.regimentUnitIds,
+        viaScan.worldState.armies.single.regimentUnitIds,
+      );
+      expect(
+        viaMap.worldState.armies.single.regimentUnitIds,
+        ['u_existing', 'u_new'],
+      );
+    });
+
+    test('mutates armiesById in place when appending to an existing army', () {
+      final game = gameWithExistingHomeArmy();
+      final armiesById = armiesByIdForWorld(game.worldState);
+      final homeArmyId = homeArmyIdFor(playerId);
+      expect(armiesById[homeArmyId]!.regimentUnitIds, ['u_existing']);
+
+      final next = appendMilitaryRegimentToArmy(
+        game,
+        game.players.single,
+        capProvinceId,
+        'u_new',
+        armiesById: armiesById,
+      );
+
+      expect(
+        armiesById[homeArmyId]!.regimentUnitIds,
+        ['u_existing', 'u_new'],
+      );
+      expect(
+        next.worldState.armies.single.regimentUnitIds,
+        ['u_existing', 'u_new'],
+      );
+    });
+
+    test('mutates armiesById in place when creating a new army', () {
+      final game = emptyArmyGame();
+      final armiesById = armiesByIdForWorld(game.worldState);
+      expect(armiesById, isEmpty);
+
+      final next = appendMilitaryRegimentToArmy(
+        game,
+        game.players.single,
+        capProvinceId,
+        'u_new',
+        armiesById: armiesById,
+      );
+
+      final homeArmyId = homeArmyIdFor(playerId);
+      expect(armiesById.containsKey(homeArmyId), isTrue);
+      expect(armiesById[homeArmyId]!.regimentUnitIds, ['u_new']);
+      expect(next.worldState.armies.single.id, homeArmyId);
+    });
+
+    test('multiple recruits with shared map match repeated scan-path runs', () {
+      // The shared map must never drift from the canonical world-state-derived
+      // behavior; comparing the K-step pipelines exercises this invariant.
+      final start = emptyArmyGame();
+
+      var mapGame = start;
+      final armiesById = armiesByIdForWorld(start.worldState);
+      for (final id in const ['u_a', 'u_b', 'u_c']) {
+        mapGame = appendMilitaryRegimentToArmy(
+          mapGame,
+          start.players.single,
+          capProvinceId,
+          id,
+          armiesById: armiesById,
+        );
+      }
+
+      var scanGame = start;
+      for (final id in const ['u_a', 'u_b', 'u_c']) {
+        scanGame = appendMilitaryRegimentToArmy(
+          scanGame,
+          start.players.single,
+          capProvinceId,
+          id,
+        );
+      }
+
+      expect(
+        mapGame.worldState.armies.single.regimentUnitIds,
+        scanGame.worldState.armies.single.regimentUnitIds,
+      );
+      expect(
+        mapGame.worldState.armies.single.regimentUnitIds,
+        ['u_a', 'u_b', 'u_c'],
+      );
+    });
+
+    test('falls back to single-pass scan when armiesById lacks the entry', () {
+      // Partial maps (e.g. built before a recent insertion) must still resolve
+      // correctly via the fallback scan instead of forking duplicate armies.
+      final game = gameWithExistingHomeArmy();
+      final partialMap = <String, Army>{};
+
+      final next = appendMilitaryRegimentToArmy(
+        game,
+        game.players.single,
+        capProvinceId,
+        'u_new',
+        armiesById: partialMap,
+      );
+
+      expect(next.worldState.armies.length, 1);
+      expect(
+        next.worldState.armies.single.regimentUnitIds,
+        ['u_existing', 'u_new'],
+      );
+      expect(
+        partialMap[homeArmyIdFor(playerId)]!.regimentUnitIds,
+        ['u_existing', 'u_new'],
+      );
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/orders/run_build_phase_index_maps_test.dart
+++ b/packages/colonizethis_logic/test/orders/run_build_phase_index_maps_test.dart
@@ -1,0 +1,150 @@
+/// End-to-end build-phase coverage for the O(1) army/fleet index maps shared
+/// inside `runBuildPhase` (Refs #2394;
+/// SPEC/program/order-suggestions.md § Throughput bounds).
+///
+/// Verifies that multiple military/naval builds in a single phase converge on
+/// a single home army/fleet via the rebased `armiesByIdForWorld` /
+/// `fleetsByIdForWorld` snapshots, instead of duplicating or fragmenting state.
+library;
+
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  suppressLogsForTests();
+
+  const playerId = 'p1';
+  const capProvinceId = 'oldWorld|P1';
+
+  group('runBuildPhase O(1) maps end-to-end (Refs #2394)', () {
+    test(
+      'consecutive military recruits build one home army with all regiments',
+      () {
+        const k = 3;
+        final econ = RegimentEconomyCatalog.byId['peasant_levies']!;
+        var stockpile = const Stockpile();
+        for (final entry in econ.buildInputs.entries) {
+          stockpile = stockpile.applyDelta(entry.key, entry.value * k + 1);
+        }
+        final player = Player(
+          id: playerId,
+          displayName: 'P1',
+          isHuman: true,
+          capitalProvinceId: capProvinceId,
+          stockpile: stockpile,
+          workerPool: const WorkerPool(peasants: k + 1),
+          treasury: econ.buildTreasuryCost * k + 100,
+        );
+        final world = WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(
+                id: capProvinceId,
+                regionId: 'oldWorld',
+                ownerId: playerId,
+              ),
+            ],
+            units: [],
+          ),
+          newWorld: const RegionData(),
+        );
+        final game = Game(id: 'g', worldState: world, players: [player]);
+        final orders = Orders(
+          buildUnitOrdersByPlayerId: {
+            playerId: [
+              for (var i = 0; i < k; i++)
+                BuildUnitOrder(
+                  unitType: 'peasant_levies',
+                  isMilitary: true,
+                  spawnProvinceId: capProvinceId,
+                ),
+            ],
+          },
+        );
+
+        final next = applyBuildAndWorkOrders(game, orders);
+
+        expect(next.worldState.armies.length, 1);
+        final army = next.worldState.armies.single;
+        expect(army.id, homeArmyIdFor(playerId));
+        expect(army.isHomeArmy, isTrue);
+        expect(army.regimentUnitIds.length, k);
+      },
+    );
+
+    test(
+      'consecutive ship recruits add ships to a single home fleet (cache reuse)',
+      () {
+        final topology = MapTopology(
+          nodes: const [
+            TopologyNode(
+              id: 'P1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+            TopologyNode(
+              id: 'sea1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.seaZone,
+            ),
+          ],
+          edges: const [TopologyEdge(id1: 'P1', id2: 'sea1')],
+        );
+        final shipEcon = ShipEconomyCatalog.byId['fluyte']!;
+        const k = 2;
+        var stockpile = const Stockpile();
+        for (final e in shipEcon.buildInputs.entries) {
+          stockpile = stockpile.applyDelta(e.key, e.value * k + 1);
+        }
+        final player = Player(
+          id: playerId,
+          displayName: 'P1',
+          isHuman: true,
+          capitalProvinceId: capProvinceId,
+          stockpile: stockpile,
+          workerPool: const WorkerPool(peasants: k + 1),
+          treasury: shipEcon.buildTreasuryCost * k + 100,
+          techUnlocked: const {kTechIdSuperiorHullDesign: true},
+        );
+        final world = WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: const RegionData(
+            provinces: [
+              Province(id: 'P1', regionId: 'oldWorld', ownerId: playerId),
+            ],
+            units: [],
+          ),
+          newWorld: const RegionData(),
+        );
+        final game = Game(id: 'g', worldState: world, players: [player]);
+        final orders = Orders(
+          buildUnitOrdersByPlayerId: {
+            playerId: [
+              for (var i = 0; i < k; i++)
+                BuildUnitOrder(
+                  unitType: 'fluyte',
+                  isMilitary: false,
+                  spawnProvinceId: capProvinceId,
+                ),
+            ],
+          },
+        );
+
+        final next = applyBuildAndWorkOrders(
+          game,
+          orders,
+          topology: topology,
+        );
+
+        final ownedFleets = next.worldState.fleets
+            .where((f) => f.ownerId == playerId)
+            .toList();
+        expect(ownedFleets.length, 1);
+        expect(ownedFleets.single.shipTypeIds.length, k);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Refs #2394, SPEC/program/order-suggestions.md § Throughput bounds.

Closes a Category C hot-path lookup in the build phase. For each affordable
build order the legacy path scanned `WorldState.armies` (and inside
`_NavalBuildSession`, `WorldState.fleets`) via `indexWhere` and rebuilt a
defensive list copy of the same collection — two full O(armies)/O(fleets)
passes per recruited unit or built ship.

This PR threads a mutable `Map<String, Army>` index through
`runBuildPhase` -> `_applyAffordableBuildUnitOrder` ->
`appendMilitaryRegimentToArmy` so the recruit path resolves the home/field
army in O(1) and updates the snapshot in place. `_NavalBuildSession` now
caches a `Map<String, Fleet>` via the existing `fleetsByIdForWorld` helper
and rebases it whenever the session takes on a new game snapshot; successive
ship builds for the same player resolve the home fleet in O(1).

Behavior is preserved end-to-end:

- `appendMilitaryRegimentToArmy` retains the legacy single-pass scan when
  no map is supplied, so external callers and tests built around the prior
  signature continue to work.
- When a partial map is supplied (e.g. an older snapshot), the helper falls
  back to a single-pass scan and primes the map for subsequent reuse — no
  silent duplicate armies.
- The naval session keeps the existing ownership predicate
  (`f.ownerId == player.id`) by treating same-id-but-different-owner map
  entries as "no home fleet" for the current player.

## SPEC coverage

- SPEC/program/order-suggestions.md § Throughput bounds (Refs #2394) — endorses
  shared indexing across the suggestion/build pipelines.

## Implementation

- `packages/colonizethis_logic/lib/src/world/army_movement.dart`
  - Adds `Map<String, Army> armiesByIdForWorld(WorldState world)` mirroring
    `fleetsByIdForWorld`.
  - Replaces two inline `{for (final a in worldState.armies) a.id: a}`
    duplicates with the new helper.
- `packages/colonizethis_logic/lib/src/orders/orders_application_context.dart`
  - `appendMilitaryRegimentToArmy` gains optional `armiesById`; uses it for
    O(1) existence lookup with a single-pass ownership-aware fallback when
    absent or stale.
  - On both the "append-existing" and "create-new" branches the map is
    mutated in place so subsequent calls see the just-updated/added army.
- `packages/colonizethis_logic/lib/src/orders/orders_application_build_phase.dart`
  - `_NavalBuildSession` caches `_fleetById` initialized in the constructor
    and refreshed on `rebase(...)`. `spawnHomeFleetShipIfEligible` uses the
    cache for the home-fleet lookup and updates it for both spawn paths.
  - `_applyAffordableBuildUnitOrder` accepts an `armiesById` parameter and
    threads it into `_MilitaryBuildState.appendRegimentToArmy`.
  - `runBuildPhase` builds the army index map once per phase via
    `armiesByIdForWorld` and reuses it across every recruit. Naval builds
    do not touch armies, so the map remains consistent across mixed-order
    sequences.

## Tests

New tests run via `cd packages/colonizethis_logic && dart test ...`:

- `test/orders/append_military_regiment_armies_by_id_test.dart` (6 tests)
  - Map-vs-scan equivalence on both "create new army" and "append to
    existing army" branches.
  - In-place mutation on both branches (so multi-recruit reuse is safe).
  - K-step pipeline parity between shared-map and scan-only paths.
  - Partial-map fallback resolves correctly via single-pass scan and primes
    the map for downstream reuse.
- `test/orders/run_build_phase_index_maps_test.dart` (2 tests)
  - K consecutive `peasant_levies` recruits converge on a single home
    army with K regiments.
  - K consecutive `fluyte` ship builds converge on a single home fleet via
    the rebased `fleetsByIdForWorld` cache.

Existing logic test suite remains green (`dart test` in
`packages/colonizethis_logic`, 1554 tests pass on the branch tip including
characterization, turn-resolver and performance tests).

## Out of scope

- Other Refs #2394 hot paths (army move picker trial validator, naval
  retreat zone scans, etc.) — already covered by other open/merged PRs.
- AST lint rules for linear-scan anti-patterns (separate AC line item in #2394).

Refs #2394

Made with [Cursor](https://cursor.com)