### PR TITLE
refactor(logic): unify work order validator rejection gates (Refs #2391)

### DIFF
--- a/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
+++ b/packages/colonizethis_logic/lib/src/orders/validators/work_order_validator.dart
@@ -87,35 +87,30 @@ class WorkOrderValidator extends StatefulValidator {
       previousRejected: previousRejected,
       body: () {
         final unit = _context.unitsById[o.unitId];
-        final unitValidation = _validateOwnedUnseenUnit(o, unit);
-        if (unitValidation != null) return unitValidation;
-        final validatedUnit = unit;
-        if (validatedUnit == null) {
-          return OrderValidationResult.rejected('Unit not found');
-        }
-        final type = validatedUnit.type;
-        final targetValidation = _validateWorkTargetAndTile(o, type);
-        if (targetValidation != null) return targetValidation;
-
         final targetProvinceId = Unit.provinceIdFromTileKey(o.targetTileKey);
         final province = targetProvinceId != null
             ? _context.game.worldState.tryGetProvince(targetProvinceId)
             : null;
         final ownerId = province?.ownerId;
 
-        final postContextGates = <_WorkOrderValidationGate>[
+        final gates = <_WorkOrderValidationGate>[
+          () => _validateOwnedUnseenUnit(o, unit),
+          () {
+            final type = unit!.type;
+            return _validateWorkTargetAndTile(o, type);
+          },
           () => _runTargetPrecheck(
             o: o,
             targetProvinceId: targetProvinceId,
             ownerId: ownerId,
-            type: type,
+            type: unit!.type,
           ),
           () => _validateForeignProvinceWork(
             o: o,
-            type: type,
+            type: unit!.type,
             ownerId: ownerId,
           ),
-          () => _validateDevExclusiveWorkTarget(o, type),
+          () => _validateDevExclusiveWorkTarget(o, unit!.type),
           () => _validateMaterialAndTechRules(
             o,
             province?.fortLevel ?? 0,
@@ -123,7 +118,7 @@ class WorkOrderValidator extends StatefulValidator {
           () {
             if (!workOrderVisibilityOk(
               _context.view,
-              validatedUnit,
+              unit!,
               o.target,
               targetTileKey: o.targetTileKey,
               worldState: _context.game.worldState,
@@ -138,7 +133,7 @@ class WorkOrderValidator extends StatefulValidator {
             if (!civilianMayOccupyLandTileKey(
               game: _context.game,
               playerId: _context.playerId,
-              unitType: type,
+              unitType: unit!.type,
               destinationTileKey: o.targetTileKey,
               factionMembership: _context.factionMembership,
             )) {
@@ -151,13 +146,14 @@ class WorkOrderValidator extends StatefulValidator {
           () => _validateProspectTarget(o),
         ];
 
-        for (final gate in postContextGates) {
+        for (final gate in gates) {
           final hit = gate();
           if (hit != null) {
             return hit;
           }
         }
 
+        final type = unit!.type;
         if (isDevExclusiveUnitType(type) &&
             isDevExclusiveWorkTarget(o.target)) {
           _context.devExclusiveTiles.add(o.targetTileKey);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -496,10 +496,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.12.0"
   json_schema:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

- Complete **AC9** by routing all work-order rejection checks (owned unit, target/tile, precheck, visibility, occupancy, prospect) through one ordered `_WorkOrderValidationGate` list instead of early `if (x != null) return x` blocks plus a separate post-context loop.
- Remove unreachable null-unit branch after `_validateOwnedUnseenUnit` (that gate already rejects missing units).

## Deferred

- **AC5 / AC14** shared-logger lint promotion and any remaining pattern-10 order-engine descriptor polish are already on `dev` from prior PRs; this PR is the last structural slice for AC9.
- Issue-wide closure still depends on verification of all ACs (#2391 has many merged slices).

## Acceptance criteria

| AC | Status |
|----|--------|
| AC9 — `work_order_validator.dart` uses a fold over validator steps | Done in this PR (single gate loop) |
| Other ACs | Covered by prior merged PRs on `dev` |

## Test plan

- [x] `dart test test/orders/validator_bundle_test.dart test/order_engine_validator_injection_test.dart` in `packages/colonizethis_logic`
- [x] `dart test test/orders/ --name work` in `packages/colonizethis_logic`

Refs #2391


Made with [Cursor](https://cursor.com)