### PR TITLE
perf(logic): O(1) fleet indices in naval mission orders (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/naval_mission_orders.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_mission_orders.dart
@@ -18,9 +18,8 @@ void _resyncFleetLookupMaps(
   Map<String, Fleet> fleetById,
   Map<String, int> fleetIndexById,
 ) {
-  fleetById
-    ..clear()
-    ..addEntries(fleets.map((f) => MapEntry(f.id, f)));
+  fleetById.clear();
+  fleetById.addEntries(fleets.map((f) => MapEntry(f.id, f)));
   fleetIndexById.clear();
   for (var i = 0; i < fleets.length; i++) {
     fleetIndexById[fleets[i].id] = i;

--- a/packages/colonizethis_logic/lib/src/world/naval_mission_orders.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_mission_orders.dart
@@ -13,10 +13,25 @@ final _fleetMissionByOrderName = <String, FleetMission>{
 FleetMission _fleetMissionFromOrderName(String name) =>
     _fleetMissionByOrderName[name] ?? FleetMission.none;
 
+void _resyncFleetLookupMaps(
+  List<Fleet> fleets,
+  Map<String, Fleet> fleetById,
+  Map<String, int> fleetIndexById,
+) {
+  fleetById
+    ..clear()
+    ..addEntries(fleets.map((f) => MapEntry(f.id, f)));
+  fleetIndexById.clear();
+  for (var i = 0; i < fleets.length; i++) {
+    fleetIndexById[fleets[i].id] = i;
+  }
+}
+
 List<Fleet> _applySingleNavalMissionOrder({
   required Game game,
   required List<Fleet> fleets,
   required Map<String, Fleet> fleetById,
+  required Map<String, int> fleetIndexById,
   required String playerId,
   required NavalMissionOrder order,
 }) {
@@ -40,7 +55,7 @@ List<Fleet> _applySingleNavalMissionOrder({
         .where((f) => f.id != fleet.id)
         .map((f) => f.id == homeFleetId ? updatedHome : f)
         .toList();
-    fleetById[homeFleetId] = updatedHome;
+    _resyncFleetLookupMaps(next, fleetById, fleetIndexById);
     return next;
   }
 
@@ -68,8 +83,8 @@ List<Fleet> _applySingleNavalMissionOrder({
         targetPortId: null,
         targetProvinceId: null,
       );
-      final idx = fleets.indexWhere((f) => f.id == fleet.id);
-      if (idx >= 0) {
+      final idx = fleetIndexById[fleet.id];
+      if (idx != null) {
         final next = List<Fleet>.from(fleets)..[idx] = cleared;
         fleetById[fleet.id] = cleared;
         return next;
@@ -83,8 +98,8 @@ List<Fleet> _applySingleNavalMissionOrder({
     targetPortId: order.targetPortId,
     targetProvinceId: order.targetProvinceId,
   );
-  final idx = fleets.indexWhere((f) => f.id == fleet.id);
-  if (idx >= 0) {
+  final idx = fleetIndexById[fleet.id];
+  if (idx != null) {
     final next = List<Fleet>.from(fleets)..[idx] = newFleet;
     fleetById[fleet.id] = newFleet;
     return next;
@@ -97,7 +112,9 @@ Game applyNavalMissionOrders(
   Map<String, List<NavalMissionOrder>> navalMissionOrdersByPlayerId,
 ) {
   var fleets = List<Fleet>.from(game.worldState.fleets);
-  final fleetById = {for (final f in fleets) f.id: f};
+  final fleetById = <String, Fleet>{};
+  final fleetIndexById = <String, int>{};
+  _resyncFleetLookupMaps(fleets, fleetById, fleetIndexById);
 
   for (final entry in navalMissionOrdersByPlayerId.entries) {
     final playerId = entry.key;
@@ -106,6 +123,7 @@ Game applyNavalMissionOrders(
         game: game,
         fleets: fleets,
         fleetById: fleetById,
+        fleetIndexById: fleetIndexById,
         playerId: playerId,
         order: order,
       );

--- a/packages/colonizethis_logic/test/world/naval_mission_orders_test.dart
+++ b/packages/colonizethis_logic/test/world/naval_mission_orders_test.dart
@@ -1,0 +1,44 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/src/world/naval_mission_orders.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('applyNavalMissionOrders', () {
+    test(
+      'sequential mission updates on the same fleet apply both (Refs #2394)',
+      () {
+        const ow = 'oldWorld';
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'f1',
+                ownerId: 'p1',
+                seaZoneId: 'sea1',
+                regionId: ow,
+                shipTypeIds: const ['carrack'],
+                mission: FleetMission.none,
+              ),
+            ],
+          ),
+          players: const [Player(id: 'p1', displayName: 'A', isHuman: true)],
+        );
+
+        final next = applyNavalMissionOrders(game, {
+          'p1': [
+            NavalMissionOrder(fleetId: 'f1', mission: FleetMission.patrol.name),
+            NavalMissionOrder(fleetId: 'f1', mission: FleetMission.defend.name),
+          ],
+        });
+
+        expect(next.worldState.fleets, hasLength(1));
+        expect(next.worldState.fleets.single.mission, FleetMission.defend);
+      },
+    );
+  });
+}

--- a/packages/colonizethis_logic/test/world/naval_mission_orders_test.dart
+++ b/packages/colonizethis_logic/test/world/naval_mission_orders_test.dart
@@ -1,4 +1,3 @@
-import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/src/world/naval_mission_orders.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';


### PR DESCRIPTION
## Summary
- Keep `fleet id → index in WorldState.fleets` in sync with `fleetById` while applying naval mission orders, replacing per-update `List.indexWhere` scans for mission assignment and blockade auto-clear paths.
- Full resync of both lookup maps after `join_home_fleet` (list length and membership change).

## Scope / out of scope
- In scope: `applyNavalMissionOrders` / `_applySingleNavalMissionOrder` hot path only; semantics unchanged.
- Out of scope: second pass that clears stale blockades (still index-based over the list); validator reuse, subsidy player maps, other open #2394 PRs.

## Spec
- Performance-only; authorized by `SPEC/program/turn-resolution.md` throughput / determinism guidance and issue #2394 Category C (collection lookups).

## Tests
- Added `test/world/naval_mission_orders_test.dart` (sequential mission updates on same fleet).
- Ran: `dart test test/world/naval_mission_orders_test.dart`, `dart test` on `turn_resolver_resolve_turn_for_game_part3_segment1_test.dart`, `part2_part2_segment2`, `incremental_candidate_validator_equivalence_army_naval_test.dart`.

Refs #2394

Made with [Cursor](https://cursor.com)