### PR TITLE
test(e2e): suite PNG preload and adaptive turn confirm polls (#2336)

### DIFF
--- a/app/integration_test/new_game_capital_panel_e2e_test.dart
+++ b/app/integration_test/new_game_capital_panel_e2e_test.dart
@@ -33,6 +33,7 @@ void main() {
     await tester.pump();
     await e2eWaitForNewGameEntry(tester, perf: perf);
     perf.timing('bootstrap_for_integration_test', bootstrapSw.elapsed);
+    await ensureAllRelocated64pxPngsLoadSuiteOnce();
 
     final newGameToMapSw = Stopwatch()..start();
     await bootstrapNewGameToMap(tester, perf: perf);

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -300,15 +300,18 @@ Future<void> _awaitNwCoastalOrVisibleLandForBundledExploreE2e({
         _playerHasAnyNewWorldFoggedOrBetterFromCtSnapshot()) {
       return;
     }
-    await openNavalPanel(
-      tester,
-      timeout: _kMaxUiResponseWait,
-      bottomSheetCloseTimeout: _kMaxUiResponseWait,
-    );
-    if (_nonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot() ||
-        _playerHasAnyNewWorldFoggedOrBetterFromCtSnapshot()) {
-      await closeBottomSheet(tester, overallTimeout: _kMaxUiResponseWait);
-      return;
+    // Snapshot-backed paths skip redundant naval sheet open/close (Refs #2336).
+    if (ctE2eNavalPanelSnapshot == null) {
+      await openNavalPanel(
+        tester,
+        timeout: _kMaxUiResponseWait,
+        bottomSheetCloseTimeout: _kMaxUiResponseWait,
+      );
+      if (_nonHomeHumanFleetInCoastalNewWorldSeaFromCtSnapshot() ||
+          _playerHasAnyNewWorldFoggedOrBetterFromCtSnapshot()) {
+        await closeBottomSheet(tester, overallTimeout: _kMaxUiResponseWait);
+        return;
+      }
     }
     await _tryNavalMoveSegment(
       tester,

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -592,33 +592,21 @@ Future<void> _advanceOneHumanTurn(
   final confirmNextTurn = confirmFinder.hitTestable();
   if (confirmNextTurn.evaluate().isNotEmpty) {
     await tester.tap(confirmNextTurn.first, warnIfMissed: false);
-    // Adaptive replacement for the prior fixed 150ms settle (#2336 AC5):
-    // briefly pump to flush the confirm tap so the next-turn label poll
-    // below evaluates a fresh widget tree, then fall through to the
-    // condition-first poll loop.
+    // Flush the confirm tap so the shared label poll evaluates a fresh tree.
     await tester.pump();
   }
 
-  final sw = Stopwatch()..start();
-  // Check before the first pump so already-advanced labels short-circuit
-  // (same ordering as [e2eWaitForNextTurnLabelAdvance] in e2e_test_shared).
-  final immediateAfter = _readNextTurnButtonLabel(tester);
-  if (immediateAfter != null && immediateAfter != before) {
-    perf?.timing('next_turn_advance', phaseSw.elapsed);
-    return;
+  if (before == null) {
+    fail(
+      'Next turn button label missing before advance. '
+      'Last exception: ${tester.takeException()}',
+    );
   }
-  var labelPollMs = 25;
-  while (sw.elapsed < _kMaxUiResponseWait) {
-    final after = _readNextTurnButtonLabel(tester);
-    if (after != null && after != before) {
-      perf?.timing('next_turn_advance', phaseSw.elapsed);
-      return;
-    }
-    await tester.pump(Duration(milliseconds: labelPollMs));
-    labelPollMs = e2eAdaptivePollRampAfterIdle(labelPollMs);
-  }
-  fail(
-    'Next turn label did not change within ${_kMaxUiResponseWait.inSeconds}s '
-    '(before=${before ?? '(null)'}). Last exception: ${tester.takeException()}',
+  await e2eWaitForNextTurnLabelAdvance(
+    tester,
+    turnLabelBefore: before,
+    timeout: _kMaxUiResponseWait,
+    perf: perf,
   );
+  perf?.timing('next_turn_advance', phaseSw.elapsed);
 }

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -496,16 +496,12 @@ Future<bool> _anyExplorerHasEnabledExploreAssignFleetE2e(
   // the tree. Replace the prior fixed 200ms pump with a bounded adaptive
   // poll that returns as soon as the sheet finishes dismissing.
   Future<void> waitForAssignSheetDismissed() async {
-    final wait = Stopwatch()..start();
-    var dismissPollMs = 25;
-    const dismissCap = Duration(milliseconds: 400);
-    while (wait.elapsed < dismissCap) {
-      if (exploreTile.evaluate().isEmpty) {
-        return;
-      }
-      await tester.pump(Duration(milliseconds: dismissPollMs));
-      dismissPollMs = e2eAdaptivePollRampAfterIdle(dismissPollMs);
-    }
+    await e2ePumpUntilConditionOrIdle(
+      tester,
+      () => exploreTile.evaluate().isEmpty,
+      timeout: const Duration(milliseconds: 400),
+      phaseName: 'pump_until_assign_sheet_dismissed',
+    );
   }
 
   final visitedAssignWidgets = <int>{};
@@ -571,20 +567,23 @@ Future<void> _advanceOneHumanTurn(
   // resolving immediately. Poll adaptively for whichever lands first so we
   // never pay a worst-case fixed settle here.
   final confirmFinder = find.text(l10n.common_yes);
-  final confirmSw = Stopwatch()..start();
-  var confirmPollMs = 25;
-  const confirmCap = Duration(milliseconds: 400);
-  while (confirmSw.elapsed < confirmCap) {
-    if (confirmFinder.hitTestable().evaluate().isNotEmpty) {
-      break;
-    }
-    final maybeAfter = _readNextTurnButtonLabel(tester);
-    if (maybeAfter != null && maybeAfter != before) {
-      perf?.timing('next_turn_advance', phaseSw.elapsed);
-      return;
-    }
-    await tester.pump(Duration(milliseconds: confirmPollMs));
-    confirmPollMs = e2eAdaptivePollRampAfterIdle(confirmPollMs);
+  await e2ePumpUntilConditionOrIdle(
+    tester,
+    () {
+      if (confirmFinder.hitTestable().evaluate().isNotEmpty) {
+        return true;
+      }
+      final maybeAfter = _readNextTurnButtonLabel(tester);
+      return maybeAfter != null && maybeAfter != before;
+    },
+    timeout: const Duration(milliseconds: 400),
+    perf: perf,
+    phaseName: 'pump_until_next_turn_confirm_or_label_advanced',
+  );
+  final earlyAfter = _readNextTurnButtonLabel(tester);
+  if (earlyAfter != null && earlyAfter != before) {
+    perf?.timing('next_turn_advance', phaseSw.elapsed);
+    return;
   }
 
   final confirmNextTurn = confirmFinder.hitTestable();

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers_part2.dart
@@ -318,7 +318,7 @@ Future<void> _awaitNwCoastalOrVisibleLandForBundledExploreE2e({
       l10n,
       useNewWorldMapTabFirst: true,
       allowWarpDestinations: false,
-      navalPanelAlreadyOpen: true,
+      navalPanelAlreadyOpen: ctE2eNavalPanelSnapshot == null,
     );
     await closeBottomSheet(tester, overallTimeout: _kMaxUiResponseWait);
     await _advanceOneHumanTurn(tester, l10n);

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -193,6 +193,7 @@ void main() {
       await tester.pump();
       await e2eWaitForNewGameEntry(tester, perf: perf);
       perf.timing('bootstrap_for_integration_test', bootstrapSw.elapsed);
+      await ensureAllRelocated64pxPngsLoadSuiteOnce();
 
       final wallClock = Stopwatch()..start();
       void ensureUnderWallClock(String step) {
@@ -210,12 +211,12 @@ void main() {
       final l10n = lookupAppLocalizations(const Locale('en'));
 
       await splitHomeFleetOnce(
-      tester,
-      l10n,
-      perf: perf,
-      openNavalTimeout: _kMaxUiResponseWait,
-      bottomSheetCloseTimeout: _kMaxUiResponseWait,
-    );
+        tester,
+        l10n,
+        perf: perf,
+        openNavalTimeout: _kMaxUiResponseWait,
+        bottomSheetCloseTimeout: _kMaxUiResponseWait,
+      );
       await closeBottomSheet(tester, perf: perf, overallTimeout: _kMaxUiResponseWait);
       ensureUnderWallClock('after split fleet');
       CtE2eNavalPanelSnapshot? lastKnownNavalSnapshot;
@@ -232,25 +233,31 @@ void main() {
         if (_fleetReachDoneFromCtSnapshotOnly()) {
           break;
         }
-        await openNavalPanel(
-          tester,
-          perf: perf,
-          timeout: _kMaxUiResponseWait,
-          bottomSheetCloseTimeout: _kMaxUiResponseWait,
-        );
+        if (ctE2eNavalPanelSnapshot == null) {
+          await openNavalPanel(
+            tester,
+            perf: perf,
+            timeout: _kMaxUiResponseWait,
+            bottomSheetCloseTimeout: _kMaxUiResponseWait,
+          );
+          if (_navalPanelShowsNonHomeFleetInNewWorld(tester)) {
+            await closeBottomSheet(
+              tester,
+              perf: perf,
+              overallTimeout: _kMaxUiResponseWait,
+            );
+            break;
+          }
+        }
         if (ctE2eNavalPanelSnapshot != null) {
           lastKnownNavalSnapshot = ctE2eNavalPanelSnapshot;
-        }
-        if (_harnessDetectsNonHomeFleetInNewWorld(tester)) {
-          await closeBottomSheet(tester, perf: perf, overallTimeout: _kMaxUiResponseWait);
-          break;
         }
 
         await _tryNavalMoveSegment(
           tester,
           l10n,
           perf: perf,
-          navalPanelAlreadyOpen: true,
+          navalPanelAlreadyOpen: ctE2eNavalPanelSnapshot == null,
         );
         await closeBottomSheet(tester, perf: perf, overallTimeout: _kMaxUiResponseWait);
 

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -124,7 +124,8 @@ void main() {
         tester,
         l10n,
         perf: perf,
-        navalPanelAlreadyOpen: true,
+        // Panel was opened above only when snapshot plumbing is unavailable.
+        navalPanelAlreadyOpen: ctE2eNavalPanelSnapshot == null,
       );
       await closeBottomSheet(tester, perf: perf, overallTimeout: _kMaxUiResponseWait);
 

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -96,20 +96,28 @@ void main() {
         );
         return;
       }
-      await openNavalPanel(
-        tester,
-        perf: perf,
-        timeout: _kMaxUiResponseWait,
-        bottomSheetCloseTimeout: _kMaxUiResponseWait,
-      );
-      if (_harnessDetectsNonHomeFleetInNewWorld(tester)) {
-        await closeBottomSheet(tester, perf: perf, overallTimeout: _kMaxUiResponseWait);
-        perf.timing(
-          'test_total',
-          testSw.elapsed,
-          meta: 'result=reached_in_loop',
+      // When [ctE2eNavalPanelSnapshot] is live, world-state arrival does not
+      // require opening the naval sheet (Refs #2336 Bottleneck 4).
+      if (ctE2eNavalPanelSnapshot == null) {
+        await openNavalPanel(
+          tester,
+          perf: perf,
+          timeout: _kMaxUiResponseWait,
+          bottomSheetCloseTimeout: _kMaxUiResponseWait,
         );
-        return;
+        if (_navalPanelShowsNonHomeFleetInNewWorld(tester)) {
+          await closeBottomSheet(
+            tester,
+            perf: perf,
+            overallTimeout: _kMaxUiResponseWait,
+          );
+          perf.timing(
+            'test_total',
+            testSw.elapsed,
+            meta: 'result=reached_in_loop',
+          );
+          return;
+        }
       }
 
       await _tryNavalMoveSegment(

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -52,6 +52,7 @@ void main() {
     await tester.pump();
     await e2eWaitForNewGameEntry(tester, perf: perf);
     perf.timing('bootstrap_for_integration_test', bootstrapSw.elapsed);
+    await ensureAllRelocated64pxPngsLoadSuiteOnce();
 
     final wallClock = Stopwatch()..start();
     void ensureUnderWallClock(String step) {


### PR DESCRIPTION
## Summary
- Call `ensureAllRelocated64pxPngsLoadSuiteOnce()` in capital-panel and fleet-reach E2E scenarios so relocated 64px map icons warm once per isolate (same as full-turn).
- Replace hand-rolled 400ms dismiss/confirm poll loops in fleet helpers with `e2ePumpUntilConditionOrIdle` (Refs #2336 AC5 / H9–H10 area).

## Deferred
- **AC8 / AC9 (baseline wall-clock table):** Not captured in this PR. Run locally per `SPEC/program/e2e-integration-tests.md` § Baseline / post-refactor timing:
  ```bash
  tool/run_e2e_timing.sh 3   # on dev tip (baseline)
  tool/run_e2e_timing.sh 3   # on this branch (after)
  tool/compare_e2e_timing.sh <baseline.md> <after.md>
  ```
  Paste the comparison table into a follow-up commit or verification comment when Linux desktop + xvfb timing completes.
- Full issue closure remains for verify pass after timing evidence and merged PRs.

## Acceptance criteria (this PR)
| AC | Status |
|----|--------|
| AC1–AC2 (shared helpers) | Already on `dev` |
| AC3 (parallel PNG preload) | Already on `dev`; **this PR** extends suite-once warmup to capital + fleet |
| AC4 (H1–H10 high-impact pumps) | Mostly on `dev`; **this PR** tightens H9/H10 confirm/dismiss paths |
| AC5 (adaptive polling) | **This PR** for assign-sheet dismiss + next-turn confirm probe |
| AC6–AC7, AC10 | Require local `flutter test integration_test/... -d linux --dart-define=CT_E2E=true` (3× per test) |
| AC8–AC9 | **Deferred** — timing table not in this push |

## Tests
```bash
cd app && flutter analyze integration_test/
cd app && flutter test test/e2e_test_shared_smoke_test.dart test/e2e_adaptive_poll_ramp_test.dart
```

Refs #2336


Made with [Cursor](https://cursor.com)