### PR TITLE
fix(ci): bump nightly workflow Dart SDK to 3.11.5

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1
         with:
-          sdk: '3.11.0'
+          sdk: '3.11.5'
 
       - name: Run nightly integration gate
         run: bash tool/run_nightly_integration_gate.sh
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1
         with:
-          sdk: '3.11.0'
+          sdk: '3.11.5'
 
       - name: Resolve dependencies (workspace)
         run: dart pub get


### PR DESCRIPTION
## Summary

Nightly CI failed at `dart pub get` because the workflow pinned Dart **3.11.0** while the workspace requires **>=3.11.5**.

## Changes

- Update both `setup-dart` steps in `.github/workflows/nightly.yml` from `3.11.0` to `3.11.5`.

## Test plan

- [ ] Quality CI passes on this PR
- [ ] After merge to `dev` and sync to `main`, re-run **Nightly** workflow manually

Made with [Cursor](https://cursor.com)