### PR TITLE
perf: skip redundant DiplomacyFactionMembership scan in work-target cache (#2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/incremental_candidate_validator.dart
@@ -130,6 +130,14 @@ class IncrementalCandidateValidator {
     return built;
   }
 
+  /// Faction GP/minor/tribe snapshot aligned with this validator (Refs #2394).
+  ///
+  /// Callers that run work-target tile prefilters before incremental probes may
+  /// reuse this so [rawCandidateTilesForWorkTarget] does not rebuild membership
+  /// separately from the same [game] state.
+  DiplomacyFactionMembership get factionMembershipSnapshot =>
+      _factionMembership();
+
   bool isMoveAccepted(MoveOrder candidate) {
     const validator = MoveValidator();
     final standalone = validator

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
@@ -67,7 +67,6 @@ List<MoveOrder> suggestMoveOrders(
         sharedCandidateValidator.playerId == playerId,
     'sharedCandidateValidator playerId must match view.playerId',
   );
-  final factionMembership = DiplomacyFactionMembership.from(game);
   final candidateValidator =
       sharedCandidateValidator ??
       IncrementalCandidateValidator.forPlayer(
@@ -75,7 +74,7 @@ List<MoveOrder> suggestMoveOrders(
         topology: topology,
         playerId: playerId,
         basePrefix: currentOrders,
-        factionMembership: factionMembership,
+        factionMembership: DiplomacyFactionMembership.from(game),
       );
 
   for (final unit in view.ownUnits) {
@@ -368,7 +367,6 @@ List<ArmyMoveOrder> suggestArmyMoveOrders(
         sharedCandidateValidator.playerId == playerId,
     'sharedCandidateValidator playerId must match view.playerId',
   );
-  final factionMembership = DiplomacyFactionMembership.from(game);
   final candidateValidator =
       sharedCandidateValidator ??
       IncrementalCandidateValidator.forPlayer(
@@ -376,7 +374,7 @@ List<ArmyMoveOrder> suggestArmyMoveOrders(
         topology: topology,
         playerId: playerId,
         basePrefix: currentOrders,
-        factionMembership: factionMembership,
+        factionMembership: DiplomacyFactionMembership.from(game),
       );
 
   final playerOwnedFullProvinceIds = <String>{

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work.dart
@@ -166,6 +166,7 @@ List<WorkOrder> suggestWorkOrders(
       merchantPurchaseLandTileKeys: merchantPurchaseLandTileKeys,
       suggestions: suggestions,
       candidateValidator: candidateValidator,
+      factionMembership: factionMembership,
     );
   }
 
@@ -208,6 +209,7 @@ void _addWorkSuggestionsForUnit({
   required List<String> merchantPurchaseLandTileKeys,
   required List<WorkOrder> suggestions,
   required IncrementalCandidateValidator candidateValidator,
+  required DiplomacyFactionMembership factionMembership,
   Map<String, TileMapResult>? tileMapByRegion,
 }) {
   if (unit.currentWork != null) return;
@@ -263,6 +265,7 @@ void _addWorkSuggestionsForUnit({
       suggestions: suggestions,
       candidateValidator: candidateValidator,
       tileMapByRegion: tileMapByRegion,
+      factionMembership: factionMembership,
     );
   }
 

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_tile_keys.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_tile_keys.dart
@@ -39,13 +39,14 @@ Set<String> getValidWorkOrderTileKeys(
     ignorePendingWorkOrderUnitId: unitId,
   );
 
+  final factionMembership = DiplomacyFactionMembership.from(game);
   final raw = rawCandidateTilesForWorkTarget(
     game: game,
     playerId: playerId,
     workTarget: workTarget,
     tileMapByRegion: tileMapByRegion,
+    factionMembership: factionMembership,
   );
-  final factionMembership = DiplomacyFactionMembership.from(game);
   final candidateValidator = buildIncrementalCandidateValidator(
     game: game,
     topology: topology,
@@ -122,6 +123,8 @@ Set<String> getValidWorkOrderTileKeysWithVisibility({
     ignorePendingWorkOrderUnitId: unitId,
   );
 
+  final factionMembership = sharedCandidateValidator?.factionMembershipSnapshot ??
+      DiplomacyFactionMembership.from(game);
   final raw = rawCandidateTilesForWorkTarget(
     game: game,
     playerId: playerId,
@@ -130,6 +133,7 @@ Set<String> getValidWorkOrderTileKeysWithVisibility({
         ? partiallyRevealedPrefixedProvinceIdsForPlayer(game: game, view: view)
         : null,
     tileMapByRegion: tileMapByRegion,
+    factionMembership: factionMembership,
   );
   final sortedVisible = sortedVisibleWorkTargetCandidates(view, raw);
   final candidateValidator =
@@ -140,7 +144,7 @@ Set<String> getValidWorkOrderTileKeysWithVisibility({
         playerId: playerId,
         baseOrders: currentOrders,
         tileMapByRegion: tileMapByRegion,
-        factionMembership: DiplomacyFactionMembership.from(game),
+        factionMembership: factionMembership,
       );
 
   final valid = <String>{};

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_tile_prefilter.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_tile_prefilter.dart
@@ -19,6 +19,7 @@ Set<String> _preFilterWorkTargetTiles({
   required Set<String> ownedProvinceIds,
   Set<String>? exploreProvinceScope,
   Map<String, TileMapResult>? tileMapByRegion,
+  DiplomacyFactionMembership? factionMembership,
 }) {
   final result = <String>{};
   final ctx = _WorkTilePrefilterCtx(
@@ -30,6 +31,7 @@ Set<String> _preFilterWorkTargetTiles({
     ownedProvinceIds: ownedProvinceIds,
     exploreProvinceScope: exploreProvinceScope,
     tileMapByRegion: tileMapByRegion,
+    factionMembership: factionMembership,
     result: result,
   );
   final op = _workTargetPrefilters[workTarget];
@@ -53,6 +55,11 @@ Set<String> rawCandidateTilesForWorkTarget({
   /// invoke this repeatedly in one suggestion pass should supply a shared set
   /// to avoid O(targets × provinces) rescans (Refs #2394).
   Set<String>? playerOwnedProvinceIds,
+
+  /// When non-null, [kWorkTargetPurchaseLand] prefilter reuses this snapshot
+  /// instead of calling [DiplomacyFactionMembership.from] again (Refs #2394 —
+  /// same pass often already built membership for incremental validation).
+  DiplomacyFactionMembership? factionMembership,
 }) {
   final world = game.worldState;
   final ownedProvinceIds =
@@ -71,6 +78,7 @@ Set<String> rawCandidateTilesForWorkTarget({
     ownedProvinceIds: ownedProvinceIds,
     exploreProvinceScope: exploreProvinceScope,
     tileMapByRegion: tileMapByRegion,
+    factionMembership: factionMembership,
   );
 }
 
@@ -153,6 +161,7 @@ class _WorkTilePrefilterCtx {
     required this.ownedProvinceIds,
     required this.exploreProvinceScope,
     required this.tileMapByRegion,
+    this.factionMembership,
     required this.result,
   });
 
@@ -164,6 +173,7 @@ class _WorkTilePrefilterCtx {
   final Set<String> ownedProvinceIds;
   final Set<String>? exploreProvinceScope;
   final Map<String, TileMapResult>? tileMapByRegion;
+  final DiplomacyFactionMembership? factionMembership;
   final Set<String> result;
 }
 
@@ -247,7 +257,8 @@ void _prefilterWtStealTech(_WorkTilePrefilterCtx c) {
 }
 
 void _prefilterWtPurchaseLand(_WorkTilePrefilterCtx c) {
-  final factionMembership = DiplomacyFactionMembership.from(c.game);
+  final factionMembership =
+      c.factionMembership ?? DiplomacyFactionMembership.from(c.game);
   _forEachPrefixedProvinceTile(
     tileKeysByRegion: c.tileKeysByRegion,
     onTile: (provinceId, tileKey) {

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_worker.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_work_worker.dart
@@ -16,6 +16,7 @@ void _addWorkerSuggestionsForUnit({
   required Set<String> devExclusiveReservedTiles,
   required List<WorkOrder> suggestions,
   required IncrementalCandidateValidator candidateValidator,
+  required DiplomacyFactionMembership factionMembership,
   Map<String, TileMapResult>? tileMapByRegion,
 }) {
   final allowedTargets = workOrderTargetsByUnitType[type];
@@ -31,6 +32,7 @@ void _addWorkerSuggestionsForUnit({
           workTarget: target,
           tileMapByRegion: tileMapByRegion,
           playerOwnedProvinceIds: playerOwnedProvinceIds,
+          factionMembership: factionMembership,
         );
         return sortedVisibleWorkTargetCandidates(view, raw);
       },

--- a/packages/colonizethis_logic/lib/src/orders/per_player_work_target_selection_cache.dart
+++ b/packages/colonizethis_logic/lib/src/orders/per_player_work_target_selection_cache.dart
@@ -77,19 +77,29 @@ class PerPlayerWorkTargetSelectionCache {
     return out;
   }
 
+  /// Reuses [WorkTargetSelectionSnapshot.sharedCandidateValidator] when set;
+  /// otherwise builds one and pays [DiplomacyFactionMembership.from] only on
+  /// that path (Refs #2394 — avoid redundant membership scans per strategy).
+  static IncrementalCandidateValidator _sharedOrBuildValidator(
+    WorkTargetSelectionSnapshot s,
+  ) {
+    final existing = s.sharedCandidateValidator;
+    if (existing != null) {
+      return existing;
+    }
+    return buildIncrementalCandidateValidator(
+      game: s.game,
+      topology: s.topology,
+      playerId: s.playerId,
+      baseOrders: s.currentOrders,
+      tileMapByRegion: s.tileMapByRegion,
+      view: s.playerView,
+      factionMembership: DiplomacyFactionMembership.from(s.game),
+    );
+  }
+
   void refresh(WorkTargetSelectionSnapshot snapshot) {
-    final factionMembership = DiplomacyFactionMembership.from(snapshot.game);
-    final sharedValidator =
-        snapshot.sharedCandidateValidator ??
-        buildIncrementalCandidateValidator(
-          game: snapshot.game,
-          topology: snapshot.topology,
-          playerId: snapshot.playerId,
-          baseOrders: snapshot.currentOrders,
-          tileMapByRegion: snapshot.tileMapByRegion,
-          view: snapshot.playerView,
-          factionMembership: factionMembership,
-        );
+    final sharedValidator = _sharedOrBuildValidator(snapshot);
     final snapshotForPopulation = WorkTargetSelectionSnapshot(
       game: snapshot.game,
       playerId: snapshot.playerId,
@@ -151,18 +161,7 @@ class PerPlayerWorkTargetSelectionCache {
     WorkTargetSelectionSnapshot s,
     String workTarget,
   ) {
-    final factionMembership = DiplomacyFactionMembership.from(s.game);
-    final sharedValidator =
-        s.sharedCandidateValidator ??
-        buildIncrementalCandidateValidator(
-          game: s.game,
-          topology: s.topology,
-          playerId: s.playerId,
-          baseOrders: s.currentOrders,
-          tileMapByRegion: s.tileMapByRegion,
-          view: s.playerView,
-          factionMembership: factionMembership,
-        );
+    final sharedValidator = _sharedOrBuildValidator(s);
     final merged = <String>{};
     for (final unit in _humanCivilianUnits(s.game, s.playerId)) {
       final supportsTarget =
@@ -221,18 +220,7 @@ class PerPlayerWorkTargetSelectionCache {
     WorkTargetSelectionSnapshot s,
     String workTarget,
   ) {
-    final factionMembership = DiplomacyFactionMembership.from(s.game);
-    final sharedValidator =
-        s.sharedCandidateValidator ??
-        buildIncrementalCandidateValidator(
-          game: s.game,
-          topology: s.topology,
-          playerId: s.playerId,
-          baseOrders: s.currentOrders,
-          tileMapByRegion: s.tileMapByRegion,
-          view: s.playerView,
-          factionMembership: factionMembership,
-        );
+    final sharedValidator = _sharedOrBuildValidator(s);
     final pendingWorkUnitIds = <String>{
       for (final w
           in s.currentOrders.workOrdersByPlayerId[s.playerId] ??

--- a/packages/colonizethis_logic/test/orders/order_suggestion_work_tile_prefilter_purchase_land_test.dart
+++ b/packages/colonizethis_logic/test/orders/order_suggestion_work_tile_prefilter_purchase_land_test.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/src/constants.dart';
+import 'package:colonizethis_logic/src/diplomacy/diplomacy_resolver.dart';
 import 'package:colonizethis_logic/src/orders/order_suggestion_work_tile_prefilter.dart';
 import 'package:colonizethis_logic/src/world/province_lookup.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
@@ -62,6 +63,15 @@ void main() {
 
         expect(tiles, contains(minorTile));
         expect(tiles, isNot(contains(gpTile)));
+
+        final membership = DiplomacyFactionMembership.from(game);
+        final tilesWithExplicitMembership = rawCandidateTilesForWorkTarget(
+          game: game,
+          playerId: playerId,
+          workTarget: kWorkTargetPurchaseLand,
+          factionMembership: membership,
+        );
+        expect(tilesWithExplicitMembership, tiles);
       },
     );
 

--- a/tool/logic_all_provinces_sanctions.yaml
+++ b/tool/logic_all_provinces_sanctions.yaml
@@ -50,13 +50,13 @@ sanctions:
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
   - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
-    line: 163
+    line: 162
     rationale: Army move suggestions need global province ownership snapshot when per-pass player-owned province ids are not supplied.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
   - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_move_army.dart
-    line: 243
+    line: 242
     rationale: Army move picker fallback builds owned-province ids across regions.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2394

--- a/tool/logic_all_provinces_sanctions.yaml
+++ b/tool/logic_all_provinces_sanctions.yaml
@@ -37,14 +37,14 @@ sanctions:
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
   - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_work_tile_prefilter.dart
-    line: 61
+    line: 68
     rationale: Work tile prefilter collects owned province ids via all provinces when
       callers do not supply a shared owned-province set.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2394
 
   - path: packages/colonizethis_logic/lib/src/orders/order_suggestion_work_tile_prefilter.dart
-    line: 116
+    line: 124
     rationale: Town work targets enumerate town tiles across owned provinces in both regions.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2278


### PR DESCRIPTION
## Summary
- **Done in this push:** `PerPlayerWorkTargetSelectionCache` no longer calls `DiplomacyFactionMembership.from` when `WorkTargetSelectionSnapshot.sharedCandidateValidator` is already set. `DiplomacyFactionMembership.from` runs only when building a new incremental validator via `_sharedOrBuildValidator`.
- **Why:** Each default-strategy population invoked `from` even though the shared validator path did not use that value (~11 redundant full scans per `refresh` over the strategy loop). Aligns with GitHub #2394 / `SPEC/program/order-suggestions.md` throughput bounds (reuse snapshots; avoid duplicate global scans).

## Tests
- `cd packages/colonizethis_logic && dart analyze lib/src/orders/per_player_work_target_selection_cache.dart`
- `dart test test/per_player_work_target_selection_cache_test.dart test/perf/per_player_work_target_selection_cache_perf_test.dart`

## Deferred (issue #2394)
- Broader Category A–F hot-path memoization and AST enforcement listed on the issue remain out of scope for this small slice.

Refs #2394

Made with [Cursor](https://cursor.com)