### PR TITLE
refactor(logic): centralize cardinal grid neighbor deltas (Refs #2391)

### DIFF
--- a/packages/colonizethis_logic/lib/src/constants.dart
+++ b/packages/colonizethis_logic/lib/src/constants.dart
@@ -16,6 +16,16 @@ export 'package:colonizethis_models/colonizethis_models.dart'
 const String kRegionOldWorld = 'oldWorld';
 const String kRegionNewWorld = 'newWorld';
 
+/// Cardinal (4-neighbor) grid deltas on row-major tile maps (north/up-first).
+/// Canonical ordering shared across connectivity scans, setup shortest-path BFS,
+/// capital-choice routing, and naval coastal adjacency (Refs #2391).
+const List<(int, int)> kGridNeighborsCardinal4 = [
+  (0, -1),
+  (1, 0),
+  (0, 1),
+  (-1, 0),
+];
+
 /// Default sea fraction for map generation (0.6 = 60% sea, 40% land).
 const double kDefaultSeaFraction = 0.6;
 

--- a/packages/colonizethis_logic/lib/src/setup/capital_choice.dart
+++ b/packages/colonizethis_logic/lib/src/setup/capital_choice.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../constants.dart';
 import '../world/province_lookup.dart';
 import '../world/player_state_pipeline.dart';
 import 'setup_exceptions.dart';
@@ -436,7 +437,7 @@ bool _isTileAdjacentToSea(
       .toSet();
   final w = map.width;
   final h = map.height;
-  for (final d in [(0, -1), (1, 0), (0, 1), (-1, 0)]) {
+  for (final d in kGridNeighborsCardinal4) {
     final nx = x + d.$1;
     final ny = y + d.$2;
     if (nx < 0 || nx >= w || ny < 0 || ny >= h) continue;
@@ -455,7 +456,7 @@ bool _isTileAdjacentToOtherProvince(
 ) {
   final w = map.width;
   final h = map.height;
-  for (final d in [(0, -1), (1, 0), (0, 1), (-1, 0)]) {
+  for (final d in kGridNeighborsCardinal4) {
     final nx = x + d.$1;
     final ny = y + d.$2;
     if (nx < 0 || nx >= w || ny < 0 || ny >= h) continue;
@@ -509,7 +510,7 @@ bool _isTileAdjacentToSeaZone(
       : seaZoneId;
   final w = map.width;
   final h = map.height;
-  for (final d in [(0, -1), (1, 0), (0, 1), (-1, 0)]) {
+  for (final d in kGridNeighborsCardinal4) {
     final nx = x + d.$1;
     final ny = y + d.$2;
     if (nx < 0 || nx >= w || ny < 0 || ny >= h) continue;
@@ -553,7 +554,7 @@ List<(int, int)> _shortestPathOnProvinceTiles(
       }
       return path;
     }
-    for (final d in [(0, -1), (1, 0), (0, 1), (-1, 0)]) {
+    for (final d in kGridNeighborsCardinal4) {
       final nx = cx + d.$1;
       final ny = cy + d.$2;
       if (nx < 0 || nx >= w || ny < 0 || ny >= h) continue;

--- a/packages/colonizethis_logic/lib/src/setup/game_setup_helpers_towns.dart
+++ b/packages/colonizethis_logic/lib/src/setup/game_setup_helpers_towns.dart
@@ -4,6 +4,7 @@ import 'dart:collection';
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../constants.dart';
 import '../world/province_lookup.dart';
 import '../world/tile_key_coordinates.dart';
 import 'game_setup_context.dart';
@@ -313,7 +314,7 @@ bool _tileKeyAdjacentToProvinceSeaZone({
       .where((node) => node.type == TopologyNodeType.province)
       .map((node) => node.id)
       .toSet();
-  for (final delta in const [(0, -1), (1, 0), (0, 1), (-1, 0)]) {
+  for (final delta in kGridNeighborsCardinal4) {
     final nx = x + delta.$1;
     final ny = y + delta.$2;
     if (nx < 0 || nx >= map.width || ny < 0 || ny >= map.height) {

--- a/packages/colonizethis_logic/lib/src/setup/init_town_roads.dart
+++ b/packages/colonizethis_logic/lib/src/setup/init_town_roads.dart
@@ -11,9 +11,8 @@ import '../world/tile_key_coordinates.dart';
 
 const int _initTownRoadLevel = 1;
 
-/// BFS neighbor order — matches [_shortestPathOnProvinceTiles] in capital_choice.dart
-/// for deterministic shortest paths.
-const List<(int, int)> _kBfsDeltas = [(0, -1), (1, 0), (0, 1), (-1, 0)];
+/// Neighbor iteration uses [kGridNeighborsCardinal4] ordering so shortest-path
+/// scans align with [_shortestPathOnProvinceTiles] in capital_choice.dart (Refs #2391).
 
 /// After town assignment: for each faction whose capital lies in a region listed in
 /// [GameSetupConfig.initTownRoadWiringRegionIds], raise road level to at least
@@ -187,7 +186,7 @@ Map<String, String> _bfsParentsFromCapital({
     final xy = _parseTileKeyXY(cur);
     if (xy == null) continue;
     final (cx, cy) = xy;
-    for (final d in _kBfsDeltas) {
+    for (final d in kGridNeighborsCardinal4) {
       final nx = cx + d.$1;
       final ny = cy + d.$2;
       if (nx < 0 || nx >= mapWidth || ny < 0 || ny >= mapHeight) {

--- a/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
@@ -4,6 +4,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/src/logging.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../constants.dart';
 import '../utils/graph_traversal.dart';
 import '../diplomacy/diplomacy_relation_lookup.dart';
 import 'connectivity_blockade_target.dart';
@@ -249,7 +250,7 @@ bool _isCapitalTileOnSeaboard(
   if (map == null) return false;
   final w = map.width;
   final h = map.height;
-  for (final d in [(0, -1), (1, 0), (0, 1), (-1, 0)]) {
+  for (final d in kGridNeighborsCardinal4) {
     final nx = capital.x + d.$1;
     final ny = capital.y + d.$2;
     if (nx < 0 || nx >= w || ny < 0 || ny >= h) return true;
@@ -602,7 +603,7 @@ void _applyTownRuleConnectivityClosure({
     final map = tileMapByRegion[coords.regionId];
     if (map == null) continue;
 
-    for (final d in [(0, -1), (1, 0), (0, 1), (-1, 0)]) {
+    for (final d in kGridNeighborsCardinal4) {
       final nx = coords.x + d.$1;
       final ny = coords.y + d.$2;
       if (nx < 0 || nx >= map.width || ny < 0 || ny >= map.height) continue;
@@ -646,7 +647,7 @@ List<String> _adjacentTileKeys(
   final out = <String>[];
   final w = map.width;
   final h = map.height;
-  for (final d in [(0, -1), (1, 0), (0, 1), (-1, 0)]) {
+  for (final d in kGridNeighborsCardinal4) {
     final nx = x + d.$1;
     final ny = y + d.$2;
     if (nx < 0 || nx >= w || ny < 0 || ny >= h) continue;

--- a/packages/colonizethis_logic/lib/src/world/naval_coastal_visibility.dart
+++ b/packages/colonizethis_logic/lib/src/world/naval_coastal_visibility.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../constants.dart';
 import 'naval.dart';
 import 'player_view.dart';
 import 'province_lookup.dart' show toFullProvinceId;
@@ -55,11 +56,10 @@ Set<String> _coastalTileKeysAdjacentToSeaZone({
   }
   if (seaCoords.isEmpty) return const {};
   final coastal = <String>{};
-  const deltas = [(0, -1), (1, 0), (0, 1), (-1, 0)];
   for (final provinceTileKey in provinceTileKeys) {
     final xy = _xyFromTileKey(provinceTileKey);
     if (xy == null) continue;
-    final isCoastal = deltas.any(
+    final isCoastal = kGridNeighborsCardinal4.any(
       (delta) => seaCoords.contains('${xy.x + delta.$1}|${xy.y + delta.$2}'),
     );
     if (isCoastal) coastal.add(provinceTileKey);

--- a/packages/colonizethis_logic/test/constants/grid_neighbors_cardinal_test.dart
+++ b/packages/colonizethis_logic/test/constants/grid_neighbors_cardinal_test.dart
@@ -1,0 +1,15 @@
+import 'package:colonizethis_logic/src/constants.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  test(
+    'kGridNeighborsCardinal4 preserves canonical cardinal traversal ordering '
+    '(Refs #2391 — connectivity/setup alignment)',
+    () {
+      expect(
+        kGridNeighborsCardinal4,
+        const <(int, int)>[(0, -1), (1, 0), (0, 1), (-1, 0)],
+      );
+    },
+  );
+}

--- a/tool/logic_all_provinces_sanctions.yaml
+++ b/tool/logic_all_provinces_sanctions.yaml
@@ -4,7 +4,7 @@
 version: 1
 sanctions:
   - path: packages/colonizethis_logic/lib/src/world/connectivity_resolver.dart
-    line: 176
+    line: 177
     rationale: Single dual-region pass buckets owned provinces and town-tile keys
       by playerId so per-player connectivity loops below run O(1) lookups
       instead of repeating O(provinces) scans (consolidates the legacy line-229


### PR DESCRIPTION
## Summary
- Introduces `kGridNeighborsCardinal4` in `lib/src/constants.dart` as the single canonical cardinal-neighbor ordering used across connectivity resolution, capital-choice shortest-path/adjacency scans, init town-road BFS, province town assignment, and naval coastal tile classification (behavior-preserving dedup from issue #2391).
- Adds a small regression test locking the tuple ordering so setup/connectivity tie-breaking stays aligned.

## Deferred
- Broader items from #2391 (logger duplication sweep, validator bundle ergonomics, work-handler consolidation, etc.) remain out of scope for this slice.

## Test plan
- [x] `dart analyze` on touched `lib/` files
- [x] `dart test test/constants/grid_neighbors_cardinal_test.dart`
- [x] `dart test test/capital_choice_classification_test.dart test/connectivity_resolver_test.dart test/connectivity_resolver_sea_test.dart`
- [x] `dart test test/naval_coastal_visibility_test.dart`

Refs #2391

Made with [Cursor](https://cursor.com)