### PR TITLE
perf(logic): single-scan player indices in Join Empire absorption (Refs #2394)

### DIFF
--- a/packages/colonizethis_logic/lib/src/diplomacy/faction_absorption_engine.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/faction_absorption_engine.dart
@@ -92,18 +92,30 @@ Game _absorbIntoGp(
 }) {
   final cost = joinEmpireCostForMinorOrTribe(game, absorbedFactionId);
   var players = List<Player>.from(game.players);
-  final gpIdx = players.indexWhere((p) => p.id == gpId);
 
   if (kind == _AbsorptionKind.greatPower) {
-    final targetIdx = players.indexWhere((p) => p.id == absorbedFactionId);
+    // Single pass replaces two indexWhere scans (Refs #2394 Category C).
+    var gpIdx = -1;
+    var targetIdx = -1;
+    for (var i = 0; i < players.length; i++) {
+      final id = players[i].id;
+      if (id == gpId) gpIdx = i;
+      if (id == absorbedFactionId) targetIdx = i;
+    }
     if (gpIdx < 0 || targetIdx < 0) return game;
     players[gpIdx] = players[gpIdx].copyWith(
       treasury: players[gpIdx].treasury - cost,
     );
     players.removeAt(targetIdx);
   } else {
+    var gpIdx = -1;
+    for (var i = 0; i < players.length; i++) {
+      if (players[i].id == gpId) {
+        gpIdx = i;
+        break;
+      }
+    }
     if (gpIdx >= 0) {
-      players = List<Player>.from(players);
       players[gpIdx] = players[gpIdx].copyWith(
         treasury: players[gpIdx].treasury - cost,
       );


### PR DESCRIPTION
## Summary
- Replace dual `indexWhere` scans over `players` during `_AbsorptionKind.greatPower` absorption with one linear pass while preserving treasury-update vs `removeAt` ordering.
- Minor/Tribe absorption path now finds the absorbing GP with a single loop (early exit once matched); drops an unnecessary redundant `List.from` when updating treasury.

## Scope vs issue #2394
Targets Category C-style redundant linear lookups (`faction_absorption_engine` hot-ish diplomacy Join Empire path). Does **not** close AC bullets wholesale (benchmark suite / AST gates already landed separately elsewhere).

## Test plan
- [x] `dart test packages/colonizethis_logic/test/diplomacy/faction_absorption_engine_test.dart`

Refs #2394


Made with [Cursor](https://cursor.com)