### PR TITLE
perf(integration): memoize e2e 64px preload and trim settle waits (#2336)

### DIFF
--- a/app/integration_test/e2e_test_shared.dart
+++ b/app/integration_test/e2e_test_shared.dart
@@ -508,12 +508,22 @@ Future<void> _e2eTapGameStartIntroOverlayContinueIfPresent(
 ) async {
   if (find.text('Continue').evaluate().isNotEmpty) {
     await tester.tap(find.text('Continue').first);
-    await tester.pump(const Duration(milliseconds: 200));
+    await e2ePumpUntilConditionOrIdle(
+      tester,
+      () => find.byType(GameStartIntroOverlay).evaluate().isEmpty,
+      timeout: const Duration(milliseconds: 800),
+      phaseName: 'pump_until_intro_dismissed_after_continue',
+    );
     return;
   }
   if (find.text('I shall.').evaluate().isNotEmpty) {
     await tester.tap(find.text('I shall.').first);
-    await tester.pump(const Duration(milliseconds: 200));
+    await e2ePumpUntilConditionOrIdle(
+      tester,
+      () => find.byType(GameStartIntroOverlay).evaluate().isEmpty,
+      timeout: const Duration(milliseconds: 800),
+      phaseName: 'pump_until_intro_dismissed_after_i_shall',
+    );
   }
 }
 
@@ -685,9 +695,11 @@ Future<void> e2eEnsureRelocated64pxPngDecode(
 /// Asserts the manifest matches the canonical map icon families, then decodes
 /// every PNG via [e2eDecodePngAssetPathsParallel] (bounded concurrency).
 ///
-/// Used by new-game E2E tests that need the same warm-cache behavior; callers
-/// should still invoke at most once per [testWidgets] unless a future shared
-/// fixture deduplicates across tests (GitHub #2336).
+/// Used by new-game E2E tests that need the same warm-cache behavior.
+///
+/// Prefer [e2eEnsureAllRelocated64pxPngsLoadSuiteOnce] when each scenario needs
+/// the same decode/assert path so work runs at most once per test VM (GitHub
+/// #2336 AC3).
 Future<void> e2eEnsureAllRelocated64pxPngsLoad() async {
   await e2eEnsureRelocated64pxPngDecode(<String>{
     ...kCivilianIconSlugs.map(
@@ -702,4 +714,15 @@ Future<void> e2eEnsureAllRelocated64pxPngsLoad() async {
     ),
     kFleetMapIcon64PngAssetPath,
   });
+}
+
+Future<void>? _e2eAllRelocated64pxPngLoadSuiteFuture;
+
+/// Runs [e2eEnsureAllRelocated64pxPngsLoad] at most once per isolate.
+///
+/// Subsequent calls await the same future so multiple E2E scenarios in one run
+/// do not repeat manifest + parallel decode work (GitHub #2336 AC3).
+Future<void> e2eEnsureAllRelocated64pxPngsLoadSuiteOnce() async {
+  _e2eAllRelocated64pxPngLoadSuiteFuture ??= e2eEnsureAllRelocated64pxPngsLoad();
+  return _e2eAllRelocated64pxPngLoadSuiteFuture!;
 }

--- a/app/integration_test/new_game_capital_panel_e2e_test.dart
+++ b/app/integration_test/new_game_capital_panel_e2e_test.dart
@@ -34,7 +34,7 @@ void main() {
     await e2eWaitForNewGameEntry(tester, perf: perf);
     perf.timing('bootstrap_for_integration_test', bootstrapSw.elapsed);
     final preloadSw = Stopwatch()..start();
-    await e2eEnsureAllRelocated64pxPngsLoad();
+    await e2eEnsureAllRelocated64pxPngsLoadSuiteOnce();
     perf.timing('asset_preload', preloadSw.elapsed);
 
     final newGameToMapSw = Stopwatch()..start();

--- a/app/integration_test/new_game_full_turn_e2e_test.dart
+++ b/app/integration_test/new_game_full_turn_e2e_test.dart
@@ -248,7 +248,12 @@ Future<void> _tapAssignOnCivilianRowWithTitle(
   while (titlesInList.evaluate().isEmpty &&
       sw.elapsed < const Duration(seconds: 20)) {
     await tester.drag(panelScrollable, const Offset(0, -120));
-    await e2ePumpFor(tester, const Duration(milliseconds: 120));
+    await e2ePumpUntilConditionOrIdle(
+      tester,
+      () => titlesInList.evaluate().isNotEmpty,
+      timeout: const Duration(milliseconds: 200),
+      phaseName: 'pump_until_civilian_title_visible_after_scroll_drag',
+    );
   }
   expect(
     titlesInList,
@@ -312,7 +317,7 @@ void main() {
       await e2eWaitForNewGameEntry(tester, perf: perf);
       perf.timing('bootstrap_for_integration_test', bootstrapSw.elapsed);
       final preloadSw = Stopwatch()..start();
-      await e2eEnsureAllRelocated64pxPngsLoad();
+      await e2eEnsureAllRelocated64pxPngsLoadSuiteOnce();
       perf.timing('asset_preload', preloadSw.elapsed);
 
       final newGameSw = Stopwatch()..start();


### PR DESCRIPTION
## Tracked by #2336

### Done in this push
- **AC3 (partial):** Added `e2eEnsureAllRelocated64pxPngsLoadSuiteOnce` so relocated 64px PNG manifest + parallel decode runs at most once per test isolate; `new_game_full_turn_e2e_test` and `new_game_capital_panel_e2e_test` now call it so a single process running both scenarios avoids a second full decode pass.
- **AC5 / bootstrap path:** Replaced fixed 200ms post-tap pumps in `_e2eTapGameStartIntroOverlayContinueIfPresent` with `e2ePumpUntilConditionOrIdle` waiting for `GameStartIntroOverlay` to leave the tree (bounded).
- **AC4 / H9-adjacent:** In `_tapAssignOnCivilianRowWithTitle` (full-turn E2E), replaced fixed 120ms `e2ePumpFor` per scroll-drag iteration with adaptive `e2ePumpUntilConditionOrIdle` for the in-list title finder (bounded 200ms per iteration).

### Deferred (follow-up commits / PRs on same issue)
- Full **AC8–AC10** baseline vs after measurement table (local 3-run median) — not captured in this slice; run when more of the suite is refactored for aggregate ≥25% claim.
- Remaining **H5–H10** and other files (`bundled_explore`, etc.) not touched here.
- **AC1–AC2** shared-helper consolidation beyond this entry point.

### Verification (local)
- `cd app && flutter analyze integration_test/e2e_test_shared.dart integration_test/new_game_full_turn_e2e_test.dart integration_test/new_game_capital_panel_e2e_test.dart` — clean.

Refs #2336

Made with [Cursor](https://cursor.com)