### PR TITLE
test(e2e): naval panel open hit-testable waits for fleet E2E (#2336)

### DIFF
--- a/app/integration_test/e2e_test_shared_panels.dart
+++ b/app/integration_test/e2e_test_shared_panels.dart
@@ -180,7 +180,9 @@ Future<void> e2eOpenNavalPanel(
     try {
       await tester.ensureVisible(trigger);
     } catch (_) {}
-    await tester.tap(trigger.first, warnIfMissed: false);
+    final hit = trigger.hitTestable();
+    final target = hit.evaluate().isNotEmpty ? hit : trigger;
+    await tester.tap(target.first, warnIfMissed: false);
     if (navalPanel.evaluate().isNotEmpty) {
       return true;
     }
@@ -188,12 +190,22 @@ Future<void> e2eOpenNavalPanel(
     if (navalPanel.evaluate().isNotEmpty) {
       return true;
     }
+    await e2eWaitUntilFound(
+      tester,
+      navalPanel,
+      timeout: const Duration(seconds: 5),
+      perf: perf,
+      phaseName: 'wait_until_naval_panel_after_trigger_tap',
+    );
+    if (navalPanel.evaluate().isNotEmpty) {
+      return true;
+    }
     return e2ePumpUntilConditionOrIdle(
       tester,
       () => navalPanel.evaluate().isNotEmpty,
-      timeout: const Duration(seconds: 3),
+      timeout: const Duration(seconds: 2),
       perf: perf,
-      phaseName: 'pump_until_naval_panel_after_trigger_tap',
+      phaseName: 'pump_until_naval_panel_after_trigger_tap_miss',
     );
   }
 
@@ -240,6 +252,15 @@ Future<void> e2eOpenNavalPanel(
       continue;
     }
     if (empireRailButton.evaluate().isNotEmpty) {
+      if (empireRailButton.hitTestable().evaluate().isEmpty) {
+        await e2eWaitUntilAnyFinderHitTestable(
+          tester,
+          [empireRailButton, markerButton],
+          timeout: const Duration(seconds: 5),
+          perf: perf,
+          phaseName: 'wait_until_naval_rail_hit_testable',
+        );
+      }
       if (await tryOpen(empireRailButton)) {
         perf?.timing('open_panel_naval', sw.elapsed);
         return;
@@ -248,6 +269,15 @@ Future<void> e2eOpenNavalPanel(
       continue;
     }
     if (markerButton.evaluate().isNotEmpty) {
+      if (markerButton.hitTestable().evaluate().isEmpty) {
+        await e2eWaitUntilAnyFinderHitTestable(
+          tester,
+          [markerButton, empireRailButton],
+          timeout: const Duration(seconds: 5),
+          perf: perf,
+          phaseName: 'wait_until_naval_marker_hit_testable',
+        );
+      }
       if (await tryOpen(markerButton)) {
         perf?.timing('open_panel_naval', sw.elapsed);
         return;


### PR DESCRIPTION
## Summary

- Align `e2eOpenNavalPanel` with the production-panel opener: tap hit-testable rail/marker targets, `e2eWaitUntilFound` (5s) for `kCtE2ENavalPanelRootKey` after tap, and `e2eWaitUntilAnyFinderHitTestable` before tapping when the empire rail exists but is not yet hit-testable.
- Targets PR #2515 follow-up: naval panel root never mounted after empire-rail tap within 5s (blocks fleet + full_turn AC6–AC7).

## AC status

| AC | Status |
|----|--------|
| AC1–AC5 | Already on `dev` |
| AC6–AC7 | **This PR** — expect fleet/full_turn to pass once naval panel mounts reliably |
| AC8 | Deferred — re-run `tool/run_e2e_timing.sh` after AC6–AC7 green |
| AC9 | Deferred — needs AC8 baseline on green suite (prior aggregate −21.8%, need ≥25%) |
| AC10 | Deferred — 3× stability pass after AC6–AC7 |

## Test plan

- [x] `cd app && flutter analyze integration_test/e2e_test_shared_panels.dart`
- [x] `cd app && flutter test test/e2e_test_shared_smoke_test.dart test/e2e_adaptive_poll_ramp_test.dart`
- [ ] `xvfb-run flutter test integration_test/new_game_fleet_reaches_new_world_e2e_test.dart -d linux --dart-define=CT_E2E=true`
- [ ] `xvfb-run flutter test integration_test/new_game_full_turn_e2e_test.dart -d linux --dart-define=CT_E2E=true`

Refs #2336

Made with [Cursor](https://cursor.com)