### PR TITLE
ci: minimal observer artifacts for nightly verify (Refs #2534)

### DIFF
--- a/SPEC/program/run_observer_game-tool.md
+++ b/SPEC/program/run_observer_game-tool.md
@@ -28,9 +28,25 @@ melos run run_observer_game -- [options]
 
 Under `<output>/observer-traces/<gameId>/`:
 
+### Full trace mode (default)
+
+Active when **no** `--verify-*` flag is set.
+
 - Merged turn-trace JSON per resolved turn (no pruning of prior turns for the run; exporter must not apply the default 10-file cap — see `SPEC/program/turn-resolution-json-trace.md`).
 - Per turn (post-resolution): `turn-<zero-padded>.snapshot.json` and `turn-<zero-padded>.html` — **same canonical** `ObserverSnapshot` data; HTML is a render only.
 - End: `run-summary.json` — `termination_reason` (`military_victory` \| `calendar_1800` \| `max_turns_override` \| …), `declared_winner_player_id` or none per `SPEC/game/victory.md` / calendar-cap winner rules (`greatPowerPowerScore`, tie → **no-one** where specified), final turn, seed, paths to artifacts.
+
+### Minimal trace mode (auto when `--verify-*` is set)
+
+Active when **`--verify-conquest` and/or `--verify-colonial-expansion`** is passed (no separate nightly flag). Refs **#2534**.
+
+- **No** merged turn-trace JSON, **no** `.html`, **no** in-memory phase tracing (`onTurnTracePhase` / `turnTraceRuntime` off).
+- **ObserverSnapshot** JSON only on turns required by the active verify flags (union):
+  - `--verify-conquest` → `turn-000001.snapshot.json`, `turn-000100.snapshot.json`
+  - `--verify-colonial-expansion` → `turn-000150.snapshot.json`
+  - Both (nightly) → those **three** snapshots plus `run-summary.json` only.
+- **`run-summary.json`** always written at end (`minimal_trace_mode: true` in summary when minimal mode ran).
+- **Artifact size cap:** cumulative bytes under the game trace directory must stay **strictly below 300 MB** (`300 * 1024 * 1024`); if a write would exceed the cap, the run aborts with exit **7** (`artifact_size_cap_exceeded`). Canonical nightly verify inputs are expected to be far below the cap; the cap guards regressions that reintroduce large artifacts.
 
 ## ObserverSnapshot (`ObserverSnapshot` v2)
 
@@ -61,7 +77,7 @@ Each **resolved turn** in the session loop measures the same segment as the app 
 
 - **App:** Merged trace file export when **`CT_DEBUG_CONSOLE=true`** (`--dart-define`); see logging/env TDD notes in **#2498**.
 - **Ctdev:** `SimGameController.turnTraceEnabled` defaults from the same compile-time flag **`CT_DEBUG_CONSOLE`** (`ctdev/lib/ct_debug_console.dart`), so long sim sessions can emit merged trace files without a code change.
-- **Tool:** Traces are always on for `run_observer_game`.
+- **Tool:** Full trace mode always emits merged traces; minimal mode (verify flags) skips them.
 
 ## Conquest regression verification (Refs #2504)
 

--- a/tool/run_observer_game/lib/observer_minimal_trace.dart
+++ b/tool/run_observer_game/lib/observer_minimal_trace.dart
@@ -1,0 +1,40 @@
+import 'observer_colonial_verify.dart';
+import 'observer_conquest_verify.dart';
+
+/// Exit code when verify-run artifact writes would exceed [kObserverVerifyArtifactSizeCapBytes].
+const int kExitArtifactSizeCapExceeded = 7;
+
+/// Hard cap on total bytes under `observer-traces/<gameId>/` for verify runs (Refs #2534).
+const int kObserverVerifyArtifactSizeCapBytes = 300 * 1024 * 1024;
+
+/// Turn numbers for which [ObserverSnapshot] JSON is written in minimal trace mode.
+Set<int> requiredObserverSnapshotTurns({
+  required bool verifyConquest,
+  required bool verifyColonialExpansion,
+}) {
+  final turns = <int>{};
+  if (verifyConquest) {
+    turns.add(1);
+    turns.add(kObserverConquestCanonicalTurns);
+  }
+  if (verifyColonialExpansion) {
+    turns.add(kObserverColonialCanonicalTurn);
+  }
+  return turns;
+}
+
+/// Tracks cumulative artifact bytes for a single game trace directory.
+class ObserverArtifactBudget {
+  ObserverArtifactBudget({int capBytes = kObserverVerifyArtifactSizeCapBytes})
+      : capBytes = capBytes;
+
+  final int capBytes;
+  var bytesWritten = 0;
+
+  bool wouldExceed(int additionalBytes) =>
+      bytesWritten + additionalBytes > capBytes;
+
+  void recordBytes(int additionalBytes) {
+    bytesWritten += additionalBytes;
+  }
+}

--- a/tool/run_observer_game/lib/observer_session_runner.dart
+++ b/tool/run_observer_game/lib/observer_session_runner.dart
@@ -7,6 +7,7 @@ import 'package:colonizethis_data/colonizethis_data.dart';
 import 'package:colonizethis_logic/colonizethis_logic.dart';
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import 'observer_minimal_trace.dart';
 import 'observer_snapshot_v1.dart';
 import 'package_logger.dart';
 
@@ -24,6 +25,9 @@ Future<int> runObserverSession({
   required String outputRoot,
   required GameSetupConfig setupConfig,
   int? maxTurnsCap,
+  bool verifyConquest = false,
+  bool verifyColonialExpansion = false,
+  int verifyArtifactCapBytes = kObserverVerifyArtifactSizeCapBytes,
 }) async {
   late final InitGameResult init;
   try {
@@ -40,15 +44,57 @@ Future<int> runObserverSession({
     return 2;
   }
 
+  final minimalTraceMode = verifyConquest || verifyColonialExpansion;
+  final requiredSnapshotTurns = minimalTraceMode
+      ? requiredObserverSnapshotTurns(
+          verifyConquest: verifyConquest,
+          verifyColonialExpansion: verifyColonialExpansion,
+        )
+      : null;
+
+  TurnTraceFileExporter? exporter;
+  if (!minimalTraceMode) {
+    exporter = TurnTraceFileExporter(
+      rootDirectory: '$outputRoot/observer-traces',
+      traceDirectorySegment: '',
+      pruningEnabled: false,
+    );
+  }
+
   Game game = _greatPowersAiOnly(init.game);
-  final exporter = TurnTraceFileExporter(
-    rootDirectory: '$outputRoot/observer-traces',
-    traceDirectorySegment: '',
-    pruningEnabled: false,
-  );
+  final traceRoot = '$outputRoot/observer-traces';
+  final artifactBudget = minimalTraceMode
+      ? ObserverArtifactBudget(capBytes: verifyArtifactCapBytes)
+      : null;
 
   var resolvedCount = 0;
   var terminationReason = 'unknown';
+
+  Future<void> writeTraceArtifact(
+    String gameId,
+    String relativeName,
+    String content,
+  ) async {
+    final budget = artifactBudget;
+    final byteLength = utf8.encode(content).length;
+    if (budget != null) {
+      if (budget.wouldExceed(byteLength)) {
+        stderr.writeln(
+          'observer:artifact_size_cap_exceeded gameId=$gameId '
+          'capBytes=${budget.capBytes} '
+          'written=${budget.bytesWritten} '
+          'nextWrite=$byteLength',
+        );
+        throw _ArtifactSizeCapExceeded();
+      }
+    }
+
+    final traceDir = Directory('$traceRoot/$gameId');
+    await traceDir.create(recursive: true);
+    await File('${traceDir.path}/$relativeName').writeAsString(content);
+
+    budget?.recordBytes(byteLength);
+  }
 
   try {
     while (true) {
@@ -82,19 +128,51 @@ Future<int> runObserverSession({
         (pid, plan) => MapEntry(pid, plan.productionAssignments),
       );
 
-      final phaseTraces = <TurnTracePhaseTrace>[];
-      final traceStartedAt = DateTime.now().toUtc();
-      final traceRuntime = TurnTraceRuntime();
+      final TurnResolutionResult result;
+      if (minimalTraceMode) {
+        result = validateOrdersAndResolveTurnFromTrustedOrders(
+          game: gameForResolution,
+          topology: init.combinedTopology,
+          orders: mergedOrders,
+          tileMapByRegion: init.tileMapByRegion,
+          defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+        );
+      } else {
+        final phaseTraces = <TurnTracePhaseTrace>[];
+        final traceStartedAt = DateTime.now().toUtc();
+        final traceRuntime = TurnTraceRuntime();
 
-      final result = validateOrdersAndResolveTurnFromTrustedOrders(
-        game: gameForResolution,
-        topology: init.combinedTopology,
-        orders: mergedOrders,
-        tileMapByRegion: init.tileMapByRegion,
-        defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
-        onTurnTracePhase: phaseTraces.add,
-        turnTraceRuntime: traceRuntime,
-      );
+        result = validateOrdersAndResolveTurnFromTrustedOrders(
+          game: gameForResolution,
+          topology: init.combinedTopology,
+          orders: mergedOrders,
+          tileMapByRegion: init.tileMapByRegion,
+          defaultAssignmentsByPlayerId: defaultAssignmentsByPlayerId,
+          onTurnTracePhase: phaseTraces.add,
+          turnTraceRuntime: traceRuntime,
+        );
+
+        if (result is TurnResolutionComplete) {
+          final nowUtc = DateTime.now().toUtc();
+          final document = TurnTraceMergedDocument(
+            schemaVersion: kTurnTraceSchemaVersionV1,
+            meta: TurnTraceMeta(
+              gameId: before.id,
+              turnNumber: before.worldState.turnState.turnNumber,
+              traceEnabled: true,
+              source: 'run_observer_game',
+              exportedAt: nowUtc.toIso8601String(),
+              turnStartAt: traceStartedAt.toIso8601String(),
+              turnEndAt: nowUtc.toIso8601String(),
+            ),
+            ai: List<TurnTraceAiSection>.unmodifiable(fullAi.aiTraceSections),
+            turnResolution: TurnTraceResolutionSection(
+              phases: List<TurnTracePhaseTrace>.unmodifiable(phaseTraces),
+            ),
+          );
+          await exporter!.export(document);
+        }
+      }
 
       if (result is! TurnResolutionComplete) {
         _sessionLog.e(
@@ -106,50 +184,42 @@ Future<int> runObserverSession({
 
       game = requireTurnResolutionComplete(result);
 
-      final nowUtc = DateTime.now().toUtc();
-      final document = TurnTraceMergedDocument(
-        schemaVersion: kTurnTraceSchemaVersionV1,
-        meta: TurnTraceMeta(
-          gameId: before.id,
-          turnNumber: before.worldState.turnState.turnNumber,
-          traceEnabled: true,
-          source: 'run_observer_game',
-          exportedAt: nowUtc.toIso8601String(),
-          turnStartAt: traceStartedAt.toIso8601String(),
-          turnEndAt: nowUtc.toIso8601String(),
-        ),
-        ai: List<TurnTraceAiSection>.unmodifiable(fullAi.aiTraceSections),
-        turnResolution: TurnTraceResolutionSection(
-          phases: List<TurnTracePhaseTrace>.unmodifiable(phaseTraces),
-        ),
-      );
-      await exporter.export(document);
-
       final postTurn = game.worldState.turnState.turnNumber;
       final turnLabel = postTurn.toString().padLeft(6, '0');
 
-      final traceDir = Directory('${exporter.rootDirectory}/${before.id}');
+      final writeSnapshot = requiredSnapshotTurns == null ||
+          requiredSnapshotTurns.contains(postTurn);
+      if (writeSnapshot) {
+        final snap = buildObserverSnapshotJson(
+          game,
+          postResolutionTurnNumber: postTurn,
+          tileMapByRegion: init.tileMapByRegion,
+        );
+        final snapshotText = encodeObserverSnapshotJson(snap);
+        await writeTraceArtifact(
+          before.id,
+          'turn-$turnLabel.snapshot.json',
+          snapshotText,
+        );
 
-      final snap = buildObserverSnapshotJson(
-        game,
-        postResolutionTurnNumber: postTurn,
-        tileMapByRegion: init.tileMapByRegion,
-      );
-      final snapshotText = encodeObserverSnapshotJson(snap);
-      await File(
-        '${traceDir.path}/turn-$turnLabel.snapshot.json',
-      ).writeAsString(snapshotText);
-      await File(
-        '${traceDir.path}/turn-$turnLabel.html',
-      ).writeAsString(renderObserverSnapshotHtml(snapshotText.trimRight()));
+        if (!minimalTraceMode) {
+          await writeTraceArtifact(
+            before.id,
+            'turn-$turnLabel.html',
+            renderObserverSnapshotHtml(snapshotText.trimRight()),
+          );
+        }
+      }
 
       resolvedCount++;
 
       _sessionLog.i(
         'observer:turn_resolved count=$resolvedCount postTurn=$postTurn '
-        'gameId=${game.id}',
+        'gameId=${game.id} minimalTrace=$minimalTraceMode',
       );
     }
+  } on _ArtifactSizeCapExceeded {
+    return kExitArtifactSizeCapExceeded;
   } on Object catch (e, st) {
     _sessionLog.e('observer:run_loop_failed', error: e, stackTrace: st);
     stderr.writeln('observer:run_loop_failed: $e');
@@ -157,7 +227,7 @@ Future<int> runObserverSession({
     return 2;
   }
 
-  final summaryDir = Directory('$outputRoot/observer-traces/${game.id}');
+  final summaryDir = Directory('$traceRoot/${game.id}');
   await summaryDir.create(recursive: true);
 
   final winnerId = game.victory != null
@@ -173,11 +243,18 @@ Future<int> runObserverSession({
     'seed': setupConfig.seed,
     'game_id': game.id,
     'observer_traces_relative': 'observer-traces/${game.id}',
+    if (minimalTraceMode) 'minimal_trace_mode': true,
   };
 
-  await File(
-    '${summaryDir.path}/run-summary.json',
-  ).writeAsString('${const JsonEncoder.withIndent('  ').convert(summary)}\n');
+  final summaryText =
+      '${const JsonEncoder.withIndent('  ').convert(summary)}\n';
+  try {
+    await writeTraceArtifact(game.id, 'run-summary.json', summaryText);
+  } on _ArtifactSizeCapExceeded {
+    return kExitArtifactSizeCapExceeded;
+  }
 
   return 0;
 }
+
+class _ArtifactSizeCapExceeded implements Exception {}

--- a/tool/run_observer_game/lib/run_observer_game_cli.dart
+++ b/tool/run_observer_game/lib/run_observer_game_cli.dart
@@ -23,9 +23,9 @@ String _usage(ArgParser parser) {
     ..writeln('  melos run run_observer_game -- [options]')
     ..writeln('')
     ..writeln(
-      'Full-AI observer campaign: init default GPs, merged turn traces every turn, '
-      'HTML + JSON ObserverSnapshot per turn, run-summary.json '
-      '(SPEC/program/run_observer_game-tool.md). Traces are not pruned.',
+      'Full-AI observer campaign: init default GPs, turn artifacts, run-summary.json '
+      '(SPEC/program/run_observer_game-tool.md). With --verify-* flags, minimal trace '
+      'mode emits only verification snapshots (no merged traces or HTML).',
     )
     ..writeln('')
     ..writeln('Options:')
@@ -191,6 +191,8 @@ Future<int> runObserverGameCli(
     outputRoot: outputRoot,
     setupConfig: setup,
     maxTurnsCap: maxTurnsCap,
+    verifyConquest: verifyConquest,
+    verifyColonialExpansion: verifyColonial,
   );
   if (sessionCode != 0) {
     return sessionCode;

--- a/tool/run_observer_game/test/observer_minimal_trace_test.dart
+++ b/tool/run_observer_game/test/observer_minimal_trace_test.dart
@@ -1,0 +1,46 @@
+import 'package:colonizethis_test/test.dart';
+
+import 'package:run_observer_game/observer_minimal_trace.dart';
+
+void main() {
+  group('requiredObserverSnapshotTurns', () {
+    test('conquest only requires turns 1 and 100', () {
+      expect(
+        requiredObserverSnapshotTurns(
+          verifyConquest: true,
+          verifyColonialExpansion: false,
+        ),
+        {1, 100},
+      );
+    });
+
+    test('colonial only requires turn 150', () {
+      expect(
+        requiredObserverSnapshotTurns(
+          verifyConquest: false,
+          verifyColonialExpansion: true,
+        ),
+        {150},
+      );
+    });
+
+    test('both verify flags require turns 1, 100, and 150', () {
+      expect(
+        requiredObserverSnapshotTurns(
+          verifyConquest: true,
+          verifyColonialExpansion: true,
+        ),
+        {1, 100, 150},
+      );
+    });
+  });
+
+  group('ObserverArtifactBudget', () {
+    test('rejects writes that would exceed cap', () {
+      final budget = ObserverArtifactBudget(capBytes: 20);
+      budget.recordBytes(10);
+      expect(budget.wouldExceed(11), isTrue);
+      expect(budget.wouldExceed(10), isFalse);
+    });
+  });
+}

--- a/tool/run_observer_game/test/run_observer_game_cli_test.dart
+++ b/tool/run_observer_game/test/run_observer_game_cli_test.dart
@@ -5,6 +5,7 @@ import 'package:colonizethis_test/test.dart';
 
 import 'package:colonizethis_data/colonizethis_data.dart';
 
+import 'package:run_observer_game/observer_minimal_trace.dart';
 import 'package:run_observer_game/observer_session_runner.dart';
 import 'package:run_observer_game/run_observer_game_cli.dart';
 
@@ -250,6 +251,97 @@ void main() {
           jsonDecode(snapshotText.trimRight()),
           reason: 'HTML <pre> must render the same canonical JSON as the snapshot file',
         );
+      },
+      timeout: const Timeout(Duration(minutes: 15)),
+    );
+
+    test(
+      'minimal trace mode skips merged traces and html',
+      () async {
+        final tmp = Directory.systemTemp.createTempSync('run_observer_min_');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final setup = GameSetupConfig(
+          selectedGreatPowerIds: const ['england', 'france'],
+          continentCount: 4,
+          minorNationCount: 2,
+          tribeCount: 2,
+          numProvincesOldWorld: 14,
+          numProvincesNewWorld: 6,
+          minProvincesPerMinor: 2,
+          seed: 11,
+        );
+
+        final code = await runObserverSession(
+          outputRoot: tmp.path,
+          setupConfig: setup,
+          maxTurnsCap: 1,
+          verifyConquest: true,
+          verifyColonialExpansion: true,
+        );
+
+        expect(code, 0);
+
+        final gameDir = Directory('${tmp.path}/observer-traces')
+            .listSync()
+            .whereType<Directory>()
+            .single;
+        final names =
+            gameDir.listSync().whereType<File>().map((f) => f.uri.pathSegments.last).toList()
+              ..sort();
+
+        expect(names, ['run-summary.json', 'turn-000001.snapshot.json']);
+        expect(names.where((n) => n.endsWith('.html')), isEmpty);
+        expect(
+          names.where(
+            (n) =>
+                n.endsWith('.json') &&
+                !n.endsWith('.snapshot.json') &&
+                n != 'run-summary.json',
+          ),
+          isEmpty,
+        );
+
+        final summary =
+            jsonDecode(File('${gameDir.path}/run-summary.json').readAsStringSync())
+                as Map<String, Object?>;
+        expect(summary['minimal_trace_mode'], isTrue);
+
+        var totalBytes = 0;
+        for (final f in gameDir.listSync().whereType<File>()) {
+          totalBytes += f.lengthSync();
+        }
+        expect(totalBytes, lessThan(kObserverVerifyArtifactSizeCapBytes));
+      },
+      timeout: const Timeout(Duration(minutes: 15)),
+    );
+
+    test(
+      'minimal trace mode exits 7 when artifact cap exceeded',
+      () async {
+        final tmp = Directory.systemTemp.createTempSync('run_observer_cap_');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final setup = GameSetupConfig(
+          selectedGreatPowerIds: const ['england', 'france'],
+          continentCount: 4,
+          minorNationCount: 2,
+          tribeCount: 2,
+          numProvincesOldWorld: 14,
+          numProvincesNewWorld: 6,
+          minProvincesPerMinor: 2,
+          seed: 11,
+        );
+
+        final code = await runObserverSession(
+          outputRoot: tmp.path,
+          setupConfig: setup,
+          maxTurnsCap: 1,
+          verifyConquest: true,
+          verifyArtifactCapBytes: 1,
+        );
+
+        expect(code, kExitArtifactSizeCapExceeded);
       },
       timeout: const Timeout(Duration(minutes: 15)),
     );


### PR DESCRIPTION
## Summary

- Auto-enable **minimal trace mode** when any `--verify-*` flag is set: no merged turn traces, no HTML, no in-memory phase tracing; write `ObserverSnapshot` JSON only on turns required by active verify flags (1/100/150 union) plus `run-summary.json`.
- Enforce a **300 MB** cumulative artifact cap per game trace directory (exit **7** on exceed).
- **Full mode** (no verify flags) unchanged: merged traces, every-turn snapshot + HTML, unpruned.

## SPEC

- Updated `SPEC/program/run_observer_game-tool.md` with full vs minimal artifact layout, auto-enable rule, and size cap.

## Tests

- `observer_minimal_trace_test.dart`: required turn union + budget helper.
- `run_observer_game_cli_test.dart`: minimal mode file set (no merged/json/html), cap exit 7, size under cap.
- All `tool/run_observer_game` tests pass; lib coverage ≥ 80%.

## Deferred

- Nightly workflow unchanged (minimal mode auto-enables from existing verify flags).
- Conquest AI failure (exit **5**) out of scope.

Refs #2534

Made with [Cursor](https://cursor.com)