### PR TITLE
perf(logic): O(1) player index map in faction absorption (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/diplomacy/faction_absorption_engine.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/faction_absorption_engine.dart
@@ -92,17 +92,20 @@ Game _absorbIntoGp(
 }) {
   final cost = joinEmpireCostForMinorOrTribe(game, absorbedFactionId);
   var players = List<Player>.from(game.players);
-  final gpIdx = players.indexWhere((p) => p.id == gpId);
+  final playerIndexById = <String, int>{
+    for (var i = 0; i < players.length; i++) players[i].id: i,
+  };
+  final gpIdx = playerIndexById[gpId];
 
   if (kind == _AbsorptionKind.greatPower) {
-    final targetIdx = players.indexWhere((p) => p.id == absorbedFactionId);
-    if (gpIdx < 0 || targetIdx < 0) return game;
+    final targetIdx = playerIndexById[absorbedFactionId];
+    if (gpIdx == null || targetIdx == null) return game;
     players[gpIdx] = players[gpIdx].copyWith(
       treasury: players[gpIdx].treasury - cost,
     );
     players.removeAt(targetIdx);
   } else {
-    if (gpIdx >= 0) {
+    if (gpIdx != null) {
       players = List<Player>.from(players);
       players[gpIdx] = players[gpIdx].copyWith(
         treasury: players[gpIdx].treasury - cost,


### PR DESCRIPTION
## Summary
- Replace two `List<Player>.indexWhere` scans in `_absorbIntoGp` with one `id → index` map built from the copied players list (Category C hot-path cleanup for issue #2394).

## Scope / out of scope
- **In scope:** Join-Empire / GP absorption player list indexing only.
- **Deferred:** Other `indexWhere` call sites already tracked by parallel PRs (treasury paths, subsidies resolver, etc.).

## SPEC
- No GDD/TDD change; internal performance only, consistent with `SPEC/program/turn-resolution.md` / `SPEC/program/order-suggestions.md` guidance on deterministic memoization.

## Tests
- `dart analyze lib/src/diplomacy/faction_absorption_engine.dart`
- `flutter test test/diplomacy/faction_absorption_engine_test.dart`

## Issue
Refs #2394

Made with [Cursor](https://cursor.com)