### PR TITLE
refactor(logic): co-locate overture stage next/previous (Refs #2391)

### DIFF
--- a/packages/colonizethis_logic/lib/src/diplomacy/overture_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/overture_resolver.dart
@@ -5,6 +5,7 @@ import '../constants.dart';
 import '../dossier/evidence_rules.dart';
 import '../turn/turn_resolution_result.dart';
 import 'diplomacy_resolver.dart';
+import 'overture_stage_navigation.dart';
 
 Game appendDiplomaticEvent(
   Game game,
@@ -377,21 +378,6 @@ OverturePaymentsResult processOverturePayments(
 
   state = state.copyWith(players: players, overtureStates: overtures);
   return OverturePaymentsResult(state);
-}
-
-OvertureStage previousStage(OvertureStage stage) {
-  switch (stage) {
-    case OvertureStage.tradeConsulate:
-      return OvertureStage.none;
-    case OvertureStage.embassy:
-      return OvertureStage.tradeConsulate;
-    case OvertureStage.nap:
-      return OvertureStage.embassy;
-    case OvertureStage.joinEmpire:
-      return OvertureStage.nap;
-    case OvertureStage.none:
-      return OvertureStage.none;
-  }
 }
 
 Game advanceOvertures(Game game, int turn) {

--- a/packages/colonizethis_logic/lib/src/diplomacy/overture_stage_navigation.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/overture_stage_navigation.dart
@@ -1,0 +1,39 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Forward progression of [OvertureStage] for suggestions (none → … → joinEmpire).
+///
+/// Co-located with [previousStage] so the overture chain stays single-source
+/// (Refs #2391 Pattern 2).
+OvertureStage? nextOvertureStage(OvertureStage current) {
+  switch (current) {
+    case OvertureStage.none:
+      return OvertureStage.tradeConsulate;
+    case OvertureStage.tradeConsulate:
+      return OvertureStage.embassy;
+    case OvertureStage.embassy:
+      return OvertureStage.nap;
+    case OvertureStage.nap:
+      return OvertureStage.joinEmpire;
+    case OvertureStage.joinEmpire:
+      return null;
+  }
+}
+
+/// Backward step used by turn-resolution overture handling.
+///
+/// Inverse of [nextOvertureStage] for every stage except [OvertureStage.none],
+/// which maps to itself (Refs #2391 Pattern 2).
+OvertureStage previousStage(OvertureStage stage) {
+  switch (stage) {
+    case OvertureStage.tradeConsulate:
+      return OvertureStage.none;
+    case OvertureStage.embassy:
+      return OvertureStage.tradeConsulate;
+    case OvertureStage.nap:
+      return OvertureStage.embassy;
+    case OvertureStage.joinEmpire:
+      return OvertureStage.nap;
+    case OvertureStage.none:
+      return OvertureStage.none;
+  }
+}

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_context.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_context.dart
@@ -5,6 +5,8 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import '../world/player_view.dart';
 import 'incremental_candidate_validator.dart';
 
+export '../diplomacy/overture_stage_navigation.dart';
+
 final orderSuggestionLog = packageLogger('order_suggestion');
 
 bool _orderSuggestionTrackWorkOrderAcceptanceProbes = false;
@@ -212,19 +214,4 @@ Orders appendDiplomaticOrderForTrial(
       playerId: [...prev, order],
     },
   );
-}
-
-OvertureStage? nextOvertureStage(OvertureStage current) {
-  switch (current) {
-    case OvertureStage.none:
-      return OvertureStage.tradeConsulate;
-    case OvertureStage.tradeConsulate:
-      return OvertureStage.embassy;
-    case OvertureStage.embassy:
-      return OvertureStage.nap;
-    case OvertureStage.nap:
-      return OvertureStage.joinEmpire;
-    case OvertureStage.joinEmpire:
-      return null;
-  }
 }

--- a/packages/colonizethis_logic/test/order_suggestion_context_helpers_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_context_helpers_test.dart
@@ -72,6 +72,28 @@ void main() {
     });
   });
 
+  group('previousStage', () {
+    test('reverses nextOvertureStage for progression chain', () {
+      for (final stage in [
+        OvertureStage.none,
+        OvertureStage.tradeConsulate,
+        OvertureStage.embassy,
+        OvertureStage.nap,
+      ]) {
+        final forward = nextOvertureStage(stage)!;
+        expect(previousStage(forward), stage);
+      }
+    });
+
+    test('none maps to itself', () {
+      expect(previousStage(OvertureStage.none), OvertureStage.none);
+    });
+
+    test('joinEmpire previous is nap', () {
+      expect(previousStage(OvertureStage.joinEmpire), OvertureStage.nap);
+    });
+  });
+
   group('acceptance wrappers', () {
     test('isNavalMoveOrderAccepted returns a boolean result', () {
       final accepted = isNavalMoveOrderAccepted(


### PR DESCRIPTION
## Summary

Implements **issue #2391 Pattern 2**: `nextOvertureStage` (order suggestions) and `previousStage` (diplomacy resolution) lived in separate files as inverse state graphs. They now live together in `overture_stage_navigation.dart` so the overture chain is single-source.

## Scope

- **In scope:** New `packages/colonizethis_logic/lib/src/diplomacy/overture_stage_navigation.dart`; remove duplicate definitions from `order_suggestion_context.dart` and `overture_resolver.dart`; re-export from `order_suggestion_context.dart` so existing importers (tests, naval diplomatic suggestions) stay stable; regression tests for `previousStage` and inverse relationship with `nextOvertureStage`.
- **Deferred:** Other duplication patterns on #2391; no SPEC edits (per issue non-goals).

## Tests

- `cd packages/colonizethis_logic && dart test test/order_suggestion_context_helpers_test.dart`

Refs #2391

Made with [Cursor](https://cursor.com)