### PR TITLE
perf: precompute pending work unit ids in work-target cache (#2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/ai/ai_planner.dart
+++ b/packages/colonizethis_logic/lib/src/ai/ai_planner.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../world/army_migration.dart';
 import 'ai_control.dart';
 import 'simple_ai_heuristics.dart';
 
@@ -16,6 +17,9 @@ Orders generateOrdersForPlayer(
   MapTopology topology,
   String playerId, {
   Map<String, TileMapResult>? tileMapByRegion,
+  /// When true, [game] must already satisfy [ensureMilitaryArmiesForGame]
+  /// (used by [generateOrdersForGame] after a single batch ensure).
+  bool armiesAlreadyEnsured = false,
 }) {
   final player = game.playerById(playerId);
   if (player == null || !isAiControlled(game, player.id)) {
@@ -30,6 +34,7 @@ Orders generateOrdersForPlayer(
     player.id,
     turnSeed,
     tileMapByRegion: tileMapByRegion,
+    skipEnsureMilitaryArmies: armiesAlreadyEnsured,
   );
 }
 
@@ -55,13 +60,15 @@ Orders generateOrdersForGame(
   final workByPlayer = <String, List<WorkOrder>>{};
   final researchByPlayer = <String, List<ResearchOrder>>{};
 
+  final gameWithArmies = ensureMilitaryArmiesForGame(game);
   for (final player in game.players) {
     if (!isAiControlled(game, player.id)) continue;
     final ordersForPlayer = generateOrdersForPlayer(
-      game,
+      gameWithArmies,
       topology,
       player.id,
       tileMapByRegion: tileMapByRegion,
+      armiesAlreadyEnsured: true,
     );
     _addOrdersIfNonEmpty(moveByPlayer, player.id, ordersForPlayer.moveOrdersByPlayerId[player.id]);
     _addOrdersIfNonEmpty(

--- a/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
+++ b/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
@@ -248,13 +248,19 @@ Orders generateOrdersWithSimpleHeuristics(
   String playerId,
   int turnSeed, {
   Map<String, TileMapResult>? tileMapByRegion,
+  /// When true, [game] is used as-is (callers must already have run
+  /// [ensureMilitaryArmiesForGame]). Used by [generateOrdersForGame] to avoid
+  /// O(players) redundant full-world army reconciliation (Refs #2394).
+  bool skipEnsureMilitaryArmies = false,
 }) {
   final player = game.playerById(playerId);
   if (player == null) {
     return const Orders();
   }
 
-  final g = ensureMilitaryArmiesForGame(game);
+  final g = skipEnsureMilitaryArmies
+      ? game
+      : ensureMilitaryArmiesForGame(game);
   final factionMembership = DiplomacyFactionMembership.from(g);
   final rng = math.Random(turnSeed);
   var current = const Orders();

--- a/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
+++ b/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
@@ -9,6 +9,7 @@ import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../diplomacy/diplomacy_resolver.dart';
 import '../orders/draft_orders_mutations.dart';
 import '../orders/incremental_candidate_validator.dart';
 import '../orders/order_suggestion.dart';
@@ -254,6 +255,7 @@ Orders generateOrdersWithSimpleHeuristics(
   }
 
   final g = ensureMilitaryArmiesForGame(game);
+  final factionMembership = DiplomacyFactionMembership.from(g);
   final rng = math.Random(turnSeed);
   var current = const Orders();
   final view = buildPlayerView(g, topology, player.id);
@@ -279,6 +281,7 @@ Orders generateOrdersWithSimpleHeuristics(
       tileMapByRegion: tileMapByRegion,
       view: view,
       unitsById: unitsById,
+      factionMembership: factionMembership,
     );
     final moveSuggestions = suggestMoveOrders(
       view,

--- a/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
@@ -32,6 +32,7 @@ class IncrementalCandidateValidator {
     required this.unitsById,
     required this.diplomaticOrders,
     required this.tileMapByRegion,
+    this.prefetchedFactionMembership,
   });
 
   /// Builds a validator bound to the given `basePrefix` and player. Reuse one
@@ -53,6 +54,11 @@ class IncrementalCandidateValidator {
     Map<String, TileMapResult>? tileMapByRegion,
     PlayerView? view,
     Map<String, Unit>? unitsById,
+    /// When callers rebuild this validator for many `basePrefix` snapshots over
+    /// the same [game] (for example simple-heuristic iterations), supplying the
+    /// membership snapshot avoids repeated `DiplomacyFactionMembership.from`
+    /// work. Must remain valid for [game] for the validator lifetime (Refs #2394).
+    DiplomacyFactionMembership? factionMembership,
   }) {
     assert(
       view == null || view.playerId == playerId,
@@ -72,6 +78,7 @@ class IncrementalCandidateValidator {
       unitsById: actualUnitsById,
       diplomaticOrders: diplomaticOrders,
       tileMapByRegion: tileMapByRegion,
+      prefetchedFactionMembership: factionMembership,
     );
   }
 
@@ -83,6 +90,7 @@ class IncrementalCandidateValidator {
   final Map<String, Unit> unitsById;
   final List<DiplomaticOrder> diplomaticOrders;
   final Map<String, TileMapResult>? tileMapByRegion;
+  final DiplomacyFactionMembership? prefetchedFactionMembership;
   Set<String>? _cachedDevExclusiveTiles;
   Set<String>? _cachedCivilianDraftMoveUnitIds;
   ({Stockpile stockpile, int treasury})? _cachedEconomyAfterBuildOrders;
@@ -98,6 +106,10 @@ class IncrementalCandidateValidator {
   NavalOrderValidator? _cachedNavalOrderValidator;
 
   DiplomacyFactionMembership _factionMembership() {
+    final pre = prefetchedFactionMembership;
+    if (pre != null) {
+      return pre;
+    }
     final cached = _cachedFactionMembership;
     if (cached != null) {
       return cached;

--- a/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
@@ -111,6 +111,11 @@ class IncrementalCandidateValidator {
   DiplomacyFactionMembership? _cachedFactionMembership;
   NavalOrderValidator? _cachedNavalOrderValidator;
 
+  /// When [false], existing diplomatic orders in [basePrefix] failed incremental
+  /// replay; every [isDiplomaticAccepted] probe must reject (Refs #2394).
+  bool? _cachedDiplomaticPrefixReplaySucceeded;
+  DiplomaticPrefixCheckpoint? _cachedPostDiplomaticPrefixState;
+
   DiplomacyFactionMembership _factionMembership() {
     final pre = prefetchedFactionMembership;
     if (pre != null) {
@@ -302,18 +307,42 @@ class IncrementalCandidateValidator {
   bool isDiplomaticAccepted(DiplomaticOrder candidate) {
     final player = _player();
     if (player == null) return false;
+    if (_cachedDiplomaticPrefixReplaySucceeded == false) {
+      return false;
+    }
     final economy = _projectEconomyAfterAcceptedBuildAndWorkOrders(player);
-    final validator = DiplomaticOrderValidator(
+    final membership = _factionMembership();
+
+    if (_cachedPostDiplomaticPrefixState == null) {
+      final prefixValidator = DiplomaticOrderValidator(
+        game: game,
+        playerId: playerId,
+        initialTreasury: economy.treasury,
+        factionMembership: membership,
+      );
+      for (final existing in diplomaticOrders) {
+        final result = prefixValidator.validate(
+          existing,
+          previousRejected: false,
+        );
+        if (!result.result.isAccepted) {
+          _cachedDiplomaticPrefixReplaySucceeded = false;
+          return false;
+        }
+      }
+      _cachedDiplomaticPrefixReplaySucceeded = true;
+      _cachedPostDiplomaticPrefixState =
+          prefixValidator.capturePrefixCheckpoint();
+    }
+
+    final checkpoint = _cachedPostDiplomaticPrefixState!;
+    final candidateValidator = DiplomaticOrderValidator.fromPrefixCheckpoint(
       game: game,
       playerId: playerId,
-      initialTreasury: economy.treasury,
-      factionMembership: _factionMembership(),
+      checkpoint: checkpoint,
+      factionMembership: membership,
     );
-    for (final existing in diplomaticOrders) {
-      final result = validator.validate(existing, previousRejected: false);
-      if (!result.result.isAccepted) return false;
-    }
-    return validator
+    return candidateValidator
         .validate(candidate, previousRejected: false)
         .result
         .isAccepted;

--- a/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
@@ -96,6 +96,12 @@ class IncrementalCandidateValidator {
   ({Stockpile stockpile, int treasury})? _cachedEconomyAfterBuildOrders;
   ({Stockpile stockpile, int treasury})? _cachedEconomyAfterBuildAndWorkOrders;
 
+  /// When [false], existing work orders in [basePrefix] failed incremental
+  /// replay; every [isWorkAccepted] probe must reject (Refs #2394).
+  bool? _cachedWorkPrefixReplaySucceeded;
+  ({Stockpile stockpile, int treasury, Set<String> seenUnitIds, Set<String>
+      devExclusive})? _cachedPostWorkPrefixState;
+
   /// When [false], existing build orders in [basePrefix] failed incremental
   /// replay; every [isBuildAccepted] probe must reject (Refs #2394).
   bool? _cachedBuildPrefixReplaySucceeded;
@@ -263,7 +269,13 @@ class IncrementalCandidateValidator {
   bool isWorkAccepted(WorkOrder candidate) {
     final player = _player();
     if (player == null) return false;
-    final economy = _projectEconomyAfterAcceptedBuildOrders(player);
+    if (_cachedWorkPrefixReplaySucceeded == false) {
+      return false;
+    }
+    final prefix = _ensurePostWorkPrefixState(player);
+    if (prefix == null) {
+      return false;
+    }
     final workValidator = createWorkOrderValidator(
       game: game,
       player: player,
@@ -274,17 +286,14 @@ class IncrementalCandidateValidator {
       diplomaticOrders: diplomaticOrders,
       tileMapByRegion: tileMapByRegion,
       civilianDraftMoveUnitIds: _civilianDraftMoveUnitIds(),
-      devExclusiveTiles: _devExclusiveTiles(),
-      stockpile: economy.stockpile,
-      treasury: economy.treasury,
+      devExclusiveTiles: Set<String>.from(prefix.devExclusive),
+      stockpile: Stockpile(
+        quantities: Map<String, int>.from(prefix.stockpile.quantities),
+      ),
+      treasury: prefix.treasury,
       factionMembership: _factionMembership(),
+      initialSeenUnitIds: prefix.seenUnitIds,
     );
-    final works =
-        basePrefix.workOrdersByPlayerId[playerId] ?? const <WorkOrder>[];
-    for (final existing in works) {
-      final result = workValidator.validate(existing, previousRejected: false);
-      if (!result.isAccepted) return false;
-    }
     return workValidator
         .validate(candidate, previousRejected: false)
         .isAccepted;
@@ -346,7 +355,46 @@ class IncrementalCandidateValidator {
     if (cached != null) {
       return cached;
     }
+    final prefix = _ensurePostWorkPrefixState(player);
+    if (prefix == null) {
+      final afterBuild = _projectEconomyAfterAcceptedBuildOrders(player);
+      _cachedEconomyAfterBuildAndWorkOrders = afterBuild;
+      return afterBuild;
+    }
+    final projected = (stockpile: prefix.stockpile, treasury: prefix.treasury);
+    _cachedEconomyAfterBuildAndWorkOrders = projected;
+    return projected;
+  }
+
+  /// Replays accepted work orders in [basePrefix] once per validator instance,
+  /// then exposes projected economy + work-order state for candidate probes
+  /// and diplomatic projection (Refs #2394, Category B).
+  ({Stockpile stockpile, int treasury, Set<String> seenUnitIds, Set<String>
+      devExclusive})? _ensurePostWorkPrefixState(Player player) {
+    if (_cachedWorkPrefixReplaySucceeded == false) {
+      return null;
+    }
+    final cachedState = _cachedPostWorkPrefixState;
+    if (cachedState != null) {
+      return cachedState;
+    }
     final afterBuild = _projectEconomyAfterAcceptedBuildOrders(player);
+    final works =
+        basePrefix.workOrdersByPlayerId[playerId] ?? const <WorkOrder>[];
+    final baseDev = Set<String>.from(_devExclusiveTiles());
+    if (works.isEmpty) {
+      final proj = (
+        stockpile: Stockpile(
+          quantities: Map<String, int>.from(afterBuild.stockpile.quantities),
+        ),
+        treasury: afterBuild.treasury,
+        seenUnitIds: <String>{},
+        devExclusive: baseDev,
+      );
+      _cachedWorkPrefixReplaySucceeded = true;
+      _cachedPostWorkPrefixState = proj;
+      return proj;
+    }
     final workValidator = createWorkOrderValidator(
       game: game,
       player: player,
@@ -357,26 +405,29 @@ class IncrementalCandidateValidator {
       diplomaticOrders: diplomaticOrders,
       tileMapByRegion: tileMapByRegion,
       civilianDraftMoveUnitIds: _civilianDraftMoveUnitIds(),
-      devExclusiveTiles: _devExclusiveTiles(),
+      devExclusiveTiles: baseDev,
       stockpile: afterBuild.stockpile,
       treasury: afterBuild.treasury,
       factionMembership: _factionMembership(),
     );
-    final works =
-        basePrefix.workOrdersByPlayerId[playerId] ?? const <WorkOrder>[];
     for (final existing in works) {
       final result = workValidator.validate(existing, previousRejected: false);
       if (!result.isAccepted) {
-        _cachedEconomyAfterBuildAndWorkOrders = afterBuild;
-        return afterBuild;
+        _cachedWorkPrefixReplaySucceeded = false;
+        return null;
       }
     }
-    final projected = (
-      stockpile: workValidator.stockpile,
+    final proj = (
+      stockpile: Stockpile(
+        quantities: Map<String, int>.from(workValidator.stockpile.quantities),
+      ),
       treasury: workValidator.treasury,
+      seenUnitIds: {for (final w in works) w.unitId},
+      devExclusive: Set<String>.from(baseDev),
     );
-    _cachedEconomyAfterBuildAndWorkOrders = projected;
-    return projected;
+    _cachedWorkPrefixReplaySucceeded = true;
+    _cachedPostWorkPrefixState = proj;
+    return proj;
   }
 
   Set<String> _civilianDraftMoveUnitIds() {

--- a/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
@@ -87,6 +87,12 @@ class IncrementalCandidateValidator {
   Set<String>? _cachedCivilianDraftMoveUnitIds;
   ({Stockpile stockpile, int treasury})? _cachedEconomyAfterBuildOrders;
   ({Stockpile stockpile, int treasury})? _cachedEconomyAfterBuildAndWorkOrders;
+
+  /// When [false], existing build orders in [basePrefix] failed incremental
+  /// replay; every [isBuildAccepted] probe must reject (Refs #2394).
+  bool? _cachedBuildPrefixReplaySucceeded;
+  ({Stockpile stockpile, int treasury, WorkerPool workers})?
+  _cachedPostBuildPrefixEconomy;
   Map<String, Army>? _cachedArmiesById;
   DiplomacyFactionMembership? _cachedFactionMembership;
   NavalOrderValidator? _cachedNavalOrderValidator;
@@ -202,15 +208,44 @@ class IncrementalCandidateValidator {
   bool isBuildAccepted(BuildUnitOrder candidate) {
     final player = _player();
     if (player == null) return false;
-    final validator = BuildOrderValidator(game: game, player: player);
+    if (_cachedBuildPrefixReplaySucceeded == false) {
+      return false;
+    }
     final builds =
         basePrefix.buildUnitOrdersByPlayerId[playerId] ??
         const <BuildUnitOrder>[];
-    for (final existing in builds) {
-      final result = validator.validate(existing, previousRejected: false);
-      if (!result.isAccepted) return false;
+    if (_cachedPostBuildPrefixEconomy == null) {
+      final prefixValidator = BuildOrderValidator(game: game, player: player);
+      for (final existing in builds) {
+        final result = prefixValidator.validate(
+          existing,
+          previousRejected: false,
+        );
+        if (!result.isAccepted) {
+          _cachedBuildPrefixReplaySucceeded = false;
+          return false;
+        }
+      }
+      _cachedBuildPrefixReplaySucceeded = true;
+      _cachedPostBuildPrefixEconomy = (
+        stockpile: prefixValidator.stockpile,
+        treasury: prefixValidator.treasury,
+        workers: prefixValidator.workers,
+      );
     }
-    return validator.validate(candidate, previousRejected: false).isAccepted;
+    final snap = _cachedPostBuildPrefixEconomy!;
+    final candidateValidator = BuildOrderValidator.withProjectedEconomy(
+      game: game,
+      player: player,
+      stockpile: Stockpile(
+        quantities: Map<String, int>.from(snap.stockpile.quantities),
+      ),
+      treasury: snap.treasury,
+      workerPool: snap.workers,
+    );
+    return candidateValidator
+        .validate(candidate, previousRejected: false)
+        .isAccepted;
   }
 
   bool isWorkAccepted(WorkOrder candidate) {

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_helpers.dart
@@ -46,6 +46,10 @@ List<T> filterOrdersByDiplomacy<T>(
   String Function(T order) destinationProvinceId,
 ) {
   final provinceOwner = getProvinceOwnerMap(game);
+  // Single-pass minor ids (Refs #2394): avoid O(orders × minors) scans per row.
+  final minorNationIds = <String>{
+    for (final mn in game.minorNations) mn.id,
+  };
   final filtered = <T>[];
   for (final m in orders) {
     final destOwner = provinceOwner[destinationProvinceId(m)];
@@ -55,8 +59,8 @@ List<T> filterOrdersByDiplomacy<T>(
     }
     final rel = getRelation(game, playerId, destOwner);
     if (rel != null && rel.atPeace) continue;
-    if (rel == null) {
-      if (game.minorNations.any((mn) => mn.id == destOwner)) continue;
+    if (rel == null && minorNationIds.contains(destOwner)) {
+      continue;
     }
     filtered.add(m);
   }

--- a/packages/colonizethis_logic/lib/src/orders/per_player_work_target_selection_cache.dart
+++ b/packages/colonizethis_logic/lib/src/orders/per_player_work_target_selection_cache.dart
@@ -156,6 +156,7 @@ class PerPlayerWorkTargetSelectionCache {
           playerId: s.playerId,
           baseOrders: s.currentOrders,
           tileMapByRegion: s.tileMapByRegion,
+          view: s.playerView,
         );
     final merged = <String>{};
     for (final unit in _humanCivilianUnits(s.game, s.playerId)) {
@@ -223,6 +224,7 @@ class PerPlayerWorkTargetSelectionCache {
           playerId: s.playerId,
           baseOrders: s.currentOrders,
           tileMapByRegion: s.tileMapByRegion,
+          view: s.playerView,
         );
     final pendingWorkUnitIds = <String>{
       for (final w

--- a/packages/colonizethis_logic/lib/src/orders/per_player_work_target_selection_cache.dart
+++ b/packages/colonizethis_logic/lib/src/orders/per_player_work_target_selection_cache.dart
@@ -52,7 +52,9 @@ class PerPlayerWorkTargetSelectionCache {
     Map<String, WorkTargetSelectionPopulationStrategy>? strategies,
   }) : _strategies = strategies == null
            ? _defaultStrategies
-           : Map<String, WorkTargetSelectionPopulationStrategy>.from(strategies);
+           : Map<String, WorkTargetSelectionPopulationStrategy>.from(
+               strategies,
+             );
 
   final Map<String, WorkTargetSelectionPopulationStrategy> _strategies;
   final Map<String, Map<String, Set<String>>> _cacheByPlayerAndTarget = {};
@@ -146,7 +148,8 @@ class PerPlayerWorkTargetSelectionCache {
     WorkTargetSelectionSnapshot s,
     String workTarget,
   ) {
-    final sharedValidator = s.sharedCandidateValidator ??
+    final sharedValidator =
+        s.sharedCandidateValidator ??
         buildIncrementalCandidateValidator(
           game: s.game,
           topology: s.topology,
@@ -212,7 +215,8 @@ class PerPlayerWorkTargetSelectionCache {
     WorkTargetSelectionSnapshot s,
     String workTarget,
   ) {
-    final sharedValidator = s.sharedCandidateValidator ??
+    final sharedValidator =
+        s.sharedCandidateValidator ??
         buildIncrementalCandidateValidator(
           game: s.game,
           topology: s.topology,
@@ -220,6 +224,12 @@ class PerPlayerWorkTargetSelectionCache {
           baseOrders: s.currentOrders,
           tileMapByRegion: s.tileMapByRegion,
         );
+    final pendingWorkUnitIds = <String>{
+      for (final w
+          in s.currentOrders.workOrdersByPlayerId[s.playerId] ??
+              const <WorkOrder>[])
+        w.unitId,
+    };
     final merged = <String>{};
     for (final unit in _humanCivilianUnits(s.game, s.playerId)) {
       final supportsTarget =
@@ -231,11 +241,7 @@ class PerPlayerWorkTargetSelectionCache {
       if (!isIdleNow || unit.currentWork != null) {
         continue;
       }
-      if (_hasPendingWorkOrderForUnit(
-        orders: s.currentOrders,
-        playerId: s.playerId,
-        unitId: unit.id,
-      )) {
+      if (pendingWorkUnitIds.contains(unit.id)) {
         continue;
       }
       final valid = getValidWorkOrderTileKeysWithVisibility(
@@ -264,19 +270,5 @@ class PerPlayerWorkTargetSelectionCache {
         yield unit;
       }
     }
-  }
-
-  static bool _hasPendingWorkOrderForUnit({
-    required Orders orders,
-    required String playerId,
-    required String unitId,
-  }) {
-    final pendingByPlayer = orders.workOrdersByPlayerId[playerId] ?? const [];
-    for (final pending in pendingByPlayer) {
-      if (pending.unitId == unitId) {
-        return true;
-      }
-    }
-    return false;
   }
 }

--- a/packages/colonizethis_logic/lib/src/orders/validator_bundle.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validator_bundle.dart
@@ -73,6 +73,7 @@ WorkOrderValidator createWorkOrderValidator({
   required Stockpile stockpile,
   required int treasury,
   required DiplomacyFactionMembership factionMembership,
+  Set<String> initialSeenUnitIds = const <String>{},
 }) {
   final workContext = buildWorkOrderValidationContext(
     game: game,
@@ -91,6 +92,7 @@ WorkOrderValidator createWorkOrderValidator({
     context: workContext,
     stockpile: stockpile,
     treasury: treasury,
+    initialSeenUnitIds: initialSeenUnitIds,
   );
 }
 

--- a/packages/colonizethis_logic/lib/src/orders/validators/build_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/build_order_validator.dart
@@ -23,6 +23,22 @@ class BuildOrderValidator extends StatefulValidator {
         workerPoolState: player.workerPool,
       );
 
+  /// Validates further [BuildUnitOrder]s from an economy snapshot produced by
+  /// replaying accepted build orders in submission order (Refs #2394).
+  BuildOrderValidator.withProjectedEconomy({
+    required Game game,
+    required Player player,
+    required Stockpile stockpile,
+    required int treasury,
+    required WorkerPool workerPool,
+  }) : _game = game,
+       _player = player,
+       super(
+         stockpileState: stockpile,
+         treasuryState: treasury,
+         workerPoolState: workerPool,
+       );
+
   WorkerPool get workers => workerPoolState;
   Stockpile get stockpile => stockpileState;
   int get treasury => treasuryState;

--- a/packages/colonizethis_logic/lib/src/orders/validators/diplomatic_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/diplomatic_order_validator.dart
@@ -13,6 +13,22 @@ import 'diplomatic/offer_peace_validator.dart';
 import 'diplomatic/set_subsidy_validator.dart';
 import 'stateful_validator.dart';
 
+/// Treasury and per-target diplomatic caps after replaying an accepted
+/// [Orders] prefix. Used to evaluate incremental diplomatic candidates without
+/// O(E) prefix replay per probe (Refs #2394, SPEC/program/order-suggestions.md).
+final class DiplomaticPrefixCheckpoint {
+  DiplomaticPrefixCheckpoint._({
+    required this.treasury,
+    required Map<String, Set<DiplomaticOrderType>> typesByTarget,
+  }) : typesByTarget = {
+         for (final e in typesByTarget.entries)
+           e.key: Set<DiplomaticOrderType>.from(e.value),
+       };
+
+  final int treasury;
+  final Map<String, Set<DiplomaticOrderType>> typesByTarget;
+}
+
 /// Validates diplomatic orders for a single player in submission order.
 /// SPEC/program/orders.md § Diplomatic orders.
 ///
@@ -73,6 +89,38 @@ class DiplomaticOrderValidator extends StatefulValidator {
         playerId: _playerId,
       ),
     };
+  }
+
+  /// Validator state cloned from [checkpoint] for a single candidate probe.
+  /// Does not replay prefix orders; mirrors post-prefix state only.
+  factory DiplomaticOrderValidator.fromPrefixCheckpoint({
+    required Game game,
+    required String playerId,
+    required DiplomaticPrefixCheckpoint checkpoint,
+    DiplomacyFactionMembership? factionMembership,
+  }) {
+    final validator = DiplomaticOrderValidator(
+      game: game,
+      playerId: playerId,
+      initialTreasury: checkpoint.treasury,
+      factionMembership: factionMembership,
+    );
+    for (final e in checkpoint.typesByTarget.entries) {
+      validator._typesByTarget[e.key] = Set<DiplomaticOrderType>.from(e.value);
+    }
+    return validator;
+  }
+
+  /// Captures treasury and accepted diplomatic caps after validating prefix
+  /// orders in submission order.
+  DiplomaticPrefixCheckpoint capturePrefixCheckpoint() {
+    return DiplomaticPrefixCheckpoint._(
+      treasury: treasuryState,
+      typesByTarget: {
+        for (final e in _typesByTarget.entries)
+          e.key: Set<DiplomaticOrderType>.from(e.value),
+      },
+    );
   }
 
   int get treasury => treasuryState;

--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -117,6 +117,7 @@ Map<String, ConnectivityResult> resolveConnectivity({
     'connectivity resolve start players=${game.players.length} regions=${tileMapByRegion.keys.join(",")}',
   );
   final provinceIdsByType = provinceNodeIds(topology);
+  final seaZoneNodeIds = _topologySeaZoneNodeIds(topology);
   final blockadedByPlayer =
       blockadedPortProvincesByPlayerId ??
       computeBlockadedPortProvincesByPlayer(game, topology);
@@ -145,6 +146,7 @@ Map<String, ConnectivityResult> resolveConnectivity({
       tileMapByRegion: tileMapByRegion,
       topology: topology,
       provinceIdsByType: provinceIdsByType,
+      seaZoneNodeIds: seaZoneNodeIds,
       portInfo: portInfo,
       owned: ownedByPlayer[player.id] ?? const <String>{},
       townByTileKey:
@@ -191,20 +193,25 @@ bool _topologyUsesPrefixedIds(MapTopology topology) {
   return topology.nodes.any((n) => n.id.contains('|'));
 }
 
+/// Topology sea-zone node ids, built once per connectivity resolve (Refs #2394).
+Set<String> _topologySeaZoneNodeIds(MapTopology topology) {
+  return {
+    for (final n in topology.nodes)
+      if (n.type == TopologyNodeType.seaZone) n.id,
+  };
+}
+
 /// Sea zones reachable from [startSeaZoneIds] by following S–S edges in [topology]. SPEC/game/map-topology, capital-and-connectivity § Sea paths.
 Set<String> _seaZonesReachableBySeaPath(
   MapTopology topology,
-  Set<String> startSeaZoneIds,
-) {
-  final seaZoneIds = topology.nodes
-      .where((n) => n.type == TopologyNodeType.seaZone)
-      .map((n) => n.id)
-      .toSet();
+  Set<String> startSeaZoneIds, {
+  required Set<String> seaZoneNodeIds,
+}) {
   final neighbours = <String, Set<String>>{};
   for (final e in topology.edges) {
     final a = e.id1;
     final b = e.id2;
-    if (seaZoneIds.contains(a) && seaZoneIds.contains(b)) {
+    if (seaZoneNodeIds.contains(a) && seaZoneNodeIds.contains(b)) {
       neighbours.putIfAbsent(a, () => {}).add(b);
       neighbours.putIfAbsent(b, () => {}).add(a);
     }
@@ -212,7 +219,7 @@ Set<String> _seaZonesReachableBySeaPath(
   return breadthFirstReachableInSubgraph(
     startSeaZoneIds,
     neighbours,
-    seaZoneIds,
+    seaZoneNodeIds,
     onDequeue: _recordSeaZoneBfsDequeue,
   );
 }
@@ -220,17 +227,14 @@ Set<String> _seaZonesReachableBySeaPath(
 /// Sea zone ids adjacent to province [localProvinceId] in topology (P–S edges).
 Set<String> _seaZonesAdjacentToProvince(
   MapTopology topology,
-  String localProvinceId,
-) {
-  final seaZoneIds = topology.nodes
-      .where((n) => n.type == TopologyNodeType.seaZone)
-      .map((n) => n.id)
-      .toSet();
+  String localProvinceId, {
+  required Set<String> seaZoneNodeIds,
+}) {
   final out = <String>{};
   for (final edge in topology.edges) {
     if (edge.id1 != localProvinceId && edge.id2 != localProvinceId) continue;
     final other = edge.id1 == localProvinceId ? edge.id2 : edge.id1;
-    if (seaZoneIds.contains(other)) out.add(other);
+    if (seaZoneNodeIds.contains(other)) out.add(other);
   }
   return out;
 }
@@ -324,6 +328,7 @@ ConnectivityResult _connectedTilesForPlayer({
   required Map<String, TileMapResult> tileMapByRegion,
   required MapTopology topology,
   required Set<String> provinceIdsByType,
+  required Set<String> seaZoneNodeIds,
   required Map<String, (String, String)> portInfo,
   required Set<String> owned,
   required Map<String, Province> townByTileKey,
@@ -374,6 +379,7 @@ ConnectivityResult _connectedTilesForPlayer({
     topology: topology,
     tileMapByRegion: tileMapByRegion,
     provinceIdsByType: provinceIdsByType,
+    seaZoneNodeIds: seaZoneNodeIds,
     ownedProvinceIds: owned,
     blockadedPortProvinces: blockadedPortProvinces,
     capitalRegionPortKeys: capitalRegionPortKeys,
@@ -485,6 +491,7 @@ Set<String> _seaConnectedPortKeysForCapital({
   required MapTopology topology,
   required Map<String, TileMapResult> tileMapByRegion,
   required Set<String> provinceIdsByType,
+  required Set<String> seaZoneNodeIds,
   required Set<String> ownedProvinceIds,
   required Set<String> blockadedPortProvinces,
   required Set<String> capitalRegionPortKeys,
@@ -508,8 +515,13 @@ Set<String> _seaConnectedPortKeysForCapital({
     final capitalSeaZones = _seaZonesAdjacentToProvince(
       topology,
       provinceIdForLookup,
+      seaZoneNodeIds: seaZoneNodeIds,
     );
-    final seaReachable = _seaZonesReachableBySeaPath(topology, capitalSeaZones);
+    final seaReachable = _seaZonesReachableBySeaPath(
+      topology,
+      capitalSeaZones,
+      seaZoneNodeIds: seaZoneNodeIds,
+    );
     for (final entry in worldState.portsByProvinceSeaboard.entries) {
       final portMeta = decodePortSeaboardRegistryKey(entry.key);
       if (portMeta == null) continue;

--- a/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
@@ -36,33 +36,47 @@ List<String> _adjacentSeaZones(MapTopology topology, String seaZoneId) {
   return out;
 }
 
+/// Single-pass index: sea zone id → fleets whose [Fleet.seaZoneId] equals that
+/// zone. Preserves world fleet list order within each bucket (Refs #2394).
+Map<String, List<Fleet>> _fleetsBySeaZoneId(List<Fleet> fleets) {
+  final out = <String, List<Fleet>>{};
+  for (final f in fleets) {
+    final z = f.seaZoneId;
+    if (z == null) continue;
+    out.putIfAbsent(z, () => <Fleet>[]).add(f);
+  }
+  return out;
+}
+
 String? _firstFriendlyOrNeutralRetreatZone(
-  Game game,
   MapTopology topology,
   String fromSeaZoneId,
   String ownerId,
+  Map<String, Set<String>> hostileByOwner,
+  Map<String, List<Fleet>> fleetsBySeaZoneId,
 ) {
-  final hostileByOwner = hostileFactionsByFaction(game);
   for (final adj in _adjacentSeaZones(topology, fromSeaZoneId)) {
-    final hostileOwnersPresent = game.worldState.fleets.any(
-      (fleet) =>
-          fleet.isAtSea &&
-          fleet.seaZoneId == adj &&
-          fleet.ownerId != ownerId &&
-          (hostileByOwner[ownerId]?.contains(fleet.ownerId) ?? false),
-    );
+    var hostileOwnersPresent = false;
+    for (final fleet in fleetsBySeaZoneId[adj] ?? const <Fleet>[]) {
+      if (!fleet.isAtSea) continue;
+      if (fleet.ownerId == ownerId) continue;
+      if (hostileByOwner[ownerId]?.contains(fleet.ownerId) ?? false) {
+        hostileOwnersPresent = true;
+        break;
+      }
+    }
     if (!hostileOwnersPresent) return adj;
   }
   return null;
 }
 
-String? _firstFleetRegionIdForSeaZone(Game game, String seaZoneId) {
-  for (final f in game.worldState.fleets) {
-    if (f.seaZoneId == seaZoneId) {
-      return f.regionId;
-    }
-  }
-  return null;
+String? _firstFleetRegionIdForSeaZone(
+  String seaZoneId,
+  Map<String, List<Fleet>> fleetsBySeaZoneId,
+) {
+  final inZone = fleetsBySeaZoneId[seaZoneId];
+  if (inZone == null || inZone.isEmpty) return null;
+  return inZone.first.regionId;
 }
 
 Map<String, int> _fleetIndexById(List<Fleet> fleets) => {
@@ -482,17 +496,21 @@ Game runNavalInterceptionCombatPhase(
   final turn = game.worldState.turnState.turnNumber;
   var battleIndex = 0;
   for (final battle in battles) {
+    final hostileByOwner = hostileFactionsByFaction(state);
+    final fleetsBySeaZoneId = _fleetsBySeaZoneId(state.worldState.fleets);
     final retreatZoneSide1 = _firstFriendlyOrNeutralRetreatZone(
-      state,
       topology,
       battle.seaZoneId,
       battle.side1.ownerId,
+      hostileByOwner,
+      fleetsBySeaZoneId,
     );
     final retreatZoneSide2 = _firstFriendlyOrNeutralRetreatZone(
-      state,
       topology,
       battle.seaZoneId,
       battle.side2.ownerId,
+      hostileByOwner,
+      fleetsBySeaZoneId,
     );
     final result = resolveSeaBattle(
       battle,
@@ -512,7 +530,7 @@ Game runNavalInterceptionCombatPhase(
     // within repo.control_flow_nesting_depth limits.
     final regionId =
         zoneRegionId ??
-        _firstFleetRegionIdForSeaZone(state, battle.seaZoneId) ??
+        _firstFleetRegionIdForSeaZone(battle.seaZoneId, fleetsBySeaZoneId) ??
         kRegionOldWorld;
     state = applyNavalBattleResults(
       state,

--- a/packages/colonizethis_logic/test/ai_planner_batch_ensure_test.dart
+++ b/packages/colonizethis_logic/test/ai_planner_batch_ensure_test.dart
@@ -1,0 +1,113 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/src/ai/ai_control.dart';
+import 'package:colonizethis_logic/src/ai/ai_planner.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+/// [generateOrdersForGame] must match stitching [generateOrdersForPlayer] per
+/// AI GP on the original [Game] (each call runs its own ensure). Batch path
+/// hoists [ensureMilitaryArmiesForGame] once (Refs #2394).
+void main() {
+  test('generateOrdersForGame equals per-player stitched orders', () {
+    final game = Game(
+      id: 'g1',
+      worldState: WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: RegionData(
+          provinces: const [
+            Province(id: 'oldWorld|P1', regionId: 'oldWorld', ownerId: 'gp1'),
+            Province(id: 'oldWorld|P2', regionId: 'oldWorld', ownerId: 'gp2'),
+          ],
+          units: [
+            Unit(
+              id: 'u1',
+              type: 'grenadiers',
+              ownerId: 'gp1',
+              locationProvinceId: 'oldWorld|P1',
+            ),
+            Unit(
+              id: 'u2',
+              type: 'grenadiers',
+              ownerId: 'gp2',
+              locationProvinceId: 'oldWorld|P2',
+            ),
+          ],
+        ),
+        newWorld: const RegionData(),
+        playerVisibilityByTile: const {
+          'gp1': {
+            'oldWorld|P1|0|0': 'fullyVisible',
+            'oldWorld|P2|0|0': 'fullyVisible',
+          },
+          'gp2': {
+            'oldWorld|P1|0|0': 'fullyVisible',
+            'oldWorld|P2|0|0': 'fullyVisible',
+          },
+        },
+      ),
+      players: const [
+        Player(id: 'gp1', displayName: 'AI1', isHuman: false),
+        Player(id: 'gp2', displayName: 'AI2', isHuman: false),
+      ],
+      diplomacyRelations: const [
+        DiplomacyRelation(
+          factionId1: 'gp1',
+          factionId2: 'gp2',
+          state: RelationState.atWar,
+        ),
+      ],
+      globalGameSeed: 0,
+      aiSeedByGpId: {'gp1': 11, 'gp2': 22},
+    );
+
+    const topology = MapTopology(
+      nodes: [
+        TopologyNode(
+          id: 'P1',
+          regionId: 'oldWorld',
+          type: TopologyNodeType.province,
+        ),
+        TopologyNode(
+          id: 'P2',
+          regionId: 'oldWorld',
+          type: TopologyNodeType.province,
+        ),
+      ],
+      edges: [TopologyEdge(id1: 'P1', id2: 'P2')],
+    );
+
+    final batched = generateOrdersForGame(game, topology);
+
+    final moveByPlayer = <String, List<MoveOrder>>{};
+    final armyMoveByPlayer = <String, List<ArmyMoveOrder>>{};
+    final buildByPlayer = <String, List<BuildUnitOrder>>{};
+    final workByPlayer = <String, List<WorkOrder>>{};
+    final researchByPlayer = <String, List<ResearchOrder>>{};
+    for (final player in game.players) {
+      if (!isAiControlled(game, player.id)) continue;
+      final o = generateOrdersForPlayer(game, topology, player.id);
+      final pid = player.id;
+      final m = o.moveOrdersByPlayerId[pid];
+      if (m != null && m.isNotEmpty) moveByPlayer[pid] = m;
+      final a = o.armyMoveOrdersByPlayerId[pid];
+      if (a != null && a.isNotEmpty) armyMoveByPlayer[pid] = a;
+      final b = o.buildUnitOrdersByPlayerId[pid];
+      if (b != null && b.isNotEmpty) buildByPlayer[pid] = b;
+      final w = o.workOrdersByPlayerId[pid];
+      if (w != null && w.isNotEmpty) workByPlayer[pid] = w;
+      final r = o.researchOrdersByPlayerId[pid];
+      if (r != null && r.isNotEmpty) researchByPlayer[pid] = r;
+    }
+    final stitched = Orders(
+      moveOrdersByPlayerId: moveByPlayer,
+      armyMoveOrdersByPlayerId: armyMoveByPlayer,
+      buildUnitOrdersByPlayerId: buildByPlayer,
+      workOrdersByPlayerId: workByPlayer,
+      diplomaticOrdersByPlayerId: const {},
+      researchOrdersByPlayerId: researchByPlayer,
+      navalMoveOrdersByPlayerId: const {},
+    );
+
+    expect(batched, equals(stitched));
+  });
+}

--- a/packages/colonizethis_logic/test/orders/incremental_candidate_validator_equivalence_test.dart
+++ b/packages/colonizethis_logic/test/orders/incremental_candidate_validator_equivalence_test.dart
@@ -208,6 +208,54 @@ void main() {
       );
     });
 
+    test(
+      'build: successive candidate probes stay full-pass equivalent (#2394)',
+      () {
+        final game = TestFixtures.gameWithSingleOwnedProvince(
+          ownerPlayerId: 'p1',
+          provinceId: 'oldWorld|p1',
+          treasury: 999,
+        );
+        const topology = MapTopology(
+          nodes: [
+            TopologyNode(
+              id: 'oldWorld|p1',
+              regionId: 'oldWorld',
+              type: TopologyNodeType.province,
+            ),
+          ],
+          edges: [],
+        );
+        const basePrefix = Orders();
+
+        const candidateA = BuildUnitOrder(
+          unitType: 'pikemen',
+          isMilitary: true,
+          spawnProvinceId: 'oldWorld|p1',
+        );
+        const candidateB = BuildUnitOrder(
+          unitType: 'musketeers',
+          isMilitary: true,
+          spawnProvinceId: 'oldWorld|p1',
+        );
+
+        final incremental = IncrementalCandidateValidator.forPlayer(
+          game: game,
+          topology: topology,
+          playerId: 'p1',
+          basePrefix: basePrefix,
+        );
+        expect(
+          incremental.isBuildAccepted(candidateA),
+          fullPassBuildAccepted(game, topology, 'p1', basePrefix, candidateA),
+        );
+        expect(
+          incremental.isBuildAccepted(candidateB),
+          fullPassBuildAccepted(game, topology, 'p1', basePrefix, candidateB),
+        );
+      },
+    );
+
     test('work: non-empty basePrefix replay remains equivalent', () {
       final game = moveCorpusGame();
       final topology = moveCorpusTopology();

--- a/packages/colonizethis_logic/test/orders/incremental_candidate_validator_equivalence_test.dart
+++ b/packages/colonizethis_logic/test/orders/incremental_candidate_validator_equivalence_test.dart
@@ -311,6 +311,50 @@ void main() {
     });
 
     test(
+      'diplomatic: sequential probes on one validator stay equivalent (#2394)',
+      () {
+        final game = moveCorpusGame();
+        final topology = moveCorpusTopology();
+        final basePrefix = Orders(
+          diplomaticOrdersByPlayerId: {
+            'p1': [
+              const DiplomaticOrder(
+                type: DiplomaticOrderType.declareWar,
+                targetFactionId: 'p2',
+              ),
+            ],
+          },
+        );
+        const candidateA = DiplomaticOrder(
+          type: DiplomaticOrderType.alliance,
+          targetFactionId: 'p2',
+        );
+        const candidateB = DiplomaticOrder(
+          type: DiplomaticOrderType.declareWar,
+          targetFactionId: 'p3',
+        );
+        final incremental = IncrementalCandidateValidator.forPlayer(
+          game: game,
+          topology: topology,
+          playerId: 'p1',
+          basePrefix: basePrefix,
+        );
+        expect(
+          incremental.isDiplomaticAccepted(candidateA),
+          fullPassDiplomaticAccepted(game, topology, 'p1', basePrefix, candidateA),
+        );
+        expect(
+          incremental.isDiplomaticAccepted(candidateB),
+          fullPassDiplomaticAccepted(game, topology, 'p1', basePrefix, candidateB),
+        );
+        expect(
+          incremental.isDiplomaticAccepted(candidateA),
+          fullPassDiplomaticAccepted(game, topology, 'p1', basePrefix, candidateA),
+        );
+      },
+    );
+
+    test(
       'prefetched DiplomacyFactionMembership matches lazy membership (#2394)',
       () {
         final game = armyCorpusGame();

--- a/packages/colonizethis_logic/test/orders/incremental_candidate_validator_equivalence_test.dart
+++ b/packages/colonizethis_logic/test/orders/incremental_candidate_validator_equivalence_test.dart
@@ -309,5 +309,37 @@ void main() {
         label: 'same-target non-economic conflict',
       );
     });
+
+    test(
+      'prefetched DiplomacyFactionMembership matches lazy membership (#2394)',
+      () {
+        final game = armyCorpusGame();
+        final topology = armyCorpusTopology();
+        const playerId = 'p1';
+        const basePrefix = Orders();
+        final prefetched = DiplomacyFactionMembership.from(game);
+        final baseline = IncrementalCandidateValidator.forPlayer(
+          game: game,
+          topology: topology,
+          playerId: playerId,
+          basePrefix: basePrefix,
+        );
+        final withPrefetched = IncrementalCandidateValidator.forPlayer(
+          game: game,
+          topology: topology,
+          playerId: playerId,
+          basePrefix: basePrefix,
+          factionMembership: prefetched,
+        );
+        const armyMove = ArmyMoveOrder(
+          armyId: 'field_a',
+          destinationProvinceId: 'oldWorld|P4',
+        );
+        expect(
+          withPrefetched.isArmyMoveAccepted(armyMove),
+          baseline.isArmyMoveAccepted(armyMove),
+        );
+      },
+    );
   });
 }

--- a/packages/colonizethis_logic/test/orders/order_suggestion_helpers_test.dart
+++ b/packages/colonizethis_logic/test/orders/order_suggestion_helpers_test.dart
@@ -1,0 +1,100 @@
+/// Regression tests for [filterArmyMoveOrdersByDiplomacy] / shared diplomacy
+/// filtering used on AI army-move paths (Refs #2394).
+library;
+
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  const ow = 'oldWorld';
+  const gpId = 'gp1';
+  const minorId = 'minor_doc';
+
+  Game gameWithMinorProvince({
+    required List<DiplomacyRelation> diplomacyRelations,
+  }) {
+    return Game(
+      id: 'g1',
+      worldState: WorldState(
+        turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+        oldWorld: RegionData(
+          provinces: [
+            const Province(
+              id: '$ow|P_gp',
+              regionId: ow,
+              ownerId: gpId,
+            ),
+            const Province(
+              id: '$ow|P_minor',
+              regionId: ow,
+              ownerId: minorId,
+            ),
+          ],
+        ),
+        newWorld: const RegionData(),
+      ),
+      players: const [
+        Player(id: gpId, displayName: 'GP1', isHuman: true),
+      ],
+      minorNations: const [
+        MinorNation(id: minorId, displayName: 'Minor Doc'),
+      ],
+      diplomacyRelations: diplomacyRelations,
+    );
+  }
+
+  group('filterArmyMoveOrdersByDiplomacy', () {
+    test('drops move into minor-owned province when relation row is absent', () {
+      final game = gameWithMinorProvince(diplomacyRelations: const []);
+      const orders = [
+        ArmyMoveOrder(armyId: 'a1', destinationProvinceId: '$ow|P_minor'),
+      ];
+      final out = filterArmyMoveOrdersByDiplomacy(game, gpId, orders);
+      expect(out, isEmpty);
+    });
+
+    test('keeps move into minor province when at war (relation row present)', () {
+      final game = gameWithMinorProvince(
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: gpId,
+            factionId2: minorId,
+            state: RelationState.atWar,
+          ),
+        ],
+      );
+      const orders = [
+        ArmyMoveOrder(armyId: 'a1', destinationProvinceId: '$ow|P_minor'),
+      ];
+      final out = filterArmyMoveOrdersByDiplomacy(game, gpId, orders);
+      expect(out, orders);
+    });
+
+    test('drops move into minor province when explicitly at peace', () {
+      final game = gameWithMinorProvince(
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: gpId,
+            factionId2: minorId,
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      const orders = [
+        ArmyMoveOrder(armyId: 'a1', destinationProvinceId: '$ow|P_minor'),
+      ];
+      final out = filterArmyMoveOrdersByDiplomacy(game, gpId, orders);
+      expect(out, isEmpty);
+    });
+
+    test('keeps reordering-only move within own provinces', () {
+      final game = gameWithMinorProvince(diplomacyRelations: const []);
+      const orders = [
+        ArmyMoveOrder(armyId: 'a1', destinationProvinceId: '$ow|P_gp'),
+      ];
+      final out = filterArmyMoveOrdersByDiplomacy(game, gpId, orders);
+      expect(out, orders);
+    });
+  });
+}

--- a/tool/logic_all_provinces_sanctions.yaml
+++ b/tool/logic_all_provinces_sanctions.yaml
@@ -10,7 +10,7 @@ sanctions:
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
   - path: packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
-    line: 174
+    line: 176
     rationale: Single dual-region pass buckets owned provinces and town-tile keys
       by playerId so per-player connectivity loops below run O(1) lookups
       instead of repeating O(provinces) scans (consolidates the legacy line-229


### PR DESCRIPTION
## Summary
- **Work-target cache:** `PerPlayerWorkTargetSelectionCache` idle work-target strategies (`_populateIdleNoPendingTargets`): collect draft `WorkOrder.unitId` values into a `Set` once per refresh strategy call instead of linearly scanning pending orders for every civilian unit.
- **Connectivity:** `resolveConnectivity` builds the topology sea-zone node id set once per resolve and threads it through capital seaboard adjacency + S–S BFS, removing duplicate `topology.nodes` scans per player (Refs #2394 Category E).
- **Incremental build probes:** `IncrementalCandidateValidator.isBuildAccepted` replays existing build orders in `basePrefix` once per validator instance, then evaluates each candidate from a frozen economy snapshot via `BuildOrderValidator.withProjectedEconomy` (Refs #2394 Category B).

## Issue
Tracked by **Refs #2394**. Does not complete the issue.

## Spec
No behavior change; throughput-only. Authorized by existing throughput language in `SPEC/program/order-suggestions.md`, `SPEC/program/turn-resolution.md` / budget rules, and `SPEC/program/logic-dual-region-province-access.md` (connectivity still uses sanctioned topology access only).

## Tests
- `dart test test/per_player_work_target_selection_cache_test.dart test/perf/per_player_work_target_selection_cache_perf_test.dart`
- `dart test test/connectivity_resolver_test.dart test/connectivity_resolver_sea_test.dart test/connectivity_resolver_per_player_province_cache_test.dart test/connectivity_resolver_town_closure_worklist_test.dart test/world/connectivity_resolver_blockade_segment1_test.dart test/world/connectivity_resolver_blockade_segment2_test.dart test/world/connectivity_resolver_blockade_segment3_test.dart test/connectivity_resolver_blockade_additional_test.dart`
- `dart test test/orders/incremental_candidate_validator_equivalence_test.dart test/orders/order_suggestion_shared_validator_equivalence_test.dart`
- Full package (prior slice): `dart test` in `packages/colonizethis_logic`

## Deferred
Remaining #2394 items (shared validator plumbing elsewhere, AST lints, broader map lookups, movement-phase copies, etc.).

Made with [Cursor](https://cursor.com)