### PR TITLE
perf(logic): faction snapshot in work prechecks and land battle treasury (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/combat/military_attack_economy.dart
+++ b/packages/colonizethis_logic/lib/src/combat/military_attack_economy.dart
@@ -35,6 +35,7 @@ int landBattleAttackTreasuryCostForPlayer(Player player) {
 Game applyLandBattleAttackTreasuryCosts(Game game, BattleContext ctx) {
   final ids = <String>{for (final a in ctx.attackers) a.factionId};
   var players = game.players;
+  final factionMembership = DiplomacyFactionMembership.from(game);
   // O(1) player row lookup per attacker instead of O(P) indexWhere each time.
   // First index wins for duplicate ids (matches [List.indexWhere]) — Refs #2394.
   final playerIndexById = <String, int>{};
@@ -42,7 +43,7 @@ Game applyLandBattleAttackTreasuryCosts(Game game, BattleContext ctx) {
     playerIndexById.putIfAbsent(players[i].id, () => i);
   }
   for (final id in ids) {
-    if (!isGreatPower(game, id)) continue;
+    if (!isGreatPower(game, id, factionMembership: factionMembership)) continue;
     final p = game.playerById(id);
     if (p == null) continue;
     final cost = landBattleAttackTreasuryCostForPlayer(p);

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_target_prechecks.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_target_prechecks.dart
@@ -16,12 +16,17 @@ class WorkOrderTargetPrecheckContext {
     required this.playerId,
     required this.treasury,
     required this.civilianEmbassyWorkAllowed,
+    this.factionMembership,
   });
 
   final Game game;
   final Player player;
   final String playerId;
   final int treasury;
+
+  /// When set, avoids linear scans for Minor/Tribe checks in purchase-land
+  /// prevalidation (Refs #2394).
+  final DiplomacyFactionMembership? factionMembership;
 
   /// True when the unit may perform civilian work in a Minor/Tribe province
   /// with embassy + tech (validator-specific).
@@ -120,7 +125,11 @@ OrderValidationResult? precheckPurchaseLand(
       'purchase_land target must be a Minor or Tribe province',
     );
   }
-  if (!isMinorOrTribe(ctx.game, ownerId)) {
+  if (!isMinorOrTribe(
+    ctx.game,
+    ownerId,
+    factionMembership: ctx.factionMembership,
+  )) {
     return OrderValidationResult.rejected(
       'purchase_land target must be a Minor or Tribe province',
     );

--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
@@ -211,6 +211,7 @@ class WorkOrderValidator extends StatefulValidator {
       playerId: _context.playerId,
       treasury: treasuryState,
       civilianEmbassyWorkAllowed: _civilianWorkAllowedInMinorTribeProvince,
+      factionMembership: _context.factionMembership,
     );
     return runWorkOrderTargetPrecheck(
       preCtx,
@@ -444,7 +445,13 @@ class WorkOrderValidator extends StatefulValidator {
         unitType != kUnitTypeMerchant) {
       return false;
     }
-    if (!isMinorOrTribe(_context.game, provinceOwnerId)) return false;
+    if (!isMinorOrTribe(
+      _context.game,
+      provinceOwnerId,
+      factionMembership: _context.factionMembership,
+    )) {
+      return false;
+    }
     final rel = getRelation(_context.game, _context.playerId, provinceOwnerId);
     if (rel?.atWar == true) return false;
     final overture = getOverture(

--- a/packages/colonizethis_logic/test/orders/validators/work_order_target_prechecks_test.dart
+++ b/packages/colonizethis_logic/test/orders/validators/work_order_target_prechecks_test.dart
@@ -1,7 +1,10 @@
 import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_logic/src/diplomacy/diplomacy_resolver.dart';
 import 'package:colonizethis_logic/src/orders/validators/work_order_target_prechecks.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
+
+import '../../order_engine_purchase_land_test_support.dart';
 
 void main() {
   group('workOrderTargetPrechecks', () {
@@ -169,6 +172,56 @@ void main() {
             kWorkTargetBuildImprovement,
           }),
         );
+      },
+    );
+
+    test(
+      'precheckPurchaseLand matches with or without DiplomacyFactionMembership '
+      '(Refs #2394)',
+      () {
+        final game = PurchaseLandTestFixture.baseGame(
+          treasury: 500,
+          overtureStates: [
+            const OvertureState(
+              gpId: 'p1',
+              targetId: 'minor1',
+              stage: OvertureStage.embassy,
+              sinceTurn: 0,
+            ),
+          ],
+        );
+        final player = game.players.single;
+        final membership = DiplomacyFactionMembership.from(game);
+        WorkOrderTargetPrecheckContext ctx({required bool withSnap}) =>
+            WorkOrderTargetPrecheckContext(
+              game: game,
+              player: player,
+              playerId: 'p1',
+              treasury: 500,
+              civilianEmbassyWorkAllowed: (_, __) => false,
+              factionMembership: withSnap ? membership : null,
+            );
+        final order = WorkOrder(
+          unitId: 'merchant1',
+          target: kWorkTargetPurchaseLand,
+          targetTileKey: PurchaseLandTestFixture.tileKey,
+        );
+        final withSnap = runWorkOrderTargetPrecheck(
+          ctx(withSnap: true),
+          order,
+          PurchaseLandTestFixture.minorProvinceId,
+          'minor1',
+          kUnitTypeMerchant,
+        );
+        final linear = runWorkOrderTargetPrecheck(
+          ctx(withSnap: false),
+          order,
+          PurchaseLandTestFixture.minorProvinceId,
+          'minor1',
+          kUnitTypeMerchant,
+        );
+        expect(withSnap, isNull);
+        expect(linear, isNull);
       },
     );
 


### PR DESCRIPTION
## Summary
Refs #2394.

- **`WorkOrderTargetPrecheckContext`**: optional `DiplomacyFactionMembership`; `precheckPurchaseLand` uses it for O(1) Minor/Tribe classification when provided.
- **`WorkOrderValidator`**: passes `WorkOrderValidationContext.factionMembership` into precheck context and uses the same snapshot in `_civilianWorkAllowedInMinorTribeProvince`.
- **`applyLandBattleAttackTreasuryCosts`**: builds `DiplomacyFactionMembership.from(game)` once per call so each attacker avoids repeated `players.any` scans.

## Out of scope / deferred
- Broader #2394 items (validator once per suggestion pass, movement-phase list copies, AST lints, benchmarks) remain for follow-up PRs.

## SPEC
No change: internal perf only; behavior and acceptance/reject outcomes unchanged (`SPEC/program/order-suggestions.md`, `SPEC/program/turn-resolution.md` throughput guidance).

## Tests
- `flutter test test/orders/validators/work_order_target_prechecks_test.dart test/military_attack_economy_test.dart`

## AC mapping
- Aligns with #2394 Category C (diplomacy faction `.any()` hot paths) and shared-snapshot pattern; does not complete the full issue checklist.

Made with [Cursor](https://cursor.com)