### PR TITLE
fix(ai): S10 turn-100 observer gate tuning (Refs #2509)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
+++ b/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
@@ -281,8 +281,7 @@ List<String> quotaMetFutileBelowQuotaGpPeaceTargets({
 /// Peace every at-war Great Power when OW holdings are critically low and minors
 /// remain on the map (avoid OW elimination; Refs #2509).
 ///
-/// When below the observer conquest quota, peace all GP wars even if minors were
-/// eliminated from the map (seed-42 gp3 late-game collapse).
+/// Peace all GP wars when critically weak (≤6 OW) or stalled with minors left.
 List<String> criticalOwHoldPeaceTargets({
   required Game game,
   required AIWorldSnapshot snapshot,
@@ -295,7 +294,8 @@ List<String> criticalOwHoldPeaceTargets({
   if (targets.isEmpty) {
     return const [];
   }
-  if (isBelowObserverConquestQuota(ownOw)) {
+  if (isBelowObserverConquestQuota(ownOw) &&
+      ownOw <= kFewOldWorldProvincesDefendThreshold) {
     return targets;
   }
   if (ownOw > kStalledOldWorldProvinceThreshold) {

--- a/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
+++ b/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
@@ -287,10 +287,7 @@ List<String> criticalOwHoldPeaceTargets({
   required Game game,
   required AIWorldSnapshot snapshot,
 }) {
-  if (snapshot.conquest.oldWorldProvincesOwned >
-      kStalledOldWorldProvinceThreshold) {
-    return const [];
-  }
+  final ownOw = snapshot.conquest.oldWorldProvincesOwned;
   final targets = <String>[
     for (final factionId in snapshot.threats.atWarWith)
       if (game.playerById(factionId) != null) factionId,
@@ -298,10 +295,11 @@ List<String> criticalOwHoldPeaceTargets({
   if (targets.isEmpty) {
     return const [];
   }
-  if (isBelowObserverConquestQuota(snapshot.conquest.oldWorldProvincesOwned) &&
-      snapshot.conquest.oldWorldProvincesOwned <=
-          kStalledOldWorldProvinceThreshold) {
+  if (isBelowObserverConquestQuota(ownOw)) {
     return targets;
+  }
+  if (ownOw > kStalledOldWorldProvinceThreshold) {
+    return const [];
   }
   final minorsExist = game.worldState.oldWorld.provinces.any(
     (p) =>

--- a/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
@@ -392,8 +392,9 @@ String? criticalWeakUninvadedMinorDeclareTarget({
   required Game game,
   required AIWorldSnapshot snapshot,
 }) {
-  if (snapshot.conquest.oldWorldProvincesOwned >
-      kFewOldWorldProvincesDefendThreshold) {
+  if (!isBelowObserverConquestQuota(
+    snapshot.conquest.oldWorldProvincesOwned,
+  )) {
     return null;
   }
   if (snapshot.threats.atWarWith.any((id) => game.playerById(id) != null)) {

--- a/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
@@ -387,7 +387,7 @@ List<String> mutualZeroRegimentGpStalematePeaceTargets({
 }
 
 /// First minor nation that owns invadable OW land but is not yet at war, while
-/// this GP is critically weak and not fighting any Great Power (Refs #2509).
+/// this GP is below the observer quota and not fighting any Great Power (Refs #2509).
 String? criticalWeakUninvadedMinorDeclareTarget({
   required Game game,
   required AIWorldSnapshot snapshot,

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_declare_war.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_declare_war.dart
@@ -389,10 +389,15 @@ int? _declareWarSuppressedAdjacentGpScore(
           attackerOw >= targetOw + belowQuotaSuppressLead) {
         return 0;
       }
-      if (isBelowObserverConquestQuota(targetOw) &&
-          !isBelowObserverConquestQuota(attackerOw) &&
-          targetOw <= kObserverDefaultStartOldWorldProvincesPerGp &&
+      if (targetOw <= kObserverDefaultStartOldWorldProvincesPerGp &&
+          attackerOw > targetOw &&
+          !ctx.invadableGpBlocker &&
           !ctx.snapshot.threats.atWarWith.contains(ctx.order.targetFactionId)) {
+        return 0;
+      }
+      if (targetOw <= kObserverDefaultStartOldWorldProvincesPerGp &&
+          attackerOw >= kObserverConquestMinOwProvincesPerGp - 1 &&
+          !ctx.invadableGpBlocker) {
         return 0;
       }
       if (isBelowObserverConquestQuota(attackerOw) &&
@@ -464,6 +469,11 @@ int? _declareWarSuppressedWarConcentrationScore(
     }
     final attackerOw = ctx.snapshot.conquest.oldWorldProvincesOwned;
     if (isBelowObserverConquestQuota(targetOw) && targetGpWarCount >= 1) {
+      return 0;
+    }
+    if (isBelowObserverConquestQuota(targetOw) &&
+        attackerOw >= targetOw + 2 &&
+        !ctx.invadableGpBlocker) {
       return 0;
     }
   }
@@ -720,6 +730,17 @@ int _declareWarAdjacencyAndStalledBonuses(
           (id) => ctx.game.playerById(id) != null,
         )) {
       s += kDeclareWarPlateauOwMinorBonus;
+    }
+    if (ctx.isMinorTarget &&
+        !ctx.isTribeTarget &&
+        ctx.isAdjacentOwner &&
+        ctx.invadableOwners.contains(ctx.order.targetFactionId) &&
+        ownedOw >= kObserverDefaultStartOldWorldProvincesPerGp + 1 &&
+        ownedOw < kObserverConquestMinOwProvincesPerGp &&
+        !ctx.snapshot.threats.atWarWith.any(
+          (id) => ctx.game.playerById(id) != null,
+        )) {
+      s += kDeclareWarNearObserverQuotaMinorBonus;
     }
     if (ctx.isMinorTarget && ctx.stalledOwExpansion) {
       s += kDeclareWarStalledExpansionMinorBonus;

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_declare_war.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_declare_war.dart
@@ -389,6 +389,12 @@ int? _declareWarSuppressedAdjacentGpScore(
           attackerOw >= targetOw + belowQuotaSuppressLead) {
         return 0;
       }
+      if (isBelowObserverConquestQuota(targetOw) &&
+          !isBelowObserverConquestQuota(attackerOw) &&
+          targetOw <= kObserverDefaultStartOldWorldProvincesPerGp &&
+          !ctx.snapshot.threats.atWarWith.contains(ctx.order.targetFactionId)) {
+        return 0;
+      }
       if (isBelowObserverConquestQuota(attackerOw) &&
           targetOw >= attackerOw + kUnwinnableSoleGpMinProvinceDeficit) {
         return 0;
@@ -457,10 +463,7 @@ int? _declareWarSuppressedWarConcentrationScore(
       return 0;
     }
     final attackerOw = ctx.snapshot.conquest.oldWorldProvincesOwned;
-    if (isBelowObserverConquestQuota(targetOw) &&
-        targetGpWarCount >= 1 &&
-        (ctx.currentTurn <= kDeclareWarEarlyAntiDogpileMaxTurn ||
-            !isBelowObserverConquestQuota(attackerOw))) {
+    if (isBelowObserverConquestQuota(targetOw) && targetGpWarCount >= 1) {
       return 0;
     }
   }
@@ -712,7 +715,7 @@ int _declareWarAdjacencyAndStalledBonuses(
         !ctx.isTribeTarget &&
         ctx.isAdjacentOwner &&
         ctx.invadableOwners.contains(ctx.order.targetFactionId) &&
-        (ownedOw == 8 || ownedOw == 9) &&
+        isBelowObserverConquestQuota(ownedOw) &&
         !ctx.snapshot.threats.atWarWith.any(
           (id) => ctx.game.playerById(id) != null,
         )) {

--- a/packages/colonizethis_ai/test/diplomacy_planner_below_quota_peace_test.dart
+++ b/packages/colonizethis_ai/test/diplomacy_planner_below_quota_peace_test.dart
@@ -189,6 +189,62 @@ void main() {
   );
 
   test(
+    'criticalOwHoldPeaceTargets peace GP wars at 9 OW below quota (plateau band)',
+    () {
+      final game = Game(
+        id: 'g-critical-below-quota-nine-ow',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 90),
+          oldWorld: RegionData(
+            provinces: [
+              for (var i = 1; i <= 9; i++)
+                Province(
+                  id: 'oldWorld|gp5_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp5',
+                ),
+              for (var i = 1; i <= 12; i++)
+                Province(
+                  id: 'oldWorld|gp4_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp4',
+                ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp5', displayName: 'P5', isHuman: false),
+          Player(id: 'gp4', displayName: 'P4', isHuman: false),
+        ],
+        diplomacyRelations: [
+          const DiplomacyRelation(
+            factionId1: 'gp5',
+            factionId2: 'gp4',
+            state: RelationState.atWar,
+            score: 30,
+          ),
+        ],
+      );
+      const snapshot = AIWorldSnapshot(
+        playerId: 'gp5',
+        threats: ThreatSummary(atWarWith: ['gp4']),
+        opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(
+          oldWorldProvincesOwned: 9,
+          invadableProvinceIdsSorted: ['oldWorld|inv1'],
+        ),
+        economy: EconomySummary(),
+        relations: {},
+      );
+      expect(
+        criticalOwHoldPeaceTargets(game: game, snapshot: snapshot),
+        ['gp4'],
+      );
+    },
+  );
+
+  test(
     'weakHoldingsInvadableBlockerPeaceTargets peace blocker at 7 OW below quota',
     () {
       final game = Game(
@@ -423,6 +479,51 @@ void main() {
       expect(
         criticalWeakUninvadedMinorDeclareTarget(game: game, snapshot: snapshot),
         'minor2',
+      );
+    },
+  );
+
+  test(
+    'criticalWeakUninvadedMinorDeclareTarget picks minor at 8 OW below quota',
+    () {
+      final game = Game(
+        id: 'g-plateau-minor-declare',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 40),
+          oldWorld: RegionData(
+            provinces: [
+              for (var i = 1; i <= 8; i++)
+                Province(
+                  id: 'oldWorld|gp5_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp5',
+                ),
+              const Province(
+                id: 'oldWorld|m1',
+                regionId: 'oldWorld',
+                ownerId: 'minor1',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [Player(id: 'gp5', displayName: 'P5', isHuman: false)],
+        minorNations: const [MinorNation(id: 'minor1', displayName: 'M1')],
+      );
+      const snapshot = AIWorldSnapshot(
+        playerId: 'gp5',
+        threats: ThreatSummary(),
+        opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(
+          oldWorldProvincesOwned: 8,
+          invadableProvinceIdsSorted: ['oldWorld|m1'],
+        ),
+        economy: EconomySummary(),
+        relations: {},
+      );
+      expect(
+        criticalWeakUninvadedMinorDeclareTarget(game: game, snapshot: snapshot),
+        'minor1',
       );
     },
   );

--- a/packages/colonizethis_ai/test/diplomacy_planner_below_quota_peace_test.dart
+++ b/packages/colonizethis_ai/test/diplomacy_planner_below_quota_peace_test.dart
@@ -133,7 +133,7 @@ void main() {
   );
 
   test(
-    'criticalOwHoldPeaceTargets peace sole GP war at 7 OW below quota when minors gone',
+    'criticalOwHoldPeaceTargets skips sole GP war at 7 OW (uses other peace paths)',
     () {
       final game = Game(
         id: 'g-critical-below-quota-seven-ow',
@@ -183,63 +183,7 @@ void main() {
       );
       expect(
         criticalOwHoldPeaceTargets(game: game, snapshot: snapshot),
-        ['gp4'],
-      );
-    },
-  );
-
-  test(
-    'criticalOwHoldPeaceTargets peace GP wars at 9 OW below quota (plateau band)',
-    () {
-      final game = Game(
-        id: 'g-critical-below-quota-nine-ow',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 90),
-          oldWorld: RegionData(
-            provinces: [
-              for (var i = 1; i <= 9; i++)
-                Province(
-                  id: 'oldWorld|gp5_$i',
-                  regionId: 'oldWorld',
-                  ownerId: 'gp5',
-                ),
-              for (var i = 1; i <= 12; i++)
-                Province(
-                  id: 'oldWorld|gp4_$i',
-                  regionId: 'oldWorld',
-                  ownerId: 'gp4',
-                ),
-            ],
-          ),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'gp5', displayName: 'P5', isHuman: false),
-          Player(id: 'gp4', displayName: 'P4', isHuman: false),
-        ],
-        diplomacyRelations: [
-          const DiplomacyRelation(
-            factionId1: 'gp5',
-            factionId2: 'gp4',
-            state: RelationState.atWar,
-            score: 30,
-          ),
-        ],
-      );
-      const snapshot = AIWorldSnapshot(
-        playerId: 'gp5',
-        threats: ThreatSummary(atWarWith: ['gp4']),
-        opportunities: OpportunitySummary(),
-        conquest: ConquestSummary(
-          oldWorldProvincesOwned: 9,
-          invadableProvinceIdsSorted: ['oldWorld|inv1'],
-        ),
-        economy: EconomySummary(),
-        relations: {},
-      );
-      expect(
-        criticalOwHoldPeaceTargets(game: game, snapshot: snapshot),
-        ['gp4'],
+        isEmpty,
       );
     },
   );
@@ -479,51 +423,6 @@ void main() {
       expect(
         criticalWeakUninvadedMinorDeclareTarget(game: game, snapshot: snapshot),
         'minor2',
-      );
-    },
-  );
-
-  test(
-    'criticalWeakUninvadedMinorDeclareTarget picks minor at 8 OW below quota',
-    () {
-      final game = Game(
-        id: 'g-plateau-minor-declare',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 40),
-          oldWorld: RegionData(
-            provinces: [
-              for (var i = 1; i <= 8; i++)
-                Province(
-                  id: 'oldWorld|gp5_$i',
-                  regionId: 'oldWorld',
-                  ownerId: 'gp5',
-                ),
-              const Province(
-                id: 'oldWorld|m1',
-                regionId: 'oldWorld',
-                ownerId: 'minor1',
-              ),
-            ],
-          ),
-          newWorld: const RegionData(),
-        ),
-        players: const [Player(id: 'gp5', displayName: 'P5', isHuman: false)],
-        minorNations: const [MinorNation(id: 'minor1', displayName: 'M1')],
-      );
-      const snapshot = AIWorldSnapshot(
-        playerId: 'gp5',
-        threats: ThreatSummary(),
-        opportunities: OpportunitySummary(),
-        conquest: ConquestSummary(
-          oldWorldProvincesOwned: 8,
-          invadableProvinceIdsSorted: ['oldWorld|m1'],
-        ),
-        economy: EconomySummary(),
-        relations: {},
-      );
-      expect(
-        criticalWeakUninvadedMinorDeclareTarget(game: game, snapshot: snapshot),
-        'minor1',
       );
     },
   );

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
@@ -78,8 +78,8 @@ void main() {
     }
     },
     skip:
-        'Partial AC #2509: seed-42 turn-100 gate — gp1/gp2 pass at turn 10; '
-        'gp3/gp5/gp6 still short after quota-met dogpile/peace tuning (S10)',
+        'Partial AC #2509: seed-42 turn-100 gate — gp1/gp2 meet +3 by turn 10; '
+        'gp3/gp5/gp6 still short (S10: below-quota peace/dogpile/minor-declare)',
     timeout: const Timeout(Duration(minutes: 15)),
   );
 }

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
@@ -78,8 +78,8 @@ void main() {
     }
     },
     skip:
-        'Partial AC #2509: seed-42 turn-100 gate — gp1/gp2 meet +3 by turn 10; '
-        'gp3/gp5/gp6 still short (S10: below-quota peace/dogpile/minor-declare)',
+        'Partial AC #2509 S10: seed-42 turn-100 — gp1/gp2/gp4 pass; '
+        'gp3 net -2 (collapse turns 5–15), gp5 +1, gp6 +2 (plateau 8–9 OW)',
     timeout: const Timeout(Duration(minutes: 15)),
   );
 }

--- a/packages/colonizethis_data/lib/src/ai_victory_config.dart
+++ b/packages/colonizethis_data/lib/src/ai_victory_config.dart
@@ -149,7 +149,8 @@ const int kDeclareWarEarlyExpansionTribePenalty = 160;
 const int kDeclareWarEarlyExpansionMaxTurn = 80;
 
 /// Through this turn, quota-meeting GPs must not open new wars on weaker
-/// below-quota neighbors (observer seed-42 gp3 turns 4–8; Refs #2509).
+/// below-quota neighbors when the target is not already in a GP war (Refs #2509).
+/// Pile-ons on below-quota victims already at war are suppressed at all turns.
 const int kDeclareWarEarlyAntiDogpileMaxTurn = 20;
 
 /// Penalty on adjacent minor declare-war when the GP already holds many OW provinces.

--- a/packages/colonizethis_data/lib/src/ai_victory_config.dart
+++ b/packages/colonizethis_data/lib/src/ai_victory_config.dart
@@ -132,7 +132,11 @@ const int kDeclareWarBelowQuotaOwMinorRecoveryBonus = 280;
 
 /// Extra declare-war toward adjacent invadable OW minors at 8–9 OW with no GP war
 /// (observer seed-42 gp5/gp6 plateau; Refs #2509).
-const int kDeclareWarPlateauOwMinorBonus = 160;
+const int kDeclareWarPlateauOwMinorBonus = 220;
+
+/// Extra declare-war weight toward invadable minors when 8–9 OW (one province
+/// short of the turn-100 observer gate from default start; Refs #2509).
+const int kDeclareWarNearObserverQuotaMinorBonus = 120;
 
 /// Penalize tribe declare-war while OW holdings are stalled and invadable OW
 /// minors remain (tribes without sea-reachable NW provinces for this GP).
@@ -140,13 +144,13 @@ const int kDeclareWarStalledExpansionTribePenalty = 100;
 
 /// Extra declare-war weight on adjacent OW minors while minors still exist on
 /// the map and the campaign is in the early expansion window (turn ≤ 30).
-const int kDeclareWarEarlyExpansionMinorBonus = 180;
+const int kDeclareWarEarlyExpansionMinorBonus = 260;
 
 /// Penalize tribe declare-war in that early window while any OW minor remains.
 const int kDeclareWarEarlyExpansionTribePenalty = 160;
 
 /// Last turn (inclusive) for [kDeclareWarEarlyExpansionMinorBonus].
-const int kDeclareWarEarlyExpansionMaxTurn = 80;
+const int kDeclareWarEarlyExpansionMaxTurn = 100;
 
 /// Through this turn, quota-meeting GPs must not open new wars on weaker
 /// below-quota neighbors when the target is not already in a GP war (Refs #2509).
@@ -239,7 +243,7 @@ const int kObserverConquestConsolidateMinOwProvinces =
 const int kUnwinnableSoleGpMinProvinceDeficit = 2;
 
 /// Declare-war bonus on adjacent invadable OW minors while below the observer quota.
-const int kDeclareWarBelowObserverQuotaMinorBonus = 240;
+const int kDeclareWarBelowObserverQuotaMinorBonus = 300;
 
 /// Offer-peace bonus toward any at-war Great Power when stalled with zero regiments
 /// (exit unwinnable GP wars before elimination; observer seed-42 gp3; Refs #2509).

--- a/packages/colonizethis_logic/lib/src/diplomacy/intervention_resolver_call_to_arms.dart
+++ b/packages/colonizethis_logic/lib/src/diplomacy/intervention_resolver_call_to_arms.dart
@@ -207,8 +207,7 @@ Game _processCallToArmsForWarPair(
     if (isAiControlled(state, allyGpId)) {
       final aggressorOw = provinceCountOwnedBy(state, aggressorGpId);
       final turn = state.worldState.turnState.turnNumber;
-      if (turn <= kDeclareWarEarlyAntiDogpileMaxTurn &&
-          isBelowObserverConquestQuota(aggressorOw)) {
+      if (isBelowObserverConquestQuota(aggressorOw)) {
         state = _applyCallToArmsRefuse(state, allyGpId, defenderGpId, turn);
         continue;
       }


### PR DESCRIPTION
## Summary

Continues **S10** (tune Full AI until seed-42 turn-100 `--verify-conquest` passes) after #2552 merged the first peace/dogpile slice.

- **Below-quota peace band** (from prior slice): critical OW peace, dogpile caps, call-to-arms refusal when aggressor is below quota, forced minor declare when no GP wars.
- **This PR:** Narrow `criticalOwHoldPeaceTargets` to ≤6 OW (not all `<10`) so 7–8 OW GPs are not forced into blanket GP peace; strengthen minor declare scoring (plateau/near-quota/early expansion bonuses); block quota-met GPs from opening on default start-size (7 OW) peers; update unit tests and regression skip message.

## Deferred (still open for S10)

Turn-100 seed-42 regression remains **skipped**. Latest profile: `gp1/gp2/gp4` meet +3; **gp3** net −2 (collapse turns 5–15), **gp5** +1, **gp6** +2 (plateau at 8–9 OW). Nightly turn-150 colonial gate out of scope for this slice.

## Test plan

- [x] `dart test packages/colonizethis_ai/test/diplomacy_planner_below_quota_peace_test.dart`
- [x] `dart test packages/colonizethis_ai/test/diplomatic_candidate_scoring_suppression_part2_test.dart`
- [ ] CI `quality` (not waited)

Refs #2509

Made with [Cursor](https://cursor.com)