### PR TITLE
test(e2e): compare_e2e_timing.sh fixture tests for #2336

### DIFF
--- a/test/compare_e2e_timing_test.dart
+++ b/test/compare_e2e_timing_test.dart
@@ -1,0 +1,72 @@
+// Refs #2336 — guards tool/compare_e2e_timing.sh AC8/AC9 table output.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late String repoRoot;
+  late String compareScript;
+
+  setUp(() {
+    repoRoot = Directory.current.path;
+    compareScript = p.join(repoRoot, 'tool', 'compare_e2e_timing.sh');
+  });
+
+  test('compare_e2e_timing.sh reports AC9 PASS when reduction meets threshold',
+      () async {
+    final baseline = p.join(
+      repoRoot,
+      'test',
+      'fixtures',
+      'e2e_timing',
+      'baseline_summary.md',
+    );
+    final after = p.join(
+      repoRoot,
+      'test',
+      'fixtures',
+      'e2e_timing',
+      'after_summary.md',
+    );
+    final result = await Process.run(
+      'bash',
+      [compareScript, baseline, after, '--min-reduction-pct', '25'],
+      runInShell: false,
+    );
+    expect(result.exitCode, 0, reason: '${result.stderr}\n${result.stdout}');
+    final out = result.stdout as String;
+    expect(out, contains('## Aggregate (sum of per-test medians)'));
+    expect(out, contains('| Suite total | 270.00s | 175.00s |'));
+    expect(out, contains('**AC9 (25% aggregate reduction):** PASS'));
+  });
+
+  test('compare_e2e_timing.sh reports AC9 FAIL when reduction is below threshold',
+      () async {
+    final baseline = p.join(
+      repoRoot,
+      'test',
+      'fixtures',
+      'e2e_timing',
+      'baseline_summary.md',
+    );
+    final after = p.join(
+      repoRoot,
+      'test',
+      'fixtures',
+      'e2e_timing',
+      'after_summary.md',
+    );
+    final result = await Process.run(
+      'bash',
+      [compareScript, baseline, after, '--min-reduction-pct', '50'],
+      runInShell: false,
+    );
+    expect(result.exitCode, 0, reason: '${result.stderr}\n${result.stdout}');
+    expect(
+      result.stdout as String,
+      contains('**AC9 (50% aggregate reduction):** FAIL'),
+    );
+  });
+}

--- a/test/fixtures/e2e_timing/after_summary.md
+++ b/test/fixtures/e2e_timing/after_summary.md
@@ -1,0 +1,19 @@
+# E2E timing run fixture (after)
+
+### new_game_full_turn_e2e_test
+- min: 70.00s
+- median: 80.00s
+- max: 90.00s
+
+### new_game_capital_panel_e2e_test
+- min: 30.00s
+- median: 35.00s
+- max: 40.00s
+
+### new_game_fleet_reaches_new_world_e2e_test
+- min: 50.00s
+- median: 60.00s
+- max: 70.00s
+
+## Aggregate (sum of per-test medians)
+- **175.00s** (3 tests)

--- a/test/fixtures/e2e_timing/baseline_summary.md
+++ b/test/fixtures/e2e_timing/baseline_summary.md
@@ -1,0 +1,19 @@
+# E2E timing run fixture (baseline)
+
+### new_game_full_turn_e2e_test
+- min: 100.00s
+- median: 120.00s
+- max: 140.00s
+
+### new_game_capital_panel_e2e_test
+- min: 40.00s
+- median: 50.00s
+- max: 60.00s
+
+### new_game_fleet_reaches_new_world_e2e_test
+- min: 80.00s
+- median: 100.00s
+- max: 120.00s
+
+## Aggregate (sum of per-test medians)
+- **270.00s** (3 tests)


### PR DESCRIPTION
## Summary

Follow-up to merged #2486. Adds repo-root unit tests that exercise `tool/compare_e2e_timing.sh` against checked-in fixture summaries so AC8/AC9 table formatting and PASS/FAIL thresholds cannot regress silently.

## Scope (this PR)

- `test/compare_e2e_timing_test.dart` — PASS at 25% reduction, FAIL at 50% on fixtures
- `test/fixtures/e2e_timing/baseline_summary.md` and `after_summary.md` — synthetic medians (270s → 175s aggregate)

## Deferred (issue #2336)

- **AC6–AC7:** Linux desktop `integration_test/` 3× consecutive passes (requires display or `xvfb-run`; not available on agent host)
- **AC8–AC9:** Real baseline vs post-refactor wall-clock table — maintainer must run `tool/run_e2e_timing.sh 3` on `dev` tip then PR branch and paste into PR + `tool/compare_e2e_timing.sh`
- **AC10:** Flakiness check from those runs

Refs #2336

Made with [Cursor](https://cursor.com)