### PR TITLE
refactor: deduplicate debug console parse and execute paths (#2562)

### DIFF
--- a/SPEC/program/debug-console-internals.md
+++ b/SPEC/program/debug-console-internals.md
@@ -31,9 +31,11 @@ Spawn parsers (`_parseSpawnCivilian`, `_parseSpawnRegiment`, `_parseSpawnShip`) 
 
 ## File organization
 
-- `debug_console_command_parser.dart` — verb dispatch and per-command arg extraction only.
-- `debug_console_parser_helpers.dart` — shared parse helpers (package-private top-level).
-- `debug_console_command_executor.dart` — parse → execute orchestration and read-only commands.
+- `debug_console_command_parser.dart` — verb dispatch and spawn/credit arg extraction (≤ 270 lines).
+- `debug_console_parser_helpers.dart` — shared parse helpers and credit/spawn caps (package-private top-level).
+- `debug_console_parser_province_commands.dart` — flip, reveal, and observe parse functions.
+- `debug_console_parse_result.dart` — `DebugConsoleParseResult` type.
+- `debug_console_command_executor.dart` — parse → execute orchestration and read-only commands (≤ 220 lines).
 - `debug_console_executor_helpers.dart` — event dispatch and credit message formatting.
 
 ## Acceptance criteria

--- a/SPEC/program/debug-console-internals.md
+++ b/SPEC/program/debug-console-internals.md
@@ -1,0 +1,44 @@
+# Debug console package internals (TDD)
+
+Authorizes shared parse/execute abstractions inside `packages/colonizethis_debug_console`. User-facing command semantics remain in [debug-console-panel.md](../ui/debug-console-panel.md).
+
+## Parse pipeline
+
+1. Tokenize slash input (`DebugConsoleCommandParser.parse`).
+2. Dispatch on command verb.
+3. Validate args via shared helpers in `lib/src/debug_console_parser_helpers.dart`.
+4. Canonicalize IDs via `_canonicalIdForInput`.
+5. Emit typed `DebugConsoleParsedInvocation`.
+
+## Shared parser helpers (`debug_console_parser_helpers.dart`)
+
+| Helper | Signature | Contract |
+|--------|-----------|----------|
+| Count | `(int count, String? error)? parseOptionalCount(List<String> tokens, int position)` | When `tokens.length < position`, returns `(1, null)`. Otherwise parses `tokens[position - 1]` as int in `1..kDebugConsoleMaxSpawnCount`; on failure returns `(0, errorMessage)`. |
+| Amount | `(int requested, int credited, String? error)? parseAmountWithClamp(String token)` | Parses int ≥ 1; clamps credited to `kDebugConsoleMaxTreasuryCreditAmount`; returns error when token is not a positive integer. |
+| ID | `String? canonicalIdForInput(String input, Iterable<String> candidates)` | Case-insensitive match against `candidates`; returns canonical casing from the iterable. |
+
+Spawn parsers (`_parseSpawnCivilian`, `_parseSpawnRegiment`, `_parseSpawnShip`) MUST call `parseOptionalCount`. Credit parsers (`_parseAddMoney`, `_parseAddWorker`, `_parseAddResource`) MUST call `parseAmountWithClamp` for the amount token.
+
+## Executor helpers (`debug_console_executor_helpers.dart`)
+
+| Helper | Role |
+|--------|------|
+| `dispatchDebugConsoleSessionEvents` | Maps spawn/credit/flip/reveal invocations + `humanPlayerId` to `(events, message)`. |
+| `creditExecutorMessage` | Single formatter for treasury, worker-pool, and stockpile credit success messages (requested vs credited clamp text). |
+
+`_executeInvocation` in `debug_console_command_executor.dart` MUST delegate spawn, credit, flip, and reveal branches to `dispatchDebugConsoleSessionEvents` rather than inlining per-command `DebugConsoleExecutionResult.success` event construction.
+
+## File organization
+
+- `debug_console_command_parser.dart` — verb dispatch and per-command arg extraction only.
+- `debug_console_parser_helpers.dart` — shared parse helpers (package-private top-level).
+- `debug_console_command_executor.dart` — parse → execute orchestration and read-only commands.
+- `debug_console_executor_helpers.dart` — event dispatch and credit message formatting.
+
+## Acceptance criteria
+
+- Given `debug_console_parser_helpers.dart` defines `parseOptionalCount`, when repo lint runs `repo.debug_console_shared_helpers`, then each of `_parseSpawnCivilian`, `_parseSpawnRegiment`, and `_parseSpawnShip` invokes `parseOptionalCount`.
+- Given `debug_console_parser_helpers.dart` defines `parseAmountWithClamp`, when repo lint runs `repo.debug_console_shared_helpers`, then each of `_parseAddMoney`, `_parseAddWorker`, and `_parseAddResource` invokes `parseAmountWithClamp`.
+- Given `debug_console_executor_helpers.dart` defines `creditExecutorMessage`, when repo lint runs `repo.debug_console_shared_helpers`, then `debug_console_command_executor.dart` contains no `_treasuryCreditExecutorMessage`, `_workerPoolCreditExecutorMessage`, or `_stockpileCreditExecutorMessage` functions.
+- Given a spawn or credit `DebugConsoleParsedInvocation`, when `dispatchDebugConsoleSessionEvents` runs, then it returns the same `SessionCommandEvent` list and success message semantics as before extraction (behavior-preserving).

--- a/SPEC/program/repo-lint.md
+++ b/SPEC/program/repo-lint.md
@@ -49,6 +49,7 @@
 | `tool/check_function_size.dart` | Function measured-line threshold (`SPEC/program/function-size.md`); rule `repo.function_size` |
 | `tool/check_part_unit_size.dart` | Dart `part` fragment physical line limit (`SPEC/program/part-unit-size.md`); rule `repo.part_unit_size` |
 | `tool/check_debug_console_logic_contract_boundary.dart` | AST-enforced scoped package import contract for debug-console → logic boundary; rule `repo.debug_console_logic_contract_boundary` |
+| `tool/check_debug_console_shared_helpers.dart` | Positive invariants for shared debug-console parse/execute helpers (`SPEC/program/debug-console-internals.md`); rule `repo.debug_console_shared_helpers` |
 | `tool/check_app_event_handler_scope_logic_boundary.dart` | Enforce that `app/lib/core/services/app_event_handler_scope.dart` has no direct import from `app/lib/features/game/logic/**`; rule `repo.app_event_handler_scope_logic_boundary` |
 | `tool/check_subscription_tracker.dart` | Enforce that `app/lib/features/**/*.dart` does not store subscriptions in raw `StreamSubscription` lists; use `SubscriptionTracker` for shared-lifecycle subscription cleanup; rule `repo.subscription_tracker` |
 | `tool/check_app_lib_no_suggest_work_orders.sh` | Forbid `suggestWorkOrders(` call sites under `app/lib/**` (per-unit UI uses `getAvailableWorkTargetsForUnit` / `getValidWorkOrderTileKeysWithVisibility`; Refs #2133); rule `repo.app_lib_no_broad_suggest_work_orders` |

--- a/packages/colonizethis_debug_console/lib/src/debug_console_command_executor.dart
+++ b/packages/colonizethis_debug_console/lib/src/debug_console_command_executor.dart
@@ -1,6 +1,7 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 
 import 'debug_console_command_parser.dart';
+import 'debug_console_executor_helpers.dart';
 import 'debug_console_gp_target_resolver.dart';
 import 'debug_console_parsed_invocation.dart';
 
@@ -65,136 +66,18 @@ class DebugConsoleCommandExecutor {
     required String humanPlayerId,
     DebugConsoleReadOnlyContext? readOnlyContext,
   }) {
+    final dispatched = dispatchDebugConsoleSessionEvents(
+      invocation,
+      humanPlayerId: humanPlayerId,
+    );
+    if (dispatched != null) {
+      return DebugConsoleExecutionResult.success(
+        events: dispatched.events,
+        message: dispatched.message,
+      );
+    }
+
     return switch (invocation) {
-      DebugConsoleSpawnCivilianAtCapital(:final unitType, :final count) =>
-        DebugConsoleExecutionResult.success(
-          events: [
-            SpawnDebugCivilianAtCapitalEvent(
-              humanPlayerId: humanPlayerId,
-              unitType: unitType,
-              count: count,
-            ),
-          ],
-          message: 'Queued debug spawn: ${count}x $unitType at capital.',
-        ),
-      DebugConsoleSpawnRegimentAtCapital(:final regimentTypeId, :final count) =>
-        DebugConsoleExecutionResult.success(
-          events: [
-            SpawnDebugRegimentAtCapitalEvent(
-              humanPlayerId: humanPlayerId,
-              regimentTypeId: regimentTypeId,
-              count: count,
-            ),
-          ],
-          message:
-              'Queued debug regiment spawn: ${count}x $regimentTypeId at capital.',
-        ),
-      DebugConsoleSpawnShipAtCapitalHomeFleet(
-        :final shipTypeId,
-        :final count,
-      ) =>
-        DebugConsoleExecutionResult.success(
-          events: [
-            SpawnDebugShipAtCapitalHomeFleetEvent(
-              humanPlayerId: humanPlayerId,
-              shipTypeId: shipTypeId,
-              count: count,
-            ),
-          ],
-          message:
-              'Queued debug ship spawn: ${count}x $shipTypeId at capital home fleet.',
-        ),
-      DebugConsoleTreasuryCredit(
-        :final requestedAmount,
-        :final creditedAmount,
-      ) =>
-        DebugConsoleExecutionResult.success(
-          events: [
-            CreditDebugTreasuryEvent(
-              humanPlayerId: humanPlayerId,
-              requestedAmount: requestedAmount,
-              creditedAmount: creditedAmount,
-            ),
-          ],
-          message: _treasuryCreditExecutorMessage(
-            requestedAmount: requestedAmount,
-            creditedAmount: creditedAmount,
-          ),
-        ),
-      DebugConsoleWorkerPoolCredit(
-        :final workerTierId,
-        :final requestedAmount,
-        :final creditedAmount,
-      ) =>
-        DebugConsoleExecutionResult.success(
-          events: [
-            CreditDebugWorkerPoolEvent(
-              humanPlayerId: humanPlayerId,
-              workerTierId: workerTierId,
-              requestedAmount: requestedAmount,
-              creditedAmount: creditedAmount,
-            ),
-          ],
-          message: _workerPoolCreditExecutorMessage(
-            workerTierId: workerTierId,
-            requestedAmount: requestedAmount,
-            creditedAmount: creditedAmount,
-          ),
-        ),
-      DebugConsoleStockpileCredit(
-        :final commodityId,
-        :final requestedAmount,
-        :final creditedAmount,
-      ) =>
-        DebugConsoleExecutionResult.success(
-          events: [
-            CreditDebugStockpileCommodityEvent(
-              humanPlayerId: humanPlayerId,
-              commodityId: commodityId,
-              requestedAmount: requestedAmount,
-              creditedAmount: creditedAmount,
-            ),
-          ],
-          message: _stockpileCreditExecutorMessage(
-            commodityId: commodityId,
-            requestedAmount: requestedAmount,
-            creditedAmount: creditedAmount,
-          ),
-        ),
-      DebugConsoleFlipProvince(
-        :final fullProvinceId,
-        :final regionId,
-        :final provinceDisplayName,
-      ) =>
-        DebugConsoleExecutionResult.success(
-          events: [
-            FlipDebugProvinceOwnershipEvent(
-              humanPlayerId: humanPlayerId,
-              fullProvinceId: fullProvinceId,
-              regionId: regionId,
-              provinceDisplayName: provinceDisplayName,
-            ),
-          ],
-          message: fullProvinceId != null
-              ? 'Queued debug province flip by id: $fullProvinceId.'
-              : 'Queued debug province flip: $regionId / $provinceDisplayName.',
-        ),
-      DebugConsoleRevealProvince(
-        :final target,
-        :final targetIsFullProvinceId,
-      ) =>
-        DebugConsoleExecutionResult.success(
-          events: [
-            RevealDebugProvinceEvent(
-              humanPlayerId: humanPlayerId,
-              target: target,
-              targetIsFullProvinceId: targetIsFullProvinceId,
-            ),
-          ],
-          message: targetIsFullProvinceId
-              ? 'Queued debug province reveal by id: $target.'
-              : 'Queued debug province reveal by name: $target.',
-        ),
       DebugConsoleGetTileBasicInfo() => _executeGetTileBasicInfo(
         readOnlyContext,
       ),
@@ -211,6 +94,7 @@ class DebugConsoleCommandExecutor {
         target,
         readOnlyContext,
       ),
+      _ => const DebugConsoleExecutionResult.error('Invalid command.'),
     };
   }
 
@@ -297,42 +181,6 @@ String? _provinceIdFromTileKey(String tileKey) {
     return null;
   }
   return '${parts[0]}|${parts[1]}';
-}
-
-String _treasuryCreditExecutorMessage({
-  required int requestedAmount,
-  required int creditedAmount,
-}) {
-  if (requestedAmount != creditedAmount) {
-    return 'Queued debug treasury credit: requested $requestedAmount, '
-        'crediting $creditedAmount (clamped to $kDebugConsoleMaxTreasuryCreditAmount).';
-  }
-  return 'Queued debug treasury credit: $creditedAmount.';
-}
-
-String _workerPoolCreditExecutorMessage({
-  required String workerTierId,
-  required int requestedAmount,
-  required int creditedAmount,
-}) {
-  if (requestedAmount != creditedAmount) {
-    return 'Queued debug worker credit ($workerTierId): requested $requestedAmount, '
-        'crediting $creditedAmount (clamped to $kDebugConsoleMaxTreasuryCreditAmount).';
-  }
-  return 'Queued debug worker credit ($workerTierId): $creditedAmount.';
-}
-
-String _stockpileCreditExecutorMessage({
-  required String commodityId,
-  required int requestedAmount,
-  required int creditedAmount,
-}) {
-  if (requestedAmount != creditedAmount) {
-    return 'Queued debug stockpile credit for $commodityId: requested '
-        '$requestedAmount, crediting $creditedAmount (clamped to '
-        '$kDebugConsoleMaxTreasuryCreditAmount).';
-  }
-  return 'Queued debug stockpile credit for $commodityId: $creditedAmount.';
 }
 
 class DebugConsoleExecutionResult {

--- a/packages/colonizethis_debug_console/lib/src/debug_console_command_parser.dart
+++ b/packages/colonizethis_debug_console/lib/src/debug_console_command_parser.dart
@@ -1,12 +1,13 @@
 import 'package:colonizethis_logic/debug_console_api.dart';
 
+import 'debug_console_parse_result.dart';
+import 'debug_console_parser_helpers.dart';
+import 'debug_console_parser_province_commands.dart';
 import 'debug_console_parsed_invocation.dart';
 
-const int kDebugConsoleMaxSpawnCount = 25;
-
-/// Upper bound for `/add_money` credited amount (parser clamps here).
-const int kDebugConsoleMaxTreasuryCreditAmount = 9999;
-final RegExp _localProvinceIdPattern = RegExp(r'^P[0-9]+$');
+export 'debug_console_parse_result.dart';
+export 'debug_console_parser_helpers.dart'
+    show kDebugConsoleMaxSpawnCount, kDebugConsoleMaxTreasuryCreditAmount;
 
 class DebugConsoleCommandParser {
   const DebugConsoleCommandParser();
@@ -33,11 +34,11 @@ class DebugConsoleCommandParser {
       '/add_money' => _parseAddMoney(tokens),
       '/add_worker' => _parseAddWorker(tokens),
       '/add_resource' => _parseAddResource(tokens),
-      '/flip_province' => _parseFlipProvince(tokens),
-      '/reveal_province' => _parseRevealProvince(tokens),
+      '/flip_province' => parseFlipProvinceCommand(tokens),
+      '/reveal_province' => parseRevealProvinceCommand(tokens),
       '/get_tile_basic_info' => _parseGetTileBasicInfo(tokens),
       '/list_players' => _parseListPlayers(tokens),
-      '/observe' => _parseObserve(tokens),
+      '/observe' => parseObserveCommand(tokens),
       '/help' => DebugConsoleParseResult.error(_buildHelpMessage()),
       _ => DebugConsoleParseResult.error(
         'Unknown command: $command. Try /help.',
@@ -57,21 +58,14 @@ class DebugConsoleCommandParser {
         'Unknown civilian type. Use explorer, builder, engineer, spy, merchant, or rail_builder.',
       );
     }
-    final parsedCount = tokens.length >= 3 ? int.tryParse(tokens[2]) : 1;
-    if (parsedCount == null) {
-      return const DebugConsoleParseResult.error(
-        'Count must be an integer between 1 and 25.',
-      );
-    }
-    if (parsedCount < 1 || parsedCount > kDebugConsoleMaxSpawnCount) {
-      return const DebugConsoleParseResult.error(
-        'Count must be between 1 and 25.',
-      );
+    final countResult = parseOptionalCount(tokens, 3);
+    if (countResult.error != null) {
+      return DebugConsoleParseResult.error(countResult.error!);
     }
     return DebugConsoleParseResult.success(
       DebugConsoleParsedInvocation.spawnCivilianAtCapital(
         unitType: canonicalUnitType,
-        count: parsedCount,
+        count: countResult.count,
       ),
     );
   }
@@ -80,20 +74,14 @@ class DebugConsoleCommandParser {
     if (tokens.length < 2) {
       return const DebugConsoleParseResult.error('Usage: /add_money <amount>');
     }
-    final rawAmount = int.tryParse(tokens[1]);
-    if (rawAmount == null) {
-      return const DebugConsoleParseResult.error('Amount must be an integer.');
+    final amountResult = parseAmountWithClamp(tokens[1]);
+    if (amountResult.error != null) {
+      return DebugConsoleParseResult.error(amountResult.error!);
     }
-    if (rawAmount < 1) {
-      return const DebugConsoleParseResult.error('Amount must be at least 1.');
-    }
-    final creditedAmount = rawAmount > kDebugConsoleMaxTreasuryCreditAmount
-        ? kDebugConsoleMaxTreasuryCreditAmount
-        : rawAmount;
     return DebugConsoleParseResult.success(
       DebugConsoleParsedInvocation.treasuryCredit(
-        requestedAmount: rawAmount,
-        creditedAmount: creditedAmount,
+        requestedAmount: amountResult.requested,
+        creditedAmount: amountResult.credited,
       ),
     );
   }
@@ -105,27 +93,24 @@ class DebugConsoleCommandParser {
       );
     }
     final tierInput = tokens[1].trim().toLowerCase();
-    final canonicalTierId = _canonicalWorkerTierIdForInput(tierInput);
+    final canonicalTierId = canonicalIdForInput(
+      tierInput,
+      debugConsoleSupportedWorkerTierIds,
+    );
     if (canonicalTierId == null) {
       return const DebugConsoleParseResult.error(
         'Unknown worker tier. Use peasants, apprentices, journeymen, or masters.',
       );
     }
-    final rawAmount = int.tryParse(tokens[2]);
-    if (rawAmount == null) {
-      return const DebugConsoleParseResult.error('Amount must be an integer.');
+    final amountResult = parseAmountWithClamp(tokens[2]);
+    if (amountResult.error != null) {
+      return DebugConsoleParseResult.error(amountResult.error!);
     }
-    if (rawAmount < 1) {
-      return const DebugConsoleParseResult.error('Amount must be at least 1.');
-    }
-    final creditedAmount = rawAmount > kDebugConsoleMaxTreasuryCreditAmount
-        ? kDebugConsoleMaxTreasuryCreditAmount
-        : rawAmount;
     return DebugConsoleParseResult.success(
       DebugConsoleParsedInvocation.workerPoolCredit(
         workerTierId: canonicalTierId,
-        requestedAmount: rawAmount,
-        creditedAmount: creditedAmount,
+        requestedAmount: amountResult.requested,
+        creditedAmount: amountResult.credited,
       ),
     );
   }
@@ -138,29 +123,24 @@ class DebugConsoleCommandParser {
     }
     final requestedCommodityId = tokens[1].trim();
     final normalizedCommodityId = requestedCommodityId.toLowerCase();
-    final canonicalCommodityId = _canonicalCommodityIdForInput(
+    final canonicalCommodityId = canonicalIdForInput(
       normalizedCommodityId,
+      debugConsoleSupportedCommodityIds,
     );
     if (canonicalCommodityId == null) {
       return const DebugConsoleParseResult.error(
         'Unknown commodity id. Use /help for supported commodity ids.',
       );
     }
-    final rawAmount = int.tryParse(tokens[2]);
-    if (rawAmount == null) {
-      return const DebugConsoleParseResult.error('Amount must be an integer.');
+    final amountResult = parseAmountWithClamp(tokens[2]);
+    if (amountResult.error != null) {
+      return DebugConsoleParseResult.error(amountResult.error!);
     }
-    if (rawAmount < 1) {
-      return const DebugConsoleParseResult.error('Amount must be at least 1.');
-    }
-    final creditedAmount = rawAmount > kDebugConsoleMaxTreasuryCreditAmount
-        ? kDebugConsoleMaxTreasuryCreditAmount
-        : rawAmount;
     return DebugConsoleParseResult.success(
       DebugConsoleParsedInvocation.stockpileCredit(
         commodityId: canonicalCommodityId,
-        requestedAmount: rawAmount,
-        creditedAmount: creditedAmount,
+        requestedAmount: amountResult.requested,
+        creditedAmount: amountResult.credited,
       ),
     );
   }
@@ -177,21 +157,14 @@ class DebugConsoleCommandParser {
         'Unknown regiment type id. Use /help for supported regiment ids.',
       );
     }
-    final parsedCount = tokens.length >= 3 ? int.tryParse(tokens[2]) : 1;
-    if (parsedCount == null) {
-      return const DebugConsoleParseResult.error(
-        'Count must be an integer between 1 and 25.',
-      );
-    }
-    if (parsedCount < 1 || parsedCount > kDebugConsoleMaxSpawnCount) {
-      return const DebugConsoleParseResult.error(
-        'Count must be between 1 and 25.',
-      );
+    final countResult = parseOptionalCount(tokens, 3);
+    if (countResult.error != null) {
+      return DebugConsoleParseResult.error(countResult.error!);
     }
     return DebugConsoleParseResult.success(
       DebugConsoleParsedInvocation.spawnRegimentAtCapital(
         regimentTypeId: regimentTypeId,
-        count: parsedCount,
+        count: countResult.count,
       ),
     );
   }
@@ -208,86 +181,14 @@ class DebugConsoleCommandParser {
         'Unknown ship type id. Use /help for supported ship ids.',
       );
     }
-    final parsedCount = tokens.length >= 3 ? int.tryParse(tokens[2]) : 1;
-    if (parsedCount == null) {
-      return const DebugConsoleParseResult.error(
-        'Count must be an integer between 1 and 25.',
-      );
-    }
-    if (parsedCount < 1 || parsedCount > kDebugConsoleMaxSpawnCount) {
-      return const DebugConsoleParseResult.error(
-        'Count must be between 1 and 25.',
-      );
+    final countResult = parseOptionalCount(tokens, 3);
+    if (countResult.error != null) {
+      return DebugConsoleParseResult.error(countResult.error!);
     }
     return DebugConsoleParseResult.success(
       DebugConsoleParsedInvocation.spawnShipAtCapitalHomeFleet(
         shipTypeId: shipTypeId,
-        count: parsedCount,
-      ),
-    );
-  }
-
-  DebugConsoleParseResult _parseFlipProvince(List<String> tokens) {
-    if (tokens.length == 2) {
-      final fullProvinceId = tokens[1].trim();
-      if (!_looksLikePrefixedProvinceId(fullProvinceId)) {
-        return const DebugConsoleParseResult.error(
-          'Usage: /flip_province <regionId> <province_display_name> OR /flip_province <regionId|localId>',
-        );
-      }
-      return DebugConsoleParseResult.success(
-        DebugConsoleParsedInvocation.flipProvince(
-          fullProvinceId: fullProvinceId,
-        ),
-      );
-    }
-    if (tokens.length < 3) {
-      return const DebugConsoleParseResult.error(
-        'Usage: /flip_province <regionId> <province_display_name> OR /flip_province <regionId|localId>',
-      );
-    }
-    final regionId = tokens[1].trim();
-    if (regionId.isEmpty) {
-      return const DebugConsoleParseResult.error(
-        'Region id must not be empty.',
-      );
-    }
-    final provinceDisplayName = tokens.sublist(2).join(' ').trim();
-    if (provinceDisplayName.isEmpty) {
-      return const DebugConsoleParseResult.error(
-        'Province display name must not be empty.',
-      );
-    }
-    return DebugConsoleParseResult.success(
-      DebugConsoleParsedInvocation.flipProvince(
-        regionId: regionId,
-        provinceDisplayName: provinceDisplayName,
-      ),
-    );
-  }
-
-  DebugConsoleParseResult _parseRevealProvince(List<String> tokens) {
-    if (tokens.length < 2) {
-      return const DebugConsoleParseResult.error(
-        'Usage: /reveal_province <regionId|localId | province_display_name>',
-      );
-    }
-    final target = tokens.sublist(1).join(' ').trim();
-    if (target.isEmpty) {
-      return const DebugConsoleParseResult.error(
-        'Usage: /reveal_province <regionId|localId | province_display_name>',
-      );
-    }
-    if (_localProvinceIdPattern.hasMatch(target)) {
-      return const DebugConsoleParseResult.error(
-        'Use full province id format: regionId|localId',
-      );
-    }
-    final targetIsFullProvinceId = _looksLikePrefixedProvinceId(target);
-    return DebugConsoleParseResult.success(
-      DebugConsoleParsedInvocation.revealProvince(
-        target: target,
-        targetIsFullProvinceId: targetIsFullProvinceId,
+        count: countResult.count,
       ),
     );
   }
@@ -310,45 +211,6 @@ class DebugConsoleCommandParser {
     );
   }
 
-  DebugConsoleParseResult _parseObserve(List<String> tokens) {
-    if (tokens.length == 1) {
-      return const DebugConsoleParseResult.success(
-        DebugConsoleParsedInvocation.setObserveGlobal(),
-      );
-    }
-    if (tokens.length == 2 && tokens[1].toLowerCase() == 'off') {
-      return const DebugConsoleParseResult.success(
-        DebugConsoleParsedInvocation.setObserveOff(),
-      );
-    }
-    if (tokens.length >= 2) {
-      final target = tokens.sublist(1).join(' ');
-      return DebugConsoleParseResult.success(
-        DebugConsoleParsedInvocation.setObservePlayer(target: target),
-      );
-    }
-    return const DebugConsoleParseResult.error(
-      'Usage: /observe | /observe off | /observe <player_id | display_name>',
-    );
-  }
-}
-
-String? _canonicalCommodityIdForInput(String normalizedInput) {
-  for (final candidate in debugConsoleSupportedCommodityIds) {
-    if (candidate.toLowerCase() == normalizedInput) {
-      return candidate;
-    }
-  }
-  return null;
-}
-
-String? _canonicalWorkerTierIdForInput(String normalizedInput) {
-  for (final candidate in debugConsoleSupportedWorkerTierIds) {
-    if (candidate.toLowerCase() == normalizedInput) {
-      return candidate;
-    }
-  }
-  return null;
 }
 
 String _buildHelpMessage() {
@@ -382,28 +244,6 @@ String _buildHelpMessage() {
       '- /observe\n'
       '- /observe off\n'
       '- /observe <player_id | display_name>';
-}
-
-bool _looksLikePrefixedProvinceId(String value) {
-  final separator = value.indexOf('|');
-  if (separator <= 0 || separator == value.length - 1) {
-    return false;
-  }
-  return true;
-}
-
-class DebugConsoleParseResult {
-  const DebugConsoleParseResult.success(this.invocation)
-    : message = null,
-      isError = false;
-
-  const DebugConsoleParseResult.error(this.message)
-    : invocation = null,
-      isError = true;
-
-  final DebugConsoleParsedInvocation? invocation;
-  final String? message;
-  final bool isError;
 }
 
 String? _unitTypeFromAlias(String alias) {

--- a/packages/colonizethis_debug_console/lib/src/debug_console_executor_helpers.dart
+++ b/packages/colonizethis_debug_console/lib/src/debug_console_executor_helpers.dart
@@ -1,0 +1,153 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import 'debug_console_parser_helpers.dart';
+import 'debug_console_parsed_invocation.dart';
+
+typedef DebugConsoleSessionDispatch = ({
+  List<SessionCommandEvent> events,
+  String message,
+});
+
+DebugConsoleSessionDispatch? dispatchDebugConsoleSessionEvents(
+  DebugConsoleParsedInvocation invocation, {
+  required String humanPlayerId,
+}) {
+  return switch (invocation) {
+    DebugConsoleSpawnCivilianAtCapital(:final unitType, :final count) => (
+      events: [
+        SpawnDebugCivilianAtCapitalEvent(
+          humanPlayerId: humanPlayerId,
+          unitType: unitType,
+          count: count,
+        ),
+      ],
+      message: 'Queued debug spawn: ${count}x $unitType at capital.',
+    ),
+    DebugConsoleSpawnRegimentAtCapital(:final regimentTypeId, :final count) => (
+      events: [
+        SpawnDebugRegimentAtCapitalEvent(
+          humanPlayerId: humanPlayerId,
+          regimentTypeId: regimentTypeId,
+          count: count,
+        ),
+      ],
+      message:
+          'Queued debug regiment spawn: ${count}x $regimentTypeId at capital.',
+    ),
+    DebugConsoleSpawnShipAtCapitalHomeFleet(:final shipTypeId, :final count) => (
+      events: [
+        SpawnDebugShipAtCapitalHomeFleetEvent(
+          humanPlayerId: humanPlayerId,
+          shipTypeId: shipTypeId,
+          count: count,
+        ),
+      ],
+      message:
+          'Queued debug ship spawn: ${count}x $shipTypeId at capital home fleet.',
+    ),
+    DebugConsoleTreasuryCredit(
+      :final requestedAmount,
+      :final creditedAmount,
+    ) =>
+      (
+        events: [
+          CreditDebugTreasuryEvent(
+            humanPlayerId: humanPlayerId,
+            requestedAmount: requestedAmount,
+            creditedAmount: creditedAmount,
+          ),
+        ],
+        message: creditExecutorMessage(
+          what: 'treasury credit',
+          requestedAmount: requestedAmount,
+          creditedAmount: creditedAmount,
+        ),
+      ),
+    DebugConsoleWorkerPoolCredit(
+      :final workerTierId,
+      :final requestedAmount,
+      :final creditedAmount,
+    ) =>
+      (
+        events: [
+          CreditDebugWorkerPoolEvent(
+            humanPlayerId: humanPlayerId,
+            workerTierId: workerTierId,
+            requestedAmount: requestedAmount,
+            creditedAmount: creditedAmount,
+          ),
+        ],
+        message: creditExecutorMessage(
+          what: 'worker credit',
+          requestedAmount: requestedAmount,
+          creditedAmount: creditedAmount,
+          qualifier: workerTierId,
+        ),
+      ),
+    DebugConsoleStockpileCredit(
+      :final commodityId,
+      :final requestedAmount,
+      :final creditedAmount,
+    ) =>
+      (
+        events: [
+          CreditDebugStockpileCommodityEvent(
+            humanPlayerId: humanPlayerId,
+            commodityId: commodityId,
+            requestedAmount: requestedAmount,
+            creditedAmount: creditedAmount,
+          ),
+        ],
+        message: creditExecutorMessage(
+          what: 'stockpile credit for $commodityId',
+          requestedAmount: requestedAmount,
+          creditedAmount: creditedAmount,
+        ),
+      ),
+    DebugConsoleFlipProvince(
+      :final fullProvinceId,
+      :final regionId,
+      :final provinceDisplayName,
+    ) =>
+      (
+        events: [
+          FlipDebugProvinceOwnershipEvent(
+            humanPlayerId: humanPlayerId,
+            fullProvinceId: fullProvinceId,
+            regionId: regionId,
+            provinceDisplayName: provinceDisplayName,
+          ),
+        ],
+        message: fullProvinceId != null
+            ? 'Queued debug province flip by id: $fullProvinceId.'
+            : 'Queued debug province flip: $regionId / $provinceDisplayName.',
+      ),
+    DebugConsoleRevealProvince(:final target, :final targetIsFullProvinceId) => (
+      events: [
+        RevealDebugProvinceEvent(
+          humanPlayerId: humanPlayerId,
+          target: target,
+          targetIsFullProvinceId: targetIsFullProvinceId,
+        ),
+      ],
+      message: targetIsFullProvinceId
+          ? 'Queued debug province reveal by id: $target.'
+          : 'Queued debug province reveal by name: $target.',
+    ),
+    _ => null,
+  };
+}
+
+String creditExecutorMessage({
+  required String what,
+  required int requestedAmount,
+  required int creditedAmount,
+  String? qualifier,
+}) {
+  final label = qualifier == null ? what : '$what ($qualifier)';
+  if (requestedAmount != creditedAmount) {
+    return 'Queued debug $label: requested $requestedAmount, '
+        'crediting $creditedAmount (clamped to $kDebugConsoleMaxTreasuryCreditAmount).';
+  }
+  return 'Queued debug $label: $creditedAmount.';
+}

--- a/packages/colonizethis_debug_console/lib/src/debug_console_parse_result.dart
+++ b/packages/colonizethis_debug_console/lib/src/debug_console_parse_result.dart
@@ -1,0 +1,15 @@
+import 'debug_console_parsed_invocation.dart';
+
+class DebugConsoleParseResult {
+  const DebugConsoleParseResult.success(this.invocation)
+    : message = null,
+      isError = false;
+
+  const DebugConsoleParseResult.error(this.message)
+    : invocation = null,
+      isError = true;
+
+  final DebugConsoleParsedInvocation? invocation;
+  final String? message;
+  final bool isError;
+}

--- a/packages/colonizethis_debug_console/lib/src/debug_console_parser_helpers.dart
+++ b/packages/colonizethis_debug_console/lib/src/debug_console_parser_helpers.dart
@@ -1,0 +1,55 @@
+/// Upper bound for spawn commands (`/spawn_civilian`, `/spawn_regiment`, `/spawn_ship`).
+const int kDebugConsoleMaxSpawnCount = 25;
+
+/// Upper bound for credit commands; parser clamps here.
+const int kDebugConsoleMaxTreasuryCreditAmount = 9999;
+
+/// Parses optional spawn count at [position] (1-based token index).
+///
+/// When fewer than [position] tokens exist, returns count `1`.
+/// On invalid or out-of-range values, returns an error message in the record.
+({int count, String? error}) parseOptionalCount(
+  List<String> tokens,
+  int position,
+) {
+  final parsedCount = tokens.length >= position ? int.tryParse(tokens[position - 1]) : 1;
+  if (parsedCount == null) {
+    return (
+      count: 0,
+      error: 'Count must be an integer between 1 and $kDebugConsoleMaxSpawnCount.',
+    );
+  }
+  if (parsedCount < 1 || parsedCount > kDebugConsoleMaxSpawnCount) {
+    return (
+      count: 0,
+      error: 'Count must be between 1 and $kDebugConsoleMaxSpawnCount.',
+    );
+  }
+  return (count: parsedCount, error: null);
+}
+
+/// Parses a positive integer amount and clamps to [kDebugConsoleMaxTreasuryCreditAmount].
+({int requested, int credited, String? error}) parseAmountWithClamp(
+  String token,
+) {
+  final rawAmount = int.tryParse(token);
+  if (rawAmount == null) {
+    return (requested: 0, credited: 0, error: 'Amount must be an integer.');
+  }
+  if (rawAmount < 1) {
+    return (requested: 0, credited: 0, error: 'Amount must be at least 1.');
+  }
+  final creditedAmount = rawAmount > kDebugConsoleMaxTreasuryCreditAmount
+      ? kDebugConsoleMaxTreasuryCreditAmount
+      : rawAmount;
+  return (requested: rawAmount, credited: creditedAmount, error: null);
+}
+
+String? canonicalIdForInput(String input, Iterable<String> candidates) {
+  for (final candidate in candidates) {
+    if (candidate.toLowerCase() == input) {
+      return candidate;
+    }
+  }
+  return null;
+}

--- a/packages/colonizethis_debug_console/lib/src/debug_console_parser_province_commands.dart
+++ b/packages/colonizethis_debug_console/lib/src/debug_console_parser_province_commands.dart
@@ -1,0 +1,97 @@
+import 'debug_console_parse_result.dart';
+import 'debug_console_parsed_invocation.dart';
+
+final RegExp debugConsoleLocalProvinceIdPattern = RegExp(r'^P[0-9]+$');
+
+DebugConsoleParseResult parseFlipProvinceCommand(List<String> tokens) {
+  if (tokens.length == 2) {
+    final fullProvinceId = tokens[1].trim();
+    if (!debugConsoleLooksLikePrefixedProvinceId(fullProvinceId)) {
+      return const DebugConsoleParseResult.error(
+        'Usage: /flip_province <regionId> <province_display_name> OR /flip_province <regionId|localId>',
+      );
+    }
+    return DebugConsoleParseResult.success(
+      DebugConsoleParsedInvocation.flipProvince(
+        fullProvinceId: fullProvinceId,
+      ),
+    );
+  }
+  if (tokens.length < 3) {
+    return const DebugConsoleParseResult.error(
+      'Usage: /flip_province <regionId> <province_display_name> OR /flip_province <regionId|localId>',
+    );
+  }
+  final regionId = tokens[1].trim();
+  if (regionId.isEmpty) {
+    return const DebugConsoleParseResult.error('Region id must not be empty.');
+  }
+  final provinceDisplayName = tokens.sublist(2).join(' ').trim();
+  if (provinceDisplayName.isEmpty) {
+    return const DebugConsoleParseResult.error(
+      'Province display name must not be empty.',
+    );
+  }
+  return DebugConsoleParseResult.success(
+    DebugConsoleParsedInvocation.flipProvince(
+      regionId: regionId,
+      provinceDisplayName: provinceDisplayName,
+    ),
+  );
+}
+
+DebugConsoleParseResult parseRevealProvinceCommand(List<String> tokens) {
+  if (tokens.length < 2) {
+    return const DebugConsoleParseResult.error(
+      'Usage: /reveal_province <regionId|localId | province_display_name>',
+    );
+  }
+  final target = tokens.sublist(1).join(' ').trim();
+  if (target.isEmpty) {
+    return const DebugConsoleParseResult.error(
+      'Usage: /reveal_province <regionId|localId | province_display_name>',
+    );
+  }
+  if (debugConsoleLocalProvinceIdPattern.hasMatch(target)) {
+    return const DebugConsoleParseResult.error(
+      'Use full province id format: regionId|localId',
+    );
+  }
+  final targetIsFullProvinceId = debugConsoleLooksLikePrefixedProvinceId(target);
+  return DebugConsoleParseResult.success(
+    DebugConsoleParsedInvocation.revealProvince(
+      target: target,
+      targetIsFullProvinceId: targetIsFullProvinceId,
+    ),
+  );
+}
+
+DebugConsoleParseResult parseObserveCommand(List<String> tokens) {
+  if (tokens.length == 1) {
+    return const DebugConsoleParseResult.success(
+      DebugConsoleParsedInvocation.setObserveGlobal(),
+    );
+  }
+  if (tokens.length == 2 && tokens[1].toLowerCase() == 'off') {
+    return const DebugConsoleParseResult.success(
+      DebugConsoleParsedInvocation.setObserveOff(),
+    );
+  }
+  if (tokens.length >= 2) {
+    final target = tokens.sublist(1).join(' ');
+    return DebugConsoleParseResult.success(
+      DebugConsoleParsedInvocation.setObservePlayer(target: target),
+    );
+  }
+  return const DebugConsoleParseResult.error(
+    'Usage: /observe | /observe off | /observe <player_id | display_name>',
+  );
+}
+
+bool debugConsoleLooksLikePrefixedProvinceId(String value) {
+  final separator = value.indexOf('|');
+  if (separator <= 0 || separator == value.length - 1) {
+    return false;
+  }
+  return true;
+}

--- a/packages/colonizethis_debug_console/test/debug_console_history_test.dart
+++ b/packages/colonizethis_debug_console/test/debug_console_history_test.dart
@@ -13,5 +13,38 @@ void main() {
       expect(history.newer(), '/spawn_civilian builder 2');
       expect(history.newer(), '');
     });
+
+    test('ignores duplicate consecutive push', () {
+      final history = DebugConsoleHistory();
+      history.push('/add_money 100');
+      history.push('/add_money 100');
+
+      expect(history.snapshot(), ['/add_money 100']);
+    });
+
+    test('older and newer return null on empty history', () {
+      final history = DebugConsoleHistory();
+      expect(history.older(), isNull);
+      expect(history.newer(), isNull);
+    });
+
+    test('older at oldest entry stays on oldest', () {
+      final history = DebugConsoleHistory();
+      history.push('/help');
+      expect(history.older(), '/help');
+      expect(history.older(), '/help');
+    });
+
+    test('snapshot returns unmodifiable list', () {
+      final history = DebugConsoleHistory();
+      history.push('/list_players');
+      final snapshot = history.snapshot();
+      expect(
+        () => snapshot.add('/spawn_civilian explorer'),
+        throwsUnsupportedError,
+      );
+      history.push('/observe');
+      expect(snapshot, ['/list_players']);
+    });
   });
 }

