### PR TITLE
perf(logic): stateless accept helpers reuse shared validator (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_context.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_context.dart
@@ -65,23 +65,71 @@ IncrementalCandidateValidator buildIncrementalCandidateValidator({
   );
 }
 
+/// Resolves the [IncrementalCandidateValidator] for a stateless candidate probe.
+///
+/// When [sharedCandidateValidator] is supplied for the same suggestion pass,
+/// rebinds via [IncrementalCandidateValidator.forBasePrefix] when [baseOrders]
+/// differs from the embedded prefix; otherwise reuses the instance without
+/// incrementing [incrementalCandidateValidatorBuildCountForTests]. Refs #2394.
+IncrementalCandidateValidator incrementalValidatorForCandidateProbe({
+  required Game game,
+  required MapTopology topology,
+  required String playerId,
+  required Orders baseOrders,
+  Map<String, TileMapResult>? tileMapByRegion,
+  PlayerView? view,
+  Map<String, Unit>? unitsById,
+  DiplomacyFactionMembership? factionMembership,
+  IncrementalCandidateValidator? sharedCandidateValidator,
+}) {
+  assert(
+    sharedCandidateValidator == null ||
+        sharedCandidateValidator.playerId == playerId,
+    'sharedCandidateValidator playerId must match playerId',
+  );
+  final shared = sharedCandidateValidator;
+  if (shared != null) {
+    return shared.basePrefix == baseOrders
+        ? shared
+        : shared.forBasePrefix(baseOrders);
+  }
+  return buildIncrementalCandidateValidator(
+    game: game,
+    topology: topology,
+    playerId: playerId,
+    baseOrders: baseOrders,
+    tileMapByRegion: tileMapByRegion,
+    view: view,
+    unitsById: unitsById,
+    factionMembership: factionMembership,
+  );
+}
+
 bool isMoveOrderAccepted(
   Game game,
   MapTopology topology,
   String playerId,
   Orders baseOrders,
-  MoveOrder candidate,
-) {
+  MoveOrder candidate, {
+  IncrementalCandidateValidator? sharedCandidateValidator,
+  PlayerView? view,
+  Map<String, Unit>? unitsById,
+  DiplomacyFactionMembership? factionMembership,
+}) {
   // Stateless candidate-probe path: validate the candidate against an
   // already-accepted [baseOrders] without re-running full-pass
   // [validatePlayerOrdersWithContext]. SPEC/program/order-suggestions.md
   // § Incremental candidate validation; SPEC/program/order-engine.md
   // § Validation (candidate-probe context). Refs #2237.
-  final validator = buildIncrementalCandidateValidator(
+  final validator = incrementalValidatorForCandidateProbe(
     game: game,
     topology: topology,
     playerId: playerId,
     baseOrders: baseOrders,
+    view: view,
+    unitsById: unitsById,
+    factionMembership: factionMembership,
+    sharedCandidateValidator: sharedCandidateValidator,
   );
   return validator.isMoveAccepted(candidate);
 }
@@ -91,17 +139,25 @@ bool isArmyMoveOrderAccepted(
   MapTopology topology,
   String playerId,
   Orders baseOrders,
-  ArmyMoveOrder candidate,
-) {
+  ArmyMoveOrder candidate, {
+  IncrementalCandidateValidator? sharedCandidateValidator,
+  PlayerView? view,
+  Map<String, Unit>? unitsById,
+  DiplomacyFactionMembership? factionMembership,
+}) {
   // Stateless candidate-probe path: validate the candidate against
   // [baseOrders]'s diplomatic context without re-running full-pass
   // [validatePlayerOrdersWithContext]. SPEC/program/order-suggestions.md
   // § Incremental candidate validation. Refs #2237.
-  final validator = buildIncrementalCandidateValidator(
+  final validator = incrementalValidatorForCandidateProbe(
     game: game,
     topology: topology,
     playerId: playerId,
     baseOrders: baseOrders,
+    view: view,
+    unitsById: unitsById,
+    factionMembership: factionMembership,
+    sharedCandidateValidator: sharedCandidateValidator,
   );
   return validator.isArmyMoveAccepted(candidate);
 }
@@ -113,13 +169,21 @@ bool isWorkOrderAccepted(
   Orders baseOrders,
   WorkOrder candidate, {
   Map<String, TileMapResult>? tileMapByRegion,
+  IncrementalCandidateValidator? sharedCandidateValidator,
+  PlayerView? view,
+  Map<String, Unit>? unitsById,
+  DiplomacyFactionMembership? factionMembership,
 }) {
-  final validator = buildIncrementalCandidateValidator(
+  final validator = incrementalValidatorForCandidateProbe(
     game: game,
     topology: topology,
     playerId: playerId,
     baseOrders: baseOrders,
     tileMapByRegion: tileMapByRegion,
+    view: view,
+    unitsById: unitsById,
+    factionMembership: factionMembership,
+    sharedCandidateValidator: sharedCandidateValidator,
   );
   return isWorkOrderAcceptedWithValidator(validator, candidate);
 }
@@ -129,13 +193,21 @@ bool isBuildOrderAccepted(
   MapTopology topology,
   String playerId,
   Orders baseOrders,
-  BuildUnitOrder candidate,
-) {
-  final validator = buildIncrementalCandidateValidator(
+  BuildUnitOrder candidate, {
+  IncrementalCandidateValidator? sharedCandidateValidator,
+  PlayerView? view,
+  Map<String, Unit>? unitsById,
+  DiplomacyFactionMembership? factionMembership,
+}) {
+  final validator = incrementalValidatorForCandidateProbe(
     game: game,
     topology: topology,
     playerId: playerId,
     baseOrders: baseOrders,
+    view: view,
+    unitsById: unitsById,
+    factionMembership: factionMembership,
+    sharedCandidateValidator: sharedCandidateValidator,
   );
   return isBuildOrderAcceptedWithValidator(validator, candidate);
 }
@@ -145,15 +217,23 @@ bool isNavalMoveOrderAccepted(
   MapTopology topology,
   String playerId,
   Orders baseOrders,
-  NavalMoveOrder candidate,
-) {
+  NavalMoveOrder candidate, {
+  IncrementalCandidateValidator? sharedCandidateValidator,
+  PlayerView? view,
+  Map<String, Unit>? unitsById,
+  DiplomacyFactionMembership? factionMembership,
+}) {
   // Stateless candidate-probe path. SPEC/program/order-suggestions.md
   // § Incremental candidate validation. Refs #2237.
-  final validator = buildIncrementalCandidateValidator(
+  final validator = incrementalValidatorForCandidateProbe(
     game: game,
     topology: topology,
     playerId: playerId,
     baseOrders: baseOrders,
+    view: view,
+    unitsById: unitsById,
+    factionMembership: factionMembership,
+    sharedCandidateValidator: sharedCandidateValidator,
   );
   return validator.isNavalMoveAccepted(candidate);
 }
@@ -163,15 +243,23 @@ bool isNavalMissionOrderAccepted(
   MapTopology topology,
   String playerId,
   Orders baseOrders,
-  NavalMissionOrder candidate,
-) {
+  NavalMissionOrder candidate, {
+  IncrementalCandidateValidator? sharedCandidateValidator,
+  PlayerView? view,
+  Map<String, Unit>? unitsById,
+  DiplomacyFactionMembership? factionMembership,
+}) {
   // Stateless candidate-probe path. SPEC/program/order-suggestions.md
   // § Incremental candidate validation. Refs #2237.
-  final validator = buildIncrementalCandidateValidator(
+  final validator = incrementalValidatorForCandidateProbe(
     game: game,
     topology: topology,
     playerId: playerId,
     baseOrders: baseOrders,
+    view: view,
+    unitsById: unitsById,
+    factionMembership: factionMembership,
+    sharedCandidateValidator: sharedCandidateValidator,
   );
   return validator.isNavalMissionAccepted(candidate);
 }
@@ -190,8 +278,10 @@ bool isDiplomaticOrderAccepted(
   /// § Throughput bounds.
   PlayerView? view,
   Map<String, Unit>? unitsById,
+  DiplomacyFactionMembership? factionMembership,
+  IncrementalCandidateValidator? sharedCandidateValidator,
 }) {
-  final validator = buildIncrementalCandidateValidator(
+  final validator = incrementalValidatorForCandidateProbe(
     game: game,
     topology: topology,
     playerId: playerId,
@@ -199,6 +289,8 @@ bool isDiplomaticOrderAccepted(
     tileMapByRegion: tileMapByRegion,
     view: view,
     unitsById: unitsById,
+    factionMembership: factionMembership,
+    sharedCandidateValidator: sharedCandidateValidator,
   );
   return validator.isDiplomaticAccepted(candidate);
 }

--- a/packages/colonizethis_logic/test/order_suggestion_context_helpers_test.dart
+++ b/packages/colonizethis_logic/test/order_suggestion_context_helpers_test.dart
@@ -201,6 +201,76 @@ void main() {
     );
 
     test(
+      'stateless accept helpers reuse sharedCandidateValidator without rebuild',
+      () {
+        final game = Game(
+          id: 'g1',
+          worldState: WorldState(
+            turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'A', isHuman: false),
+            Player(id: 'gp2', displayName: 'B', isHuman: false),
+          ],
+          diplomacyRelations: const [
+            DiplomacyRelation(
+              factionId1: 'gp1',
+              factionId2: 'gp2',
+              state: RelationState.atPeace,
+              level: RelationLevel.neutral,
+            ),
+          ],
+        );
+        const topology = MapTopology(nodes: [], edges: []);
+        const baseOrders = Orders();
+        final sharedView = buildPlayerView(game, topology, 'gp1');
+        final sharedUnits = unitsByIdFromWorld(game.worldState);
+        resetIncrementalCandidateValidatorBuildCountForTests();
+        final sharedValidator = buildIncrementalCandidateValidator(
+          game: game,
+          topology: topology,
+          playerId: 'gp1',
+          baseOrders: baseOrders,
+          view: sharedView,
+          unitsById: sharedUnits,
+        );
+        expect(incrementalCandidateValidatorBuildCountForTests, 1);
+
+        const candidate = DiplomaticOrder(
+          type: DiplomaticOrderType.alliance,
+          targetFactionId: 'gp2',
+        );
+        for (var i = 0; i < 5; i++) {
+          isDiplomaticOrderAccepted(
+            game,
+            topology,
+            'gp1',
+            baseOrders,
+            candidate,
+            sharedCandidateValidator: sharedValidator,
+          );
+          isMoveOrderAccepted(
+            game,
+            topology,
+            'gp1',
+            baseOrders,
+            const MoveOrder(unitId: 'u1', destinationTileKey: 't'),
+            sharedCandidateValidator: sharedValidator,
+          );
+        }
+        expect(
+          incrementalCandidateValidatorBuildCountForTests,
+          1,
+          reason:
+              'shared validator path must not call buildIncrementalCandidateValidator '
+              'per probe (Refs #2394)',
+        );
+      },
+    );
+
+    test(
       'isDiplomaticOrderAcceptedWithValidator matches isDiplomaticOrderAccepted',
       () {
         final game = Game(


### PR DESCRIPTION
## Summary

- Add `incrementalValidatorForCandidateProbe` so stateless `is*OrderAccepted` helpers can reuse an existing `IncrementalCandidateValidator` from a suggestion pass instead of calling `buildIncrementalCandidateValidator` on every probe.
- Extend all `is*OrderAccepted` wrappers with optional `sharedCandidateValidator` (and aligned `view` / `unitsById` / `factionMembership` hooks where useful) for callers that already amortize validator setup in hot loops.

## Deferred

- Full issue closure: most Category A–F refactors and CI AST rules are already on `dev` from prior PRs (#2488, #2491, etc.). This PR is one additional throughput hook for external/stateless probe call sites.

## Acceptance criteria

| AC area | Status |
|---------|--------|
| Shared validator per suggestion pass (Category A) | Extended to stateless accept API |
| Existing suggest* / heuristic paths | Unchanged (already shared) |
| Determinism / equivalence | Covered by existing shared-validator tests + new build-count test |

## Test plan

- [x] `dart test test/order_suggestion_context_helpers_test.dart test/orders/order_suggestion_shared_validator_equivalence_test.dart` in `packages/colonizethis_logic`

Refs #2394

Made with [Cursor](https://cursor.com)