### PR TITLE
refactor(logic): unify full-pass validation phases in order engine (Refs #2391)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_engine.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_engine.dart
@@ -113,8 +113,6 @@ typedef OrderValidatorFactory =
 
 /// One post–move/army validation round: caller constructs a fresh [OrderValidators]
 /// bundle, then invokes this to append results and propagate economy state.
-typedef _OrderCategoryDescriptor = void Function(OrderValidators validators);
-
 /// Order engine: holds per-player orders, validates in submission order,
 /// exposes projected effects. SPEC/program/order-engine.md.
 /// Slot table and public add/remove/withContext methods are generated from
@@ -299,109 +297,135 @@ class OrderEngine with _OrderEngineGeneratedOrderMethods {
       factionMembership,
     );
 
-    var validators = newValidatorBundle();
-
-    OrderValidationResult validateMove(MoveOrder o, bool previousRejected) {
-      return validators.moveValidator.validate(
-        o,
-        game,
-        playerId,
-        unitsById,
-        diplomatic,
-        view,
-        topology,
-        previousRejected: previousRejected,
-        factionMembership: factionMembership,
-      );
-    }
-
-    OrderValidationResult validateArmyMove(ArmyMoveOrder o) {
-      return validators.armyMoveValidator.validate(
-        o,
-        game,
-        playerId,
-        diplomatic,
-        view,
-        topology,
-        armiesById: armiesById,
-        factionMembership: factionMembership,
-      );
-    }
-
-    rejected = _appendValidationResults(
-      results,
-      moves,
-      rejected,
-      (o, prev) => validateMove(o, prev),
-    );
-
-    rejected = _appendValidationResults(
-      results,
-      armyMoves,
-      rejected,
-      (o, prev) => prev ? previousInvalidOrderResult : validateArmyMove(o),
-    );
-
-    final postArmyCategories = <_OrderCategoryDescriptor>[
-      (v) {
-        rejected = _appendValidationResults(
-          results,
-          builds,
-          rejected,
-          (o, prev) => v.buildValidator.validate(o, previousRejected: prev),
-        );
-        stockpile = v.buildValidator.stockpile;
-        treasury = v.buildValidator.treasury;
-      },
-      (v) {
-        rejected = _appendValidationResults(
-          results,
-          works,
-          rejected,
-          (o, prev) => v.workValidator.validate(o, previousRejected: prev),
-        );
-        stockpile = v.workValidator.stockpile;
-        treasury = v.workValidator.treasury;
-      },
-      (v) {
-        final afterDiplomatic =
-            _appendValidationResultsWithState<DiplomaticOrder, int>(
-              results,
-              diplomatic,
-              rejected,
-              treasury,
-              (o, prev) {
-                final r = v.diplomaticValidator.validate(
+    // One ordered list: move + army share the initial bundle; each later
+    // category refreshes validators so stockpile/treasury/diplomatic state
+    // matches incremental validation ordering (Refs #2391 AC7,
+    // SPEC/program/order-engine.md).
+    final validationPhases =
+        <({bool refreshBundleBefore, void Function(OrderValidators) run})>[
+          (
+            refreshBundleBefore: false,
+            run: (v) {
+              rejected = _appendValidationResults(
+                results,
+                moves,
+                rejected,
+                (o, prev) => v.moveValidator.validate(
+                  o,
+                  game,
+                  playerId,
+                  unitsById,
+                  diplomatic,
+                  view,
+                  topology,
+                  previousRejected: prev,
+                  factionMembership: factionMembership,
+                ),
+              );
+            },
+          ),
+          (
+            refreshBundleBefore: false,
+            run: (v) {
+              rejected = _appendValidationResults(
+                results,
+                armyMoves,
+                rejected,
+                (o, prev) => prev
+                    ? previousInvalidOrderResult
+                    : v.armyMoveValidator.validate(
+                        o,
+                        game,
+                        playerId,
+                        diplomatic,
+                        view,
+                        topology,
+                        armiesById: armiesById,
+                        factionMembership: factionMembership,
+                      ),
+              );
+            },
+          ),
+          (
+            refreshBundleBefore: true,
+            run: (v) {
+              rejected = _appendValidationResults(
+                results,
+                builds,
+                rejected,
+                (o, prev) =>
+                    v.buildValidator.validate(o, previousRejected: prev),
+              );
+              stockpile = v.buildValidator.stockpile;
+              treasury = v.buildValidator.treasury;
+            },
+          ),
+          (
+            refreshBundleBefore: true,
+            run: (v) {
+              rejected = _appendValidationResults(
+                results,
+                works,
+                rejected,
+                (o, prev) =>
+                    v.workValidator.validate(o, previousRejected: prev),
+              );
+              stockpile = v.workValidator.stockpile;
+              treasury = v.workValidator.treasury;
+            },
+          ),
+          (
+            refreshBundleBefore: true,
+            run: (v) {
+              final afterDiplomatic =
+                  _appendValidationResultsWithState<DiplomaticOrder, int>(
+                    results,
+                    diplomatic,
+                    rejected,
+                    treasury,
+                    (o, prev) {
+                      final r = v.diplomaticValidator.validate(
+                        o,
+                        previousRejected: prev,
+                      );
+                      return (result: r.result, state: r.treasury);
+                    },
+                  );
+              rejected = afterDiplomatic.rejected;
+              treasury = afterDiplomatic.state;
+            },
+          ),
+          (
+            refreshBundleBefore: true,
+            run: (v) {
+              rejected = _appendValidationResults(
+                results,
+                navals,
+                rejected,
+                (o, prev) => v.navalValidator.validateNavalMove(
                   o,
                   previousRejected: prev,
-                );
-                return (result: r.result, state: r.treasury);
-              },
-            );
-        rejected = afterDiplomatic.rejected;
-        treasury = afterDiplomatic.state;
-      },
-      (v) {
-        rejected = _appendValidationResults(
-          results,
-          navals,
-          rejected,
-          (o, prev) =>
-              v.navalValidator.validateNavalMove(o, previousRejected: prev),
-        );
-        rejected = _appendValidationResults(
-          results,
-          missions,
-          rejected,
-          (o, prev) =>
-              v.navalValidator.validateNavalMission(o, previousRejected: prev),
-        );
-      },
-    ];
+                ),
+              );
+              rejected = _appendValidationResults(
+                results,
+                missions,
+                rejected,
+                (o, prev) => v.navalValidator.validateNavalMission(
+                  o,
+                  previousRejected: prev,
+                ),
+              );
+            },
+          ),
+        ];
 
-    for (final step in postArmyCategories) {
-      validators = newValidatorBundle();
-      step(validators);
+    var validators = newValidatorBundle();
+    for (final phase in validationPhases) {
+      if (phase.refreshBundleBefore) {
+        validators = newValidatorBundle();
+      }
+      phase.run(validators);
     }
     return results;
   }

--- a/packages/colonizethis_logic/test/order_engine_validator_injection_test.dart
+++ b/packages/colonizethis_logic/test/order_engine_validator_injection_test.dart
@@ -1,7 +1,6 @@
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/src/orders/order_engine.dart';
-import 'package:colonizethis_logic/src/orders/validator_bundle.dart';
 import 'package:colonizethis_logic/src/orders/validators/army_move_validator.dart';
 import 'package:colonizethis_logic/src/orders/validators/build_order_validator.dart';
 import 'package:colonizethis_logic/src/orders/validators/diplomatic_order_validator.dart';
@@ -107,5 +106,53 @@ void main() {
     expect(results, hasLength(1));
     expect(results.single.isAccepted, isFalse);
     expect(results.single.reason, 'Injected move validator rejection');
+  });
+
+  test(
+    'validatePlayerOrdersWithContext builds five validator bundles '
+    '(shared move+army, then fresh per later category; Refs #2391 AC7)',
+    () {
+    var factoryCalls = 0;
+    final game = TestFixtures.minimalGame();
+    final topology = MapTopology(nodes: const [], edges: const []);
+    final engine = OrderEngine(
+      initialOrders: const Orders(),
+      validatorFactory:
+          (
+            Game game,
+            Player player,
+            String playerId,
+            PlayerView view,
+            MapTopology topology,
+            Map<String, Unit> unitsById,
+            List<DiplomaticOrder> diplomaticOrders,
+            Map<String, TileMapResult>? tileMapByRegion,
+            Set<String> civilianDraftMoveUnitIds,
+            Set<String> devExclusiveTiles,
+            Stockpile stockpile,
+            int treasury,
+            DiplomacyFactionMembership factionMembership,
+          ) {
+            factoryCalls++;
+            return createOrderValidators(
+              game: game,
+              player: player,
+              playerId: playerId,
+              view: view,
+              topology: topology,
+              unitsById: unitsById,
+              diplomaticOrders: diplomaticOrders,
+              tileMapByRegion: tileMapByRegion,
+              civilianDraftMoveUnitIds: civilianDraftMoveUnitIds,
+              devExclusiveTiles: devExclusiveTiles,
+              stockpile: stockpile,
+              treasury: treasury,
+              factionMembership: factionMembership,
+            );
+          },
+    );
+
+    engine.validatePlayerOrdersWithContext(game, topology, 'h1');
+    expect(factoryCalls, 5);
   });
 }


### PR DESCRIPTION
## Summary

- Collapse `validatePlayerOrdersWithContext` move/army steps and the post-army category passes into one ordered `validationPhases` list.
- Each phase declares whether to refresh the validator bundle first, preserving the prior semantics: one shared bundle for move + army; a fresh bundle before builds, works, diplomatic, and naval (missions still paired with naval moves in the naval phase).

## Deferred

- Remaining #2391 AC items (if any) beyond this AC7 structural slice — tracked on the issue.

## Tests

- `dart test test/order_engine_validator_injection_test.dart test/orders/order_engine_core_part1_test.dart test/orders/order_engine_core_part2_test.dart` (from `packages/colonizethis_logic`)

Refs #2391


Made with [Cursor](https://cursor.com)