### PR TITLE
feat(ai): victory-aware conquest pipeline and paired declare-war invasion (#2504)

### DIFF
--- a/SPEC/ai/ai-architecture.md
+++ b/SPEC/ai/ai-architecture.md
@@ -74,6 +74,18 @@ Per-turn seed: `turnSeed[P, T] = hash(globalGameSeed, aiSeed[P], T)`. Sub-seeds:
 - Program: [ai-planner.md](../program/ai-planner.md) — control rules, order merge
 - Program: [ai-systems-impl.md](../program/ai-systems-impl.md) — module boundaries, APIs
 
+### Victory-aware military planning (Full AI)
+
+Military victory requires a Great Power to control **≥31 Old World provinces** per [victory.md](../game/victory.md). Full AI must plan toward that threshold, not only declare war without follow-up invasion.
+
+**Perception (`ConquestSummary` on `AIWorldSnapshot`):** From `PlayerView` only: `oldWorldProvincesOwned`, `provincesToVictory` (= max(0, 31 − owned)), `invadableProvinceIdsSorted` (adjacent enemy/minor/tribe Old World provinces reachable from owned territory or army positions), `preferredConquestTargetFactionIdsSorted` (weak neighbors and current war targets, stable sort).
+
+**Goal selection:** Deterministic bonuses to `conquer` and military `expand` from `provincesToVictory` and non-empty `invadableProvinceIds` (weights in `colonizethis_data` `ai_victory_config.dart`). When `provincesToVictory > 20`, `conquer` score is floored at **0** so agenda penalties cannot suppress all conquest intent for GPs far from victory.
+
+**Domain planner order (Full AI military):** After civilian move planning, **diplomacy (declare-war pass)** runs before invasion army moves so merged orders can include same-turn `declareWar` + `ArmyMoveOrder` (human parity per [app-ui-wiring.md](../program/app-ui-wiring.md)). Sequence: declare-war diplomacy → **conquest army-move pass** (suggestions against orders that already contain declare war) → relocation/at-war army-move pass → naval → diplomacy (non–declare-war pass; no duplicate declare war to the same target) → research. Staged progress id `aiStageD` covers the military block (declare war, conquest invasion, army relocation).
+
+**Conquest army-move pass:** Uses `suggestArmyMoveOrders` with draft orders including any declare war chosen this turn; diplomacy filtering treats pending same-turn `declareWar` toward the destination owner as sufficient for invasion (logic `filterArmyMoveOrdersByDiplomacy` with `draftOrders`). Prefer destinations owned by the declare-war target, then other at-war owners, then provinces in `invadableProvinceIdsSorted`.
+
 ### Implementation (turn pipeline)
 AI order generation runs so that orders are available for the **Orders** phase of turn resolution. Merge (human + AI) and application order are defined in [turn-resolution-phases.md](../program/turn-resolution-phases.md) (phase 1 Orders) and [turn-resolution-phase-details.md](../program/turn-resolution-phase-details.md) § Orders. Control rules and merge semantics: [ai-planner.md](../program/ai-planner.md); module boundaries and APIs: [ai-systems-impl.md](../program/ai-systems-impl.md).
 
@@ -86,3 +98,4 @@ AI order generation runs so that orders are available for the **Orders** phase o
 - **Movement (filter and prefer):** Move orders are filtered by diplomacy (no move to at-peace or minor-without-war). Among valid moves, selection prefers moves into enemy/contested territory via configurable score bonus.
 - **Army movement parity:** AI-generated `ArmyMoveOrder` uses the same destination legality as human orders, including cross-region moves to any AI-owned province in prefixed province-id form.
 - **Difficulty:** Difficulty affects starting parameters and ruleset modifiers only, not AI logic or personality.
+- **Victory-aware conquest (Full AI):** Given the AI agent selects `declareWar` on faction T and valid army-move candidates into T’s provinces exist in `PlayerView`, when domain planning completes for that turn, then merged orders include both `declareWar` toward T and at least one `ArmyMoveOrder` into T’s territory (deterministic for fixed seed). Given a GP owns fewer than 20 Old World provinces, when goal scores are evaluated, then `conquer` or expand-with-hostile-opportunity receives a deterministic bonus from `provincesToVictory` (trace fields `provincesToVictory`, `invadableCount` on AI trace export).

--- a/SPEC/ai/ai-architecture.md
+++ b/SPEC/ai/ai-architecture.md
@@ -86,6 +86,8 @@ Military victory requires a Great Power to control **≥31 Old World provinces**
 
 **Conquest army-move pass:** Uses `suggestArmyMoveOrders` with draft orders including any declare war chosen this turn; diplomacy filtering treats pending same-turn `declareWar` toward the destination owner as sufficient for invasion (logic `filterArmyMoveOrdersByDiplomacy` with `draftOrders`). Prefer destinations owned by the declare-war target, then other at-war owners, then provinces in `invadableProvinceIdsSorted`.
 
+**Diplomacy targeting:** Declare-war scoring adds a bonus toward weak-neighbor **Great Powers** when war desire is high (`ai_victory_config.dart`), so minors are not the only targets when GP neighbors are favorable. Build selection adds a regiment weight bonus when `provincesToVictory` exceeds the configured pace threshold and the primary goal is military.
+
 ### Implementation (turn pipeline)
 AI order generation runs so that orders are available for the **Orders** phase of turn resolution. Merge (human + AI) and application order are defined in [turn-resolution-phases.md](../program/turn-resolution-phases.md) (phase 1 Orders) and [turn-resolution-phase-details.md](../program/turn-resolution-phase-details.md) § Orders. Control rules and merge semantics: [ai-planner.md](../program/ai-planner.md); module boundaries and APIs: [ai-systems-impl.md](../program/ai-systems-impl.md).
 

--- a/SPEC/program/run_observer_game-tool.md
+++ b/SPEC/program/run_observer_game-tool.md
@@ -55,6 +55,10 @@ HTML is a render-only wrapper: the `<pre>` body uses the **same** pretty-printed
 - **Ctdev:** `SimGameController.turnTraceEnabled` defaults from the same compile-time flag **`CT_DEBUG_CONSOLE`** (`ctdev/lib/ct_debug_console.dart`), so long sim sessions can emit merged trace files without a code change.
 - **Tool:** Traces are always on for `run_observer_game`.
 
+## Conquest regression verification (Refs #2504)
+
+`lib/observer_conquest_verify.dart` compares `turn-000001.snapshot.json` vs `turn-000100.snapshot.json` under a game trace directory: each Great Power `gp1`–`gp6` must gain **≥3** net **Old World** provinces (`oldWorld|…` ids only). Canonical seed **42**, **100** resolved turns. Unit tests cover the parser; a full observer run is slow (~minutes) and is not part of the default quality gate until a golden trace artifact or nightly job is wired.
+
 ## Coverage
 
 CI: **≥ 80% line coverage on `tool/run_observer_game/lib/`** (`quality` workflow: `tool/check_coverage_threshold.sh 80 tool/run_observer_game` after `dart test --coverage` for that package).

--- a/packages/colonizethis_ai/lib/src/perception/perception_snapshot.dart
+++ b/packages/colonizethis_ai/lib/src/perception/perception_snapshot.dart
@@ -33,6 +33,21 @@ class OpportunitySummary {
   final int unclaimedProvinces;
 }
 
+/// Victory-pace and invasion targets from PlayerView. SPEC/ai/ai-architecture.md.
+class ConquestSummary {
+  const ConquestSummary({
+    this.oldWorldProvincesOwned = 0,
+    this.provincesToVictory = kMilitaryVictoryOldWorldProvinceThreshold,
+    this.invadableProvinceIdsSorted = const [],
+    this.preferredConquestTargetFactionIdsSorted = const [],
+  });
+
+  final int oldWorldProvincesOwned;
+  final int provincesToVictory;
+  final List<String> invadableProvinceIdsSorted;
+  final List<String> preferredConquestTargetFactionIdsSorted;
+}
+
 /// Economy summary from view (stockpile, workers, treasury).
 class EconomySummary {
   const EconomySummary({
@@ -53,6 +68,7 @@ class AIWorldSnapshot {
     required this.playerId,
     required this.threats,
     required this.opportunities,
+    required this.conquest,
     required this.economy,
     required this.relations,
   });
@@ -60,6 +76,7 @@ class AIWorldSnapshot {
   final String playerId;
   final ThreatSummary threats;
   final OpportunitySummary opportunities;
+  final ConquestSummary conquest;
   final EconomySummary economy;
 
   /// Relation state keyed by other faction id (war, peace, etc.).
@@ -72,11 +89,13 @@ class AIWorldSnapshot {
   }) {
     final threats = _buildThreatSummary(view, topology);
     final opportunities = _buildOpportunitySummary(view, topology);
+    final conquest = _buildConquestSummary(view, topology, threats, opportunities);
     final economy = _buildEconomySummary(view);
     final snapshot = AIWorldSnapshot(
       playerId: view.playerId,
       threats: threats,
       opportunities: opportunities,
+      conquest: conquest,
       economy: economy,
       relations: Map<String, DiplomacyRelation>.from(view.diplomacyByOtherId),
     );
@@ -88,6 +107,9 @@ class AIWorldSnapshot {
       'weakNeighbors=${snapshot.opportunities.weakNeighbors} '
       'richUnexploitedProvinces=${snapshot.opportunities.richUnexploitedProvinces} '
       'unclaimedProvinces=${snapshot.opportunities.unclaimedProvinces} '
+      'oldWorldProvincesOwned=${snapshot.conquest.oldWorldProvincesOwned} '
+      'provincesToVictory=${snapshot.conquest.provincesToVictory} '
+      'invadableCount=${snapshot.conquest.invadableProvinceIdsSorted.length} '
       'workerCount=${snapshot.economy.workerCount} '
       'treasury=${snapshot.economy.treasury} '
       'ownProvinceCount=${snapshot.economy.ownProvinceCount} '
@@ -208,6 +230,70 @@ class AIWorldSnapshot {
       if (!weakNeighbors.contains(ownerId)) weakNeighbors.add(ownerId);
     }
     return weakNeighbors;
+  }
+
+  static ConquestSummary _buildConquestSummary(
+    PlayerView view,
+    MapTopology? topology,
+    ThreatSummary threats,
+    OpportunitySummary opportunities,
+  ) {
+    var oldWorldOwned = 0;
+    for (final p in view.provincesById.entries) {
+      if (p.value.ownerId != view.playerId) continue;
+      if (ProvinceId.regionIdFrom(p.key) != kOldWorldRegionId) continue;
+      oldWorldOwned++;
+    }
+    final provincesToVictory =
+        provincesToVictoryFromOldWorldOwned(oldWorldOwned);
+    final invadable = topology == null
+        ? <String>[]
+        : _invadableOldWorldProvinceIds(view, topology);
+    final preferredTargets = <String>{
+      ...threats.atWarWith,
+      ...opportunities.weakNeighbors,
+    }.toList()
+      ..sort();
+    return ConquestSummary(
+      oldWorldProvincesOwned: oldWorldOwned,
+      provincesToVictory: provincesToVictory,
+      invadableProvinceIdsSorted: invadable,
+      preferredConquestTargetFactionIdsSorted: preferredTargets,
+    );
+  }
+
+  static List<String> _invadableOldWorldProvinceIds(
+    PlayerView view,
+    MapTopology topology,
+  ) {
+    final anchorProvinces = <String>{};
+    for (final p in view.provincesById.entries) {
+      if (p.value.ownerId == view.playerId) {
+        anchorProvinces.add(p.key);
+      }
+    }
+    for (final u in view.ownUnits) {
+      final loc = u.locationProvinceId;
+      if (loc.isNotEmpty) anchorProvinces.add(loc);
+    }
+    final neighbors = neighborProvinceIdsFromTopology(
+      topology,
+      anchorProvinces,
+      view,
+    );
+    final invadable = <String>[];
+    for (final fullId in neighbors) {
+      if (ProvinceId.regionIdFrom(fullId) != kOldWorldRegionId) continue;
+      final prov = view.provincesById[fullId];
+      if (prov == null) continue;
+      final ownerId = prov.ownerId;
+      if (ownerId == null || ownerId.isEmpty || ownerId == view.playerId) {
+        continue;
+      }
+      invadable.add(fullId);
+    }
+    invadable.sort();
+    return invadable;
   }
 
   static EconomySummary _buildEconomySummary(PlayerView view) {

--- a/packages/colonizethis_ai/lib/src/planning/ai_trace_builder.dart
+++ b/packages/colonizethis_ai/lib/src/planning/ai_trace_builder.dart
@@ -17,6 +17,8 @@ TurnTraceAiSection buildAiTraceSection({
   required Orders orders,
   required Map<String, Object?> ordersByDomain,
   required List<Map<String, Object?>> finalOrders,
+  String? declaredWarTargetFactionId,
+  int conquestArmyMoveCount = 0,
 }) {
   final domainWeights = getDomainWeightsForLeader(config.personalityId);
   final goalWeights = getGoalWeightsForLeader(config.personalityId);
@@ -59,6 +61,11 @@ TurnTraceAiSection buildAiTraceSection({
           'workerCount': snapshot.economy.workerCount,
           'treasury': snapshot.economy.treasury,
           'ownProvinceCount': snapshot.economy.ownProvinceCount,
+          'provincesToVictory': snapshot.conquest.provincesToVictory,
+          'invadableCount':
+              snapshot.conquest.invadableProvinceIdsSorted.length,
+          'declaredWarTarget': declaredWarTargetFactionId,
+          'conquestArmyMoveCount': conquestArmyMoveCount,
         },
       },
       'decisionContext': <String, Object?>{
@@ -120,7 +127,10 @@ TurnTraceAiSection buildAiTraceSection({
       'gates': <Object?>[...goalSelectionGates(goalScores, primaryGoal)],
     },
     outcome: <String, Object?>{
-      'domainOutputs': ordersByDomain,
+      'domainOutputs': <String, Object?>{
+        ...ordersByDomain,
+        'conquestArmyMove': conquestArmyMoveCount,
+      },
       'finalAggregatedOrders': finalOrders,
       'emittedOrderCount': finalOrders.length,
     },

--- a/packages/colonizethis_ai/lib/src/planning/build_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/build_planner.dart
@@ -16,6 +16,7 @@ BuildUnitOrder? pickBuildOrder({
   required AIConfig config,
   required int seed,
   required String nationId,
+  int provincesToVictory = 0,
 }) {
   if (buildCandidates.isEmpty) return null;
   final thresholds = getThresholdsForLeader(config.personalityId);
@@ -44,6 +45,9 @@ BuildUnitOrder? pickBuildOrder({
         primaryGoal == StrategicGoal.defend) {
       if (isRegiment) {
         militaryBonus = 1.0;
+        if (provincesToVictory > kBuildRegimentVictoryPaceThreshold) {
+          militaryBonus += kBuildRegimentBonusWhenBehindVictoryPace;
+        }
       } else if (isShip && cargoHold == 0) {
         militaryBonus = 1.0;
       }

--- a/packages/colonizethis_ai/lib/src/planning/conquest_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/conquest_planner.dart
@@ -1,0 +1,91 @@
+import 'package:colonizethis_ai/package_logger.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/ai_api.dart';
+import 'package:colonizethis_logic/order_suggestion_api.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'goal_manager.dart';
+import '../perception/perception_snapshot.dart';
+import '../util/ai_random_utils.dart';
+
+final _log = packageLogger();
+
+/// Invasion army moves after same-turn declare war. SPEC/ai/ai-architecture.md.
+Orders runConquestArmyMovePlanner({
+  required String nationId,
+  required PlayerView view,
+  required Game game,
+  required MapTopology topology,
+  required Orders orders,
+  required AIWorldSnapshot snapshot,
+  required AIConfig config,
+  required StrategicGoal primaryGoal,
+  required AISeedBundle seeds,
+  required OrderSuggestionAPI suggestionAPI,
+  String? declaredWarTargetFactionId,
+}) {
+  final armyMoveCandidates = suggestionAPI.suggestArmyMoveOrders(
+    view,
+    game,
+    topology,
+    orders,
+  );
+  if (armyMoveCandidates.isEmpty) {
+    _log.d('conquest army move nationId=$nationId candidatesCount=0');
+    return orders;
+  }
+  final filtered = filterArmyMoveOrdersByDiplomacy(
+    game,
+    nationId,
+    armyMoveCandidates,
+    draftOrders: orders,
+  );
+  if (filtered.isEmpty) {
+    _log.d('conquest army move filtered empty nationId=$nationId');
+    return orders;
+  }
+  final domainWeights = getDomainWeightsForLeader(config.personalityId);
+  var weight =
+      primaryGoal == StrategicGoal.conquer ||
+          primaryGoal == StrategicGoal.defend
+      ? domainWeights.military
+      : primaryGoal == StrategicGoal.expand
+      ? domainWeights.economy
+      : 50;
+  final provincesToVictory = snapshot.conquest.provincesToVictory;
+  if (primaryGoal == StrategicGoal.conquer || provincesToVictory > 10) {
+    weight = weight < 10 ? 10 : weight;
+  }
+  if (weight < 10) {
+    _log.d('conquest army move skipped nationId=$nationId weight=$weight');
+    return orders;
+  }
+  final provinceOwner = getProvinceOwnerMap(game);
+  final invadable = snapshot.conquest.invadableProvinceIdsSorted.toSet();
+  final scores = filtered.map((m) {
+    final destOwner = provinceOwner[m.destinationProvinceId] ?? '';
+    var score = 1.0;
+    if (declaredWarTargetFactionId != null &&
+        destOwner == declaredWarTargetFactionId) {
+      score += 50;
+    } else {
+      final rel = getRelation(game, nationId, destOwner);
+      if (rel != null && rel.atWar) {
+        score += kMovePreferEnemyTerritoryBonus.toDouble();
+      }
+    }
+    if (invadable.contains(m.destinationProvinceId)) {
+      score += 10;
+    }
+    return score;
+  }).toList();
+  final idx = pickWeightedIndex(scores, seeds.militarySeed + 4000);
+  if (idx == null) return orders;
+  final selected = filtered[idx];
+  _log.i(
+    'conquest army move chosen nationId=$nationId '
+    'armyId=${selected.armyId} destinationProvinceId=${selected.destinationProvinceId} '
+    'declaredWarTarget=$declaredWarTargetFactionId',
+  );
+  return applyArmyMoveOrderForPlayer(orders, nationId, selected);
+}

--- a/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
@@ -9,9 +9,12 @@ import '../perception/perception_snapshot.dart';
 import '../util/ai_random_utils.dart';
 import '../util/orders_extensions.dart';
 import 'diplomatic_candidate_scoring.dart';
+import 'diplomacy_planner_result.dart';
 
 export 'diplomatic_candidate_scoring.dart' show computeDiplomaticCandidateScores;
 export 'war_desire_calculator.dart' show computeWarDesireScore;
+export 'diplomacy_planner_result.dart'
+    show DiplomacyPlannerPass, DiplomacyPlannerResult;
 
 final _log = packageLogger();
 
@@ -26,6 +29,32 @@ Orders runDiplomacyPlanner({
   required StrategicGoal primaryGoal,
   required AISeedBundle seeds,
   required OrderSuggestionAPI suggestionAPI,
+}) =>
+    runDiplomacyPlannerWithResult(
+      nationId: nationId,
+      view: view,
+      game: game,
+      topology: topology,
+      orders: orders,
+      snapshot: snapshot,
+      config: config,
+      primaryGoal: primaryGoal,
+      seeds: seeds,
+      suggestionAPI: suggestionAPI,
+    ).orders;
+
+DiplomacyPlannerResult runDiplomacyPlannerWithResult({
+  required String nationId,
+  required PlayerView view,
+  required Game game,
+  required MapTopology topology,
+  required Orders orders,
+  required AIWorldSnapshot snapshot,
+  required AIConfig config,
+  required StrategicGoal primaryGoal,
+  required AISeedBundle seeds,
+  required OrderSuggestionAPI suggestionAPI,
+  DiplomacyPlannerPass pass = DiplomacyPlannerPass.all,
 }) {
   final domainWeights = getDomainWeightsForLeader(config.personalityId);
   final weight =
@@ -36,16 +65,45 @@ Orders runDiplomacyPlanner({
       : 40;
   if (weight < 25) {
     _log.d('diplomacy skipped nationId=$nationId weight=$weight < 25');
-    return orders;
+    return DiplomacyPlannerResult(orders: orders);
   }
 
-  final diploCandidates = suggestionAPI.suggestDiplomaticOrders(
+  var diploCandidates = suggestionAPI.suggestDiplomaticOrders(
     view,
     game,
     topology,
     orders,
   );
-  if (diploCandidates.isEmpty) return orders;
+  if (diploCandidates.isEmpty) {
+    return DiplomacyPlannerResult(orders: orders);
+  }
+
+  final declaredThisTurn = <String>{
+    for (final o in orders.diplomaticOrdersByPlayerId[nationId] ?? const [])
+      if (o.type == DiplomaticOrderType.declareWar) o.targetFactionId,
+  };
+
+  switch (pass) {
+    case DiplomacyPlannerPass.declareWarOnly:
+      diploCandidates = diploCandidates
+          .where((o) => o.type == DiplomaticOrderType.declareWar)
+          .toList();
+      break;
+    case DiplomacyPlannerPass.nonDeclareWarOnly:
+      diploCandidates = diploCandidates
+          .where(
+            (o) =>
+                o.type != DiplomaticOrderType.declareWar &&
+                !declaredThisTurn.contains(o.targetFactionId),
+          )
+          .toList();
+      break;
+    case DiplomacyPlannerPass.all:
+      break;
+  }
+  if (diploCandidates.isEmpty) {
+    return DiplomacyPlannerResult(orders: orders);
+  }
 
   final scores = computeDiplomaticCandidateScores(
     candidates: diploCandidates,
@@ -53,6 +111,7 @@ Orders runDiplomacyPlanner({
     game: game,
     snapshot: snapshot,
     config: config,
+    primaryGoal: primaryGoal,
   );
 
   final candidateDesc = diploCandidates
@@ -67,11 +126,18 @@ Orders runDiplomacyPlanner({
   );
 
   final idx = pickWeightedIndex(scores, seeds.diplomacySeed);
-  if (idx == null) return orders;
+  if (idx == null) return DiplomacyPlannerResult(orders: orders);
   final chosen = diploCandidates[idx];
   _log.i(
     'diplomacy chosen nationId=$nationId '
     'type=${chosen.type}${chosen.type == DiplomaticOrderType.declareWar ? " targetFactionId=${chosen.targetFactionId}" : ""} score=${scores[idx]}',
   );
-  return orders.appendDiplomaticOrders(nationId, [chosen]);
+  final nextOrders = orders.appendDiplomaticOrders(nationId, [chosen]);
+  final declaredTarget = chosen.type == DiplomaticOrderType.declareWar
+      ? chosen.targetFactionId
+      : null;
+  return DiplomacyPlannerResult(
+    orders: nextOrders,
+    declaredWarTargetFactionId: declaredTarget,
+  );
 }

--- a/packages/colonizethis_ai/lib/src/planning/diplomacy_planner_result.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomacy_planner_result.dart
@@ -1,0 +1,24 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Outcome of a diplomacy planner pass (orders plus optional declare-war target).
+class DiplomacyPlannerResult {
+  const DiplomacyPlannerResult({
+    required this.orders,
+    this.declaredWarTargetFactionId,
+  });
+
+  final Orders orders;
+  final String? declaredWarTargetFactionId;
+}
+
+/// Which diplomatic candidates a planner pass may consider.
+enum DiplomacyPlannerPass {
+  /// All diplomatic order types (legacy single-pass callers).
+  all,
+
+  /// Only [DiplomaticOrderType.declareWar] candidates.
+  declareWarOnly,
+
+  /// All types except declare war; skips targets already declared this turn.
+  nonDeclareWarOnly,
+}

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring.dart
@@ -96,6 +96,10 @@ List<int> computeDiplomaticCandidateScores({
               o.targetFactionId,
             )) {
               s += getDeclareWarTargetBonusWeakerNeighbor(agendaId);
+              if (game.playerById(o.targetFactionId) != null &&
+                  warDesire >= kDeclareWarGpWeakNeighborMinWarDesire) {
+                s += kDeclareWarGpWeakNeighborBonus;
+              }
             }
             if (snapshot.conquest.preferredConquestTargetFactionIdsSorted
                 .contains(o.targetFactionId)) {

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring.dart
@@ -6,6 +6,7 @@ import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../perception/perception_snapshot.dart';
+import 'goal_manager.dart';
 import 'war_desire_calculator.dart';
 
 final _log = packageLogger();
@@ -18,6 +19,7 @@ List<int> computeDiplomaticCandidateScores({
   required Game game,
   required AIWorldSnapshot snapshot,
   required AIConfig config,
+  StrategicGoal? primaryGoal,
 }) {
   final agendaId = config.hiddenAgendaId;
   final thresholds = getThresholdsForLeader(config.personalityId);
@@ -95,6 +97,16 @@ List<int> computeDiplomaticCandidateScores({
             )) {
               s += getDeclareWarTargetBonusWeakerNeighbor(agendaId);
             }
+            if (snapshot.conquest.preferredConquestTargetFactionIdsSorted
+                .contains(o.targetFactionId)) {
+              s += 15;
+            }
+            if (primaryGoal == StrategicGoal.conquer) {
+              s += 20;
+            }
+            s += conquerScoreBonusForProvincesToVictory(
+              snapshot.conquest.provincesToVictory,
+            ) ~/ 4;
             if (rel?.level == RelationLevel.allied) {
               s += getDeclareWarTargetBonusAlly(agendaId);
             }

--- a/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
+++ b/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
@@ -8,6 +8,7 @@ import 'goal_manager.dart';
 import '../perception/perception_snapshot.dart';
 import '../util/orders_extensions.dart';
 import 'build_planner.dart';
+import 'conquest_planner.dart';
 import 'diplomacy_planner.dart';
 import 'move_planner.dart';
 import 'naval_planner.dart';
@@ -137,6 +138,34 @@ Orders runDomainPlanners({
   );
   emit('aiStageC');
 
+  // Military: declare war before invasion army moves (SPEC/ai/ai-architecture.md).
+  final declareWarResult = runDiplomacyPlannerWithResult(
+    nationId: nationId,
+    view: view,
+    game: game,
+    topology: topology,
+    orders: orders,
+    snapshot: snapshot,
+    config: config,
+    primaryGoal: primaryGoal,
+    seeds: seeds,
+    suggestionAPI: suggestionAPI,
+    pass: DiplomacyPlannerPass.declareWarOnly,
+  );
+  orders = declareWarResult.orders;
+  orders = runConquestArmyMovePlanner(
+    nationId: nationId,
+    view: view,
+    game: game,
+    topology: topology,
+    orders: orders,
+    snapshot: snapshot,
+    config: config,
+    primaryGoal: primaryGoal,
+    seeds: seeds,
+    suggestionAPI: suggestionAPI,
+    declaredWarTargetFactionId: declareWarResult.declaredWarTargetFactionId,
+  );
   orders = runArmyMovePlanner(
     nationId: nationId,
     view: view,
@@ -147,6 +176,7 @@ Orders runDomainPlanners({
     primaryGoal: primaryGoal,
     seeds: seeds,
     suggestionAPI: suggestionAPI,
+    provincesToVictory: snapshot.conquest.provincesToVictory,
   );
   emit('aiStageD');
 
@@ -164,8 +194,8 @@ Orders runDomainPlanners({
   );
   emit('aiStageE');
 
-  // Diplomacy: suggest diplomatic orders; weight by diplomacy domain and goal.
-  orders = runDiplomacyPlanner(
+  // Diplomacy follow-up (peace, alliance, overture — no duplicate declare war).
+  orders = runDiplomacyPlannerWithResult(
     nationId: nationId,
     view: view,
     game: game,
@@ -176,7 +206,8 @@ Orders runDomainPlanners({
     primaryGoal: primaryGoal,
     seeds: seeds,
     suggestionAPI: suggestionAPI,
-  );
+    pass: DiplomacyPlannerPass.nonDeclareWarOnly,
+  ).orders;
   emit('aiStageF');
 
   orders = runResearchPlanner(

--- a/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
+++ b/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
@@ -145,6 +145,7 @@ DomainPlannerOutcome runDomainPlannersWithOutcome({
       config: config,
       seed: seeds.economySeed + 1,
       nationId: nationId,
+      provincesToVictory: snapshot.conquest.provincesToVictory,
     );
     if (chosen != null) {
       _log.i('build chosen nationId=$nationId unitType=${chosen.unitType}');

--- a/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
+++ b/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
@@ -10,6 +10,7 @@ import '../util/orders_extensions.dart';
 import 'build_planner.dart';
 import 'conquest_planner.dart';
 import 'diplomacy_planner.dart';
+import 'domain_planner_outcome.dart';
 import 'move_planner.dart';
 import 'naval_planner.dart';
 import 'research_planner.dart';
@@ -25,6 +26,36 @@ final _log = packageLogger();
 /// When [onStagedPlannerProgress] is set, emits coarse phase ids aligned with
 /// staged planners A–G (Refs #2277): `suggestionPools`, `aiStageA` … `aiStageG`.
 Orders runDomainPlanners({
+  required Game game,
+  required MapTopology topology,
+  required String nationId,
+  required PlayerView view,
+  required AIWorldSnapshot snapshot,
+  required AIConfig config,
+  required StrategicGoal primaryGoal,
+  required AISeedBundle seeds,
+  required OrderSuggestionAPI suggestionAPI,
+  required EconomyPlan economyPlan,
+  Map<String, TileMapResult>? tileMapByRegion,
+  void Function(String phaseId)? onStagedPlannerProgress,
+}) {
+  return runDomainPlannersWithOutcome(
+    game: game,
+    topology: topology,
+    nationId: nationId,
+    view: view,
+    snapshot: snapshot,
+    config: config,
+    primaryGoal: primaryGoal,
+    seeds: seeds,
+    suggestionAPI: suggestionAPI,
+    economyPlan: economyPlan,
+    tileMapByRegion: tileMapByRegion,
+    onStagedPlannerProgress: onStagedPlannerProgress,
+  ).orders;
+}
+
+DomainPlannerOutcome runDomainPlannersWithOutcome({
   required Game game,
   required MapTopology topology,
   required String nationId,
@@ -153,6 +184,8 @@ Orders runDomainPlanners({
     pass: DiplomacyPlannerPass.declareWarOnly,
   );
   orders = declareWarResult.orders;
+  final armyMovesBeforeConquest =
+      orders.armyMoveOrdersByPlayerId[nationId]?.length ?? 0;
   orders = runConquestArmyMovePlanner(
     nationId: nationId,
     view: view,
@@ -166,6 +199,9 @@ Orders runDomainPlanners({
     suggestionAPI: suggestionAPI,
     declaredWarTargetFactionId: declareWarResult.declaredWarTargetFactionId,
   );
+  final conquestArmyMoveCount =
+      (orders.armyMoveOrdersByPlayerId[nationId]?.length ?? 0) -
+      armyMovesBeforeConquest;
   orders = runArmyMovePlanner(
     nationId: nationId,
     view: view,
@@ -223,5 +259,9 @@ Orders runDomainPlanners({
   );
   emit('aiStageG');
 
-  return orders;
+  return DomainPlannerOutcome(
+    orders: orders,
+    declaredWarTargetFactionId: declareWarResult.declaredWarTargetFactionId,
+    conquestArmyMoveCount: conquestArmyMoveCount,
+  );
 }

--- a/packages/colonizethis_ai/lib/src/planning/domain_planner_outcome.dart
+++ b/packages/colonizethis_ai/lib/src/planning/domain_planner_outcome.dart
@@ -1,0 +1,14 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Orders plus conquest-pass metadata for AI trace export.
+class DomainPlannerOutcome {
+  const DomainPlannerOutcome({
+    required this.orders,
+    this.declaredWarTargetFactionId,
+    this.conquestArmyMoveCount = 0,
+  });
+
+  final Orders orders;
+  final String? declaredWarTargetFactionId;
+  final int conquestArmyMoveCount;
+}

--- a/packages/colonizethis_ai/lib/src/planning/goal_manager.dart
+++ b/packages/colonizethis_ai/lib/src/planning/goal_manager.dart
@@ -47,6 +47,17 @@ Map<StrategicGoal, int> evaluateStrategicGoalScores(
     expand += 15;
   }
 
+  final provincesToVictory = snapshot.conquest.provincesToVictory;
+  conquer += conquerScoreBonusForProvincesToVictory(provincesToVictory);
+  conquer += endgameConquerScoreBonus(provincesToVictory);
+  if (snapshot.conquest.invadableProvinceIdsSorted.isNotEmpty) {
+    expand += kExpandBonusWhenInvadableProvinces;
+  }
+  if (provincesToVictory > kConquerScoreFloorProvincesToVictoryThreshold &&
+      conquer < 0) {
+    conquer = 0;
+  }
+
   return <StrategicGoal, int>{
     StrategicGoal.defend: defend,
     StrategicGoal.expand: expand,
@@ -77,7 +88,9 @@ String majorConstraintForStrategicGoal(
           ? 'lowWorkerCount'
           : 'none',
     StrategicGoal.conquer =>
-      getAgendaConquerModifier(config.hiddenAgendaId) != 0
+      snapshot.conquest.provincesToVictory > 0
+          ? 'provincesToVictory'
+          : getAgendaConquerModifier(config.hiddenAgendaId) != 0
           ? 'hiddenAgendaConquerModifier'
           : (thresholds.warLikelihood - 50) != 0
           ? 'warLikelihoodThreshold'

--- a/packages/colonizethis_ai/lib/src/planning/move_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/move_planner.dart
@@ -76,6 +76,7 @@ Orders runArmyMovePlanner({
   required StrategicGoal primaryGoal,
   required AISeedBundle seeds,
   required OrderSuggestionAPI suggestionAPI,
+  int provincesToVictory = 0,
 }) {
   final armyMoveCandidates = suggestionAPI.suggestArmyMoveOrders(
     view,
@@ -104,8 +105,12 @@ Orders runArmyMovePlanner({
       : primaryGoal == StrategicGoal.expand
       ? domainWeights.economy
       : 50;
-  if (weight < 20) {
-    _log.d('army move skipped nationId=$nationId weight=$weight < 20');
+  final minWeight =
+      primaryGoal == StrategicGoal.conquer || provincesToVictory > 10 ? 10 : 20;
+  if (weight < minWeight) {
+    _log.d(
+      'army move skipped nationId=$nationId weight=$weight < $minWeight',
+    );
     return orders;
   }
   _log.d(

--- a/packages/colonizethis_ai/lib/src/planning/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/planning/strategic_ai.dart
@@ -86,7 +86,7 @@ StrategicOrderTraceResult generateStrategicOrdersWithTrace({
     config: config,
     seeds: seeds,
   );
-  final orders = runDomainPlanners(
+  final plannerOutcome = runDomainPlannersWithOutcome(
     game: game,
     topology: topology,
     nationId: nationId,
@@ -100,6 +100,7 @@ StrategicOrderTraceResult generateStrategicOrdersWithTrace({
     tileMapByRegion: tileMapByRegion,
     onStagedPlannerProgress: onStagedPlannerProgress,
   );
+  final orders = plannerOutcome.orders;
   final moveCount = orders.moveOrdersByPlayerId[nationId]?.length ?? 0;
   final armyMoveCount = orders.armyMoveOrdersByPlayerId[nationId]?.length ?? 0;
   final buildCount = orders.buildUnitOrdersByPlayerId[nationId]?.length ?? 0;
@@ -131,6 +132,8 @@ StrategicOrderTraceResult generateStrategicOrdersWithTrace({
       orders: orders,
       ordersByDomain: ordersByDomain,
       finalOrders: finalOrders,
+      declaredWarTargetFactionId: plannerOutcome.declaredWarTargetFactionId,
+      conquestArmyMoveCount: plannerOutcome.conquestArmyMoveCount,
     ),
   );
 }

--- a/packages/colonizethis_ai/test/ai_trace_builder_test.dart
+++ b/packages/colonizethis_ai/test/ai_trace_builder_test.dart
@@ -1,0 +1,57 @@
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+import 'package:colonizethis_ai/src/planning/ai_trace_builder.dart';
+
+void main() {
+  test('buildAiTraceSection exports conquest trace fields', () {
+    const config = AIConfig(
+      leaderId: 'napoleon',
+      personalityId: 'napoleon',
+      hiddenAgendaId: 'warmonger',
+    );
+    const snapshot = AIWorldSnapshot(
+      playerId: 'gp1',
+      threats: ThreatSummary(),
+      opportunities: OpportunitySummary(),
+      economy: EconomySummary(ownProvinceCount: 7),
+      conquest: ConquestSummary(
+        oldWorldProvincesOwned: 7,
+        provincesToVictory: 24,
+        invadableProvinceIdsSorted: ['oldWorld|p_target'],
+        preferredConquestTargetFactionIdsSorted: ['minor1'],
+      ),
+      relations: {},
+    );
+    final section = buildAiTraceSection(
+      nationId: 'gp1',
+      turn: 5,
+      config: config,
+      seeds: AISeedBundle.fromTurnSeed(99),
+      snapshot: snapshot,
+      primaryGoal: StrategicGoal.conquer,
+      goalScores: const {StrategicGoal.conquer: 80},
+      economyPlan: const EconomyPlan(
+        productionAssignments: [],
+        cargoPreference: CargoPreference.none,
+      ),
+      orders: const Orders(),
+      ordersByDomain: const {'armyMove': 1},
+      finalOrders: const [],
+      declaredWarTargetFactionId: 'minor1',
+      conquestArmyMoveCount: 1,
+    );
+
+    final aggregates = section.state['aggregates'] as Map<String, Object?>;
+    final snap = aggregates['snapshot'] as Map<String, Object?>;
+    expect(snap['provincesToVictory'], 24);
+    expect(snap['invadableCount'], 1);
+    expect(snap['declaredWarTarget'], 'minor1');
+    expect(snap['conquestArmyMoveCount'], 1);
+
+    final domainOutputs =
+        section.outcome['domainOutputs'] as Map<String, Object?>;
+    expect(domainOutputs['conquestArmyMove'], 1);
+  });
+}

--- a/packages/colonizethis_ai/test/build_planner_test.dart
+++ b/packages/colonizethis_ai/test/build_planner_test.dart
@@ -1,0 +1,39 @@
+import 'package:colonizethis_ai/src/planning/build_planner.dart';
+import 'package:colonizethis_ai/src/planning/goal_manager.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('pickBuildOrder', () {
+    test('prefers regiment when behind victory pace and conquer goal', () {
+      const candidates = [
+        BuildUnitOrder(
+          unitType: 'sloop',
+          isMilitary: false,
+          spawnProvinceId: 'oldWorld|p1',
+        ),
+        BuildUnitOrder(
+          unitType: 'grenadiers',
+          isMilitary: true,
+          spawnProvinceId: 'oldWorld|p1',
+        ),
+      ];
+      const config = AIConfig(
+        leaderId: 'napoleon',
+        personalityId: 'napoleon',
+        hiddenAgendaId: 'warmonger',
+      );
+      final chosen = pickBuildOrder(
+        buildCandidates: candidates,
+        cargoPreference: CargoPreference.none,
+        primaryGoal: StrategicGoal.conquer,
+        config: config,
+        seed: 1,
+        nationId: 'gp1',
+        provincesToVictory: 20,
+      );
+      expect(chosen?.unitType, 'grenadiers');
+    });
+  });
+}

--- a/packages/colonizethis_ai/test/diplomatic_candidate_scoring_test.dart
+++ b/packages/colonizethis_ai/test/diplomatic_candidate_scoring_test.dart
@@ -229,5 +229,104 @@ void main() {
       ).single;
       expect(peaceLo, greaterThan(peaceHi));
     });
+
+    test('declareWar toward weak-neighbor GP gets GP targeting bonus', () {
+      final game = Game(
+        id: 'g-gp-war-bonus',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: RegionData(
+            provinces: [
+              for (var i = 0; i < 8; i++)
+                Province(
+                  id: 'oldWorld|p1_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp1',
+                ),
+              const Province(
+                id: 'oldWorld|p2',
+                regionId: 'oldWorld',
+                ownerId: 'gp2',
+              ),
+            ],
+            units: [
+              for (var i = 0; i < 6; i++)
+                Unit(
+                  id: 'a$i',
+                  type: 'grenadiers',
+                  ownerId: 'gp1',
+                  locationProvinceId: 'oldWorld|p1_0',
+                ),
+              Unit(
+                id: 'b1',
+                type: 'grenadiers',
+                ownerId: 'gp2',
+                locationProvinceId: 'oldWorld|p2',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp1', displayName: 'A', isHuman: false),
+          Player(id: 'gp2', displayName: 'B', isHuman: false),
+        ],
+        diplomacyRelations: const [
+          DiplomacyRelation(
+            factionId1: 'gp1',
+            factionId2: 'gp2',
+            score: 25,
+            level: RelationLevel.hostile,
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      const config = AIConfig(
+        leaderId: 'napoleon',
+        personalityId: 'napoleon',
+        hiddenAgendaId: 'warmonger',
+      );
+      const candidate = [
+        DiplomaticOrder(
+          type: DiplomaticOrderType.declareWar,
+          targetFactionId: 'gp2',
+        ),
+      ];
+      final withWeakGp = computeDiplomaticCandidateScores(
+        candidates: candidate,
+        nationId: 'gp1',
+        game: game,
+        snapshot: const AIWorldSnapshot(
+          playerId: 'gp1',
+          threats: ThreatSummary(),
+          opportunities: OpportunitySummary(weakNeighbors: ['gp2']),
+          conquest: ConquestSummary(provincesToVictory: 23),
+          economy: EconomySummary(),
+          relations: {},
+        ),
+        config: config,
+        primaryGoal: StrategicGoal.conquer,
+      ).single;
+      final withoutWeakGp = computeDiplomaticCandidateScores(
+        candidates: candidate,
+        nationId: 'gp1',
+        game: game,
+        snapshot: const AIWorldSnapshot(
+          playerId: 'gp1',
+          threats: ThreatSummary(),
+          opportunities: OpportunitySummary(),
+          conquest: ConquestSummary(provincesToVictory: 23),
+          economy: EconomySummary(),
+          relations: {},
+        ),
+        config: config,
+        primaryGoal: StrategicGoal.conquer,
+      ).single;
+      expect(withWeakGp, greaterThan(withoutWeakGp));
+      expect(
+        withWeakGp - withoutWeakGp,
+        greaterThanOrEqualTo(kDeclareWarGpWeakNeighborBonus),
+      );
+    });
   });
 }

--- a/packages/colonizethis_ai/test/domain_planner_orchestrator_conquest_pair_test.dart
+++ b/packages/colonizethis_ai/test/domain_planner_orchestrator_conquest_pair_test.dart
@@ -1,0 +1,96 @@
+import 'package:colonizethis_test/test.dart';
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'domain_planner_test_fake_api.dart';
+
+void main() {
+  group('runDomainPlanners conquest pairing', () {
+    test('after declareWar on minor emits army move into minor province', () {
+      const declareMinor = DiplomaticOrder(
+        type: DiplomaticOrderType.declareWar,
+        targetFactionId: 'minor1',
+      );
+      const invasionMove = ArmyMoveOrder(
+        armyId: 'field_a',
+        destinationProvinceId: 'oldWorld|p_minor',
+      );
+      final fakeApi = FakeOrderSuggestionAPIForDomainPlannerTests(
+        work: const [],
+        build: const [],
+        move: const [],
+        research: const [],
+        navalMove: const [],
+        navalMission: const [],
+        diplomatic: [declareMinor],
+        armyMove: [invasionMove],
+      );
+      final game = Game(
+        id: 'g_conquest_pair',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: RegionData(provinces: [], units: []),
+          newWorld: RegionData(provinces: [], units: []),
+        ),
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'Leader',
+            isHuman: false,
+            leaderKey: 'napoleon',
+          ),
+        ],
+      );
+      const topology = MapTopology(nodes: [], edges: []);
+      final view = PlayerView(
+        playerId: 'gp1',
+        player: game.players.single,
+        ownUnitsById: const {},
+        provincesById: const {},
+        visibilityByTile: const {},
+        prospectedTiles: const {},
+        diplomacyByOtherId: const {},
+      );
+      final snapshot = AIWorldSnapshot.fromPlayerView(view);
+      const config = AIConfig(
+        leaderId: 'napoleon',
+        personalityId: 'napoleon',
+        hiddenAgendaId: 'warmonger',
+      );
+      final seeds = AISeedBundle.fromTurnSeed(99);
+      const economyPlan = EconomyPlan(
+        productionAssignments: [],
+        cargoPreference: CargoPreference.none,
+      );
+
+      final orders = runDomainPlanners(
+        game: game,
+        topology: topology,
+        nationId: 'gp1',
+        view: view,
+        snapshot: snapshot,
+        config: config,
+        primaryGoal: StrategicGoal.conquer,
+        seeds: seeds,
+        suggestionAPI: fakeApi,
+        economyPlan: economyPlan,
+      );
+
+      final diplo = orders.diplomaticOrdersByPlayerId['gp1'] ?? const [];
+      expect(
+        diplo.any(
+          (o) =>
+              o.type == DiplomaticOrderType.declareWar &&
+              o.targetFactionId == 'minor1',
+        ),
+        isTrue,
+      );
+      expect(
+        orders.armyMoveOrdersByPlayerId['gp1']?.single.destinationProvinceId,
+        'oldWorld|p_minor',
+      );
+    });
+  });
+}

--- a/packages/colonizethis_ai/test/goal_manager_test.dart
+++ b/packages/colonizethis_ai/test/goal_manager_test.dart
@@ -3,12 +3,53 @@ import 'package:colonizethis_ai/colonizethis_ai.dart';
 import 'package:logger/logger.dart';
 
 void main() {
+  group('evaluateStrategicGoalScores', () {
+    test('raises conquer above default when far from military victory', () {
+      const snapshot = AIWorldSnapshot(
+        playerId: 'gp1',
+        threats: ThreatSummary(),
+        opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(
+          oldWorldProvincesOwned: 7,
+          provincesToVictory: 24,
+        ),
+        economy: EconomySummary(),
+        relations: {},
+      );
+      const config = AIConfig(
+        leaderId: 'victoria',
+        personalityId: 'victoria',
+        hiddenAgendaId: 'peacemaker',
+      );
+      final scores = evaluateStrategicGoalScores(snapshot, config);
+      final baseline = evaluateStrategicGoalScores(
+        const AIWorldSnapshot(
+          playerId: 'gp1',
+          threats: ThreatSummary(),
+          opportunities: OpportunitySummary(),
+          conquest: ConquestSummary(
+            oldWorldProvincesOwned: 31,
+            provincesToVictory: 0,
+          ),
+          economy: EconomySummary(),
+          relations: {},
+        ),
+        config,
+      );
+      expect(
+        scores[StrategicGoal.conquer]!,
+        greaterThan(baseline[StrategicGoal.conquer]!),
+      );
+    });
+  });
+
   group('selectPrimaryGoal', () {
     test('returns expand when snapshot has no threats and default weights', () {
       const snapshot = AIWorldSnapshot(
         playerId: 'gp1',
         threats: ThreatSummary(),
         opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(),
         economy: EconomySummary(),
         relations: {},
       );
@@ -33,6 +74,7 @@ void main() {
         playerId: 'gp1',
         threats: ThreatSummary(atWarWith: ['gp2']),
         opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(),
         economy: EconomySummary(),
         relations: {},
       );
@@ -56,6 +98,7 @@ void main() {
         playerId: 'gp1',
         threats: ThreatSummary(capitalThreatened: true),
         opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(),
         economy: EconomySummary(),
         relations: {},
       );
@@ -79,6 +122,7 @@ void main() {
         playerId: 'gp1',
         threats: ThreatSummary(),
         opportunities: OpportunitySummary(unclaimedProvinces: 5),
+        conquest: ConquestSummary(),
         economy: EconomySummary(),
         relations: {},
       );
@@ -102,6 +146,7 @@ void main() {
         playerId: 'gp1',
         threats: ThreatSummary(),
         opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(),
         economy: EconomySummary(workerCount: 1),
         relations: {},
       );
@@ -140,6 +185,7 @@ void main() {
             capitalThreatened: true,
           ),
           opportunities: OpportunitySummary(unclaimedProvinces: 0),
+          conquest: ConquestSummary(),
           economy: EconomySummary(workerCount: 10),
           relations: {},
         );

--- a/packages/colonizethis_data/lib/colonizethis_data.dart
+++ b/packages/colonizethis_data/lib/colonizethis_data.dart
@@ -37,6 +37,7 @@ export 'src/starting_resources_config.dart';
 export 'src/unit_roles.dart';
 export 'src/leader_bonuses.dart';
 export 'src/ai_personality_config.dart';
+export 'src/ai_victory_config.dart';
 export 'src/hidden_agenda_config.dart';
 export 'src/dialogue_catalog.dart';
 export 'src/great_power_colors.dart';

--- a/packages/colonizethis_data/lib/src/ai_victory_config.dart
+++ b/packages/colonizethis_data/lib/src/ai_victory_config.dart
@@ -31,3 +31,15 @@ const int kExpandBonusWhenInvadableProvinces = 15;
 
 /// When behind victory pace by more than this many provinces, conquer score is floored at 0.
 const int kConquerScoreFloorProvincesToVictoryThreshold = 20;
+
+/// Bonus to declare-war scoring toward a weak-neighbor Great Power when war desire is high.
+const int kDeclareWarGpWeakNeighborBonus = 12;
+
+/// Minimum war-desire score (0..100) for [kDeclareWarGpWeakNeighborBonus].
+const int kDeclareWarGpWeakNeighborMinWarDesire = 55;
+
+/// Extra build weight for regiments when behind military victory pace.
+const double kBuildRegimentBonusWhenBehindVictoryPace = 1.5;
+
+/// Provinces-to-victory threshold for [kBuildRegimentBonusWhenBehindVictoryPace].
+const int kBuildRegimentVictoryPaceThreshold = 10;

--- a/packages/colonizethis_data/lib/src/ai_victory_config.dart
+++ b/packages/colonizethis_data/lib/src/ai_victory_config.dart
@@ -1,0 +1,33 @@
+/// Victory-pace bonuses for Full AI goal selection. SPEC/game/victory.md, SPEC/ai/ai-architecture.md.
+library;
+
+/// Old World province count required for military victory.
+const int kMilitaryVictoryOldWorldProvinceThreshold = 31;
+
+/// Region id for Old World provinces (prefixed `oldWorld|…`).
+const String kOldWorldRegionId = 'oldWorld';
+
+/// Provinces still needed to reach military victory from [oldWorldOwned].
+int provincesToVictoryFromOldWorldOwned(int oldWorldOwned) {
+  final gap =
+      kMilitaryVictoryOldWorldProvinceThreshold - oldWorldOwned;
+  return gap < 0 ? 0 : gap;
+}
+
+/// Deterministic conquer-goal bonus from victory pace (0 when at/above threshold).
+int conquerScoreBonusForProvincesToVictory(int provincesToVictory) {
+  if (provincesToVictory <= 0) return 0;
+  return (provincesToVictory * 2).clamp(0, 40);
+}
+
+/// Extra conquer weight when within 12 provinces of military victory.
+int endgameConquerScoreBonus(int provincesToVictory) {
+  if (provincesToVictory <= 12) return 25;
+  return 0;
+}
+
+/// Expand-goal bonus when invadable Old World targets exist.
+const int kExpandBonusWhenInvadableProvinces = 15;
+
+/// When behind victory pace by more than this many provinces, conquer score is floored at 0.
+const int kConquerScoreFloorProvincesToVictoryThreshold = 20;

--- a/packages/colonizethis_data/test/ai_victory_config_test.dart
+++ b/packages/colonizethis_data/test/ai_victory_config_test.dart
@@ -8,5 +8,10 @@ void main() {
       expect(provincesToVictoryFromOldWorldOwned(31), 0);
       expect(provincesToVictoryFromOldWorldOwned(40), 0);
     });
+
+    test('GP declare-war and build pace constants are configured', () {
+      expect(kDeclareWarGpWeakNeighborBonus, greaterThan(0));
+      expect(kBuildRegimentBonusWhenBehindVictoryPace, greaterThan(0));
+    });
   });
 }

--- a/packages/colonizethis_data/test/ai_victory_config_test.dart
+++ b/packages/colonizethis_data/test/ai_victory_config_test.dart
@@ -1,0 +1,12 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  group('ai_victory_config', () {
+    test('provincesToVictoryFromOldWorldOwned matches 31 threshold', () {
+      expect(provincesToVictoryFromOldWorldOwned(7), 24);
+      expect(provincesToVictoryFromOldWorldOwned(31), 0);
+      expect(provincesToVictoryFromOldWorldOwned(40), 0);
+    });
+  });
+}

--- a/packages/colonizethis_logic/lib/src/orders/order_suggestion_helpers.dart
+++ b/packages/colonizethis_logic/lib/src/orders/order_suggestion_helpers.dart
@@ -39,12 +39,27 @@ Map<String, String> getProvinceOwnerMap(Game game) {
 ///
 /// [destinationProvinceId] returns the destination province id for each order
 /// (full id: regionId|localId).
+bool _hasPendingDeclareWarToward(
+  Orders draftOrders,
+  String playerId,
+  String targetFactionId,
+) {
+  for (final o in draftOrders.diplomaticOrdersByPlayerId[playerId] ?? const []) {
+    if (o.type == DiplomaticOrderType.declareWar &&
+        o.targetFactionId == targetFactionId) {
+      return true;
+    }
+  }
+  return false;
+}
+
 List<T> filterOrdersByDiplomacy<T>(
   Game game,
   String playerId,
   List<T> orders,
-  String Function(T order) destinationProvinceId,
-) {
+  String Function(T order) destinationProvinceId, {
+  Orders? draftOrders,
+}) {
   final provinceOwner = getProvinceOwnerMap(game);
   // Single-pass minor ids (Refs #2394): avoid O(orders × minors) scans per row.
   final minorNationIds = <String>{
@@ -54,6 +69,11 @@ List<T> filterOrdersByDiplomacy<T>(
   for (final m in orders) {
     final destOwner = provinceOwner[destinationProvinceId(m)];
     if (destOwner == null || destOwner == playerId) {
+      filtered.add(m);
+      continue;
+    }
+    if (draftOrders != null &&
+        _hasPendingDeclareWarToward(draftOrders, playerId, destOwner)) {
       filtered.add(m);
       continue;
     }
@@ -82,10 +102,12 @@ List<MoveOrder> filterMoveOrdersByDiplomacy(
 List<ArmyMoveOrder> filterArmyMoveOrdersByDiplomacy(
   Game game,
   String playerId,
-  List<ArmyMoveOrder> orders,
-) => filterOrdersByDiplomacy(
+  List<ArmyMoveOrder> orders, {
+  Orders? draftOrders,
+}) => filterOrdersByDiplomacy(
   game,
   playerId,
   orders,
   (ArmyMoveOrder o) => o.destinationProvinceId,
+  draftOrders: draftOrders,
 );

--- a/packages/colonizethis_logic/test/orders/order_suggestion_helpers_test.dart
+++ b/packages/colonizethis_logic/test/orders/order_suggestion_helpers_test.dart
@@ -96,5 +96,37 @@ void main() {
       final out = filterArmyMoveOrdersByDiplomacy(game, gpId, orders);
       expect(out, orders);
     });
+
+    test('keeps move into minor at peace when draft orders declare war', () {
+      final game = gameWithMinorProvince(
+        diplomacyRelations: [
+          DiplomacyRelation(
+            factionId1: gpId,
+            factionId2: minorId,
+            state: RelationState.atPeace,
+          ),
+        ],
+      );
+      const armyOrders = [
+        ArmyMoveOrder(armyId: 'a1', destinationProvinceId: '$ow|P_minor'),
+      ];
+      final draftOrders = Orders(
+        diplomaticOrdersByPlayerId: {
+          gpId: [
+            DiplomaticOrder(
+              type: DiplomaticOrderType.declareWar,
+              targetFactionId: minorId,
+            ),
+          ],
+        },
+      );
+      final out = filterArmyMoveOrdersByDiplomacy(
+        game,
+        gpId,
+        armyOrders,
+        draftOrders: draftOrders,
+      );
+      expect(out, armyOrders);
+    });
   });
 }

--- a/tool/run_observer_game/lib/observer_conquest_verify.dart
+++ b/tool/run_observer_game/lib/observer_conquest_verify.dart
@@ -1,0 +1,119 @@
+import 'dart:convert';
+import 'dart:io';
+
+/// Canonical Full-AI observer seed for conquest regression (Refs #2504).
+const int kObserverConquestCanonicalSeed = 42;
+
+/// Minimum resolved turns for per-GP Old World conquest AC.
+const int kObserverConquestCanonicalTurns = 100;
+
+/// Minimum net Old World provinces gained per Great Power vs turn 1.
+const int kObserverConquestMinOwGainPerGp = 3;
+
+const List<String> kObserverGreatPowerIds = [
+  'gp1',
+  'gp2',
+  'gp3',
+  'gp4',
+  'gp5',
+  'gp6',
+];
+
+const String kOldWorldProvinceIdPrefix = 'oldWorld|';
+
+/// Counts provinces in [snapshotJson] owned by [ownerId] whose id starts with
+/// [kOldWorldProvinceIdPrefix].
+int countOldWorldProvincesOwned(
+  Map<String, Object?> snapshotJson,
+  String ownerId,
+) {
+  final rows = snapshotJson['provinceOwnershipSorted'];
+  if (rows is! List<Object?>) {
+    return 0;
+  }
+  var count = 0;
+  for (final row in rows) {
+    if (row is! Map) {
+      continue;
+    }
+    final id = row['id']?.toString() ?? '';
+    final rowOwner = row['ownerId']?.toString();
+    if (rowOwner == ownerId && id.startsWith(kOldWorldProvinceIdPrefix)) {
+      count++;
+    }
+  }
+  return count;
+}
+
+Map<String, int> oldWorldProvinceCountsByGp(Map<String, Object?> snapshotJson) {
+  return <String, int>{
+    for (final gpId in kObserverGreatPowerIds)
+      gpId: countOldWorldProvincesOwned(snapshotJson, gpId),
+  };
+}
+
+/// Returns human-readable failure lines; empty when every GP meets [minGainPerGp].
+List<String> verifyPerGpOldWorldConquestGains({
+  required Map<String, Object?> turnStartSnapshot,
+  required Map<String, Object?> turnEndSnapshot,
+  int minGainPerGp = kObserverConquestMinOwGainPerGp,
+}) {
+  final failures = <String>[];
+  for (final gpId in kObserverGreatPowerIds) {
+    final start = countOldWorldProvincesOwned(turnStartSnapshot, gpId);
+    final end = countOldWorldProvincesOwned(turnEndSnapshot, gpId);
+    final gain = end - start;
+    if (gain < minGainPerGp) {
+      failures.add(
+        '$gpId gained $gain Old World provinces (need >= $minGainPerGp; '
+        'start=$start end=$end)',
+      );
+    }
+  }
+  return failures;
+}
+
+Map<String, Object?> loadObserverSnapshotJsonFile(String path) {
+  final text = File(path).readAsStringSync();
+  final decoded = jsonDecode(text);
+  if (decoded is! Map<String, Object?>) {
+    throw FormatException('Observer snapshot root must be a JSON object: $path');
+  }
+  return decoded;
+}
+
+String observerTurnSnapshotPath({
+  required String tracesGameDir,
+  required int turnNumber,
+}) {
+  final label = turnNumber.toString().padLeft(6, '0');
+  return '$tracesGameDir/turn-$label.snapshot.json';
+}
+
+/// Verifies turn-1 vs turn-[endTurn] snapshots under [tracesGameDir].
+List<String> verifyObserverConquestFromTraceDir(
+  String tracesGameDir, {
+  int endTurn = kObserverConquestCanonicalTurns,
+  int startTurn = 1,
+  int minGainPerGp = kObserverConquestMinOwGainPerGp,
+}) {
+  final startPath = observerTurnSnapshotPath(
+    tracesGameDir: tracesGameDir,
+    turnNumber: startTurn,
+  );
+  final endPath = observerTurnSnapshotPath(
+    tracesGameDir: tracesGameDir,
+    turnNumber: endTurn,
+  );
+  if (!File(startPath).existsSync()) {
+    return ['missing start snapshot: $startPath'];
+  }
+  if (!File(endPath).existsSync()) {
+    return ['missing end snapshot: $endPath'];
+  }
+  return verifyPerGpOldWorldConquestGains(
+    turnStartSnapshot: loadObserverSnapshotJsonFile(startPath),
+    turnEndSnapshot: loadObserverSnapshotJsonFile(endPath),
+    minGainPerGp: minGainPerGp,
+  );
+}

--- a/tool/run_observer_game/lib/observer_conquest_verify.dart
+++ b/tool/run_observer_game/lib/observer_conquest_verify.dart
@@ -33,7 +33,7 @@ int countOldWorldProvincesOwned(
   }
   var count = 0;
   for (final row in rows) {
-    if (row is! Map) {
+    if (row is! Map<String, Object?>) {
       continue;
     }
     final id = row['id']?.toString() ?? '';

--- a/tool/run_observer_game/test/observer_conquest_verify_test.dart
+++ b/tool/run_observer_game/test/observer_conquest_verify_test.dart
@@ -1,0 +1,86 @@
+import 'package:colonizethis_test/test.dart';
+
+import 'package:run_observer_game/observer_conquest_verify.dart';
+
+Map<String, Object?> _snapshotWithOwOwnership(Map<String, String> owByGp) {
+  final rows = <Map<String, String?>>[];
+  for (final entry in owByGp.entries) {
+    rows.add(<String, String?>{
+      'id': 'oldWorld|p_${entry.key}',
+      'ownerId': entry.value,
+    });
+  }
+  rows.add(<String, String?>{'id': 'newWorld|p_nw1', 'ownerId': 'gp1'});
+  rows.sort((a, b) => (a['id'] ?? '').compareTo(b['id'] ?? ''));
+  return <String, Object?>{'provinceOwnershipSorted': rows};
+}
+
+void main() {
+  group('countOldWorldProvincesOwned', () {
+    test('counts only oldWorld| provinces for owner', () {
+      final snap = _snapshotWithOwOwnership(<String, String>{
+        'gp1a': 'gp1',
+        'gp1b': 'gp1',
+        'gp2': 'gp2',
+      });
+      expect(countOldWorldProvincesOwned(snap, 'gp1'), 2);
+      expect(countOldWorldProvincesOwned(snap, 'gp2'), 1);
+    });
+  });
+
+  group('verifyPerGpOldWorldConquestGains', () {
+    test('passes when each GP gains at least minGain', () {
+      final start = _snapshotWithOwOwnership(<String, String>{
+        for (final gp in kObserverGreatPowerIds) gp: gp,
+      });
+      final endRows = <Map<String, String?>>[];
+      for (final gp in kObserverGreatPowerIds) {
+        for (var i = 0; i < 10; i++) {
+          endRows.add(<String, String?>{
+            'id': 'oldWorld|p_${gp}_$i',
+            'ownerId': gp,
+          });
+        }
+      }
+      endRows.sort((a, b) => (a['id'] ?? '').compareTo(b['id'] ?? ''));
+      final end = <String, Object?>{'provinceOwnershipSorted': endRows};
+
+      expect(
+        verifyPerGpOldWorldConquestGains(
+          turnStartSnapshot: start,
+          turnEndSnapshot: end,
+          minGainPerGp: 3,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('fails when a GP gains fewer than minGain', () {
+      final start = _snapshotWithOwOwnership(<String, String>{
+        'gp1': 'gp1',
+        'gp2': 'gp2',
+        'gp3': 'gp3',
+        'gp4': 'gp4',
+        'gp5': 'gp5',
+        'gp6': 'gp6',
+      });
+      final end = _snapshotWithOwOwnership(<String, String>{
+        'gp1': 'gp1',
+        'gp1b': 'gp1',
+        'gp2': 'gp2',
+        'gp3': 'gp3',
+        'gp4': 'gp4',
+        'gp5': 'gp5',
+        'gp6': 'gp6',
+      });
+
+      final failures = verifyPerGpOldWorldConquestGains(
+        turnStartSnapshot: start,
+        turnEndSnapshot: end,
+        minGainPerGp: 3,
+      );
+      expect(failures, isNotEmpty);
+      expect(failures.first, contains('gp1'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Document victory-aware Full AI military planning in `SPEC/ai/ai-architecture.md` (31 OW province pace, planner order, same-turn declare-war + invasion).
- Add `ConquestSummary` on `AIWorldSnapshot` (`provincesToVictory`, invadable OW provinces, preferred targets) and victory-pace bonuses in `goal_manager` via `colonizethis_data` `ai_victory_config.dart`.
- Reorder domain planners: declare-war diplomacy → `runConquestArmyMovePlanner` → relocation army moves → naval → non–declare-war diplomacy.
- Extend `filterArmyMoveOrdersByDiplomacy` to honor pending same-turn `declareWar` in draft orders (logic + tests).

## Deferred (follow-up on same issue)
- **Observer regression gate:** 100-turn canonical run asserting each GP gains ≥3 OW provinces (AC observer / CI).
- **AI trace fields:** `provincesToVictory`, `invadableCount`, `declaredWarTarget`, `conquestArmyMoveCount` on trace export.
- **GP-vs-GP war targeting** tuning and build-planner military bias when `conquer` goal.
- **End-to-end observer validation** on seed 42 / 30-turn repro (manual or scripted).

## Acceptance criteria (this PR)
| AC | Status |
|----|--------|
| SPEC victory-aware conquer + paired declare/move | **This PR** |
| Same-turn invasion (declareWar + ArmyMoveOrder) | **This PR** (orchestrator unit test) |
| Army moves in play / all GPs conquer (observer) | **Deferred** |
| Victory path signal in trace | **Partial** (goal scoring; trace fields deferred) |
| Unit tests orchestrator / logic draft declare | **This PR** |
| Observer regression CI | **Deferred** |

## Tests
```bash
cd packages/colonizethis_data && dart test test/ai_victory_config_test.dart
cd packages/colonizethis_logic && dart test test/orders/order_suggestion_helpers_test.dart
cd packages/colonizethis_ai && dart test test/goal_manager_test.dart test/domain_planner_orchestrator_conquest_pair_test.dart
```

Refs #2504

Made with [Cursor](https://cursor.com)