--- a/test/check_debug_console_shared_helpers_test.dart
+++ b/test/check_debug_console_shared_helpers_test.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../tool/check_debug_console_shared_helpers.dart';
+
+void main() {
+  test('passes on the repository debug console package', () {
+    final repoRoot = Directory.current.path;
+    expect(runCheckDebugConsoleSharedHelpers(repoRoot), 0);
+  });
+
+  test('fails when spawn parser omits parseOptionalCount', () {
+    final temp = Directory.systemTemp.createTempSync(
+      'check_debug_console_shared_helpers_fail_',
+    );
+    addTearDown(() => temp.deleteSync(recursive: true));
+    final srcDir = Directory(
+      '${temp.path}/packages/colonizethis_debug_console/lib/src',
+    )..createSync(recursive: true);
+
+    File('${srcDir.path}/debug_console_parser_helpers.dart').writeAsStringSync('''
+int parseOptionalCount(List<String> tokens, int position) => 1;
+({int requested, int credited, String? error}) parseAmountWithClamp(String token) =>
+    (requested: 1, credited: 1, error: null);
+String? canonicalIdForInput(String input, Iterable<String> candidates) => null;
+''');
+
+    File('${srcDir.path}/debug_console_command_parser.dart').writeAsStringSync('''
+class DebugConsoleCommandParser {
+  void _parseSpawnCivilian(List<String> tokens) {
+    final count = 1;
+  }
+  void _parseSpawnRegiment(List<String> tokens) {
+    parseOptionalCount(tokens, 3);
+  }
+  void _parseSpawnShip(List<String> tokens) {
+    parseOptionalCount(tokens, 3);
+  }
+  void _parseAddMoney(List<String> tokens) {
+    parseAmountWithClamp('1');
+  }
+  void _parseAddWorker(List<String> tokens) {
+    parseAmountWithClamp('1');
+  }
+  void _parseAddResource(List<String> tokens) {
+    parseAmountWithClamp('1');
+  }
+}
+''');
+
+    File('${srcDir.path}/debug_console_executor_helpers.dart').writeAsStringSync('''
+void dispatchDebugConsoleSessionEvents() {}
+String creditExecutorMessage({
+  required String what,
+  required int requestedAmount,
+  required int creditedAmount,
+}) => '';
+''');
+
+    File('${srcDir.path}/debug_console_command_executor.dart').writeAsStringSync('''
+class DebugConsoleCommandExecutor {
+  void _executeInvocation() {
+    dispatchDebugConsoleSessionEvents();
+  }
+}
+''');
+
+    final logs = <String>[];
+    final code = runCheckDebugConsoleSharedHelpers(
+      temp.path,
+      info: logs.add,
+      err: logs.add,
+    );
+    expect(code, 1);
+    expect(
+      logs.join('\n'),
+      contains('_parseSpawnCivilian must call parseOptionalCount'),
+    );
+  });
+}

