### PR TITLE
ci: nightly gate for tool tests, sim_scenarios, and observer verify

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,13 +1,30 @@
-name: Observer conquest nightly
+name: Nightly
 
+# 23:00 Asia/Hong_Kong daily (15:00 UTC). Refs #2509.
 on:
   schedule:
-    - cron: '0 4 * * 0'
+    - cron: '0 15 * * *'
   workflow_dispatch:
 
 jobs:
+  integration:
+    name: Tool packages + sim_scenarios
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: '3.11.0'
+
+      - name: Run nightly integration gate
+        run: bash tool/run_nightly_integration_gate.sh
+
   observer_conquest_verify:
-    name: Full-AI 100-turn conquest verify (seed 42)
+    name: Full-AI conquest verify (seed 42)
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
@@ -33,3 +50,4 @@ jobs:
             --seed 42 \
             --max-turns 100 \
             --verify-conquest
+          # When --verify-colonial-expansion lands (#2509): --max-turns 150 and both flags.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -440,17 +440,6 @@ jobs:
             (cd packages/colonizethis_map && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
           fi
 
-      - name: Test tool packages (Dart)
-        if: needs.changes.outputs.tests == 'true'
-        env:
-          SUPPRESS_IMAGE_VIEWER: "1"
-        run: |
-          set -e
-          for dir in tool/sim_scenarios tool/sim_combat_montecarlo tool/sim_combat tool/generate_map tool/init_game tool/sim_economy tool/show_tech; do
-            [ -d "$dir/test" ] || continue
-            (cd "$dir" && dart test -j 2 --reporter=compact)
-          done
-
       - name: Test run_observer_game (Dart, coverage)
         if: needs.changes.outputs.tests == 'true'
         env:
@@ -488,10 +477,6 @@ jobs:
       - name: Coverage gate (run_observer_game lib >= 80%)
         if: needs.changes.outputs.tests == 'true'
         run: tool/check_coverage_threshold.sh 80 tool/run_observer_game
-
-      - name: sim_scenarios integration gate (all scenarios must pass)
-        if: needs.changes.outputs.tests == 'true'
-        run: melos run sim_scenarios
 
   quality_app_coverage:
     name: App coverage (merge shards)

--- a/SPEC/program/run_observer_game-tool.md
+++ b/SPEC/program/run_observer_game-tool.md
@@ -57,7 +57,7 @@ HTML is a render-only wrapper: the `<pre>` body uses the **same** pretty-printed
 
 ## Conquest regression verification (Refs #2504)
 
-`lib/observer_conquest_verify.dart` compares `turn-000001.snapshot.json` vs `turn-000100.snapshot.json` under a game trace directory: each Great Power `gp1`–`gp6` must gain **≥3** net **Old World** provinces (`oldWorld|…` ids only). Canonical seed **42**, **100** resolved turns. Pass **`--verify-conquest`** after a successful run to execute this check (exit **5** on failure; requires `--max-turns >= 100` or no turn cap). Unit tests cover the parser; a full observer run is slow (~minutes) and is not part of the default quality gate. **Nightly:** `.github/workflows/observer-conquest-nightly.yml` runs seed **42**, **100** turns, and `--verify-conquest` on schedule and `workflow_dispatch`.
+`lib/observer_conquest_verify.dart` compares `turn-000001.snapshot.json` vs `turn-000100.snapshot.json` under a game trace directory: each Great Power `gp1`–`gp6` must gain **≥3** net **Old World** provinces (`oldWorld|…` ids only). Canonical seed **42**, **100** resolved turns. Pass **`--verify-conquest`** after a successful run to execute this check (exit **5** on failure; requires `--max-turns >= 100` or no turn cap). Unit tests cover the parser; a full observer run is slow (~minutes) and is not part of the default quality gate. **Nightly:** `.github/workflows/nightly.yml` job `observer_conquest_verify` runs seed **42**, **100** turns, and `--verify-conquest` daily at **23:00 Asia/Hong_Kong** (`workflow_dispatch` supported). When `--verify-colonial-expansion` lands (#2509), extend that job to **150** turns and both verify flags.
 
 ## Coverage
 

--- a/SPEC/program/sim-scenarios.md
+++ b/SPEC/program/sim-scenarios.md
@@ -15,7 +15,7 @@ Province ids in scenario JSON (setup units, order targets, assertion `province` 
 
 ## Responsibility
 
-Run composite integration tests that verify game systems work correctly together. Unlike unit tests, scenarios test the full pipeline: game initialization → turn resolution → state verification. Provides a tool for CI/testing workflows via `melos run sim_scenarios`.
+Run composite integration tests that verify game systems work correctly together. Unlike unit tests, scenarios test the full pipeline: game initialization → turn resolution → state verification. Provides a tool for CI/testing workflows via `melos run sim_scenarios`. **CI:** batch driver runs in **`.github/workflows/nightly.yml`** (not the PR `quality` workflow); local parity: **`tool/run_nightly_gate_tests.sh`**.
 
 ---
 

--- a/SPEC/program/test-logging.md
+++ b/SPEC/program/test-logging.md
@@ -47,8 +47,11 @@ Any package or app that has tests adds **colonizethis_test** as a **dev_dependen
 
 ## Verifying the quality gate
 
-The GitHub workflow **.github/workflows/quality.yml** runs the same test scope as `tool/test_coverage.py` but in split steps with `--reporter=compact` (pass/fail only). You can verify it locally in either of these ways:
+The GitHub workflow **.github/workflows/quality.yml** runs PR checks (packages, app, ctdev, `run_observer_game` unit tests and coverage, repo lint, etc.) with `--reporter=compact` (pass/fail only). **Tool package tests** and **`melos run sim_scenarios`** run in **`.github/workflows/nightly.yml`** (daily **23:00 Asia/Hong_Kong**, `workflow_dispatch`); local parity: **`tool/run_nightly_gate_tests.sh`**. Refs #2509.
 
-1. **Run the same steps locally:** From the repo root, run **`tool/run_quality_gate_tests.sh`**. This runs the same commands as the workflow (packages Dart, app Flutter, ctdev Flutter, tool packages Dart, coverage gate, sim_scenarios). Requires `dart`, `flutter`, and `lcov`.
-2. **Run the workflow with act:** If [act](https://github.com/nektos/act) is installed, run `act pull_request -n` (dry run) or `act pull_request` to execute the Quality job locally.
-3. **Trigger CI:** Push to a branch and open a PR against `main` or `dev`; the Quality job runs on the push.
+You can verify locally in either of these ways:
+
+1. **PR quality gate:** From the repo root, run **`tool/run_quality_gate_tests.sh`** (same scope as `quality.yml`; does not run tool packages or sim_scenarios). Requires `dart`, `flutter`, and `lcov`.
+2. **Nightly integration:** Run **`tool/run_nightly_gate_tests.sh`** (tool packages + sim_scenarios; observer campaign verify is a separate nightly job in the same workflow).
+3. **Run the workflow with act:** If [act](https://github.com/nektos/act) is installed, run `act pull_request -n` (dry run) or `act pull_request` to execute the Quality job locally.
+4. **Trigger CI:** Push to a branch and open a PR against `main` or `dev`; the Quality job runs on the push.

--- a/docs/project-tools.md
+++ b/docs/project-tools.md
@@ -316,7 +316,7 @@ Paste the script output into the PR description for AC8–AC9 evidence.
 
 ## run_quality_gate_tests.sh (CI verification)
 
-Runs the same test and coverage steps as the GitHub Quality workflow (`.github/workflows/quality.yml`): **Wang incremental assets** (`python3 pytool/test_wang_incremental_assets_and_preview.py`; CI installs **`python3-pil`** via apt; locally install Pillow e.g. `python3 -m pip install pillow` or use your `pytool` venv), packages (Dart), app (Flutter) with **app widget coverage gate ≥ 80%** (applies to `lib/widgets/` only; see SPEC/program/test-logging.md), ctdev (Flutter), tool packages (Dart), coverage gate (logic/map/ai ≥ 90%), and sim_scenarios. Use this to verify the quality gate locally before pushing. Spec: [SPEC/program/test-logging.md](../SPEC/program/test-logging.md).
+Runs the same test and coverage steps as the GitHub Quality workflow (`.github/workflows/quality.yml`): **Wang incremental assets** (`python3 pytool/test_wang_incremental_assets_and_preview.py`; CI installs **`python3-pil`** via apt; locally install Pillow e.g. `python3 -m pip install pillow` or use your `pytool` venv), packages (Dart), app (Flutter) with **app widget coverage gate ≥ 80%** (applies to `lib/widgets/` only; see SPEC/program/test-logging.md), ctdev (Flutter), `run_observer_game` coverage gate, and logic/map/ai coverage. **Tool packages** and **sim_scenarios** are in the nightly gate — see **`tool/run_nightly_gate_tests.sh`** and [SPEC/program/test-logging.md](../SPEC/program/test-logging.md). Use this to verify the PR quality gate locally before pushing.
 
 **Invocation**
 
@@ -325,6 +325,20 @@ tool/run_quality_gate_tests.sh
 ```
 
 Requires `dart`, `flutter`, and `lcov` (e.g. `sudo apt-get install lcov`).
+
+---
+
+## run_nightly_gate_tests.sh (nightly CI)
+
+Runs tool package `dart test` for `tool/sim_scenarios`, `tool/sim_combat_montecarlo`, `tool/sim_combat`, `tool/generate_map`, `tool/init_game`, `tool/sim_economy`, `tool/show_tech`, then **`melos run sim_scenarios`**. Same as the **integration** job in `.github/workflows/nightly.yml` (daily **23:00 Asia/Hong_Kong**). Observer campaign verify is a separate job in that workflow. Spec: [SPEC/program/test-logging.md](../SPEC/program/test-logging.md).
+
+**Invocation**
+
+```bash
+tool/run_nightly_gate_tests.sh
+```
+
+Requires `dart` only (Melos activated by the script).
 
 ---
 

--- a/tool/run_nightly_gate_tests.sh
+++ b/tool/run_nightly_gate_tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Run the same steps as .github/workflows/nightly.yml integration job locally.
+# Observer campaign verify is slow (~minutes); run via melos/workflow or:
+#   cd tool/run_observer_game && dart run run_observer_game --output /tmp/obs --seed 42 --max-turns 100 --verify-conquest
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+bash "$ROOT/tool/run_nightly_integration_gate.sh"

--- a/tool/run_nightly_integration_gate.sh
+++ b/tool/run_nightly_integration_gate.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Tool package tests + sim_scenarios integration (nightly CI gate).
+# See .github/workflows/nightly.yml and SPEC/program/test-logging.md.
+set -euo pipefail
+export SUPPRESS_IMAGE_VIEWER=1
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+dart pub get
+dart pub global activate melos
+melos --version
+
+echo "=== Test tool packages (Dart) ==="
+for dir in tool/sim_scenarios tool/sim_combat_montecarlo tool/sim_combat tool/generate_map tool/init_game tool/sim_economy tool/show_tech; do
+  [ -d "$dir/test" ] || continue
+  (cd "$dir" && dart test -j 2 --reporter=compact)
+done
+
+echo ""
+echo "=== sim_scenarios integration gate ==="
+melos run sim_scenarios
+
+echo "Nightly integration gate passed."

--- a/tool/run_quality_gate_tests.sh
+++ b/tool/run_quality_gate_tests.sh
@@ -59,14 +59,6 @@ if [ -d ctdev/test ]; then
 fi
 
 echo ""
-echo "=== Test tool packages (Dart) ==="
-for dir in tool/sim_scenarios tool/sim_combat_montecarlo tool/sim_combat tool/generate_map tool/init_game tool/sim_economy tool/show_tech; do
-  [ -d "$dir/test" ] || continue
-  (cd "$dir" && dart test --coverage=coverage -j 4 --reporter=compact)
-  (cd "$dir" && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
-done
-
-echo ""
 echo "=== Test run_observer_game (Dart, coverage) ==="
 (cd tool/run_observer_game && dart test --coverage=coverage -j 4 --reporter=compact)
 (cd tool/run_observer_game && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
@@ -80,8 +72,9 @@ echo "=== Coverage gate (logic/map/ai >= 90%) ==="
 "$ROOT/tool/check_coverage_threshold.sh" 90 packages/colonizethis_logic packages/colonizethis_map packages/colonizethis_ai
 
 echo ""
-echo "=== sim_scenarios integration gate ==="
-melos run sim_scenarios
+echo "=== Nightly-only gates (skipped) ==="
+echo "Tool package tests + sim_scenarios: run tool/run_nightly_gate_tests.sh"
+echo "(CI: .github/workflows/nightly.yml at 23:00 Asia/Hong_Kong)"
 
 echo ""
 echo "All quality-gate steps passed."


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/nightly.yml` scheduled daily at **23:00 Asia/Hong_Kong** (`0 15 * * *` UTC) with `workflow_dispatch`.
- **integration** job: tool package `dart test` (7 dirs) + `melos run sim_scenarios` via `tool/run_nightly_integration_gate.sh`.
- **observer_conquest_verify** job: seed 42, 100 turns, `--verify-conquest` (replaces weekly `observer-conquest-nightly.yml`).
- Removes tool package tests and `sim_scenarios` from PR `quality.yml` to shorten PR CI.
- Adds `tool/run_nightly_gate_tests.sh`; updates `run_quality_gate_tests.sh` and SPEC/docs.

Refs #2509

## Test plan

- [ ] PR `quality` workflow passes on this branch
- [ ] `workflow_dispatch` on **Nightly** workflow (optional; integration job is the moved PR gate)
- [ ] Local: `tool/run_quality_gate_tests.sh` (PR scope)
- [ ] Local: `tool/run_nightly_gate_tests.sh` (nightly integration scope)

Made with [Cursor](https://cursor.com)