### PR TITLE
perf(logic): O(1) fleet id map for starting home-fleet merge (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/setup/game_setup_helpers_bootstrap.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup_helpers_bootstrap.dart
@@ -136,20 +136,30 @@ void _addStartingRegimentsForPlayer({
   }
 }
 
+Map<String, int> _fleetIdToIndex(List<Fleet> fleets) {
+  final out = <String, int>{};
+  for (var i = 0; i < fleets.length; i++) {
+    out[fleets[i].id] = i;
+  }
+  return out;
+}
+
 int _mergeHomeFleetShipsForPlayer({
   required Player player,
   required String regionId,
   required String localProvinceId,
   required int shipCount,
   required List<Fleet> fleets,
+  required Map<String, int> fleetIndexById,
   required int nextSeq,
 }) {
   if (shipCount <= 0 || regionId != kRegionOldWorld) return nextSeq;
   final fullProvinceId = '$regionId|$localProvinceId';
   final homeFleetId = homeFleetIdFor(player.id);
-  final existingIndex = fleets.indexWhere((f) => f.id == homeFleetId);
-  final existingFleet = existingIndex >= 0 ? fleets[existingIndex] : null;
-  final existingShips = existingFleet?.ships ?? const <ShipInstance>[];
+  final existingIdx = fleetIndexById[homeFleetId];
+  final existingShips = existingIdx != null
+      ? fleets[existingIdx].ships
+      : const <ShipInstance>[];
   final shipTypeId = startingShipTypeForPlayer(player);
   final (seqAfter, newInstances) = mintShipInstances(
     nextShipInstanceSeq: nextSeq,
@@ -164,10 +174,11 @@ int _mergeHomeFleetShipsForPlayer({
     regionId: regionId,
     ships: [...existingShips, ...newInstances],
   );
-  if (existingFleet == null) {
+  if (existingIdx == null) {
     fleets.add(homeFleet);
+    fleetIndexById[homeFleetId] = fleets.length - 1;
   } else {
-    fleets[existingIndex] = homeFleet;
+    fleets[existingIdx] = homeFleet;
   }
   return seqAfter;
 }
@@ -187,6 +198,7 @@ Game addStartingMilitaryAndNaval({
   var oldWorldUnits = List<Unit>.from(game.worldState.oldWorld.units);
   var newWorldUnits = List<Unit>.from(game.worldState.newWorld.units);
   var fleets = List<Fleet>.from(game.worldState.fleets);
+  var fleetIndexById = _fleetIdToIndex(fleets);
   var nextSeq = game.worldState.nextShipInstanceSeq;
   final inferredStart = inferNextShipInstanceSeqFromFleets(fleets);
   if (nextSeq < inferredStart) nextSeq = inferredStart;
@@ -213,6 +225,7 @@ Game addStartingMilitaryAndNaval({
       localProvinceId: localProvinceId,
       shipCount: shipCount,
       fleets: fleets,
+      fleetIndexById: fleetIndexById,
       nextSeq: nextSeq,
     );
   }

--- a/packages/colonizethis_logic/test/game_setup_home_fleet_index_test.dart
+++ b/packages/colonizethis_logic/test/game_setup_home_fleet_index_test.dart
@@ -1,0 +1,106 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart' show ProvinceId;
+
+void main() {
+  test(
+    'multi-GP setup assigns one home fleet per GP with expected ship counts',
+    () {
+      final owNodes = <TopologyNode>[
+        const TopologyNode(
+          id: 'sea1',
+          regionId: 'oldWorld',
+          type: TopologyNodeType.seaZone,
+        ),
+        for (var i = 1; i <= 8; i++)
+          TopologyNode(
+            id: 'p$i',
+            regionId: 'oldWorld',
+            type: TopologyNodeType.province,
+          ),
+      ];
+      final owEdges = <TopologyEdge>[
+        const TopologyEdge(id1: 'p1', id2: 'sea1'),
+        const TopologyEdge(id1: 'p2', id2: 'sea1'),
+        const TopologyEdge(id1: 'p8', id2: 'sea1'),
+        for (var i = 1; i < 8; i++) TopologyEdge(id1: 'p$i', id2: 'p${i + 1}'),
+      ];
+      final owTopology = MapTopology(nodes: owNodes, edges: owEdges);
+      final owTileMap = TileMapResult(
+        width: 8,
+        height: 2,
+        grid: [
+          [for (var i = 1; i <= 8; i++) 'p$i'],
+          [for (var i = 1; i <= 8; i++) 'sea1'],
+        ],
+      );
+
+      final nwTopology = MapTopology(
+        nodes: const [
+          TopologyNode(
+            id: 'nw1',
+            regionId: 'newWorld',
+            type: TopologyNodeType.province,
+          ),
+          TopologyNode(
+            id: 'nwSea',
+            regionId: 'newWorld',
+            type: TopologyNodeType.seaZone,
+          ),
+        ],
+        edges: const [TopologyEdge(id1: 'nw1', id2: 'nwSea')],
+      );
+      final nwTileMap = TileMapResult(
+        width: 1,
+        height: 2,
+        grid: const [
+          ['nw1'],
+          ['nwSea'],
+        ],
+      );
+
+      final config = GameSetupConfig(
+        selectedGreatPowerIds: ['england', 'france'],
+        continentCount: 1,
+        minorNationCount: 0,
+        tribeCount: 1,
+        numProvincesOldWorld: 8,
+        numProvincesNewWorld: 1,
+        minProvincesPerMinor: 0,
+      );
+
+      final result = createGameFromGeneratedMaps(
+        config: config,
+        tileMapOldWorld: owTileMap,
+        topologyOldWorld: owTopology,
+        tileMapNewWorld: nwTileMap,
+        topologyNewWorld: nwTopology,
+        gameId: 'home-fleet-index',
+      );
+
+      final startingShips = config.startingResources.initialNavalShips;
+      expect(result.game.players.length, 2);
+
+      for (final p in result.game.players) {
+        final cap = p.capitalProvinceId;
+        expect(cap, isNotNull);
+        expect(
+          ProvinceId.regionIdFrom(cap!),
+          kRegionOldWorld,
+          reason: 'home fleet merge path is OW-only',
+        );
+        final fid = homeFleetIdFor(p.id);
+        final fleets = result.game.worldState.fleets
+            .where((f) => f.id == fid)
+            .toList();
+        expect(fleets.length, 1, reason: 'single home fleet for ${p.id}');
+        expect(
+          fleets.single.ships.length,
+          startingShips,
+          reason: 'default ruleset starting naval ships',
+        );
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Replaces per-Great-Power `fleets.indexWhere` scans in `addStartingMilitaryAndNaval` with a single `Map<String, int>` built once from the mutable fleet list and updated when a new home fleet row is appended.

## Scope
- **In:** `packages/colonizethis_logic/lib/src/setup/game_setup_helpers_bootstrap.dart`, new `test/game_setup_home_fleet_index_test.dart`
- **Out:** Runtime turn resolution, diplomacy, AI, semantics of starting fleets (unchanged)

## SPEC / issue
- **Refs #2394** — Category C (linear scans); setup-time perf only; determinism unchanged.
- Throughput guidance: `SPEC/program/turn-resolution.md`, `SPEC/program/order-suggestions.md` (memoization, no semantic drift).

## Tests
```bash
cd packages/colonizethis_logic && dart test test/game_setup_home_fleet_index_test.dart
```

## Label
Leave **backlog:implementation** on #2394 (issue not complete).

Refs #2394

Made with [Cursor](https://cursor.com)