--- a/tool/check_debug_console_shared_helpers.dart
+++ b/tool/check_debug_console_shared_helpers.dart
@@ -1,0 +1,220 @@
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:path/path.dart' as p;
+
+const _packageLib = 'packages/colonizethis_debug_console/lib/src';
+
+int runCheckDebugConsoleSharedHelpers(
+  String repoRoot, {
+  void Function(String line)? info,
+  void Function(String line)? err,
+}) {
+  final logI = info ?? stdout.writeln;
+  final logE = err ?? stderr.writeln;
+  final violations = <String>[];
+
+  final parserPath = p.join(
+    repoRoot,
+    _packageLib,
+    'debug_console_command_parser.dart',
+  );
+  final executorPath = p.join(
+    repoRoot,
+    _packageLib,
+    'debug_console_command_executor.dart',
+  );
+  final parserHelpersPath = p.join(
+    repoRoot,
+    _packageLib,
+    'debug_console_parser_helpers.dart',
+  );
+  final executorHelpersPath = p.join(
+    repoRoot,
+    _packageLib,
+    'debug_console_executor_helpers.dart',
+  );
+
+  for (final path in [
+    parserPath,
+    executorPath,
+    parserHelpersPath,
+    executorHelpersPath,
+  ]) {
+    if (!File(path).existsSync()) {
+      logE('check_debug_console_shared_helpers: missing $path');
+      return 1;
+    }
+  }
+
+  final parserUnit = _parseUnit(parserPath, repoRoot);
+  final executorUnit = _parseUnit(executorPath, repoRoot);
+  final parserHelpersUnit = _parseUnit(parserHelpersPath, repoRoot);
+
+  if (!_definesTopLevelFunction(parserHelpersUnit, 'parseOptionalCount')) {
+    violations.add(
+      '${p.relative(parserHelpersPath, from: repoRoot)} must define parseOptionalCount',
+    );
+  }
+  if (!_definesTopLevelFunction(parserHelpersUnit, 'parseAmountWithClamp')) {
+    violations.add(
+      '${p.relative(parserHelpersPath, from: repoRoot)} must define parseAmountWithClamp',
+    );
+  }
+  if (!_definesTopLevelFunction(parserHelpersUnit, 'canonicalIdForInput')) {
+    violations.add(
+      '${p.relative(parserHelpersPath, from: repoRoot)} must define canonicalIdForInput',
+    );
+  }
+
+  for (final methodName in [
+    '_parseSpawnCivilian',
+    '_parseSpawnRegiment',
+    '_parseSpawnShip',
+  ]) {
+    if (!_methodInvokesFunction(
+      parserUnit,
+      methodName: methodName,
+      invokedName: 'parseOptionalCount',
+    )) {
+      violations.add(
+        'debug_console_command_parser.dart:$methodName must call parseOptionalCount',
+      );
+    }
+  }
+
+  for (final methodName in [
+    '_parseAddMoney',
+    '_parseAddWorker',
+    '_parseAddResource',
+  ]) {
+    if (!_methodInvokesFunction(
+      parserUnit,
+      methodName: methodName,
+      invokedName: 'parseAmountWithClamp',
+    )) {
+      violations.add(
+        'debug_console_command_parser.dart:$methodName must call parseAmountWithClamp',
+      );
+    }
+  }
+
+  for (final legacyName in [
+    '_treasuryCreditExecutorMessage',
+    '_workerPoolCreditExecutorMessage',
+    '_stockpileCreditExecutorMessage',
+  ]) {
+    if (_definesTopLevelFunction(executorUnit, legacyName) ||
+        _classDefinesMethod(executorUnit, 'DebugConsoleCommandExecutor', legacyName)) {
+      violations.add(
+        'debug_console_command_executor.dart must not define $legacyName; '
+        'use creditExecutorMessage in debug_console_executor_helpers.dart',
+      );
+    }
+  }
+
+  if (!_methodInvokesFunction(
+    executorUnit,
+    methodName: '_executeInvocation',
+    invokedName: 'dispatchDebugConsoleSessionEvents',
+  )) {
+    violations.add(
+      'debug_console_command_executor.dart:_executeInvocation must call '
+      'dispatchDebugConsoleSessionEvents',
+    );
+  }
+
+  if (violations.isEmpty) {
+    logI('check_debug_console_shared_helpers: no violations found.');
+    return 0;
+  }
+  logE('check_debug_console_shared_helpers: ${violations.length} violation(s):');
+  for (final violation in violations) {
+    logE(' - $violation');
+  }
+  return 1;
+}
+
+CompilationUnit _parseUnit(String absolutePath, String repoRoot) {
+  return parseString(
+    content: File(absolutePath).readAsStringSync(),
+    path: p.relative(absolutePath, from: repoRoot),
+  ).unit;
+}
+
+bool _definesTopLevelFunction(CompilationUnit unit, String name) {
+  return unit.declarations
+      .whereType<FunctionDeclaration>()
+      .any((decl) => decl.name.lexeme == name);
+}
+
+bool _classDefinesMethod(
+  CompilationUnit unit,
+  String className,
+  String methodName,
+) {
+  return unit.declarations
+      .whereType<ClassDeclaration>()
+      .where((decl) => decl.name.lexeme == className)
+      .any(
+        (decl) => decl.members
+            .whereType<MethodDeclaration>()
+            .any((member) => member.name.lexeme == methodName),
+      );
+}
+
+bool _methodInvokesFunction(
+  CompilationUnit unit, {
+  required String methodName,
+  required String invokedName,
+}) {
+  final method = _findMethod(unit, methodName);
+  if (method == null) {
+    return false;
+  }
+  var found = false;
+  method.body?.visitChildren(_InvocationCollector(invokedName, (value) {
+    found = value;
+  }));
+  return found;
+}
+
+MethodDeclaration? _findMethod(CompilationUnit unit, String methodName) {
+  for (final decl in unit.declarations.whereType<ClassDeclaration>()) {
+    for (final member in decl.members.whereType<MethodDeclaration>()) {
+      if (member.name.lexeme == methodName) {
+        return member;
+      }
+    }
+  }
+  return null;
+}
+
+class _InvocationCollector extends RecursiveAstVisitor<void> {
+  _InvocationCollector(this.invokedName, this.onFound);
+
+  final String invokedName;
+  final void Function(bool found) onFound;
+  var _found = false;
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    final name = node.methodName.name;
+    if (name == invokedName) {
+      _found = true;
+      onFound(true);
+    }
+    super.visitMethodInvocation(node);
+  }
+
+  @override
+  void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
+    super.visitFunctionExpressionInvocation(node);
+  }
+}
+
+void main() {
+  exit(runCheckDebugConsoleSharedHelpers(Directory.current.path));
+}

