### PR TITLE
chore: pin workspace toolchain deps at resolvable Latest (#2532)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,11 +21,19 @@ If `dart pub get` or `flutter pub get` fails while resolving hosted packages wit
 
 `dart pub outdated` and `flutter pub outdated` compare the lockfile to **pub.dev “Latest”**; several rows often stay behind even on a healthy workspace. Common reasons in this repo:
 
-- **`test` / `test_api` / `test_core`:** Flutter’s **`flutter_test`** (from the SDK) pins **`test_api`** to the version shipped with that Flutter release. The standalone **`test`** package may therefore sit **below** pub.dev “Latest” (for example when Latest needs a newer `test_api`) until a **newer Flutter stable** relaxes that pin. This is expected; do not “fix” it by forcing `dependency_overrides` on `test_api` for normal work.
-- **`analyzer` / `analyzer_plugin` / `_fe_analyzer_shared`:** **`colonizethis_exception_lint`** and **`custom_lint_builder`** must agree on an **`analyzer`** major. **`analyzer_plugin` 0.14.x** depends on **`analyzer` 13**, while today’s **`custom_lint_builder`** line stays on **`analyzer` ^8.x**—so the workspace intentionally holds **`analyzer` ^8** and **`analyzer_plugin` ^0.13.x`** until upstream `custom_lint` packages publish a compatible analyzer-13 stack. Treat that gap as an **intentional cap**, not a stale lockfile.
-- **Other transitives (`xml`, `inspector`, …):** May lag “Latest” until a **direct** dependency raises its constraints; the solver picks the **newest jointly resolvable** graph across all workspace members.
+- **`test` / `test_api` / `test_core`:** Flutter’s **`flutter_test`** (from the SDK) pins **`test_api`** to the version shipped with that Flutter release. The standalone **`test`** package may therefore sit **below** pub.dev “Latest” (for example when Latest needs a newer `test_api`) until a **newer Flutter stable** relaxes that pin. This is expected; do not “fix” it by forcing `dependency_overrides` on `test_api` for normal work. **Follow-up:** [#2541](https://github.com/waigore/colonizethisv3/issues/2541).
+- **`analyzer` / `analyzer_plugin` / `_fe_analyzer_shared` / `custom_lint_visitor`:** **`colonizethis_exception_lint`** and **`custom_lint_builder`** must agree on an **`analyzer`** major. **`analyzer_plugin` 0.14.x** depends on **`analyzer` 13**, while today’s **`custom_lint_builder`** line stays on **`analyzer` 8.x**—so the workspace intentionally holds **`analyzer` 8.4.0** and **`analyzer_plugin` 0.13.10** until upstream `custom_lint` packages publish a compatible analyzer-13 stack. Treat that gap as an **intentional cap**, not a stale lockfile. **Follow-up:** [#2539](https://github.com/waigore/colonizethisv3/issues/2539).
+- **`hardcoded_strings_lint`:** **1.0.4** stays on the analyzer-8 stack; **2.x** requires analyzer 13 and conflicts with **`custom_lint`** Latest until **#2539** lands. **Follow-up:** [#2540](https://github.com/waigore/colonizethisv3/issues/2540).
+- **`meta`:** Direct **`meta` 1.17.0** in **`colonizethis_data`** matches the version pinned by SDK **`flutter_test`**; **1.18.x** is not jointly resolvable with Flutter workspace members until the Flutter pin moves.
+- **Other transitives (`xml`, `vector_math`, `matcher`, `custom_lint_core`, …):** May lag “Latest” until a **direct** dependency raises its constraints; the solver picks the **newest jointly resolvable** graph across all workspace members.
 
 When bumping dependencies, prefer **`dart pub upgrade`** / **`flutter pub upgrade`** (and coordinated `pubspec.yaml` edits) over overrides; if a row cannot move yet, note the **blocker** (SDK pin or shared dev-tool stack) in the PR or issue.
+
+### Toolchain dependency pinning (GitHub #2532)
+
+**Policy:** Toolchain-related **direct** and **dev** dependencies (`analyzer`, `test`, `custom_lint`, `custom_lint_builder`, `analyzer_plugin`, `hardcoded_strings_lint`, `meta` where declared) use **explicit pinned versions** in `pubspec.yaml` (exact `x.y.z`, not floating `^`). Deliberate upgrades happen via PR that refreshes pins and lockfiles together—routine `pub get` must not silently drift those versions.
+
+**Predecessor:** [#2073](https://github.com/waigore/colonizethisv3/issues/2073) (Flutter pin, advisories path, `repo.workspace_outdated_*` rules). **Phase 1 (#2532):** pin at jointly resolvable Latest; **Phase 2:** [#2539](https://github.com/waigore/colonizethisv3/issues/2539), [#2540](https://github.com/waigore/colonizethisv3/issues/2540), [#2541](https://github.com/waigore/colonizethisv3/issues/2541).
 
 ### Workspace outdated audit command set (GitHub #2073)
 

--- a/SPEC/program/pub-workspace-toolchain.md
+++ b/SPEC/program/pub-workspace-toolchain.md
@@ -25,7 +25,9 @@
 
 ## Intentional dependency caps
 
- Maintainer-facing detail (Flutter `test_api` pin, `analyzer` / **`custom_lint_builder`** / **`custom_lint`** stack, and related transitives) lives in **CONTRIBUTING.md** under **`dart pub outdated` / “Latest” vs what the workspace resolves**. Those caps are the **documented intentional exceptions** for **#2073** acceptance criteria until upstream publishes a compatible **`custom_lint_builder`** (or the project migrates lint integration per a future issue).
+ Maintainer-facing detail (Flutter `test_api` pin, `analyzer` / **`custom_lint_builder`** / **`custom_lint`** stack, `hardcoded_strings_lint`, `meta` / `flutter_test`, and related transitives) lives in **CONTRIBUTING.md** under **`dart pub outdated` / “Latest” vs what the workspace resolves** and **Toolchain dependency pinning (#2532)**. Those caps are the **documented intentional exceptions** until linked follow-ups land: **#2539** (analyzer-13 / `custom_lint`), **#2540** (`hardcoded_strings_lint` 2.x), **#2541** (`test` / `test_api` on Flutter pin).
+
+**Pinning (#2532):** Toolchain direct/dev deps use **exact** versions in `pubspec.yaml`; lockfiles are refreshed in the same PR as pin changes. Do not use `CT_WORKSPACE_OUTDATED_EXCLUDE` for documented blockers—cite the follow-up issue in CONTRIBUTING instead.
 
 ---
 

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -41,8 +41,8 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   colonizethis_exception_lint:
     path: ../packages/colonizethis_exception_lint
-  custom_lint: ^0.8.1
-  hardcoded_strings_lint: ^1.0.4
+  custom_lint: 0.8.1
+  hardcoded_strings_lint: 1.0.4
 
 flutter:
   generate: true

--- a/ctdev/pubspec.yaml
+++ b/ctdev/pubspec.yaml
@@ -27,7 +27,7 @@ dev_dependencies:
   colonizethis_exception_lint:
     path: ../packages/colonizethis_exception_lint
   colonizethis_test:
-  custom_lint: ^0.8.1
+  custom_lint: 0.8.1
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0

--- a/packages/colonizethis_ai/pubspec.yaml
+++ b/packages/colonizethis_ai/pubspec.yaml
@@ -20,5 +20,5 @@ dev_dependencies:
   colonizethis_exception_lint:
     path: ../colonizethis_exception_lint
   colonizethis_test:
-  custom_lint: ^0.8.1
-  test: ^1.24.0
+  custom_lint: 0.8.1
+  test: 1.30.0

--- a/packages/colonizethis_data/pubspec.yaml
+++ b/packages/colonizethis_data/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   logger: ^2.0.2
-  meta: ^1.17.0
+  meta: 1.17.0
   yaml: ^3.1.3
   colonizethis_logger:
   colonizethis_models:
@@ -20,5 +20,5 @@ dev_dependencies:
     path: ../colonizethis_exception_lint
   colonizethis_test:
   coverage: ^1.15.0
-  custom_lint: ^0.8.1
-  test: ^1.24.0
+  custom_lint: 0.8.1
+  test: 1.30.0

--- a/packages/colonizethis_debug_console/pubspec.yaml
+++ b/packages/colonizethis_debug_console/pubspec.yaml
@@ -16,5 +16,5 @@ dev_dependencies:
   colonizethis_exception_lint:
     path: ../colonizethis_exception_lint
   colonizethis_test:
-  custom_lint: ^0.8.1
-  test: ^1.24.0
+  custom_lint: 0.8.1
+  test: 1.30.0

--- a/packages/colonizethis_exception_lint/pubspec.yaml
+++ b/packages/colonizethis_exception_lint/pubspec.yaml
@@ -10,13 +10,13 @@ environment:
   sdk: '>=3.11.5 <4.0.0'
 
 dependencies:
-  analyzer: ^8.4.0
-  analyzer_plugin: ^0.13.7
-  custom_lint_builder: ^0.8.1
+  analyzer: 8.4.0
+  analyzer_plugin: 0.13.10
+  custom_lint_builder: 0.8.1
 
 dev_dependencies:
   colonizethis_test:
-  custom_lint: ^0.8.1
+  custom_lint: 0.8.1
   lints: ^6.0.0
   path: ^1.9.1
-  test: ^1.24.0
+  test: 1.30.0

--- a/packages/colonizethis_logger/pubspec.yaml
+++ b/packages/colonizethis_logger/pubspec.yaml
@@ -16,5 +16,5 @@ dev_dependencies:
     path: ../colonizethis_exception_lint
   colonizethis_test:
   coverage: ^1.15.0
-  custom_lint: ^0.8.1
-  test: ^1.24.0
+  custom_lint: 0.8.1
+  test: 1.30.0

--- a/packages/colonizethis_logic/pubspec.yaml
+++ b/packages/colonizethis_logic/pubspec.yaml
@@ -21,6 +21,6 @@ dev_dependencies:
     path: ../colonizethis_exception_lint
   colonizethis_test:
   coverage: ^1.15.0
-  custom_lint: ^0.8.1
+  custom_lint: 0.8.1
   json_schema: ^5.2.2
-  test: ^1.24.0
+  test: 1.30.0

--- a/packages/colonizethis_map/pubspec.yaml
+++ b/packages/colonizethis_map/pubspec.yaml
@@ -21,6 +21,6 @@ dev_dependencies:
     path: ../colonizethis_exception_lint
   colonizethis_test:
   coverage: ^1.15.0
-  custom_lint: ^0.8.1
-  test: ^1.24.0
+  custom_lint: 0.8.1
+  test: 1.30.0
 

--- a/packages/colonizethis_models/pubspec.yaml
+++ b/packages/colonizethis_models/pubspec.yaml
@@ -15,8 +15,8 @@ dev_dependencies:
     path: ../colonizethis_exception_lint
   colonizethis_test:
   coverage: ^1.15.0
-  custom_lint: ^0.8.1
-  test: ^1.24.0
+  custom_lint: 0.8.1
+  test: 1.30.0
 
 dependencies:
   colonizethis_logger: any

--- a/packages/colonizethis_save/pubspec.yaml
+++ b/packages/colonizethis_save/pubspec.yaml
@@ -20,5 +20,5 @@ dev_dependencies:
     path: ../colonizethis_exception_lint
   colonizethis_test:
   coverage: ^1.15.0
-  custom_lint: ^0.8.1
-  test: ^1.24.0
+  custom_lint: 0.8.1
+  test: 1.30.0

--- a/packages/colonizethis_test/pubspec.yaml
+++ b/packages/colonizethis_test/pubspec.yaml
@@ -11,9 +11,9 @@ environment:
 dependencies:
   colonizethis_logger: any
   logger: ^2.0.2
-  test: ^1.24.0
+  test: 1.30.0
 
 dev_dependencies:
   colonizethis_exception_lint:
     path: ../colonizethis_exception_lint
-  custom_lint: ^0.8.1
+  custom_lint: 0.8.1

--- a/packages/session_log_buffer/pubspec.yaml
+++ b/packages/session_log_buffer/pubspec.yaml
@@ -15,5 +15,5 @@ dev_dependencies:
   colonizethis_exception_lint:
     path: ../colonizethis_exception_lint
   colonizethis_test:
-  custom_lint: ^0.8.1
-  test: ^1.24.0
+  custom_lint: 0.8.1
+  test: 1.30.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,13 +30,13 @@ workspace:
   - tool/check_gdd_coverage
 
 dev_dependencies:
-  analyzer: ^8.4.0
+  analyzer: 8.4.0
   colonizethis_exception_lint:
     path: packages/colonizethis_exception_lint
   image: ^4.5.4
   melos: ^7.7.0
   path: ^1.9.1
-  test: ^1.24.0
+  test: 1.30.0
   yaml: ^3.1.3
 
 melos:

--- a/tool/check_gdd_coverage/pubspec.yaml
+++ b/tool/check_gdd_coverage/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   colonizethis_exception_lint:
     path: ../../packages/colonizethis_exception_lint
-  custom_lint: ^0.8.1
+  custom_lint: 0.8.1
 
 executables:
   check_gdd_coverage: bin/check_gdd_coverage.dart

--- a/tool/generate_map/pubspec.yaml
+++ b/tool/generate_map/pubspec.yaml
@@ -17,9 +17,9 @@ dev_dependencies:
   colonizethis_exception_lint:
     path: ../../packages/colonizethis_exception_lint
   colonizethis_test:
-  custom_lint: ^0.8.1
+  custom_lint: 0.8.1
   path: ^1.9.0
-  test: ^1.24.0
+  test: 1.30.0
 
 executables:
   generate_map: bin/generate_map.dart

--- a/tool/init_game/pubspec.yaml
+++ b/tool/init_game/pubspec.yaml
@@ -18,9 +18,9 @@ dev_dependencies:
   colonizethis_exception_lint:
     path: ../../packages/colonizethis_exception_lint
   colonizethis_test:
-  custom_lint: ^0.8.1
+  custom_lint: 0.8.1
   path: ^1.9.0
-  test: ^1.24.0
+  test: 1.30.0
 
 executables:
   init_game: bin/init_game.dart

--- a/tool/run_observer_game/pubspec.yaml
+++ b/tool/run_observer_game/pubspec.yaml
@@ -21,9 +21,9 @@ dev_dependencies:
   colonizethis_exception_lint:
     path: ../../packages/colonizethis_exception_lint
   colonizethis_test:
-  custom_lint: ^0.8.1
+  custom_lint: 0.8.1
   path: ^1.9.0
-  test: ^1.24.0
+  test: 1.30.0
 
 executables:
   run_observer_game: bin/run_observer_game.dart

--- a/tool/show_tech/pubspec.yaml
+++ b/tool/show_tech/pubspec.yaml
@@ -16,5 +16,5 @@ dev_dependencies:
   colonizethis_exception_lint:
     path: ../../packages/colonizethis_exception_lint
   colonizethis_test:
-  custom_lint: ^0.8.1
-  test: ^1.24.0
+  custom_lint: 0.8.1
+  test: 1.30.0

--- a/tool/sim_combat/pubspec.yaml
+++ b/tool/sim_combat/pubspec.yaml
@@ -17,8 +17,8 @@ dev_dependencies:
   colonizethis_exception_lint:
     path: ../../packages/colonizethis_exception_lint
   colonizethis_test:
-  custom_lint: ^0.8.1
-  test: ^1.24.0
+  custom_lint: 0.8.1
+  test: 1.30.0
 
 executables:
   sim_combat: bin/sim_combat.dart

--- a/tool/sim_combat_montecarlo/pubspec.yaml
+++ b/tool/sim_combat_montecarlo/pubspec.yaml
@@ -17,9 +17,9 @@ dev_dependencies:
   colonizethis_exception_lint:
     path: ../../packages/colonizethis_exception_lint
   colonizethis_test:
-  custom_lint: ^0.8.1
+  custom_lint: 0.8.1
   path: ^1.9.0
-  test: ^1.24.0
+  test: 1.30.0
 
 executables:
   sim_combat_montecarlo: bin/sim_combat_montecarlo.dart

--- a/tool/sim_economy/pubspec.yaml
+++ b/tool/sim_economy/pubspec.yaml
@@ -17,8 +17,8 @@ dev_dependencies:
   colonizethis_exception_lint:
     path: ../../packages/colonizethis_exception_lint
   colonizethis_test:
-  custom_lint: ^0.8.1
-  test: ^1.24.0
+  custom_lint: 0.8.1
+  test: 1.30.0
 
 executables:
   sim_economy: bin/sim_economy.dart

--- a/tool/sim_scenarios/pubspec.yaml
+++ b/tool/sim_scenarios/pubspec.yaml
@@ -22,8 +22,8 @@ dev_dependencies:
   colonizethis_exception_lint:
     path: ../../packages/colonizethis_exception_lint
   colonizethis_test:
-  custom_lint: ^0.8.1
-  test: ^1.24.0
+  custom_lint: 0.8.1
+  test: 1.30.0
 
 executables:
   sim_scenarios: bin/sim_scenarios.dart


### PR DESCRIPTION
## Summary

- Pin toolchain-related direct/dev dependencies to **explicit** versions (`analyzer` 8.4.0, `test` 1.30.0, `custom_lint` 0.8.1, `hardcoded_strings_lint` 1.0.4, `analyzer_plugin` 0.13.10, `meta` 1.17.0) across workspace `pubspec.yaml` files.
- Document remaining below-Latest rows in **CONTRIBUTING.md** and **SPEC/program/pub-workspace-toolchain.md** with linked Phase 2 follow-ups **#2539**, **#2540**, **#2541**.
- No version upgrades in this slice: solver already at newest **Resolvable** graph on Flutter 3.41.9 / Dart 3.11.5.

## Acceptance criteria

| AC | Status |
|----|--------|
| In-scope rows at Latest | N/A — none resolvable below Latest except documented blockers |
| Documented blockers + linked issues | Done (#2539–#2541) |
| #2073 audit recorded | Issue comment on #2532 |
| `repo.workspace_outdated_*` pass | Verified locally |
| Pinning policy in CONTRIBUTING | Done |
| Lint gates on current stack | `colonizethis_exception_lint` + `colonizethis_data` tests pass |
| Phase 2 follow-ups filed | #2539, #2540, #2541 |

## Deferred

- Phase 2 analyzer-13 / `hardcoded_strings_lint` 2.x / `test` Latest → follow-up issues above.

## Tests

- `dart pub get`
- `dart run tool/ct_repo_lint.dart --rule repo.workspace_outdated_resolvable`
- `dart run tool/ct_repo_lint.dart --rule repo.workspace_outdated_latest_direct`
- `cd packages/colonizethis_exception_lint && dart test`
- `cd packages/colonizethis_data && dart test`

Refs #2532

Made with [Cursor](https://cursor.com)