### PR TITLE
perf(logic): single-pass join_home_fleet fleet list rebuild (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/world/naval_mission_orders.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_mission_orders.dart
@@ -50,10 +50,12 @@ List<Fleet> _applySingleNavalMissionOrder({
     final updatedHome = homeFleet.copyWith(
       ships: [...homeFleet.ships, ...fleet.ships],
     );
-    final next = fleets
-        .where((f) => f.id != fleet.id)
-        .map((f) => f.id == homeFleetId ? updatedHome : f)
-        .toList();
+    // Single-pass rebuild: same ordering as the prior where/map chain without
+    // allocating two intermediate iterables (Refs #2394).
+    final next = <Fleet>[
+      for (final f in fleets)
+        if (f.id != fleet.id) f.id == homeFleetId ? updatedHome : f,
+    ];
     _resyncFleetLookupMaps(next, fleetById, fleetIndexById);
     return next;
   }

--- a/packages/colonizethis_logic/test/world/naval_mission_orders_test.dart
+++ b/packages/colonizethis_logic/test/world/naval_mission_orders_test.dart
@@ -39,5 +39,67 @@ void main() {
         expect(next.worldState.fleets.single.mission, FleetMission.defend);
       },
     );
+
+    test(
+      'join_home_fleet merges ships into home and preserves fleet order (Refs #2394)',
+      () {
+        const ow = 'oldWorld';
+        final capId = '$ow|cap1';
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+            fleets: [
+              Fleet(
+                id: 'fleet_p1',
+                ownerId: 'p1',
+                regionId: ow,
+                inPortAtProvinceId: capId,
+                ships: const [ShipInstance(id: 'ship_1', typeId: 'carrack')],
+              ),
+              Fleet(
+                id: 'f_mid',
+                ownerId: 'p1',
+                regionId: ow,
+                inPortAtProvinceId: capId,
+                ships: const [ShipInstance(id: 'ship_mid', typeId: 'carrack')],
+              ),
+              Fleet(
+                id: 'f_join',
+                ownerId: 'p1',
+                regionId: ow,
+                inPortAtProvinceId: capId,
+                ships: const [ShipInstance(id: 'ship_join', typeId: 'galleon')],
+              ),
+            ],
+          ),
+          players: [
+            Player(
+              id: 'p1',
+              displayName: 'A',
+              isHuman: true,
+              capitalProvinceId: capId,
+            ),
+          ],
+        );
+
+        final next = applyNavalMissionOrders(game, {
+          'p1': [
+            NavalMissionOrder(fleetId: 'f_join', mission: 'join_home_fleet'),
+          ],
+        });
+
+        expect(next.worldState.fleets, hasLength(2));
+        expect(next.worldState.fleets.map((f) => f.id).toList(), [
+          'fleet_p1',
+          'f_mid',
+        ]);
+        final home = next.worldState.fleets.first;
+        expect(home.ships.map((s) => s.id).toList(), ['ship_1', 'ship_join']);
+        expect(next.worldState.fleets[1].ships.single.id, 'ship_mid');
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
Replaces the `join_home_fleet` branch in `applyNavalMissionOrders` that rebuilt the fleet list via `.where(...).map(...).toList()` with a single collection-for pass. Same deterministic ordering and merge semantics; fewer intermediate iterable allocations on the naval mission apply path.

## Scope
- **In:** `packages/colonizethis_logic/lib/src/world/naval_mission_orders.dart`, `packages/colonizethis_logic/test/world/naval_mission_orders_test.dart`
- **Out:** Other mission branches, UI, semantics changes.

## SPEC / issue
- **Refs #2394** — Category C/D style hot-path cleanup; no behavior change.
- Throughput guidance: `SPEC/program/turn-resolution.md`, `SPEC/program/order-suggestions.md` (internal perf, determinism preserved).

## Tests
```bash
cd packages/colonizethis_logic && dart test test/world/naval_mission_orders_test.dart
```

## Deferred
- Broader `naval_fleet_commands` / other fleet-list paths are tracked by other open slices for #2394.

## Label
Leave **backlog:implementation** on #2394 (issue not complete).

Refs #2394

Made with [Cursor](https://cursor.com)