### PR TITLE
ci: parallelize colonizethis package tests in quality workflow

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -291,13 +291,53 @@ jobs:
           path: app/coverage/lcov.shard${{ matrix.shard }}.info
           retention-days: 2
 
+  # colonizethis_* package unit tests + package coverage gates (parallel to quality / app tests).
+  package_tests:
+    name: Package tests (colonizethis)
+    needs: changes
+    if: always() && needs.changes.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Skip when no test-relevant paths changed
+        if: needs.changes.outputs.tests != 'true'
+        run: echo "No test-relevant paths matched; skipping package tests."
+
+      - name: Checkout
+        if: needs.changes.outputs.tests == 'true'
+        uses: actions/checkout@v6
+
+      - name: Setup Flutter
+        if: needs.changes.outputs.tests == 'true'
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: '3.41.9'
+          cache: true
+
+      - name: Install lcov
+        if: needs.changes.outputs.tests == 'true'
+        run: sudo apt-get update && sudo apt-get install -y lcov
+
+      - name: Resolve dependencies
+        if: needs.changes.outputs.tests == 'true'
+        run: dart pub get
+
+      - name: Package tests and coverage gates
+        if: needs.changes.outputs.tests == 'true'
+        env:
+          SUPPRESS_IMAGE_VIEWER: "1"
+          PACKAGE_TEST_JOBS: "2"
+        run: bash tool/run_package_tests.sh
+
   quality:
+    name: Quality (lint, analyze, observer)
     needs: changes
     runs-on: ubuntu-latest
-    # Dart coverage + package matrix; Flutter app tests run in parallel shards (app_tests_shard).
+    # Lint, analyze, checker tests, run_observer_game; package tests run in package_tests.
     # Workspace analyzer runs flutter/dart analyze per member (many packages); allow enough time
     # so the job is not cancelled mid-analyze when the workspace grows (Refs #2036).
-    timeout-minutes: 150
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -308,14 +348,6 @@ jobs:
           channel: stable
           flutter-version: '3.41.9'
           cache: true
-
-      - name: Install melos
-        if: needs.changes.outputs.tests == 'true'
-        run: dart pub global activate melos
-
-      - name: Check melos version
-        if: needs.changes.outputs.tests == 'true'
-        run: melos --version
 
       - name: Install lcov
         if: needs.changes.outputs.tests == 'true'
@@ -380,66 +412,6 @@ jobs:
           sudo apt-get install -y --no-install-recommends python3-pil
           cd pytool && python3 test_wang_incremental_assets_and_preview.py
 
