### PR TITLE
refactor: O(1) home fleet lookup during starting naval setup (#2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/setup/game_setup_helpers_bootstrap.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup_helpers_bootstrap.dart
@@ -142,13 +142,15 @@ int _mergeHomeFleetShipsForPlayer({
   required String localProvinceId,
   required int shipCount,
   required List<Fleet> fleets,
+  required Map<String, int> fleetIndexById,
   required int nextSeq,
 }) {
   if (shipCount <= 0 || regionId != kRegionOldWorld) return nextSeq;
   final fullProvinceId = '$regionId|$localProvinceId';
   final homeFleetId = homeFleetIdFor(player.id);
-  final existingIndex = fleets.indexWhere((f) => f.id == homeFleetId);
-  final existingFleet = existingIndex >= 0 ? fleets[existingIndex] : null;
+  final existingIndex = fleetIndexById[homeFleetId];
+  final existingFleet =
+      existingIndex != null ? fleets[existingIndex] : null;
   final existingShips = existingFleet?.ships ?? const <ShipInstance>[];
   final shipTypeId = startingShipTypeForPlayer(player);
   final (seqAfter, newInstances) = mintShipInstances(
@@ -166,8 +168,9 @@ int _mergeHomeFleetShipsForPlayer({
   );
   if (existingFleet == null) {
     fleets.add(homeFleet);
+    fleetIndexById[homeFleetId] = fleets.length - 1;
   } else {
-    fleets[existingIndex] = homeFleet;
+    fleets[existingIndex!] = homeFleet;
   }
   return seqAfter;
 }
@@ -187,6 +190,9 @@ Game addStartingMilitaryAndNaval({
   var oldWorldUnits = List<Unit>.from(game.worldState.oldWorld.units);
   var newWorldUnits = List<Unit>.from(game.worldState.newWorld.units);
   var fleets = List<Fleet>.from(game.worldState.fleets);
+  final fleetIndexById = <String, int>{
+    for (var i = 0; i < fleets.length; i++) fleets[i].id: i,
+  };
   var nextSeq = game.worldState.nextShipInstanceSeq;
   final inferredStart = inferNextShipInstanceSeqFromFleets(fleets);
   if (nextSeq < inferredStart) nextSeq = inferredStart;
@@ -213,6 +219,7 @@ Game addStartingMilitaryAndNaval({
       localProvinceId: localProvinceId,
       shipCount: shipCount,
       fleets: fleets,
+      fleetIndexById: fleetIndexById,
       nextSeq: nextSeq,
     );
   }

--- a/packages/colonizethis_logic/test/setup/game_setup_home_fleet_merge_test.dart
+++ b/packages/colonizethis_logic/test/setup/game_setup_home_fleet_merge_test.dart
@@ -1,0 +1,100 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+void main() {
+  test(
+    'addStartingMilitaryAndNaval merges home fleets with pre-seeded fleets (Refs #2394)',
+    () {
+      final shipTypeId = ShipEconomyCatalog.carrack.shipTypeId;
+
+      final gp1Capital = const CapitalTile(
+        regionId: kRegionOldWorld,
+        provinceId: 'oldWorld|p1',
+        x: 0,
+        y: 0,
+      );
+      final gp2Capital = const CapitalTile(
+        regionId: kRegionOldWorld,
+        provinceId: 'oldWorld|p2',
+        x: 0,
+        y: 0,
+      );
+
+      final game = Game(
+        id: 't',
+        worldState: WorldState(
+          turnState: const TurnState(turnNumber: 1, phase: TurnPhase.orders),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+          fleets: [
+            Fleet(
+              id: 'z_unrelated_fleet_first',
+              ownerId: 'gp1',
+              regionId: kRegionOldWorld,
+              seaZoneId: 'oldWorld|sea1',
+              ships: const [],
+            ),
+            Fleet(
+              id: 'fleet_gp1',
+              ownerId: 'gp1',
+              regionId: kRegionOldWorld,
+              inPortAtProvinceId: 'oldWorld|p1',
+              ships: [
+                ShipInstance(id: 'ship_1', typeId: shipTypeId),
+              ],
+            ),
+          ],
+          nextShipInstanceSeq: 1,
+        ),
+        players: [
+          Player(
+            id: 'gp1',
+            displayName: 'England',
+            isHuman: true,
+            capitalProvinceId: 'oldWorld|p1',
+            capitalTile: gp1Capital,
+          ),
+          Player(
+            id: 'gp2',
+            displayName: 'France',
+            isHuman: false,
+            capitalProvinceId: 'oldWorld|p2',
+            capitalTile: gp2Capital,
+          ),
+        ],
+      );
+
+      final config = GameSetupConfig(
+        selectedGreatPowerIds: ['england'],
+        startingResources: const StartingResourcesConfig(
+          initialMilitaryRegiments: 0,
+          initialNavalShips: 2,
+        ),
+      );
+
+      final out = addStartingMilitaryAndNaval(
+        game: game,
+        config: config,
+        topologyOldWorld: const MapTopology(nodes: [], edges: []),
+      );
+
+      final fleets = out.worldState.fleets;
+      expect(fleets.length, 3);
+
+      final gp1 = fleets.firstWhere((f) => f.id == 'fleet_gp1');
+      expect(gp1.ships.length, 3);
+      expect(gp1.ships.first.id, 'ship_1');
+      expect(gp1.ships[1].id, 'ship_2');
+      expect(gp1.ships[2].id, 'ship_3');
+
+      final gp2 = fleets.firstWhere((f) => f.id == 'fleet_gp2');
+      expect(gp2.inPortAtProvinceId, 'oldWorld|p2');
+      expect(gp2.ships.length, 2);
+      expect(gp2.ships.map((s) => s.id).toList(), ['ship_4', 'ship_5']);
+
+      expect(out.worldState.nextShipInstanceSeq, 6);
+    },
+  );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -496,10 +496,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.12.0"
   json_schema:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- Replace per-player `List.indexWhere` over `fleets` in `_mergeHomeFleetShipsForPlayer` with a single `fleetId → index` map built once in `addStartingMilitaryAndNaval`, updated on insert/replace (Refs #2394, Category C / sea_transport-style fleet scans).
- Add a regression test that pre-seeds unrelated + home fleets so merge order no longer relies on linear search semantics.

## Done vs deferred
- **Done:** Setup-time O(1) lookup for merging into an existing home fleet row.
- **Deferred (issue #2394):** Broader items (PlayerView rebuild memoization, diplomacy `.any()` scans, suggestion-loop validators, etc.) remain for follow-up PRs.

## Tests
- `cd packages/colonizethis_logic && dart test test/setup/game_setup_home_fleet_merge_test.dart`

Refs #2394


Made with [Cursor](https://cursor.com)