### PR TITLE
perf(logic): O(1) player index map for subsidy and grant-aid resolution (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_subsidies_relations_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_subsidies_relations_resolver.dart
@@ -9,6 +9,18 @@ import 'diplomacy_relation_updates.dart';
 import 'diplomacy_resolver.dart';
 import 'overture_resolver.dart';
 
+/// O(1) lookup of list index by player id for [players] snapshots.
+///
+/// Callers that replace [players] with `List<Player>.from(players)` preserve
+/// index order, so the returned map remains valid for the new list instance.
+Map<String, int> _playerListIndexById(List<Player> players) {
+  final out = <String, int>{};
+  for (var i = 0; i < players.length; i++) {
+    out[players[i].id] = i;
+  }
+  return out;
+}
+
 Game terminateAgreementsOnWar(Game game) {
   final turn = game.worldState.turnState.turnNumber;
   var overtures = game.overtureStates;
@@ -55,6 +67,7 @@ Game applyRelationModifiersAndUpdateScores(
   int turn,
 ) {
   var players = game.players;
+  var playerIndexById = _playerListIndexById(players);
   var relations = List<DiplomacyRelation>.from(game.diplomacyRelations);
 
   // GrantAid: deduct treasury, add relation modifier (+5 per grant). Requires Embassy.
@@ -81,7 +94,7 @@ Game applyRelationModifiersAndUpdateScores(
       final overture = getOverture(game, gpId, targetId);
       if (overture == null || !overture.hasEmbassy) continue;
 
-      final playerIdx = players.indexWhere((p) => p.id == gpId);
+      final playerIdx = playerIndexById[gpId] ?? -1;
       if (playerIdx >= 0) {
         players = List<Player>.from(players);
         players[playerIdx] = players[playerIdx].copyWith(
@@ -136,7 +149,7 @@ Game applyRelationModifiersAndUpdateScores(
       if (overture == null || !overture.hasConsulate) continue;
 
       // Deduct initial payment
-      final payerIdx = players.indexWhere((p) => p.id == gpId);
+      final payerIdx = playerIndexById[gpId] ?? -1;
       if (payerIdx >= 0) {
         players = List<Player>.from(players);
         players[payerIdx] = players[payerIdx].copyWith(
@@ -200,6 +213,7 @@ Game processOngoingSubsidies(
   required DiplomacyFactionMembership factionMembership,
 }) {
   var players = game.players;
+  var playerIndexById = _playerListIndexById(players);
   var relations = List<DiplomacyRelation>.from(game.diplomacyRelations);
   var subsidyStates = List<SubsidyState>.from(game.subsidyStates);
 
@@ -253,7 +267,7 @@ Game processOngoingSubsidies(
     }
 
     // Deduct subsidy payment
-    final payerIdx = players.indexWhere((p) => p.id == payerId);
+    final payerIdx = playerIndexById[payerId] ?? -1;
     if (payerIdx >= 0) {
       players = List<Player>.from(players);
       players[payerIdx] = players[payerIdx].copyWith(
@@ -280,7 +294,7 @@ Game processOngoingSubsidies(
       );
     } else {
       // GP target: transfer treasury
-      final targetIdx = players.indexWhere((p) => p.id == targetId);
+      final targetIdx = playerIndexById[targetId] ?? -1;
       if (targetIdx >= 0) {
         players[targetIdx] = players[targetIdx].copyWith(
           treasury: players[targetIdx].treasury + amount,

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_subsidies_relations_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_subsidies_relations_resolver.dart
@@ -1,7 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../ai/ai_control.dart';
 import '../constants.dart';
 import '../dossier/evidence_rules.dart';
 import 'diplomacy_relation_lookup.dart';

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_subsidies_relations_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_subsidies_relations_resolver.dart
@@ -21,6 +21,18 @@ Map<String, int> _playerListIndexById(List<Player> players) {
   return out;
 }
 
+String _subsidyPairKey(String payerId, String targetId) =>
+    '$payerId\x1F$targetId';
+
+Map<String, int> _subsidyStateIndexByPair(List<SubsidyState> states) {
+  final out = <String, int>{};
+  for (var i = 0; i < states.length; i++) {
+    final s = states[i];
+    out[_subsidyPairKey(s.payerId, s.targetId)] = i;
+  }
+  return out;
+}
+
 Game terminateAgreementsOnWar(Game game) {
   final turn = game.worldState.turnState.turnNumber;
   var overtures = game.overtureStates;
@@ -126,6 +138,7 @@ Game applyRelationModifiersAndUpdateScores(
   // SetSubsidy: Create or update ongoing subsidy. Requires Consulate or Embassy.
   // Deducts initial payment immediately; ongoing payments processed each turn.
   var subsidyStates = List<SubsidyState>.from(game.subsidyStates);
+  var subsidyIndexByPair = _subsidyStateIndexByPair(subsidyStates);
   for (final entry in diploByPlayer.entries) {
     final gpId = entry.key;
 
@@ -158,9 +171,8 @@ Game applyRelationModifiersAndUpdateScores(
       }
 
       // Store/update ongoing subsidy state
-      final existingSubsidyIdx = subsidyStates.indexWhere(
-        (s) => s.payerId == gpId && s.targetId == targetId,
-      );
+      final pairKey = _subsidyPairKey(gpId, targetId);
+      final existingSubsidyIdx = subsidyIndexByPair[pairKey] ?? -1;
       final isUpdate = existingSubsidyIdx >= 0;
       if (isUpdate) {
         subsidyStates[existingSubsidyIdx] = subsidyStates[existingSubsidyIdx]
@@ -173,6 +185,7 @@ Game applyRelationModifiersAndUpdateScores(
             amountPerTurn: amount,
           ),
         );
+        subsidyIndexByPair[pairKey] = subsidyStates.length - 1;
       }
 
       game = game.copyWith(players: players, subsidyStates: subsidyStates);

--- a/packages/colonizethis_logic/test/diplomacy_apply_relation_modifiers_subsidy_index_test.dart
+++ b/packages/colonizethis_logic/test/diplomacy_apply_relation_modifiers_subsidy_index_test.dart
@@ -1,0 +1,196 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/src/diplomacy/diplomacy_subsidies_relations_resolver.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+import 'diplomacy_resolver_phase_test_support.dart';
+
+void main() {
+  group(
+    'applyRelationModifiersAndUpdateScores subsidy pair index (Refs #2394)',
+    () {
+      test(
+        'two SetSubsidy toward same target in one pass keeps one state with final amount',
+        () {
+          var game = diplomacyResolverPhaseTestBaseGame().copyWith(
+            players: [
+              const Player(
+                id: 'gp1',
+                displayName: 'GP1',
+                isHuman: true,
+                treasury: 10000,
+              ).copyWith(
+                techUnlocked: const {kTechIdDiplomaticExpertise: true},
+              ),
+            ],
+            overtureStates: const [
+              OvertureState(
+                gpId: 'gp1',
+                targetId: 'minor1',
+                stage: OvertureStage.tradeConsulate,
+                sinceTurn: 0,
+              ),
+            ],
+            diplomacyRelations: [
+              DiplomacyRelation(
+                factionId1: 'gp1',
+                factionId2: 'minor1',
+                score: 50,
+                level: RelationLevel.neutral,
+              ),
+            ],
+          );
+
+          final after = applyRelationModifiersAndUpdateScores(game, {
+            'gp1': [
+              const DiplomaticOrder(
+                type: DiplomaticOrderType.setSubsidy,
+                targetFactionId: 'minor1',
+                amount: 500,
+              ),
+              const DiplomaticOrder(
+                type: DiplomaticOrderType.setSubsidy,
+                targetFactionId: 'minor1',
+                amount: 800,
+              ),
+            ],
+          }, 1);
+
+          expect(after.subsidyStates, hasLength(1));
+          final s = after.subsidyStates.single;
+          expect(s.payerId, 'gp1');
+          expect(s.targetId, 'minor1');
+          expect(s.amountPerTurn, 800);
+          final gp1 = after.players.where((p) => p.id == 'gp1').single;
+          expect(gp1.treasury, 10000 - 500 - 800);
+        },
+      );
+
+      test(
+        'two SetSubsidy toward different targets in one pass records both',
+        () {
+          var game = diplomacyResolverPhaseTestBaseGame().copyWith(
+            minorNations: const [
+              MinorNation(id: 'minor1', displayName: 'Minor 1'),
+              MinorNation(id: 'minor2', displayName: 'Minor 2'),
+            ],
+            players: [
+              const Player(
+                id: 'gp1',
+                displayName: 'GP1',
+                isHuman: true,
+                treasury: 10000,
+              ).copyWith(
+                techUnlocked: const {kTechIdDiplomaticExpertise: true},
+              ),
+            ],
+            overtureStates: const [
+              OvertureState(
+                gpId: 'gp1',
+                targetId: 'minor1',
+                stage: OvertureStage.tradeConsulate,
+                sinceTurn: 0,
+              ),
+              OvertureState(
+                gpId: 'gp1',
+                targetId: 'minor2',
+                stage: OvertureStage.tradeConsulate,
+                sinceTurn: 0,
+              ),
+            ],
+            diplomacyRelations: [
+              DiplomacyRelation(
+                factionId1: 'gp1',
+                factionId2: 'minor1',
+                score: 50,
+                level: RelationLevel.neutral,
+              ),
+              DiplomacyRelation(
+                factionId1: 'gp1',
+                factionId2: 'minor2',
+                score: 50,
+                level: RelationLevel.neutral,
+              ),
+            ],
+          );
+
+          final after = applyRelationModifiersAndUpdateScores(game, {
+            'gp1': [
+              const DiplomaticOrder(
+                type: DiplomaticOrderType.setSubsidy,
+                targetFactionId: 'minor1',
+                amount: 300,
+              ),
+              const DiplomaticOrder(
+                type: DiplomaticOrderType.setSubsidy,
+                targetFactionId: 'minor2',
+                amount: 400,
+              ),
+            ],
+          }, 1);
+
+          expect(after.subsidyStates, hasLength(2));
+          final byTarget = {
+            for (final x in after.subsidyStates) x.targetId: x.amountPerTurn,
+          };
+          expect(byTarget['minor1'], 300);
+          expect(byTarget['minor2'], 400);
+        },
+      );
+
+      test(
+        'pre-existing subsidy row is updated by later SetSubsidy in same pass',
+        () {
+          var game = diplomacyResolverPhaseTestBaseGame().copyWith(
+            players: [
+              const Player(
+                id: 'gp1',
+                displayName: 'GP1',
+                isHuman: true,
+                treasury: 10000,
+              ).copyWith(
+                techUnlocked: const {kTechIdDiplomaticExpertise: true},
+              ),
+            ],
+            overtureStates: const [
+              OvertureState(
+                gpId: 'gp1',
+                targetId: 'minor1',
+                stage: OvertureStage.tradeConsulate,
+                sinceTurn: 0,
+              ),
+            ],
+            diplomacyRelations: [
+              DiplomacyRelation(
+                factionId1: 'gp1',
+                factionId2: 'minor1',
+                score: 50,
+                level: RelationLevel.neutral,
+              ),
+            ],
+            subsidyStates: const [
+              SubsidyState(
+                payerId: 'gp1',
+                targetId: 'minor1',
+                amountPerTurn: 200,
+              ),
+            ],
+          );
+
+          final after = applyRelationModifiersAndUpdateScores(game, {
+            'gp1': [
+              const DiplomaticOrder(
+                type: DiplomaticOrderType.setSubsidy,
+                targetFactionId: 'minor1',
+                amount: 600,
+              ),
+            ],
+          }, 1);
+
+          expect(after.subsidyStates, hasLength(1));
+          expect(after.subsidyStates.single.amountPerTurn, 600);
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Replaces repeated `players.indexWhere((p) => p.id == …)` scans in `applyRelationModifiersAndUpdateScores` and `processOngoingSubsidies` with a single per-pass `Map<String, int>` keyed by player id. List copies (`List<Player>.from(players)`) preserve index order, so the map stays valid across those snapshots.

## Scope
- **In:** `packages/colonizethis_logic/lib/src/diplomacy/diplomacy_subsidies_relations_resolver.dart`
- **Out:** Semantics changes, logging, other resolvers. Overlapping open work (e.g. PR #2458) may need merge coordination if it touches the same lines.

## SPEC / issue
- **Refs #2394** — Category C (linear scans); internal perf only; determinism unchanged.
- Authorized by `SPEC/program/turn-resolution.md` / `SPEC/program/order-suggestions.md` throughput guidance (memoization, no semantic drift).

## Tests
```bash
cd packages/colonizethis_logic && dart test test/diplomacy/
cd packages/colonizethis_logic && dart test test/diplomacy_resolver_phase_test_part1_test.dart test/diplomacy_resolver_phase_test_part2_test.dart test/order_engine_validate_diplomatic_aid_subsidy_test.dart
```

## Label
Leave **backlog:implementation** on #2394 (issue not complete; multiple PRs remain).

Refs #2394


Made with [Cursor](https://cursor.com)