### PR TITLE
fix(ai): S10 turn-100 gate follow-up — peace filters and OW priority (Refs #2509)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
+++ b/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
@@ -87,8 +87,38 @@ List<String> belowQuotaPeerGpPeaceTargets({
     for (final factionId in snapshot.threats.atWarWith)
       if (game.playerById(factionId) != null &&
           isBelowObserverConquestQuota(provinceCountOwnedBy(game, factionId)) &&
+          ownOw <= provinceCountOwnedBy(game, factionId) &&
           (provinceCountOwnedBy(game, factionId) - ownOw).abs() <= 2)
         factionId,
+  ]..sort();
+  return targets;
+}
+
+/// Peace non-blocker Great Power wars when one province short of the observer
+/// quota (hold early gains; seed-42 gp3; Refs #2509).
+List<String> nearQuotaHoldPeaceTargets({
+  required Game game,
+  required AIWorldSnapshot snapshot,
+}) {
+  final ownOw = snapshot.conquest.oldWorldProvincesOwned;
+  if (ownOw < kObserverConquestMinOwProvincesPerGp - 1 ||
+      !isBelowObserverConquestQuota(ownOw)) {
+    return const [];
+  }
+  final gpWars = <String>[
+    for (final factionId in snapshot.threats.atWarWith)
+      if (game.playerById(factionId) != null) factionId,
+  ];
+  if (gpWars.isEmpty) {
+    return const [];
+  }
+  final blocker = primaryInvadableOldWorldGpBlocker(
+    game: game,
+    snapshot: snapshot,
+  );
+  final targets = <String>[
+    for (final factionId in gpWars)
+      if (factionId != blocker) factionId,
   ]..sort();
   return targets;
 }

--- a/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
+++ b/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
@@ -83,12 +83,18 @@ List<String> belowQuotaPeerGpPeaceTargets({
   if (!minorsOnMap) {
     return const [];
   }
+  final gpOnlyFrontier = isOldWorldGpOnlyInvadableFrontier(
+    game: game,
+    snapshot: snapshot,
+  );
+  final soleGpWar = soleAtWarGreatPowerId(game: game, snapshot: snapshot);
   final targets = <String>[
     for (final factionId in snapshot.threats.atWarWith)
       if (game.playerById(factionId) != null &&
           isBelowObserverConquestQuota(provinceCountOwnedBy(game, factionId)) &&
           ownOw <= provinceCountOwnedBy(game, factionId) &&
-          (provinceCountOwnedBy(game, factionId) - ownOw).abs() <= 2)
+          (provinceCountOwnedBy(game, factionId) - ownOw).abs() <= 2 &&
+          !(gpOnlyFrontier && soleGpWar == factionId))
         factionId,
   ]..sort();
   return targets;
@@ -109,7 +115,7 @@ List<String> nearQuotaHoldPeaceTargets({
     for (final factionId in snapshot.threats.atWarWith)
       if (game.playerById(factionId) != null) factionId,
   ];
-  if (gpWars.isEmpty) {
+  if (gpWars.length < 2) {
     return const [];
   }
   final blocker = primaryInvadableOldWorldGpBlocker(
@@ -460,7 +466,7 @@ List<String> criticalOwHoldPeaceTargets({
     return const [];
   }
   if (isBelowObserverConquestQuota(ownOw) &&
-      ownOw <= kFewOldWorldProvincesDefendThreshold) {
+      ownOw < kFewOldWorldProvincesDefendThreshold) {
     return targets;
   }
   if (ownOw > kStalledOldWorldProvinceThreshold) {

--- a/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
+++ b/packages/colonizethis_ai/lib/src/planning/colonial_pressure.dart
@@ -55,7 +55,42 @@ bool shouldSkipBelowQuotaGpOnlyBlockerPeacePass({
     for (final factionId in snapshot.threats.atWarWith)
       if (game.playerById(factionId) != null) factionId,
   ];
-  return gpWars.length == 1 && gpWars.single == blocker;
+  if (gpWars.length != 1 || gpWars.single != blocker) {
+    return false;
+  }
+  // Keep fighting a winnable sole-blocker war; pivot when clearly outgunned.
+  return unwinnableSoleGpFrontierPeaceTarget(game: game, snapshot: snapshot) ==
+      null;
+}
+
+/// Peace other below-quota Great Powers in peer-stalled wars while minors remain
+/// (exit mutual gp5/gp6 distraction; Refs #2509).
+List<String> belowQuotaPeerGpPeaceTargets({
+  required Game game,
+  required AIWorldSnapshot snapshot,
+}) {
+  final ownOw = snapshot.conquest.oldWorldProvincesOwned;
+  if (!isBelowObserverConquestQuota(ownOw)) {
+    return const [];
+  }
+  final provinceOwner = getProvinceOwnerMap(game);
+  final minorsOnMap = game.worldState.oldWorld.provinces.any(
+    (p) =>
+        p.ownerId != null &&
+        p.ownerId!.isNotEmpty &&
+        game.minorNations.any((m) => m.id == p.ownerId),
+  );
+  if (!minorsOnMap) {
+    return const [];
+  }
+  final targets = <String>[
+    for (final factionId in snapshot.threats.atWarWith)
+      if (game.playerById(factionId) != null &&
+          isBelowObserverConquestQuota(provinceCountOwnedBy(game, factionId)) &&
+          (provinceCountOwnedBy(game, factionId) - ownOw).abs() <= 2)
+        factionId,
+  ]..sort();
+  return targets;
 }
 
 /// GP owning the most invadable Old World provinces (frontier blocker).
@@ -258,7 +293,9 @@ List<String> stalledBelowQuotaGpLeadPeaceTargets({
     return const [];
   }
   final own = snapshot.conquest.oldWorldProvincesOwned;
-  final minLeadDeficit = 1;
+  final minLeadDeficit = own <= kObserverDefaultStartOldWorldProvincesPerGp
+      ? kUnwinnableSoleGpMinProvinceDeficit
+      : 1;
   final invadableBlocker = isOldWorldGpOnlyInvadableFrontier(
         game: game,
         snapshot: snapshot,
@@ -270,6 +307,24 @@ List<String> stalledBelowQuotaGpLeadPeaceTargets({
       if (game.playerById(factionId) != null &&
           factionId != invadableBlocker &&
           provinceCountOwnedBy(game, factionId) >= own + minLeadDeficit)
+        factionId,
+  ]..sort();
+  return targets;
+}
+
+/// Peace every below-quota Great Power at war once this GP meets the observer
+/// quota (stop mop-up wars after the frontier is cleared; Refs #2509).
+List<String> quotaMetBelowQuotaAtWarPeaceTargets({
+  required Game game,
+  required AIWorldSnapshot snapshot,
+}) {
+  if (isBelowObserverConquestQuota(snapshot.conquest.oldWorldProvincesOwned)) {
+    return const [];
+  }
+  final targets = <String>[
+    for (final factionId in snapshot.threats.atWarWith)
+      if (game.playerById(factionId) != null &&
+          isBelowObserverConquestQuota(provinceCountOwnedBy(game, factionId)))
         factionId,
   ]..sort();
   return targets;
@@ -374,7 +429,8 @@ List<String> criticalOwHoldPeaceTargets({
   if (targets.isEmpty) {
     return const [];
   }
-  if (isBelowObserverConquestQuota(ownOw) && ownOw <= 5) {
+  if (isBelowObserverConquestQuota(ownOw) &&
+      ownOw <= kFewOldWorldProvincesDefendThreshold) {
     return targets;
   }
   if (ownOw > kStalledOldWorldProvinceThreshold) {

--- a/packages/colonizethis_ai/lib/src/planning/conquest_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/conquest_planner.dart
@@ -417,7 +417,13 @@ double _scoreArmyMoveDestination({
   }
   if (snapshot.colonial.invadableNewWorldProvinceIdsSorted
       .contains(move.destinationProvinceId)) {
-    score += kConquestArmyMoveNwInvadableBonus;
+    if (isBelowObserverConquestQuota(
+      snapshot.conquest.oldWorldProvincesOwned,
+    )) {
+      score -= kConquestArmyMoveNwInvadableBonus;
+    } else {
+      score += kConquestArmyMoveNwInvadableBonus;
+    }
   }
   if (snapshot.conquest.adjacentOwnerFactionIdsSorted.contains(destOwner)) {
     score += 8;

--- a/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
@@ -14,6 +14,7 @@ export 'colonial_pressure.dart'
         quotaMetFutileBelowQuotaGpPeaceTargets,
         stalledBelowQuotaGpLeadPeaceTargets,
         belowQuotaPeerGpPeaceTargets,
+        nearQuotaHoldPeaceTargets,
         unwinnableSoleGpFrontierPeaceTarget;
 import 'planner_context.dart';
 import '../util/ai_random_utils.dart';

--- a/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
@@ -10,8 +10,10 @@ export 'colonial_pressure.dart'
         primaryInvadableOldWorldGpBlocker,
         plateauMutualInvadableBlockerPeaceTargets,
         shouldSkipBelowQuotaGpOnlyBlockerPeacePass,
+        quotaMetBelowQuotaAtWarPeaceTargets,
         quotaMetFutileBelowQuotaGpPeaceTargets,
         stalledBelowQuotaGpLeadPeaceTargets,
+        belowQuotaPeerGpPeaceTargets,
         unwinnableSoleGpFrontierPeaceTarget;
 import 'planner_context.dart';
 import '../util/ai_random_utils.dart';
@@ -30,6 +32,8 @@ final _log = packageLogger();
 
 /// First minor nation that owns invadable OW land but is not yet at war, while
 /// this GP is below the observer quota and not fighting any Great Power (Refs #2509).
+///
+/// Also fires during an unwinnable sole-GP war so the GP can pivot to minors.
 String? criticalWeakUninvadedMinorDeclareTarget({
   required Game game,
   required AIWorldSnapshot snapshot,
@@ -39,7 +43,17 @@ String? criticalWeakUninvadedMinorDeclareTarget({
   )) {
     return null;
   }
-  if (snapshot.threats.atWarWith.any((id) => game.playerById(id) != null)) {
+  final atWarWithGp = snapshot.threats.atWarWith
+      .where((id) => game.playerById(id) != null)
+      .toList();
+  if (atWarWithGp.length > 1) {
+    return null;
+  }
+  if (atWarWithGp.length == 1 &&
+      unwinnableSoleGpFrontierPeaceTarget(game: game, snapshot: snapshot) ==
+          null &&
+      snapshot.conquest.oldWorldProvincesOwned >
+          kFewOldWorldProvincesDefendThreshold) {
     return null;
   }
   if (snapshot.conquest.invadableProvinceIdsSorted.isEmpty) {
@@ -84,6 +98,10 @@ String? stalledGpBlockerDeclareWarTarget({
   if (blocker == null ||
       snapshot.threats.atWarWith.contains(blocker) ||
       snapshot.relations[blocker]?.atWar == true) {
+    return null;
+  }
+  if (unwinnableSoleGpFrontierPeaceTarget(game: game, snapshot: snapshot) ==
+      blocker) {
     return null;
   }
   final turn = game.worldState.turnState.turnNumber;
@@ -259,10 +277,15 @@ List<DiplomaticOrder> _filterDiplomacyCandidatesForPass({
       snapshot: snapshot,
     );
     final allowBlockerPeace = blocker != null &&
-        plateauMutualInvadableBlockerPeaceTargets(
-          game: ctx.game,
-          snapshot: snapshot,
-        ).contains(blocker);
+        (plateauMutualInvadableBlockerPeaceTargets(
+              game: ctx.game,
+              snapshot: snapshot,
+            ).contains(blocker) ||
+            unwinnableSoleGpFrontierPeaceTarget(
+                  game: ctx.game,
+                  snapshot: snapshot,
+                ) ==
+                blocker);
     filtered = filtered
         .where(
           (o) =>

--- a/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
@@ -50,13 +50,6 @@ String? criticalWeakUninvadedMinorDeclareTarget({
   if (atWarWithGp.length > 1) {
     return null;
   }
-  if (atWarWithGp.length == 1 &&
-      unwinnableSoleGpFrontierPeaceTarget(game: game, snapshot: snapshot) ==
-          null &&
-      snapshot.conquest.oldWorldProvincesOwned >
-          kFewOldWorldProvincesDefendThreshold) {
-    return null;
-  }
   if (snapshot.conquest.invadableProvinceIdsSorted.isEmpty) {
     return null;
   }

--- a/packages/colonizethis_ai/lib/src/planning/diplomacy_planner_peace_targets.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomacy_planner_peace_targets.dart
@@ -398,6 +398,9 @@ bool stalledOwExpansionNeedsPeacePass({
     criticalOwHoldPeaceTargets(game: game, snapshot: snapshot).isNotEmpty ||
     stalledBelowQuotaGpLeadPeaceTargets(game: game, snapshot: snapshot)
         .isNotEmpty ||
+    belowQuotaPeerGpPeaceTargets(game: game, snapshot: snapshot).isNotEmpty ||
+    quotaMetBelowQuotaAtWarPeaceTargets(game: game, snapshot: snapshot)
+        .isNotEmpty ||
     quotaMetFutileBelowQuotaGpPeaceTargets(game: game, snapshot: snapshot)
         .isNotEmpty ||
     unwinnableSoleGpFrontierPeaceTarget(game: game, snapshot: snapshot) !=
@@ -476,6 +479,8 @@ Set<String> collectStalledGreatPowerPeaceTargets({
       stalledStrongerGpBlockerPeaceTarget(game: game, snapshot: snapshot)!,
     ...criticalOwHoldPeaceTargets(game: game, snapshot: snapshot),
     ...stalledBelowQuotaGpLeadPeaceTargets(game: game, snapshot: snapshot),
+    ...belowQuotaPeerGpPeaceTargets(game: game, snapshot: snapshot),
+    ...quotaMetBelowQuotaAtWarPeaceTargets(game: game, snapshot: snapshot),
     ...quotaMetFutileBelowQuotaGpPeaceTargets(game: game, snapshot: snapshot),
     if (unwinnableSoleGpFrontierPeaceTarget(game: game, snapshot: snapshot)
         case final enemy?)
@@ -489,6 +494,10 @@ Set<String> collectStalledGreatPowerPeaceTargets({
           isOldWorldGpOnlyInvadableFrontier(game: game, snapshot: snapshot)
       ? primaryInvadableOldWorldGpBlocker(game: game, snapshot: snapshot)
       : null;
+  final unwinnableBlockerPeace = unwinnableSoleGpFrontierPeaceTarget(
+    game: game,
+    snapshot: snapshot,
+  );
   final preserveBlockerPeace = <String>{
     if (!isOldWorldGpOnlyInvadableFrontier(game: game, snapshot: snapshot))
       ...weakHoldingsInvadableBlockerPeaceTargets(
@@ -499,6 +508,9 @@ Set<String> collectStalledGreatPowerPeaceTargets({
       game: game,
       snapshot: snapshot,
     ),
+    if (unwinnableBlockerPeace != null) unwinnableBlockerPeace,
+    ...quotaMetBelowQuotaAtWarPeaceTargets(game: game, snapshot: snapshot),
+    ...belowQuotaPeerGpPeaceTargets(game: game, snapshot: snapshot),
   };
   return targets
       .where(

--- a/packages/colonizethis_ai/lib/src/planning/diplomacy_planner_peace_targets.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomacy_planner_peace_targets.dart
@@ -399,6 +399,7 @@ bool stalledOwExpansionNeedsPeacePass({
     stalledBelowQuotaGpLeadPeaceTargets(game: game, snapshot: snapshot)
         .isNotEmpty ||
     belowQuotaPeerGpPeaceTargets(game: game, snapshot: snapshot).isNotEmpty ||
+    nearQuotaHoldPeaceTargets(game: game, snapshot: snapshot).isNotEmpty ||
     quotaMetBelowQuotaAtWarPeaceTargets(game: game, snapshot: snapshot)
         .isNotEmpty ||
     quotaMetFutileBelowQuotaGpPeaceTargets(game: game, snapshot: snapshot)
@@ -480,6 +481,7 @@ Set<String> collectStalledGreatPowerPeaceTargets({
     ...criticalOwHoldPeaceTargets(game: game, snapshot: snapshot),
     ...stalledBelowQuotaGpLeadPeaceTargets(game: game, snapshot: snapshot),
     ...belowQuotaPeerGpPeaceTargets(game: game, snapshot: snapshot),
+    ...nearQuotaHoldPeaceTargets(game: game, snapshot: snapshot),
     ...quotaMetBelowQuotaAtWarPeaceTargets(game: game, snapshot: snapshot),
     ...quotaMetFutileBelowQuotaGpPeaceTargets(game: game, snapshot: snapshot),
     if (unwinnableSoleGpFrontierPeaceTarget(game: game, snapshot: snapshot)
@@ -511,6 +513,7 @@ Set<String> collectStalledGreatPowerPeaceTargets({
     if (unwinnableBlockerPeace != null) unwinnableBlockerPeace,
     ...quotaMetBelowQuotaAtWarPeaceTargets(game: game, snapshot: snapshot),
     ...belowQuotaPeerGpPeaceTargets(game: game, snapshot: snapshot),
+    ...nearQuotaHoldPeaceTargets(game: game, snapshot: snapshot),
   };
   return targets
       .where(

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_declare_war.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_declare_war.dart
@@ -369,7 +369,8 @@ int? _declareWarSuppressedAdjacentGpScore(
       }
       if (attackerOw >= kObserverDefaultStartOldWorldProvincesPerGp &&
           isBelowObserverConquestQuota(targetOw) &&
-          targetOw <= kObserverDefaultStartOldWorldProvincesPerGp + 1) {
+          targetOw <= kObserverDefaultStartOldWorldProvincesPerGp + 1 &&
+          !ctx.invadableGpBlocker) {
         return 0;
       }
       if (isBelowObserverConquestQuota(attackerOw) &&

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_declare_war.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_declare_war.dart
@@ -353,6 +353,25 @@ int? _declareWarSuppressedAdjacentGpScore(
     final attackerOw = ctx.snapshot.conquest.oldWorldProvincesOwned;
     final targetOw = provinceCountOwnedBy(ctx.game, ctx.order.targetFactionId);
     if (ctx.game.playerById(ctx.order.targetFactionId) != null) {
+      final minorsOwnInvadable =
+          ctx.snapshot.conquest.invadableProvinceIdsSorted.any((pid) {
+        final owner = ctx.provinceOwner[pid];
+        return owner != null &&
+            ctx.game.minorNations.any((m) => m.id == owner);
+      });
+      if (minorsOwnInvadable &&
+          isBelowObserverConquestQuota(attackerOw) &&
+          isBelowObserverConquestQuota(targetOw) &&
+          (targetOw - attackerOw).abs() <= 2 &&
+          !ctx.invadableGpBlocker &&
+          !ctx.snapshot.threats.atWarWith.contains(ctx.order.targetFactionId)) {
+        return 0;
+      }
+      if (attackerOw >= kObserverDefaultStartOldWorldProvincesPerGp &&
+          isBelowObserverConquestQuota(targetOw) &&
+          targetOw <= kObserverDefaultStartOldWorldProvincesPerGp + 1) {
+        return 0;
+      }
       if (isBelowObserverConquestQuota(attackerOw) &&
           pendingDeclareWarFrom(
             sameTurnPriorDiplomaticOrders: sameTurnPriorDiplomaticOrders,
@@ -734,9 +753,7 @@ int _declareWarAdjacencyAndStalledBonuses(
         ctx.isAdjacentOwner &&
         ctx.invadableOwners.contains(ctx.order.targetFactionId) &&
         isBelowObserverConquestQuota(ownedOw) &&
-        !ctx.snapshot.threats.atWarWith.any(
-          (id) => ctx.game.playerById(id) != null,
-        )) {
+        !_gpWarBlocksPlateauMinorDeclare(ctx)) {
       s += kDeclareWarPlateauOwMinorBonus;
     }
     if (ctx.isMinorTarget &&
@@ -745,9 +762,7 @@ int _declareWarAdjacencyAndStalledBonuses(
         ctx.invadableOwners.contains(ctx.order.targetFactionId) &&
         ownedOw >= kObserverDefaultStartOldWorldProvincesPerGp + 1 &&
         ownedOw < kObserverConquestMinOwProvincesPerGp &&
-        !ctx.snapshot.threats.atWarWith.any(
-          (id) => ctx.game.playerById(id) != null,
-        )) {
+        !_gpWarBlocksPlateauMinorDeclare(ctx)) {
       s += kDeclareWarNearObserverQuotaMinorBonus;
     }
     if (ctx.isMinorTarget && ctx.stalledOwExpansion) {
@@ -929,4 +944,34 @@ int _declareWarFinalizeBonuses(_DeclareWarTargetContext ctx, int s) {
     s = math.max(s, kDeclareWarStalledLowWarLikelihoodMinorFloor);
   }
   return s;
+}
+
+/// Plateau minor declare is blocked only by distracting multi-front GP wars.
+bool _gpWarBlocksPlateauMinorDeclare(_DeclareWarTargetContext ctx) {
+  final gpWars = ctx.snapshot.threats.atWarWith
+      .where((id) => ctx.game.playerById(id) != null)
+      .toList();
+  if (gpWars.isEmpty) {
+    return false;
+  }
+  if (unwinnableSoleGpFrontierPeaceTarget(
+        game: ctx.game,
+        snapshot: ctx.snapshot,
+      ) !=
+      null) {
+    return false;
+  }
+  if (gpWars.length == 1 &&
+      isStalledOldWorldGpBlockerFocus(
+        game: ctx.game,
+        snapshot: ctx.snapshot,
+      ) &&
+      gpWars.single ==
+          primaryInvadableOldWorldGpBlocker(
+            game: ctx.game,
+            snapshot: ctx.snapshot,
+          )) {
+    return false;
+  }
+  return true;
 }

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_offer_peace.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_offer_peace.dart
@@ -108,6 +108,12 @@ int _scoreOfferPeaceDiplomaticOrder({
   }
   if (targetGp != null &&
       snapshot.threats.atWarWith.contains(order.targetFactionId) &&
+      nearQuotaHoldPeaceTargets(game: game, snapshot: snapshot)
+          .contains(order.targetFactionId)) {
+    s += kOfferPeaceConsolidateGainsSoleGpWarBonus;
+  }
+  if (targetGp != null &&
+      snapshot.threats.atWarWith.contains(order.targetFactionId) &&
       quotaMetFutileBelowQuotaGpPeaceTargets(
             game: game,
             snapshot: snapshot,

--- a/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_offer_peace.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomatic_candidate_scoring_offer_peace.dart
@@ -102,10 +102,22 @@ int _scoreOfferPeaceDiplomaticOrder({
   }
   if (targetGp != null &&
       snapshot.threats.atWarWith.contains(order.targetFactionId) &&
+      belowQuotaPeerGpPeaceTargets(game: game, snapshot: snapshot)
+          .contains(order.targetFactionId)) {
+    s += kOfferPeaceStalledFutileGpWarBonus;
+  }
+  if (targetGp != null &&
+      snapshot.threats.atWarWith.contains(order.targetFactionId) &&
       quotaMetFutileBelowQuotaGpPeaceTargets(
             game: game,
             snapshot: snapshot,
           )
+          .contains(order.targetFactionId)) {
+    s += kOfferPeaceStalledFutileGpWarBonus;
+  }
+  if (targetGp != null &&
+      snapshot.threats.atWarWith.contains(order.targetFactionId) &&
+      quotaMetBelowQuotaAtWarPeaceTargets(game: game, snapshot: snapshot)
           .contains(order.targetFactionId)) {
     s += kOfferPeaceStalledFutileGpWarBonus;
   }
@@ -165,6 +177,14 @@ int _scoreOfferPeaceDiplomaticOrder({
       snapshot.conquest.oldWorldProvincesOwned >
           kFewOldWorldProvincesDefendThreshold) {
     s -= kOfferPeaceBelowQuotaInvadableBlockerPenalty;
+  }
+  if (targetGp != null &&
+      isBelowObserverConquestQuota(
+        snapshot.conquest.oldWorldProvincesOwned,
+      ) &&
+      snapshot.conquest.oldWorldProvincesOwned <=
+          kObserverDefaultStartOldWorldProvincesPerGp) {
+    s -= kOfferPeaceBelowQuotaStartSizeGpWarPenalty;
   }
   s += getAgendaPeaceAcceptanceModifier(agendaId);
   s += (thresholds.peaceTendency - 50);

--- a/packages/colonizethis_ai/lib/src/planning/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/planning/strategic_ai.dart
@@ -79,9 +79,12 @@ StrategicOrderTraceResult generateStrategicOrdersWithTrace({
   _log.i('generateStrategicOrders nationId=$nationId turn=$turn');
   final snapshot = AIWorldSnapshot.fromPlayerView(view, topology: topology);
   final suppressColonialPressure = isStalledOldWorldGpBlockerFocus(
-    game: game,
-    snapshot: snapshot,
-  );
+        game: game,
+        snapshot: snapshot,
+      ) ||
+      isBelowObserverConquestQuota(
+        snapshot.conquest.oldWorldProvincesOwned,
+      );
   final goalScores = evaluateStrategicGoalScores(
     snapshot,
     config,

--- a/packages/colonizethis_ai/lib/src/planning/strategic_ai.dart
+++ b/packages/colonizethis_ai/lib/src/planning/strategic_ai.dart
@@ -79,12 +79,9 @@ StrategicOrderTraceResult generateStrategicOrdersWithTrace({
   _log.i('generateStrategicOrders nationId=$nationId turn=$turn');
   final snapshot = AIWorldSnapshot.fromPlayerView(view, topology: topology);
   final suppressColonialPressure = isStalledOldWorldGpBlockerFocus(
-        game: game,
-        snapshot: snapshot,
-      ) ||
-      isBelowObserverConquestQuota(
-        snapshot.conquest.oldWorldProvincesOwned,
-      );
+    game: game,
+    snapshot: snapshot,
+  );
   final goalScores = evaluateStrategicGoalScores(
     snapshot,
     config,

--- a/packages/colonizethis_ai/test/diplomacy_planner_below_quota_peace_part2_test.dart
+++ b/packages/colonizethis_ai/test/diplomacy_planner_below_quota_peace_part2_test.dart
@@ -8,12 +8,12 @@ import 'planner_test_helpers.dart';
 
 void main() {
   test(
-    'stalledBelowQuotaGpLeadPeaceTargets skips invadable GP blocker on GP-only frontier',
+    'belowQuotaPeerGpPeaceTargets peace peer below-quota GP when minors remain',
     () {
       final game = Game(
-        id: 'g-below-quota-skip-blocker',
+        id: 'g-peer-below-quota-peace',
         worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 40),
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 80),
           oldWorld: RegionData(
             provinces: [
               for (var i = 1; i <= 8; i++)
@@ -23,6 +23,129 @@ void main() {
                   ownerId: 'gp5',
                 ),
               for (var i = 1; i <= 9; i++)
+                Province(
+                  id: 'oldWorld|gp6_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp6',
+                ),
+              const Province(
+                id: 'oldWorld|minor2',
+                regionId: 'oldWorld',
+                ownerId: 'minor2',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp5', displayName: 'P5', isHuman: false),
+          Player(id: 'gp6', displayName: 'P6', isHuman: false),
+        ],
+        minorNations: const [MinorNation(id: 'minor2', displayName: 'M2')],
+        diplomacyRelations: [
+          const DiplomacyRelation(
+            factionId1: 'gp5',
+            factionId2: 'gp6',
+            state: RelationState.atWar,
+            score: 30,
+          ),
+        ],
+      );
+      const snapshot = AIWorldSnapshot(
+        playerId: 'gp5',
+        threats: ThreatSummary(atWarWith: ['gp6']),
+        opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(
+          oldWorldProvincesOwned: 8,
+          invadableProvinceIdsSorted: ['oldWorld|minor2'],
+        ),
+        economy: EconomySummary(),
+        relations: {},
+      );
+      expect(
+        belowQuotaPeerGpPeaceTargets(game: game, snapshot: snapshot),
+        ['gp6'],
+      );
+    },
+  );
+
+  test(
+    'collectStalledGreatPowerPeaceTargets keeps quota-met mop-up vs blocker',
+    () {
+      final game = Game(
+        id: 'g-quota-met-mopup',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 80),
+          oldWorld: RegionData(
+            provinces: [
+              for (var i = 1; i <= 10; i++)
+                Province(
+                  id: 'oldWorld|gp4_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp4',
+                ),
+              for (var i = 1; i <= 6; i++)
+                Province(
+                  id: 'oldWorld|gp3_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp3',
+                ),
+              const Province(
+                id: 'oldWorld|frontier',
+                regionId: 'oldWorld',
+                ownerId: 'gp3',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp3', displayName: 'P3', isHuman: false),
+          Player(id: 'gp4', displayName: 'P4', isHuman: false),
+        ],
+        diplomacyRelations: [
+          const DiplomacyRelation(
+            factionId1: 'gp3',
+            factionId2: 'gp4',
+            state: RelationState.atWar,
+            score: 30,
+          ),
+        ],
+      );
+      const snapshot = AIWorldSnapshot(
+        playerId: 'gp4',
+        threats: ThreatSummary(atWarWith: ['gp3']),
+        opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(
+          oldWorldProvincesOwned: 10,
+          invadableProvinceIdsSorted: ['oldWorld|frontier'],
+        ),
+        economy: EconomySummary(),
+        relations: {},
+      );
+      expect(
+        collectStalledGreatPowerPeaceTargets(game: game, snapshot: snapshot),
+        contains('gp3'),
+      );
+    },
+  );
+
+  test(
+    'shouldSkipBelowQuotaGpOnlyBlockerPeacePass true for sole blocker war',
+    () {
+      final game = Game(
+        id: 'g-skip-gp-only-peace',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 50),
+          oldWorld: RegionData(
+            provinces: [
+              for (var i = 1; i <= 8; i++)
+                Province(
+                  id: 'oldWorld|gp5_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp5',
+                ),
+              for (var i = 1; i <= 8; i++)
                 Province(
                   id: 'oldWorld|gp6_$i',
                   regionId: 'oldWorld',
@@ -62,75 +185,22 @@ void main() {
         relations: {},
       );
       expect(
-        stalledBelowQuotaGpLeadPeaceTargets(game: game, snapshot: snapshot),
-        isEmpty,
+        shouldSkipBelowQuotaGpOnlyBlockerPeacePass(
+          game: game,
+          snapshot: snapshot,
+        ),
+        isTrue,
       );
     },
   );
 
   test(
-    'stalledBelowQuotaGpLeadPeaceTargets skips 1-province lead at default start OW',
+    'stalledZeroRegimentGpPeaceTargets includes all GP wars when stalled',
     () {
       final game = Game(
-        id: 'g-below-quota-no-1-lead',
+        id: 'g-zero-reg-gp-peace',
         worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 70),
-          oldWorld: RegionData(
-            provinces: [
-              for (var i = 1; i <= 7; i++)
-                Province(
-                  id: 'oldWorld|gp3_$i',
-                  regionId: 'oldWorld',
-                  ownerId: 'gp3',
-                ),
-              for (var i = 1; i <= 8; i++)
-                Province(
-                  id: 'oldWorld|gp4_$i',
-                  regionId: 'oldWorld',
-                  ownerId: 'gp4',
-                ),
-            ],
-          ),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'gp3', displayName: 'P3', isHuman: false),
-          Player(id: 'gp4', displayName: 'P4', isHuman: false),
-        ],
-        diplomacyRelations: [
-          const DiplomacyRelation(
-            factionId1: 'gp3',
-            factionId2: 'gp4',
-            state: RelationState.atWar,
-            score: 30,
-          ),
-        ],
-      );
-      const snapshot = AIWorldSnapshot(
-        playerId: 'gp3',
-        threats: ThreatSummary(atWarWith: ['gp4']),
-        opportunities: OpportunitySummary(),
-        conquest: ConquestSummary(
-          oldWorldProvincesOwned: 7,
-          invadableProvinceIdsSorted: ['oldWorld|inv1'],
-        ),
-        economy: EconomySummary(),
-        relations: {},
-      );
-      expect(
-        stalledBelowQuotaGpLeadPeaceTargets(game: game, snapshot: snapshot),
-        isEmpty,
-      );
-    },
-  );
-
-  test(
-    'stalledBelowQuotaGpLeadPeaceTargets peace stronger GP while below quota',
-    () {
-      final game = Game(
-        id: 'g-below-quota-gp-lead',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 70),
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 80),
           oldWorld: RegionData(
             provinces: [
               for (var i = 1; i <= 8; i++)
@@ -174,153 +244,96 @@ void main() {
         relations: {},
       );
       expect(
-        stalledBelowQuotaGpLeadPeaceTargets(game: game, snapshot: snapshot),
+        stalledZeroRegimentGpPeaceTargets(game: game, snapshot: snapshot),
         ['gp4'],
       );
     },
   );
 
   test(
-    'criticalOwHoldPeaceTargets peace all GP wars below quota without minors',
+    'plateauMutualInvadableBlockerPeaceTargets peace mutual below-quota blockers',
     () {
       final game = Game(
-        id: 'g-critical-below-quota-no-minors',
+        id: 'g-plateau-mutual-blocker',
         worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 90),
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 60),
           oldWorld: RegionData(
             provinces: [
-              for (var i = 1; i <= 5; i++)
-                Province(
-                  id: 'oldWorld|gp3_$i',
-                  regionId: 'oldWorld',
-                  ownerId: 'gp3',
-                ),
-              for (var i = 1; i <= 12; i++)
-                Province(
-                  id: 'oldWorld|gp4_$i',
-                  regionId: 'oldWorld',
-                  ownerId: 'gp4',
-                ),
-              for (var i = 1; i <= 10; i++)
+              for (var i = 1; i <= 8; i++)
                 Province(
                   id: 'oldWorld|gp5_$i',
                   regionId: 'oldWorld',
                   ownerId: 'gp5',
                 ),
+              for (var i = 1; i <= 8; i++)
+                Province(
+                  id: 'oldWorld|gp6_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp6',
+                ),
+              const Province(
+                id: 'oldWorld|inv1',
+                regionId: 'oldWorld',
+                ownerId: 'gp6',
+              ),
+              const Province(
+                id: 'oldWorld|inv2',
+                regionId: 'oldWorld',
+                ownerId: 'minor1',
+              ),
             ],
           ),
           newWorld: const RegionData(),
         ),
         players: const [
-          Player(id: 'gp3', displayName: 'P3', isHuman: false),
-          Player(id: 'gp4', displayName: 'P4', isHuman: false),
           Player(id: 'gp5', displayName: 'P5', isHuman: false),
+          Player(id: 'gp6', displayName: 'P6', isHuman: false),
         ],
+        minorNations: const [MinorNation(id: 'minor1', displayName: 'M1')],
         diplomacyRelations: [
           const DiplomacyRelation(
-            factionId1: 'gp3',
-            factionId2: 'gp4',
-            state: RelationState.atWar,
-            score: 30,
-          ),
-          const DiplomacyRelation(
-            factionId1: 'gp3',
-            factionId2: 'gp5',
+            factionId1: 'gp5',
+            factionId2: 'gp6',
             state: RelationState.atWar,
             score: 30,
           ),
         ],
       );
       const snapshot = AIWorldSnapshot(
-        playerId: 'gp3',
-        threats: ThreatSummary(atWarWith: ['gp4', 'gp5']),
+        playerId: 'gp5',
+        threats: ThreatSummary(atWarWith: ['gp6']),
         opportunities: OpportunitySummary(),
         conquest: ConquestSummary(
-          oldWorldProvincesOwned: 5,
-          invadableProvinceIdsSorted: ['oldWorld|inv1'],
+          oldWorldProvincesOwned: 8,
+          invadableProvinceIdsSorted: ['oldWorld|inv1', 'oldWorld|inv2'],
         ),
         economy: EconomySummary(),
         relations: {},
       );
       expect(
-        criticalOwHoldPeaceTargets(game: game, snapshot: snapshot),
-        ['gp4', 'gp5'],
-      );
-    },
-  );
-
-  test(
-    'criticalOwHoldPeaceTargets skips sole GP war at 7 OW (uses other peace paths)',
-    () {
-      final game = Game(
-        id: 'g-critical-below-quota-seven-ow',
-        worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 90),
-          oldWorld: RegionData(
-            provinces: [
-              for (var i = 1; i <= 7; i++)
-                Province(
-                  id: 'oldWorld|gp3_$i',
-                  regionId: 'oldWorld',
-                  ownerId: 'gp3',
-                ),
-              for (var i = 1; i <= 12; i++)
-                Province(
-                  id: 'oldWorld|gp4_$i',
-                  regionId: 'oldWorld',
-                  ownerId: 'gp4',
-                ),
-            ],
-          ),
-          newWorld: const RegionData(),
-        ),
-        players: const [
-          Player(id: 'gp3', displayName: 'P3', isHuman: false),
-          Player(id: 'gp4', displayName: 'P4', isHuman: false),
-        ],
-        diplomacyRelations: [
-          const DiplomacyRelation(
-            factionId1: 'gp3',
-            factionId2: 'gp4',
-            state: RelationState.atWar,
-            score: 30,
-          ),
-        ],
-      );
-      const snapshot = AIWorldSnapshot(
-        playerId: 'gp3',
-        threats: ThreatSummary(atWarWith: ['gp4']),
-        opportunities: OpportunitySummary(),
-        conquest: ConquestSummary(
-          oldWorldProvincesOwned: 7,
-          invadableProvinceIdsSorted: ['oldWorld|inv1'],
-        ),
-        economy: EconomySummary(),
-        relations: {},
-      );
-      expect(
-        criticalOwHoldPeaceTargets(game: game, snapshot: snapshot),
+        plateauMutualInvadableBlockerPeaceTargets(game: game, snapshot: snapshot),
         isEmpty,
+        reason: 'below-quota mutual blocker peace stalls observer conquest',
       );
     },
   );
 
   test(
-    'weakHoldingsInvadableBlockerPeaceTargets peace blocker at 7 OW below quota',
+    'weakHoldingsInvadableBlockerPeaceTargets peace frontier GP when outmatched',
     () {
       final game = Game(
-        id: 'g-weak-blocker-below-quota-seven',
+        id: 'g-weak-blocker-peace',
         worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 70),
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 60),
           oldWorld: RegionData(
             provinces: [
-              for (var i = 1; i <= 7; i++)
+              for (var i = 1; i <= 4; i++)
                 Province(
                   id: 'oldWorld|gp3_$i',
                   regionId: 'oldWorld',
                   ownerId: 'gp3',
                 ),
-              for (var i = 1; i <= 10; i++)
+              for (var i = 1; i <= 11; i++)
                 Province(
                   id: 'oldWorld|gp4_$i',
                   regionId: 'oldWorld',
@@ -359,7 +372,7 @@ void main() {
         threats: ThreatSummary(atWarWith: ['gp4']),
         opportunities: OpportunitySummary(),
         conquest: ConquestSummary(
-          oldWorldProvincesOwned: 7,
+          oldWorldProvincesOwned: 4,
           invadableProvinceIdsSorted: ['oldWorld|inv1', 'oldWorld|inv2'],
         ),
         economy: EconomySummary(),
@@ -373,76 +386,76 @@ void main() {
   );
 
   test(
-    'weakHoldingsInvadableBlockerPeaceTargets skips blocker on GP-only frontier',
+    'criticalWeakUninvadedMinorDeclareTarget picks uninvaded minor owner',
     () {
       final game = Game(
-        id: 'g-weak-blocker-gp-only',
+        id: 'g-critical-minor-declare',
         worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 70),
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 40),
           oldWorld: RegionData(
             provinces: [
-              for (var i = 1; i <= 7; i++)
+              for (var i = 1; i <= 5; i++)
                 Province(
-                  id: 'oldWorld|gp5_$i',
+                  id: 'oldWorld|gp3_$i',
                   regionId: 'oldWorld',
-                  ownerId: 'gp5',
-                ),
-              for (var i = 1; i <= 9; i++)
-                Province(
-                  id: 'oldWorld|gp6_$i',
-                  regionId: 'oldWorld',
-                  ownerId: 'gp6',
+                  ownerId: 'gp3',
                 ),
               const Province(
-                id: 'oldWorld|frontier',
+                id: 'oldWorld|m1',
                 regionId: 'oldWorld',
-                ownerId: 'gp6',
+                ownerId: 'minor1',
+              ),
+              const Province(
+                id: 'oldWorld|m2',
+                regionId: 'oldWorld',
+                ownerId: 'minor2',
               ),
             ],
           ),
           newWorld: const RegionData(),
         ),
-        players: const [
-          Player(id: 'gp5', displayName: 'P5', isHuman: false),
-          Player(id: 'gp6', displayName: 'P6', isHuman: false),
+        players: const [Player(id: 'gp3', displayName: 'P3', isHuman: false)],
+        minorNations: const [
+          MinorNation(id: 'minor1', displayName: 'M1'),
+          MinorNation(id: 'minor2', displayName: 'M2'),
         ],
         diplomacyRelations: [
           const DiplomacyRelation(
-            factionId1: 'gp5',
-            factionId2: 'gp6',
+            factionId1: 'gp3',
+            factionId2: 'minor1',
             state: RelationState.atWar,
             score: 30,
           ),
         ],
       );
       const snapshot = AIWorldSnapshot(
-        playerId: 'gp5',
-        threats: ThreatSummary(atWarWith: ['gp6']),
+        playerId: 'gp3',
+        threats: ThreatSummary(atWarWith: ['minor1']),
         opportunities: OpportunitySummary(),
         conquest: ConquestSummary(
-          oldWorldProvincesOwned: 7,
-          invadableProvinceIdsSorted: ['oldWorld|frontier'],
+          oldWorldProvincesOwned: 6,
+          invadableProvinceIdsSorted: ['oldWorld|m1', 'oldWorld|m2'],
         ),
         economy: EconomySummary(),
         relations: {},
       );
       expect(
-        weakHoldingsInvadableBlockerPeaceTargets(game: game, snapshot: snapshot),
-        isEmpty,
+        criticalWeakUninvadedMinorDeclareTarget(game: game, snapshot: snapshot),
+        'minor2',
       );
     },
   );
 
   test(
-    'shouldSkipBelowQuotaGpOnlyBlockerPeacePass false when sole blocker unwinnable',
+    'runDiplomacyPlannerWithResult forces peace when candidates are empty',
     () {
       final game = Game(
-        id: 'g-skip-unwinnable-blocker',
+        id: 'g-empty-candidates-peace',
         worldState: WorldState(
-          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 80),
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 60),
           oldWorld: RegionData(
             provinces: [
-              for (var i = 1; i <= 6; i++)
+              for (var i = 1; i <= 5; i++)
                 Province(
                   id: 'oldWorld|gp3_$i',
                   regionId: 'oldWorld',
@@ -454,16 +467,6 @@ void main() {
                   regionId: 'oldWorld',
                   ownerId: 'gp4',
                 ),
-              const Province(
-                id: 'oldWorld|frontier',
-                regionId: 'oldWorld',
-                ownerId: 'gp4',
-              ),
-              const Province(
-                id: 'oldWorld|minor1',
-                regionId: 'oldWorld',
-                ownerId: 'minor1',
-              ),
             ],
           ),
           newWorld: const RegionData(),
@@ -472,7 +475,6 @@ void main() {
           Player(id: 'gp3', displayName: 'P3', isHuman: false),
           Player(id: 'gp4', displayName: 'P4', isHuman: false),
         ],
-        minorNations: const [MinorNation(id: 'minor1', displayName: 'M1')],
         diplomacyRelations: [
           const DiplomacyRelation(
             factionId1: 'gp3',
@@ -481,29 +483,50 @@ void main() {
             score: 30,
           ),
         ],
+        aiControlByGpId: const {'gp3': true},
+      );
+      const topology = MapTopology(nodes: [], edges: []);
+      final ctx = buildTestPlannerContext(
+        game: game,
+        topology: topology,
+        nationId: 'gp3',
+        primaryGoal: StrategicGoal.trade,
+        suggestionAPI: const FakeOrderSuggestionAPIForDomainPlannerTests(
+          work: [],
+          build: [],
+          move: [],
+          research: [],
+          navalMove: [],
+          navalMission: [],
+          diplomatic: [],
+        ),
       );
       const snapshot = AIWorldSnapshot(
         playerId: 'gp3',
         threats: ThreatSummary(atWarWith: ['gp4']),
         opportunities: OpportunitySummary(),
         conquest: ConquestSummary(
-          oldWorldProvincesOwned: 6,
-          invadableProvinceIdsSorted: ['oldWorld|frontier', 'oldWorld|minor1'],
+          oldWorldProvincesOwned: 5,
+          invadableProvinceIdsSorted: ['oldWorld|gp4_10'],
         ),
         economy: EconomySummary(),
         relations: {},
       );
+      final result = runDiplomacyPlannerWithResult(
+        ctx: ctx,
+        snapshot: snapshot,
+        pass: DiplomacyPlannerPass.nonDeclareWarOnly,
+      );
+      final peaceOrders =
+          result.orders.diplomaticOrdersByPlayerId['gp3'] ?? const [];
       expect(
-        shouldSkipBelowQuotaGpOnlyBlockerPeacePass(
-          game: game,
-          snapshot: snapshot,
+        peaceOrders.any(
+          (o) =>
+              o.type == DiplomaticOrderType.offerPeace &&
+              o.targetFactionId == 'gp4',
         ),
         isFalse,
-        reason: 'outgunned sole-blocker war should run peace pass',
-      );
-      expect(
-        unwinnableSoleGpFrontierPeaceTarget(game: game, snapshot: snapshot),
-        'gp4',
+        reason: 'below-quota GP-only frontier keeps war on invadable blocker',
       );
     },
   );

--- a/packages/colonizethis_ai/test/diplomacy_planner_below_quota_peace_part2_test.dart
+++ b/packages/colonizethis_ai/test/diplomacy_planner_below_quota_peace_part2_test.dart
@@ -85,6 +85,73 @@ void main() {
   );
 
   test(
+    'belowQuotaPeerGpPeaceTargets skips sole GP blocker on GP-only frontier',
+    () {
+      final game = Game(
+        id: 'g-peer-gp-only-blocker',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 80),
+          oldWorld: RegionData(
+            provinces: [
+              for (var i = 1; i <= 8; i++)
+                Province(
+                  id: 'oldWorld|gp6_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp6',
+                ),
+              for (var i = 1; i <= 9; i++)
+                Province(
+                  id: 'oldWorld|gp5_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp5',
+                ),
+              const Province(
+                id: 'oldWorld|frontier',
+                regionId: 'oldWorld',
+                ownerId: 'gp6',
+              ),
+              const Province(
+                id: 'oldWorld|minor2',
+                regionId: 'oldWorld',
+                ownerId: 'minor2',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp5', displayName: 'P5', isHuman: false),
+          Player(id: 'gp6', displayName: 'P6', isHuman: false),
+        ],
+        minorNations: const [MinorNation(id: 'minor2', displayName: 'M2')],
+        diplomacyRelations: [
+          const DiplomacyRelation(
+            factionId1: 'gp5',
+            factionId2: 'gp6',
+            state: RelationState.atWar,
+            score: 30,
+          ),
+        ],
+      );
+      const snapshot = AIWorldSnapshot(
+        playerId: 'gp6',
+        threats: ThreatSummary(atWarWith: ['gp5']),
+        opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(
+          oldWorldProvincesOwned: 8,
+          invadableProvinceIdsSorted: ['oldWorld|frontier'],
+        ),
+        economy: EconomySummary(),
+        relations: {},
+      );
+      expect(
+        belowQuotaPeerGpPeaceTargets(game: game, snapshot: snapshot),
+        isEmpty,
+      );
+    },
+  );
+
+  test(
     'nearQuotaHoldPeaceTargets peace non-blocker GP wars at 9 OW',
     () {
       final game = Game(
@@ -154,6 +221,67 @@ void main() {
       expect(
         nearQuotaHoldPeaceTargets(game: game, snapshot: snapshot),
         ['gp5'],
+      );
+    },
+  );
+
+  test(
+    'nearQuotaHoldPeaceTargets skips sole GP war at 9 OW',
+    () {
+      final game = Game(
+        id: 'g-near-quota-sole-gp-war',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 25),
+          oldWorld: RegionData(
+            provinces: [
+              for (var i = 1; i <= 9; i++)
+                Province(
+                  id: 'oldWorld|gp6_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp6',
+                ),
+              for (var i = 1; i <= 8; i++)
+                Province(
+                  id: 'oldWorld|gp5_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp5',
+                ),
+              const Province(
+                id: 'oldWorld|frontier',
+                regionId: 'oldWorld',
+                ownerId: 'gp5',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp5', displayName: 'P5', isHuman: false),
+          Player(id: 'gp6', displayName: 'P6', isHuman: false),
+        ],
+        diplomacyRelations: [
+          const DiplomacyRelation(
+            factionId1: 'gp5',
+            factionId2: 'gp6',
+            state: RelationState.atWar,
+            score: 30,
+          ),
+        ],
+      );
+      const snapshot = AIWorldSnapshot(
+        playerId: 'gp6',
+        threats: ThreatSummary(atWarWith: ['gp5']),
+        opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(
+          oldWorldProvincesOwned: 9,
+          invadableProvinceIdsSorted: ['oldWorld|frontier'],
+        ),
+        economy: EconomySummary(),
+        relations: {},
+      );
+      expect(
+        nearQuotaHoldPeaceTargets(game: game, snapshot: snapshot),
+        isEmpty,
       );
     },
   );
@@ -531,6 +659,68 @@ void main() {
       expect(
         criticalWeakUninvadedMinorDeclareTarget(game: game, snapshot: snapshot),
         'minor2',
+      );
+    },
+  );
+
+  test(
+    'criticalWeakUninvadedMinorDeclareTarget fires at 8 OW with sole GP war',
+    () {
+      final game = Game(
+        id: 'g-critical-minor-with-gp-war',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 40),
+          oldWorld: RegionData(
+            provinces: [
+              for (var i = 1; i <= 8; i++)
+                Province(
+                  id: 'oldWorld|gp5_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp5',
+                ),
+              for (var i = 1; i <= 8; i++)
+                Province(
+                  id: 'oldWorld|gp6_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp6',
+                ),
+              const Province(
+                id: 'oldWorld|m1',
+                regionId: 'oldWorld',
+                ownerId: 'minor1',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp5', displayName: 'P5', isHuman: false),
+          Player(id: 'gp6', displayName: 'P6', isHuman: false),
+        ],
+        minorNations: const [MinorNation(id: 'minor1', displayName: 'M1')],
+        diplomacyRelations: [
+          const DiplomacyRelation(
+            factionId1: 'gp5',
+            factionId2: 'gp6',
+            state: RelationState.atWar,
+            score: 30,
+          ),
+        ],
+      );
+      const snapshot = AIWorldSnapshot(
+        playerId: 'gp5',
+        threats: ThreatSummary(atWarWith: ['gp6']),
+        opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(
+          oldWorldProvincesOwned: 8,
+          invadableProvinceIdsSorted: ['oldWorld|m1'],
+        ),
+        economy: EconomySummary(),
+        relations: {},
+      );
+      expect(
+        criticalWeakUninvadedMinorDeclareTarget(game: game, snapshot: snapshot),
+        'minor1',
       );
     },
   );

--- a/packages/colonizethis_ai/test/diplomacy_planner_below_quota_peace_part2_test.dart
+++ b/packages/colonizethis_ai/test/diplomacy_planner_below_quota_peace_part2_test.dart
@@ -66,6 +66,95 @@ void main() {
         belowQuotaPeerGpPeaceTargets(game: game, snapshot: snapshot),
         ['gp6'],
       );
+      const snapshotGp6 = AIWorldSnapshot(
+        playerId: 'gp6',
+        threats: ThreatSummary(atWarWith: ['gp5']),
+        opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(
+          oldWorldProvincesOwned: 9,
+          invadableProvinceIdsSorted: ['oldWorld|minor2'],
+        ),
+        economy: EconomySummary(),
+        relations: {},
+      );
+      expect(
+        belowQuotaPeerGpPeaceTargets(game: game, snapshot: snapshotGp6),
+        isEmpty,
+      );
+    },
+  );
+
+  test(
+    'nearQuotaHoldPeaceTargets peace non-blocker GP wars at 9 OW',
+    () {
+      final game = Game(
+        id: 'g-near-quota-multi-front',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 25),
+          oldWorld: RegionData(
+            provinces: [
+              for (var i = 1; i <= 9; i++)
+                Province(
+                  id: 'oldWorld|gp3_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp3',
+                ),
+              for (var i = 1; i <= 8; i++)
+                Province(
+                  id: 'oldWorld|gp4_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp4',
+                ),
+              for (var i = 1; i <= 7; i++)
+                Province(
+                  id: 'oldWorld|gp5_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp5',
+                ),
+              const Province(
+                id: 'oldWorld|frontier',
+                regionId: 'oldWorld',
+                ownerId: 'gp4',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp3', displayName: 'P3', isHuman: false),
+          Player(id: 'gp4', displayName: 'P4', isHuman: false),
+          Player(id: 'gp5', displayName: 'P5', isHuman: false),
+        ],
+        diplomacyRelations: [
+          const DiplomacyRelation(
+            factionId1: 'gp3',
+            factionId2: 'gp4',
+            state: RelationState.atWar,
+            score: 30,
+          ),
+          const DiplomacyRelation(
+            factionId1: 'gp3',
+            factionId2: 'gp5',
+            state: RelationState.atWar,
+            score: 30,
+          ),
+        ],
+      );
+      const snapshot = AIWorldSnapshot(
+        playerId: 'gp3',
+        threats: ThreatSummary(atWarWith: ['gp4', 'gp5']),
+        opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(
+          oldWorldProvincesOwned: 9,
+          invadableProvinceIdsSorted: ['oldWorld|frontier'],
+        ),
+        economy: EconomySummary(),
+        relations: {},
+      );
+      expect(
+        nearQuotaHoldPeaceTargets(game: game, snapshot: snapshot),
+        ['gp5'],
+      );
     },
   );
 

--- a/packages/colonizethis_ai/test/diplomacy_planner_below_quota_peace_test.dart
+++ b/packages/colonizethis_ai/test/diplomacy_planner_below_quota_peace_test.dart
@@ -69,6 +69,62 @@ void main() {
   );
 
   test(
+    'stalledBelowQuotaGpLeadPeaceTargets skips 1-province lead at default start OW',
+    () {
+      final game = Game(
+        id: 'g-below-quota-no-1-lead',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 70),
+          oldWorld: RegionData(
+            provinces: [
+              for (var i = 1; i <= 7; i++)
+                Province(
+                  id: 'oldWorld|gp3_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp3',
+                ),
+              for (var i = 1; i <= 8; i++)
+                Province(
+                  id: 'oldWorld|gp4_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp4',
+                ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp3', displayName: 'P3', isHuman: false),
+          Player(id: 'gp4', displayName: 'P4', isHuman: false),
+        ],
+        diplomacyRelations: [
+          const DiplomacyRelation(
+            factionId1: 'gp3',
+            factionId2: 'gp4',
+            state: RelationState.atWar,
+            score: 30,
+          ),
+        ],
+      );
+      const snapshot = AIWorldSnapshot(
+        playerId: 'gp3',
+        threats: ThreatSummary(atWarWith: ['gp4']),
+        opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(
+          oldWorldProvincesOwned: 7,
+          invadableProvinceIdsSorted: ['oldWorld|inv1'],
+        ),
+        economy: EconomySummary(),
+        relations: {},
+      );
+      expect(
+        stalledBelowQuotaGpLeadPeaceTargets(game: game, snapshot: snapshot),
+        isEmpty,
+      );
+    },
+  );
+
+  test(
     'stalledBelowQuotaGpLeadPeaceTargets peace stronger GP while below quota',
     () {
       final game = Game(
@@ -373,6 +429,204 @@ void main() {
       expect(
         weakHoldingsInvadableBlockerPeaceTargets(game: game, snapshot: snapshot),
         isEmpty,
+      );
+    },
+  );
+
+  test(
+    'shouldSkipBelowQuotaGpOnlyBlockerPeacePass false when sole blocker unwinnable',
+    () {
+      final game = Game(
+        id: 'g-skip-unwinnable-blocker',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 80),
+          oldWorld: RegionData(
+            provinces: [
+              for (var i = 1; i <= 6; i++)
+                Province(
+                  id: 'oldWorld|gp3_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp3',
+                ),
+              for (var i = 1; i <= 10; i++)
+                Province(
+                  id: 'oldWorld|gp4_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp4',
+                ),
+              const Province(
+                id: 'oldWorld|frontier',
+                regionId: 'oldWorld',
+                ownerId: 'gp4',
+              ),
+              const Province(
+                id: 'oldWorld|minor1',
+                regionId: 'oldWorld',
+                ownerId: 'minor1',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp3', displayName: 'P3', isHuman: false),
+          Player(id: 'gp4', displayName: 'P4', isHuman: false),
+        ],
+        minorNations: const [MinorNation(id: 'minor1', displayName: 'M1')],
+        diplomacyRelations: [
+          const DiplomacyRelation(
+            factionId1: 'gp3',
+            factionId2: 'gp4',
+            state: RelationState.atWar,
+            score: 30,
+          ),
+        ],
+      );
+      const snapshot = AIWorldSnapshot(
+        playerId: 'gp3',
+        threats: ThreatSummary(atWarWith: ['gp4']),
+        opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(
+          oldWorldProvincesOwned: 6,
+          invadableProvinceIdsSorted: ['oldWorld|frontier', 'oldWorld|minor1'],
+        ),
+        economy: EconomySummary(),
+        relations: {},
+      );
+      expect(
+        shouldSkipBelowQuotaGpOnlyBlockerPeacePass(
+          game: game,
+          snapshot: snapshot,
+        ),
+        isFalse,
+        reason: 'outgunned sole-blocker war should run peace pass',
+      );
+      expect(
+        unwinnableSoleGpFrontierPeaceTarget(game: game, snapshot: snapshot),
+        'gp4',
+      );
+    },
+  );
+
+  test(
+    'belowQuotaPeerGpPeaceTargets peace peer below-quota GP when minors remain',
+    () {
+      final game = Game(
+        id: 'g-peer-below-quota-peace',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 80),
+          oldWorld: RegionData(
+            provinces: [
+              for (var i = 1; i <= 8; i++)
+                Province(
+                  id: 'oldWorld|gp5_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp5',
+                ),
+              for (var i = 1; i <= 9; i++)
+                Province(
+                  id: 'oldWorld|gp6_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp6',
+                ),
+              const Province(
+                id: 'oldWorld|minor2',
+                regionId: 'oldWorld',
+                ownerId: 'minor2',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp5', displayName: 'P5', isHuman: false),
+          Player(id: 'gp6', displayName: 'P6', isHuman: false),
+        ],
+        minorNations: const [MinorNation(id: 'minor2', displayName: 'M2')],
+        diplomacyRelations: [
+          const DiplomacyRelation(
+            factionId1: 'gp5',
+            factionId2: 'gp6',
+            state: RelationState.atWar,
+            score: 30,
+          ),
+        ],
+      );
+      const snapshot = AIWorldSnapshot(
+        playerId: 'gp5',
+        threats: ThreatSummary(atWarWith: ['gp6']),
+        opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(
+          oldWorldProvincesOwned: 8,
+          invadableProvinceIdsSorted: ['oldWorld|minor2'],
+        ),
+        economy: EconomySummary(),
+        relations: {},
+      );
+      expect(
+        belowQuotaPeerGpPeaceTargets(game: game, snapshot: snapshot),
+        ['gp6'],
+      );
+    },
+  );
+
+  test(
+    'collectStalledGreatPowerPeaceTargets keeps quota-met mop-up vs blocker',
+    () {
+      final game = Game(
+        id: 'g-quota-met-mopup',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 80),
+          oldWorld: RegionData(
+            provinces: [
+              for (var i = 1; i <= 10; i++)
+                Province(
+                  id: 'oldWorld|gp4_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp4',
+                ),
+              for (var i = 1; i <= 6; i++)
+                Province(
+                  id: 'oldWorld|gp3_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp3',
+                ),
+              const Province(
+                id: 'oldWorld|frontier',
+                regionId: 'oldWorld',
+                ownerId: 'gp3',
+              ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp3', displayName: 'P3', isHuman: false),
+          Player(id: 'gp4', displayName: 'P4', isHuman: false),
+        ],
+        diplomacyRelations: [
+          const DiplomacyRelation(
+            factionId1: 'gp3',
+            factionId2: 'gp4',
+            state: RelationState.atWar,
+            score: 30,
+          ),
+        ],
+      );
+      const snapshot = AIWorldSnapshot(
+        playerId: 'gp4',
+        threats: ThreatSummary(atWarWith: ['gp3']),
+        opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(
+          oldWorldProvincesOwned: 10,
+          invadableProvinceIdsSorted: ['oldWorld|frontier'],
+        ),
+        economy: EconomySummary(),
+        relations: {},
+      );
+      expect(
+        collectStalledGreatPowerPeaceTargets(game: game, snapshot: snapshot),
+        contains('gp3'),
       );
     },
   );

--- a/packages/colonizethis_ai/test/diplomacy_planner_below_quota_peace_test.dart
+++ b/packages/colonizethis_ai/test/diplomacy_planner_below_quota_peace_test.dart
@@ -250,6 +250,62 @@ void main() {
   );
 
   test(
+    'criticalOwHoldPeaceTargets skips at 6 OW (mass peace only below threshold)',
+    () {
+      final game = Game(
+        id: 'g-critical-six-ow',
+        worldState: WorldState(
+          turnState: const TurnState(phase: TurnPhase.orders, turnNumber: 90),
+          oldWorld: RegionData(
+            provinces: [
+              for (var i = 1; i <= 6; i++)
+                Province(
+                  id: 'oldWorld|gp3_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp3',
+                ),
+              for (var i = 1; i <= 12; i++)
+                Province(
+                  id: 'oldWorld|gp4_$i',
+                  regionId: 'oldWorld',
+                  ownerId: 'gp4',
+                ),
+            ],
+          ),
+          newWorld: const RegionData(),
+        ),
+        players: const [
+          Player(id: 'gp3', displayName: 'P3', isHuman: false),
+          Player(id: 'gp4', displayName: 'P4', isHuman: false),
+        ],
+        diplomacyRelations: [
+          const DiplomacyRelation(
+            factionId1: 'gp3',
+            factionId2: 'gp4',
+            state: RelationState.atWar,
+            score: 30,
+          ),
+        ],
+      );
+      const snapshot = AIWorldSnapshot(
+        playerId: 'gp3',
+        threats: ThreatSummary(atWarWith: ['gp4']),
+        opportunities: OpportunitySummary(),
+        conquest: ConquestSummary(
+          oldWorldProvincesOwned: 6,
+          invadableProvinceIdsSorted: const [],
+        ),
+        economy: EconomySummary(),
+        relations: {},
+      );
+      expect(
+        criticalOwHoldPeaceTargets(game: game, snapshot: snapshot),
+        isEmpty,
+      );
+    },
+  );
+
+  test(
     'criticalOwHoldPeaceTargets skips sole GP war at 7 OW (uses other peace paths)',
     () {
       final game = Game(

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
@@ -79,9 +79,8 @@ void main() {
     },
     skip:
         'Partial AC #2509 S10: seed-42 turn-100 — gp1/gp2/gp4 pass; '
-        'gp3 net -1 (early OW peak then loss), gp5 +2, gp6 +1 '
-        '(peer declare suppress + weak-target suppress help gp5 vs dev; '
-        'asymmetric peer peace + near-quota hold pending gp3/gp6)',
+        'gp3 net -2 (peak by turn 20 then loss), gp5 +2, gp6 +1 '
+        '(gp5/gp6 GP-only blocker stalemate; survival peace narrowed to <6 OW)',
     timeout: const Timeout(Duration(minutes: 15)),
   );
 }

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
@@ -79,8 +79,8 @@ void main() {
     },
     skip:
         'Partial AC #2509 S10: seed-42 turn-100 — gp1/gp2/gp4 pass; '
-        'gp3 net -1, gp5 +1, gp6 +2 (GP-blocker conquest still short after '
-        'GP-only peace-pass skip + plateau mutual peace off)',
+        'gp3 net -1, gp5 +2, gp6 +1 (v2 follow-up + OW-priority overlay; '
+        'gp6 regressed vs dev +2)',
     timeout: const Timeout(Duration(minutes: 15)),
   );
 }

--- a/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
+++ b/packages/colonizethis_ai/test/seed42_observer_conquest_regression_test.dart
@@ -79,8 +79,9 @@ void main() {
     },
     skip:
         'Partial AC #2509 S10: seed-42 turn-100 — gp1/gp2/gp4 pass; '
-        'gp3 net -1, gp5 +2, gp6 +1 (v2 follow-up + OW-priority overlay; '
-        'gp6 regressed vs dev +2)',
+        'gp3 net -1 (early OW peak then loss), gp5 +2, gp6 +1 '
+        '(peer declare suppress + weak-target suppress help gp5 vs dev; '
+        'asymmetric peer peace + near-quota hold pending gp3/gp6)',
     timeout: const Timeout(Duration(minutes: 15)),
   );
 }

--- a/packages/colonizethis_data/lib/src/ai_victory_config.dart
+++ b/packages/colonizethis_data/lib/src/ai_victory_config.dart
@@ -132,7 +132,7 @@ const int kDeclareWarBelowQuotaOwMinorRecoveryBonus = 380;
 
 /// Extra declare-war toward adjacent invadable OW minors at 8–9 OW with no GP war
 /// (observer seed-42 gp5/gp6 plateau; Refs #2509).
-const int kDeclareWarPlateauOwMinorBonus = 480;
+const int kDeclareWarPlateauOwMinorBonus = 600;
 
 /// Extra declare-war weight toward invadable minors when 8–9 OW (one province
 /// short of the turn-100 observer gate from default start; Refs #2509).
@@ -177,7 +177,7 @@ const int kDeclareWarMinorWithInvadableProvinceBonus = 45;
 
 /// Conquest army-move passes per turn while Old World holdings are stalled
 /// (one order per pass so each field army can march toward the frontier).
-const int kStalledConquestArmyMovePasses = 16;
+const int kStalledConquestArmyMovePasses = 22;
 
 /// Max field armies created from Home Army splits when Old World expansion is
 /// stalled (parallel marches toward invasion frontiers; Refs #2509).

--- a/packages/colonizethis_data/lib/src/ai_victory_config.dart
+++ b/packages/colonizethis_data/lib/src/ai_victory_config.dart
@@ -181,14 +181,14 @@ const int kStalledConquestArmyMovePasses = 22;
 
 /// Max field armies created from Home Army splits when Old World expansion is
 /// stalled (parallel marches toward invasion frontiers; Refs #2509).
-const int kStalledConquestFieldArmySplitCap = 8;
+const int kStalledConquestFieldArmySplitCap = 12;
 
 /// While stalled and at war, build regiments until at least this many exist in
 /// all armies (Home + field) so splits and invasions can proceed (Refs #2509).
 const int kStalledMinRegimentCountWhenAtWar = 10;
 
 /// Higher floor when fighting the sole GP that owns the invadable OW frontier.
-const int kStalledMinRegimentCountWhenGpBlockerAtWar = 16;
+const int kStalledMinRegimentCountWhenGpBlockerAtWar = 22;
 
 /// Regiment build floor when critically weak with minor wars only (Refs #2509).
 const int kStalledMinRegimentCountWhenCriticallyWeakNoGpWar = 12;

--- a/packages/colonizethis_data/lib/src/ai_victory_config.dart
+++ b/packages/colonizethis_data/lib/src/ai_victory_config.dart
@@ -132,11 +132,11 @@ const int kDeclareWarBelowQuotaOwMinorRecoveryBonus = 380;
 
 /// Extra declare-war toward adjacent invadable OW minors at 8–9 OW with no GP war
 /// (observer seed-42 gp5/gp6 plateau; Refs #2509).
-const int kDeclareWarPlateauOwMinorBonus = 400;
+const int kDeclareWarPlateauOwMinorBonus = 480;
 
 /// Extra declare-war weight toward invadable minors when 8–9 OW (one province
 /// short of the turn-100 observer gate from default start; Refs #2509).
-const int kDeclareWarNearObserverQuotaMinorBonus = 180;
+const int kDeclareWarNearObserverQuotaMinorBonus = 260;
 
 /// Penalize tribe declare-war while OW holdings are stalled and invadable OW
 /// minors remain (tribes without sea-reachable NW provinces for this GP).
@@ -177,7 +177,7 @@ const int kDeclareWarMinorWithInvadableProvinceBonus = 45;
 
 /// Conquest army-move passes per turn while Old World holdings are stalled
 /// (one order per pass so each field army can march toward the frontier).
-const int kStalledConquestArmyMovePasses = 14;
+const int kStalledConquestArmyMovePasses = 16;
 
 /// Max field armies created from Home Army splits when Old World expansion is
 /// stalled (parallel marches toward invasion frontiers; Refs #2509).
@@ -188,7 +188,7 @@ const int kStalledConquestFieldArmySplitCap = 8;
 const int kStalledMinRegimentCountWhenAtWar = 10;
 
 /// Higher floor when fighting the sole GP that owns the invadable OW frontier.
-const int kStalledMinRegimentCountWhenGpBlockerAtWar = 14;
+const int kStalledMinRegimentCountWhenGpBlockerAtWar = 16;
 
 /// Regiment build floor when critically weak with minor wars only (Refs #2509).
 const int kStalledMinRegimentCountWhenCriticallyWeakNoGpWar = 12;
@@ -243,7 +243,7 @@ const int kObserverConquestConsolidateMinOwProvinces =
 const int kUnwinnableSoleGpMinProvinceDeficit = 2;
 
 /// Declare-war bonus on adjacent invadable OW minors while below the observer quota.
-const int kDeclareWarBelowObserverQuotaMinorBonus = 300;
+const int kDeclareWarBelowObserverQuotaMinorBonus = 360;
 
 /// Offer-peace bonus toward any at-war Great Power when stalled with zero regiments
 /// (exit unwinnable GP wars before elimination; observer seed-42 gp3; Refs #2509).
@@ -472,6 +472,10 @@ const double kConquestArmyMoveStalledBehindGpBlockerBonusPerProvince = 300;
 /// Penalize offer-peace toward the invadable OW frontier GP while still below
 /// the turn-100 observer quota (avoid premature blocker peace; Refs #2509).
 const int kOfferPeaceBelowQuotaInvadableBlockerPenalty = 420;
+
+/// Penalize offer-peace toward any Great Power while at default start OW size
+/// and below the observer quota (avoid net OW loss; seed-42 gp3; Refs #2509).
+const int kOfferPeaceBelowQuotaStartSizeGpWarPenalty = 180;
 
 /// Offer-peace bonus when both sides are below the observer quota, stalled, and
 /// each other's sole invadable OW frontier GP (seed-42 gp5/gp6; Refs #2509).


### PR DESCRIPTION
## Summary

Follow-up to merged #2558 for **#2509** S10 (seed-42 turn-100 OW conquest gate):

- Mop-up / peer-GP / plateau mutual-blocker peace filters and minor-pivot declare path (unmerged remainder from `fix/issue-2509-s10-turn100-gate-v2`)
- Defer colonial goal/army-move pressure while a GP is **below** the observer OW quota (OW-first until 10 provinces)
- Tighter below-quota peace heuristics (1-province lead at default start size, start-size GP peace penalty, sole-blocker plateau minor declare)

## Test results (seed 42, turn 100, `--verify-conquest` semantics)

| GP | OW net gain | Gate (+3) |
|----|-------------|-----------|
| gp1 | +6 | pass |
| gp2 | +6 | pass |
| gp3 | -1 | **fail** |
| gp4 | +3 | pass |
| gp5 | +2 | **fail** (was +1 on `dev`) |
| gp6 | +1 | **fail** (was +2 on `dev`) |

`seed42_observer_conquest_regression_test` remains **skipped** with updated partial status. Unit tests added/extended in `diplomacy_planner_below_quota_peace_test.dart` (16 cases) plus existing stalled/multi-front peace suites.

## Deferred (same issue, follow-up commits)

- Green seed-42 turn-100 for **gp3**, **gp5**, **gp6** without regressing gp6 vs current `dev`
- Turn-150 colonial gates (S10 nightly target) — separate tuning once OW gate is stable

Refs #2509

Made with [Cursor](https://cursor.com)