### PR TITLE
perf(logic): O(1) faction classification in diplomatic validators (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
@@ -245,6 +245,7 @@ class IncrementalCandidateValidator {
       game: game,
       playerId: playerId,
       initialTreasury: economy.treasury,
+      factionMembership: _factionMembership(),
     );
     for (final existing in diplomaticOrders) {
       final result = validator.validate(existing, previousRejected: false);

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -518,6 +518,7 @@ OrderValidators _defaultOrderValidatorFactory(
       game: game,
       playerId: playerId,
       initialTreasury: treasury,
+      factionMembership: factionMembership,
     ),
     navalValidator: NavalOrderValidator(
       game: game,

--- a/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/alliance_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/alliance_validator.dart
@@ -7,10 +7,18 @@ import 'diplomatic_sub_validator.dart';
 /// Type-specific validator for [DiplomaticOrderType.alliance] orders.
 /// SPEC/program/orders.md § Diplomatic orders / alliance.
 class AllianceSubValidator implements DiplomaticSubValidator {
-  const AllianceSubValidator({required this.game, required this.playerId});
+  const AllianceSubValidator({
+    required this.game,
+    required this.playerId,
+    this.factionMembership,
+  });
 
   final Game game;
   final String playerId;
+
+  /// Optional precomputed faction classification snapshot reused across
+  /// per-candidate probes to avoid linear `game.players` scans (Refs #2394).
+  final DiplomacyFactionMembership? factionMembership;
 
   @override
   ({OrderValidationResult result, int treasury}) validate({
@@ -18,7 +26,7 @@ class AllianceSubValidator implements DiplomaticSubValidator {
     required int treasury,
   }) {
     final targetId = order.targetFactionId;
-    if (!isGreatPower(game, targetId)) {
+    if (!isGreatPower(game, targetId, factionMembership: factionMembership)) {
       return rejectDiplomaticSub(
         'Alliance target must be a Great Power',
         treasury,

--- a/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/establish_overture_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/diplomatic/establish_overture_validator.dart
@@ -14,10 +14,16 @@ class EstablishOvertureSubValidator implements DiplomaticSubValidator {
   const EstablishOvertureSubValidator({
     required this.game,
     required this.playerId,
+    this.factionMembership,
   });
 
   final Game game;
   final String playerId;
+
+  /// Optional precomputed faction classification snapshot reused across
+  /// per-candidate probes to avoid linear `game.players` /
+  /// `game.minorNations` / `game.tribes` scans (Refs #2394).
+  final DiplomacyFactionMembership? factionMembership;
 
   @override
   ({OrderValidationResult result, int treasury}) validate({
@@ -32,7 +38,8 @@ class EstablishOvertureSubValidator implements DiplomaticSubValidator {
       );
     }
     final targetId = order.targetFactionId;
-    if (!isMinorOrTribe(game, targetId) && !isGreatPower(game, targetId)) {
+    if (!isMinorOrTribe(game, targetId, factionMembership: factionMembership) &&
+        !isGreatPower(game, targetId, factionMembership: factionMembership)) {
       return rejectDiplomaticSub(
         'Overtures are only valid toward Minor Nations, Tribes, or Great Powers',
         treasury,
@@ -178,10 +185,10 @@ class EstablishOvertureSubValidator implements DiplomaticSubValidator {
         treasury,
       );
     }
-    if (isGreatPower(game, targetId)) {
+    if (isGreatPower(game, targetId, factionMembership: factionMembership)) {
       return _validateJoinEmpireTowardGreatPower(targetId, treasury);
     }
-    if (!isMinorOrTribe(game, targetId)) {
+    if (!isMinorOrTribe(game, targetId, factionMembership: factionMembership)) {
       return rejectDiplomaticSub(
         'Join Empire target must be a Minor Nation, Tribe, or Great Power',
         treasury,
@@ -206,7 +213,11 @@ class EstablishOvertureSubValidator implements DiplomaticSubValidator {
         treasury,
       );
     }
-    if (!isGreatPowerNearlyDefeatedForJoinEmpire(game, targetId)) {
+    if (!isGreatPowerNearlyDefeatedForJoinEmpire(
+      game,
+      targetId,
+      factionMembership: factionMembership,
+    )) {
       return rejectDiplomaticSub(
         'Join Empire toward Great Power requires target to be nearly defeated (at most 3 provinces and original capital not held by target)',
         treasury,
@@ -219,7 +230,9 @@ class EstablishOvertureSubValidator implements DiplomaticSubValidator {
     String targetId,
     OvertureStage stage,
   ) {
-    if (!isMinorOrTribe(game, targetId)) return false;
+    if (!isMinorOrTribe(game, targetId, factionMembership: factionMembership)) {
+      return false;
+    }
     return stage == OvertureStage.tradeConsulate ||
         stage == OvertureStage.embassy ||
         stage == OvertureStage.nap;

--- a/packages/colonizethis_logic/lib/src/orders/validators/diplomatic_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/diplomatic_order_validator.dart
@@ -23,6 +23,7 @@ import 'stateful_validator.dart';
 class DiplomaticOrderValidator extends StatefulValidator {
   final Game _game;
   final String _playerId;
+  final DiplomacyFactionMembership? _factionMembership;
 
   /// Types already accepted toward each target this turn. SPEC/program/orders.md § diplomatic cap.
   final Map<String, Set<DiplomaticOrderType>> _typesByTarget =
@@ -34,8 +35,10 @@ class DiplomaticOrderValidator extends StatefulValidator {
     required Game game,
     required String playerId,
     required int initialTreasury,
+    DiplomacyFactionMembership? factionMembership,
   }) : _game = game,
        _playerId = playerId,
+       _factionMembership = factionMembership,
        super(
          stockpileState: game.playerById(playerId)?.stockpile ?? Stockpile.empty,
          treasuryState: initialTreasury,
@@ -54,10 +57,12 @@ class DiplomaticOrderValidator extends StatefulValidator {
       DiplomaticOrderType.alliance: AllianceSubValidator(
         game: _game,
         playerId: _playerId,
+        factionMembership: _factionMembership,
       ),
       DiplomaticOrderType.establishOverture: EstablishOvertureSubValidator(
         game: _game,
         playerId: _playerId,
+        factionMembership: _factionMembership,
       ),
       DiplomaticOrderType.grantAid: GrantAidSubValidator(
         game: _game,
@@ -124,7 +129,8 @@ class DiplomaticOrderValidator extends StatefulValidator {
     }
 
     final targetExists =
-        isGreatPower(_game, targetId) || isMinorOrTribe(_game, targetId);
+        isGreatPower(_game, targetId, factionMembership: _factionMembership) ||
+        isMinorOrTribe(_game, targetId, factionMembership: _factionMembership);
     if (!targetExists) {
       return _reject('Target faction not found');
     }

--- a/packages/colonizethis_logic/test/orders/validators/diplomatic/diplomatic_sub_validators_faction_membership_test.dart
+++ b/packages/colonizethis_logic/test/orders/validators/diplomatic/diplomatic_sub_validators_faction_membership_test.dart
@@ -1,0 +1,251 @@
+/// Validates that the per-target classification step of the diplomatic
+/// sub-validators consults the optional `DiplomacyFactionMembership` snapshot
+/// instead of falling back to linear `game.players` / `game.minorNations` /
+/// `game.tribes` scans when the snapshot is supplied (Refs #2394 — O(1)
+/// classification on per-candidate probe paths).
+///
+/// Coverage strategy:
+///
+/// 1. Positive equivalence — when the snapshot reflects the same membership
+///    as `Game`, the validator's accept/reject decision is identical to the
+///    no-snapshot path (membership must not change established behavior).
+/// 2. Negative override — when the snapshot intentionally disagrees with
+///    `Game`, the validator's classification follows the snapshot, proving
+///    the fast path is on the active branch (snapshot is consulted, not the
+///    `Game` collections).
+library;
+
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logic/src/orders/validators/diplomatic/alliance_validator.dart';
+import 'package:colonizethis_logic/src/orders/validators/diplomatic/establish_overture_validator.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'diplomatic_sub_validators_test_support.dart';
+
+void main() {
+  group('AllianceSubValidator factionMembership', () {
+    test('accepts known GP target identically with and without snapshot', () {
+      final game = twoGpGame();
+      final membership = DiplomacyFactionMembership.from(game);
+      const order = DiplomaticOrder(
+        type: DiplomaticOrderType.alliance,
+        targetFactionId: 'gp2',
+      );
+
+      final withoutSnapshot = AllianceSubValidator(
+        game: game,
+        playerId: 'gp1',
+      ).validate(order: order, treasury: 0);
+      final withSnapshot = AllianceSubValidator(
+        game: game,
+        playerId: 'gp1',
+        factionMembership: membership,
+      ).validate(order: order, treasury: 0);
+
+      expect(withoutSnapshot.result.status, OrderValidationStatus.accepted);
+      expect(withSnapshot.result.status, OrderValidationStatus.accepted);
+      expect(withSnapshot.treasury, withoutSnapshot.treasury);
+    });
+
+    test(
+      'rejects non-GP target identically when snapshot has no GP membership',
+      () {
+        final game = gpMinorGame();
+        final membership = DiplomacyFactionMembership.from(game);
+        const order = DiplomaticOrder(
+          type: DiplomaticOrderType.alliance,
+          targetFactionId: 'minor1',
+        );
+
+        final withoutSnapshot = AllianceSubValidator(
+          game: game,
+          playerId: 'gp1',
+        ).validate(order: order, treasury: 0);
+        final withSnapshot = AllianceSubValidator(
+          game: game,
+          playerId: 'gp1',
+          factionMembership: membership,
+        ).validate(order: order, treasury: 0);
+
+        expect(withoutSnapshot.result.status, OrderValidationStatus.rejected);
+        expect(withSnapshot.result.status, OrderValidationStatus.rejected);
+        expect(withSnapshot.result.reason, withoutSnapshot.result.reason);
+      },
+    );
+
+    test(
+      'snapshot is consulted on active path: rejects target listed only in Game.players',
+      () {
+        final game = twoGpGame();
+        final emptyMembership = DiplomacyFactionMembership.from(
+          Game(
+            id: 'empty',
+            worldState: WorldState(
+              turnState: const TurnState(
+                phase: TurnPhase.orders,
+                turnNumber: 0,
+              ),
+              oldWorld: const RegionData(),
+              newWorld: const RegionData(),
+            ),
+            players: const [],
+          ),
+        );
+
+        final r = AllianceSubValidator(
+          game: game,
+          playerId: 'gp1',
+          factionMembership: emptyMembership,
+        ).validate(
+          order: const DiplomaticOrder(
+            type: DiplomaticOrderType.alliance,
+            targetFactionId: 'gp2',
+          ),
+          treasury: 0,
+        );
+
+        expect(r.result.status, OrderValidationStatus.rejected);
+        expect(r.result.reason, contains('Great Power'));
+      },
+    );
+  });
+
+  group('EstablishOvertureSubValidator factionMembership', () {
+    test(
+      'accepts Trade Consulate toward Minor identically with snapshot',
+      () {
+        final game = gpMinorGame(overtureStage: OvertureStage.none);
+        final membership = DiplomacyFactionMembership.from(game);
+        const order = DiplomaticOrder(
+          type: DiplomaticOrderType.establishOverture,
+          targetFactionId: 'minor1',
+          overtureStage: OvertureStage.tradeConsulate,
+        );
+        final initialTreasury = overtureConsulateCost + 5;
+
+        final withoutSnapshot = EstablishOvertureSubValidator(
+          game: game,
+          playerId: 'gp1',
+        ).validate(order: order, treasury: initialTreasury);
+        final withSnapshot = EstablishOvertureSubValidator(
+          game: game,
+          playerId: 'gp1',
+          factionMembership: membership,
+        ).validate(order: order, treasury: initialTreasury);
+
+        expect(withoutSnapshot.result.status, OrderValidationStatus.accepted);
+        expect(withSnapshot.result.status, OrderValidationStatus.accepted);
+        expect(withSnapshot.treasury, withoutSnapshot.treasury);
+      },
+    );
+
+    test(
+      'snapshot is consulted: rejects overture toward target absent from snapshot',
+      () {
+        final game = gpMinorGame(overtureStage: OvertureStage.none);
+        final emptyMembership = DiplomacyFactionMembership.from(
+          Game(
+            id: 'empty',
+            worldState: WorldState(
+              turnState: const TurnState(
+                phase: TurnPhase.orders,
+                turnNumber: 0,
+              ),
+              oldWorld: const RegionData(),
+              newWorld: const RegionData(),
+            ),
+            players: const [],
+          ),
+        );
+
+        final r = EstablishOvertureSubValidator(
+          game: game,
+          playerId: 'gp1',
+          factionMembership: emptyMembership,
+        ).validate(
+          order: const DiplomaticOrder(
+            type: DiplomaticOrderType.establishOverture,
+            targetFactionId: 'minor1',
+            overtureStage: OvertureStage.tradeConsulate,
+          ),
+          treasury: overtureConsulateCost + 5,
+        );
+
+        expect(r.result.status, OrderValidationStatus.rejected);
+        expect(
+          r.result.reason,
+          contains('Minor Nations, Tribes, or Great Powers'),
+        );
+        expect(r.treasury, overtureConsulateCost + 5);
+      },
+    );
+  });
+
+  group('DiplomaticOrderValidator factionMembership', () {
+    test('accepts equivalent classification with snapshot snapshot present', () {
+      final game = gpMinorGame();
+      final membership = DiplomacyFactionMembership.from(game);
+      final withoutSnapshot = DiplomaticOrderValidator(
+        game: game,
+        playerId: 'gp1',
+        initialTreasury: overtureConsulateCost + 1000,
+      );
+      final withSnapshot = DiplomaticOrderValidator(
+        game: game,
+        playerId: 'gp1',
+        initialTreasury: overtureConsulateCost + 1000,
+        factionMembership: membership,
+      );
+
+      final order = DiplomaticOrder(
+        type: DiplomaticOrderType.establishOverture,
+        targetFactionId: 'minor1',
+        overtureStage: OvertureStage.tradeConsulate,
+      );
+
+      final a = withoutSnapshot.validate(order, previousRejected: false);
+      final b = withSnapshot.validate(order, previousRejected: false);
+      expect(b.result.status, a.result.status);
+      expect(b.treasury, a.treasury);
+    });
+
+    test(
+      'snapshot is consulted on active path: rejects unknown target id',
+      () {
+        final game = gpMinorGame();
+        final emptyMembership = DiplomacyFactionMembership.from(
+          Game(
+            id: 'empty',
+            worldState: WorldState(
+              turnState: const TurnState(
+                phase: TurnPhase.orders,
+                turnNumber: 0,
+              ),
+              oldWorld: const RegionData(),
+              newWorld: const RegionData(),
+            ),
+            players: const [],
+          ),
+        );
+        final validator = DiplomaticOrderValidator(
+          game: game,
+          playerId: 'gp1',
+          initialTreasury: overtureConsulateCost + 1000,
+          factionMembership: emptyMembership,
+        );
+
+        final r = validator.validate(
+          const DiplomaticOrder(
+            type: DiplomaticOrderType.establishOverture,
+            targetFactionId: 'minor1',
+            overtureStage: OvertureStage.tradeConsulate,
+          ),
+          previousRejected: false,
+        );
+        expect(r.result.status, OrderValidationStatus.rejected);
+        expect(r.result.reason, contains('Target faction not found'));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Threads the existing `DiplomacyFactionMembership` snapshot (built once per `validatePlayerOrdersWithContext` call) through the diplomatic order validators so per-candidate `isGreatPower` / `isMinorOrTribe` classification uses `Set<String>.contains` lookups instead of falling back to linear `game.players` / `game.minorNations` / `game.tribes` scans.

Targets issue #2394 Category C (linear scans on diplomacy_resolver classifications) and the **expected behavior** bullet "All linear collection lookups on game-state collections replaced with O(1) `Map<String, T>` or `Set<String>` lookups."

## Scope (this PR)

Validators threaded with the optional `factionMembership` parameter:

- `DiplomaticOrderValidator` — target existence check (`diplomatic_order_validator.dart:127`).
- `EstablishOvertureSubValidator` — stage-1 classification (line 35), Join Empire branch dispatch (lines 181, 184), nearly-defeated GP gate (line 209), Minor/Tribe diplomatic-expertise gate (line 222).
- `AllianceSubValidator` — target must be a Great Power (line 21).

Wiring sites (no semantic change; pass through the membership already built upstream):

- `_defaultOrderValidatorFactory` in `order_engine.dart` forwards `factionMembership` to `DiplomaticOrderValidator`.
- `IncrementalCandidateValidator._diplomaticAccepted` forwards the cached `_factionMembership()` snapshot.

## Behavior

Unchanged whenever the membership snapshot reflects `Game.players` / `Game.minorNations` / `Game.tribes` (the only mode reachable in production, since both call sites build the snapshot from the same `Game`). When a snapshot is passed in, classification deterministically follows the snapshot, which is the documented O(1) contract on `DiplomacyFactionMembership` (mirrors the pattern already used by `MoveValidator`, `ArmyMoveValidator`, `WorkOrderValidator`, etc.).

## Out of scope (deferred, same issue #2394)

- Other linear `isGreatPower`/`isMinorOrTribe` call sites that need their context plumbing extended first (e.g. `work_order_target_prechecks.dart:124`, `validators/work_order_validator.dart:447`, `combat/military_attack_economy.dart:39`).
- Other Category C linear-scan sites (resource_extractor, combat_phase_helpers, tile_keys, etc.).
- CI AST lint rules (`prohibited_linear_province_lookup`, etc.).
- Sharing `PlayerView` / `IncrementalCandidateValidator` across suggestion calls in `simple_ai_heuristics`.

## SPEC

None. Pure internal optimization — preserves observable validator behavior. Authorized by `SPEC/program/order-suggestions.md` § Throughput bounds ("incremental validation, memoization, and bounded search") and `colonizethis-turn-resolution-budget.mdc` *Required optimization approach when over budget* — "Avoid repeated expensive scoring: Memoize per-target/per-player computations".

## Tests

- New: `test/orders/validators/diplomatic/diplomatic_sub_validators_faction_membership_test.dart` (7 tests). For each of `AllianceSubValidator`, `EstablishOvertureSubValidator`, `DiplomaticOrderValidator`:
  - **Positive equivalence**: accept/reject decision and treasury state identical with vs without snapshot when snapshot mirrors `Game`.
  - **Negative (active path)**: empty snapshot rejects targets that exist only in `Game`, proving the snapshot is consulted on the hot path.
- Re-run: `test/orders/validators/diplomatic/` (full directory, 38 tests), plus `order_engine_validate_diplomatic_{aid_subsidy,relations}_test.dart`, `order_engine_validator_injection_test.dart`, `order_engine_move_and_work_context_part{1,2}_test.dart` — all green.

Commands run:

```
cd packages/colonizethis_logic
dart analyze lib
dart test test/orders/validators/diplomatic/diplomatic_sub_validators_faction_membership_test.dart
dart test test/orders/validators/diplomatic/
dart test test/order_engine_validate_diplomatic_aid_subsidy_test.dart \
         test/order_engine_validate_diplomatic_relations_test.dart \
         test/order_engine_validator_injection_test.dart \
         test/order_engine_move_and_work_context_part1_test.dart \
         test/order_engine_move_and_work_context_part2_test.dart
```

Refs #2394

Made with [Cursor](https://cursor.com)