### PR TITLE
fix(ai): block mutual-plateau GP-only wars on seed-42 (Refs #2509)

### DIFF
--- a/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
+++ b/packages/colonizethis_ai/lib/src/planning/diplomacy_planner.dart
@@ -91,7 +91,10 @@ String? belowQuotaUninvadedMinorDeclareTarget({
     return null;
   }
   if (isOldWorldGpOnlyInvadableFrontier(game: game, snapshot: snapshot)) {
-    return null;
+    if (ownOw <= kObserverDefaultStartOldWorldProvincesPerGp + 1 ||
+        !hasUninvadedOldWorldMinor(game: game, snapshot: snapshot)) {
+      return null;
+    }
   }
   final candidates = <String>{
     for (final minor in game.minorNations)
@@ -244,15 +247,23 @@ String? stalledInvadableGpOwnerDeclareTarget({
     if (snapshot.threats.atWarWith.contains(owner)) {
       continue;
     }
+    final partnerOw = provinceCountOwnedBy(game, owner);
     if (isMutualBelowQuotaPlateauPeer(
       ownOw: ownOw,
-      partnerOw: provinceCountOwnedBy(game, owner),
+      partnerOw: partnerOw,
     )) {
       final blocker = primaryInvadableOldWorldGpBlocker(
         game: game,
         snapshot: snapshot,
       );
       if (owner != blocker) {
+        continue;
+      }
+      if (isOldWorldGpOnlyInvadableFrontier(game: game, snapshot: snapshot) &&
+          (partnerOw - ownOw).abs() <= 1 &&
+          regimentCountForPlayer(game, snapshot.playerId) > 0 &&
+          regimentCountForPlayer(game, owner) > 0 &&
+          !hasUninvadedOldWorldMinor(game: game, snapshot: snapshot)) {
         continue;
       }
     }
@@ -297,15 +308,22 @@ String? stalledGpBlockerDeclareWarTarget({
     ownOw: ownOw,
     partnerOw: blockerOw,
   )) {
+    // GP-only mutual plateau at similar holdings: peace when no minor pivot
+    // remains (avoids seed-42 gp5/gp6 wipeouts; Refs #2509).
+    if (isOldWorldGpOnlyInvadableFrontier(game: game, snapshot: snapshot) &&
+        (blockerOw - ownOw).abs() <= 1 &&
+        regimentCountForPlayer(game, snapshot.playerId) > 0 &&
+        regimentCountForPlayer(game, blocker) > 0 &&
+        !hasUninvadedOldWorldMinor(game: game, snapshot: snapshot)) {
+      return null;
+    }
     if (regimentCountForPlayer(game, blocker) == 0) {
       return null;
     }
-    // Already at war with the mutual plateau blocker (gp3/gp4 seed-42 fronts).
     if (snapshot.threats.atWarWith.contains(blocker) ||
         snapshot.relations[blocker]?.atWar == true) {
       return null;
     }
-    // Open the front from the weaker peer only (gp5 vs gp6 at peace).
     if (ownOw > blockerOw ||
         (ownOw == blockerOw && snapshot.playerId.compareTo(blocker) > 0)) {
       return null;

--- a/packages/colonizethis_ai/test/diplomatic_candidate_scoring_suppression_part2_test.dart
+++ b/packages/colonizethis_ai/test/diplomatic_candidate_scoring_suppression_part2_test.dart
@@ -144,7 +144,7 @@ void main() {
     );
 
     test(
-      'stalledGpBlockerDeclareWarTarget weaker opens mutual plateau when at peace',
+      'stalledGpBlockerDeclareWarTarget skips mutual plateau within one OW on GP-only',
       () {
         final game = Game(
           id: 'g-mutual-plateau-peace-declare',
@@ -222,10 +222,81 @@ void main() {
         );
         expect(
           stalledGpBlockerDeclareWarTarget(game: game, snapshot: weakerSnap),
-          'gp6',
+          isNull,
         );
         expect(
           stalledGpBlockerDeclareWarTarget(game: game, snapshot: strongerSnap),
+          isNull,
+        );
+      },
+    );
+
+    test(
+      'stalledGpBlockerDeclareWarTarget skips mutual plateau when no minor pivot',
+      () {
+        final game = Game(
+          id: 'g-mutual-plateau-no-minor-pivot',
+          worldState: WorldState(
+            turnState: const TurnState(
+              phase: TurnPhase.orders,
+              turnNumber: 60,
+            ),
+            oldWorld: RegionData(
+              provinces: [
+                for (var i = 0; i < 9; i++)
+                  Province(
+                    id: 'oldWorld|gp6_$i',
+                    regionId: 'oldWorld',
+                    ownerId: 'gp6',
+                  ),
+                for (var i = 0; i < 8; i++)
+                  Province(
+                    id: 'oldWorld|gp5_$i',
+                    regionId: 'oldWorld',
+                    ownerId: 'gp5',
+                  ),
+              ],
+            ),
+            newWorld: const RegionData(),
+            armies: [
+              Army(
+                id: homeArmyIdFor('gp5'),
+                ownerId: 'gp5',
+                regionId: 'oldWorld',
+                stationedProvinceId: 'oldWorld|gp5_0',
+                regimentUnitIds: const ['u_gp5'],
+                isHomeArmy: true,
+              ),
+              Army(
+                id: homeArmyIdFor('gp6'),
+                ownerId: 'gp6',
+                regionId: 'oldWorld',
+                stationedProvinceId: 'oldWorld|gp6_0',
+                regimentUnitIds: const ['u_gp6'],
+                isHomeArmy: true,
+              ),
+            ],
+          ),
+          players: const [
+            Player(id: 'gp5', displayName: 'P5', isHuman: false),
+            Player(id: 'gp6', displayName: 'P6', isHuman: false),
+          ],
+        );
+        const snap = AIWorldSnapshot(
+          playerId: 'gp5',
+          threats: ThreatSummary(),
+          opportunities: OpportunitySummary(),
+          conquest: ConquestSummary(
+            oldWorldProvincesOwned: 8,
+            invadableProvinceIdsSorted: ['oldWorld|gp6_8'],
+            adjacentOwnerFactionIdsSorted: ['gp6'],
+          ),
+          colonial: ColonialSummary(),
+          economy: EconomySummary(),
+          relations: {},
+        );
+        expect(
+          stalledGpBlockerDeclareWarTarget(game: game, snapshot: snap),
           isNull,
         );
       },


### PR DESCRIPTION
## Summary

- Suppress `stalledGpBlockerDeclareWarTarget` and `stalledInvadableGpOwnerDeclareTarget` declare-war paths between armed 8–9 OW peers on a **GP-only** frontier when holdings are within one province and **no uninvaded minor pivot** remains (avoids seed-42 gp5/gp6 mutual wipeouts).
- Allow `belowQuotaUninvadedMinorDeclareTarget` at 8+ OW on GP-only frontiers when minors are still open (redirect expansion off peer GP wars).

## Issue scope (#2509)

**Done in this PR (S10 slice):**
- Mutual-plateau GP-only peace/declare guard + unit tests (observer goal phases).

**Deferred (follow-up on same issue):**
- Nightly green on seed 42 for `--verify-conquest` (turn 100) and `--verify-colonial-expansion` (turn 150).
- Remaining S10 phase ACs and systemic must-have #1/#5 integration gates.

## Tests

- `dart test` in `packages/colonizethis_ai`: diplomacy suppression part 2, below-quota peace part 2, colonial pressure, seed42 gp3/gp4 war activity, seed42 observer conquest regression (skipped integration AC).

Refs #2509

Made with [Cursor](https://cursor.com)