### PR TITLE
refactor(logic): Game/WorldState mutation helpers (Refs #2560)

### DIFF
--- a/SPEC/program/repo-and-packages.md
+++ b/SPEC/program/repo-and-packages.md
@@ -34,6 +34,10 @@ Five shared Dart packages under `packages/`. TDD 15 allows merging _models and _
 
 **Rule:** No UI in shared packages. Game logic lives only in shared packages; app is shell, routing, and integration.
 
+### `colonizethis_logic` internal mutation helpers
+
+Turn pipelines and order application mutate nested `Game` → `WorldState` → `TurnState` fields frequently. Call sites use **`Game.updateWorldState`**, **`WorldState.updateTurnState`**, and **`TurnPipelineState.updateWorldState`** (`game_world_mutations.dart`, `turn_pipeline_state.dart`) instead of three-level `copyWith` chains. Refs #2560.
+
 **Riverpod in packages:** Canonical `Provider`s for logic/map/AI seams live in optional `di.dart` libraries; see [dependency-injection.md](dependency-injection.md).
 
 ---

--- a/packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
+++ b/packages/colonizethis_logic/lib/src/turn/end_of_turn_resolver.dart
@@ -8,6 +8,7 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../dossier/event_dialogue.dart';
 import '../world/fog_resolution.dart';
+import '../world/game_world_mutations.dart';
 import 'turn_seed_constants.dart';
 
 /// Runs the end-of-turn phase: victory check, era-change dialogue, Spy timers, fog decay,
@@ -46,8 +47,8 @@ Game runEndOfTurnPhase(
   }
 
   final (visibilityByTile, nextSpyTimers) = applySpyRevealTimerDecay(game);
-  var stateForFog = game.copyWith(
-    worldState: game.worldState.copyWith(
+  var stateForFog = game.updateWorldState(
+    (ws) => ws.copyWith(
       playerVisibilityByTile: visibilityByTile,
       spyRevealTurnsByPlayer: nextSpyTimers,
     ),
@@ -74,27 +75,30 @@ Game runEndOfTurnPhase(
       'calendar campaign halt at turn=$currentTurn '
       '(year ${mapping.yearAtTurn(currentTurn)})',
     );
-    return game.copyWith(
-      calendarCampaignHalted: true,
-      worldState: game.worldState.copyWith(
-        turnState: game.worldState.turnState.copyWith(
-          phase: TurnPhase.orders,
-        ),
-        playerVisibilityByTile: nextVisibility,
-        spyRevealTurnsByPlayer: nextSpyTimers,
-      ),
-    );
+    return game
+        .copyWith(calendarCampaignHalted: true)
+        .updateWorldState(
+          (ws) => ws
+              .updateTurnState((ts) => ts.copyWith(phase: TurnPhase.orders))
+              .copyWith(
+                playerVisibilityByTile: nextVisibility,
+                spyRevealTurnsByPlayer: nextSpyTimers,
+              ),
+        );
   }
 
-  return game.copyWith(
-    worldState: game.worldState.copyWith(
-      turnState: game.worldState.turnState.copyWith(
-        turnNumber: game.worldState.turnState.turnNumber + 1,
-        phase: TurnPhase.orders,
-      ),
-      playerVisibilityByTile: nextVisibility,
-      spyRevealTurnsByPlayer: nextSpyTimers,
-    ),
+  return game.updateWorldState(
+    (ws) => ws
+        .updateTurnState(
+          (ts) => ts.copyWith(
+            turnNumber: ts.turnNumber + 1,
+            phase: TurnPhase.orders,
+          ),
+        )
+        .copyWith(
+          playerVisibilityByTile: nextVisibility,
+          spyRevealTurnsByPlayer: nextSpyTimers,
+        ),
   );
 }
 

--- a/packages/colonizethis_logic/lib/src/turn/phases/movement_phase.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases/movement_phase.dart
@@ -5,6 +5,7 @@ import '../../constants.dart';
 import '../../orders/bundled_civilian_work_order.dart';
 import '../../orders/draft_orders_mutations.dart';
 import '../../world/army_movement.dart';
+import '../../world/game_world_mutations.dart';
 import '../../world/movement.dart';
 import '../trace/turn_trace_runtime.dart';
 import '../turn_pipeline_state.dart';
@@ -79,8 +80,8 @@ Game runMovementPhase(
 
     recordSpyProvinceChanges(originalOldWorld, oldWorld);
     recordSpyProvinceChanges(originalNewWorld, newWorld);
-    state = state.copyWith(
-      worldState: state.worldState.copyWith(
+    state = state.updateWorldState(
+      (ws) => ws.copyWith(
         oldWorld: oldWorld,
         newWorld: newWorld,
         spyRevealTurnsByPlayer: mutableSpyTimers ?? originalSpyTimers,

--- a/packages/colonizethis_logic/lib/src/turn/turn_pipeline_state.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_pipeline_state.dart
@@ -1,5 +1,6 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 
+import '../world/game_world_mutations.dart';
 import 'turn_resolution_result.dart';
 
 /// Immutable carry-over between economy and combat phases (feeding coverage,
@@ -40,6 +41,11 @@ class TurnPipelineState {
       idleLabourByPlayerId: idleLabourByPlayerId ?? this.idleLabourByPlayerId,
     );
   }
+
+  /// Returns a copy whose [game.worldState] is updated via [update] (Refs #2560).
+  TurnPipelineState updateWorldState(
+    WorldState Function(WorldState current) update,
+  ) => copyWith(game: game.updateWorldState(update));
 }
 
 /// Result of stepping one turn phase: continue the pipeline or exit with a

--- a/packages/colonizethis_logic/lib/src/world/game_world_mutations.dart
+++ b/packages/colonizethis_logic/lib/src/world/game_world_mutations.dart
@@ -1,0 +1,18 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+/// Shallow [Game] / [WorldState] mutation helpers (Refs #2560).
+///
+/// Call sites avoid `game.copyWith(worldState: game.worldState.copyWith(
+/// turnState: game.worldState.turnState.copyWith(...)))` chains; nested
+/// updates live inside these helpers instead.
+extension GameWorldMutations on Game {
+  /// Returns a copy of this game with [worldState] replaced by [update](worldState).
+  Game updateWorldState(WorldState Function(WorldState current) update) =>
+      copyWith(worldState: update(worldState));
+}
+
+extension WorldStateTurnMutations on WorldState {
+  /// Returns a copy with [turnState] replaced by [update](turnState).
+  WorldState updateTurnState(TurnState Function(TurnState current) update) =>
+      copyWith(turnState: update(turnState));
+}

--- a/packages/colonizethis_logic/test/world/game_world_mutations_test.dart
+++ b/packages/colonizethis_logic/test/world/game_world_mutations_test.dart
@@ -1,0 +1,28 @@
+import 'package:colonizethis_logic/src/world/game_world_mutations.dart';
+import 'package:colonizethis_test/test.dart';
+
+import '../test_fixtures.dart';
+
+void main() {
+  group('GameWorldMutations', () {
+    test('updateWorldState replaces worldState without nested game.copyWith chain', () {
+      final game = TestFixtures.minimalGame();
+      final next = game.updateWorldState(
+        (ws) => ws.copyWith(nextArmySeq: ws.nextArmySeq + 1),
+      );
+      expect(next.worldState.nextArmySeq, game.worldState.nextArmySeq + 1);
+      expect(next, isNot(same(game)));
+    });
+
+    test('updateTurnState replaces turnState on WorldState', () {
+      final ws = TestFixtures.minimalGame().worldState;
+      final next = ws.updateTurnState(
+        (ts) => ts.copyWith(turnNumber: ts.turnNumber + 1),
+      );
+      expect(
+        next.turnState.turnNumber,
+        ws.turnState.turnNumber + 1,
+      );
+    });
+  });
+}

--- a/tool/logic_all_provinces_sanctions.yaml
+++ b/tool/logic_all_provinces_sanctions.yaml
@@ -25,7 +25,7 @@ sanctions:
     issue: https://github.com/waigore/colonizethisv3/issues/2278
 
   - path: packages/colonizethis_logic/lib/src/turn/phases/movement_phase.dart
-    line: 30
+    line: 31
     rationale: Movement phase owner map keyed by all province ids across regions.
     spec: SPEC/program/logic-dual-region-province-access.md
     issue: https://github.com/waigore/colonizethisv3/issues/2278


### PR DESCRIPTION
## Summary

- Adds `Game.updateWorldState`, `WorldState.updateTurnState`, and `TurnPipelineState.updateWorldState` so callers avoid three-level `copyWith` chains (`Game` → `WorldState` → `TurnState`).
- Refactors end-of-turn fog/calendar paths and movement spy-timer updates to use the helpers.
- Documents the pattern in `SPEC/program/repo-and-packages.md`.

## Scope (issue #2560)

**Done in this PR:** slice 7 (partial) — mutation helpers + first call-site migrations + unit tests.

**Deferred (follow-up on same issue):**
- Province/adjacency traversal utility (`connectivity_resolver`, `fog_resolution`, `naval_resolution`)
- Remaining `copyWith` chain migrations outside touched files
- CI gates (`logic.diplomatic_sub_validator_size`, work-target switch registry lint)
- `SPEC/program/orders.md` / `order-suggestions.md` registry prose updates

**Already on `dev` from prior PRs:** diplomatic sub-validator factory (#2566), work-order handler registry (#2572), turn-phase handler registry.

Refs #2560

## Test plan

- [x] `dart test packages/colonizethis_logic/test/world/game_world_mutations_test.dart`
- [x] `dart test packages/colonizethis_logic/test/end_of_turn_calendar_halt_test.dart`
- [ ] CI `quality` / `package_tests` (remote)


Made with [Cursor](https://cursor.com)