### PR TITLE
perf(map): wire per-continent distance maps for organic placement (#2489)

### DIFF
--- a/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds.dart
@@ -18,6 +18,7 @@ import 'tile_map_distance_sentinels.dart';
 import 'tile_map_land_seed_contract.dart';
 import 'tile_map_grid_copy.dart';
 import 'tile_map_land_sentinel.dart';
+import 'tile_map_manhattan_distance_maps.dart';
 import 'tile_map_manhattan_distance_transform.dart';
 import 'tile_map_province_budget.dart';
 

--- a/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds_organic_part.dart
+++ b/packages/colonizethis_map/lib/src/tile_map_generator_land_seeds_organic_part.dart
@@ -29,22 +29,10 @@ List<(int x, int y)> _organicSeedCloseSeaCandidates(
 (int, int) _pickBestOrganicSeaCandidate(
   List<(int x, int y)> candidates,
   List<List<int>> minDistToOwnLand,
-  List<List<int>> continentGrid,
-  TileMapLandSeedParams params,
-  int continentIndex,
+  List<List<int>> distToOtherContinent,
   double awayPenalty,
   Random rnd,
 ) {
-  final unreachableOther = params.width + params.height;
-  final distToOtherContinent = manhattanDistToNearestSourceXY(
-    params.width,
-    params.height,
-    (x, y) {
-      final cell = continentGrid[y][x];
-      return cell >= 0 && cell != continentIndex;
-    },
-    distanceWhenNoSources: unreachableOther,
-  );
   var bestScore = -1e100;
   final bestCandidates = <(int x, int y)>[];
   for (final (x, y) in candidates) {
@@ -67,14 +55,13 @@ List<(int x, int y)> _organicSeedCloseSeaCandidates(
 (int, int) _placeOneOrganicSeed(
   TileMapLandSeedParams params,
   List<List<String>> grid,
-  List<List<int>> continentGrid,
+  List<List<int>> distToOtherContinent,
   (int x, int y) continentSeed,
   List<(int x, int y)> existingLandSeeds,
   List<int> continentBySeedIndex,
   int c,
   int closeRadius,
   double awayPenalty,
-  int numContinents,
   String seaZoneId,
   Random rnd,
 ) {
@@ -113,9 +100,7 @@ List<(int x, int y)> _organicSeedCloseSeaCandidates(
   return _pickBestOrganicSeaCandidate(
     candidates,
     minDistToOwnLand,
-    continentGrid,
-    params,
-    c,
+    distToOtherContinent,
     awayPenalty,
     rnd,
   );
@@ -265,20 +250,25 @@ _placeLandSeedsOrganicImpl(
       numContinents: numContinents,
     );
     voronoiRemaining -= roundBudget;
+    final distToOtherByContinent = manhattanDistToOtherContinentsMaps(
+      continentGrid: continentGrid,
+      width: params.width,
+      height: params.height,
+      numContinents: numContinents,
+    );
     // Step 1: Place one land seed per continent (if needed)
     for (var c = 0; c < numContinents; c++) {
       if (seedCountsPerContinent[c] >= seedsPerContinent[c]) continue;
       final (sx, sy) = _placeOneOrganicSeed(
         params,
         g,
-        continentGrid,
+        distToOtherByContinent[c],
         continentSeeds[c],
         landSeeds,
         continentBySeedIndex,
         c,
         closeRadius,
         awayPenalty,
-        numContinents,
         seaZoneId,
         rnd,
       );


### PR DESCRIPTION
## Summary
- Completes **P2** for #2489: organic land-seed placement now precomputes `manhattanDistToOtherContinentsMaps` once per round and reuses the per-continent slice when scoring sea candidates, instead of running a full-grid `manhattanDistToNearestSourceXY` on every `_placeOneOrganicSeed` call.
- Prior slices for this issue are already on `dev` (#2490, #2495, #2499, #2501): direction constants, nearest-seed consolidation, `copyTileMapGrid`, shared resource placement, legend helpers, `seaZoneIdsFromTopology`, capital/faction color dedup, P1 `oceanCells` continent-set cache, P3 post-mountain scan, P4 join land-cell cache, and related dedup.

## Deferred
- Optional `ct_repo_lint` rule for inline 4-direction tuples (issue lists as low priority; not required for AC closure).

## Acceptance criteria
| AC | Status |
|----|--------|
| D1–D14, P1, P3, P4, legends, coverage, file size | On `dev` via prior PRs |
| P2: per-continent distance precompute, no inner O(W×H) in candidate loop | **This PR** |
| Fixed-seed generation unchanged | `tile_map_generator_test.dart`, `tile_map_gen_land_seeds_test.dart`, `tile_map_topology_validation_test.dart` |
| Package tests / 90% coverage | `dart test` in `packages/colonizethis_map` (221 tests) |

## Tests
```bash
cd packages/colonizethis_map && dart test
```

Refs #2489

Made with [Cursor](https://cursor.com)