### PR TITLE
refactor(logic): per-phase handler files in turn/phases/ (Refs #2560)

### DIFF
--- a/SPEC/program/turn-resolution-phase-details.md
+++ b/SPEC/program/turn-resolution-phase-details.md
@@ -6,7 +6,7 @@
 
 ## Phase handler registry
 
-Turn resolution uses a fixed phase sequence ([turn-resolution-phases.md](turn-resolution-phases.md)). Each phase is implemented by a **`TurnPhaseHandler`** (`turn_resolver_config.dart`): `(TurnPipelineState, TurnResolverConfig, turn) → TurnPhaseStepOutcome`. The canonical map is **`TurnPhaseHandlerRegistry.defaults`** (`turn_phase_handler_registry.dart`): one handler per `TurnPhase` in `turnResolutionSequence`. Thin pipeline adapters live in `turn/phases/*.dart`; orchestration handlers (orders noop, research/diplomacy/combat/build-work/end-of-turn event emission) live in the registry module. Tests and callers may override individual phases via `TurnResolverConfig.phaseHandlerOverrides` (merged over defaults). Refs #2560.
+Turn resolution uses a fixed phase sequence ([turn-resolution-phases.md](turn-resolution-phases.md)). Each phase is implemented by a **`TurnPhaseHandler`** (`turn_resolver_config.dart`): `(TurnPipelineState, TurnResolverConfig, turn) → TurnPhaseStepOutcome`. The canonical map is **`TurnPhaseHandlerRegistry.defaults`** (`turn_phase_handler_registry.dart`): one handler per `TurnPhase` in `turnResolutionSequence`. Every `TurnPhaseHandler` implementation — including the Orders noop and the research/diplomacy/combat/build-work/end-of-turn handlers that emit events — lives in **`turn/phases/*.dart`** (one phase per file, re-exported by `turn/phases.dart`); the registry module only maps each `TurnPhase` to its handler. Tests and callers may override individual phases via `TurnResolverConfig.phaseHandlerOverrides` (merged over defaults). Refs #2560.
 
 ---
 

--- a/packages/colonizethis_logic/lib/src/turn/phases.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases.dart
@@ -1,12 +1,16 @@
-/// Barrel: turn phase step implementations (import reduction). Refs #1531.
+/// Barrel: turn phase step implementations (import reduction). Refs #1531, #2560.
 library;
 
 export 'phases/build_work_phase.dart';
 export 'phases/combat_phase.dart';
 export 'phases/consumption_phase.dart';
+export 'phases/diplomacy_phase.dart';
+export 'phases/end_of_turn_phase.dart';
 export 'phases/extraction_phase.dart';
 export 'phases/minor_regiment_upgrade_phase.dart';
 export 'phases/movement_phase.dart';
 export 'phases/naval_interception_turn_phase.dart';
+export 'phases/orders_phase.dart';
 export 'phases/production_phase.dart';
+export 'phases/research_phase.dart';
 export 'phases/riches_to_treasury_phase.dart';

--- a/packages/colonizethis_logic/lib/src/turn/phases/build_work_phase.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases/build_work_phase.dart
@@ -3,6 +3,9 @@ import 'package:colonizethis_models/colonizethis_models.dart';
 
 import '../../orders/orders_application.dart';
 import '../trace/turn_trace_runtime.dart';
+import '../turn_pipeline_state.dart';
+import '../turn_resolution_events.dart';
+import '../turn_resolver_config.dart';
 
 Game runBuildWorkPhase(
   Game game,
@@ -20,4 +23,30 @@ Game runBuildWorkPhase(
     onDialogue: onDialogue,
     onWorkOrderTrace: onWorkOrderTrace,
   );
+}
+
+/// Build/work phase handler — runs build and work orders and emits
+/// work-order-completed events. Refs #2560.
+TurnPhaseStepOutcome buildWorkTurnPhaseHandler(
+  TurnPipelineState acc,
+  TurnResolverConfig config,
+  int turn,
+) {
+  final stateBeforeBuildWork = acc.game;
+  final afterBuildWork = runBuildWorkPhase(
+    acc.game,
+    config.orders,
+    config.topology,
+    config.tileMapByRegion,
+    onDialogue: config.onDialogue,
+    onWorkOrderTrace: config.turnTraceRuntime?.handleWorkOrderTrace,
+  );
+  emitWorkOrderCompletedEvents(
+    stateBeforeBuildWork,
+    afterBuildWork,
+    turn,
+    config.eventBus,
+    config.onGameEvent,
+  );
+  return TurnPhaseStepContinue(acc.copyWith(game: afterBuildWork));
 }

--- a/packages/colonizethis_logic/lib/src/turn/phases/combat_phase.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases/combat_phase.dart
@@ -8,9 +8,12 @@ import '../../combat/conflict_detection.dart';
 import '../../combat/unopposed_province_capture.dart';
 import '../../dossier/event_dialogue.dart';
 import '../../game_events.dart';
-import '../combat_phase_helpers.dart';
-import '../turn_seed_constants.dart';
 import '../../world/capital_and_gp_fall.dart';
+import '../combat_phase_helpers.dart';
+import '../turn_pipeline_state.dart';
+import '../turn_resolution_events.dart';
+import '../turn_resolver_config.dart';
+import '../turn_seed_constants.dart';
 
 void _emitPreBattleDialogueForConflicts(
   Game state,
@@ -21,8 +24,7 @@ void _emitPreBattleDialogueForConflicts(
 ) {
   if (battles.isEmpty) return;
   for (final ctx in battles) {
-    final attackerIds = ctx.attackers.map((a) => a.factionId).toList()
-      ..sort();
+    final attackerIds = ctx.attackers.map((a) => a.factionId).toList()..sort();
     final capitalThreatened = dialogueEventsForCapitalThreatened(
       state,
       capitalOwnerId: ctx.defenderFactionId,
@@ -125,4 +127,41 @@ Game runCombatPhase(
   );
   state = applyGreatPowerFall(state, previousCapitalByPlayer);
   return state;
+}
+
+/// Combat phase handler — captures pre-combat ownership, runs combat, emits
+/// province-captured events, and updates the pipeline. Refs #2560.
+TurnPhaseStepOutcome combatTurnPhaseHandler(
+  TurnPipelineState acc,
+  TurnResolverConfig config,
+  int turn,
+) {
+  final previousOwnership = <String, String?>{};
+  for (final region in [
+    acc.game.worldState.oldWorld,
+    acc.game.worldState.newWorld,
+  ]) {
+    for (final prov in region.provinces) {
+      previousOwnership[prov.id] = prov.ownerId;
+    }
+  }
+  final afterCombat = runCombatPhase(
+    acc.game,
+    config.orders,
+    acc.landFeedingCoverageByPlayerId,
+    config.topology,
+    config.tileMapByRegion,
+    topologyByRegion: config.topologyByRegion,
+    onDialogue: config.onDialogue,
+    onGameEvent: config.onGameEvent,
+  );
+  emitProvinceCapturedEvents(
+    previousOwnership,
+    afterCombat,
+    turn,
+    config.eventBus,
+    config.onGameEvent,
+    config.onDialogue,
+  );
+  return TurnPhaseStepContinue(acc.copyWith(game: afterCombat));
 }

--- a/packages/colonizethis_logic/lib/src/turn/phases/diplomacy_phase.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases/diplomacy_phase.dart
@@ -1,0 +1,78 @@
+import 'package:colonizethis_models/colonizethis_models.dart';
+
+import '../../diplomacy/diplomacy_resolver.dart';
+import '../turn_pipeline_state.dart';
+import '../turn_resolution_events.dart';
+import '../turn_resolution_result.dart';
+import '../turn_resolver_config.dart';
+
+/// Diplomacy phase handler — resolves overtures, interventions, calls to arms,
+/// and relation updates; emits diplomacy events; may exit early with a pending
+/// result. Refs #2560.
+TurnPhaseStepOutcome diplomacyTurnPhaseHandler(
+  TurnPipelineState acc,
+  TurnResolverConfig config,
+  int turn,
+) {
+  final stateBeforeDiplomacy = acc.game;
+  final previousRelations = <String, Map<String, RelationState>>{};
+  for (final rel in acc.game.diplomacyRelations) {
+    previousRelations.putIfAbsent(rel.factionId1, () => {});
+    previousRelations.putIfAbsent(rel.factionId2, () => {});
+    previousRelations[rel.factionId1]![rel.factionId2] = rel.state;
+    previousRelations[rel.factionId2]![rel.factionId1] = rel.state;
+  }
+  final diploResult = resolveDiplomacyPhase(
+    acc.game,
+    config.orders,
+    onDialogue: config.onDialogue,
+    overtureDecisions: config.overtureDecisions,
+    interventionDecisions: config.interventionDecisions,
+    callToArmsDecisions: config.callToArmsDecisions,
+  );
+  if (diploResult.isPending) {
+    final po = diploResult.pendingOvertures;
+    if (po != null && po.isNotEmpty) {
+      return TurnPhaseStepExit(
+        TurnResolutionPendingOvertures(
+          game: diploResult.game,
+          pendingOvertures: po,
+        ),
+      );
+    }
+    final pi = diploResult.pendingInterventions;
+    if (pi != null && pi.isNotEmpty) {
+      return TurnPhaseStepExit(
+        TurnResolutionPendingIntervention(
+          game: diploResult.game,
+          pendingInterventions: pi,
+        ),
+      );
+    }
+    final cta = diploResult.pendingCallToArms;
+    if (cta != null && cta.isNotEmpty) {
+      return TurnPhaseStepExit(
+        TurnResolutionPendingCallToArms(
+          game: diploResult.game,
+          pendingCallToArms: cta,
+        ),
+      );
+    }
+    throw StateError('diplomacy pending but no pending lists populated');
+  }
+  emitDiplomacyChangeEvents(
+    previousRelations,
+    diploResult.game,
+    turn,
+    config.eventBus,
+    config.onGameEvent,
+  );
+  emitOvertureAdvancedEvents(
+    stateBeforeDiplomacy,
+    diploResult.game,
+    turn,
+    config.eventBus,
+    config.onGameEvent,
+  );
+  return TurnPhaseStepContinue(acc.copyWith(game: diploResult.game));
+}

--- a/packages/colonizethis_logic/lib/src/turn/phases/end_of_turn_phase.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases/end_of_turn_phase.dart
@@ -1,0 +1,21 @@
+import '../end_of_turn_resolver.dart';
+import '../turn_pipeline_state.dart';
+import '../turn_resolution_events.dart';
+import '../turn_resolver_config.dart';
+
+/// End-of-turn phase handler — runs victory checks, fog decay, coastal
+/// visibility, and turn-advance, then emits victory events. Refs #2560.
+TurnPhaseStepOutcome endOfTurnTurnPhaseHandler(
+  TurnPipelineState acc,
+  TurnResolverConfig config,
+  int turn,
+) {
+  final after = runEndOfTurnPhase(
+    acc.game,
+    topology: config.topology,
+    topologyByRegion: config.topologyByRegion,
+    onDialogue: config.onDialogue,
+  );
+  emitVictorySetEvent(after, turn, config.eventBus, config.onGameEvent);
+  return TurnPhaseStepContinue(acc.copyWith(game: after));
+}

--- a/packages/colonizethis_logic/lib/src/turn/phases/orders_phase.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases/orders_phase.dart
@@ -1,0 +1,12 @@
+import '../turn_pipeline_state.dart';
+import '../turn_resolver_config.dart';
+
+/// Orders phase handler — passes pipeline state through unchanged.
+/// Orders are already merged and validated before turn resolution begins;
+/// this phase exists in the sequence so downstream phases can observe a
+/// stable Orders boundary in traces. Refs #2560.
+TurnPhaseStepOutcome ordersTurnPhaseHandler(
+  TurnPipelineState acc,
+  TurnResolverConfig config,
+  int turn,
+) => TurnPhaseStepContinue(acc);

--- a/packages/colonizethis_logic/lib/src/turn/phases/research_phase.dart
+++ b/packages/colonizethis_logic/lib/src/turn/phases/research_phase.dart
@@ -1,0 +1,24 @@
+import '../research_resolver.dart';
+import '../turn_pipeline_state.dart';
+import '../turn_resolution_events.dart';
+import '../turn_resolver_config.dart';
+
+/// Research phase handler — resolves research orders, emits research-complete
+/// events, and updates the pipeline. Refs #2560.
+TurnPhaseStepOutcome researchTurnPhaseHandler(
+  TurnPipelineState acc,
+  TurnResolverConfig config,
+  int turn,
+) {
+  final stateBeforeResearch = acc.game;
+  final afterResearch = resolveResearchPhase(acc.game, config.orders);
+  emitResearchCompleteEvents(
+    stateBeforeResearch,
+    afterResearch,
+    turn,
+    config.eventBus,
+    config.onGameEvent,
+    config.onDialogue,
+  );
+  return TurnPhaseStepContinue(acc.copyWith(game: afterResearch));
+}

--- a/packages/colonizethis_logic/lib/src/turn/turn_phase_handler_registry.dart
+++ b/packages/colonizethis_logic/lib/src/turn/turn_phase_handler_registry.dart
@@ -1,16 +1,13 @@
 import 'package:colonizethis_models/colonizethis_models.dart';
 
-import '../diplomacy/diplomacy_resolver.dart';
-import 'end_of_turn_resolver.dart';
 import 'phases.dart';
-import 'research_resolver.dart';
-import 'turn_pipeline_state.dart';
-import 'turn_resolution_events.dart';
-import 'turn_resolution_result.dart';
 import 'turn_resolution_sequence.dart';
 import 'turn_resolver_config.dart';
 
 /// Canonical turn-phase handler registry. SPEC/program/turn-resolution-phase-details.md § Phase handler registry.
+///
+/// Every `TurnPhaseHandler` implementation lives in `turn/phases/*.dart`;
+/// this module only maps each [TurnPhase] to its handler. Refs #2560.
 final class TurnPhaseHandlerRegistry {
   TurnPhaseHandlerRegistry._();
 
@@ -30,7 +27,8 @@ final class TurnPhaseHandlerRegistry {
         TurnPhase.research: researchTurnPhaseHandler,
         TurnPhase.movement: movementTurnPhaseHandler,
         TurnPhase.minorRegimentUpgrade: minorRegimentUpgradeTurnPhaseHandler,
-        TurnPhase.navalInterceptionCombat: navalInterceptionCombatTurnPhaseHandler,
+        TurnPhase.navalInterceptionCombat:
+            navalInterceptionCombatTurnPhaseHandler,
         TurnPhase.combat: combatTurnPhaseHandler,
         TurnPhase.buildWork: buildWorkTurnPhaseHandler,
         TurnPhase.endOfTurn: endOfTurnTurnPhaseHandler,
@@ -46,170 +44,4 @@ void assertTurnPhaseHandlerRegistryComplete() {
       );
     }
   }
-}
-
-TurnPhaseStepOutcome ordersTurnPhaseHandler(
-  TurnPipelineState acc,
-  TurnResolverConfig config,
-  int turn,
-) => TurnPhaseStepContinue(acc);
-
-TurnPhaseStepOutcome researchTurnPhaseHandler(
-  TurnPipelineState acc,
-  TurnResolverConfig config,
-  int turn,
-) {
-  final stateBeforeResearch = acc.game;
-  final afterResearch = resolveResearchPhase(acc.game, config.orders);
-  emitResearchCompleteEvents(
-    stateBeforeResearch,
-    afterResearch,
-    turn,
-    config.eventBus,
-    config.onGameEvent,
-    config.onDialogue,
-  );
-  return TurnPhaseStepContinue(acc.copyWith(game: afterResearch));
-}
-
-TurnPhaseStepOutcome diplomacyTurnPhaseHandler(
-  TurnPipelineState acc,
-  TurnResolverConfig config,
-  int turn,
-) {
-  final stateBeforeDiplomacy = acc.game;
-  final previousRelations = <String, Map<String, RelationState>>{};
-  for (final rel in acc.game.diplomacyRelations) {
-    previousRelations.putIfAbsent(rel.factionId1, () => {});
-    previousRelations.putIfAbsent(rel.factionId2, () => {});
-    previousRelations[rel.factionId1]![rel.factionId2] = rel.state;
-    previousRelations[rel.factionId2]![rel.factionId1] = rel.state;
-  }
-  final diploResult = resolveDiplomacyPhase(
-    acc.game,
-    config.orders,
-    onDialogue: config.onDialogue,
-    overtureDecisions: config.overtureDecisions,
-    interventionDecisions: config.interventionDecisions,
-    callToArmsDecisions: config.callToArmsDecisions,
-  );
-  if (diploResult.isPending) {
-    final po = diploResult.pendingOvertures;
-    if (po != null && po.isNotEmpty) {
-      return TurnPhaseStepExit(
-        TurnResolutionPendingOvertures(
-          game: diploResult.game,
-          pendingOvertures: po,
-        ),
-      );
-    }
-    final pi = diploResult.pendingInterventions;
-    if (pi != null && pi.isNotEmpty) {
-      return TurnPhaseStepExit(
-        TurnResolutionPendingIntervention(
-          game: diploResult.game,
-          pendingInterventions: pi,
-        ),
-      );
-    }
-    final cta = diploResult.pendingCallToArms;
-    if (cta != null && cta.isNotEmpty) {
-      return TurnPhaseStepExit(
-        TurnResolutionPendingCallToArms(
-          game: diploResult.game,
-          pendingCallToArms: cta,
-        ),
-      );
-    }
-    throw StateError('diplomacy pending but no pending lists populated');
-  }
-  emitDiplomacyChangeEvents(
-    previousRelations,
-    diploResult.game,
-    turn,
-    config.eventBus,
-    config.onGameEvent,
-  );
-  emitOvertureAdvancedEvents(
-    stateBeforeDiplomacy,
-    diploResult.game,
-    turn,
-    config.eventBus,
-    config.onGameEvent,
-  );
-  return TurnPhaseStepContinue(acc.copyWith(game: diploResult.game));
-}
-
-TurnPhaseStepOutcome combatTurnPhaseHandler(
-  TurnPipelineState acc,
-  TurnResolverConfig config,
-  int turn,
-) {
-  final previousOwnership = <String, String?>{};
-  for (final region in [
-    acc.game.worldState.oldWorld,
-    acc.game.worldState.newWorld,
-  ]) {
-    for (final prov in region.provinces) {
-      previousOwnership[prov.id] = prov.ownerId;
-    }
-  }
-  final afterCombat = runCombatPhase(
-    acc.game,
-    config.orders,
-    acc.landFeedingCoverageByPlayerId,
-    config.topology,
-    config.tileMapByRegion,
-    topologyByRegion: config.topologyByRegion,
-    onDialogue: config.onDialogue,
-    onGameEvent: config.onGameEvent,
-  );
-  emitProvinceCapturedEvents(
-    previousOwnership,
-    afterCombat,
-    turn,
-    config.eventBus,
-    config.onGameEvent,
-    config.onDialogue,
-  );
-  return TurnPhaseStepContinue(acc.copyWith(game: afterCombat));
-}
-
-TurnPhaseStepOutcome buildWorkTurnPhaseHandler(
-  TurnPipelineState acc,
-  TurnResolverConfig config,
-  int turn,
-) {
-  final stateBeforeBuildWork = acc.game;
-  final afterBuildWork = runBuildWorkPhase(
-    acc.game,
-    config.orders,
-    config.topology,
-    config.tileMapByRegion,
-    onDialogue: config.onDialogue,
-    onWorkOrderTrace: config.turnTraceRuntime?.handleWorkOrderTrace,
-  );
-  emitWorkOrderCompletedEvents(
-    stateBeforeBuildWork,
-    afterBuildWork,
-    turn,
-    config.eventBus,
-    config.onGameEvent,
-  );
-  return TurnPhaseStepContinue(acc.copyWith(game: afterBuildWork));
-}
-
-TurnPhaseStepOutcome endOfTurnTurnPhaseHandler(
-  TurnPipelineState acc,
-  TurnResolverConfig config,
-  int turn,
-) {
-  final after = runEndOfTurnPhase(
-    acc.game,
-    topology: config.topology,
-    topologyByRegion: config.topologyByRegion,
-    onDialogue: config.onDialogue,
-  );
-  emitVictorySetEvent(after, turn, config.eventBus, config.onGameEvent);
-  return TurnPhaseStepContinue(acc.copyWith(game: after));
 }

--- a/packages/colonizethis_logic/test/turn/turn_phase_handler_registry_test.dart
+++ b/packages/colonizethis_logic/test/turn/turn_phase_handler_registry_test.dart
@@ -1,20 +1,24 @@
+import 'dart:io';
+
 import 'package:colonizethis_logic/src/turn/turn_phase_handler_registry.dart';
 import 'package:colonizethis_logic/src/turn/turn_resolution_sequence.dart';
-import 'package:colonizethis_models/colonizethis_models.dart';
 import 'package:colonizethis_test/test.dart';
 
 void main() {
   group('TurnPhaseHandlerRegistry', () {
-    test('defaults registers a handler for every turnResolutionSequence phase', () {
-      assertTurnPhaseHandlerRegistryComplete();
-      for (final phase in turnResolutionSequence) {
-        expect(
-          TurnPhaseHandlerRegistry.handlerFor(phase),
-          isNotNull,
-          reason: 'missing handler for ${phase.name}',
-        );
-      }
-    });
+    test(
+      'defaults registers a handler for every turnResolutionSequence phase',
+      () {
+        assertTurnPhaseHandlerRegistryComplete();
+        for (final phase in turnResolutionSequence) {
+          expect(
+            TurnPhaseHandlerRegistry.handlerFor(phase),
+            isNotNull,
+            reason: 'missing handler for ${phase.name}',
+          );
+        }
+      },
+    );
 
     test('defaults map keys match turnResolutionSequence exactly', () {
       expect(
@@ -22,5 +26,30 @@ void main() {
         turnResolutionSequence,
       );
     });
+
+    test(
+      'registry module contains no inline TurnPhaseHandler implementations',
+      () {
+        // Locks AC4 of #2560: every `TurnPhaseHandler` body lives in
+        // `turn/phases/*.dart`. The registry module must remain a thin
+        // `(TurnPhase, handler)` lookup with no inline handler functions
+        // beyond `assertTurnPhaseHandlerRegistryComplete`.
+        final source = File(
+          'lib/src/turn/turn_phase_handler_registry.dart',
+        ).readAsStringSync();
+        final inlineHandlerDecl = RegExp(
+          r'^TurnPhaseStepOutcome\s+\w+TurnPhaseHandler\s*\(',
+          multiLine: true,
+        );
+        expect(
+          inlineHandlerDecl.hasMatch(source),
+          isFalse,
+          reason:
+              'turn_phase_handler_registry.dart must not define '
+              '*TurnPhaseHandler functions inline; move them under '
+              'lib/src/turn/phases/*.dart (Refs #2560).',
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Moves the six inline `TurnPhaseHandler` implementations out of
`turn_phase_handler_registry.dart` into their dedicated
`turn/phases/*.dart` files, leaving the registry as a thin
`(TurnPhase → handler)` lookup. Picks up the deferred follow-up
explicitly listed in PR #2580 ("turn-phase handler exports moved
into individual `turn/phases/*.dart` files") and tightens AC4 of
#2560: every phase handler is a standalone function in a
dedicated file; the registry contains no handler bodies.

## Refs

Refs #2560

## Scope (this push)

- New / extended phase files (one handler per phase, alongside any
  existing `runXxxPhase` helper):
  - `packages/colonizethis_logic/lib/src/turn/phases/orders_phase.dart` (new) — `ordersTurnPhaseHandler`.
  - `packages/colonizethis_logic/lib/src/turn/phases/research_phase.dart` (new) — `researchTurnPhaseHandler`.
  - `packages/colonizethis_logic/lib/src/turn/phases/diplomacy_phase.dart` (new) — `diplomacyTurnPhaseHandler`.
  - `packages/colonizethis_logic/lib/src/turn/phases/end_of_turn_phase.dart` (new) — `endOfTurnTurnPhaseHandler`.
  - `packages/colonizethis_logic/lib/src/turn/phases/combat_phase.dart` — appended `combatTurnPhaseHandler` next to `runCombatPhase`.
  - `packages/colonizethis_logic/lib/src/turn/phases/build_work_phase.dart` — appended `buildWorkTurnPhaseHandler` next to `runBuildWorkPhase`.
- Barrel `packages/colonizethis_logic/lib/src/turn/phases.dart` updated to export the new files.
- `packages/colonizethis_logic/lib/src/turn/turn_phase_handler_registry.dart` slimmed from ~216 lines to ~46: only the `TurnPhaseHandlerRegistry` class, the `Map<TurnPhase, TurnPhaseHandler>` literal, and `assertTurnPhaseHandlerRegistryComplete`. No `TurnPhaseHandler` bodies remain in the registry module.
- `packages/colonizethis_logic/test/turn/turn_phase_handler_registry_test.dart` — new case asserts `turn_phase_handler_registry.dart` contains no inline `*TurnPhaseHandler` function definitions, locking the AC across future edits.
- `SPEC/program/turn-resolution-phase-details.md` § Phase handler registry — updated to describe the new layout: every handler lives in `turn/phases/*.dart`; the registry only maps each `TurnPhase` to its handler.

No behavior changes: imports, types, event emission and pipeline flow are preserved verbatim — only the file each handler lives in changes.

## ACs covered (issue #2560)

- AC4 (`Turn-phase handlers self-register via a TurnPhaseHandlerRegistry; _defaultTurnPhaseHandlers() no longer contains a 50+ entry literal map`): registry is a 13-entry thin lookup; every handler lives in its own phase file; new regression test enforces the registry stays handler-body-free.

Other ACs (diplomatic sub-validators, work-order handler registry, `WorkSuggestionPipeline`, `traverseProvinces`, `Game.copyWith` helpers) remain unchanged and are tracked by prior merged PRs / remaining slices on `dev`.

## Deferred / out of scope

- Broader `traverseProvinces` adoption in `naval_resolution.dart` (no explicit dual-region province loops there today) and deeper `Game.copyWith` chain migration.
- AST gate for work-target `switch` statements (registry pattern already enforced in code).
- Any other dedup work scoped to #2560 outside the turn-phase handler layout.

## Verification

Run from `packages/colonizethis_logic` unless noted:

- `dart analyze lib/src/turn/` → no new issues (4 pre-existing warnings unrelated to this PR remain across `lib/`).
- `dart test test/turn/turn_phase_handler_registry_test.dart` → 3 / 3 passed (registry coverage + new no-inline-handlers assertion).
- `dart test test/turn/` → 23 / 23 passed.
- `dart test --concurrency=4` (full package) → 1714 / 1714 passed.
- Repo root: `dart test test/ct_repo_lint_test.dart` → 4 / 4 passed.
- `dart format` clean on all touched files.

Made with [Cursor](https://cursor.com)