### PR TITLE
refactor(map): reuse grid graph nearest land-seed index (Refs #2489)

### DIFF
--- a/packages/colonizethis_map/lib/colonizethis_map.dart
+++ b/packages/colonizethis_map/lib/colonizethis_map.dart
@@ -19,8 +19,10 @@ export 'src/tile_map_visualization_shared.dart'
         geographicGameWorldLegendResources,
         geographicGameWorldResourceGlyphLetter,
         geographicGameWorldResourceGlyphs,
+        kGameWorldMapOwnershipLegendBlurb,
         landSeedMarkerRgb,
         resourceIdToLegendLetter,
+        seaZoneLocalIdsFromRegionCells,
         tileMapResourceGlyphs;
 export 'src/init_game_map_view_data.dart';
 export 'src/sea_zone_centroid_tile.dart';

--- a/packages/colonizethis_map/lib/src/game_world_state_map_visualizer.dart
+++ b/packages/colonizethis_map/lib/src/game_world_state_map_visualizer.dart
@@ -29,12 +29,11 @@ Map<String, String> _provinceIdToOwnerIdFromProvinces(
   return out;
 }
 
-typedef _RegionRenderInputs =
-    ({
-      Map<String, String> ownerByProvinceId,
-      List<TileMapCapitalMarker> capitalTiles,
-      Map<String, (int r, int g, int b)> factionColors,
-    });
+typedef _RegionRenderInputs = ({
+  Map<String, String> ownerByProvinceId,
+  List<TileMapCapitalMarker> capitalTiles,
+  Map<String, (int r, int g, int b)> factionColors,
+});
 
 _RegionRenderInputs _buildRegionRenderInputs({
   required Game game,
@@ -443,19 +442,13 @@ Uint8List renderInitGameMapToPngFromViewData({
         color: black,
       );
       legendY += legendLineHeight;
-      for (final r in geographicGameWorldLegendResources) {
-        final letter = resourceToLegendLetter(r);
-        final label = resourceToLegendLabel(r);
-        img.drawString(
-          image,
-          '$letter  $label',
-          font: img.arial14,
-          x: legendPadding,
-          y: legendY,
-          color: black,
-        );
-        legendY += legendLineHeight;
-      }
+      legendY = drawResourceLegendRows(
+        image,
+        legendY: legendY,
+        textColor: black,
+        resources: geographicGameWorldLegendResources,
+        style: ResourceLegendRowsStyle.compactInline,
+      );
     } else {
       img.drawString(
         image,

--- a/packages/colonizethis_map/lib/src/game_world_state_map_visualizer.dart
+++ b/packages/colonizethis_map/lib/src/game_world_state_map_visualizer.dart
@@ -186,7 +186,7 @@ Uint8List renderSingleRegionGameStateMapToPng({
   var legendY = legendY0;
   img.drawString(
     image,
-    'Ownership by faction. Black = land borders; light blue = sea borders.',
+    kGameWorldMapOwnershipLegendBlurb,
     font: img.arial14,
     x: legendPadding,
     y: legendY,
@@ -314,13 +314,7 @@ Uint8List renderInitGameMapToPngFromViewData({
     final mapW = region.width * region.cellSize;
     final mapH = region.height * region.cellSize;
 
-    // Determine sea zone ids from cells marked as sea.
-    final seaZoneIds = <String>{};
-    for (final cell in region.cells) {
-      if (cell.isSea) {
-        seaZoneIds.add(cell.regionCellId);
-      }
-    }
+    final seaZoneIds = seaZoneLocalIdsFromRegionCells(region.cells);
 
     // Legend height: geographic = title + Sea + terrains + "Resources:" + g/t/i + ports; else title + factions + ports.
     final legendLines = geographicMode
@@ -465,7 +459,7 @@ Uint8List renderInitGameMapToPngFromViewData({
     } else {
       img.drawString(
         image,
-        'Ownership by faction. Black = land borders; light blue = sea borders.',
+        kGameWorldMapOwnershipLegendBlurb,
         font: img.arial14,
         x: legendPadding,
         y: legendY,

--- a/packages/colonizethis_map/lib/src/tile_map_directions.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_directions.dart
@@ -22,6 +22,17 @@ const kTileMapDirections4NorthSouthWestEast = <(int dx, int dy)>[
   (1, 0),
 ];
 
+/// West, East, North, South deltas (orthogonal).
+///
+/// Matches legacy `(x±1,y)` / `(x,y±1)` tuple order where iteration order affects
+/// deterministic outcomes (for example `_tryBorderNoiseSwapAtCell`). Refs #2489.
+const kTileMapDirections4WestEastNorthSouth = <(int dx, int dy)>[
+  (-1, 0),
+  (1, 0),
+  (0, -1),
+  (0, 1),
+];
+
 /// Eight-neighborhood deltas (4 orthogonal + 4 diagonal). Refs #2489.
 const kTileMapDirections8 = <(int dx, int dy)>[
   ...kTileMapDirections4,

--- a/packages/colonizethis_map/lib/src/tile_map_generator_join_sea_bridge_part.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_join_sea_bridge_part.dart
@@ -92,9 +92,9 @@ extension _TileMapGenJoinSeaBridgePart on _TileMapGenJoinSea {
         }
       }
       if (joinIterations >= maxJoinIterationsPerContinent) {
-        final stillSplit = _graph.connectedComponentsOfLand(
-          _landCellsForContinent(g, provinceToContinent, c, seaZoneId),
-        );
+        // [landCells] is kept in sync with the grid across bridge / sea-restore;
+        // avoid a redundant O(W×H) rescan for the diagnostic path (Refs #2489 P4).
+        final stillSplit = _graph.connectedComponentsOfLand(landCells);
         if (stillSplit.length > 1) {
           _log.w(
             'join continents hit iteration cap with >1 land component for '

--- a/packages/colonizethis_map/lib/src/tile_map_generator_join_sea_bridge_part.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_join_sea_bridge_part.dart
@@ -45,20 +45,16 @@ extension _TileMapGenJoinSeaBridgePart on _TileMapGenJoinSea {
           )
         : null;
 
-    // Single row-major pass buckets land tiles per continent; avoids numContinents
-    // redundant full-grid rescans at join entry (Refs #2489 P4).
-    final landCellsByContinentIndex = _landCellsGroupedByContinentIndex(
-      g,
-      provinceToContinent,
-      seaZoneId,
-    );
-
     for (var c = 0; c < numContinents; c++) {
-      final seeded = landCellsByContinentIndex[c];
-      var landCells = seeded != null ? seeded : <(int x, int y)>{};
       var joinIterations = 0;
       while (joinIterations < maxJoinIterationsPerContinent) {
         joinIterations++;
+        final landCells = _landCellsForContinent(
+          g,
+          provinceToContinent,
+          c,
+          seaZoneId,
+        );
         final components = _graph.connectedComponentsOfLand(landCells);
         if (components.length <= 1) break;
         didJoin = true;
@@ -79,10 +75,7 @@ extension _TileMapGenJoinSeaBridgePart on _TileMapGenJoinSea {
           rnd,
           capState,
         );
-        for (final p in path) {
-          landCells.add(p);
-        }
-        final restoredToSea = preserveSeaFraction(
+        preserveSeaFraction(
           g,
           tg,
           rg,
@@ -91,14 +84,11 @@ extension _TileMapGenJoinSeaBridgePart on _TileMapGenJoinSea {
           path.length,
           landCellsExcludedFromSeaRestore: bridgeCells,
         );
-        for (final p in restoredToSea) {
-          landCells.remove(p);
-        }
       }
       if (joinIterations >= maxJoinIterationsPerContinent) {
-        // [landCells] is kept in sync with the grid across bridge / sea-restore;
-        // avoid a redundant O(W×H) rescan for the diagnostic path (Refs #2489 P4).
-        final stillSplit = _graph.connectedComponentsOfLand(landCells);
+        final stillSplit = _graph.connectedComponentsOfLand(
+          _landCellsForContinent(g, provinceToContinent, c, seaZoneId),
+        );
         if (stillSplit.length > 1) {
           _log.w(
             'join continents hit iteration cap with >1 land component for '
@@ -144,21 +134,18 @@ extension _TileMapGenJoinSeaBridgePart on _TileMapGenJoinSea {
     }
   }
 
-  Map<int, Set<(int x, int y)>> _landCellsGroupedByContinentIndex(
+  Set<(int x, int y)> _landCellsForContinent(
     List<List<String>> grid,
     Map<String, int> membership,
+    int continentIndex,
     String seaZoneId,
   ) {
-    final out = <int, Set<(int x, int y)>>{};
+    final out = <(int x, int y)>{};
     for (var y = 0; y < params.height; y++) {
       for (var x = 0; x < params.width; x++) {
         final id = grid[y][x];
         if (id == seaZoneId) continue;
-        final continentIndex = membership[id];
-        if (continentIndex == null) continue;
-        out
-            .putIfAbsent(continentIndex, () => <(int x, int y)>{})
-            .add((x, y));
+        if (membership[id] == continentIndex) out.add((x, y));
       }
     }
     return out;

--- a/packages/colonizethis_map/lib/src/tile_map_generator_join_sea_bridge_part.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_join_sea_bridge_part.dart
@@ -46,15 +46,15 @@ extension _TileMapGenJoinSeaBridgePart on _TileMapGenJoinSea {
         : null;
 
     for (var c = 0; c < numContinents; c++) {
+      var landCells = _landCellsForContinent(
+        g,
+        provinceToContinent,
+        c,
+        seaZoneId,
+      );
       var joinIterations = 0;
       while (joinIterations < maxJoinIterationsPerContinent) {
         joinIterations++;
-        final landCells = _landCellsForContinent(
-          g,
-          provinceToContinent,
-          c,
-          seaZoneId,
-        );
         final components = _graph.connectedComponentsOfLand(landCells);
         if (components.length <= 1) break;
         didJoin = true;
@@ -75,7 +75,10 @@ extension _TileMapGenJoinSeaBridgePart on _TileMapGenJoinSea {
           rnd,
           capState,
         );
-        preserveSeaFraction(
+        for (final p in path) {
+          landCells.add(p);
+        }
+        final restoredToSea = preserveSeaFraction(
           g,
           tg,
           rg,
@@ -84,6 +87,9 @@ extension _TileMapGenJoinSeaBridgePart on _TileMapGenJoinSea {
           path.length,
           landCellsExcludedFromSeaRestore: bridgeCells,
         );
+        for (final p in restoredToSea) {
+          landCells.remove(p);
+        }
       }
       if (joinIterations >= maxJoinIterationsPerContinent) {
         final stillSplit = _graph.connectedComponentsOfLand(

--- a/packages/colonizethis_map/lib/src/tile_map_generator_join_sea_bridge_part.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_join_sea_bridge_part.dart
@@ -45,13 +45,17 @@ extension _TileMapGenJoinSeaBridgePart on _TileMapGenJoinSea {
           )
         : null;
 
+    // Single row-major pass buckets land tiles per continent; avoids numContinents
+    // redundant full-grid rescans at join entry (Refs #2489 P4).
+    final landCellsByContinentIndex = _landCellsGroupedByContinentIndex(
+      g,
+      provinceToContinent,
+      seaZoneId,
+    );
+
     for (var c = 0; c < numContinents; c++) {
-      var landCells = _landCellsForContinent(
-        g,
-        provinceToContinent,
-        c,
-        seaZoneId,
-      );
+      final seeded = landCellsByContinentIndex[c];
+      var landCells = seeded != null ? seeded : <(int x, int y)>{};
       var joinIterations = 0;
       while (joinIterations < maxJoinIterationsPerContinent) {
         joinIterations++;
@@ -140,18 +144,21 @@ extension _TileMapGenJoinSeaBridgePart on _TileMapGenJoinSea {
     }
   }
 
-  Set<(int x, int y)> _landCellsForContinent(
+  Map<int, Set<(int x, int y)>> _landCellsGroupedByContinentIndex(
     List<List<String>> grid,
     Map<String, int> membership,
-    int continentIndex,
     String seaZoneId,
   ) {
-    final out = <(int x, int y)>{};
+    final out = <int, Set<(int x, int y)>>{};
     for (var y = 0; y < params.height; y++) {
       for (var x = 0; x < params.width; x++) {
         final id = grid[y][x];
         if (id == seaZoneId) continue;
-        if (membership[id] == continentIndex) out.add((x, y));
+        final continentIndex = membership[id];
+        if (continentIndex == null) continue;
+        out
+            .putIfAbsent(continentIndex, () => <(int x, int y)>{})
+            .add((x, y));
       }
     }
     return out;

--- a/packages/colonizethis_map/lib/src/tile_map_generator_lakes_provinces.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_lakes_provinces.dart
@@ -32,24 +32,6 @@ class _TileMapGenLakesProvinces {
     }
   }
 
-  int _nearestLandSeedIndexForCell(
-    int x,
-    int y,
-    List<(int x, int y)> landSeeds,
-  ) {
-    var bestSeedIndex = 0;
-    var bestD2 = kUnsetSquaredDistanceInt31;
-    for (var i = 0; i < landSeeds.length; i++) {
-      final (sx, sy) = landSeeds[i];
-      final d2 = (x - sx) * (x - sx) + (y - sy) * (y - sy);
-      if (d2 < bestD2) {
-        bestD2 = d2;
-        bestSeedIndex = i;
-      }
-    }
-    return bestSeedIndex;
-  }
-
   void _tryBorderNoiseSwapAtCell(
     List<List<String>> grid,
     List<List<String>> next,
@@ -237,7 +219,11 @@ class _TileMapGenLakesProvinces {
     for (var y = 0; y < params.height; y++) {
       for (var x = 0; x < params.width; x++) {
         if (grid[y][x] != _landSentinel) continue;
-        final bestSeedIndex = _nearestLandSeedIndexForCell(x, y, landSeeds);
+        final bestSeedIndex = _graph.nearestLandSeedIndexForCell(
+          x,
+          y,
+          landSeeds,
+        );
         final c = continentBySeedIndex[bestSeedIndex];
         byContinent[c]!.add((x, y));
       }

--- a/packages/colonizethis_map/lib/src/tile_map_generator_lakes_provinces.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_lakes_provinces.dart
@@ -69,7 +69,7 @@ class _TileMapGenLakesProvinces {
       landSeeds,
       continentBySeedIndex,
     );
-    final next = grid.map((row) => row.toList()).toList();
+    final next = copyTileMapGrid(grid);
     final lakeCells = <(int x, int y)>[];
     for (var y = 0; y < params.height; y++) {
       for (var x = 0; x < params.width; x++) {
@@ -141,7 +141,7 @@ class _TileMapGenLakesProvinces {
     );
     if (ocean.isEmpty) return grid;
 
-    final next = grid.map((row) => row.toList()).toList();
+    final next = copyTileMapGrid(grid);
     final moatCells = <(int x, int y)>[];
 
     for (var y = 0; y < params.height; y++) {
@@ -300,7 +300,7 @@ class _TileMapGenLakesProvinces {
       noiseScale: 0,
       noiseSeed: params.seed,
     );
-    final next = grid.map((row) => row.toList()).toList();
+    final next = copyTileMapGrid(grid);
     for (final entry in assignment.entries) {
       final (x, y) = entry.key;
       next[y][x] = entry.value;
@@ -314,7 +314,7 @@ class _TileMapGenLakesProvinces {
     String seaZoneId,
     Random rnd,
   ) {
-    final next = grid.map((row) => row.toList()).toList();
+    final next = copyTileMapGrid(grid);
     for (var y = 1; y < params.height - 1; y++) {
       for (var x = 1; x < params.width - 1; x++) {
         _tryBorderNoiseSwapAtCell(grid, next, x, y, seaZoneId, rnd);

--- a/packages/colonizethis_map/lib/src/tile_map_generator_lakes_provinces.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_lakes_provinces.dart
@@ -42,8 +42,9 @@ class _TileMapGenLakesProvinces {
   ) {
     if (rnd.nextDouble() >= params.borderNoise) return;
     final id = grid[y][x];
-    final neighbors = [(x - 1, y), (x + 1, y), (x, y - 1), (x, y + 1)];
-    for (final (nx, ny) in neighbors) {
+    for (final (dx, dy) in kTileMapDirections4WestEastNorthSouth) {
+      final nx = x + dx;
+      final ny = y + dy;
       final nid = grid[ny][nx];
       final atBoundary =
           (id == _landSentinel && nid == seaZoneId) ||

--- a/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds.dart
@@ -18,6 +18,7 @@ import 'tile_map_distance_sentinels.dart';
 import 'tile_map_land_seed_contract.dart';
 import 'tile_map_grid_copy.dart';
 import 'tile_map_land_sentinel.dart';
+import 'tile_map_manhattan_distance_transform.dart';
 import 'tile_map_province_budget.dart';
 
 part 'tile_map_generator_land_seeds_shared_part.dart';

--- a/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds_coast_part.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds_coast_part.dart
@@ -205,7 +205,6 @@ bool _tryGrowOneCoastalCellForContinent(
   for (final e in provinceToContinent.entries) {
     provincesByContinent.putIfAbsent(e.value, () => []).add(e.key);
   }
-  final totalProvinces = provinceToContinent.length;
 
   var g = copyTileMapGrid(grid);
   var cg = copyTileMapGrid(continentGrid);
@@ -222,17 +221,11 @@ bool _tryGrowOneCoastalCellForContinent(
     coastalByContinent,
   );
 
-  final budgetPerContinent = List<int>.filled(numContinents, 0);
-  var allocated = 0;
-  for (var c = 0; c < numContinents; c++) {
-    budgetPerContinent[c] =
-        (remaining * provincesByContinent[c]!.length / totalProvinces)
-            .round();
-    allocated += budgetPerContinent[c];
-  }
-  if (allocated < remaining && numContinents > 0) {
-    budgetPerContinent[0] += remaining - allocated;
-  }
+  final budgetPerContinent = allocateBudgetByProvinceCount(
+    totalBudget: remaining,
+    provincesByContinent: provincesByContinent,
+    numContinents: numContinents,
+  );
 
   // Radius for local land-neighbour scoring when picking coastal cells.
   const scoreRadius = 3;

--- a/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds_coast_part.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds_coast_part.dart
@@ -207,8 +207,8 @@ bool _tryGrowOneCoastalCellForContinent(
   }
   final totalProvinces = provinceToContinent.length;
 
-  var g = grid.map((row) => row.toList()).toList();
-  var cg = continentGrid.map((row) => row.toList()).toList();
+  var g = copyTileMapGrid(grid);
+  var cg = copyTileMapGrid(continentGrid);
   final coastalByContinent = <int, List<(int x, int y)>>{};
   for (var c = 0; c < numContinents; c++) {
     coastalByContinent[c] = [];

--- a/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds_organic_part.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds_organic_part.dart
@@ -35,25 +35,6 @@ List<(int x, int y)> _organicSeedCloseSeaCandidates(
   return candidates;
 }
 
-int _minManhattanDistToOtherContinentCells(
-  List<List<int>> continentGrid,
-  TileMapLandSeedParams params,
-  int x,
-  int y,
-  int ownContinent,
-) {
-  var minDistToOther = params.width + params.height;
-  for (var ny = 0; ny < params.height; ny++) {
-    for (var nx = 0; nx < params.width; nx++) {
-      final cell = continentGrid[ny][nx];
-      if (cell < 0 || cell == ownContinent) continue;
-      final d = (x - nx).abs() + (y - ny).abs();
-      if (d < minDistToOther) minDistToOther = d;
-    }
-  }
-  return minDistToOther;
-}
-
 (int, int) _pickBestOrganicSeaCandidate(
   List<(int x, int y)> candidates,
   List<(int x, int y)> ownLandOrSeed,
@@ -63,17 +44,21 @@ int _minManhattanDistToOtherContinentCells(
   double awayPenalty,
   Random rnd,
 ) {
+  final unreachableOther = params.width + params.height;
+  final distToOtherContinent = manhattanDistToNearestSourceXY(
+    params.width,
+    params.height,
+    (x, y) {
+      final cell = continentGrid[y][x];
+      return cell >= 0 && cell != continentIndex;
+    },
+    distanceWhenNoSources: unreachableOther,
+  );
   var bestScore = -1e100;
   final bestCandidates = <(int x, int y)>[];
   for (final (x, y) in candidates) {
     final minDistToOwn = _minManhattanDistToPoints(x, y, ownLandOrSeed);
-    final minDistToOther = _minManhattanDistToOtherContinentCells(
-      continentGrid,
-      params,
-      x,
-      y,
-      continentIndex,
-    );
+    final minDistToOther = distToOtherContinent[y][x];
     final score = -minDistToOwn + awayPenalty * minDistToOther;
     if (score > bestScore) {
       bestScore = score;

--- a/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds_organic_part.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds_organic_part.dart
@@ -255,8 +255,6 @@ _placeLandSeedsOrganicImpl(
     0,
     landBudgetTotal,
   );
-  final totalProvinces = provinceToContinent.length;
-
   final seedCountsPerContinent = List<int>.filled(numContinents, 0);
   var voronoiRemaining = voronoiBudgetTotal;
 
@@ -264,20 +262,11 @@ _placeLandSeedsOrganicImpl(
     final roundBudget = (round + 1 == totalRounds)
         ? voronoiRemaining
         : (voronoiBudgetTotal / totalRounds).round();
-    final budgetPerContinent = <int>[];
-    for (var c = 0; c < numContinents; c++) {
-      budgetPerContinent.add(
-        (roundBudget * provincesByContinent[c]!.length / totalProvinces)
-            .round(),
-      );
-    }
-    var roundUsed = 0;
-    for (var c = 0; c < numContinents; c++) {
-      roundUsed += budgetPerContinent[c];
-    }
-    if (roundUsed != roundBudget && numContinents > 0) {
-      budgetPerContinent[0] += roundBudget - roundUsed;
-    }
+    final budgetPerContinent = allocateBudgetByProvinceCount(
+      totalBudget: roundBudget,
+      provincesByContinent: provincesByContinent,
+      numContinents: numContinents,
+    );
     voronoiRemaining -= roundBudget;
     // Step 1: Place one land seed per continent (if needed)
     for (var c = 0; c < numContinents; c++) {

--- a/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds_organic_part.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds_organic_part.dart
@@ -171,8 +171,8 @@ int _minManhattanDistToOtherContinentCells(
   );
   entries.sort((a, b) => a.$1.compareTo(b.$1));
 
-  final next = grid.map((row) => row.toList()).toList();
-  final nextContinent = continentGrid.map((row) => row.toList()).toList();
+  final next = copyTileMapGrid(grid);
+  final nextContinent = copyTileMapGrid(continentGrid);
   final used = List<int>.filled(numContinents, 0);
   final buffer = params.continentBufferTiles == 0
       ? 1
@@ -256,7 +256,7 @@ _placeLandSeedsOrganicImpl(
 
   final landSeeds = <(int x, int y)>[];
   final continentBySeedIndex = <int>[];
-  var g = grid.map((row) => row.toList()).toList();
+  var g = copyTileMapGrid(grid);
   final continentGrid = List.generate(
     params.height,
     (_) => List.filled(params.width, -1),

--- a/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
@@ -148,35 +148,38 @@ class _TileMapGenTerrainResource {
     );
   }
 
-  Set<(int x, int y)> _mountainAdjacentNonMountainLandFrontier(
+  /// One full-grid pass for mountain ridge top-up: cells eligible for frontier
+  /// growth and the list of all non-mountain land (for final random fill).
+  /// Refs #2489 P3.
+  (Set<(int x, int y)> frontier, List<(int x, int y)> remainingNonMountain)
+  _mountainRidgeTopUpScan(
     List<List<TerrainType?>> terrainGrid,
     List<List<String>> grid,
     List<(int dx, int dy)> directions,
   ) {
     final frontier = <(int x, int y)>{};
+    final remaining = <(int x, int y)>[];
     for (var y = 0; y < params.height; y++) {
       for (var x = 0; x < params.width; x++) {
-        if (terrainGrid[y][x] != TerrainType.mountain) continue;
-        for (final (dx, dy) in directions) {
-          final nx = x + dx;
-          final ny = y + dy;
-          if (nx < 0 || nx >= params.width || ny < 0 || ny >= params.height) {
-            continue;
+        if (grid[y][x] != _landSentinel) continue;
+        final t = terrainGrid[y][x];
+        if (t == TerrainType.mountain) {
+          for (final (dx, dy) in directions) {
+            final nx = x + dx;
+            final ny = y + dy;
+            if (nx < 0 || nx >= params.width || ny < 0 || ny >= params.height) {
+              continue;
+            }
+            if (grid[ny][nx] != _landSentinel) continue;
+            if (terrainGrid[ny][nx] == TerrainType.mountain) continue;
+            frontier.add((nx, ny));
           }
-          if (grid[ny][nx] != _landSentinel) continue;
-          if (terrainGrid[ny][nx] == TerrainType.mountain) continue;
-          frontier.add((nx, ny));
+          continue;
         }
+        remaining.add((x, y));
       }
     }
-    return frontier;
-  }
-
-  List<(int x, int y)> _nonMountainLandCells(
-    List<List<String>> grid,
-    List<List<TerrainType?>> terrainGrid,
-  ) {
-    return _collectRemainingNonMountainLand(terrainGrid, grid);
+    return (frontier, remaining);
   }
 
   /// Pass 6a: generate mountain ridges via random walks over land cells.
@@ -273,7 +276,7 @@ class _TileMapGenTerrainResource {
       return;
     }
 
-    final frontier = _mountainAdjacentNonMountainLandFrontier(
+    final (frontier, remainingNonMountain) = _mountainRidgeTopUpScan(
       terrainGrid,
       grid,
       directions,
@@ -293,11 +296,10 @@ class _TileMapGenTerrainResource {
     // fragmented land), convert random remaining land cells until we reach
     // the target. This should be rare and only adjusts a handful of tiles.
     if (currentMountain < targetMountain) {
-      final remainingLand = _nonMountainLandCells(grid, terrainGrid);
-      remainingLand.shuffle(rnd);
+      remainingNonMountain.shuffle(rnd);
       var i = 0;
-      while (currentMountain < targetMountain && i < remainingLand.length) {
-        final (lx, ly) = remainingLand[i++];
+      while (currentMountain < targetMountain && i < remainingNonMountain.length) {
+        final (lx, ly) = remainingNonMountain[i++];
         if (terrainGrid[ly][lx] == TerrainType.mountain) continue;
         terrainGrid[ly][lx] = TerrainType.mountain;
         currentMountain++;

--- a/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
@@ -274,12 +274,9 @@ class _TileMapGenTerrainResource {
     // termination of ranges, top up mountain tiles by growing existing ridges
     // along their edges. This keeps the overall pattern ridge-like while
     // nudging the global count closer to the configured fraction.
-    var currentMountain = 0;
-    for (var y = 0; y < params.height; y++) {
-      for (var x = 0; x < params.width; x++) {
-        if (terrainGrid[y][x] == TerrainType.mountain) currentMountain++;
-      }
-    }
+    // Each ridge placement decrements [remainingMountain]; avoid an extra O(W×H)
+    // count pass (Refs #2489 P3).
+    var currentMountain = targetMountain - remainingMountain;
     if (currentMountain >= targetMountain) {
       return;
     }

--- a/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
@@ -148,6 +148,26 @@ class _TileMapGenTerrainResource {
     );
   }
 
+  void _addMountainAdjacentLandFrontierNeighbors(
+    Set<(int x, int y)> frontier,
+    List<List<TerrainType?>> terrainGrid,
+    List<List<String>> grid,
+    int x,
+    int y,
+    List<(int dx, int dy)> directions,
+  ) {
+    for (final (dx, dy) in directions) {
+      final nx = x + dx;
+      final ny = y + dy;
+      if (nx < 0 || nx >= params.width || ny < 0 || ny >= params.height) {
+        continue;
+      }
+      if (grid[ny][nx] != _landSentinel) continue;
+      if (terrainGrid[ny][nx] == TerrainType.mountain) continue;
+      frontier.add((nx, ny));
+    }
+  }
+
   /// One full-grid pass for mountain ridge top-up: cells eligible for frontier
   /// growth and the list of all non-mountain land (for final random fill).
   /// Refs #2489 P3.
@@ -164,16 +184,14 @@ class _TileMapGenTerrainResource {
         if (grid[y][x] != _landSentinel) continue;
         final t = terrainGrid[y][x];
         if (t == TerrainType.mountain) {
-          for (final (dx, dy) in directions) {
-            final nx = x + dx;
-            final ny = y + dy;
-            if (nx < 0 || nx >= params.width || ny < 0 || ny >= params.height) {
-              continue;
-            }
-            if (grid[ny][nx] != _landSentinel) continue;
-            if (terrainGrid[ny][nx] == TerrainType.mountain) continue;
-            frontier.add((nx, ny));
-          }
+          _addMountainAdjacentLandFrontierNeighbors(
+            frontier,
+            terrainGrid,
+            grid,
+            x,
+            y,
+            directions,
+          );
           continue;
         }
         remaining.add((x, y));
@@ -298,7 +316,8 @@ class _TileMapGenTerrainResource {
     if (currentMountain < targetMountain) {
       remainingNonMountain.shuffle(rnd);
       var i = 0;
-      while (currentMountain < targetMountain && i < remainingNonMountain.length) {
+      while (currentMountain < targetMountain &&
+          i < remainingNonMountain.length) {
         final (lx, ly) = remainingNonMountain[i++];
         if (terrainGrid[ly][lx] == TerrainType.mountain) continue;
         terrainGrid[ly][lx] = TerrainType.mountain;

--- a/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
@@ -136,30 +136,16 @@ class _TileMapGenTerrainResource {
     if (grid[y][x] != _landSentinel) return;
     final terrain = terrainGrid[y][x];
     if (terrain == null) return;
-    var allowed = Resource.values
-        .where(
-          (r) =>
-              rules.isAllowedInRegion(r, mapRegionId) &&
-              rules.isAllowedOnTerrain(r, terrain),
-        )
-        .toList();
-    if (allowed.isEmpty) return;
-    if (capState != null && capState.shouldRestrictToRegionOnly(allowed)) {
-      allowed = capState.filterToRegionOnly(allowed);
-      if (allowed.isEmpty) return;
-    }
-    if (rnd.nextDouble() > 0.4) return;
-    final weights = allowed.map((r) => rules.spawnWeight(r)).toList();
-    final sum = weights.reduce((a, b) => a + b);
-    var roll = rnd.nextDouble() * sum;
-    for (var i = 0; i < allowed.length; i++) {
-      roll -= weights[i];
-      if (roll > 0) continue;
-      final placed = allowed[i];
-      resourceGrid[y][x] = placed;
-      capState?.record(placed);
-      return;
-    }
+    tryPlaceWeightedResourceAtCell(
+      resourceGrid: resourceGrid,
+      x: x,
+      y: y,
+      terrain: terrain,
+      mapRegionId: mapRegionId,
+      rules: rules,
+      rnd: rnd,
+      capState: capState,
+    );
   }
 
   Set<(int x, int y)> _mountainAdjacentNonMountainLandFrontier(

--- a/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
@@ -176,15 +176,7 @@ class _TileMapGenTerrainResource {
     List<List<String>> grid,
     List<List<TerrainType?>> terrainGrid,
   ) {
-    final remainingLand = <(int x, int y)>[];
-    for (var y = 0; y < params.height; y++) {
-      for (var x = 0; x < params.width; x++) {
-        if (grid[y][x] != _landSentinel) continue;
-        if (terrainGrid[y][x] == TerrainType.mountain) continue;
-        remainingLand.add((x, y));
-      }
-    }
-    return remainingLand;
+    return _collectRemainingNonMountainLand(terrainGrid, grid);
   }
 
   /// Pass 6a: generate mountain ridges via random walks over land cells.

--- a/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
@@ -148,56 +148,43 @@ class _TileMapGenTerrainResource {
     );
   }
 
-  void _addMountainAdjacentLandFrontierNeighbors(
-    Set<(int x, int y)> frontier,
-    List<List<TerrainType?>> terrainGrid,
-    List<List<String>> grid,
-    int x,
-    int y,
-    List<(int dx, int dy)> directions,
-  ) {
-    for (final (dx, dy) in directions) {
-      final nx = x + dx;
-      final ny = y + dy;
-      if (nx < 0 || nx >= params.width || ny < 0 || ny >= params.height) {
-        continue;
-      }
-      if (grid[ny][nx] != _landSentinel) continue;
-      if (terrainGrid[ny][nx] == TerrainType.mountain) continue;
-      frontier.add((nx, ny));
-    }
-  }
-
-  /// One full-grid pass for mountain ridge top-up: cells eligible for frontier
-  /// growth and the list of all non-mountain land (for final random fill).
-  /// Refs #2489 P3.
-  (Set<(int x, int y)> frontier, List<(int x, int y)> remainingNonMountain)
-  _mountainRidgeTopUpScan(
+  Set<(int x, int y)> _mountainAdjacentNonMountainLandFrontier(
     List<List<TerrainType?>> terrainGrid,
     List<List<String>> grid,
     List<(int dx, int dy)> directions,
   ) {
     final frontier = <(int x, int y)>{};
-    final remaining = <(int x, int y)>[];
+    for (var y = 0; y < params.height; y++) {
+      for (var x = 0; x < params.width; x++) {
+        if (terrainGrid[y][x] != TerrainType.mountain) continue;
+        for (final (dx, dy) in directions) {
+          final nx = x + dx;
+          final ny = y + dy;
+          if (nx < 0 || nx >= params.width || ny < 0 || ny >= params.height) {
+            continue;
+          }
+          if (grid[ny][nx] != _landSentinel) continue;
+          if (terrainGrid[ny][nx] == TerrainType.mountain) continue;
+          frontier.add((nx, ny));
+        }
+      }
+    }
+    return frontier;
+  }
+
+  List<(int x, int y)> _nonMountainLandCells(
+    List<List<String>> grid,
+    List<List<TerrainType?>> terrainGrid,
+  ) {
+    final remainingLand = <(int x, int y)>[];
     for (var y = 0; y < params.height; y++) {
       for (var x = 0; x < params.width; x++) {
         if (grid[y][x] != _landSentinel) continue;
-        final t = terrainGrid[y][x];
-        if (t == TerrainType.mountain) {
-          _addMountainAdjacentLandFrontierNeighbors(
-            frontier,
-            terrainGrid,
-            grid,
-            x,
-            y,
-            directions,
-          );
-          continue;
-        }
-        remaining.add((x, y));
+        if (terrainGrid[y][x] == TerrainType.mountain) continue;
+        remainingLand.add((x, y));
       }
     }
-    return (frontier, remaining);
+    return remainingLand;
   }
 
   /// Pass 6a: generate mountain ridges via random walks over land cells.
@@ -287,14 +274,17 @@ class _TileMapGenTerrainResource {
     // termination of ranges, top up mountain tiles by growing existing ridges
     // along their edges. This keeps the overall pattern ridge-like while
     // nudging the global count closer to the configured fraction.
-    // Each ridge placement decrements [remainingMountain]; avoid an extra O(W×H)
-    // count pass (Refs #2489 P3).
-    var currentMountain = targetMountain - remainingMountain;
+    var currentMountain = 0;
+    for (var y = 0; y < params.height; y++) {
+      for (var x = 0; x < params.width; x++) {
+        if (terrainGrid[y][x] == TerrainType.mountain) currentMountain++;
+      }
+    }
     if (currentMountain >= targetMountain) {
       return;
     }
 
-    final (frontier, remainingNonMountain) = _mountainRidgeTopUpScan(
+    final frontier = _mountainAdjacentNonMountainLandFrontier(
       terrainGrid,
       grid,
       directions,
@@ -314,11 +304,11 @@ class _TileMapGenTerrainResource {
     // fragmented land), convert random remaining land cells until we reach
     // the target. This should be rare and only adjusts a handful of tiles.
     if (currentMountain < targetMountain) {
-      remainingNonMountain.shuffle(rnd);
+      final remainingLand = _nonMountainLandCells(grid, terrainGrid);
+      remainingLand.shuffle(rnd);
       var i = 0;
-      while (currentMountain < targetMountain &&
-          i < remainingNonMountain.length) {
-        final (lx, ly) = remainingNonMountain[i++];
+      while (currentMountain < targetMountain && i < remainingLand.length) {
+        final (lx, ly) = remainingLand[i++];
         if (terrainGrid[ly][lx] == TerrainType.mountain) continue;
         terrainGrid[ly][lx] = TerrainType.mountain;
         currentMountain++;

--- a/packages/colonizethis_map/lib/src/tile_map_grid_graph.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_grid_graph.dart
@@ -146,7 +146,9 @@ class TileMapGridGraph {
     const dominantOceanPercentNumerator = 80;
     final legacyOcean = _legacyBoundaryReachableSea(grid, seaZoneId);
     final components = connectedComponentsOfSea(grid, seaZoneId);
-    final totalSea = countSeaCells(grid, seaZoneId);
+    // One full-grid sea pass via [connectedComponentsOfSea]; avoid a second
+    // [countSeaCells] scan (Refs #2489).
+    final totalSea = components.fold<int>(0, (sum, c) => sum + c.length);
     // One continent-set computation per sea component (Refs #2489 P1); both passes
     // below reuse this cache instead of calling [_continentSetForSeaComponent]
     // twice per component.

--- a/packages/colonizethis_map/lib/src/tile_map_grid_graph.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_grid_graph.dart
@@ -99,7 +99,9 @@ class TileMapGridGraph {
     }
     while (queue.isNotEmpty) {
       final (x, y) = queue.removeLast();
-      for (final (nx, ny) in [(x - 1, y), (x + 1, y), (x, y - 1), (x, y + 1)]) {
+      for (final (dx, dy) in kTileMapDirections4WestEastNorthSouth) {
+        final nx = x + dx;
+        final ny = y + dy;
         if (nx >= 0 &&
             nx < params.width &&
             ny >= 0 &&

--- a/packages/colonizethis_map/lib/src/tile_map_grid_graph.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_grid_graph.dart
@@ -145,15 +145,22 @@ class TileMapGridGraph {
     final legacyOcean = _legacyBoundaryReachableSea(grid, seaZoneId);
     final components = connectedComponentsOfSea(grid, seaZoneId);
     final totalSea = countSeaCells(grid, seaZoneId);
-    final touchLegacyFillable = <Set<(int x, int y)>>[];
-    for (final component in components) {
-      final continentSet = _continentSetForSeaComponent(
+    // One continent-set computation per sea component (Refs #2489 P1); both passes
+    // below reuse this cache instead of calling [_continentSetForSeaComponent]
+    // twice per component.
+    final continentSets = List<Set<int>>.generate(components.length, (i) {
+      return _continentSetForSeaComponent(
         grid,
         seaZoneId,
-        component,
+        components[i],
         landSeeds,
         continentBySeedIndex,
       );
+    });
+    final touchLegacyFillable = <Set<(int x, int y)>>[];
+    for (var i = 0; i < components.length; i++) {
+      final component = components[i];
+      final continentSet = continentSets[i];
       if (continentSet.length != 1) continue;
       if (!component.any((p) => legacyOcean.contains(p))) continue;
       touchLegacyFillable.add(component);
@@ -178,14 +185,9 @@ class TileMapGridGraph {
     }
 
     final fillableLake = <(int x, int y)>{};
-    for (final component in components) {
-      final continentSet = _continentSetForSeaComponent(
-        grid,
-        seaZoneId,
-        component,
-        landSeeds,
-        continentBySeedIndex,
-      );
+    for (var i = 0; i < components.length; i++) {
+      final component = components[i];
+      final continentSet = continentSets[i];
       if (continentSet.length != 1) continue;
       if (excludedMainOcean != null &&
           component.length == excludedMainOcean.length &&

--- a/packages/colonizethis_map/lib/src/tile_map_manhattan_distance_maps.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_manhattan_distance_maps.dart
@@ -1,3 +1,5 @@
+import 'tile_map_manhattan_distance_transform.dart';
+
 /// Per-continent Manhattan distance to the nearest cell assigned to another
 /// continent ([continentGrid] value >= 0 and != c). Unassigned cells (-1) are
 /// not targets; distance is geometric |dx|+|dy| to the nearest target, not
@@ -10,63 +12,11 @@ List<List<List<int>>> manhattanDistToOtherContinentsMaps({
 }) {
   if (numContinents <= 0) return const [];
   final unreachable = width + height;
-  final maps = List.generate(
+  return List.generate(
     numContinents,
-    (_) => List.generate(height, (_) => List.filled(width, unreachable)),
+    (c) => manhattanDistToNearestSourceXY(width, height, (x, y) {
+      final cell = continentGrid[y][x];
+      return cell >= 0 && cell != c;
+    }, distanceWhenNoSources: unreachable),
   );
-  for (var c = 0; c < numContinents; c++) {
-    _fillManhattanDistancesForContinent(
-      continentGrid: continentGrid,
-      width: width,
-      height: height,
-      continentIndex: c,
-      unreachable: unreachable,
-      dist: maps[c],
-    );
-  }
-  return maps;
-}
-
-void _fillManhattanDistancesForContinent({
-  required List<List<int>> continentGrid,
-  required int width,
-  required int height,
-  required int continentIndex,
-  required int unreachable,
-  required List<List<int>> dist,
-}) {
-  for (var y = 0; y < height; y++) {
-    for (var x = 0; x < width; x++) {
-      dist[y][x] = _minManhattanDistToForeignContinent(
-        continentGrid: continentGrid,
-        width: width,
-        height: height,
-        continentIndex: continentIndex,
-        x: x,
-        y: y,
-        unreachable: unreachable,
-      );
-    }
-  }
-}
-
-int _minManhattanDistToForeignContinent({
-  required List<List<int>> continentGrid,
-  required int width,
-  required int height,
-  required int continentIndex,
-  required int x,
-  required int y,
-  required int unreachable,
-}) {
-  var minDist = unreachable;
-  for (var ny = 0; ny < height; ny++) {
-    for (var nx = 0; nx < width; nx++) {
-      final cell = continentGrid[ny][nx];
-      if (cell < 0 || cell == continentIndex) continue;
-      final d = (x - nx).abs() + (y - ny).abs();
-      if (d < minDist) minDist = d;
-    }
-  }
-  return minDist;
 }

--- a/packages/colonizethis_map/lib/src/tile_map_manhattan_distance_transform.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_manhattan_distance_transform.dart
@@ -1,0 +1,54 @@
+import 'dart:math' show min;
+
+/// Exact grid Manhattan (L1) distance from each cell to the nearest cell where
+/// [isSource] is true.
+///
+/// When no cell satisfies [isSource], every cell is set to [distanceWhenNoSources]
+/// so callers can preserve legacy sentinel semantics.
+List<List<int>> manhattanDistToNearestSourceXY(
+  int width,
+  int height,
+  bool Function(int x, int y) isSource, {
+  required int distanceWhenNoSources,
+}) {
+  if (width <= 0 || height <= 0) {
+    return [];
+  }
+  const inf = 1 << 30;
+  final dist = List.generate(
+    height,
+    (y) => List.generate(width, (x) => isSource(x, y) ? 0 : inf),
+  );
+  for (var y = 0; y < height; y++) {
+    for (var x = 0; x < width; x++) {
+      var d = dist[y][x];
+      if (y > 0) {
+        d = min(d, dist[y - 1][x] + 1);
+      }
+      if (x > 0) {
+        d = min(d, dist[y][x - 1] + 1);
+      }
+      dist[y][x] = d;
+    }
+  }
+  for (var y = height - 1; y >= 0; y--) {
+    for (var x = width - 1; x >= 0; x--) {
+      var d = dist[y][x];
+      if (y + 1 < height) {
+        d = min(d, dist[y + 1][x] + 1);
+      }
+      if (x + 1 < width) {
+        d = min(d, dist[y][x + 1] + 1);
+      }
+      dist[y][x] = d;
+    }
+  }
+  for (var y = 0; y < height; y++) {
+    for (var x = 0; x < width; x++) {
+      if (dist[y][x] >= inf) {
+        dist[y][x] = distanceWhenNoSources;
+      }
+    }
+  }
+  return dist;
+}

--- a/packages/colonizethis_map/lib/src/tile_map_visualization.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_visualization.dart
@@ -15,13 +15,12 @@ import 'tile_map_visualization_shared.dart'
         drawLegendContinentSeedMarker,
         drawLegendLandSeedMarker,
         drawLegendLine,
+        drawResourceLegendRows,
         drawResourceLetterAtCellCenter,
         landSeedMarkerRgb,
         legendLineHeight,
         legendPadding,
         regionPalette,
-        resourceToLegendLabel,
-        resourceToLegendLetter,
         swatchGap,
         swatchSize,
         terrainColorRgb,
@@ -118,26 +117,13 @@ int _drawOptionalLegendSections(
     }
   }
   if (hasResourceGrid) {
-    for (final r in Resource.values) {
-      final y = legendY0 + row * legendLineHeight;
-      img.drawString(
-        image,
-        resourceToLegendLetter(r),
-        font: img.arial14,
-        x: legendPadding,
-        y: y,
-        color: black,
-      );
-      img.drawString(
-        image,
-        '  ${resourceToLegendLabel(r)}',
-        font: img.arial14,
-        x: legendPadding + swatchSize + swatchGap,
-        y: y,
-        color: black,
-      );
-      row++;
-    }
+    final yAfter = drawResourceLegendRows(
+      image,
+      legendY: legendY0 + row * legendLineHeight,
+      textColor: black,
+      resources: Resource.values,
+    );
+    row += (yAfter - (legendY0 + row * legendLineHeight)) ~/ legendLineHeight;
   }
   return row;
 }

--- a/packages/colonizethis_map/lib/src/tile_map_visualization.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_visualization.dart
@@ -15,7 +15,6 @@ import 'tile_map_visualization_shared.dart'
         drawLegendContinentSeedMarker,
         drawLegendLandSeedMarker,
         drawLegendLine,
-        drawLegendSwatch,
         drawResourceLetterAtCellCenter,
         landSeedMarkerRgb,
         legendLineHeight,
@@ -99,18 +98,10 @@ int _drawOptionalLegendSections(
         (a, b) => a > b ? a : b,
       );
       for (var c = 0; c <= maxContinent; c++) {
-        final y = legendY0 + row * legendLineHeight;
+        var y = legendY0 + row * legendLineHeight;
         final (r, g, b) = regionPalette[c % regionPalette.length];
-        drawLegendSwatch(image, y, r, g, b);
-        img.drawString(
-          image,
-          'Continent $c',
-          font: img.arial14,
-          x: legendPadding + swatchSize + swatchGap,
-          y: y,
-          color: black,
-        );
-        row++;
+        y = drawLegendLine(image, y, r, g, b, 'Continent $c');
+        row = (y - legendY0) ~/ legendLineHeight;
       }
     } else {
       final y = legendY0 + row * legendLineHeight;

--- a/packages/colonizethis_map/lib/src/tile_map_visualization_shared.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_visualization_shared.dart
@@ -4,6 +4,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:image/image.dart' as img;
 
+import 'init_game_map_view_data.dart';
 import 'tile_map_colors.dart';
 
 export 'tile_map_colors.dart';
@@ -14,6 +15,25 @@ const int legendPadding = 12;
 const int legendLineHeight = 20;
 const int swatchSize = 14;
 const int swatchGap = 8;
+
+/// Title line for PNG game-world ownership overlays (combined and view-data paths).
+/// SPEC/program/map-visualization.md § Game world state map visualizer.
+const String kGameWorldMapOwnershipLegendBlurb =
+    'Ownership by faction. Black = land borders; light blue = sea borders.';
+
+/// Sea-zone local ids from flattened [RegionMapViewData] cells.
+///
+/// Use when rendering from view data without a [MapTopology] (dual with
+/// [seaZoneIdsFromTopology]). Order is not preserved; ids are unique.
+Set<String> seaZoneLocalIdsFromRegionCells(List<CellViewData> cells) {
+  final out = <String>{};
+  for (final cell in cells) {
+    if (cell.isSea) {
+      out.add(cell.regionCellId);
+    }
+  }
+  return out;
+}
 
 img.Color _borderColorForAdjacentCells(
   String id,

--- a/packages/colonizethis_map/lib/src/tile_map_visualization_shared.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_visualization_shared.dart
@@ -6,6 +6,7 @@ import 'package:image/image.dart' as img;
 
 import 'init_game_map_view_data.dart';
 import 'tile_map_colors.dart';
+import 'tile_map_resource_legend.dart';
 
 export 'tile_map_colors.dart';
 export 'tile_map_resource_legend.dart';
@@ -282,6 +283,60 @@ int drawLegendLine(img.Image image, int y, int r, int g, int b, String label) {
     color: black,
   );
   return y + legendLineHeight;
+}
+
+/// Layout variant for [drawResourceLegendRows] (Refs #2489 D7/D9 legend dedup).
+enum ResourceLegendRowsStyle {
+  /// `"<letter>  <label>"` at [legendPadding] (game-world geographic PNG).
+  compactInline,
+
+  /// Letter at [legendPadding]; label column aligned with color-swatch legends.
+  tileMapColumns,
+}
+
+/// Draws resource legend rows. Returns y after the last row.
+int drawResourceLegendRows(
+  img.Image image, {
+  required int legendY,
+  required img.Color textColor,
+  required Iterable<Resource> resources,
+  ResourceLegendRowsStyle style = ResourceLegendRowsStyle.tileMapColumns,
+}) {
+  var y = legendY;
+  for (final r in resources) {
+    final letter = resourceToLegendLetter(r);
+    final label = resourceToLegendLabel(r);
+    switch (style) {
+      case ResourceLegendRowsStyle.compactInline:
+        img.drawString(
+          image,
+          '$letter  $label',
+          font: img.arial14,
+          x: legendPadding,
+          y: y,
+          color: textColor,
+        );
+      case ResourceLegendRowsStyle.tileMapColumns:
+        img.drawString(
+          image,
+          letter,
+          font: img.arial14,
+          x: legendPadding,
+          y: y,
+          color: textColor,
+        );
+        img.drawString(
+          image,
+          '  $label',
+          font: img.arial14,
+          x: legendPadding + swatchSize + swatchGap,
+          y: y,
+          color: textColor,
+        );
+    }
+    y += legendLineHeight;
+  }
+  return y;
 }
 
 /// Draws the "Ports marked with teal square." legend line at [y]. Returns y + legendLineHeight.

--- a/packages/colonizethis_map/test/tile_map_generator_test.dart
+++ b/packages/colonizethis_map/test/tile_map_generator_test.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_map/src/tile_map_directions.dart';
 import 'package:colonizethis_map/src/tile_map_topology_helpers.dart';
 import 'package:logger/logger.dart';
 
@@ -424,7 +425,7 @@ void main() {
         final reachable = queue.toSet();
         while (queue.isNotEmpty) {
           final (x, y) = queue.removeLast();
-          for (final (dx, dy) in [(0, -1), (0, 1), (-1, 0), (1, 0)]) {
+          for (final (dx, dy) in kTileMapDirections4NorthSouthWestEast) {
             final nx = x + dx;
             final ny = y + dy;
             if (nx >= 0 && nx < result.width && ny >= 0 && ny < result.height) {

--- a/packages/colonizethis_map/test/tile_map_generator_test.dart
+++ b/packages/colonizethis_map/test/tile_map_generator_test.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_map/src/tile_map_topology_helpers.dart';
 import 'package:logger/logger.dart';
 
 void main() {
@@ -456,10 +457,7 @@ void main() {
             seaFraction: 0.6,
           ),
         ).generate(numProvinces: 2, numContinents: 1, regionId: 'r1');
-        final seaZoneIds = topology.nodes
-            .where((n) => n.type == TopologyNodeType.seaZone)
-            .map((n) => n.id)
-            .toSet();
+        final seaZoneIds = seaZoneIdsFromTopology(topology);
         if (seaZoneIds.isEmpty) return;
         final boundaryIds = <String>{};
         final w = result.width;
@@ -486,10 +484,7 @@ void main() {
       final (result, topology) = TileMapGenerator(
         params: TileMapParams(width: 24, height: 24, seed: 7, seaFraction: 0.6),
       ).generate(numProvinces: 2, numContinents: 1, regionId: 'r1');
-      final seaNodes = topology.nodes
-          .where((n) => n.type == TopologyNodeType.seaZone)
-          .map((n) => n.id)
-          .toSet();
+      final seaNodes = seaZoneIdsFromTopology(topology);
       expect(seaNodes, isNotEmpty);
       for (final id in seaNodes) {
         expect(RegExp(r'^s\d+$').hasMatch(id), isTrue);
@@ -523,9 +518,7 @@ void main() {
           }
         }
         if (totalSea == 0) return;
-        final seaZoneCount = topology.nodes
-            .where((n) => n.type == TopologyNodeType.seaZone)
-            .length;
+        final seaZoneCount = seaZoneIdsFromTopology(topology).length;
         // With 5% cap, one ocean should be split into at least ~20 zones.
         expect(
           seaZoneCount,

--- a/packages/colonizethis_map/test/tile_map_manhattan_distance_transform_test.dart
+++ b/packages/colonizethis_map/test/tile_map_manhattan_distance_transform_test.dart
@@ -1,0 +1,135 @@
+import 'dart:math';
+
+import 'package:colonizethis_map/src/tile_map_manhattan_distance_transform.dart';
+import 'package:colonizethis_test/test.dart';
+
+int _bruteManhattanMin(
+  int width,
+  int height,
+  int x,
+  int y,
+  bool Function(int x, int y) isSource,
+  int distanceWhenNoSources,
+) {
+  var best = distanceWhenNoSources;
+  for (var ny = 0; ny < height; ny++) {
+    for (var nx = 0; nx < width; nx++) {
+      if (!isSource(nx, ny)) continue;
+      final d = (x - nx).abs() + (y - ny).abs();
+      if (d < best) best = d;
+    }
+  }
+  return best;
+}
+
+void main() {
+  group('manhattanDistToNearestSourceXY', () {
+    test('matches brute force on a small grid with sparse sources', () {
+      const w = 6;
+      const h = 5;
+      const emptySentinel = w + h;
+      bool isSource(int x, int y) =>
+          (x == 2 && y == 1) || (x == 5 && y == 4) || (x == 0 && y == 0);
+
+      final dist = manhattanDistToNearestSourceXY(
+        w,
+        h,
+        isSource,
+        distanceWhenNoSources: emptySentinel,
+      );
+
+      for (var y = 0; y < h; y++) {
+        for (var x = 0; x < w; x++) {
+          expect(
+            dist[y][x],
+            _bruteManhattanMin(w, h, x, y, isSource, emptySentinel),
+          );
+        }
+      }
+    });
+
+    test('uses distanceWhenNoSources when no source cells exist', () {
+      const w = 4;
+      const h = 4;
+      const emptySentinel = 99;
+      final dist = manhattanDistToNearestSourceXY(
+        w,
+        h,
+        (_, __) => false,
+        distanceWhenNoSources: emptySentinel,
+      );
+      for (var y = 0; y < h; y++) {
+        for (var x = 0; x < w; x++) {
+          expect(dist[y][x], emptySentinel);
+        }
+      }
+    });
+
+    test('returns empty list for non-positive dimensions', () {
+      expect(
+        manhattanDistToNearestSourceXY(
+          0,
+          3,
+          (_, __) => true,
+          distanceWhenNoSources: 0,
+        ),
+        isEmpty,
+      );
+      expect(
+        manhattanDistToNearestSourceXY(
+          3,
+          0,
+          (_, __) => true,
+          distanceWhenNoSources: 0,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('every cell is 0 when all cells are sources', () {
+      const w = 3;
+      const h = 3;
+      final dist = manhattanDistToNearestSourceXY(
+        w,
+        h,
+        (_, __) => true,
+        distanceWhenNoSources: 10,
+      );
+      for (var y = 0; y < h; y++) {
+        for (var x = 0; x < w; x++) {
+          expect(dist[y][x], 0);
+        }
+      }
+    });
+
+    test('matches brute force on pseudo-random 8x8 masks', () {
+      final rnd = Random(42);
+      const w = 8;
+      const h = 8;
+      const emptySentinel = w + h;
+      for (var trial = 0; trial < 40; trial++) {
+        final mask = List.generate(
+          h,
+          (_) => List<bool>.generate(w, (_) => rnd.nextBool()),
+        );
+        bool isSource(int x, int y) => mask[y][x];
+
+        final dist = manhattanDistToNearestSourceXY(
+          w,
+          h,
+          isSource,
+          distanceWhenNoSources: emptySentinel,
+        );
+        for (var y = 0; y < h; y++) {
+          for (var x = 0; x < w; x++) {
+            expect(
+              dist[y][x],
+              _bruteManhattanMin(w, h, x, y, isSource, emptySentinel),
+              reason: 'trial=$trial cell=($x,$y)',
+            );
+          }
+        }
+      }
+    });
+  });
+}

--- a/packages/colonizethis_map/test/tile_map_pass4_lakes_test.dart
+++ b/packages/colonizethis_map/test/tile_map_pass4_lakes_test.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_map/src/tile_map_directions.dart';
 
 void main() {
   group('Pass 4 lake fill (issue 1864)', () {
@@ -81,7 +82,7 @@ void main() {
         final reachable = queue.toSet();
         while (queue.isNotEmpty) {
           final (x, y) = queue.removeLast();
-          for (final (dx, dy) in [(0, -1), (0, 1), (-1, 0), (1, 0)]) {
+          for (final (dx, dy) in kTileMapDirections4NorthSouthWestEast) {
             final nx = x + dx;
             final ny = y + dy;
             if (nx >= 0 && nx < result.width && ny >= 0 && ny < result.height) {

--- a/packages/colonizethis_map/test/tile_map_visualization_shared_helpers_test.dart
+++ b/packages/colonizethis_map/test/tile_map_visualization_shared_helpers_test.dart
@@ -1,6 +1,9 @@
-import 'package:colonizethis_test/test.dart';
+import 'package:image/image.dart' as img;
 
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_test/test.dart';
 import 'package:colonizethis_map/colonizethis_map.dart';
+import 'package:colonizethis_map/src/tile_map_visualization_shared.dart';
 
 void main() {
   group('seaZoneLocalIdsFromRegionCells', () {
@@ -10,34 +13,47 @@ void main() {
 
     test('collects unique sea zone local ids', () {
       final cells = <CellViewData>[
-        const CellViewData(
-          x: 0,
-          y: 0,
-          regionCellId: 'p1',
-          isSea: false,
-        ),
-        const CellViewData(
-          x: 1,
-          y: 0,
-          regionCellId: 's1',
-          isSea: true,
-        ),
-        const CellViewData(
-          x: 2,
-          y: 0,
-          regionCellId: 's1',
-          isSea: true,
-        ),
-        const CellViewData(
-          x: 0,
-          y: 1,
-          regionCellId: 's2',
-          isSea: true,
-        ),
+        const CellViewData(x: 0, y: 0, regionCellId: 'p1', isSea: false),
+        const CellViewData(x: 1, y: 0, regionCellId: 's1', isSea: true),
+        const CellViewData(x: 2, y: 0, regionCellId: 's1', isSea: true),
+        const CellViewData(x: 0, y: 1, regionCellId: 's2', isSea: true),
       ];
+      expect(seaZoneLocalIdsFromRegionCells(cells), equals({'s1', 's2'}));
+    });
+  });
+
+  group('drawResourceLegendRows', () {
+    test(
+      'advances by one legend line height per resource (tile-map columns)',
+      () {
+        final image = img.Image(width: 320, height: 120);
+        final black = image.getColor(0, 0, 0);
+        const y0 = 10;
+        final yEnd = drawResourceLegendRows(
+          image,
+          legendY: y0,
+          textColor: black,
+          resources: const [Resource.grain, Resource.iron],
+          style: ResourceLegendRowsStyle.tileMapColumns,
+        );
+        expect(yEnd, y0 + 2 * legendLineHeight);
+      },
+    );
+
+    test('advances similarly for compactInline style', () {
+      final image = img.Image(width: 320, height: 120);
+      final black = image.getColor(0, 0, 0);
+      const y0 = 4;
+      final yEnd = drawResourceLegendRows(
+        image,
+        legendY: y0,
+        textColor: black,
+        resources: geographicGameWorldLegendResources,
+        style: ResourceLegendRowsStyle.compactInline,
+      );
       expect(
-        seaZoneLocalIdsFromRegionCells(cells),
-        equals({'s1', 's2'}),
+        yEnd,
+        y0 + geographicGameWorldLegendResources.length * legendLineHeight,
       );
     });
   });

--- a/packages/colonizethis_map/test/tile_map_visualization_shared_helpers_test.dart
+++ b/packages/colonizethis_map/test/tile_map_visualization_shared_helpers_test.dart
@@ -1,0 +1,44 @@
+import 'package:colonizethis_test/test.dart';
+
+import 'package:colonizethis_map/colonizethis_map.dart';
+
+void main() {
+  group('seaZoneLocalIdsFromRegionCells', () {
+    test('empty list yields empty set', () {
+      expect(seaZoneLocalIdsFromRegionCells([]), isEmpty);
+    });
+
+    test('collects unique sea zone local ids', () {
+      final cells = <CellViewData>[
+        const CellViewData(
+          x: 0,
+          y: 0,
+          regionCellId: 'p1',
+          isSea: false,
+        ),
+        const CellViewData(
+          x: 1,
+          y: 0,
+          regionCellId: 's1',
+          isSea: true,
+        ),
+        const CellViewData(
+          x: 2,
+          y: 0,
+          regionCellId: 's1',
+          isSea: true,
+        ),
+        const CellViewData(
+          x: 0,
+          y: 1,
+          regionCellId: 's2',
+          isSea: true,
+        ),
+      ];
+      expect(
+        seaZoneLocalIdsFromRegionCells(cells),
+        equals({'s1', 's2'}),
+      );
+    });
+  });
+}


### PR DESCRIPTION
"## Summary\n- Ongoing **#2489** refactor/perf for `packages/colonizethis_map` (dedup + hot-path); **no intentional generation semantics change**.\n- **Latest push:** **map visualization** \u2014 `kGameWorldMapOwnershipLegendBlurb` replaces duplicated PNG title strings and `seaZoneLocalIdsFromRegionCells` dedupes the view-data sea-zone id scan (`tile_map_visualization_shared.dart`, `game_world_state_map_visualizer.dart`); new unit tests for the collector.\n- Earlier slices on this branch: **P4** `joinContinents` incremental land-cell maintenance; D1 nearest-land-seed consolidation, shared direction deltas, resource placement helper, `copyTileMapGrid`, continent land-seed legend via `drawLegendLine`, organic seed Manhattan precompute, terrain/ridge scan reductions, unified non-mountain land collection, `oceanCells` redundant scan removal, `seaZoneIdsFromTopology` test usage, and related commits.\n\n## Deferred\n- Remaining **#2489** checklist items (see issue): e.g. any leftover D3/D4 literals, D8/D9 map visualizer dedup beyond this slice, P3 terrain-assignment full combined pass wording in AC if any gaps, full AC closure.\n\n## Tests\n- `cd packages/colonizethis_map && dart analyze lib && dart test` (green locally after latest commit)\n\nRefs #2489\n"