-      - name: Test colonizethis_models (Dart)
-        if: needs.changes.outputs.tests == 'true'
-        env:
-          SUPPRESS_IMAGE_VIEWER: "1"
-        run: |
-          if [ -d packages/colonizethis_models/test ]; then
-            (cd packages/colonizethis_models && dart test --coverage=coverage -j 2 --reporter=compact)
-            (cd packages/colonizethis_models && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
-          fi
-
-      - name: Test colonizethis_data (Dart)
-        if: needs.changes.outputs.tests == 'true'
-        env:
-          SUPPRESS_IMAGE_VIEWER: "1"
-        run: |
-          if [ -d packages/colonizethis_data/test ]; then
-            (cd packages/colonizethis_data && dart test --coverage=coverage -j 2 --reporter=compact)
-            (cd packages/colonizethis_data && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
-          fi
-
-      - name: Test colonizethis_save (Dart)
-        if: needs.changes.outputs.tests == 'true'
-        env:
-          SUPPRESS_IMAGE_VIEWER: "1"
-        run: |
-          if [ -d packages/colonizethis_save/test ]; then
-            (cd packages/colonizethis_save && dart test --coverage=coverage -j 2 --reporter=compact)
-            (cd packages/colonizethis_save && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
-          fi
-
-      - name: Test colonizethis_logic (Dart)
-        if: needs.changes.outputs.tests == 'true'
-        env:
-          SUPPRESS_IMAGE_VIEWER: "1"
-        run: |
-          if [ -d packages/colonizethis_logic/test ]; then
-            (cd packages/colonizethis_logic && dart test --coverage=coverage -j 2 --reporter=compact)
-            (cd packages/colonizethis_logic && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
-          fi
-
-      - name: Test colonizethis_ai (Dart)
-        if: needs.changes.outputs.tests == 'true'
-        env:
-          SUPPRESS_IMAGE_VIEWER: "1"
-        run: |
-          if [ -d packages/colonizethis_ai/test ]; then
-            (cd packages/colonizethis_ai && dart test --coverage=coverage -j 2 --reporter=compact)
-            (cd packages/colonizethis_ai && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
-          fi
-
-      - name: Test colonizethis_map (Dart)
-        if: needs.changes.outputs.tests == 'true'
-        env:
-          SUPPRESS_IMAGE_VIEWER: "1"
-        run: |
-          if [ -d packages/colonizethis_map/test ]; then
-            (cd packages/colonizethis_map && dart test --coverage=coverage -j 2 --reporter=compact)
-            (cd packages/colonizethis_map && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
-          fi
-
       - name: Test run_observer_game (Dart, coverage)
         if: needs.changes.outputs.tests == 'true'
         env:
@@ -466,25 +438,16 @@ jobs:
             fi
           fi
 
-      - name: Coverage gate (logic/map/ai >= 90%)
-        if: needs.changes.outputs.tests == 'true'
-        run: tool/check_coverage_threshold.sh 90 packages/colonizethis_logic packages/colonizethis_map packages/colonizethis_ai
-
-      - name: Coverage gate (data >= 80%)
-        if: needs.changes.outputs.tests == 'true'
-        run: tool/check_coverage_threshold.sh 80 packages/colonizethis_data
-
       - name: Coverage gate (run_observer_game lib >= 80%)
         if: needs.changes.outputs.tests == 'true'
         run: tool/check_coverage_threshold.sh 80 tool/run_observer_game
 
   quality_app_coverage:
     name: App coverage (merge shards)
-    needs: [changes, quality, app_tests_shard]
+    needs: [changes, app_tests_shard]
     if: |
       always() &&
       needs.changes.result == 'success' &&
-      needs.quality.result == 'success' &&
       (
         needs.changes.outputs.tests != 'true' ||
         needs.app_tests_shard.result == 'success'

--- a/SPEC/program/test-logging.md
+++ b/SPEC/program/test-logging.md
@@ -47,11 +47,11 @@ Any package or app that has tests adds **colonizethis_test** as a **dev_dependen
 
 ## Verifying the quality gate
 
-The GitHub workflow **.github/workflows/quality.yml** runs PR checks (packages, app, ctdev, `run_observer_game` unit tests and coverage, repo lint, etc.) with `--reporter=compact` (pass/fail only). **Tool package tests** and **`melos run sim_scenarios`** run in **`.github/workflows/nightly.yml`** (daily **23:00 Asia/Hong_Kong**, `workflow_dispatch`); local parity: **`tool/run_nightly_gate_tests.sh`**. Refs #2509.
+The GitHub workflow **.github/workflows/quality.yml** runs PR checks in parallel jobs: **`package_tests`** (six `colonizethis_*` packages + package coverage gates via **`tool/run_package_tests.sh`**), **`quality`** (lint, analyze, checker tests, `run_observer_game` + observer coverage), and app test shards + **`quality_app_coverage`**. All use `--reporter=compact` (pass/fail only). **Tool package tests** and **`melos run sim_scenarios`** run in **`.github/workflows/nightly.yml`** (daily **23:00 Asia/Hong_Kong**, `workflow_dispatch`); local parity: **`tool/run_nightly_gate_tests.sh`**. Refs #2509.
 
 You can verify locally in either of these ways:
 
-1. **PR quality gate:** From the repo root, run **`tool/run_quality_gate_tests.sh`** (same scope as `quality.yml`; does not run tool packages or sim_scenarios). Requires `dart`, `flutter`, and `lcov`.
+1. **PR quality gate:** From the repo root, run **`tool/run_quality_gate_tests.sh`** (same scope as `quality.yml`; does not run tool packages or sim_scenarios). Package-only slice: **`tool/run_package_tests.sh`**. Requires `dart`, `flutter`, and `lcov`.
 2. **Nightly integration:** Run **`tool/run_nightly_gate_tests.sh`** (tool packages + sim_scenarios; observer campaign verify is a separate nightly job in the same workflow).
 3. **Run the workflow with act:** If [act](https://github.com/nektos/act) is installed, run `act pull_request -n` (dry run) or `act pull_request` to execute the Quality job locally.
 4. **Trigger CI:** Push to a branch and open a PR against `main` or `dev`; the Quality job runs on the push.

--- a/docs/project-tools.md
+++ b/docs/project-tools.md
@@ -316,7 +316,7 @@ Paste the script output into the PR description for AC8–AC9 evidence.
 
 ## run_quality_gate_tests.sh (CI verification)
 
-Runs the same test and coverage steps as the GitHub Quality workflow (`.github/workflows/quality.yml`): **Wang incremental assets** (`python3 pytool/test_wang_incremental_assets_and_preview.py`; CI installs **`python3-pil`** via apt; locally install Pillow e.g. `python3 -m pip install pillow` or use your `pytool` venv), packages (Dart), app (Flutter) with **app widget coverage gate ≥ 80%** (applies to `lib/widgets/` only; see SPEC/program/test-logging.md), ctdev (Flutter), `run_observer_game` coverage gate, and logic/map/ai coverage. **Tool packages** and **sim_scenarios** are in the nightly gate — see **`tool/run_nightly_gate_tests.sh`** and [SPEC/program/test-logging.md](../SPEC/program/test-logging.md). Use this to verify the PR quality gate locally before pushing.
+Runs the same test and coverage steps as the GitHub Quality workflow (`.github/workflows/quality.yml`): **Wang incremental assets** (`python3 pytool/test_wang_incremental_assets_and_preview.py`; CI installs **`python3-pil`** via apt; locally install Pillow e.g. `python3 -m pip install pillow` or use your `pytool` venv), packages via **`tool/run_package_tests.sh`** (CI job **`package_tests`**), app (Flutter) with **app widget coverage gate ≥ 80%** (applies to `lib/widgets/` only; see SPEC/program/test-logging.md), ctdev (Flutter), `run_observer_game` coverage gate. **Tool packages** and **sim_scenarios** are in the nightly gate — see **`tool/run_nightly_gate_tests.sh`** and [SPEC/program/test-logging.md](../SPEC/program/test-logging.md). Use this to verify the PR quality gate locally before pushing.
 
 **Invocation**
 

--- a/tool/run_package_tests.sh
+++ b/tool/run_package_tests.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Run colonizethis workspace package unit tests + coverage gates (CI: package_tests job).
+# Same scope as the former quality.yml package steps. Requires: dart, lcov.
+set -euo pipefail
+export SUPPRESS_IMAGE_VIEWER="${SUPPRESS_IMAGE_VIEWER:-1}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+PARALLEL="${PACKAGE_TEST_JOBS:-2}"
+
+for dir in \
+  packages/colonizethis_models \
+  packages/colonizethis_data \
+  packages/colonizethis_save \
+  packages/colonizethis_logic \
+  packages/colonizethis_ai \
+  packages/colonizethis_map; do
+  [ -d "$dir/test" ] || continue
+  echo "=== Test $dir (Dart) ==="
+  (cd "$dir" && dart test --coverage=coverage -j "$PARALLEL" --reporter=compact)
+  (cd "$dir" && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
+done
+
+echo ""
+echo "=== Coverage gate (logic/map/ai >= 90%) ==="
+"$ROOT/tool/check_coverage_threshold.sh" 90 \
+  packages/colonizethis_logic \
+  packages/colonizethis_map \
+  packages/colonizethis_ai
+
+echo ""
+echo "=== Coverage gate (data >= 80%) ==="
+"$ROOT/tool/check_coverage_threshold.sh" 80 packages/colonizethis_data
+
+echo "Package tests and coverage gates passed."

--- a/tool/run_quality_gate_tests.sh
+++ b/tool/run_quality_gate_tests.sh
@@ -22,12 +22,8 @@ fi
 (cd pytool && python3 test_wang_incremental_assets_and_preview.py)
 
 echo ""
-echo "=== Test packages (Dart) ==="
-for dir in packages/colonizethis_models packages/colonizethis_data packages/colonizethis_save packages/colonizethis_logic packages/colonizethis_ai packages/colonizethis_map; do
-  [ -d "$dir/test" ] || continue
-  (cd "$dir" && dart test --coverage=coverage -j 4 --reporter=compact)
-  (cd "$dir" && dart run coverage:format_coverage --lcov -i coverage -o coverage/lcov.info --report-on=lib --package=.)
-done
+echo "=== Package tests (colonizethis; CI: package_tests job) ==="
+PACKAGE_TEST_JOBS=4 tool/run_package_tests.sh
 
 echo ""
 echo "=== Workspace analyze (errors only; includes test/ + integration_test/; CI: quality job) ==="
@@ -66,10 +62,6 @@ echo "=== Test run_observer_game (Dart, coverage) ==="
 echo ""
 echo "=== Coverage gate (run_observer_game lib >= 80%) ==="
 "$ROOT/tool/check_coverage_threshold.sh" 80 tool/run_observer_game
-
-echo ""
-echo "=== Coverage gate (logic/map/ai >= 90%) ==="
-"$ROOT/tool/check_coverage_threshold.sh" 90 packages/colonizethis_logic packages/colonizethis_map packages/colonizethis_ai
 
 echo ""
 echo "=== Nightly-only gates (skipped) ==="


### PR DESCRIPTION
## Summary

- Extracts all six `colonizethis_*` package unit tests and package coverage gates (logic/map/ai ≥ 90%, data ≥ 80%) into a new parallel **`package_tests`** job (`Package tests (colonizethis)`).
- Slims the **`quality`** job to lint/analyze/checkers/Wang/`run_observer_game`/observer coverage (45 min timeout; was 150 min with packages inline).
- Decouples **`quality_app_coverage`** from `quality` so it only waits on app test shards.
- Adds **`tool/run_package_tests.sh`** and wires **`tool/run_quality_gate_tests.sh`** for local parity.

## Branch protection

After this merges, update required checks on `dev`:

- Add: **Package tests (colonizethis)**
- Replace `quality` with: **Quality (lint, analyze, observer)** (if the old check name was `quality`)

## Test plan

- [ ] Quality workflow passes on this PR (all jobs green)
- [ ] Confirm new check **Package tests (colonizethis)** appears under the Quality workflow
- [ ] Optional local: `tool/run_package_tests.sh` and `tool/run_quality_gate_tests.sh`


Made with [Cursor](https://cursor.com)