### PR TITLE
perf(logic): O(1) fleet map for naval split/transfer commands (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/naval_fleet_commands.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_fleet_commands.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../economy/sea_transport.dart';
 import 'naval.dart';
 
 /// Returns [game] unchanged if the fleet is missing or [shipInstanceIdsToNewFleet] is empty.
@@ -12,13 +13,8 @@ Game applyNavalSplitFleet({
 }) {
   if (shipInstanceIdsToNewFleet.isEmpty) return game;
 
-  Fleet? originalFleet;
-  for (final f in game.worldState.fleets) {
-    if (f.id == originalFleetId) {
-      originalFleet = f;
-      break;
-    }
-  }
+  final fleetById = fleetsByIdForWorld(game.worldState);
+  final originalFleet = fleetById[originalFleetId];
   if (originalFleet == null) return game;
   final orig = originalFleet;
 
@@ -30,13 +26,12 @@ Game applyNavalSplitFleet({
       .where((s) => !idSet.contains(s.id))
       .toList();
 
-  final allFleetIds = game.worldState.fleets
-      .map((f) => int.tryParse(f.id.replaceAll(RegExp(r'[^0-9]'), '')) ?? 0)
-      .toList();
-  final maxId = allFleetIds.isEmpty
-      ? 0
-      : allFleetIds.reduce((a, b) => a > b ? a : b);
-  final newFleetId = '${maxId + 1}';
+  var maxParsedId = 0;
+  for (final id in fleetById.keys) {
+    final parsed = int.tryParse(id.replaceAll(RegExp(r'[^0-9]'), '')) ?? 0;
+    if (parsed > maxParsedId) maxParsedId = parsed;
+  }
+  final newFleetId = '${maxParsedId + 1}';
 
   final newFleet = Fleet(
     id: newFleetId,
@@ -52,7 +47,8 @@ Game applyNavalSplitFleet({
   final isHomeFleet = orig.id == homeFleetIdFor(humanPlayerId);
 
   final updatedFleets = <Fleet>[
-    ...game.worldState.fleets.where((f) => f.id != orig.id),
+    for (final f in game.worldState.fleets)
+      if (f.id != orig.id) f,
     if (remainingShips.isNotEmpty || isHomeFleet) updatedOriginal,
     newFleet,
   ];
@@ -78,15 +74,9 @@ Game applyNavalTransferShipsBetweenFleets({
     return game;
   }
 
-  Fleet? sourceFleet;
-  Fleet? targetFleet;
-  for (final fleet in game.worldState.fleets) {
-    if (fleet.id == sourceFleetId) {
-      sourceFleet = fleet;
-    } else if (fleet.id == targetFleetId) {
-      targetFleet = fleet;
-    }
-  }
+  final fleetById = fleetsByIdForWorld(game.worldState);
+  final sourceFleet = fleetById[sourceFleetId];
+  final targetFleet = fleetById[targetFleetId];
   if (sourceFleet == null || targetFleet == null) {
     return game;
   }

--- a/packages/colonizethis_logic/test/world/naval_fleet_commands_test.dart
+++ b/packages/colonizethis_logic/test/world/naval_fleet_commands_test.dart
@@ -40,6 +40,27 @@ void main() {
       expect(next, same(original));
     });
 
+    test('Given missing fleet id When applied Then returns unchanged game', () {
+      final original = _gameWithFleets([
+        Fleet(
+          id: '1',
+          ownerId: 'gp_human',
+          regionId: 'oldWorld',
+          seaZoneId: 'sea_a',
+          ships: [ShipInstance(id: 'ship_1', typeId: 'carrack')],
+        ),
+      ]);
+
+      final next = applyNavalSplitFleet(
+        game: original,
+        humanPlayerId: 'gp_human',
+        originalFleetId: 'missing',
+        shipInstanceIdsToNewFleet: const ['ship_1'],
+      );
+
+      expect(next, same(original));
+    });
+
     test(
       'Given existing fleet and selected ships When applied Then creates split fleet and updates original',
       () {
@@ -129,6 +150,33 @@ void main() {
   });
 
   group('applyNavalTransferShipsBetweenFleets', () {
+    test(
+      'Given unknown target fleet When transferred Then returns unchanged game',
+      () {
+        final game = _gameWithFleets([
+          Fleet(
+            id: 'source',
+            ownerId: 'gp_human',
+            regionId: 'oldWorld',
+            seaZoneId: 'sea_a',
+            ships: const [
+              ShipInstance(id: 'ship_1', typeId: 'carrack'),
+            ],
+          ),
+        ]);
+
+        final next = applyNavalTransferShipsBetweenFleets(
+          game: game,
+          humanPlayerId: 'gp_human',
+          sourceFleetId: 'source',
+          targetFleetId: 'no_such_fleet',
+          shipInstanceIdsToTransfer: const ['ship_1'],
+        );
+
+        expect(next, same(game));
+      },
+    );
+
     test(
       'Given subset selected When transferred Then target gains selected and source remains',
       () {


### PR DESCRIPTION
## Summary
Implements another `#2394` Category C slice for immediate naval fleet-management paths: resolve fleets via the shared `fleetsByIdForWorld` map, avoid an extra list allocation when computing the next numeric fleet id, and build the post-split fleet list in one pass (no `.where` spread).

## Scope
- **In:** `packages/colonizethis_logic/lib/src/world/naval_fleet_commands.dart`, `test/world/naval_fleet_commands_test.dart`
- **Out:** Turn resolver / mission orders (covered by other PRs); SPEC edits (issue already cites perf authorization under TDD turn-resolution / order-suggestions).

## Acceptance / verification
- Split and transfer semantics unchanged (existing tests + new no-op cases for missing fleets).

## Tests
```
cd packages/colonizethis_logic && dart test test/world/naval_fleet_commands_test.dart test/world/naval_home_fleet_split_movement_resolve_integration_test.dart
```

Refs #2394

Made with [Cursor](https://cursor.com)