### PR TITLE
refactor(logic): add lib/src logging barrel for shared logicLog (#2391)

### DIFF
--- a/packages/colonizethis_logic/lib/package_logger.dart
+++ b/packages/colonizethis_logic/lib/package_logger.dart
@@ -11,6 +11,9 @@ CtLogger packageLogger([String? subPrefix]) {
 
 /// Shared package-level [CtLogger] for `colonizethis_logic` source files.
 ///
+/// `lib/src/**` should import [logicLog] via `package:colonizethis_logic/src/logging.dart`
+/// (Refs #2391 AC5) instead of importing this file directly.
+///
 /// Every `lib/src/**/*.dart` file that previously declared a private
 /// `final _log = packageLogger();` should import and reuse [logicLog] instead.
 /// Named module loggers that keep the default `logic:` prefix should alias

--- a/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
+++ b/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
@@ -5,7 +5,7 @@ library;
 import 'dart:math' as math;
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';

--- a/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';

--- a/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/naval_combat_resolver.dart
@@ -2,7 +2,7 @@
 // Interception and retreat: SPEC/game/ships-and-naval.md.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../diplomacy/diplomacy_relation_lookup.dart';

--- a/packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';

--- a/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/diplomacy_resolver.dart
@@ -5,7 +5,7 @@
 /// relation modifiers, score update.
 library;
 
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';

--- a/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
+++ b/packages/colonizethis_logic/lib/src/dossier/evidence_rules.dart
@@ -2,7 +2,7 @@
 // When diplomatic (or other) actions are applied, evidence rules add suspicion points per agenda type.
 // Evidence is stored per (observer, subject, agenda type); only human observers receive entries.
 
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';

--- a/packages/colonizethis_logic/lib/src/economy/economy_consumption.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_consumption.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 /// Thrown when [resolveConsumption] sees a ship type id not in [ShipEconomyCatalog].

--- a/packages/colonizethis_logic/lib/src/economy/economy_extraction.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_extraction.dart
@@ -1,4 +1,4 @@
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../world/player_state_pipeline.dart';

--- a/packages/colonizethis_logic/lib/src/economy/economy_production.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_production.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 /// Production resolution helpers.

--- a/packages/colonizethis_logic/lib/src/economy/economy_riches_to_treasury.dart
+++ b/packages/colonizethis_logic/lib/src/economy/economy_riches_to_treasury.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 /// Riches-to-treasury phase: convert riches in stockpile to treasury at base price.

--- a/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
+++ b/packages/colonizethis_logic/lib/src/economy/resource_extractor.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';

--- a/packages/colonizethis_logic/lib/src/economy/sea_transport.dart
+++ b/packages/colonizethis_logic/lib/src/economy/sea_transport.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
 

--- a/packages/colonizethis_logic/lib/src/event_bus/game_event_logger.dart
+++ b/packages/colonizethis_logic/lib/src/event_bus/game_event_logger.dart
@@ -1,4 +1,4 @@
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 
 import '../game_events.dart';
 

--- a/packages/colonizethis_logic/lib/src/logging.dart
+++ b/packages/colonizethis_logic/lib/src/logging.dart
@@ -1,0 +1,8 @@
+/// Shared logging entrypoints for `lib/src/**` (Refs #2391 AC5).
+///
+/// Import this library instead of reaching for [package_logger] directly so
+/// package-level logging stays on one canonical path.
+library;
+
+export 'package:colonizethis_logic/package_logger.dart'
+    show CtLogger, logicLog, packageLogger;

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'order_projections.dart';

--- a/packages/colonizethis_logic/lib/src/orders/order_projections.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_projections.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_api_impl.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_api_impl.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'order_suggestion.dart' as suggestion;

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_context.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_context.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../world/player_view.dart';

--- a/packages/colonizethis_logic/lib/src/orders/orders_application_context.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_context.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../turn/trace/turn_trace_runtime.dart';

--- a/packages/colonizethis_logic/lib/src/orders/work_handlers/explore_work_handler.dart
+++ b/packages/colonizethis_logic/lib/src/orders/work_handlers/explore_work_handler.dart
@@ -1,4 +1,4 @@
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../constants.dart';

--- a/packages/colonizethis_logic/lib/src/orders/work_handlers/shared_work_assignment.dart
+++ b/packages/colonizethis_logic/lib/src/orders/work_handlers/shared_work_assignment.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../constants.dart';

--- a/packages/colonizethis_logic/lib/src/orders/work_handlers/standard_work_handler.dart
+++ b/packages/colonizethis_logic/lib/src/orders/work_handlers/standard_work_handler.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../constants.dart';

--- a/packages/colonizethis_logic/lib/src/setup/game_setup_context.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup_context.dart
@@ -1,4 +1,4 @@
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 
 /// Same runtime prefix as [logicLog]; kept for readable call sites in setup.
 final gameSetupLog = logicLog;

--- a/packages/colonizethis_logic/lib/src/setup/gp_old_world_resource_redistribution.dart
+++ b/packages/colonizethis_logic/lib/src/setup/gp_old_world_resource_redistribution.dart
@@ -3,7 +3,7 @@
 import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';

--- a/packages/colonizethis_logic/lib/src/setup/gp_old_world_terrain_redistribution.dart
+++ b/packages/colonizethis_logic/lib/src/setup/gp_old_world_terrain_redistribution.dart
@@ -1,7 +1,7 @@
 // SPEC/game/tile-map-and-generation.md; SPEC/program/game-setup-pipeline.md (§7d.terrain).
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';

--- a/packages/colonizethis_logic/lib/src/setup/gp_starting_grain.dart
+++ b/packages/colonizethis_logic/lib/src/setup/gp_starting_grain.dart
@@ -1,7 +1,7 @@
 // SPEC/game/tile-map-and-generation.md § Great Power starting grain (bootstrap).
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';

--- a/packages/colonizethis_logic/lib/src/setup/init_game_orchestrator.dart
+++ b/packages/colonizethis_logic/lib/src/setup/init_game_orchestrator.dart
@@ -4,7 +4,7 @@
 import 'dart:typed_data';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 

--- a/packages/colonizethis_logic/lib/src/setup/init_town_roads.dart
+++ b/packages/colonizethis_logic/lib/src/setup/init_town_roads.dart
@@ -3,7 +3,7 @@
 import 'dart:collection';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';

--- a/packages/colonizethis_logic/lib/src/setup/locked_province_assigner.dart
+++ b/packages/colonizethis_logic/lib/src/setup/locked_province_assigner.dart
@@ -2,7 +2,7 @@
 
 import 'dart:math';
 
-import '../../package_logger.dart' show logicLog;
+import 'package:colonizethis_logic/src/logging.dart' show logicLog;
 
 /// When true (`dart run --define=CT_TRACE_LOCKED_ASSIGNER_DFS=true`),
 /// prints every DFS branch to stdout (tabu skips, greedy prunes, try_push with

--- a/packages/colonizethis_logic/lib/src/setup/warp_zone_generator.dart
+++ b/packages/colonizethis_logic/lib/src/setup/warp_zone_generator.dart
@@ -4,7 +4,7 @@
 import 'dart:math';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 
 /// Picks one representative sea zone per map edge (top, bottom, left, right).
 /// Returns a map of edge name ('top', 'bottom', 'left', 'right') to sea zone id.

--- a/packages/colonizethis_logic/lib/src/turn/combat_phase_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/turn/combat_phase_helpers.dart
@@ -1,7 +1,7 @@
 // Helpers for the combat phase: apply one land battle (quick or auto-resolve), evidence, dialogue.
 // SPEC/program/turn-resolution-phase-details.md § Combat. Called from turn_resolver._runCombatPhase.
 
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../combat/battle_general_assignment.dart';

--- a/packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
@@ -3,7 +3,7 @@
 // Called from turn_resolver.resolveTurnForGame.
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../dossier/event_dialogue.dart';

--- a/packages/colonizethis_logic/lib/src/turn/phases/combat_phase.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases/combat_phase.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../combat/battle_general_assignment.dart';

--- a/packages/colonizethis_logic/lib/src/turn/research_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/research_resolver.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';

--- a/packages/colonizethis_logic/lib/src/turn/turn_phase_runner.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_phase_runner.dart
@@ -1,4 +1,4 @@
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../diplomacy/diplomacy_resolver.dart';

--- a/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_resolver.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../event_bus/game_event_bus.dart';

--- a/packages/colonizethis_logic/lib/src/world/army_movement.dart
+++ b/packages/colonizethis_logic/lib/src/world/army_movement.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
 

--- a/packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
+++ b/packages/colonizethis_logic/lib/src/world/capital_and_gp_fall.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../setup/capital_choice.dart';

--- a/packages/colonizethis_logic/lib/src/world/civilian_ownership_legality.dart
+++ b/packages/colonizethis_logic/lib/src/world/civilian_ownership_legality.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';

--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -1,7 +1,7 @@
 import 'dart:collection';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../utils/graph_traversal.dart';

--- a/packages/colonizethis_logic/lib/src/world/movement.dart
+++ b/packages/colonizethis_logic/lib/src/world/movement.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:logger/logger.dart';
 

--- a/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
@@ -1,5 +1,5 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../combat/naval_combat_resolver.dart';

--- a/packages/colonizethis_logic/test/package_logger_shared_test.dart
+++ b/packages/colonizethis_logic/test/package_logger_shared_test.dart
@@ -4,31 +4,41 @@
 // the package exposes a single shared `logicLog` whose prefix matches the
 // package log prefix `logic` and forwards through `CtLogger`.
 
+import 'package:colonizethis_logger/colonizethis_logger.dart' show CtLogger;
 import 'package:colonizethis_logic/package_log_prefix.dart';
-import 'package:colonizethis_logic/package_logger.dart';
+import 'package:colonizethis_logic/package_logger.dart'
+    as pkg_logger
+    show logicLog, packageLogger;
+import 'package:colonizethis_logic/src/logging.dart' as logic_logging;
 import 'package:colonizethis_test/test.dart';
 import 'package:logger/logger.dart' show Level, LogEvent, Logger;
 
 void main() {
   group('packageLogger / logicLog (Refs #2391)', () {
     test('logicLog prefix matches kPackageLogPrefix', () {
-      expect(logicLog, isA<CtLogger>());
-      expect(logicLog.prefix, equals(kPackageLogPrefix));
+      expect(pkg_logger.logicLog, isA<CtLogger>());
+      expect(pkg_logger.logicLog.prefix, equals(kPackageLogPrefix));
       expect(kPackageLogPrefix, equals('logic'));
     });
 
+    test('lib/src/logging.dart barrel re-exports the same logicLog (AC5)', () {
+      expect(identical(pkg_logger.logicLog, logic_logging.logicLog), isTrue);
+    });
+
     test('logicLog is the single shared instance for the package', () {
-      final first = logicLog;
-      final second = logicLog;
+      final first = pkg_logger.logicLog;
+      final second = pkg_logger.logicLog;
       expect(identical(first, second), isTrue);
     });
 
-    test('packageLogger() still returns a fresh logger with the same prefix',
-        () {
-      final fresh = packageLogger();
-      expect(fresh.prefix, equals(logicLog.prefix));
-      expect(identical(fresh, logicLog), isFalse);
-    });
+    test(
+      'packageLogger() still returns a fresh logger with the same prefix',
+      () {
+        final fresh = pkg_logger.packageLogger();
+        expect(fresh.prefix, equals(pkg_logger.logicLog.prefix));
+        expect(identical(fresh, pkg_logger.logicLog), isFalse);
+      },
+    );
 
     test('logicLog emits messages with the `logic:` prefix', () {
       final captured = <LogEvent>[];
@@ -37,13 +47,14 @@ void main() {
       final priorLevel = Logger.level;
       Logger.level = Level.debug;
       try {
-        logicLog.i('shared_logger_smoke');
+        pkg_logger.logicLog.i('shared_logger_smoke');
       } finally {
         Logger.removeLogListener(listener);
         Logger.level = priorLevel;
       }
-      final messages =
-          captured.map((e) => e.message?.toString() ?? '').toList();
+      final messages = captured
+          .map((e) => e.message?.toString() ?? '')
+          .toList();
       expect(
         messages.any((m) => m.contains('logic: shared_logger_smoke')),
         isTrue,


### PR DESCRIPTION
## Summary
Completes the **AC5 logging entrypoint** slice for GitHub #2391: `packages/colonizethis_logic/lib/src/**` now imports the shared logger surface through a single barrel (`lib/src/logging.dart`) instead of reaching for `package_logger.dart` directly.

## Done in this PR
- New `lib/src/logging.dart` re-exporting `logicLog`, `packageLogger`, and `CtLogger` from `package_logger.dart`.
- All `lib/src/**/*.dart` files that previously imported `package:colonizethis_logic/package_logger.dart` (including `locked_province_assigner`) now import `package:colonizethis_logic/src/logging.dart`.
- `package_logger.dart` doc comment updated to steer `lib/src` consumers to the barrel.
- Positive test: `package_logger_shared_test.dart` asserts the barrel exposes the **same** `logicLog` instance as `package_logger.dart`.

## Deferred (issue remains open)
- Remaining #2391 AC items (ValidatorBundle loop polish, diplomatic validator split, `order_engine` descriptor-only loop, CI severity promotion narrative, etc.) are unchanged and still tracked on the issue.

## Tests
- `cd packages/colonizethis_logic && dart test test/package_logger_shared_test.dart`
- `cd packages/colonizethis_logic && dart test test/order_engine_validate_build_civilian_test.dart`
- `dart run tool/check_logic_dedup_logger.dart`

Refs #2391

Made with [Cursor](https://cursor.com)