### PR TITLE
perf(logic): pass prefetched faction membership into more incremental validators (#2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/combat_resolver.dart
@@ -415,10 +415,10 @@ Game _buildResolvedBattleGame({
   var updatedProvinces = region.provinces;
   var provinceChangedOwner = false;
   if (defenderUnitIds.isEmpty && survivingAttackerFactionId != null) {
-    final idx = updatedProvinces.indexWhere((p) => p.id == ctx.provinceId);
-    if (idx >= 0) {
-      provinceChangedOwner = true;
-    }
+    provinceChangedOwner = provinceListContainsProvinceId(
+      updatedProvinces,
+      ctx.provinceId,
+    );
   }
 
   final recoveredUnits = unitsById.values

--- a/packages/colonizethis_logic/lib/src/combat/military_strength.dart
+++ b/packages/colonizethis_logic/lib/src/combat/military_strength.dart
@@ -4,6 +4,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../constants.dart';
 import '../world/unit_lookup.dart';
 
 /// Military strength aggregation for display (e.g., Game Overview tab).
@@ -58,6 +59,9 @@ double moraleMultiplierForFeedingCoverage(double coverage) {
 /// Computes the effective military level for a faction.
 /// Great Powers use era 4; Minor Nations and Tribes use their effectiveMilitaryLevel.
 int effectiveEraForFaction(Game game, String factionId) {
+  if (game.playerById(factionId) != null) {
+    return 4;
+  }
   for (final m in game.minorNations) {
     if (m.id == factionId) return m.effectiveMilitaryLevel;
   }

--- a/packages/colonizethis_logic/lib/src/combat/military_strength.dart
+++ b/packages/colonizethis_logic/lib/src/combat/military_strength.dart
@@ -72,9 +72,11 @@ int effectiveEraForFaction(Game game, String factionId) {
 ///
 /// Spec: SPEC/program/military-strength.md
 double aggregateMilitaryStrengthForPlayer(Game game, String playerId) {
-  final units = allUnitsFromWorld(game.worldState)
-      .where((u) => u.ownerId == playerId)
-      .toList();
   final effectiveEra = effectiveEraForFaction(game, playerId);
-  return aggregateStrength(units, effectiveEra);
+  var total = 0.0;
+  for (final u in allUnitsFromWorld(game.worldState)) {
+    if (u.ownerId != playerId) continue;
+    total += unitStrength(u, effectiveEra);
+  }
+  return total;
 }

--- a/packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/combat/quick_battle_resolver.dart
@@ -307,12 +307,10 @@ Game applyQuickBattleResultToGame(
 
   var provinces = region.provinces;
   if (result.fortDowngradeFromDestroyedEmplaced) {
-    final idx = provinces.indexWhere((p) => p.id == ctx.provinceId);
-    if (idx >= 0) {
-      final p = provinces[idx];
-      final newLevel = (p.fortLevel - 1).clamp(0, 3);
-      provinces = List.from(provinces)..[idx] = p.copyWith(fortLevel: newLevel);
-    }
+    provinces = decrementFortLevelForProvinceIdIfPresent(
+      provinces,
+      ctx.provinceId,
+    );
   }
 
   final newRegion = RegionData(provinces: provinces, units: survivingUnits);

--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -276,6 +276,13 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
 
     final factionMembership = DiplomacyFactionMembership.from(game);
 
+    // Single-pass army index for full-pass army-move validation (Refs #2394,
+    // SPEC/program/order-suggestions.md — same snapshot semantics as
+    // [IncrementalCandidateValidator._armiesById] for read-only [game]).
+    final armiesById = <String, Army>{
+      for (final a in game.worldState.armies) a.id: a,
+    };
+
     OrderValidators newValidatorBundle() => _validatorFactory(
       game,
       player,
@@ -316,6 +323,7 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
         diplomatic,
         view,
         topology,
+        armiesById: armiesById,
         factionMembership: factionMembership,
       );
     }

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_context.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_context.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../diplomacy/diplomacy_resolver.dart';
 import '../world/player_view.dart';
 import 'incremental_candidate_validator.dart';
 
@@ -36,6 +37,9 @@ IncrementalCandidateValidator buildIncrementalCandidateValidator({
   Map<String, TileMapResult>? tileMapByRegion,
   PlayerView? view,
   Map<String, Unit>? unitsById,
+  /// When callers already built membership for this [game], pass it to avoid a
+  /// second [DiplomacyFactionMembership.from] inside the validator.
+  DiplomacyFactionMembership? factionMembership,
 }) {
   return IncrementalCandidateValidator.forPlayer(
     game: game,
@@ -45,6 +49,7 @@ IncrementalCandidateValidator buildIncrementalCandidateValidator({
     tileMapByRegion: tileMapByRegion,
     view: view,
     unitsById: unitsById,
+    factionMembership: factionMembership,
   );
 }
 

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
@@ -253,6 +253,7 @@ List<ArmyMovePickerDestination> armyMovePickerDestinations({
     topology: topology,
     playerId: playerId,
     basePrefix: currentOrders,
+    factionMembership: factionMembership,
   );
   final declareWarTrialValidatorsByTargetFaction =
       <String, IncrementalCandidateValidator>{};
@@ -294,6 +295,7 @@ List<ArmyMovePickerDestination> armyMovePickerDestinations({
           topology: topology,
           playerId: playerId,
           basePrefix: trialOrders,
+          factionMembership: factionMembership,
         );
       });
       if (!trialValidator.isArmyMoveAccepted(move)) {

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
@@ -67,6 +67,7 @@ List<MoveOrder> suggestMoveOrders(
         sharedCandidateValidator.playerId == playerId,
     'sharedCandidateValidator playerId must match view.playerId',
   );
+  final factionMembership = DiplomacyFactionMembership.from(game);
   final candidateValidator =
       sharedCandidateValidator ??
       IncrementalCandidateValidator.forPlayer(
@@ -74,6 +75,7 @@ List<MoveOrder> suggestMoveOrders(
         topology: topology,
         playerId: playerId,
         basePrefix: currentOrders,
+        factionMembership: factionMembership,
       );
 
   for (final unit in view.ownUnits) {
@@ -366,6 +368,7 @@ List<ArmyMoveOrder> suggestArmyMoveOrders(
         sharedCandidateValidator.playerId == playerId,
     'sharedCandidateValidator playerId must match view.playerId',
   );
+  final factionMembership = DiplomacyFactionMembership.from(game);
   final candidateValidator =
       sharedCandidateValidator ??
       IncrementalCandidateValidator.forPlayer(
@@ -373,6 +376,7 @@ List<ArmyMoveOrder> suggestArmyMoveOrders(
         topology: topology,
         playerId: playerId,
         basePrefix: currentOrders,
+        factionMembership: factionMembership,
       );
 
   final playerOwnedFullProvinceIds = <String>{

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
@@ -258,6 +258,7 @@ List<DiplomaticOrder> _diplomaticCandidatesForTargetOrdered({
   required Set<String> knownTargetIds,
   required Set<String> knownFactionIds,
   required DiplomacyFactionMembership factionMembership,
+  required Map<String, OvertureState> playerOverturesByTargetId,
 }) {
   final treasury = player.treasury;
   final out = <DiplomaticOrder>[];
@@ -302,13 +303,7 @@ List<DiplomaticOrder> _diplomaticCandidatesForTargetOrdered({
     if (overtureOrder != null) out.add(overtureOrder);
   }
 
-  OvertureState? overtureRow;
-  for (final o in game.overtureStates) {
-    if (o.gpId == playerId && o.targetId == targetId) {
-      overtureRow = o;
-      break;
-    }
-  }
+  final overtureRow = playerOverturesByTargetId[targetId];
   if (overtureRow != null) {
     if (overtureRow.hasEmbassy && treasury >= grantAidDefaultAmount) {
       out.add(
@@ -436,6 +431,13 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
   };
   final knownTargetIds = knownTargets.toSet();
 
+  // First matching overture row per target (same order as legacy linear scan).
+  final playerOverturesByTargetId = <String, OvertureState>{};
+  for (final o in game.overtureStates) {
+    if (o.gpId != playerId) continue;
+    playerOverturesByTargetId.putIfAbsent(o.targetId, () => o);
+  }
+
   // One world scan for the suggestion pass: every diplomatic probe shares the
   // same `(game, topology, playerId)` view/units snapshot (Refs #2394).
   final unitsByIdForDiplomatic = unitsByIdFromWorld(game.worldState);
@@ -443,8 +445,7 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
   final unionTargets = <String>{
     ...knownTargets,
     ...otherGps,
-    for (final o in game.overtureStates)
-      if (o.gpId == playerId) o.targetId,
+    ...playerOverturesByTargetId.keys,
   };
 
   final sortedTargetIds = unionTargets.toList()..sort();
@@ -460,6 +461,7 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
       knownTargetIds: knownTargetIds,
       knownFactionIds: knownFactionIds,
       factionMembership: factionMembership,
+      playerOverturesByTargetId: playerOverturesByTargetId,
     );
     var trialOrders = workingOrders;
 

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_naval_diplomatic.dart
@@ -473,6 +473,7 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
       tileMapByRegion: tileMapByRegion,
       view: view,
       unitsById: unitsByIdForDiplomatic,
+      factionMembership: factionMembership,
     );
     for (final candidate in candidates) {
       if (candidate.type == DiplomaticOrderType.grantAid ||
@@ -502,6 +503,7 @@ List<DiplomaticOrder> suggestDiplomaticOrders(
       tileMapByRegion: tileMapByRegion,
       view: view,
       unitsById: unitsByIdForDiplomatic,
+      factionMembership: factionMembership,
     );
     for (final candidate in candidates) {
       if (candidate.type != DiplomaticOrderType.grantAid &&

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_unit_availability.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_unit_availability.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../diplomacy/diplomacy_resolver.dart';
 import '../world/player_view.dart';
 import 'order_suggestion_context.dart';
 import 'order_suggestion_helpers.dart';
@@ -97,12 +98,14 @@ AvailableWorkTargetsForUnit getAvailableWorkTargetsForUnit({
     );
   }
 
+  final factionMembership = DiplomacyFactionMembership.from(game);
   final sharedValidator = buildIncrementalCandidateValidator(
     game: game,
     topology: topology,
     playerId: playerId,
     baseOrders: currentOrders,
     tileMapByRegion: tileMapByRegion,
+    factionMembership: factionMembership,
   );
   final byTarget = <String, Set<String>>{};
   for (final target in allowed) {

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
@@ -4,6 +4,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../diplomacy/diplomacy_resolver.dart';
 import '../world/player_view.dart';
 import '../world/province_lookup.dart';
 import '../world/unit_lookup.dart';
@@ -118,6 +119,7 @@ List<WorkOrder> suggestWorkOrders(
         sharedCandidateValidator.playerId == playerId,
     'sharedCandidateValidator playerId must match view.playerId',
   );
+  final factionMembership = DiplomacyFactionMembership.from(game);
   final candidateValidator =
       sharedCandidateValidator ??
       buildIncrementalCandidateValidator(
@@ -126,6 +128,7 @@ List<WorkOrder> suggestWorkOrders(
         playerId: playerId,
         baseOrders: currentOrders,
         tileMapByRegion: tileMapByRegion,
+        factionMembership: factionMembership,
       );
 
   var needsMerchantPurchaseLandTileIndex = false;

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
@@ -23,6 +23,35 @@ part 'order_suggestion_work_worker.dart';
 part 'order_suggestion_work_spy.dart';
 part 'order_suggestion_work_merchant.dart';
 
+/// Tile keys that are merchant purchase-land suggestion candidates for [game]:
+/// tiles in provinces not owned by any [Game.players] entry that carry a
+/// resource, excluding development-exclusive tiles.
+///
+/// Built once per [suggestWorkOrders] pass when any merchant unit is present so
+/// each merchant does not rescan [allProvinces] (Refs #2394,
+/// SPEC/program/order-suggestions.md).
+List<String> merchantPurchaseLandCandidateTileKeys({
+  required Game game,
+  required Map<String, Map<String, List<String>>> tileKeysByRegion,
+  required Set<String> devExclusiveReservedTiles,
+}) {
+  final resourceByTile = game.worldState.resourceByTileKey;
+  final playerIds = {for (final p in game.players) p.id};
+  final out = <String>[];
+  for (final province in allProvinces(game.worldState)) {
+    final ownerId = province.ownerId;
+    if (ownerId == null || playerIds.contains(ownerId)) continue;
+    final regionId = province.regionId;
+    final tiles = tileKeysByRegion[regionId]?[province.id] ?? const <String>[];
+    for (final tk in tiles) {
+      if (resourceByTile[tk] == null) continue;
+      if (devExclusiveReservedTiles.contains(tk)) continue;
+      out.add(tk);
+    }
+  }
+  return out;
+}
+
 /// Suggests candidate work orders for explorers and civilian workers owned by
 /// [view.playerId]. Worker units (Builder, Engineer, Rail Builder): at least
 /// one suggestion per (unit, allowed target) when any **player-controlled** tile
@@ -99,6 +128,22 @@ List<WorkOrder> suggestWorkOrders(
         tileMapByRegion: tileMapByRegion,
       );
 
+  var needsMerchantPurchaseLandTileIndex = false;
+  for (final unit in view.ownUnits) {
+    if (unit.currentWork != null) continue;
+    if (isMerchantUnit(unit.type)) {
+      needsMerchantPurchaseLandTileIndex = true;
+      break;
+    }
+  }
+  final merchantPurchaseLandTileKeys = needsMerchantPurchaseLandTileIndex
+      ? merchantPurchaseLandCandidateTileKeys(
+          game: game,
+          tileKeysByRegion: tileKeysByRegion,
+          devExclusiveReservedTiles: devExclusiveReservedTiles,
+        )
+      : const <String>[];
+
   for (final unit in view.ownUnits) {
     _addWorkSuggestionsForUnit(
       view: view,
@@ -115,6 +160,7 @@ List<WorkOrder> suggestWorkOrders(
       visibleCandidatesSortedByWorkTarget: visibleCandidatesSortedByWorkTarget,
       playerOwnedProvinceIds: playerOwnedProvinceIds,
       devExclusiveReservedTiles: devExclusiveReservedTiles,
+      merchantPurchaseLandTileKeys: merchantPurchaseLandTileKeys,
       suggestions: suggestions,
       candidateValidator: candidateValidator,
     );
@@ -156,6 +202,7 @@ void _addWorkSuggestionsForUnit({
   required Map<String, List<String>> visibleCandidatesSortedByWorkTarget,
   required Set<String> playerOwnedProvinceIds,
   required Set<String> devExclusiveReservedTiles,
+  required List<String> merchantPurchaseLandTileKeys,
   required List<WorkOrder> suggestions,
   required IncrementalCandidateValidator candidateValidator,
   Map<String, TileMapResult>? tileMapByRegion,
@@ -237,17 +284,12 @@ void _addWorkSuggestionsForUnit({
 
   if (isMerchant) {
     _addMerchantSuggestionsForUnit(
-      game: game,
-      topology: topology,
-      currentOrders: currentOrders,
-      tileKeysByRegion: tileKeysByRegion,
-      playerId: playerId,
       unit: unit,
       type: type,
       unitRegionId: regionId,
       atProvinceId: provinceId,
       existingTargetsByUnit: existingTargetsByUnit,
-      devExclusiveReservedTiles: devExclusiveReservedTiles,
+      purchaseLandCandidateTileKeys: merchantPurchaseLandTileKeys,
       suggestions: suggestions,
       candidateValidator: candidateValidator,
     );

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_merchant.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_merchant.dart
@@ -1,17 +1,12 @@
 part of 'order_suggestion_work.dart';
 
 void _addMerchantSuggestionsForUnit({
-  required Game game,
-  required MapTopology topology,
-  required Orders currentOrders,
-  required Map<String, Map<String, List<String>>> tileKeysByRegion,
-  required String playerId,
   required Unit unit,
   required String type,
   required String unitRegionId,
   required String atProvinceId,
   required Map<String, Set<String>> existingTargetsByUnit,
-  required Set<String> devExclusiveReservedTiles,
+  required List<String> purchaseLandCandidateTileKeys,
   required List<WorkOrder> suggestions,
   required IncrementalCandidateValidator candidateValidator,
 }) {
@@ -21,8 +16,6 @@ void _addMerchantSuggestionsForUnit({
     return;
   }
 
-  final resourceByTile = game.worldState.resourceByTileKey;
-  final playerIds = game.players.map((p) => p.id).toSet();
   WorkSuggestionPipeline.run(
     unit: unit,
     unitType: type,
@@ -33,19 +26,12 @@ void _addMerchantSuggestionsForUnit({
     suggestions: suggestions,
     noCandidateReason: 'no_valid_tile',
     candidatesProvider: () sync* {
-      for (final p in allProvinces(game.worldState)) {
-        if (p.ownerId == null || playerIds.contains(p.ownerId!)) continue;
-        final regionId = p.regionId;
-        final tiles = tileKeysByRegion[regionId]?[p.id] ?? const <String>[];
-        for (final tk in tiles) {
-          if (resourceByTile[tk] == null) continue;
-          if (devExclusiveReservedTiles.contains(tk)) continue;
-          yield WorkOrder(
-            unitId: unit.id,
-            target: kWorkTargetPurchaseLand,
-            targetTileKey: tk,
-          );
-        }
+      for (final tk in purchaseLandCandidateTileKeys) {
+        yield WorkOrder(
+          unitId: unit.id,
+          target: kWorkTargetPurchaseLand,
+          targetTileKey: tk,
+        );
       }
     },
     candidateAcceptor: (candidate) =>

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_tile_keys.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_tile_keys.dart
@@ -2,6 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../diplomacy/diplomacy_resolver.dart';
 import '../world/player_view.dart';
 import '../world/unit_lookup.dart';
 import 'incremental_candidate_validator.dart';
@@ -44,12 +45,14 @@ Set<String> getValidWorkOrderTileKeys(
     workTarget: workTarget,
     tileMapByRegion: tileMapByRegion,
   );
+  final factionMembership = DiplomacyFactionMembership.from(game);
   final candidateValidator = buildIncrementalCandidateValidator(
     game: game,
     topology: topology,
     playerId: playerId,
     baseOrders: currentOrders,
     tileMapByRegion: tileMapByRegion,
+    factionMembership: factionMembership,
   );
   final valid = <String>{};
   for (final tileKey in raw) {
@@ -137,6 +140,7 @@ Set<String> getValidWorkOrderTileKeysWithVisibility({
         playerId: playerId,
         baseOrders: currentOrders,
         tileMapByRegion: tileMapByRegion,
+        factionMembership: DiplomacyFactionMembership.from(game),
       );
 
   final valid = <String>{};

--- a/packages/colonizethis_logic/lib/src/orders/orders_application_completed_work.dart
+++ b/packages/colonizethis_logic/lib/src/orders/orders_application_completed_work.dart
@@ -181,13 +181,17 @@ BuildWorkState _completedWorkUpgradeTown(
   BuildWorkState Function(BuildWorkState, Unit, String) applyExploreCompletion,
 ) {
   final provinces = getProvinces();
-  final idx = provinces.indexWhere((p) => p.id == u.locationProvinceId);
-  if (idx < 0) return s;
-  final p = provinces[idx];
-  final next = List<Province>.from(provinces)
-    ..[idx] = p.copyWith(
-      townDevelopmentLevel: (p.townDevelopmentLevel + 1).clamp(0, 4),
-    );
+  var replaced = false;
+  final next = provinces.map((p) {
+    if (!replaced && p.id == u.locationProvinceId) {
+      replaced = true;
+      return p.copyWith(
+        townDevelopmentLevel: (p.townDevelopmentLevel + 1).clamp(0, 4),
+      );
+    }
+    return p;
+  }).toList();
+  if (!replaced) return s;
   return s.copyWith(work: replaceProvinces(s.work, next));
 }
 
@@ -276,13 +280,17 @@ BuildWorkState _completedWorkBuildFort(
   BuildWorkState Function(BuildWorkState, Unit, String) applyExploreCompletion,
 ) {
   final provinces = getProvinces();
-  final idx = provinces.indexWhere((p) => p.id == u.locationProvinceId);
+  var replaced = false;
+  final nextProvinces = provinces.map((p) {
+    if (!replaced && p.id == u.locationProvinceId) {
+      replaced = true;
+      return p.copyWith(fortLevel: (p.fortLevel + 1).clamp(0, 3));
+    }
+    return p;
+  }).toList();
   WorkOrderState work = s.work;
-  if (idx >= 0) {
-    final p = provinces[idx];
-    final next = List<Province>.from(provinces)
-      ..[idx] = p.copyWith(fortLevel: (p.fortLevel + 1).clamp(0, 3));
-    work = replaceProvinces(work, next);
+  if (replaced) {
+    work = replaceProvinces(work, nextProvinces);
   }
   if (s.topology != null && s.onDialogue != null) {
     final seed =

--- a/packages/colonizethis_logic/lib/src/orders/per_player_work_target_selection_cache.dart
+++ b/packages/colonizethis_logic/lib/src/orders/per_player_work_target_selection_cache.dart
@@ -4,6 +4,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../constants.dart';
+import '../diplomacy/diplomacy_resolver.dart';
 import '../world/player_view.dart';
 import 'incremental_candidate_validator.dart';
 import 'order_suggestion_context.dart';
@@ -77,6 +78,7 @@ class PerPlayerWorkTargetSelectionCache {
   }
 
   void refresh(WorkTargetSelectionSnapshot snapshot) {
+    final factionMembership = DiplomacyFactionMembership.from(snapshot.game);
     final sharedValidator =
         snapshot.sharedCandidateValidator ??
         buildIncrementalCandidateValidator(
@@ -86,6 +88,7 @@ class PerPlayerWorkTargetSelectionCache {
           baseOrders: snapshot.currentOrders,
           tileMapByRegion: snapshot.tileMapByRegion,
           view: snapshot.playerView,
+          factionMembership: factionMembership,
         );
     final snapshotForPopulation = WorkTargetSelectionSnapshot(
       game: snapshot.game,
@@ -148,6 +151,7 @@ class PerPlayerWorkTargetSelectionCache {
     WorkTargetSelectionSnapshot s,
     String workTarget,
   ) {
+    final factionMembership = DiplomacyFactionMembership.from(s.game);
     final sharedValidator =
         s.sharedCandidateValidator ??
         buildIncrementalCandidateValidator(
@@ -157,6 +161,7 @@ class PerPlayerWorkTargetSelectionCache {
           baseOrders: s.currentOrders,
           tileMapByRegion: s.tileMapByRegion,
           view: s.playerView,
+          factionMembership: factionMembership,
         );
     final merged = <String>{};
     for (final unit in _humanCivilianUnits(s.game, s.playerId)) {
@@ -216,6 +221,7 @@ class PerPlayerWorkTargetSelectionCache {
     WorkTargetSelectionSnapshot s,
     String workTarget,
   ) {
+    final factionMembership = DiplomacyFactionMembership.from(s.game);
     final sharedValidator =
         s.sharedCandidateValidator ??
         buildIncrementalCandidateValidator(
@@ -225,6 +231,7 @@ class PerPlayerWorkTargetSelectionCache {
           baseOrders: s.currentOrders,
           tileMapByRegion: s.tileMapByRegion,
           view: s.playerView,
+          factionMembership: factionMembership,
         );
     final pendingWorkUnitIds = <String>{
       for (final w

--- a/packages/colonizethis_logic/lib/src/world/army_migration.dart
+++ b/packages/colonizethis_logic/lib/src/world/army_migration.dart
@@ -89,8 +89,11 @@ bool _ensureHomeArmyForPlayer(WorldState ws, List<Army> armies, Player player) {
   final cap = player.capitalProvinceId;
   if (cap == null) return false;
   final hid = homeArmyIdFor(player.id);
-  final exists = armies.any((a) => a.id == hid && a.ownerId == player.id);
-  if (exists) return false;
+  for (final a in armies) {
+    if (a.id == hid && a.ownerId == player.id) {
+      return false;
+    }
+  }
   armies.add(_homeArmyForPlayerAtCapital(ws, player, cap));
   return true;
 }
@@ -422,10 +425,21 @@ bool _bothMissing(({int owIdx, int nwIdx}) indices) =>
   List<Unit> owUnits,
   List<Unit> nwUnits,
   String regimentUnitId,
-) => (
-  owIdx: owUnits.indexWhere((u) => u.id == regimentUnitId),
-  nwIdx: nwUnits.indexWhere((u) => u.id == regimentUnitId),
-);
+) {
+  // Old-world list is authoritative when the same id appears in both (invalid
+  // state); skip scanning new world once a match is found (Refs #2394).
+  for (var i = 0; i < owUnits.length; i++) {
+    if (owUnits[i].id == regimentUnitId) {
+      return (owIdx: i, nwIdx: -1);
+    }
+  }
+  for (var i = 0; i < nwUnits.length; i++) {
+    if (nwUnits[i].id == regimentUnitId) {
+      return (owIdx: -1, nwIdx: i);
+    }
+  }
+  return (owIdx: -1, nwIdx: -1);
+}
 
 bool _isOldWorldIndex(int owIdx) => owIdx >= 0;
 String _sourceRegionForIndex(bool inOldWorld) =>

--- a/packages/colonizethis_logic/lib/src/world/army_migration.dart
+++ b/packages/colonizethis_logic/lib/src/world/army_migration.dart
@@ -123,8 +123,15 @@ Game _rebuildArmiesFromMilitaryUnits(Game game) {
   );
 }
 
-List<Unit> _militaryUnitsFromWorld(WorldState ws) =>
-    allUnitsFromWorld(ws).where((u) => isMilitaryUnit(u.type)).toList();
+List<Unit> _militaryUnitsFromWorld(WorldState ws) {
+  final out = <Unit>[];
+  for (final u in allUnitsFromWorld(ws)) {
+    if (isMilitaryUnit(u.type)) {
+      out.add(u);
+    }
+  }
+  return out;
+}
 
 Map<String, String> _capitalByPlayer(List<Player> players) => {
   for (final p in players)

--- a/packages/colonizethis_logic/lib/src/world/movement.dart
+++ b/packages/colonizethis_logic/lib/src/world/movement.dart
@@ -422,8 +422,12 @@ Unit? _findCivilianMoveUnit(List<Unit> ow, List<Unit> nw, String id) {
 }
 
 String _regionHoldingUnit(List<Unit> ow, List<Unit> nw, String unitId) {
-  if (ow.any((u) => u.id == unitId)) return kRegionOldWorld;
-  if (nw.any((u) => u.id == unitId)) return kRegionNewWorld;
+  for (final u in ow) {
+    if (u.id == unitId) return kRegionOldWorld;
+  }
+  for (final u in nw) {
+    if (u.id == unitId) return kRegionNewWorld;
+  }
   return '';
 }
 

--- a/packages/colonizethis_logic/lib/src/world/naval.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval.dart
@@ -405,20 +405,27 @@ Set<String> provinceIdsAdjacentToSeaZone(
 /// Region id for a sea zone (from topology node). Returns null when not found;
 /// callers must not infer region by defaulting (SPEC/game/world-model-identity.md).
 String? regionIdForSeaZone(MapTopology topology, String seaZoneId) {
-  final direct = topology.nodes.where((n) => n.id == seaZoneId).toList();
-  if (direct.isNotEmpty) return direct.first.regionId;
+  for (final n in topology.nodes) {
+    if (n.id == seaZoneId) {
+      return n.regionId;
+    }
+  }
   if (isCanonicalSeaZoneId(seaZoneId)) return null;
-  final localMatches = topology.nodes
-      .where(
-        (n) =>
-            n.type == TopologyNodeType.seaZone &&
-            isCanonicalSeaZoneId(n.id) &&
-            canonicalizeSeaZoneId(regionId: n.regionId, seaZoneId: seaZoneId) ==
-                n.id,
-      )
-      .toList();
-  if (localMatches.length == 1) return localMatches.first.regionId;
-  return null;
+  TopologyNode? soleLocal;
+  for (final n in topology.nodes) {
+    if (n.type != TopologyNodeType.seaZone) continue;
+    if (!isCanonicalSeaZoneId(n.id)) continue;
+    if (canonicalizeSeaZoneId(regionId: n.regionId, seaZoneId: seaZoneId) !=
+        n.id) {
+      continue;
+    }
+    if (soleLocal == null) {
+      soleLocal = n;
+    } else {
+      return null;
+    }
+  }
+  return soleLocal?.regionId;
 }
 
 /// Sea zone ids that share an edge with [provinceId] (P↔S). [provinceId] may be

--- a/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_resolution.dart
@@ -190,10 +190,12 @@ _applyDockNavalMoveOrder({
       targetPortId: null,
       targetProvinceId: null,
     );
-    final nextFleets = fleets
-        .where((f) => f.id != fleet.id)
-        .map((f) => f.id == homeFleetId ? updatedHome : f)
-        .toList();
+    // Single-pass list build (Refs #2394): avoids intermediate lazy chains from
+    // `.where` / `.map` when merging a docking fleet into the capital home fleet.
+    final nextFleets = <Fleet>[
+      for (final f in fleets)
+        if (f.id != fleet.id) f.id == homeFleetId ? updatedHome : f,
+    ];
     final nextFleetIndexById = _fleetIndexById(nextFleets);
     fleetById[homeFleetId] = updatedHome;
     fleetById.remove(fleet.id);

--- a/packages/colonizethis_logic/lib/src/world/province_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/world/province_lookup.dart
@@ -21,6 +21,33 @@ Map<String, Province> _provinceIdIndexForList(List<Province> provinces) {
   return index;
 }
 
+/// O(1) check that [provinces] contains a row whose [Province.id] equals [provinceId].
+///
+/// Uses the same per-list index as region-scoped lookup (Refs #2394).
+bool provinceListContainsProvinceId(
+  List<Province> provinces,
+  String provinceId,
+) => _provinceIdIndexForList(provinces).containsKey(provinceId);
+
+/// When a row with [provinceId] exists, returns a new list with that row's
+/// [Province.fortLevel] decremented by one (clamped 0–3). Otherwise returns
+/// [provinces] unchanged (same reference).
+List<Province> decrementFortLevelForProvinceIdIfPresent(
+  List<Province> provinces,
+  String provinceId,
+) {
+  if (!_provinceIdIndexForList(provinces).containsKey(provinceId)) {
+    return provinces;
+  }
+  return [
+    for (final p in provinces)
+      if (p.id == provinceId)
+        p.copyWith(fortLevel: (p.fortLevel - 1).clamp(0, 3))
+      else
+        p,
+  ];
+}
+
 RegionData? _regionForId(WorldState world, String regionId) {
   return regionId == kRegionOldWorld
       ? world.oldWorld

--- a/packages/colonizethis_logic/lib/src/world/province_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/world/province_lookup.dart
@@ -3,6 +3,24 @@ import 'package:colonizethis_models/colonizethis_models.dart'
 
 import '../constants.dart';
 
+/// Id → province row for one [RegionData.provinces] list instance (Refs #2394).
+/// First matching id wins, matching [List.indexWhere] semantics on duplicates.
+final Expando<Map<String, Province>> _provinceByIdForProvinceList =
+    Expando<Map<String, Province>>('provinceByIdForProvinceList');
+
+Map<String, Province> _provinceIdIndexForList(List<Province> provinces) {
+  var index = _provinceByIdForProvinceList[provinces];
+  if (index != null) {
+    return index;
+  }
+  index = <String, Province>{};
+  for (final p in provinces) {
+    index.putIfAbsent(p.id, () => p);
+  }
+  _provinceByIdForProvinceList[provinces] = index;
+  return index;
+}
+
 RegionData? _regionForId(WorldState world, String regionId) {
   return regionId == kRegionOldWorld
       ? world.oldWorld
@@ -15,9 +33,7 @@ Province? _findProvinceInRegion(
   String localId,
 ) {
   final fullId = ProvinceId.full(regionId, localId);
-  final idx = region.provinces.indexWhere((p) => p.id == fullId);
-  if (idx < 0) return null;
-  return region.provinces[idx];
+  return _provinceIdIndexForList(region.provinces)[fullId];
 }
 
 /// Returns the region data for [regionId], or null if unknown.
@@ -158,10 +174,10 @@ extension WorldStateProvinceLookup on WorldState {
   /// lookups prefer [tryGetProvince] with a prefixed id; this exists for
   /// legacy short ids and tests (waigore/colonizethis#2071 Phase 1).
   String? tryGetRegionIdForLegacyProvinceKey(String key) {
-    if (oldWorld.provinces.indexWhere((p) => p.id == key) >= 0) {
+    if (_provinceIdIndexForList(oldWorld.provinces).containsKey(key)) {
       return kRegionOldWorld;
     }
-    if (newWorld.provinces.indexWhere((p) => p.id == key) >= 0) {
+    if (_provinceIdIndexForList(newWorld.provinces).containsKey(key)) {
       return kRegionNewWorld;
     }
     return null;

--- a/packages/colonizethis_logic/lib/src/world/province_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/world/province_lookup.dart
@@ -3,10 +3,28 @@ import 'package:colonizethis_models/colonizethis_models.dart'
 
 import '../constants.dart';
 
+/// Id → first list index for one [RegionData.provinces] list instance (Refs #2394).
+/// First matching id wins, matching [List.indexWhere] semantics on duplicates.
+final Expando<Map<String, int>> _provinceFirstIndexByIdForProvinceList =
+    Expando<Map<String, int>>('provinceFirstIndexByIdForProvinceList');
+
 /// Id → province row for one [RegionData.provinces] list instance (Refs #2394).
 /// First matching id wins, matching [List.indexWhere] semantics on duplicates.
 final Expando<Map<String, Province>> _provinceByIdForProvinceList =
     Expando<Map<String, Province>>('provinceByIdForProvinceList');
+
+Map<String, int> _provinceFirstIndexByIdForList(List<Province> provinces) {
+  final cached = _provinceFirstIndexByIdForProvinceList[provinces];
+  if (cached != null) {
+    return cached;
+  }
+  final built = <String, int>{};
+  for (var i = 0; i < provinces.length; i++) {
+    built.putIfAbsent(provinces[i].id, () => i);
+  }
+  _provinceFirstIndexByIdForProvinceList[provinces] = built;
+  return built;
+}
 
 Map<String, Province> _provinceIdIndexForList(List<Province> provinces) {
   var index = _provinceByIdForProvinceList[provinces];
@@ -28,6 +46,14 @@ bool provinceListContainsProvinceId(
   List<Province> provinces,
   String provinceId,
 ) => _provinceIdIndexForList(provinces).containsKey(provinceId);
+
+/// First index in [provinces] whose [Province.id] equals [provinceId], or null
+/// when none match. Matches [List.indexWhere] semantics on duplicate ids
+/// (first occurrence wins). Refs #2394.
+int? provinceListIndexOfProvinceId(
+  List<Province> provinces,
+  String provinceId,
+) => _provinceFirstIndexByIdForList(provinces)[provinceId];
 
 /// When a row with [provinceId] exists, returns a new list with that row's
 /// [Province.fortLevel] decremented by one (clamped 0–3). Otherwise returns

--- a/packages/colonizethis_logic/lib/src/world/province_ownership_transfer.dart
+++ b/packages/colonizethis_logic/lib/src/world/province_ownership_transfer.dart
@@ -168,8 +168,11 @@ _CanonicalProvinceTransferContext _resolveValidatedCanonicalTransfer(
       '$canonicalId (regionId=$regionId)',
     );
   }
-  final provinceIndex = region.provinces.indexWhere((p) => p.id == canonicalId);
-  if (provinceIndex < 0) {
+  final provinceIndex = provinceListIndexOfProvinceId(
+    region.provinces,
+    canonicalId,
+  );
+  if (provinceIndex == null) {
     throw StateError(
       'Canonical province transfer: province missing from region data '
       '$canonicalId',

--- a/packages/colonizethis_logic/lib/src/world/unit_lookup.dart
+++ b/packages/colonizethis_logic/lib/src/world/unit_lookup.dart
@@ -36,10 +36,15 @@ Map<String, int> regimentTypeCountsForPlayer(
   String playerId,
 ) {
   final map = <String, int>{};
-  for (final u in allUnitsFromWorld(world)) {
-    if (u.ownerId != playerId) continue;
-    map.update(u.type, (v) => v + 1, ifAbsent: () => 1);
+  void count(Iterable<Unit> units) {
+    for (final u in units) {
+      if (u.ownerId != playerId) continue;
+      map.update(u.type, (v) => v + 1, ifAbsent: () => 1);
+    }
   }
+
+  count(world.oldWorld.units);
+  count(world.newWorld.units);
   return map;
 }
 
@@ -73,13 +78,18 @@ final class MilitaryTypeCountsByPlayer {
 /// Builds regiment and ship type counts for all players in one pass.
 MilitaryTypeCountsByPlayer militaryTypeCountsByPlayer(WorldState world) {
   final regimentCountsByPlayerId = <String, Map<String, int>>{};
-  for (final unit in allUnitsFromWorld(world)) {
-    final perPlayer = regimentCountsByPlayerId.putIfAbsent(
-      unit.ownerId,
-      () => <String, int>{},
-    );
-    perPlayer.update(unit.type, (count) => count + 1, ifAbsent: () => 1);
+  void countRegiments(Iterable<Unit> units) {
+    for (final unit in units) {
+      final perPlayer = regimentCountsByPlayerId.putIfAbsent(
+        unit.ownerId,
+        () => <String, int>{},
+      );
+      perPlayer.update(unit.type, (count) => count + 1, ifAbsent: () => 1);
+    }
   }
+
+  countRegiments(world.oldWorld.units);
+  countRegiments(world.newWorld.units);
 
   final shipCountsByPlayerId = <String, Map<String, int>>{};
   for (final fleet in world.fleets) {

--- a/packages/colonizethis_logic/test/orders/merchant_purchase_land_candidate_tile_keys_test.dart
+++ b/packages/colonizethis_logic/test/orders/merchant_purchase_land_candidate_tile_keys_test.dart
@@ -2,7 +2,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/src/orders/order_suggestion_work.dart';
 import 'package:colonizethis_logic/src/world/province_lookup.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
-import 'package:test/test.dart';
+import 'package:colonizethis_test/test.dart';
 
 import '../test_fixtures.dart';
 

--- a/packages/colonizethis_logic/test/orders/merchant_purchase_land_candidate_tile_keys_test.dart
+++ b/packages/colonizethis_logic/test/orders/merchant_purchase_land_candidate_tile_keys_test.dart
@@ -1,0 +1,111 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/src/orders/order_suggestion_work.dart';
+import 'package:colonizethis_logic/src/world/province_lookup.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:test/test.dart';
+
+import '../test_fixtures.dart';
+
+/// Reference ordering from the pre-#2394 merchant nested loops (provinces × tiles).
+List<String> _referencePurchaseLandTileKeys({
+  required Game game,
+  required Map<String, Map<String, List<String>>> tileKeysByRegion,
+  required Set<String> devExclusiveReservedTiles,
+}) {
+  final resourceByTile = game.worldState.resourceByTileKey;
+  final playerIds = game.players.map((p) => p.id).toSet();
+  final out = <String>[];
+  for (final p in allProvinces(game.worldState)) {
+    if (p.ownerId == null || playerIds.contains(p.ownerId!)) continue;
+    final regionId = p.regionId;
+    final tiles = tileKeysByRegion[regionId]?[p.id] ?? const <String>[];
+    for (final tk in tiles) {
+      if (resourceByTile[tk] == null) continue;
+      if (devExclusiveReservedTiles.contains(tk)) continue;
+      out.add(tk);
+    }
+  }
+  return out;
+}
+
+void main() {
+  group('merchantPurchaseLandCandidateTileKeys', () {
+    test('matches legacy nested province scan ordering', () {
+      const ow = 'oldWorld';
+      const gp = 'gp1';
+      const minor = 'minor1';
+      const pPlayer = '$ow|p_owned';
+      const pMinor = '$ow|p_minor';
+      final provinces = [
+        Province(id: pPlayer, regionId: ow, ownerId: gp),
+        Province(id: pMinor, regionId: ow, ownerId: minor),
+      ];
+      const tkMinor0 = '$pMinor|0|0';
+      const tkMinor1 = '$pMinor|0|1';
+      const tkPlayer0 = '$pPlayer|0|0';
+      final game = TestFixtures.minimalGame(
+        id: 'g-merchant-tile-index',
+        players: const [Player(id: gp, displayName: 'GP', isHuman: true)],
+        oldWorld: RegionData(provinces: provinces, units: const []),
+        tileKeysByRegionAndProvince: {
+          ow: {
+            pMinor: [tkMinor1, tkMinor0],
+            pPlayer: [tkPlayer0],
+          },
+        },
+        resourceByTileKey: {
+          tkMinor0: 'grain',
+          tkMinor1: 'iron',
+          tkPlayer0: 'grain',
+        },
+      );
+      final tileKeysByRegion = game.worldState.tileKeysByRegionAndProvince;
+      const devExclusive = <String>{};
+
+      expect(
+        merchantPurchaseLandCandidateTileKeys(
+          game: game,
+          tileKeysByRegion: tileKeysByRegion,
+          devExclusiveReservedTiles: devExclusive,
+        ),
+        _referencePurchaseLandTileKeys(
+          game: game,
+          tileKeysByRegion: tileKeysByRegion,
+          devExclusiveReservedTiles: devExclusive,
+        ),
+      );
+    });
+
+    test('excludes dev-exclusive reserved tiles like legacy path', () {
+      const ow = 'oldWorld';
+      const gp = 'gp1';
+      const minor = 'minor1';
+      const pMinor = '$ow|p_minor';
+      final provinces = [
+        Province(id: pMinor, regionId: ow, ownerId: minor),
+      ];
+      const tk0 = '$pMinor|0|0';
+      const tk1 = '$pMinor|0|1';
+      final game = TestFixtures.minimalGame(
+        id: 'g-merchant-tile-index-reserved',
+        players: const [Player(id: gp, displayName: 'GP', isHuman: true)],
+        oldWorld: RegionData(provinces: provinces, units: const []),
+        tileKeysByRegionAndProvince: {
+          ow: {pMinor: [tk0, tk1]},
+        },
+        resourceByTileKey: {tk0: 'grain', tk1: 'grain'},
+      );
+      final tileKeysByRegion = game.worldState.tileKeysByRegionAndProvince;
+      final devExclusive = {tk1};
+
+      expect(
+        merchantPurchaseLandCandidateTileKeys(
+          game: game,
+          tileKeysByRegion: tileKeysByRegion,
+          devExclusiveReservedTiles: devExclusive,
+        ),
+        [tk0],
+      );
+    });
+  });
+}

--- a/packages/colonizethis_logic/test/province_lookup_test.dart
+++ b/packages/colonizethis_logic/test/province_lookup_test.dart
@@ -202,4 +202,47 @@ void main() {
       );
     });
   });
+
+  group('provinceListContainsProvinceId', () {
+    test('true when id matches a row', () {
+      expect(
+        provinceListContainsProvinceId(world.oldWorld.provinces, 'oldWorld|p1'),
+        isTrue,
+      );
+    });
+
+    test('false when absent', () {
+      expect(
+        provinceListContainsProvinceId(
+          world.oldWorld.provinces,
+          'oldWorld|missing',
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('decrementFortLevelForProvinceIdIfPresent', () {
+    test('returns same list reference when id missing', () {
+      final provinces = world.oldWorld.provinces;
+      final out = decrementFortLevelForProvinceIdIfPresent(
+        provinces,
+        'oldWorld|missing',
+      );
+      expect(identical(out, provinces), isTrue);
+    });
+
+    test('decrements fort for matching row', () {
+      final withFort = Province(
+        id: 'oldWorld|fx',
+        regionId: 'oldWorld',
+        displayName: 'Fort',
+        fortLevel: 2,
+      );
+      final list = [withFort];
+      final out = decrementFortLevelForProvinceIdIfPresent(list, 'oldWorld|fx');
+      expect(identical(out, list), isFalse);
+      expect(out.single.fortLevel, 1);
+    });
+  });
 }

--- a/packages/colonizethis_logic/test/province_lookup_test.dart
+++ b/packages/colonizethis_logic/test/province_lookup_test.dart
@@ -222,6 +222,34 @@ void main() {
     });
   });
 
+  group('provinceListIndexOfProvinceId', () {
+    test('returns first index and matches indexWhere on duplicate ids', () {
+      final dupA = Province(
+        id: 'dup',
+        regionId: 'oldWorld',
+        displayName: 'First',
+      );
+      final dupB = Province(
+        id: 'dup',
+        regionId: 'oldWorld',
+        displayName: 'Second',
+      );
+      final provinces = [dupA, dupB];
+      expect(provinceListIndexOfProvinceId(provinces, 'dup'), 0);
+      expect(provinces.indexWhere((p) => p.id == 'dup'), 0);
+    });
+
+    test('returns null when absent', () {
+      expect(
+        provinceListIndexOfProvinceId(
+          world.oldWorld.provinces,
+          'oldWorld|missing',
+        ),
+        isNull,
+      );
+    });
+  });
+
   group('decrementFortLevelForProvinceIdIfPresent', () {
     test('returns same list reference when id missing', () {
       final provinces = world.oldWorld.provinces;

--- a/tool/logic_all_provinces_sanctions.yaml
+++ b/tool/logic_all_provinces_sanctions.yaml
@@ -96,11 +96,11 @@ sanctions:
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
-  - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_work_merchant.dart
-    line: 36
-    rationale: Merchant work suggestions evaluate provinces in both regions.
+  - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
+    line: 41
+    rationale: merchantPurchaseLandCandidateTileKeys walks all provinces once per suggestWorkOrders pass when merchants are present (foreign-owned resource tiles).
     spec: SPEC/program/logic-dual-region-province-access.md
-    issue: https://github.com/waigore/colonizethisv3/issues/2278
+    issue: https://github.com/waigore/colonizethisv3/issues/2394
 
   - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_helpers.dart
     line: 26

--- a/tool/logic_all_provinces_sanctions.yaml
+++ b/tool/logic_all_provinces_sanctions.yaml
@@ -50,13 +50,13 @@ sanctions:
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
   - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
-    line: 161
+    line: 163
     rationale: Army move suggestions need global province ownership snapshot when per-pass player-owned province ids are not supplied.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
   - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
-    line: 241
+    line: 243
     rationale: Army move picker fallback builds owned-province ids across regions.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2394
@@ -97,7 +97,7 @@ sanctions:
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
   - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
-    line: 41
+    line: 42
     rationale: merchantPurchaseLandCandidateTileKeys walks all provinces once per suggestWorkOrders pass when merchants are present (foreign-owned resource tiles).
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2394


### PR DESCRIPTION
## Summary
Extends the `#2394` hot-path work by (1) threading prefetched `DiplomacyFactionMembership` through incremental validator construction where it was still rebuilt, and (2) building a single `armiesById` snapshot during full-pass `validatePlayerOrdersWithContext` so each army move order uses O(1) army lookup (matching incremental probes).

## Done in this push
- `buildIncrementalCandidateValidator` / army-move and naval diplomatic suggestion paths: optional `factionMembership` forwarded to `IncrementalCandidateValidator.forPlayer` (prior commit on this branch).
- `order_engine.dart`: one `Map<String, Army>` built per validation pass; `validateArmyMove` passes `armiesById` into `ArmyMoveValidator.validate` (latest commit).

## Deferred
- Broader `#2394` items (AST lints, additional map lookups, movement-phase list copies) remain on the issue for follow-up PRs.

## SPEC / AC
- Performance-only refactor; behavior and determinism unchanged. Aligns with `SPEC/program/turn-resolution.md` and `SPEC/program/order-suggestions.md` throughput guidance.

## Tests
- `dart analyze lib/src/orders/order_engine.dart`
- `dart test test/orders/order_engine_core_part1_test.dart test/orders/order_engine_core_part2_test.dart test/orders/incremental_candidate_validator_equivalence_test.dart`

Refs #2394

Made with [Cursor](https://cursor.com)
