### PR TITLE
perf(logic): O(1) region province-by-id cache in province_lookup (Refs #2394)

### DIFF
--- a/SPEC/program/logic-dual-region-province-access.md
+++ b/SPEC/program/logic-dual-region-province-access.md
@@ -5,6 +5,7 @@
 ## Policy
 
 - **Canonical implementation:** `packages/colonizethis_logic/lib/src/world/province_lookup.dart` may use `oldWorld.provinces` and `newWorld.provinces` to implement `allProvinces`, `WorldState.allProvinces()`, region-scoped lookup, and related helpers.
+- **Region province-by-id cache (internal):** The canonical file may maintain an internal weak per-`RegionData` cache of `Province.id` -> `Province` to back O(1) amortized region-scoped lookups (`tryGetProvince`, `getProvince`, `tryGetProvinceByRegion`, `getProvinceByRegion`, `tryGetRegionIdForLegacyProvinceKey`). The cache must preserve "first match wins" semantics for any duplicated `Province.id` within a region (matching the previous `indexWhere` scan). The cache is per-instance and bound to the [RegionData] lifetime; each `copyWith`-produced [RegionData] (e.g. via `WorldState.updateRegionById`) gets an independent cache (Refs **#2394** Category C).
 - **Canonical implementation (units):** `packages/colonizethis_logic/lib/src/world/unit_lookup.dart` may use `oldWorld.units` and `newWorld.units` to implement `allUnits`, `WorldState.allUnits()`, region-scoped lookup, and related helpers.
 - **Canonical region updates:** Prefer `WorldState.updateRegionById(...)` (for one-region updates) and `WorldState.mapBothRegions(...)` / `WorldState.mapBothRegionUnits(...)` (for two-region updates) over inline `if (regionId == oldWorld)` or `copyWith(oldWorld: ...)/copyWith(newWorld: ...)` branching in `lib/src/**`.
 - **Elsewhere under** `packages/colonizethis_logic/lib/src/**`: prefer `allProvinces(world)` / `allUnits(world)` or the related `WorldState` lookup extension methods so dual-region iteration stays centralized.
@@ -26,6 +27,9 @@ Raising the budget requires a SPEC update in this file and a maintainer-reviewed
 
 - Given the repository at `dev` with `packages/colonizethis_logic/lib/src/**` sources, when CI runs `dart run tool/ct_repo_lint.dart` including rule `repo.logic_dual_region_province_field_access`, then the checker counts matching lines outside `province_lookup.dart` and `unit_lookup.dart` and the run passes when the count is at most 28.
 - Given a contributor adds a 29th matching line outside `province_lookup.dart` and `unit_lookup.dart` without updating the budget in this SPEC and the checker constant, when repo lint runs, then the run fails and lists each `path:line` hit.
+- Given a [RegionData] instance with provinces `[Province(id: "X|p1"), Province(id: "X|p2")]`, when `tryGetProvince(world, "X|p1")` is called twice for the same `world`, then the canonical implementation returns the identical [Province] instance on both calls (cache hit; Refs #2394).
+- Given a [RegionData] instance with two `Province` rows that share the same `id`, when `tryGetProvince` is called with that id, then the canonical implementation returns the first `Province` in the underlying provinces list (matches the prior `indexWhere` first-match semantics).
+- Given a `WorldState` whose `oldWorld` is replaced via `updateRegionById` so that the [Province] for `oldWorld|p1` now has `displayName = "AlphaPrime"`, when `tryGetProvince` is invoked on the updated `WorldState`, then the canonical implementation returns the new [Province] (the new [RegionData] has an independent cache; no stale cache reuse).
 
 ## `allProvinces(` call-site sanction gate (Refs **#2278**)
 

--- a/packages/colonizethis_logic/lib/src/world/province_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/world/province_lookup.dart
@@ -9,15 +9,35 @@ RegionData? _regionForId(WorldState world, String regionId) {
       : (regionId == kRegionNewWorld ? world.newWorld : null);
 }
 
+/// Per-[RegionData] cache of `Province.id` -> `Province`.
+///
+/// [RegionData] is value-typed and effectively immutable for the lifetime of
+/// each instance (provinces is `final` and replaced via `copyWith`), so a
+/// weak per-instance cache is safe: when the [RegionData] becomes unreachable
+/// the entry is collected automatically. Cache build preserves the
+/// "first match wins" semantics of the previous `indexWhere` scan via
+/// `putIfAbsent`. Refs #2394 — Category C O(1) province lookup.
+final Expando<Map<String, Province>> _provincesByFullIdCache =
+    Expando<Map<String, Province>>('provincesByFullId');
+
+Map<String, Province> _provincesByFullIdFor(RegionData region) {
+  final cached = _provincesByFullIdCache[region];
+  if (cached != null) return cached;
+  final map = <String, Province>{};
+  for (final p in region.provinces) {
+    map.putIfAbsent(p.id, () => p);
+  }
+  _provincesByFullIdCache[region] = map;
+  return map;
+}
+
 Province? _findProvinceInRegion(
   RegionData region,
   String regionId,
   String localId,
 ) {
   final fullId = ProvinceId.full(regionId, localId);
-  final idx = region.provinces.indexWhere((p) => p.id == fullId);
-  if (idx < 0) return null;
-  return region.provinces[idx];
+  return _provincesByFullIdFor(region)[fullId];
 }
 
 /// Returns the region data for [regionId], or null if unknown.
@@ -157,11 +177,14 @@ extension WorldStateProvinceLookup on WorldState {
   /// equals [key] in that region (old world checked first). For canonical
   /// lookups prefer [tryGetProvince] with a prefixed id; this exists for
   /// legacy short ids and tests (waigore/colonizethis#2071 Phase 1).
+  ///
+  /// Uses the per-region cached `id -> Province` map (Refs #2394 Category C)
+  /// so lookups are O(1) amortized instead of O(P/2) per region scan.
   String? tryGetRegionIdForLegacyProvinceKey(String key) {
-    if (oldWorld.provinces.indexWhere((p) => p.id == key) >= 0) {
+    if (_provincesByFullIdFor(oldWorld).containsKey(key)) {
       return kRegionOldWorld;
     }
-    if (newWorld.provinces.indexWhere((p) => p.id == key) >= 0) {
+    if (_provincesByFullIdFor(newWorld).containsKey(key)) {
       return kRegionNewWorld;
     }
     return null;

--- a/packages/colonizethis_logic/test/province_lookup_test.dart
+++ b/packages/colonizethis_logic/test/province_lookup_test.dart
@@ -202,4 +202,94 @@ void main() {
       );
     });
   });
+
+  // Refs #2394 — Category C: O(1) province-by-id lookup cache. The per-region
+  // cache is populated lazily on first lookup and reused for subsequent calls
+  // against the same RegionData instance.
+  group('region province-by-id cache (Refs #2394)', () {
+    test('repeated tryGetProvince returns identical Province instance', () {
+      final first = tryGetProvince(world, 'oldWorld|p1');
+      final second = tryGetProvince(world, 'oldWorld|p1');
+      expect(first, isNotNull);
+      expect(identical(first, second), isTrue);
+    });
+
+    test('updateRegionById produces a region with an independent cache', () {
+      final originalAlpha = tryGetProvince(world, 'oldWorld|p1');
+      expect(originalAlpha?.displayName, 'Alpha');
+
+      final renamed = world.updateRegionById(
+        kRegionOldWorld,
+        (region) => RegionData(
+          provinces: [
+            for (final p in region.provinces)
+              if (p.id == 'oldWorld|p1')
+                Province(
+                  id: p.id,
+                  regionId: p.regionId,
+                  displayName: 'AlphaPrime',
+                )
+              else
+                p,
+          ],
+          units: region.units,
+        ),
+      );
+
+      expect(
+        tryGetProvince(renamed, 'oldWorld|p1')?.displayName,
+        'AlphaPrime',
+      );
+      expect(tryGetProvince(world, 'oldWorld|p1')?.displayName, 'Alpha');
+    });
+
+    test('cache preserves first-match semantics when ids are duplicated', () {
+      final dup = WorldState(
+        turnState: world.turnState,
+        oldWorld: RegionData(
+          provinces: [
+            Province(
+              id: 'oldWorld|p1',
+              regionId: 'oldWorld',
+              displayName: 'First',
+            ),
+            Province(
+              id: 'oldWorld|p1',
+              regionId: 'oldWorld',
+              displayName: 'Second',
+            ),
+          ],
+        ),
+        newWorld: RegionData(provinces: const []),
+      );
+      expect(tryGetProvince(dup, 'oldWorld|p1')?.displayName, 'First');
+    });
+
+    test('lookup correctness scales to larger regions', () {
+      const provinceCount = 200;
+      final big = WorldState(
+        turnState: world.turnState,
+        oldWorld: RegionData(
+          provinces: [
+            for (var i = 0; i < provinceCount; i++)
+              Province(
+                id: 'oldWorld|p$i',
+                regionId: 'oldWorld',
+                displayName: 'P$i',
+              ),
+          ],
+        ),
+        newWorld: RegionData(provinces: const []),
+      );
+
+      for (var i = 0; i < provinceCount; i++) {
+        expect(
+          tryGetProvince(big, 'oldWorld|p$i')?.displayName,
+          'P$i',
+          reason: 'lookup failed for index $i',
+        );
+      }
+      expect(tryGetProvince(big, 'oldWorld|missing'), isNull);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Replace `_findProvinceInRegion`'s `indexWhere((p) => p.id == fullId)` linear scan with a per-`RegionData` `Expando`-backed `Map<String, Province>` cache so `tryGetProvince`, `getProvince`, `tryGetProvinceByRegion`, `getProvinceByRegion`, and `tryGetRegionIdForLegacyProvinceKey` become **O(1) amortized** on hot paths.

This slice targets issue #2394 Category C (linear collection scans on game-state) at its foundational call site: `tryGetProvince` is invoked many times per turn from combat, economy, orders, and turn-resolution paths. The previous per-call O(P/2) cost is replaced with O(1) lookups after a single per-`RegionData` pass.

## Scope

- **In scope:** Internal cache inside the canonical lookup file (`packages/colonizethis_logic/lib/src/world/province_lookup.dart`). Observable behavior is unchanged.
- **Deferred:** Other Category C / D / E hot paths in the issue (already covered by other open PRs or to be tackled in follow-up slices).

## Mechanics

- `Expando<Map<String, Province>>` keyed by `RegionData` instance. `RegionData.provinces` is `final` and replaced via `copyWith`, so the cache is correct for the lifetime of each instance and automatically collected when the instance becomes unreachable.
- Cache build uses `putIfAbsent`, preserving the prior `indexWhere` "first match wins" semantics for any duplicated `Province.id` within a region.
- `WorldState.tryGetRegionIdForLegacyProvinceKey` updated to use the same cache via `containsKey`.

## SPEC updates

`SPEC/program/logic-dual-region-province-access.md`

- Document the internal weak per-`RegionData` cache as an authorized implementation detail of the canonical file.
- Add three Given/When/Then ACs:
  - Repeat lookups return the identical `Province` instance (cache hit).
  - First-match wins when two rows share an id.
  - `updateRegionById` produces a `RegionData` with an **independent** cache (no stale reuse).

## Tests

`packages/colonizethis_logic/test/province_lookup_test.dart` — new group `region province-by-id cache (Refs #2394)` covers:

- Repeat `tryGetProvince` returns the identical `Province` instance.
- `WorldState.updateRegionById` produces a region whose cache reflects the renamed province while the original `WorldState` keeps its old data.
- Duplicated `id` rows resolve to the first row (parity with the prior `indexWhere`).
- 200-province correctness scan ensures lookup correctness at scale.

## Verification

- `dart test packages/colonizethis_logic` — **1569/1569 passed** (full suite).
- `dart analyze packages/colonizethis_logic/lib/src/world/province_lookup.dart packages/colonizethis_logic/test/province_lookup_test.dart` — clean.
- `dart run tool/check_dart_file_non_comment_line_size.dart` — clean.
- `dart run tool/check_disallowed_ast_patterns.dart` — clean.
- `dart run tool/check_logic_dual_region_province_field_access.dart` — clean (27/28).
- `dart run tool/check_logic_all_provinces_sanctioned_calls.dart` — clean.

Refs #2394

Made with [Cursor](https://cursor.com)