### PR TITLE
fix(ci): use Flutter setup in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,10 +15,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Dart
-        uses: dart-lang/setup-dart@v1
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
         with:
-          sdk: '3.11.5'
+          channel: stable
+          flutter-version: '3.41.9'
+          cache: true
 
       - name: Run nightly integration gate
         run: bash tool/run_nightly_integration_gate.sh
@@ -31,10 +33,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Dart
-        uses: dart-lang/setup-dart@v1
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
         with:
-          sdk: '3.11.5'
+          channel: stable
+          flutter-version: '3.41.9'
+          cache: true
 
       - name: Resolve dependencies (workspace)
         run: dart pub get


### PR DESCRIPTION
## Summary

Nightly failed at `dart pub get` because the workspace includes `app` (Flutter), which requires the Flutter SDK for `flutter_test` and other `sdk: flutter` deps. Nightly only installed Dart via `setup-dart`.

## Changes

Replace `dart-lang/setup-dart` with `subosito/flutter-action@v2` (**3.41.9** stable), matching **Quality** CI, in both nightly jobs.

## Test plan

- [ ] Quality CI passes on this PR
- [ ] After merge to `main`, re-run **Nightly** workflow manually

Made with [Cursor](https://cursor.com)