--- a/tool/ct_repo_lint_lib.dart
+++ b/tool/ct_repo_lint_lib.dart
@@ -18,6 +18,7 @@ import 'check_custom_exceptions.dart';
 import 'check_dart_file_non_comment_line_size.dart';
 import 'check_debug_handler_one_per_file.dart';
 import 'check_debug_console_logic_contract_boundary.dart';
+import 'check_debug_console_shared_helpers.dart';
 import 'check_disallowed_ast_patterns.dart';
 import 'check_long_string_switches.dart';
 import 'check_flutter_action_pins.dart';
@@ -722,6 +723,8 @@ int? _tryRunDartRuleInProcess({
         repoRoot,
         incrementalRelativeDartPaths: incrementalPaths,
       );
+    case 'repo.debug_console_shared_helpers':
+      return runCheckDebugConsoleSharedHelpers(repoRoot);
     case 'repo.app_event_handler_scope_logic_boundary':
       return runCheckAppEventHandlerScopeLogicBoundary(repoRoot);
     case 'repo.control_flow_nesting_depth':

--- a/tool/ct_repo_lint_manifest.yaml
+++ b/tool/ct_repo_lint_manifest.yaml
@@ -144,6 +144,13 @@ rules:
     script: tool/check_debug_console_logic_contract_boundary.dart
     pr_incremental: true
 
+  - rule_id: repo.debug_console_shared_helpers
+    group: structure
+    title: debug console shared parse and executor helpers
+    spec: SPEC/program/debug-console-internals.md
+    runner: dart
+    script: tool/check_debug_console_shared_helpers.dart
+
   - rule_id: repo.app_event_handler_scope_logic_boundary
     group: architecture
     title: app_event_handler_scope must not import features/game/logic directly


### PR DESCRIPTION
## Summary

- Extracts five shared abstractions in `colonizethis_debug_console`: `parseOptionalCount`, `parseAmountWithClamp`, `canonicalIdForInput`, `dispatchDebugConsoleSessionEvents`, and `creditExecutorMessage`.
- Adds `SPEC/program/debug-console-internals.md` and CI rule `repo.debug_console_shared_helpers` (`tool/check_debug_console_shared_helpers.dart`).
- Shrinks `debug_console_command_parser.dart` (260 lines) and `debug_console_command_executor.dart` (199 lines); expands `debug_console_history_test.dart` for edge cases.

## AC coverage

| AC | Status |
|----|--------|
| TDD spec for abstractions | Done |
| Shared spawn count helper (3 call sites) | Done + checker |
| Shared amount-with-clamp helper (3 call sites) | Done + checker |
| Unified ID canonicalization | Done |
| Executor event factory for spawn/credit/flip/reveal | Done + checker |
| Single credit message formatter | Done + checker |
| Parser ≤ 270 / executor ≤ 220 lines | Done (260 / 199) |
| Helper files exist | Done |
| CI checker + test | Done |
| Existing parser/executor tests unchanged | Pass (79 tests) |
| History edge-case tests | Done |

## Test plan

- [x] `cd packages/colonizethis_debug_console && dart test`
- [x] `dart test test/check_debug_console_shared_helpers_test.dart`
- [x] `dart run tool/check_debug_console_shared_helpers.dart`

Refs #2562

Made with [Cursor](https://cursor.com)