### PR TITLE
perf(map): phase-2 hot-path optimizations for map generation (#2489)

### DIFF
--- a/app/test/ct_region_map_widget_test_part2_test.dart
+++ b/app/test/ct_region_map_widget_test_part2_test.dart
@@ -567,44 +567,55 @@ void main() {
       'tapping non-civilian tile clears civilian selection and still opens tile detail',
       (WidgetTester tester) async {
         final base = ctRegionMapTestOldWorldRegion();
-        final selectedMarkerCell = base.cells.firstWhere((c) => !c.isSea);
-        final otherCell = base.cells.firstWhere(
-          (c) =>
-              !c.isSea &&
-              (c.x != selectedMarkerCell.x || c.y != selectedMarkerCell.y),
-        );
-        final selectedMarkerTileKey =
-            '${base.regionId}|${selectedMarkerCell.regionCellId}|${selectedMarkerCell.x}|${selectedMarkerCell.y}';
+        final landTemplate = base.cells.firstWhere((c) => !c.isSea);
+        const cellSize = 32;
+        const selectedMarkerTileKey = 'oldWorld|p1|0|0';
+        const otherTileKey = 'oldWorld|p1|1|0';
         final region = RegionMapViewData(
-          regionId: base.regionId,
-          width: base.width,
-          height: base.height,
-          cellSize: base.cellSize,
-          cells: base.cells,
-          capitalMarkers: base.capitalMarkers,
-          portMarkers: base.portMarkers,
-          townMarkers: base.townMarkers,
+          regionId: 'oldWorld',
+          width: 2,
+          height: 1,
+          cellSize: cellSize,
+          cells: [
+            CellViewData(
+              x: 0,
+              y: 0,
+              regionCellId: 'p1',
+              isSea: false,
+              terrainTypeId: landTemplate.terrainTypeId,
+              terrainType: landTemplate.terrainType,
+              ownerFactionId: landTemplate.ownerFactionId,
+            ),
+            CellViewData(
+              x: 1,
+              y: 0,
+              regionCellId: 'p1',
+              isSea: false,
+              terrainTypeId: landTemplate.terrainTypeId,
+              terrainType: landTemplate.terrainType,
+              ownerFactionId: landTemplate.ownerFactionId,
+            ),
+          ],
+          capitalMarkers: const [],
+          portMarkers: const [],
+          townMarkers: const [],
           factionColors: base.factionColors,
           greatPowerFactionIds: base.greatPowerFactionIds,
           terrainColors: base.terrainColors,
-          unitMarkers: base.unitMarkers,
+          unitMarkers: const [],
           civilianTileMarkers: [
             CivilianTileMarkerView(
               tileKey: selectedMarkerTileKey,
-              x: selectedMarkerCell.x,
-              y: selectedMarkerCell.y,
-              localProvinceId: selectedMarkerCell.regionCellId,
+              x: 0,
+              y: 0,
+              localProvinceId: 'p1',
               unitIds: const ['u_builder'],
               unitTypes: const {'u_builder': kUnitTypeBuilder},
               representativeUnitType: kUnitTypeBuilder,
               stackCount: 1,
             ),
           ],
-          warpMarkers: base.warpMarkers,
-          provinceUnitPresenceByProvinceId:
-              base.provinceUnitPresenceByProvinceId,
-          provincePoliticalOwnerByPrefixedProvinceId:
-              base.provincePoliticalOwnerByPrefixedProvinceId,
+          warpMarkers: const [],
         );
         var clearCount = 0;
         String? detailTileKey;
@@ -612,7 +623,9 @@ void main() {
         await tester.pumpWidget(
           ctRegionMapTestHarness(
             region: region,
-            cellSizePx: region.cellSize.toDouble(),
+            width: 96,
+            height: 64,
+            cellSizePx: cellSize.toDouble(),
             selectedCivilianTileKey: selectedMarkerTileKey,
             onCivilianTileSelectionCleared: () => clearCount++,
             onMapTileTappedForDetail: (tileKey) => detailTileKey = tileKey,
@@ -622,18 +635,13 @@ void main() {
 
         final mapFinder = find.byType(CtRegionMap);
         final topLeft = tester.getTopLeft(mapFinder);
-        final tapOffset =
-            topLeft +
-            Offset(
-              (otherCell.x + 0.5) * region.cellSize.toDouble(),
-              (otherCell.y + 0.5) * region.cellSize.toDouble(),
-            );
-        await tester.tapAt(tapOffset);
+        await tester.tapAt(
+          topLeft + const Offset(cellSize * 1.5, cellSize * 0.5),
+        );
         await tester.pump();
 
         expect(clearCount, equals(1));
-        expect(detailTileKey, isNotNull);
-        expect(detailTileKey, isNot(equals(selectedMarkerTileKey)));
+        expect(detailTileKey, otherTileKey);
       },
       timeout: const Timeout(Duration(seconds: 5)),
     );

--- a/app/test/province_overlay_test.dart
+++ b/app/test/province_overlay_test.dart
@@ -525,26 +525,35 @@ void main() {
       'Tile section shows ??? for unrevealed tiles in player-constrained view',
       (WidgetTester tester) async {
         final baseRegion = demoRegionForOverlay;
-        final cells = <CellViewData>[];
-        for (var i = 0; i < baseRegion.cells.length; i++) {
-          final c = baseRegion.cells[i];
-          cells.add(
-            CellViewData(
-              x: c.x,
-              y: c.y,
-              regionCellId: c.regionCellId,
-              isSea: c.isSea,
-              terrainTypeId: c.terrainTypeId,
-              terrainType: c.terrainType,
-              resourceId: c.resourceId,
-              ownerFactionId: c.ownerFactionId,
-              provinceDisplayName: c.provinceDisplayName,
-              improvementLevel: c.improvementLevel,
-              roadLevel: c.roadLevel,
-              visibility: i == 0 ? TileVisibility.unrevealed : c.visibility,
-            ),
-          );
-        }
+        final targetCell = baseRegion.cells.firstWhere(
+          (c) =>
+              !c.isSea &&
+              baseRegion.cells.any(
+                (other) =>
+                    other.regionCellId == c.regionCellId &&
+                    other.visibility != TileVisibility.unrevealed,
+              ),
+        );
+        final cells = baseRegion.cells
+            .map(
+              (c) => CellViewData(
+                x: c.x,
+                y: c.y,
+                regionCellId: c.regionCellId,
+                isSea: c.isSea,
+                terrainTypeId: c.terrainTypeId,
+                terrainType: c.terrainType,
+                resourceId: c.resourceId,
+                ownerFactionId: c.ownerFactionId,
+                provinceDisplayName: c.provinceDisplayName,
+                improvementLevel: c.improvementLevel,
+                roadLevel: c.roadLevel,
+                visibility: c.x == targetCell.x && c.y == targetCell.y
+                    ? TileVisibility.unrevealed
+                    : c.visibility,
+              ),
+            )
+            .toList();
         final region = RegionMapViewData(
           regionId: baseRegion.regionId,
           width: baseRegion.width,
@@ -559,10 +568,9 @@ void main() {
           unitMarkers: baseRegion.unitMarkers,
         );
 
-        final hoveredCell = region.cells.first;
         final selectedTileKey =
-            '${region.regionId}|${hoveredCell.regionCellId}|${hoveredCell.x}|${hoveredCell.y}';
-        final provinceId = '${region.regionId}|${hoveredCell.regionCellId}';
+            '${region.regionId}|${targetCell.regionCellId}|${targetCell.x}|${targetCell.y}';
+        final provinceId = '${region.regionId}|${targetCell.regionCellId}';
 
         await tester.pumpWidget(
           MaterialApp(

--- a/packages/colonizethis_map/lib/src/tile_map_generator_join_sea_bridge_part.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_join_sea_bridge_part.dart
@@ -30,6 +30,12 @@ extension _TileMapGenJoinSeaBridgePart on _TileMapGenJoinSea {
       continentBySeedIndex,
     );
     final maxJoinIterationsPerContinent = params.width * params.height;
+    var landCellsByContinent = _buildLandCellsByContinentIndex(
+      g,
+      provinceToContinent,
+      seaZoneId,
+      numContinents,
+    );
 
     final capState =
         (tg != null &&
@@ -49,12 +55,7 @@ extension _TileMapGenJoinSeaBridgePart on _TileMapGenJoinSea {
       var joinIterations = 0;
       while (joinIterations < maxJoinIterationsPerContinent) {
         joinIterations++;
-        final landCells = _landCellsForContinent(
-          g,
-          provinceToContinent,
-          c,
-          seaZoneId,
-        );
+        final landCells = landCellsByContinent[c];
         final components = _graph.connectedComponentsOfLand(landCells);
         if (components.length <= 1) break;
         didJoin = true;
@@ -75,7 +76,8 @@ extension _TileMapGenJoinSeaBridgePart on _TileMapGenJoinSea {
           rnd,
           capState,
         );
-        preserveSeaFraction(
+        landCellsByContinent[c].addAll(path);
+        final restoredToSea = preserveSeaFraction(
           g,
           tg,
           rg,
@@ -84,10 +86,15 @@ extension _TileMapGenJoinSeaBridgePart on _TileMapGenJoinSea {
           path.length,
           landCellsExcludedFromSeaRestore: bridgeCells,
         );
+        for (final (x, y) in restoredToSea) {
+          for (var ci = 0; ci < numContinents; ci++) {
+            landCellsByContinent[ci].remove((x, y));
+          }
+        }
       }
       if (joinIterations >= maxJoinIterationsPerContinent) {
         final stillSplit = _graph.connectedComponentsOfLand(
-          _landCellsForContinent(g, provinceToContinent, c, seaZoneId),
+          landCellsByContinent[c],
         );
         if (stillSplit.length > 1) {
           _log.w(
@@ -134,18 +141,29 @@ extension _TileMapGenJoinSeaBridgePart on _TileMapGenJoinSea {
     }
   }
 
-  Set<(int x, int y)> _landCellsForContinent(
+  /// One O(W×H) scan; [joinContinents] reuses and incrementally updates these sets
+  /// (Refs #2489 P4).
+  List<Set<(int x, int y)>> _buildLandCellsByContinentIndex(
     List<List<String>> grid,
     Map<String, int> membership,
-    int continentIndex,
     String seaZoneId,
+    int numContinents,
   ) {
-    final out = <(int x, int y)>{};
+    final out = List<Set<(int x, int y)>>.generate(
+      numContinents,
+      (_) => <(int x, int y)>{},
+    );
     for (var y = 0; y < params.height; y++) {
       for (var x = 0; x < params.width; x++) {
         final id = grid[y][x];
         if (id == seaZoneId) continue;
-        if (membership[id] == continentIndex) out.add((x, y));
+        final continentIndex = membership[id];
+        if (continentIndex == null ||
+            continentIndex < 0 ||
+            continentIndex >= numContinents) {
+          continue;
+        }
+        out[continentIndex].add((x, y));
       }
     }
     return out;

--- a/packages/colonizethis_map/lib/src/tile_map_generator_join_sea_bridge_part.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_join_sea_bridge_part.dart
@@ -278,26 +278,24 @@ extension _TileMapGenJoinSeaBridgePart on _TileMapGenJoinSea {
     int count, {
     Set<(int x, int y)>? landCellsExcludedFromSeaRestore,
   }) {
-    final coastal = <(int x, int y)>[];
+    // One ocean-neighbour count per candidate; reuse for sort keys (Refs #2489).
+    final coastal = <(int x, int y, int oceanNeighbours)>[];
     for (var y = 0; y < params.height; y++) {
       for (var x = 0; x < params.width; x++) {
         if (grid[y][x] == seaZoneId) continue;
         if (landCellsExcludedFromSeaRestore?.contains((x, y)) ?? false) {
           continue;
         }
-        if (_graph.oceanNeighbourCount(grid, x, y, seaZoneId, ocean) >= 1) {
-          coastal.add((x, y));
+        final n = _graph.oceanNeighbourCount(grid, x, y, seaZoneId, ocean);
+        if (n >= 1) {
+          coastal.add((x, y, n));
         }
       }
     }
-    coastal.sort((a, b) {
-      final na = _graph.oceanNeighbourCount(grid, a.$1, a.$2, seaZoneId, ocean);
-      final nb = _graph.oceanNeighbourCount(grid, b.$1, b.$2, seaZoneId, ocean);
-      return nb.compareTo(na);
-    });
+    coastal.sort((a, b) => b.$3.compareTo(a.$3));
     final restoredToSea = <(int x, int y)>[];
     for (var i = 0; i < count && i < coastal.length; i++) {
-      final (x, y) = coastal[i];
+      final (x, y, _) = coastal[i];
       grid[y][x] = seaZoneId;
       if (terrainGrid != null) terrainGrid[y][x] = null;
       if (resourceGrid != null) resourceGrid[y][x] = null;

--- a/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds_organic_part.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds_organic_part.dart
@@ -7,27 +7,18 @@
 //   (`_placeLandSeedsOrganicImpl`).
 part of 'tile_map_generator_land_seeds.dart';
 
-int _minManhattanDistToPoints(int x, int y, List<(int x, int y)> points) {
-  var minD = 1 << 30;
-  for (final (ox, oy) in points) {
-    final d = (x - ox).abs() + (y - oy).abs();
-    if (d < minD) minD = d;
-  }
-  return minD;
-}
-
 List<(int x, int y)> _organicSeedCloseSeaCandidates(
   TileMapLandSeedParams params,
   List<List<String>> grid,
   String seaZoneId,
-  List<(int x, int y)> ownLandOrSeed,
   int closeRadius,
+  List<List<int>> minDistToOwnLand,
 ) {
   final candidates = <(int x, int y)>[];
   for (var y = 0; y < params.height; y++) {
     for (var x = 0; x < params.width; x++) {
       if (grid[y][x] != seaZoneId) continue;
-      final minDistToOwn = _minManhattanDistToPoints(x, y, ownLandOrSeed);
+      final minDistToOwn = minDistToOwnLand[y][x];
       if (minDistToOwn > closeRadius) continue;
       candidates.add((x, y));
     }
@@ -37,7 +28,7 @@ List<(int x, int y)> _organicSeedCloseSeaCandidates(
 
 (int, int) _pickBestOrganicSeaCandidate(
   List<(int x, int y)> candidates,
-  List<(int x, int y)> ownLandOrSeed,
+  List<List<int>> minDistToOwnLand,
   List<List<int>> continentGrid,
   TileMapLandSeedParams params,
   int continentIndex,
@@ -57,7 +48,7 @@ List<(int x, int y)> _organicSeedCloseSeaCandidates(
   var bestScore = -1e100;
   final bestCandidates = <(int x, int y)>[];
   for (final (x, y) in candidates) {
-    final minDistToOwn = _minManhattanDistToPoints(x, y, ownLandOrSeed);
+    final minDistToOwn = minDistToOwnLand[y][x];
     final minDistToOther = distToOtherContinent[y][x];
     final score = -minDistToOwn + awayPenalty * minDistToOther;
     if (score > bestScore) {
@@ -93,12 +84,18 @@ List<(int x, int y)> _organicSeedCloseSeaCandidates(
       ownLandOrSeed.add(existingLandSeeds[i]);
     }
   }
+  final minDistToOwnLand = manhattanDistToNearestPoints(
+    params.width,
+    params.height,
+    ownLandOrSeed,
+    distanceWhenNoSources: 1 << 30,
+  );
   final candidates = _organicSeedCloseSeaCandidates(
     params,
     grid,
     seaZoneId,
-    ownLandOrSeed,
     closeRadius,
+    minDistToOwnLand,
   );
   if (candidates.isEmpty) {
     final (cx, cy) = continentSeed;
@@ -115,7 +112,7 @@ List<(int x, int y)> _organicSeedCloseSeaCandidates(
   }
   return _pickBestOrganicSeaCandidate(
     candidates,
-    ownLandOrSeed,
+    minDistToOwnLand,
     continentGrid,
     params,
     c,

--- a/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds_organic_part.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds_organic_part.dart
@@ -239,7 +239,7 @@ _placeLandSeedsOrganicImpl(
   final landSeeds = <(int x, int y)>[];
   final continentBySeedIndex = <int>[];
   var g = copyTileMapGrid(grid);
-  final continentGrid = List.generate(
+  var continentGrid = List.generate(
     params.height,
     (_) => List.filled(params.width, -1),
   );
@@ -302,11 +302,9 @@ _placeLandSeedsOrganicImpl(
       budgetPerContinent,
     );
     g = voronoiResult.$1;
-    for (var y = 0; y < params.height; y++) {
-      for (var x = 0; x < params.width; x++) {
-        continentGrid[y][x] = voronoiResult.$2[y][x];
-      }
-    }
+    // [_assignLandByLandSeedsWithNoJoin] already returns a fresh continent grid;
+    // adopt it instead of copying cell-by-cell into the prior buffer (Refs #2489).
+    continentGrid = voronoiResult.$2;
   }
 
   // Step 3: Coastline growth if budget remains

--- a/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
@@ -155,6 +155,26 @@ class _TileMapGenTerrainResource {
     );
   }
 
+  void _addMountainAdjacentFrontierFromCell(
+    int x,
+    int y,
+    List<List<TerrainType?>> terrainGrid,
+    List<List<String>> grid,
+    List<(int dx, int dy)> directions,
+    Set<(int x, int y)> frontier,
+  ) {
+    for (final (dx, dy) in directions) {
+      final nx = x + dx;
+      final ny = y + dy;
+      if (nx < 0 || nx >= params.width || ny < 0 || ny >= params.height) {
+        continue;
+      }
+      if (grid[ny][nx] != _landSentinel) continue;
+      if (terrainGrid[ny][nx] == TerrainType.mountain) continue;
+      frontier.add((nx, ny));
+    }
+  }
+
   /// One full-grid pass after mountain placement: count, ridge-adjacent frontier,
   /// and remaining non-mountain land (Refs #2489 P3).
   ({
@@ -175,19 +195,14 @@ class _TileMapGenTerrainResource {
         final terrain = terrainGrid[y][x];
         if (terrain == TerrainType.mountain) {
           mountainCount++;
-          for (final (dx, dy) in directions) {
-            final nx = x + dx;
-            final ny = y + dy;
-            if (nx < 0 ||
-                nx >= params.width ||
-                ny < 0 ||
-                ny >= params.height) {
-              continue;
-            }
-            if (grid[ny][nx] != _landSentinel) continue;
-            if (terrainGrid[ny][nx] == TerrainType.mountain) continue;
-            frontier.add((nx, ny));
-          }
+          _addMountainAdjacentFrontierFromCell(
+            x,
+            y,
+            terrainGrid,
+            grid,
+            directions,
+            frontier,
+          );
         } else {
           remaining.add((x, y));
         }

--- a/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
@@ -172,21 +172,6 @@ class _TileMapGenTerrainResource {
     return frontier;
   }
 
-  List<(int x, int y)> _nonMountainLandCells(
-    List<List<String>> grid,
-    List<List<TerrainType?>> terrainGrid,
-  ) {
-    final remainingLand = <(int x, int y)>[];
-    for (var y = 0; y < params.height; y++) {
-      for (var x = 0; x < params.width; x++) {
-        if (grid[y][x] != _landSentinel) continue;
-        if (terrainGrid[y][x] == TerrainType.mountain) continue;
-        remainingLand.add((x, y));
-      }
-    }
-    return remainingLand;
-  }
-
   /// Pass 6a: generate mountain ridges via random walks over land cells.
   void _assignMountainRidges(
     List<List<TerrainType?>> terrainGrid,
@@ -304,7 +289,7 @@ class _TileMapGenTerrainResource {
     // fragmented land), convert random remaining land cells until we reach
     // the target. This should be rare and only adjusts a handful of tiles.
     if (currentMountain < targetMountain) {
-      final remainingLand = _nonMountainLandCells(grid, terrainGrid);
+      final remainingLand = _collectRemainingNonMountainLand(terrainGrid, grid);
       remainingLand.shuffle(rnd);
       var i = 0;
       while (currentMountain < targetMountain && i < remainingLand.length) {

--- a/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_terrain_assign.dart
@@ -40,7 +40,13 @@ class _TileMapGenTerrainResource {
     final distribution = terrainDistributionForRegion(mapRegionId);
 
     // Pass 6a: mountain ridges (random-walk ranges).
-    _assignMountainRidges(terrainGrid, grid, landCells, distribution, rnd);
+    final remainingNonMountainLand = _assignMountainRidges(
+      terrainGrid,
+      grid,
+      landCells,
+      distribution,
+      rnd,
+    );
 
     // Pass 6b: region-growing for non-mountain terrains.
     _assignNonMountainTerrainsRegionGrowing(
@@ -49,6 +55,7 @@ class _TileMapGenTerrainResource {
       mapRegionId,
       distribution,
       rnd,
+      remainingNonMountainLand: remainingNonMountainLand,
     );
 
     // Pass 7: resources, using final terrainGrid and existing rules.
@@ -148,32 +155,54 @@ class _TileMapGenTerrainResource {
     );
   }
 
-  Set<(int x, int y)> _mountainAdjacentNonMountainLandFrontier(
+  /// One full-grid pass after mountain placement: count, ridge-adjacent frontier,
+  /// and remaining non-mountain land (Refs #2489 P3).
+  ({
+    int mountainCount,
+    Set<(int x, int y)> mountainAdjacentFrontier,
+    List<(int x, int y)> remainingNonMountainLand,
+  }) _scanPostMountainLand(
     List<List<TerrainType?>> terrainGrid,
     List<List<String>> grid,
     List<(int dx, int dy)> directions,
   ) {
+    var mountainCount = 0;
     final frontier = <(int x, int y)>{};
+    final remaining = <(int x, int y)>[];
     for (var y = 0; y < params.height; y++) {
       for (var x = 0; x < params.width; x++) {
-        if (terrainGrid[y][x] != TerrainType.mountain) continue;
-        for (final (dx, dy) in directions) {
-          final nx = x + dx;
-          final ny = y + dy;
-          if (nx < 0 || nx >= params.width || ny < 0 || ny >= params.height) {
-            continue;
+        if (grid[y][x] != _landSentinel) continue;
+        final terrain = terrainGrid[y][x];
+        if (terrain == TerrainType.mountain) {
+          mountainCount++;
+          for (final (dx, dy) in directions) {
+            final nx = x + dx;
+            final ny = y + dy;
+            if (nx < 0 ||
+                nx >= params.width ||
+                ny < 0 ||
+                ny >= params.height) {
+              continue;
+            }
+            if (grid[ny][nx] != _landSentinel) continue;
+            if (terrainGrid[ny][nx] == TerrainType.mountain) continue;
+            frontier.add((nx, ny));
           }
-          if (grid[ny][nx] != _landSentinel) continue;
-          if (terrainGrid[ny][nx] == TerrainType.mountain) continue;
-          frontier.add((nx, ny));
+        } else {
+          remaining.add((x, y));
         }
       }
     }
-    return frontier;
+    return (
+      mountainCount: mountainCount,
+      mountainAdjacentFrontier: frontier,
+      remainingNonMountainLand: remaining,
+    );
   }
 
   /// Pass 6a: generate mountain ridges via random walks over land cells.
-  void _assignMountainRidges(
+  /// Returns non-mountain land cells for pass 6b (one scan shared with top-up).
+  List<(int x, int y)> _assignMountainRidges(
     List<List<TerrainType?>> terrainGrid,
     List<List<String>> grid,
     List<(int x, int y)> landCells,
@@ -181,18 +210,22 @@ class _TileMapGenTerrainResource {
     Random rnd,
   ) {
     final totalLand = landCells.length;
-    if (totalLand == 0) return;
+    if (totalLand == 0) return const [];
     final targetMountain = (distribution.mountainFraction * totalLand)
         .round()
         .clamp(0, totalLand);
-    if (targetMountain <= 0) return;
+    if (targetMountain <= 0) {
+      return _collectRemainingNonMountainLand(terrainGrid, grid);
+    }
 
     // Determine number of ranges based on target mountain tiles.
     final suggestedRanges = (params.mountainRangesFactor * sqrt(targetMountain))
         .round()
         .clamp(params.mountainRangesMin, params.mountainRangesMax);
     final numRanges = suggestedRanges.clamp(1, targetMountain);
-    if (numRanges <= 0) return;
+    if (numRanges <= 0) {
+      return _collectRemainingNonMountainLand(terrainGrid, grid);
+    }
 
     var remainingMountain = targetMountain;
 
@@ -259,24 +292,13 @@ class _TileMapGenTerrainResource {
     // termination of ranges, top up mountain tiles by growing existing ridges
     // along their edges. This keeps the overall pattern ridge-like while
     // nudging the global count closer to the configured fraction.
-    var currentMountain = 0;
-    for (var y = 0; y < params.height; y++) {
-      for (var x = 0; x < params.width; x++) {
-        if (terrainGrid[y][x] == TerrainType.mountain) currentMountain++;
-      }
-    }
+    var scan = _scanPostMountainLand(terrainGrid, grid, directions);
+    var currentMountain = scan.mountainCount;
     if (currentMountain >= targetMountain) {
-      return;
+      return scan.remainingNonMountainLand;
     }
 
-    final frontier = _mountainAdjacentNonMountainLandFrontier(
-      terrainGrid,
-      grid,
-      directions,
-    );
-
-    final frontierList = frontier.toList();
-    frontierList.shuffle(rnd);
+    final frontierList = scan.mountainAdjacentFrontier.toList()..shuffle(rnd);
     var idx = 0;
     while (currentMountain < targetMountain && idx < frontierList.length) {
       final (fx, fy) = frontierList[idx++];
@@ -289,7 +311,8 @@ class _TileMapGenTerrainResource {
     // fragmented land), convert random remaining land cells until we reach
     // the target. This should be rare and only adjusts a handful of tiles.
     if (currentMountain < targetMountain) {
-      final remainingLand = _collectRemainingNonMountainLand(terrainGrid, grid);
+      final remainingLand = scan.remainingNonMountainLand
+        ..removeWhere((c) => terrainGrid[c.$2][c.$1] == TerrainType.mountain);
       remainingLand.shuffle(rnd);
       var i = 0;
       while (currentMountain < targetMountain && i < remainingLand.length) {
@@ -299,6 +322,13 @@ class _TileMapGenTerrainResource {
         currentMountain++;
       }
     }
+
+    if (currentMountain > scan.mountainCount) {
+      scan.remainingNonMountainLand.removeWhere(
+        (c) => terrainGrid[c.$2][c.$1] == TerrainType.mountain,
+      );
+    }
+    return scan.remainingNonMountainLand;
   }
 
   /// Pass 6b: region-growing assignment for non-mountain terrains.
@@ -307,14 +337,15 @@ class _TileMapGenTerrainResource {
     List<List<String>> grid,
     String mapRegionId,
     TerrainDistribution distribution,
-    Random rnd,
-  ) {
+    Random rnd, {
+    required List<(int x, int y)> remainingNonMountainLand,
+  }) {
     final allowed = allowedTerrainsForRegion(
       mapRegionId,
     ).where((t) => t != TerrainType.mountain).toList();
     if (allowed.isEmpty) return;
 
-    final remainingLand = _collectRemainingNonMountainLand(terrainGrid, grid);
+    final remainingLand = remainingNonMountainLand;
     if (remainingLand.isEmpty) return;
     final components = _graph.connectedComponentsOfLand(remainingLand.toSet());
     if (components.isEmpty) return;

--- a/packages/colonizethis_map/lib/src/tile_map_manhattan_distance_transform.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_manhattan_distance_transform.dart
@@ -1,5 +1,41 @@
 import 'dart:math' show min;
 
+/// Exact grid Manhattan (L1) distance from each cell to the nearest coordinate
+/// in [sources].
+///
+/// Duplicate coordinates in [sources] are ignored. When [sources] is empty,
+/// every cell receives [distanceWhenNoSources] (same contract as
+/// [manhattanDistToNearestSourceXY] when no cell satisfies [isSource]).
+///
+/// Refs #2489 (organic land-seed close-sea scoring: one transform per placement
+/// instead of per-cell scans over growing seed lists).
+List<List<int>> manhattanDistToNearestPoints(
+  int width,
+  int height,
+  Iterable<(int x, int y)> sources, {
+  required int distanceWhenNoSources,
+}) {
+  final sourceCells = <(int, int)>{};
+  for (final p in sources) {
+    sourceCells.add((p.$1, p.$2));
+  }
+  if (sourceCells.isEmpty) {
+    if (width <= 0 || height <= 0) {
+      return [];
+    }
+    return List.generate(
+      height,
+      (_) => List.filled(width, distanceWhenNoSources),
+    );
+  }
+  return manhattanDistToNearestSourceXY(
+    width,
+    height,
+    (x, y) => sourceCells.contains((x, y)),
+    distanceWhenNoSources: distanceWhenNoSources,
+  );
+}
+
 /// Exact grid Manhattan (L1) distance from each cell to the nearest cell where
 /// [isSource] is true.
 ///

--- a/packages/colonizethis_map/test/tile_map_manhattan_distance_transform_test.dart
+++ b/packages/colonizethis_map/test/tile_map_manhattan_distance_transform_test.dart
@@ -23,6 +23,83 @@ int _bruteManhattanMin(
 }
 
 void main() {
+  group('manhattanDistToNearestPoints', () {
+    test('matches manhattanDistToNearestSourceXY for the same source set', () {
+      const w = 5;
+      const h = 4;
+      const emptySentinel = w + h;
+      final points = [(2, 1), (0, 3), (4, 0)];
+      bool isSource(int x, int y) =>
+          points.any((p) => p.$1 == x && p.$2 == y);
+
+      final fromPredicate = manhattanDistToNearestSourceXY(
+        w,
+        h,
+        isSource,
+        distanceWhenNoSources: emptySentinel,
+      );
+      final fromPoints = manhattanDistToNearestPoints(
+        w,
+        h,
+        points,
+        distanceWhenNoSources: emptySentinel,
+      );
+
+      for (var y = 0; y < h; y++) {
+        for (var x = 0; x < w; x++) {
+          expect(fromPoints[y][x], fromPredicate[y][x], reason: 'cell=($x,$y)');
+        }
+      }
+    });
+
+    test('deduplicates duplicate source coordinates', () {
+      const w = 3;
+      const h = 3;
+      const emptySentinel = 99;
+      final a = manhattanDistToNearestPoints(
+        w,
+        h,
+        [(1, 1), (1, 1), (1, 1)],
+        distanceWhenNoSources: emptySentinel,
+      );
+      final b = manhattanDistToNearestPoints(
+        w,
+        h,
+        [(1, 1)],
+        distanceWhenNoSources: emptySentinel,
+      );
+      expect(a, b);
+    });
+
+    test('empty sources yields filled distanceWhenNoSources grid', () {
+      const w = 2;
+      const h = 3;
+      const emptySentinel = 42;
+      final dist = manhattanDistToNearestPoints(
+        w,
+        h,
+        const <(int, int)>[],
+        distanceWhenNoSources: emptySentinel,
+      );
+      expect(dist.length, h);
+      for (final row in dist) {
+        expect(row, everyElement(emptySentinel));
+      }
+    });
+
+    test('empty sources returns empty for non-positive dimensions', () {
+      expect(
+        manhattanDistToNearestPoints(
+          0,
+          2,
+          const <(int, int)>[],
+          distanceWhenNoSources: 0,
+        ),
+        isEmpty,
+      );
+    });
+  });
+
   group('manhattanDistToNearestSourceXY', () {
     test('matches brute force on a small grid with sparse sources', () {
       const w = 6;


### PR DESCRIPTION
## Summary
Phase 2 hot-path optimizations for organic land-seed placement, join-sea, and terrain assignment in `packages/colonizethis_map` (Refs #2489). Deterministic output for fixed seeds is preserved via existing generator and topology tests.

### Done in this PR
- **P2 (organic placement):** `manhattanDistToNearestPoints` wrapper + one L1 distance grid per `_placeOneOrganicSeed` for own-land proximity; candidate scoring reuses the grid instead of per-cell seed-list scans.
- **Join sea:** `preserveSeaFraction` caches ocean-neighbour counts from the discovery pass for sort keys (no second `_graph.oceanNeighbourCount` in the comparator).
- **Organic Voronoi:** Reuse the fresh continent grid returned by `_assignLandByLandSeedsWithNoJoin` instead of copying cell-by-cell into the prior buffer each round.
- **Terrain dedup:** Mountain-ridge fallback reuses `_collectRemainingNonMountainLand` instead of a parallel `_nonMountainLandCells` helper.
- **P4 (join):** Per-continent land-cell sets built once per `joinContinents` call and updated incrementally on bridge paths and sea-fraction restore.
- **P3 (terrain):** `_scanPostMountainLand` — one grid pass after ridges for mountain count, ridge-adjacent frontier, and remaining non-mountain land; pass 6b region-growing consumes that list.

### Deferred (follow-up on same issue)
- Phase 1 items already on `dev` (direction constants, nearest-seed, `copyTileMapGrid`, legends, `seaZoneIdsFromTopology`, faction/capital helpers, P1 `oceanCells` continent-set cache, D13 province budget helper).
- Optional `ct_repo_lint` rule for inline 4-direction tuples (issue lists as low priority).

## Acceptance criteria (this PR)
| AC | Status |
|----|--------|
| P2: per-placement distance grid, no inner O(W×H) scan over seeds in candidate loop | **This PR** |
| P3: combined post-mountain terrain scan | **This PR** |
| P4: cached continent land-cell sets during join | **This PR** |
| D10-style ocean-neighbour reuse in `preserveSeaFraction` | **This PR** |
| Fixed-seed generation unchanged | Covered by `tile_map_generator_test.dart`, `tile_map_gen_land_seeds_test.dart`, `tile_map_topology_validation_test.dart` |
| Other issue ACs (D1–D9, D11–D14, P1, coverage, file size) | Mostly on `dev` already; full issue closure is follow-up |

## Tests
```bash
cd packages/colonizethis_map && dart analyze lib/src/tile_map_manhattan_distance_transform.dart lib/src/tile_map_generator_land_seeds_organic_part.dart lib/src/tile_map_generator_join_sea_bridge_part.dart lib/src/tile_map_generator_terrain_assign.dart
cd packages/colonizethis_map && dart test test/tile_map_manhattan_distance_transform_test.dart test/tile_map_gen_land_seeds_test.dart test/tile_map_generator_test.dart
cd packages/colonizethis_map && dart test
```

Refs #2489