### PR TITLE
fix(ai): observer-quota OW expansion pressure alignment (Refs #2509)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
+++ b/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
@@ -139,15 +139,14 @@ List<String> stalledBelowQuotaGpLeadPeaceTargets({
   if (!isBelowObserverConquestQuota(snapshot.conquest.oldWorldProvincesOwned)) {
     return const [];
   }
-  if (!isStalledOldWorldExpansion(snapshot.conquest.oldWorldProvincesOwned)) {
-    return const [];
-  }
   final own = snapshot.conquest.oldWorldProvincesOwned;
+  final minLeadDeficit = own <= kFewOldWorldProvincesDefendThreshold
+      ? 1
+      : kUnwinnableSoleGpMinProvinceDeficit;
   final targets = <String>[
     for (final factionId in snapshot.threats.atWarWith)
       if (game.playerById(factionId) != null &&
-          provinceCountOwnedBy(game, factionId) >=
-              own + kUnwinnableSoleGpMinProvinceDeficit)
+          provinceCountOwnedBy(game, factionId) >= own + minLeadDeficit)
         factionId,
   ]..sort();
   return targets;

--- a/packages/colonizethis_ai/lib/src/planning/conquest_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/conquest_planner.dart
@@ -32,7 +32,9 @@ String? stalledConquestDeclaredWarTarget({
       )) {
     return gpBlocker;
   }
-  if (!isStalledOldWorldExpansion(snapshot.conquest.oldWorldProvincesOwned)) {
+  if (!isObserverConquestExpansionPressure(
+    snapshot.conquest.oldWorldProvincesOwned,
+  )) {
     return declaredThisTurn;
   }
   String? bestMinorId;
@@ -57,7 +59,7 @@ Orders runConquestArmyMovePlanner({
   required AIWorldSnapshot snapshot,
   String? declaredWarTargetFactionId,
 }) {
-  final stalledExpansion = isStalledOldWorldExpansion(
+  final stalledExpansion = isObserverConquestExpansionPressure(
     snapshot.conquest.oldWorldProvincesOwned,
   );
   final armyMoveCandidates = ctx.suggestionAPI.suggestArmyMoveOrders(

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_declare_war.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_declare_war.dart
@@ -495,12 +495,12 @@ int _declareWarStalledOldWorldExpansionBonuses(
   _DeclareWarTargetContext ctx,
   int s,
 ) {
-  final stalledOldWorldExpansion =
-      ctx.snapshot.conquest.oldWorldProvincesOwned <=
-      kStalledOldWorldProvinceThreshold;
+  final observerExpansionPressure = isObserverConquestExpansionPressure(
+    ctx.snapshot.conquest.oldWorldProvincesOwned,
+  );
   final hasInvadableOldWorld =
       ctx.snapshot.conquest.invadableProvinceIdsSorted.isNotEmpty;
-  if (!stalledOldWorldExpansion || !hasInvadableOldWorld) {
+  if (!observerExpansionPressure || !hasInvadableOldWorld) {
     return s;
   }
   if (_isStalledOwMinorInvadableTarget(ctx)) {
@@ -517,14 +517,14 @@ int _declareWarStalledOldWorldExpansionBonuses(
 }
 
 int _declareWarEarlyExpansionBonuses(_DeclareWarTargetContext ctx, int s) {
-  final stalledOldWorldExpansion =
-      ctx.snapshot.conquest.oldWorldProvincesOwned <=
-      kStalledOldWorldProvinceThreshold;
+  final observerExpansionPressure = isObserverConquestExpansionPressure(
+    ctx.snapshot.conquest.oldWorldProvincesOwned,
+  );
   final hasInvadableOldWorld =
       ctx.snapshot.conquest.invadableProvinceIdsSorted.isNotEmpty;
   if (ctx.currentTurn > kDeclareWarEarlyExpansionMaxTurn ||
       !ctx.anyMinorOwnsOldWorld ||
-      !stalledOldWorldExpansion ||
+      !observerExpansionPressure ||
       !hasInvadableOldWorld) {
     return s;
   }

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
@@ -79,7 +79,7 @@ void main() {
     },
     skip:
         'Partial AC #2509: seed-42 turn-100 gate passes gp1/gp2/gp4; '
-        'gp3 survives (-2 net, was -7), gp5 +1, gp6 +2; nightly S10 follow-up',
+        'gp3 -2, gp5 +1, gp6 +2; observer-quota expansion pressure aligned (S10)',
     timeout: const Timeout(Duration(minutes: 15)),
   );
 }

--- a/packages/colonizethis_data/lib/src/ai_victory_config.dart
+++ b/packages/colonizethis_data/lib/src/ai_victory_config.dart
@@ -90,6 +90,9 @@ const int kDeclareWarAdjacentMinorBonusWhenFarFromVictory = 55;
 /// per-GP conquest AC; only 18 non-GP Old World provinces at default setup).
 const int kSuppressGpDeclareWarMinProvincesToVictory = 12;
 
+/// Observer default start OW provinces per GP (Refs #2509).
+const int kObserverDefaultStartOldWorldProvincesPerGp = 7;
+
 /// Old World holdings at or below this count are treated as stalled expansion
 /// (observer default start is 7 provinces per GP).
 const int kStalledOldWorldProvinceThreshold = 8;
@@ -125,7 +128,7 @@ const int kDeclareWarWeakGpOwMinorRecoveryBonus = 120;
 
 /// Extra declare-war weight toward OW minors while below the observer quota
 /// (7–9 OW holdings; Refs #2509).
-const int kDeclareWarBelowQuotaOwMinorRecoveryBonus = 110;
+const int kDeclareWarBelowQuotaOwMinorRecoveryBonus = 150;
 
 /// Penalize tribe declare-war while OW holdings are stalled and invadable OW
 /// minors remain (tribes without sea-reachable NW provinces for this GP).
@@ -222,14 +225,14 @@ const int kObserverConquestConsolidateMinOwProvinces =
 const int kUnwinnableSoleGpMinProvinceDeficit = 2;
 
 /// Declare-war bonus on adjacent invadable OW minors while below the observer quota.
-const int kDeclareWarBelowObserverQuotaMinorBonus = 165;
+const int kDeclareWarBelowObserverQuotaMinorBonus = 195;
 
 /// Offer-peace bonus toward any at-war Great Power when stalled with zero regiments
 /// (exit unwinnable GP wars before elimination; observer seed-42 gp3; Refs #2509).
 const int kOfferPeaceStalledZeroRegimentGpWarBonus = 270;
 
 /// Regiment build floor when critically weak, below the observer quota, and at war.
-const int kStalledMinRegimentCountWhenCriticallyWeakBelowQuota = 8;
+const int kStalledMinRegimentCountWhenCriticallyWeakBelowQuota = 12;
 
 /// Offer-peace bonus for [unwinnableSoleGpFrontierPeaceTarget] (Refs #2509).
 const int kOfferPeaceUnwinnableSoleGpWarBonus = 250;


### PR DESCRIPTION
## Summary

Follow-up S10 tuning on top of merged #2550 for issue #2509:

- Route declare-war minor bonuses and conquest army-move fallbacks through `isObserverConquestExpansionPressure` (stalled band **or** below turn-100 observer quota) so GPs with 9 OW provinces still get below-quota pressure.
- Raise below-quota minor declare-war and critically-weak regiment-rebuild floors in `ai_victory_config.dart`.
- Ease stalled below-quota peace when critically weak (`colonial_pressure.dart`).

## Deferred (same issue)

- **S10 / nightly green:** Seed-42 turn-100 `--verify-conquest` remains partial — `seed42_observer_conquest_regression_test` stays skipped (gp3 −2, gp5 +1, gp6 +2 vs +3 gate). Turn-150 `--verify-colonial-expansion` not re-run here (nightly only).
- Colonial perception/scoring/civilian slices and observer tool/CI largely landed in prior PRs; no new observer CLI changes in this PR.

## Acceptance criteria (this PR)

| AC | Status |
|----|--------|
| Must-have #5 (OW not weakened) | Partial — stronger below-quota OW pressure; turn-100 gate still open for gp3/gp5/gp6 |
| Systemic turn-100/150 observer gates | Not claimed complete |

## Tests

- `packages/colonizethis_ai`: `diplomacy_planner_below_quota_peace_test.dart`, `diplomatic_candidate_scoring_suppression_test.dart`, `seed42_gp4_war_focus_test.dart` (all green)

Refs #2509

Made with [Cursor](https://cursor.com)