### PR TITLE
perf(logic): first player row index map for diplomacy paths (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/combat/military_attack_economy.dart
+++ b/packages/colonizethis_logic/lib/src/combat/military_attack_economy.dart
@@ -36,11 +36,7 @@ Game applyLandBattleAttackTreasuryCosts(Game game, BattleContext ctx) {
   final ids = <String>{for (final a in ctx.attackers) a.factionId};
   var players = game.players;
   // O(1) player row lookup per attacker instead of O(P) indexWhere each time.
-  // First index wins for duplicate ids (matches [List.indexWhere]) — Refs #2394.
-  final playerIndexById = <String, int>{};
-  for (var i = 0; i < players.length; i++) {
-    playerIndexById.putIfAbsent(players[i].id, () => i);
-  }
+  final playerIndexById = firstPlayerRowIndexById(players);
   for (final id in ids) {
     if (!isGreatPower(game, id)) continue;
     final p = game.playerById(id);

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_relation_lookup.dart
@@ -74,6 +74,16 @@ int joinEmpireCostForMinorOrTribe(Game game, String targetId) {
   return joinEmpireBaseCost + n * joinEmpirePerProvinceCost;
 }
 
+/// First row index per [Player.id] in [players] (matches [Iterable.indexWhere]
+/// for the first matching id). Refs #2394.
+Map<String, int> firstPlayerRowIndexById(List<Player> players) {
+  final m = <String, int>{};
+  for (var i = 0; i < players.length; i++) {
+    m.putIfAbsent(players[i].id, () => i);
+  }
+  return m;
+}
+
 // --- Relation score bounds and thresholds. SPEC/game/diplomacy.md. ---
 
 /// Relation score range: min and max (inclusive).

--- a/packages/colonizethis_logic/lib/src/diplomacy/faction_absorption_engine.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/faction_absorption_engine.dart
@@ -92,17 +92,18 @@ Game _absorbIntoGp(
 }) {
   final cost = joinEmpireCostForMinorOrTribe(game, absorbedFactionId);
   var players = List<Player>.from(game.players);
-  final gpIdx = players.indexWhere((p) => p.id == gpId);
+  final playerIdxById = firstPlayerRowIndexById(players);
+  final gpIdx = playerIdxById[gpId];
 
   if (kind == _AbsorptionKind.greatPower) {
-    final targetIdx = players.indexWhere((p) => p.id == absorbedFactionId);
-    if (gpIdx < 0 || targetIdx < 0) return game;
+    final targetIdx = playerIdxById[absorbedFactionId];
+    if (gpIdx == null || targetIdx == null) return game;
     players[gpIdx] = players[gpIdx].copyWith(
       treasury: players[gpIdx].treasury - cost,
     );
     players.removeAt(targetIdx);
   } else {
-    if (gpIdx >= 0) {
+    if (gpIdx != null) {
       players = List<Player>.from(players);
       players[gpIdx] = players[gpIdx].copyWith(
         treasury: players[gpIdx].treasury - cost,

--- a/packages/colonizethis_logic/lib/src/diplomacy/overture_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/overture_resolver.dart
@@ -344,11 +344,14 @@ OverturePaymentsResult processOverturePayments(
   var players = List<Player>.from(game.players);
   var overtures = List<OvertureState>.from(game.overtureStates);
   var state = game;
+  // One O(P) pass; [players] length/order stay stable while processing
+  // establish-overture orders (only in-place row updates). Refs #2394.
+  final playerIdxById = firstPlayerRowIndexById(players);
 
   for (final entry in diploByPlayer.entries) {
     final gpId = entry.key;
-    final playerIdx = players.indexWhere((p) => p.id == gpId);
-    if (playerIdx < 0) continue;
+    final playerIdx = playerIdxById[gpId];
+    if (playerIdx == null) continue;
     var player = players[playerIdx];
 
     for (final order in entry.value) {

--- a/packages/colonizethis_logic/test/diplomacy/first_player_row_index_by_id_test.dart
+++ b/packages/colonizethis_logic/test/diplomacy/first_player_row_index_by_id_test.dart
@@ -1,0 +1,35 @@
+import 'package:colonizethis_logic/src/diplomacy/diplomacy_relation_lookup.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('firstPlayerRowIndexById', () {
+    test('empty list yields empty map', () {
+      expect(firstPlayerRowIndexById(const <Player>[]), isEmpty);
+    });
+
+    test('maps each id to its first row index', () {
+      const players = [
+        Player(id: 'a', displayName: 'A', isHuman: false),
+        Player(id: 'b', displayName: 'B', isHuman: false),
+        Player(id: 'c', displayName: 'C', isHuman: false),
+      ];
+      expect(
+        firstPlayerRowIndexById(players),
+        equals(<String, int>{'a': 0, 'b': 1, 'c': 2}),
+      );
+    });
+
+    test('duplicate ids keep earliest index (indexWhere semantics)', () {
+      const players = [
+        Player(id: 'dup', displayName: 'First', isHuman: false),
+        Player(id: 'other', displayName: 'X', isHuman: false),
+        Player(id: 'dup', displayName: 'Second', isHuman: false),
+      ];
+      expect(
+        firstPlayerRowIndexById(players)['dup'],
+        0,
+      );
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/diplomacy/first_player_row_index_by_id_test.dart
+++ b/packages/colonizethis_logic/test/diplomacy/first_player_row_index_by_id_test.dart
@@ -1,6 +1,7 @@
+import 'package:colonizethis_test/test.dart';
+
 import 'package:colonizethis_logic/src/diplomacy/diplomacy_relation_lookup.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:test/test.dart';
 
 void main() {
   group('firstPlayerRowIndexById', () {


### PR DESCRIPTION
## Summary
Adds `firstPlayerRowIndexById` in `diplomacy_relation_lookup.dart` (first index per id, matching `List.indexWhere` semantics) and uses it where repeated `indexWhere` over `game.players` was redundant or could be amortized.

## Scope (this PR)
- **`processOverturePayments`**: one O(P) map at start of the pass; lookups per `diploByPlayer` key are O(1). Safe because establish-overture handling only mutates player rows in place (same length/order).
- **`_absorbIntoGp`**: single map for GP and absorbed target indices.
- **`applyLandBattleAttackTreasuryCosts`**: reuse shared helper (behavior unchanged).

## Out of scope / deferred
- Broader #2394 items (validator sharing, movement-phase copies, AST lints, benchmarks) remain for other PRs.

## SPEC
No behavior change; performance-only refactor authorized under `SPEC/program/turn-resolution.md` and `SPEC/program/order-suggestions.md` throughput guidance (Refs #2394).

## Tests
- `flutter test test/diplomacy/first_player_row_index_by_id_test.dart test/diplomacy_resolver_phase_test_part1_test.dart`

Refs #2394

Made with [Cursor](https://cursor.com)