### PR TITLE
perf(logic): cache army move picker declare-war trial validators (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
@@ -1,18 +1,15 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../constants.dart';
 import '../diplomacy/diplomacy_resolver.dart';
 import '../world/movement.dart';
 import '../world/player_view.dart';
 import '../world/province_lookup.dart';
 import '../world/civilian_tile_occupancy.dart';
-import '../world/topology_helpers.dart';
 import 'draft_orders_mutations.dart';
 import 'incremental_candidate_validator.dart';
 import 'order_suggestion_context.dart';
 import 'order_visibility.dart';
-import 'unit_type_helpers.dart';
 
 const int _kMaxMoveSuggestionsPerUnit = 24;
 const int _kMaxArmyMoveSuggestionsPerArmy = 12;
@@ -257,6 +254,8 @@ List<ArmyMovePickerDestination> armyMovePickerDestinations({
     playerId: playerId,
     basePrefix: currentOrders,
   );
+  final declareWarTrialValidatorsByTargetFaction =
+      <String, IncrementalCandidateValidator>{};
   final out = <ArmyMovePickerDestination>[];
   for (final fullId in raw) {
     final province = game.worldState.tryGetProvince(fullId);
@@ -276,22 +275,27 @@ List<ArmyMovePickerDestination> armyMovePickerDestinations({
       )) {
         continue;
       }
-      final trial = ordersWithAppendedDiplomaticOrder(
-        currentOrders,
-        playerId,
-        DiplomaticOrder(
-          type: DiplomaticOrderType.declareWar,
-          targetFactionId: ownerId,
-        ),
-      );
       // Trial diplomatic context differs from [currentOrders] (extra declare
-      // war), so use a per-trial validator rather than the base one above.
-      final trialValidator = IncrementalCandidateValidator.forPlayer(
-        game: game,
-        topology: topology,
-        playerId: playerId,
-        basePrefix: trial,
-      );
+      // war on [ownerId]). Reuse one validator per target faction so multiple
+      // provinces with the same owner do not each pay a full PlayerView build
+      // (Refs #2394, SPEC/program/order-suggestions.md § Throughput bounds).
+      final trialValidator =
+          declareWarTrialValidatorsByTargetFaction.putIfAbsent(ownerId, () {
+        final trialOrders = ordersWithAppendedDiplomaticOrder(
+          currentOrders,
+          playerId,
+          DiplomaticOrder(
+            type: DiplomaticOrderType.declareWar,
+            targetFactionId: ownerId,
+          ),
+        );
+        return IncrementalCandidateValidator.forPlayer(
+          game: game,
+          topology: topology,
+          playerId: playerId,
+          basePrefix: trialOrders,
+        );
+      });
       if (!trialValidator.isArmyMoveAccepted(move)) {
         continue;
       }

--- a/packages/colonizethis_logic/test/army_move_picker_destinations_test.dart
+++ b/packages/colonizethis_logic/test/army_move_picker_destinations_test.dart
@@ -182,6 +182,84 @@ void main() {
     expect(inv.ownerFactionId, p2);
   });
 
+  test(
+    'two reachable enemy provinces of same owner both require declare war '
+    '(Refs #2394 trial-validator cache keyed by defender)',
+    () {
+    const p1 = 'gp1';
+    const p2 = 'gp2';
+    const loc1 = '$ow|P1';
+    const loc2 = '$ow|P2';
+    const loc3 = '$ow|P3';
+    final army = fieldArmy(ow, p1, 'P1', 'u1');
+    final topology = MapTopology(
+      nodes: const [
+        TopologyNode(id: 'P1', regionId: ow, type: TopologyNodeType.province),
+        TopologyNode(id: 'P2', regionId: ow, type: TopologyNodeType.province),
+        TopologyNode(id: 'P3', regionId: ow, type: TopologyNodeType.province),
+      ],
+      edges: const [
+        TopologyEdge(id1: 'P1', id2: 'P2'),
+        TopologyEdge(id1: 'P1', id2: 'P3'),
+      ],
+    );
+    final game = Game(
+      id: 'g_two_enemy_same_owner',
+      worldState: WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: RegionData(
+          provinces: [
+            Province(id: loc1, regionId: ow, ownerId: p1),
+            Province(id: loc2, regionId: ow, ownerId: p2),
+            Province(id: loc3, regionId: ow, ownerId: p2),
+          ],
+          units: [
+            Unit(
+              id: 'u1',
+              type: 'musketeers',
+              ownerId: p1,
+              locationProvinceId: loc1,
+            ),
+          ],
+        ),
+        newWorld: const RegionData(),
+        armies: [army],
+        playerVisibilityByTile: {
+          p1: vis([
+            (loc1, '$ow|P1|0|0'),
+            (loc2, '$ow|P2|0|0'),
+            (loc3, '$ow|P3|0|0'),
+          ]),
+        },
+        tileKeysByRegionAndProvince: {
+          ow: {
+            loc1: ['$ow|P1|0|0'],
+            loc2: ['$ow|P2|0|0'],
+            loc3: ['$ow|P3|0|0'],
+          },
+        },
+      ),
+      players: const [
+        Player(id: p1, displayName: 'A', isHuman: true),
+        Player(id: p2, displayName: 'B', isHuman: true),
+      ],
+      diplomacyRelations: const [],
+    );
+    final list = armyMovePickerDestinations(
+      game: game,
+      topology: topology,
+      playerId: p1,
+      army: army,
+      currentOrders: const Orders(),
+    );
+    final a = list.firstWhere((e) => e.fullProvinceId == loc2);
+    final b = list.firstWhere((e) => e.fullProvinceId == loc3);
+    expect(a.requiresDeclareWarOnConfirm, isTrue);
+    expect(b.requiresDeclareWarOnConfirm, isTrue);
+    expect(a.ownerFactionId, p2);
+    expect(b.ownerFactionId, p2);
+  });
+
   test('at war with enemy: invasion confirm not required', () {
     const p1 = 'gp1';
     const p2 = 'gp2';

--- a/tool/logic_all_provinces_sanctions.yaml
+++ b/tool/logic_all_provinces_sanctions.yaml
@@ -51,13 +51,13 @@ sanctions:
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
   - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
-    line: 164
+    line: 161
     rationale: Army move suggestions need global province ownership snapshot when per-pass player-owned province ids are not supplied.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
   - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
-    line: 244
+    line: 241
     rationale: Army move picker fallback builds owned-province ids across regions.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2394


### PR DESCRIPTION
## Summary
- Reuse `IncrementalCandidateValidator` instances in `armyMovePickerDestinations` keyed by declare-war **target faction id** when the picker needs a diplomatic trial, instead of constructing a fresh validator for every destination province that shares the same trial prefix.
- Removes three unused imports on `order_suggestion_move_army.dart` (analyzer warnings).

## Issue / SPEC
- **Refs #2394** — Category C / suggestion throughput (amortize `PlayerView` construction); behavior unchanged.
- **SPEC:** `SPEC/program/order-suggestions.md` § Throughput bounds (memoization / shared validation context).

## Tests
- `dart analyze lib/src/orders/order_suggestion_move_army.dart`
- `dart test test/army_move_picker_destinations_test.dart test/order_suggestion_army_move_picker_test.dart`

## Out of scope
- Broader `IncrementalCandidateValidator` replay caching (issue items 6–8) and AST benchmark gates remain for follow-up PRs.

Refs #2394

Made with [Cursor](https://cursor.com)