### PR TITLE
perf(logic): reuse explorer units-by-id for prospect pass (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_explorer.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_explorer.dart
@@ -186,6 +186,8 @@ void _addExplorerWorkSuggestionsForUnit({
     unit: unit,
     regionId: regionId,
     provinceId: provinceId,
+    unitsById: unitsById,
+    diplomatic: diplomatic,
     tileKeysByRegion: tileKeysByRegion,
     existingTargetsByUnit: existingTargetsByUnit,
     suggestions: suggestions,
@@ -272,6 +274,8 @@ void _addProspectSuggestionIfEligible({
   required Unit unit,
   required String regionId,
   required String provinceId,
+  required Map<String, Unit> unitsById,
+  required List<DiplomaticOrder> diplomatic,
   required Map<String, Map<String, List<String>>> tileKeysByRegion,
   required Map<String, Set<String>> existingTargetsByUnit,
   required List<WorkOrder> suggestions,
@@ -292,10 +296,6 @@ void _addProspectSuggestionIfEligible({
     );
     return;
   }
-
-  final unitsById = Map<String, Unit>.from(unitsByIdFromWorld(game.worldState));
-  final diplomatic =
-      currentOrders.diplomaticOrdersByPlayerId[playerId] ?? const [];
 
   final prospected =
       game.worldState.playerProspectedTiles[playerId] ?? const <String>{};


### PR DESCRIPTION
## Summary
Refs #2394 (duplicate computation / hot-path throughput).

`_addExplorerWorkSuggestionsForUnit` already built a `Map<String, Unit>` from `unitsByIdFromWorld` for explore probes. `_addProspectSuggestionIfEligible` immediately rebuilt the same map. Prospect now receives the same `unitsById` and diplomatic list instance for that unit pass, eliminating one full-world unit scan per explorer work-suggestion unit.

## Behavior
No semantic change: same `unitsById` snapshot and diplomatic orders list as before the prospect phase.

## SPEC
No SPEC edits; aligns with `SPEC/program/order-suggestions.md` throughput guidance and issue #2394 Category F (duplicate computation).

## Tests
```
cd packages/colonizethis_logic && flutter test \
  test/orders/order_suggestion_core_part1_prospect_player_view_test.dart \
  test/orders/work_suggestion_pipeline_test.dart \
  test/per_player_work_target_selection_cache_test.dart \
  test/orders/partial_province_reveal_test.dart
```
All passed locally.

## Deferred
Broader #2394 items (other call sites, benchmarks, AST lints) remain for separate PRs.

Made with [Cursor](https://cursor.com)