### PR TITLE
test(e2e): naval panel opener retry and fleet snapshot exits (Refs #2336)

### DIFF
--- a/app/integration_test/e2e_test_shared_panels.dart
+++ b/app/integration_test/e2e_test_shared_panels.dart
@@ -190,22 +190,14 @@ Future<void> e2eOpenNavalPanel(
     if (navalPanel.evaluate().isNotEmpty) {
       return true;
     }
-    await e2eWaitUntilFound(
-      tester,
-      navalPanel,
-      timeout: const Duration(seconds: 5),
-      perf: perf,
-      phaseName: 'wait_until_naval_panel_after_trigger_tap',
-    );
-    if (navalPanel.evaluate().isNotEmpty) {
-      return true;
-    }
+    // Match [e2eOpenCivilianPanel] tryOpen: bounded poll without fail() so the
+    // outer opener loop can dismiss sheets and retry rail/marker (Refs #2336).
     return e2ePumpUntilConditionOrIdle(
       tester,
       () => navalPanel.evaluate().isNotEmpty,
-      timeout: const Duration(seconds: 2),
+      timeout: const Duration(seconds: 3),
       perf: perf,
-      phaseName: 'pump_until_naval_panel_after_trigger_tap_miss',
+      phaseName: 'pump_until_naval_panel_after_trigger_tap',
     );
   }
 

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_helpers.dart
@@ -124,7 +124,7 @@ Future<void> _pickMoveDestinationAndConfirm(
           // Row may not be built yet; fall back to drag probing below.
         }
       }
-      const maxWarpDragProbes = 12;
+      const maxWarpDragProbes = 8;
       for (var i = 0;
           i < maxWarpDragProbes && warp.hitTestable().evaluate().isEmpty;
           i++) {

--- a/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
+++ b/app/integration_test/new_game_fleet_reaches_new_world_e2e_test.dart
@@ -86,7 +86,23 @@ void main() {
     ) {
       ensureUnderWallClock('turn loop start turnIdx=$turnIdx');
       perf.bumpCounter('turn_loop_iterations');
+      if (_fleetReachDoneFromCtSnapshotOnly()) {
+        perf.timing(
+          'test_total',
+          testSw.elapsed,
+          meta: 'result=reached_snapshot_precheck',
+        );
+        return;
+      }
       await dismissTransientUi(tester, perf: perf);
+      if (_fleetReachDoneFromCtSnapshotOnly()) {
+        perf.timing(
+          'test_total',
+          testSw.elapsed,
+          meta: 'result=reached_snapshot_after_dismiss',
+        );
+        return;
+      }
       await _tapNewWorldRegionTabIfPresent(tester);
       if (_fleetReachDoneFromCtSnapshotOnly()) {
         perf.timing(
@@ -228,7 +244,13 @@ void main() {
       ) {
         ensureUnderWallClock('turn loop start turnIdx=$turnIdx');
         perf.bumpCounter('turn_loop_iterations');
+        if (_fleetReachDoneFromCtSnapshotOnly()) {
+          break;
+        }
         await dismissTransientUi(tester, perf: perf);
+        if (_fleetReachDoneFromCtSnapshotOnly()) {
+          break;
+        }
         await _tapNewWorldRegionTabIfPresent(tester);
         if (_fleetReachDoneFromCtSnapshotOnly()) {
           break;

--- a/app/integration_test/new_game_full_turn_e2e_test.dart
+++ b/app/integration_test/new_game_full_turn_e2e_test.dart
@@ -170,12 +170,12 @@ void main() {
       await closeBottomSheet(tester, perf: perf);
 
       // --- Civilian rail: after draft orders ---
-      await tester.tap(find.byKey(kEmpireCivilianUnitsButtonKey));
+      await openCivilianPanel(tester, perf: perf);
       await expectCivilianPanelTexts();
       await closeBottomSheet(tester, perf: perf);
 
       // --- Naval rail: collapsed ---
-      await tester.tap(find.byKey(kEmpireNavalUnitsButtonKey));
+      await openNavalPanel(tester, perf: perf);
       await expectNavalPanelTexts(expanded: false);
       await expandEachExpansionTileOnce(tester);
       final navalPanelRoot = find.byKey(kCtE2ENavalPanelRootKey);


### PR DESCRIPTION
## Summary

- **Naval panel opener:** `e2eOpenNavalPanel` `tryOpen` now uses `e2ePumpUntilConditionOrIdle` (same as civilian) instead of `e2eWaitUntilFound`, which called `fail()` after 5s and prevented the outer opener loop from dismissing sheets and retrying rail/marker taps — the root cause of `wait_until_naval_panel_after_trigger_tap` failures on fleet + full_turn (PR #2515 follow-up).
- **Full-turn:** Civilian/naval empire-rail steps use `openCivilianPanel` / `openNavalPanel` instead of raw `tester.tap` so transient UI and sheet dismissal match other scenarios.
- **Fleet reach:** Check `_fleetReachDoneFromCtSnapshotOnly()` before dismiss/region-tab work each turn; reduce warp-row drag probes from 12 → 8 (H4).

## AC coverage (this PR)

| AC | Status |
|----|--------|
| AC1–AC5 | No change (already on `dev`) |
| AC6–AC7 | **Expected fix** for naval-rail timeout; maintainer must run 3× Linux `integration_test` |
| AC8–AC9 | **Deferred** — re-run `tool/run_e2e_timing.sh 3` on Linux after AC6–AC7 green |
| AC10 | **Deferred** — depends on AC6–AC7 |

## Tests

```bash
cd app && flutter analyze integration_test/e2e_test_shared_panels.dart
cd app && flutter test test/e2e_test_shared_smoke_test.dart test/e2e_adaptive_poll_ramp_test.dart
dart test test/compare_e2e_timing_test.dart
```

Local macOS `integration_test/new_game_capital_panel_e2e_test.dart` still times out opening province panel (unrelated to this diff); Linux desktop remains the AC6 source of truth per SPEC.

Refs #2336

Made with [Cursor](https://cursor.com)