### PR TITLE
perf(logic): O(1) moved-fleet checks in naval attacker normalization (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
@@ -58,19 +58,21 @@ class BattleContextSea {
 }
 
 bool _ownerHadMovingFleetInZone(
-  Game game,
+  Map<String, Fleet> fleetsById,
   String seaZoneId,
   String ownerId,
   Set<String> movedFleetIds,
 ) {
   if (movedFleetIds.isEmpty) return false;
-  return game.worldState.fleets.any(
-    (f) =>
-        f.isAtSea &&
-        f.seaZoneId == seaZoneId &&
-        f.ownerId == ownerId &&
-        movedFleetIds.contains(f.id),
-  );
+  for (final id in movedFleetIds) {
+    final f = fleetsById[id];
+    if (f == null) continue;
+    if (!f.isAtSea) continue;
+    if (f.seaZoneId != seaZoneId) continue;
+    if (f.ownerId != ownerId) continue;
+    return true;
+  }
+  return false;
 }
 
 bool _isInterceptorMission(FleetMission m) =>
@@ -99,16 +101,19 @@ BattleContextSea normalizeNavalBattleSidesForAttacker(
   Game game,
   Set<String> movedFleetIds,
 ) {
+  final fleetsById = <String, Fleet>{
+    for (final f in game.worldState.fleets) f.id: f,
+  };
   final s1 = battle.side1;
   final s2 = battle.side2;
   final m1 = _ownerHadMovingFleetInZone(
-    game,
+    fleetsById,
     battle.seaZoneId,
     s1.ownerId,
     movedFleetIds,
   );
   final m2 = _ownerHadMovingFleetInZone(
-    game,
+    fleetsById,
     battle.seaZoneId,
     s2.ownerId,
     movedFleetIds,

--- a/packages/colonizethis_logic/test/naval_combat_resolver_test.dart
+++ b/packages/colonizethis_logic/test/naval_combat_resolver_test.dart
@@ -180,6 +180,47 @@ void main() {
       expect(n.side2.ownerId, 'p2');
     });
 
+    test('stale or unknown fleet ids in movedFleetIds are ignored', () {
+      final game = gameTwoFleets(
+        fleet1: Fleet(
+          id: 'mv',
+          ownerId: 'p1',
+          seaZoneId: 'sea1',
+          regionId: 'oldWorld',
+          shipTypeIds: ['carrack'],
+          mission: FleetMission.none,
+        ),
+        fleet2: Fleet(
+          id: 'st',
+          ownerId: 'p2',
+          seaZoneId: 'sea1',
+          regionId: 'oldWorld',
+          shipTypeIds: ['fluyte'],
+          mission: FleetMission.defend,
+        ),
+      );
+      final battle = BattleContextSea(
+        seaZoneId: 'sea1',
+        side1: NavalBattleSide(
+          ownerId: 'p2',
+          ships: legacyShipInstancesForFleet('x', ['fluyte']),
+          mission: FleetMission.defend,
+        ),
+        side2: NavalBattleSide(
+          ownerId: 'p1',
+          ships: legacyShipInstancesForFleet('y', ['carrack']),
+          mission: FleetMission.none,
+        ),
+      );
+      final n = normalizeNavalBattleSidesForAttacker(
+        battle,
+        game,
+        {'mv', 'not-a-fleet-id'},
+      );
+      expect(n.side1.ownerId, 'p1');
+      expect(n.side2.ownerId, 'p2');
+    });
+
     test('interceptor is attacker when the other faction moved', () {
       final game = gameTwoFleets(
         fleet1: Fleet(


### PR DESCRIPTION
## Summary

- `normalizeNavalBattleSidesForAttacker` now builds one `Map<String, Fleet>` from `game.worldState.fleets` per battle normalization and determines whether each side had a **moved** fleet in the battle zone by iterating `movedFleetIds` with O(1) lookups, instead of two `fleets.any(...)` passes over the full fleet list.
- Semantics unchanged: a side counts as having moved into the zone iff some fleet id in `movedFleetIds` refers to an at-sea fleet in that zone with matching `ownerId`.

## Issue / SPEC

- Refs #2394 (Category C: reduce linear collection work on turn-resolution hot paths).
- Performance-only; authorized by `SPEC/program/turn-resolution.md` throughput / determinism guidance (no ordering or combat rule changes).

## Tests

- `cd packages/colonizethis_logic && dart analyze lib/src/combat/naval_combat_resolver.dart`
- `dart test test/naval_combat_resolver_test.dart`

## Out of scope

- Broader naval conflict detection / retreat-zone indexing (other open #2394 PRs).

Refs #2394
