### PR TITLE
chore(logic): drop unused incremental validator import (#2391)

### DIFF
--- a/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
+++ b/packages/colonizethis_logic/lib/src/ai/simple_ai_heuristics.dart
@@ -11,7 +11,6 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 import '../constants.dart';
 import '../diplomacy/diplomacy_resolver.dart';
 import '../orders/draft_orders_mutations.dart';
-import '../orders/incremental_candidate_validator.dart';
 import '../orders/order_suggestion.dart';
 import '../orders/order_suggestion_context.dart';
 import '../world/army_migration.dart';


### PR DESCRIPTION
## Summary
- Remove stale `incremental_candidate_validator.dart` import from `simple_ai_heuristics.dart` after validator reuse moved to `order_suggestion_context.dart` (Refs #2391 AC11).

## Deferred
- Full issue closure remains for verify pass; this is a hygiene slice only.

## Acceptance criteria (this PR)
| AC | Status |
|----|--------|
| AC11 (`dart analyze` zero errors for colonizethis_logic) | **This PR** |

## Tests
```bash
cd packages/colonizethis_logic && dart analyze lib/src/ai/simple_ai_heuristics.dart
cd packages/colonizethis_logic && dart test test/orders/simple_ai_validator_reuse_test.dart
```

Refs #2391

Made with [Cursor](https://cursor.com)