### PR TITLE
feat: colonial expansion observer gates and Full AI NW support (#2509)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
         run: bash tool/run_nightly_integration_gate.sh
 
   observer_conquest_verify:
-    name: Full-AI conquest verify (seed 42)
+    name: Full-AI observer verify (seed 42, turns 150)
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
@@ -39,7 +39,7 @@ jobs:
       - name: Resolve dependencies (workspace)
         run: dart pub get
 
-      - name: Run observer game with conquest verification
+      - name: Run observer game with conquest and colonial verification
         run: |
           set -e
           out="${RUNNER_TEMP}/observer-conquest"
@@ -48,6 +48,6 @@ jobs:
           dart run run_observer_game \
             --output "$out" \
             --seed 42 \
-            --max-turns 100 \
-            --verify-conquest
-          # When --verify-colonial-expansion lands (#2509): --max-turns 150 and both flags.
+            --max-turns 150 \
+            --verify-conquest \
+            --verify-colonial-expansion

--- a/SPEC/ai/ai-architecture.md
+++ b/SPEC/ai/ai-architecture.md
@@ -88,6 +88,22 @@ Military victory requires a Great Power to control **≥31 Old World provinces**
 
 **Conquest army-move pass:** Uses `suggestArmyMoveOrders` with draft orders including any declare war chosen this turn; diplomacy filtering treats pending same-turn `declareWar` toward the destination owner as sufficient for invasion (logic `filterArmyMoveOrdersByDiplomacy` with `draftOrders`). Prefer destinations owned by the declare-war target, then other at-war owners, then provinces in `invadableProvinceIdsSorted`.
 
+### Colonial expansion (Full AI)
+
+New World province acquisition is a **supporting strategy** for the Old World military victory path (31 provinces per [victory.md](../game/victory.md)). Full AI pursues colonies and overseas extraction to fuel OW conquest; NW goals must **not** weaken OW victory-aware floors in `ai_victory_config.dart`.
+
+**Perception (`ColonialSummary` on `AIWorldSnapshot`):** From `PlayerView` only: `newWorldProvincesOwned`, `invadableNewWorldProvinceIdsSorted` (adjacent non-owned `newWorld|` provinces reachable from owned territory or army positions), `adjacentNewWorldOwnerFactionIdsSorted`, `preferredColonialTargetFactionIdsSorted` (war targets, weak neighbors, adjacent NW owners — stable sort). Topology walks use **`combinedTopology`** with `kNewWorldRegionId` (`newWorld`) the same way as Old World conquest lists.
+
+**Goal selection:** When `invadableNewWorldProvinceIdsSorted` is non-empty, deterministic bonuses to `expand` and `conquer` (`kColonialExpandBonusWhenInvadableNw`, `kColonialConquerBonusWhenInvadableNw`) without reducing `kMinimumConquerScoreWhenFarFromVictory` or other OW conquest floors.
+
+**Diplomacy:** Declare-war scoring adds `kDeclareWarColonialAdjacentTribeBonus` toward tribe/minor factions in `adjacentNewWorldOwnerFactionIdsSorted`. Colonial-adjacent targets are **not** suppressed by the OW-only non-adjacent declare-war guard when far from victory. `establishOverture` toward `preferredColonialTargetFactionIdsSorted` receives `kEstablishOvertureColonialTribeBonus`. Weight tuning only — no hard skip that removes all tribe declare-war candidates for intervention risk.
+
+**Military:** Conquest army-move pass scores destinations in `invadableNewWorldProvinceIdsSorted` with `kConquestArmyMoveNwInvadableBonus` in addition to OW invadable bonuses.
+
+**Economy / civilian:** Full AI Builder work selection prefers `build_improvement` on unimproved resource tiles (higher score when `improvementLevel` is 0 and the tile has a resource) before lexicographic fallback among other work targets.
+
+**Observer gates (nightly):** Seed **42**, turn **150**: all `newWorld|` provinces GP-owned; **≥70%** of extractable GP resource tiles improved (level ≥ 1). See [run_observer_game-tool.md](../program/run_observer_game-tool.md). Turn **100** OW per-GP conquest gate unchanged.
+
 **Diplomacy targeting:** Declare-war scoring adds a bonus toward weak-neighbor **Great Powers** when war desire is high (`ai_victory_config.dart`), so minors are not the only targets when GP neighbors are favorable. When `provincesToVictory > 20`, declare-war candidates also receive the full `conquerScoreBonusForProvincesToVictory` (not the quarter-scale used when nearer victory). Targets in `adjacentOwnerFactionIdsSorted` receive `kDeclareWarAdjacentOwnerBonus` (and an extra bonus for low-`warLikelihood` personalities) so trade-focused leaders declare on **reachable** minors/GPs instead of distant factions. When far from victory and `adjacentOwnerFactionIdsSorted` is non-empty, declare-war toward any other faction is suppressed. When far from victory, declare-war on **non-weak adjacent Great Powers** is suppressed (score 0) so trade-focused leaders prosecute adjacent **minors/tribes** instead of wars they cannot win. Weak adjacent GPs use `kDeclareWarGpMaxRelationWhenFarFromVictory` under the same victory-pace condition. Goal selection caps trade weight when far from victory and adds extra defend weight when at war with few Old World holdings. Build selection adds a regiment weight bonus when `provincesToVictory` exceeds the configured pace threshold and the primary goal is military.
 
 ### Implementation (turn pipeline)

--- a/SPEC/ai/ai-architecture.md
+++ b/SPEC/ai/ai-architecture.md
@@ -100,7 +100,11 @@ New World province acquisition is a **supporting strategy** for the Old World mi
 
 **Military:** Conquest army-move pass scores destinations in `invadableNewWorldProvinceIdsSorted` with `kConquestArmyMoveNwInvadableBonus` in addition to OW invadable bonuses.
 
-**Economy / civilian:** Full AI Builder work selection prefers `build_improvement` on unimproved resource tiles (higher score when `improvementLevel` is 0 and the tile has a resource) before lexicographic fallback among other work targets.
+**Economy / civilian:** Full AI Builder work selection prefers `build_improvement` on unimproved resource tiles (higher score when `improvementLevel` is 0 and the tile has a resource) before lexicographic fallback among other work targets. Merchant units prefer `purchase_land` in `newWorld|` tribe/minor provinces via scored selection. Civilian work runs when colonial invadable or adjacent NW owners exist even if economy weight is below the default threshold.
+
+**Economy (cargo):** `runEconomyPlanner` boosts effective economy weight for `cargoPreference` when colonial targets exist (`kColonialCargoPreferenceEconomyBoost`; extra when the GP owns zero NW provinces).
+
+**Naval:** `runNavalPlanner` adds `kColonialNavalWeightBonus` to naval domain weight when colonial invasion/colonization targets are visible, favouring fleets that enable overseas access.
 
 **Observer gates (nightly):** Seed **42**, turn **150**: all `newWorld|` provinces GP-owned; **≥70%** of extractable GP resource tiles improved (level ≥ 1). See [run_observer_game-tool.md](../program/run_observer_game-tool.md). Turn **100** OW per-GP conquest gate unchanged.
 

--- a/SPEC/ai/economy-planner.md
+++ b/SPEC/ai/economy-planner.md
@@ -68,6 +68,7 @@ Cargo capacity is the sum of **cargoHold** over ships in the **home fleet** at t
 ### When to prefer cargo
 
 - **Overseas extraction** — Player has meaningful overseas extraction (e.g. New World) that exceeds or is close to current cargo capacity → prefer bringing ships home to increase capacity next turn.
+- **Colonial expansion (Full AI)** — When `ColonialSummary` lists invadable or adjacent New World owners, effective economy weight receives `kColonialCargoPreferenceEconomyBoost` (and `kColonialCargoPreferenceNoNwColoniesBoost` when the GP owns zero NW provinces). See [ai-architecture.md](ai-architecture.md) § Colonial expansion.
 - **Economy goal / personality** — High economy domain weight or trade-oriented agenda → more likely to set `prefer_cargo` or `strong_cargo`.
 - **No urgent naval need** — When not at war or not blockading, favouring cargo is safer.
 

--- a/SPEC/program/run_observer_game-tool.md
+++ b/SPEC/program/run_observer_game-tool.md
@@ -19,6 +19,8 @@ melos run run_observer_game -- [options]
 | `--seed <int>` | Optional; matches `init_game` / `GameSetupConfig` semantics when omitted vs set. |
 | `--max-turns <int>` | Optional; default = campaign calendar cap turn **T** (`yearAtTurn(T)==1800` under game mapping; **201** for `gdd01`). Lower values shorten runs. |
 | `--config <path>` | Optional JSON `GameSetupConfig` consistent with **`init_game`**. |
+| `--verify-conquest` | After success: turn-1 vs turn-100 OW per-GP net +3 provinces (exit **5** on failure; requires `--max-turns >= 100` or no cap). |
+| `--verify-colonial-expansion` | After success: turn-150 snapshot checks NW GP ownership and extractable improvement ratio (exit **6** on failure; requires `--max-turns >= 150` or no cap). |
 
 **Errors:** Diagnostics via `logger`; user-facing failures → **stderr** and non-zero exit; no raw stack traces by default (match `init_game`).
 
@@ -30,13 +32,13 @@ Under `<output>/observer-traces/<gameId>/`:
 - Per turn (post-resolution): `turn-<zero-padded>.snapshot.json` and `turn-<zero-padded>.html` — **same canonical** `ObserverSnapshot` data; HTML is a render only.
 - End: `run-summary.json` — `termination_reason` (`military_victory` \| `calendar_1800` \| `max_turns_override` \| …), `declared_winner_player_id` or none per `SPEC/game/victory.md` / calendar-cap winner rules (`greatPowerPowerScore`, tie → **no-one** where specified), final turn, seed, paths to artifacts.
 
-## ObserverSnapshot (`ObserverSnapshot` v1)
+## ObserverSnapshot (`ObserverSnapshot` v2)
 
-Versioned map written to `turn-<nnnnnn>.snapshot.json` and embedded (escaped) in paired `turn-<nnnnnn>.html`. **`observerSnapshotSchemaVersion` is `1`.**
+Versioned map written to `turn-<nnnnnn>.snapshot.json` and embedded (escaped) in paired `turn-<nnnnnn>.html`. **`observerSnapshotSchemaVersion` is `2`.**
 
 | Field | Meaning |
 |-------|---------|
-| `observerSnapshotSchemaVersion` | Always `1` for this shape. |
+| `observerSnapshotSchemaVersion` | Always `2` for this shape (v1 lacked extraction rollups). |
 | `gameId` | Game id string. |
 | `turnNumber` | Post-resolution turn index (`Game.worldState.turnState.turnNumber`). |
 | `calendarYearAtTurnStart` | `yearAtTurn(turnNumber)` using the game's active `TurnTimeMapping` (if `turnNumber` is below 1, the lookup uses 1). |
@@ -46,6 +48,8 @@ Versioned map written to `turn-<nnnnnn>.snapshot.json` and embedded (escaped) in
 | `diplomacyRelationSummariesSorted` | Stable string lines summarizing each `diplomacyRelations` row (pair, score, level, war/peace). |
 | `militaryArmySummariesSorted` | One string per land army (id, owner, region, regiment count). |
 | `militaryFleetSummariesSorted` | One string per fleet (id, owner, ship count). |
+| `extractableResourceTileCount` | Count of extractable resource tiles on GP-owned land at snapshot time (see § Extractable tile definition). |
+| `improvedExtractableResourceTileCount` | Subset of the above with `improvementLevel >= 1`. |
 
 HTML is a render-only wrapper: the `<pre>` body uses the **same** pretty-printed JSON bytes as the `.snapshot.json` file (after `HtmlEscape`).
 
@@ -57,7 +61,18 @@ HTML is a render-only wrapper: the `<pre>` body uses the **same** pretty-printed
 
 ## Conquest regression verification (Refs #2504)
 
-`lib/observer_conquest_verify.dart` compares `turn-000001.snapshot.json` vs `turn-000100.snapshot.json` under a game trace directory: each Great Power `gp1`–`gp6` must gain **≥3** net **Old World** provinces (`oldWorld|…` ids only). Canonical seed **42**, **100** resolved turns. Pass **`--verify-conquest`** after a successful run to execute this check (exit **5** on failure; requires `--max-turns >= 100` or no turn cap). Unit tests cover the parser; a full observer run is slow (~minutes) and is not part of the default quality gate. **Nightly:** `.github/workflows/nightly.yml` job `observer_conquest_verify` runs seed **42**, **100** turns, and `--verify-conquest` daily at **23:00 Asia/Hong_Kong** (`workflow_dispatch` supported). When `--verify-colonial-expansion` lands (#2509), extend that job to **150** turns and both verify flags.
+`lib/observer_conquest_verify.dart` compares `turn-000001.snapshot.json` vs `turn-000100.snapshot.json` under a game trace directory: each Great Power `gp1`–`gp6` must gain **≥3** net **Old World** provinces (`oldWorld|…` ids only). Canonical seed **42**, **100** resolved turns. Pass **`--verify-conquest`** after a successful run (exit **5** on failure).
+
+## Colonial expansion verification (Refs #2509)
+
+`lib/observer_colonial_verify.dart` reads `turn-000150.snapshot.json`:
+
+- **Global NW ownership:** every `provinceOwnershipSorted` row with id prefix `newWorld|` has `ownerId` ∈ `{gp1,…,gp6}`.
+- **Improvement coverage:** `improvedExtractableResourceTileCount / extractableResourceTileCount >= 0.70` (if denominator is **0**, pass only when both counts are zero).
+
+Pass **`--verify-colonial-expansion`** after a successful run (exit **6** on failure; requires `--max-turns >= 150` or no turn cap). Rollup computation: `lib/observer_extractable_rollup.dart` (init static resource grid ∩ GP-owned provinces at verify turn; excludes capital and province town tiles per [extraction-and-improvements.md](../game/extraction-and-improvements.md)).
+
+Unit tests cover parsers; full observer runs are slow and are **not** in the default `quality` gate. **Nightly:** `.github/workflows/nightly.yml` job `observer_conquest_verify` runs seed **42**, **150** turns, **`--verify-conquest`**, and **`--verify-colonial-expansion`** daily at **23:00 Asia/Hong_Kong** (`0 15 * * *` UTC; `workflow_dispatch` supported).
 
 ## Coverage
 

--- a/packages/colonizethis_ai/lib/src/perception/perception_snapshot.dart
+++ b/packages/colonizethis_ai/lib/src/perception/perception_snapshot.dart
@@ -52,6 +52,21 @@ class ConquestSummary {
   final List<String> adjacentOwnerFactionIdsSorted;
 }
 
+/// New World colonial pace from PlayerView. SPEC/ai/ai-architecture.md § Colonial expansion.
+class ColonialSummary {
+  const ColonialSummary({
+    this.newWorldProvincesOwned = 0,
+    this.invadableNewWorldProvinceIdsSorted = const [],
+    this.adjacentNewWorldOwnerFactionIdsSorted = const [],
+    this.preferredColonialTargetFactionIdsSorted = const [],
+  });
+
+  final int newWorldProvincesOwned;
+  final List<String> invadableNewWorldProvinceIdsSorted;
+  final List<String> adjacentNewWorldOwnerFactionIdsSorted;
+  final List<String> preferredColonialTargetFactionIdsSorted;
+}
+
 /// Economy summary from view (stockpile, workers, treasury).
 class EconomySummary {
   const EconomySummary({
@@ -73,6 +88,7 @@ class AIWorldSnapshot {
     required this.threats,
     required this.opportunities,
     required this.conquest,
+    this.colonial = const ColonialSummary(),
     required this.economy,
     required this.relations,
   });
@@ -81,6 +97,7 @@ class AIWorldSnapshot {
   final ThreatSummary threats;
   final OpportunitySummary opportunities;
   final ConquestSummary conquest;
+  final ColonialSummary colonial;
   final EconomySummary economy;
 
   /// Relation state keyed by other faction id (war, peace, etc.).
@@ -94,12 +111,14 @@ class AIWorldSnapshot {
     final threats = _buildThreatSummary(view, topology);
     final opportunities = _buildOpportunitySummary(view, topology);
     final conquest = _buildConquestSummary(view, topology, threats, opportunities);
+    final colonial = _buildColonialSummary(view, topology, threats, opportunities);
     final economy = _buildEconomySummary(view);
     final snapshot = AIWorldSnapshot(
       playerId: view.playerId,
       threats: threats,
       opportunities: opportunities,
       conquest: conquest,
+      colonial: colonial,
       economy: economy,
       relations: Map<String, DiplomacyRelation>.from(view.diplomacyByOtherId),
     );
@@ -114,6 +133,7 @@ class AIWorldSnapshot {
       'oldWorldProvincesOwned=${snapshot.conquest.oldWorldProvincesOwned} '
       'provincesToVictory=${snapshot.conquest.provincesToVictory} '
       'invadableCount=${snapshot.conquest.invadableProvinceIdsSorted.length} '
+      'nwInvadableCount=${snapshot.colonial.invadableNewWorldProvinceIdsSorted.length} '
       'workerCount=${snapshot.economy.workerCount} '
       'treasury=${snapshot.economy.treasury} '
       'ownProvinceCount=${snapshot.economy.ownProvinceCount} '
@@ -271,9 +291,61 @@ class AIWorldSnapshot {
     );
   }
 
+  static ColonialSummary _buildColonialSummary(
+    PlayerView view,
+    MapTopology? topology,
+    ThreatSummary threats,
+    OpportunitySummary opportunities,
+  ) {
+    var nwOwned = 0;
+    for (final p in view.provincesById.entries) {
+      if (p.value.ownerId != view.playerId) continue;
+      if (ProvinceId.regionIdFrom(p.key) != kNewWorldRegionId) continue;
+      nwOwned++;
+    }
+    final invadable = topology == null
+        ? <String>[]
+        : _invadableProvinceIdsForRegion(
+            view,
+            topology,
+            kNewWorldRegionId,
+          );
+    final adjacentOwners = topology == null
+        ? <String>[]
+        : _adjacentOwnerFactionIdsForRegion(
+            view,
+            topology,
+            kNewWorldRegionId,
+          );
+    final preferredTargets = <String>{
+      ...threats.atWarWith,
+      ...opportunities.weakNeighbors,
+      ...adjacentOwners,
+    }.toList()
+      ..sort();
+    return ColonialSummary(
+      newWorldProvincesOwned: nwOwned,
+      invadableNewWorldProvinceIdsSorted: invadable,
+      adjacentNewWorldOwnerFactionIdsSorted: adjacentOwners,
+      preferredColonialTargetFactionIdsSorted: preferredTargets,
+    );
+  }
+
   static List<String> _adjacentOwnerFactionIdsSorted(
     PlayerView view,
     MapTopology topology,
+  ) {
+    return _adjacentOwnerFactionIdsForRegion(
+      view,
+      topology,
+      kOldWorldRegionId,
+    );
+  }
+
+  static List<String> _adjacentOwnerFactionIdsForRegion(
+    PlayerView view,
+    MapTopology topology,
+    String regionId,
   ) {
     final anchorProvinces = <String>{};
     for (final p in view.provincesById.entries) {
@@ -288,7 +360,7 @@ class AIWorldSnapshot {
     );
     final owners = <String>{};
     for (final fullId in neighbors) {
-      if (ProvinceId.regionIdFrom(fullId) != kOldWorldRegionId) continue;
+      if (ProvinceId.regionIdFrom(fullId) != regionId) continue;
       final ownerId = view.provincesById[fullId]?.ownerId;
       if (ownerId == null ||
           ownerId.isEmpty ||
@@ -304,6 +376,14 @@ class AIWorldSnapshot {
   static List<String> _invadableOldWorldProvinceIds(
     PlayerView view,
     MapTopology topology,
+  ) {
+    return _invadableProvinceIdsForRegion(view, topology, kOldWorldRegionId);
+  }
+
+  static List<String> _invadableProvinceIdsForRegion(
+    PlayerView view,
+    MapTopology topology,
+    String regionId,
   ) {
     final anchorProvinces = <String>{};
     for (final p in view.provincesById.entries) {
@@ -322,7 +402,7 @@ class AIWorldSnapshot {
     );
     final invadable = <String>[];
     for (final fullId in neighbors) {
-      if (ProvinceId.regionIdFrom(fullId) != kOldWorldRegionId) continue;
+      if (ProvinceId.regionIdFrom(fullId) != regionId) continue;
       final prov = view.provincesById[fullId];
       if (prov == null) continue;
       final ownerId = prov.ownerId;

--- a/packages/colonizethis_ai/lib/src/planning/conquest_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/conquest_planner.dart
@@ -65,7 +65,10 @@ Orders runConquestArmyMovePlanner({
     return orders;
   }
   final provinceOwner = getProvinceOwnerMap(game);
-  final invadable = snapshot.conquest.invadableProvinceIdsSorted.toSet();
+  final invadable = {
+    ...snapshot.conquest.invadableProvinceIdsSorted,
+    ...snapshot.colonial.invadableNewWorldProvinceIdsSorted,
+  };
   final scores = filtered.map((m) {
     final destOwner = provinceOwner[m.destinationProvinceId] ?? '';
     var score = 1.0;
@@ -80,6 +83,10 @@ Orders runConquestArmyMovePlanner({
     }
     if (invadable.contains(m.destinationProvinceId)) {
       score += 10;
+    }
+    if (snapshot.colonial.invadableNewWorldProvinceIdsSorted
+        .contains(m.destinationProvinceId)) {
+      score += kConquestArmyMoveNwInvadableBonus;
     }
     if (snapshot.conquest.adjacentOwnerFactionIdsSorted.contains(destOwner)) {
       score += 8;

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring.dart
@@ -66,10 +66,15 @@ List<int> computeDiplomaticCandidateScores({
           final rel = snapshot.relations[o.targetFactionId];
           final relationScore = rel?.score ?? 50;
           final adjacentOwners = snapshot.conquest.adjacentOwnerFactionIdsSorted;
+          final colonialAdjacent =
+              snapshot.colonial.adjacentNewWorldOwnerFactionIdsSorted;
           final isAdjacentOwner = adjacentOwners.contains(o.targetFactionId);
+          final isColonialAdjacentOwner =
+              colonialAdjacent.contains(o.targetFactionId);
           if (behindVictoryPace &&
               adjacentOwners.isNotEmpty &&
-              !isAdjacentOwner) {
+              !isAdjacentOwner &&
+              !isColonialAdjacentOwner) {
             s = kDeclareWarNonAdjacentSuppressedScore;
             break;
           }
@@ -130,6 +135,9 @@ List<int> computeDiplomaticCandidateScores({
                 .contains(o.targetFactionId)) {
               s += 15;
             }
+            if (isColonialAdjacentOwner && isMinorTarget) {
+              s += kDeclareWarColonialAdjacentTribeBonus;
+            }
             if (isAdjacentOwner) {
               s += kDeclareWarAdjacentOwnerBonus;
               if (behindVictoryPace && isMinorTarget) {
@@ -187,6 +195,10 @@ List<int> computeDiplomaticCandidateScores({
           );
           final improveRelationsDesire = 100 - warDesire;
           s += (improveRelationsDesire - 50);
+          if (snapshot.colonial.preferredColonialTargetFactionIdsSorted
+              .contains(o.targetFactionId)) {
+            s += kEstablishOvertureColonialTribeBonus;
+          }
           break;
         }
       default:

--- a/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
+++ b/packages/colonizethis_ai/lib/src/planning/domain_planner_orchestrator.dart
@@ -97,7 +97,9 @@ DomainPlannerOutcome runDomainPlannersWithOutcome({
       40 - (hasSpyWork ? getAgendaSpyOrderModifier(config.hiddenAgendaId) : 0);
   final runFullAiCivilianWork =
       primaryGoal == StrategicGoal.expand ||
-      domainWeights.economy >= workThreshold;
+      domainWeights.economy >= workThreshold ||
+      snapshot.colonial.invadableNewWorldProvinceIdsSorted.isNotEmpty ||
+      snapshot.colonial.adjacentNewWorldOwnerFactionIdsSorted.isNotEmpty;
   _log.d(
     'work eval nationId=$nationId workThreshold=$workThreshold '
     'domainWeights.economy=${domainWeights.economy} primaryGoal=$primaryGoal '
@@ -228,6 +230,7 @@ DomainPlannerOutcome runDomainPlannersWithOutcome({
     primaryGoal: primaryGoal,
     seeds: seeds,
     suggestionAPI: suggestionAPI,
+    colonial: snapshot.colonial,
   );
   emit('aiStageE');
 

--- a/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/economy_planner.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_ai/package_logger.dart';
 import 'package:colonizethis_logic/ai_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../perception/perception_snapshot.dart';
 import 'recipe_scoring.dart';
 
 final _log = packageLogger('economy_planner');
@@ -17,6 +18,7 @@ EconomyPlan runEconomyPlanner({
   required PlayerView view,
   required AIConfig config,
   required AISeedBundle seeds,
+  ColonialSummary colonial = const ColonialSummary(),
 }) {
   final player = game.playerById(view.playerId);
   if (player == null) {
@@ -44,7 +46,12 @@ EconomyPlan runEconomyPlanner({
   if (effectiveLabour <= 0) {
     return EconomyPlan(
       productionAssignments: [],
-      cargoPreference: _cargoPreference(game, view.playerId, config),
+      cargoPreference: _cargoPreference(
+        game,
+        view.playerId,
+        config,
+        colonial: colonial,
+      ),
     );
   }
 
@@ -56,7 +63,12 @@ EconomyPlan runEconomyPlanner({
     seeds: seeds,
   );
 
-  final cargoPref = _cargoPreference(game, view.playerId, config);
+  final cargoPref = _cargoPreference(
+    game,
+    view.playerId,
+    config,
+    colonial: colonial,
+  );
   _log.i(
     'economy plan playerId=${view.playerId} '
     'cargoPreference=$cargoPref productionAssignmentsCount=${assignments.length}',
@@ -67,11 +79,24 @@ EconomyPlan runEconomyPlanner({
   );
 }
 
-CargoPreference _cargoPreference(Game game, String playerId, AIConfig config) {
+CargoPreference _cargoPreference(
+  Game game,
+  String playerId,
+  AIConfig config, {
+  ColonialSummary colonial = const ColonialSummary(),
+}) {
   final domainWeights = getDomainWeightsForLeader(config.personalityId);
   final agendaId = config.hiddenAgendaId;
   // Trade-oriented agendas/personalities favour cargo.
-  final economyWeight = domainWeights.economy;
+  var economyWeight = domainWeights.economy;
+  if (colonial.invadableNewWorldProvinceIdsSorted.isNotEmpty ||
+      colonial.adjacentNewWorldOwnerFactionIdsSorted.isNotEmpty) {
+    economyWeight += kColonialCargoPreferenceEconomyBoost;
+  }
+  if (colonial.newWorldProvincesOwned == 0 &&
+      colonial.adjacentNewWorldOwnerFactionIdsSorted.isNotEmpty) {
+    economyWeight += kColonialCargoPreferenceNoNwColoniesBoost;
+  }
   if (economyWeight < 30) {
     _log.d('cargoPreference none economyWeight=$economyWeight');
     return CargoPreference.none;

--- a/packages/colonizethis_ai/lib/src/planning/goal_manager.dart
+++ b/packages/colonizethis_ai/lib/src/planning/goal_manager.dart
@@ -66,6 +66,10 @@ Map<StrategicGoal, int> evaluateStrategicGoalScores(
   if (snapshot.conquest.invadableProvinceIdsSorted.isNotEmpty) {
     expand += kExpandBonusWhenInvadableProvinces;
   }
+  if (snapshot.colonial.invadableNewWorldProvinceIdsSorted.isNotEmpty) {
+    expand += kColonialExpandBonusWhenInvadableNw;
+    conquer += kColonialConquerBonusWhenInvadableNw;
+  }
   if (provincesToVictory > kConquerScoreFloorProvincesToVictoryThreshold &&
       conquer < kMinimumConquerScoreWhenFarFromVictory) {
     conquer = kMinimumConquerScoreWhenFarFromVictory;

--- a/packages/colonizethis_ai/lib/src/planning/naval_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/naval_planner.dart
@@ -7,6 +7,7 @@ import 'package:colonizethis_logic/order_suggestion_api.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'goal_manager.dart';
+import '../perception/perception_snapshot.dart';
 import '../util/orders_extensions.dart';
 
 final _log = packageLogger();
@@ -21,14 +22,19 @@ Orders runNavalPlanner({
   required StrategicGoal primaryGoal,
   required AISeedBundle seeds,
   required OrderSuggestionAPI suggestionAPI,
+  ColonialSummary colonial = const ColonialSummary(),
 }) {
   final domainWeights = getDomainWeightsForLeader(config.personalityId);
-  final weight =
+  var weight =
       primaryGoal == StrategicGoal.conquer ||
           primaryGoal == StrategicGoal.defend ||
           primaryGoal == StrategicGoal.expand
       ? domainWeights.military
       : 40;
+  if (colonial.invadableNewWorldProvinceIdsSorted.isNotEmpty ||
+      colonial.adjacentNewWorldOwnerFactionIdsSorted.isNotEmpty) {
+    weight += kColonialNavalWeightBonus;
+  }
   if (weight < 25) {
     _log.d('naval skipped nationId=$nationId weight=$weight < 25');
     return orders;

--- a/packages/colonizethis_ai/lib/src/planning/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/planning/strategic_ai.dart
@@ -96,6 +96,7 @@ StrategicOrderTraceResult generateStrategicOrdersWithTrace({
     view: view,
     config: config,
     seeds: seeds,
+    colonial: snapshot.colonial,
   );
   final plannerOutcome = runDomainPlannersWithOutcome(
     game: planningGame,

--- a/packages/colonizethis_ai/test/diplomatic_candidate_scoring_test.dart
+++ b/packages/colonizethis_ai/test/diplomatic_candidate_scoring_test.dart
@@ -666,5 +666,61 @@ void main() {
         expect(gpScore, kDeclareWarNonAdjacentSuppressedScore);
       },
     );
+
+    test(
+      'colonial-adjacent tribe declareWar is not suppressed when only OW-adjacent list is empty',
+      () {
+        const snap = AIWorldSnapshot(
+          playerId: 'gp1',
+          threats: ThreatSummary(),
+          opportunities: OpportunitySummary(),
+          conquest: ConquestSummary(
+            provincesToVictory: 24,
+            adjacentOwnerFactionIdsSorted: [],
+          ),
+          colonial: ColonialSummary(
+            adjacentNewWorldOwnerFactionIdsSorted: ['tribe1'],
+          ),
+          economy: EconomySummary(),
+          relations: {},
+        );
+        final game = Game(
+          id: 'g-colonial-tribe',
+          worldState: WorldState(
+            turnState: const TurnState(
+              phase: TurnPhase.orders,
+              turnNumber: 1,
+            ),
+            oldWorld: const RegionData(),
+            newWorld: const RegionData(),
+          ),
+          players: const [
+            Player(id: 'gp1', displayName: 'A', isHuman: false),
+          ],
+          tribes: const [
+            Tribe(id: 'tribe1', displayName: 'T1'),
+          ],
+        );
+        const config = AIConfig(
+          leaderId: 'henry',
+          personalityId: 'henry',
+          hiddenAgendaId: 'merchant',
+        );
+        final score = computeDiplomaticCandidateScores(
+          candidates: const [
+            DiplomaticOrder(
+              type: DiplomaticOrderType.declareWar,
+              targetFactionId: 'tribe1',
+            ),
+          ],
+          nationId: 'gp1',
+          game: game,
+          snapshot: snap,
+          config: config,
+        ).single;
+        expect(score, greaterThan(0));
+        expect(score, greaterThanOrEqualTo(kDeclareWarColonialAdjacentTribeBonus));
+      },
+    );
   });
 }

--- a/packages/colonizethis_ai/test/economy_planner_test.dart
+++ b/packages/colonizethis_ai/test/economy_planner_test.dart
@@ -214,5 +214,61 @@ void main() {
         reason: 'high economy leader should prefer cargo at least as much as warmonger',
       );
     });
+
+    test('colonial summary boosts cargo preference for overseas expansion', () {
+      final game = Game(
+        id: 'g1',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 0),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(
+            id: 'gp1',
+            displayName: 'France',
+            isHuman: false,
+            stockpile: Stockpile(),
+            workerPool: WorkerPool(peasants: 0),
+          ),
+        ],
+      );
+      const topology = MapTopology(nodes: [], edges: []);
+      final view = buildPlayerView(game, topology, 'gp1');
+      const config = AIConfig(
+        leaderId: 'napoleon',
+        personalityId: 'napoleon',
+        hiddenAgendaId: 'warmonger',
+      );
+      final seeds = AISeedBundle.fromTurnSeed(7);
+
+      int cargoLevel(CargoPreference p) => p == CargoPreference.strongCargo
+          ? 2
+          : p == CargoPreference.preferCargo
+          ? 1
+          : 0;
+
+      final baseline = runEconomyPlanner(
+        game: game,
+        view: view,
+        config: config,
+        seeds: seeds,
+      );
+      final colonial = runEconomyPlanner(
+        game: game,
+        view: view,
+        config: config,
+        seeds: seeds,
+        colonial: const ColonialSummary(
+          invadableNewWorldProvinceIdsSorted: ['newWorld|colony'],
+          adjacentNewWorldOwnerFactionIdsSorted: ['tribe1'],
+        ),
+      );
+
+      expect(
+        cargoLevel(colonial.cargoPreference),
+        greaterThan(cargoLevel(baseline.cargoPreference)),
+      );
+    });
   });
 }

--- a/packages/colonizethis_ai/test/perception_colonial_summary_test.dart
+++ b/packages/colonizethis_ai/test/perception_colonial_summary_test.dart
@@ -1,0 +1,64 @@
+import 'package:colonizethis_ai/colonizethis_ai.dart';
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+import 'package:colonizethis_test/test.dart';
+
+void main() {
+  test('fromPlayerView lists adjacent New World tribe provinces as invadable', () {
+    const topology = MapTopology(
+      nodes: [
+        TopologyNode(id: 'oldWorld|home', regionId: 'oldWorld', type: TopologyNodeType.province),
+        TopologyNode(id: 'newWorld|colony', regionId: 'newWorld', type: TopologyNodeType.province),
+      ],
+      edges: [
+        TopologyEdge(id1: 'oldWorld|home', id2: 'newWorld|colony'),
+      ],
+    );
+    final game = Game(
+      id: 'g1',
+      worldState: WorldState(
+        turnState: const TurnState(
+          phase: TurnPhase.orders,
+          turnNumber: 1,
+        ),
+        oldWorld: const RegionData(
+          provinces: [
+            Province(
+              id: 'oldWorld|home',
+              regionId: 'oldWorld',
+              ownerId: 'gp1',
+            ),
+          ],
+        ),
+        newWorld: const RegionData(
+          provinces: [
+            Province(
+              id: 'newWorld|colony',
+              regionId: 'newWorld',
+              ownerId: 'tribe1',
+            ),
+          ],
+        ),
+      ),
+      players: const [
+        Player(id: 'gp1', displayName: 'GP1', isHuman: false),
+      ],
+      tribes: const [
+        Tribe(id: 'tribe1', displayName: 'Tribe'),
+      ],
+    );
+    final view = buildPlayerView(game, topology, 'gp1');
+    final snapshot = AIWorldSnapshot.fromPlayerView(view, topology: topology);
+
+    expect(snapshot.colonial.newWorldProvincesOwned, 0);
+    expect(
+      snapshot.colonial.invadableNewWorldProvinceIdsSorted,
+      ['newWorld|colony'],
+    );
+    expect(
+      snapshot.colonial.adjacentNewWorldOwnerFactionIdsSorted,
+      ['tribe1'],
+    );
+  });
+}

--- a/packages/colonizethis_data/lib/src/ai_victory_config.dart
+++ b/packages/colonizethis_data/lib/src/ai_victory_config.dart
@@ -96,16 +96,25 @@ const int kDefendBonusWhenAtWarAndFewHoldings = 45;
 const int kFewOldWorldProvincesDefendThreshold = 6;
 
 /// Expand-goal bonus when invadable New World tribe/minor provinces exist.
-const int kColonialExpandBonusWhenInvadableNw = 12;
+const int kColonialExpandBonusWhenInvadableNw = 18;
 
 /// Conquer-goal bonus for colonial pressure (below OW victory floors).
-const int kColonialConquerBonusWhenInvadableNw = 8;
+const int kColonialConquerBonusWhenInvadableNw = 14;
 
 /// Declare-war bonus toward a tribe/minor that owns adjacent New World provinces.
-const int kDeclareWarColonialAdjacentTribeBonus = 32;
+const int kDeclareWarColonialAdjacentTribeBonus = 40;
 
 /// Establish-overture bonus toward a preferred colonial tribe target.
-const int kEstablishOvertureColonialTribeBonus = 28;
+const int kEstablishOvertureColonialTribeBonus = 35;
 
 /// Conquest army-move bonus for New World invadable destinations.
-const int kConquestArmyMoveNwInvadableBonus = 12;
+const int kConquestArmyMoveNwInvadableBonus = 18;
+
+/// Economy-domain weight boost for cargo preference when colonial targets exist.
+const int kColonialCargoPreferenceEconomyBoost = 28;
+
+/// Extra cargo boost when the GP owns no New World provinces yet.
+const int kColonialCargoPreferenceNoNwColoniesBoost = 12;
+
+/// Naval planner weight boost when New World invasion/colonization is viable.
+const int kColonialNavalWeightBonus = 22;

--- a/packages/colonizethis_data/lib/src/ai_victory_config.dart
+++ b/packages/colonizethis_data/lib/src/ai_victory_config.dart
@@ -7,6 +7,9 @@ const int kMilitaryVictoryOldWorldProvinceThreshold = 31;
 /// Region id for Old World provinces (prefixed `oldWorld|…`).
 const String kOldWorldRegionId = 'oldWorld';
 
+/// Region id for New World provinces (prefixed `newWorld|…`).
+const String kNewWorldRegionId = 'newWorld';
+
 /// Provinces still needed to reach military victory from [oldWorldOwned].
 int provincesToVictoryFromOldWorldOwned(int oldWorldOwned) {
   final gap =
@@ -91,3 +94,18 @@ const int kDefendBonusWhenAtWarAndFewHoldings = 45;
 
 /// Old World province count at or below which [kDefendBonusWhenFewOldWorldProvinces] applies.
 const int kFewOldWorldProvincesDefendThreshold = 6;
+
+/// Expand-goal bonus when invadable New World tribe/minor provinces exist.
+const int kColonialExpandBonusWhenInvadableNw = 12;
+
+/// Conquer-goal bonus for colonial pressure (below OW victory floors).
+const int kColonialConquerBonusWhenInvadableNw = 8;
+
+/// Declare-war bonus toward a tribe/minor that owns adjacent New World provinces.
+const int kDeclareWarColonialAdjacentTribeBonus = 32;
+
+/// Establish-overture bonus toward a preferred colonial tribe target.
+const int kEstablishOvertureColonialTribeBonus = 28;
+
+/// Conquest army-move bonus for New World invadable destinations.
+const int kConquestArmyMoveNwInvadableBonus = 12;

--- a/packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart
+++ b/packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart
@@ -379,6 +379,50 @@ WorkOrder? _bestBuildImprovementRow(List<WorkOrder> candidates, Game game) {
   return best;
 }
 
+int _purchaseLandWorkScore(
+  WorkOrder w,
+  Game game,
+  DiplomacyFactionMembership factionMembership,
+) {
+  if (w.target != kWorkTargetPurchaseLand) return 0;
+  final provId = Unit.provinceIdFromTileKey(w.targetTileKey);
+  if (provId == null || provId.isEmpty) return 1;
+  if (ProvinceId.regionIdFrom(provId) == kNewWorldRegionId) {
+    final ownerId = tryGetProvince(game.worldState, provId)?.ownerId;
+    if (ownerId != null &&
+        isMinorOrTribe(game, ownerId, factionMembership: factionMembership)) {
+      return 240;
+    }
+    return 120;
+  }
+  return 60;
+}
+
+WorkOrder? _bestPurchaseLandRow(
+  List<WorkOrder> candidates,
+  Game game,
+  DiplomacyFactionMembership factionMembership,
+) {
+  final purchases =
+      candidates.where((w) => w.target == kWorkTargetPurchaseLand).toList();
+  if (purchases.isEmpty) return null;
+  var best = purchases.first;
+  var bestScore = _purchaseLandWorkScore(best, game, factionMembership);
+  for (var i = 1; i < purchases.length; i++) {
+    final w = purchases[i];
+    final s = _purchaseLandWorkScore(w, game, factionMembership);
+    if (s > bestScore) {
+      bestScore = s;
+      best = w;
+      continue;
+    }
+    if (s == bestScore && _compareWorkOrderLex(w, best) < 0) {
+      best = w;
+    }
+  }
+  return best;
+}
+
 void _appendBuilderPathResult({
   required Unit? unit,
   required List<WorkOrder> w,
@@ -387,6 +431,30 @@ void _appendBuilderPathResult({
   required List<FullAiCivilianWorkIdle> idleEvents,
 }) {
   final chosen = _bestBuildImprovementRow(w, game) ?? _pickLexicographic(w);
+  if (chosen != null) {
+    workOrders.add(chosen);
+    return;
+  }
+  if (unit == null) return;
+  idleEvents.add(
+    FullAiCivilianWorkIdle(
+      unitId: unit.id,
+      unitType: unit.type,
+      reason: 'no_suggestions',
+    ),
+  );
+}
+
+void _appendMerchantPathResult({
+  required Unit? unit,
+  required List<WorkOrder> w,
+  required Game game,
+  required DiplomacyFactionMembership factionMembership,
+  required List<WorkOrder> workOrders,
+  required List<FullAiCivilianWorkIdle> idleEvents,
+}) {
+  final chosen =
+      _bestPurchaseLandRow(w, game, factionMembership) ?? _pickLexicographic(w);
   if (chosen != null) {
     workOrders.add(chosen);
     return;
@@ -529,6 +597,18 @@ void _appendSelectionForUnitId({
       unit: unit,
       w: W,
       game: game,
+      workOrders: workOrders,
+      idleEvents: idleEvents,
+    );
+    return;
+  }
+
+  if (unit != null && isMerchantUnit(unit.type)) {
+    _appendMerchantPathResult(
+      unit: unit,
+      w: W,
+      game: game,
+      factionMembership: factionMembership,
       workOrders: workOrders,
       idleEvents: idleEvents,
     );

--- a/packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart
+++ b/packages/colonizethis_logic/lib/src/ai/full_ai_civilian_work_selection.dart
@@ -348,6 +348,59 @@ WorkOrder? _pickExplorerCandidateSet(
   return bestE;
 }
 
+int _buildImprovementWorkScore(WorkOrder w, Game game) {
+  if (w.target != kWorkTargetBuildImprovement) return 0;
+  final level = game.worldState.tileState.improvementLevel(w.targetTileKey);
+  if (level >= 1) return 1;
+  final resourceId = game.worldState.resourceByTileKey[w.targetTileKey];
+  if (resourceId == null || resourceId.isEmpty) return 2;
+  return 200;
+}
+
+WorkOrder? _bestBuildImprovementRow(List<WorkOrder> candidates, Game game) {
+  final improvements = candidates
+      .where((w) => w.target == kWorkTargetBuildImprovement)
+      .toList();
+  if (improvements.isEmpty) return null;
+  var best = improvements.first;
+  var bestScore = _buildImprovementWorkScore(best, game);
+  for (var i = 1; i < improvements.length; i++) {
+    final w = improvements[i];
+    final s = _buildImprovementWorkScore(w, game);
+    if (s > bestScore) {
+      bestScore = s;
+      best = w;
+      continue;
+    }
+    if (s == bestScore && _compareWorkOrderLex(w, best) < 0) {
+      best = w;
+    }
+  }
+  return best;
+}
+
+void _appendBuilderPathResult({
+  required Unit? unit,
+  required List<WorkOrder> w,
+  required Game game,
+  required List<WorkOrder> workOrders,
+  required List<FullAiCivilianWorkIdle> idleEvents,
+}) {
+  final chosen = _bestBuildImprovementRow(w, game) ?? _pickLexicographic(w);
+  if (chosen != null) {
+    workOrders.add(chosen);
+    return;
+  }
+  if (unit == null) return;
+  idleEvents.add(
+    FullAiCivilianWorkIdle(
+      unitId: unit.id,
+      unitType: unit.type,
+      reason: 'no_suggestions',
+    ),
+  );
+}
+
 WorkOrder? _pickLexicographic(List<WorkOrder> w) {
   if (w.isEmpty) return null;
   final copy = List<WorkOrder>.from(w)..sort(_compareWorkOrderLex);
@@ -465,6 +518,17 @@ void _appendSelectionForUnitId({
       playerId: view.playerId,
       tileMapByRegion: tileMapByRegion,
       factionMembership: factionMembership,
+      workOrders: workOrders,
+      idleEvents: idleEvents,
+    );
+    return;
+  }
+
+  if (unit != null && unit.type == kUnitTypeBuilder) {
+    _appendBuilderPathResult(
+      unit: unit,
+      w: W,
+      game: game,
       workOrders: workOrders,
       idleEvents: idleEvents,
     );

--- a/packages/colonizethis_logic/test/full_ai_civilian_work_selection_test.dart
+++ b/packages/colonizethis_logic/test/full_ai_civilian_work_selection_test.dart
@@ -61,6 +61,57 @@ void main() {
       },
     );
 
+    test('Builder prefers unimproved resource tile over lexicographically smaller road', () {
+      const playerId = 'gp1';
+      const tileRoad = 'oldWorld|p1|0|0';
+      const tileResource = 'oldWorld|p1|1|0';
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: const RegionData(),
+          resourceByTileKey: {tileResource: 'grain'},
+        ),
+        players: const [
+          Player(id: playerId, displayName: 'GP', isHuman: false),
+        ],
+      );
+      final view = PlayerView(
+        playerId: playerId,
+        player: game.players.single,
+        ownUnitsById: {
+          'b1': Unit(
+            id: 'b1',
+            type: kUnitTypeBuilder,
+            ownerId: playerId,
+            locationProvinceId: 'oldWorld|p1',
+          ),
+        },
+        provincesById: const {},
+        visibilityByTile: const {},
+        prospectedTiles: const {},
+        diplomacyByOtherId: const {},
+      );
+      final r = selectFullAiCivilianWorkOrders(
+        workSuggestions: [
+          const WorkOrder(
+            unitId: 'b1',
+            target: kWorkTargetBuildRoad,
+            targetTileKey: tileRoad,
+          ),
+          const WorkOrder(
+            unitId: 'b1',
+            target: kWorkTargetBuildImprovement,
+            targetTileKey: tileResource,
+          ),
+        ],
+        view: view,
+        game: game,
+      );
+      expect(r.workOrders.single.targetTileKey, tileResource);
+    });
+
     test(
       'Explorer with two equal E_score explores picks lexicographically smaller tile',
       () {

--- a/packages/colonizethis_logic/test/full_ai_civilian_work_selection_test.dart
+++ b/packages/colonizethis_logic/test/full_ai_civilian_work_selection_test.dart
@@ -61,6 +61,65 @@ void main() {
       },
     );
 
+    test('Merchant prefers purchase_land in newWorld tribe province', () {
+      const playerId = 'gp1';
+      const nwTile = 'newWorld|tribeProv|2|3';
+      final game = Game(
+        id: 'g',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 1),
+          oldWorld: const RegionData(),
+          newWorld: RegionData(
+            provinces: [
+              Province(
+                id: 'newWorld|tribeProv',
+                regionId: 'newWorld',
+                ownerId: 'tribe1',
+              ),
+            ],
+          ),
+        ),
+        players: const [
+          Player(id: playerId, displayName: 'GP', isHuman: false),
+        ],
+        tribes: const [Tribe(id: 'tribe1', displayName: 'T')],
+      );
+      final view = PlayerView(
+        playerId: playerId,
+        player: game.players.single,
+        ownUnitsById: {
+          'm1': Unit(
+            id: 'm1',
+            type: kUnitTypeMerchant,
+            ownerId: playerId,
+            locationProvinceId: 'newWorld|tribeProv',
+          ),
+        },
+        provincesById: const {},
+        visibilityByTile: const {},
+        prospectedTiles: const {},
+        diplomacyByOtherId: const {},
+      );
+      final r = selectFullAiCivilianWorkOrders(
+        workSuggestions: [
+          const WorkOrder(
+            unitId: 'm1',
+            target: kWorkTargetExplore,
+            targetTileKey: 'newWorld|tribeProv|0|0',
+          ),
+          const WorkOrder(
+            unitId: 'm1',
+            target: kWorkTargetPurchaseLand,
+            targetTileKey: nwTile,
+          ),
+        ],
+        view: view,
+        game: game,
+      );
+      expect(r.workOrders.single.target, kWorkTargetPurchaseLand);
+      expect(r.workOrders.single.targetTileKey, nwTile);
+    });
+
     test('Builder prefers unimproved resource tile over lexicographically smaller road', () {
       const playerId = 'gp1';
       const tileRoad = 'oldWorld|p1|0|0';

--- a/tool/run_observer_game/lib/observer_colonial_verify.dart
+++ b/tool/run_observer_game/lib/observer_colonial_verify.dart
@@ -1,0 +1,87 @@
+import 'dart:io';
+
+import 'observer_conquest_verify.dart';
+import 'observer_extractable_rollup.dart';
+
+/// Canonical turn for colonial expansion regression (Refs #2509).
+const int kObserverColonialCanonicalTurn = 150;
+
+/// Minimum fraction of extractable GP resource tiles improved (level ≥ 1).
+const double kObserverColonialMinImprovementRatio = 0.70;
+
+const String kNewWorldProvinceIdPrefix = 'newWorld|';
+
+/// Every `newWorld|` province row must be owned by a Great Power.
+List<String> verifyGlobalNewWorldGpOwnership(
+  Map<String, Object?> snapshotJson,
+) {
+  final rows = snapshotJson['provinceOwnershipSorted'];
+  if (rows is! List<Object?>) {
+    return ['provinceOwnershipSorted missing or not a list'];
+  }
+  final gpIds = kObserverGreatPowerIds.toSet();
+  final failures = <String>[];
+  for (final row in rows) {
+    if (row is! Map<String, Object?>) continue;
+    final id = row['id']?.toString() ?? '';
+    if (!id.startsWith(kNewWorldProvinceIdPrefix)) continue;
+    final owner = row['ownerId']?.toString();
+    if (owner == null || owner.isEmpty || !gpIds.contains(owner)) {
+      failures.add(
+        'newWorld province $id owned by ${owner ?? "null"} (expected gp1–gp6)',
+      );
+    }
+  }
+  return failures;
+}
+
+/// Improvement ratio gate using snapshot rollup fields.
+List<String> verifyExtractableImprovementRatio(
+  Map<String, Object?> snapshotJson, {
+  double minRatio = kObserverColonialMinImprovementRatio,
+}) {
+  final rollup = extractableRollupFromSnapshotJson(snapshotJson);
+  if (rollup == null) {
+    return [
+      'snapshot missing extractableResourceTileCount / '
+      'improvedExtractableResourceTileCount',
+    ];
+  }
+  if (rollup.extractableResourceTileCount == 0) {
+    return const [];
+  }
+  final ratio = rollup.improvementRatio;
+  if (ratio + 1e-12 >= minRatio) {
+    return const [];
+  }
+  return [
+    'extractable improvement ratio ${ratio.toStringAsFixed(3)} '
+    '(${rollup.improvedExtractableResourceTileCount}/'
+    '${rollup.extractableResourceTileCount}) below minimum '
+    '${minRatio.toStringAsFixed(2)}',
+  ];
+}
+
+/// Turn-[endTurn] snapshot checks for NW ownership and improvement ratio.
+List<String> verifyObserverColonialExpansionFromTraceDir(
+  String tracesGameDir, {
+  int endTurn = kObserverColonialCanonicalTurn,
+  double minImprovementRatio = kObserverColonialMinImprovementRatio,
+}) {
+  final endPath = observerTurnSnapshotPath(
+    tracesGameDir: tracesGameDir,
+    turnNumber: endTurn,
+  );
+  if (!File(endPath).existsSync()) {
+    return ['missing end snapshot: $endPath'];
+  }
+  final snapshot = loadObserverSnapshotJsonFile(endPath);
+  final failures = <String>[
+    ...verifyGlobalNewWorldGpOwnership(snapshot),
+    ...verifyExtractableImprovementRatio(
+      snapshot,
+      minRatio: minImprovementRatio,
+    ),
+  ];
+  return failures;
+}

--- a/tool/run_observer_game/lib/observer_extractable_rollup.dart
+++ b/tool/run_observer_game/lib/observer_extractable_rollup.dart
@@ -1,0 +1,149 @@
+import 'package:colonizethis_data/colonizethis_data.dart';
+import 'package:colonizethis_logic/colonizethis_logic.dart';
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'observer_conquest_verify.dart';
+
+/// Counts extractable resource tiles on GP-owned land and how many are improved.
+/// SPEC/program/run_observer_game-tool.md § Colonial expansion verification.
+class ExtractableImprovementRollup {
+  const ExtractableImprovementRollup({
+    required this.extractableResourceTileCount,
+    required this.improvedExtractableResourceTileCount,
+  });
+
+  final int extractableResourceTileCount;
+  final int improvedExtractableResourceTileCount;
+
+  double get improvementRatio => extractableResourceTileCount <= 0
+      ? 1.0
+      : improvedExtractableResourceTileCount / extractableResourceTileCount;
+}
+
+/// Tiles excluded from the extractable universe (capital and province towns).
+Set<String> excludedCapitalAndTownTileKeys(Game game) {
+  final excluded = <String>{};
+  for (final p in game.players) {
+    final cap = p.capitalTile;
+    if (cap != null) {
+      excluded.add(cap.toTileKey());
+    }
+  }
+  for (final m in game.minorNations) {
+    final cap = m.capitalTile;
+    if (cap != null) {
+      excluded.add(cap.toTileKey());
+    }
+  }
+  for (final t in game.tribes) {
+    final cap = t.capitalTile;
+    if (cap != null) {
+      excluded.add(cap.toTileKey());
+    }
+  }
+  for (final p in allProvinces(game.worldState)) {
+    final tk = p.townTileKey;
+    if (tk != null && tk.isNotEmpty) {
+      excluded.add(tk);
+    }
+  }
+  return excluded;
+}
+
+Set<String> _gpOwnedProvinceIds(Game game) {
+  final gpIds = kObserverGreatPowerIds.toSet();
+  return <String>{
+    for (final p in allProvinces(game.worldState))
+      if (p.ownerId != null && gpIds.contains(p.ownerId!)) p.id,
+  };
+}
+
+({String regionId, int x, int y})? _parseTileKeyCoords(String tileKey) {
+  final parts = tileKey.split('|');
+  if (parts.length < 4) return null;
+  final x = int.tryParse(parts[parts.length - 2]);
+  final y = int.tryParse(parts[parts.length - 1]);
+  if (x == null || y == null) return null;
+  return (regionId: parts[0], x: x, y: y);
+}
+
+String? _staticResourceIdAtTile(
+  String tileKey,
+  Map<String, TileMapResult>? tileMapByRegion,
+) {
+  final parsed = _parseTileKeyCoords(tileKey);
+  if (parsed == null) return null;
+  final tileMap = tileMapByRegion?[parsed.regionId];
+  final resource = tileMap?.resourceAt(parsed.x, parsed.y);
+  return resource?.name;
+}
+
+String? _resourceIdForExtractableTile(
+  String tileKey,
+  Game game,
+  Map<String, TileMapResult>? tileMapByRegion,
+) {
+  final fromInit = _staticResourceIdAtTile(tileKey, tileMapByRegion);
+  if (fromInit != null && fromInit.isNotEmpty) {
+    return fromInit;
+  }
+  final fromState = game.worldState.resourceByTileKey[tileKey];
+  if (fromState == null || fromState.isEmpty) {
+    return null;
+  }
+  return fromState;
+}
+
+/// Computes global GP-land extractable/improved counts for observer snapshots.
+ExtractableImprovementRollup computeExtractableImprovementRollup(
+  Game game, {
+  Map<String, TileMapResult>? tileMapByRegion,
+}) {
+  final ownedProvinces = _gpOwnedProvinceIds(game);
+  final excludedTiles = excludedCapitalAndTownTileKeys(game);
+  var extractable = 0;
+  var improved = 0;
+
+  for (final regionEntry
+      in game.worldState.tileKeysByRegionAndProvince.entries) {
+    for (final provEntry in regionEntry.value.entries) {
+      final provinceId = provEntry.key;
+      if (!ProvinceId.isPrefixed(provinceId)) continue;
+      if (!ownedProvinces.contains(provinceId)) continue;
+
+      for (final tileKey in provEntry.value) {
+        if (excludedTiles.contains(tileKey)) continue;
+        final resourceId = _resourceIdForExtractableTile(
+          tileKey,
+          game,
+          tileMapByRegion,
+        );
+        if (resourceId == null || resourceId.isEmpty) continue;
+        extractable++;
+        if (game.worldState.tileState.improvementLevel(tileKey) >= 1) {
+          improved++;
+        }
+      }
+    }
+  }
+
+  return ExtractableImprovementRollup(
+    extractableResourceTileCount: extractable,
+    improvedExtractableResourceTileCount: improved,
+  );
+}
+
+/// Reads rollup fields from a snapshot JSON map (schema v2+).
+ExtractableImprovementRollup? extractableRollupFromSnapshotJson(
+  Map<String, Object?> snapshotJson,
+) {
+  final extractable = snapshotJson['extractableResourceTileCount'];
+  final improved = snapshotJson['improvedExtractableResourceTileCount'];
+  if (extractable is! int || improved is! int) {
+    return null;
+  }
+  return ExtractableImprovementRollup(
+    extractableResourceTileCount: extractable,
+    improvedExtractableResourceTileCount: improved,
+  );
+}

--- a/tool/run_observer_game/lib/observer_extractable_rollup.dart
+++ b/tool/run_observer_game/lib/observer_extractable_rollup.dart
@@ -94,6 +94,34 @@ String? _resourceIdForExtractableTile(
   return fromState;
 }
 
+({int extractable, int improved}) _countProvinceExtractableTiles(
+  Iterable<String> tileKeys,
+  Set<String> excludedTiles,
+  Game game,
+  Map<String, TileMapResult>? tileMapByRegion,
+) {
+  var extractable = 0;
+  var improved = 0;
+  for (final tileKey in tileKeys) {
+    if (excludedTiles.contains(tileKey)) continue;
+    final resourceId = _resourceIdForExtractableTile(
+      tileKey,
+      game,
+      tileMapByRegion,
+    );
+    if (resourceId == null || resourceId.isEmpty) continue;
+    extractable++;
+    if (game.worldState.tileState.improvementLevel(tileKey) >= 1) {
+      improved++;
+    }
+  }
+  return (extractable: extractable, improved: improved);
+}
+
+bool _isGpOwnedPrefixedProvince(String provinceId, Set<String> ownedProvinces) {
+  return ProvinceId.isPrefixed(provinceId) && ownedProvinces.contains(provinceId);
+}
+
 /// Computes global GP-land extractable/improved counts for observer snapshots.
 ExtractableImprovementRollup computeExtractableImprovementRollup(
   Game game, {
@@ -107,23 +135,17 @@ ExtractableImprovementRollup computeExtractableImprovementRollup(
   for (final regionEntry
       in game.worldState.tileKeysByRegionAndProvince.entries) {
     for (final provEntry in regionEntry.value.entries) {
-      final provinceId = provEntry.key;
-      if (!ProvinceId.isPrefixed(provinceId)) continue;
-      if (!ownedProvinces.contains(provinceId)) continue;
-
-      for (final tileKey in provEntry.value) {
-        if (excludedTiles.contains(tileKey)) continue;
-        final resourceId = _resourceIdForExtractableTile(
-          tileKey,
-          game,
-          tileMapByRegion,
-        );
-        if (resourceId == null || resourceId.isEmpty) continue;
-        extractable++;
-        if (game.worldState.tileState.improvementLevel(tileKey) >= 1) {
-          improved++;
-        }
+      if (!_isGpOwnedPrefixedProvince(provEntry.key, ownedProvinces)) {
+        continue;
       }
+      final counts = _countProvinceExtractableTiles(
+        provEntry.value,
+        excludedTiles,
+        game,
+        tileMapByRegion,
+      );
+      extractable += counts.extractable;
+      improved += counts.improved;
     }
   }
 

--- a/tool/run_observer_game/lib/observer_session_runner.dart
+++ b/tool/run_observer_game/lib/observer_session_runner.dart
@@ -133,6 +133,7 @@ Future<int> runObserverSession({
       final snap = buildObserverSnapshotJson(
         game,
         postResolutionTurnNumber: postTurn,
+        tileMapByRegion: init.tileMapByRegion,
       );
       final snapshotText = encodeObserverSnapshotJson(snap);
       await File(

--- a/tool/run_observer_game/lib/observer_snapshot_v1.dart
+++ b/tool/run_observer_game/lib/observer_snapshot_v1.dart
@@ -1,15 +1,19 @@
 import 'dart:convert';
 
+import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 
+import 'observer_extractable_rollup.dart';
+
 /// Observer canonical snapshot (SPEC/program/run_observer_game-tool.md).
-const int observerSnapshotSchemaVersion = 1;
+const int observerSnapshotSchemaVersion = 2;
 
 Map<String, Object?> buildObserverSnapshotJson(
   Game game, {
   required int postResolutionTurnNumber,
+  Map<String, TileMapResult>? tileMapByRegion,
 }) {
   final mapping = game.turnTimeMapping ?? TurnTimeMapping.gdd01;
 
@@ -59,6 +63,11 @@ Map<String, Object?> buildObserverSnapshotJson(
     ),
   ]..sort();
 
+  final extractableRollup = computeExtractableImprovementRollup(
+    game,
+    tileMapByRegion: tileMapByRegion,
+  );
+
   return <String, Object?>{
     'observerSnapshotSchemaVersion': observerSnapshotSchemaVersion,
     'gameId': game.id,
@@ -72,6 +81,10 @@ Map<String, Object?> buildObserverSnapshotJson(
     'diplomacyRelationSummariesSorted': diplomacyBrief,
     'militaryArmySummariesSorted': armiesBrief,
     'militaryFleetSummariesSorted': fleetsBrief,
+    'extractableResourceTileCount':
+        extractableRollup.extractableResourceTileCount,
+    'improvedExtractableResourceTileCount':
+        extractableRollup.improvedExtractableResourceTileCount,
   };
 }
 

--- a/tool/run_observer_game/lib/run_observer_game_cli.dart
+++ b/tool/run_observer_game/lib/run_observer_game_cli.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:colonizethis_data/colonizethis_data.dart';
 
+import 'observer_colonial_verify.dart';
 import 'observer_conquest_verify.dart';
 import 'observer_session_runner.dart';
 import 'setup_config_parser.dart';
@@ -12,6 +13,9 @@ const int kExitUsage = 64;
 
 /// Exit code when `--verify-conquest` fails (Refs #2504).
 const int kExitConquestVerifyFailed = 5;
+
+/// Exit code when `--verify-colonial-expansion` fails (Refs #2509).
+const int kExitColonialVerifyFailed = 6;
 
 String _usage(ArgParser parser) {
   final buf = StringBuffer()
@@ -27,6 +31,22 @@ String _usage(ArgParser parser) {
     ..writeln('Options:')
     ..writeln(parser.usage);
   return buf.toString();
+}
+
+/// Resolves the most recently modified game trace directory under [outputRoot].
+String? findLatestObserverGameTraceDir(String outputRoot) {
+  final traceRoot = Directory('$outputRoot/observer-traces');
+  if (!traceRoot.existsSync()) {
+    return null;
+  }
+  final gameDirs = traceRoot.listSync().whereType<Directory>().toList();
+  if (gameDirs.isEmpty) {
+    return null;
+  }
+  gameDirs.sort(
+    (a, b) => b.statSync().modified.compareTo(a.statSync().modified),
+  );
+  return gameDirs.first.path;
 }
 
 /// Parses CLI arguments; writes help to [emitStdout], errors to [emitStderr].
@@ -67,6 +87,14 @@ Future<int> runObserverGameCli(
           'provinces between turn 1 and turn '
           '$kObserverConquestCanonicalTurns snapshots (requires '
           '--max-turns >= $kObserverConquestCanonicalTurns or omit cap).',
+    )
+    ..addFlag(
+      'verify-colonial-expansion',
+      help:
+          'After a successful run, verify turn-$kObserverColonialCanonicalTurn '
+          'snapshot: all newWorld| provinces owned by gp1–gp6 and >=70% of '
+          'extractable GP resource tiles improved (requires --max-turns >= '
+          '$kObserverColonialCanonicalTurn or omit cap).',
     );
 
   late final ArgResults results;
@@ -138,12 +166,23 @@ Future<int> runObserverGameCli(
   }
 
   final verifyConquest = results['verify-conquest'] == true;
+  final verifyColonial = results['verify-colonial-expansion'] == true;
+
   if (verifyConquest &&
       maxTurnsCap != null &&
       maxTurnsCap < kObserverConquestCanonicalTurns) {
     emitStderr(
       'Error: --verify-conquest requires --max-turns >= '
       '$kObserverConquestCanonicalTurns (got $maxTurnsCap).',
+    );
+    return kExitUsage;
+  }
+  if (verifyColonial &&
+      maxTurnsCap != null &&
+      maxTurnsCap < kObserverColonialCanonicalTurn) {
+    emitStderr(
+      'Error: --verify-colonial-expansion requires --max-turns >= '
+      '$kObserverColonialCanonicalTurn (got $maxTurnsCap).',
     );
     return kExitUsage;
   }
@@ -157,40 +196,52 @@ Future<int> runObserverGameCli(
     return sessionCode;
   }
 
-  if (!verifyConquest) {
+  if (!verifyConquest && !verifyColonial) {
     return 0;
   }
 
-  final traceRoot = Directory('$outputRoot/observer-traces');
-  if (!traceRoot.existsSync()) {
-    emitStderr('Error: observer traces missing under $outputRoot');
-    return 2;
-  }
-  final gameDirs = traceRoot.listSync().whereType<Directory>().toList();
-  if (gameDirs.isEmpty) {
+  final gameDir = findLatestObserverGameTraceDir(outputRoot);
+  if (gameDir == null) {
     emitStderr('Error: no game trace directory under $outputRoot');
     return 2;
   }
-  gameDirs.sort(
-    (a, b) => b.statSync().modified.compareTo(a.statSync().modified),
-  );
-  final gameDir = gameDirs.first;
 
-  final failures = verifyObserverConquestFromTraceDir(
-    gameDir.path,
-    endTurn: kObserverConquestCanonicalTurns,
-  );
-  if (failures.isEmpty) {
+  if (verifyConquest) {
+    final failures = verifyObserverConquestFromTraceDir(
+      gameDir,
+      endTurn: kObserverConquestCanonicalTurns,
+    );
+    if (failures.isNotEmpty) {
+      for (final line in failures) {
+        emitStderr('conquest_verify: $line');
+      }
+      return kExitConquestVerifyFailed;
+    }
     emitStdout(
-      'Conquest verification passed (seed=${setup.seed ?? "default"}, '
+      'Conquest verification passed (seed=${setup.seed}, '
       '$kObserverConquestCanonicalTurns turns, '
       '>=$kObserverConquestMinOwGainPerGp OW provinces per GP).',
     );
-    return 0;
   }
 
-  for (final line in failures) {
-    emitStderr('conquest_verify: $line');
+  if (verifyColonial) {
+    final failures = verifyObserverColonialExpansionFromTraceDir(
+      gameDir,
+      endTurn: kObserverColonialCanonicalTurn,
+    );
+    if (failures.isNotEmpty) {
+      for (final line in failures) {
+        emitStderr('colonial_verify: $line');
+      }
+      return kExitColonialVerifyFailed;
+    }
+    emitStdout(
+      'Colonial expansion verification passed (seed=${setup.seed}, '
+      'turn $kObserverColonialCanonicalTurn, all newWorld| GP-owned, '
+      'extractable improvement >= '
+      '${(kObserverColonialMinImprovementRatio * 100).round()}%).',
+    );
   }
-  return kExitConquestVerifyFailed;
+
+  return 0;
 }

--- a/tool/run_observer_game/test/observer_colonial_verify_test.dart
+++ b/tool/run_observer_game/test/observer_colonial_verify_test.dart
@@ -1,0 +1,74 @@
+import 'package:colonizethis_test/test.dart';
+
+import 'package:run_observer_game/observer_colonial_verify.dart';
+import 'package:run_observer_game/observer_conquest_verify.dart';
+
+Map<String, Object?> _snapshot({
+  required List<Map<String, String?>> provinces,
+  int extractable = 100,
+  int improved = 70,
+}) {
+  return <String, Object?>{
+    'provinceOwnershipSorted': provinces,
+    'extractableResourceTileCount': extractable,
+    'improvedExtractableResourceTileCount': improved,
+  };
+}
+
+void main() {
+  group('verifyGlobalNewWorldGpOwnership', () {
+    test('passes when every newWorld province is GP-owned', () {
+      final snap = _snapshot(
+        provinces: [
+          {'id': 'newWorld|p1', 'ownerId': 'gp1'},
+          {'id': 'newWorld|p2', 'ownerId': 'gp2'},
+          {'id': 'oldWorld|p3', 'ownerId': 'tribe1'},
+        ],
+      );
+      expect(verifyGlobalNewWorldGpOwnership(snap), isEmpty);
+    });
+
+    test('fails when tribe owns a newWorld province', () {
+      final snap = _snapshot(
+        provinces: [
+          {'id': 'newWorld|p1', 'ownerId': 'tribe1'},
+        ],
+      );
+      final failures = verifyGlobalNewWorldGpOwnership(snap);
+      expect(failures, isNotEmpty);
+      expect(failures.first, contains('newWorld|p1'));
+    });
+  });
+
+  group('verifyExtractableImprovementRatio', () {
+    test('passes at exactly 0.70', () {
+      final snap = _snapshot(
+        provinces: const [],
+        extractable: 100,
+        improved: 70,
+      );
+      expect(verifyExtractableImprovementRatio(snap), isEmpty);
+    });
+
+    test('fails at 0.69 with ratio in message', () {
+      final snap = _snapshot(
+        provinces: const [],
+        extractable: 100,
+        improved: 69,
+      );
+      final failures = verifyExtractableImprovementRatio(snap);
+      expect(failures, isNotEmpty);
+      expect(failures.first, contains('0.690'));
+      expect(failures.first, contains('0.70'));
+    });
+
+    test('passes when denominator is zero', () {
+      final snap = _snapshot(
+        provinces: const [],
+        extractable: 0,
+        improved: 0,
+      );
+      expect(verifyExtractableImprovementRatio(snap), isEmpty);
+    });
+  });
+}

--- a/tool/run_observer_game/test/run_observer_game_cli_test.dart
+++ b/tool/run_observer_game/test/run_observer_game_cli_test.dart
@@ -79,6 +79,20 @@ void main() {
       expect(err.join('\n'), contains('integer'));
     });
 
+    test('verify-colonial-expansion with low max-turns yields EX_USAGE', () async {
+      final out = <String>[];
+      final err = <String>[];
+      final tmp = Directory.systemTemp.createTempSync('roc_colonial_');
+      addTearDown(() => tmp.deleteSync(recursive: true));
+      final code = await runObserverGameCli(
+        ['--output', tmp.path, '--max-turns', '100', '--verify-colonial-expansion'],
+        emitStdout: out.add,
+        emitStderr: err.add,
+      );
+      expect(code, kExitUsage);
+      expect(err.join('\n'), contains('verify-colonial-expansion'));
+    });
+
     test('verify-conquest with low max-turns yields EX_USAGE', () async {
       final out = <String>[];
       final err = <String>[];


### PR DESCRIPTION
## Summary

- **Observer (S2–S5, S9):** Snapshot schema v2 adds `extractableResourceTileCount` / `improvedExtractableResourceTileCount`; new `--verify-colonial-expansion` (exit 6) checks turn-150 global NW GP ownership and ≥70% extractable improvement ratio; nightly `observer_conquest_verify` job extended to 150 turns with both verify flags.
- **AI (S1, S6–S8):** `ColonialSummary` on `AIWorldSnapshot`; NW invadable/adjacent perception; colonial goal/diplomacy/conquest scoring; Builder prioritizes `build_improvement` on unimproved resource tiles.
- **SPEC:** `SPEC/ai/ai-architecture.md` § Colonial expansion; `SPEC/program/run_observer_game-tool.md` colonial verification.

## Deferred (follow-up on same issue)

- **S10 — AI tuning:** Nightly seed-42 / 150-turn campaign is expected to fail until weights are tuned to pass both gates without weakening turn-100 OW conquest. No threshold relaxation.

## Acceptance criteria covered in this PR

| Area | Status |
|------|--------|
| Observer NW ownership / 70% ratio (synthetic snapshots) | Unit tests |
| CLI `--verify-colonial-expansion` / exit 6 / max-turns guard | Unit tests |
| Nightly workflow 150 turns + both flags | CI config |
| AI perception NW lists | Unit test |
| AI tribe declare-war not hard-suppressed (colonial adjacent) | Unit test |
| AI Builder `build_improvement` priority | Unit test |
| Systemic turn-100/150 observer pass (seed 42) | **Deferred** — S10 tuning |

## Test plan

- [x] `dart test` in `tool/run_observer_game` (colonial verify, CLI)
- [x] `dart test` in `packages/colonizethis_ai` (perception, diplomacy colonial)
- [x] `dart test` in `packages/colonizethis_logic` (civilian work selection)
- [ ] Nightly observer job green after S10 tuning (separate commits acceptable)

Refs #2509

Made with [Cursor](https://cursor.com)